### PR TITLE
[next][ClangImporter] Updated ModuleFileExtension constructor call

### DIFF
--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1572,8 +1572,8 @@ public:
                            LookupTableMap &tables, ASTContext &ctx,
                            ClangSourceBufferImporter &buffersForDiagnostics,
                            const PlatformAvailability &avail)
-      : // An unfortunate workaround until D97702 lands.
-        clang::ModuleFileExtension(static_cast<ModuleFileExtensionKind>(42)),
+      : // Update in response to D97702 landing.
+        clang::ModuleFileExtension(),
         pchLookupTable(pchLookupTable), lookupTables(tables), swiftCtx(ctx),
         buffersForDiagnostics(buffersForDiagnostics), availability(avail) {}
 


### PR DESCRIPTION
Constructor call of ModuleFileExtension has been updated to allow the
toolchain to build.
Previously this constructor call was passed a bogus value as a
workaround in response to clang change https://reviews.llvm.org/D96155.
Aforementioned workaround was added in commit 2dfe3551a356797db49086a91db8059dc135655e.
Due to clang update https://reviews.llvm.org/D97702, ModuleFileExtension no longer requires a constructor parameter.
Unable to verify this fix works due to other problems in next branch.

<!-- What's in this pull request? -->

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
I believe this resolves rdar://76127053.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
