### PR TITLE
[CodeComplete] Show completions from constrained protocol extension

### DIFF
--- a/test/IDE/complete_protocol_static_member.swift
+++ b/test/IDE/complete_protocol_static_member.swift
@@ -1,0 +1,72 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+protocol FontStyle {}
+struct FontStyleOne: FontStyle {}
+struct FontStyleTwo: FontStyle {}
+
+extension FontStyle where Self == FontStyleOne {
+    static var variableDeclaredInConstraintExtension: FontStyleOne { FontStyleOne() }
+}
+
+func foo<T: FontStyle>(x: T) {}
+func test() {
+    foo(x: .#^COMPLETE_STATIC_MEMBER?check=EXTENSION_APPLIED^#)
+}
+
+// EXTENSION_APPLIED: Begin completions, 1 item
+// EXTENSION_APPLIED-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: variableDeclaredInConstraintExtension[#FontStyleOne#];
+// EXTENSION_APPLIED: End completions
+
+func test<T: FontStyle>(x: T) {
+  x.#^COMPLETE_MEMBER_IN_GENERIC_CONTEXT?check=EXTENSION_NOT_APPLIED^#
+}
+
+// EXTENSION_NOT_APPLIED: Begin completions, 1 item
+// EXTENSION_NOT_APPLIED-DAG: Keyword[self]/CurrNominal:          self[#T#];
+// EXTENSION_NOT_APPLIED-NOT: variableDeclaredInConstraintExtension
+// EXTENSION_NOT_APPLIED: End completions
+
+struct WrapperStruct<T: FontStyle> {
+  let y: T
+
+  func test(x: T) {
+    x.#^COMPLETE_MEMBER_IN_NESTED_GENERIC_CONTEXT?check=EXTENSION_NOT_APPLIED^#
+    y.#^COMPLETE_MEMBER_FROM_OUTER_GENERIC_CONTEXT_IN_INNER?check=EXTENSION_NOT_APPLIED^#
+    test(x: .#^COMPLETE_GENERIC_FUNC_WITH_TYPE_SPECIALIZED^#)
+    // COMPLETE_GENERIC_FUNC_WITH_TYPE_SPECIALIZED-NOT: variableDeclaredInConstraintExtension
+  }
+}
+
+func bar<T: FontStyle>(x: T) -> T { return x }
+func test2<T: FontStyle>(x: T) {
+  bar(x).#^COMPLETE_ON_GENERIC_FUNC_WITH_GENERIC_ARG?check=EXTENSION_NOT_APPLIED^#
+  bar(FontStyleTwo()).#^COMPLETE_ON_GENERIC_FUNC^#
+  // COMPLETE_ON_GENERIC_FUNC: Begin completions, 1 item
+  // COMPLETE_ON_GENERIC_FUNC-DAG: Keyword[self]/CurrNominal:          self[#FontStyleTwo#];
+  // COMPLETE_ON_GENERIC_FUNC: End completions
+}
+
+struct Sr12973 {}
+struct Indicator<T> {}
+extension Indicator where T == Sr12973 {
+  static var activity: Indicator<Sr12973> { fatalError() }
+}
+
+func receiver<T>(_ inidicator: Indicator<T>) {}
+
+func test() {
+  receiver(.#^COMPLETE_GENERIC_TYPE^#)
+}
+// COMPLETE_GENERIC_TYPE: Begin completions, 2 items
+// COMPLETE_GENERIC_TYPE: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init()[#Indicator<T>#];
+// COMPLETE_GENERIC_TYPE: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: activity[#Indicator<Sr12973>#];
+// COMPLETE_GENERIC_TYPE: End completions
+
+func testRecursive<T>(_ inidicator: Indicator<T>) {
+  testRecursive(.#^COMPLETE_RECURSIVE_GENERIC^#)
+// FIXME: We should be suggesting `.activity` here because the call to `testRecursive` happens with new generic parameters
+// COMPLETE_RECURSIVE_GENERIC: Begin completions, 1 item
+// COMPLETE_RECURSIVE_GENERIC-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init()[#Indicator<T>#];
+// COMPLETE_RECURSIVE_GENERIC: End completions
+}


### PR DESCRIPTION
Consider the following example.

```swift
protocol FontStyle {}
struct FontStyleOne: FontStyle {}

extension FontStyle where Self == FontStyleOne {
    static var one: FontStyleOne { FontStyleOne() }
}

func foo<T: FontStyle>(x: T) {}
func case1() {
    foo(x: .#^COMPLETE^#)
}
```

With SE-0299 accepted, we should be suggesting `.one`.

For that, we need to consider the extension applied when performing the unresolved dot code completion with a primary archetype that conforms to `FontStyle`.

However, in the following case, which performs an unresolved dot completion on the same base type, we don't want to suggest `.one` because that would require `T == FontStyleOne`, which we can’t assume.

```swift
func case2<T: FontStyle>(x: T) {
    x.#^COMPLETE_2^#
}
```

Since the constraint system cannot tell us how it came up with the archetype, we need to apply a heuristic to differentiate between the two cases.

What seems to work fine in most cases, is to determine if `T` referes to a generic parameter that is visible from the decl context we are completing in (i.e. the decl context we are completing in is a child context of the context that `T` is declared in). If it is not, then `T` cannot be the type of a variable we are completing on. Thus, we are in the first case and we should consider all extensions of `FontStyle` because we can further specialize `T` by picking a more concrete type.
Otherwise `T` may be the type of a variable we are completing on and we should be conservative and only suggest those extensions whose requirements are fulfilled by `T`.

Since this is just a heuristic, there are some corner cases, where we aren’t suggesting constrainted extensions although we should. For example, in the following example the call to `testRecursive` doesn’t use `T` and we should thus suggest `one`. But by the rules described above we detect that `T` is accessible at the call and thus don’t apply extension whose requirements aren’t satisfied.

```swift
func testRecursive<T: FontStyle>(_ style: T) {
  testRecursive(.#^COMPLETE_RECURSIVE_GENERIC^#)
}
```

Similar completion issues also occurred without SE-0299 in more complicated, generic scenarios.

Resolves rdar://74958497 and SR-12973