### PR TITLE
[5.5][CodeCompletion] Prioritize call argument pattern

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1294,8 +1294,8 @@ CodeCompletionResult *CodeCompletionResultBuilder::takeResult() {
     }
 
     return new (*Sink.Allocator) CodeCompletionResult(
-        SemanticContext, NumBytesToErase, CCS, AssociatedDecl, ModuleName,
-        NotRecReason, copyString(*Sink.Allocator, BriefComment),
+        SemanticContext, IsArgumentLabels, NumBytesToErase, CCS, AssociatedDecl,
+        ModuleName, NotRecReason, copyString(*Sink.Allocator, BriefComment),
         copyAssociatedUSRs(*Sink.Allocator, AssociatedDecl),
         copyArray(*Sink.Allocator, CommentWords), ExpectedTypeRelation);
   }
@@ -1303,22 +1303,22 @@ CodeCompletionResult *CodeCompletionResultBuilder::takeResult() {
   case CodeCompletionResult::ResultKind::Keyword:
     return new (*Sink.Allocator)
         CodeCompletionResult(
-          KeywordKind, SemanticContext, NumBytesToErase,
+          KeywordKind, SemanticContext, IsArgumentLabels, NumBytesToErase,
           CCS, ExpectedTypeRelation,
           copyString(*Sink.Allocator, BriefDocComment));
 
   case CodeCompletionResult::ResultKind::BuiltinOperator:
   case CodeCompletionResult::ResultKind::Pattern:
     return new (*Sink.Allocator) CodeCompletionResult(
-        Kind, SemanticContext, NumBytesToErase, CCS, ExpectedTypeRelation,
-        CodeCompletionOperatorKind::None,
+        Kind, SemanticContext, IsArgumentLabels, NumBytesToErase, CCS,
+        ExpectedTypeRelation, CodeCompletionOperatorKind::None,
         copyString(*Sink.Allocator, BriefDocComment));
 
   case CodeCompletionResult::ResultKind::Literal:
     assert(LiteralKind.hasValue());
     return new (*Sink.Allocator)
-        CodeCompletionResult(*LiteralKind, SemanticContext, NumBytesToErase,
-                             CCS, ExpectedTypeRelation);
+        CodeCompletionResult(*LiteralKind, SemanticContext, IsArgumentLabels,
+                             NumBytesToErase, CCS, ExpectedTypeRelation);
   }
 
   llvm_unreachable("Unhandled CodeCompletionResult in switch.");
@@ -2895,6 +2895,7 @@ public:
               : CodeCompletionResult::ResultKind::Pattern,
           SemanticContext ? *SemanticContext : getSemanticContextKind(AFD),
           expectedTypeContext);
+      Builder.setIsArgumentLabels();
       if (AFD) {
         Builder.setAssociatedDecl(AFD);
         setClangDeclKeywords(AFD, Pairs, Builder);

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -228,15 +228,16 @@ static bool readCachedModule(llvm::MemoryBuffer *in,
     CodeCompletionResult *result = nullptr;
     if (kind == CodeCompletionResult::Declaration) {
       result = new (*V.Sink.Allocator) CodeCompletionResult(
-          context, numBytesToErase, string, declKind, isSystem, moduleName,
-          notRecommended, briefDocComment,
+          context, /*IsArgumentLabels=*/false, numBytesToErase, string,
+          declKind, isSystem, moduleName, notRecommended, briefDocComment,
           copyArray(*V.Sink.Allocator, ArrayRef<StringRef>(assocUSRs)),
           copyArray(*V.Sink.Allocator,
                     ArrayRef<std::pair<StringRef, StringRef>>(declKeywords)),
           CodeCompletionResult::Unknown, opKind);
     } else {
       result = new (*V.Sink.Allocator)
-          CodeCompletionResult(kind, context, numBytesToErase, string,
+          CodeCompletionResult(kind, context, /*IsArgumentLabels=*/false,
+                               numBytesToErase, string,
                                CodeCompletionResult::NotApplicable, opKind);
     }
 
@@ -340,6 +341,7 @@ static void writeCachedModule(llvm::raw_ostream &out,
   {
     endian::Writer LE(results, little);
     for (CodeCompletionResult *R : V.Sink.Results) {
+      assert(!R->isArgumentLabels() && "Argument labels should not be cached");
       // FIXME: compress bitfield
       LE.write(static_cast<uint8_t>(R->getKind()));
       if (R->getKind() == CodeCompletionResult::Declaration)

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -87,6 +87,7 @@ class CodeCompletionResultBuilder {
   ExpectedTypeContext declTypeContext;
   CodeCompletionResult::ExpectedTypeRelation ExpectedTypeRelation =
       CodeCompletionResult::Unknown;
+  bool IsArgumentLabels = false;
   bool Cancelled = false;
   ArrayRef<std::pair<StringRef, StringRef>> CommentWords;
   CodeCompletionResult::NotRecommendedReason NotRecReason =
@@ -152,6 +153,10 @@ public:
 
   void setSemanticContext(SemanticContextKind Kind) {
     SemanticContext = Kind;
+  }
+
+  void setIsArgumentLabels(bool Flag = true) {
+    IsArgumentLabels = Flag;
   }
 
   void

--- a/test/SourceKit/CodeComplete/complete_sort_order.swift
+++ b/test/SourceKit/CodeComplete/complete_sort_order.swift
@@ -220,3 +220,26 @@ func test7() {
 // CASE_0: caseSensitiveCheck
 // CASE_0: CaseSensitiveCheck(
 // CASE_0: ]
+
+// RUN: %complete-test -tok=CALLARG_1 %s | %FileCheck %s -check-prefix=CALLARG
+// RUN: %complete-test -tok=CALLARG_2 %s | %FileCheck %s -check-prefix=CALLARG
+func test8() {
+    struct CallArgumentTest {
+        init(_ arg: String) {}
+        init(label arg: Int) {}
+        func argTest(_ arg: String) {}
+        func argTest(label arg: Int) {}
+    }
+    var stringVal: String = "";
+    var intVal: Int = 1
+
+    _ = CallArgumentTest(#^CALLARG_1^#)
+    func methodTest(obj: CallArgumentTest) {
+      obj.argTest(#^CALLARG_2^#)
+    }
+// CALLARG: (arg: String)
+// CALLARG: (label: Int)
+// CALLARG: stringVal
+// CALLARG: String
+// CALLARG: intVal
+}

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -158,7 +158,7 @@ bool SourceKit::CodeCompletion::addCustomCompletions(
     CodeCompletion::SwiftResult swiftResult(
         CodeCompletion::SwiftResult::ResultKind::Pattern,
         SemanticContextKind::ExpressionSpecific,
-        /*NumBytesToErase=*/0, completionString,
+        /*IsArgumentLabels=*/false, /*NumBytesToErase=*/0, completionString,
         CodeCompletionResult::ExpectedTypeRelation::Unknown);
 
     CompletionBuilder builder(sink, swiftResult);
@@ -666,6 +666,9 @@ static ResultBucket getResultBucket(Item &item, bool hasRequiredTypes,
       !skipMetaGroups)
     return ResultBucket::ExpressionSpecific;
 
+  if (completion->isArgumentLabels() && !skipMetaGroups)
+    return ResultBucket::ExpressionSpecific;
+
   if (completion->isOperator())
     return ResultBucket::Operator;
 
@@ -1167,13 +1170,15 @@ Completion *CompletionBuilder::finish() {
 
     if (current.getKind() == SwiftResult::Declaration) {
       base = SwiftResult(
-          semanticContext, current.getNumBytesToErase(), completionString,
+          semanticContext, current.isArgumentLabels(),
+          current.getNumBytesToErase(), completionString,
           current.getAssociatedDeclKind(), current.isSystem(),
           current.getModuleName(), current.getNotRecommendedReason(),
           current.getBriefDocComment(), current.getAssociatedUSRs(),
           current.getDeclKeywords(), typeRelation, opKind);
     } else {
       base = SwiftResult(current.getKind(), semanticContext,
+                         current.isArgumentLabels(),
                          current.getNumBytesToErase(), completionString,
                          typeRelation, opKind);
     }

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -912,7 +912,7 @@ static void transformAndForwardResults(
         CodeCompletionString::create(innerSink.allocator, chunks);
     CodeCompletion::SwiftResult paren(
         CodeCompletion::SwiftResult::ResultKind::BuiltinOperator,
-        SemanticContextKind::ExpressionSpecific,
+        SemanticContextKind::ExpressionSpecific, /*IsArgumentLabels=*/false,
         exactMatch ? exactMatch->getNumBytesToErase() : 0, completionString,
         CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
 


### PR DESCRIPTION
Cherry-pick #37144 into `release/5.5` reviewed by @benlangmuir 

---

```swift
  struct Foo {
    init(_ arg1: String, arg2: Int) {}
    init(label: Int) {}
  }
  func test(strVal: String) {
    _ = Foo(<HERE>)
  }
```

In this case, `strVal` was prioritized because it can be use as an argument for `init(_:arg2:)`. However, argument labels are almost always preferable, and if the user actually want `strVal`, they can input a few characters to get it at the top. So we should always prioritize call argument patterns.

rdar://77188260
