### PR TITLE
[Build] Allow to specify a subset of CMake targets for which to enable LTO

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -121,6 +121,10 @@ function(_add_host_variant_c_compile_link_flags name)
       "-F${SWIFT_SDK_${SWIFT_HOST_VARIANT_ARCH}_PATH}/../../../Developer/Library/Frameworks")
   endif()
 
+  add_lto_flags(${name})
+endfunction()
+
+function(add_lto_flags name)
   _compute_lto_flag("${SWIFT_TOOLS_ENABLE_LTO}" _lto_flag_out)
   if (_lto_flag_out)
     target_compile_options(${name} PRIVATE ${_lto_flag_out})

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -129,6 +129,12 @@ function(add_lto_flags name)
   if (_lto_flag_out)
     target_compile_options(${name} PRIVATE ${_lto_flag_out})
     target_link_options(${name} PRIVATE ${_lto_flag_out})
+
+    if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_APPLE_PLATFORMS AND
+        SWIFT_TOOLS_DARWIN_ENABLE_LTO_ONLY_FOR_TARGETS AND
+        NOT name IN_LIST SWIFT_TOOLS_DARWIN_ENABLE_LTO_ONLY_FOR_TARGETS)
+        target_link_options(${name} PRIVATE "LINKER:-flto-codegen-only")
+    endif()
   endif()
 endfunction()
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -214,6 +214,11 @@ swift_obj_root = getattr(config, 'swift_obj_root', None)
 assert(config.cmake)
 config.substitutions.append( ('%cmake',  config.cmake) )
 lit_config.note('Using cmake: ' + config.cmake)
+assert(config.cmake_generator)
+config.substitutions.append( (
+    '%{cmake-generate}',
+    '{0} -DCMAKE_GENERATOR={1} -DCMAKE_MAKE_PROGRAM={2}'.format(
+        config.cmake, config.cmake_generator, config.cmake_make_program) ) )
 
 # Set llvm_{src,obj}_root for use by others.
 config.llvm_src_root = getattr(config, 'llvm_src_root', None)

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -15,6 +15,8 @@ import platform
 import sys
 
 config.cmake = "@CMAKE_COMMAND@"
+config.cmake_make_program = "@CMAKE_MAKE_PROGRAM@"
+config.cmake_generator = "@CMAKE_GENERATOR@"
 config.llvm_src_root = "@LLVM_MAIN_SRC_DIR@"
 config.llvm_obj_root = "@LLVM_BINARY_DIR@"
 config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"

--- a/utils/build-script
+++ b/utils/build-script
@@ -510,6 +510,8 @@ class BuildScriptInvocation(object):
             "--build-args=%s" % ' '.join(
                 pipes.quote(arg) for arg in cmake.build_args()),
             "--dsymutil-jobs", str(args.dsymutil_jobs),
+            "--darwin-enable-lto-only-for-cmake-targets=%s" % (
+                str(args.darwin_enable_lto_only_for_cmake_targets)),
         ]
 
         # Compute any product specific cmake arguments.

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -118,6 +118,7 @@ KNOWN_SETTINGS=(
     darwin-toolchain-version                      ""                "Version for xctoolchain info plist and installer pkg"
     darwin-toolchain-require-use-os-runtime       "0"               "When setting up a plist for a toolchain, require the users of the toolchain to link against the OS instead of the packaged toolchain runtime. 0 for false, 1 for true"
     darwin-xcrun-toolchain                        "default"         "the name of the toolchain to use on Darwin"
+    darwin-enable-lto-only-for-cmake-targets       ""               "Swift CMake targets for which to enable LTO (Darwin only)"
 
     ## Build Types for Components
     swift-stdlib-build-type                       "Debug"           "the CMake build variant for Swift"
@@ -1940,6 +1941,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DSWIFT_TOOLS_ENABLE_LTO:STRING="${SWIFT_TOOLS_ENABLE_LTO}"
                     -DSWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER:BOOL=$(true_false "${BUILD_RUNTIME_WITH_HOST_COMPILER}")
                     -DLIBDISPATCH_CMAKE_BUILD_TYPE:STRING="${LIBDISPATCH_BUILD_TYPE}"
+                    -DSWIFT_TOOLS_DARWIN_ENABLE_LTO_ONLY_FOR_TARGETS:STRING="${DARWIN_ENABLE_LTO_ONLY_FOR_CMAKE_TARGETS}"
                     "${swift_cmake_options[@]}"
                 )
 

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -494,6 +494,14 @@ def create_argument_parser():
                 'imply using lto on the swift standard library or runtime. '
                 'Options: thin, full. If no optional arg is provided, full is '
                 'chosen by default')
+    option('--darwin-enable-lto-only-for-cmake-targets', store,
+           default='',
+           help='A semi-colon split list of CMake targets for '
+           'which to explicitly enable LTO when building for '
+           'Darwin. The net effect of this option is to '
+           'add a linker flags for other tool targets '
+           'to skip optimization phase. '
+           'The setting is ignored for other platforms.')
 
     option('--clang-profile-instr-use', store_path,
            help='profile file to use for clang PGO')

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -137,6 +137,7 @@ EXPECTED_DEFAULTS = {
         defaults.DARWIN_DEPLOYMENT_VERSION_TVOS,
     'darwin_deployment_version_watchos':
         defaults.DARWIN_DEPLOYMENT_VERSION_WATCHOS,
+    'darwin_enable_lto_only_for_cmake_targets': '',
     'darwin_symroot_path_filters': [],
     'darwin_xcrun_toolchain': None,
     'distcc': False,
@@ -713,6 +714,7 @@ EXPECTED_OPTIONS = [
     # valid choices
     SetOption('--lto', dest='lto_type'),
     ChoicesOption('--lto', dest='lto_type', choices=['thin', 'full']),
+    StrOption('--darwin-enable-lto-only-for-cmake-targets'),
 
     # NOTE: We'll need to manually test the behavior of these since they
     # validate compiler version strings.

--- a/validation-test/BuildSystem/LTO/add_host_variant_c_compile_link_flags_characterization_lto.test
+++ b/validation-test/BuildSystem/LTO/add_host_variant_c_compile_link_flags_characterization_lto.test
@@ -1,0 +1,48 @@
+# REQUIRES: standalone_build
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t/build
+# RUN: mkdir -p %t/source
+# RUN: split-file %s %t/source
+# RUN: %{cmake-generate} -DSWIFT_TOOLS_ENABLE_LTO="thin" -DCMAKE_MODULE_PATH=%swift_src_root/cmake/modules -S %t/source -B %t/build | %FileCheck --check-prefix=CHECK-THIN %s
+
+# CHECK-THIN: COMPILE_OPTIONS
+# CHECK-THIN-SAME: -flto=thin
+# CHECK-THIN: LINK_OPTIONS
+# CHECK-THIN-SAME: -flto=thin
+
+# RUN: %{cmake-generate} -DSWIFT_TOOLS_ENABLE_LTO="full" -DCMAKE_MODULE_PATH=%swift_src_root/cmake/modules -S %t/source -B %t/build | %FileCheck --check-prefix=CHECK-FULL %s
+
+# CHECK-FULL: COMPILE_OPTIONS
+# CHECK-FULL-SAME: -flto=full
+# CHECK-FULL: LINK_OPTIONS
+# CHECK-FULL-SAME: -flto=full
+
+# RUN: %{cmake-generate} -DSWIFT_TOOLS_ENABLE_LTO="" -DCMAKE_MODULE_PATH=%swift_src_root/cmake/modules -S %t/source -B %t/build | %FileCheck %s
+
+# CHECK-NOT: COMPILE_OPTIONS {{.*}}-flto=
+# CHECK-NOT: LINK_OPTIONS {{.*}}-flto=
+
+#--- CMakeLists.txt
+cmake_minimum_required(VERSION 3.12.4)
+
+project(character)
+
+include(AddSwift)
+
+set(SWIFT_HOST_VARIANT_SDK "OSX")
+set(SWIFT_HOST_VARIANT_ARCH "x86_64")
+set(DEPLOYMENT_VERSION "10.9")
+set(SWIFT_SDK_OSX_ARCH_X86_64_TRIPLE "x86_64-apple-macos")
+
+add_executable(placeholder hello.c)
+
+_add_host_variant_c_compile_link_flags(placeholder)
+
+get_target_property(placeholder_compile_options placeholder COMPILE_OPTIONS)
+message(STATUS "COMPILE_OPTIONS ${placeholder_compile_options}")
+get_target_property(placeholder_link_options placeholder LINK_OPTIONS)
+message(STATUS "LINK_OPTIONS ${placeholder_link_options}")
+
+#--- hello.c
+int main(){}

--- a/validation-test/BuildSystem/LTO/add_lto_flags.test
+++ b/validation-test/BuildSystem/LTO/add_lto_flags.test
@@ -1,0 +1,43 @@
+# REQUIRES: standalone_build
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t/build
+# RUN: mkdir -p %t/source
+# RUN: split-file %s %t/source
+# RUN: %{cmake-generate} -DSWIFT_TOOLS_ENABLE_LTO="thin" -DCMAKE_MODULE_PATH=%swift_src_root/cmake/modules -S %t/source -B %t/build | %FileCheck --check-prefix=CHECK-THIN %s
+
+# CHECK-THIN: COMPILE_OPTIONS
+# CHECK-THIN-SAME: -flto=thin
+# CHECK-THIN: LINK_OPTIONS
+# CHECK-THIN-SAME: -flto=thin
+
+# RUN: %{cmake-generate} -DSWIFT_TOOLS_ENABLE_LTO="full" -DCMAKE_MODULE_PATH=%swift_src_root/cmake/modules -S %t/source -B %t/build | %FileCheck --check-prefix=CHECK-FULL %s
+
+# CHECK-FULL: COMPILE_OPTIONS
+# CHECK-FULL-SAME: -flto=full
+# CHECK-FULL: LINK_OPTIONS
+# CHECK-FULL-SAME: -flto=full
+
+# RUN: %{cmake-generate} -DSWIFT_TOOLS_ENABLE_LTO="" -DCMAKE_MODULE_PATH=%swift_src_root/cmake/modules -S %t/source -B %t/build | %FileCheck %s
+
+# CHECK-NOT: COMPILE_OPTIONS {{.*}}-flto=
+# CHECK-NOT: LINK_OPTIONS {{.*}}-flto=
+
+#--- CMakeLists.txt
+cmake_minimum_required(VERSION 3.12.4)
+
+project(character)
+
+include(AddSwift)
+
+add_executable(placeholder hello.c)
+
+add_lto_flags(placeholder)
+
+get_target_property(placeholder_compile_options placeholder COMPILE_OPTIONS)
+message(STATUS "COMPILE_OPTIONS ${placeholder_compile_options}")
+get_target_property(placeholder_link_options placeholder LINK_OPTIONS)
+message(STATUS "LINK_OPTIONS ${placeholder_link_options}")
+
+#--- hello.c
+int main(){}

--- a/validation-test/BuildSystem/LTO/add_lto_flags_only_for_targets.test
+++ b/validation-test/BuildSystem/LTO/add_lto_flags_only_for_targets.test
@@ -1,0 +1,58 @@
+# REQUIRES: standalone_build
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t/build
+# RUN: mkdir -p %t/source
+# RUN: split-file %s %t/source
+
+# ensure SWIFT_TOOLS_DARWIN_ENABLE_LTO_ONLY_FOR_TARGETS is honored for Darwin platforms
+# RUN: %{cmake-generate} -DSWIFT_TOOLS_ENABLE_LTO="thin" -DSWIFT_TOOLS_DARWIN_ENABLE_LTO_ONLY_FOR_TARGETS="placeholder;placeholder-missing" -DSWIFT_HOST_VARIANT_SDK="OSX" -DCMAKE_MODULE_PATH=%swift_src_root/cmake/modules -S %t/source -B %t/build | %FileCheck %s
+
+# CHECK: placeholder COMPILE_OPTIONS
+# CHECK-SAME: -flto=thin
+# CHECK: placeholder LINK_OPTIONS
+# CHECK-SAME: -flto=thin
+# CHECK: placeholder-alternate COMPILE_OPTIONS
+# CHECK-SAME: -flto=thin
+# CHECK: placeholder-alternate LINK_OPTIONS
+# CHECK-SAME: -flto=thin
+# CHECK-SAME: -flto-codegen-only
+
+# ensure SWIFT_TOOLS_DARWIN_ENABLE_LTO_ONLY_FOR_TARGETS is ignored for other platforms or
+# when the setting is empty
+# RUN: %{cmake-generate} -DSWIFT_TOOLS_ENABLE_LTO="thin" -DSWIFT_TOOLS_DARWIN_ENABLE_LTO_ONLY_FOR_TARGETS="placeholder;placeholder-missing" -DSWIFT_HOST_VARIANT_SDK="LINUX" -DCMAKE_MODULE_PATH=%swift_src_root/cmake/modules -S %t/source -B %t/build | %FileCheck --check-prefix CHECK-IGNORED %s
+# RUN: %{cmake-generate} -DSWIFT_TOOLS_ENABLE_LTO="thin" -DSWIFT_TOOLS_DARWIN_ENABLE_LTO_ONLY_FOR_TARGETS="" -DSWIFT_HOST_VARIANT_SDK="LINUX" -DCMAKE_MODULE_PATH=%swift_src_root/cmake/modules -S %t/source -B %t/build | %FileCheck --check-prefix CHECK-IGNORED %s
+
+# CHECK-IGNORED: placeholder COMPILE_OPTIONS
+# CHECK-IGNORED-SAME: -flto=thin
+# CHECK-IGNORED: placeholder LINK_OPTIONS
+# CHECK-IGNORED-SAME: -flto=thin
+# CHECK-IGNORED: placeholder-alternate COMPILE_OPTIONS
+# CHECK-IGNORED-SAME: -flto=thin
+# CHECK-IGNORED-LABEL: placeholder-alternate LINK_OPTIONS
+# CHECK-IGNORED-SAME: -flto=thin
+# CHECK-IGNORED-NOT: -flto-codegen-only
+# CHECK-IGNORED-LABEL: Configuring done
+
+#--- CMakeLists.txt
+cmake_minimum_required(VERSION 3.12.4)
+
+project(character)
+
+include(AddSwift)
+
+SET(SWIFT_APPLE_PLATFORMS OSX)
+
+foreach(current_target placeholder;placeholder-alternate)
+    add_executable(${current_target} hello.c)
+
+    add_lto_flags(${current_target})
+
+    get_target_property(${current_target}_compile_options ${current_target} COMPILE_OPTIONS)
+    message(STATUS "${current_target} COMPILE_OPTIONS ${${current_target}_compile_options}")
+    get_target_property(${current_target}_link_options ${current_target} LINK_OPTIONS)
+    message(STATUS "${current_target} LINK_OPTIONS ${${current_target}_link_options}")
+endforeach()
+
+#--- hello.c
+int main(){}

--- a/validation-test/BuildSystem/LTO/darwin-enable-lto-only-for-cmake-targets.test
+++ b/validation-test/BuildSystem/LTO/darwin-enable-lto-only-for-cmake-targets.test
@@ -1,0 +1,13 @@
+# REQUIRES: standalone_build
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake  2>&1 | %FileCheck --check-prefix=CHECK-NO-PARAM %s
+
+# CHECK-NO-PARAM: -DSWIFT_TOOLS_DARWIN_ENABLE_LTO_ONLY_FOR_TARGETS:STRING={{ |$}}
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --darwin-enable-lto-only-for-cmake-targets="swift-frontend;sil-nm" --dry-run --cmake %cmake  2>&1 | %FileCheck --check-prefix=CHECK-PARAM %s
+
+# CHECK-PARAM: -DSWIFT_TOOLS_DARWIN_ENABLE_LTO_ONLY_FOR_TARGETS:STRING=swift-frontend;sil-nm

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -14,6 +14,8 @@ import sys
 import platform
 
 config.cmake = "@CMAKE_COMMAND@"
+config.cmake_make_program = "@CMAKE_MAKE_PROGRAM@"
+config.cmake_generator = "@CMAKE_GENERATOR@"
 config.llvm_src_root = "@LLVM_MAIN_SRC_DIR@"
 config.llvm_obj_root = "@LLVM_BINARY_DIR@"
 config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"


### PR DESCRIPTION
This would be needed in certain configurations to reduce overall build times.

This is only supported under Darwin, since it requires `ld`.

The provided tests, in addition to test the build-script flags, also verifies that the expected flags are added to CMake targets.

Addresses rdar://76702687