### PR TITLE
[5.4][SourceKit] Verify the stdlib is loaded before creating an AST

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -848,6 +848,11 @@ ASTUnitRef ASTProducer::createASTUnit(
     Error = "compilation setup failed";
     return nullptr;
   }
+  if (CompIns.loadStdlibIfNeeded()) {
+    LOG_WARN_FUNC("Loading the stdlib failed");
+    Error = "Loading the stdlib failed";
+    return nullptr;
+  }
   registerIDERequestFunctions(CompIns.getASTContext().evaluator);
   if (TracedOp.enabled()) {
     TracedOp.start(TraceInfo);


### PR DESCRIPTION
Cherry-picks https://github.com/apple/swift/pull/36797 to `release/5.4`.

* **Explanation**: When `sourcekitd` is unable to load the stdlib, report an error and fail early instead of trying to compile and crashing somewhere in the type checker because required types from the standard library cannot be found.
* **Scope**: `sourcektid` requests that are unable to load the standard library
* **Risk**: Very low
* **Testing**: None, the fix was synthesized from a set of crash reports
* **Issue**: rdar://78035923
* **Reviewer**: Argyrios Kyrtzidis (@akyrtzi)