### PR TITLE
[sil][debug-info] Refactor SILInstruction SILLocation verification out of SILVerifier onto a helper/use to verify in SILBuilder

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2622,6 +2622,11 @@ private:
     C.notifyInserted(TheInst);
 
 #ifndef NDEBUG
+    // If we are inserting into a specific function (rather than a block for a
+    // global_addr), verify that our instruction/the associated location are in
+    // sync. We don't care if an instruction is used in global_addr.
+    if (F)
+      TheInst->verifyDebugInfo();
     TheInst->verifyOperandOwnership();
 #endif
   }

--- a/include/swift/SIL/SILDebugScope.h
+++ b/include/swift/SIL/SILDebugScope.h
@@ -95,7 +95,7 @@ public:
 };
 
 /// Determine whether an instruction may not have a SILDebugScope.
-bool maybeScopeless(SILInstruction &I);
+bool maybeScopeless(const SILInstruction &inst);
 
 /// Knows how to make a deep copy of a debug scope.
 class ScopeCloner {

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -733,6 +733,10 @@ public:
   /// with this instruction.
   void verifyOperandOwnership() const;
 
+  /// Verify that this instruction and its associated debug information follow
+  /// all SIL debug info invariants.
+  void verifyDebugInfo() const;
+
   /// Get the number of created SILInstructions.
   static int getNumCreatedInstructions() {
     return NumCreatedInstructions;

--- a/lib/SIL/IR/SILDebugScope.cpp
+++ b/lib/SIL/IR/SILDebugScope.cpp
@@ -57,8 +57,8 @@ SILFunction *SILDebugScope::getParentFunction() const {
 }
 
 /// Determine whether an instruction may not have a SILDebugScope.
-bool swift::maybeScopeless(SILInstruction &I) {
-  if (I.getFunction()->isBare())
+bool swift::maybeScopeless(const SILInstruction &inst) {
+  if (inst.getFunction()->isBare())
     return true;
-  return !isa<DebugValueInst>(I) && !isa<DebugValueAddrInst>(I);
+  return !isa<DebugValueInst>(inst) && !isa<DebugValueAddrInst>(inst);
 }

--- a/lib/SIL/Verifier/CMakeLists.txt
+++ b/lib/SIL/Verifier/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(swiftSIL PRIVATE
+  DebugInfoVerifier.cpp
   LoadBorrowImmutabilityChecker.cpp
   LinearLifetimeChecker.cpp
   MemoryLifetimeVerifier.cpp

--- a/lib/SIL/Verifier/DebugInfoVerifier.cpp
+++ b/lib/SIL/Verifier/DebugInfoVerifier.cpp
@@ -1,0 +1,57 @@
+//===--- DebugInfoVerifier.cpp --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// Utility verifier code for validating debug info.
+///
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/SILDebugScope.h"
+#include "swift/SIL/SILInstruction.h"
+
+using namespace swift;
+
+//===----------------------------------------------------------------------===//
+//                   MARK: Verify SILInstruction Debug Info
+//===----------------------------------------------------------------------===//
+
+void SILInstruction::verifyDebugInfo() const {
+  auto require = [&](bool reqt, StringRef message) {
+    if (!reqt) {
+      llvm::errs() << message << "\n";
+      assert(false && "invoking standard assertion failure");
+    }
+  };
+
+  // Check the location kind.
+  SILLocation loc = getLoc();
+  SILLocation::LocationKind locKind = loc.getKind();
+  SILInstructionKind instKind = getKind();
+
+  // Regular locations are allowed on all instructions.
+  if (locKind == SILLocation::RegularKind)
+    return;
+
+  if (locKind == SILLocation::ReturnKind ||
+      locKind == SILLocation::ImplicitReturnKind)
+    require(
+        instKind == SILInstructionKind::BranchInst ||
+            instKind == SILInstructionKind::ReturnInst ||
+            instKind == SILInstructionKind::UnreachableInst,
+        "return locations are only allowed on branch and return instructions");
+
+  if (locKind == SILLocation::ArtificialUnreachableKind)
+    require(
+        instKind == SILInstructionKind::UnreachableInst,
+        "artificial locations are only allowed on Unreachable instructions");
+}


### PR DESCRIPTION
This will ensure that we catch these issues earlier when they are introduced rather than after a pass that introduced the problem finished running (and we run the verifier).