### PR TITLE
LIT argument --incremental is deprecated

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -128,12 +128,6 @@ endfunction()
 
 set(LIT "${LLVM_MAIN_SRC_DIR}/utils/lit/lit.py")
 
-# Incremental mode in lit orders test files by the last modification time
-# instead of by the path, which is good for CI. In this mode lit also updates
-# the mtime on the failed tests, which makes them run first on the
-# consecutive execution, which makes local builds fail faster.
-set(SWIFT_LIT_ARGS "--incremental" CACHE STRING "Arguments to pass to lit")
-
 set(SWIFT_LIT_ENVIRONMENT "" CACHE STRING "Environment to use for lit invocations")
 
 if(NOT SWIFT_INCLUDE_TOOLS)


### PR DESCRIPTION
```
WARNING: --incremental is deprecated. Failing tests now always run first.
```
