### PR TITLE
[Concurrency] don't require Sendable (yet)

### DIFF
--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -18,7 +18,7 @@ import Swift
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Task {
   @available(*, deprecated, message: "`Task.Group` was replaced by `ThrowingTaskGroup` and `TaskGroup` and will be removed shortly.")
-  public typealias Group<TaskResult: Sendable> = ThrowingTaskGroup<TaskResult, Error>
+  public typealias Group<TaskResult> = ThrowingTaskGroup<TaskResult, Error>
 
   @available(*, deprecated, message: "`Task.withGroup` was replaced by `withThrowingTaskGroup` and `withTaskGroup` and will be removed shortly.")
   public static func withGroup<TaskResult, BodyResult>(
@@ -81,7 +81,7 @@ extension Task {
 ///   - once the `withTaskGroup` returns the group is guaranteed to be empty.
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @inlinable
-public func withTaskGroup<ChildTaskResult: Sendable, GroupResult>(
+public func withTaskGroup<ChildTaskResult, GroupResult>(
   of childTaskResultType: ChildTaskResult.Type,
   returning returnType: GroupResult.Type = GroupResult.self,
   body: (inout TaskGroup<ChildTaskResult>) async -> GroupResult
@@ -160,7 +160,7 @@ public func withTaskGroup<ChildTaskResult: Sendable, GroupResult>(
 ///   - all tasks remaining in the group will be automatically cancelled.
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @inlinable
-public func withThrowingTaskGroup<ChildTaskResult: Sendable, GroupResult>(
+public func withThrowingTaskGroup<ChildTaskResult, GroupResult>(
   of childTaskResultType: ChildTaskResult.Type,
   returning returnType: GroupResult.Type = GroupResult.self,
   body: (inout ThrowingTaskGroup<ChildTaskResult, Error>) async throws -> GroupResult
@@ -197,7 +197,7 @@ public func withThrowingTaskGroup<ChildTaskResult: Sendable, GroupResult>(
 /// It is created by the `withTaskGroup` function.
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @frozen
-public struct TaskGroup<ChildTaskResult: Sendable> {
+public struct TaskGroup<ChildTaskResult> {
 
   /// Group task into which child tasks offer their results,
   /// and the `next()` function polls those results from.
@@ -457,7 +457,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
 /// It is created by the `withTaskGroup` function.
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @frozen
-public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
+public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
 
   /// Group task into which child tasks offer their results,
   /// and the `next()` function polls those results from.

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -96,7 +96,8 @@ import Swift
 /// value for lookups in the task local storage.
 @propertyWrapper
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible {
+// TODO: add Sendable enforcement when we're ready to do so rdar://77441933
+public final class TaskLocal<Value>: UnsafeSendable, CustomStringConvertible {
   let defaultValue: Value
 
   public init(wrappedValue defaultValue: Value) {
@@ -207,7 +208,7 @@ extension UnsafeCurrentTask {
   /// This function MUST NOT be invoked by any other task than the current task
   /// represented by this object.
   @discardableResult
-  public func withTaskLocal<Value: Sendable, R>(
+  public func withTaskLocal<Value, R>(
       _ taskLocal: TaskLocal<Value>,
       boundTo valueDuringOperation: Value,
       operation: () throws -> R,

--- a/test/Concurrency/task_local.swift
+++ b/test/Concurrency/task_local.swift
@@ -23,15 +23,6 @@ var global: Int = 0
 class NotSendable {}
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-enum T2 {
-  @TaskLocal // expected-error{{generic class 'TaskLocal' requires that 'NotSendable' conform to 'Sendable'}}
-  static var notSendable: NotSendable?
-
-  @TaskLocal // expected-error{{generic class 'TaskLocal' requires that 'NotSendable' conform to 'Sendable'}}
-  static var notSendable2: NotSendable = NotSendable()
-}
-
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test () async {
   TL.number = 10 // expected-error{{cannot assign to property: 'number' is a get-only property}}
   TL.$number = 10 // expected-error{{cannot assign value of type 'Int' to type 'TaskLocal<Int>'}}


### PR DESCRIPTION
We should not be enforcing `Sendable` usage (yet), so we need to remove the requirements from task group type parameters

This removes the requirement from:

- task groups
- task locals