### PR TITLE
[cmake] Some more small changes to enable host side tools that use swift using standard cmake.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -390,6 +390,7 @@ endfunction()
 #     [SHARED]
 #     [STATIC]
 #     [OBJECT]
+#     [IGNORE_LLVM_UPDATE_COMPILE_FLAGS]
 #     [LLVM_LINK_COMPONENTS comp1 ...]
 #     source1 [source2 source3 ...])
 #
@@ -408,13 +409,19 @@ endfunction()
 # LLVM_LINK_COMPONENTS
 #   LLVM components this library depends on.
 #
+# IGNORE_LLVM_UPDATE_COMPILE_FLAGS
+#   If set do not use llvm_update_compile_flags to generate cflags/etc.  This is
+#   generally used when compiling a mixed c/c++/swift library and one wants to
+#   disable this for the swift part.
+#
 # source1 ...
 #   Sources to add into this library.
 function(add_swift_host_library name)
   set(options
         SHARED
         STATIC
-        OBJECT)
+        OBJECT
+        IGNORE_LLVM_UPDATE_COMPILE_FLAGS)
   set(single_parameter_options)
   set(multiple_parameter_options
         LLVM_LINK_COMPONENTS)
@@ -460,7 +467,9 @@ function(add_swift_host_library name)
 
   add_library(${name} ${libkind} ${ASHL_SOURCES})
   add_dependencies(${name} ${LLVM_COMMON_DEPENDS})
-  llvm_update_compile_flags(${name})
+  if (NOT ASHL_IGNORE_LLVM_UPDATE_COMPILE_FLAGS)
+    llvm_update_compile_flags(${name})
+  endif()
   swift_common_llvm_config(${name} ${ASHL_LLVM_LINK_COMPONENTS})
   set_output_directory(${name}
       BINARY_DIR ${SWIFT_RUNTIME_OUTPUT_INTDIR}

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -389,6 +389,7 @@ endfunction()
 #   add_swift_host_library(name
 #     [SHARED]
 #     [STATIC]
+#     [OBJECT]
 #     [LLVM_LINK_COMPONENTS comp1 ...]
 #     source1 [source2 source3 ...])
 #
@@ -401,6 +402,9 @@ endfunction()
 # STATIC
 #   Build a static library.
 #
+# OBJECT
+#   Build an object library
+#
 # LLVM_LINK_COMPONENTS
 #   LLVM components this library depends on.
 #
@@ -409,7 +413,8 @@ endfunction()
 function(add_swift_host_library name)
   set(options
         SHARED
-        STATIC)
+        STATIC
+        OBJECT)
   set(single_parameter_options)
   set(multiple_parameter_options
         LLVM_LINK_COMPONENTS)
@@ -423,8 +428,8 @@ function(add_swift_host_library name)
 
   translate_flags(ASHL "${options}")
 
-  if(NOT ASHL_SHARED AND NOT ASHL_STATIC)
-    message(FATAL_ERROR "Either SHARED or STATIC must be specified")
+  if(NOT ASHL_SHARED AND NOT ASHL_STATIC AND NOT ASHL_OBJECT)
+    message(FATAL_ERROR "One of SHARED/STATIC/OBJECT must be specified")
   endif()
 
   if(XCODE)
@@ -449,6 +454,8 @@ function(add_swift_host_library name)
     set(libkind SHARED)
   elseif(ASHL_STATIC)
     set(libkind STATIC)
+  elseif(ASHL_OBJECT)
+    set(libkind OBJECT)
   endif()
 
   add_library(${name} ${libkind} ${ASHL_SOURCES})


### PR DESCRIPTION
There are 3 commits here. 2 are important one is just utility (I can split it out, but seemed useful):

1. The first commit conditionalizes -target being passed on the link line to link jobs with language C/CXX/OBJC/OBJCXX. We do not require this of Swift now since we need to do some extra work to upgrade the minimum deployment target of the compiler (NOTE: not the stdlib which will still backwards deploy to 10.9 in what I am suggesting). I put more info into the commit itself.
2. The 2nd commit exposes object libraries as a type of swiftest library. This is useful and is just putting in plumbing. I am find removing it though.
3. I am currently working with compnerd with upstream to conditionalize the cxx flags modified by llvm_update_compile_flags. That is going to take a few days to work out and I want to unblock ErikE's work on libswift so I put in temporarily a work around option while that discussion is happening upstream.
