### PR TITLE
[Parser] Reduce the max nesting level and add environment variable to control it

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -331,9 +331,14 @@ public:
   class StructureMarkerRAII {
     Parser *const P;
 
-    /// Max nesting level
-    // TODO: customizable.
-    enum { MaxDepth = 256 };
+    /// The maximum depth that StructureMarkerRAII can be nested to avoid a
+    /// stack overflow in the parser.
+    /// This is set on first access through \c getMaxDepth() from the \c
+    /// SWIFT_MAX_NESTING_LEVEL environment variable. If that doesn't exist,
+    /// defaults to 100.
+    static size_t MaxDepth;
+
+    static size_t getMaxDepth();
 
     StructureMarkerRAII(Parser *parser) : P(parser) {}
 


### PR DESCRIPTION
A max nesting level of 256 was still causing stack overflows in some situations. Reduce the default nesting level to 100 and add an environment variable to adjust the value.

Resolves rdar://75090563
