### PR TITLE
[SymbolGraph] add sourceOrigin field for symbols implementing remote protocol requirements

### DIFF
--- a/lib/SymbolGraphGen/Edge.cpp
+++ b/lib/SymbolGraphGen/Edge.cpp
@@ -15,8 +15,28 @@
 #include "Symbol.h"
 #include "SymbolGraphASTWalker.h"
 
+#include <queue>
+
 using namespace swift;
 using namespace symbolgraphgen;
+
+namespace {
+const ValueDecl *getForeignProtocolRequirement(const ValueDecl *VD, const ModuleDecl *M) {
+  std::queue<const ValueDecl *> requirements;
+  while (true) {
+    for (auto *req : VD->getSatisfiedProtocolRequirements()) {
+      if (req->getModuleContext()->getNameStr() != M->getNameStr())
+        return req;
+      else
+        requirements.push(req);
+    }
+    if (requirements.empty())
+      return nullptr;
+    VD = requirements.front();
+    requirements.pop();
+  }
+}
+} // end anonymous namespace
 
 void Edge::serialize(llvm::json::OStream &OS) const {
   OS.object([&](){
@@ -66,6 +86,11 @@ void Edge::serialize(llvm::json::OStream &OS) const {
 
     if (!InheritingDecl && Source.getSynthesizedBaseTypeDecl())
       InheritingDecl = Source.getSymbolDecl();
+
+    if (!InheritingDecl) {
+      if (const auto *ID = getForeignProtocolRequirement(Source.getSymbolDecl(), &Graph->M))
+        InheritingDecl = ID;
+    }
     
     // If our source symbol is a inheriting decl, write in information about
     // where it's inheriting docs from.

--- a/test/SymbolGraph/Relationships/Synthesized/Inputs/RemoteP.swift
+++ b/test/SymbolGraph/Relationships/Synthesized/Inputs/RemoteP.swift
@@ -1,0 +1,9 @@
+/// Some Protocol
+public protocol P {
+    func someFunc()
+
+    /// This one has docs!
+    func otherFunc()
+
+    func bonusFunc()
+}

--- a/test/SymbolGraph/Relationships/Synthesized/Inputs/RemoteP.swift
+++ b/test/SymbolGraph/Relationships/Synthesized/Inputs/RemoteP.swift
@@ -7,3 +7,8 @@ public protocol P {
 
     func bonusFunc()
 }
+
+public extension P {
+    /// Extra default docs!
+    func extraFunc() {}
+}

--- a/test/SymbolGraph/Relationships/Synthesized/RemoteInheritedDocs.swift
+++ b/test/SymbolGraph/Relationships/Synthesized/RemoteInheritedDocs.swift
@@ -1,0 +1,56 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/Inputs/RemoteP.swift -module-name RemoteP -emit-module -emit-module-path %t/RemoteP.swiftmodule -emit-module-source-info-path %t/RemoteP.swiftsourceinfo -emit-module-doc-path %t/RemoteP.swiftdoc
+// RUN: %target-swift-frontend %s -module-name RemoteInheritedDocs -emit-module -emit-module-path %t/RemoteInheritedDocs.swiftmodule -emit-module-source-info-path %t/RemoteInheritedDocs.swiftsourceinfo -emit-module-doc-path %t/RemoteInheritedDocs.swiftdoc -I %t
+
+// RUN: %target-swift-symbolgraph-extract -module-name RemoteInheritedDocs -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/RemoteInheritedDocs.symbols.json --check-prefix SOME
+// RUN: %FileCheck %s --input-file %t/RemoteInheritedDocs.symbols.json --check-prefix OTHER
+// RUN: %FileCheck %s --input-file %t/RemoteInheritedDocs.symbols.json --check-prefix BONUS
+// RUN: %FileCheck %s --input-file %t/RemoteInheritedDocs.symbols.json --check-prefix INHERIT
+// RUN: %FileCheck %s --input-file %t/RemoteInheritedDocs.symbols.json --check-prefix LOCAL
+
+// RUN: %target-swift-symbolgraph-extract -module-name RemoteInheritedDocs -I %t -pretty-print -output-dir %t -skip-inherited-docs
+// RUN: %FileCheck %s --input-file %t/RemoteInheritedDocs.symbols.json --check-prefix SOME
+// RUN: %FileCheck %s --input-file %t/RemoteInheritedDocs.symbols.json --check-prefix OTHER
+// RUN: %FileCheck %s --input-file %t/RemoteInheritedDocs.symbols.json --check-prefix BONUS
+// RUN: %FileCheck %s --input-file %t/RemoteInheritedDocs.symbols.json --check-prefix SKIP
+// RUN: %FileCheck %s --input-file %t/RemoteInheritedDocs.symbols.json --check-prefix LOCAL
+
+// SOME:           "source": "s:19RemoteInheritedDocs1SV8someFuncyyF"
+// SOME-NEXT:      "target": "s:19RemoteInheritedDocs1SV"
+// SOME-NEXT:      "sourceOrigin"
+// SOME-NEXT:        "identifier": "s:7RemoteP1PP8someFuncyyF"
+// SOME-NEXT:        "displayName": "P.someFunc()"
+
+// OTHER:           "source": "s:19RemoteInheritedDocs1SV9otherFuncyyF"
+// OTHER-NEXT:      "target": "s:19RemoteInheritedDocs1SV"
+// OTHER-NEXT:      "sourceOrigin"
+// OTHER-NEXT:        "identifier": "s:7RemoteP1PP9otherFuncyyF"
+// OTHER-NEXT:        "displayName": "P.otherFunc()"
+
+// BONUS:           "source": "s:19RemoteInheritedDocs1SV9bonusFuncyyF"
+// BONUS-NEXT:      "target": "s:19RemoteInheritedDocs1SV"
+// BONUS-NEXT:      "sourceOrigin"
+// BONUS-NEXT:        "identifier": "s:7RemoteP1PP9bonusFuncyyF"
+// BONUS-NEXT:        "displayName": "P.bonusFunc()"
+
+// INHERIT: This one has docs!
+// SKIP-NOT: This one has docs!
+
+// LOCAL: Local docs override!
+
+import RemoteP
+
+// The `RemoteP.P` protocol has three methods: `someFunc` and `bonusFunc` don't have docs upstream,
+// but `otherFunc` does. Regardless, each one needs a `sourceOrigin` field connecting it to
+// upstream.
+
+public struct S: P {
+    public func someFunc() {}
+
+    public func otherFunc() {}
+
+    /// Local docs override!
+    public func bonusFunc() {}
+}
+

--- a/test/SymbolGraph/Relationships/Synthesized/RemoteInheritedDocs.swift
+++ b/test/SymbolGraph/Relationships/Synthesized/RemoteInheritedDocs.swift
@@ -8,6 +8,7 @@
 // RUN: %FileCheck %s --input-file %t/RemoteInheritedDocs.symbols.json --check-prefix BONUS
 // RUN: %FileCheck %s --input-file %t/RemoteInheritedDocs.symbols.json --check-prefix INHERIT
 // RUN: %FileCheck %s --input-file %t/RemoteInheritedDocs.symbols.json --check-prefix LOCAL
+// RUN: %FileCheck %s --input-file %t/RemoteInheritedDocs.symbols.json --check-prefix OVERRIDE
 
 // RUN: %target-swift-symbolgraph-extract -module-name RemoteInheritedDocs -I %t -pretty-print -output-dir %t -skip-inherited-docs
 // RUN: %FileCheck %s --input-file %t/RemoteInheritedDocs.symbols.json --check-prefix SOME
@@ -15,6 +16,7 @@
 // RUN: %FileCheck %s --input-file %t/RemoteInheritedDocs.symbols.json --check-prefix BONUS
 // RUN: %FileCheck %s --input-file %t/RemoteInheritedDocs.symbols.json --check-prefix SKIP
 // RUN: %FileCheck %s --input-file %t/RemoteInheritedDocs.symbols.json --check-prefix LOCAL
+// RUN: %FileCheck %s --input-file %t/RemoteInheritedDocs.symbols.json --check-prefix OVERRIDE
 
 // SOME:           "source": "s:19RemoteInheritedDocs1SV8someFuncyyF"
 // SOME-NEXT:      "target": "s:19RemoteInheritedDocs1SV"
@@ -39,11 +41,17 @@
 
 // LOCAL: Local docs override!
 
+// OVERRIDE-NOT: Extra default docs!
+// OVERRIDE-NOT: Extension override!
+
 import RemoteP
 
 // The `RemoteP.P` protocol has three methods: `someFunc` and `bonusFunc` don't have docs upstream,
 // but `otherFunc` does. Regardless, each one needs a `sourceOrigin` field connecting it to
 // upstream.
+
+// `RemoteP.P` also has an extension with a default implementation for `extraFunc` that does have
+// docs, but overriding it here should prevent those from appearing
 
 public struct S: P {
     public func someFunc() {}
@@ -52,5 +60,12 @@ public struct S: P {
 
     /// Local docs override!
     public func bonusFunc() {}
+
+    public func extraFunc() {}
+}
+
+public extension P {
+    /// Extension override!
+    func someFunc() {}
 }
 


### PR DESCRIPTION
Resolves rdar://77626724

Currently, the symbol graph has no way to relate symbols that implement protocol requirements from another module to that remote protocol. This causes situations where "inherited docs" appear on these locally-defined symbols.

This PR adds a `sourceOrigin` field to these symbols, relating them to their upstream protocol.