### PR TITLE
[SE-0313] Enable `nonisolated` by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,24 @@ CHANGELOG
 Swift 5.5
 ---------
 
+* [SE-0313][]:
+
+  Declarations inside an actor that would normally by actor-isolated can
+  explicitly become non-isolated using the `nonisolated` keyword. Non-isolated
+  declarations can be used to conform to synchronous protocol requirements:
+
+  ```swift
+  actor Account: Hashable {
+    let idNumber: Int
+    let balance: Double
+
+    nonisolated func hash(into hasher: inout Hasher) { // okay, non-isolated satisfies synchronous requirement
+      hasher.combine(idNumber) // okay, can reference idNumber from outside the let
+      hasher.combine(balance) // error: cannot synchronously access actor-isolated property
+    }
+  }
+  ```
+
 * Type names are no longer allowed as an argument to a subscript parameter that expects a metatype type
 
 ```swift
@@ -8516,6 +8534,7 @@ Swift 1.0
 [SE-0299]: <https://github.com/apple/swift-evolution/blob/main/proposals/0299-extend-generic-static-member-lookup.md>
 [SE-0306]: <https://github.com/apple/swift-evolution/blob/main/proposals/0306-actors.md>
 [SE-0310]: <https://github.com/apple/swift-evolution/blob/main/proposals/0310-effectful-readonly-properties.md>
+[SE-0313]: <https://github.com/apple/swift-evolution/blob/main/proposals/0313-actor-isolation-control.md>
 
 [SR-75]: <https://bugs.swift.org/browse/SR-75>
 [SR-106]: <https://bugs.swift.org/browse/SR-106>

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -632,7 +632,6 @@ DECL_ATTR(completionHandlerAsync, CompletionHandlerAsync,
 
 CONTEXTUAL_SIMPLE_DECL_ATTR(nonisolated, Nonisolated,
   DeclModifier | OnFunc | OnConstructor | OnVar | OnSubscript |
-  ConcurrencyOnly |
   ABIStableToAdd | ABIStableToRemove |
   APIBreakingToAdd | APIStableToRemove,
   112)

--- a/test/SourceKit/CodeComplete/complete_override.swift.response
+++ b/test/SourceKit/CodeComplete/complete_override.swift.response
@@ -216,6 +216,16 @@
     },
     {
       key.kind: source.lang.swift.keyword,
+      key.name: "nonisolated",
+      key.sourcetext: "nonisolated",
+      key.description: "nonisolated",
+      key.typename: "",
+      key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
+      key.num_bytes_to_erase: 0
+    },
+    {
+      key.kind: source.lang.swift.keyword,
       key.name: "nonmutating",
       key.sourcetext: "nonmutating",
       key.description: "nonmutating",

--- a/test/decl/class/actor/noconcurrency.swift
+++ b/test/decl/class/actor/noconcurrency.swift
@@ -1,8 +1,0 @@
-// RUN: %target-typecheck-verify-swift
-
-actor C {
-  nonisolated func f() { } // expected-error{{'nonisolated' modifier is only valid when experimental concurrency is enabled}}
-}
-
-
-


### PR DESCRIPTION
**Explanation**:  Based on the acceptance of [SE-0313](https://github.com/apple/swift-evolution/blob/main/proposals/0313-actor-isolation-control.md),  enable the `nonisolated` declaration modifier to make a declaration non-isolated.
**Scope**: Actor clients can now explicitly make declarations non-isolated rather than isolated.
**Radar/SR Issue**: rdar://78331401
**Risk**: Very low.
**Testing**: PR testing and CI on main.
**Original PR**: https://github.com/apple/swift/pull/37590
