### PR TITLE
Disable ModuleInterface/swift_build_sdk_interfaces/xfail-logs.test-sh

### DIFF
--- a/test/ModuleInterface/swift_build_sdk_interfaces/xfail-logs.test-sh
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/xfail-logs.test-sh
@@ -1,3 +1,6 @@
+# Timing out in CI
+REQUIRES: rdar78318467
+
 RUN: %empty-directory(%t)
 RUN: env SWIFT_EXEC=%swiftc_driver_plain not %{python} %utils/swift_build_sdk_interfaces.py %mcp_opt -sdk %S/Inputs/xfails-sdk/ -o %t/output -log-path %t/logs | %FileCheck %s
 RUN: %FileCheck -check-prefix PRINTS-ERROR %s < %t/logs/Bad-Bad-err.txt


### PR DESCRIPTION
This is timing out in CI in some configurations.

rdar://78318467

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
