### PR TITLE
[5.5-05142021][CodeComplete] Fix crash when completing inside a result builder containing a variable initialized with `nil`

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4733,6 +4733,9 @@ bool constraints::isStandardComparisonOperator(ASTNode node) {
 Optional<std::pair<Expr *, unsigned>>
 ConstraintSystem::isArgumentExpr(Expr *expr) {
   auto *argList = getParentExpr(expr);
+  if (!argList) {
+    return None;
+  }
 
   if (isa<ParenExpr>(argList)) {
     for (;;) {

--- a/validation-test/IDE/crashers_2_fixed/rdar78017503.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar78017503.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=COMPLETE -source-filename=%s
+
+@resultBuilder
+struct TupleBuilder<T> {
+  static func buildBlock() -> () { }
+}
+
+func testPatternMatching() {
+  @TupleBuilder<String> var x3 {
+    let x: Int? = nil
+    #^COMPLETE^#
+  }
+}


### PR DESCRIPTION
* **Explanation**: Code completion currently crashes when completing inside a result builder that contains a variable initialized by the `nil` literal. Add a `nullptr` check to prevent the crash.
* **Scope**: Type checking
* **Risk**: Low (only affects code paths that were previously crashing)
* **Testing**: Added a test to the validation suite
* **Issue**: rdar://78017503
* **Reviewer**: @xedin (of original PR https://github.com/apple/swift/pull/37421)