### PR TITLE
[SILGen] Allow capturing local wrapped properties.

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2829,8 +2829,15 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
       // of its accessors.
       if (auto capturedVar = dyn_cast<VarDecl>(capture.getDecl())) {
         auto collectAccessorCaptures = [&](AccessorKind kind) {
-          if (auto *accessor = capturedVar->getParsedAccessor(kind))
+          if (auto *accessor = capturedVar->getParsedAccessor(kind)) {
             collectFunctionCaptures(accessor);
+          } else if (capturedVar->hasAttachedPropertyWrapper() ||
+                     capturedVar->getOriginalWrappedProperty(
+                         PropertyWrapperSynthesizedPropertyKind::Projection)) {
+            // Wrapped properties have synthesized accessors.
+            if (auto *accessor = capturedVar->getSynthesizedAccessor(kind))
+              collectFunctionCaptures(accessor);
+          }
         };
 
         // 'Lazy' properties don't fit into the below categorization,

--- a/test/SILGen/property_wrapper_local.swift
+++ b/test/SILGen/property_wrapper_local.swift
@@ -173,3 +173,20 @@ func testLocalReference(count: Int) {
   // setter of value #1 in testLocalReference(count:)
   // CHECK: sil private [ossa] @$s22property_wrapper_local18testLocalReference5countySi_tF5valueL_Sivs : $@convention(thin) (Int, @guaranteed { var BoundedNumber<Int> }) -> ()
 }
+
+func takesAutoclosure(_: @autoclosure () -> Int) {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s22property_wrapper_local12testCapturesyyF : $@convention(thin) () -> ()
+func testCaptures() {
+  @Wrapper var value = 10
+  takesAutoclosure(value)
+  // implicit closure #1 in testCaptures()
+  // CHECK-LABEL: sil private [transparent] [ossa] @$s22property_wrapper_local12testCapturesyyFSiyXEfu_ : $@convention(thin) (@guaranteed { var Wrapper<Int> }) -> Int
+
+  let _: () -> Void = {
+    _ = value
+    value = 100
+  }
+  // closure #1 in testCaptures()
+  // CHECK-LABEL: sil private [ossa] @$s22property_wrapper_local12testCapturesyyFyycfU_ : $@convention(thin) (@guaranteed { var Wrapper<Int> }) -> ()
+}

--- a/test/SILGen/property_wrapper_parameter.swift
+++ b/test/SILGen/property_wrapper_parameter.swift
@@ -301,3 +301,41 @@ func testImplicitWrapperWithResilientStruct() {
   // property wrapper init from projected value of $value #1 in closure #1 in implicit closure #1 in testImplicitWrapperWithResilientStruct()
   // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter38testImplicitWrapperWithResilientStructyyFyAA010ProjectionF0Vy11def_structA1AVGcfu_yAHcfU_6$valueL_AHvpfW : $@convention(thin) (@in ProjectionWrapper<A>) -> @out ProjectionWrapper<A>
 }
+
+func takesAutoclosure(_: @autoclosure () -> Int) {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter12testCaptures3ref5valueySi_AA7WrapperVySiGtF : $@convention(thin) (Int, Wrapper<Int>) -> ()
+func testCaptures(@ClassWrapper ref: Int, @Wrapper value: Int) {
+  takesAutoclosure(ref)
+  // implicit closure #1 in testCaptures(ref:value:)
+  // CHECK-LABEL: sil private [transparent] [ossa] @$s26property_wrapper_parameter12testCaptures3ref5valueySi_AA7WrapperVySiGtFSiyXEfu_ : $@convention(thin) (@guaranteed ClassWrapper<Int>) -> Int
+
+  let _: () -> Void = {
+    _ = ref
+    ref = 100
+  }
+  // closure #1 in testCaptures(ref:value:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter12testCaptures3ref5valueySi_AA7WrapperVySiGtFyycfU_ : $@convention(thin) (@guaranteed ClassWrapper<Int>) -> ()
+
+  let _: () -> Projection<Int> = { $value }
+  // closure #2 in testCaptures(ref:value:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter12testCaptures3ref5valueySi_AA7WrapperVySiGtFAA10ProjectionVySiGycfU0_ : $@convention(thin) (Wrapper<Int>) -> Projection<Int>
+
+  let _: (ProjectionWrapper<Int>) -> Void = { $x in
+    _ = { x }
+    _ = { $x }
+  }
+  // Make sure there are 4 closures here with the right arguments
+
+  // implicit closure #2 in testCaptures(ref:value:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter12testCaptures3ref5valueySi_AA7WrapperVySiGtFyAA010ProjectionH0VySiGcfu0_ : $@convention(thin) (ProjectionWrapper<Int>) -> ()
+
+  // closure #3 in implicit closure #2 in testCaptures(ref:value:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter12testCaptures3ref5valueySi_AA7WrapperVySiGtFyAA010ProjectionH0VySiGcfu0_yAJcfU1_ : $@convention(thin) (ProjectionWrapper<Int>) -> ()
+
+  // closure #1 in closure #2 in implicit closure #2 in testCaptures(ref:value:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter12testCaptures3ref5valueySi_AA7WrapperVySiGtFyAA010ProjectionH0VySiGcfu0_yAJcfU1_SiycfU_ : $@convention(thin) (ProjectionWrapper<Int>) -> Int
+
+  // closure #2 in closure #2 in implicit closure #2 in testCaptures(ref:value:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter12testCaptures3ref5valueySi_AA7WrapperVySiGtFyAA010ProjectionH0VySiGcfu0_yAJcfU1_AJycfU0_ : $@convention(thin) (ProjectionWrapper<Int>) -> ProjectionWrapper<Int>
+}


### PR DESCRIPTION
When collecting transitive captures of local computed property accessors, use synthesized accessors for wrapped and projected properties. Otherwise, the backing property wrapper storage won't be emitted as a capture, leading to a cryptic (and bogus) compiler error:

```swift
@propertyWrapper
struct IntWrapper {
  var wrappedValue: Int
}

func fn() {
  @IntWrapper var myInt = 42 // error: Closure captures '_myInt' before it is declared
  let _ = {
    myInt = 100
  }
}
```

This change fixes capturing local wrapped properties (including parameters).

Resolves: rdar://74457878