### PR TITLE
[cxx-interop] Detect IndirectFields nested in non-importable anon-union.

### DIFF
--- a/test/Interop/Cxx/union/Inputs/anonymous-union-partly-invalid.h
+++ b/test/Interop/Cxx/union/Inputs/anonymous-union-partly-invalid.h
@@ -1,0 +1,16 @@
+@class C;
+@interface C
+{}
+@end
+
+struct S {
+  union {
+    C *t;
+    char c;
+  };
+  S(const S &s) {}
+  ~S() { }
+  int f() { return 42; }
+};
+
+S *getSPtr();

--- a/test/Interop/Cxx/union/Inputs/module.modulemap
+++ b/test/Interop/Cxx/union/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module AnonymousUnionPartlyInvalid {
+  header "anonymous-union-partly-invalid.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/union/anonymous-union-partly-invalid-module-interface.swift
+++ b/test/Interop/Cxx/union/anonymous-union-partly-invalid-module-interface.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=AnonymousUnionPartlyInvalid -I %S/Inputs -source-filename=x -enable-cxx-interop -enable-objc-interop | %FileCheck %s
+
+// CHECK: class C {
+// CHECK-NEXT: }
+// CHECK-NEXT: struct S {
+// CHECK-NEXT:   mutating func f() -> Int32
+// CHECK-NEXT: }
+// CHECK-NEXT: func getSPtr() -> UnsafeMutablePointer<S>!

--- a/test/Interop/Cxx/union/anonymous-union-partly-invalid.swift
+++ b/test/Interop/Cxx/union/anonymous-union-partly-invalid.swift
@@ -1,0 +1,13 @@
+// RUN: %swift -I %S/Inputs -enable-cxx-interop -enable-objc-interop -emit-ir %s | %FileCheck %s
+
+import AnonymousUnionPartlyInvalid
+
+let sPtr = getSPtr()
+let a = sPtr![0].f()
+
+// CHECK: i32 @main
+// CHECK-NEXT: entry:
+// CHECK-NEXT: bitcast
+// CHECK-NEXT: call %struct.S
+// CHECK-NEXT: ptrtoint %struct.S
+


### PR DESCRIPTION
    [cxx-interop] Detect IndirectFields nested in non-importable anon-unions

    This patch to the Clang Importer avoids an assert by detecting when an
    IndirectField belongs to an anonymous union that is not importable. How
    it does this is by determining if an IndirectFieldDecl's anonymous
    parent field is non-importable (based on isCxxRecordImportable) and if
    so skips importing the IndirectFieldDecl.

    This avoids the mentioned assert because makeIndirectFieldAccessors
    expects a FieldDecl of __Unnamed_union___Anonymous_field that is only
    populated when the top-level union is imported from an
    IndirectFieldDecl's parent. IndirectFieldDecls for the members of an
    anonymous union are dependent on their parent and should not be imported
    if their parent can not also be imported.

    This corner case can happen in cases when an anonymous union contains an
    ARC pointer, which results in a non-trivial but also inaccessible dtor.

@zoecarver @egorzhdan @compnerd 
