### PR TITLE
[SE-0283] Implement Equatable, Hashable, and Comparable conformance for tuples (again)

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -392,7 +392,19 @@ enum : unsigned {
   NumGenericMetadataPrivateDataWords = 16,
 };
 
-/// Kinds of type metadata/protocol conformance records.
+/// Kinds of type metadata records.
+enum class TypeMetadataRecordKind : unsigned {
+  /// A direct reference to the nominal type descriptor.
+  DirectTypeDescriptor = 0x00,
+
+  /// An indirect reference to a nominal type descriptor.
+  IndirectTypeDescriptor = 0x01,
+
+  First_Kind = DirectTypeDescriptor,
+  Last_Kind = IndirectTypeDescriptor,
+};
+
+/// Kinds of references to type metadata.
 enum class TypeReferenceKind : unsigned {
   /// The conformance is for a nominal type referenced directly;
   /// getTypeDescriptor() points to the type context descriptor.
@@ -415,10 +427,14 @@ enum class TypeReferenceKind : unsigned {
   /// unused.
   IndirectObjCClass = 0x03,
 
+  /// The conformance is for a non-nominal type whose metadata kind we recorded;
+  /// getMetadataKind() returns the kind.
+  MetadataKind = 0x04,
+
   // We only reserve three bits for this in the various places we store it.
 
   First_Kind = DirectTypeDescriptor,
-  Last_Kind = IndirectObjCClass,
+  Last_Kind = MetadataKind,
 };
 
 /// Flag that indicates whether an existential type is class-constrained or not.

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -104,6 +104,7 @@ namespace swift {
   class InheritedProtocolConformance;
   class SelfProtocolConformance;
   class SpecializedProtocolConformance;
+  class BuiltinProtocolConformance;
   enum class ProtocolConformanceState;
   class Pattern;
   enum PointerTypeKind : unsigned;
@@ -999,6 +1000,11 @@ public:
   /// Produce a self-conformance for the given protocol.
   SelfProtocolConformance *
   getSelfConformance(ProtocolDecl *protocol);
+
+  /// Produce the builtin conformance for some structural type to some protocol.
+  BuiltinProtocolConformance *
+  getBuiltinConformance(Type type, ProtocolDecl *protocol,
+                        ArrayRef<ProtocolConformanceRef> conformances);
 
   /// A callback used to produce a diagnostic for an ill-formed protocol
   /// conformance that was type-checked before we're actually walking the

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -66,7 +66,10 @@ enum class ProtocolConformanceKind {
   Specialized,
   /// Conformance of a generic class type projected through one of its
   /// superclass's conformances.
-  Inherited
+  Inherited,
+  /// Builtin conformances are special conformances that the runtime handles
+  /// and isn't implemented directly in Swift.
+  Builtin
 };
 
 /// Describes the state of a protocol conformance, which may be complete,
@@ -330,6 +333,8 @@ public:
 ///   normal conformance) or
 /// - the protocol's existential type is known to conform to itself (a
 ///   self-conformance).
+/// - the type's conformance is declared within the runtime (a builtin
+///   conformance).
 class RootProtocolConformance : public ProtocolConformance {
 protected:
   RootProtocolConformance(ProtocolConformanceKind kind, Type conformingType)
@@ -380,7 +385,8 @@ public:
 
   static bool classof(const ProtocolConformance *conformance) {
     return conformance->getKind() == ProtocolConformanceKind::Normal ||
-           conformance->getKind() == ProtocolConformanceKind::Self;
+           conformance->getKind() == ProtocolConformanceKind::Self ||
+           conformance->getKind() == ProtocolConformanceKind::Builtin;
   }
 };
 
@@ -969,6 +975,111 @@ public:
 
   static bool classof(const ProtocolConformance *conformance) {
     return conformance->getKind() == ProtocolConformanceKind::Inherited;
+  }
+};
+
+/// A builtin conformance appears when a special non-nominal type has a runtime
+/// declared conformance. E.g. the runtime implements Equatable for tuples.
+class BuiltinProtocolConformance final : public RootProtocolConformance,
+    private llvm::TrailingObjects<BuiltinProtocolConformance,
+                                  ProtocolConformanceRef> {
+  friend ASTContext;
+  friend TrailingObjects;
+
+  ProtocolDecl *protocol = nullptr;
+  size_t numConformances;
+
+  mutable Optional<ArrayRef<Requirement>> conditionalConformances = None;
+
+  BuiltinProtocolConformance(Type conformingType, ProtocolDecl *protocol,
+                             ArrayRef<ProtocolConformanceRef> conformances);
+
+  size_t numTrailingObjects(OverloadToken<ProtocolConformanceRef>) const {
+    return numConformances;
+  }
+
+public:
+  /// Get the protocol being conformed to.
+  ProtocolDecl *getProtocol() const {
+    return protocol;
+  }
+
+  /// Get the trailing conformances that this builtin conformance needs.
+  MutableArrayRef<ProtocolConformanceRef> getConformances() {
+    return {getTrailingObjects<ProtocolConformanceRef>(), numConformances};
+  }
+
+  /// Get the trailing conformances that this builtin conformance needs.
+  ArrayRef<ProtocolConformanceRef> getConformances() const {
+    return {getTrailingObjects<ProtocolConformanceRef>(), numConformances};
+  }
+
+  /// Get any requirements that must be satisfied for this conformance to apply.
+  Optional<ArrayRef<Requirement>>
+  getConditionalRequirementsIfAvailable() const {
+    return ArrayRef<Requirement>();
+  }
+
+  /// Get any requirements that must be satisfied for this conformance to apply.
+  ArrayRef<Requirement> getConditionalRequirements() const;
+
+  /// Get the declaration context that contains the nominal type declaration.
+  DeclContext *getDeclContext() const {
+    return getProtocol();
+  }
+
+  /// Retrieve the state of this conformance.
+  ProtocolConformanceState getState() const {
+    return ProtocolConformanceState::Complete;
+  }
+
+  /// Get the kind of soure from which this conformance comes from.
+  ConformanceEntryKind getSourceKind() const {
+    return ConformanceEntryKind::Synthesized;
+  }
+
+  /// Get the protocol conformance which implied this implied conformance.
+  NormalProtocolConformance *getImplyingConformance() const {
+    return nullptr;
+  }
+
+  bool hasTypeWitness(AssociatedTypeDecl *assocType) const {
+    llvm_unreachable("builtin-conformances currently don't have associated \
+                      types.");
+  }
+
+  /// Retrieve the type witness and type decl (if one exists)
+  /// for the given associated type.
+  TypeWitnessAndDecl
+  getTypeWitnessAndDecl(AssociatedTypeDecl *assocType,
+                        SubstOptions options=None) const {
+    llvm_unreachable("builtin-conformances currently don't have associated \
+                      types.");
+  }
+
+  /// Given that the requirement signature of the protocol directly states that
+  /// the given dependent type must conform to the given protocol,
+  /// return its associated conformance.
+  ProtocolConformanceRef
+  getAssociatedConformance(Type assocType, ProtocolDecl *protocol) const {
+    llvm_unreachable("builtin-conformances currently don't have associated \
+                      types.");
+  }
+
+  /// Retrieve the witness corresponding to the given value requirement.
+  ConcreteDeclRef getWitnessDeclRef(ValueDecl *requirement) const {
+    return ConcreteDeclRef(requirement);
+  }
+
+  /// Determine whether the witness for the given requirement is either the
+  /// default definition of was otherwise deduced.
+  bool usesDefaultDefinition(AssociatedTypeDecl *requirement) const {
+    llvm_unreachable("builtin-conformances currently don't have associated \
+                      types.");
+  }
+
+  static bool classof(const ProtocolConformance *conformance) {
+    return conformance->getKind() == ProtocolConformanceKind::Builtin;
   }
 };
 

--- a/include/swift/Remote/MemoryReader.h
+++ b/include/swift/Remote/MemoryReader.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -1435,6 +1435,10 @@ public:
 
       return metadataFn(metadata);
     }
+
+    case TypeReferenceKind::MetadataKind: {
+      return None;
+    }
     }
 
     return None;

--- a/include/swift/Runtime/BuiltinProtocolConformances.h
+++ b/include/swift/Runtime/BuiltinProtocolConformances.h
@@ -1,0 +1,222 @@
+//===--- BuiltinProtocolConformances.h --------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Swift runtime support for builtin protocol witnesses and related items.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_BUILTINPROTOCOLCONFORMANCES_H
+#define SWIFT_RUNTIME_BUILTINPROTOCOLCONFORMANCES_H
+
+#include "swift/ABI/Metadata.h"
+#include "swift/Basic/RelativePointer.h"
+#include <cstdint>
+
+namespace swift {
+
+#define STR(a) #a
+#define XSTR(a) STR(a)
+#define SYMBOL(name) XSTR(__USER_LABEL_PREFIX__) name
+
+template<typename T>
+struct _RelativeIndirectablePointer {
+  int32_t offset;
+
+  void set(const T *ptr, bool isIndirect = false) {
+    offset = intptr_t(ptr) - intptr_t(this);
+
+    if (isIndirect) {
+      offset += 1;
+    }
+  }
+};
+
+template<typename T>
+struct _RelativeDirectPointer {
+  int32_t offset;
+
+  void set(const T *ptr) {
+    offset = intptr_t(ptr) - intptr_t(this);
+  }
+};
+
+struct _ResilientWitness {
+  _RelativeIndirectablePointer<MethodDescriptor> methodDescriptor;
+  _RelativeDirectPointer<void> impl;
+};
+
+template<int numResilientWitnesses>
+struct _ConformanceDescriptor {
+  // Base conformance descriptor fields.
+  _RelativeIndirectablePointer<ProtocolDescriptor> protocol;
+  int32_t typeRef;
+  int32_t witnessTablePattern;
+  int32_t flags;
+
+  // Resilient Witness fields.
+  int32_t resilientWitnessHeader;
+  _ResilientWitness resilientWitnesses[numResilientWitnesses];
+
+  // Generic witness table fields.
+  int16_t witnessTableSize;
+  int16_t privateSizeAndRequiresInstantiation;
+  int32_t witnessTableInstantiator;
+  _RelativeDirectPointer<char> privateData;
+};
+
+template<>
+struct _ConformanceDescriptor<0> {
+  // Base conformance descriptor fields.
+  int32_t protocol;
+  int32_t typeRef;
+  int32_t witnessTablePattern;
+  int32_t flags;
+};
+
+#if defined(__ELF__)
+#define SWIFT_ASSOCIATED_CONFORMANCE \
+          __attribute__((__visibility__("hidden"))) \
+          __attribute__((__weak__)) \
+          __attribute__((__aligned__(2)))
+
+#elif defined(__MACH__)
+#define SWIFT_ASSOCIATED_CONFORMANCE \
+          __attribute__((__visibility__("hidden"))) \
+          __attribute__((__weak__)) \
+          __attribute__((__aligned__(2)))
+
+#elif defined(_WIN32)
+#define SWIFT_ASSOCIATED_CONFORMANCE \
+          __declspec(align(2))
+#endif
+
+#if defined(_WIN32)
+#pragma pack(push, 1)
+#endif
+struct _AssociatedConformance {
+  uint8_t byte0;
+  uint8_t byte1;
+  _RelativeDirectPointer<void> baseAccessor;
+  uint8_t null;
+}
+#if defined(__ELF__) || defined(__MACH__)
+__attribute__((packed))
+#endif
+; // Ending struct semicolon
+#if defined(_WIN32)
+#pragma pack(pop)
+#endif
+
+static_assert(sizeof(_AssociatedConformance) == 7,
+              "_AssociatedConformance should be packed!");
+
+//===----------------------------------------------------------------------===//
+// Tuple Equatable Conformance
+//===----------------------------------------------------------------------===//
+
+#define EQUATABLE_DESCRIPTOR $sSQMp
+#define EQUATABLE_EE_METHOD_DESCRIPTOR $sSQ2eeoiySbx_xtFZTq
+
+SWIFT_RUNTIME_EXPORT
+_ConformanceDescriptor<1> _swift_tupleEquatable_conf;
+
+/// The protocol witness for static Swift.Equatable.== infix(A, A) -> Swift.Bool
+/// in conformance (A...): Swift.Equatable in Swift.
+SWIFT_CC(swift)
+bool _swift_tupleEquatable_equals(OpaqueValue *tuple1, OpaqueValue *tuple2,
+                                  SWIFT_CONTEXT Metadata *swiftSelf,
+                                  Metadata *Self, void *witnessTable);
+
+//===----------------------------------------------------------------------===//
+// Tuple Comparable Conformance
+//===----------------------------------------------------------------------===//
+
+#define COMPARABLE_DESCRIPTOR $sSLMp
+#define COMPARABLE_BASE_CONFORMANCE_DESCRIPTOR $sSLSQTb
+#define COMPARABLE_LT_METHOD_DESCRIPTOR $sSL1loiySbx_xtFZTq
+#define COMPARBALE_LTE_METHOD_DESCRIPTOR $sSL2leoiySbx_xtFZTq
+#define COMPARABLE_GTE_METHOD_DESCRIPTOR $sSL2geoiySbx_xtFZTq
+#define COMPARABLE_GT_METHOD_DESCRIPTOR $sSL1goiySbx_xtFZTq
+
+SWIFT_RUNTIME_EXPORT
+_ConformanceDescriptor<5> _swift_tupleComparable_conf;
+
+SWIFT_CC(swift)
+const WitnessTable *
+_swift_tupleComparable_baseAccessorEquatable(Metadata *assocType,
+                                             Metadata *conformingType,
+                                             void **witnessTable);
+
+/// The protocol witness for static Swift.Comparable.< infix(A, A) -> Swift.Bool
+/// in conformance (A...): Swift.Comparable in Swift.
+SWIFT_CC(swift)
+bool _swift_tupleComparable_lessThan(OpaqueValue *tuple1, OpaqueValue *tuple2,
+                                     SWIFT_CONTEXT Metadata *swiftSelf,
+                                     Metadata *Self, void *witnessTable);
+
+/// The protocol witness for static Swift.Comparable.<= infix(A, A) -> Swift.Bool
+/// in conformance (A...): Swift.Comparable in Swift.
+SWIFT_CC(swift)
+bool _swift_tupleComparable_lessThanOrEqual(OpaqueValue *tuple1,
+                                            OpaqueValue *tuple2,
+                                            SWIFT_CONTEXT Metadata *swiftSelf,
+                                            Metadata *Self, void *witnessTable);
+
+/// The protocol witness for static Swift.Comparable.>= infix(A, A) -> Swift.Bool
+/// in conformance (A...): Swift.Comparable in Swift.
+SWIFT_CC(swift)
+bool _swift_tupleComparable_greaterThanOrEqual(OpaqueValue *tuple1,
+                                               OpaqueValue *tuple2,
+                                              SWIFT_CONTEXT Metadata *swiftSelf,
+                                            Metadata *Self, void *witnessTable);
+
+/// The protocol witness for static Swift.Comparable.> infix(A, A) -> Swift.Bool
+/// in conformance (A...): Swift.Comparable in Swift.
+SWIFT_CC(swift)
+bool _swift_tupleComparable_greaterThan(OpaqueValue *tuple1, OpaqueValue *tuple2,
+                                        SWIFT_CONTEXT Metadata *swiftSelf,
+                                        Metadata *Self, void *witnessTable);
+
+//===----------------------------------------------------------------------===//
+// Tuple Hashable Conformance
+//===----------------------------------------------------------------------===//
+
+#define HASHABLE_DESCRIPTOR $sSHMp
+#define HASHABLE_BASE_CONFORMANCE_DESCRIPTOR $sSHSQTb
+#define HASHABLE_HASHVALUE_METHOD_DESCRIPTOR $sSH9hashValueSivgTq
+#define HASHABLE_HASH_METHOD_DESCRIPTOR $sSH4hash4intoys6HasherVz_tFTq
+#define HASHABLE_RAWHASHVALUE_METHOD_DESCRIPTOR $sSH13_rawHashValue4seedS2i_tFTq
+
+// Swift._hashValue<A where A: Swift.Hashable>(for: A) -> Swift.Int
+#define SWIFT_HASHVALUE_FUNC $ss10_hashValue3forSix_tSHRzlF
+// Swift.Hasher.combine<A where A: Swift.Hashable>(A) -> ()
+#define SWIFT_HASHER_COMBINE_FUNC $ss6HasherV7combineyyxSHRzlF
+
+SWIFT_RUNTIME_EXPORT
+_ConformanceDescriptor<4> _swift_tupleHashable_conf;
+
+/// The protocol witness for Swift.Hashable.hashValue.getter: Swift.Int in
+/// conformance (A...): Swift.Hashable in Swift.
+SWIFT_CC(swift)
+intptr_t _swift_tupleHashable_hashValue(SWIFT_CONTEXT OpaqueValue *tuple,
+                                        Metadata *Self, void *witnessTable);
+
+/// The protocol witness for Swift.Hashable.hash(into:) in conformance
+/// (A...): Swift.Hashable in Swift.
+SWIFT_CC(swift)
+void _swift_tupleHashable_hash(OpaqueValue *hasher,
+                               SWIFT_CONTEXT OpaqueValue *tuple,
+                               Metadata *Self, void *witnessTable);
+
+} // end namespace swift
+
+#endif

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -2095,7 +2095,8 @@ SILCloner<ImplClass>::visitWitnessMethodInst(WitnessMethodInst *Inst) {
   if (conformance.isConcrete()) {
     CanType Ty = conformance.getConcrete()->getType()->getCanonicalType();
 
-    if (Ty != newLookupType) {
+    if (Ty != newLookupType &&
+        !isa<BuiltinProtocolConformance>(conformance.getConcrete())) {
       assert(
           (Ty->isExactSuperclassOf(newLookupType) ||
            getBuilder().getModule().Types.getLoweredRValueType(

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -3341,6 +3341,11 @@ static void dumpProtocolConformanceRec(
     }
     dumpProtocolConformanceRec(conf->getGenericConformance(), out, indent + 2,
                                visited);
+    break;
+  }
+
+  case ProtocolConformanceKind::Builtin: {
+    printCommon("builtin");
     break;
   }
   }

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -209,9 +209,11 @@ std::string ASTMangler::mangleWitnessTable(const RootProtocolConformance *C) {
   if (isa<NormalProtocolConformance>(C)) {
     appendProtocolConformance(C);
     appendOperator("WP");
-  } else {
+  } else if (isa<SelfProtocolConformance>(C)) {
     appendProtocolName(cast<SelfProtocolConformance>(C)->getProtocol());
     appendOperator("WS");
+  } else {
+    llvm_unreachable("mangling unknown conformance kind");
   }
   return finalize();
 }
@@ -1550,7 +1552,8 @@ void ASTMangler::appendBoundGenericArgs(Type type, bool &isFirstArgList) {
 static bool conformanceHasIdentity(const RootProtocolConformance *root) {
   auto conformance = dyn_cast<NormalProtocolConformance>(root);
   if (!conformance) {
-    assert(isa<SelfProtocolConformance>(root));
+    assert(isa<SelfProtocolConformance>(root) ||
+           isa<BuiltinProtocolConformance>(root));
     return true;
   }
 
@@ -1571,8 +1574,9 @@ static bool conformanceHasIdentity(const RootProtocolConformance *root) {
 static bool isRetroactiveConformance(const RootProtocolConformance *root) {
   auto conformance = dyn_cast<NormalProtocolConformance>(root);
   if (!conformance) {
-    assert(isa<SelfProtocolConformance>(root));
-    return false; // self-conformances are never retroactive.
+    assert(isa<SelfProtocolConformance>(root) ||
+           isa<BuiltinProtocolConformance>(root));
+    return false; // self and builtin conformances are never retroactive.
   }
 
   return conformance->isRetroactive();
@@ -3055,6 +3059,11 @@ ASTMangler::appendProtocolConformance(const ProtocolConformance *conformance) {
     appendModule(Mod, DC->getAsDecl()->getAlternateModuleName());
   }
 
+  // If this is a non-nominal type, we're done.
+  if (!conformingType->getAnyNominal()) {
+    return;
+  }
+
   contextSig =
     conformingType->getAnyNominal()->getGenericSignatureOfContext();
 
@@ -3079,6 +3088,9 @@ void ASTMangler::appendProtocolConformanceRef(
     assert(DC->getAsDecl());
     appendModule(conformance->getDeclContext()->getParentModule(),
                  DC->getAsDecl()->getAlternateModuleName());
+  // Builtin conformances are always from the Swift module.
+  } else if (isa<BuiltinProtocolConformance>(conformance)) {
+    appendOperator("HP");
   } else if (conformance->getDeclContext()->getParentModule() ==
                conformance->getType()->getAnyNominal()->getParentModule()) {
     appendOperator("HP");

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -5717,6 +5717,13 @@ void ProtocolConformance::printName(llvm::raw_ostream &os,
     os << "inherit (";
     inherited->getInheritedConformance()->printName(os, PO);
     os << ")";
+    break;
+  }
+
+  case ProtocolConformanceKind::Builtin: {
+    auto builtin = cast<BuiltinProtocolConformance>(this);
+    os << builtin->getProtocol()->getName()
+       << " type " << builtin->getType();
     break;
   }
   }

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -1061,6 +1061,12 @@ bool IRGenerator::canEmitWitnessTableLazily(SILWitnessTable *wt) {
   // its own shared copy of it.
   if (wt->getLinkage() == SILLinkage::Shared)
     return true;
+
+  // If we happen to see a builtin witness table here, we can't emit those.
+  // The runtime has those for us.
+  if (isa<BuiltinProtocolConformance>(wt->getConformance())) {
+    return false;
+  }
 
   NominalTypeDecl *ConformingTy =
     wt->getConformingType()->getNominalOrBoundGenericNominal();

--- a/lib/SIL/IR/SIL.cpp
+++ b/lib/SIL/IR/SIL.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -79,6 +79,12 @@ swift::getLinkageForProtocolConformance(const RootProtocolConformance *C,
   // shared linkage.
   if (isa<ClangModuleUnit>(C->getDeclContext()->getModuleScopeContext()))
     return SILLinkage::Shared;
+
+  // If the conforming type is a non-nominal, give it public linkage.
+  // These conformances are implemented within the runtime.
+  if (!C->getType()->getAnyNominal()) {
+    return definition ? SILLinkage::Public : SILLinkage::PublicExternal;
+  }
 
   auto typeDecl = C->getType()->getNominalOrBoundGenericNominal();
   AccessLevel access = std::min(C->getProtocol()->getEffectiveAccess(),

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -254,6 +254,12 @@ SILModule::lookUpWitnessTable(const ProtocolConformance *C,
   SILWitnessTable *wtable;
 
   auto rootC = C->getRootConformance();
+
+  // Builtin conformances don't have witness tables in SIL.
+  if (isa<BuiltinProtocolConformance>(rootC)) {
+    return nullptr;
+  }
+
   // Attempt to lookup the witness table from the table.
   auto found = WitnessTableMap.find(rootC);
   if (found == WitnessTableMap.end()) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -6085,7 +6085,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
 
     // This conformance may be conditional, in which case we need to consider
     // those requirements as constraints too.
-    if (conformance.isConcrete()) {
+    if (conformance.isConcrete() &&
+        !isa<BuiltinProtocolConformance>(conformance.getConcrete())) {
       unsigned index = 0;
       auto *conformanceLoc = getConstraintLocator(
           loc,

--- a/lib/Serialization/DeclTypeRecordNodes.def
+++ b/lib/Serialization/DeclTypeRecordNodes.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -168,7 +168,7 @@ OTHER(GENERIC_PARAM_LIST, 230)
 OTHER(GENERIC_SIGNATURE, 231)
 TRAILING_INFO(GENERIC_REQUIREMENT)
 TRAILING_INFO(LAYOUT_REQUIREMENT)
-// 234 is unused
+OTHER(BUILTIN_PROTOCOL_CONFORMANCE, 234)
 OTHER(SIL_GENERIC_SIGNATURE, 235)
 OTHER(SUBSTITUTION_MAP, 236)
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 612; // add user-defined module version
+const uint16_t SWIFTMODULE_VERSION_MINOR = 613; // builtin protocol conformances
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1660,6 +1660,14 @@ namespace decls_block {
   using InheritedProtocolConformanceLayout = BCRecordLayout<
     INHERITED_PROTOCOL_CONFORMANCE,
     TypeIDField // the conforming type
+  >;
+
+  using BuiltinProtocolConformanceLayout = BCRecordLayout<
+    BUILTIN_PROTOCOL_CONFORMANCE,
+    TypeIDField, // the conforming type
+    DeclIDField, // the protocol
+    BCVBR<5> // the number of element conformances
+    // the (optional) element conformances follow
   >;
 
   // Refers to a normal protocol conformance in the given module via its id.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -907,6 +907,8 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD_WITH_NAMESPACE(sil_block,
                               decls_block::INHERITED_PROTOCOL_CONFORMANCE);
   BLOCK_RECORD_WITH_NAMESPACE(sil_block,
+                              decls_block::BUILTIN_PROTOCOL_CONFORMANCE);
+  BLOCK_RECORD_WITH_NAMESPACE(sil_block,
                               decls_block::NORMAL_PROTOCOL_CONFORMANCE_ID);
   BLOCK_RECORD_WITH_NAMESPACE(sil_block,
                               decls_block::PROTOCOL_CONFORMANCE_XREF);
@@ -1579,6 +1581,19 @@ Serializer::writeConformance(ProtocolConformanceRef conformanceRef,
       Out, ScratchRecord, abbrCode, addTypeRef(type));
 
     writeConformance(conf->getInheritedConformance(), abbrCodes, genericEnv);
+    break;
+  }
+
+  case ProtocolConformanceKind::Builtin: {
+    auto builtin = cast<BuiltinProtocolConformance>(conformance);
+    unsigned abbrCode = abbrCodes[BuiltinProtocolConformanceLayout::Code];
+    auto typeID = addTypeRef(builtin->getType());
+    auto protocolID = addDeclRef(builtin->getProtocol());
+    BuiltinProtocolConformanceLayout::emitRecord(Out, ScratchRecord, abbrCode,
+                                                 typeID, protocolID,
+                                             builtin->getConformances().size());
+
+    writeConformances(builtin->getConformances(), abbrCodes);
     break;
   }
   }
@@ -4775,6 +4790,7 @@ void Serializer::writeAllDeclsAndTypes() {
   registerDeclTypeAbbr<SpecializedProtocolConformanceLayout>();
   registerDeclTypeAbbr<InheritedProtocolConformanceLayout>();
   registerDeclTypeAbbr<InvalidProtocolConformanceLayout>();
+  registerDeclTypeAbbr<BuiltinProtocolConformanceLayout>();
   registerDeclTypeAbbr<NormalProtocolConformanceIdLayout>();
   registerDeclTypeAbbr<ProtocolConformanceXrefLayout>();
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -2775,6 +2775,7 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
   registerSILAbbr<decls_block::SelfProtocolConformanceLayout>();
   registerSILAbbr<decls_block::SpecializedProtocolConformanceLayout>();
   registerSILAbbr<decls_block::InheritedProtocolConformanceLayout>();
+  registerSILAbbr<decls_block::BuiltinProtocolConformanceLayout>();
   registerSILAbbr<decls_block::NormalProtocolConformanceIdLayout>();
   registerSILAbbr<decls_block::ProtocolConformanceXrefLayout>();
   registerSILAbbr<decls_block::GenericRequirementLayout>();

--- a/stdlib/public/runtime/BuiltinProtocolConformances.cpp
+++ b/stdlib/public/runtime/BuiltinProtocolConformances.cpp
@@ -1,0 +1,805 @@
+//===--- BuiltinProtocolConformances.cpp ----------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Definitions of some builtin protocol witnesses.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/BuiltinProtocolConformances.h"
+#include "swift/Runtime/Casting.h"
+#include "swift/Runtime/Debug.h"
+#include "swift/Runtime/Metadata.h"
+
+#include <vector>
+
+using namespace swift;
+
+using StaticInfixWitness = SWIFT_CC(swift) bool(OpaqueValue *, OpaqueValue *,
+                                                SWIFT_CONTEXT const Metadata *,
+                                                const Metadata *,
+                                                const WitnessTable *);
+
+#if defined(__ELF__)
+#define CONFORMANCE_PRIVATE_DATA(NAME) \
+          __asm( \
+            "  .type " SYMBOL(NAME) ", @object\n" \
+            "  .local " SYMBOL(NAME) "\n" \
+            "  .comm " SYMBOL(NAME) ", 128, 16\n" \
+          );
+#elif defined(__MACH__)
+#define CONFORMANCE_PRIVATE_DATA(NAME) \
+          __asm( \
+            "  .zerofill __DATA, __bss, " SYMBOL(NAME) ", 128, 4\n" \
+          );
+#elif defined(_WIN32)
+#define CONFORMANCE_PRIVATE_DATA(NAME) \
+          __asm( \
+            "  .lcomm " SYMBOL(NAME) ", 128, 16\n" \
+          );
+#endif
+
+//===----------------------------------------------------------------------===//
+// Associated Conformances
+//===----------------------------------------------------------------------===//
+
+SWIFT_ASSOCIATED_CONFORMANCE
+_AssociatedConformance _swift_tupleComparable_associatedConformance = {
+  // Header bits for the demangler.
+  255,
+  7,
+
+  // This is a direct relative reference to the base accessor for tuple
+  // Equatable defined below.
+  {
+    0
+  },
+
+  // Null
+  0
+};
+
+//===----------------------------------------------------------------------===//
+// Builtin Conformance Initializer
+//===----------------------------------------------------------------------===//
+
+// Equatable Information
+extern "C" const ProtocolDescriptor EQUATABLE_DESCRIPTOR;
+extern "C" const MethodDescriptor EQUATABLE_EE_METHOD_DESCRIPTOR;
+extern "C" const char __swift_tupleEquatable_private;
+
+// Comparable Information
+extern "C" const ProtocolDescriptor COMPARABLE_DESCRIPTOR;
+extern "C" const MethodDescriptor COMPARABLE_BASE_CONFORMANCE_DESCRIPTOR;
+extern "C" const MethodDescriptor COMPARABLE_LT_METHOD_DESCRIPTOR;
+extern "C" const MethodDescriptor COMPARBALE_LTE_METHOD_DESCRIPTOR;
+extern "C" const MethodDescriptor COMPARABLE_GTE_METHOD_DESCRIPTOR;
+extern "C" const MethodDescriptor COMPARABLE_GT_METHOD_DESCRIPTOR;
+extern "C" const char __swift_tupleComparable_private;
+
+// Hashable Information
+extern "C" const ProtocolDescriptor HASHABLE_DESCRIPTOR;
+extern "C" const MethodDescriptor HASHABLE_BASE_CONFORMANCE_DESCRIPTOR;
+extern "C" const MethodDescriptor HASHABLE_HASHVALUE_METHOD_DESCRIPTOR;
+extern "C" const MethodDescriptor HASHABLE_HASH_METHOD_DESCRIPTOR;
+extern "C" const MethodDescriptor HASHABLE_RAWHASHVALUE_METHOD_DESCRIPTOR;
+extern "C" const char __swift_tupleHashable_private;
+
+// This is needed to properly emplace relative references within the data
+// structures defined in this file. Because we can't directly express relative
+// references within C++, we have to calculate the offsets ourselves. A
+// previous version used assembly to work around this, but the use of assembly
+// is very non-portable and makes it incredibly easy to get things wrong.
+__attribute__((__constructor__))
+static void initializeBuiltinConformances() {
+  //---------------------------------//
+  // Tuple Equatable Initialization
+  //---------------------------------//
+
+  // Setup the protocol descriptor.
+  _swift_tupleEquatable_conf.protocol.set(&EQUATABLE_DESCRIPTOR);
+
+  // Setup the == witness (MethodDescriptor + Impl).
+  _swift_tupleEquatable_conf.resilientWitnesses[0].methodDescriptor.set(
+      &EQUATABLE_EE_METHOD_DESCRIPTOR);
+  _swift_tupleEquatable_conf.resilientWitnesses[0].impl.set(
+      reinterpret_cast<void *>(_swift_tupleEquatable_equals));
+
+  // Setup the private data.
+  _swift_tupleEquatable_conf.privateData.set(&__swift_tupleEquatable_private);
+
+  //---------------------------------//
+  // Tuple Comparable Initialization
+  //---------------------------------//
+
+  // Setup the protocol descriptor.
+  _swift_tupleComparable_conf.protocol.set(&COMPARABLE_DESCRIPTOR);
+
+  // Setup the associated conformance witness (MethodDescriptor + Impl).
+  _swift_tupleComparable_conf.resilientWitnesses[0].methodDescriptor.set(
+      &COMPARABLE_BASE_CONFORMANCE_DESCRIPTOR);
+  _swift_tupleComparable_conf.resilientWitnesses[0].impl.set(
+      reinterpret_cast<void *>(&_swift_tupleComparable_associatedConformance));
+
+  // Setup the < witness (MethodDescriptor + Impl).
+  _swift_tupleComparable_conf.resilientWitnesses[1].methodDescriptor.set(
+      &COMPARABLE_LT_METHOD_DESCRIPTOR);
+  _swift_tupleComparable_conf.resilientWitnesses[1].impl.set(
+      reinterpret_cast<void *>(_swift_tupleComparable_lessThan));
+
+  // Setup the <= witness (MethodDescriptor + Impl).
+  _swift_tupleComparable_conf.resilientWitnesses[2].methodDescriptor.set(
+      &COMPARBALE_LTE_METHOD_DESCRIPTOR);
+  _swift_tupleComparable_conf.resilientWitnesses[2].impl.set(
+      reinterpret_cast<void *>(_swift_tupleComparable_lessThanOrEqual));
+
+  // Setup the >= witness (MethodDescriptor + Impl).
+  _swift_tupleComparable_conf.resilientWitnesses[3].methodDescriptor.set(
+      &COMPARABLE_GTE_METHOD_DESCRIPTOR);
+  _swift_tupleComparable_conf.resilientWitnesses[3].impl.set(
+      reinterpret_cast<void *>(_swift_tupleComparable_greaterThanOrEqual));
+
+  // Setup the > witness (MethodDescriptor + Impl).
+  _swift_tupleComparable_conf.resilientWitnesses[4].methodDescriptor.set(
+      &COMPARABLE_GT_METHOD_DESCRIPTOR);
+  _swift_tupleComparable_conf.resilientWitnesses[4].impl.set(
+      reinterpret_cast<void *>(_swift_tupleComparable_greaterThan));
+
+  // Setup the private data.
+  _swift_tupleComparable_conf.privateData.set(&__swift_tupleComparable_private);
+
+  // Setup the associated conformances accessor implementation.
+  _swift_tupleComparable_associatedConformance.baseAccessor.set(
+      reinterpret_cast<void *>(_swift_tupleComparable_baseAccessorEquatable));
+
+  //---------------------------------//
+  // Tuple Hashable Initialization
+  //---------------------------------//
+
+  // Setup the protocol descriptor.
+  _swift_tupleHashable_conf.protocol.set(&HASHABLE_DESCRIPTOR);
+
+  // Setup the associated conformance witness (MethodDescriptor + Impl).
+  _swift_tupleHashable_conf.resilientWitnesses[0].methodDescriptor.set(
+      &HASHABLE_BASE_CONFORMANCE_DESCRIPTOR);
+  // NOTE: We intentionally use the Comparable implementation for this because
+  // the implementation is the same for both Hashable and Comparable. Both want
+  // to grab the Equatable table from its elements whose witness table is
+  // located in the same place for both protocols.
+  _swift_tupleHashable_conf.resilientWitnesses[0].impl.set(
+      reinterpret_cast<void *>(&_swift_tupleComparable_associatedConformance));
+
+  // Setup the hashValue witness (MethodDescriptor + Impl).
+  _swift_tupleHashable_conf.resilientWitnesses[1].methodDescriptor.set(
+      &HASHABLE_HASHVALUE_METHOD_DESCRIPTOR);
+  _swift_tupleHashable_conf.resilientWitnesses[1].impl.set(
+      reinterpret_cast<void *>(&_swift_tupleHashable_hashValue));
+
+  // Setup the hash(into:) witness (MethodDescriptor + Impl).
+  _swift_tupleHashable_conf.resilientWitnesses[2].methodDescriptor.set(
+      &HASHABLE_HASH_METHOD_DESCRIPTOR);
+  _swift_tupleHashable_conf.resilientWitnesses[2].impl.set(
+      reinterpret_cast<void *>(&_swift_tupleHashable_hash));
+
+  // Setup the _rawHashValue witness (MethodDescriptor + Impl).
+  _swift_tupleHashable_conf.resilientWitnesses[3].methodDescriptor.set(
+      &HASHABLE_RAWHASHVALUE_METHOD_DESCRIPTOR);
+  // NOTE: Because we're not setting the implementation pointer (which is
+  // currently 0), that means we're requesting the default implementation for
+  // this witness.
+
+  // Setup the private data.
+  _swift_tupleHashable_conf.privateData.set(&__swift_tupleHashable_private);
+}
+
+//===----------------------------------------------------------------------===//
+// Tuple Equatable Conformance
+//===----------------------------------------------------------------------===//
+
+CONFORMANCE_PRIVATE_DATA("__swift_tupleEquatable_private")
+SWIFT_RUNTIME_EXPORT
+_ConformanceDescriptor<1> swift::_swift_tupleEquatable_conf = {
+  // This is an indirectable relative reference to the Equatable protocol
+  // descriptor.
+  {
+    0
+  },
+
+  // 769 is the MetadataKind::Tuple
+  769,
+
+  // This indicates that we have no witness table pattern. We use a generic
+  // witness table for builtin conformances.
+  0,
+
+  // 196640 are the ConformanceFlags with the type reference bit set to
+  // MetadataKind, the has resilient witness bit, and the generic witness table
+  // bit.
+  196640,
+
+  // This 1 is the ResilientWitnessesHeader indicating we have 1 resilient
+  // witness.
+  1,
+
+  // This is our resilient witness list.
+  {
+    {
+      // This is an indirectable relative reference to the Equatable ==
+      // method descriptor.
+      {
+        0
+      },
+
+      // This is a direct relative reference to the equals witness defined below.
+      {
+        0
+      }
+    }
+  },
+
+  // The witness table size in words.
+  0,
+
+  // The witness table private size in words & requires instantiation.
+  1,
+
+  // The witness table instantiator function (we don't have one).
+  0,
+
+  // This is a direct relative reference to the private data for the
+  // conformance.
+  {
+    0
+  }
+};
+
+/// The protocol witness for static Swift.Equatable.== infix(A, A) -> Swift.Bool
+/// in conformance (A...): Swift.Equatable in Swift.
+SWIFT_CC(swift)
+bool swift::_swift_tupleEquatable_equals(OpaqueValue *tuple1,
+                                         OpaqueValue *tuple2,
+                                         SWIFT_CONTEXT Metadata *swiftSelf,
+                                         Metadata *Self, void *witnessTable) {
+  auto tuple = cast<TupleTypeMetadata>(Self);
+  auto table = reinterpret_cast<void**>(witnessTable);
+
+  // Loop through all elements, and check if both tuples element is equal.
+  for (size_t i = 0; i != tuple->NumElements; i += 1) {
+    auto elt = tuple->getElement(i);
+
+    // Get the element conformance from the private data in the witness table.
+    auto conformance = reinterpret_cast<const WitnessTable *>(table[-1 - i]);
+
+    // Get the respective values from both tuples.
+    auto value1 = reinterpret_cast<OpaqueValue *>(
+                    reinterpret_cast<char *>(tuple1) + elt.Offset);
+    auto value2 = reinterpret_cast<OpaqueValue *>(
+                    reinterpret_cast<char *>(tuple2) + elt.Offset);
+
+    // Grab the specific witness for this element type.
+    auto equatableTable = reinterpret_cast<void * const *>(conformance);
+    auto equalsWitness = equatableTable[WitnessTableFirstRequirementOffset];
+    auto equals = reinterpret_cast<StaticInfixWitness *>(equalsWitness);
+
+    // Call the equal function
+    auto result = equals(value1, value2, elt.Type, elt.Type, conformance);
+
+    // If the values aren't equal, this tuple isn't equal. :)
+    if (!result)
+      return false;
+  }
+
+  // Otherwise this tuple has value equality with all elements.
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+// Tuple Comparable Conformance
+//===----------------------------------------------------------------------===//
+
+CONFORMANCE_PRIVATE_DATA("__swift_tupleComparable_private")
+SWIFT_RUNTIME_EXPORT
+_ConformanceDescriptor<5> swift::_swift_tupleComparable_conf = {
+  // This is an indirectable relative reference to the Comparable protocol
+  // descriptor.
+  {
+    0
+  },
+
+  // 769 is the MetadataKind::Tuple
+  769,
+
+  // This indicates that we have no witness table pattern. We use a generic
+  // witness table for builtin conformances.
+  0,
+
+  // 196640 are the ConformanceFlags with the type reference bit set to
+  // MetadataKind, the has resilient witness bit, and the generic witness table
+  // bit.
+  196640,
+
+  // This 5 is the ResilientWitnessesHeader indicating we have 5 resilient
+  // witnesses.
+  5,
+
+  // This is our resilient witness list.
+  {
+    {
+      // This is an indirectable relative reference to the Comparable base
+      // conformance for Equatable.
+      {
+        0
+      },
+
+      // This is a direct relative reference to the associated conformance for
+      // Equatable defined above.
+      {
+        0
+      }
+    },
+    {
+      // This is an indirectable relative reference to the Comparable.<
+      // method descriptor.
+      {
+        0
+      },
+
+      // This is a direct relative reference to the < witness defined below.
+      {
+        0
+      }
+    },
+    {
+      // This is an indirectable relative reference to the Comparable.<=
+      // method descriptor.
+      {
+        0
+      },
+
+      // This is a direct relative reference to the <= witness defined below.
+      {
+        0
+      }
+    },
+    {
+      // This is an indirectable relative reference to the Comparable.>=
+      // method descriptor.
+      {
+        0
+      },
+
+      // This is a direct relative reference to the >= witness defined below.
+      {
+        0
+      }
+    },
+    {
+      // This is an indirectable relative reference to the Comparable.>
+      // method descriptor.
+      {
+        0
+      },
+
+      // This is a direct relative reference to the > witness defined below.
+      {
+        0
+      }
+    }
+  },
+
+  // The witness table size in words.
+  0,
+
+  // The witness table private size in words & requires instantiation.
+  1,
+
+  // The witness table instantiator function (we don't have one).
+  0,
+
+  // This is a direct relative reference to the private data for the
+  // conformance.
+  {
+    0
+  }
+};
+
+SWIFT_CC(swift)
+const WitnessTable *
+swift::_swift_tupleComparable_baseAccessorEquatable(Metadata *assocType,
+                                                    Metadata *conformingType,
+                                                    void **witnessTable) {
+  auto tuple = cast<TupleTypeMetadata>(assocType);
+  std::vector<void *> instantiationArgs;
+  instantiationArgs.reserve(tuple->NumElements);
+
+  // Fill the instantiationArgs with the element Equatable tables.
+  for (size_t i = 0; i != tuple->NumElements; i += 1) {
+    // Get the element's Comparable table.
+    auto comparableTable = reinterpret_cast<void **>(witnessTable[-1 - i]);
+
+    // The Equatable table is the first requirement, thus it'll be right after
+    // the conformance descriptor.
+    auto equatableTable = comparableTable[WitnessTableFirstRequirementOffset];
+
+    instantiationArgs.push_back(equatableTable);
+  }
+
+  auto tupleEquatableConf = reinterpret_cast<ProtocolConformanceDescriptor *>(
+      &_swift_tupleEquatable_conf);
+  // Finally, call getWitnessTable to realize the tuple's Equatable table.
+  auto equatableTable = swift_getWitnessTable(tupleEquatableConf,
+                                              assocType,
+                                              instantiationArgs.data());
+
+  return equatableTable;
+}
+
+SWIFT_CC(swift)
+bool swift::_swift_tupleComparable_lessThan(OpaqueValue *tuple1,
+                                            OpaqueValue *tuple2,
+                                            SWIFT_CONTEXT Metadata *swiftSelf,
+                                            Metadata *Self,
+                                            void *witnessTable) {
+  auto tuple = cast<TupleTypeMetadata>(Self);
+  auto table = reinterpret_cast<void**>(witnessTable);
+
+  // Loop through all elements, and check if both tuples element is equal.
+  for (size_t i = 0; i != tuple->NumElements; i += 1) {
+    auto elt = tuple->getElement(i);
+
+    // Get the element conformance from the private data in the witness table.
+    auto conformance = reinterpret_cast<const WitnessTable *>(table[-1 - i]);
+
+    // Get the respective values from both tuples.
+    auto value1 = reinterpret_cast<OpaqueValue *>(
+                    reinterpret_cast<char *>(tuple1) + elt.Offset);
+    auto value2 = reinterpret_cast<OpaqueValue *>(
+                    reinterpret_cast<char *>(tuple2) + elt.Offset);
+
+    // First, grab the equatable conformance to prepare to check if the elements
+    // are equal. (Since this require Equatable conformance, the witness table
+    // is right after the conformance descriptor, which is at index 0.)
+    auto comparableTable = reinterpret_cast<void * const *>(conformance);
+    auto equatableTable = reinterpret_cast<void * const *>(comparableTable[1]);
+    auto equalsWitness = equatableTable[WitnessTableFirstRequirementOffset];
+    auto equals = reinterpret_cast<StaticInfixWitness *>(equalsWitness);
+
+    // Call the equal function.
+    auto isEqual = equals(value1, value2, elt.Type, elt.Type,
+                        reinterpret_cast<const WitnessTable *>(equatableTable));
+
+    // If these are equal, skip to the next element.
+    if (isEqual)
+      continue;
+
+    // Now that we know they are not equal, we can call their less than function
+    // and return the result.
+    auto lessThanWitness = comparableTable[WitnessTableFirstRequirementOffset + 1];
+    auto lessThan = reinterpret_cast<StaticInfixWitness *>(lessThanWitness);
+
+    // Call the less than function.
+    auto isLessThan = lessThan(value1, value2, elt.Type, elt.Type, conformance);
+
+    return isLessThan;
+  }
+
+  // Otherwise these tuples are completely equal, thus they are not less than
+  // each other.
+  return false;
+}
+
+SWIFT_CC(swift)
+bool swift::_swift_tupleComparable_lessThanOrEqual(OpaqueValue *tuple1,
+                                                   OpaqueValue *tuple2,
+                                              SWIFT_CONTEXT Metadata *swiftSelf,
+                                                   Metadata *Self,
+                                                   void *witnessTable) {
+  auto tuple = cast<TupleTypeMetadata>(Self);
+  auto table = reinterpret_cast<void**>(witnessTable);
+
+  // Loop through all elements, and check if both tuples element is equal.
+  for (size_t i = 0; i != tuple->NumElements; i += 1) {
+    auto elt = tuple->getElement(i);
+
+    // Get the element conformance from the private data in the witness table.
+    auto conformance = reinterpret_cast<const WitnessTable *>(table[-1 - i]);
+
+    // Get the respective values from both tuples.
+    auto value1 = reinterpret_cast<OpaqueValue *>(
+                    reinterpret_cast<char *>(tuple1) + elt.Offset);
+    auto value2 = reinterpret_cast<OpaqueValue *>(
+                    reinterpret_cast<char *>(tuple2) + elt.Offset);
+
+    // First, grab the equatable conformance to prepare to check if the elements
+    // are equal. (Since this require Equatable conformance, the witness table
+    // is right after the conformance descriptor, which is at index 0.)
+    auto comparableTable = reinterpret_cast<void * const *>(conformance);
+    auto equatableTable = reinterpret_cast<void * const *>(comparableTable[1]);
+    auto equalsWitness = equatableTable[WitnessTableFirstRequirementOffset];
+    auto equals = reinterpret_cast<StaticInfixWitness *>(equalsWitness);
+
+    // Call the equal function.
+    auto isEqual = equals(value1, value2, elt.Type, elt.Type,
+                        reinterpret_cast<const WitnessTable *>(equatableTable));
+
+    // If these are equal, skip to the next element.
+    if (isEqual)
+      continue;
+
+    // Now that we know they are not equal, we can call their less than or equal
+    // function and return the result.
+    auto lessThanOrEqualWitness = 
+        comparableTable[WitnessTableFirstRequirementOffset + 2];
+    auto lessThanOrEqual = 
+        reinterpret_cast<StaticInfixWitness *>(lessThanOrEqualWitness);
+
+    // Call the less than function.
+    auto isLessThanOrEqual = lessThanOrEqual(value1, value2, elt.Type, elt.Type,
+                                             conformance);
+
+    return isLessThanOrEqual;
+  }
+
+  // Otherwise these tuples are completely equal.
+  return true;
+}
+
+SWIFT_CC(swift)
+bool swift::_swift_tupleComparable_greaterThanOrEqual(OpaqueValue *tuple1,
+                                                      OpaqueValue *tuple2,
+                                              SWIFT_CONTEXT Metadata *swiftSelf,
+                                                      Metadata *Self,
+                                                      void *witnessTable) {
+  auto tuple = cast<TupleTypeMetadata>(Self);
+  auto table = reinterpret_cast<void**>(witnessTable);
+
+  // Loop through all elements, and check if both tuples element is equal.
+  for (size_t i = 0; i != tuple->NumElements; i += 1) {
+    auto elt = tuple->getElement(i);
+
+    // Get the element conformance from the private data in the witness table.
+    auto conformance = reinterpret_cast<const WitnessTable *>(table[-1 - i]);
+
+    // Get the respective values from both tuples.
+    auto value1 = reinterpret_cast<OpaqueValue *>(
+                    reinterpret_cast<char *>(tuple1) + elt.Offset);
+    auto value2 = reinterpret_cast<OpaqueValue *>(
+                    reinterpret_cast<char *>(tuple2) + elt.Offset);
+
+    // First, grab the equatable conformance to prepare to check if the elements
+    // are equal. (Since this require Equatable conformance, the witness table
+    // is right after the conformance descriptor, which is at index 0.)
+    auto comparableTable = reinterpret_cast<void * const *>(conformance);
+    auto equatableTable = reinterpret_cast<void * const *>(comparableTable[1]);
+    auto equalsWitness = equatableTable[WitnessTableFirstRequirementOffset];
+    auto equals = reinterpret_cast<StaticInfixWitness *>(equalsWitness);
+
+    // Call the equal function.
+    auto isEqual = equals(value1, value2, elt.Type, elt.Type,
+                        reinterpret_cast<const WitnessTable *>(equatableTable));
+
+    // If these are equal, skip to the next element.
+    if (isEqual)
+      continue;
+
+    // Now that we know they are not equal, we can call their greater than or
+    // equal function and return the result.
+    auto greaterThanOrEqualWitness =
+        comparableTable[WitnessTableFirstRequirementOffset + 3];
+    auto greaterThanOrEqual =
+        reinterpret_cast<StaticInfixWitness *>(greaterThanOrEqualWitness);
+
+    // Call the greater than or equal function.
+    auto isGreaterThanOrEqual = greaterThanOrEqual(value1, value2, elt.Type,
+                                                   elt.Type, conformance);
+
+    return isGreaterThanOrEqual;
+  }
+
+  // Otherwise these tuples are completely equal.
+  return true;
+}
+
+SWIFT_CC(swift)
+bool swift::_swift_tupleComparable_greaterThan(OpaqueValue *tuple1,
+                                               OpaqueValue *tuple2,
+                                              SWIFT_CONTEXT Metadata *swiftSelf,
+                                               Metadata *Self,
+                                               void *witnessTable) {
+  auto tuple = cast<TupleTypeMetadata>(Self);
+  auto table = reinterpret_cast<void**>(witnessTable);
+
+  // Loop through all elements, and check if both tuples element is equal.
+  for (size_t i = 0; i != tuple->NumElements; i += 1) {
+    auto elt = tuple->getElement(i);
+
+    // Get the element conformance from the private data in the witness table.
+    auto conformance = reinterpret_cast<const WitnessTable *>(table[-1 - i]);
+
+    // Get the respective values from both tuples.
+    auto value1 = reinterpret_cast<OpaqueValue *>(
+                    reinterpret_cast<char *>(tuple1) + elt.Offset);
+    auto value2 = reinterpret_cast<OpaqueValue *>(
+                    reinterpret_cast<char *>(tuple2) + elt.Offset);
+
+    // First, grab the equatable conformance to prepare to check if the elements
+    // are equal. (Since this require Equatable conformance, the witness table
+    // is right after the conformance descriptor, which is at index 0.)
+    auto comparableTable = reinterpret_cast<void * const *>(conformance);
+    auto equatableTable = reinterpret_cast<void * const *>(comparableTable[1]);
+    auto equalsWitness = equatableTable[WitnessTableFirstRequirementOffset];
+    auto equals = reinterpret_cast<StaticInfixWitness *>(equalsWitness);
+
+    // Call the equal function.
+    auto isEqual = equals(value1, value2, elt.Type, elt.Type,
+                        reinterpret_cast<const WitnessTable *>(equatableTable));
+
+    // If these are equal, skip to the next element.
+    if (isEqual)
+      continue;
+
+    // Now that we know they are not equal, we can call their greater than
+    // function and return the result.
+    auto greaterThanWitness =
+        comparableTable[WitnessTableFirstRequirementOffset + 4];
+    auto greaterThan =
+        reinterpret_cast<StaticInfixWitness *>(greaterThanWitness);
+
+    // Call the greater than function.
+    auto isGreaterThan = greaterThan(value1, value2, elt.Type, elt.Type,
+                                     conformance);
+
+    return isGreaterThan;
+  }
+
+  // Otherwise these tuples are completely equal, thus they are not greater than
+  // each other.
+  return false;
+}
+
+//===----------------------------------------------------------------------===//
+// Tuple Hashable Conformance
+//===----------------------------------------------------------------------===//
+
+extern "C" SWIFT_CC(swift)
+intptr_t SWIFT_HASHVALUE_FUNC(OpaqueValue *value, Metadata *Self,
+                              void *witnessTable);
+
+extern "C" SWIFT_CC(swift)
+void SWIFT_HASHER_COMBINE_FUNC(OpaqueValue *value, const Metadata *Self,
+                               const WitnessTable *witnessTable,
+                               SWIFT_CONTEXT OpaqueValue *hasher);
+
+CONFORMANCE_PRIVATE_DATA("__swift_tupleHashable_private")
+SWIFT_RUNTIME_EXPORT
+_ConformanceDescriptor<4> swift::_swift_tupleHashable_conf = {
+  // This is an indirectable relative reference to the Hashable protocol
+  // descriptor.
+  {
+    0
+  },
+
+  // 769 is the MetadataKind::Tuple
+  769,
+
+  // This indicates that we have no witness table pattern. We use a generic
+  // witness table for builtin conformances.
+  0,
+
+  // 196640 are the ConformanceFlags with the type reference bit set to
+  // MetadataKind, the has resilient witness bit, and the generic witness table
+  // bit.
+  196640,
+
+  // This 4 is the ResilientWitnessesHeader indicating we have 4 resilient
+  // witnesses.
+  4,
+
+  // This is our resilient witness list.
+  {
+    {
+      // This is an indirectable relative reference to the Hashable base
+      // conformance for Equatable.
+      {
+        0
+      },
+
+      // This is a direct relative reference to the associated conformance for
+      // Equatable defined above.
+      {
+        0
+      }
+    },
+    {
+      // This is an indirectable relative reference to the Hashable hashValue
+      // method descriptor.
+      {
+        0
+      },
+
+      // This is a direct relative reference to the hashValue witness defined
+      // below.
+      {
+        0
+      }
+    },
+    {
+      // This is an indirectable relative reference to the Hashable hash(into:)
+      // method descriptor.
+      {
+        0
+      },
+
+      // This is a direct relative reference to the hash witness defined below.
+      {
+        0
+      }
+    },
+    {
+      // This is an indirectable relative reference to the Hashable
+      // _rawHashValue method descriptor.
+      {
+        0
+      },
+
+      // This is requesting the default implemenation of _rawHashValue.
+      {
+        0
+      }
+    }
+  },
+
+  // The witness table size in words.
+  0,
+
+  // The witness table private size in words & requires instantiation.
+  1,
+
+  // The witness table instantiator function (we don't have one).
+  0,
+
+  // This is a direct relative reference to the private data for the
+  // conformance.
+  {
+    0
+  }
+};
+
+SWIFT_CC(swift)
+intptr_t swift::_swift_tupleHashable_hashValue(SWIFT_CONTEXT OpaqueValue *tuple,
+                                               Metadata *Self,
+                                               void *witnessTable) {
+  return SWIFT_HASHVALUE_FUNC(tuple, Self, witnessTable);
+}
+
+SWIFT_CC(swift)
+void swift::_swift_tupleHashable_hash(OpaqueValue *hasher,
+                                      SWIFT_CONTEXT OpaqueValue *tuple,
+                                      Metadata *Self, void *witnessTable) {
+  auto tupleTy = cast<TupleTypeMetadata>(Self);
+  auto table = reinterpret_cast<void**>(witnessTable);
+
+  // Loop through all elements and hash them into the Hasher.
+  for (size_t i = 0; i != tupleTy->NumElements; i += 1) {
+    auto elt = tupleTy->getElement(i);
+
+    // Get the element conformance from the private data in the witness table.
+    auto conformance = reinterpret_cast<const WitnessTable *>(table[-1 - i]);
+
+    // Get the element value from the tuple.
+    auto value = reinterpret_cast<OpaqueValue *>(
+                  reinterpret_cast<char *>(tuple) + elt.Offset);
+
+    // Call the combine function on the hasher for this element value and we're
+    // done!
+    SWIFT_HASHER_COMBINE_FUNC(value, elt.Type, conformance, hasher);
+  }
+}

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -31,6 +31,7 @@ set(swift_runtime_sources
     Array.cpp
     AutoDiffSupport.cpp
     Bincompat.cpp
+    BuiltinProtocolConformances.cpp
     Casting.cpp
     CygwinPort.cpp
     Demangle.cpp

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -21,6 +21,7 @@
 #include "swift/Basic/STLExtras.h"
 #include "swift/Demangling/Demangler.h"
 #include "swift/ABI/TypeIdentity.h"
+#include "swift/Runtime/BuiltinProtocolConformances.h"
 #include "swift/Runtime/Casting.h"
 #include "swift/Runtime/EnvironmentVariables.h"
 #include "swift/Runtime/ExistentialContainer.h"
@@ -194,6 +195,11 @@ computeMetadataBoundsForSuperclass(const void *ref,
 #else
     break;
 #endif
+  }
+
+  // Non-nominals don't have superclass bounds.
+  case TypeReferenceKind::MetadataKind: {
+    break;
   }
   }
   swift_unreachable("unsupported superclass reference kind");
@@ -4507,6 +4513,13 @@ template <> SWIFT_USED void EnumDescriptor::dump() const {
 
 namespace {
 
+static bool
+isTupleBuiltinConformance(const ProtocolConformanceDescriptor *conformance) {
+  return intptr_t(conformance) == intptr_t(&_swift_tupleEquatable_conf) ||
+         intptr_t(conformance) == intptr_t(&_swift_tupleComparable_conf) ||
+         intptr_t(conformance) == intptr_t(&_swift_tupleHashable_conf);
+}
+
 /// A cache-entry type suitable for use with LockingConcurrentMap.
 class WitnessTableCacheEntry :
     public SimpleLockingCacheEntryBase<WitnessTableCacheEntry, WitnessTable*> {
@@ -4543,18 +4556,27 @@ public:
                              const Metadata *type,
                              const ProtocolConformanceDescriptor *conformance,
                              const void * const *instantiationArgs) {
-    return getWitnessTableSize(conformance);
+    return getWitnessTableSize(type, conformance);
   }
 
   size_t getExtraAllocationSize() const {
-    return getWitnessTableSize(Conformance);
+    return getWitnessTableSize(Type, Conformance);
   }
 
-  static size_t getWitnessTableSize(
+  static size_t getWitnessTableSize(const Metadata *type,
                             const ProtocolConformanceDescriptor *conformance) {
     auto protocol = conformance->getProtocol();
     auto genericTable = conformance->getGenericWitnessTable();
     size_t numPrivateWords = genericTable->getWitnessTablePrivateSizeInWords();
+
+    // Builtin conformance descriptors, namely tuple conformances at the moment,
+    // have their private size in words be determined via the number of elements
+    // the type has.
+    if (isTupleBuiltinConformance(conformance)) {
+      auto tuple = cast<TupleTypeMetadata>(type);
+      numPrivateWords = tuple->NumElements;
+    }
+
     size_t numRequirementWords =
       WitnessTableFirstRequirementOffset + protocol->NumRequirements;
     return (numPrivateWords + numRequirementWords) * sizeof(void*);
@@ -4813,6 +4835,14 @@ instantiateWitnessTable(const Metadata *Type,
   // Number of bytes for any private storage used by the conformance itself.
   size_t privateSizeInWords = genericTable->getWitnessTablePrivateSizeInWords();
 
+  // Builtin conformance descriptors, namely tuple conformances at the moment,
+  // have their private size in words be determined via the number of elements
+  // the type has.
+  if (isTupleBuiltinConformance(conformance)) {
+    auto tuple = cast<TupleTypeMetadata>(Type);
+    privateSizeInWords = tuple->NumElements;
+  }
+
   // Advance the address point; the private storage area is accessed via
   // negative offsets.
   auto table = fullTable + privateSizeInWords;
@@ -4855,6 +4885,16 @@ instantiateWitnessTable(const Metadata *Type,
       if (conditionalRequirement.Flags.hasExtraArgument())
         copyNextInstantiationArg();
     }
+
+    // Builtin conformance descriptors, namely tuple conformances at the moment,
+    // have instantiation arguments equal to the number of element conformances.
+    if (isTupleBuiltinConformance(conformance)) {
+      auto tuple = cast<TupleTypeMetadata>(Type);
+
+      for (size_t i = 0; i != tuple->NumElements; i += 1) {
+        copyNextInstantiationArg();
+      }
+    }
   }
 
   // Fill in any default requirements.
@@ -4878,7 +4918,7 @@ WitnessTableCacheEntry::allocate(
   void **fullTable = reinterpret_cast<void**>(this + 1);
 
   // Zero out the witness table.
-  memset(fullTable, 0, getWitnessTableSize(conformance));
+  memset(fullTable, 0, getWitnessTableSize(Type, conformance));
 
   // Instantiate the table.
   return instantiateWitnessTable(Type, Conformance, instantiationArgs, fullTable);
@@ -4899,7 +4939,7 @@ getNondependentWitnessTable(const ProtocolConformanceDescriptor *conformance,
   }
 
   // Allocate space for the table.
-  auto tableSize = WitnessTableCacheEntry::getWitnessTableSize(conformance);
+  auto tableSize = WitnessTableCacheEntry::getWitnessTableSize(type, conformance);
   TaggedMetadataAllocator<SingletonGenericWitnessTableCacheTag> allocator;
   auto buffer = (void **)allocator.Allocate(tableSize, alignof(void*));
   memset(buffer, 0, tableSize);

--- a/stdlib/toolchain/Compatibility51/ProtocolConformance.cpp
+++ b/stdlib/toolchain/Compatibility51/ProtocolConformance.cpp
@@ -229,6 +229,10 @@ override_getCanonicalTypeMetadata(const ProtocolConformanceDescriptor *conf) {
 
     return nullptr;
   }
+
+  case TypeReferenceKind::MetadataKind: {
+    return nullptr;
+  }
   }
 
   swift_unreachable("Unhandled TypeReferenceKind in switch.");


### PR DESCRIPTION
This is another attempt to getting tuples to conform to these protocols. I made some very different choices when implementing this one to prevent the usage of assembly to create these conformance data structures. Notably, the only real changes should be in `BuiltinProtocolConformances.h` and the respectful `BuiltinProtocolConformances.cpp`. This approach creates placeholders for relative references instead of using assembly to create relocations. On startup, we setup the relative references to their respectful offsets. Because the assembly we needed to make had to make use of dynamic relocations like `@GOT` (because LLVM won't let us reference undefined symbols right now), there had to be startup overhead for the dynamic linker to figure out the relative references anyway, so I figured that performance characteristics would roughly be about the same.

Right now, I haven't implemented any of the compatibility stuff because I wanted to get a feel for whether or not this approach was worth looking into. In terms of the stub needed for back deployment, the best solution I could come up with was to reference `swift_conformsToProtocol` to get the witness table when back deploying. This is great for older clients because they instantly get the witness table that's already created within the compatibility library, but the Swift current suffers in that it now needs to search for the witness tables of its elements. Obviously if we're not back deploying we can simply stick with `swift_getWitnessTable` and reference the conformance descriptor directly.

Please let me know what you think about this approach or if you had any other ideas! I really want people to get their hands on this feature, but I also want a solution that is sustainable (at least until actual non-nominal conformances come, then we can rip most of this out).

Edit: Alternatively, instead of a constructor that sets up all of these references, we could lazily set up each conformance descriptor when they're being used in either `swift_getWitnessTable` or `swift_conformsToProtocol` (if we choose to use that as a stub).