### PR TITLE
Update the correct size of Builting.Executor, it is now 2 pointers.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1340,10 +1340,9 @@ private:
     }
 
     case TypeKind::BuiltinExecutor: {
-      unsigned PtrSize = CI.getTargetInfo().getPointerWidth(0);
-      return DBuilder.createPointerType(nullptr, PtrSize, 0,
-                                        /* DWARFAddressSpace */ None,
-                                        MangledName);
+      return createDoublePointerSizedStruct(
+          Scope, "Builtin.Executor", nullptr, MainFile, 0,
+          llvm::DINode::FlagArtificial, MangledName);
     }
 
     case TypeKind::DynamicSelf: {


### PR DESCRIPTION
Fixes an assertion while building the Concurrency module.

(cherry picked from commit a6304c5168bfc67f4288e9e1f1578cc06b6898b8)
