### PR TITLE
[CSApply] Load l-value before wrapping it in try expression

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3412,7 +3412,21 @@ namespace {
     }
 
     Expr *visitAnyTryExpr(AnyTryExpr *expr) {
-      cs.setType(expr, cs.getType(expr->getSubExpr()));
+      auto *subExpr = expr->getSubExpr();
+      auto type = simplifyType(cs.getType(subExpr));
+
+      // Let's load the value associated with this try.
+      if (type->hasLValueType()) {
+        subExpr = coerceToType(subExpr, type->getRValueType(),
+                               cs.getConstraintLocator(subExpr));
+
+        if (!subExpr)
+          return nullptr;
+      }
+
+      cs.setType(expr, cs.getType(subExpr));
+      expr->setSubExpr(subExpr);
+
       return expr;
     }
 

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar78102266.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar78102266.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend %s -typecheck
+
+struct Info {
+}
+
+class Test {
+  var info: Info = Info()
+
+  init() throws {}
+}
+
+_ = try  Test().info // Ok
+_ = try! Test().info // Ok


### PR DESCRIPTION
Just like `try?` other types of try - `try` and `try!` have to load
the value before using it.

Resolve: rdar://78102266

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
