### PR TITLE
[Refactoring] Convert completion handler when converting function to async

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -5371,8 +5371,8 @@ bool RefactoringActionConvertToAsync::performChange() {
   assert(FD &&
          "Should not run performChange when refactoring is not applicable");
 
-  AsyncHandlerDesc TempDesc;
-  AsyncConverter Converter(SM, DiagEngine, FD, TempDesc);
+  auto HandlerDesc = AsyncHandlerDesc::find(FD, /*ignoreName=*/true);
+  AsyncConverter Converter(SM, DiagEngine, FD, HandlerDesc);
   if (!Converter.convert())
     return true;
 

--- a/test/refactoring/ConvertAsync/basic.swift
+++ b/test/refactoring/ConvertAsync/basic.swift
@@ -151,14 +151,9 @@ func retStruct() -> MyStruct { return MyStruct() }
 
 protocol MyProtocol {
   // RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=PROTO-MEMBER %s
-  // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=PROTO-MEMBER-TO-ASYNC %s
+  // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=PROTO-MEMBER %s
   func protoMember(completion: (String) -> Void)
   // PROTO-MEMBER: func protoMember() async -> String{{$}}
-
-  // FIXME: The current async refactoring only refactors the client side and thus only adds the 'async' keyword.
-  // We should be refactoring the entire method signature here and removing the completion parameter.
-  // This test currently checks that we are not crashing.
-  // PROTO-MEMBER-TO-ASYNC: func protoMember(completion: (String) -> Void) async
 }
 
 // RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1

--- a/test/refactoring/ConvertAsync/convert_function.swift
+++ b/test/refactoring/ConvertAsync/convert_function.swift
@@ -71,6 +71,7 @@ func manyNested() {
 // MANY-NESTED-NEXT: print("after")
 // MANY-NESTED-NEXT: }
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=ASYNC-SIMPLE %s
 // RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-SIMPLE %s
 func asyncParams(arg: String, _ completion: (String?, Error?) -> Void) {
   simpleErr(arg: arg) { str, err in
@@ -196,3 +197,8 @@ func voidResultCompletion(completion: (Result<Void, Error>) -> Void) {
 // VOID-RESULT-HANDLER-NEXT:     throw CustomError.Bad
 // VOID-RESULT-HANDLER-NEXT:   }
 // VOID-RESULT-HANDLER-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=NON-COMPLETION-HANDLER %s
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NON-COMPLETION-HANDLER %s
+func functionWithSomeHandler(handler: (String) -> Void) {}
+// NON-COMPLETION-HANDLER: func functionWithSomeHandler() async -> String {}


### PR DESCRIPTION
Convert function to async currently only adds "async" to the function and runs the convert call refactoring on the body.

This was intentional, but it turns out to be somewhat confusing. Instead, run the same refactoring as the add async alternative refactoring but just replace rather than add.