### PR TITLE
[SourceKit] Update SyntaxInfo but with lazy parsing in "edit" request

### DIFF
--- a/test/SourceKit/CodeExpand/code-expand-rdar77665805.swift
+++ b/test/SourceKit/CodeExpand/code-expand-rdar77665805.swift
@@ -1,0 +1,32 @@
+// BEGIN main.swift
+enum E { case foo, bar }
+func foo(x: (E) -> Void) {}
+func test() {
+  foo(x: <#T##(E) -> Void#>)
+}
+
+// BEGIN expand.json.in
+{
+    key.request: source.request.editor.expand_placeholder,
+    key.offset: 23,
+    key.length: 18,
+    key.name: "FILENAME"
+}
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: sed "s#FILENAME#%t/main.swift#" %t/expand.json.in > %t/expand.json
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=open %t/main.swift -- %t/main.swift == \
+// RUN:   -req=edit -offset=0 -length=53 -replace="" -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/main.swift -- %t/main.swift == \
+// RUN:   -json-request-path %t/expand.json \
+// RUN: | %FileCheck %s
+
+// CHECK: {
+// CHECK:   key.offset: 19,
+// CHECK:   key.length: 23,
+// CHECK:   key.sourcetext: " { <#E#> in\n<#code#>\n}"
+// CHECK: }
+

--- a/test/SourceKit/CodeExpand/code-expand-rdar77665805.swift
+++ b/test/SourceKit/CodeExpand/code-expand-rdar77665805.swift
@@ -1,27 +1,13 @@
-// BEGIN main.swift
 enum E { case foo, bar }
 func foo(x: (E) -> Void) {}
 func test() {
   foo(x: <#T##(E) -> Void#>)
 }
 
-// BEGIN expand.json.in
-{
-    key.request: source.request.editor.expand_placeholder,
-    key.offset: 23,
-    key.length: 18,
-    key.name: "FILENAME"
-}
-
-// RUN: %empty-directory(%t)
-// RUN: %{python} %utils/split_file.py -o %t %s
-
-// RUN: sed "s#FILENAME#%t/main.swift#" %t/expand.json.in > %t/expand.json
-
 // RUN: %sourcekitd-test \
-// RUN:   -req=open %t/main.swift -- %t/main.swift == \
-// RUN:   -req=edit -offset=0 -length=53 -replace="" -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/main.swift -- %t/main.swift == \
-// RUN:   -json-request-path %t/expand.json \
+// RUN:   -req=open %s -- %s == \
+// RUN:   -req=edit -offset=0 -length=53 -replace="" -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %s -- %s == \
+// RUN:   -req=expand-placeholder -offset=23 -length=18 %s \
 // RUN: | %FileCheck %s
 
 // CHECK: {

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -107,9 +107,9 @@ public:
   ImmutableTextSnapshotRef getLatestSnapshot() const;
   std::pair<unsigned, unsigned> getLineAndColumnInBuffer(unsigned Offset);
 
-  void parse(ImmutableTextSnapshotRef Snapshot, SwiftLangSupport &Lang,
-             bool BuildSyntaxTree,
-             swift::SyntaxParsingCache *SyntaxCache = nullptr);
+  void resetSyntaxInfo(ImmutableTextSnapshotRef Snapshot,
+                       SwiftLangSupport &Lang, bool BuildSyntaxTree,
+                       swift::SyntaxParsingCache *SyntaxCache = nullptr);
   void readSyntaxInfo(EditorConsumer &consumer, bool ReportDiags);
   void readSemanticInfo(ImmutableTextSnapshotRef Snapshot,
                         EditorConsumer& Consumer);
@@ -129,7 +129,7 @@ public:
 
   /// Whether or not the AST stored for this document is up-to-date or just an
   /// artifact of incremental syntax parsing
-  bool hasUpToDateAST() const;
+  bool isIncrementalParsingEnabled() const;
 
   /// Returns the virtual filesystem associated with this document.
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> getFileSystem() const;


### PR DESCRIPTION
Previously, if the client requests no information from "edit" request, the syntax info wasn't updated. But "expand placeholder" request requires the up-to-date syntax info.

rdar://77665805
