### PR TITLE
[5.5][Concurrency] Actor cannot conform to global actor isolated protocol

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4459,6 +4459,11 @@ ERROR(global_actor_isolated_requirement_witness_conflict,none,
       "%0 %1 isolated to global actor %2 can not satisfy corresponding "
       "requirement from protocol %3 isolated to global actor %4",
       (DescriptiveDeclKind, DeclName, Type, Identifier, Type))
+ERROR(actor_cannot_conform_to_global_actor_protocol,none,
+      "actor %0 cannot conform to global actor isolated protocol %1",
+      (Type, Type))
+NOTE(protocol_isolated_to_global_actor_here,none,
+     "%0 is isolated to global actor %1 here", (Type, Type))
 
 WARNING(non_concurrent_param_type,none,
         "cannot pass argument of non-sendable type %0 across actors",

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1899,6 +1899,26 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
     return conformance;
   }
 
+  if (T->isActorType()) {
+    if (auto globalActor = Proto->getGlobalActorAttr()) {
+      C.Diags.diagnose(ComplainLoc,
+                       diag::actor_cannot_conform_to_global_actor_protocol, T,
+                       ProtoType);
+
+      CustomAttr *attr;
+      NominalTypeDecl *actor;
+
+      std::tie(attr, actor) = *globalActor;
+
+      C.Diags.diagnose(attr->getLocation(),
+                       diag::protocol_isolated_to_global_actor_here, ProtoType,
+                       actor->getDeclaredInterfaceType());
+
+      conformance->setInvalid();
+      return conformance;
+    }
+  }
+
   if (Proto->isObjC()) {
     // Foreign classes cannot conform to objc protocols.
     if (auto clas = canT->getClassOrBoundGenericClass()) {

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -818,3 +818,15 @@ extension MyActor {
     }
   }
 }
+
+@available(SwiftStdlib 5.5, *)
+@MainActor // expected-note {{'GloballyIsolatedProto' is isolated to global actor 'MainActor' here}}
+protocol GloballyIsolatedProto {
+}
+
+// rdar://75849035 - trying to conform an actor to a global-actor isolated protocol should result in an error
+func test_conforming_actor_to_global_actor_protocol() {
+  @available(SwiftStdlib 5.5, *)
+  actor MyValue : GloballyIsolatedProto {}
+  // expected-error@-1 {{actor 'MyValue' cannot conform to global actor isolated protocol 'GloballyIsolatedProto'}}
+}

--- a/test/Concurrency/actor_isolation_unsafe.swift
+++ b/test/Concurrency/actor_isolation_unsafe.swift
@@ -100,3 +100,13 @@ class C7: C2 {
     globalSome() // okay
   }
 }
+
+@MainActor(unsafe) // expected-note {{'GloballyIsolatedProto' is isolated to global actor 'MainActor' here}}
+protocol GloballyIsolatedProto {
+}
+
+// rdar://75849035 - trying to conform an actor to a global-actor isolated protocol should result in an error
+func test_conforming_actor_to_global_actor_protocol() {
+  actor MyValue : GloballyIsolatedProto {}
+  // expected-error@-1 {{actor 'MyValue' cannot conform to global actor isolated protocol 'GloballyIsolatedProto'}}
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/37395

---

- Explanation:

Attempting to conform an actor to a global actor isolated protocol
creates a clash in isolation when members are accessed so, let's
detect and diagnose that.

- Scope: Declarations where actors are declared to conform to a global actor isolated protocol.

- Main Branch PR: https://github.com/apple/swift/pull/37395

- Resolves: rdar://75849035

- Risk: Very low

- Reviewed By: @hborla, @etcwilde 

- Testing: Regression tests added to the suite

Resolves: rdar://75849035
(cherry picked from commit ecfff76552590a2fb03736d7201cde28b956504e)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
