### PR TITLE
Teach TypeLayout the Different Types of References

### DIFF
--- a/lib/IRGen/ClassTypeInfo.h
+++ b/lib/IRGen/ClassTypeInfo.h
@@ -19,6 +19,7 @@
 
 #include "ClassLayout.h"
 #include "HeapTypeInfo.h"
+#include "TypeLayout.h"
 
 namespace swift {
 namespace irgen {
@@ -46,7 +47,7 @@ public:
   ClassTypeInfo(llvm::PointerType *irType, Size size, SpareBitVector spareBits,
                 Alignment align, ClassDecl *theClass,
                 ReferenceCounting refcount)
-      : HeapTypeInfo(irType, size, std::move(spareBits), align),
+      : HeapTypeInfo(refcount, irType, size, std::move(spareBits), align),
         TheClass(theClass), Refcount(refcount) {}
 
   ReferenceCounting getReferenceCounting() const { return Refcount; }

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -16,6 +16,7 @@
 
 #include "GenArchetype.h"
 
+#include "TypeLayout.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/GenericEnvironment.h"
@@ -126,13 +127,11 @@ class ClassArchetypeTypeInfo
 {
   ReferenceCounting RefCount;
 
-  ClassArchetypeTypeInfo(llvm::PointerType *storageType,
-                         Size size, const SpareBitVector &spareBits,
-                         Alignment align,
+  ClassArchetypeTypeInfo(llvm::PointerType *storageType, Size size,
+                         const SpareBitVector &spareBits, Alignment align,
                          ReferenceCounting refCount)
-    : HeapTypeInfo(storageType, size, spareBits, align),
-      RefCount(refCount)
-  {}
+      : HeapTypeInfo(refCount, storageType, size, spareBits, align),
+        RefCount(refCount) {}
 
 public:
   static const ClassArchetypeTypeInfo *create(llvm::PointerType *storageType,

--- a/lib/IRGen/GenConcurrency.cpp
+++ b/lib/IRGen/GenConcurrency.cpp
@@ -53,7 +53,8 @@ public:
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T,
+                                                      ScalarKind::POD);
   }
 
   static Size getSecondElementOffset(IRGenModule &IGM) {

--- a/lib/IRGen/GenDiffFunc.cpp
+++ b/lib/IRGen/GenDiffFunc.cpp
@@ -120,7 +120,7 @@ public:
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
     if (!IGM.getOptions().ForceStructTypeLayouts || !areFieldsABIAccessible()) {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+      return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
     }
 
     if (getFields().empty()) {
@@ -292,7 +292,7 @@ public:
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
     if (!IGM.getOptions().ForceStructTypeLayouts || !areFieldsABIAccessible()) {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+      return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
     }
 
     if (getFields().empty()) {

--- a/lib/IRGen/GenExistential.h
+++ b/lib/IRGen/GenExistential.h
@@ -95,6 +95,14 @@ namespace irgen {
   void emitDeallocateBoxedOpaqueExistentialBuffer(IRGenFunction &IGF,
                                                   SILType existentialType,
                                                   Address existentialContainer);
+
+  /// Free the storage for an opaque existential in the existential
+  /// container.
+  /// If the value is not stored inline, this will free the box for the
+  /// value.
+  void emitDestroyBoxedOpaqueExistentialBuffer(IRGenFunction &IGF,
+                                               SILType existentialType,
+                                               Address existentialContainer);
   Address emitOpaqueBoxedExistentialProjection(
       IRGenFunction &IGF, OpenedExistentialAccess accessKind, Address base,
       SILType existentialType, CanArchetypeType openedArchetype);

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -156,7 +156,8 @@ namespace {
 
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T,
+                                                        ScalarKind::POD);
     }
 
     bool mayHaveExtraInhabitants(IRGenModule &IGM) const override {
@@ -223,7 +224,13 @@ namespace {
 
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+      if (isPOD(ResilienceExpansion::Maximal)) {
+        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T,
+                                                          ScalarKind::POD);
+      } else {
+        return IGM.typeLayoutCache.getOrCreateScalarEntry(
+            *this, T, ScalarKind::ThickFunc);
+      }
     }
 
     static Size getFirstElementSize(IRGenModule &IGM) {
@@ -385,20 +392,19 @@ namespace {
                         public FuncSignatureInfo
   {
   public:
-    BlockTypeInfo(CanSILFunctionType ty,
-                  llvm::PointerType *storageType,
+    BlockTypeInfo(CanSILFunctionType ty, llvm::PointerType *storageType,
                   Size size, SpareBitVector spareBits, Alignment align)
-      : HeapTypeInfo(storageType, size, spareBits, align),
-        FuncSignatureInfo(ty)
-    {
-    }
+        : HeapTypeInfo(ReferenceCounting::Block, storageType, size, spareBits,
+                       align),
+          FuncSignatureInfo(ty) {}
 
     ReferenceCounting getReferenceCounting() const {
       return ReferenceCounting::Block;
     }
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(
+          *this, T, ScalarKind::BlockReference);
     }
   };
   
@@ -420,7 +426,8 @@ namespace {
     
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(
+          *this, T, ScalarKind::BlockStorage);
     }
     // The lowered type should be an LLVM struct comprising the block header
     // (IGM.ObjCBlockStructTy) as its first element and the capture as its

--- a/lib/IRGen/GenIntegerLiteral.cpp
+++ b/lib/IRGen/GenIntegerLiteral.cpp
@@ -53,7 +53,8 @@ public:
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T,
+                                                      ScalarKind::POD);
   }
 
   static Size getSecondElementOffset(IRGenModule &IGM) {

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -190,9 +190,9 @@ namespace {
   class UnknownTypeInfo : public HeapTypeInfo<UnknownTypeInfo> {
   public:
     UnknownTypeInfo(llvm::PointerType *storageType, Size size,
-                 SpareBitVector spareBits, Alignment align)
-      : HeapTypeInfo(storageType, size, spareBits, align) {
-    }
+                    SpareBitVector spareBits, Alignment align)
+        : HeapTypeInfo(ReferenceCounting::Unknown, storageType, size, spareBits,
+                       align) {}
 
     /// AnyObject requires ObjC reference-counting.
     ReferenceCounting getReferenceCounting() const {
@@ -219,9 +219,9 @@ namespace {
   class BridgeObjectTypeInfo : public HeapTypeInfo<BridgeObjectTypeInfo> {
   public:
     BridgeObjectTypeInfo(llvm::PointerType *storageType, Size size,
-                 SpareBitVector spareBits, Alignment align)
-      : HeapTypeInfo(storageType, size, spareBits, align) {
-    }
+                         SpareBitVector spareBits, Alignment align)
+        : HeapTypeInfo(ReferenceCounting::Bridge, storageType, size, spareBits,
+                       align) {}
 
     /// Builtin.BridgeObject uses its own specialized refcounting implementation.
     ReferenceCounting getReferenceCounting() const {

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -355,7 +355,7 @@ namespace {
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
       if (!IGM.getOptions().ForceStructTypeLayouts) {
-        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+        return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
       }
       if (!areFieldsABIAccessible()) {
         return IGM.typeLayoutCache.getOrCreateResilientEntry(T);
@@ -542,7 +542,7 @@ namespace {
                                           SILType T) const override {
       if (!IGM.getOptions().ForceStructTypeLayouts || getCXXDestructor(T) ||
           !areFieldsABIAccessible()) {
-        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+        return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
       }
 
       std::vector<TypeLayoutEntry *> fields;
@@ -622,7 +622,7 @@ namespace {
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
       if (!IGM.getOptions().ForceStructTypeLayouts) {
-        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+        return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
       }
 
       if (!areFieldsABIAccessible()) {
@@ -684,7 +684,7 @@ namespace {
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
       if (!IGM.getOptions().ForceStructTypeLayouts) {
-        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+        return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
       }
 
       if (!areFieldsABIAccessible()) {

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -233,7 +233,7 @@ namespace {
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
       if (!IGM.getOptions().ForceStructTypeLayouts) {
-        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+        return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
       }
       if (getFields().empty()) {
         return IGM.typeLayoutCache.getEmptyEntry();
@@ -278,7 +278,7 @@ namespace {
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
       if (!IGM.getOptions().ForceStructTypeLayouts) {
-        return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+        return IGM.typeLayoutCache.getOrCreateTypeInfoBasedEntry(*this, T);
       }
       if (getFields().empty()) {
         return IGM.typeLayoutCache.getEmptyEntry();

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1135,7 +1135,8 @@ namespace {
 
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T,
+                                                        ScalarKind::POD);
     }
 
     unsigned getExplosionSize() const override {
@@ -1225,7 +1226,8 @@ namespace {
                          IsNotPOD, IsNotBitwiseTakable, IsFixedSize) {}
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T,
+                                                        ScalarKind::Immovable);
     }
 
     void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
@@ -2299,7 +2301,7 @@ public:
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+    llvm_unreachable("Cannot construct type layout for legacy types");
   }
 
   virtual unsigned getFixedExtraInhabitantCount(IRGenModule &IGM) const override {

--- a/lib/IRGen/HeapTypeInfo.h
+++ b/lib/IRGen/HeapTypeInfo.h
@@ -64,9 +64,10 @@ class HeapTypeInfo
 protected:
   using super::asDerived;
 public:
-  HeapTypeInfo(llvm::PointerType *storage, Size size, SpareBitVector spareBits,
-               Alignment align)
-    : super(storage, size, spareBits, align) {}
+  HeapTypeInfo(ReferenceCounting refcounting, llvm::PointerType *storage,
+               Size size, SpareBitVector spareBits, Alignment align)
+      : super(swift::irgen::refcountingToScalarKind(refcounting), storage, size, spareBits,
+              align) {}
 
   bool isSingleRetainablePointer(ResilienceExpansion expansion,
                                  ReferenceCounting *refcounting) const override {

--- a/lib/IRGen/ScalarTypeInfo.h
+++ b/lib/IRGen/ScalarTypeInfo.h
@@ -240,8 +240,9 @@ class SingleScalarTypeInfoWithTypeLayout
     : public SingleScalarTypeInfo<Derived, Base> {
 protected:
   template <class... T>
-  SingleScalarTypeInfoWithTypeLayout(T &&... args)
-      : SingleScalarTypeInfo<Derived, Base>(::std::forward<T>(args)...) {}
+  SingleScalarTypeInfoWithTypeLayout(ScalarKind kind, T &&...args)
+      : SingleScalarTypeInfo<Derived, Base>(::std::forward<T>(args)...),
+        kind(kind) {}
 
   const Derived &asDerived() const {
     return static_cast<const Derived &>(*this);
@@ -252,8 +253,11 @@ public:
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-    return IGM.typeLayoutCache.getOrCreateScalarEntry(asDerived(), T);
+    return IGM.typeLayoutCache.getOrCreateScalarEntry(asDerived(), T, kind);
   }
+
+private:
+  ScalarKind kind;
 };
 
 /// PODSingleScalarTypeInfo - A further specialization of
@@ -289,7 +293,8 @@ private:
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
-    return IGM.typeLayoutCache.getOrCreateScalarEntry(asDerived(), T);
+    return IGM.typeLayoutCache.getOrCreateScalarEntry(asDerived(), T,
+                                                      ScalarKind::POD);
   }
 
 };


### PR DESCRIPTION
As part of SR-14273, the type layout infrastructure needs to be able to be able
to differentiate between types of scalars so it knows how to release/retain
appropriately. Right now, for example, to destroy a scalar, it blindly calls
into typeInfo's irgen functions which means it's not able to generate any of
the needed information for itself.

This patch adds a field to ScalarTypeLayout to allow them to know what kind of
reference they are and strings through the machinery to provide the information
to set it.

This also moves ScalarTypeLayout::destroy to use the new information.