### PR TITLE
[TaskLocals] Windows: fix missing io.h

### DIFF
--- a/stdlib/public/Concurrency/TaskLocal.cpp
+++ b/stdlib/public/Concurrency/TaskLocal.cpp
@@ -26,6 +26,10 @@
 #include <android/log.h>
 #endif
 
+#if defined(_WIN32)
+#include <io.h>
+#endif
+
 using namespace swift;
 
 // =============================================================================


### PR DESCRIPTION
TaskLocals print a verbose error before crashing if API is abused within a task-group.
This printing needs `io.h` on windows.
