### PR TITLE
Remap aarch64_32 to arm64_32 When Searching for Modules

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -254,6 +254,7 @@ getArchForAppleTargetSpecificModuleTriple(const llvm::Triple &triple) {
 
   return llvm::StringSwitch<StringRef>(tripleArchName)
               .Cases("arm64", "aarch64", "arm64")
+              .Cases("arm64_32", "aarch64_32", "arm64_32")
               .Cases("x86_64", "amd64", "x86_64")
               .Cases("i386", "i486", "i586", "i686", "i786", "i886", "i986",
                      "i386")
@@ -262,7 +263,6 @@ getArchForAppleTargetSpecificModuleTriple(const llvm::Triple &triple) {
   //          .Case ("armv7s", "armv7s")
   //          .Case ("armv7k", "armv7k")
   //          .Case ("armv7", "armv7")
-  //          .Case ("arm64_32", "arm64_32")
   //          .Case ("arm64e", "arm64e")
               .Default(tripleArchName);
 }

--- a/test/ClangImporter/nested_protocol_name.swift
+++ b/test/ClangImporter/nested_protocol_name.swift
@@ -19,9 +19,6 @@
 // HEADER:   func flower()
 // HEADER: }
 
-// rdar://77281393
-// UNSUPPORTED: CPU=arm64_32
-
 func grow(_ branch: Trunk.Branch, from trunk: Trunk) {
   branch.flower()
   trunk.addLimb(branch)

--- a/test/IDE/print_clang_header.swift
+++ b/test/IDE/print_clang_header.swift
@@ -1,8 +1,6 @@
 // FIXME: rdar://problem/19648117 Needs splitting objc parts out
 // REQUIRES: objc_interop
 
-// UNSUPPORTED: CPU=arm64_32
-
 // RUN: echo '#include "header-to-print.h"' > %t.m
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.m -I %S/Inputs/print_clang_header > %t.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print.h.printed.txt %t.txt

--- a/test/IDE/print_clang_header_swift_name.swift
+++ b/test/IDE/print_clang_header_swift_name.swift
@@ -3,8 +3,6 @@
 // RUN:     %S/Inputs/print_clang_header_swift_name.h -skip-unavailable --cc-args %target-cc-options \
 // RUN:     -isysroot %clang-importer-sdk-path -fsyntax-only %t.m -I %S/Inputs | %FileCheck %s
 
-// UNSUPPORTED: CPU=arm64_32
-
 // REQUIRES: objc_interop
 
 // CHECK: enum Normal : Int {


### PR DESCRIPTION
The triple name aarch64_32 does not actually name a valid platform. The
actual platform (and valid triple arch string, confusingly enough) is
arm64_32. Remap between the two to correct for this difference.

rdar://77281393