### PR TITLE
Don't Force the Interface Type While Checking Isolation

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2558,7 +2558,8 @@ static Optional<ActorIsolation> getIsolationFromConformances(
     return None;
 
   Optional<ActorIsolation> foundIsolation;
-  for (auto proto : nominal->getLocalProtocols()) {
+  for (auto proto :
+       nominal->getLocalProtocols(ConformanceLookupKind::NonStructural)) {
     switch (auto protoIsolation = getActorIsolation(proto)) {
     case ActorIsolation::ActorInstance:
     case ActorIsolation::Unspecified:

--- a/test/Concurrency/Inputs/sendable_cycle_other.swift
+++ b/test/Concurrency/Inputs/sendable_cycle_other.swift
@@ -1,0 +1,3 @@
+struct Foo {
+  static let member = Bar()
+}

--- a/test/Concurrency/sendable_cycle.swift
+++ b/test/Concurrency/sendable_cycle.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift %S/Inputs/sendable_cycle_other.swift -enable-experimental-concurrency
+// REQUIRES: concurrency
+
+struct Bar {
+  lazy var foo = {
+    self.x()
+  }
+
+  func x() -> Int { 42 }
+}

--- a/test/Sema/option-set-empty.swift
+++ b/test/Sema/option-set-empty.swift
@@ -1,8 +1,6 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
 struct SomeOptions: OptionSet {
-  // expected-error@-1{{circular reference}}
-  // expected-note@-2 2{{through reference here}}
     var rawValue: Int
     
     static let some = MyOptions(rawValue: 4)
@@ -12,7 +10,6 @@ struct SomeOptions: OptionSet {
     let someVal = MyOptions(rawValue: 6)
     let option = MyOptions(float: Float.infinity)
     let none = SomeOptions(rawValue: 0) // expected-error {{value type 'SomeOptions' cannot have a stored property that recursively contains it}}
-  // expected-note@-1 3{{through reference here}}
 }
 
 struct MyOptions: OptionSet {


### PR DESCRIPTION
Asking for Sendable conformances on this path is going to lead to
a traversal of the stored properties of the type. If there is an
interface type computation ongoing, as is very likely the case, this
traversal can wind up causing a cycle when it forces the interface type
of a member once again.

Request only the non-structural conformances to break the cycle.

rdar://77189542