### PR TITLE
Mark test async_stream as executable_test

### DIFF
--- a/test/Concurrency/Runtime/async_stream.swift
+++ b/test/Concurrency/Runtime/async_stream.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: concurrency
 // REQUIRES: libdispatch
+// REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 
 // https://bugs.swift.org/browse/SR-14466


### PR DESCRIPTION
It fails on non_executable bots.

rdar://77963528