### PR TITLE
Parser: teach canImport to take an additional parameter indicating the minimum module version

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -892,7 +892,9 @@ public:
   ///
   /// Note that even if this check succeeds, errors may still occur if the
   /// module is loaded in full.
-  bool canImportModuleImpl(ImportPath::Element ModulePath) const;
+  bool canImportModuleImpl(ImportPath::Element ModulePath,
+                           llvm::VersionTuple version,
+                           bool underlyingVersion) const;
 public:
   namelookup::ImportCache &getImportCache() const;
 
@@ -921,8 +923,12 @@ public:
   ///
   /// Note that even if this check succeeds, errors may still occur if the
   /// module is loaded in full.
-  bool canImportModule(ImportPath::Element ModulePath);
-  bool canImportModule(ImportPath::Element ModulePath) const;
+  bool canImportModule(ImportPath::Element ModulePath,
+                       llvm::VersionTuple version = llvm::VersionTuple(),
+                       bool underlyingVersion = false);
+  bool canImportModule(ImportPath::Element ModulePath,
+                       llvm::VersionTuple version = llvm::VersionTuple(),
+                       bool underlyingVersion = false) const;
 
   /// \returns a module with a given name that was already loaded.  If the
   /// module was not loaded, returns nullptr.

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1772,6 +1772,12 @@ WARNING(likely_simulator_platform_condition,none,
       "use 'targetEnvironment(simulator)' instead",
       ())
 
+ERROR(canimport_two_parameters, none, "canImport can take only two parameters", ())
+
+ERROR(canimport_label, none, "2nd parameter of canImport should be labeled as version or underlyingVersion", ())
+
+ERROR(canimport_version, none, "cannot parse module version: %0", (StringRef))
+
 //------------------------------------------------------------------------------
 // MARK: Availability query parsing diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -27,6 +27,7 @@
 #include "swift/Basic/SourceLoc.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/TinyPtrVector.h"
+#include "llvm/Support/VersionTuple.h"
 #include <system_error>
 
 namespace llvm {
@@ -199,7 +200,9 @@ public:
   ///
   /// Note that even if this check succeeds, errors may still occur if the
   /// module is loaded in full.
-  virtual bool canImportModule(ImportPath::Element named) = 0;
+  virtual bool canImportModule(ImportPath::Element named,
+                               llvm::VersionTuple version,
+                               bool underlyingVersion) = 0;
 
   /// Import a module with the given module path.
   ///

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -186,7 +186,8 @@ public:
   ///
   /// Note that even if this check succeeds, errors may still occur if the
   /// module is loaded in full.
-  virtual bool canImportModule(ImportPath::Element named) override;
+  virtual bool canImportModule(ImportPath::Element named, llvm::VersionTuple version,
+                               bool underlyingVersion) override;
 
   /// Import a module with the given module path.
   ///

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -150,7 +150,8 @@ class ExplicitSwiftModuleLoader: public SerializedModuleLoaderBase {
                   std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
                   bool IsFramework) override;
 
-  bool canImportModule(ImportPath::Element mID) override;
+  bool canImportModule(ImportPath::Element mID, llvm::VersionTuple version,
+                       bool underlyingVersion) override;
 
   bool isCached(StringRef DepPath) override { return false; };
 

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -57,7 +57,9 @@ public:
   ///
   /// Note that even if this check succeeds, errors may still occur if the
   /// module is loaded in full.
-  virtual bool canImportModule(ImportPath::Element named) override;
+  virtual bool canImportModule(ImportPath::Element named,
+                               llvm::VersionTuple version,
+                               bool underlyingVersion) override;
 
   /// Import a module with the given module path.
   ///

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -166,7 +166,9 @@ public:
   ///
   /// Note that even if this check succeeds, errors may still occur if the
   /// module is loaded in full.
-  virtual bool canImportModule(ImportPath::Element named) override;
+  virtual bool canImportModule(ImportPath::Element named,
+                               llvm::VersionTuple version,
+                               bool underlyingVersion) override;
 
   /// Import a module with the given module path.
   ///
@@ -274,7 +276,8 @@ class MemoryBufferSerializedModuleLoader : public SerializedModuleLoaderBase {
 public:
   virtual ~MemoryBufferSerializedModuleLoader();
 
-  bool canImportModule(ImportPath::Element named) override;
+  bool canImportModule(ImportPath::Element named, llvm::VersionTuple version,
+                       bool underlyingVersion) override;
   ModuleDecl *
   loadModule(SourceLoc importLoc,
              ImportPath::Module path) override;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1955,7 +1955,9 @@ bool ASTContext::shouldPerformTypoCorrection() {
   return NumTypoCorrections <= LangOpts.TypoCorrectionLimit;
 }
 
-bool ASTContext::canImportModuleImpl(ImportPath::Element ModuleName) const {
+bool ASTContext::canImportModuleImpl(ImportPath::Element ModuleName,
+                                     llvm::VersionTuple version,
+                                     bool underlyingVersion) const {
   // If this module has already been successfully imported, it is importable.
   if (getLoadedModule(ImportPath::Module::Builder(ModuleName).get()) != nullptr)
     return true;
@@ -1966,7 +1968,7 @@ bool ASTContext::canImportModuleImpl(ImportPath::Element ModuleName) const {
 
   // Otherwise, ask the module loaders.
   for (auto &importer : getImpl().ModuleLoaders) {
-    if (importer->canImportModule(ModuleName)) {
+    if (importer->canImportModule(ModuleName, version, underlyingVersion)) {
       return true;
     }
   }
@@ -1974,8 +1976,10 @@ bool ASTContext::canImportModuleImpl(ImportPath::Element ModuleName) const {
   return false;
 }
 
-bool ASTContext::canImportModule(ImportPath::Element ModuleName) {
-  if (canImportModuleImpl(ModuleName)) {
+bool ASTContext::canImportModule(ImportPath::Element ModuleName,
+                                 llvm::VersionTuple version,
+                                 bool underlyingVersion) {
+  if (canImportModuleImpl(ModuleName, version, underlyingVersion)) {
     return true;
   } else {
     FailedModuleImportNames.insert(ModuleName.Item);
@@ -1983,8 +1987,10 @@ bool ASTContext::canImportModule(ImportPath::Element ModuleName) {
   }
 }
 
-bool ASTContext::canImportModule(ImportPath::Element ModuleName) const {
-  return canImportModuleImpl(ModuleName);
+bool ASTContext::canImportModule(ImportPath::Element ModuleName,
+                                 llvm::VersionTuple version,
+                                 bool underlyingVersion) const {
+  return canImportModuleImpl(ModuleName, version, underlyingVersion);
 }
 
 ModuleDecl *

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1731,7 +1731,9 @@ bool ClangImporter::isModuleImported(const clang::Module *M) {
   return M->NameVisibility == clang::Module::NameVisibilityKind::AllVisible;
 }
 
-bool ClangImporter::canImportModule(ImportPath::Element moduleID) {
+bool ClangImporter::canImportModule(ImportPath::Element moduleID,
+                                    llvm::VersionTuple version,
+                                    bool underlyingVersion) {
   // Look up the top-level module to see if it exists.
   // FIXME: This only works with top-level modules.
   auto &clangHeaderSearch = Impl.getClangPreprocessor().getHeaderSearchInfo();

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1629,7 +1629,7 @@ std::error_code ExplicitSwiftModuleLoader::findModuleFilesInDirectory(
 }
 
 bool ExplicitSwiftModuleLoader::canImportModule(
-    ImportPath::Element mID) {
+    ImportPath::Element mID, llvm::VersionTuple version, bool underlyingVersion) {
   StringRef moduleName = mID.Item.str();
   auto it = Impl.ExplicitModuleMap.find(moduleName);
   // If no provided explicit module matches the name, then it cannot be imported.

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -76,6 +76,57 @@ static bool isValidVersion(const version::Version &Version,
   llvm_unreachable("unsupported unary operator");
 }
 
+static llvm::VersionTuple getCanImportVersion(TupleExpr *te,
+                                              DiagnosticEngine *D,
+                                              bool &underlyingVersion) {
+  llvm::VersionTuple result;
+  if (te->getElements().size() != 2) {
+    if (D) {
+      D->diagnose(te->getLoc(), diag::canimport_two_parameters);
+    }
+    return result;
+  }
+  auto label = te->getElementName(1);
+  auto subE = te->getElement(1);
+  if (label.str() == "version") {
+    underlyingVersion = false;
+  } else if (label.str() == "underlyingVersion") {
+    underlyingVersion = true;
+  } else {
+    if (D) {
+      D->diagnose(subE->getLoc(), diag::canimport_label);
+    }
+    return result;
+  }
+  if (auto *nle = dyn_cast<NumberLiteralExpr>(subE)) {
+    auto digits = nle->getDigitsText();
+    if (result.tryParse(digits)) {
+      if (D) {
+        D->diagnose(nle->getLoc(), diag::canimport_version, digits);
+      }
+    }
+  }
+  return result;
+}
+
+static Expr *getSingleSubExp(Expr *exp, StringRef kindName,
+                             DiagnosticEngine *D) {
+  if (auto *pe = dyn_cast<ParenExpr>(exp)) {
+    return pe->getSubExpr();
+  }
+  if (kindName == "canImport") {
+    if (auto *te = dyn_cast<TupleExpr>(exp)) {
+      bool underlyingVersion;
+      if (D) {
+        // Diagnose canImport syntax
+        (void)getCanImportVersion(te, D, underlyingVersion);
+      }
+      return te->getElement(0);
+    }
+  }
+  return nullptr;
+}
+
 /// The condition validator.
 class ValidateIfConfigCondition :
   public ExprVisitor<ValidateIfConfigCondition, Expr*> {
@@ -208,13 +259,11 @@ public:
       return nullptr;
     }
 
-    auto *ArgP = dyn_cast<ParenExpr>(E->getArg());
-    if (!ArgP) {
+    Expr *Arg = getSingleSubExp(E->getArg(), *KindName, &D);
+    if (!Arg) {
       D.diagnose(E->getLoc(), diag::platform_condition_expected_one_argument);
       return nullptr;
     }
-    Expr *Arg = ArgP->getSubExpr();
-
     // '_compiler_version' '(' string-literal ')'
     if (*KindName == "_compiler_version") {
       auto SLE = dyn_cast<StringLiteralExpr>(Arg);
@@ -424,8 +473,7 @@ public:
 
   bool visitCallExpr(CallExpr *E) {
     auto KindName = getDeclRefStr(E->getFn());
-    auto *Arg = cast<ParenExpr>(E->getArg())->getSubExpr();
-
+    auto *Arg = getSingleSubExp(E->getArg(), KindName, nullptr);
     if (KindName == "_compiler_version") {
       auto Str = cast<StringLiteralExpr>(Arg)->getValue();
       auto Val = version::Version::parseCompilerVersionString(
@@ -450,7 +498,13 @@ public:
       }
     } else if (KindName == "canImport") {
       auto Str = extractExprSource(Ctx.SourceMgr, Arg);
-      return Ctx.canImportModule({ Ctx.getIdentifier(Str) , E->getLoc()  });
+      bool underlyingModule = false;
+      llvm::VersionTuple version;
+      if (auto *te = dyn_cast<TupleExpr>(E->getArg())) {
+        version = getCanImportVersion(te, nullptr, underlyingModule);
+      }
+      return Ctx.canImportModule({ Ctx.getIdentifier(Str) , E->getLoc() },
+                                 version, underlyingModule);
     }
 
     auto Val = getDeclRefStr(Arg);

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -62,7 +62,9 @@ void SourceLoader::collectVisibleTopLevelModuleNames(
   // TODO: Implement?
 }
 
-bool SourceLoader::canImportModule(ImportPath::Element ID) {
+bool SourceLoader::canImportModule(ImportPath::Element ID,
+                                   llvm::VersionTuple version,
+                                   bool underlyingVersion) {
   // Search the memory buffers to see if we can find this file on disk.
   FileOrError inputFileOrError = findModule(Ctx, ID.Item.str(),
                                             ID.Loc);

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -192,7 +192,8 @@ Optional<ModuleDependencies> SerializedModuleLoaderBase::getModuleDependencies(
   assert(isa<PlaceholderSwiftModuleScanner>(scanners[0].get()) &&
          "Expected PlaceholderSwiftModuleScanner as the first dependency scanner loader.");
   for (auto &scanner : scanners) {
-    if (scanner->canImportModule({moduleId, SourceLoc()})) {
+    if (scanner->canImportModule({moduleId, SourceLoc()},
+                                 llvm::VersionTuple(), false)) {
       // Record the dependencies.
       cache.recordDependencies(moduleName, *(scanner->dependencies));
       return std::move(scanner->dependencies);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -948,7 +948,7 @@ void swift::serialization::diagnoseSerializedASTLoadFailure(
 }
 
 bool SerializedModuleLoaderBase::canImportModule(
-    ImportPath::Element mID) {
+    ImportPath::Element mID, llvm::VersionTuple version, bool underlyingVersion) {
   // Look on disk.
   SmallVector<char, 0> *unusedModuleInterfacePath = nullptr;
   std::unique_ptr<llvm::MemoryBuffer> *unusedModuleBuffer = nullptr;
@@ -962,7 +962,7 @@ bool SerializedModuleLoaderBase::canImportModule(
 }
 
 bool MemoryBufferSerializedModuleLoader::canImportModule(
-    ImportPath::Element mID) {
+    ImportPath::Element mID, llvm::VersionTuple version, bool underlyingVersion) {
   // See if we find it in the registered memory buffers.
   return MemoryBuffers.count(mID.Item.str());
 }

--- a/test/Parse/ifconfig_expr.swift
+++ b/test/Parse/ifconfig_expr.swift
@@ -125,3 +125,33 @@ func ifconfigExprInExpr(baseExpr: MyStruct) {
 #endif
   )
 }
+
+func canImportVersioned() {
+#if canImport(A, version: 2)
+  let a = 1
+#endif
+
+#if canImport(A, version: 2.2)
+  let a = 1
+#endif
+
+#if canImport(A, underlyingVersion: 4)
+  let a = 1
+#endif
+
+#if canImport(A, underlyingVersion: 2.200)
+  let a = 1
+#endif
+
+#if canImport(A, unknown: 2.2) // expected-error {{2nd parameter of canImport should be labeled as version or underlyingVersion}}
+  let a = 1
+#endif
+
+#if canImport(A, 2.2) // expected-error {{2nd parameter of canImport should be labeled as version or underlyingVersion}}
+  let a = 1
+#endif
+
+#if canImport(A, 2.2, 1.1) // expected-error {{canImport can take only two parameters}}
+  let a = 1
+#endif
+}


### PR DESCRIPTION
canImport should be able to take an additional parameter labeled by either version or
underlyingVersion. We need underlyingVersion for clang modules with Swift overlays because they
have separate version numbers. The library users are usually interested in checking the importability
of the underlying clang module instead of its Swift overlay.

Part of rdar://73992299