### PR TITLE
[5.5] In DI, cache whether a memory object is a box

### DIFF
--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
@@ -72,6 +72,9 @@ class DIMemoryObjectInfo {
   /// non-empty.
   bool HasDummyElement = false;
 
+  /// True if this object has a single user of type ProjectBoxInst.
+  bool IsBox = false;
+
 public:
   DIMemoryObjectInfo(MarkUninitializedInst *MemoryInst);
 
@@ -98,8 +101,12 @@ public:
   /// instruction. For alloc_box though it returns the project_box associated
   /// with the memory info.
   SingleValueInstruction *getUninitializedValue() const {
-    if (auto *pbi = MemoryInst->getSingleUserOfType<ProjectBoxInst>())
+    if (IsBox) {
+      // TODO: consider just storing the ProjectBoxInst in this case.
+      auto *pbi = MemoryInst->getSingleUserOfType<ProjectBoxInst>();
+      assert(pbi);
       return pbi;
+    }
     return MemoryInst;
   }
 


### PR DESCRIPTION
Boxes tend to have a small number of uses, so frequently finding the unique projection isn't too bad. Non-boxes, however, can have a large number of uses: for example, a class instance has expected uses proportionate to the number of stored properties. So if we do a linear scan of the uses on a non-box instruction, we'll scale quadratically.

Fixes SR-14532. 5.5 version of #37328

Explanation: Avoid a quadratic slowdown in DI in class initializers when a class reference has many uses.  This is typical when a class has a large number of properties.
Scope: The change is to Swift’s definitive initialization pass, which is run on all functions
Risk: Low
Testing: Manual; no straightforward way to test future regressions here
Issue: rdar://77217125
Reviewer: Erik Eckstein