### PR TITLE
[5.5][ConstraintSystem] Fix a constraint system crash with property wrapper inference using the $ syntax.

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6769,13 +6769,9 @@ bool UnableToInferClosureParameterType::diagnoseAsError() {
   llvm::SmallString<16> id;
   llvm::raw_svector_ostream OS(id);
 
-  if (PD->isAnonClosureParam()) {
-    OS << "$" << paramIdx;
-  } else {
-    OS << "'" << PD->getParameterName() << "'";
-  }
+  OS << "'" << PD->getParameterName() << "'";
 
-  auto loc = PD->isAnonClosureParam() ? getLoc() : PD->getLoc();
+  auto loc = PD->isImplicit() ? getLoc() : PD->getLoc();
   emitDiagnosticAt(loc, diag::cannot_infer_closure_parameter_type, OS.str());
   return true;
 }

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1533,11 +1533,7 @@ std::string SpecifyClosureParameterType::getName() const {
   auto *PD = closure->getParameters()->get(paramLoc.getIndex());
 
   OS << "specify type for parameter ";
-  if (PD->isAnonClosureParam()) {
-    OS << "$" << paramLoc.getIndex();
-  } else {
-    OS << "'" << PD->getParameterName() << "'";
-  }
+  OS << "'" << PD->getParameterName() << "'";
 
   return OS.str();
 }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8693,8 +8693,18 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
       Type wrappedValueType;
 
       if (paramDecl->hasImplicitPropertyWrapper()) {
-        backingType = getContextualParamAt(i)->getPlainType();
-        wrappedValueType = createTypeVariable(getConstraintLocator(locator),
+        if (auto contextualType = getContextualParamAt(i)) {
+          backingType = contextualType->getPlainType();
+        } else {
+          // There may not be a contextual parameter type if the contextual
+          // type is not a function type or if closure body declares too many
+          // parameters.
+          auto *paramLoc =
+              getConstraintLocator(closure, LocatorPathElt::TupleElement(i));
+          backingType = createTypeVariable(paramLoc, TVO_CanBindToHole);
+        }
+
+        wrappedValueType = createTypeVariable(getConstraintLocator(paramDecl),
                                               TVO_CanBindToHole | TVO_CanBindToLValue);
       } else {
         auto *wrapperAttr = paramDecl->getAttachedPropertyWrappers().front();

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -499,7 +499,7 @@ struct S_3520 {
 func sr3520_set_via_closure<S, T>(_ closure: (inout S, T) -> ()) {} // expected-note {{in call to function 'sr3520_set_via_closure'}}
 sr3520_set_via_closure({ $0.number1 = $1 })
 // expected-error@-1 {{generic parameter 'S' could not be inferred}}
-// expected-error@-2 {{unable to infer type of a closure parameter $1 in the current context}}
+// expected-error@-2 {{unable to infer type of a closure parameter '$1' in the current context}}
 
 // SR-3073: UnresolvedDotExpr in single expression closure
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -296,7 +296,7 @@ func r18800223(_ i : Int) {
 }
 
 // <rdar://problem/21883806> Bogus "'_' can only appear in a pattern or on the left side of an assignment" is back
-_ = { $0 }  // expected-error {{unable to infer type of a closure parameter $0 in the current context}}
+_ = { $0 }  // expected-error {{unable to infer type of a closure parameter '$0' in the current context}}
 
 
 

--- a/test/Constraints/one_way_closure_params.swift
+++ b/test/Constraints/one_way_closure_params.swift
@@ -3,6 +3,6 @@
 func testBasic() {
   let _: (Float) -> Float = { $0 + 1 }
 
-  let _ = { $0 + 1 } // expected-error{{unable to infer type of a closure parameter $0 in the current context}}
+  let _ = { $0 + 1 } // expected-error{{unable to infer type of a closure parameter '$0' in the current context}}
 }
 

--- a/test/Sema/property_wrapper_parameter_invalid.swift
+++ b/test/Sema/property_wrapper_parameter_invalid.swift
@@ -224,9 +224,7 @@ func testInvalidWrapperInference() {
   S<Int>.test({ $value in })
 
   func testGenericClosure<T>(_ closure: T) {}
-  // FIXME: the following error should use the name of the closure parameter.
-  // It's not anonymous, even though it starts with $
-  // expected-error@+1 {{unable to infer type of a closure parameter $0 in the current context}}
+  // expected-error@+1 {{unable to infer type of a closure parameter '$value' in the current context}}
   testGenericClosure { $value in }
   testGenericClosure { ($value: ProjectionWrapper<Int>) in } // okay
 

--- a/test/expr/closure/anonymous.swift
+++ b/test/expr/closure/anonymous.swift
@@ -32,7 +32,7 @@ func variadic() {
   // FIXME: Problem here is related to multi-statement closure body not being type-checked together with
   // enclosing context. We could have inferred `$0` to be `[Int]` if `let` was a part of constraint system.
   takesVariadicGeneric({let _: [Int] = $0})
-  // expected-error@-1 {{unable to infer type of a closure parameter $0 in the current context}}
+  // expected-error@-1 {{unable to infer type of a closure parameter '$0' in the current context}}
 
   takesVariadicIntInt({_ = $0; takesIntArray($1)})
   takesVariadicIntInt({_ = $0; let _: [Int] = $1})


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/37380

* **Explanation**: With SE-0293, closure parameters can use the `$` prefix to have a property wrapper type inferred from context. However, when a closure is resolved, the contextual parameter type doesn't always exist. This happens most commonly when the solver is attempting an overload where the contextual type for the closure isn't a function type (e.g. a concrete nominal type, or a type parameter). The implementation was assuming the contextual parameter type always existed, resulting in a crash in the constraint system when attempting to bind to a null type.  The solution is to simply create a type variable for the property wrapper type if the contextual parameter type doesn't exist.
* **Scope**: This only affects the new `$` syntax on closure parameters.
* **Risk**: Very low.
* **Testing**: Added several tests covering a variety of cases where a contextual type for a closure parameter doesn't exist.
* **Reviewer**: @xedin 

Resolves: rdar://77793820