### PR TITLE
Add CanonicalName to mock SDKSettings.json

### DIFF
--- a/test/Driver/Inputs/MacOSX10.15.4.versioned.sdk/SDKSettings.json
+++ b/test/Driver/Inputs/MacOSX10.15.4.versioned.sdk/SDKSettings.json
@@ -1,5 +1,6 @@
 {
   "Version":"10.15.4",
+  "CanonicalName": "macosx10.15.4",
   "VersionMap" : {
       "macOS_iOSMac" : {
           "10.14.4" : "12.4",

--- a/test/Driver/Inputs/MacOSX10.15.versioned.sdk/SDKSettings.json
+++ b/test/Driver/Inputs/MacOSX10.15.versioned.sdk/SDKSettings.json
@@ -1,5 +1,6 @@
 {
   "Version":"10.15",
+  "CanonicalName": "macosx10.15",
   "VersionMap" : {
       "macOS_iOSMac" : {
           "10.15" : "13.1",


### PR DESCRIPTION
`swift-driver` expects `CanonicalName` field.

Fixes `Driver/macabi-environment.swift` and `Driver/sdk-version.swift` for `swift-driver`