### PR TITLE
Add a missing check for the number of children before accessing them.

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -2477,6 +2477,9 @@ private:
     // Use private declaration names for anonymous context references.
     if (parentDemangling->getKind() == Node::Kind::AnonymousContext
         && nameNode->getKind() == Node::Kind::Identifier) {
+      if (parentDemangling->getNumChildren() < 2)
+        return nullptr;
+
       auto privateDeclName =
         dem.createNode(Node::Kind::PrivateDeclName);
       privateDeclName->addChild(parentDemangling->getChild(0), dem);


### PR DESCRIPTION
`parentDemangling` is going to be added as the first child of the return node, so we can't construct one unless we have both children.

rdar://77530286
