### PR TITLE
Serialize the information if a module is compiled as static library.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -588,7 +588,10 @@ protected:
     HasAnyUnavailableValues : 1
   );
 
-  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1,
+    /// If the module is compiled as static library.
+    StaticLibrary : 1,
+
     /// If the module was or is being compiled with `-enable-testing`.
     TestingEnabled : 1,
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -416,6 +416,14 @@ public:
     DebugClient = R;
   }
 
+  /// Returns true if this module is compiled as static library.
+  bool isStaticLibrary() const {
+    return Bits.ModuleDecl.StaticLibrary;
+  }
+  void setStaticLibrary(bool isStatic = true) {
+    Bits.ModuleDecl.StaticLibrary = isStatic;
+  }
+
   /// Returns true if this module was or is being compiled for testing.
   bool isTestingEnabled() const {
     return Bits.ModuleDecl.TestingEnabled;

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -311,6 +311,9 @@ public:
   /// skip nodes entirely, depending on the errors involved.
   bool AllowModuleWithCompilerErrors = false;
 
+  /// True if the "-static" option is set.
+  bool Static = false;
+
   /// The different modes for validating TBD against the LLVM IR.
   enum class TBDValidationMode {
     Default,        ///< Do the default validation for the current platform.

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -300,6 +300,10 @@ private:
   /// serialization.
   unsigned WasDeserializedCanonical : 1;
 
+  /// True if this function was imported from a module which is compiled as
+  /// static library.
+  unsigned ImportedFromStaticLibrary : 1;
+
   /// True if this is a reabstraction thunk of escaping function type whose
   /// single argument is a potentially non-escaping closure. This is an escape
   /// hatch to allow non-escaping functions to be stored or passed as an
@@ -532,6 +536,14 @@ public:
 
   void setWasDeserializedCanonical(bool val = true) {
     WasDeserializedCanonical = val;
+  }
+
+  /// Returns true if this function was imported from a module which is compiled
+  /// as static library.
+  bool wasImportedFromStaticLibrary() const { return ImportedFromStaticLibrary; }
+
+  void setImportedFromStaticLibrary(bool val = true) {
+    ImportedFromStaticLibrary = val;
   }
 
   /// Returns true if this is a reabstraction thunk of escaping function type

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -134,6 +134,7 @@ namespace swift {
     bool SerializeOptionsForDebugging = false;
     bool IsSIB = false;
     bool DisableCrossModuleIncrementalInfo = false;
+    bool StaticLibrary = false;
   };
 
 } // end namespace swift

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -97,6 +97,7 @@ class ExtendedValidationInfo {
   struct {
     unsigned ArePrivateImportsEnabled : 1;
     unsigned IsSIB : 1;
+    unsigned IsStaticLibrary: 1;
     unsigned IsTestable : 1;
     unsigned ResilienceStrategy : 2;
     unsigned IsImplicitDynamicEnabled : 1;
@@ -129,6 +130,10 @@ public:
   bool isImplicitDynamicEnabled() { return Bits.IsImplicitDynamicEnabled; }
   void setImplicitDynamicEnabled(bool val) {
     Bits.IsImplicitDynamicEnabled = val;
+  }
+  bool isStaticLibrary() const { return Bits.IsStaticLibrary; }
+  void setIsStaticLibrary(bool val) {
+    Bits.IsStaticLibrary = val;
   }
   bool isTestable() const { return Bits.IsTestable; }
   void setIsTestable(bool val) {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -475,6 +475,7 @@ ModuleDecl::ModuleDecl(Identifier name, ASTContext &ctx,
 
   setAccess(AccessLevel::Public);
 
+  Bits.ModuleDecl.StaticLibrary = 0;
   Bits.ModuleDecl.TestingEnabled = 0;
   Bits.ModuleDecl.FailedToLoad = 0;
   Bits.ModuleDecl.RawResilienceStrategy = 0;

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -251,6 +251,8 @@ bool ArgsToFrontendOptionsConverter::convert(
   
   Opts.SkipInheritedDocs = Args.hasArg(OPT_skip_inherited_docs);
 
+  Opts.Static = Args.hasArg(OPT_static);
+
   return false;
 }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -181,6 +181,8 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
   serializationOpts.DisableCrossModuleIncrementalInfo =
       opts.DisableCrossModuleIncrementalBuild;
 
+  serializationOpts.StaticLibrary = opts.Static;
+
   return serializationOpts;
 }
 

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -178,6 +178,7 @@ void SILFunction::init(SILLinkage Linkage, StringRef Name,
   this->Zombie = false;
   this->HasOwnership = true,
   this->WasDeserializedCanonical = false;
+  this->ImportedFromStaticLibrary = false;
   this->IsWithoutActuallyEscapingThunk = false;
   this->OptMode = unsigned(OptimizationMode::NotSet);
   this->EffectsKindAttr = unsigned(E);

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -219,6 +219,8 @@ SILFunction *SILFunctionBuilder::getOrCreateFunction(
 
   if (constant.hasDecl()) {
     auto decl = constant.getDecl();
+    ModuleDecl *moduleDecl = decl->getModuleContext();
+    F->setImportedFromStaticLibrary(moduleDecl->isStaticLibrary());
 
     if (constant.isForeign && decl->hasClangNode())
       F->setClangNodeOwner(decl);

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -649,6 +649,7 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     fn->setAlwaysWeakImported(isWeakImported);
     fn->setClassSubclassScope(SubclassScope(subclassScope));
     fn->setHasCReferences(bool(hasCReferences));
+    fn->setImportedFromStaticLibrary(MF->isStaticLibrary());
 
     llvm::VersionTuple available;
     DECODE_VER_TUPLE(available);

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -457,6 +457,11 @@ public:
     return Core->Bits.IsTestable;
   }
 
+  /// Whether this module is compiled as static library.
+  bool isStaticLibrary() const {
+    return Core->Bits.IsStaticLibrary;
+  }
+
   /// Whether the module is resilient. ('-enable-library-evolution')
   ResilienceStrategy getResilienceStrategy() const {
     return ResilienceStrategy(Core->Bits.ResilienceStrategy);

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -131,6 +131,9 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
       options_block::IsSIBLayout::readRecord(scratch, IsSIB);
       extendedInfo.setIsSIB(IsSIB);
       break;
+    case options_block::IS_STATICLIBRARY:
+      extendedInfo.setIsStaticLibrary(true);
+      break;
     case options_block::IS_TESTABLE:
       extendedInfo.setIsTestable(true);
       break;
@@ -1174,6 +1177,7 @@ ModuleFileSharedCore::ModuleFileSharedCore(
       CompatibilityVersion = info.compatibilityVersion;
       Bits.ArePrivateImportsEnabled = extInfo.arePrivateImportsEnabled();
       Bits.IsSIB = extInfo.isSIB();
+      Bits.IsStaticLibrary = extInfo.isStaticLibrary();
       Bits.IsTestable = extInfo.isTestable();
       Bits.ResilienceStrategy = unsigned(extInfo.getResilienceStrategy());
       Bits.IsImplicitDynamicEnabled = extInfo.isImplicitDynamicEnabled();

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -323,6 +323,9 @@ private:
     /// Whether this module file is actually a .sib file.
     unsigned IsSIB: 1;
 
+    /// Whether this module is compiled as static library.
+    unsigned IsStaticLibrary: 1;
+
     /// Whether this module file is compiled with '-enable-testing'.
     unsigned IsTestable : 1;
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 610; // async initializers for nominal types
+const uint16_t SWIFTMODULE_VERSION_MINOR = 611; // isStaticLibrary option
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -786,6 +786,7 @@ namespace options_block {
     SDK_PATH = 1,
     XCC,
     IS_SIB,
+    IS_STATICLIBRARY,
     IS_TESTABLE,
     RESILIENCE_STRATEGY,
     ARE_PRIVATE_IMPORTS_ENABLED,
@@ -807,6 +808,10 @@ namespace options_block {
   using IsSIBLayout = BCRecordLayout<
     IS_SIB,
     BCFixed<1> // Is this an intermediate file?
+  >;
+
+  using IsStaticLibraryLayout = BCRecordLayout<
+    IS_STATICLIBRARY
   >;
 
   using IsTestableLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -975,6 +975,11 @@ void Serializer::writeHeader(const SerializationOptions &options) {
       options_block::IsSIBLayout IsSIB(Out);
       IsSIB.emit(ScratchRecord, options.IsSIB);
 
+      if (options.StaticLibrary) {
+        options_block::IsStaticLibraryLayout IsStaticLibrary(Out);
+        IsStaticLibrary.emit(ScratchRecord);
+      }
+
       if (M->isTestingEnabled()) {
         options_block::IsTestableLayout IsTestable(Out);
         IsTestable.emit(ScratchRecord);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -715,6 +715,7 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
 
     // We've loaded the file. Now try to bring it into the AST.
     fileUnit = new (Ctx) SerializedASTFile(M, *loadedModuleFile);
+    M.setStaticLibrary(loadedModuleFile->isStaticLibrary());
     if (loadedModuleFile->isTestable())
       M.setTestingEnabled();
     if (loadedModuleFile->arePrivateImportsEnabled())


### PR DESCRIPTION
If the -static option is specified, store that in the generated swiftmodule file.
When deserializing, set this bit in all SILFunctions which are deserialized from such a module file.

This will be used for code generation on Windows.
