### PR TITLE
[5.5][CodeCompletion] Make object literals optional

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -867,6 +867,9 @@ struct CodeCompletionResultSink {
   /// Whether to annotate the results with XML.
   bool annotateResult = false;
 
+  /// Whether to emit object literals if desired.
+  bool includeObjectLiterals = true;
+
   std::vector<CodeCompletionResult *> Results;
 
   /// A single-element cache for module names stored in Allocator, keyed by a
@@ -937,6 +940,11 @@ public:
 
   void setAnnotateResult(bool flag) { CurrentResults.annotateResult = flag; }
   bool getAnnotateResult() { return CurrentResults.annotateResult; }
+
+  void setIncludeObjectLiterals(bool flag) {
+    CurrentResults.includeObjectLiterals = flag;
+  }
+  bool includeObjectLiterals() { return CurrentResults.includeObjectLiterals; }
 
   /// Allocate a string owned by the code completion context.
   StringRef copyString(StringRef Str);

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4346,28 +4346,31 @@ public:
       builder.addRightBracket();
     });
 
-    auto floatType = context.getFloatDecl()->getDeclaredInterfaceType();
-    addFromProto(LK::ColorLiteral, [&](Builder &builder) {
-      builder.addBaseName("#colorLiteral");
-      builder.addLeftParen();
-      builder.addCallParameter(context.getIdentifier("red"), floatType);
-      builder.addComma();
-      builder.addCallParameter(context.getIdentifier("green"), floatType);
-      builder.addComma();
-      builder.addCallParameter(context.getIdentifier("blue"), floatType);
-      builder.addComma();
-      builder.addCallParameter(context.getIdentifier("alpha"), floatType);
-      builder.addRightParen();
-    });
+    // Optionally add object literals.
+    if (CompletionContext->includeObjectLiterals()) {
+      auto floatType = context.getFloatDecl()->getDeclaredInterfaceType();
+      addFromProto(LK::ColorLiteral, [&](Builder &builder) {
+        builder.addBaseName("#colorLiteral");
+        builder.addLeftParen();
+        builder.addCallParameter(context.getIdentifier("red"), floatType);
+        builder.addComma();
+        builder.addCallParameter(context.getIdentifier("green"), floatType);
+        builder.addComma();
+        builder.addCallParameter(context.getIdentifier("blue"), floatType);
+        builder.addComma();
+        builder.addCallParameter(context.getIdentifier("alpha"), floatType);
+        builder.addRightParen();
+      });
 
-    auto stringType = context.getStringDecl()->getDeclaredInterfaceType();
-    addFromProto(LK::ImageLiteral, [&](Builder &builder) {
-      builder.addBaseName("#imageLiteral");
-      builder.addLeftParen();
-      builder.addCallParameter(context.getIdentifier("resourceName"),
-                               stringType);
-      builder.addRightParen();
-    });
+      auto stringType = context.getStringDecl()->getDeclaredInterfaceType();
+      addFromProto(LK::ImageLiteral, [&](Builder &builder) {
+        builder.addBaseName("#imageLiteral");
+        builder.addLeftParen();
+        builder.addCallParameter(context.getIdentifier("resourceName"),
+                                 stringType);
+        builder.addRightParen();
+      });
+    }
 
     // Add tuple completion (item, item).
     {

--- a/test/SourceKit/CodeComplete/complete_object_literals.swift
+++ b/test/SourceKit/CodeComplete/complete_object_literals.swift
@@ -1,0 +1,58 @@
+func test(color: String) {
+    
+}
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=complete -pos=2:1 %s -- %s == \
+// RUN:   -req=complete -pos=2:1 -req-opts=includeobjectliterals=1 %s -- %s == \
+// RUN:   -req=complete -pos=2:1 -req-opts=includeobjectliterals=0 %s -- %s == \
+// RUN:   -req=complete -pos=2:1 %s -- %s \
+// RUN: | tee %t.out | %FileCheck --check-prefix=CHECK1 %s 
+
+// CHECK1-LABEL: key.results: [
+// CHECK1:     {
+// CHECK1:       key.kind: source.lang.swift.literal.color,
+// CHECK1:       key.name: "#colorLiteral(red:green:blue:alpha:)",
+// CHECK1:       key.sourcetext: "#colorLiteral(red: <#T##Float#>, green: <#T##Float#>, blue: <#T##Float#>, alpha: <#T##Float#>)",
+// CHECK1:       key.description: "#colorLiteral(red: Float, green: Float, blue: Float, alpha: Float)",
+// CHECK1:     },
+// CHECK1:     {
+// CHECK1:       key.kind: source.lang.swift.literal.image,
+// CHECK1:       key.name: "#imageLiteral(resourceName:)",
+// CHECK1:       key.sourcetext: "#imageLiteral(resourceName: <#T##String#>)",
+// CHECK1:       key.description: "#imageLiteral(resourceName: String)",
+// CHECK1:     },
+
+// CHECK1-LABEL: key.results: [
+// CHECK1:     {
+// CHECK1:       key.kind: source.lang.swift.literal.color,
+// CHECK1:       key.name: "#colorLiteral(red:green:blue:alpha:)",
+// CHECK1:       key.sourcetext: "#colorLiteral(red: <#T##Float#>, green: <#T##Float#>, blue: <#T##Float#>, alpha: <#T##Float#>)",
+// CHECK1:       key.description: "#colorLiteral(red: Float, green: Float, blue: Float, alpha: Float)",
+// CHECK1:     },
+// CHECK1:     {
+// CHECK1:       key.kind: source.lang.swift.literal.image,
+// CHECK1:       key.name: "#imageLiteral(resourceName:)",
+// CHECK1:       key.sourcetext: "#imageLiteral(resourceName: <#T##String#>)",
+// CHECK1:       key.description: "#imageLiteral(resourceName: String)",
+// CHECK1:     },
+
+// CHECK1-LABEL: key.results: [
+// CHECK1-NOT: source.lang.swift.literal.color
+// CHECK1-NOT: colorLiteral
+// CHECK1-NOT: source.lang.swift.literal.image,
+// CHECK1-NOT: imageLiteral 
+
+// CHECK1-LABEL: key.results: [
+// CHECK1:     {
+// CHECK1:       key.kind: source.lang.swift.literal.color,
+// CHECK1:       key.name: "#colorLiteral(red:green:blue:alpha:)",
+// CHECK1:       key.sourcetext: "#colorLiteral(red: <#T##Float#>, green: <#T##Float#>, blue: <#T##Float#>, alpha: <#T##Float#>)",
+// CHECK1:       key.description: "#colorLiteral(red: Float, green: Float, blue: Float, alpha: Float)",
+// CHECK1:     },
+// CHECK1:     {
+// CHECK1:       key.kind: source.lang.swift.literal.image,
+// CHECK1:       key.name: "#imageLiteral(resourceName:)",
+// CHECK1:       key.sourcetext: "#imageLiteral(resourceName: <#T##String#>)",
+// CHECK1:       key.description: "#imageLiteral(resourceName: String)",
+// CHECK1:     },

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
@@ -43,6 +43,7 @@ struct Options {
   bool hideByNameStyle = true;
   bool fuzzyMatching = true;
   bool annotatedDescription = false;
+  bool includeObjectLiterals = true;
   unsigned minFuzzyLength = 2;
   unsigned showTopNonLiteralResults = 3;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -121,7 +121,7 @@ static bool swiftCodeCompleteImpl(
     unsigned Offset, SwiftCodeCompletionConsumer &SwiftConsumer,
     ArrayRef<const char *> Args,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
-    bool annotateDescription, std::string &Error) {
+    const CodeCompletion::Options &opts, std::string &Error) {
   return Lang.performCompletionLikeOperation(
       UnresolvedInputFile, Offset, Args, FileSystem, Error,
       [&](CompilerInstance &CI, bool reusingASTContext) {
@@ -130,7 +130,8 @@ static bool swiftCodeCompleteImpl(
         auto swiftCache = Lang.getCodeCompletionCache(); // Pin the cache.
         ide::CodeCompletionContext CompletionContext(swiftCache->getCache());
         CompletionContext.ReusingASTContext = reusingASTContext;
-        CompletionContext.setAnnotateResult(annotateDescription);
+        CompletionContext.setAnnotateResult(opts.annotatedDescription);
+        CompletionContext.setIncludeObjectLiterals(opts.includeObjectLiterals);
         std::unique_ptr<CodeCompletionCallbacksFactory> callbacksFactory(
             ide::makeCodeCompletionCallbacksFactory(CompletionContext,
                                                     SwiftConsumer));
@@ -214,8 +215,7 @@ void SwiftLangSupport::codeComplete(
 
   std::string Error;
   if (!swiftCodeCompleteImpl(*this, UnresolvedInputFile, Offset, SwiftConsumer,
-                             Args, fileSystem,
-                             CCOpts.annotatedDescription, Error)) {
+                             Args, fileSystem, CCOpts, Error)) {
     SKConsumer.failed(Error);
   }
 }
@@ -728,6 +728,7 @@ static void translateCodeCompletionOptions(OptionsDictionary &from,
   static UIdent KeyFuzzyWeight("key.codecomplete.sort.fuzzyweight");
   static UIdent KeyPopularityBonus("key.codecomplete.sort.popularitybonus");
   static UIdent KeyAnnotatedDescription("key.codecomplete.annotateddescription");
+  static UIdent KeyIncludeObjectLiterals("key.codecomplete.includeobjectliterals");
 
   from.valueForOption(KeySortByName, to.sortByName);
   from.valueForOption(KeyUseImportDepth, to.useImportDepth);
@@ -753,6 +754,7 @@ static void translateCodeCompletionOptions(OptionsDictionary &from,
   from.valueForOption(KeyHideByName, to.hideByNameStyle);
   from.valueForOption(KeyTopNonLiteral, to.showTopNonLiteralResults);
   from.valueForOption(KeyAnnotatedDescription, to.annotatedDescription);
+  from.valueForOption(KeyIncludeObjectLiterals, to.includeObjectLiterals);
 }
 
 /// Canonicalize a name that is in the format of a reference to a function into
@@ -1023,7 +1025,7 @@ static void transformAndForwardResults(
     std::string error;
     if (!swiftCodeCompleteImpl(lang, buffer.get(), str.size(), swiftConsumer,
                                cargs, session->getFileSystem(),
-                               options.annotatedDescription, error)) {
+                               options, error)) {
       consumer.failed(error);
       return;
     }
@@ -1123,8 +1125,7 @@ void SwiftLangSupport::codeCompleteOpen(
 
   // Invoke completion.
   if (!swiftCodeCompleteImpl(*this, inputBuf, offset, swiftConsumer,
-                             extendedArgs, fileSystem,
-                             CCOpts.annotatedDescription, error)) {
+                             extendedArgs, fileSystem, CCOpts, error)) {
     consumer.failed(error);
     return;
   }


### PR DESCRIPTION
Cherry-pick #37330 into `release/5.5`

* **Explanation**: Non-Darwin platforms don't want object literals (i.e. `#colorLiteral(red:green:blue":alpha:)` and `#imageLiteral(named:)`) in code completion. Make it optional and default it `true`
* **Scope**: code completion
* **Risk**: Low
* **Testing**: Added regression test cases
* **Issue**: rdar://75620636
* **Reviewer**: Ben Langmuir (@benlangmuir)
