### PR TITLE
[5.5][Property Wrappers] Always make sure the storage for a wrapped parameter is immutable.

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2776,8 +2776,9 @@ PropertyWrapperAuxiliaryVariablesRequest::evaluate(Evaluator &evaluator,
     backingVar = ParamDecl::cloneWithoutType(ctx, param);
     backingVar->setName(name);
   } else {
+    auto introducer = isa<ParamDecl>(var) ? VarDecl::Introducer::Let : VarDecl::Introducer::Var;
     backingVar = new (ctx) VarDecl(/*IsStatic=*/var->isStatic(),
-                                   VarDecl::Introducer::Var,
+                                   introducer,
                                    var->getLoc(),
                                    name, dc);
     backingVar->setImplicit();

--- a/test/SILGen/property_wrapper_parameter.swift
+++ b/test/SILGen/property_wrapper_parameter.swift
@@ -123,28 +123,28 @@ class ClassWrapper<Value> {
 
 // CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2ySS_SitF : $@convention(thin) (@guaranteed String, Int) -> ()
 func testNonMutatingSetter(@NonMutatingSetterWrapper value1: String, @ClassWrapper value2: Int) {
-  // CHECK: alloc_box ${ var NonMutatingSetterWrapper<String> }, var, name "_value1"
   // CHECK: function_ref @$s26property_wrapper_parameter24NonMutatingSetterWrapperV12wrappedValueACyxGx_tcfC : $@convention(method) <τ_0_0> (@in τ_0_0, @thin NonMutatingSetterWrapper<τ_0_0>.Type) -> @out NonMutatingSetterWrapper<τ_0_0>
-  // CHECK: alloc_box ${ var ClassWrapper<Int> }, var, name "_value2"
+  // CHECK: debug_value {{.*}} : $NonMutatingSetterWrapper<String>, let, name "_value1"
   // CHECK: function_ref @$s26property_wrapper_parameter12ClassWrapperC12wrappedValueACyxGx_tcfC : $@convention(method) <τ_0_0> (@in τ_0_0, @thick ClassWrapper<τ_0_0>.Type) -> @owned ClassWrapper<τ_0_0>
+  // CHECK: debug_value {{.*}} : $ClassWrapper<Int>, let, name "_value2"
 
   _ = value1
   value1 = "hello!"
 
   // getter of value1 #1 in testNonMutatingSetter(value1:value2:)
-  // CHECK: sil private [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2ySS_SitFACL_SSvg : $@convention(thin) (@guaranteed { var NonMutatingSetterWrapper<String> }) -> @owned String
+  // CHECK: sil private [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2ySS_SitFACL_SSvg : $@convention(thin) (@guaranteed NonMutatingSetterWrapper<String>) -> @owned String
 
   // setter of value1 #1 in testNonMutatingSetter(value1:value2:)
-  // CHECK: sil private [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2ySS_SitFACL_SSvs : $@convention(thin) (@owned String, @guaranteed { var NonMutatingSetterWrapper<String> }) -> ()
+  // CHECK: sil private [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2ySS_SitFACL_SSvs : $@convention(thin) (@owned String, @guaranteed NonMutatingSetterWrapper<String>) -> ()
 
   _ = value2
   value2 = 10
 
   // getter of value2 #1 in testNonMutatingSetter(value1:value2:)
-  // CHECK: sil private [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2ySS_SitFADL_Sivg : $@convention(thin) (@guaranteed { var ClassWrapper<Int> }) -> Int
+  // CHECK: sil private [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2ySS_SitFADL_Sivg : $@convention(thin) (@guaranteed ClassWrapper<Int>) -> Int
 
   // setter of value2 #1 in testNonMutatingSetter(value1:value2:)
-  // CHECK: sil private [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2ySS_SitFADL_Sivs : $@convention(thin) (Int, @guaranteed { var ClassWrapper<Int> }) -> ()
+  // CHECK: sil private [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2ySS_SitFADL_Sivs : $@convention(thin) (Int, @guaranteed ClassWrapper<Int>) -> ()
 }
 
 @propertyWrapper

--- a/test/Sema/property_wrapper_parameter_invalid.swift
+++ b/test/Sema/property_wrapper_parameter_invalid.swift
@@ -144,6 +144,12 @@ struct InternalWrapper<T> { // expected-note 3 {{type declared here}}
   init(wrappedValue: T) { self.wrappedValue = wrappedValue }
 }
 
+func testWrapperStorageMutability(@InternalWrapper value: Int) {
+  _ = _value
+  // expected-error@+1 {{cannot assign to value: '_value' is immutable}}
+  _value = InternalWrapper(wrappedValue: 10)
+}
+
 // expected-error@+1 {{function cannot be declared public because its parameter uses an internal API wrapper type}}
 public func testComposition1(@PublicWrapper @InternalWrapper value: Int) {}
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/37143

---
This is a missing detail from SE-0293. The mutability of implementation-detail property wrappers is specified [here](https://github.com/apple/swift-evolution/blob/main/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md#implementation-detail-property-wrappers):

> A local let-constant representing the backing storage will be synthesized with the name of the parameter prefixed with an underscore. The backing storage is initialized by passing the parameter to init(wrappedValue:).

Resolves: rdar://77337477