### PR TITLE
Change the name of the hasSuffix argument of the StringProtocol requirement to `suffix` from `prefix`.

### DIFF
--- a/stdlib/public/core/StringProtocol.swift
+++ b/stdlib/public/core/StringProtocol.swift
@@ -43,7 +43,7 @@ public protocol StringProtocol
   var unicodeScalars: UnicodeScalarView { get }
 
   func hasPrefix(_ prefix: String) -> Bool
-  func hasSuffix(_ prefix: String) -> Bool
+  func hasSuffix(_ suffix: String) -> Bool
 
   func lowercased() -> String
   func uppercased() -> String


### PR DESCRIPTION
[SR-14611](https://bugs.swift.org/browse/SR-14611)

<!-- What's in this pull request? -->
https://github.com/apple/swift/blob/7f4a1d5e20b4f43192d2cee9dd40a6869dba7f82/stdlib/public/core/StringProtocol.swift#L46
The argument of `hasSuffix` that `StringProtocol` requires is currently wrongly named. This PR replaces its name into `suffix` from `prefix`.  

Because the argument is labeled as `_`, this is an internal change. It wouldn't affect anywhere.

I posted a question on the [forum](https://forums.swift.org/t/why-stringprotocol-hassuffix-has-argument-prefix/47976) just in case. I'm sorry if there is some purpose to name that `prefix`.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
