### PR TITLE
[5.5] Windows Profiling Improvements

### DIFF
--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -180,8 +180,9 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
                             Twine("clang_rt.profile-") +
                                 getTriple().getArchName() + ".lib");
     Arguments.push_back(context.Args.MakeArgString(LibProfile));
+    Arguments.push_back(context.Args.MakeArgString("-Xlinker"));
     Arguments.push_back(context.Args.MakeArgString(
-        Twine("-u", llvm::getInstrProfRuntimeHookVarName())));
+        Twine({"-include:", llvm::getInstrProfRuntimeHookVarName()})));
   }
 
   context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);

--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -172,17 +172,10 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
   }
 
   if (context.Args.hasArg(options::OPT_profile_generate)) {
-    SmallString<128> LibProfile(SharedResourceDirPath);
-    llvm::sys::path::remove_filename(LibProfile); // remove platform name
-    llvm::sys::path::append(LibProfile, "clang", "lib");
-
-    llvm::sys::path::append(LibProfile, getTriple().getOSName(),
-                            Twine("clang_rt.profile-") +
-                                getTriple().getArchName() + ".lib");
-    Arguments.push_back(context.Args.MakeArgString(LibProfile));
     Arguments.push_back(context.Args.MakeArgString("-Xlinker"));
     Arguments.push_back(context.Args.MakeArgString(
         Twine({"-include:", llvm::getInstrProfRuntimeHookVarName()})));
+    Arguments.push_back(context.Args.MakeArgString("-lclang_rt.profile"));
   }
 
   context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);

--- a/test/Driver/profiling.swift
+++ b/test/Driver/profiling.swift
@@ -52,7 +52,7 @@
 
 // WINDOWS: clang{{(\.exe)?"? }}
 // WINDOWS: lib{{(\\\\|/)}}swift{{(\\\\|/)}}clang{{(\\\\|/)}}lib{{(\\\\|/)}}windows{{(\\\\|/)}}clang_rt.profile-x86_64.lib
-// WINDOWS: -u__llvm_profile_runtime
+// WINDOWS: -Xlinker -include:__llvm_profile_runtime
 
 // WASI: clang{{(\.exe)?"? }}
 // WASI: lib{{(\\\\|/)}}swift{{(\\\\|/)}}clang{{(\\\\|/)}}lib{{(\\\\|/)}}wasi{{(\\\\|/)}}libclang_rt.profile-wasm32.a

--- a/test/Driver/profiling.swift
+++ b/test/Driver/profiling.swift
@@ -51,8 +51,8 @@
 // LINUX: -u__llvm_profile_runtime
 
 // WINDOWS: clang{{(\.exe)?"? }}
-// WINDOWS: lib{{(\\\\|/)}}swift{{(\\\\|/)}}clang{{(\\\\|/)}}lib{{(\\\\|/)}}windows{{(\\\\|/)}}clang_rt.profile-x86_64.lib
 // WINDOWS: -Xlinker -include:__llvm_profile_runtime
+// WINDOWS: -lclang_rt.profile
 
 // WASI: clang{{(\.exe)?"? }}
 // WASI: lib{{(\\\\|/)}}swift{{(\\\\|/)}}clang{{(\\\\|/)}}lib{{(\\\\|/)}}wasi{{(\\\\|/)}}libclang_rt.profile-wasm32.a


### PR DESCRIPTION
This is a super low risk change for 5.5 to improve the clang (linker) driver invocation and linker options for enabling profiling support on Windows.  This only impacts the Windows toolchain, and under `-profile-generate` only.