### PR TITLE
Revert "Only run TBD emit-tbd-from-driver.swift test on macOS (76541224)"

### DIFF
--- a/test/TBD/emit-tbd-from-driver.swift
+++ b/test/TBD/emit-tbd-from-driver.swift
@@ -1,5 +1,4 @@
 // REQUIRES: VENDOR=apple
-// REQUIRES: OS=macosx
 // UNSUPPORTED: CPU=i386
 
 // RUN: %empty-directory(%t)


### PR DESCRIPTION
This reverts commit 0e5edd3d47d5e5495d365c12b6e0d1f9a3443977.
