### PR TITLE
[5.5] Mark test class_resilience_objc as UNSUPPORTED on arm64e

### DIFF
--- a/test/IRGen/class_resilience_objc.swift
+++ b/test/IRGen/class_resilience_objc.swift
@@ -7,7 +7,8 @@
 //   The test is cloned as class_resilience_objc_armv7k.swift for them.
 // XFAIL: CPU=armv7k
 // XFAIL: CPU=arm64_32
-// XFAIL: CPU=arm64e
+// UNSUPPORTED: CPU=arm64
+// UNSUPPORTED: CPU=arm64e
 // REQUIRES: objc_interop
 
 import Foundation


### PR DESCRIPTION
It succeeds on the public non_executable bot but fails on another bot.

rdar://77399307