### PR TITLE
add symbol-graph flag to include SPI symbols

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -409,6 +409,9 @@ public:
   /// which are inherited through classes or default implementations.
   bool SkipInheritedDocs = false;
 
+  /// Whether to include symbols with SPI information in the symbol graph.
+  bool IncludeSPISymbolsInSymbolGraph = false;
+
 private:
   static bool canActionEmitDependencies(ActionType);
   static bool canActionEmitReferenceDependencies(ActionType);

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1247,6 +1247,11 @@ def skip_inherited_docs : Flag<["-"], "skip-inherited-docs">,
   HelpText<"Skip emitting doc comments for members inherited through classes or "
            "default implementations">;
 
+def include_spi_symbols : Flag<["-"], "include-spi-symbols">,
+  Flags<[SwiftSymbolGraphExtractOption, FrontendOption,
+         NoInteractiveOption, SupplementaryOutput, HelpHidden]>,
+  HelpText<"Add symbols with SPI information to the symbol graph">;
+
 // swift-api-digester-only options
 def dump_sdk: Flag<["-", "--"], "dump-sdk">,
   Flags<[NoDriverOption, SwiftAPIDigesterOption]>,

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -33,6 +33,7 @@ namespace swift {
     const char *SourceInfoOutputPath = nullptr;
     std::string SymbolGraphOutputDir;
     bool SkipSymbolGraphInheritedDocs = true;
+    bool IncludeSPISymbolsInSymbolGraph = false;
     llvm::VersionTuple UserModuleVersion;
 
     StringRef GroupInfoPath;

--- a/include/swift/SymbolGraphGen/SymbolGraphOptions.h
+++ b/include/swift/SymbolGraphGen/SymbolGraphOptions.h
@@ -42,6 +42,9 @@ struct SymbolGraphOptions {
   
   /// Whether to skip docs for symbols with compound, "SYNTHESIZED" USRs.
   bool SkipInheritedDocs;
+
+  /// Whether to emit symbols with SPI information.
+  bool IncludeSPISymbols;
 };
 
 } // end namespace symbolgraphgen

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -581,6 +581,7 @@ ToolChain::constructInvocation(const CompileJobAction &job,
   if (context.OI.CompilerMode == OutputInfo::Mode::SingleCompile) {
     context.Args.AddLastArg(Arguments, options::OPT_emit_symbol_graph);
     context.Args.AddLastArg(Arguments, options::OPT_emit_symbol_graph_dir);
+    context.Args.AddLastArg(Arguments, options::OPT_include_spi_symbols);
   }
 
   return II;
@@ -1071,6 +1072,7 @@ ToolChain::constructInvocation(const MergeModuleJobAction &job,
 
   context.Args.AddLastArg(Arguments, options::OPT_emit_symbol_graph);
   context.Args.AddLastArg(Arguments, options::OPT_emit_symbol_graph_dir);
+  context.Args.AddLastArg(Arguments, options::OPT_include_spi_symbols);
 
   context.Args.AddLastArg(Arguments, options::OPT_import_objc_header);
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -264,6 +264,7 @@ bool ArgsToFrontendOptionsConverter::convert(
   }
   
   Opts.SkipInheritedDocs = Args.hasArg(OPT_skip_inherited_docs);
+  Opts.IncludeSPISymbolsInSymbolGraph = Args.hasArg(OPT_include_spi_symbols);
 
   Opts.Static = Args.hasArg(OPT_static);
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -168,6 +168,7 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
     serializationOpts.SymbolGraphOutputDir = OutputDir.str().str();
   }
   serializationOpts.SkipSymbolGraphInheritedDocs = opts.SkipInheritedDocs;
+  serializationOpts.IncludeSPISymbolsInSymbolGraph = opts.IncludeSPISymbolsInSymbolGraph;
   
   if (!getIRGenOptions().ForceLoadSymbolName.empty())
     serializationOpts.AutolinkForceLoad = true;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5651,6 +5651,7 @@ void swift::serialize(ModuleOrSourceFile DC,
         /*EmitSynthesizedMembers*/true,
         /*PrintMessages*/false,
         /*EmitInheritedDocs*/options.SkipSymbolGraphInheritedDocs,
+        /*IncludeSPISymbols*/options.IncludeSPISymbolsInSymbolGraph,
       };
       symbolgraphgen::emitSymbolGraphForModule(M, SGOpts);
     }

--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -471,6 +471,11 @@ void Symbol::serializeAvailabilityMixin(llvm::json::OStream &OS) const {
   });
 }
 
+void Symbol::serializeSPIMixin(llvm::json::OStream &OS) const {
+  if (VD->isSPI())
+    OS.attribute("spi", true);
+}
+
 void Symbol::serialize(llvm::json::OStream &OS) const {
   OS.object([&](){
     serializeKind(OS);
@@ -487,6 +492,7 @@ void Symbol::serialize(llvm::json::OStream &OS) const {
     serializeAccessLevelMixin(OS);
     serializeAvailabilityMixin(OS);
     serializeLocationMixin(OS);
+    serializeSPIMixin(OS);
   });
 }
 

--- a/lib/SymbolGraphGen/Symbol.h
+++ b/lib/SymbolGraphGen/Symbol.h
@@ -76,6 +76,8 @@ class Symbol {
 
   void serializeAvailabilityMixin(llvm::json::OStream &OS) const;
 
+  void serializeSPIMixin(llvm::json::OStream &OS) const;
+
 public:
   Symbol(SymbolGraph *Graph, const ValueDecl *VD,
          const NominalTypeDecl *SynthesizedBaseTypeDecl,

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -630,7 +630,7 @@ bool SymbolGraph::isImplicitlyPrivate(const Decl *D,
 
   // Don't include declarations with the @_spi attribute unless the
   // access control filter is internal or below.
-  if (D->isSPI()) {
+  if (D->isSPI() && !Walker.Options.IncludeSPISymbols) {
     return Walker.Options.MinimumAccessLevel > AccessLevel::Internal;
   }
 

--- a/test/SymbolGraph/Symbols/Mixins/SPI.swift
+++ b/test/SymbolGraph/Symbols/Mixins/SPI.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name SPI -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name SPI -I %t -pretty-print -output-dir %t -include-spi-symbols
+// RUN: %FileCheck %s --input-file %t/SPI.symbols.json --check-prefix SPI
+
+// RUN: %target-swift-symbolgraph-extract -module-name SPI -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/SPI.symbols.json --check-prefix NOSPI
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name SPI -emit-module -emit-module-path %t/SPI.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/ -include-spi-symbols -v
+// RUN: %FileCheck %s --input-file %t/SPI.symbols.json --check-prefix SPI-COMPILE
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name SPI -emit-module -emit-module-path %t/SPI.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/
+// RUN: %FileCheck %s --input-file %t/SPI.symbols.json --check-prefix NOSPI-COMPILE
+
+@_spi(SPI) public struct SomeStruct {}
+
+// SPI: "precise": "s:3SPI10SomeStructV"
+// SPI: "spi": true
+
+// NOSPI-NOT: "precise": "s:3SPI10SomeStructV"
+
+// SPI-COMPILE: s:3SPI10SomeStructV
+// NOSPI-COMPILE-NOT: s:3SPI10SomeStructV

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -959,6 +959,7 @@ fillSymbolInfo(CursorSymbolInfo &Symbol, const DeclInfo &DInfo,
         /*EmitSynthesizedMembers*/ false,
         /*PrintMessages*/ false,
         /*SkipInheritedDocs*/ false,
+        /*IncludeSPISymbols*/ true,
     };
 
     symbolgraphgen::printSymbolGraphForDecl(DInfo.VD, DInfo.BaseType,

--- a/tools/driver/swift_symbolgraph_extract_main.cpp
+++ b/tools/driver/swift_symbolgraph_extract_main.cpp
@@ -168,6 +168,7 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
       !ParsedArgs.hasArg(OPT_skip_synthesized_members),
       ParsedArgs.hasArg(OPT_v),
       ParsedArgs.hasArg(OPT_skip_inherited_docs),
+      ParsedArgs.hasArg(OPT_include_spi_symbols),
   };
 
   if (auto *A = ParsedArgs.getLastArg(OPT_minimum_access_level)) {


### PR DESCRIPTION
Resolves rdar://70794131

This PR adds a new flag to swift-symbolgraph-extract and the frontend: `-include-spi-symbols`. When present, this overrides the current filter that removes symbols tagged with `@_spi` if the requested visibility isn't `internal`. It also adds a new "mixin" field, `"spi"`, which is a boolean that is present and `true` for SPI symbols.