### PR TITLE
[5.5][Refactoring] Support refactoring calls to async if a variable or function is used as completion handler

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -4376,6 +4376,11 @@ struct AsyncHandlerParamDesc : public AsyncHandlerDesc {
     return AsyncHandlerParamDesc(AsyncHandlerDesc::get(Param, ignoreName),
                                  Index);
   }
+
+  bool operator==(const AsyncHandlerParamDesc &Other) const {
+    return Handler == Other.Handler && Type == Other.Type &&
+           HasError == Other.HasError && Index == Other.Index;
+  }
 };
 
 enum class ConditionType { INVALID, NIL, NOT_NIL };
@@ -4952,6 +4957,7 @@ public:
       OS << "await ";
       addCallToAsyncMethod(FD, TopHandler);
     });
+    OS << "\n";
     OS << tok::r_brace << "\n"; // end 'async'
     OS << tok::r_brace << "\n"; // end function body
     return true;
@@ -5300,6 +5306,22 @@ private:
       return;
     }
     if (auto CallbackDecl = getReferencedDecl(CallbackArg)) {
+      if (CallbackDecl == TopHandler.getHandler()) {
+        // We are refactoring the function that declared the completion handler
+        // that would be called here. We can't call the completion handler
+        // anymore because it will be removed. But since the function that
+        // declared it is being refactored to async, we can just return the
+        // values.
+        if (!HandlerDesc.willAsyncReturnVoid()) {
+          OS << tok::kw_return << " ";
+        }
+        addAwaitCall(CE, ArgList.ref(), ClassifiedBlock(), {}, HandlerDesc,
+                     /*AddDeclarations=*/false);
+        return;
+      }
+      // We are not removing the completion handler, so we can call it once the
+      // async function returns.
+
       // The completion handler that is called as part of the \p CE call.
       // This will be called once the async function returns.
       auto CompletionHandler = AsyncHandlerDesc::get(CallbackDecl,
@@ -5456,7 +5478,7 @@ private:
       OS << "\n";
       OS << tok::r_brace << " " << tok::kw_catch << " " << tok::l_brace << "\n";
       addCallToCompletionHandler(/*HasResult=*/false, HandlerDesc, HandlerName);
-      OS << "\n" << tok::r_brace << "\n"; // end catch
+      OS << "\n" << tok::r_brace; // end catch
     } else {
       if (!HandlerDesc.willAsyncReturnVoid()) {
         OS << tok::kw_let << " result";
@@ -5466,7 +5488,6 @@ private:
       AddAwaitCall();
       OS << "\n";
       addCallToCompletionHandler(/*HasResult=*/true, HandlerDesc, HandlerName);
-      OS << "\n";
     }
   }
 

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -4865,31 +4865,30 @@ public:
     FuncDecl *FD = cast<FuncDecl>(StartNode.get<Decl *>());
     Identifier CompletionHandlerName = TopHandler.Handler->getParameterName();
 
-    OS << "{\n"; // start function body
-    OS << "async {\n";
+    OS << tok::l_brace << "\n"; // start function body
+    OS << "async " << tok::l_brace << "\n";
     if (TopHandler.HasError) {
-      OS << "do {\n";
+      addDo();
       if (!TopHandler.willAsyncReturnVoid()) {
-        OS << "let result";
+        OS << tok::kw_let << " result";
         addResultTypeAnnotationIfNecessary(FD, TopHandler);
-        OS << " = ";
+        OS << " " << tok::equal << " ";
       }
-      OS << "try await ";
+      OS << tok::kw_try << " await ";
       addCallToAsyncMethod(FD, TopHandler);
       OS << "\n";
       addCallToCompletionHandler(/*HasResult=*/true, CompletionHandlerName, FD,
                                  TopHandler);
       OS << "\n"
-         << "} catch {\n";
+         << tok::r_brace << " " << tok::kw_catch << " " << tok::l_brace << "\n";
       addCallToCompletionHandler(/*HasResult=*/false, CompletionHandlerName, FD,
                                  TopHandler);
-      OS << "\n"
-         << "}\n"; // end catch
+      OS << "\n" << tok::r_brace << "\n"; // end catch
     } else {
       if (!TopHandler.willAsyncReturnVoid()) {
-        OS << "let result";
+        OS << tok::kw_let << " result";
         addResultTypeAnnotationIfNecessary(FD, TopHandler);
-        OS << " = ";
+        OS << " " << tok::equal << " ";
       }
       OS << "await ";
       addCallToAsyncMethod(FD, TopHandler);
@@ -4898,8 +4897,8 @@ public:
                                  TopHandler);
       OS << "\n";
     }
-    OS << "}\n"; // end 'async'
-    OS << "}\n"; // end function body
+    OS << tok::r_brace << "\n"; // end 'async'
+    OS << tok::r_brace << "\n"; // end function body
     return true;
   }
 
@@ -5518,7 +5517,7 @@ private:
   /// 'await' keyword.
   void addCallToAsyncMethod(const FuncDecl *FD,
                             const AsyncHandlerDesc &HandlerDesc) {
-    OS << FD->getBaseName() << "(";
+    OS << FD->getBaseName() << tok::l_paren;
     bool FirstParam = true;
     for (auto Param : *FD->getParameters()) {
       if (Param == HandlerDesc.Handler) {
@@ -5526,16 +5525,16 @@ private:
         continue;
       }
       if (!FirstParam) {
-        OS << ", ";
+        OS << tok::comma << " ";
       } else {
         FirstParam = false;
       }
       if (!Param->getArgumentName().empty()) {
-        OS << Param->getArgumentName() << ": ";
+        OS << Param->getArgumentName() << tok::colon << " ";
       }
       OS << Param->getParameterName();
     }
-    OS << ")";
+    OS << tok::r_paren;
   }
 
   /// If the error type of \p HandlerDesc is more specialized than \c Error,
@@ -5545,7 +5544,7 @@ private:
                                            const ASTContext &Ctx) {
     auto ErrorType = *HandlerDesc.getErrorType();
     if (ErrorType->getCanonicalType() != Ctx.getExceptionType()) {
-      OS << " as! ";
+      OS << " " << tok::kw_as << tok::exclaim_postfix << " ";
       ErrorType->lookThroughSingleOptionalType()->print(OS);
     }
   }
@@ -5567,18 +5566,18 @@ private:
         OS << "error";
         addCastToCustomErrorTypeIfNecessary(HandlerDesc, FD->getASTContext());
       } else {
-        OS << "nil";
+        OS << tok::kw_nil;
       }
     } else {
       if (!HasResult) {
-        OS << "nil";
+        OS << tok::kw_nil;
       } else if (HandlerDesc
                      .getSuccessParamAsyncReturnType(
                          HandlerDesc.params()[Index].getPlainType())
                      ->isVoid()) {
         // Void return types are not returned by the async function, synthesize
         // a Void instance.
-        OS << "()";
+        OS << tok::l_paren << tok::r_paren;
       } else if (HandlerDesc.getSuccessParams().size() > 1) {
         // If the async method returns a tuple, we need to pass its elements to
         // the completion handler separately. For example:
@@ -5593,7 +5592,7 @@ private:
         //     completion(result.0, result.1)
         //   }
         // }
-        OS << "result." << Index;
+        OS << "result" << tok::period << Index;
       } else {
         OS << "result";
       }
@@ -5609,7 +5608,7 @@ private:
   void addCallToCompletionHandler(bool HasResult, Identifier HandlerName,
                                   const FuncDecl *FD,
                                   const AsyncHandlerDesc &HandlerDesc) {
-    OS << HandlerName << "(";
+    OS << HandlerName << tok::l_paren;
 
     // Construct arguments to pass to the completion handler
     switch (HandlerDesc.Type) {
@@ -5619,7 +5618,7 @@ private:
     case HandlerType::PARAMS: {
       for (size_t I = 0; I < HandlerDesc.params().size(); ++I) {
         if (I > 0) {
-          OS << ", ";
+          OS << tok::comma << " ";
         }
         addCompletionHandlerArgument(I, HasResult, FD, HandlerDesc);
       }
@@ -5627,16 +5626,17 @@ private:
     }
     case HandlerType::RESULT: {
       if (HasResult) {
-        OS << ".success(result)";
+        OS << tok::period_prefix << "success" << tok::l_paren << "result"
+           << tok::r_paren;
       } else {
-        OS << ".failure(error";
+        OS << tok::period_prefix << "failure" << tok::l_paren << "error";
         addCastToCustomErrorTypeIfNecessary(HandlerDesc, FD->getASTContext());
-        OS << ")";
+        OS << tok::r_paren;
       }
       break;
     }
     }
-    OS << ")"; // Close the call to the completion handler
+    OS << tok::r_paren; // Close the call to the completion handler
   }
 
   /// Adds the result type of a refactored async function that previously
@@ -5645,14 +5645,15 @@ private:
     SmallVector<Type, 2> Scratch;
     auto ReturnTypes = HandlerDesc.getAsyncReturnTypes(Scratch);
     if (ReturnTypes.size() > 1) {
-      OS << "(";
+      OS << tok::l_paren;
     }
 
     llvm::interleave(
-        ReturnTypes, [&](Type Ty) { Ty->print(OS); }, [&]() { OS << ", "; });
+        ReturnTypes, [&](Type Ty) { Ty->print(OS); },
+        [&]() { OS << tok::comma << " "; });
 
     if (ReturnTypes.size() > 1) {
-      OS << ")";
+      OS << tok::r_paren;
     }
   }
 
@@ -5677,7 +5678,7 @@ private:
   void addResultTypeAnnotationIfNecessary(const FuncDecl *FD,
                                           const AsyncHandlerDesc &HandlerDesc) {
     if (FD->isGeneric()) {
-      OS << ": ";
+      OS << tok::colon << " ";
       addAsyncFuncReturnType(HandlerDesc);
     }
   }

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -4989,28 +4989,7 @@ private:
                                        "if the original function throws");
       return false;
     }
-    switch (TopHandler.Type) {
-    case HandlerType::INVALID:
-      return false;
-    case HandlerType::PARAMS: {
-      if (TopHandler.HasError) {
-        // The non-error parameters must be optional so that we can set them to
-        // nil in the error case.
-        // The error parameter must be optional so we can set it to nil in the
-        // success case.
-        // Otherwise we can't synthesize the values to return for these
-        // parameters.
-        return llvm::all_of(TopHandler.params(),
-                            [](AnyFunctionType::Param Param) -> bool {
-                              return Param.getPlainType()->isOptional();
-                            });
-      } else {
-        return true;
-      }
-    }
-    case HandlerType::RESULT:
-      return true;
-    }
+    return TopHandler.isValid();
   }
 
 
@@ -5683,6 +5662,21 @@ private:
     }
   }
 
+  /// If \p T has a natural default value like \c nil for \c Optional or \c ()
+  /// for \c Void, add that default value to the output. Otherwise, add a
+  /// placeholder that contains \p T's name as the hint.
+  void addDefaultValueOrPlaceholder(Type T) {
+    if (T->isOptional()) {
+      OS << tok::kw_nil;
+    } else if (T->isVoid()) {
+      OS << "()";
+    } else {
+      OS << "<#";
+      T.print(OS);
+      OS << "#>";
+    }
+  }
+
   /// Adds the \c Index -th parameter to the completion handler described by \p
   /// HanderDesc.
   /// If \p HasResult is \c true, it is assumed that a variable named
@@ -5699,11 +5693,11 @@ private:
         OS << "error";
         addCastToCustomErrorTypeIfNecessary(HandlerDesc);
       } else {
-        OS << tok::kw_nil;
+        addDefaultValueOrPlaceholder(HandlerDesc.params()[Index].getPlainType());
       }
     } else {
       if (!HasResult) {
-        OS << tok::kw_nil;
+        addDefaultValueOrPlaceholder(HandlerDesc.params()[Index].getPlainType());
       } else if (HandlerDesc
                      .getSuccessParamAsyncReturnType(
                          HandlerDesc.params()[Index].getPlainType())

--- a/test/refactoring/ConvertAsync/basic.swift
+++ b/test/refactoring/ConvertAsync/basic.swift
@@ -111,11 +111,18 @@ func errorOnly(completion: (Error?) -> Void) { }
 // ASYNC-ERRORONLY-NEXT: }
 // ASYNC-ERRORONLY: func errorOnly() async throws { }
 
-// RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-ERRORNONOPTIONALRESULT %s
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-ERRORNONOPTIONALRESULT %s
 func errorNonOptionalResult(completion: (String, Error?) -> Void) { }
-// We cannot convert the deprecated non-async method to call the async method because we can't synthesize the non-optional completion param. Smoke check for some keywords that would indicate we rewrote the body.
-// ASYNC-ERRORNONOPTIONALRESULT-NOT: detach
-// ASYNC-ERRORNONOPTIONALRESULT-NOT: await
+// ASYNC-ERRORNONOPTIONALRESULT: {
+// ASYNC-ERRORNONOPTIONALRESULT-NEXT: async {
+// ASYNC-ERRORNONOPTIONALRESULT-NEXT: do {
+// ASYNC-ERRORNONOPTIONALRESULT-NEXT: let result = try await errorNonOptionalResult()
+// ASYNC-ERRORNONOPTIONALRESULT-NEXT: completion(result, nil)
+// ASYNC-ERRORNONOPTIONALRESULT-NEXT: } catch {
+// ASYNC-ERRORNONOPTIONALRESULT-NEXT: completion(<#String#>, error)
+// ASYNC-ERRORNONOPTIONALRESULT-NEXT: }
+// ASYNC-ERRORNONOPTIONALRESULT-NEXT: }
+// ASYNC-ERRORNONOPTIONALRESULT-NEXT: }
 // ASYNC-ERRORNONOPTIONALRESULT: func errorNonOptionalResult() async throws -> String { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-CUSTOMERROR %s
@@ -244,9 +251,18 @@ func mixed(_ completion: (String?, Int) -> Void) { }
 // MIXED-NEXT: }
 // MIXED: func mixed() async -> (String?, Int) { }
 
-// RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MIXED-OPTIONAL-ERROR %s
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
 func mixedOptionalError(_ completion: (String?, Int, Error?) -> Void) { }
-// MIXED-OPTIONAL-ERROR-NOT: async {
+// MIXED-OPTIONAL-ERROR: {
+// MIXED-OPTIONAL-ERROR-NEXT: async {
+// MIXED-OPTIONAL-ERROR-NEXT: do {
+// MIXED-OPTIONAL-ERROR-NEXT: let result = try await mixedOptionalError()
+// MIXED-OPTIONAL-ERROR-NEXT: completion(result.0, result.1, nil)
+// MIXED-OPTIONAL-ERROR-NEXT: } catch {
+// MIXED-OPTIONAL-ERROR-NEXT: completion(nil, <#Int#>, error)
+// MIXED-OPTIONAL-ERROR-NEXT: }
+// MIXED-OPTIONAL-ERROR-NEXT: }
+// MIXED-OPTIONAL-ERROR-NEXT: }
 // MIXED-OPTIONAL-ERROR: func mixedOptionalError() async throws -> (String, Int) { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MIXED-ERROR %s
@@ -450,9 +466,18 @@ func tooVoidProperAndErrorCompletion(completion: (Void?, String?, Error?) -> Voi
 // VOID-PROPER-AND-ERROR-HANDLER-NEXT: }
 // VOID-PROPER-AND-ERROR-HANDLER: func tooVoidProperAndErrorCompletion() async throws -> (Void, String) {}
 
-// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix VOID-AND-ERROR-HANDLER %s
+// RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
 func voidAndErrorCompletion(completion: (Void, Error?) -> Void) {}
-// VOID-AND-ERROR-HANDLER-NOT: async {
+// VOID-AND-ERROR-HANDLER: {
+// VOID-AND-ERROR-HANDLER-NEXT: async {
+// VOID-AND-ERROR-HANDLER-NEXT: do {
+// VOID-AND-ERROR-HANDLER-NEXT: try await voidAndErrorCompletion()
+// VOID-AND-ERROR-HANDLER-NEXT: completion((), nil)
+// VOID-AND-ERROR-HANDLER-NEXT: } catch {
+// VOID-AND-ERROR-HANDLER-NEXT: completion((), error)
+// VOID-AND-ERROR-HANDLER-NEXT: }
+// VOID-AND-ERROR-HANDLER-NEXT: }
+// VOID-AND-ERROR-HANDLER-NEXT: }
 // VOID-AND-ERROR-HANDLER: func voidAndErrorCompletion() async throws {}
 
 // 2. Check that the various ways to call a function (and the positions the

--- a/test/refactoring/ConvertAsync/variable_as_callback.swift
+++ b/test/refactoring/ConvertAsync/variable_as_callback.swift
@@ -89,10 +89,16 @@ func testErrorOnlyWithVariableCompletionHandler(completionHandler: (Error?) -> V
 // ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(error)
 // ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-NEXT: }
 
-// FIXME: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3  | %FileCheck -check-prefix=ERROR-NON-OPTIONAL-RESULT %s
 func testErrorNonOptionalResultWithVariableCompletionHandler(completionHandler: (String, Error?) -> Void) {
   errorNonOptionalResult(completion: completionHandler)
 }
+// ERROR-NON-OPTIONAL-RESULT: do {
+// ERROR-NON-OPTIONAL-RESULT-NEXT: let result = try await errorNonOptionalResult()
+// ERROR-NON-OPTIONAL-RESULT-NEXT: completionHandler(result, nil)
+// ERROR-NON-OPTIONAL-RESULT-NEXT: } catch {
+// ERROR-NON-OPTIONAL-RESULT-NEXT: completionHandler(<#String#>, error)
+// ERROR-NON-OPTIONAL-RESULT-NEXT: }
 
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ALIAS-VARIABLE-COMPLETION-HANDLER %s
 func testAliasWithVariableCompletionHandler(completionHandler: SomeCallback) {

--- a/test/refactoring/ConvertAsync/variable_as_callback.swift
+++ b/test/refactoring/ConvertAsync/variable_as_callback.swift
@@ -24,52 +24,88 @@ func genericResult<T>(completion: (T?, Error?) -> Void) where T: Numeric { }
 func genericError<E>(completion: (String?, E?) -> Void) where E: Error { }
 func defaultArgs(a: Int, b: Int = 10, completion: (String) -> Void) { }
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=SIMPLE-WITH-VARIABLE-COMPLETION-HANDLER-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SIMPLE-WITH-VARIABLE-COMPLETION-HANDLER %s
 func testSimpleWithVariableCompletionHandler(completionHandler: (String) -> Void) {
   simple(completion: completionHandler)
 }
+// SIMPLE-WITH-VARIABLE-COMPLETION-HANDLER-FUNC: func testSimpleWithVariableCompletionHandler() async -> String {
+// SIMPLE-WITH-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await simple()
+// SIMPLE-WITH-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+
 // SIMPLE-WITH-VARIABLE-COMPLETION-HANDLER: let result = await simple()
 // SIMPLE-WITH-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result)
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=SIMPLE-WITH-ARG-VARIABLE-COMPLETION-HANDLER-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SIMPLE-WITH-ARG-VARIABLE-COMPLETION-HANDLER %s
 func testSimpleWithArgVariableCompletionHandler(b: Int, completionHandler: (String) -> Void) {
   simpleWithArg(a: b, completion: completionHandler)
 }
+// SIMPLE-WITH-ARG-VARIABLE-COMPLETION-HANDLER-FUNC: func testSimpleWithArgVariableCompletionHandler(b: Int) async -> String {
+// SIMPLE-WITH-ARG-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await simpleWithArg(a: b)
+// SIMPLE-WITH-ARG-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+
 // SIMPLE-WITH-ARG-VARIABLE-COMPLETION-HANDLER: let result = await simpleWithArg(a: b)
 // SIMPLE-WITH-ARG-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result)
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=SIMPLE-WITH-CONSTANT-ARG-VARIABLE-COMPLETION-HANDLER-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SIMPLE-WITH-CONSTANT-ARG-VARIABLE-COMPLETION-HANDLER %s
 func testSimpleWithConstantArgVariableCompletionHandler(completionHandler: (String) -> Void) {
   simpleWithArg(a: 1, completion: completionHandler)
 }
+// SIMPLE-WITH-CONSTANT-ARG-VARIABLE-COMPLETION-HANDLER-FUNC: func testSimpleWithConstantArgVariableCompletionHandler() async -> String {
+// SIMPLE-WITH-CONSTANT-ARG-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await simpleWithArg(a: 1)
+// SIMPLE-WITH-CONSTANT-ARG-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+
 // SIMPLE-WITH-CONSTANT-ARG-VARIABLE-COMPLETION-HANDLER: let result = await simpleWithArg(a: 1)
 // SIMPLE-WITH-CONSTANT-ARG-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result)
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=MULTIPLE-RESULTS-VARIABLE-COMPLETION-HANDLER-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=MULTIPLE-RESULTS-VARIABLE-COMPLETION-HANDLER %s
 func testMultipleResultsVariableCompletionHandler(completionHandler: (String, Int) -> Void) {
   multipleResults(completion: completionHandler)
 }
+// MULTIPLE-RESULTS-VARIABLE-COMPLETION-HANDLER-FUNC: func testMultipleResultsVariableCompletionHandler() async -> (String, Int) {
+// MULTIPLE-RESULTS-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await multipleResults()
+// MULTIPLE-RESULTS-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+
 // MULTIPLE-RESULTS-VARIABLE-COMPLETION-HANDLER: let result = await multipleResults()
 // MULTIPLE-RESULTS-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result.0, result.1)
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=NON-OPTIONAL-ERROR-VARIABLE-COMPLETION-HANDLER-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=NON-OPTIONAL-ERROR-VARIABLE-COMPLETION-HANDLER %s
 func testNonOptionalErrorVariableCompletionHandler(completionHandler: (String, Error) -> Void) {
   nonOptionalError(completion: completionHandler)
 }
+// NON-OPTIONAL-ERROR-VARIABLE-COMPLETION-HANDLER-FUNC: func testNonOptionalErrorVariableCompletionHandler() async -> (String, Error) {
+// NON-OPTIONAL-ERROR-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await nonOptionalError()
+// NON-OPTIONAL-ERROR-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+
 // NON-OPTIONAL-ERROR-VARIABLE-COMPLETION-HANDLER: let result = await nonOptionalError()
 // NON-OPTIONAL-ERROR-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result.0, result.1)
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=NO-PARAMS-VARIABLE-COMPLETION-HANDLER-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=NO-PARAMS-VARIABLE-COMPLETION-HANDLER %s
 func testNoParamsVariableCompletionHandler(completionHandler: () -> Void) {
   noParams(completion: completionHandler)
 }
+// NO-PARAMS-VARIABLE-COMPLETION-HANDLER-FUNC: func testNoParamsVariableCompletionHandler() async {
+// NO-PARAMS-VARIABLE-COMPLETION-HANDLER-FUNC-NOT: return
+// NO-PARAMS-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  await noParams()
+// NO-PARAMS-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+
 // NO-PARAMS-VARIABLE-COMPLETION-HANDLER: await noParams()
 // NO-PARAMS-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler()
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=ERROR-VARIABLE-COMPLETION-HANDLER-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ERROR-VARIABLE-COMPLETION-HANDLER %s
 func testErrorWithVariableCompletionHandler(completionHandler: (String?, Error?) -> Void) {
   error(completion: completionHandler)
 }
+// ERROR-VARIABLE-COMPLETION-HANDLER-FUNC: func testErrorWithVariableCompletionHandler() async throws -> String {
+// ERROR-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return try await error()
+// ERROR-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+
 // ERROR-VARIABLE-COMPLETION-HANDLER: do {
 // ERROR-VARIABLE-COMPLETION-HANDLER-NEXT:   let result = try await error()
 // ERROR-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(result, nil)
@@ -77,11 +113,16 @@ func testErrorWithVariableCompletionHandler(completionHandler: (String?, Error?)
 // ERROR-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(nil, error)
 // ERROR-VARIABLE-COMPLETION-HANDLER-NEXT: }
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ERROR-ONLY-VARIABLE-COMPLETION-HANDLER %s
 func testErrorOnlyWithVariableCompletionHandler(completionHandler: (Error?) -> Void) {
   errorOnly(completion: completionHandler)
-
 }
+// ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-FUNC: func testErrorOnlyWithVariableCompletionHandler() async throws {
+// ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-FUNC-NOT:   return
+// ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:   try await errorOnly()
+// ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+
 // ERROR-ONLY-VARIABLE-COMPLETION-HANDLER: do {
 // ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-NEXT:   try await errorOnly()
 // ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(nil)
@@ -89,10 +130,15 @@ func testErrorOnlyWithVariableCompletionHandler(completionHandler: (Error?) -> V
 // ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(error)
 // ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-NEXT: }
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1  | %FileCheck -check-prefix=ERROR-NON-OPTIONAL-RESULT-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3  | %FileCheck -check-prefix=ERROR-NON-OPTIONAL-RESULT %s
 func testErrorNonOptionalResultWithVariableCompletionHandler(completionHandler: (String, Error?) -> Void) {
   errorNonOptionalResult(completion: completionHandler)
 }
+// ERROR-NON-OPTIONAL-RESULT-FUNC: func testErrorNonOptionalResultWithVariableCompletionHandler() async throws -> String {
+// ERROR-NON-OPTIONAL-RESULT-FUNC-NEXT:  return try await errorNonOptionalResult()
+// ERROR-NON-OPTIONAL-RESULT-FUNC-NEXT: }
+
 // ERROR-NON-OPTIONAL-RESULT: do {
 // ERROR-NON-OPTIONAL-RESULT-NEXT: let result = try await errorNonOptionalResult()
 // ERROR-NON-OPTIONAL-RESULT-NEXT: completionHandler(result, nil)
@@ -100,24 +146,39 @@ func testErrorNonOptionalResultWithVariableCompletionHandler(completionHandler: 
 // ERROR-NON-OPTIONAL-RESULT-NEXT: completionHandler(<#String#>, error)
 // ERROR-NON-OPTIONAL-RESULT-NEXT: }
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=ALIAS-VARIABLE-COMPLETION-HANDLER-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ALIAS-VARIABLE-COMPLETION-HANDLER %s
 func testAliasWithVariableCompletionHandler(completionHandler: SomeCallback) {
   alias(completion: completionHandler)
 }
+// ALIAS-VARIABLE-COMPLETION-HANDLER-FUNC: func testAliasWithVariableCompletionHandler() async -> String {
+// ALIAS-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await alias()
+// ALIAS-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+
 // ALIAS-VARIABLE-COMPLETION-HANDLER: let result = await alias()
 // ALIAS-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result)
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=SIMPLE-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SIMPLE-RESULT-VARIABLE-COMPLETION-HANDLER %s
 func testSimpleResultVariableCompletionHandler(completionHandler: (Result<String, Never>) -> Void) {
   simpleResult(completion: completionHandler)
 }
+// SIMPLE-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC: func testSimpleResultVariableCompletionHandler() async -> String {
+// SIMPLE-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await simpleResult()
+// SIMPLE-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+
 // SIMPLE-RESULT-VARIABLE-COMPLETION-HANDLER: let result = await simpleResult()
 // SIMPLE-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(.success(result))
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ERROR-RESULT-VARIABLE-COMPLETION-HANDLER %s
 func testErrorResultVariableCompletionHandler(completionHandler: (Result<String, Error>) -> Void) {
   errorResult(completion: completionHandler)
 }
+// ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC: func testErrorResultVariableCompletionHandler() async throws -> String {
+// ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return try await errorResult()
+// ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+
 // ERROR-RESULT-VARIABLE-COMPLETION-HANDLER: do {
 // ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   let result = try await errorResult()
 // ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(.success(result))
@@ -125,10 +186,15 @@ func testErrorResultVariableCompletionHandler(completionHandler: (Result<String,
 // ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(.failure(error))
 // ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT: }
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER %s
 func testErrorResultVariableCompletionHandler(completionHandler: (Result<String, CustomError>) -> Void) {
   customErrorResult(completion: completionHandler)
 }
+// CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC: func testErrorResultVariableCompletionHandler() async throws -> String {
+// CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return try await customErrorResult()
+// CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+
 // CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER: do {
 // CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   let result = try await customErrorResult()
 // CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(.success(result))
@@ -136,38 +202,63 @@ func testErrorResultVariableCompletionHandler(completionHandler: (Result<String,
 // CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(.failure(error as! CustomError))
 // CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT: }
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=OPTIONAL-SINGLE-VARIABLE-COMPLETION-HANDLER-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=OPTIONAL-SINGLE-VARIABLE-COMPLETION-HANDLER %s
 func testOptionalSingleVariableCompletionHandler(completionHandler: (String?) -> Void) {
   optionalSingle(completion: completionHandler)
 }
+// OPTIONAL-SINGLE-VARIABLE-COMPLETION-HANDLER-FUNC: func testOptionalSingleVariableCompletionHandler() async -> String? {
+// OPTIONAL-SINGLE-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await optionalSingle()
+// OPTIONAL-SINGLE-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+
 // OPTIONAL-SINGLE-VARIABLE-COMPLETION-HANDLER: let result = await optionalSingle()
 // OPTIONAL-SINGLE-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result)
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=MANY-OPTIONAL-VARIABLE-COMPLETION-HANDLER-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=MANY-OPTIONAL-VARIABLE-COMPLETION-HANDLER %s
 func testManyOptionalVariableCompletionHandler(completionHandler: (String?, Int?) -> Void) {
   manyOptional(completionHandler)
 }
+// MANY-OPTIONAL-VARIABLE-COMPLETION-HANDLER-FUNC: func testManyOptionalVariableCompletionHandler() async -> (String?, Int?) {
+// MANY-OPTIONAL-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await manyOptional()
+// MANY-OPTIONAL-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+
 // MANY-OPTIONAL-VARIABLE-COMPLETION-HANDLER: let result = await manyOptional()
 // MANY-OPTIONAL-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result.0, result.1)
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=GENERIC-VARIABLE-COMPLETION-HANDLER-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=GENERIC-VARIABLE-COMPLETION-HANDLER %s
 func testGenericVariableCompletionHandler<T, R>(completionHandler: (T, R) -> Void) {
   generic(completion: completionHandler)
 }
+// GENERIC-VARIABLE-COMPLETION-HANDLER-FUNC: func testGenericVariableCompletionHandler<T, R>() async -> (T, R) {
+// GENERIC-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await generic()
+// GENERIC-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+
 // GENERIC-VARIABLE-COMPLETION-HANDLER: let result: (T, R) = await generic()
 // GENERIC-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result.0, result.1)
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=SPECIALIZE-GENERIC-VARIABLE-COMPLETION-HANDLER-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SPECIALIZE-GENERIC-VARIABLE-COMPLETION-HANDLER %s
 func testSpecializeGenericsVariableCompletionHandler(completionHandler: (String, Int) -> Void) {
   generic(completion: completionHandler)
 }
+// SPECIALIZE-GENERIC-VARIABLE-COMPLETION-HANDLER-FUNC: func testSpecializeGenericsVariableCompletionHandler() async -> (String, Int) {
+// SPECIALIZE-GENERIC-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await generic()
+// SPECIALIZE-GENERIC-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+
 // SPECIALIZE-GENERIC-VARIABLE-COMPLETION-HANDLER: let result: (String, Int) = await generic()
 // SPECIALIZE-GENERIC-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result.0, result.1)
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER %s
 func testGenericResultVariableCompletionHandler<T>(completionHandler: (T?, Error?) -> Void) where T: Numeric {
   genericResult(completion: completionHandler)
 }
+// GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC: func testGenericResultVariableCompletionHandler<T>() async throws -> T where T: Numeric {
+// GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return try await genericResult()
+// GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+
 // GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER: do {
 // GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   let result: T = try await genericResult()
 // GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(result, nil)
@@ -175,10 +266,15 @@ func testGenericResultVariableCompletionHandler<T>(completionHandler: (T?, Error
 // GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(nil, error)
 // GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT: }
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER %s
 func testGenericErrorVariableCompletionHandler<MyGenericError>(completionHandler: (String?, MyGenericError?) -> Void) where MyGenericError: Error {
   genericError(completion: completionHandler)
 }
+// GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-FUNC: func testGenericErrorVariableCompletionHandler<MyGenericError>() async throws -> String where MyGenericError: Error {
+// GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return try await genericError()
+// GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+
 // GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER: do {
 // GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-NEXT:   let result: String = try await genericError()
 // GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(result, nil)
@@ -186,10 +282,15 @@ func testGenericErrorVariableCompletionHandler<MyGenericError>(completionHandler
 // GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(nil, error as! MyGenericError)
 // GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-NEXT: }
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=DEFAULT-ARGS-VARIABLE-COMPLETION-HANDLER-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=DEFAULT-ARGS-VARIABLE-COMPLETION-HANDLER %s
 func testDefaultArgsVariableCompletionHandler(completionHandler: (String) -> Void) {
   defaultArgs(a: 5, completion: completionHandler)
 }
+// DEFAULT-ARGS-VARIABLE-COMPLETION-HANDLER-FUNC: func testDefaultArgsVariableCompletionHandler() async -> String {
+// DEFAULT-ARGS-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await defaultArgs(a: 5)
+// DEFAULT-ARGS-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+
 // DEFAULT-ARGS-VARIABLE-COMPLETION-HANDLER: let result = await defaultArgs(a: 5)
 // DEFAULT-ARGS-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result)
 
@@ -197,12 +298,45 @@ func myPrint(_ message: String) {
   print(message)
 }
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=GLOBAL-FUNC-AS-COMPLETION-HANDLER-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=GLOBAL-FUNC-AS-COMPLETION-HANDLER %s
 func testGlobalFuncAsCompletionHandler() {
   simple(completion: myPrint)
 }
+// GLOBAL-FUNC-AS-COMPLETION-HANDLER-FUNC: func testGlobalFuncAsCompletionHandler() async {
+// GLOBAL-FUNC-AS-COMPLETION-HANDLER-FUNC-NEXT:  let result = await simple()
+// GLOBAL-FUNC-AS-COMPLETION-HANDLER-FUNC-NEXT:  myPrint(result)
+// GLOBAL-FUNC-AS-COMPLETION-HANDLER-FUNC-NEXT: }
+
 // GLOBAL-FUNC-AS-COMPLETION-HANDLER: let result = await simple()
 // GLOBAL-FUNC-AS-COMPLETION-HANDLER-NEXT: myPrint(result)
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=VARIABLE-AS-COMPLETION-HANDLER-FUNC %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+3):3 | %FileCheck -check-prefix=VARIABLE-AS-COMPLETION-HANDLER %s
+func testVariableAsCompletionHandler() {
+  let complete: (String) -> Void = { print($0) }
+  simple(completion: complete)
+}
+// VARIABLE-AS-COMPLETION-HANDLER-FUNC: func testVariableAsCompletionHandler() async {
+// VARIABLE-AS-COMPLETION-HANDLER-FUNC-NEXT: let complete: (String) -> Void = { print($0) }
+// VARIABLE-AS-COMPLETION-HANDLER-FUNC-NEXT:  let result = await simple()
+// VARIABLE-AS-COMPLETION-HANDLER-FUNC-NEXT:  complete(result)
+// VARIABLE-AS-COMPLETION-HANDLER-FUNC-NEXT: }
+
+// VARIABLE-AS-COMPLETION-HANDLER: let result = await simple()
+// VARIABLE-AS-COMPLETION-HANDLER-NEXT: complete(result)
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=PRINTING-WRAPPER-FUNC %s
+func testPrintingWrapper(completionHandler: (String) -> Void) {
+  print("Starting")
+  simple(completion: completionHandler)
+  print("Operation scheduled")
+}
+// PRINTING-WRAPPER-FUNC: func testPrintingWrapper() async -> String {
+// PRINTING-WRAPPER-FUNC-NEXT:   print("Starting")
+// PRINTING-WRAPPER-FUNC-NEXT:   return await simple()
+// PRINTING-WRAPPER-FUNC-NEXT:   print("Operation scheduled")
+// PRINTING-WRAPPER-FUNC-NEXT: }
 
 class Foo {
   var foo: Foo
@@ -215,24 +349,42 @@ class Foo {
     print("FOO: \(message)")
   }
 
+  // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=MEMBER-FUNC-AS-COMPLETION-HANDLER-FUNC %s
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):5 | %FileCheck -check-prefix=MEMBER-FUNC-AS-COMPLETION-HANDLER %s
   func testMethodAsCompletionHandler() {
     simple(completion: myFooPrint)
   }
+  // MEMBER-FUNC-AS-COMPLETION-HANDLER-FUNC: func testMethodAsCompletionHandler() async {
+  // MEMBER-FUNC-AS-COMPLETION-HANDLER-FUNC-NEXT:   let result = await simple()
+  // MEMBER-FUNC-AS-COMPLETION-HANDLER-FUNC-NEXT:   myFooPrint(result)
+  // MEMBER-FUNC-AS-COMPLETION-HANDLER-FUNC-NEXT: }
+
   // MEMBER-FUNC-AS-COMPLETION-HANDLER: let result = await simple()
   // MEMBER-FUNC-AS-COMPLETION-HANDLER-NEXT: myFooPrint(result)
 
+  // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=MEMBER-FUNC-ON-OTHER-OBJECT-AS-COMPLETION-HANDLER-FUNC %s
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):5 | %FileCheck -check-prefix=MEMBER-FUNC-ON-OTHER-OBJECT-AS-COMPLETION-HANDLER %s
   func testMethodOnOtherObjectAsCompletionHandler(foo: Foo) {
     simple(completion: foo.myFooPrint)
   }
+  // MEMBER-FUNC-ON-OTHER-OBJECT-AS-COMPLETION-HANDLER-FUNC: func testMethodOnOtherObjectAsCompletionHandler(foo: Foo) async {
+  // MEMBER-FUNC-ON-OTHER-OBJECT-AS-COMPLETION-HANDLER-FUNC-NEXT:   let result = await simple()
+  // MEMBER-FUNC-ON-OTHER-OBJECT-AS-COMPLETION-HANDLER-FUNC-NEXT:   foo.myFooPrint(result)
+  // MEMBER-FUNC-ON-OTHER-OBJECT-AS-COMPLETION-HANDLER-FUNC-NEXT: }
+
   // MEMBER-FUNC-ON-OTHER-OBJECT-AS-COMPLETION-HANDLER: let result = await simple()
   // MEMBER-FUNC-ON-OTHER-OBJECT-AS-COMPLETION-HANDLER-NEXT: foo.myFooPrint(result)
 
+  // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=MEMBER-FUNC-ON-NESTED-OTHER-OBJECT-AS-COMPLETION-HANDLER-FUNC %s
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):5 | %FileCheck -check-prefix=MEMBER-FUNC-ON-NESTED-OTHER-OBJECT-AS-COMPLETION-HANDLER %s
   func testMethodOnNestedOtherObjectAsCompletionHandler(foo: Foo) {
     simple(completion: foo.foo.myFooPrint)
   }
+  // MEMBER-FUNC-ON-NESTED-OTHER-OBJECT-AS-COMPLETION-HANDLER-FUNC: func testMethodOnNestedOtherObjectAsCompletionHandler(foo: Foo) async {
+  // MEMBER-FUNC-ON-NESTED-OTHER-OBJECT-AS-COMPLETION-HANDLER-FUNC-NEXT:   let result = await simple()
+  // MEMBER-FUNC-ON-NESTED-OTHER-OBJECT-AS-COMPLETION-HANDLER-FUNC-NEXT:   foo.foo.myFooPrint(result)
+  // MEMBER-FUNC-ON-NESTED-OTHER-OBJECT-AS-COMPLETION-HANDLER-FUNC-NEXT: }
+
   // MEMBER-FUNC-ON-NESTED-OTHER-OBJECT-AS-COMPLETION-HANDLER: let result = await simple()
   // MEMBER-FUNC-ON-NESTED-OTHER-OBJECT-AS-COMPLETION-HANDLER-NEXT: foo.foo.myFooPrint(result)
 

--- a/test/refactoring/ConvertAsync/variable_as_callback.swift
+++ b/test/refactoring/ConvertAsync/variable_as_callback.swift
@@ -24,111 +24,111 @@ func genericResult<T>(completion: (T?, Error?) -> Void) where T: Numeric { }
 func genericError<E>(completion: (String?, E?) -> Void) where E: Error { }
 func defaultArgs(a: Int, b: Int = 10, completion: (String) -> Void) { }
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=SIMPLE-WITH-VARIABLE-COMPLETION-HANDLER-FUNC %s
-// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SIMPLE-WITH-VARIABLE-COMPLETION-HANDLER %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=SIMPLE-WITH-FUNC %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SIMPLE-WITH %s
 func testSimpleWithVariableCompletionHandler(completionHandler: (String) -> Void) {
   simple(completion: completionHandler)
 }
-// SIMPLE-WITH-VARIABLE-COMPLETION-HANDLER-FUNC: func testSimpleWithVariableCompletionHandler() async -> String {
-// SIMPLE-WITH-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await simple()
-// SIMPLE-WITH-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+// SIMPLE-WITH-FUNC: func testSimpleWithVariableCompletionHandler() async -> String {
+// SIMPLE-WITH-FUNC-NEXT:  return await simple()
+// SIMPLE-WITH-FUNC-NEXT: }
 
-// SIMPLE-WITH-VARIABLE-COMPLETION-HANDLER: let result = await simple()
-// SIMPLE-WITH-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result)
+// SIMPLE-WITH: let result = await simple()
+// SIMPLE-WITH-NEXT: completionHandler(result)
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=SIMPLE-WITH-ARG-VARIABLE-COMPLETION-HANDLER-FUNC %s
-// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SIMPLE-WITH-ARG-VARIABLE-COMPLETION-HANDLER %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=SIMPLE-WITH-ARG-FUNC %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SIMPLE-WITH-ARG %s
 func testSimpleWithArgVariableCompletionHandler(b: Int, completionHandler: (String) -> Void) {
   simpleWithArg(a: b, completion: completionHandler)
 }
-// SIMPLE-WITH-ARG-VARIABLE-COMPLETION-HANDLER-FUNC: func testSimpleWithArgVariableCompletionHandler(b: Int) async -> String {
-// SIMPLE-WITH-ARG-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await simpleWithArg(a: b)
-// SIMPLE-WITH-ARG-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+// SIMPLE-WITH-ARG-FUNC: func testSimpleWithArgVariableCompletionHandler(b: Int) async -> String {
+// SIMPLE-WITH-ARG-FUNC-NEXT:  return await simpleWithArg(a: b)
+// SIMPLE-WITH-ARG-FUNC-NEXT: }
 
-// SIMPLE-WITH-ARG-VARIABLE-COMPLETION-HANDLER: let result = await simpleWithArg(a: b)
-// SIMPLE-WITH-ARG-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result)
+// SIMPLE-WITH-ARG: let result = await simpleWithArg(a: b)
+// SIMPLE-WITH-ARG-NEXT: completionHandler(result)
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=SIMPLE-WITH-CONSTANT-ARG-VARIABLE-COMPLETION-HANDLER-FUNC %s
-// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SIMPLE-WITH-CONSTANT-ARG-VARIABLE-COMPLETION-HANDLER %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=SIMPLE-WITH-CONSTANT-ARG-FUNC %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SIMPLE-WITH-CONSTANT-ARG %s
 func testSimpleWithConstantArgVariableCompletionHandler(completionHandler: (String) -> Void) {
   simpleWithArg(a: 1, completion: completionHandler)
 }
-// SIMPLE-WITH-CONSTANT-ARG-VARIABLE-COMPLETION-HANDLER-FUNC: func testSimpleWithConstantArgVariableCompletionHandler() async -> String {
-// SIMPLE-WITH-CONSTANT-ARG-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await simpleWithArg(a: 1)
-// SIMPLE-WITH-CONSTANT-ARG-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+// SIMPLE-WITH-CONSTANT-ARG-FUNC: func testSimpleWithConstantArgVariableCompletionHandler() async -> String {
+// SIMPLE-WITH-CONSTANT-ARG-FUNC-NEXT:  return await simpleWithArg(a: 1)
+// SIMPLE-WITH-CONSTANT-ARG-FUNC-NEXT: }
 
-// SIMPLE-WITH-CONSTANT-ARG-VARIABLE-COMPLETION-HANDLER: let result = await simpleWithArg(a: 1)
-// SIMPLE-WITH-CONSTANT-ARG-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result)
+// SIMPLE-WITH-CONSTANT-ARG: let result = await simpleWithArg(a: 1)
+// SIMPLE-WITH-CONSTANT-ARG-NEXT: completionHandler(result)
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=MULTIPLE-RESULTS-VARIABLE-COMPLETION-HANDLER-FUNC %s
-// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=MULTIPLE-RESULTS-VARIABLE-COMPLETION-HANDLER %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=MULTIPLE-RESULTS-FUNC %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=MULTIPLE-RESULTS %s
 func testMultipleResultsVariableCompletionHandler(completionHandler: (String, Int) -> Void) {
   multipleResults(completion: completionHandler)
 }
-// MULTIPLE-RESULTS-VARIABLE-COMPLETION-HANDLER-FUNC: func testMultipleResultsVariableCompletionHandler() async -> (String, Int) {
-// MULTIPLE-RESULTS-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await multipleResults()
-// MULTIPLE-RESULTS-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+// MULTIPLE-RESULTS-FUNC: func testMultipleResultsVariableCompletionHandler() async -> (String, Int) {
+// MULTIPLE-RESULTS-FUNC-NEXT:  return await multipleResults()
+// MULTIPLE-RESULTS-FUNC-NEXT: }
 
-// MULTIPLE-RESULTS-VARIABLE-COMPLETION-HANDLER: let result = await multipleResults()
-// MULTIPLE-RESULTS-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result.0, result.1)
+// MULTIPLE-RESULTS: let result = await multipleResults()
+// MULTIPLE-RESULTS-NEXT: completionHandler(result.0, result.1)
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=NON-OPTIONAL-ERROR-VARIABLE-COMPLETION-HANDLER-FUNC %s
-// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=NON-OPTIONAL-ERROR-VARIABLE-COMPLETION-HANDLER %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=NON-OPTIONAL-ERROR-FUNC %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=NON-OPTIONAL-ERROR %s
 func testNonOptionalErrorVariableCompletionHandler(completionHandler: (String, Error) -> Void) {
   nonOptionalError(completion: completionHandler)
 }
-// NON-OPTIONAL-ERROR-VARIABLE-COMPLETION-HANDLER-FUNC: func testNonOptionalErrorVariableCompletionHandler() async -> (String, Error) {
-// NON-OPTIONAL-ERROR-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await nonOptionalError()
-// NON-OPTIONAL-ERROR-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+// NON-OPTIONAL-ERROR-FUNC: func testNonOptionalErrorVariableCompletionHandler() async -> (String, Error) {
+// NON-OPTIONAL-ERROR-FUNC-NEXT:  return await nonOptionalError()
+// NON-OPTIONAL-ERROR-FUNC-NEXT: }
 
-// NON-OPTIONAL-ERROR-VARIABLE-COMPLETION-HANDLER: let result = await nonOptionalError()
-// NON-OPTIONAL-ERROR-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result.0, result.1)
+// NON-OPTIONAL-ERROR: let result = await nonOptionalError()
+// NON-OPTIONAL-ERROR-NEXT: completionHandler(result.0, result.1)
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=NO-PARAMS-VARIABLE-COMPLETION-HANDLER-FUNC %s
-// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=NO-PARAMS-VARIABLE-COMPLETION-HANDLER %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=NO-PARAMS-FUNC %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=NO-PARAMS %s
 func testNoParamsVariableCompletionHandler(completionHandler: () -> Void) {
   noParams(completion: completionHandler)
 }
-// NO-PARAMS-VARIABLE-COMPLETION-HANDLER-FUNC: func testNoParamsVariableCompletionHandler() async {
-// NO-PARAMS-VARIABLE-COMPLETION-HANDLER-FUNC-NOT: return
-// NO-PARAMS-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  await noParams()
-// NO-PARAMS-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+// NO-PARAMS-FUNC: func testNoParamsVariableCompletionHandler() async {
+// NO-PARAMS-FUNC-NOT: return
+// NO-PARAMS-FUNC-NEXT:  await noParams()
+// NO-PARAMS-FUNC-NEXT: }
 
-// NO-PARAMS-VARIABLE-COMPLETION-HANDLER: await noParams()
-// NO-PARAMS-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler()
+// NO-PARAMS: await noParams()
+// NO-PARAMS-NEXT: completionHandler()
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=ERROR-VARIABLE-COMPLETION-HANDLER-FUNC %s
-// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ERROR-VARIABLE-COMPLETION-HANDLER %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=ERROR-FUNC %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ERROR %s
 func testErrorWithVariableCompletionHandler(completionHandler: (String?, Error?) -> Void) {
   error(completion: completionHandler)
 }
-// ERROR-VARIABLE-COMPLETION-HANDLER-FUNC: func testErrorWithVariableCompletionHandler() async throws -> String {
-// ERROR-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return try await error()
-// ERROR-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+// ERROR-FUNC: func testErrorWithVariableCompletionHandler() async throws -> String {
+// ERROR-FUNC-NEXT:  return try await error()
+// ERROR-FUNC-NEXT: }
 
-// ERROR-VARIABLE-COMPLETION-HANDLER: do {
-// ERROR-VARIABLE-COMPLETION-HANDLER-NEXT:   let result = try await error()
-// ERROR-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(result, nil)
-// ERROR-VARIABLE-COMPLETION-HANDLER-NEXT: } catch {
-// ERROR-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(nil, error)
-// ERROR-VARIABLE-COMPLETION-HANDLER-NEXT: }
+// ERROR: do {
+// ERROR-NEXT:   let result = try await error()
+// ERROR-NEXT:   completionHandler(result, nil)
+// ERROR-NEXT: } catch {
+// ERROR-NEXT:   completionHandler(nil, error)
+// ERROR-NEXT: }
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-FUNC %s
-// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ERROR-ONLY-VARIABLE-COMPLETION-HANDLER %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=ERROR-ONLY-FUNC %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ERROR-ONLY %s
 func testErrorOnlyWithVariableCompletionHandler(completionHandler: (Error?) -> Void) {
   errorOnly(completion: completionHandler)
 }
-// ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-FUNC: func testErrorOnlyWithVariableCompletionHandler() async throws {
-// ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-FUNC-NOT:   return
-// ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:   try await errorOnly()
-// ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+// ERROR-ONLY-FUNC: func testErrorOnlyWithVariableCompletionHandler() async throws {
+// ERROR-ONLY-FUNC-NOT:   return
+// ERROR-ONLY-FUNC-NEXT:   try await errorOnly()
+// ERROR-ONLY-FUNC-NEXT: }
 
-// ERROR-ONLY-VARIABLE-COMPLETION-HANDLER: do {
-// ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-NEXT:   try await errorOnly()
-// ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(nil)
-// ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-NEXT: } catch {
-// ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(error)
-// ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-NEXT: }
+// ERROR-ONLY: do {
+// ERROR-ONLY-NEXT:   try await errorOnly()
+// ERROR-ONLY-NEXT:   completionHandler(nil)
+// ERROR-ONLY-NEXT: } catch {
+// ERROR-ONLY-NEXT:   completionHandler(error)
+// ERROR-ONLY-NEXT: }
 
 // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1  | %FileCheck -check-prefix=ERROR-NON-OPTIONAL-RESULT-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3  | %FileCheck -check-prefix=ERROR-NON-OPTIONAL-RESULT %s
@@ -146,153 +146,153 @@ func testErrorNonOptionalResultWithVariableCompletionHandler(completionHandler: 
 // ERROR-NON-OPTIONAL-RESULT-NEXT: completionHandler(<#String#>, error)
 // ERROR-NON-OPTIONAL-RESULT-NEXT: }
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=ALIAS-VARIABLE-COMPLETION-HANDLER-FUNC %s
-// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ALIAS-VARIABLE-COMPLETION-HANDLER %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=ALIAS-FUNC %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ALIAS %s
 func testAliasWithVariableCompletionHandler(completionHandler: SomeCallback) {
   alias(completion: completionHandler)
 }
-// ALIAS-VARIABLE-COMPLETION-HANDLER-FUNC: func testAliasWithVariableCompletionHandler() async -> String {
-// ALIAS-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await alias()
-// ALIAS-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+// ALIAS-FUNC: func testAliasWithVariableCompletionHandler() async -> String {
+// ALIAS-FUNC-NEXT:  return await alias()
+// ALIAS-FUNC-NEXT: }
 
-// ALIAS-VARIABLE-COMPLETION-HANDLER: let result = await alias()
-// ALIAS-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result)
+// ALIAS: let result = await alias()
+// ALIAS-NEXT: completionHandler(result)
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=SIMPLE-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC %s
-// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SIMPLE-RESULT-VARIABLE-COMPLETION-HANDLER %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=SIMPLE-RESULT-FUNC %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SIMPLE-RESULT %s
 func testSimpleResultVariableCompletionHandler(completionHandler: (Result<String, Never>) -> Void) {
   simpleResult(completion: completionHandler)
 }
-// SIMPLE-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC: func testSimpleResultVariableCompletionHandler() async -> String {
-// SIMPLE-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await simpleResult()
-// SIMPLE-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+// SIMPLE-RESULT-FUNC: func testSimpleResultVariableCompletionHandler() async -> String {
+// SIMPLE-RESULT-FUNC-NEXT:  return await simpleResult()
+// SIMPLE-RESULT-FUNC-NEXT: }
 
-// SIMPLE-RESULT-VARIABLE-COMPLETION-HANDLER: let result = await simpleResult()
-// SIMPLE-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(.success(result))
+// SIMPLE-RESULT: let result = await simpleResult()
+// SIMPLE-RESULT-NEXT: completionHandler(.success(result))
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC %s
-// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ERROR-RESULT-VARIABLE-COMPLETION-HANDLER %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=ERROR-RESULT-FUNC %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ERROR-RESULT %s
 func testErrorResultVariableCompletionHandler(completionHandler: (Result<String, Error>) -> Void) {
   errorResult(completion: completionHandler)
 }
-// ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC: func testErrorResultVariableCompletionHandler() async throws -> String {
-// ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return try await errorResult()
-// ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+// ERROR-RESULT-FUNC: func testErrorResultVariableCompletionHandler() async throws -> String {
+// ERROR-RESULT-FUNC-NEXT:  return try await errorResult()
+// ERROR-RESULT-FUNC-NEXT: }
 
-// ERROR-RESULT-VARIABLE-COMPLETION-HANDLER: do {
-// ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   let result = try await errorResult()
-// ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(.success(result))
-// ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT: } catch {
-// ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(.failure(error))
-// ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT: }
+// ERROR-RESULT: do {
+// ERROR-RESULT-NEXT:   let result = try await errorResult()
+// ERROR-RESULT-NEXT:   completionHandler(.success(result))
+// ERROR-RESULT-NEXT: } catch {
+// ERROR-RESULT-NEXT:   completionHandler(.failure(error))
+// ERROR-RESULT-NEXT: }
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC %s
-// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=CUSTOM-ERROR-RESULT-FUNC %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=CUSTOM-ERROR-RESULT %s
 func testErrorResultVariableCompletionHandler(completionHandler: (Result<String, CustomError>) -> Void) {
   customErrorResult(completion: completionHandler)
 }
-// CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC: func testErrorResultVariableCompletionHandler() async throws -> String {
-// CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return try await customErrorResult()
-// CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+// CUSTOM-ERROR-RESULT-FUNC: func testErrorResultVariableCompletionHandler() async throws -> String {
+// CUSTOM-ERROR-RESULT-FUNC-NEXT:  return try await customErrorResult()
+// CUSTOM-ERROR-RESULT-FUNC-NEXT: }
 
-// CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER: do {
-// CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   let result = try await customErrorResult()
-// CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(.success(result))
-// CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT: } catch {
-// CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(.failure(error as! CustomError))
-// CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT: }
+// CUSTOM-ERROR-RESULT: do {
+// CUSTOM-ERROR-RESULT-NEXT:   let result = try await customErrorResult()
+// CUSTOM-ERROR-RESULT-NEXT:   completionHandler(.success(result))
+// CUSTOM-ERROR-RESULT-NEXT: } catch {
+// CUSTOM-ERROR-RESULT-NEXT:   completionHandler(.failure(error as! CustomError))
+// CUSTOM-ERROR-RESULT-NEXT: }
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=OPTIONAL-SINGLE-VARIABLE-COMPLETION-HANDLER-FUNC %s
-// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=OPTIONAL-SINGLE-VARIABLE-COMPLETION-HANDLER %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=OPTIONAL-SINGLE-FUNC %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=OPTIONAL-SINGLE %s
 func testOptionalSingleVariableCompletionHandler(completionHandler: (String?) -> Void) {
   optionalSingle(completion: completionHandler)
 }
-// OPTIONAL-SINGLE-VARIABLE-COMPLETION-HANDLER-FUNC: func testOptionalSingleVariableCompletionHandler() async -> String? {
-// OPTIONAL-SINGLE-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await optionalSingle()
-// OPTIONAL-SINGLE-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+// OPTIONAL-SINGLE-FUNC: func testOptionalSingleVariableCompletionHandler() async -> String? {
+// OPTIONAL-SINGLE-FUNC-NEXT:  return await optionalSingle()
+// OPTIONAL-SINGLE-FUNC-NEXT: }
 
-// OPTIONAL-SINGLE-VARIABLE-COMPLETION-HANDLER: let result = await optionalSingle()
-// OPTIONAL-SINGLE-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result)
+// OPTIONAL-SINGLE: let result = await optionalSingle()
+// OPTIONAL-SINGLE-NEXT: completionHandler(result)
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=MANY-OPTIONAL-VARIABLE-COMPLETION-HANDLER-FUNC %s
-// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=MANY-OPTIONAL-VARIABLE-COMPLETION-HANDLER %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=MANY-OPTIONAL-FUNC %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=MANY-OPTIONAL %s
 func testManyOptionalVariableCompletionHandler(completionHandler: (String?, Int?) -> Void) {
   manyOptional(completionHandler)
 }
-// MANY-OPTIONAL-VARIABLE-COMPLETION-HANDLER-FUNC: func testManyOptionalVariableCompletionHandler() async -> (String?, Int?) {
-// MANY-OPTIONAL-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await manyOptional()
-// MANY-OPTIONAL-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+// MANY-OPTIONAL-FUNC: func testManyOptionalVariableCompletionHandler() async -> (String?, Int?) {
+// MANY-OPTIONAL-FUNC-NEXT:  return await manyOptional()
+// MANY-OPTIONAL-FUNC-NEXT: }
 
-// MANY-OPTIONAL-VARIABLE-COMPLETION-HANDLER: let result = await manyOptional()
-// MANY-OPTIONAL-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result.0, result.1)
+// MANY-OPTIONAL: let result = await manyOptional()
+// MANY-OPTIONAL-NEXT: completionHandler(result.0, result.1)
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=GENERIC-VARIABLE-COMPLETION-HANDLER-FUNC %s
-// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=GENERIC-VARIABLE-COMPLETION-HANDLER %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=GENERIC-FUNC %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=GENERIC %s
 func testGenericVariableCompletionHandler<T, R>(completionHandler: (T, R) -> Void) {
   generic(completion: completionHandler)
 }
-// GENERIC-VARIABLE-COMPLETION-HANDLER-FUNC: func testGenericVariableCompletionHandler<T, R>() async -> (T, R) {
-// GENERIC-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await generic()
-// GENERIC-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+// GENERIC-FUNC: func testGenericVariableCompletionHandler<T, R>() async -> (T, R) {
+// GENERIC-FUNC-NEXT:  return await generic()
+// GENERIC-FUNC-NEXT: }
 
-// GENERIC-VARIABLE-COMPLETION-HANDLER: let result: (T, R) = await generic()
-// GENERIC-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result.0, result.1)
+// GENERIC: let result: (T, R) = await generic()
+// GENERIC-NEXT: completionHandler(result.0, result.1)
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=SPECIALIZE-GENERIC-VARIABLE-COMPLETION-HANDLER-FUNC %s
-// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SPECIALIZE-GENERIC-VARIABLE-COMPLETION-HANDLER %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=SPECIALIZE-GENERIC-FUNC %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SPECIALIZE-GENERIC %s
 func testSpecializeGenericsVariableCompletionHandler(completionHandler: (String, Int) -> Void) {
   generic(completion: completionHandler)
 }
-// SPECIALIZE-GENERIC-VARIABLE-COMPLETION-HANDLER-FUNC: func testSpecializeGenericsVariableCompletionHandler() async -> (String, Int) {
-// SPECIALIZE-GENERIC-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await generic()
-// SPECIALIZE-GENERIC-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+// SPECIALIZE-GENERIC-FUNC: func testSpecializeGenericsVariableCompletionHandler() async -> (String, Int) {
+// SPECIALIZE-GENERIC-FUNC-NEXT:  return await generic()
+// SPECIALIZE-GENERIC-FUNC-NEXT: }
 
-// SPECIALIZE-GENERIC-VARIABLE-COMPLETION-HANDLER: let result: (String, Int) = await generic()
-// SPECIALIZE-GENERIC-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result.0, result.1)
+// SPECIALIZE-GENERIC: let result: (String, Int) = await generic()
+// SPECIALIZE-GENERIC-NEXT: completionHandler(result.0, result.1)
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC %s
-// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=GENERIC-RESULT-FUNC %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=GENERIC-RESULT %s
 func testGenericResultVariableCompletionHandler<T>(completionHandler: (T?, Error?) -> Void) where T: Numeric {
   genericResult(completion: completionHandler)
 }
-// GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC: func testGenericResultVariableCompletionHandler<T>() async throws -> T where T: Numeric {
-// GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return try await genericResult()
-// GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+// GENERIC-RESULT-FUNC: func testGenericResultVariableCompletionHandler<T>() async throws -> T where T: Numeric {
+// GENERIC-RESULT-FUNC-NEXT:  return try await genericResult()
+// GENERIC-RESULT-FUNC-NEXT: }
 
-// GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER: do {
-// GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   let result: T = try await genericResult()
-// GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(result, nil)
-// GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT: } catch {
-// GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(nil, error)
-// GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT: }
+// GENERIC-RESULT: do {
+// GENERIC-RESULT-NEXT:   let result: T = try await genericResult()
+// GENERIC-RESULT-NEXT:   completionHandler(result, nil)
+// GENERIC-RESULT-NEXT: } catch {
+// GENERIC-RESULT-NEXT:   completionHandler(nil, error)
+// GENERIC-RESULT-NEXT: }
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-FUNC %s
-// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=GENERIC-ERROR-FUNC %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=GENERIC-ERROR %s
 func testGenericErrorVariableCompletionHandler<MyGenericError>(completionHandler: (String?, MyGenericError?) -> Void) where MyGenericError: Error {
   genericError(completion: completionHandler)
 }
-// GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-FUNC: func testGenericErrorVariableCompletionHandler<MyGenericError>() async throws -> String where MyGenericError: Error {
-// GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return try await genericError()
-// GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+// GENERIC-ERROR-FUNC: func testGenericErrorVariableCompletionHandler<MyGenericError>() async throws -> String where MyGenericError: Error {
+// GENERIC-ERROR-FUNC-NEXT:  return try await genericError()
+// GENERIC-ERROR-FUNC-NEXT: }
 
-// GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER: do {
-// GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-NEXT:   let result: String = try await genericError()
-// GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(result, nil)
-// GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-NEXT: } catch {
-// GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(nil, error as! MyGenericError)
-// GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-NEXT: }
+// GENERIC-ERROR: do {
+// GENERIC-ERROR-NEXT:   let result: String = try await genericError()
+// GENERIC-ERROR-NEXT:   completionHandler(result, nil)
+// GENERIC-ERROR-NEXT: } catch {
+// GENERIC-ERROR-NEXT:   completionHandler(nil, error as! MyGenericError)
+// GENERIC-ERROR-NEXT: }
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=DEFAULT-ARGS-VARIABLE-COMPLETION-HANDLER-FUNC %s
-// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=DEFAULT-ARGS-VARIABLE-COMPLETION-HANDLER %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=DEFAULT-ARGS-FUNC %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=DEFAULT-ARGS %s
 func testDefaultArgsVariableCompletionHandler(completionHandler: (String) -> Void) {
   defaultArgs(a: 5, completion: completionHandler)
 }
-// DEFAULT-ARGS-VARIABLE-COMPLETION-HANDLER-FUNC: func testDefaultArgsVariableCompletionHandler() async -> String {
-// DEFAULT-ARGS-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT:  return await defaultArgs(a: 5)
-// DEFAULT-ARGS-VARIABLE-COMPLETION-HANDLER-FUNC-NEXT: }
+// DEFAULT-ARGS-FUNC: func testDefaultArgsVariableCompletionHandler() async -> String {
+// DEFAULT-ARGS-FUNC-NEXT:  return await defaultArgs(a: 5)
+// DEFAULT-ARGS-FUNC-NEXT: }
 
-// DEFAULT-ARGS-VARIABLE-COMPLETION-HANDLER: let result = await defaultArgs(a: 5)
-// DEFAULT-ARGS-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result)
+// DEFAULT-ARGS: let result = await defaultArgs(a: 5)
+// DEFAULT-ARGS-NEXT: completionHandler(result)
 
 func myPrint(_ message: String) {
   print(message)

--- a/test/refactoring/ConvertAsync/variable_as_callback.swift
+++ b/test/refactoring/ConvertAsync/variable_as_callback.swift
@@ -1,0 +1,233 @@
+enum CustomError: Error {
+  case invalid
+  case insecure
+}
+
+typealias SomeCallback = (String) -> Void
+
+func simple(completion: (String) -> Void) { }
+func simpleWithArg(a: Int, completion: (String) -> Void) { }
+func multipleResults(completion: (String, Int) -> Void) { }
+func nonOptionalError(completion: (String, Error) -> Void) { }
+func noParams(completion: () -> Void) { }
+func error(completion: (String?, Error?) -> Void) { }
+func errorOnly(completion: (Error?) -> Void) { }
+func errorNonOptionalResult(completion: (String, Error?) -> Void) { }
+func alias(completion: SomeCallback) { }
+func simpleResult(completion: (Result<String, Never>) -> Void) { }
+func errorResult(completion: (Result<String, Error>) -> Void) { }
+func customErrorResult(completion: (Result<String, CustomError>) -> Void) { }
+func optionalSingle(completion: (String?) -> Void) { }
+func manyOptional(_ completion: (String?, Int?) -> Void) { }
+func generic<T, R>(completion: (T, R) -> Void) { }
+func genericResult<T>(completion: (T?, Error?) -> Void) where T: Numeric { }
+func genericError<E>(completion: (String?, E?) -> Void) where E: Error { }
+func defaultArgs(a: Int, b: Int = 10, completion: (String) -> Void) { }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SIMPLE-WITH-VARIABLE-COMPLETION-HANDLER %s
+func testSimpleWithVariableCompletionHandler(completionHandler: (String) -> Void) {
+  simple(completion: completionHandler)
+}
+// SIMPLE-WITH-VARIABLE-COMPLETION-HANDLER: let result = await simple()
+// SIMPLE-WITH-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result)
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SIMPLE-WITH-ARG-VARIABLE-COMPLETION-HANDLER %s
+func testSimpleWithArgVariableCompletionHandler(b: Int, completionHandler: (String) -> Void) {
+  simpleWithArg(a: b, completion: completionHandler)
+}
+// SIMPLE-WITH-ARG-VARIABLE-COMPLETION-HANDLER: let result = await simpleWithArg(a: b)
+// SIMPLE-WITH-ARG-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result)
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SIMPLE-WITH-CONSTANT-ARG-VARIABLE-COMPLETION-HANDLER %s
+func testSimpleWithConstantArgVariableCompletionHandler(completionHandler: (String) -> Void) {
+  simpleWithArg(a: 1, completion: completionHandler)
+}
+// SIMPLE-WITH-CONSTANT-ARG-VARIABLE-COMPLETION-HANDLER: let result = await simpleWithArg(a: 1)
+// SIMPLE-WITH-CONSTANT-ARG-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result)
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=MULTIPLE-RESULTS-VARIABLE-COMPLETION-HANDLER %s
+func testMultipleResultsVariableCompletionHandler(completionHandler: (String, Int) -> Void) {
+  multipleResults(completion: completionHandler)
+}
+// MULTIPLE-RESULTS-VARIABLE-COMPLETION-HANDLER: let result = await multipleResults()
+// MULTIPLE-RESULTS-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result.0, result.1)
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=NON-OPTIONAL-ERROR-VARIABLE-COMPLETION-HANDLER %s
+func testNonOptionalErrorVariableCompletionHandler(completionHandler: (String, Error) -> Void) {
+  nonOptionalError(completion: completionHandler)
+}
+// NON-OPTIONAL-ERROR-VARIABLE-COMPLETION-HANDLER: let result = await nonOptionalError()
+// NON-OPTIONAL-ERROR-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result.0, result.1)
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=NO-PARAMS-VARIABLE-COMPLETION-HANDLER %s
+func testNoParamsVariableCompletionHandler(completionHandler: () -> Void) {
+  noParams(completion: completionHandler)
+}
+// NO-PARAMS-VARIABLE-COMPLETION-HANDLER: await noParams()
+// NO-PARAMS-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler()
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ERROR-VARIABLE-COMPLETION-HANDLER %s
+func testErrorWithVariableCompletionHandler(completionHandler: (String?, Error?) -> Void) {
+  error(completion: completionHandler)
+}
+// ERROR-VARIABLE-COMPLETION-HANDLER: do {
+// ERROR-VARIABLE-COMPLETION-HANDLER-NEXT:   let result = try await error()
+// ERROR-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(result, nil)
+// ERROR-VARIABLE-COMPLETION-HANDLER-NEXT: } catch {
+// ERROR-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(nil, error)
+// ERROR-VARIABLE-COMPLETION-HANDLER-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ERROR-ONLY-VARIABLE-COMPLETION-HANDLER %s
+func testErrorOnlyWithVariableCompletionHandler(completionHandler: (Error?) -> Void) {
+  errorOnly(completion: completionHandler)
+
+}
+// ERROR-ONLY-VARIABLE-COMPLETION-HANDLER: do {
+// ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-NEXT:   try await errorOnly()
+// ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(nil)
+// ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-NEXT: } catch {
+// ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(error)
+// ERROR-ONLY-VARIABLE-COMPLETION-HANDLER-NEXT: }
+
+// FIXME: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3
+func testErrorNonOptionalResultWithVariableCompletionHandler(completionHandler: (String, Error?) -> Void) {
+  errorNonOptionalResult(completion: completionHandler)
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ALIAS-VARIABLE-COMPLETION-HANDLER %s
+func testAliasWithVariableCompletionHandler(completionHandler: SomeCallback) {
+  alias(completion: completionHandler)
+}
+// ALIAS-VARIABLE-COMPLETION-HANDLER: let result = await alias()
+// ALIAS-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result)
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SIMPLE-RESULT-VARIABLE-COMPLETION-HANDLER %s
+func testSimpleResultVariableCompletionHandler(completionHandler: (Result<String, Never>) -> Void) {
+  simpleResult(completion: completionHandler)
+}
+// SIMPLE-RESULT-VARIABLE-COMPLETION-HANDLER: let result = await simpleResult()
+// SIMPLE-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(.success(result))
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ERROR-RESULT-VARIABLE-COMPLETION-HANDLER %s
+func testErrorResultVariableCompletionHandler(completionHandler: (Result<String, Error>) -> Void) {
+  errorResult(completion: completionHandler)
+}
+// ERROR-RESULT-VARIABLE-COMPLETION-HANDLER: do {
+// ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   let result = try await errorResult()
+// ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(.success(result))
+// ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT: } catch {
+// ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(.failure(error))
+// ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER %s
+func testErrorResultVariableCompletionHandler(completionHandler: (Result<String, CustomError>) -> Void) {
+  customErrorResult(completion: completionHandler)
+}
+// CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER: do {
+// CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   let result = try await customErrorResult()
+// CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(.success(result))
+// CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT: } catch {
+// CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(.failure(error as! CustomError))
+// CUSTOM-ERROR-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=OPTIONAL-SINGLE-VARIABLE-COMPLETION-HANDLER %s
+func testOptionalSingleVariableCompletionHandler(completionHandler: (String?) -> Void) {
+  optionalSingle(completion: completionHandler)
+}
+// OPTIONAL-SINGLE-VARIABLE-COMPLETION-HANDLER: let result = await optionalSingle()
+// OPTIONAL-SINGLE-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result)
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=MANY-OPTIONAL-VARIABLE-COMPLETION-HANDLER %s
+func testManyOptionalVariableCompletionHandler(completionHandler: (String?, Int?) -> Void) {
+  manyOptional(completionHandler)
+}
+// MANY-OPTIONAL-VARIABLE-COMPLETION-HANDLER: let result = await manyOptional()
+// MANY-OPTIONAL-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result.0, result.1)
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=GENERIC-VARIABLE-COMPLETION-HANDLER %s
+func testGenericVariableCompletionHandler<T, R>(completionHandler: (T, R) -> Void) {
+  generic(completion: completionHandler)
+}
+// GENERIC-VARIABLE-COMPLETION-HANDLER: let result: (T, R) = await generic()
+// GENERIC-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result.0, result.1)
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SPECIALIZE-GENERIC-VARIABLE-COMPLETION-HANDLER %s
+func testSpecializeGenericsVariableCompletionHandler(completionHandler: (String, Int) -> Void) {
+  generic(completion: completionHandler)
+}
+// SPECIALIZE-GENERIC-VARIABLE-COMPLETION-HANDLER: let result: (String, Int) = await generic()
+// SPECIALIZE-GENERIC-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result.0, result.1)
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER %s
+func testGenericResultVariableCompletionHandler<T>(completionHandler: (T?, Error?) -> Void) where T: Numeric {
+  genericResult(completion: completionHandler)
+}
+// GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER: do {
+// GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   let result: T = try await genericResult()
+// GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(result, nil)
+// GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT: } catch {
+// GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(nil, error)
+// GENERIC-RESULT-VARIABLE-COMPLETION-HANDLER-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER %s
+func testGenericErrorVariableCompletionHandler<MyGenericError>(completionHandler: (String?, MyGenericError?) -> Void) where MyGenericError: Error {
+  genericError(completion: completionHandler)
+}
+// GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER: do {
+// GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-NEXT:   let result: String = try await genericError()
+// GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(result, nil)
+// GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-NEXT: } catch {
+// GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-NEXT:   completionHandler(nil, error as! MyGenericError)
+// GENERIC-ERROR-VARIABLE-COMPLETION-HANDLER-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=DEFAULT-ARGS-VARIABLE-COMPLETION-HANDLER %s
+func testDefaultArgsVariableCompletionHandler(completionHandler: (String) -> Void) {
+  defaultArgs(a: 5, completion: completionHandler)
+}
+// DEFAULT-ARGS-VARIABLE-COMPLETION-HANDLER: let result = await defaultArgs(a: 5)
+// DEFAULT-ARGS-VARIABLE-COMPLETION-HANDLER-NEXT: completionHandler(result)
+
+func myPrint(_ message: String) {
+  print(message)
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=GLOBAL-FUNC-AS-COMPLETION-HANDLER %s
+func testGlobalFuncAsCompletionHandler() {
+  simple(completion: myPrint)
+}
+// GLOBAL-FUNC-AS-COMPLETION-HANDLER: let result = await simple()
+// GLOBAL-FUNC-AS-COMPLETION-HANDLER-NEXT: myPrint(result)
+
+class Foo {
+  var foo: Foo
+
+  init(foo: Foo) {
+    self.foo = foo
+  }
+
+  func myFooPrint(_ message: String) {
+    print("FOO: \(message)")
+  }
+
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):5 | %FileCheck -check-prefix=MEMBER-FUNC-AS-COMPLETION-HANDLER %s
+  func testMethodAsCompletionHandler() {
+    simple(completion: myFooPrint)
+  }
+  // MEMBER-FUNC-AS-COMPLETION-HANDLER: let result = await simple()
+  // MEMBER-FUNC-AS-COMPLETION-HANDLER-NEXT: myFooPrint(result)
+
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):5 | %FileCheck -check-prefix=MEMBER-FUNC-ON-OTHER-OBJECT-AS-COMPLETION-HANDLER %s
+  func testMethodOnOtherObjectAsCompletionHandler(foo: Foo) {
+    simple(completion: foo.myFooPrint)
+  }
+  // MEMBER-FUNC-ON-OTHER-OBJECT-AS-COMPLETION-HANDLER: let result = await simple()
+  // MEMBER-FUNC-ON-OTHER-OBJECT-AS-COMPLETION-HANDLER-NEXT: foo.myFooPrint(result)
+
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):5 | %FileCheck -check-prefix=MEMBER-FUNC-ON-NESTED-OTHER-OBJECT-AS-COMPLETION-HANDLER %s
+  func testMethodOnNestedOtherObjectAsCompletionHandler(foo: Foo) {
+    simple(completion: foo.foo.myFooPrint)
+  }
+  // MEMBER-FUNC-ON-NESTED-OTHER-OBJECT-AS-COMPLETION-HANDLER: let result = await simple()
+  // MEMBER-FUNC-ON-NESTED-OTHER-OBJECT-AS-COMPLETION-HANDLER-NEXT: foo.foo.myFooPrint(result)
+
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/37314 into `release/5.5`

* **Explanation**: Async refactoring previously failed if we were using a variable as a completion handler. For example, we couldn’t refactor `wrapperAroundSimple` to async.
```swift
func simple(completion: (String) -> Void) {}
func simple() async -> String {}

func wrapperAroundSimple(completionHandler: (String) -> Void) {
  simple(completion: completionHandler)
}
```
Now we generate
```swift
func wrapperAroundSimple() async {
  return await simple()
}
```

Similarly, we previously failed if a function was used as completion handler
```swift
func printResultOfSimple() {
  simple(completion: print)
}
```
We now generate
```swift
func printResultOfSimple() async {
  let result = await simple()
  print(result)
}
```

* **Scope**: Async refactoring (add async alternative, convert to async, convert call to async)
* **Risk**: Low (this only affects async refactoring)
* **Testing**: Added new test cases to the refactoring test suite
* **Issue**: rdar://77460524
* **Reviewer**: Ben Barham (@bnbarham)