### PR TITLE
[5.5][CodeCompletion] Boost exact case-sensitive prefix match

### DIFF
--- a/lib/IDE/FuzzyStringMatcher.cpp
+++ b/lib/IDE/FuzzyStringMatcher.cpp
@@ -47,7 +47,7 @@ FuzzyStringMatcher::FuzzyStringMatcher(StringRef pattern_)
                pattern.size() * pattern.size(); // max run length score
     if (upperCharCount)                         // max uppercase match score
       maxScore += (upperCharCount + 1) * (upperCharCount + 1);
-    maxScore *= 1.1 * 2.5; // exact prefix match bonus
+    maxScore *= 1.1 * 2.5 * 1.2; // exact prefix match bonus
   }
 }
 
@@ -503,8 +503,12 @@ CandidateSpecificMatcher::scoreCandidateTrial(unsigned firstPatternPos) {
   }
 
   // Exact prefix matches are the best.
-  if (!runs.empty() && runs[0].location == 0 && runs[0].length == patternLength)
+  if (!runs.empty() && runs[0].location == 0 && runs[0].length == patternLength) {
     trialScore *= 2.5;
+    // Case sensitive exact prefix matches are the best of the best.
+    if (candidate.startswith(pattern))
+      trialScore *= 1.2;
+  }
 
   // FIXME: popular/unpopular API.
 

--- a/test/SourceKit/CodeComplete/complete_fuzzy.swift
+++ b/test/SourceKit/CodeComplete/complete_fuzzy.swift
@@ -100,8 +100,8 @@ struct Test4 {
     #^CONTEXT_SORT_1,myVa^#
 // CONTEXT_SORT_1: Results for filterText: myVa [
 // CONTEXT_SORT_1-NEXT: myVarTest4
-// CONTEXT_SORT_1-NEXT: myLocalVar
 // CONTEXT_SORT_1-NEXT: myVar
+// CONTEXT_SORT_1-NEXT: myLocalVar
 
 // CONTEXT_SORT_2: Results for filterText: myVa [
 // CONTEXT_SORT_2-NEXT: myVarTest4

--- a/test/SourceKit/CodeComplete/complete_popular_api.swift
+++ b/test/SourceKit/CodeComplete/complete_popular_api.swift
@@ -77,13 +77,13 @@ struct OuterNominal {
 // POPULAR_STMT_0-LABEL: Results for filterText: [
 // POPULAR_STMT_0:   argColor
 // POPULAR_STMT_0:   localColor
+// POPULAR_STMT_0:   good()
 // POPULAR_STMT_0:   fromDerivedColor
 // POPULAR_STMT_0:   fromSuperColor
-// POPULAR_STMT_0:   good()
-// POPULAR_STMT_0:   fromOuterNominalColor
 // POPULAR_STMT_0:   DDModuleColor
-// POPULAR_STMT_0:   CCModuleColor
 // POPULAR_STMT_0:   EEModuleColor
+// POPULAR_STMT_0:   CCModuleColor
+// POPULAR_STMT_0:   fromOuterNominalColor
 // POPULAR_STMT_0:   globalColor
 // POPULAR_STMT_0:   okay()
 // POPULAR_STMT_0:   ModuleCollaborate
@@ -94,11 +94,11 @@ struct OuterNominal {
 // POPULAR_STMT_0:   localColor
 // POPULAR_STMT_0:   fromDerivedColor
 // POPULAR_STMT_0:   fromSuperColor
+// POPULAR_STMT_0:   DDModuleColor
+// POPULAR_STMT_0:   EEModuleColor
+// POPULAR_STMT_0:   CCModuleColor
 // POPULAR_STMT_0:   fromOuterNominalColor
 // POPULAR_STMT_0:   globalColor
-// POPULAR_STMT_0:   DDModuleColor
-// POPULAR_STMT_0:   CCModuleColor
-// POPULAR_STMT_0:   EEModuleColor
 // POPULAR_STMT_0:   ModuleCollaborate
 // POPULAR_STMT_0:   BBModuleColor
 // POPULAR_STMT_0:   AAModuleColor

--- a/test/SourceKit/CodeComplete/complete_sort_order.swift
+++ b/test/SourceKit/CodeComplete/complete_sort_order.swift
@@ -211,12 +211,12 @@ func test7() {
   #^CASE_0,caseSensitiveCheck,CaseSensitiveCheck^#
 }
 // CASE_0: Results for filterText: caseSensitiveCheck [
-// CASE_0: CaseSensitiveCheck
 // CASE_0: caseSensitiveCheck
+// CASE_0: CaseSensitiveCheck
 // CASE_0: caseSensitiveCheck.
 // CASE_0: ]
 // CASE_0: Results for filterText: CaseSensitiveCheck [
-// CASE_0: caseSensitiveCheck
 // CASE_0: CaseSensitiveCheck
+// CASE_0: caseSensitiveCheck
 // CASE_0: CaseSensitiveCheck(
 // CASE_0: ]

--- a/test/SourceKit/CodeComplete/complete_sort_order_prefixexact.swift
+++ b/test/SourceKit/CodeComplete/complete_sort_order_prefixexact.swift
@@ -1,0 +1,65 @@
+// BEGIN TheModule.swift
+public struct Machine {
+    public init() {}
+}
+
+public func machineFunc() {}
+
+// BEGIN main.swift
+import TheModule
+public struct MyMachine {}
+
+struct Local {
+    var machineHidden: Bool { true }
+    func hideMachine() -> Void {}
+
+    func test() {
+        #^COMPLETE,,M,Ma,Mac,Mach^#
+    }
+}
+
+// RUN: %empty-directory(%t/src)
+// RUN: %{python} %utils/split_file.py -o %t/src %s
+
+// RUN: %empty-directory(%t/Modules)
+// RUN: %target-swift-frontend -emit-module %t/src/TheModule.swift -module-name TheModule -o %t/Modules/TheModule.swiftmodule
+
+// RUN: %complete-test -tok=COMPLETE %t/src/main.swift -- -target %target-triple -I %t/Modules | %FileCheck --check-prefix=CHECK %s 
+
+// CHECK-LABEL: Results for filterText:  [
+// CHECK: hideMachine()
+// CHECK: machineHidden
+// CHECK: MyMachine
+// CHECK: ]
+
+// CHECK-LABEL: Results for filterText: M [
+// CHECK: MyMachine
+// CHECK: Machine
+// CHECK: machineHidden
+// CHECK: machineFunc()
+// CHECK: ]
+
+// CHECK-LABEL: Results for filterText: Ma [
+// CHECK: Machine
+// CHECK: machineHidden
+// CHECK: hideMachine()
+// CHECK: machineFunc()
+// CHECK: MyMachine
+// CHECK: ]
+
+// CHECK-LABEL: Results for filterText: Mac [
+// CHECK: Machine
+// CHECK: machineHidden
+// CHECK: machineFunc()
+// CHECK: hideMachine()
+// CHECK: MyMachine
+// CHECK: ]
+
+// CHECK-LABEL: Results for filterText: Mach [
+// CHECK: Machine
+// CHECK: machineHidden
+// CHECK: machineFunc()
+// CHECK: hideMachine()
+// CHECK: MyMachine
+// CHECK: ]
+

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
@@ -47,8 +47,8 @@ struct Options {
   unsigned showTopNonLiteralResults = 3;
 
   // Options for combining priorities.
-  unsigned semanticContextWeight = 15;
-  unsigned fuzzyMatchWeight = 10;
+  unsigned semanticContextWeight = 7;
+  unsigned fuzzyMatchWeight = 13;
   unsigned popularityBonus = 2;
 };
 

--- a/unittests/IDE/FuzzyStringMatcherTest.cpp
+++ b/unittests/IDE/FuzzyStringMatcherTest.cpp
@@ -292,7 +292,7 @@ TEST(FuzzyStringMatcher, NormalizeScore) {
   FuzzyStringMatcher n("abc");
   n.normalize = true;
   EXPECT_DOUBLE_EQ(1.0, n.scoreCandidate("abc"));
-  EXPECT_DOUBLE_EQ(1.0, n.scoreCandidate("ABC"));
+  EXPECT_DOUBLE_EQ(0.83333333333333337, n.scoreCandidate("ABC"));
 }
 
 TEST(FuzzyStringMatcher, TokenizingCharacters) {


### PR DESCRIPTION
Cherry-pick #37095 into `release/5.5` originally reviewed by @benlangmuir 

rdar://77164709
