### PR TITLE
Fix availability, should be SwiftStdlib 5.5 for all Task APIs

### DIFF
--- a/test/Concurrency/Runtime/async_let_throws.swift
+++ b/test/Concurrency/Runtime/async_let_throws.swift
@@ -14,7 +14,7 @@ func boom() throws -> Int {
   throw Boom()
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test() async {
   async let result = boom()
 
@@ -25,7 +25,7 @@ func test() async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test()

--- a/test/Concurrency/Runtime/async_task_async_let_child_cancel.swift
+++ b/test/Concurrency/Runtime/async_task_async_let_child_cancel.swift
@@ -9,7 +9,7 @@
 
 // REQUIRES: rdar_77671328
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func printWaitPrint(_ int: Int) async -> Int {
   print("start, cancelled:\(Task.isCancelled), id:\(int)")
   while !Task.isCancelled {
@@ -19,7 +19,7 @@ func printWaitPrint(_ int: Int) async -> Int {
   return int
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func test() async {
   let h = detach {
     await printWaitPrint(0)
@@ -70,7 +70,7 @@ func test() async {
   print("exit")
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await test()

--- a/test/Concurrency/Runtime/async_task_locals_basic.swift
+++ b/test/Concurrency/Runtime/async_task_locals_basic.swift
@@ -54,7 +54,7 @@ func printTaskLocalAsync<V>(
   printTaskLocal(key, expected, file: file, line: line)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
@@ -156,7 +156,7 @@ func nested_3_onlyTopContributes() async {
   printTaskLocal(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func nested_3_onlyTopContributesAsync() async {
   await printTaskLocalAsync(TL.$string) // CHECK: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
   await TL.$string.withValue("one") {
@@ -173,7 +173,7 @@ func nested_3_onlyTopContributesAsync() async {
   await printTaskLocalAsync(TL.$string) // CHECK-NEXT: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func nested_3_onlyTopContributesMixed() async {
   await printTaskLocalAsync(TL.$string) // CHECK: TaskLocal<String>(defaultValue: <undefined>) (<undefined>)
   await TL.$string.withValue("one") {

--- a/test/Concurrency/Runtime/async_task_locals_copy_to_async.swift
+++ b/test/Concurrency/Runtime/async_task_locals_copy_to_async.swift
@@ -8,7 +8,7 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 enum TL {
   @TaskLocal
   static var number: Int = 0
@@ -16,7 +16,7 @@ enum TL {
   static var other: Int = 0
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
@@ -34,7 +34,7 @@ func printTaskLocal<V>(
 
 // ==== ------------------------------------------------------------------------
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func copyTo_async() async {
   await TL.$number.withValue(1111) {
     printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (1111)
@@ -58,7 +58,7 @@ func copyTo_async() async {
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 func copyTo_async_noWait() async {
   print(#function)
   TL.$number.withValue(1111) {
@@ -80,7 +80,7 @@ func copyTo_async_noWait() async {
   await Task.sleep(2 * second)
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await copyTo_async()


### PR DESCRIPTION
All those APIs are 5.5.