### PR TITLE
[NFC] Cleanup uncovered async diagnostic inserts

### DIFF
--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -2651,15 +2651,10 @@ private:
         Expr *expr = E.dyn_cast<Expr*>();
         Expr *anchor = walkToAnchor(expr, parentMap,
                                     CurContext.isWithinInterpolatedString());
-
-        auto key = uncoveredAsync.find(anchor);
-        if (key == uncoveredAsync.end()) {
-          uncoveredAsync.insert({anchor, {}});
+        if (uncoveredAsync.find(anchor) == uncoveredAsync.end())
           errorOrder.push_back(anchor);
-        }
-        uncoveredAsync[anchor].emplace_back(
-            *expr,
-            classification.getAsyncReason());
+        uncoveredAsync[anchor].emplace_back(*expr,
+                                            classification.getAsyncReason());
       }
     }
 


### PR DESCRIPTION
All of the work to insert can be done much more easily with just the
subscript operator. The densemap subscript will automatically initialize
an element at the key if it hasn't already been created. This way we
don't need to insert the empty vector at the anchor before emplacing it,
we can jump straight to grabbing the vector and doing the insertion.

This was the main part that I disliked, so this largely eliminates my motives for introducing the diagnostic collecting mechanism in https://github.com/apple/swift/pull/37294.