### PR TITLE
[5.4][ConstraintSystem] Re-activate constraints if, due to incorrect refer…

### DIFF
--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -199,9 +199,13 @@ public:
   /// via key path dynamic member lookup.
   bool isForKeyPathDynamicMemberLookup() const;
 
-  /// Determine whether this locator points to one of the key path
-  /// components.
-  bool isForKeyPathComponent() const;
+  /// Determine whether this locator points to element inside
+  /// of a key path component.
+  bool isInKeyPathComponent() const;
+
+  /// Determine whether this locator points to a result type of
+  /// a key path component.
+  bool isForKeyPathComponentResult() const;
 
   /// Determine whether this locator points to the generic parameter.
   bool isForGenericParameter() const;

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1304,6 +1304,13 @@ bool TypeVarBindingProducer::computeNext() {
       }
     }
 
+    // There is a tailored fix for optional key path root references,
+    // let's not create ambiguity by attempting unwrap when it's
+    // not allowed.
+    if (binding.Kind != BindingKind::Subtypes &&
+        getLocator()->isKeyPathRoot() && type->getOptionalObjectType())
+      continue;
+
     // Allow solving for T even for a binding kind where that's invalid
     // if fixes are allowed, because that gives us the opportunity to
     // match T? values to the T binding by adding an unwrap fix.

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3930,7 +3930,7 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
     // If this is a reference to a static member by one of the key path
     // components, let's provide a tailored diagnostic and return because
     // that is unsupported so there is no fix-it.
-    if (locator->isForKeyPathComponent()) {
+    if (locator->isInKeyPathComponent()) {
       InvalidStaticMemberRefInKeyPath failure(getSolution(), Member, locator);
       return failure.diagnoseAsError();
     }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1543,7 +1543,7 @@ public:
                             ConstraintLocator *locator)
       : FailureDiagnostic(solution, locator), Member(member) {
     assert(member->hasName());
-    assert(locator->isForKeyPathComponent() ||
+    assert(locator->isInKeyPathComponent() ||
            locator->isForKeyPathDynamicMemberLookup());
   }
 

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -168,10 +168,14 @@ bool ConstraintLocator::isForKeyPathDynamicMemberLookup() const {
   return !path.empty() && path.back().isKeyPathDynamicMember();
 }
 
-bool ConstraintLocator::isForKeyPathComponent() const {
+bool ConstraintLocator::isInKeyPathComponent() const {
   return llvm::any_of(getPath(), [&](const LocatorPathElt &elt) {
     return elt.isKeyPathComponent();
   });
+}
+
+bool ConstraintLocator::isForKeyPathComponentResult() const {
+  return isLastElement<LocatorPathElt::KeyPathComponentResult>();
 }
 
 bool ConstraintLocator::isForGenericParameter() const {

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -1052,3 +1052,45 @@ func testSyntaxErrors() {
   _ = \A.a?;
   _ = \A.a!;
 }
+
+// SR-13364 - keypath missing optional crashes compiler: "Inactive constraints left over?"
+func sr13364() {
+  let _: KeyPath<String?, Int?> = \.utf8.count // expected-error {{no exact matches in reference to property 'count'}}
+  // expected-note@-1 {{found candidate with type 'Int'}}
+}
+
+// rdar://74711236 - crash due to incorrect member access in key path
+func rdar74711236() {
+  struct S {
+    var arr: [V] = []
+  }
+
+  struct V : Equatable {
+  }
+
+  enum Type {
+  case store
+  }
+
+  struct Context {
+    func supported() -> [Type] {
+      return []
+    }
+  }
+
+  func test(context: Context?) {
+    var s = S()
+
+    s.arr = {
+      // FIXME: Missing member reference is pattern needs a better diagnostic
+      if let type = context?.store { // expected-error {{type of expression is ambiguous without more context}}
+        // `isSupported` should be an invalid declaration to trigger a crash in `map(\.option)`
+        let isSupported = context!.supported().contains(type) // expected-error {{missing argument label 'where:' in call}} expected-error {{converting non-escaping value to '(Type) throws -> Bool' may allow it to escape}}
+        return (isSupported ? [type] : []).map(\.option)
+        // expected-error@-1 {{value of type 'Any' has no member 'option'}}
+        // expected-note@-2 {{cast 'Any' to 'AnyObject' or use 'as!' to force downcast to a more specific type to access members}}
+      }
+      return []
+    }()
+  }
+}


### PR DESCRIPTION
…ence, member type has been bound before base type

Cherry-pick of https://github.com/apple/swift/pull/36427

---

- Explanation:

Fixes a crash in constraint solver when it encounters an incorrect
member reference that managed to resolve a type from an enclosing context.

If member has been bound before the base and the base was
incorrect at that (e.g. fallback to default `Any` type),
then solver needs to re-activate all of the constraints
associated with this member reference otherwise some of
the constraints could be left unchecked in inactive state.

This is especially important for key path expressions because
`key path` constraint can't be retired until all components
are simplified.

- Scope: Expressions with incorrect member references, especially key path expressions.

- Main Branch PR: https://github.com/apple/swift/pull/36427

- Resolves: rdar://78035829

- Risk: Low

- Reviewed By: @hborla 

- Testing: Regression tests added to the suite

Resolves: rdar://78035829

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
