### PR TITLE
[5.5] fix missing effects specifiers on some properties in swiftinterface

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -36,6 +36,7 @@
 
 LANGUAGE_FEATURE(StaticAssert, 0, "#assert", langOpts.EnableExperimentalStaticAssert)
 LANGUAGE_FEATURE(AsyncAwait, 296, "async/await", true)
+LANGUAGE_FEATURE(EffectfulProp, 310, "Effectful properties", langOpts.EnableExperimentalConcurrency)
 LANGUAGE_FEATURE(MarkerProtocol, 0, "@_marker protocol", true)
 LANGUAGE_FEATURE(Actors, 0, "actors", langOpts.EnableExperimentalConcurrency)
 LANGUAGE_FEATURE(ConcurrentFunctions, 0, "@concurrent functions", true)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3496,6 +3496,10 @@ void PrintAST::visitAccessorDecl(AccessorDecl *decl) {
       });
   }
 
+  // handle effects specifiers before the body
+  if (decl->hasAsync()) Printer << " async";
+  if (decl->hasThrows()) Printer << " throws";
+
   printBodyIfNecessary(decl);
 }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2481,6 +2481,12 @@ static bool usesFeatureStaticAssert(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureEffectfulProp(Decl *decl) {
+  if (auto asd = dyn_cast<AbstractStorageDecl>(decl))
+    return asd->getEffectfulGetAccessor() != nullptr;
+  return false;
+}
+
 static bool usesFeatureAsyncAwait(Decl *decl) {
   if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
     if (func->hasAsync())
@@ -2857,6 +2863,12 @@ static std::vector<Feature> getUniqueFeaturesUsed(Decl *decl) {
 
 bool swift::printCompatibilityFeatureChecksPre(
     ASTPrinter &printer, Decl *decl) {
+
+  // A single accessor does not get a feature check,
+  // it should go around the whole decl.
+  if (isa<AccessorDecl>(decl))
+    return false;
+
   auto features = getUniqueFeaturesUsed(decl);
   if (features.empty())
     return false;

--- a/test/ModuleInterface/effectful_properties.swift
+++ b/test/ModuleInterface/effectful_properties.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -enable-experimental-concurrency -typecheck -swift-version 5 -enable-library-evolution -emit-module-interface-path %t.swiftinterface %s -module-name EffProps
+// RUN: %FileCheck %s < %t.swiftinterface
+
+public struct MyStruct {}
+
+// CHECK-LABEL: public var status
+// CHECK: get async throws
+
+public extension MyStruct {
+  struct InnerStruct {
+      public var status: Bool { get async throws { false } }
+    }
+}
+
+// CHECK-LABEL: public var hello
+// CHECK: get async
+
+// CHECK-LABEL: public subscript
+// CHECK: get async throws
+
+public class C {
+  public var hello: Int { get async { 0 } }
+
+  public subscript(_ x: Int) -> Void {
+    get async throws { }
+  }
+}
+
+// CHECK-LABEL: public var world
+// CHECK: get throws
+
+public enum E {
+  public var world: Int { get throws { 0 } }
+}

--- a/test/ModuleInterface/effectful_properties.swift
+++ b/test/ModuleInterface/effectful_properties.swift
@@ -3,8 +3,11 @@
 
 public struct MyStruct {}
 
-// CHECK-LABEL: public var status
-// CHECK: get async throws
+// CHECK-LABEL:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK:        public var status: Swift.Bool {
+// CHECK:          get async throws
+// CHECK:        }
+// CHECK:        #endif
 
 public extension MyStruct {
   struct InnerStruct {
@@ -12,11 +15,18 @@ public extension MyStruct {
     }
 }
 
-// CHECK-LABEL: public var hello
-// CHECK: get async
+// CHECK-LABEL:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK:        public var hello: Swift.Int {
+// CHECK:            get async
+// CHECK:          }
+// CHECK:        #endif
 
-// CHECK-LABEL: public subscript
-// CHECK: get async throws
+
+// CHECK-LABEL:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK:        public subscript(x: Swift.Int) -> Swift.Void {
+// CHECK:            get async throws
+// CHECK:          }
+// CHECK:        #endif
 
 public class C {
   public var hello: Int { get async { 0 } }
@@ -26,9 +36,26 @@ public class C {
   }
 }
 
-// CHECK-LABEL: public var world
-// CHECK: get throws
+// CHECK-LABEL:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK:        public var world: Swift.Int {
+// CHECK:          get throws
+// CHECK:        }
+// CHECK:        #endif
 
 public enum E {
   public var world: Int { get throws { 0 } }
+}
+
+// CHECK-LABEL:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK:        var books: Swift.Int { get async }
+// CHECK:        #endif
+
+
+// CHECK-LABEL:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK:        subscript(x: Swift.Int) -> Swift.Int { get throws }
+// CHECK:        #endif
+
+public protocol P {
+  var books: Int { get async }
+  subscript(_ x: Int) -> Int { get throws }
 }


### PR DESCRIPTION
Cherry-pick for 5.5 of https://github.com/apple/swift/pull/37156  and https://github.com/apple/swift/pull/37190 to resolve rdar://77324796
