### PR TITLE
[5.5][Property Wrappers] Fix a crash in merge-modules with wrapped parameters.

### DIFF
--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -622,6 +622,11 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
   if (!type)
     return Type();
 
+  // If the declaration came from a module file, there's no need to
+  // compute the auxiliary variables.
+  if (!var->getDeclContext()->getParentSourceFile())
+    return type;
+
   // Set the interface type of each synthesized declaration.
   auto auxiliaryVars = var->getPropertyWrapperAuxiliaryVariables();
   auxiliaryVars.backingVar->setInterfaceType(type);

--- a/validation-test/Serialization/rdar77804605.swift
+++ b/validation-test/Serialization/rdar77804605.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/WrappedParameter.swiftmodule -emit-module-source-info-path %t/WrappedParameter.swiftsourceinfo -module-name WrappedParameter -enable-testing %s
+// RUN: %target-swift-frontend -merge-modules -emit-module %t/WrappedParameter.swiftmodule -module-name WrappedParameter -o %t/WrappedParameter.swiftmodule
+
+// Make sure wrapped parameters don't crash in merge-modules when
+// they were compiled with -emit-module-source-info and -enable-testing.
+
+@propertyWrapper
+struct ProjectionWrapper<Value> {
+  var wrappedValue: Value
+
+  var projectedValue: Self { self }
+
+  public init(projectedValue: Self) {
+    self = projectedValue
+  }
+}
+
+func test(@ProjectionWrapper value: Int) {}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/37407

* **Explanation**: When merging modules, after deserializing a parameter with an attached property wrapper, the compiler checks if the interface type of the parameter is valid. For property wrappers with `init(projectedValue)`, this ends up going through `PropertyWrapperBackingPropertyTypeRequest`, which is called from `ParamDecl::toFunctionParam`. After https://github.com/apple/swift/pull/36521, this request now depends on `PropertyWrapperAuxiliaryVariablesRequest`. The compiler ended up in infinite recursion (and eventually crashed) trying to synthesize the auxiliary variables for the wrapped parameter, because it got stuck trying to find the serialized location of the wrapped parameter. The fix is to return early from computing the backing property wrapper type in the case where the declaration came from a module file, because the auxiliary variables have already been computed and type checked anyway and all we really need from the request is the backing property wrapper type.
* **Scope**: This only affects property wrappers on function parameters. The crash only manifests during merge modules when the source was built with both `-emit-module-source-info` and `-enable-testing`.
* **Risk**: Very low.
* **Testing**: Added a regression test that makes sure wrapped parameters don't crash in merge-modules when they were compiled with `-emit-module-source-info` and `-enable-testing`
* **Reviewer**: @xedin 

Resolves: rdar://77804605