### PR TITLE
AliasAnalysis: check for immutable scopes.

### DIFF
--- a/include/swift/Basic/ValueEnumerator.h
+++ b/include/swift/Basic/ValueEnumerator.h
@@ -18,18 +18,20 @@
 
 namespace swift {
 
+typedef unsigned ValueIndexTy;
+
 /// / This class maps values to unique indices.
-template<class ValueTy, class IndexTy = size_t>
+template<class ValueTy>
 class ValueEnumerator {
   /// A running counter to enumerate values.
-  IndexTy counter = 0;
+  ValueIndexTy counter = 0;
 
   /// Maps values to unique integers.
-  llvm::DenseMap<ValueTy, IndexTy> ValueToIndex;
+  llvm::DenseMap<ValueTy, ValueIndexTy> ValueToIndex;
 
 public:
   /// Return the index of value \p v.
-  IndexTy getIndex(const ValueTy &v) {
+  ValueIndexTy getIndex(const ValueTy &v) {
     // Return the index of this Key, if we've assigned one already.
     auto It = ValueToIndex.find(v);
     if (It != ValueToIndex.end()) {
@@ -38,6 +40,7 @@ public:
 
     // Generate a new counter for the key.
     ValueToIndex[v] = ++counter;
+    assert(counter != 0 && "counter overflow in ValueEnumerator");
     return counter;
   }
 

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -1076,10 +1076,10 @@ void findTransitiveReborrowBaseValuePairs(
     BorrowingOperand initialScopeOperand, SILValue origBaseValue,
     function_ref<void(SILPhiArgument *, SILValue)> visitReborrowBaseValuePair);
 
-/// Given a begin_borrow visit all end_borrow users of the borrow or its
-/// reborrows.
+/// Given a begin of a borrow scope, visit all end_borrow users of the borrow or
+/// its reborrows.
 void visitTransitiveEndBorrows(
-    BeginBorrowInst *borrowInst,
+    BorrowedValue beginBorrow,
     function_ref<void(EndBorrowInst *)> visitEndBorrow);
 
 } // namespace swift

--- a/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
@@ -27,26 +27,26 @@ namespace {
   /// A key used for the AliasAnalysis cache.
   ///
   /// This struct represents the argument list to the method 'alias'.  The two
-  /// SILValue pointers are mapped to size_t indices because we need an
+  /// SILValue pointers are mapped to integer indices because we need an
   /// efficient way to invalidate them (the mechanism is described below). The
   /// Type arguments are translated to void* because their underlying storage is
   /// opaque pointers that never goes away.
   struct AliasKeyTy {
     // The SILValue pair:
-    size_t V1, V2;
+    swift::ValueIndexTy V1, V2;
     // The TBAAType pair:
     void *T1, *T2;
   };
 
   /// A key used for the MemoryBehavior Analysis cache.
   ///
-  /// The two SILValue pointers are mapped to size_t indices because we need an
+  /// The two SILValue pointers are mapped to integer indices because we need an
   /// efficient way to invalidate them (the mechanism is described below).  The
   /// RetainObserveKind represents the inspection mode for the memory behavior
   /// analysis.
   struct MemBehaviorKeyTy {
     // The SILValue pair:
-    size_t V1, V2;
+    swift::ValueIndexTy V1, V2;
   };
 }
 
@@ -276,17 +276,17 @@ SILType computeTBAAType(SILValue V);
 namespace llvm {
   template <> struct DenseMapInfo<AliasKeyTy> {
     static inline AliasKeyTy getEmptyKey() {
-      auto Allone = std::numeric_limits<size_t>::max();
+      auto Allone = std::numeric_limits<swift::ValueIndexTy>::max();
       return {0, Allone, nullptr, nullptr};
     }
     static inline AliasKeyTy getTombstoneKey() {
-      auto Allone = std::numeric_limits<size_t>::max();
+      auto Allone = std::numeric_limits<swift::ValueIndexTy>::max();
       return {Allone, 0, nullptr, nullptr};
     }
     static unsigned getHashValue(const AliasKeyTy Val) {
       unsigned H = 0;
-      H ^= DenseMapInfo<size_t>::getHashValue(Val.V1);
-      H ^= DenseMapInfo<size_t>::getHashValue(Val.V2);
+      H ^= DenseMapInfo<swift::ValueIndexTy>::getHashValue(Val.V1);
+      H ^= DenseMapInfo<swift::ValueIndexTy>::getHashValue(Val.V2);
       H ^= DenseMapInfo<void *>::getHashValue(Val.T1);
       H ^= DenseMapInfo<void *>::getHashValue(Val.T2);
       return H;
@@ -301,17 +301,17 @@ namespace llvm {
 
   template <> struct DenseMapInfo<MemBehaviorKeyTy> {
     static inline MemBehaviorKeyTy getEmptyKey() {
-      auto Allone = std::numeric_limits<size_t>::max();
+      auto Allone = std::numeric_limits<swift::ValueIndexTy>::max();
       return {0, Allone};
     }
     static inline MemBehaviorKeyTy getTombstoneKey() {
-      auto Allone = std::numeric_limits<size_t>::max();
+      auto Allone = std::numeric_limits<swift::ValueIndexTy>::max();
       return {Allone, 0};
     }
     static unsigned getHashValue(const MemBehaviorKeyTy V) {
       unsigned H = 0;
-      H ^= DenseMapInfo<size_t>::getHashValue(V.V1);
-      H ^= DenseMapInfo<size_t>::getHashValue(V.V2);
+      H ^= DenseMapInfo<swift::ValueIndexTy>::getHashValue(V.V1);
+      H ^= DenseMapInfo<swift::ValueIndexTy>::getHashValue(V.V2);
       return H;
     }
     static bool isEqual(const MemBehaviorKeyTy LHS,

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -1327,10 +1327,10 @@ void swift::findTransitiveReborrowBaseValuePairs(
 }
 
 void swift::visitTransitiveEndBorrows(
-    BeginBorrowInst *borrowInst,
+    BorrowedValue beginBorrow,
     function_ref<void(EndBorrowInst *)> visitEndBorrow) {
   SmallSetVector<SILValue, 4> worklist;
-  worklist.insert(borrowInst);
+  worklist.insert(beginBorrow.value);
 
   while (!worklist.empty()) {
     auto val = worklist.pop_back_val();

--- a/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
@@ -818,11 +818,11 @@ SILAnalysis *swift::createAliasAnalysis(SILModule *M) {
 
 AliasKeyTy AliasAnalysis::toAliasKey(SILValue V1, SILValue V2,
                                      SILType Type1, SILType Type2) {
-  size_t idx1 = ValueToIndex.getIndex(V1);
-  assert(idx1 != std::numeric_limits<size_t>::max() &&
+  ValueIndexTy idx1 = ValueToIndex.getIndex(V1);
+  assert(idx1 != std::numeric_limits<ValueIndexTy>::max() &&
          "~0 index reserved for empty/tombstone keys");
-  size_t idx2 = ValueToIndex.getIndex(V2);
-  assert(idx2 != std::numeric_limits<size_t>::max() &&
+  ValueIndexTy idx2 = ValueToIndex.getIndex(V2);
+  assert(idx2 != std::numeric_limits<ValueIndexTy>::max() &&
          "~0 index reserved for empty/tombstone keys");
   void *t1 = Type1.getOpaqueValue();
   void *t2 = Type2.getOpaqueValue();

--- a/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
+++ b/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
@@ -15,6 +15,8 @@
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/MemAccessUtils.h"
 #include "swift/SIL/SILVisitor.h"
+#include "swift/SIL/OwnershipUtils.h"
+#include "swift/SIL/BasicBlockBits.h"
 #include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
 #include "swift/SILOptimizer/Analysis/EscapeAnalysis.h"
 #include "swift/SILOptimizer/Analysis/SideEffectAnalysis.h"
@@ -27,6 +29,11 @@ using namespace swift;
 // We limit the size of the MB cache to 2**14 because we want to limit the
 // memory usage of this cache.
 static const int MemoryBehaviorAnalysisMaxCacheSize = 16384;
+
+// The maximum size of instsInImmutableScopes.
+// Usually more than enough. But in corner cases it can grow quadratically (in
+// case of many large nested immutable scopes).
+static const int ImmutableScopeInstsMaxSize = 18384;
 
 //===----------------------------------------------------------------------===//
 //                       Memory Behavior Implementation
@@ -536,12 +543,162 @@ AliasAnalysis::computeMemoryBehavior(SILInstruction *Inst, SILValue V) {
   return Result;
 }
 
+/// If \p V is an address of an immutable memory, return the begin of the
+/// scope where the memory can be considered to be immutable.
+///
+/// This is either a ``begin_access [read]`` in case V is the result of the
+/// begin_access or a projection of it.
+/// Or it is the begin of a borrow scope (begin_borrow, load_borrow, a
+/// guaranteed function argument) of an immutable copy-on-write buffer.
+/// For example:
+///   %b = begin_borrow %array_buffer
+///   %V = ref_element_addr [immutable] %b : $BufferType, #BufferType.someField
+///
+static SILValue getBeginScopeInst(SILValue V) {
+  SILValue accessScope = getAccessScope(V);
+  if (auto *access = dyn_cast<BeginAccessInst>(accessScope)) {
+    if (access->getAccessKind() == SILAccessKind::Read &&
+        access->getEnforcement() != SILAccessEnforcement::Unsafe)
+      return access;
+    return SILValue();
+  }
+  SILValue accessBase = getAccessBase(V);
+  SILValue object;
+  if (auto *elementAddr = dyn_cast<RefElementAddrInst>(accessBase)) {
+    if (!elementAddr->isImmutable())
+      return SILValue();
+    object = elementAddr->getOperand();
+  } else if (auto *tailAddr = dyn_cast<RefTailAddrInst>(accessBase)) {
+    if (!tailAddr->isImmutable())
+      return SILValue();
+    object = tailAddr->getOperand();
+  } else {
+    return SILValue();
+  }
+  if (BorrowedValue borrowedObj = getSingleBorrowIntroducingValue(object)) {
+    return borrowedObj.value;
+  }
+  return SILValue();
+}
+
+/// Collect all instructions which are inside an immutable scope.
+///
+/// The \p beginScopeInst is either a ``begin_access [read]`` or the begin of a
+/// borrow scope (begin_borrow, load_borrow) of an immutable copy-on-write
+/// buffer.
+void AliasAnalysis::computeImmutableScope(SingleValueInstruction *beginScopeInst,
+                                          ValueIndexTy beginIdx) {
+  BasicBlockSet visitedBlocks(beginScopeInst->getFunction());
+  llvm::SmallVector<std::pair<SILInstruction *, SILBasicBlock *>, 16> workList;
+  
+  auto addEndScopeInst = [&](SILInstruction *endScope) {
+    workList.push_back({endScope, endScope->getParent()});
+    bool isNew = visitedBlocks.insert(endScope->getParent());
+    (void)isNew;
+    assert(isNew);
+  };
+  
+  // First step: add all scope-ending instructions to the worklist.
+  if (auto *beginAccess = dyn_cast<BeginAccessInst>(beginScopeInst)) {
+    for (EndAccessInst *endAccess : beginAccess->getEndAccesses()) {
+      addEndScopeInst(endAccess);
+    }
+  } else {
+    visitTransitiveEndBorrows(BorrowedValue(beginScopeInst), addEndScopeInst);
+  }
+
+  // Second step: walk up the control flow until the beginScopeInst and add
+  // all (potentially) memory writing instructions to instsInImmutableScopes.
+  while (!workList.empty()) {
+    auto instAndBlock = workList.pop_back_val();
+    SILBasicBlock *block = instAndBlock.second;
+    // If the worklist entry doesn't have an instruction, start at the end of
+    // the block.
+    auto iter = instAndBlock.first ? instAndBlock.first->getIterator()
+                                   : block->end();
+    // Walk up the instruction list - either to the begin of the block or until
+    // we hit the beginScopeInst.
+    while (true) {
+      if (iter == block->begin()) {
+        assert(block != block->getParent()->getEntryBlock() &&
+               "didn't find the beginScopeInst when walking up the CFG");
+        // Add all predecessor blocks to the worklist.
+        for (SILBasicBlock *pred : block->getPredecessorBlocks()) {
+          if (visitedBlocks.insert(pred))
+            workList.push_back({nullptr, pred});
+        }
+        break;
+      }
+      --iter;
+      SILInstruction *inst = &*iter;
+      if (inst == beginScopeInst) {
+        // When we are at the beginScopeInst we terminate the CFG walk.
+        break;
+      }
+      if (inst->mayWriteToMemory()) {
+        instsInImmutableScopes.insert({beginIdx,
+                                       InstructionToIndex.getIndex(inst)});
+      }
+    }
+  }
+}
+
+/// Returns true if \p inst is in an immutable scope of V.
+///
+/// That means that even if we don't know anything about inst, we can be sure
+/// that inst cannot write to V.
+/// An immutable scope is for example a read-only begin_access/end_access scope.
+/// Another example is a borrow scope of an immutable copy-on-write buffer.
+bool AliasAnalysis::isInImmutableScope(SILInstruction *inst, SILValue V) {
+  if (!V->getType().isAddress())
+    return false;
+    
+  SILValue beginScope = getBeginScopeInst(V);
+  if (!beginScope)
+    return false;
+
+  if (auto *funcArg = dyn_cast<SILFunctionArgument>(beginScope)) {
+    // The immutable scope (= an guaranteed argument) spans over the whole
+    // function. We don't need to do any scope computation in this case.
+    assert(funcArg->getArgumentConvention().isGuaranteedConvention());
+    return true;
+  }
+
+  auto *beginScopeInst = dyn_cast<SingleValueInstruction>(beginScope);
+  if (!beginScopeInst)
+    return false;
+
+  ValueIndexTy beginIdx = InstructionToIndex.getIndex(beginScopeInst);
+  
+  // Recompute the scope if not done yet.
+  if (immutableScopeComputed.insert(beginIdx).second) {
+    // In practice this will never happen. Just be be sure to not run into
+    // quadratic complexity in obscure corner cases.
+    if (instsInImmutableScopes.size() > ImmutableScopeInstsMaxSize)
+      return false;
+
+    computeImmutableScope(beginScopeInst, beginIdx);
+  }
+
+  ValueIndexTy instIdx = InstructionToIndex.getIndex(inst);
+  return instsInImmutableScopes.contains({beginIdx, instIdx});
+}
+
 MemBehavior
 AliasAnalysis::computeMemoryBehaviorInner(SILInstruction *Inst, SILValue V) {
   LLVM_DEBUG(llvm::dbgs() << "GET MEMORY BEHAVIOR FOR:\n    " << *Inst << "    "
                           << *V);
   assert(SEA && "SideEffectsAnalysis must be initialized!");
-  return MemoryBehaviorVisitor(this, SEA, EA, V).visit(Inst);
+  
+  MemBehavior result = MemoryBehaviorVisitor(this, SEA, EA, V).visit(Inst);
+  
+  // If the "regular" alias analysis thinks that Inst may modify V, check if
+  // Inst is in an immutable scope of V.
+  if (result > MemBehavior::MayRead && isInImmutableScope(Inst, V)) {
+    return (result == MemBehavior::MayWrite) ? MemBehavior::None
+                                             : MemBehavior::MayRead;
+  }
+  return result;
 }
 
 MemBehaviorKeyTy AliasAnalysis::toMemoryBehaviorKey(SILInstruction *V1,

--- a/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
+++ b/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
@@ -546,11 +546,11 @@ AliasAnalysis::computeMemoryBehaviorInner(SILInstruction *Inst, SILValue V) {
 
 MemBehaviorKeyTy AliasAnalysis::toMemoryBehaviorKey(SILInstruction *V1,
                                                     SILValue V2) {
-  size_t idx1 = InstructionToIndex.getIndex(V1);
-  assert(idx1 != std::numeric_limits<size_t>::max() &&
+  ValueIndexTy idx1 = InstructionToIndex.getIndex(V1);
+  assert(idx1 != std::numeric_limits<ValueIndexTy>::max() &&
          "~0 index reserved for empty/tombstone keys");
-  size_t idx2 = ValueToIndex.getIndex(V2);
-  assert(idx2 != std::numeric_limits<size_t>::max() &&
+  ValueIndexTy idx2 = ValueToIndex.getIndex(V2);
+  assert(idx2 != std::numeric_limits<ValueIndexTy>::max() &&
          "~0 index reserved for empty/tombstone keys");
   return {idx1, idx2};
 }

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -282,10 +282,10 @@ void DCE::markLive() {
             OwnershipKind::Owned) {
           markInstructionLive(borrowInst);
           // Visit all end_borrows and mark them live
-          auto visitEndBorrow = [&](EndBorrowInst *endBorrow) {
-            markInstructionLive(endBorrow);
-          };
-          visitTransitiveEndBorrows(borrowInst, visitEndBorrow);
+          visitTransitiveEndBorrows(BorrowedValue(borrowInst),
+            [&](EndBorrowInst *endBorrow) {
+              markInstructionLive(endBorrow);
+            });
           continue;
         }
         // If not populate reborrowDependencies for this borrow

--- a/test/SILOptimizer/licm_exclusivity.sil
+++ b/test/SILOptimizer/licm_exclusivity.sil
@@ -29,10 +29,10 @@ sil hidden_external @globalAddressor : $@convention(thin) () -> Builtin.RawPoint
 // CHECK-LABEL: sil @hoist_access_with_conflict : $@convention(thin) () -> () {
 // CHECK: [[GLOBAL:%.*]] = global_addr @globalX : $*X
 // CHECK: [[BEGIN:%.*]] = begin_access [read] [dynamic] [[GLOBAL]] : $*X
+// CHECK-NEXT: load
 // CHECK-NEXT: br bb1
 // CHECK: apply
-// CHECK: load
-// CHECK: cond_br
+// CHECK-NEXT: cond_br
 // CHECK: bb2
 // CHECK: end_access [[BEGIN]]
 // CHECK-LABEL: } // end sil function 'hoist_access_with_conflict'
@@ -89,9 +89,9 @@ bb2:
 // CHECK-LABEL: sil @hoist_access_with_may_release : $@convention(thin) () -> () {
 // CHECK: [[GLOBAL:%.*]] = global_addr @globalX : $*X
 // CHECK: [[BEGIN:%.*]] = begin_access [read] [dynamic] [[GLOBAL]] : $*X
+// CHECK-NEXT: load
 // CHECK-NEXT: br bb1
 // CHECK: apply
-// CHECK: load
 // CHECK: cond_br
 // CHECK: bb2
 // CHECK: end_access [[BEGIN]]
@@ -153,10 +153,10 @@ bb2:
 // CHECK-LABEL: sil @hoist_access_static : $@convention(thin) () -> () {
 // CHECK: [[GLOBAL:%.*]] = global_addr @globalX : $*X
 // CHECK: [[BEGIN:%.*]] = begin_access [read] [static] [[GLOBAL]] : $*X
+// CHECK-NEXT: load
 // CHECK-NEXT: br bb1
 // CHECK: apply
-// CHECK: load
-// CHECK: cond_br
+// CHECK-NEXT: cond_br
 // CHECK: bb2
 // CHECK: end_access [[BEGIN]]
 // CHECK-LABEL: } // end sil function 'hoist_access_static'

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -12,6 +12,8 @@ class X {
   init()
 }
 
+class Derived : X { }
+
 class C {
   @_hasStorage @_hasInitialValue final let prop: Builtin.Int32 { get }
 }
@@ -556,6 +558,134 @@ bb0(%0 : $*Builtin.Int32, %1 : $Builtin.Int32):
   return %r : $()
 }
 
+// CHECK-LABEL: @testReadAccessOfClassProperty
+// CHECK:      PAIR #3.
+// CHECK-NEXT:     %5 = apply %4() : $@convention(thin) () -> ()
+// CHECK-NEXT:     %1 = ref_element_addr %0 : $X, #X.a
+// CHECK-NEXT:   r=1,w=1
+// CHECK:      PAIR #4.
+// CHECK-NEXT:     %5 = apply %4() : $@convention(thin) () -> ()
+// CHECK-NEXT:     %2 = begin_access [read] [dynamic] %1 : $*Int32
+// CHECK-NEXT:   r=1,w=0
+// CHECK:      PAIR #8.
+// CHECK-NEXT:     %7 = apply %4() : $@convention(thin) () -> ()
+// CHECK-NEXT:     %2 = begin_access [read] [dynamic] %1 : $*Int32
+// CHECK-NEXT:   r=1,w=1
+sil [ossa] @testReadAccessOfClassProperty : $@convention(thin) (@guaranteed X) -> Int32 {
+bb0(%0 : @guaranteed $X):
+  %1 = ref_element_addr %0 : $X, #X.a
+  %2 = begin_access [read] [dynamic] %1 : $*Int32
+  %3 = load [trivial] %2 : $*Int32
+  %4 = function_ref @nouser_func : $@convention(thin) () -> ()
+  %5 = apply %4() : $@convention(thin) () -> ()
+  end_access %2 : $*Int32
+  %7 = apply %4() : $@convention(thin) () -> ()
+  return %3 : $Int32
+}
+
+// CHECK-LABEL: @testModifyAccessOfClassProperty
+// CHECK:      PAIR #3.
+// CHECK-NEXT:     %6 = apply %5() : $@convention(thin) () -> ()
+// CHECK-NEXT:     %2 = ref_element_addr %0 : $X, #X.a
+// CHECK-NEXT:   r=1,w=1
+// CHECK:      PAIR #4.
+// CHECK-NEXT:     %6 = apply %5() : $@convention(thin) () -> ()
+// CHECK-NEXT:     %3 = begin_access [modify] [dynamic] %2 : $*Int32
+// CHECK-NEXT:   r=1,w=1
+sil [ossa] @testModifyAccessOfClassProperty : $@convention(thin) (@guaranteed X, Int32) -> () {
+bb0(%0 : @guaranteed $X, %1 : $Int32):
+  %2 = ref_element_addr %0 : $X, #X.a
+  %3 = begin_access [modify] [dynamic] %2 : $*Int32
+  store %1 to [trivial] %3 : $*Int32
+  %5 = function_ref @nouser_func : $@convention(thin) () -> ()
+  %6 = apply %5() : $@convention(thin) () -> ()
+  end_access %3 : $*Int32
+  %8 = tuple ()
+  return %8 : $()
+}
+
+// CHECK-LABEL: @testImmutableRefWithGuaranteedParam
+// CHECK:      PAIR #1.
+// CHECK-NEXT:     %4 = apply %3() : $@convention(thin) () -> ()
+// CHECK-NEXT:     %1 = ref_element_addr [immutable] %0 : $X, #X.a
+// CHECK-NEXT:   r=1,w=0
+sil [ossa] @testImmutableRefWithGuaranteedParam : $@convention(thin) (@guaranteed X) -> Int32 {
+bb0(%0 : @guaranteed $X):
+  %1 = ref_element_addr [immutable] %0 : $X, #X.a
+  %3 = load [trivial] %1 : $*Int32
+  %5 = function_ref @nouser_func : $@convention(thin) () -> ()
+  %6 = apply %5() : $@convention(thin) () -> ()
+  return %3 : $Int32
+}
+
+// CHECK-LABEL: @testImmutableRefWithBorrow
+// CHECK:      PAIR #1.
+// CHECK-NEXT:     %5 = apply %4() : $@convention(thin) () -> ()
+// CHECK-NEXT:     %2 = ref_element_addr [immutable] %1 : $X, #X.a
+// CHECK-NEXT:   r=1,w=0
+// CHECK:      PAIR #3.
+// CHECK-NEXT:     %7 = apply %4() : $@convention(thin) () -> ()
+// CHECK-NEXT:     %2 = ref_element_addr [immutable] %1 : $X, #X.a
+// CHECK-NEXT:   r=1,w=1
+sil [ossa] @testImmutableRefWithBorrow : $@convention(thin) (@owned X) -> Int32 {
+bb0(%0 : @owned $X):
+  %1 = begin_borrow %0 : $X
+  %2 = ref_element_addr [immutable] %1 : $X, #X.a
+  %3 = load [trivial] %2 : $*Int32
+  %4 = function_ref @nouser_func : $@convention(thin) () -> ()
+  %5 = apply %4() : $@convention(thin) () -> ()
+  end_borrow %1 : $X
+  %7 = apply %4() : $@convention(thin) () -> ()
+  destroy_value %0 : $X
+  return %3 : $Int32
+}
+
+// CHECK-LABEL: @testImmutableRefWithControlFlow
+// CHECK:      PAIR #0.
+// CHECK-NEXT:     %2 = apply %1() : $@convention(thin) () -> ()
+// CHECK-NEXT:     %4 = ref_element_addr [immutable] %3 : $X, #X.a
+// CHECK-NEXT:   r=1,w=1
+// CHECK:      PAIR #2.
+// CHECK-NEXT:     %6 = apply %1() : $@convention(thin) () -> ()
+// CHECK-NEXT:     %4 = ref_element_addr [immutable] %3 : $X, #X.a
+// CHECK-NEXT:   r=1,w=0
+// CHECK:      PAIR #4.
+// CHECK-NEXT:     %9 = apply %1() : $@convention(thin) () -> ()
+// CHECK-NEXT:     %4 = ref_element_addr [immutable] %3 : $X, #X.a
+// CHECK-NEXT:   r=1,w=1
+// CHECK:      PAIR #5.
+// CHECK-NEXT:     %11 = apply %1() : $@convention(thin) () -> ()
+// CHECK-NEXT:     %4 = ref_element_addr [immutable] %3 : $X, #X.a
+// CHECK-NEXT:   r=1,w=0
+// CHECK:      PAIR #7.
+// CHECK-NEXT:     %14 = apply %1() : $@convention(thin) () -> ()
+// CHECK-NEXT:     %4 = ref_element_addr [immutable] %3 : $X, #X.a
+// CHECK-NEXT:   r=1,w=1
+sil [ossa] @testImmutableRefWithControlFlow : $@convention(thin) (@owned X) -> Int32 {
+bb0(%0 : @owned $X):
+  %1 = function_ref @nouser_func : $@convention(thin) () -> ()
+  %2 = apply %1() : $@convention(thin) () -> ()
+  %3 = begin_borrow %0 : $X
+  %4 = ref_element_addr [immutable] %3 : $X, #X.a
+  %5 = load [trivial] %4 : $*Int32
+  %6 = apply %1() : $@convention(thin) () -> ()
+  cond_br undef, bb1, bb2
+bb1:
+  end_borrow %3 : $X
+  %9 = apply %1() : $@convention(thin) () -> ()
+  br bb4
+bb2:
+  %11 = apply %1() : $@convention(thin) () -> ()
+  br bb3
+bb3:
+  end_borrow %3 : $X
+  %14 = apply %1() : $@convention(thin) () -> ()
+  br bb4
+bb4:
+  destroy_value %0 : $X
+  return %5 : $Int32
+}
+
 // CHECK-LABEL: @testLoadTake
 // CHECK:      PAIR #0.
 // CHECK-NEXT:   %2 = load [take] %0 : $*C
@@ -606,10 +736,9 @@ struct Int64Wrapper {
 
 // CHECK-LABEL: @testNestedAccessWithInterposedProjection
 // CHECK: PAIR #2.
-// CHECK:     %1 = begin_access [modify] [static] %0 : $*Int64Wrapper // users: %7, %2
-// CHECK:     %3 = begin_access [read] [static] %2 : $*Int64  // users: %6, %4
-// CHECK:   r=1,w=1
-// CHECK: PAIR #3.
+// CHECK-NEXT:   %1 = begin_access [modify] [static] %0 : $*Int64Wrapper // users: %7, %2
+// CHECK-NEXT:   %3 = begin_access [read] [static] %2 : $*Int64  // users: %6, %4
+// CHECK-NEXT: r=1,w=1
 sil @testNestedAccessWithInterposedProjection : $@convention(thin) (@inout Int64Wrapper) -> () {
 bb0(%0 : $*Int64Wrapper):
   %1 = begin_access [modify] [static] %0 : $*Int64Wrapper


### PR DESCRIPTION
 If the "regular" alias analysis thinks that an instruction may write to an address, check if the instruction is in an immutable scope of `V`.
That means that even if we don't know anything about the instruction (e.g. a call to an unknown function), we can be sure that it cannot write to the address.

An immutable scope is for example a read-only begin_access/end_access scope.
Another example is a borrow scope of an immutable copy-on-write buffer, for example:
```
   %b = begin_borrow %array_buffer
   %addr = ref_element_addr [immutable] %b : $BufferType, #BufferType.someField
```