### PR TITLE
[5.5][SymbolGraph] Fix a crash for member in invalid extension

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -240,6 +240,12 @@ void SymbolGraph::recordMemberRelationship(Symbol S) {
       if (isRequirementOrDefaultImplementation(S.getSymbolDecl())) {
         return;
       }
+      if (DC->getSelfNominalTypeDecl() == nullptr) {
+        // If we couldn't look up the type the member is declared on (e.g.
+        // because the member is declared in an extension whose extended type
+        // doesn't exist), don't record a memberOf relationship.
+        return;
+      }
       return recordEdge(S,
                         Symbol(this, DC->getSelfNominalTypeDecl(), nullptr),
                         RelationshipKind::MemberOf());

--- a/test/SourceKit/CursorInfo/rdar77234243.swift
+++ b/test/SourceKit/CursorInfo/rdar77234243.swift
@@ -1,0 +1,6 @@
+// RUN: %sourcekitd-test -req=cursor -pos=3:9 -req-opts=retrieve_symbol_graph=1 %s -- %s
+extension NonExistentSymbolName {
+    var myType: String {
+        ""
+    }
+}


### PR DESCRIPTION
Cherry-picks https://github.com/apple/swift/pull/37128.

----------------------

Don’t record a `memberOf` relationship if we couldn’t look up the target, e.g. because the member is declared in an extension whose extended type doesn’t exist.

Resolves rdar://77234243