### PR TITLE
[Test] Disable objc_swift3_deprecated_objc_inference.swift for 32 bits watchOS

### DIFF
--- a/test/Interpreter/SDK/objc_swift3_deprecated_objc_inference.swift
+++ b/test/Interpreter/SDK/objc_swift3_deprecated_objc_inference.swift
@@ -18,6 +18,9 @@
 // Requires explicit swift-version 4.
 // UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
 
+// rdar://77087781
+// UNSUPPORTED: OS=watchos && CPU=arm64_32
+
 import StdlibUnittest
 import Foundation
 


### PR DESCRIPTION
Cherry-pick disable from https://github.com/apple/swift/pull/37187 for 5.5.

rdar://77087781