### PR TITLE
Revert "Disable Interpreter/async_fib.swift"

### DIFF
--- a/test/Interpreter/async_fib.swift
+++ b/test/Interpreter/async_fib.swift
@@ -9,9 +9,6 @@
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: OS=windows-msvc
 
-// Test fails sporadically on macOS-x86_64 and other configurations.
-// REQUIRES: rdar78192131
-
 var gg = 0
 
 @inline(never)


### PR DESCRIPTION
Reverts apple/swift#37498

The failures with debug stdlibs should be fixed by: https://github.com/apple/swift/pull/37461

rdar://78192131