### PR TITLE
[Concurrency] Push an autorelease pool around job runs.

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -62,6 +62,11 @@
 #include <processthreadsapi.h>
 #endif
 
+#if SWIFT_OBJC_INTEROP
+extern "C" void *objc_autoreleasePoolPush();
+extern "C" void objc_autoreleasePoolPop(void *);
+#endif
+
 using namespace swift;
 
 /// Should we yield the thread?
@@ -198,6 +203,10 @@ SWIFT_RUNTIME_DECLARE_THREAD_LOCAL(
 void swift::runJobInEstablishedExecutorContext(Job *job) {
   _swift_tsan_acquire(job);
 
+#if SWIFT_OBJC_INTEROP
+  auto pool = objc_autoreleasePoolPush();
+#endif
+
   if (auto task = dyn_cast<AsyncTask>(job)) {
     // Update the active task in the current thread.
     ActiveTask::set(task);
@@ -215,6 +224,10 @@ void swift::runJobInEstablishedExecutorContext(Job *job) {
     // There's no extra bookkeeping to do for simple jobs.
     job->runSimpleInFullyEstablishedContext();
   }
+
+#if SWIFT_OBJC_INTEROP
+  objc_autoreleasePoolPop(pool);
+#endif
 
   _swift_tsan_release(job);
 }


### PR DESCRIPTION
This ensures that job code that calls out to ObjC code will see a consistent autorelease environment.

rdar://75329282