### PR TITLE
Disable test/Sanitizers/tsan/async_taskgroup_next.swift

### DIFF
--- a/test/Sanitizers/tsan/async_taskgroup_next.swift
+++ b/test/Sanitizers/tsan/async_taskgroup_next.swift
@@ -1,5 +1,8 @@
 // RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch -parse-as-library -sanitize=thread)
 
+// Segfaulted in CI on TSan bot. rdar://78264164
+// REQUIRES: rdar78264164
+
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: libdispatch


### PR DESCRIPTION
Segfaulted in CI

rdar://78264164
(cherry picked from commit 30c957b05c9e7521bf043b62d61148a68b588f0a)
