### PR TITLE
SourceKit: add a newline to logged messages

### DIFF
--- a/tools/SourceKit/lib/Support/Logging.cpp
+++ b/tools/SourceKit/lib/Support/Logging.cpp
@@ -63,7 +63,7 @@ Logger::~Logger() {
   OS << llvm::format("%7.4f] ", TR.getWallTime() - sBeginTR.getWallTime());
   OS << Msg.str();
 
-  fprintf(stderr, "%s: %s", LoggerName.c_str(), LogMsg.c_str());
+  fprintf(stderr, "%s: %s\n", LoggerName.c_str(), LogMsg.c_str());
 
 #if __APPLE__
   // Use the Apple System Log facility.


### PR DESCRIPTION
Add a trailing newline to log messages in SourceKit to ensure that
messages are not merged with surrounding messages.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
