### PR TITLE
SILCombine: fix keypath optimization with optional chaining and classes

### DIFF
--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -sil-combine | %FileCheck %s
 
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also
@@ -4225,4 +4225,43 @@ bb0:
   strong_release %0 : $_ContiguousArrayStorage<Int>
   return %16 : $Int
 } // end sil function 'test_global_value'
+
+final class Kp1 {
+  @_hasStorage @_hasInitialValue final var b: Kp2? { get set }
+  @objc deinit
+  init()
+}
+
+class Kp2 {
+  @_hasStorage @_hasInitialValue var s: String { get set }
+  @objc deinit
+  init()
+}
+
+sil @kpgetter : $@convention(thin) (@in_guaranteed Kp2) -> @out String
+sil @kpsetter : $@convention(thin) (@in_guaranteed String, @in_guaranteed Kp2) -> ()
+sil @swift_getAtKeyPath : $@convention(thin) <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, @guaranteed KeyPath<τ_0_0, τ_0_1>) -> @out τ_0_1
+
+// Test keypath optimization for optional chaining with accesses scopes.
+// E.g.   \.a?.b   (on a class)
+//
+// CHECK-LABEL: sil @test_optional_chaining_keypath
+// CHECK:    [[BA:%[0-9]+]] = begin_access
+// CHECK:    switch_enum {{.*}} case #Optional.none!enumelt: bb2, case #Optional.some!enumelt: bb1
+// CHECK:  bb1:
+// CHECK:    apply
+// CHECK:    end_access [[BA]]
+// CHECK:  bb2:
+// CHECK:    end_access [[BA]]
+// CHECK:  bb3:
+// CHECK:     } // end sil function 'test_optional_chaining_keypath'
+sil @test_optional_chaining_keypath : $@convention(thin) (@in_guaranteed Kp1) -> @out Optional<String> {
+bb0(%0 : $*Optional<String>, %1 : $*Kp1):
+  %kp = keypath $KeyPath<Kp1, Optional<String>>, (root $Kp1; stored_property #Kp1.b : $Optional<Kp2>; optional_chain : $Kp2; settable_property $String,  id #Kp2.s!getter : (Kp2) -> () -> String, getter @kpgetter : $@convention(thin) (@in_guaranteed Kp2) -> @out String, setter @kpsetter : $@convention(thin) (@in_guaranteed String, @in_guaranteed Kp2) -> (); optional_wrap : $Optional<String>)
+  %f = function_ref @swift_getAtKeyPath : $@convention(thin) <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, @guaranteed KeyPath<τ_0_0, τ_0_1>) -> @out τ_0_1
+  %a = apply %f<Kp1, Optional<String>>(%0, %1, %kp) : $@convention(thin) <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, @guaranteed KeyPath<τ_0_0, τ_0_1>) -> @out τ_0_1
+  strong_release %kp : $KeyPath<Kp1, Optional<String>>
+  %r = tuple ()
+  return %r : $()
+}
 


### PR DESCRIPTION
For optional chaining a swift_enum is created.
If the sub-projection is ending a begin_access in the some-branch, it also needs to be ended in the none-branch.

Fixes a compiler crash and/or a miscompile.

https://bugs.swift.org/browse/SR-14534
rdar://77224220
