### PR TITLE
[5.5] [AST] Mark @completionHandlerAsync user-inaccessible

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -625,7 +625,7 @@ SIMPLE_DECL_ATTR(reasync, AtReasync,
   110)
 
 DECL_ATTR(completionHandlerAsync, CompletionHandlerAsync,
-  OnAbstractFunction | ConcurrencyOnly | LongAttribute |
+  OnAbstractFunction | ConcurrencyOnly | LongAttribute | UserInaccessible |
   ABIStableToAdd | ABIStableToRemove |
   APIStableToAdd | APIStableToRemove,
   111)

--- a/test/IDE/print_objc_concurrency_interface.swift
+++ b/test/IDE/print_objc_concurrency_interface.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -print-interface -source-filename %s -module-to-print=ObjCConcurrency -function-definitions=false -enable-experimental-concurrency | %FileCheck %s
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+import _Concurrency
+
+// CHECK-LABEL: class SlowServer : NSObject, ServiceProvider {
+
+// rdar://76685011: Make sure we don't print @completionHandlerAsync in generated interfaces.
+// CHECK-NOT: @completionHandlerAsync
+// CHECK: func doSomethingSlow(_ operation: String, completionHandler handler: @escaping (Int) -> Void)
+// CHECK: func doSomethingSlow(_ operation: String) async -> Int


### PR DESCRIPTION
*5.5 cherry-pick of https://github.com/apple/swift/pull/37146*

---

This attribute is only really useful to the compiler, so don't expose it to the user through e.g generated interfaces.

Resolves rdar://76685011