### PR TITLE
XFAIL: test/Concurrency/throwing.swift on windows

### DIFF
--- a/test/Concurrency/throwing.swift
+++ b/test/Concurrency/throwing.swift
@@ -4,6 +4,7 @@
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// XFAIL: OS=windows-msvc
 
 import _Concurrency
 import StdlibUnittest


### PR DESCRIPTION
It seems to fail.
