### PR TITLE
Re-Enable IR Hash Test

### DIFF
--- a/test/multifile/batch-mode-llvmIRHash-consistency.swift
+++ b/test/multifile/batch-mode-llvmIRHash-consistency.swift
@@ -1,13 +1,9 @@
 // Ensure that the LLVMIR hash of the 2nd compilation in batch mode
 // is consistent no matter if the first one generates code or not.
 
-// This test fails in some configurations.
-// REQUIRES: rdar_62338337
-
 // RUN: %empty-directory(%t)
 // RUN: echo 'public enum E: Error {}' >%t/main.swift
 // RUN: echo >%t/other.swift
-// RUN: touch -t 201901010101 %t/*.swift
 
 // RUN: cd %t; %target-swift-frontend -c -g -enable-batch-mode -module-name main -primary-file ./main.swift -primary-file other.swift
 
@@ -20,7 +16,7 @@
 
 // Ensure that code generation was not performed for other.swift
 
-// RUN: ls -t %t | %FileCheck %s
+// RUN: ls -1t %t | %FileCheck %s
 
 // CHECK: other.swift
 // CHECK: other.o


### PR DESCRIPTION
This was disabled due to timing issues on the bots. Now that everything
is on APFS/ext/NTFS, we should have the resolution necessary to turn
this back on.

rdar://62338337