### PR TITLE
GSB: Rewrite redundant requirements algorithm for the second time

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -102,6 +102,9 @@ ERROR(generic_signature_not_valid,none,
 ERROR(generic_signature_not_equal,none,
       "generic signature %0 is not equal to new signature %1",
       (StringRef, StringRef))
+ERROR(generic_signature_not_reducible,none,
+      "generic signature %0 does not have any single removable requirement",
+      (StringRef))
 
 // Used in diagnostics that are split across requests implemented in several places.
 ERROR(concurrency_default_actor_not_found,none,

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -624,7 +624,7 @@ public:
 
   GenericSignature rebuildSignatureWithoutRedundantRequirements(
                       bool allowConcreteGenericParams,
-                      bool buildingRequirementSignature) &&;
+                      const ProtocolDecl *requirementSignatureSelfProto) &&;
 
   /// Finalize the set of requirements and compute the generic
   /// signature.
@@ -633,7 +633,7 @@ public:
   /// generic signature builder no longer has valid state.
   GenericSignature computeGenericSignature(
                       bool allowConcreteGenericParams = false,
-                      bool buildingRequirementSignature = false,
+                      const ProtocolDecl *requirementSignatureSelfProto = nullptr,
                       bool rebuildingWithoutRedundantConformances = false) &&;
 
   /// Compute the requirement signature for the given protocol.
@@ -646,7 +646,8 @@ private:
   /// \param allowConcreteGenericParams If true, allow generic parameters to
   /// be made concrete.
   void finalize(TypeArrayView<GenericTypeParamType> genericParams,
-                bool allowConcreteGenericParams=false);
+                bool allowConcreteGenericParams,
+                const ProtocolDecl *requirementSignatureSelfProto);
 
 public:
   /// Process any delayed requirements that can be handled now.
@@ -657,7 +658,7 @@ public:
   bool isRedundantExplicitRequirement(const ExplicitRequirement &req) const;
 
 private:
-  void computeRedundantRequirements();
+  void computeRedundantRequirements(const ProtocolDecl *requirementSignatureSelfProto);
 
   void diagnoseRedundantRequirements() const;
 

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -663,8 +663,6 @@ private:
 
   void diagnoseConflictingConcreteTypeRequirements() const;
 
-  bool hasExplicitConformancesImpliedByConcrete() const;
-
   /// Describes the relationship between a given constraint and
   /// the canonical constraint of the equivalence class.
   enum class ConstraintRelation {

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -658,11 +658,27 @@ public:
   bool isRedundantExplicitRequirement(const ExplicitRequirement &req) const;
 
 private:
-  void computeRedundantRequirements(const ProtocolDecl *requirementSignatureSelfProto);
+  using GetKindAndRHS = llvm::function_ref<std::pair<RequirementKind, RequirementRHS>()>;
+  void getBaseRequirements(
+      GetKindAndRHS getKindAndRHS,
+      const RequirementSource *source,
+      const ProtocolDecl *requirementSignatureSelfProto,
+      ASTContext &ctx, SmallVectorImpl<ExplicitRequirement> &result);
+
+  template<typename T, typename Filter>
+  void checkRequirementRedundancy(
+      const ExplicitRequirement &req,
+      const std::vector<Constraint<T>> &constraints,
+      const ProtocolDecl *requirementSignatureSelfProto,
+      Filter filter);
+
+  void computeRedundantRequirements(
+      const ProtocolDecl *requirementSignatureSelfProto);
 
   void diagnoseRedundantRequirements() const;
 
-  void diagnoseConflictingConcreteTypeRequirements() const;
+  void diagnoseConflictingConcreteTypeRequirements(
+      const ProtocolDecl *requirementSignatureSelfProto);
 
   /// Describes the relationship between a given constraint and
   /// the canonical constraint of the equivalence class.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -727,12 +727,6 @@ private:
                             TypeArrayView<GenericTypeParamType> genericParams,
                             EquivalenceClass *equivClass);
 
-  /// Check conformance constraints within the equivalence class of the
-  /// given potential archetype.
-  void checkConformanceConstraints(
-                            TypeArrayView<GenericTypeParamType> genericParams,
-                            EquivalenceClass *equivClass);
-
   /// Check same-type constraints within the equivalence class of the
   /// given potential archetype.
   void checkSameTypeConstraints(

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -727,22 +727,11 @@ private:
                             TypeArrayView<GenericTypeParamType> genericParams,
                             EquivalenceClass *equivClass);
 
-  /// Check the superclass constraints within the equivalence
-  /// class of the given potential archetype.
-  void checkSuperclassConstraints(
-                            TypeArrayView<GenericTypeParamType> genericParams,
-                            EquivalenceClass *equivClass);
-
   /// Check conformance constraints within the equivalence class of the
   /// given potential archetype.
   void checkConformanceConstraints(
                             TypeArrayView<GenericTypeParamType> genericParams,
                             EquivalenceClass *equivClass);
-
-  /// Check layout constraints within the equivalence class of the given
-  /// potential archetype.
-  void checkLayoutConstraints(TypeArrayView<GenericTypeParamType> genericParams,
-                              EquivalenceClass *equivClass);
 
   /// Check same-type constraints within the equivalence class of the
   /// given potential archetype.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1229,8 +1229,7 @@ public:
   /// requirement redundant, because without said original requirement, the
   /// derived requirement ceases to hold.
   bool isSelfDerivedSource(GenericSignatureBuilder &builder,
-                           Type type,
-                           bool &derivedViaConcrete) const;
+                           Type type) const;
 
   /// For a requirement source that describes the requirement \c type:proto,
   /// retrieve the minimal subpath of this requirement source that will
@@ -1242,8 +1241,7 @@ public:
   const RequirementSource *getMinimalConformanceSource(
                                             GenericSignatureBuilder &builder,
                                             Type type,
-                                            ProtocolDecl *proto,
-                                            bool &derivedViaConcrete) const;
+                                            ProtocolDecl *proto) const;
 
   /// Retrieve a source location that corresponds to the requirement.
   SourceLoc getLoc() const;

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -580,6 +580,10 @@ public:
     return sourceAndKind.getInt();
   }
 
+  Type getSubjectType() const {
+    return getSource()->getStoredType();
+  }
+
   const RequirementSource *getSource() const {
     return sourceAndKind.getPointer();
   }
@@ -7179,7 +7183,7 @@ void GenericSignatureBuilder::diagnoseRedundantRequirements() const {
                      }))
       continue;
 
-    auto subjectType = getSugaredDependentType(source->getStoredType(),
+    auto subjectType = getSugaredDependentType(req.getSubjectType(),
                                                getGenericParams());
 
     switch (req.getKind()) {
@@ -7321,7 +7325,7 @@ void GenericSignatureBuilder::diagnoseConflictingConcreteTypeRequirements() cons
     if (loc.isInvalid() && otherLoc.isInvalid())
       continue;
 
-    auto subjectType = pair.concreteTypeRequirement.getSource()->getStoredType();
+    auto subjectType = pair.concreteTypeRequirement.getSubjectType();
     SourceLoc subjectLoc = (loc.isInvalid() ? otherLoc : loc);
 
     Impl->HadAnyError = true;
@@ -8292,7 +8296,7 @@ void GenericSignatureBuilder::enumerateRequirements(
       continue;
 
     auto depTy = getCanonicalTypeInContext(
-        req.getSource()->getStoredType(), { });
+        req.getSubjectType(), { });
 
     // FIXME: This should be an assert once we ensure that concrete
     // same-type requirements always mark other requirements on the
@@ -8561,7 +8565,7 @@ GenericSignature GenericSignatureBuilder::rebuildSignatureWithoutRedundantRequir
         Impl->ExplicitConformancesImpliedByConcrete.count(req))
       continue;
 
-    auto subjectType = req.getSource()->getStoredType();
+    auto subjectType = req.getSubjectType();
     subjectType = stripBoundDependentMemberTypes(subjectType);
     auto resolvedSubjectType =
         resolveDependentMemberTypes(*this, subjectType,

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -930,10 +930,8 @@ bool RequirementSource::shouldDiagnoseRedundancy(bool primary) const {
 }
 
 bool RequirementSource::isSelfDerivedSource(GenericSignatureBuilder &builder,
-                                            Type type,
-                                            bool &derivedViaConcrete) const {
-  return getMinimalConformanceSource(builder, type, /*proto=*/nullptr,
-                                     derivedViaConcrete)
+                                            Type type) const {
+  return getMinimalConformanceSource(builder, type, /*proto=*/nullptr)
     != this;
 }
 
@@ -983,10 +981,7 @@ static bool isSelfDerivedProtocolRequirementInProtocol(
 const RequirementSource *RequirementSource::getMinimalConformanceSource(
                                              GenericSignatureBuilder &builder,
                                              Type currentType,
-                                             ProtocolDecl *proto,
-                                             bool &derivedViaConcrete) const {
-  derivedViaConcrete = false;
-
+                                             ProtocolDecl *proto) const {
   // If it's not a derived requirement, it's not self-derived.
   if (!isDerivedRequirement()) return this;
 
@@ -1052,15 +1047,6 @@ const RequirementSource *RequirementSource::getMinimalConformanceSource(
           builder.resolveEquivalenceClass(parentType,
                                           ArchetypeResolutionKind::WellFormed);
       assert(parentEquivClass && "Not a well-formed type?");
-
-      if (requirementSignatureSelfProto) {
-        if (parentEquivClass->concreteType)
-          derivedViaConcrete = true;
-        else if (parentEquivClass->superclass &&
-                 builder.lookupConformance(parentEquivClass->superclass,
-                                           source->getProtocolDecl()))
-          derivedViaConcrete = true;
-      }
 
       // The parent potential archetype must conform to the protocol in which
       // this requirement resides. Add this constraint.
@@ -1130,7 +1116,7 @@ const RequirementSource *RequirementSource::getMinimalConformanceSource(
                               redundantSubpath->first,
                               redundantSubpath->second);
     return shorterSource
-      ->getMinimalConformanceSource(builder, currentType, proto, derivedViaConcrete);
+      ->getMinimalConformanceSource(builder, currentType, proto);
   }
 
   // It's self-derived but we don't have a redundant subpath to eliminate.
@@ -2824,13 +2810,10 @@ static void concretizeNestedTypeFromConcreteParent(
   const RequirementSource *parentConcreteSource = nullptr;
 
   for (const auto &constraint : parentEquiv->conformsTo.find(proto)->second) {
-    bool derivedViaConcrete = false;
-
     auto *minimal = constraint.source->getMinimalConformanceSource(
-        builder, constraint.getSubjectDependentType({ }), proto,
-        derivedViaConcrete);
+        builder, constraint.getSubjectDependentType({ }), proto);
 
-    if (minimal == nullptr || derivedViaConcrete)
+    if (minimal == nullptr)
       continue;
 
     if (!isSuperclassConstrained) {
@@ -5679,13 +5662,10 @@ static void expandSameTypeConstraints(GenericSignatureBuilder &builder,
       bool alreadyFound = false;
       const RequirementSource *conformsSource = nullptr;
       for (const auto &constraint : conforms.second) {
-        bool derivedViaConcrete = false;
-
         auto *minimal = constraint.source->getMinimalConformanceSource(
-            builder, constraint.getSubjectDependentType({ }), proto,
-            derivedViaConcrete);
+            builder, constraint.getSubjectDependentType({ }), proto);
 
-        if (minimal == nullptr || derivedViaConcrete)
+        if (minimal == nullptr)
           continue;
 
         if (minimal->getAffectedType()->isEqual(dependentType)) {
@@ -5910,16 +5890,12 @@ void GenericSignatureBuilder::computeRedundantRequirements(
           requirementSignatureSelfProto,
           [&](const Constraint<ProtocolDecl *> &constraint) {
             // FIXME: Remove this.
-            bool derivedViaConcrete;
             auto minimalSource =
               constraint.source->getMinimalConformanceSource(
                   *this,
                   constraint.getSubjectDependentType({ }),
-                  proto, derivedViaConcrete);
+                  proto);
             if (minimalSource != constraint.source)
-              return true;
-
-            if (derivedViaConcrete)
               return true;
 
             return false;
@@ -6495,27 +6471,21 @@ void GenericSignatureBuilder::processDelayedRequirements() {
 
 namespace {
   /// Remove self-derived sources from the given vector of constraints.
-  ///
-  /// \returns true if any derived-via-concrete constraints were found.
   template<typename T>
-  bool removeSelfDerived(GenericSignatureBuilder &builder,
+  void removeSelfDerived(GenericSignatureBuilder &builder,
                          std::vector<Constraint<T>> &constraints,
                          ProtocolDecl *proto,
-                         bool dropDerivedViaConcrete = true,
                          bool allCanBeSelfDerived = false) {
     auto genericParams = builder.getGenericParams();
-    bool anyDerivedViaConcrete = false;
-    Optional<Constraint<T>> remainingConcrete;
     SmallVector<Constraint<T>, 4> minimalSources;
     constraints.erase(
       std::remove_if(constraints.begin(), constraints.end(),
         [&](const Constraint<T> &constraint) {
-          bool derivedViaConcrete;
           auto minimalSource =
             constraint.source->getMinimalConformanceSource(
                          builder,
                          constraint.getSubjectDependentType(genericParams),
-                         proto, derivedViaConcrete);
+                         proto);
           if (minimalSource != constraint.source) {
             // The minimal source is smaller than the original source, so the
             // original source is self-derived.
@@ -6532,21 +6502,8 @@ namespace {
             return true;
           }
 
-           if (!derivedViaConcrete)
-             return false;
-
-           anyDerivedViaConcrete = true;
-
-           if (!dropDerivedViaConcrete)
-             return false;
-
-           // Drop derived-via-concrete requirements.
-           if (!remainingConcrete)
-             remainingConcrete = constraint;
-
-           ++NumSelfDerived;
-           return true;
-         }),
+          return false;
+        }),
       constraints.end());
 
     // If we found any minimal sources, add them now, avoiding introducing any
@@ -6566,13 +6523,8 @@ namespace {
       }
     }
 
-    // If we only had concrete conformances, put one back.
-    if (constraints.empty() && remainingConcrete)
-      constraints.push_back(*remainingConcrete);
-
     assert((!constraints.empty() || allCanBeSelfDerived) &&
            "All constraints were self-derived!");
-    return anyDerivedViaConcrete;
   }
 } // end anonymous namespace
 
@@ -7135,9 +7087,7 @@ static void computeDerivedSameTypeComponents(
     // construction of self-derived sources really don't work, because we
     // discover more information later, so we need a more on-line or
     // iterative approach.
-    bool derivedViaConcrete;
-    if (concrete.source->isSelfDerivedSource(builder, subjectType,
-                                             derivedViaConcrete))
+    if (concrete.source->isSelfDerivedSource(builder, subjectType))
       continue;
 
     // If it has a better source than we'd seen before for this component,
@@ -7471,13 +7421,10 @@ void GenericSignatureBuilder::checkSameTypeConstraints(
   if (!equivClass->derivedSameTypeComponents.empty())
     return;
 
-  bool anyDerivedViaConcrete = false;
   // Remove self-derived constraints.
-  if (removeSelfDerived(*this, equivClass->sameTypeConstraints,
-                        /*proto=*/nullptr,
-                        /*dropDerivedViaConcrete=*/false,
-                        /*allCanBeSelfDerived=*/true))
-    anyDerivedViaConcrete = true;
+  removeSelfDerived(*this, equivClass->sameTypeConstraints,
+                    /*proto=*/nullptr,
+                    /*allCanBeSelfDerived=*/true);
 
   // Sort the constraints, so we get a deterministic ordering of diagnostics.
   llvm::array_pod_sort(equivClass->sameTypeConstraints.begin(),
@@ -7553,16 +7500,6 @@ void GenericSignatureBuilder::checkSameTypeConstraints(
     // Ignore inferred requirements; we don't want to diagnose them.
     intercomponentEdges.push_back(
       IntercomponentEdge(firstComponentIdx, secondComponentIdx, constraint));
-  }
-
-  // If there were any derived-via-concrete constraints, drop them now before
-  // we emit other diagnostics.
-  if (anyDerivedViaConcrete) {
-    // Remove derived-via-concrete constraints.
-    (void)removeSelfDerived(*this, equivClass->sameTypeConstraints,
-                            /*proto=*/nullptr,
-                            /*dropDerivedViaConcrete=*/true,
-                            /*allCanBeSelfDerived=*/true);
   }
 
   // Walk through each of the components, checking the intracomponent edges.
@@ -7762,7 +7699,6 @@ void GenericSignatureBuilder::checkConcreteTypeConstraints(
 
   removeSelfDerived(*this, equivClass->concreteTypeConstraints,
                     /*proto=*/nullptr,
-                    /*dropDerivedViaConcrete=*/true,
                     /*allCanBeSelfDerived=*/true);
 
   // This can occur if the combination of a superclass requirement and

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -6253,13 +6253,10 @@ GenericSignatureBuilder::finalize(TypeArrayView<GenericTypeParamType> genericPar
         }
 
         equivClass.recursiveSuperclassType = true;
-      } else {
-        checkSuperclassConstraints(genericParams, &equivClass);
       }
     }
 
     checkConformanceConstraints(genericParams, &equivClass);
-    checkLayoutConstraints(genericParams, &equivClass);
   };
 
   if (!Impl->ExplicitSameTypeRequirements.empty()) {
@@ -7797,22 +7794,6 @@ void GenericSignatureBuilder::checkConcreteTypeConstraints(
     diag::same_type_conflict,
     diag::redundant_same_type_to_concrete,
     diag::same_type_redundancy_here);
-}
-
-void GenericSignatureBuilder::checkSuperclassConstraints(
-                              TypeArrayView<GenericTypeParamType> genericParams,
-                              EquivalenceClass *equivClass) {
-  assert(equivClass->superclass && "No superclass constraint?");
-
-  removeSelfDerived(*this, equivClass->superclassConstraints, /*proto=*/nullptr);
-}
-
-void GenericSignatureBuilder::checkLayoutConstraints(
-                              TypeArrayView<GenericTypeParamType> genericParams,
-                              EquivalenceClass *equivClass) {
-  if (!equivClass->layout) return;
-
-  removeSelfDerived(*this, equivClass->layoutConstraints, /*proto=*/nullptr);
 }
 
 bool GenericSignatureBuilder::isRedundantExplicitRequirement(

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -5002,7 +5002,7 @@ GenericSignatureBuilder::addSameTypeRequirementBetweenTypeParameters(
       updateLayout(T1, equivClass2->layout);
       equivClass->layoutConstraints.insert(
                                    equivClass->layoutConstraints.end(),
-                                   equivClass2->layoutConstraints.begin() + 1,
+                                   equivClass2->layoutConstraints.begin(),
                                    equivClass2->layoutConstraints.end());
     }
   }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2374,6 +2374,13 @@ Type EquivalenceClass::getTypeInContext(GenericSignatureBuilder &builder,
 
 void EquivalenceClass::dump(llvm::raw_ostream &out,
                             GenericSignatureBuilder *builder) const {
+  auto dumpSource = [&](const RequirementSource *source) {
+    source->dump(out, &builder->getASTContext().SourceMgr, 4);
+    if (source->isDerivedRequirement())
+      out << " [derived]";
+    out << "\n";
+  };
+
   out << "Equivalence class represented by "
     << members.front()->getRepresentative()->getDebugName() << ":\n";
   out << "Members: ";
@@ -2387,10 +2394,7 @@ void EquivalenceClass::dump(llvm::raw_ostream &out,
   for (auto entry : conformsTo) {
     out << "  " << entry.first->getNameStr() << "\n";
     for (auto constraint : entry.second) {
-      constraint.source->dump(out, &builder->getASTContext().SourceMgr, 4);
-      if (constraint.source->isDerivedRequirement())
-        out << " [derived]";
-      out << "\n";
+      dumpSource(constraint.source);
     }
   }
 
@@ -2398,18 +2402,33 @@ void EquivalenceClass::dump(llvm::raw_ostream &out,
   for (auto constraint : sameTypeConstraints) {
     out << "  " << constraint.getSubjectDependentType({})
         << " == " << constraint.value << "\n";
-    constraint.source->dump(out, &builder->getASTContext().SourceMgr, 4);
-    if (constraint.source->isDerivedRequirement())
-      out << " [derived]";
-    out << "\n";
+      dumpSource(constraint.source);
   }
 
-  if (concreteType)
+  if (concreteType) {
     out << "Concrete type: " << concreteType.getString() << "\n";
-  if (superclass)
+    for (auto constraint : concreteTypeConstraints) {
+      out << "  " << constraint.getSubjectDependentType({})
+          << " == " << constraint.value << "\n";
+      dumpSource(constraint.source);
+    }
+  }
+  if (superclass) {
     out << "Superclass: " << superclass.getString() << "\n";
-  if (layout)
+    for (auto constraint : superclassConstraints) {
+      out << "  " << constraint.getSubjectDependentType({})
+          << " : " << constraint.value << "\n";
+      dumpSource(constraint.source);
+    }
+  }
+  if (layout) {
     out << "Layout: " << layout.getString() << "\n";
+    for (auto constraint : layoutConstraints) {
+      out << "  " << constraint.getSubjectDependentType({})
+          << " : " << constraint.value << "\n";
+      dumpSource(constraint.source);
+    }
+  }
 
   if (!delayedRequirements.empty()) {
     out << "Delayed requirements:\n";

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2822,14 +2822,24 @@ static void concretizeNestedTypeFromConcreteParent(
   assert(parentEquiv->conformsTo.count(proto) > 0 &&
          "No conformance requirement");
   const RequirementSource *parentConcreteSource = nullptr;
+
   for (const auto &constraint : parentEquiv->conformsTo.find(proto)->second) {
+    bool derivedViaConcrete = false;
+
+    auto *minimal = constraint.source->getMinimalConformanceSource(
+        builder, constraint.getSubjectDependentType({ }), proto,
+        derivedViaConcrete);
+
+    if (minimal == nullptr || derivedViaConcrete)
+      continue;
+
     if (!isSuperclassConstrained) {
-      if (constraint.source->kind == RequirementSource::Concrete) {
-        parentConcreteSource = constraint.source;
+      if (minimal->kind == RequirementSource::Concrete) {
+        parentConcreteSource = minimal;
       }
     } else {
-      if (constraint.source->kind == RequirementSource::Superclass) {
-        parentConcreteSource = constraint.source;
+      if (minimal->kind == RequirementSource::Superclass) {
+        parentConcreteSource = minimal;
       }
     }
   }
@@ -5669,16 +5679,24 @@ static void expandSameTypeConstraints(GenericSignatureBuilder &builder,
       bool alreadyFound = false;
       const RequirementSource *conformsSource = nullptr;
       for (const auto &constraint : conforms.second) {
-        if (constraint.source->getAffectedType()->isEqual(dependentType)) {
+        bool derivedViaConcrete = false;
+
+        auto *minimal = constraint.source->getMinimalConformanceSource(
+            builder, constraint.getSubjectDependentType({ }), proto,
+            derivedViaConcrete);
+
+        if (minimal == nullptr || derivedViaConcrete)
+          continue;
+
+        if (minimal->getAffectedType()->isEqual(dependentType)) {
           alreadyFound = true;
           break;
         }
 
         // Capture the source for later use, skipping
         if (!conformsSource &&
-            constraint.source->kind
-              != RequirementSource::RequirementSignatureSelf)
-          conformsSource = constraint.source;
+            minimal->kind != RequirementSource::RequirementSignatureSelf)
+          conformsSource = minimal;
       }
 
       if (alreadyFound) continue;
@@ -6255,9 +6273,7 @@ GenericSignatureBuilder::finalize(TypeArrayView<GenericTypeParamType> genericPar
         equivClass.recursiveSuperclassType = true;
       }
     }
-
-    checkConformanceConstraints(genericParams, &equivClass);
-  };
+  }
 
   if (!Impl->ExplicitSameTypeRequirements.empty()) {
     // FIXME: Expand all conformance requirements. This is expensive :(
@@ -6726,18 +6742,6 @@ static bool isRedundantlyInheritableObjCProtocol(
   auto &ctx = proto->getASTContext();
   inheritingProto->getAttrs().add(new (ctx) RestatedObjCConformanceAttr(proto));
   return true;
-}
-
-void GenericSignatureBuilder::checkConformanceConstraints(
-                          TypeArrayView<GenericTypeParamType> genericParams,
-                          EquivalenceClass *equivClass) {
-  for (auto &entry : equivClass->conformsTo) {
-    // Remove self-derived constraints.
-    assert(!entry.second.empty() && "No constraints to work with?");
-
-    // Remove any self-derived constraints.
-    removeSelfDerived(*this, entry.second, entry.first);
-  }
 }
 
 void GenericSignatureBuilder::diagnoseRedundantRequirements() const {

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -445,21 +445,6 @@ public:
       this->rhs = type->getCanonicalType();
   }
 
-  /// For a Constraint<T> with an explicit requirement source, we recover the
-  /// subject type from the requirement source and the right hand side from the
-  /// constraint.
-  ///
-  /// The requirement kind must be passed in since Constraint<T>'s kind is
-  /// implicit by virtue of which list it appears under inside its equivalence
-  /// class, and is not stored inside the constraint.
-  template<typename T>
-  static ExplicitRequirement fromExplicitConstraint(RequirementKind kind,
-                                                    Constraint<T> constraint) {
-    assert(!constraint.source->isDerivedNonRootRequirement());
-
-    return ExplicitRequirement(kind, constraint.source, constraint.value);
-  }
-
   static std::pair<RequirementKind, RequirementRHS>
   getKindAndRHS(const RequirementSource *source,
                 ASTContext &ctx) {
@@ -532,55 +517,16 @@ public:
       return std::make_pair(RequirementKind::Superclass, type);
     }
 
+    case RequirementSource::RequirementSignatureSelf:
+      return std::make_pair(RequirementKind::Conformance,
+                            source->getProtocolDecl());
+
     default: {
       source->dump(llvm::errs(), &ctx.SourceMgr, 0);
       llvm::errs() << "\n";
       llvm_unreachable("Unhandled source kind");
     }
     }
-  }
-
-  static ExplicitRequirement fromRequirementSource(const RequirementSource *source,
-                                                   ASTContext &ctx) {
-    auto *parent = source->parent;
-
-    RequirementKind kind;
-    RequirementRHS rhs;
-    std::tie(kind, rhs) = getKindAndRHS(source, ctx);
-
-    return ExplicitRequirement(kind, parent, rhs);
-  }
-
-  /// To recover the root explicit requirement from a Constraint<T>, we walk the
-  /// requirement source up the root, and look at both the root and the next
-  /// innermost child.
-  /// Together, these give us the subject type (via the root) and the right hand
-  /// side of the requirement (from the next innermost child).
-  ///
-  /// The requirement kind must be passed in since Constraint<T>'s kind is
-  /// implicit by virtue of which list it appears under inside its equivalence
-  /// class, and is not stored inside the constraint.
-  ///
-  /// The constraint's actual value is ignored; that's the right hand
-  /// side of the derived constraint, not the right hand side of the original
-  /// explicit requirement.
-  template<typename T>
-  static ExplicitRequirement fromDerivedConstraint(Constraint<T> constraint,
-                                                   ASTContext &ctx) {
-    assert(constraint.source->isDerivedNonRootRequirement());
-
-    const RequirementSource *root = constraint.source;
-    const RequirementSource *child = nullptr;
-
-    while (root->parent && root->isDerivedRequirement()) {
-      child = root;
-      root = root->parent;
-    }
-
-    assert(child != nullptr);
-    assert(root != nullptr);
-
-    return fromRequirementSource(child, ctx);
   }
 
   RequirementKind getKind() const {
@@ -661,7 +607,6 @@ template<> struct DenseMapInfo<swift::GenericSignatureBuilder::ExplicitRequireme
 
 namespace {
   struct ConflictingConcreteTypeRequirement {
-    ExplicitRequirement concreteTypeRequirement;
     ExplicitRequirement otherRequirement;
     Type resolvedConcreteType;
     RequirementRHS otherRHS;
@@ -5630,13 +5575,13 @@ namespace {
         bool thisIsNonRedundantExplicit =
             (!constraint.source->isDerivedNonRootRequirement() &&
              !builder.isRedundantExplicitRequirement(
-               ExplicitRequirement::fromExplicitConstraint(
-                 kind, constraint)));
+               ExplicitRequirement(
+                 kind, constraint.source, constraint.value)));
         bool representativeIsNonRedundantExplicit =
             (!representativeConstraint->source->isDerivedNonRootRequirement() &&
              !builder.isRedundantExplicitRequirement(
-               ExplicitRequirement::fromExplicitConstraint(
-                 kind, *representativeConstraint)));
+               ExplicitRequirement(
+                 kind, representativeConstraint->source, representativeConstraint->value)));
 
         if (thisIsNonRedundantExplicit != representativeIsNonRedundantExplicit) {
           if (thisIsNonRedundantExplicit)
@@ -5730,510 +5675,6 @@ static void expandSameTypeConstraints(GenericSignatureBuilder &builder,
   }
 }
 
-static bool compareSourceLocs(SourceManager &SM, SourceLoc lhsLoc, SourceLoc rhsLoc) {
-  if (lhsLoc.isValid() != rhsLoc.isValid())
-    return lhsLoc.isValid();
-
-  if (lhsLoc.isValid() && rhsLoc.isValid()) {
-    unsigned lhsBuffer = SM.findBufferContainingLoc(lhsLoc);
-    unsigned rhsBuffer = SM.findBufferContainingLoc(rhsLoc);
-
-    // If the buffers are the same, use source location ordering.
-    if (lhsBuffer == rhsBuffer) {
-      if (SM.isBeforeInBuffer(lhsLoc, rhsLoc))
-        return true;
-    } else {
-      // Otherwise, order by buffer identifier.
-      if (SM.getIdentifierForBuffer(lhsBuffer)
-               .compare(SM.getIdentifierForBuffer(lhsBuffer)))
-        return true;
-    }
-  }
-
-  return false;
-}
-
-/// A directed graph where the vertices are explicit requirement sources and
-/// an edge (v, w) records that the explicit source v implies the explicit
-/// source w.
-///
-/// The roots of the strongly connected component graph are the basic set of
-/// explicit requirements which imply everything else. We pick the best
-/// representative from each root strongly connected component to form the
-/// final set of non-redundant explicit requirements.
-class RedundantRequirementGraph {
-  /// 2**16 explicit requirements ought to be enough for everybody.
-  using VertexID = uint16_t;
-  using ComponentID = uint16_t;
-
-  struct Vertex {
-    ExplicitRequirement req;
-
-    explicit Vertex(ExplicitRequirement req) : req(req) {}
-
-    /// The SCC that this vertex belongs to.
-    ComponentID component = UndefinedComponent;
-
-    /// State for the SCC algorithm.
-    VertexID index = UndefinedIndex;
-    VertexID lowLink = -1;
-    bool onStack = false;
-
-    /// Outgoing edges.
-    SmallVector<VertexID, 1> successors;
-
-#ifndef NDEBUG
-    bool sawVertex = false;
-#endif
-
-    static const ComponentID UndefinedComponent = -1;
-    static const VertexID UndefinedIndex = -1;
-  };
-
-  /// Maps each requirement source to a unique 16-bit ID.
-  llvm::SmallDenseMap<ExplicitRequirement, VertexID, 2> reqs;
-
-  SmallVector<Vertex, 2> vertices;
-
-  ComponentID componentCount = 0;
-  VertexID vertexCount = 0;
-
-  SmallVector<VertexID, 2> stack;
-
-public:
-  template<typename T>
-  void handleConstraintsImpliedByConcrete(
-      RequirementKind kind,
-      const SmallVectorImpl<Constraint<T>> &impliedByConcrete,
-      const Optional<ExplicitRequirement> &concreteTypeRequirement) {
-    // This can occur if the combination of a superclass requirement and
-    // protocol conformance requirement force a type to become concrete.
-    if (!concreteTypeRequirement)
-      return;
-
-    for (auto constraint : impliedByConcrete) {
-      if (constraint.source->isDerivedNonRootRequirement())
-        continue;
-
-      auto req = ExplicitRequirement::fromExplicitConstraint(kind, constraint);
-      addEdge(*concreteTypeRequirement, req);
-    }
-  }
-
-  template<typename T>
-  Optional<ExplicitRequirement>
-  addConstraintsFromEquivClass(
-      RequirementKind kind,
-      const SmallVectorImpl<Constraint<T>> &exact,
-      const SmallVectorImpl<Constraint<T>> &lessSpecific,
-      ASTContext &ctx) {
-    // The set of 'redundant explicit requirements', which are known to be less
-    // specific than some other explicit requirements. An example is a type
-    // parameter with multiple superclass constraints:
-    //
-    // class A {}
-    // class B : A {}
-    // class C : B {}
-    //
-    // func f<T>(_: T) where T : A, T : B, T : C {}
-    //
-    // 'T : C' supercedes 'T : A' and 'T : B', because C is a subclass of
-    // 'A' and 'B'.
-    SmallVector<ExplicitRequirement, 1> redundantExplicitReqs;
-
-    // The set of all other explicit requirements, which are known to be the most
-    // specific. These imply the less specific 'redundant explicit sources'
-    // above.
-    //
-    // Also, if there is more than one most specific explicit requirements, they
-    // all imply each other.
-    SmallVector<ExplicitRequirement, 1> explicitReqs;
-
-    // The set of root explicit requirements for each derived requirements.
-    //
-    // These 'root requirements' imply the 'explicit requirements'.
-    SmallVector<ExplicitRequirement, 1> rootReqs;
-
-    for (auto constraint : exact) {
-      if (constraint.source->isDerivedNonRootRequirement()) {
-        auto req = ExplicitRequirement::fromDerivedConstraint(
-            constraint, ctx);
-
-        rootReqs.push_back(req);
-      } else {
-        auto req = ExplicitRequirement::fromExplicitConstraint(
-            kind, constraint);
-
-        VertexID v = addVertex(req);
-#ifndef NDEBUG
-        // Record that we saw an actual explicit requirement rooted at this vertex,
-        // for verification purposes.
-        vertices[v].sawVertex = true;
-#endif
-        (void) v;
-
-        explicitReqs.push_back(req);
-      }
-    }
-
-    for (auto constraint : lessSpecific) {
-      if (constraint.source->isDerivedNonRootRequirement())
-        continue;
-
-      auto req = ExplicitRequirement::fromExplicitConstraint(kind, constraint);
-
-      VertexID v = addVertex(req);
-#ifndef NDEBUG
-      // Record that we saw an actual explicit requirement rooted at this vertex,
-      // for verification purposes.
-      vertices[v].sawVertex = true;
-#endif
-      (void) v;
-
-      redundantExplicitReqs.push_back(req);
-    }
-
-    // Get the "best" explicit requirement that implies the rest.
-    Optional<ExplicitRequirement> result;
-    if (!rootReqs.empty())
-      result = rootReqs[0];
-    else if (!explicitReqs.empty())
-      result = explicitReqs[0];
-
-    // If all requirements are derived, there is nothing to do.
-    if (explicitReqs.empty()) {
-      if (!redundantExplicitReqs.empty()) {
-        assert(!rootReqs.empty());
-        for (auto rootReq : rootReqs) {
-          for (auto redundantReq : redundantExplicitReqs) {
-            addEdge(rootReq, redundantReq);
-          }
-        }
-      }
-      return result;
-    }
-
-    // If there are multiple most specific explicit requirements, they will form a cycle.
-    if (explicitReqs.size() > 1) {
-      for (unsigned index : indices(explicitReqs)) {
-        auto firstReq = explicitReqs[index];
-        auto secondReq = explicitReqs[(index + 1) % explicitReqs.size()];
-        addEdge(firstReq, secondReq);
-      }
-    }
-
-    // The cycle of most specific explicit requirements implies all less specific
-    // explicit requirements.
-    for (auto redundantReq : redundantExplicitReqs) {
-      addEdge(explicitReqs[0], redundantReq);
-    }
-
-    // The root explicit requirement of each derived requirement implies the cycle of
-    // most specific explicit requirements.
-    for (auto rootReq : rootReqs) {
-      addEdge(rootReq, explicitReqs[0]);
-    }
-
-    return result;
-  }
-
-private:
-  /// If we haven't seen this requirement yet, add it and
-  /// return a new ID. Otherwise, return an existing ID.
-  VertexID addVertex(ExplicitRequirement req) {
-    assert(!req.getSource()->isDerivedNonRootRequirement());
-
-    VertexID id = vertices.size();
-
-    // Check for wrap-around.
-    if (id != vertices.size()) {
-      llvm::errs() << "Too many explicit requirements";
-      abort();
-    }
-
-    assert(reqs.size() == vertices.size());
-
-    auto inserted = reqs.insert(std::make_pair(req, id));
-
-    // Check if we've already seen this vertex.
-    if (!inserted.second)
-      return inserted.first->second;
-
-    vertices.emplace_back(req);
-    return id;
-  }
-
-  /// Add a directed edge from one requirement to another.
-  /// If we haven't seen either requirement yet, we add a
-  /// new vertex; this allows visiting equivalence classes in
-  /// a single pass, without having to build the set of vertices
-  /// first.
-  void addEdge(ExplicitRequirement fromReq,
-               ExplicitRequirement toReq) {
-    assert(!fromReq.getSource()->isDerivedNonRootRequirement());
-    assert(!toReq.getSource()->isDerivedNonRootRequirement());
-
-    VertexID from = addVertex(fromReq);
-    VertexID to = addVertex(toReq);
-
-    vertices[from].successors.push_back(to);
-  }
-
-  /// Tarjan's algorithm.
-  void computeSCCs() {
-    for (VertexID v : indices(vertices)) {
-      if (vertices[v].index == Vertex::UndefinedIndex)
-        strongConnect(v);
-    }
-  }
-
-  void strongConnect(VertexID v) {
-    // Set the depth index for v to the smallest unused index.
-    assert(vertices[v].index == Vertex::UndefinedIndex);
-    vertices[v].index = vertexCount;
-    assert(vertices[v].lowLink == Vertex::UndefinedIndex);
-    vertices[v].lowLink = vertexCount;
-
-    vertexCount++;
-
-    stack.push_back(v);
-    assert(!vertices[v].onStack);
-    vertices[v].onStack = true;
-
-    // Consider successors of v.
-    for (VertexID w : vertices[v].successors) {
-      if (vertices[w].index == Vertex::UndefinedIndex) {
-        // Successor w has not yet been visited; recurse on it.
-        strongConnect(w);
-
-        assert(vertices[w].lowLink != Vertex::UndefinedIndex);
-        vertices[v].lowLink = std::min(vertices[v].lowLink,
-                                       vertices[w].lowLink);
-      } else if (vertices[w].onStack) {
-        // Successor w is in stack S and hence in the current SCC.
-        //
-        // If w is not on stack, then (v, w) is an edge pointing
-        // to an SCC already found and must be ignored.
-        assert(vertices[w].lowLink != Vertex::UndefinedIndex);
-        vertices[v].lowLink = std::min(vertices[v].lowLink,
-                                       vertices[w].index);
-      }
-    }
-
-    // If v is a root node, pop the stack and generate an SCC.
-    if (vertices[v].lowLink == vertices[v].index) {
-      VertexID w = Vertex::UndefinedIndex;
-
-      do {
-        w = stack.back();
-        assert(vertices[w].onStack);
-        stack.pop_back();
-
-        vertices[w].onStack = false;
-        assert(vertices[w].component == Vertex::UndefinedComponent);
-
-        vertices[w].component = componentCount;
-      } while (v != w);
-
-      componentCount++;
-    }
-  }
-
-public:
-  using RedundantRequirementMap =
-      llvm::DenseMap<ExplicitRequirement,
-                     llvm::SmallDenseSet<ExplicitRequirement, 2>>;
-
-  void computeRedundantRequirements(SourceManager &SM,
-                                    RedundantRequirementMap &redundant) {
-    // First, compute SCCs.
-    computeSCCs();
-
-    // The set of edges pointing to each connected component.
-    SmallVector<SmallVector<ComponentID, 2>, 2> inboundComponentEdges;
-    inboundComponentEdges.resize(componentCount);
-
-    // The set of edges originating from this connected component.
-    SmallVector<SmallVector<ComponentID, 2>, 2> outboundComponentEdges;
-    outboundComponentEdges.resize(componentCount);
-
-    // Visit all vertices and build the adjacency sets for the connected
-    // component graph.
-    for (const auto &vertex : vertices) {
-      assert(vertex.component != Vertex::UndefinedComponent);
-      for (auto successor : vertex.successors) {
-        ComponentID otherComponent = vertices[successor].component;
-        if (vertex.component != otherComponent) {
-          inboundComponentEdges[otherComponent].push_back(vertex.component);
-          outboundComponentEdges[vertex.component].push_back(otherComponent);
-        }
-      }
-    }
-
-    auto isRootComponent = [&](ComponentID component) -> bool {
-      return inboundComponentEdges[component].empty();
-    };
-
-    // The set of root components.
-    llvm::SmallDenseSet<ComponentID, 2> rootComponents;
-
-    // The best explicit requirement for each root component.
-    SmallVector<Optional<ExplicitRequirement>, 2> bestExplicitReq;
-    bestExplicitReq.resize(componentCount);
-
-    // Visit all vertices and find the best requirement for each root component.
-    for (const auto &vertex : vertices) {
-      if (isRootComponent(vertex.component)) {
-        rootComponents.insert(vertex.component);
-
-        // If this vertex is part of a root SCC, see if the requirement is
-        // better than the one we have so far.
-        auto &best = bestExplicitReq[vertex.component];
-        if (isBetterExplicitRequirement(SM, best, vertex.req))
-          best = vertex.req;
-      }
-    }
-
-    // The set of root components that each component is reachable from.
-    SmallVector<llvm::SmallDenseSet<ComponentID, 2>, 2> reachableFromRoot;
-    reachableFromRoot.resize(componentCount);
-
-    // Traverse the graph of connected components starting from the roots.
-    for (auto rootComponent : rootComponents) {
-      SmallVector<ComponentID, 2> worklist;
-
-      auto addToWorklist = [&](ComponentID nextComponent) {
-        if (!reachableFromRoot[nextComponent].count(rootComponent))
-          worklist.push_back(nextComponent);
-      };
-
-      addToWorklist(rootComponent);
-
-      while (!worklist.empty()) {
-        auto component = worklist.back();
-        worklist.pop_back();
-
-        reachableFromRoot[component].insert(rootComponent);
-
-        for (auto nextComponent : outboundComponentEdges[component])
-          addToWorklist(nextComponent);
-      }
-    }
-
-    // Compute the mapping of redundant requirements to the best root
-    // requirement that implies them.
-    for (const auto &vertex : vertices) {
-      if (isRootComponent(vertex.component)) {
-        // A root component is reachable from itself, and itself only.
-        assert(reachableFromRoot[vertex.component].size() == 1);
-        assert(reachableFromRoot[vertex.component].count(vertex.component) == 1);
-      } else {
-        assert(!bestExplicitReq[vertex.component].hasValue() &&
-               "Recorded best requirement for non-root SCC?");
-      }
-
-      // We have a non-root component. This requirement is always
-      // redundant.
-      auto reachableFromRootSet = reachableFromRoot[vertex.component];
-      assert(reachableFromRootSet.size() > 0);
-
-      for (auto rootComponent : reachableFromRootSet) {
-        assert(isRootComponent(rootComponent));
-
-        auto best = bestExplicitReq[rootComponent];
-        assert(best.hasValue() &&
-               "Did not record best requirement for root SCC?");
-
-        assert(vertex.req != *best || vertex.component == rootComponent);
-        if (vertex.req != *best) {
-          redundant[vertex.req].insert(*best);
-        }
-      }
-    }
-  }
-
-private:
-  bool isBetterExplicitRequirement(SourceManager &SM,
-                                   Optional<ExplicitRequirement> optExisting,
-                                   ExplicitRequirement current) {
-    if (!optExisting.hasValue())
-      return true;
-
-    auto existing = *optExisting;
-
-    auto *existingSource = existing.getSource();
-    auto *currentSource = current.getSource();
-
-    // Prefer explicit sources over inferred ones, so that you can
-    // write either of the following without a warning:
-    //
-    // func foo<T>(_: Set<T>) {}
-    // func foo<T : Hashable>(_: Set<T>) {}
-    bool existingInferred = existingSource->isInferredRequirement();
-    bool currentInferred = currentSource->isInferredRequirement();
-    if (existingInferred != currentInferred)
-      return currentInferred;
-
-    // Prefer a RequirementSignatureSelf over anything else.
-    if ((currentSource->kind == RequirementSource::RequirementSignatureSelf) ||
-        (existingSource->kind == RequirementSource::RequirementSignatureSelf))
-      return (currentSource->kind == RequirementSource::RequirementSignatureSelf);
-
-    // Prefer sources with a shorter type.
-    auto existingType = existingSource->getStoredType();
-    auto currentType = currentSource->getStoredType();
-    int cmpTypes = compareDependentTypes(currentType, existingType);
-    if (cmpTypes != 0)
-      return cmpTypes < 0;
-
-    auto existingLoc = existingSource->getLoc();
-    auto currentLoc = currentSource->getLoc();
-
-    return compareSourceLocs(SM, currentLoc, existingLoc);
-  }
-
-public:
-  void dump(llvm::raw_ostream &out, SourceManager *SM) const {
-    out << "* Vertices:\n";
-    for (const auto &vertex : vertices) {
-      out << "Component " << vertex.component << ", ";
-      vertex.req.dump(out, SM);
-      out << "\n";
-    }
-
-    out << "* Edges:\n";
-    for (const auto &from : vertices) {
-      for (VertexID w : from.successors) {
-        const auto &to = vertices[w];
-
-        from.req.dump(out, SM);
-        out << " -> ";
-        to.req.dump(out, SM);
-        out << "\n";
-      }
-    }
-  }
-
-#ifndef NDEBUG
-  void verifyAllVerticesWereSeen(SourceManager *SM) const {
-    for (const auto &vertex : vertices) {
-      if (!vertex.sawVertex) {
-        // We found a vertex that was referenced by an edge, but was
-        // never added explicitly. This means we have a derived
-        // requirement rooted at the source, but we never saw the
-        // corresponding explicit requirement. This should not happen.
-        llvm::errs() << "Found an orphaned vertex:\n";
-        vertex.req.dump(llvm::errs(), SM);
-        llvm::errs() << "\nRedundant requirement graph:\n";
-        dump(llvm::errs(), SM);
-        abort();
-      }
-    }
-  }
-#endif
-
-};
-
 void GenericSignatureBuilder::ExplicitRequirement::dump(
     llvm::raw_ostream &out, SourceManager *SM) const {
   switch (getKind()) {
@@ -6292,6 +5733,85 @@ static bool isConcreteConformance(const EquivalenceClass &equivClass,
   return false;
 }
 
+void GenericSignatureBuilder::getBaseRequirements(
+    GenericSignatureBuilder::GetKindAndRHS getKindAndRHS,
+    const RequirementSource *source,
+    const ProtocolDecl *requirementSignatureSelfProto,
+    ASTContext &ctx, SmallVectorImpl<ExplicitRequirement> &result) {
+  // If we're building a generic signature, the base requirement is
+  // built from the root of the path.
+  if (source->parent == nullptr) {
+    RequirementKind kind;
+    RequirementRHS rhs;
+    std::tie(kind, rhs) = getKindAndRHS();
+    result.push_back(ExplicitRequirement(kind, source, rhs));
+    return;
+  }
+
+  // If we're building a requirement signature, there can be multiple
+  // base requirements from the same protocol appearing along the path.
+  if (requirementSignatureSelfProto != nullptr &&
+      source->isProtocolRequirement() &&
+      source->getProtocolDecl() == requirementSignatureSelfProto) {
+    auto *shortSource = source->withoutRedundantSubpath(
+        *this, source->getRoot(), source->parent);
+    RequirementKind kind;
+    RequirementRHS rhs;
+    std::tie(kind, rhs) = getKindAndRHS();
+    result.push_back(ExplicitRequirement(kind, shortSource, rhs));
+  }
+
+  getBaseRequirements(
+      [&]() {
+        return ExplicitRequirement::getKindAndRHS(source, ctx);
+      },
+      source->parent, requirementSignatureSelfProto, ctx, result);
+}
+
+template<typename T, typename Filter>
+void GenericSignatureBuilder::checkRequirementRedundancy(
+    const ExplicitRequirement &req,
+    const std::vector<Constraint<T>> &constraints,
+    const ProtocolDecl *requirementSignatureSelfProto,
+    Filter filter) {
+  assert(!constraints.empty());
+
+  for (const auto &constraint : constraints) {
+    if (filter(constraint))
+      continue;
+
+    SmallVector<ExplicitRequirement, 2> result;
+    getBaseRequirements(
+        [&]() {
+          return std::make_pair(req.getKind(), constraint.value);
+        },
+        constraint.source, requirementSignatureSelfProto, Context, result);
+    assert(result.size() > 0);
+
+    bool anyWereRedundant =
+        llvm::any_of(result, [&](const ExplicitRequirement &otherReq) {
+          // Don't consider paths that are based on the requirement
+          // itself; such a path doesn't "prove" this requirement,
+          // since if we drop the requirement the path is no longer
+          // valid.
+          if (req == otherReq)
+            return true;
+
+          // Don't consider paths based on requirements that are already
+          // known to be redundant either, since those paths become
+          // invalid once redundant requirements are dropped.
+          return isRedundantExplicitRequirement(otherReq);
+        });
+
+    // If this requirement can be derived from a set of
+    // non-redundant base requirements, then this requirement
+    // is redundant.
+    if (!anyWereRedundant) {
+      Impl->RedundantRequirements[req].insert(result.front());
+    }
+  }
+}
+
 void GenericSignatureBuilder::computeRedundantRequirements(
     const ProtocolDecl *requirementSignatureSelfProto) {
   assert(!Impl->computedRedundantRequirements &&
@@ -6300,250 +5820,282 @@ void GenericSignatureBuilder::computeRedundantRequirements(
   Impl->computedRedundantRequirements = true;
 #endif
 
-  RedundantRequirementGraph graph;
+  // This sort preserves iteration order with the legacy algorithm.
+  SmallVector<ExplicitRequirement, 2> requirements(
+      Impl->ExplicitRequirements.begin(),
+      Impl->ExplicitRequirements.end());
+  std::stable_sort(requirements.begin(), requirements.end(),
+                   [](const ExplicitRequirement &req1,
+                      const ExplicitRequirement &req2) {
+                      if (req1.getSource()->isInferredRequirement() &&
+                          !req2.getSource()->isInferredRequirement())
+                        return true;
 
-  // Visit each equivalence class, recording all explicit requirement sources,
-  // and the root of each derived requirement source that implies an explicit
-  // source.
-  for (auto &equivClass : Impl->EquivalenceClasses) {
-    for (auto &entry : equivClass.conformsTo) {
-      SmallVector<Constraint<ProtocolDecl *>, 2> exact;
-      SmallVector<Constraint<ProtocolDecl *>, 2> lessSpecific;
+                      if (compareDependentTypes(req1.getSubjectType(),
+                                                req2.getSubjectType()) > 0)
+                        return true;
 
-      for (const auto &constraint : entry.second) {
-        auto *source = constraint.source;
+                      return false;
+                   });
 
-        // FIXME: Remove this check.
-        bool derivedViaConcrete = false;
-        if (source->getMinimalConformanceSource(
-            *this, constraint.getSubjectDependentType({ }), entry.first,
-            derivedViaConcrete)
-            != source)
-          continue;
+  for (const auto &req : requirements) {
+    auto subjectType = req.getSubjectType();
 
-        if (derivedViaConcrete)
-          continue;
-
-        // FIXME: Check for a conflict via the concrete type.
-        exact.push_back(constraint);
-
-        if (!source->isDerivedRequirement()) {
-          if (isConcreteConformance(equivClass, entry.first, *this)) {
-            Impl->ExplicitConformancesImpliedByConcrete.insert(
-                ExplicitRequirement::fromExplicitConstraint(
-                    RequirementKind::Conformance, constraint));
-          }
-        }
-      }
-
-      graph.addConstraintsFromEquivClass(RequirementKind::Conformance,
-                                         exact, lessSpecific, Context);
-    }
+    auto *equivClass = resolveEquivalenceClass(subjectType,
+                                         ArchetypeResolutionKind::AlreadyKnown);
+    assert(equivClass &&
+           "Explicit requirement names an unknown equivalence class?");
 
     Type resolvedConcreteType;
-    Optional<ExplicitRequirement> concreteTypeRequirement;
-
-    if (equivClass.concreteType) {
+    if (equivClass->concreteType) {
       resolvedConcreteType =
-        getCanonicalTypeInContext(equivClass.concreteType, { });
-
-      SmallVector<Constraint<Type>, 2> exact;
-      SmallVector<Constraint<Type>, 2> lessSpecific;
-
-      for (const auto &constraint : equivClass.concreteTypeConstraints) {
-        auto *source = constraint.source;
-        Type t = constraint.value;
-
-        // FIXME: Remove this check.
-        bool derivedViaConcrete = false;
-        if (source->getMinimalConformanceSource(
-            *this, constraint.getSubjectDependentType({ }), nullptr,
-            derivedViaConcrete)
-            != source)
-          continue;
-
-        if (derivedViaConcrete)
-          continue;
-
-        if (t->isEqual(resolvedConcreteType)) {
-          exact.push_back(constraint);
-          continue;
-        }
-
-        auto resolvedType = getCanonicalTypeInContext(t, { });
-        if (resolvedType->isEqual(resolvedConcreteType)) {
-          exact.push_back(constraint);
-        }
-
-        // Record the conflict.
-        if (!source->isDerivedRequirement()) {
-          auto req =
-              ExplicitRequirement::fromExplicitConstraint(
-                  RequirementKind::SameType, constraint);
-          Impl->ConflictingRequirements.insert(
-              std::make_pair(req, resolvedConcreteType));
-        }
-
-        lessSpecific.push_back(constraint);
-      }
-
-      concreteTypeRequirement =
-          graph.addConstraintsFromEquivClass(RequirementKind::SameType,
-                                             exact, lessSpecific, Context);
+          getCanonicalTypeInContext(equivClass->concreteType,
+                                    getGenericParams());
     }
 
     Type resolvedSuperclass;
-    Optional<ExplicitRequirement> superclassRequirement;
-
-    if (equivClass.superclass) {
-      // Resolve any thus-far-unresolved dependent types.
+    if (equivClass->superclass) {
       resolvedSuperclass =
-        getCanonicalTypeInContext(equivClass.superclass, getGenericParams());
-
-      SmallVector<Constraint<Type>, 2> exact;
-      SmallVector<Constraint<Type>, 2> lessSpecific;
-      SmallVector<Constraint<Type>, 2> impliedByConcrete;
-
-      for (const auto &constraint : equivClass.superclassConstraints) {
-        auto *source = constraint.source;
-        Type t = constraint.value;
-
-        // FIXME: Remove this check.
-        bool derivedViaConcrete = false;
-        if (source->getMinimalConformanceSource(
-            *this, constraint.getSubjectDependentType({ }), nullptr,
-            derivedViaConcrete)
-            != source)
-          continue;
-
-        if (derivedViaConcrete)
-          continue;
-
-        if (resolvedConcreteType) {
-          Type resolvedType = getCanonicalTypeInContext(t, { });
-          if (resolvedType->isExactSuperclassOf(resolvedConcreteType))
-            impliedByConcrete.push_back(constraint);
-        }
-
-        if (t->isEqual(resolvedSuperclass)) {
-          exact.push_back(constraint);
-          continue;
-        }
-
-        Type resolvedType = getCanonicalTypeInContext(t, { });
-        if (resolvedType->isEqual(resolvedSuperclass)) {
-          exact.push_back(constraint);
-          continue;
-        }
-
-        // Check for a conflict.
-        if (!source->isDerivedRequirement() &&
-            !resolvedType->isExactSuperclassOf(resolvedSuperclass)) {
-          auto req =
-              ExplicitRequirement::fromExplicitConstraint(
-                  RequirementKind::Superclass, constraint);
-          Impl->ConflictingRequirements.insert(
-              std::make_pair(req, resolvedSuperclass));
-        }
-
-        lessSpecific.push_back(constraint);
-      }
-
-      superclassRequirement =
-          graph.addConstraintsFromEquivClass(RequirementKind::Superclass,
-                                             exact, lessSpecific, Context);
-
-      graph.handleConstraintsImpliedByConcrete(RequirementKind::Superclass,
-                                               impliedByConcrete,
-                                               concreteTypeRequirement);
+          getCanonicalTypeInContext(equivClass->superclass,
+                                    getGenericParams());
     }
 
-    Optional<ExplicitRequirement> layoutRequirement;
+    switch (req.getKind()) {
+    case RequirementKind::Conformance: {
+      // TODO: conflicts with concrete
+      auto *proto = req.getRHS().get<ProtocolDecl *>();
 
-    if (equivClass.layout) {
-      SmallVector<Constraint<LayoutConstraint>, 2> exact;
-      SmallVector<Constraint<LayoutConstraint>, 2> lessSpecific;
-      SmallVector<Constraint<LayoutConstraint>, 2> impliedByConcrete;
+      auto found = equivClass->conformsTo.find(proto);
+      assert(found != equivClass->conformsTo.end());
 
-      for (const auto &constraint : equivClass.layoutConstraints) {
-        auto *source = constraint.source;
-        auto layout = constraint.value;
+      checkRequirementRedundancy(
+          req, found->second,
+          requirementSignatureSelfProto,
+          [&](const Constraint<ProtocolDecl *> &constraint) {
+            // FIXME: Remove this.
+            bool derivedViaConcrete;
+            auto minimalSource =
+              constraint.source->getMinimalConformanceSource(
+                  *this,
+                  constraint.getSubjectDependentType({ }),
+                  proto, derivedViaConcrete);
+            if (minimalSource != constraint.source)
+              return true;
 
-        // FIXME: Remove this check.
-        bool derivedViaConcrete = false;
-        if (source->getMinimalConformanceSource(
-            *this, constraint.getSubjectDependentType({ }), nullptr,
-            derivedViaConcrete)
-            != source)
-          continue;
+            if (derivedViaConcrete)
+              return true;
 
-        if (derivedViaConcrete)
-          continue;
+            return false;
+          });
+
+      if (isConcreteConformance(*equivClass, proto, *this))
+        Impl->ExplicitConformancesImpliedByConcrete.insert(req);
+
+      break;
+    }
+
+    case RequirementKind::Superclass: {
+      auto superclass = getCanonicalTypeInContext(
+          req.getRHS().get<Type>(), { });
+
+      if (!superclass->isExactSuperclassOf(resolvedSuperclass)) {
+        // Case 1. We have a requirement 'T : C', and we've
+        // previously resolved the superclass of 'T' to some
+        // class 'D' where 'C' is not a superclass of 'D'.
+        //
+        // This means 'T : C' conflicts with some other
+        // requirement that implies 'T : D'.
+        Impl->ConflictingRequirements[req] = resolvedSuperclass;
+
+        checkRequirementRedundancy(
+            req, equivClass->superclassConstraints,
+            requirementSignatureSelfProto,
+            [&](const Constraint<Type> &constraint) {
+              auto otherSuperclass = getCanonicalTypeInContext(
+                 constraint.value, { });
+              // Filter out requirements where the superclass
+              // is not equal to the resolved superclass.
+              if (!resolvedSuperclass->isEqual(otherSuperclass))
+               return true;
+
+              return false;
+            });
+      } else {
+        // Case 2. We have a requirement 'T : C', and we've
+        // previously resolved the superclass of 'T' to some
+        // class 'D' where 'C' is a superclass of 'D'.
+        //
+        // This means that 'T : C' is made redundant by any
+        // requirement that implies 'T : B', such that 'C' is a
+        // superclass of 'B'.
+        checkRequirementRedundancy(
+            req, equivClass->superclassConstraints,
+            requirementSignatureSelfProto,
+            [&](const Constraint<Type> &constraint) {
+              auto otherSuperclass = getCanonicalTypeInContext(
+                 constraint.value, { });
+              // Filter out requirements where the superclass is less
+              // specific than the original requirement.
+              if (!superclass->isExactSuperclassOf(otherSuperclass))
+               return true;
+
+              return false;
+            });
 
         if (resolvedConcreteType) {
-          if (typeImpliesLayoutConstraint(resolvedConcreteType, layout)) {
-            impliedByConcrete.push_back(constraint);
+          // We have a superclass requirement 'T : C' and a same-type
+          // requirement 'T == D'.
+          if (resolvedSuperclass->isExactSuperclassOf(resolvedConcreteType)) {
+            // 'C' is a superclass of 'D', so 'T : C' is redundant.
+            checkRequirementRedundancy(
+                req, equivClass->concreteTypeConstraints,
+                requirementSignatureSelfProto,
+                [&](const Constraint<Type> &constraint) {
+                  auto otherType = getCanonicalTypeInContext(
+                      constraint.value, { });
+                  if (!resolvedSuperclass->isExactSuperclassOf(otherType))
+                    return true;
 
-            if (!source->isDerivedRequirement()) {
-              Impl->ExplicitConformancesImpliedByConcrete.insert(
-                  ExplicitRequirement::fromExplicitConstraint(
-                      RequirementKind::Layout, constraint));
-            }
+                  return false;
+                });
+          } else {
+            // 'C' is not a superclass of 'D'; we have a conflict.
+            Impl->ConflictingConcreteTypeRequirements.push_back(
+                {req, resolvedConcreteType, resolvedSuperclass});
           }
         }
-
-        if (layout == equivClass.layout) {
-          exact.push_back(constraint);
-          continue;
-        }
-
-        // Check for a conflict.
-        if (!source->isDerivedRequirement() &&
-            !layout.merge(equivClass.layout)->isKnownLayout()) {
-          auto req =
-              ExplicitRequirement::fromExplicitConstraint(
-                  RequirementKind::Layout, constraint);
-          Impl->ConflictingRequirements.insert(
-              std::make_pair(req, equivClass.layout));
-        }
-
-        lessSpecific.push_back(constraint);
       }
 
-      layoutRequirement =
-          graph.addConstraintsFromEquivClass(RequirementKind::Layout,
-                                             exact, lessSpecific, Context);
-
-      graph.handleConstraintsImpliedByConcrete(RequirementKind::Layout,
-                                               impliedByConcrete,
-                                               concreteTypeRequirement);
+      break;
     }
 
-    if (resolvedConcreteType && resolvedSuperclass) {
-      if (!resolvedSuperclass->isExactSuperclassOf(resolvedConcreteType)) {
-        Impl->ConflictingConcreteTypeRequirements.push_back(
-            {*concreteTypeRequirement, *superclassRequirement,
-             resolvedConcreteType, resolvedSuperclass});
+    case RequirementKind::Layout: {
+      // TODO: less-specific constraints
+      // TODO: conflicts with other layout constraints
+      // TODO: conflicts with concrete and superclass
+      auto layout = req.getRHS().get<LayoutConstraint>();
+
+      if (!layout.merge(equivClass->layout)->isKnownLayout()) {
+        // Case 1. We have a requirement 'T : L1', and we've
+        // previously resolved the layout of 'T' to some
+        // layout constraint 'L2', where 'L1' and 'L2' are not
+        // mergeable.
+        //
+        // This means that 'T : L1' conflicts with some other
+        // requirement that implies 'T : L2'.
+        Impl->ConflictingRequirements[req] = equivClass->layout;
+
+        checkRequirementRedundancy(
+            req, equivClass->layoutConstraints,
+            requirementSignatureSelfProto,
+            [&](const Constraint<LayoutConstraint> &constraint) {
+              auto otherLayout = constraint.value;
+              // Filter out requirements where the layout is not
+              // equal to the resolved layout.
+              if (equivClass->layout != otherLayout)
+               return true;
+
+              return false;
+            });
+      } else if (layout == equivClass->layout) {
+        // Case 2. We have a requirement 'T : L1', and we know
+        // the most specific resolved layout for 'T' is also 'L1'.
+        //
+        // This means that 'T : L1' is made redundant by any
+        // requirement that implies 'T : L1'.
+        checkRequirementRedundancy(
+            req, equivClass->layoutConstraints,
+            requirementSignatureSelfProto,
+            [&](const Constraint<LayoutConstraint> &constraint) {
+              // Filter out requirements where the implied layout is
+              // not equal to the resolved layout.
+              auto otherLayout = constraint.value;
+              if (layout != otherLayout)
+                return true;
+
+              return false;
+            });
+
+        if (resolvedConcreteType) {
+          auto layout = req.getRHS().get<LayoutConstraint>();
+          if (typeImpliesLayoutConstraint(resolvedConcreteType,
+                                          layout)) {
+            Impl->ExplicitConformancesImpliedByConcrete.insert(req);
+
+            checkRequirementRedundancy(
+                req, equivClass->concreteTypeConstraints,
+                requirementSignatureSelfProto,
+                [&](const Constraint<Type> &constraint) {
+                  // Filter out requirements where the concrete type
+                  // does not have the resolved layout.
+                  auto otherType = getCanonicalTypeInContext(
+                      constraint.value, { });
+                  if (!typeImpliesLayoutConstraint(otherType, layout))
+                    return true;
+
+                  return false;
+                });
+          } else if (typeConflictsWithLayoutConstraint(resolvedConcreteType,
+                                                       layout)) {
+            // We have a concrete type requirement 'T == C' and 'C' does
+            // not satisfy 'L1'.
+            Impl->ConflictingConcreteTypeRequirements.push_back(
+                {req, resolvedConcreteType, equivClass->layout});
+          }
+        }
+      } else {
+        // Case 3. We have a requirement 'T : L1', and we know
+        // the most specific resolved layout for 'T' is some other
+        // layout 'L2', such that 'L2' is mergeable with 'L1'.
+        //
+        // This means that 'T : L1' is made redundant by any
+        // requirement that implies 'T : L3', where L3 is
+        // mergeable with L1.
+        checkRequirementRedundancy(
+            req, equivClass->layoutConstraints,
+            requirementSignatureSelfProto,
+            [&](const Constraint<LayoutConstraint> &constraint) {
+              auto otherLayout = constraint.value;
+              // Filter out requirements where the implied layout
+              // is not mergeable with the original requirement's
+              // layout.
+              if (!layout.merge(otherLayout)->isKnownLayout())
+                return true;
+
+              return false;
+            });
+
+        if (resolvedConcreteType) {
+          auto layout = req.getRHS().get<LayoutConstraint>();
+          if (typeImpliesLayoutConstraint(resolvedConcreteType, layout)) {
+            Impl->ExplicitConformancesImpliedByConcrete.insert(req);
+
+            checkRequirementRedundancy(
+                req, equivClass->concreteTypeConstraints,
+                requirementSignatureSelfProto,
+                [&](const Constraint<Type> &constraint) {
+                  // Filter out requirements where the concrete type
+                  // does not have the resolved layout.
+                  auto otherType = getCanonicalTypeInContext(
+                      constraint.value, { });
+
+                  if (!typeImpliesLayoutConstraint(otherType,
+                                                   equivClass->layout))
+                    return true;
+
+                  return false;
+                });
+          }
+        }
       }
-    } else if (resolvedConcreteType && equivClass.layout) {
-      if (typeConflictsWithLayoutConstraint(resolvedConcreteType,
-                                            equivClass.layout)) {
-        Impl->ConflictingConcreteTypeRequirements.push_back(
-            {*concreteTypeRequirement, *layoutRequirement,
-             resolvedConcreteType, equivClass.layout});
-      }
+
+      break;
+    }
+
+    case RequirementKind::SameType:
+      llvm_unreachable("Should not see same type requirements here");
     }
   }
-
-  auto &SM = getASTContext().SourceMgr;
-
-#ifndef NDEBUG
-  graph.verifyAllVerticesWereSeen(&SM);
-#endif
-
-  // Determine which explicit requirement sources are actually redundant.
-  assert(Impl->RedundantRequirements.empty());
-  graph.computeRedundantRequirements(SM, Impl->RedundantRequirements);
 }
 
 void
@@ -6555,7 +6107,7 @@ GenericSignatureBuilder::finalize(TypeArrayView<GenericTypeParamType> genericPar
 
   computeRedundantRequirements(requirementSignatureSelfProto);
   diagnoseRedundantRequirements();
-  diagnoseConflictingConcreteTypeRequirements();
+  diagnoseConflictingConcreteTypeRequirements(requirementSignatureSelfProto);
 
   assert(!Impl->finalized && "Already finalized builder");
 #ifndef NDEBUG
@@ -7332,15 +6884,40 @@ void GenericSignatureBuilder::diagnoseRedundantRequirements() const {
   }
 }
 
-void GenericSignatureBuilder::diagnoseConflictingConcreteTypeRequirements() const {
+void GenericSignatureBuilder::diagnoseConflictingConcreteTypeRequirements(
+    const ProtocolDecl *requirementSignatureSelfProto) {
   for (auto pair : Impl->ConflictingConcreteTypeRequirements) {
-    SourceLoc loc = pair.concreteTypeRequirement.getSource()->getLoc();
+    auto subjectType = pair.otherRequirement.getSubjectType();
+
+    auto *equivClass = resolveEquivalenceClass(subjectType,
+                                         ArchetypeResolutionKind::AlreadyKnown);
+    assert(equivClass &&
+           "Explicit requirement names an unknown equivalence class?");
+
+    auto foundConcreteRequirement = llvm::find_if(
+        equivClass->concreteTypeConstraints,
+        [&](const Constraint<Type> &constraint) {
+          SmallVector<ExplicitRequirement, 2> result;
+          getBaseRequirements(
+              [&]() {
+                return std::make_pair(RequirementKind::SameType, constraint.value);
+              },
+              constraint.source, requirementSignatureSelfProto, Context, result);
+
+        return
+            !llvm::any_of(result, [&](const ExplicitRequirement &otherReq) {
+              return isRedundantExplicitRequirement(otherReq);
+            });
+        });
+
+    assert(foundConcreteRequirement != equivClass->concreteTypeConstraints.end());
+
+    SourceLoc loc = foundConcreteRequirement->source->getLoc();
     SourceLoc otherLoc = pair.otherRequirement.getSource()->getLoc();
 
     if (loc.isInvalid() && otherLoc.isInvalid())
       continue;
 
-    auto subjectType = pair.concreteTypeRequirement.getSubjectType();
     SourceLoc subjectLoc = (loc.isInvalid() ? otherLoc : loc);
 
     Impl->HadAnyError = true;

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -8147,7 +8147,31 @@ GenericSignature GenericSignatureBuilder::rebuildSignatureWithoutRedundantRequir
   for (auto param : getGenericParams())
     newBuilder.addGenericParameter(param);
 
-  auto newSource = FloatingRequirementSource::forAbstract();
+  const RequirementSource *requirementSignatureSource = nullptr;
+  if (auto *proto = const_cast<ProtocolDecl *>(requirementSignatureSelfProto)) {
+    auto selfType = proto->getSelfInterfaceType();
+    requirementSignatureSource =
+        RequirementSource::forRequirementSignature(newBuilder, selfType, proto);
+
+    // Add the conformance requirement 'Self : Proto' directly without going
+    // through addConformanceRequirement(), since the latter calls
+    // expandConformanceRequirement(), which we want to skip since we're
+    // re-adding the requirements directly below.
+    auto resolvedType = ResolvedType(newBuilder.Impl->PotentialArchetypes[0]);
+    auto equivClass = resolvedType.getEquivalenceClass(newBuilder);
+
+    (void) equivClass->recordConformanceConstraint(newBuilder, resolvedType, proto,
+                                                   requirementSignatureSource);
+  }
+
+  auto newSource = [&]() {
+    if (auto *proto = const_cast<ProtocolDecl *>(requirementSignatureSelfProto)) {
+      return FloatingRequirementSource::viaProtocolRequirement(
+          requirementSignatureSource, proto, /*inferred=*/false);
+    }
+
+    return FloatingRequirementSource::forAbstract();
+  }();
 
   for (const auto &req : Impl->ExplicitRequirements) {
     assert(req.getKind() != RequirementKind::SameType &&
@@ -8236,9 +8260,6 @@ GenericSignature GenericSignatureBuilder::computeGenericSignature(
            requirementSignatureSelfProto);
 
   if (rebuildingWithoutRedundantConformances) {
-    assert(requirementSignatureSelfProto == nullptr &&
-           "Rebuilding a requirement signature?");
-
     assert(!Impl->HadAnyError &&
            "Rebuilt signature had errors");
 
@@ -8260,7 +8281,6 @@ GenericSignature GenericSignatureBuilder::computeGenericSignature(
   //
   // Also, don't do this when building a requirement signature.
   if (!rebuildingWithoutRedundantConformances &&
-      requirementSignatureSelfProto == nullptr &&
       !Impl->HadAnyError &&
       !Impl->ExplicitConformancesImpliedByConcrete.empty()) {
     return std::move(*this).rebuildSignatureWithoutRedundantRequirements(

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -929,7 +929,7 @@ RequirementSignatureRequest::evaluate(Evaluator &evaluator,
     proto->getSelfInterfaceType()->castTo<GenericTypeParamType>();
   auto requirement =
     Requirement(RequirementKind::Conformance, selfType,
-              proto->getDeclaredInterfaceType());
+                proto->getDeclaredInterfaceType());
 
   builder.addRequirement(
           requirement,
@@ -939,7 +939,7 @@ RequirementSignatureRequest::evaluate(Evaluator &evaluator,
 
   auto reqSignature = std::move(builder).computeGenericSignature(
                         /*allowConcreteGenericParams=*/false,
-                        /*buildingRequirementSignature=*/true);
+                        /*requirementSignatureSelfProto=*/proto);
   return reqSignature->getRequirements();
 }
 

--- a/test/Generics/concrete_same_type_versus_anyobject.swift
+++ b/test/Generics/concrete_same_type_versus_anyobject.swift
@@ -30,3 +30,13 @@ extension G2 where U == C, U : AnyObject {}
 extension G2 where U : C, U : AnyObject {}
 // expected-warning@-1 {{redundant constraint 'U' : 'AnyObject'}}
 // expected-note@-2 {{constraint 'U' : 'AnyObject' implied here}}
+
+// Explicit AnyObject conformance vs derived same-type
+protocol P {
+  associatedtype A where A == C
+}
+
+// CHECK-LABEL: Generic signature: <T where T : P>
+func explicitAnyObjectIsRedundant<T : P>(_: T) where T.A : AnyObject {}
+// expected-warning@-1 {{redundant constraint 'T.A' : 'AnyObject'}}
+// expected-note@-2 {{constraint 'T.A' : 'AnyObject' implied here}}

--- a/test/Generics/derived_via_concrete.swift
+++ b/test/Generics/derived_via_concrete.swift
@@ -1,0 +1,67 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -debug-generic-signatures -typecheck %s 2>&1 | %FileCheck %s
+
+protocol P {}
+class C {}
+
+class X<T : P> : U {}
+class Y<T : C> : V {}
+class Z<T : AnyObject> : W {}
+
+protocol U {
+  associatedtype T : P
+}
+
+protocol V {
+  associatedtype T : C
+}
+
+protocol W {
+  associatedtype T : AnyObject
+}
+
+// CHECK: Generic signature: <A, B where A : X<B>, B : P>
+func derivedViaConcreteX1<A, B>(_: A, _: B)
+  where A : U, A : X<B> {}
+// expected-warning@-1 {{redundant conformance constraint 'A' : 'U'}}
+// expected-note@-2 {{conformance constraint 'A' : 'U' implied here}}
+
+// FIXME: We should not diagnose 'B : P' as redundant, even though it
+// really is, because it was made redundant by an inferred requirement.
+
+// CHECK: Generic signature: <A, B where A : X<B>, B : P>
+func derivedViaConcreteX2<A, B>(_: A, _: B)
+  where A : U, B : P, A : X<B> {}
+// expected-warning@-1 {{redundant conformance constraint 'A' : 'U'}}
+// expected-note@-2 {{conformance constraint 'A' : 'U' implied here}}
+// expected-warning@-3 {{redundant conformance constraint 'B' : 'P'}}
+// expected-note@-4 {{conformance constraint 'B' : 'P' implied here}}
+
+// CHECK: Generic signature: <A, B where A : Y<B>, B : C>
+func derivedViaConcreteY1<A, B>(_: A, _: B)
+  where A : V, A : Y<B> {}
+// expected-warning@-1 {{redundant conformance constraint 'A' : 'V'}}
+// expected-note@-2 {{conformance constraint 'A' : 'V' implied here}}
+
+// FIXME: We should not diagnose 'B : C' as redundant, even though it
+// really is, because it was made redundant by an inferred requirement.
+
+// CHECK: Generic signature: <A, B where A : Y<B>, B : C>
+func derivedViaConcreteY2<A, B>(_: A, _: B)
+  where A : V, B : C, A : Y<B> {}
+// expected-warning@-1 {{redundant conformance constraint 'A' : 'V'}}
+// expected-note@-2 {{conformance constraint 'A' : 'V' implied here}}
+// expected-warning@-3 {{redundant superclass constraint 'B' : 'C'}}
+// expected-note@-4 {{superclass constraint 'B' : 'C' implied here}}
+
+// CHECK: Generic signature: <A, B where A : Z<B>, B : AnyObject>
+func derivedViaConcreteZ1<A, B>(_: A, _: B)
+  where A : W, A : Z<B> {}
+// expected-warning@-1 {{redundant conformance constraint 'A' : 'W'}}
+// expected-note@-2 {{conformance constraint 'A' : 'W' implied here}}
+
+// CHECK: Generic signature: <A, B where A : Z<B>, B : AnyObject>
+func derivedViaConcreteZ2<A, B>(_: A, _: B)
+  where A : W, B : AnyObject, A : Z<B> {}
+// expected-warning@-1 {{redundant conformance constraint 'A' : 'W'}}
+// expected-note@-2 {{conformance constraint 'A' : 'W' implied here}}

--- a/test/Generics/derived_via_concrete.swift
+++ b/test/Generics/derived_via_concrete.swift
@@ -60,8 +60,14 @@ func derivedViaConcreteZ1<A, B>(_: A, _: B)
 // expected-warning@-1 {{redundant conformance constraint 'A' : 'W'}}
 // expected-note@-2 {{conformance constraint 'A' : 'W' implied here}}
 
+// FIXME: We should not diagnose 'B : AnyObject' as redundant, even
+// though it really is, because it was made redundant by an inferred
+// requirement.
+
 // CHECK: Generic signature: <A, B where A : Z<B>, B : AnyObject>
 func derivedViaConcreteZ2<A, B>(_: A, _: B)
   where A : W, B : AnyObject, A : Z<B> {}
 // expected-warning@-1 {{redundant conformance constraint 'A' : 'W'}}
 // expected-note@-2 {{conformance constraint 'A' : 'W' implied here}}
+// expected-warning@-3 {{redundant constraint 'B' : 'AnyObject'}}
+// expected-note@-4 {{constraint 'B' : 'AnyObject' implied here}}

--- a/test/Generics/rdar62903491.swift
+++ b/test/Generics/rdar62903491.swift
@@ -5,7 +5,7 @@ protocol P {
   associatedtype X : P
 }
 
-// Anything that mentions 'T : P' minimizes to 'U : P'.
+// Anything that mentions 'T : P' and 'U : P' minimizes to 'U : P'.
 
 // expected-warning@+2 {{redundant conformance constraint 'U' : 'P'}}
 // expected-note@+1 {{conformance constraint 'U' : 'P' implied here}}
@@ -31,6 +31,8 @@ func oneProtocol4<T, U>(_: T, _: U) where U : P, T.X == U, T : P, U.X == T {}
 // CHECK-LABEL: oneProtocol4
 // CHECK: Generic signature: <T, U where T : P, T == U.X, U == T.X>
 
+// Anything that only mentions 'T : P' minimizes to 'T : P'.
+
 func oneProtocol5<T, U>(_: T, _: U) where T : P, T.X == U, U.X == T {}
 // CHECK-LABEL: oneProtocol5
 // CHECK: Generic signature: <T, U where T : P, T == U.X, U == T.X>
@@ -39,14 +41,12 @@ func oneProtocol6<T, U>(_: T, _: U) where T.X == U, U.X == T, T : P {}
 // CHECK-LABEL: oneProtocol6
 // CHECK: Generic signature: <T, U where T : P, T == U.X, U == T.X>
 
-// Anything that mentions 'U : P' but not 'T : P' minimizes to 'U : P'.
+// Anything that only mentions 'U : P' minimizes to 'U : P'.
 
-// FIXME: Need to emit warning here too
 func oneProtocol7<T, U>(_: T, _: U) where U : P, T.X == U, U.X == T {}
 // CHECK-LABEL: oneProtocol7
 // CHECK: Generic signature: <T, U where T == U.X, U : P, U == T.X>
 
-// FIXME: Need to emit warning here too
 func oneProtocol8<T, U>(_: T, _: U) where T.X == U, U.X == T, U : P {}
 // CHECK-LABEL: oneProtocol8
 // CHECK: Generic signature: <T, U where T == U.X, U : P, U == T.X>

--- a/test/Generics/rdar75656022.swift
+++ b/test/Generics/rdar75656022.swift
@@ -48,9 +48,9 @@ struct OriginalExampleWithWarning<A, B> where A : P2, B : P2, A.T == B.T {
   init<C, D, E>(_: C)
     where C : P1,
           D : P1, // expected-warning {{redundant conformance constraint 'D' : 'P1'}}
-          C.T : P1, // expected-warning {{redundant conformance constraint 'C.T' : 'P1'}}
-          A == S1<C, C.T.T, S2<C.T>>, // expected-note {{conformance constraint 'D' : 'P1' implied here}}
           // expected-note@-1 {{conformance constraint 'C.T' : 'P1' implied here}}
+          C.T : P1, // expected-warning {{redundant conformance constraint 'C.T' : 'P1'}}
+          A == S1<C, C.T.T, S2<C.T>>,
           C.T == D,
           E == D.T { }
 }
@@ -72,7 +72,6 @@ struct WithoutBogusGenericParametersWithWarning<A, B> where A : P2, B : P2, A.T 
     where C : P1,
           C.T : P1, // expected-warning {{redundant conformance constraint 'C.T' : 'P1'}}
           A == S1<C, C.T.T, S2<C.T>> {}
-          // expected-note@-1 {{conformance constraint 'C.T' : 'P1' implied here}}
 }
 
 // Same as above but without unnecessary generic parameters

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -354,20 +354,22 @@ protocol P26 {
   associatedtype C: X3
 }
 
-struct X26<T: X3> : P26 { // expected-note {{requirement specified as 'T' : 'X3' [with T = Self.B]}}
+struct X26<T: X3> : P26 {
   typealias C = T
 }
 
 // CHECK-LABEL: .P27a@
-// CHECK-NEXT: Requirement signature: <Self where Self.A == X26<Self.B>>
-// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X26<τ_0_0.B>>
+// CHECK-NEXT: Requirement signature: <Self where Self.A == X26<Self.B>, Self.B : X3>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X26<τ_0_0.B>, τ_0_0.B : X3>
 protocol P27a {
   associatedtype A: P26 // expected-warning{{redundant conformance constraint 'Self.A' : 'P26'}}
   // expected-note@-1 {{superclass constraint 'Self.B' : 'X3' implied here}}
 
   associatedtype B: X3 where A == X26<B> // expected-note{{conformance constraint 'Self.A' : 'P26' implied here}}
   // expected-warning@-1 {{redundant superclass constraint 'Self.B' : 'X3'}}
-  // expected-error@-2 {{'X26' requires that 'Self.B' inherit from 'X3'}}
+
+  // FIXME: The above warning should not be emitted -- while the requirement
+  // really is redundant, it is made redundant by an inferred requirement.
 }
 
 // CHECK-LABEL: .P27b@

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -328,7 +328,9 @@ struct X24<T: P20> : P24 {
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X24<τ_0_0.B>, τ_0_0.B : P20>
 protocol P25a {
   associatedtype A: P24 // expected-warning{{redundant conformance constraint 'Self.A' : 'P24'}}
+  // expected-note@-1 {{conformance constraint 'Self.B' : 'P20' implied here}}
   associatedtype B: P20 where A == X24<B> // expected-note{{conformance constraint 'Self.A' : 'P24' implied here}}
+  // expected-warning@-1 {{redundant conformance constraint 'Self.B' : 'P20'}}
 }
 
 // CHECK-LABEL: .P25b@

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -354,16 +354,20 @@ protocol P26 {
   associatedtype C: X3
 }
 
-struct X26<T: X3> : P26 {
+struct X26<T: X3> : P26 { // expected-note {{requirement specified as 'T' : 'X3' [with T = Self.B]}}
   typealias C = T
 }
 
 // CHECK-LABEL: .P27a@
-// CHECK-NEXT: Requirement signature: <Self where Self.A == X26<Self.B>, Self.B : X3>
-// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X26<τ_0_0.B>, τ_0_0.B : X3>
+// CHECK-NEXT: Requirement signature: <Self where Self.A == X26<Self.B>>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X26<τ_0_0.B>>
 protocol P27a {
   associatedtype A: P26 // expected-warning{{redundant conformance constraint 'Self.A' : 'P26'}}
+  // expected-note@-1 {{superclass constraint 'Self.B' : 'X3' implied here}}
+
   associatedtype B: X3 where A == X26<B> // expected-note{{conformance constraint 'Self.A' : 'P26' implied here}}
+  // expected-warning@-1 {{redundant superclass constraint 'Self.B' : 'X3'}}
+  // expected-error@-2 {{'X26' requires that 'Self.B' inherit from 'X3'}}
 }
 
 // CHECK-LABEL: .P27b@

--- a/test/Generics/sr12531.swift
+++ b/test/Generics/sr12531.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol AnyPropertyProtocol {
+    associatedtype Root = Any
+    associatedtype Value = Any
+    associatedtype KP: AnyKeyPath
+    var key: KP { get }
+    var value: Value { get }
+}
+
+protocol PartialPropertyProtocol: AnyPropertyProtocol
+where KP: PartialKeyPath<Root> {
+}
+
+protocol PropertyProtocol: PartialPropertyProtocol
+where KP: WritableKeyPath<Root, Value> {
+}
+
+extension Dictionary where Value: AnyPropertyProtocol {
+    subscript<R, V, P>(key: Key, path: WritableKeyPath<R, V>) -> P? where P: PropertyProtocol, P.Root == R, P.Value == V {
+        return self[key] as? P
+    }
+}

--- a/test/Generics/sr14510.swift
+++ b/test/Generics/sr14510.swift
@@ -1,0 +1,35 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -debug-generic-signatures -typecheck %s 2>&1 | %FileCheck %s
+
+// CHECK-LABEL: Requirement signature: <Self where Self == Self.Dual.Dual, Self.Dual : Adjoint>
+public protocol Adjoint {
+  associatedtype Dual: Adjoint where Self.Dual.Dual == Self
+}
+
+// CHECK-LABEL: Requirement signature: <Self>
+public protocol Diffable {
+  associatedtype Patch
+}
+
+// CHECK-LABEL: Requirement signature: <Self where Self : Adjoint, Self : Diffable, Self.Dual : AdjointDiffable, Self.Patch : Adjoint, Self.Dual.Patch == Self.Patch.Dual>
+public protocol AdjointDiffable: Adjoint & Diffable
+where Self.Patch: Adjoint, Self.Dual: AdjointDiffable,
+      Self.Patch.Dual == Self.Dual.Patch {
+}
+
+// This is another example used to hit the same problem. Any one of the three
+// conformance requirements 'A : P', 'B : P' or 'C : P' can be dropped and
+// proven from the other two, but dropping two or more conformance requirements
+// leaves us with an invalid signature.
+//
+// Note that this minimization is still not quite correct; the requirement
+// 'Self.B.C == Self.A.A.A' is unnecessary.
+
+// CHECK-LABEL: Requirement signature: <Self where Self.A : P, Self.A == Self.B.C, Self.B : P, Self.B == Self.A.C, Self.C == Self.A.B, Self.B.C == Self.A.A.A>
+protocol P {
+  associatedtype A : P where A == B.C
+  associatedtype B : P where B == A.C
+  // expected-note@-1 {{conformance constraint 'Self.C' : 'P' implied here}}
+  associatedtype C : P where C == A.B
+  // expected-warning@-1 {{redundant conformance constraint 'Self.C' : 'P'}}
+}


### PR DESCRIPTION
This rewrites the existing redundant requirements algorithm to be simpler, and fix an incorrect behavior in the case where
we're building a protocol requirement signature.

Consider the following example:

    protocol P {
      associatedtype A : P
      associatedtype B : P where A.B == B
    }

The requirement B : P has two conformance paths here:

    (B : P)
    (A : P)(B : P)

The naive redundancy algorithm would conclude that (B : P) is redundant because it can be derived as (A : P)(B : P). However, if we drop (B : P), we lose the derived conformance path as well, since it involves the same requirement (B : P).

The above example actually worked before this change, because we handled this case in getMinimalConformanceSource() by dropping any derived conformance paths that involve the requirement itself appearing in the "middle" of the path.

However, this is insufficient because you can have a "cycle" here with length more than 1. For example,

    protocol P {
      associatedtype A : P where A == B.C
      associatedtype B : P where B == A.C
      associatedtype C : P where C == A.B
    }

The requirement A : P has two conformance paths here:

    (A : P)
    (B : P)(C : P)

Similarly, B : P has these two paths:

    (B : P)
    (A : P)(C : P)

And C : P has these two paths:

    (C : P)
    (A : P)(B : P)

Since each one of A : P, B : P and C : P has a derived conformance path that does not involve itself, we would conclude that all three were redundant. But this was wrong; while (B : P)(C : P) is a valid derived path for A : P that allows us to drop A : P, once we commit to dropping A : P, we can no longer use the other derived paths (A : P)(C : P) for B : P, and (A : P)(B : P) for C : P, respectively, because they involve A : P, which we dropped.

The problem is that we were losing information here. The explicit requirement A : P can be derived as (B : P)(C : P), but we would just say that it was implied by B : P alone.

For non-protocol generic signatures, just looking at the root is still sufficient.

However, when building a requirement signature of a self-recursive protocol, instead of looking at the root explicit requirement only, we need to look at _all_ intermediate steps in the path that involve the same protocol.

This is implemented in a new getBaseRequirements() method, which generalizes the operation of getting the explicit requirement at the root of a derived conformance path by returning a vector of one or more explicit requirements that appear in the path.

Also the new algorithm computes redundancy online instead of building a directed graph and then computing SCCs. This is possible by recording newly-discovered redundant requirements immediately, and then using the set of so-far-redundant requirements when evaluating a path.

Fixes https://bugs.swift.org/browse/SR-14510 / rdar://problem/76883924.