### PR TITLE
Add a defensive nullptr check.

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2302,6 +2302,8 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
     if (kind == SpecialMethodKind::NSDictionarySubscriptGetter &&
         paramTy->isObjCIdType()) {
       swiftParamTy = SwiftContext.getNSCopyingType();
+      if (!swiftParamTy)
+        return {Type(), false};
       if (optionalityOfParam != OTK_None)
         swiftParamTy = OptionalType::get(swiftParamTy);
 


### PR DESCRIPTION
ASTContext::get##NAME##Type() can return an empty type and we have LLDB crash
logs that show this can really happen.

rdar://74503567
(cherry picked from commit 9c8f32517768a78b2e877810161483eb04a4185a)
