### PR TITLE
[Serialization] Do not absolute path the serialized line directive

### DIFF
--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -619,10 +619,7 @@ static void writeRawLoc(const ExternalSourceLocs::RawLoc &Loc,
   Writer.write<uint32_t>(Loc.Directive.Offset);
   Writer.write<int32_t>(Loc.Directive.LineOffset);
   Writer.write<uint32_t>(Loc.Directive.Length);
-  llvm::SmallString<128> AbsName = Loc.Directive.Name;
-  if (!AbsName.empty())
-    llvm::sys::fs::make_absolute(AbsName);
-  Writer.write<uint32_t>(Strings.getTextOffset(AbsName.str()));
+  Writer.write<uint32_t>(Strings.getTextOffset(Loc.Directive.Name));
 }
 
 /**

--- a/test/diagnostics/multi-module-diagnostics.swift
+++ b/test/diagnostics/multi-module-diagnostics.swift
@@ -3,6 +3,7 @@ open class ParentClass {
   open func overridableMethodA(param: Int) {}
   open func overridableMethodB(param: Int) {}
   open func overridableMethodC(param: Int) {}
+  open func overridableMethodD(param: Int) {}
 }
 #endif
 
@@ -10,9 +11,10 @@ open class ParentClass {
 open class ParentClass {
 #sourceLocation(file: "doesnotexist.swift", line: 10)
   open func overridableMethodA(param: Int) {}
-#sourceLocation(file: "REPLACEDWITHSED", line: 20)
   open func overridableMethodB(param: Int) {}
+#sourceLocation(file: "REPLACEDWITHSED", line: 20)
   open func overridableMethodC(param: Int) {}
+  open func overridableMethodD(param: Int) {}
 #sourceLocation()
 }
 #endif
@@ -24,6 +26,7 @@ open class SubClass: ParentClass {
   open override func overridableMethodA(param: String) {}
   open override func overridableMethodB(param: String) {}
   open override func overridableMethodC(param: String) {}
+  open override func overridableMethodD(param: String) {}
 }
 #endif
 
@@ -41,6 +44,7 @@ open class SubClass: ParentClass {
 // CHECK-EXISTS: moda.swift:3:13: note
 // CHECK-EXISTS: moda.swift:4:13: note
 // CHECK-EXISTS: moda.swift:5:13: note
+// CHECK-EXISTS: moda.swift:6:13: note
 
 // Removed the underlying file, so should use the generated source instead
 // RUN: mv %t/moda.swift %t/moda.swift-moved
@@ -65,7 +69,8 @@ open class SubClass: ParentClass {
 
 // RUN: cp %t/moda.swift %t/alternative.swift
 // RUN: not %target-swift-frontend -typecheck -I %t/mods -D MODB %s 2>&1 | %FileCheck -check-prefix=CHECK-DIRECTIVE %s
-// CHECK-DIRECTIVE: doesnotexist.swift:10:13: note
+// CHECK-DIRECTIVE: {{^}}doesnotexist.swift:10:13: note
+// CHECK-DIRECTIVE: {{^}}doesnotexist.swift:11:13: note
 // CHECK-DIRECTIVE: alternative.swift:20:13: note
 // CHECK-DIRECTIVE: alternative.swift:21:13: note
 


### PR DESCRIPTION
Line directive paths are used as-is, do not convert them to their
absolute path during serialization.