### PR TITLE
Frontend: teach the compiler to use a backup directory to find .swiftinterface files to compile

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -405,6 +405,8 @@ ERROR(error_option_required,none, "option '%0' is required", (StringRef))
 ERROR(error_nonexistent_output_dir,none,
       "'-output-dir' argument '%0' does not exist or is not a directory", (StringRef))
 
+REMARK(interface_file_backup_used,none,
+      "building module from '%0' failed; retrying building module from '%1'", (StringRef, StringRef))
 
 // Dependency Verifier Diagnostics
 ERROR(missing_member_dependency,none,

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -157,6 +157,8 @@ public:
                                ArrayRef<std::string> candidates,
                                StringRef outPath) = 0;
   virtual ~ModuleInterfaceChecker() = default;
+  virtual std::string getBackupPublicModuleInterfacePath(StringRef moduleName,
+                                                         StringRef interfacePath) = 0;
 };
 
 /// Abstract interface to run an action in a sub ASTContext.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -81,6 +81,10 @@ public:
   /// binary module has already been built for use by the compiler.
   std::string PrebuiltModuleCachePath;
 
+  /// The path to look in to find backup .swiftinterface files if those found
+  /// from SDKs are failing.
+  std::string BackupModuleInterfaceDir;
+
   /// For these modules, we should prefer using Swift interface when importing them.
   std::vector<std::string> PreferInterfaceForModules;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -695,6 +695,13 @@ def prebuilt_module_cache_path_EQ :
   Joined<["-"], "prebuilt-module-cache-path=">,
   Alias<prebuilt_module_cache_path>;
 
+def backup_module_interface_path :
+  Separate<["-"], "backup-module-interface-path">,
+  HelpText<"Directory of module interfaces as backups to those from SDKs">;
+def backup_module_interface_path_EQ :
+  Joined<["-"], "backup-module-interface-path=">,
+  Alias<backup_module_interface_path>;
+
 def force_public_linkage : Flag<["-"], "force-public-linkage">,
    HelpText<"Force public linkage for private symbols. Used by LLDB.">;
 

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -471,6 +471,9 @@ public:
 /// Extract compiler arguments from an interface file buffer.
 bool extractCompilerFlagsFromInterface(StringRef buffer, llvm::StringSaver &ArgSaver,
                                        SmallVectorImpl<const char *> &SubArgs);
+
+/// Extract the user module version number from an interface file.
+llvm::VersionTuple extractUserModuleVersionFromInterface(StringRef moduleInterfacePath);
 } // end namespace swift
 
 #endif

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1240,10 +1240,11 @@ swift::dependencies::performModuleScan(CompilerInstance &instance,
   auto &FEOpts = instance.getInvocation().getFrontendOptions();
   ModuleInterfaceLoaderOptions LoaderOpts(FEOpts);
   InterfaceSubContextDelegateImpl ASTDelegate(
-      ctx.SourceMgr, ctx.Diags, ctx.SearchPathOpts, ctx.LangOpts,
+      ctx.SourceMgr, &ctx.Diags, ctx.SearchPathOpts, ctx.LangOpts,
       ctx.ClangImporterOpts, LoaderOpts,
       /*buildModuleCacheDirIfAbsent*/ false, ModuleCachePath,
       FEOpts.PrebuiltModuleCachePath,
+      FEOpts.BackupModuleInterfaceDir,
       FEOpts.SerializeModuleInterfaceDependencyHashes,
       FEOpts.shouldTrackSystemDependencies(),
       RequireOSSAModules_t(instance.getSILOptions()));
@@ -1332,10 +1333,11 @@ swift::dependencies::performBatchModuleScan(
                         std::set<ModuleDependencyID>>
             allModules;
         InterfaceSubContextDelegateImpl ASTDelegate(
-            ctx.SourceMgr, ctx.Diags, ctx.SearchPathOpts, ctx.LangOpts,
+            ctx.SourceMgr, &ctx.Diags, ctx.SearchPathOpts, ctx.LangOpts,
             ctx.ClangImporterOpts, LoaderOpts,
             /*buildModuleCacheDirIfAbsent*/ false, ModuleCachePath,
             FEOpts.PrebuiltModuleCachePath,
+            FEOpts.BackupModuleInterfaceDir,
             FEOpts.SerializeModuleInterfaceDependencyHashes,
             FEOpts.shouldTrackSystemDependencies(),
             RequireOSSAModules_t(instance.getSILOptions()));
@@ -1400,10 +1402,11 @@ swift::dependencies::performBatchModulePrescan(
                         std::set<ModuleDependencyID>>
             allModules;
         InterfaceSubContextDelegateImpl ASTDelegate(
-            ctx.SourceMgr, ctx.Diags, ctx.SearchPathOpts, ctx.LangOpts,
+            ctx.SourceMgr, &ctx.Diags, ctx.SearchPathOpts, ctx.LangOpts,
             ctx.ClangImporterOpts, LoaderOpts,
             /*buildModuleCacheDirIfAbsent*/ false, ModuleCachePath,
             FEOpts.PrebuiltModuleCachePath,
+            FEOpts.BackupModuleInterfaceDir,
             FEOpts.SerializeModuleInterfaceDependencyHashes,
             FEOpts.shouldTrackSystemDependencies(),
             RequireOSSAModules_t(instance.getSILOptions()));

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -63,6 +63,9 @@ bool ArgsToFrontendOptionsConverter::convert(
   if (const Arg *A = Args.getLastArg(OPT_prebuilt_module_cache_path)) {
     Opts.PrebuiltModuleCachePath = A->getValue();
   }
+  if (const Arg *A = Args.getLastArg(OPT_backup_module_interface_path)) {
+    Opts.BackupModuleInterfaceDir = A->getValue();
+  }
   if (const Arg *A = Args.getLastArg(OPT_bridging_header_directory_for_print)) {
     Opts.BridgingHeaderDirForPrint = A->getValue();
   }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -129,6 +129,13 @@ void CompilerInvocation::setDefaultPrebuiltCacheIfNecessary() {
 
   FrontendOpts.PrebuiltModuleCachePath = computePrebuiltCachePath(
       SearchPathOpts.RuntimeResourcePath, LangOpts.Target, LangOpts.SDKVersion);
+  if (!FrontendOpts.PrebuiltModuleCachePath.empty())
+    return;
+  StringRef anchor = "prebuilt-modules";
+  assert(((StringRef)FrontendOpts.PrebuiltModuleCachePath).contains(anchor));
+  auto pair = ((StringRef)FrontendOpts.PrebuiltModuleCachePath).split(anchor);
+  FrontendOpts.BackupModuleInterfaceDir =
+    (llvm::Twine(pair.first) + "preferred-interfaces" + pair.second).str();
 }
 
 static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -530,7 +530,8 @@ bool CompilerInstance::setUpModuleLoaders() {
   ModuleInterfaceLoaderOptions LoaderOpts(FEOpts);
   Context->addModuleInterfaceChecker(
       std::make_unique<ModuleInterfaceCheckerImpl>(
-          *Context, ModuleCachePath, FEOpts.PrebuiltModuleCachePath, LoaderOpts,
+          *Context, ModuleCachePath, FEOpts.PrebuiltModuleCachePath,
+          FEOpts.BackupModuleInterfaceDir, LoaderOpts,
           RequireOSSAModules_t(Invocation.getSILOptions())));
   // If implicit modules are disabled, we need to install an explicit module
   // loader.
@@ -571,10 +572,11 @@ bool CompilerInstance::setUpModuleLoaders() {
     auto &FEOpts = Invocation.getFrontendOptions();
     ModuleInterfaceLoaderOptions LoaderOpts(FEOpts);
     InterfaceSubContextDelegateImpl ASTDelegate(
-        Context->SourceMgr, Context->Diags, Context->SearchPathOpts,
+        Context->SourceMgr, &Context->Diags, Context->SearchPathOpts,
         Context->LangOpts, Context->ClangImporterOpts, LoaderOpts,
         /*buildModuleCacheDirIfAbsent*/ false, ModuleCachePath,
         FEOpts.PrebuiltModuleCachePath,
+        FEOpts.BackupModuleInterfaceDir,
         FEOpts.SerializeModuleInterfaceDependencyHashes,
         FEOpts.shouldTrackSystemDependencies(),
         RequireOSSAModules_t(Invocation.getSILOptions()));

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -103,7 +103,11 @@ bool ModuleInterfaceBuilder::collectDepsForSerialization(
     // dependency list -- don't serialize that.
     if (!prebuiltCachePath.empty() && DepName.startswith(prebuiltCachePath))
       continue;
-
+    // Don't serialize interface path if it's from the preferred interface dir.
+    // This ensures the prebuilt module caches generated from these interfaces are
+    // relocatable.
+    if (!backupInterfaceDir.empty() && DepName.startswith(backupInterfaceDir))
+      continue;
     if (dependencyTracker) {
       dependencyTracker->addDependency(DepName, /*isSystem*/IsSDKRelative);
     }

--- a/lib/Frontend/ModuleInterfaceBuilder.h
+++ b/lib/Frontend/ModuleInterfaceBuilder.h
@@ -35,12 +35,13 @@ class DependencyTracker;
 
 class ModuleInterfaceBuilder {
   SourceManager &sourceMgr;
-  DiagnosticEngine &diags;
+  DiagnosticEngine *diags;
   InterfaceSubContextDelegate &subASTDelegate;
   const StringRef interfacePath;
   const StringRef moduleName;
   const StringRef moduleCachePath;
   const StringRef prebuiltCachePath;
+  const StringRef backupInterfaceDir;
   const bool disableInterfaceFileLock;
   const SourceLoc diagnosticLoc;
   DependencyTracker *const dependencyTracker;
@@ -50,7 +51,7 @@ public:
   /// Emit a diagnostic tied to this declaration.
   template<typename ...ArgTypes>
   static InFlightDiagnostic diagnose(
-      DiagnosticEngine &Diags,
+      DiagnosticEngine *Diags,
       SourceManager &SM,
       StringRef InterfacePath,
       SourceLoc Loc,
@@ -60,7 +61,7 @@ public:
       // Diagnose this inside the interface file, if possible.
       Loc = SM.getLocFromExternalSource(InterfacePath, 1, 1);
     }
-    return Diags.diagnose(Loc, ID, std::move(Args)...);
+    return Diags->diagnose(Loc, ID, std::move(Args)...);
   }
 
 private:
@@ -88,11 +89,12 @@ private:
                                 std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
                                 ArrayRef<std::string> CandidateModules);
 public:
-  ModuleInterfaceBuilder(SourceManager &sourceMgr, DiagnosticEngine &diags,
+  ModuleInterfaceBuilder(SourceManager &sourceMgr, DiagnosticEngine *diags,
                             InterfaceSubContextDelegate &subASTDelegate,
                             StringRef interfacePath,
                             StringRef moduleName,
                             StringRef moduleCachePath,
+                            StringRef backupInterfaceDir,
                             StringRef prebuiltCachePath,
                             bool disableInterfaceFileLock = false,
                             SourceLoc diagnosticLoc = SourceLoc(),
@@ -101,6 +103,7 @@ public:
       subASTDelegate(subASTDelegate),
       interfacePath(interfacePath), moduleName(moduleName),
       moduleCachePath(moduleCachePath), prebuiltCachePath(prebuiltCachePath),
+      backupInterfaceDir(backupInterfaceDir),
       disableInterfaceFileLock(disableInterfaceFileLock),
       diagnosticLoc(diagnosticLoc), dependencyTracker(tracker) {}
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -418,6 +418,7 @@ static bool buildModuleFromInterface(CompilerInstance &Instance) {
       Invocation.getSearchPathOptions(), Invocation.getLangOptions(),
       Invocation.getClangImporterOptions(),
       Invocation.getClangModuleCachePath(), PrebuiltCachePath,
+      FEOpts.BackupModuleInterfaceDir,
       Invocation.getModuleName(), InputPath, Invocation.getOutputFilename(),
       FEOpts.SerializeModuleInterfaceDependencyHashes,
       FEOpts.shouldTrackSystemDependencies(), LoaderOpts,

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -54,6 +54,7 @@ std::error_code ModuleDependencyScanner::findModuleFilesInDirectory(
     }
   }
   assert(fs.exists(InPath));
+
   // Use the private interface file if exits.
   auto PrivateInPath =
   BaseName.getName(file_types::TY_PrivateSwiftModuleInterfaceFile);

--- a/test/ModuleInterface/Inputs/DummyFramework.framework/Modules/DummyFramework.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/test/ModuleInterface/Inputs/DummyFramework.framework/Modules/DummyFramework.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,0 +1,6 @@
+// swift-interface-format-version: 1.0
+// swift-tools-version: Apple Swift version 5.1 (swiftlang-1100.0.38 clang-1100.0.20.14)
+// swift-module-flags: -target arm64-apple-macos10.14 -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -O -module-name DummyFramework
+import Swift
+
+mess_mess_mess

--- a/test/ModuleInterface/Inputs/alternative-interfaces/DummyFramework.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/test/ModuleInterface/Inputs/alternative-interfaces/DummyFramework.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-tools-version: Apple Swift version 5.1 (swiftlang-1100.0.38 clang-1100.0.20.14)
+// swift-module-flags: -target arm64-apple-macos10.14 -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -O -module-name DummyFramework
+import Swift

--- a/test/ModuleInterface/build-alternative-interface-framework.swift
+++ b/test/ModuleInterface/build-alternative-interface-framework.swift
@@ -1,0 +1,6 @@
+// REQUIRES: VENDOR=apple
+// RUN: %empty-directory(%t/module-cache)
+// RUN: not %target-swift-frontend-typecheck -disable-implicit-concurrency-module-import -target arm64-apple-macosx13.0 -F %S/Inputs %s -module-cache-path %t/module-cache
+// RUN: %target-swift-frontend-typecheck -disable-implicit-concurrency-module-import -target arm64-apple-macosx13.0 -F %S/Inputs %s -module-cache-path %t/module-cache -backup-module-interface-path %S/Inputs/alternative-interfaces
+
+import DummyFramework

--- a/test/ModuleInterface/build-alternative-interface.swift
+++ b/test/ModuleInterface/build-alternative-interface.swift
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/sources)
+// RUN: %empty-directory(%t/inputs)
+// RUN: %empty-directory(%t/alternative-inputs)
+// RUN: %empty-directory(%t/module-cache)
+
+// RUN: echo "public func foo() {}" > %t/sources/Foo.swift
+// RUN: %target-swift-frontend-typecheck -emit-module-interface-path %t/inputs/Foo.swiftinterface %t/sources/Foo.swift -module-name Foo -disable-implicit-concurrency-module-import -enable-library-evolution -module-cache-path %t/module-cache -I %t/inputs -swift-version 5
+// RUN: cp %t/inputs/Foo.swiftinterface %t/alternative-inputs/Foo.swiftinterface
+
+// RUN: echo "import Foo" > %t/sources/Bar.swift
+// RUN: echo "public func foo() {}" >> %t/sources/Bar.swift
+// RUN: %target-swift-frontend-typecheck -emit-module-interface-path %t/inputs/Bar.swiftinterface %t/sources/Bar.swift -module-name Bar -disable-implicit-concurrency-module-import -enable-library-evolution -module-cache-path %t/module-cache -I %t/inputs -swift-version 5
+// RUN: cp %t/inputs/Bar.swiftinterface %t/alternative-inputs/Bar.swiftinterface
+
+// RUN: echo "import Bar" > %t/sources/FooBar.swift
+// RUN: echo "public func foo() {}" >> %t/sources/FooBar.swift
+// RUN: %target-swift-frontend-typecheck -emit-module-interface-path %t/inputs/FooBar.swiftinterface %t/sources/FooBar.swift -module-name FooBar -disable-implicit-concurrency-module-import -enable-library-evolution -module-cache-path %t/module-cache -I %t/inputs -swift-version 5
+
+// RUN: echo "messmessmess" >> %t/inputs/Foo.swiftinterface
+// RUN: echo "messmessmess" >> %t/inputs/Bar.swiftinterface
+
+// RUN: %target-typecheck-verify-swift -disable-implicit-concurrency-module-import -I %t/inputs -backup-module-interface-path %t/alternative-inputs -module-cache-path %t/module-cache
+
+// RUN: touch %t/inputs/Bar.swiftinterface
+// RUN: %target-swift-frontend-typecheck -disable-implicit-concurrency-module-import -I %t/inputs -backup-module-interface-path %t/alternative-inputs -module-cache-path %t/module-cache -Rmodule-interface-rebuild %s &> %t/remarks.txt
+// RUN: %FileCheck --input-file %t/remarks.txt %s --check-prefix=CHECK-REBUILD
+// CHECK-REBUILD: remark: rebuilding module 'FooBar' from interface
+// CHECK-REBUILD: remark: rebuilding module 'Bar' from interface
+
+// RUN: %target-swift-frontend-typecheck -disable-implicit-concurrency-module-import -I %t/inputs -backup-module-interface-path %t/alternative-inputs -module-cache-path %t/module-cache -Rmodule-interface-rebuild %s &> %t/no-remarks.txt
+// RUN: echo "additional" >> %t/no-remarks.txt
+// RUN: %FileCheck --input-file %t/no-remarks.txt %s --check-prefix=CHECK-REBUILD-NOT
+// CHECK-REBUILD-NOT-NOT: remark
+
+import FooBar
+import Foo
+import Bar


### PR DESCRIPTION
This mechanism allows the compiler to use a backup interface file to build into a binary module when a corresponding interface file from the SDK is failing for whatever reasons. This mechansim should be entirely opaque to end users except several diagnostic messages communicating backup interfaces are used.

Part of rdar://77676064