### PR TITLE
[Concurrency] Harden async_task_async_let_child_cancel so it does not need sleep

### DIFF
--- a/test/Concurrency/Runtime/async_task_async_let_child_cancel.swift
+++ b/test/Concurrency/Runtime/async_task_async_let_child_cancel.swift
@@ -18,6 +18,10 @@ func printWaitPrint(_ int: Int) async -> Int {
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test() async {
+  let h = detach {
+    await printWaitPrint(0)
+  }
+
   let handle = detach {
     print("detached run, cancelled:\(Task.isCancelled)")
 
@@ -26,6 +30,8 @@ func test() async {
     print("spawned: 1")
     async let two = printWaitPrint(2)
     print("spawned: 2")
+
+    h.cancel()
 
     let first = await one
     print("awaited: 1: \(first)")
@@ -40,7 +46,7 @@ func test() async {
     print("exit detach")
   }
 
-  await Task.sleep(2 * 1_000_000)
+  await h.get()
 
   print("cancel")
   handle.cancel()


### PR DESCRIPTION
This should make the test more resilient on slow platforms where the sleep was not enough to force the expected ordering.