### PR TITLE
Disable runtime unit test with use_os_stdlib

### DIFF
--- a/test/Unit/lit.cfg
+++ b/test/Unit/lit.cfg
@@ -90,3 +90,8 @@ if 'use_os_stdlib' not in lit_config.params:
     # to handle dependencies of the dylibs loaded by `SwiftRuntimeTests`
     # (for which we cannot run `swift-rpathize.py`)
     config.environment['DYLD_LIBRARY_PATH'] = os.path.join(test_resource_dir, 'macosx')
+
+if 'use_os_stdlib' in lit_config.params:
+    # Runtime tests are failing in back-deployment due to missing _Concurrency.
+    # rdar://78139218
+    config.excludes += ['runtime']


### PR DESCRIPTION
This test is failing in back deployment testing due to it failing to
find _Concurrency. Disable the test until we can figure out a more
targeted solution.

rdar://78139218