### PR TITLE
Disable test/Interpreter/async_resilience.swift for back deployment

### DIFF
--- a/test/Interpreter/async_resilience.swift
+++ b/test/Interpreter/async_resilience.swift
@@ -14,7 +14,8 @@
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
-
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 
 import resilient_async
 


### PR DESCRIPTION
Match the other Interpreter async tests and disable this test case for
back deployment scenarios.

rdar://78464319