### PR TITLE
[libSyntax] Add a `dumpStack` method to `SyntaxParsingContext`

### DIFF
--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -44,6 +44,14 @@ enum class SyntaxContextKind {
   Syntax,
 };
 
+} // end namespace swift
+
+namespace llvm {
+raw_ostream &operator<<(raw_ostream &OS, swift::SyntaxContextKind Kind);
+} // end namespace llvm
+
+namespace swift {
+
 enum class SyntaxNodeCreationKind {
   /// This is for \c SyntaxParsingContext to collect the syntax data and create
   /// a 'recorded' ParsedRawSyntaxNode object, which would be a result of
@@ -355,6 +363,9 @@ public:
 
   /// Dump the nodes that are in the storage stack of the SyntaxParsingContext
   SWIFT_DEBUG_DUMPER(dumpStorage());
+
+  void dumpStack(llvm::raw_ostream &OS) const;
+  SWIFT_DEBUG_DUMPER(dumpStack()) { dumpStack(llvm::errs()); }
 };
 
 } // namespace swift

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -25,9 +25,35 @@
 #include "swift/Parse/SyntaxParsingCache.h"
 #include "swift/Parse/Token.h"
 #include "swift/Syntax/SyntaxFactory.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace swift;
 using namespace swift::syntax;
+
+llvm::raw_ostream &llvm::operator<<(llvm::raw_ostream &OS,
+                                    SyntaxContextKind Kind) {
+  switch (Kind) {
+  case SyntaxContextKind::Decl:
+    OS << "Decl";
+    break;
+  case SyntaxContextKind::Stmt:
+    OS << "Stmt";
+    break;
+  case SyntaxContextKind::Expr:
+    OS << "Expr";
+    break;
+  case SyntaxContextKind::Type:
+    OS << "Type";
+    break;
+  case SyntaxContextKind::Pattern:
+    OS << "Pattern";
+    break;
+  case SyntaxContextKind::Syntax:
+    OS << "Syntax";
+    break;
+  }
+  return OS;
+}
 
 void SyntaxParseActions::_anchor() {}
 
@@ -353,6 +379,38 @@ void SyntaxParsingContext::dumpStorage() const  {
     llvm::errs() << "\n";
     if (i + 1 == Offset)
       llvm::errs() << "--------------\n";
+  }
+}
+
+void SyntaxParsingContext::dumpStack(llvm::raw_ostream &OS) const {
+  if (!isRoot()) {
+    getParent()->dumpStack(OS);
+  }
+  switch (Mode) {
+  case AccumulationMode::CreateSyntax:
+    llvm::errs() << "CreateSyntax (" << SynKind << ")\n";
+    break;
+  case AccumulationMode::DeferSyntax:
+    llvm::errs() << "DeferSyntax (" << SynKind << ")\n";
+    break;
+  case AccumulationMode::CoerceKind:
+    llvm::errs() << "CoerceKind (" << CtxtKind << ")\n";
+    break;
+  case AccumulationMode::Transparent:
+    llvm::errs() << "Transparent\n";
+    break;
+  case AccumulationMode::Discard:
+    llvm::errs() << "Discard\n";
+    break;
+  case AccumulationMode::SkippedForIncrementalUpdate:
+    llvm::errs() << "SkippedForIncrementalUpdate\n";
+    break;
+  case AccumulationMode::Root:
+    llvm::errs() << "Root\n";
+    break;
+  case AccumulationMode::NotSet:
+    llvm::errs() << "NotSet\n";
+    break;
   }
 }
 


### PR DESCRIPTION
This function walks the stack of `SyntaxParsingContext`s and dumps their kind. Useful for debugging.