### PR TITLE
Disable flaky test/Concurrency/Runtime/objc_async.swift test.

### DIFF
--- a/test/Concurrency/Runtime/objc_async.swift
+++ b/test/Concurrency/Runtime/objc_async.swift
@@ -11,6 +11,10 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
+// Disable this test because it's flaky without a proper way to make the main
+// Swift task await a background queue.
+// REQUIRES: rdar77934626
+
 func buttTest() async {
   let butt = Butt()
   let result = await butt.butt(1738)


### PR DESCRIPTION
We need to introduce some proper synchronization between the @main task and the ObjC
completion handler to make this reliably deterministic. rdar://77934626

(cherry picked from commit 74736c75ba9abbb9ada58cfef19d537baebad5c0)
