### PR TITLE
[APIDigester] Provide a category when serializing diagnostics representing API/ABI breakage

### DIFF
--- a/include/swift/AST/DiagnosticConsumer.h
+++ b/include/swift/AST/DiagnosticConsumer.h
@@ -45,6 +45,7 @@ struct DiagnosticInfo {
   DiagnosticKind Kind;
   StringRef FormatString;
   ArrayRef<DiagnosticArgument> FormatArgs;
+  StringRef Category;
 
   /// Only used when directing diagnostics to different outputs.
   /// In batch mode a diagnostic may be
@@ -85,13 +86,13 @@ struct DiagnosticInfo {
 
   DiagnosticInfo(DiagID ID, SourceLoc Loc, DiagnosticKind Kind,
                  StringRef FormatString,
-                 ArrayRef<DiagnosticArgument> FormatArgs,
+                 ArrayRef<DiagnosticArgument> FormatArgs, StringRef Category,
                  SourceLoc BufferIndirectlyCausingDiagnostic,
                  ArrayRef<DiagnosticInfo *> ChildDiagnosticInfo,
                  ArrayRef<CharSourceRange> Ranges, ArrayRef<FixIt> FixIts,
                  bool IsChildNote)
       : ID(ID), Loc(Loc), Kind(Kind), FormatString(FormatString),
-        FormatArgs(FormatArgs),
+        FormatArgs(FormatArgs), Category(Category),
         BufferIndirectlyCausingDiagnostic(BufferIndirectlyCausingDiagnostic),
         ChildDiagnosticInfo(ChildDiagnosticInfo), Ranges(Ranges),
         FixIts(FixIts), IsChildNote(IsChildNote) {}

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -1013,6 +1013,10 @@ namespace swift {
     /// option.
     bool isDiagnosticPointsToFirstBadToken(DiagID id) const;
 
+    /// \returns true if the diagnostic is an API digester API or ABI breakage
+    /// diagnostic.
+    bool isAPIDigesterBreakageDiagnostic(DiagID id) const;
+
     /// \returns true if any diagnostic consumer gave an error while invoking
     //// \c finishProcessing.
     bool finishProcessing();

--- a/include/swift/AST/DiagnosticsModuleDiffer.def
+++ b/include/swift/AST/DiagnosticsModuleDiffer.def
@@ -20,73 +20,73 @@
 #define DEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"
 
-ERROR(generic_sig_change,none,"%0 has generic signature change from %1 to %2", (StringRef, StringRef, StringRef))
+ERROR(generic_sig_change,APIDigesterBreakage,"%0 has generic signature change from %1 to %2", (StringRef, StringRef, StringRef))
 
-ERROR(raw_type_change,none,"%0(%1) is now %2 representable", (StringRef, StringRef, StringRef))
+ERROR(raw_type_change,APIDigesterBreakage,"%0(%1) is now %2 representable", (StringRef, StringRef, StringRef))
 
-ERROR(removed_decl,none,"%0 has been removed%select{| (deprecated)}1", (StringRef, bool))
+ERROR(removed_decl,APIDigesterBreakage,"%0 has been removed%select{| (deprecated)}1", (StringRef, bool))
 
-ERROR(moved_decl,none,"%0 has been moved to %1", (StringRef, StringRef))
+ERROR(moved_decl,APIDigesterBreakage,"%0 has been moved to %1", (StringRef, StringRef))
 
-ERROR(renamed_decl,none,"%0 has been renamed to %1", (StringRef, StringRef))
+ERROR(renamed_decl,APIDigesterBreakage,"%0 has been renamed to %1", (StringRef, StringRef))
 
-ERROR(decl_type_change,none,"%0 has %1 type change from %2 to %3", (StringRef, StringRef, StringRef, StringRef))
+ERROR(decl_type_change,APIDigesterBreakage,"%0 has %1 type change from %2 to %3", (StringRef, StringRef, StringRef, StringRef))
 
-ERROR(decl_attr_change,none,"%0 changes from %1 to %2", (StringRef, StringRef, StringRef))
+ERROR(decl_attr_change,APIDigesterBreakage,"%0 changes from %1 to %2", (StringRef, StringRef, StringRef))
 
-ERROR(decl_new_attr,none,"%0 is now %1", (StringRef, StringRef))
+ERROR(decl_new_attr,APIDigesterBreakage,"%0 is now %1", (StringRef, StringRef))
 
-ERROR(decl_reorder,none,"%0 in a non-resilient type changes position from %1 to %2", (StringRef, unsigned, unsigned))
+ERROR(decl_reorder,APIDigesterBreakage,"%0 in a non-resilient type changes position from %1 to %2", (StringRef, unsigned, unsigned))
 
-ERROR(decl_added,none,"%0 is added to a non-resilient type", (StringRef))
+ERROR(decl_added,APIDigesterBreakage,"%0 is added to a non-resilient type", (StringRef))
 
-ERROR(var_has_fixed_order_change,none,"%0 is %select{now|no longer}1 a stored property", (StringRef, bool))
+ERROR(var_has_fixed_order_change,APIDigesterBreakage,"%0 is %select{now|no longer}1 a stored property", (StringRef, bool))
 
-ERROR(func_has_fixed_order_change,none,"%0 is %select{now|no longer}1 a non-final instance function", (StringRef, bool))
+ERROR(func_has_fixed_order_change,APIDigesterBreakage,"%0 is %select{now|no longer}1 a non-final instance function", (StringRef, bool))
 
-ERROR(default_arg_removed,none,"%0 has removed default argument from %1", (StringRef, StringRef))
+ERROR(default_arg_removed,APIDigesterBreakage,"%0 has removed default argument from %1", (StringRef, StringRef))
 
-ERROR(conformance_removed,none,"%0 has removed %select{conformance to|inherited protocol}2 %1", (StringRef, StringRef, bool))
+ERROR(conformance_removed,APIDigesterBreakage,"%0 has removed %select{conformance to|inherited protocol}2 %1", (StringRef, StringRef, bool))
 
-ERROR(conformance_added,none,"%0 has added inherited protocol %1", (StringRef, StringRef))
+ERROR(conformance_added,APIDigesterBreakage,"%0 has added inherited protocol %1", (StringRef, StringRef))
 
-ERROR(existing_conformance_added,none,"%0 has added a conformance to an existing protocol %1", (StringRef, StringRef))
+ERROR(existing_conformance_added,APIDigesterBreakage,"%0 has added a conformance to an existing protocol %1", (StringRef, StringRef))
 
-ERROR(default_associated_type_removed,none,"%0 has removed default type %1", (StringRef, StringRef))
+ERROR(default_associated_type_removed,APIDigesterBreakage,"%0 has removed default type %1", (StringRef, StringRef))
 
-ERROR(protocol_req_added,none,"%0 has been added as a protocol requirement", (StringRef))
+ERROR(protocol_req_added,APIDigesterBreakage,"%0 has been added as a protocol requirement", (StringRef))
 
-ERROR(super_class_removed,none,"%0 has removed its super class %1", (StringRef, StringRef))
+ERROR(super_class_removed,APIDigesterBreakage,"%0 has removed its super class %1", (StringRef, StringRef))
 
-ERROR(super_class_changed,none,"%0 has changed its super class from %1 to %2", (StringRef, StringRef, StringRef))
+ERROR(super_class_changed,APIDigesterBreakage,"%0 has changed its super class from %1 to %2", (StringRef, StringRef, StringRef))
 
-ERROR(decl_kind_changed,none,"%0 has been changed to a %1", (StringRef, StringRef))
+ERROR(decl_kind_changed,APIDigesterBreakage,"%0 has been changed to a %1", (StringRef, StringRef))
 
-ERROR(optional_req_changed,none,"%0 is %select{now|no longer}1 an optional requirement", (StringRef, bool))
+ERROR(optional_req_changed,APIDigesterBreakage,"%0 is %select{now|no longer}1 an optional requirement", (StringRef, bool))
 
-ERROR(no_longer_open,none,"%0 is no longer open for subclassing", (StringRef))
+ERROR(no_longer_open,APIDigesterBreakage,"%0 is no longer open for subclassing", (StringRef))
 
-ERROR(func_type_escaping_changed,none,"%0 has %select{removed|added}2 @escaping in %1", (StringRef, StringRef, bool))
+ERROR(func_type_escaping_changed,APIDigesterBreakage,"%0 has %select{removed|added}2 @escaping in %1", (StringRef, StringRef, bool))
 
-ERROR(func_self_access_change,none,"%0 has self access kind changing from %1 to %2", (StringRef, StringRef, StringRef))
+ERROR(func_self_access_change,APIDigesterBreakage,"%0 has self access kind changing from %1 to %2", (StringRef, StringRef, StringRef))
 
-ERROR(param_ownership_change,none,"%0 has %1 changing from %2 to %3", (StringRef, StringRef, StringRef, StringRef))
+ERROR(param_ownership_change,APIDigesterBreakage,"%0 has %1 changing from %2 to %3", (StringRef, StringRef, StringRef, StringRef))
 
-ERROR(type_witness_change,none,"%0 has type witness type for %1 changing from %2 to %3", (StringRef, StringRef, StringRef, StringRef))
+ERROR(type_witness_change,APIDigesterBreakage,"%0 has type witness type for %1 changing from %2 to %3", (StringRef, StringRef, StringRef, StringRef))
 
-ERROR(decl_new_witness_table_entry,none,"%0 now requires%select{| no}1 new witness table entry", (StringRef, bool))
+ERROR(decl_new_witness_table_entry,APIDigesterBreakage,"%0 now requires%select{| no}1 new witness table entry", (StringRef, bool))
 
-ERROR(new_decl_without_intro,none,"%0 is a new API without @available attribute", (StringRef))
+ERROR(new_decl_without_intro,APIDigesterBreakage,"%0 is a new API without @available attribute", (StringRef))
 
-ERROR(objc_name_change,none,"%0 has ObjC name change from %1 to %2", (StringRef, StringRef, StringRef))
+ERROR(objc_name_change,APIDigesterBreakage,"%0 has ObjC name change from %1 to %2", (StringRef, StringRef, StringRef))
 
-ERROR(desig_init_added,none,"%0 has been added as a designated initializer to an open class", (StringRef))
+ERROR(desig_init_added,APIDigesterBreakage,"%0 has been added as a designated initializer to an open class", (StringRef))
 
-ERROR(added_invisible_designated_init,none,"%0 has new designated initializers that are not visible to clients", (StringRef))
+ERROR(added_invisible_designated_init,APIDigesterBreakage,"%0 has new designated initializers that are not visible to clients", (StringRef))
 
-ERROR(not_inheriting_convenience_inits,none,"%0 no longer inherits convenience inits from its superclass", (StringRef))
+ERROR(not_inheriting_convenience_inits,APIDigesterBreakage,"%0 no longer inherits convenience inits from its superclass", (StringRef))
 
-ERROR(enum_case_added,none,"%0 has been added as a new enum case", (StringRef))
+ERROR(enum_case_added,APIDigesterBreakage,"%0 has been added as a new enum case", (StringRef))
 
 WARNING(cannot_read_allowlist,none,"cannot read breakage allowlist at '%0'", (StringRef))
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1973,9 +1973,10 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     DiagnosticInfo errorInfo(
         DiagID(0), SourceLoc(), DiagnosticKind::Error,
         "fatal error encountered during compilation; " SWIFT_BUG_REPORT_MESSAGE,
-        {}, SourceLoc(), {}, {}, {}, false);
+        {}, StringRef(), SourceLoc(), {}, {}, {}, false);
     DiagnosticInfo noteInfo(DiagID(0), SourceLoc(), DiagnosticKind::Note,
-                            reason, {}, SourceLoc(), {}, {}, {}, false);
+                            reason, {}, StringRef(), SourceLoc(), {}, {}, {},
+                            false);
     PDC.handleDiagnostic(dummyMgr, errorInfo);
     PDC.handleDiagnostic(dummyMgr, noteInfo);
     if (shouldCrash)

--- a/test/api-digester/serialized-diagnostics.swift
+++ b/test/api-digester/serialized-diagnostics.swift
@@ -1,0 +1,10 @@
+// REQUIRES: VENDOR=apple
+
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t/color.swiftmodule %S/Inputs/cake_baseline/color.swift -parse-as-library -enable-library-evolution %clang-importer-sdk-nosource -module-name color
+// RUN: not %api-digester -diagnose-sdk -serialize-diagnostics-path %t/result.dia -empty-baseline -I %t %clang-importer-sdk-nosource -module color -abi
+// RUN: c-index-test -read-diagnostics %t/result.dia 2>&1 | %FileCheck %s -check-prefix CHECK-DIA
+
+// Ensure the 'api-digester-breaking-change' category is included in the serialized diagnostics file.
+// CHECK-DIA: error: ABI breakage: enum Color is a new API without @available attribute [] [api-digester-breaking-change]

--- a/unittests/AST/DiagnosticConsumerTests.cpp
+++ b/unittests/AST/DiagnosticConsumerTests.cpp
@@ -54,6 +54,7 @@ namespace {
   DiagnosticInfo testDiagnosticInfo(SourceLoc Loc, const char *Message,
                                     DiagnosticKind Kind) {
     return DiagnosticInfo(DiagID(0), Loc, Kind, Message, /*args*/ {},
+                          /*category*/ StringRef(),
                           /*indirectBuffer*/ SourceLoc(), /*childInfo*/ {},
                           /*ranges*/ {}, /*fixIts*/ {}, /*isChild*/ false);
   }


### PR DESCRIPTION
Previously, the 'category' field in .dia files was unused by Swift (Clang uses it though). This PR sets the category of diagnostics emitted by the API digester which represent breaking changes to be 'api-digester-breaking-change'. I'd like to use this in SwiftPM so that it can easily identify breaking changes when parsing digester diagnostics, and then format them differently from other errors that may have occurred.

Right now, the DiagnosticEngine uses an `APIDigesterBreakingChange` option to flag a diagnostic as being part of this category. This probably will work fine for now, but if we ever want to introduce more categories it might be worth updating the diagnostic macros to make 'Category' distinct from 'Options'