### PR TITLE
C++ Interop: import namespace aliases

### DIFF
--- a/test/Interop/Cxx/namespace/Inputs/classes.h
+++ b/test/Interop/Cxx/namespace/Inputs/classes.h
@@ -40,4 +40,35 @@ struct BasicStruct {
 };
 } // namespace ClassesNS3
 
+namespace GlobalAliasToNS1 = ClassesNS1;
+
+namespace ClassesNS4 {
+namespace AliasToGlobalNS1 = ::ClassesNS1;
+namespace AliasToGlobalNS2 = ::ClassesNS1::ClassesNS2;
+
+namespace ClassesNS5 {
+struct BasicStruct {};
+} // namespace ClassesNS5
+
+namespace AliasToInnerNS5 = ClassesNS5;
+namespace AliasToNS2 = ClassesNS1::ClassesNS2;
+
+namespace AliasChainToNS1 = GlobalAliasToNS1;
+namespace AliasChainToNS2 = AliasChainToNS1::ClassesNS2;
+} // namespace ClassesNS4
+
+namespace ClassesNS5 {
+struct BasicStruct {};
+namespace AliasToAnotherNS5 = ClassesNS4::ClassesNS5;
+
+namespace ClassesNS5 {
+struct BasicStruct {};
+namespace AliasToNS5NS5 = ClassesNS5;
+} // namespace ClassesNS5
+
+namespace AliasToGlobalNS5 = ::ClassesNS5;
+namespace AliasToLocalNS5 = ClassesNS5;
+namespace AliasToNS5 = ::ClassesNS5::ClassesNS5;
+} // namespace ClassesNS5
+
 #endif // TEST_INTEROP_CXX_NAMESPACE_INPUTS_CLASSES_H

--- a/test/Interop/Cxx/namespace/classes-irgen.swift
+++ b/test/Interop/Cxx/namespace/classes-irgen.swift
@@ -6,6 +6,7 @@ import Classes
 // CHECK: call i8* @{{_ZN10ClassesNS111BasicStruct11basicMemberEv|"\?basicMember@BasicStruct@ClassesNS1@@QEAAPEBDXZ"}}(%"struct.ClassesNS1::BasicStruct"*
 // CHECK: call i8* @{{_ZN10ClassesNS110ClassesNS211BasicStruct11basicMemberEv|"\?basicMember@BasicStruct@ClassesNS2@ClassesNS1@@QEAAPEBDXZ"}}(%"struct.ClassesNS1::ClassesNS2::BasicStruct"*
 // CHECK: call i8* @{{_ZN10ClassesNS311BasicStruct11basicMemberEv|"\?basicMember@BasicStruct@ClassesNS3@@QEAAPEBDXZ"}}(%"struct.ClassesNS3::BasicStruct"*
+// CHECK: call i8* @{{_ZN10ClassesNS111BasicStruct11basicMemberEv|"\?basicMember@BasicStruct@ClassesNS1@@QEAAPEBDXZ"}}(%"struct.ClassesNS1::BasicStruct"*
 // CHECK: ret void
 public func basicTests() {
   var basicStructInst = ClassesNS1.BasicStruct()
@@ -16,6 +17,9 @@ public func basicTests() {
 
   var siblingBasicStruct = ClassesNS3.BasicStruct()
   siblingBasicStruct.basicMember()
+
+  var basicStructViaAlias = ClassesNS4.AliasToGlobalNS1.BasicStruct()
+  basicStructViaAlias.basicMember()
 }
 
 // CHECK-LABEL: define {{.*}}void @"$s4main15forwardDeclaredyyF"()

--- a/test/Interop/Cxx/namespace/classes-module-interface.swift
+++ b/test/Interop/Cxx/namespace/classes-module-interface.swift
@@ -32,3 +32,34 @@
 // CHECK:   }
 // CHECK: }
 // CHECK-NOT: extension
+
+// CHECK: typealias GlobalAliasToNS1 = ClassesNS1
+// CHECK: extension ClassesNS4 {
+// CHECK:   typealias AliasToGlobalNS1 = ClassesNS1
+// CHECK:   typealias AliasToGlobalNS2 = ClassesNS1.ClassesNS2
+// CHECK:   typealias AliasToInnerNS5 = ClassesNS4.ClassesNS5
+// CHECK:   typealias AliasToNS2 = ClassesNS1.ClassesNS2
+// CHECK:   typealias AliasChainToNS1 = ClassesNS1
+// CHECK:   typealias AliasChainToNS2 = ClassesNS1.ClassesNS2
+// CHECK: }
+// CHECK: extension ClassesNS4.ClassesNS5 {
+// CHECK:   struct BasicStruct {
+// CHECK:     init()
+// CHECK:   }
+// CHECK: }
+// CHECK: extension ClassesNS5 {
+// CHECK:   struct BasicStruct {
+// CHECK:     init()
+// CHECK:   }
+// CHECK:   typealias AliasToAnotherNS5 = ClassesNS4.ClassesNS5
+// CHECK:   typealias AliasToGlobalNS5 = ClassesNS5
+// CHECK:   typealias AliasToLocalNS5 = ClassesNS5.ClassesNS5
+// CHECK:   typealias AliasToNS5 = ClassesNS5.ClassesNS5
+// CHECK: }
+// CHECK: extension ClassesNS5.ClassesNS5 {
+// CHECK:   struct BasicStruct {
+// CHECK:     init()
+// CHECK:   }
+// CHECK:   typealias AliasToNS5NS5 = ClassesNS5.ClassesNS5
+// CHECK: }
+// CHECK-NOT: extension

--- a/test/Interop/Cxx/namespace/classes.swift
+++ b/test/Interop/Cxx/namespace/classes.swift
@@ -20,6 +20,10 @@ NamespacesTestSuite.test("Basic classes") {
   var siblingBasicStruct = ClassesNS3.BasicStruct()
   let siblingMemberCString = siblingBasicStruct.basicMember()
   expectEqual(String(cString: siblingMemberCString!), "ClassesNS3::BasicStruct::basicMember")
+
+  var basicStructViaAlias = ClassesNS4.AliasToGlobalNS1.BasicStruct()
+  let basicMemberViaAliasCString = basicStructViaAlias.basicMember()
+  expectEqual(String(cString: basicMemberViaAliasCString!), "ClassesNS1::BasicStruct::basicMember")
 }
 
 NamespacesTestSuite.test("Forward declared classes") {


### PR DESCRIPTION
Previously they weren't imported, now they are imported as typealiases to enums representing namespaces.

Fixes SR-12467.