### PR TITLE
[RemoteMirror] Add NULL checks to Remote Mirror malloc calls.

### DIFF
--- a/include/swift/Remote/MemoryReader.h
+++ b/include/swift/Remote/MemoryReader.h
@@ -100,6 +100,8 @@ public:
   virtual ReadBytesResult
   readBytes(RemoteAddress address, uint64_t size) {
     auto *Buf = malloc(size);
+    if (!Buf)
+      return ReadBytesResult{};
     ReadBytesResult Result(Buf, [](const void *ptr) {
       free(const_cast<void *>(ptr));
     });

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -1802,6 +1802,9 @@ private:
   MetadataRef _readMetadata(StoredPointer address, size_t sizeAfter) {
     auto size = sizeAfter;
     uint8_t *buffer = (uint8_t *) malloc(size);
+    if (!buffer)
+      return nullptr;
+
     if (!Reader->readBytes(RemoteAddress(address), buffer, size)) {
       free(buffer);
       return nullptr;
@@ -2522,6 +2525,8 @@ private:
   std::string readObjCProtocolName(StoredPointer Address) {
     auto Size = sizeof(TargetObjCProtocolPrefix<Runtime>);
     auto Buffer = (uint8_t *)malloc(Size);
+    if (!Buffer)
+      return std::string();
     SWIFT_DEFER {
       free(Buffer);
     };


### PR DESCRIPTION
These calls can fail when passed absurd sizes, which can happen when we try to read data that's corrupt or doesn't contain what we think it should. Fail gracefully instead of crashing.

rdar://78210820