### PR TITLE
[5.5] IRGen: Don't ignore the error parameter in some async functions

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2668,7 +2668,7 @@ void CallEmission::emitToUnmappedMemory(Address result) {
   auto call = emitCallSite();
 
   // Async calls need to store the error result that is passed as a parameter.
-  if (IGF.isAsync()) {
+  if (CurCallee.getSubstFunctionType()->isAsync()) {
     auto &IGM = IGF.IGM;
     auto &Builder = IGF.Builder;
     auto numAsyncContextParams =

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2487,14 +2487,16 @@ public:
   }
   void emitCallToUnmappedExplosion(llvm::CallInst *call, Explosion &out) override {
     // Bail out on a void result type.
+    auto &IGM = IGF.IGM;
     llvm::Value *result = call;
     auto *suspendResultTy = cast<llvm::StructType>(result->getType());
     auto numAsyncContextParams =
-        getCalleeFunctionPointer().getSignature().getAsyncContextIndex() + 1;
+        Signature::forAsyncReturn(IGM, getCallee().getSubstFunctionType())
+            .getAsyncContextIndex() +
+        1;
     if (suspendResultTy->getNumElements() == numAsyncContextParams)
       return;
 
-    auto &IGM = IGF.IGM;
     auto &Builder = IGF.Builder;
 
     auto resultTys =
@@ -2663,7 +2665,29 @@ void CallEmission::emitToUnmappedMemory(Address result) {
   LastArgWritten = 0; // appease an assert
 #endif
   
-  emitCallSite();
+  auto call = emitCallSite();
+
+  // Async calls need to store the error result that is passed as a parameter.
+  if (IGF.isAsync()) {
+    auto &IGM = IGF.IGM;
+    auto &Builder = IGF.Builder;
+    auto numAsyncContextParams =
+        Signature::forAsyncReturn(IGM, CurCallee.getSubstFunctionType())
+            .getAsyncContextIndex() +
+        1;
+
+    auto substCalleeType = CurCallee.getSubstFunctionType();
+    SILFunctionConventions substConv(substCalleeType, IGF.getSILModule());
+    auto hasError = substCalleeType->hasErrorResult();
+    SILType errorType;
+    if (hasError) {
+      errorType =
+          substConv.getSILErrorType(IGM.getMaximalTypeExpansionContext());
+      auto result = Builder.CreateExtractValue(call, numAsyncContextParams);
+      Address errorAddr = IGF.getCalleeErrorResultSlot(errorType);
+      Builder.CreateStore(result, errorAddr);
+    }
+  }
 }
 
 /// The private routine to ultimately emit a call or invoke instruction.

--- a/test/Concurrency/throwing.swift
+++ b/test/Concurrency/throwing.swift
@@ -1,0 +1,88 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency -parse-as-library)
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import _Concurrency
+import StdlibUnittest
+
+class P<T> {
+  var t: T
+  init(_ v: T) {
+    t = v
+  }
+}
+
+class A {}
+class B {}
+class C {}
+
+enum E : Error {
+    case err
+}
+
+protocol MP { }
+
+class M : MP {
+
+  @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+  func throwWithIndirectResult<T>(_ a: P<T>) async throws -> T {
+    throw E.err
+  }
+}
+
+extension MP {
+  @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+  func l<A, B, C, D, E2, F> (_ a : P<A>, _ b: P<B>, _ c: P<C>, _ d : P<D>, _ e: P<E2>, _ f: P<F>) async throws -> (A, B, C, D, E2, F) {
+    throw E.err
+  }
+}
+
+@main struct Main {
+  static func main() async {
+    var tests = TestSuite("Async Throw")
+
+    if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+      tests.test("throwing of naturally direct but indirect reabstration") {
+        let task2 = detach {
+          let m = M()
+          await verifyCancelled {
+            try await m.l(P(A()), P(B()), P(C()), P(A()), P(B()), P(C()))
+          }
+          func verifyCancelled<T>(execute operation: () async throws -> T) async {
+            do {
+              let _ = try await operation()
+              assertionFailure("operation() threw")
+            }
+            catch _ as E {
+              // This is what we expect to happen
+            }
+            catch {
+             assertionFailure("unknown error thrown")
+            }
+          }
+        }
+        _ = await task2.get()
+      }
+      tests.test("throwing with indirect result") {
+        let task2 = detach {
+          let m = M()
+          do {
+            let _ = try await m.throwWithIndirectResult(P(A()))
+            assertionFailure("operation() threw")
+          }
+          catch _ as E {
+            // This is what we expect to happen
+          }
+          catch {
+           assertionFailure("unknown error thrown")
+          }
+        }
+        _ = await task2.get()
+      }
+    }
+    await runAllTestsAsync()
+  }
+}


### PR DESCRIPTION
Calls that emit the result to memory follow a different path that we
missed to update with error handling code.

rdar://76599021