### PR TITLE
Xfail async test on Windows.

### DIFF
--- a/test/IRGen/async_dynamic_replacement.swift
+++ b/test/IRGen/async_dynamic_replacement.swift
@@ -1,5 +1,8 @@
 // RUN: %target-swift-frontend %s -emit-ir -disable-objc-interop | %FileCheck %s
 
+// Windows does not do swiftailcc
+// XFAIL: OS=windows-msvc
+
 // REQUIRES: concurrency
 
 public dynamic func number() async -> Int {


### PR DESCRIPTION
The swifttailcc convention is not supported on Windows right now.