### PR TITLE
[Concurrency] Perform userInitiated adjustment after determining priority

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -264,12 +264,12 @@ static bool isExecutingOnMainThread() {
 }
 
 JobPriority swift::swift_task_getCurrentThreadPriority() {
-  if (isExecutingOnMainThread())
-    return JobPriority::UserInitiated;
-
 #if defined(__APPLE__)
   return static_cast<JobPriority>(qos_class_self());
 #else
+  if (isExecutingOnMainThread())
+    return JobPriority::UserInitiated;
+
   return JobPriority::Unspecified;
 #endif
 }

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -473,6 +473,10 @@ public func async(
     actualPriority = priority
   }
 
+  let adjustedPriority = actualPriority == .userInteractive
+    ? .userInitiated
+    : actualPriority
+
   // Set up the job flags for a new task.
   var flags = Task.JobFlags()
   flags.kind = .task


### PR DESCRIPTION
Based on feedback, perform the adjustment from `userInteractive` to
`userInitiated` all the time, and rely on `qos_class_self` whenever we
don't have a task.
