### PR TITLE
Emit a remark when rebuilding the standard library interface

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -371,6 +371,11 @@ WARNING(warning_module_shadowing_may_break_module_interface,none,
         /*shadowedModule=*/ModuleDecl *, /*interfaceModule*/ModuleDecl *))
 REMARK(rebuilding_module_from_interface,none,
        "rebuilding module '%0' from interface '%1'", (StringRef, StringRef))
+REMARK(rebuilding_stdlib_from_interface,none,
+       "did not find a prebuilt standard library for target '%0' compatible "
+       "with this Swift compiler; building it may take a few minutes, but it "
+       "should only happen once for this combination of compiler and target",
+       (StringRef))
 NOTE(sdk_version_pbm_version,none,
      "SDK build version is '%0'; prebuilt modules were "
      "built using SDK build version: '%1'", (StringRef, StringRef))

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -287,44 +287,45 @@ struct ModuleRebuildInfo {
 
   /// Emits a diagnostic for all out-of-date compiled or forwarding modules
   /// encountered while trying to load a module.
-  void diagnose(ASTContext &ctx, SourceLoc loc, StringRef moduleName,
-                 StringRef interfacePath, StringRef prebuiltCacheDir) {
-    ctx.Diags.diagnose(loc, diag::rebuilding_module_from_interface,
-                       moduleName, interfacePath);
+  template<typename... DiagArgs>
+  void diagnose(ASTContext &ctx, DiagnosticEngine &diags,
+                StringRef prebuiltCacheDir, SourceLoc loc,
+                DiagArgs &&...diagArgs) {
+    diags.diagnose(loc, std::forward<DiagArgs>(diagArgs)...);
     auto SDKVer = getSDKBuildVersion(ctx.SearchPathOpts.SDKPath);
     llvm::SmallString<64> buffer = prebuiltCacheDir;
     llvm::sys::path::append(buffer, "SystemVersion.plist");
     auto PBMVer = getSDKBuildVersionFromPlist(buffer.str());
     if (!SDKVer.empty() && !PBMVer.empty()) {
       // Remark the potential version difference.
-      ctx.Diags.diagnose(loc, diag::sdk_version_pbm_version, SDKVer,
+      diags.diagnose(loc, diag::sdk_version_pbm_version, SDKVer,
                          PBMVer);
     }
     // We may have found multiple failing modules, that failed for different
     // reasons. Emit a note for each of them.
     for (auto &mod : outOfDateModules) {
-      ctx.Diags.diagnose(loc, diag::out_of_date_module_here,
+      diags.diagnose(loc, diag::out_of_date_module_here,
                          (unsigned)mod.kind, mod.path);
 
       // Diagnose any out-of-date dependencies in this module.
       for (auto &dep : mod.outOfDateDependencies) {
-        ctx.Diags.diagnose(loc, diag::module_interface_dependency_out_of_date,
+        diags.diagnose(loc, diag::module_interface_dependency_out_of_date,
                            dep);
       }
 
       // Diagnose any missing dependencies in this module.
       for (auto &dep : mod.missingDependencies) {
-        ctx.Diags.diagnose(loc, diag::module_interface_dependency_missing, dep);
+        diags.diagnose(loc, diag::module_interface_dependency_missing, dep);
       }
 
       // If there was a compiled module that wasn't able to be read, diagnose
       // the reason we couldn't read it.
       if (auto status = mod.serializationStatus) {
         if (auto reason = invalidModuleReason(*status)) {
-          ctx.Diags.diagnose(loc, diag::compiled_module_invalid_reason,
+          diags.diagnose(loc, diag::compiled_module_invalid_reason,
               mod.path, reason);
         } else {
-          ctx.Diags.diagnose(loc, diag::compiled_module_invalid, mod.path);
+          diags.diagnose(loc, diag::compiled_module_invalid, mod.path);
         }
       }
     }
@@ -957,12 +958,33 @@ class ModuleInterfaceLoaderImpl {
     }
 
     std::unique_ptr<llvm::MemoryBuffer> moduleBuffer;
+
     // We didn't discover a module corresponding to this interface.
     // Diagnose that we didn't find a loadable module, if we were asked to.
-    auto remarkRebuild = [&]() {
-      rebuildInfo.diagnose(ctx, diagnosticLoc, moduleName,
-                           interfacePath, prebuiltCacheDir);
+    //
+    // Note that we use `diags` so that we emit this remark even when we're
+    // emitting other messages to `emptyDiags` (see below); these act as status
+    // messages to explain what's taking so long.
+    auto remarkRebuildAll = [&]() {
+      rebuildInfo.diagnose(ctx, diags, prebuiltCacheDir, diagnosticLoc,
+                           diag::rebuilding_module_from_interface, moduleName,
+                           interfacePath);
     };
+    // Diagnose only for the standard library; it should be prebuilt in typical
+    // workflows, but if it isn't, building it may take several minutes and a
+    // lot of memory, so users may think the compiler is busy-hung.
+    auto remarkRebuildStdlib = [&]() {
+      if (moduleName != "Swift")
+        return;
+      
+      auto moduleTriple = getTargetSpecificModuleTriple(ctx.LangOpts.Target);
+      rebuildInfo.diagnose(ctx, diags, prebuiltCacheDir, SourceLoc(),
+                           diag::rebuilding_stdlib_from_interface,
+                           moduleTriple.str());
+    };
+    auto remarkRebuild = Opts.remarkOnRebuildFromInterface
+                       ? llvm::function_ref<void()>(remarkRebuildAll)
+                       : remarkRebuildStdlib;
 
     bool failed = false;
     std::string backupPath = getBackupPublicModuleInterfacePath();
@@ -996,11 +1018,8 @@ class ModuleInterfaceLoaderImpl {
       if (rebuildInfo.sawOutOfDateModule(modulePath))
         builder.addExtraDependency(modulePath);
       failed = builder.buildSwiftModule(cachedOutputPath,
-                                             /*shouldSerializeDeps*/true,
-                                             &moduleBuffer,
-                                             Opts.remarkOnRebuildFromInterface ?
-                                               remarkRebuild:
-                                             llvm::function_ref<void()>());
+                                        /*shouldSerializeDeps*/true,
+                                        &moduleBuffer, remarkRebuild);
     }
     if (!failed) {
       // If succeeded, we are done.
@@ -1033,9 +1052,7 @@ class ModuleInterfaceLoaderImpl {
       // calcualted using the canonical interface file path to make sure we
       // can find it from the canonical interface file.
       auto failedAgain = fallbackBuilder.buildSwiftModule(cachedOutputPath,
-        /*shouldSerializeDeps*/true, &moduleBuffer,
-        Opts.remarkOnRebuildFromInterface ? remarkRebuild:
-                                            llvm::function_ref<void()>());
+          /*shouldSerializeDeps*/true, &moduleBuffer, remarkRebuild);
       if (failedAgain)
         return std::make_error_code(std::errc::invalid_argument);
       assert(moduleBuffer);

--- a/test/ModuleInterface/BadStdlib.swiftinterface
+++ b/test/ModuleInterface/BadStdlib.swiftinterface
@@ -9,7 +9,7 @@
 // other things.)
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: -sdk %/S/Inputs/BadStdlib.sdk -module-cache-path %/t/module-cache -resource-dir %/S/Inputs/BadStdlib.sdk) -compile-module-from-interface -o %/t/BadStdlib.swiftmodule %s -verify -verify-additional-file %/S/Inputs/BadStdlib.sdk/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface
+// RUN: %target-swift-frontend(mock-sdk: -sdk %/S/Inputs/BadStdlib.sdk -module-cache-path %/t/module-cache -resource-dir %/S/Inputs/BadStdlib.sdk) -compile-module-from-interface -o %/t/BadStdlib.swiftmodule %s -verify -verify-additional-file %/S/Inputs/BadStdlib.sdk/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface -verify-ignore-unknown
 
 import ClangMod
 

--- a/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/OtherModule.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/OtherModule.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -target x86_64-apple-macos10.9 -module-name OtherModule -O
+
+import Swift

--- a/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -target x86_64-apple-macos10.9 -module-name Swift -parse-stdlib
+
+public struct Int {}

--- a/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/_Concurrency.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/_Concurrency.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -target x86_64-apple-macos10.9 -module-name _Concurrency -parse-stdlib
+
+@frozen public enum Task {}

--- a/test/ModuleInterface/stdlib_rebuild.swift
+++ b/test/ModuleInterface/stdlib_rebuild.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t.mcps)
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs/stdlib_rebuild -resource-dir %S/Inputs/stdlib_rebuild -module-cache-path %t.mcps/rebuild-remarks-off) -typecheck %s 2>&1 | %FileCheck -check-prefixes SLOW-DIAG,ALL %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs/stdlib_rebuild -resource-dir %S/Inputs/stdlib_rebuild -module-cache-path %t.mcps/rebuild-remarks-off) -typecheck %s 2>&1 | %FileCheck -check-prefixes ALL --allow-empty %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs/stdlib_rebuild -resource-dir %S/Inputs/stdlib_rebuild -module-cache-path %t.mcps/rebuild-remarks-off) -D OTHER_IMPORT -typecheck %s 2>&1 | %FileCheck -check-prefixes ALL --allow-empty %s
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs/stdlib_rebuild -resource-dir %S/Inputs/stdlib_rebuild -module-cache-path %t.mcps/rebuild-remarks-on) -Rmodule-interface-rebuild -typecheck %s 2>&1 | %FileCheck -check-prefixes NORMAL-DIAG,ALL %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs/stdlib_rebuild -resource-dir %S/Inputs/stdlib_rebuild -module-cache-path %t.mcps/rebuild-remarks-on) -Rmodule-interface-rebuild -typecheck %s 2>&1 | %FileCheck -check-prefixes ALL --allow-empty %s
+
+// Our test directory only contains interfaces for x86_64-apple-macos.
+// REQUIRES: CPU=x86_64
+// REQUIRES: OS=macosx
+
+#if OTHER_IMPORT
+import OtherModule
+#endif
+
+func fn(_: Int) {}
+
+// SLOW-DIAG: remark: did not find a prebuilt standard library for target '{{.*}}' compatible with this Swift compiler; building it may take a few minutes, but it should only happen once for this combination of compiler and target
+
+// NORMAL-DIAG-DAG: remark: rebuilding module 'Swift' from interface '{{.*}}'
+// NORMAL-DIAG-DAG: remark: rebuilding module '_Concurrency' from interface '{{.*}}'
+
+// Used even when one of the above ones is also used, since the diagnostics should only be emitted once
+// ALL-NOT: remark: did not find a prebuilt standard library
+// ALL-NOT: remark: rebuilding module '{{Swift|_Concurrency}}' from interface '{{.*}}'


### PR DESCRIPTION
Although users should usually use a prebuilt standard library, in those rare configurations where one needs to be built, the compiler appears to hang for several minutes, even on a trivial compilation. This PR adds a remark that's emitted when this happens, explaining that the standard library is being rebuilt and it will take a few minutes.