### PR TITLE
[Concurrency] Cleanup `async` signature and priority handling

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -2007,6 +2007,7 @@ public:
     Task_IsChildTask      = 24,
     Task_IsFuture         = 25,
     Task_IsGroupChildTask = 26,
+    Task_IsContinuingAsyncTask      = 27,
   };
 
   explicit JobFlags(size_t bits) : FlagSet(bits) {}
@@ -2036,6 +2037,9 @@ public:
   FLAGSET_DEFINE_FLAG_ACCESSORS(Task_IsGroupChildTask,
                                 task_isGroupChildTask,
                                 task_setIsGroupChildTask)
+  FLAGSET_DEFINE_FLAG_ACCESSORS(Task_IsContinuingAsyncTask,
+                                task_isContinuingAsyncTask,
+                                task_setIsContinuingAsyncTask)
 };
 
 /// Kinds of task status record.

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -104,6 +104,8 @@ extension Task {
     case `default`       = 0x15
     case utility         = 0x11
     case background      = 0x09
+
+    @available(*, deprecated, message: "unspecified priority will be removed; use nil")
     case unspecified     = 0x00
 
     public static func < (lhs: Priority, rhs: Priority) -> Bool {
@@ -273,13 +275,13 @@ extension Task {
     var isAsyncTask: Bool { kind == .task }
 
     /// The priority given to the job.
-    var priority: Priority {
+    var priority: Priority? {
       get {
-        Priority(rawValue: (bits & 0xFF00) >> 8)!
+        Priority(rawValue: (bits & 0xFF00) >> 8)
       }
 
       set {
-        bits = (bits & ~0xFF00) | (newValue.rawValue << 8)
+        bits = (bits & ~0xFF00) | ((newValue?.rawValue ?? 0) << 8)
       }
     }
 
@@ -470,23 +472,21 @@ public func detach<T>(
 }
 
 @discardableResult
-@_alwaysEmitIntoClient
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public func asyncDetached<T>(
-  priority: Task.Priority = .unspecified,
+  priority: Task.Priority? = nil,
   @_implicitSelfCapture operation: __owned @Sendable @escaping () async -> T
 ) -> Task.Handle<T, Never> {
-  return detach(priority: priority, operation: operation)
+  return detach(priority: priority ?? .unspecified, operation: operation)
 }
 
 @discardableResult
-@_alwaysEmitIntoClient
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public func asyncDetached<T>(
-  priority: Task.Priority = .unspecified,
+  priority: Task.Priority? = nil,
   @_implicitSelfCapture operation: __owned @Sendable @escaping () async throws -> T
 ) -> Task.Handle<T, Error> {
-  return detach(priority: priority, operation: operation)
+  return detach(priority: priority ?? .unspecified, operation: operation)
 }
 
 /// ABI stub while we stage in the new signatures
@@ -520,6 +520,7 @@ func async(
 ///     Task.currentPriority.
 ///   - operation: the operation to execute
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@discardableResult
 public func async<T>(
   priority: Task.Priority? = nil,
   @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping () async -> T
@@ -555,6 +556,7 @@ public func async<T>(
 ///     Task.currentPriority.
 ///   - operation: the operation to execute
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@discardableResult
 public func async<T>(
   priority: Task.Priority? = nil,
   @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping () async throws -> T
@@ -721,12 +723,10 @@ public struct UnsafeCurrentTask {
 
   /// Returns the `current` task's priority.
   ///
-  /// If no current `Task` is available, returns `Priority.default`.
-  ///
   /// - SeeAlso: `Task.Priority`
   /// - SeeAlso: `Task.currentPriority`
   public var priority: Task.Priority {
-    getJobFlags(_task).priority
+    getJobFlags(_task).priority ?? .default
   }
 
 }

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -47,17 +47,21 @@ extension Task {
 
   /// Returns the `current` task's priority.
   ///
-  /// If no current `Task` is available, returns `Priority.default`.
+  /// If no current `Task` is available, queries the system to determine the
+  /// priority at which the current function is running. If the system cannot
+  /// provide an appropriate priority, returns `Priority.default`.
   ///
   /// - SeeAlso: `Task.Priority`
   /// - SeeAlso: `Task.priority`
   public static var currentPriority: Priority {
     withUnsafeCurrentTask { task in
-      guard let task = task else {
-        return Priority.default
+      // If we are running on behalf of a task, use that task's priority.
+      if let task = task {
+        return task.priority
       }
 
-      return getJobFlags(task._task).priority
+      // Otherwise, query the system.
+      return Task.Priority(rawValue: _getCurrentThreadPriority()) ?? .default
     }
   }
 
@@ -105,6 +109,28 @@ extension Task {
     public static func < (lhs: Priority, rhs: Priority) -> Bool {
       lhs.rawValue < rhs.rawValue
     }
+  }
+}
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+extension Task.Priority {
+  /// Downgrade user-interactive to user-initiated.
+  var _downgradeUserInteractive: Task.Priority {
+    if self == .userInteractive {
+      return .userInitiated
+    }
+
+    return self
+  }
+
+  /// Adjust the given priority (when it is unspecified) by the current
+  /// priority Return the current priority that,
+  var _inheritingContextualPriority: Task.Priority {
+    if self != .unspecified {
+      return self
+    }
+
+    return Task.currentPriority._downgradeUserInteractive
   }
 }
 
@@ -478,29 +504,10 @@ public func async(
   priority: Task.Priority = .unspecified,
   @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping () async -> Void
 ) {
-  // Determine the priority at which we should create this task
-  let actualPriority: Task.Priority
-  if priority == .unspecified {
-    actualPriority = withUnsafeCurrentTask { task in
-      // If we are running on behalf of a task,
-      if let task = task {
-        return task.priority
-      }
-
-      return Task.Priority(rawValue: _getCurrentThreadPriority()) ?? .unspecified
-    }
-  } else {
-    actualPriority = priority
-  }
-
-  let adjustedPriority = actualPriority == .userInteractive
-    ? .userInitiated
-    : actualPriority
-
   // Set up the job flags for a new task.
   var flags = Task.JobFlags()
   flags.kind = .task
-  flags.priority = actualPriority
+  flags.priority = priority._inheritingContextualPriority
   flags.isFuture = true
 
   // Create the asynchronous task future.

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -220,6 +220,16 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
     }
   }
 
+  // Historical entry point, maintained for ABI compatibility
+  @usableFromInline
+  mutating func spawn(
+    priority: Task.Priority,
+    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) {
+    let optPriority: Task.Priority? = priority
+    spawn(priority: optPriority, operation: operation)
+  }
+
   /// Add a child task to the group.
   ///
   /// ### Error handling
@@ -236,7 +246,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   ///   - `true` if the operation was added to the group successfully,
   ///     `false` otherwise (e.g. because the group `isCancelled`)
   public mutating func spawn(
-    priority: Task.Priority = .unspecified,
+    priority: Task.Priority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) {
     _ = _taskGroupAddPendingTask(group: _group, unconditionally: true)
@@ -260,6 +270,16 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
     _enqueueJobGlobal(Builtin.convertTaskToJob(childTask))
   }
 
+    // Historical entry point, maintained for ABI compatibility
+  @usableFromInline
+  mutating func spawnUnlessCancelled(
+    priority: Task.Priority = .unspecified,
+    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) -> Bool {
+    let optPriority: Task.Priority? = priority
+    return spawnUnlessCancelled(priority: optPriority, operation: operation)
+  }
+
   /// Add a child task to the group.
   ///
   /// ### Error handling
@@ -276,7 +296,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   ///   - `true` if the operation was added to the group successfully,
   ///     `false` otherwise (e.g. because the group `isCancelled`)
   public mutating func spawnUnlessCancelled(
-    priority: Task.Priority = .unspecified,
+    priority: Task.Priority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) -> Bool {
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
@@ -472,6 +492,16 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
     }
   }
 
+  // Historical entry point for ABI reasons
+  @usableFromInline
+  mutating func spawn(
+    priority: Task.Priority = .unspecified,
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) {
+    let optPriority: Task.Priority? = priority
+    return spawn(priority: optPriority, operation: operation)
+  }
+
   /// Spawn, unconditionally, a child task in the group.
   ///
   /// ### Error handling
@@ -488,7 +518,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   ///   - `true` if the operation was added to the group successfully,
   ///     `false` otherwise (e.g. because the group `isCancelled`)
   public mutating func spawn(
-    priority: Task.Priority = .unspecified,
+    priority: Task.Priority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) {
     // we always add, so no need to check if group was cancelled
@@ -513,6 +543,16 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
     _enqueueJobGlobal(Builtin.convertTaskToJob(childTask))
   }
 
+  // Historical entry point for ABI reasons
+  @usableFromInline
+  mutating func spawnUnlessCancelled(
+    priority: Task.Priority,
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) -> Bool {
+    let optPriority: Task.Priority? = priority
+    return spawnUnlessCancelled(priority: optPriority, operation: operation)
+  }
+
   /// Add a child task to the group.
   ///
   /// ### Error handling
@@ -529,7 +569,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   ///   - `true` if the operation was added to the group successfully,
   ///     `false` otherwise (e.g. because the group `isCancelled`)
   public mutating func spawnUnlessCancelled(
-    priority: Task.Priority = .unspecified,
+    priority: Task.Priority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) -> Bool {
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)


### PR DESCRIPTION
Fix a few related issues with `async` and priorities:
* Make `async` return a task handle. Overload on throwing/non-throwing operations for it to work out.
* Make the `priority` parameter to `async`, `asyncDetached`, `spawn`, and `spawnUnlessCancelled` optional, defaulting to `nil`.
* Deprecate `Task.Priority.unspecified`. This is better represented via optional `nil` in the APIs that use it.