### PR TITLE
Disable swift-inspect build in presets

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -334,7 +334,8 @@ swiftpm
 swift-driver
 indexstore-db
 sourcekit-lsp
-swift-inspect
+# Failing to build in CI: rdar://78408440
+# swift-inspect
 swiftsyntax
 swiftsyntax-verify-generated-files
 
@@ -600,7 +601,8 @@ swiftsyntax-verify-generated-files
 swift-driver
 indexstore-db
 sourcekit-lsp
-swift-inspect
+# Failing to build in CI: rdar://78408440
+# swift-inspect
 install-llvm
 install-swift
 install-llbuild
@@ -1180,7 +1182,8 @@ lldb
 llbuild
 swiftpm
 swift-driver
-swift-inspect
+# Failing to build in CI: rdar://78408440
+# swift-inspect
 swiftsyntax
 skstresstester
 swiftevolve
@@ -1508,7 +1511,8 @@ libcxx
 # Build llbuild & swiftpm here
 llbuild
 swiftpm
-swift-inspect
+# Failing to build in CI: rdar://78408440
+# swift-inspect
 swift-driver
 swiftsyntax
 


### PR DESCRIPTION
It is failing to build on at least our package bots.

rdar://78408440