### PR TITLE
[NFC][tests] Add regression tests for SR-14499

### DIFF
--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -1111,3 +1111,42 @@ func test_kp_as_function_mismatch() {
   _ = a.filter(\String.filterOut) // expected-error{{key path value type '(String) throws -> Bool' cannot be converted to contextual type 'Bool'}}
 
 }
+
+// SR-14499
+struct SR14499_A { }
+struct SR14499_B { }
+
+func sr14499() {
+  func reproduceA() -> [(SR14499_A, SR14499_B)] {
+    [
+      (true, .init(), SR14499_B.init()) // expected-error {{cannot infer contextual base in reference to member 'init'}}
+    ]
+    .filter(\.0) // expected-error {{value of type 'Any' has no member '0'}}
+    // expected-note@-1 {{cast 'Any' to 'AnyObject' or use 'as!' to force downcast to a more specific type to access members}}
+    .prefix(3)
+    .map { ($0.1, $0.2) } // expected-error {{value of type 'Any' has no member '1'}} expected-error{{value of type 'Any' has no member '2'}}
+    // expected-note@-1 2 {{cast 'Any' to 'AnyObject' or use 'as!' to force downcast to a more specific type to access members}}
+  }
+
+  func reproduceB() -> [(SR14499_A, SR14499_B)] {
+    [
+      (true, SR14499_A.init(), .init()) // expected-error {{cannot infer contextual base in reference to member 'init'}}
+    ]
+    .filter(\.0) // expected-error {{value of type 'Any' has no member '0'}}
+    // expected-note@-1 {{cast 'Any' to 'AnyObject' or use 'as!' to force downcast to a more specific type to access members}}
+    .prefix(3)
+    .map { ($0.1, $0.2) } // expected-error {{value of type 'Any' has no member '1'}} expected-error{{value of type 'Any' has no member '2'}}
+    // expected-note@-1 2 {{cast 'Any' to 'AnyObject' or use 'as!' to force downcast to a more specific type to access members}}
+  }
+
+  func reproduceC() -> [(SR14499_A, SR14499_B)] {
+    [
+      (true, .init(), .init()) // expected-error 2 {{cannot infer contextual base in reference to member 'init'}}
+    ]
+    .filter(\.0) // expected-error {{value of type 'Any' has no member '0'}}
+    // expected-note@-1 {{cast 'Any' to 'AnyObject' or use 'as!' to force downcast to a more specific type to access members}}
+    .prefix(3)
+    .map { ($0.1, $0.2) } // expected-error {{value of type 'Any' has no member '1'}} expected-error{{value of type 'Any' has no member '2'}}
+    // expected-note@-1 2 {{cast 'Any' to 'AnyObject' or use 'as!' to force downcast to a more specific type to access members}}
+  }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
SR-14499 was probably fixed by #36427 as well, but since is a slightly different context case to reproduce, maybe worth add the regression test? I thought would be a good thing to add also because of the diagnostics. So let me know if makes sense =]

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
