### PR TITLE
[gardening] remove unnecessary condition in symbol extraction logic

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3160,54 +3160,49 @@ for host in "${ALL_HOSTS[@]}"; do
         # descibes
         host_symroot="${INSTALL_SYMROOT}/${host}"
 
-        # FIXME this if statement is a trick to have a more readable
-        # diff for the PR that made the following code
-        # amenable to dry run testing
-        if [ -n "${DRY_RUN}" -o -z "${DRY_RUN}" ]; then
-            set -x
+        set -x
 
-            CURRENT_INSTALL_DIR=${host_install_destdir}
-            CURRENT_PREFIX="${TOOLCHAIN_PREFIX}"
+        CURRENT_INSTALL_DIR=${host_install_destdir}
+        CURRENT_PREFIX="${TOOLCHAIN_PREFIX}"
 
-            # Copy executables and shared libraries from the `host_install_destdir` to
-            # INSTALL_SYMROOT and run dsymutil on them.
-            (cd "${CURRENT_INSTALL_DIR}" &&
-             find ./"${CURRENT_PREFIX}" -perm -0111 -type f -print | \
-             filter_paths "${DARWIN_SYMROOT_PATH_FILTERS}" | \
-             cpio --insecure -pdm -v "${host_symroot}")
+        # Copy executables and shared libraries from the `host_install_destdir` to
+        # INSTALL_SYMROOT and run dsymutil on them.
+        (cd "${CURRENT_INSTALL_DIR}" &&
+         find ./"${CURRENT_PREFIX}" -perm -0111 -type f -print | \
+         filter_paths "${DARWIN_SYMROOT_PATH_FILTERS}" | \
+         cpio --insecure -pdm -v "${host_symroot}")
 
-            dsymutil_path=
-            if [[ -n "${DARWIN_INSTALL_EXTRACT_SYMBOLS_USE_JUST_BUILT_DSYMUTIL}" ]]; then
-                dsymutil_path=$(find_just_built_local_host_llvm_tool dsymutil)
-            else
-                dsymutil_path=$(xcrun_find_tool dsymutil)
-            fi
-
-            # Run dsymutil on executables and shared libraries.
-            #
-            # Exclude shell scripts and static archives.
-            # Tweak carefully the amount of parallelism -- dsymutil can be memory intensive and
-            # as such too many instance can exhaust the memory and slow down/panic the machine
-            printJSONStartTimestamp dsymutil
-            (cd "${host_symroot}" &&
-             find ./"${CURRENT_PREFIX}" -perm -0111 -type f -not -name "*.a" -not -name "*.py" -print | \
-               xargs -n 1 -P ${DSYMUTIL_JOBS} ${dsymutil_path})
-            printJSONEndTimestamp dsymutil
-
-            # Strip executables, shared libraries and static libraries in
-            # `host_install_destdir`.
-            find "${CURRENT_INSTALL_DIR}${CURRENT_PREFIX}/" \
-              '(' -perm -0111 -or -name "*.a" ')' -type f -print | \
-              xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool strip) -S
-
-            # Codesign dylibs after strip tool
-            # rdar://45388785
-            find "${CURRENT_INSTALL_DIR}${CURRENT_PREFIX}/" \
-              '(' -name "*.dylib" ')' -type f -print | \
-              xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool codesign) -f -s -
-
-            { set +x; } 2>/dev/null
+        dsymutil_path=
+        if [[ -n "${DARWIN_INSTALL_EXTRACT_SYMBOLS_USE_JUST_BUILT_DSYMUTIL}" ]]; then
+            dsymutil_path=$(find_just_built_local_host_llvm_tool dsymutil)
+        else
+            dsymutil_path=$(xcrun_find_tool dsymutil)
         fi
+
+        # Run dsymutil on executables and shared libraries.
+        #
+        # Exclude shell scripts and static archives.
+        # Tweak carefully the amount of parallelism -- dsymutil can be memory intensive and
+        # as such too many instance can exhaust the memory and slow down/panic the machine
+        printJSONStartTimestamp dsymutil
+        (cd "${host_symroot}" &&
+         find ./"${CURRENT_PREFIX}" -perm -0111 -type f -not -name "*.a" -not -name "*.py" -print | \
+           xargs -n 1 -P ${DSYMUTIL_JOBS} ${dsymutil_path})
+        printJSONEndTimestamp dsymutil
+
+        # Strip executables, shared libraries and static libraries in
+        # `host_install_destdir`.
+        find "${CURRENT_INSTALL_DIR}${CURRENT_PREFIX}/" \
+          '(' -perm -0111 -or -name "*.a" ')' -type f -print | \
+          xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool strip) -S
+
+        # Codesign dylibs after strip tool
+        # rdar://45388785
+        find "${CURRENT_INSTALL_DIR}${CURRENT_PREFIX}/" \
+          '(' -name "*.dylib" ')' -type f -print | \
+          xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool codesign) -f -s -
+
+        { set +x; } 2>/dev/null
     fi
 done
 # Everything is 'installed', but some products may be awaiting lipo.


### PR DESCRIPTION
This was introduced to avoid indentation changes when making this logic
amenable to testing in #37120 .