### PR TITLE
[TaskLocals] Enable sync functions to bind task-locals; Keep Storage in TLS

### DIFF
--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -271,8 +271,9 @@ public:
     return Local.getValue(this, key);
   }
 
-  void localValuePop() {
-    Local.popValue(this);
+  /// Returns true if storage has still more bindings.
+  bool localValuePop() {
+    return Local.popValue(this);
   }
 
   // ==== Child Fragment -------------------------------------------------------

--- a/include/swift/ABI/TaskLocal.h
+++ b/include/swift/ABI/TaskLocal.h
@@ -118,6 +118,8 @@ public:
         reinterpret_cast<char *>(this) + storageOffset(valueType));
     }
 
+    void copyTo(AsyncTask *task);
+
     /// Compute the offset of the storage from the base of the item.
     static size_t storageOffset(const Metadata *valueType) {
       size_t offset = sizeof(Item);
@@ -188,6 +190,18 @@ public:
     /// and `false` if the just popped value was the last one and the storage
     /// can be safely disposed of.
     bool popValue(AsyncTask *task);
+
+    /// Copy all task-local bindings to the target task.
+    ///
+    /// The new bindings allocate their own items and can out-live the current task.
+    ///
+    /// ### Optimizations
+    /// Only the most recent binding of a value is copied over, i.e. given
+    /// a key bound to `A` and then `B`, only the `B` binding will be copied.
+    /// This is safe and correct because the new task would never have a chance
+    /// to observe the `A` value, because it semantically will never observe a
+    /// "pop" of the `B` value - it was spawned from a scope where only B was observable.
+    void copyTo(AsyncTask *target);
 
     /// Destroy and deallocate all items stored by this specific task.
     ///

--- a/include/swift/ABI/TaskLocal.h
+++ b/include/swift/ABI/TaskLocal.h
@@ -184,7 +184,10 @@ public:
 
     OpaqueValue* getValue(AsyncTask *task, const HeapObject *key);
 
-    void popValue(AsyncTask *task);
+    /// Returns `true` of more bindings remain in this storage,
+    /// and `false` if the just popped value was the last one and the storage
+    /// can be safely disposed of.
+    bool popValue(AsyncTask *task);
 
     /// Destroy and deallocate all items stored by this specific task.
     ///

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -480,6 +480,16 @@ void swift_task_localValuePush(const HeapObject *key,
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_localValuePop();
 
+/// Copy all task locals from the current context to the target task.
+///
+/// Its Swift signature is
+///
+/// \code
+/// func _taskLocalValueGet<Key>(AsyncTask* task)
+/// \endcode
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_task_localsCopyTo(AsyncTask* target);
+
 /// This should have the same representation as an enum like this:
 ///    enum NearestTaskDeadline {
 ///      case none

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -433,50 +433,52 @@ void swift_task_reportIllegalTaskLocalBindingWithinWithTaskGroup(
     const unsigned char *file, uintptr_t fileLength,
     bool fileIsASCII, uintptr_t line);
 
-/// Get a task local value from the passed in task. Its Swift signature is
+/// Get a task local value from either the current task, or fallback task-local
+/// storage.
+///
+/// Its Swift signature is
 ///
 /// \code
 /// func _taskLocalValueGet<Key>(
-///   _ task: Builtin.NativeObject,
 ///   keyType: Any.Type /*Key.Type*/
 /// ) -> UnsafeMutableRawPointer? where Key: TaskLocalKey
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 OpaqueValue*
-swift_task_localValueGet(AsyncTask* task, const HeapObject *key);
+swift_task_localValueGet(const HeapObject *key);
 
-/// Add a task local value to the passed in task.
-///
-/// This must be only invoked by the task itself to avoid concurrent writes.
+/// Bind a task local key to a value in the context of either the current
+/// AsyncTask if present, or in the thread-local fallback context if no task
+/// available.
 ///
 /// Its Swift signature is
 ///
 /// \code
 ///  public func _taskLocalValuePush<Value>(
-///    _ task: Builtin.NativeObject,
 ///    keyType: Any.Type/*Key.Type*/,
 ///    value: __owned Value
 ///  )
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-void swift_task_localValuePush(AsyncTask* task,
-                         const HeapObject *key,
-                         /* +1 */ OpaqueValue *value,
-                         const Metadata *valueType);
+void swift_task_localValuePush(const HeapObject *key,
+                                   /* +1 */ OpaqueValue *value,
+                                   const Metadata *valueType);
 
-/// Remove task a local binding from the task local values stack.
+/// Pop a single task local binding from the binding stack of the current task,
+/// or the fallback thread-local storage if no task is available.
 ///
-/// This must be only invoked by the task itself to avoid concurrent writes.
+/// This operation must be paired up with a preceding "push" operation, as otherwise
+/// it may attempt to "pop" off an empty value stuck which will lead to a crash.
+///
+/// The Swift surface API ensures proper pairing of push and pop operations.
 ///
 /// Its Swift signature is
 ///
 /// \code
-///  public func _taskLocalValuePop(
-///    _ task: Builtin.NativeObject
-///  )
+///  public func _taskLocalValuePop()
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-void swift_task_localValuePop(AsyncTask* task);
+void swift_task_localValuePop();
 
 /// This should have the same representation as an enum like this:
 ///    enum NearestTaskDeadline {

--- a/include/swift/Runtime/ThreadLocal.h
+++ b/include/swift/Runtime/ThreadLocal.h
@@ -65,7 +65,7 @@ namespace swift {
 //   itself thread-local, and no internal support is required.
 //
 //   Note that this includes platforms that set
-//   SWIFT_STDLIB_SINGLE_THREADED_RUNTIME, for whhch
+//   SWIFT_STDLIB_SINGLE_THREADED_RUNTIME, for which
 //   SWIFT_RUNTIME_ATTRIBUTE_THREAD_LOCAL is empty;
 //   thread-local declarations then create an ordinary global.
 //

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -233,19 +233,19 @@ OVERRIDE_TASK_LOCAL(task_reportIllegalTaskLocalBindingWithinWithTaskGroup, void,
 OVERRIDE_TASK_LOCAL(task_localValuePush, void,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                     swift::,
-                    (AsyncTask *task, const HeapObject *key,
-                     OpaqueValue *value, const Metadata *valueType),
-                    (task, key, value, valueType))
+                    (const HeapObject *key, OpaqueValue *value,
+                     const Metadata *valueType),
+                    (key, value, valueType))
 
 OVERRIDE_TASK_LOCAL(task_localValueGet, OpaqueValue *,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                     swift::,
-                    (AsyncTask *task, const HeapObject *key),
-                    (task, key))
+                    (const HeapObject *key),
+                    (key))
 
 OVERRIDE_TASK_LOCAL(task_localValuePop, void,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
-                    swift::, (AsyncTask *task), (task))
+                    swift::, ,)
 
 OVERRIDE_TASK_STATUS(task_addStatusRecord, bool,
                      SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -247,6 +247,12 @@ OVERRIDE_TASK_LOCAL(task_localValuePop, void,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                     swift::, ,)
 
+OVERRIDE_TASK_LOCAL(task_localsCopyTo, void,
+                    SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
+                    swift::,
+                    (AsyncTask *target),
+                    (target))
+
 OVERRIDE_TASK_STATUS(task_addStatusRecord, bool,
                      SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                      swift::, (TaskStatusRecord *newRecord), (newRecord))

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -195,6 +195,10 @@ AsyncTask::~AsyncTask() {
   }
 
   // Release any objects potentially held as task local values.
+  //
+  // This must be called last when destroying a task - to keep stack discipline of the allocator.
+  // because it may have created some task-locals immediately upon creation,
+  // e.g. if the task is spawned with async{} and inherited some task-locals.
   Local.destroy(this);
 }
 

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -535,6 +535,15 @@ public func async<T>(
   // Create the asynchronous task future.
   let (task, _) = Builtin.createAsyncTaskFuture(flags.bits, operation)
 
+  // Copy all task locals to the newly created task.
+  // We must copy them rather than point to the current task since the new task
+  // is not structured and may out-live the current task.
+  //
+  // WARNING: This MUST be done BEFORE we enqueue the task,
+  // because it acts as-if it was running inside the task and thus does not
+  // take any extra steps to synchronize the task-local operations.
+  _taskLocalsCopy(to: task)
+
   // Enqueue the resulting job.
   _enqueueJobGlobal(Builtin.convertTaskToJob(task))
 

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -212,20 +212,26 @@ public final class TaskLocal<Value>: UnsafeSendable, CustomStringConvertible {
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_localValuePush")
-public func _taskLocalValuePush<Value>(
+func _taskLocalValuePush<Value>(
   key: Builtin.RawPointer/*: Key*/,
   value: __owned Value
 ) // where Key: TaskLocal
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_localValuePop")
-public func _taskLocalValuePop()
+func _taskLocalValuePop()
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_localValueGet")
-public func _taskLocalValueGet(
+func _taskLocalValueGet(
   key: Builtin.RawPointer/*Key*/
 ) -> UnsafeMutableRawPointer? // where Key: TaskLocal
+
+@available(SwiftStdlib 5.5, *)
+@_silgen_name("swift_task_localsCopyTo")
+func _taskLocalsCopy(
+  to target: Builtin.NativeObject
+)
 
 // ==== Checks -----------------------------------------------------------------
 

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -87,7 +87,6 @@ import Swift
 ///       }
 ///     }
 ///
-///
 ///     func call() {
 ///       print("traceID: \(traceID)") // 1234
 ///     }
@@ -114,25 +113,17 @@ public final class TaskLocal<Value>: UnsafeSendable, CustomStringConvertible {
   /// or if the task-local has no value bound, this will return the `defaultValue`
   /// of the task local.
   public func get() -> Value {
-    withUnsafeCurrentTask { task in
-      guard let task = task else {
-        return self.defaultValue
-      }
-
-      let value = _taskLocalValueGet(task._task, key: key)
-
-      guard let rawValue = value else {
-        return self.defaultValue
-      }
-
-      // Take the value; The type should be correct by construction
-      let storagePtr =
-          rawValue.bindMemory(to: Value.self, capacity: 1)
-      return UnsafeMutablePointer<Value>(mutating: storagePtr).pointee
+    guard let rawValue = _taskLocalValueGet(key: key) else {
+      return self.defaultValue
     }
+
+    // Take the value; The type should be correct by construction
+    let storagePtr =
+        rawValue.bindMemory(to: Value.self, capacity: 1)
+    return UnsafeMutablePointer<Value>(mutating: storagePtr).pointee
   }
 
-  /// Binds the task-local to the specific value for the duration of the operation.
+  /// Binds the task-local to the specific value for the duration of the asynchronous operation.
   ///
   /// The value is available throughout the execution of the operation closure,
   /// including any `get` operations performed by child-tasks created during the
@@ -150,16 +141,34 @@ public final class TaskLocal<Value>: UnsafeSendable, CustomStringConvertible {
     // check if we're not trying to bind a value from an illegal context; this may crash
     _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: file, line: line)
 
-    // we need to escape the `_task` since the withUnsafeCurrentTask closure is not `async`.
-    // this is safe, since we know the task will remain alive because we are running inside of it.
-    let _task = withUnsafeCurrentTask { task in
-      task!._task // !-safe, guaranteed to have task available inside async function
-    }
-
-    _taskLocalValuePush(_task, key: key, value: valueDuringOperation)
-    defer { _taskLocalValuePop(_task) }
+    _taskLocalValuePush(key: key, value: valueDuringOperation)
+    defer { _taskLocalValuePop() }
 
     return try await operation()
+  }
+
+  /// Binds the task-local to the specific value for the duration of the synchronous operation.
+  ///
+  /// The value is available throughout the execution of the operation closure,
+  /// including any `get` operations performed by child-tasks created during the
+  /// execution of the operation closure.
+  ///
+  /// If the same task-local is bound multiple times, be it in the same task, or
+  /// in specific child tasks, the more specific (i.e. "deeper") binding is
+  /// returned when the value is read.
+  ///
+  /// If the value is a reference type, it will be retained for the duration of
+  /// the operation closure.
+  @discardableResult
+  public func withValue<R>(_ valueDuringOperation: Value, operation: () throws -> R,
+                           file: String = #file, line: UInt = #line) rethrows -> R {
+    // check if we're not trying to bind a value from an illegal context; this may crash
+    _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: file, line: line)
+
+    _taskLocalValuePush(key: key, value: valueDuringOperation)
+    defer { _taskLocalValuePop() }
+
+    return try operation()
   }
 
   public var projectedValue: TaskLocal<Value> {
@@ -199,50 +208,22 @@ public final class TaskLocal<Value>: UnsafeSendable, CustomStringConvertible {
 
 }
 
-@available(SwiftStdlib 5.5, *)
-extension UnsafeCurrentTask {
-
-  /// Allows for executing a synchronous `operation` while binding a task-local value
-  /// in the current task.
-  ///
-  /// This function MUST NOT be invoked by any other task than the current task
-  /// represented by this object.
-  @discardableResult
-  public func withTaskLocal<Value, R>(
-      _ taskLocal: TaskLocal<Value>,
-      boundTo valueDuringOperation: Value,
-      operation: () throws -> R,
-      file: String = #file, line: UInt = #line) rethrows -> R {
-    // check if we're not trying to bind a value from an illegal context; this may crash
-    _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: file, line: line)
-
-    _taskLocalValuePush(self._task, key: taskLocal.key, value: valueDuringOperation)
-    defer { _taskLocalValuePop(_task) }
-
-    return try operation()
-  }
-}
-
 // ==== ------------------------------------------------------------------------
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_localValuePush")
 public func _taskLocalValuePush<Value>(
-  _ task: Builtin.NativeObject,
   key: Builtin.RawPointer/*: Key*/,
   value: __owned Value
 ) // where Key: TaskLocal
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_localValuePop")
-public func _taskLocalValuePop(
-  _ task: Builtin.NativeObject
-)
+public func _taskLocalValuePop()
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_localValueGet")
 public func _taskLocalValueGet(
-  _ task: Builtin.NativeObject,
   key: Builtin.RawPointer/*Key*/
 ) -> UnsafeMutableRawPointer? // where Key: TaskLocal
 

--- a/test/Concurrency/Runtime/async_task_locals_basic.swift
+++ b/test/Concurrency/Runtime/async_task_locals_basic.swift
@@ -46,6 +46,16 @@ final class ClassTaskLocal: Sendable {
 
 @available(SwiftStdlib 5.5, *)
 @discardableResult
+func printTaskLocalAsync<V>(
+    _ key: TaskLocal<V>,
+    _ expected: V? = nil,
+    file: String = #file, line: UInt = #line
+) async -> V? {
+  printTaskLocal(key, expected, file: file, line: line)
+}
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
     _ expected: V? = nil,
@@ -65,14 +75,14 @@ func printTaskLocal<V>(
 @available(SwiftStdlib 5.5, *)
 func simple() async {
   printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (0)
-  await TL.$number.withValue(1) {
+  TL.$number.withValue(1) {
     printTaskLocal(TL.$number) // CHECK-NEXT: TaskLocal<Int>(defaultValue: 0) (1)
   }
 }
 
 @available(SwiftStdlib 5.5, *)
 func simple_deinit() async {
-  await TL.$clazz.withValue(ClassTaskLocal()) {
+  TL.$clazz.withValue(ClassTaskLocal()) {
     // CHECK: clazz init [[C:.*]]
     printTaskLocal(TL.$clazz) // CHECK: TaskLocal<Optional<ClassTaskLocal>>(defaultValue: nil) (Optional(main.ClassTaskLocal))
   }
@@ -86,7 +96,7 @@ struct Boom: Error {
 @available(SwiftStdlib 5.5, *)
 func simple_throw() async {
   do {
-    try await TL.$clazz.withValue(ClassTaskLocal()) {
+    try TL.$clazz.withValue(ClassTaskLocal()) {
       throw Boom(value: "oh no!")
     }
   } catch {
@@ -98,10 +108,10 @@ func simple_throw() async {
 @available(SwiftStdlib 5.5, *)
 func nested() async {
   printTaskLocal(TL.$string) // CHECK: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
-  await TL.$string.withValue("hello") {
+  TL.$string.withValue("hello") {
     printTaskLocal(TL.$number) // CHECK-NEXT: TaskLocal<Int>(defaultValue: 0) (0)
     printTaskLocal(TL.$string)// CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (hello)
-    await TL.$number.withValue(2) {
+    TL.$number.withValue(2) {
       printTaskLocal(TL.$number) // CHECK-NEXT: TaskLocal<Int>(defaultValue: 0) (2)
       printTaskLocal(TL.$string, "hello") // CHECK: TaskLocal<String>(defaultValue: <undefined>) (hello)
     }
@@ -115,11 +125,11 @@ func nested() async {
 @available(SwiftStdlib 5.5, *)
 func nested_allContribute() async {
   printTaskLocal(TL.$string) // CHECK: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
-  await TL.$string.withValue("one") {
+  TL.$string.withValue("one") {
     printTaskLocal(TL.$string, "one")// CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (one)
-    await TL.$string.withValue("two") {
+    TL.$string.withValue("two") {
       printTaskLocal(TL.$string, "two") // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (two)
-      await TL.$string.withValue("three") {
+      TL.$string.withValue("three") {
         printTaskLocal(TL.$string, "three") // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (three)
       }
       printTaskLocal(TL.$string, "two") // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (two)
@@ -132,11 +142,11 @@ func nested_allContribute() async {
 @available(SwiftStdlib 5.5, *)
 func nested_3_onlyTopContributes() async {
   printTaskLocal(TL.$string) // CHECK: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
-  await TL.$string.withValue("one") {
+  TL.$string.withValue("one") {
     printTaskLocal(TL.$string)// CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (one)
-    await TL.$number.withValue(2) {
+    TL.$number.withValue(2) {
       printTaskLocal(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (one)
-      await TL.$number.withValue(3) {
+      TL.$number.withValue(3) {
         printTaskLocal(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (one)
       }
       printTaskLocal(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (one)
@@ -146,10 +156,44 @@ func nested_3_onlyTopContributes() async {
   printTaskLocal(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+func nested_3_onlyTopContributesAsync() async {
+  await printTaskLocalAsync(TL.$string) // CHECK: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
+  await TL.$string.withValue("one") {
+    await printTaskLocalAsync(TL.$string)// CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (one)
+    await TL.$number.withValue(2) {
+      await printTaskLocalAsync(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (one)
+      await TL.$number.withValue(3) {
+        await printTaskLocalAsync(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (one)
+      }
+      await printTaskLocalAsync(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (one)
+    }
+    await printTaskLocalAsync(TL.$string)// CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (one)
+  }
+  await printTaskLocalAsync(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
+}
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+func nested_3_onlyTopContributesMixed() async {
+  await printTaskLocalAsync(TL.$string) // CHECK: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
+  await TL.$string.withValue("one") {
+    await printTaskLocalAsync(TL.$string)// CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (one)
+    await TL.$number.withValue(2) {
+      printTaskLocal(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (one)
+      TL.$number.withValue(3) {
+        printTaskLocal(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (one)
+      }
+      await printTaskLocalAsync(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (one)
+    }
+    await printTaskLocalAsync(TL.$string)// CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (one)
+  }
+  await printTaskLocalAsync(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
+}
+
 @available(SwiftStdlib 5.5, *)
 func withLocal_body_mustNotEscape() async {
   var something = "Nice"
-  await TL.$string.withValue("xxx") {
+  TL.$string.withValue("xxx") {
     something = "very nice"
   }
   _ = something // silence not used warning
@@ -164,5 +208,7 @@ func withLocal_body_mustNotEscape() async {
     await nested()
     await nested_allContribute()
     await nested_3_onlyTopContributes()
+    await nested_3_onlyTopContributesAsync()
+    await nested_3_onlyTopContributesMixed()
   }
 }

--- a/test/Concurrency/Runtime/async_task_locals_copy_to_async.swift
+++ b/test/Concurrency/Runtime/async_task_locals_copy_to_async.swift
@@ -1,0 +1,90 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency -parse-as-library %import-libdispatch) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+enum TL {
+  @TaskLocal
+  static var number: Int = 0
+  @TaskLocal
+  static var other: Int = 0
+}
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@discardableResult
+func printTaskLocal<V>(
+    _ key: TaskLocal<V>,
+    _ expected: V? = nil,
+    file: String = #file, line: UInt = #line
+) -> V? {
+  let value = key.get()
+  print("\(key) (\(value)) at \(file):\(line)")
+  if let expected = expected {
+    assert("\(expected)" == "\(value)",
+        "Expected [\(expected)] but found: \(value), at \(file):\(line)")
+  }
+  return expected
+}
+
+// ==== ------------------------------------------------------------------------
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+func copyTo_async() async {
+  await TL.$number.withValue(1111) {
+    printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (1111)
+
+    await TL.$number.withValue(2222) {
+      await TL.$other.withValue(9999) {
+        printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (2222)
+        printTaskLocal(TL.$other) // CHECK: TaskLocal<Int>(defaultValue: 0) (9999)
+        let handle = async {
+          printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (2222)
+          printTaskLocal(TL.$other) // CHECK: TaskLocal<Int>(defaultValue: 0) (9999)
+          TL.$number.withValue(3333) {
+            printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (3333)
+            printTaskLocal(TL.$other) // CHECK: TaskLocal<Int>(defaultValue: 0) (9999)
+          }
+        }
+
+        _ = await handle.get()
+      }
+    }
+  }
+}
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+func copyTo_async_noWait() async {
+  print(#function)
+  TL.$number.withValue(1111) {
+    TL.$number.withValue(2222) {
+      TL.$other.withValue(9999) {
+        async {
+          printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (2222)
+          printTaskLocal(TL.$other) // CHECK: TaskLocal<Int>(defaultValue: 0) (9999)
+          TL.$number.withValue(3333) {
+            printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (3333)
+            printTaskLocal(TL.$other) // CHECK: TaskLocal<Int>(defaultValue: 0) (9999)
+          }
+        }
+      }
+    }
+  }
+
+  let second = UInt64(100_000_000) // ns
+  await Task.sleep(2 * second)
+}
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@main struct Main {
+  static func main() async {
+    await copyTo_async()
+    await copyTo_async()
+    await copyTo_async_noWait()
+  }
+}

--- a/test/Concurrency/Runtime/async_task_locals_groups.swift
+++ b/test/Concurrency/Runtime/async_task_locals_groups.swift
@@ -44,7 +44,7 @@ func groups() async {
     group.spawn {
       printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (0)
       // inside the child task, set a value
-      _ = await TL.$number.withValue(1) {
+      _ = TL.$number.withValue(1) {
         printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (1)
       }
       printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (0)

--- a/test/Concurrency/Runtime/async_task_locals_prevent_illegal_use.swift
+++ b/test/Concurrency/Runtime/async_task_locals_prevent_illegal_use.swift
@@ -23,9 +23,8 @@ enum TL {
 func bindAroundGroupSpawn() async {
   await TL.$number.withValue(1111) { // ok
     await withTaskGroup(of: Int.self) { group in
-
       // CHECK: error: task-local: detected illegal task-local value binding at {{.*}}illegal_use.swift:[[# @LINE + 1]]
-      await TL.$number.withValue(2222) { // bad!
+      TL.$number.withValue(2222) { // bad!
         print("Survived, inside withValue!") // CHECK-NOT: Survived, inside withValue!
         group.spawn {
           0 // don't actually perform the read, it would be unsafe.

--- a/test/Concurrency/Runtime/async_task_locals_synchronous_bind.swift
+++ b/test/Concurrency/Runtime/async_task_locals_synchronous_bind.swift
@@ -38,16 +38,8 @@ func synchronous_bind() async {
   func synchronous() {
     printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (1111)
 
-    withUnsafeCurrentTask { task in
-      guard let task = task else {
-        fatalError()
-      }
-
-      task.withTaskLocal(TL.$number, boundTo: 2222) {
-        printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (2222)
-      }
-
-      printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (1111)
+    TL.$number.withValue(2222) {
+      printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (2222)
     }
 
     printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (1111)

--- a/unittests/runtime/CompatibilityOverrideConcurrency.cpp
+++ b/unittests/runtime/CompatibilityOverrideConcurrency.cpp
@@ -225,15 +225,15 @@ TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_taskGroup_addPending) {
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_localValuePush) {
-  swift_task_localValuePush(nullptr, nullptr, nullptr, nullptr);
+  swift_task_localValuePush(nullptr, nullptr, nullptr);
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_localValueGet) {
-  swift_task_localValueGet(nullptr, nullptr);
+  swift_task_localValueGet(nullptr);
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_localValuePop) {
-  swift_task_localValuePop(nullptr);
+  swift_task_localValuePop();
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_addStatusRecord) {

--- a/unittests/runtime/CompatibilityOverrideConcurrency.cpp
+++ b/unittests/runtime/CompatibilityOverrideConcurrency.cpp
@@ -236,6 +236,10 @@ TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_localValuePop) {
   swift_task_localValuePop();
 }
 
+TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_localsCopyTo) {
+  swift_task_localsCopyTo(nullptr);
+}
+
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_addStatusRecord) {
   swift_task_addStatusRecord(nullptr);
 }


### PR DESCRIPTION
This implements two things:

--- 

1. The ability to bind values in synchronous functions; even if there is no task available at all (!)

```
T.$key.withValue(222) {  // bind
  T.key // read
}
```

without `await`, and regardless if the function is called in a task context or not.

If a task is available, the usual functions are used and we store the locals in the task context; if not, a fallback thread local TaskLocal::Storage is used.


--- 

2. Task-locals being copied (as efficiently as possible) to `async{}` created tasks:

```
  TL.$number.withValue(1111) {
    TL.$number.withValue(2222) {
      TL.$other.withValue(9999) {
        async {
          printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (2222)
          printTaskLocal(TL.$other) // CHECK: TaskLocal<Int>(defaultValue: 0) (9999)
          TL.$number.withValue(3333) {
            printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (3333)
            printTaskLocal(TL.$other) // CHECK: TaskLocal<Int>(defaultValue: 0) (9999)
          }
        }
      }
    }
  }
```

We have to copy the items, but can use the targets task local allocator for this. We also can skip copying any item for which key we've already observed a value. The new async task is guaranteed to never be able to witness such values anyway.