### PR TITLE
[SourceKit] Expose all refactoring actions as requests in `sourcekitd-test`

### DIFF
--- a/test/SourceKit/Refactoring/semantic-refactoring/expand-default.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/expand-default.swift
@@ -10,7 +10,7 @@ func foo(e : E) {
 }
 
 // RUN: %empty-directory(%t.result)
-// RUN: %sourcekitd-test -req=expand-default -pos=7:7 %s -- %s > %t.result/expand-default.swift.expected
+// RUN: %sourcekitd-test -req=refactoring.expand.default -pos=7:7 %s -- %s > %t.result/expand-default.swift.expected
 // RUN: %diff -u %S/expand-default.swift.expected %t.result/expand-default.swift.expected
 
 // REQUIRES: OS=macosx || OS=linux-gnu

--- a/test/SourceKit/Refactoring/semantic-refactoring/extract-func-default.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/extract-func-default.swift
@@ -5,7 +5,7 @@ func foo() -> Int {
 }
 
 // RUN: %empty-directory(%t.result)
-// RUN: %sourcekitd-test -req=extract-func -pos=2:1 -end-pos 4:11 %s -- %s > %t.result/extract-func-default.swift.expected
+// RUN: %sourcekitd-test -req=refactoring.extract.function -pos=2:1 -end-pos 4:11 %s -- %s > %t.result/extract-func-default.swift.expected
 // RUN: %diff -u %S/extract-func-default.swift.expected %t.result/extract-func-default.swift.expected
 
 // FIXME: Fails on linux with assertion: "!GlibcModuleMapPath.empty()"" failed

--- a/test/SourceKit/Refactoring/semantic-refactoring/extract-func-with-args.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/extract-func-with-args.swift
@@ -5,7 +5,7 @@ func foo() -> Int {
 }
 
 // RUN: %empty-directory(%t.result)
-// RUN: %sourcekitd-test -req=extract-func -pos=3:1 -end-pos 3:12 -name new_name %s -- %s > %t.result/extract-func-with-args.swift.expected
+// RUN: %sourcekitd-test -req=refactoring.extract.function -pos=3:1 -end-pos 3:12 -name new_name %s -- %s > %t.result/extract-func-with-args.swift.expected
 // RUN: %diff -u %S/extract-func-with-args.swift.expected %t.result/extract-func-with-args.swift.expected
 
 // FIXME: Fails on linux with assertion: "!GlibcModuleMapPath.empty()"" failed

--- a/test/SourceKit/Refactoring/semantic-refactoring/extract-func.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/extract-func.swift
@@ -5,7 +5,7 @@ func foo() -> Int {
 }
 
 // RUN: %empty-directory(%t.result)
-// RUN: %sourcekitd-test -req=extract-func -pos=2:1 -end-pos 4:11 -name new_name %s -- %s > %t.result/extract-func.swift.expected
+// RUN: %sourcekitd-test -req=refactoring.extract.function -pos=2:1 -end-pos 4:11 -name new_name %s -- %s > %t.result/extract-func.swift.expected
 // RUN: %diff -u %S/extract-func.swift.expected %t.result/extract-func.swift.expected
 
 // FIXME: Fails on linux with assertion: "!GlibcModuleMapPath.empty()"" failed

--- a/test/SourceKit/Refactoring/semantic-refactoring/extract-repeated-expression.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/extract-repeated-expression.swift
@@ -5,7 +5,7 @@ func foo() -> Int {
 }
 
 // RUN: %empty-directory(%t.result)
-// RUN: %sourcekitd-test -req=extract-repeated -pos=3:11 -end-pos 3:12 -name new_name %s -- %s > %t.result/extract-repeated-expression.swift.expected
+// RUN: %sourcekitd-test -req=refactoring.extract.expr.repeated -pos=3:11 -end-pos 3:12 -name new_name %s -- %s > %t.result/extract-repeated-expression.swift.expected
 // RUN: %diff -u %S/extract-repeated-expression.swift.expected %t.result/extract-repeated-expression.swift.expected
 
 // REQUIRES: OS=macosx || OS=linux-gnu

--- a/test/SourceKit/Refactoring/semantic-refactoring/fill-stub.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/fill-stub.swift
@@ -5,7 +5,7 @@ protocol P {
 class C1 : P {}
 
 // RUN: %empty-directory(%t.result)
-// RUN: %sourcekitd-test -req=fill-stub -pos=5:8 %s -- %s > %t.result/fill-stub.swift.expected
+// RUN: %sourcekitd-test -req=refactoring.fillstub -pos=5:8 %s -- %s > %t.result/fill-stub.swift.expected
 // RUN: %diff -u %S/fill-stub.swift.expected %t.result/fill-stub.swift.expected
 
 // REQUIRES: OS=macosx || OS=linux-gnu

--- a/test/SourceKit/Refactoring/semantic-refactoring/line-col-conversion.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/line-col-conversion.swift
@@ -1,4 +1,4 @@
-// RUN: %sourcekitd-test -req=local-rename -pos=4:7 -name new_name %s -- %s
+// RUN: %sourcekitd-test -req=refactoring.rename.local -pos=4:7 -name new_name %s -- %s
 
 var Foo: Int {
 	var missingNewlineAtEndOfFile

--- a/test/SourceKit/Refactoring/semantic-refactoring/local-rename.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/local-rename.swift
@@ -12,7 +12,7 @@ func foo() {
 }
 
 // RUN: %empty-directory(%t.result)
-// RUN: %sourcekitd-test -req=local-rename -pos=2:8 -name new_name %s -- %s > %t.result/local-rename.swift.expected
+// RUN: %sourcekitd-test -req=refactoring.rename.local -pos=2:8 -name new_name %s -- %s > %t.result/local-rename.swift.expected
 // RUN: %diff -u %S/local-rename.swift.expected %t.result/local-rename.swift.expected
 // RUN: %sourcekitd-test -req=find-local-rename-ranges -pos=2:8 %s -- %s > %t.result/local-rename-ranges.swift.expected
 // RUN: %diff -u %S/local-rename-ranges.swift.expected %t.result/local-rename-ranges.swift.expected

--- a/test/SourceKit/Refactoring/semantic-refactoring/localize-string.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/localize-string.swift
@@ -1,7 +1,7 @@
 // REQUIRES: OS=macosx || OS=linux-gnu
 
 func foo() -> String {
-  // RUN: %sourcekitd-test -req=localize-string -pos=%(line+1):10 %s -- %s | %FileCheck %s --check-prefix=CHECK-BASIC
+  // RUN: %sourcekitd-test -req=refactoring.localize.string -pos=%(line+1):10 %s -- %s | %FileCheck %s --check-prefix=CHECK-BASIC
   return "abc"
   // CHECK-BASIC: source.edit.kind.active:
   // CHECK-BASIC: [[# @LINE-2]]:10-[[# @LINE-2]]:10 "NSLocalizedString("
@@ -11,7 +11,7 @@ func foo() -> String {
 
 #sourceLocation(file: "someFile.swift", line: 20)
 func bar() -> String {
-  // RUN: %sourcekitd-test -req=localize-string -pos=%(line+1):10 %s -- %s | %FileCheck %s --check-prefix=CHECK-DIRECTIVE
+  // RUN: %sourcekitd-test -req=refactoring.localize.string -pos=%(line+1):10 %s -- %s | %FileCheck %s --check-prefix=CHECK-DIRECTIVE
   return "abc"
   // CHECK-DIRECTIVE: [[# @LINE-1]]:10-[[# @LINE-1]]:10
 }

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -143,31 +143,66 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
         .Case("find-rename-ranges", SourceKitRequest::FindRenameRanges)
         .Case("find-local-rename-ranges", SourceKitRequest::FindLocalRenameRanges)
         .Case("translate", SourceKitRequest::NameTranslation)
-        .Case("local-rename", SourceKitRequest::LocalRename)
-        .Case("extract-expr", SourceKitRequest::ExtractExpr)
-        .Case("extract-repeated", SourceKitRequest::ExtractRepeatedExpr)
-        .Case("extract-func", SourceKitRequest::ExtractFunction)
-        .Case("fill-stub", SourceKitRequest::FillProtocolStub)
-        .Case("expand-default", SourceKitRequest::ExpandDefault)
-        .Case("localize-string", SourceKitRequest::LocalizeString)
         .Case("markup-xml", SourceKitRequest::MarkupToXML)
         .Case("stats", SourceKitRequest::Statistics)
         .Case("track-compiles", SourceKitRequest::EnableCompileNotifications)
         .Case("collect-type", SourceKitRequest::CollectExpresstionType)
         .Case("global-config", SourceKitRequest::GlobalConfiguration)
         .Case("dependency-updated", SourceKitRequest::DependencyUpdated)
+#define SEMANTIC_REFACTORING(KIND, NAME, ID) .Case("refactoring." #ID, SourceKitRequest::KIND)
+#include "swift/IDE/RefactoringKinds.def"
         .Default(SourceKitRequest::None);
 
       if (Request == SourceKitRequest::None) {
         llvm::errs() << "error: invalid request '" << InputArg->getValue()
-            << "'\nexpected one of "
-            << "version/demangle/mangle/index/complete/complete.open/complete.cursor/"
-               "complete.update/complete.cache.ondisk/complete.cache.setpopularapi/"
-               "cursor/related-idents/syntax-map/structure/format/expand-placeholder/"
-               "doc-info/sema/interface-gen/interface-gen-openfind-usr/find-interface/"
-               "open/close/edit/print-annotations/print-diags/extract-comment/module-groups/"
-               "range/syntactic-rename/find-rename-ranges/translate/markup-xml/stats/"
-               "track-compiles/collect-type\n";
+                     << "'\nexpected one of "
+                     << "- version\n"
+                     << "- compiler-version\n"
+                     << "- demangle\n"
+                     << "- mangle\n"
+                     << "- index\n"
+                     << "- complete\n"
+                     << "- complete.open\n"
+                     << "- complete.close\n"
+                     << "- complete.update\n"
+                     << "- complete.cache.ondisk\n"
+                     << "- complete.setpopularapi\n"
+                     << "- typecontextinfo\n"
+                     << "- conformingmethods\n"
+                     << "- cursor\n"
+                     << "- related-idents\n"
+                     << "- syntax-map\n"
+                     << "- syntax-tree\n"
+                     << "- structure\n"
+                     << "- format\n"
+                     << "- expand-placeholder\n"
+                     << "- doc-info\n"
+                     << "- sema\n"
+                     << "- interface-gen\n"
+                     << "- interface-gen-open\n"
+                     << "- find-usr\n"
+                     << "- find-interface\n"
+                     << "- open\n"
+                     << "- close\n"
+                     << "- edit\n"
+                     << "- print-annotations\n"
+                     << "- print-diags\n"
+                     << "- extract-comment\n"
+                     << "- module-groups\n"
+                     << "- range\n"
+                     << "- syntactic-rename\n"
+                     << "- find-rename-ranges\n"
+                     << "- find-local-rename-ranges\n"
+                     << "- translate\n"
+                     << "- markup-xml\n"
+                     << "- stats\n"
+                     << "- track-compiles\n"
+                     << "- collect-type\n"
+                     << "- global-config\n"
+                     << "- dependency-updated\n"
+#define SEMANTIC_REFACTORING(KIND, NAME, ID) << "- refactoring." #ID "\n"
+#include "swift/IDE/RefactoringKinds.def"
+                        "\n";
         return true;
       }
       break;


### PR DESCRIPTION
Previously, not all refactoring requests were available in `sourcekitd-test`. Now they are. 