### PR TITLE
[docs] Update Testing.md

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,4 +1,3 @@
-
 # Testing Swift
 
 This document describes how we test the Swift compiler, the Swift runtime, and
@@ -26,22 +25,6 @@ We use multiple approaches to test the Swift toolchain.
 * Buildbots run all tests, on all supported platforms.
   [Smoke testing](ContinuousIntegration.md#smoke-testing)
   skips the iOS, tvOS, and watchOS platforms.
-
-The [test/lit.cfg](https://github.com/apple/swift/blob/main/test/lit.cfg)
-uses an iOS 10.3 simulator configuration named "iPhone 5" for 32-bit testing.
-
-1.  Download and install the iOS 10.3 simulator runtime, in Xcode's
-    [Components](https://help.apple.com/xcode/#/deva7379ae35) preferences.
-
-2.  Create an "iPhone 5" simulator configuration, either in Xcode's
-    [Devices and Simulators](https://help.apple.com/xcode/#/devf225e58da)
-    window, or with the command line:
-
-    ```sh
-    xcrun simctl create 'iPhone 5' com.apple.CoreSimulator.SimDeviceType.iPhone-5 com.apple.CoreSimulator.SimRuntime.iOS-10-3
-    ```
-
-3.  Append `--ios` to the `utils/build-script` command line (see below).
 
 ### Testsuite subsets
 


### PR DESCRIPTION
Remove details on 32-bit testing with an iOS simulator.

* The iOS 10.3 simulator runtime is unavailable in Xcode 12.5
* The latest instructions for 32-bit testing are printed by [test/lit.cfg](https://github.com/apple/swift/blob/724e015dae518c79560a957cf1ac012ce0470a86/test/lit.cfg#L83-L114)

Reverts: #31866