### PR TITLE
[ABI] Set a bit in the class context descriptor for actor types.

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -4290,6 +4290,10 @@ public:
     return FieldOffsetVectorOffset;
   }
 
+  bool isActor() const {
+    return this->getTypeContextDescriptorFlags().class_isActor();
+  }
+
   bool isDefaultActor() const {
     return this->getTypeContextDescriptorFlags().class_isDefaultActor();
   }

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1389,6 +1389,11 @@ class TypeContextDescriptorFlags : public FlagSet<uint16_t> {
 
     // Type-specific flags:
 
+    /// Set if the class is an actor.
+    ///
+    /// Only meaningful for class descriptors.
+    Class_IsActor = 7,
+
     /// Set if the class is a default actor class.  Note that this is
     /// based on the best knowledge available to the class; actor
     /// classes with resilient superclassess might be default actors
@@ -1479,6 +1484,9 @@ public:
   FLAGSET_DEFINE_FLAG_ACCESSORS(Class_IsDefaultActor,
                                 class_isDefaultActor,
                                 class_setIsDefaultActor)
+  FLAGSET_DEFINE_FLAG_ACCESSORS(Class_IsActor,
+                                class_isActor,
+                                class_setIsActor)
 
   FLAGSET_DEFINE_FIELD_ACCESSORS(Class_ResilientSuperclassReferenceKind,
                                  Class_ResilientSuperclassReferenceKind_width,

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1620,6 +1620,9 @@ namespace {
         if (MetadataLayout->hasResilientSuperclass())
           flags.class_setHasResilientSuperclass(true);
 
+        if (getType()->isActor())
+          flags.class_setIsActor(true);
+
         if (getType()->isDefaultActor(IGM.getSwiftModule(),
                                       ResilienceExpansion::Maximal))
           flags.class_setIsDefaultActor(true);

--- a/test/IRGen/async/default_actor.swift
+++ b/test/IRGen/async/default_actor.swift
@@ -4,9 +4,9 @@
 // REQUIRES: concurrency
 
 // CHECK: @"$s13default_actor1ACMn" = hidden constant
-//   0x81000050: 0x01000000 IsDefaultActor
-//   0x81010050: the same, but using a singleton metadata initialization
-// CHECK-SAME: i32 {{-2130706352|-2130640816}},
+//   0x81800050: 0x01800000 IsActor + IsDefaultActor
+//   0x81810050: the same, but using a singleton metadata initialization
+// CHECK-SAME: i32 {{-2122317744|-2122252208}},
 
 // CHECK: @"$s13default_actor1BCMn" = hidden constant
 //   0x62010050: 0x02000000 IndirectTypeDescriptor + 0x01000000 IsDefaultActor

--- a/test/IRGen/async/default_actor.swift
+++ b/test/IRGen/async/default_actor.swift
@@ -8,18 +8,6 @@
 //   0x81810050: the same, but using a singleton metadata initialization
 // CHECK-SAME: i32 {{-2122317744|-2122252208}},
 
-// CHECK: @"$s13default_actor1BCMn" = hidden constant
-//   0x62010050: 0x02000000 IndirectTypeDescriptor + 0x01000000 IsDefaultActor
-// CHECK-SAME: i32 1644232784,
-
-// CHECK: @"$s13default_actor1CCMn" = hidden constant
-//   0x62010050: 0x02000000 IndirectTypeDescriptor + 0x01000000 IsDefaultActor
-// CHECK-SAME: i32 1644232784,
-
-// CHECK: @"$s13default_actor1DCMn" = hidden constant
-//   0x63010050: 0x02000000 IndirectTypeDescriptor + 0x01000000 IsDefaultActor
-// CHECK-SAME: i32 1661010000,
-
 import resilient_actor
 
 // CHECK-LABEL: define hidden swiftcc void @"$s13default_actor1ACfD"(%T13default_actor1AC* swiftself %0)
@@ -27,21 +15,3 @@ import resilient_actor
 // CHECK:     call swiftcc void @swift_defaultActor_deallocate(
 // CHECK:     ret void
 actor A {}
-
-// CHECK-LABEL: define hidden swiftcc void @"$s13default_actor1BCfD"(%T13default_actor1BC* swiftself %0)
-// CHECK-NOT: ret void
-// CHECK:     call swiftcc void @swift_defaultActor_deallocateResilient(
-// CHECK:     ret void
-actor B : ResilientBaseActor {}
-
-// CHECK-LABEL: define hidden swiftcc void @"$s13default_actor1CCfD"(%T13default_actor1CC* swiftself %0)
-// CHECK-NOT: ret void
-// CHECK:     call swiftcc void @swift_defaultActor_deallocateResilient(
-// CHECK:     ret void
-actor C : FixedSubclassOfResilientBaseActor {}
-
-// CHECK-LABEL: define hidden swiftcc void @"$s13default_actor1DCfD"(%T13default_actor1DC* swiftself %0)
-// CHECK-NOT: ret void
-// CHECK:     call swiftcc void @swift_defaultActor_deallocate(
-// CHECK:     ret void
-actor D : FixedBaseActor {}


### PR DESCRIPTION
Allow runtime metadata queries to determine if a "class" (in the
runtime) is actually an actor by adding a bit to the class context
descriptor's type-specific kind flags.

Implements rdar://77073762.
