### PR TITLE
[5.5][Property Wrappers] Fix a diagnostic crash when a parameter has a wrapped value mismatch.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6355,10 +6355,12 @@ Type ParamDecl::getVarargBaseTy(Type VarArgT) {
 
 AnyFunctionType::Param ParamDecl::toFunctionParam(Type type) const {
   if (!type) {
+    type = getInterfaceType();
+
     if (hasExternalPropertyWrapper()) {
-      type = getPropertyWrapperBackingPropertyType();
-    } else {
-      type = getInterfaceType();
+      if (auto wrapper = getPropertyWrapperBackingPropertyType()) {
+        type = wrapper;
+      }
     }
   }
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3026,10 +3026,12 @@ void TypeChecker::checkParameterList(ParameterList *params,
       (void) param->getPropertyWrapperInitializerInfo();
 
     auto *SF = param->getDeclContext()->getParentSourceFile();
-    param->visitAuxiliaryDecls([&](VarDecl *auxiliaryDecl) {
-      if (!isa<ParamDecl>(auxiliaryDecl))
-        DeclChecker(param->getASTContext(), SF).visitBoundVariable(auxiliaryDecl);
-    });
+    if (!param->isInvalid()) {
+      param->visitAuxiliaryDecls([&](VarDecl *auxiliaryDecl) {
+        if (!isa<ParamDecl>(auxiliaryDecl))
+          DeclChecker(param->getASTContext(), SF).visitBoundVariable(auxiliaryDecl);
+      });
+    }
   }
 
   // For source compatibilty, allow duplicate internal parameter names

--- a/test/Sema/property_wrapper_parameter_invalid.swift
+++ b/test/Sema/property_wrapper_parameter_invalid.swift
@@ -187,3 +187,15 @@ func testMissingWrapperType() {
     return
   }
 }
+
+@propertyWrapper
+struct OptionalWrapper<Value> { // expected-note {{'Value' declared as parameter to type 'OptionalWrapper'}}
+  var wrappedValue: Value?
+  var projectedValue: Self { self }
+  init(wrappedValue: Value?) { self.wrappedValue = wrappedValue }
+  init(projectedValue: Self) { self = projectedValue }
+}
+
+// expected-error@+2 {{generic parameter 'Value' could not be inferred}} expected-note@+2 {{}}
+// expected-error@+1 {{property type 'Int' does not match 'wrappedValue' type 'Value?'}}
+func testWrappedValueMismatch(@OptionalWrapper value: Int) {}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/37093

---
If there's an error in property wrapper application, the backing property wrapper type request will return a null type, which would cause the compiler to crash when the property wrapper is applied to a parameter because most error recovery code expects `ErrorType`. If the wrapper application has an error, use the interface type of the parameter instead.

Resolves: [SR-14305](https://bugs.swift.org/browse/SR-14305)
