### PR TITLE
[Serialization] Skip MissingMembers when allowing errors

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1631,6 +1631,8 @@ static bool shouldSerializeMember(Decl *D) {
     llvm_unreachable("decl should never be a member");
 
   case DeclKind::MissingMember:
+    if (D->getASTContext().LangOpts.AllowModuleWithCompilerErrors)
+      return false;
     llvm_unreachable("should never need to reserialize a member placeholder");
 
   case DeclKind::IfConfig:

--- a/test/Serialization/AllowErrors/invalid-xref.swift
+++ b/test/Serialization/AllowErrors/invalid-xref.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/mods)
+
+// RUN: touch %t/empty.swift
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// We're going to swap A and B around to cause an invalid xref
+// RUN: %target-swift-frontend -emit-module -o %t/mods/A.swiftmodule -module-name A %t/lib.swift
+// RUN: %target-swift-frontend -emit-module -o %t/mods/B.swiftmodule -module-name B %t/empty.swift
+
+// Compile using SomeType from A
+// RUN: %target-swift-frontend -module-name errors -emit-module -o %t/mods/errorsmain.partial.swiftmodule -I %t/mods %t/errors.swift
+// Empty module so we can do a merge modules step
+// RUN: %target-swift-frontend -module-name errors -emit-module -o %t/mods/errorsempty.partial.swiftmodule %t/empty.swift
+
+// Swap A and B
+// RUN: %target-swift-frontend -emit-module -o %t/mods/A.swiftmodule -module-name A %t/empty.swift
+// RUN: %target-swift-frontend -emit-module -o %t/mods/B.swiftmodule -module-name B %t/lib.swift
+
+// RUN: %target-swift-frontend -module-name errors -emit-module -o %t/mods/errors.swiftmodule -experimental-allow-module-with-compiler-errors %t/mods/errorsmain.partial.swiftmodule %t/mods/errorsempty.partial.swiftmodule
+
+// Expect this to crash without allowing errors (we should never get into a
+// situation where merge modules is run with MissingMemberDecls)
+// RUN: not --crash %target-swift-frontend -module-name errors -emit-module -o %t/mods/errors.swiftmodule %t/mods/errorsmain.partial.swiftmodule %t/mods/errorsempty.partial.swiftmodule
+
+// BEGIN lib.swift
+public struct SomeType {
+    public init() {}
+}
+
+
+// BEGIN errors.swift
+import A
+import B
+
+public class SomeClass {
+  public let member: SomeType
+  public init(member: SomeType) {
+    self.member = member
+  }
+}


### PR DESCRIPTION
A normal compilation would error before merging modules when there are
MissingMemberDecls, so the missing member case is unreachable. That's
not true when allowing errors though, where we continue regardless. Skip
the missing member instead of crashing.

Resolves rdar://76365694.