### PR TITLE
[Concurrency] Fix await fix-it placement

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4253,17 +4253,17 @@ WARNING(no_throw_in_do_with_catch,none,
 //------------------------------------------------------------------------------
 // MARK: Concurrency
 //------------------------------------------------------------------------------
-ERROR(async_call_without_await,none,
-      "call is 'async' but is not marked with 'await'", ())
-ERROR(async_call_without_await_in_autoclosure,none,
-      "call is 'async' in an autoclosure argument that is not marked with 'await'", ())
-ERROR(async_call_without_await_in_async_let,none,
-      "call is 'async' in an 'async let' initializer that is not marked "
-      "with 'await'", ())
-ERROR(async_prop_access_without_await,none,
-      "property access is 'async' but is not marked with 'await'", ())
-ERROR(async_subscript_access_without_await,none,
-      "subscript access is 'async' but is not marked with 'await'", ())
+ERROR(async_expr_without_await,none,
+      "expression is 'async' but is not marked with 'await'", ())
+
+NOTE(async_access_without_await,none,
+    "%select{call|property access|subscript access|}0 is 'async'", (unsigned))
+
+NOTE(async_call_without_await_in_autoclosure,none,
+      "call is 'async' in an autoclosure argument", ())
+NOTE(async_call_without_await_in_async_let,none,
+      "call is 'async' in an 'async let' initializer", ())
+
 WARNING(no_async_in_await,none,
         "no 'async' operations occur within 'await' expression", ())
 ERROR(async_call_in_illegal_context,none,
@@ -4310,8 +4310,8 @@ ERROR(async_let_not_initialized,none,
       "'async let' binding requires an initializer expression", ())
 ERROR(async_let_no_variables,none,
       "'async let' requires at least one named variable", ())
-ERROR(async_let_without_await,none,
-      "reference to async let %0 is not marked with 'await'", (DeclName))
+NOTE(async_let_without_await,none,
+      "reference to async let %0 is 'async'", (DeclName))
 ERROR(async_let_in_illegal_context,none,
       "async let %0 cannot be referenced in "
       "%select{<<ERROR>>|a default argument|a property wrapper initializer|a property initializer|a global variable initializer|an enum case raw value|a catch pattern|a catch guard expression|a defer body}1",

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -427,6 +427,7 @@ public:
   }
 
   std::pair<bool, Expr*> walkToExprPre(Expr *E) override {
+    visitExprPre(E);
     ShouldRecurse_t recurse = ShouldRecurse;
     if (isa<ErrorExpr>(E)) {
       asImpl().flagInvalidCode();
@@ -486,6 +487,8 @@ public:
   ShouldRecurse_t checkForEach(ForEachStmt *S) {
     return ShouldRecurse;
   }
+
+  void visitExprPre(Expr *expr) { asImpl().visitExprPre(expr); }
 };
 
 /// A potential reason why something might have an effect.
@@ -1098,6 +1101,8 @@ private:
         // guaranteed to give back None, which leaves our ThrowKind unchanged.
       }
     }
+
+    void visitExprPre(Expr *expr) { return; }
   };
 
   class FunctionAsyncClassifier
@@ -1182,6 +1187,8 @@ private:
 
       return ShouldRecurse;
     }
+
+    void visitExprPre(Expr *expr) { return; }
   };
 
   Optional<ConditionalEffectKind>
@@ -2290,6 +2297,8 @@ public:
   }
 
 private:
+  void visitExprPre(Expr *expr) { return; }
+
   ShouldRecurse_t checkClosure(ClosureExpr *E) {
     ContextScope scope(*this, Context::forClosure(E));
     scope.enterSubFunction();

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1907,67 +1907,6 @@ public:
     }
   }
 
-  void diagnoseUncoveredAsyncSite(ASTContext &ctx, ASTNode node,
-                                  PotentialEffectReason reason) {
-    SourceRange highlight = node.getSourceRange();
-    auto diag = diag::async_call_without_await;
-
-    switch (reason.getKind()) {
-    case PotentialEffectReason::Kind::AsyncLet:
-      // Reference to an 'async let' missing an 'await'.
-      if (auto declR = dyn_cast_or_null<DeclRefExpr>(node.dyn_cast<Expr*>())) {
-        if (auto var = dyn_cast<VarDecl>(declR->getDecl())) {
-          if (var->isAsyncLet()) {
-            ctx.Diags.diagnose(declR->getLoc(), diag::async_let_without_await,
-                               var->getName());
-            return;
-          }
-        }
-      }
-      LLVM_FALLTHROUGH; // fallthrough to a message about property access
-
-    case PotentialEffectReason::Kind::PropertyAccess:
-      diag = diag::async_prop_access_without_await;
-      break;
-
-    case PotentialEffectReason::Kind::SubscriptAccess:
-      diag = diag::async_subscript_access_without_await;
-      break;
-
-    case PotentialEffectReason::Kind::ByClosure:
-    case PotentialEffectReason::Kind::ByDefaultClosure:
-    case PotentialEffectReason::Kind::ByConformance:
-    case PotentialEffectReason::Kind::Apply: {
-      if (Function) {
-        // To produce a better error message, check if it is an autoclosure.
-        // We do not use 'Context::isAutoClosure' b/c it gives conservative
-        // answers.
-        if (auto autoclosure = dyn_cast_or_null<AutoClosureExpr>(
-                Function->getAbstractClosureExpr())) {
-          switch (autoclosure->getThunkKind()) {
-          case AutoClosureExpr::Kind::None:
-            diag = diag::async_call_without_await_in_autoclosure;
-            break;
-
-          case AutoClosureExpr::Kind::AsyncLet:
-            diag = diag::async_call_without_await_in_async_let;
-            break;
-
-          case AutoClosureExpr::Kind::SingleCurryThunk:
-          case AutoClosureExpr::Kind::DoubleCurryThunk:
-            break;
-          }
-        }
-      }
-      break;
-    }
-    };
-
-    ctx.Diags.diagnose(node.getStartLoc(), diag)
-        .fixItInsert(node.getStartLoc(), "await ")
-        .highlight(highlight);
-  }
-
   void diagnoseAsyncInIllegalContext(DiagnosticEngine &Diags, ASTNode node) {
     if (auto *e = node.dyn_cast<Expr*>()) {
       if (isa<ApplyExpr>(e)) {
@@ -2119,7 +2058,42 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
   /// context.
   ConditionalEffectKind MaxThrowingKind;
 
+  struct DiagnosticInfo {
+    DiagnosticInfo(Expr &failingExpr,
+                   PotentialEffectReason reason) :
+      reason(reason),
+      expr(failingExpr) {}
+
+    /// Reason for throwing
+    PotentialEffectReason reason;
+
+    /// Failing expression
+    Expr &expr;
+  };
+
+  SmallVector<Expr *, 4> errorOrder;
+  llvm::DenseMap<Expr *, std::vector<DiagnosticInfo>> uncoveredAsync;
   llvm::DenseMap<Expr *, Expr *> parentMap;
+
+  static bool isEffectAnchor(Expr *e) {
+    return isa<AbstractClosureExpr>(e) || isa<DiscardAssignmentExpr>(e) || isa<AssignExpr>(e);
+  }
+
+  static bool isAnchorTooEarly(Expr *e) {
+    return isa<AssignExpr>(e) || isa<DiscardAssignmentExpr>(e);
+  }
+
+  /// Find the top location where we should put the await
+  static Expr* walkToAnchor(Expr *e,
+                            llvm::DenseMap<Expr *, Expr*> &parentMap) {
+    Expr *parent = e;
+    Expr *lastParent = e;
+    while (parent && !isEffectAnchor(parent)) {
+      lastParent = parent;
+      parent = parentMap[parent];
+    }
+    return parent && !isAnchorTooEarly(parent) ? parent : lastParent;
+  }
 
   void flagInvalidCode() {
     // Suppress warnings about useless try or catch.
@@ -2281,6 +2255,13 @@ public:
       ReasyncDC = reasyncDC;
     }
   }
+
+  ~CheckEffectsCoverage() {
+    for (Expr *anchor: errorOrder) {
+      diagnoseUncoveredAsyncSite(anchor);
+    }
+  }
+
 
   /// Mark that the current context is top-level code with
   /// throw-without-try enabled.
@@ -2638,8 +2619,17 @@ private:
       }
       // Diagnose async calls that are outside of an await context.
       else if (!Flags.has(ContextFlags::IsAsyncCovered)) {
-        CurContext.diagnoseUncoveredAsyncSite(Ctx, E,
-                                              classification.getAsyncReason());
+        Expr *expr = E.dyn_cast<Expr*>();
+        Expr *anchor = walkToAnchor(expr, parentMap);
+
+        auto key = uncoveredAsync.find(anchor);
+        if (key == uncoveredAsync.end()) {
+          uncoveredAsync.insert({anchor, {}});
+          errorOrder.push_back(anchor);
+        }
+        uncoveredAsync[anchor].emplace_back(
+            *expr,
+            classification.getAsyncReason());
       }
     }
 
@@ -2787,6 +2777,78 @@ private:
     }
 
     return ShouldRecurse;
+  }
+
+  void diagnoseUncoveredAsyncSite(const Expr *anchor) const {
+    auto asyncPointIter = uncoveredAsync.find(anchor);
+    if (asyncPointIter == uncoveredAsync.end())
+      return;
+    const std::vector<DiagnosticInfo> &errors = asyncPointIter->getSecond();
+    SourceLoc awaitInsertLoc = anchor->getStartLoc();
+    if (const AnyTryExpr *tryExpr = dyn_cast<AnyTryExpr>(anchor))
+      awaitInsertLoc = tryExpr->getSubExpr()->getStartLoc();
+    else if (const AutoClosureExpr *autoClosure = dyn_cast<AutoClosureExpr>(anchor)) {
+      if (const AnyTryExpr *tryExpr = dyn_cast<AnyTryExpr>(autoClosure->getSingleExpressionBody()))
+        awaitInsertLoc = tryExpr->getSubExpr()->getStartLoc();
+    }
+
+    Ctx.Diags.diagnose(anchor->getStartLoc(), diag::async_expr_without_await)
+      .fixItInsert(awaitInsertLoc, "await ")
+      .highlight(anchor->getSourceRange());
+
+    for (const DiagnosticInfo &diag: errors) {
+      switch (diag.reason.getKind()) {
+        case PotentialEffectReason::Kind::AsyncLet:
+          if (auto declR = dyn_cast<DeclRefExpr>(&diag.expr)) {
+            if (auto var = dyn_cast<VarDecl>(declR->getDecl())) {
+              if (var->isAsyncLet()) {
+                Ctx.Diags.diagnose(declR->getLoc(),
+                                   diag::async_let_without_await,
+                                   var->getName());
+                continue;
+              }
+            }
+          }
+          LLVM_FALLTHROUGH; // fallthrough to a message about PropertyAccess
+        case PotentialEffectReason::Kind::PropertyAccess:
+          Ctx.Diags.diagnose(diag.expr.getStartLoc(),
+                             diag::async_access_without_await, 1);
+          continue;
+
+        case PotentialEffectReason::Kind::SubscriptAccess:
+          Ctx.Diags.diagnose(diag.expr.getStartLoc(),
+                             diag::async_access_without_await, 2);
+          continue;
+
+        case PotentialEffectReason::Kind::ByClosure:
+        case PotentialEffectReason::Kind::ByDefaultClosure:
+        case PotentialEffectReason::Kind::ByConformance:
+        case PotentialEffectReason::Kind::Apply: {
+         if (auto autoclosure = dyn_cast<AutoClosureExpr>(anchor)) {
+           switch(autoclosure->getThunkKind()) {
+             case AutoClosureExpr::Kind::None:
+               Ctx.Diags.diagnose(diag.expr.getStartLoc(),
+                                  diag::async_call_without_await_in_autoclosure);
+               break;
+             case AutoClosureExpr::Kind::AsyncLet:
+               Ctx.Diags.diagnose(diag.expr.getStartLoc(),
+                                  diag::async_call_without_await_in_async_let);
+               break;
+             case AutoClosureExpr::Kind::SingleCurryThunk:
+             case AutoClosureExpr::Kind::DoubleCurryThunk:
+               Ctx.Diags.diagnose(diag.expr.getStartLoc(),
+                                  diag::async_access_without_await, 0);
+               break;
+           }
+          continue;
+         }
+         Ctx.Diags.diagnose(diag.expr.getStartLoc(),
+                            diag::async_access_without_await, 0);
+
+         continue;
+        }
+      }
+    }
   }
 };
 

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -2119,6 +2119,8 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
   /// context.
   ConditionalEffectKind MaxThrowingKind;
 
+  llvm::DenseMap<Expr *, Expr *> parentMap;
+
   void flagInvalidCode() {
     // Suppress warnings about useless try or catch.
     Flags.set(ContextFlags::HasAnyThrowSite);
@@ -2297,7 +2299,11 @@ public:
   }
 
 private:
-  void visitExprPre(Expr *expr) { return; }
+  void visitExprPre(Expr *expr) {
+    if (parentMap.count(expr) == 0)
+      parentMap = expr->getParentMap();
+    return;
+  }
 
   ShouldRecurse_t checkClosure(ClosureExpr *E) {
     ContextScope scope(*this, Context::forClosure(E));

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -29,7 +29,8 @@ func testSlowServer(slowServer: SlowServer) async throws {
 
   // still async version...
   let _: Int = slowServer.doSomethingConflicted("thinking")
-  // expected-error@-1{{call is 'async' but is not marked with 'await'}}{{16-16=await }}
+  // expected-error@-1{{expression is 'async' but is not marked with 'await'}}{{16-16=await }}
+  // expected-note@-2{{call is 'async'}}
 
   let _: String? = try await slowServer.fortune()
   let _: Int = try await slowServer.magicNumber(withSeed: 42)

--- a/test/Concurrency/async_initializer.swift
+++ b/test/Concurrency/async_initializer.swift
@@ -6,7 +6,8 @@
 // some functions to play with
 
 func f() async {
-  let _ = Person() // expected-error {{call is 'async' but is not marked with 'await'}} {{11-11=await }}
+  // expected-error@+1 {{expression is 'async' but is not marked with 'await'}} {{11-11=await }}
+  let _ = Person() // expected-note {{call is 'async'}}
 }
 
 func g() {}
@@ -16,7 +17,9 @@ func g() {}
 
 class Person {
   init() async {
-    f() // expected-error {{call is 'async' but is not marked with 'await'}} {{5-5=await }}
+
+    // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{5-5=await }}
+    f() // expected-note{{call is 'async'}}
   }
 
   convenience init(_ s: String) async {
@@ -76,7 +79,8 @@ class MyType {
 }
 
 func beep() async {
-  let _ = MyType(f) // expected-error{{call is 'async' but is not marked with 'await'}}
+  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{11-11=await }}
+  let _ = MyType(f) // expected-note{{call is 'async'}}
   let _ = await MyType(f)
 
   let _ = MyType(g)

--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -31,11 +31,17 @@ actor Alex {
 func referenceGlobalActor() async {
   let a = Alex()
   _ = a.method
-  _ = a.const_memb // expected-error{{property access is 'async' but is not marked with 'await'}}
-  _ = a.mut_memb  // expected-error{{property access is 'async' but is not marked with 'await'}}
+  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
+  _ = a.const_memb // expected-note{{property access is 'async'}}
+  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
+  _ = a.mut_memb // expected-note{{property access is 'async'}}
 
-  _ = a[1]  // expected-error{{subscript access is 'async' but is not marked with 'await'}}
+  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
+  _ = a[1]  // expected-note{{subscript access is 'async'}}
   a[0] = 1  // expected-error{{subscript 'subscript(_:)' isolated to global actor 'SomeGlobalActor' can not be mutated from this context}}
+
+  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
+  _ = 32 + a[1] // expected-note@:12{{subscript access is 'async'}}
 }
 
 
@@ -102,18 +108,26 @@ class Taylor {
 
 func fromAsync() async {
   let x = syncGlobActorFn
-  x() // expected-error{{call is 'async' but is not marked with 'await'}}
+  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{3-3=await }}
+  x() // expected-note{{call is 'async'}}
+
 
   let y = asyncGlobalActFn
-  y() // expected-error{{call is 'async' but is not marked with 'await'}}
+  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{3-3=await }}
+  y() // expected-note{{call is 'async'}}
 
   let a = Alex()
-  let fn = a.method
-  fn() // expected-error{{call is 'async' but is not marked with 'await'}}
-  _ = a.const_memb // expected-error{{property access is 'async' but is not marked with 'await'}}
-  _ = a.mut_memb  // expected-error{{property access is 'async' but is not marked with 'await'}}
 
-  _ = a[1]  // expected-error{{subscript access is 'async' but is not marked with 'await'}}
+  let fn = a.method
+  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{3-3=await }}
+  fn() //expected-note{{call is 'async}}
+  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
+  _ = a.const_memb // expected-note{{property access is 'async'}}
+  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
+  _ = a.mut_memb  // expected-note{{property access is 'async'}}
+
+  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
+  _ = a[1]  // expected-note{{subscript access is 'async'}}
   _ = await a[1]
   a[0] = 1  // expected-error{{subscript 'subscript(_:)' isolated to global actor 'SomeGlobalActor' can not be mutated from this context}}
 }

--- a/test/Concurrency/global_actor_function_types.swift
+++ b/test/Concurrency/global_actor_function_types.swift
@@ -129,8 +129,13 @@ func testTypesConcurrencyContext() async {
   let _: () -> Int = f1 // expected-error{{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
   let _: () -> Int = f2 // expected-error{{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
 
-  _ = f1() // expected-error{{call is 'async' but is not marked with 'await'}}
-  _ = f2() // expected-error{{call is 'async' but is not marked with 'await'}}
+  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
+  _ = f1() //expected-note{{call is 'async}}
+  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
+  _ = f2() //expected-note{{call is 'async'}}
+
+  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
+  _ = f1() + f2() // expected-note 2 {{call is 'async'}}
 
   _ = await f1()
   _ = await f2()

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -236,7 +236,9 @@ class SubclassWithGlobalActors : SuperclassWithGlobalActors {
   @asyncHandler
   override func j() { // okay, isolated to GenericGlobalActor<String>
     onGenericGlobalActorString() // okay
-    onGenericGlobalActorInt() // expected-error{{call is 'async' but is not marked with 'await'}}
+
+    // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{5-5=await }}
+    onGenericGlobalActorInt() // expected-note{{call is 'async'}}
   }
 }
 
@@ -250,7 +252,8 @@ class SubclassWithGlobalActors : SuperclassWithGlobalActors {
 @SomeGlobalActor func sibling() { foo() }
 
 func bar() async {
-  foo() // expected-error{{call is 'async' but is not marked with 'await'}}
+  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{3-3=await }}
+  foo() // expected-note{{call is 'async'}}
 }
 
 // expected-note@+1 {{add '@SomeGlobalActor' to make global function 'barSync()' part of global actor 'SomeGlobalActor'}} {{1-1=@SomeGlobalActor }}

--- a/test/Concurrency/objc_async_overload.swift
+++ b/test/Concurrency/objc_async_overload.swift
@@ -16,9 +16,9 @@ func syncContext() {
 func asyncNoAwait() async {
   let r = Request()
   let d = Delegate()
-  d.makeRequest1(r) // expected-error {{call is 'async' but is not marked with 'await'}}
-  d.makeRequest2(r) // expected-error {{call is 'async' but is not marked with 'await'}}
-  d.makeRequest3(r) // expected-error {{call is 'async' but is not marked with 'await'}}
+  d.makeRequest1(r) // expected-error@:3 {{expression is 'async' but is not marked with 'await'}} expected-note {{call is 'async'}}
+  d.makeRequest2(r) // expected-error@:3 {{expression is 'async' but is not marked with 'await'}} expected-note {{call is 'async'}}
+  d.makeRequest3(r) // expected-error@:3 {{expression is 'async' but is not marked with 'await'}} expected-note {{call is 'async'}}
 }
 
 

--- a/test/Concurrency/reasync.swift
+++ b/test/Concurrency/reasync.swift
@@ -41,7 +41,10 @@ func callReasyncFunction() async {
   reasyncFunction { }
   await reasyncFunction { } // expected-warning {{no 'async' operations occur within 'await' expression}}
 
-  reasyncFunction { await asyncFunction() } // expected-error {{call is 'async' but is not marked with 'await'}}
+  reasyncFunction { await asyncFunction() }
+  // expected-error@-1:3 {{expression is 'async' but is not marked with 'await'}}{{3-3=await }}
+  // expected-note@-2:3 {{call is 'async'}}
+
   await reasyncFunction { await asyncFunction() }
 }
 
@@ -60,11 +63,15 @@ func callReasyncRethrowsFunction() async throws {
   // expected-warning@-2 {{no calls to throwing functions occur within 'try' expression}}
 
   reasyncRethrowsFunction { await asyncFunction() }
-  // expected-error@-1 {{call is 'async' but is not marked with 'await'}}
+  // expected-error@-1:3 {{expression is 'async' but is not marked with 'await'}}{{3-3=await }}
+  // expected-note@-2:3 {{call is 'async'}}
+
   await reasyncRethrowsFunction { await asyncFunction() }
   try reasyncRethrowsFunction { await asyncFunction() }
-  // expected-error@-1 {{call is 'async' but is not marked with 'await'}}
-  // expected-warning@-2 {{no calls to throwing functions occur within 'try' expression}}
+  // expected-warning@-1 {{no calls to throwing functions occur within 'try' expression}}
+  // expected-error@-2:3 {{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
+  // expected-note@-3:7 {{call is 'async'}}
+
   try await reasyncRethrowsFunction { await asyncFunction() }
   // expected-warning@-1 {{no calls to throwing functions occur within 'try' expression}}
 
@@ -82,12 +89,14 @@ func callReasyncRethrowsFunction() async throws {
   reasyncRethrowsFunction { await asyncFunction(); throw HorseError.colic }
   // expected-error@-1 {{call can throw but is not marked with 'try'}}
   // expected-note@-2 {{call is to 'rethrows' function, but argument function can throw}}
-  // expected-error@-3 {{call is 'async' but is not marked with 'await'}}
+  // expected-error@-3:3 {{expression is 'async' but is not marked with 'await'}}{{3-3=await }}
+  // expected-note@-4:3 {{call is 'async'}}
   await reasyncRethrowsFunction { await asyncFunction(); throw HorseError.colic }
   // expected-error@-1 {{call can throw but is not marked with 'try'}}
   // expected-note@-2 {{call is to 'rethrows' function, but argument function can throw}}
   try reasyncRethrowsFunction { await asyncFunction(); throw HorseError.colic }
-  // expected-error@-1 {{call is 'async' but is not marked with 'await'}}
+  // expected-error@-1:3 {{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
+  // expected-note@-2:7 {{call is 'async'}}
   try await reasyncRethrowsFunction { await asyncFunction(); throw HorseError.colic }
 }
 
@@ -103,16 +112,18 @@ func callReasyncWithAutoclosure1() {
   // expected-error@-1 {{'async' call in a function that does not support concurrency}}
 
   await reasyncWithAutoclosure(computeValueAsync())
-  // expected-error@-1 {{call is 'async' in an autoclosure argument that is not marked with 'await'}}
-  // expected-error@-2 {{'async' call in a function that does not support concurrency}}
+  // expected-error@-1:32 {{expression is 'async' but is not marked with 'await'}}{{32-32=await }}
+  // expected-note@-2:32 {{call is 'async' in an autoclosure argument}}
+  // expected-error@-3 {{'async' call in a function that does not support concurrency}}
 }
 
 func callReasyncWithAutoclosure2() async {
   reasyncWithAutoclosure(computeValue())
   await reasyncWithAutoclosure(await computeValueAsync())
 
-  await reasyncWithAutoclosure(computeValueAsync())
-  // expected-error@-1 {{call is 'async' in an autoclosure argument that is not marked with 'await'}}
+  await reasyncWithAutoclosure(15 + computeValueAsync())
+  // expected-error@-1:32 {{expression is 'async' but is not marked with 'await'}}{{32-32=await }}
+  // expected-note@-2:37 {{call is 'async' in an autoclosure argument}}
 }
 
 //// Reasync body checking

--- a/test/Constraints/async.swift
+++ b/test/Constraints/async.swift
@@ -59,7 +59,10 @@ func testOverloadedAsync() async {
   let _: String? = await overloadedOptDifference() // no warning
 
   let _ = await overloaded()
-  let _ = overloaded() // expected-error{{call is 'async' but is not marked with 'await'}}{{11-11=await }}
+  let _ = overloaded()
+  // expected-error@-1:11{{expression is 'async' but is not marked with 'await'}}{{11-11=await }}
+  // expected-note@-2:11{{call is 'async'}}
+
 
   let fn = {
     overloaded()
@@ -136,5 +139,7 @@ func incrementAsync(_ x: Int) async -> Int {
 func testAsyncWithConversions() async {
   _ = bar(incrementSync)
   _ = bar { -$0 }
-  _ = bar(incrementAsync) // expected-error{{call is 'async' but is not marked with 'await'}}
+  _ = bar(incrementAsync)
+  // expected-error@-1:7{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
+  // expected-note@-2:7{{call is 'async'}}
 }

--- a/test/decl/class/effectful_properties.swift
+++ b/test/decl/class/effectful_properties.swift
@@ -64,8 +64,9 @@ func timeToPlay(gc : Presidio) async {
   _ = (gc as GolfCourse).yards // expected-error{{property access can throw, but it is not marked with 'try' and the error is not handled}}
   _ = try? (gc as GolfCourse).yards
 
-  // expected-error@+2 {{property access can throw, but it is not marked with 'try' and the error is not handled}}
-  // expected-error@+1 {{property access is 'async' but is not marked with 'await'}}
+  // expected-error@+3 {{property access can throw, but it is not marked with 'try' and the error is not handled}}
+  // expected-error@+2 {{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
+  // expected-note@+1:7{{property access is 'async'}}
   _ = (gc as GolfCourse).par
   _ = try? await (gc as GolfCourse).par
 

--- a/test/decl/protocol/effectful_properties.swift
+++ b/test/decl/protocol/effectful_properties.swift
@@ -108,7 +108,8 @@ func asNone<U : None>(u : U) async throws {
 }
 
 func asAsync<U : A>(u : U) async {
-  _ = u.someProp // expected-error {{property access is 'async' but is not marked with 'await'}}
+  // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
+  _ = u.someProp // expected-note@:7{{property access is 'async'}}
 
   _ = await u.someProp
 }
@@ -123,10 +124,11 @@ func asThrows<U : T>(u : U) throws {
 }
 
 func asAsyncThrows<U : AT>(u : U) async throws {
-  // expected-note@+5 {{did you mean to handle error as optional value?}}
-  // expected-note@+4 {{did you mean to disable error propagation?}}
-  // expected-note@+3 {{did you mean to use 'try'?}}
-  // expected-error@+2 {{property access is 'async' but is not marked with 'await'}}
+  // expected-note@+6 {{did you mean to handle error as optional value?}}
+  // expected-note@+5 {{did you mean to disable error propagation?}}
+  // expected-note@+4 {{did you mean to use 'try'?}}
+  // expected-error@+3 {{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
+  // expected-note@+2 {{property access is 'async'}}
   // expected-error@+1 {{property access can throw but is not marked with 'try'}}
     _ = u.someProp
 

--- a/test/decl/var/effectful_properties_global.swift
+++ b/test/decl/var/effectful_properties_global.swift
@@ -16,7 +16,9 @@ var asyncThrowsProp : Int {
 func hello() async {
   _ = intThrowsProp // expected-error{{property access can throw, but it is not marked with 'try' and the error is not handled}}
 
-  _ = intAsyncProp // expected-error{{property access is 'async' but is not marked with 'await'}}
+
+  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
+  _ = intAsyncProp // expected-note{{property access is 'async'}}
 }
 
 class C {
@@ -34,6 +36,6 @@ var refTypeAsyncProp : C {
 func salam() async {
   _ = refTypeThrowsProp // expected-error{{property access can throw, but it is not marked with 'try' and the error is not handled}}
 
-
-  _ = refTypeAsyncProp // expected-error {{property access is 'async' but is not marked with 'await'}}
+  // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
+  _ = refTypeAsyncProp // expected-note {{property access is 'async'}}
 }


### PR DESCRIPTION
This PR does some work around the diagnostics on `await`. The first issue is that the fix-it for await put the await in the wrong place. The issue also exists for the placement of `try`. The fix-it would put the `await` immediately before the call or access, but this doesn't work if that point is immediately after a binary operation.

e.g.

```swift
let _ = 32 + await asyncFunc()
```
fails to compile, despite that being where the fix-it suggests putting it.
That gets fixed in this PR. We do this by walking up the parent to an anchor point where we want to emit the await to. By keeping those in a map, we can effectively de-dupe them and map all of the warnings back to a given anchor.
I did run into some difficulties with finding a decent anchor in string interpolated expressions (see `CheckEffectsCoverage::walkToAnchor`). If we're in a string interpolation, I've found that we make it to the top of the expression and parent becomes a `nullptr`. The top of the expression for a string interpolation appears to always be a `CallExpr`, which you then pull out the args from to get a `ParenExpr`. The subExpr of that appears to be thing thing we're looking for. If this always holds true, we can remove the cascade of `if`'s and just make those the appropriate casts. My concern with being too forceful is getting this assumption wrong and leading to a crashing compiler. As implemented now, it will just suggest that the await goes in a weird spot. e.g. 
```
  print("\(32 + x.number)")
          ^~~~~~~~~~~~~~~
          await
```
instead of 
```
  print("\(32 + x.number)")
           ^~~~~~~~~~~~~
           await
```

Additionally, instead of repeatedly emitting errors for every part of the expression, we emit one error with the necessary fix-it, and emit notes for each part that is the cause for needing to put the await in the right place.

e.g.

```swift
let _ = 32 + longTask() + longTask() + actorInstance.myNumber + actorInstance.myNumber
```

will now emit:

```
awaitPlacement.swift:20:11: error: expression is 'async' but is not marked with 'await'
  let _ = 32 + longTask() + longTask() + actorInstance.myNumber + actorInstance.myNumber
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          await
awaitPlacement.swift:20:16: note: call is 'async'
  let _ = 32 + longTask() + longTask() + actorInstance.myNumber + actorInstance.myNumber
               ^
awaitPlacement.swift:20:29: note: call is 'async'
  let _ = 32 + longTask() + longTask() + actorInstance.myNumber + actorInstance.myNumber
                            ^
awaitPlacement.swift:20:42: note: property access is 'async'
  let _ = 32 + longTask() + longTask() + actorInstance.myNumber + actorInstance.myNumber
                                         ^
awaitPlacement.swift:20:67: note: property access is 'async'
  let _ = 32 + longTask() + longTask() + actorInstance.myNumber + actorInstance.myNumber
                                                                  ^
```

Will need to eventually fix the fix-it for `try`, but given that this is new syntax, it's a bit more important to get right. Folks are probably more familiar with where a try goes by now. Maybe.

Fixes: rdar://76245239