### PR TITLE
[CodeCompletion] Don't suggest underscored module name

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2078,6 +2078,12 @@ public:
     IncludeInstanceMembers = true;
   }
 
+  bool isHiddenModuleName(Identifier Name) {
+    return (Name.str().startswith("_") ||
+            Name == Ctx.SwiftShimsModuleName ||
+            Name.str() == SWIFT_ONONE_SUPPORT);
+  }
+
   void addSubModuleNames(std::vector<std::pair<std::string, bool>>
       &SubModuleNameVisibilityPairs) {
     for (auto &Pair : SubModuleNameVisibilityPairs) {
@@ -2142,10 +2148,7 @@ public:
 
     auto mainModuleName = CurrModule->getName();
     for (auto ModuleName : ModuleNames) {
-      if (ModuleName.str().startswith("_") ||
-          ModuleName == mainModuleName ||
-          ModuleName == Ctx.SwiftShimsModuleName ||
-          ModuleName.str() == SWIFT_ONONE_SUPPORT)
+      if (ModuleName == mainModuleName || isHiddenModuleName(ModuleName))
         continue;
 
       auto MD = ModuleDecl::create(ModuleName, Ctx);
@@ -6257,8 +6260,10 @@ static void deliverCompletionResults(CodeCompletionContext &CompletionContext,
         RequestedModules.push_back({std::move(K), TheModule,
           Request.OnlyTypes, Request.OnlyPrecedenceGroups});
 
+        auto TheModuleName = TheModule->getName();
         if (Request.IncludeModuleQualifier &&
-            seenModuleNames.insert(TheModule->getName()).second)
+            !Lookup.isHiddenModuleName(TheModuleName) &&
+            seenModuleNames.insert(TheModuleName).second)
           Lookup.addModuleName(TheModule);
       }
     };

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -6212,6 +6212,25 @@ static void deliverCompletionResults(CodeCompletionContext &CompletionContext,
   llvm::SmallPtrSet<Identifier, 8> seenModuleNames;
   std::vector<RequestedCachedModule> RequestedModules;
 
+  SmallPtrSet<ModuleDecl *, 4> explictlyImportedModules;
+  {
+    // Collect modules directly imported in this SourceFile.
+    SmallVector<ImportedModule, 4> directImport;
+    SF.getImportedModules(directImport,
+                          {ModuleDecl::ImportFilterKind::Default,
+                           ModuleDecl::ImportFilterKind::ImplementationOnly});
+    for (auto import : directImport)
+      explictlyImportedModules.insert(import.importedModule);
+
+    // Exclude modules implicitly imported in the current module.
+    auto implicitImports = SF.getParentModule()->getImplicitImports();
+    for (auto import : implicitImports.imports)
+      explictlyImportedModules.erase(import.module.importedModule);
+
+    // Consider the current module "explicit".
+    explictlyImportedModules.insert(SF.getParentModule());
+  }
+
   for (auto &Request: Lookup.RequestedCachedResults) {
     llvm::DenseSet<CodeCompletionCache::Key> ImportsSeen;
     auto handleImport = [&](ImportedModule Import) {
@@ -6262,7 +6281,8 @@ static void deliverCompletionResults(CodeCompletionContext &CompletionContext,
 
         auto TheModuleName = TheModule->getName();
         if (Request.IncludeModuleQualifier &&
-            !Lookup.isHiddenModuleName(TheModuleName) &&
+            (!Lookup.isHiddenModuleName(TheModuleName) ||
+             explictlyImportedModules.contains(TheModule)) &&
             seenModuleNames.insert(TheModuleName).second)
           Lookup.addModuleName(TheModule);
       }

--- a/test/IDE/complete_modulename.swift
+++ b/test/IDE/complete_modulename.swift
@@ -1,16 +1,21 @@
+// BEGIN _Helper.swift
+public struct HelperTy {}
+public func helperFunc() {}
+
 // BEGIN MyModule.swift
+@_exported import _Helper
+
 public struct MyModuleTy {}
 public func myModuleFunc() {}
 
-
-// BEGIN _Hidden.swift
+// BEGIN _Explicit.swift
 public struct HiddenTy {}
 public func hiddenFunc() {}
 
 // BEGIN App.swift
 
 import MyModule
-import _Hidden
+import _Explicit
 
 func test() {
  let _ = #^EXPR^#
@@ -19,35 +24,49 @@ func test() {
 }
 
 // EXPR: Begin completion
+
 // EXPR-NOT: _Concurrency[#Module#]
 // EXPR-NOT: SwiftShims[#Module#]
 // EXPR-NOT: SwiftOnoneSupport[#Module#]
+// EXPR-NOT: _Helper[#Module#]
+
 // EXPR-DAG: Decl[Module]/None:                  swift_ide_test[#Module#]; name=swift_ide_test
 // EXPR-DAG: Decl[Module]/None/IsSystem:         Swift[#Module#]; name=Swift
 // EXPR-DAG: Decl[Module]/None:                  MyModule[#Module#]; name=MyModule
+// EXPR-DAG: Decl[Module]/None:                  _Explicit[#Module#]; name=_Explicit
 // EXPR-DAG: Decl[Struct]/OtherModule[MyModule]: MyModuleTy[#MyModuleTy#]; name=MyModuleTy
-// EXPR-DAG: Decl[Struct]/OtherModule[_Hidden]:  HiddenTy[#HiddenTy#]; name=HiddenTy
+// EXPR-DAG: Decl[Struct]/OtherModule[_Explicit]: HiddenTy[#HiddenTy#]; name=HiddenTy
+// EXPR-DAG: Decl[Struct]/OtherModule[_Helper]:  HelperTy[#HelperTy#]; name=HelperTy
 // EXPR-DAG: Decl[FreeFunction]/OtherModule[MyModule]: myModuleFunc()[#Void#]; name=myModuleFunc()
-// EXPR-DAG: Decl[FreeFunction]/OtherModule[_Hidden]: hiddenFunc()[#Void#]; name=hiddenFunc()
+// EXPR-DAG: Decl[FreeFunction]/OtherModule[_Explicit]: hiddenFunc()[#Void#]; name=hiddenFunc()
+// EXPR-DAG: Decl[FreeFunction]/OtherModule[_Helper]: helperFunc()[#Void#]; name=helperFunc()
+
 // EXPR: End completions
 
 // TYPE: Begin completion
+
 // TYPE-NOT: _Concurrency[#Module#]
 // TYPE-NOT: SwiftShims[#Module#]
 // TYPE-NOT: SwiftOnoneSupport[#Module#]
+// TYPE-NOT: _Helper[#Module#]
+
 // TYPE-DAG: Decl[Module]/None:                  swift_ide_test[#Module#]; name=swift_ide_test
 // TYPE-DAG: Decl[Module]/None/IsSystem:         Swift[#Module#]; name=Swift
 // TYPE-DAG: Decl[Module]/None:                  MyModule[#Module#]; name=MyModule
+// TYPE-DAG: Decl[Module]/None:                  _Explicit[#Module#]; name=_Explicit
 // TYPE-DAG: Decl[Struct]/OtherModule[MyModule]: MyModuleTy[#MyModuleTy#]; name=MyModuleTy
-// TYPE-DAG: Decl[Struct]/OtherModule[_Hidden]:  HiddenTy[#HiddenTy#]; name=HiddenTy
+// TYPE-DAG: Decl[Struct]/OtherModule[_Explicit]: HiddenTy[#HiddenTy#]; name=HiddenTy
+// TYPE-DAG: Decl[Struct]/OtherModule[_Helper]:  HelperTy[#HelperTy#]; name=HelperTy
+
 // TYPE: End completions
 
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 
 // RUN: %empty-directory(%t/Modules)
-// RUN: %target-swift-frontend -emit-module -module-name MyModule -o %t/Modules %t/MyModule.swift
-// RUN: %target-swift-frontend -emit-module -module-name _Hidden -o %t/Modules %t/_Hidden.swift
+// RUN: %target-swift-frontend -emit-module -module-name _Helper -o %t/Modules %t/_Helper.swift
+// RUN: %target-swift-frontend -emit-module -module-name MyModule -o %t/Modules %t/MyModule.swift -I %t/Modules
+// RUN: %target-swift-frontend -emit-module -module-name _Explicit -o %t/Modules %t/_Explicit.swift -I %t/Modules
 
 // RUN: %empty-directory(%t/Out)
 // RUN: %target-swift-ide-test -batch-code-completion -source-filename %t/App.swift -filecheck %raw-FileCheck -completion-output-dir %t/Out -I %t/Modules

--- a/test/IDE/complete_modulename.swift
+++ b/test/IDE/complete_modulename.swift
@@ -1,0 +1,53 @@
+// BEGIN MyModule.swift
+public struct MyModuleTy {}
+public func myModuleFunc() {}
+
+
+// BEGIN _Hidden.swift
+public struct HiddenTy {}
+public func hiddenFunc() {}
+
+// BEGIN App.swift
+
+import MyModule
+import _Hidden
+
+func test() {
+ let _ = #^EXPR^#
+
+ func test() -> #^TYPE^#
+}
+
+// EXPR: Begin completion
+// EXPR-NOT: _Concurrency[#Module#]
+// EXPR-NOT: SwiftShims[#Module#]
+// EXPR-NOT: SwiftOnoneSupport[#Module#]
+// EXPR-DAG: Decl[Module]/None:                  swift_ide_test[#Module#]; name=swift_ide_test
+// EXPR-DAG: Decl[Module]/None/IsSystem:         Swift[#Module#]; name=Swift
+// EXPR-DAG: Decl[Module]/None:                  MyModule[#Module#]; name=MyModule
+// EXPR-DAG: Decl[Struct]/OtherModule[MyModule]: MyModuleTy[#MyModuleTy#]; name=MyModuleTy
+// EXPR-DAG: Decl[Struct]/OtherModule[_Hidden]:  HiddenTy[#HiddenTy#]; name=HiddenTy
+// EXPR-DAG: Decl[FreeFunction]/OtherModule[MyModule]: myModuleFunc()[#Void#]; name=myModuleFunc()
+// EXPR-DAG: Decl[FreeFunction]/OtherModule[_Hidden]: hiddenFunc()[#Void#]; name=hiddenFunc()
+// EXPR: End completions
+
+// TYPE: Begin completion
+// TYPE-NOT: _Concurrency[#Module#]
+// TYPE-NOT: SwiftShims[#Module#]
+// TYPE-NOT: SwiftOnoneSupport[#Module#]
+// TYPE-DAG: Decl[Module]/None:                  swift_ide_test[#Module#]; name=swift_ide_test
+// TYPE-DAG: Decl[Module]/None/IsSystem:         Swift[#Module#]; name=Swift
+// TYPE-DAG: Decl[Module]/None:                  MyModule[#Module#]; name=MyModule
+// TYPE-DAG: Decl[Struct]/OtherModule[MyModule]: MyModuleTy[#MyModuleTy#]; name=MyModuleTy
+// TYPE-DAG: Decl[Struct]/OtherModule[_Hidden]:  HiddenTy[#HiddenTy#]; name=HiddenTy
+// TYPE: End completions
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %empty-directory(%t/Modules)
+// RUN: %target-swift-frontend -emit-module -module-name MyModule -o %t/Modules %t/MyModule.swift
+// RUN: %target-swift-frontend -emit-module -module-name _Hidden -o %t/Modules %t/_Hidden.swift
+
+// RUN: %empty-directory(%t/Out)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %t/App.swift -filecheck %raw-FileCheck -completion-output-dir %t/Out -I %t/Modules


### PR DESCRIPTION
Underscored modules (e.g. `_Concurrency`) are usually not meant be written explicitly in source code. They are usually implicitly imported with other modules. Code completion should not suggest them in type and expression context.

rdar://78232229

