### PR TITLE
[5.5][TypeChecker] Clear param specifiers before re-typechecking expression for completion

### DIFF
--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -242,6 +242,9 @@ public:
       if (auto closure = dyn_cast<ClosureExpr>(expr)) {
         if (!shouldTypeCheckInEnclosingExpression(closure))
           return { false, expr };
+        for (auto &Param : *closure->getParameters()) {
+          Param->setSpecifier(swift::ParamSpecifier::Default);
+        }
       }
 
       // Now, we're ready to walk into sub expressions.

--- a/validation-test/IDE/crashers_2_fixed/sr14494.swift
+++ b/validation-test/IDE/crashers_2_fixed/sr14494.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=COMPLETE -source-filename=%s | %FileCheck %s
+
+protocol MyView {
+    associatedtype Body : MyView
+    @MyViewBuilder var body: Self.Body { get }
+}
+
+@resultBuilder public struct MyViewBuilder {
+    static func buildBlock() -> MyZStack<Never> { fatalError() }
+    static func buildBlock<Content>(_ content: Content) -> Content { content }
+}
+
+struct MyAlignment {
+  static let center: MyAlignment
+}
+
+struct MyZStack<Content> : MyView {
+    init(alignment: MyAlignment, @MyViewBuilder content: () -> Content) {
+        fatalError()
+    }
+
+    func my_updating<State>(body: (inout State) -> Void) {}
+}
+
+struct BottomMenu: MyView {
+    var body: some MyView {
+        let a = MyZStack(alignment: .#^COMPLETE^#center, content: {})
+        .my_updating(body: { state in
+            state = false
+        })
+    }
+}
+
+// CHECK: Begin completions, 2 items
+// CHECK: Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: center[#MyAlignment#]; name=center
+// CHECK: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init()[#MyAlignment#]; name=init()
+// CHECK: End completions


### PR DESCRIPTION
Cherry-picking https://github.com/apple/swift/pull/36992 to 5.5

--------------------


Because we are completing inside a result builder, we are never calling into `typeCheckExpression` and thus never call into `typeCheckForCodeCompletion` before `fallbackTypeCheck` (SR-14601).

This works fine in most cases, but in the added test case, we are hitting an assertion because the specifiers are not correctly erased from the `ClosureExpr` before re-typechecking for completion. Erasing them before fixes the test case until the underlying issue described above is fixed.

Fixes rdar://76710904 [SR-14494]