### PR TITLE
[Refactoring] Preserve comments in async transform

### DIFF
--- a/test/refactoring/ConvertAsync/convert_function.swift
+++ b/test/refactoring/ConvertAsync/convert_function.swift
@@ -150,6 +150,51 @@ func asyncUnhandledCompletion(_ completion: (String) -> Void) {
 // ASYNC-UNHANDLED-NEXT: }
 // ASYNC-UNHANDLED-NEXT: }
 
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-UNHANDLED-COMMENT %s
+func asyncUnhandledCommentedCompletion(_ completion: (String) -> Void) {
+  // a
+  simple { str in // b
+    // c
+    let success = run {
+      // d
+      completion(str)
+      // e
+      return true
+      // f
+    }
+    // g
+    if !success {
+      // h
+      completion("bad")
+      // i
+    }
+    // j
+  }
+  // k
+}
+// ASYNC-UNHANDLED-COMMENT:      func asyncUnhandledCommentedCompletion() async -> String {
+// ASYNC-UNHANDLED-COMMENT-NEXT:   // a
+// ASYNC-UNHANDLED-COMMENT-NEXT:   let str = await simple()
+// ASYNC-UNHANDLED-COMMENT-NEXT:   // b
+// ASYNC-UNHANDLED-COMMENT-NEXT:   // c
+// ASYNC-UNHANDLED-COMMENT-NEXT:   let success = run {
+// ASYNC-UNHANDLED-COMMENT-NEXT:     // d
+// ASYNC-UNHANDLED-COMMENT-NEXT:     <#completion#>(str)
+// ASYNC-UNHANDLED-COMMENT-NEXT:     // e
+// ASYNC-UNHANDLED-COMMENT-NEXT:     {{^}} return true{{$}}
+// ASYNC-UNHANDLED-COMMENT-NEXT:     // f
+// ASYNC-UNHANDLED-COMMENT-NEXT:   }
+// ASYNC-UNHANDLED-COMMENT-NEXT:   // g
+// ASYNC-UNHANDLED-COMMENT-NEXT:   if !success {
+// ASYNC-UNHANDLED-COMMENT-NEXT:     // h
+// ASYNC-UNHANDLED-COMMENT-NEXT:     {{^}} return "bad"{{$}}
+// ASYNC-UNHANDLED-COMMENT-NEXT:     // i
+// ASYNC-UNHANDLED-COMMENT-NEXT:   }
+// ASYNC-UNHANDLED-COMMENT-NEXT:   // j
+// ASYNC-UNHANDLED-COMMENT-NEXT:   {{ }}
+// ASYNC-UNHANDLED-COMMENT-NEXT:   // k
+// ASYNC-UNHANDLED-COMMENT-NEXT: }
+
 // RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix VOID-AND-ERROR-HANDLER %s
 func voidAndErrorCompletion(completion: (Void?, Error?) -> Void) {
   if .random() {

--- a/test/refactoring/ConvertAsync/convert_params_single.swift
+++ b/test/refactoring/ConvertAsync/convert_params_single.swift
@@ -40,6 +40,53 @@ withError { res, err in
 // BOUND-NEXT: print("got error \(bad)")
 // BOUND-NEXT: }
 
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=BOUND-COMMENT %s
+withError { res, err in // a
+  // b
+  print("before")
+  // c
+  if let bad = err { // d
+    // e
+    print("got error \(bad)")
+    // f
+    return
+    // g
+  }
+  // h
+  if let str = res { // i
+    // j
+    print("got result \(str)")
+    // k
+  }
+  // l
+  print("after")
+  // m
+}
+// BOUND-COMMENT: do {
+// BOUND-COMMENT-NEXT: let str = try await withError()
+// BOUND-COMMENT-NEXT: // a
+// BOUND-COMMENT-NEXT: // b
+// BOUND-COMMENT-NEXT: print("before")
+// BOUND-COMMENT-NEXT: // c
+// BOUND-COMMENT-NEXT: // h
+// BOUND-COMMENT-NEXT: // i
+// BOUND-COMMENT-NEXT: // j
+// BOUND-COMMENT-NEXT: print("got result \(str)")
+// BOUND-COMMENT-NEXT: // k
+// BOUND-COMMENT-NEXT: // l
+// BOUND-COMMENT-NEXT: print("after")
+// BOUND-COMMENT-NEXT: // m
+// BOUND-COMMENT-EMPTY:
+// BOUND-COMMENT-NEXT: } catch let bad {
+// BOUND-COMMENT-NEXT: // d
+// BOUND-COMMENT-NEXT: // e
+// BOUND-COMMENT-NEXT: print("got error \(bad)")
+// BOUND-COMMENT-NEXT: // f
+// BOUND-COMMENT-NEXT: // g
+// BOUND-COMMENT-NEXT: {{ }}
+// BOUND-COMMENT-NEXT: }
+
+
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNBOUND-ERR %s
 withError { res, err in
   print("before")
@@ -403,6 +450,7 @@ withError { str, err in
   print("before")
   guard err == nil else { return }
   _ = str!.count
+  _ = /*before*/str!/*after*/.count
   _ = str?.count
   _ = str!.count.bitWidth
   _ = str?.count.bitWidth
@@ -415,6 +463,7 @@ withError { str, err in
 // UNWRAPPING:      let str = try await withError()
 // UNWRAPPING-NEXT: print("before")
 // UNWRAPPING-NEXT: _ = str.count
+// UNWRAPPING-NEXT: _ = /*before*/str/*after*/.count
 // UNWRAPPING-NEXT: _ = str.count
 // UNWRAPPING-NEXT: _ = str.count.bitWidth
 // UNWRAPPING-NEXT: _ = str.count.bitWidth

--- a/test/refactoring/ConvertAsync/convert_result.swift
+++ b/test/refactoring/ConvertAsync/convert_result.swift
@@ -317,6 +317,96 @@ simple { res in
 // NESTEDBREAK-NEXT: print("after")
 // NESTEDBREAK-NOT: }
 
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NESTEDBREAK-COMMENT %s
+simple { res in // a
+  // b
+  print("before")
+  // c
+  switch res {
+  // d
+  case .success(let str): // e
+    if test(str) {
+      // f
+      break
+      // g
+    }
+    // h
+    print("result \(str)")
+    // i
+  case .failure:
+    // j
+    break
+    // k
+  }
+  // l
+  print("after")
+  // m
+}
+// NESTEDBREAK-COMMENT:      let str = try await simple()
+// NESTEDBREAK-COMMENT-NEXT: // a
+// NESTEDBREAK-COMMENT-NEXT: // b
+// NESTEDBREAK-COMMENT-NEXT: print("before")
+// NESTEDBREAK-COMMENT-NEXT: // c
+// NESTEDBREAK-COMMENT-NEXT: // d
+// NESTEDBREAK-COMMENT-NEXT: // e
+// NESTEDBREAK-COMMENT-NEXT: if test(str) {
+// NESTEDBREAK-COMMENT-NEXT: // f
+// NESTEDBREAK-COMMENT-NEXT:   <#break#>
+// NESTEDBREAK-COMMENT-NEXT: // g
+// NESTEDBREAK-COMMENT-NEXT: }
+// NESTEDBREAK-COMMENT-NEXT: // h
+// NESTEDBREAK-COMMENT-NEXT: print("result \(str)")
+// NESTEDBREAK-COMMENT-NEXT: // i
+// NESTEDBREAK-COMMENT-NEXT: // j
+// NESTEDBREAK-COMMENT-NEXT: // k
+// NESTEDBREAK-COMMENT-NEXT: // l
+// NESTEDBREAK-COMMENT-NEXT: print("after")
+// NESTEDBREAK-COMMENT-NEXT: // m
+// NESTEDBREAK-COMMENT-EMPTY:
+// NESTEDBREAK-COMMENT-NOT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ERROR-BLOCK-COMMENT %s
+simple { res in
+  // a
+  print("before")
+  // b
+  switch res {
+  case .success(let str):
+    // c
+    print("result \(str)")
+    // d
+  case .failure:
+    // e
+    print("fail")
+    // f
+    return
+    // g
+  }
+  // h
+  print("after")
+  // i
+}
+// ERROR-BLOCK-COMMENT:      do {
+// ERROR-BLOCK-COMMENT-NEXT:   let str = try await simple()
+// ERROR-BLOCK-COMMENT-NEXT:   // a
+// ERROR-BLOCK-COMMENT-NEXT:   print("before")
+// ERROR-BLOCK-COMMENT-NEXT:   // b
+// ERROR-BLOCK-COMMENT-NEXT:   // c
+// ERROR-BLOCK-COMMENT-NEXT:   print("result \(str)")
+// ERROR-BLOCK-COMMENT-NEXT:   // d
+// ERROR-BLOCK-COMMENT-NEXT:   // h
+// ERROR-BLOCK-COMMENT-NEXT:   print("after")
+// ERROR-BLOCK-COMMENT-NEXT:   // i
+// ERROR-BLOCK-COMMENT-EMPTY:
+// ERROR-BLOCK-COMMENT-NEXT: } catch {
+// ERROR-BLOCK-COMMENT-NEXT:   // e
+// ERROR-BLOCK-COMMENT-NEXT:   print("fail")
+// ERROR-BLOCK-COMMENT-NEXT:   // f
+// ERROR-BLOCK-COMMENT-NEXT:   // g
+// ERROR-BLOCK-COMMENT-NEXT:   {{ }}
+// ERROR-BLOCK-COMMENT-NEXT: }
+// ERROR-BLOCK-COMMENT-NOT: }
+
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=VOID-RESULT-CALL %s
 voidResult { res in
   print(res)


### PR DESCRIPTION
Previously we would drop comments between nodes in a BraceStmt, as we printed each node out individually. To remedy this, always make sure we scan backwards to find any preceding comments attached to a node. In addition, make sure we keep track of any SourceLocs which we don't print, but may have comments attached which we want to preserve.

rdar://77401810
