### PR TITLE
[5.5-0514202] Use a async function pointer for default async protocol witness implemenations

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -916,6 +916,10 @@ namespace {
         if (!entry.isValid() || entry.getKind() != SILWitnessTable::Method ||
             entry.getMethodWitness().Requirement != func)
           continue;
+        auto silFunc = entry.getMethodWitness().Witness;
+        if (silFunc->isAsync()) {
+          return IGM.getAddrOfAsyncFunctionPointer(silFunc);
+        }
         return IGM.getAddrOfSILFunction(entry.getMethodWitness().Witness,
                                         NotForDefinition);
       }

--- a/test/Interpreter/Inputs/resilient_async.swift
+++ b/test/Interpreter/Inputs/resilient_async.swift
@@ -1,0 +1,9 @@
+public protocol Problem : class {
+}
+
+public extension Problem {
+}
+
+public func callGenericWitness<T: Problem> (_ t: T) async -> Int {
+  return 0
+}

--- a/test/Interpreter/Inputs/resilient_async2.swift
+++ b/test/Interpreter/Inputs/resilient_async2.swift
@@ -1,0 +1,13 @@
+public protocol Problem : class {
+  func theProblem() async -> Int
+}
+
+public extension Problem {
+  func theProblem() async -> Int {
+			return 1
+  }
+}
+
+public func callGenericWitness<T: Problem> (_ t: T) async -> Int {
+  return await t.theProblem()
+}

--- a/test/Interpreter/async_resilience.swift
+++ b/test/Interpreter/async_resilience.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_async)) -enable-library-evolution %S/Inputs/resilient_async.swift -emit-module -emit-module-path %t/resilient_async.swiftmodule -module-name resilient_async
+// RUN: %target-codesign %t/%target-library-name(resilient_async)
+
+// RUN: %target-build-swift -parse-as-library %s -lresilient_async -I %t -L %t -o %t/main %target-rpath(%t)
+// RUN: %target-codesign %t/main
+
+// Introduce a defaulted protocol method.
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_async)) -enable-library-evolution %S/Inputs/resilient_async2.swift -emit-module -emit-module-path %t/resilient_async.swiftmodule -module-name resilient_async
+// RUN: %target-codesign %t/%target-library-name(resilient_async)
+
+// RUN: %target-run %t/main %t/%target-library-name(resilient_async)
+
+// REQUIRES: executable_test
+
+
+import resilient_async
+
+class Impl : Problem {}
+
+@main struct Main {
+  static func main() async {
+      let i = Impl()
+      // This used to crash.
+      let r = await callGenericWitness(i)
+      assert(r == 1)
+  }
+}


### PR DESCRIPTION
Protocol witness table entries of async functions need to be async
function pointers.

rdar://77474699

Original PR: https://github.com/apple/swift/pull/37579