### PR TITLE
Revert "Revert "[TypeChecker] PreCheck: Don't strip away tuple/paren from subscripts …""

### DIFF
--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -1061,10 +1061,24 @@ namespace {
     }
 
     std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
-      // If this is a call, record the argument expression.
-      if (auto call = dyn_cast<ApplyExpr>(expr)) {
-        if (!isa<SelfApplyExpr>(expr)) {
-          CallArgs.insert(call->getArg());
+      // If this is a call or subscript, record the argument expression.
+      {
+        if (auto call = dyn_cast<ApplyExpr>(expr)) {
+          if (!isa<SelfApplyExpr>(expr)) {
+            CallArgs.insert(call->getArg());
+          }
+        }
+
+        if (auto *subscript = dyn_cast<SubscriptExpr>(expr)) {
+          CallArgs.insert(subscript->getIndex());
+        }
+
+        if (auto *dynamicSubscript = dyn_cast<DynamicSubscriptExpr>(expr)) {
+          CallArgs.insert(dynamicSubscript->getIndex());
+        }
+
+        if (auto *OLE = dyn_cast<ObjectLiteralExpr>(expr)) {
+          CallArgs.insert(OLE->getArg());
         }
       }
 

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar61749633.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar61749633.swift
@@ -1,0 +1,12 @@
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck
+// REQUIRES: objc_interop
+
+import Foundation
+
+_ = Dictionary[String: Any]()
+
+func test(obj: AnyObject) {
+  obj[String: Any] // Dynamic subscript
+}
+
+#colorLiteral(String: Any)

--- a/validation-test/compiler_crashers_2_fixed/sr12990.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr12990.swift
@@ -5,7 +5,7 @@ class ContainerTransition {
   func completeTransition() {
     viewControllers?[Int//.max
     // expected-error@-1 {{no exact matches in call to subscript}}
-    // expected-note@-2 {{found candidate with type '((Int).Type) -> Dictionary<Int, String>.SubSequence' (aka '((Int).Type) -> Slice<Dictionary<Int, String>>')}}
+    // expected-note@-2 {{found candidate with type '(Int.Type) -> Dictionary<Int, String>.SubSequence' (aka '(Int.Type) -> Slice<Dictionary<Int, String>>')}}
     // expected-note@-3 {{to match this opening '['}}
   } // expected-error {{expected ']' in expression list}}
 }


### PR DESCRIPTION
Reverts apple/swift#37221

