### PR TITLE
GSB: New algorithm for computing redundant requirements

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -723,12 +723,6 @@ private:
                             TypeArrayView<GenericTypeParamType> genericParams,
                             EquivalenceClass *equivClass);
 
-  /// Check conformance constraints within the equivalence class of the
-  /// given potential archetype.
-  void checkConformanceConstraints(
-                            TypeArrayView<GenericTypeParamType> genericParams,
-                            EquivalenceClass *equivClass);
-
   /// Check same-type constraints within the equivalence class of the
   /// given potential archetype.
   void checkSameTypeConstraints(

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -654,11 +654,27 @@ public:
   bool isRedundantExplicitRequirement(const ExplicitRequirement &req) const;
 
 private:
-  void computeRedundantRequirements(const ProtocolDecl *requirementSignatureSelfProto);
+  using GetKindAndRHS = llvm::function_ref<std::pair<RequirementKind, RequirementRHS>()>;
+  void getBaseRequirements(
+      GetKindAndRHS getKindAndRHS,
+      const RequirementSource *source,
+      const ProtocolDecl *requirementSignatureSelfProto,
+      ASTContext &ctx, SmallVectorImpl<ExplicitRequirement> &result);
+
+  template<typename T, typename Filter>
+  void checkRequirementRedundancy(
+      const ExplicitRequirement &req,
+      const std::vector<Constraint<T>> &constraints,
+      const ProtocolDecl *requirementSignatureSelfProto,
+      Filter filter);
+
+  void computeRedundantRequirements(
+      const ProtocolDecl *requirementSignatureSelfProto);
 
   void diagnoseRedundantRequirements() const;
 
-  void diagnoseConflictingConcreteTypeRequirements() const;
+  void diagnoseConflictingConcreteTypeRequirements(
+      const ProtocolDecl *requirementSignatureSelfProto);
 
   /// Describes the relationship between a given constraint and
   /// the canonical constraint of the equivalence class.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -723,22 +723,11 @@ private:
                             TypeArrayView<GenericTypeParamType> genericParams,
                             EquivalenceClass *equivClass);
 
-  /// Check the superclass constraints within the equivalence
-  /// class of the given potential archetype.
-  void checkSuperclassConstraints(
-                            TypeArrayView<GenericTypeParamType> genericParams,
-                            EquivalenceClass *equivClass);
-
   /// Check conformance constraints within the equivalence class of the
   /// given potential archetype.
   void checkConformanceConstraints(
                             TypeArrayView<GenericTypeParamType> genericParams,
                             EquivalenceClass *equivClass);
-
-  /// Check layout constraints within the equivalence class of the given
-  /// potential archetype.
-  void checkLayoutConstraints(TypeArrayView<GenericTypeParamType> genericParams,
-                              EquivalenceClass *equivClass);
 
   /// Check same-type constraints within the equivalence class of the
   /// given potential archetype.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1241,8 +1241,7 @@ public:
   /// requirement redundant, because without said original requirement, the
   /// derived requirement ceases to hold.
   bool isSelfDerivedSource(GenericSignatureBuilder &builder,
-                           Type type,
-                           bool &derivedViaConcrete) const;
+                           Type type) const;
 
   /// For a requirement source that describes the requirement \c type:proto,
   /// retrieve the minimal subpath of this requirement source that will
@@ -1254,8 +1253,7 @@ public:
   const RequirementSource *getMinimalConformanceSource(
                                             GenericSignatureBuilder &builder,
                                             Type type,
-                                            ProtocolDecl *proto,
-                                            bool &derivedViaConcrete) const;
+                                            ProtocolDecl *proto) const;
 
   /// Retrieve a source location that corresponds to the requirement.
   SourceLoc getLoc() const;

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -224,6 +224,10 @@ FRONTEND_STATISTIC(Sema, NumAccessorBodiesSynthesized)
 /// amount of work the GSB does analyzing type signatures.
 FRONTEND_STATISTIC(Sema, NumGenericSignatureBuilders)
 
+/// Number of steps in the GSB's redundant requirements algorithm, which is in
+/// the worst-case exponential.
+FRONTEND_STATISTIC(Sema, NumRedundantRequirementSteps)
+
 /// Number of conformance access paths we had to compute.
 FRONTEND_STATISTIC(Sema, NumConformanceAccessPathsRecorded)
 

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -224,6 +224,9 @@ FRONTEND_STATISTIC(Sema, NumAccessorBodiesSynthesized)
 /// amount of work the GSB does analyzing type signatures.
 FRONTEND_STATISTIC(Sema, NumGenericSignatureBuilders)
 
+/// Number of conformance access paths we had to compute.
+FRONTEND_STATISTIC(Sema, NumConformanceAccessPathsRecorded)
+
 /// Number of lazy requirement signatures registered.
 FRONTEND_STATISTIC(Sema, NumLazyRequirementSignatures)
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -6380,13 +6380,10 @@ GenericSignatureBuilder::finalize(TypeArrayView<GenericTypeParamType> genericPar
         }
 
         equivClass.recursiveSuperclassType = true;
-      } else {
-        checkSuperclassConstraints(genericParams, &equivClass);
       }
     }
 
     checkConformanceConstraints(genericParams, &equivClass);
-    checkLayoutConstraints(genericParams, &equivClass);
   };
 
   if (!Impl->ExplicitSameTypeRequirements.empty()) {
@@ -7924,22 +7921,6 @@ void GenericSignatureBuilder::checkConcreteTypeConstraints(
     diag::same_type_conflict,
     diag::redundant_same_type_to_concrete,
     diag::same_type_redundancy_here);
-}
-
-void GenericSignatureBuilder::checkSuperclassConstraints(
-                              TypeArrayView<GenericTypeParamType> genericParams,
-                              EquivalenceClass *equivClass) {
-  assert(equivClass->superclass && "No superclass constraint?");
-
-  removeSelfDerived(*this, equivClass->superclassConstraints, /*proto=*/nullptr);
-}
-
-void GenericSignatureBuilder::checkLayoutConstraints(
-                              TypeArrayView<GenericTypeParamType> genericParams,
-                              EquivalenceClass *equivClass) {
-  if (!equivClass->layout) return;
-
-  removeSelfDerived(*this, equivClass->layoutConstraints, /*proto=*/nullptr);
 }
 
 bool GenericSignatureBuilder::isRedundantExplicitRequirement(

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -5129,7 +5129,7 @@ GenericSignatureBuilder::addSameTypeRequirementBetweenTypeParameters(
       updateLayout(T1, equivClass2->layout);
       equivClass->layoutConstraints.insert(
                                    equivClass->layoutConstraints.end(),
-                                   equivClass2->layoutConstraints.begin() + 1,
+                                   equivClass2->layoutConstraints.begin(),
                                    equivClass2->layoutConstraints.end());
     }
   }

--- a/test/Generics/concrete_same_type_versus_anyobject.swift
+++ b/test/Generics/concrete_same_type_versus_anyobject.swift
@@ -30,3 +30,13 @@ extension G2 where U == C, U : AnyObject {}
 extension G2 where U : C, U : AnyObject {}
 // expected-warning@-1 {{redundant constraint 'U' : 'AnyObject'}}
 // expected-note@-2 {{constraint 'U' : 'AnyObject' implied here}}
+
+// Explicit AnyObject conformance vs derived same-type
+protocol P {
+  associatedtype A where A == C
+}
+
+// CHECK-LABEL: Generic signature: <T where T : P>
+func explicitAnyObjectIsRedundant<T : P>(_: T) where T.A : AnyObject {}
+// expected-warning@-1 {{redundant constraint 'T.A' : 'AnyObject'}}
+// expected-note@-2 {{constraint 'T.A' : 'AnyObject' implied here}}

--- a/test/Generics/derived_via_concrete.swift
+++ b/test/Generics/derived_via_concrete.swift
@@ -1,0 +1,67 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -debug-generic-signatures -typecheck %s 2>&1 | %FileCheck %s
+
+protocol P {}
+class C {}
+
+class X<T : P> : U {}
+class Y<T : C> : V {}
+class Z<T : AnyObject> : W {}
+
+protocol U {
+  associatedtype T : P
+}
+
+protocol V {
+  associatedtype T : C
+}
+
+protocol W {
+  associatedtype T : AnyObject
+}
+
+// CHECK: Generic signature: <A, B where A : X<B>, B : P>
+func derivedViaConcreteX1<A, B>(_: A, _: B)
+  where A : U, A : X<B> {}
+// expected-warning@-1 {{redundant conformance constraint 'A' : 'U'}}
+// expected-note@-2 {{conformance constraint 'A' : 'U' implied here}}
+
+// FIXME: We should not diagnose 'B : P' as redundant, even though it
+// really is, because it was made redundant by an inferred requirement.
+
+// CHECK: Generic signature: <A, B where A : X<B>, B : P>
+func derivedViaConcreteX2<A, B>(_: A, _: B)
+  where A : U, B : P, A : X<B> {}
+// expected-warning@-1 {{redundant conformance constraint 'A' : 'U'}}
+// expected-note@-2 {{conformance constraint 'A' : 'U' implied here}}
+// expected-warning@-3 {{redundant conformance constraint 'B' : 'P'}}
+// expected-note@-4 {{conformance constraint 'B' : 'P' implied here}}
+
+// CHECK: Generic signature: <A, B where A : Y<B>, B : C>
+func derivedViaConcreteY1<A, B>(_: A, _: B)
+  where A : V, A : Y<B> {}
+// expected-warning@-1 {{redundant conformance constraint 'A' : 'V'}}
+// expected-note@-2 {{conformance constraint 'A' : 'V' implied here}}
+
+// FIXME: We should not diagnose 'B : C' as redundant, even though it
+// really is, because it was made redundant by an inferred requirement.
+
+// CHECK: Generic signature: <A, B where A : Y<B>, B : C>
+func derivedViaConcreteY2<A, B>(_: A, _: B)
+  where A : V, B : C, A : Y<B> {}
+// expected-warning@-1 {{redundant conformance constraint 'A' : 'V'}}
+// expected-note@-2 {{conformance constraint 'A' : 'V' implied here}}
+// expected-warning@-3 {{redundant superclass constraint 'B' : 'C'}}
+// expected-note@-4 {{superclass constraint 'B' : 'C' implied here}}
+
+// CHECK: Generic signature: <A, B where A : Z<B>, B : AnyObject>
+func derivedViaConcreteZ1<A, B>(_: A, _: B)
+  where A : W, A : Z<B> {}
+// expected-warning@-1 {{redundant conformance constraint 'A' : 'W'}}
+// expected-note@-2 {{conformance constraint 'A' : 'W' implied here}}
+
+// CHECK: Generic signature: <A, B where A : Z<B>, B : AnyObject>
+func derivedViaConcreteZ2<A, B>(_: A, _: B)
+  where A : W, B : AnyObject, A : Z<B> {}
+// expected-warning@-1 {{redundant conformance constraint 'A' : 'W'}}
+// expected-note@-2 {{conformance constraint 'A' : 'W' implied here}}

--- a/test/Generics/derived_via_concrete.swift
+++ b/test/Generics/derived_via_concrete.swift
@@ -60,8 +60,14 @@ func derivedViaConcreteZ1<A, B>(_: A, _: B)
 // expected-warning@-1 {{redundant conformance constraint 'A' : 'W'}}
 // expected-note@-2 {{conformance constraint 'A' : 'W' implied here}}
 
+// FIXME: We should not diagnose 'B : AnyObject' as redundant, even
+// though it really is, because it was made redundant by an inferred
+// requirement.
+
 // CHECK: Generic signature: <A, B where A : Z<B>, B : AnyObject>
 func derivedViaConcreteZ2<A, B>(_: A, _: B)
   where A : W, B : AnyObject, A : Z<B> {}
 // expected-warning@-1 {{redundant conformance constraint 'A' : 'W'}}
 // expected-note@-2 {{conformance constraint 'A' : 'W' implied here}}
+// expected-warning@-3 {{redundant constraint 'B' : 'AnyObject'}}
+// expected-note@-4 {{constraint 'B' : 'AnyObject' implied here}}

--- a/test/Generics/explicit_requirements_perf.swift
+++ b/test/Generics/explicit_requirements_perf.swift
@@ -1,0 +1,9 @@
+// RUN: %scale-test --begin 1 --end 20 --step 1 --select NumRedundantRequirementSteps --polynomial-threshold 2 %s
+
+protocol P {}
+
+func f<T>(_: T) where
+%for i in range(0, N):
+  T : P,
+%end
+  T : P {}

--- a/test/Generics/rdar62903491.swift
+++ b/test/Generics/rdar62903491.swift
@@ -5,7 +5,7 @@ protocol P {
   associatedtype X : P
 }
 
-// Anything that mentions 'T : P' minimizes to 'U : P'.
+// Anything that mentions 'T : P' and 'U : P' minimizes to 'U : P'.
 
 // expected-warning@+2 {{redundant conformance constraint 'U' : 'P'}}
 // expected-note@+1 {{conformance constraint 'U' : 'P' implied here}}
@@ -31,6 +31,8 @@ func oneProtocol4<T, U>(_: T, _: U) where U : P, T.X == U, T : P, U.X == T {}
 // CHECK-LABEL: oneProtocol4
 // CHECK: Generic signature: <T, U where T : P, T == U.X, U == T.X>
 
+// Anything that only mentions 'T : P' minimizes to 'T : P'.
+
 func oneProtocol5<T, U>(_: T, _: U) where T : P, T.X == U, U.X == T {}
 // CHECK-LABEL: oneProtocol5
 // CHECK: Generic signature: <T, U where T : P, T == U.X, U == T.X>
@@ -39,14 +41,12 @@ func oneProtocol6<T, U>(_: T, _: U) where T.X == U, U.X == T, T : P {}
 // CHECK-LABEL: oneProtocol6
 // CHECK: Generic signature: <T, U where T : P, T == U.X, U == T.X>
 
-// Anything that mentions 'U : P' but not 'T : P' minimizes to 'U : P'.
+// Anything that only mentions 'U : P' minimizes to 'U : P'.
 
-// FIXME: Need to emit warning here too
 func oneProtocol7<T, U>(_: T, _: U) where U : P, T.X == U, U.X == T {}
 // CHECK-LABEL: oneProtocol7
 // CHECK: Generic signature: <T, U where T == U.X, U : P, U == T.X>
 
-// FIXME: Need to emit warning here too
 func oneProtocol8<T, U>(_: T, _: U) where T.X == U, U.X == T, U : P {}
 // CHECK-LABEL: oneProtocol8
 // CHECK: Generic signature: <T, U where T == U.X, U : P, U == T.X>

--- a/test/Generics/rdar74890907.swift
+++ b/test/Generics/rdar74890907.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+
+protocol P1 {
+  associatedtype A : P2
+}
+
+protocol P2 {
+  associatedtype A
+}
+
+// CHECK: Generic signature: <T, U where T : P2, T == U.A.A, U == T.A.A, T.A : P1, U.A : P1>
+func testTU<T : P2, U : P2>(_: T, _: U) where T.A : P1, T.A.A == U, U.A : P1, U.A.A == T {}
+// expected-warning@-1 {{redundant conformance constraint 'U' : 'P2'}}
+// expected-note@-2 {{conformance constraint 'U' : 'P2' implied here}}
+
+// CHECK: Generic signature: <T, U where T == U.A.A, U : P2, U == T.A.A, T.A : P1, U.A : P1>
+func testU<T, U : P2>(_: T, _: U) where T.A : P1, T.A.A == U, U.A : P1, U.A.A == T {}
+
+// CHECK: Generic signature: <T, U where T : P2, T == U.A.A, U == T.A.A, T.A : P1, U.A : P1>
+func testT<T : P2, U>(_: T, _: U) where T.A : P1, T.A.A == U, U.A : P1, U.A.A == T {}

--- a/test/Generics/rdar75656022.swift
+++ b/test/Generics/rdar75656022.swift
@@ -48,9 +48,9 @@ struct OriginalExampleWithWarning<A, B> where A : P2, B : P2, A.T == B.T {
   init<C, D, E>(_: C)
     where C : P1,
           D : P1, // expected-warning {{redundant conformance constraint 'D' : 'P1'}}
-          C.T : P1, // expected-warning {{redundant conformance constraint 'C.T' : 'P1'}}
-          A == S1<C, C.T.T, S2<C.T>>, // expected-note {{conformance constraint 'D' : 'P1' implied here}}
           // expected-note@-1 {{conformance constraint 'C.T' : 'P1' implied here}}
+          C.T : P1, // expected-warning {{redundant conformance constraint 'C.T' : 'P1'}}
+          A == S1<C, C.T.T, S2<C.T>>,
           C.T == D,
           E == D.T { }
 }
@@ -72,7 +72,6 @@ struct WithoutBogusGenericParametersWithWarning<A, B> where A : P2, B : P2, A.T 
     where C : P1,
           C.T : P1, // expected-warning {{redundant conformance constraint 'C.T' : 'P1'}}
           A == S1<C, C.T.T, S2<C.T>> {}
-          // expected-note@-1 {{conformance constraint 'C.T' : 'P1' implied here}}
 }
 
 // Same as above but without unnecessary generic parameters

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -354,20 +354,22 @@ protocol P26 {
   associatedtype C: X3
 }
 
-struct X26<T: X3> : P26 { // expected-note {{requirement specified as 'T' : 'X3' [with T = Self.B]}}
+struct X26<T: X3> : P26 {
   typealias C = T
 }
 
 // CHECK-LABEL: .P27a@
-// CHECK-NEXT: Requirement signature: <Self where Self.A == X26<Self.B>>
-// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X26<τ_0_0.B>>
+// CHECK-NEXT: Requirement signature: <Self where Self.A == X26<Self.B>, Self.B : X3>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X26<τ_0_0.B>, τ_0_0.B : X3>
 protocol P27a {
   associatedtype A: P26 // expected-warning{{redundant conformance constraint 'Self.A' : 'P26'}}
   // expected-note@-1 {{superclass constraint 'Self.B' : 'X3' implied here}}
 
   associatedtype B: X3 where A == X26<B> // expected-note{{conformance constraint 'Self.A' : 'P26' implied here}}
   // expected-warning@-1 {{redundant superclass constraint 'Self.B' : 'X3'}}
-  // expected-error@-2 {{'X26' requires that 'Self.B' inherit from 'X3'}}
+
+  // FIXME: The above warning should not be emitted -- while the requirement
+  // really is redundant, it is made redundant by an inferred requirement.
 }
 
 // CHECK-LABEL: .P27b@

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -328,7 +328,9 @@ struct X24<T: P20> : P24 {
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X24<τ_0_0.B>, τ_0_0.B : P20>
 protocol P25a {
   associatedtype A: P24 // expected-warning{{redundant conformance constraint 'Self.A' : 'P24'}}
+  // expected-note@-1 {{conformance constraint 'Self.B' : 'P20' implied here}}
   associatedtype B: P20 where A == X24<B> // expected-note{{conformance constraint 'Self.A' : 'P24' implied here}}
+  // expected-warning@-1 {{redundant conformance constraint 'Self.B' : 'P20'}}
 }
 
 // CHECK-LABEL: .P25b@

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -354,16 +354,20 @@ protocol P26 {
   associatedtype C: X3
 }
 
-struct X26<T: X3> : P26 {
+struct X26<T: X3> : P26 { // expected-note {{requirement specified as 'T' : 'X3' [with T = Self.B]}}
   typealias C = T
 }
 
 // CHECK-LABEL: .P27a@
-// CHECK-NEXT: Requirement signature: <Self where Self.A == X26<Self.B>, Self.B : X3>
-// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X26<τ_0_0.B>, τ_0_0.B : X3>
+// CHECK-NEXT: Requirement signature: <Self where Self.A == X26<Self.B>>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X26<τ_0_0.B>>
 protocol P27a {
   associatedtype A: P26 // expected-warning{{redundant conformance constraint 'Self.A' : 'P26'}}
+  // expected-note@-1 {{superclass constraint 'Self.B' : 'X3' implied here}}
+
   associatedtype B: X3 where A == X26<B> // expected-note{{conformance constraint 'Self.A' : 'P26' implied here}}
+  // expected-warning@-1 {{redundant superclass constraint 'Self.B' : 'X3'}}
+  // expected-error@-2 {{'X26' requires that 'Self.B' inherit from 'X3'}}
 }
 
 // CHECK-LABEL: .P27b@

--- a/test/Generics/sr14510.swift
+++ b/test/Generics/sr14510.swift
@@ -1,0 +1,35 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -debug-generic-signatures -typecheck %s 2>&1 | %FileCheck %s
+
+// CHECK-LABEL: Requirement signature: <Self where Self == Self.Dual.Dual, Self.Dual : Adjoint>
+public protocol Adjoint {
+  associatedtype Dual: Adjoint where Self.Dual.Dual == Self
+}
+
+// CHECK-LABEL: Requirement signature: <Self>
+public protocol Diffable {
+  associatedtype Patch
+}
+
+// CHECK-LABEL: Requirement signature: <Self where Self : Adjoint, Self : Diffable, Self.Dual : AdjointDiffable, Self.Patch : Adjoint, Self.Dual.Patch == Self.Patch.Dual>
+public protocol AdjointDiffable: Adjoint & Diffable
+where Self.Patch: Adjoint, Self.Dual: AdjointDiffable,
+      Self.Patch.Dual == Self.Dual.Patch {
+}
+
+// This is another example used to hit the same problem. Any one of the three
+// conformance requirements 'A : P', 'B : P' or 'C : P' can be dropped and
+// proven from the other two, but dropping two or more conformance requirements
+// leaves us with an invalid signature.
+//
+// Note that this minimization is still not quite correct; the requirement
+// 'Self.B.C == Self.A.A.A' is unnecessary.
+
+// CHECK-LABEL: Requirement signature: <Self where Self.A : P, Self.A == Self.B.C, Self.B : P, Self.B == Self.A.C, Self.C == Self.A.B, Self.B.C == Self.A.A.A>
+protocol P {
+  associatedtype A : P where A == B.C
+  associatedtype B : P where B == A.C
+  // expected-note@-1 {{conformance constraint 'Self.C' : 'P' implied here}}
+  associatedtype C : P where C == A.B
+  // expected-warning@-1 {{redundant conformance constraint 'Self.C' : 'P'}}
+}

--- a/test/Generics/sr14580.swift
+++ b/test/Generics/sr14580.swift
@@ -1,0 +1,32 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+
+public protocol ScalarProtocol: ScalarMultiplicative where Self == Scalar {
+}
+
+public protocol ScalarMultiplicative {
+  associatedtype Scalar: ScalarProtocol
+}
+
+public protocol MapReduceArithmetic: ScalarMultiplicative, Collection where Element: ScalarMultiplicative {}
+
+public protocol Tensor: MapReduceArithmetic where Element == Scalar {
+}
+
+// FIXME: The same-type requirement canonicalization still produces bugus results here, but
+// at least we don't crash.
+
+// CHECK-LABEL: Requirement signature: <Self where Self : Tensor, Self == Self.Float16Components.Model, Self.Element == Double, Self.Float16Components : ColorComponents, Self.Float32Components : ColorComponents, Self.Float16Components.Element == Double, Self.Float16Components.Model == Self.Float32Components.Model, Self.Float32Components.Element == Double, Self.Float32Components.Indices == Self.Float32Components.Indices.SubSequence, Self.Float32Components.SubSequence == Self.Float32Components.SubSequence.SubSequence, Self.Float32Components.Indices.Indices == Self.Float32Components.Indices.Indices.SubSequence, Self.Float32Components.SubSequence.Indices == Self.Float32Components.SubSequence.Indices.SubSequence, Self.Float32Components.SubSequence.Indices.Indices == Self.Float32Components.SubSequence.Indices.Indices.SubSequence>
+public protocol ColorModel: Tensor where Scalar == Double {
+  associatedtype Float16Components: ColorComponents where Float16Components.Model == Self, Float16Components.Scalar == Double
+  associatedtype Float32Components: ColorComponents where Float32Components.Model == Self, Float32Components.Scalar == Double
+}
+
+public protocol ColorComponents: Tensor {
+  associatedtype Model: ColorModel
+}
+
+extension Double : ScalarMultiplicative {}
+extension Double : ScalarProtocol {
+  public typealias Scalar = Self
+}

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -213,3 +213,16 @@ _ = G<Base & P>() // expected-error {{'G' requires that 'Base & P' inherit from 
 
 func badClassConstrainedType(_: G<Base & P>) {}
 // expected-error@-1 {{'G' requires that 'Base & P' inherit from 'Base'}}
+
+// Reduced from CoreStore in source compat suite
+public protocol Pony {}
+
+public class Teddy: Pony {}
+
+public struct Paddock<P: Pony> {}
+
+public struct Barn<T: Teddy> {
+  // CHECK-DAG: Barn.foo@
+  // CHECK: Generic signature: <T, S where T : Teddy>
+  public func foo<S>(_: S, _: Barn<T>, _: Paddock<T>) {}
+}


### PR DESCRIPTION
This PR now contains changes from two PRs.

# First PR

This rewrites the existing redundant requirements algorithm to be simpler, and fix an incorrect behavior in the case where
we're building a protocol requirement signature.

Consider the following example:

    protocol P {
      associatedtype A : P
      associatedtype B : P where A.B == B
    }

The requirement B : P has two conformance paths here:

    (B : P)
    (A : P)(B : P)

The naive redundancy algorithm would conclude that (B : P) is redundant because it can be derived as (A : P)(B : P). However, if we drop (B : P), we lose the derived conformance path as well, since it involves the same requirement (B : P).

The above example actually worked before this change, because we handled this case in getMinimalConformanceSource() by dropping any derived conformance paths that involve the requirement itself appearing in the "middle" of the path.

However, this is insufficient because you can have a "cycle" here with length more than 1. For example,

    protocol P {
      associatedtype A : P where A == B.C
      associatedtype B : P where B == A.C
      associatedtype C : P where C == A.B
    }

The requirement A : P has two conformance paths here:

    (A : P)
    (B : P)(C : P)

Similarly, B : P has these two paths:

    (B : P)
    (A : P)(C : P)

And C : P has these two paths:

    (C : P)
    (A : P)(B : P)

Since each one of A : P, B : P and C : P has a derived conformance path that does not involve itself, we would conclude that all three were redundant. But this was wrong; while (B : P)(C : P) is a valid derived path for A : P that allows us to drop A : P, once we commit to dropping A : P, we can no longer use the other derived paths (A : P)(C : P) for B : P, and (A : P)(B : P) for C : P, respectively, because they involve A : P, which we dropped.

The problem is that we were losing information here. The explicit requirement A : P can be derived as (B : P)(C : P), but we would just say that it was implied by B : P alone.

For non-protocol generic signatures, just looking at the root is still sufficient.

However, when building a requirement signature of a self-recursive protocol, instead of looking at the root explicit requirement only, we need to look at _all_ intermediate steps in the path that involve the same protocol.

This is implemented in a new getBaseRequirements() method, which generalizes the operation of getting the explicit requirement at the root of a derived conformance path by returning a vector of one or more explicit requirements that appear in the path.

Also the new algorithm computes redundancy online instead of building a directed graph and then computing SCCs. This is possible by recording newly-discovered redundant requirements immediately, and then using the set of so-far-redundant requirements when evaluating a path.

Fixes https://bugs.swift.org/browse/SR-14510 / rdar://problem/76883924.

# Second PR

Consider this example:

    protocol P1 {
      associatedtype A : P2
    }

    protocol P2 {
      associatedtype A
    }

    func foo<T : P2>(_: T) where T.A : P1, T.A.A == T {}

We cannot drop 'T : P2', even though it can be derived from T.A.A == T and Self.A : P2 in protocol P1, because we actually
need the conformance T : P2 in order to recover the concrete type for T.A.

This was handled via a hack which would ensure that the conformance path (T.A : P1)(Self.A : P2) was not a candidate
derivation for T : P2, because T : P2 is one of the conformances used to construct the subject type T.A in the conformance path.

This hack did not generalize to "cycles" of length greater than 1 however:

    func foo<T : P2, U : P2>(_: T, _: U)
      where T.A : P1, T.A.A == U, U.A : P1, U.A.A == T {}

We used to drop both T : P2 and U : P2, because each one had a conformance path (U.A : P1)(Self.A : P2) and (T.A : P1)(Self.A : P2), respectively; however, once we drop T : P2 and U : P2, these two paths become invalid for the same reason that the concrete type for T.A and U.A can no longer be recovered.

The correct fix is to recursively visit the subject type of each base requirement when evaluating a conformance path, and not consider any requirement whose subject type's parent type cannot be recovered.

In the worst case, this algorithm is exponential in the number of conformance requirements, but it is not always exponential, and a generic signature is not going to have a large number of conformance requirements anyway (hopefully). Also, the old logic in getMinimalConformanceSource() wasn't cheap either.

Perhaps some clever memoization can speed this up too, but I'm going to focus on correctness first, before looking at performance here.

Fixes rdar://problem/74890907.