### PR TITLE
ModuleLoader: teach canImport to check Swift user module versions

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -347,7 +347,7 @@ private:
     DelayedPatternContexts;
 
   /// Cache of module names that fail the 'canImport' test in this context.
-  llvm::SmallPtrSet<Identifier, 8> FailedModuleImportNames;
+  mutable llvm::SmallPtrSet<Identifier, 8> FailedModuleImportNames;
   
   /// Retrieve the allocator for the given arena.
   llvm::BumpPtrAllocator &
@@ -894,7 +894,8 @@ public:
   /// module is loaded in full.
   bool canImportModuleImpl(ImportPath::Element ModulePath,
                            llvm::VersionTuple version,
-                           bool underlyingVersion) const;
+                           bool underlyingVersion,
+                           bool updateFailingList) const;
 public:
   namelookup::ImportCache &getImportCache() const;
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -943,6 +943,9 @@ REMARK(module_loaded,none,
        "loaded module at %0",
        (StringRef))
 
+WARNING(cannot_find_project_version,none,
+        "cannot find user version number for %0 module '%1'; version number ignored", (StringRef, StringRef))
+
 // Operator decls
 ERROR(ambiguous_operator_decls,none,
       "ambiguous operator declarations found for operator", ())

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -250,7 +250,13 @@ public:
 /// Imports serialized Swift modules from a MemoryBuffer into an ASTContext.
 /// This interface is primarily used by LLDB.
 class MemoryBufferSerializedModuleLoader : public SerializedModuleLoaderBase {
-  llvm::StringMap<std::unique_ptr<llvm::MemoryBuffer>> MemoryBuffers;
+
+  struct MemoryBufferInfo {
+    std::unique_ptr<llvm::MemoryBuffer> buffer;
+    llvm::VersionTuple userVersion;
+  };
+
+  llvm::StringMap<MemoryBufferInfo> MemoryBuffers;
 
   MemoryBufferSerializedModuleLoader(ASTContext &ctx,
                                      DependencyTracker *tracker,
@@ -289,8 +295,9 @@ public:
   ///
   /// FIXME: make this an actual import *path* once submodules are designed.
   void registerMemoryBuffer(StringRef importPath,
-                            std::unique_ptr<llvm::MemoryBuffer> input) {
-    MemoryBuffers[importPath] = std::move(input);
+                            std::unique_ptr<llvm::MemoryBuffer> input,
+                            llvm::VersionTuple version) {
+    MemoryBuffers[importPath] = {std::move(input), version};
   }
 
   void collectVisibleTopLevelModuleNames(

--- a/lib/ASTSectionImporter/ASTSectionImporter.cpp
+++ b/lib/ASTSectionImporter/ASTSectionImporter.cpp
@@ -46,7 +46,8 @@ bool swift::parseASTSection(MemoryBufferSerializedModuleLoader &Loader,
           llvm::MemoryBuffer::getMemBuffer(moduleData, info.name, false));
 
         // Register the memory buffer.
-        Loader.registerMemoryBuffer(info.name, std::move(bitstream));
+        Loader.registerMemoryBuffer(info.name, std::move(bitstream),
+                                    info.userModuleVersion);
         foundModules.push_back(info.name.str());
       }
     } else {

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -962,22 +962,91 @@ bool swift::extractCompilerFlagsFromInterface(StringRef buffer,
 
 bool SerializedModuleLoaderBase::canImportModule(
     ImportPath::Element mID, llvm::VersionTuple version, bool underlyingVersion) {
+  // If underlying version is specified, this should be handled by Clang importer.
+  if (!version.empty() && underlyingVersion)
+    return false;
   // Look on disk.
-  SmallVector<char, 0> *unusedModuleInterfacePath = nullptr;
+  SmallVectorImpl<char> *unusedModuleInterfacePath = nullptr;
   std::unique_ptr<llvm::MemoryBuffer> *unusedModuleBuffer = nullptr;
   std::unique_ptr<llvm::MemoryBuffer> *unusedModuleDocBuffer = nullptr;
   std::unique_ptr<llvm::MemoryBuffer> *unusedModuleSourceInfoBuffer = nullptr;
   bool isFramework = false;
   bool isSystemModule = false;
-  return findModule(mID, unusedModuleInterfacePath, unusedModuleBuffer,
-                    unusedModuleDocBuffer, unusedModuleSourceInfoBuffer,
-                    isFramework, isSystemModule);
+
+  llvm::SmallString<256> moduleInterfacePath;
+  std::unique_ptr<llvm::MemoryBuffer> moduleInputBuffer;
+  std::unique_ptr<llvm::MemoryBuffer> moduleDocBuffer;
+  if (!version.empty()) {
+    unusedModuleInterfacePath = &moduleInterfacePath;
+    unusedModuleBuffer = &moduleInputBuffer;
+    unusedModuleDocBuffer = &moduleDocBuffer;
+  }
+
+  auto found = findModule(mID, unusedModuleInterfacePath, unusedModuleBuffer,
+                          unusedModuleDocBuffer, unusedModuleSourceInfoBuffer,
+                          isFramework, isSystemModule);
+  // If we cannot find the module, don't continue.
+  if (!found)
+    return false;
+  // If no version number is specified, don't continue.
+  if (version.empty())
+    return true;
+  assert(found);
+  assert(!version.empty());
+  assert(!underlyingVersion);
+  llvm::VersionTuple currentVersion;
+  if (!moduleInterfacePath.empty()) {
+    // Read the inteface file and extract its compiler arguments line
+    if (auto file = llvm::MemoryBuffer::getFile(moduleInterfacePath)) {
+      llvm::BumpPtrAllocator alloc;
+      llvm::StringSaver argSaver(alloc);
+      SmallVector<const char*, 8> args;
+      (void)extractCompilerFlagsFromInterface((*file)->getBuffer(), argSaver, args);
+      for (unsigned I = 0, N = args.size(); I + 1 < N; I++) {
+        // Check the version number specified via -user-module-version.
+        StringRef current(args[I]), next(args[I + 1]);
+        if (current == "-user-module-version") {
+          currentVersion.tryParse(next);
+          break;
+        }
+      }
+    }
+  }
+  // If failing to extract the user version from the interface file, try the binary
+  // format, if present.
+  if (currentVersion.empty() && unusedModuleBuffer) {
+    auto metaData =
+      serialization::validateSerializedAST((*unusedModuleBuffer)->getBuffer());
+    currentVersion = metaData.userModuleVersion;
+  }
+
+  if (currentVersion.empty()) {
+    Ctx.Diags.diagnose(mID.Loc, diag::cannot_find_project_version, "Swift",
+                       mID.Item.str());
+    return true;
+  }
+
+  return currentVersion >= version;
 }
 
 bool MemoryBufferSerializedModuleLoader::canImportModule(
     ImportPath::Element mID, llvm::VersionTuple version, bool underlyingVersion) {
-  // See if we find it in the registered memory buffers.
-  return MemoryBuffers.count(mID.Item.str());
+  // If underlying version is specified, this should be handled by Clang importer.
+  if (!version.empty() && underlyingVersion)
+    return false;
+  auto mIt = MemoryBuffers.find(mID.Item.str());
+  if (mIt == MemoryBuffers.end())
+    return false;
+  if (version.empty())
+    return true;
+  if (mIt->second.userVersion.empty()) {
+    Ctx.Diags.diagnose(mID.Loc, diag::cannot_find_project_version, "Swift",
+                       mID.Item.str());
+    return true;
+  }
+  assert(!version.empty());
+  assert(!(mIt->second.userVersion.empty()));
+  return mIt->second.userVersion >= version;
 }
 
 ModuleDecl *
@@ -1055,7 +1124,7 @@ MemoryBufferSerializedModuleLoader::loadModule(SourceLoc importLoc,
 
   bool isFramework = false;
   std::unique_ptr<llvm::MemoryBuffer> moduleInputBuffer;
-  moduleInputBuffer = std::move(bufIter->second);
+  moduleInputBuffer = std::move(bufIter->second.buffer);
   MemoryBuffers.erase(bufIter);
   assert(moduleInputBuffer);
 

--- a/test/Parse/versioned_canimport.swift
+++ b/test/Parse/versioned_canimport.swift
@@ -1,0 +1,58 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/textual)
+// RUN: %empty-directory(%t/binary)
+// RUN: %empty-directory(%t/module-cache)
+
+// RUN: echo "public func foo() {}" > %t/Foo.swift
+// RUN: %target-swift-frontend -emit-module %t/Foo.swift -module-name Foo -swift-version 5 -disable-implicit-concurrency-module-import -user-module-version 113.330 -emit-module-interface-path %t/textual/Foo.swiftinterface -enable-library-evolution -emit-module-path %t/binary/Foo.swiftmodule
+// RUN: %target-swift-frontend -emit-module %t/Foo.swift -module-name Bar -swift-version 5 -disable-implicit-concurrency-module-import -emit-module-interface-path %t/textual/Bar.swiftinterface -enable-library-evolution -emit-module-path %t/binary/Bar.swiftmodule
+
+// RUN: %target-typecheck-verify-swift -disable-implicit-concurrency-module-import -I %t/textual
+// RUN: %target-typecheck-verify-swift -disable-implicit-concurrency-module-import -I %t/binary
+
+import Foo
+import Bar
+
+#if canImport(Bar, version: 113.331) // expected-warning {{cannot find user version number for Swift module 'Bar'; version number ignored}}
+#endif
+
+#if canImport(Bar, version: 2) // expected-warning {{cannot find user version number for Swift module 'Bar'; version number ignored}}
+#endif
+
+func canImportVersioned() {
+#if canImport(Foo, version: 113.331)
+  let a = 1
+#endif
+
+#if canImport(Foo, version: 113.3000)
+  let b = 1
+#endif
+
+#if canImport(Foo, version: 114)
+  let c = 1
+#endif
+
+#if canImport(Foo, version: 4)
+  let d = 1 // expected-warning {{initialization of immutable value 'd' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
+#if canImport(Foo, version: 113.33)
+  let e = 1 // expected-warning {{initialization of immutable value 'e' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
+#if canImport(Foo, underlyingVersion: 113.33)
+  let ee = 1
+#endif
+
+#if canImport(Foo, version: 113.329)
+  let f = 1 // expected-warning {{initialization of immutable value 'f' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
+#if canImport(Foo, version: 113.330)
+  let g = 1 // expected-warning {{initialization of immutable value 'g' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
+#if canImport(Foo)
+  let h = 1 // expected-warning {{initialization of immutable value 'h' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+}


### PR DESCRIPTION
For config condition `canImport(Foo, version: N)`, this patch teaches the compiler to check N
against the version of the Swift module Foo on disk. It returns true if the module version on
disk is greater or equal to N and returns false otherwise.

Part of rdar://73992299
