### PR TITLE
[cmake] Change set_swift_llvm_is_available to set definitions on a specific target.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -638,6 +638,7 @@ endmacro()
 
 # Declare that files in this library are built with LLVM's support
 # libraries available.
-macro(set_swift_llvm_is_available)
-  add_compile_options(-DSWIFT_LLVM_SUPPORT_IS_AVAILABLE)
-endmacro()
+function(set_swift_llvm_is_available name)
+  target_compile_definitions(${name} PRIVATE
+    $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:SWIFT_LLVM_SUPPORT_IS_AVAILABLE>)
+endfunction()

--- a/lib/APIDigester/CMakeLists.txt
+++ b/lib/APIDigester/CMakeLists.txt
@@ -1,4 +1,4 @@
-set_swift_llvm_is_available()
+
 
 add_swift_host_library(swiftAPIDigester STATIC
   ModuleAnalyzerNodes.cpp
@@ -8,3 +8,5 @@ target_link_libraries(swiftAPIDigester PRIVATE
   swiftFrontend
   swiftSIL
   swiftIDE)
+
+set_swift_llvm_is_available(swiftAPIDigester)

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -9,8 +9,6 @@ else()
   )
 endif()
 
-set_swift_llvm_is_available()
-
 add_swift_host_library(swiftAST STATIC
   AbstractSourceFileDepGraphFactory.cpp
   AccessNotes.cpp
@@ -146,3 +144,5 @@ endif()
 # headers.
 # For more information see the comment at the top of lib/CMakeLists.txt.
 add_dependencies(swiftAST intrinsics_gen clang-tablegen-targets)
+
+set_swift_llvm_is_available(swiftAST)

--- a/lib/ASTSectionImporter/CMakeLists.txt
+++ b/lib/ASTSectionImporter/CMakeLists.txt
@@ -1,4 +1,4 @@
-set_swift_llvm_is_available()
+
 
 add_swift_host_library(swiftASTSectionImporter STATIC
   ASTSectionImporter.cpp
@@ -6,3 +6,4 @@ add_swift_host_library(swiftASTSectionImporter STATIC
 target_link_libraries(swiftASTSectionImporter PRIVATE
   swiftBasic)
 
+set_swift_llvm_is_available(swiftASTSectionImporter)

--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -4,8 +4,6 @@ set(SWIFT_GYB_FLAGS
 add_gyb_target(generated_sorted_cf_database
     SortedCFDatabase.def.gyb)
 
-set_swift_llvm_is_available()
-
 add_swift_host_library(swiftClangImporter STATIC
   CFTypeInfo.cpp
   ClangAdapter.cpp
@@ -37,3 +35,5 @@ get_property(CLANG_TABLEGEN_TARGETS GLOBAL PROPERTY CLANG_TABLEGEN_TARGETS)
 add_dependencies(swiftClangImporter
   generated_sorted_cf_database
   ${CLANG_TABLEGEN_TARGETS})
+
+set_swift_llvm_is_available(swiftClangImporter)

--- a/lib/DependencyScan/CMakeLists.txt
+++ b/lib/DependencyScan/CMakeLists.txt
@@ -1,4 +1,4 @@
-#set_swift_llvm_is_available()
+
 
 add_swift_host_library(swiftDependencyScan STATIC
   DependencyScanningTool.cpp

--- a/lib/Driver/CMakeLists.txt
+++ b/lib/Driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-set_swift_llvm_is_available()
+
 
 set(swiftDriver_sources
   Action.cpp
@@ -25,3 +25,5 @@ target_link_libraries(swiftDriver PRIVATE
   swiftAST
   swiftBasic
   swiftOption)
+
+set_swift_llvm_is_available(swiftDriver)

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -1,4 +1,4 @@
-set_swift_llvm_is_available()
+
 add_swift_host_library(swiftFrontend STATIC
   ArgsToFrontendInputsConverter.cpp
   ArgsToFrontendOptionsConverter.cpp
@@ -29,3 +29,4 @@ target_link_libraries(swiftFrontend PRIVATE
   swiftSerialization
   swiftTBDGen)
 
+set_swift_llvm_is_available(swiftFrontend)

--- a/lib/FrontendTool/CMakeLists.txt
+++ b/lib/FrontendTool/CMakeLists.txt
@@ -1,4 +1,4 @@
-set_swift_llvm_is_available()
+
 add_swift_host_library(swiftFrontendTool STATIC
   FrontendTool.cpp
   ImportedModules.cpp
@@ -27,3 +27,5 @@ target_link_libraries(swiftFrontendTool PRIVATE
     swiftSILGen
     swiftSILOptimizer
     swiftTBDGen)
+
+set_swift_llvm_is_available(swiftFrontendTool)

--- a/lib/IDE/CMakeLists.txt
+++ b/lib/IDE/CMakeLists.txt
@@ -1,4 +1,4 @@
-set_swift_llvm_is_available()
+
 add_swift_host_library(swiftIDE STATIC
   CodeCompletion.cpp
   CodeCompletionCache.cpp
@@ -29,3 +29,4 @@ target_link_libraries(swiftIDE PRIVATE
   swiftParse
   swiftSema)
 
+set_swift_llvm_is_available(swiftIDE)

--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -1,4 +1,4 @@
-set_swift_llvm_is_available()
+
 add_swift_host_library(swiftIRGen STATIC
   AllocStackHoisting.cpp
   ClassLayout.cpp
@@ -73,3 +73,5 @@ target_link_libraries(swiftIRGen PRIVATE
   swiftSILGen
   swiftSILOptimizer
   swiftTBDGen)
+
+set_swift_llvm_is_available(swiftIRGen)

--- a/lib/LLVMPasses/CMakeLists.txt
+++ b/lib/LLVMPasses/CMakeLists.txt
@@ -1,4 +1,4 @@
-set_swift_llvm_is_available()
+
 add_swift_host_library(swiftLLVMPasses STATIC
   LLVMSwiftAA.cpp
   LLVMSwiftRCIdentity.cpp
@@ -12,3 +12,5 @@ add_swift_host_library(swiftLLVMPasses STATIC
   )
 target_link_libraries(swiftLLVMPasses PRIVATE
   swiftDemangling)
+
+set_swift_llvm_is_available(swiftLLVMPasses)

--- a/lib/Migrator/CMakeLists.txt
+++ b/lib/Migrator/CMakeLists.txt
@@ -47,8 +47,6 @@ swift_install_in_component(FILES ${datafiles}
                            DESTINATION "lib/swift/migrator"
                            COMPONENT compiler)
 
-set_swift_llvm_is_available()
-
 add_swift_host_library(swiftMigrator STATIC
   APIDiffMigratorPass.cpp
   EditorAdapter.cpp
@@ -63,3 +61,5 @@ target_link_libraries(swiftMigrator PRIVATE
 
 add_dependencies(swiftMigrator
   "symlink_migrator_data")
+
+set_swift_llvm_is_available(swiftMigrator)

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -1,4 +1,4 @@
-set_swift_llvm_is_available()
+
 
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
   set(SWIFT_GYB_FLAGS --line-directive "^\"#line %(line)d \\\"%(file)s\\\"^\"")
@@ -34,3 +34,5 @@ target_link_libraries(swiftParse PRIVATE
   swiftSyntaxParse)
 
 add_dependencies(swiftParse swift-parse-syntax-generated-headers)
+
+set_swift_llvm_is_available(swiftParse)

--- a/lib/PrintAsObjC/CMakeLists.txt
+++ b/lib/PrintAsObjC/CMakeLists.txt
@@ -1,4 +1,4 @@
-set_swift_llvm_is_available()
+
 add_swift_host_library(swiftPrintAsObjC STATIC
   DeclAndTypePrinter.cpp
   ModuleContentsWriter.cpp
@@ -9,3 +9,4 @@ target_link_libraries(swiftPrintAsObjC PRIVATE
   swiftFrontend
   swiftIDE)
 
+set_swift_llvm_is_available(swiftPrintAsObjC)

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -1,4 +1,3 @@
-set_swift_llvm_is_available()
 add_swift_host_library(swiftSIL STATIC
   SIL.cpp)
 target_link_libraries(swiftSIL PUBLIC
@@ -17,3 +16,5 @@ add_subdirectory(Parser)
 # headers.
 # For more information see the comment at the top of lib/CMakeLists.txt.
 add_dependencies(swiftSIL intrinsics_gen clang-tablegen-targets)
+
+set_swift_llvm_is_available(swiftSIL)

--- a/lib/SILGen/CMakeLists.txt
+++ b/lib/SILGen/CMakeLists.txt
@@ -1,4 +1,4 @@
-set_swift_llvm_is_available()
+
 add_swift_host_library(swiftSILGen STATIC
   ArgumentSource.cpp
   Cleanup.cpp
@@ -35,3 +35,5 @@ add_swift_host_library(swiftSILGen STATIC
   SILGenType.cpp)
 target_link_libraries(swiftSILGen PRIVATE
   swiftSIL)
+
+set_swift_llvm_is_available(swiftSILGen)

--- a/lib/SILOptimizer/CMakeLists.txt
+++ b/lib/SILOptimizer/CMakeLists.txt
@@ -1,8 +1,8 @@
-set_swift_llvm_is_available()
 add_swift_host_library(swiftSILOptimizer STATIC
   SILOptimizer.cpp)
 target_link_libraries(swiftSILOptimizer PRIVATE
   swiftSIL)
+set_swift_llvm_is_available(swiftSILOptimizer)
 
 add_subdirectory(ARC)
 add_subdirectory(Analysis)

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -1,4 +1,4 @@
-set_swift_llvm_is_available()
+
 add_swift_host_library(swiftSema STATIC
   BuilderTransform.cpp
   CSApply.cpp
@@ -77,3 +77,5 @@ target_link_libraries(swiftSema PRIVATE
   swiftAST
   swiftParse
   swiftSerialization)
+
+set_swift_llvm_is_available(swiftSema)

--- a/lib/Serialization/CMakeLists.txt
+++ b/lib/Serialization/CMakeLists.txt
@@ -1,4 +1,4 @@
-set_swift_llvm_is_available()
+
 add_swift_host_library(swiftSerialization STATIC
   Deserialization.cpp
   DeserializeSIL.cpp
@@ -19,3 +19,4 @@ target_link_libraries(swiftSerialization PRIVATE
   swiftSIL
   swiftSymbolGraphGen)
 
+set_swift_llvm_is_available(swiftSerialization)

--- a/lib/SyntaxParse/CMakeLists.txt
+++ b/lib/SyntaxParse/CMakeLists.txt
@@ -1,6 +1,8 @@
-set_swift_llvm_is_available()
+
 add_swift_host_library(swiftSyntaxParse STATIC
   SyntaxTreeCreator.cpp)
 target_link_libraries(swiftSyntaxParse PRIVATE
   swiftParse
   swiftSyntax)
+
+set_swift_llvm_is_available(swiftSyntaxParse)

--- a/lib/TBDGen/CMakeLists.txt
+++ b/lib/TBDGen/CMakeLists.txt
@@ -1,4 +1,4 @@
-set_swift_llvm_is_available()
+
 add_swift_host_library(swiftTBDGen STATIC
   APIGen.cpp
   TBDGen.cpp
@@ -11,3 +11,5 @@ target_link_libraries(swiftTBDGen PRIVATE
   swiftAST
   swiftIRGen
   swiftSIL)
+
+set_swift_llvm_is_available(swiftTBDGen)


### PR DESCRIPTION
Otherwise we set it on all targets/languages in a subdirectory (I forgot if it
propagates up). Regardless, this type of viral stuff is something we want to
move away from since it creates a code that is a "forall" piece of code rather
than a piece of code that only effects a single target.

I also conditionalized the actual definitions being added on the compiled file's
language being C,CXX,OBJC,OBJCXX since as we add Swift sources to the host side
of the compiler, we will not want these flags to propagate to Swift sources.
