### PR TITLE
[PrintAsObjc] Import/fwd-declare the unbridged type for known types.

### DIFF
--- a/lib/PrintAsObjC/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.cpp
@@ -1183,7 +1183,7 @@ private:
             copyTy->isDictionary() ||
             copyTy->isSet() ||
             copyTy->isString() ||
-            (!getKnownTypeInfo(nominal) && getObjCBridgedClass(nominal))) {
+            getObjCBridgedClass(nominal)) {
           // We fast-path the most common cases in the condition above.
           os << ", copy";
         } else if (copyTy->isUnmanaged()) {
@@ -1371,10 +1371,15 @@ private:
 
 public:
   /// If \p nominal is bridged to an Objective-C class (via a conformance to
-  /// _ObjectiveCBridgeable), return that class.
+  /// _ObjectiveCBridgeable) and is not an imported Clang type or a known type,
+  /// return that class.
   ///
   /// Otherwise returns null.
   const ClassDecl *getObjCBridgedClass(const NominalTypeDecl *nominal) {
+    // Print known types as their unbridged type.
+    if (getKnownTypeInfo(nominal))
+      return nullptr;
+
     // Print imported bridgeable decls as their unbridged type.
     if (nominal->hasClangNode())
       return nullptr;

--- a/test/PrintAsObjC/bridged-known-types.swift
+++ b/test/PrintAsObjC/bridged-known-types.swift
@@ -1,0 +1,29 @@
+// Test that known types that conform to `_ObjectiveCBridgeable` import or
+// forward-declare based on the Clang type in their known type mapping, not
+// their bridged type.
+//
+// This is particularly important for `CGFloat`, which has a native Swift decl
+// in the CoreGraphics overlay that shadows the imported Clang decl, so relying
+// solely on whether or not the decl has a Clang node is not sufficient.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck %s -parse-as-library -emit-objc-header-path %t/swift.h
+// RUN: %FileCheck %s < %t/swift.h
+
+// REQUIRES: objc_interop
+
+import CoreGraphics
+import Foundation
+
+// CHECK: @import CoreGraphics;
+
+// CHECK-NOT: @class NSNumber;
+
+// CHECK-LABEL: @interface Test : NSObject{{$}}
+public class Test: NSObject {
+  // CHECK-NEXT: - (CGFloat)level
+  @objc public func level() -> CGFloat { 9000.0 }
+  // CHECK-NEXT: - (BOOL)isEnabled
+  @objc public func isEnabled() -> Bool { true }
+  // CHECK-NEXT: init
+} // CHECK-NEXT: @end


### PR DESCRIPTION
For non-Clang types that conform to `_ObjectiveCBridgeable` but have type mappings defined in `getKnownTypeInfo`, always use the Clang type in the mapping to determine which module to import.

`CGFloat` is a rare case of an `_ObjectiveCBridgeable` type that is a native Swift `struct` declared in an overlay instead of extending the original Clang decl with the conformance. Since `hasClangNode` returns false in this case, it fell through to the rest of the logic for `getObjCBridgedClass` and would forward declare `@class NSNumber` instead of `@import CoreGraphics`. Thus, in some cases (e.g., the header only defines APIs that use `CGFloat`), the header would be invalid.

Fixes SR-14266.
