### PR TITLE
[5.5][CSApply] Load l-value before wrapping it in try expression

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3417,7 +3417,21 @@ namespace {
     }
 
     Expr *visitAnyTryExpr(AnyTryExpr *expr) {
-      cs.setType(expr, cs.getType(expr->getSubExpr()));
+      auto *subExpr = expr->getSubExpr();
+      auto type = simplifyType(cs.getType(subExpr));
+
+      // Let's load the value associated with this try.
+      if (type->hasLValueType()) {
+        subExpr = coerceToType(subExpr, type->getRValueType(),
+                               cs.getConstraintLocator(subExpr));
+
+        if (!subExpr)
+          return nullptr;
+      }
+
+      cs.setType(expr, cs.getType(subExpr));
+      expr->setSubExpr(subExpr);
+
       return expr;
     }
 

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar78102266.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar78102266.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend %s -typecheck
+
+struct Info {
+}
+
+class Test {
+  var info: Info = Info()
+
+  init() throws {}
+}
+
+_ = try  Test().info // Ok
+_ = try! Test().info // Ok


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/37598

---

- Explanation:

Fixes a crash in SILGen due to incorrect type-checked AST
produced by the solver. Members have to be loaded before
the can be used by `try` variants.

Just like `try?` other types of try - `try` and `try!` have to load
the value before using it.

- Scope: `try` expressions wrapping loadable member reference

- Main Branch PR: https://github.com/apple/swift/pull/37598

- Resolves: rdar://78102266

- Risk: Low

- Reviewed By: @hborla  

- Testing: Regression tests added to the suite


Resolve: rdar://78102266
(cherry picked from commit 8ab8b2e3e9107f32ea13efd38e270ff3b45d324a)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
