### PR TITLE
[5.5] Don't crash RemoteMirror if malloc fails

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -1088,6 +1088,9 @@ public:
     
     unsigned size = baseSize + genericsSize + metadataInitSize + vtableSize;
     auto buffer = (uint8_t *)malloc(size);
+    if (buffer == nullptr) {
+      return nullptr;
+    }
     if (!Reader->readBytes(RemoteAddress(address), buffer, size)) {
       free(buffer);
       return nullptr;


### PR DESCRIPTION
Work around some RemoteMirror issues by returning `null` when malloc fails.

Resolves rdar://61159451