### PR TITLE
[Frontend] Do not output swiftinterface when there has been errors

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -816,6 +816,7 @@ static void emitIndexData(const CompilerInstance &Instance) {
 /// anything past type-checking.
 static bool emitAnyWholeModulePostTypeCheckSupplementaryOutputs(
     CompilerInstance &Instance) {
+  const auto &Context = Instance.getASTContext();
   const auto &Invocation = Instance.getInvocation();
   const FrontendOptions &opts = Invocation.getFrontendOptions();
 
@@ -834,7 +835,8 @@ static bool emitAnyWholeModulePostTypeCheckSupplementaryOutputs(
   // failure does not mean skipping the rest.
   bool hadAnyError = false;
 
-  if (opts.InputsAndOutputs.hasObjCHeaderOutputPath()) {
+  if ((!Context.hadError() || opts.AllowModuleWithCompilerErrors) &&
+      opts.InputsAndOutputs.hasObjCHeaderOutputPath()) {
     std::string BridgingHeaderPathForPrint;
     if (!opts.ImplicitObjCHeaderPath.empty()) {
       if (opts.BridgingHeaderDirForPrint.hasValue()) {
@@ -853,6 +855,11 @@ static bool emitAnyWholeModulePostTypeCheckSupplementaryOutputs(
         Instance.getMainModule(), BridgingHeaderPathForPrint,
         Invocation.isModuleExternallyConsumed(Instance.getMainModule()));
   }
+
+  // Only want the header if there's been any errors, ie. there's not much
+  // point outputting a swiftinterface for an invalid module
+  if (Context.hadError())
+    return hadAnyError;
 
   if (opts.InputsAndOutputs.hasModuleInterfaceOutputPath()) {
     hadAnyError |= printModuleInterfaceIfNeeded(
@@ -996,9 +1003,10 @@ static void performEndOfPipelineActions(CompilerInstance &Instance) {
 
     dumpAPIIfNeeded(Instance);
   }
-  if (!ctx.hadError() || opts.AllowModuleWithCompilerErrors) {
-    emitAnyWholeModulePostTypeCheckSupplementaryOutputs(Instance);
-  }
+
+  // Contains the hadError checks internally, we still want to output the
+  // Objective-C header when there's errors and currently allowing them
+  emitAnyWholeModulePostTypeCheckSupplementaryOutputs(Instance);
 
   // Verify reference dependencies of the current compilation job. Note this
   // must be run *before* verifying diagnostics so that the former can be tested

--- a/test/Frontend/allow-errors.swift
+++ b/test/Frontend/allow-errors.swift
@@ -1,11 +1,18 @@
 // RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/mods)
+// RUN: touch %t/empty.swift
 
 // The module should be generated regardless of errors, including .swiftdeps, .d,
 // .swiftsourceinfo, etc. Diagnostics should still be output as well
 
-// RUN: %target-swift-frontend -verify -emit-module -o %t/errors.swiftmodule -emit-module-source-info -emit-module-doc -emit-reference-dependencies-path %t/errors.swiftdeps -emit-dependencies-path %t/errors.d -experimental-allow-module-with-compiler-errors -primary-file %s
-// RUN: llvm-bcanalyzer %t/errors.swiftmodule | %FileCheck -check-prefix=CHECK-BC %s
-// RUN: ls %t/errors.swiftdeps %t/errors.d %t/errors.swiftsourceinfo %t/errors.swiftdoc
+// RUN: %target-swift-frontend -module-name errors -emit-module -o %t/mods/errorsmain.partial.swiftmodule -emit-reference-dependencies-path %t/mods/errorsmain.partial.swiftdeps -experimental-allow-module-with-compiler-errors -primary-file %s
+// RUN: %target-swift-frontend -module-name errors -emit-module -o %t/mods/errorsempty.partial.swiftmodule %t/empty.swift
+// RUN: %target-swift-frontend -module-name errors -emit-module -o %t/mods/errors.swiftmodule -experimental-allow-module-with-compiler-errors %t/mods/errorsmain.partial.swiftmodule %t/mods/errorsempty.partial.swiftmodule -emit-module-source-info -emit-module-doc -emit-dependencies-path %t/mods/errors.d -emit-objc-header -emit-objc-header-path %t/mods/errors.h -emit-module-interface-path %t/mods/errors.swiftinterface -emit-tbd-path %t/mods/errors.tbd
+
+// RUN: llvm-bcanalyzer %t/mods/errors.swiftmodule | %FileCheck -check-prefix=CHECK-BC %s
+// RUN: ls %t/mods/errorsmain.partial.swiftdeps %t/mods/errors.d %t/mods/errors.swiftsourceinfo %t/mods/errors.swiftdoc %t/mods/errors.h
+// RUN: not ls %t/mods/errors.swiftinterface
+// RUN: not ls %t/mods/errors.tbd
 // CHECK-BC-NOT: UnknownCode
 
 public func invalid() -> undefined {} // expected-error {{cannot find type 'undefined'}}


### PR DESCRIPTION
When allowing errors with
-experimental-allow-module-with-compiler-errors, do not output the
.swiftinterface when there has been errors. There's no real need to
output them for invalid modules, so this avoids module interface
printing having to have checks for normally-impossible cases.

Resolves rdar://78039608.