### PR TITLE
Enable `swift-driver` forwarding on non-Apple platforms.

### DIFF
--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -158,18 +158,18 @@ static bool appendSwiftDriverName(SmallString<256> &buffer) {
     llvm::sys::path::append(buffer, *driverNameOp);
     return true;
   }
-#ifdef __APPLE__
-  // FIXME: use swift-driver as the default driver for all platforms.
+
   llvm::sys::path::append(buffer, "swift-driver");
   if (llvm::sys::fs::exists(buffer)) {
     return true;
   }
   llvm::sys::path::remove_filename(buffer);
   llvm::sys::path::append(buffer, "swift-driver-new");
-  return true;
-#else
+  if (llvm::sys::fs::exists(buffer)) {
+    return true;
+  }
+
   return false;
-#endif
 }
 
 static int run_driver(StringRef ExecName,


### PR DESCRIPTION
This removes the `#ifdef __APPLE__` guard that restricts this forwarding to Apple platforms only.
If a given build/toolchain does not build or include the `swift-driver` executable alongside the compiler executables, the driver will still safely default to the legacy driver.

Resolves rdar://75534188
