### PR TITLE
[cxx-interop] Allows clang importer to visit partially invalid anonymous unions

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3725,8 +3725,17 @@ namespace {
 
       // It is import that we bail on an unimportable record *before* we import
       // any of its members or cache the decl.
-      if (!isCxxRecordImportable(decl))
+      if (!isCxxRecordImportable(decl)) {
+        // Anonymous unions can have valid and invalid decls inside of them.
+        // When the getters and setters for such unions are generated, if the
+        // __Unnamed_union___Anonymous_field is missing due to a field not
+        // being visited here then code in makeIndirectFieldAccessors() will
+        // assert. For now this could be considered a workaround.
+        // TODO: Investigate if there is a better way to avoid asserting.
+        if (decl->isAnonymousStructOrUnion() && decl->isUnion())
+          VisitRecordDecl(decl);
         return nullptr;
+      }
 
       return VisitRecordDecl(decl);
     }

--- a/test/Interop/Cxx/union/Inputs/anonymous-union-partly-invalid.h
+++ b/test/Interop/Cxx/union/Inputs/anonymous-union-partly-invalid.h
@@ -1,0 +1,16 @@
+@class C;
+@interface C
+{}
+@end
+
+struct S {
+  union {
+    C *t;
+    char c;
+  };
+  S(const S &s) {}
+  ~S() { }
+  int f() { return 42; }
+};
+
+S *getSPtr();

--- a/test/Interop/Cxx/union/Inputs/module.modulemap
+++ b/test/Interop/Cxx/union/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module AnonymousUnionPartlyInvalid {
+  header "anonymous-union-partly-invalid.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/union/anonymous-union-partly-invalid-module-interface.swift
+++ b/test/Interop/Cxx/union/anonymous-union-partly-invalid-module-interface.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=AnonymousUnionPartlyInvalid -I %S/Inputs -source-filename=x -enable-cxx-interop -enable-objc-interop | %FileCheck %s
+
+// CHECK: class C {
+// CHECK-NEXT: }
+// CHECK-NEXT: struct S {
+// CHECK-NEXT:   var __Anonymous_field0: S.__Unnamed_union___Anonymous_field0
+// CHECK-NEXT:   var t: C!
+// CHECK-NEXT:   var c: CChar
+// CHECK-NEXT:   mutating func f() -> Int32
+// CHECK-NEXT: }
+// CHECK-NEXT: func getSPtr() -> UnsafeMutablePointer<S>!

--- a/test/Interop/Cxx/union/anonymous-union-partly-invalid.swift
+++ b/test/Interop/Cxx/union/anonymous-union-partly-invalid.swift
@@ -1,0 +1,13 @@
+// RUN: %swift -I %S/Inputs -enable-cxx-interop -enable-objc-interop -emit-ir %s | %FileCheck %s
+
+import AnonymousUnionPartlyInvalid
+
+let sPtr = getSPtr()
+let a = sPtr![0].f()
+
+// CHECK: define i32 @main
+// CHECK-NEXT: entry:
+// CHECK-NEXT: bitcast
+// CHECK-NEXT: call %struct.S
+// CHECK-NEXT: ptrtoint %struct.S
+


### PR DESCRIPTION


At times when an anonymous union has contents that is invalid it can
cause an assert in the clang importer because the field named
__Unnamed_union___Anonymous_field is not generated because the importer
attempts to avoid visiting invalid decls. This allows for visiting the
decl for a narrow case so that getter/setter generation surrounding the
union does not result in an assert.

@zoecarver @egorzhdan 