### PR TITLE
Restrict uses of 'self' in actor initializers

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -168,6 +168,18 @@ ERROR(variable_defer_use_uninit,none,
 ERROR(self_closure_use_uninit,none,
       "'self' captured by a closure before all members were initialized", ())
 
+/// false == sync; true == global-actor isolated
+ERROR(self_use_actor_init,none,
+      "this use of actor 'self' %select{can only|cannot}0 appear in "
+      "%select{an async|a global-actor isolated}0 initializer",
+      (bool))
+ERROR(self_disallowed_actor_init,none,
+      "actor 'self' %select{can only|cannot}0 %1 from "
+      "%select{an async|a global-actor isolated}0 initializer",
+      (bool, StringRef))
+
+
+
 
 ERROR(variable_addrtaken_before_initialized,none,
       "address of %select{variable|constant}1 '%0' taken before it is"

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -432,6 +432,23 @@ bool DIMemoryObjectInfo::isElementLetProperty(unsigned Element) const {
   return false;
 }
 
+ConstructorDecl *DIMemoryObjectInfo::isActorInitSelf() const {
+  // is it 'self'?
+  if (!MemoryInst->isVar())
+    if (auto decl =
+        dyn_cast_or_null<ClassDecl>(getASTType()->getAnyNominal()))
+      // is it for an actor?
+      if (decl->isActor() && !decl->isDistributedActor()) // FIXME(78484431) skip distributed actors for now, until their initializers are fixed!
+        if (auto *silFn = MemoryInst->getFunction())
+          // is it a designated initializer?
+          if (auto *ctor = dyn_cast_or_null<ConstructorDecl>(
+                            silFn->getDeclContext()->getAsDecl()))
+            if (ctor->isDesignatedInit())
+              return ctor;
+
+  return nullptr;
+}
+
 //===----------------------------------------------------------------------===//
 //                        DIMemoryUse Implementation
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
@@ -164,6 +164,10 @@ public:
     return false;
   }
 
+  /// Returns the initializer if the memory use is 'self' and appears in an
+  /// actor's designated initializer. Otherwise, returns nullptr.
+  ConstructorDecl *isActorInitSelf() const;
+
   /// True if this memory object is the 'self' of a derived class initializer.
   bool isDerivedClassSelf() const { return MemoryInst->isDerivedClassSelf(); }
 

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -384,6 +384,13 @@ namespace {
 
   using BlockStates = BasicBlockData<LiveOutBlockState>;
 
+  enum class ActorInitKind {
+    None,           // not an actor init
+    Plain,          // synchronous, not isolated to global-actor
+    PlainAsync,     // asynchronous, not isolated to global-actor
+    GlobalActorIsolated  // isolated to global-actor (sync or async).
+  };
+
   /// LifetimeChecker - This is the main heavy lifting for definite
   /// initialization checking of a memory object.
   class LifetimeChecker {
@@ -479,6 +486,20 @@ namespace {
 
     bool diagnoseReturnWithoutInitializingStoredProperties(
         const SILInstruction *Inst, SILLocation loc, const DIMemoryUse &Use);
+
+    /// Returns true iff the use involves 'self' in a restricted kind of
+    /// actor initializer. If a non-null Kind pointer was passed in,
+    /// then the specific kind of restricted actor initializer will be
+    /// written out. Otherwise, the None initializer kind will be written out.
+    bool isRestrictedActorInitSelf(const DIMemoryUse& Use,
+                               ActorInitKind *Kind = nullptr) const;
+
+    void reportIllegalUseForActorInit(const DIMemoryUse &Use,
+                                      ActorInitKind ActorKind,
+                                      StringRef ProblemDesc) const;
+
+    void handleLoadUseFailureForActorInit(const DIMemoryUse &Use,
+                                          ActorInitKind ActorKind) const;
 
     void handleLoadUseFailure(const DIMemoryUse &Use,
                               bool SuperInitDone,
@@ -866,9 +887,13 @@ void LifetimeChecker::doIt() {
 
 void LifetimeChecker::handleLoadUse(const DIMemoryUse &Use) {
   bool IsSuperInitComplete, FailedSelfUse;
+  ActorInitKind ActorKind = ActorInitKind::None;
   // If the value is not definitively initialized, emit an error.
   if (!isInitializedAtUse(Use, &IsSuperInitComplete, &FailedSelfUse))
     return handleLoadUseFailure(Use, IsSuperInitComplete, FailedSelfUse);
+  // Check if it involves 'self' in a restricted actor init.
+  if (isRestrictedActorInitSelf(Use, &ActorKind))
+    return handleLoadUseFailureForActorInit(Use, ActorKind);
 }
 
 static void replaceValueMetatypeInstWithMetatypeArgument(
@@ -1177,6 +1202,7 @@ static FullApplySite findApply(SILInstruction *I, bool &isSelfParameter) {
 
 void LifetimeChecker::handleInOutUse(const DIMemoryUse &Use) {
   bool IsSuperInitDone, FailedSelfUse;
+  ActorInitKind ActorKind = ActorInitKind::None;
 
   // inout uses are generally straight-forward: the memory must be initialized
   // before the "address" is passed as an l-value.
@@ -1194,6 +1220,10 @@ void LifetimeChecker::handleInOutUse(const DIMemoryUse &Use) {
     diagnoseInitError(Use, diagID);
     return;
   }
+
+  // 'self' cannot be passed 'inout' from some kinds of actor initializers.
+  if (isRestrictedActorInitSelf(Use, &ActorKind))
+    reportIllegalUseForActorInit(Use, ActorKind, "be passed 'inout'");
 
   // One additional check: 'let' properties may never be passed inout, because
   // they are only allowed to have their initial value set, not a subsequent
@@ -1357,12 +1387,19 @@ static bool isLoadForReturn(SingleValueInstruction *loadInst) {
 }
 
 void LifetimeChecker::handleEscapeUse(const DIMemoryUse &Use) {
+
   // The value must be fully initialized at all escape points.  If not, diagnose
   // the error.
   bool SuperInitDone, FailedSelfUse, FullyUninitialized;
+  ActorInitKind ActorKind = ActorInitKind::None;
 
   if (isInitializedAtUse(Use, &SuperInitDone, &FailedSelfUse,
                          &FullyUninitialized)) {
+
+    // no escaping uses of 'self' are allowed in restricted actor inits.
+    if (isRestrictedActorInitSelf(Use, &ActorKind))
+      reportIllegalUseForActorInit(Use, ActorKind, "be captured by a closure");
+
     return;
   }
 
@@ -1744,6 +1781,89 @@ bool LifetimeChecker::diagnoseReturnWithoutInitializingStoredProperties(
   }
 
   return true;
+}
+
+bool LifetimeChecker::isRestrictedActorInitSelf(const DIMemoryUse& Use,
+                                            ActorInitKind *Kind) const {
+
+  auto result = [&](ActorInitKind k, bool isRestricted) -> bool {
+    if (Kind)
+      *Kind = k;
+    return isRestricted;
+  };
+
+  // Currently: being synchronous, or global-actor isolated, means the actor's
+  // self is restricted within the init.
+  if (auto *ctor = TheMemory.isActorInitSelf()) {
+    if (getActorIsolation(ctor).isGlobalActor())  // global-actor isolated?
+      return result(ActorInitKind::GlobalActorIsolated, true);
+    else if (!ctor->hasAsync()) // synchronous?
+      return result(ActorInitKind::Plain, true);
+    else
+      return result(ActorInitKind::PlainAsync, false);
+  }
+
+  return result(ActorInitKind::None, false);
+}
+
+void LifetimeChecker::reportIllegalUseForActorInit(
+                                           const DIMemoryUse &Use,
+                                           ActorInitKind ActorKind,
+                                           StringRef ProblemDesc) const {
+  switch(ActorKind) {
+  case ActorInitKind::None:
+  case ActorInitKind::PlainAsync:
+    llvm::report_fatal_error("this actor init is never problematic!");
+
+  case ActorInitKind::Plain:
+    diagnose(Module, Use.Inst->getLoc(), diag::self_disallowed_actor_init,
+             false, ProblemDesc);
+    break;
+
+  case ActorInitKind::GlobalActorIsolated:
+    diagnose(Module, Use.Inst->getLoc(), diag::self_disallowed_actor_init,
+             true, ProblemDesc);
+    break;
+  }
+}
+
+void LifetimeChecker::handleLoadUseFailureForActorInit(
+                                           const DIMemoryUse &Use,
+                                           ActorInitKind ActorKind) const {
+  assert(TheMemory.isAnyInitSelf());
+  SILInstruction *Inst = Use.Inst;
+
+  // While enum instructions have no side-effects, they do wrap-up `self`
+  // such that it can escape our analysis. So, enum instruction uses are only
+  // acceptable if the enum is part of a specific pattern of usage that is
+  // generated for a failable initializer.
+  if (auto *enumInst = dyn_cast<EnumInst>(Inst)) {
+    if (isFailableInitReturnUseOfEnum(enumInst))
+      return;
+
+    // Otherwise, if the use has no possibility of side-effects, then its OK.
+  } else if (!Inst->mayHaveSideEffects()) {
+    return;
+
+  // While loads can have side-effects, we are not concerned by them here.
+  } else if (isa<LoadInst>(Inst)) {
+    return;
+  }
+
+  // Everything else is disallowed!
+  switch(ActorKind) {
+  case ActorInitKind::None:
+  case ActorInitKind::PlainAsync:
+    llvm::report_fatal_error("this actor init is never problematic!");
+
+  case ActorInitKind::Plain:
+    diagnose(Module, Use.Inst->getLoc(), diag::self_use_actor_init, false);
+    break;
+
+  case ActorInitKind::GlobalActorIsolated:
+    diagnose(Module, Use.Inst->getLoc(), diag::self_use_actor_init, true);
+    break;
+  }
 }
 
 /// Check and diagnose various failures when a load use is not fully

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2143,12 +2143,14 @@ namespace {
     }
 
     /// Check whether we are in an actor's initializer or deinitializer.
-    static bool isActorInitOrDeInitContext(const DeclContext *dc) {
+    /// \returns nullptr iff we are not in such a declaration. Otherwise,
+    ///          returns a pointer to the declaration.
+    static AbstractFunctionDecl const* isActorInitOrDeInitContext(const DeclContext *dc) {
       while (true) {
         // Non-Sendable closures are considered part of the enclosing context.
         if (auto closure = dyn_cast<AbstractClosureExpr>(dc)) {
           if (isSendableClosure(closure, /*forActorIsolation=*/false))
-            return false;
+            return nullptr;
 
           dc = dc->getParent();
           continue;
@@ -2158,7 +2160,7 @@ namespace {
           // If this is an initializer or deinitializer of an actor, we're done.
           if ((isa<ConstructorDecl>(func) || isa<DestructorDecl>(func)) &&
               getSelfActorDecl(dc->getParent()))
-            return true;
+            return func;
 
           // Non-Sendable local functions are considered part of the enclosing
           // context.
@@ -2166,7 +2168,7 @@ namespace {
             if (auto fnType =
                     func->getInterfaceType()->getAs<AnyFunctionType>()) {
               if (fnType->isSendable())
-                return false;
+                return nullptr;
 
               dc = dc->getParent();
               continue;
@@ -2174,8 +2176,15 @@ namespace {
           }
         }
 
-        return false;
+        return nullptr;
       }
+    }
+
+    static bool isConvenienceInit(AbstractFunctionDecl const* fn) {
+      if (auto ctor = dyn_cast_or_null<ConstructorDecl>(fn))
+        return ctor->isConvenienceInit();
+
+      return false;
     }
 
     /// Check a reference to a local or global.
@@ -2251,9 +2260,10 @@ namespace {
         bool continueToCheckingLocalIsolation = false;
         // Must reference distributed actor-isolated state on 'self'.
         //
-        // FIXME: For now, be loose about access to "self" in actor
-        // initializers/deinitializers. We'll want to tighten this up once
-        // we decide exactly how the model should go.
+        // FIXME(78484431): For now, be loose about access to "self" in actor
+        // initializers/deinitializers for distributed actors.
+        // We'll want to tighten this up once we decide exactly
+        // how the model should go.
         auto isolatedActor = getIsolatedActor(base);
         if (!isolatedActor &&
             !(isolatedActor.isActorSelf() &&
@@ -2311,14 +2321,12 @@ namespace {
         if (isolatedActor)
           return false;
 
-        // An instance member of an actor can be referenced from an initializer
-        // or deinitializer.
-        // FIXME: We likely want to narrow this down to only stored properties,
-        // but this matches existing behavior.
-        if (isolatedActor.isActorSelf() &&
-            member->isInstanceMember() &&
-            isActorInitOrDeInitContext(getDeclContext()))
-          return false;
+        // An instance member of an actor can be referenced from an actor's
+        // designated initializer or deinitializer.
+        if (isolatedActor.isActorSelf() && member->isInstanceMember())
+          if (auto fn = isActorInitOrDeInitContext(getDeclContext()))
+            if (!isConvenienceInit(fn))
+              return false;
 
         // An escaping partial application of something that is part of
         // the actor's isolated state is never permitted.
@@ -2936,8 +2944,10 @@ static Optional<MemberIsolationPropagation> getMemberIsolationPropagation(
   case DeclKind::PatternBinding:
   case DeclKind::EnumCase:
   case DeclKind::EnumElement:
-  case DeclKind::Constructor:
     return MemberIsolationPropagation::GlobalActor;
+
+  case DeclKind::Constructor:
+    return MemberIsolationPropagation::AnyIsolation;
 
   case DeclKind::Func:
   case DeclKind::Accessor:
@@ -3020,6 +3030,13 @@ ActorIsolation ActorIsolationRequest::evaluate(
       defaultIsolation = ActorIsolation::forIndependent();
     }
   }
+
+  // An actor's convenience init is assumed to be actor-independent.
+  if (auto nominal = value->getDeclContext()->getSelfNominalTypeDecl())
+    if (nominal->isActor())
+      if (auto ctor = dyn_cast<ConstructorDecl>(value))
+        if (ctor->isConvenienceInit())
+          defaultIsolation = ActorIsolation::forIndependent();
 
   // Function used when returning an inferred isolation.
   auto inferredIsolation = [&](
@@ -3180,10 +3197,6 @@ bool HasIsolatedSelfRequest::evaluate(
 
   switch (*memberIsolation) {
   case MemberIsolationPropagation::GlobalActor:
-    // Treat constructors as being actor-isolated... for now.
-    if (isa<ConstructorDecl>(value))
-      break;
-
     return false;
 
   case MemberIsolationPropagation::AnyIsolation:
@@ -3218,6 +3231,13 @@ bool HasIsolatedSelfRequest::evaluate(
       if (isolation.getActor() != selfTypeDecl)
         return false;
       break;
+    }
+  }
+
+  // In an actor's convenience init, self is not isolated.
+  if (auto ctor = dyn_cast<ConstructorDecl>(value)) {
+    if (ctor->isConvenienceInit()) {
+      return false;
     }
   }
 

--- a/test/Concurrency/Runtime/actor_keypaths.swift
+++ b/test/Concurrency/Runtime/actor_keypaths.swift
@@ -17,10 +17,14 @@ actor Page {
       set { numWordsMem.pointee = newValue }
     }
 
-    init(_ words : Int) {
+    private init(withWords words : Int) {
         initialNumWords = words
         numWordsMem = .allocate(capacity: 1)
         numWordsMem.initialize(to: words)
+    }
+
+    convenience init(_ words: Int) {
+        self.init(withWords: words)
         numWords = words
     }
 

--- a/test/Concurrency/actor_definite_init.swift
+++ b/test/Concurrency/actor_definite_init.swift
@@ -1,0 +1,343 @@
+// RUN: %target-swift-frontend -parse-as-library -emit-sil -verify %s
+
+// REQUIRES: concurrency
+
+enum BogusError: Error {
+    case blah
+}
+
+@available(SwiftStdlib 5.5, *)
+actor Convenient {
+    var x: Int
+    var y: Convenient?
+
+    init(val: Int) {
+        self.x = val
+    }
+
+    convenience init(bigVal: Int) {
+        if bigVal < 0 {
+            self.init(val: 0)
+            say(msg: "hello from actor!")
+        }
+        say(msg: "said this too early!") // expected-error {{'self' used before 'self.init' call or assignment to 'self'}}
+        self.init(val: bigVal)
+
+        Task { await self.mutateIsolatedState() }
+    }
+
+    convenience init!(biggerVal1 biggerVal: Int) {
+        guard biggerVal < 1234567 else { return nil }
+        self.init(bigVal: biggerVal)
+        say(msg: "hello?")
+    }
+
+    @MainActor
+    convenience init?(biggerVal2 biggerVal: Int) async {
+        guard biggerVal < 1234567 else { return nil }
+        self.init(bigVal: biggerVal)
+        say(msg: "hello?")
+        await mutateIsolatedState()
+    }
+
+    convenience init() async {
+        self.init(val: 10)
+        await mutateIsolatedState()
+    }
+
+    init(throwyDesignated val: Int) throws {
+        guard val > 0 else { throw BogusError.blah }
+        self.x = 10
+        say(msg: "hello?")  // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+        Task { self }       // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+    }
+
+    init(asyncThrowyDesignated val: Int) async throws {
+        guard val > 0 else { throw BogusError.blah }
+        self.x = 10
+        say(msg: "hello?")
+        Task { self }
+    }
+
+    convenience init(throwyConvenient val: Int) throws {
+        try self.init(throwyDesignated: val)
+        say(msg: "hello?")
+        Task { self }
+    }
+
+    func mutateIsolatedState() {
+        self.y = self
+    }
+
+    nonisolated func say(msg: String) {
+        print(msg)
+    }
+}
+
+func randomInt() -> Int { return 4 }
+
+@available(SwiftStdlib 5.5, *)
+func callMethod(_ a: MyActor) {}
+
+@available(SwiftStdlib 5.5, *)
+func passInout<T>(_ a: inout T) {}
+
+@available(SwiftStdlib 5.5, *)
+actor MyActor {
+    var x: Int
+    var y: Int
+    var hax: MyActor?
+
+    var computedProp : Int {
+        get { 0 }
+        set { }
+    }
+
+    func helloWorld() {}
+
+    init(i1 c:  Bool) {
+        self.x = 0
+        _ = self.x
+        self.y = self.x
+
+        Task { self }     // expected-error{{actor 'self' can only be captured by a closure from an async initializer}}
+
+        self.helloWorld() // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        callMethod(self) // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        passInout(&self.x) // expected-error{{actor 'self' can only be passed 'inout' from an async initializer}}
+
+        self.x = self.y
+        self.x = randomInt()
+        (_, _) = (self.x, self.y)
+        _ = self.x == 0
+
+        self.hax = self     // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        _ = self.hax
+
+        _ = computedProp    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        computedProp = 1    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+
+        Task { // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+            _ = await self.hax
+            await self.helloWorld()
+        }
+    }
+
+    init?(i1_nil c:  Bool) {
+        self.x = 0
+        guard c else { return nil }
+        self.y = self.x
+
+        Task { self }     // expected-error{{actor 'self' can only be captured by a closure from an async initializer}}
+
+        self.helloWorld() // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        callMethod(self) // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        passInout(&self.x) // expected-error{{actor 'self' can only be passed 'inout' from an async initializer}}
+
+        self.x = self.y
+
+        self.hax = self     // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        _ = self.hax
+
+        _ = computedProp    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        computedProp = 1    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+
+        Task { // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+            _ = await self.hax
+            await self.helloWorld()
+        }
+    }
+
+    init!(i1_boom c:  Bool) {
+        self.x = 0
+        guard c else { return nil }
+        self.y = self.x
+
+        Task { self }     // expected-error{{actor 'self' can only be captured by a closure from an async initializer}}
+
+        self.helloWorld() // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        callMethod(self) // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        passInout(&self.x) // expected-error{{actor 'self' can only be passed 'inout' from an async initializer}}
+
+        self.x = self.y
+
+        self.hax = self     // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        _ = self.hax
+
+        _ = computedProp    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        computedProp = 1    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+
+        Task { // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+            _ = await self.hax
+            await self.helloWorld()
+        }
+    }
+
+    @MainActor
+    init(i2 c:  Bool) {
+        self.x = 0
+        self.y = self.x
+
+        Task { self }     // expected-error{{actor 'self' cannot be captured by a closure from a global-actor isolated initializer}}
+
+        self.helloWorld() // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+        callMethod(self) // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+        passInout(&self.x) // expected-error{{actor 'self' cannot be passed 'inout' from a global-actor isolated initializer}}
+
+        self.x = self.y
+
+        self.hax = self     // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+        _ = self.hax
+
+        _ = computedProp    // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+        computedProp = 1    // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+
+        Task { // expected-error {{actor 'self' cannot be captured by a closure from a global-actor isolated initializer}}
+            _ = await self.hax
+            await self.helloWorld()
+        }
+    }
+
+    init(i3 c:  Bool) async {
+        self.x = 0
+        self.y = self.x
+
+        Task { self }
+
+        self.helloWorld()
+        callMethod(self)
+        passInout(&self.x)
+
+        self.x = self.y
+
+        self.hax = self
+        _ = Optional.some(self)
+
+        _ = computedProp
+        computedProp = 1
+
+        Task {
+            _ = await self.hax
+            await self.helloWorld()
+        }
+    }
+
+    @MainActor
+    init(i4 c:  Bool) async {
+        self.x = 0
+        self.y = self.x
+
+        Task { self }     // expected-error{{actor 'self' cannot be captured by a closure from a global-actor isolated initializer}}
+
+        self.helloWorld() // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+        callMethod(self) // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+        passInout(&self.x) // expected-error{{actor 'self' cannot be passed 'inout' from a global-actor isolated initializer}}
+
+        self.x = self.y
+
+        self.hax = self     // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+        _ = self.hax
+
+        _ = computedProp    // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+        computedProp = 1    // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+
+        Task { // expected-error {{actor 'self' cannot be captured by a closure from a global-actor isolated initializer}}
+            _ = await self.hax
+            await self.helloWorld()
+        }
+    }
+
+}
+
+
+@available(SwiftStdlib 5.5, *)
+actor X {
+    var counter: Int
+
+    init(v1 start: Int) {
+        self.counter = start
+        Task { await self.setCounter(start + 1) } // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+
+        if self.counter != start {
+            fatalError("where's my protection?")
+        }
+    }
+
+    func setCounter(_ x : Int) {
+        self.counter = x
+    }
+}
+
+struct CardboardBox<T> {
+    public let item: T
+}
+
+
+@available(SwiftStdlib 5.5, *)
+var globalVar: EscapeArtist?
+
+@available(SwiftStdlib 5.5, *)
+actor EscapeArtist {
+    var x: Int
+
+    init(attempt1: Bool) {
+        self.x = 0
+
+        globalVar = self    // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+        Task { await globalVar!.isolatedMethod() }
+
+        if self.x == 0 {
+            fatalError("race detected.")
+        }
+    }
+
+    init(attempt2: Bool) {
+        self.x = 0
+
+        let wrapped: EscapeArtist? = .some(self)    // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+        let selfUnchained = wrapped!
+
+        Task { await selfUnchained.isolatedMethod() }
+        if self.x == 0 {
+            fatalError("race detected.")
+        }
+    }
+
+    init(attempt3: Bool) {
+        self.x = 0
+
+        // expected-warning@+2 {{variable 'unchainedSelf' was never mutated; consider changing to 'let' constant}}
+        // expected-error@+1 {{this use of actor 'self' can only appear in an async initializer}}
+        var unchainedSelf = self
+
+        unchainedSelf.nonisolated()
+    }
+
+    init(attempt4: Bool) {
+        self.x = 0
+
+        let unchainedSelf = self
+
+        unchainedSelf.nonisolated() // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+
+        let _ = { unchainedSelf.nonisolated() } // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+    }
+
+    init(attempt5: Bool) {
+        self.x = 0
+
+        let box = CardboardBox(item: self) // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+        box.item.nonisolated()
+    }
+
+    init(attempt6: Bool) {
+        self.x = 0
+        func fn() {
+            self.nonisolated()
+        }
+        fn()    // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+    }
+
+    func isolatedMethod() { x += 1 }
+    nonisolated func nonisolated() {}
+}

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -685,21 +685,72 @@ extension SomeClassInActor.ID {
 }
 
 // ----------------------------------------------------------------------
-// Initializers
+// Initializers (through typechecking only)
 // ----------------------------------------------------------------------
 @available(SwiftStdlib 5.5, *)
 actor SomeActorWithInits {
   var mutableState: Int = 17
   var otherMutableState: Int
 
-  init() {
+  init(i1: Bool) {
     self.mutableState = 42
     self.otherMutableState = 17
 
     self.isolated()
+    self.nonisolated()
   }
 
-  func isolated() { }
+  init(i2: Bool) async {
+    self.mutableState = 0
+    self.otherMutableState = 1
+
+    self.isolated()
+    self.nonisolated()
+  }
+
+  convenience init(i3: Bool) {
+    self.init(i1: i3)
+    self.isolated()     // expected-error{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context}}
+    self.nonisolated()
+  }
+
+  convenience init(i4: Bool) async {
+    self.init(i1: i4)
+    await self.isolated()
+    self.nonisolated()
+  }
+
+  @MainActor init(i5: Bool) {
+    self.mutableState = 42
+    self.otherMutableState = 17
+
+    self.isolated()
+    self.nonisolated()
+  }
+
+  @MainActor init(i6: Bool) async {
+    self.mutableState = 42
+    self.otherMutableState = 17
+
+    self.isolated()
+    self.nonisolated()
+  }
+
+  @MainActor convenience init(i7: Bool) {
+    self.init(i1: i7)
+    self.isolated()     // expected-error{{actor-isolated instance method 'isolated()' can not be referenced from the main actor}}
+    self.nonisolated()
+  }
+
+  @MainActor convenience init(i8: Bool) async {
+    self.init(i1: i8)
+    await self.isolated()
+    self.nonisolated()
+  }
+
+
+  func isolated() { } // expected-note 2 {{calls to instance method 'isolated()' from outside of its actor context are implicitly asynchronous}}
+  nonisolated func nonisolated() {}
 }
 
 @available(SwiftStdlib 5.5, *)


### PR DESCRIPTION
Fixes the following:

- [x] Actors permit synchronous initializers, and initializers isolated to a global-actor, which makes it difficult to both create the actor-instance and switch to it within the initializer function. Thus, data races can be created with the initializer. This PR fixes this by broadly restricting the uses of `self` in such initializers to ensure that one unique reference to `self` exists throughout the `init`.

- ~When I added support for async initializers, I deferred the appropriate insertion of `hop_to_executor` in actor initializers because it's not so simple to determine where that should take place. This PR fixes that and emits the hop.~ Deferred to a later PR

Resolves rdar://76620928
