### PR TITLE
[5.4][CSBindings] Adjust type variable viability condition

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -577,8 +577,10 @@ ConstraintSystem::determineBestBindings() {
 
     return bindings || !bindings.Defaults.empty() ||
            llvm::any_of(bindings.Protocols, [&](Constraint *constraint) {
-             return bool(
-                 TypeChecker::getDefaultType(constraint->getProtocol(), DC));
+             return constraint->getKind() ==
+                        ConstraintKind::LiteralConformsTo &&
+                    bool(TypeChecker::getDefaultType(constraint->getProtocol(),
+                                                     DC));
            });
   };
 

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -858,3 +858,15 @@ func rdar56212087() {
 
   setValue(foo("", ""), forKey: "") // Ok (T is inferred as a `String` instead of `Any?`)
 }
+
+// rdar://77233864 - Ternary operator fails to deduce non-default literal type in SwiftUI preview
+func test_ternary_operator_with_regular_conformance_to_literal_protocol() {
+  // Note that in this case `ExpressibleByIntegerLiteral` is a non-literal requirement
+  func test<T: ExpressibleByIntegerLiteral>(_: T) -> T {
+    fatalError()
+  }
+
+  func bug(_: Float?) {}
+
+  bug(true ? test(0) : test(42)) // Ok - type is `CGFloat` for 0 and 42
+}


### PR DESCRIPTION
- Explanation:

Fixes an issue where valid code might fail due to incorrect inference.

To be viable to be attempted next type variable should have
at least one of the following:

- a direct binding (from relational constraint);
- a default (from `Defaultable` constraint);
- a literal protocol conformance with a default type
  described by `LiteralConformsTo` constraint;

Third condition was under-defined in 5.4 since it would consider
_all_ protocol requirements, but that discounts the fact that
only literal conformances could be binding sources, which leads
to problems where type variables with incomplete set of bindings
could be picked to be attempted.

- Scope: Expressions with ternary operator that has literals on both sides passed as an argument to a generic function with conformance requirements to literal protocol(s).

- Resolves: rdar://78035555

- Risk: Very Low

- Reviewed By: @hborla 

- Testing: Regression tests added to the suite

Resolves: rdar://78035555

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
