### PR TITLE
fix missing effects specifiers on some properties in swiftinterface

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3490,6 +3490,10 @@ void PrintAST::visitAccessorDecl(AccessorDecl *decl) {
       });
   }
 
+  // handle effects specifiers before the body
+  if (decl->hasAsync()) Printer << " async";
+  if (decl->hasThrows()) Printer << " throws";
+
   printBodyIfNecessary(decl);
 }
 

--- a/test/ModuleInterface/effectful_properties.swift
+++ b/test/ModuleInterface/effectful_properties.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -enable-experimental-concurrency -typecheck -swift-version 5 -enable-library-evolution -emit-module-interface-path %t.swiftinterface %s -module-name EffProps
+// RUN: %FileCheck %s < %t.swiftinterface
+
+public struct MyStruct {}
+
+// CHECK-LABEL: public var status
+// CHECK: get async throws
+
+public extension MyStruct {
+  struct InnerStruct {
+      public var status: Bool { get async throws { false } }
+    }
+}
+
+// CHECK-LABEL: public var hello
+// CHECK: get async
+
+// CHECK-LABEL: public subscript
+// CHECK: get async throws
+
+public class C {
+  public var hello: Int { get async { 0 } }
+
+  public subscript(_ x: Int) -> Void {
+    get async throws { }
+  }
+}
+
+// CHECK-LABEL: public var world
+// CHECK: get throws
+
+public enum E {
+  public var world: Int { get throws { 0 } }
+}


### PR DESCRIPTION
I missed the case where the body was requested to be printed in the interface file. That is, in `ASTPrinter.cpp` this is the case when `PrintAccessorBody` is true in this branch:

```
auto PrintAccessor = [&](AccessorKind Kind) -> bool {
    // ...
    if (!PrintAccessorBody) {
    // had already covered this
   } else {
   // forgot to cover this side!
   }
   // ...
}
```

Resolves rdar://77324796
