### PR TITLE
Clean up duplicate logic for checking if generic requirements are satisfied

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -25,6 +25,7 @@ class raw_ostream;
 
 namespace swift {
 class DeclContext;
+class ModuleDecl;
 class NominalTypeDecl;
 class SubstitutionMap;
 
@@ -33,7 +34,7 @@ class SubstitutionMap;
 bool areTypesEqual(Type type1, Type type2);
 
 /// Determine whether the given type is suitable as a concurrent value type.
-bool isSendableType(const DeclContext *dc, Type type);
+bool isSendableType(ModuleDecl *module, Type type);
 
 /// Describes the actor isolation of a given declaration, which determines
 /// the actors with which it can interact.

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -76,6 +76,21 @@ public:
 
   ProtocolDecl *getProtocolDecl() const;
 
+  /// Determines if this substituted requirement is satisfied.
+  ///
+  /// \param conditionalRequirements An out parameter initialized to an
+  /// array of requirements that the caller must check to ensure this
+  /// requirement is completely satisfied.
+  bool isSatisfied(ArrayRef<Requirement> &conditionalRequirements) const;
+
+  /// Determines if this substituted requirement can ever be satisfied,
+  /// possibly with additional substitutions.
+  ///
+  /// For example, if 'T' is unconstrained, then a superclass requirement
+  /// 'T : C' can be satisfied; however, if 'T' already has an unrelated
+  /// superclass requirement, 'T : C' cannot be satisfied.
+  bool canBeSatisfied() const;
+
   SWIFT_DEBUG_DUMP;
   void dump(raw_ostream &out) const;
   void print(raw_ostream &os, const PrintOptions &opts) const;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5269,17 +5269,9 @@ bool hasAppliedSelf(ConstraintSystem &cs, const OverloadChoice &choice);
 bool hasAppliedSelf(const OverloadChoice &choice,
                     llvm::function_ref<Type(Type)> getFixedType);
 
-/// Check whether type conforms to a given known protocol.
-bool conformsToKnownProtocol(DeclContext *dc, Type type,
-                             KnownProtocolKind protocol);
-
-/// Check whether given type conforms to `RawPepresentable` protocol
+/// Check whether given type conforms to `RawRepresentable` protocol
 /// and return witness type.
 Type isRawRepresentable(ConstraintSystem &cs, Type type);
-/// Check whether given type conforms to a specific known kind
-/// `RawPepresentable` protocol and return witness type.
-Type isRawRepresentable(ConstraintSystem &cs, Type type,
-                        KnownProtocolKind rawRepresentableProtocol);
 
 /// Compute the type that shall stand in for dynamic 'Self' in a member
 /// reference with a base of the given object type.

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -428,62 +428,28 @@ bool GenericSignatureImpl::areSameTypeParameterInContext(Type type1,
 
 bool GenericSignatureImpl::isRequirementSatisfied(
     Requirement requirement) const {
-  auto GSB = getGenericSignatureBuilder();
+  if (requirement.getFirstType()->hasTypeParameter()) {
+    auto *genericEnv = getGenericEnvironment();
 
-  auto firstType = requirement.getFirstType();
-  auto canFirstType = getCanonicalTypeInContext(firstType);
+    auto substituted = requirement.subst(
+        [&](SubstitutableType *type) -> Type {
+          if (auto *paramType = type->getAs<GenericTypeParamType>())
+            return genericEnv->mapTypeIntoContext(paramType);
 
-  switch (requirement.getKind()) {
-  case RequirementKind::Conformance: {
-    auto *protocol = requirement.getProtocolDecl();
+          return type;
+        },
+        LookUpConformanceInSignature(this));
 
-    if (canFirstType->isTypeParameter())
-      return requiresProtocol(canFirstType, protocol);
-    else
-      return (bool)GSB->lookupConformance(canFirstType, protocol);
-  }
-
-  case RequirementKind::SameType: {
-    auto canSecondType = getCanonicalTypeInContext(requirement.getSecondType());
-    return canFirstType->isEqual(canSecondType);
-  }
-
-  case RequirementKind::Superclass: {
-    auto requiredSuperclass =
-        getCanonicalTypeInContext(requirement.getSecondType());
-
-    // The requirement could be in terms of type parameters like a user-written
-    // requirement, but it could also be in terms of concrete types if it has
-    // been substituted/otherwise 'resolved', so we need to handle both.
-    auto baseType = canFirstType;
-    if (baseType->isTypeParameter()) {
-      auto directSuperclass = getSuperclassBound(baseType);
-      if (!directSuperclass)
-        return false;
-
-      baseType = getCanonicalTypeInContext(directSuperclass);
-    }
-
-    return requiredSuperclass->isExactSuperclassOf(baseType);
-  }
-
-  case RequirementKind::Layout: {
-    auto requiredLayout = requirement.getLayoutConstraint();
-
-    if (canFirstType->isTypeParameter()) {
-      if (auto layout = getLayoutConstraint(canFirstType))
-        return static_cast<bool>(layout.merge(requiredLayout));
-
+    if (!substituted)
       return false;
-    }
 
-    // The requirement is on a concrete type, so it's either globally correct
-    // or globally incorrect, independent of this generic context. The latter
-    // case should be diagnosed elsewhere, so let's assume it's correct.
-    return true;
+    requirement = *substituted;
   }
-  }
-  llvm_unreachable("unhandled kind");
+
+  // FIXME: Need to check conditional requirements here.
+  ArrayRef<Requirement> conditionalRequirements;
+
+  return requirement.isSatisfied(conditionalRequirements);
 }
 
 SmallVector<Requirement, 4> GenericSignatureImpl::requirementsNotSatisfiedBy(
@@ -494,7 +460,7 @@ SmallVector<Requirement, 4> GenericSignatureImpl::requirementsNotSatisfiedBy(
   if (otherSig.getPointer() == this) return result;
 
   // If there is no other signature, no requirements are satisfied.
-  if (!otherSig){
+  if (!otherSig) {
     const auto reqs = getRequirements();
     result.append(reqs.begin(), reqs.end());
     return result;

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2539,20 +2539,21 @@ public:
 
     // If the reference is 'async', all types must be 'Sendable'.
     if (implicitlyAsync && T) {
+      auto *M = CurrDeclContext->getParentModule();
       if (isa<VarDecl>(VD)) {
-        if (!isSendableType(CurrDeclContext, T)) {
+        if (!isSendableType(M, T)) {
           NotRecommended = NotRecommendedReason::CrossActorReference;
         }
       } else {
         assert(isa<FuncDecl>(VD) || isa<SubscriptDecl>(VD));
         // Check if the result and the param types are all 'Sendable'.
         auto *AFT = T->castTo<AnyFunctionType>();
-        if (!isSendableType(CurrDeclContext, AFT->getResult())) {
+        if (!isSendableType(M, AFT->getResult())) {
           NotRecommended = NotRecommendedReason::CrossActorReference;
         } else {
           for (auto &param : AFT->getParams()) {
             Type paramType = param.getPlainType();
-            if (!isSendableType(CurrDeclContext, paramType)) {
+            if (!isSendableType(M, paramType)) {
               NotRecommended = NotRecommendedReason::CrossActorReference;
               break;
             }

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/Requirement.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/Types.h"
 #include "swift/Sema/IDETypeChecking.h"
@@ -169,13 +170,13 @@ struct SynthesizedExtensionAnalyzer::Implementation {
     bool Unmergable;
     unsigned InheritsCount;
     std::set<Requirement> Requirements;
-    void addRequirement(GenericSignature GenericSig,
-                        Type First, Type Second, RequirementKind Kind) {
-      CanType CanFirst = GenericSig->getCanonicalTypeInContext(First);
-      CanType CanSecond;
-      if (Second) CanSecond = GenericSig->getCanonicalTypeInContext(Second);
+    void addRequirement(GenericSignature GenericSig, swift::Requirement Req) {
+      auto First = Req.getFirstType();
+      auto CanFirst = GenericSig->getCanonicalTypeInContext(First);
+      auto Second = Req.getSecondType();
+      auto CanSecond = GenericSig->getCanonicalTypeInContext(Second);
 
-      Requirements.insert({First, Second, Kind, CanFirst, CanSecond});
+      Requirements.insert({First, Second, Req.getKind(), CanFirst, CanSecond});
     }
     bool operator== (const ExtensionMergeInfo& Another) const {
       // Trivially unmergeable.
@@ -289,84 +290,53 @@ struct SynthesizedExtensionAnalyzer::Implementation {
       ProtocolDecl *BaseProto = OwningExt->getInnermostDeclContext()
         ->getSelfProtocolDecl();
       for (auto Req : Reqs) {
-        auto Kind = Req.getKind();
-
-        // FIXME: Could do something here
-        if (Kind == RequirementKind::Layout)
+        // FIXME: Don't skip layout requirements.
+        if (Req.getKind() == RequirementKind::Layout)
           continue;
-
-        Type First = Req.getFirstType();
-        Type Second = Req.getSecondType();
 
         // Skip protocol's Self : <Protocol> requirement.
         if (BaseProto &&
             Req.getKind() == RequirementKind::Conformance &&
-            First->isEqual(BaseProto->getSelfInterfaceType()) &&
-            Second->getAnyNominal() == BaseProto)
+            Req.getFirstType()->isEqual(BaseProto->getSelfInterfaceType()) &&
+            Req.getProtocolDecl() == BaseProto)
           continue;
 
         if (!BaseType->isExistentialType()) {
           // Apply any substitutions we need to map the requirements from a
           // a protocol extension to an extension on the conforming type.
-          First = First.subst(subMap);
-          Second = Second.subst(subMap);
-
-          if (First->hasError() || Second->hasError()) {
+          auto SubstReq = Req.subst(subMap);
+          if (!SubstReq) {
             // Substitution with interface type bases can only fail
             // if a concrete type fails to conform to a protocol.
             // In this case, just give up on the extension altogether.
             return true;
           }
+
+          Req = *SubstReq;
         }
 
-        assert(!First->hasArchetype() && !Second->hasArchetype());
-        switch (Kind) {
-        case RequirementKind::Conformance: {
-          auto *M = DC->getParentModule();
-          auto *Proto = Second->castTo<ProtocolType>()->getDecl();
-          if (!First->isTypeParameter() &&
-              M->conformsToProtocol(First, Proto).isInvalid())
-            return true;
-          if (M->conformsToProtocol(First, Proto).isInvalid())
-            MergeInfo.addRequirement(GenericSig, First, Second, Kind);
-          break;
-        }
+        assert(!Req.getFirstType()->hasArchetype());
+        assert(!Req.getSecondType()->hasArchetype());
 
-        case RequirementKind::Superclass:
-          // If the subject type of the requirement is still a type parameter,
-          // we need to check if the contextual type could possibly be bound to
-          // the superclass. If not, this extension isn't applicable.
-          if (First->isTypeParameter()) {
-            if (!Target->mapTypeIntoContext(First)->isBindableTo(
-                    Target->mapTypeIntoContext(Second))) {
-              return true;
-            }
-            MergeInfo.addRequirement(GenericSig, First, Second, Kind);
-            break;
-          }
+        auto *M = DC->getParentModule();
+        auto SubstReq = Req.subst(
+          [&](Type type) -> Type {
+            if (type->isTypeParameter())
+              return Target->mapTypeIntoContext(type);
 
-          // If we've substituted in a concrete type for the subject, we can
-          // check for an exact superclass match, and disregard the extension if
-          // it missed.
-          // FIXME: What if it ends being something like `C<U> : C<Int>`?
-          // Arguably we should allow that to be mirrored with a U == Int
-          // constraint.
-          if (!Second->isExactSuperclassOf(First))
+            return type;
+          },
+          LookUpConformanceInModule(M));
+        if (!SubstReq)
+          return true;
+
+        // FIXME: Need to handle conditional requirements here!
+        ArrayRef<Requirement> conditionalRequirements;
+        if (!SubstReq->isSatisfied(conditionalRequirements)) {
+          if (!SubstReq->canBeSatisfied())
             return true;
 
-          break;
-
-        case RequirementKind::SameType:
-          if (!First->isBindableTo(Second) &&
-              !Second->isBindableTo(First)) {
-            return true;
-          } else if (!First->isEqual(Second)) {
-            MergeInfo.addRequirement(GenericSig, First, Second, Kind);
-          }
-          break;
-
-        case RequirementKind::Layout:
-          llvm_unreachable("Handled above");
+          MergeInfo.addRequirement(GenericSig, Req);
         }
       }
       return false;

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -859,7 +859,8 @@ bool LiteralRequirement::isCoveredBy(Type type, DeclContext *useDC) const {
   if (hasDefaultType() && coversDefaultType(type, getDefaultType()))
     return true;
 
-  return bool(TypeChecker::conformsToProtocol(type, getProtocol(), useDC));
+  return (bool)TypeChecker::conformsToProtocol(type, getProtocol(),
+                                               useDC->getParentModule());
 }
 
 std::pair<bool, Type>

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -150,6 +150,10 @@ protected:
     return cs.DC;
   }
 
+  ModuleDecl *getParentModule() const {
+    return getDC()->getParentModule();
+  }
+
   ASTContext &getASTContext() const {
     auto &cs = getConstraintSystem();
     return cs.getASTContext();

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -411,7 +411,7 @@ namespace {
       if (otherArgTy && otherArgTy->getAnyNominal()) {
         if (otherArgTy->isEqual(paramTy) &&
             TypeChecker::conformsToProtocol(
-                otherArgTy, literalProto, CS.DC)) {
+                otherArgTy, literalProto, CS.DC->getParentModule())) {
           return true;
         }
       } else if (Type defaultType =
@@ -1737,13 +1737,15 @@ namespace {
         if (!contextualType)
           return false;
 
+        auto *M = CS.DC->getParentModule();
+
         auto type = contextualType->lookThroughAllOptionalTypes();
-        if (conformsToKnownProtocol(
-                CS.DC, type, KnownProtocolKind::ExpressibleByArrayLiteral))
+        if (TypeChecker::conformsToKnownProtocol(
+                type, KnownProtocolKind::ExpressibleByArrayLiteral, M))
           return false;
 
-        return conformsToKnownProtocol(
-            CS.DC, type, KnownProtocolKind::ExpressibleByDictionaryLiteral);
+        return TypeChecker::conformsToKnownProtocol(
+            type, KnownProtocolKind::ExpressibleByDictionaryLiteral, M);
       };
 
       if (isDictionaryContextualType(contextualType)) {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4135,31 +4135,6 @@ void ConstraintSystem::optimizeConstraints(Expr *e) {
   e->walk(optimizer);
 }
 
-bool swift::areGenericRequirementsSatisfied(
-    const DeclContext *DC, GenericSignature sig,
-    SubstitutionMap Substitutions, bool isExtension) {
-
-  ConstraintSystemOptions Options;
-  ConstraintSystem CS(const_cast<DeclContext *>(DC), Options);
-  auto Loc = CS.getConstraintLocator({});
-
-  // For every requirement, add a constraint.
-  for (auto Req : sig->getRequirements()) {
-    if (auto resolved = Req.subst(
-          QuerySubstitutionMap{Substitutions},
-          LookUpConformanceInModule(DC->getParentModule()))) {
-      CS.addConstraint(*resolved, Loc);
-    } else if (isExtension) {
-      return false;
-    }
-    // Unresolved requirements are requirements of the function itself. This
-    // does not prevent it from being applied. E.g. func foo<T: Sequence>(x: T).
-  }
-
-  // Having a solution implies the requirements have been fulfilled.
-  return CS.solveSingle().hasValue();
-}
-
 struct ResolvedMemberResult::Implementation {
   llvm::SmallVector<ValueDecl*, 4> AllDecls;
   unsigned ViableStartIdx;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1890,7 +1890,7 @@ void DisjunctionChoiceProducer::partitionGenericOperators(
       return refined->inheritsFrom(protocol);
 
     return (bool)TypeChecker::conformsToProtocol(nominal->getDeclaredType(), protocol,
-                                                 nominal->getDeclContext());
+                                                 CS.DC->getParentModule());
   };
 
   // Gather Numeric and Sequence overloads into separate buckets.
@@ -1938,15 +1938,18 @@ void DisjunctionChoiceProducer::partitionGenericOperators(
     if (argType->isTypeVariableOrMember())
       continue;
 
-    if (conformsToKnownProtocol(CS.DC, argType,
-                                KnownProtocolKind::AdditiveArithmetic)) {
+    if (TypeChecker::conformsToKnownProtocol(
+            argType, KnownProtocolKind::AdditiveArithmetic,
+            CS.DC->getParentModule())) {
       first =
           std::copy(numericOverloads.begin(), numericOverloads.end(), first);
       numericOverloads.clear();
       break;
     }
 
-    if (conformsToKnownProtocol(CS.DC, argType, KnownProtocolKind::Sequence)) {
+    if (TypeChecker::conformsToKnownProtocol(
+            argType, KnownProtocolKind::Sequence,
+            CS.DC->getParentModule())) {
       first =
           std::copy(sequenceOverloads.begin(), sequenceOverloads.end(), first);
       sequenceOverloads.clear();

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -578,7 +578,9 @@ bool IsDeclRefinementOfRequest::evaluate(Evaluator &evaluator,
     return false;
 
   auto result = TypeChecker::checkGenericArguments(
-      genericSignatureB, QueryTypeSubstitutionMap{ substMap });
+      declA->getDeclContext()->getParentModule(),
+      genericSignatureB->getRequirements(),
+      QueryTypeSubstitutionMap{ substMap });
 
   if (result != RequirementCheckResult::Success)
     return false;
@@ -678,7 +680,8 @@ bool DisjunctionStep::shouldSkip(const DisjunctionChoice &choice) const {
           continue;
 
         for (auto *protocol : signature->getRequiredProtocols(paramType)) {
-          if (!TypeChecker::conformsToProtocol(argType, protocol, useDC))
+          if (!TypeChecker::conformsToProtocol(argType, protocol,
+                                               useDC->getParentModule()))
             return skip("unsatisfied");
         }
       }

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -538,8 +538,8 @@ StepResult DisjunctionStep::resume(bool prevFailed) {
 }
 
 bool IsDeclRefinementOfRequest::evaluate(Evaluator &evaluator,
-                                          ValueDecl *declA,
-                                          ValueDecl *declB) const {
+                                         ValueDecl *declA,
+                                         ValueDecl *declB) const {
   auto *typeA = declA->getInterfaceType()->getAs<GenericFunctionType>();
   auto *typeB = declB->getInterfaceType()->getAs<GenericFunctionType>();
 
@@ -578,10 +578,7 @@ bool IsDeclRefinementOfRequest::evaluate(Evaluator &evaluator,
     return false;
 
   auto result = TypeChecker::checkGenericArguments(
-      declA->getDeclContext(), SourceLoc(), SourceLoc(), typeB,
-      genericSignatureB->getGenericParams(),
-      genericSignatureB->getRequirements(),
-      QueryTypeSubstitutionMap{ substMap });
+      genericSignatureB, QueryTypeSubstitutionMap{ substMap });
 
   if (result != RequirementCheckResult::Success)
     return false;

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -745,7 +745,8 @@ createDesignatedInitOverride(ClassDecl *classDecl,
     // satisfied by the derived class. In this case, we don't want to inherit
     // this initializer; there's no way to call it on the derived class.
     auto checkResult = TypeChecker::checkGenericArguments(
-        superclassCtorSig,
+        classDecl->getParentModule(),
+        superclassCtorSig->getRequirements(),
         [&](Type type) -> Type {
           auto substType = type.subst(overrideInfo.OverrideSubMap);
           return GenericEnvironment::mapTypeIntoContext(

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -745,9 +745,7 @@ createDesignatedInitOverride(ClassDecl *classDecl,
     // satisfied by the derived class. In this case, we don't want to inherit
     // this initializer; there's no way to call it on the derived class.
     auto checkResult = TypeChecker::checkGenericArguments(
-        superclassCtor, SourceLoc(), SourceLoc(), Type(),
-        superclassCtorSig->getGenericParams(),
-        superclassCtorSig->getRequirements(),
+        superclassCtorSig,
         [&](Type type) -> Type {
           auto substType = type.subst(overrideInfo.OverrideSubMap);
           return GenericEnvironment::mapTypeIntoContext(

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4347,14 +4347,6 @@ bool constraints::hasAppliedSelf(const OverloadChoice &choice,
          doesMemberRefApplyCurriedSelf(baseType, decl);
 }
 
-bool constraints::conformsToKnownProtocol(DeclContext *dc, Type type,
-                                          KnownProtocolKind protocol) {
-  if (auto *proto =
-          TypeChecker::getProtocol(dc->getASTContext(), SourceLoc(), protocol))
-    return (bool)TypeChecker::conformsToProtocol(type, proto, dc);
-  return false;
-}
-
 /// Check whether given type conforms to `RawPepresentable` protocol
 /// and return the witness type.
 Type constraints::isRawRepresentable(ConstraintSystem &cs, Type type) {
@@ -4365,22 +4357,12 @@ Type constraints::isRawRepresentable(ConstraintSystem &cs, Type type) {
   if (!rawReprType)
     return Type();
 
-  auto conformance = TypeChecker::conformsToProtocol(type, rawReprType, DC);
+  auto conformance = TypeChecker::conformsToProtocol(type, rawReprType,
+                                                     DC->getParentModule());
   if (conformance.isInvalid())
     return Type();
 
   return conformance.getTypeWitnessByName(type, cs.getASTContext().Id_RawValue);
-}
-
-Type constraints::isRawRepresentable(
-    ConstraintSystem &cs, Type type,
-    KnownProtocolKind rawRepresentableProtocol) {
-  Type rawTy = isRawRepresentable(cs, type);
-  if (!rawTy ||
-      !conformsToKnownProtocol(cs.DC, rawTy, rawRepresentableProtocol))
-    return Type();
-
-  return rawTy;
 }
 
 void ConstraintSystem::generateConstraints(

--- a/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
+++ b/lib/Sema/DerivedConformanceAdditiveArithmetic.cpp
@@ -77,7 +77,8 @@ bool DerivedConformance::canDeriveAdditiveArithmetic(NominalTypeDecl *nominal,
     if (v->getInterfaceType()->hasError())
       return false;
     auto varType = DC->mapTypeIntoContext(v->getValueInterfaceType());
-    return (bool)TypeChecker::conformsToProtocol(varType, proto, DC);
+    return (bool)TypeChecker::conformsToProtocol(varType, proto,
+                                                 DC->getParentModule());
   });
 }
 

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -249,7 +249,7 @@ static EnumDecl *validateCodingKeysType(const DerivedConformance &derived,
   // Ensure that the type we found conforms to the CodingKey protocol.
   auto *codingKeyProto = C.getProtocol(KnownProtocolKind::CodingKey);
   if (!TypeChecker::conformsToProtocol(codingKeysType, codingKeyProto,
-                                       derived.getConformanceContext())) {
+                                       derived.getParentModule())) {
     // If CodingKeys is a typealias which doesn't point to a valid nominal type,
     // codingKeysTypeDecl will be nullptr here. In that case, we need to warn on
     // the location of the usage, since there isn't an underlying type to
@@ -308,7 +308,7 @@ static bool validateCodingKeysEnum(const DerivedConformance &derived,
     auto target = derived.getConformanceContext()->mapTypeIntoContext(
          it->second->getValueInterfaceType());
     if (TypeChecker::conformsToProtocol(target, derived.Protocol,
-                                        derived.getConformanceContext())
+                                        derived.getParentModule())
             .isInvalid()) {
       TypeLoc typeLoc = {
           it->second->getTypeReprOrParentPatternTypeRepr(),
@@ -1828,7 +1828,8 @@ static bool canSynthesize(DerivedConformance &derived, ValueDecl *requirement) {
     if (auto *superclassDecl = classDecl->getSuperclassDecl()) {
       DeclName memberName;
       auto superType = superclassDecl->getDeclaredInterfaceType();
-      if (TypeChecker::conformsToProtocol(superType, proto, superclassDecl)) {
+      if (TypeChecker::conformsToProtocol(superType, proto,
+                                          derived.getParentModule())) {
         // super.init(from:) must be accessible.
         memberName = cast<ConstructorDecl>(requirement)->getName();
       } else {

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -864,17 +864,16 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
 
   // We can't form a Hashable conformance if Int isn't Hashable or
   // ExpressibleByIntegerLiteral.
-  if (TypeChecker::conformsToProtocol(
-          intType, C.getProtocol(KnownProtocolKind::Hashable), parentDC)
-          .isInvalid()) {
+  if (!TypeChecker::conformsToKnownProtocol(
+          intType, KnownProtocolKind::Hashable,
+          derived.getParentModule())) {
     derived.ConformanceDecl->diagnose(diag::broken_int_hashable_conformance);
     return nullptr;
   }
 
-  ProtocolDecl *intLiteralProto =
-      C.getProtocol(KnownProtocolKind::ExpressibleByIntegerLiteral);
-  if (TypeChecker::conformsToProtocol(intType, intLiteralProto, parentDC)
-          .isInvalid()) {
+  if (!TypeChecker::conformsToKnownProtocol(
+          intType, KnownProtocolKind::ExpressibleByIntegerLiteral,
+          derived.getParentModule())) {
     derived.ConformanceDecl->diagnose(
       diag::broken_int_integer_literal_convertible_conformance);
     return nullptr;

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -403,12 +403,9 @@ deriveRawRepresentable_init(DerivedConformance &derived) {
 
 
   assert([&]() -> bool {
-    auto equatableProto = TypeChecker::getProtocol(C, enumDecl->getLoc(),
-                                                   KnownProtocolKind::Equatable);
-    if (!equatableProto) {
-      return false;
-    }
-    return !TypeChecker::conformsToProtocol(rawType, equatableProto, enumDecl).isInvalid();
+    return TypeChecker::conformsToKnownProtocol(
+        rawType, KnownProtocolKind::Equatable,
+        derived.getParentModule());
   }());
 
   auto *rawDecl = new (C)
@@ -464,14 +461,8 @@ bool DerivedConformance::canDeriveRawRepresentable(DeclContext *DC,
 
   // The raw type must be Equatable, so that we have a suitable ~= for
   // synthesized switch statements.
-  auto equatableProto =
-      TypeChecker::getProtocol(enumDecl->getASTContext(), enumDecl->getLoc(),
-                               KnownProtocolKind::Equatable);
-  if (!equatableProto)
-    return false;
-
-  if (TypeChecker::conformsToProtocol(rawType, equatableProto, DC)
-          .isInvalid())
+  if (!TypeChecker::conformsToKnownProtocol(rawType, KnownProtocolKind::Equatable,
+                                            DC->getParentModule()))
     return false;
 
   auto &C = type->getASTContext();

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -40,6 +40,10 @@ DeclContext *DerivedConformance::getConformanceContext() const {
   return cast<DeclContext>(ConformanceDecl);
 }
 
+ModuleDecl *DerivedConformance::getParentModule() const {
+  return cast<DeclContext>(ConformanceDecl)->getParentModule();
+}
+
 void DerivedConformance::addMembersToConformanceContext(
     ArrayRef<Decl *> children) {
   auto IDC = cast<IterableDeclContext>(ConformanceDecl);
@@ -162,7 +166,7 @@ DerivedConformance::storedPropertiesNotConformingToProtocol(
       nonconformingProperties.push_back(propertyDecl);
 
     if (!TypeChecker::conformsToProtocol(DC->mapTypeIntoContext(type), protocol,
-                                         DC)) {
+                                         DC->getParentModule())) {
       nonconformingProperties.push_back(propertyDecl);
     }
   }
@@ -715,8 +719,8 @@ DeclRefExpr *DerivedConformance::convertEnumToIndex(SmallVectorImpl<ASTNode> &st
 /// \p protocol The protocol being requested.
 /// \return The ParamDecl of each associated value whose type does not conform.
 SmallVector<ParamDecl *, 4>
-DerivedConformance::associatedValuesNotConformingToProtocol(DeclContext *DC, EnumDecl *theEnum,
-                                        ProtocolDecl *protocol) {
+DerivedConformance::associatedValuesNotConformingToProtocol(
+    DeclContext *DC, EnumDecl *theEnum, ProtocolDecl *protocol) {
   SmallVector<ParamDecl *, 4> nonconformingAssociatedValues;
   for (auto elt : theEnum->getAllElements()) {
     auto PL = elt->getParameterList();
@@ -726,7 +730,7 @@ DerivedConformance::associatedValuesNotConformingToProtocol(DeclContext *DC, Enu
     for (auto param : *PL) {
       auto type = param->getInterfaceType();
       if (TypeChecker::conformsToProtocol(DC->mapTypeIntoContext(type),
-                                          protocol, DC)
+                                          protocol, DC->getParentModule())
               .isInvalid()) {
         nonconformingAssociatedValues.push_back(param);
       }

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -62,6 +62,9 @@ public:
   /// nominal type, or an extension of it) as a \c DeclContext.
   DeclContext *getConformanceContext() const;
 
+  /// Retrieve the module in which the conformance is declared.
+  ModuleDecl *getParentModule() const;
+
   /// Add \c children as members of the context that declares the conformance.
   void addMembersToConformanceContext(ArrayRef<Decl *> children);
 

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -131,11 +131,12 @@ static bool isExtensionAppliedInternal(const DeclContext *DC, Type BaseTy,
     return true;
 
   GenericSignature genericSig = ED->getGenericSignature();
+  auto *module = DC->getParentModule();
   SubstitutionMap substMap = BaseTy->getContextSubstitutionMap(
-      DC->getParentModule(), ED->getExtendedNominal());
+      module, ED->getExtendedNominal());
   return TypeChecker::checkGenericArguments(
-      genericSig, QuerySubstitutionMap{substMap})
-      == RequirementCheckResult::Success;
+      module, genericSig->getRequirements(),
+      QuerySubstitutionMap{substMap}) == RequirementCheckResult::Success;
 }
 
 static bool isMemberDeclAppliedInternal(const DeclContext *DC, Type BaseTy,
@@ -156,14 +157,15 @@ static bool isMemberDeclAppliedInternal(const DeclContext *DC, Type BaseTy,
   if (!genericSig)
     return true;
 
+  auto *module = DC->getParentModule();
   SubstitutionMap substMap = BaseTy->getContextSubstitutionMap(
-      DC->getParentModule(), VD->getDeclContext());
+      module, VD->getDeclContext());
 
   // Note: we treat substitution failure as success, to avoid tripping
   // up over generic parameters introduced by the declaration itself.
   return TypeChecker::checkGenericArguments(
-      genericSig, QuerySubstitutionMap{substMap})
-      != RequirementCheckResult::Failure;
+      module, genericSig->getRequirements(),
+      QuerySubstitutionMap{substMap}) != RequirementCheckResult::Failure;
 }
 
 bool

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4561,12 +4561,12 @@ static void diagnoseComparisonWithNaN(const Expr *E, const DeclContext *DC) {
       auto secondArg = BE->getArg()->getElement(1);
 
       // Both arguments must conform to FloatingPoint protocol.
-      if (!conformsToKnownProtocol(const_cast<DeclContext *>(DC),
-                                   firstArg->getType(),
-                                   KnownProtocolKind::FloatingPoint) ||
-          !conformsToKnownProtocol(const_cast<DeclContext *>(DC),
-                                   secondArg->getType(),
-                                   KnownProtocolKind::FloatingPoint)) {
+      if (!TypeChecker::conformsToKnownProtocol(firstArg->getType(),
+                                                KnownProtocolKind::FloatingPoint,
+                                                DC->getParentModule()) ||
+          !TypeChecker::conformsToKnownProtocol(secondArg->getType(),
+                                                KnownProtocolKind::FloatingPoint,
+                                                DC->getParentModule())) {
         return;
       }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1229,9 +1229,9 @@ void TypeChecker::checkDeclAttributes(Decl *D) {
 /// @dynamicCallable attribute requirement. The method is given to be defined
 /// as one of the following: `dynamicallyCall(withArguments:)` or
 /// `dynamicallyCall(withKeywordArguments:)`.
-bool swift::isValidDynamicCallableMethod(FuncDecl *decl, DeclContext *DC,
+bool swift::isValidDynamicCallableMethod(FuncDecl *decl, ModuleDecl *module,
                                          bool hasKeywordArguments) {
-  auto &ctx = decl->getASTContext();
+  auto &ctx = module->getASTContext();
   // There are two cases to check.
   // 1. `dynamicallyCall(withArguments:)`.
   //    In this case, the method is valid if the argument has type `A` where
@@ -1252,7 +1252,7 @@ bool swift::isValidDynamicCallableMethod(FuncDecl *decl, DeclContext *DC,
   if (!hasKeywordArguments) {
     auto arrayLitProto =
       ctx.getProtocol(KnownProtocolKind::ExpressibleByArrayLiteral);
-    return (bool)TypeChecker::conformsToProtocol(argType, arrayLitProto, DC);
+    return (bool)TypeChecker::conformsToProtocol(argType, arrayLitProto, module);
   }
   // If keyword arguments, check that argument type conforms to
   // `ExpressibleByDictionaryLiteral` and that the `Key` associated type
@@ -1261,11 +1261,11 @@ bool swift::isValidDynamicCallableMethod(FuncDecl *decl, DeclContext *DC,
     ctx.getProtocol(KnownProtocolKind::ExpressibleByStringLiteral);
   auto dictLitProto =
     ctx.getProtocol(KnownProtocolKind::ExpressibleByDictionaryLiteral);
-  auto dictConf = TypeChecker::conformsToProtocol(argType, dictLitProto, DC);
+  auto dictConf = TypeChecker::conformsToProtocol(argType, dictLitProto, module);
   if (dictConf.isInvalid())
     return false;
   auto keyType = dictConf.getTypeWitnessByName(argType, ctx.Id_Key);
-  return (bool)TypeChecker::conformsToProtocol(keyType, stringLitProtocol, DC);
+  return (bool)TypeChecker::conformsToProtocol(keyType, stringLitProtocol, module);
 }
 
 /// Returns true if the given nominal type has a valid implementation of a
@@ -1280,9 +1280,10 @@ static bool hasValidDynamicCallableMethod(NominalTypeDecl *decl,
   if (candidates.empty()) return false;
 
   // Filter valid candidates.
+  auto *module = decl->getParentModule();
   candidates.filter([&](LookupResultEntry entry, bool isOuter) {
     auto candidate = cast<FuncDecl>(entry.getValueDecl());
-    return isValidDynamicCallableMethod(candidate, decl, hasKeywordArgs);
+    return isValidDynamicCallableMethod(candidate, module, hasKeywordArgs);
   });
 
   // If there are no valid candidates, return false.
@@ -1331,17 +1332,17 @@ static bool hasSingleNonVariadicParam(SubscriptDecl *decl,
 /// the `subscript(dynamicMember:)` requirement for @dynamicMemberLookup.
 /// The method is given to be defined as `subscript(dynamicMember:)`.
 bool swift::isValidDynamicMemberLookupSubscript(SubscriptDecl *decl,
-                                                DeclContext *DC,
+                                                ModuleDecl *module,
                                                 bool ignoreLabel) {
   // It could be
   // - `subscript(dynamicMember: {Writable}KeyPath<...>)`; or
   // - `subscript(dynamicMember: String*)`
   return isValidKeyPathDynamicMemberLookup(decl, ignoreLabel) ||
-         isValidStringDynamicMemberLookup(decl, DC, ignoreLabel);
+         isValidStringDynamicMemberLookup(decl, module, ignoreLabel);
 }
 
 bool swift::isValidStringDynamicMemberLookup(SubscriptDecl *decl,
-                                             DeclContext *DC,
+                                             ModuleDecl *module,
                                              bool ignoreLabel) {
   auto &ctx = decl->getASTContext();
   // There are two requirements:
@@ -1354,11 +1355,9 @@ bool swift::isValidStringDynamicMemberLookup(SubscriptDecl *decl,
   const auto *param = decl->getIndices()->get(0);
   auto paramType = param->getType();
 
-  auto stringLitProto =
-    ctx.getProtocol(KnownProtocolKind::ExpressibleByStringLiteral);
-
   // If this is `subscript(dynamicMember: String*)`
-  return (bool)TypeChecker::conformsToProtocol(paramType, stringLitProto, DC);
+  return TypeChecker::conformsToKnownProtocol(
+      paramType, KnownProtocolKind::ExpressibleByStringLiteral, module);
 }
 
 bool swift::isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl,
@@ -1389,6 +1388,8 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
   auto type = decl->getDeclaredType();
   auto &ctx = decl->getASTContext();
 
+  auto *module = decl->getParentModule();
+
   auto emitInvalidTypeDiagnostic = [&](const SourceLoc loc) {
     diagnose(loc, diag::invalid_dynamic_member_lookup_type, type);
     attr->setInvalid();
@@ -1404,7 +1405,7 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
     auto oneCandidate = candidates.front().getValueDecl();
     candidates.filter([&](LookupResultEntry entry, bool isOuter) -> bool {
       auto cand = cast<SubscriptDecl>(entry.getValueDecl());
-      return isValidDynamicMemberLookupSubscript(cand, decl);
+      return isValidDynamicMemberLookupSubscript(cand, module);
     });
 
     if (candidates.empty()) {
@@ -1426,7 +1427,7 @@ visitDynamicMemberLookupAttr(DynamicMemberLookupAttr *attr) {
   // Validate the candidates while ignoring the label.
   newCandidates.filter([&](const LookupResultEntry entry, bool isOuter) {
     auto cand = cast<SubscriptDecl>(entry.getValueDecl());
-    return isValidDynamicMemberLookupSubscript(cand, decl,
+    return isValidDynamicMemberLookupSubscript(cand, module,
                                                /*ignoreLabel*/ true);
   });
 
@@ -1800,8 +1801,9 @@ void AttributeChecker::checkApplicationMainAttribute(DeclAttribute *attr,
   }
 
   if (!ApplicationDelegateProto ||
-      !TypeChecker::conformsToProtocol(CD->getDeclaredType(),
-                                       ApplicationDelegateProto, CD)) {
+      !TypeChecker::conformsToProtocol(CD->getDeclaredInterfaceType(),
+                                       ApplicationDelegateProto,
+                                       CD->getParentModule())) {
     diagnose(attr->getLocation(),
              diag::attr_ApplicationMain_not_ApplicationDelegate,
              applicationMainKind);
@@ -2721,9 +2723,10 @@ bool
 TypeEraserHasViableInitRequest::evaluate(Evaluator &evaluator,
                                          TypeEraserAttr *attr,
                                          ProtocolDecl *protocol) const {
-  auto &ctx = protocol->getASTContext();
-  auto &diags = ctx.Diags;
   DeclContext *dc = protocol->getDeclContext();
+  ModuleDecl *module = dc->getParentModule();
+  auto &ctx = module->getASTContext();
+  auto &diags = ctx.Diags;
   Type protocolType = protocol->getDeclaredInterfaceType();
 
   // Get the NominalTypeDecl for the type eraser.
@@ -2751,7 +2754,7 @@ TypeEraserHasViableInitRequest::evaluate(Evaluator &evaluator,
   }
 
   // The type eraser must conform to the annotated protocol
-  if (!TypeChecker::conformsToProtocol(typeEraser, protocol, dc)) {
+  if (!TypeChecker::conformsToProtocol(typeEraser, protocol, module)) {
     diags.diagnose(attr->getLoc(), diag::type_eraser_does_not_conform,
                    typeEraser, protocolType);
     diags.diagnose(nominalTypeDecl->getLoc(), diag::type_eraser_declared_here);
@@ -2794,14 +2797,15 @@ TypeEraserHasViableInitRequest::evaluate(Evaluator &evaluator,
     // type conforming to the annotated protocol. We will check this by
     // substituting the protocol's Self type for the generic arg and check that
     // the requirements in the generic signature are satisfied.
+    auto *module = nominalTypeDecl->getParentModule();
     auto baseMap =
-        typeEraser->getContextSubstitutionMap(nominalTypeDecl->getParentModule(),
+        typeEraser->getContextSubstitutionMap(module,
                                               nominalTypeDecl);
     QuerySubstitutionMap getSubstitution{baseMap};
 
     // Use invalid 'SourceLoc's to suppress diagnostics.
     auto result = TypeChecker::checkGenericArguments(
-          genericSignature,
+          module, genericSignature->getRequirements(),
           [&](SubstitutableType *type) -> Type {
             if (type->isEqual(genericParamType))
               return protocol->getSelfTypeInContext();
@@ -3542,12 +3546,12 @@ SpecializeAttrTargetDeclRequest::evaluate(Evaluator &evaluator,
 /// Returns true if the given type conforms to `Differentiable` in the given
 /// context. If `tangentVectorEqualsSelf` is true, also check whether the given
 /// type satisfies `TangentVector == Self`.
-static bool conformsToDifferentiable(Type type, DeclContext *DC,
+static bool conformsToDifferentiable(Type type, ModuleDecl *module,
                                      bool tangentVectorEqualsSelf = false) {
-  auto &ctx = type->getASTContext();
+  auto &ctx = module->getASTContext();
   auto *differentiableProto =
       ctx.getProtocol(KnownProtocolKind::Differentiable);
-  auto conf = TypeChecker::conformsToProtocol(type, differentiableProto, DC);
+  auto conf = TypeChecker::conformsToProtocol(type, differentiableProto, module);
   if (conf.isInvalid())
     return false;
   if (!tangentVectorEqualsSelf)
@@ -3558,7 +3562,8 @@ static bool conformsToDifferentiable(Type type, DeclContext *DC,
 
 IndexSubset *TypeChecker::inferDifferentiabilityParameters(
     AbstractFunctionDecl *AFD, GenericEnvironment *derivativeGenEnv) {
-  auto &ctx = AFD->getASTContext();
+  auto *module = AFD->getParentModule();
+  auto &ctx = module->getASTContext();
   auto *functionType = AFD->getInterfaceType()->castTo<AnyFunctionType>();
   auto numUncurriedParams = functionType->getNumParams();
   if (auto *resultFnType =
@@ -3581,7 +3586,7 @@ IndexSubset *TypeChecker::inferDifferentiabilityParameters(
     if (paramType->isExistentialType())
       return false;
     // Return true if the type conforms to `Differentiable`.
-    return conformsToDifferentiable(paramType, AFD);
+    return conformsToDifferentiable(paramType, module);
   };
 
   // Get all parameter types.
@@ -3614,7 +3619,8 @@ static IndexSubset *computeDifferentiabilityParameters(
     ArrayRef<ParsedAutoDiffParameter> parsedDiffParams,
     AbstractFunctionDecl *function, GenericEnvironment *derivativeGenEnv,
     StringRef attrName, SourceLoc attrLoc) {
-  auto &ctx = function->getASTContext();
+  auto *module = function->getParentModule();
+  auto &ctx = module->getASTContext();
   auto &diags = ctx.Diags;
 
   // Get function type and parameters.
@@ -3641,7 +3647,7 @@ static IndexSubset *computeDifferentiabilityParameters(
         selfType = derivativeGenEnv->mapTypeIntoContext(selfType);
       else
         selfType = function->mapTypeIntoContext(selfType);
-      if (!conformsToDifferentiable(selfType, function)) {
+      if (!conformsToDifferentiable(selfType, module)) {
         diags
             .diagnose(attrLoc, diag::diff_function_no_parameters,
                       function->getName())
@@ -5134,7 +5140,7 @@ static bool checkLinearityParameters(
     SmallVector<AnyFunctionType::Param, 4> linearParams,
     GenericEnvironment *derivativeGenEnv, ModuleDecl *module,
     ArrayRef<ParsedAutoDiffParameter> parsedLinearParams, SourceLoc attrLoc) {
-  auto &ctx = originalAFD->getASTContext();
+  auto &ctx = module->getASTContext();
   auto &diags = ctx.Diags;
 
   // Check that linearity parameters have allowed types.
@@ -5150,7 +5156,7 @@ static bool checkLinearityParameters(
         parsedLinearParams.empty() ? attrLoc : parsedLinearParams[i].getLoc();
     // Parameter must conform to `Differentiable` and satisfy
     // `Self == Self.TangentVector`.
-    if (!conformsToDifferentiable(linearParamType, originalAFD,
+    if (!conformsToDifferentiable(linearParamType, module,
                                   /*tangentVectorEqualsSelf*/ true)) {
       diags.diagnose(loc,
                      diag::transpose_attr_invalid_linearity_parameter_or_result,
@@ -5197,6 +5203,7 @@ doTransposeStaticAndInstanceSelfTypesMatch(AnyFunctionType *transposeType,
 
 void AttributeChecker::visitTransposeAttr(TransposeAttr *attr) {
   auto *transpose = cast<FuncDecl>(D);
+  auto *module = transpose->getParentModule();
   auto originalName = attr->getOriginalFunctionName();
   auto *transposeInterfaceType =
       transpose->getInterfaceType()->castTo<AnyFunctionType>();
@@ -5262,7 +5269,7 @@ void AttributeChecker::visitTransposeAttr(TransposeAttr *attr) {
   if (expectedOriginalResultType->hasTypeParameter())
     expectedOriginalResultType = transpose->mapTypeIntoContext(
         expectedOriginalResultType);
-  if (!conformsToDifferentiable(expectedOriginalResultType, transpose,
+  if (!conformsToDifferentiable(expectedOriginalResultType, module,
                                 /*tangentVectorEqualsSelf*/ true)) {
     diagnoseAndRemoveAttr(
         attr, diag::transpose_attr_invalid_linearity_parameter_or_result,

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -198,7 +198,7 @@ bool contextUsesConcurrencyFeatures(const DeclContext *dc);
 /// domain, including the substitutions so that (e.g.) we can consider the
 /// specific types at the use site.
 ///
-/// \param dc The declaration context from which the reference occurs. This is
+/// \param module The module from which the reference occurs. This is
 /// used to perform lookup of conformances to the \c Sendable protocol.
 ///
 /// \param loc The location at which the reference occurs, which will be
@@ -209,7 +209,7 @@ bool contextUsesConcurrencyFeatures(const DeclContext *dc);
 ///
 /// \returns true if an problem was detected, false otherwise.
 bool diagnoseNonConcurrentTypesInReference(
-    ConcreteDeclRef declRef, const DeclContext *dc, SourceLoc loc,
+    ConcreteDeclRef declRef, ModuleDecl *module, SourceLoc loc,
     ConcurrentReferenceKind refKind,
     DiagnosticBehavior behavior = DiagnosticBehavior::Unspecified);
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1325,6 +1325,8 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   Type origFromType = fromType;
   Type origToType = toType;
 
+  auto *module = dc->getParentModule();
+
   auto &diags = dc->getASTContext().Diags;
   bool optionalToOptionalCast = false;
 
@@ -1713,7 +1715,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
     //
     if (auto *protocolDecl =
           dyn_cast_or_null<ProtocolDecl>(fromType->getAnyNominal())) {
-      if (!couldDynamicallyConformToProtocol(toType, protocolDecl, dc)) {
+      if (!couldDynamicallyConformToProtocol(toType, protocolDecl, module)) {
         return failed();
       }
     } else if (auto protocolComposition =
@@ -1723,7 +1725,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
                          if (auto protocolDecl = dyn_cast_or_null<ProtocolDecl>(
                                  protocolType->getAnyNominal())) {
                            return !couldDynamicallyConformToProtocol(
-                               toType, protocolDecl, dc);
+                               toType, protocolDecl, module);
                          }
                          return false;
                        })) {
@@ -1819,7 +1821,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
     auto nsErrorTy = Context.getNSErrorType();
 
     if (auto errorTypeProto = Context.getProtocol(KnownProtocolKind::Error)) {
-      if (!conformsToProtocol(toType, errorTypeProto, dc).isInvalid()) {
+      if (conformsToProtocol(toType, errorTypeProto, module)) {
         if (nsErrorTy) {
           if (isSubtypeOf(fromType, nsErrorTy, dc)
               // Don't mask "always true" warnings if NSError is cast to
@@ -1829,7 +1831,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
         }
       }
 
-      if (!conformsToProtocol(fromType, errorTypeProto, dc).isInvalid()) {
+      if (conformsToProtocol(fromType, errorTypeProto, module)) {
         // Cast of an error-conforming type to NSError or NSObject.
         if ((nsObject && toType->isEqual(nsObject)) ||
              (nsErrorTy && toType->isEqual(nsErrorTy)))

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -216,7 +216,7 @@ void ParentConditionalConformance::diagnoseConformanceStack(
     ArrayRef<ParentConditionalConformance> conformances) {
   for (auto history : llvm::reverse(conformances)) {
     diags.diagnose(loc, diag::requirement_implied_by_conditional_conformance,
-                   history.ConformingType, history.Protocol);
+                   history.ConformingType, history.Protocol->getDeclaredInterfaceType());
   }
 }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1102,13 +1102,13 @@ swift::computeAutomaticEnumValueKind(EnumDecl *ED) {
   
   if (ED->getGenericEnvironmentOfContext() != nullptr)
     rawTy = ED->mapTypeIntoContext(rawTy);
-  
+
+  auto *module = ED->getParentModule();
+
   // Swift enums require that the raw type is convertible from one of the
   // primitive literal protocols.
   auto conformsToProtocol = [&](KnownProtocolKind protoKind) {
-    ProtocolDecl *proto = ED->getASTContext().getProtocol(protoKind);
-    return proto &&
-        TypeChecker::conformsToProtocol(rawTy, proto, ED->getDeclContext());
+    return TypeChecker::conformsToKnownProtocol(rawTy, protoKind, module);
   };
 
   static auto otherLiteralProtocolKinds = {

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -407,8 +407,8 @@ static bool checkObjCActorIsolation(const ValueDecl *VD,
   case ActorIsolationRestriction::CrossActorSelf:
     // FIXME: Substitution map?
     diagnoseNonConcurrentTypesInReference(
-        const_cast<ValueDecl *>(VD), VD->getDeclContext(), VD->getLoc(),
-        ConcurrentReferenceKind::CrossActor, behavior);
+        const_cast<ValueDecl *>(VD), VD->getDeclContext()->getParentModule(),
+        VD->getLoc(), ConcurrentReferenceKind::CrossActor, behavior);
     return false;
   case ActorIsolationRestriction::ActorSelf:
     // Actor-isolated functions cannot be @objc.

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -871,15 +871,15 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
 }
 
 RequirementCheckResult
-TypeChecker::checkGenericArguments(GenericSignature sig,
+TypeChecker::checkGenericArguments(ModuleDecl *module,
+                                   ArrayRef<Requirement> requirements,
                                    TypeSubstitutionFn substitutions) {
   SmallVector<Requirement, 4> worklist;
   bool valid = true;
 
-  for (auto req : sig->getRequirements()) {
-    if (auto resolved = req.subst(
-          substitutions,
-          LookUpConformanceInSignature(sig.getPointer()))) {
+  for (auto req : requirements) {
+    if (auto resolved = req.subst(substitutions,
+                                  LookUpConformanceInModule(module))) {
       worklist.push_back(*resolved);
     } else {
       valid = false;

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -978,7 +978,8 @@ static ProtocolConformanceRef checkConformanceToNSCopying(VarDecl *var,
   auto proto = ctx.getNSCopyingDecl();
 
   if (proto) {
-    if (auto result = TypeChecker::conformsToProtocol(type, proto, dc))
+    if (auto result = TypeChecker::conformsToProtocol(type, proto,
+                                                      dc->getParentModule()))
       return result;
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3197,7 +3197,8 @@ NeverNullType TypeResolver::resolveSILFunctionType(
     }
 
     witnessMethodConformance = TypeChecker::conformsToProtocol(
-        selfType, protocolType->getDecl(), getDeclContext());
+        selfType, protocolType->getDecl(),
+        getDeclContext()->getParentModule());
     assert(witnessMethodConformance &&
            "found witness_method without matching conformance");
   }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -188,7 +188,7 @@ enum class Comparison {
 /// formatted with \c diagnoseConformanceStack.
 struct ParentConditionalConformance {
   Type ConformingType;
-  ProtocolType *Protocol;
+  ProtocolDecl *Protocol;
 
   /// Format the stack \c conformances as a series of notes that trace a path of
   /// conditional conformances that lead to some other failing requirement (that

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -498,6 +498,10 @@ RequirementCheckResult checkGenericArguments(
     ArrayRef<Requirement> requirements, TypeSubstitutionFn substitutions,
     SubstOptions options = None);
 
+/// A lower-level version of the above without diagnostic emission.
+RequirementCheckResult checkGenericArguments(
+    GenericSignature sig, TypeSubstitutionFn substitutions);
+
 bool checkContextualRequirements(GenericTypeDecl *decl,
                                  Type parentTy,
                                  SourceLoc loc,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1285,11 +1285,6 @@ bool diagnoseObjCUnsatisfiedOptReqConflicts(SourceFile &sf);
 std::pair<unsigned, DeclName> getObjCMethodDiagInfo(
                                 AbstractFunctionDecl *method);
 
-bool areGenericRequirementsSatisfied(const DeclContext *DC,
-                                     GenericSignature sig,
-                                     SubstitutionMap Substitutions,
-                                     bool isExtension);
-
 /// Check for restrictions on the use of the @unknown attribute on a
 /// case statement.
 void checkUnknownAttrRestrictions(

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -500,7 +500,9 @@ RequirementCheckResult checkGenericArguments(
 
 /// A lower-level version of the above without diagnostic emission.
 RequirementCheckResult checkGenericArguments(
-    GenericSignature sig, TypeSubstitutionFn substitutions);
+    ModuleDecl *module,
+    ArrayRef<Requirement> requirements,
+    TypeSubstitutionFn substitutions);
 
 bool checkContextualRequirements(GenericTypeDecl *decl,
                                  Type parentTy,
@@ -714,13 +716,10 @@ Expr *addImplicitLoadExpr(
 
 /// Determine whether the given type contains the given protocol.
 ///
-/// \param DC The context in which to check conformance. This affects, for
-/// example, extension visibility.
-///
 /// \returns the conformance, if \c T conforms to the protocol \c Proto, or
 /// an empty optional.
 ProtocolConformanceRef containsProtocol(Type T, ProtocolDecl *Proto,
-                                        DeclContext *DC,
+                                        ModuleDecl *M,
                                         bool skipConditionalRequirements=false);
 
 /// Determine whether the given type conforms to the given protocol.
@@ -728,25 +727,22 @@ ProtocolConformanceRef containsProtocol(Type T, ProtocolDecl *Proto,
 /// Unlike subTypeOfProtocol(), this will return false for existentials of
 /// non-self conforming protocols.
 ///
-/// \param DC The context in which to check conformance. This affects, for
-/// example, extension visibility.
-///
 /// \returns The protocol conformance, if \c T conforms to the
 /// protocol \c Proto, or \c None.
 ProtocolConformanceRef conformsToProtocol(Type T, ProtocolDecl *Proto,
-                                          DeclContext *DC);
+                                          ModuleDecl *M);
+
+/// Check whether the type conforms to a given known protocol.
+bool conformsToKnownProtocol(Type type, KnownProtocolKind protocol,
+                             ModuleDecl *module);
 
 /// This is similar to \c conformsToProtocol, but returns \c true for cases where
 /// the type \p T could be dynamically cast to \p Proto protocol, such as a non-final
 /// class where a subclass conforms to \p Proto.
 ///
-/// \param DC The context in which to check conformance. This affects, for
-/// example, extension visibility.
-///
-///
 /// \returns True if \p T conforms to the protocol \p Proto, false otherwise.
 bool couldDynamicallyConformToProtocol(Type T, ProtocolDecl *Proto,
-                                       DeclContext *DC);
+                                       ModuleDecl *M);
 /// Completely check the given conformance.
 void checkConformance(NormalProtocolConformance *conformance);
 
@@ -1185,13 +1181,13 @@ diag::RequirementKind getProtocolRequirementKind(ValueDecl *Requirement);
 /// @dynamicCallable attribute requirement. The method is given to be defined
 /// as one of the following: `dynamicallyCall(withArguments:)` or
 /// `dynamicallyCall(withKeywordArguments:)`.
-bool isValidDynamicCallableMethod(FuncDecl *decl, DeclContext *DC,
+bool isValidDynamicCallableMethod(FuncDecl *decl, ModuleDecl *module,
                                   bool hasKeywordArguments);
 
 /// Returns true if the given subscript method is an valid implementation of
 /// the `subscript(dynamicMember:)` requirement for @dynamicMemberLookup.
 /// The method is given to be defined as `subscript(dynamicMember:)`.
-bool isValidDynamicMemberLookupSubscript(SubscriptDecl *decl, DeclContext *DC,
+bool isValidDynamicMemberLookupSubscript(SubscriptDecl *decl, ModuleDecl *module,
                                          bool ignoreLabel = false);
 
 /// Returns true if the given subscript method is an valid implementation of
@@ -1199,7 +1195,7 @@ bool isValidDynamicMemberLookupSubscript(SubscriptDecl *decl, DeclContext *DC,
 /// The method is given to be defined as `subscript(dynamicMember:)` which
 /// takes a single non-variadic parameter that conforms to
 /// `ExpressibleByStringLiteral` protocol.
-bool isValidStringDynamicMemberLookup(SubscriptDecl *decl, DeclContext *DC,
+bool isValidStringDynamicMemberLookup(SubscriptDecl *decl, ModuleDecl *module,
                                       bool ignoreLabel = false);
 
 /// Returns true if the given subscript method is an valid implementation of

--- a/test/IDE/print_synthesized_extensions.swift
+++ b/test/IDE/print_synthesized_extensions.swift
@@ -393,7 +393,7 @@ extension C : P8 {}
 public class F<T : D> {}
 extension F : P8 {}
 
-// CHECK16:      <synthesized>extension <ref:Class>F</ref> where <ref:GenericTypeParam>T</ref> : <ref:Class>D</ref> {
+// CHECK16:      <decl:Class>public class <loc>F<<decl:GenericTypeParam>T</decl>></loc> where <ref:GenericTypeParam>T</ref> : <ref:module>print_synthesized_extensions</ref>.<ref:Class>D</ref> {</decl>
 // CHECK16-NEXT:   <decl:Func>public func <loc>bar()</loc></decl>
 // CHECK16-NEXT: }</synthesized>
 

--- a/test/IDE/print_synthesized_extensions_superclass.swift
+++ b/test/IDE/print_synthesized_extensions_superclass.swift
@@ -1,0 +1,132 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/print_synthesized_extensions_superclass.swiftmodule -emit-module-doc -emit-module-doc-path %t/print_synthesized_extensions_superclass.swiftdoc %s
+// RUN: %target-swift-ide-test -print-module -synthesize-extension -print-interface -no-empty-line-between-members -module-to-print=print_synthesized_extensions_superclass -I %t -source-filename=%s | %FileCheck %s
+
+public class Base {}
+public class Middle<T> : Base {}
+public class Most : Middle<Int> {}
+
+public protocol P {
+  associatedtype T
+  associatedtype U
+}
+
+public extension P where T : Base {
+  func withBase() {}
+}
+
+public extension P where T : Middle<U> {
+  func withMiddleAbstract() {}
+}
+
+public extension P where T : Middle<Int> {
+  func withMiddleConcrete() {}
+}
+
+public extension P where T : Most {
+  func withMost() {}
+}
+
+// CHECK-LABEL: public struct S1 : print_synthesized_extensions_superclass.P {
+// CHECK-NEXT:    public typealias T = print_synthesized_extensions_superclass.Base
+// CHECK-NEXT:    public typealias U = Int
+// CHECK-NEXT:    public func withBase()
+// CHECk-NEXT:  }
+
+public struct S1 : P {
+  public typealias T = Base
+  public typealias U = Int
+}
+
+// CHECK-LABEL: public struct S2 : print_synthesized_extensions_superclass.P {
+// CHECK-NEXT:    public typealias T = print_synthesized_extensions_superclass.Middle<Int>
+// CHECK-NEXT:    public typealias U = Int
+// CHECK-NEXT:    public func withBase()
+// CHECk-NEXT:    public func withMiddleAbstract()
+// CHECk-NEXT:    public func withMiddleConcrete()
+// CHECk-NEXT:  }
+
+public struct S2 : P {
+  public typealias T = Middle<Int>
+  public typealias U = Int
+}
+
+// CHECK-LABEL: public struct S3 : print_synthesized_extensions_superclass.P {
+// CHECK-NEXT:    public typealias T = print_synthesized_extensions_superclass.Middle<String>
+// CHECK-NEXT:    public typealias U = String
+// CHECK-NEXT:    public func withBase()
+// CHECK-NEXT:    public func withMiddleAbstract()
+// CHECK-NEXT:  }
+
+public struct S3 : P {
+  public typealias T = Middle<String>
+  public typealias U = String
+}
+
+// CHECK-LABEL: public struct S4 : print_synthesized_extensions_superclass.P {
+// CHECK-NEXT:    public typealias T = print_synthesized_extensions_superclass.Most
+// CHECK-NEXT:    public typealias U = Int
+// CHECK-NEXT:    public func withBase()
+// CHECK-NEXT:    public func withMiddleAbstract()
+// CHECK-NEXT:    public func withMiddleConcrete()
+// CHECK-NEXT:    public func withMost()
+// CHECK-NEXT:  }
+
+public struct S4 : P {
+  public typealias T = Most
+  public typealias U = Int
+}
+
+// CHECK-LABEL: public struct S5 : print_synthesized_extensions_superclass.P {
+// CHECK-NEXT:   public typealias T = print_synthesized_extensions_superclass.Most
+// CHECK-NEXT:   public typealias U = String
+// CHECK-NEXT:   public func withBase()
+// CHECK-NEXT:   public func withMiddleConcrete()
+// CHECK-NEXT:   public func withMost()
+// CHECK-NEXT: }
+
+public struct S5 : P {
+  public typealias T = Most
+  public typealias U = String
+}
+
+// CHECK-LABEL: public struct S6<T, U> : print_synthesized_extensions_superclass.P where T : print_synthesized_extensions_superclass.Base {
+// CHECK-NEXT:    public func withBase()
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: extension S6 where T : Middle<U> {
+// CHECK-NEXT:    public func withMiddleAbstract()
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: extension S6 where T : Middle<Int> {
+// CHECK-NEXT:    public func withMiddleConcrete()
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: extension S6 where T : Most {
+// CHECK-NEXT:    public func withMost()
+// CHECK-NEXT:  }
+
+public struct S6<T, U> : P where T : Base {}
+
+// CHECK-LABEL: public struct S7<T, U> : print_synthesized_extensions_superclass.P where T : print_synthesized_extensions_superclass.Middle<U> {
+// CHECK-NEXT:    public func withBase()
+// CHECK-NEXT:    public func withMiddleAbstract()
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: extension S7 where T : Middle<Int> {
+// CHECK-NEXT:    public func withMiddleConcrete()
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: extension S7 where T : Most {
+// CHECK-NEXT:    public func withMost()
+// CHECK-NEXT:  }
+
+public struct S7<T, U> : P where T : Middle<U> {}
+
+// CHECK-LABEL: public struct S8<T, U> : print_synthesized_extensions_superclass.P where T : print_synthesized_extensions_superclass.Most {
+// CHECK-NEXT:    public func withBase()
+// CHECK-NEXT:    public func withMiddleConcrete()
+// CHECK-NEXT:    public func withMost()
+// CHECK-NEXT:  }
+
+public struct S8<T, U> : P where T : Most {}

--- a/test/SourceKit/DocSupport/doc_swift_module_class_extension.swift.response
+++ b/test/SourceKit/DocSupport/doc_swift_module_class_extension.swift.response
@@ -26,14 +26,11 @@ class E {
 }
 
 class F<T> where T : module_with_class_extension.D {
+
+    func bar()
 }
 
 extension F : module_with_class_extension.P8 {
-}
-
-extension F where T : D {
-
-    func bar()
 }
 
 protocol P8 {
@@ -270,193 +267,162 @@ extension P8 where Self.T : module_with_class_extension.E {
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 328,
+    key.offset: 330,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 335,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 344,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "F",
     key.usr: "s:27module_with_class_extension1FC",
-    key.offset: 338,
+    key.offset: 354,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 342,
+    key.offset: 358,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P8",
     key.usr: "s:27module_with_class_extension2P8P",
-    key.offset: 370,
+    key.offset: 386,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 378,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.ref.class,
-    key.name: "F",
-    key.usr: "s:27module_with_class_extension1FC",
-    key.offset: 388,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 390,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.ref.generic_type_param,
-    key.name: "T",
-    key.usr: "s:27module_with_class_extension1FC1Txmfp",
-    key.offset: 396,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.class,
-    key.name: "D",
-    key.usr: "s:27module_with_class_extension1DC",
-    key.offset: 400,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 409,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 414,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 423,
+    key.offset: 394,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 432,
+    key.offset: 403,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 442,
+    key.offset: 413,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 457,
+    key.offset: 428,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 462,
+    key.offset: 433,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P8",
     key.usr: "s:27module_with_class_extension2P8P",
-    key.offset: 472,
+    key.offset: 443,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 475,
+    key.offset: 446,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Self",
     key.usr: "s:27module_with_class_extension2P8PA2A1DC1TRczrlE4Selfxmfp",
-    key.offset: 481,
+    key.offset: 452,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.associatedtype,
     key.name: "T",
     key.usr: "s:27module_with_class_extension2P8P1TQa",
-    key.offset: 486,
+    key.offset: 457,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 490,
+    key.offset: 461,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "D",
     key.usr: "s:27module_with_class_extension1DC",
-    key.offset: 518,
+    key.offset: 489,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 527,
+    key.offset: 498,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 532,
+    key.offset: 503,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 541,
+    key.offset: 512,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P8",
     key.usr: "s:27module_with_class_extension2P8P",
-    key.offset: 551,
+    key.offset: 522,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 554,
+    key.offset: 525,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Self",
     key.usr: "s:27module_with_class_extension2P8PA2A1EC1TRczrlE4Selfxmfp",
-    key.offset: 560,
+    key.offset: 531,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.associatedtype,
     key.name: "T",
     key.usr: "s:27module_with_class_extension2P8P1TQa",
-    key.offset: 565,
+    key.offset: 536,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 569,
+    key.offset: 540,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "E",
     key.usr: "s:27module_with_class_extension1EC",
-    key.offset: 597,
+    key.offset: 568,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 606,
+    key.offset: 577,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 611,
+    key.offset: 582,
     key.length: 3
   }
 ]
@@ -590,8 +556,19 @@ extension P8 where Self.T : module_with_class_extension.E {
       }
     ],
     key.offset: 272,
-    key.length: 54,
-    key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>F</decl.name>&lt;<decl.generic_type_param usr=\"s:27module_with_class_extension1FC1Txmfp\"><decl.generic_type_param.name>T</decl.generic_type_param.name></decl.generic_type_param>&gt; <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:27module_with_class_extension1FC1Txmfp\">T</ref.generic_type_param> : <ref.class usr=\"s:27module_with_class_extension1DC\">D</ref.class></decl.generic_type_requirement></decl.class>"
+    key.length: 70,
+    key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>F</decl.name>&lt;<decl.generic_type_param usr=\"s:27module_with_class_extension1FC1Txmfp\"><decl.generic_type_param.name>T</decl.generic_type_param.name></decl.generic_type_param>&gt; <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:27module_with_class_extension1FC1Txmfp\">T</ref.generic_type_param> : <ref.class usr=\"s:27module_with_class_extension1DC\">D</ref.class></decl.generic_type_requirement></decl.class>",
+    key.entities: [
+      {
+        key.kind: source.lang.swift.decl.function.method.instance,
+        key.name: "bar()",
+        key.usr: "s:27module_with_class_extension2P8PA2A1DC1TRczrlE3baryyF::SYNTHESIZED::s:27module_with_class_extension1FC",
+        key.original_usr: "s:27module_with_class_extension2P8PA2A1DC1TRczrlE3baryyF",
+        key.offset: 330,
+        key.length: 10,
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>bar</decl.name>()</decl.function.method.instance>"
+      }
+    ]
   },
   {
     key.kind: source.lang.swift.decl.extension.class,
@@ -605,7 +582,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.description: "T : D"
       }
     ],
-    key.offset: 328,
+    key.offset: 344,
     key.length: 48,
     key.fully_annotated_decl: "<decl.extension.class>extension <decl.name><ref.class usr=\"s:27module_with_class_extension1FC\">F</ref.class></decl.name> : <ref.protocol usr=\"s:27module_with_class_extension2P8P\">P8</ref.protocol></decl.extension.class>",
     key.conforms: [
@@ -622,37 +599,10 @@ extension P8 where Self.T : module_with_class_extension.E {
     }
   },
   {
-    key.kind: source.lang.swift.decl.extension.class,
-    key.generic_requirements: [
-      {
-        key.description: "T : D"
-      }
-    ],
-    key.offset: 378,
-    key.length: 43,
-    key.fully_annotated_decl: "<syntaxtype.keyword>extension</syntaxtype.keyword> <ref.class usr=\"s:27module_with_class_extension1FC\">F</ref.class> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:27module_with_class_extension1FC1Txmfp\">T</ref.generic_type_param> : <ref.class usr=\"s:27module_with_class_extension1DC\">D</ref.class></decl.generic_type_requirement>",
-    key.extends: {
-      key.kind: source.lang.swift.ref.class,
-      key.name: "F",
-      key.usr: "s:27module_with_class_extension1FC"
-    },
-    key.entities: [
-      {
-        key.kind: source.lang.swift.decl.function.method.instance,
-        key.name: "bar()",
-        key.usr: "s:27module_with_class_extension2P8PA2A1DC1TRczrlE3baryyF::SYNTHESIZED::s:27module_with_class_extension1FC",
-        key.original_usr: "s:27module_with_class_extension2P8PA2A1DC1TRczrlE3baryyF",
-        key.offset: 409,
-        key.length: 10,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>bar</decl.name>()</decl.function.method.instance>"
-      }
-    ]
-  },
-  {
     key.kind: source.lang.swift.decl.protocol,
     key.name: "P8",
     key.usr: "s:27module_with_class_extension2P8P",
-    key.offset: 423,
+    key.offset: 394,
     key.length: 37,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P8</decl.name></decl.protocol>",
     key.entities: [
@@ -660,7 +610,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.kind: source.lang.swift.decl.associatedtype,
         key.name: "T",
         key.usr: "s:27module_with_class_extension2P8P1TQa",
-        key.offset: 442,
+        key.offset: 413,
         key.length: 16,
         key.fully_annotated_decl: "<decl.associatedtype><syntaxtype.keyword>associatedtype</syntaxtype.keyword> <decl.name>T</decl.name></decl.associatedtype>"
       }
@@ -673,7 +623,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.description: "Self.T : D"
       }
     ],
-    key.offset: 462,
+    key.offset: 433,
     key.length: 77,
     key.fully_annotated_decl: "<decl.extension.protocol>extension <decl.name><ref.protocol usr=\"s:27module_with_class_extension2P8P\">P8</ref.protocol></decl.name> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:27module_with_class_extension2P8PA2A1DC1TRczrlE4Selfxmfp\">Self</ref.generic_type_param>.<ref.associatedtype usr=\"s:27module_with_class_extension2P8P1TQa\">T</ref.associatedtype> : <ref.class usr=\"s:27module_with_class_extension1DC\">D</ref.class></decl.generic_type_requirement></decl.extension.protocol>",
     key.extends: {
@@ -686,7 +636,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "bar()",
         key.usr: "s:27module_with_class_extension2P8PA2A1DC1TRczrlE3baryyF",
-        key.offset: 527,
+        key.offset: 498,
         key.length: 10,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>bar</decl.name>()</decl.function.method.instance>"
       }
@@ -699,7 +649,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.description: "Self.T : E"
       }
     ],
-    key.offset: 541,
+    key.offset: 512,
     key.length: 77,
     key.fully_annotated_decl: "<decl.extension.protocol>extension <decl.name><ref.protocol usr=\"s:27module_with_class_extension2P8P\">P8</ref.protocol></decl.name> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:27module_with_class_extension2P8PA2A1EC1TRczrlE4Selfxmfp\">Self</ref.generic_type_param>.<ref.associatedtype usr=\"s:27module_with_class_extension2P8P1TQa\">T</ref.associatedtype> : <ref.class usr=\"s:27module_with_class_extension1EC\">E</ref.class></decl.generic_type_requirement></decl.extension.protocol>",
     key.extends: {
@@ -712,7 +662,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "baz()",
         key.usr: "s:27module_with_class_extension2P8PA2A1EC1TRczrlE3bazyyF",
-        key.offset: 606,
+        key.offset: 577,
         key.length: 10,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>baz</decl.name>()</decl.function.method.instance>"
       }


### PR DESCRIPTION
We were doing similar things in four different places:

- `GenericSignature::isRequirementSatisfied()`
- `TypeChecker::checkGenericArguments()`
- `areGenericRequirementsSatisfied()`
- `SynthesizedExtensionAnalyzer`

Refactor them all to use a new `Requirement::isSatisfied()` entry point.

The `SynthesizedExtensionAnalyzer` needs more work. It doesn't handle Layout requirements because of representational issues in the IDE code itself. Also, conditional requirements are handled in a weird way and I'm not sure it's correct. I added FIXMEs for both issues.