### PR TITLE
[5.5] Updating diagnostic message for convenience init in struct

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3480,7 +3480,7 @@ ERROR(cfclass_designated_init_in_extension,none,
       "designated initializer cannot be declared in an extension of %0",
       (DeclName))
 ERROR(enumstruct_convenience_init,none,
-      "delegating initializers in %0 are not marked with 'convenience'",
+      "initializers in %0 are not marked with 'convenience'",
       (StringRef))
 ERROR(nonclass_convenience_init,none,
       "convenience initializer not allowed in non-class type %0",

--- a/test/decl/func/complete_object_init.swift
+++ b/test/decl/func/complete_object_init.swift
@@ -40,7 +40,7 @@ class DerivesA : A {
 }
 
 struct S {
-  convenience init(int i: Int) { // expected-error{{delegating initializers in structs are not marked with 'convenience'}}
+  convenience init(int i: Int) { // expected-error{{initializers in structs are not marked with 'convenience'}}
     self.init(double: Double(i))
   }  
 

--- a/test/decl/init/basic_init.swift
+++ b/test/decl/init/basic_init.swift
@@ -44,7 +44,7 @@ extension InitStruct {
 struct MyStruct {
   init(k: Int) {
   }
-  convenience init() {  // expected-error {{delegating initializers in structs are not marked with 'convenience'}} {{3-15=}}
+  convenience init() {  // expected-error {{initializers in structs are not marked with 'convenience'}} {{3-15=}}
     self.init(k: 1)
   }
 }


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/37267 to 5.5