### PR TITLE
[5.5] [Refactoring] Preserve comments in async transform

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -4553,12 +4553,112 @@ private:
   }
 };
 
+/// A list of nodes to print, along with a list of locations that may have
+/// preceding comments attached, which also need printing. For example:
+///
+/// \code
+/// if .random() {
+///   // a
+///   print("hello")
+///   // b
+/// }
+/// \endcode
+///
+/// To print out the contents of the if statement body, we'll include the AST
+/// node for the \c print call. This will also include the preceding comment
+/// \c a, but won't include the comment \c b. To ensure the comment \c b gets
+/// printed, the SourceLoc for the closing brace \c } is added as a possible
+/// comment loc.
+class NodesToPrint {
+  SmallVector<ASTNode, 0> Nodes;
+  SmallVector<SourceLoc, 2> PossibleCommentLocs;
+
+public:
+  NodesToPrint() {}
+  NodesToPrint(ArrayRef<ASTNode> Nodes, ArrayRef<SourceLoc> PossibleCommentLocs)
+      : Nodes(Nodes.begin(), Nodes.end()),
+        PossibleCommentLocs(PossibleCommentLocs.begin(),
+                            PossibleCommentLocs.end()) {}
+
+  ArrayRef<ASTNode> getNodes() const { return Nodes; }
+  ArrayRef<SourceLoc> getPossibleCommentLocs() const {
+    return PossibleCommentLocs;
+  }
+
+  /// Add an AST node to print.
+  void addNode(ASTNode Node) {
+    // Note we skip vars as they'll be printed as a part of their
+    // PatternBindingDecl.
+    if (!Node.isDecl(DeclKind::Var))
+      Nodes.push_back(Node);
+  }
+
+  /// Add a SourceLoc which may have a preceding comment attached. If so, the
+  /// comment will be printed out at the appropriate location.
+  void addPossibleCommentLoc(SourceLoc Loc) {
+    if (Loc.isValid())
+      PossibleCommentLocs.push_back(Loc);
+  }
+
+  /// Add all the nodes in the brace statement to the list of nodes to print.
+  /// This should be preferred over adding the nodes manually as it picks up the
+  /// end location of the brace statement as a possible comment loc, ensuring
+  /// that we print any trailing comments in the brace statement.
+  void addNodesInBraceStmt(BraceStmt *Brace) {
+    for (auto Node : Brace->getElements())
+      addNode(Node);
+
+    // Ignore the end locations of implicit braces, as they're likely bogus.
+    // e.g for a case statement, the r-brace loc points to the last token of the
+    // last node in the body.
+    if (!Brace->isImplicit())
+      addPossibleCommentLoc(Brace->getRBraceLoc());
+  }
+
+  /// Add the nodes and comment locs from another NodesToPrint.
+  void addNodes(NodesToPrint OtherNodes) {
+    Nodes.append(OtherNodes.Nodes.begin(), OtherNodes.Nodes.end());
+    PossibleCommentLocs.append(OtherNodes.PossibleCommentLocs.begin(),
+                               OtherNodes.PossibleCommentLocs.end());
+  }
+
+  /// Whether the last recorded node is an explicit return or break statement.
+  bool hasTrailingReturnOrBreak() const {
+    if (Nodes.empty())
+      return false;
+    return (Nodes.back().isStmt(StmtKind::Return) ||
+            Nodes.back().isStmt(StmtKind::Break)) &&
+           !Nodes.back().isImplicit();
+  }
+
+  /// If the last recorded node is an explicit return or break statement, drop
+  /// it from the list.
+  void dropTrailingReturnOrBreak() {
+    if (!hasTrailingReturnOrBreak())
+      return;
+
+    // Remove the node from the list, but make sure to add it as a possible
+    // comment loc to preserve any of its attached comments.
+    auto Node = Nodes.pop_back_val();
+    addPossibleCommentLoc(Node.getStartLoc());
+  }
+
+  /// Returns a list of nodes to print in a brace statement. This picks up the
+  /// end location of the brace statement as a possible comment loc, ensuring
+  /// that we print any trailing comments in the brace statement.
+  static NodesToPrint inBraceStmt(BraceStmt *stmt) {
+    NodesToPrint Nodes;
+    Nodes.addNodesInBraceStmt(stmt);
+    return Nodes;
+  }
+};
+
 /// The statements within the closure of call to a function taking a callback
 /// are split into a `SuccessBlock` and `ErrorBlock` (`ClassifiedBlocks`).
 /// This class stores the nodes for each block, as well as a mapping of
 /// decls to any patterns they are used in.
 class ClassifiedBlock {
-  SmallVector<ASTNode, 0> Nodes;
+  NodesToPrint Nodes;
   // closure param -> name
   llvm::DenseMap<const Decl *, StringRef> BoundNames;
   // var (ie. from a let binding) -> closure param
@@ -4566,7 +4666,7 @@ class ClassifiedBlock {
   bool AllLet = true;
 
 public:
-  ArrayRef<ASTNode> nodes() const { return llvm::makeArrayRef(Nodes); }
+  const NodesToPrint &nodesToPrint() const { return Nodes; }
 
   StringRef boundName(const Decl *D) const { return BoundNames.lookup(D); }
 
@@ -4576,15 +4676,18 @@ public:
 
   bool allLet() const { return AllLet; }
 
-  void addAllNodes(ArrayRef<ASTNode> Nodes) {
-    for (auto Node : Nodes) {
-      addNode(Node);
-    }
+  void addNodesInBraceStmt(BraceStmt *Brace) {
+    Nodes.addNodesInBraceStmt(Brace);
+  }
+  void addPossibleCommentLoc(SourceLoc Loc) {
+    Nodes.addPossibleCommentLoc(Loc);
+  }
+  void addAllNodes(NodesToPrint OtherNodes) {
+    Nodes.addNodes(std::move(OtherNodes));
   }
 
-  void addNode(const ASTNode Node) {
-    if (!Node.isDecl(DeclKind::Var))
-      Nodes.push_back(Node);
+  void addNode(ASTNode Node) {
+    Nodes.addNode(Node);
   }
 
   void addBinding(const CallbackCondition &FromCondition,
@@ -4647,12 +4750,12 @@ struct CallbackClassifier {
                            DiagnosticEngine &DiagEngine,
                            llvm::DenseSet<const Decl *> UnwrapParams,
                            const ParamDecl *ErrParam, HandlerType ResultType,
-                           ArrayRef<ASTNode> Body) {
-    assert(!Body.empty() && "Cannot classify empty body");
+                           BraceStmt *Body) {
+    assert(!Body->getElements().empty() && "Cannot classify empty body");
     CallbackClassifier Classifier(Blocks, HandledSwitches, DiagEngine,
                                   UnwrapParams, ErrParam,
                                   ResultType == HandlerType::RESULT);
-    Classifier.classifyNodes(Body);
+    Classifier.classifyNodes(Body->getElements(), Body->getRBraceLoc());
   }
 
 private:
@@ -4674,21 +4777,21 @@ private:
         UnwrapParams(UnwrapParams), ErrParam(ErrParam),
         IsResultParam(IsResultParam) {}
 
-  void classifyNodes(ArrayRef<ASTNode> Nodes) {
+  void classifyNodes(ArrayRef<ASTNode> Nodes, SourceLoc endCommentLoc) {
     for (auto I = Nodes.begin(), E = Nodes.end(); I < E; ++I) {
       auto *Statement = I->dyn_cast<Stmt *>();
       if (auto *IS = dyn_cast_or_null<IfStmt>(Statement)) {
-        ArrayRef<ASTNode> TempNodes;
+        NodesToPrint TempNodes;
         if (auto *BS = dyn_cast<BraceStmt>(IS->getThenStmt())) {
-          TempNodes = BS->getElements();
+          TempNodes = NodesToPrint::inBraceStmt(BS);
         } else {
-          TempNodes = ArrayRef<ASTNode>(IS->getThenStmt());
+          TempNodes = NodesToPrint({IS->getThenStmt()}, /*commentLocs*/ {});
         }
 
-        classifyConditional(IS, IS->getCond(), TempNodes, IS->getElseStmt());
+        classifyConditional(IS, IS->getCond(), std::move(TempNodes),
+                            IS->getElseStmt());
       } else if (auto *GS = dyn_cast_or_null<GuardStmt>(Statement)) {
-        classifyConditional(GS, GS->getCond(), ArrayRef<ASTNode>(),
-                            GS->getBody());
+        classifyConditional(GS, GS->getCond(), NodesToPrint(), GS->getBody());
       } else if (auto *SS = dyn_cast_or_null<SwitchStmt>(Statement)) {
         classifySwitch(SS);
       } else {
@@ -4698,10 +4801,12 @@ private:
       if (DiagEngine.hadAnyError())
         return;
     }
+    // Make sure to pick up any trailing comments.
+    CurrentBlock->addPossibleCommentLoc(endCommentLoc);
   }
 
   void classifyConditional(Stmt *Statement, StmtCondition Condition,
-                           ArrayRef<ASTNode> ThenNodes, Stmt *ElseStmt) {
+                           NodesToPrint ThenNodesToPrint, Stmt *ElseStmt) {
     llvm::DenseMap<const Decl *, CallbackCondition> CallbackConditions;
     bool UnhandledConditions =
         !CallbackCondition::all(Condition, UnwrapParams, CallbackConditions);
@@ -4773,33 +4878,35 @@ private:
       }
     }
 
+    // We'll be dropping the statement, but make sure to keep any attached
+    // comments.
+    CurrentBlock->addPossibleCommentLoc(Statement->getStartLoc());
+
     ThenBlock->addAllBindings(CallbackConditions, DiagEngine);
     if (DiagEngine.hadAnyError())
       return;
 
     // TODO: Handle nested ifs
-    setNodes(ThenBlock, ElseBlock, ThenNodes);
+    setNodes(ThenBlock, ElseBlock, std::move(ThenNodesToPrint));
 
     if (ElseStmt) {
       if (auto *BS = dyn_cast<BraceStmt>(ElseStmt)) {
-        setNodes(ElseBlock, ThenBlock, BS->getElements());
+        setNodes(ElseBlock, ThenBlock, NodesToPrint::inBraceStmt(BS));
       } else {
-        classifyNodes(ArrayRef<ASTNode>(ElseStmt));
+        classifyNodes(ArrayRef<ASTNode>(ElseStmt),
+                      /*endCommentLoc*/ SourceLoc());
       }
     }
   }
 
   void setNodes(ClassifiedBlock *Block, ClassifiedBlock *OtherBlock,
-                ArrayRef<ASTNode> Nodes) {
-    if (Nodes.empty())
-      return;
-    if ((Nodes.back().isStmt(StmtKind::Return) ||
-         Nodes.back().isStmt(StmtKind::Break)) &&
-        !Nodes.back().isImplicit()) {
+                NodesToPrint Nodes) {
+    if (Nodes.hasTrailingReturnOrBreak()) {
       CurrentBlock = OtherBlock;
-      Block->addAllNodes(Nodes.drop_back());
+      Nodes.dropTrailingReturnOrBreak();
+      Block->addAllNodes(std::move(Nodes));
     } else {
-      Block->addAllNodes(Nodes);
+      Block->addAllNodes(std::move(Nodes));
     }
   }
 
@@ -4809,7 +4916,16 @@ private:
       return;
     }
 
-    for (auto *CS : SS->getCases()) {
+    // We'll be dropping the switch, but make sure to keep any attached
+    // comments.
+    CurrentBlock->addPossibleCommentLoc(SS->getStartLoc());
+
+    // Push the cases into a vector. This is only done to eagerly evaluate the
+    // AsCaseStmtRange sequence so we can know what the last case is.
+    SmallVector<CaseStmt *, 2> Cases;
+    Cases.append(SS->getCases().begin(), SS->getCases().end());
+
+    for (auto *CS : Cases) {
       if (CS->hasFallthroughDest()) {
         DiagEngine.diagnose(CS->getLoc(), diag::callback_with_fallthrough);
         return;
@@ -4839,7 +4955,16 @@ private:
         OtherBlock = &Blocks.SuccessBlock;
       }
 
-      setNodes(Block, OtherBlock, CS->getBody()->getElements());
+      // We'll be dropping the case, but make sure to keep any attached
+      // comments. Because these comments will effectively be part of the
+      // previous case, add them to CurrentBlock.
+      CurrentBlock->addPossibleCommentLoc(CS->getStartLoc());
+
+      // Make sure to grab trailing comments in the last case stmt.
+      if (CS == Cases.back())
+        Block->addPossibleCommentLoc(SS->getRBraceLoc());
+
+      setNodes(Block, OtherBlock, NodesToPrint::inBraceStmt(CS->getBody()));
       Block->addBinding(CC, DiagEngine);
       if (DiagEngine.hadAnyError())
         return;
@@ -5279,10 +5404,65 @@ private:
   }
 
 
-  void convertNodes(ArrayRef<ASTNode> Nodes) {
-    for (auto Node : Nodes) {
+  /// Retrieves the location for the start of a comment attached to the token
+  /// at the provided location, or the location itself if there is no comment.
+  SourceLoc getLocIncludingPrecedingComment(SourceLoc loc) {
+    auto tokens = SF->getAllTokens();
+    auto tokenIter = token_lower_bound(tokens, loc);
+    if (tokenIter != tokens.end() && tokenIter->hasComment())
+      return tokenIter->getCommentStart();
+    return loc;
+  }
+
+  /// If the provided SourceLoc has a preceding comment, print it out. Returns
+  /// true if a comment was printed, false otherwise.
+  bool printCommentIfNeeded(SourceLoc Loc, bool AddNewline = false) {
+    auto PrecedingLoc = getLocIncludingPrecedingComment(Loc);
+    if (Loc == PrecedingLoc)
+      return false;
+    if (AddNewline)
       OS << "\n";
+    OS << CharSourceRange(SM, PrecedingLoc, Loc).str();
+    return true;
+  }
+
+  void convertNodes(const NodesToPrint &ToPrint) {
+    // Sort the possible comment locs in reverse order so we can pop them as we
+    // go.
+    SmallVector<SourceLoc, 2> CommentLocs;
+    CommentLocs.append(ToPrint.getPossibleCommentLocs().begin(),
+                       ToPrint.getPossibleCommentLocs().end());
+    llvm::sort(CommentLocs.begin(), CommentLocs.end(), [](auto lhs, auto rhs) {
+      return lhs.getOpaquePointerValue() > rhs.getOpaquePointerValue();
+    });
+
+    // First print the nodes we've been asked to print.
+    for (auto Node : ToPrint.getNodes()) {
+      OS << "\n";
+
+      // If we need to print comments, do so now.
+      while (!CommentLocs.empty()) {
+        auto CommentLoc = CommentLocs.back().getOpaquePointerValue();
+        auto NodeLoc = Node.getStartLoc().getOpaquePointerValue();
+        assert(CommentLoc != NodeLoc &&
+               "Added node to both comment locs and nodes to print?");
+
+        // If the comment occurs after the node, don't print now. Wait until
+        // the right node comes along.
+        if (CommentLoc > NodeLoc)
+          break;
+
+        printCommentIfNeeded(CommentLocs.pop_back_val());
+      }
       convertNode(Node);
+    }
+
+    // We're done printing nodes. Make sure to output the remaining comments.
+    bool HasPrintedComment = false;
+    while (!CommentLocs.empty()) {
+      HasPrintedComment |=
+          printCommentIfNeeded(CommentLocs.pop_back_val(),
+                               /*AddNewline*/ !HasPrintedComment);
     }
   }
 
@@ -5290,6 +5470,12 @@ private:
                    bool ConvertCalls = true) {
     if (!StartOverride.isValid())
       StartOverride = Node.getStartLoc();
+
+    // Unless this is the start node, make sure to include any preceding
+    // comments attached to the loc. If it's the start node, the attached
+    // comment is outside the range of the transform.
+    if (Node != StartNode)
+      StartOverride = getLocIncludingPrecedingComment(StartOverride);
 
     llvm::SaveAndRestore<SourceLoc> RestoreLoc(LastAddedLoc, StartOverride);
     llvm::SaveAndRestore<int> RestoreCount(NestedExprCount,
@@ -5669,7 +5855,7 @@ private:
                                  PtrArrayRef<Expr *> ArgList) {
     ArrayRef<const ParamDecl *> CallbackParams =
         Callback->getParameters()->getArray();
-    ArrayRef<ASTNode> CallbackBody = Callback->getBody()->getElements();
+    auto CallbackBody = Callback->getBody();
     if (HandlerDesc.params().size() != CallbackParams.size()) {
       DiagEngine.diagnose(CE->getStartLoc(), diag::mismatched_callback_args);
       return;
@@ -5689,8 +5875,8 @@ private:
 
     ClassifiedBlocks Blocks;
     if (!HandlerDesc.HasError) {
-      Blocks.SuccessBlock.addAllNodes(CallbackBody);
-    } else if (!CallbackBody.empty()) {
+      Blocks.SuccessBlock.addNodesInBraceStmt(CallbackBody);
+    } else if (!CallbackBody->getElements().empty()) {
       llvm::DenseSet<const Decl *> UnwrapParams;
       for (auto *Param : SuccessParams) {
         if (HandlerDesc.shouldUnwrap(Param->getType()))
@@ -5720,16 +5906,17 @@ private:
                    HandlerDesc, /*AddDeclarations=*/!HandlerDesc.HasError);
       addFallbackCatch(ErrParam);
       OS << "\n";
-      convertNodes(CallbackBody);
+      convertNodes(NodesToPrint::inBraceStmt(CallbackBody));
 
       clearNames(CallbackParams);
       return;
     }
 
-    bool RequireDo = !Blocks.ErrorBlock.nodes().empty();
+    auto ErrorNodes = Blocks.ErrorBlock.nodesToPrint().getNodes();
+    bool RequireDo = !ErrorNodes.empty();
     // Check if we *actually* need a do/catch (see class comment)
-    if (Blocks.ErrorBlock.nodes().size() == 1) {
-      auto Node = Blocks.ErrorBlock.nodes()[0];
+    if (ErrorNodes.size() == 1) {
+      auto Node = ErrorNodes[0];
       if (auto *HandlerCall = TopHandler.getAsHandlerCall(Node)) {
         auto Res = TopHandler.extractResultArgs(HandlerCall);
         if (Res.args().size() == 1) {
@@ -5743,6 +5930,16 @@ private:
       }
     }
 
+    // If we're not requiring a 'do', we'll be dropping the error block. But
+    // let's make sure we at least preserve the comments in the error block by
+    // transplanting them into the success block. This should make sure they
+    // maintain a sensible ordering.
+    if (!RequireDo) {
+      auto ErrorNodes = Blocks.ErrorBlock.nodesToPrint();
+      for (auto CommentLoc : ErrorNodes.getPossibleCommentLocs())
+        Blocks.SuccessBlock.addPossibleCommentLoc(CommentLoc);
+    }
+
     if (RequireDo) {
       addDo();
     }
@@ -5753,7 +5950,7 @@ private:
 
     addAwaitCall(CE, ArgList.ref(), Blocks.SuccessBlock, SuccessParams,
                  HandlerDesc, /*AddDeclarations=*/true);
-    convertNodes(Blocks.SuccessBlock.nodes());
+    convertNodes(Blocks.SuccessBlock.nodesToPrint());
     clearNames(SuccessParams);
 
     if (RequireDo) {
@@ -5764,7 +5961,7 @@ private:
                                     /*Success=*/false);
 
       addCatch(ErrParam);
-      convertNodes(Blocks.ErrorBlock.nodes());
+      convertNodes(Blocks.ErrorBlock.nodesToPrint());
       OS << "\n" << tok::r_brace;
       clearNames(llvm::makeArrayRef(ErrParam));
     }

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -5117,7 +5117,7 @@ private:
 /// the code the user intended. In most cases the refactoring will continue,
 /// with any unhandled decls wrapped in placeholders instead.
 class AsyncConverter : private SourceEntityWalker {
-  ASTContext &Context;
+  SourceFile *SF;
   SourceManager &SM;
   DiagnosticEngine &DiagEngine;
 
@@ -5170,11 +5170,11 @@ class AsyncConverter : private SourceEntityWalker {
 
 public:
   /// Convert a function
-  AsyncConverter(ASTContext &Context, SourceManager &SM,
+  AsyncConverter(SourceFile *SF, SourceManager &SM,
                  DiagnosticEngine &DiagEngine, AbstractFunctionDecl *FD,
                  const AsyncHandlerParamDesc &TopHandler)
-      : Context(Context), SM(SM), DiagEngine(DiagEngine),
-        StartNode(FD), TopHandler(TopHandler), OS(Buffer) {
+      : SF(SF), SM(SM), DiagEngine(DiagEngine), StartNode(FD),
+        TopHandler(TopHandler), OS(Buffer) {
     Placeholders.insert(TopHandler.getHandler());
     ScopedDecls.collect(FD);
 
@@ -5184,20 +5184,20 @@ public:
   }
 
   /// Convert a call
-  AsyncConverter(ASTContext &Context, SourceManager &SM,
-                 DiagnosticEngine &DiagEngine, CallExpr *CE, BraceStmt *Scope,
-                 SourceFile &SF)
-      : Context(Context), SM(SM), DiagEngine(DiagEngine),
-        StartNode(CE), OS(Buffer) {
+  AsyncConverter(SourceFile *SF, SourceManager &SM,
+                 DiagnosticEngine &DiagEngine, CallExpr *CE, BraceStmt *Scope)
+      : SF(SF), SM(SM), DiagEngine(DiagEngine), StartNode(CE), OS(Buffer) {
     ScopedDecls.collect(CE);
 
     // Create the initial scope, can be more accurate than the general
     // \c ScopedDeclCollector as there is a starting point.
     llvm::DenseSet<const Decl *> UsedDecls;
-    DeclCollector::collect(Scope, SF, UsedDecls);
-    ReferenceCollector::collect(StartNode, Scope, SF, UsedDecls);
+    DeclCollector::collect(Scope, *SF, UsedDecls);
+    ReferenceCollector::collect(StartNode, Scope, *SF, UsedDecls);
     addNewScope(UsedDecls);
   }
+
+  ASTContext &getASTContext() const { return SF->getASTContext(); }
 
   bool convert() {
     assert(Buffer.empty() && "AsyncConverter can only be used once");
@@ -5956,7 +5956,7 @@ private:
   /// Returns a unique name using \c Name as base that doesn't clash with any
   /// other names in the current scope.
   Identifier createUniqueName(StringRef Name) {
-    Identifier Ident = Context.getIdentifier(Name);
+    Identifier Ident = getASTContext().getIdentifier(Name);
 
     auto &CurrentNames = ScopedNames.back();
     if (CurrentNames.count(Ident)) {
@@ -5967,7 +5967,7 @@ private:
       do {
         UniquedName = Name;
         UniquedName.append(std::to_string(UniqueId));
-        Ident = Context.getIdentifier(UniquedName);
+        Ident = getASTContext().getIdentifier(UniquedName);
         UniqueId++;
       } while (CurrentNames.count(Ident));
     }
@@ -6254,7 +6254,7 @@ bool RefactoringActionConvertCallToAsyncAlternative::performChange() {
   if (!Scopes.empty())
     Scope = cast<BraceStmt>(Scopes.back().get<Stmt *>());
 
-  AsyncConverter Converter(Ctx, SM, DiagEngine, CE, Scope, *CursorInfo.SF);
+  AsyncConverter Converter(TheFile, SM, DiagEngine, CE, Scope);
   if (!Converter.convert())
     return true;
 
@@ -6282,7 +6282,7 @@ bool RefactoringActionConvertToAsync::performChange() {
          "Should not run performChange when refactoring is not applicable");
 
   auto HandlerDesc = AsyncHandlerParamDesc::find(FD, /*ignoreName=*/true);
-  AsyncConverter Converter(Ctx, SM, DiagEngine, FD, HandlerDesc);
+  AsyncConverter Converter(TheFile, SM, DiagEngine, FD, HandlerDesc);
   if (!Converter.convert())
     return true;
 
@@ -6319,14 +6319,14 @@ bool RefactoringActionAddAsyncAlternative::performChange() {
   assert(HandlerDesc.isValid() &&
          "Should not run performChange when refactoring is not applicable");
 
-  AsyncConverter Converter(Ctx, SM, DiagEngine, FD, HandlerDesc);
+  AsyncConverter Converter(TheFile, SM, DiagEngine, FD, HandlerDesc);
   if (!Converter.convert())
     return true;
 
   EditConsumer.accept(SM, FD->getAttributeInsertionLoc(false),
                       "@available(*, deprecated, message: \"Prefer async "
                       "alternative instead\")\n");
-  AsyncConverter LegacyBodyCreator(Ctx, SM, DiagEngine, FD, HandlerDesc);
+  AsyncConverter LegacyBodyCreator(TheFile, SM, DiagEngine, FD, HandlerDesc);
   if (LegacyBodyCreator.createLegacyBody()) {
     LegacyBodyCreator.replace(FD->getBody(), EditConsumer);
   }

--- a/test/refactoring/ConvertAsync/convert_function.swift
+++ b/test/refactoring/ConvertAsync/convert_function.swift
@@ -150,6 +150,51 @@ func asyncUnhandledCompletion(_ completion: (String) -> Void) {
 // ASYNC-UNHANDLED-NEXT: }
 // ASYNC-UNHANDLED-NEXT: }
 
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-UNHANDLED-COMMENT %s
+func asyncUnhandledCommentedCompletion(_ completion: (String) -> Void) {
+  // a
+  simple { str in // b
+    // c
+    let success = run {
+      // d
+      completion(str)
+      // e
+      return true
+      // f
+    }
+    // g
+    if !success {
+      // h
+      completion("bad")
+      // i
+    }
+    // j
+  }
+  // k
+}
+// ASYNC-UNHANDLED-COMMENT:      func asyncUnhandledCommentedCompletion() async -> String {
+// ASYNC-UNHANDLED-COMMENT-NEXT:   // a
+// ASYNC-UNHANDLED-COMMENT-NEXT:   let str = await simple()
+// ASYNC-UNHANDLED-COMMENT-NEXT:   // b
+// ASYNC-UNHANDLED-COMMENT-NEXT:   // c
+// ASYNC-UNHANDLED-COMMENT-NEXT:   let success = run {
+// ASYNC-UNHANDLED-COMMENT-NEXT:     // d
+// ASYNC-UNHANDLED-COMMENT-NEXT:     <#completion#>(str)
+// ASYNC-UNHANDLED-COMMENT-NEXT:     // e
+// ASYNC-UNHANDLED-COMMENT-NEXT:     {{^}} return true{{$}}
+// ASYNC-UNHANDLED-COMMENT-NEXT:     // f
+// ASYNC-UNHANDLED-COMMENT-NEXT:   }
+// ASYNC-UNHANDLED-COMMENT-NEXT:   // g
+// ASYNC-UNHANDLED-COMMENT-NEXT:   if !success {
+// ASYNC-UNHANDLED-COMMENT-NEXT:     // h
+// ASYNC-UNHANDLED-COMMENT-NEXT:     {{^}} return "bad"{{$}}
+// ASYNC-UNHANDLED-COMMENT-NEXT:     // i
+// ASYNC-UNHANDLED-COMMENT-NEXT:   }
+// ASYNC-UNHANDLED-COMMENT-NEXT:   // j
+// ASYNC-UNHANDLED-COMMENT-NEXT:   {{ }}
+// ASYNC-UNHANDLED-COMMENT-NEXT:   // k
+// ASYNC-UNHANDLED-COMMENT-NEXT: }
+
 // RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix VOID-AND-ERROR-HANDLER %s
 func voidAndErrorCompletion(completion: (Void?, Error?) -> Void) {
   if .random() {

--- a/test/refactoring/ConvertAsync/convert_params_single.swift
+++ b/test/refactoring/ConvertAsync/convert_params_single.swift
@@ -40,6 +40,53 @@ withError { res, err in
 // BOUND-NEXT: print("got error \(bad)")
 // BOUND-NEXT: }
 
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=BOUND-COMMENT %s
+withError { res, err in // a
+  // b
+  print("before")
+  // c
+  if let bad = err { // d
+    // e
+    print("got error \(bad)")
+    // f
+    return
+    // g
+  }
+  // h
+  if let str = res { // i
+    // j
+    print("got result \(str)")
+    // k
+  }
+  // l
+  print("after")
+  // m
+}
+// BOUND-COMMENT: do {
+// BOUND-COMMENT-NEXT: let str = try await withError()
+// BOUND-COMMENT-NEXT: // a
+// BOUND-COMMENT-NEXT: // b
+// BOUND-COMMENT-NEXT: print("before")
+// BOUND-COMMENT-NEXT: // c
+// BOUND-COMMENT-NEXT: // h
+// BOUND-COMMENT-NEXT: // i
+// BOUND-COMMENT-NEXT: // j
+// BOUND-COMMENT-NEXT: print("got result \(str)")
+// BOUND-COMMENT-NEXT: // k
+// BOUND-COMMENT-NEXT: // l
+// BOUND-COMMENT-NEXT: print("after")
+// BOUND-COMMENT-NEXT: // m
+// BOUND-COMMENT-EMPTY:
+// BOUND-COMMENT-NEXT: } catch let bad {
+// BOUND-COMMENT-NEXT: // d
+// BOUND-COMMENT-NEXT: // e
+// BOUND-COMMENT-NEXT: print("got error \(bad)")
+// BOUND-COMMENT-NEXT: // f
+// BOUND-COMMENT-NEXT: // g
+// BOUND-COMMENT-NEXT: {{ }}
+// BOUND-COMMENT-NEXT: }
+
+
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNBOUND-ERR %s
 withError { res, err in
   print("before")
@@ -403,6 +450,7 @@ withError { str, err in
   print("before")
   guard err == nil else { return }
   _ = str!.count
+  _ = /*before*/str!/*after*/.count
   _ = str?.count
   _ = str!.count.bitWidth
   _ = str?.count.bitWidth
@@ -415,6 +463,7 @@ withError { str, err in
 // UNWRAPPING:      let str = try await withError()
 // UNWRAPPING-NEXT: print("before")
 // UNWRAPPING-NEXT: _ = str.count
+// UNWRAPPING-NEXT: _ = /*before*/str/*after*/.count
 // UNWRAPPING-NEXT: _ = str.count
 // UNWRAPPING-NEXT: _ = str.count.bitWidth
 // UNWRAPPING-NEXT: _ = str.count.bitWidth

--- a/test/refactoring/ConvertAsync/convert_result.swift
+++ b/test/refactoring/ConvertAsync/convert_result.swift
@@ -317,6 +317,96 @@ simple { res in
 // NESTEDBREAK-NEXT: print("after")
 // NESTEDBREAK-NOT: }
 
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NESTEDBREAK-COMMENT %s
+simple { res in // a
+  // b
+  print("before")
+  // c
+  switch res {
+  // d
+  case .success(let str): // e
+    if test(str) {
+      // f
+      break
+      // g
+    }
+    // h
+    print("result \(str)")
+    // i
+  case .failure:
+    // j
+    break
+    // k
+  }
+  // l
+  print("after")
+  // m
+}
+// NESTEDBREAK-COMMENT:      let str = try await simple()
+// NESTEDBREAK-COMMENT-NEXT: // a
+// NESTEDBREAK-COMMENT-NEXT: // b
+// NESTEDBREAK-COMMENT-NEXT: print("before")
+// NESTEDBREAK-COMMENT-NEXT: // c
+// NESTEDBREAK-COMMENT-NEXT: // d
+// NESTEDBREAK-COMMENT-NEXT: // e
+// NESTEDBREAK-COMMENT-NEXT: if test(str) {
+// NESTEDBREAK-COMMENT-NEXT: // f
+// NESTEDBREAK-COMMENT-NEXT:   <#break#>
+// NESTEDBREAK-COMMENT-NEXT: // g
+// NESTEDBREAK-COMMENT-NEXT: }
+// NESTEDBREAK-COMMENT-NEXT: // h
+// NESTEDBREAK-COMMENT-NEXT: print("result \(str)")
+// NESTEDBREAK-COMMENT-NEXT: // i
+// NESTEDBREAK-COMMENT-NEXT: // j
+// NESTEDBREAK-COMMENT-NEXT: // k
+// NESTEDBREAK-COMMENT-NEXT: // l
+// NESTEDBREAK-COMMENT-NEXT: print("after")
+// NESTEDBREAK-COMMENT-NEXT: // m
+// NESTEDBREAK-COMMENT-EMPTY:
+// NESTEDBREAK-COMMENT-NOT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ERROR-BLOCK-COMMENT %s
+simple { res in
+  // a
+  print("before")
+  // b
+  switch res {
+  case .success(let str):
+    // c
+    print("result \(str)")
+    // d
+  case .failure:
+    // e
+    print("fail")
+    // f
+    return
+    // g
+  }
+  // h
+  print("after")
+  // i
+}
+// ERROR-BLOCK-COMMENT:      do {
+// ERROR-BLOCK-COMMENT-NEXT:   let str = try await simple()
+// ERROR-BLOCK-COMMENT-NEXT:   // a
+// ERROR-BLOCK-COMMENT-NEXT:   print("before")
+// ERROR-BLOCK-COMMENT-NEXT:   // b
+// ERROR-BLOCK-COMMENT-NEXT:   // c
+// ERROR-BLOCK-COMMENT-NEXT:   print("result \(str)")
+// ERROR-BLOCK-COMMENT-NEXT:   // d
+// ERROR-BLOCK-COMMENT-NEXT:   // h
+// ERROR-BLOCK-COMMENT-NEXT:   print("after")
+// ERROR-BLOCK-COMMENT-NEXT:   // i
+// ERROR-BLOCK-COMMENT-EMPTY:
+// ERROR-BLOCK-COMMENT-NEXT: } catch {
+// ERROR-BLOCK-COMMENT-NEXT:   // e
+// ERROR-BLOCK-COMMENT-NEXT:   print("fail")
+// ERROR-BLOCK-COMMENT-NEXT:   // f
+// ERROR-BLOCK-COMMENT-NEXT:   // g
+// ERROR-BLOCK-COMMENT-NEXT:   {{ }}
+// ERROR-BLOCK-COMMENT-NEXT: }
+// ERROR-BLOCK-COMMENT-NOT: }
+
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=VOID-RESULT-CALL %s
 voidResult { res in
   print(res)


### PR DESCRIPTION
*5.5 cherry-pick of https://github.com/apple/swift/pull/37387*

---

Previously we would drop comments between nodes in a BraceStmt, as we printed each node out individually. To remedy this, always make sure we scan backwards to find any preceding comments attached to a node. In addition, make sure we keep track of any SourceLocs which we don't print, but may have comments attached which we want to preserve.

rdar://77401810
