### PR TITLE
libswift: Start implementing SIL optimizations in Swift

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,10 @@ set(SWIFT_TOOLS_ENABLE_LTO OFF CACHE STRING "Build Swift tools with LTO. One
     option only affects the tools that run on the host (the compiler), and has
     no effect on the target libraries (the standard library and the runtime).")
 
+option(SWIFT_TOOLS_ENABLE_LIBSWIFT
+  "Enable building libswift and linking libswift into the compiler itself."
+  FALSE)
+
 # The following only works with the Ninja generator in CMake >= 3.0.
 set(SWIFT_PARALLEL_LINK_JOBS "" CACHE STRING
   "Define the maximum number of linker jobs for swift.")
@@ -891,6 +895,7 @@ if(SWIFT_INCLUDE_TOOLS)
   message(STATUS "  Build type:     ${CMAKE_BUILD_TYPE}")
   message(STATUS "  Assertions:     ${LLVM_ENABLE_ASSERTIONS}")
   message(STATUS "  LTO:            ${SWIFT_TOOLS_ENABLE_LTO}")
+  message(STATUS "  libswift:       ${SWIFT_TOOLS_ENABLE_LIBSWIFT}")
   message(STATUS "")
 else()
   message(STATUS "Not building host Swift tools")
@@ -1033,6 +1038,11 @@ add_subdirectory(include)
 
 if(SWIFT_INCLUDE_TOOLS)
   add_subdirectory(lib)
+
+  # "libswift" must come before "tools".
+  # It adds libswift module names to the global property "libswift_modules"
+  # which is used in add_swift_host_tool for the lldb workaround.
+  add_subdirectory(libswift)
 
   # Always include this after including stdlib/!
   # Refer to the large comment above the add_subdirectory(stdlib) call.

--- a/include/swift/Basic/InitializeLibSwift.h
+++ b/include/swift/Basic/InitializeLibSwift.h
@@ -1,0 +1,26 @@
+//===--- InitializeLibSwift.h -----------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_INITIALIZELIBSWIFT_H
+#define SWIFT_BASIC_INITIALIZELIBSWIFT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void initializeLibSwift();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SWIFT_BASIC_INITIALIZELIBSWIFT_H

--- a/include/swift/SIL/BridgedSwiftObject.h
+++ b/include/swift/SIL/BridgedSwiftObject.h
@@ -1,0 +1,43 @@
+//===--- BridgedSwiftObject.h - C header which defines SwiftObject --------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This is a C header, which defines the SwiftObject header. For the C++ version
+// see SwiftObjectHeader.h.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_BRIDGEDSWIFTOBJECT_H
+#define SWIFT_SIL_BRIDGEDSWIFTOBJECT_H
+
+#include <stdint.h>
+
+#if !__has_feature(nullability)
+# define _Nullable
+# define _Nonnull
+# define _Null_unspecified
+#endif
+
+typedef const void * _Nonnull SwiftMetatype;
+
+/// The header of a Swift object.
+///
+/// This must be in sync with HeapObject, which is defined in the runtime lib.
+/// It must be layout compatible with the Swift object header.
+struct BridgedSwiftObject {
+  SwiftMetatype metatype;
+  int64_t refCounts;
+};
+
+typedef struct BridgedSwiftObject * _Nonnull SwiftObject;
+typedef struct BridgedSwiftObject * _Nullable OptionalSwiftObject;
+
+#endif

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -196,6 +196,10 @@ protected:
   }
 };
 
+inline SILArgument *castToArgument(SwiftObject argument) {
+  return static_cast<SILArgument *>(argument);
+}
+
 class SILPhiArgument : public SILArgument {
   friend class SILBasicBlock;
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1,0 +1,164 @@
+//===--- SILBridging.h - header for the swift SILBridging module ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_SILBRIDGING_H
+#define SWIFT_SIL_SILBRIDGING_H
+
+#include "BridgedSwiftObject.h"
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  const unsigned char * _Nullable data;
+  size_t length;
+} BridgedStringRef;
+
+typedef struct {
+  const unsigned char * _Nonnull data;
+  size_t numOperands;
+} BridgedOperandArray;
+
+enum {
+  BridgedOperandSize = 4 * sizeof(uintptr_t)
+};
+
+enum ChangeNotificationKind {
+  instructionsChanged,
+  callsChanged,
+  branchesChanged
+};
+
+typedef struct {
+  void * _Null_unspecified word0;
+  void * _Null_unspecified word1;
+  void * _Null_unspecified word2;
+} BridgedLocation;
+
+typedef struct {
+  void * _Nullable typePtr;
+} BridgedType;
+
+typedef struct {
+  const void * _Nullable data;
+  size_t count;
+} BridgedValueArray;
+
+typedef struct {
+  const void * _Nonnull op;
+} BridgedOperand;
+
+typedef struct {
+  const void * _Nullable op;
+} OptionalBridgedOperand;
+
+typedef struct {
+  SwiftObject obj;
+} BridgedFunction;
+
+typedef struct {
+  SwiftObject obj;
+} BridgedGlobalVar;
+
+typedef struct {
+  SwiftObject obj;
+} BridgedBasicBlock;
+
+typedef struct {
+  OptionalSwiftObject obj;
+} OptionalBridgedBasicBlock;
+
+typedef struct {
+  SwiftObject obj;
+} BridgedArgument;
+
+typedef struct {
+  OptionalSwiftObject obj;
+} OptionalBridgedArgument;
+
+typedef struct {
+  SwiftObject obj;
+} BridgedNode;
+
+typedef struct {
+  SwiftObject obj;
+} BridgedValue;
+
+typedef struct {
+  SwiftObject obj;
+} BridgedInstruction;
+
+typedef struct {
+  OptionalSwiftObject obj;
+} OptionalBridgedInstruction;
+
+typedef struct {
+  SwiftObject obj;
+} BridgedMultiValueResult;
+
+typedef long SwiftInt;
+
+void registerBridgedClass(BridgedStringRef className, SwiftMetatype metatype);
+
+void freeBridgedStringRef(BridgedStringRef str);
+
+BridgedStringRef SILFunction_getName(BridgedFunction function);
+BridgedStringRef SILFunction_debugDescription(BridgedFunction function);
+OptionalBridgedBasicBlock SILFunction_firstBlock(BridgedFunction function);
+OptionalBridgedBasicBlock SILFunction_lastBlock(BridgedFunction function);
+
+BridgedStringRef SILGlobalVariable_getName(BridgedGlobalVar global);
+BridgedStringRef SILGlobalVariable_debugDescription(BridgedGlobalVar global);
+
+OptionalBridgedBasicBlock SILBasicBlock_next(BridgedBasicBlock block);
+OptionalBridgedBasicBlock SILBasicBlock_previous(BridgedBasicBlock block);
+BridgedStringRef SILBasicBlock_debugDescription(BridgedBasicBlock block);
+OptionalBridgedInstruction SILBasicBlock_firstInst(BridgedBasicBlock block);
+OptionalBridgedInstruction SILBasicBlock_lastInst(BridgedBasicBlock block);
+SwiftInt SILBasicBlock_getNumArguments(BridgedBasicBlock block);
+BridgedArgument SILBasicBlock_getArgument(BridgedBasicBlock block, SwiftInt index);
+
+BridgedValue Operand_getValue(BridgedOperand);
+OptionalBridgedOperand Operand_nextUse(BridgedOperand);
+BridgedInstruction Operand_getUser(BridgedOperand);
+
+BridgedStringRef SILNode_debugDescription(BridgedNode node);
+OptionalBridgedOperand SILValue_firstUse(BridgedValue value);
+BridgedType SILValue_getType(BridgedValue value);
+
+BridgedBasicBlock SILArgument_getParent(BridgedArgument argument);
+
+OptionalBridgedInstruction SILInstruction_next(BridgedInstruction inst);
+OptionalBridgedInstruction SILInstruction_previous(BridgedInstruction inst);
+BridgedBasicBlock SILInstruction_getParent(BridgedInstruction inst);
+BridgedOperandArray SILInstruction_getOperands(BridgedInstruction inst);
+BridgedLocation SILInstruction_getLocation(BridgedInstruction inst);
+int SILInstruction_mayHaveSideEffects(BridgedInstruction inst);
+int SILInstruction_mayReadFromMemory(BridgedInstruction inst);
+int SILInstruction_mayWriteToMemory(BridgedInstruction inst);
+int SILInstruction_mayReadOrWriteMemory(BridgedInstruction inst);
+
+BridgedInstruction MultiValueInstResult_getParent(BridgedMultiValueResult result);
+SwiftInt MultipleValueInstruction_getNumResults(BridgedInstruction inst);
+BridgedMultiValueResult
+  MultipleValueInstruction_getResult(BridgedInstruction inst, SwiftInt index);
+
+BridgedStringRef CondFailInst_getMessage(BridgedInstruction cfi);
+BridgedGlobalVar GlobalAccessInst_getGlobal(BridgedInstruction globalInst);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -34,6 +34,14 @@ enum {
   BridgedOperandSize = 4 * sizeof(uintptr_t)
 };
 
+typedef struct {
+  void * _Nullable data;
+} BridgedSlab;
+
+enum {
+  BridgedSlabCapacity = 64 * sizeof(uintptr_t)
+};
+
 enum ChangeNotificationKind {
   instructionsChanged,
   callsChanged,
@@ -121,6 +129,11 @@ void PassContext_notifyChanges(BridgedPassContext passContext,
                                enum ChangeNotificationKind changeKind);
 void PassContext_eraseInstruction(BridgedPassContext passContext,
                                   BridgedInstruction inst);
+BridgedSlab PassContext_getNextSlab(BridgedSlab slab);
+BridgedSlab PassContext_allocSlab(BridgedPassContext passContext,
+                                  BridgedSlab afterSlab);
+BridgedSlab PassContext_freeSlab(BridgedPassContext passContext,
+                                 BridgedSlab slab);
 
 BridgedStringRef SILFunction_getName(BridgedFunction function);
 BridgedStringRef SILFunction_debugDescription(BridgedFunction function);

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -41,6 +41,10 @@ enum ChangeNotificationKind {
 };
 
 typedef struct {
+  const void * _Nonnull opaqueCtxt;
+} BridgedPassContext;
+
+typedef struct {
   void * _Null_unspecified word0;
   void * _Null_unspecified word1;
   void * _Null_unspecified word2;
@@ -112,6 +116,11 @@ typedef long SwiftInt;
 void registerBridgedClass(BridgedStringRef className, SwiftMetatype metatype);
 
 void freeBridgedStringRef(BridgedStringRef str);
+
+void PassContext_notifyChanges(BridgedPassContext passContext,
+                               enum ChangeNotificationKind changeKind);
+void PassContext_eraseInstruction(BridgedPassContext passContext,
+                                  BridgedInstruction inst);
 
 BridgedStringRef SILFunction_getName(BridgedFunction function);
 BridgedStringRef SILFunction_debugDescription(BridgedFunction function);

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -166,6 +166,13 @@ BridgedMultiValueResult
 BridgedStringRef CondFailInst_getMessage(BridgedInstruction cfi);
 BridgedGlobalVar GlobalAccessInst_getGlobal(BridgedInstruction globalInst);
 
+BridgedInstruction SILBuilder_createBuiltinBinaryFunction(
+          BridgedInstruction insertionPoint,
+          BridgedLocation loc, BridgedStringRef name,
+          BridgedType operandType, BridgedType resultType, BridgedValueArray arguments);
+BridgedInstruction SILBuilder_createCondFail(BridgedInstruction insertionPoint,
+          BridgedLocation loc, BridgedValue condition, BridgedStringRef messge);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/include/swift/SIL/SILBridgingUtils.h
+++ b/include/swift/SIL/SILBridgingUtils.h
@@ -1,0 +1,95 @@
+//===--- SILBridgingUtils.h - utilities for swift bridging ----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_SILBRIDGINGUTILS_H
+#define SWIFT_SIL_SILBRIDGINGUTILS_H
+
+#include "swift/SIL/SILBridging.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILGlobalVariable.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <string>
+
+namespace swift {
+
+inline BridgedStringRef getBridgedStringRef(llvm::StringRef str) {
+  return { (const unsigned char *)str.data(), str.size() };
+}
+
+inline StringRef getStringRef(BridgedStringRef str) {
+  return StringRef((const char *)str.data, str.length);
+}
+
+/// Copies the string in an malloc'ed memory and the caller is responsible for
+/// freeing it.
+inline BridgedStringRef getCopiedBridgedStringRef(std::string str,
+                                           bool removeTrailingNewline = false) {
+  // A couple of mallocs are needed for passing a std::string to libswift. But
+  // it's currently only used or debug descriptions. So, its' maybe not so bad -
+  // for now.
+  // TODO: find a better way to pass std::strings to libswift.
+  StringRef strRef(str);
+  if (removeTrailingNewline)
+    strRef.consume_back("\n");
+  llvm::MallocAllocator allocator;
+  StringRef copy = strRef.copy(allocator);
+  return getBridgedStringRef(copy);
+}
+
+inline SILLocation getSILLocation(BridgedLocation loc) {
+  return reinterpret_cast<SILDebugLocation *>(&loc)->getLocation();
+}
+
+inline RegularLocation getRegularLocation(BridgedLocation loc) {
+  return RegularLocation(getSILLocation(loc));
+}
+
+inline const SILDebugScope *getSILDebugScope(BridgedLocation loc) {
+  return reinterpret_cast<SILDebugLocation *>(&loc)->getScope();
+}
+
+inline SILType getSILType(BridgedType ty) {
+  return SILType::getFromOpaqueValue(ty.typePtr);
+}
+
+inline SILNode *castToSILNode(BridgedNode node) {
+  return static_cast<SILNode *>(node.obj);
+}
+
+inline SILValue castToSILValue(BridgedValue value) {
+  return static_cast<ValueBase *>(value.obj);
+}
+
+template <class I = SILInstruction> I *castToInst(BridgedInstruction inst) {
+  return cast<I>(static_cast<SILNode *>(inst.obj)->castToInstruction());
+}
+
+inline SILBasicBlock *castToBasicBlock(BridgedBasicBlock block) {
+  return static_cast<SILBasicBlock *>(block.obj);
+}
+
+inline SILFunction *castToFunction(BridgedFunction function) {
+  return static_cast<SILFunction *>(function.obj);
+}
+
+inline SILGlobalVariable *castToGlobal(BridgedGlobalVar global) {
+  return static_cast<SILGlobalVariable *>(global.obj);
+}
+
+ArrayRef<SILValue> getSILValues(BridgedValueArray values,
+                                SmallVectorImpl<SILValue> &storage);
+
+} // namespace swift
+
+#endif
+

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -123,6 +123,13 @@ public:
     setInsertionPoint(I);
   }
 
+  // Used by libswift bridging.
+  explicit SILBuilder(SILInstruction *I, const SILDebugScope *debugScope)
+      : TempContext(I->getFunction()->getModule()),
+        C(TempContext), F(I->getFunction()), CurDebugScope(debugScope) {
+    setInsertionPoint(I);
+  }
+
   explicit SILBuilder(SILBasicBlock::iterator I,
                       SmallVectorImpl<SILInstruction *> *InsertedInstrs = 0)
       : SILBuilder(&*I, InsertedInstrs) {}

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -21,6 +21,7 @@
 #include "swift/AST/Availability.h"
 #include "swift/AST/ResilienceExpansion.h"
 #include "swift/Basic/ProfileCounter.h"
+#include "swift/SIL/SwiftObjectHeader.h"
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILDeclRef.h"
@@ -129,7 +130,11 @@ private:
 /// zero or more SIL SILBasicBlock objects that contain the SILInstruction
 /// objects making up the function.
 class SILFunction
-  : public llvm::ilist_node<SILFunction>, public SILAllocated<SILFunction> {
+  : public llvm::ilist_node<SILFunction>, public SILAllocated<SILFunction>,
+    public SwiftObjectHeader {
+    
+  static SwiftMetatype registeredMetatype;
+    
 public:
   using BlockListType = llvm::iplist<SILBasicBlock>;
 
@@ -385,6 +390,10 @@ private:
   void setHasOwnership(bool newValue) { HasOwnership = newValue; }
 
 public:
+  static void registerBridgedMetatype(SwiftMetatype metatype) {
+    registeredMetatype = metatype;
+  }
+
   ~SILFunction();
 
   SILModule &getModule() const { return Module; }

--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -21,6 +21,7 @@
 #include "swift/SIL/SILLocation.h"
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILType.h"
+#include "swift/SIL/SwiftObjectHeader.h"
 #include "llvm/ADT/ilist_node.h"
 #include "llvm/ADT/ilist.h"
 
@@ -35,8 +36,11 @@ class VarDecl;
 /// A global variable that has been referenced in SIL.
 class SILGlobalVariable
   : public llvm::ilist_node<SILGlobalVariable>,
-    public SILAllocated<SILGlobalVariable>
+    public SILAllocated<SILGlobalVariable>,
+    public SwiftObjectHeader
 {
+  static SwiftMetatype registeredMetatype;
+    
 public:
   using const_iterator = SILBasicBlock::const_iterator;
 
@@ -97,6 +101,10 @@ private:
                     Optional<SILLocation> loc, VarDecl *decl);
   
 public:
+  static void registerBridgedMetatype(SwiftMetatype metatype) {
+    registeredMetatype = metatype;
+  }
+
   static SILGlobalVariable *create(SILModule &Module, SILLinkage Linkage,
                                    IsSerialized_t IsSerialized,
                                    StringRef MangledName, SILType LoweredType,

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -365,9 +365,14 @@ class SILInstruction : public llvm::ilist_node<SILInstruction> {
   SILInstructionResultArray getResultsImpl() const;
 
 protected:
+  friend class LibswiftPassInvocation;
+
   SILInstruction() {
     NumCreatedInstructions++;
   }
+
+  /// This method unlinks 'self' from the containing basic block.
+  void removeFromParent();
 
   ~SILInstruction() {
     NumDeletedInstructions++;

--- a/include/swift/SIL/SILInstructionWorklist.h
+++ b/include/swift/SIL/SILInstructionWorklist.h
@@ -35,6 +35,7 @@
 
 #include "swift/Basic/BlotSetVector.h"
 #include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/SILValue.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "llvm/ADT/DenseMap.h"
@@ -65,12 +66,19 @@ template <typename VectorT = std::vector<SILInstruction *>,
 class SILInstructionWorklist : SILInstructionWorklistBase {
   BlotSetVector<SILInstruction *, VectorT, MapT> worklist;
 
+  /// For invoking Swift instruction passes in libswift.
+  LibswiftPassInvocation *libswiftPassInvocation = nullptr;
+
   void operator=(const SILInstructionWorklist &rhs) = delete;
   SILInstructionWorklist(const SILInstructionWorklist &worklist) = delete;
 
 public:
   SILInstructionWorklist(const char *loggingName = "InstructionWorklist")
       : SILInstructionWorklistBase(loggingName) {}
+
+  void setLibswiftPassInvocation(LibswiftPassInvocation *invocation) {
+    libswiftPassInvocation = invocation;
+  }
 
   /// Returns true if the worklist is empty.
   bool isEmpty() const { return worklist.empty(); }

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -57,10 +57,10 @@ class Output;
 
 namespace swift {
 
-/// A fixed size slab of memory, which can be allocated and freed by the
-/// SILModule at (basically) zero cost.
-class FixedSizeSlab : public llvm::ilist_node<FixedSizeSlab>,
-                       public SILAllocated<FixedSizeSlab> {
+/// The payload for the FixedSizeSlab.
+/// This is a super-class rather than a member of FixedSizeSlab to make bridging
+/// with libswift easier.
+class FixedSizeSlabPayload {
 public:
   /// The capacity of the payload.
   static constexpr size_t capacity = 64 * sizeof(uintptr_t);
@@ -78,7 +78,7 @@ private:
   uintptr_t overflowGuard = magicNumber;
 
 public:
-  void operator=(const FixedSizeSlab &) = delete;
+  void operator=(const FixedSizeSlabPayload &) = delete;
   void operator delete(void *Ptr, size_t) = delete;
 
   /// Returns the payload pointing to \p T.
@@ -86,6 +86,17 @@ public:
 
   /// Returns the payload pointing to const \p T
   template<typename T> const T *dataFor() const { return (const T *)(&data[0]); }
+};
+
+/// A fixed size slab of memory, which can be allocated and freed by the
+/// SILModule at (basically) zero cost.
+/// See SILModule::allocSlab().
+class FixedSizeSlab : public llvm::ilist_node<FixedSizeSlab>,
+                      public SILAllocated<FixedSizeSlab>,
+                      public FixedSizeSlabPayload {
+public:
+  void operator=(const FixedSizeSlab &) = delete;
+  void operator delete(void *Ptr, size_t) = delete;
 };
 
 class AnyFunctionType;

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -102,6 +102,11 @@
 #endif
 #endif
 
+#ifndef BRIDGED_SINGLE_VALUE_INST
+#define BRIDGED_SINGLE_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
+  SINGLE_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
+#endif
+
 /// DYNAMICCAST_SINGLE_VALUE_INST(ID, TEXTUALNAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
 ///
 /// A SINGLE_VALUE_INST that is a cast instruction. ID is a member of
@@ -204,11 +209,19 @@
 #define VALUE(ID, PARENT) NODE(ID, PARENT)
 #endif
 
+#ifndef BRIDGED_VALUE
+#define BRIDGED_VALUE(ID, PARENT) VALUE(ID, PARENT)
+#endif
+
 /// ARGUMENT(ID, PARENT)
 ///
 ///   A concrete subclass of SILArgument, which is a subclass of ValueBase.
 #ifndef ARGUMENT
 #define ARGUMENT(ID, PARENT) VALUE(ID, PARENT)
+#endif
+
+#ifndef BRIDGED_ARGUMENT
+#define BRIDGED_ARGUMENT(ID, PARENT) ARGUMENT(ID, PARENT)
 #endif
 
 /// INST(ID, PARENT)
@@ -243,6 +256,11 @@
 #ifndef NON_VALUE_INST
 #define NON_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
   FULL_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
+#endif
+
+#ifndef BRIDGED_NON_VALUE_INST
+#define BRIDGED_NON_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
+  NON_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE)
 #endif
 
 #ifndef DYNAMICCAST_NON_VALUE_INST
@@ -407,17 +425,17 @@
 ABSTRACT_NODE(ValueBase, SILNode)
 
 ABSTRACT_VALUE(SILArgument, ValueBase)
-  ARGUMENT(SILPhiArgument, SILArgument)
-  ARGUMENT(SILFunctionArgument, SILArgument)
+  BRIDGED_ARGUMENT(SILPhiArgument, SILArgument)
+  BRIDGED_ARGUMENT(SILFunctionArgument, SILArgument)
   ARGUMENT_RANGE(SILArgument, SILPhiArgument, SILFunctionArgument)
 
-VALUE(MultipleValueInstructionResult, ValueBase)
+BRIDGED_VALUE(MultipleValueInstructionResult, ValueBase)
 
-VALUE(SILUndef, ValueBase)
+BRIDGED_VALUE(SILUndef, ValueBase)
 
 /// Used internally in e.g. the SIL parser and deserializer.
 /// A PlaceholderValue must not appear in valid SIL.
-VALUE(PlaceholderValue, ValueBase)
+BRIDGED_VALUE(PlaceholderValue, ValueBase)
 
 ABSTRACT_NODE(SILInstruction, SILNode)
 
@@ -455,11 +473,11 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
                       LiteralInst, None, DoesNotRelease)
     SINGLE_VALUE_INST(PreviousDynamicFunctionRefInst, prev_dynamic_function_ref,
                       LiteralInst, None, DoesNotRelease)
-    SINGLE_VALUE_INST(GlobalAddrInst, global_addr,
+    BRIDGED_SINGLE_VALUE_INST(GlobalAddrInst, global_addr,
                       LiteralInst, None, DoesNotRelease)
     SINGLE_VALUE_INST(BaseAddrForOffsetInst, base_addr_for_offset,
                       LiteralInst, None, DoesNotRelease)
-    SINGLE_VALUE_INST(GlobalValueInst, global_value,
+    BRIDGED_SINGLE_VALUE_INST(GlobalValueInst, global_value,
                       LiteralInst, None, DoesNotRelease)
     SINGLE_VALUE_INST(IntegerLiteralInst, integer_literal,
                       LiteralInst, None, DoesNotRelease)
@@ -485,7 +503,7 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
 
   // Conversions
   ABSTRACT_SINGLE_VALUE_INST(ConversionInst, SingleValueInstruction)
-    SINGLE_VALUE_INST(UpcastInst, upcast,
+    BRIDGED_SINGLE_VALUE_INST(UpcastInst, upcast,
                       ConversionInst, None, DoesNotRelease)
     SINGLE_VALUE_INST(AddressToPointerInst, address_to_pointer,
                       ConversionInst, None, DoesNotRelease)
@@ -619,7 +637,7 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
   // Function Application
   FULLAPPLYSITE_SINGLE_VALUE_INST(ApplyInst, apply,
                                   SingleValueInstruction, MayHaveSideEffects, MayRelease)
-  SINGLE_VALUE_INST(BuiltinInst, builtin,
+  BRIDGED_SINGLE_VALUE_INST(BuiltinInst, builtin,
                     SingleValueInstruction, MayHaveSideEffects, MayRelease)
   APPLYSITE_SINGLE_VALUE_INST(PartialApplyInst, partial_apply,
                               SingleValueInstruction, MayHaveSideEffects, DoesNotRelease)
@@ -639,7 +657,7 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
                     SingleValueInstruction, None, DoesNotRelease)
   SINGLE_VALUE_INST(TupleInst, tuple,
                     SingleValueInstruction, None, DoesNotRelease)
-  SINGLE_VALUE_INST(TupleExtractInst, tuple_extract,
+  BRIDGED_SINGLE_VALUE_INST(TupleExtractInst, tuple_extract,
                     SingleValueInstruction, None, DoesNotRelease)
   SINGLE_VALUE_INST(TupleElementAddrInst, tuple_element_addr,
                     SingleValueInstruction, None, DoesNotRelease)
@@ -649,9 +667,9 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
                     SingleValueInstruction, None, DoesNotRelease)
   SINGLE_VALUE_INST(StructElementAddrInst, struct_element_addr,
                     SingleValueInstruction, None, DoesNotRelease)
-  SINGLE_VALUE_INST(RefElementAddrInst, ref_element_addr,
+  BRIDGED_SINGLE_VALUE_INST(RefElementAddrInst, ref_element_addr,
                     SingleValueInstruction, None, DoesNotRelease)
-  SINGLE_VALUE_INST(RefTailAddrInst, ref_tail_addr,
+  BRIDGED_SINGLE_VALUE_INST(RefTailAddrInst, ref_tail_addr,
                     SingleValueInstruction, None, DoesNotRelease)
 
   // Enums
@@ -861,7 +879,7 @@ NON_VALUE_INST(AssignByWrapperInst, assign_by_wrapper,
                SILInstruction, MayWrite, DoesNotRelease)
 NON_VALUE_INST(MarkFunctionEscapeInst, mark_function_escape,
                SILInstruction, None, DoesNotRelease)
-NON_VALUE_INST(DebugValueInst, debug_value,
+BRIDGED_NON_VALUE_INST(DebugValueInst, debug_value,
                SILInstruction, None, DoesNotRelease)
 NON_VALUE_INST(DebugValueAddrInst, debug_value_addr,
                SILInstruction, None, DoesNotRelease)
@@ -895,7 +913,7 @@ NON_VALUE_INST(AbortApplyInst, abort_apply,
 
 // Runtime failure
 // FIXME: Special MemBehavior for runtime failure?
-NON_VALUE_INST(CondFailInst, cond_fail,
+BRIDGED_NON_VALUE_INST(CondFailInst, cond_fail,
                SILInstruction, MayHaveSideEffects, DoesNotRelease)
 
 NODE_RANGE(NonValueInstruction, UnreachableInst, CondFailInst)
@@ -935,6 +953,7 @@ NODE_RANGE(SILNode, SILPhiArgument, DestructureTupleInst)
 #undef DYNAMICCAST_TERMINATOR
 #undef TERMINATOR
 #undef NON_VALUE_INST
+#undef BRIDGED_NON_VALUE_INST
 #undef DYNAMICCAST_NON_VALUE_INST
 #undef MULTIPLE_VALUE_INST_RESULT
 #undef FULLAPPLYSITE_MULTIPLE_VALUE_INST
@@ -945,10 +964,13 @@ NODE_RANGE(SILNode, SILPhiArgument, DestructureTupleInst)
 #undef DYNAMICCAST_SINGLE_VALUE_INST
 #undef DYNAMICCAST_INST
 #undef SINGLE_VALUE_INST
+#undef BRIDGED_SINGLE_VALUE_INST
 #undef FULL_INST
 #undef INST
 #undef ARGUMENT
+#undef BRIDGED_ARGUMENT
 #undef VALUE
+#undef BRIDGED_VALUE
 #undef NODE
 #undef APPLYSITE_INST
 #undef FULLAPPLYSITE_INST

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -1006,6 +1006,8 @@ public:
   SILInstruction *getUser() { return Owner; }
   const SILInstruction *getUser() const { return Owner; }
 
+  Operand *getNextUse() const { return NextUse; }
+
   /// Return true if this operand is a type dependent operand.
   ///
   /// Implemented in SILInstruction.h

--- a/include/swift/SIL/SwiftObjectHeader.h
+++ b/include/swift/SIL/SwiftObjectHeader.h
@@ -1,0 +1,36 @@
+//===--- SwiftObjectHeader.h - Defines SwiftObjectHeader ------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_SIL_SWIFTOBJECTHEADER_H
+#define SWIFT_SIL_SWIFTOBJECTHEADER_H
+
+#include "BridgedSwiftObject.h"
+
+/// The C++ version of SwiftObject.
+///
+/// It is used for bridging the SIL core classes (e.g. SILFunction, SILNode,
+/// etc.) with libswift.
+/// For details see libswift/README.md.
+///
+/// In C++ code, never use BridgedSwiftObject directly. SwiftObjectHeader has
+/// the proper constructor, which avoids the header to be uninitialized.
+struct SwiftObjectHeader : BridgedSwiftObject {
+  SwiftObjectHeader(SwiftMetatype metatype) {
+     this->metatype = metatype;
+     this->refCounts = ~(uint64_t)0;
+  }
+  
+  bool isBridged() const {
+    return metatype != nullptr;
+  }
+};
+
+#endif

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -1,0 +1,35 @@
+//===--- OptimizerBridging.h - header for the OptimizerBridging module ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_OPTIMIZERBRIDGING_H
+#define SWIFT_SILOPTIMIZER_OPTIMIZERBRIDGING_H
+
+#include "../SIL/SILBridging.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  BridgedFunction function;
+  BridgedPassContext passContext;
+} BridgedFunctionPassCtxt;
+
+typedef void (*BridgedFunctionPassRunFn)(BridgedFunctionPassCtxt);
+void SILPassManager_registerFunctionPass(BridgedStringRef name,
+                                         BridgedFunctionPassRunFn runFn);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -24,9 +24,19 @@ typedef struct {
   BridgedPassContext passContext;
 } BridgedFunctionPassCtxt;
 
+typedef struct {
+  BridgedInstruction instruction;
+  BridgedPassContext passContext;
+} BridgedInstructionPassCtxt;
+
 typedef void (*BridgedFunctionPassRunFn)(BridgedFunctionPassCtxt);
+typedef void (*BridgedInstructionPassRunFn)(BridgedInstructionPassCtxt);
+
 void SILPassManager_registerFunctionPass(BridgedStringRef name,
                                          BridgedFunctionPassRunFn runFn);
+
+void SILCombine_registerInstructionPass(BridgedStringRef name,
+                                        BridgedInstructionPassRunFn runFn);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -52,9 +52,16 @@ class LibswiftPassInvocation {
   /// Non-null if this is an instruction pass, invoked from SILCombine.
   SILCombiner *silCombiner;
 
+  /// All slabs, allocated by the pass.
+  SILModule::SlabList allocatedSlabs;
+
 public:
   LibswiftPassInvocation(SILPassManager *passManager, SILCombiner *silCombiner) :
     passManager(passManager), silCombiner(silCombiner) {}
+
+  FixedSizeSlab *allocSlab(FixedSizeSlab *afterSlab);
+
+  FixedSizeSlab *freeSlab(FixedSizeSlab *slab);
 
   /// The top-level API to erase an instruction, called from the Swift pass.
   void eraseInstruction(SILInstruction *inst);

--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/SIL/Notifications.h"
+#include "swift/SIL/InstructionUtils.h"
 #include "swift/SILOptimizer/Analysis/Analysis.h"
 #include "swift/SILOptimizer/PassManager/PassPipeline.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
@@ -31,6 +32,8 @@ class SILModule;
 class SILModuleTransform;
 class SILOptions;
 class SILTransform;
+class SILPassManager;
+class SILCombiner;
 
 namespace irgen {
 class IRGenModule;
@@ -40,6 +43,28 @@ class IRGenModule;
 void executePassPipelinePlan(SILModule *SM, const SILPassPipelinePlan &plan,
                              bool isMandatory = false,
                              irgen::IRGenModule *IRMod = nullptr);
+
+/// Utility class to invoke passes in libswift.
+class LibswiftPassInvocation {
+  /// Backlink to the pass manager.
+  SILPassManager *passManager;
+  
+  /// Non-null if this is an instruction pass, invoked from SILCombine.
+  SILCombiner *silCombiner;
+
+public:
+  LibswiftPassInvocation(SILPassManager *passManager, SILCombiner *silCombiner) :
+    passManager(passManager), silCombiner(silCombiner) {}
+
+  /// The top-level API to erase an instruction, called from the Swift pass.
+  void eraseInstruction(SILInstruction *inst);
+
+  /// Called by the pass when changes are made to the SIL.
+  void notifyChanges(SILAnalysis::InvalidationKind invalidationKind);
+
+  /// Called by the pass manager when the pass has finished.
+  void finishedPassRun();
+};
 
 /// The SIL pass manager.
 class SILPassManager {
@@ -78,6 +103,13 @@ class SILPassManager {
 
   /// The number of passes run so far.
   unsigned NumPassesRun = 0;
+
+  /// For invoking Swift passes in libswift.
+  LibswiftPassInvocation libswiftPassInvocation;
+
+  /// Change notifications, collected during a bridged pass run.
+  SILAnalysis::InvalidationKind changeNotifications =
+      SILAnalysis::InvalidationKind::Nothing;
 
   /// A mask which has one bit for each pass. A one for a pass-bit means that
   /// the pass doesn't need to run, because nothing has changed since the
@@ -147,6 +179,10 @@ public:
   /// \returns the associated IGenModule or null if this is not an IRGen
   /// pass manager.
   irgen::IRGenModule *getIRGenModule() { return IRMod; }
+
+  LibswiftPassInvocation *getLibswiftPassInvocation() {
+    return &libswiftPassInvocation;
+  }
 
   /// Restart the function pass pipeline on the same function
   /// that is currently being processed.
@@ -224,6 +260,11 @@ public:
     CurrentPassHasInvalidated = true;
     // Any change let all passes run again.
     CompletedPassesMap[F].reset();
+  }
+
+  void notifyPassChanges(SILAnalysis::InvalidationKind invalidationKind) {
+    changeNotifications = (SILAnalysis::InvalidationKind)
+        (changeNotifications | invalidationKind);
   }
 
   /// Reset the state of the pass manager and remove all transformation
@@ -314,6 +355,11 @@ private:
   /// When asserts are disabled, this is a NoOp.
   void viewCallGraph();
 };
+
+inline void LibswiftPassInvocation::
+notifyChanges(SILAnalysis::InvalidationKind invalidationKind) {
+  passManager->notifyPassChanges(invalidationKind);
+}
 
 } // end namespace swift
 

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -421,6 +421,8 @@ PASS(PruneVTables, "prune-vtables",
      "Mark class methods that do not require vtable dispatch")
 PASS_RANGE(AllPasses, AADumper, PruneVTables)
 
+SWIFT_INSTRUCTION_PASS_WITH_LEGACY(GlobalValueInst, "simplify-global_value")
+
 #undef IRGEN_PASS
 #undef SWIFT_FUNCTION_PASS
 #undef SWIFT_FUNCTION_PASS_WITH_LEGACY

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -271,7 +271,7 @@ PASS(MemBehaviorDumper, "mem-behavior-dump",
      "Print SIL Instruction MemBehavior from Alias Analysis over all Pairs")
 PASS(LSLocationPrinter, "lslocation-dump",
      "Print Load-Store Location Results Covering all Accesses")
-PASS(MergeCondFails, "merge-cond_fails",
+SWIFT_FUNCTION_PASS_WITH_LEGACY(MergeCondFails, "merge-cond_fails",
      "Merge SIL cond_fail to Eliminate Redundant Overflow Checks")
 PASS(MoveCondFailToPreds, "move-cond-fail-to-preds",
      "Move SIL cond_fail by Hoisting Checks")

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -64,6 +64,31 @@
         SWIFT_FUNCTION_PASS(Id, Tag, Description)
 #endif
 
+/// SWIFT_INSTRUCTION_PASS(Inst, Tag)
+///   Similar to SWIFT_FUNCTION_PASS, but defines an instruction pass which is
+///   implemented in libswift and is run by the SILCombiner.
+///   The \p Inst argument specifies the instruction class, and \p Tag a name
+///   for the pass.
+///
+///   No further code is need on the C++ side. In libswift an instruction pass
+///   with the same name must be registered with 'registerPass()'.
+///
+#ifndef SWIFT_INSTRUCTION_PASS
+#define SWIFT_INSTRUCTION_PASS(Inst, Tag)
+#endif
+
+/// SWIFT_INSTRUCTION_PASS_WITH_LEGACY(Inst, Tag)
+///   Like SWIFT_INSTRUCTION_PASS, but the a C++ legacy SILCombine visit
+///   function is used if the not
+///   built with libswift.
+///   The C++ legacy visit function must be named
+///   'SILCombiner::legacyVisit<Inst>'.
+///
+#ifndef SWIFT_INSTRUCTION_PASS_WITH_LEGACY
+#define SWIFT_INSTRUCTION_PASS_WITH_LEGACY(Inst, Tag) \
+        SWIFT_INSTRUCTION_PASS(Inst, Tag)
+#endif
+
 /// PASS_RANGE(RANGE_ID, START, END)
 ///   Pass IDs between PassKind::START and PassKind::END, inclusive,
 ///   fall within the set known as
@@ -399,5 +424,7 @@ PASS_RANGE(AllPasses, AADumper, PruneVTables)
 #undef IRGEN_PASS
 #undef SWIFT_FUNCTION_PASS
 #undef SWIFT_FUNCTION_PASS_WITH_LEGACY
+#undef SWIFT_INSTRUCTION_PASS
+#undef SWIFT_INSTRUCTION_PASS_WITH_LEGACY
 #undef PASS
 #undef PASS_RANGE

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -43,6 +43,27 @@
 #define IRGEN_PASS(Id, Tag, Description) PASS(Id, Tag, Description)
 #endif
 
+/// SWIFT_FUNCTION_PASS(Id, Tag, Description)
+///   This macro follows the same conventions as PASS(Id, Tag, Description),
+///   but is used for function passes which are implemented in libswift.
+///
+///   No further code is need on the C++ side. In libswift a function pass with
+///   the same name must be registered with 'registerPass()'.
+///
+#ifndef SWIFT_FUNCTION_PASS
+#define SWIFT_FUNCTION_PASS(Id, Tag, Description) PASS(Id, Tag, Description)
+#endif
+
+/// SWIFT_FUNCTION_PASS_WITH_LEGACY(Id, Tag, Description)
+///   Like SWIFT_FUNCTION_PASS, but the a C++ legacy pass is used if the not
+///   built with libswift.
+///   The C++ legacy creation function must be named 'createLegacy<Id>'
+///
+#ifndef SWIFT_FUNCTION_PASS_WITH_LEGACY
+#define SWIFT_FUNCTION_PASS_WITH_LEGACY(Id, Tag, Description) \
+        SWIFT_FUNCTION_PASS(Id, Tag, Description)
+#endif
+
 /// PASS_RANGE(RANGE_ID, START, END)
 ///   Pass IDs between PassKind::START and PassKind::END, inclusive,
 ///   fall within the set known as
@@ -374,5 +395,7 @@ PASS(PruneVTables, "prune-vtables",
 PASS_RANGE(AllPasses, AADumper, PruneVTables)
 
 #undef IRGEN_PASS
+#undef SWIFT_FUNCTION_PASS
+#undef SWIFT_FUNCTION_PASS_WITH_LEGACY
 #undef PASS
 #undef PASS_RANGE

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -339,6 +339,8 @@ PASS(SILDebugInfoGenerator, "sil-debuginfo-gen",
      "Generate Debug Information with Source Locations into Textual SIL")
 PASS(EarlySROA, "early-sroa",
      "Scalar Replacement of Aggregate Stack Objects on high-level SIL")
+SWIFT_FUNCTION_PASS(SILPrinter, "sil-printer",
+     "Test pass which prints the SIL of a function")
 PASS(SROA, "sroa",
      "Scalar Replacement of Aggregate Stack Objects")
 PASS(SROABBArgs, "sroa-bb-args",

--- a/include/swift/SILOptimizer/PassManager/Passes.h
+++ b/include/swift/SILOptimizer/PassManager/Passes.h
@@ -74,7 +74,11 @@ namespace swift {
   StringRef PassKindID(PassKind Kind);
   StringRef PassKindTag(PassKind Kind);
 
-#define PASS(ID, TAG, NAME) SILTransform *create##ID();
+#define PASS(ID, TAG, NAME) \
+  SILTransform *create##ID();
+#define SWIFT_FUNCTION_PASS_WITH_LEGACY(ID, TAG, NAME) \
+  PASS(ID, TAG, NAME) \
+  SILTransform *createLegacy##ID();
 #define IRGEN_PASS(ID, TAG, NAME)
 #include "Passes.def"
 

--- a/include/swift/module.modulemap
+++ b/include/swift/module.modulemap
@@ -3,3 +3,8 @@ module SILBridging {
   export *
 }
 
+module OptimizerBridging {
+  header "SILOptimizer/OptimizerBridging.h"
+  export *
+}
+

--- a/include/swift/module.modulemap
+++ b/include/swift/module.modulemap
@@ -1,0 +1,5 @@
+module SILBridging {
+  header "SIL/SILBridging.h"
+  export *
+}
+

--- a/lib/SIL/IR/SILBasicBlock.cpp
+++ b/lib/SIL/IR/SILBasicBlock.cpp
@@ -19,6 +19,7 @@
 #include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILBuilder.h"
+#include "swift/SIL/SILBridging.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILFunction.h"
@@ -26,11 +27,20 @@
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILUndef.h"
 #include "swift/Strings.h"
+
 using namespace swift;
 
 //===----------------------------------------------------------------------===//
 // SILBasicBlock Implementation
 //===----------------------------------------------------------------------===//
+
+SwiftMetatype SILBasicBlock::registeredMetatype;    
+
+SILBasicBlock::SILBasicBlock() :
+  SwiftObjectHeader(registeredMetatype), Parent(nullptr) {}
+
+SILBasicBlock::SILBasicBlock(SILFunction *parent) :
+  SwiftObjectHeader(registeredMetatype), Parent(parent) {}
 
 SILBasicBlock::~SILBasicBlock() {
   if (!getParent()) {

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -14,6 +14,7 @@
 
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILBridging.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILModule.h"
@@ -124,6 +125,8 @@ SILFunction::create(SILModule &M, SILLinkage linkage, StringRef name,
   return fn;
 }
 
+SwiftMetatype SILFunction::registeredMetatype;
+
 SILFunction::SILFunction(SILModule &Module, SILLinkage Linkage, StringRef Name,
                          CanSILFunctionType LoweredType,
                          GenericEnvironment *genericEnv,
@@ -135,7 +138,8 @@ SILFunction::SILFunction(SILModule &Module, SILLinkage Linkage, StringRef Name,
                          const SILDebugScope *DebugScope,
                          IsDynamicallyReplaceable_t isDynamic,
                          IsExactSelfClass_t isExactSelfClass)
-    : Module(Module), Availability(AvailabilityContext::alwaysAvailable())  {
+    : SwiftObjectHeader(registeredMetatype),
+      Module(Module), Availability(AvailabilityContext::alwaysAvailable())  {
   init(Linkage, Name, LoweredType, genericEnv, Loc, isBareSILFunction, isTrans,
        isSerialized, entryCount, isThunk, classSubclassScope, inlineStrategy,
        E, DebugScope, isDynamic, isExactSelfClass);

--- a/lib/SIL/IR/SILGlobalVariable.cpp
+++ b/lib/SIL/IR/SILGlobalVariable.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/SIL/SILBridging.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILGlobalVariable.h"
 #include "swift/SIL/SILInstruction.h"
@@ -18,6 +19,8 @@
 
 using namespace swift;
 
+SwiftMetatype SILGlobalVariable::registeredMetatype;
+    
 SILGlobalVariable *SILGlobalVariable::create(SILModule &M, SILLinkage linkage,
                                              IsSerialized_t isSerialized,
                                              StringRef name,
@@ -44,7 +47,8 @@ SILGlobalVariable::SILGlobalVariable(SILModule &Module, SILLinkage Linkage,
                                      IsSerialized_t isSerialized,
                                      StringRef Name, SILType LoweredType,
                                      Optional<SILLocation> Loc, VarDecl *Decl)
-  : Module(Module),
+  : SwiftObjectHeader(registeredMetatype),
+    Module(Module),
     Name(Name),
     LoweredType(LoweredType),
     Location(Loc.getValueOr(SILLocation::invalid())),

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -103,6 +103,16 @@ SILModule &SILInstruction::getModule() const {
   return getFunction()->getModule();
 }
 
+void SILInstruction::removeFromParent() {
+#ifndef NDEBUG
+  for (auto result : getResults()) {
+    assert(result->use_empty() && "Uses of SILInstruction remain at deletion.");
+  }
+#endif
+  getParent()->remove(this);
+  ParentBB = nullptr;
+}
+
 /// eraseFromParent - This method unlinks 'self' from the containing basic
 /// block and deletes it.
 ///

--- a/lib/SIL/Utils/CMakeLists.txt
+++ b/lib/SIL/Utils/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(swiftSIL PRIVATE
   OwnershipUtils.cpp
   PrettyStackTrace.cpp
   Projection.cpp
+  SILBridging.cpp
   SILInstructionWorklist.cpp
   SILRemarkStreamer.cpp
   ValueUtils.cpp)

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -1,0 +1,363 @@
+//===--- SILBridgingUtils.cpp - Utilities for swift bridging --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/SILNode.h"
+#include "swift/SIL/SILBridgingUtils.h"
+#include "swift/SIL/SILGlobalVariable.h"
+
+using namespace swift;
+
+namespace {
+
+bool nodeMetatypesInitialized = false;
+
+// Filled in by class registration in initializeLibSwift().
+SwiftMetatype nodeMetatypes[(unsigned)SILNodeKind::Last_SILNode + 1];
+
+}
+
+// Does return null, if libswift is not used, i.e. initializeLibSwift() is
+// never called.
+SwiftMetatype SILNode::getSILNodeMetatype(SILNodeKind kind) {
+  SwiftMetatype metatype = nodeMetatypes[(unsigned)kind];
+  assert((!nodeMetatypesInitialized || metatype) &&
+        "no metatype for bridged SIL node");
+  return metatype;
+}
+
+static_assert(sizeof(BridgedLocation) == sizeof(SILDebugLocation),
+              "BridgedLocation has wrong size");
+
+/// Fills \p storage with all Values from the bridged \p values array.
+ArrayRef<SILValue> swift::getSILValues(BridgedValueArray values,
+                                       SmallVectorImpl<SILValue> &storage) {
+  auto *base = reinterpret_cast<const SwiftObject *>(values.data);
+
+  // The bridged array contains class existentials, which have a layout of two
+  // words. The first word is the actual object. Pick the objects and store them
+  // into storage.
+  for (unsigned idx = 0; idx < values.count; ++idx) {
+    storage.push_back(castToSILValue({base[idx * 2]}));
+  }
+  return storage;
+}
+
+//===----------------------------------------------------------------------===//
+//                          Class registration
+//===----------------------------------------------------------------------===//
+
+static llvm::StringMap<SILNodeKind> valueNamesToKind;
+static llvm::SmallPtrSet<SwiftMetatype, 4> unimplementedTypes;
+
+// Utility to fill in a metatype of an "unimplemented" class for a whole range
+// of class types.
+static void setUnimplementedRange(SwiftMetatype metatype,
+                                  SILNodeKind from, SILNodeKind to) {
+  unimplementedTypes.insert(metatype);
+  for (unsigned kind = (unsigned)from; kind <= (unsigned)to; ++kind) {
+    assert((!nodeMetatypes[kind] || unimplementedTypes.count(metatype)) &&
+           "unimplemented nodes must be registered first");
+    nodeMetatypes[kind] = metatype;
+  }
+}
+
+/// Registers the metatype of a libswift class.
+/// Called by initializeLibSwift().
+void registerBridgedClass(BridgedStringRef className, SwiftMetatype metatype) {
+  nodeMetatypesInitialized = true;
+
+  // Handle the important non Node classes.
+  StringRef clName = getStringRef(className);
+  if (clName == "Function")
+    return SILFunction::registerBridgedMetatype(metatype);
+  if (clName == "BasicBlock")
+    return SILBasicBlock::registerBridgedMetatype(metatype);
+  if (clName == "GlobalVariable")
+    return SILGlobalVariable::registerBridgedMetatype(metatype);
+  if (clName == "BlockArgument") {
+    nodeMetatypes[(unsigned)SILNodeKind::SILPhiArgument] = metatype;
+    nodeMetatypes[(unsigned)SILNodeKind::SILFunctionArgument] = metatype;
+    return;
+  }
+
+  // Pre-populate the "unimplemented" ranges of metatypes.
+  // If a specifc class is not implemented yet in libswift, it bridges to an
+  // "unimplemented" class. This ensures that optimizations handle _all_ kind of
+  // instructions gracefully, without the need to define the not-yet-used
+  // classes in libswift.
+#define VALUE_RANGE(ID) SILNodeKind::First_##ID, SILNodeKind::Last_##ID
+  if (clName == "UnimplementedRefCountingInst")
+    return setUnimplementedRange(metatype, VALUE_RANGE(RefCountingInst));
+  if (clName == "UnimplementedSingleValueInst")
+    return setUnimplementedRange(metatype, VALUE_RANGE(SingleValueInstruction));
+  if (clName == "UnimplementedMultiValueInst")
+    return setUnimplementedRange(metatype, VALUE_RANGE(MultipleValueInstruction));
+  if (clName == "UnimplementedInstruction")
+    return setUnimplementedRange(metatype, VALUE_RANGE(SILInstruction));
+#undef VALUE_RANGE
+
+  if (valueNamesToKind.empty()) {
+#define BRIDGED_VALUE(ID, PARENT) \
+    valueNamesToKind[#ID] = SILNodeKind::ID;
+#define BRIDGED_NON_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
+    BRIDGED_VALUE(ID, NAME)
+#define BRIDGED_ARGUMENT(ID, PARENT) \
+    BRIDGED_VALUE(ID, NAME)
+#define BRIDGED_SINGLE_VALUE_INST(ID, NAME, PARENT, MEMBEHAVIOR, MAYRELEASE) \
+    BRIDGED_VALUE(ID, NAME)
+#include "swift/SIL/SILNodes.def"
+  }
+
+  std::string prefixedName;
+  auto iter = valueNamesToKind.find(clName);
+  if (iter == valueNamesToKind.end()) {
+    // Try again with a "SIL" prefix. For example Argument -> SILArgument.
+    prefixedName = std::string("SIL") + std::string(clName);
+    clName = prefixedName;
+  }
+
+  iter = valueNamesToKind.find(clName);
+  if (iter == valueNamesToKind.end()) {
+    llvm::errs() << "Unknonwn bridged node class " << clName << '\n';
+    abort();
+  }
+  SILNodeKind kind = iter->second;
+  SwiftMetatype existingTy = nodeMetatypes[(unsigned)kind];
+  if (existingTy && !unimplementedTypes.count(existingTy)) {
+    llvm::errs() << "Double registration of class " << clName << '\n';
+    abort();
+  }
+  nodeMetatypes[(unsigned)kind] = metatype;
+}
+
+//===----------------------------------------------------------------------===//
+//                            Bridging C functions
+//===----------------------------------------------------------------------===//
+
+/// Frees a string which was allocated by getCopiedBridgedStringRef.
+void freeBridgedStringRef(BridgedStringRef str) {
+  llvm::MallocAllocator().Deallocate(str.data, str.length);
+}
+
+//===----------------------------------------------------------------------===//
+//                                SILFunction
+//===----------------------------------------------------------------------===//
+
+BridgedStringRef SILFunction_getName(BridgedFunction function) {
+  return getBridgedStringRef(castToFunction(function)->getName());
+}
+
+BridgedStringRef SILFunction_debugDescription(BridgedFunction function) {
+  std::string str;
+  llvm::raw_string_ostream os(str);
+  castToFunction(function)->print(os);
+  return getCopiedBridgedStringRef(str, /*removeTrailingNewline*/ true);
+}
+
+OptionalBridgedBasicBlock SILFunction_firstBlock(BridgedFunction function) {
+  SILFunction *f = castToFunction(function);
+  if (f->empty())
+    return {nullptr};
+  return {f->getEntryBlock()};
+}
+
+OptionalBridgedBasicBlock SILFunction_lastBlock(BridgedFunction function) {
+  SILFunction *f = castToFunction(function);
+  if (f->empty())
+    return {nullptr};
+  return {&*f->rbegin()};
+}
+
+//===----------------------------------------------------------------------===//
+//                               SILBasicBlock
+//===----------------------------------------------------------------------===//
+
+OptionalBridgedBasicBlock SILBasicBlock_next(BridgedBasicBlock block) {
+  SILBasicBlock *b = castToBasicBlock(block);
+  auto iter = std::next(b->getIterator());
+  if (iter == b->getParent()->end())
+    return {nullptr};
+  return {&*iter};
+}
+
+OptionalBridgedBasicBlock SILBasicBlock_previous(BridgedBasicBlock block) {
+  SILBasicBlock *b = castToBasicBlock(block);
+  auto iter = std::next(b->getReverseIterator());
+  if (iter == b->getParent()->rend())
+    return {nullptr};
+  return {&*iter};
+}
+
+BridgedStringRef SILBasicBlock_debugDescription(BridgedBasicBlock block) {
+  std::string str;
+  llvm::raw_string_ostream os(str);
+  castToBasicBlock(block)->print(os);
+  return getCopiedBridgedStringRef(str, /*removeTrailingNewline*/ true);
+}
+
+OptionalBridgedInstruction SILBasicBlock_firstInst(BridgedBasicBlock block) {
+  SILBasicBlock *b = castToBasicBlock(block);
+  if (b->empty())
+    return {nullptr};
+  return {b->front().asSILNode()};
+}
+
+OptionalBridgedInstruction SILBasicBlock_lastInst(BridgedBasicBlock block) {
+  SILBasicBlock *b = castToBasicBlock(block);
+  if (b->empty())
+    return {nullptr};
+  return {b->back().asSILNode()};
+}
+
+SwiftInt SILBasicBlock_getNumArguments(BridgedBasicBlock block) {
+  return castToBasicBlock(block)->getNumArguments();
+}
+
+BridgedArgument SILBasicBlock_getArgument(BridgedBasicBlock block, SwiftInt index) {
+  return {castToBasicBlock(block)->getArgument(index)};
+}
+
+
+//===----------------------------------------------------------------------===//
+//                                SILArgument
+//===----------------------------------------------------------------------===//
+
+BridgedBasicBlock SILArgument_getParent(BridgedArgument argument) {
+  return {static_cast<SILArgument *>(argument.obj)->getParent()};
+}
+
+//===----------------------------------------------------------------------===//
+//                                SILValue
+//===----------------------------------------------------------------------===//
+
+static_assert(BridgedOperandSize == sizeof(Operand),
+              "wrong bridged Operand size");
+
+BridgedStringRef SILNode_debugDescription(BridgedNode node) {
+  std::string str;
+  llvm::raw_string_ostream os(str);
+  castToSILNode(node)->print(os);
+  return getCopiedBridgedStringRef(str, /*removeTrailingNewline*/ true);
+}
+
+static Operand *castToOperand(BridgedOperand operand) {
+  return const_cast<Operand *>(static_cast<const Operand *>(operand.op));
+}
+
+BridgedValue Operand_getValue(BridgedOperand operand) {
+  return {castToOperand(operand)->get()};
+}
+
+OptionalBridgedOperand Operand_nextUse(BridgedOperand operand) {
+  return {castToOperand(operand)->getNextUse()};
+}
+
+BridgedInstruction Operand_getUser(BridgedOperand operand) {
+  return {castToOperand(operand)->getUser()->asSILNode()};
+}
+
+OptionalBridgedOperand SILValue_firstUse(BridgedValue value) {
+  return {*castToSILValue(value)->use_begin()};
+}
+
+BridgedType SILValue_getType(BridgedValue value) {
+  return { castToSILValue(value)->getType().getOpaqueValue() };
+}
+
+//===----------------------------------------------------------------------===//
+//                            SILGlobalVariable
+//===----------------------------------------------------------------------===//
+
+BridgedStringRef SILGlobalVariable_getName(BridgedGlobalVar global) {
+  return getBridgedStringRef(castToGlobal(global)->getName());
+}
+
+BridgedStringRef SILGlobalVariable_debugDescription(BridgedGlobalVar global) {
+  std::string str;
+  llvm::raw_string_ostream os(str);
+  castToGlobal(global)->print(os);
+  return getCopiedBridgedStringRef(str, /*removeTrailingNewline*/ true);
+}
+
+//===----------------------------------------------------------------------===//
+//                               SILInstruction
+//===----------------------------------------------------------------------===//
+
+OptionalBridgedInstruction SILInstruction_next(BridgedInstruction inst) {
+  SILInstruction *i = castToInst(inst);
+  auto iter = std::next(i->getIterator());
+  if (iter == i->getParent()->end())
+    return {nullptr};
+  return {iter->asSILNode()};
+}
+
+OptionalBridgedInstruction SILInstruction_previous(BridgedInstruction inst) {
+  SILInstruction *i = castToInst(inst);
+  auto iter = std::next(i->getReverseIterator());
+  if (iter == i->getParent()->rend())
+    return {nullptr};
+  return {iter->asSILNode()};
+}
+
+BridgedBasicBlock SILInstruction_getParent(BridgedInstruction inst) {
+  SILInstruction *i = castToInst(inst);
+  assert(!i->isStaticInitializerInst() &&
+         "cannot get the parent of a static initializer instruction");
+  return {i->getParent()};
+}
+
+BridgedOperandArray SILInstruction_getOperands(BridgedInstruction inst) {
+  auto operands = castToInst(inst)->getAllOperands();
+  return {(const unsigned char *)operands.data(), operands.size()};
+}
+
+BridgedLocation SILInstruction_getLocation(BridgedInstruction inst) {
+  SILDebugLocation loc = castToInst(inst)->getDebugLocation();
+  return *reinterpret_cast<BridgedLocation *>(&loc);
+}
+
+int SILInstruction_mayHaveSideEffects(BridgedInstruction inst) {
+  return castToInst(inst)->mayHaveSideEffects();
+}
+int SILInstruction_mayReadFromMemory(BridgedInstruction inst) {
+  return castToInst(inst)->mayReadFromMemory();
+}
+int SILInstruction_mayWriteToMemory(BridgedInstruction inst) {
+  return castToInst(inst)->mayWriteToMemory();
+}
+int SILInstruction_mayReadOrWriteMemory(BridgedInstruction inst) {
+  return castToInst(inst)->mayReadOrWriteMemory();
+}
+
+BridgedInstruction MultiValueInstResult_getParent(BridgedMultiValueResult result) {
+  return {static_cast<MultipleValueInstructionResult *>(result.obj)->getParent()};
+}
+
+SwiftInt MultipleValueInstruction_getNumResults(BridgedInstruction inst) {
+  return castToInst<MultipleValueInstruction>(inst)->getNumResults();
+}
+BridgedMultiValueResult
+MultipleValueInstruction_getResult(BridgedInstruction inst, SwiftInt index) {
+  return {castToInst<MultipleValueInstruction>(inst)->getResult(index)};
+}
+
+//===----------------------------------------------------------------------===//
+//                            Instruction classes
+//===----------------------------------------------------------------------===//
+
+BridgedStringRef CondFailInst_getMessage(BridgedInstruction cfi) {
+  return getBridgedStringRef(castToInst<CondFailInst>(cfi)->getMessage());
+}
+
+BridgedGlobalVar GlobalAccessInst_getGlobal(BridgedInstruction globalInst) {
+  return {castToInst<GlobalAccessInst>(globalInst)->getReferencedGlobal()};
+}

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -13,6 +13,7 @@
 #include "swift/SIL/SILNode.h"
 #include "swift/SIL/SILBridgingUtils.h"
 #include "swift/SIL/SILGlobalVariable.h"
+#include "swift/SIL/SILBuilder.h"
 
 using namespace swift;
 
@@ -360,4 +361,27 @@ BridgedStringRef CondFailInst_getMessage(BridgedInstruction cfi) {
 
 BridgedGlobalVar GlobalAccessInst_getGlobal(BridgedInstruction globalInst) {
   return {castToInst<GlobalAccessInst>(globalInst)->getReferencedGlobal()};
+}
+
+//===----------------------------------------------------------------------===//
+//                                SILBuilder
+//===----------------------------------------------------------------------===//
+
+BridgedInstruction SILBuilder_createBuiltinBinaryFunction(
+          BridgedInstruction insertionPoint,
+          BridgedLocation loc, BridgedStringRef name,
+          BridgedType operandType, BridgedType resultType,
+          BridgedValueArray arguments) {
+    SILBuilder builder(castToInst(insertionPoint), getSILDebugScope(loc));
+    SmallVector<SILValue, 16> argValues;
+    return {builder.createBuiltinBinaryFunction(getRegularLocation(loc),
+      getStringRef(name), getSILType(operandType), getSILType(resultType),
+      getSILValues(arguments, argValues))};
+}
+
+BridgedInstruction SILBuilder_createCondFail(BridgedInstruction insertionPoint,
+          BridgedLocation loc, BridgedValue condition, BridgedStringRef messge) {
+  SILBuilder builder(castToInst(insertionPoint), getSILDebugScope(loc));
+  return {builder.createCondFail(getRegularLocation(loc),
+    castToSILValue(condition), getStringRef(messge))};
 }

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -16,10 +16,12 @@
 #include "swift/AST/SILOptimizerRequests.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/SIL/ApplySite.h"
+#include "swift/SIL/SILBridgingUtils.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
 #include "swift/SILOptimizer/Analysis/FunctionOrder.h"
+#include "swift/SILOptimizer/OptimizerBridging.h"
 #include "swift/SILOptimizer/PassManager/PrettyStackTrace.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/OptimizerStatsUtils.h"
@@ -318,8 +320,9 @@ void swift::executePassPipelinePlan(SILModule *SM,
 
 SILPassManager::SILPassManager(SILModule *M, bool isMandatory,
                                irgen::IRGenModule *IRMod)
-    : Mod(M), IRMod(IRMod), isMandatory(isMandatory),
-      deserializationNotificationHandler(nullptr) {
+    : Mod(M), IRMod(IRMod),
+      libswiftPassInvocation(this, /*SILCombiner*/ nullptr),
+      isMandatory(isMandatory), deserializationNotificationHandler(nullptr) {
 #define ANALYSIS(NAME) \
   Analyses.push_back(create##NAME##Analysis(Mod));
 #include "swift/SILOptimizer/Analysis/Analysis.def"
@@ -462,7 +465,19 @@ void SILPassManager::runPassOnFunction(unsigned TransIdx, SILFunction *F) {
                        SILForceVerifyAroundPass.end(), MatchFun)) {
     forcePrecomputeAnalyses(F);
   }
+  
+  assert(changeNotifications == SILAnalysis::InvalidationKind::Nothing
+         && "change notifications not cleared");
+  
+  // Run it!
   SFT->run();
+
+  if (changeNotifications != SILAnalysis::InvalidationKind::Nothing) {
+    invalidateAnalysis(F, changeNotifications);
+    changeNotifications = SILAnalysis::InvalidationKind::Nothing;
+  }
+  libswiftPassInvocation.finishedPassRun();
+
   if (SILForceVerifyAll ||
       SILForceVerifyAroundPass.end() !=
           std::find_if(SILForceVerifyAroundPass.begin(),
@@ -1059,3 +1074,49 @@ void SILPassManager::viewCallGraph() {
   llvm::ViewGraph(&OCG, "callgraph");
 #endif
 }
+
+//===----------------------------------------------------------------------===//
+//                           LibswiftPassInvocation
+//===----------------------------------------------------------------------===//
+
+void LibswiftPassInvocation::eraseInstruction(SILInstruction *inst) {
+  if (silCombiner) {
+    // TODO
+  } else {
+    inst->eraseFromParent();
+  }
+}
+
+void LibswiftPassInvocation::finishedPassRun() {
+}
+
+//===----------------------------------------------------------------------===//
+//                            Swift Bridging
+//===----------------------------------------------------------------------===//
+
+inline LibswiftPassInvocation *castToPassInvocation(BridgedPassContext ctxt) {
+  return const_cast<LibswiftPassInvocation *>(
+    static_cast<const LibswiftPassInvocation *>(ctxt.opaqueCtxt));
+}
+
+void PassContext_notifyChanges(BridgedPassContext passContext,
+                               enum ChangeNotificationKind changeKind) {
+  LibswiftPassInvocation *inv = castToPassInvocation(passContext);
+  switch (changeKind) {
+  case instructionsChanged:
+    inv->notifyChanges(SILAnalysis::InvalidationKind::Instructions);
+    break;
+  case callsChanged:
+    inv->notifyChanges(SILAnalysis::InvalidationKind::CallsAndInstructions);
+    break;
+  case branchesChanged:
+    inv->notifyChanges(SILAnalysis::InvalidationKind::BranchesAndInstructions);
+    break;
+  }
+}
+
+void PassContext_eraseInstruction(BridgedPassContext passContext,
+                                   BridgedInstruction inst) {
+  castToPassInvocation(passContext)->eraseInstruction(castToInst(inst));
+}
+

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -1099,14 +1099,6 @@ FixedSizeSlab *LibswiftPassInvocation::freeSlab(FixedSizeSlab *slab) {
   return prev;
 }
 
-void LibswiftPassInvocation::eraseInstruction(SILInstruction *inst) {
-  if (silCombiner) {
-    // TODO
-  } else {
-    inst->eraseFromParent();
-  }
-}
-
 void LibswiftPassInvocation::finishedPassRun() {
   assert(allocatedSlabs.empty() && "StackList is leaking slabs");
 }

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -1079,6 +1079,26 @@ void SILPassManager::viewCallGraph() {
 //                           LibswiftPassInvocation
 //===----------------------------------------------------------------------===//
 
+static_assert(BridgedSlabCapacity == FixedSizeSlab::capacity,
+              "wrong bridged slab capacity");
+
+FixedSizeSlab *LibswiftPassInvocation::allocSlab(FixedSizeSlab *afterSlab) {
+  FixedSizeSlab *slab = passManager->getModule()->allocSlab();
+  if (afterSlab) {
+    allocatedSlabs.insert(std::next(afterSlab->getIterator()), *slab);
+  } else {
+    allocatedSlabs.push_back(*slab);
+  }
+  return slab;
+}
+
+FixedSizeSlab *LibswiftPassInvocation::freeSlab(FixedSizeSlab *slab) {
+  FixedSizeSlab *prev = std::prev(&*slab->getIterator());
+  allocatedSlabs.remove(*slab);
+  passManager->getModule()->freeSlab(slab);
+  return prev;
+}
+
 void LibswiftPassInvocation::eraseInstruction(SILInstruction *inst) {
   if (silCombiner) {
     // TODO
@@ -1088,6 +1108,7 @@ void LibswiftPassInvocation::eraseInstruction(SILInstruction *inst) {
 }
 
 void LibswiftPassInvocation::finishedPassRun() {
+  assert(allocatedSlabs.empty() && "StackList is leaking slabs");
 }
 
 //===----------------------------------------------------------------------===//
@@ -1097,6 +1118,38 @@ void LibswiftPassInvocation::finishedPassRun() {
 inline LibswiftPassInvocation *castToPassInvocation(BridgedPassContext ctxt) {
   return const_cast<LibswiftPassInvocation *>(
     static_cast<const LibswiftPassInvocation *>(ctxt.opaqueCtxt));
+}
+
+inline FixedSizeSlab *castToSlab(BridgedSlab slab) {
+  if (slab.data)
+    return static_cast<FixedSizeSlab *>((FixedSizeSlabPayload *)slab.data);
+  return nullptr;
+}
+
+inline BridgedSlab toBridgedSlab(FixedSizeSlab *slab) {
+  if (slab) {
+    FixedSizeSlabPayload *payload = slab;
+    assert((void *)payload == slab->dataFor<void>());
+    return {payload};
+  }
+  return {nullptr};
+}
+
+
+BridgedSlab PassContext_getNextSlab(BridgedSlab slab) {
+  return toBridgedSlab(&*std::next(castToSlab(slab)->getIterator()));
+}
+
+BridgedSlab PassContext_allocSlab(BridgedPassContext passContext,
+                                  BridgedSlab afterSlab) {
+  auto *inv = castToPassInvocation(passContext);
+  return toBridgedSlab(inv->allocSlab(castToSlab(afterSlab)));
+}
+
+BridgedSlab PassContext_freeSlab(BridgedPassContext passContext,
+                                 BridgedSlab slab) {
+  auto *inv = castToPassInvocation(passContext);
+  return toBridgedSlab(inv->freeSlab(castToSlab(slab)));
 }
 
 void PassContext_notifyChanges(BridgedPassContext passContext,

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -326,10 +326,11 @@ public:
       
   SILInstruction *visitMarkDependenceInst(MarkDependenceInst *MDI);
   SILInstruction *visitClassifyBridgeObjectInst(ClassifyBridgeObjectInst *CBOI);
-  SILInstruction *visitGlobalValueInst(GlobalValueInst *globalValue);
   SILInstruction *visitConvertFunctionInst(ConvertFunctionInst *CFI);
   SILInstruction *
   visitConvertEscapeToNoEscapeInst(ConvertEscapeToNoEscapeInst *Cvt);
+
+  SILInstruction *legacyVisitGlobalValueInst(GlobalValueInst *globalValue);
 
 #define PASS(ID, TAG, DESCRIPTION)
 #define SWIFT_FUNCTION_PASS(ID, TAG, DESCRIPTION)

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -28,13 +28,17 @@
 #include "swift/SIL/SILInstructionWorklist.h"
 #include "swift/SIL/SILValue.h"
 #include "swift/SIL/SILVisitor.h"
+#include "swift/SIL/InstructionUtils.h"
 #include "swift/SILOptimizer/Analysis/ClassHierarchyAnalysis.h"
 #include "swift/SILOptimizer/Analysis/NonLocalAccessBlockAnalysis.h"
 #include "swift/SILOptimizer/Analysis/ProtocolConformanceAnalysis.h"
+#include "swift/SILOptimizer/OptimizerBridging.h"
 #include "swift/SILOptimizer/Utils/CastOptimizer.h"
 #include "swift/SILOptimizer/Utils/Existential.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "swift/SILOptimizer/Utils/OwnershipOptUtils.h"
+#include "swift/SILOptimizer/PassManager/PassManager.h"
+
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 
@@ -101,6 +105,9 @@ class SILCombiner :
 
   /// External context struct used by \see ownershipRAUWHelper.
   OwnershipFixupContext ownershipFixupContext;
+  
+  /// For invoking Swift instruction passes in libswift.
+  LibswiftPassInvocation libswiftPassInvocation;
 
 public:
   SILCombiner(SILFunctionTransform *parentTransform,
@@ -145,7 +152,8 @@ public:
                         /* EraseAction */
                         [&](SILInstruction *I) { eraseInstFromFunction(*I); }),
         deBlocks(&B.getFunction()),
-        ownershipFixupContext(getInstModCallbacks(), deBlocks) {}
+        ownershipFixupContext(getInstModCallbacks(), deBlocks),
+        libswiftPassInvocation(parentTransform->getPassManager(), this) {}
 
   bool runOnFunction(SILFunction &F);
 
@@ -323,6 +331,12 @@ public:
   SILInstruction *
   visitConvertEscapeToNoEscapeInst(ConvertEscapeToNoEscapeInst *Cvt);
 
+#define PASS(ID, TAG, DESCRIPTION)
+#define SWIFT_FUNCTION_PASS(ID, TAG, DESCRIPTION)
+#define SWIFT_INSTRUCTION_PASS(INST, TAG) \
+  SILInstruction *visit##INST(INST *);
+#include "swift/SILOptimizer/PassManager/Passes.def"
+
   /// Instruction visitor helpers.
   SILInstruction *optimizeBuiltinCanBeObjCClass(BuiltinInst *AI);
 
@@ -453,6 +467,10 @@ private:
   bool hasOwnership() const {
     return Builder.hasOwnership();
   }
+  
+  void runSwiftInstructionPass(SILInstruction *inst,
+                               void (*runFunction)(BridgedInstructionPassCtxt));
+
 };
 
 } // end namespace swift

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -2312,7 +2312,7 @@ static bool checkGlobalValueUsers(SILValue val,
 }
 
 SILInstruction *
-SILCombiner::visitGlobalValueInst(GlobalValueInst *globalValue) {
+SILCombiner::legacyVisitGlobalValueInst(GlobalValueInst *globalValue) {
   // Delete all reference count instructions on a global_value if the only other
   // users are projections (ref_element_addr and ref_tail_addr).
   SmallVector<SILInstruction *, 8> toDelete;

--- a/lib/SILOptimizer/Transforms/MergeCondFail.cpp
+++ b/lib/SILOptimizer/Transforms/MergeCondFail.cpp
@@ -125,6 +125,6 @@ public:
 };
 } // end anonymous namespace
 
-SILTransform *swift::createMergeCondFails() {
+SILTransform *swift::createLegacyMergeCondFails() {
   return new MergeCondFailInsts();
 }

--- a/libswift/CMakeLists.txt
+++ b/libswift/CMakeLists.txt
@@ -1,0 +1,23 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+if (NOT SWIFT_TOOLS_ENABLE_LIBSWIFT)
+  # A dummy libswift if libswift is disabled
+  add_swift_host_library(libswift OBJECT LibSwiftStubs.cpp)
+else()
+  project(LibSwift LANGUAGES C CXX Swift)
+
+  if (NOT CMAKE_Swift_COMPILER)
+    message(FATAL_ERROR "Need a swift toolchain for building libswift")
+  endif()
+
+  add_subdirectory(Sources)
+
+  add_libswift("libswift")  
+endif()
+

--- a/libswift/LibSwiftStubs.cpp
+++ b/libswift/LibSwiftStubs.cpp
@@ -1,0 +1,20 @@
+//===--- LibSwiftStubs.cpp ------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extern "C" {
+
+void initializeLibSwift();
+
+}
+
+void initializeLibSwift() {}
+

--- a/libswift/Package.swift
+++ b/libswift/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+  name: "libswift",
+  platforms: [
+    .macOS("10.9"),
+  ],
+  products: [
+    .library(
+      name: "Swift",
+      type: .static,
+      targets: ["SIL", "Optimizer"]),
+  ],
+  dependencies: [
+  ],
+  // Note that all modules must be added to LIBSWIFT_MODULES in the top-level
+  // CMakeLists.txt file to get debugging working.
+  targets: [
+    .target(
+      name: "SIL",
+      dependencies: [],
+      swiftSettings: [SwiftSetting.unsafeFlags([
+          "-I", "../include/swift",
+          "-cross-module-optimization"
+        ])]),
+    .target(
+      name: "Optimizer",
+      dependencies: ["SIL"],
+      swiftSettings: [SwiftSetting.unsafeFlags([
+          "-I", "../include/swift",
+          "-cross-module-optimization"
+        ])]),
+  ]
+)

--- a/libswift/README.md
+++ b/libswift/README.md
@@ -1,0 +1,21 @@
+# Swift implemented in Swift
+
+_Libswift_ is the part of the Swift compiler, which is implemented in Swift.
+
+With _libswift_ it is possible to add SIL optimization passes written in Swift. It allows to gradually migrate the SIL optimizer from C++ to Swift.
+
+## Building
+
+_Libswift_ is a static library and it is built as part of the swift compiler using build-script and CMake.
+
+To enable _libswift_, add the build-script option `--libswift`.
+
+In this early stage of development _libswift_ is disabled by default. Right now _libswift_ does not contain any optimizations or features which are not available in the existing optimizer. Therefore a compiler with disabled _libswift_ still behaves as a compiler with enabled _libswift_. This will change soon.
+
+When _libswift_ is enabled, it is built with a Swift toolchain (5.3 or newer), which must be installed on the host system. The `swiftc` compiler driver is expected to be in the command search path.
+
+Currently the `swift-frontend` and `sil-opt` tools use _libswift_. Tools, which don't use any optimization passes from _libswift_ don't need to link _libswift_. For example, all tools, which compile Swift source code, but don't optimize it, like SourceKit or lldb, don't need to link _libswift_. As long as `initializeLibSwift()` is not called there is no dependency on _libswift_.
+
+This also means that currently it is not possible to implement mandatory passes in _libswift_, because this would break tools which compile Swift code but don't use _libswift_. When we want to implement mandatory passes in _libswift_ in the future, we'll need to link _libswift_ to all those tools.
+
+

--- a/libswift/README.md
+++ b/libswift/README.md
@@ -83,6 +83,20 @@ To add a new function pass:
 
 All SIL modifications, which a pass can do, are going through the `FunctionPassContext` - the second parameter of its run-function. In other words, the context is the central place to make modifications. This enables automatic change notifications to the pass manager. Also, it makes it easier to build a concurrent pass manager in future.
 
+### Instruction Passes
+
+In addition to function passes, _libswift_ provides the infrastructure for instruction passes. Instruction passes are invoked from SILCombine (in the C++ SILOptimizer) and correspond to a visit-function in SILCombine.
+
+With instruction passes it's possible to implement small peephole optimizations for certain instruction classes.
+
+To add a new instruction pass:
+
+* add a `SWIFT_INSTRUCTION_PASS` entry in `Passes.def`
+* create a new Swift file in `libswift/Sources/Optimizer/InstructionPasses`
+* add an `InstructionPass` global
+* register the pass in `registerSwiftPasses()`
+* if this passes replaces an existing `SILCombiner` visit function, remove the old visit function
+
 ## Performance
 
 The performance of _libswift_ is very important, because compile time is critical.

--- a/libswift/README.md
+++ b/libswift/README.md
@@ -68,6 +68,20 @@ For example, to add a new instruction class:
 
 No yet implemented instruction classes are mapped to a "placeholder" instruction, e.g `UnimplementedInstruction`. This ensures that optimizations can process any kind of SIL, even if some instructions don't have a representation in _libswift_ yet.
 
+## The Optimizer
+
+Similar to SIL, the optimizer also uses a small bridging layer (`OptimizerBriding.h`).
+Passes are registered in `registerSwiftPasses()`, called from `initializeLibSwift()`.
+The C++ PassManager can then call a _libwift_ pass like any other `SILFunctionTransform` pass.
+
+To add a new function pass:
+
+* add a `SWIFT_FUNCTION_PASS` entry in `Passes.def`
+* create a new Swift file in `libswift/Sources/Optimizer/FunctionPasses`
+* add a `FunctionPass` global
+* register the pass in `registerSwiftPasses()`
+
+All SIL modifications, which a pass can do, are going through the `FunctionPassContext` - the second parameter of its run-function. In other words, the context is the central place to make modifications. This enables automatic change notifications to the pass manager. Also, it makes it easier to build a concurrent pass manager in future.
 
 ## Performance
 

--- a/libswift/README.md
+++ b/libswift/README.md
@@ -90,4 +90,6 @@ Some performance considerations:
 
 * Memory is managed on the C++ side. On the Swift side, SIL objects are treated as "immortal" objects, which avoids (most of) ARC overhead. ARC runtime functions are still being called, but no atomic reference counting operations are done. In future we could add a compiler feature to mark classes as immortal to avoid the runtime calls at all.
 
+* Minimizing memory allocations: _libswift_ provides data structures which are malloc-free. For example `StackList` can be used in optimizations to implement work lists without any memory allocations. (Not yet done: `BasicBlockSet`, `BasicBlockData`)
+
 But most importantly, if there are performance issues with the current compiler, the design of _libswift_ should make it possible to fix performance deficiencies with future compiler improvements.

--- a/libswift/Sources/CMakeLists.txt
+++ b/libswift/Sources/CMakeLists.txt
@@ -1,0 +1,10 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_subdirectory(SIL)
+add_subdirectory(Optimizer)

--- a/libswift/Sources/Optimizer/CMakeLists.txt
+++ b/libswift/Sources/Optimizer/CMakeLists.txt
@@ -1,0 +1,12 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_libswift_module(Optimizer
+    DEPENDS SIL)
+
+add_subdirectory(PassManager)

--- a/libswift/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/libswift/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -6,8 +6,6 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-add_libswift_module(Optimizer
-    DEPENDS SIL)
-
-add_subdirectory(PassManager)
-add_subdirectory(FunctionPasses)
+libswift_sources(Optimizer
+  SILPrinter.swift
+)

--- a/libswift/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/libswift/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -8,4 +8,5 @@
 
 libswift_sources(Optimizer
   SILPrinter.swift
+  MergeCondFails.swift
 )

--- a/libswift/Sources/Optimizer/FunctionPasses/MergeCondFails.swift
+++ b/libswift/Sources/Optimizer/FunctionPasses/MergeCondFails.swift
@@ -1,0 +1,94 @@
+//===--- MergeCondFail.swift -  Merge cond_fail instructions --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+let mergeCondFailsPass = FunctionPass(name: "merge-cond_fails", runMergeCondFails)
+
+/// Return true if the operand of the cond_fail instruction looks like
+/// the overflow bit of an arithmetic instruction.
+private func hasOverflowConditionOperand(_ cfi: CondFailInst) -> Bool {
+  if let tei = cfi.condition as? TupleExtractInst {
+    return tei.tuple is BuiltinInst
+  }
+  return false
+}
+
+/// Merge cond_fail instructions.
+///
+/// We can merge cond_fail instructions if there is no side-effect or memory
+/// write in between them.
+/// This pass merges cond_fail instructions by building the disjunction of
+/// their operands.
+private func runMergeCondFails(function: Function, context: FunctionPassContext) {
+
+  // Merge cond_fail instructions if there is no side-effect or read in
+  // between them.
+  for block in function.blocks {
+    // Per basic block list of cond_fails to merge.
+    var condFailToMerge = StackList<CondFailInst>(context)
+
+    for inst in block.instructions {
+      if let cfi = inst as? CondFailInst {
+        // Do not process arithmetic overflow checks. We typically generate more
+        // efficient code with separate jump-on-overflow.
+        if !hasOverflowConditionOperand(cfi) &&
+           (condFailToMerge.isEmpty || cfi.message == condFailToMerge.first!.message) {
+          condFailToMerge.push(cfi)
+        }
+      } else if inst.mayHaveSideEffects || inst.mayReadFromMemory {
+        // Stop merging at side-effects or reads from memory.
+        mergeCondFails(&condFailToMerge, context: context)
+      }
+    }
+    // Process any remaining cond_fail instructions in the current basic
+    // block.
+    mergeCondFails(&condFailToMerge, context: context)
+  }
+}
+
+/// Try to merge the cond_fail instructions. Returns true if any could
+/// be merge.
+private func mergeCondFails(_ condFailToMerge: inout StackList<CondFailInst>,
+                            context: FunctionPassContext) {
+  guard let lastCFI = condFailToMerge.last else {
+    return
+  }
+  var mergedCond: Value? = nil
+  var didMerge = false
+  let builder = Builder(at: lastCFI.next!, location: lastCFI.location, context)
+
+  // Merge conditions and remove the merged cond_fail instructions.
+  for cfi in condFailToMerge {
+    if let prevCond = mergedCond {
+      mergedCond = builder.createBuiltinBinaryFunction(name: "or",
+                                        operandType: prevCond.type,
+                                        resultType: prevCond.type,
+                                        arguments: [prevCond, cfi.condition])
+      didMerge = true
+    } else {
+      mergedCond = cfi.condition
+    }
+  }
+  if !didMerge {
+    condFailToMerge.removeAll()
+    return
+  }
+
+  // Create a new cond_fail using the merged condition.
+  _ = builder.createCondFail(condition: mergedCond!,
+                             message: lastCFI.message)
+
+  while let cfi = condFailToMerge.pop() {
+    context.erase(instruction: cfi)
+  }
+}

--- a/libswift/Sources/Optimizer/FunctionPasses/SILPrinter.swift
+++ b/libswift/Sources/Optimizer/FunctionPasses/SILPrinter.swift
@@ -1,0 +1,45 @@
+//===--- SILPrinter.swift - Example swift function pass -------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+let silPrinterPass = FunctionPass(name: "sil-printer", runSILPrinter)
+
+func runSILPrinter(function: Function, context: FunctionPassContext) {
+  print("run SILPrinter on function: \(function.name)")
+
+  for (bbIdx, block) in function.blocks.enumerated() {
+    print("bb\(bbIdx):")
+
+    print("  arguments:")
+    for arg in block.arguments {
+      print("    arg: \(arg)")
+      for use in arg.uses {
+        print("      user: \(use.instruction)")
+      }
+    }
+
+    print("  instructions:")
+    for inst in block.instructions {
+      print("  \(inst)")
+      for op in inst.operands {
+        print("      op: \(op.value)")
+      }
+      for (resultIdx, result) in inst.results.enumerated() {
+        for use in result.uses {
+          print("      user of result \(resultIdx): \(use.instruction)")
+        }
+      }
+    }
+    print()
+  }
+}

--- a/libswift/Sources/Optimizer/InstructionPasses/CMakeLists.txt
+++ b/libswift/Sources/Optimizer/InstructionPasses/CMakeLists.txt
@@ -6,9 +6,5 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-add_libswift_module(Optimizer
-    DEPENDS SIL)
-
-add_subdirectory(InstructionPasses)
-add_subdirectory(PassManager)
-add_subdirectory(FunctionPasses)
+libswift_sources(Optimizer
+  SimplifyGlobalValue.swift)

--- a/libswift/Sources/Optimizer/InstructionPasses/SimplifyGlobalValue.swift
+++ b/libswift/Sources/Optimizer/InstructionPasses/SimplifyGlobalValue.swift
@@ -1,0 +1,52 @@
+//===--- SimplifyGlobalValue.swift - Simplify global_value instruction ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+let simplifyGlobalValuePass = InstructionPass<GlobalValueInst>(
+  name: "simplify-global_value", {
+  (globalValue: GlobalValueInst, context: InstructionPassContext) in
+
+  var users = StackList<Instruction>(context)
+  if checkUsers(of: globalValue, users: &users) {
+    while let inst = users.pop() {
+      context.erase(instruction: inst)
+    }
+  } else {
+    users.removeAll()
+  }
+})
+  
+/// Returns true if reference counting and debug_value users of a global_value
+/// can be deleted.
+private func checkUsers(of val: Value, users: inout StackList<Instruction>) -> Bool {
+  for use in val.uses {
+    let user = use.instruction
+    if user is RefCountingInst || user is DebugValueInst {
+      users.push(user)
+      continue
+    }
+    if let upCast = user as? UpcastInst {
+      if !checkUsers(of: upCast, users: &users) {
+        return false
+      }
+      continue
+    }
+    // Projection instructions don't access the object header, so they don't
+    // prevent deleting reference counting instructions.
+    if user is RefElementAddrInst || user is RefTailAddrInst {
+      continue
+    }
+    return false
+  }
+  return true
+}

--- a/libswift/Sources/Optimizer/PassManager/CMakeLists.txt
+++ b/libswift/Sources/Optimizer/PassManager/CMakeLists.txt
@@ -1,0 +1,11 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+libswift_sources(Optimizer
+  PassRegistration.swift)
+

--- a/libswift/Sources/Optimizer/PassManager/CMakeLists.txt
+++ b/libswift/Sources/Optimizer/PassManager/CMakeLists.txt
@@ -7,5 +7,6 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 libswift_sources(Optimizer
+  PassUtils.swift
   PassRegistration.swift)
 

--- a/libswift/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/libswift/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -29,4 +29,5 @@ private func registerPass(
 
 private func registerSwiftPasses() {
   registerPass(silPrinterPass, { silPrinterPass.run($0) })
+  registerPass(mergeCondFailsPass, { mergeCondFailsPass.run($0) })
 }

--- a/libswift/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/libswift/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -38,4 +38,5 @@ private func registerPass<InstType: Instruction>(
 private func registerSwiftPasses() {
   registerPass(silPrinterPass, { silPrinterPass.run($0) })
   registerPass(mergeCondFailsPass, { mergeCondFailsPass.run($0) })
+  registerPass(simplifyGlobalValuePass, { simplifyGlobalValuePass.run($0) })
 }

--- a/libswift/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/libswift/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -27,6 +27,14 @@ private func registerPass(
   }
 }
 
+private func registerPass<InstType: Instruction>(
+      _ pass: InstructionPass<InstType>,
+      _ runFn: @escaping (@convention(c) (BridgedInstructionPassCtxt) -> ())) {
+  pass.name.withBridgedStringRef { nameStr in
+    SILCombine_registerInstructionPass(nameStr, runFn)
+  }
+}
+
 private func registerSwiftPasses() {
   registerPass(silPrinterPass, { silPrinterPass.run($0) })
   registerPass(mergeCondFailsPass, { mergeCondFailsPass.run($0) })

--- a/libswift/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/libswift/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -28,4 +28,5 @@ private func registerPass(
 }
 
 private func registerSwiftPasses() {
+  registerPass(silPrinterPass, { silPrinterPass.run($0) })
 }

--- a/libswift/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/libswift/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -1,0 +1,17 @@
+//===--- PassRegistration.swift - Register optimzation passes -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+@_cdecl("initializeLibSwift")
+public func initializeLibSwift() {
+}

--- a/libswift/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/libswift/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -11,8 +11,21 @@
 //===----------------------------------------------------------------------===//
 
 import SIL
+import OptimizerBridging
 
 @_cdecl("initializeLibSwift")
 public func initializeLibSwift() {
   registerSILClasses()
+  registerSwiftPasses()
+}
+
+private func registerPass(
+      _ pass: FunctionPass,
+      _ runFn: @escaping (@convention(c) (BridgedFunctionPassCtxt) -> ())) {
+  pass.name.withBridgedStringRef { nameStr in
+    SILPassManager_registerFunctionPass(nameStr, runFn)
+  }
+}
+
+private func registerSwiftPasses() {
 }

--- a/libswift/Sources/Optimizer/PassManager/PassUtils.swift
+++ b/libswift/Sources/Optimizer/PassManager/PassUtils.swift
@@ -49,3 +49,15 @@ struct FunctionPass {
   }
 }
 
+extension Builder {
+  init(at insPnt: Instruction, location: Location,
+       _ context: FunctionPassContext) {
+    self.init(insertionPoint: insPnt, location: location,
+              passContext: context.passContext)
+  }
+
+  init(at insPnt: Instruction, _ context: FunctionPassContext) {
+    self.init(insertionPoint: insPnt, location: insPnt.location,
+              passContext: context.passContext)
+  }
+}

--- a/libswift/Sources/Optimizer/PassManager/PassUtils.swift
+++ b/libswift/Sources/Optimizer/PassManager/PassUtils.swift
@@ -49,6 +49,12 @@ struct FunctionPass {
   }
 }
 
+extension StackList {
+  init(_ context: FunctionPassContext) {
+    self.init(context: context.passContext)
+  }
+}
+
 extension Builder {
   init(at insPnt: Instruction, location: Location,
        _ context: FunctionPassContext) {

--- a/libswift/Sources/Optimizer/PassManager/PassUtils.swift
+++ b/libswift/Sources/Optimizer/PassManager/PassUtils.swift
@@ -1,0 +1,51 @@
+//===--- PassUtils.swift - Utilities for optimzation passes ---------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+import OptimizerBridging
+
+public typealias BridgedFunctionPassCtxt =
+  OptimizerBridging.BridgedFunctionPassCtxt
+
+struct FunctionPassContext {
+
+  fileprivate let passContext: BridgedPassContext
+  fileprivate let function: Function
+  
+  func erase(instruction: Instruction) {
+    PassContext_eraseInstruction(passContext, instruction.bridged)
+  }
+  
+  private func notifyChanges(_ kind: ChangeNotificationKind) {
+    PassContext_notifyChanges(passContext, kind)
+  }
+}
+
+struct FunctionPass {
+
+  let name: String
+  let runFunction: (Function, FunctionPassContext) -> ()
+
+  public init(name: String,
+              _ runFunction: @escaping (Function, FunctionPassContext) -> ()) {
+    self.name = name
+    self.runFunction = runFunction
+  }
+
+  func run(_ bridgedCtxt: BridgedFunctionPassCtxt) {
+    let function = bridgedCtxt.function.function
+    let context = FunctionPassContext(passContext: bridgedCtxt.passContext,
+                                      function: function)
+    runFunction(function, context)
+  }
+}
+

--- a/libswift/Sources/SIL/Argument.swift
+++ b/libswift/Sources/SIL/Argument.swift
@@ -1,0 +1,33 @@
+//===--- Argument.swift - Defines the Argument classes --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SILBridging
+
+/// A basic block argument.
+///
+/// Maps to both, SILPhiArgument and SILFunctionArgument.
+public class BlockArgument : Value {
+  final public var definingInstruction: Instruction? { nil }
+
+  final public var block: BasicBlock {
+    return SILArgument_getParent(bridged).block
+  }
+
+  var bridged: BridgedArgument { BridgedArgument(obj: SwiftObject(self)) }
+}
+
+// Bridging utilities
+
+extension BridgedArgument {
+  var argument: BlockArgument { obj.getAs(BlockArgument.self) }
+}
+

--- a/libswift/Sources/SIL/BasicBlock.swift
+++ b/libswift/Sources/SIL/BasicBlock.swift
@@ -1,0 +1,55 @@
+//===--- BasicBlock.swift - Defines the BasicBlock class ------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SILBridging
+
+final public class BasicBlock : ListNode, CustomStringConvertible {
+  public var next: BasicBlock? { SILBasicBlock_next(bridged).block }
+  public var previous: BasicBlock? { SILBasicBlock_previous(bridged).block }
+  
+  public var description: String {
+    SILBasicBlock_debugDescription(bridged).takeString()
+  }
+
+  public var arguments: ArgumentArray { ArgumentArray(block: self) }
+
+  public var instructions: List<Instruction> {
+    List(startAt: SILBasicBlock_firstInst(bridged).instruction)
+  }
+
+  public var reverseInstructions: ReverseList<Instruction> {
+    ReverseList(startAt: SILBasicBlock_lastInst(bridged).instruction)
+  }
+
+  var bridged: BridgedBasicBlock { BridgedBasicBlock(obj: SwiftObject(self)) }
+}
+
+public struct ArgumentArray : RandomAccessCollection {
+  fileprivate let block: BasicBlock
+
+  public var startIndex: Int { return 0 }
+  public var endIndex: Int { SILBasicBlock_getNumArguments(block.bridged) }
+
+  public subscript(_ index: Int) -> BlockArgument {
+    SILBasicBlock_getArgument(block.bridged, index).argument
+  }
+}
+
+// Bridging utilities
+
+extension BridgedBasicBlock {
+  var block: BasicBlock { obj.getAs(BasicBlock.self) }
+}
+
+extension OptionalBridgedBasicBlock {
+  var block: BasicBlock? { obj.getAs(BasicBlock.self) }
+}

--- a/libswift/Sources/SIL/Builder.swift
+++ b/libswift/Sources/SIL/Builder.swift
@@ -1,0 +1,63 @@
+//===--- Builder.swift -  Building and modifying SIL ----------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SILBridging
+
+/// A utility to create new instructions at a given insertion point.
+public struct Builder {
+  let insertionPoint: Instruction
+  let location: Location
+  private let passContext: BridgedPassContext
+
+  private var bridgedInsPoint: BridgedInstruction { insertionPoint.bridged }
+
+  private func notifyInstructionsChanged() {
+    PassContext_notifyChanges(passContext, instructionsChanged)
+  }
+
+  private func notifyCallsChanged() {
+    PassContext_notifyChanges(passContext, callsChanged)
+  }
+
+  private func notifyBranchesChanged() {
+    PassContext_notifyChanges(passContext, branchesChanged)
+  }
+
+  public init(insertionPoint: Instruction, location: Location,
+              passContext: BridgedPassContext) {
+    self.insertionPoint = insertionPoint
+    self.location = location;
+    self.passContext = passContext
+  }
+
+  public func createBuiltinBinaryFunction(name: String,
+      operandType: Type, resultType: Type, arguments: [Value]) -> BuiltinInst {
+    notifyInstructionsChanged()
+    return arguments.withBridgedValues { valuesRef in
+      return name.withBridgedStringRef { nameStr in
+        let bi = SILBuilder_createBuiltinBinaryFunction(
+          bridgedInsPoint, location.bridgedLocation, nameStr,
+          operandType.silType, resultType.silType, valuesRef)
+        return bi.getAs(BuiltinInst.self)
+      }
+    }
+  }
+
+  public func createCondFail(condition: Value, message: String) -> CondFailInst {
+    notifyInstructionsChanged()
+    return message.withBridgedStringRef { messageStr in
+      let cf = SILBuilder_createCondFail(
+        bridgedInsPoint, location.bridgedLocation, condition.bridged, messageStr)
+      return cf.getAs(CondFailInst.self)
+    }
+  }
+}

--- a/libswift/Sources/SIL/CMakeLists.txt
+++ b/libswift/Sources/SIL/CMakeLists.txt
@@ -1,0 +1,11 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_libswift_module(SIL
+  Value.swift)
+

--- a/libswift/Sources/SIL/CMakeLists.txt
+++ b/libswift/Sources/SIL/CMakeLists.txt
@@ -9,6 +9,7 @@
 add_libswift_module(SIL
   Argument.swift
   BasicBlock.swift
+  Builder.swift
   Function.swift
   GlobalVariable.swift
   Instruction.swift

--- a/libswift/Sources/SIL/CMakeLists.txt
+++ b/libswift/Sources/SIL/CMakeLists.txt
@@ -18,5 +18,6 @@ add_libswift_module(SIL
   Registration.swift
   Type.swift
   Utils.swift
+  StackList.swift
   Value.swift)
 

--- a/libswift/Sources/SIL/CMakeLists.txt
+++ b/libswift/Sources/SIL/CMakeLists.txt
@@ -7,5 +7,15 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_libswift_module(SIL
+  Argument.swift
+  BasicBlock.swift
+  Function.swift
+  GlobalVariable.swift
+  Instruction.swift
+  Location.swift
+  Operand.swift
+  Registration.swift
+  Type.swift
+  Utils.swift
   Value.swift)
 

--- a/libswift/Sources/SIL/Function.swift
+++ b/libswift/Sources/SIL/Function.swift
@@ -1,0 +1,43 @@
+//===--- Function.swift - Defines the Function class ----------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SILBridging
+
+final public class Function : CustomStringConvertible {
+  public var name: String {
+    return SILFunction_getName(bridged).string
+  }
+
+  final public var description: String {
+    return SILFunction_debugDescription(bridged).takeString()
+  }
+
+  public var entryBlock: BasicBlock {
+    SILFunction_firstBlock(bridged).block!
+  }
+
+  public var blocks : List<BasicBlock> {
+    return List(startAt: SILFunction_firstBlock(bridged).block)
+  }
+
+  public var reverseBlocks : ReverseList<BasicBlock> {
+    return ReverseList(startAt: SILFunction_lastBlock(bridged).block)
+  }
+
+  public var bridged: BridgedFunction { BridgedFunction(obj: SwiftObject(self)) }
+}
+
+// Bridging utilities
+
+extension BridgedFunction {
+  public var function: Function { obj.getAs(Function.self) }
+}

--- a/libswift/Sources/SIL/GlobalVariable.swift
+++ b/libswift/Sources/SIL/GlobalVariable.swift
@@ -1,0 +1,33 @@
+//===--- GlobalVariable.swift - Defines the GlobalVariable class ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SILBridging
+
+final public class GlobalVariable : CustomStringConvertible {
+  public var name: String {
+    return SILGlobalVariable_getName(bridged).string
+  }
+
+  public var description: String {
+    return SILGlobalVariable_debugDescription(bridged).takeString()
+  }
+
+  // TODO: initializer instructions
+
+  var bridged: BridgedGlobalVar { BridgedGlobalVar(obj: SwiftObject(self)) }
+}
+
+// Bridging utilities
+
+extension BridgedGlobalVar {
+  var globalVar: GlobalVariable { obj.getAs(GlobalVariable.self) }
+}

--- a/libswift/Sources/SIL/Instruction.swift
+++ b/libswift/Sources/SIL/Instruction.swift
@@ -1,0 +1,205 @@
+//===--- Instruction.swift - Defines the Instruction classes --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SILBridging
+
+//===----------------------------------------------------------------------===//
+//                       Instruction base classes
+//===----------------------------------------------------------------------===//
+
+public class Instruction : ListNode, CustomStringConvertible {
+  final public var next: Instruction? {
+    SILInstruction_next(bridged).instruction
+  }
+
+  final public var previous: Instruction? {
+    SILInstruction_previous(bridged).instruction
+  }
+
+  final public var block: BasicBlock {
+    SILInstruction_getParent(bridged).block
+  }
+
+  final public var description: String {
+    SILNode_debugDescription(bridgedNode).takeString()
+  }
+  
+  final public var operands: OperandArray {
+    return OperandArray(opArray: SILInstruction_getOperands(bridged))
+  }
+  
+  fileprivate var resultCount: Int { 0 }
+  fileprivate func getResult(index: Int) -> Value { fatalError() }
+
+  final public var results: InstructionResults { InstructionResults(self) }
+
+  final public var location: Location {
+    return Location(bridgedLocation: SILInstruction_getLocation(bridged))
+  }
+
+  final public var mayHaveSideEffects: Bool {
+    return SILInstruction_mayHaveSideEffects(bridged) != 0
+  }
+  final public var mayReadFromMemory: Bool {
+    return SILInstruction_mayReadFromMemory(bridged) != 0
+  }
+  final public var mayWriteToMemory: Bool {
+    return SILInstruction_mayWriteToMemory(bridged) != 0
+  }
+  final public var mayReadOrWriteMemory: Bool {
+    return SILInstruction_mayReadOrWriteMemory(bridged) != 0
+  }
+
+  public var bridged: BridgedInstruction {
+    BridgedInstruction(obj: SwiftObject(self))
+  }
+  var bridgedNode: BridgedNode { BridgedNode(obj: SwiftObject(self)) }
+}
+
+extension BridgedInstruction {
+  public var instruction: Instruction { obj.getAs(Instruction.self) }
+  public func getAs<T: Instruction>(_ instType: T.Type) -> T { obj.getAs(T.self) }
+}
+
+extension OptionalBridgedInstruction {
+  var instruction: Instruction? { obj.getAs(Instruction.self) }
+}
+
+public struct InstructionResults : Sequence, IteratorProtocol {
+  let inst: Instruction
+  let numResults: Int
+  var index: Int = 0
+
+  init(_ inst: Instruction) {
+    self.inst = inst
+    numResults = inst.resultCount
+  }
+
+  public mutating func next() -> Value? {
+    let idx = index
+    if idx < numResults {
+      index += 1
+      return inst.getResult(index: idx)
+    }
+    return nil
+  }
+}
+
+public class SingleValueInstruction : Instruction, Value {
+  final public var definingInstruction: Instruction? { self }
+
+  fileprivate final override var resultCount: Int { 1 }
+  fileprivate final override func getResult(index: Int) -> Value { self }
+}
+
+public final class MultipleValueInstructionResult : Value {
+  final public var description: String {
+    SILNode_debugDescription(bridgedNode).takeString()
+  }
+
+  public var definingInstruction: Instruction? {
+    MultiValueInstResult_getParent(bridged).instruction
+  }
+
+  var bridged: BridgedMultiValueResult {
+    BridgedMultiValueResult(obj: SwiftObject(self))
+  }
+  var bridgedNode: BridgedNode { BridgedNode(obj: SwiftObject(self)) }
+}
+
+extension BridgedMultiValueResult {
+  var result: MultipleValueInstructionResult {
+    obj.getAs(MultipleValueInstructionResult.self)
+  }
+}
+
+public class MultipleValueInstruction : Instruction {
+  fileprivate final override var resultCount: Int {
+    return MultipleValueInstruction_getNumResults(bridged)
+  }
+  fileprivate final override func getResult(index: Int) -> Value {
+    MultipleValueInstruction_getResult(bridged, index).result
+  }
+}
+
+//===----------------------------------------------------------------------===//
+//                             no-value instructions
+//===----------------------------------------------------------------------===//
+
+/// Used for all non-value instructions which are not implemented here, yet.
+/// See registerBridgedClass() in SILBridgingUtils.cpp.
+final public class UnimplementedInstruction : Instruction {
+}
+
+final public class CondFailInst : Instruction {
+  public var condition: Value { operands[0].value }
+  
+  public var message: String { CondFailInst_getMessage(bridged).string }
+}
+
+public class RefCountingInst : Instruction {
+  final public var global: GlobalVariable {
+    GlobalAccessInst_getGlobal(bridged).globalVar
+  }
+}
+
+final public class DebugValueInst : Instruction {
+  public var value: Value { operands[0].value }
+}
+
+final public class UnimplementedRefCountingInst : RefCountingInst {}
+
+//===----------------------------------------------------------------------===//
+//                           single-value instructions
+//===----------------------------------------------------------------------===//
+
+/// Used for all SingleValueInstructions which are not implemented here, yet.
+/// See registerBridgedClass() in SILBridgingUtils.cpp.
+final public class UnimplementedSingleValueInst : SingleValueInstruction {
+}
+
+final public class BuiltinInst : SingleValueInstruction {}
+
+final public class UpcastInst : SingleValueInstruction {
+  var source: Value { operands[0].value }
+}
+
+public class GlobalAccessInst : SingleValueInstruction {
+  final public var global: GlobalVariable {
+    GlobalAccessInst_getGlobal(bridged).globalVar
+  }
+}
+
+final public class GlobalAddrInst : GlobalAccessInst {}
+
+final public class GlobalValueInst : GlobalAccessInst {}
+
+final public class TupleExtractInst : SingleValueInstruction {
+  public var tuple: Value { operands[0].value }
+}
+
+final public class RefElementAddrInst : SingleValueInstruction {
+  var ref: Value { operands[0].value }
+}
+
+final public class RefTailAddrInst : SingleValueInstruction {
+  var ref: Value { operands[0].value }
+}
+
+//===----------------------------------------------------------------------===//
+//                            multi-value instructions
+//===----------------------------------------------------------------------===//
+
+/// Used for all UnimplementedMultiValueInst which are not implemented here, yet.
+/// See registerBridgedClass() in SILBridgingUtils.cpp.
+final public class UnimplementedMultiValueInst : MultipleValueInstruction {
+}

--- a/libswift/Sources/SIL/Location.swift
+++ b/libswift/Sources/SIL/Location.swift
@@ -1,4 +1,4 @@
-//===--- PassRegistration.swift - Register optimzation passes -------------===//
+//===--- Location.swift - Source location ---------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,9 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SIL
+import SILBridging
 
-@_cdecl("initializeLibSwift")
-public func initializeLibSwift() {
-  registerSILClasses()
+public struct Location {
+  let bridgedLocation: BridgedLocation
 }

--- a/libswift/Sources/SIL/Operand.swift
+++ b/libswift/Sources/SIL/Operand.swift
@@ -1,0 +1,106 @@
+//===--- Operand.swift - Instruction operands -----------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SILBridging
+
+/// An operand of an instruction.
+public struct Operand : CustomStringConvertible, CustomReflectable {
+  fileprivate let bridged: BridgedOperand
+
+  init(_ bridged: BridgedOperand) {
+    self.bridged = bridged
+  }
+
+  public var value: Value {
+    let v = Operand_getValue(bridged).getAs(AnyObject.self)
+    switch v {
+      case let inst as SingleValueInstruction:
+        return inst
+      case let arg as BlockArgument:
+        return arg
+      case let mvr as MultipleValueInstructionResult:
+        return mvr
+      case let undef as Undef:
+        return undef
+      default:
+        fatalError("unknown Value type")
+    }
+  }
+
+  public var instruction: Instruction {
+    return Operand_getUser(bridged).instruction
+  }
+  
+  public var index: Int { instruction.operands.getIndex(of: self) }
+  
+  public var description: String { "operand #\(index) of \(instruction)" }
+  
+  public var customMirror: Mirror { Mirror(self, children: []) }
+}
+
+public struct OperandArray : RandomAccessCollection, CustomReflectable {
+  private let opArray: BridgedOperandArray
+  
+  init(opArray: BridgedOperandArray) {
+    self.opArray = opArray
+  }
+  
+  public var startIndex: Int { return 0 }
+  public var endIndex: Int { return Int(opArray.numOperands) }
+  
+  public subscript(_ index: Int) -> Operand {
+    precondition(index >= 0 && index < endIndex)
+    return Operand(BridgedOperand(op: opArray.data + index &* BridgedOperandSize))
+  }
+  
+  public func getIndex(of operand: Operand) -> Int {
+    let idx = (operand.bridged.op - UnsafeRawPointer(opArray.data)) /
+                BridgedOperandSize
+    precondition(self[idx].bridged.op == operand.bridged.op)
+    return idx
+  }
+  
+  public var customMirror: Mirror {
+    let c: [Mirror.Child] = map { (label: nil, value: $0.value) }
+    return Mirror(self, children: c)
+  }
+}
+
+public struct UseList : Sequence, CustomReflectable {
+  public struct Iterator : IteratorProtocol {
+    var currentOpPtr: UnsafeRawPointer?
+    
+    public mutating func next() -> Operand? {
+      if let opPtr = currentOpPtr {
+        let bridged = BridgedOperand(op: opPtr)
+        currentOpPtr = Operand_nextUse(bridged).op
+        return Operand(bridged)
+      }
+      return nil
+    }
+  }
+
+  private let firstOpPtr: UnsafeRawPointer?
+
+  init(_ firstOpPtr: OptionalBridgedOperand) {
+    self.firstOpPtr = firstOpPtr.op
+  }
+
+  public func makeIterator() -> Iterator {
+    return Iterator(currentOpPtr: firstOpPtr)
+  }
+
+  public var customMirror: Mirror {
+    let c: [Mirror.Child] = map { (label: "use", value: $0) }
+    return Mirror(self, children: c)
+  }
+}

--- a/libswift/Sources/SIL/Registration.swift
+++ b/libswift/Sources/SIL/Registration.swift
@@ -1,0 +1,49 @@
+//===--- Registration.swift - register SIL classes ------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SILBridging
+
+private func register<T: AnyObject>(_ cl: T.Type) {
+  String(describing: cl).withBridgedStringRef { nameStr in
+    let metatype = unsafeBitCast(cl, to: SwiftMetatype.self)
+    registerBridgedClass(nameStr, metatype)
+  }
+}
+
+public func registerSILClasses() {
+  register(Function.self)
+  register(BasicBlock.self)
+  register(GlobalVariable.self)
+
+  // The "unimplemented" registrations must be done before all other node
+  // registrations. In the order from super -> sub class.
+  register(UnimplementedInstruction.self)
+  register(UnimplementedSingleValueInst.self)
+  register(UnimplementedRefCountingInst.self)
+  register(MultipleValueInstructionResult.self)
+  register(UnimplementedMultiValueInst.self)
+
+  register(Undef.self)
+  register(PlaceholderValue.self)
+
+  register(BlockArgument.self)
+
+  register(CondFailInst.self)
+  register(DebugValueInst.self)
+  register(BuiltinInst.self)
+  register(UpcastInst.self)
+  register(GlobalAddrInst.self)
+  register(GlobalValueInst.self)
+  register(TupleExtractInst.self)
+  register(RefElementAddrInst.self)
+  register(RefTailAddrInst.self)
+}

--- a/libswift/Sources/SIL/StackList.swift
+++ b/libswift/Sources/SIL/StackList.swift
@@ -1,0 +1,137 @@
+//===--- StackList.swift - defines the StackList data structure -----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SILBridging
+
+/// A very efficient implementation of a stack, which can also be iterated over.
+///
+/// A StackList is the best choice for things like worklists, etc., if no random
+/// access is needed.
+/// Compared to Array, it does not require any memory allocations, because it
+/// uses the bump pointer allocator of the SILModule.
+/// All operations have (almost) zero cost.
+///
+/// Ideally this would be a move-only type. Until then, only pass StackLists as
+/// inout!
+/// Note: it is required to manually remove all elements - either by pop() or
+///       removeAll().
+public struct StackList<Element> : Sequence, CustomReflectable {
+
+  private let context: BridgedPassContext
+  private var firstSlab = BridgedSlab(data: nil)
+  private var lastSlab = BridgedSlab(data: nil)
+  private var endIndex: Int = slabCapacity
+
+  private static var slabCapacity: Int {
+    BridgedSlabCapacity / MemoryLayout<Element>.size
+  }
+
+  private static func bind(_ slab: BridgedSlab) -> UnsafeMutablePointer<Element> {
+    return slab.data!.bindMemory(to: Element.self, capacity: StackList.slabCapacity)
+  }
+
+  public struct Iterator : IteratorProtocol {
+    var slab: BridgedSlab
+    var index: Int
+    let lastSlab: BridgedSlab
+    let endIndex: Int
+    
+    public mutating func next() -> Element? {
+      let end = (slab.data == lastSlab.data ? endIndex : slabCapacity)
+      if index < end {
+        let elem = StackList.bind(slab)[index]
+        index += 1
+
+        if index >= end && slab.data != lastSlab.data {
+          slab = PassContext_getNextSlab(slab)
+          index = 0
+        }
+        return elem
+      }
+      return nil
+    }
+  }
+  
+  public init(context: BridgedPassContext) { self.context = context }
+
+  public func makeIterator() -> Iterator {
+    return Iterator(slab: firstSlab, index: 0, lastSlab: lastSlab, endIndex: endIndex)
+  }
+
+  public var first: Element? {
+    if isEmpty {
+      return nil
+    }
+    return StackList.bind(firstSlab)[0]
+  }
+
+  public var last: Element? {
+    if isEmpty {
+      return nil
+    }
+    return StackList.bind(lastSlab)[endIndex - 1]
+  }
+
+  public mutating func push(_ element: Element) {
+    if endIndex >= StackList.slabCapacity {
+      lastSlab = PassContext_allocSlab(context, lastSlab)
+      if firstSlab.data == nil {
+        firstSlab = lastSlab
+      }
+      endIndex = 0
+    }
+    (StackList.bind(lastSlab) + endIndex).initialize(to: element)
+    endIndex += 1
+  }
+  
+  public var isEmpty: Bool { return firstSlab.data == nil }
+  
+  public mutating func pop() -> Element? {
+    if isEmpty {
+      return nil
+    }
+    assert(endIndex > 0)
+    endIndex -= 1
+    let elem = (StackList.bind(lastSlab) + endIndex).move()
+    
+    if endIndex == 0 {
+      if lastSlab.data == firstSlab.data {
+        _ = PassContext_freeSlab(context, lastSlab)
+        firstSlab.data = nil
+        lastSlab.data = nil
+      } else {
+        lastSlab = PassContext_freeSlab(context, lastSlab)
+      }
+      endIndex = StackList.slabCapacity
+    }
+
+    return elem
+  }
+  
+  public mutating func removeAll() {
+    if isEmpty {
+      return
+    }
+    while lastSlab.data != firstSlab.data {
+      lastSlab = PassContext_freeSlab(context, lastSlab)
+    }
+    _ = PassContext_freeSlab(context, lastSlab)
+    firstSlab.data = nil
+    lastSlab.data = nil
+    endIndex = StackList.slabCapacity
+  }
+  
+  public var customMirror: Mirror {
+    let c: [Mirror.Child] = map { (label: nil, value: $0) }
+    return Mirror(self, children: c)
+  }
+}

--- a/libswift/Sources/SIL/Type.swift
+++ b/libswift/Sources/SIL/Type.swift
@@ -1,4 +1,4 @@
-//===--- PassRegistration.swift - Register optimzation passes -------------===//
+//===--- Type.swift - Value type ------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,9 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SIL
+import SILBridging
 
-@_cdecl("initializeLibSwift")
-public func initializeLibSwift() {
-  registerSILClasses()
+public struct Type {
+  var silType: BridgedType
 }

--- a/libswift/Sources/SIL/Utils.swift
+++ b/libswift/Sources/SIL/Utils.swift
@@ -1,0 +1,123 @@
+//===--- Utils.swift - some SIL utilities ---------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SILBridging
+
+//===----------------------------------------------------------------------===//
+//                              Lists
+//===----------------------------------------------------------------------===//
+
+public protocol ListNode : AnyObject {
+  associatedtype Element
+  var next: Element? { get }
+  var previous: Element? { get }
+}
+
+public struct List<NodeType: ListNode> :
+      Sequence, IteratorProtocol, CustomReflectable
+      where NodeType.Element == NodeType {
+  private var currentNode: NodeType?
+  
+  public init(startAt: NodeType?) { currentNode = startAt }
+
+  public mutating func next() -> NodeType? {
+    if let node = currentNode {
+      currentNode = node.next
+      return node
+    }
+    return nil
+  }
+
+  public var customMirror: Mirror {
+    let c: [Mirror.Child] = map { (label: nil, value: $0) }
+    return Mirror(self, children: c)
+  }
+}
+
+public struct ReverseList<NodeType: ListNode> :
+      Sequence, IteratorProtocol, CustomReflectable
+      where NodeType.Element == NodeType {
+  private var currentNode: NodeType?
+  
+  public init(startAt: NodeType?) { currentNode = startAt }
+
+  public mutating func next() -> NodeType? {
+    if let node = currentNode {
+      currentNode = node.previous
+      return node
+    }
+    return nil
+  }
+
+  public var customMirror: Mirror {
+    let c: [Mirror.Child] = map { (label: nil, value: $0) }
+    return Mirror(self, children: c)
+  }
+}
+
+//===----------------------------------------------------------------------===//
+//                            Bridging Utilities
+//===----------------------------------------------------------------------===//
+
+extension BridgedStringRef {
+  public var string: String {
+    let buffer = UnsafeBufferPointer<UInt8>(start: data, count: Int(length))
+    return String(decoding: buffer, as: UTF8.self)
+  }
+  
+  func takeString() -> String {
+    let str = string
+    freeBridgedStringRef(self)
+    return str
+  }
+}
+
+extension String {
+  public func withBridgedStringRef<T>(_ c: (BridgedStringRef) -> T) -> T {
+    var str = self
+    return str.withUTF8 { buffer in
+      return c(BridgedStringRef(data: buffer.baseAddress, length: buffer.count))
+    }
+  }
+}
+
+extension Array where Element == Value {
+  public func withBridgedValues<T>(_ c: (BridgedValueArray) -> T) -> T {
+    return self.withUnsafeBytes { valPtr in
+      assert(valPtr.count == self.count * 16)
+      return c(BridgedValueArray(data: valPtr.baseAddress, count: self.count))
+    }
+  }
+}
+
+public typealias SwiftObject = UnsafeMutablePointer<BridgedSwiftObject>
+
+extension UnsafeMutablePointer where Pointee == BridgedSwiftObject {
+  init<T: AnyObject>(_ object: T) {
+    let ptr = Unmanaged.passUnretained(object).toOpaque()
+    self = ptr.bindMemory(to: BridgedSwiftObject.self, capacity: 1)
+  }
+  
+  func getAs<T: AnyObject>(_ objectType: T.Type) -> T {
+    return Unmanaged<T>.fromOpaque(self).takeUnretainedValue()
+  }
+}
+
+extension Optional where Wrapped == UnsafeMutablePointer<BridgedSwiftObject> {
+  func getAs<T: AnyObject>(_ objectType: T.Type) -> T? {
+    if let pointer = self {
+      return Unmanaged<T>.fromOpaque(pointer).takeUnretainedValue()
+    }
+    return nil
+  }
+}
+

--- a/libswift/Sources/SIL/Value.swift
+++ b/libswift/Sources/SIL/Value.swift
@@ -1,0 +1,52 @@
+//===--- Value.swift - the Value protocol ---------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SILBridging
+
+public protocol Value : AnyObject, CustomStringConvertible {
+  var uses: UseList { get }
+  var type: Type { get }
+  var definingInstruction: Instruction? { get }
+}
+
+extension Value {
+  public var description: String {
+    SILNode_debugDescription(bridgedNode).takeString()
+  }
+
+  public var uses: UseList {
+    return UseList(SILValue_firstUse(bridged))
+  }
+
+  public var type: Type {
+    return Type(silType: SILValue_getType(bridged))
+  }
+
+  var bridged: BridgedValue {
+    BridgedValue(obj: SwiftObject(self as AnyObject))
+  }
+  var bridgedNode: BridgedNode {
+    BridgedNode(obj: SwiftObject(self as AnyObject))
+  }
+}
+
+extension BridgedValue {
+  func getAs<T: AnyObject>(_ valueType: T.Type) -> T { obj.getAs(T.self) }
+}
+
+final class Undef : Value {
+  public var definingInstruction: Instruction? { nil }
+}
+
+final class PlaceholderValue : Value {
+  public var definingInstruction: Instruction? { nil }
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -153,6 +153,10 @@ if(NOT CMAKE_CFG_INTDIR STREQUAL ".")
        "--param" "build_mode=${CMAKE_CFG_INTDIR}")
 endif()
 
+if(SWIFT_TOOLS_ENABLE_LIBSWIFT)
+  list(APPEND SWIFT_LIT_ARGS "--param" "libswift")
+endif()
+
 if (LLVM_USE_SANITIZER STREQUAL "Address")
   set(SWIFT_ASAN_BUILD TRUE)
 endif()

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -254,6 +254,9 @@ native_swift_tools_path = lit_config.params.get('native_swift_tools_path')
 if native_swift_tools_path is not None:
     append_to_env_path(native_swift_tools_path)
 
+if lit_config.params.get('libswift', None) is not None:
+    config.available_features.add('libswift')
+
 ###
 
 # Discover the Swift binaries to use.

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -1,20 +1,32 @@
+
+set(driver_sources_and_options
+                driver.cpp
+                autolink_extract_main.cpp
+                modulewrap_main.cpp
+                swift_api_digester_main.cpp
+                swift_indent_main.cpp
+                swift_symbolgraph_extract_main.cpp
+                swift_api_extract_main.cpp
+                )
+
+set(driver_common_libs
+                swiftAPIDigester
+                swiftDriver
+                swiftFrontendTool
+                swiftSymbolGraphGen
+                LLVMBitstreamReader)
+
+# The swift-frontend tool
+
 add_swift_host_tool(swift-frontend
-  driver.cpp
-  autolink_extract_main.cpp
-  modulewrap_main.cpp
-  swift_api_digester_main.cpp
-  swift_indent_main.cpp
-  swift_symbolgraph_extract_main.cpp
-  swift_api_extract_main.cpp
+  ${driver_sources_and_options}
   SWIFT_COMPONENT compiler
+  HAS_LIBSWIFT
 )
 target_link_libraries(swift-frontend
                       PRIVATE
-                        swiftAPIDigester
-                        swiftDriver
-                        swiftFrontendTool
-                        swiftSymbolGraphGen
-                        LLVMBitstreamReader)
+                        ${driver_common_libs}
+                        libswift)
 
 # Create a `swift-driver` symlinks adjacent to the `swift-frontend` executable
 # to ensure that `swiftc` forwards to the standalone driver when invoked.

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsDriver.h"
 #include "swift/Basic/LLVMInitialize.h"
+#include "swift/Basic/InitializeLibSwift.h"
 #include "swift/Basic/PrettyStackTrace.h"
 #include "swift/Basic/Program.h"
 #include "swift/Basic/TaskQueue.h"
@@ -183,6 +184,10 @@ static bool appendSwiftDriverName(SmallString<256> &buffer) {
 
 static int run_driver(StringRef ExecName,
                        const ArrayRef<const char *> argv) {
+  // This is done here and not done in FrontendTool.cpp, because
+  // FrontendTool.cpp is linked to tools, which don't use libswift.
+  initializeLibSwift();
+
   // Handle integrated tools.
   if (argv.size() > 1) {
     StringRef FirstArg(argv[1]);

--- a/tools/sil-opt/CMakeLists.txt
+++ b/tools/sil-opt/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_swift_host_tool(sil-opt
   SILOpt.cpp
   SWIFT_COMPONENT tools
+  HAS_LIBSWIFT
 )
 target_link_libraries(sil-opt
                       PRIVATE
@@ -9,6 +10,7 @@ target_link_libraries(sil-opt
                         swiftSIL
                         swiftSILGen
                         swiftSILOptimizer
+                        libswift
                         # Clang libraries included to appease the linker on linux.
                         clangBasic
                         clangCodeGen)

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/SILOptions.h"
 #include "swift/Basic/FileTypes.h"
 #include "swift/Basic/LLVMInitialize.h"
+#include "swift/Basic/InitializeLibSwift.h"
 #include "swift/Frontend/DiagnosticVerifier.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
@@ -356,6 +357,8 @@ int main(int argc, char **argv) {
   llvm::EnablePrettyStackTraceOnSigInfoForThisThread();
 
   llvm::cl::ParseCommandLineOptions(argc, argv, "Swift SIL optimizer\n");
+
+  initializeLibSwift();
 
   if (PrintStats)
     llvm::EnableStatistics();

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -64,6 +64,7 @@ KNOWN_SETTINGS=(
     build-runtime-with-host-compiler              ""                "use the host c++ compiler to build everything"
     build-stdlib-deployment-targets               "all"             "space-separated list that filters which of the configured targets to build the Swift standard library for, or 'all'"
     build-toolchain-only                          ""                "If set, only build the necessary tools to build an external toolchain"
+    libswift                                      ""                "Build the compiler with libswift"
     cmake-generator                               "Unix Makefiles"  "kind of build system to generate; see output of 'cmake --help' for choices"
     llvm-num-parallel-lto-link-jobs               ""                "The number of parallel link jobs to use when compiling llvm"
     reconfigure                                   ""                "force a CMake configuration run even if CMakeCache.txt already exists"
@@ -1913,6 +1914,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -DNDEBUG"
                     -DCMAKE_BUILD_TYPE:STRING="${SWIFT_BUILD_TYPE}"
                     -DLLVM_ENABLE_ASSERTIONS:BOOL=$(true_false "${SWIFT_ENABLE_ASSERTIONS}")
+                    -DSWIFT_TOOLS_ENABLE_LIBSWIFT:STRING=$(true_false "${LIBSWIFT}")
                     -DSWIFT_ANALYZE_CODE_COVERAGE:STRING=$(toupper "${SWIFT_ANALYZE_CODE_COVERAGE}")
                     -DSWIFT_STDLIB_BUILD_TYPE:STRING="${SWIFT_STDLIB_BUILD_TYPE}"
                     -DSWIFT_STDLIB_ASSERTIONS:BOOL=$(true_false "${SWIFT_STDLIB_ENABLE_ASSERTIONS}")


### PR DESCRIPTION
With libswift it is possible to add SIL optimization passes written in Swift. It allows to gradually migrate the SIL optimizer from C++ to Swift.

`libswift` is a Swift package, parallel to the `lib` directory in the repository.

This PR is a very first initial version - a proof of concept.

It contains the basic (and still imcomplete) SIL and optimizer API and some example passes.
To see how how a Swift optimization pass looks like, take a look at  [SILPrinter](https://github.com/eeckstein/swift/blob/libswift/libswift/Sources/Optimizer/FunctionPasses/SILPrinter.swift), [MergeCondFails](https://github.com/eeckstein/swift/blob/libswift/libswift/Sources/Optimizer/FunctionPasses/MergeCondFails.swift) or [SimplifyGlobalValue](https://github.com/eeckstein/swift/blob/libswift/libswift/Sources/Optimizer/InstructionPasses/SimplifyGlobalValue.swift)

To see how all this works, take a look at [libswift/README.md](https://github.com/eeckstein/swift/blob/libswift/libswift/README.md). It contains a lot more information about design and implementation.
