### PR TITLE
[5.5][Refactoring] Avoid redeclarations or shadowing in async refactored code

### DIFF
--- a/include/swift/AST/DiagnosticsRefactoring.def
+++ b/include/swift/AST/DiagnosticsRefactoring.def
@@ -62,8 +62,6 @@ ERROR(unknown_callback_conditions, none, "cannot refactor complex if conditions"
 
 ERROR(mixed_callback_conditions, none, "cannot refactor mixed nil and not-nil conditions", ())
 
-ERROR(callback_multiple_bound_names, none, "cannot refactor when multiple names bound to single declaration, had '%0' and found '%1'", (StringRef, StringRef))
-
 ERROR(callback_with_fallthrough, none, "cannot refactor switch with fallthrough", ())
 
 ERROR(callback_with_default, none, "cannot refactor switch with default case", ())

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -4561,12 +4561,18 @@ class ClassifiedBlock {
   SmallVector<ASTNode, 0> Nodes;
   // closure param -> name
   llvm::DenseMap<const Decl *, StringRef> BoundNames;
+  // var (ie. from a let binding) -> closure param
+  llvm::DenseMap<const Decl *, const Decl *> Aliases;
   bool AllLet = true;
 
 public:
   ArrayRef<ASTNode> nodes() const { return llvm::makeArrayRef(Nodes); }
 
   StringRef boundName(const Decl *D) const { return BoundNames.lookup(D); }
+
+  const llvm::DenseMap<const Decl *, const Decl *> &aliases() const {
+    return Aliases;
+  }
 
   bool allLet() const { return AllLet; }
 
@@ -4593,22 +4599,16 @@ public:
     }
 
     StringRef Name = FromCondition.BindPattern->getBoundName().str();
-    if (Name.empty())
+    VarDecl *SingleVar = FromCondition.BindPattern->getSingleVar();
+    if (Name.empty() || !SingleVar)
       return;
 
-    auto Res = BoundNames.try_emplace(FromCondition.Subject, Name);
-    if (Res.second)
-      return;
+    auto Res = Aliases.try_emplace(SingleVar, FromCondition.Subject);
+    assert(Res.second && "Should not have seen this var before");
+    (void)Res;
 
-    // Already inserted, only handle cases where the name is the same
-    // TODO: This wouldn't be that hard to handle, just need to keep track
-    //       of the decl and replace its name with the same as the original
-    StringRef OldName = Res.first->second;
-    if (OldName != Name) {
-      DiagEngine.diagnose(FromCondition.BindPattern->getLoc(),
-                          diag::callback_multiple_bound_names,
-                          StringRef(OldName), Name);
-    }
+    // Use whichever name comes first
+    BoundNames.try_emplace(FromCondition.Subject, Name);
   }
 
   void addAllBindings(
@@ -4849,6 +4849,244 @@ private:
   }
 };
 
+/// Whether or not the given statement starts a new scope. Note that most
+/// statements are handled by the \c BraceStmt check. The others listed are
+/// a somewhat special case since they can also declare variables in their
+/// condition.
+static bool startsNewScope(Stmt *S) {
+  switch (S->getKind()) {
+  case StmtKind::Brace:
+  case StmtKind::If:
+  case StmtKind::While:
+  case StmtKind::ForEach:
+  case StmtKind::Case:
+    return true;
+  default:
+    return false;
+  }
+}
+
+/// Name of a decl if it has one, an empty \c Identifier otherwise.
+static Identifier getDeclName(const Decl *D) {
+  if (auto *VD = dyn_cast<ValueDecl>(D)) {
+    if (VD->hasName())
+      return VD->getBaseIdentifier();
+  }
+  return Identifier();
+}
+
+class DeclCollector : private SourceEntityWalker {
+  llvm::DenseSet<const Decl *> &Decls;
+
+public:
+  /// Collect all explicit declarations declared in \p Scope (or \p SF if
+  /// \p Scope is a nullptr) that are not within their own scope.
+  static void collect(BraceStmt *Scope, SourceFile &SF,
+                      llvm::DenseSet<const Decl *> &Decls) {
+    DeclCollector Collector(Decls);
+    if (Scope) {
+      for (auto Node : Scope->getElements()) {
+        Collector.walk(Node);
+      }
+    } else {
+      Collector.walk(SF);
+    }
+  }
+
+private:
+  DeclCollector(llvm::DenseSet<const Decl *> &Decls)
+      : Decls(Decls) {}
+
+  bool walkToDeclPre(Decl *D, CharSourceRange Range) override {
+    // Want to walk through top level code decls (which are implicitly added
+    // for top level non-decl code) and pattern binding decls (which contain
+    // the var decls that we care about).
+    if (isa<TopLevelCodeDecl>(D) || isa<PatternBindingDecl>(D))
+      return true;
+
+    if (!D->isImplicit())
+      Decls.insert(D);
+    return false;
+  }
+
+  bool walkToExprPre(Expr *E) override {
+    return !isa<ClosureExpr>(E);
+  }
+
+  bool walkToStmtPre(Stmt *S) override {
+    return S->isImplicit() || !startsNewScope(S);
+  }
+};
+
+class ReferenceCollector : private SourceEntityWalker {
+  SourceManager *SM;
+  llvm::DenseSet<const Decl *> DeclaredDecls;
+  llvm::DenseSet<const Decl *> &ReferencedDecls;
+
+  ASTNode Target;
+  bool AfterTarget;
+
+public:
+  /// Collect all explicit references in \p Scope (or \p SF if \p Scope is
+  /// a nullptr) that are after \p Target and not first declared. That is,
+  /// references that we don't want to shadow with hoisted declarations.
+  ///
+  /// Also collect all declarations that are \c DeclContexts, which is an
+  /// over-appoximation but let's us ignore them elsewhere.
+  static void collect(ASTNode Target, BraceStmt *Scope, SourceFile &SF,
+                      llvm::DenseSet<const Decl *> &Decls) {
+    ReferenceCollector Collector(Target, &SF.getASTContext().SourceMgr,
+                                 Decls);
+    if (Scope)
+      Collector.walk(Scope);
+    else
+      Collector.walk(SF);
+  }
+
+private:
+  ReferenceCollector(ASTNode Target, SourceManager *SM,
+                     llvm::DenseSet<const Decl *> &Decls)
+      : SM(SM), DeclaredDecls(), ReferencedDecls(Decls), Target(Target),
+        AfterTarget(false) {}
+
+  bool walkToDeclPre(Decl *D, CharSourceRange Range) override {
+    // Bit of a hack, include all contexts so they're never renamed (seems worse
+    // to rename a class/function than it does a variable). Again, an
+    // over-approximation, but hopefully doesn't come up too often.
+    if (isa<DeclContext>(D) && !D->isImplicit()) {
+      ReferencedDecls.insert(D);
+    }
+
+    if (AfterTarget && !D->isImplicit()) {
+      DeclaredDecls.insert(D);
+    } else if (D == Target.dyn_cast<Decl *>()) {
+      AfterTarget = true;
+    }
+    return shouldWalkInto(D->getSourceRange());
+  }
+
+  bool walkToExprPre(Expr *E) override {
+    if (AfterTarget && !E->isImplicit()) {
+      if (auto *DRE = dyn_cast<DeclRefExpr>(E)) {
+        if (auto *D = DRE->getDecl()) {
+          // Only care about references that aren't declared as seen decls will
+          // be renamed (if necessary) during the refactoring.
+          if (!D->isImplicit() && !DeclaredDecls.count(D))
+            ReferencedDecls.insert(D);
+        }
+      }
+    } else if (E == Target.dyn_cast<Expr *>()) {
+      AfterTarget = true;
+    }
+    return shouldWalkInto(E->getSourceRange());
+  }
+
+  bool walkToStmtPre(Stmt *S) override {
+    if (S == Target.dyn_cast<Stmt *>())
+      AfterTarget = true;
+    return shouldWalkInto(S->getSourceRange());
+  }
+
+  std::pair<bool, Pattern *> walkToPatternPre(Pattern *P) {
+    if (P == Target.dyn_cast<Pattern *>())
+      AfterTarget = true;
+    return { shouldWalkInto(P->getSourceRange()), P };
+  }
+
+  bool shouldWalkInto(SourceRange Range) {
+    return AfterTarget || (SM &&
+        SM->rangeContainsTokenLoc(Range, Target.getStartLoc()));
+  }
+};
+
+/// Similar to the \c ReferenceCollector but collects references in all scopes
+/// without any starting point in each scope.
+class ScopedDeclCollector : private SourceEntityWalker {
+public:
+  using DeclsTy = llvm::DenseSet<const Decl *>;
+
+private:
+  using ScopedDeclsTy = llvm::DenseMap<const Stmt *, DeclsTy>;
+
+  struct Scope {
+    DeclsTy DeclaredDecls;
+    DeclsTy *ReferencedDecls;
+    Scope(DeclsTy *ReferencedDecls) : DeclaredDecls(),
+        ReferencedDecls(ReferencedDecls) {}
+  };
+
+  ScopedDeclsTy ReferencedDecls;
+  llvm::SmallVector<Scope, 4> ScopeStack;
+
+public:
+  /// Starting at \c Scope, collect all explicit references in every scope
+  /// within (including the initial) that are not first declared, ie. those that
+  /// could end up shadowed. Also include all \c DeclContext declarations as
+  /// we'd like to avoid renaming functions and types completely.
+  void collect(ASTNode Node) {
+    walk(Node);
+  }
+
+  DeclsTy *getReferencedDecls(Stmt *Scope) {
+    auto Res = ReferencedDecls.find(Scope);
+    if (Res == ReferencedDecls.end())
+      return nullptr;
+    return &Res->second;
+  }
+
+private:
+  bool walkToDeclPre(Decl *D, CharSourceRange Range) override {
+    if (ScopeStack.empty() || D->isImplicit())
+      return true;
+
+    ScopeStack.back().DeclaredDecls.insert(D);
+    if (isa<DeclContext>(D))
+      ScopeStack.back().ReferencedDecls->insert(D);
+    return true;
+  }
+
+  bool walkToExprPre(Expr *E) override {
+    if (ScopeStack.empty())
+      return true;
+
+    if (!E->isImplicit()) {
+      if (auto *DRE = dyn_cast<DeclRefExpr>(E)) {
+        if (auto *D = DRE->getDecl()) {
+          if (!D->isImplicit() && !ScopeStack.back().DeclaredDecls.count(D))
+            ScopeStack.back().ReferencedDecls->insert(D);
+        }
+      }
+    }
+    return true;
+  }
+
+  bool walkToStmtPre(Stmt *S) override {
+    // Purposely check \c BraceStmt here rather than \c startsNewScope.
+    // References in the condition should be applied to the previous scope, not
+    // the scope of that statement.
+    if (isa<BraceStmt>(S))
+      ScopeStack.emplace_back(&ReferencedDecls[S]);
+    return true;
+  }
+
+  bool walkToStmtPost(Stmt *S) override {
+    if (isa<BraceStmt>(S)) {
+      size_t NumScopes = ScopeStack.size();
+      if (NumScopes >= 2) {
+        // Add any referenced decls to the parent scope that weren't declared
+        // there.
+        auto &ParentStack = ScopeStack[NumScopes - 2];
+        for (auto *D : *ScopeStack.back().ReferencedDecls) {
+          if (!ParentStack.DeclaredDecls.count(D))
+            ParentStack.ReferencedDecls->insert(D);
+        }
+      }
+      ScopeStack.pop_back();
+    }
+    return true;
+  }
+};
+
 /// Builds up async-converted code for an AST node.
 ///
 /// If it is a function, its declaration will have `async` added. If a
@@ -4879,6 +5117,7 @@ private:
 /// the code the user intended. In most cases the refactoring will continue,
 /// with any unhandled decls wrapped in placeholders instead.
 class AsyncConverter : private SourceEntityWalker {
+  ASTContext &Context;
   SourceManager &SM;
   DiagnosticEngine &DiagEngine;
 
@@ -4887,7 +5126,8 @@ class AsyncConverter : private SourceEntityWalker {
 
   // Completion handler of `StartNode` (if it's a function with an async
   // alternative)
-  const AsyncHandlerParamDesc &TopHandler;
+  AsyncHandlerParamDesc TopHandler;
+
   SmallString<0> Buffer;
   llvm::raw_svector_ostream OS;
 
@@ -4895,28 +5135,68 @@ class AsyncConverter : private SourceEntityWalker {
   // elided, e.g for a previously optional closure parameter that has become a
   // non-optional local.
   llvm::DenseSet<const Decl *> Unwraps;
+
   // Decls whose references should be replaced with, either because they no
   // longer exist or are a different type. Any replaced code should ideally be
   // handled by the refactoring properly, but that's not possible in all cases
   llvm::DenseSet<const Decl *> Placeholders;
-  // Mapping from decl -> name, used as both the name of possibly new local
-  // declarations of old parameters, as well as the replacement for any
-  // references to it
-  llvm::DenseMap<const Decl *, std::string> Names;
+
+  // Mapping from decl -> name, used as the name of possible new local
+  // declarations of old completion handler parametes, as well as the
+  // replacement for other hoisted declarations and their references
+  llvm::DenseMap<const Decl *, Identifier> Names;
+  // Names of decls in each scope, where the first element is the initial scope
+  // and the last is the current scope.
+  llvm::SmallVector<llvm::DenseSet<Identifier>, 4> ScopedNames;
+  // Mapping of \c BraceStmt -> declarations referenced in that statement
+  // without first being declared. These are used to fill the \c ScopeNames
+  // map on entering that scope.
+  ScopedDeclCollector ScopedDecls;
 
   /// The switch statements that have been re-written by this transform.
   llvm::DenseSet<SwitchStmt *> HandledSwitches;
 
-  // These are per-node (ie. are saved and restored on each convertNode call)
+  // The last source location that has been output. Used to output the source
+  // between handled nodes
   SourceLoc LastAddedLoc;
+
+  // Number of expressions (or pattern binding decl) currently nested in, taking
+  // into account hoisting and the possible removal of ifs/switches
   int NestedExprCount = 0;
 
+  // Whether a completion handler body is currently being hoisted out of its
+  // call
+  bool Hoisting = false;
+
 public:
-  AsyncConverter(SourceManager &SM, DiagnosticEngine &DiagEngine,
-                 ASTNode StartNode, const AsyncHandlerParamDesc &TopHandler)
-      : SM(SM), DiagEngine(DiagEngine), StartNode(StartNode),
-        TopHandler(TopHandler), Buffer(), OS(Buffer) {
+  /// Convert a function
+  AsyncConverter(ASTContext &Context, SourceManager &SM,
+                 DiagnosticEngine &DiagEngine, AbstractFunctionDecl *FD,
+                 const AsyncHandlerParamDesc &TopHandler)
+      : Context(Context), SM(SM), DiagEngine(DiagEngine),
+        StartNode(FD), TopHandler(TopHandler), OS(Buffer) {
     Placeholders.insert(TopHandler.getHandler());
+    ScopedDecls.collect(FD);
+
+    // Shouldn't strictly be necessary, but prefer possible shadowing over
+    // crashes caused by a missing scope
+    addNewScope({});
+  }
+
+  /// Convert a call
+  AsyncConverter(ASTContext &Context, SourceManager &SM,
+                 DiagnosticEngine &DiagEngine, CallExpr *CE, BraceStmt *Scope,
+                 SourceFile &SF)
+      : Context(Context), SM(SM), DiagEngine(DiagEngine),
+        StartNode(CE), OS(Buffer) {
+    ScopedDecls.collect(CE);
+
+    // Create the initial scope, can be more accurate than the general
+    // \c ScopedDeclCollector as there is a starting point.
+    llvm::DenseSet<const Decl *> UsedDecls;
+    DeclCollector::collect(Scope, SF, UsedDecls);
+    ReferenceCollector::collect(StartNode, Scope, SF, UsedDecls);
+    addNewScope(UsedDecls);
   }
 
   bool convert() {
@@ -5014,6 +5294,7 @@ private:
     llvm::SaveAndRestore<SourceLoc> RestoreLoc(LastAddedLoc, StartOverride);
     llvm::SaveAndRestore<int> RestoreCount(NestedExprCount,
                                            ConvertCalls ? 0 : 1);
+
     walk(Node);
     addRange(LastAddedLoc, Node.getEndLoc(), /*ToEndOfToken=*/true);
   }
@@ -5023,6 +5304,19 @@ private:
       NestedExprCount++;
       return true;
     }
+
+    // Functions and types already have their names in \c ScopedNames, only
+    // variables should need to be renamed.
+    if (isa<VarDecl>(D) && Names.find(D) == Names.end()) {
+      Identifier Ident = assignUniqueName(D, StringRef());
+      if (!Ident.empty()) {
+        ScopedNames.back().insert(Ident);
+        addCustom(D->getSourceRange(), [&]() {
+          OS << Ident.str();
+        });
+      }
+    }
+
     // Note we don't walk into any nested local function decls. If we start
     // doing so in the future, be sure to update the logic that deals with
     // converting unhandled returns into placeholders in walkToStmtPre.
@@ -5094,34 +5388,54 @@ private:
     });
   }
 
-  bool walkToStmtPre(Stmt *S) override {
-    // Some break and return statements need to be turned into placeholders,
-    // as they may no longer perform the control flow that the user is
-    // expecting.
-    if (!S->isImplicit()) {
-      // For a break, if it's jumping out of a switch statement that we've
-      // re-written as a part of the transform, turn it into a placeholder, as
-      // it would have been lifted out of the switch statement.
-      if (auto *BS = dyn_cast<BreakStmt>(S)) {
-        if (auto *SS = dyn_cast<SwitchStmt>(BS->getTarget())) {
-          if (HandledSwitches.contains(SS))
-            replaceRangeWithPlaceholder(S->getSourceRange());
-        }
-      }
-
-      // For a return, if it's not nested inside another closure or function,
-      // turn it into a placeholder, as it will be lifted out of the callback.
-      if (isa<ReturnStmt>(S) && NestedExprCount == 0)
-        replaceRangeWithPlaceholder(S->getSourceRange());
-    }
+  bool walkToExprPost(Expr *E) override {
+    NestedExprCount--;
     return true;
   }
 
 #undef PLACEHOLDER_START
 #undef PLACEHOLDER_END
 
-  bool walkToExprPost(Expr *E) override {
-    NestedExprCount--;
+  bool walkToStmtPre(Stmt *S) override {
+    // CaseStmt has an implicit BraceStmt inside it, which *should* start a new
+    // scope, so don't check isImplicit here.
+    if (startsNewScope(S)) {
+      // Add all names of decls referenced within this statement that aren't
+      // also declared first, plus any contexts. Note that \c getReferencedDecl
+      // will only return a value for a \c BraceStmt. This means that \c IfStmt
+      // (and other statements with conditions) will have their own empty scope,
+      // which is fine for our purposes - their existing names are always valid.
+      // The body of those statements will include the decls if they've been
+      // referenced, so shadowing is still avoided there.
+      if (auto *ReferencedDecls = ScopedDecls.getReferencedDecls(S)) {
+        addNewScope(*ReferencedDecls);
+      } else {
+        addNewScope({});
+      }
+    } else if (Hoisting && !S->isImplicit()) {
+      // Some break and return statements need to be turned into placeholders,
+      // as they may no longer perform the control flow that the user is
+      // expecting.
+      if (auto *BS = dyn_cast<BreakStmt>(S)) {
+        // For a break, if it's jumping out of a switch statement that we've
+        // re-written as a part of the transform, turn it into a placeholder, as
+        // it would have been lifted out of the switch statement.
+        if (auto *SS = dyn_cast<SwitchStmt>(BS->getTarget())) {
+          if (HandledSwitches.contains(SS))
+            replaceRangeWithPlaceholder(S->getSourceRange());
+        }
+      } else if (isa<ReturnStmt>(S) && NestedExprCount == 0) {
+        // For a return, if it's not nested inside another closure or function,
+        // turn it into a placeholder, as it will be lifted out of the callback.
+        replaceRangeWithPlaceholder(S->getSourceRange());
+      }
+    }
+    return true;
+  }
+
+  bool walkToStmtPost(Stmt *S) override {
+    if (startsNewScope(S))
+      ScopedNames.pop_back();
     return true;
   }
 
@@ -5292,6 +5606,8 @@ private:
 
   void addHoistedCallback(const CallExpr *CE,
                           const AsyncHandlerParamDesc &HandlerDesc) {
+    llvm::SaveAndRestore<bool> RestoreHoisting(Hoisting, true);
+
     auto ArgList = callArgs(CE);
     if ((size_t)HandlerDesc.Index >= ArgList.ref().size()) {
       DiagEngine.diagnose(CE->getStartLoc(), diag::missing_callback_arg);
@@ -5466,6 +5782,8 @@ private:
                                StringRef HandlerName,
                                std::function<void(void)> AddAwaitCall) {
     if (HandlerDesc.HasError) {
+      // "result" and "error" always okay to use here since they're added
+      // in their own scope, which only contains new code.
       addDo();
       if (!HandlerDesc.willAsyncReturnVoid()) {
         OS << tok::kw_let << " result";
@@ -5474,20 +5792,31 @@ private:
       }
       AddAwaitCall();
       OS << "\n";
-      addCallToCompletionHandler(/*HasResult=*/true, HandlerDesc, HandlerName);
+      addCallToCompletionHandler("result", HandlerDesc, HandlerName);
       OS << "\n";
       OS << tok::r_brace << " " << tok::kw_catch << " " << tok::l_brace << "\n";
-      addCallToCompletionHandler(/*HasResult=*/false, HandlerDesc, HandlerName);
+      addCallToCompletionHandler(StringRef(), HandlerDesc, HandlerName);
       OS << "\n" << tok::r_brace; // end catch
     } else {
+      // This code may be placed into an existing scope, in that case create
+      // a unique "result" name so that it doesn't cause shadowing or redecls.
+      StringRef ResultName;
       if (!HandlerDesc.willAsyncReturnVoid()) {
-        OS << tok::kw_let << " result";
+        Identifier Unique = createUniqueName("result");
+        ScopedNames.back().insert(Unique);
+        ResultName = Unique.str();
+
+        OS << tok::kw_let << " " << ResultName;
         addResultTypeAnnotationIfNecessary(FD, HandlerDesc);
         OS << " " << tok::equal << " ";
+      } else {
+        // The name won't end up being used, just give it a bogus one so that
+        // the result path is taken (versus the error path).
+        ResultName = "result";
       }
       AddAwaitCall();
       OS << "\n";
-      addCallToCompletionHandler(/*HasResult=*/true, HandlerDesc, HandlerName);
+      addCallToCompletionHandler(ResultName, HandlerDesc, HandlerName);
     }
   }
 
@@ -5604,28 +5933,71 @@ private:
     }
   }
 
-  // TODO: Check for clashes with existing names and add all decls, not just
-  //       params
+  /// Add a mapping from each passed parameter to a new name, possibly
+  /// synthesizing a new one if hoisting it would cause a redeclaration or
+  /// shadowing. If there's no bound name and \c AddIfMissing is false, no
+  /// name will be added.
   void prepareNames(const ClassifiedBlock &Block,
                     ArrayRef<const ParamDecl *> Params,
                     bool AddIfMissing = true) {
-    for (auto *Param : Params) {
-      StringRef Name = Block.boundName(Param);
-      if (!Name.empty()) {
-        Names[Param] = Name.str();
-        continue;
-      }
-
-      if (!AddIfMissing)
-        continue;
-
-      auto ParamName = Param->getNameStr();
-      if (ParamName.startswith("$")) {
-        Names[Param] = "val" + ParamName.drop_front().str();
-      } else {
-        Names[Param] = ParamName.str();
-      }
+    for (auto *PD : Params) {
+      StringRef Name = Block.boundName(PD);
+      if (!Name.empty() || AddIfMissing)
+        assignUniqueName(PD, Name);
     }
+
+    for (auto &Entry : Block.aliases()) {
+      auto It = Names.find(Entry.second);
+      assert(It != Names.end() && "Param should already have an entry");
+      Names[Entry.first] = It->second;
+    }
+  }
+
+  /// Returns a unique name using \c Name as base that doesn't clash with any
+  /// other names in the current scope.
+  Identifier createUniqueName(StringRef Name) {
+    Identifier Ident = Context.getIdentifier(Name);
+
+    auto &CurrentNames = ScopedNames.back();
+    if (CurrentNames.count(Ident)) {
+      // Add a number to the end of the name until it's unique given the current
+      // names in scope.
+      llvm::SmallString<32> UniquedName;
+      unsigned UniqueId = 1;
+      do {
+        UniquedName = Name;
+        UniquedName.append(std::to_string(UniqueId));
+        Ident = Context.getIdentifier(UniquedName);
+        UniqueId++;
+      } while (CurrentNames.count(Ident));
+    }
+    return Ident;
+  }
+
+  /// Create a unique name for the variable declared by \p D that doesn't
+  /// clash with any other names in scope, using \p BoundName as the base name
+  /// if not empty and the name of \p D otherwise. Adds this name to both
+  /// \c Names and the current scope's names (\c ScopedNames).
+  Identifier assignUniqueName(const Decl *D, StringRef BoundName) {
+    Identifier Ident;
+    if (BoundName.empty()) {
+      BoundName = getDeclName(D).str();
+      if (BoundName.empty())
+        return Ident;
+    }
+
+    if (BoundName.startswith("$")) {
+      llvm::SmallString<8> NewName;
+      NewName.append("val");
+      NewName.append(BoundName.drop_front());
+      Ident = createUniqueName(NewName);
+    } else {
+      Ident = createUniqueName(BoundName);
+    }
+
+    Names.try_emplace(D, Ident);
+    ScopedNames.back().insert(Ident);
+    return Ident;
   }
 
   StringRef newNameFor(const Decl *D, bool Required = true) {
@@ -5634,7 +6006,16 @@ private:
       assert(!Required && "Missing name for decl when one was required");
       return StringRef();
     }
-    return StringRef(Res->second);
+    return Res->second.str();
+  }
+
+  void addNewScope(const llvm::DenseSet<const Decl *> &Decls) {
+    ScopedNames.push_back({});
+    for (auto *D : Decls) {
+      auto Name = getDeclName(D);
+      if (!Name.empty())
+        ScopedNames.back().insert(Name);
+    }
   }
 
   void clearNames(ArrayRef<const ParamDecl *> Params) {
@@ -5700,24 +6081,24 @@ private:
 
   /// Adds the \c Index -th parameter to the completion handler described by \p
   /// HanderDesc.
-  /// If \p HasResult is \c true, it is assumed that a variable named
-  /// 'result' contains the result returned from the async alternative. If the
+  /// If \p ResultName is not empty, it is assumed that a variable with that
+  /// name contains the result returned from the async alternative. If the
   /// callback also takes an error parameter, \c nil passed to the completion
-  /// handler for the error. If \p HasResult is \c false, it is a assumed that a
+  /// handler for the error. If \p ResultName is empty, it is a assumed that a
   /// variable named 'error' contains the error thrown from the async method and
   /// 'nil' will be passed to the completion handler for all result parameters.
-  void addCompletionHandlerArgument(size_t Index, bool HasResult,
+  void addCompletionHandlerArgument(size_t Index, StringRef ResultName,
                                     const AsyncHandlerDesc &HandlerDesc) {
     if (HandlerDesc.HasError && Index == HandlerDesc.params().size() - 1) {
       // The error parameter is the last argument of the completion handler.
-      if (!HasResult) {
+      if (ResultName.empty()) {
         OS << "error";
         addCastToCustomErrorTypeIfNecessary(HandlerDesc);
       } else {
         addDefaultValueOrPlaceholder(HandlerDesc.params()[Index].getPlainType());
       }
     } else {
-      if (!HasResult) {
+      if (ResultName.empty()) {
         addDefaultValueOrPlaceholder(HandlerDesc.params()[Index].getPlainType());
       } else if (HandlerDesc
                      .getSuccessParamAsyncReturnType(
@@ -5740,9 +6121,9 @@ private:
         //     completion(result.0, result.1)
         //   }
         // }
-        OS << "result" << tok::period << Index;
+        OS << ResultName << tok::period << Index;
       } else {
-        OS << "result";
+        OS << ResultName;
       }
     }
   }
@@ -5750,7 +6131,7 @@ private:
   /// Add a call to the completion handler named \p HandlerName and described by
   /// \p HandlerDesc, passing all the required arguments. See \c
   /// getCompletionHandlerArgument for how the arguments are synthesized.
-  void addCallToCompletionHandler(bool HasResult,
+  void addCallToCompletionHandler(StringRef ResultName,
                                   const AsyncHandlerDesc &HandlerDesc,
                                   StringRef HandlerName) {
     OS << HandlerName << tok::l_paren;
@@ -5765,13 +6146,13 @@ private:
         if (I > 0) {
           OS << tok::comma << " ";
         }
-        addCompletionHandlerArgument(I, HasResult, HandlerDesc);
+        addCompletionHandlerArgument(I, ResultName, HandlerDesc);
       }
       break;
     }
     case HandlerType::RESULT: {
-      if (HasResult) {
-        OS << tok::period_prefix << "success" << tok::l_paren << "result"
+      if (!ResultName.empty()) {
+        OS << tok::period_prefix << "success" << tok::l_paren << ResultName
            << tok::r_paren;
       } else {
         OS << tok::period_prefix << "failure" << tok::l_paren << "error";
@@ -5862,8 +6243,18 @@ bool RefactoringActionConvertCallToAsyncAlternative::performChange() {
   assert(CE &&
          "Should not run performChange when refactoring is not applicable");
 
-  AsyncHandlerParamDesc TempDesc;
-  AsyncConverter Converter(SM, DiagEngine, CE, TempDesc);
+  // Find the scope this call is in
+  ContextFinder Finder(*CursorInfo.SF, CursorInfo.Loc,
+                      [](ASTNode N) {
+    return N.isStmt(StmtKind::Brace) && !N.isImplicit();
+  });
+  Finder.resolve();
+  auto Scopes = Finder.getContexts();
+  BraceStmt *Scope = nullptr;
+  if (!Scopes.empty())
+    Scope = cast<BraceStmt>(Scopes.back().get<Stmt *>());
+
+  AsyncConverter Converter(Ctx, SM, DiagEngine, CE, Scope, *CursorInfo.SF);
   if (!Converter.convert())
     return true;
 
@@ -5891,7 +6282,7 @@ bool RefactoringActionConvertToAsync::performChange() {
          "Should not run performChange when refactoring is not applicable");
 
   auto HandlerDesc = AsyncHandlerParamDesc::find(FD, /*ignoreName=*/true);
-  AsyncConverter Converter(SM, DiagEngine, FD, HandlerDesc);
+  AsyncConverter Converter(Ctx, SM, DiagEngine, FD, HandlerDesc);
   if (!Converter.convert())
     return true;
 
@@ -5928,14 +6319,14 @@ bool RefactoringActionAddAsyncAlternative::performChange() {
   assert(HandlerDesc.isValid() &&
          "Should not run performChange when refactoring is not applicable");
 
-  AsyncConverter Converter(SM, DiagEngine, FD, HandlerDesc);
+  AsyncConverter Converter(Ctx, SM, DiagEngine, FD, HandlerDesc);
   if (!Converter.convert())
     return true;
 
   EditConsumer.accept(SM, FD->getAttributeInsertionLoc(false),
                       "@available(*, deprecated, message: \"Prefer async "
                       "alternative instead\")\n");
-  AsyncConverter LegacyBodyCreator(SM, DiagEngine, FD, HandlerDesc);
+  AsyncConverter LegacyBodyCreator(Ctx, SM, DiagEngine, FD, HandlerDesc);
   if (LegacyBodyCreator.createLegacyBody()) {
     LegacyBodyCreator.replace(FD->getBody(), EditConsumer);
   }

--- a/test/refactoring/ConvertAsync/basic.swift
+++ b/test/refactoring/ConvertAsync/basic.swift
@@ -390,7 +390,9 @@ func completionNotLast(completion: (String) -> Void, a: Int) { }
 // NOT-LAST: func completionNotLast(completion: (String) -> Void, a: Int) async { }
 
 // RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+2):1
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NON-VOID %s
 func nonVoid(completion: (String) -> Void) -> Int { return 0 }
+// NON-VOID: func nonVoid(completion: (String) -> Void) async -> Int { return 0 }
 
 // RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+2):1
 // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=COMPLETION-NON-VOID %s
@@ -496,9 +498,8 @@ func simpleClassParam(completion: (MyClass) -> Void) { }
 // before the 'RUN' lines were removed, thus pointing past the end of the
 // rewritten buffer.
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefixes=CONVERT-FUNC,CALL,CALL-NOLABEL,CALL-WRAPPED,TRAILING,TRAILING-PARENS,TRAILING-WRAPPED,CALL-ARG,MANY-CALL,MEMBER-CALL,MEMBER-CALL2,MEMBER-PARENS,EMPTY-CAPTURE,CAPTURE,DEFAULT-ARGS-MISSING,DEFAULT-ARGS-CALL,BLOCK-CONVENTION-CALL,C-CONVENTION-CALL,VOID-AND-ERROR-CALL,VOID-AND-ERROR-CALL2,VOID-AND-ERROR-CALL3,VOID-AND-ERROR-CALL4 %s
-func testCalls() {
-// CONVERT-FUNC: {{^}}func testCalls() async {
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=CALL %s
+func testSimple() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+4):3 | %FileCheck -check-prefix=CALL %s
   // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+3):10
   // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):24
@@ -507,177 +508,247 @@ func testCalls() {
     // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):5
     print("with label")
   })
-  // CALL: let str = await simple(){{$}}
-  // CALL-NEXT: {{^}}print("with label")
+}
+// CALL: let str = await simple(){{$}}
+// CALL-NEXT: {{^}}print("with label")
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=CALL-NOLABEL %s
+func testSimpleWithoutLabel() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=CALL-NOLABEL %s
   simpleWithoutLabel({ str in
     print("without label")
   })
-  // CALL-NOLABEL: let str = await simpleWithoutLabel(){{$}}
-  // CALL-NOLABEL-NEXT: {{^}}print("without label")
+}
+// CALL-NOLABEL: let str = await simpleWithoutLabel(){{$}}
+// CALL-NOLABEL-NEXT: {{^}}print("without label")
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=CALL-WRAPPED %s
+func testWrapped() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=CALL-WRAPPED %s
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):5 | %FileCheck -check-prefix=CALL-WRAPPED %s
   ((simple))(completion: { str in
     print("wrapped call")
   })
-  // CALL-WRAPPED: let str = await ((simple))(){{$}}
-  // CALL-WRAPPED-NEXT: {{^}}print("wrapped call")
+}
+// CALL-WRAPPED: let str = await ((simple))(){{$}}
+// CALL-WRAPPED-NEXT: {{^}}print("wrapped call")
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=TRAILING %s
+func testTrailing() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=TRAILING %s
   // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):12
   simple { str in
     print("trailing")
   }
-  // TRAILING: let str = await simple(){{$}}
-  // TRAILING-NEXT: {{^}}print("trailing")
+}
+// TRAILING: let str = await simple(){{$}}
+// TRAILING-NEXT: {{^}}print("trailing")
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=TRAILING-PARENS %s
+func testTrailingParens() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=TRAILING-PARENS %s
   simple() { str in
     print("trailing with parens")
   }
-  // TRAILING-PARENS: let str = await simple(){{$}}
-  // TRAILING-PARENS-NEXT: {{^}}print("trailing with parens")
+}
+// TRAILING-PARENS: let str = await simple(){{$}}
+// TRAILING-PARENS-NEXT: {{^}}print("trailing with parens")
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefixes=TRAILING-WRAPPED %s
+func testTrailingWrapped() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):5 | %FileCheck -check-prefix=TRAILING-WRAPPED %s
   ((simple)) { str in
     print("trailing with wrapped call")
   }
-  // TRAILING-WRAPPED: let str = await ((simple))(){{$}}
-  // TRAILING-WRAPPED-NEXT: {{^}}print("trailing with wrapped call")
+}
+// TRAILING-WRAPPED: let str = await ((simple))(){{$}}
+// TRAILING-WRAPPED-NEXT: {{^}}print("trailing with wrapped call")
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=CALL-ARG %s
+func testCallArg() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+3):3 | %FileCheck -check-prefix=CALL-ARG %s
   // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):17
   // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):20
   simpleWithArg(a: 10) { str in
     print("with arg")
   }
-  // CALL-ARG: let str = await simpleWithArg(a: 10){{$}}
-  // CALL-ARG-NEXT: {{^}}print("with arg")
+}
+// CALL-ARG: let str = await simpleWithArg(a: 10){{$}}
+// CALL-ARG-NEXT: {{^}}print("with arg")
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefixes=MANY-CALL %s
+func testMany() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MANY-CALL %s
   many { str, num in
     print("many")
   }
-  // MANY-CALL: let (str, num) = await many(){{$}}
-  // MANY-CALL-NEXT: {{^}}print("many")
+}
+// MANY-CALL: let (str, num) = await many(){{$}}
+// MANY-CALL-NEXT: {{^}}print("many")
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MEMBER-CALL %s
+func testMember() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):15 | %FileCheck -check-prefix=MEMBER-CALL %s
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MEMBER-CALL %s
   retStruct().publicMember { str in
     print("call on member")
   }
-  // MEMBER-CALL: let str = await retStruct().publicMember(){{$}}
-  // MEMBER-CALL-NEXT: {{^}}print("call on member")
+}
+// MEMBER-CALL: let str = await retStruct().publicMember(){{$}}
+// MEMBER-CALL-NEXT: {{^}}print("call on member")
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MEMBER-CALL2 %s
+func testMember2() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):25 | %FileCheck -check-prefix=MEMBER-CALL2 %s
   retStruct().retSelf().publicMember { str in
     print("call on member 2")
   }
-  // MEMBER-CALL2: let str = await retStruct().retSelf().publicMember(){{$}}
-  // MEMBER-CALL2-NEXT: {{^}}print("call on member 2")
+}
+// MEMBER-CALL2: let str = await retStruct().retSelf().publicMember(){{$}}
+// MEMBER-CALL2-NEXT: {{^}}print("call on member 2")
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MEMBER-PARENS %s
+func testMemberParens() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+3):3 | %FileCheck -check-prefix=MEMBER-PARENS %s
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):5 | %FileCheck -check-prefix=MEMBER-PARENS %s
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):15 | %FileCheck -check-prefix=MEMBER-PARENS %s
   (((retStruct().retSelf()).publicMember)) { str in
     print("call on member parens")
   }
-  // MEMBER-PARENS: let str = await (((retStruct().retSelf()).publicMember))(){{$}}
-  // MEMBER-PARENS-NEXT: {{^}}print("call on member parens")
+}
+// MEMBER-PARENS: let str = await (((retStruct().retSelf()).publicMember))(){{$}}
+// MEMBER-PARENS-NEXT: {{^}}print("call on member parens")
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefixes=SKIP-ASSIGN-FUNC %s
+func testSkipAssign() {
   // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):13
   let _: Void = simple { str in
     print("assigned")
   }
-  // CONVERT-FUNC: let _: Void = simple { str in{{$}}
-  // CONVERT-FUNC-NEXT: print("assigned"){{$}}
-  // CONVERT-FUNC-NEXT: }{{$}}
+}
+// SKIP-ASSIGN-FUNC: {{^}}func testSkipAssign() async {
+// SKIP-ASSIGN-FUNC: let _: Void = simple { str in{{$}}
+// SKIP-ASSIGN-FUNC-NEXT: print("assigned"){{$}}
+// SKIP-ASSIGN-FUNC-NEXT: }{{$}}
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefixes=SKIP-AUTOCLOSURE-FUNC %s
+func testSkipAutoclosure() {
   // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3
   noParamAutoclosure(completion: print("autoclosure"))
-  // CONVERT-FUNC: noParamAutoclosure(completion: print("autoclosure")){{$}}
+}
+// SKIP-AUTOCLOSURE-FUNC: {{^}}func testSkipAutoclosure() async {
+// SKIP-AUTOCLOSURE-FUNC: noParamAutoclosure(completion: print("autoclosure")){{$}}
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=EMPTY-CAPTURE %s
+func testEmptyCapture() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=EMPTY-CAPTURE %s
   simple { [] str in
     print("closure with empty capture list")
   }
-  // EMPTY-CAPTURE: let str = await simple(){{$}}
-  // EMPTY-CAPTURE-NEXT: {{^}}print("closure with empty capture list")
+}
+// EMPTY-CAPTURE: let str = await simple(){{$}}
+// EMPTY-CAPTURE-NEXT: {{^}}print("closure with empty capture list")
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=CAPTURE %s
+func testCapture() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=CAPTURE %s
   let myClass = MyClass()
   simpleClassParam { [unowned myClass] str in
     print("closure with capture list \(myClass)")
   }
-  // CAPTURE: let str = await simpleClassParam(){{$}}
-  // CAPTURE-NEXT: {{^}}print("closure with capture list \(myClass)")
+}
+// CAPTURE: let str = await simpleClassParam(){{$}}
+// CAPTURE-NEXT: {{^}}print("closure with capture list \(myClass)")
 
-  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=OTHER-DIRECT %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefixes=NOT-HANDLER-FUNC %s
+func testNotCompletionHandler() {
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=NOT-HANDLER %s
   otherName(execute: { str in
     print("otherName")
   })
-  // OTHER-DIRECT: let str = await otherName(){{$}}
-  // OTHER-DIRECT-NEXT: {{^}}print("otherName")
-  // CONVERT-FUNC: otherName(execute: { str in{{$}}
-  // CONVERT-FUNC-NEXT: print("otherName"){{$}}
-  // CONVERT-FUNC-NEXT: }){{$}}
+}
+// NOT-HANDLER-FUNC: otherName(execute: { str in{{$}}
+// NOT-HANDLER-FUNC-NEXT: print("otherName"){{$}}
+// NOT-HANDLER-FUNC-NEXT: }){{$}}
+// NOT-HANDLER: let str = await otherName(){{$}}
+// NOT-HANDLER-NEXT: {{^}}print("otherName")
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=DEFAULT-ARGS-MISSING %s
+func testDefaultArgsMissing() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=DEFAULT-ARGS-MISSING %s
   defaultArgs(a: 1) { str in
     print("defaultArgs missing")
   }
-  // DEFAULT-ARGS-MISSING: let str = await defaultArgs(a: 1){{$}}
-  // DEFAULT-ARGS-MISSING-NEXT: {{^}}print("defaultArgs missing")
+}
+// DEFAULT-ARGS-MISSING: let str = await defaultArgs(a: 1){{$}}
+// DEFAULT-ARGS-MISSING-NEXT: {{^}}print("defaultArgs missing")
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=DEFAULT-ARGS-CALL %s
+func testDefaultArgs() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=DEFAULT-ARGS-CALL %s
   defaultArgs(a: 1, b: 2) { str in
     print("defaultArgs")
   }
-  // DEFAULT-ARGS-CALL: let str = await defaultArgs(a: 1, b: 2){{$}}
-  // DEFAULT-ARGS-CALL-NEXT: {{^}}print("defaultArgs")
+}
+// DEFAULT-ARGS-CALL: let str = await defaultArgs(a: 1, b: 2){{$}}
+// DEFAULT-ARGS-CALL-NEXT: {{^}}print("defaultArgs")
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=BLOCK-CONVENTION-CALL %s
+func testBlockConvention() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=BLOCK-CONVENTION-CALL %s
   blockConvention {
     print("blockConvention")
   }
-  // BLOCK-CONVENTION-CALL: await blockConvention(){{$}}
-  // BLOCK-CONVENTION-CALL-NEXT: {{^}}print("blockConvention")
+}
+// BLOCK-CONVENTION-CALL: await blockConvention(){{$}}
+// BLOCK-CONVENTION-CALL-NEXT: {{^}}print("blockConvention")
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=C-CONVENTION-CALL %s
+func testCConvention() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=C-CONVENTION-CALL %s
   cConvention {
     print("cConvention")
   }
-  // C-CONVENTION-CALL: await cConvention(){{$}}
-  // C-CONVENTION-CALL-NEXT: {{^}}print("cConvention")
+}
+// C-CONVENTION-CALL: await cConvention(){{$}}
+// C-CONVENTION-CALL-NEXT: {{^}}print("cConvention")
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=VOID-AND-ERROR-CALL %s
+func testVoidAndError() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=VOID-AND-ERROR-CALL %s
   optVoidAndErrorCompletion { v, err in
     print("opt void and error completion \(v)")
   }
-  // VOID-AND-ERROR-CALL: try await optVoidAndErrorCompletion(){{$}}
-  // VOID-AND-ERROR-CALL-NEXT: {{^}}print("opt void and error completion \(<#v#>)"){{$}}
+}
+// VOID-AND-ERROR-CALL: try await optVoidAndErrorCompletion(){{$}}
+// VOID-AND-ERROR-CALL-NEXT: {{^}}print("opt void and error completion \(<#v#>)"){{$}}
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=VOID-AND-ERROR-CALL2 %s
+func testVoidAndError2() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=VOID-AND-ERROR-CALL2 %s
   optVoidAndErrorCompletion { _, err in
     print("opt void and error completion 2")
   }
-  // VOID-AND-ERROR-CALL2: try await optVoidAndErrorCompletion(){{$}}
-  // VOID-AND-ERROR-CALL2-NEXT: {{^}}print("opt void and error completion 2"){{$}}
+}
+// VOID-AND-ERROR-CALL2: try await optVoidAndErrorCompletion(){{$}}
+// VOID-AND-ERROR-CALL2-NEXT: {{^}}print("opt void and error completion 2"){{$}}
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=VOID-AND-ERROR-CALL3 %s
+func testVoidAndError3() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=VOID-AND-ERROR-CALL3 %s
   tooMuchVoidAndErrorCompletion { v, v1, err in
     print("void and error completion 3")
   }
-  // VOID-AND-ERROR-CALL3: try await tooMuchVoidAndErrorCompletion(){{$}}
-  // VOID-AND-ERROR-CALL3-NEXT: {{^}}print("void and error completion 3"){{$}}
+}
+// VOID-AND-ERROR-CALL3: try await tooMuchVoidAndErrorCompletion(){{$}}
+// VOID-AND-ERROR-CALL3-NEXT: {{^}}print("void and error completion 3"){{$}}
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=VOID-AND-ERROR-CALL4 %s
+func testVoidAndError4() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=VOID-AND-ERROR-CALL4 %s
   voidAndErrorCompletion { v, err in
     print("void and error completion \(v)")
   }
-  // VOID-AND-ERROR-CALL4: try await voidAndErrorCompletion(){{$}}
-  // VOID-AND-ERROR-CALL4-NEXT: {{^}}print("void and error completion \(<#v#>)"){{$}}
 }
-// CONVERT-FUNC: {{^}}}
+// VOID-AND-ERROR-CALL4: try await voidAndErrorCompletion(){{$}}
+// VOID-AND-ERROR-CALL4-NEXT: {{^}}print("void and error completion \(<#v#>)"){{$}}

--- a/test/refactoring/ConvertAsync/convert_async_renames.swift
+++ b/test/refactoring/ConvertAsync/convert_async_renames.swift
@@ -1,0 +1,603 @@
+// RUN: %empty-directory(%t)
+
+func simple(_ completion: (String) -> Void) { }
+func simple() async -> String { }
+
+func simpleArg(arg: String, _ completion: (String) -> Void) { }
+func simpleArg(arg: String) async -> String { }
+
+func simpleErr(arg: String, _ completion: (String?, Error?) -> Void) { }
+func simpleErr(arg: String) async throws -> String { }
+
+func whatever() -> Bool { return true }
+
+// Ideally we wouldn't rename anything here since it's correct as is, but the
+// collector picks up the param `str` use in the if condition.
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):6 | %FileCheck -check-prefix=LOCALREDECL %s
+func localRedecl(str: String?) {
+  if let str = str {
+    print(str)
+  }
+  let str = "str"
+  print(str)
+}
+// LOCALREDECL: func localRedecl(str: String?) async {
+// LOCALREDECL-NEXT: if let str = str {
+// LOCALREDECL-NEXT:   print(str)
+// LOCALREDECL-NEXT: }
+// LOCALREDECL-NEXT: let str1 = "str"
+// LOCALREDECL-NEXT: print(str1)
+
+// Again, ideally wouldn't rename as the use of `str` is above the hoisted call.
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefixes=SHADOWUNUSEDPARAM %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+3):3 | %FileCheck -check-prefix=HOISTED-SIMPLE-CALL %s
+func shadowUnusedParam(str: String) {
+  print(str)
+  simple { str in
+    print(str)
+  }
+}
+// SHADOWUNUSEDPARAM: func shadowUnusedParam(str: String) async {
+// SHADOWUNUSEDPARAM-NEXT: print(str)
+// SHADOWUNUSEDPARAM-NEXT: let str1 = await simple()
+// SHADOWUNUSEDPARAM-NEXT: print(str1)
+
+// HOISTED-SIMPLE-CALL: let str = await simple()
+// HOISTED-SIMPLE-CALL-NEXT: print(str)
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=SHADOWUSEDPARAM %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+3):3 | %FileCheck -check-prefix=RENAMED-SIMPLE-CALL %s
+func shadowUsedParam(str: String) {
+  print(str)
+  simple { str in
+    print(str)
+  }
+  print(str)
+}
+// SHADOWUSEDPARAM: func shadowUsedParam(str: String) async {
+// SHADOWUSEDPARAM-NEXT: print(str)
+// SHADOWUSEDPARAM-NEXT: let str1 = await simple()
+// SHADOWUSEDPARAM-NEXT: print(str1)
+// SHADOWUSEDPARAM-NEXT: print(str)
+
+// RENAMED-SIMPLE-CALL: let str1 = await simple()
+// RENAMED-SIMPLE-CALL-NEXT: print(str1)
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=NESTEDBEFORE %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+5):5 | %FileCheck -check-prefix=HOISTED-SIMPLE-CALL %s
+func nestedBefore() {
+  let str = "str"
+  print(str)
+  if whatever() {
+    simple { str in
+      print(str)
+    }
+  }
+}
+// NESTEDBEFORE: func nestedBefore() async {
+// NESTEDBEFORE-NEXT: let str = "str"
+// NESTEDBEFORE-NEXT: print(str)
+// NESTEDBEFORE-NEXT: if whatever() {
+// NESTEDBEFORE-NEXT: let str = await simple()
+// NESTEDBEFORE-NEXT: print(str)
+// NESTEDBEFORE-NEXT: }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=NESTEDAFTER %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+3):5 | %FileCheck -check-prefix=HOISTED-SIMPLE-CALL %s
+func nestedAfter() {
+  if whatever() {
+    simple { str in
+      print(str)
+    }
+  }
+  let str = "str"
+  print(str)
+}
+// NESTEDAFTER: func nestedAfter() async {
+// NESTEDAFTER-NEXT: if whatever() {
+// NESTEDAFTER-NEXT: let str = await simple()
+// NESTEDAFTER-NEXT: print(str)
+// NESTEDAFTER-NEXT: }
+// NESTEDAFTER-NEXT: let str = "str"
+// NESTEDAFTER-NEXT: print(str)
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=NESTED-DECL-BEFORE %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+4):5 | %FileCheck -check-prefix=RENAMED-SIMPLE-CALL %s
+func nestedDeclBefore() {
+  if whatever() {
+    let str = "str"
+    simple { str in
+      print(str)
+    }
+  }
+}
+// NESTED-DECL-BEFORE: func nestedDeclBefore() async {
+// NESTED-DECL-BEFORE-NEXT: if whatever() {
+// NESTED-DECL-BEFORE-NEXT: let str = "str"
+// NESTED-DECL-BEFORE-NEXT: let str1 = await simple()
+// NESTED-DECL-BEFORE-NEXT: print(str1)
+// NESTED-DECL-BEFORE-NEXT: }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=NESTED-DECL-AFTER %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+3):5 | %FileCheck -check-prefix=RENAMED-SIMPLE-CALL %s
+func nestedDeclAfter() {
+  if whatever() {
+    simple { str in
+      print(str)
+    }
+    let str = "str"
+  }
+}
+// NESTED-DECL-AFTER: func nestedDeclAfter() async {
+// NESTED-DECL-AFTER-NEXT: if whatever() {
+// NESTED-DECL-AFTER-NEXT: let str = await simple()
+// NESTED-DECL-AFTER-NEXT: print(str)
+// NESTED-DECL-AFTER-NEXT: let str1 = "str"
+// NESTED-DECL-AFTER-NEXT: }
+
+// Ideally wouldn't rename, but is for the same reason as before
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=NESTED-USE-BEFORE %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+5):5 | %FileCheck -check-prefix=HOISTED-SIMPLE-CALL %s
+func nestedUseBefore() {
+  let str = "str"
+  if whatever() {
+    print(str)
+    simple { str in
+      print(str)
+    }
+  }
+}
+// NESTED-USE-BEFORE: func nestedUseBefore() async {
+// NESTED-USE-BEFORE-NEXT: let str = "str"
+// NESTED-USE-BEFORE-NEXT: if whatever() {
+// NESTED-USE-BEFORE-NEXT: print(str)
+// NESTED-USE-BEFORE-NEXT: let str1 = await simple()
+// NESTED-USE-BEFORE-NEXT: print(str1)
+// NESTED-USE-BEFORE-NEXT: }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=NESTED-USE-AFTER %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+4):5 | %FileCheck -check-prefix=RENAMED-SIMPLE-CALL %s
+func nestedUseAfter() {
+  let str = "str"
+  if whatever() {
+    simple { str in
+      print(str)
+    }
+    print(str)
+  }
+}
+// NESTED-USE-AFTER: func nestedUseAfter() async {
+// NESTED-USE-AFTER-NEXT: let str = "str"
+// NESTED-USE-AFTER-NEXT: if whatever() {
+// NESTED-USE-AFTER-NEXT: let str1 = await simple()
+// NESTED-USE-AFTER-NEXT: print(str1)
+// NESTED-USE-AFTER-NEXT: print(str)
+// NESTED-USE-AFTER-NEXT: }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=REDECLBEFORE %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+4):3 | %FileCheck -check-prefix=RENAMED-SIMPLE-CALL %s
+func redeclBefore() {
+  let str = "do not redecl"
+  print(str)
+  simple { str in
+    print(str)
+  }
+}
+// REDECLBEFORE: func redeclBefore() async {
+// REDECLBEFORE-NEXT: let str = "do not redecl"
+// REDECLBEFORE-NEXT: print(str)
+// REDECLBEFORE-NEXT: let str1 = await simple()
+// REDECLBEFORE-NEXT: print(str1)
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=GUARDREDECLBEFORE %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+6):3 | %FileCheck -check-prefix=RENAMED-SIMPLE-CALL %s
+func guardRedeclBefore(arg: String?) {
+  guard let str = arg else {
+    return
+  }
+  print(str)
+  simple { str in
+    print(str)
+  }
+}
+// GUARDREDECLBEFORE: func guardRedeclBefore(arg: String?) async {
+// GUARDREDECLBEFORE-NEXT: guard let str = arg else {
+// GUARDREDECLBEFORE-NEXT: return
+// GUARDREDECLBEFORE-NEXT: }
+// GUARDREDECLBEFORE-NEXT: print(str)
+// GUARDREDECLBEFORE-NEXT: let str1 = await simple()
+// GUARDREDECLBEFORE-NEXT: print(str1)
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=IFDECLBEFORE %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+5):3 | %FileCheck -check-prefix=HOISTED-SIMPLE-CALL %s
+func ifDeclBefore(arg: String?) {
+  if let str = arg {
+    print(str)
+  }
+  simple { str in
+    print(str)
+  }
+}
+// IFDECLBEFORE: func ifDeclBefore(arg: String?) async {
+// IFDECLBEFORE-NEXT: if let str = arg {
+// IFDECLBEFORE-NEXT: print(str)
+// IFDECLBEFORE-NEXT: }
+// IFDECLBEFORE-NEXT: let str = await simple()
+// IFDECLBEFORE-NEXT: print(str)
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=REDECLAFTER %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=RENAMED-SIMPLE-CALL %s
+func redeclAfter() {
+  simple { str in
+    print(str)
+  }
+  let str = "do not redecl"
+  print(str)
+}
+// REDECLAFTER: func redeclAfter() async {
+// REDECLAFTER-NEXT: let str = await simple()
+// REDECLAFTER-NEXT: print(str)
+// REDECLAFTER-NEXT: let str1 = "do not redecl"
+// REDECLAFTER-NEXT: print(str1)
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=GUARDREDECLAFTER %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=RENAMED-SIMPLE-CALL %s
+func guardRedeclAfter(arg: String?) {
+  simple { str in
+    print(str)
+  }
+  guard let str = arg else {
+    return
+  }
+  print(str)
+}
+// GUARDREDECLAFTER: func guardRedeclAfter(arg: String?) async {
+// GUARDREDECLAFTER-NEXT: let str = await simple()
+// GUARDREDECLAFTER-NEXT: print(str)
+// GUARDREDECLAFTER-NEXT: guard let str1 = arg else {
+// GUARDREDECLAFTER-NEXT: return
+// GUARDREDECLAFTER-NEXT: }
+// GUARDREDECLAFTER-NEXT: print(str1)
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=IFDECLAFTER %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=HOISTED-SIMPLE-CALL %s
+func ifDeclAfter(arg: String?) {
+  simple { str in
+    print(str)
+  }
+  if let str = arg {
+    print(str)
+  }
+}
+// IFDECLAFTER: func ifDeclAfter(arg: String?) async {
+// IFDECLAFTER-NEXT: let str = await simple()
+// IFDECLAFTER-NEXT: print(str)
+// IFDECLAFTER-NEXT: if let str = arg {
+// IFDECLAFTER-NEXT: print(str)
+// IFDECLAFTER-NEXT: }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=REDECLINNER %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=REDECLINNER %s
+func redeclInner() {
+  simple { str in
+    simpleArg(arg: str) { other in
+      let str = other
+      print(str)
+    }
+  }
+}
+// REDECLINNER: let str = await simple()
+// REDECLINNER-NEXT: let other = await simpleArg(arg: str)
+// REDECLINNER-NEXT: let str1 = other
+// REDECLINNER-NEXT: print(str1)
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=DECLINNER %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=DECLINNER %s
+func declInner() {
+  simple { str in
+    simpleArg(arg: str) { other in
+      if other == "anything" {
+        let str = other
+        print(str)
+      }
+    }
+  }
+}
+// DECLINNER: let str = await simple()
+// DECLINNER-NEXT: let other = await simpleArg(arg: str)
+// DECLINNER-NEXT: if other == "anything" {
+// DECLINNER-NEXT: let str = other
+// DECLINNER-NEXT: print(str)
+// DECLINNER-NEXT: }
+
+// TODO: `throws` isn't added to the function declaration
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=REDECLHOISTED %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=REDECLHOISTED %s
+func redeclInnerHoisted() {
+  simple { str in
+    simpleErr(arg: str) { other, err in
+      if let other = other {
+        let str = other
+        print(str)
+      }
+    }
+  }
+}
+// REDECLHOISTED: let str = await simple()
+// REDECLHOISTED-NEXT: let other = try await simpleErr(arg: str)
+// REDECLHOISTED-NEXT: let str1 = other
+// REDECLHOISTED-NEXT: print(str1)
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=SHADOWINNER %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SHADOWINNER %s
+func shadowInner() {
+  simple { str in
+    simpleArg(arg: str) { str in
+      print(str)
+    }
+  }
+}
+// SHADOWINNER: let str = await simple()
+// SHADOWINNER-NEXT: let str1 = await simpleArg(arg: str)
+// SHADOWINNER-NEXT: print(str1)
+
+// TODO: `throws` isn't added to the function declaration
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=SHADOWINNERBIND %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SHADOWINNERBIND %s
+func shadowInnerBind() {
+  simple { str in
+    simpleErr(arg: str) { other, err in
+      if let str = other {
+        print(str)
+      }
+    }
+  }
+}
+// SHADOWINNERBIND: let str = await simple()
+// SHADOWINNERBIND-NEXT: let str1 = try await simpleErr(arg: str)
+// SHADOWINNERBIND-NEXT: print(str1)
+
+// TODO: `throws` isn't added to the function declaration
+// RUN: %refactor  -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=SHADOWNAMEEXISTS %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SHADOWNAMEEXISTS %s
+func shadowNameAlreadyExists() {
+  simple { str in
+    simpleErr(arg: str) { str, err in
+      let str1 = "str1"
+      print(str1)
+      if let str1 = str {
+        print(str1)
+      }
+      if let str2 = str {
+        print(str2)
+      }
+    }
+  }
+}
+// SHADOWNAMEEXISTS: let str = await simple()
+// SHADOWNAMEEXISTS-NEXT: let str1 = try await simpleErr(arg: str)
+// SHADOWNAMEEXISTS-NEXT: let str11 = "str1"
+// SHADOWNAMEEXISTS-NEXT: print(str11)
+// SHADOWNAMEEXISTS-NEXT: print(str1)
+// SHADOWNAMEEXISTS-NEXT: print(str1)
+
+func shadowsUsedDecl() {
+  let inOuter: String = "str"
+  print(inOuter)
+  // TODO: `throws` isn't added to the function declaration
+  // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):8 | %FileCheck -check-prefix=SHADOWOUTERUSED %s
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):10 | %FileCheck -check-prefix=SHADOWOUTERUSED %s
+  func inner() {
+    simpleErr(arg: "str") { inCall, err in
+      if inCall != nil {
+        let inOuter = inCall!
+        print(inOuter)
+      }
+      print(inOuter)
+    }
+  }
+}
+// SHADOWOUTERUSED: let inCall = try await simpleErr(arg: "str")
+// SHADOWOUTERUSED-NEXT: let inOuter1 = inCall
+// SHADOWOUTERUSED-NEXT: print(inOuter1)
+// SHADOWOUTERUSED-NEXT: print(inOuter)
+
+func shadowsUnusedDecl() {
+  let inOuter: String = "str"
+  print(inOuter)
+  // TODO: `throws` isn't added to the function declaration
+  // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):8 | %FileCheck -check-prefix=SHADOWOUTERUNUSED %s
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):10 | %FileCheck -check-prefix=SHADOWOUTERUNUSED %s
+  func inner() {
+    simpleErr(arg: "str") { inCall, err in
+      if inCall != nil {
+        let inOuter = inCall!
+        print(inOuter)
+      }
+    }
+  }
+}
+// SHADOWOUTERUNUSED: let inCall = try await simpleErr(arg: "str")
+// SHADOWOUTERUNUSED-NEXT: let inOuter = inCall
+// SHADOWOUTERUNUSED-NEXT: print(inOuter)
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=IGNORE-SCOPED-BEFORE %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+16):3 | %FileCheck -check-prefix=HOISTED-SIMPLE-CALL %s
+func ignoreScopedBefore(arg: String?, args: [String]) {
+  if let str = arg {
+    print(str)
+  }
+  for str in args {
+    print(str)
+  }
+  var check = arg
+  while let str = check {
+    check = str
+  }
+  do {
+    let str = arg!
+    print(str)
+  }
+  simple { str in
+    print(str)
+  }
+}
+// IGNORE-SCOPED-BEFORE: if let str = arg {
+// IGNORE-SCOPED-BEFORE-NEXT: print(str)
+// IGNORE-SCOPED-BEFORE-NEXT: }
+// IGNORE-SCOPED-BEFORE-NEXT: for str in args {
+// IGNORE-SCOPED-BEFORE-NEXT: print(str)
+// IGNORE-SCOPED-BEFORE-NEXT: }
+// IGNORE-SCOPED-BEFORE-NEXT: var check = arg
+// IGNORE-SCOPED-BEFORE-NEXT: while let str = check {
+// IGNORE-SCOPED-BEFORE-NEXT:   check = str
+// IGNORE-SCOPED-BEFORE-NEXT: }
+// IGNORE-SCOPED-BEFORE-NEXT: do {
+// IGNORE-SCOPED-BEFORE-NEXT: let str = arg!
+// IGNORE-SCOPED-BEFORE-NEXT: print(str)
+// IGNORE-SCOPED-BEFORE-NEXT: }
+// IGNORE-SCOPED-BEFORE-NEXT: let str = await simple()
+// IGNORE-SCOPED-BEFORE-NEXT: print(str)
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=IGNORE-SCOPED-AFTER %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=HOISTED-SIMPLE-CALL %s
+func ignoreScopedAfter(arg: String?, args: [String]) {
+  simple { str in
+    print(str)
+  }
+  if let str = arg {
+    print(str)
+  }
+  for str in args {
+    print(str)
+  }
+  var check = arg
+  while let str = check {
+    check = str
+  }
+  do {
+    let str = arg!
+    print(str)
+  }
+}
+// IGNORE-SCOPED-AFTER: let str = await simple()
+// IGNORE-SCOPED-AFTER-NEXT: print(str)
+// IGNORE-SCOPED-AFTER-NEXT: if let str = arg {
+// IGNORE-SCOPED-AFTER-NEXT: print(str)
+// IGNORE-SCOPED-AFTER-NEXT: }
+// IGNORE-SCOPED-AFTER-NEXT: for str in args {
+// IGNORE-SCOPED-AFTER-NEXT: print(str)
+// IGNORE-SCOPED-AFTER-NEXT: }
+// IGNORE-SCOPED-AFTER-NEXT: var check = arg
+// IGNORE-SCOPED-AFTER-NEXT: while let str = check {
+// IGNORE-SCOPED-AFTER-NEXT:   check = str
+// IGNORE-SCOPED-AFTER-NEXT: }
+// IGNORE-SCOPED-AFTER-NEXT: do {
+// IGNORE-SCOPED-AFTER-NEXT: let str = arg!
+// IGNORE-SCOPED-AFTER-NEXT: print(str)
+// IGNORE-SCOPED-AFTER-NEXT: }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefixes=TYPE-BEFORE,TYPE-BEFORE-CALL %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+3):3 | %FileCheck -check-prefix=TYPE-BEFORE-CALL %s
+func typeBefore() {
+  struct Foo {}
+  simple { Foo in
+    print(Foo)
+  }
+}
+// TYPE-BEFORE: struct Foo {}
+// TYPE-BEFORE-CALL: let Foo1 = await simple()
+// TYPE-BEFORE-CALL-NEXT: print(Foo1)
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefixes=FUNC-BEFORE,FUNC-BEFORE-CALL %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+3):3 | %FileCheck -check-prefix=FUNC-BEFORE-CALL %s
+func funcBefore() {
+  func foo() {}
+  simple { foo in
+    print(foo)
+  }
+}
+// FUNC-BEFORE: func foo() {}
+// FUNC-BEFORE-CALL: let foo1 = await simple()
+// FUNC-BEFORE-CALL-NEXT: print(foo1)
+
+enum SomeEnum {
+  case foo(String)
+  case bar(String)
+  case baz(String)
+}
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):6 | %FileCheck -check-prefix=CASE-SCOPES %s
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+15):5 | %FileCheck -check-prefix=HOISTED-SIMPLE-CALL %s
+func caseScopes() {
+  switch SomeEnum.foo("a") {
+  case .foo(let arg):
+    simple { str in
+      print(str)
+    }
+  case .bar(let str):
+    simple { str in
+      print(str)
+    }
+  case .baz(let arg):
+    simple { str in
+      print(str)
+    }
+    simple { str in
+      print(str)
+    }
+  }
+}
+// CASE-SCOPES: func caseScopes() async {
+// CASE-SCOPES-NEXT: switch SomeEnum.foo("a") {
+// CASE-SCOPES-NEXT: case .foo(let arg):
+// CASE-SCOPES-NEXT: let str = await simple()
+// CASE-SCOPES-NEXT: print(str)
+// CASE-SCOPES-NEXT: case .bar(let str):
+// CASE-SCOPES-NEXT: let str = await simple()
+// CASE-SCOPES-NEXT: print(str)
+// CASE-SCOPES-NEXT: case .baz(let arg):
+// CASE-SCOPES-NEXT: let str = await simple()
+// CASE-SCOPES-NEXT: print(str)
+// CASE-SCOPES-NEXT: let str1 = await simple()
+// CASE-SCOPES-NEXT: print(str1)
+// CASE-SCOPES-NEXT: }
+// CASE-SCOPES-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=TOP-LEVEL-VAR %s
+let inFile = "inFile"
+simple { inFile in
+  print(inFile)
+}
+// TOP-LEVEL-VAR: let inFile1 = await simple()
+// TOP-LEVEL-VAR-NEXT: print(inFile1)
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=TOP-LEVEL-FUNC %s
+func fileFunc() {}
+simple { fileFunc in
+  print(fileFunc)
+}
+// TOP-LEVEL-FUNC: let fileFunc1 = await simple()
+// TOP-LEVEL-FUNC-NEXT: print(fileFunc1)
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=TOP-LEVEL-PROTO %s
+protocol FileProto {}
+simple { FileProto in
+  print(FileProto)
+}
+// TOP-LEVEL-PROTO: let FileProto1 = await simple()
+// TOP-LEVEL-PROTO-NEXT: print(FileProto1)
+
+// The following results in two TopLevelCodeDecls each with their own BraceStmt,
+// we want to make sure that we still find the `someGlobal` reference and thus
+// rename the `someGlobal` closure arg.
+let someGlobal = "someGlobal"
+func between1() {}
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=TOP-LEVEL-REFERENCE %s
+simple { someGlobal in
+  print(someGlobal)
+}
+func between2() {}
+print(someGlobal)
+// TOP-LEVEL-REFERENCE: let someGlobal1 = await simple()
+// TOP-LEVEL-REFERENCE-NEXT: print(someGlobal1)

--- a/test/refactoring/ConvertAsync/convert_params_single.swift
+++ b/test/refactoring/ConvertAsync/convert_params_single.swift
@@ -327,21 +327,10 @@ withError { res, err in
   }
   print("after")
 }
-// MULTIBIND: var res: String? = nil
-// MULTIBIND-NEXT: var err: Error? = nil
-// MULTIBIND-NEXT: do {
-// MULTIBIND-NEXT: res = try await withError()
-// MULTIBIND-NEXT: } catch {
-// MULTIBIND-NEXT: err = error
-// MULTIBIND-NEXT: }
-// MULTIBIND-EMPTY:
+// MULTIBIND: let str = try await withError()
 // MULTIBIND-NEXT: print("before")
-// MULTIBIND-NEXT: if let str = res {
 // MULTIBIND-NEXT: print("got result \(str)")
-// MULTIBIND-NEXT: }
-// MULTIBIND-NEXT: if let str2 = res {
-// MULTIBIND-NEXT: print("got result \(str2)")
-// MULTIBIND-NEXT: }
+// MULTIBIND-NEXT: print("got result \(str)")
 // MULTIBIND-NEXT: print("after")
 
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=NESTEDRET %s

--- a/test/refactoring/ConvertAsync/convert_result.swift
+++ b/test/refactoring/ConvertAsync/convert_result.swift
@@ -178,7 +178,7 @@ simple { res in
 // UNKNOWNUNBOUND-NEXT: print("after")
 // UNKNOWN-NOT: }
 
-// RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MULTIPLE-BINDS %s
 simple { res in
   print("before")
   if case .success(let str) = res {
@@ -189,6 +189,13 @@ simple { res in
   }
   print("after")
 }
+// MULTIPLE-BINDS: convert_result.swift
+// MULTIPLE-BINDS-NEXT: let str = try await simple()
+// MULTIPLE-BINDS-NEXT: print("before")
+// MULTIPLE-BINDS-NEXT: print("result \(str)")
+// MULTIPLE-BINDS-NEXT: print("result \(str)")
+// MULTIPLE-BINDS-NEXT: print("after")
+// MULTIPLE-BINDS-NOT: }
 
 // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
 simple { res in

--- a/test/refactoring/ConvertAsync/variable_as_callback.swift
+++ b/test/refactoring/ConvertAsync/variable_as_callback.swift
@@ -376,6 +376,30 @@ func testPrintingWrapper(completionHandler: (String) -> Void) {
 // PRINTING-WRAPPER-FUNC-NEXT:   print("Operation scheduled")
 // PRINTING-WRAPPER-FUNC-NEXT: }
 
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=SHADOWING-BEFORE %s
+func testShadowingBefore() {
+  let complete: (String) -> Void = { print($0) }
+  let result = 1
+  simple(completion: complete)
+}
+// SHADOWING-BEFORE: func testShadowingBefore() async {
+// SHADOWING-BEFORE-NEXT: let complete: (String) -> Void = { print($0) }
+// SHADOWING-BEFORE-NEXT: let result = 1
+// SHADOWING-BEFORE-NEXT: let result1 = await simple()
+// SHADOWING-BEFORE-NEXT: complete(result1)
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=SHADOWING-AFTER %s
+func testShadowingAfter() {
+  let complete: (String) -> Void = { print($0) }
+  simple(completion: complete)
+  let result = 1
+}
+// SHADOWING-AFTER: func testShadowingAfter() async {
+// SHADOWING-AFTER-NEXT: let complete: (String) -> Void = { print($0) }
+// SHADOWING-AFTER-NEXT: let result = await simple()
+// SHADOWING-AFTER-NEXT: complete(result)
+// SHADOWING-AFTER-NEXT: let result1 = 1
+
 class Foo {
   var foo: Foo
 


### PR DESCRIPTION
Cherry-picking https://github.com/apple/swift/pull/37302

-----

When converting a call or function, rename declarations such that
redeclaration errors and shadowing are avoided. In some cases this will
be overly conservative, but since any renamed variable can be fixed with
edit all in scope, this is preferred over causing redeclaration errors
or possible shadowing.

Resolves rdar://73973517