### PR TITLE
[5.4][sil][debug-info] Turn off a few asserts just on 5.4 to eliminate some crashes in user code.

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1214,6 +1214,16 @@ public:
       }
     }
 
+// Disable these checks just on 5.4 when compiler asserts are enabled.
+//
+// These just verify some things about debug info that shouldn't stop a program
+// from not-compiling. When optimizing in certain cases, we found that we were
+// hitting these on linux platforms since on linux platforms, we ship the
+// compiler with assertions enabled. So by disabling this we can at least at
+// the expense of slightly worse debug info when compiling with optimization
+// eliminate these crashes. Darwin does not ship with compiler-asserts so is
+// unaffected.
+#if 0
     // Regular locations are allowed on all instructions.
     if (LocKind == SILLocation::RegularKind)
       return;
@@ -1228,6 +1238,7 @@ public:
     if (LocKind == SILLocation::ArtificialUnreachableKind)
       require(InstKind == SILInstructionKind::UnreachableInst,
         "artificial locations are only allowed on Unreachable instructions");
+#endif
   }
 
   /// Check that the types of this value producer are all legal in the function


### PR DESCRIPTION
[sil][debug-info] Turn off a few asserts just on 5.4 to eliminate some crashes in user code.

These asserts validate some behavior of the compiler around which
SILInstruction can be paired with what type of SILLocation. That being said,
these asserts only effect debug info and are tripping in some programs on Linux
where we ship the compiler with assertions enabled. Darwin does not have these
issues since the compiler is shipped /without/ compiler assertions enabled.

rdar://77325585

----

Explanation: Avoid a harmless debug-info assertion that some people are seeing on Linux (when compiled with optimization) where we ship the compiler with assertions enabled.
Scope: The change turns off an assertion that validates that certain structural debug info properties are maintained. The problem itself being found results in just a small code local degradation in debug info quality. The assert in the mean time stops the user from being able to compile their code with optimizations enabled on Linux. So to balance that out, given where we are with the 5.4 release, it makes sense to just turn this off for now. The issue here does not happen on master and I am adding a new form of this assert that should make it much easier to track these down here: https://github.com/apple/swift/pull/37468.
Risk: Low
Testing: None. Commented out the debug info assert that was firing.
Issue: rdar://77325585
Reviewer: Adrian Prantl