### PR TITLE
fix feature guards in swiftinterface for eff. props

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -36,6 +36,7 @@
 
 LANGUAGE_FEATURE(StaticAssert, 0, "#assert", langOpts.EnableExperimentalStaticAssert)
 LANGUAGE_FEATURE(AsyncAwait, 296, "async/await", true)
+LANGUAGE_FEATURE(EffectfulProp, 310, "Effectful properties", langOpts.EnableExperimentalConcurrency)
 LANGUAGE_FEATURE(MarkerProtocol, 0, "@_marker protocol", true)
 LANGUAGE_FEATURE(Actors, 0, "actors", true)
 LANGUAGE_FEATURE(ConcurrentFunctions, 0, "@concurrent functions", true)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2475,6 +2475,12 @@ static bool usesFeatureStaticAssert(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureEffectfulProp(Decl *decl) {
+  if (auto asd = dyn_cast<AbstractStorageDecl>(decl))
+    return asd->getEffectfulGetAccessor() != nullptr;
+  return false;
+}
+
 static bool usesFeatureAsyncAwait(Decl *decl) {
   if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
     if (func->hasAsync())
@@ -2834,6 +2840,12 @@ static std::vector<Feature> getUniqueFeaturesUsed(Decl *decl) {
 
 bool swift::printCompatibilityFeatureChecksPre(
     ASTPrinter &printer, Decl *decl) {
+
+  // A single accessor does not get a feature check,
+  // it should go around the whole decl.
+  if (isa<AccessorDecl>(decl))
+    return false;
+
   auto features = getUniqueFeaturesUsed(decl);
   if (features.empty())
     return false;

--- a/test/ModuleInterface/effectful_properties.swift
+++ b/test/ModuleInterface/effectful_properties.swift
@@ -3,8 +3,11 @@
 
 public struct MyStruct {}
 
-// CHECK-LABEL: public var status
-// CHECK: get async throws
+// CHECK-LABEL:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK:        public var status: Swift.Bool {
+// CHECK:          get async throws
+// CHECK:        }
+// CHECK:        #endif
 
 public extension MyStruct {
   struct InnerStruct {
@@ -12,11 +15,18 @@ public extension MyStruct {
     }
 }
 
-// CHECK-LABEL: public var hello
-// CHECK: get async
+// CHECK-LABEL:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK:        public var hello: Swift.Int {
+// CHECK:            get async
+// CHECK:          }
+// CHECK:        #endif
 
-// CHECK-LABEL: public subscript
-// CHECK: get async throws
+
+// CHECK-LABEL:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK:        public subscript(x: Swift.Int) -> Swift.Void {
+// CHECK:            get async throws
+// CHECK:          }
+// CHECK:        #endif
 
 public class C {
   public var hello: Int { get async { 0 } }
@@ -26,9 +36,26 @@ public class C {
   }
 }
 
-// CHECK-LABEL: public var world
-// CHECK: get throws
+// CHECK-LABEL:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK:        public var world: Swift.Int {
+// CHECK:          get throws
+// CHECK:        }
+// CHECK:        #endif
 
 public enum E {
   public var world: Int { get throws { 0 } }
+}
+
+// CHECK-LABEL:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK:        var books: Swift.Int { get async }
+// CHECK:        #endif
+
+
+// CHECK-LABEL:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK:        subscript(x: Swift.Int) -> Swift.Int { get throws }
+// CHECK:        #endif
+
+public protocol P {
+  var books: Int { get async }
+  subscript(_ x: Int) -> Int { get throws }
 }


### PR DESCRIPTION
Effectful properties were not being properly guarded for feature availability in the swiftinterface file. Previously it was only being guarded if the property was `async` and not just simply `throws`, plus, the guards were around the accessor like this:

```
var x: T {
#if ...
  get async
#endif
}
```

instead of around the whole decl like this

```
#if ...
var x: T {
  get async
}
#endif
```

So, this patch adds two things
1. A new feature in `Features.def` for Effectful Properties (currently set to be enabled only when `-enable-experimental-concurrency` is passed since I haven't enabled it by default yet).
2. A fix for the printing of these guards, to not put them around an accessor, so that it ends up being printed around the enclosing decl instead.

This finishes the resolution to rdar://77324796