### PR TITLE
Disable test stdlib/PrintFloat.swift.gyb on arm64_32 watchos

### DIFF
--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -6,6 +6,9 @@
 // RUN: %line-directive %t/FloatingPointPrinting.swift -- %target-run %t/main.out --locale ru_RU.UTF-8
 // REQUIRES: executable_test
 
+// rdar://77087867
+// UNSUPPORTED: CPU=arm64_32 && OS=watchos
+
 import StdlibUnittest
 #if canImport(Darwin)
   import Darwin


### PR DESCRIPTION
It fails on a bot.

rdar://77087867