### PR TITLE
[Sema][Diagnostics][SR-14644] Improving diagnostics for key path with invalid components

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -5833,7 +5833,10 @@ public:
   /// Indicates if the key path expression is composed by a single invalid
   /// component. e.g. missing component `\Root`
   bool hasSingleInvalidComponent() const {
-    return Components.size() == 1 && !Components.front().isValid();
+    if (ParsedRoot && ParsedRoot->getKind() == ExprKind::Type) {
+      return Components.size() == 1 && !Components.front().isValid();
+    }
+    return false;
   }
 
   /// Retrieve the string literal expression, which will be \c NULL prior to

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1851,6 +1851,15 @@ TypeVariableBinding::fixForHole(ConstraintSystem &cs) const {
     if (cs.hasFixFor(kpLocator, FixKind::AllowKeyPathWithoutComponents))
       return None;
 
+    // If key path has any invalid component, let's just skip fix because the
+    // invalid component would be already diagnosed.
+    auto keyPath = castToExpr<KeyPathExpr>(srcLocator->getAnchor());
+    if (llvm::any_of(keyPath->getComponents(),
+                     [](KeyPathExpr::Component component) {
+                       return !component.isValid();
+                     }))
+      return None;
+
     ConstraintFix *fix = SpecifyKeyPathRootType::create(cs, dstLocator);
     return std::make_pair(fix, defaultImpact);
   }

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -1054,6 +1054,16 @@ func testSyntaxErrors() {
   _ = \A.a!;
 }
 
+// SR-14644
+func sr14644() {
+  _ = \Int.byteSwapped.signum() // expected-error {{invalid component of Swift key path}}
+  _ = \Int.byteSwapped.init() // expected-error {{invalid component of Swift key path}}
+  _ = \Int // expected-error {{key path must have at least one component}}
+  _ = \Int? // expected-error {{key path must have at least one component}}
+  _ = \Int. // expected-error {{invalid component of Swift key path}}
+  // expected-error@-1 {{expected member name following '.'}}
+}
+
 // SR-13364 - keypath missing optional crashes compiler: "Inactive constraints left over?"
 func sr13364() {
   let _: KeyPath<String?, Int?> = \.utf8.count // expected-error {{no exact matches in reference to property 'count'}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
This just adjust the `hasSingleInvalidComponent` key path expr method to only consider key path rooted on type expr because we only want to detect key paths without components e.g. `\Int` because actually key paths with invalid components like the SR example `\Int.byteSwapped.signum()` are represented in the AST also with a single invalid component but rooted on the whole expression. Also skips the fix for hole root key path if it has any invalid component as it would be already diagnosed.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-14644.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
