### PR TITLE
[Localization] Add a couple of missing imports

### DIFF
--- a/lib/Localization/LocalizationFormat.cpp
+++ b/lib/Localization/LocalizationFormat.cpp
@@ -14,14 +14,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/Basic/Range.h"
 #include "swift/Localization/LocalizationFormat.h"
+#include "swift/Basic/Range.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Bitstream/BitstreamReader.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/YAMLParser.h"
 #include "llvm/Support/YAMLTraits.h"
 #include <cstdint>


### PR DESCRIPTION
Import `Path.h` and `FileSystem.h` directly since they are the source
of `llvm::sys::path::extension` and `llvm::system::fs::OpenFlags`
respectively.

Resolves: rdar://77277253

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
