### PR TITLE
Use 'Apple TV' as tvOS device simulator

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -97,7 +97,7 @@ def get_simulator_command(run_os, run_cpu, sdk_path):
         else:
             return "simctl spawn --standalone 'iPhone 8'"
     elif run_os == 'tvos':
-        return "simctl spawn --standalone 'Apple TV 4K'"
+        return "simctl spawn --standalone 'Apple TV'"
     elif run_os == 'watchos':
         if run_cpu == "i386":
            if min(darwin_get_watchos_sim_vers()) > 6.2:


### PR DESCRIPTION
<!-- What's in this pull request? -->
Updates lit configuration to use 'Apple TV' as the device simulator when running tvOS simulator tests.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
