### PR TITLE
[CodeComplete] Add test case for completing in `inout` arguments

### DIFF
--- a/test/IDE/complete_inout.swift
+++ b/test/IDE/complete_inout.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+struct Bar() {
+    init?(withInout: inout Int) {}
+    init?(withPointer: UnsafePointer<Int>) {}
+}
+
+struct Foo {
+    var myInt: Int
+
+    func bar() {
+        let context = Bar(wihtInout: &self.#^COMPLETE_INOUT?check=CHECK^#)
+        let context = Bar(withPointer: &self.#^COMPLETE_POINTER?check=CHECK^#)
+    }
+}
+
+// CHECK: Decl[InstanceVar]/CurrNominal:      myInt[#Int#]; name=myInt


### PR DESCRIPTION
This captures a crash found in rdar://74786497 that no longer occurs in `main`.