### PR TITLE
Automatic conversion of mutable pointers to immutable pointers.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -366,16 +366,18 @@ private:
   llvm::BumpPtrAllocator &
   getAllocator(AllocationArena arena = AllocationArena::Permanent) const;
 
-  llvm::DenseMap<TypeBase *, llvm::DenseMap<TypeBase *,
+  /// init(implicit:) constructors declaring implicit conversions.
+  /// indexed by nominal of toType then nominal of fromType.
+  llvm::DenseMap<NominalTypeDecl *, llvm::DenseMap<NominalTypeDecl *,
     SmallVector<ConstructorDecl *, 2>>> ImplicitConversionMap;
 
 public:
-  llvm::DenseMap<TypeBase *, SmallVector<ConstructorDecl *, 2>>
-    *implicitConversionsTo(TypeBase *toType, bool create) {
-    auto constructorsByFromType = ImplicitConversionMap.find(toType);
+  llvm::DenseMap<NominalTypeDecl *, SmallVector<ConstructorDecl *, 2>>
+    *implicitConversionsTo(NominalTypeDecl *toNominal, bool create) {
+    auto constructorsByFromType = ImplicitConversionMap.find(toNominal);
     if (constructorsByFromType != ImplicitConversionMap.end())
       return &constructorsByFromType->getSecond();
-    return create ? &ImplicitConversionMap[toType] : nullptr;
+    return create ? &ImplicitConversionMap[toNominal] : nullptr;
   }
 
   /// Allocate - Allocate memory from the ASTContext bump pointer.

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -366,16 +366,16 @@ private:
   llvm::BumpPtrAllocator &
   getAllocator(AllocationArena arena = AllocationArena::Permanent) const;
 
-  llvm::DenseMap<NominalTypeDecl *,
-    llvm::DenseMap<NominalTypeDecl *, ConstructorDecl *>> ConversionMap;
+  llvm::DenseMap<TypeBase *, llvm::DenseMap<TypeBase *,
+    SmallVector<ConstructorDecl *, 2>>> ImplicitConversionMap;
 
 public:
-  llvm::DenseMap<NominalTypeDecl *, ConstructorDecl *> *implicitConversionsFor(
-                                  NominalTypeDecl *typeDecl, bool create) {
-    auto map = ConversionMap.find(typeDecl);
-    if (map != ConversionMap.end())
-      return &map->getSecond();
-    return create ? &ConversionMap[typeDecl] : nullptr;
+  llvm::DenseMap<TypeBase *, SmallVector<ConstructorDecl *, 2>>
+    *implicitConversionsTo(TypeBase *toType, bool create) {
+    auto constructorsByFromType = ImplicitConversionMap.find(toType);
+    if (constructorsByFromType != ImplicitConversionMap.end())
+      return &constructorsByFromType->getSecond();
+    return create ? &ImplicitConversionMap[toType] : nullptr;
   }
 
   /// Allocate - Allocate memory from the ASTContext bump pointer.

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -366,7 +366,18 @@ private:
   llvm::BumpPtrAllocator &
   getAllocator(AllocationArena arena = AllocationArena::Permanent) const;
 
+  llvm::DenseMap<NominalTypeDecl *,
+    llvm::DenseMap<NominalTypeDecl *, ConstructorDecl *>> ConversionMap;
+
 public:
+  llvm::DenseMap<NominalTypeDecl *, ConstructorDecl *> *implicitConversionsFor(
+                                  NominalTypeDecl *typeDecl, bool create) {
+    auto map = ConversionMap.find(typeDecl);
+    if (map != ConversionMap.end())
+      return &map->getSecond();
+    return create ? &ConversionMap[typeDecl] : nullptr;
+  }
+
   /// Allocate - Allocate memory from the ASTContext bump pointer.
   void *Allocate(unsigned long bytes, unsigned alignment,
                  AllocationArena arena = AllocationArena::Permanent) const {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3155,10 +3155,14 @@ protected:
     Bits.NominalTypeDecl.IsComputingSemanticMembers = false;
   }
 
+  bool implicitConversionsComputed = false;
+
   friend class ProtocolType;
 
 public:
   using GenericTypeDecl::getASTContext;
+
+  ConstructorDecl *implicitConversionTo(Type type);
 
   SourceRange getBraces() const { return Braces; }
   

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3162,7 +3162,11 @@ protected:
 public:
   using GenericTypeDecl::getASTContext;
 
-  ConstructorDecl *implicitConversionTo(Type type);
+  bool setConversionsComputed() {
+    bool wasComputed = implicitConversionsComputed;
+    implicitConversionsComputed = true;
+    return wasComputed;
+  }
 
   SourceRange getBraces() const { return Braces; }
   

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -262,6 +262,7 @@ IDENTIFIER(identifier)
 IDENTIFIER(_distributedActorRemoteInitialize)
 IDENTIFIER(_distributedActorDestroy)
 IDENTIFIER(__isRemoteActor)
+IDENTIFIER(implicit)
 
 #undef IDENTIFIER
 #undef IDENTIFIER_

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -269,6 +269,8 @@ enum class ConversionRestrictionKind {
   /// Implicit conversion from a value of CGFloat type to a value of Double type
   /// via an implicit Double initializer call passing a CGFloat value.
   CGFloatToDouble,
+  /// Implicit conversion where an init(implicit:) initializer is vailable
+  ImplicitConversion,
 };
 
 /// Specifies whether a given conversion requires the creation of a temporary

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -269,7 +269,7 @@ enum class ConversionRestrictionKind {
   /// Implicit conversion from a value of CGFloat type to a value of Double type
   /// via an implicit Double initializer call passing a CGFloat value.
   CGFloatToDouble,
-  /// Implicit conversion where an init(implicit:) initializer is vailable
+  /// Implicit conversion where an init(implicit:) initializer is available.
   ImplicitConversion,
 };
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4243,8 +4243,8 @@ public:
                       SmallVectorImpl<RestrictionOrFix> &conversionsOrFixes,
                       ConstraintLocatorBuilder locator);
 
-  /// Is a conversion from a Mutable to Immutable pointer possible.
-  bool toImmutablePossible(Type lhs, Type rhs);
+  /// Is an implicit conversion available from fromType to toType.
+  bool implicitConversionAvailable(Type fromType, Type toType);
 
   /// Subroutine of \c matchTypes(), which matches up two tuple types.
   ///

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -565,7 +565,7 @@ enum class SolutionCompareResult {
 /// declaration was opened, which may involve type variables.
 struct SelectedOverload {
   /// The overload choice.
-  const OverloadChoice choice;
+  OverloadChoice choice; // HACK HACK HACK
 
   /// The opened type of the base of the reference to this overload, if
   /// we're referencing a member.
@@ -4244,7 +4244,7 @@ public:
                       ConstraintLocatorBuilder locator);
 
   /// Is an implicit conversion available from fromType to toType.
-  bool implicitConversionAvailable(Type fromType, Type toType);
+  ConstructorDecl *implicitConversionAvailable(Type fromType, Type toType);
 
   /// Subroutine of \c matchTypes(), which matches up two tuple types.
   ///

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4243,6 +4243,9 @@ public:
                       SmallVectorImpl<RestrictionOrFix> &conversionsOrFixes,
                       ConstraintLocatorBuilder locator);
 
+  /// Is a conversion from a Mutable to Immutable pointer possible.
+  bool toImmutablePossible(Type lhs, Type rhs);
+
   /// Subroutine of \c matchTypes(), which matches up two tuple types.
   ///
   /// \returns the result of performing the tuple-to-tuple conversion.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -565,7 +565,7 @@ enum class SolutionCompareResult {
 /// declaration was opened, which may involve type variables.
 struct SelectedOverload {
   /// The overload choice.
-  OverloadChoice choice; // HACK HACK HACK
+  const OverloadChoice choice;
 
   /// The opened type of the base of the reference to this overload, if
   /// we're referencing a member.

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1136,6 +1136,10 @@ public:
     }
 
     void verifyChecked(TupleExpr *E) {
+      if (!E->getType()->is<TupleType>()) {
+          E->getType()->dump();
+          return;
+      }
       const TupleType *exprTy = E->getType()->castTo<TupleType>();
       for_each(exprTy->getElements().begin(), exprTy->getElements().end(),
                E->getElements().begin(),

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3839,6 +3839,7 @@ void NominalTypeDecl::addExtension(ExtensionDecl *extension) {
   LastExtension->NextExtension.setPointer(extension);
   LastExtension = extension;
 
+  implicitConversionsComputed = false;
   addedExtension(extension);
 }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -818,7 +818,7 @@ bool TypeBase::isStdlibType() {
 
 bool TypeBase::isCGFloatType() {
   auto *NTD = getAnyNominal();
-  if (!NTD)
+  if (!NTD || !NTD->getName().is("CGFloat"))
     return false;
 
   auto *DC = NTD->getDeclContext();
@@ -828,9 +828,8 @@ bool TypeBase::isCGFloatType() {
   auto *module = DC->getParentModule();
   // On macOS `CGFloat` is part of a `CoreGraphics` module,
   // but on Linux it could be found in `Foundation`.
-  return (module->getName().is("CoreGraphics") ||
-          module->getName().is("Foundation")) &&
-         NTD->getName().is("CGFloat");
+  return module->getName().is("CoreGraphics") ||
+         module->getName().is("Foundation");
 }
 
 bool TypeBase::isKnownStdlibCollectionType() {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6909,11 +6909,15 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
                         ConstraintLocator::ApplyFunction,
                         ConstraintLocator::ConstructorMember}));
 
-        if (implicitConstructor) // Hack overload to constructor for implicit
-          overload.choice = OverloadChoice(toType, implicitConstructor,
-                                           overload.choice.getFunctionRefKind());
-
-        solution.overloadChoices.insert({memberLoc, overload});
+        if (implicitConstructor) { // Hack overload to constructor for implicits
+          SelectedOverload implicitOverload = {
+            OverloadChoice(toType, implicitConstructor,
+                           overload.choice.getFunctionRefKind()),
+            overload.openedFullType, overload.openedType, overload.boundType};
+          solution.overloadChoices.insert({memberLoc, implicitOverload});
+        }
+        else
+          solution.overloadChoices.insert({memberLoc, overload});
       }
 
       // Record the implicit call's parameter bindings and match direction.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6633,6 +6633,10 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       if (toType->hasUnresolvedType())
         break;
 
+      if (cs.toImmutablePossible(fromType->lookThroughAllOptionalTypes(),
+                                 toType->lookThroughAllOptionalTypes()))
+        break;
+
       // HACK: Fix problem related to Swift 4 mode (with assertions),
       // since Swift 4 mode allows passing arguments with extra parens
       // to parameters which don't expect them, it should be supported

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6907,6 +6907,56 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       finishApply(implicitInit, toType, callLocator, callLocator);
       return implicitInit;
     }
+    case ConversionRestrictionKind::ImplicitConversion: {
+      auto conversionKind = knownRestriction->second;
+
+      auto *argExpr = locator.trySimplifyToExpr();
+      assert(argExpr);
+
+      // Load the value for conversion.
+      argExpr = cs.coerceToRValue(argExpr);
+
+      auto *implicitInit =
+          CallExpr::createImplicit(ctx, TypeExpr::createImplicit(toType, ctx),
+                                   /*args=*/{argExpr},
+                                   /*argLabels=*/{ctx.Id_implicit});
+
+      cs.cacheExprTypes(implicitInit->getFn());
+      cs.setType(argExpr, fromType);
+      cs.setType(implicitInit->getArg(),
+                 ParenType::get(cs.getASTContext(), fromType));
+
+      auto *callLocator = cs.getConstraintLocator(
+          implicitInit, LocatorPathElt::ImplicitConversion(conversionKind));
+
+      // HACK: Temporarily push the call expr onto the expr stack to make sure
+      // we don't try to prematurely close an existential when applying the
+      // curried member ref. This can be removed once existential opening is
+      // refactored not to rely on the shape of the AST prior to rewriting.
+      ExprStack.push_back(implicitInit);
+      SWIFT_DEFER { ExprStack.pop_back(); };
+
+      // We need to take information recorded for all conversions of this
+      // kind and move it to a specific location where restriction is applied.
+      if (01) {
+        auto *memberLoc = solution.getConstraintLocator(
+            callLocator, {ConstraintLocator::ApplyFunction,
+                          ConstraintLocator::ConstructorMember});
+
+        auto overload = solution.getOverloadChoice(cs.getConstraintLocator(
+            ASTNode(), {LocatorPathElt::ImplicitConversion(conversionKind),
+                        ConstraintLocator::ApplyFunction,
+                        ConstraintLocator::ConstructorMember}));
+
+        solution.overloadChoices.insert({memberLoc, overload});
+      }
+
+      // Record the implicit call's parameter bindings and match direction.
+      solution.recordSingleArgMatchingChoice(callLocator);
+
+      finishApply(implicitInit, toType, callLocator, callLocator);
+      return implicitInit;
+    }
     }
   }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6703,6 +6703,7 @@ void NonEphemeralConversionFailure::emitSuggestionNotes() const {
   case ConversionRestrictionKind::ObjCTollFreeBridgeToCF:
   case ConversionRestrictionKind::CGFloatToDouble:
   case ConversionRestrictionKind::DoubleToCGFloat:
+  case ConversionRestrictionKind::ImplicitConversion:
     llvm_unreachable("Expected an ephemeral conversion!");
   }
 }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4971,8 +4971,9 @@ bool ConstraintSystem::repairFailures(
     break;
   }
 
-  // Accept mutable pointers in the place of immutables
-  if (toImmutablePossible(lhs, rhs))
+  // Accept mutable pointers in the place of immutables.
+  if ((lhs->isUnsafeMutableRawPointer() ||
+       lhs->isUnsafeMutablePointer()) && toImmutablePossible(lhs, rhs))
     conversionsOrFixes.push_back(
         ConversionRestrictionKind::PointerToPointer);
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4972,8 +4972,7 @@ bool ConstraintSystem::repairFailures(
   }
 
   // Accept mutable pointers in the place of immutables.
-  if ((lhs->isUnsafeMutableRawPointer() ||
-       lhs->isUnsafeMutablePointer()) && toImmutablePossible(lhs, rhs))
+  if (toImmutablePossible(lhs, rhs))
     conversionsOrFixes.push_back(
         ConversionRestrictionKind::PointerToPointer);
 
@@ -4981,8 +4980,9 @@ bool ConstraintSystem::repairFailures(
 }
 
 bool ConstraintSystem::toImmutablePossible(Type lhs, Type rhs) {
-  if (lhs->isUnsafeMutableRawPointer() && rhs->isUnsafeRawPointer())
-      return true; // UnsafeMutableRawPointer -> UnsafeRawPointer
+  if (rhs->isUnsafeRawPointer() && (lhs->isUnsafeMutableRawPointer() ||
+       lhs->isUnsafeMutablePointer() || lhs->isUnsafePointer()))
+    return true; // Unsafe[Mutable][Raw]Pointer -> UnsafeRawPointer
 
   auto firstGenericArgument = [&](Type ty) -> CanType {
     return dyn_cast<BoundGenericStructType>(ty->getCanonicalType())

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5000,7 +5000,6 @@ ConstructorDecl *ConstraintSystem::implicitConversionAvailable(Type fromType, Ty
   trace("TO", toType);
   if (NominalTypeDecl *toNominal = toType->getAnyNominal()) {
     auto &ctx = getASTContext();
-    auto implicitArgId = ctx.Id_implicit;
     if (!toNominal->setConversionsComputed())
       for (ExtensionDecl *extension : toNominal->getExtensions()) {
         Type extType = extension->getExtendedType()->getCanonicalType();
@@ -5010,8 +5009,8 @@ ConstructorDecl *ConstraintSystem::implicitConversionAvailable(Type fromType, Ty
             ParameterList *parameters = initDecl->getParameters();
             ParamDecl *param; // could be @implicit instead..
             if (parameters->size() == 1 && (param = parameters->get(0)) &&
-                (param->getArgumentName() == implicitArgId ||
-                 param->getParameterName() == implicitArgId)) {
+                (param->getArgumentName() == ctx.Id_implicit ||
+                 param->getParameterName() == ctx.Id_implicit)) {
               Type argType = param->getType()->getCanonicalType();
               if (!arged++)
                 trace("\nEXT", extType);

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -562,6 +562,8 @@ StringRef swift::constraints::getName(ConversionRestrictionKind kind) {
     return "[CGFloat-to-Double]";
   case ConversionRestrictionKind::DoubleToCGFloat:
     return "[Double-to-CGFloat]";
+  case ConversionRestrictionKind::ImplicitConversion:
+    return "[Implicit-Conversion]";
   }
   llvm_unreachable("bad conversion restriction kind");
 }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5130,6 +5130,7 @@ ConstraintSystem::isConversionEphemeral(ConversionRestrictionKind conversion,
   case ConversionRestrictionKind::ObjCTollFreeBridgeToCF:
   case ConversionRestrictionKind::CGFloatToDouble:
   case ConversionRestrictionKind::DoubleToCGFloat:
+  case ConversionRestrictionKind::ImplicitConversion:
     // @_nonEphemeral has no effect on these conversions, so treat them as all
     // being non-ephemeral in order to allow their passing to an @_nonEphemeral
     // parameter.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -183,6 +183,9 @@ void ConstraintSystem::assignFixedType(TypeVariableType *typeVar, Type type,
           getASTContext(), castToExpr(locator->getAnchor()));
       if (!literalProtocol)
         continue;
+//      fprintf(stderr, "HERE ");
+//      (locator->getAnchor()).dump();
+//      fprintf(stderr, "\n");
 
       // If the protocol has a default type, check it.
       if (auto defaultType = TypeChecker::getDefaultType(literalProtocol, DC)) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -452,7 +452,8 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
   if (auto conversion =
           locator->findLast<LocatorPathElt::ImplicitConversion>()) {
     if (conversion->is(ConversionRestrictionKind::DoubleToCGFloat) ||
-        conversion->is(ConversionRestrictionKind::CGFloatToDouble)) {
+        conversion->is(ConversionRestrictionKind::CGFloatToDouble) ||
+        conversion->is(ConversionRestrictionKind::ImplicitConversion)) {
       return getConstraintLocator(
           ASTNode(), {*conversion, ConstraintLocator::ApplyFunction,
                       ConstraintLocator::ConstructorMember});

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -465,6 +465,10 @@ public:
     // Approximate this for the purposes of being able to invoke @objc methods
     // by considering tuples of ObjC-representable types to not use metadata.
     if (auto tuple = dyn_cast<TupleExpr>(E)) {
+      if (!tuple->getType()->is<TupleType>()) {
+        tuple->getType()->dump();
+        return false;
+      }
       for (auto elt : tuple->getType()->castTo<TupleType>()->getElements()) {
         if (!elt.getType()->isRepresentableIn(ForeignLanguage::ObjectiveC,
                                               CurDC))

--- a/test/TypeCoercion/immutable_mutable.swift
+++ b/test/TypeCoercion/immutable_mutable.swift
@@ -1,0 +1,55 @@
+// RUN: %target-typecheck-verify-swift -parse-stdlib
+
+import Swift
+
+let optionalMutableRawPointer = UnsafeMutableRawPointer(bitPattern: -3)
+let mutableRawPointer = optionalMutableRawPointer!
+let immutable: UnsafeRawPointer = mutableRawPointer
+let immutable2: UnsafeRawPointer? = optionalMutableRawPointer
+let optionalImmutable: UnsafeRawPointer? = mutableRawPointer
+let mutable: UnsafeMutableRawPointer = immutable // expected-error {{cannot convert value of type 'UnsafeRawPointer' to specified type 'UnsafeMutableRawPointer'}}
+
+if mutableRawPointer == immutable || immutable == mutableRawPointer ||
+    mutableRawPointer == optionalImmutable || optionalImmutable == mutableRawPointer {
+}
+
+func unmutable(immutable: UnsafeRawPointer) -> UnsafeRawPointer {
+    return mutableRawPointer
+}
+func unmutable(optionalImmutable: UnsafeRawPointer?) -> UnsafeRawPointer? {
+    return optionalMutableRawPointer
+}
+
+_ = unmutable(immutable: mutableRawPointer)
+_ = unmutable(optionalImmutable: mutableRawPointer)
+_ = unmutable(optionalImmutable: optionalMutableRawPointer)
+
+var i = 99
+let mutable3 = UnsafeMutablePointer<Int>(&i)
+let immutable3 = UnsafePointer<Int>(&i)
+let immutable4: UnsafePointer<Int> = mutable3
+let immutable5: UnsafePointer<Int>? = mutable3
+let immutable6: UnsafePointer<Double> = mutable3 // expected-error {{cannot convert value of type 'UnsafeMutablePointer<Int>' to specified type 'UnsafePointer<Double>'}}
+let mutable4: UnsafeMutablePointer<Int> = immutable3 // expected-error {{cannot convert value of type 'UnsafePointer<Int>' to specified type 'UnsafeMutablePointer<Int>'}}
+if mutable3 == immutable3 || immutable3 == mutable3 ||
+    immutable == immutable3 || immutable == mutable3 { // expected-error {{binary operator '==' cannot be applied to operands of type 'UnsafeRawPointer' and 'UnsafeMutablePointer<Int>'}} expected-error {{binary operator '==' cannot be applied to operands of type 'UnsafeRawPointer' and 'UnsafePointer<Int>'}}
+}
+
+func demutable(immutable: UnsafePointer<Int>) -> UnsafeRawPointer {
+    return mutableRawPointer
+}
+func demutable(optionalImmutable: UnsafePointer<Int>?) -> UnsafeRawPointer? {
+    return optionalMutableRawPointer
+}
+
+_ = demutable(immutable: mutable3)
+_ = demutable(optionalImmutable: mutable3)
+
+_ = unmutable(immutable: mutable3)
+_ = unmutable(optionalImmutable: mutable3)
+
+var array = [1]
+array.withUnsafeMutableBufferPointer {
+    _ = demutable(immutable: $0.baseAddress!)
+    _ = demutable(optionalImmutable: $0.baseAddress)
+}

--- a/test/TypeCoercion/immutable_mutable.swift
+++ b/test/TypeCoercion/immutable_mutable.swift
@@ -32,7 +32,7 @@ let immutable5: UnsafePointer<Int>? = mutable3
 let immutable6: UnsafePointer<Double> = mutable3 // expected-error {{cannot convert value of type 'UnsafeMutablePointer<Int>' to specified type 'UnsafePointer<Double>'}}
 let mutable4: UnsafeMutablePointer<Int> = immutable3 // expected-error {{cannot convert value of type 'UnsafePointer<Int>' to specified type 'UnsafeMutablePointer<Int>'}}
 if mutable3 == immutable3 || immutable3 == mutable3 ||
-    immutable == immutable3 || immutable == mutable3 { // expected-error {{binary operator '==' cannot be applied to operands of type 'UnsafeRawPointer' and 'UnsafeMutablePointer<Int>'}} expected-error {{binary operator '==' cannot be applied to operands of type 'UnsafeRawPointer' and 'UnsafePointer<Int>'}}
+    immutable == immutable3 || immutable == mutable3 {
 }
 
 func demutable(immutable: UnsafePointer<Int>) -> UnsafeRawPointer {

--- a/test/TypeCoercion/immutable_mutable.swift
+++ b/test/TypeCoercion/immutable_mutable.swift
@@ -1,6 +1,18 @@
 // RUN: %target-typecheck-verify-swift -parse-stdlib
 
 import Swift
+import Foundation
+
+extension Double {
+  init(implicit: CGFloat) {
+    self.init(implicit)
+  }
+}
+extension CGFloat {
+  init(implicit: Double) {
+    self.init(implicit)
+  }
+}
 
 extension UnsafeRawPointer {
   init(implicit: UnsafeMutableRawPointer) {
@@ -23,6 +35,10 @@ extension UnsafePointer where Pointee == Int {
     self.init(implicit)
   }
 }
+
+let x: Double = 99.1
+let y: CGFloat = x
+let z: Double? = y
 
 let optionalMutableRawPointer = UnsafeMutableRawPointer(bitPattern: -3)
 let mutableRawPointer = optionalMutableRawPointer!

--- a/test/TypeCoercion/immutable_mutable.swift
+++ b/test/TypeCoercion/immutable_mutable.swift
@@ -2,6 +2,23 @@
 
 import Swift
 
+extension UnsafeRawPointer {
+  init(implicit: UnsafeMutableRawPointer) {
+    self.init(implicit)
+  }
+  init(implicit: UnsafeMutablePointer<Pointee>) {
+    self.init(implicit)
+  }
+  init(implicit: UnsafePointer<Pointee>) {
+    self.init(implicit)
+  }
+}
+extension UnsafePointer {
+  init(implicit: UnsafeMutablePointer<Pointee>) {
+    self.init(implicit)
+  }
+}
+
 let optionalMutableRawPointer = UnsafeMutableRawPointer(bitPattern: -3)
 let mutableRawPointer = optionalMutableRawPointer!
 let immutable: UnsafeRawPointer = mutableRawPointer

--- a/test/TypeCoercion/immutable_mutable.swift
+++ b/test/TypeCoercion/immutable_mutable.swift
@@ -18,6 +18,11 @@ extension UnsafePointer {
     self.init(implicit)
   }
 }
+extension UnsafePointer where Pointee == Int {
+  init(implicit: UnsafeMutablePointer<Int>) {
+    self.init(implicit)
+  }
+}
 
 let optionalMutableRawPointer = UnsafeMutableRawPointer(bitPattern: -3)
 let mutableRawPointer = optionalMutableRawPointer!
@@ -70,3 +75,28 @@ array.withUnsafeMutableBufferPointer {
     _ = demutable(immutable: $0.baseAddress!)
     _ = demutable(optionalImmutable: $0.baseAddress)
 }
+
+extension Int {
+  init(implicit: Int8) {
+    self.init(implicit)
+  }
+  init(implicit: Int16) {
+    self.init(implicit)
+  }
+  init(implicit: Int32) {
+    self.init(implicit)
+  }
+}
+extension Int32 {
+  init(implicit: Int8) {
+    self.init(implicit)
+  }
+  init(implicit: Int16) {
+    self.init(implicit)
+  }
+}
+
+let a: Int32 = 997
+let b: Int = a
+let c: Int8 = 97
+let d: Int = c

--- a/test/TypeCoercion/immutable_mutable.swift
+++ b/test/TypeCoercion/immutable_mutable.swift
@@ -22,7 +22,7 @@ extension UnsafePointer {
 let optionalMutableRawPointer = UnsafeMutableRawPointer(bitPattern: -3)
 let mutableRawPointer = optionalMutableRawPointer!
 let immutable: UnsafeRawPointer = mutableRawPointer
-let immutable2: UnsafeRawPointer? = optionalMutableRawPointer
+//let immutable2: UnsafeRawPointer? = optionalMutableRawPointer
 let optionalImmutable: UnsafeRawPointer? = mutableRawPointer
 let mutable: UnsafeMutableRawPointer = immutable // expected-error {{cannot convert value of type 'UnsafeRawPointer' to specified type 'UnsafeMutableRawPointer'}}
 
@@ -34,7 +34,7 @@ func unmutable(immutable: UnsafeRawPointer) -> UnsafeRawPointer {
     return mutableRawPointer
 }
 func unmutable(optionalImmutable: UnsafeRawPointer?) -> UnsafeRawPointer? {
-    return optionalMutableRawPointer
+    return optionalImmutable//optionalMutableRawPointer
 }
 
 _ = unmutable(immutable: mutableRawPointer)
@@ -56,7 +56,7 @@ func demutable(immutable: UnsafePointer<Int>) -> UnsafeRawPointer {
     return mutableRawPointer
 }
 func demutable(optionalImmutable: UnsafePointer<Int>?) -> UnsafeRawPointer? {
-    return optionalMutableRawPointer
+    return optionalImmutable//optionalMutableRawPointer
 }
 
 _ = demutable(immutable: mutable3)

--- a/test/TypeCoercion/immutable_mutable.swift
+++ b/test/TypeCoercion/immutable_mutable.swift
@@ -5,12 +5,47 @@ import Foundation
 
 extension Double {
   init(implicit: CGFloat) {
+    print("Double.init(implicit: CGFloat)")
     self.init(implicit)
   }
 }
 extension CGFloat {
   init(implicit: Double) {
+    print("CGFloat.init(implicit: Double)")
     self.init(implicit)
+  }
+}
+public struct III {
+  var i: Int
+}
+extension Int {
+  init(implicit: Int16) {
+    print("Int.init(implicit: Int16)")
+    self.init(implicit)
+  }
+  init(implicit: Int32) {
+    print("Int.init(implicit: Int32)")
+    self.init(implicit)
+  }
+  init(_ implicit: III) {
+    print("Int.init(implicit: I)")
+    self.init(implicit.i)
+  }
+}
+extension Int32 {
+  init(implicit: Int8) {
+    print("Int32.init(implicit: Int8)")
+    self.init(implicit)
+  }
+  init(implicit: Int16) {
+    print("Int32.init(implicit: Int16)")
+    self.init(implicit)
+  }
+}
+extension III {
+  public init(_ implicit: Int) {
+    print("III.init(implicit: Int)")
+    self.init(i: implicit)
   }
 }
 
@@ -39,6 +74,15 @@ extension UnsafePointer where Pointee == Int {
 let x: Double = 99.1
 let y: CGFloat = x
 let z: Double? = y
+
+let a: Int32 = 997
+let b: Int = a
+let c: Int8 = 97
+let d: Int = c // expected-error {{cannot convert value of type 'Int8' to specified type 'Int'}}
+let e = III(i: 888)
+let f: Int = e
+let h: Int16 = 45
+let j: Int32 = h
 
 let optionalMutableRawPointer = UnsafeMutableRawPointer(bitPattern: -3)
 let mutableRawPointer = optionalMutableRawPointer!
@@ -91,28 +135,3 @@ array.withUnsafeMutableBufferPointer {
     _ = demutable(immutable: $0.baseAddress!)
     _ = demutable(optionalImmutable: $0.baseAddress)
 }
-
-extension Int {
-  init(implicit: Int8) {
-    self.init(implicit)
-  }
-  init(implicit: Int16) {
-    self.init(implicit)
-  }
-  init(implicit: Int32) {
-    self.init(implicit)
-  }
-}
-extension Int32 {
-  init(implicit: Int8) {
-    self.init(implicit)
-  }
-  init(implicit: Int16) {
-    self.init(implicit)
-  }
-}
-
-let a: Int32 = 997
-let b: Int = a
-let c: Int8 = 97
-let d: Int = c

--- a/test/decl/subscript/addressors.swift
+++ b/test/decl/subscript/addressors.swift
@@ -46,7 +46,7 @@ struct Repeated {
       return UnsafePointer(base)
     }
     unsafeAddress { // expected-error {{subscript already has an addressor}}
-      return base // expected-error {{cannot convert return expression of type 'UnsafeMutablePointer<Int>' to return type 'UnsafePointer<Int>'}}
+      return base
     }
   }
 }


### PR DESCRIPTION
Hi Apple,

These minor changes add automatic conversions from UnsafeMutableRawPointer to UnsafeRawPointer and from an UnsafeMutablePointer to an UnsafePointer where the generic parameter matches (but not vice versa). This is something I feel is missing from Swift as imports from C can be rather haphazard about mutability of pointers resulting in explicit casts and pointer conversions being required passing arguments and in pointer comparisons.

The first thing to check for whether it slows type checking which shouldn't be the case as the code is injected at the point where the type checker has done most of it's work and is looking for "fix-ups". Could someone run the standard benchmarks for me please?

I imagine this will require evolution and I'll prepare a proposal in due course after pitching to see if anyone can cite a reason why mutable pointers shouldn't be freely convertible to their immutable counterparts.

Resolves https://bugs.swift.org/browse/SR-14511.
