### PR TITLE
[Refactoring] A couple of fixes for async return handling

### DIFF
--- a/include/swift/IDE/SourceEntityWalker.h
+++ b/include/swift/IDE/SourceEntityWalker.h
@@ -14,6 +14,7 @@
 #define SWIFT_IDE_SOURCE_ENTITY_WALKER_H
 
 #include "swift/AST/ASTWalker.h"
+#include "swift/Basic/Defer.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceLoc.h"
 #include "llvm/ADT/PointerUnion.h"
@@ -176,6 +177,24 @@ protected:
   virtual ~SourceEntityWalker() {}
 
   virtual void anchor();
+
+  /// Retrieve the current ASTWalker being used to traverse the AST.
+  const ASTWalker &getWalker() const {
+    assert(Walker && "Not walking!");
+    return *Walker;
+  }
+
+private:
+  ASTWalker *Walker = nullptr;
+
+  /// Utility that lets us keep track of an ASTWalker when walking.
+  bool performWalk(ASTWalker &W, llvm::function_ref<bool(void)> DoWalk) {
+    Walker = &W;
+    SWIFT_DEFER {
+      Walker = nullptr;
+    };
+    return DoWalk();
+  }
 };
 
 } // namespace swift

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -5600,12 +5600,14 @@ private:
         // it would have been lifted out of the switch statement.
         if (auto *SS = dyn_cast<SwitchStmt>(BS->getTarget())) {
           if (HandledSwitches.contains(SS))
-            replaceRangeWithPlaceholder(S->getSourceRange());
+            return replaceRangeWithPlaceholder(S->getSourceRange());
         }
       } else if (isa<ReturnStmt>(S) && NestedExprCount == 0) {
         // For a return, if it's not nested inside another closure or function,
         // turn it into a placeholder, as it will be lifted out of the callback.
-        replaceRangeWithPlaceholder(S->getSourceRange());
+        // Note that we only turn the 'return' token into a placeholder as we
+        // still want to be able to apply transforms to the argument.
+        replaceRangeWithPlaceholder(S->getStartLoc());
       }
     }
     return true;

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -806,32 +806,32 @@ bool SemaAnnotator::shouldIgnore(Decl *D) {
 
 bool SourceEntityWalker::walk(SourceFile &SrcFile) {
   SemaAnnotator Annotator(*this);
-  return SrcFile.walk(Annotator);
+  return performWalk(Annotator, [&]() { return SrcFile.walk(Annotator); });
 }
 
 bool SourceEntityWalker::walk(ModuleDecl &Mod) {
   SemaAnnotator Annotator(*this);
-  return Mod.walk(Annotator);
+  return performWalk(Annotator, [&]() { return Mod.walk(Annotator); });
 }
 
 bool SourceEntityWalker::walk(Stmt *S) {
   SemaAnnotator Annotator(*this);
-  return S->walk(Annotator);
+  return performWalk(Annotator, [&]() { return S->walk(Annotator); });
 }
 
 bool SourceEntityWalker::walk(Expr *E) {
   SemaAnnotator Annotator(*this);
-  return E->walk(Annotator);
+  return performWalk(Annotator, [&]() { return E->walk(Annotator); });
 }
 
 bool SourceEntityWalker::walk(Decl *D) {
   SemaAnnotator Annotator(*this);
-  return D->walk(Annotator);
+  return performWalk(Annotator, [&]() { return D->walk(Annotator); });
 }
 
 bool SourceEntityWalker::walk(DeclContext *DC) {
   SemaAnnotator Annotator(*this);
-  return DC->walkContext(Annotator);
+  return performWalk(Annotator, [&]() { return DC->walkContext(Annotator); });
 }
 
 bool SourceEntityWalker::walk(ASTNode N) {

--- a/test/refactoring/ConvertAsync/convert_function.swift
+++ b/test/refactoring/ConvertAsync/convert_function.swift
@@ -280,3 +280,12 @@ func testReturnHandling2(completion: @escaping (String) -> ()) {
 // RETURN-HANDLING2-NEXT:     {{^}}<#return#> a{{$}}
 // RETURN-HANDLING2-NEXT:   }
 // RETURN-HANDLING2-NEXT: }
+
+// FIXME: We should arguably be able to handle transforming this completion handler call (rdar://78011350).
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=RETURN-HANDLING3 %s
+func testReturnHandling3(_ completion: (String?, Error?) -> Void) {
+  return (completion("", nil))
+}
+// RETURN-HANDLING3:      func testReturnHandling3() async throws -> String {
+// RETURN-HANDLING3-NEXT:   {{^}} return (<#completion#>("", nil)){{$}}
+// RETURN-HANDLING3-NEXT: }

--- a/test/refactoring/ConvertAsync/convert_function.swift
+++ b/test/refactoring/ConvertAsync/convert_function.swift
@@ -247,3 +247,13 @@ func voidResultCompletion(completion: (Result<Void, Error>) -> Void) {
 // RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NON-COMPLETION-HANDLER %s
 func functionWithSomeHandler(handler: (String) -> Void) {}
 // NON-COMPLETION-HANDLER: func functionWithSomeHandler() async -> String {}
+
+// rdar://77789360 Make sure we don't print a double return statement.
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=RETURN-HANDLING %s
+func testReturnHandling(_ completion: (String?, Error?) -> Void) {
+  return completion("", nil)
+}
+// RETURN-HANDLING:      func testReturnHandling() async throws -> String {
+// RETURN-HANDLING-NEXT:   {{^}} return ""{{$}}
+// RETURN-HANDLING-NEXT: }
+


### PR DESCRIPTION
- Fix placeholder handling so we don't crash while re-writing a return statement with a return expression
- Avoid duplicating return statements when converting a completion handler call into a return statement
- Don't drop return statements at the end of a block if they have an expression

rdar://77789360