### PR TITLE
[Serialization] Store offset of decls in .swiftsourceinfo

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -73,6 +73,7 @@ namespace swift {
   class DerivativeAttr;
   class DifferentiableAttr;
   class ExtensionDecl;
+  struct ExternalSourceLocs;
   class ForeignRepresentationInfo;
   class FuncDecl;
   class GenericContext;
@@ -1184,6 +1185,10 @@ public:
 
 private:
   friend Decl;
+
+  Optional<ExternalSourceLocs *> getExternalSourceLocs(const Decl *D);
+  void setExternalSourceLocs(const Decl *D, ExternalSourceLocs *Locs);
+
   Optional<std::pair<RawComment, bool>> getRawComment(const Decl *D);
   void setRawComment(const Decl *D, RawComment RC, bool FromSerialized);
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -62,6 +62,7 @@ namespace swift {
   class DynamicSelfType;
   class Type;
   class Expr;
+  struct ExternalSourceLocs;
   class CaptureListExpr;
   class DeclRefExpr;
   class ForeignAsyncConvention;
@@ -688,14 +689,12 @@ private:
   void operator=(const Decl&) = delete;
   SourceLoc getLocFromSource() const;
 
-  struct CachedExternalSourceLocs {
-    SourceLoc Loc;
-    SourceLoc StartLoc;
-    SourceLoc EndLoc;
-    SmallVector<CharSourceRange, 4> DocRanges;
-  };
-  mutable CachedExternalSourceLocs const *CachedSerializedLocs = nullptr;
-  const CachedExternalSourceLocs *getSerializedLocs() const;
+  /// Returns the serialized locations of this declaration from the
+  /// corresponding .swiftsourceinfo file. "Empty" (ie. \c BufferID of 0, an
+  /// invalid \c Loc, and empty \c DocRanges) if either there is no
+  /// .swiftsourceinfo or the buffer could not be created, eg. if the file
+  /// no longer exists.
+  const ExternalSourceLocs *getSerializedLocs() const;
 
   /// Directly set the invalid bit
   void setInvalidBit();

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -164,7 +164,8 @@ public:
     return None;
   }
 
-  virtual Optional<BasicDeclLocs> getBasicLocsForDecl(const Decl *D) const {
+  virtual Optional<ExternalSourceLocs::RawLocs>
+  getExternalRawLocsForDecl(const Decl *D) const {
     return None;
   }
 

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -399,7 +399,8 @@ public:
 
   Identifier getDiscriminatorForPrivateValue(const ValueDecl *D) const override;
   Identifier getPrivateDiscriminator() const { return PrivateDiscriminator; }
-  Optional<BasicDeclLocs> getBasicLocsForDecl(const Decl *D) const override;
+  Optional<ExternalSourceLocs::RawLocs>
+  getExternalRawLocsForDecl(const Decl *D) const override;
 
   /// Returns the synthesized file for this source file, if it exists.
   SynthesizedFileUnit *getSynthesizedFile() const { return SynthesizedFile; };

--- a/include/swift/Basic/BasicSourceInfo.h
+++ b/include/swift/Basic/BasicSourceInfo.h
@@ -15,6 +15,7 @@
 
 #include "swift/Basic/Fingerprint.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/SourceLoc.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/Support/Chrono.h"
 
@@ -22,18 +23,34 @@ namespace swift {
 
 class SourceFile;
 
-struct SourcePosition {
-  uint32_t Line = 0;
-  uint32_t Column = 0;
-  bool isValid() const { return Line && Column; }
-};
+struct ExternalSourceLocs {
+  struct LocationDirective {
+    uint32_t Offset = 0;
+    int32_t LineOffset = 0;
+    uint32_t Length = 0;
+    StringRef Name;
 
-struct BasicDeclLocs {
-  StringRef SourceFilePath;
-  SmallVector<std::pair<SourcePosition, uint32_t>, 4> DocRanges;
-  SourcePosition Loc;
-  SourcePosition StartLoc;
-  SourcePosition EndLoc;
+    bool isValid() const { return Length > 0; }
+  };
+
+  struct RawLoc {
+    uint32_t Offset = 0;
+    uint32_t Line = 0;
+    uint32_t Column = 0;
+    LocationDirective Directive;
+  };
+
+  struct RawLocs {
+    StringRef SourceFilePath;
+    SmallVector<std::pair<RawLoc, uint32_t>, 4> DocRanges;
+    RawLoc Loc;
+    RawLoc StartLoc;
+    RawLoc EndLoc;
+  };
+
+  unsigned BufferID = 0;
+  SourceLoc Loc;
+  SmallVector<CharSourceRange, 4> DocRanges;
 };
 
 class BasicSourceFileInfo {

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -24,6 +24,18 @@ namespace swift {
 
 /// This class manages and owns source buffers.
 class SourceManager {
+public:
+  /// A \c #sourceLocation-defined virtual file region, representing the source
+  /// source after a \c #sourceLocation (or between two). It provides a
+  /// filename and line offset to be applied to \c SourceLoc's within its
+  /// \c Range.
+  struct VirtualFile {
+    CharSourceRange Range;
+    std::string Name;
+    int LineOffset;
+  };
+
+private:
   llvm::SourceMgr LLVMSourceMgr;
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem;
   unsigned CodeCompletionBufferID = 0U;
@@ -52,12 +64,6 @@ class SourceManager {
   };
   ReplacedRangeType ReplacedRange;
 
-  // \c #sourceLocation directive handling.
-  struct VirtualFile {
-    CharSourceRange Range;
-    std::string Name;
-    int LineOffset;
-  };
   std::map<const char *, VirtualFile> VirtualFiles;
   mutable std::pair<const char *, const VirtualFile*> CachedVFile = {nullptr, nullptr};
 
@@ -142,6 +148,10 @@ public:
 
   /// Adds a memory buffer to the SourceManager, taking ownership of it.
   unsigned addNewSourceBuffer(std::unique_ptr<llvm::MemoryBuffer> Buffer);
+
+  /// Add a \c #sourceLocation-defined virtual file region of \p Length.
+  void createVirtualFile(SourceLoc Loc, StringRef Name, int LineOffset,
+                         unsigned Length);
 
   /// Add a \c #sourceLocation-defined virtual file region.
   ///
@@ -275,18 +285,17 @@ public:
 
   std::string getLineString(unsigned BufferID, unsigned LineNumber);
 
-  SourceLoc getLocFromExternalSource(StringRef Path, unsigned Line, unsigned Col);
-private:
-  const VirtualFile *getVirtualFile(SourceLoc Loc) const;
-  unsigned getExternalSourceBufferId(StringRef Path);
-  int getLineOffset(SourceLoc Loc) const {
-    if (auto VFile = getVirtualFile(Loc))
-      return VFile->LineOffset;
-    else
-      return 0;
-  }
+  /// Retrieve the buffer ID for \p Path, loading if necessary.
+  unsigned getExternalSourceBufferID(StringRef Path);
 
-public:
+  SourceLoc getLocFromExternalSource(StringRef Path, unsigned Line, unsigned Col);
+
+  /// Retrieve the virtual file for the given \p Loc, or nullptr if none exists.
+  const VirtualFile *getVirtualFile(SourceLoc Loc) const;
+
+  /// Whether or not \p Loc is after a \c #sourceLocation directive, ie. its
+  /// file, line, and column should be reported using the information in the
+  /// directive.
   bool isLocInVirtualFile(SourceLoc Loc) const {
     return getVirtualFile(Loc) != nullptr;
   }
@@ -295,6 +304,14 @@ public:
   /// owned by \p otherManager. Returns an invalid SourceLoc if it cannot be
   /// translated.
   SourceLoc getLocForForeignLoc(SourceLoc otherLoc, SourceManager &otherMgr);
+
+private:
+  int getLineOffset(SourceLoc Loc) const {
+    if (auto VFile = getVirtualFile(Loc))
+      return VFile->LineOffset;
+    else
+      return 0;
+  }
 };
 
 } // end namespace swift

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -392,7 +392,8 @@ public:
 
   Optional<StringRef> getGroupNameByUSR(StringRef USR) const override;
 
-  Optional<BasicDeclLocs> getBasicLocsForDecl(const Decl *D) const override;
+  Optional<ExternalSourceLocs::RawLocs>
+  getExternalRawLocsForDecl(const Decl *D) const override;
 
   void collectAllGroups(SmallVectorImpl<StringRef> &Names) const override;
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -610,36 +610,50 @@ case DeclKind::ID: return cast<ID##Decl>(this)->getLocFromSource();
   llvm_unreachable("Unknown decl kind");
 }
 
-const Decl::CachedExternalSourceLocs *Decl::getSerializedLocs() const {
-  if (CachedSerializedLocs) {
-    return CachedSerializedLocs;
-  }
+const ExternalSourceLocs *Decl::getSerializedLocs() const {
+  auto &Context = getASTContext();
+  if (auto EL = Context.getExternalSourceLocs(this).getValueOr(nullptr))
+    return EL;
+
+  static ExternalSourceLocs NullLocs{};
+
   auto *File = cast<FileUnit>(getDeclContext()->getModuleScopeContext());
-  assert(File->getKind() == FileUnitKind::SerializedAST &&
-         "getSerializedLocs() should only be called on decls in "
-         "a 'SerializedASTFile'");
-  auto Locs = File->getBasicLocsForDecl(this);
-  if (!Locs.hasValue()) {
-    static const Decl::CachedExternalSourceLocs NullLocs{};
+  if (File->getKind() != FileUnitKind::SerializedAST)
+    return &NullLocs;
+
+  auto RawLocs = File->getExternalRawLocsForDecl(this);
+  if (!RawLocs.hasValue()) {
+    // Don't read .swiftsourceinfo again on failure
+    Context.setExternalSourceLocs(this, &NullLocs);
     return &NullLocs;
   }
-  auto *Result = getASTContext().Allocate<Decl::CachedExternalSourceLocs>();
-  auto &SM = getASTContext().SourceMgr;
-#define CASE(X)                                                               \
-Result->X = SM.getLocFromExternalSource(Locs->SourceFilePath, Locs->X.Line,   \
-                                       Locs->X.Column);
-  CASE(Loc)
-  CASE(StartLoc)
-  CASE(EndLoc)
-#undef CASE
 
-  for (const auto &LineColumnAndLength : Locs->DocRanges) {
-    auto Start = SM.getLocFromExternalSource(Locs->SourceFilePath,
-      LineColumnAndLength.first.Line,
-      LineColumnAndLength.first.Column);
-    Result->DocRanges.push_back({ Start, LineColumnAndLength.second });
+  auto &SM = getASTContext().SourceMgr;
+  unsigned BufferID = SM.getExternalSourceBufferID(RawLocs->SourceFilePath);
+  if (!BufferID) {
+    // Don't try open the file again on failure
+    Context.setExternalSourceLocs(this, &NullLocs);
+    return &NullLocs;
   }
 
+  auto ResolveLoc = [&](const ExternalSourceLocs::RawLoc &Raw) -> SourceLoc {
+    // If the decl had a presumed loc, create its virtual file so that
+    // getPresumedLineAndColForLoc works from serialized locations as well.
+    if (Raw.Directive.isValid()) {
+      auto &LD = Raw.Directive;
+      SourceLoc Loc = SM.getLocForOffset(BufferID, LD.Offset);
+      SM.createVirtualFile(Loc, LD.Name, LD.LineOffset, LD.Length);
+    }
+    return SM.getLocForOffset(BufferID, Raw.Offset);
+  };
+
+  auto *Result = getASTContext().Allocate<ExternalSourceLocs>();
+  Result->BufferID = BufferID;
+  Result->Loc = ResolveLoc(RawLocs->Loc);
+  for (auto &Range : RawLocs->DocRanges) {
+    Result->DocRanges.emplace_back(ResolveLoc(Range.first), Range.second);
+  }
+  Context.setExternalSourceLocs(this, Result);
   return Result;
 }
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -864,37 +864,50 @@ TypeDecl *SourceFile::lookupLocalType(llvm::StringRef mangledName) const {
   return nullptr;
 }
 
-Optional<BasicDeclLocs>
-SourceFile::getBasicLocsForDecl(const Decl *D) const {
+Optional<ExternalSourceLocs::RawLocs>
+SourceFile::getExternalRawLocsForDecl(const Decl *D) const {
   auto *FileCtx = D->getDeclContext()->getModuleScopeContext();
   assert(FileCtx == this && "D doesn't belong to this source file");
   if (FileCtx != this) {
     // D doesn't belong to this file. This shouldn't happen in practice.
     return None;
   }
-  if (D->getLoc().isInvalid())
+
+  SourceLoc Loc = D->getLoc(/*SerializedOK=*/false);
+  if (Loc.isInvalid())
     return None;
+
   SourceManager &SM = getASTContext().SourceMgr;
-  BasicDeclLocs Result;
-  Result.SourceFilePath = SM.getDisplayNameForLoc(D->getLoc());
+  auto BufferID = SM.findBufferContainingLoc(Loc);
 
-  for (const auto &SRC : D->getRawComment(/*SerializedOK*/false).Comments) {
-    auto LineAndCol = SM.getLineAndColumnInBuffer(SRC.Range.getStart());
-    Result.DocRanges.push_back(
-        std::make_pair(SourcePosition{LineAndCol.first, LineAndCol.second},
-                       SRC.Range.getByteLength()));
-  }
+  ExternalSourceLocs::RawLocs Result;
+  auto setLoc = [&](ExternalSourceLocs::RawLoc &RawLoc, SourceLoc Loc) {
+    if (!Loc.isValid())
+      return;
 
-  auto setLineColumn = [&SM](SourcePosition &Home, SourceLoc Loc) {
-    if (Loc.isValid()) {
-      std::tie(Home.Line, Home.Column) = SM.getPresumedLineAndColumnForLoc(Loc);
-    }
+    RawLoc.Offset = SM.getLocOffsetInBuffer(Loc, BufferID);
+    std::tie(RawLoc.Line, RawLoc.Column) = SM.getLineAndColumnInBuffer(Loc);
+
+    auto *VF = SM.getVirtualFile(Loc);
+    if (!VF)
+      return;
+
+    RawLoc.Directive.Offset =
+        SM.getLocOffsetInBuffer(VF->Range.getStart(), BufferID);
+    RawLoc.Directive.LineOffset = VF->LineOffset;
+    RawLoc.Directive.Length = VF->Range.getByteLength();
+    RawLoc.Directive.Name = StringRef(VF->Name);
   };
-#define SET(X) setLineColumn(Result.X, D->get##X());
-  SET(Loc)
-  SET(StartLoc)
-  SET(EndLoc)
-#undef SET
+
+  Result.SourceFilePath = SM.getIdentifierForBuffer(BufferID);
+  for (const auto &SRC : D->getRawComment(/*SerializedOK=*/false).Comments) {
+    Result.DocRanges.emplace_back(ExternalSourceLocs::RawLoc(),
+                                  SRC.Range.getByteLength());
+    setLoc(Result.DocRanges.back().first, SRC.Range.getStart());
+  }
+  setLoc(Result.Loc, D->getLoc(/*SerializedOK=*/false));
+  setLoc(Result.StartLoc, D->getStartLoc());
+  setLoc(Result.EndLoc, D->getEndLoc());
   return Result;
 }
 

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -83,6 +83,29 @@ unsigned SourceManager::addMemBufferCopy(StringRef InputData,
   return addNewSourceBuffer(std::move(Buffer));
 }
 
+void SourceManager::createVirtualFile(SourceLoc Loc, StringRef Name,
+                                      int LineOffset, unsigned Length) {
+  CharSourceRange Range = CharSourceRange(Loc, Length);
+
+  // Skip if this range has already been added
+  VirtualFile &File = VirtualFiles[Range.getEnd().Value.getPointer()];
+  if (File.Range.isValid()) {
+    assert(Name == StringRef(File.Name));
+    assert(LineOffset == File.LineOffset);
+    assert(Range == File.Range);
+    return;
+  }
+
+  File.Range = Range;
+  File.Name = Name.str();
+  File.LineOffset = LineOffset;
+
+  if (CachedVFile.first && Range.contains(SourceLoc(llvm::SMLoc::getFromPointer(
+                               CachedVFile.first)))) {
+    CachedVFile = {nullptr, nullptr};
+  }
+}
+
 bool SourceManager::openVirtualFile(SourceLoc loc, StringRef name,
                                     int lineOffset) {
   CharSourceRange fullRange = getRangeForBuffer(findBufferContainingLoc(loc));
@@ -368,7 +391,7 @@ llvm::Optional<unsigned> SourceManager::resolveFromLineCol(unsigned BufferId,
   return Ptr - InputBuf->getBufferStart();
 }
 
-unsigned SourceManager::getExternalSourceBufferId(StringRef Path) {
+unsigned SourceManager::getExternalSourceBufferID(StringRef Path) {
   auto It = BufIdentIDMap.find(Path);
   if (It != BufIdentIDMap.end()) {
     return It->getSecond();
@@ -387,7 +410,7 @@ unsigned SourceManager::getExternalSourceBufferId(StringRef Path) {
 SourceLoc
 SourceManager::getLocFromExternalSource(StringRef Path, unsigned Line,
                                         unsigned Col) {
-  auto BufferId = getExternalSourceBufferId(Path);
+  auto BufferId = getExternalSourceBufferID(Path);
   if (BufferId == 0u)
     return SourceLoc();
   auto Offset = resolveFromLineCol(BufferId, Line, Col);

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -697,7 +697,8 @@ public:
   Optional<CommentInfo> getCommentForDecl(const Decl *D) const;
   Optional<CommentInfo> getCommentForDeclByUSR(StringRef USR) const;
   Optional<StringRef> getGroupNameByUSR(StringRef USR) const;
-  Optional<BasicDeclLocs> getBasicDeclLocsForDecl(const Decl *D) const;
+  Optional<ExternalSourceLocs::RawLocs>
+  getExternalRawLocsForDecl(const Decl *D) const;
   Identifier getDiscriminatorForPrivateValue(const ValueDecl *D);
   Optional<Fingerprint> loadFingerprint(const IterableDeclContext *IDC) const;
   void collectBasicSourceFileInfo(

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -523,14 +523,6 @@ void serialization::writeDocToStream(raw_ostream &os, ModuleOrSourceFile DC,
   S.writeToStream(os);
 }
 namespace {
-struct DeclLocationsTableData {
-  uint32_t SourceFileOffset;
-  uint32_t DocRangesOffset;
-  SourcePosition Loc;
-  SourcePosition StartLoc;
-  SourcePosition EndLoc;
-};
-
 class USRTableInfo {
 public:
   using key_type = StringRef;
@@ -618,6 +610,20 @@ public:
   }
 };
 
+static void writeRawLoc(const ExternalSourceLocs::RawLoc &Loc,
+                        endian::Writer &Writer, StringWriter &Strings) {
+  Writer.write<uint32_t>(Loc.Offset);
+  Writer.write<uint32_t>(Loc.Line);
+  Writer.write<uint32_t>(Loc.Column);
+
+  Writer.write<uint32_t>(Loc.Directive.Offset);
+  Writer.write<int32_t>(Loc.Directive.LineOffset);
+  Writer.write<uint32_t>(Loc.Directive.Length);
+  llvm::SmallString<128> AbsName = Loc.Directive.Name;
+  if (!AbsName.empty())
+    llvm::sys::fs::make_absolute(AbsName);
+  Writer.write<uint32_t>(Strings.getTextOffset(AbsName.str()));
+}
 
 /**
  Records the locations of `SingleRawComment` pieces for a declaration
@@ -626,10 +632,11 @@ public:
  See: \c decl_locs_block::DocRangesLayout
  */
 class DocRangeWriter {
+  StringWriter &Strings;
   llvm::DenseMap<const Decl *, uint32_t> DeclOffsetMap;
   llvm::SmallString<1024> Buffer;
 public:
-  DocRangeWriter() {
+  DocRangeWriter(StringWriter &Strings) : Strings(Strings) {
     /**
      Offset 0 is reserved to mean "no offset", meaning that a declaration
      didn't have a doc comment.
@@ -642,8 +649,9 @@ public:
    twice on the same declaration will not duplicate data but return the
    original offset.
    */
-  uint32_t getDocRangesOffset(const Decl *D,
-      ArrayRef<std::pair<SourcePosition, uint32_t>> DocRanges) {
+  uint32_t getDocRangesOffset(
+      const Decl *D,
+      ArrayRef<std::pair<ExternalSourceLocs::RawLoc, uint32_t>> DocRanges) {
     if (DocRanges.empty()) {
       return 0;
     }
@@ -655,13 +663,11 @@ public:
     }
 
     llvm::raw_svector_ostream OS(Buffer);
-
-    endian::write<uint32_t>(OS, DocRanges.size(), little);
-
-    for (const auto &LineColumnAndLength : DocRanges) {
-      endian::write<uint32_t>(OS, LineColumnAndLength.first.Line, little);
-      endian::write<uint32_t>(OS, LineColumnAndLength.first.Column, little);
-      endian::write<uint32_t>(OS, LineColumnAndLength.second, little);
+    endian::Writer Writer(OS, little);
+    Writer.write<uint32_t>(DocRanges.size());
+    for (const auto &DocRange : DocRanges) {
+      writeRawLoc(DocRange.first, Writer, Strings);
+      Writer.write<uint32_t>(DocRange.second);
     }
 
     return StartOffset;
@@ -690,47 +696,12 @@ struct BasicDeclLocsTableWriter : public ASTWalker {
   bool walkToTypeReprPre(TypeRepr *T) override { return false; }
   bool walkToParameterListPre(ParameterList *PL) override { return false; }
 
-  void appendToBuffer(DeclLocationsTableData data) {
-    llvm::raw_svector_ostream out(Buffer);
-    endian::Writer writer(out, little);
-    writer.write<uint32_t>(data.SourceFileOffset);
-    writer.write<uint32_t>(data.DocRangesOffset);
-#define WRITE_LINE_COLUMN(X)                                                  \
-writer.write<uint32_t>(data.X.Line);                                          \
-writer.write<uint32_t>(data.X.Column);
-    WRITE_LINE_COLUMN(Loc)
-    WRITE_LINE_COLUMN(StartLoc);
-    WRITE_LINE_COLUMN(EndLoc);
-#undef WRITE_LINE_COLUMN
-  }
-
   Optional<uint32_t> calculateNewUSRId(Decl *D) {
     llvm::SmallString<512> Buffer;
     llvm::raw_svector_ostream OS(Buffer);
     if (ide::printDeclUSR(D, OS))
       return None;
     return USRWriter.getNewUSRId(OS.str());
-  }
-
-  Optional<DeclLocationsTableData> getLocData(Decl *D) {
-    auto *File = D->getDeclContext()->getModuleScopeContext();
-    auto Locs = cast<FileUnit>(File)->getBasicLocsForDecl(D);
-    if (!Locs.hasValue())
-      return None;
-    DeclLocationsTableData Result;
-    llvm::SmallString<128> AbsolutePath = Locs->SourceFilePath;
-    llvm::sys::fs::make_absolute(AbsolutePath);
-    Result.SourceFileOffset = FWriter.getTextOffset(AbsolutePath.str());
-    Result.DocRangesOffset = DocWriter.getDocRangesOffset(D,
-      llvm::makeArrayRef(Locs->DocRanges));
-#define COPY_LINE_COLUMN(X)                                                   \
-Result.X.Line = Locs->X.Line;                                                 \
-Result.X.Column = Locs->X.Column;
-    COPY_LINE_COLUMN(Loc)
-    COPY_LINE_COLUMN(StartLoc)
-    COPY_LINE_COLUMN(EndLoc)
-#undef COPY_LINE_COLUMN
-    return Result;
   }
 
   bool shouldSerializeSourceLoc(Decl *D) {
@@ -740,11 +711,6 @@ Result.X.Column = Locs->X.Column;
   }
 
   bool walkToDeclPre(Decl *D) override {
-    SWIFT_DEFER {
-      assert(USRWriter.peekNextId() * sizeof(DeclLocationsTableData)
-             == Buffer.size() &&
-            "USR Id has a one-to-one mapping with DeclLocationsTableData");
-    };
     // .swiftdoc doesn't include comments for double underscored symbols, but
     // for .swiftsourceinfo, having the source location for these symbols isn't
     // a concern because these symbols are in .swiftinterface anyway.
@@ -752,15 +718,29 @@ Result.X.Column = Locs->X.Column;
       return false;
     if (!shouldSerializeSourceLoc(D))
       return true;
-    // If we cannot get loc data for D, don't proceed.
-    auto LocData = getLocData(D);
-    if (!LocData.hasValue())
+
+    auto *File = D->getDeclContext()->getModuleScopeContext();
+    auto RawLocs = cast<FileUnit>(File)->getExternalRawLocsForDecl(D);
+    if (!RawLocs.hasValue())
       return true;
-    // If we have handled this USR before, don't proceed.
+
+    // If we have handled this USR before, don't proceed
     auto USR = calculateNewUSRId(D);
     if (!USR.hasValue())
       return true;
-    appendToBuffer(*LocData);
+
+    llvm::SmallString<128> AbsolutePath = RawLocs->SourceFilePath;
+    llvm::sys::fs::make_absolute(AbsolutePath);
+
+    llvm::raw_svector_ostream Out(Buffer);
+    endian::Writer Writer(Out, little);
+    Writer.write<uint32_t>(FWriter.getTextOffset(AbsolutePath.str()));
+    Writer.write<uint32_t>(DocWriter.getDocRangesOffset(
+        D, llvm::makeArrayRef(RawLocs->DocRanges)));
+    writeRawLoc(RawLocs->Loc, Writer, FWriter);
+    writeRawLoc(RawLocs->StartLoc, Writer, FWriter);
+    writeRawLoc(RawLocs->EndLoc, Writer, FWriter);
+
     return true;
   }
 };
@@ -919,7 +899,7 @@ void serialization::writeSourceInfoToStream(raw_ostream &os,
       BCBlockRAII restoreBlock(S.Out, DECL_LOCS_BLOCK_ID, 4);
       DeclUSRsTableWriter USRWriter;
       StringWriter FPWriter;
-      DocRangeWriter DocWriter;
+      DocRangeWriter DocWriter(FPWriter);
       emitFileListRecord(S.Out, DC, FPWriter);
       emitBasicLocsRecord(S.Out, DC, USRWriter, FPWriter, DocWriter);
       // Emit USR table mapping from a USR to USR Id.

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1243,9 +1243,9 @@ SerializedASTFile::getCommentForDecl(const Decl *D) const {
   return File.getCommentForDecl(D);
 }
 
-Optional<BasicDeclLocs>
-SerializedASTFile::getBasicLocsForDecl(const Decl *D) const {
-  return File.getBasicDeclLocsForDecl(D);
+Optional<ExternalSourceLocs::RawLocs>
+SerializedASTFile::getExternalRawLocsForDecl(const Decl *D) const {
+  return File.getExternalRawLocsForDecl(D);
 }
 
 Optional<StringRef>

--- a/lib/Serialization/SourceInfoFormat.h
+++ b/lib/Serialization/SourceInfoFormat.h
@@ -41,7 +41,7 @@ const unsigned char SWIFTSOURCEINFO_SIGNATURE[] = { 0xF0, 0x9F, 0x8F, 0x8E };
 ///
 /// See docs/StableBitcode.md for information on how to make
 /// backwards-compatible changes using the LLVM bitcode format.
-const uint16_t SWIFTSOURCEINFO_VERSION_MAJOR = 2;
+const uint16_t SWIFTSOURCEINFO_VERSION_MAJOR = 3;
 
 /// Serialized swiftsourceinfo format minor version number.
 ///
@@ -49,7 +49,7 @@ const uint16_t SWIFTSOURCEINFO_VERSION_MAJOR = 2;
 /// interesting to test for. A backwards-compatible change is one where an \e
 /// old compiler can read the new format without any problems (usually by
 /// ignoring new information).
-const uint16_t SWIFTSOURCEINFO_VERSION_MINOR = 1; // Last change: add source file list
+const uint16_t SWIFTSOURCEINFO_VERSION_MINOR = 0; // add location offset
 
 /// The hash seed used for the string hashes(llvm::djbHash) in a .swiftsourceinfo file.
 const uint32_t SWIFTSOURCEINFO_HASH_SEED = 5387;

--- a/test/diagnostics/multi-module-diagnostics.swift
+++ b/test/diagnostics/multi-module-diagnostics.swift
@@ -1,13 +1,18 @@
 #if MODA_NORMAL
 open class ParentClass {
-  open func overridableMethod(param: Int) {}
+  open func overridableMethodA(param: Int) {}
+  open func overridableMethodB(param: Int) {}
+  open func overridableMethodC(param: Int) {}
 }
 #endif
 
 #if MODA_LOC
 open class ParentClass {
-#sourceLocation(file: "REPLACEDWITHSED", line: 10)
-  open func overridableMethod(param: Int) {}
+#sourceLocation(file: "doesnotexist.swift", line: 10)
+  open func overridableMethodA(param: Int) {}
+#sourceLocation(file: "REPLACEDWITHSED", line: 20)
+  open func overridableMethodB(param: Int) {}
+  open func overridableMethodC(param: Int) {}
 #sourceLocation()
 }
 #endif
@@ -16,7 +21,9 @@ open class ParentClass {
 import moda
 
 open class SubClass: ParentClass {
-  open override func overridableMethod(param: String) {}
+  open override func overridableMethodA(param: String) {}
+  open override func overridableMethodB(param: String) {}
+  open override func overridableMethodC(param: String) {}
 }
 #endif
 
@@ -32,6 +39,8 @@ open class SubClass: ParentClass {
 // The diagnostic should have the real location from .swiftsourceinfo
 // RUN: not %target-swift-frontend -typecheck -I %t/mods -D MODB %s 2>&1 | %FileCheck -check-prefix=CHECK-EXISTS %s
 // CHECK-EXISTS: moda.swift:3:13: note
+// CHECK-EXISTS: moda.swift:4:13: note
+// CHECK-EXISTS: moda.swift:5:13: note
 
 // Removed the underlying file, so should use the generated source instead
 // RUN: mv %t/moda.swift %t/moda.swift-moved
@@ -42,8 +51,9 @@ open class SubClass: ParentClass {
 // make sense any more. Ignored for now (ie. it is used regardless)
 // RUN: echo "// file was modified" > %t/moda.swift
 // RUN: cat %t/moda.swift-moved >> %t/moda.swift
-// RUN: not %target-swift-frontend -typecheck -I %t/mods -D MODB %s 2>&1 | %FileCheck -check-prefix=CHECK-EXISTS %s
-
+// RUN: not %target-swift-frontend -typecheck -I %t/mods -D MODB %s 2>&1 | %FileCheck -check-prefix=CHECK-OUTOFDATE %s
+// CHECK-OUTOFDATE-NOT: moda.ParentClass:{{.*}}: note:
+// CHECK-OUTOFDATE: moda.swift:{{.*}}: note:
 
 // The file and line from a location directive should be used whether or not it
 // exists - the actual source still comes from the original file, so that's what
@@ -53,26 +63,18 @@ open class SubClass: ParentClass {
 // RUN: mv %t/moda.swift-moved %t/moda.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-source-info -o %t/mods/moda.swiftmodule -D MODA_LOC %t/moda.swift
 
-// Line directive file exists
 // RUN: cp %t/moda.swift %t/alternative.swift
 // RUN: not %target-swift-frontend -typecheck -I %t/mods -D MODB %s 2>&1 | %FileCheck -check-prefix=CHECK-DIRECTIVE %s
+// CHECK-DIRECTIVE: doesnotexist.swift:10:13: note
+// CHECK-DIRECTIVE: alternative.swift:20:13: note
+// CHECK-DIRECTIVE: alternative.swift:21:13: note
 
-// File missing
+// File in line directive exists, but location does not
 // RUN: mv %t/alternative.swift %t/alternative.swift-moved
-// FIXME: Because the presumed location is output and then read back in, the
-//        location is invalid and it falls back to the generated. This should be
-//        CHECK-DIRECTIVE
-// RUN: not %target-swift-frontend -typecheck -I %t/mods -D MODB %s 2>&1 | %FileCheck -check-prefix=CHECK-GENERATED %s
-// CHECK-DIRECTIVE: alternative.swift:10:13: note
-
-// File exists but location does not
 // RUN: echo "" > %t/alternative.swift
-// FIXME: As above, this should be CHECK-DIRECTIVE
-// RUN: not %target-swift-frontend -typecheck -I %t/mods -D MODB %s 2>&1 | %FileCheck -check-prefix=CHECK-GENERATED %s
+// RUN: not %target-swift-frontend -typecheck -I %t/mods -D MODB %s 2>&1 | %FileCheck -check-prefix=CHECK-DIRECTIVE %s
 
 // Removed the underlying file, so should use the generated source instead
 // RUN: mv %t/alternative.swift-moved %t/alternative.swift
 // RUN: mv %t/moda.swift %t/moda.swift-moved
-// FIXME: Should be CHECK-GENERATED but works as, again, it's the presumed
-//        location that's output
-// RUN: not %target-swift-frontend -typecheck -I %t/mods -D MODB %s 2>&1 | %FileCheck -check-prefix=CHECK-DIRECTIVE %s
+// RUN: not %target-swift-frontend -typecheck -I %t/mods -D MODB %s 2>&1 | %FileCheck -check-prefix=CHECK-GENERATED %s

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -3047,30 +3047,16 @@ public:
     }
   }
 
-  void printSerializedLoc(Decl *D) {
-    auto moduleLoc = cast<FileUnit>(D->getDeclContext()->getModuleScopeContext())->
-      getBasicLocsForDecl(D);
-    if (!moduleLoc.hasValue())
-      return;
-    if (!moduleLoc->Loc.isValid())
-      return;
-    OS << moduleLoc->SourceFilePath
-       << ":" << moduleLoc->Loc.Line
-       << ":" << moduleLoc->Loc.Column << ": ";
-  }
-
   bool walkToDeclPre(Decl *D) override {
     if (D->isImplicit())
       return true;
 
     if (auto *VD = dyn_cast<ValueDecl>(D)) {
-      SourceLoc Loc = D->getLoc();
+      SourceLoc Loc = D->getLoc(/*SerializedOK=*/true);
       if (Loc.isValid()) {
         auto LineAndColumn = SM.getPresumedLineAndColumnForLoc(Loc);
         OS << SM.getDisplayNameForLoc(Loc)
            << ":" << LineAndColumn.first << ":" << LineAndColumn.second << ": ";
-      } else {
-        printSerializedLoc(D);
       }
       OS << Decl::getKindName(VD->getKind()) << "/";
       printDeclName(VD);
@@ -3083,13 +3069,11 @@ public:
       printDocComment(D);
       OS << "\n";
     } else if (isa<ExtensionDecl>(D)) {
-      SourceLoc Loc = D->getLoc();
+      SourceLoc Loc = D->getLoc(/*SerializedOK=*/true);
       if (Loc.isValid()) {
         auto LineAndColumn = SM.getPresumedLineAndColumnForLoc(Loc);
         OS << SM.getDisplayNameForLoc(Loc)
         << ":" << LineAndColumn.first << ":" << LineAndColumn.second << ": ";
-      } else {
-        printSerializedLoc(D);
       }
       OS << Decl::getKindName(D->getKind()) << "/";
       OS << " ";


### PR DESCRIPTION
The locations stored in .swiftsourceinfo included the presumed file,
line, and column. When a location is requested it would read these, open
the external file, create a line map, and find the offset corresponding
to that line/column.

The offset is known during serialization though, so output it as well to
avoid having to read the file and generate the line map.

Since the serialized location is returned from `Decl::getLoc()`, it
should not be the presumed location. Instead, also output the line
directives so that the presumed location can be built as per normal
locations.

Finally, move the cache out of `Decl` and into `ASTContext`, since very
few declarations will actually have their locations deserialized. Make
sure to actually write to that cache so it's used - the old cache was
never written to.