### PR TITLE
[sil-optimizer] Fix feedback from #37016 and finish removing confusing constructors

### DIFF
--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -48,11 +48,6 @@ template <class T> class NullablePtr;
 /// that in a loop this property should predict well since you have a single
 /// branch that is going to go the same way everytime.
 class InstModCallbacks {
-  /// A function that takes in an instruction and deletes the inst.
-  ///
-  /// Default implementation is instToDelete->eraseFromParent();
-  std::function<void(SILInstruction *instToDelete)> deleteInstFunc;
-
   /// A function that is called to notify that a new function was created.
   ///
   /// Default implementation is a no-op, but we still mark madeChange.
@@ -66,8 +61,37 @@ class InstModCallbacks {
   /// iterators.
   std::function<void(Operand *use, SILValue newValue)> setUseValueFunc;
 
+  /// A function that takes in an instruction and deletes the inst.
+  ///
+  /// Default implementation is instToDelete->eraseFromParent();
+  ///
+  /// NOTE: The reason why we have deleteInstFunc and notifyWillBeDeletedFunc is
+  /// InstModCallback supports 2 stage deletion where a callee passed
+  /// InstModCallback is allowed to drop all references to the instruction
+  /// before calling deleteInstFunc. In contrast, notifyWillBeDeletedFunc
+  /// assumes that the IR is in a good form before being called so that the
+  /// caller can via the callback gather state about the instruction that will
+  /// be deleted. As an example, see InstructionDeleter::deleteInstruction() in
+  /// InstOptUtils.cpp.
+  std::function<void(SILInstruction *instToDelete)> deleteInstFunc;
+
   /// If non-null, called before an instruction is deleted or has its references
-  /// dropped.
+  /// dropped. If null, no-op.
+  ///
+  /// NOTE: The reason why we have deleteInstFunc and notifyWillBeDeletedFunc is
+  /// InstModCallback supports 2 stage deletion where a callee passed
+  /// InstModCallback is allowed to drop all references to the instruction
+  /// before calling deleteInstFunc. In contrast, notifyWillBeDeletedFunc
+  /// assumes that the IR is in a good form before being called so that the
+  /// caller can via the callback gather state about the instruction that will
+  /// be deleted. As an example, see InstructionDeleter::deleteInstruction() in
+  /// InstOptUtils.cpp.
+  ///
+  /// NOTE: This is called in InstModCallback::deleteInst() if one does not use
+  /// a default bool argument to disable the notification. In general that
+  /// should only be done when one is writing custom handling and is performing
+  /// the notification ones self. It is assumed that the notification will be
+  /// called with a valid instruction.
   std::function<void(SILInstruction *instThatWillBeDeleted)>
       notifyWillBeDeletedFunc;
 
@@ -80,18 +104,18 @@ public:
 
   InstModCallbacks(decltype(deleteInstFunc) deleteInstFunc,
                    decltype(createdNewInstFunc) createdNewInstFunc)
-      : deleteInstFunc(deleteInstFunc), createdNewInstFunc(createdNewInstFunc) {
+      : createdNewInstFunc(createdNewInstFunc), deleteInstFunc(deleteInstFunc) {
   }
 
   InstModCallbacks(decltype(deleteInstFunc) deleteInstFunc,
                    decltype(setUseValueFunc) setUseValueFunc)
-      : deleteInstFunc(deleteInstFunc), setUseValueFunc(setUseValueFunc) {}
+      : setUseValueFunc(setUseValueFunc), deleteInstFunc(deleteInstFunc) {}
 
   InstModCallbacks(decltype(deleteInstFunc) deleteInstFunc,
                    decltype(createdNewInstFunc) createdNewInstFunc,
                    decltype(setUseValueFunc) setUseValueFunc)
-      : deleteInstFunc(deleteInstFunc), createdNewInstFunc(createdNewInstFunc),
-        setUseValueFunc(setUseValueFunc) {}
+      : createdNewInstFunc(createdNewInstFunc),
+        setUseValueFunc(setUseValueFunc), deleteInstFunc(deleteInstFunc) {}
 
   InstModCallbacks() = default;
   ~InstModCallbacks() = default;

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -99,28 +99,9 @@ class InstModCallbacks {
   bool wereAnyCallbacksInvoked = false;
 
 public:
-  InstModCallbacks(decltype(deleteInstFunc) deleteInstFunc)
-      : deleteInstFunc(deleteInstFunc) {}
-
-  InstModCallbacks(decltype(deleteInstFunc) deleteInstFunc,
-                   decltype(createdNewInstFunc) createdNewInstFunc)
-      : createdNewInstFunc(createdNewInstFunc), deleteInstFunc(deleteInstFunc) {
-  }
-
-  InstModCallbacks(decltype(deleteInstFunc) deleteInstFunc,
-                   decltype(setUseValueFunc) setUseValueFunc)
-      : setUseValueFunc(setUseValueFunc), deleteInstFunc(deleteInstFunc) {}
-
-  InstModCallbacks(decltype(deleteInstFunc) deleteInstFunc,
-                   decltype(createdNewInstFunc) createdNewInstFunc,
-                   decltype(setUseValueFunc) setUseValueFunc)
-      : createdNewInstFunc(createdNewInstFunc),
-        setUseValueFunc(setUseValueFunc), deleteInstFunc(deleteInstFunc) {}
-
   InstModCallbacks() = default;
   ~InstModCallbacks() = default;
   InstModCallbacks(const InstModCallbacks &) = default;
-  InstModCallbacks(InstModCallbacks &&) = default;
 
   /// Return a copy of self with deleteInstFunc set to \p newDeleteInstFunc.
   InstModCallbacks onDelete(decltype(deleteInstFunc) newDeleteInstFunc) const {

--- a/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
@@ -527,7 +527,7 @@ static bool stripOwnership(SILFunction &func) {
     auto value = visitor.instructionsToSimplify.pop_back_val();
     if (!value.hasValue())
       continue;
-    InstModCallbacks callbacks([&](SILInstruction *instToErase) {
+    auto callbacks = InstModCallbacks().onDelete([&](SILInstruction *instToErase) {
       visitor.eraseInstruction(instToErase);
     });
     // We are no longer in OSSA, so we don't need to pass in a deBlocks.

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
@@ -52,9 +52,10 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
   explicit SemanticARCOptVisitor(SILFunction &fn, DeadEndBlocks &deBlocks,
                                  bool onlyMandatoryOpts)
       : ctx(fn, deBlocks, onlyMandatoryOpts,
-            InstModCallbacks(
-                [this](SILInstruction *inst) { eraseInstruction(inst); },
-                [this](Operand *use, SILValue newValue) {
+            InstModCallbacks()
+                .onDelete(
+                    [this](SILInstruction *inst) { eraseInstruction(inst); })
+                .onSetUseValue([this](Operand *use, SILValue newValue) {
                   use->set(newValue);
                   worklist.insert(newValue);
                 })) {}

--- a/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
+++ b/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
@@ -783,7 +783,7 @@ void TempRValueOptPass::run() {
     }
   }
 
-  InstModCallbacks callbacks(
+  auto callbacks = InstModCallbacks().onDelete(
     [](SILInstruction *instToKill) {
       // SimplifyInstruction is not in the business of removing
       // copy_addr. If it were, then we would need to update deadCopies.


### PR DESCRIPTION
The first commit is addressing Andy's feedback/request in #37016. The 2nd change eliminates the constructors from InstModCallback. I am worried that people are going to mix up which closure is passed in for which argument. The value type based .onACTION() model at least puts a name on the closure being initialized which is clearer.