### PR TITLE
tests: un-XFAIL a couple of tests on Windows

### DIFF
--- a/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
@@ -7,8 +7,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// XFAIL: OS=windows-msvc
-
 struct Boom: Error {}
 struct IgnoredBoom: Error {}
 

--- a/test/Concurrency/throwing.swift
+++ b/test/Concurrency/throwing.swift
@@ -2,9 +2,9 @@
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
+
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
-// XFAIL: OS=windows-msvc
 
 import _Concurrency
 import StdlibUnittest


### PR DESCRIPTION
These tests are now passing after frame lowering changes for Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
