### PR TITLE
[5.5][Diagnostics] Improve diagnostics when passing `async` to a sync parameter

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -563,8 +563,8 @@ ERROR(cannot_pass_async_func_to_sync_parameter,none,
       "cannot pass function of type %0 "
       "to parameter expecting synchronous function type", (Type))
 
-NOTE(async_in_closure_that_does_not_support_concurrency,none,
-     "'async' in a closure that does not support concurrency", ())
+NOTE(async_inferred_from_operation,none,
+     "'async' inferred from asynchronous operation used here", ())
 
 // Key-path expressions.
 ERROR(expr_keypath_no_objc_runtime,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -559,6 +559,13 @@ ERROR(async_functiontype_mismatch,none,
       "invalid conversion from 'async' function of type %0 to "
       "synchronous function type %1", (Type, Type))
 
+ERROR(cannot_pass_async_func_to_sync_parameter,none,
+      "cannot pass function of type %0 "
+      "to parameter expecting synchronous function type", (Type))
+
+NOTE(async_in_closure_that_does_not_support_concurrency,none,
+     "'async' in a closure that does not support concurrency", ())
+
 // Key-path expressions.
 ERROR(expr_keypath_no_objc_runtime,none,
       "'#keyPath' can only be used with the Objective-C runtime", ())

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5595,6 +5595,11 @@ Type getConcreteReplacementForProtocolSelfType(ValueDecl *member);
 /// of operator overload choices.
 bool isOperatorDisjunction(Constraint *disjunction);
 
+/// Find out whether closure body has any `async` or `await` expressions,
+/// declarations, or statements directly in its body (no in other closures
+/// or nested declarations).
+ASTNode findAsyncNode(ClosureExpr *closure);
+
 } // end namespace constraints
 
 template<typename ...Args>

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5895,9 +5895,8 @@ bool AsyncFunctionConversionFailure::diagnoseAsError() {
       // 'async' effect is inferred from the body of the closure.
       if (asyncLoc.isInvalid()) {
         if (auto asyncNode = findAsyncNode(closure)) {
-          emitDiagnosticAt(
-              ::getLoc(asyncNode),
-              diag::async_in_closure_that_does_not_support_concurrency);
+          emitDiagnosticAt(::getLoc(asyncNode),
+                           diag::async_inferred_from_operation);
         }
       }
     }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5883,6 +5883,28 @@ bool ThrowingFunctionConversionFailure::diagnoseAsError() {
 }
 
 bool AsyncFunctionConversionFailure::diagnoseAsError() {
+  auto *locator = getLocator();
+
+  if (locator->isLastElement<LocatorPathElt::ApplyArgToParam>()) {
+    emitDiagnostic(diag::cannot_pass_async_func_to_sync_parameter,
+                   getFromType());
+
+    if (auto *closure = getAsExpr<ClosureExpr>(getAnchor())) {
+      auto asyncLoc = closure->getAsyncLoc();
+
+      // 'async' effect is inferred from the body of the closure.
+      if (asyncLoc.isInvalid()) {
+        if (auto asyncNode = findAsyncNode(closure)) {
+          emitDiagnosticAt(
+              ::getLoc(asyncNode),
+              diag::async_in_closure_that_does_not_support_concurrency);
+        }
+      }
+    }
+
+    return true;
+  }
+
   emitDiagnostic(diag::async_functiontype_mismatch, getFromType(),
                  getToType());
   return true;

--- a/test/Concurrency/async_sequence_syntax.swift
+++ b/test/Concurrency/async_sequence_syntax.swift
@@ -33,9 +33,9 @@ func missingTryInBlock<T : AsyncSequence>(_ seq: T) {
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func missingAsyncInBlock<T : AsyncSequence>(_ seq: T) { 
-  execute { // expected-error{{invalid conversion from 'async' function of type '() async -> Void' to synchronous function type '() -> Void'}}
+  execute { // expected-error{{cannot pass function of type '() async -> Void' to parameter expecting synchronous function type}}
     do { 
-      for try await _ in seq { }
+      for try await _ in seq { } // expected-note {{'async' in a closure that does not support concurrency}}
     } catch { }
   }
 }

--- a/test/Concurrency/async_sequence_syntax.swift
+++ b/test/Concurrency/async_sequence_syntax.swift
@@ -35,7 +35,7 @@ func missingTryInBlock<T : AsyncSequence>(_ seq: T) {
 func missingAsyncInBlock<T : AsyncSequence>(_ seq: T) { 
   execute { // expected-error{{cannot pass function of type '() async -> Void' to parameter expecting synchronous function type}}
     do { 
-      for try await _ in seq { } // expected-note {{'async' in a closure that does not support concurrency}}
+      for try await _ in seq { } // expected-note {{'async' inferred from asynchronous operation used here}}
     } catch { }
   }
 }

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -47,8 +47,8 @@ func buyVegetables(shoppingList: [String]) async throws -> [Vegetable] {
 func test_unsafeContinuations() async {
   // the closure should not allow async operations;
   // after all: if you have async code, just call it directly, without the unsafe continuation
-  let _: String = withUnsafeContinuation { continuation in // expected-error{{invalid conversion from 'async' function of type '(UnsafeContinuation<String, Never>) async -> Void' to synchronous function type '(UnsafeContinuation<String, Never>) -> Void'}}
-    let s = await someAsyncFunc() // rdar://70610141 for getting a better error message here
+  let _: String = withUnsafeContinuation { continuation in // expected-error{{cannot pass function of type '(UnsafeContinuation<String, Never>) async -> Void' to parameter expecting synchronous function type}}
+    let s = await someAsyncFunc() // expected-note {{'async' in a closure that does not support concurrency}}
     continuation.resume(returning: s)
   }
 

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -48,7 +48,7 @@ func test_unsafeContinuations() async {
   // the closure should not allow async operations;
   // after all: if you have async code, just call it directly, without the unsafe continuation
   let _: String = withUnsafeContinuation { continuation in // expected-error{{cannot pass function of type '(UnsafeContinuation<String, Never>) async -> Void' to parameter expecting synchronous function type}}
-    let s = await someAsyncFunc() // expected-note {{'async' in a closure that does not support concurrency}}
+    let s = await someAsyncFunc() // expected-note {{'async' inferred from asynchronous operation used here}}
     continuation.resume(returning: s)
   }
 


### PR DESCRIPTION
- Explanation:

It's sometimes hard to figure out why closure is `async`, it could
either be declared or inferred from the body. 

If `async` effect has been inferred from the body of the closure,
let's find out the first occurrence of async node and point it out
to make it clear why closure is `async`.

- Scope: Calls where `async` closure is passed to a parameter expecting sync function type.

- Resolves: rdar://70610141

- Risk: Very low

- Testing: Regression tests added to the suite

- Reviewed By: @hborla @etcwilde

Resolves: rdar://70610141

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
