### PR TITLE
[5.5][AST] Return `null` type in `AbstractClosureExpr::getResultType` if `getType` is `null`

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1931,10 +1931,11 @@ void AbstractClosureExpr::setParameterList(ParameterList *P) {
 Type AbstractClosureExpr::getResultType(
     llvm::function_ref<Type(Expr *)> getType) const {
   auto *E = const_cast<AbstractClosureExpr *>(this);
-  if (getType(E)->hasError())
-    return getType(E);
+  Type T = getType(E);
+  if (!T || T->hasError())
+    return T;
 
-  return getType(E)->castTo<FunctionType>()->getResult();
+  return T->castTo<FunctionType>()->getResult();
 }
 
 bool AbstractClosureExpr::isBodyThrowing() const {


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/37341 into `release/5.5`

* **Explanation**: If `getType` returns a `null` type, also return a `null` type in `AbstractClosureExpr::getResultType`. Previously, we were crashing.
* **Scope**: Invalid code where the type checker fails to set a type on closure expressions
* **Risk**: Very low
* **Testing**: None, the fix was created based on a crash trace without a reproducer
* **Issue**: rdar://77565983
* **Reviewer**: Pavel Yaskevich (@xedin)