### PR TITLE
[concurrency] Avoid capacity in Deque on OpenBSD.

### DIFF
--- a/stdlib/public/Concurrency/Deque.swift
+++ b/stdlib/public/Concurrency/Deque.swift
@@ -228,8 +228,13 @@ struct _Deque<Element> {
       let object = _Storage._DequeBuffer.create(
         minimumCapacity: minimumCapacity,
         makingHeaderWith: {
-          _Storage._Header(
-            capacity: $0.capacity,
+#if os(OpenBSD)
+          let capacity = minimumCapacity
+#else
+          let capacity = $0.capacity
+#endif
+          return _Storage._Header(
+            capacity: capacity,
             count: count,
             startSlot: .zero)
         })


### PR DESCRIPTION
Deque creates a new ManagedBuffer when growing the underlying storage for
its elements. It sets the capacity in the header object, however it
initializes that field with ManagedBuffer.capacity.

ManagedBuffer.capacity is marked unavailable on OpenBSD because
ManagedBuffer unavoidably depends on malloc introspection which is
unavailable on this platform.

Obviously, we could mark the whole class as unavailable, but we don't
need to do anything so drastic since it appears though that Deque doesn't
unavoidably need this introspection. Therefore, on OpenBSD, just use
`minimumCapacity` when creating a new ManagedBuffer when growing and
moving elements.