### PR TITLE
[CSFix] Suppress ambiguity warning about non-`Optional` base with sta…

### DIFF
--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1896,6 +1896,26 @@ SpecifyBaseTypeForOptionalUnresolvedMember::attempt(
           if (memberDecl->isInstanceMember())
             continue;
 
+          // Disable this warning for ambiguities related to a
+          // static member lookup in generic context because it's
+          // possible to declare a member with the same name on
+          // a concrete type and in an extension of a protocol
+          // that type conforms to e.g.:
+          //
+          // struct S : P { static var test: S { ... }
+          //
+          // extension P where Self == S { static var test: { ... } }
+          //
+          // And use that in an optional context e.g. passing `.test`
+          // to a parameter of expecting `S?`.
+          if (auto *extension =
+                  dyn_cast<ExtensionDecl>(memberDecl->getDeclContext())) {
+            if (extension->getSelfProtocolDecl()) {
+              allOptionalBase = false;
+              break;
+            }
+          }
+
           allOptionalBase &= bool(choice.getBaseType()
                                       ->getMetatypeInstanceType()
                                       ->getOptionalObjectType());

--- a/test/Constraints/static_members_on_protocol_in_generic_context.swift
+++ b/test/Constraints/static_members_on_protocol_in_generic_context.swift
@@ -299,3 +299,20 @@ func test_fixit_with_where_clause() {
   func test_assoc<T: TestWithAssoc>(_: T) {}
   test_assoc(.intVar) // expected-error {{contextual member reference to static property 'intVar' requires 'Self' constraint in the protocol extension}}
 }
+
+// rdar://77700261 - incorrect warning about assuming non-optional base for unresolved member lookup
+struct WithShadowedMember : P {}
+
+extension WithShadowedMember {
+  static var warnTest: WithShadowedMember { get { WithShadowedMember() } }
+}
+
+extension P where Self == WithShadowedMember {
+  static var warnTest: WithShadowedMember { get { fatalError() } }
+}
+
+func test_no_warning_about_optional_base() {
+  func test(_: WithShadowedMember?) {}
+
+  test(.warnTest) // Ok and no warning even though the `warnTest` name is shadowed
+}


### PR DESCRIPTION
…tic member lookup

Disable non-Optional "assumption" warning for ambiguities related to a
static member lookup in generic context because it's possible to declare
a member with the same name on a concrete type and in an extension of a
protocol that type conforms to e.g.:

```swift
struct S : P { static var test: S { ... }

extension P where Self == S { static var test: { ... } }
```

And use that in an optional context e.g. passing `.test`
to a parameter of expecting `S?`.

Resolves: rdar://77700261

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
