### PR TITLE
[cmake] Copy Dispatch to the SDK subdir on host.

### DIFF
--- a/cmake/modules/Libdispatch.cmake
+++ b/cmake/modules/Libdispatch.cmake
@@ -110,6 +110,14 @@ foreach(sdk ${DISPATCH_SDKS})
                           ${CMAKE_COMMAND} -E copy
                           <INSTALL_DIR>/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
                           ${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
+                        COMMAND
+                          ${CMAKE_COMMAND} -E copy
+                          <INSTALL_DIR>/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}dispatch${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
+                          ${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}dispatch${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
+                        COMMAND
+			  ${CMAKE_COMMAND} -E copy
+                          <INSTALL_DIR>/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
+                          ${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
                         STEP_TARGETS
                           install
                         BUILD_BYPRODUCTS

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -995,6 +995,10 @@ function(_add_swift_target_library_single target name)
         PROPERTIES
         INSTALL_RPATH "$ORIGIN")
     endif()
+  elseif("${SWIFTLIB_SINGLE_SDK}" STREQUAL "OPENBSD")
+    set_target_properties("${target}"
+      PROPERTIES
+      INSTALL_RPATH "$ORIGIN")
   endif()
 
   set_target_properties("${target}" PROPERTIES BUILD_WITH_INSTALL_RPATH YES)


### PR DESCRIPTION
We have two directories for Swift libraries,
* `SWIFT_SDK_<platform>_LIB_SUBDIR`, a.k.a., the SDK subdir,
  a.k.a., `swift-<platform>-<arch>/lib/swift/<platform>`, and
* `SWIFTLIB_SINGLE_SUBDIR`,
  a.k.a., `swift-<platform>-<arch>/lib/swift/<platform>/<arch>`.

We unconditionally copy libdispatch.so and libBlocksRuntime.so to
SWIFTLIB_SINGLE_SUBDIR. But this is insufficient, because swiftc emits
binaries with an RPATH with the SDK subdir.

This does not cause problems when these libraries are installed on the
platform itself, but the platform loader will choke since it can't find
those libraries -- as they are not in the RPATH.

This itself isn't so much of an issue, but it is an inconsistency since
we normally do the needful to ensure we don't need to install binaries
and libraries to the system to run and execute the Swift compiler and
binaries, so this is indeed something of a regression.

Normally, we would require adding a `-ldispatch` flag to make this all
work but this is difficult to do correctly, and more
importantly because other platforms are using `$ORIGIN` to get the
dependency search to work properly, let's do so also here.

This seems like the best way to do this; please advise if there is some
better mechanism to go about achieving this goal. 