### PR TITLE
[cxx-importer] Disable some tests on windows only on 5.4

### DIFF
--- a/test/Interop/Cxx/class/constructors-executable.swift
+++ b/test/Interop/Cxx/class/constructors-executable.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop)
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import StdlibUnittest
 import Constructors

--- a/test/Interop/Cxx/class/memory-layout-execution.swift
+++ b/test/Interop/Cxx/class/memory-layout-execution.swift
@@ -4,6 +4,7 @@
 // RUN: %target-run %t/class_layout 2&>1
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import MemoryLayout
 import StdlibUnittest

--- a/test/Interop/Cxx/class/type-classification-non-trivial.swift
+++ b/test/Interop/Cxx/class/type-classification-non-trivial.swift
@@ -4,6 +4,7 @@
 // RUN: %target-run %t/address_only 2&>1
 
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import TypeClassification
 import StdlibUnittest

--- a/test/Interop/Cxx/extern-var/extern-var.swift
+++ b/test/Interop/Cxx/extern-var/extern-var.swift
@@ -5,6 +5,7 @@
 // RUN: %target-run %t/extern-var
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import ExternVar
 import StdlibUnittest

--- a/test/Interop/Cxx/operators/non-member-inline.swift
+++ b/test/Interop/Cxx/operators/non-member-inline.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import NonMemberInline
 import StdlibUnittest

--- a/test/Interop/Cxx/operators/non-member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line.swift
@@ -5,6 +5,7 @@
 // RUN: %target-run %t/non-member-out-of-line
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import NonMemberOutOfLine
 import StdlibUnittest

--- a/test/Interop/Cxx/reference/reference.swift
+++ b/test/Interop/Cxx/reference/reference.swift
@@ -5,6 +5,7 @@
 // RUN: %target-run %t/reference
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import Reference
 import StdlibUnittest

--- a/test/Interop/Cxx/static/constexpr-static-member-var.swift
+++ b/test/Interop/Cxx/static/constexpr-static-member-var.swift
@@ -5,6 +5,7 @@
 // RUN: %target-run %t/statics
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import StaticMemberVar
 import StdlibUnittest

--- a/test/Interop/Cxx/static/inline-static-member-var.swift
+++ b/test/Interop/Cxx/static/inline-static-member-var.swift
@@ -5,6 +5,7 @@
 // RUN: %target-run %t/statics 2&>1
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import InlineStaticMemberVar
 import StdlibUnittest

--- a/test/Interop/Cxx/static/static-local-var.swift
+++ b/test/Interop/Cxx/static/static-local-var.swift
@@ -5,6 +5,7 @@
 // RUN: %target-run %t/statics
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import StaticLocalVar
 import StdlibUnittest

--- a/test/Interop/Cxx/static/static-member-func.swift
+++ b/test/Interop/Cxx/static/static-member-func.swift
@@ -5,6 +5,7 @@
 // RUN: %target-run %t/statics
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import StaticMemberFunc
 import StdlibUnittest

--- a/test/Interop/Cxx/static/static-member-var.swift
+++ b/test/Interop/Cxx/static/static-member-var.swift
@@ -5,6 +5,7 @@
 // RUN: %target-run %t/statics
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import StaticMemberVar
 import StdlibUnittest

--- a/test/Interop/Cxx/static/static-var.swift
+++ b/test/Interop/Cxx/static/static-var.swift
@@ -5,6 +5,7 @@
 // RUN: %target-run %t/statics
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import StaticVar
 import StdlibUnittest

--- a/test/Interop/Cxx/templates/canonical-types.swift
+++ b/test/Interop/Cxx/templates/canonical-types.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import CanonicalTypes
 import StdlibUnittest

--- a/test/Interop/Cxx/templates/class-template-eager-instatiation-problems.swift
+++ b/test/Interop/Cxx/templates/class-template-eager-instatiation-problems.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import ClassTemplateEagerInstantiationProblems
 import StdlibUnittest

--- a/test/Interop/Cxx/templates/class-template-non-type-parameter.swift
+++ b/test/Interop/Cxx/templates/class-template-non-type-parameter.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import ClassTemplateNonTypeParameter
 import StdlibUnittest

--- a/test/Interop/Cxx/templates/class-template-template-parameter.swift
+++ b/test/Interop/Cxx/templates/class-template-template-parameter.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import ClassTemplateTemplateParameter
 import StdlibUnittest

--- a/test/Interop/Cxx/templates/class-template-with-primitive-argument.swift
+++ b/test/Interop/Cxx/templates/class-template-with-primitive-argument.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import ClassTemplateWithPrimitiveArgument
 import StdlibUnittest

--- a/test/Interop/Cxx/templates/explicit-class-specialization.swift
+++ b/test/Interop/Cxx/templates/explicit-class-specialization.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import ExplicitClassSpecialization
 import StdlibUnittest

--- a/test/Interop/Cxx/templates/fully-pre-defined-class-template.swift
+++ b/test/Interop/Cxx/templates/fully-pre-defined-class-template.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import FullyPreDefinedClassTemplate
 import StdlibUnittest

--- a/test/Interop/Cxx/templates/function-template.swift
+++ b/test/Interop/Cxx/templates/function-template.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import FunctionTemplates
 import StdlibUnittest

--- a/test/Interop/Cxx/templates/not-pre-defined-class-template.swift
+++ b/test/Interop/Cxx/templates/not-pre-defined-class-template.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import NotPreDefinedClassTemplate
 import StdlibUnittest

--- a/test/Interop/Cxx/templates/partially-pre-defined-class-template.swift
+++ b/test/Interop/Cxx/templates/partially-pre-defined-class-template.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import PartiallyPreDefinedClassTemplate
 import StdlibUnittest

--- a/test/Interop/Cxx/templates/using-directive.swift
+++ b/test/Interop/Cxx/templates/using-directive.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
 //
 // REQUIRES: executable_test
+// XFAIL: OS=windows-msvc
 
 import StdlibUnittest
 import UsingDirective


### PR DESCRIPTION
Just noticed these failed when I was trying to land a different change to 5.4.

Trying to keep the PR test green.
