### PR TITLE
[test] pass `host-target` to `build-script`...

### DIFF
--- a/validation-test/BuildSystem/dsymutil_jobs.test
+++ b/validation-test/BuildSystem/dsymutil_jobs.test
@@ -4,7 +4,7 @@
 # RUN: mkdir -p %t
 # RUN: mkdir -p %t/destdir
 # RUN: mkdir -p %t/symroot/macosx-%target-cpu
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --darwin-install-extract-symbols --dsymutil-jobs 5 --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --host-target=macosx-%target-cpu --darwin-install-extract-symbols --dsymutil-jobs 5 --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
 
 # CHECK: --- Extracting symbols ---
 # CHECK: { "command": "dsymutil", "start": "

--- a/validation-test/BuildSystem/extractsymbols-darwin-symroot-path-filters.test
+++ b/validation-test/BuildSystem/extractsymbols-darwin-symroot-path-filters.test
@@ -29,14 +29,14 @@
 # ensure build-script pass the argument to build-script-impl
 # RUN: %empty-directory(%t/symroot)
 # RUN: mkdir -p %t/symroot/macosx-%target-cpu
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --darwin-install-extract-symbols=1 --install-destdir=%t/destdir --toolchain-prefix="" --install-symroot=%t/symroot --darwin-symroot-path-filters="/lib/ /swift-demangle" --jobs=1  2>&1 | tee %t/build-script-output.txt
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --darwin-install-extract-symbols=1 --install-destdir=%t/destdir --toolchain-prefix="" --install-symroot=%t/symroot --darwin-symroot-path-filters="/lib/ /swift-demangle" --jobs=1 --host-target=macosx-%target-cpu 2>&1 | tee %t/build-script-output.txt
 # RUN: %FileCheck --input-file=%t/build-script-output.txt %s
 # RUN: %FileCheck --input-file=%t/build-script-output.txt --check-prefixes CHECK-SKIPPED %s
 
 # ensure we get all the values if we specify the flag multiple times
 # RUN: %empty-directory(%t/symroot)
 # RUN: mkdir -p %t/symroot/macosx-%target-cpu
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --darwin-install-extract-symbols=1 --install-destdir=%t/destdir --toolchain-prefix="" --install-symroot=%t/symroot --darwin-symroot-path-filters="/lib/" --darwin-symroot-path-filters="/swift-demangle" --jobs=1  2>&1 | tee %t/build-script-output.txt
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --darwin-install-extract-symbols=1 --install-destdir=%t/destdir --toolchain-prefix="" --install-symroot=%t/symroot --darwin-symroot-path-filters="/lib/" --darwin-symroot-path-filters="/swift-demangle" --jobs=1 --host-target=macosx-%target-cpu 2>&1 | tee %t/build-script-output.txt
 # RUN: %FileCheck --input-file=%t/build-script-output.txt %s
 # RUN: %FileCheck --input-file=%t/build-script-output.txt --check-prefixes CHECK-SKIPPED %s
 


### PR DESCRIPTION
... in tests related to symbol generation.

This is to ensure that the dry run invocations of `build-script` use the
same value as `%target-cpu` and prevent failures when running validation
tests for an architecture different from the current one.

Addresses rdar://78141544