### PR TITLE
[5.4][CodeCompletion] Reset 'hasSingleExpressionBody' when setting function body

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6622,8 +6622,10 @@ BraceStmt *Parser::parseAbstractFunctionBodyImpl(AbstractFunctionDecl *AFD) {
     return nullptr;
 
   BraceStmt *BS = Body.get();
+  // Reset the single expression body status.
+  AFD->setHasSingleExpressionBody(false);
   AFD->setBodyParsed(BS);
-  
+
   if (Parser::shouldReturnSingleExpressionElement(BS->getElements())) {
     auto Element = BS->getLastElement();
     if (auto *stmt = Element.dyn_cast<Stmt *>()) {

--- a/test/SourceKit/CodeComplete/complete_sequence_rdar75358153.swift
+++ b/test/SourceKit/CodeComplete/complete_sequence_rdar75358153.swift
@@ -1,0 +1,47 @@
+// BEGIN t1.swift
+enum E {
+  case foo, bar
+}
+func foo(_ arg: E) {}
+func test(val: E) {
+  foo(.bar)
+}
+
+// BEGIN t2.swift
+enum E {
+  case foo, bar
+}
+func foo(_ arg: E) {}
+func test(val: E) {
+  foo(.bar)
+  if v
+}
+
+// BEGIN dummy.swift
+
+// rdar://75358153
+// Previously, completing inside single expression body, then completing inside
+// *non* single expression body in the same function caused a crash because the
+// "has single expression" flag didn't cleard. This file tests the scenario not
+// to regress again.
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=complete -pos=6:8 -text-input %t/t1.swift %t/t.swift -- %t/t.swift == \
+// RUN:   -req=complete -pos=7:6 -text-input %t/t2.swift %t/t.swift -- %t/t.swift \
+// RUN: | %FileCheck %s
+
+// CHECK-LABEL: key.results: [
+// CHECK-DAG: key.description: "bar",
+// CHECK-DAG: key.description: "foo",
+// CHECK-DAG: key.description: "hash(self: E)",
+// CHECK: ]
+// CHECK-NOT: key.reusingastcontext: 1
+
+// CHECK-LABEL: key.results: [
+// CHECK-DAG: key.description: "val",
+// CHECK-DAG: key.description: "foo(arg: E)",
+// CHECK: ],
+// CHECK: key.reusingastcontext: 1


### PR DESCRIPTION
Cherry-pick of #37324 into `release/5.4`


* **Explanation**: Fix a crash when fast-completion in a function body with multiple statements but if the user had done completions with single expression in the same body. Previously, fast-completion didn't reset `hasSingleExpressionBody` flag before setting the new body. Because of that, type checker tried to get the single expression from the non single expression body, which caused the crash
* **Scope**: Code completion inside function bodies
* **Risk**: Low
* **Testing**: Added regression test to the suite
* **Issue**: rdar://78122363
* **Reviewer**: Ben Langmuir (@benlangmuir)

