### PR TITLE
Enable effectful properties (SE-310) by default.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -36,7 +36,7 @@
 
 LANGUAGE_FEATURE(StaticAssert, 0, "#assert", langOpts.EnableExperimentalStaticAssert)
 LANGUAGE_FEATURE(AsyncAwait, 296, "async/await", true)
-LANGUAGE_FEATURE(EffectfulProp, 310, "Effectful properties", langOpts.EnableExperimentalConcurrency)
+LANGUAGE_FEATURE(EffectfulProp, 310, "Effectful properties", true)
 LANGUAGE_FEATURE(MarkerProtocol, 0, "@_marker protocol", true)
 LANGUAGE_FEATURE(Actors, 0, "actors", true)
 LANGUAGE_FEATURE(ConcurrentFunctions, 0, "@concurrent functions", true)

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1620,8 +1620,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
         result.info.accessorKind = ImportedAccessorKind::PropertySetter;
 
       // only allow effectful property imports if through `swift_async_name`
-      const bool effectfulProperty = parsedName.IsGetter && nameAttr->isAsync
-                      && swiftCtx.LangOpts.EnableExperimentalConcurrency;
+      const bool effectfulProperty = parsedName.IsGetter && nameAttr->isAsync;
 
       // Consider throws and async imports.
       if (method && (parsedName.IsFunctionName || effectfulProperty)) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6067,9 +6067,6 @@ ParserStatus Parser::parseGetEffectSpecifier(ParsedAccessors &accessors,
                                              SourceLoc const& currentLoc) {
   ParserStatus Status;
 
-  if (!shouldParseExperimentalConcurrency())
-    return Status;
-
   if (isEffectsSpecifier(Tok)) {
     if (currentKind == AccessorKind::Get) {
       Status |=

--- a/test/Concurrency/Runtime/effectful_properties.swift
+++ b/test/Concurrency/Runtime/effectful_properties.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-parse-as-library -Xfrontend -enable-experimental-concurrency %import-libdispatch) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library %import-libdispatch) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/IDE/print_clang_objc_effectful_properties.swift
+++ b/test/IDE/print_clang_objc_effectful_properties.swift
@@ -1,10 +1,9 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -print-implicit-attrs -source-filename %s -module-to-print=EffectfulProperties -function-definitions=false -enable-experimental-concurrency > %t/EffectfulProperties.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -print-implicit-attrs -source-filename %s -module-to-print=EffectfulProperties -function-definitions=false > %t/EffectfulProperties.printed.txt
 // RUN: %FileCheck -input-file %t/EffectfulProperties.printed.txt %s
 
 // REQUIRES: objc_interop
-// REQUIRES: concurrency
 
 // CHECK-LABEL: class EffProps : NSObject {
 // CHECK:  func getDogWithCompletion(_ completionHandler: @escaping (NSObject) -> Void)
@@ -26,11 +25,11 @@
 // CHECK:       func nullableHandler(_ completion: ((String) -> Void)? = nil)
 // CHECK-NEXT:  var fromNullableHandler: String { get async }
 
-// CHECK:  func getMainDog(_ completion: @escaping @MainActor (String) -> Void)
+// CHECK:  func getMainDog(_ completion: @escaping (String) -> Void)
 // CHECK-NEXT:  var mainDogProp: String { get async }
 
 // CHECK:  @completionHandlerAsync("regularMainDog()", completionHandlerIndex: 0)
-// CHECK-NEXT:  func regularMainDog(_ completion: @escaping @MainActor (String) -> Void)
+// CHECK-NEXT:  func regularMainDog(_ completion: @escaping (String) -> Void)
 // CHECK-NEXT:  @discardableResult
 // CHECK-NEXT:  func regularMainDog() async -> String
 // CHECK: }

--- a/test/Misc/effectful_properties_keypath.swift
+++ b/test/Misc/effectful_properties_keypath.swift
@@ -1,6 +1,5 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
+// RUN: %target-typecheck-verify-swift
 
-// REQUIRES: concurrency
 // REQUIRES: objc_interop
 
 enum E : Error {

--- a/test/ModuleInterface/effectful_properties.swift
+++ b/test/ModuleInterface/effectful_properties.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-concurrency -typecheck -swift-version 5 -enable-library-evolution -emit-module-interface-path %t.swiftinterface %s -module-name EffProps
+// RUN: %target-swift-frontend -typecheck -swift-version 5 -enable-library-evolution -emit-module-interface-path %t.swiftinterface %s -module-name EffProps
 // RUN: %FileCheck %s < %t.swiftinterface
 
 public struct MyStruct {}

--- a/test/Parse/effectful_properties.swift
+++ b/test/Parse/effectful_properties.swift
@@ -1,5 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
-// REQUIRES: concurrency
+// RUN: %target-typecheck-verify-swift
 
 struct MyProps {
   var prop1 : Int {
@@ -112,10 +111,9 @@ var bad1 : Int {
 }
 
 var bad2 : Int {
-  get reasync { 0 }  // expected-error{{only function declarations may be marked 'reasync'; did you mean 'async'?}}
+  get reasync { 0 }  // expected-error{{expected '{' to start getter definition}}
 
-  // expected-error@+1 {{'set' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'}}
-  set reasync { }   // expected-error{{'set' accessor cannot have specifier 'reasync'}}
+  set reasync { }
 }
 
 var bad3 : Int {
@@ -158,18 +156,12 @@ var bad8 : Double {
 }
 
 protocol BadP {
-  // expected-error@+3 {{'set' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'}}
-  // expected-error@+2 {{only function declarations may be marked 'rethrows'; did you mean 'throws'?}}
-  // expected-error@+1 {{only function declarations may be marked 'reasync'; did you mean 'async'?}}
-  var prop1 : Int { get reasync rethrows set }
-
   var prop2 : Int { get bogus rethrows set } // expected-error{{expected get or set in a protocol property}}
 
   // expected-error@+2 {{only function declarations may be marked 'rethrows'; did you mean 'throws'?}}
   // expected-error@+1 {{expected get or set in a protocol property}}
   var prop3 : Int { get rethrows bogus set }
 
-  // expected-error@+2 {{only function declarations may be marked 'reasync'; did you mean 'async'?}}
   // expected-error@+1 {{expected get or set in a protocol property}}
   var prop4 : Int { get reasync bogus set }
 

--- a/test/SILGen/effectful_properties.swift
+++ b/test/SILGen/effectful_properties.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -module-name accessors -swift-version 5 -enable-experimental-concurrency | %FileCheck --enable-var-scope %s
-// REQUIRES: concurrency
+// RUN: %target-swift-frontend -emit-silgen %s -module-name accessors -swift-version 5 | %FileCheck --enable-var-scope %s
 
 class C {
   // CHECK-DAG: sil hidden [ossa] @$s9accessors1CC16prop_asyncThrowsSivg : $@convention(method) @async (@guaranteed C) -> (Int, @error Error) {

--- a/test/SILGen/objc_effectful_properties.swift
+++ b/test/SILGen/objc_effectful_properties.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -I %S/Inputs/custom-modules -enable-experimental-concurrency %s -verify | %FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -I %S/Inputs/custom-modules %s -verify | %FileCheck --enable-var-scope --check-prefix=CHECK --check-prefix=CHECK-%target-cpu %s
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 

--- a/test/Serialization/effectful_properties.swift
+++ b/test/Serialization/effectful_properties.swift
@@ -1,10 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -enable-experimental-concurrency -emit-module-path %t/a.swiftmodule -module-name a %s
+// RUN: %target-swift-frontend -emit-module-path %t/a.swiftmodule -module-name a %s
 // RUN: %target-swift-ide-test -print-module -module-to-print a -source-filename x -I %t | %FileCheck -check-prefix MODULE-CHECK %s
-// RUN: %target-swift-frontend -enable-experimental-concurrency -emit-module-path %t/b.swiftmodule -module-name a  %t/a.swiftmodule
+// RUN: %target-swift-frontend -emit-module-path %t/b.swiftmodule -module-name a  %t/a.swiftmodule
 // RUN: cmp -s %t/a.swiftmodule %t/b.swiftmodule
-
-// REQUIRES: concurrency
 
 ///////////
 // This test checks for correct serialization & deserialization of

--- a/test/decl/class/effectful_properties.swift
+++ b/test/decl/class/effectful_properties.swift
@@ -1,6 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
-
-// REQUIRES: concurrency
+// RUN: %target-typecheck-verify-swift
 
 enum E : Error {
   case NotAvailable

--- a/test/decl/class/effectful_properties_objc.swift
+++ b/test/decl/class/effectful_properties_objc.swift
@@ -1,6 +1,5 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
+// RUN: %target-typecheck-verify-swift
 
-// REQUIRES: concurrency
 // REQUIRES: objc_interop
 
 enum E : Error {

--- a/test/decl/protocol/effectful_properties.swift
+++ b/test/decl/protocol/effectful_properties.swift
@@ -1,6 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
-
-// REQUIRES: concurrency
+// RUN: %target-typecheck-verify-swift
 
 /////
 // This test is focused on checking protocol conformance and constraint checking

--- a/test/decl/protocol/effectful_properties_objc.swift
+++ b/test/decl/protocol/effectful_properties_objc.swift
@@ -1,6 +1,5 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
+// RUN: %target-typecheck-verify-swift
 
-// REQUIRES: concurrency
 // REQUIRES: objc_interop
 
 /////////

--- a/test/decl/var/effectful_properties_global.swift
+++ b/test/decl/var/effectful_properties_global.swift
@@ -1,5 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
-// REQUIRES: concurrency
+// RUN: %target-typecheck-verify-swift
 
 var intAsyncProp : Int {
   get async { 0 }

--- a/test/decl/var/effectful_property_wrapper.swift
+++ b/test/decl/var/effectful_property_wrapper.swift
@@ -1,5 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
-// REQUIRES: concurrency
+// RUN: %target-typecheck-verify-swift
 
 // Currently, we don't support having property wrappers that are effectful.
 // Eventually we'd like to add this.


### PR DESCRIPTION
1. Removes gating on -enable-experimental-concurrency.
2. Updates eff. prop tests to remove experimental flag,
   and also adjusts some tests slightly to avoid things
   that are still behind that flag.

Resolves rdar://77224151
