### PR TITLE
IRGen: Fix the insert point after inserting the dynamic replacement prolog

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1958,7 +1958,7 @@ static void emitEntryPointArgumentsNativeCC(IRGenSILFunction &IGF,
     if (IGF.CurSILFn->isDynamicallyReplaceable()) {
       IGF.IGM.createReplaceableProlog(IGF, IGF.CurSILFn);
       // Remap the entry block.
-      IGF.LoweredBBs[&*IGF.CurSILFn->begin()] = LoweredBB(&IGF.CurFn->back(), {});
+      IGF.LoweredBBs[&*IGF.CurSILFn->begin()] = LoweredBB(IGF.Builder.GetInsertBlock(), {});
     }
   }
 

--- a/test/Interpreter/async_dynamic.swift
+++ b/test/Interpreter/async_dynamic.swift
@@ -12,8 +12,29 @@ public dynamic func number() async -> Int {
     return 100
 }
 
+enum SomeError : Error {
+  case err
+}
+
+class C {
+  dynamic func a() async throws -> Int? {
+    return 0
+  }
+
+  dynamic func b() async throws {
+    guard let data = try await a() else {
+      throw SomeError.err
+    }
+  }
+
+}
 @main struct Main {
+
   static func main() async {
+    do {
+      try await C().b()
+    } catch _ { assertionFailure("should not throw") }
+
     // CHECK: 100
     let value = await number()
     print(value)


### PR DESCRIPTION

The code used the last basic block in the function instead of the last
basic block created for the dynamic replacement prolog.

rdar://77073666
