### PR TITLE
[5.5] Test Only - Do not load Concurrency modile in `batch_module_scan_versioned`

### DIFF
--- a/test/ScanDependencies/batch_module_scan_versioned.swift
+++ b/test/ScanDependencies/batch_module_scan_versioned.swift
@@ -14,7 +14,7 @@
 // RUN: echo "\"output\": \"%/t/outputs/G_109.pcm.json\"" >> %/t/inputs/input.json
 // RUN: echo "}]" >> %/t/inputs/input.json
 
-// RUN: %target-swift-frontend -scan-dependencies -target x86_64-apple-macosx11.0 -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -batch-scan-input-file %/t/inputs/input.json
+// RUN: %target-swift-frontend -scan-dependencies -disable-implicit-concurrency-module-import -target x86_64-apple-macosx11.0 -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -batch-scan-input-file %/t/inputs/input.json
 
 // Check the contents of the JSON output
 // RUN: %FileCheck %s -check-prefix=CHECK-PCM109 < %t/outputs/G_109.pcm.json


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/37089
---------------------------------------------------------------------
It has a specific target (`x86_64`) and on other platforms, Concurrency will not be found with this architecture by default.
e.g. Apple Silicon failure:
https://ci.swift.org/job/oss-swift-5.5-incremental-RA-macos-apple-silicon/112/consoleFull#12337284463122a513-f36a-4c87-8ed7-cbc36a1ec144
