### PR TITLE
Add a missing check for the number of children before accessing them.

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -2474,6 +2474,9 @@ private:
     // Use private declaration names for anonymous context references.
     if (parentDemangling->getKind() == Node::Kind::AnonymousContext
         && nameNode->getKind() == Node::Kind::Identifier) {
+      if (parentDemangling->getNumChildren() < 2)
+        return nullptr;
+
       auto privateDeclName =
         dem.createNode(Node::Kind::PrivateDeclName);
       privateDeclName->addChild(parentDemangling->getChild(0), dem);


### PR DESCRIPTION
parentDemangling is going to be added as the first child of the return node, so
we can't construct one unless we have both children.

rdar://77530286
(cherry picked from commit a50c048aa06f5aa5d55d01eafdce5c22d876cf51)

• Explanation: Fix a crash in LLDB by adding missing error handling in MetadataReader.h in the Swift repository.
• Scope: LLDB
• Risk: Low
• Issue: rdar://77530286
• Reviewer: Joe Groff @jckarter