### PR TITLE
[SymbolGraph] add "memberOf" relations for remote protocol implementations

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -426,6 +426,17 @@ void SymbolGraph::recordDefaultImplementationRelationships(Symbol S) {
           recordEdge(Symbol(this, VD, nullptr),
                      Symbol(this, MemberVD, nullptr),
                      RelationshipKind::DefaultImplementationOf());
+
+          // If P is from a different module, and it's being added to a type
+          // from the current module, add a `memberOf` relation to the extended
+          // protocol.
+          if (MemberVD->getModuleContext() != &M && VD->getDeclContext()) {
+            if (auto *ExP = VD->getDeclContext()->getSelfNominalTypeDecl()) {
+              recordEdge(Symbol(this, VD, nullptr),
+                         Symbol(this, ExP, nullptr),
+                         RelationshipKind::MemberOf());
+            }
+          }
         }
       }
     }

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -430,7 +430,7 @@ void SymbolGraph::recordDefaultImplementationRelationships(Symbol S) {
           // If P is from a different module, and it's being added to a type
           // from the current module, add a `memberOf` relation to the extended
           // protocol.
-          if (MemberVD->getModuleContext() != &M && VD->getDeclContext()) {
+          if (MemberVD->getModuleContext()->getNameStr() != M.getNameStr() && VD->getDeclContext()) {
             if (auto *ExP = VD->getDeclContext()->getSelfNominalTypeDecl()) {
               recordEdge(Symbol(this, VD, nullptr),
                          Symbol(this, ExP, nullptr),

--- a/test/SymbolGraph/Relationships/DefaultImplementationOf/Inputs/RemoteP.swift
+++ b/test/SymbolGraph/Relationships/DefaultImplementationOf/Inputs/RemoteP.swift
@@ -1,0 +1,3 @@
+public protocol RemoteP {
+    func someFunc()
+}

--- a/test/SymbolGraph/Relationships/DefaultImplementationOf/Remote.swift
+++ b/test/SymbolGraph/Relationships/DefaultImplementationOf/Remote.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %S/Inputs/RemoteP.swift -module-name RemoteP -emit-module -emit-module-path %t/
+// RUN: %target-build-swift %s -module-name Remote -emit-module -emit-module-path %t/ -I %t
+// RUN: %target-swift-symbolgraph-extract -module-name Remote -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/Remote.symbols.json
+// RUN: %FileCheck %s --input-file %t/Remote.symbols.json --check-prefix MEMBER
+
+import RemoteP
+
+public protocol LocalP: RemoteP {}
+
+public extension LocalP {
+    func someFunc() {}
+}
+
+// default implementations that are for protocols in a different module should have a `memberOf`
+// relation linking them to a local symbol, if one exists
+
+// CHECK:           "kind": "defaultImplementationOf"
+// CHECK-NEXT:      "source": "s:6Remote6LocalPPAAE8someFuncyyF"
+// CHECK-NEXT:      "target": "s:7RemotePAAP8someFuncyyF"
+// CHECK-NEXT:      "targetFallback": "RemoteP.RemoteP.someFunc()"
+
+// MEMBER:           "kind": "memberOf"
+// MEMBER-NEXT:      "source": "s:6Remote6LocalPPAAE8someFuncyyF"
+// MEMBER-NEXT:      "target": "s:6Remote6LocalPP"


### PR DESCRIPTION
Resolves rdar://75729692

When generating symbol graphs for a module that includes a default implementation for a protocol from another module, there's currently no way to relate the default implementation to the type or protocol in the current module. This PR adds an additional `memberOf` relation for these default implementations, that links them to the protocol or type in the current module that it's extending.