### PR TITLE
[5.5][Refactoring] Add @completionHandlerAsync to sync function

### DIFF
--- a/test/refactoring/ConvertAsync/async_attribute_added.swift
+++ b/test/refactoring/ConvertAsync/async_attribute_added.swift
@@ -1,0 +1,48 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -enable-experimental-concurrency | %FileCheck -check-prefix=SIMPLE %s
+func simple(completion: @escaping (String) -> Void) { }
+// SIMPLE: async_attribute_added.swift [[# @LINE-1]]:1 -> [[# @LINE-1]]:1
+// SIMPLE-NEXT: @available(*, deprecated, message: "Prefer async alternative instead")
+// SIMPLE-EMPTY:
+// SIMPLE-NEXT: async_attribute_added.swift [[# @LINE-4]]:1 -> [[# @LINE-4]]:1
+// SIMPLE-NEXT: @completionHandlerAsync("simple()", completionHandlerIndex: 0)
+// SIMPLE-EMPTY:
+// SIMPLE-NEXT: async_attribute_added.swift [[# @LINE-7]]:53 -> [[# @LINE-7]]:56
+// SIMPLE-NEXT: {
+// SIMPLE-NEXT: async {
+// SIMPLE-NEXT: let result = await simple()
+// SIMPLE-NEXT: completion(result)
+// SIMPLE-NEXT: }
+// SIMPLE-NEXT: }
+// SIMPLE-EMPTY:
+// SIMPLE-NEXT: async_attribute_added.swift [[# @LINE-15]]:56 -> [[# @LINE-15]]:56
+// SIMPLE-EMPTY:
+// SIMPLE-EMPTY:
+// SIMPLE-EMPTY:
+// SIMPLE-NEXT: async_attribute_added.swift [[# @LINE-19]]:56 -> [[# @LINE-19]]:56
+// SIMPLE-NEXT: func simple() async -> String { }
+
+// RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):5 -enable-experimental-concurrency | %FileCheck -check-prefix=OTHER-ARGS %s
+func otherArgs(first: Int, second: String, completion: @escaping (String) -> Void) { }
+// OTHER-ARGS: @completionHandlerAsync("otherArgs(first:second:)", completionHandlerIndex: 2)
+
+// RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):5 -enable-experimental-concurrency | %FileCheck -check-prefix=EMPTY-NAMES %s
+func emptyNames(first: Int, _ second: String, completion: @escaping (String) -> Void) { }
+// EMPTY-NAMES: @completionHandlerAsync("emptyNames(first:_:)", completionHandlerIndex: 2)
+
+// Not a completion handler named parameter, but should still be converted
+// during function conversion since it has been attributed
+@completionHandlerAsync("otherName()", completionHandlerIndex: 0)
+func otherName(notHandlerName: @escaping (String) -> (Void)) {}
+func otherName() async -> String {}
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):5 -enable-experimental-concurrency | %FileCheck -check-prefix=OTHER-CONVERTED %s
+func otherStillConverted() {
+  otherName { str in
+    print(str)
+  }
+}
+// OTHER-CONVERTED: func otherStillConverted() async {
+// OTHER-CONVERTED-NEXT: let str = await otherName()
+// OTHER-CONVERTED-NEXT: print(str)

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -118,6 +118,10 @@ static llvm::cl::opt<bool>
 IsNonProtocolType("is-non-protocol-type",
                   llvm::cl::desc("The symbol being renamed is a type and not a protocol"));
 
+static llvm::cl::opt<bool> EnableExperimentalConcurrency(
+    "enable-experimental-concurrency",
+    llvm::cl::desc("Whether to enable experimental concurrency or not"));
+
 enum class DumpType {
   REWRITTEN,
   JSON,
@@ -273,7 +277,9 @@ int main(int argc, char *argv[]) {
   Invocation.getLangOptions().AttachCommentsToDecls = true;
   Invocation.getLangOptions().CollectParsedToken = true;
   Invocation.getLangOptions().BuildSyntaxTree = true;
-  Invocation.getLangOptions().EnableExperimentalConcurrency = true;
+
+  if (options::EnableExperimentalConcurrency)
+    Invocation.getLangOptions().EnableExperimentalConcurrency = true;
 
   for (auto FileName : options::InputFilenames)
     Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(FileName);

--- a/utils/refactor-check-compiles.py
+++ b/utils/refactor-check-compiles.py
@@ -21,16 +21,17 @@ def parse_args():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description="""
         A drop-in replacement for a 'swift-refactor -dump-text' call that
-        1. Checkes that the file still compiles after the refactoring by doing
+        1. Checks that the file still compiles after the refactoring by doing
            'swift-refactor -dump-rewritten' and feeding the result to
            'swift-frontend -typecheck'
         2. Outputting the result of the 'swift-refactor -dump-text' call
 
-        All arguments other than the following will be forwarded to :
+        All arguments other than the following will be forwarded to
         'swift-refactor':
          - swift-frontend
          - swift-refactor
          - temp-dir
+         - enable-experimental-concurrency (sent to both)
         """)
 
     parser.add_argument(
@@ -61,15 +62,29 @@ def parse_args():
         '-pos',
         help='The position to invoke the refactoring at'
     )
+    parser.add_argument(
+        '-enable-experimental-concurrency',
+        action='store_true',
+        help='''
+        Whether to enable experimental concurrency in both swift-refactor and
+        swift-frontend
+        '''
+    )
 
     return parser.parse_known_args()
 
 
 def main():
-    (args, unknown_args) = parse_args()
+    (args, extra_refactor_args) = parse_args()
     temp_file_name = os.path.split(args.source_filename)[-1] + '.' + \
         args.pos.replace(':', '.')
     temp_file_path = os.path.join(args.temp_dir, temp_file_name)
+
+    extra_frontend_args = []
+    if args.enable_experimental_concurrency:
+        extra_refactor_args.append('-enable-experimental-concurrency')
+        extra_frontend_args.append('-enable-experimental-concurrency')
+
     # FIXME: `refactor-check-compiles` should generate both `-dump-text` and
     # `dump-rewritten` from a single `swift-refactor` invocation (SR-14587).
     dump_text_output = run_cmd([
@@ -77,14 +92,14 @@ def main():
         '-dump-text',
         '-source-filename', args.source_filename,
         '-pos', args.pos
-    ] + unknown_args, desc='producing edit').decode("utf-8")
+    ] + extra_refactor_args, desc='producing edit').decode("utf-8")
 
     dump_rewritten_output = run_cmd([
         args.swift_refactor,
         '-dump-rewritten',
         '-source-filename', args.source_filename,
         '-pos', args.pos
-    ] + unknown_args, desc='producing rewritten file')
+    ] + extra_refactor_args, desc='producing rewritten file')
     with open(temp_file_path, 'wb') as f:
         f.write(dump_rewritten_output)
 
@@ -93,7 +108,7 @@ def main():
         '-typecheck',
         temp_file_path,
         '-disable-availability-checking'
-    ], desc='checking that rewritten file compiles')
+    ] + extra_frontend_args, desc='checking that rewritten file compiles')
     sys.stdout.write(dump_text_output)
 
 

--- a/utils/refactor-check-compiles.py
+++ b/utils/refactor-check-compiles.py
@@ -77,7 +77,7 @@ def main():
         '-dump-text',
         '-source-filename', args.source_filename,
         '-pos', args.pos
-    ] + unknown_args, desc='producing edit')
+    ] + unknown_args, desc='producing edit').decode("utf-8")
 
     dump_rewritten_output = run_cmd([
         args.swift_refactor,


### PR DESCRIPTION
Cherry-picks https://github.com/apple/swift/pull/37358 (to avoid a merge conflict) and https://github.com/apple/swift/pull/37417

-----

When adding an async alternative, add the @completionHandlerAsync
attribute to the sync function. Check for this attribute in addition to
the name check, ie. convert a call if the callee has either
@completionHandlerAsync or a name that is completion-handler-like name.

The addition of the attribute is currently gated behind the experimental
concurrency flag.

Resolves rdar://77486504