### PR TITLE
Driver: correct profiling symbol preservation on Windows

### DIFF
--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -180,8 +180,9 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
                             Twine("clang_rt.profile-") +
                                 getTriple().getArchName() + ".lib");
     Arguments.push_back(context.Args.MakeArgString(LibProfile));
+    Arguments.push_back(context.Args.MakeArgString("-Xlinker"));
     Arguments.push_back(context.Args.MakeArgString(
-        Twine("-u", llvm::getInstrProfRuntimeHookVarName())));
+        Twine({"-include:", llvm::getInstrProfRuntimeHookVarName()})));
   }
 
   context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);

--- a/test/Driver/profiling.swift
+++ b/test/Driver/profiling.swift
@@ -52,7 +52,7 @@
 
 // WINDOWS: clang{{(\.exe)?"? }}
 // WINDOWS: lib{{(\\\\|/)}}swift{{(\\\\|/)}}clang{{(\\\\|/)}}lib{{(\\\\|/)}}windows{{(\\\\|/)}}clang_rt.profile-x86_64.lib
-// WINDOWS: -u__llvm_profile_runtime
+// WINDOWS: -Xlinker -include:__llvm_profile_runtime
 
 // WASI: clang{{(\.exe)?"? }}
 // WASI: lib{{(\\\\|/)}}swift{{(\\\\|/)}}clang{{(\\\\|/)}}lib{{(\\\\|/)}}wasi{{(\\\\|/)}}libclang_rt.profile-wasm32.a


### PR DESCRIPTION
The Windows linker does not support `-u`.  Furthermore, the compiler
driver does not forward the `-u` option to the linker.  We correctly use
the `/include:` option from the linker.  This should ensure that the
symbol is preserved even with `/opt:ref`.  This spelling should be
compatible with both lld and link, which should provide sufficient
portability.

Take the opportunity to make it more obvious that the two parameters are
creating a pair that will be concatenated by using a braced initializer.

See
https://docs.microsoft.com/en-us/cpp/build/reference/include-force-symbol-references?view=msvc-160
for more details on the option.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
