### PR TITLE
Fix refactor-check-compiles.py for python3

### DIFF
--- a/utils/refactor-check-compiles.py
+++ b/utils/refactor-check-compiles.py
@@ -77,7 +77,7 @@ def main():
         '-dump-text',
         '-source-filename', args.source_filename,
         '-pos', args.pos
-    ] + unknown_args, desc='producing edit')
+    ] + unknown_args, desc='producing edit').decode("utf-8")
 
     dump_rewritten_output = run_cmd([
         args.swift_refactor,


### PR DESCRIPTION
Fixes:
    sys.stdout.write(dump_text_output)
TypeError: write() argument must be str, not bytes
