### PR TITLE
[Diagnostics] NFC: Add asserts to verify from/to types in contextual …

### DIFF
--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -608,7 +608,10 @@ public:
   ContextualFailure(const Solution &solution, ContextualTypePurpose purpose,
                     Type lhs, Type rhs, ConstraintLocator *locator)
       : FailureDiagnostic(solution, locator), CTP(purpose), RawFromType(lhs),
-        RawToType(rhs) {}
+        RawToType(rhs) {
+    assert(lhs && "Expected a valid 'from' type");
+    assert(rhs && "Expected a valid 'to' type");
+  }
 
   SourceLoc getLoc() const override;
 


### PR DESCRIPTION
…failure

We have a couple of reports that `ContextualFailure` crashes in
`trySequenceSubsequenceFixIts` even with the check for a valid
stdlib was added, which can only mean that from/to types are
somehow invalid.

Let's add a couple of asserts to verify their presence to aid us
in determining what expressions can cause the problem.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
