### PR TITLE
[SR-13637] Handling Diagnostic for [unowned self] when in is missing

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2519,9 +2519,6 @@ ParserStatus Parser::parseClosureSignatureIfPresent(
       }
     }
     
-    // Parse the 'in' at the end.
-    if (Tok.isNot(tok::kw_in))
-      return makeParserSuccess();
 
     // Okay, we have a closure signature.
   } else {


### PR DESCRIPTION
<!-- What's in this pull request? -->
```
class X {
    func foo() {
        // error: cannot find 'unowned' in scope
        // error: expected ',' separator
        let fn: () -> Int = { [unowned self] 42 }
        //                     ^~~~~~~
        //                             ^
        //                            ,
    }
}
```
* Above code leads to error.   This is caused due to the removed code, where the parser ignores capture list parsing, if `in` keyword is missing. Hence capture list is treated as closure body. 

* As we have handled missing `in` keyword other places can we remove this check?

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves  https://bugs.swift.org/browse/SR-13637

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
