### PR TITLE
Disable swift function merging for swift async functions

### DIFF
--- a/lib/LLVMPasses/LLVMMergeFunctions.cpp
+++ b/lib/LLVMPasses/LLVMMergeFunctions.cpp
@@ -664,6 +664,9 @@ static bool isEligibleFunction(Function *F) {
 
   if (F->getFunctionType()->isVarArg())
     return false;
+
+  if (F->getCallingConv() == CallingConv::SwiftTail)
+    return false;
   
   unsigned Benefit = getBenefit(F);
   if (Benefit < FunctionMergeThreshold)

--- a/test/Concurrency/Runtime/checked_continuation.swift
+++ b/test/Concurrency/Runtime/checked_continuation.swift
@@ -41,6 +41,30 @@ struct TestError: Error {}
         }
         await task.get()
       }
+
+      tests.test("test withCheckedThrowingContinuation") {
+        let task2 = detach {
+          do {
+            let x: Int = try await withCheckedThrowingContinuation { c in
+              c.resume(returning: 17)
+            }
+            expectEqual(17, x)
+          } catch {
+          }
+        }
+
+        let task = detach {
+          do {
+            let x: Int = try await withCheckedThrowingContinuation { c in
+              c.resume(returning: 17)
+            }
+            expectEqual(17, x)
+          } catch {
+          }
+        }
+        await task.get()
+        await task2.get()
+      }
     }
 
     await runAllTestsAsync()


### PR DESCRIPTION
It breaks withCheckedContinuation.

I have not gotten to the bottom of why. But for now disable the pass for
all async functions until we can fix it.

rdar://77166575