### PR TITLE
[5.5] Mark imported @completionHandlerAsync attrs as implicit

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -625,7 +625,7 @@ SIMPLE_DECL_ATTR(reasync, AtReasync,
   110)
 
 DECL_ATTR(completionHandlerAsync, CompletionHandlerAsync,
-  OnAbstractFunction | ConcurrencyOnly | LongAttribute | UserInaccessible |
+  OnAbstractFunction | ConcurrencyOnly | LongAttribute |
   ABIStableToAdd | ABIStableToRemove |
   APIStableToAdd | APIStableToRemove,
   111)

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2077,9 +2077,10 @@ public:
   CompletionHandlerAsyncAttr(AbstractFunctionDecl &asyncFunctionDecl,
                              size_t completionHandlerIndex,
                              SourceLoc completionHandlerIndexLoc,
-                             SourceLoc atLoc, SourceRange range)
+                             SourceLoc atLoc, SourceRange range,
+                             bool implicit)
       : DeclAttribute(DAK_CompletionHandlerAsync, atLoc, range,
-                      /*implicit*/ false),
+                      implicit),
         AsyncFunctionDecl(&asyncFunctionDecl) ,
         CompletionHandlerIndex(completionHandlerIndex),
         CompletionHandlerIndexLoc(completionHandlerIndexLoc) {}

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1090,7 +1090,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     } else {
       Printer << attr->AsyncFunctionName;
     }
-    Printer << "\", completionHandleIndex: " <<
+    Printer << "\", completionHandlerIndex: " <<
         attr->CompletionHandlerIndex << ')';
     break;
   }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8104,7 +8104,7 @@ void addCompletionHandlerAttribute(Decl *asyncImport,
       member->getAttrs().add(
           new (SwiftContext) CompletionHandlerAsyncAttr(
               cast<AbstractFunctionDecl>(*asyncImport), completionIndex,
-              SourceLoc(), SourceLoc(), SourceRange()));
+              SourceLoc(), SourceLoc(), SourceRange(), /*implicit*/ true));
     }
   }
 }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4639,16 +4639,17 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
       }
 
       case decls_block::CompletionHandlerAsync_DECL_ATTR: {
+        bool isImplicit;
         uint64_t handlerIndex;
         uint64_t asyncFunctionDeclID;
         serialization::decls_block::CompletionHandlerAsyncDeclAttrLayout::
-            readRecord(scratch, handlerIndex, asyncFunctionDeclID);
+            readRecord(scratch, isImplicit, handlerIndex, asyncFunctionDeclID);
 
         auto mappedFunctionDecl =
             cast<AbstractFunctionDecl>(MF.getDecl(asyncFunctionDeclID));
         Attr = new (ctx) CompletionHandlerAsyncAttr(
             *mappedFunctionDecl, handlerIndex, /*handlerIndexLoc*/ SourceLoc(),
-            /*atLoc*/ SourceLoc(), /*range*/ SourceRange());
+            /*atLoc*/ SourceLoc(), /*range*/ SourceRange(), isImplicit);
         break;
       }
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 610; // async initializers for nominal types
+const uint16_t SWIFTMODULE_VERSION_MINOR = 611; // implicit bit for CompletionHandlerAsyncAttr
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1930,6 +1930,7 @@ namespace decls_block {
 
   using CompletionHandlerAsyncDeclAttrLayout = BCRecordLayout<
     CompletionHandlerAsync_DECL_ATTR,
+    BCFixed<1>,                 // Implicit flag.
     BCVBR<5>,                   // Completion handler index
     DeclIDField                 // Mapped async function decl
   >;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2633,8 +2633,8 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       auto asyncFuncDeclID = S.addDeclRef(attr->AsyncFunctionDecl);
 
       CompletionHandlerAsyncDeclAttrLayout::emitRecord(
-          S.Out, S.ScratchRecord, abbrCode, attr->CompletionHandlerIndex,
-          asyncFuncDeclID);
+          S.Out, S.ScratchRecord, abbrCode, attr->isImplicit(),
+          attr->CompletionHandlerIndex, asyncFuncDeclID);
       return;
     }
     }

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=ObjCConcurrency -function-definitions=false -enable-experimental-concurrency > %t/ObjCConcurrency.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -print-implicit-attrs -source-filename %s -module-to-print=ObjCConcurrency -function-definitions=false -enable-experimental-concurrency > %t/ObjCConcurrency.printed.txt
 // RUN: %FileCheck -input-file %t/ObjCConcurrency.printed.txt %s
 
 // REQUIRES: objc_interop
@@ -11,42 +11,52 @@ import _Concurrency
 
 // CHECK: @completionHandlerAsync("doSomethingSlow(_:)", completionHandleIndex: 1)
 // CHECK-NEXT: func doSomethingSlow(_ operation: String, completionHandler handler: @escaping (Int) -> Void)
+// CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func doSomethingSlow(_ operation: String) async -> Int
 
 // CHECK: @completionHandlerAsync("doSomethingDangerous(_:)", completionHandleIndex: 1)
 // CHECK-NEXT: func doSomethingDangerous(_ operation: String, completionHandler handler: ((String?, Error?) -> Void)? = nil)
+// CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func doSomethingDangerous(_ operation: String) async throws -> String
 
 // CHECK: @completionHandlerAsync("checkAvailability()", completionHandleIndex: 0)
 // CHECK-NEXT: func checkAvailability(completionHandler: @escaping (Bool) -> Void)
+// CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func checkAvailability() async -> Bool
 
 // CHECK: @completionHandlerAsync("anotherExample()", completionHandleIndex: 0)
 // CHECK-NEXT: func anotherExample(completionBlock block: @escaping (String) -> Void)
+// CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func anotherExample() async -> String
 
 // CHECK: @completionHandlerAsync("finalExample()", completionHandleIndex: 0)
 // CHECK-NEXT: func finalExampleWithReply(to block: @escaping (String) -> Void)
+// CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func finalExample() async -> String
 
 // CHECK: @completionHandlerAsync("replyingOperation(_:)", completionHandleIndex: 1)
 // CHECK-NEXT: func replyingOperation(_ operation: String, replyTo block: @escaping (String) -> Void)
+// CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func replyingOperation(_ operation: String) async -> String
 
 // CHECK: @completionHandlerAsync("findAnswer()", completionHandleIndex: 0)
 // CHECK-NEXT: func findAnswer(completionHandler handler: @escaping (String?, Error?) -> Void)
+// CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func findAnswer() async throws -> String
 
 // CHECK: @completionHandlerAsync("findAnswerFailingly()", completionHandleIndex: 0)
 // CHECK-NEXT: func findAnswerFailingly(completionHandler handler: @escaping (String?, Error?) -> Void) throws
+// CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func findAnswerFailingly() async throws -> String
 
 // CHECK: @completionHandlerAsync("findQAndA()", completionHandleIndex: 0)
 // CHECK-NEXT: func findQAndA(completionHandler handler: @escaping (String?, String?, Error?) -> Void)
+// CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func findQAndA() async throws -> (String?, String)
 
 // CHECK: @completionHandlerAsync("findQuestionableAnswers()", completionHandleIndex: 0)
 // CHECK-NEXT: func findQuestionableAnswers(completionHandler handler: @escaping CompletionHandler)
+// CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func findQuestionableAnswers() async throws -> (String, String?)
 
 // CHECK: @completionHandlerAsync("doSomethingFun(_:)", completionHandleIndex: 1)
@@ -55,7 +65,9 @@ import _Concurrency
 
 // CHECK: @completionHandlerAsync("doSomethingConflicted(_:)", completionHandleIndex: 1)
 // CHECK-NEXT: func doSomethingConflicted(_ operation: String, completionHandler handler: @escaping (Int) -> Void)
+// CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func doSomethingConflicted(_ operation: String) async -> Int
+// CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func doSomethingConflicted(_ operation: String) -> Int
 
 // CHECK: func dance(_ step: String) async -> String
@@ -63,10 +75,12 @@ import _Concurrency
 
 // CHECK: @completionHandlerAsync("runOnMainThread()", completionHandleIndex: 0)
 // CHECK-NEXT: func runOnMainThread(completionHandler completion: (@MainActor (String) -> Void)? = nil)
+// CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func runOnMainThread() async -> String
 
 // CHECK: @completionHandlerAsync("asyncImportSame(_:)", completionHandleIndex: 1)
 // CHECK-NEXT: func asyncImportSame(_ operation: String, completionHandler handler: @escaping (Int) -> Void)
+// CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func asyncImportSame(_ operation: String) async -> Int
 // CHECK-NEXT: func asyncImportSame(_ operation: String, replyTo handler: @escaping (Int) -> Void)
 // CHECK-NOT: func asyncImportSame(_ operation: String) async -> Int
@@ -76,20 +90,21 @@ import _Concurrency
 // CHECK-LABEL: protocol RefrigeratorDelegate
 // CHECK-NEXT: func someoneDidOpenRefrigerator(_ fridge: Any)
 // CHECK-NEXT: func refrigerator(_ fridge: Any, didGetFilledWithItems items: [Any])
-// CHECK-NEXT: {{^}}  func refrigerator(_ fridge: Any, didGetFilledWithIntegers items: UnsafeMutablePointer<Int>, count: Int)
-// CHECK-NEXT: {{^}}  func refrigerator(_ fridge: Any, willAddItem item: Any)
-// CHECK-NEXT: {{^}}  func refrigerator(_ fridge: Any, didRemoveItem item: Any) -> Bool
+// CHECK-NEXT: {{^}} @objc func refrigerator(_ fridge: Any, didGetFilledWithIntegers items: UnsafeMutablePointer<Int>, count: Int)
+// CHECK-NEXT: {{^}} @objc func refrigerator(_ fridge: Any, willAddItem item: Any)
+// CHECK-NEXT: @discardableResult
+// CHECK-NEXT: {{^}} @objc func refrigerator(_ fridge: Any, didRemoveItem item: Any) -> Bool
 // CHECK-NEXT: {{^[}]$}}
 
 // CHECK-LABEL: protocol ProtocolWithSwiftAttributes {
 // CHECK-NEXT: @actorIndependent func independentMethod()
 // CHECK-NEXT: func asyncHandlerMethod()
-// CHECK-NEXT: {{^}}  @MainActor func mainActorMethod()
-// CHECK-NEXT: {{^}}  @MainActor func uiActorMethod()
-// CHECK-NEXT: {{^}}  optional func missingAtAttributeMethod()
+// CHECK-NEXT: {{^}} @objc @MainActor func mainActorMethod()
+// CHECK-NEXT: {{^}} @objc @MainActor func uiActorMethod()
+// CHECK-NEXT: {{^}} @objc optional func missingAtAttributeMethod()
 // CHECK-NEXT: {{^[}]$}}
 
-// CHECK: {{^}}var MAGIC_NUMBER: Int32 { get }
+// CHECK: {{^}}@actorIndependent(unsafe) var MAGIC_NUMBER: Int32 { get }
 
 // CHECK: func doSomethingConcurrently(_ block: @Sendable () -> Void)
 

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -9,61 +9,61 @@ import _Concurrency
 
 // CHECK-LABEL: class SlowServer : NSObject, ServiceProvider {
 
-// CHECK: @completionHandlerAsync("doSomethingSlow(_:)", completionHandleIndex: 1)
+// CHECK: @completionHandlerAsync("doSomethingSlow(_:)", completionHandlerIndex: 1)
 // CHECK-NEXT: func doSomethingSlow(_ operation: String, completionHandler handler: @escaping (Int) -> Void)
 // CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func doSomethingSlow(_ operation: String) async -> Int
 
-// CHECK: @completionHandlerAsync("doSomethingDangerous(_:)", completionHandleIndex: 1)
+// CHECK: @completionHandlerAsync("doSomethingDangerous(_:)", completionHandlerIndex: 1)
 // CHECK-NEXT: func doSomethingDangerous(_ operation: String, completionHandler handler: ((String?, Error?) -> Void)? = nil)
 // CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func doSomethingDangerous(_ operation: String) async throws -> String
 
-// CHECK: @completionHandlerAsync("checkAvailability()", completionHandleIndex: 0)
+// CHECK: @completionHandlerAsync("checkAvailability()", completionHandlerIndex: 0)
 // CHECK-NEXT: func checkAvailability(completionHandler: @escaping (Bool) -> Void)
 // CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func checkAvailability() async -> Bool
 
-// CHECK: @completionHandlerAsync("anotherExample()", completionHandleIndex: 0)
+// CHECK: @completionHandlerAsync("anotherExample()", completionHandlerIndex: 0)
 // CHECK-NEXT: func anotherExample(completionBlock block: @escaping (String) -> Void)
 // CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func anotherExample() async -> String
 
-// CHECK: @completionHandlerAsync("finalExample()", completionHandleIndex: 0)
+// CHECK: @completionHandlerAsync("finalExample()", completionHandlerIndex: 0)
 // CHECK-NEXT: func finalExampleWithReply(to block: @escaping (String) -> Void)
 // CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func finalExample() async -> String
 
-// CHECK: @completionHandlerAsync("replyingOperation(_:)", completionHandleIndex: 1)
+// CHECK: @completionHandlerAsync("replyingOperation(_:)", completionHandlerIndex: 1)
 // CHECK-NEXT: func replyingOperation(_ operation: String, replyTo block: @escaping (String) -> Void)
 // CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func replyingOperation(_ operation: String) async -> String
 
-// CHECK: @completionHandlerAsync("findAnswer()", completionHandleIndex: 0)
+// CHECK: @completionHandlerAsync("findAnswer()", completionHandlerIndex: 0)
 // CHECK-NEXT: func findAnswer(completionHandler handler: @escaping (String?, Error?) -> Void)
 // CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func findAnswer() async throws -> String
 
-// CHECK: @completionHandlerAsync("findAnswerFailingly()", completionHandleIndex: 0)
+// CHECK: @completionHandlerAsync("findAnswerFailingly()", completionHandlerIndex: 0)
 // CHECK-NEXT: func findAnswerFailingly(completionHandler handler: @escaping (String?, Error?) -> Void) throws
 // CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func findAnswerFailingly() async throws -> String
 
-// CHECK: @completionHandlerAsync("findQAndA()", completionHandleIndex: 0)
+// CHECK: @completionHandlerAsync("findQAndA()", completionHandlerIndex: 0)
 // CHECK-NEXT: func findQAndA(completionHandler handler: @escaping (String?, String?, Error?) -> Void)
 // CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func findQAndA() async throws -> (String?, String)
 
-// CHECK: @completionHandlerAsync("findQuestionableAnswers()", completionHandleIndex: 0)
+// CHECK: @completionHandlerAsync("findQuestionableAnswers()", completionHandlerIndex: 0)
 // CHECK-NEXT: func findQuestionableAnswers(completionHandler handler: @escaping CompletionHandler)
 // CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func findQuestionableAnswers() async throws -> (String, String?)
 
-// CHECK: @completionHandlerAsync("doSomethingFun(_:)", completionHandleIndex: 1)
+// CHECK: @completionHandlerAsync("doSomethingFun(_:)", completionHandlerIndex: 1)
 // CHECK-NEXT: func doSomethingFun(_ operation: String, then completionHandler: @escaping () -> Void)
 // CHECK-NEXT: func doSomethingFun(_ operation: String) async
 
-// CHECK: @completionHandlerAsync("doSomethingConflicted(_:)", completionHandleIndex: 1)
+// CHECK: @completionHandlerAsync("doSomethingConflicted(_:)", completionHandlerIndex: 1)
 // CHECK-NEXT: func doSomethingConflicted(_ operation: String, completionHandler handler: @escaping (Int) -> Void)
 // CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func doSomethingConflicted(_ operation: String) async -> Int
@@ -73,12 +73,12 @@ import _Concurrency
 // CHECK: func dance(_ step: String) async -> String
 // CHECK: func __leap(_ height: Int) async -> String
 
-// CHECK: @completionHandlerAsync("runOnMainThread()", completionHandleIndex: 0)
+// CHECK: @completionHandlerAsync("runOnMainThread()", completionHandlerIndex: 0)
 // CHECK-NEXT: func runOnMainThread(completionHandler completion: (@MainActor (String) -> Void)? = nil)
 // CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func runOnMainThread() async -> String
 
-// CHECK: @completionHandlerAsync("asyncImportSame(_:)", completionHandleIndex: 1)
+// CHECK: @completionHandlerAsync("asyncImportSame(_:)", completionHandlerIndex: 1)
 // CHECK-NEXT: func asyncImportSame(_ operation: String, completionHandler handler: @escaping (Int) -> Void)
 // CHECK-NEXT: @discardableResult
 // CHECK-NEXT: func asyncImportSame(_ operation: String) async -> Int

--- a/test/IDE/print_clang_objc_effectful_properties.swift
+++ b/test/IDE/print_clang_objc_effectful_properties.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=EffectfulProperties -function-definitions=false -enable-experimental-concurrency > %t/EffectfulProperties.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -print-implicit-attrs -source-filename %s -module-to-print=EffectfulProperties -function-definitions=false -enable-experimental-concurrency > %t/EffectfulProperties.printed.txt
 // RUN: %FileCheck -input-file %t/EffectfulProperties.printed.txt %s
 
 // REQUIRES: objc_interop
@@ -31,6 +31,7 @@
 
 // CHECK:  @completionHandlerAsync("regularMainDog()", completionHandleIndex: 0)
 // CHECK-NEXT:  func regularMainDog(_ completion: @escaping @MainActor (String) -> Void)
+// CHECK-NEXT:  @discardableResult
 // CHECK-NEXT:  func regularMainDog() async -> String
 // CHECK: }
 

--- a/test/IDE/print_clang_objc_effectful_properties.swift
+++ b/test/IDE/print_clang_objc_effectful_properties.swift
@@ -29,7 +29,7 @@
 // CHECK:  func getMainDog(_ completion: @escaping @MainActor (String) -> Void)
 // CHECK-NEXT:  var mainDogProp: String { get async }
 
-// CHECK:  @completionHandlerAsync("regularMainDog()", completionHandleIndex: 0)
+// CHECK:  @completionHandlerAsync("regularMainDog()", completionHandlerIndex: 0)
 // CHECK-NEXT:  func regularMainDog(_ completion: @escaping @MainActor (String) -> Void)
 // CHECK-NEXT:  @discardableResult
 // CHECK-NEXT:  func regularMainDog() async -> String

--- a/test/SourceKit/InterfaceGen/Inputs/gen_concurrency.swift
+++ b/test/SourceKit/InterfaceGen/Inputs/gen_concurrency.swift
@@ -1,0 +1,5 @@
+class ClassWithAsyncAndHandler {
+  @completionHandlerAsync("foo(_:)", completionHandlerIndex: 1)
+  func foo(_ operation: String, completionHandler handler: @escaping (Int) -> Void) {}
+  func foo(_ operation: String) async -> Int { 0 }
+}

--- a/test/SourceKit/InterfaceGen/Inputs/header_concurrency.h
+++ b/test/SourceKit/InterfaceGen/Inputs/header_concurrency.h
@@ -1,0 +1,5 @@
+@import Foundation;
+
+@interface ClassWithHandlerMethod
+-(void)methodWithHandler:(NSString *)operation completionHandler:(void (^)(NSInteger))handler;
+@end

--- a/test/SourceKit/InterfaceGen/gen_objc_concurrency.swift
+++ b/test/SourceKit/InterfaceGen/gen_objc_concurrency.swift
@@ -1,0 +1,20 @@
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+
+// RUN: %empty-directory(%t)
+
+// RUN: %sourcekitd-test -req=interface-gen %S/Inputs/gen_concurrency.swift -- %S/Inputs/gen_concurrency.swift -target %target-triple -I %t -Xfrontend -enable-experimental-concurrency | %FileCheck %s --check-prefix=SWIFT-GEN-INTERFACE
+
+// Make sure we print @completionHandlerAsync when it was explicitly written by the user.
+// SWIFT-GEN-INTERFACE-LABEL: class ClassWithAsyncAndHandler {
+// SWIFT-GEN-INTERFACE:         @completionHandlerAsync("foo(_:)", completionHandlerIndex: 1)
+// SWIFT-GEN-INTERFACE-NEXT:    internal func foo(_ operation: String, completionHandler handler: @escaping (Int) -> Void)
+// SWIFT-GEN-INTERFACE:         internal func foo(_ operation: String) async -> Int
+
+// RUN: %sourcekitd-test -req=interface-gen -using-swift-args -header %S/Inputs/header_concurrency.h -- %s -Xfrontend -enable-objc-interop -Xfrontend -enable-experimental-concurrency -import-objc-header %S/Inputs/header_concurrency.h -sdk %clang-importer-sdk | %FileCheck %s --check-prefix=OBJC-GEN-INTERFACE
+
+// But don't print @completionHandlerAsync if it was implicitly added to an imported Clang decl (rdar://76685011).
+// OBJC-GEN-INTERFACE-LABEL: class ClassWithHandlerMethod {
+// OBJC-GEN-INTERFACE-NOT:     @completionHandlerAsync
+// OBJC-GEN-INTERFACE:         func method(withHandler operation: String!, completionHandler handler: ((Int) -> Void)!)
+// OBJC-GEN-INTERFACE:         func method(withHandler operation: String!) async -> Int


### PR DESCRIPTION
*5.5 cherry-pick of https://github.com/apple/swift/pull/37170*

---

Marking the attribute user-inaccessible is too extreme, as we still want it to appear in things like code completion and generated interfaces if it was explicitly written by the user. Instead, mark the attribute as implicit when it's added by the Clang Importer, which stops it from being printed in the generated interface.

In addition, fix a typo with the printing of `@completionHandlerAsync`.

Resolves rdar://76685011.