### PR TITLE
[DRAFT][build-script] Refactor llbuild out of build-script-impl and into build-script.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ include(CheckLanguage)
 check_language(Swift)
 if(CMAKE_Swift_COMPILER)
   enable_language(Swift)
+
 else()
   message(STATUS "WARNING! Did not find a host compiler swift?! Can not build
                   any compiler host sources written in Swift")
@@ -190,6 +191,10 @@ set(SWIFT_TOOLS_ENABLE_LTO OFF CACHE STRING "Build Swift tools with LTO. One
     must specify the form of LTO by setting this to one of: 'full', 'thin'. This
     option only affects the tools that run on the host (the compiler), and has
     no effect on the target libraries (the standard library and the runtime).")
+
+option(SWIFT_TOOLS_ENABLE_LIBSWIFT
+  "Enable building libswift and linking libswift into the compiler itself."
+  TRUE)
 
 # The following only works with the Ninja generator in CMake >= 3.0.
 set(SWIFT_PARALLEL_LINK_JOBS "" CACHE STRING
@@ -883,6 +888,7 @@ if(SWIFT_INCLUDE_TOOLS)
   message(STATUS "  Build type:     ${CMAKE_BUILD_TYPE}")
   message(STATUS "  Assertions:     ${LLVM_ENABLE_ASSERTIONS}")
   message(STATUS "  LTO:            ${SWIFT_TOOLS_ENABLE_LTO}")
+  message(STATUS "  libswift:       ${SWIFT_TOOLS_ENABLE_LIBSWIFT}")
   message(STATUS "")
 else()
   message(STATUS "Not building host Swift tools")
@@ -1024,6 +1030,7 @@ add_subdirectory(include)
 
 if(SWIFT_INCLUDE_TOOLS)
   add_subdirectory(lib)
+  add_subdirectory(libswift)
 
   # Always include this after including stdlib/!
   # Refer to the large comment above the add_subdirectory(stdlib) call.

--- a/include/swift/Basic/InitializeLibSwift.h
+++ b/include/swift/Basic/InitializeLibSwift.h
@@ -1,0 +1,26 @@
+//===--- InitializeLibSwift.h -----------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_INITIALIZELIBSWIFT_H
+#define SWIFT_BASIC_INITIALIZELIBSWIFT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void initializeLibSwift();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SWIFT_BASIC_INITIALIZELIBSWIFT_H

--- a/libswift/CMakeLists.txt
+++ b/libswift/CMakeLists.txt
@@ -1,0 +1,40 @@
+################################################################################
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+################################################################################
+
+# In the absence of fine grained tablegen dependencies we need to ensure that
+# Swift's libraries all build after the LLVM & Clang tablegen-generated headers
+# are generated. When building out-of-tree (as with build-script) LLVM & Clang's
+# CMake configuration files create these targets as dummies so we can safely
+# depend on them directly here (See: SR-6026)
+# LLVM_COMMON_DEPENDS is a construct from the LLVM build system. It is a special
+# purpose variable that provides common dependencies for all libraries, and
+# executables generated when it is set. CMake's scoping rules enforce that these
+# new dependencies will only be added to targets created under Swift's lib
+# directory.
+list(APPEND LLVM_COMMON_DEPENDS intrinsics_gen clang-tablegen-targets)
+
+# Add generated libSyntax headers to global dependencies.
+list(APPEND LLVM_COMMON_DEPENDS swift-syntax-generated-headers)
+list(APPEND LLVM_COMMON_DEPENDS swift-parse-syntax-generated-headers)
+
+#add_swift_host_library(LibSwiftStub OBJECT DisabledLibswiftStub.c)
+
+if (NOT SWIFT_TOOLS_ENABLE_LIBSWIFT)
+  # A dummy libswift if libswift is disabled
+#  add_swift_host_library(LibSwift STATIC $<TARGET_OBJECTS:LibSwiftStub>)
+else()
+  project(LibSwift LANGUAGES C CXX Swift)
+
+  # Add path for custom CMake modules.
+  list(APPEND CMAKE_MODULE_PATH
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+
+  add_subdirectory(Sources)
+endif()

--- a/libswift/Package.swift
+++ b/libswift/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+  name: "libswift",
+  platforms: [
+    .macOS("10.9"),
+  ],
+  products: [
+    .library(
+      name: "Swift",
+      type: .static,
+      targets: ["SIL", "Optimizer"]),
+  ],
+  dependencies: [
+  ],
+  // Note that all modules must be added to LIBSWIFT_MODULES in the top-level
+  // CMakeLists.txt file to get debugging working.
+  targets: [
+    .target(
+      name: "SIL",
+      dependencies: [],
+      swiftSettings: [SwiftSetting.unsafeFlags([
+          "-I", "../include/swift",
+          "-cross-module-optimization"
+        ])]),
+    .target(
+      name: "Optimizer",
+      dependencies: ["SIL"],
+      swiftSettings: [SwiftSetting.unsafeFlags([
+          "-I", "../include/swift",
+          "-cross-module-optimization"
+        ])]),
+  ]
+)

--- a/libswift/Sources/CMakeLists.txt
+++ b/libswift/Sources/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(SIL)
+add_subdirectory(Optimizer)

--- a/libswift/Sources/Optimizer/CMakeLists.txt
+++ b/libswift/Sources/Optimizer/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+add_subdirectory(PassManager)

--- a/libswift/Sources/Optimizer/PassManager/CMakeLists.txt
+++ b/libswift/Sources/Optimizer/PassManager/CMakeLists.txt
@@ -1,0 +1,7 @@
+
+add_swift_host_library(LibSwiftOptimizer
+  STATIC
+  IGNORE_LLVM_UPDATE_COMPILE_FLAGS
+  PassRegistration.swift)
+
+target_link_libraries(LibSwiftOptimizer PRIVATE LibSwiftSIL)

--- a/libswift/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/libswift/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -1,0 +1,17 @@
+//===--- PassRegistration.swift - Register optimzation passes -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LibSwiftSIL
+
+@_cdecl("initializeLibSwift")
+public func initializeLibSwift() {
+}

--- a/libswift/Sources/SIL/CMakeLists.txt
+++ b/libswift/Sources/SIL/CMakeLists.txt
@@ -1,0 +1,5 @@
+
+add_swift_host_library(LibSwiftSIL
+  STATIC
+  IGNORE_LLVM_UPDATE_COMPILE_FLAGS
+  Value.swift)

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -1,20 +1,34 @@
+
+set(driver_sources_and_options
+                driver.cpp
+                autolink_extract_main.cpp
+                modulewrap_main.cpp
+                swift_api_digester_main.cpp
+                swift_indent_main.cpp
+                swift_symbolgraph_extract_main.cpp
+                swift_api_extract_main.cpp
+                )
+
+set(driver_common_libs
+                swiftAPIDigester
+                swiftDriver
+                swiftFrontendTool
+                swiftSymbolGraphGen
+                LLVMBitstreamReader
+                LibSwiftSIL
+                LibSwiftOptimizer
+                )
+
+# The swift-frontend tool
+
 add_swift_host_tool(swift-frontend
-  driver.cpp
-  autolink_extract_main.cpp
-  modulewrap_main.cpp
-  swift_api_digester_main.cpp
-  swift_indent_main.cpp
-  swift_symbolgraph_extract_main.cpp
-  swift_api_extract_main.cpp
+  ${driver_sources_and_options}
   SWIFT_COMPONENT compiler
 )
 target_link_libraries(swift-frontend
                       PRIVATE
-                        swiftAPIDigester
-                        swiftDriver
-                        swiftFrontendTool
-                        swiftSymbolGraphGen
-                        LLVMBitstreamReader)
+                      ${driver_common_libs}
+                      )
 
 # Create a `swift-driver` symlinks adjacent to the `swift-frontend` executable
 # to ensure that `swiftc` forwards to the standalone driver when invoked.

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -14,15 +14,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/Driver/Driver.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsDriver.h"
+#include "swift/Basic/InitializeLibSwift.h"
 #include "swift/Basic/LLVMInitialize.h"
 #include "swift/Basic/PrettyStackTrace.h"
 #include "swift/Basic/Program.h"
-#include "swift/Basic/TaskQueue.h"
 #include "swift/Basic/SourceManager.h"
+#include "swift/Basic/TaskQueue.h"
 #include "swift/Driver/Compilation.h"
-#include "swift/Driver/Driver.h"
 #include "swift/Driver/FrontendUtil.h"
 #include "swift/Driver/Job.h"
 #include "swift/Driver/ToolChain.h"
@@ -183,6 +184,10 @@ static bool appendSwiftDriverName(SmallString<256> &buffer) {
 
 static int run_driver(StringRef ExecName,
                        const ArrayRef<const char *> argv) {
+  // This is done here and not done in FrontendTool.cpp, because
+  // FrontendTool.cpp is linked to tools, which don't use libswift.
+  initializeLibSwift();
+
   // Handle integrated tools.
   if (argv.size() > 1) {
     StringRef FirstArg(argv[1]);

--- a/tools/sil-opt/CMakeLists.txt
+++ b/tools/sil-opt/CMakeLists.txt
@@ -9,6 +9,8 @@ target_link_libraries(sil-opt
                         swiftSIL
                         swiftSILGen
                         swiftSILOptimizer
+                        LibSwiftSIL
+                        LibSwiftOptimizer
                         # Clang libraries included to appease the linker on linux.
                         clangBasic
                         clangCodeGen)

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -15,23 +15,24 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/Subsystems.h"
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/SILOptions.h"
 #include "swift/Basic/FileTypes.h"
+#include "swift/Basic/InitializeLibSwift.h"
 #include "swift/Basic/LLVMInitialize.h"
 #include "swift/Frontend/DiagnosticVerifier.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
-#include "swift/SIL/SILRemarkStreamer.h"
-#include "swift/SILOptimizer/Analysis/Analysis.h"
-#include "swift/SILOptimizer/PassManager/Passes.h"
-#include "swift/SILOptimizer/PassManager/PassManager.h"
-#include "swift/Serialization/SerializedModuleLoader.h"
-#include "swift/Serialization/SerializedSILLoader.h"
-#include "swift/Serialization/SerializationOptions.h"
 #include "swift/IRGen/IRGenPublic.h"
 #include "swift/IRGen/IRGenSILPasses.h"
+#include "swift/SIL/SILRemarkStreamer.h"
+#include "swift/SILOptimizer/Analysis/Analysis.h"
+#include "swift/SILOptimizer/PassManager/PassManager.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/Serialization/SerializationOptions.h"
+#include "swift/Serialization/SerializedModuleLoader.h"
+#include "swift/Serialization/SerializedSILLoader.h"
+#include "swift/Subsystems.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileSystem.h"
@@ -352,6 +353,8 @@ int main(int argc, char **argv) {
   llvm::EnablePrettyStackTraceOnSigInfoForThisThread();
 
   llvm::cl::ParseCommandLineOptions(argc, argv, "Swift SIL optimizer\n");
+
+  initializeLibSwift();
 
   if (PrintStats)
     llvm::EnableStatistics();

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -138,6 +138,7 @@ class CMake(object):
         define("CMAKE_C_COMPILER:PATH", toolchain.cc)
         define("CMAKE_CXX_COMPILER:PATH", toolchain.cxx)
         define("CMAKE_LIBTOOL:PATH", toolchain.libtool)
+        define("CMAKE_AR:PATH", toolchain.ar)
 
         if args.cmake_generator == 'Xcode':
             define("CMAKE_CONFIGURATION_TYPES",

--- a/utils/swift_build_support/swift_build_support/toolchain.py
+++ b/utils/swift_build_support/swift_build_support/toolchain.py
@@ -62,6 +62,7 @@ _register("llvm_profdata", "llvm-profdata")
 _register("llvm_cov", "llvm-cov")
 _register("lipo", "lipo")
 _register("libtool", "libtool")
+_register("ar", "ar")
 _register("sccache", "sccache")
 _register("swiftc", "swiftc")
 

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -48,6 +48,7 @@ class CMakeTestCase(unittest.TestCase):
         return Namespace(host_cc="/path/to/clang",
                          host_cxx="/path/to/clang++",
                          host_libtool="/path/to/libtool",
+                         host_ar="/path/to/ar",
                          enable_asan=False,
                          enable_ubsan=False,
                          enable_tsan=False,
@@ -81,6 +82,7 @@ class CMakeTestCase(unittest.TestCase):
         toolchain.cc = args.host_cc
         toolchain.cxx = args.host_cxx
         toolchain.libtool = args.host_libtool
+        toolchain.ar = args.host_ar
         if args.distcc:
             toolchain.distcc = self.mock_distcc_path()
         if args.sccache:
@@ -97,6 +99,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_asan(self):
@@ -110,6 +113,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_ubsan(self):
@@ -123,6 +127,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_tsan(self):
@@ -136,6 +141,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_asan_ubsan(self):
@@ -150,6 +156,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_ubsan_tsan(self):
@@ -164,6 +171,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_asan_ubsan_tsan(self):
@@ -179,6 +187,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_lsan(self):
@@ -192,6 +201,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_coverage_sanitizer(self):
@@ -205,6 +215,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_export_compile_commands(self):
@@ -218,6 +229,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_distcc(self):
@@ -232,6 +244,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_sccache(self):
@@ -246,6 +259,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_launcher(self):
@@ -263,6 +277,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_xcode(self):
@@ -275,6 +290,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_CONFIGURATION_TYPES=" +
              "Debug;Release;MinSizeRel;RelWithDebInfo"])
 
@@ -288,6 +304,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_clang_user_visible_version(self):
@@ -300,6 +317,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DLLVM_VERSION_MAJOR:STRING=9",
              "-DLLVM_VERSION_MINOR:STRING=0",
              "-DLLVM_VERSION_PATCH:STRING=0",
@@ -318,6 +336,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_full(self):
@@ -341,6 +360,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_CONFIGURATION_TYPES=" +
              "Debug;Release;MinSizeRel;RelWithDebInfo",
              "-DLLVM_VERSION_MAJOR:STRING=9",


### PR DESCRIPTION
I did this by introducing a new thing called a "cmake product". I am going to
use this to split off all of the cmake products at the end of
build-script-impl.

Still a draft, just to show Dario and talk about it.
