### PR TITLE
Actors + concurrency fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,25 @@ CHANGELOG
 Swift 5.5
 ---------
 
+* [SE-0306][]:
+
+	Swift 5.5 includes support for actors, a new kind of type that isolates its instance data to protect it from concurrent access. Accesses to an actor's instance declarations from outside the must be asynchronous:
+
+	```swift
+  actor Counter {
+    var value = 0
+
+    func increment() {
+      value = value + 1
+    }
+  }
+
+  func useCounter(counter: Counter) async {
+    print(await counter.value) // interaction must be async
+    await counter.increment()  // interaction must be async
+  }
+	```
+
 * The determination of whether a call to a `rethrows` function can throw now considers default arguments of `Optional` type.
 
   In Swift 5.4, such default arguments were ignored entirely by `rethrows` checking. This meant that the following example was accepted:
@@ -8434,6 +8453,7 @@ Swift 1.0
 [SE-0297]: <https://github.com/apple/swift-evolution/blob/main/proposals/0297-concurrency-objc.md>
 [SE-0298]: <https://github.com/apple/swift-evolution/blob/main/proposals/0298-asyncsequence.md>
 [SE-0299]: <https://github.com/apple/swift-evolution/blob/main/proposals/0299-extend-generic-static-member-lookup.md>
+[SE-0306]: <https://github.com/apple/swift-evolution/blob/main/proposals/0306-actors.md>
 
 [SR-75]: <https://bugs.swift.org/browse/SR-75>
 [SR-106]: <https://bugs.swift.org/browse/SR-106>

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -2001,6 +2001,7 @@ public:
     Task_IsChildTask      = 24,
     Task_IsFuture         = 25,
     Task_IsGroupChildTask = 26,
+    Task_IsContinuingAsyncTask      = 27,
   };
 
   explicit JobFlags(size_t bits) : FlagSet(bits) {}
@@ -2030,6 +2031,9 @@ public:
   FLAGSET_DEFINE_FLAG_ACCESSORS(Task_IsGroupChildTask,
                                 task_isGroupChildTask,
                                 task_setIsGroupChildTask)
+  FLAGSET_DEFINE_FLAG_ACCESSORS(Task_IsContinuingAsyncTask,
+                                task_isContinuingAsyncTask,
+                                task_setIsContinuingAsyncTask)
 };
 
 /// Kinds of task status record.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4351,8 +4351,8 @@ NOTE(objc_ambiguous_async_convention_candidate,none,
 ERROR(async_objc_dynamic_self,none,
       "asynchronous method returning 'Self' cannot be '@objc'", ())
 
-ERROR(actor_with_nonactor_superclass,none,
-      "actor cannot inherit from non-actor class %0", (DeclName))
+ERROR(actor_inheritance,none,
+      "actor types do not support inheritance", ())
 
 ERROR(actor_isolated_non_self_reference,none,
         "actor-isolated %0 %1 can only be %select{referenced|mutated|used 'inout'}3 "

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -37,7 +37,7 @@
 LANGUAGE_FEATURE(StaticAssert, 0, "#assert", langOpts.EnableExperimentalStaticAssert)
 LANGUAGE_FEATURE(AsyncAwait, 296, "async/await", true)
 LANGUAGE_FEATURE(MarkerProtocol, 0, "@_marker protocol", true)
-LANGUAGE_FEATURE(Actors, 0, "actors", langOpts.EnableExperimentalConcurrency)
+LANGUAGE_FEATURE(Actors, 0, "actors", true)
 LANGUAGE_FEATURE(ConcurrentFunctions, 0, "@concurrent functions", true)
 LANGUAGE_FEATURE(RethrowsProtocol, 0, "@rethrows protocol", true)
 LANGUAGE_FEATURE(GlobalActors, 0, "Global actors", langOpts.EnableExperimentalConcurrency)

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3604,7 +3604,7 @@ bool Parser::parseDeclModifierList(DeclAttributes &Attributes,
       if (Kind == DAK_Count)
         break;
 
-      if (Kind == DAK_Actor && shouldParseExperimentalConcurrency()) {
+      if (Kind == DAK_Actor) {
         // If the next token is a startOfSwiftDecl, we are part of the modifier
         // list and should consume the actor token (e.g, actor public class Foo)
         // otherwise, it's the decl keyword (e.g. actor Foo) and shouldn't be.
@@ -4075,8 +4075,7 @@ bool Parser::isStartOfSwiftDecl() {
     return isStartOfSwiftDecl();
   }
 
-  if (shouldParseExperimentalConcurrency() &&
-      Tok.isContextualKeyword("actor")) {
+  if (Tok.isContextualKeyword("actor")) {
     if (Tok2.is(tok::identifier)) // actor Foo {}
       return true;
     BacktrackingScope Scope(*this);
@@ -4428,8 +4427,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
   // Obvious nonsense.
   default:
 
-    if (shouldParseExperimentalConcurrency() &&
-        Tok.isContextualKeyword("actor") && peekToken().is(tok::identifier)) {
+    if (Tok.isContextualKeyword("actor") && peekToken().is(tok::identifier)) {
       Tok.setKind(tok::contextual_keyword);
       DeclParsingContext.setCreateSyntax(SyntaxKind::ClassDecl);
       DeclResult = parseDeclClass(Flags, Attributes);

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2314,6 +2314,14 @@ public:
     // Check for circular inheritance.
     (void)CD->getSuperclassDecl();
 
+    if (auto superclass = CD->getSuperclassDecl()) {
+      // Actors cannot have superclasses, nor can they be superclasses.
+      if (CD->isActor() && !superclass->isNSObject())
+        CD->diagnose(diag::actor_inheritance);
+      else if (superclass->isActor())
+        CD->diagnose(diag::actor_inheritance);
+    }
+
     // Force lowering of stored properties.
     (void) CD->getStoredProperties();
 

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -261,12 +261,12 @@ static bool isExecutingOnMainThread() {
 }
 
 JobPriority swift::swift_task_getCurrentThreadPriority() {
-  if (isExecutingOnMainThread())
-    return JobPriority::UserInitiated;
-
 #if defined(__APPLE__)
   return static_cast<JobPriority>(qos_class_self());
 #else
+  if (isExecutingOnMainThread())
+    return JobPriority::UserInitiated;
+
   return JobPriority::Unspecified;
 #endif
 }

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -159,16 +159,6 @@ extension Task.Priority {
 
     return self
   }
-
-  /// Adjust the given priority (when it is unspecified) by the current
-  /// priority Return the current priority that,
-  var _inheritingContextualPriority: Task.Priority {
-    if self != .unspecified {
-      return self
-    }
-
-    return Task.currentPriority._downgradeUserInteractive
-  }
 }
 
 // ==== Task Handle ------------------------------------------------------------
@@ -389,6 +379,22 @@ extension Task {
       }
     }
 
+    /// Whether this is a task created by the 'async' operation, which
+    /// conceptually continues the work of the synchronous code that invokes
+    /// it.
+    var isContinuingAsyncTask: Bool {
+      get {
+        (bits & (1 << 27)) != 0
+      }
+
+      set {
+        if newValue {
+          bits = bits | 1 << 27
+        } else {
+          bits = (bits & ~(1 << 27))
+        }
+      }
+    }
   }
 }
 
@@ -534,6 +540,22 @@ public func asyncDetached<T>(
   return detach(priority: priority, operation: operation)
 }
 
+/// ABI stub while we stage in the new signatures
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@usableFromInline
+func async(
+  priority: Task.Priority,
+  @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping () async -> Void
+) {
+  let adjustedPriority: Task.Priority?
+  if priority == .unspecified {
+    adjustedPriority = nil
+  } else {
+    adjustedPriority = priority
+  }
+  let _: Task.Handle = async(priority: adjustedPriority, operation: operation)
+}
+
 /// Run given `operation` as asynchronously in its own top-level task.
 ///
 /// The `async` function should be used when creating asynchronous work
@@ -545,27 +567,63 @@ public func asyncDetached<T>(
 /// does not return a handle to refer to the task.
 ///
 /// - Parameters:
-///   - priority: priority of the task. If unspecified, the priority will
-///               be inherited from the task that is currently executing
-///               or, if there is none, from the platform's understanding of
-///               which thread is executing.
+///   - priority: priority of the task. If nil, the priority will come from
+///     Task.currentPriority.
 ///   - operation: the operation to execute
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-public func async(
-  priority: Task.Priority = .unspecified,
-  @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping () async -> Void
-) {
+public func async<T>(
+  priority: Task.Priority? = nil,
+  @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping () async -> T
+) -> Task.Handle<T, Never> {
   // Set up the job flags for a new task.
   var flags = Task.JobFlags()
   flags.kind = .task
-  flags.priority = priority._inheritingContextualPriority
+  flags.priority = priority ?? Task.currentPriority._downgradeUserInteractive
   flags.isFuture = true
+  flags.isContinuingAsyncTask = true
 
   // Create the asynchronous task future.
   let (task, _) = Builtin.createAsyncTaskFuture(flags.bits, operation)
 
   // Enqueue the resulting job.
   _enqueueJobGlobal(Builtin.convertTaskToJob(task))
+
+  return Task.Handle(task)
+}
+
+/// Run given `operation` as asynchronously in its own top-level task.
+///
+/// The `async` function should be used when creating asynchronous work
+/// that operates on behalf of the synchronous function that calls it.
+/// Like `detach`, the async function creates a separate, top-level task.
+/// Unlike `detach`, the task creating by `async` inherits the priority and
+/// actor context of the caller, so the `operation` is treated more like an
+/// asynchronous extension to the synchronous operation. Additionally, `async`
+/// does not return a handle to refer to the task.
+///
+/// - Parameters:
+///   - priority: priority of the task. If nil, the priority will come from
+///     Task.currentPriority.
+///   - operation: the operation to execute
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public func async<T>(
+  priority: Task.Priority? = nil,
+  @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping () async throws -> T
+) -> Task.Handle<T, Error> {
+  // Set up the job flags for a new task.
+  var flags = Task.JobFlags()
+  flags.kind = .task
+  flags.priority = priority ?? Task.currentPriority._downgradeUserInteractive
+  flags.isFuture = true
+  flags.isContinuingAsyncTask = true
+
+  // Create the asynchronous task future.
+  let (task, _) = Builtin.createAsyncTaskFuture(flags.bits, operation)
+
+  // Enqueue the resulting job.
+  _enqueueJobGlobal(Builtin.convertTaskToJob(task))
+
+  return Task.Handle(task)
 }
 
 // ==== Async Handler ----------------------------------------------------------

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -489,7 +489,7 @@ public func detach<T>(
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public func asyncDetached<T>(
   priority: Task.Priority = .unspecified,
-  operation: __owned @Sendable @escaping () async -> T
+  @_implicitSelfCapture operation: __owned @Sendable @escaping () async -> T
 ) -> Task.Handle<T, Never> {
   return detach(priority: priority, operation: operation)
 }
@@ -499,7 +499,7 @@ public func asyncDetached<T>(
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public func asyncDetached<T>(
   priority: Task.Priority = .unspecified,
-  operation: __owned @Sendable @escaping () async throws -> T
+  @_implicitSelfCapture operation: __owned @Sendable @escaping () async throws -> T
 ) -> Task.Handle<T, Error> {
   return detach(priority: priority, operation: operation)
 }

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -484,6 +484,26 @@ public func detach<T>(
   return Task.Handle<T, Error>(task)
 }
 
+@discardableResult
+@_alwaysEmitIntoClient
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public func asyncDetached<T>(
+  priority: Task.Priority = .unspecified,
+  operation: __owned @Sendable @escaping () async -> T
+) -> Task.Handle<T, Never> {
+  return detach(priority: priority, operation: operation)
+}
+
+@discardableResult
+@_alwaysEmitIntoClient
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public func asyncDetached<T>(
+  priority: Task.Priority = .unspecified,
+  operation: __owned @Sendable @escaping () async throws -> T
+) -> Task.Handle<T, Error> {
+  return detach(priority: priority, operation: operation)
+}
+
 /// Run given `operation` as asynchronously in its own top-level task.
 ///
 /// The `async` function should be used when creating asynchronous work

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -854,12 +854,8 @@ func _getCurrentThreadPriority() -> Int
 @_alwaysEmitIntoClient
 @usableFromInline
 internal func _runTaskForBridgedAsyncMethod(_ body: @escaping () async -> Void) {
-  // TODO: We can probably do better than detach
-  // if we're already running on behalf of a task,
-  // if the receiver of the method invocation is itself an Actor, or in other
-  // situations.
 #if compiler(>=5.5) && $Sendable
-  detach { await body() }
+  async { await body() }
 #endif
 }
 

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -540,6 +540,10 @@ public func async(
     actualPriority = priority
   }
 
+  let adjustedPriority = actualPriority == .userInteractive
+    ? .userInitiated
+    : actualPriority
+
   // Set up the job flags for a new task.
   var flags = Task.JobFlags()
   flags.kind = .task

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -99,7 +99,7 @@ extension Task {
   /// - SeeAlso: `Task.currentPriority`
   @available(*, deprecated, message: "Storing `Task` instances has been deprecated, and as such instance functions on Task are deprecated and will be removed soon. Use the static 'Task.currentPriority' instead.")
   public var priority: Priority {
-    getJobFlags(_task).priority
+    getJobFlags(_task).priority ?? .default
   }
 
   /// Task priority may inform decisions an `Executor` makes about how and when
@@ -879,7 +879,7 @@ public func _runChildTask<T>(
   // Set up the job flags for a new task.
   var flags = Task.JobFlags()
   flags.kind = .task
-  flags.priority = getJobFlags(currentTask).priority
+  flags.priority = getJobFlags(currentTask).priority ?? .unspecified
   flags.isFuture = true
   flags.isChildTask = true
 

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -220,6 +220,16 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
     }
   }
 
+  // Historical entry point, maintained for ABI compatibility
+  @usableFromInline
+  mutating func spawn(
+    priority: Task.Priority,
+    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) {
+    let optPriority: Task.Priority? = priority
+    spawn(priority: optPriority, operation: operation)
+  }
+
   /// Add a child task to the group.
   ///
   /// ### Error handling
@@ -236,7 +246,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   ///   - `true` if the operation was added to the group successfully,
   ///     `false` otherwise (e.g. because the group `isCancelled`)
   public mutating func spawn(
-    priority: Task.Priority = .unspecified,
+    priority: Task.Priority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) {
     _ = _taskGroupAddPendingTask(group: _group, unconditionally: true)
@@ -260,6 +270,16 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
     _enqueueJobGlobal(Builtin.convertTaskToJob(childTask))
   }
 
+    // Historical entry point, maintained for ABI compatibility
+  @usableFromInline
+  mutating func spawnUnlessCancelled(
+    priority: Task.Priority = .unspecified,
+    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) -> Bool {
+    let optPriority: Task.Priority? = priority
+    return spawnUnlessCancelled(priority: optPriority, operation: operation)
+  }
+
   /// Add a child task to the group.
   ///
   /// ### Error handling
@@ -276,7 +296,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   ///   - `true` if the operation was added to the group successfully,
   ///     `false` otherwise (e.g. because the group `isCancelled`)
   public mutating func spawnUnlessCancelled(
-    priority: Task.Priority = .unspecified,
+    priority: Task.Priority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) -> Bool {
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
@@ -472,6 +492,16 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
     }
   }
 
+  // Historical entry point for ABI reasons
+  @usableFromInline
+  mutating func spawn(
+    priority: Task.Priority = .unspecified,
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) {
+    let optPriority: Task.Priority? = priority
+    return spawn(priority: optPriority, operation: operation)
+  }
+
   /// Spawn, unconditionally, a child task in the group.
   ///
   /// ### Error handling
@@ -488,7 +518,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   ///   - `true` if the operation was added to the group successfully,
   ///     `false` otherwise (e.g. because the group `isCancelled`)
   public mutating func spawn(
-    priority: Task.Priority = .unspecified,
+    priority: Task.Priority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) {
     // we always add, so no need to check if group was cancelled
@@ -513,6 +543,16 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
     _enqueueJobGlobal(Builtin.convertTaskToJob(childTask))
   }
 
+  // Historical entry point for ABI reasons
+  @usableFromInline
+  mutating func spawnUnlessCancelled(
+    priority: Task.Priority,
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) -> Bool {
+    let optPriority: Task.Priority? = priority
+    return spawnUnlessCancelled(priority: optPriority, operation: operation)
+  }
+
   /// Add a child task to the group.
   ///
   /// ### Error handling
@@ -529,7 +569,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   ///   - `true` if the operation was added to the group successfully,
   ///     `false` otherwise (e.g. because the group `isCancelled`)
   public mutating func spawnUnlessCancelled(
-    priority: Task.Priority = .unspecified,
+    priority: Task.Priority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) -> Bool {
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -48,7 +48,7 @@ class Point {
 }
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-actor MyActor: MySuperActor {
+actor MyActor: MySuperActor { // expected-error{{actor types do not support inheritance}}
   nonisolated let immutable: Int = 17
   // expected-note@+2 2{{property declared here}}
   // expected-note@+1 6{{mutation of this property is only permitted within the actor}}

--- a/test/Concurrency/async_initializer.swift
+++ b/test/Concurrency/async_initializer.swift
@@ -95,8 +95,7 @@ actor A {
   }
 }
 
-// NOTE: actor inheritance is probably being removed soon, so just remove this def of B
-actor B: A {
+actor B: A { // expected-error{{actor types do not support inheritance}}
   init(x : String) async {} // expected-error {{missing call to superclass's initializer; 'super.init' is 'async' and requires an explicit call}}
 }
 

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -173,7 +173,7 @@ actor GenericSuper<T> {
   @GenericGlobalActor<T> func method5() { }
 }
 
-actor GenericSub<T> : GenericSuper<[T]> {
+actor GenericSub<T> : GenericSuper<[T]> { // expected-error{{actor types do not support inheritance}}
   override func method() { }  // expected-note {{calls to instance method 'method()' from outside of its actor context are implicitly asynchronous}}
 
   @GenericGlobalActor<T> override func method2() { } // expected-error{{global actor 'GenericGlobalActor<T>'-isolated instance method 'method2()' has different actor isolation from global actor 'GenericGlobalActor<[T]>'-isolated overridden declaration}}

--- a/test/IRGen/actor_class_forbid_objc_assoc_objects.swift
+++ b/test/IRGen/actor_class_forbid_objc_assoc_objects.swift
@@ -15,10 +15,6 @@ final actor Actor {
 actor Actor2 {
 }
 
-// CHECK: @_METACLASS_DATA__TtC37actor_class_forbid_objc_assoc_objects6Actor3 = internal constant { {{.*}} } { i32 [[METAFLAGS]],
-// CHECK: @_DATA__TtC37actor_class_forbid_objc_assoc_objects6Actor3 = internal constant { {{.*}} } { i32 [[OBJECTFLAGS]],
-class Actor3 : Actor2 {}
-
 actor GenericActor<T> {
     var state: T
     init(state: T) { self.state = state }

--- a/test/IRGen/async/Inputs/resilient_actor.swift
+++ b/test/IRGen/async/Inputs/resilient_actor.swift
@@ -3,11 +3,6 @@ open actor ResilientBaseActor {
 }
 
 @_fixed_layout
-open actor FixedSubclassOfResilientBaseActor : ResilientBaseActor {
-  public override init() {}
-}
-
-@_fixed_layout
 open actor FixedBaseActor {
   public init() {}
 }

--- a/test/IRGen/async/default_actor.swift
+++ b/test/IRGen/async/default_actor.swift
@@ -8,18 +8,6 @@
 //   0x81010050: the same, but using a singleton metadata initialization
 // CHECK-SAME: i32 {{-2130706352|-2130640816}},
 
-// CHECK: @"$s13default_actor1BCMn" = hidden constant
-//   0x62010050: 0x02000000 IndirectTypeDescriptor + 0x01000000 IsDefaultActor
-// CHECK-SAME: i32 1644232784,
-
-// CHECK: @"$s13default_actor1CCMn" = hidden constant
-//   0x62010050: 0x02000000 IndirectTypeDescriptor + 0x01000000 IsDefaultActor
-// CHECK-SAME: i32 1644232784,
-
-// CHECK: @"$s13default_actor1DCMn" = hidden constant
-//   0x63010050: 0x02000000 IndirectTypeDescriptor + 0x01000000 IsDefaultActor
-// CHECK-SAME: i32 1661010000,
-
 import resilient_actor
 
 // CHECK-LABEL: define hidden swiftcc void @"$s13default_actor1ACfD"(%T13default_actor1AC* swiftself %0)
@@ -27,21 +15,3 @@ import resilient_actor
 // CHECK:     call swiftcc void @swift_defaultActor_deallocate(
 // CHECK:     ret void
 actor A {}
-
-// CHECK-LABEL: define hidden swiftcc void @"$s13default_actor1BCfD"(%T13default_actor1BC* swiftself %0)
-// CHECK-NOT: ret void
-// CHECK:     call swiftcc void @swift_defaultActor_deallocateResilient(
-// CHECK:     ret void
-actor B : ResilientBaseActor {}
-
-// CHECK-LABEL: define hidden swiftcc void @"$s13default_actor1CCfD"(%T13default_actor1CC* swiftself %0)
-// CHECK-NOT: ret void
-// CHECK:     call swiftcc void @swift_defaultActor_deallocateResilient(
-// CHECK:     ret void
-actor C : FixedSubclassOfResilientBaseActor {}
-
-// CHECK-LABEL: define hidden swiftcc void @"$s13default_actor1DCfD"(%T13default_actor1DC* swiftself %0)
-// CHECK-NOT: ret void
-// CHECK:     call swiftcc void @swift_defaultActor_deallocate(
-// CHECK:     ret void
-actor D : FixedBaseActor {}

--- a/test/Interpreter/actor_class_forbid_objc_assoc_objects.swift
+++ b/test/Interpreter/actor_class_forbid_objc_assoc_objects.swift
@@ -45,48 +45,6 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
 }
 
 @available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-class Actor3 : Actor2 {}
-
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
-  Tests.test("non-final subclass crash when set assoc object")
-  .crashOutputMatches("objc_setAssociatedObject called on instance")
-  .code {
-    expectCrashLater()
-    let x = Actor3()
-    objc_setAssociatedObject(x, "myKey", "myValue", .OBJC_ASSOCIATION_RETAIN)
-  }
-}
-
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-final class Actor3Final : Actor2 {}
-
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
-  Tests.test("final subclass crash when set assoc object")
-  .crashOutputMatches("objc_setAssociatedObject called on instance")
-  .code {
-    expectCrashLater()
-    let x = Actor3Final()
-    objc_setAssociatedObject(x, "myKey", "myValue", .OBJC_ASSOCIATION_RETAIN)
-  }
-}
-
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-class Actor4<T> : Actor2 {
-  var state: T
-  init(state: T) { self.state = state }
-}
-
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
-  Tests.test("generic subclass crash when set assoc object")
-  .crashOutputMatches("objc_setAssociatedObject called on instance")
-  .code {
-    expectCrashLater()
-    let x = Actor4(state: 5)
-    objc_setAssociatedObject(x, "myKey", "myValue", .OBJC_ASSOCIATION_RETAIN)
-  }
-}
-
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
 actor Actor5<T> {
   var state: T
   init(state: T) { self.state = state }
@@ -106,50 +64,6 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
   .code {
     expectCrashLater()
     let x = Actor5<Int>.self
-    objc_setAssociatedObject(x, "myKey", "myValue", .OBJC_ASSOCIATION_RETAIN)
-  }
-}
-
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-class Actor6<T> : Actor5<T> {
-  override init(state: T) { super.init(state: state) }
-}
-
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
-  Tests.test("sub-generic class base generic class crash when set assoc object")
-  .crashOutputMatches("objc_setAssociatedObject called on instance")
-  .code {
-    expectCrashLater()
-    let x = Actor6(state: 5)
-    objc_setAssociatedObject(x, "myKey", "myValue", .OBJC_ASSOCIATION_RETAIN)
-  }
-}
-
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-final class Actor6Final<T> : Actor5<T> {
-  override init(state: T) { super.init(state: state) }
-}
-
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
-  Tests.test("final sub-generic class base generic class crash when set assoc object")
-  .crashOutputMatches("objc_setAssociatedObject called on instance")
-  .code {
-    expectCrashLater()
-    let x = Actor6Final(state: 5)
-    objc_setAssociatedObject(x, "myKey", "myValue", .OBJC_ASSOCIATION_RETAIN)
-  }
-
-  Tests.test("final sub-generic class base generic class crash when set assoc object2")
-  .code {
-    let x = Actor6Final(state: 5)
-    print(type(of: x))
-  }
-
-  Tests.test("final sub-generic class metatype, base generic class crash when set assoc object")
-  .crashOutputMatches("objc_setAssociatedObject called on instance")
-  .code {
-    expectCrashLater()
-    let x = Actor6Final<Int>.self
     objc_setAssociatedObject(x, "myKey", "myValue", .OBJC_ASSOCIATION_RETAIN)
   }
 }

--- a/test/Interpreter/actor_subclass_metatypes.swift
+++ b/test/Interpreter/actor_subclass_metatypes.swift
@@ -26,23 +26,3 @@ Tests.test("base generic class")
   let x = Actor5(state: 5)
   print(type(of: x))
 }
-
-class Actor6<T> : Actor5<T> {
-  override init(state: T) { super.init(state: state) }
-}
-
-Tests.test("non-final sub-generic class parent generic class crash")
-  .code {
-  let x = Actor6(state: 5)
-  print(type(of: x))
-}
-
-final class Actor6Final<T> : Actor5<T> {
-  override init(state: T) { super.init(state: state) }
-}
-
-Tests.test("final sub-generic class parent generic class crash")
-  .code {
-  let x = Actor6Final(state: 5)
-  print(type(of: x))
-}

--- a/test/ModuleInterface/actor_isolation.swift
+++ b/test/ModuleInterface/actor_isolation.swift
@@ -38,9 +38,3 @@ public class C2 { }
 
 // CHECK: @{{(Test.)?}}SomeGlobalActor public class C2
 public class C3: C2 { }
-
-// CHECK: public actor SomeSubActor
-// CHECK-NEXT: @actorIndependent public func maine()
-public actor SomeSubActor: SomeActor {
-  override public func maine() { }
-}

--- a/test/decl/class/actor/basic.swift
+++ b/test/decl/class/actor/basic.swift
@@ -4,16 +4,17 @@
 
 actor MyActor { }
 
-class MyActorSubclass1: MyActor { }
+class MyActorSubclass1: MyActor { } // expected-error{{actor types do not support inheritance}}
+// expected-error@-1{{non-final class 'MyActorSubclass1' cannot conform to `Sendable`; use `UnsafeSendable`}}
 
-actor MyActorSubclass2: MyActor { }
+actor MyActorSubclass2: MyActor { } // expected-error{{actor types do not support inheritance}}
 
 // expected-warning@+1{{'actor class' has been renamed to 'actor'}}{{7-13=}}
 actor class MyActorClass { }
 
 class NonActor { }
 
-actor NonActorSubclass : NonActor { } // expected-error{{actor cannot inherit from non-actor class 'NonActor'}}
+actor NonActorSubclass : NonActor { } // expected-error{{actor types do not support inheritance}}
 
 // expected-warning@+1{{'actor class' has been renamed to 'actor'}}{{14-20=}}
 public actor class BobHope {}

--- a/test/decl/class/actor/noconcurrency.swift
+++ b/test/decl/class/actor/noconcurrency.swift
@@ -1,4 +1,8 @@
 // RUN: %target-typecheck-verify-swift
 
-actor class C { } // expected-error{{'actor' modifier is only valid when experimental concurrency is enabled}}
+actor C {
+  nonisolated func f() { } // expected-error{{'nonisolated' modifier is only valid when experimental concurrency is enabled}}
+}
+
+
 

--- a/test/decl/protocol/special/Actor.swift
+++ b/test/decl/protocol/special/Actor.swift
@@ -19,16 +19,17 @@ actor A3<T>: Actor {
 }
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-actor A4: A1 {
+actor A4: A1 { // expected-error{{actor types do not support inheritance}}
 }
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-actor A5: A2 {
+actor A5: A2 { // expected-error{{actor types do not support inheritance}}
 }
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor A6: A1, Actor { // expected-error{{redundant conformance of 'A6' to protocol 'Actor'}}
   // expected-note@-1{{'A6' inherits conformance to protocol 'Actor' from superclass here}}
+  // expected-error@-2{{actor types do not support inheritance}}
 }
 
 // Explicitly satisfying the requirement.


### PR DESCRIPTION
Fix a few small but important issues with actors and the concurrency APIs:
* Disable actor inheritance
* Enable actors by default (no need for compiler flags)
* Add `asyncDetached` API
* Bring `async` API up-to-date with the structured concurrency proposal
* Clean up handling of priorities in concurrency APIs and deprecate `Task.Priority.unspecified`