### PR TITLE
[5.5] Disable IDE/import_as_member_objc.swift on the simulator.

### DIFF
--- a/test/IDE/import_as_member_objc.swift
+++ b/test/IDE/import_as_member_objc.swift
@@ -7,6 +7,7 @@
 
 // rdar://77916860
 // UNSUPPORTED: OS=watchos && CPU=i386
+// UNSUPPORTED: OS=ios && CPU=x86_64
 
 // PRINT-CLASS-LABEL: class SomeClass : NSObject {
 // PRINT-CLASS-NEXT:   init()


### PR DESCRIPTION
Assertion failed: (I != F.TypeRemap.end() && "Invalid index into type
index remap"), function getGlobalTypeID, file
/llvm-project/clang/lib/Serialization/ASTReader.cpp, line 7115.

Test fails on the release branch. It was already disabled on other
simulator platforms.

Piggybacking on existing rdar://77916860

