### PR TITLE
GSB: When looking at protocol refinements, only consider other sources on 'Self'

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2424,6 +2424,10 @@ NOTE(redundant_conformance_here,none,
      "conformance constraint %0 : %1 implied here",
      (Type, ProtocolDecl *))
 
+WARNING(missing_protocol_refinement, none,
+        "protocol %0 should be declared to refine %1 due to a same-type constraint on 'Self'",
+        (ProtocolDecl *, ProtocolDecl *))
+
 ERROR(unsupported_recursive_requirements, none,
       "requirement involves recursion that is not currently supported", ())
 

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -689,6 +689,9 @@ private:
   void computeRedundantRequirements(
       const ProtocolDecl *requirementSignatureSelfProto);
 
+  void diagnoseProtocolRefinement(
+      const ProtocolDecl *requirementSignatureSelfProto);
+
   void diagnoseRedundantRequirements() const;
 
   void diagnoseConflictingConcreteTypeRequirements(

--- a/test/Generics/redundant_protocol_refinement.swift
+++ b/test/Generics/redundant_protocol_refinement.swift
@@ -1,0 +1,24 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+
+protocol Base {}
+protocol Middle : Base {}
+protocol Derived : Middle, Base {}
+// expected-note@-1 {{conformance constraint 'Self' : 'Base' implied here}}
+// expected-warning@-2 {{redundant conformance constraint 'Self' : 'Base'}}
+
+protocol P1 {}
+
+protocol P2 {
+  associatedtype Assoc: P1
+}
+
+// no warning here
+protocol Good: P2, P1 where Assoc == Self {}
+// CHECK-LABEL: Requirement signature: <Self where Self : P1, Self : P2, Self == Self.Assoc>
+
+// missing refinement of 'P1'
+protocol Bad: P2 where Assoc == Self {}
+// expected-warning@-1 {{protocol 'Bad' should be declared to refine 'P1' due to a same-type constraint on 'Self'}}
+// expected-note@-2 {{conformance constraint 'Self' : 'P1' implied here}}
+// CHECK-LABEL: Requirement signature: <Self where Self : P2, Self == Self.Assoc>

--- a/test/Interpreter/sr10941.swift
+++ b/test/Interpreter/sr10941.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+// REQUIRES: executable_test
+
+// https://bugs.swift.org/browse/SR-10941
+
+public protocol SupportedPropertyType { }
+
+public protocol TypedSupportedType: SupportedPropertyType where FactoryType.BuildType == Self {
+    associatedtype FactoryType: TypedSupportedTypeFactory
+}
+
+public protocol TypedSupportedTypeFactory {
+    associatedtype BuildType: SupportedPropertyType
+}
+
+public class Factory<BuildType: TypedSupportedType>: TypedSupportedTypeFactory {
+}
+
+public struct ContentMode : TypedSupportedType {
+    public typealias FactoryType = Factory<ContentMode>
+}
+
+func bar<T : SupportedPropertyType>(_: T.Type) {}
+
+func baz<T : TypedSupportedType>(_ t: T.Type) {
+  bar(t)
+}
+
+// This used to recurse infinitely because the base witness table
+// for 'ContentMode : SupportedPropertyType' was incorrectly
+// minimized away.
+baz(ContentMode.self)

--- a/validation-test/compiler_crashers_2_fixed/rdar57728533.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar57728533.swift
@@ -1,0 +1,10 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+protocol Item {
+  associatedtype Rule
+  func isValide(valid: Rule) -> Bool
+}
+
+protocol PairableItem: Item {
+  associatedtype AssociatedItem: PairableItem where AssociatedItem.Rule: Rule
+}

--- a/validation-test/compiler_crashers_2_fixed/sr9584.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr9584.swift
@@ -1,0 +1,14 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+struct S<N> {}
+
+protocol P {
+  associatedtype A: P = Self
+  static func f(_ x: A) -> A
+}
+
+extension S: P where N: P {
+  static func f<X: P>(_ x: X) -> S<X.A> where A == X, X.A == N {
+    return S<X.A>()
+  }
+}


### PR DESCRIPTION
In a protocol requirement signature, a conformance requirement on 'Self'
can only be considered redundant if it is derived entirely from other
sources only involving 'Self' as a subject type.

What this means in practice is that we will never try to build
a witness table for an inherited conformance from an associated
conformance.

This is important since witness tables for inherited conformances
are realized eagerly before the witness table for the original
conformance, and allowing more complex requirement sources for
inherited conformances could introduce cycles at runtime.

What used to happen is that we would emit a bogus 'redundant conformance'
warning if a refined protocol conformance was also reachable via a
same-type requirement involving 'Self'. Fixing this warning by removing
the requirement could produce code that type checked, however it could
crash at runtime.

In addition to the runtime issue, such 'overly minimized' protocols
could also break name lookup at compile-time, since name lookup
only consults the inheritance clause of a protocol declaration instead
of computing its generic signature to determine the set of refined
protocols.

Now, we will no longer emit the bogus redundant conformance warnings.
Instead, we produce a warning if a protocol is 'overly minimized'.

Since the 'overly minimized' protocols that were obtained by fixing
the bogus warning would in some cases still work, we cannot diagnose
the new violation as an error, to preserve source and ABI compatibility.

Currently this warning fires for the SIMDScalar protocol in the
standard library, and _ErrorCodeProtocol in the Foundation overlay.
We should see if we can fix the protocols in an ABI-compatible way,
or just add a hack to muffle the warning.

Fixes https://bugs.swift.org/browse/SR-8198 / rdar://problem/77358480,
https://bugs.swift.org/browse/SR-10941 / rdar://problem/77358477,
https://bugs.swift.org/browse/SR-11670 / rdar://problem/77358476.