### PR TITLE
[Concurrency] Speculatively add asyncDetached as a synonym for async.

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -437,6 +437,26 @@ public func detach<T>(
   return Task.Handle<T, Error>(task)
 }
 
+@discardableResult
+@_alwaysEmitIntoClient
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public func asyncDetached<T>(
+  priority: Task.Priority = .unspecified,
+  operation: __owned @Sendable @escaping () async -> T
+) -> Task.Handle<T, Never> {
+  return detach(priority: priority, operation: operation)
+}
+
+@discardableResult
+@_alwaysEmitIntoClient
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public func asyncDetached<T>(
+  priority: Task.Priority = .unspecified,
+  operation: __owned @Sendable @escaping () async throws -> T
+) -> Task.Handle<T, Error> {
+  return detach(priority: priority, operation: operation)
+}
+
 /// Run given `operation` as asynchronously in its own top-level task.
 ///
 /// The `async` function should be used when creating asynchronous work


### PR DESCRIPTION
Given that `async` is the dominant way to initiate asynchronous work from
a synchronous function, speculatively rename `detach` to `asyncDetached`
to both fit into the naming scheme and clearly bias toward `async.
