### PR TITLE
 [SR-14135]Updating diagnostic message for convenience init in struct

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3470,7 +3470,7 @@ ERROR(cfclass_designated_init_in_extension,none,
       "designated initializer cannot be declared in an extension of %0",
       (DeclName))
 ERROR(enumstruct_convenience_init,none,
-      "delegating initializers in %0 are not marked with 'convenience'",
+      "initializers in %0 are not marked with 'convenience'",
       (StringRef))
 ERROR(nonclass_convenience_init,none,
       "convenience initializer not allowed in non-class type %0",

--- a/test/decl/func/complete_object_init.swift
+++ b/test/decl/func/complete_object_init.swift
@@ -40,7 +40,7 @@ class DerivesA : A {
 }
 
 struct S {
-  convenience init(int i: Int) { // expected-error{{delegating initializers in structs are not marked with 'convenience'}}
+  convenience init(int i: Int) { // expected-error{{initializers in structs are not marked with 'convenience'}}
     self.init(double: Double(i))
   }  
 

--- a/test/decl/init/basic_init.swift
+++ b/test/decl/init/basic_init.swift
@@ -44,7 +44,7 @@ extension InitStruct {
 struct MyStruct {
   init(k: Int) {
   }
-  convenience init() {  // expected-error {{delegating initializers in structs are not marked with 'convenience'}} {{3-15=}}
+  convenience init() {  // expected-error {{initializers in structs are not marked with 'convenience'}} {{3-15=}}
     self.init(k: 1)
   }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
```
struct Foo {
    let code: String

    convenience init(someCode: String) {    // error: delegating initializers in structs are not marked with 'convenience' 
        self.init(code: someCode)
    }

    init(code: String) {
        self.code = code
    }
}
```

Updating the above error message to `  initializers in structs are not marked with 'convenience'  `

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
* https://bugs.swift.org/browse/SR-14135
* There is already a fix it to remove the word `convenience`
https://github.com/apple/swift/blob/7a15b7a453ef218e17478a39879f3bc83d7e4e53/lib/Sema/TypeCheckDecl.cpp#L410

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
