### PR TITLE
Disable Concurrency/Runtime/executor_deinit1.swift on tvOS

### DIFF
--- a/test/Concurrency/Runtime/executor_deinit1.swift
+++ b/test/Concurrency/Runtime/executor_deinit1.swift
@@ -12,7 +12,8 @@
 // UNSUPPORTED: CPU=x86_64 && OS=ios
 // rdar://78039465
 // UNSUPPORTED: CPU=x86_64 && OS=watchos
-
+// rdar://78193017
+// UNSUPPORTED: CPU=x86_64 && OS=tvos
 
 // doesn't matter that it's bool identity function or not
 func boolIdentityFn(_ x : Bool) -> Bool { return x }


### PR DESCRIPTION
This test fails on all the simulators. I'm not sure of a smarter way
to disable it on non-native builds.

rdar://78193017
