### PR TITLE
[test] Update `get_simulator_command` for macOS 11

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https://swift.org/LICENSE.txt for license information
@@ -81,12 +81,16 @@ def darwin_get_watchos_sim_vers():
     return [float(v.strip('watchOS')) for v in watchos_version_str]
 
 # Returns the "prefix" command that should be prepended to the command line to
-# run an executable compiled for iOS or AppleTV simulator.
-def get_simulator_command(run_os, run_cpu, sdk_path):
-    (name, vers, build) = darwin_get_sdk_version(sdk_path)
+# run an executable compiled for an iOS, tvOS, or watchOS simulator.
+def get_simulator_command(run_os, run_cpu):
+    mac_ver_tuple = tuple(int(v) for v in
+        platform.mac_ver()[0].replace('.', ' ').split())
     if run_os == 'ios':
         if run_cpu == "i386":
-            if min(darwin_get_ios_sim_vers()) > 10.3:
+            if mac_ver_tuple >= (11,):
+                print("ERROR: The 32-bit iOS simulator is unavailable on macOS 11.0+")
+                sys.exit(1)
+            elif min(darwin_get_ios_sim_vers()) > 10.3:
                 print("ERROR: Your system does not have a 32-bit iOS simulator installed.")
                 print("INFO: 1. Install iOS 10.3 or older simulator (Xcode -> Preferences -> Components -> Simulators).")
                 print("INFO: 2. Create a 32-bit iPhone 5 device. Run:")
@@ -1012,7 +1016,7 @@ if run_vendor == 'apple':
         # segmentation faults)
         config.target_run = (
             "%s %s " %
-            (xcrun_prefix, get_simulator_command(run_os, run_cpu, config.variant_sdk)))
+            (xcrun_prefix, get_simulator_command(run_os, run_cpu)))
 
         (sw_vers_name, sw_vers_vers, sw_vers_build) = \
             darwin_get_sdk_version(config.variant_sdk)


### PR DESCRIPTION
The new error message is printed when using:

* `utils/build-script` with `--skip-test-ios-32bit-simulator=0`
* `utils/run-test` with `--target=iphonesimulator-i386`

Follow-up to: apple/swift#37399 and apple/swift#35770