### PR TITLE
[5.5][CSBindings] Don't infer subtypes/supertype bindings for a closure type

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1646,6 +1646,15 @@ bool TypeVarBindingProducer::computeNext() {
     newBindings.push_back(std::move(binding));
   };
 
+  // Let's attempt only directly inferrable bindings for
+  // a type variable representing a closure type because
+  // such type variables are handled specially and only
+  // bound to a type inferred from their expression, having
+  // contextual bindings is just a trigger for that to
+  // happen.
+  if (TypeVar->getImpl().isClosureType())
+    return false;
+
   for (auto &binding : Bindings) {
     const auto type = binding.BindingType;
     assert(!type->hasError());

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1105,3 +1105,12 @@ struct R_76250381<Result, Failure: Error> {
 // expected-error@-1 {{contextual closure type '(Range<Int>.Element) throws -> ()' (aka '(Int) throws -> ()') expects 1 argument, but 3 were used in closure body}}
 (0..<10).map { x, y, z, w in } 
 // expected-error@-1 {{contextual closure type '(Range<Int>.Element) throws -> ()' (aka '(Int) throws -> ()') expects 1 argument, but 4 were used in closure body}}
+
+// rdar://77022842 - crash due to a missing argument to a ternary operator
+func rdar77022842(argA: Bool? = nil, argB: Bool? = nil) {
+  if let a = argA ?? false, if let b = argB ?? {
+    // expected-error@-1 {{initializer for conditional binding must have Optional type, not 'Bool'}}
+    // expected-error@-2 {{cannot convert value of type '() -> ()' to expected argument type 'Bool?'}}
+    // expected-error@-3 {{expected expression in conditional}}
+  } // expected-error {{expected '{' after 'if' condition}}
+}


### PR DESCRIPTION
- Explanation:

Fixes a crash during invalid solution application which was formed
due to incorrect inference of a closure type.

A type representing a closure expression is always bound to its
"inferred" type based on the body, so contextual bindings just
serve as a trigger to "resolve" a closure. Let's not attempt any
subtype/supertype inference for a type variable representing a
closure since if "direct" bindings have failed, it wouldn't be bound
to such types regardless.

- Scope: Invalid expressions where closure is passed to a parameter represented by generic parameter wrapped into an optional or similar situation when it's possible to "infer" subtype/supertype bindings based on direct ones.

- Main Branch PR: https://github.com/apple/swift/pull/37292

- Resolves: rdar://77022842

- Risk: Very low

- Reviewed By: @hborla 

- Testing: Regression tests added to the suite

Resolves: rdar://77022842
(cherry picked from commit 3c0388d9458733c32940f9ed25bb35b9742ea9aa)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
