### PR TITLE
[5.5][SourceKit] Allow same filename

### DIFF
--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -201,6 +201,10 @@ private:
   /// Indicates whether the driver should check that the input files exist.
   bool CheckInputFilesExist = true;
 
+  /// Indicates whether the driver should suppress the "same filename used
+  /// twice" error.
+  bool SuppressSameFileNameError = false;
+
   /// Indicates that this driver never actually executes any commands but is
   /// just set up to retrieve the swift-frontend invocation that would be
   /// executed during compilation.
@@ -231,6 +235,8 @@ public:
   bool getCheckInputFilesExist() const { return CheckInputFilesExist; }
 
   void setCheckInputFilesExist(bool Value) { CheckInputFilesExist = Value; }
+
+  void setSuppressSameFileNameError(bool Value) { SuppressSameFileNameError = Value; }
 
   bool isDummyDriverForFrontendInvocation() const {
     return IsDummyDriverForFrontendInvocation;

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1315,9 +1315,11 @@ void Driver::buildInputs(const ToolChain &TC,
       if (Ty == file_types::TY_Swift) {
         StringRef Basename = llvm::sys::path::filename(Value);
         if (!SourceFileNames.insert({Basename, Value}).second) {
-          Diags.diagnose(SourceLoc(), diag::error_two_files_same_name,
-                         Basename, SourceFileNames[Basename], Value);
-          Diags.diagnose(SourceLoc(), diag::note_explain_two_files_same_name);
+          if (!SuppressSameFileNameError) {
+            Diags.diagnose(SourceLoc(), diag::error_two_files_same_name,
+                           Basename, SourceFileNames[Basename], Value);
+            Diags.diagnose(SourceLoc(), diag::note_explain_two_files_same_name);
+          }
         }
       }
     }

--- a/lib/Driver/FrontendUtil.cpp
+++ b/lib/Driver/FrontendUtil.cpp
@@ -100,6 +100,7 @@ bool swift::driver::getSingleFrontendInvocationFromDriverArguments(
   if (Diags.hadAnyError())
     return true;
 
+  TheDriver.setSuppressSameFileNameError(true);
   std::unique_ptr<Compilation> C =
       TheDriver.buildCompilation(*TC, std::move(ArgList));
   if (!C || C->getJobs().empty())

--- a/test/Frontend/Inputs/same_filename/A/File.swift
+++ b/test/Frontend/Inputs/same_filename/A/File.swift
@@ -1,0 +1,1 @@
+class Foo {}

--- a/test/Frontend/Inputs/same_filename/B/File.swift
+++ b/test/Frontend/Inputs/same_filename/B/File.swift
@@ -1,0 +1,1 @@
+class Bar {}

--- a/test/Frontend/same_filename_twice.swift
+++ b/test/Frontend/same_filename_twice.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+
+// A module should fail to be generated if the same filename is used twice and '-experimental-allow-module-with-compiler-errors' is not passed
+
+// RUN: not %target-swift-frontend -emit-module -o %t/no_allow_compiler_errors.swiftmodule %S/Inputs/same_filename/A/File.swift %S/Inputs/same_filename/B/File.swift
+// RUN: not ls %t/no_allow_compiler_errors.swiftmodule
+
+// If '-experimental-allow-module-with-compiler-errors' is passed, we should throw an error but still generate a module
+
+// RUN: %target-swift-frontend -emit-module -experimental-allow-module-with-compiler-errors -o %t/allow_compiler_errors.swiftmodule %S/Inputs/same_filename/A/File.swift %S/Inputs/same_filename/B/File.swift 2>&1 | %FileCheck %s
+// RUN: ls %t/allow_compiler_errors.swiftmodule
+
+// CHECK: filename "File.swift" used twice:

--- a/test/SourceKit/CursorInfo/Inputs/invalid_compiler_args/A/File.swift
+++ b/test/SourceKit/CursorInfo/Inputs/invalid_compiler_args/A/File.swift
@@ -1,0 +1,1 @@
+class Foo {}

--- a/test/SourceKit/CursorInfo/Inputs/invalid_compiler_args/B/File.swift
+++ b/test/SourceKit/CursorInfo/Inputs/invalid_compiler_args/B/File.swift
@@ -1,0 +1,1 @@
+class Bar {}

--- a/test/SourceKit/CursorInfo/invalid_compiler_args.swift
+++ b/test/SourceKit/CursorInfo/invalid_compiler_args.swift
@@ -1,0 +1,12 @@
+// We should not fail if two distinct file have the same name - this is only an issue in CodeGen
+// RUN: %sourcekitd-test -req=cursor -pos=1:7 %S/Inputs/invalid_compiler_args/A/File.swift -- %S/Inputs/invalid_compiler_args/A/File.swift %S/Inputs/invalid_compiler_args/B/File.swift | %FileCheck %s
+
+// We can't do anything if the requested file is not in the compiler arguments
+// RUN: not %sourcekitd-test -req=cursor -pos=1:7 %S/Inputs/invalid_compiler_args/A/File.swift --
+// RUN: not %sourcekitd-test -req=cursor -pos=1:7 %S/Inputs/invalid_compiler_args/A/File.swift -- %S/Inputs/invalid_compiler_args/B/File.swift
+
+// Specifying a file twice should just ignore one of them
+// RUN: %sourcekitd-test -req=cursor -pos=1:7 %S/Inputs/invalid_compiler_args/A/File.swift -- %S/Inputs/invalid_compiler_args/A/File.swift %S/Inputs/invalid_compiler_args/A/File.swift
+
+
+// CHECK: source.lang.swift.decl.class


### PR DESCRIPTION
When compiling a module, we can’t have two files with the same filename because the filename is used to disambiguate private declarations during CodeGen. For SourceKit this is not an issue and we shouldn’t stop providing semantic functionality because of it.

This is a more targeted version of https://github.com/apple/swift/pull/37512 (merged into `main`), ignoring just the same-filename-used-twice-error, whereas https://github.com/apple/swift/pull/37512 ignores all errors generated by the driver.

Fixes rdar://77618144