### PR TITLE
[Concurrency] Provide an alternative implementation when "async { }" is unusable

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -831,8 +831,10 @@ func _getCurrentThreadPriority() -> Int
 @_alwaysEmitIntoClient
 @usableFromInline
 internal func _runTaskForBridgedAsyncMethod(_ body: @escaping () async -> Void) {
-#if compiler(>=5.5) && $Sendable
+#if compiler(>=5.5) && $Sendable && $InheritActorContext && $ImplicitSelfCapture
   async { await body() }
+#else
+  detach { await body() }
 #endif
 }
 


### PR DESCRIPTION
There exist Swift builds that support `Sendable` but not the attributes
used on `async`. Make sure that have an implementation of
`_runTaskForBridgedAsyncMethod` that does something.

Fixes rdar://77637570.
