### PR TITLE
[5.4][ClangImporter] Load the stdlib even if there is a `-fmodule-map-file` argument pointing to a missing file

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -80,5 +80,7 @@ WARNING(implicit_bridging_header_imported_from_module,none,
         "is deprecated and will be removed in a later version of Swift",
         (StringRef, Identifier))
 
+ERROR(module_map_not_found, none, "module map file '%0' not found", (StringRef))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -987,8 +987,38 @@ ClangImporter::createClangInvocation(ClangImporter *importer,
                                                  &tempDiagClient,
                                                  /*owned*/false);
 
-  return clang::createInvocationFromCommandLine(invocationArgs, tempClangDiags,
-                                                nullptr, false, CC1Args);
+  auto CI = clang::createInvocationFromCommandLine(
+      invocationArgs, tempClangDiags, nullptr, false, CC1Args);
+
+  if (!CI) {
+    return CI;
+  }
+
+  // FIXME: clang fails to generate a module if there is a `-fmodule-map-file`
+  // argument pointing to a missing file.
+  // Such missing module files occur frequently in SourceKit. If the files are
+  // missing, SourceKit fails to build SwiftShims (which wouldn't have required
+  // the missing module file), thus fails to load the stdlib and hence looses
+  // all semantic functionality.
+  // To work around this issue, drop all `-fmodule-map-file` arguments pointing
+  // to missing files and report the error that clang would throw manually.
+  // rdar://77516546 is tracking that the clang importer should be more
+  // resilient and provide a module even if there were building it.
+  auto VFS = clang::createVFSFromCompilerInvocation(
+      *CI, *tempClangDiags,
+      importer->Impl.SwiftContext.SourceMgr.getFileSystem());
+  std::vector<std::string> FilteredModuleMapFiles;
+  for (auto ModuleMapFile : CI->getFrontendOpts().ModuleMapFiles) {
+    if (VFS->exists(ModuleMapFile)) {
+      FilteredModuleMapFiles.push_back(ModuleMapFile);
+    } else {
+      importer->Impl.SwiftContext.Diags.diagnose(
+          SourceLoc(), diag::module_map_not_found, ModuleMapFile);
+    }
+  }
+  CI->getFrontendOpts().ModuleMapFiles = FilteredModuleMapFiles;
+
+  return CI;
 }
 
 std::unique_ptr<ClangImporter>

--- a/test/SourceKit/CursorInfo/missing_module_map.swift
+++ b/test/SourceKit/CursorInfo/missing_module_map.swift
@@ -1,0 +1,9 @@
+// RUN: %empty-directory(%t.mcp)
+// RUN: %sourcekitd-test -req=cursor -pos=6:9 %s -- -Xcc -fmodule-map-file=/some/missing/file -module-cache-path %t.mcp %s | %FileCheck %s
+
+// We used to fail to load the stdlib if there is a `-fmodule-map-file` option pointing to a missing file
+
+let x: String = "abc"
+// CHECK: source.lang.swift.ref.struct ()
+// CHECK: String
+// CHECK: s:SS


### PR DESCRIPTION
Cherry-picks https://github.com/apple/swift/pull/37252 to `release/5.4`.

* **Explanation**: 

If there is a `-fmodule-map-file` argument whose file doesn’t exist and SwiftShims is not in the module cache, we fail to build it, because clang throws an error about the missing module map. This causes SourceKit to drop all semantic functionality, even if the missing module map isn’t required.

To work around this, drop all `-fmodule-map-file` arguments with missing files from the clang importer’s arguments, reporting the error that `clang` would throw manually.
* **Scope**: Invalid compiler invocations (module map is missing)
* **Risk**: Low
* **Testing**: Added a test to the test suite
* **Issue**: rdar://78035990
* **Reviewer**: Argyrios Kyrtzidis (@akyrtzi), Xi Ge (@nkcsgexi)
