### PR TITLE
Disable validation-test/BuildSystem/llvm-targets-options.test on Linux

### DIFF
--- a/validation-test/BuildSystem/llvm-targets-options.test
+++ b/validation-test/BuildSystem/llvm-targets-options.test
@@ -1,3 +1,6 @@
+# Failing in CI with "%cmake is not an executable" rdar://78320684
+# UNSUPPORTED: OS=linux-gnu
+
 # REQUIRES: standalone_build
 
 # RUN: %empty-directory(%t)


### PR DESCRIPTION
This has failed a couple of times in CI with an error about cmake not
being an executable. Disbale until we can fix it.

rdar://78320684