### PR TITLE
[NFC][AutoDiff] Pass AutoDiffConfig by const ref.

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -186,7 +186,7 @@ public:
   std::string
   mangleAutoDiffDerivativeFunction(const AbstractFunctionDecl *originalAFD,
                                    AutoDiffDerivativeFunctionKind kind,
-                                   AutoDiffConfig config,
+                                   const AutoDiffConfig &config,
                                    bool isVTableThunk = false);
 
   /// Mangle the linear map (differential/pullback) for the given:
@@ -196,7 +196,7 @@ public:
   ///   derivative generic signature.
   std::string mangleAutoDiffLinearMap(const AbstractFunctionDecl *originalAFD,
                                       AutoDiffLinearMapKind kind,
-                                      AutoDiffConfig config);
+                                      const AutoDiffConfig &config);
 
   /// Mangle the linear map self parameter reordering thunk the given:
   /// - Mangled original function declaration.
@@ -210,7 +210,7 @@ public:
   /// Mangle a SIL differentiability witness.
   std::string mangleSILDifferentiabilityWitness(StringRef originalName,
                                                 DifferentiabilityKind kind,
-                                                AutoDiffConfig config);
+                                                const AutoDiffConfig &config);
 
   /// Mangle the AutoDiff generated declaration for the given:
   /// - Generated declaration kind: linear map struct or branching trace enum.
@@ -223,7 +223,7 @@ public:
   mangleAutoDiffGeneratedDeclaration(AutoDiffGeneratedDeclarationKind declKind,
                                      StringRef origFnName, unsigned bbId,
                                      AutoDiffLinearMapKind linearMapKind,
-                                     AutoDiffConfig config);
+                                     const AutoDiffConfig &config);
 
   std::string mangleKeyPathGetterThunkHelper(const AbstractStorageDecl *property,
                                              GenericSignature signature,
@@ -453,7 +453,7 @@ protected:
       const AbstractFunctionDecl *afd);
   void appendAutoDiffFunctionParts(StringRef op, 
                                    Demangle::AutoDiffFunctionKind kind,
-                                   AutoDiffConfig config);
+                                   const AutoDiffConfig &config);
   void appendIndexSubset(IndexSubset *indexSubset);
 };
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5718,7 +5718,7 @@ public:
   ArrayRef<AutoDiffConfig> getDerivativeFunctionConfigurations();
 
   /// Add the given derivative function configuration.
-  void addDerivativeFunctionConfiguration(AutoDiffConfig config);
+  void addDerivativeFunctionConfiguration(const AutoDiffConfig &config);
 
 protected:
   // If a function has a body at all, we have either a parsed body AST node or

--- a/include/swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h
@@ -207,7 +207,7 @@ public:
                 IndexSubset *resultIndices) const;
 
   /// Returns true if the given value is active for the given config.
-  bool isActive(SILValue value, AutoDiffConfig config) const {
+  bool isActive(SILValue value, const AutoDiffConfig &config) const {
     return isActive(value, config.parameterIndices, config.resultIndices);
   }
 
@@ -217,7 +217,7 @@ public:
                        IndexSubset *resultIndices) const;
 
   /// Returns the activity of the given value for the given config.
-  Activity getActivity(SILValue value, AutoDiffConfig config) const {
+  Activity getActivity(SILValue value, const AutoDiffConfig &config) const {
     return getActivity(value, config.parameterIndices, config.resultIndices);
   }
 
@@ -227,7 +227,7 @@ public:
             llvm::raw_ostream &s = llvm::dbgs()) const;
 
   /// Prints activity information for the config of the given value.
-  void dump(SILValue value, AutoDiffConfig config,
+  void dump(SILValue value, const AutoDiffConfig &config,
             llvm::raw_ostream &s = llvm::dbgs()) const {
     return dump(value, config.parameterIndices, config.resultIndices, s);
   }
@@ -238,7 +238,8 @@ public:
             llvm::raw_ostream &s = llvm::dbgs()) const;
 
   /// Prints all activity information for the given config.
-  void dump(AutoDiffConfig config, llvm::raw_ostream &s = llvm::dbgs()) const {
+  void dump(const AutoDiffConfig &config,
+            llvm::raw_ostream &s = llvm::dbgs()) const {
     return dump(config.parameterIndices, config.resultIndices, s);
   }
 };

--- a/include/swift/SILOptimizer/Differentiation/Common.h
+++ b/include/swift/SILOptimizer/Differentiation/Common.h
@@ -121,7 +121,7 @@ void collectAllActualResultsInTypeOrder(
 /// - The set of minimal parameter and result indices for differentiating the
 ///   `apply` instruction.
 void collectMinimalIndicesForFunctionCall(
-    ApplyInst *ai, AutoDiffConfig parentConfig,
+    ApplyInst *ai, const AutoDiffConfig &parentConfig,
     const DifferentiableActivityInfo &activityInfo,
     SmallVectorImpl<SILValue> &results, SmallVectorImpl<unsigned> &paramIndices,
     SmallVectorImpl<unsigned> &resultIndices);

--- a/include/swift/SILOptimizer/Differentiation/LinearMapInfo.h
+++ b/include/swift/SILOptimizer/Differentiation/LinearMapInfo.h
@@ -149,7 +149,7 @@ public:
 
   explicit LinearMapInfo(ADContext &context, AutoDiffLinearMapKind kind,
                          SILFunction *original, SILFunction *derivative,
-                         AutoDiffConfig config,
+                         const AutoDiffConfig &config,
                          const DifferentiableActivityInfo &activityInfo,
                          SILLoopInfo *loopInfo);
 

--- a/include/swift/SILOptimizer/Differentiation/Thunk.h
+++ b/include/swift/SILOptimizer/Differentiation/Thunk.h
@@ -108,8 +108,8 @@ SILValue reabstractFunction(
 std::pair<SILFunction *, SubstitutionMap>
 getOrCreateSubsetParametersThunkForDerivativeFunction(
     SILOptFunctionBuilder &fb, SILValue origFnOperand, SILValue derivativeFn,
-    AutoDiffDerivativeFunctionKind kind, AutoDiffConfig desiredConfig,
-    AutoDiffConfig actualConfig, ADContext &adContext);
+    AutoDiffDerivativeFunctionKind kind, const AutoDiffConfig &desiredConfig,
+    const AutoDiffConfig &actualConfig, ADContext &adContext);
 
 /// Get or create a derivative function parameter index subset thunk from
 /// `actualIndices` to `desiredIndices` for the given associated function

--- a/include/swift/SILOptimizer/Differentiation/VJPCloner.h
+++ b/include/swift/SILOptimizer/Differentiation/VJPCloner.h
@@ -49,7 +49,7 @@ public:
   SILFunction &getVJP() const;
   SILFunction &getPullback() const;
   SILDifferentiabilityWitness *getWitness() const;
-  AutoDiffConfig getConfig() const;
+  const AutoDiffConfig &getConfig() const;
   DifferentiationInvoker getInvoker() const;
   LinearMapInfo &getPullbackInfo() const;
   SILLoopInfo *getLoopInfo() const;

--- a/include/swift/SILOptimizer/Utils/DifferentiationMangler.h
+++ b/include/swift/SILOptimizer/Utils/DifferentiationMangler.h
@@ -29,15 +29,15 @@ public:
   /// Returns the mangled name for a differentiation function of the given kind.
   std::string mangleAutoDiffFunction(StringRef originalName,
                                      Demangle::AutoDiffFunctionKind kind,
-                                     AutoDiffConfig config);
+                                     const AutoDiffConfig &config);
   /// Returns the mangled name for a derivative function of the given kind.
   std::string mangleDerivativeFunction(StringRef originalName,
                                        AutoDiffDerivativeFunctionKind kind,
-                                       AutoDiffConfig config);
+                                       const AutoDiffConfig &config);
   /// Returns the mangled name for a linear map of the given kind.
   std::string mangleLinearMap(StringRef originalName,
                               AutoDiffLinearMapKind kind,
-                              AutoDiffConfig config);
+                              const AutoDiffConfig &config);
   /// Returns the mangled name for a derivative function subset parameters
   /// thunk.
   std::string mangleDerivativeFunctionSubsetParametersThunk(

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -424,7 +424,7 @@ std::string ASTMangler::mangleObjCAsyncCompletionHandlerImpl(
 std::string ASTMangler::mangleAutoDiffDerivativeFunction(
     const AbstractFunctionDecl *originalAFD,
     AutoDiffDerivativeFunctionKind kind,
-    AutoDiffConfig config,
+    const AutoDiffConfig &config,
     bool isVTableThunk) {
   beginManglingWithAutoDiffOriginalFunction(originalAFD);
   appendAutoDiffFunctionParts(
@@ -434,7 +434,7 @@ std::string ASTMangler::mangleAutoDiffDerivativeFunction(
 
 std::string ASTMangler::mangleAutoDiffLinearMap(
     const AbstractFunctionDecl *originalAFD, AutoDiffLinearMapKind kind,
-    AutoDiffConfig config) {
+    const AutoDiffConfig &config) {
   beginManglingWithAutoDiffOriginalFunction(originalAFD);
   appendAutoDiffFunctionParts("TJ", getAutoDiffFunctionKind(kind), config);
   return finalize();
@@ -456,7 +456,7 @@ void ASTMangler::beginManglingWithAutoDiffOriginalFunction(
 
 void ASTMangler::appendAutoDiffFunctionParts(StringRef op,
                                              AutoDiffFunctionKind kind,
-                                             AutoDiffConfig config) {
+                                             const AutoDiffConfig &config) {
   if (auto sig = config.derivativeGenericSignature)
     appendGenericSignature(sig);
   auto kindCode = (char)kind;
@@ -486,8 +486,8 @@ void ASTMangler::appendIndexSubset(IndexSubset *indices) {
 }
 
 static NodePointer mangleSILDifferentiabilityWitnessAsNode(
-    StringRef originalName, DifferentiabilityKind kind, AutoDiffConfig config,
-    Demangler &demangler) {
+    StringRef originalName, DifferentiabilityKind kind,
+    const AutoDiffConfig &config, Demangler &demangler) {
   auto *diffWitnessNode = demangler.createNode(
       Node::Kind::DifferentiabilityWitness);
   auto origNode = demangler.demangleSymbol(originalName);
@@ -518,8 +518,9 @@ static NodePointer mangleSILDifferentiabilityWitnessAsNode(
   return diffWitnessNode;
 }
 
-std::string ASTMangler::mangleSILDifferentiabilityWitness(
-    StringRef originalName, DifferentiabilityKind kind, AutoDiffConfig config) {
+std::string ASTMangler::mangleSILDifferentiabilityWitness(StringRef originalName,
+                                              DifferentiabilityKind kind,
+                                              const AutoDiffConfig &config) {
   // If the original name was a mangled name, differentiability witnesses must
   // be mangled as node because they contain generic signatures which may repeat
   // entities in the original function name. Mangling as node will make sure the
@@ -545,7 +546,8 @@ std::string ASTMangler::mangleSILDifferentiabilityWitness(
 
 std::string ASTMangler::mangleAutoDiffGeneratedDeclaration(
     AutoDiffGeneratedDeclarationKind declKind, StringRef origFnName,
-    unsigned bbId, AutoDiffLinearMapKind linearMapKind, AutoDiffConfig config) {
+    unsigned bbId, AutoDiffLinearMapKind linearMapKind,
+    const AutoDiffConfig &config) {
   beginManglingWithoutPrefix();
 
   Buffer << "_AD__" << origFnName << "_bb" + std::to_string(bbId);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7378,7 +7378,7 @@ AbstractFunctionDecl::getDerivativeFunctionConfigurations() {
 }
 
 void AbstractFunctionDecl::addDerivativeFunctionConfiguration(
-    AutoDiffConfig config) {
+    const AutoDiffConfig &config) {
   prepareDerivativeFunctionConfigurations();
   DerivativeFunctionConfigs->insert(config);
 }

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -243,7 +243,7 @@ public:
   /// - The last result in the returned pullback.
   SILFunction *getOrCreateCustomDerivativeThunk(
       AbstractFunctionDecl *originalAFD, SILFunction *originalFn,
-      SILFunction *customDerivativeFn, AutoDiffConfig config,
+      SILFunction *customDerivativeFn, const AutoDiffConfig &config,
       AutoDiffDerivativeFunctionKind kind);
 
   /// Get or create a derivative function vtable entry thunk for the given

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3912,7 +3912,7 @@ ManagedValue SILGenFunction::getThunkedAutoDiffLinearMap(
 
 SILFunction *SILGenModule::getOrCreateCustomDerivativeThunk(
     AbstractFunctionDecl *originalAFD, SILFunction *originalFn,
-    SILFunction *customDerivativeFn, AutoDiffConfig config,
+    SILFunction *customDerivativeFn, const AutoDiffConfig &config,
     AutoDiffDerivativeFunctionKind kind) {
   auto customDerivativeFnTy = customDerivativeFn->getLoweredFunctionType();
   auto *thunkGenericEnv = customDerivativeFnTy->getSubstGenericSignature()

--- a/lib/SILOptimizer/Differentiation/Common.cpp
+++ b/lib/SILOptimizer/Differentiation/Common.cpp
@@ -184,7 +184,7 @@ void collectAllActualResultsInTypeOrder(
 }
 
 void collectMinimalIndicesForFunctionCall(
-    ApplyInst *ai, AutoDiffConfig parentConfig,
+    ApplyInst *ai, const AutoDiffConfig &parentConfig,
     const DifferentiableActivityInfo &activityInfo,
     SmallVectorImpl<SILValue> &results, SmallVectorImpl<unsigned> &paramIndices,
     SmallVectorImpl<unsigned> &resultIndices) {
@@ -452,7 +452,7 @@ findMinimalDerivativeConfiguration(AbstractFunctionDecl *original,
                                    IndexSubset *&minimalASTParameterIndices) {
   Optional<AutoDiffConfig> minimalConfig = None;
   auto configs = original->getDerivativeFunctionConfigurations();
-  for (auto config : configs) {
+  for (auto &config : configs) {
     auto *silParameterIndices = autodiff::getLoweredParameterIndices(
         config.parameterIndices,
         original->getInterfaceType()->castTo<AnyFunctionType>());

--- a/lib/SILOptimizer/Differentiation/JVPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/JVPCloner.cpp
@@ -1216,7 +1216,7 @@ public:
   ///
   ///   Original: y = apply f(x0, x1, ...)
   ///    Tangent: tan[y] = apply diff_f(tan[x0], tan[x1], ...)
-  void emitTangentForApplyInst(ApplyInst *ai, AutoDiffConfig applyConfig,
+  void emitTangentForApplyInst(ApplyInst *ai, const AutoDiffConfig &applyConfig,
                                CanSILFunctionType originalDifferentialType) {
     assert(differentialInfo.shouldDifferentiateApplySite(ai));
     auto *bb = ai->getParent();
@@ -1393,7 +1393,7 @@ static SubstitutionMap getSubstitutionMap(SILFunction *original,
 /// and JVP generic signature.
 static const DifferentiableActivityInfo &
 getActivityInfo(ADContext &context, SILFunction *original,
-                AutoDiffConfig config, SILFunction *jvp) {
+                const AutoDiffConfig &config, SILFunction *jvp) {
   // Get activity info of the original function.
   auto &passManager = context.getPassManager();
   auto *activityAnalysis =

--- a/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
+++ b/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
@@ -54,7 +54,7 @@ static GenericParamList *cloneGenericParameters(ASTContext &ctx,
 
 LinearMapInfo::LinearMapInfo(ADContext &context, AutoDiffLinearMapKind kind,
                              SILFunction *original, SILFunction *derivative,
-                             AutoDiffConfig config,
+                             const AutoDiffConfig &config,
                              const DifferentiableActivityInfo &activityInfo,
                              SILLoopInfo *loopInfo)
     : kind(kind), original(original), derivative(derivative),
@@ -313,8 +313,7 @@ void LinearMapInfo::addLinearMapToStruct(ADContext &context, ApplyInst *ai) {
   auto *results = IndexSubset::get(original->getASTContext(), numResults,
                                    activeResultIndices);
   // Create autodiff indices for the `apply` instruction.
-  AutoDiffConfig
-  applyConfig(parameters, results);
+  AutoDiffConfig applyConfig(parameters, results);
 
   // Check for non-differentiable original function type.
   auto checkNondifferentiableOriginalFunctionType = [&](CanSILFunctionType

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -149,7 +149,7 @@ private:
   }
   DifferentiationInvoker getInvoker() const { return vjpCloner.getInvoker(); }
   LinearMapInfo &getPullbackInfo() const { return vjpCloner.getPullbackInfo(); }
-  AutoDiffConfig getConfig() const { return vjpCloner.getConfig(); }
+  const AutoDiffConfig &getConfig() const { return vjpCloner.getConfig(); }
   const DifferentiableActivityInfo &getActivityInfo() const {
     return vjpCloner.getActivityInfo();
   }

--- a/lib/SILOptimizer/Differentiation/Thunk.cpp
+++ b/lib/SILOptimizer/Differentiation/Thunk.cpp
@@ -804,8 +804,8 @@ getOrCreateSubsetParametersThunkForLinearMap(
 std::pair<SILFunction *, SubstitutionMap>
 getOrCreateSubsetParametersThunkForDerivativeFunction(
     SILOptFunctionBuilder &fb, SILValue origFnOperand, SILValue derivativeFn,
-    AutoDiffDerivativeFunctionKind kind, AutoDiffConfig desiredConfig,
-    AutoDiffConfig actualConfig, ADContext &adContext) {
+    AutoDiffDerivativeFunctionKind kind, const AutoDiffConfig &desiredConfig,
+    const AutoDiffConfig &actualConfig, ADContext &adContext) {
   LLVM_DEBUG(getADDebugStream()
              << "Getting a subset parameters thunk for derivative function "
              << derivativeFn << " of the original function " << origFnOperand

--- a/lib/SILOptimizer/Differentiation/VJPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPCloner.cpp
@@ -94,7 +94,7 @@ class VJPCloner::Implementation final
 
   ASTContext &getASTContext() const { return vjp->getASTContext(); }
   SILModule &getModule() const { return vjp->getModule(); }
-  AutoDiffConfig getConfig() const {
+  const AutoDiffConfig &getConfig() const {
     return witness->getConfig();
   }
 
@@ -757,7 +757,7 @@ static SubstitutionMap getSubstitutionMap(SILFunction *original,
 /// and VJP generic signature.
 static const DifferentiableActivityInfo &
 getActivityInfoHelper(ADContext &context, SILFunction *original,
-                      AutoDiffConfig config, SILFunction *vjp) {
+                      const AutoDiffConfig &config, SILFunction *vjp) {
   // Get activity info of the original function.
   auto &passManager = context.getPassManager();
   auto *activityAnalysis =
@@ -805,7 +805,7 @@ SILFunction &VJPCloner::getPullback() const { return *impl.pullback; }
 SILDifferentiabilityWitness *VJPCloner::getWitness() const {
   return impl.witness;
 }
-AutoDiffConfig VJPCloner::getConfig() const {
+const AutoDiffConfig &VJPCloner::getConfig() const {
   return impl.getConfig();
 }
 DifferentiationInvoker VJPCloner::getInvoker() const { return impl.invoker; }

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -466,7 +466,7 @@ static SILValue reapplyFunctionConversion(
 static Optional<std::pair<SILValue, AutoDiffConfig>>
 emitDerivativeFunctionReference(
     DifferentiationTransformer &transformer, SILBuilder &builder,
-    AutoDiffConfig desiredConfig, AutoDiffDerivativeFunctionKind kind,
+    const AutoDiffConfig &desiredConfig, AutoDiffDerivativeFunctionKind kind,
     SILValue original, DifferentiationInvoker invoker,
     SmallVectorImpl<AllocStackInst *> &newBuffersToDealloc) {
   ADContext &context = transformer.getContext();

--- a/lib/SILOptimizer/Utils/DifferentiationMangler.cpp
+++ b/lib/SILOptimizer/Utils/DifferentiationMangler.cpp
@@ -43,7 +43,7 @@ static NodePointer mangleGenericSignatureAsNode(GenericSignature sig,
 
 static NodePointer mangleAutoDiffFunctionAsNode(
     StringRef originalName, Demangle::AutoDiffFunctionKind kind,
-    AutoDiffConfig config, Demangler &demangler) {
+    const AutoDiffConfig &config, Demangler &demangler) {
   assert(isMangledName(originalName));
   auto demangledOrig = demangler.demangleSymbol(originalName);
   assert(demangledOrig && "Should only be called when the original "
@@ -75,7 +75,7 @@ static NodePointer mangleAutoDiffFunctionAsNode(
 
 std::string DifferentiationMangler::mangleAutoDiffFunction(
     StringRef originalName, Demangle::AutoDiffFunctionKind kind,
-    AutoDiffConfig config) {
+    const AutoDiffConfig &config) {
   // If the original function is mangled, mangle the tree.
   if (isMangledName(originalName)) {
     Demangler demangler;
@@ -94,7 +94,7 @@ std::string DifferentiationMangler::mangleAutoDiffFunction(
 // Returns the mangled name for a derivative function of the given kind.
 std::string DifferentiationMangler::mangleDerivativeFunction(
     StringRef originalName, AutoDiffDerivativeFunctionKind kind,
-    AutoDiffConfig config) {
+    const AutoDiffConfig &config) {
   return mangleAutoDiffFunction(
       originalName, getAutoDiffFunctionKind(kind), config);
 }
@@ -102,7 +102,7 @@ std::string DifferentiationMangler::mangleDerivativeFunction(
 // Returns the mangled name for a derivative function of the given kind.
 std::string DifferentiationMangler::mangleLinearMap(
     StringRef originalName, AutoDiffLinearMapKind kind,
-    AutoDiffConfig config) {
+    const AutoDiffConfig &config) {
   return mangleAutoDiffFunction(
       originalName, getAutoDiffFunctionKind(kind), config);
 }

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -560,7 +560,7 @@ void TBDGenVisitor::addConformances(const IterableDeclContext *IDC) {
 }
 
 void TBDGenVisitor::addAutoDiffLinearMapFunction(AbstractFunctionDecl *original,
-                                                 AutoDiffConfig config,
+                                                 const AutoDiffConfig &config,
                                                  AutoDiffLinearMapKind kind) {
   auto &ctx = original->getASTContext();
   auto declRef =
@@ -636,7 +636,7 @@ void TBDGenVisitor::addDifferentiabilityWitness(
 
 void TBDGenVisitor::addDerivativeConfiguration(DifferentiabilityKind diffKind,
                                                AbstractFunctionDecl *original,
-                                               AutoDiffConfig config) {
+                                               const AutoDiffConfig &config) {
   auto inserted = AddedDerivatives.insert({original, config});
   if (!inserted.second)
     return;

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -140,7 +140,7 @@ class TBDGenVisitor : public ASTVisitor<TBDGenVisitor> {
   /// Adds the symbol for the linear map function of the given kind associated
   /// with the given original function and derivative function configuration.
   void addAutoDiffLinearMapFunction(AbstractFunctionDecl *original,
-                                    AutoDiffConfig config,
+                                    const AutoDiffConfig &config,
                                     AutoDiffLinearMapKind kind);
 
   /// Adds the symbol for the autodiff function of the given kind associated
@@ -165,7 +165,7 @@ class TBDGenVisitor : public ASTVisitor<TBDGenVisitor> {
   /// derivative function configuration.
   void addDerivativeConfiguration(DifferentiabilityKind diffKind,
                                   AbstractFunctionDecl *original,
-                                  AutoDiffConfig config);
+                                  const AutoDiffConfig &config);
 
 public:
   TBDGenVisitor(const llvm::Triple &target, const llvm::DataLayout &dataLayout,


### PR DESCRIPTION
AutoDiffConfig is a trivial structure but its size is greater than two registers. It makes an object most likely to be placed on a stack while passing it by value. Here is a small example: https://godbolt.org/z/onMbz1vnW

The change is NFC, making all functions that expect AutoDiffConfig as an argument to be passes by constant reference.
