### PR TITLE
[5.5][Sema] Remove `TypeCheckExprFlags::AllowUnresolvedTypeVariables`

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -764,7 +764,6 @@ public:
       assert(DiagnosticSuppression::isEnabled(getASTContext().Diags) &&
              "Diagnosing and AllowUnresolvedTypeVariables don't seem to mix");
       options |= TypeCheckExprFlags::LeaveClosureBodyUnchecked;
-      options |= TypeCheckExprFlags::AllowUnresolvedTypeVariables;
     }
 
     ContextualTypePurpose ctp = CTP_ReturnStmt;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -122,22 +122,15 @@ enum class TypeCheckExprFlags {
   /// disables constraints forcing an lvalue result to be loadable.
   IsDiscarded = 0x01,
 
-  /// If set, the client wants a best-effort solution to the constraint system,
-  /// but can tolerate a solution where all of the constraints are solved, but
-  /// not all type variables have been determined.  In this case, the constraint
-  /// system is not applied to the expression AST, but the ConstraintSystem is
-  /// left in-tact.
-  AllowUnresolvedTypeVariables = 0x02,
-
   /// If set, this expression isn't embedded in a larger expression or
   /// statement. This should only be used for syntactic restrictions, and should
   /// not affect type checking itself.
-  IsExprStmt = 0x04,
+  IsExprStmt = 0x02,
 
   /// Don't try to type check closure expression bodies, and leave them
   /// unchecked. This is used by source tooling functionalities such as code
   /// completion.
-  LeaveClosureBodyUnchecked = 0x08,
+  LeaveClosureBodyUnchecked = 0x04,
 };
 
 using TypeCheckExprOptions = OptionSet<TypeCheckExprFlags>;

--- a/validation-test/IDE/crashers_2_fixed/rdar76686564.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar76686564.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-ide-test --conforming-methods -code-completion-token=COMPLETE --conforming-methods-expected-types=s:14swift_ide_test10MySequenceP -source-filename %s
+// RUN: %target-swift-ide-test --conforming-methods -code-completion-token=COMPLETE_EXPR --conforming-methods-expected-types=s:14swift_ide_test10MySequenceP -source-filename %s
+// RUN: %target-swift-ide-test --conforming-methods -code-completion-token=COMPLETE_STMT --conforming-methods-expected-types=s:14swift_ide_test10MySequenceP -source-filename %s
 
 protocol MySequence {
   associatedtype Element
@@ -17,5 +18,11 @@ func myFlatMap<SegmentOfResult: MySequence>(_ transform: (ArgumentDefinition) ->
 }
 
 func generateArgumentWords() {
-  _ = myFlatMap { $0.#^COMPLETE^# } as Foo<String>
+  // Explicitly coerce the type using 'as'. This is type checked as an expression.
+  _ = myFlatMap { $0.#^COMPLETE_EXPR^# } as Foo<String>
+}
+
+func generateArgumentWords() -> Foo<String> {
+  // Implicitly coerce the type from the return type. This is type checked as a stmt.
+  return myFlatMap { $0.#^COMPLETE_STMT^# }
 }


### PR DESCRIPTION
Cherry-picks https://github.com/apple/swift/pull/37344 to `release/5.5`.

* **Explanation**: Remove the TypeCheckExprFlags::AllowUnresolvedTypeVariables flag, fixing another occurance of rdar://76686564 
* **Scope**: SourceKit (Code completion, Conforming Methods), type checking of naming patterns
* **Risk**: Low to Medium
* **Testing**: Added a test in the validation suite
* **Issue**: rdar://76686564
* **Reviewer**: Pavel Yaskevich (@xedin)