### PR TITLE
[standalone-stdlib] Add an RD presets for the standalone stdlib.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2321,6 +2321,21 @@ native-clang-tools-path=%(toolchain_path)s
 build-ninja
 lit-args=--filter=stdlib/
 
+[preset: stdlib_RD_standalone,build]
+mixin-preset=stdlib_base_standalone
+
+build-subdir=stdlib_RD_standalone
+release-debuginfo
+no-assertions
+
+verbose-build
+
+[preset: stdlib_RD_standalone,build,test]
+mixin-preset=stdlib_RD_standalone,build
+
+test
+validation-test
+
 [preset: stdlib_RA_standalone,build]
 mixin-preset=stdlib_base_standalone
 


### PR DESCRIPTION
This lets stdlib people use the standalone stdlib build for benchmarking.
