### PR TITLE
[AST] Remove a call to mapOutOfContext in ASTPrinter

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -756,12 +756,6 @@ class PrintAST : public ASTVisitor<PrintAST> {
 
   void printTransformedTypeWithOptions(Type T, PrintOptions options) {
     if (CurrentType && Current && CurrentType->mayHaveMembers()) {
-      if (T->hasArchetype()) {
-        // Get the interface type, since TypeLocs still have
-        // contextual types in them.
-        T = T->mapTypeOutOfContext();
-      }
-
       auto *M = Current->getDeclContext()->getParentModule();
       SubstitutionMap subMap;
 


### PR DESCRIPTION
As suggested by @slavapestov [here](https://github.com/apple/swift/pull/36989#discussion_r620685379), it appears that the call is not necessary anymore.
