### PR TITLE
Allow functions marked @LLDBDebuggerFunction to bypass actor isolatio…

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2391,6 +2391,10 @@ void swift::checkTopLevelActorIsolation(TopLevelCodeDecl *decl) {
 }
 
 void swift::checkFunctionActorIsolation(AbstractFunctionDecl *decl) {
+  // Disable this check for @LLDBDebuggerFunction functions.
+  if (decl->getAttrs().hasAttribute<LLDBDebuggerFunctionAttr>())
+    return;
+
   ActorIsolationChecker checker(decl);
   if (auto body = decl->getBody()) {
     body->walk(checker);

--- a/test/Concurrency/LLDBDebuggerFunctionActorExtension.swift
+++ b/test/Concurrency/LLDBDebuggerFunctionActorExtension.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency -debugger-support
+// REQUIRES: concurrency
+
+// This test simulates LLDB's expression evaluator makeing an otherwise illegal
+// synchronous call into an extension of an actor, as it would to run `p n` in
+// this example.
+
+actor A {
+  var n : Int = 0
+}
+
+extension A {
+  final func lldb_wrapped_expr() {
+    n = 1
+  }
+}
+
+@LLDBDebuggerFunction
+func lldb_expr(a: A) {
+  a.lldb_wrapped_expr()
+}


### PR DESCRIPTION
…n checks

In order to allow LLDB to evaluate expressions inside an actor without spawining
async functions and potentially continue all threads, this relaxes the actor
isolation checks in @LLDBDebuggerFunction functions to allow a synchronous call
into an extension method.

rdar://75905336
