### PR TITLE
[cmake] Fix a couple of small issues with building host side tools in Swift.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -519,6 +519,12 @@ function(add_swift_host_library name)
       target_link_options(${name} PRIVATE
         "LINKER:-current_version,${SWIFT_COMPILER_VERSION}")
     endif()
+
+    # For now turn off in swift targets, debug info if we are compiling a static
+    # library.
+    if (ASHL_STATIC)
+      target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:Swift>:-gnone>)
+    endif()
   endif()
 
   add_dependencies(dev ${name})

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -572,6 +572,9 @@ function(add_swift_host_tool executable)
   _add_host_variant_c_compile_link_flags(${executable})
   target_link_directories(${executable} PRIVATE
     ${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR})
+  # Force executables linker language to be CXX so that we do not link using the
+  # host toolchain swiftc.
+  set_target_properties(${executable} PROPERTIES LINKER_LANGUAGE CXX)
   add_dependencies(${executable} ${LLVM_COMMON_DEPENDS})
 
   set_target_properties(${executable} PROPERTIES

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -527,6 +527,11 @@ function(add_swift_host_library name)
     endif()
   endif()
 
+  # If we are compiling in release or release with deb info, compile swift code
+  # with -cross-module-optimization enabled.
+  target_compile_options(${name} PRIVATE
+    $<$<AND:$<COMPILE_LANGUAGE:Swift>,$<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>>:-cross-module-optimization>)
+
   add_dependencies(dev ${name})
   if(NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
     swift_install_in_component(TARGETS ${name}


### PR DESCRIPTION
Specifically:

1. There is currently a bug where swift's driver tries to run dsymutil on static libraries. This is unsupported behavior so dsymutil fails causing the driver to fail. To work around that, we for now put -gnone. I fixed the issue with @compnerd in 5.5. Once we start using "host" compilers based on 5.5 we can get rid of this code.
2. I forced the linker language of executables to always be CXX. Right now there are some issues that @compnerd and I are trying to shake out around using swiftc as the linker for our compiler executables.
3. I added -cross-module-optimization flag to all Swift host files that we compile when we compile with release/relwithdebinfo.