### PR TITLE
[TypeChecker] NFC: Complicate perf test-case expression by adding mor…

### DIFF
--- a/validation-test/Sema/type_checker_perf/slow/rdar19737632.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar19737632.swift
@@ -1,11 +1,10 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
 // REQUIRES: tools-release,no_asan
 
-// rdar://77656775
-// UNSUPPORTED: CPU=arm64 && OS=macosx
-
 let a = "a"
 let b = "b"
 let c = 42
-_ = "a=" + a + ";b=" + b + ";c=" + c
+let d = 0.0
+
+_ = "a=" + a + ";b=" + b + ";c=" + c + ";d=" + d
 // expected-error@-1 {{reasonable time}}


### PR DESCRIPTION
…e operators

This test has become flaky in different configurations due to a varying
number of available operator overloads, let's use more operators to make
sure that it's "too complex" regardless of configuration.

Resolves: rdar://77656775

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
