### PR TITLE
[5.5-05142021][ConstraintSystem] Detect passing sync closure to async argument early

### DIFF
--- a/test/Concurrency/async_overload_filtering.swift
+++ b/test/Concurrency/async_overload_filtering.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift -debug-constraints 2>%t.err
+// RUN: %FileCheck %s < %t.err
+
+// rdar://77942193 - adding async overload leads to expressions becoming "too complex"
+
+struct Obj {
+  func op<T>(_: T) {}
+  func op(_: Int) {}
+}
+
+// Three overloads of `filter_async` to avoid generic overload optimization
+
+func filter_async<T>(fn1: () -> T) -> T { fn1() }
+func filter_async<T>(fn2: () async -> T) -> T { fatalError() }
+func filter_async(_: String) -> Void {}
+
+var a: String? = nil
+
+// CHECK: attempting disjunction choice $T0 bound to decl async_overload_filtering.(file).filter_async(fn2:)
+// CHECK-NEXT: overload set choice binding $T0 := {{.*}}
+// CHECK-NEXT: increasing score due to sync-in-asynchronous
+// CHECK-NEXT: solution is worse than the best solution
+filter_async {
+  Obj()
+}.op("" + (a ?? "a"))


### PR DESCRIPTION
Cherry-pick of (main) https://github.com/apple/swift/pull/37430, (5.5) https://github.com/apple/swift/pull/37479

---

- Explanation:

This helps in situations where there are multiple overloads which
differ only in async effect of their parameters. Passing sync argument
to a sync parameter is always preferred and when detected early
allows solver to avoid some of the duplicate work re-solving for
the rest of the path e.g.

```swift
func test<T>(_: () -> T) {}
func test<T>(_: () async -> T) {}

test {
  // sync work
}.op(...)
```

In this case since closure is synchronous first overload of `test`
is always preferred (when it's a match) and solver can skip re-checking
body of the closure and `op` call when it encounters `async` version.

- Scope: Passing a sync closure to a call that has two overloads that differ only in `async` for one or more arguments.

- Main Branch PR: https://github.com/apple/swift/pull/37430

- Resolves: rdar://77942193

- Risk: Low

- Reviewed By: @hborla

- Testing: Regression tests added to the suite

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
