### PR TITLE
[NFC][Sema] Changing API to facilitate recording pontential holes recursively

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3225,7 +3225,8 @@ public:
   /// subsequent solution would be worse than the best known solution.
   bool recordFix(ConstraintFix *fix, unsigned impact = 1);
 
-  void recordPotentialHole(Type type);
+  void recordPotentialHole(TypeVariableType *typeVar);
+  void recordAnyTypeVarAsPotentialHole(Type type);
 
   void recordMatchCallArgumentResult(ConstraintLocator *locator,
                                      MatchCallArgumentResult result);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4085,8 +4085,7 @@ ConstraintSystem::applyPropertyWrapperToParameter(
     if (!shouldAttemptFixes())
       return getTypeMatchFailure(locator);
 
-    if (paramType->hasTypeVariable())
-      recordPotentialHole(paramType);
+    recordAnyTypeVarAsPotentialHole(paramType);
 
     auto *loc = getConstraintLocator(locator);
     auto *fix = RemoveProjectedValueArgument::create(*this, wrapperType, param, loc);


### PR DESCRIPTION
Just noted while looking up another issue that there are quite few points where we use the same `visit` pattern to record holes recursively, but since we changed `recordPotentialHole` some time ago to do that already, we could remove those `visit` patterns. One thing to improve clarity at call site I try to make `recordPotentialHole` back to take a `TypeVarType` and created a new `recordAnyTypeVarAsPotentialHole`(maybe we can think about a better name) that takes a type a `visit` recording for all type variable within the type.

So let me know if this makes sense :)

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
