### PR TITLE
[5.5][Concurrency] Use SwiftStdlib 5.5 availability macro in Concurrency module and tests

### DIFF
--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -17,30 +17,30 @@ import Swift
 ///
 /// The \c Actor protocol generalizes over all actor types. Actor types
 /// implicitly conform to this protocol.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public protocol Actor: AnyObject, Sendable {
 }
 
 /// Called to initialize the default actor instance in an actor.
 /// The implementation will call this within the actor's initializer.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_defaultActor_initialize")
 public func _defaultActorInitialize(_ actor: AnyObject)
 
 /// Called to destroy the default actor instance in an actor.
 /// The implementation will call this within the actor's deinit.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_defaultActor_destroy")
 public func _defaultActorDestroy(_ actor: AnyObject)
 
 /// FIXME: only exists for the quick-and-dirty MainActor implementation.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_MainActor_register")
 fileprivate func _registerMainActor(actor: AnyObject)
 
 /// A singleton actor whose executor is equivalent to 
 /// \c DispatchQueue.main, which is the main dispatch queue.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @globalActor public actor MainActor {
   public static let shared = MainActor()
   
@@ -49,7 +49,7 @@ fileprivate func _registerMainActor(actor: AnyObject)
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension MainActor {
   /// Execute the given body closure on the main actor.
   public static func run<T>(

--- a/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func compactMap<ElementOfResult>(
@@ -22,7 +22,7 @@ extension AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public struct AsyncCompactMapSequence<Base: AsyncSequence, ElementOfResult> {
   @usableFromInline
   let base: Base
@@ -40,7 +40,7 @@ public struct AsyncCompactMapSequence<Base: AsyncSequence, ElementOfResult> {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncCompactMapSequence: AsyncSequence {
   public typealias Element = ElementOfResult
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncDropFirstSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropFirstSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func dropFirst(
@@ -24,7 +24,7 @@ extension AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public struct AsyncDropFirstSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -39,7 +39,7 @@ public struct AsyncDropFirstSequence<Base: AsyncSequence> {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncDropFirstSequence: AsyncSequence {
   public typealias Element = Base.Element
   public typealias AsyncIterator = Iterator
@@ -78,7 +78,7 @@ extension AsyncDropFirstSequence: AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncDropFirstSequence {
   @inlinable
   public __consuming func dropFirst(

--- a/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func drop(
@@ -22,7 +22,7 @@ extension AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public struct AsyncDropWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -40,7 +40,7 @@ public struct AsyncDropWhileSequence<Base: AsyncSequence> {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncDropWhileSequence: AsyncSequence {
   public typealias Element = Base.Element
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFilterSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func filter(
@@ -22,7 +22,7 @@ extension AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public struct AsyncFilterSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -40,7 +40,7 @@ public struct AsyncFilterSequence<Base: AsyncSequence> {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncFilterSequence: AsyncSequence {
   public typealias Element = Base.Element
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func flatMap<SegmentOfResult: AsyncSequence>(
@@ -22,7 +22,7 @@ extension AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public struct AsyncFlatMapSequence<Base: AsyncSequence, SegmentOfResult: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -40,7 +40,7 @@ public struct AsyncFlatMapSequence<Base: AsyncSequence, SegmentOfResult: AsyncSe
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncFlatMapSequence: AsyncSequence {
   public typealias Element = SegmentOfResult.Element
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncIteratorProtocol.swift
+++ b/stdlib/public/Concurrency/AsyncIteratorProtocol.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @rethrows
 public protocol AsyncIteratorProtocol {
   associatedtype Element

--- a/stdlib/public/Concurrency/AsyncMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncMapSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func map<Transformed>(
@@ -22,7 +22,7 @@ extension AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public struct AsyncMapSequence<Base: AsyncSequence, Transformed> {
   @usableFromInline
   let base: Base
@@ -40,7 +40,7 @@ public struct AsyncMapSequence<Base: AsyncSequence, Transformed> {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncMapSequence: AsyncSequence {
   public typealias Element = Transformed
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncPrefixSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func prefix(
@@ -24,7 +24,7 @@ extension AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public struct AsyncPrefixSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -39,7 +39,7 @@ public struct AsyncPrefixSequence<Base: AsyncSequence> {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncPrefixSequence: AsyncSequence {
   public typealias Element = Base.Element
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func prefix(
@@ -22,7 +22,7 @@ extension AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public struct AsyncPrefixWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -40,7 +40,7 @@ public struct AsyncPrefixWhileSequence<Base: AsyncSequence> {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncPrefixWhileSequence: AsyncSequence {
   public typealias Element = Base.Element
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncSequence.swift
+++ b/stdlib/public/Concurrency/AsyncSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @rethrows
 public protocol AsyncSequence {
   associatedtype AsyncIterator: AsyncIteratorProtocol where AsyncIterator.Element == Element
@@ -20,7 +20,7 @@ public protocol AsyncSequence {
   __consuming func makeAsyncIterator() -> AsyncIterator
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence {
   @inlinable
   public func reduce<Result>(
@@ -51,7 +51,7 @@ extension AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @inlinable
 @inline(__always)
 func _contains<Source: AsyncSequence>(
@@ -66,7 +66,7 @@ func _contains<Source: AsyncSequence>(
   return false
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence {
   @inlinable
   public func contains(
@@ -83,7 +83,7 @@ extension AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence where Element: Equatable {
   @inlinable
   public func contains(_ search: Element) async rethrows -> Bool {
@@ -96,7 +96,7 @@ extension AsyncSequence where Element: Equatable {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @inlinable
 @inline(__always)
 func _first<Source: AsyncSequence>(
@@ -111,7 +111,7 @@ func _first<Source: AsyncSequence>(
   return nil
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence {
   @inlinable
   public func first(
@@ -121,7 +121,7 @@ extension AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence {
   @inlinable
   @warn_unqualified_access
@@ -158,7 +158,7 @@ extension AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence where Element: Comparable {
   @inlinable
   @warn_unqualified_access

--- a/stdlib/public/Concurrency/AsyncThrowingCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingCompactMapSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func compactMap<ElementOfResult>(
@@ -22,7 +22,7 @@ extension AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public struct AsyncThrowingCompactMapSequence<Base: AsyncSequence, ElementOfResult> {
   @usableFromInline
   let base: Base
@@ -40,7 +40,7 @@ public struct AsyncThrowingCompactMapSequence<Base: AsyncSequence, ElementOfResu
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncThrowingCompactMapSequence: AsyncSequence {
   public typealias Element = ElementOfResult
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncThrowingDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingDropWhileSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func drop(
@@ -22,7 +22,7 @@ extension AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public struct AsyncThrowingDropWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -40,7 +40,7 @@ public struct AsyncThrowingDropWhileSequence<Base: AsyncSequence> {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncThrowingDropWhileSequence: AsyncSequence {
   public typealias Element = Base.Element
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncThrowingFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFilterSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func filter(
@@ -22,7 +22,7 @@ extension AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public struct AsyncThrowingFilterSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -40,7 +40,7 @@ public struct AsyncThrowingFilterSequence<Base: AsyncSequence> {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncThrowingFilterSequence: AsyncSequence {
   public typealias Element = Base.Element
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func flatMap<SegmentOfResult: AsyncSequence>(
@@ -22,7 +22,7 @@ extension AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public struct AsyncThrowingFlatMapSequence<Base: AsyncSequence, SegmentOfResult: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -40,7 +40,7 @@ public struct AsyncThrowingFlatMapSequence<Base: AsyncSequence, SegmentOfResult:
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncThrowingFlatMapSequence: AsyncSequence {
   public typealias Element = SegmentOfResult.Element
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func map<Transformed>(
@@ -22,7 +22,7 @@ extension AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public struct AsyncThrowingMapSequence<Base: AsyncSequence, Transformed> {
   @usableFromInline
   let base: Base
@@ -40,7 +40,7 @@ public struct AsyncThrowingMapSequence<Base: AsyncSequence, Transformed> {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncThrowingMapSequence: AsyncSequence {
   public typealias Element = Transformed
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func prefix(
@@ -22,7 +22,7 @@ extension AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public struct AsyncThrowingPrefixWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -40,7 +40,7 @@ public struct AsyncThrowingPrefixWhileSequence<Base: AsyncSequence> {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncThrowingPrefixWhileSequence: AsyncSequence {
   public typealias Element = Base.Element
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -87,6 +87,8 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -parse-stdlib
     -Xfrontend -enable-experimental-concurrency
+    -Xfrontend -define-availability
+    -Xfrontend \"SwiftStdlib 5.5:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999\"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   INSTALL_IN_COMPONENT stdlib
 )

--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -12,13 +12,13 @@
 
 import Swift
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_continuation_logFailedCheck")
 internal func logFailedCheck(_ message: UnsafeRawPointer)
 
 /// Implementation class that holds the `UnsafeContinuation` instance for
 /// a `CheckedContinuation`.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 internal final class CheckedContinuationCanary {
   // The instance state is stored in tail-allocated raw memory, so that
   // we can atomically check the continuation state.
@@ -109,7 +109,7 @@ internal final class CheckedContinuationCanary {
 /// of `withCheckedContinuation` or `withCheckedThrowingContinuation` should be
 /// enough to obtain the extra checking without further source modification in
 /// most circumstances.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public struct CheckedContinuation<T, E: Error> {
   private let canary: CheckedContinuationCanary
   
@@ -175,7 +175,7 @@ public struct CheckedContinuation<T, E: Error> {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension CheckedContinuation {
   /// Resume the task awaiting the continuation by having it either
   /// return normally or throw an error based on the state of the given
@@ -241,7 +241,7 @@ extension CheckedContinuation {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public func withCheckedContinuation<T>(
     function: String = #function,
     _ body: (CheckedContinuation<T, Never>) -> Void
@@ -251,7 +251,7 @@ public func withCheckedContinuation<T>(
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public func withCheckedThrowingContinuation<T>(
     function: String = #function,
     _ body: (CheckedContinuation<T, Error>) -> Void

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -15,7 +15,7 @@ import Swift
 // TODO: Custom Executors proposal will define these types
 //       https://forums.swift.org/t/support-custom-executors-in-swift-concurrency/44425/38
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @frozen
 public struct UnownedExecutorRef: Equatable {
   let identity: OpaquePointer
@@ -23,7 +23,7 @@ public struct UnownedExecutorRef: Equatable {
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_transparent
 public // COMPILER_INTRINSIC
 func _checkExpectedExecutor(Builtin

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -14,7 +14,7 @@ import Swift
 @_implementationOnly import _SwiftConcurrencyShims
 
 /// A partial task is a unit of scheduleable work.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @frozen
 public struct PartialAsyncTask {
   private var context: Builtin.Job
@@ -22,7 +22,7 @@ public struct PartialAsyncTask {
   public func run() { }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @frozen
 public struct UnsafeContinuation<T, E: Error> {
   @usableFromInline internal var context: Builtin.RawUnsafeContinuation
@@ -96,7 +96,7 @@ public struct UnsafeContinuation<T, E: Error> {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension UnsafeContinuation {
   /// Resume the task awaiting the continuation by having it either
   /// return normally or throw an error based on the state of the given
@@ -165,7 +165,7 @@ extension UnsafeContinuation {
 #if _runtime(_ObjC)
 
 // Intrinsics used by SILGen to resume or fail continuations.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_alwaysEmitIntoClient
 internal func _resumeUnsafeContinuation<T>(
   _ continuation: UnsafeContinuation<T, Never>,
@@ -174,7 +174,7 @@ internal func _resumeUnsafeContinuation<T>(
   continuation.resume(returning: value)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_alwaysEmitIntoClient
 internal func _resumeUnsafeThrowingContinuation<T>(
   _ continuation: UnsafeContinuation<T, Error>,
@@ -183,7 +183,7 @@ internal func _resumeUnsafeThrowingContinuation<T>(
   continuation.resume(returning: value)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_alwaysEmitIntoClient
 internal func _resumeUnsafeThrowingContinuationWithError<T>(
   _ continuation: UnsafeContinuation<T, Error>,
@@ -197,7 +197,7 @@ internal func _resumeUnsafeThrowingContinuationWithError<T>(
 /// The operation functions must resume the continuation *exactly once*.
 ///
 /// The continuation will not begin executing until the operation function returns.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_alwaysEmitIntoClient
 public func withUnsafeContinuation<T>(
   _ fn: (UnsafeContinuation<T, Never>) -> Void
@@ -210,7 +210,7 @@ public func withUnsafeContinuation<T>(
 /// The operation functions must resume the continuation *exactly once*.
 ///
 /// The continuation will not begin executing until the operation function returns.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_alwaysEmitIntoClient
 public func withUnsafeThrowingContinuation<T>(
   _ fn: (UnsafeContinuation<T, Error>) -> Void
@@ -220,6 +220,6 @@ public func withUnsafeThrowingContinuation<T>(
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @available(*, deprecated, message: "please use UnsafeContination<..., Error>")
 public typealias UnsafeThrowingContinuation<T> = UnsafeContinuation<T, Error>

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -31,7 +31,7 @@ import Swift
 /// These partial periods towards the task's completion are `PartialAsyncTask`.
 /// Partial tasks are generally not interacted with by end-users directly,
 /// unless implementing a scheduler.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public struct Task {
   internal let _task: Builtin.NativeObject
 
@@ -43,7 +43,7 @@ public struct Task {
 
 // ==== Current Task -----------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Task {
 
   /// Returns 'current' `Task` instance, representing the task from within which
@@ -68,7 +68,7 @@ extension Task {
 
 // ==== Task Priority ----------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Task {
 
   /// Returns the `current` task's priority.
@@ -151,7 +151,7 @@ extension Task {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Task.Priority {
   /// Downgrade user-interactive to user-initiated.
   var _downgradeUserInteractive: Task.Priority {
@@ -165,7 +165,7 @@ extension Task.Priority {
 
 // ==== Task Handle ------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Task {
   /// A task handle refers to an in-flight `Task`,
   /// allowing for potentially awaiting for its result or Cancelling it.
@@ -241,7 +241,7 @@ extension Task {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Task.Handle where Failure == Never {
 
   /// Wait for the task to complete, returning its result.
@@ -263,14 +263,14 @@ extension Task.Handle where Failure == Never {
   
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Task.Handle: Hashable {
   public func hash(into hasher: inout Hasher) {
     UnsafeRawPointer(Builtin.bridgeToRawPointer(_task)).hash(into: &hasher)
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Task.Handle: Equatable {
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     UnsafeRawPointer(Builtin.bridgeToRawPointer(lhs._task)) ==
@@ -280,14 +280,14 @@ extension Task.Handle: Equatable {
 
 // ==== Conformances -----------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Task: Hashable {
   public func hash(into hasher: inout Hasher) {
     UnsafeRawPointer(Builtin.bridgeToRawPointer(_task)).hash(into: &hasher)
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Task: Equatable {
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     UnsafeRawPointer(Builtin.bridgeToRawPointer(lhs._task)) ==
@@ -297,7 +297,7 @@ extension Task: Equatable {
 
 // ==== Job Flags --------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Task {
   /// Flags for schedulable jobs.
   ///
@@ -402,7 +402,7 @@ extension Task {
 
 // ==== Detached Tasks ---------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Task {
 
   @discardableResult
@@ -449,7 +449,7 @@ extension Task {
 ///     tasks result or `cancel` it. If the operation fails the handle will
 ///     throw the error the operation has thrown when awaited on.
 @discardableResult
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public func detach<T>(
   priority: Task.Priority = .unspecified,
   operation: __owned @Sendable @escaping () async -> T
@@ -502,7 +502,7 @@ public func detach<T>(
 ///     tasks result or `cancel` it. If the operation fails the handle will
 ///     throw the error the operation has thrown when awaited on.
 @discardableResult
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public func detach<T>(
   priority: Task.Priority = .unspecified,
   operation: __owned @Sendable @escaping () async throws -> T
@@ -523,7 +523,7 @@ public func detach<T>(
 }
 
 @discardableResult
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public func asyncDetached<T>(
   priority: Task.Priority? = nil,
   @_implicitSelfCapture operation: __owned @Sendable @escaping () async -> T
@@ -532,7 +532,7 @@ public func asyncDetached<T>(
 }
 
 @discardableResult
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public func asyncDetached<T>(
   priority: Task.Priority? = nil,
   @_implicitSelfCapture operation: __owned @Sendable @escaping () async throws -> T
@@ -541,7 +541,7 @@ public func asyncDetached<T>(
 }
 
 /// ABI stub while we stage in the new signatures
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @usableFromInline
 func async(
   priority: Task.Priority,
@@ -570,7 +570,7 @@ func async(
 ///   - priority: priority of the task. If nil, the priority will come from
 ///     Task.currentPriority.
 ///   - operation: the operation to execute
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @discardableResult
 public func async<T>(
   priority: Task.Priority? = nil,
@@ -606,7 +606,7 @@ public func async<T>(
 ///   - priority: priority of the task. If nil, the priority will come from
 ///     Task.currentPriority.
 ///   - operation: the operation to execute
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @discardableResult
 public func async<T>(
   priority: Task.Priority? = nil,
@@ -631,7 +631,7 @@ public func async<T>(
 // ==== Async Handler ----------------------------------------------------------
 
 // TODO: remove this?
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func _runAsyncHandler(operation: @escaping () async -> ()) {
   typealias ConcurrentFunctionType = @Sendable () async -> ()
   detach(
@@ -641,7 +641,7 @@ func _runAsyncHandler(operation: @escaping () async -> ()) {
 
 // ==== Async Sleep ------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Task {
   /// Suspends the current task for _at least_ the given duration
   /// in nanoseconds.
@@ -660,7 +660,7 @@ extension Task {
 
 // ==== Voluntary Suspension -----------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Task {
 
   /// Explicitly suspend the current task, potentially giving up execution actor
@@ -682,7 +682,7 @@ extension Task {
 
 // ==== UnsafeCurrentTask ------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Task {
 
   @available(*, deprecated, message: "`Task.unsafeCurrent` was replaced by `withUnsafeCurrentTask { task in ... }`, and will be removed soon.")
@@ -714,7 +714,7 @@ extension Task {
 /// It is possible to obtain a `Task` fom the `UnsafeCurrentTask` which is safe
 /// to access from other tasks or even store for future reference e.g. equality
 /// checks.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public func withUnsafeCurrentTask<T>(body: (UnsafeCurrentTask?) throws -> T) rethrows -> T {
   guard let _task = _getCurrentAsyncTask() else {
     return try body(nil)
@@ -741,7 +741,7 @@ public func withUnsafeCurrentTask<T>(body: (UnsafeCurrentTask?) throws -> T) ret
 /// represented by this handle itself. Doing so may result in undefined behavior,
 /// and most certainly will break invariants in other places of the program
 /// actively running on this task.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public struct UnsafeCurrentTask {
   internal let _task: Builtin.NativeObject
 
@@ -776,14 +776,14 @@ public struct UnsafeCurrentTask {
 
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension UnsafeCurrentTask: Hashable {
   public func hash(into hasher: inout Hasher) {
     UnsafeRawPointer(Builtin.bridgeToRawPointer(_task)).hash(into: &hasher)
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension UnsafeCurrentTask: Equatable {
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     UnsafeRawPointer(Builtin.bridgeToRawPointer(lhs._task)) ==
@@ -793,29 +793,29 @@ extension UnsafeCurrentTask: Equatable {
 
 // ==== Internal ---------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_getCurrent")
 func _getCurrentAsyncTask() -> Builtin.NativeObject?
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_getJobFlags")
 func getJobFlags(_ task: Builtin.NativeObject) -> Task.JobFlags
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_enqueueGlobal")
 @usableFromInline
 func _enqueueJobGlobal(_ task: Builtin.Job)
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_enqueueGlobalWithDelay")
 @usableFromInline
 func _enqueueJobGlobalWithDelay(_ delay: UInt64, _ task: Builtin.Job)
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_asyncMainDrainQueue")
 public func _asyncMainDrainQueue() -> Never
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public func _runAsyncMain(_ asyncFun: @escaping () async throws -> ()) {
 #if os(Windows)
   detach {
@@ -847,15 +847,15 @@ public func _runAsyncMain(_ asyncFun: @escaping () async throws -> ()) {
 // FIXME: both of these ought to take their arguments _owned so that
 // we can do a move out of the future in the common case where it's
 // unreferenced
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_future_wait")
 public func _taskFutureGet<T>(_ task: Builtin.NativeObject) async -> T
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_future_wait_throwing")
 public func _taskFutureGetThrowing<T>(_ task: Builtin.NativeObject) async throws -> T
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public func _runChildTask<T>(
   operation: @Sendable @escaping () async throws -> T
 ) async -> Builtin.NativeObject {
@@ -878,24 +878,24 @@ public func _runChildTask<T>(
   return task
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_cancel")
 func _taskCancel(_ task: Builtin.NativeObject)
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_isCancelled")
 func _taskIsCancelled(_ task: Builtin.NativeObject) -> Bool
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_createNullaryContinuationJob")
 func _taskCreateNullaryContinuationJob(priority: Int, continuation: Builtin.RawUnsafeContinuation) -> Builtin.Job
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @usableFromInline
 @_silgen_name("swift_task_isCurrentExecutor")
 func _taskIsCurrentExecutor(_ executor: Builtin.Executor) -> Bool
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @usableFromInline
 @_silgen_name("swift_task_reportUnexpectedExecutor")
 func _reportUnexpectedExecutor(_ _filenameStart: Builtin.RawPointer,
@@ -904,7 +904,7 @@ func _reportUnexpectedExecutor(_ _filenameStart: Builtin.RawPointer,
                                _ _line: Builtin.Word,
                                _ _executor: Builtin.Executor)
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_getCurrentThreadPriority")
 func _getCurrentThreadPriority() -> Int
 
@@ -912,7 +912,7 @@ func _getCurrentThreadPriority() -> Int
 
 /// Intrinsic used by SILGen to launch a task for bridging a Swift async method
 /// which was called through its ObjC-exported completion-handler-based API.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_alwaysEmitIntoClient
 @usableFromInline
 internal func _runTaskForBridgedAsyncMethod(_ body: @escaping () async -> Void) {

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -27,7 +27,7 @@ import Swift
 /// Does not check for cancellation, and always executes the passed `operation`.
 ///
 /// This function returns instantly and will never suspend.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public func withTaskCancellationHandler<T>(
   handler: @Sendable () -> (),
   operation: () async throws -> T
@@ -46,7 +46,7 @@ public func withTaskCancellationHandler<T>(
   return try await operation()
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Task {
 
   /// Returns `true` if the task is cancelled, and should stop executing.
@@ -107,11 +107,11 @@ extension Task {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_addCancellationHandler")
 func _taskAddCancellationHandler(handler: @Sendable () -> ()) -> UnsafeRawPointer /*CancellationNotificationStatusRecord*/
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_removeCancellationHandler")
 func _taskRemoveCancellationHandler(
   record: UnsafeRawPointer /*CancellationNotificationStatusRecord*/

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -15,7 +15,7 @@ import Swift
 
 // ==== TaskGroup --------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Task {
   @available(*, deprecated, message: "`Task.Group` was replaced by `ThrowingTaskGroup` and `TaskGroup` and will be removed shortly.")
   public typealias Group<TaskResult> = ThrowingTaskGroup<TaskResult, Error>
@@ -79,7 +79,7 @@ extension Task {
 /// - if the body returns normally:
 ///   - the group will await any not yet complete tasks,
 ///   - once the `withTaskGroup` returns the group is guaranteed to be empty.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @inlinable
 public func withTaskGroup<ChildTaskResult, GroupResult>(
   of childTaskResultType: ChildTaskResult.Type,
@@ -158,7 +158,7 @@ public func withTaskGroup<ChildTaskResult, GroupResult>(
 ///   - once the `withTaskGroup` returns the group is guaranteed to be empty.
 /// - if the body throws:
 ///   - all tasks remaining in the group will be automatically cancelled.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @inlinable
 public func withThrowingTaskGroup<ChildTaskResult, GroupResult>(
   of childTaskResultType: ChildTaskResult.Type,
@@ -195,7 +195,7 @@ public func withThrowingTaskGroup<ChildTaskResult, GroupResult>(
 /// A task group serves as storage for dynamically spawned tasks.
 ///
 /// It is created by the `withTaskGroup` function.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @frozen
 public struct TaskGroup<ChildTaskResult> {
 
@@ -471,7 +471,7 @@ public struct TaskGroup<ChildTaskResult> {
 /// child tasks.
 ///
 /// It is created by the `withTaskGroup` function.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @frozen
 public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
 
@@ -744,7 +744,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
 
 /// ==== TaskGroup: AsyncSequence ----------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension TaskGroup: AsyncSequence {
   public typealias AsyncIterator = Iterator
   public typealias Element = ChildTaskResult
@@ -763,7 +763,7 @@ extension TaskGroup: AsyncSequence {
   /// after any task completes by throwing an error.
   ///
   /// - SeeAlso: `TaskGroup.next()`
-  @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+  @available(SwiftStdlib 5.5, *)
   public struct Iterator: AsyncIteratorProtocol {
     public typealias Element = ChildTaskResult
 
@@ -797,7 +797,7 @@ extension TaskGroup: AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension ThrowingTaskGroup: AsyncSequence {
   public typealias AsyncIterator = Iterator
   public typealias Element = ChildTaskResult
@@ -817,7 +817,7 @@ extension ThrowingTaskGroup: AsyncSequence {
   /// throwing an error, no further task results are returned.
   ///
   /// - SeeAlso: `ThrowingTaskGroup.next()`
-  @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+  @available(SwiftStdlib 5.5, *)
   public struct Iterator: AsyncIteratorProtocol {
     public typealias Element = ChildTaskResult
 
@@ -857,43 +857,43 @@ extension ThrowingTaskGroup: AsyncSequence {
 /// ==== -----------------------------------------------------------------------
 
 /// Attach task group child to the group group to the task.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_taskGroup_attachChild")
 func _taskGroupAttachChild(
   group: Builtin.RawPointer,
   child: Builtin.NativeObject
 ) -> UnsafeRawPointer /*ChildTaskStatusRecord*/
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_taskGroup_destroy")
 func _taskGroupDestroy(group: __owned Builtin.RawPointer)
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_taskGroup_addPending")
 func _taskGroupAddPendingTask(
   group: Builtin.RawPointer,
   unconditionally: Bool
 ) -> Bool
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_taskGroup_cancelAll")
 func _taskGroupCancelAll(group: Builtin.RawPointer)
 
 /// Checks ONLY if the group was specifically cancelled.
 /// The task itself being cancelled must be checked separately.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_taskGroup_isCancelled")
 func _taskGroupIsCancelled(group: Builtin.RawPointer) -> Bool
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_taskGroup_wait_next_throwing")
 func _taskGroupWaitNext<T>(group: Builtin.RawPointer) async throws -> T?
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_hasTaskGroupStatusRecord")
 func _taskHasTaskGroupStatusRecord() -> Bool
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 enum PollStatus: Int {
   case empty   = 0
   case waiting = 1
@@ -901,7 +901,7 @@ enum PollStatus: Int {
   case error   = 3
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_taskGroup_isEmpty")
 func _taskGroupIsEmpty(
   _ group: Builtin.RawPointer

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -95,7 +95,7 @@ import Swift
 /// This type must be a `class` so it has a stable identity, that is used as key
 /// value for lookups in the task local storage.
 @propertyWrapper
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 // TODO: add Sendable enforcement when we're ready to do so rdar://77441933
 public final class TaskLocal<Value>: UnsafeSendable, CustomStringConvertible {
   let defaultValue: Value
@@ -199,7 +199,7 @@ public final class TaskLocal<Value>: UnsafeSendable, CustomStringConvertible {
 
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension UnsafeCurrentTask {
 
   /// Allows for executing a synchronous `operation` while binding a task-local value
@@ -225,7 +225,7 @@ extension UnsafeCurrentTask {
 
 // ==== ------------------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_localValuePush")
 public func _taskLocalValuePush<Value>(
   _ task: Builtin.NativeObject,
@@ -233,13 +233,13 @@ public func _taskLocalValuePush<Value>(
   value: __owned Value
 ) // where Key: TaskLocal
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_localValuePop")
 public func _taskLocalValuePop(
   _ task: Builtin.NativeObject
 )
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_localValueGet")
 public func _taskLocalValueGet(
   _ task: Builtin.NativeObject,
@@ -248,7 +248,7 @@ public func _taskLocalValueGet(
 
 // ==== Checks -----------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @usableFromInline
 func _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: String, line: UInt) {
   if _taskHasTaskGroupStatusRecord() {
@@ -259,7 +259,7 @@ func _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: String, line: UInt) 
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @usableFromInline
 @_silgen_name("swift_task_reportIllegalTaskLocalBindingWithinWithTaskGroup")
 func _reportIllegalTaskLocalBindingWithinWithTaskGroup(

--- a/stdlib/public/Concurrency/YieldingContinuation.swift
+++ b/stdlib/public/Concurrency/YieldingContinuation.swift
@@ -16,7 +16,7 @@ internal final class _YieldingContinuationStorage: UnsafeSendable {
   var continuation: Builtin.RawUnsafeContinuation?
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public struct YieldingContinuation<Element, Failure: Error>: Sendable {
   let storage = _YieldingContinuationStorage()
 
@@ -87,7 +87,7 @@ public struct YieldingContinuation<Element, Failure: Error>: Sendable {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension YieldingContinuation where Failure == Error {
   /// Await a resume from a call to a yielding function.
   ///
@@ -111,7 +111,7 @@ extension YieldingContinuation where Failure == Error {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension YieldingContinuation where Failure == Never {
   /// Construct a YieldingContinuation with a specific Element type.
   ///
@@ -135,7 +135,7 @@ extension YieldingContinuation where Failure == Never {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension YieldingContinuation {
   /// Resume the task awaiting the continuation by having it either
   /// return normally or throw an error based on the state of the given

--- a/test/Concurrency/Runtime/actor_counters.swift
+++ b/test/Concurrency/Runtime/actor_counters.swift
@@ -8,7 +8,7 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor Counter {
   private var value = 0
   private let scratchBuffer: UnsafeMutableBufferPointer<Int>
@@ -31,7 +31,7 @@ actor Counter {
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   for i in 0..<numIterations {
     let counterIndex = Int.random(in: 0 ..< counters.count)
@@ -41,7 +41,7 @@ func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   // Create counter actors.
   var counters: [Counter] = []
@@ -68,7 +68,7 @@ func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   print("DONE!")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     // Useful for debugging: specify counter/worker/iteration counts

--- a/test/Concurrency/Runtime/async.swift
+++ b/test/Concurrency/Runtime/async.swift
@@ -19,7 +19,7 @@ import StdlibUnittest
 
 var asyncTests = TestSuite("Async")
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor MyActor {
   func synchronous() { }
 
@@ -31,7 +31,7 @@ actor MyActor {
   }
 }
 
-if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+if #available(SwiftStdlib 5.5, *) {
   let actor = MyActor()
 
   asyncTests.test("Detach") {

--- a/test/Concurrency/Runtime/async_initializer.swift
+++ b/test/Concurrency/Runtime/async_initializer.swift
@@ -7,7 +7,7 @@
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor NameGenerator {
   private var counter = 0
   private var prefix : String
@@ -18,13 +18,13 @@ actor NameGenerator {
    }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 protocol Person {
   init() async
   var name : String { get set }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 class EarthPerson : Person {
   private static let oracle = NameGenerator("Earthling")
 
@@ -39,7 +39,7 @@ class EarthPerson : Person {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 class NorthAmericaPerson : EarthPerson {
   private static let oracle = NameGenerator("NorthAmerican")
   required init() async {
@@ -52,7 +52,7 @@ class NorthAmericaPerson : EarthPerson {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 class PrecariousClass {
   init?(nilIt : Int) async {
     let _ : Optional<Int> = await (detach { nil }).get()
@@ -86,7 +86,7 @@ enum Something : Error {
   case bogus
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct PrecariousStruct {
   init?(nilIt : Int) async {
     let _ : Optional<Int> = await (detach { nil }).get()
@@ -121,7 +121,7 @@ struct PrecariousStruct {
 // CHECK-NEXT: struct threw
 // CHECK: done
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct RunIt {
   static func main() async {
     let people : [Person] = [

--- a/test/Concurrency/Runtime/async_let_fibonacci.swift
+++ b/test/Concurrency/Runtime/async_let_fibonacci.swift
@@ -19,7 +19,7 @@ func fib(_ n: Int) -> Int {
   return first
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncFib(_ n: Int) async -> Int {
   if n == 0 || n == 1 {
     return n
@@ -39,7 +39,7 @@ func asyncFib(_ n: Int) async -> Int {
   return result
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func runFibonacci(_ n: Int) async {
   let result = await asyncFib(n)
 
@@ -48,7 +48,7 @@ func runFibonacci(_ n: Int) async {
   assert(result == fib(n))
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await runFibonacci(10)

--- a/test/Concurrency/Runtime/async_sequence.swift
+++ b/test/Concurrency/Runtime/async_sequence.swift
@@ -14,27 +14,27 @@ import StdlibUnittest
 // Utility functions for closure based operators to force them into throwing
 // and async and throwing async contexts.
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func throwing<T>(_ value: T) throws -> T {
   return value
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asynchronous<T>(_ value: T) async -> T {
   return value
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asynchronousThrowing<T>(_ value: T) async throws -> T {
   return value
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct Failure: Error, Equatable {
   var value = 1
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func failable<T, E: Error>(
   _ results: [Result<T, E>]
 ) -> AsyncThrowingMapSequence<AsyncLazySequence<[Result<T, E>]>, T> {
@@ -42,7 +42,7 @@ func failable<T, E: Error>(
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Sequence {
   @inlinable
   public var async: AsyncLazySequence<Self> {
@@ -52,7 +52,7 @@ extension Sequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public struct AsyncLazySequence<S: Sequence>: AsyncSequence {
   public typealias Element = S.Element
   public typealias AsyncIterator = Iterator
@@ -85,7 +85,7 @@ public struct AsyncLazySequence<S: Sequence>: AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence {
   @inlinable
   public func collect() async rethrows -> [Element] {
@@ -98,7 +98,7 @@ extension AsyncSequence {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension AsyncSequence where Element: Equatable {
   func `throw`(_ error: Error, on element: Element) -> AsyncThrowingMapSequence<Self, Element> {
     return map { (value: Element) throws -> Element in
@@ -110,7 +110,7 @@ extension AsyncSequence where Element: Equatable {
 
 @main struct Main {
   static func main() async {
-    if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    if #available(SwiftStdlib 5.5, *) {
 
     var AsyncLazySequenceTests = TestSuite("AsyncLazySequence")
 

--- a/test/Concurrency/Runtime/async_task_cancellation_early.swift
+++ b/test/Concurrency/Runtime/async_task_cancellation_early.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_detach_cancel_child_early() async {
   print(#function) // CHECK: test_detach_cancel_child_early
   let h: Task.Handle<Bool, Error> = detach {
@@ -35,7 +35,7 @@ func test_detach_cancel_child_early() async {
   print("was cancelled: \(got)") // CHECK: was cancelled: true
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_detach_cancel_child_early()

--- a/test/Concurrency/Runtime/async_task_cancellation_while_running.swift
+++ b/test/Concurrency/Runtime/async_task_cancellation_while_running.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_detach_cancel_while_child_running() async {
   let h: Task.Handle<Bool, Error> = detach {
     async let childCancelled: Bool = { () -> Bool in
@@ -34,7 +34,7 @@ func test_detach_cancel_while_child_running() async {
   print("was cancelled: \(got)") // CHECK: was cancelled: true
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_detach_cancel_while_child_running()

--- a/test/Concurrency/Runtime/async_task_detach.swift
+++ b/test/Concurrency/Runtime/async_task_detach.swift
@@ -21,7 +21,7 @@ class X {
 
 struct Boom: Error {}
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_detach() async {
   let x = X()
   let h = detach {
@@ -33,7 +33,7 @@ func test_detach() async {
   // CHECK: X: deinit
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_detach_throw() async {
   let x = X()
   let h = detach {
@@ -51,7 +51,7 @@ func test_detach_throw() async {
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_detach()

--- a/test/Concurrency/Runtime/async_task_handle_cancellation.swift
+++ b/test/Concurrency/Runtime/async_task_handle_cancellation.swift
@@ -14,7 +14,7 @@
 //
 // UNSUPPORTED: OS=windows-msvc
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     let handle = detach {

--- a/test/Concurrency/Runtime/async_task_locals_basic.swift
+++ b/test/Concurrency/Runtime/async_task_locals_basic.swift
@@ -17,7 +17,7 @@ final class StringLike: Sendable, CustomStringConvertible {
   var description: String { value }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 enum TL {
 
   @TaskLocal
@@ -33,7 +33,7 @@ enum TL {
   static var clazz: ClassTaskLocal?
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 final class ClassTaskLocal: Sendable {
   init() {
     print("clazz init \(ObjectIdentifier(self))")
@@ -44,7 +44,7 @@ final class ClassTaskLocal: Sendable {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
@@ -62,7 +62,7 @@ func printTaskLocal<V>(
 
 // ==== ------------------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func simple() async {
   printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (0)
   await TL.$number.withValue(1) {
@@ -70,7 +70,7 @@ func simple() async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func simple_deinit() async {
   await TL.$clazz.withValue(ClassTaskLocal()) {
     // CHECK: clazz init [[C:.*]]
@@ -83,7 +83,7 @@ func simple_deinit() async {
 struct Boom: Error {
   let value: String
 }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func simple_throw() async {
   do {
     try await TL.$clazz.withValue(ClassTaskLocal()) {
@@ -95,7 +95,7 @@ func simple_throw() async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func nested() async {
   printTaskLocal(TL.$string) // CHECK: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
   await TL.$string.withValue("hello") {
@@ -112,7 +112,7 @@ func nested() async {
   printTaskLocal(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func nested_allContribute() async {
   printTaskLocal(TL.$string) // CHECK: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
   await TL.$string.withValue("one") {
@@ -129,7 +129,7 @@ func nested_allContribute() async {
   printTaskLocal(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func nested_3_onlyTopContributes() async {
   printTaskLocal(TL.$string) // CHECK: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
   await TL.$string.withValue("one") {
@@ -146,7 +146,7 @@ func nested_3_onlyTopContributes() async {
   printTaskLocal(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func withLocal_body_mustNotEscape() async {
   var something = "Nice"
   await TL.$string.withValue("xxx") {
@@ -155,7 +155,7 @@ func withLocal_body_mustNotEscape() async {
   _ = something // silence not used warning
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await simple()

--- a/test/Concurrency/Runtime/async_task_locals_groups.swift
+++ b/test/Concurrency/Runtime/async_task_locals_groups.swift
@@ -8,13 +8,13 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 enum TL {
   @TaskLocal
   static var number = 0
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
@@ -32,7 +32,7 @@ func printTaskLocal<V>(
 
 // ==== ------------------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func groups() async {
   // no value
   _ = await withTaskGroup(of: Int.self) { group in
@@ -78,7 +78,7 @@ func groups() async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await groups()

--- a/test/Concurrency/Runtime/async_task_locals_prevent_illegal_use.swift
+++ b/test/Concurrency/Runtime/async_task_locals_prevent_illegal_use.swift
@@ -9,7 +9,7 @@
 // REQUIRES: concurrency
 // REQUIRES: libdispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 enum TL {
   @TaskLocal
   static var number: Int = 2
@@ -17,7 +17,7 @@ enum TL {
 
 // ==== ------------------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func bindAroundGroupSpawn() async {
   await TL.$number.withValue(1111) { // ok
     await withTaskGroup(of: Int.self) { group in
@@ -35,7 +35,7 @@ func bindAroundGroupSpawn() async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await bindAroundGroupSpawn()

--- a/test/Concurrency/Runtime/async_task_locals_spawn_let.swift
+++ b/test/Concurrency/Runtime/async_task_locals_spawn_let.swift
@@ -8,13 +8,13 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 enum TL {
   @TaskLocal
   static var number: Int = 0
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
@@ -32,7 +32,7 @@ func printTaskLocal<V>(
 
 // ==== ------------------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func async_let_nested() async {
   printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (0)
   async let x1: () = TL.$number.withValue(2) {
@@ -54,7 +54,7 @@ func async_let_nested() async {
   printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (0)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func async_let_nested_skip_optimization() async {
   async let x1: Int? = TL.$number.withValue(2) {
     async let x2: Int? = { () async -> Int? in
@@ -77,7 +77,7 @@ func async_let_nested_skip_optimization() async {
   _ = await x1
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await async_let_nested()

--- a/test/Concurrency/Runtime/async_task_locals_synchronous_bind.swift
+++ b/test/Concurrency/Runtime/async_task_locals_synchronous_bind.swift
@@ -8,13 +8,13 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 enum TL {
   @TaskLocal
   static var number: Int = 0
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
@@ -32,7 +32,7 @@ func printTaskLocal<V>(
 
 // ==== ------------------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func synchronous_bind() async {
 
   func synchronous() {
@@ -58,7 +58,7 @@ func synchronous_bind() async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await synchronous_bind()

--- a/test/Concurrency/Runtime/async_task_locals_wrapper.swift
+++ b/test/Concurrency/Runtime/async_task_locals_wrapper.swift
@@ -8,13 +8,13 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 enum TL {
   @TaskLocal
   static var number: Int = 0
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
@@ -32,7 +32,7 @@ func printTaskLocal<V>(
 
 // ==== ------------------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func async_let_nested() async {
   print("TL: \(TL.$number)")
   
@@ -56,7 +56,7 @@ func async_let_nested() async {
   printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (0)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func async_let_nested_skip_optimization() async {
   async let x1: Int? = TL.$number.withValue(2) {
     async let x2: Int? = { () async -> Int? in
@@ -79,7 +79,7 @@ func async_let_nested_skip_optimization() async {
   _ = await x1
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await async_let_nested()

--- a/test/Concurrency/Runtime/async_task_priority_current.swift
+++ b/test/Concurrency/Runtime/async_task_priority_current.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_detach() async {
   let a1 = Task.currentPriority
   print("a1: \(a1)") // CHECK: a1: unspecified
@@ -27,7 +27,7 @@ func test_detach() async {
   print("a3: \(a3)") // CHECK: a3: unspecified
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_multiple_lo_indirectly_escalated() async {
   @Sendable
   func loopUntil(priority: Task.Priority) async {
@@ -59,7 +59,7 @@ func test_multiple_lo_indirectly_escalated() async {
   print("default done") // CHECK: default done
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_detach()

--- a/test/Concurrency/Runtime/async_task_sleep.swift
+++ b/test/Concurrency/Runtime/async_task_sleep.swift
@@ -11,7 +11,7 @@ import _Concurrency
 // FIXME: should not depend on Dispatch
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static let pause = 500_000_000 // 500ms
   

--- a/test/Concurrency/Runtime/async_task_yield.swift
+++ b/test/Concurrency/Runtime/async_task_yield.swift
@@ -6,12 +6,12 @@
 // https://bugs.swift.org/browse/SR-14333
 // UNSUPPORTED: OS=windows-msvc
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 protocol Go: Actor {
   func go(times: Int) async -> Int
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Go {
   func go(times: Int) async -> Int {
     for i in 0...times {
@@ -22,12 +22,12 @@ extension Go {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor One: Go {}
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor Two: Go {}
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func yielding() async {
   let one = One()
   let two = Two()
@@ -41,7 +41,7 @@ func yielding() async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await yielding()

--- a/test/Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift
@@ -12,7 +12,7 @@ func boom() async throws -> Int {
   throw Boom()
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_next() async {
   let sum = await withThrowingTaskGroup(of: Int.self, returning: Int.self) { group in
     for n in 1...10 {
@@ -43,7 +43,7 @@ func test_taskGroup_next() async {
   print("result with group.next(): \(sum)")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_for_in() async {
   let sum = await withThrowingTaskGroup(of: Int.self, returning: Int.self) { group in
     for n in 1...10 {
@@ -74,7 +74,7 @@ func test_taskGroup_for_in() async {
   print("result with for-in: \(sum)")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_asyncIterator() async {
   let sum = await withThrowingTaskGroup(of: Int.self, returning: Int.self) { group in
     for n in 1...10 {
@@ -112,7 +112,7 @@ func test_taskGroup_asyncIterator() async {
   print("result with async iterator: \(sum)")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_next()

--- a/test/Concurrency/Runtime/async_taskgroup_cancelAll_only_specific_group.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancelAll_only_specific_group.swift
@@ -10,14 +10,14 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncEcho(_ value: Int) async -> Int {
   value
 }
 
 /// Tests that only the specific group we cancelAll on is cancelled,
 /// and not accidentally all tasks in all groups within the given parent task.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_cancelAll_onlySpecificGroup() async {
   async let g1: Int = withTaskGroup(of: Int.self) { group in
 
@@ -79,7 +79,7 @@ func test_taskGroup_cancelAll_onlySpecificGroup() async {
 
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_cancelAll_onlySpecificGroup()

--- a/test/Concurrency/Runtime/async_taskgroup_cancel_from_inside_child.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancel_from_inside_child.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_cancel_from_inside_child() async {
   let one = try! await withTaskGroup(of: Int.self, returning: Int.self) { group in
     await group.next()
@@ -45,7 +45,7 @@ func test_taskGroup_cancel_from_inside_child() async {
 
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_cancel_from_inside_child()

--- a/test/Concurrency/Runtime/async_taskgroup_cancel_parent_affects_group.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancel_parent_affects_group.swift
@@ -10,12 +10,12 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncEcho(_ value: Int) async -> Int {
   value
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_cancel_parent_affects_group() async {
 
   let x = detach {
@@ -47,7 +47,7 @@ func test_taskGroup_cancel_parent_affects_group() async {
 
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_cancel_parent_affects_group()

--- a/test/Concurrency/Runtime/async_taskgroup_cancel_then_completions.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancel_then_completions.swift
@@ -10,14 +10,14 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncEcho(_ value: Int) async -> Int {
   value
 }
 
 // FIXME: this is a workaround since (A, B) today isn't inferred to be Sendable
 //        and causes an error, but should be a warning (this year at least)
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct SendableTuple2<A: Sendable, B: Sendable>: Sendable {
   let first: A
   let second: B
@@ -28,7 +28,7 @@ struct SendableTuple2<A: Sendable, B: Sendable>: Sendable {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_cancel_then_completions() async {
   // CHECK: test_taskGroup_cancel_then_completions
   print("before \(#function)")
@@ -73,7 +73,7 @@ func test_taskGroup_cancel_then_completions() async {
   print("result: \(result)") // CHECK: result: 3
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_cancel_then_completions()

--- a/test/Concurrency/Runtime/async_taskgroup_cancel_then_spawn.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancel_then_spawn.swift
@@ -10,12 +10,12 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncEcho(_ value: Int) async -> Int {
   value
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_cancel_then_add() async {
   // CHECK: test_taskGroup_cancel_then_add
   print("\(#function)")
@@ -52,7 +52,7 @@ func test_taskGroup_cancel_then_add() async {
 
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_cancel_then_add()

--- a/test/Concurrency/Runtime/async_taskgroup_is_asyncsequence.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_is_asyncsequence.swift
@@ -10,7 +10,7 @@
 // UNSUPPORTED: linux
 // XFAIL: windows
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_is_asyncSequence() async {
   print(#function)
 
@@ -34,7 +34,7 @@ func test_taskGroup_is_asyncSequence() async {
   print("result: \(sum)")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_throwingTaskGroup_is_asyncSequence() async throws {
   print(#function)
 
@@ -58,7 +58,7 @@ func test_throwingTaskGroup_is_asyncSequence() async throws {
   print("result: \(sum)")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_is_asyncSequence()

--- a/test/Concurrency/Runtime/async_taskgroup_is_empty.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_is_empty.swift
@@ -10,12 +10,12 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncEcho(_ value: Int) async -> Int {
   value
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_isEmpty() async {
   print("before all")
   let result = await withTaskGroup(of: Int.self, returning: Int.self) { group in
@@ -44,7 +44,7 @@ func test_taskGroup_isEmpty() async {
   print("result: \(result)")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_isEmpty()

--- a/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_cancelAll.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_cancelAll.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_skipCallingNext_butInvokeCancelAll() async {
   let numbers = [1, 1]
 
@@ -47,7 +47,7 @@ func test_skipCallingNext_butInvokeCancelAll() async {
   assert(result == 0)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_skipCallingNext_butInvokeCancelAll()

--- a/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_without_cancelAll.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_without_cancelAll.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_skipCallingNext() async {
   let numbers = [1, 1]
 
@@ -43,7 +43,7 @@ func test_skipCallingNext() async {
   assert(result == 0)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_skipCallingNext()

--- a/test/Concurrency/Runtime/async_taskgroup_next_on_completed.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_on_completed.swift
@@ -10,7 +10,7 @@
 
 import Dispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_sum_nextOnCompleted() async {
   let numbers = [1, 2, 3, 4, 5]
   let expected = 15 // FIXME: numbers.reduce(0, +) this hangs?
@@ -66,7 +66,7 @@ func test_sum_nextOnCompleted() async {
   print("result: \(sum)")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_sum_nextOnCompleted()

--- a/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
@@ -12,15 +12,15 @@
 struct Boom: Error {}
 struct IgnoredBoom: Error {}
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func one() async -> Int { 1 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func boom() async throws -> Int {
   throw Boom()
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_throws() async {
   let got: Int = try await withThrowingTaskGroup(of: Int.self) { group in
     group.spawn { try await boom()  }
@@ -63,7 +63,7 @@ func test_taskGroup_throws() async {
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_throws()

--- a/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
@@ -12,12 +12,12 @@
 struct Boom: Error {}
 struct IgnoredBoom: Error {}
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func echo(_ i: Int) async -> Int { i }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func boom() async throws -> Int { throw Boom() }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_throws_rethrows() async {
   do {
     let got = try await withThrowingTaskGroup(of: Int.self, returning: Int.self) { group in
@@ -47,7 +47,7 @@ func test_taskGroup_throws_rethrows() async {
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_throws_rethrows()

--- a/test/Concurrency/Runtime/basic_future.swift
+++ b/test/Concurrency/Runtime/basic_future.swift
@@ -14,12 +14,12 @@ enum HomeworkError: Error, Equatable {
   case dogAteIt(String)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func formGreeting(name: String) async -> String {
   return "Hello \(name) from async world"
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func testSimple(
   name: String, dogName: String, shouldThrow: Bool, doSuspend: Bool
 ) async {
@@ -72,7 +72,7 @@ func testSimple(
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await testSimple(name: "Ted", dogName: "Hazel", shouldThrow: false, doSuspend: false)

--- a/test/Concurrency/Runtime/cancellation_handler.swift
+++ b/test/Concurrency/Runtime/cancellation_handler.swift
@@ -20,7 +20,7 @@ class Canary {
   }
 }
 
-if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+if #available(SwiftStdlib 5.5, *) {
   let task = detach {
     let canary = Canary()
     _ = await Task.withCancellationHandler {

--- a/test/Concurrency/Runtime/checked_continuation.swift
+++ b/test/Concurrency/Runtime/checked_continuation.swift
@@ -14,7 +14,7 @@ struct TestError: Error {}
   static func main() async {
     var tests = TestSuite("CheckedContinuation")
 
-    if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    if #available(SwiftStdlib 5.5, *) {
       tests.test("trap on double resume non-throwing continuation") {
         expectCrashLater()
 

--- a/test/Concurrency/Runtime/effectful_properties.swift
+++ b/test/Concurrency/Runtime/effectful_properties.swift
@@ -20,7 +20,7 @@ enum BallKind {
   case KirksandLignature
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 class Specs {
   // obtains the number of dimples
   subscript(_ bk : BallKind) -> Int {
@@ -37,7 +37,7 @@ class Specs {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor Database {
   var currentData : Specs {
     get async {
@@ -52,21 +52,21 @@ actor Database {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 protocol SphericalObject {
   var name : String { get async throws }
   var dimples : Int { get async throws }
   var description : String { get async throws }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 class Ball : SphericalObject {
   var name : String { get async throws { throw GeneralError.Todo } }
   var dimples : Int { get async throws { throw GeneralError.Todo } }
   var description : String { get async throws { throw GeneralError.Todo } }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 class GolfBall : Ball {
   private static let db : Database = Database()
 
@@ -110,17 +110,17 @@ class GolfBall : Ball {
 // CHECK: obtaining specs...
 // CHECK: this golf ball has 0 dimples
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func printAsBall(_ b : Ball) async {
   print(try! await b.description)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func printAsAsSphericalObject(_ b : SphericalObject) async {
   print(try! await b.description)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct RunIt {
   static func main() async {
     let balls : [(Bool, Ball)] = [

--- a/test/Concurrency/Runtime/executor_deinit2.swift
+++ b/test/Concurrency/Runtime/executor_deinit2.swift
@@ -11,7 +11,7 @@
 // this needs to match with the check count below.
 let NUM_TASKS : Int = 100
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 final class Capture : Sendable {
     func doSomething() { }
     deinit {
@@ -20,7 +20,7 @@ final class Capture : Sendable {
     }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main
 struct App {
     static func main() async {

--- a/test/Concurrency/Runtime/executor_deinit3.swift
+++ b/test/Concurrency/Runtime/executor_deinit3.swift
@@ -15,7 +15,7 @@
     import Glibc
 #endif
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 class Runner {
     func run() async {
         while !Task.isCancelled {
@@ -24,7 +24,7 @@ class Runner {
     }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor Container {
     var generation = 0
     var runners = [Int : Task.Handle<Void, Never>]()
@@ -66,7 +66,7 @@ actor Container {
 // FIXME: this doesn't work until we have https://github.com/apple/swift/pull/36298
 // COM: deinit Container with {{[0-9]+}} runners
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct RunIt {
     static func startTest() async {
         let c = Container()
@@ -75,7 +75,7 @@ actor Container {
         await c.cancelAll()
     }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 static func main() async {
         print("starting")
         await RunIt.startTest()

--- a/test/Concurrency/Runtime/future_fibonacci.swift
+++ b/test/Concurrency/Runtime/future_fibonacci.swift
@@ -21,7 +21,7 @@ func fib(_ n: Int) -> Int {
     return first
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncFib(_ n: Int) async -> Int {
   if n == 0 || n == 1 {
     return n
@@ -46,7 +46,7 @@ func asyncFib(_ n: Int) async -> Int {
   return result
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func runFibonacci(_ n: Int) async {
   var result = await asyncFib(n)
 
@@ -55,7 +55,7 @@ func runFibonacci(_ n: Int) async {
   assert(result == fib(n))
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await runFibonacci(15)

--- a/test/Concurrency/Runtime/yielding_continuation.swift
+++ b/test/Concurrency/Runtime/yielding_continuation.swift
@@ -24,7 +24,7 @@ func forceBeingAsync() async -> Void { }
 @main struct Main {
 
 static func main() async {
-    if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    if #available(SwiftStdlib 5.5, *) {
       tests.test("yield with no awaiting next") {
         let task = detach {
           let continuation = YieldingContinuation(yielding: String.self)

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -22,7 +22,7 @@ struct Point {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor TestActor {
   // expected-note@+1{{mutation of this property is only permitted within the actor}}
   var position = Point(x: 0, y: 0)
@@ -37,15 +37,15 @@ actor TestActor {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func modifyAsynchronously(_ foo: inout Int) async { foo += 1 }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 enum Container {
   static let modifyAsyncValue = modifyAsynchronously
 }
 
 // external function call
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension TestActor {
 
   // Can't pass actor-isolated primitive into a function
@@ -82,7 +82,7 @@ extension TestActor {
 }
 
 // internal method call
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension TestActor {
   func modifyByValue(_ other: inout Int) async {
     other += value1
@@ -95,7 +95,7 @@ extension TestActor {
 }
 
 // external class method call
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 class NonAsyncClass {
   func modifyOtherAsync(_ other : inout Int) async {
     // ...
@@ -107,7 +107,7 @@ class NonAsyncClass {
 }
 
 // Calling external class/struct async function
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension TestActor {
   // Can't pass state into async method of another class
 
@@ -136,12 +136,12 @@ extension TestActor {
 }
 
 // Check implicit async testing
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor DifferentActor {
   func modify(_ state: inout Int) {}
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension TestActor {
   func modify(_ state: inout Int) {}
 
@@ -160,7 +160,7 @@ extension TestActor {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor MyActor {
   var points: [Point] = []
   var int: Int = 0
@@ -194,7 +194,7 @@ actor MyActor {
 
 // Verify global actor protection
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @globalActor
 struct MyGlobalActor {
   static let shared = TestActor()
@@ -207,34 +207,34 @@ struct MyGlobalActor {
 
 // expected-error@+3{{actor-isolated var 'number' cannot be passed 'inout' to 'async' function call}}
 // expected-error@+2{{var 'number' isolated to global actor 'MyGlobalActor' can not be used 'inout' from a non-isolated context}}
-if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+if #available(SwiftStdlib 5.5, *) {
 let _ = detach { await { (_ foo: inout Int) async in foo += 1 }(&number) }
 }
 
 // attempt to pass global state owned by the global actor to another async function
 // expected-error@+2{{actor-isolated var 'number' cannot be passed 'inout' to 'async' function call}}
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @MyGlobalActor func sneaky() async { await modifyAsynchronously(&number) }
 
 // It's okay to pass actor state inout to synchronous functions!
 
 func globalSyncFunction(_ foo: inout Int) { }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @MyGlobalActor func globalActorSyncFunction(_ foo: inout Int) { }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @MyGlobalActor func globalActorAsyncOkay() async { globalActorSyncFunction(&number) }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @MyGlobalActor func globalActorAsyncOkay2() async { globalSyncFunction(&number) }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @MyGlobalActor func globalActorSyncOkay() { globalSyncFunction(&number) }
 
 // Gently unwrap things that are fine
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct Cat {
   mutating func meow() async { }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct Dog {
   var cat: Cat?
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -4,29 +4,29 @@
 let immutableGlobal: String = "hello"
 var mutableGlobal: String = "can't touch this" // expected-note 5{{var declared here}}
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func globalFunc() { }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func acceptClosure<T>(_: () -> T) { }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func acceptConcurrentClosure<T>(_: @Sendable () -> T) { }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func acceptEscapingClosure<T>(_: @escaping () -> T) { }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func acceptEscapingClosure<T>(_: @escaping (String) -> ()) async -> T? { nil }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @discardableResult func acceptAsyncClosure<T>(_: () async -> T) -> T { }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func acceptEscapingAsyncClosure<T>(_: @escaping () async -> T) { }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func acceptInout<T>(_: inout T) {}
 
 
 // ----------------------------------------------------------------------
 // Actor state isolation restrictions
 // ----------------------------------------------------------------------
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor MySuperActor {
   var superState: Int = 25 // expected-note {{mutation of this property is only permitted within the actor}}
 
@@ -47,7 +47,7 @@ class Point {
   var y : Int = 0
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor MyActor: MySuperActor { // expected-error{{actor types do not support inheritance}}
   let immutable: Int = 17
   // expected-note@+2 2{{property declared here}}
@@ -77,14 +77,14 @@ actor MyActor: MySuperActor { // expected-error{{actor types do not support inhe
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor Camera {
   func accessProp(act : MyActor) async -> String {
     return await act.name
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func checkAsyncPropertyAccess() async {
   let act = MyActor()
   let _ : Int = await act.mutable + act.mutable
@@ -105,7 +105,7 @@ func checkAsyncPropertyAccess() async {
   _ = act.point  // expected-warning{{cannot use property 'point' with a non-sendable type 'Point' across actors}}
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension MyActor {
   nonisolated var actorIndependentVar: Int {
     get { 5 }
@@ -317,35 +317,35 @@ extension MyActor {
 // ----------------------------------------------------------------------
 // Global actor isolation restrictions
 // ----------------------------------------------------------------------
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor SomeActor { }
 
 @globalActor
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct SomeGlobalActor {
   static let shared = SomeActor()
 }
 
 @globalActor
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct SomeOtherGlobalActor {
   static let shared = SomeActor()
 }
 
 @globalActor
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct GenericGlobalActor<T> {
   static var shared: SomeActor { SomeActor() }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @SomeGlobalActor func onions() {} // expected-note{{calls to global function 'onions()' from outside of its actor context are implicitly asynchronous}}
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @MainActor func beets() { onions() } // expected-error{{call to global actor 'SomeGlobalActor'-isolated global function 'onions()' in a synchronous main actor-isolated context}}
 // expected-note@-1{{calls to global function 'beets()' from outside of its actor context are implicitly asynchronous}}
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor Crystal {
   // expected-note@+2 {{property declared here}}
   // expected-note@+1 2 {{mutation of this property is only permitted within the actor}}
@@ -374,31 +374,31 @@ actor Crystal {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @SomeGlobalActor func syncGlobalActorFunc() { syncGlobalActorFunc() } // expected-note {{calls to global function 'syncGlobalActorFunc()' from outside of its actor context are implicitly asynchronous}}
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @SomeGlobalActor func asyncGlobalActorFunc() async { await asyncGlobalActorFunc() }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @SomeOtherGlobalActor func syncOtherGlobalActorFunc() { }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @SomeOtherGlobalActor func asyncOtherGlobalActorFunc() async {
   await syncGlobalActorFunc()
   await asyncGlobalActorFunc()
 }
 
 // test global actor funcs that are marked asyncHandler
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @SomeGlobalActor func goo1() async {
   let _ = goo2
   // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{3-3=await }}
   goo2() // expected-note{{calls to global function 'goo2()' from outside of its actor context are implicitly asynchronous}}
 }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @asyncHandler @SomeOtherGlobalActor func goo2() { await goo1() }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func testGlobalActorClosures() {
   let _: Int = acceptAsyncClosure { @SomeGlobalActor in
     syncGlobalActorFunc()
@@ -412,7 +412,7 @@ func testGlobalActorClosures() {
   acceptConcurrentClosure { @SomeGlobalActor in 5 } // expected-error{{converting function value of type '@SomeGlobalActor @Sendable () -> Int' to '@Sendable () -> Int' loses global actor 'SomeGlobalActor'}}
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension MyActor {
   @SomeGlobalActor func onGlobalActor(otherActor: MyActor) async {
     // Access to other functions in this actor are okay.
@@ -476,7 +476,7 @@ extension MyActor {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct GenericStruct<T> {
   @GenericGlobalActor<T> func f() { } // expected-note {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
 
@@ -491,7 +491,7 @@ struct GenericStruct<T> {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension GenericStruct where T == String {
   @GenericGlobalActor<T>
   func h2() {
@@ -510,7 +510,7 @@ func badNumberUser() {
   print("The protected number is: \(number)")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncBadNumberUser() async {
   print("The protected number is: \(await number)")
 }
@@ -518,7 +518,7 @@ func asyncBadNumberUser() async {
 // ----------------------------------------------------------------------
 // Non-actor code isolation restrictions
 // ----------------------------------------------------------------------
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func testGlobalRestrictions(actor: MyActor) async {
   let _ = MyActor()
 
@@ -578,7 +578,7 @@ func testGlobalRestrictions(actor: MyActor) async {
 
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func f() {
   acceptConcurrentClosure {
     _ = mutableGlobal // expected-warning{{reference to var 'mutableGlobal' is not concurrency-safe because it involves shared mutable state}}
@@ -592,7 +592,7 @@ func f() {
 // ----------------------------------------------------------------------
 // Local function isolation restrictions
 // ----------------------------------------------------------------------
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func checkLocalFunctions() async {
   var i = 0
   var j = 0
@@ -641,7 +641,7 @@ func checkLocalFunctions() async {
 // Lazy properties with initializers referencing 'self'
 // ----------------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor LazyActor {
     var v: Int = 0
     // expected-note@-1 6 {{property declared here}}
@@ -679,7 +679,7 @@ actor LazyActor {
 }
 
 // Infer global actors from context only for instance members.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @MainActor
 class SomeClassInActor {
   enum ID: String { case best }
@@ -687,7 +687,7 @@ class SomeClassInActor {
   func inActor() { } // expected-note{{calls to instance method 'inActor()' from outside of its actor context are implicitly asynchronous}}
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension SomeClassInActor.ID {
   func f(_ object: SomeClassInActor) { // expected-note{{add '@MainActor' to make instance method 'f' part of global actor 'MainActor'}}
     object.inActor() // expected-error{{call to main actor-isolated instance method 'inActor()' in a synchronous nonisolated context}}
@@ -697,7 +697,7 @@ extension SomeClassInActor.ID {
 // ----------------------------------------------------------------------
 // Initializers
 // ----------------------------------------------------------------------
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor SomeActorWithInits {
   var mutableState: Int = 17
   var otherMutableState: Int
@@ -712,7 +712,7 @@ actor SomeActorWithInits {
   func isolated() { }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @MainActor
 class SomeClassWithInits {
   var mutableState: Int = 17
@@ -752,7 +752,7 @@ class SomeClassWithInits {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func outsideSomeClassWithInits() { // expected-note 3 {{add '@MainActor' to make global function 'outsideSomeClassWithInits()' part of global actor 'MainActor'}}
   _ = SomeClassWithInits() // expected-error{{call to main actor-isolated initializer 'init()' in a synchronous nonisolated context}}
   _ = SomeClassWithInits.shared // expected-error{{static property 'shared' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
@@ -762,24 +762,24 @@ func outsideSomeClassWithInits() { // expected-note 3 {{add '@MainActor' to make
 // ----------------------------------------------------------------------
 // Actor protocols.
 // ----------------------------------------------------------------------
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 protocol P: Actor {
   func f()
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension P {
   func g() { f() }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor MyActorP: P {
   func f() { }
 
   func h() { g() }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func testCrossActorProtocol<T: P>(t: T) async {
   await t.f()
   await t.g()
@@ -797,7 +797,7 @@ func testCrossActorProtocol<T: P>(t: T) async {
 func acceptAsyncSendableClosure<T>(_: @Sendable () async -> T) { }
 func acceptAsyncSendableClosureInheriting<T>(@_inheritActorContext _: @Sendable () async -> T) { }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension MyActor {
   func testSendableAndInheriting() {
     acceptAsyncSendableClosure {

--- a/test/Concurrency/async_cancellation.swift
+++ b/test/Concurrency/async_cancellation.swift
@@ -6,12 +6,12 @@ enum PictureData {
   case failedToLoadImagePlaceholder
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_cancellation_checkCancellation() async throws {
   try Task.checkCancellation()
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_cancellation_guard_isCancelled(_ any: Any) async -> PictureData {
   guard !Task.isCancelled else {
     return PictureData.failedToLoadImagePlaceholder
@@ -20,12 +20,12 @@ func test_cancellation_guard_isCancelled(_ any: Any) async -> PictureData {
   return PictureData.value("...")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct SomeFile: Sendable {
   func close() {}
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_cancellation_withTaskCancellationHandler(_ anything: Any) async -> PictureData {
   let handle: Task.Handle<PictureData, Error> = detach {
     let file = SomeFile()
@@ -39,7 +39,7 @@ func test_cancellation_withTaskCancellationHandler(_ anything: Any) async -> Pic
   handle.cancel()
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_cancellation_loop() async -> Int {
   struct SampleTask { func process() async {} }
 

--- a/test/Concurrency/async_sequence_syntax.swift
+++ b/test/Concurrency/async_sequence_syntax.swift
@@ -2,36 +2,36 @@
 // REQUIRES: concurrency
 
 // expected-note@+2{{add 'async' to function 'missingAsync' to make it asynchronous}}
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func missingAsync<T : AsyncSequence>(_ seq: T) throws { 
   for try await _ in seq { } // expected-error{{'async' in a function that does not support concurrency}}
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func missingThrows<T : AsyncSequence>(_ seq: T) async {
   for try await _ in seq { } // expected-error{{error is not handled because the enclosing function is not declared 'throws'}}
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func executeAsync(_ work: () async -> Void) { }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func execute(_ work: () -> Void) { }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func missingThrowingInBlock<T : AsyncSequence>(_ seq: T) { 
   executeAsync { // expected-error{{invalid conversion from throwing function of type '() async throws -> Void' to non-throwing function type '() async -> Void'}}
     for try await _ in seq { }
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func missingTryInBlock<T : AsyncSequence>(_ seq: T) { 
   executeAsync { 
     for await _ in seq { } // expected-error{{call can throw, but the error is not handled}}
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func missingAsyncInBlock<T : AsyncSequence>(_ seq: T) { 
   execute { // expected-error{{cannot pass function of type '() async -> Void' to parameter expecting synchronous function type}}
     do { 
@@ -40,7 +40,7 @@ func missingAsyncInBlock<T : AsyncSequence>(_ seq: T) {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func doubleDiagCheckGeneric<T : AsyncSequence>(_ seq: T) async {
   var it = seq.makeAsyncIterator()
   // expected-note@+2{{call is to 'rethrows' function, but a conformance has a throwing witness}}
@@ -48,7 +48,7 @@ func doubleDiagCheckGeneric<T : AsyncSequence>(_ seq: T) async {
   let _ = await it.next()
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct ThrowingAsyncSequence: AsyncSequence, AsyncIteratorProtocol {
   typealias Element = Int
   typealias AsyncIterator = Self
@@ -59,7 +59,7 @@ struct ThrowingAsyncSequence: AsyncSequence, AsyncIteratorProtocol {
   func makeAsyncIterator() -> Self { return self }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func doubleDiagCheckConcrete(_ seq: ThrowingAsyncSequence) async {
   var it = seq.makeAsyncIterator()
   // expected-error@+1{{call can throw, but it is not marked with 'try' and the error is not handled}}
@@ -67,7 +67,7 @@ func doubleDiagCheckConcrete(_ seq: ThrowingAsyncSequence) async {
 }
 
 // rdar://75274975
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func forAwaitInsideDoCatch<Source: AsyncSequence>(_ source: Source) async {
   do {
     for try await item in source {
@@ -76,7 +76,7 @@ func forAwaitInsideDoCatch<Source: AsyncSequence>(_ source: Source) async {
   } catch {} // no-warning
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func forAwaitWithConcreteType(_ seq: ThrowingAsyncSequence) throws { // expected-note {{add 'async' to function 'forAwaitWithConcreteType' to make it asynchronous}}
   for try await elt in seq { // expected-error {{'async' in a function that does not support concurrency}}
     _ = elt

--- a/test/Concurrency/async_task_groups.swift
+++ b/test/Concurrency/async_task_groups.swift
@@ -4,11 +4,11 @@
 // REQUIRES: concurrency
 // REQUIRES: libdispatch
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncFunc() async -> Int { 42 }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncThrowsFunc() async throws -> Int { 42 }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func asyncThrowsOnCancel() async throws -> Int {
   // terrible suspend-spin-loop -- do not do this
   // only for purposes of demonstration
@@ -19,7 +19,7 @@ func asyncThrowsOnCancel() async throws -> Int {
   throw Task.CancellationError()
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_add() async throws -> Int {
   try await withThrowingTaskGroup(of: Int.self) { group in
     group.spawn {
@@ -42,12 +42,12 @@ func test_taskGroup_add() async throws -> Int {
 // MARK: Example group Usages
 
 struct Boom: Error {}
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func work() async -> Int { 42 }
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func boom() async throws -> Int { throw Boom() }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func first_allMustSucceed() async throws {
 
   let first: Int = try await withThrowingTaskGroup(of: Int.self) { group in
@@ -66,7 +66,7 @@ func first_allMustSucceed() async throws {
   // Expected: re-thrown Boom
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func first_ignoreFailures() async throws {
   @Sendable func work() async -> Int { 42 }
   @Sendable func boom() async throws -> Int { throw Boom() }
@@ -100,7 +100,7 @@ func first_ignoreFailures() async throws {
 // ==== ------------------------------------------------------------------------
 // MARK: Advanced Custom Task Group Usage
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_taskGroup_quorum_thenCancel() async {
   // imitates a typical "gather quorum" routine that is typical in distributed systems programming
   enum Vote {
@@ -156,7 +156,7 @@ func test_taskGroup_quorum_thenCancel() async {
 
 // FIXME: this is a workaround since (A, B) today isn't inferred to be Sendable
 //        and causes an error, but should be a warning (this year at least)
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct SendableTuple2<A: Sendable, B: Sendable>: Sendable {
   let first: A
   let second: B
@@ -167,7 +167,7 @@ struct SendableTuple2<A: Sendable, B: Sendable>: Sendable {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Collection where Self: Sendable, Element: Sendable, Self.Index: Sendable {
 
   /// Just another example of how one might use task groups.

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -1,11 +1,11 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
 // REQUIRES: concurrency
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func someAsyncFunc() async -> String { "" }
 
 struct MyError: Error {}
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func someThrowingAsyncFunc() async throws -> String { throw MyError() }
 
 // ==== Unsafe Continuations ---------------------------------------------------
@@ -27,7 +27,7 @@ func buyVegetables(
 ) {}
 
 // returns 1 or more vegetables or throws an error
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func buyVegetables(shoppingList: [String]) async throws -> [Vegetable] {
   try await withUnsafeThrowingContinuation { continuation in
     var veggies: [Vegetable] = []
@@ -43,7 +43,7 @@ func buyVegetables(shoppingList: [String]) async throws -> [Vegetable] {
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_unsafeContinuations() async {
   // the closure should not allow async operations;
   // after all: if you have async code, just call it directly, without the unsafe continuation
@@ -64,7 +64,7 @@ func test_unsafeContinuations() async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_unsafeThrowingContinuations() async throws {
   let _: String = try await withUnsafeThrowingContinuation { continuation in
     continuation.resume(returning: "")
@@ -89,7 +89,7 @@ func test_unsafeThrowingContinuations() async throws {
 
 // ==== Detached Tasks ---------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_detached() async throws {
   let handle = detach() {
     await someAsyncFunc() // able to call async functions
@@ -99,7 +99,7 @@ func test_detached() async throws {
   _ = result
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_detached_throwing() async -> String {
   let handle: Task.Handle<String, Error> = detach() {
     try await someThrowingAsyncFunc() // able to call async functions

--- a/test/Concurrency/concurrency_module_shadowing.swift
+++ b/test/Concurrency/concurrency_module_shadowing.swift
@@ -6,10 +6,10 @@
 
 import ShadowsConcur
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func f(_ t : Task) -> Bool {
   return t.someProperty == "123"
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func g(_: _Concurrency.Task) {}

--- a/test/Concurrency/task_local.swift
+++ b/test/Concurrency/task_local.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
 // REQUIRES: concurrency
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 struct TL {
   @TaskLocal
   static var number: Int = 0
@@ -22,7 +22,7 @@ var global: Int = 0
 
 class NotSendable {}
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test () async {
   TL.number = 10 // expected-error{{cannot assign to property: 'number' is a get-only property}}
   TL.$number = 10 // expected-error{{cannot assign value of type 'Int' to type 'TaskLocal<Int>'}}

--- a/test/Concurrency/throwing.swift
+++ b/test/Concurrency/throwing.swift
@@ -28,14 +28,14 @@ protocol MP { }
 
 class M : MP {
 
-  @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+  @available(SwiftStdlib 5.5, *)
   func throwWithIndirectResult<T>(_ a: P<T>) async throws -> T {
     throw E.err
   }
 }
 
 extension MP {
-  @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+  @available(SwiftStdlib 5.5, *)
   func l<A, B, C, D, E2, F> (_ a : P<A>, _ b: P<B>, _ c: P<C>, _ d : P<D>, _ e: P<E2>, _ f: P<F>) async throws -> (A, B, C, D, E2, F) {
     throw E.err
   }
@@ -45,7 +45,7 @@ extension MP {
   static func main() async {
     var tests = TestSuite("Async Throw")
 
-    if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    if #available(SwiftStdlib 5.5, *) {
       tests.test("throwing of naturally direct but indirect reabstration") {
         let task2 = detach {
           let m = M()

--- a/test/DebugInfo/async-boxed-arg.swift
+++ b/test/DebugInfo/async-boxed-arg.swift
@@ -2,7 +2,7 @@
 // RUN:    -module-name M -enable-experimental-concurrency | %FileCheck %s --dump-input always
 // REQUIRES: concurrency
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension Collection where Element: Sendable {
   public func f() async throws {
     return try await withThrowingTaskGroup(of: Element.self) { group in

--- a/test/ModuleInterface/Inputs/MeowActor.swift
+++ b/test/ModuleInterface/Inputs/MeowActor.swift
@@ -1,4 +1,4 @@
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @globalActor public final class MeowActor {
   public static let shared = _Impl()
   

--- a/test/ModuleInterface/actor_protocol.swift
+++ b/test/ModuleInterface/actor_protocol.swift
@@ -12,46 +12,46 @@
 // CHECK-EXTENSION-NOT: extension {{.+}} : _Concurrency.Actor
 
 // CHECK: public actor PlainActorClass {
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public actor PlainActorClass {
   @actorIndependent public func enqueue(partialTask: PartialAsyncTask) { }
 }
 
 // CHECK: public actor ExplicitActorClass : _Concurrency.Actor {
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public actor ExplicitActorClass : Actor {
   @actorIndependent public func enqueue(partialTask: PartialAsyncTask) { }
 }
 
 // CHECK: public actor EmptyActor {
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public actor EmptyActor {}
 
 // CHECK: actor public class EmptyActorClass {
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public actor class EmptyActorClass {}
 
 // CHECK: public protocol Cat : _Concurrency.Actor {
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public protocol Cat : Actor {
   func mew()
 }
 
 // CHECK: public actor HouseCat : Library.Cat {
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public actor HouseCat : Cat {
   @asyncHandler public func mew() {}
   @actorIndependent public func enqueue(partialTask: PartialAsyncTask) { }
 }
 
 // CHECK: public protocol ToothyMouth {
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public protocol ToothyMouth {
   func chew()
 }
 
 // CHECK: public actor Lion : Library.ToothyMouth, _Concurrency.Actor {
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 public actor Lion : ToothyMouth, Actor {
   @asyncHandler public func chew() {}
   @actorIndependent public func enqueue(partialTask: PartialAsyncTask) { }

--- a/test/ModuleInterface/global-actor.swift
+++ b/test/ModuleInterface/global-actor.swift
@@ -3,7 +3,7 @@
 
 import MeowActor
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @MeowActor func doMeow() {}
 
 // RUN: %target-swift-frontend -enable-experimental-concurrency -enable-library-evolution -emit-module -o %t/MeowActor.swiftmodule %S/Inputs/MeowActor.swift
@@ -14,7 +14,7 @@ import MeowActor
 // RUN: %target-swift-frontend -enable-experimental-concurrency -emit-silgen %s -I %t | %FileCheck --check-prefix CHECK-FRAGILE %s
 // CHECK-FRAGILE: metatype $@thin MeowActor.Type
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func someFunc() async {
   await doMeow()
 }

--- a/test/Sanitizers/tsan/actor_counters.swift
+++ b/test/Sanitizers/tsan/actor_counters.swift
@@ -14,7 +14,7 @@ import Darwin
 import Glibc
 #endif
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor Counter {
   private var value = 0
   private let scratchBuffer: UnsafeMutableBufferPointer<Int>
@@ -43,7 +43,7 @@ actor Counter {
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   for i in 0..<numIterations {
     let counterIndex = Int.random(in: 0 ..< counters.count)
@@ -53,7 +53,7 @@ func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   // Create counter actors.
   var counters: [Counter] = []
@@ -80,7 +80,7 @@ func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   print("DONE!")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     // Useful for debugging: specify counter/worker/iteration counts

--- a/test/Sanitizers/tsan/async_taskgroup_next.swift
+++ b/test/Sanitizers/tsan/async_taskgroup_next.swift
@@ -8,7 +8,7 @@
 
 var scratchBuffer: UnsafeMutableBufferPointer<Int> = .allocate(capacity: 1000)
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func completeFastOrSlow(n: Int) async -> Int {
   if n % 2 == 0 {
     await Task.sleep(2_000_000_000)
@@ -18,7 +18,7 @@ func completeFastOrSlow(n: Int) async -> Int {
   return n
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test_sum_nextOnCompletedOrPending() async {
   scratchBuffer.initialize(repeating: 0)
 
@@ -54,7 +54,7 @@ func test_sum_nextOnCompletedOrPending() async {
   assert(sum == expected, "Expected: \(expected), got: \(sum)")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test_sum_nextOnCompletedOrPending()

--- a/test/Sanitizers/tsan/basic_future.swift
+++ b/test/Sanitizers/tsan/basic_future.swift
@@ -18,12 +18,12 @@ enum HomeworkError: Error, Equatable {
   case dogAteIt(String)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func formGreeting(name: String) async -> String {
   return "Hello \(name) from async world"
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func testSimple(
   name: String, dogName: String, shouldThrow: Bool, doSuspend: Bool
 ) async {
@@ -76,7 +76,7 @@ func testSimple(
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await testSimple(name: "Ted", dogName: "Hazel", shouldThrow: false, doSuspend: false)

--- a/test/Sanitizers/tsan/racy_actor_counters.swift
+++ b/test/Sanitizers/tsan/racy_actor_counters.swift
@@ -17,7 +17,7 @@
 
 var globalCounterValue = 0
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor Counter {
   func next() -> Int {
     let current = globalCounterValue
@@ -26,7 +26,7 @@ actor Counter {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   for _ in 0..<numIterations {
     let counterIndex = Int.random(in: 0 ..< counters.count)
@@ -36,7 +36,7 @@ func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   // Create counter actors.
   var counters: [Counter] = []
@@ -62,7 +62,7 @@ func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   print("DONE!")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     // Useful for debugging: specify counter/worker/iteration counts

--- a/test/Syntax/round_trip_concurrency.swift
+++ b/test/Syntax/round_trip_concurrency.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %round-trip-syntax-test --swift-syntax-test %swift-syntax-test --file %s
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor Counter {
   private var value = 0
   private let scratchBuffer: UnsafeMutableBufferPointer<Int>
@@ -24,7 +24,7 @@ actor Counter {
 }
 
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   for i in 0..<numIterations {
     let counterIndex = Int.random(in: 0 ..< counters.count)
@@ -34,7 +34,7 @@ func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   // Create counter actors.
   var counters: [Counter] = []
@@ -61,7 +61,7 @@ func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   print("DONE!")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     // Useful for debugging: specify counter/worker/iteration counts

--- a/test/decl/protocol/special/Actor.swift
+++ b/test/decl/protocol/special/Actor.swift
@@ -3,30 +3,30 @@
 
 // Synthesis of for actores.
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor A1 {
   var x: Int = 17
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor A2: Actor {
   var x: Int = 17
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor A3<T>: Actor {
   var x: Int = 17
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor A4: A1 { // expected-error{{actor types do not support inheritance}}
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor A5: A2 { // expected-error{{actor types do not support inheritance}}
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor A6: A1, Actor { // expected-error{{redundant conformance of 'A6' to protocol 'Actor'}}
   // expected-note@-1{{'A6' inherits conformance to protocol 'Actor' from superclass here}}
   // expected-error@-2{{actor types do not support inheritance}}
@@ -34,23 +34,23 @@ actor A6: A1, Actor { // expected-error{{redundant conformance of 'A6' to protoc
 
 // Explicitly satisfying the requirement.
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 actor A7 {
   // Okay: satisfy the requirement explicitly
   nonisolated func enqueue(partialTask: PartialAsyncTask) { }
 }
 
 // A non-actor can conform to the Actor protocol, if it does it properly.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 class C1: Actor { // expected-error{{non-final class 'C1' cannot conform to `Sendable`; use `UnsafeSendable`}}
   func enqueue(partialTask: PartialAsyncTask) { }
 }
 
 // Make sure the conformances actually happen.
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func acceptActor<T: Actor>(_: T.Type) { }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func testConformance() {
   acceptActor(A1.self)
   acceptActor(A2.self)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -399,6 +399,12 @@ swift_version = lit_config.params.get('swift-version',
 lit_config.note('Compiling with -swift-version ' + swift_version)
 config.swift_test_options = '-swift-version ' + swift_version
 
+# Define a macro for the next release OS version.
+# This macro can be used in code as `@available(SwiftStdlib 5.5, *)`.
+swift_stdlib_macro = '\'SwiftStdlib 5.5:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999\''
+config.swift_frontend_test_options += ' -define-availability ' + swift_stdlib_macro
+config.swift_driver_test_options += ' -Xfrontend -define-availability -Xfrontend ' + swift_stdlib_macro
+
 differentiable_programming = lit_config.params.get('differentiable_programming', None)
 if differentiable_programming is not None:
     config.available_features.add('differentiable_programming')

--- a/test/stdlib/Concurrency.swift
+++ b/test/stdlib/Concurrency.swift
@@ -5,6 +5,6 @@
 import _Concurrency
 
 // Make sure the type shows up
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 extension PartialAsyncTask {
 }

--- a/test/stmt/errors_async.swift
+++ b/test/stmt/errors_async.swift
@@ -6,7 +6,7 @@ enum MyError : Error {
   case bad
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func shouldThrow() async {
   // expected-error@+1 {{errors thrown from here are not handled}}
   let _: Int = try await withUnsafeThrowingContinuation { continuation in


### PR DESCRIPTION
Replace the Concurrency related placeholder availability declaration that were using the 9999 OS versions with one availability macro, centralizing the actual OS versions definition in two locations. This simplifies merging changes between branches as it causes much less merge conflicts.

- Scope: Affects the Swift compiler internal source management only.
- Risk: Very low, this shouldn’t change the resulting software in anyway.
- Testing: The tests have been updated to use the same macro.
- Cherry-pick of #37244 and #37269.
- Resolves: rdar://77929657