### PR TITLE
[5.5] Async let family

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1862,7 +1862,7 @@ public:
   bool isComputingPatternBindingEntry(const VarDecl *vd) const;
 
   /// Is this an "async let" declaration?
-  bool isSpawnLet() const;
+  bool isAsyncLet() const;
 
   /// Gets the text of the initializer expression for the pattern entry at the
   /// given index, stripping out inactive branches of any #ifs inside the
@@ -4942,7 +4942,7 @@ public:
   bool isLet() const { return getIntroducer() == Introducer::Let; }
 
   /// Is this an "async let" property?
-  bool isSpawnLet() const;
+  bool isAsyncLet() const;
 
   Introducer getIntroducer() const {
     return Introducer(Bits.VarDecl.Introducer);

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4243,8 +4243,8 @@ ERROR(throwing_interpolation_without_try,none,
       "interpolation can throw but is not marked with 'try'", ())
 ERROR(throwing_call_without_try,none,
       "call can throw but is not marked with 'try'", ())
-ERROR(throwing_spawn_let_without_try,none,
-      "reading 'spawn let' can throw but is not marked with 'try'", ())
+ERROR(throwing_async_let_without_try,none,
+      "reading 'async let' can throw but is not marked with 'try'", ())
 ERROR(throwing_prop_access_without_try,none,
       "property access can throw but is not marked with 'try'", ())
 ERROR(throwing_subscript_access_without_try,none,
@@ -4273,8 +4273,8 @@ NOTE(async_access_without_await,none,
 
 NOTE(async_call_without_await_in_autoclosure,none,
       "call is 'async' in an autoclosure argument", ())
-NOTE(async_call_without_await_in_spawn_let,none,
-      "call is 'async' in an 'spawn let' initializer", ())
+NOTE(async_call_without_await_in_async_let,none,
+      "call is 'async' in an 'async let' initializer", ())
 
 WARNING(no_async_in_await,none,
         "no 'async' operations occur within 'await' expression", ())
@@ -4287,7 +4287,7 @@ ERROR(await_in_illegal_context,none,
       "%select{<<ERROR>>|a default argument|a property wrapper initializer|a property initializer|a global variable initializer|an enum case raw value|a catch pattern|a catch guard expression|a defer body}0",
       (unsigned))
 ERROR(async_in_nonasync_function,none,
-      "%select{'async'|'async' call|'await'|'spawn let'|'async' property access|'async' subscript access}0 in "
+      "%select{'async'|'async' call|'await'|'async let'|'async' property access|'async' subscript access}0 in "
       "%select{a function|an autoclosure}1 that does not support concurrency",
       (unsigned, bool))
 NOTE(note_add_async_to_function,none,
@@ -4418,8 +4418,8 @@ ERROR(actor_isolated_from_concurrent_closure,none,
 ERROR(actor_isolated_from_concurrent_function,none,
         "actor-isolated %0 %1 cannot be %select{referenced|mutated|used 'inout'}2 from a concurrent function",
         (DescriptiveDeclKind, DeclName, unsigned))
-ERROR(actor_isolated_from_spawn_let,none,
-        "actor-isolated %0 %1 cannot be %select{referenced|mutated|used 'inout'}2 from 'spawn let' initializer",
+ERROR(actor_isolated_from_async_let,none,
+        "actor-isolated %0 %1 cannot be %select{referenced|mutated|used 'inout'}2 from 'async let' initializer",
         (DescriptiveDeclKind, DeclName, unsigned))
 ERROR(actor_isolated_keypath_component,none,
       "cannot form key path to actor-isolated %0 %1",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4314,21 +4314,18 @@ NOTE(protocol_witness_async_conflict,none,
 ERROR(async_autoclosure_nonasync_function,none,
       "'async' autoclosure parameter in a non-'async' function", ())
 
-WARNING(async_let_is_spawn_let,none,
-      "'async let' is now 'spawn let'", ())
-
-ERROR(spawn_not_let,none,
-      "'spawn' can only be used with 'let' declarations", ())
-ERROR(spawn_let_not_local,none,
-      "'spawn let' can only be used on local declarations", ())
-ERROR(spawn_let_not_initialized,none,
-      "'spawn let' binding requires an initializer expression", ())
-ERROR(spawn_let_no_variables,none,
-      "'spawn let' requires at least one named variable", ())
-NOTE(spawn_let_without_await,none,
-      "reference to spawn let %0 is 'async'", (DeclName))
-ERROR(spawn_let_in_illegal_context,none,
-      "spawn let %0 cannot be referenced in "
+ERROR(async_not_let,none,
+      "'async' can only be used with 'let' declarations", ())
+ERROR(async_let_not_local,none,
+      "'async let' can only be used on local declarations", ())
+ERROR(async_let_not_initialized,none,
+      "'async let' binding requires an initializer expression", ())
+ERROR(async_let_no_variables,none,
+      "'async let' requires at least one named variable", ())
+NOTE(async_let_without_await,none,
+      "reference to async let %0 is 'async'", (DeclName))
+ERROR(async_let_in_illegal_context,none,
+      "async let %0 cannot be referenced in "
       "%select{<<ERROR>>|a default argument|a property wrapper initializer|a property initializer|a global variable initializer|an enum case raw value|a catch pattern|a catch guard expression|a defer body}1",
       (DeclName, unsigned))
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4433,7 +4433,7 @@ public:
   /// Given expression represents computed result of the closure.
   Expr *buildAutoClosureExpr(Expr *expr, FunctionType *closureType,
                              bool isDefaultWrappedValue = false,
-                             bool isSpawnLetWrapper = false);
+                             bool isAsyncLetWrapper = false);
 
   /// Builds a type-erased return expression that can be used in dynamic
   /// replacement.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1581,9 +1581,9 @@ StaticSpellingKind PatternBindingDecl::getCorrectStaticSpelling() const {
   return getCorrectStaticSpellingForDecl(this);
 }
 
-bool PatternBindingDecl::isSpawnLet() const {
+bool PatternBindingDecl::isAsyncLet() const {
   if (auto var = getAnchoringVarDecl(0))
-    return var->isSpawnLet();
+    return var->isAsyncLet();
 
   return false;
 }
@@ -5876,7 +5876,7 @@ bool VarDecl::isMemberwiseInitialized(bool preferDeclaredProperties) const {
   return true;
 }
 
-bool VarDecl::isSpawnLet() const {
+bool VarDecl::isAsyncLet() const {
   return getAttrs().hasAttribute<AsyncAttr>() || getAttrs().hasAttribute<SpawnAttr>();
 }
 

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -440,7 +440,7 @@ public:
       // buffer.  DI will make sure it is only assigned to once.
       needsTemporaryBuffer = true;
       isUninitialized = true;
-    } else if (vd->isSpawnLet()) {
+    } else if (vd->isAsyncLet()) {
       // If this is an async let, treat it like a let-value without an
       // initializer. The initializer runs concurrently in a child task,
       // and value will be initialized at the point the variable in the
@@ -1146,7 +1146,7 @@ void SILGenFunction::emitPatternBinding(PatternBindingDecl *PBD,
 
   // If this is an async let, create a child task to compute the initializer
   // value.
-  if (PBD->isSpawnLet()) {
+  if (PBD->isAsyncLet()) {
     // Look through the implicit await (if present), try (if present), and
     // call to reach the autoclosure that computes the value.
     auto *init = PBD->getExecutableInit(idx);

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2816,7 +2816,7 @@ SILGenFunction::maybeEmitValueOfLocalVarDecl(
   if (It != VarLocs.end()) {
     // If the variable is part of an async let, ensure that the child task
     // has completed first.
-    if (var->isSpawnLet() && accessKind != AccessKind::Write) {
+    if (var->isAsyncLet() && accessKind != AccessKind::Write) {
       auto patternBinding = var->getParentPatternBinding();
       unsigned index = patternBinding->getPatternEntryIndexForVarDecl(var);
       completeAsyncLetChildTask(patternBinding, index);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8330,7 +8330,7 @@ static Expr *wrapAsyncLetInitializer(
   ASTContext &ctx = dc->getASTContext();
   Expr *autoclosureExpr = cs.buildAutoClosureExpr(
       initializer, closureType, /*isDefaultWrappedValue=*/false,
-      /*isSpawnLetWrapper=*/true);
+      /*isAsyncLetWrapper=*/true);
 
   // Call the autoclosure so that the AST types line up. SILGen will ignore the
   // actual calls and translate them into a different mechanism.
@@ -8431,7 +8431,7 @@ static Optional<SolutionApplicationTarget> applySolutionToInitialization(
   // For an async let, wrap the initializer appropriately to make it a child
   // task.
   if (auto patternBinding = target.getInitializationPatternBindingDecl()) {
-    if (patternBinding->isSpawnLet()) {
+    if (patternBinding->isAsyncLet()) {
       resultTarget.setExpr(
           wrapAsyncLetInitializer(
             cs, resultTarget.getAsExpr(), resultTarget.getDeclContext()));

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4960,7 +4960,7 @@ ConstraintSystem::isConversionEphemeral(ConversionRestrictionKind conversion,
 Expr *ConstraintSystem::buildAutoClosureExpr(Expr *expr,
                                              FunctionType *closureType,
                                              bool isDefaultWrappedValue,
-                                             bool isSpawnLetWrapper) {
+                                             bool isAsyncLetWrapper) {
   auto &Context = DC->getASTContext();
   bool isInDefaultArgumentContext = false;
   if (auto *init = dyn_cast<Initializer>(DC)) {
@@ -4982,7 +4982,7 @@ Expr *ConstraintSystem::buildAutoClosureExpr(Expr *expr,
 
   closure->setParameterList(ParameterList::createEmpty(Context));
 
-  if (isSpawnLetWrapper)
+  if (isAsyncLetWrapper)
     closure->setThunkKind(AutoClosureExpr::Kind::AsyncLet);
 
   Expr *result = closure;
@@ -5724,7 +5724,7 @@ ASTNode constraints::findAsyncNode(ClosureExpr *closure) {
     bool walkToDeclPre(Decl *decl) override {
       // Do not walk into function or type declarations.
       if (auto *patternBinding = dyn_cast<PatternBindingDecl>(decl)) {
-        if (patternBinding->isSpawnLet())
+        if (patternBinding->isAsyncLet())
           AsyncNode = patternBinding;
 
         return true;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5506,10 +5506,6 @@ void AttributeChecker::visitGlobalActorAttr(GlobalActorAttr *attr) {
 
 void AttributeChecker::visitAsyncAttr(AsyncAttr *attr) {
   if (isa<VarDecl>(D)) {
-    D->getASTContext().Diags.diagnose(
-        attr->getLocation(), diag::async_let_is_spawn_let)
-      .fixItReplace(attr->getRange(), "spawn");
-
     visitAsyncOrSpawnAttr(attr);
   }
 }
@@ -5529,7 +5525,7 @@ void AttributeChecker::visitAsyncOrSpawnAttr(DeclAttribute *attr) {
 
   // "Async" modifier can only be applied to local declarations.
   if (!patternBinding->getDeclContext()->isLocalContext()) {
-    diagnoseAndRemoveAttr(attr, diag::spawn_let_not_local);
+    diagnoseAndRemoveAttr(attr, diag::async_let_not_local);
     return;
   }
 
@@ -5550,21 +5546,21 @@ void AttributeChecker::visitAsyncOrSpawnAttr(DeclAttribute *attr) {
     // Each entry must bind at least one named variable, so that there is
     // something to "await".
     if (!foundAnyVariable) {
-      diagnose(pattern->getLoc(), diag::spawn_let_no_variables);
+      diagnose(pattern->getLoc(), diag::async_let_no_variables);
       attr->setInvalid();
       return;
     }
 
     // Async can only be used on an "async let".
     if (!isLet && !diagnosedVar) {
-      diagnose(patternBinding->getLoc(), diag::spawn_not_let)
+      diagnose(patternBinding->getLoc(), diag::async_not_let)
         .fixItReplace(patternBinding->getLoc(), "let");
       diagnosedVar = true;
     }
 
     // Each pattern entry must have an initializer expression.
     if (patternBinding->getEqualLoc(index).isInvalid()) {
-      diagnose(pattern->getLoc(), diag::spawn_let_not_initialized);
+      diagnose(pattern->getLoc(), diag::async_let_not_initialized);
       attr->setInvalid();
       return;
     }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2039,7 +2039,7 @@ namespace {
       if (auto autoclosure = dyn_cast<AutoClosureExpr>(dc)) {
         switch (autoclosure->getThunkKind()) {
         case AutoClosureExpr::Kind::AsyncLet:
-          return diag::actor_isolated_from_spawn_let;
+          return diag::actor_isolated_from_async_let;
 
         case AutoClosureExpr::Kind::DoubleCurryThunk:
         case AutoClosureExpr::Kind::SingleCurryThunk:

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -418,7 +418,7 @@ public:
     if (auto ic = dyn_cast<IfConfigDecl>(D)) {
       recurse = asImpl().checkIfConfig(ic);
     } else if (auto patternBinding = dyn_cast<PatternBindingDecl>(D)) {
-      if (patternBinding->isSpawnLet())
+      if (patternBinding->isAsyncLet())
         recurse = asImpl().checkAsyncLet(patternBinding);
     } else {
       recurse = ShouldNotRecurse;
@@ -1922,7 +1922,7 @@ public:
 
       if (auto declRef = dyn_cast<DeclRefExpr>(e)) {
         if (auto var = dyn_cast<VarDecl>(declRef->getDecl())) {
-          if (var->isSpawnLet()) {
+          if (var->isAsyncLet()) {
             Diags.diagnose(
                 e->getLoc(), diag::async_let_in_illegal_context,
                 var->getName(), static_cast<unsigned>(getKind()));
@@ -1932,7 +1932,7 @@ public:
       }
     } else if (auto patternBinding = dyn_cast_or_null<PatternBindingDecl>(
                    node.dyn_cast<Decl *>())) {
-      if (patternBinding->isSpawnLet()) {
+      if (patternBinding->isAsyncLet()) {
         auto var = patternBinding->getAnchoringVarDecl(0);
         Diags.diagnose(
             e->getLoc(), diag::async_let_in_illegal_context,
@@ -2529,7 +2529,7 @@ private:
         // "Async let" declarations are treated as an asynchronous call
         // (to the underlying task's "get"). If the initializer was throwing,
         // then the access is also treated as throwing.
-        if (var->isSpawnLet()) {
+        if (var->isAsyncLet()) {
           // If the initializer could throw, we will have a 'try' in the
           // application of its autoclosure.
           bool throws = false;
@@ -2831,7 +2831,7 @@ private:
         case PotentialEffectReason::Kind::AsyncLet:
           if (auto declR = dyn_cast<DeclRefExpr>(&diag.expr)) {
             if (auto var = dyn_cast<VarDecl>(declR->getDecl())) {
-              if (var->isSpawnLet()) {
+              if (var->isAsyncLet()) {
                 Ctx.Diags.diagnose(declR->getLoc(),
                                    diag::async_let_without_await,
                                    var->getName());

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1689,7 +1689,7 @@ public:
     bool suggestTryFixIt = reasonKind == PotentialEffectReason::Kind::Apply;
 
     if (reasonKind == PotentialEffectReason::Kind::AsyncLet) {
-      message = diag::throwing_spawn_let_without_try;
+      message = diag::throwing_async_let_without_try;
 
     } else if (reasonKind == PotentialEffectReason::Kind::PropertyAccess) {
       message = diag::throwing_prop_access_without_try;
@@ -1924,7 +1924,7 @@ public:
         if (auto var = dyn_cast<VarDecl>(declRef->getDecl())) {
           if (var->isSpawnLet()) {
             Diags.diagnose(
-                e->getLoc(), diag::spawn_let_in_illegal_context,
+                e->getLoc(), diag::async_let_in_illegal_context,
                 var->getName(), static_cast<unsigned>(getKind()));
             return;
           }
@@ -1935,7 +1935,7 @@ public:
       if (patternBinding->isSpawnLet()) {
         auto var = patternBinding->getAnchoringVarDecl(0);
         Diags.diagnose(
-            e->getLoc(), diag::spawn_let_in_illegal_context,
+            e->getLoc(), diag::async_let_in_illegal_context,
             var->getName(), static_cast<unsigned>(getKind()));
         return;
       }
@@ -2833,7 +2833,7 @@ private:
             if (auto var = dyn_cast<VarDecl>(declR->getDecl())) {
               if (var->isSpawnLet()) {
                 Ctx.Diags.diagnose(declR->getLoc(),
-                                   diag::spawn_let_without_await,
+                                   diag::async_let_without_await,
                                    var->getName());
                 continue;
               }
@@ -2862,7 +2862,7 @@ private:
                break;
              case AutoClosureExpr::Kind::AsyncLet:
                Ctx.Diags.diagnose(diag.expr.getStartLoc(),
-                                  diag::async_call_without_await_in_spawn_let);
+                                  diag::async_call_without_await_in_async_let);
                break;
              case AutoClosureExpr::Kind::SingleCurryThunk:
              case AutoClosureExpr::Kind::DoubleCurryThunk:

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -230,6 +230,14 @@ public struct TaskGroup<ChildTaskResult> {
     spawn(priority: optPriority, operation: operation)
   }
 
+  @_alwaysEmitIntoClient
+  public mutating func async(
+    priority: Task.Priority? = nil,
+    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) {
+    spawn(priority: priority, operation: operation)
+  }
+
   /// Add a child task to the group.
   ///
   /// ### Error handling
@@ -278,6 +286,14 @@ public struct TaskGroup<ChildTaskResult> {
   ) -> Bool {
     let optPriority: Task.Priority? = priority
     return spawnUnlessCancelled(priority: optPriority, operation: operation)
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func asyncUnlessCancelled(
+    priority: Task.Priority? = nil,
+    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) -> Bool {
+    spawnUnlessCancelled(priority: priority, operation: operation)
   }
 
   /// Add a child task to the group.
@@ -502,6 +518,14 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
     return spawn(priority: optPriority, operation: operation)
   }
 
+  @_alwaysEmitIntoClient
+  public mutating func async(
+    priority: Task.Priority? = nil,
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) {
+    spawn(priority: priority, operation: operation)
+  }
+
   /// Spawn, unconditionally, a child task in the group.
   ///
   /// ### Error handling
@@ -551,6 +575,14 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   ) -> Bool {
     let optPriority: Task.Priority? = priority
     return spawnUnlessCancelled(priority: optPriority, operation: operation)
+  }
+
+  @_alwaysEmitIntoClient
+  public mutating func asyncUnlessCancelled(
+    priority: Task.Priority? = nil,
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) -> Bool {
+    spawnUnlessCancelled(priority: priority, operation: operation)
   }
 
   /// Add a child task to the group.

--- a/test/Concurrency/async_let_isolation.swift
+++ b/test/Concurrency/async_let_isolation.swift
@@ -9,14 +9,14 @@ actor MyActor {
   func asynchronous() async -> String { synchronous() }
 
   func testAsyncLetIsolation() async {
-    spawn let x = self.synchronous()
+    async let x = self.synchronous()
 
-    spawn let y = await self.asynchronous()
+    async let y = await self.asynchronous()
 
-    spawn let z = synchronous()
+    async let z = synchronous()
 
     var localText = text
-    spawn let w = localText.removeLast() // expected-error{{mutation of captured var 'localText' in concurrently-executing code}}
+    async let w = localText.removeLast() // expected-error{{mutation of captured var 'localText' in concurrently-executing code}}
 
     _ = await x
     _ = await y
@@ -27,8 +27,8 @@ actor MyActor {
 
 func outside() async {
   let a = MyActor()
-  spawn let x = a.synchronous() // okay, await is implicit
-  spawn let y = await a.synchronous()
+  async let x = a.synchronous() // okay, await is implicit
+  async let y = await a.synchronous()
   _ = await x
   _ = await y
 }

--- a/test/Concurrency/await_typo_correction.swift
+++ b/test/Concurrency/await_typo_correction.swift
@@ -21,9 +21,8 @@ func async() throws { }
     // expected-error@+1 {{found 'async' in expression; did you mean 'await'?}}{{13-18=await}}
     let _ = async anotherAsyncFunc()
 
-    // Don't emit a diagnostic here related to 'await'
+    // Don't emit a diagnostic here
     async let foo = anotherAsyncFunc()
-    // expected-warning@-1{{'async let' is now 'spawn let'}}{{5-10=spawn}}
     let _ = await foo
 
     // I question the name choice, but it's valid

--- a/test/Concurrency/reasync.swift
+++ b/test/Concurrency/reasync.swift
@@ -149,11 +149,11 @@ func callReasyncWithAutoclosure3() {
   reasyncWithAutoclosure2("Hello \(world)")
 }
 
-//// spawn let
+//// async let
 
 func callReasyncWithAutoclosure4(_: () async -> ()) reasync {
   await reasyncFunction {
-    spawn let x = 123
+    async let x = 123
 
     _ = await x
   }

--- a/test/Parse/async.swift
+++ b/test/Parse/async.swift
@@ -75,7 +75,7 @@ func testAwaitExpr() async {
 func getIntSomeday() async -> Int { 5 }
 
 func testAsyncLet() async {
-  spawn let x = await getIntSomeday()
+  async let x = await getIntSomeday()
   _ = await x
 }
 

--- a/test/decl/var/async_let.swift
+++ b/test/decl/var/async_let.swift
@@ -3,23 +3,23 @@
 // REQUIRES: concurrency
 
 func test() async {
-  spawn let x = 1 // okay
+  async let x = 1 // okay
   _ = await x
 }
 
 struct X {
-  spawn let x = 1 // expected-error{{'spawn let' can only be used on local declarations}}
+  async let x = 1 // expected-error{{'async let' can only be used on local declarations}}
   // FIXME: expected-error@-1{{'async' call cannot occur in a property initializer}}
 }
 
 func testAsyncFunc() async {
-  spawn let (z1, z2) = (2, 3)
-  spawn let (_, _) = (2, 3)
-  spawn let x2 = 1
+  async let (z1, z2) = (2, 3)
+  async let (_, _) = (2, 3)
+  async let x2 = 1
 
-  spawn var x = 17 // expected-error{{'spawn' can only be used with 'let' declarations}}{{9-12=let}}
-  spawn let (_, _) = (1, 2), y2 = 7 // expected-error{{'spawn let' requires at least one named variable}}
-  spawn let y: Int // expected-error{{'spawn let' binding requires an initializer expression}}
+  async var x = 17 // expected-error{{'async' can only be used with 'let' declarations}}{{9-12=let}}
+  async let (_, _) = (1, 2), y2 = 7 // expected-error{{'async let' requires at least one named variable}}
+  async let y: Int // expected-error{{'async let' binding requires an initializer expression}}
   _ = await x
   _ = y
   _ = await z1
@@ -34,7 +34,7 @@ func chopVegetables() async throws -> [String] { [] }
 func marinateMeat() async -> String { "MEAT" }
 
 func cook() async throws {
-  spawn let veggies = try await chopVegetables(), meat = await marinateMeat()
+  async let veggies = try await chopVegetables(), meat = await marinateMeat()
   _ = try await veggies
   _ = await meat
 }

--- a/test/decl/var/async_let.swift
+++ b/test/decl/var/async_let.swift
@@ -42,4 +42,7 @@ func cook() async throws {
 func testInterpolation() async {
   spawn let x = "\(12345)"
   _ = await x
+
+  async let y = "\(12345)"
+  _ = await y
 }

--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -158,7 +158,7 @@ func validAsyncFunction() async throws {
   _ = try await throwingAndAsync()
 }
 
-// spawn let checking
+// Async let checking
 func mightThrow() throws { }
 
 func getIntUnsafely() throws -> Int { 0 }
@@ -169,27 +169,27 @@ extension Error {
 }
 
 func testAsyncLet() async throws {
-  spawn let x = await getInt()
+  async let x = await getInt()
   print(x) // expected-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1:9{{reference to spawn let 'x' is 'async'}}
+  // expected-note@-1:9{{reference to async let 'x' is 'async'}}
 
   print(await x)
 
   do {
     try mightThrow()
-  } catch let e where e.number == x { // expected-error{{spawn let 'x' cannot be referenced in a catch guard expression}}
+  } catch let e where e.number == x { // expected-error{{async let 'x' cannot be referenced in a catch guard expression}}
   } catch {
   }
 
-  spawn let x1 = getIntUnsafely() // okay, try is implicit here
+  async let x1 = getIntUnsafely() // okay, try is implicit here
 
-  spawn let x2 = getInt() // okay, await is implicit here
+  async let x2 = getInt() // okay, await is implicit here
 
-  spawn let x3 = try getIntUnsafely()
-  spawn let x4 = try! getIntUnsafely()
-  spawn let x5 = try? getIntUnsafely()
+  async let x3 = try getIntUnsafely()
+  async let x4 = try! getIntUnsafely()
+  async let x5 = try? getIntUnsafely()
 
-  _ = await x1 // expected-error{{reading 'spawn let' can throw but is not marked with 'try'}}
+  _ = await x1 // expected-error{{reading 'async let' can throw but is not marked with 'try'}}
   _ = await x2
   _ = try await x3
   _ = await x4
@@ -198,9 +198,9 @@ func testAsyncLet() async throws {
 
 // expected-note@+1 4{{add 'async' to function 'testAsyncLetOutOfAsync()' to make it asynchronous}} {{30-30= async}}
 func testAsyncLetOutOfAsync() {
-  spawn let x = 1 // expected-error{{'spawn let' in a function that does not support concurrency}}
+  async let x = 1 // expected-error{{'async let' in a function that does not support concurrency}}
   // FIXME: expected-error@-1{{'async' call in a function that does not support concurrency}}
 
-  _ = await x  // expected-error{{'spawn let' in a function that does not support concurrency}}
-  _ = x // expected-error{{'spawn let' in a function that does not support concurrency}}
+  _ = await x  // expected-error{{'async let' in a function that does not support concurrency}}
+  _ = x // expected-error{{'async let' in a function that does not support concurrency}}
 }

--- a/test/stmt/async.swift
+++ b/test/stmt/async.swift
@@ -6,5 +6,5 @@ func f() async -> Int { 0 }
 
 _ = await f() // expected-error{{'async' call in a function that does not support concurrency}}
 
-spawn let y = await f() // expected-error{{'spawn let' in a function that does not support concurrency}}
+async let y = await f() // expected-error{{'async let' in a function that does not support concurrency}}
 // expected-error@-1{{'async' call in a function that does not support concurrency}}


### PR DESCRIPTION
Introduce the "family" of names around `async let`:
* `async let` for child task variables
* `TaskGroup.async` for initiating async work as a child task

rdar://77658153