### PR TITLE
Disable IDE/import_as_member.swift

### DIFF
--- a/test/IDE/import_as_member.swift
+++ b/test/IDE/import_as_member.swift
@@ -9,6 +9,9 @@
 
 // RUN: %target-typecheck-verify-swift -I %S/Inputs/custom-modules
 
+// Assertion failed: (I != F.TypeRemap.end() && "Invalid index into type index remap"))
+// REQUIRES: rdar70691386
+
 // PRINT: struct Struct1 {
 // PRINT-NEXT:   var x: Double
 // PRINT-NEXT:   var y: Double


### PR DESCRIPTION
This test fails periodically across all configurations.

rdar://70691386 (IDE/import_as_member.swift; fails sporadically;
Assertion failed: (I != F.TypeRemap.end() && "Invalid index into type index remap"))

(cherry picked from commit 72716c3dbb2bdfa5b6329ff022ccc3887edf9a8a)