### PR TITLE
[Clang importer] Fix mirroring of protocol decls for 'async' imports.

### DIFF
--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -164,3 +164,10 @@ class MyButton : NXButton {
 func testButtons(mb: MyButton) {
   mb.onButtonPress()
 }
+
+
+func testMirrored(instance: ClassWithAsync) async {
+  await instance.instanceAsync()
+  await instance.protocolMethod()
+  await instance.customAsyncName()
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -161,4 +161,13 @@ void doSomethingConcurrentlyButUnsafe(__attribute__((noescape)) __attribute__((s
 MAIN_ACTOR MAIN_ACTOR __attribute__((__swift_attr__("@MainActor(unsafe)"))) @protocol TripleMainActor
 @end
 
+@protocol ProtocolWithAsync
+- (void)protocolMethodWithCompletionHandler:(void (^)(void))completionHandler;
+- (void)customAsyncNameProtocolMethodWithCompletionHandler:(void (^)(void))completionHandler __attribute__((swift_async_name("customAsyncName()")));
+@end
+
+@interface ClassWithAsync: NSObject <ProtocolWithAsync>
+- (void)instanceMethodWithCompletionHandler:(void (^)(void))completionHandler __attribute__((swift_async_name("instanceAsync()")));
+@end
+
 #pragma clang assume_nonnull end


### PR DESCRIPTION
The de-duplication checks to preventing redundant mirroring of protocol
declarations failed to consider that a given method could be
implemented as both 'async' and non-'async' declarations, and
therefore would fail to mirror the 'async' form. Account for this
distinction.

Fixes rdar://76799297.
