### PR TITLE
[update-checkout] On Linux for main, next, and master-rebranch, bump the cmake to v3.19.6.

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -78,7 +78,7 @@
                 "ninja": "release",
                 "icu": "release-65-1",
                 "yams": "4.0.2",
-                "cmake": "v3.16.5",
+                "cmake": "v3.19.6",
                 "indexstore-db": "main",
                 "sourcekit-lsp": "main",
                 "swift-format": "main"
@@ -190,7 +190,7 @@
                 "ninja": "release",
                 "icu": "release-65-1",
                 "yams": "3.0.1",
-                "cmake": "v3.16.5",
+                "cmake": "v3.19.6",
                 "indexstore-db": "main",
                 "sourcekit-lsp": "main",
                 "swift-format": "main"
@@ -221,7 +221,7 @@
                 "ninja": "release",
                 "icu": "release-65-1",
                 "yams": "4.0.2",
-                "cmake": "v3.16.5",
+                "cmake": "v3.19.6",
                 "indexstore-db": "main",
                 "sourcekit-lsp": "main",
                 "swift-format": "main"


### PR DESCRIPTION
This is not touching the minimum yet since we need to do a bit more work over
the next couple of weeks to get the bots ready on macOS for the newer cmake.
Windows bots already support the newer cmake.

https://forums.swift.org/t/bump-cmake-version-to-3-18/45033/10
