### PR TITLE
[5.5][SILGen] Fix a miscompile when emitting the application of a wrapped parameter

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5258,7 +5258,7 @@ RValue RValueEmitter::visitPropertyWrapperValuePlaceholderExpr(
 RValue RValueEmitter::visitAppliedPropertyWrapperExpr(
     AppliedPropertyWrapperExpr *E, SGFContext C) {
   auto *param = const_cast<ParamDecl *>(E->getParamDecl());
-  auto argument = visit(E->getValue(), C);
+  auto argument = visit(E->getValue());
   SILDeclRef::Kind initKind;
   switch (E->getValueKind()) {
   case swift::AppliedPropertyWrapperExpr::ValueKind::WrappedValue:

--- a/test/SILGen/property_wrapper_parameter.swift
+++ b/test/SILGen/property_wrapper_parameter.swift
@@ -1,4 +1,7 @@
-// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t -enable-library-evolution %S/Inputs/def_structA.swift
+// RUN: %target-swift-emit-silgen %s -I %t | %FileCheck %s
+import def_structA
 
 public struct Projection<T> {
   public var wrappedValue: T
@@ -282,4 +285,19 @@ func testNonmutatingSetterSynthesis(@NonmutatingSetter value: Int) {
   // setter of value #1 in closure #1 in implicit closure #1 in testNonmutatingSetterSynthesis(value:)
   // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter30testNonmutatingSetterSynthesis5valueyAA0eF0VySiG_tFSiAFcfu_SiAFcfU_ACL_Sivs : $@convention(thin) (Int, NonmutatingSetter<Int>) -> ()
   // CHECK: function_ref @$s26property_wrapper_parameter17NonmutatingSetterV12wrappedValuexvs : $@convention(method) <τ_0_0> (@in τ_0_0, NonmutatingSetter<τ_0_0>) -> ()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter38testImplicitWrapperWithResilientStructyyF : $@convention(thin) () -> ()
+func testImplicitWrapperWithResilientStruct() {
+  let _: (ProjectionWrapper<A>) -> Void = { $value in }
+
+  // implicit closure #1 in testImplicitWrapperWithResilientStruct()
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter38testImplicitWrapperWithResilientStructyyFyAA010ProjectionF0Vy11def_structA1AVGcfu_ : $@convention(thin) (@in_guaranteed ProjectionWrapper<A>) -> ()
+  // CHECK: [[P:%.*]] = alloc_stack $ProjectionWrapper<A>
+  // CHECK: copy_addr %0 to [initialization] [[P]]
+  // CHECK: [[I:%.*]] = function_ref @$s26property_wrapper_parameter38testImplicitWrapperWithResilientStructyyFyAA010ProjectionF0Vy11def_structA1AVGcfu_yAHcfU_6$valueL_AHvpfW : $@convention(thin) (@in ProjectionWrapper<A>) -> @out ProjectionWrapper<A>
+  // CHECK: apply [[I]]({{.*}}, [[P]]) : $@convention(thin) (@in ProjectionWrapper<A>) -> @out ProjectionWrapper<A>
+
+  // property wrapper init from projected value of $value #1 in closure #1 in implicit closure #1 in testImplicitWrapperWithResilientStruct()
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter38testImplicitWrapperWithResilientStructyyFyAA010ProjectionF0Vy11def_structA1AVGcfu_yAHcfU_6$valueL_AHvpfW : $@convention(thin) (@in ProjectionWrapper<A>) -> @out ProjectionWrapper<A>
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/37301

- **Explanation**: Extending property wrappers to parameters added a new way to invoke property wrapper generator functions. When emitting a call to the generator function for wrapped parameters, SILGen passed down the `SGFContext` when emitting the r-value of the argument. This caused a miscompile when the argument was an address-only type (e.g. a resilient type), because the argument was incorrectly initialized in place using the context, which was meant for the result of the generator function. The caller ended up overwriting the initialization with the result of the generator function anyway, and the r-value of the argument was never emitted, which violated ownership rules. The solution is to simply not pass down the context when emitting the argument.

- **Scope**: The scope is limited to property wrappers on function and closure parameters.

- **Risk**: Low risk. `SGFContext` is just an optimization, so not including it will not impact the correctness of emitting an r-value.

- **Testing**: Added an automated test to ensure that the problematic case does not violate any ownership rules. Without this change, the added test trips up the SIL verifier with `SIL verification failed: Found mutating or consuming use of an in_guaranteed parameter?!: !ImmutableAddressUseVerifier().isMutatingOrConsuming(fArg)`.

- **Reviewer**: @slavapestov 

Resolves: rdar://77572130