### PR TITLE
[update-checkout] Update the cmake that we build on Linux on main to cmake 3.20.2 (latest).

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -78,7 +78,7 @@
                 "ninja": "release",
                 "icu": "release-65-1",
                 "yams": "4.0.2",
-                "cmake": "v3.16.5",
+                "cmake": "v3.20.2",
                 "indexstore-db": "main",
                 "sourcekit-lsp": "main",
                 "swift-format": "main"


### PR DESCRIPTION
I am not changing the minimum cmake requirements anywhere. I am just changing
this to get ahead of bumpings of minimum cmake requirements in various places.
