### PR TITLE
Revert "Remove `@actorIndependent` attribute."

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -574,7 +574,12 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(actor, Actor,
   APIBreakingToAdd | APIBreakingToRemove,
   102)
 
-// Unused attribute 103
+DECL_ATTR(actorIndependent, ActorIndependent,
+  OnClass | OnStruct | OnEnum | OnExtension | OnFunc | OnConstructor |
+  OnVar | OnSubscript | ConcurrencyOnly |
+  ABIBreakingToAdd | ABIBreakingToRemove |
+  APIBreakingToAdd | APIBreakingToRemove,
+  103)
 
 SIMPLE_DECL_ATTR(globalActor, GlobalActor,
   OnClass | OnStruct | OnEnum | ConcurrencyOnly |

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -162,6 +162,10 @@ protected:
       kind : NumInlineKindBits
     );
 
+    SWIFT_INLINE_BITFIELD(ActorIndependentAttr, DeclAttribute, NumActorIndependentKindBits,
+      kind : NumActorIndependentKindBits
+    );
+
     SWIFT_INLINE_BITFIELD(OptimizeAttr, DeclAttribute, NumOptimizationModeBits,
       mode : NumOptimizationModeBits
     );
@@ -1209,6 +1213,25 @@ public:
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DAK_ReferenceOwnership;
+  }
+};
+
+/// Represents an actorIndependent/actorIndependent(unsafe) decl attribute.
+class ActorIndependentAttr : public DeclAttribute {
+public:
+  ActorIndependentAttr(SourceLoc atLoc, SourceRange range, ActorIndependentKind kind)
+      : DeclAttribute(DAK_ActorIndependent, atLoc, range, /*Implicit=*/false) {
+    Bits.ActorIndependentAttr.kind = unsigned(kind);
+  }
+
+  ActorIndependentAttr(ActorIndependentKind kind, bool IsImplicit=false)
+    : ActorIndependentAttr(SourceLoc(), SourceRange(), kind) {
+      setImplicit(IsImplicit);
+    }
+
+  ActorIndependentKind getKind() const { return ActorIndependentKind(Bits.ActorIndependentAttr.kind); }
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DAK_ActorIndependent;
   }
 };
 

--- a/include/swift/AST/AttrKind.h
+++ b/include/swift/AST/AttrKind.h
@@ -80,6 +80,16 @@ enum : unsigned { NumInlineKindBits =
   countBitsUsed(static_cast<unsigned>(InlineKind::Last_InlineKind)) };
 
 
+/// Indicates whether an actorIndependent decl is unsafe or not
+enum class ActorIndependentKind : uint8_t {
+  Safe = 0,
+  Unsafe = 1,
+  Last_InlineKind = Unsafe
+};
+
+enum : unsigned { NumActorIndependentKindBits =
+  countBitsUsed(static_cast<unsigned>(ActorIndependentKind::Last_InlineKind)) };
+
 /// This enum represents the possible values of the @_effects attribute.
 /// These values are ordered from the strongest guarantee to the weakest,
 /// so please do not reorder existing values.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4489,12 +4489,23 @@ ERROR(concurrent_value_inherit,none,
       "%select{| other than 'NSObject'}0",
       (bool, DeclName))
 
+ERROR(actorindependent_let,none,
+      "'@actorIndependent' is meaningless on 'let' declarations because "
+      "they are immutable",
+      ())
+ERROR(actorindependent_mutable_storage,none,
+      "'@actorIndependent' can not be applied to stored properties",
+      ())
+ERROR(actorindependent_local_var,none,
+      "'@actorIndependent' can not be applied to local variables",
+      ())
+
 ERROR(nonisolated_let,none,
       "'nonisolated' is meaningless on 'let' declarations because "
       "they are immutable",
       ())
 ERROR(nonisolated_mutable_storage,none,
-      "'nonisolated' can not be applied to stored properties",
+      "nonisolated' can not be applied to stored properties",
       ())
 ERROR(nonisolated_local_var,none,
       "'nonisolated' can not be applied to local variables",

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -790,6 +790,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
   case DAK_ReferenceOwnership:
   case DAK_Effects:
   case DAK_Optimize:
+  case DAK_ActorIndependent:
     if (DeclAttribute::isDeclModifier(getKind())) {
       Printer.printKeyword(getAttrName(), Options);
     } else if (Options.IsForSwiftInterface && getKind() == DAK_ResultBuilder) {
@@ -1176,6 +1177,15 @@ StringRef DeclAttribute::getAttrName() const {
       return "inline(__always)";
     }
     llvm_unreachable("Invalid inline kind");
+  }
+  case DAK_ActorIndependent: {
+    switch (cast<ActorIndependentAttr>(this)->getKind()) {
+    case ActorIndependentKind::Safe:
+      return "actorIndependent";
+    case ActorIndependentKind::Unsafe:
+      return "actorIndependent(unsafe)";
+    }
+    llvm_unreachable("Invalid actorIndependent kind");
   }
   case DAK_Optimize: {
     switch (cast<OptimizeAttr>(this)->getMode()) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8706,14 +8706,6 @@ void ClangImporter::Implementation::importAttributes(
         continue;
       }
 
-      // Hard-code @actorIndependent, until Objective-C clients start
-      // using nonisolated.
-      if (swiftAttr->getAttribute() == "@actorIndependent") {
-        auto attr = new (SwiftContext) NonisolatedAttr(/*isImplicit=*/true);
-        MappedDecl->getAttrs().add(attr);
-        continue;
-      }
-
       // Dig out a buffer with the attribute text.
       unsigned bufferID = getClangSwiftAttrSourceBuffer(
           swiftAttr->getAttribute());
@@ -9638,8 +9630,9 @@ ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
 
   // Mark the function transparent so that we inline it away completely.
   func->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
-  auto nonisolatedAttr = new (C) NonisolatedAttr(/*IsImplicit=*/true);
-  var->getAttrs().add(nonisolatedAttr);
+  auto actorIndependentAttr = new (C) ActorIndependentAttr(
+      ActorIndependentKind::Unsafe, /*IsImplicit=*/true);
+  var->getAttrs().add(actorIndependentAttr);
 
   // Set the function up as the getter.
   makeComputed(var, func, nullptr);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1784,6 +1784,45 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     break;
   }
 
+  case DAK_ActorIndependent: {
+    // if no option is provided, then it's the 'safe' version.
+    if (!consumeIf(tok::l_paren)) {
+      if (!DiscardAttribute) {
+        AttrRange = SourceRange(Loc, Tok.getRange().getStart());
+        Attributes.add(new (Context) ActorIndependentAttr(AtLoc, AttrRange, 
+                                                  ActorIndependentKind::Safe));
+      }
+      break;
+    }
+
+    // otherwise, make sure it looks like an identifier.
+    if (Tok.isNot(tok::identifier)) {
+      diagnose(Loc, diag::attr_expected_option_such_as, AttrName, "unsafe");
+      return false;
+    }
+
+    // make sure the identifier is 'unsafe'
+    if (Tok.getText() != "unsafe") {
+      diagnose(Loc, diag::attr_unknown_option, Tok.getText(), AttrName);
+      return false;
+    }
+
+    consumeToken(tok::identifier);
+    AttrRange = SourceRange(Loc, Tok.getRange().getStart());
+    
+    if (!consumeIf(tok::r_paren)) {
+      diagnose(Loc, diag::attr_expected_rparen, AttrName,
+               DeclAttribute::isDeclModifier(DK));
+      return false;
+    }
+
+    if (!DiscardAttribute)
+      Attributes.add(new (Context) ActorIndependentAttr(AtLoc, AttrRange, 
+                                                ActorIndependentKind::Unsafe));
+
+    break;
+  }
+
   case DAK_Optimize: {
     if (!consumeIf(tok::l_paren)) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1533,6 +1533,7 @@ namespace  {
     UNINTERESTING_ATTR(ProjectedValueProperty)
     UNINTERESTING_ATTR(OriginallyDefinedIn)
     UNINTERESTING_ATTR(Actor)
+    UNINTERESTING_ATTR(ActorIndependent)
     UNINTERESTING_ATTR(GlobalActor)
     UNINTERESTING_ATTR(Async)
     UNINTERESTING_ATTR(Spawn)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4284,6 +4284,14 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         break;
       }
 
+      case decls_block::ActorIndependent_DECL_ATTR: {
+        unsigned kind;
+        serialization::decls_block::ActorIndependentDeclAttrLayout::readRecord(
+            scratch, kind);
+        Attr = new (ctx) ActorIndependentAttr((ActorIndependentKind)kind);
+        break;
+      }
+
       case decls_block::Optimize_DECL_ATTR: {
         unsigned kind;
         serialization::decls_block::OptimizeDeclAttrLayout::readRecord(

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -1857,6 +1857,11 @@ namespace decls_block {
     BCFixed<2>  // inline value
   >;
 
+  using ActorIndependentDeclAttrLayout = BCRecordLayout<
+    ActorIndependent_DECL_ATTR,
+    BCFixed<1>  // unsafe flag
+  >;
+
   using OptimizeDeclAttrLayout = BCRecordLayout<
     Optimize_DECL_ATTR,
     BCFixed<2>  // optimize value

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2406,6 +2406,14 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
+    case DAK_ActorIndependent: {
+      auto *theAttr = cast<ActorIndependentAttr>(DA);
+      auto abbrCode = S.DeclTypeAbbrCodes[ActorIndependentDeclAttrLayout::Code];
+      ActorIndependentDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord,
+                                        abbrCode, (unsigned)theAttr->getKind());
+      return;
+    }
+
     case DAK_Optimize: {
       auto *theAttr = cast<OptimizeAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[OptimizeDeclAttrLayout::Code];

--- a/test/Concurrency/Runtime/actor_keypaths.swift
+++ b/test/Concurrency/Runtime/actor_keypaths.swift
@@ -9,23 +9,12 @@
 actor Page {
     let initialNumWords : Int
 
-    private let numWordsMem: UnsafeMutablePointer<Int>
-
-    nonisolated
-    var numWords : Int {
-      get { numWordsMem.pointee }
-      set { numWordsMem.pointee = newValue }
-    }
+    @actorIndependent(unsafe)
+    var numWords : Int
 
     init(_ words : Int) {
-        initialNumWords = words
-        numWordsMem = .allocate(capacity: 1)
-        numWordsMem.initialize(to: words)
         numWords = words
-    }
-
-    deinit {
-      numWordsMem.deallocate()
+        initialNumWords = words
     }
 }
 
@@ -40,7 +29,7 @@ actor Book {
         pages = stack
     }
 
-    nonisolated
+    @actorIndependent
     subscript(_ page : Int) -> Page {
         return pages[page]
     }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -118,7 +118,7 @@ extension MyActor {
     _ = text[0] // expected-error{{actor-isolated property 'text' can not be referenced from a non-isolated context}}
     _ = synchronous() // expected-error{{actor-isolated instance method 'synchronous()' can not be referenced from a non-isolated context}}
 
-    // nonisolated
+    // @actorIndependent
     _ = actorIndependentFunc(otherActor: self)
     _ = actorIndependentVar
 
@@ -127,7 +127,7 @@ extension MyActor {
     _ = self.actorIndependentVar
     self.actorIndependentVar = 17
 
-    // nonisolated on another actor
+    // @actorIndependent on another actor
     _ = otherActor.actorIndependentFunc(otherActor: self)
     _ = otherActor.actorIndependentVar
     otherActor.actorIndependentVar = 17
@@ -538,7 +538,7 @@ func testGlobalRestrictions(actor: MyActor) async {
   // expected-note@-1{{subscript access is 'async'}}
   _ = await actor[0]
 
-  // nonisolated declarations are permitted.
+  // @actorIndependent declarations are permitted.
   _ = actor.actorIndependentFunc(otherActor: actor)
   _ = actor.actorIndependentVar
   actor.actorIndependentVar = 5

--- a/test/Concurrency/actor_isolation_objc.swift
+++ b/test/Concurrency/actor_isolation_objc.swift
@@ -24,6 +24,8 @@ actor A {
 
     // expected-error@+1 {{cannot form key path to actor-isolated property 'computed'}}
     _ = #keyPath(A.computed) // expected-error{{argument of '#keyPath' refers to non-'@objc' property 'computed'}}
+
+    _ = #keyPath(A.z)
   }
 
   let w: Int = 0 // expected-note{{add '@objc' to expose this property to Objective-C}}
@@ -32,6 +34,8 @@ actor A {
 
   @objc var y: Int = 0 // expected-note{{add '@objc' to expose this property to Objective-C}}
   // expected-error@-1{{actor-isolated property 'y' cannot be @objc}}
+
+  @objc @actorIndependent(unsafe) var z: Int = 0
 
   // expected-note@+1 {{add '@objc' to expose this property to Objective-C}}
   @objc var computed : Int { // expected-error{{actor-isolated property 'computed' cannot be @objc}}

--- a/test/Concurrency/actor_isolation_unsafe.swift
+++ b/test/Concurrency/actor_isolation_unsafe.swift
@@ -26,7 +26,7 @@ struct S2_P1: P1 {
 }
 
 struct S3_P1: P1 {
-  nonisolated func onMainActor() { }
+  @actorIndependent func onMainActor() { }
 }
 
 struct S4_P1: P1 {
@@ -36,7 +36,7 @@ struct S4_P1: P1 {
 @MainActor(unsafe)
 protocol P2 {
   func f() // expected-note{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
-  nonisolated func g()
+  @actorIndependent func g()
 }
 
 struct S5_P2: P2 {
@@ -44,7 +44,7 @@ struct S5_P2: P2 {
   func g() { }
 }
 
-nonisolated func testP2(x: S5_P2, p2: P2) {
+@actorIndependent func testP2(x: S5_P2, p2: P2) {
   p2.f() // expected-error{{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
   p2.g() // OKAY
   x.f() // expected-error{{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
@@ -72,7 +72,7 @@ class C2: C1 {
 }
 
 class C3: C1 {
-  nonisolated override func method() {
+  @actorIndependent override func method() {
     globalSome() // expected-error{{call to global actor 'SomeGlobalActor'-isolated global function 'globalSome()' in a synchronous nonisolated context}}
   }
 }

--- a/test/Concurrency/actor_keypath_isolation.swift
+++ b/test/Concurrency/actor_keypath_isolation.swift
@@ -20,6 +20,8 @@ actor Door {
         get { 0 }
     }
 
+    @actorIndependent(unsafe) var unsafeIndependent : Int = 0
+
     @MainActor var globActor_mutable : Int = 0
     @MainActor let globActor_immutable : Int = 0
 
@@ -30,7 +32,7 @@ actor Door {
 
     @MainActor subscript(byName: String) -> Int { 0 }
 
-    nonisolated subscript(byIEEE754: Double) -> Int { 0 }
+    @actorIndependent subscript(byIEEE754: Double) -> Int { 0 }
 }
 
 func attemptAccess<T, V>(_ t : T, _ f : (T) -> V) -> V {
@@ -69,6 +71,7 @@ func tryKeypaths() {
     _ = \Door.unsafeGlobActor_mutable // okay for now
 
     _ = \Door.immutable
+    _ = \Door.unsafeIndependent
     _ = \Door.globActor_immutable
     _ = \Door.[4.2]
     _ = \Door.immutableNeighbor?.immutableNeighbor?.immutableNeighbor

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -255,20 +255,20 @@ func barSync() {
 @propertyWrapper
 @OtherGlobalActor
 struct WrapperOnActor<Wrapped> {
-  private var stored: Wrapped
+  @actorIndependent(unsafe) private var stored: Wrapped
 
   nonisolated init(wrappedValue: Wrapped) {
     stored = wrappedValue
   }
 
   @MainActor var wrappedValue: Wrapped {
-    get { }
-    set { }
+    get { stored }
+    set { stored = newValue }
   }
 
   @SomeGlobalActor var projectedValue: Wrapped {
-    get {  }
-    set { }
+    get { stored }
+    set { stored = newValue }
   }
 }
 
@@ -285,20 +285,20 @@ public struct WrapperOnMainActor<Wrapped> {
 
 @propertyWrapper
 actor WrapperActor<Wrapped> {
-  var storage: Wrapped
+  @actorIndependent(unsafe) var storage: Wrapped
 
   init(wrappedValue: Wrapped) {
     storage = wrappedValue
   }
 
   nonisolated var wrappedValue: Wrapped {
-    get { }
-    set { }
+    get { storage }
+    set { storage = newValue }
   }
 
   nonisolated var projectedValue: Wrapped {
-    get { }
-    set { }
+    get { storage }
+    set { storage = newValue }
   }
 }
 
@@ -344,20 +344,20 @@ actor WrapperActorBad1<Wrapped> {
 
 @propertyWrapper
 actor WrapperActorBad2<Wrapped> {
-  var storage: Wrapped
+  @actorIndependent(unsafe) var storage: Wrapped
 
   init(wrappedValue: Wrapped) {
     storage = wrappedValue
   }
 
   nonisolated var wrappedValue: Wrapped {
-    get { }
-    set { }
+    get { storage }
+    set { storage = newValue }
   }
 
   var projectedValue: Wrapped { // expected-error{{'projectedValue' property in property wrapper type 'WrapperActorBad2' cannot be isolated to the actor instance; consider 'nonisolated'}}
-    get {  }
-    set {  }
+    get { storage }
+    set { storage = newValue }
   }
 }
 
@@ -373,7 +373,7 @@ actor ActorWithWrapper {
 
 @propertyWrapper
 struct WrapperOnSomeGlobalActor<Wrapped> {
-  private var stored: Wrapped
+  @actorIndependent(unsafe) private var stored: Wrapped
 
   nonisolated init(wrappedValue: Wrapped) {
     stored = wrappedValue
@@ -441,20 +441,20 @@ class UGASubclass2: UGAClass {
 @propertyWrapper
 @OtherGlobalActor(unsafe)
 struct WrapperOnUnsafeActor<Wrapped> {
-  private var stored: Wrapped
+  @actorIndependent(unsafe) private var stored: Wrapped
 
   init(wrappedValue: Wrapped) {
     stored = wrappedValue
   }
 
   @MainActor(unsafe) var wrappedValue: Wrapped {
-    get { }
-    set { }
+    get { stored }
+    set { stored = newValue }
   }
 
   @SomeGlobalActor(unsafe) var projectedValue: Wrapped {
-    get { }
-    set { }
+    get { stored }
+    set { stored = newValue }
   }
 }
 
@@ -481,13 +481,14 @@ struct HasWrapperOnUnsafeActor {
 }
 
 // ----------------------------------------------------------------------
-// Nonisolated closures
+// Actor-independent closures
 // ----------------------------------------------------------------------
-@SomeGlobalActor func getGlobal7() -> Int { 7 }
+@SomeGlobalActor func getGlobal7() -> Int { 7 } // expected-note{{calls to global function 'getGlobal7()' from outside of its actor context are implicitly asynchronous}}
 func acceptClosure<T>(_: () -> T) { }
 
 @SomeGlobalActor func someGlobalActorFunc() async {
   acceptClosure { getGlobal7() } // okay
+  acceptClosure { @actorIndependent in getGlobal7() } // expected-error{{call to global actor 'SomeGlobalActor'-isolated global function 'getGlobal7()' in a synchronous nonisolated context}}
 }
 
 // ----------------------------------------------------------------------

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -97,13 +97,13 @@ import _Concurrency
 // CHECK-NEXT: {{^[}]$}}
 
 // CHECK-LABEL: protocol ProtocolWithSwiftAttributes {
-// CHECK-NEXT: nonisolated func independentMethod()
+// CHECK-NEXT: @actorIndependent func independentMethod()
 // CHECK-NEXT: {{^}} @objc @MainActor func mainActorMethod()
 // CHECK-NEXT: {{^}} @objc @MainActor func uiActorMethod()
 // CHECK-NEXT: {{^}} @objc optional func missingAtAttributeMethod()
 // CHECK-NEXT: {{^[}]$}}
 
-// CHECK: {{^}}nonisolated var MAGIC_NUMBER: Int32 { get }
+// CHECK: {{^}}@actorIndependent(unsafe) var MAGIC_NUMBER: Int32 { get }
 
 // CHECK: func doSomethingConcurrently(_ block: @Sendable () -> Void)
 

--- a/test/ModuleInterface/Inputs/MeowActor.swift
+++ b/test/ModuleInterface/Inputs/MeowActor.swift
@@ -3,7 +3,7 @@
   public static let shared = _Impl()
   
   public actor _Impl {
-    nonisolated
+    @actorIndependent
     public func enqueue(_ job: UnownedJob) {
       // DOES NOTHING! :)
     }

--- a/test/ModuleInterface/actor_isolation.swift
+++ b/test/ModuleInterface/actor_isolation.swift
@@ -11,7 +11,7 @@
 
 // CHECK: public actor SomeActor
 public actor SomeActor {
-  nonisolated func maine() { }
+  @actorIndependent func maine() { }
 }
 
 // CHECK: @globalActor public struct SomeGlobalActor

--- a/test/ModuleInterface/actor_protocol.swift
+++ b/test/ModuleInterface/actor_protocol.swift
@@ -14,13 +14,13 @@
 // CHECK: public actor PlainActorClass {
 @available(SwiftStdlib 5.5, *)
 public actor PlainActorClass {
-  nonisolated public func enqueue(_ job: UnownedJob) { }
+  @actorIndependent public func enqueue(_ job: UnownedJob) { }
 }
 
 // CHECK: public actor ExplicitActorClass : _Concurrency.Actor {
 @available(SwiftStdlib 5.5, *)
 public actor ExplicitActorClass : Actor {
-  nonisolated public func enqueue(_ job: UnownedJob) { }
+  @actorIndependent public func enqueue(_ job: UnownedJob) { }
 }
 
 // CHECK: public actor EmptyActor {
@@ -41,7 +41,7 @@ public protocol Cat : Actor {
 @available(SwiftStdlib 5.5, *)
 public actor HouseCat : Cat {
   nonisolated public func mew() {}
-  nonisolated public func enqueue(_ job: UnownedJob) { }
+  @actorIndependent public func enqueue(_ job: UnownedJob) { }
 }
 
 // CHECK: public protocol ToothyMouth {
@@ -54,5 +54,5 @@ public protocol ToothyMouth {
 @available(SwiftStdlib 5.5, *)
 public actor Lion : ToothyMouth, Actor {
   nonisolated public func chew() {}
-  nonisolated public func enqueue(_ job: UnownedJob) { }
+  @actorIndependent public func enqueue(_ job: UnownedJob) { }
 }

--- a/test/Serialization/attr-actorindependent.swift
+++ b/test/Serialization/attr-actorindependent.swift
@@ -9,29 +9,37 @@
 
 ///////////
 // This test checks for correct serialization & deserialization of
-// nonisolated
+// @actorIndependent and @actorIndependent(unsafe)
 
 // look for correct annotation after first deserialization's module print:
 
 // MODULE-CHECK:      actor UnsafeCounter {
-// MODULE-CHECK-NEXT:   var storage: Int
-// MODULE-CHECK-NEXT:   nonisolated var count: Int
+// MODULE-CHECK-NEXT:   @actorIndependent(unsafe) var storage: Int
+// MODULE-CHECK-NEXT:   @actorIndependent var count: Int
+// MODULE-CHECK-NEXT:   var actorCount: Int
 // MODULE-CHECK-NEXT:   init()
 // MODULE-CHECK-NEXT: }
 
-// and look for nonisolated
+// and look for unsafe and safe versions of decl in BC dump:
 
 // BC-CHECK-NOT: UnknownCode
-// BC-CHECK: <Nonisolated_DECL_ATTR abbrevid={{[0-9]+}} op0=0/>
+// BC-CHECK: <ActorIndependent_DECL_ATTR abbrevid={{[0-9]+}} op0=1/>
+// BC-CHECK: <ActorIndependent_DECL_ATTR abbrevid={{[0-9]+}} op0=0/>
 
 
 actor UnsafeCounter {
 
+  @actorIndependent(unsafe)
   private var storage : Int = 0
 
-  nonisolated
+  @actorIndependent
   var count : Int {
-    get { 0 }
-    set {  }
+    get { storage }
+    set { storage = newValue }
+  }
+
+  var actorCount : Int {
+    get { storage }
+    set { storage = newValue }
   }
 }

--- a/test/attr/actorindependent.swift
+++ b/test/attr/actorindependent.swift
@@ -1,0 +1,101 @@
+// RUN: %target-swift-frontend -typecheck -verify %s -enable-experimental-concurrency
+
+// REQUIRES: concurrency
+
+@actorIndependent func globalFunction() { }
+
+@actorIndependent var globalComputedProperty1: Int { 17 }
+
+@actorIndependent var globalComputedProperty2: Int {
+  get { 17 }
+  set { }
+}
+
+// expected-error@+1{{'@actorIndependent' can not be applied to stored properties}}
+@actorIndependent var globalStoredProperty: Int = 17
+
+struct X {
+  @actorIndependent
+  static var staticProperty1: Int {
+    return 5
+  }
+
+  @actorIndependent
+  static var staticProperty2: Int {
+    get { 5 }
+    set { }
+  }
+
+  // expected-error@+1{{'@actorIndependent' can not be applied to stored properties}}
+  @actorIndependent
+  static var storedStaticProperty: Int = 17
+}
+
+class C {
+  @actorIndependent
+  var property3: Int { 5 }
+
+  @actorIndependent
+  func f() { }
+}
+
+actor A {
+  var property: Int = 5
+
+  // expected-error@+1{{'@actorIndependent' can not be applied to stored properties}}
+  @actorIndependent
+  var property2: Int = 5
+
+  @actorIndependent
+  var property3: Int { 5 }
+
+  @actorIndependent
+  var property4: Int {
+    get { 5 }
+    set { }
+  }
+
+  @actorIndependent
+  static var staticProperty1: Int {
+    return 5
+  }
+
+  @actorIndependent
+  static var staticProperty2: Int {
+    get { 5 }
+    set { }
+  }
+
+  @actorIndependent init() { }
+
+  @actorIndependent
+  func synchronousFunc() { }
+
+  @actorIndependent
+  func asynchronousFunc() async { }
+
+  @actorIndependent
+  subscript(index: Int) -> String { "\(index)" }
+
+  @actorIndependent static func staticFunc() { }
+}
+
+actor FromProperty {
+  // expected-note@+2 1{{mutation of this property is only permitted within the actor}}
+  // expected-note@+1 2{{property declared here}}
+  var counter : Int = 0
+
+  // expected-error@+2{{actor-isolated property 'counter' can not be referenced from a non-isolated context}}
+  @actorIndependent
+  var halfCounter : Int { counter / 2 }
+
+  @actorIndependent
+  var ticks : Int {
+    // expected-error@+1{{actor-isolated property 'counter' can not be referenced from a non-isolated context}}
+    get { counter }
+    // expected-error@+1{{actor-isolated property 'counter' can not be mutated from a non-isolated context}}
+    set { counter = newValue }
+  }
+}
+
+@actorIndependent extension FromProperty { }


### PR DESCRIPTION
Temporarily revert apple/swift#37462, to allow existing code that uses `@actorIndependent` to continue to work with toolchains built from the main branch. (Until that code gets updated.)