### PR TITLE
Mark executor_deinit1 unsupported on watchsimulator.

### DIFF
--- a/test/Concurrency/Runtime/executor_deinit1.swift
+++ b/test/Concurrency/Runtime/executor_deinit1.swift
@@ -10,6 +10,8 @@
 // UNSUPPORTED: linux
 // rdar://76611676
 // UNSUPPORTED: CPU=x86_64 && OS=ios
+// rdar://78039465
+// UNSUPPORTED: CPU=x86_64 && OS=watchos
 
 
 // doesn't matter that it's bool identity function or not


### PR DESCRIPTION
There's no test output. This was already marked unsupported on iOS simulator (rdar://76611676)

Fixes rdar://78039465 (release/5.5) test failure - Concurrency/Runtime/executor_deinit1.swift)
