### PR TITLE
Disable Concurrency/Runtime/checked_continuation.swift on windows

### DIFF
--- a/test/Concurrency/Runtime/checked_continuation.swift
+++ b/test/Concurrency/Runtime/checked_continuation.swift
@@ -5,6 +5,8 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
+// UNSUPPORTED: OS=windows-msvc
+
 import _Concurrency
 import StdlibUnittest
 


### PR DESCRIPTION
It seems to fail sometimes.