### PR TITLE
[Concurrency] Don't produce notes about invalid calls for partial applies

### DIFF
--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -33,11 +33,9 @@ actor BankAccount {
     curBalance = initialDeposit
   }
 
-  // NOTE: this func is accessed through both async and sync calls.
-  // expected-note@+1 {{calls to instance method 'balance()' from outside of its actor context are implicitly asynchronous}}
   func balance() -> Int { return curBalance }
 
-  // expected-note@+1 2{{calls to instance method 'deposit' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@+1 {{calls to instance method 'deposit' from outside of its actor context are implicitly asynchronous}}
   func deposit(_ amount : Int) -> Int {
     guard amount >= 0 else { return 0 }
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -70,7 +70,7 @@ actor MyActor: MySuperActor { // expected-error{{actor types do not support inhe
   class func synchronousClass() { }
   static func synchronousStatic() { }
 
-  func synchronous() -> String { text.first ?? "nothing" } // expected-note 19{{calls to instance method 'synchronous()' from outside of its actor context are implicitly asynchronous}}
+  func synchronous() -> String { text.first ?? "nothing" } // expected-note 5{{calls to instance method 'synchronous()' from outside of its actor context are implicitly asynchronous}}
   func asynchronous() async -> String {
     super.superState += 4
     return synchronous()
@@ -819,4 +819,18 @@ func test_conforming_actor_to_global_actor_protocol() {
   @available(SwiftStdlib 5.5, *)
   actor MyValue : GloballyIsolatedProto {}
   // expected-error@-1 {{actor 'MyValue' cannot conform to global actor isolated protocol 'GloballyIsolatedProto'}}
+}
+
+func test_invalid_reference_to_actor_member_without_a_call_note() {
+  actor A {
+    func partial() { }
+  }
+
+  actor Test {
+    func returnPartial(other: A) async -> () async -> () {
+      let a = other.partial
+      // expected-error@-1 {{actor-isolated instance method 'partial()' can only be referenced from inside the actor}}
+      return a
+    }
+  }
 }


### PR DESCRIPTION
If invalid actor reference is a partial application, let's not
produce a note that talks about invalid "call".

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
