### PR TITLE
[5.5][AST] Don’t print internal function labels if they start with '$'

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4878,11 +4878,13 @@ public:
                           PrintNameContext::FunctionParameterExternal);
         Printer << ": ";
       } else if (Options.AlwaysTryPrintParameterLabels &&
-                 Param.hasInternalLabel()) {
+                 Param.hasInternalLabel() &&
+                 !Param.getInternalLabel().hasDollarPrefix()) {
         // We didn't have an external parameter label but were requested to
-        // always try and print parameter labels. Print The internal label.
-        // If we have neither an external nor an internal label, only print the
-        // type.
+        // always try and print parameter labels.
+        // If the internal label is a valid internal parameter label (does not
+        // start with '$'), print the internal label. If we have neither an
+        // external nor a printable internal label, only print the type.
         Printer << "_ ";
         Printer.printName(Param.getInternalLabel(),
                           PrintNameContext::FunctionParameterLocal);

--- a/test/ModuleInterface/closure.swift
+++ b/test/ModuleInterface/closure.swift
@@ -1,0 +1,12 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck %s -emit-module-interface-path %t/main.swiftinterface -enable-library-evolution
+// RUN: %FileCheck %s < %t/main.swiftinterface
+
+// CHECK: import Swift
+
+// CHECK: public let MyClosureVar: (Swift.Int) -> Swift.Int
+public let MyClosureVar: (Int) -> Int = { $0 }
+
+// CHECK: public var MyOtherClosureVar: (_ x: Swift.Int) -> Swift.Int
+public let MyOtherClosureVar: (_ x: Int) -> Int


### PR DESCRIPTION
Cherry-picks https://github.com/apple/swift/pull/37238 to 5.5

-------------------

We might infer internal function labels as `$0` from a closure with which a variable is initialised. But we don’t want to print the function signature as `(_ $0: Int) -> Int` because `$0` is not a valid variable name to declare.

So, in the case described above, only print the type.

Fixes rdar://77462547