### PR TITLE
[5.5-05142021][SourceKit] Map line and column using the latest snapshot

### DIFF
--- a/test/SourceKit/CursorInfo/cursor_after_edit.swift
+++ b/test/SourceKit/CursorInfo/cursor_after_edit.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+
+// RUN: touch %t/empty.swift
+// RUN: echo "func foo() {}" >> %t/func.swift
+
+// Edit previously did not update the syntax info. Cursor info was using its
+// buffer to calculate line and column (before rdar://78161348).
+// RUN: %sourcekitd-test \
+// RUN:   -req=open -text-input %t/empty.swift %t/func.swift -- %t/func.swift == \
+// RUN:   -req=edit -offset=0 -length=0 -replace="func foo() {}" -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/func.swift -- %t/func.swift == \
+// RUN:   -req=cursor -offset=5 %t/func.swift -- %t/func.swift

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -2300,17 +2300,6 @@ ImmutableTextSnapshotRef SwiftEditorDocument::getLatestSnapshot() const {
   return Impl.EditableBuffer->getSnapshot();
 }
 
-std::pair<unsigned, unsigned>
-SwiftEditorDocument::getLineAndColumnInBuffer(unsigned Offset) {
-  llvm::sys::ScopedLock L(Impl.AccessMtx);
-
-  auto SyntaxInfo = Impl.getSyntaxInfo();
-  auto &SM = SyntaxInfo->getSourceManager();
-
-  auto Loc = SM.getLocForOffset(SyntaxInfo->getBufferID(), Offset);
-  return SM.getLineAndColumnInBuffer(Loc);
-}
-
 void SwiftEditorDocument::reportDocumentStructure(SourceFile &SrcFile,
                                                   EditorConsumer &Consumer) {
   ide::SyntaxModelContext ModelContext(SrcFile);

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -105,7 +105,6 @@ public:
   void removeCachedAST();
 
   ImmutableTextSnapshotRef getLatestSnapshot() const;
-  std::pair<unsigned, unsigned> getLineAndColumnInBuffer(unsigned Offset);
 
   void resetSyntaxInfo(ImmutableTextSnapshotRef Snapshot,
                        SwiftLangSupport &Lang, bool BuildSyntaxTree,

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -639,7 +639,7 @@ static void mapLocToLatestSnapshot(
   }
 
   std::tie(Location.Line, Location.Column) =
-      EditorDoc->getLineAndColumnInBuffer(Location.Offset);
+      LatestSnap->getBuffer()->getLineAndColumn(Location.Offset);
 }
 
 


### PR DESCRIPTION
Cherry-picks https://github.com/apple/swift/pull/37547

-----

CCC Nomination

Explanation: Cursor info (ie. "Go to Definition") can currently crash when there's a mismatch between the buffer stored in SourceKit's syntax info and the snapshots added while editing. This can cause a mapped offset to be greater than the buffer size, causing a crash. Rather than using the syntax info buffer to map the line/column, use the snapshot instead.  

Scope: SourceKit Cursor Info ("Go to Definition")

Radar/SR Issue: rdar://78161348

Risk: Low. This change only affects SourceKit.

Testing: Added a test case to check that the cursor info request handles the above situation. Also manually tested to check the crash no longer occurs with these changes.