### PR TITLE
[Concurrency] Switch _runTaskForBridgedAsyncMethod over to using 'async'

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -755,12 +755,8 @@ func _getCurrentThreadPriority() -> Int
 @_alwaysEmitIntoClient
 @usableFromInline
 internal func _runTaskForBridgedAsyncMethod(_ body: @escaping () async -> Void) {
-  // TODO: We can probably do better than detach
-  // if we're already running on behalf of a task,
-  // if the receiver of the method invocation is itself an Actor, or in other
-  // situations.
 #if compiler(>=5.5) && $Sendable
-  detach { await body() }
+  async { await body() }
 #endif
 }
 


### PR DESCRIPTION
We want the task created when running ObjC methods bridged as `async` to pick up the priority of the currently-executing thread, so use `async` rather than `detach`.