### PR TITLE
[SourceKit] Avoid unnecessary parsing in 'open' request

### DIFF
--- a/test/SourceKit/Sema/edit_nowait.swift
+++ b/test/SourceKit/Sema/edit_nowait.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
-// RUN: echo "" > %t/t.swift
+// RUN: echo "func f() { f() }" > %t/t.swift
 
 // RUN: %sourcekitd-test \
-// RUN:   -req=open %t/t.swift -- %t/t.swift == \
-// RUN:   -req=edit -offset=0 -replace="func foo() { warn("") }" -length=0 -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/t.swift -print-raw-response == \
+// RUN:   -req=open -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/t.swift -print-raw-response -- %t/t.swift == \
+// RUN:   -req=edit -offset=0 -replace="func foo() { warn("") }" -length=16 -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/t.swift -print-raw-response == \
 // RUN:   -req=edit -offset=13 -replace="print" -length=5 -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/t.swift -print-raw-response \
 // RUN: | %FileCheck --check-prefix=EDIT_NOWAIT %s
 
@@ -11,16 +11,26 @@
 // EDIT_NOWAIT-NEXT: }
 // EDIT_NOWAIT-NEXT: {
 // EDIT_NOWAIT-NEXT: }
+// EDIT_NOWAIT-NEXT: {
+// EDIT_NOWAIT-NEXT: }
 
 // RUN: %sourcekitd-test \
-// RUN: %sourcekitd-test \
-// RUN:   -req=open %t/t.swift -- %t/t.swift == \
-// RUN:   -req=edit -offset=0 -replace="func foo() { warn("") }" -length=0 -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/t.swift == \
+// RUN:   -req=open -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/t.swift -- %t/t.swift == \
+// RUN:   -req=print-annotations %t/t.swift  == \
+// RUN:   -req=edit -offset=0 -replace="func foo() { warn("") }" -length=16 -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/t.swift == \
 // RUN:   -req=edit -offset=13 -replace="print" -length=4 -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/t.swift == \
-// RUN:   -req=print-annotations %s \
+// RUN:   -req=print-annotations %t/t.swift \
 // RUN: | %FileCheck --check-prefix=ANNOTATION %s
 
-// ANNOTATION:      [
+// ANNOTATION-LABEL: [
+// ANNOTATION-NEXT:   {
+// ANNOTATION-NEXT:     key.kind: source.lang.swift.ref.function.free,
+// ANNOTATION-NEXT:     key.offset: 11,
+// ANNOTATION-NEXT:     key.length: 1
+// ANNOTATION-NEXT:   }
+// ANNOTATION-NEXT: ]
+
+// ANNOTATION-LABEL: [
 // ANNOTATION-NEXT:   {
 // ANNOTATION-NEXT:     key.kind: source.lang.swift.ref.function.free,
 // ANNOTATION-NEXT:     key.offset: 13,

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -2358,6 +2358,13 @@ void SwiftLangSupport::editorOpen(
     EditorDoc->updateSemaInfo();
   }
 
+  if (!Consumer.documentStructureEnabled() &&
+      !Consumer.syntaxMapEnabled() &&
+      !Consumer.diagnosticsEnabled() &&
+      !Consumer.syntaxTreeEnabled()) {
+    return;
+  }
+
   EditorDoc->readSyntaxInfo(Consumer, /*ReportDiags=*/true);
 
   if (Consumer.syntaxTreeEnabled()) {


### PR DESCRIPTION
If the client doesn't want anything as the response of `editor.open`, avoid parsing the source code because it's not necessary. We already do this for `editor.replacetext` request, this PR just do the same thing for 'editor.open' too.

rdar://77693214
