### PR TITLE
[CSBindings] Account for literal bindings when checking "subtype of e…

### DIFF
--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -391,6 +391,13 @@ public:
     if (Bindings.empty())
       return false;
 
+    // Literal requirements always result in a subtype/supertype
+    // relationship to a concrete type.
+    if (llvm::any_of(Literals, [](const auto &literal) {
+          return literal.second.viableAsBinding();
+        }))
+      return false;
+
     return llvm::all_of(Bindings, [](const PotentialBinding &binding) {
       return binding.BindingType->isExistentialType() &&
              binding.Kind == AllowedBindingKind::Subtypes;

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -492,3 +492,30 @@ func test_arg_conformance_with_conditional_reqs(i: Int) {
   let _: Int?? = simple(overloaded_result())
   let _: Int?? = overloaded(overloaded_result())
 }
+
+// rdar://77570994 - regression in type unification for literal collections
+
+protocol Elt {
+}
+
+extension Int : Elt {}
+extension Int64 : Elt {}
+extension Dictionary : Elt where Key == String, Value: Elt {}
+
+struct Object {}
+
+extension Object : ExpressibleByDictionaryLiteral {
+  init(dictionaryLiteral elements: (String, Elt)...) {
+  }
+}
+
+enum E {
+case test(cond: Bool, v: Int64)
+
+  var test_prop: Object {
+    switch self {
+    case let .test(cond, v):
+      return ["obj": ["a": v, "b": cond ? 0 : 42]] // Ok
+    }
+  }
+}


### PR DESCRIPTION
…xistential" property

It's important to know whether a binding set has all of its bindings
as subtypes of some existential type(s), type variables like that
should be delayed.

Incremental binding inference introduced a bug into computation of
this property by checking only directly inferable bindings, but
it's also important to check that there are no literal requirements
that can produce bindings, because that would mean that type variable
can never be just a subtype of existential type(s).

Resolves: rdar://77570994

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
