### PR TITLE
ClangImporter: check version specified in canImport with the project version specified in .tbd files

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -65,6 +65,8 @@
 #include "llvm/Support/FileCollector.h"
 #include "llvm/Support/Memory.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/YAMLTraits.h"
+#include "llvm/Support/YAMLParser.h"
 #include <algorithm>
 #include <memory>
 
@@ -1731,6 +1733,11 @@ bool ClangImporter::isModuleImported(const clang::Module *M) {
   return M->NameVisibility == clang::Module::NameVisibilityKind::AllVisible;
 }
 
+static std::string getScalaNodeText(llvm::yaml::Node *N) {
+  SmallString<32> Buffer;
+  return cast<llvm::yaml::ScalarNode>(N)->getValue(Buffer).str();
+}
+
 bool ClangImporter::canImportModule(ImportPath::Element moduleID,
                                     llvm::VersionTuple version,
                                     bool underlyingVersion) {
@@ -1748,7 +1755,66 @@ bool ClangImporter::canImportModule(ImportPath::Element moduleID,
   clang::Module::UnresolvedHeaderDirective mh;
   clang::Module *m;
   auto &ctx = Impl.getClangASTContext();
-  return clangModule->isAvailable(ctx.getLangOpts(), getTargetInfo(), r, mh, m);
+  auto available = clangModule->isAvailable(ctx.getLangOpts(), getTargetInfo(),
+                                            r, mh, m);
+  if (!available)
+    return false;
+  if (version.empty())
+    return true;
+  assert(available);
+  assert(!version.empty());
+  llvm::VersionTuple currentVersion;
+  StringRef path = getClangASTContext().getSourceManager()
+    .getFilename(clangModule->DefinitionLoc);
+  // Look for the .tbd file inside .framework dir to get the project version
+  // number.
+  std::string fwName = (llvm::Twine(moduleID.Item.str()) + ".framework").str();
+  auto pos = path.find(fwName);
+  while (pos != StringRef::npos) {
+    llvm::SmallString<256> buffer(path.substr(0, pos + fwName.size()));
+    llvm::sys::path::append(buffer, llvm::Twine(moduleID.Item.str()) + ".tbd");
+    auto tbdPath = buffer.str();
+    llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> tbdBufOrErr =
+      llvm::MemoryBuffer::getFile(tbdPath);
+    // .tbd file doesn't exist, break.
+    if (!tbdBufOrErr) {
+      break;
+    }
+    StringRef tbdBuffer = tbdBufOrErr->get()->getBuffer();
+
+    // Use a new source manager instead of the one from ASTContext because we
+    // don't want the Json file to be persistent.
+    SourceManager SM;
+    llvm::yaml::Stream Stream(llvm::MemoryBufferRef(tbdBuffer, tbdPath),
+                              SM.getLLVMSourceMgr());
+    auto DI = Stream.begin();
+    assert(DI != Stream.end() && "Failed to read a document");
+    llvm::yaml::Node *N = DI->getRoot();
+    assert(N && "Failed to find a root");
+    auto *pairs = dyn_cast_or_null<llvm::yaml::MappingNode>(N);
+    if (!pairs)
+      break;
+    for (auto &keyValue: *pairs) {
+      auto key = getScalaNodeText(keyValue.getKey());
+      // Look for field "current-version" in the .tbd file.
+      if (key == "current-version") {
+        auto ver = getScalaNodeText(keyValue.getValue());
+        currentVersion.tryParse(ver);
+        break;
+      }
+    }
+    break;
+  }
+  // Diagnose unable to checking the current version.
+  if (currentVersion.empty()) {
+    Impl.diagnose(moduleID.Loc, diag::cannot_find_project_version, "Clang",
+                  moduleID.Item.str());
+    return true;
+  }
+  assert(!currentVersion.empty());
+  // Give a green light if the version on disk is greater or equal to the version
+  // specified in the canImport condition.
+  return currentVersion >= version;
 }
 
 ModuleDecl *ClangImporter::Implementation::loadModuleClang(

--- a/test/ClangImporter/versioned_canimport.swift
+++ b/test/ClangImporter/versioned_canimport.swift
@@ -1,0 +1,39 @@
+// REQUIRES: VENDOR=apple
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/overlaydir)
+// RUN: %empty-directory(%t/frameworks)
+
+// RUN: cp -rf %S/Inputs/frameworks/Simple.framework %t/frameworks/
+
+// RUN: echo "current-version: 1830.100" > %t/frameworks/Simple.framework/Simple.tbd
+// RUN: echo "@_exported import Simple" > %t.overlay.swift
+// RUN: echo "public func additional() {}" >> %t.overlay.swift
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -disable-implicit-concurrency-module-import -module-name Simple -F %t/frameworks/ %t.overlay.swift -emit-module-path %t/overlaydir/Simple.swiftmodule
+// RUN: %target-typecheck-verify-swift -disable-implicit-concurrency-module-import -I %t/overlaydir/ -F %t/frameworks
+
+import Simple
+
+func canImportVersioned() {
+#if canImport(Simple, underlyingVersion: 3.3)
+  let a = 1  // expected-warning {{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
+#if canImport(Simple, underlyingVersion: 1830.100)
+  let b = 1  // expected-warning {{initialization of immutable value 'b' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
+#if canImport(Simple, underlyingVersion: 1830.11)
+  let c = 1  // expected-warning {{initialization of immutable value 'c' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+}
+
+func canNotImportVersioned() {
+#if canImport(Simple, underlyingVersion: 1831)
+  let a = 1
+#endif
+
+#if canImport(Simple, underlyingVersion: 1830.101)
+  let b = 1
+#endif
+}

--- a/test/ClangImporter/versioned_canimport_no_version.swift
+++ b/test/ClangImporter/versioned_canimport_no_version.swift
@@ -1,0 +1,20 @@
+// REQUIRES: VENDOR=apple
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/overlaydir)
+// RUN: %empty-directory(%t/frameworks)
+
+// RUN: cp -rf %S/Inputs/frameworks/Simple.framework %t/frameworks/
+
+// RUN: echo "" > %t/frameworks/Simple.framework/Simple.tbd
+// RUN: echo "@_exported import Simple" > %t.overlay.swift
+// RUN: echo "public func additional() {}" >> %t.overlay.swift
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -disable-implicit-concurrency-module-import -module-name Simple -F %t/frameworks/ %t.overlay.swift -emit-module-path %t/overlaydir/Simple.swiftmodule
+// RUN: %target-typecheck-verify-swift -disable-implicit-concurrency-module-import -I %t/overlaydir/ -F %t/frameworks
+
+import Simple
+
+func canImportVersioned() {
+#if canImport(Simple, underlyingVersion: 3.3) // expected-warning {{cannot find user version number for Clang module 'Simple'; version number ignored}}
+#endif
+}


### PR DESCRIPTION
Project versions are embedded in the .tbd files of Clang frameworks. This patch teaches the compiler
to check the desired version specified in `canImport` against the project version in .tbd file. The
condition returns true if the Clang module on disk has a version number greater or equal to the one from `canImport`
condition; it returns false otherwise.

Part of rdar://73992299
