### PR TITLE
[lit] Ensure unittests run target the just built libraries...

### DIFF
--- a/test/Unit/lit.cfg
+++ b/test/Unit/lit.cfg
@@ -77,3 +77,16 @@ config.test_format = lit.formats.GoogleTest(config.build_mode, 'Tests')
 # module cache for all those tests that do not set that explicitly
 if 'XDG_CACHE_HOME' in os.environ:
   config.environment['XDG_CACHE_HOME'] = os.environ['XDG_CACHE_HOME']
+
+# Find the resource directory.  Assume it's near the swift compiler if not set.
+test_resource_dir = lit_config.params.get('test_resource_dir')
+if not test_resource_dir:
+    test_resource_dir = config.swiftlib_dir
+
+if 'use_os_stdlib' not in lit_config.params:
+    # Ensure we load the libraries from the just built compiler
+    # when building on Darwin
+    # This is needed in addition to what is done in `add_swift_unittest`
+    # to handle dependencies of the dylibs loaded by `SwiftRuntimeTests`
+    # (for which we cannot run `swift-rpathize.py`)
+    config.environment['DYLD_LIBRARY_PATH'] = os.path.join(test_resource_dir, 'macosx')

--- a/test/Unit/lit.site.cfg.in
+++ b/test/Unit/lit.site.cfg.in
@@ -7,6 +7,7 @@ config.llvm_libs_dir = "@LLVM_LIBS_DIR@"
 config.build_mode = lit_config.params.get('build_mode', "@SWIFT_BUILD_MODE@")
 config.swift_obj_root = "@SWIFT_BINARY_DIR@"
 config.target_triple = "@TARGET_TRIPLE@"
+config.swiftlib_dir = "@LIT_SWIFTLIB_DIR@"
 config.swift_test_results_dir = \
     lit_config.params.get("swift_test_results_dir", "@SWIFT_TEST_RESULTS_DIR@")
 


### PR DESCRIPTION
...when tests are configured to do so.
    
The change here matches in spirit what we do in `add_swift_unittest`.