### PR TITLE
[5.5][Property Wrappers] Always check actor isolation and initializer effects in `PropertyWrapperInitializerInfoRequest`.

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1792,31 +1792,6 @@ public:
     });
   }
 
-  /// If the given pattern binding has a property wrapper, check the
-  /// isolation and effects of the backing storage initializer.
-  void checkPropertyWrapperBackingInitializer(PatternBindingDecl *PBD) {
-    auto singleVar = PBD->getSingleVar();
-    if (!singleVar)
-      return;
-
-    if (!singleVar->hasAttachedPropertyWrapper())
-      return;
-
-    auto *backingVar = singleVar->getPropertyWrapperBackingProperty();
-    if (!backingVar)
-      return;
-
-    auto backingPBD = backingVar->getParentPatternBinding();
-    if (!backingPBD)
-      return;
-
-    auto initInfo = singleVar->getPropertyWrapperInitializerInfo();
-    if (auto initializer = initInfo.getInitFromWrappedValue()) {
-      checkPropertyWrapperActorIsolation(backingPBD, initializer);
-      TypeChecker::checkPropertyWrapperEffects(backingPBD, initializer);
-    }
-  }
-
   void visitPatternBindingDecl(PatternBindingDecl *PBD) {
     DeclContext *DC = PBD->getDeclContext();
 
@@ -1963,8 +1938,6 @@ public:
         }
       }
     }
-
-    checkPropertyWrapperBackingInitializer(PBD);
   }
 
   void visitSubscriptDecl(SubscriptDecl *SD) {

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2875,10 +2875,16 @@ PropertyWrapperInitializerInfoRequest::evaluate(Evaluator &evaluator,
       if (!parentPBD->isInitialized(patternNumber) && wrapperInfo.defaultInit) {
         // FIXME: Record this expression somewhere so that DI can perform the
         // initialization itself.
-        Expr *initializer = nullptr;
-        typeCheckSynthesizedWrapperInitializer(var, initializer);
-        pbd->setInit(0, initializer);
+        Expr *defaultInit = nullptr;
+        typeCheckSynthesizedWrapperInitializer(var, defaultInit);
+        pbd->setInit(0, defaultInit);
         pbd->setInitializerChecked(0);
+
+        // If a static, global, or local wrapped property has a default
+        // initializer, this is the only initializer that will be used.
+        if (var->isStatic() || !dc->isTypeContext()) {
+          initializer = defaultInit;
+        }
       } else if (var->hasObservers() && !dc->isTypeContext()) {
         var->diagnose(diag::observingprop_requires_initializer);
       }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2583,6 +2583,11 @@ static void typeCheckSynthesizedWrapperInitializer(VarDecl *wrappedVar,
           dyn_cast_or_null<Initializer>(parentPBD->getInitContext(i))) {
     TypeChecker::contextualizeInitializer(initializerContext, initializer);
   }
+
+  auto *backingVar = wrappedVar->getPropertyWrapperBackingProperty();
+  auto *backingPBD = backingVar->getParentPatternBinding();
+  checkPropertyWrapperActorIsolation(backingPBD, initializer);
+  TypeChecker::checkPropertyWrapperEffects(backingPBD, initializer);
 }
 
 static PropertyWrapperMutability::Value

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -374,6 +374,13 @@ actor WrapperActorBad2<Wrapped> {
   }
 }
 
+@propertyWrapper
+struct WrapperWithMainActorDefaultInit {
+  var wrappedValue: Int { fatalError() }
+
+  @MainActor init() {} // expected-note {{calls to initializer 'init()' from outside of its actor context are implicitly asynchronous}}
+}
+
 actor ActorWithWrapper {
   @WrapperOnActor var synced: Int = 0
   // expected-note@-1 3{{property declared here}}
@@ -381,6 +388,8 @@ actor ActorWithWrapper {
     _ = synced // expected-error{{'synced' isolated to global actor}}
     _ = $synced // expected-error{{'$synced' isolated to global actor}}
     _ = _synced // expected-error{{'_synced' isolated to global actor}}
+
+    @WrapperWithMainActorDefaultInit var value: Int // expected-error {{call to main actor-isolated initializer 'init()' in a synchronous actor-isolated context}}
   }
 }
 

--- a/test/SILGen/property_wrapper_local.swift
+++ b/test/SILGen/property_wrapper_local.swift
@@ -206,6 +206,12 @@ struct DefaultInit {
   }
 }
 
+@propertyWrapper
+struct DefaultWrappedValue {
+  // CHECK-LABEL: sil hidden [ossa] @$s22property_wrapper_local19DefaultWrappedValueVACycfC : $@convention(method) (@thin DefaultWrappedValue.Type) -> DefaultWrappedValue
+  var wrappedValue: Int = 10
+}
+
 // CHECK-LABEL: sil hidden [ossa] @$s22property_wrapper_local20testLocalDefaultInityyF : $@convention(thin) () -> ()
 func testLocalDefaultInit() {
   // CHECK: function_ref @$s22property_wrapper_local11DefaultInitVACycfC : $@convention(method) (@thin DefaultInit.Type) -> DefaultInit
@@ -216,4 +222,7 @@ func testLocalDefaultInit() {
 
   // CHECK: function_ref @$s22property_wrapper_local11DefaultInitVACycfC : $@convention(method) (@thin DefaultInit.Type) -> DefaultInit
   @DefaultInit() var y: Int
+
+  // CHECK: function_ref @$s22property_wrapper_local19DefaultWrappedValueVACycfC : $@convention(method) (@thin DefaultWrappedValue.Type) -> DefaultWrappedValue
+  @DefaultWrappedValue var w: Int
 }

--- a/test/SILGen/property_wrapper_local.swift
+++ b/test/SILGen/property_wrapper_local.swift
@@ -190,3 +190,30 @@ func testCaptures() {
   // closure #1 in testCaptures()
   // CHECK-LABEL: sil private [ossa] @$s22property_wrapper_local12testCapturesyyFyycfU_ : $@convention(thin) (@guaranteed { var Wrapper<Int> }) -> ()
 }
+
+@propertyWrapper
+struct DefaultInit {
+  var wrappedValue: Int
+
+  // CHECK-LABEL: sil hidden [ossa] @$s22property_wrapper_local11DefaultInitVACycfC : $@convention(method) (@thin DefaultInit.Type) -> DefaultInit
+  init() {
+    self.wrappedValue = 0
+  }
+
+  // CHECK-LABEL: sil hidden [ossa] @$s22property_wrapper_local11DefaultInitV5valueACSi_tcfC : $@convention(method) (Int, @thin DefaultInit.Type) -> DefaultInit
+  init(value: Int) {
+    self.wrappedValue = value
+  }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s22property_wrapper_local20testLocalDefaultInityyF : $@convention(thin) () -> ()
+func testLocalDefaultInit() {
+  // CHECK: function_ref @$s22property_wrapper_local11DefaultInitVACycfC : $@convention(method) (@thin DefaultInit.Type) -> DefaultInit
+  @DefaultInit var x: Int
+
+  // CHECK: function_ref @$s22property_wrapper_local11DefaultInitV5valueACSi_tcfC : $@convention(method) (Int, @thin DefaultInit.Type) -> DefaultInit
+  @DefaultInit(value: 10) var z: Int
+
+  // CHECK: function_ref @$s22property_wrapper_local11DefaultInitVACycfC : $@convention(method) (@thin DefaultInit.Type) -> DefaultInit
+  @DefaultInit() var y: Int
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/37627

* **Explanation**: Property wrappers can be initialized in a number of different ways. Most property wrappers are initialized via `init(wrappedValue:)`, which allows assignment to the wrapped property to be treated as initialization of the backing property wrapper. Property wrappers can also be default-initialized if the wrapper has an `init()` or if all arguments to the initializer are specified in the wrapper attribute. For local property wrappers, default initializers were never checked for effects and actor isolation, which caused 2 bugs: a SILGen crash, and allowing invalid code to compile. These checks were removed from `typeCheckSynthesizedWrapperInitializer` (which applies to both initialization via `init(wrappedValue:)` and default initializers) to avoid a circular dependency with actor isolation checking, but the new code only checked the `init(wrappedValue:)` initializer. The circular dependency issue with actor isolation checking was fixed in https://github.com/apple/swift/pull/36521, so actor isolation and effects checking can safely be done when these initializers are created.
* **Scope**: The scope of the change is limited to property wrappers.
* **Risk**: Low. The change is mostly moving code from one place to another to make sure it applies to both possible property wrapper initializers.
* **Testing**: Added SILGen tests exercising local property wrapper default initialization, and a test for actor isolation checking in local wrapper initializers.
* **Reviewer**: @slavapestov 

Resolves: rdar://74616133