### PR TITLE
[Property Wrappers] Fix a crash in merge-modules with wrapped parameters.

### DIFF
--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -622,6 +622,11 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
   if (!type)
     return Type();
 
+  // If the declaration came from a module file, there's no need to
+  // compute the auxiliary variables.
+  if (!var->getDeclContext()->getParentSourceFile())
+    return type;
+
   // Set the interface type of each synthesized declaration.
   auto auxiliaryVars = var->getPropertyWrapperAuxiliaryVariables();
   auxiliaryVars.backingVar->setInterfaceType(type);

--- a/validation-test/Serialization/rdar77804605.swift
+++ b/validation-test/Serialization/rdar77804605.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/WrappedParameter.swiftmodule -emit-module-source-info-path %t/WrappedParameter.swiftsourceinfo -module-name WrappedParameter -enable-testing %s
+// RUN: %target-swift-frontend -merge-modules -emit-module %t/WrappedParameter.swiftmodule -module-name WrappedParameter -o %t/WrappedParameter.swiftmodule
+
+// Make sure wrapped parameters don't crash in merge-modules when
+// they were compiled with -emit-module-source-info and -enable-testing.
+
+@propertyWrapper
+struct ProjectionWrapper<Value> {
+  var wrappedValue: Value
+
+  var projectedValue: Self { self }
+
+  public init(projectedValue: Self) {
+    self = projectedValue
+  }
+}
+
+func test(@ProjectionWrapper value: Int) {}


### PR DESCRIPTION
This is fallout from https://github.com/apple/swift/pull/36521 that caused a crash in merge modules when the source was compiled with `-emit-module-source-info` and `-enable-testing`.

After deserializing a property wrapper on a parameter, we check if the interface type of the parameter is valid. For property wrappers with `init(projectedValue)`, this ends up going through `PropertyWrapperBackingPropertyTypeRequest`, which is called from `ParamDecl::toFunctionParam`. After the above PR, this request now depends on `PropertyWrapperAuxiliaryVariablesRequest`. The compiler ended up in infinite recursion (and eventually crashed) trying to synthesize the auxiliary variables for the wrapped parameter, because it got stuck trying to find the serialized location of the wrapped parameter. The fix is to return early from computing the backing property wrapper type in the case where the declaration came from a module file, because the auxiliary variables have already been computed and type checked anyway.

Note: I think a better way to handle this is to set the resolved type of the wrapper attribute in the constraint system (and get rid of the side cache for the backing type) so it’s always serialized with the resolved type, but doing this breaks a lot of interface printing and SourceKit tests, and I intend to cherry-pick this to `release/5.5` so I'd like to keep the fix targeted for now.

Resolves: rdar://77804605