### PR TITLE
[5.4][Deserialization] Fix error when typealias required by protocol refers to type in @_implementationOnly module

### DIFF
--- a/test/Serialization/Recovery/Inputs/protocol-requirement-in-implementation-only/module.modulemap
+++ b/test/Serialization/Recovery/Inputs/protocol-requirement-in-implementation-only/module.modulemap
@@ -1,0 +1,1 @@
+module public_lib [system] {}

--- a/test/Serialization/Recovery/protocol-requirement-in-implementation-only.swift
+++ b/test/Serialization/Recovery/protocol-requirement-in-implementation-only.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+
+//// Build the private module and the public module normally.
+//// Force the public module to be system with an underlying Clang module.
+// RUN: %target-swift-frontend -emit-module -DPRIVATE_LIB %s -module-name private_lib -emit-module-path %t/private_lib.swiftmodule
+// RUN: %target-swift-frontend -emit-module -DPUBLIC_LIB %s -module-name public_lib -emit-module-path %t/public_lib.swiftmodule -I %t -I %S/Inputs/protocol-requirement-in-implementation-only -import-underlying-module
+
+//// Printing the public module should not crash when reading the HiddenStruct typealias in `M`.
+// RUN: %target-swift-ide-test -print-module -module-to-print=public_lib -source-filename=x -skip-overrides -I %t
+
+#if PRIVATE_LIB
+
+public struct HiddenStruct {
+  public init() {}
+}
+
+#elseif PUBLIC_LIB
+
+@_implementationOnly import private_lib
+
+protocol SomeProtocol {
+  associatedtype Value
+  static var defaultValue: Value { get }
+}
+public struct M: SomeProtocol {
+  typealias Value = HiddenStruct
+  static let defaultValue = HiddenStruct()
+}
+#endif


### PR DESCRIPTION
Cherry-picks https://github.com/apple/swift/pull/37011 to `release/5.4`.

* **Explanation**:  If a `typealias` refers to a type defined in a module which is imported as `@_implementationOnly`, deserialization fails (crashes). If `LangOpts.EnableDeserializationRecovery` is set to `true` (e.g. in SourceKit), we should recover from such failures more graceful and resolve unknown type as an  `ErrorType`.

* **Scope**: Modules that previously failed to deserialize
* **Risk**: Low (we were previously crashing in all cases that exhibit new behavior)
* **Testing**: Added test case to the test suite
* **Issue**: rdar://78035645
* **Reviewer**: Argyrios Kyrtzidis (@akyrtzi), Alexis Laferriere (@xymus)