### PR TITLE
[SymbolGraph] Fix crasher when retrieving cursor info of method defined in ObjC

### DIFF
--- a/lib/SymbolGraphGen/JSON.h
+++ b/lib/SymbolGraphGen/JSON.h
@@ -43,6 +43,7 @@ void serialize(const llvm::Triple &T, llvm::json::OStream &OS);
 void serialize(const ExtensionDecl *Extension, llvm::json::OStream &OS);
 void serialize(const Requirement &Req, llvm::json::OStream &OS);
 void serialize(const swift::GenericTypeParamType *Param, llvm::json::OStream &OS);
+void serialize(const ModuleDecl &M, llvm::json::OStream &OS, llvm::Triple Target);
 
 void filterGenericParams(
     TypeArrayView<GenericTypeParamType> GenericParams,

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -17,9 +17,7 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/USRGeneration.h"
 #include "swift/Basic/Version.h"
-#include "swift/ClangImporter/ClangModule.h"
 #include "swift/Sema/IDETypeChecking.h"
-#include "swift/Serialization/SerializedModuleLoader.h"
 
 #include "DeclarationFragmentPrinter.h"
 #include "FormatVersion.h"
@@ -524,38 +522,7 @@ void SymbolGraph::serialize(llvm::json::OStream &OS) {
       }
       AttributeRAII Platform("platform", OS);
 
-      auto *MainFile = M.getFiles().front();
-      switch (MainFile->getKind()) {
-          case FileUnitKind::Builtin:
-            llvm_unreachable("Unexpected module kind: Builtin");
-          case FileUnitKind::DWARFModule:
-            llvm_unreachable("Unexpected module kind: DWARFModule");
-          case FileUnitKind::Synthesized:
-            llvm_unreachable("Unexpected module kind: Synthesized");
-            break;
-          case FileUnitKind::Source:
-            symbolgraphgen::serialize(M.getASTContext().LangOpts.Target, OS);
-            break;
-          case FileUnitKind::SerializedAST: {
-            auto SerializedAST = cast<SerializedASTFile>(MainFile);
-            auto Target = llvm::Triple(SerializedAST->getTargetTriple());
-            symbolgraphgen::serialize(Target, OS);
-            break;
-          }
-          case FileUnitKind::ClangModule: {
-            auto ClangModule = cast<ClangModuleUnit>(MainFile);
-            if (const auto *Overlay = ClangModule->getOverlayModule()) {
-              auto &OverlayMainFile =
-                  Overlay->getMainFile(FileUnitKind::SerializedAST);
-              auto SerializedAST = cast<SerializedASTFile>(OverlayMainFile);
-              auto Target = llvm::Triple(SerializedAST.getTargetTriple());
-              symbolgraphgen::serialize(Target, OS);
-            } else {
-              symbolgraphgen::serialize(Walker.Options.Target, OS);
-            }
-            break;
-        }
-      }
+      symbolgraphgen::serialize(M, OS, Walker.Options.Target);
     });
 
     if (ModuleVersion) {

--- a/test/SourceKit/CursorInfo/Inputs/mixed_framework/MixedFramework.framework/Headers/MixedFramework.h
+++ b/test/SourceKit/CursorInfo/Inputs/mixed_framework/MixedFramework.framework/Headers/MixedFramework.h
@@ -1,0 +1,3 @@
+@interface MyObjcType
+- (void)foo;
+@end

--- a/test/SourceKit/CursorInfo/Inputs/mixed_framework/MixedFramework.framework/Modules/module.modulemap
+++ b/test/SourceKit/CursorInfo/Inputs/mixed_framework/MixedFramework.framework/Modules/module.modulemap
@@ -1,0 +1,6 @@
+framework module MixedFramework {
+  umbrella header "MixedFramework.h"
+
+  export *
+  module * { export * }
+}

--- a/test/SourceKit/CursorInfo/mixed_framework.swift
+++ b/test/SourceKit/CursorInfo/mixed_framework.swift
@@ -1,0 +1,9 @@
+// RUN: %empty-directory(%t.mcp)
+
+public class MySwiftType {
+    public func bar(x: MyObjcType) {
+// Check that we don't crash
+// RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):11 -req-opts=retrieve_symbol_graph=1 %s -- -module-name MixedFramework -F %S/Inputs/mixed_framework -import-underlying-module -module-cache-path %t.mcp %s
+        x.foo()
+    }
+}


### PR DESCRIPTION
In a mixed Objective-C / Swift module, we have a Clang module overlay that’s a Source file, not a serialized AST as is currently assumed. That assumption caused a crash when retrieving the symbol graph as part of a cursor info request to SourceKit, which was invoked on a method defined in the Objective-C part of the module.

To fix the crash, recursively use the same logic that already exists to serialize a module to also serialize the clang overlay module since that function already correctly handles the distinction between source files and serialized ASTs.