### PR TITLE
Fix Windows build

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -17,6 +17,14 @@
 
 #include "swift/Runtime/Concurrency.h"
 
+#ifdef _WIN32
+// On Windows, an include below triggers an indirect include of minwindef.h
+// which contains a definition of the `max` macro, generating an error in our
+// use of std::max in this file. This define prevents those macros from being
+// defined.
+#define NOMINMAX
+#endif
+
 #include "../CompatibilityOverride/CompatibilityOverride.h"
 #include "../runtime/ThreadLocalStorage.h"
 #include "swift/Runtime/Atomic.h"


### PR DESCRIPTION
```
S:\jenkins\workspace\swift-PR-windows\swift\stdlib\public\Concurrency\Actor.cpp(1612,22): error: expected unqualified-id
              : std::max(oldPriority, job->getPriority());
                     ^
C:\Program Files (x86)\Windows Kits\10\\Include\10.0.18362.0\shared\minwindef.h(193,29): note: expanded from macro max
#define max(a,b)            (((a) > (b)) ? (a) : (b))
                            ^
1 error generated.
```
