### PR TITLE
[Parse] Parse generic argument list after '->'

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1391,6 +1391,7 @@ public:
                                       bool &reasync,
                                       SourceLoc &throws,
                                       bool &rethrows,
+                                      GenericParamList *&genericParams,
                                       TypeRepr *&retType);
 
   /// Parse 'async' and 'throws', if present, putting the locations of the

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -65,6 +65,9 @@ func zlop() -> some C & AnyObject & P {
   return D()
 }
 
+// Generalized opaque return types.
+func bar1() -> <T> () { } // TODO: make test do more than return unit when sematics of general synatax is implemented
+
 // Don't allow opaque types to propagate by inference into other global decls'
 // types
 struct Test {


### PR DESCRIPTION
In order to support generalized opaque return types like `func foo() -> <T> T where T.U == Int`, we need this syntax extension. See https://forums.swift.org/t/improving-the-ui-of-generics/22814.