### PR TITLE
[vs2017] Adapt some variadic template aliases to not trip MSVC 2017.

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2906,8 +2906,13 @@ class TargetGenericEnvironment
        uint16_t, GenericParamDescriptor, GenericRequirementDescriptor>;
   friend TrailingObjects;
 
+#if !defined(_MSC_VER) || _MSC_VER >= 1920
   template<typename T>
   using OverloadToken = typename TrailingObjects::template OverloadToken<T>;
+#else
+// MSVC 2017 trips parsing an using of an using, of a variadic template
+#define OverloadToken typename TrailingObjects::template OverloadToken
+#endif
 
   size_t numTrailingObjects(OverloadToken<uint16_t>) const {
     return Flags.getNumGenericParameterLevels();
@@ -2920,6 +2925,10 @@ class TargetGenericEnvironment
   size_t numTrailingObjects(OverloadToken<GenericRequirementDescriptor>) const {
     return Flags.getNumGenericRequirements();
   }
+
+#if defined(_MSC_VER) && _MSC_VER < 1920
+#undef OverloadToken
+#endif
 
   GenericEnvironmentFlags Flags;
 
@@ -2982,8 +2991,13 @@ protected:
     FollowingTrailingObjects...>;
   friend TrailingObjects;
 
+#if !defined(_MSC_VER) || _MSC_VER >= 1920
   template<typename T>
   using OverloadToken = typename TrailingObjects::template OverloadToken<T>;
+#else
+// MSVC 2017 trips parsing an using of an using, of a variadic template
+#define OverloadToken typename TrailingObjects::template OverloadToken
+#endif
   
   const Self *asSelf() const {
     return static_cast<const Self *>(this);
@@ -3047,6 +3061,11 @@ protected:
   size_t numTrailingObjects(OverloadToken<GenericRequirementDescriptor>) const {
     return asSelf()->isGeneric() ? getGenericContextHeader().NumRequirements : 0;
   }
+
+#if defined(_MSC_VER) && _MSC_VER < 1920
+#undef OverloadToken
+#endif
+
 };
 
 /// Reference to a generic context.


### PR DESCRIPTION
It seems that MSVC 2017 trips parsing an `using` of an `using` of a variadic
template. Removing one level of using seems to work fine. A preprocessor
macro allows to keep using the same syntax in both MSVC 2017 and other
compilers without making a lot of a mess.

I think this might have been uncovered by landing apple/llvm-project#2898
when it was picked up by the auto-merger for the swift/main branch.
I think this was not a problem until now, because Metadata.h was
compiled using the just compiled Clang until now. LLDB is compiled using
MSVC in Windows.

Windows VS2017 CI: https://ci-external.swift.org/job/oss-swift-windows-x86_64/
First failing: https://ci-external.swift.org/job/oss-swift-windows-x86_64/7448/ (might disappear)
Last failure until now: https://ci-external.swift.org/job/oss-swift-windows-x86_64/7462/

/cc @bulbazord @compnerd 