### PR TITLE
[Refactoring] Improve Void handling for async conversion

### DIFF
--- a/test/refactoring/ConvertAsync/convert_function.swift
+++ b/test/refactoring/ConvertAsync/convert_function.swift
@@ -148,3 +148,51 @@ func asyncUnhandledCompletion(_ completion: (String) -> Void) {
 // ASYNC-UNHANDLED-NEXT: return "bad"
 // ASYNC-UNHANDLED-NEXT: }
 // ASYNC-UNHANDLED-NEXT: }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix VOID-AND-ERROR-HANDLER %s
+func voidAndErrorCompletion(completion: (Void?, Error?) -> Void) {
+  if .random() {
+    completion((), nil) // Make sure we drop the ()
+  } else {
+    completion(nil, CustomError.Bad)
+  }
+}
+// VOID-AND-ERROR-HANDLER:      func voidAndErrorCompletion() async throws {
+// VOID-AND-ERROR-HANDLER-NEXT:   if .random() {
+// VOID-AND-ERROR-HANDLER-NEXT:     return // Make sure we drop the ()
+// VOID-AND-ERROR-HANDLER-NEXT:   } else {
+// VOID-AND-ERROR-HANDLER-NEXT:     throw CustomError.Bad
+// VOID-AND-ERROR-HANDLER-NEXT:   }
+// VOID-AND-ERROR-HANDLER-NEXT: }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix TOO-MUCH-VOID-AND-ERROR-HANDLER %s
+func tooMuchVoidAndErrorCompletion(completion: (Void?, Void?, Error?) -> Void) {
+  if .random() {
+    completion((), (), nil) // Make sure we drop the ()s
+  } else {
+    completion(nil, nil, CustomError.Bad)
+  }
+}
+// TOO-MUCH-VOID-AND-ERROR-HANDLER:      func tooMuchVoidAndErrorCompletion() async throws {
+// TOO-MUCH-VOID-AND-ERROR-HANDLER-NEXT:   if .random() {
+// TOO-MUCH-VOID-AND-ERROR-HANDLER-NEXT:     return // Make sure we drop the ()s
+// TOO-MUCH-VOID-AND-ERROR-HANDLER-NEXT:   } else {
+// TOO-MUCH-VOID-AND-ERROR-HANDLER-NEXT:     throw CustomError.Bad
+// TOO-MUCH-VOID-AND-ERROR-HANDLER-NEXT:   }
+// TOO-MUCH-VOID-AND-ERROR-HANDLER-NEXT: }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix VOID-RESULT-HANDLER %s
+func voidResultCompletion(completion: (Result<Void, Error>) -> Void) {
+  if .random() {
+    completion(.success(())) // Make sure we drop the .success(())
+  } else {
+    completion(.failure(CustomError.Bad))
+  }
+}
+// VOID-RESULT-HANDLER:      func voidResultCompletion() async throws {
+// VOID-RESULT-HANDLER-NEXT:   if .random() {
+// VOID-RESULT-HANDLER-NEXT:     return // Make sure we drop the .success(())
+// VOID-RESULT-HANDLER-NEXT:   } else {
+// VOID-RESULT-HANDLER-NEXT:     throw CustomError.Bad
+// VOID-RESULT-HANDLER-NEXT:   }
+// VOID-RESULT-HANDLER-NEXT: }

--- a/test/refactoring/ConvertAsync/convert_result.swift
+++ b/test/refactoring/ConvertAsync/convert_result.swift
@@ -2,6 +2,14 @@ func simple(_ completion: (Result<String, Error>) -> Void) { }
 func noError(_ completion: (Result<String, Never>) -> Void) { }
 func test(_ str: String) -> Bool { return false }
 
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix VOID-RESULT %s
+func voidResult(completion: (Result<Void, Never>) -> Void) {}
+// VOID-RESULT: func voidResult() async {}
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix VOID-AND-ERROR-RESULT %s
+func voidAndErrorResult(completion: (Result<Void, Error>) -> Void) {}
+// VOID-AND-ERROR-RESULT: func voidAndErrorResult() async throws {}
+
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=SIMPLE %s
 simple { res in
   print("result \(res)")
@@ -301,3 +309,16 @@ simple { res in
 // NESTEDBREAK-NEXT: print("after")
 // NESTEDBREAK-NOT: }
 
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=VOID-RESULT-CALL %s
+voidResult { res in
+  print(res)
+}
+// VOID-RESULT-CALL: {{^}}await voidResult()
+// VOID-RESULT-CALL: {{^}}print(<#res#>)
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=VOID-AND-ERROR-RESULT-CALL %s
+voidAndErrorResult { res in
+  print(res)
+}
+// VOID-AND-ERROR-RESULT-CALL: {{^}}try await voidAndErrorResult()
+// VOID-AND-ERROR-RESULT-CALL: {{^}}print(<#res#>)


### PR DESCRIPTION
When converting a function with a completion handler that has a Void success parameter, e.g `(Void?, Error?) -> Void`, or more likely a `Result<Void, Error>` parameter, make sure to omit the `-> Void` from the resulting async function conversion.

In addition, strip any Void bindings from an async function call, and any explicit Void return values from inside the async function.

Resolves rdar://75189289
