### PR TITLE
[APIDigester] Migrate to shared frontend option tables

### DIFF
--- a/include/swift/Option/Options.h
+++ b/include/swift/Option/Options.h
@@ -39,6 +39,7 @@ namespace options {
     SupplementaryOutput = (1 << 14),
     SwiftAPIExtractOption = (1 << 15),
     SwiftSymbolGraphExtractOption = (1 << 16),
+    SwiftAPIDigesterOption = (1 << 17),
   };
 
   enum ID {

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -61,6 +61,9 @@ def SwiftAPIExtractOption : OptionFlag;
 // The option should be accepted by swift-symbolgraph-extract.
 def SwiftSymbolGraphExtractOption : OptionFlag;
 
+// The option should be accepted by swift-api-digester.
+def SwiftAPIDigesterOption : OptionFlag;
+
 /////////
 // Options
 
@@ -177,7 +180,7 @@ def driver_mode : Joined<["--"], "driver-mode=">, Flags<[HelpHidden]>,
 def help : Flag<["-", "--"], "help">,
   Flags<[FrontendOption, AutolinkExtractOption, ModuleWrapOption,
          SwiftIndentOption, SwiftAPIExtractOption,
-         SwiftSymbolGraphExtractOption]>,
+         SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
   HelpText<"Display available options">;
 def h : Flag<["-"], "h">, Alias<help>;
 def help_hidden : Flag<["-", "--"], "help-hidden">,
@@ -185,7 +188,7 @@ def help_hidden : Flag<["-", "--"], "help-hidden">,
   HelpText<"Display available options, including hidden options">;
 
 def v : Flag<["-"], "v">,
-  Flags<[DoesNotAffectIncrementalBuild, SwiftSymbolGraphExtractOption]>,
+  Flags<[DoesNotAffectIncrementalBuild, SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
   HelpText<"Show commands to run and use verbose output">;
 def version : Flag<["-", "--"], "version">, Flags<[FrontendOption]>,
   HelpText<"Print version information and exit">;
@@ -201,18 +204,20 @@ def _DASH_DASH : Option<["--"], "", KIND_REMAINING_ARGS>,
 def o : JoinedOrSeparate<["-"], "o">,
   Flags<[FrontendOption, AutolinkExtractOption, ModuleWrapOption,
          NoInteractiveOption, SwiftIndentOption, ArgumentIsPath,
-         SwiftAPIExtractOption]>,
+         SwiftAPIExtractOption, SwiftAPIDigesterOption]>,
   HelpText<"Write output to <file>">, MetaVarName<"<file>">;
 
 def j : JoinedOrSeparate<["-"], "j">, Flags<[DoesNotAffectIncrementalBuild]>,
   HelpText<"Number of commands to execute in parallel">, MetaVarName<"<n>">;
 
 def sdk : Separate<["-"], "sdk">,
-  Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption]>,
+  Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption,
+         SwiftAPIDigesterOption]>,
   HelpText<"Compile against <sdk>">, MetaVarName<"<sdk>">;
 
 def swift_version : Separate<["-"], "swift-version">,
-  Flags<[FrontendOption, ModuleInterfaceOption, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption]>,
+  Flags<[FrontendOption, ModuleInterfaceOption, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption,
+         SwiftAPIDigesterOption]>,
   HelpText<"Interpret input according to a specific Swift language version number">,
   MetaVarName<"<vers>">;
 
@@ -230,7 +235,7 @@ def D : JoinedOrSeparate<["-"], "D">, Flags<[FrontendOption]>,
   HelpText<"Marks a conditional compilation flag as true">;
 
 def F : JoinedOrSeparate<["-"], "F">,
-  Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption]>,
+  Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
   HelpText<"Add directory to framework search path">;
 def F_EQ : Joined<["-"], "F=">, Flags<[FrontendOption, ArgumentIsPath]>,
   Alias<F>;
@@ -240,7 +245,7 @@ def Fsystem : Separate<["-"], "Fsystem">,
   HelpText<"Add directory to system framework search path">;
 
 def I : JoinedOrSeparate<["-"], "I">,
-  Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption]>,
+  Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
   HelpText<"Add directory to the import search path">;
 def I_EQ : Joined<["-"], "I=">, Flags<[FrontendOption, ArgumentIsPath]>,
   Alias<I>;
@@ -347,11 +352,13 @@ def serialize_diagnostics : Flag<["-"], "serialize-diagnostics">,
   Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput]>,
   HelpText<"Serialize diagnostics in a binary format">;
 def serialize_diagnostics_path : Separate<["-"], "serialize-diagnostics-path">,
-  Flags<[FrontendOption, NoBatchOption, ArgumentIsPath, SupplementaryOutput]>,
+  Flags<[FrontendOption, SwiftAPIDigesterOption, NoBatchOption,
+         ArgumentIsPath, SupplementaryOutput]>,
   HelpText<"Emit a serialized diagnostics file to <path>">,
   MetaVarName<"<path>">;
 def serialize_diagnostics_path_EQ: Joined<["-"], "serialize-diagnostics-path=">,
-  Flags<[FrontendOption, NoBatchOption, ArgumentIsPath, SupplementaryOutput]>,
+  Flags<[FrontendOption, SwiftAPIDigesterOption, NoBatchOption,
+         ArgumentIsPath, SupplementaryOutput]>,
   Alias<serialize_diagnostics_path>;
 def color_diagnostics : Flag<["-"], "color-diagnostics">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
@@ -383,7 +390,7 @@ def localization_path : Separate<["-"], "localization-path">,
 
 def module_cache_path : Separate<["-"], "module-cache-path">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath, SwiftAPIExtractOption,
-         SwiftSymbolGraphExtractOption]>,
+         SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
   HelpText<"Specifies the Clang module cache path">;
 
 def enable_library_evolution : Flag<["-"], "enable-library-evolution">,
@@ -1045,12 +1052,13 @@ def Xllvm : Separate<["-"], "Xllvm">,
   MetaVarName<"<arg>">, HelpText<"Pass <arg> to LLVM.">;
 
 def resource_dir : Separate<["-"], "resource-dir">,
-  Flags<[FrontendOption, SwiftSymbolGraphExtractOption, HelpHidden, ArgumentIsPath]>,
+  Flags<[FrontendOption, SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption, HelpHidden, ArgumentIsPath]>,
   MetaVarName<"</usr/lib/swift>">,
   HelpText<"The directory that holds the compiler resource files">;
 
 def target : Separate<["-"], "target">,
-  Flags<[FrontendOption, ModuleWrapOption, ModuleInterfaceOption, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption]>,
+  Flags<[FrontendOption, ModuleWrapOption, ModuleInterfaceOption, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption,
+         SwiftAPIDigesterOption]>,
   HelpText<"Generate code for the given target <triple>, such as x86_64-apple-macos10.9">, MetaVarName<"<triple>">;
 def target_legacy_spelling : Joined<["--"], "target=">,
   Flags<[FrontendOption]>, Alias<target>;
@@ -1216,8 +1224,9 @@ def pretty_print: Flag<["-"], "pretty-print">,
 
 // swift-symbolgraph-extract-only options
 def output_dir : Separate<["-"], "output-dir">,
-  Flags<[NoDriverOption, SwiftSymbolGraphExtractOption, ArgumentIsPath]>,
-  HelpText<"Symbol Graph JSON Output Directory (Required)">,
+  Flags<[NoDriverOption, SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption,
+         ArgumentIsPath]>,
+  HelpText<"Output directory">,
   MetaVarName<"<dir>">;
 
 def skip_synthesized_members: Flag<[ "-" ], "skip-synthesized-members">,
@@ -1234,5 +1243,152 @@ def skip_inherited_docs : Flag<["-"], "skip-inherited-docs">,
          NoInteractiveOption, SupplementaryOutput, HelpHidden]>,
   HelpText<"Skip emitting doc comments for members inherited through classes or "
            "default implementations">;
+
+// swift-api-digester-only options
+def dump_sdk: Flag<["-", "--"], "dump-sdk">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Dump SDK content to JSON file">;
+
+def generate_migration_script: Flag<["-", "--"], "generate-migration-script">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Compare SDK content in JSON file and generate migration script">;
+
+def diagnose_sdk: Flag<["-", "--"], "diagnose-sdk">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Diagnose SDK content in JSON file">;
+
+def deserialize_diff: Flag<["-", "--"], "deserialize-diff">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Deserialize diff items in a JSON file">;
+
+def deserialize_sdk: Flag<["-", "--"], "deserialize-sdk">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Deserialize sdk digester in a JSON file">;
+
+def find_usr: Flag<["-", "--"], "find-usr">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Find USR for decls by given condition">;
+
+def generate_name_correction: Flag<["-", "--"], "generate-name-correction">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Generate name correction template">;
+
+def generate_empty_baseline: Flag<["-", "--"], "generate-empty-baseline">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Generate an empty baseline">;
+
+def empty_baseline: Flag<["-", "--"], "empty-baseline">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Use empty baseline for diagnostics">;
+
+def ignored_usrs: Separate<["-", "--"], "ignored-usrs">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption, ArgumentIsPath]>,
+  HelpText<"the file containing USRs of removed decls that the digester should ignore">,
+  MetaVarName<"<path>">;
+
+def protocol_requirement_allow_list: Separate<["-", "--"], "protocol-requirement-allow-list">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption, ArgumentIsPath]>,
+  HelpText<"File containing a new-line separated list of protocol names">,
+  MetaVarName<"<path>">;
+
+def input_paths: Separate<["-", "--"], "input-paths">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption, ArgumentIsPath]>,
+  HelpText<"The SDK contents under comparison">,
+  MetaVarName<"<path>">;
+
+def compiler_style_diags: Flag<["-", "--"], "compiler-style-diags">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Print compiler style diagnostics to stderr.">;
+
+def json: Flag<["-", "--"], "json">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Print output in JSON format.">;
+
+def avoid_location: Flag<["-", "--"], "avoid-location">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Avoid serializing the file paths of SDK nodes.">;
+
+def location: Separate<["-", "--"], "location">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Filter nodes with the given location.">,
+  MetaVarName<"<location>">;
+
+def avoid_tool_args: Flag<["-", "--"], "avoid-tool-args">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Avoid serializing the arguments for invoking the tool.">;
+
+def abi: Flag<["-", "--"], "abi">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Dumping ABI interface">;
+
+def swift_only: Flag<["-", "--"], "swift-only">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Only include APIs defined from Swift source">;
+
+def disable_os_checks: Flag<["-", "--"], "disable-os-checks">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Skip OS related diagnostics">;
+
+def print_module: Flag<["-", "--"], "print-module">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Print module names in diagnostics">;
+
+def migrator: Flag<["-", "--"], "migrator">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Dump Json suitable for generating migration script">;
+
+def abort_on_module_fail: Flag<["-", "--"], "abort-on-module-fail">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Abort if a module failed to load">;
+
+def debug_mapping: Flag<["-", "--"], "debug-mapping">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Dumping information for debug purposes">;
+
+def BF : JoinedOrSeparate<["-"], "BF">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption, ArgumentIsPath]>,
+  HelpText<"add a directory to the baseline framework search path">;
+def BF_EQ : Joined<["-"], "BF=">, Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  Alias<BF>;
+
+def BI : JoinedOrSeparate<["-"], "BI">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption, ArgumentIsPath]>,
+  HelpText<"add a module for baseline input">;
+def BI_EQ : Joined<["-"], "BI=">, Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  Alias<BI>;
+
+def iframework : JoinedOrSeparate<["-"], "iframework">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption, ArgumentIsPath]>,
+  HelpText<"add a directory to the clang importer system framework search path">;
+
+def baseline_path : JoinedOrSeparate<["-"], "baseline-path">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption, ArgumentIsPath]>,
+  HelpText<"The path to the Json file that we should use as the baseline">;
+
+def baseline_dir : JoinedOrSeparate<["-"], "baseline-dir">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption, ArgumentIsPath]>,
+  HelpText<"The path to a directory containing baseline files: macos.json, iphoneos.json, appletvos.json, watchos.json, and iosmac.json">;
+
+def breakage_allowlist_path : JoinedOrSeparate<["-"], "breakage-allowlist-path">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption, ArgumentIsPath]>,
+  HelpText<"An allowlist of breakages to not complain about">;
+
+def bsdk : JoinedOrSeparate<["-"], "bsdk">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption, ArgumentIsPath]>,
+  HelpText<"path to the baseline SDK to import frameworks">;
+
+def module_list_file : JoinedOrSeparate<["-"], "module-list-file">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption, ArgumentIsPath]>,
+  HelpText<"File containing a new-line separated list of modules">;
+
+def module: Separate<["-", "--"], "module">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Names of modules">,
+  MetaVarName<"<name>">;
+
+def use_interface_for_module: Separate<["-", "--"], "use-interface-for-module">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Prefer loading these modules via interface">,
+  MetaVarName<"<name>">;
 
 include "FrontendOptions.td"

--- a/tools/driver/swift_api_digester_main.cpp
+++ b/tools/driver/swift_api_digester_main.cpp
@@ -26,19 +26,21 @@
 // can be reflected as source-breaking changes for API users. If they are,
 // the output of api-digester will include such changes.
 
+#include "swift/APIDigester/ModuleAnalyzerNodes.h"
+#include "swift/APIDigester/ModuleDiagsConsumer.h"
+#include "swift/AST/DiagnosticsModuleDiffer.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/Frontend/SerializedDiagnosticConsumer.h"
-#include "swift/AST/DiagnosticsModuleDiffer.h"
 #include "swift/IDE/APIDigesterData.h"
+#include "swift/Option/Options.h"
 #include <functional>
-#include "swift/APIDigester/ModuleAnalyzerNodes.h"
-#include "swift/APIDigester/ModuleDiagsConsumer.h"
 
 using namespace swift;
 using namespace ide;
 using namespace api;
+using namespace swift::options;
 
 namespace  {
   enum class ActionType {
@@ -54,213 +56,6 @@ namespace  {
     GenerateEmptyBaseline,
   };
 } // end anonymous namespace
-
-namespace options {
-
-static llvm::cl::OptionCategory Category("swift-api-digester Options");
-
-static llvm::cl::list<std::string>
-ModuleNames("module", llvm::cl::ZeroOrMore, llvm::cl::desc("Names of modules"),
-            llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-ModuleList("module-list-file",
-           llvm::cl::desc("File containing a new-line separated list of modules"),
-           llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-ProtReqAllowList("protocol-requirement-allow-list",
-           llvm::cl::desc("File containing a new-line separated list of protocol names"),
-           llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-OutputFile("o", llvm::cl::desc("Output file"),
-           llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-OutputDir("output-dir", llvm::cl::desc("Directory path to where we dump the generated Json files"),
-           llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-SDK("sdk", llvm::cl::desc("path to the SDK to build against"),
-    llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-BaselineSDK("bsdk", llvm::cl::desc("path to the baseline SDK to import frameworks"),
-    llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-Triple("target", llvm::cl::desc("target triple"),
-       llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-ModuleCachePath("module-cache-path", llvm::cl::desc("Clang module cache path"),
-                llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-ResourceDir("resource-dir",
-            llvm::cl::desc("The directory that holds the compiler resource files"),
-            llvm::cl::cat(Category));
-
-static llvm::cl::list<std::string>
-FrameworkPaths("F", llvm::cl::desc("add a directory to the framework search path"),
-               llvm::cl::cat(Category));
-
-static llvm::cl::list<std::string>
-BaselineFrameworkPaths("BF", llvm::cl::desc("add a directory to the baseline framework search path"),
-                       llvm::cl::cat(Category));
-
-static llvm::cl::list<std::string>
-BaselineModuleInputPaths("BI", llvm::cl::desc("add a module for baseline input"),
-                         llvm::cl::cat(Category));
-
-static llvm::cl::list<std::string>
-ModuleInputPaths("I", llvm::cl::desc("add a module for input"),
-                 llvm::cl::cat(Category));
-
-static llvm::cl::list<std::string>
-CCSystemFrameworkPaths("iframework",
-  llvm::cl::desc("add a directory to the clang importer system framework search path"),
-  llvm::cl::cat(Category));
-
-static llvm::cl::opt<bool>
-AbortOnModuleLoadFailure("abort-on-module-fail",
-                        llvm::cl::desc("Abort if a module failed to load"),
-                        llvm::cl::cat(Category));
-
-static llvm::cl::opt<bool>
-Verbose("v", llvm::cl::desc("Verbose"),
-        llvm::cl::cat(Category));
-
-static llvm::cl::opt<bool>
-DebugMapping("debug-mapping", llvm::cl::desc("Dumping information for debug purposes"),
-             llvm::cl::cat(Category));
-
-static llvm::cl::opt<bool>
-Abi("abi", llvm::cl::desc("Dumping ABI interface"),  llvm::cl::init(false),
-    llvm::cl::cat(Category));
-
-static llvm::cl::opt<bool>
-SwiftOnly("swift-only",
-          llvm::cl::desc("Only include APIs defined from Swift source"),
-          llvm::cl::init(false),
-          llvm::cl::cat(Category));
-
-static llvm::cl::opt<bool>
-DisableOSChecks("disable-os-checks",
-                llvm::cl::desc("Skip OS related diagnostics"),
-                llvm::cl::init(false),
-                llvm::cl::cat(Category));
-
-static llvm::cl::opt<bool>
-PrintModule("print-module", llvm::cl::desc("Print module names in diagnostics"),
-            llvm::cl::cat(Category));
-
-static llvm::cl::opt<ActionType>
-Action(llvm::cl::desc("Mode:"), llvm::cl::init(ActionType::None),
-      llvm::cl::cat(Category),
-      llvm::cl::values(
-          clEnumValN(ActionType::DumpSDK,
-                     "dump-sdk",
-                     "Dump SDK content to JSON file"),
-          clEnumValN(ActionType::MigratorGen,
-                     "generate-migration-script",
-                     "Compare SDK content in JSON file and generate migration script"),
-          clEnumValN(ActionType::DiagnoseSDKs,
-                     "diagnose-sdk",
-                     "Diagnose SDK content in JSON file"),
-          clEnumValN(ActionType::DeserializeDiffItems,
-                     "deserialize-diff",
-                     "Deserialize diff items in a JSON file"),
-          clEnumValN(ActionType::DeserializeSDK,
-                     "deserialize-sdk",
-                     "Deserialize sdk digester in a JSON file"),
-          clEnumValN(ActionType::FindUsr,
-                     "find-usr",
-                     "Find USR for decls by given condition"),
-          clEnumValN(ActionType::GenerateNameCorrectionTemplate,
-                     "generate-name-correction",
-                     "Generate name correction template"),
-          clEnumValN(ActionType::GenerateEmptyBaseline,
-                     "generate-empty-baseline",
-                     "Generate an empty baseline")));
-
-static llvm::cl::list<std::string>
-SDKJsonPaths("input-paths",
-            llvm::cl::desc("The SDK contents under comparison"),
-            llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-IgnoreRemovedDeclUSRs("ignored-usrs",
-                      llvm::cl::desc("the file containing USRs of removed decls "
-                                     "that the digester should ignore"),
-                      llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-SwiftVersion("swift-version",
-             llvm::cl::desc("The Swift compiler version to invoke"),
-             llvm::cl::cat(Category));
-
-static llvm::cl::opt<bool>
-OutputInJson("json", llvm::cl::desc("Print output in JSON format."),
-             llvm::cl::cat(Category));
-
-static llvm::cl::opt<bool>
-AvoidLocation("avoid-location",
-              llvm::cl::desc("Avoid serializing the file paths of SDK nodes."),
-              llvm::cl::cat(Category));
-
-static llvm::cl::opt<bool>
-AvoidToolArgs("avoid-tool-args",
-              llvm::cl::desc("Avoid serializing the arguments for invoking the tool."),
-              llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-LocationFilter("location",
-              llvm::cl::desc("Filter nodes with the given location."),
-              llvm::cl::cat(Category));
-
-static llvm::cl::opt<bool>
-CompilerStyleDiags("compiler-style-diags",
-                   llvm::cl::desc("Print compiler style diagnostics to stderr."),
-                   llvm::cl::cat(Category));
-
-static llvm::cl::opt<bool>
-Migrator("migrator",
-         llvm::cl::desc("Dump Json suitable for generating migration script"),
-         llvm::cl::cat(Category));
-
-static llvm::cl::list<std::string>
-PreferInterfaceForModules("use-interface-for-module", llvm::cl::ZeroOrMore,
-                          llvm::cl::desc("Prefer loading these modules via interface"),
-                          llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-BaselineFilePath("baseline-path",
-                 llvm::cl::desc("The path to the Json file that we should use as the baseline"),
-                 llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-BaselineDirPath("baseline-dir",
-                 llvm::cl::desc("The path to a directory containing baseline files: macos.json, iphoneos.json, appletvos.json, watchos.json, and iosmac.json"),
-                 llvm::cl::cat(Category));
-
-static llvm::cl::opt<bool>
-UseEmptyBaseline("empty-baseline",
-                llvm::cl::desc("Use empty baseline for diagnostics"),
-                llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-SerializedDiagPath("serialize-diagnostics-path",
-                   llvm::cl::desc("Serialize diagnostics to a path"),
-                   llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-BreakageAllowlistPath("breakage-allowlist-path",
-                      llvm::cl::desc("An allowlist of breakages to not complain about"),
-                      llvm::cl::cat(Category));
-
-} // namespace options
 
 namespace {
 
@@ -1086,6 +881,7 @@ class PrunePass : public MatchedNodeListener, public SDKTreeDiffPass {
   llvm::StringSet<> ProtocolReqAllowlist;
   SDKNodeRoot *LeftRoot;
   SDKNodeRoot *RightRoot;
+  bool DebugMapping;
 
   static void printSpaces(llvm::raw_ostream &OS, SDKNode *N) {
     assert(N);
@@ -1131,11 +927,13 @@ class PrunePass : public MatchedNodeListener, public SDKTreeDiffPass {
   }
 
 public:
-  PrunePass(SDKContext &Ctx): Ctx(Ctx), UpdateMap(Ctx.getNodeUpdateMap()) {}
-  PrunePass(SDKContext &Ctx, llvm::StringSet<> prAllowlist):
-    Ctx(Ctx),
-    UpdateMap(Ctx.getNodeUpdateMap()),
-    ProtocolReqAllowlist(std::move(prAllowlist)) {}
+  PrunePass(SDKContext &Ctx, bool DebugMapping)
+      : Ctx(Ctx), UpdateMap(Ctx.getNodeUpdateMap()),
+        DebugMapping(DebugMapping) {}
+  PrunePass(SDKContext &Ctx, llvm::StringSet<> prAllowlist, bool DebugMapping)
+      : Ctx(Ctx), UpdateMap(Ctx.getNodeUpdateMap()),
+        ProtocolReqAllowlist(std::move(prAllowlist)),
+        DebugMapping(DebugMapping) {}
 
   void diagnoseMissingAvailable(SDKNodeDecl *D) {
     // For extensions of external types, we diagnose individual member's missing
@@ -1163,7 +961,7 @@ public:
     }
   }
   void foundMatch(NodePtr Left, NodePtr Right, NodeMatchReason Reason) override {
-    if (options::DebugMapping)
+    if (DebugMapping)
       debugMatch(Left, Right, Reason, llvm::errs());
     switch (Reason) {
     case NodeMatchReason::Added:
@@ -2372,7 +2170,8 @@ static int diagnoseModuleChange(SDKContext &Ctx, SDKNodeRoot *LeftModule,
                                 llvm::StringSet<> ProtocolReqAllowlist,
                                 bool CompilerStyleDiags,
                                 StringRef SerializedDiagPath,
-                                StringRef BreakageAllowlistPath) {
+                                StringRef BreakageAllowlistPath,
+                                bool DebugMapping) {
   assert(LeftModule);
   assert(RightModule);
   llvm::raw_ostream *OS = &llvm::errs();
@@ -2402,7 +2201,7 @@ static int diagnoseModuleChange(SDKContext &Ctx, SDKNodeRoot *LeftModule,
                                 RightModule->getJsonFormatVersion()));
   TypeAliasDiffFinder(LeftModule, RightModule,
                       Ctx.getTypeAliasUpdateMap()).search();
-  PrunePass Prune(Ctx, std::move(ProtocolReqAllowlist));
+  PrunePass Prune(Ctx, std::move(ProtocolReqAllowlist), DebugMapping);
   Prune.pass(LeftModule, RightModule);
   ChangeRefinementPass RefinementPass(Ctx.getNodeUpdateMap());
   RefinementPass.pass(LeftModule, RightModule);
@@ -2417,7 +2216,8 @@ static int diagnoseModuleChange(StringRef LeftPath, StringRef RightPath,
                                 llvm::StringSet<> ProtocolReqAllowlist,
                                 bool CompilerStyleDiags,
                                 StringRef SerializedDiagPath,
-                                StringRef BreakageAllowlistPath) {
+                                StringRef BreakageAllowlistPath,
+                                bool DebugMapping) {
   if (!fs::exists(LeftPath)) {
     llvm::errs() << LeftPath << " does not exist\n";
     return 1;
@@ -2434,7 +2234,7 @@ static int diagnoseModuleChange(StringRef LeftPath, StringRef RightPath,
   return diagnoseModuleChange(
       Ctx, LeftCollector.getSDKRoot(), RightCollector.getSDKRoot(), OutputPath,
       std::move(ProtocolReqAllowlist), CompilerStyleDiags, SerializedDiagPath,
-      BreakageAllowlistPath);
+      BreakageAllowlistPath, DebugMapping);
 }
 
 static void populateAliasChanges(NodeMap &AliasMap, DiffVector &AllItems,
@@ -2461,7 +2261,8 @@ static void populateAliasChanges(NodeMap &AliasMap, DiffVector &AllItems,
 static int generateMigrationScript(StringRef LeftPath, StringRef RightPath,
                                    StringRef DiffPath,
                                    llvm::StringSet<> &IgnoredRemoveUsrs,
-                                   CheckerOptions Opts, bool OutputInJson) {
+                                   CheckerOptions Opts, bool OutputInJson,
+                                   bool DebugMapping) {
   if (!fs::exists(LeftPath)) {
     llvm::errs() << LeftPath << " does not exist\n";
     return 1;
@@ -2491,7 +2292,7 @@ static int generateMigrationScript(StringRef LeftPath, StringRef RightPath,
   llvm::errs() << "Detecting type member diffs" << "\n";
   findTypeMemberDiffs(LeftModule, RightModule, Ctx.getTypeMemberDiffs());
 
-  PrunePass Prune(Ctx);
+  PrunePass Prune(Ctx, DebugMapping);
   Prune.pass(LeftModule, RightModule);
   llvm::errs() << "Finished pruning" << "\n";
   ChangeRefinementPass RefinementPass(Ctx.getNodeUpdateMap());
@@ -2570,18 +2371,6 @@ static void setSDKPath(CompilerInvocation &InitInvok, bool IsBaseline,
       exit(1);
     }
   }
-}
-
-static void readIgnoredUsrs(llvm::StringSet<> &IgnoredUsrs,
-                            StringRef IgnoreRemovedDeclUSRs) {
-  StringRef Path = IgnoreRemovedDeclUSRs;
-  if (Path.empty())
-    return;
-  if (!fs::exists(Path)) {
-    llvm::errs() << Path << " does not exist.\n";
-    return;
-  }
-  readFileLineByLine(Path, IgnoredUsrs);
 }
 
 static int deserializeDiffItems(APIDiffItemStore &Store, StringRef DiffPath,
@@ -2696,10 +2485,10 @@ static std::string getJsonOutputFilePath(llvm::Triple Triple, bool ABI,
 class SwiftAPIDigesterInvocation {
 private:
   std::string MainExecutablePath;
+  std::unique_ptr<llvm::opt::OptTable> Table;
   CompilerInvocation InitInvok;
-  ActionType Action;
+  ActionType Action = ActionType::None;
   CheckerOptions CheckerOpts;
-  llvm::StringSet<> Modules;
   llvm::StringSet<> IgnoredUsrs;
   std::string ProtReqAllowList;
   std::vector<std::string> SDKJsonPaths;
@@ -2711,6 +2500,7 @@ private:
   std::string BaselineDirPath;
   bool UseEmptyBaseline;
   bool Verbose;
+  bool DebugMapping;
   std::string BreakageAllowlistPath;
   bool OutputInJson;
   std::string SDK;
@@ -2730,75 +2520,142 @@ private:
 
 public:
   SwiftAPIDigesterInvocation(const std::string &ExecPath)
-      : MainExecutablePath(ExecPath) {}
+      : MainExecutablePath(ExecPath), Table(createSwiftOptTable()) {}
 
   int parseArgs(ArrayRef<const char *> Args) {
-    llvm::cl::HideUnrelatedOptions(options::Category);
-    llvm::cl::ParseCommandLineOptions(
-        Args.size(), llvm::makeArrayRef(Args).data(), "Swift SDK Digester\n");
+    unsigned MissingIndex;
+    unsigned MissingCount;
+    llvm::opt::InputArgList ParsedArgs = Table->ParseArgs(
+        Args, MissingIndex, MissingCount, SwiftAPIDigesterOption);
+    if (MissingCount) {
+      llvm::errs() << "error: missing argument for option '"
+                   << ParsedArgs.getArgString(MissingIndex) << "'\n";
+      return 1;
+    }
 
-    Action = options::Action;
+    if (ParsedArgs.hasArg(OPT_UNKNOWN)) {
+      for (const auto *A : ParsedArgs.filtered(OPT_UNKNOWN)) {
+        llvm::errs() << "error: unknown argument '"
+                     << A->getAsString(ParsedArgs) << "'\n";
+      }
+      return 1;
+    }
 
-    readIgnoredUsrs(IgnoredUsrs, options::IgnoreRemovedDeclUSRs);
-    CheckerOpts = getCheckOpts(Args);
+    if (ParsedArgs.getLastArg(OPT_help)) {
+      printHelp();
+      return 1;
+    }
 
-    ProtReqAllowList = options::ProtReqAllowList;
-    SDKJsonPaths = options::SDKJsonPaths;
-    OutputFile = options::OutputFile;
-    OutputDir = options::OutputDir;
-    CompilerStyleDiags = options::CompilerStyleDiags;
-    SerializedDiagPath = options::SerializedDiagPath;
-    BaselineFilePath = options::BaselineFilePath;
-    BaselineDirPath = options::BaselineDirPath;
-    UseEmptyBaseline = options::UseEmptyBaseline;
-    Verbose = options::Verbose;
-    BreakageAllowlistPath = options::BreakageAllowlistPath;
-    OutputInJson = options::OutputInJson;
-    SDK = options::SDK;
-    BaselineSDK = options::BaselineSDK;
-    Triple = options::Triple;
-    SwiftVersion = options::SwiftVersion;
-    CCSystemFrameworkPaths = options::CCSystemFrameworkPaths;
-    BaselineFrameworkPaths = options::BaselineFrameworkPaths;
-    FrameworkPaths = options::FrameworkPaths;
-    BaselineModuleInputPaths = options::BaselineModuleInputPaths;
-    ModuleInputPaths = options::ModuleInputPaths;
-    ModuleList = options::ModuleList;
-    ModuleNames = options::ModuleNames;
-    PreferInterfaceForModules = options::PreferInterfaceForModules;
-    ResourceDir = options::ResourceDir;
-    ModuleCachePath = options::ModuleCachePath;
+    if (auto *A = ParsedArgs.getLastArg(
+            OPT_dump_sdk, OPT_generate_migration_script, OPT_diagnose_sdk,
+            OPT_deserialize_diff, OPT_deserialize_sdk, OPT_find_usr,
+            OPT_generate_name_correction, OPT_generate_empty_baseline)) {
+      switch (A->getOption().getID()) {
+      case OPT_dump_sdk:
+        Action = ActionType::DumpSDK;
+        break;
+      case OPT_generate_migration_script:
+        Action = ActionType::MigratorGen;
+        break;
+      case OPT_diagnose_sdk:
+        Action = ActionType::DiagnoseSDKs;
+        break;
+      case OPT_deserialize_diff:
+        Action = ActionType::DeserializeDiffItems;
+        break;
+      case OPT_deserialize_sdk:
+        Action = ActionType::DeserializeSDK;
+        break;
+      case OPT_find_usr:
+        Action = ActionType::FindUsr;
+        break;
+      case OPT_generate_name_correction:
+        Action = ActionType::GenerateNameCorrectionTemplate;
+        break;
+      case OPT_generate_empty_baseline:
+        Action = ActionType::GenerateEmptyBaseline;
+        break;
+      }
+    }
+
+    if (auto *A = ParsedArgs.getLastArg(OPT_ignored_usrs)) {
+      auto Path = A->getValue();
+      if (!fs::exists(Path)) {
+        llvm::errs() << Path << " does not exist.\n";
+        return 1;
+      }
+      readFileLineByLine(Path, IgnoredUsrs);
+    }
+
+    ProtReqAllowList =
+        ParsedArgs.getLastArgValue(OPT_protocol_requirement_allow_list).str();
+    SDKJsonPaths = ParsedArgs.getAllArgValues(OPT_input_paths);
+    OutputFile = ParsedArgs.getLastArgValue(OPT_o).str();
+    OutputDir = ParsedArgs.getLastArgValue(OPT_output_dir).str();
+    CompilerStyleDiags = ParsedArgs.hasArg(OPT_compiler_style_diags);
+    SerializedDiagPath =
+        ParsedArgs.getLastArgValue(OPT_serialize_diagnostics_path).str();
+    BaselineFilePath = ParsedArgs.getLastArgValue(OPT_baseline_path).str();
+    BaselineDirPath = ParsedArgs.getLastArgValue(OPT_baseline_dir).str();
+    UseEmptyBaseline = ParsedArgs.hasArg(OPT_empty_baseline);
+    Verbose = ParsedArgs.hasArg(OPT_v);
+    BreakageAllowlistPath =
+        ParsedArgs.getLastArgValue(OPT_breakage_allowlist_path).str();
+    OutputInJson = ParsedArgs.hasArg(OPT_json);
+    SDK = ParsedArgs.getLastArgValue(OPT_sdk).str();
+    BaselineSDK = ParsedArgs.getLastArgValue(OPT_bsdk).str();
+    Triple = ParsedArgs.getLastArgValue(OPT_target).str();
+    SwiftVersion = ParsedArgs.getLastArgValue(OPT_swift_version).str();
+    CCSystemFrameworkPaths = ParsedArgs.getAllArgValues(OPT_iframework);
+    BaselineFrameworkPaths = ParsedArgs.getAllArgValues(OPT_BF);
+    FrameworkPaths = ParsedArgs.getAllArgValues(OPT_F);
+    BaselineModuleInputPaths = ParsedArgs.getAllArgValues(OPT_BI);
+    ModuleInputPaths = ParsedArgs.getAllArgValues(OPT_I);
+    ModuleList = ParsedArgs.getLastArgValue(OPT_module_list_file).str();
+    ModuleNames = ParsedArgs.getAllArgValues(OPT_module);
+    PreferInterfaceForModules =
+        ParsedArgs.getAllArgValues(OPT_use_interface_for_module);
+    ResourceDir = ParsedArgs.getLastArgValue(OPT_resource_dir).str();
+    ModuleCachePath = ParsedArgs.getLastArgValue(OPT_module_cache_path).str();
+    DebugMapping = ParsedArgs.hasArg(OPT_debug_mapping);
+
+    CheckerOpts.AvoidLocation = ParsedArgs.hasArg(OPT_avoid_location);
+    CheckerOpts.AvoidToolArgs = ParsedArgs.hasArg(OPT_avoid_tool_args);
+    CheckerOpts.ABI = ParsedArgs.hasArg(OPT_abi);
+    CheckerOpts.Migrator = ParsedArgs.hasArg(OPT_migrator);
+    CheckerOpts.Verbose = Verbose;
+    CheckerOpts.AbortOnModuleLoadFailure =
+        ParsedArgs.hasArg(OPT_abort_on_module_fail);
+    CheckerOpts.LocationFilter = ParsedArgs.getLastArgValue(OPT_location);
+    CheckerOpts.PrintModule = ParsedArgs.hasArg(OPT_print_module);
+    // When ABI checking is enabled, we should only include Swift symbols
+    // because the checking logics are language-specific.
+    CheckerOpts.SwiftOnly =
+        ParsedArgs.hasArg(OPT_abi) || ParsedArgs.hasArg(OPT_swift_only);
+    CheckerOpts.SkipOSCheck = ParsedArgs.hasArg(OPT_disable_os_checks);
+    CheckerOpts.CompilerStyle =
+        CompilerStyleDiags || !SerializedDiagPath.empty();
+    for (auto Arg : Args)
+      CheckerOpts.ToolArgs.push_back(Arg);
+
+    if (!SDK.empty()) {
+      auto Ver = getSDKBuildVersion(SDK);
+      if (!Ver.empty()) {
+        CheckerOpts.ToolArgs.push_back("-sdk-version");
+        CheckerOpts.ToolArgs.push_back(Ver);
+      }
+    }
 
     return 0;
   }
 
-  CheckerOptions getCheckOpts(ArrayRef<const char *> Args) {
-    CheckerOptions Opts;
-    Opts.AvoidLocation = options::AvoidLocation;
-    Opts.AvoidToolArgs = options::AvoidToolArgs;
-    Opts.ABI = options::Abi;
-    Opts.Migrator = options::Migrator;
-    Opts.Verbose = options::Verbose;
-    Opts.AbortOnModuleLoadFailure = options::AbortOnModuleLoadFailure;
-    Opts.LocationFilter = options::LocationFilter;
-    Opts.PrintModule = options::PrintModule;
-    // When ABI checking is enabled, we should only include Swift symbols
-    // because the checking logics are language-specific.
-    Opts.SwiftOnly = options::Abi || options::SwiftOnly;
-    Opts.SkipOSCheck = options::DisableOSChecks;
-    Opts.CompilerStyle =
-        options::CompilerStyleDiags || !options::SerializedDiagPath.empty();
-    for (auto Arg : Args)
-      Opts.ToolArgs.push_back(Arg);
-
-    if (!options::SDK.empty()) {
-      auto Ver = getSDKBuildVersion(options::SDK);
-      if (!Ver.empty()) {
-        Opts.ToolArgs.push_back("-sdk-version");
-        Opts.ToolArgs.push_back(Ver);
-      }
-    }
-    return Opts;
+  void printHelp() {
+    std::string ExecutableName =
+        llvm::sys::path::stem(MainExecutablePath).str();
+    Table->PrintHelp(llvm::outs(), ExecutableName.c_str(), "Swift API Digester",
+                     /*IncludedFlagsBitmask*/ SwiftAPIDigesterOption,
+                     /*ExcludedFlagsBitmask*/ 0,
+                     /*ShowAllAliases*/ false);
   }
 
   bool hasBaselineInput() {
@@ -2934,7 +2791,8 @@ public:
 
   int run(ArrayRef<const char *> Args) {
     switch (Action) {
-    case ActionType::DumpSDK:
+    case ActionType::DumpSDK: {
+      llvm::StringSet<> Modules;
       return (prepareForDump(InitInvok, Modules))
                  ? 1
                  : dumpSDKContent(InitInvok, Modules,
@@ -2942,6 +2800,7 @@ public:
                                       InitInvok.getLangOptions().Target,
                                       CheckerOpts.ABI, OutputFile, OutputDir),
                                   CheckerOpts);
+    }
     case ActionType::MigratorGen:
     case ActionType::DiagnoseSDKs: {
       ComparisonInputMode Mode = checkComparisonInputMode();
@@ -2955,35 +2814,35 @@ public:
                "Only BothJson mode is supported");
         return generateMigrationScript(SDKJsonPaths[0], SDKJsonPaths[1],
                                        OutputFile, IgnoredUsrs, CheckerOpts,
-                                       OutputInJson);
+                                       OutputInJson, DebugMapping);
       }
       switch (Mode) {
       case ComparisonInputMode::BothJson: {
         return diagnoseModuleChange(
             SDKJsonPaths[0], SDKJsonPaths[1], OutputFile, CheckerOpts,
             std::move(protocolAllowlist), CompilerStyleDiags,
-            SerializedDiagPath, BreakageAllowlistPath);
+            SerializedDiagPath, BreakageAllowlistPath, DebugMapping);
       }
       case ComparisonInputMode::BaselineJson: {
         SDKContext Ctx(CheckerOpts);
         return diagnoseModuleChange(
             Ctx, getBaselineFromJson(Ctx), getSDKRoot(Ctx, false), OutputFile,
             std::move(protocolAllowlist), CompilerStyleDiags,
-            SerializedDiagPath, BreakageAllowlistPath);
+            SerializedDiagPath, BreakageAllowlistPath, DebugMapping);
       }
       case ComparisonInputMode::BothLoad: {
         SDKContext Ctx(CheckerOpts);
         return diagnoseModuleChange(
             Ctx, getSDKRoot(Ctx, true), getSDKRoot(Ctx, false), OutputFile,
             std::move(protocolAllowlist), CompilerStyleDiags,
-            SerializedDiagPath, BreakageAllowlistPath);
+            SerializedDiagPath, BreakageAllowlistPath, DebugMapping);
       }
       }
     }
     case ActionType::DeserializeSDK:
     case ActionType::DeserializeDiffItems: {
       if (SDKJsonPaths.size() != 1) {
-        llvm::cl::PrintHelpMessage();
+        printHelp();
         return 1;
       }
       if (Action == ActionType::DeserializeDiffItems) {
@@ -3009,14 +2868,14 @@ public:
     }
     case ActionType::FindUsr: {
       if (SDKJsonPaths.size() != 1) {
-        llvm::cl::PrintHelpMessage();
+        printHelp();
         return 1;
       }
       return findDeclUsr(SDKJsonPaths[0], CheckerOpts);
     }
     case ActionType::None:
       llvm::errs() << "Action required\n";
-      llvm::cl::PrintHelpMessage();
+      printHelp();
       return 1;
     }
   }
@@ -3026,16 +2885,13 @@ int swift_api_digester_main(ArrayRef<const char *> Args, const char *Argv0,
                             void *MainAddr) {
   INITIALIZE_LLVM();
 
-  // LLVM Command Line parsing expects to trim off argv[0].
-  SmallVector<const char *, 8> ArgsWithArgv0{Argv0};
-  ArgsWithArgv0.append(Args.begin(), Args.end());
-
   std::string MainExecutablePath = fs::getMainExecutable(Argv0, MainAddr);
   SwiftAPIDigesterInvocation Invocation(MainExecutablePath);
-  if (Invocation.parseArgs(ArgsWithArgv0) != 0)
+
+  if (Invocation.parseArgs(Args) != 0)
     return EXIT_FAILURE;
 
-  if (Invocation.run(ArgsWithArgv0) != 0)
+  if (Invocation.run(Args) != 0)
     return EXIT_FAILURE;
 
   return EXIT_SUCCESS;

--- a/tools/driver/swift_api_digester_main.cpp
+++ b/tools/driver/swift_api_digester_main.cpp
@@ -59,11 +59,6 @@ namespace options {
 
 static llvm::cl::OptionCategory Category("swift-api-digester Options");
 
-static llvm::cl::opt<bool>
-IncludeAllModules("include-all",
-                  llvm::cl::desc("Include all modules from the SDK"),
-                  llvm::cl::cat(Category));
-
 static llvm::cl::list<std::string>
 ModuleNames("module", llvm::cl::ZeroOrMore, llvm::cl::desc("Names of modules"),
             llvm::cl::cat(Category));
@@ -194,12 +189,6 @@ static llvm::cl::list<std::string>
 SDKJsonPaths("input-paths",
             llvm::cl::desc("The SDK contents under comparison"),
             llvm::cl::cat(Category));
-
-static llvm::cl::list<std::string>
-ApisPrintUsrs("api-usrs",
-              llvm::cl::desc("The name of APIs to print their usrs, "
-                             "e.g. Type::Function"),
-              llvm::cl::cat(Category));
 
 static llvm::cl::opt<std::string>
 IgnoreRemovedDeclUSRs("ignored-usrs",
@@ -2711,7 +2700,6 @@ private:
   ActionType Action;
   CheckerOptions CheckerOpts;
   llvm::StringSet<> Modules;
-  std::vector<std::string> PrintApis;
   llvm::StringSet<> IgnoredUsrs;
   std::string ProtReqAllowList;
   std::vector<std::string> SDKJsonPaths;
@@ -2753,8 +2741,6 @@ public:
 
     readIgnoredUsrs(IgnoredUsrs, options::IgnoreRemovedDeclUSRs);
     CheckerOpts = getCheckOpts(Args);
-    for (auto Name : options::ApisPrintUsrs)
-      PrintApis.push_back(Name);
 
     ProtReqAllowList = options::ProtReqAllowList;
     SDKJsonPaths = options::SDKJsonPaths;


### PR DESCRIPTION
This PR replaces the use of llvm::cl for argument parsing with the shared frontend option tables defined in Options.td. Now that the API digester is a frontend tool, this prevents option definition conflicts with -Xllvm options and any frontend tools that get added in the future. It also means options like `-I` & `-F` are parsed the same way by the driver and digester, which will let me remove some hacks in SwiftPM's command line construction for the tool.

This change is not quite NFC. It removes the `-include-all` and `-api-usrs` flags, which the tool was no longer checking for. Also, some of the long-form options no longer support the `-option=arg` form. Because some of the tests rely on it, I am still allowing all of the options to have a single- or double-dash prefix for compatibility.