### PR TITLE
GSB: Preserve source locations when rebuilding a generic signature

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2428,9 +2428,6 @@ WARNING(missing_protocol_refinement, none,
         "protocol %0 should be declared to refine %1 due to a same-type constraint on 'Self'",
         (ProtocolDecl *, ProtocolDecl *))
 
-ERROR(unsupported_recursive_requirements, none,
-      "requirement involves recursion that is not currently supported", ())
-
 ERROR(same_type_conflict,none,
       "%select{generic parameter |protocol |}0%1 cannot be equal to both "
       "%2 and %3", (unsigned, Type, Type, Type))

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -624,8 +624,7 @@ public:
   /// generic signature builder no longer has valid state.
   GenericSignature computeGenericSignature(
                       bool allowConcreteGenericParams = false,
-                      const ProtocolDecl *requirementSignatureSelfProto = nullptr,
-                      bool rebuildingWithoutRedundantConformances = false) &&;
+                      const ProtocolDecl *requirementSignatureSelfProto = nullptr) &&;
 
   /// Compute the requirement signature for the given protocol.
   static GenericSignature computeRequirementSignature(ProtocolDecl *proto);

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -342,10 +342,8 @@ private:
                                    UnresolvedHandlingKind unresolvedHandling);
 
   /// Add any conditional requirements from the given conformance.
-  ///
-  /// \returns \c true if an error occurred, \c false if not.
-  bool addConditionalRequirements(ProtocolConformanceRef conformance,
-                                  ModuleDecl *inferForModule, SourceLoc loc);
+  void addConditionalRequirements(ProtocolConformanceRef conformance,
+                                  ModuleDecl *inferForModule);
 
   /// Resolve the conformance of the given type to the given protocol when the
   /// potential archetype is known to be equivalent to a concrete type.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -685,7 +685,8 @@ private:
   void diagnoseProtocolRefinement(
       const ProtocolDecl *requirementSignatureSelfProto);
 
-  void diagnoseRedundantRequirements() const;
+  void diagnoseRedundantRequirements(
+      bool onlyDiagnoseExplicitConformancesImpliedByConcrete=false) const;
 
   void diagnoseConflictingConcreteTypeRequirements(
       const ProtocolDecl *requirementSignatureSelfProto);

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3943,7 +3943,7 @@ auto GenericSignatureBuilder::resolve(UnresolvedType paOrT,
   // Determine what kind of resolution we want.
   ArchetypeResolutionKind resolutionKind =
     ArchetypeResolutionKind::WellFormed;
-  if (!source.isExplicit() && source.isRecursive(*this))
+  if (source.isDerived() && source.isRecursive(*this))
     resolutionKind = ArchetypeResolutionKind::AlreadyKnown;
 
   Type type = paOrT.get<Type>();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2226,7 +2226,8 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
         using FloatingRequirementSource =
           GenericSignatureBuilder::FloatingRequirementSource;
         Builder.addRequirement(req, reqRepr,
-                               FloatingRequirementSource::forExplicit(reqRepr),
+                               FloatingRequirementSource::forExplicit(
+                                 reqRepr->getSeparatorLoc()),
                                nullptr, DC->getParentModule());
         return false;
       });
@@ -4297,7 +4298,8 @@ bool resolveDifferentiableAttrDerivativeGenericSignature(
 
               // Add requirement to generic signature builder.
               builder.addRequirement(
-                  req, reqRepr, FloatingRequirementSource::forExplicit(reqRepr),
+                  req, reqRepr, FloatingRequirementSource::forExplicit(
+                    reqRepr->getSeparatorLoc()),
                   nullptr, original->getModuleContext());
               return false;
             });

--- a/test/Generics/derived_via_concrete.swift
+++ b/test/Generics/derived_via_concrete.swift
@@ -26,16 +26,11 @@ func derivedViaConcreteX1<A, B>(_: A, _: B)
 // expected-warning@-1 {{redundant conformance constraint 'A' : 'U'}}
 // expected-note@-2 {{conformance constraint 'A' : 'U' implied here}}
 
-// FIXME: We should not diagnose 'B : P' as redundant, even though it
-// really is, because it was made redundant by an inferred requirement.
-
 // CHECK: Generic signature: <A, B where A : X<B>, B : P>
 func derivedViaConcreteX2<A, B>(_: A, _: B)
   where A : U, B : P, A : X<B> {}
 // expected-warning@-1 {{redundant conformance constraint 'A' : 'U'}}
 // expected-note@-2 {{conformance constraint 'A' : 'U' implied here}}
-// expected-warning@-3 {{redundant conformance constraint 'B' : 'P'}}
-// expected-note@-4 {{conformance constraint 'B' : 'P' implied here}}
 
 // CHECK: Generic signature: <A, B where A : Y<B>, B : C>
 func derivedViaConcreteY1<A, B>(_: A, _: B)
@@ -43,16 +38,11 @@ func derivedViaConcreteY1<A, B>(_: A, _: B)
 // expected-warning@-1 {{redundant conformance constraint 'A' : 'V'}}
 // expected-note@-2 {{conformance constraint 'A' : 'V' implied here}}
 
-// FIXME: We should not diagnose 'B : C' as redundant, even though it
-// really is, because it was made redundant by an inferred requirement.
-
 // CHECK: Generic signature: <A, B where A : Y<B>, B : C>
 func derivedViaConcreteY2<A, B>(_: A, _: B)
   where A : V, B : C, A : Y<B> {}
 // expected-warning@-1 {{redundant conformance constraint 'A' : 'V'}}
 // expected-note@-2 {{conformance constraint 'A' : 'V' implied here}}
-// expected-warning@-3 {{redundant superclass constraint 'B' : 'C'}}
-// expected-note@-4 {{superclass constraint 'B' : 'C' implied here}}
 
 // CHECK: Generic signature: <A, B where A : Z<B>, B : AnyObject>
 func derivedViaConcreteZ1<A, B>(_: A, _: B)
@@ -60,14 +50,8 @@ func derivedViaConcreteZ1<A, B>(_: A, _: B)
 // expected-warning@-1 {{redundant conformance constraint 'A' : 'W'}}
 // expected-note@-2 {{conformance constraint 'A' : 'W' implied here}}
 
-// FIXME: We should not diagnose 'B : AnyObject' as redundant, even
-// though it really is, because it was made redundant by an inferred
-// requirement.
-
 // CHECK: Generic signature: <A, B where A : Z<B>, B : AnyObject>
 func derivedViaConcreteZ2<A, B>(_: A, _: B)
   where A : W, B : AnyObject, A : Z<B> {}
 // expected-warning@-1 {{redundant conformance constraint 'A' : 'W'}}
 // expected-note@-2 {{conformance constraint 'A' : 'W' implied here}}
-// expected-warning@-3 {{redundant constraint 'B' : 'AnyObject'}}
-// expected-note@-4 {{constraint 'B' : 'AnyObject' implied here}}

--- a/test/Generics/rdar77462797.swift
+++ b/test/Generics/rdar77462797.swift
@@ -1,0 +1,38 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+
+protocol P {}
+
+protocol Q {
+  associatedtype T : P
+}
+
+class S<T : P> : Q {}
+
+struct G<X, Y> where X : Q {
+  // no redundancies
+  func foo1() where X == S<Y> {}
+  // CHECK: Generic signature: <X, Y where X == S<Y>, Y : P>
+
+  // 'Y : P' is redundant, but only via an inferred requirement from S<Y>,
+  // so we should not diagnose it
+  func foo2() where X == S<Y>, Y : P {}
+  // CHECK: Generic signature: <X, Y where X == S<Y>, Y : P>
+
+  // 'X : Q' is redundant
+  func foo3() where X : Q, X == S<Y>, Y : P {}
+  // expected-warning@-1 {{redundant conformance constraint 'X' : 'Q'}}
+  // expected-note@-2 {{conformance constraint 'X' : 'Q' implied here}}
+  // CHECK: Generic signature: <X, Y where X == S<Y>, Y : P>
+
+  // 'T.T : P' is redundant
+  func foo4<T : Q>(_: T) where X == S<Y>, T.T : P {}
+  // expected-warning@-1 {{redundant conformance constraint 'T.T' : 'P'}}
+  // expected-note@-2 {{conformance constraint 'T.T' : 'P' implied here}}
+  // CHECK: Generic signature: <X, Y, T where X == S<Y>, Y : P, T : Q>
+}
+
+func foo<X, Y>(_: X, _: Y) where X : Q, X : S<Y>, Y : P {}
+// expected-warning@-1 {{redundant conformance constraint 'X' : 'Q'}}
+// expected-note@-2 {{conformance constraint 'X' : 'Q' implied here}}
+// CHECK: Generic signature: <X, Y where X : S<Y>, Y : P>

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -328,9 +328,7 @@ struct X24<T: P20> : P24 {
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X24<τ_0_0.B>, τ_0_0.B : P20>
 protocol P25a {
   associatedtype A: P24 // expected-warning{{redundant conformance constraint 'Self.A' : 'P24'}}
-  // expected-note@-1 {{conformance constraint 'Self.B' : 'P20' implied here}}
   associatedtype B: P20 where A == X24<B> // expected-note{{conformance constraint 'Self.A' : 'P24' implied here}}
-  // expected-warning@-1 {{redundant conformance constraint 'Self.B' : 'P20'}}
 }
 
 // CHECK-LABEL: .P25b@
@@ -365,13 +363,8 @@ struct X26<T: X3> : P26 {
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X26<τ_0_0.B>, τ_0_0.B : X3>
 protocol P27a {
   associatedtype A: P26 // expected-warning{{redundant conformance constraint 'Self.A' : 'P26'}}
-  // expected-note@-1 {{superclass constraint 'Self.B' : 'X3' implied here}}
 
   associatedtype B: X3 where A == X26<B> // expected-note{{conformance constraint 'Self.A' : 'P26' implied here}}
-  // expected-warning@-1 {{redundant superclass constraint 'Self.B' : 'X3'}}
-
-  // FIXME: The above warning should not be emitted -- while the requirement
-  // really is redundant, it is made redundant by an inferred requirement.
 }
 
 // CHECK-LABEL: .P27b@

--- a/test/Generics/sr13884.swift
+++ b/test/Generics/sr13884.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-frontend -emit-ir -debug-generic-signatures %s 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
 
 public protocol P {
   associatedtype A : Q where A.B == Self
@@ -27,8 +27,10 @@ public class D : Q {
 public func takesBoth1<T : P & C>(_: T) {}
 // expected-warning@-1 {{redundant conformance constraint 'T' : 'P'}}
 // expected-note@-2 {{conformance constraint 'T' : 'P' implied here}}
+// expected-error@-3 {{same-type requirement makes generic parameter 'T' non-generic}}
 
 // CHECK-LABEL: Generic signature: <U where U == D.B>
 public func takesBoth2<U : C & P>(_: U) {}
 // expected-warning@-1 {{redundant conformance constraint 'U' : 'P'}}
 // expected-note@-2 {{conformance constraint 'U' : 'P' implied here}}
+// expected-error@-3 {{same-type requirement makes generic parameter 'U' non-generic}}

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -95,7 +95,7 @@ struct FloatElement : HasElt {
   typealias Element = Float
 }
 @_specialize(where T == FloatElement)
-@_specialize(where T == IntElement) // expected-error{{'T.Element' cannot be equal to both 'IntElement.Element' (aka 'Int') and 'Float'}}
+@_specialize(where T == IntElement) // FIXME e/xpected-error{{'T.Element' cannot be equal to both 'IntElement.Element' (aka 'Int') and 'Float'}}
 func sameTypeRequirement<T : HasElt>(_ t: T) where T.Element == Float {}
 
 @_specialize(where T == Sub)


### PR DESCRIPTION
When rebuilding a signature after dropping conformance requirements made redundant by superclass and concrete requirements, preserve source locations, and perform diagnostics on the rebuilt signature only.

This avoids some duplicated work and fixes an issue where we were too eager to diagnose redundant requirements.

Fixes rdar://problem/77462797.