### PR TITLE
GSB: Workaround iterator invalidation issue with getMinimalConformanceSource()

### DIFF
--- a/test/Generics/rdar77807692.swift
+++ b/test/Generics/rdar77807692.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+
+protocol P1 {
+  associatedtype T : Hashable
+}
+
+struct S1<Value> {}
+
+extension S1 : P1 where Value : P1 {
+  typealias T = Value.T
+}
+
+protocol P2 {
+  associatedtype Value: P1
+}
+
+struct S2<X, Y: P2> where Y.Value == X {
+  // CHECK-LABEL: Generic signature: <X, Y, T where X == S1<T>, Y : P2, T : P1, Y.Value == S1<T>>
+  init<T>(_: T) where X == S1<T> { }
+}


### PR DESCRIPTION
In a few places we call getMinimalConformanceSource() while iterating
over all equivalence classes, or the conformances of a specific
equivalence class.

In both cases, getMinimalConformanceSource() can modify the storage
of the collection being iterated over, because it can end up calling
maybeResolveEquivalenceClass(), which can introduce new constraints.

Work around this by iterating a copy of the list of equivalence
classes first, calling getMinimalConformanceSource() and discarding
the result on each conformance source.

This is a terrible workaround, but should address the issue in the
meantime until I finish removing getMinimalConformanceSource().

Fixes rdar://problem/46420886 / https://bugs.swift.org/browse/SR-9398,
rdar://problem/77807692.