### PR TITLE
[CodeCompletion] Update for SE-0293 Property Wrappers for func params

### DIFF
--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -555,9 +555,7 @@ public:
                VisibleDeclConsumer &Consumer)
       : SM(SM), Loc(Loc), Consumer(Consumer) {}
 
-  void checkValueDecl(ValueDecl *D, DeclVisibilityKind Reason) {
-    Consumer.foundDecl(D, Reason);
-  }
+  void checkValueDecl(ValueDecl *D, DeclVisibilityKind Reason);
 
   void checkPattern(const Pattern *Pat, DeclVisibilityKind Reason);
   

--- a/test/IDE/complete_property_delegate.swift
+++ b/test/IDE/complete_property_delegate.swift
@@ -6,9 +6,17 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=SELF_VARNAME | %FileCheck %s -check-prefix=CONTEXT_VARNAME
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=SELF_STORAGE_VARNAME | %FileCheck %s -check-prefix=CONTEXT_STORAGE_VARNAME
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PARAM | %FileCheck %s -check-prefix=PARAM
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PARAM_CLOSURE | %FileCheck %s -check-prefix=PARAM
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=LOCAL | %FileCheck %s -check-prefix=LOCAL
+
 @propertyWrapper
 struct Lazzzy<T> {
   var wrappedValue: T
+  var projectedValue: String { "" }
+
+  init(wrappedValue: T) { fatalError() }
+
   func delegateOperation() -> Int {}
 }
 
@@ -26,6 +34,7 @@ class MyClass {
     let _ = #^CONTEXT^#
 // CONTEXT: Begin completions
 // CONTEXT-DAG: Decl[InstanceVar]/CurrNominal:      foo[#MyMember#];
+// CONTEXT-DAG: Decl[InstanceVar]/CurrNominal:      $foo[#String#];
 // CONTEXT-DAG: Decl[InstanceVar]/CurrNominal:      _foo[#Lazzzy<MyMember>#];
 // CONTEXT: End completions
 
@@ -38,9 +47,10 @@ class MyClass {
 // CONTEXT_VARNAME-DAG: End completions
 
     let _ = _foo.#^CONTEXT_STORAGE_VARNAME^#
-// CONTEXT_STORAGE_VARNAME: Begin completions, 3 items
+// CONTEXT_STORAGE_VARNAME: Begin completions, 4 items
 // CONTEXT_STORAGE_VARNAME-DAG: Keyword[self]/CurrNominal:          self[#Lazzzy<MyMember>#]; name=self
 // CONTEXT_STORAGE_VARNAME-DAG: Decl[InstanceVar]/CurrNominal:      wrappedValue[#MyMember#]; name=wrappedValue
+// CONTEXT_STORAGE_VARNAME-DAG: Decl[InstanceVar]/CurrNominal:      projectedValue[#String#]; name=projectedValue
 // CONTEXT_STORAGE_VARNAME-DAG: Decl[InstanceMethod]/CurrNominal:   delegateOperation()[#Int#]; name=delegateOperation()
 // CONTEXT_STORAGE_VARNAME-NOT: _
 // CONTEXT_STORAGE_VARNAME: End completions
@@ -55,3 +65,34 @@ class MyClass {
 // Same as CONTEXT_STORAGE_VARNAME.
   }
 }
+
+func paramTest(@Lazzzy arg: MyMember) {
+    #^PARAM^#
+// PARAM: Begin completions
+// PARAM-DAG: Decl[LocalVar]/Local:               arg[#MyMember#]; name=arg
+// PARAM-DAG: Decl[LocalVar]/Local:               $arg[#String#]; name=$arg
+// PARAM-DAG: Decl[LocalVar]/Local:               _arg[#Lazzzy<MyMember>#]; name=_arg
+// PARAM-DAG: Decl[FreeFunction]/CurrModule:      paramTest({#arg: MyMember#})[#Void#]; name=paramTest(arg: MyMember)
+// PARAM: End completions
+}
+func closureTest() {
+    func receive(fn: (MyMember) -> Void) {}
+
+    receive { (@Lazzzy arg: MyMember) in
+        #^PARAM_CLOSURE^#
+// Same as PARAM
+    }
+}
+
+func localTest() {
+    @Lazzzy var local: MyMember = .zero
+
+    #^LOCAL^#
+// LOCAL: Begin completions
+// LOCAL-DAG: Decl[LocalVar]/Local:               local[#MyMember#]; name=local
+// LOCAL-DAG: Decl[LocalVar]/Local:               $local[#String#]; name=$local
+// LOCAL-DAG: Decl[LocalVar]/Local:               _local[#Lazzzy<MyMember>#]; name=_local
+// LOCAL-DAG: Decl[FreeFunction]/CurrModule:      paramTest({#arg: MyMember#})[#Void#]; name=paramTest(arg: MyMember)
+// LOCAL: End completions
+}
+


### PR DESCRIPTION
Emit `ParamDecl::getPropertyWrapperAuxiliaryVariables()` variables instead of the param itself.

rdar://76355405
