### PR TITLE
[5.5] [Refactoring] Add async wrapper refactoring action

### DIFF
--- a/include/swift/AST/ParameterList.h
+++ b/include/swift/AST/ParameterList.h
@@ -76,7 +76,10 @@ public:
   iterator end() { return getArray().end(); }
   const_iterator begin() const { return getArray().begin(); }
   const_iterator end() const { return getArray().end(); }
-  
+
+  ParamDecl *front() const { return getArray().front(); }
+  ParamDecl *back() const { return getArray().back(); }
+
   MutableArrayRef<ParamDecl*> getArray() {
     return {getTrailingObjects<ParamDecl*>(), numParameters};
   }

--- a/include/swift/IDE/RefactoringKinds.def
+++ b/include/swift/IDE/RefactoringKinds.def
@@ -60,6 +60,8 @@ CURSOR_REFACTORING(ConvertToAsync, "Convert Function to Async", convert.func-to-
 
 CURSOR_REFACTORING(AddAsyncAlternative, "Add Async Alternative", add.async-alternative)
 
+CURSOR_REFACTORING(AddAsyncWrapper, "Add Async Wrapper", add.async-wrapper)
+
 RANGE_REFACTORING(ExtractExpr, "Extract Expression", extract.expr)
 
 RANGE_REFACTORING(ExtractFunction, "Extract Method", extract.function)

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -5440,6 +5440,20 @@ private:
     return TopHandler.isValid();
   }
 
+  /// Prints a tuple of elements, or a lone single element if only one is
+  /// present, using the provided printing function.
+  template <typename T, typename PrintFn>
+  void addTupleOf(ArrayRef<T> Elements, llvm::raw_ostream &OS,
+                  PrintFn PrintElt) {
+    if (Elements.size() == 1) {
+      PrintElt(Elements[0]);
+      return;
+    }
+    OS << tok::l_paren;
+    llvm::interleave(Elements, PrintElt, [&]() { OS << tok::comma << " "; });
+    OS << tok::r_paren;
+  }
+
 
   /// Retrieves the location for the start of a comment attached to the token
   /// at the provided location, or the location itself if there is no comment.
@@ -6083,16 +6097,9 @@ private:
         }
         OS << " ";
       }
-      if (SuccessParams.size() > 1)
-        OS << tok::l_paren;
-      OS << newNameFor(SuccessParams.front());
-      for (const auto Param : SuccessParams.drop_front()) {
-        OS << tok::comma << " ";
-        OS << newNameFor(Param);
-      }
-      if (SuccessParams.size() > 1) {
-        OS << tok::r_paren;
-      }
+      // 'res =' or '(res1, res2, ...) ='
+      addTupleOf(SuccessParams, OS,
+                 [&](auto &Param) { OS << newNameFor(Param); });
       OS << " " << tok::equal << " ";
     }
 
@@ -6416,19 +6423,10 @@ private:
   /// Adds the result type of a refactored async function that previously
   /// returned results via a completion handler described by \p HandlerDesc.
   void addAsyncFuncReturnType(const AsyncHandlerDesc &HandlerDesc) {
+    // Type or (Type1, Type2, ...)
     SmallVector<Type, 2> Scratch;
-    auto ReturnTypes = HandlerDesc.getAsyncReturnTypes(Scratch);
-    if (ReturnTypes.size() > 1) {
-      OS << tok::l_paren;
-    }
-
-    llvm::interleave(
-        ReturnTypes, [&](Type Ty) { Ty->print(OS); },
-        [&]() { OS << tok::comma << " "; });
-
-    if (ReturnTypes.size() > 1) {
-      OS << tok::r_paren;
-    }
+    addTupleOf(HandlerDesc.getAsyncReturnTypes(Scratch), OS,
+               [&](auto Ty) { Ty->print(OS); });
   }
 
   /// If \p FD is generic, adds a type annotation with the return type of the

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -4204,6 +4204,13 @@ struct AsyncHandlerDesc {
     return params();
   }
 
+  /// If the completion handler has an Error parameter, return it.
+  Optional<AnyFunctionType::Param> getErrorParam() const {
+    if (HasError && Type == HandlerType::PARAMS)
+      return params().back();
+    return None;
+  }
+
   /// Get the type of the error that will be thrown by the \c async method or \c
   /// None if the completion handler doesn't accept an error parameter.
   /// This may be more specialized than the generic 'Error' type if the
@@ -5405,6 +5412,41 @@ public:
     return true;
   }
 
+  /// Creates an async alternative function that forwards onto the completion
+  /// handler function through
+  /// withCheckedContinuation/withCheckedThrowingContinuation.
+  bool createAsyncWrapper() {
+    assert(Buffer.empty() && "AsyncConverter can only be used once");
+    auto *FD = cast<FuncDecl>(StartNode.get<Decl *>());
+
+    // First add the new async function declaration.
+    addFuncDecl(FD);
+    OS << tok::l_brace << "\n";
+
+    // Then add the body.
+    OS << tok::kw_return << " ";
+    if (TopHandler.HasError)
+      OS << tok::kw_try << " ";
+
+    OS << "await ";
+
+    // withChecked[Throwing]Continuation { cont in
+    if (TopHandler.HasError) {
+      OS << "withCheckedThrowingContinuation";
+    } else {
+      OS << "withCheckedContinuation";
+    }
+    OS << " " << tok::l_brace << " cont " << tok::kw_in << "\n";
+
+    // fnWithHandler(args...) { ... }
+    auto ClosureStr = getAsyncWrapperCompletionClosure("cont", TopHandler);
+    addForwardingCallTo(FD, TopHandler, /*HandlerReplacement*/ ClosureStr);
+
+    OS << tok::r_brace << "\n"; // end continuation closure
+    OS << tok::r_brace << "\n"; // end function body
+    return true;
+  }
+
   void replace(ASTNode Node, SourceEditConsumer &EditConsumer,
                SourceLoc StartOverride = SourceLoc()) {
     SourceRange Range = Node.getSourceRange();
@@ -5454,6 +5496,116 @@ private:
     OS << tok::r_paren;
   }
 
+  /// Retrieve the completion handler closure argument for an async wrapper
+  /// function.
+  std::string
+  getAsyncWrapperCompletionClosure(StringRef ContName,
+                                   const AsyncHandlerParamDesc &HandlerDesc) {
+    std::string OutputStr;
+    llvm::raw_string_ostream OS(OutputStr);
+
+    OS << " " << tok::l_brace; // start closure
+
+    // Prepare parameter names for the closure.
+    auto SuccessParams = HandlerDesc.getSuccessParams();
+    SmallVector<SmallString<4>, 2> SuccessParamNames;
+    for (auto idx : indices(SuccessParams)) {
+      SuccessParamNames.emplace_back("res");
+
+      // If we have multiple success params, number them e.g res1, res2...
+      if (SuccessParams.size() > 1)
+        SuccessParamNames.back().append(std::to_string(idx + 1));
+    }
+    Optional<SmallString<4>> ErrName;
+    if (HandlerDesc.getErrorParam())
+      ErrName.emplace("err");
+
+    auto HasAnyParams = !SuccessParamNames.empty() || ErrName;
+    if (HasAnyParams)
+      OS << " ";
+
+    // res1, res2
+    llvm::interleave(
+        SuccessParamNames, [&](auto Name) { OS << Name; },
+        [&]() { OS << tok::comma << " "; });
+
+    // , err
+    if (ErrName) {
+      if (!SuccessParamNames.empty())
+        OS << tok::comma << " ";
+
+      OS << *ErrName;
+    }
+    if (HasAnyParams)
+      OS << " " << tok::kw_in;
+
+    OS << "\n";
+
+    // The closure body.
+    switch (HandlerDesc.Type) {
+    case HandlerType::PARAMS: {
+      // For a (Success?, Error?) -> Void handler, we do an if let on the error.
+      if (ErrName) {
+        // if let err = err {
+        OS << tok::kw_if << " " << tok::kw_let << " ";
+        OS << *ErrName << " " << tok::equal << " " << *ErrName << " ";
+        OS << tok::l_brace << "\n";
+
+        // cont.resume(throwing: err)
+        OS << ContName << tok::period << "resume" << tok::l_paren;
+        OS << "throwing" << tok::colon << " " << *ErrName;
+        OS << tok::r_paren << "\n";
+
+        // return }
+        OS << tok::kw_return << "\n";
+        OS << tok::r_brace << "\n";
+      }
+
+      // If we have any success params that we need to unwrap, insert a guard.
+      for (auto Idx : indices(SuccessParamNames)) {
+        auto &Name = SuccessParamNames[Idx];
+        auto ParamTy = SuccessParams[Idx].getParameterType();
+        if (!HandlerDesc.shouldUnwrap(ParamTy))
+          continue;
+
+        // guard let res = res else {
+        OS << tok::kw_guard << " " << tok::kw_let << " ";
+        OS << Name << " " << tok::equal << " " << Name << " " << tok::kw_else;
+        OS << " " << tok::l_brace << "\n";
+
+        // fatalError(...)
+        OS << "fatalError" << tok::l_paren;
+        OS << "\"Expected non-nil success param '" << Name;
+        OS << "' for nil error\"";
+        OS << tok::r_paren << "\n";
+
+        // End guard.
+        OS << tok::r_brace << "\n";
+      }
+
+      // cont.resume(returning: (res1, res2, ...))
+      OS << ContName << tok::period << "resume" << tok::l_paren;
+      OS << "returning" << tok::colon << " ";
+      addTupleOf(llvm::makeArrayRef(SuccessParamNames), OS,
+                 [&](auto Ref) { OS << Ref; });
+      OS << tok::r_paren << "\n";
+      break;
+    }
+    case HandlerType::RESULT: {
+      // cont.resume(with: res)
+      assert(SuccessParamNames.size() == 1);
+      OS << ContName << tok::period << "resume" << tok::l_paren;
+      OS << "with" << tok::colon << " " << SuccessParamNames[0];
+      OS << tok::r_paren << "\n";
+      break;
+    }
+    case HandlerType::INVALID:
+      llvm_unreachable("Should not have an invalid handler here");
+    }
+
+    OS << tok::r_brace << "\n"; // end closure
+    return OutputStr;
+  }
 
   /// Retrieves the location for the start of a comment attached to the token
   /// at the provided location, or the location itself if there is no comment.
@@ -6480,6 +6632,24 @@ private:
   }
 };
 
+/// Adds an attribute to describe a completion handler function's async
+/// alternative if necessary.
+void addCompletionHandlerAsyncAttrIfNeccessary(
+    ASTContext &Ctx, const FuncDecl *FD,
+    const AsyncHandlerParamDesc &HandlerDesc,
+    SourceEditConsumer &EditConsumer) {
+  if (!Ctx.LangOpts.EnableExperimentalConcurrency)
+    return;
+
+  llvm::SmallString<0> HandlerAttribute;
+  llvm::raw_svector_ostream OS(HandlerAttribute);
+  OS << "@completionHandlerAsync(\"";
+  HandlerDesc.printAsyncFunctionName(OS);
+  OS << "\", completionHandlerIndex: " << HandlerDesc.Index << ")\n";
+  EditConsumer.accept(Ctx.SourceMgr, FD->getAttributeInsertionLoc(false),
+                      HandlerAttribute);
+}
+
 } // namespace asyncrefactorings
 
 bool RefactoringActionConvertCallToAsyncAlternative::isApplicable(
@@ -6601,16 +6771,7 @@ bool RefactoringActionAddAsyncAlternative::performChange() {
                       "@available(*, deprecated, message: \"Prefer async "
                       "alternative instead\")\n");
 
-  if (Ctx.LangOpts.EnableExperimentalConcurrency) {
-    // Add an attribute to describe its async alternative
-    llvm::SmallString<0> HandlerAttribute;
-    llvm::raw_svector_ostream OS(HandlerAttribute);
-    OS << "@completionHandlerAsync(\"";
-    HandlerDesc.printAsyncFunctionName(OS);
-    OS << "\", completionHandlerIndex: " << HandlerDesc.Index << ")\n";
-    EditConsumer.accept(SM, FD->getAttributeInsertionLoc(false),
-                        HandlerAttribute);
-  }
+  addCompletionHandlerAsyncAttrIfNeccessary(Ctx, FD, HandlerDesc, EditConsumer);
 
   AsyncConverter LegacyBodyCreator(TheFile, SM, DiagEngine, FD, HandlerDesc);
   if (LegacyBodyCreator.createLegacyBody()) {
@@ -6622,6 +6783,43 @@ bool RefactoringActionAddAsyncAlternative::performChange() {
 
   return false;
 }
+
+bool RefactoringActionAddAsyncWrapper::isApplicable(
+    const ResolvedCursorInfo &CursorInfo, DiagnosticEngine &Diag) {
+  using namespace asyncrefactorings;
+
+  auto *FD = findFunction(CursorInfo);
+  if (!FD)
+    return false;
+
+  auto HandlerDesc =
+      AsyncHandlerParamDesc::find(FD, /*RequireAttributeOrName=*/false);
+  return HandlerDesc.isValid();
+}
+
+bool RefactoringActionAddAsyncWrapper::performChange() {
+  using namespace asyncrefactorings;
+
+  auto *FD = findFunction(CursorInfo);
+  assert(FD &&
+         "Should not run performChange when refactoring is not applicable");
+
+  auto HandlerDesc =
+      AsyncHandlerParamDesc::find(FD, /*RequireAttributeOrName=*/false);
+  assert(HandlerDesc.isValid() &&
+         "Should not run performChange when refactoring is not applicable");
+
+  AsyncConverter Converter(TheFile, SM, DiagEngine, FD, HandlerDesc);
+  if (!Converter.createAsyncWrapper())
+    return true;
+
+  addCompletionHandlerAsyncAttrIfNeccessary(Ctx, FD, HandlerDesc, EditConsumer);
+
+  // Add the async wrapper.
+  Converter.insertAfter(FD, EditConsumer);
+  return false;
+}
+
 } // end of anonymous namespace
 
 StringRef swift::ide::

--- a/test/SourceKit/Refactoring/basic.swift
+++ b/test/SourceKit/Refactoring/basic.swift
@@ -248,12 +248,12 @@ func hasCallToAsyncAlternative() {
 // CHECK-ASYNC: ACTIONS END
 
 // CHECK-CALLASYNC: ACTIONS BEGIN
-// CHECK-ASYNC-NOT: source.refactoring.kind.add.async-alternative
-// CHECK-ASYNC-NOT: source.refactoring.kind.convert.func-to-async
+// CHECK-CALLASYNC-NOT: source.refactoring.kind.add.async-alternative
+// CHECK-CALLASYNC-NOT: source.refactoring.kind.convert.func-to-async
 // CHECK-CALLASYNC: source.refactoring.kind.convert.call-to-async
 // CHECK-CALLASYNC-NEXT: Convert Call to Async Alternative
-// CHECK-ASYNC-NOT: source.refactoring.kind.add.async-alternative
-// CHECK-ASYNC-NOT: source.refactoring.kind.convert.func-to-async
+// CHECK-CALLASYNC-NOT: source.refactoring.kind.add.async-alternative
+// CHECK-CALLASYNC-NOT: source.refactoring.kind.convert.func-to-async
 // CHECK-CALLASYNC: ACTIONS END
 
 // REQUIRES: OS=macosx || OS=linux-gnu

--- a/test/SourceKit/Refactoring/basic.swift
+++ b/test/SourceKit/Refactoring/basic.swift
@@ -244,16 +244,20 @@ func hasCallToAsyncAlternative() {
 // CHECK-ASYNC-NEXT: Convert Function to Async
 // CHECK-ASYNC-NEXT: source.refactoring.kind.add.async-alternative
 // CHECK-ASYNC-NEXT: Add Async Alternative
+// CHECK-ASYNC-NEXT: source.refactoring.kind.add.async-wrapper
+// CHECK-ASYNC-NEXT: Add Async Wrapper
 // CHECK-ASYNC-NOT: source.refactoring.kind.convert.call-to-async
 // CHECK-ASYNC: ACTIONS END
 
 // CHECK-CALLASYNC: ACTIONS BEGIN
 // CHECK-CALLASYNC-NOT: source.refactoring.kind.add.async-alternative
 // CHECK-CALLASYNC-NOT: source.refactoring.kind.convert.func-to-async
+// CHECK-CALLASYNC-NOT: source.refactoring.kind.add.async-wrapper
 // CHECK-CALLASYNC: source.refactoring.kind.convert.call-to-async
 // CHECK-CALLASYNC-NEXT: Convert Call to Async Alternative
 // CHECK-CALLASYNC-NOT: source.refactoring.kind.add.async-alternative
 // CHECK-CALLASYNC-NOT: source.refactoring.kind.convert.func-to-async
+// CHECK-CALLASYNC-NOT: source.refactoring.kind.add.async-wrapper
 // CHECK-CALLASYNC: ACTIONS END
 
 // REQUIRES: OS=macosx || OS=linux-gnu

--- a/test/refactoring/ConvertAsync/convert_async_wrapper.swift
+++ b/test/refactoring/ConvertAsync/convert_async_wrapper.swift
@@ -1,0 +1,180 @@
+// RUN: %empty-directory(%t)
+
+enum CustomError : Error {
+  case e
+}
+
+// RUN: %refactor-check-compiles -add-async-wrapper -dump-text -source-filename %s -pos=%(line+1):1 -enable-experimental-concurrency | %FileCheck -check-prefix=FOO1 %s
+func foo1(_ completion: @escaping () -> Void) {}
+// FOO1:      convert_async_wrapper.swift [[# @LINE-1]]:1 -> [[# @LINE-1]]:1
+// FOO1-NEXT: @completionHandlerAsync("foo1()", completionHandlerIndex: 0)
+// FOO1-EMPTY:
+// FOO1-NEXT: convert_async_wrapper.swift [[# @LINE-4]]:49 -> [[# @LINE-4]]:49
+// FOO1-EMPTY:
+// FOO1-EMPTY:
+// FOO1-EMPTY:
+// FOO1-NEXT: convert_async_wrapper.swift [[# @LINE-8]]:49 -> [[# @LINE-8]]:49
+// FOO1-NEXT: func foo1() async {
+// FOO1-NEXT:   return await withCheckedContinuation { cont in
+// FOO1-NEXT:     foo1() {
+// FOO1-NEXT:       cont.resume(returning: ())
+// FOO1-NEXT:     }
+// FOO1-NEXT:   }
+// FOO1-NEXT: }
+
+// RUN: %refactor-check-compiles -add-async-wrapper -dump-text -source-filename %s -pos=%(line+1):1 -enable-experimental-concurrency | %FileCheck -check-prefix=FOO2 %s
+func foo2(arg: String, _ completion: @escaping (String) -> Void) {}
+// FOO2:      convert_async_wrapper.swift [[# @LINE-1]]:1 -> [[# @LINE-1]]:1
+// FOO2-NEXT: @completionHandlerAsync("foo2(arg:)", completionHandlerIndex: 1)
+// FOO2-EMPTY:
+// FOO2-NEXT: convert_async_wrapper.swift [[# @LINE-4]]:68 -> [[# @LINE-4]]:68
+// FOO2-EMPTY:
+// FOO2-EMPTY:
+// FOO2-EMPTY:
+// FOO2-NEXT: convert_async_wrapper.swift [[# @LINE-8]]:68 -> [[# @LINE-8]]:68
+// FOO2:      func foo2(arg: String) async -> String {
+// FOO2-NEXT:   return await withCheckedContinuation { cont in
+// FOO2-NEXT:     foo2(arg: arg) { res in
+// FOO2-NEXT:       cont.resume(returning: res)
+// FOO2-NEXT:     }
+// FOO2-NEXT:   }
+// FOO2-NEXT: }
+
+// RUN: %refactor-check-compiles -add-async-wrapper -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=FOO3 %s
+func foo3(arg: String, _ arg2: Int, _ completion: @escaping (String?) -> Void) {}
+
+// FOO3:      func foo3(arg: String, _ arg2: Int) async -> String? {
+// FOO3-NEXT:   return await withCheckedContinuation { cont in
+// FOO3-NEXT:     foo3(arg: arg, arg2) { res in
+// FOO3-NEXT:       cont.resume(returning: res)
+// FOO3-NEXT:     }
+// FOO3-NEXT:   }
+// FOO3-NEXT: }
+
+// RUN: %refactor-check-compiles -add-async-wrapper -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=FOO4 %s
+func foo4(_ completion: @escaping (Error?) -> Void) {}
+
+// FOO4:      func foo4() async throws {
+// FOO4-NEXT:   return try await withCheckedThrowingContinuation { cont in
+// FOO4-NEXT:     foo4() { err in
+// FOO4-NEXT:       if let err = err {
+// FOO4-NEXT:         cont.resume(throwing: err)
+// FOO4-NEXT:         return
+// FOO4-NEXT:       }
+// FOO4-NEXT:       cont.resume(returning: ())
+// FOO4-NEXT:     }
+// FOO4-NEXT:   }
+// FOO4-NEXT: }
+
+
+// RUN: %refactor-check-compiles -add-async-wrapper -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=FOO5 %s
+func foo5(_ completion: @escaping (Error) -> Void) {}
+
+// FOO5:      func foo5() async -> Error {
+// FOO5-NEXT:   return await withCheckedContinuation { cont in
+// FOO5-NEXT:     foo5() { res in
+// FOO5-NEXT:       cont.resume(returning: res)
+// FOO5-NEXT:     }
+// FOO5-NEXT:   }
+// FOO5-NEXT: }
+
+// RUN: %refactor-check-compiles -add-async-wrapper -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=FOO6 %s
+func foo6(_ completion: @escaping (String?, Error?) -> Void) {}
+
+// FOO6:      func foo6() async throws -> String {
+// FOO6-NEXT:   return try await withCheckedThrowingContinuation { cont in
+// FOO6-NEXT:     foo6() { res, err in
+// FOO6-NEXT:       if let err = err {
+// FOO6-NEXT:         cont.resume(throwing: err)
+// FOO6-NEXT:         return
+// FOO6-NEXT:       }
+// FOO6-NEXT:       guard let res = res else {
+// FOO6-NEXT:         fatalError("Expected non-nil success param 'res' for nil error")
+// FOO6-NEXT:       }
+// FOO6-NEXT:       cont.resume(returning: res)
+// FOO6-NEXT:     }
+// FOO6-NEXT:   }
+// FOO6-NEXT: }
+
+// RUN: %refactor-check-compiles -add-async-wrapper -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=FOO7 %s
+func foo7(_ completion: @escaping (String?, Int, Error?) -> Void) {}
+
+// FOO7:      func foo7() async throws -> (String, Int) {
+// FOO7-NEXT:   return try await withCheckedThrowingContinuation { cont in
+// FOO7-NEXT:     foo7() { res1, res2, err in
+// FOO7-NEXT:       if let err = err {
+// FOO7-NEXT:         cont.resume(throwing: err)
+// FOO7-NEXT:         return
+// FOO7-NEXT:       }
+// FOO7-NEXT:       guard let res1 = res1 else {
+// FOO7-NEXT:         fatalError("Expected non-nil success param 'res1' for nil error")
+// FOO7-NEXT:       }
+// FOO7-NEXT:       cont.resume(returning: (res1, res2))
+// FOO7-NEXT:     }
+// FOO7-NEXT:   }
+// FOO7-NEXT: }
+
+// RUN: %refactor-check-compiles -add-async-wrapper -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=FOO8 %s
+func foo8(_ completion: @escaping (String?, Int?, Error?) -> Void) {}
+
+// FOO8:      func foo8() async throws -> (String, Int) {
+// FOO8-NEXT:   return try await withCheckedThrowingContinuation { cont in
+// FOO8-NEXT:     foo8() { res1, res2, err in
+// FOO8-NEXT:       if let err = err {
+// FOO8-NEXT:         cont.resume(throwing: err)
+// FOO8-NEXT:         return
+// FOO8-NEXT:       }
+// FOO8-NEXT:       guard let res1 = res1 else {
+// FOO8-NEXT:         fatalError("Expected non-nil success param 'res1' for nil error")
+// FOO8-NEXT:       }
+// FOO8-NEXT:       guard let res2 = res2 else {
+// FOO8-NEXT:         fatalError("Expected non-nil success param 'res2' for nil error")
+// FOO8-NEXT:       }
+// FOO8-NEXT:       cont.resume(returning: (res1, res2))
+// FOO8-NEXT:     }
+// FOO8-NEXT:   }
+// FOO8-NEXT: }
+
+// RUN: %refactor-check-compiles -add-async-wrapper -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=FOO9 %s
+func foo9(_ completion: @escaping (Result<String, Error>) -> Void) {}
+
+// FOO9:      func foo9() async throws -> String {
+// FOO9-NEXT:   return try await withCheckedThrowingContinuation { cont in
+// FOO9-NEXT:     foo9() { res in
+// FOO9-NEXT:       cont.resume(with: res)
+// FOO9-NEXT:     }
+// FOO9-NEXT:   }
+// FOO9-NEXT: }
+
+// RUN: %refactor-check-compiles -add-async-wrapper -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=FOO10 %s
+func foo10(arg: Int, _ completion: @escaping (Result<(String, Int), Error>) -> Void) {}
+
+// FOO10:      func foo10(arg: Int) async throws -> (String, Int) {
+// FOO10-NEXT:   return try await withCheckedThrowingContinuation { cont in
+// FOO10-NEXT:     foo10(arg: arg) { res in
+// FOO10-NEXT:       cont.resume(with: res)
+// FOO10-NEXT:     }
+// FOO10-NEXT:   }
+// FOO10-NEXT: }
+
+// RUN: %refactor-check-compiles -add-async-wrapper -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=FOO11 %s
+func foo11(completion: @escaping (Result<String, Never>) -> Void) {}
+
+// FOO11:      func foo11() async -> String {
+// FOO11-NEXT:   return await withCheckedContinuation { cont in
+// FOO11-NEXT:     foo11() { res in
+// FOO11-NEXT:       cont.resume(with: res)
+// FOO11-NEXT:     }
+// FOO11-NEXT:   }
+// FOO11-NEXT: }
+
+// RUN: %refactor-check-compiles -add-async-wrapper -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=FOO12 %s
+func foo12(completion: @escaping (Result<String, CustomError>) -> Void) {}
+
+// FOO12:      func foo12() async throws -> String {
+// FOO12-NEXT:   return try await withCheckedThrowingContinuation { cont in
+// FOO12-NEXT:     foo12() { res in
+// FOO12-NEXT:       cont.resume(with: res)
+// FOO12-NEXT:     }
+// FOO12-NEXT:   }
+// FOO12-NEXT: }

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -82,7 +82,9 @@ Action(llvm::cl::desc("kind:"), llvm::cl::init(RefactoringKind::None),
            clEnumValN(RefactoringKind::ConvertToAsync,
                       "convert-to-async", "Convert the entire function to async"),
            clEnumValN(RefactoringKind::AddAsyncAlternative,
-                      "add-async-alternative", "Add an async alternative of a function taking a callback")));
+                      "add-async-alternative", "Add an async alternative of a function taking a callback"),
+           clEnumValN(RefactoringKind::AddAsyncWrapper,
+                      "add-async-wrapper", "Add an async alternative that forwards onto the function taking a callback")));
 
 
 static llvm::cl::opt<std::string>


### PR DESCRIPTION
*5.5 cherry-pick of https://github.com/apple/swift/pull/37491*

---

This allows an async alternative function to be created that forwards onto the user's completion handler function through the use of `withCheckedContinuation`/`withCheckedThrowingContinuation`.

rdar://77802486