### PR TITLE
Backport some fixes for C++ interop tests on 5.4

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -520,21 +520,44 @@ importer::getNormalInvocationArguments(
     invocationArgStrs.push_back(
         "-Werror=non-modular-include-in-framework-module");
 
+  bool EnableCXXInterop = LangOpts.EnableCXXInterop;
+
   if (LangOpts.EnableObjCInterop) {
-    bool EnableCXXInterop = LangOpts.EnableCXXInterop;
-    invocationArgStrs.insert(
-        invocationArgStrs.end(),
-        {"-x", EnableCXXInterop ? "objective-c++" : "objective-c",
-         EnableCXXInterop ? "-std=gnu++17" : "-std=gnu11", "-fobjc-arc"});
+    invocationArgStrs.insert(invocationArgStrs.end(), {"-fobjc-arc"});
     // TODO: Investigate whether 7.0 is a suitable default version.
     if (!triple.isOSDarwin())
       invocationArgStrs.insert(invocationArgStrs.end(),
                                {"-fobjc-runtime=ios-7.0"});
+    invocationArgStrs.insert(invocationArgStrs.end(), {
+      "-x", EnableCXXInterop ? "objective-c++" : "objective-c"
+    });
   } else {
-    bool EnableCXXInterop = LangOpts.EnableCXXInterop;
-    invocationArgStrs.insert(invocationArgStrs.end(),
-                             {"-x", EnableCXXInterop ? "c++" : "c",
-                              EnableCXXInterop ? "-std=gnu++17" : "-std=gnu11"});
+    invocationArgStrs.insert(invocationArgStrs.end(), {
+      "-x", EnableCXXInterop ? "c++" : "c"
+    });
+  }
+
+  {
+    const clang::LangStandard &stdcxx =
+#if defined(CLANG_DEFAULT_STD_CXX)
+        *clang::LangStandard::getLangStandardForName(CLANG_DEFAULT_STD_CXX);
+#else
+        clang::LangStandard::getLangStandardForKind(
+            clang::LangStandard::lang_gnucxx14);
+#endif
+
+    const clang::LangStandard &stdc =
+#if defined(CLANG_DEFAULT_STD_C)
+        *clang::LangStandard::getLangStandardForName(CLANG_DEFAULT_STD_C);
+#else
+        clang::LangStandard::getLangStandardForKind(
+            clang::LangStandard::lang_gnu11);
+#endif
+
+    invocationArgStrs.insert(invocationArgStrs.end(), {
+      (Twine("-std=") + StringRef(EnableCXXInterop ? stdcxx.getName()
+                                                   : stdc.getName())).str()
+    });
   }
 
   // Set C language options.

--- a/test/ClangImporter/cxx_interop.swift
+++ b/test/ClangImporter/cxx_interop.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules -module-cache-path %t -enable-cxx-interop
+// RUN: %target-swiftxx-frontend -typecheck %s -I %S/Inputs/custom-modules
 
 import CXXInterop
 

--- a/test/ClangImporter/cxx_interop_ir.swift
+++ b/test/ClangImporter/cxx_interop_ir.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -module-name cxx_ir -I %S/Inputs/custom-modules -module-cache-path %t -enable-cxx-interop -emit-ir -o - -primary-file %s | %FileCheck %s
+// RUN: %target-swiftxx-frontend -module-name cxx_ir -I %S/Inputs/custom-modules -emit-ir -o - -primary-file %s | %FileCheck %s
 
 import CXXInterop
 

--- a/test/ClangImporter/enum-cxx.swift
+++ b/test/ClangImporter/enum-cxx.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -primary-file %s -I %S/Inputs/custom-modules -module-cache-path %t -enable-cxx-interop -o - | %FileCheck %s
+// RUN: %target-swiftxx-frontend -emit-ir -primary-file %s -I %S/Inputs/custom-modules -o - | %FileCheck %s
 
 import CXXInterop
 

--- a/test/Interop/C/function/emit-called-inline-function-irgen.swift
+++ b/test/Interop/C/function/emit-called-inline-function-irgen.swift
@@ -6,7 +6,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -I %S/Inputs -Xcc -std=c99 -emit-ir -o - | %FileCheck %s -check-prefix C99 --implicit-check-not notCalled
-// RUN: %target-swift-frontend %s -I %S/Inputs -enable-cxx-interop -emit-ir -o - | %FileCheck %s -check-prefix CXX --implicit-check-not notCalled
+// RUN: %target-swiftxx-frontend %s -I %S/Inputs -emit-ir -o - | %FileCheck %s -check-prefix CXX --implicit-check-not notCalled
 
 import EmitCalledInlineFunction
 

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -1,47 +1,59 @@
 module AccessSpecifiers {
   header "access-specifiers.h"
+  requires cplusplus
 }
 
 module TypeClassification {
   header "type-classification.h"
+  requires cplusplus
 }
 
 module Constructors {
   header "constructors.h"
+  requires cplusplus
 }
 
 module ConstructorsObjC {
   header "constructors-objc.h"
+  requires cplusplus
 }
 
 module LoadableTypes {
   header "loadable-types.h"
+  requires cplusplus
 }
 
 module MemberwiseInitializer {
   header "memberwise-initializer.h"
+  requires cplusplus
 }
 
 module MemoryLayout {
   header "memory-layout.h"
+  requires cplusplus
 }
 
 module MemberVariables {
   header "member-variables.h"
+  requires cplusplus
 }
 
 module ProtocolConformance {
   header "protocol-conformance.h"
+  requires cplusplus
 }
 
 module SynthesizedInitializers {
   header "synthesized-initializers.h"
+  requires cplusplus
 }
 
 module DebugInfo {
   header "debug-info.h"
+  requires cplusplus
 }
 
 module NestedRecords {
   header "nested-records.h"
+  requires cplusplus
 }

--- a/test/Interop/Cxx/class/constructors-silgen.swift
+++ b/test/Interop/Cxx/class/constructors-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -I %S/Inputs -enable-cxx-interop -emit-silgen %s | %FileCheck %s
+// RUN: %target-swiftxx-frontend -I %S/Inputs -emit-silgen %s | %FileCheck %s
 
 import Constructors
 

--- a/test/Interop/Cxx/class/debug-info-irgen.swift
+++ b/test/Interop/Cxx/class/debug-info-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-cxx-interop -I %S/Inputs %s -emit-ir -g | %FileCheck %s
+// RUN: %target-swiftxx-frontend -I %S/Inputs %s -emit-ir -g | %FileCheck %s
 
 // Validate that we don't crash when trying to deserialize C++ type debug info.
 // Note, however, that the actual debug info is not generated, see SR-13223.

--- a/test/Interop/Cxx/class/memory-layout-silgen.swift
+++ b/test/Interop/Cxx/class/memory-layout-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -I %S/Inputs -enable-cxx-interop -emit-ir -o - %s | %FileCheck %s
+// RUN: %target-swiftxx-frontend -I %S/Inputs -emit-ir -o - %s | %FileCheck %s
 
 import MemoryLayout
 

--- a/test/Interop/Cxx/class/type-classification-non-trivial-irgen.swift
+++ b/test/Interop/Cxx/class/type-classification-non-trivial-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-cxx-interop -I %S/Inputs %s -emit-ir | %FileCheck %s
+// RUN: %target-swiftxx-frontend -I %S/Inputs %s -emit-ir | %FileCheck %s
 
 // Verify that non-trival/address-only C++ classes are constructed and accessed
 // correctly. Make sure that we correctly IRGen functions that construct

--- a/test/Interop/Cxx/class/type-classification-non-trivial-silgen.swift
+++ b/test/Interop/Cxx/class/type-classification-non-trivial-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -I %S/Inputs -enable-cxx-interop -emit-silgen %s | %FileCheck %s
+// RUN: %target-swiftxx-frontend -I %S/Inputs -emit-silgen %s | %FileCheck %s
 
 import TypeClassification
 

--- a/test/Interop/Cxx/enum/Inputs/module.modulemap
+++ b/test/Interop/Cxx/enum/Inputs/module.modulemap
@@ -1,3 +1,4 @@
 module BoolEnums {
   header "bool-enums.h"
+  requires cplusplus
 }

--- a/test/Interop/Cxx/extern-var/Inputs/module.modulemap
+++ b/test/Interop/Cxx/extern-var/Inputs/module.modulemap
@@ -1,3 +1,4 @@
 module ExternVar {
   header "extern-var.h"
+  requires cplusplus
 }

--- a/test/Interop/Cxx/extern-var/extern-var.swift
+++ b/test/Interop/Cxx/extern-var/extern-var.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/extern-var.cpp -I %S/Inputs -o %t/extern-var.o
+// RUN: %target-clangxx -c %S/Inputs/extern-var.cpp -I %S/Inputs -o %t/extern-var.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/extern-var %t/extern-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/extern-var
 // RUN: %target-run %t/extern-var

--- a/test/Interop/Cxx/implementation-only-imports/Inputs/module.modulemap
+++ b/test/Interop/Cxx/implementation-only-imports/Inputs/module.modulemap
@@ -1,24 +1,29 @@
 module UserA {
     header "user-a.h"
     export *
+    requires cplusplus
 }
 
 module UserB {
     header "user-b.h"
     export *
+    requires cplusplus
 }
 
 module UserC {
     header "user-c.h"
     export *
+    requires cplusplus
 }
 
 module DeclA {
     header "decl-a.h"
     export *
+    requires cplusplus
 }
 
 module DeclB {
     header "decl-b.h"
     export *
+    requires cplusplus
 }

--- a/test/Interop/Cxx/implementation-only-imports/check-constructor-visibility-inversed.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-constructor-visibility-inversed.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s -enable-cxx-interop
+// RUN: %target-swiftxx-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s
 
 // Swift should consider all sources for a decl and recognize that the
 // decl is not hidden behind @_implementationOnly in all modules.

--- a/test/Interop/Cxx/implementation-only-imports/check-constructor-visibility.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-constructor-visibility.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s -enable-cxx-interop
+// RUN: %target-swiftxx-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s
 
 // Swift should consider all sources for a decl and recognize that the
 // decl is not hidden behind @_implementationOnly in all modules.

--- a/test/Interop/Cxx/implementation-only-imports/check-decls-are-identical.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-decls-are-identical.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: not %target-swift-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs -enable-cxx-interop %s 2>&1 | %FileCheck %s
+// RUN: not %target-swiftxx-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s 2>&1 | %FileCheck %s
 
 // This test checks that Swift recognizes that the DeclA and DeclB provide
 // different implementations for `getFortySomething()`

--- a/test/Interop/Cxx/implementation-only-imports/check-function-transitive-visibility-inversed.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-function-transitive-visibility-inversed.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: mkdir %t/use_module_a %t/use_module_b
-// RUN: %target-swift-frontend -enable-library-evolution -swift-version 5 -emit-module -o %t/use_module_a/UseModuleA.swiftmodule %S/Inputs/use-module-a.swift -I %S/Inputs -enable-cxx-interop
-// RUN: %target-swift-frontend -enable-library-evolution -swift-version 5 -emit-module -o %t/use_module_b/UseModuleB.swiftmodule %S/Inputs/use-module-b.swift -I %S/Inputs -enable-cxx-interop
+// RUN: %target-swiftxx-frontend -enable-library-evolution -swift-version 5 -emit-module -o %t/use_module_a/UseModuleA.swiftmodule %S/Inputs/use-module-a.swift -I %S/Inputs
+// RUN: %target-swiftxx-frontend -enable-library-evolution -swift-version 5 -emit-module -o %t/use_module_b/UseModuleB.swiftmodule %S/Inputs/use-module-b.swift -I %S/Inputs
 
-// RUN: %target-swift-frontend -typecheck -swift-version 5 -I %t/use_module_a -I %t/use_module_b -I %S/Inputs -enable-cxx-interop %s
+// RUN: %target-swiftxx-frontend -typecheck -swift-version 5 -I %t/use_module_a -I %t/use_module_b -I %S/Inputs %s
 
 // Swift should consider all sources for a decl and recognize that the
 // decl is not hidden behind @_implementationOnly in all modules.

--- a/test/Interop/Cxx/implementation-only-imports/check-function-transitive-visibility.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-function-transitive-visibility.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: mkdir %t/use_module_a %t/use_module_b
-// RUN: %target-swift-frontend -enable-library-evolution -swift-version 5 -emit-module -o %t/use_module_a/UseModuleA.swiftmodule %S/Inputs/use-module-a.swift -I %S/Inputs -enable-cxx-interop
-// RUN: %target-swift-frontend -enable-library-evolution -swift-version 5 -emit-module -o %t/use_module_b/UseModuleB.swiftmodule %S/Inputs/use-module-b.swift -I %S/Inputs -enable-cxx-interop
+// RUN: %target-swiftxx-frontend -enable-library-evolution -swift-version 5 -emit-module -o %t/use_module_a/UseModuleA.swiftmodule %S/Inputs/use-module-a.swift -I %S/Inputs
+// RUN: %target-swiftxx-frontend -enable-library-evolution -swift-version 5 -emit-module -o %t/use_module_b/UseModuleB.swiftmodule %S/Inputs/use-module-b.swift -I %S/Inputs
 
-// RUN: %target-swift-frontend -typecheck -swift-version 5 -I %t/use_module_a -I %t/use_module_b -I %S/Inputs -enable-cxx-interop %s
+// RUN: %target-swiftxx-frontend -typecheck -swift-version 5 -I %t/use_module_a -I %t/use_module_b -I %S/Inputs %s
 
 
 // Swift should consider all sources for a decl and recognize that the

--- a/test/Interop/Cxx/implementation-only-imports/check-function-visibility-inversed.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-function-visibility-inversed.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs -enable-cxx-interop %s
+// RUN: %target-swiftxx-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s
 
 // Swift should consider all sources for a decl and recognize that the
 // decl is not hidden behind @_implementationOnly in all modules.

--- a/test/Interop/Cxx/implementation-only-imports/check-function-visibility.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-function-visibility.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs -enable-cxx-interop %s
+// RUN: %target-swiftxx-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s
 
 // Swift should consider all sources for a decl and recognize that the
 // decl is not hidden behind @_implementationOnly in all modules.

--- a/test/Interop/Cxx/implementation-only-imports/check-operator-visibility-inversed.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-operator-visibility-inversed.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s -enable-cxx-interop
+// RUN: %target-swiftxx-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s
 
 // Swift should consider all sources for a decl and recognize that the
 // decl is not hidden behind @_implementationOnly in all modules.

--- a/test/Interop/Cxx/implementation-only-imports/check-operator-visibility.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-operator-visibility.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s -enable-cxx-interop
+// RUN: %target-swiftxx-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s
 
 // Swift should consider all sources for a decl and recognize that the
 // decl is not hidden behind @_implementationOnly in all modules.

--- a/test/Interop/Cxx/implementation-only-imports/skip-forward-declarations.swift
+++ b/test/Interop/Cxx/implementation-only-imports/skip-forward-declarations.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: not %target-swift-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs -enable-cxx-interop %s 2>&1 | %FileCheck %s
+// RUN: not %target-swiftxx-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s 2>&1 | %FileCheck %s
 
 // This test checks that forward declarations are not considered
 // when determining the visibility of the decl.

--- a/test/Interop/Cxx/operators/Inputs/module.modulemap
+++ b/test/Interop/Cxx/operators/Inputs/module.modulemap
@@ -1,15 +1,19 @@
 module MemberInline {
   header "member-inline.h"
+  requires cplusplus
 }
 
 module MemberOutOfLine {
   header "member-out-of-line.h"
+  requires cplusplus
 }
 
 module NonMemberInline {
   header "non-member-inline.h"
+  requires cplusplus
 }
 
 module NonMemberOutOfLine {
   header "non-member-out-of-line.h"
+  requires cplusplus
 }

--- a/test/Interop/Cxx/operators/member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -std=c++11 -c %S/Inputs/member-out-of-line.cpp -I %S/Inputs -o %t/member-out-of-line.o
+// RUN: %target-clangxx -c %S/Inputs/member-out-of-line.cpp -I %S/Inputs -o %t/member-out-of-line.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/member-out-of-line %t/member-out-of-line.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/member-out-of-line
 // RUN: %target-run %t/member-out-of-line

--- a/test/Interop/Cxx/operators/member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/member-out-of-line.cpp -I %S/Inputs -o %t/member-out-of-line.o
+// RUN: %target-clang -std=c++11 -c %S/Inputs/member-out-of-line.cpp -I %S/Inputs -o %t/member-out-of-line.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/member-out-of-line %t/member-out-of-line.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/member-out-of-line
 // RUN: %target-run %t/member-out-of-line

--- a/test/Interop/Cxx/operators/member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/member-out-of-line.cpp -I %S/Inputs -o %t/member-out-of-line.o -std=c++17
+// RUN: %target-clang -c %S/Inputs/member-out-of-line.cpp -I %S/Inputs -o %t/member-out-of-line.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/member-out-of-line %t/member-out-of-line.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/member-out-of-line
 // RUN: %target-run %t/member-out-of-line

--- a/test/Interop/Cxx/operators/non-member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -std=c++11 -c %S/Inputs/non-member-out-of-line.cpp -I %S/Inputs -o %t/non-member-out-of-line.o
+// RUN: %target-clangxx -c %S/Inputs/non-member-out-of-line.cpp -I %S/Inputs -o %t/non-member-out-of-line.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/non-member-out-of-line %t/non-member-out-of-line.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/non-member-out-of-line
 // RUN: %target-run %t/non-member-out-of-line

--- a/test/Interop/Cxx/operators/non-member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/non-member-out-of-line.cpp -I %S/Inputs -o %t/non-member-out-of-line.o -std=c++17
+// RUN: %target-clang -c %S/Inputs/non-member-out-of-line.cpp -I %S/Inputs -o %t/non-member-out-of-line.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/non-member-out-of-line %t/non-member-out-of-line.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/non-member-out-of-line
 // RUN: %target-run %t/non-member-out-of-line

--- a/test/Interop/Cxx/operators/non-member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/non-member-out-of-line.cpp -I %S/Inputs -o %t/non-member-out-of-line.o
+// RUN: %target-clang -std=c++11 -c %S/Inputs/non-member-out-of-line.cpp -I %S/Inputs -o %t/non-member-out-of-line.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/non-member-out-of-line %t/non-member-out-of-line.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/non-member-out-of-line
 // RUN: %target-run %t/non-member-out-of-line

--- a/test/Interop/Cxx/reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/reference/Inputs/module.modulemap
@@ -1,3 +1,4 @@
 module Reference {
   header "reference.h"
+  requires cplusplus
 }

--- a/test/Interop/Cxx/reference/reference.swift
+++ b/test/Interop/Cxx/reference/reference.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -std=c++11 -c %S/Inputs/reference.cpp -I %S/Inputs -o %t/reference.o
+// RUN: %target-clangxx -c %S/Inputs/reference.cpp -I %S/Inputs -o %t/reference.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/reference %t/reference.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/reference
 // RUN: %target-run %t/reference

--- a/test/Interop/Cxx/reference/reference.swift
+++ b/test/Interop/Cxx/reference/reference.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/reference.cpp -I %S/Inputs -o %t/reference.o
+// RUN: %target-clang -std=c++11 -c %S/Inputs/reference.cpp -I %S/Inputs -o %t/reference.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/reference %t/reference.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/reference
 // RUN: %target-run %t/reference

--- a/test/Interop/Cxx/reference/reference.swift
+++ b/test/Interop/Cxx/reference/reference.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/reference.cpp -I %S/Inputs -o %t/reference.o -std=c++17
+// RUN: %target-clang -c %S/Inputs/reference.cpp -I %S/Inputs -o %t/reference.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/reference %t/reference.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/reference
 // RUN: %target-run %t/reference

--- a/test/Interop/Cxx/static/Inputs/module.modulemap
+++ b/test/Interop/Cxx/static/Inputs/module.modulemap
@@ -1,19 +1,24 @@
 module StaticVar {
   header "static-var.h"
+  requires cplusplus
 }
 
 module StaticLocalVar {
   header "static-local-var.h"
+  requires cplusplus
 }
 
 module StaticMemberVar {
   header "static-member-var.h"
+  requires cplusplus
 }
 
 module InlineStaticMemberVar {
   header "inline-static-member-var.h"
+  requires cplusplus
 }
 
 module StaticMemberFunc {
   header "static-member-func.h"
+  requires cplusplus
 }

--- a/test/Interop/Cxx/static/constexpr-static-member-var.swift
+++ b/test/Interop/Cxx/static/constexpr-static-member-var.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -std=c++11 -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o
+// RUN: %target-clangxx -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o
 // NOTE: we must use `-O` here to ensure that the constexpr value is inlined and no undefined reference remains.
 // RUN: %target-build-swift -O %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics

--- a/test/Interop/Cxx/static/constexpr-static-member-var.swift
+++ b/test/Interop/Cxx/static/constexpr-static-member-var.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o -std=c++17
+// RUN: %target-clang -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o
 // NOTE: we must use `-O` here to ensure that the constexpr value is inlined and no undefined reference remains.
 // RUN: %target-build-swift -O %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics

--- a/test/Interop/Cxx/static/constexpr-static-member-var.swift
+++ b/test/Interop/Cxx/static/constexpr-static-member-var.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o
+// RUN: %target-clang -std=c++11 -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o
 // NOTE: we must use `-O` here to ensure that the constexpr value is inlined and no undefined reference remains.
 // RUN: %target-build-swift -O %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics

--- a/test/Interop/Cxx/static/constexpr-static-member-var.swift
+++ b/test/Interop/Cxx/static/constexpr-static-member-var.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clang -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o -std=c++17
-// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-cxx-interop
+// NOTE: we must use `-O` here to ensure that the constexpr value is inlined and no undefined reference remains.
+// RUN: %target-build-swift -O %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics
 //

--- a/test/Interop/Cxx/static/inline-static-member-var.swift
+++ b/test/Interop/Cxx/static/inline-static-member-var.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/inline-static-member-var.cpp -I %S/Inputs -o %t/inline-static-member-var.o
+// RUN: %target-clangxx -c %S/Inputs/inline-static-member-var.cpp -I %S/Inputs -o %t/inline-static-member-var.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/inline-static-member-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics 2&>1

--- a/test/Interop/Cxx/static/inline-static-member-var.swift
+++ b/test/Interop/Cxx/static/inline-static-member-var.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/inline-static-member-var.cpp -I %S/Inputs -o %t/inline-static-member-var.o -std=c++17
+// RUN: %target-clang -c %S/Inputs/inline-static-member-var.cpp -I %S/Inputs -o %t/inline-static-member-var.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/inline-static-member-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics 2&>1

--- a/test/Interop/Cxx/static/static-local-var.swift
+++ b/test/Interop/Cxx/static/static-local-var.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/static-local-var.cpp -I %S/Inputs -o %t/static-local-var.o
+// RUN: %target-clangxx -c %S/Inputs/static-local-var.cpp -I %S/Inputs -o %t/static-local-var.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-local-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics

--- a/test/Interop/Cxx/static/static-member-func.swift
+++ b/test/Interop/Cxx/static/static-member-func.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/static-member-func.cpp -I %S/Inputs -o %t/static-member-func.o
+// RUN: %target-clangxx -c %S/Inputs/static-member-func.cpp -I %S/Inputs -o %t/static-member-func.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-func.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics

--- a/test/Interop/Cxx/static/static-member-func.swift
+++ b/test/Interop/Cxx/static/static-member-func.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/static-member-func.cpp -I %S/Inputs -o %t/static-member-func.o -std=c++11
+// RUN: %target-clang -c %S/Inputs/static-member-func.cpp -I %S/Inputs -o %t/static-member-func.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-func.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics

--- a/test/Interop/Cxx/static/static-member-var-irgen.swift
+++ b/test/Interop/Cxx/static/static-member-var-irgen.swift
@@ -14,7 +14,10 @@
 //to depend on external definitions. However, our code generation pattern loads
 //the value dynamically. Instead, we should inline known constants. That would
 //allow Swift code to even read the value of WithIncompleteStaticMember::notDefined.
-// CHECK: @{{_ZN25WithConstexprStaticMember13definedInlineE|"\?definedInline@WithConstexprStaticMember@@2HB"}} = linkonce_odr {{(dso_local )?}}constant i32 139, {{(comdat, )?}}align 4
+// NOTE: we allow both available_externally and linkonce_odr as there are
+// differences in between MSVC and itanium model semantics where the constexpr
+// value is emitted into COMDAT.
+// CHECK: @{{_ZN25WithConstexprStaticMember13definedInlineE|"\?definedInline@WithConstexprStaticMember@@2HB"}} = {{available_externally|linkonce_odr}} {{(dso_local )?}}constant i32 139, {{(comdat, )?}}align 4
 
 import StaticMemberVar
 

--- a/test/Interop/Cxx/static/static-member-var.swift
+++ b/test/Interop/Cxx/static/static-member-var.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -std=c++11 -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o
+// RUN: %target-clangxx -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics

--- a/test/Interop/Cxx/static/static-member-var.swift
+++ b/test/Interop/Cxx/static/static-member-var.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o -std=c++11
+// RUN: %target-clang -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics

--- a/test/Interop/Cxx/static/static-member-var.swift
+++ b/test/Interop/Cxx/static/static-member-var.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o
+// RUN: %target-clang -std=c++11 -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics

--- a/test/Interop/Cxx/static/static-var.swift
+++ b/test/Interop/Cxx/static/static-var.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/static-var.cpp -I %S/Inputs -o %t/static-var.o
+// RUN: %target-clangxx -c %S/Inputs/static-var.cpp -I %S/Inputs -o %t/static-var.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics

--- a/test/Interop/Cxx/static/static-var.swift
+++ b/test/Interop/Cxx/static/static-var.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/static-var.cpp -I %S/Inputs -o %t/static-var.o -std=c++17
+// RUN: %target-clang -c %S/Inputs/static-var.cpp -I %S/Inputs -o %t/static-var.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics

--- a/test/Interop/Cxx/templates/Inputs/class-template-non-type-parameter.h
+++ b/test/Interop/Cxx/templates/Inputs/class-template-non-type-parameter.h
@@ -1,7 +1,11 @@
 #ifndef TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_NON_TYPE_PARAMETER_H
 #define TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_NON_TYPE_PARAMETER_H
 
-template<class T, auto Size>
+#if defined(__clang__)
+using size_t = __SIZE_TYPE__;
+#endif
+
+template<class T, size_t Size>
 struct MagicArray {
     T t[Size];
 };

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -1,67 +1,84 @@
 module ClassTemplateWithPrimitiveArgument {
   header "class-template-with-primitive-argument.h"
+  requires cplusplus
 }
 
 module NotPreDefinedClassTemplate {
   header "not-pre-defined-class-template.h"
+  requires cplusplus
 }
 
 module PartiallyPreDefinedClassTemplate {
   header "partially-pre-defined-class-template.h"
+  requires cplusplus
 }
 
 module FullyPreDefinedClassTemplate {
   header "fully-pre-defined-class-template.h"
+  requires cplusplus
 }
 
 module CanonicalTypes {
   header "canonical-types.h"
+  requires cplusplus
 }
 
 module ExplicitClassSpecialization {
   header "explicit-class-specialization.h"
+  requires cplusplus
 }
 
 module FunctionTemplates {
   header "function-templates.h"
+  requires cplusplus
 }
 
 module UsingDirective {
   header "using-directive.h"
+  requires cplusplus
 }
 
 module ClassTemplateEagerInstantiationProblems {
   header "class-template-eager-instantiation-problems.h"
+  requires cplusplus
 }
 
 module Mangling {
   header "mangling.h"
+  requires cplusplus
 }
 
 module LinkageOfSwiftSymbolsForImportedTypes {
   header "linkage-of-swift-symbols-for-imported-types.h"
+  requires cplusplus
 }
 
 module ClassTemplateVariadic {
   header "class-template-variadic.h"
+  requires cplusplus
 }
 
 module ClassTemplateNonTypeParameter {
   header "class-template-non-type-parameter.h"
+  requires cplusplus
 }
 
 module ClassTemplateTemplateParameter {
   header "class-template-template-parameter.h"
+  requires cplusplus
 }
 
 module ClassTemplateWithTypedef {
   header "class-template-with-typedef.h"
+  requires cplusplus
 }
 
 module ClassTemplateInNamespace {
   header "class-template-in-namespace.h"
+  requires cplusplus
 }
 
 module MemberTemplates {
   header "member-templates.h"
+  requires cplusplus
 }

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1953,6 +1953,7 @@ config.substitutions.append(('%target-jit-run', subst_target_jit_run))
 config.substitutions.append(('%target-build-swift-dylib\(([^)]+)\)', config.target_build_swift_dylib))
 config.substitutions.append(('%target-codesign', config.target_codesign))
 config.substitutions.append(('%target-build-swift', config.target_build_swift))
+config.substitutions.append(('%target-clangxx', '%s -std=c++11' % config.target_clang))
 config.substitutions.append(('%target-clang', config.target_clang))
 config.substitutions.append(('%target-ld', config.target_ld))
 if hasattr(config, 'target_cc_options'):

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1919,6 +1919,9 @@ if platform.system() != 'Darwin' or swift_test_mode == 'optimize_none_with_impli
 # When changing substitutions, update docs/Testing.md.
 #
 
+config.substitutions.append(('%target-clangxx', '%s -std=c++11' % config.target_clang))
+config.substitutions.append(('%target-swiftxx-frontend', '%s -enable-cxx-interop' % config.target_swift_frontend))
+
 config.substitutions.append(('%target-runtime', config.target_runtime))
 
 config.substitutions.append(('%target-typecheck-verify-swift', config.target_parse_verify_swift))
@@ -1953,7 +1956,6 @@ config.substitutions.append(('%target-jit-run', subst_target_jit_run))
 config.substitutions.append(('%target-build-swift-dylib\(([^)]+)\)', config.target_build_swift_dylib))
 config.substitutions.append(('%target-codesign', config.target_codesign))
 config.substitutions.append(('%target-build-swift', config.target_build_swift))
-config.substitutions.append(('%target-clangxx', '%s -std=c++11' % config.target_clang))
 config.substitutions.append(('%target-clang', config.target_clang))
 config.substitutions.append(('%target-ld', config.target_ld))
 if hasattr(config, 'target_cc_options'):


### PR DESCRIPTION
Backport some changes from main, which should repair the tests for the 5.4 release branch.  This should allow us to get the CI into a green state on Windows as well.