### PR TITLE
Fix missing musttail for dynamic replacement calls.

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2955,6 +2955,10 @@ void IRGenModule::emitDynamicReplacementOriginalFunctionThunk(SILFunction *f) {
       FunctionPointer(fnType, typeFnPtr, authInfo, signature)
           .getAsFunction(IGF),
       forwardedArgs);
+  Res->setTailCall();
+  if (f->isAsync()) {
+    Res->setTailCallKind(IGF.IGM.AsyncTailCallKind);
+  }
 
   if (implFn->getReturnType()->isVoidTy())
     IGF.Builder.CreateRetVoid();

--- a/test/IRGen/async_dynamic_replacement.swift
+++ b/test/IRGen/async_dynamic_replacement.swift
@@ -14,8 +14,7 @@ internal func _replacement_number() async -> Int {
 // rdar://78284346 - Dynamic replacement should use musttail
 //                   for tail calls from swifttailcc to swifttailcc
 // CHECK-LABEL: define {{.*}} swifttailcc void @"$s25async_dynamic_replacement01_C7_numberSiyYaFTI"
-// CHECK-NOT: musttail
-// CHECK: call swifttailcc void
+// CHECK: musttail call swifttailcc void
 // CHECK-NEXT: ret void
 
 public func calls_number() async -> Int {

--- a/test/IRGen/async_dynamic_replacement.swift
+++ b/test/IRGen/async_dynamic_replacement.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend %s -emit-ir -disable-objc-interop | %FileCheck %s
+
+// REQUIRES: concurrency
+
+public dynamic func number() async -> Int {
+    return 100
+}
+
+@_dynamicReplacement(for: number())
+internal func _replacement_number() async -> Int {
+    return 200
+}
+
+// rdar://78284346 - Dynamic replacement should use musttail
+//                   for tail calls from swifttailcc to swifttailcc
+// CHECK-LABEL: define {{.*}} swifttailcc void @"$s25async_dynamic_replacement01_C7_numberSiyYaFTI"
+// CHECK-NOT: musttail
+// CHECK: call swifttailcc void
+// CHECK-NEXT: ret void
+
+public func calls_number() async -> Int {
+  await number()
+}


### PR DESCRIPTION
When we make a tail call from swifttailcc → swifttailcc, the call should be marked musttail even when dynamic replacement is involved. However, this wasn't handled earlier, leading to an assertion failure when I tried to turn on musttail verification. (See https://github.com/apple/swift/pull/36805#issuecomment-844418793)

Fixes rdar://78284346 .