### PR TITLE
[Build Script] Fix `--infer` with `earlyswiftdriver`.

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -957,11 +957,13 @@ class BuildScriptInvocation(object):
         # infer dependencies, infer the dependencies now and then re-split the
         # list.
         if self.args.infer_dependencies:
-            combined = impl_product_classes + product_classes
+            combined_classes = before_impl_product_classes +\
+                impl_product_classes +\
+                product_classes
             if self.args.verbose_build:
                 print("-- Build Graph Inference --")
                 print("Initial Product List:")
-                for p in combined:
+                for p in combined_classes:
                     print("    {}".format(p.product_name()))
 
             # Now that we have produced the schedule, resplit. We require our
@@ -974,17 +976,18 @@ class BuildScriptInvocation(object):
             impl_product_classes = []
             product_classes = []
             is_darwin = platform.system() == 'Darwin'
-            final_schedule = build_graph.produce_scheduled_build(combined)[0]
+            final_schedule =\
+                build_graph.produce_scheduled_build(combined_classes)[0]
             for p in final_schedule:
                 if is_darwin and p.is_nondarwin_only_build_product():
                     continue
-
                 if p.is_build_script_impl_product():
                     impl_product_classes.append(p)
                 elif p.is_before_build_script_impl_product():
                     before_impl_product_classes.append(p)
                 else:
                     product_classes.append(p)
+
             if self.args.verbose_build:
                 print("Final Build Order:")
                 for p in before_impl_product_classes:
@@ -1148,8 +1151,14 @@ class BuildScriptInvocation(object):
             print("--- Running tests for %s ---" % product_name)
             product.test(host_target)
             print("--- Finished tests for %s ---" % product_name)
+        # Install the product if it should be installed specifically, or
+        # if it should be built and `install_all` is set to True.
+        # The exception is select before_build_script_impl products
+        # which set `is_ignore_install_all_product` to True, ensuring
+        # they are never installed. (e.g. earlySwiftDriver).
         if product.should_install(host_target) or \
-           (self.install_all and product.should_build(host_target)):
+           (self.install_all and product.should_build(host_target) and
+           not product.is_ignore_install_all_product()):
             print("--- Installing %s ---" % product_name)
             product.install(host_target)
 

--- a/utils/swift_build_support/swift_build_support/products/cmark.py
+++ b/utils/swift_build_support/swift_build_support/products/cmark.py
@@ -13,6 +13,7 @@
 from build_swift.build_swift.wrappers import xcrun
 
 from . import cmake_product
+from . import earlyswiftdriver
 
 
 class CMark(cmake_product.CMakeProduct):
@@ -32,10 +33,11 @@ class CMark(cmake_product.CMakeProduct):
         """
         return True
 
-    # This is the root of the build-graph, so it doesn't have any dependencies.
+    # EarlySwiftDriver is the root of the graph, and is the only dependency of
+    # this product.
     @classmethod
     def get_dependencies(cls):
-        return []
+        return [earlyswiftdriver.EarlySwiftDriver]
 
     def should_build(self, host_target):
         """should_build() -> Bool

--- a/utils/swift_build_support/swift_build_support/products/earlyswiftdriver.py
+++ b/utils/swift_build_support/swift_build_support/products/earlyswiftdriver.py
@@ -83,6 +83,16 @@ class EarlySwiftDriver(product.Product):
         # product with `--swift-driver --install-swift-driver`.
         return False
 
+    @classmethod
+    def is_ignore_install_all_product(cls):
+        # Ensures that `install_all` setting triggered by `--infer` does not
+        # affect products which specify `is_ignore_install_all_product` as
+        # True. This is useful for products which should not be installed into the
+        # toolchain (corresponding build products that use the just-built
+        # toolchain are the products that get installed, e.g. `swiftdriver` to
+        # `earlyswiftdriver`).
+        return True
+
     def install(self, host_target):
         run_build_script_helper('install', host_target, self, self.args)
 

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -70,6 +70,18 @@ class Product(object):
         raise NotImplementedError
 
     @classmethod
+    def is_ignore_install_all_product(cls):
+        """is_ignore_install_all_product -> bool
+
+        Whether this product is to ignore the install-all directive
+        and insted always respect its own should_install.
+        This is useful when we run -install-all but have products
+        which should never be installed into the toolchain
+        (e.g. earlyswiftdriver)
+        """
+        return False
+
+    @classmethod
     def is_swiftpm_unified_build_product(cls):
         """is_swiftpm_unified_build_product -> bool
 

--- a/utils/swift_build_support/swift_build_support/products/swift.py
+++ b/utils/swift_build_support/swift_build_support/products/swift.py
@@ -11,6 +11,7 @@
 # ----------------------------------------------------------------------------
 
 from . import cmark
+from . import earlyswiftdriver
 from . import libcxx
 from . import libicu
 from . import llvm
@@ -149,6 +150,7 @@ updated without updating swift.py?")
     @classmethod
     def get_dependencies(cls):
         return [cmark.CMark,
+                earlyswiftdriver.EarlySwiftDriver,
                 llvm.LLVM,
                 libcxx.LibCXX,
                 libicu.LibICU]

--- a/validation-test/BuildSystem/infer_dumps_deps_if_verbose_build.test
+++ b/validation-test/BuildSystem/infer_dumps_deps_if_verbose_build.test
@@ -8,12 +8,18 @@
 #
 # CHECK: -- Build Graph Inference --
 # CHECK: Initial Product List:
+# CHECK:     earlyswiftdriver
 # CHECK:     llvm
 # CHECK:     swift
 # CHECK: Final Build Order:
+# CHECK:     earlyswiftdriver
 # CHECK:     cmark
 # CHECK:     llvm
 # CHECK:     swift
+
+# Ensure early SwiftDriver is built first
+#
+# CHECK: --- Building earlyswiftdriver ---
 
 # Build and install the SwiftPM dependencies first.
 #

--- a/validation-test/BuildSystem/test_early_swift_driver_and_infer.swift
+++ b/validation-test/BuildSystem/test_early_swift_driver_and_infer.swift
@@ -1,0 +1,7 @@
+# REQUIRES: standalone_build
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --swiftpm --infer 2>&1 | %FileCheck %s
+
+# CHECK: --- Building earlyswiftdriver ---


### PR DESCRIPTION
In the original implementation (https://github.com/apple/swift/pull/36377), using `--infer` accidentally disables the `earlyswiftdriver` product (`before_impl_product_classes` set to always empty). This change fixes that and makes sure early SwiftDriver is always built, regardless of whether or not `--infer` is used.

This change also ensures that `install_all` setting triggered by `--infer` does not affect `before_build_script_impl` products, which should not be installed into the toolchain (corresponding build products that use the just-built toolchain are the products that get installed, e.g. `swiftdriver` to `earlyswiftdriver`).