### PR TITLE
Bump swift-argument-parser

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -93,7 +93,7 @@
                 "llbuild": "release/5.5",
                 "swift-tools-support-core": "release/5.5",
                 "swiftpm": "release/5.5",
-                "swift-argument-parser": "0.4.1",
+                "swift-argument-parser": "0.4.3",
                 "swift-crypto": "1.1.5",
                 "swift-driver": "release/5.5",
                 "swift-syntax": "release/5.5",


### PR DESCRIPTION
SwiftPM needs `swift-argument-parser 0.4.3` for release/5.5 