### PR TITLE
Add another troubleshooting step to build issues

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -322,6 +322,8 @@ care when moving across branches.
     output and link it, while highlighting the most important part of the
     build log in the post.
   - Include the output of `utils/update-checkout --dump-hashes`.
+ - If `util/build-script` raises an exception `AttributeError: 'NoneType' object has no attribute 'rfind'`,
+   you may need to accept the Xcode license agreement: `sudo xcodebuild -license accept` 
 
 [Swift JIRA]: https://bugs.swift.org
 


### PR DESCRIPTION
After installing Xcode and trying to compile the compiler, the build script may crash with a vague error message. This can be fixed by accepting the Xcode license