### PR TITLE
[AddSwift.cmake] Unbreak non-assertions build

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -254,7 +254,7 @@ function(_add_host_variant_c_compile_flags target)
   if(LLVM_ENABLE_ASSERTIONS)
     target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:-UNDEBUG>)
   else()
-    target_compile_definitions(${target} PRIVATE $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:-DNDEBUG>)
+    target_compile_definitions(${target} PRIVATE $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:NDEBUG>)
   endif()
 
   if(SWIFT_ENABLE_RUNTIME_FUNCTION_COUNTERS)


### PR DESCRIPTION
Fails to build with "error: macro name must be an identifier" due to trying to pass `-D-DNDEBUG` as compiler argument.
