### PR TITLE
[5.5][libSyntax] Explicitly return 0 as length of missing deferred tokens

### DIFF
--- a/test/Syntax/Parser/fixed_crashers.swift
+++ b/test/Syntax/Parser/fixed_crashers.swift
@@ -6,3 +6,6 @@ let x: a[i] & b
 
 let x2: a & b[1]
 // CHECK: |x2|
+
+let x3: (A -> B)
+// CHECK: |x3|

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -111,6 +111,16 @@ struct DeferredTokenNode {
       : IsMissing(IsMissing), TokenKind(TokenKind),
         LeadingTrivia(LeadingTrivia), TrailingTrivia(TrailingTrivia),
         Range(Range) {}
+
+  /// Returns the length of this token or \c 0 if the token is missing.
+  size_t getLength() const {
+    if (IsMissing) {
+      return 0;
+    } else {
+      assert(Range.isValid());
+      return Range.getByteLength();
+    }
+  }
 };
 
 struct DeferredLayoutNode {
@@ -272,7 +282,7 @@ private:
         break;
       case RecordedOrDeferredNode::Kind::DeferredToken:
         length += static_cast<const DeferredTokenNode *>(child.getOpaque())
-                      ->Range.getByteLength();
+                      ->getLength();
         break;
       }
     }
@@ -373,7 +383,7 @@ private:
       case RecordedOrDeferredNode::Kind::DeferredToken:
         StartLoc = StartLoc.getAdvancedLoc(
             static_cast<const DeferredTokenNode *>(Child.getOpaque())
-                ->Range.getByteLength());
+                ->getLength());
         break;
       }
     }


### PR DESCRIPTION
Cherry-picking https://github.com/apple/swift/pull/37241 to 5.5

-------------------------------

Previously, we were always accessing the `DeferredTokenNode`’s `Range`, which is not valid if the token is missing, thus causing an assertion failure when asked for its length.

Fixes rdar://77391988 [SR-14552]