### PR TITLE
Fix and make consistent @resultBuilder documentation

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -5392,7 +5392,7 @@ public:
       ResultBuilderBuildFunction function) {
     switch (function) {
     case ResultBuilderBuildFunction::BuildArray:
-      return "Enables support for..in loops in a result builder by "
+      return "Enables support for 'for-in' loops in a result builder by "
         "combining the results of all iterations into a single result";
 
     case ResultBuilderBuildFunction::BuildBlock:
@@ -5423,7 +5423,7 @@ public:
         "type information";
 
     case ResultBuilderBuildFunction::BuildOptional:
-      return "Enables support for `if` statements that do not have an `else`";
+      return "Enables support for 'if' statements that do not have an 'else'";
     }
   }
 

--- a/userdocs/diagnostics/result-builder-methods.md
+++ b/userdocs/diagnostics/result-builder-methods.md
@@ -29,7 +29,7 @@ struct ExampleResultBuilder {
   /// expressions to translate them into partial results.
   static func buildExpression(_ expression: Expression) -> Component { ... }
 
-  /// Enables support for `if` statements that do not have an `else`.
+  /// Enables support for 'if' statements that do not have an 'else'.
   static func buildOptional(_ component: Component?) -> Component { ... }
 
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
@@ -40,7 +40,7 @@ struct ExampleResultBuilder {
   /// statements by folding conditional results into a single result.
   static func buildEither(second component: Component) -> Component { ... }
 
-  /// Enables support for..in loops in a result builder by combining the
+  /// Enables support for 'for-in' loops in a result builder by combining the
   /// results of all iterations into a single result.
   static func buildArray(_ components: [Component]) -> Component { ... }
 


### PR DESCRIPTION
Simply fix a little error in @resultBuilder documentation (a missing _for_).

Also, make consistent documentation punctuation with other docs.