### PR TITLE
[5.5] Revert "[Driver][Frontend] add the symbol graph dir to the supplementary file map"

### DIFF
--- a/include/swift/Basic/FileTypes.def
+++ b/include/swift/Basic/FileTypes.def
@@ -83,8 +83,6 @@ TYPE("index-unit-output-path", IndexUnitOutputPath,    "",                "")
 TYPE("yaml-opt-record",     YAMLOptRecord,             "opt.yaml",        "")
 TYPE("bitstream-opt-record",BitstreamOptRecord,        "opt.bitstream",   "")
 
-TYPE("symbol-graph-output-path", SymbolGraphOutputPath, "",               "")
-
 // Overlay files declare wrapper modules, called "separately-imported overlays",
 // that should be automatically imported when a particular module is imported.
 // Cross-import directories conditionalize overlay files so they only take

--- a/include/swift/Basic/SupplementaryOutputPaths.h
+++ b/include/swift/Basic/SupplementaryOutputPaths.h
@@ -152,9 +152,6 @@ struct SupplementaryOutputPaths {
 
   /// The path to which we should emit module summary file.
   std::string ModuleSummaryOutputPath;
-  
-  /// The directory to which we should emit symbol graphs for the current module.
-  std::string SymbolGraphOutputDir;
 
   SupplementaryOutputPaths() = default;
   SupplementaryOutputPaths(const SupplementaryOutputPaths &) = default;
@@ -189,8 +186,6 @@ struct SupplementaryOutputPaths {
       fn(LdAddCFilePath); 
     if (!ModuleSummaryOutputPath.empty())
       fn(ModuleSummaryOutputPath);
-    if (!SymbolGraphOutputDir.empty())
-      fn(SymbolGraphOutputDir);
   }
 
   bool empty() const {
@@ -199,8 +194,7 @@ struct SupplementaryOutputPaths {
            ReferenceDependenciesFilePath.empty() &&
            SerializedDiagnosticsPath.empty() && LoadedModuleTracePath.empty() &&
            TBDPath.empty() && ModuleInterfaceOutputPath.empty() &&
-           ModuleSourceInfoOutputPath.empty() && LdAddCFilePath.empty() &&
-           SymbolGraphOutputDir.empty();
+           ModuleSourceInfoOutputPath.empty() && LdAddCFilePath.empty();
   }
 };
 } // namespace swift

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -416,11 +416,6 @@ private:
                                         const TypeToPathMap *OutputMap,
                                         StringRef workingDirectory,
                                         CommandOutput *Output) const;
-  
-  void chooseSymbolGraphOutputPath(Compilation &C,
-                                   const TypeToPathMap *OutputMap,
-                                   StringRef workingDirectory,
-                                   CommandOutput *Output) const;
 
   void chooseLoadedModuleTracePath(Compilation &C,
                                    StringRef workingDirectory,

--- a/lib/Basic/FileTypes.cpp
+++ b/lib/Basic/FileTypes.cpp
@@ -106,7 +106,6 @@ bool file_types::isTextual(ID Id) {
   case file_types::TY_IndexData:
   case file_types::TY_BitstreamOptRecord:
   case file_types::TY_IndexUnitOutputPath:
-  case file_types::TY_SymbolGraphOutputPath:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");
@@ -158,7 +157,6 @@ bool file_types::isAfterLLVM(ID Id) {
   case file_types::TY_JSONDependencies:
   case file_types::TY_JSONFeatures:
   case file_types::TY_IndexUnitOutputPath:
-  case file_types::TY_SymbolGraphOutputPath:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");
@@ -210,7 +208,6 @@ bool file_types::isPartOfSwiftCompilation(ID Id) {
   case file_types::TY_JSONDependencies:
   case file_types::TY_JSONFeatures:
   case file_types::TY_IndexUnitOutputPath:
-  case file_types::TY_SymbolGraphOutputPath:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2045,7 +2045,6 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
       case file_types::TY_RawSIL:
       case file_types::TY_Nothing:
       case file_types::TY_IndexUnitOutputPath:
-      case file_types::TY_SymbolGraphOutputPath:
       case file_types::TY_INVALID:
         llvm_unreachable("these types should never be inferred");
       }
@@ -2957,9 +2956,6 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
                          options::OPT_emit_objc_header_path))
     chooseObjectiveCHeaderOutputPath(C, OutputMap, workingDirectory,
                                      Output.get());
-  
-  if (C.getArgs().hasArg(options::OPT_emit_symbol_graph))
-    chooseSymbolGraphOutputPath(C, OutputMap, workingDirectory, Output.get());
 
   // 4. Construct a Job which produces the right CommandOutput.
   std::unique_ptr<Job> ownedJob = TC.constructJob(*JA, C, std::move(InputJobs),
@@ -3428,31 +3424,6 @@ void Driver::chooseOptimizationRecordPath(Compilation &C,
   } else
     // FIXME: We should use the OutputMap in this case.
     Diags.diagnose({}, diag::warn_opt_remark_disabled);
-}
-
-void Driver::chooseSymbolGraphOutputPath(Compilation &C,
-                                         const TypeToPathMap *OutputMap,
-                                         StringRef workingDirectory,
-                                         CommandOutput *Output) const {
-  StringRef optionOutput = C.getArgs().getLastArgValue(options::OPT_emit_symbol_graph_dir);
-  if (hasExistingAdditionalOutput(*Output, file_types::TY_SymbolGraphOutputPath, optionOutput)) {
-    return;
-  }
-  
-  StringRef SymbolGraphDir;
-  if (OutputMap) {
-    auto iter = OutputMap->find(file_types::TY_SymbolGraphOutputPath);
-    if (iter != OutputMap->end())
-      SymbolGraphDir = iter->second;
-  }
-  
-  if (SymbolGraphDir.empty() && !optionOutput.empty()) {
-    SymbolGraphDir = optionOutput;
-  }
-  
-  if (!SymbolGraphDir.empty()) {
-    Output->setAdditionalOutputForType(file_types::TY_SymbolGraphOutputPath, SymbolGraphDir);
-  }
 }
 
 void Driver::chooseObjectiveCHeaderOutputPath(Compilation &C,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -578,6 +578,11 @@ ToolChain::constructInvocation(const CompileJobAction &job,
       options::
           OPT_disable_autolinking_runtime_compatibility_dynamic_replacements);
 
+  if (context.OI.CompilerMode == OutputInfo::Mode::SingleCompile) {
+    context.Args.AddLastArg(Arguments, options::OPT_emit_symbol_graph);
+    context.Args.AddLastArg(Arguments, options::OPT_emit_symbol_graph_dir);
+  }
+
   return II;
 }
 
@@ -655,7 +660,6 @@ const char *ToolChain::JobContext::computeFrontendModeForCompile() const {
   case file_types::TY_SwiftCrossImportDir:
   case file_types::TY_SwiftOverlayFile:
   case file_types::TY_IndexUnitOutputPath:
-  case file_types::TY_SymbolGraphOutputPath:
     llvm_unreachable("Output type can never be primary output.");
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID");
@@ -797,8 +801,6 @@ void ToolChain::JobContext::addFrontendSupplementaryOutputArguments(
   addOutputsOfType(arguments, Output, Args,
                    file_types::TY_SwiftModuleSummaryFile,
                    "-emit-module-summary-path");
-  addOutputsOfType(arguments, Output, Args, file_types::TY_SymbolGraphOutputPath,
-                   "-emit-symbol-graph-dir");
 }
 
 ToolChain::InvocationInfo
@@ -916,7 +918,6 @@ ToolChain::constructInvocation(const BackendJobAction &job,
     case file_types::TY_SwiftCrossImportDir:
     case file_types::TY_SwiftOverlayFile:
     case file_types::TY_IndexUnitOutputPath:
-    case file_types::TY_SymbolGraphOutputPath:
       llvm_unreachable("Output type can never be primary output.");
     case file_types::TY_INVALID:
       llvm_unreachable("Invalid type ID");

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -341,14 +341,11 @@ SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
       options::OPT_emit_ldadd_cfile_path);
   auto moduleSummaryOutput = getSupplementaryFilenamesFromArguments(
       options::OPT_emit_module_summary_path);
-  auto symbolGraphOutput = getSupplementaryFilenamesFromArguments(
-      options::OPT_emit_symbol_graph_dir);
   if (!objCHeaderOutput || !moduleOutput || !moduleDocOutput ||
       !dependenciesFile || !referenceDependenciesFile ||
       !serializedDiagnostics || !fixItsOutput || !loadedModuleTrace || !TBD ||
       !moduleInterfaceOutput || !privateModuleInterfaceOutput ||
-      !moduleSourceInfoOutput || !ldAddCFileOutput || !moduleSummaryOutput ||
-      !symbolGraphOutput) {
+      !moduleSourceInfoOutput || !ldAddCFileOutput || !moduleSummaryOutput) {
     return None;
   }
   std::vector<SupplementaryOutputPaths> result;
@@ -371,7 +368,6 @@ SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
     sop.ModuleSourceInfoOutputPath = (*moduleSourceInfoOutput)[i];
     sop.LdAddCFilePath = (*ldAddCFileOutput)[i];
     sop.ModuleSummaryOutputPath = (*moduleSummaryOutput)[i];
-    sop.SymbolGraphOutputDir = (*symbolGraphOutput)[i];
     result.push_back(sop);
   }
   return result;
@@ -463,11 +459,6 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
       OPT_emit_module_summary, pathsFromArguments.ModuleSummaryOutputPath,
       file_types::TY_SwiftModuleSummaryFile, "",
       defaultSupplementaryOutputPathExcludingExtension);
-  
-  auto symbolGraphOutputDir = determineSupplementaryOutputFilename(
-      OPT_emit_symbol_graph_dir, pathsFromArguments.SymbolGraphOutputDir,
-      file_types::TY_SymbolGraphOutputPath, "",
-      defaultSupplementaryOutputPathExcludingExtension);
 
   // There is no non-path form of -emit-interface-path
   auto ModuleInterfaceOutputPath =
@@ -501,7 +492,6 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
   sop.ModuleSourceInfoOutputPath = moduleSourceInfoOutputPath;
   sop.LdAddCFilePath = pathsFromArguments.LdAddCFilePath;
   sop.ModuleSummaryOutputPath = moduleSummaryOutputPath;
-  sop.SymbolGraphOutputDir = symbolGraphOutputDir;
   return sop;
 }
 
@@ -584,7 +574,6 @@ createFromTypeToPathMap(const TypeToPathMap *map) {
       {file_types::TY_SwiftModuleSummaryFile, paths.ModuleSummaryOutputPath},
       {file_types::TY_PrivateSwiftModuleInterfaceFile,
        paths.PrivateModuleInterfaceOutputPath},
-      {file_types::TY_SymbolGraphOutputPath, paths.SymbolGraphOutputDir},
   };
   for (const std::pair<file_types::ID, std::string &> &typeAndString :
        typesAndStrings) {
@@ -608,8 +597,7 @@ SupplementaryOutputPathsComputer::readSupplementaryOutputFileMap() const {
         options::OPT_emit_private_module_interface_path,
         options::OPT_emit_module_source_info_path,
         options::OPT_emit_tbd_path,
-        options::OPT_emit_ldadd_cfile_path,
-        options::OPT_emit_symbol_graph_dir)) {
+        options::OPT_emit_ldadd_cfile_path)) {
     Diags.diagnose(SourceLoc(),
                    diag::error_cannot_have_supplementary_outputs,
                    A->getSpelling(), "-supplementary-output-file-map");

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -156,9 +156,7 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
   serializationOpts.ModuleLinkName = opts.ModuleLinkName;
   serializationOpts.ExtraClangOptions = getClangImporterOptions().ExtraArgs;
   
-  if (!outs.SymbolGraphOutputDir.empty()) {
-    serializationOpts.SymbolGraphOutputDir = outs.SymbolGraphOutputDir;
-  } else if (opts.EmitSymbolGraph) {
+  if (opts.EmitSymbolGraph) {
     if (!opts.SymbolGraphOutputDir.empty()) {
       serializationOpts.SymbolGraphOutputDir = opts.SymbolGraphOutputDir;
     } else {

--- a/test/Driver/filelists.swift
+++ b/test/Driver/filelists.swift
@@ -35,16 +35,6 @@
 // CHECK-WMO-NOT: Handled
 
 
-// RUN: %swiftc_driver -save-temps -driver-print-jobs -c %S/Inputs/lib.swift -module-name lib -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -whole-module-optimization -emit-module -emit-symbol-graph -emit-symbol-graph-dir %t 2>&1 | tee %t/forWMOFilelistCapture | %FileCheck -check-prefix=CHECK-WMO-SYM-FILELIST %s
-// RUN: grep -e ' -supplementary-output-file-map ' %t/forWMOFilelistCapture | tail -1 | sed 's/.*-supplementary-output-file-map //' | sed 's/ .*//' > %t/supplementary-output
-// RUN: cat $(cat %t/supplementary-output) | %FileCheck -check-prefix CHECK-WMO-SYM-SUPP %s
-
-// CHECK-WMO-SYM-FILELIST: swift
-// CHECK-WMO-SYM-FILELIST-DAG: -supplementary-output-file-map
-
-// CHECK-WMO-SYM-SUPP: symbol-graph-output-path
-
-
 // RUN: %empty-directory(%t/bin)
 // RUN: ln -s %S/Inputs/filelists/fake-ld.py %t/bin/ld
 
@@ -87,8 +77,8 @@
 // RUN: echo "int dummy;" >%t/a.cpp
 // RUN: %target-clang -c %t/a.cpp -o %t/a.o
 // RUN: %swiftc_driver -save-temps -driver-print-jobs %S/../Inputs/empty.swift %t/a.o -lto=llvm-full -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -o filelist 2>&1 | tee %t/forFilelistCapture | %FileCheck -check-prefix FILELIST %s
-// RUN: grep -e ' -output-filelist ' %t/forFilelistCapture | tail -1 | sed 's/.*-output-filelist //' | sed 's/ .*//' > %t/output-filelist
-// RUN: grep -e ' -filelist ' %t/forFilelistCapture | tail -1 | sed 's/.*-filelist //' | sed 's/ .*//' > %t/input-filelist
+// RUN: tail -2 %t/forFilelistCapture | head -1 | sed 's/.*-output-filelist //' | sed 's/ .*//' > %t/output-filelist
+// RUN: tail -1 %t/forFilelistCapture | sed 's/.*-filelist //' | sed 's/ .*//' > %t/input-filelist
 // RUN: cat $(cat %t/output-filelist) | %FileCheck -check-prefix OUTPUT-FILELIST-CONTENTS %s
 // RUN: cat $(cat %t/input-filelist)  | %FileCheck -check-prefix INPUT-FILELIST-CONTENTS %s
 

--- a/test/SymbolGraph/Inputs/EmitWhileBuilding.output.json
+++ b/test/SymbolGraph/Inputs/EmitWhileBuilding.output.json
@@ -4,7 +4,7 @@
     },
     "EmitWhileBuilding.swift": {
         "object": "./EmitWhileBuilding.o",
-        "swiftmodule": "./EmitWhileBuilding.swiftmodule",
+        "swiftmodule": "./EmitWhileBuilding_partial.swiftmodule",
         "dependencies": "./EmitWhileBuilding.d",
         "swift-dependencies": "./EmitWhileBuilding.swiftdeps"
     }


### PR DESCRIPTION
Resolves rdar://78312183

When https://github.com/apple/swift/pull/37017 was posted, the `release/5.5` branch had been cut. However, the PR was only applied to `main`. This means that the issue that that PR was meant to fix is still present on the `release/5.5` branch. This PR applies the reversion (and the test fix that allowed swift-driver to run the `SymbolGraph/EmitWhileBuilding` test) to `release/5.5`.