### PR TITLE
ModuleInterface: move -user-module-version to a new field

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -20,6 +20,7 @@
 #define SWIFT_INTERFACE_FORMAT_VERSION_KEY "swift-interface-format-version"
 #define SWIFT_COMPILER_VERSION_KEY "swift-compiler-version"
 #define SWIFT_MODULE_FLAGS_KEY "swift-module-flags"
+#define SWIFT_MODULE_FLAGS_IGNORABLE_KEY "swift-module-flags-ignorable"
 
 namespace swift {
 
@@ -40,6 +41,10 @@ struct ModuleInterfaceOptions {
   /// generation time, re-applied to CompilerInvocation when reading
   /// back .swiftinterface and reconstructing .swiftmodule.
   std::string Flags;
+
+  /// Flags that should be emitted to the .swiftinterface file but are OK to be
+  /// ignored by the earlier version of the compiler.
+  std::string IgnorableFlags;
 
   /// Print SPI decls and attributes.
   bool PrintSPIs = false;

--- a/include/swift/Option/Options.h
+++ b/include/swift/Option/Options.h
@@ -41,6 +41,7 @@ namespace options {
     SwiftSymbolGraphExtractOption = (1 << 16),
     SwiftAPIDigesterOption = (1 << 17),
     NewDriverOnlyOption = (1 << 18),
+    ModuleInterfaceOptionIgnorable = (1 << 19),
   };
 
   enum ID {

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -51,6 +51,11 @@ def ArgumentIsPath : OptionFlag;
 // and read/parsed from there when reconstituting a .swiftmodule from it.
 def ModuleInterfaceOption : OptionFlag;
 
+// The option should be written into a .swiftinterface module interface file,
+// and read/parsed from there when reconstituting a .swiftmodule from it.
+// The option can be safely ignored by the older compiler.
+def ModuleInterfaceOptionIgnorable : OptionFlag;
+
 // The option causes the output of a supplementary output, or is the path option
 // for a supplementary output. E.g., `-emit-module` and `-emit-module-path`.
 def SupplementaryOutput : OptionFlag;
@@ -1184,7 +1189,7 @@ def working_directory_EQ : Joined<["-"], "working-directory=">,
   Alias<working_directory>;
 
 def user_module_version : Separate<["-"], "user-module-version">,
-  Flags<[FrontendOption, ModuleInterfaceOption, NewDriverOnlyOption]>,
+  Flags<[FrontendOption, ModuleInterfaceOptionIgnorable, NewDriverOnlyOption]>,
   HelpText<"Module version specified from Swift module authors">,
   MetaVarName<"<vers>">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -355,14 +355,26 @@ static void SaveModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
   if (!FOpts.InputsAndOutputs.hasModuleInterfaceOutputPath())
     return;
   ArgStringList RenderedArgs;
+  ArgStringList RenderedArgsIgnorable;
   for (auto A : Args) {
-    if (A->getOption().hasFlag(options::ModuleInterfaceOption))
+    if (A->getOption().hasFlag(options::ModuleInterfaceOptionIgnorable)) {
+      A->render(Args, RenderedArgsIgnorable);
+    } else if (A->getOption().hasFlag(options::ModuleInterfaceOption)) {
       A->render(Args, RenderedArgs);
+    }
   }
-  llvm::raw_string_ostream OS(Opts.Flags);
-  interleave(RenderedArgs,
-             [&](const char *Argument) { PrintArg(OS, Argument, StringRef()); },
-             [&] { OS << " "; });
+  {
+    llvm::raw_string_ostream OS(Opts.Flags);
+    interleave(RenderedArgs,
+               [&](const char *Argument) { PrintArg(OS, Argument, StringRef()); },
+               [&] { OS << " "; });
+  }
+  {
+    llvm::raw_string_ostream OS(Opts.IgnorableFlags);
+    interleave(RenderedArgsIgnorable,
+               [&](const char *Argument) { PrintArg(OS, Argument, StringRef()); },
+               [&] { OS << " "; });
+  }
 }
 
 static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -56,6 +56,10 @@ static void printToolVersionAndFlagsComment(raw_ostream &out,
       << ToolsVersion << "\n";
   out << "// " SWIFT_MODULE_FLAGS_KEY ": "
       << Opts.Flags << "\n";
+  if (!Opts.IgnorableFlags.empty()) {
+    out << "// " SWIFT_MODULE_FLAGS_IGNORABLE_KEY ": "
+        << Opts.IgnorableFlags << "\n";
+  }
 }
 
 std::string

--- a/test/ModuleInterface/ignorable-compiler-flags.swift
+++ b/test/ModuleInterface/ignorable-compiler-flags.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/textual)
+// RUN: %empty-directory(%t/module-cache)
+
+// RUN: echo "// swift-interface-format-version: 1.0" > %t/textual/Foo.swiftinterface
+// RUN: echo "// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name Foo" >> %t/textual/Foo.swiftinterface
+
+// RUN: %target-swift-ide-test -print-module-metadata -module-to-print Foo -I %t/textual -source-filename %s -module-cache-path %t/module-cache | %FileCheck %s --check-prefix=USER-MODULE-PRINT-NOT
+
+// RUN: echo "// swift-module-flags-ignorable: -enable-library-evolution -user-module-version 13.13 -future-flag1 3 -future-flag2 abc -future-flag3 /tmp/t.swift /tmp/u.swift -tbd-install_name=aaa" >> %t/textual/Foo.swiftinterface
+
+// RUN: %target-swift-ide-test -print-module-metadata -module-to-print Foo -I %t/textual -source-filename %s -module-cache-path %t/module-cache | %FileCheck %s --check-prefix=USER-MODULE-PRINT
+
+// USER-MODULE-PRINT-NOT-NOT: user module version: 13.13.0.0
+// USER-MODULE-PRINT: user module version: 13.13.0.0


### PR DESCRIPTION
Titled as "// swift-module-flags-ignorable:", this new field contains new
frontend arguments that can be safely ignored by the older version of the compiler.
For compilers that don't know the field at all, all arguments in it are ignored.

rdar://78233352