### PR TITLE
[Tests] Make some checks in invalid-top less specific

### DIFF
--- a/test/Serialization/AllowErrors/invalid-top.swift
+++ b/test/Serialization/AllowErrors/invalid-top.swift
@@ -36,9 +36,9 @@ func test(s: ValidType) {
 // Check SIL diagnostics are still output (no reason not to output SIL since
 // there were no errors)
 func other() -> Int {}
-// CHECK-VALID: valid-uses.swift:10:22: error: missing return in global function expected to return 'Int'
+// CHECK-VALID: valid-uses.swift:10:22: error: missing return
 func other2() -> Bool {}
-// CHECK-VALID: valid-uses.swift:12:24: error: missing return in global function expected to return 'Bool'
+// CHECK-VALID: valid-uses.swift:12:24: error: missing return
 
 
 // BEGIN invalid-uses.swift


### PR DESCRIPTION
There was a change in the diagnostics that isn't in 5.5. The error
message itself doesn't matter too much here, just that there was one.
Simplify the CHECK clause so that it will pass in main and 5.5 to avoid
future conflicts.