### PR TITLE
[Serialization] Add warning when .swiftsourceinfo is malformed

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -799,6 +799,8 @@ ERROR(serialization_error_type,Fatal,
 ERROR(serialization_allowing_error_type,none,
       "allowing deserialization of error type '%0' in module '%1'",
       (StringRef, StringRef))
+WARNING(serialization_malformed_sourceinfo,none,
+      "unable to use malformed module source info '%0'", (StringRef))
 
 ERROR(reserved_member_name,none,
       "type member must not be named %0, since it would conflict with the"

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -476,6 +476,13 @@ public:
   /// \c true if this module has incremental dependency information.
   bool hasIncrementalInfo() const { return Core->hasIncrementalInfo(); }
 
+  /// \c true if this module has a corresponding .swiftsourceinfo file.
+  bool hasSourceInfoFile() const { return Core->hasSourceInfoFile(); }
+
+  /// \c true if this module has information from a corresponding
+  /// .swiftsourceinfo file (ie. the file exists and has been read).
+  bool hasSourceInfo() const { return Core->hasSourceInfo(); }
+
   /// Associates this module file with the AST node representing it.
   ///
   /// Checks that the file is compatible with the AST module it's being loaded

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -1490,3 +1490,7 @@ ModuleFileSharedCore::ModuleFileSharedCore(
     return;
   }
 }
+
+bool ModuleFileSharedCore::hasSourceInfo() const {
+  return !!DeclUSRsTable;
+}

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -518,6 +518,13 @@ public:
   /// Returns \c true if this module file contains a section with incremental
   /// information.
   bool hasIncrementalInfo() const { return HasIncrementalInfo; }
+
+  /// Returns \c true if a corresponding .swiftsourceinfo has been found.
+  bool hasSourceInfoFile() const { return !!ModuleSourceInfoInputBuffer; }
+
+  /// Returns \c true if a corresponding .swiftsourceinfo has been found *and
+  /// read*.
+  bool hasSourceInfo() const;
 };
 
 template <typename T, typename RawData>

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -686,10 +686,16 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
     std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
     bool isFramework) {
   assert(moduleInputBuffer);
+
+  // The buffers are moved into the shared core, so grab their IDs now in case
+  // they're needed for diagnostics later.
   StringRef moduleBufferID = moduleInputBuffer->getBufferIdentifier();
   StringRef moduleDocBufferID;
   if (moduleDocInputBuffer)
     moduleDocBufferID = moduleDocInputBuffer->getBufferIdentifier();
+  StringRef moduleSourceInfoID;
+  if (moduleSourceInfoInputBuffer)
+    moduleSourceInfoID = moduleSourceInfoInputBuffer->getBufferIdentifier();
 
   if (moduleInputBuffer->getBufferSize() % 4 != 0) {
     if (diagLoc)
@@ -742,6 +748,12 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
         (Ctx.LangOpts.AllowModuleWithCompilerErrors &&
          (loadInfo.status == serialization::Status::TargetTooNew ||
           loadInfo.status == serialization::Status::TargetIncompatible))) {
+      if (loadedModuleFile->hasSourceInfoFile() &&
+          !loadedModuleFile->hasSourceInfo())
+        Ctx.Diags.diagnose(diagLocOrInvalid,
+                           diag::serialization_malformed_sourceinfo,
+                           moduleSourceInfoID);
+
       Ctx.bumpGeneration();
       LoadedModuleFiles.emplace_back(std::move(loadedModuleFile),
                                      Ctx.getCurrentGeneration());

--- a/test/Serialization/load-invalid-sourceinfo.swift
+++ b/test/Serialization/load-invalid-sourceinfo.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t %S/../Inputs/empty.swift
+// RUN: %target-swift-frontend -typecheck -I %t %s
+
+// RUN: touch %t/empty.swiftsourceinfo
+// RUN: %target-swift-frontend -typecheck -I %t %s -verify
+
+// RUN: echo -n 'a' > %t/empty.swiftsourceinfo
+// RUN: %target-swift-frontend -typecheck -I %t %s -verify
+
+// RUN: echo -n 'abcd' > %t/empty.swiftsourceinfo
+// RUN: %target-swift-frontend -typecheck -I %t %s -verify
+
+// RUN: echo -n 'abcde' > %t/empty.swiftsourceinfo
+// RUN: %target-swift-frontend -typecheck -I %t %s -verify
+
+import empty // expected-warning{{unable to use malformed module source info}}


### PR DESCRIPTION
Output a warning rather than ignoring a malformed .swiftsourceinfo
completely.

Resolves rdar://77350048
