### PR TITLE
[Verification] Skip checking minimal resilience expansion functions

### DIFF
--- a/lib/SILOptimizer/UtilityPasses/SILSkippingChecker.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SILSkippingChecker.cpp
@@ -51,6 +51,9 @@ static bool shouldHaveSkippedFunction(const SILFunction &F) {
   if (!func)
     return false;
 
+  if (func->getResilienceExpansion() == ResilienceExpansion::Minimal)
+    return false;
+
   // If a body is synthesized/implicit, it shouldn't be skipped.
   if (func->isImplicit())
     return false;
@@ -72,9 +75,8 @@ static bool shouldHaveSkippedFunction(const SILFunction &F) {
       return false;
   }
 
-  // If none of those conditions trip, then this is something that _should_
-  // be serialized in the module even when we're skipping non-inlinable
-  // function bodies.
+  // If none of those conditions trip, then this is something that should
+  // _not_ be serialized in the module (ie. should be skipped).
   return true;
 }
 

--- a/test/Frontend/skip-function-bodies.swift
+++ b/test/Frontend/skip-function-bodies.swift
@@ -39,6 +39,21 @@
 @inline(never)
 func _blackHole(_ s: String) {}
 
+struct StructOuter {
+  @usableFromInline
+  struct StructInner {}
+}
+extension StructOuter.StructInner {
+  @inlinable
+  func inlinableInnerFunc() {
+    let ALLNOTYPECHECK_innerStructAndFuncLocal = 1
+    _blackHole("@inlinable func in inner @usableFromInline struct")
+    // CHECK-NONINLINE-SIL: "@inlinable func in inner @usableFromInline struct"
+    // CHECK-NONINLINE-TEXTUAL-NOT: "@inlinable func in inner @usableFromInline struct"
+    // CHECK-ALL-ONLY-NOT: "@inlinable func in inner @usableFromInline struct"
+  }
+}
+
 // NOTE: The order of the checks below is important. The checks try to be
 // logically grouped, but sometimes -emit-sorted-sil needs to break the logical
 // order.
@@ -174,9 +189,9 @@ public func inlinableNestedLocalTypeFunc() {
     typealias InlinableNestedLocalType = Int
     func takesLocalType(_ x: InlinableNestedLocalType) {
       let ALLNOTYPECHECK_innerLocal2 = 1
-      _blackHole("nested func body inside @inlinable func body taking local type")
-      // CHECK-NONINLINE-ONLY: "nested func body inside @inlinable func body taking local type"
-      // CHECK-ALL-ONLY-NOT: "nested func body inside @inlinable func body taking local type"
+      _blackHole("nested func body inside @inlinable func body taking nested local type")
+      // CHECK-NONINLINE-ONLY: "nested func body inside @inlinable func body taking nested local type"
+      // CHECK-ALL-ONLY-NOT: "nested func body inside @inlinable func body taking nested local type"
     }
     takesLocalType(0)
   }


### PR DESCRIPTION
When -experimental-skip-non-inlinable-function-bodies is enabled, do not
verify that functions with minimal resilience expansion did not have any
SIL generated (since they will).

Resolves rdar://77683841.