### PR TITLE
[5.5-05142021][SILGen] Allow capturing local wrapped properties. 

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2829,8 +2829,15 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
       // of its accessors.
       if (auto capturedVar = dyn_cast<VarDecl>(capture.getDecl())) {
         auto collectAccessorCaptures = [&](AccessorKind kind) {
-          if (auto *accessor = capturedVar->getParsedAccessor(kind))
+          if (auto *accessor = capturedVar->getParsedAccessor(kind)) {
             collectFunctionCaptures(accessor);
+          } else if (capturedVar->hasAttachedPropertyWrapper() ||
+                     capturedVar->getOriginalWrappedProperty(
+                         PropertyWrapperSynthesizedPropertyKind::Projection)) {
+            // Wrapped properties have synthesized accessors.
+            if (auto *accessor = capturedVar->getSynthesizedAccessor(kind))
+              collectFunctionCaptures(accessor);
+          }
         };
 
         // 'Lazy' properties don't fit into the below categorization,

--- a/test/SILGen/property_wrapper_local.swift
+++ b/test/SILGen/property_wrapper_local.swift
@@ -173,3 +173,20 @@ func testLocalReference(count: Int) {
   // setter of value #1 in testLocalReference(count:)
   // CHECK: sil private [ossa] @$s22property_wrapper_local18testLocalReference5countySi_tF5valueL_Sivs : $@convention(thin) (Int, @guaranteed { var BoundedNumber<Int> }) -> ()
 }
+
+func takesAutoclosure(_: @autoclosure () -> Int) {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s22property_wrapper_local12testCapturesyyF : $@convention(thin) () -> ()
+func testCaptures() {
+  @Wrapper var value = 10
+  takesAutoclosure(value)
+  // implicit closure #1 in testCaptures()
+  // CHECK-LABEL: sil private [transparent] [ossa] @$s22property_wrapper_local12testCapturesyyFSiyXEfu_ : $@convention(thin) (@guaranteed { var Wrapper<Int> }) -> Int
+
+  let _: () -> Void = {
+    _ = value
+    value = 100
+  }
+  // closure #1 in testCaptures()
+  // CHECK-LABEL: sil private [ossa] @$s22property_wrapper_local12testCapturesyyFyycfU_ : $@convention(thin) (@guaranteed { var Wrapper<Int> }) -> ()
+}

--- a/test/SILGen/property_wrapper_parameter.swift
+++ b/test/SILGen/property_wrapper_parameter.swift
@@ -301,3 +301,41 @@ func testImplicitWrapperWithResilientStruct() {
   // property wrapper init from projected value of $value #1 in closure #1 in implicit closure #1 in testImplicitWrapperWithResilientStruct()
   // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter38testImplicitWrapperWithResilientStructyyFyAA010ProjectionF0Vy11def_structA1AVGcfu_yAHcfU_6$valueL_AHvpfW : $@convention(thin) (@in ProjectionWrapper<A>) -> @out ProjectionWrapper<A>
 }
+
+func takesAutoclosure(_: @autoclosure () -> Int) {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter12testCaptures3ref5valueySi_AA7WrapperVySiGtF : $@convention(thin) (Int, Wrapper<Int>) -> ()
+func testCaptures(@ClassWrapper ref: Int, @Wrapper value: Int) {
+  takesAutoclosure(ref)
+  // implicit closure #1 in testCaptures(ref:value:)
+  // CHECK-LABEL: sil private [transparent] [ossa] @$s26property_wrapper_parameter12testCaptures3ref5valueySi_AA7WrapperVySiGtFSiyXEfu_ : $@convention(thin) (@guaranteed ClassWrapper<Int>) -> Int
+
+  let _: () -> Void = {
+    _ = ref
+    ref = 100
+  }
+  // closure #1 in testCaptures(ref:value:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter12testCaptures3ref5valueySi_AA7WrapperVySiGtFyycfU_ : $@convention(thin) (@guaranteed ClassWrapper<Int>) -> ()
+
+  let _: () -> Projection<Int> = { $value }
+  // closure #2 in testCaptures(ref:value:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter12testCaptures3ref5valueySi_AA7WrapperVySiGtFAA10ProjectionVySiGycfU0_ : $@convention(thin) (Wrapper<Int>) -> Projection<Int>
+
+  let _: (ProjectionWrapper<Int>) -> Void = { $x in
+    _ = { x }
+    _ = { $x }
+  }
+  // Make sure there are 4 closures here with the right arguments
+
+  // implicit closure #2 in testCaptures(ref:value:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter12testCaptures3ref5valueySi_AA7WrapperVySiGtFyAA010ProjectionH0VySiGcfu0_ : $@convention(thin) (ProjectionWrapper<Int>) -> ()
+
+  // closure #3 in implicit closure #2 in testCaptures(ref:value:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter12testCaptures3ref5valueySi_AA7WrapperVySiGtFyAA010ProjectionH0VySiGcfu0_yAJcfU1_ : $@convention(thin) (ProjectionWrapper<Int>) -> ()
+
+  // closure #1 in closure #2 in implicit closure #2 in testCaptures(ref:value:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter12testCaptures3ref5valueySi_AA7WrapperVySiGtFyAA010ProjectionH0VySiGcfu0_yAJcfU1_SiycfU_ : $@convention(thin) (ProjectionWrapper<Int>) -> Int
+
+  // closure #2 in closure #2 in implicit closure #2 in testCaptures(ref:value:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter12testCaptures3ref5valueySi_AA7WrapperVySiGtFyAA010ProjectionH0VySiGcfu0_yAJcfU1_AJycfU0_ : $@convention(thin) (ProjectionWrapper<Int>) -> ProjectionWrapper<Int>
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/37467 (5.5) / https://github.com/apple/swift/pull/37464 (main)

* **Explanation**: Property wrappers on local variables were new in Swift 5.4, and in Swift 5.5 property wrappers are allowed on parameters as well. This is the first kind of local computed property to have synthesized accessors that capture other variables, rather than accessors that are explicitly written by the programmer. The compiler's implementation of computing and emitting local captures in SILGen relied on accessors being parsed rather than synthesized. So, transitive captures in local property wrapper accessors were not properly emitted when the wrapped variable is captured in a closure, leading to cryptic/bogus compiler errors because the backing property wrapper storage was not captured in the closure. The fix is simply to use synthesized accessors to compute transitive captures for wrapped variables in a local context.
* **Scope**: The scope is limited to property wrappers on local variables and parameters that are captured in closures.
* **Risk**: Very low.
* **Testing**: Added several SILGen tests to exercise capturing local property wrappers and wrapped parameters.
* **Reviewer**: @slavapestov 

Resolves: rdar://74457878