### PR TITLE
Disable IDE/import_as_member.swift on the tv simulator

### DIFF
--- a/test/IDE/import_as_member.swift
+++ b/test/IDE/import_as_member.swift
@@ -9,6 +9,9 @@
 
 // RUN: %target-typecheck-verify-swift -I %S/Inputs/custom-modules
 
+// rdar://77558075
+// UNSUPPORTED: OS=tvos && CPU=x86_64
+
 // PRINT: struct Struct1 {
 // PRINT-NEXT:   var x: Double
 // PRINT-NEXT:   var y: Double


### PR DESCRIPTION
It fails on the bots.
rdar://77558075