### PR TITLE
[5.5][Refactoring] Support refactoring to async if callback is `@convention(block)`

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -5012,6 +5012,22 @@ private:
     }
   }
 
+  /// From the given expression \p E, which is an argument to a function call,
+  /// extract the passed closure if there is one. Otherwise return \c nullptr.
+  ClosureExpr *extractCallback(Expr *E) {
+    if (auto Closure = dyn_cast<ClosureExpr>(E)) {
+      return Closure;
+    } else if (auto CaptureList = dyn_cast<CaptureListExpr>(E)) {
+      return CaptureList->getClosureBody();
+    } else if (auto FunctionConversion = dyn_cast<FunctionConversionExpr>(E)) {
+      // Closure arguments marked as e.g. `@convention(block)` produce arguments
+      // that are `FunctionConversionExpr`.
+      return extractCallback(FunctionConversion->getSubExpr());
+    } else {
+      return nullptr;
+    }
+  }
+
   void addAsyncAlternativeCall(const CallExpr *CE,
                                const AsyncHandlerDesc &HandlerDesc) {
     auto ArgList = callArgs(CE);
@@ -5020,11 +5036,7 @@ private:
       return;
     }
 
-    auto Callback = dyn_cast<ClosureExpr>(ArgList.ref()[HandlerDesc.Index]);
-    auto Capture = dyn_cast<CaptureListExpr>(ArgList.ref()[HandlerDesc.Index]);
-    if (Capture) {
-      Callback = Capture->getClosureBody();
-    }
+    ClosureExpr *Callback = extractCallback(ArgList.ref()[HandlerDesc.Index]);
     if (!Callback) {
       DiagEngine.diagnose(CE->getStartLoc(), diag::missing_callback_arg);
       return;

--- a/test/refactoring/ConvertAsync/basic.swift
+++ b/test/refactoring/ConvertAsync/basic.swift
@@ -176,10 +176,18 @@ func alreadyThrows(completion: (String) -> Void) throws { }
 // RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
 func noParamAutoclosure(completion: @autoclosure () -> Void) { }
 
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix BLOCK-CONVENTION %s
+func blockConvention(completion: @convention(block) () -> Void) { }
+// BLOCK-CONVENTION: func blockConvention() async { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix C-CONVENTION %s
+func cConvention(completion: @convention(c) () -> Void) { }
+// C-CONVENTION: func cConvention() async { }
+
 // 2. Check that the various ways to call a function (and the positions the
 //    refactoring is called from) are handled correctly
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefixes=CONVERT-FUNC,CALL,CALL-NOLABEL,CALL-WRAPPED,TRAILING,TRAILING-PARENS,TRAILING-WRAPPED,CALL-ARG,MANY-CALL,MEMBER-CALL,MEMBER-CALL2,MEMBER-PARENS,EMPTY-CAPTURE,CAPTURE,DEFAULT-ARGS-MISSING,DEFAULT-ARGS-CALL %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefixes=CONVERT-FUNC,CALL,CALL-NOLABEL,CALL-WRAPPED,TRAILING,TRAILING-PARENS,TRAILING-WRAPPED,CALL-ARG,MANY-CALL,MEMBER-CALL,MEMBER-CALL2,MEMBER-PARENS,EMPTY-CAPTURE,CAPTURE,DEFAULT-ARGS-MISSING,DEFAULT-ARGS-CALL,BLOCK-CONVENTION-CALL,C-CONVENTION-CALL %s
 func testCalls() {
 // CONVERT-FUNC: {{^}}func testCalls() async {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+4):3 | %FileCheck -check-prefix=CALL %s
@@ -320,5 +328,19 @@ func testCalls() {
   }
   // DEFAULT-ARGS-CALL: let str = await defaultArgs(a: 1, b: 2){{$}}
   // DEFAULT-ARGS-CALL-NEXT: {{^}}print("defaultArgs")
+
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=BLOCK-CONVENTION-CALL %s
+  blockConvention {
+    print("blockConvention")
+  }
+  // BLOCK-CONVENTION-CALL: await blockConvention(){{$}}
+  // BLOCK-CONVENTION-CALL-NEXT: {{^}}print("blockConvention")
+
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=C-CONVENTION-CALL %s
+  cConvention {
+    print("cConvention")
+  }
+  // C-CONVENTION-CALL: await cConvention(){{$}}
+  // C-CONVENTION-CALL-NEXT: {{^}}print("cConvention")
 }
 // CONVERT-FUNC: {{^}}}


### PR DESCRIPTION
Cherry-picks https://github.com/apple/swift/pull/37071.

----------------------

We already have special logic to extrac the closure for closures with capture lists, add the same kind of logic for closures that are marked `@convention(block)` etc.

Resolves rdar://75301524 [SR-14328]