### PR TITLE
[SourceKit] Recover if compiler arguments have errors

### DIFF
--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -262,13 +262,17 @@ public:
   /// Construct a compilation object for a given ToolChain and command line
   /// argument vector.
   ///
+  /// If \p AllowErrors is set to \c true, this method tries to build a
+  /// compilation even if there were errors.
+  ///
   /// \return A Compilation, or nullptr if none was built for the given argument
   /// vector. A null return value does not necessarily indicate an error
   /// condition; the diagnostics should be queried to determine if an error
   /// occurred.
   std::unique_ptr<Compilation>
   buildCompilation(const ToolChain &TC,
-                   std::unique_ptr<llvm::opt::InputArgList> ArgList);
+                   std::unique_ptr<llvm::opt::InputArgList> ArgList,
+                   bool AllowErrors = false);
 
   /// Parse the given list of strings into an InputArgList.
   std::unique_ptr<llvm::opt::InputArgList>

--- a/lib/Driver/FrontendUtil.cpp
+++ b/lib/Driver/FrontendUtil.cpp
@@ -101,7 +101,7 @@ bool swift::driver::getSingleFrontendInvocationFromDriverArguments(
     return true;
 
   std::unique_ptr<Compilation> C =
-      TheDriver.buildCompilation(*TC, std::move(ArgList));
+      TheDriver.buildCompilation(*TC, std::move(ArgList), /*AllowErrors=*/true);
   if (!C || C->getJobs().empty())
     return true; // Don't emit an error; one should already have been emitted
 
@@ -113,7 +113,6 @@ bool swift::driver::getSingleFrontendInvocationFromDriverArguments(
   if (CompileCommands.size() != 1) {
     // TODO: include Jobs in the diagnostic.
     Diags.diagnose(SourceLoc(), diag::error_expected_one_frontend_job);
-    return true;
   }
 
   const Job *Cmd = *CompileCommands.begin();

--- a/test/Frontend/Inputs/same_filename/A/File.swift
+++ b/test/Frontend/Inputs/same_filename/A/File.swift
@@ -1,0 +1,1 @@
+class Foo {}

--- a/test/Frontend/Inputs/same_filename/B/File.swift
+++ b/test/Frontend/Inputs/same_filename/B/File.swift
@@ -1,0 +1,1 @@
+class Bar {}

--- a/test/Frontend/same_filename_twice.swift
+++ b/test/Frontend/same_filename_twice.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+
+// A module should fail to be generated if the same filename is used twice and '-experimental-allow-module-with-compiler-errors' is not passed
+
+// RUN: not %target-swift-frontend -emit-module -o %t/no_allow_compiler_errors.swiftmodule %S/Inputs/same_filename/A/File.swift %S/Inputs/same_filename/B/File.swift
+// RUN: not ls %t/no_allow_compiler_errors.swiftmodule
+
+// If '-experimental-allow-module-with-compiler-errors' is passed, we should throw an error but still generate a module
+
+// RUN: %target-swift-frontend -emit-module -experimental-allow-module-with-compiler-errors -o %t/allow_compiler_errors.swiftmodule %S/Inputs/same_filename/A/File.swift %S/Inputs/same_filename/B/File.swift 2>&1 | %FileCheck %s
+// RUN: ls %t/allow_compiler_errors.swiftmodule
+
+// CHECK: filename "File.swift" used twice:

--- a/test/SourceKit/CursorInfo/Inputs/invalid_compiler_args/A/File.swift
+++ b/test/SourceKit/CursorInfo/Inputs/invalid_compiler_args/A/File.swift
@@ -1,0 +1,1 @@
+class Foo {}

--- a/test/SourceKit/CursorInfo/Inputs/invalid_compiler_args/B/File.swift
+++ b/test/SourceKit/CursorInfo/Inputs/invalid_compiler_args/B/File.swift
@@ -1,0 +1,1 @@
+class Bar {}

--- a/test/SourceKit/CursorInfo/invalid_compiler_args.swift
+++ b/test/SourceKit/CursorInfo/invalid_compiler_args.swift
@@ -1,0 +1,12 @@
+// We should not fail if two distinct file have the same name - this is only an issue in CodeGen
+// RUN: %sourcekitd-test -req=cursor -pos=1:7 %S/Inputs/invalid_compiler_args/A/File.swift -- %S/Inputs/invalid_compiler_args/A/File.swift %S/Inputs/invalid_compiler_args/B/File.swift | %FileCheck %s
+
+// We can't do anything if the requested file is not in the compiler arguments
+// RUN: not %sourcekitd-test -req=cursor -pos=1:7 %S/Inputs/invalid_compiler_args/A/File.swift --
+// RUN: not %sourcekitd-test -req=cursor -pos=1:7 %S/Inputs/invalid_compiler_args/A/File.swift -- %S/Inputs/invalid_compiler_args/B/File.swift
+
+// Specifying a file twice should just ignore one of them
+// RUN: %sourcekitd-test -req=cursor -pos=1:7 %S/Inputs/invalid_compiler_args/A/File.swift -- %S/Inputs/invalid_compiler_args/A/File.swift %S/Inputs/invalid_compiler_args/A/File.swift
+
+
+// CHECK: source.lang.swift.decl.class

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1788,8 +1788,10 @@ void SwiftLangSupport::getCursorInfo(
   std::string Error;
   SwiftInvocationRef Invok =
       ASTMgr->getInvocation(Args, InputFile, fileSystem, Error);
+  if (!Error.empty()) {
+    LOG_WARN_FUNC("error creating ASTInvocation: " << Error);
+  }
   if (!Invok) {
-    LOG_WARN_FUNC("failed to create an ASTInvocation: " << Error);
     Receiver(RequestResult<CursorInfoData>::fromError(Error));
     return;
   }


### PR DESCRIPTION
If the compiler arguments have errors in them (e.g. because a file with the same name is used twice), we can often still fulfill SourceKit requests because the compiler argument errors are only relevant for later stages of the compilation process.

Instead of bailing out early, do a best effort retrieving the compiler arguments that are valid and ignoring the errors.

Also add a test case that we can create a module if same filename is used twice and `-experimental-allow-module-with-compiler-errors` is passed

Fixes rdar://77618144