### PR TITLE
[Concurrency] Define and use the SwiftStdlib 5.5 availability macro in tests

### DIFF
--- a/test/Concurrency/Runtime/actor_counters.swift
+++ b/test/Concurrency/Runtime/actor_counters.swift
@@ -8,7 +8,7 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor Counter {
   private var value = 0
   private let scratchBuffer: UnsafeMutableBufferPointer<Int>
@@ -31,7 +31,7 @@ actor Counter {
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   for i in 0..<numIterations {
     let counterIndex = Int.random(in: 0 ..< counters.count)
@@ -41,7 +41,7 @@ func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   // Create counter actors.
   var counters: [Counter] = []
@@ -68,7 +68,7 @@ func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   print("DONE!")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     // Useful for debugging: specify counter/worker/iteration counts

--- a/test/Concurrency/Runtime/async.swift
+++ b/test/Concurrency/Runtime/async.swift
@@ -19,7 +19,7 @@ import StdlibUnittest
 
 var asyncTests = TestSuite("Async")
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor MyActor {
   func synchronous() { }
 
@@ -31,7 +31,7 @@ actor MyActor {
   }
 }
 
-if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+if #available(SwiftStdlib 5.5, *) {
   let actor = MyActor()
 
   asyncTests.test("Detach") {

--- a/test/Concurrency/Runtime/async_initializer.swift
+++ b/test/Concurrency/Runtime/async_initializer.swift
@@ -8,7 +8,7 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor NameGenerator {
   private var counter = 0
   private var prefix : String
@@ -19,13 +19,13 @@ actor NameGenerator {
    }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 protocol Person {
   init() async
   var name : String { get set }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 class EarthPerson : Person {
   private static let oracle = NameGenerator("Earthling")
 
@@ -40,7 +40,7 @@ class EarthPerson : Person {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 class NorthAmericaPerson : EarthPerson {
   private static let oracle = NameGenerator("NorthAmerican")
   required init() async {
@@ -53,7 +53,7 @@ class NorthAmericaPerson : EarthPerson {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 class PrecariousClass {
   init?(nilIt : Int) async {
     let _ : Optional<Int> = await (detach { nil }).get()
@@ -87,7 +87,7 @@ enum Something : Error {
   case bogus
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct PrecariousStruct {
   init?(nilIt : Int) async {
     let _ : Optional<Int> = await (detach { nil }).get()
@@ -122,7 +122,7 @@ struct PrecariousStruct {
 // CHECK-NEXT: struct threw
 // CHECK: done
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct RunIt {
   static func main() async {
     let people : [Person] = [

--- a/test/Concurrency/Runtime/async_let_fibonacci.swift
+++ b/test/Concurrency/Runtime/async_let_fibonacci.swift
@@ -19,7 +19,7 @@ func fib(_ n: Int) -> Int {
   return first
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncFib(_ n: Int) async -> Int {
   if n == 0 || n == 1 {
     return n
@@ -39,7 +39,7 @@ func asyncFib(_ n: Int) async -> Int {
   return result
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func runFibonacci(_ n: Int) async {
   let result = await asyncFib(n)
 
@@ -48,7 +48,7 @@ func runFibonacci(_ n: Int) async {
   assert(result == fib(n))
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await runFibonacci(10)

--- a/test/Concurrency/Runtime/async_let_throws.swift
+++ b/test/Concurrency/Runtime/async_let_throws.swift
@@ -14,7 +14,7 @@ func boom() throws -> Int {
   throw Boom()
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test() async {
   async let result = boom()
 
@@ -25,7 +25,7 @@ func test() async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test()

--- a/test/Concurrency/Runtime/async_sequence.swift
+++ b/test/Concurrency/Runtime/async_sequence.swift
@@ -14,27 +14,27 @@ import StdlibUnittest
 // Utility functions for closure based operators to force them into throwing
 // and async and throwing async contexts.
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func throwing<T>(_ value: T) throws -> T {
   return value
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asynchronous<T>(_ value: T) async -> T {
   return value
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asynchronousThrowing<T>(_ value: T) async throws -> T {
   return value
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct Failure: Error, Equatable {
   var value = 1
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func failable<T, E: Error>(
   _ results: [Result<T, E>]
 ) -> AsyncThrowingMapSequence<AsyncLazySequence<[Result<T, E>]>, T> {
@@ -42,7 +42,7 @@ func failable<T, E: Error>(
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Sequence {
   @inlinable
   public var async: AsyncLazySequence<Self> {
@@ -52,7 +52,7 @@ extension Sequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public struct AsyncLazySequence<S: Sequence>: AsyncSequence {
   public typealias Element = S.Element
   public typealias AsyncIterator = Iterator
@@ -85,7 +85,7 @@ public struct AsyncLazySequence<S: Sequence>: AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence {
   @inlinable
   public func collect() async rethrows -> [Element] {
@@ -98,7 +98,7 @@ extension AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence where Element: Equatable {
   func `throw`(_ error: Error, on element: Element) -> AsyncThrowingMapSequence<Self, Element> {
     return map { (value: Element) throws -> Element in
@@ -110,7 +110,7 @@ extension AsyncSequence where Element: Equatable {
 
 @main struct Main {
   static func main() async {
-    if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    if #available(SwiftStdlib 5.5, *) {
 
     var AsyncLazySequenceTests = TestSuite("AsyncLazySequence")
 

--- a/test/Concurrency/Runtime/async_task_async_let_child_cancel.swift
+++ b/test/Concurrency/Runtime/async_task_async_let_child_cancel.swift
@@ -7,7 +7,7 @@
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: use_os_stdlib
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func printWaitPrint(_ int: Int) async -> Int {
   print("start, cancelled:\(Task.isCancelled), id:\(int)")
   while !Task.isCancelled {
@@ -17,7 +17,7 @@ func printWaitPrint(_ int: Int) async -> Int {
   return int
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test() async {
   let h = detach {
     await printWaitPrint(0)
@@ -68,7 +68,7 @@ func test() async {
   print("exit")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test()

--- a/test/Concurrency/Runtime/async_task_cancellation_early.swift
+++ b/test/Concurrency/Runtime/async_task_cancellation_early.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_detach_cancel_child_early() async {
   print(#function) // CHECK: test_detach_cancel_child_early
   let h: Task.Handle<Bool, Error> = detach {
@@ -35,7 +35,7 @@ func test_detach_cancel_child_early() async {
   print("was cancelled: \(got)") // CHECK: was cancelled: true
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_detach_cancel_child_early()

--- a/test/Concurrency/Runtime/async_task_cancellation_while_running.swift
+++ b/test/Concurrency/Runtime/async_task_cancellation_while_running.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_detach_cancel_while_child_running() async {
   let h: Task.Handle<Bool, Error> = detach {
     async let childCancelled: Bool = { () -> Bool in
@@ -34,7 +34,7 @@ func test_detach_cancel_while_child_running() async {
   print("was cancelled: \(got)") // CHECK: was cancelled: true
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_detach_cancel_while_child_running()

--- a/test/Concurrency/Runtime/async_task_detach.swift
+++ b/test/Concurrency/Runtime/async_task_detach.swift
@@ -21,7 +21,7 @@ class X {
 
 struct Boom: Error {}
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_detach() async {
   let x = X()
   let h = detach {
@@ -33,7 +33,7 @@ func test_detach() async {
   // CHECK: X: deinit
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_detach_throw() async {
   let x = X()
   let h = detach {
@@ -51,7 +51,7 @@ func test_detach_throw() async {
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_detach()

--- a/test/Concurrency/Runtime/async_task_handle_cancellation.swift
+++ b/test/Concurrency/Runtime/async_task_handle_cancellation.swift
@@ -14,7 +14,7 @@
 //
 // UNSUPPORTED: OS=windows-msvc
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     let handle = detach {

--- a/test/Concurrency/Runtime/async_task_locals_basic.swift
+++ b/test/Concurrency/Runtime/async_task_locals_basic.swift
@@ -17,7 +17,7 @@ final class StringLike: Sendable, CustomStringConvertible {
   var description: String { value }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 enum TL {
 
   @TaskLocal
@@ -33,7 +33,7 @@ enum TL {
   static var clazz: ClassTaskLocal?
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 final class ClassTaskLocal: Sendable {
   init() {
     print("clazz init \(ObjectIdentifier(self))")
@@ -44,7 +44,7 @@ final class ClassTaskLocal: Sendable {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
@@ -62,7 +62,7 @@ func printTaskLocal<V>(
 
 // ==== ------------------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func simple() async {
   printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (0)
   await TL.$number.withValue(1) {
@@ -70,7 +70,7 @@ func simple() async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func simple_deinit() async {
   await TL.$clazz.withValue(ClassTaskLocal()) {
     // CHECK: clazz init [[C:.*]]
@@ -83,7 +83,7 @@ func simple_deinit() async {
 struct Boom: Error {
   let value: String
 }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func simple_throw() async {
   do {
     try await TL.$clazz.withValue(ClassTaskLocal()) {
@@ -95,7 +95,7 @@ func simple_throw() async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func nested() async {
   printTaskLocal(TL.$string) // CHECK: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
   await TL.$string.withValue("hello") {
@@ -112,7 +112,7 @@ func nested() async {
   printTaskLocal(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func nested_allContribute() async {
   printTaskLocal(TL.$string) // CHECK: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
   await TL.$string.withValue("one") {
@@ -129,7 +129,7 @@ func nested_allContribute() async {
   printTaskLocal(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func nested_3_onlyTopContributes() async {
   printTaskLocal(TL.$string) // CHECK: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
   await TL.$string.withValue("one") {
@@ -146,7 +146,7 @@ func nested_3_onlyTopContributes() async {
   printTaskLocal(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func withLocal_body_mustNotEscape() async {
   var something = "Nice"
   await TL.$string.withValue("xxx") {
@@ -155,7 +155,7 @@ func withLocal_body_mustNotEscape() async {
   _ = something // silence not used warning
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await simple()

--- a/test/Concurrency/Runtime/async_task_locals_groups.swift
+++ b/test/Concurrency/Runtime/async_task_locals_groups.swift
@@ -8,13 +8,13 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 enum TL {
   @TaskLocal
   static var number = 0
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
@@ -32,7 +32,7 @@ func printTaskLocal<V>(
 
 // ==== ------------------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func groups() async {
   // no value
   _ = await withTaskGroup(of: Int.self) { group in
@@ -78,7 +78,7 @@ func groups() async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await groups()

--- a/test/Concurrency/Runtime/async_task_locals_prevent_illegal_use.swift
+++ b/test/Concurrency/Runtime/async_task_locals_prevent_illegal_use.swift
@@ -11,7 +11,7 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 enum TL {
   @TaskLocal
   static var number: Int = 2
@@ -19,7 +19,7 @@ enum TL {
 
 // ==== ------------------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func bindAroundGroupSpawn() async {
   await TL.$number.withValue(1111) { // ok
     await withTaskGroup(of: Int.self) { group in
@@ -37,7 +37,7 @@ func bindAroundGroupSpawn() async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await bindAroundGroupSpawn()

--- a/test/Concurrency/Runtime/async_task_locals_spawn_let.swift
+++ b/test/Concurrency/Runtime/async_task_locals_spawn_let.swift
@@ -8,13 +8,13 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 enum TL {
   @TaskLocal
   static var number: Int = 0
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
@@ -32,7 +32,7 @@ func printTaskLocal<V>(
 
 // ==== ------------------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func async_let_nested() async {
   printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (0)
   async let x1: () = TL.$number.withValue(2) {
@@ -54,7 +54,7 @@ func async_let_nested() async {
   printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (0)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func async_let_nested_skip_optimization() async {
   async let x1: Int? = TL.$number.withValue(2) {
     async let x2: Int? = { () async -> Int? in
@@ -77,7 +77,7 @@ func async_let_nested_skip_optimization() async {
   _ = await x1
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await async_let_nested()

--- a/test/Concurrency/Runtime/async_task_locals_synchronous_bind.swift
+++ b/test/Concurrency/Runtime/async_task_locals_synchronous_bind.swift
@@ -8,13 +8,13 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 enum TL {
   @TaskLocal
   static var number: Int = 0
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
@@ -32,7 +32,7 @@ func printTaskLocal<V>(
 
 // ==== ------------------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func synchronous_bind() async {
 
   func synchronous() {
@@ -58,7 +58,7 @@ func synchronous_bind() async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await synchronous_bind()

--- a/test/Concurrency/Runtime/async_task_locals_wrapper.swift
+++ b/test/Concurrency/Runtime/async_task_locals_wrapper.swift
@@ -8,13 +8,13 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 enum TL {
   @TaskLocal
   static var number: Int = 0
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
@@ -32,7 +32,7 @@ func printTaskLocal<V>(
 
 // ==== ------------------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func async_let_nested() async {
   print("TL: \(TL.$number)")
   
@@ -56,7 +56,7 @@ func async_let_nested() async {
   printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (0)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func async_let_nested_skip_optimization() async {
   async let x1: Int? = TL.$number.withValue(2) {
     async let x2: Int? = { () async -> Int? in
@@ -79,7 +79,7 @@ func async_let_nested_skip_optimization() async {
   _ = await x1
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await async_let_nested()

--- a/test/Concurrency/Runtime/async_task_priority_current.swift
+++ b/test/Concurrency/Runtime/async_task_priority_current.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_detach() async {
   let a1 = Task.currentPriority
   print("a1: \(a1)") // CHECK: a1: unspecified
@@ -27,7 +27,7 @@ func test_detach() async {
   print("a3: \(a3)") // CHECK: a3: unspecified
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_multiple_lo_indirectly_escalated() async {
   @Sendable
   func loopUntil(priority: Task.Priority) async {
@@ -59,7 +59,7 @@ func test_multiple_lo_indirectly_escalated() async {
   print("default done") // CHECK: default done
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_detach()

--- a/test/Concurrency/Runtime/async_task_sleep.swift
+++ b/test/Concurrency/Runtime/async_task_sleep.swift
@@ -11,7 +11,7 @@ import _Concurrency
 // FIXME: should not depend on Dispatch
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static let pause = 500_000_000 // 500ms
   

--- a/test/Concurrency/Runtime/async_task_yield.swift
+++ b/test/Concurrency/Runtime/async_task_yield.swift
@@ -8,12 +8,12 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 protocol Go: Actor {
   func go(times: Int) async -> Int
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Go {
   func go(times: Int) async -> Int {
     for i in 0...times {
@@ -24,12 +24,12 @@ extension Go {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor One: Go {}
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor Two: Go {}
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func yielding() async {
   let one = One()
   let two = Two()
@@ -43,7 +43,7 @@ func yielding() async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await yielding()

--- a/test/Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift
@@ -12,7 +12,7 @@ func boom() async throws -> Int {
   throw Boom()
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_next() async {
   let sum = await withThrowingTaskGroup(of: Int.self, returning: Int.self) { group in
     for n in 1...10 {
@@ -43,7 +43,7 @@ func test_taskGroup_next() async {
   print("result with group.next(): \(sum)")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_for_in() async {
   let sum = await withThrowingTaskGroup(of: Int.self, returning: Int.self) { group in
     for n in 1...10 {
@@ -74,7 +74,7 @@ func test_taskGroup_for_in() async {
   print("result with for-in: \(sum)")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_asyncIterator() async {
   let sum = await withThrowingTaskGroup(of: Int.self, returning: Int.self) { group in
     for n in 1...10 {
@@ -112,7 +112,7 @@ func test_taskGroup_asyncIterator() async {
   print("result with async iterator: \(sum)")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_contains() async {
   let sum = await withTaskGroup(of: Int.self, returning: Int.self) { group in
     for n in 1...4 {
@@ -144,7 +144,7 @@ func test_taskGroup_contains() async {
   print("result with async iterator: \(sum)")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_next()

--- a/test/Concurrency/Runtime/async_taskgroup_cancelAll_only_specific_group.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancelAll_only_specific_group.swift
@@ -10,14 +10,14 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncEcho(_ value: Int) async -> Int {
   value
 }
 
 /// Tests that only the specific group we cancelAll on is cancelled,
 /// and not accidentally all tasks in all groups within the given parent task.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_cancelAll_onlySpecificGroup() async {
   async let g1: Int = withTaskGroup(of: Int.self) { group in
 
@@ -79,7 +79,7 @@ func test_taskGroup_cancelAll_onlySpecificGroup() async {
 
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_cancelAll_onlySpecificGroup()

--- a/test/Concurrency/Runtime/async_taskgroup_cancel_from_inside_child.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancel_from_inside_child.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_cancel_from_inside_child() async {
   let one = try! await withTaskGroup(of: Int.self, returning: Int.self) { group in
     await group.next()
@@ -45,7 +45,7 @@ func test_taskGroup_cancel_from_inside_child() async {
 
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_cancel_from_inside_child()

--- a/test/Concurrency/Runtime/async_taskgroup_cancel_parent_affects_group.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancel_parent_affects_group.swift
@@ -10,12 +10,12 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncEcho(_ value: Int) async -> Int {
   value
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_cancel_parent_affects_group() async {
 
   let x = detach {
@@ -47,7 +47,7 @@ func test_taskGroup_cancel_parent_affects_group() async {
 
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_cancel_parent_affects_group()

--- a/test/Concurrency/Runtime/async_taskgroup_cancel_then_completions.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancel_then_completions.swift
@@ -10,14 +10,14 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncEcho(_ value: Int) async -> Int {
   value
 }
 
 // FIXME: this is a workaround since (A, B) today isn't inferred to be Sendable
 //        and causes an error, but should be a warning (this year at least)
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct SendableTuple2<A: Sendable, B: Sendable>: Sendable {
   let first: A
   let second: B
@@ -28,7 +28,7 @@ struct SendableTuple2<A: Sendable, B: Sendable>: Sendable {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_cancel_then_completions() async {
   // CHECK: test_taskGroup_cancel_then_completions
   print("before \(#function)")
@@ -73,7 +73,7 @@ func test_taskGroup_cancel_then_completions() async {
   print("result: \(result)") // CHECK: result: 3
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_cancel_then_completions()

--- a/test/Concurrency/Runtime/async_taskgroup_cancel_then_spawn.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancel_then_spawn.swift
@@ -10,12 +10,12 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncEcho(_ value: Int) async -> Int {
   value
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_cancel_then_add() async {
   // CHECK: test_taskGroup_cancel_then_add
   print("\(#function)")
@@ -52,7 +52,7 @@ func test_taskGroup_cancel_then_add() async {
 
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_cancel_then_add()

--- a/test/Concurrency/Runtime/async_taskgroup_is_asyncsequence.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_is_asyncsequence.swift
@@ -10,7 +10,7 @@
 // UNSUPPORTED: linux
 // XFAIL: windows
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_is_asyncSequence() async {
   print(#function)
 
@@ -34,7 +34,7 @@ func test_taskGroup_is_asyncSequence() async {
   print("result: \(sum)")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_throwingTaskGroup_is_asyncSequence() async throws {
   print(#function)
 
@@ -58,7 +58,7 @@ func test_throwingTaskGroup_is_asyncSequence() async throws {
   print("result: \(sum)")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_is_asyncSequence()

--- a/test/Concurrency/Runtime/async_taskgroup_is_empty.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_is_empty.swift
@@ -10,12 +10,12 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncEcho(_ value: Int) async -> Int {
   value
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_isEmpty() async {
   print("before all")
   let result = await withTaskGroup(of: Int.self, returning: Int.self) { group in
@@ -44,7 +44,7 @@ func test_taskGroup_isEmpty() async {
   print("result: \(result)")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_isEmpty()

--- a/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_cancelAll.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_cancelAll.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_skipCallingNext_butInvokeCancelAll() async {
   let numbers = [1, 1]
 
@@ -47,7 +47,7 @@ func test_skipCallingNext_butInvokeCancelAll() async {
   assert(result == 0)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_skipCallingNext_butInvokeCancelAll()

--- a/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_without_cancelAll.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_without_cancelAll.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_skipCallingNext() async {
   let numbers = [1, 1]
 
@@ -43,7 +43,7 @@ func test_skipCallingNext() async {
   assert(result == 0)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_skipCallingNext()

--- a/test/Concurrency/Runtime/async_taskgroup_next_on_completed.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_on_completed.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_sum_nextOnCompleted() async {
   let numbers = [1, 2, 3, 4, 5]
   let expected = 15 // FIXME: numbers.reduce(0, +) this hangs?
@@ -66,7 +66,7 @@ func test_sum_nextOnCompleted() async {
   print("result: \(sum)")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_sum_nextOnCompleted()

--- a/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
@@ -12,15 +12,15 @@
 struct Boom: Error {}
 struct IgnoredBoom: Error {}
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func one() async -> Int { 1 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func boom() async throws -> Int {
   throw Boom()
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_throws() async {
   let got: Int = try await withThrowingTaskGroup(of: Int.self) { group in
     group.spawn { try await boom()  }
@@ -63,7 +63,7 @@ func test_taskGroup_throws() async {
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_throws()

--- a/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
@@ -12,12 +12,12 @@
 struct Boom: Error {}
 struct IgnoredBoom: Error {}
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func echo(_ i: Int) async -> Int { i }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func boom() async throws -> Int { throw Boom() }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_throws_rethrows() async {
   do {
     let got = try await withThrowingTaskGroup(of: Int.self, returning: Int.self) { group in
@@ -47,7 +47,7 @@ func test_taskGroup_throws_rethrows() async {
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_throws_rethrows()

--- a/test/Concurrency/Runtime/basic_future.swift
+++ b/test/Concurrency/Runtime/basic_future.swift
@@ -14,12 +14,12 @@ enum HomeworkError: Error, Equatable {
   case dogAteIt(String)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func formGreeting(name: String) async -> String {
   return "Hello \(name) from async world"
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func testSimple(
   name: String, dogName: String, shouldThrow: Bool, doSuspend: Bool
 ) async {
@@ -72,7 +72,7 @@ func testSimple(
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await testSimple(name: "Ted", dogName: "Hazel", shouldThrow: false, doSuspend: false)

--- a/test/Concurrency/Runtime/cancellation_handler.swift
+++ b/test/Concurrency/Runtime/cancellation_handler.swift
@@ -20,7 +20,7 @@ class Canary {
   }
 }
 
-if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+if #available(SwiftStdlib 5.5, *) {
   let task = detach {
     let canary = Canary()
     _ = await Task.withCancellationHandler {

--- a/test/Concurrency/Runtime/checked_continuation.swift
+++ b/test/Concurrency/Runtime/checked_continuation.swift
@@ -16,7 +16,7 @@ struct TestError: Error {}
   static func main() async {
     var tests = TestSuite("CheckedContinuation")
 
-    if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    if #available(SwiftStdlib 5.5, *) {
       tests.test("trap on double resume non-throwing continuation") {
         expectCrashLater()
 

--- a/test/Concurrency/Runtime/custom_executors.swift
+++ b/test/Concurrency/Runtime/custom_executors.swift
@@ -19,7 +19,7 @@ actor Custom {
   var count = 0
   nonisolated let simple = Simple()
 
-  @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+  @available(SwiftStdlib 5.5, *)
   nonisolated var unownedExecutor: UnownedSerialExecutor {
     print("custom unownedExecutor")
     return simple.unownedExecutor
@@ -33,7 +33,7 @@ actor Custom {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     print("begin")

--- a/test/Concurrency/Runtime/effectful_properties.swift
+++ b/test/Concurrency/Runtime/effectful_properties.swift
@@ -20,7 +20,7 @@ enum BallKind {
   case KirksandLignature
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 class Specs {
   // obtains the number of dimples
   subscript(_ bk : BallKind) -> Int {
@@ -37,7 +37,7 @@ class Specs {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor Database {
   var currentData : Specs {
     get async {
@@ -52,21 +52,21 @@ actor Database {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 protocol SphericalObject {
   var name : String { get async throws }
   var dimples : Int { get async throws }
   var description : String { get async throws }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 class Ball : SphericalObject {
   var name : String { get async throws { throw GeneralError.Todo } }
   var dimples : Int { get async throws { throw GeneralError.Todo } }
   var description : String { get async throws { throw GeneralError.Todo } }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 class GolfBall : Ball {
   private static let db : Database = Database()
 
@@ -110,17 +110,17 @@ class GolfBall : Ball {
 // CHECK: obtaining specs...
 // CHECK: this golf ball has 0 dimples
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func printAsBall(_ b : Ball) async {
   print(try! await b.description)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func printAsAsSphericalObject(_ b : SphericalObject) async {
   print(try! await b.description)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct RunIt {
   static func main() async {
     let balls : [(Bool, Ball)] = [

--- a/test/Concurrency/Runtime/executor_deinit2.swift
+++ b/test/Concurrency/Runtime/executor_deinit2.swift
@@ -11,7 +11,7 @@
 // this needs to match with the check count below.
 let NUM_TASKS : Int = 100
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 final class Capture : Sendable {
     func doSomething() { }
     deinit {
@@ -20,7 +20,7 @@ final class Capture : Sendable {
     }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main
 struct App {
     static func main() async {

--- a/test/Concurrency/Runtime/executor_deinit3.swift
+++ b/test/Concurrency/Runtime/executor_deinit3.swift
@@ -15,7 +15,7 @@
     import Glibc
 #endif
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 class Runner {
     func run() async {
         while !Task.isCancelled {
@@ -24,7 +24,7 @@ class Runner {
     }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor Container {
     var generation = 0
     var runners = [Int : Task.Handle<Void, Never>]()
@@ -66,7 +66,7 @@ actor Container {
 // FIXME: this doesn't work until we have https://github.com/apple/swift/pull/36298
 // COM: deinit Container with {{[0-9]+}} runners
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct RunIt {
     static func startTest() async {
         let c = Container()
@@ -75,7 +75,7 @@ actor Container {
         await c.cancelAll()
     }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 static func main() async {
         print("starting")
         await RunIt.startTest()

--- a/test/Concurrency/Runtime/future_fibonacci.swift
+++ b/test/Concurrency/Runtime/future_fibonacci.swift
@@ -21,7 +21,7 @@ func fib(_ n: Int) -> Int {
     return first
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncFib(_ n: Int) async -> Int {
   if n == 0 || n == 1 {
     return n
@@ -46,7 +46,7 @@ func asyncFib(_ n: Int) async -> Int {
   return result
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func runFibonacci(_ n: Int) async {
   var result = await asyncFib(n)
 
@@ -55,7 +55,7 @@ func runFibonacci(_ n: Int) async {
   assert(result == fib(n))
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await runFibonacci(15)

--- a/test/Concurrency/Runtime/yielding_continuation.swift
+++ b/test/Concurrency/Runtime/yielding_continuation.swift
@@ -24,7 +24,7 @@ func forceBeingAsync() async -> Void { }
 @main struct Main {
 
 static func main() async {
-    if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    if #available(SwiftStdlib 5.5, *) {
       tests.test("yield with no awaiting next") {
         let task = detach {
           let continuation = YieldingContinuation(yielding: String.self)

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -22,7 +22,7 @@ struct Point {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor TestActor {
   // expected-note@+1{{mutation of this property is only permitted within the actor}}
   var position = Point(x: 0, y: 0)
@@ -37,15 +37,15 @@ actor TestActor {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func modifyAsynchronously(_ foo: inout Int) async { foo += 1 }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 enum Container {
   static let modifyAsyncValue = modifyAsynchronously
 }
 
 // external function call
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension TestActor {
 
   // Can't pass actor-isolated primitive into a function
@@ -82,7 +82,7 @@ extension TestActor {
 }
 
 // internal method call
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension TestActor {
   func modifyByValue(_ other: inout Int) async {
     other += value1
@@ -95,7 +95,7 @@ extension TestActor {
 }
 
 // external class method call
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 class NonAsyncClass {
   func modifyOtherAsync(_ other : inout Int) async {
     // ...
@@ -107,7 +107,7 @@ class NonAsyncClass {
 }
 
 // Calling external class/struct async function
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension TestActor {
   // Can't pass state into async method of another class
 
@@ -136,12 +136,12 @@ extension TestActor {
 }
 
 // Check implicit async testing
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor DifferentActor {
   func modify(_ state: inout Int) {}
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension TestActor {
   func modify(_ state: inout Int) {}
 
@@ -160,7 +160,7 @@ extension TestActor {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor MyActor {
   var points: [Point] = []
   var int: Int = 0
@@ -194,7 +194,7 @@ actor MyActor {
 
 // Verify global actor protection
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @globalActor
 struct MyGlobalActor {
   static let shared = TestActor()
@@ -207,34 +207,34 @@ struct MyGlobalActor {
 
 // expected-error@+3{{actor-isolated var 'number' cannot be passed 'inout' to 'async' function call}}
 // expected-error@+2{{var 'number' isolated to global actor 'MyGlobalActor' can not be used 'inout' from a non-isolated context}}
-if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+if #available(SwiftStdlib 5.5, *) {
 let _ = detach { await { (_ foo: inout Int) async in foo += 1 }(&number) }
 }
 
 // attempt to pass global state owned by the global actor to another async function
 // expected-error@+2{{actor-isolated var 'number' cannot be passed 'inout' to 'async' function call}}
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @MyGlobalActor func sneaky() async { await modifyAsynchronously(&number) }
 
 // It's okay to pass actor state inout to synchronous functions!
 
 func globalSyncFunction(_ foo: inout Int) { }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @MyGlobalActor func globalActorSyncFunction(_ foo: inout Int) { }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @MyGlobalActor func globalActorAsyncOkay() async { globalActorSyncFunction(&number) }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @MyGlobalActor func globalActorAsyncOkay2() async { globalSyncFunction(&number) }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @MyGlobalActor func globalActorSyncOkay() { globalSyncFunction(&number) }
 
 // Gently unwrap things that are fine
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct Cat {
   mutating func meow() async { }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct Dog {
   var cat: Cat?
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -4,29 +4,29 @@
 let immutableGlobal: String = "hello"
 var mutableGlobal: String = "can't touch this" // expected-note 5{{var declared here}}
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func globalFunc() { }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func acceptClosure<T>(_: () -> T) { }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func acceptConcurrentClosure<T>(_: @Sendable () -> T) { }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func acceptEscapingClosure<T>(_: @escaping () -> T) { }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func acceptEscapingClosure<T>(_: @escaping (String) -> ()) async -> T? { nil }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @discardableResult func acceptAsyncClosure<T>(_: () async -> T) -> T { }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func acceptEscapingAsyncClosure<T>(_: @escaping () async -> T) { }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func acceptInout<T>(_: inout T) {}
 
 
 // ----------------------------------------------------------------------
 // Actor state isolation restrictions
 // ----------------------------------------------------------------------
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor MySuperActor {
   var superState: Int = 25 // expected-note {{mutation of this property is only permitted within the actor}}
 
@@ -47,7 +47,7 @@ class Point {
   var y : Int = 0
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor MyActor: MySuperActor { // expected-error{{actor types do not support inheritance}}
   nonisolated let immutable: Int = 17
   // expected-note@+2 2{{property declared here}}
@@ -78,14 +78,14 @@ actor MyActor: MySuperActor { // expected-error{{actor types do not support inhe
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor Camera {
   func accessProp(act : MyActor) async -> String {
     return await act.name
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func checkAsyncPropertyAccess() async {
   let act = MyActor()
   let _ : Int = await act.mutable + act.mutable
@@ -111,7 +111,7 @@ func checkAsyncPropertyAccess() async {
   _ = await act.otherPoint // expected-warning{{cannot use property 'otherPoint' with a non-sendable type 'Point' across actors}}
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension MyActor {
   nonisolated var actorIndependentVar: Int {
     get { 5 }
@@ -323,35 +323,35 @@ extension MyActor {
 // ----------------------------------------------------------------------
 // Global actor isolation restrictions
 // ----------------------------------------------------------------------
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor SomeActor { }
 
 @globalActor
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct SomeGlobalActor {
   static let shared = SomeActor()
 }
 
 @globalActor
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct SomeOtherGlobalActor {
   static let shared = SomeActor()
 }
 
 @globalActor
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct GenericGlobalActor<T> {
   static var shared: SomeActor { SomeActor() }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @SomeGlobalActor func onions() {} // expected-note{{calls to global function 'onions()' from outside of its actor context are implicitly asynchronous}}
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @MainActor func beets() { onions() } // expected-error{{call to global actor 'SomeGlobalActor'-isolated global function 'onions()' in a synchronous main actor-isolated context}}
 // expected-note@-1{{calls to global function 'beets()' from outside of its actor context are implicitly asynchronous}}
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor Crystal {
   // expected-note@+2 {{property declared here}}
   // expected-note@+1 2 {{mutation of this property is only permitted within the actor}}
@@ -380,31 +380,31 @@ actor Crystal {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @SomeGlobalActor func syncGlobalActorFunc() { syncGlobalActorFunc() } // expected-note {{calls to global function 'syncGlobalActorFunc()' from outside of its actor context are implicitly asynchronous}}
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @SomeGlobalActor func asyncGlobalActorFunc() async { await asyncGlobalActorFunc() }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @SomeOtherGlobalActor func syncOtherGlobalActorFunc() { }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @SomeOtherGlobalActor func asyncOtherGlobalActorFunc() async {
   await syncGlobalActorFunc()
   await asyncGlobalActorFunc()
 }
 
 // test global actor funcs that are marked asyncHandler
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @SomeGlobalActor func goo1() async {
   let _ = goo2
   // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{3-3=await }}
   goo2() // expected-note{{call is 'async'}}
 }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @asyncHandler @SomeOtherGlobalActor func goo2() { await goo1() }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func testGlobalActorClosures() {
   let _: Int = acceptAsyncClosure { @SomeGlobalActor in
     syncGlobalActorFunc()
@@ -418,7 +418,7 @@ func testGlobalActorClosures() {
   acceptConcurrentClosure { @SomeGlobalActor in 5 } // expected-error{{converting function value of type '@SomeGlobalActor @Sendable () -> Int' to '@Sendable () -> Int' loses global actor 'SomeGlobalActor'}}
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension MyActor {
   @SomeGlobalActor func onGlobalActor(otherActor: MyActor) async {
     // Access to other functions in this actor are okay.
@@ -482,7 +482,7 @@ extension MyActor {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct GenericStruct<T> {
   @GenericGlobalActor<T> func f() { } // expected-note {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
 
@@ -497,7 +497,7 @@ struct GenericStruct<T> {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension GenericStruct where T == String {
   @GenericGlobalActor<T>
   func h2() {
@@ -516,7 +516,7 @@ func badNumberUser() {
   print("The protected number is: \(number)")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncBadNumberUser() async {
   print("The protected number is: \(await number)")
 }
@@ -524,7 +524,7 @@ func asyncBadNumberUser() async {
 // ----------------------------------------------------------------------
 // Non-actor code isolation restrictions
 // ----------------------------------------------------------------------
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func testGlobalRestrictions(actor: MyActor) async {
   let _ = MyActor()
 
@@ -584,7 +584,7 @@ func testGlobalRestrictions(actor: MyActor) async {
 
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func f() {
   acceptConcurrentClosure {
     _ = mutableGlobal // expected-warning{{reference to var 'mutableGlobal' is not concurrency-safe because it involves shared mutable state}}
@@ -598,7 +598,7 @@ func f() {
 // ----------------------------------------------------------------------
 // Local function isolation restrictions
 // ----------------------------------------------------------------------
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func checkLocalFunctions() async {
   var i = 0
   var j = 0
@@ -647,7 +647,7 @@ func checkLocalFunctions() async {
 // Lazy properties with initializers referencing 'self'
 // ----------------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor LazyActor {
     var v: Int = 0
     // expected-note@-1 6 {{property declared here}}
@@ -685,7 +685,7 @@ actor LazyActor {
 }
 
 // Infer global actors from context only for instance members.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @MainActor
 class SomeClassInActor {
   enum ID: String { case best }
@@ -693,7 +693,7 @@ class SomeClassInActor {
   func inActor() { } // expected-note{{calls to instance method 'inActor()' from outside of its actor context are implicitly asynchronous}}
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension SomeClassInActor.ID {
   func f(_ object: SomeClassInActor) { // expected-note{{add '@MainActor' to make instance method 'f' part of global actor 'MainActor'}}
     object.inActor() // expected-error{{call to main actor-isolated instance method 'inActor()' in a synchronous nonisolated context}}
@@ -703,7 +703,7 @@ extension SomeClassInActor.ID {
 // ----------------------------------------------------------------------
 // Initializers
 // ----------------------------------------------------------------------
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor SomeActorWithInits {
   var mutableState: Int = 17
   var otherMutableState: Int
@@ -718,7 +718,7 @@ actor SomeActorWithInits {
   func isolated() { }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @MainActor
 class SomeClassWithInits {
   var mutableState: Int = 17
@@ -758,7 +758,7 @@ class SomeClassWithInits {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func outsideSomeClassWithInits() { // expected-note 3 {{add '@MainActor' to make global function 'outsideSomeClassWithInits()' part of global actor 'MainActor'}}
   _ = SomeClassWithInits() // expected-error{{call to main actor-isolated initializer 'init()' in a synchronous nonisolated context}}
   _ = SomeClassWithInits.shared // expected-error{{static property 'shared' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
@@ -768,24 +768,24 @@ func outsideSomeClassWithInits() { // expected-note 3 {{add '@MainActor' to make
 // ----------------------------------------------------------------------
 // Actor protocols.
 // ----------------------------------------------------------------------
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 protocol P: Actor {
   func f()
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension P {
   func g() { f() }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor MyActorP: P {
   func f() { }
 
   func h() { g() }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func testCrossActorProtocol<T: P>(t: T) async {
   await t.f()
   await t.g()
@@ -803,7 +803,7 @@ func testCrossActorProtocol<T: P>(t: T) async {
 func acceptAsyncSendableClosure<T>(_: @Sendable () async -> T) { }
 func acceptAsyncSendableClosureInheriting<T>(@_inheritActorContext _: @Sendable () async -> T) { }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension MyActor {
   func testSendableAndInheriting() {
     acceptAsyncSendableClosure {

--- a/test/Concurrency/async_cancellation.swift
+++ b/test/Concurrency/async_cancellation.swift
@@ -6,12 +6,12 @@ enum PictureData {
   case failedToLoadImagePlaceholder
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_cancellation_checkCancellation() async throws {
   try Task.checkCancellation()
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_cancellation_guard_isCancelled(_ any: Any) async -> PictureData {
   guard !Task.isCancelled else {
     return PictureData.failedToLoadImagePlaceholder
@@ -20,12 +20,12 @@ func test_cancellation_guard_isCancelled(_ any: Any) async -> PictureData {
   return PictureData.value("...")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct SomeFile: Sendable {
   func close() {}
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_cancellation_withTaskCancellationHandler(_ anything: Any) async -> PictureData {
   let handle: Task.Handle<PictureData, Error> = detach {
     let file = SomeFile()
@@ -39,7 +39,7 @@ func test_cancellation_withTaskCancellationHandler(_ anything: Any) async -> Pic
   handle.cancel()
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_cancellation_loop() async -> Int {
   struct SampleTask { func process() async {} }
 

--- a/test/Concurrency/async_sequence_syntax.swift
+++ b/test/Concurrency/async_sequence_syntax.swift
@@ -2,36 +2,36 @@
 // REQUIRES: concurrency
 
 // expected-note@+2{{add 'async' to function 'missingAsync' to make it asynchronous}}
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func missingAsync<T : AsyncSequence>(_ seq: T) throws { 
   for try await _ in seq { } // expected-error{{'async' in a function that does not support concurrency}}
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func missingThrows<T : AsyncSequence>(_ seq: T) async {
   for try await _ in seq { } // expected-error{{error is not handled because the enclosing function is not declared 'throws'}}
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func executeAsync(_ work: () async -> Void) { }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func execute(_ work: () -> Void) { }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func missingThrowingInBlock<T : AsyncSequence>(_ seq: T) { 
   executeAsync { // expected-error{{invalid conversion from throwing function of type '() async throws -> Void' to non-throwing function type '() async -> Void'}}
     for try await _ in seq { }
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func missingTryInBlock<T : AsyncSequence>(_ seq: T) { 
   executeAsync { 
     for await _ in seq { } // expected-error{{call can throw, but the error is not handled}}
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func missingAsyncInBlock<T : AsyncSequence>(_ seq: T) { 
   execute { // expected-error{{cannot pass function of type '() async -> Void' to parameter expecting synchronous function type}}
     do { 
@@ -40,7 +40,7 @@ func missingAsyncInBlock<T : AsyncSequence>(_ seq: T) {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func doubleDiagCheckGeneric<T : AsyncSequence>(_ seq: T) async {
   var it = seq.makeAsyncIterator()
   // expected-note@+2{{call is to 'rethrows' function, but a conformance has a throwing witness}}
@@ -48,7 +48,7 @@ func doubleDiagCheckGeneric<T : AsyncSequence>(_ seq: T) async {
   let _ = await it.next()
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct ThrowingAsyncSequence: AsyncSequence, AsyncIteratorProtocol {
   typealias Element = Int
   typealias AsyncIterator = Self
@@ -59,7 +59,7 @@ struct ThrowingAsyncSequence: AsyncSequence, AsyncIteratorProtocol {
   func makeAsyncIterator() -> Self { return self }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func doubleDiagCheckConcrete(_ seq: ThrowingAsyncSequence) async {
   var it = seq.makeAsyncIterator()
   // expected-error@+1{{call can throw, but it is not marked with 'try' and the error is not handled}}
@@ -67,7 +67,7 @@ func doubleDiagCheckConcrete(_ seq: ThrowingAsyncSequence) async {
 }
 
 // rdar://75274975
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func forAwaitInsideDoCatch<Source: AsyncSequence>(_ source: Source) async {
   do {
     for try await item in source {
@@ -76,7 +76,7 @@ func forAwaitInsideDoCatch<Source: AsyncSequence>(_ source: Source) async {
   } catch {} // no-warning
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func forAwaitWithConcreteType(_ seq: ThrowingAsyncSequence) throws { // expected-note {{add 'async' to function 'forAwaitWithConcreteType' to make it asynchronous}}
   for try await elt in seq { // expected-error {{'async' in a function that does not support concurrency}}
     _ = elt

--- a/test/Concurrency/async_task_groups.swift
+++ b/test/Concurrency/async_task_groups.swift
@@ -4,11 +4,11 @@
 // REQUIRES: concurrency
 // REQUIRES: libdispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncFunc() async -> Int { 42 }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncThrowsFunc() async throws -> Int { 42 }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncThrowsOnCancel() async throws -> Int {
   // terrible suspend-spin-loop -- do not do this
   // only for purposes of demonstration
@@ -19,7 +19,7 @@ func asyncThrowsOnCancel() async throws -> Int {
   throw Task.CancellationError()
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_add() async throws -> Int {
   try await withThrowingTaskGroup(of: Int.self) { group in
     group.spawn {
@@ -42,12 +42,12 @@ func test_taskGroup_add() async throws -> Int {
 // MARK: Example group Usages
 
 struct Boom: Error {}
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func work() async -> Int { 42 }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func boom() async throws -> Int { throw Boom() }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func first_allMustSucceed() async throws {
 
   let first: Int = try await withThrowingTaskGroup(of: Int.self) { group in
@@ -66,7 +66,7 @@ func first_allMustSucceed() async throws {
   // Expected: re-thrown Boom
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func first_ignoreFailures() async throws {
   @Sendable func work() async -> Int { 42 }
   @Sendable func boom() async throws -> Int { throw Boom() }
@@ -100,7 +100,7 @@ func first_ignoreFailures() async throws {
 // ==== ------------------------------------------------------------------------
 // MARK: Advanced Custom Task Group Usage
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_quorum_thenCancel() async {
   // imitates a typical "gather quorum" routine that is typical in distributed systems programming
   enum Vote {
@@ -156,7 +156,7 @@ func test_taskGroup_quorum_thenCancel() async {
 
 // FIXME: this is a workaround since (A, B) today isn't inferred to be Sendable
 //        and causes an error, but should be a warning (this year at least)
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct SendableTuple2<A: Sendable, B: Sendable>: Sendable {
   let first: A
   let second: B
@@ -167,7 +167,7 @@ struct SendableTuple2<A: Sendable, B: Sendable>: Sendable {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Collection where Self: Sendable, Element: Sendable, Self.Index: Sendable {
 
   /// Just another example of how one might use task groups.

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -1,11 +1,11 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
 // REQUIRES: concurrency
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func someAsyncFunc() async -> String { "" }
 
 struct MyError: Error {}
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func someThrowingAsyncFunc() async throws -> String { throw MyError() }
 
 // ==== Unsafe Continuations ---------------------------------------------------
@@ -27,7 +27,7 @@ func buyVegetables(
 ) {}
 
 // returns 1 or more vegetables or throws an error
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func buyVegetables(shoppingList: [String]) async throws -> [Vegetable] {
   try await withUnsafeThrowingContinuation { continuation in
     var veggies: [Vegetable] = []
@@ -43,7 +43,7 @@ func buyVegetables(shoppingList: [String]) async throws -> [Vegetable] {
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_unsafeContinuations() async {
   // the closure should not allow async operations;
   // after all: if you have async code, just call it directly, without the unsafe continuation
@@ -64,7 +64,7 @@ func test_unsafeContinuations() async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_unsafeThrowingContinuations() async throws {
   let _: String = try await withUnsafeThrowingContinuation { continuation in
     continuation.resume(returning: "")
@@ -89,7 +89,7 @@ func test_unsafeThrowingContinuations() async throws {
 
 // ==== Detached Tasks ---------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_detached() async throws {
   let handle = detach() {
     await someAsyncFunc() // able to call async functions
@@ -99,7 +99,7 @@ func test_detached() async throws {
   _ = result
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_detached_throwing() async -> String {
   let handle: Task.Handle<String, Error> = detach() {
     try await someThrowingAsyncFunc() // able to call async functions

--- a/test/Concurrency/concurrency_module_shadowing.swift
+++ b/test/Concurrency/concurrency_module_shadowing.swift
@@ -6,10 +6,10 @@
 
 import ShadowsConcur
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func f(_ t : Task) -> Bool {
   return t.someProperty == "123"
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func g(_: _Concurrency.Task) {}

--- a/test/Concurrency/task_local.swift
+++ b/test/Concurrency/task_local.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
 // REQUIRES: concurrency
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct TL {
   @TaskLocal
   static var number: Int = 0
@@ -22,7 +22,7 @@ var global: Int = 0
 
 class NotSendable {}
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test () async {
   TL.number = 10 // expected-error{{cannot assign to property: 'number' is a get-only property}}
   TL.$number = 10 // expected-error{{cannot assign value of type 'Int' to type 'TaskLocal<Int>'}}

--- a/test/Concurrency/throwing.swift
+++ b/test/Concurrency/throwing.swift
@@ -28,14 +28,14 @@ protocol MP { }
 
 class M : MP {
 
-  @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+  @available(SwiftStdlib 5.5, *)
   func throwWithIndirectResult<T>(_ a: P<T>) async throws -> T {
     throw E.err
   }
 }
 
 extension MP {
-  @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+  @available(SwiftStdlib 5.5, *)
   func l<A, B, C, D, E2, F> (_ a : P<A>, _ b: P<B>, _ c: P<C>, _ d : P<D>, _ e: P<E2>, _ f: P<F>) async throws -> (A, B, C, D, E2, F) {
     throw E.err
   }
@@ -45,7 +45,7 @@ extension MP {
   static func main() async {
     var tests = TestSuite("Async Throw")
 
-    if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    if #available(SwiftStdlib 5.5, *) {
       tests.test("throwing of naturally direct but indirect reabstration") {
         let task2 = detach {
           let m = M()

--- a/test/DebugInfo/async-boxed-arg.swift
+++ b/test/DebugInfo/async-boxed-arg.swift
@@ -2,7 +2,7 @@
 // RUN:    -module-name M -enable-experimental-concurrency | %FileCheck %s --dump-input always
 // REQUIRES: concurrency
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Collection where Element: Sendable {
   public func f() async throws {
     return try await withThrowingTaskGroup(of: Element.self) { group in

--- a/test/ModuleInterface/Inputs/MeowActor.swift
+++ b/test/ModuleInterface/Inputs/MeowActor.swift
@@ -1,4 +1,4 @@
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @globalActor public final class MeowActor {
   public static let shared = _Impl()
   

--- a/test/ModuleInterface/actor_protocol.swift
+++ b/test/ModuleInterface/actor_protocol.swift
@@ -12,46 +12,46 @@
 // CHECK-EXTENSION-NOT: extension {{.+}} : _Concurrency.Actor
 
 // CHECK: public actor PlainActorClass {
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public actor PlainActorClass {
   @actorIndependent public func enqueue(_ job: UnownedJob) { }
 }
 
 // CHECK: public actor ExplicitActorClass : _Concurrency.Actor {
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public actor ExplicitActorClass : Actor {
   @actorIndependent public func enqueue(_ job: UnownedJob) { }
 }
 
 // CHECK: public actor EmptyActor {
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public actor EmptyActor {}
 
 // CHECK: actor public class EmptyActorClass {
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public actor class EmptyActorClass {}
 
 // CHECK: public protocol Cat : _Concurrency.Actor {
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public protocol Cat : Actor {
   func mew()
 }
 
 // CHECK: public actor HouseCat : Library.Cat {
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public actor HouseCat : Cat {
   @asyncHandler public func mew() {}
   @actorIndependent public func enqueue(_ job: UnownedJob) { }
 }
 
 // CHECK: public protocol ToothyMouth {
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public protocol ToothyMouth {
   func chew()
 }
 
 // CHECK: public actor Lion : Library.ToothyMouth, _Concurrency.Actor {
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public actor Lion : ToothyMouth, Actor {
   @asyncHandler public func chew() {}
   @actorIndependent public func enqueue(_ job: UnownedJob) { }

--- a/test/ModuleInterface/global-actor.swift
+++ b/test/ModuleInterface/global-actor.swift
@@ -3,7 +3,7 @@
 
 import MeowActor
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @MeowActor func doMeow() {}
 
 // RUN: %target-swift-frontend -enable-experimental-concurrency -enable-library-evolution -emit-module -o %t/MeowActor.swiftmodule %S/Inputs/MeowActor.swift
@@ -14,7 +14,7 @@ import MeowActor
 // RUN: %target-swift-frontend -enable-experimental-concurrency -emit-silgen %s -I %t | %FileCheck --check-prefix CHECK-FRAGILE %s
 // CHECK-FRAGILE: metatype $@thin MeowActor.Type
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func someFunc() async {
   await doMeow()
 }

--- a/test/Sanitizers/tsan/actor_counters.swift
+++ b/test/Sanitizers/tsan/actor_counters.swift
@@ -14,7 +14,7 @@ import Darwin
 import Glibc
 #endif
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor Counter {
   private var value = 0
   private let scratchBuffer: UnsafeMutableBufferPointer<Int>
@@ -43,7 +43,7 @@ actor Counter {
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   for i in 0..<numIterations {
     let counterIndex = Int.random(in: 0 ..< counters.count)
@@ -53,7 +53,7 @@ func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   // Create counter actors.
   var counters: [Counter] = []
@@ -80,7 +80,7 @@ func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   print("DONE!")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     // Useful for debugging: specify counter/worker/iteration counts

--- a/test/Sanitizers/tsan/async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/async_let_fibonacci.swift
@@ -14,7 +14,7 @@ import Darwin
 import Glibc
 #endif
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func fib(_ n: Int) -> Int {
   var first = 0
   var second = 1
@@ -26,7 +26,7 @@ func fib(_ n: Int) -> Int {
   return first
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncFib(_ n: Int) async -> Int {
   if n == 0 || n == 1 {
     return n
@@ -46,7 +46,7 @@ func asyncFib(_ n: Int) async -> Int {
   return result
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func runFibonacci(_ n: Int) async {
   let result = await asyncFib(n)
 
@@ -55,7 +55,7 @@ func runFibonacci(_ n: Int) async {
   assert(result == fib(n))
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await runFibonacci(10)

--- a/test/Sanitizers/tsan/async_taskgroup_next.swift
+++ b/test/Sanitizers/tsan/async_taskgroup_next.swift
@@ -8,7 +8,7 @@
 
 var scratchBuffer: UnsafeMutableBufferPointer<Int> = .allocate(capacity: 1000)
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func completeFastOrSlow(n: Int) async -> Int {
   if n % 2 == 0 {
     await Task.sleep(2_000_000_000)
@@ -18,7 +18,7 @@ func completeFastOrSlow(n: Int) async -> Int {
   return n
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_sum_nextOnCompletedOrPending() async {
   scratchBuffer.initialize(repeating: 0)
 
@@ -54,7 +54,7 @@ func test_sum_nextOnCompletedOrPending() async {
   assert(sum == expected, "Expected: \(expected), got: \(sum)")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_sum_nextOnCompletedOrPending()

--- a/test/Sanitizers/tsan/basic_future.swift
+++ b/test/Sanitizers/tsan/basic_future.swift
@@ -18,12 +18,12 @@ enum HomeworkError: Error, Equatable {
   case dogAteIt(String)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func formGreeting(name: String) async -> String {
   return "Hello \(name) from async world"
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func testSimple(
   name: String, dogName: String, shouldThrow: Bool, doSuspend: Bool
 ) async {
@@ -76,7 +76,7 @@ func testSimple(
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await testSimple(name: "Ted", dogName: "Hazel", shouldThrow: false, doSuspend: false)

--- a/test/Sanitizers/tsan/racy_actor_counters.swift
+++ b/test/Sanitizers/tsan/racy_actor_counters.swift
@@ -17,7 +17,7 @@
 
 var globalCounterValue = 0
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor Counter {
   func next() -> Int {
     let current = globalCounterValue
@@ -26,7 +26,7 @@ actor Counter {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   for _ in 0..<numIterations {
     let counterIndex = Int.random(in: 0 ..< counters.count)
@@ -36,7 +36,7 @@ func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   // Create counter actors.
   var counters: [Counter] = []
@@ -62,7 +62,7 @@ func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   print("DONE!")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     // Useful for debugging: specify counter/worker/iteration counts

--- a/test/Syntax/round_trip_concurrency.swift
+++ b/test/Syntax/round_trip_concurrency.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %round-trip-syntax-test --swift-syntax-test %swift-syntax-test --file %s
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor Counter {
   private var value = 0
   private let scratchBuffer: UnsafeMutableBufferPointer<Int>
@@ -24,7 +24,7 @@ actor Counter {
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   for i in 0..<numIterations {
     let counterIndex = Int.random(in: 0 ..< counters.count)
@@ -34,7 +34,7 @@ func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   // Create counter actors.
   var counters: [Counter] = []
@@ -61,7 +61,7 @@ func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   print("DONE!")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     // Useful for debugging: specify counter/worker/iteration counts

--- a/test/decl/protocol/special/Actor.swift
+++ b/test/decl/protocol/special/Actor.swift
@@ -3,30 +3,30 @@
 
 // Synthesis of for actores.
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor A1 {
   var x: Int = 17
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor A2: Actor {
   var x: Int = 17
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor A3<T>: Actor {
   var x: Int = 17
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor A4: A1 { // expected-error{{actor types do not support inheritance}}
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor A5: A2 { // expected-error{{actor types do not support inheritance}}
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor A6: A1, Actor { // expected-error{{redundant conformance of 'A6' to protocol 'Actor'}}
   // expected-note@-1{{'A6' inherits conformance to protocol 'Actor' from superclass here}}
   // expected-error@-2{{actor types do not support inheritance}}
@@ -34,21 +34,21 @@ actor A6: A1, Actor { // expected-error{{redundant conformance of 'A6' to protoc
 
 // Explicitly satisfying the requirement.
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor A7 {
   // Okay: satisfy the requirement explicitly
   nonisolated func enqueue(_ job: UnownedJob) { }
 }
 
 // A non-actor can conform to the Actor protocol, if it does it properly.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 class C1: Actor { // expected-error{{non-final class 'C1' cannot conform to `Sendable`; use `UnsafeSendable`}}
   nonisolated var unownedExecutor: UnownedSerialExecutor {
     fatalError("")
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 class C2: Actor { // expected-error{{non-final class 'C2' cannot conform to `Sendable`; use `UnsafeSendable`}}
   // FIXME: this should be an isolation violation
   var unownedExecutor: UnownedSerialExecutor {
@@ -56,16 +56,16 @@ class C2: Actor { // expected-error{{non-final class 'C2' cannot conform to `Sen
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 class C3: Actor { // expected-error{{non-final class 'C3' cannot conform to `Sendable`; use `UnsafeSendable`}} expected-error {{type 'C3' does not conform to protocol 'Actor'}}
   nonisolated func enqueue(_ job: UnownedJob) { }
 }
 
 // Make sure the conformances actually happen.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func acceptActor<T: Actor>(_: T.Type) { }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func testConformance() {
   acceptActor(A1.self)
   acceptActor(A2.self)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -399,6 +399,12 @@ swift_version = lit_config.params.get('swift-version',
 lit_config.note('Compiling with -swift-version ' + swift_version)
 config.swift_test_options = '-swift-version ' + swift_version
 
+# Define a macro for the next release OS version.
+# This macro can be used in code as `@available(SwiftStdlib 5.5, *)`.
+swift_stdlib_macro = '\'SwiftStdlib 5.5:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999\''
+config.swift_frontend_test_options += ' -define-availability ' + swift_stdlib_macro
+config.swift_driver_test_options += ' -Xfrontend -define-availability -Xfrontend ' + swift_stdlib_macro
+
 differentiable_programming = lit_config.params.get('differentiable_programming', None)
 if differentiable_programming is not None:
     config.available_features.add('differentiable_programming')

--- a/test/stdlib/Concurrency.swift
+++ b/test/stdlib/Concurrency.swift
@@ -6,9 +6,9 @@ import _Concurrency
 
 // Make sure the type shows up (including under its old name, for
 // short-term source compatibility)
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension PartialAsyncTask {
 }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension UnownedJob {
 }

--- a/test/stmt/errors_async.swift
+++ b/test/stmt/errors_async.swift
@@ -6,7 +6,7 @@ enum MyError : Error {
   case bad
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func shouldThrow() async {
   // expected-error@+1 {{errors thrown from here are not handled}}
   let _: Int = try await withUnsafeThrowingContinuation { continuation in


### PR DESCRIPTION
Follow up to #37244.