### PR TITLE
[Reflection] Prevent symbolic reference mangling induced crashes

### DIFF
--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -630,7 +630,7 @@ public:
 private:
   std::vector<ReflectionInfo> ReflectionInfos;
     
-  std::string normalizeReflectionName(RemoteRef<char> name);
+  llvm::Optional<std::string> normalizeReflectionName(RemoteRef<char> name);
   bool reflectionNameMatches(RemoteRef<char> reflectionName,
                              StringRef searchName);
 
@@ -654,7 +654,7 @@ private:
   // TypeRefBuilder struct, to isolate its template-ness from the rest of
   // TypeRefBuilder.
   unsigned PointerSize;
-  std::function<Demangle::Node * (RemoteRef<char>)>
+  std::function<Demangle::Node * (RemoteRef<char>, bool)>
     TypeRefDemangler;
   std::function<const TypeRef* (uint64_t, unsigned)>
     OpaqueUnderlyingTypeReader;
@@ -665,10 +665,10 @@ public:
     : TC(*this),
       PointerSize(sizeof(typename Runtime::StoredPointer)),
       TypeRefDemangler(
-      [this, &reader](RemoteRef<char> string) -> Demangle::Node * {
+      [this, &reader](RemoteRef<char> string, bool useOpaqueTypeSymbolicReferences) -> Demangle::Node * {
         return reader.demangle(string,
                                remote::MangledNameKind::Type,
-                               Dem, /*useOpaqueTypeSymbolicReferences*/ true);
+                               Dem, useOpaqueTypeSymbolicReferences);
       }),
       OpaqueUnderlyingTypeReader(
       [&reader](uint64_t descriptorAddr, unsigned ordinal) -> const TypeRef* {
@@ -677,8 +677,9 @@ public:
       })
   {}
 
-  Demangle::Node *demangleTypeRef(RemoteRef<char> string) {
-    return TypeRefDemangler(string);
+  Demangle::Node *demangleTypeRef(RemoteRef<char> string,
+                                  bool useOpaqueTypeSymbolicReferences = true) {
+    return TypeRefDemangler(string, useOpaqueTypeSymbolicReferences);
   }
 
   TypeConverter &getTypeConverter() { return TC; }

--- a/stdlib/public/Reflection/TypeRefBuilder.cpp
+++ b/stdlib/public/Reflection/TypeRefBuilder.cpp
@@ -88,9 +88,16 @@ std::string
 TypeRefBuilder::normalizeReflectionName(RemoteRef<char> reflectionName) {
   // Remangle the reflection name to resolve symbolic references.
   if (auto node = demangleTypeRef(reflectionName)) {
-    auto result = mangleNode(node);
-    clearNodeFactory();
-    return result;
+    switch (node->getKind()) {
+    case Node::Kind::TypeSymbolicReference:
+    case Node::Kind::ProtocolSymbolicReference:
+    case Node::Kind::OpaqueTypeDescriptorSymbolicReference:
+      break;
+    default:
+      auto result = mangleNode(node);
+      clearNodeFactory();
+      return result;
+    }
   }
 
   // Fall back to the raw string.


### PR DESCRIPTION
Based on lldb crash logs, `TypeRefBuilder` is crashing on instances of [symbolic references](https://github.com/apple/swift/blob/main/docs/ABI/Mangling.rst#symbolic-references) in mangled names.

The crash happens when a symbolic reference is attempted to be mangled (via `mangleNode()`), which leads to a call to `unreachable` which aborts. For library usage, such as from lldb, these cases need to be handled without an abort.

The improvements to gracefully handle symbolic references are:

1. Change the return type of `normalizeReflectionName` from `std::string` to `llvm::Optional<std::string>`
2. Thread through a bool flag named `useOpaqueTypeSymbolicReferences`

Both of these start in `normalizeReflectionName`. 

First, the call to `demangleTypeRef()` now sets `useOpaqueTypeSymbolicReferences` to false. Without this, `demangleTypeRef()` can return a node of kind `OpaqueTypeDescriptorSymbolicReference`, which is guaranteed to fail in this code path when in subsequent call to `mangleNode()`.

Second, if the result of `demangleTypeRef()` is one of the symbolic reference kinds, then the function exits early with a value of `None`. Callers of `normalizeReflectionName()` are now forced to handle such cases, where the mangled name could not be normalized.

In `TypeRefBuilder::getFieldTypeInfo()`, if `normalizeReflectionName()` fails, then the corresponding field is not supported, or in other words, dropped.

rdar://77613304 