### PR TITLE
[build-script] Remove old name swift-dt from source for swift-inspect.

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swiftinspect.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftinspect.py
@@ -32,7 +32,7 @@ from .. import targets
 class SwiftInspect(product.Product):
     @classmethod
     def product_source_name(cls):
-        return "swift-dt"
+        return "swift-inspect"
 
     @classmethod
     def is_build_script_impl_product(cls):


### PR DESCRIPTION
We did this rename everywhere else, just missed this one.
