### PR TITLE
Reenable test/Concurrency/Runtime/executor_deinit1.swift on iOS simulator.

### DIFF
--- a/test/Concurrency/Runtime/executor_deinit1.swift
+++ b/test/Concurrency/Runtime/executor_deinit1.swift
@@ -8,8 +8,6 @@
 
 // https://bugs.swift.org/browse/SR-14461
 // UNSUPPORTED: linux
-// rdar://76611676
-// UNSUPPORTED: CPU=x86_64 && OS=ios
 
 
 // doesn't matter that it's bool identity function or not


### PR DESCRIPTION
The failure no longer reproduces. rdar://76611676