### PR TITLE
Lexicon: Split "existential" into two terms for clarity

### DIFF
--- a/docs/Lexicon.md
+++ b/docs/Lexicon.md
@@ -172,10 +172,13 @@ the same bug ("I have a dup of this"); as a verb, the act of marking a bug
 written "dupe". Pronounced the same way as the first syllable of
 "duplicate", which for most American English speakers is "doop".
 
-## existential
+## existential type
 
-A value whose type is a protocol composition (including a single protocol
-and *zero* protocols; the latter is the `Any` type).
+A type that is a protocol composition (including a single protocol and *zero* protocols; the latter is the `Any` type).
+
+## existential value
+
+A value of [existential type](#existential-type), commonly referred to simply as an "existential".
 
 ## explicit module build
 


### PR DESCRIPTION
We had a lively discussion around these terms during the review of [SE-309](https://forums.swift.org/t/se-0309-unlock-existential-types-for-all-protocols/47515), and suggestions of adding them and their Swift interpretations to user-facing official resources.
Looks like the [type spec](https://docs.swift.org/swift-book/ReferenceManual/Types.html) is not open-source; I suppose being slightly more wordy in the compiler docs will do no harm.