### PR TITLE
Diagnostic Collector

### DIFF
--- a/include/swift/Basic/DiagnosticCollector.h
+++ b/include/swift/Basic/DiagnosticCollector.h
@@ -1,0 +1,80 @@
+//===--- DiagnosticCollector.h --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This defines a diagnostic collector, collecting information required for
+// emitting, de-duplicating, and coalescing individual diagnostics into
+// something more meaningful.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_DIAGNOSTICCOLLECTOR_H
+#define SWIFT_BASIC_DIAGNOSTICCOLLECTOR_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <type_traits>
+#include <vector>
+
+namespace swift {
+
+/// A container for collecting multiple diagnostics that have a common anchor.
+template <typename AnchorType, typename DiagnosticInformationType>
+class DiagnosticCollector {
+  llvm::DenseMap<AnchorType, std::vector<DiagnosticInformationType>>
+      diagnostics;
+  llvm::SmallVector<AnchorType> anchors;
+
+  decltype(diagnostics.begin()) initializeOrGet(AnchorType anchor) {
+    auto key = diagnostics.find(anchor);
+    if (key == diagnostics.end()) {
+      anchors.push_back(anchor);
+      key = diagnostics.insert({anchor, {}}).first;
+    }
+    return key;
+  }
+
+public:
+  DiagnosticCollector() {}
+
+  void addDiagnostic(AnchorType anchor,
+                     DiagnosticInformationType &&diagnostic) {
+    auto key = initializeOrGet(anchor);
+    key->second.push_back(std::forward<DiagnosticInformationType>(diagnostic));
+  }
+
+  template <typename... Args>
+  void emplaceDiagnostic(AnchorType anchor, Args &&... args) {
+    auto key = initializeOrGet(anchor);
+    key->second.emplace_back(std::forward<Args>(args)...);
+  }
+
+  const llvm::ArrayRef<DiagnosticInformationType>
+  getDiagnostics(AnchorType anchor) const {
+    auto key = diagnostics.find(anchor);
+    if (key == diagnostics.end())
+      return {};
+    return key->second;
+  }
+
+  /// Iterate the keys in the order they were emitted
+  decltype(anchors.begin()) begin() { return anchors.begin(); }
+  decltype(anchors.end()) end() { return anchors.end(); }
+
+  bool empty() const { return anchors.empty(); }
+
+  bool empty(AnchorType anchor) const { return getDiagnostics(anchor).empty(); }
+};
+} // namespace swift
+
+#endif // SWIFT_BASIC_DIAGNOSTICCOLLECTOR_H

--- a/unittests/Basic/CMakeLists.txt
+++ b/unittests/Basic/CMakeLists.txt
@@ -11,6 +11,7 @@ add_swift_unittest(SwiftBasicTests
   ClusteredBitVectorTest.cpp
   DemangleTest.cpp
   DiverseStackTest.cpp
+  DiagnosticCollectorTest.cpp
   EditorPlaceholderTest.cpp
   EncodedSequenceTest.cpp
   ExponentialGrowthAppendingBinaryByteStreamTests.cpp

--- a/unittests/Basic/DiagnosticCollectorTest.cpp
+++ b/unittests/Basic/DiagnosticCollectorTest.cpp
@@ -1,0 +1,74 @@
+//===--- DiagnosticCollectorTest.cpp --------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "diagnostic-collector-test"
+
+#include "swift/Basic/DiagnosticCollector.h"
+
+#include "gtest/gtest.h"
+
+using namespace swift;
+
+struct DiagnosticInfo {
+  DiagnosticInfo(bool isOdd) : isOdd(isOdd) {}
+  bool isOdd;
+};
+
+TEST(DiagnosticCollectorTest, GetEmptyCollector) {
+  DiagnosticCollector<uint32_t, DiagnosticInfo> diagnostics;
+  // Expect the diagnostics to be empty!
+  EXPECT_TRUE(diagnostics.getDiagnostics(32).empty());
+  EXPECT_TRUE(diagnostics.empty());
+  EXPECT_TRUE(diagnostics.empty(32));
+}
+
+TEST(DiagnosticCollectorTest, CollectorInsertion) {
+  DiagnosticCollector<uint32_t, DiagnosticInfo> diagnostics;
+  // is the anchor odd?
+  diagnostics.emplaceDiagnostic(32, false);
+  diagnostics.emplaceDiagnostic(33, true);
+  diagnostics.emplaceDiagnostic(32, false);
+
+  auto evenDiagnostics = diagnostics.getDiagnostics(32);
+  EXPECT_EQ(evenDiagnostics.size(), 2);
+  for (const DiagnosticInfo &diagInfo : evenDiagnostics)
+    EXPECT_FALSE(diagInfo.isOdd);
+
+  auto oddDiagnostics = diagnostics.getDiagnostics(33);
+  ASSERT_EQ(oddDiagnostics.size(), 1);
+  EXPECT_EQ(oddDiagnostics[0].isOdd, true);
+}
+
+TEST(DiagnosticCollectorTest, AnchorIterator) {
+  DiagnosticCollector<uint32_t, DiagnosticInfo> diagnostics;
+
+  diagnostics.addDiagnostic(30, {false});
+  diagnostics.addDiagnostic(31, {true});
+  diagnostics.addDiagnostic(32, {false});
+  diagnostics.addDiagnostic(31, {true});
+  diagnostics.addDiagnostic(30, {false});
+
+  // Ensure that we're iterating the anchors in the order they were first
+  // inserted
+
+  llvm::SmallVector<uint32_t, 3> expectedAnchorOrder = {30, 31, 32};
+  unsigned anchorCount = 0;
+  for (auto anchorIt = diagnostics.begin(), begin = anchorIt,
+            end = diagnostics.end();
+       anchorIt != end; ++anchorIt) {
+    size_t diff = anchorIt - begin;
+    EXPECT_EQ(expectedAnchorOrder[diff], *anchorIt);
+    EXPECT_FALSE(diagnostics.empty(*anchorIt));
+    ++anchorCount;
+  }
+  EXPECT_EQ(anchorCount, expectedAnchorOrder.size());
+}


### PR DESCRIPTION
This patch contains a quick implementation of a diagnostic collector that makes it easier to store information for multiple error messages at a given anchor. I've migrated the ad-hoc bits that were collecting the diagnostics for the await effects-coverage AST walker. It's pretty much just an ordered llvm::DenseMap, mapping an anchor to a list of diagnostics associated with that anchor. It's been templated to make it pretty easy to provide additional information about the anchor or diagnostics without having to conform to a class hierarchy.

The deleted-code-to-new-code ratio isn't quite what I was hoping for, though I have plans for using this mechanism in other places so it will get amortized as more places get added. 

I did make an attempt to migrate the ConstraintFix collection in the constraint solver/Solution to use this with an ASTNode anchor and ConstraintFix diagnostic. Getting it to compile was fairly straightforward, given that it's already pretty close to what `ConstraintSystem::applySolutionFixes` already does.
While it looked right, I ended up getting a bunch of errors when building the standard library like what follows, so I clearly messed something up there:

```
/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface:21763:1: error: type 'UnsafeRawPointer' does not conform to protocol 'Equatable'
extension UnsafeRawPointer : Swift.Strideable {
^
/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface:7813:15: note: multiple matching functions named '==' with type '(UnsafeRawPointer, UnsafeRawPointer) -> Bool'
  static func == (lhs: Self, rhs: Self) -> Swift.Bool
              ^
/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface:4648:24: note: candidate exactly matches
@inlinable public func == <T>(lhs: T, rhs: T) -> Swift.Bool where T : Swift.RawRepresentable, T.RawValue : Swift.Equatable {
                       ^
/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface:9773:36: note: candidate exactly matches
  @_transparent public static func == (lhs: Self, rhs: Self) -> Swift.Bool {
                                   ^
/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface:10836:36: note: candidate exactly matches
  @_transparent public static func == <Other>(lhs: Self, rhs: Other) -> Swift.Bool where Other : Swift.BinaryInteger {
                                   ^
/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface:14067:36: note: candidate exactly matches
  @_transparent public static func == (lhs: Self, rhs: Self) -> Swift.Bool {
                                   ^
/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface:18045:33: note: candidate exactly matches
  @inlinable public static func == (x: Self, y: Self) -> Swift.Bool {
                                ^
/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface:18525:53: note: candidate exactly matches
  @inlinable @_effects(readonly) public static func == <RHS>(lhs: Self, rhs: RHS) -> Swift.Bool where RHS : Swift.StringProtocol {
                                                    ^
/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface:23830:36: note: candidate exactly matches
  @_transparent public static func == (lhs: Self, rhs: Self) -> Swift.Bool {
                                   ^
```

I'm pretty sure it's something dumb that I did in the migration, but will need to debug that further later.