### PR TITLE
Driver: do not generate a dSYM bundle for static archives

### DIFF
--- a/test/Driver/darwin-static-library-debug.swift
+++ b/test/Driver/darwin-static-library-debug.swift
@@ -1,0 +1,14 @@
+// RUN: %swiftc_driver -driver-print-actions -target x86_64-apple-macosx10.15 -g -emit-library -static -o library.a %s 2>&1 | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-STATIC
+// RUN: %swiftc_driver -driver-print-actions -target x86_64-apple-macosx10.15 -g -emit-library -o library.a %s 2>&1 | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-SHARED
+// RUN: %swiftc_driver -driver-print-actions -target x86_64-apple-macosx10.15 -g -o a.out %s 2>&1 | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-EXEC
+
+// CHECK: 0: input, "{{.*}}darwin-static-library-debug.swift", swift
+// CHECK: 1: compile, {0}, object
+// CHECK: 2: merge-module, {1}, swiftmodule
+// CHECK-STATIC: 3: static-link, {1, 2}, image
+// CHECK-STATIC-NOT: 4: generate-dSYM, {3}, dSYM
+// CHECK-SHARED: 3: link, {1, 2}, image
+// CHECK-SHARED: 4: generate-dSYM, {3}, dSYM
+// CHECK-EXEC: 3: link, {1, 2}, image
+// CHECK-EXEC: 4: generate-dSYM, {3}, dSYM
+


### PR DESCRIPTION
When building a static library with debug information, do not create a
dSYM generation job as it cannot be executed on a non-image target.
This is important for the case where the single invocation is both the
compile and link job.

This was detected in conjunction with @gottesmm 

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
