### PR TITLE
[test] Isolate `build-script` calls in `skip-local-build.test-sh`

### DIFF
--- a/validation-test/BuildSystem/llvm-targets-options.test
+++ b/validation-test/BuildSystem/llvm-targets-options.test
@@ -1,6 +1,3 @@
-# Failing in CI with "%cmake is not an executable" rdar://78320684
-# UNSUPPORTED: OS=linux-gnu
-
 # REQUIRES: standalone_build
 
 # RUN: %empty-directory(%t)

--- a/validation-test/BuildSystem/skip-local-build.test-sh
+++ b/validation-test/BuildSystem/skip-local-build.test-sh
@@ -1,8 +1,10 @@
 # REQUIRES: standalone_build
-#
-# RUN: %swift_src_root/utils/build-script --dump-config --skip-local-build 2>&1 | %FileCheck %s -check-prefix=CONFIG
+
+# RUN: %empty-directory(%t)
+# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --cmake %cmake --dump-config --skip-local-build 2>&1 | %FileCheck %s -check-prefix=CONFIG
 # CONFIG: "skip_local_build": true
 
-# RUN: %swift_src_root/utils/build-script --dry-run --verbose-build --skip-local-build 2>&1 | %FileCheck %s -check-prefix=DRY
+# RUN: %empty-directory(%t)
+# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --cmake %cmake --dry-run --verbose-build --skip-local-build 2>&1 | %FileCheck %s -check-prefix=DRY
 # DRY: build-script-impl
 # DRY-SAME: --skip-local-build


### PR DESCRIPTION
...and reenable `llvm-targets-options.test` (previously disabled in #37573).

This will align `skip-local-build.test-sh` with the behaviour of the
other BuildSystem tests, by

* ensuring we use the `cmake` exposed in `lit.cfg`, so that under Linux we
don't attempt to rebuild it
* using a separate build folder for `build-script` invocations, so that
side effects will not affect the main invocation and other lit tests.

I expect these changes to prevent `llvm-targets-options.test` to fail in Linux
presets with an error related to cmake, e.g.

```
build-script: error: argument --cmake: /home/buildnode/jenkins/workspace/
oss-swift-package-linux-ubuntu-18_04/build/cmake-linux-x86_64/bin/cmake is not an executable
```

Addresses rdar://78320684