### PR TITLE
Sema: Fix a couple of issues with implicit overrides of generic designated initializers

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -418,30 +418,49 @@ synthesizeStubBody(AbstractFunctionDecl *fn, void *) {
            /*isTypeChecked=*/true };
 }
 
-static std::tuple<GenericSignature, GenericParamList *, SubstitutionMap>
-configureGenericDesignatedInitOverride(ASTContext &ctx,
+namespace {
+  struct DesignatedInitOverrideInfo {
+    GenericSignature GenericSig;
+    GenericParamList *GenericParams;
+    SubstitutionMap OverrideSubMap;
+  };
+}
+
+static DesignatedInitOverrideInfo
+computeDesignatedInitOverrideSignature(ASTContext &ctx,
                                        ClassDecl *classDecl,
                                        Type superclassTy,
                                        ConstructorDecl *superclassCtor) {
+  auto *moduleDecl = classDecl->getParentModule();
+
   auto *superclassDecl = superclassTy->getAnyNominal();
 
-  auto *moduleDecl = classDecl->getParentModule();
-  auto subMap = superclassTy->getContextSubstitutionMap(
-      moduleDecl, superclassDecl);
-
-  GenericSignature genericSig;
-  auto *genericParams = superclassCtor->getGenericParams();
-
+  auto classSig = classDecl->getGenericSignature();
   auto superclassCtorSig = superclassCtor->getGenericSignature();
   auto superclassSig = superclassDecl->getGenericSignature();
 
+  // These are our outputs.
+  GenericSignature genericSig = classSig;
+  auto *genericParams = superclassCtor->getGenericParams();
+  auto subMap = superclassTy->getContextSubstitutionMap(
+      moduleDecl, superclassDecl);
+
   if (superclassCtorSig.getPointer() != superclassSig.getPointer()) {
+    // If the base initiliazer's generic signature is different
+    // from that of the base class, the base class initializer either
+    // has generic parameters or a 'where' clause.
+    //
+    // We need to "rebase" the requirements on top of the derived class's
+    // generic signature.
+
     SmallVector<GenericTypeParamDecl *, 4> newParams;
     SmallVector<GenericTypeParamType *, 1> newParamTypes;
 
-    // Inheriting initializers that have their own generic parameters
+    // If genericParams is non-null, the base class initializer has its own
+    // generic parameters. Otherwise, it is non-generic with a contextual
+    // 'where' clause.
     if (genericParams) {
-      // First, clone the superclass constructor's generic parameter list,
+      // First, clone the base class initializer's generic parameter list,
       // but change the depth of the generic parameters to be one greater
       // than the depth of the subclass.
       unsigned depth = 0;
@@ -457,8 +476,8 @@ configureGenericDesignatedInitOverride(ASTContext &ctx,
         newParams.push_back(newParam);
       }
 
-      // We don't have to clone the requirements, because they're not
-      // used for anything.
+      // We don't have to clone the RequirementReprs, because they're not
+      // used for anything other than SIL mode.
       genericParams = GenericParamList::create(ctx,
                                                SourceLoc(),
                                                newParams,
@@ -473,7 +492,7 @@ configureGenericDesignatedInitOverride(ASTContext &ctx,
       }
     }
 
-    // Build a generic signature for the derived class initializer.
+    // The depth at which the initializer's own generic parameters start, if any.
     unsigned superclassDepth = 0;
     if (superclassSig)
       superclassDepth = superclassSig->getGenericParams().back()->getDepth() + 1;
@@ -482,44 +501,52 @@ configureGenericDesignatedInitOverride(ASTContext &ctx,
     // initializer to form the requirements of the derived class initializer.
     auto substFn = [&](SubstitutableType *type) -> Type {
       auto *gp = cast<GenericTypeParamType>(type);
+      // Generic parameters of the base class itself are mapped via the
+      // substitution map of the superclass type.
       if (gp->getDepth() < superclassDepth)
         return Type(gp).subst(subMap);
+
+      // Generic parameters added by the base class initializer map to the new
+      // generic parameters of the derived initializer.
       return genericParams->getParams()[gp->getIndex()]
                  ->getDeclaredInterfaceType();
     };
 
-    auto lookupConformanceFn =
-        [&](CanType depTy, Type substTy,
-            ProtocolDecl *proto) -> ProtocolConformanceRef {
-      if (auto conf = subMap.lookupConformance(depTy, proto))
-        return conf;
+    // If we don't have any new generic parameters and the derived class is
+    // not generic, the base class initializer's 'where' clause should already
+    // be fully satisfied, and we can just drop it.
+    if (genericParams != nullptr || classSig) {
+      auto lookupConformanceFn =
+          [&](CanType depTy, Type substTy,
+              ProtocolDecl *proto) -> ProtocolConformanceRef {
+        if (auto conf = subMap.lookupConformance(depTy, proto))
+          return conf;
 
-      return ProtocolConformanceRef(proto);
-    };
+        return ProtocolConformanceRef(proto);
+      };
 
-    SmallVector<Requirement, 2> requirements;
-    for (auto reqt : superclassCtorSig->getRequirements())
-      if (auto substReqt = reqt.subst(substFn, lookupConformanceFn))
-        requirements.push_back(*substReqt);
+      SmallVector<Requirement, 2> requirements;
+      for (auto reqt : superclassCtorSig->getRequirements())
+        if (auto substReqt = reqt.subst(substFn, lookupConformanceFn))
+          requirements.push_back(*substReqt);
 
-    // Now form the substitution map that will be used to remap parameter
-    // types.
-    subMap = SubstitutionMap::get(superclassCtorSig,
-                                  substFn, lookupConformanceFn);
+      // Now form the substitution map that will be used to remap parameter
+      // types.
+      subMap = SubstitutionMap::get(superclassCtorSig,
+                                    substFn, lookupConformanceFn);
 
-    genericSig = evaluateOrDefault(
-        ctx.evaluator,
-        AbstractGenericSignatureRequest{
-          classDecl->getGenericSignature().getPointer(),
-          std::move(newParamTypes),
-          std::move(requirements)
-        },
-        GenericSignature());
-  } else {
-    genericSig = classDecl->getGenericSignature();
+      genericSig = evaluateOrDefault(
+          ctx.evaluator,
+          AbstractGenericSignatureRequest{
+            classSig.getPointer(),
+            std::move(newParamTypes),
+            std::move(requirements)
+          },
+          GenericSignature());
+    }
   }
 
-  return std::make_tuple(genericSig, genericParams, subMap);
+  return DesignatedInitOverrideInfo{genericSig, genericParams, subMap};
 }
 
 static void
@@ -703,17 +730,33 @@ createDesignatedInitOverride(ClassDecl *classDecl,
     return nullptr;
   }
 
-  GenericSignature genericSig;
-  GenericParamList *genericParams;
-  SubstitutionMap subMap;
-
-  std::tie(genericSig, genericParams, subMap) =
-      configureGenericDesignatedInitOverride(ctx,
+  auto overrideInfo =
+      computeDesignatedInitOverrideSignature(ctx,
                                              classDecl,
                                              superclassTy,
                                              superclassCtor);
 
-  // Determine the initializer parameters.
+  if (auto superclassCtorSig = superclassCtor->getGenericSignature()) {
+    auto *genericEnv = (overrideInfo.GenericSig
+                        ? overrideInfo.GenericSig->getGenericEnvironment()
+                        : nullptr);
+
+    // If the base class initializer has a 'where' clause, it might impose
+    // requirements on the base class's own generic parameters that are not
+    // satisfied by the derived class. In this case, we don't want to inherit
+    // this initializer; there's no way to call it on the derived class.
+    auto checkResult = TypeChecker::checkGenericArguments(
+        superclassCtor, SourceLoc(), SourceLoc(), Type(),
+        superclassCtorSig->getGenericParams(),
+        superclassCtorSig->getRequirements(),
+        [&](Type type) -> Type {
+          auto substType = type.subst(overrideInfo.OverrideSubMap);
+          return GenericEnvironment::mapTypeIntoContext(
+            genericEnv, substType);
+        });
+    if (checkResult != RequirementCheckResult::Success)
+      return nullptr;
+  }
 
   // Create the initializer parameter patterns.
   OptionSet<ParameterList::CloneFlags> options
@@ -733,7 +776,7 @@ createDesignatedInitOverride(ClassDecl *classDecl,
     auto *bodyParam = bodyParams->get(idx);
 
     auto paramTy = superclassParam->getInterfaceType();
-    auto substTy = paramTy.subst(subMap);
+    auto substTy = paramTy.subst(overrideInfo.OverrideSubMap);
 
     bodyParam->setInterfaceType(substTy);
   }
@@ -748,12 +791,13 @@ createDesignatedInitOverride(ClassDecl *classDecl,
                               /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
                               /*Throws=*/superclassCtor->hasThrows(),
                               /*ThrowsLoc=*/SourceLoc(),
-                              bodyParams, genericParams, classDecl);
+                              bodyParams, overrideInfo.GenericParams,
+                              classDecl);
 
   ctor->setImplicit();
 
   // Set the interface type of the initializer.
-  ctor->setGenericSignature(genericSig);
+  ctor->setGenericSignature(overrideInfo.GenericSig);
 
   ctor->setImplicitlyUnwrappedOptional(
     superclassCtor->isImplicitlyUnwrappedOptional());

--- a/test/SILGen/designated_init_inheritance_with_where_clause.swift
+++ b/test/SILGen/designated_init_inheritance_with_where_clause.swift
@@ -20,3 +20,32 @@ public class Pony<U : Ungulate> : Horse<U> {
   // CHECK-LABEL: sil [serialized] [exact_self_class] [ossa] @$s45designated_init_inheritance_with_where_clause4PonyCACyxGycAA12DomesticatedRzrlufC : $@convention(method) <U where U : Domesticated, U : Ungulate> (@thick Pony<U>.Type) -> @owned Pony<U> {
   // CHECK-LABEL: sil [ossa] @$s45designated_init_inheritance_with_where_clause4PonyCACyxGycAA12DomesticatedRzrlufc : $@convention(method) <U where U : Domesticated, U : Ungulate> (@owned Pony<U>) -> @owned Pony<U> {
 }
+
+public class Barn<T> {
+  init(_: T) where T : AnyObject {}
+  init<U>(_: T, _: U) where T : Domesticated, U : Ungulate {}
+}
+
+public class BigBarn : Barn<AnyObject> {
+  // CHECK-LABEL: sil hidden [ossa] @$s45designated_init_inheritance_with_where_clause7BigBarnCyACyXlcfc : $@convention(method) (@owned AnyObject, @owned BigBarn) -> @owned BigBarn {
+}
+
+public struct Cat : Domesticated {}
+public struct Sheep : Ungulate {}
+
+public class SmallBarn : Barn<Cat> {
+  // CHECK-LABEL: sil hidden [ossa] @$s45designated_init_inheritance_with_where_clause9SmallBarnCyAcA3CatV_xtcAA8UngulateRzlufc : $@convention(method) <U where U : Ungulate> (Cat, @in U, @owned SmallBarn) -> @owned SmallBarn {
+  // CHECK-LABEL: sil private [thunk] [ossa] @$s45designated_init_inheritance_with_where_clause9SmallBarnCyAcA3CatV_xtcAA8UngulateRzlufCAA0H0CyAHyxGx_qd__tcAA12DomesticatedRzAaFRd__lufCTV : $@convention(method) <τ_0_0 where τ_0_0 : Ungulate> (@in Cat, @in τ_0_0, @thick SmallBarn.Type) -> @owned SmallBarn {
+}
+
+// CHECK-LABEL: sil_vtable [serialized] BigBarn {
+// CHECK-NEXT:     #Barn.init!allocator: <T where T : AnyObject> (Barn<T>.Type) -> (T) -> Barn<T> : @$s45designated_init_inheritance_with_where_clause7BigBarnCyACyXlcfC [override] // BigBarn.__allocating_init(_:)
+// CHECK-NEXT:   #Barn.init!allocator: <T where T : Domesticated><U where U : Ungulate> (Barn<T>.Type) -> (T, U) -> Barn<T> : @$s45designated_init_inheritance_with_where_clause4BarnCyACyxGx_qd__tcAA12DomesticatedRzAA8UngulateRd__lufC [inherited]  // Barn.__allocating_init<A>(_:_:)
+// CHECK-NEXT:   #BigBarn.deinit!deallocator: @$s45designated_init_inheritance_with_where_clause7BigBarnCfD  // BigBarn.__deallocating_deinit
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_vtable [serialized] SmallBarn {
+// CHECK-NEXT:   #Barn.init!allocator: <T where T : AnyObject> (Barn<T>.Type) -> (T) -> Barn<T> : @$s45designated_init_inheritance_with_where_clause4BarnCyACyxGxcRlzClufC [inherited] // Barn.__allocating_init<A>(_:)
+// CHECK-NEXT:   <T where T : Domesticated><U where U : Ungulate> (Barn<T>.Type) -> (T, U) -> Barn<T> : @$s45designated_init_inheritance_with_where_clause9SmallBarnCyAcA3CatV_xtcAA8UngulateRzlufCAA0H0CyAHyxGx_qd__tcAA12DomesticatedRzAaFRd__lufCTV [override] // vtable thunk for Barn.__allocating_init<A>(_:_:) dispatching to SmallBarn.__allocating_init<A>(_:_:)
+// CHECK-NEXT:   #SmallBarn.deinit!deallocator: @$s45designated_init_inheritance_with_where_clause9SmallBarnCfD  // SmallBarn.__deallocating_deinit
+// CHECK-NEXT: }


### PR DESCRIPTION
If a base class initializer was not generic but had a contextual 'where'
clause, we would unconditionally inherit the 'where' clause in the override as
part of the fix for another issue (https://bugs.swift.org/browse/SR-14118).

However, it is possible that some of those requirements are satisfied by
the derived class itself. For example:

    class Base<T> {
        init() where T : AnyObject {}
    }

    class Derived : Base<AnyObject> {}

In this case, the implicit override Derived.init() has no generic requirements
at all. We used to assert because we would create a GSB with no generic
parameters.

It was also possible for a base class initializer to have generic
requirements that are not satisfied by the derived class. In this case,
we need to drop the initializer from consideration altogether.

While I'm here, I improved the comments in computeDesignatedInitOverrideSignature(),
which is the new name for configureGenericDesignatedInitOverride().

Fixes rdar://problem/77285618.