### PR TITLE
Disable executor_deinit1.swift test in optimized mode

### DIFF
--- a/test/Concurrency/Runtime/executor_deinit1.swift
+++ b/test/Concurrency/Runtime/executor_deinit1.swift
@@ -9,6 +9,10 @@
 // https://bugs.swift.org/browse/SR-14461
 // UNSUPPORTED: linux
 
+// rdar://77658743
+// UNSUPPORTED: swift_test_mode_optimize
+// UNSUPPORTED: swift_test_mode_optimize_size
+
 
 // doesn't matter that it's bool identity function or not
 func boolIdentityFn(_ x : Bool) -> Bool { return x }


### PR DESCRIPTION
It fails on some bots.

rdar://77658743