### PR TITLE
[SR-13976] Updated diagnostic message for calling a mutating method

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3670,7 +3670,7 @@ NOTE(ambiguous_because_of_trailing_closure,none,
 // Partial application of foreign functions not supported
 ERROR(partial_application_of_function_invalid,none,
       "partial application of %select{"
-        "'mutating' method|"
+        "calling a 'mutating' method without an argument list is not allowed|"
         "'super.init' initializer chain|"
         "'self.init' initializer delegation|"
         "'super' instance method with metatype base"
@@ -3678,7 +3678,7 @@ ERROR(partial_application_of_function_invalid,none,
       (unsigned))
 WARNING(partial_application_of_function_invalid_swift4,none,
       "partial application of %select{"
-        "'mutating' method|"
+        "calling a 'mutating' method without an argument list is not allowed|"
         "'super.init' initializer chain|"
         "'self.init' initializer delegation|"
         "'super' instance method with metatype base"


### PR DESCRIPTION
<!-- What's in this pull request? -->

```
struct Hello {
    let message: String

    mutating func mutatingFunc() { }
}

var hello = Hello(message: "Hi")
let aaa = hello.mutatingFunc  //  compile error: partial application of 'mutating' method is not allowed
```
This message is not clear, will update the message to 
` partial application of calling a 'mutating' method without an argument list is not allowed `


<!-- If this pull request resolveReplace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

Bug: https://bugs.swift.org/browse/SR-13976
More context: https://forums.swift.org/t/compile-error-partial-application-of-mutating-method-is-not-allowed-what-is-partial-application/43163