### PR TITLE
[Refactoring] generate both '-dump-text' and `dump-rewritten` from a single swift-refactor invocation

### DIFF
--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -544,6 +544,17 @@ public:
   void accept(SourceManager &SM, RegionType RegionType, ArrayRef<Replacement> Replacements) override;
 };
 
+class DuplicatingSourceEditConsumer : public SourceEditConsumer {
+  SourceEditConsumer *ConsumerA;
+  SourceEditConsumer *ConsumerB;
+
+public:
+  DuplicatingSourceEditConsumer(SourceEditConsumer *ConsumerA,
+                                SourceEditConsumer *ConsumerB);
+  void accept(SourceManager &SM, RegionType RegionType,
+              ArrayRef<Replacement> Replacements) override;
+};
+
 enum class LabelRangeEndAt: int8_t {
   BeforeElemStart,
   LabelNameOnly,

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -1116,6 +1116,17 @@ accept(SourceManager &SM, RegionType RegionType,
   }
 }
 
+swift::ide::DuplicatingSourceEditConsumer::DuplicatingSourceEditConsumer(
+    SourceEditConsumer *ConsumerA, SourceEditConsumer *ConsumerB)
+    : ConsumerA(ConsumerA), ConsumerB(ConsumerB) {}
+
+void swift::ide::DuplicatingSourceEditConsumer::accept(
+    SourceManager &SM, RegionType RegionType,
+    ArrayRef<Replacement> Replacements) {
+  ConsumerA->accept(SM, RegionType, Replacements);
+  ConsumerB->accept(SM, RegionType, Replacements);
+}
+
 bool swift::ide::isFromClang(const Decl *D) {
   if (getEffectiveClangNode(D))
     return true;

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -99,6 +99,10 @@ InputFilenames(llvm::cl::Positional, llvm::cl::desc("[input files...]"),
                llvm::cl::ZeroOrMore);
 
 static llvm::cl::opt<std::string>
+    RewrittenOutputFile("rewritten-output-file",
+                        llvm::cl::desc("Name of the rewritten output file"));
+
+static llvm::cl::opt<std::string>
 LineColumnPair("pos", llvm::cl::desc("Line:Column pair or /*label*/"));
 
 static llvm::cl::opt<std::string>
@@ -402,14 +406,27 @@ int main(int argc, char *argv[]) {
   switch (options::DumpIn) {
   case options::DumpType::REWRITTEN:
     pConsumer.reset(new SourceEditOutputConsumer(SF->getASTContext().SourceMgr,
-                                                 BufferID,
-                                                 llvm::outs()));
+                                                 BufferID, llvm::outs()));
     break;
   case options::DumpType::JSON:
     pConsumer.reset(new SourceEditJsonConsumer(llvm::outs()));
     break;
   case options::DumpType::TEXT:
-    pConsumer.reset(new SourceEditTextConsumer(llvm::outs()));
+    if (options::RewrittenOutputFile.empty()) {
+      pConsumer.reset(new SourceEditTextConsumer(llvm::outs()));
+    } else {
+      std::error_code EC;
+      static llvm::raw_fd_ostream FileStream(options::RewrittenOutputFile, EC,
+                                             llvm::sys::fs::OF_None);
+      if (FileStream.has_error() || EC) {
+        llvm::errs() << "Could not open rewritten output file";
+        return 1;
+      }
+      pConsumer.reset(new DuplicatingSourceEditConsumer(
+          new SourceEditTextConsumer(llvm::outs()),
+          new SourceEditOutputConsumer(SF->getASTContext().SourceMgr, BufferID,
+                                       FileStream)));
+    }
     break;
   }
 

--- a/utils/refactor-check-compiles.py
+++ b/utils/refactor-check-compiles.py
@@ -85,23 +85,13 @@ def main():
         extra_refactor_args.append('-enable-experimental-concurrency')
         extra_frontend_args.append('-enable-experimental-concurrency')
 
-    # FIXME: `refactor-check-compiles` should generate both `-dump-text` and
-    # `dump-rewritten` from a single `swift-refactor` invocation (SR-14587).
     dump_text_output = run_cmd([
         args.swift_refactor,
         '-dump-text',
         '-source-filename', args.source_filename,
+        '-rewritten-output-file', temp_file_path,
         '-pos', args.pos
     ] + extra_refactor_args, desc='producing edit').decode("utf-8")
-
-    dump_rewritten_output = run_cmd([
-        args.swift_refactor,
-        '-dump-rewritten',
-        '-source-filename', args.source_filename,
-        '-pos', args.pos
-    ] + extra_refactor_args, desc='producing rewritten file')
-    with open(temp_file_path, 'wb') as f:
-        f.write(dump_rewritten_output)
 
     run_cmd([
         args.swift_frontend,


### PR DESCRIPTION
generate both `-dump-text` and  `dump-rewritten` from a single `swift-refactor` invocation.

Resolves SR-14587.
