### PR TITLE
[5.5-05142021][Parse] Disallow use of `actor` as a declaration modifier

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -270,8 +270,7 @@ bool IsActorRequest::evaluate(
   if (!classDecl)
     return false;
 
-  return classDecl->isExplicitActor() ||
-      classDecl->getAttrs().getAttribute<ActorAttr>();
+  return classDecl->isExplicitActor();
 }
 
 bool IsDefaultActorRequest::evaluate(

--- a/test/ModuleInterface/actor_protocol.swift
+++ b/test/ModuleInterface/actor_protocol.swift
@@ -27,10 +27,6 @@ public actor ExplicitActorClass : Actor {
 @available(SwiftStdlib 5.5, *)
 public actor EmptyActor {}
 
-// CHECK: actor public class EmptyActorClass {
-@available(SwiftStdlib 5.5, *)
-public actor class EmptyActorClass {}
-
 // CHECK: public protocol Cat : _Concurrency.Actor {
 @available(SwiftStdlib 5.5, *)
 public protocol Cat : Actor {

--- a/test/SourceKit/CursorInfo/cursor_info_concurrency.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_concurrency.swift
@@ -7,14 +7,6 @@ func test(act: MyActor) async throws {
     try await act.asyncFunc {}
 }
 
-public actor class MyActorClass {
-  public func asyncFunc(fn: () async -> Void) async throws {}
-}
-
-func test(act: MyActorClass) async throws {
-    try await act.asyncFunc {}
-}
-
 // BEGIN App.swift
 import MyModule
 
@@ -35,14 +27,8 @@ func test(act: MyActor) async throws {
 // RUN: %sourcekitd-test -req=cursor -pos=5:16 %t/MyModule.swift -- %t/MyModule.swift -target %target-triple -Xfrontend -enable-experimental-concurrency | %FileCheck -check-prefix=ACTOR %s
 // RUN: %sourcekitd-test -req=cursor -pos=6:19  %t/MyModule.swift -- %t/MyModule.swift -target %target-triple -Xfrontend -enable-experimental-concurrency | %FileCheck -check-prefix=FUNC %s
 
-// RUN: %sourcekitd-test -req=cursor -pos=9:20  %t/MyModule.swift -- %t/MyModule.swift -target %target-triple -Xfrontend -enable-experimental-concurrency | %FileCheck -check-prefix=CLASSACTOR %s
-// RUN: %sourcekitd-test -req=cursor -pos=13:16  %t/MyModule.swift -- %t/MyModule.swift -target %target-triple -Xfrontend -enable-experimental-concurrency | %FileCheck -check-prefix=CLASSACTOR %s
-
 // ACTOR: <Declaration>public actor MyActor</Declaration>
 // ACTOR: <decl.class><syntaxtype.keyword>public</syntaxtype.keyword> <syntaxtype.keyword>actor</syntaxtype.keyword> <decl.name>MyActor</decl.name></decl.class>
-
-// CLASSACTOR: <Declaration>public actor class MyActorClass</Declaration>
-// CLASSACTOR: <decl.class><syntaxtype.keyword>public</syntaxtype.keyword> <syntaxtype.keyword>actor</syntaxtype.keyword> <syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>MyActorClass</decl.name></decl.class>
 
 // FUNC: <Declaration>public func asyncFunc(fn: () async -&gt; <Type usr="s:s4Voida">Void</Type>) async throws</Declaration>
 // FUNC: <decl.function.method.instance><syntaxtype.keyword>public</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>asyncFunc</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>fn</decl.var.parameter.argument_label>: <decl.var.parameter.type>() <syntaxtype.keyword>async</syntaxtype.keyword> -&gt; <decl.function.returntype><ref.typealias usr="s:s4Voida">Void</ref.typealias></decl.function.returntype></decl.var.parameter.type></decl.var.parameter>) <syntaxtype.keyword>async</syntaxtype.keyword> <syntaxtype.keyword>throws</syntaxtype.keyword></decl.function.method.instance>

--- a/test/attr/attr_objc_async.swift
+++ b/test/attr/attr_objc_async.swift
@@ -47,13 +47,11 @@ actor MyActor {
   @objc nonisolated func synchronousGood() { }
 }
 
-// CHECK: actor class MyActor2
 actor class MyActor2 { }
-// expected-warning@-1{{'actor class' has been renamed to 'actor'}}{{7-13=}}
+// expected-error@-1 {{keyword 'class' cannot be used as an identifier here}}
 
 // CHECK: @objc actor MyObjCActor
 @objc actor MyObjCActor: NSObject { }
 
-// CHECK: @objc actor class MyObjCActor2
 @objc actor class MyObjCActor2: NSObject {}
-// expected-warning@-1{{'actor class' has been renamed to 'actor'}}{{13-19=}}
+// expected-error@-1 {{keyword 'class' cannot be used as an identifier here}}

--- a/test/decl/class/actor/basic.swift
+++ b/test/decl/class/actor/basic.swift
@@ -9,20 +9,18 @@ class MyActorSubclass1: MyActor { } // expected-error{{actor types do not suppor
 
 actor MyActorSubclass2: MyActor { } // expected-error{{actor types do not support inheritance}}
 
-// expected-warning@+1{{'actor class' has been renamed to 'actor'}}{{7-13=}}
+// expected-error@+1{{keyword 'class' cannot be used as an identifier here}}
 actor class MyActorClass { }
 
 class NonActor { }
 
 actor NonActorSubclass : NonActor { } // expected-error{{actor types do not support inheritance}}
 
-// expected-warning@+1{{'actor class' has been renamed to 'actor'}}{{14-20=}}
+// expected-error@+1{{keyword 'class' cannot be used as an identifier here}}
 public actor class BobHope {}
-// expected-warning@+1{{'actor class' has been renamed to 'actor'}}{{14-19=actor}}{{1-7=}}
+// expected-error@+1{{keyword 'public' cannot be used as an identifier here}}
 actor public class BarbraStreisand {}
-// expected-warning@+2{{'actor class' has been renamed to 'actor'}}{{14-21=}}
-// expected-error@+1{{'actor' may only be used on 'class' declarations}}
+// expected-error@+1{{keyword 'struct' cannot be used as an identifier here}}
 public actor struct JulieAndrews {}
-// expected-warning@+2{{'actor class' has been renamed to 'actor'}}{{14-18=actor}}{{1-7=}}
-// expected-error@+1{{'actor' may only be used on 'class' declarations}}
+// expected-error@+1{{keyword 'public' cannot be used as an identifier here}}
 actor public enum TomHanks {}


### PR DESCRIPTION
Cherry-pick of (main) https://github.com/apple/swift/pull/37516, (5.5) https://github.com/apple/swift/pull/37550

---

- Explanation:

Promote a warning into an error for declarations that use `actor class` syntax,
since `actor` is now a standalone contextual keyword and cannot be used as
a class declaration modifier.

- Scope: Declarations that still use `actor class` syntax regardless of warnings that it has been deprecated.

- Main Branch PR: https://github.com/apple/swift/pull/37516

- 5.5 Branch PR: https://github.com/apple/swift/pull/37550

- Resolves: rdar://75753598

- Risk: Low

- Reviewed By: @etcwilde 

- Testing: Regression tests added to the suite

Resolves: rdar://75753598
(cherry picked from commit aeddab4)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
