### PR TITLE
[CodeComplete] Fix crash when completing inside a result builder containing a variable initialized with `nil`

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4718,6 +4718,9 @@ bool constraints::isStandardComparisonOperator(ASTNode node) {
 Optional<std::pair<Expr *, unsigned>>
 ConstraintSystem::isArgumentExpr(Expr *expr) {
   auto *argList = getParentExpr(expr);
+  if (!argList) {
+    return None;
+  }
 
   if (isa<ParenExpr>(argList)) {
     for (;;) {

--- a/validation-test/IDE/crashers_2_fixed/rdar78017503.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar78017503.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=COMPLETE -source-filename=%s
+
+@resultBuilder
+struct TupleBuilder<T> {
+  static func buildBlock() -> () { }
+}
+
+func testPatternMatching() {
+  @TupleBuilder<String> var x3 {
+    let x: Int? = nil
+    #^COMPLETE^#
+  }
+}


### PR DESCRIPTION
There’s nothing to add to the title really.

Resolves rdar://78017503