### PR TITLE
[5.5] Driver: do not generate a dSYM bundle for static archives

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2223,13 +2223,25 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
     }
     TopLevelActions.push_back(LinkAction);
 
-    if (TC.getTriple().isOSDarwin() &&
-        OI.DebugInfoLevel > IRGenDebugInfoLevel::None) {
-      auto *dSYMAction = C.createAction<GenerateDSYMJobAction>(LinkAction);
-      TopLevelActions.push_back(dSYMAction);
-      if (Args.hasArg(options::OPT_verify_debug_info)) {
-        TopLevelActions.push_back(
-            C.createAction<VerifyDebugInfoJobAction>(dSYMAction));
+    if (TC.getTriple().isOSDarwin()) {
+      switch (OI.LinkAction) {
+      case LinkKind::Executable:
+      case LinkKind::DynamicLibrary:
+        if (OI.DebugInfoLevel > IRGenDebugInfoLevel::None) {
+          auto *dSYMAction = C.createAction<GenerateDSYMJobAction>(LinkAction);
+          TopLevelActions.push_back(dSYMAction);
+          if (Args.hasArg(options::OPT_verify_debug_info)) {
+            TopLevelActions.push_back(
+                C.createAction<VerifyDebugInfoJobAction>(dSYMAction));
+          }
+        }
+        break;
+
+      case LinkKind::None:
+        LLVM_FALLTHROUGH;
+      case LinkKind::StaticLibrary:
+        // Cannot build the DSYM bundle for non-image targets.
+        break;
       }
     }
   } else {

--- a/test/Driver/darwin-static-library-debug.swift
+++ b/test/Driver/darwin-static-library-debug.swift
@@ -1,0 +1,14 @@
+// RUN: %swiftc_driver -driver-print-actions -target x86_64-apple-macosx10.15 -g -emit-library -static -o library.a %s 2>&1 | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-STATIC
+// RUN: %swiftc_driver -driver-print-actions -target x86_64-apple-macosx10.15 -g -emit-library -o library.a %s 2>&1 | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-SHARED
+// RUN: %swiftc_driver -driver-print-actions -target x86_64-apple-macosx10.15 -g -o a.out %s 2>&1 | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-EXEC
+
+// CHECK: 0: input, "{{.*}}darwin-static-library-debug.swift", swift
+// CHECK: 1: compile, {0}, object
+// CHECK: 2: merge-module, {1}, swiftmodule
+// CHECK-STATIC: 3: static-link, {1, 2}, image
+// CHECK-STATIC-NOT: 4: generate-dSYM, {3}, dSYM
+// CHECK-SHARED: 3: link, {1, 2}, image
+// CHECK-SHARED: 4: generate-dSYM, {3}, dSYM
+// CHECK-EXEC: 3: link, {1, 2}, image
+// CHECK-EXEC: 4: generate-dSYM, {3}, dSYM
+


### PR DESCRIPTION
When building a static library with debug information, do not create a
dSYM generation job as it cannot be executed on a non-image target.
This is important for the case where the single invocation is both the
compile and link job.

This was detected in conjunction with @gottesmm.

----

Explanation: When emitting a static library, the driver attempts to run dsymutil on it. dsymutil is not supposed to be run on archives so it fails. As a result, one cannot compile static libraries with debug info at all. This patch just fixes the behavior by checking when adding the dsymutil job if we are emitting a static library and in such a case, do not add the dsymutil job.
Scope: Small. Just ensures that if we are compiling a static library we do not add a dsymutil job in the driver.
Risk: Low.
Testing: Adding a compiler test that validates the behavior.
Issue: rdar://78271443
Reviewer: Xi Ge