### PR TITLE
[cmake] explicitly set linker language for static libraries

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1343,6 +1343,16 @@ function(_add_swift_target_library_single target name)
       ${library_search_directories})
     target_link_libraries("${target_static}" PRIVATE
         ${SWIFTLIB_SINGLE_PRIVATE_LINK_LIBRARIES})
+
+    # Force executables linker language to be CXX so that we do not link using the
+    # host toolchain swiftc.
+    if("${SWIFTLIB_SINGLE_SDK}" STREQUAL "ANDROID")
+      set_property(TARGET "${target_static}" PROPERTY
+        LINKER_LANGUAGE "C")
+    else()
+      set_property(TARGET "${target_static}" PROPERTY
+        LINKER_LANGUAGE "CXX")
+    endif()
   endif()
 
   # Do not add code here.


### PR DESCRIPTION
This mimicks the same logic used for shared libraries a few lines above.

This will allow the minimal freestanding stdlib to build with #37511, solving errors like

```
ninja: error: build.ninja:4213: multiple rules generate stdlib/public/SwiftOnoneSupport/CMakeFiles/
swiftSwiftOnoneSupport-freestanding-x86_64-static.dir/__/__/
linker-support/magic-symbols-for-install-name.c.o [-w dupbuild=err]
```

Addresses rdar://78336832