### PR TITLE
[5.5] Disable async_task_async_let_child_cancel.swift test

### DIFF
--- a/test/Concurrency/Runtime/async_task_async_let_child_cancel.swift
+++ b/test/Concurrency/Runtime/async_task_async_let_child_cancel.swift
@@ -7,6 +7,8 @@
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: use_os_stdlib
 
+// REQUIRES: rdar_77671328
+
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func printWaitPrint(_ int: Int) async -> Int {
   print("start, cancelled:\(Task.isCancelled), id:\(int)")


### PR DESCRIPTION
Cherry-pick #37370 to release/5.5

---

It sometimes fails on bots.

rdar://77671328