### PR TITLE
[build-script] Make lib_InternalSwiftSyntaxParser.dylib fat

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3350,7 +3350,7 @@ if [[ ${#LIPO_SRC_DIRS[@]} -gt 0 ]]; then
         else
             LIPO_PATH="${HOST_LIPO}"
         fi
-        call "${SWIFT_SOURCE_DIR}"/utils/recursive-lipo --lipo=${LIPO_PATH} --copy-subdirs="$(get_host_install_prefix ${host})lib/swift $(get_host_install_prefix ${host})lib/swift_static" --explicit-src-files="$(get_host_install_prefix ${host})lib/swift/${host%%-*}/lib_InternalSwiftScan.dylib" --destination="$(get_host_install_destdir ${mergedHost})" ${LIPO_SRC_DIRS[@]}
+        call "${SWIFT_SOURCE_DIR}"/utils/recursive-lipo --lipo=${LIPO_PATH} --copy-subdirs="$(get_host_install_prefix ${host})lib/swift $(get_host_install_prefix ${host})lib/swift_static" --explicit-src-files="$(get_host_install_prefix ${host})lib/swift/${host%%-*}/lib_InternalSwiftScan.dylib $(get_host_install_prefix ${host})lib/swift/${host%%-*}/lib_InternalSwiftSyntaxParser.dylib" --destination="$(get_host_install_destdir ${mergedHost})" ${LIPO_SRC_DIRS[@]}
 
         if [[ $(should_execute_action "${mergedHost}-lipo") ]]; then
             # Build and test the lipo-ed package.


### PR DESCRIPTION
Run `recursive-lipo` on `lib_InternalSwiftSyntaxParser.dylib` to make it a fat dylib that contains slices for all platforms.

`recursive-lipo` only installed a fat dylib if `parser-lib` is in `swift-install-components`. Otherwise it ignores `lib_InternalSwiftSyntaxParser.dylib`.

Resolves rdar://78039407