### PR TITLE
Mark an LTO Test Unsupported on arm64_32

### DIFF
--- a/test/IRGen/lto_autolink.swift
+++ b/test/IRGen/lto_autolink.swift
@@ -63,3 +63,4 @@ import AutolinkModuleMapLink
 #endif
 
 // UNSUPPORTED: OS=macosx && CPU=arm64
+// UNSUPPORTED: OS=watchos && CPU=arm64_32


### PR DESCRIPTION
The %target-cpu annotations here cause us to form the triple
arm64_32-unknown-linux-gnu which is not a valid triple. We don't need to
run these tests on arm64_32 platforms anyways.

rdar://77398372