### PR TITLE
[Build Script] Pass down cross compilation host targets to swift-driver build

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swiftdriver.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftdriver.py
@@ -132,6 +132,11 @@ def run_build_script_helper(action, host_target, product, args):
         helper_cmd += [
             '--lit-test-dir', lit_test_dir
         ]
+    # Pass Cross compile host info
+    if swiftpm.SwiftPM.has_cross_compile_hosts(args):
+        helper_cmd += ['--cross-compile-hosts']
+        for cross_compile_host in args.cross_compile_hosts:
+            helper_cmd += [cross_compile_host]
     if args.verbose_build:
         helper_cmd.append('--verbose')
 


### PR DESCRIPTION
Together with https://github.com/apple/swift-driver/pull/665, this will ensure that the package-build bots are correctly building a fat `swift-driver` resulting in it being usable on either an x86 or Apple Silicon machine. 