### PR TITLE
SILGen: Copy the block before detaching a task for async methods called from ObjC.

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1460,8 +1460,15 @@ SILFunction *SILGenFunction::emitNativeAsyncToForeignThunk(SILDeclRef thunk) {
   for (auto input : objcFnTy->getParameters()) {
     SILType argTy = getSILType(input, objcFnTy);
     SILValue arg = F.begin()->createFunctionArgument(argTy);
-    
-    if (!input.isConsumed()) {
+    // Copy block arguments.
+    if (argTy.isBlockPointerCompatible()) {
+      auto argCopy = B.createCopyBlock(loc, arg);
+      // If the argument is consumed, we're still responsible for releasing the
+      // original.
+      if (input.isConsumed())
+        emitManagedRValueWithCleanup(arg);
+      arg = argCopy;
+    } else if (!input.isConsumed()) {
       arg = emitObjCUnconsumedArgument(*this, loc, arg);
     }
     auto managedArg = emitManagedRValueWithCleanup(arg);

--- a/test/Concurrency/Runtime/Inputs/objc_async.h
+++ b/test/Concurrency/Runtime/Inputs/objc_async.h
@@ -17,3 +17,5 @@
 __attribute__((swift_async_name("getter:catto()")));
 
 @end
+
+void scheduleButt(Butt *b, NSString *s);

--- a/test/Concurrency/Runtime/Inputs/objc_async.m
+++ b/test/Concurrency/Runtime/Inputs/objc_async.m
@@ -27,3 +27,10 @@
 }
 
 @end
+
+void scheduleButt(Butt *b, NSString *s) {
+  [b butt: 1738 completionHandler: ^(NSInteger i) {
+    printf("butt %p named %s occurred at %zd", b, [s UTF8String], (ssize_t)i);
+    fflush(stdout);
+  }];
+}

--- a/test/Concurrency/Runtime/objc_async.swift
+++ b/test/Concurrency/Runtime/objc_async.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clang -fobjc-arc %S/Inputs/objc_async.m -c -o %t/objc_async_objc.o
-// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-as-library -module-name main -import-objc-header %S/Inputs/objc_async.h %s %t/objc_async_objc.o -o %t/objc_async
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -Xfrontend -disable-availability-checking -parse-as-library -module-name main -import-objc-header %S/Inputs/objc_async.h %s %t/objc_async_objc.o -o %t/objc_async
 // RUN: %target-run %t/objc_async | %FileCheck %s
 
 // REQUIRES: executable_test
@@ -50,6 +50,8 @@ class Clbuttic: Butt {
     // CHECK-NEXT: called into override
     // CHECK-NEXT: butt {{.*}} named clbuttic occurred at 679
     scheduleButt(Clbuttic(), "clbuttic")
+
+    await Task.sleep(500_000)
   }
 }
 

--- a/test/Concurrency/Runtime/objc_async.swift
+++ b/test/Concurrency/Runtime/objc_async.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang %S/Inputs/objc_async.m -c -o %t/objc_async_objc.o
+// RUN: %target-clang -fobjc-arc %S/Inputs/objc_async.m -c -o %t/objc_async_objc.o
 // RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-as-library -module-name main -import-objc-header %S/Inputs/objc_async.h %s %t/objc_async_objc.o -o %t/objc_async
 // RUN: %target-run %t/objc_async | %FileCheck %s
 
@@ -28,6 +28,13 @@ func farmTest() async {
   }
 }
 
+class Clbuttic: Butt {
+    override func butt(_ x: Int) async -> Int {
+        print("called into override")
+        return 679
+    }
+}
+
 @main struct Main {
   static func main() async {
     // CHECK: starting 1738
@@ -39,6 +46,10 @@ func farmTest() async {
     // CHECK-NEXT: obtaining cat has failed!
     // CHECK-NEXT: caught exception
     await farmTest()
+
+    // CHECK-NEXT: called into override
+    // CHECK-NEXT: butt {{.*}} named clbuttic occurred at 679
+    scheduleButt(Clbuttic(), "clbuttic")
   }
 }
 

--- a/test/SILGen/objc_async_from_swift.swift
+++ b/test/SILGen/objc_async_from_swift.swift
@@ -29,7 +29,7 @@ func testSlowServing(p: SlowServing) async throws {
 
 class SlowSwiftServer: NSObject, SlowServing {
     // CHECK-LABEL: sil {{.*}} @${{.*}}10requestInt{{.*}}To :
-    // CHECK:         [[BLOCK_COPY:%.*]] = copy_value %0
+    // CHECK:         [[BLOCK_COPY:%.*]] = copy_block %0
     // CHECK:         [[SELF:%.*]] = copy_value %1
     // CHECK:         [[CLOSURE_REF:%.*]] = function_ref [[CLOSURE_IMP:@\$.*10requestInt.*U_To]] :
     // CHECK:         [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[CLOSURE_REF]]([[BLOCK_COPY]], [[SELF]])


### PR DESCRIPTION
The block needs to survive long enough for the task to get scheduled. Fixes rdar://76871310.