### PR TITLE
[Distributed] actor class is now banned, remove distributed actor class tests

### DIFF
--- a/test/Distributed/distributed_actor_is_experimental.swift
+++ b/test/Distributed/distributed_actor_is_experimental.swift
@@ -6,9 +6,6 @@ actor SomeActor {}
 
 distributed actor DA {} // expected-error{{'_Distributed' module not imported, required for 'distributed actor'}}
 // expected-error@-1{{class 'DA' has no initializers}}
-distributed actor class DAC {} // expected-error{{'_Distributed' module not imported, required for 'distributed actor'}}
-// expected-error@-1{{class 'DAC' has no initializers}}
-// expected-warning@-2{{'actor class' has been renamed to 'actor'}}
 
 actor A {
   func normal() async {}

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -24,16 +24,6 @@ distributed class ClassNope {} // expected-error{{'distributed' can only be appl
 distributed enum EnumNope {} // expected-error{{distributed' modifier cannot be applied to this declaration}}
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-distributed actor class DistributedActor_0 { // expected-warning{{'actor class' has been renamed to 'actor'}}
-  distributed func okey() {}
-}
-
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-extension DistributedActor_0 {
-  static func _remote_okey(actor: DistributedActor_0) async throws {}
-}
-
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 distributed actor DistributedActor_1 {
 
   let name: String = "alice" // expected-note{{distributed actor state is only available within the actor instance}}


### PR DESCRIPTION
Due to https://github.com/apple/swift/pull/37516 the distributed tests would fail now when testing `distributed actor class` which is now illegal.