### PR TITLE
[Sema] Do not attempt warn extraneous checked cast for placeholder types

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6442,7 +6442,8 @@ static ConstraintFix *maybeWarnAboutExtraneousCast(
     return nullptr;
 
   // Both types have to be fixed.
-  if (fromType->hasTypeVariable() || toType->hasTypeVariable())
+  if (fromType->hasTypeVariable() || toType->hasTypeVariable() ||
+      fromType->hasPlaceholder() || toType->hasPlaceholder())
     return nullptr;
 
   SmallVector<LocatorPathElt, 4> path;

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -529,3 +529,9 @@ let _ = derived is (SR13899_Derived) -> Void // expected-warning{{'is' test is a
 let _ = derived is (SR13899_Derived) throws -> Void // expected-warning{{'is' test is always true}}
 let _ = blockp is (SR13899_A) -> Void //expected-warning{{'is' test is always true}}
 let _ = blockp is (SR13899_A) throws -> Void //expected-warning{{'is' test is always true}}
+
+protocol PP1 { }
+protocol PP2: PP1 { }
+extension Optional: PP1 where Wrapped == PP2 { }
+
+nil is PP1 // expected-error {{'nil' requires a contextual type}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
As mentioned [here](https://bugs.swift.org/browse/SR-14478?focusedCommentId=61880&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-61880) those fixes shouldn't be recorded for placeholder types.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
