### PR TITLE
[Async Refactoring] Support Obj-C style bool flag checks

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -4410,12 +4410,12 @@ struct AsyncHandlerParamDesc : public AsyncHandlerDesc {
   }
 };
 
-enum class ConditionType { INVALID, NIL, NOT_NIL };
+enum class ConditionType { NIL, NOT_NIL };
 
 /// Finds the `Subject` being compared to in various conditions. Also finds any
 /// pattern that may have a bound name.
 struct CallbackCondition {
-  ConditionType Type = ConditionType::INVALID;
+  Optional<ConditionType> Type;
   const Decl *Subject = nullptr;
   const Pattern *BindPattern = nullptr;
   // Bit of a hack. When the `Subject` is a `Result` type we use this to
@@ -4487,7 +4487,7 @@ struct CallbackCondition {
     }
   }
 
-  bool isValid() const { return Type != ConditionType::INVALID; }
+  bool isValid() const { return Type.hasValue(); }
 
   /// Given an `if` condition `Cond` and a set of `Decls`, find any
   /// `CallbackCondition`s in `Cond` that use one of those `Decls` and add them
@@ -4886,10 +4886,10 @@ private:
       ThenBlock = ElseBlock;
       ElseBlock = TempBlock;
     } else {
-      ConditionType CondType = ConditionType::INVALID;
+      Optional<ConditionType> CondType;
       for (auto &Entry : CallbackConditions) {
         if (IsResultParam || Entry.second.Subject != ErrParam) {
-          if (CondType == ConditionType::INVALID) {
+          if (!CondType) {
             CondType = Entry.second.Type;
           } else if (CondType != Entry.second.Type) {
             // Similar to the unknown conditions case. Add the whole if unless

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -4449,6 +4449,7 @@ struct CallbackCondition {
   CallbackCondition(const BinaryExpr *BE, const FuncDecl *Operator) {
     bool FoundNil = false;
     for (auto *Operand : {BE->getLHS(), BE->getRHS()}) {
+      Operand = Operand->getSemanticsProvidingExpr();
       if (isa<NilLiteralExpr>(Operand)) {
         FoundNil = true;
       } else if (auto *DRE = dyn_cast<DeclRefExpr>(Operand)) {
@@ -4896,9 +4897,9 @@ private:
         Exprs.push_back(BoolExpr);
 
         while (!Exprs.empty()) {
-          auto *Next = Exprs.pop_back_val();
+          auto *Next = Exprs.pop_back_val()->getSemanticsProvidingExpr();
           if (auto *ACE = dyn_cast<AutoClosureExpr>(Next))
-            Next = ACE->getSingleExpressionBody();
+            Next = ACE->getSingleExpressionBody()->getSemanticsProvidingExpr();
 
           if (auto *BE = dyn_cast_or_null<BinaryExpr>(Next)) {
             auto *Operator = isOperator(BE);

--- a/test/refactoring/ConvertAsync/Inputs/convert_bool_objc.h
+++ b/test/refactoring/ConvertAsync/Inputs/convert_bool_objc.h
@@ -1,0 +1,13 @@
+@import Foundation;
+
+@interface ClassWithHandlerMethods
++ (void)firstBoolFlagSuccess:(NSString *_Nonnull)str
+                  completion:(void (^_Nonnull)(NSString *_Nullable, BOOL, BOOL,
+                                               NSError *_Nullable))handler
+    __attribute__((swift_async_error(zero_argument, 2)));
+
++ (void)secondBoolFlagFailure:(NSString *_Nonnull)str
+                   completion:(void (^_Nonnull)(NSString *_Nullable, BOOL, BOOL,
+                                                NSError *_Nullable))handler
+    __attribute__((swift_async_error(nonzero_argument, 3)));
+@end

--- a/test/refactoring/ConvertAsync/Inputs/module.map
+++ b/test/refactoring/ConvertAsync/Inputs/module.map
@@ -1,0 +1,3 @@
+module ConvertBoolObjC {
+  header "convert_bool_objc.h"
+}

--- a/test/refactoring/ConvertAsync/convert_bool.swift
+++ b/test/refactoring/ConvertAsync/convert_bool.swift
@@ -1,0 +1,448 @@
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+
+// RUN: %empty-directory(%t)
+
+import Foundation
+import ConvertBoolObjC
+
+func boolWithErr(completion: (Bool, Error?) -> Void) {}
+func multipleBoolWithErr(completion: (String?, Bool, Bool, Error?) -> Void) {}
+func optionalBoolWithErr(completion: (String?, Bool?, Bool, Error?) -> Void) {}
+
+// All 7 of the below should generate the same refactoring.
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=BOOL-WITH-ERR %s
+boolWithErr { b, err in
+  if !b {
+    fatalError("oh no \(err!)")
+  }
+  print("not err")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=BOOL-WITH-ERR %s
+boolWithErr { b, err in
+  if b {
+    fatalError("oh no \(err!)")
+  }
+  print("not err")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=BOOL-WITH-ERR %s
+boolWithErr { b, err in
+  if !b && err != nil {
+    fatalError("oh no \(err!)")
+  }
+  print("not err")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=BOOL-WITH-ERR %s
+boolWithErr { b, err in
+  if b && err != nil {
+    fatalError("oh no \(err!)")
+  }
+  print("not err")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=BOOL-WITH-ERR %s
+boolWithErr { b, err in
+  if err != nil && b == false {
+    fatalError("oh no \(err!)")
+  }
+  print("not err")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=BOOL-WITH-ERR %s
+boolWithErr { b, err in
+  if b == true && err == nil {
+  } else {
+    fatalError("oh no \(err!)")
+  }
+  print("not err")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=BOOL-WITH-ERR %s
+boolWithErr { b, err in
+  if !b && err == nil {
+  } else {
+    fatalError("oh no \(err!)")
+  }
+  print("not err")
+}
+
+// BOOL-WITH-ERR:      do {
+// BOOL-WITH-ERR-NEXT:   let b = try await boolWithErr()
+// BOOL-WITH-ERR-NEXT:   print("not err")
+// BOOL-WITH-ERR-NEXT: } catch let err {
+// BOOL-WITH-ERR-NEXT:   fatalError("oh no \(err)")
+// BOOL-WITH-ERR-NEXT: }
+
+// These 3 should both generate the same refactoring.
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=BOOL-WITH-ERR2 %s
+boolWithErr { success, err in
+  if success == true && err == nil {
+    print("hi")
+  } else {
+    fatalError("oh no \(err!)")
+  }
+  print("not err")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=BOOL-WITH-ERR2 %s
+boolWithErr { success, err in
+  if success && err == nil {
+    print("hi")
+  } else {
+    fatalError("oh no \(err!)")
+  }
+  print("not err")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=BOOL-WITH-ERR2 %s
+boolWithErr { success, err in
+  if err == nil {
+    print("hi")
+  } else if !success {
+    fatalError("oh no \(err!)")
+  }
+  print("not err")
+}
+
+// BOOL-WITH-ERR2:      do {
+// BOOL-WITH-ERR2-NEXT:   let success = try await boolWithErr()
+// BOOL-WITH-ERR2-NEXT:   print("hi")
+// BOOL-WITH-ERR2-NEXT:   print("not err")
+// BOOL-WITH-ERR2-NEXT: } catch let err {
+// BOOL-WITH-ERR2-NEXT:   fatalError("oh no \(err)")
+// BOOL-WITH-ERR2-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=BOOL-WITH-ERR3 %s
+boolWithErr { failure, err in
+  if failure {
+    print("a \(err!)")
+  } else if .random() {
+    print("b")
+  } else {
+    print("c")
+  }
+}
+
+// BOOL-WITH-ERR3:      do {
+// BOOL-WITH-ERR3-NEXT:   let failure = try await boolWithErr()
+// BOOL-WITH-ERR3-NEXT:   if .random() {
+// BOOL-WITH-ERR3-NEXT:     print("b")
+// BOOL-WITH-ERR3-NEXT:   } else {
+// BOOL-WITH-ERR3-NEXT:     print("c")
+// BOOL-WITH-ERR3-NEXT:   }
+// BOOL-WITH-ERR3-NEXT: } catch let err {
+// BOOL-WITH-ERR3-NEXT:   print("a \(err)")
+// BOOL-WITH-ERR3-NEXT: }
+
+// Don't handle the below example as the force unwrap of err takes place under a different condition.
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=BOOL-DONT-HANDLE %s
+boolWithErr { success, err in
+  if !success {
+    if err != nil {
+      fatalError("oh no \(err!)")
+    }
+  }
+  if !success {
+    _ = err != nil ? fatalError("oh no \(err!)") : fatalError("some worries")
+  }
+  print("not err")
+}
+
+// BOOL-DONT-HANDLE:      let success = try await boolWithErr()
+// BOOL-DONT-HANDLE-NEXT: if !success {
+// BOOL-DONT-HANDLE-NEXT:   if <#err#> != nil {
+// BOOL-DONT-HANDLE-NEXT:     fatalError("oh no \(<#err#>!)")
+// BOOL-DONT-HANDLE-NEXT:   }
+// BOOL-DONT-HANDLE-NEXT: }
+// BOOL-DONT-HANDLE-NEXT: if !success {
+// BOOL-DONT-HANDLE-NEXT:   _ = <#err#> != nil ? fatalError("oh no \(<#err#>!)") : fatalError("some worries")
+// BOOL-DONT-HANDLE-NEXT: }
+// BOOL-DONT-HANDLE-NEXT: print("not err")
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=BOOL-DONT-HANDLE2 %s
+boolWithErr { success, err in
+  if !success {
+    func doThings() {
+      fatalError("oh no \(err!)")
+    }
+    doThings()
+  }
+  if !success {
+    let doThings = {
+      fatalError("oh no \(err!)")
+    }
+    doThings()
+  }
+  if !success {
+    while err != nil {
+      fatalError("oh no \(err!)")
+    }
+  }
+  if !success {
+    for x: Int in [] {
+      fatalError("oh no \(err!)")
+    }
+  }
+  print("not err")
+}
+
+// FIXME: The 'err' in doThings() should become a placeholder (rdar://78509286).
+// BOOL-DONT-HANDLE2:      let success = try await boolWithErr()
+// BOOL-DONT-HANDLE2-NEXT: if !success {
+// BOOL-DONT-HANDLE2-NEXT:   func doThings() {
+// BOOL-DONT-HANDLE2-NEXT:     fatalError("oh no \(err!)")
+// BOOL-DONT-HANDLE2-NEXT:   }
+// BOOL-DONT-HANDLE2-NEXT:   doThings()
+// BOOL-DONT-HANDLE2-NEXT: }
+// BOOL-DONT-HANDLE2-NEXT: if !success {
+// BOOL-DONT-HANDLE2-NEXT:   let doThings = {
+// BOOL-DONT-HANDLE2-NEXT:     fatalError("oh no \(<#err#>!)")
+// BOOL-DONT-HANDLE2-NEXT:   }
+// BOOL-DONT-HANDLE2-NEXT:   doThings()
+// BOOL-DONT-HANDLE2-NEXT: }
+// BOOL-DONT-HANDLE2-NEXT: if !success {
+// BOOL-DONT-HANDLE2-NEXT:   while <#err#> != nil {
+// BOOL-DONT-HANDLE2-NEXT:     fatalError("oh no \(<#err#>!)")
+// BOOL-DONT-HANDLE2-NEXT:   }
+// BOOL-DONT-HANDLE2-NEXT: }
+// BOOL-DONT-HANDLE2-NEXT: if !success {
+// BOOL-DONT-HANDLE2-NEXT:   for x: Int in [] {
+// BOOL-DONT-HANDLE2-NEXT:     fatalError("oh no \(<#err#>!)")
+// BOOL-DONT-HANDLE2-NEXT:   }
+// BOOL-DONT-HANDLE2-NEXT: }
+// BOOL-DONT-HANDLE2-NEXT: print("not err")
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=BOOL-DONT-HANDLE3 %s
+boolWithErr { success, err in
+  if !success {
+    fatalError("oh no maybe \(err)")
+  }
+  print("not err")
+}
+
+// err is not force unwrapped, so don't handle.
+
+// BOOL-DONT-HANDLE3:      let success = try await boolWithErr()
+// BOOL-DONT-HANDLE3-NEXT: if !success {
+// BOOL-DONT-HANDLE3-NEXT:   fatalError("oh no maybe \(<#err#>)")
+// BOOL-DONT-HANDLE3-NEXT: }
+// BOOL-DONT-HANDLE3-NEXT: print("not err")
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=BOOL-DONT-HANDLE4 %s
+boolWithErr { failure, err in
+  if failure {
+    print("a")
+  } else if .random() {
+    print("b \(err!)")
+  } else {
+    print("c")
+  }
+}
+
+// Don't handle the case where the err unwrap occurs in an unrelated else if
+// clause.
+
+// BOOL-DONT-HANDLE4:      let failure = try await boolWithErr()
+// BOOL-DONT-HANDLE4-NEXT: if failure {
+// BOOL-DONT-HANDLE4-NEXT:   print("a")
+// BOOL-DONT-HANDLE4-NEXT: } else if .random() {
+// BOOL-DONT-HANDLE4-NEXT:   print("b \(<#err#>!)")
+// BOOL-DONT-HANDLE4-NEXT: } else {
+// BOOL-DONT-HANDLE4-NEXT:   print("c")
+// BOOL-DONT-HANDLE4-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=BOOL-WITH-ERR-SILLY %s
+boolWithErr { success, err in
+  if success == false && err == nil {
+    print("ummm wat \(err!)")
+    return
+  }
+  print("not err")
+}
+
+// BOOL-WITH-ERR-SILLY:      let success = try await boolWithErr()
+// BOOL-WITH-ERR-SILLY-NEXT: if success == false && <#err#> == nil {
+// BOOL-WITH-ERR-SILLY-NEXT:   print("ummm wat \(<#err#>!)")
+// BOOL-WITH-ERR-SILLY-NEXT:   <#return#>
+// BOOL-WITH-ERR-SILLY-NEXT: }
+// BOOL-WITH-ERR-SILLY-NEXT: print("not err")
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=BOOL-WITH-ERR-SILLY2 %s
+boolWithErr { success, err in
+  if success {
+    print("ummm wat \(err!)")
+  } else {
+    print("ummm wat \(err!)")
+  }
+}
+
+// The err unwrap is in both blocks, so it's not clear what to classify as.
+
+// BOOL-WITH-ERR-SILLY2:      let success = try await boolWithErr()
+// BOOL-WITH-ERR-SILLY2-NEXT: if success {
+// BOOL-WITH-ERR-SILLY2-NEXT:   print("ummm wat \(<#err#>!)")
+// BOOL-WITH-ERR-SILLY2-NEXT: } else {
+// BOOL-WITH-ERR-SILLY2-NEXT:   print("ummm wat \(<#err#>!)")
+// BOOL-WITH-ERR-SILLY2-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=MULTI-BOOL-WITH-ERR %s
+multipleBoolWithErr { str, b1, b2, err in
+  if !b1 && !b2 {
+    print("a \(err!)")
+  }
+  if b1, b2 {
+    print("b \(err!)")
+  }
+  if !b1 {
+    print("c \(err!)")
+  }
+  if !b2 {
+    print("d \(err!)")
+  }
+}
+
+// Don't handle the case where multiple flag checks are done in a single
+// condition, because it's not exactly clear what the user is doing. It's a
+// little unfortunate that we'll allow multiple flag checks in seperate
+// conditions, but both of these cases seem somewhat uncommon, and there's no
+// real way to completely enforce a single flag param across e.g multiple calls
+// to the same function, so this is probably okay for now.
+
+// MULTI-BOOL-WITH-ERR:      do {
+// MULTI-BOOL-WITH-ERR-NEXT:   let (str, b1, b2) = try await multipleBoolWithErr()
+// MULTI-BOOL-WITH-ERR-NEXT: } catch let err {
+// MULTI-BOOL-WITH-ERR-NEXT:   if !<#b1#> && !<#b2#> {
+// MULTI-BOOL-WITH-ERR-NEXT:     print("a \(err)")
+// MULTI-BOOL-WITH-ERR-NEXT:   }
+// MULTI-BOOL-WITH-ERR-NEXT:   if <#b1#>, <#b2#> {
+// MULTI-BOOL-WITH-ERR-NEXT:     print("b \(err)")
+// MULTI-BOOL-WITH-ERR-NEXT:   }
+// MULTI-BOOL-WITH-ERR-NEXT:   print("c \(err)")
+// MULTI-BOOL-WITH-ERR-NEXT:   print("d \(err)")
+// MULTI-BOOL-WITH-ERR-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=OPT-BOOL-WITH-ERR %s
+optionalBoolWithErr { str, optBool, b, err in
+  if optBool != nil {
+    print("a \(err!)")
+  }
+  if optBool == nil {
+    print("b \(err!)")
+  }
+  if optBool == true {
+    print("c \(err!)")
+  }
+  if ((optBool) == (false)) {
+    print("d \(err!)")
+  }
+  if optBool == false {
+    print("e \(err)")
+  }
+  if optBool != true {
+    print("f \(err!)")
+  }
+  if b {
+    print("g \(err!)")
+  }
+}
+
+// It's a little unfortunate that print("a \(<#err#>!)") gets classified in the success
+// block below, but it doesn't seem like a case that's likely to come up, as optBool
+// would then be inaccessible in the error block.
+
+// OPT-BOOL-WITH-ERR:      do {
+// OPT-BOOL-WITH-ERR-NEXT:   let (str, optBool, b) = try await optionalBoolWithErr()
+// OPT-BOOL-WITH-ERR-NEXT:   print("a \(<#err#>!)")
+// OPT-BOOL-WITH-ERR-NEXT:   if <#optBool#> == false {
+// OPT-BOOL-WITH-ERR-NEXT:     print("e \(<#err#>)")
+// OPT-BOOL-WITH-ERR-NEXT:   }
+// OPT-BOOL-WITH-ERR-NEXT:   if <#optBool#> != true {
+// OPT-BOOL-WITH-ERR-NEXT:     print("f \(<#err#>!)")
+// OPT-BOOL-WITH-ERR-NEXT:   }
+// OPT-BOOL-WITH-ERR-NEXT: } catch let err {
+// OPT-BOOL-WITH-ERR-NEXT:   print("b \(err)")
+// OPT-BOOL-WITH-ERR-NEXT:   print("c \(err)")
+// OPT-BOOL-WITH-ERR-NEXT:   print("d \(err)")
+// OPT-BOOL-WITH-ERR-NEXT:   print("g \(err)")
+// OPT-BOOL-WITH-ERR-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=OBJC-BOOL-WITH-ERR %s
+ClassWithHandlerMethods.firstBoolFlagSuccess("") { str, success, unrelated, err in
+  if !unrelated {
+    print(err!)
+  }
+  if !success {
+    print("oh no")
+  }
+  if !success {
+    print(err!)
+  }
+  if success {
+    print("woo")
+  }
+  if str != nil {
+    print("also woo")
+  }
+}
+
+// OBJC-BOOL-WITH-ERR:      do {
+// OBJC-BOOL-WITH-ERR-NEXT:   let (str, success, unrelated) = try await ClassWithHandlerMethods.firstBoolFlagSuccess("")
+// OBJC-BOOL-WITH-ERR-NEXT:   if !unrelated {
+// OBJC-BOOL-WITH-ERR-NEXT:     print(<#err#>!)
+// OBJC-BOOL-WITH-ERR-NEXT:   }
+// OBJC-BOOL-WITH-ERR-NEXT:   print("woo")
+// OBJC-BOOL-WITH-ERR-NEXT:   print("also woo")
+// OBJC-BOOL-WITH-ERR-NEXT: } catch let err {
+// OBJC-BOOL-WITH-ERR-NEXT:   print("oh no")
+// OBJC-BOOL-WITH-ERR-NEXT:   print(err)
+// OBJC-BOOL-WITH-ERR-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -sdk %clang-importer-sdk-path | %FileCheck -check-prefix=OBJC-BOOL-WITH-ERR2 %s
+ClassWithHandlerMethods.secondBoolFlagFailure("") { str, unrelated, failure, err in
+  if unrelated {
+    print(err!)
+  }
+  if failure {
+    print("oh no")
+  }
+  if failure {
+    print(err!)
+  }
+  if !failure {
+    print("woo")
+  }
+  if str != nil {
+    print("also woo")
+  }
+  if failure && err == nil {
+    print("wat")
+  }
+  if failure && err != nil {
+    print("neat")
+  }
+  if failure, let err = err {
+    print("neato")
+  }
+}
+
+// OBJC-BOOL-WITH-ERR2:      do {
+// OBJC-BOOL-WITH-ERR2-NEXT:   let (str, unrelated, failure) = try await ClassWithHandlerMethods.secondBoolFlagFailure("")
+// OBJC-BOOL-WITH-ERR2-NEXT:   if unrelated {
+// OBJC-BOOL-WITH-ERR2-NEXT:     print(<#err#>!)
+// OBJC-BOOL-WITH-ERR2-NEXT:   }
+// OBJC-BOOL-WITH-ERR2-NEXT:   print("woo")
+// OBJC-BOOL-WITH-ERR2-NEXT:   print("also woo")
+// OBJC-BOOL-WITH-ERR2-NEXT:   if failure && <#err#> == nil {
+// OBJC-BOOL-WITH-ERR2-NEXT:     print("wat")
+// OBJC-BOOL-WITH-ERR2-NEXT:   }
+// OBJC-BOOL-WITH-ERR2-NEXT: } catch let err {
+// OBJC-BOOL-WITH-ERR2-NEXT:   print("oh no")
+// OBJC-BOOL-WITH-ERR2-NEXT:   print(err)
+// OBJC-BOOL-WITH-ERR2-NEXT:   print("neat")
+// OBJC-BOOL-WITH-ERR2-NEXT:   print("neato")
+// OBJC-BOOL-WITH-ERR2-NEXT: }

--- a/test/refactoring/ConvertAsync/convert_params_single.swift
+++ b/test/refactoring/ConvertAsync/convert_params_single.swift
@@ -313,7 +313,7 @@ withError { res, err in
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNBOUND %s
 withError { res, err in
   print("before")
-  if res != nil && err == nil {
+  if ((res != (nil)) && err == nil) {
     print("got result \(res!)")
   } else {
     print("got error \(err!)")

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -124,6 +124,13 @@ static llvm::cl::opt<bool> EnableExperimentalConcurrency(
     "enable-experimental-concurrency",
     llvm::cl::desc("Whether to enable experimental concurrency or not"));
 
+static llvm::cl::opt<std::string>
+    SDK("sdk", llvm::cl::desc("Path to the SDK to build against"));
+
+static llvm::cl::list<std::string>
+    ImportPaths("I",
+                llvm::cl::desc("Add a directory to the import search path"));
+
 enum class DumpType {
   REWRITTEN,
   JSON,
@@ -274,6 +281,10 @@ int main(int argc, char *argv[]) {
   Invocation.setMainExecutablePath(
     llvm::sys::fs::getMainExecutable(argv[0],
     reinterpret_cast<void *>(&anchorForGetMainExecutable)));
+
+  Invocation.setSDKPath(options::SDK);
+  Invocation.setImportSearchPaths(options::ImportPaths);
+
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(
       options::SourceFilename);
   Invocation.getLangOptions().AttachCommentsToDecls = true;


### PR DESCRIPTION
Add an additional case to `CallbackCondition` to support boolean checks, and add the necessary classification logic to determine whether a bool flag check is for a success or failure path.

The logic currently first checks to see if the async alternative has a convention that specifies which parameter the flag is, and whether it's a success or failure flag. If so, it classifies the flag check accordingly. If there's no async convention specified, we use a heuristic to see if the error parameter is force unwrapped in the failure block. If so, we treat that as the error path. If there's no force unwrap of the error, we leave the condition unhandled.

rdar://74063899