### PR TITLE
[build-script] Begin tracking ar in build-script toolchains and start passing -DCMAKE_AR to cmake.

### DIFF
--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -138,6 +138,7 @@ class CMake(object):
         define("CMAKE_C_COMPILER:PATH", toolchain.cc)
         define("CMAKE_CXX_COMPILER:PATH", toolchain.cxx)
         define("CMAKE_LIBTOOL:PATH", toolchain.libtool)
+        define("CMAKE_AR:PATH", toolchain.ar)
 
         if args.cmake_generator == 'Xcode':
             define("CMAKE_CONFIGURATION_TYPES",

--- a/utils/swift_build_support/swift_build_support/toolchain.py
+++ b/utils/swift_build_support/swift_build_support/toolchain.py
@@ -62,6 +62,7 @@ _register("llvm_profdata", "llvm-profdata")
 _register("llvm_cov", "llvm-cov")
 _register("lipo", "lipo")
 _register("libtool", "libtool")
+_register("ar", "ar")
 _register("sccache", "sccache")
 _register("swiftc", "swiftc")
 

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -48,6 +48,7 @@ class CMakeTestCase(unittest.TestCase):
         return Namespace(host_cc="/path/to/clang",
                          host_cxx="/path/to/clang++",
                          host_libtool="/path/to/libtool",
+                         host_ar="/path/to/ar",
                          enable_asan=False,
                          enable_ubsan=False,
                          enable_tsan=False,
@@ -81,6 +82,7 @@ class CMakeTestCase(unittest.TestCase):
         toolchain.cc = args.host_cc
         toolchain.cxx = args.host_cxx
         toolchain.libtool = args.host_libtool
+        toolchain.ar = args.host_ar
         if args.distcc:
             toolchain.distcc = self.mock_distcc_path()
         if args.sccache:
@@ -97,6 +99,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_asan(self):
@@ -110,6 +113,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_ubsan(self):
@@ -123,6 +127,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_tsan(self):
@@ -136,6 +141,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_asan_ubsan(self):
@@ -150,6 +156,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_ubsan_tsan(self):
@@ -164,6 +171,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_asan_ubsan_tsan(self):
@@ -179,6 +187,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_lsan(self):
@@ -192,6 +201,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_coverage_sanitizer(self):
@@ -205,6 +215,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_export_compile_commands(self):
@@ -218,6 +229,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_distcc(self):
@@ -232,6 +244,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_sccache(self):
@@ -246,6 +259,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_launcher(self):
@@ -263,6 +277,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_xcode(self):
@@ -275,6 +290,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_CONFIGURATION_TYPES=" +
              "Debug;Release;MinSizeRel;RelWithDebInfo"])
 
@@ -288,6 +304,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_clang_user_visible_version(self):
@@ -300,6 +317,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DLLVM_VERSION_MAJOR:STRING=9",
              "-DLLVM_VERSION_MINOR:STRING=0",
              "-DLLVM_VERSION_PATCH:STRING=0",
@@ -318,6 +336,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
 
     def test_common_options_full(self):
@@ -341,6 +360,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
+             "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_CONFIGURATION_TYPES=" +
              "Debug;Release;MinSizeRel;RelWithDebInfo",
              "-DLLVM_VERSION_MAJOR:STRING=9",


### PR DESCRIPTION
I am currently working on being able to build cmake build-script projects as
always being cross compiled by using toolchain files (1). CMake expects in means
that I need to be able to specify CMAKE_AR in said toolchain.

(1) We still build for the host machine (of course), but instead of building it
normally with cmake, we build it as if we are cross compiling meaning we are
cross compiling for the host on the host. This makes it so that the host build
is no longer different from cross compilation builds making Swift's cross
compilation build more robust since it will be tested and less mysterious.
