### PR TITLE
Fix type signature mismatch for `_swift_task_getMainExecutor`

### DIFF
--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -76,11 +76,9 @@ internal func _enqueueOnMain(_ job: UnownedJob)
 
 // Used by the concurrency runtime
 @available(SwiftStdlib 5.5, *)
-extension SerialExecutor {
-  @_silgen_name("_swift_task_getMainExecutor")
-  internal func _getMainExecutor() -> UnownedSerialExecutor {
-    return MainActor.shared.unownedExecutor
-  }
+@_silgen_name("_swift_task_getMainExecutor")
+internal func _getMainExecutor() -> UnownedSerialExecutor {
+  return MainActor.shared.unownedExecutor
 }
 
 @available(SwiftStdlib 5.5, *)


### PR DESCRIPTION
`extension SerialExecutor` leads generic context and the defined methods have extra generic type parameters, but caller side (C++) doesn't expect such parameters, so their signatures are conflicted at swiftcc level.

https://github.com/apple/swift/blob/cc2863c136d986ce221075f8afd5caf3e7a07488/stdlib/public/Concurrency/TaskPrivate.h#L96

<!-- What's in this pull request? -->

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

CC: @MaxDesiatov 