### PR TITLE
[5.5][Sema] Suppress concurrency related diagnostics for invalid AST nodes

### DIFF
--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -2620,9 +2620,10 @@ private:
 
   void checkThrowAsyncSite(ASTNode E, bool requiresTry,
                            const Classification &classification) {
-    // Suppress all diagnostics when there's an un-analyzable throw site.
+    // Suppress all diagnostics when there's an un-analyzable throw/async site.
     if (classification.isInvalid()) {
       Flags.set(ContextFlags::HasAnyThrowSite);
+      Flags.set(ContextFlags::HasAnyAsyncSite);
       if (requiresTry) Flags.set(ContextFlags::HasTryThrowSite);
       return;
     }

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -184,9 +184,6 @@ actor MyActor {
     // expected-error@+1{{actor-isolated property 'int' cannot be passed 'inout' to 'async' function call}}
     await modifyAsynchronously(&(int))
 
-    // This warning is emitted because this fails to typecheck before the
-    // async-ness is attached.
-    // expected-warning@+2{{no 'async' operations occur within 'await' expression}}
     // expected-error@+1{{cannot pass immutable value of type 'Int' as inout argument}}
     await modifyAsynchronously(&(maybePoint?.z)!)
     // expected-error@+2{{actor-isolated property 'position' can only be used 'inout' from inside the actor}}

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -55,6 +55,13 @@ func test_unsafeContinuations() async {
   let _: String = await withUnsafeContinuation { continuation in
     continuation.resume(returning: "")
   }
+
+  // rdar://76475495 - suppress warnings for invalid expressions
+  func test_invalid_async_no_warnings() async -> Int {
+	  return await withUnsafeContinuation {
+		  $0.resume(throwing: 1) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Never'}}
+	  }
+  }
 }
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)


### PR DESCRIPTION
- Explanation:

Expressions that failed type-check can't be correctly analyzed by
effects checker due to missing type and overload choice information,
so it's possible for it to produce incorrect diagnostics.

- Scope: Invalid expressions involving concurrency

- Resolves: rdar://76475495

- Risk: Very low

- Reviewed By: @etcwilde

- Testing: Regression tests added to the suite

Resolves: rdar://76475495
(cherry picked from commit 0e9c33e47fa8eb80bf784a19b6787f6b4a4cf0ab)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
