### PR TITLE
Documentation: remove extraneous / characters from license comments in stdlib (for release branch)

### DIFF
--- a/stdlib/public/Concurrency/Errors.swift
+++ b/stdlib/public/Concurrency/Errors.swift
@@ -1,14 +1,14 @@
-////===----------------------------------------------------------------------===//
-////
-//// This source file is part of the Swift.org open source project
-////
-//// Copyright (c) 2020 Apple Inc. and the Swift project authors
-//// Licensed under Apache License v2.0 with Runtime Library Exception
-////
-//// See https://swift.org/LICENSE.txt for license information
-//// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-////
-////===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
 
 import Swift
 @_implementationOnly import _SwiftConcurrencyShims

--- a/stdlib/public/core/EitherSequence.swift
+++ b/stdlib/public/core/EitherSequence.swift
@@ -1,14 +1,14 @@
-////===--- _EitherSequence.swift - A sequence type-erasing two sequences -----===//
-////
-//// This source file is part of the Swift.org open source project
-////
-//// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
-//// Licensed under Apache License v2.0 with Runtime Library Exception
-////
-//// See https://swift.org/LICENSE.txt for license information
-//// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-////
-////===----------------------------------------------------------------------===//
+//===--- _EitherSequence.swift - A sequence type-erasing two sequences -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
 
 // Not public stdlib API, currently used in Mirror.children implementation.
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Three files in stdlib contain extraneous `/` characters in their license statement comment blocks, beginning each line with `////` instead of just `//` like other sources. Because there are three or more slashes, the license statements could be inadvertently interpreted as documentation comments associated with the first symbol in the file.

Fix: Correct `////` to `//`, for parity with other source files.

This change only affects comments.

(Previously committed to `main` as #37632, this is a cherry-pick to `release/5.5`. Note that it appears the correction to `Sendable.swift` has already been performed on this release branch.)