### PR TITLE
[Diagnostics] Augment "expected parameter" note with an argument type

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -361,8 +361,8 @@ ERROR(cannot_convert_argument_value,none,
       (Type,Type))
 
 NOTE(candidate_has_invalid_argument_at_position,none,
-     "candidate expects %select{|in-out }2value of type %0 for parameter #%1",
-     (Type, unsigned, bool))
+     "candidate expects %select{|in-out }2value of type %0 for parameter #%1 (got %3)",
+     (Type, unsigned, bool, Type))
 
 ERROR(cannot_convert_array_to_variadic,none,
       "cannot pass array of type %0 as variadic arguments of type %1",

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6135,10 +6135,10 @@ bool ArgumentMismatchFailure::diagnoseAsError() {
 bool ArgumentMismatchFailure::diagnoseAsNote() {
   auto *locator = getLocator();
   if (auto *callee = getCallee()) {
-    emitDiagnosticAt(
-        callee, diag::candidate_has_invalid_argument_at_position, getToType(),
-        getParamPosition(),
-        locator->isLastElement<LocatorPathElt::LValueConversion>());
+    emitDiagnosticAt(callee, diag::candidate_has_invalid_argument_at_position,
+                     getToType(), getParamPosition(),
+                     locator->isLastElement<LocatorPathElt::LValueConversion>(),
+                     getFromType());
     return true;
   }
 
@@ -7034,9 +7034,9 @@ bool AbstractRawRepresentableFailure::diagnoseAsNote() {
     }
   } else if (auto argConv =
                  locator->getLastElementAs<LocatorPathElt::ApplyArgToParam>()) {
-    diagnostic.emplace(
-        emitDiagnostic(diag::candidate_has_invalid_argument_at_position,
-                       RawReprType, argConv->getParamIdx(), /*inOut=*/false));
+    diagnostic.emplace(emitDiagnostic(
+        diag::candidate_has_invalid_argument_at_position, RawReprType,
+        argConv->getParamIdx(), /*inOut=*/false, ExpectedType));
   }
 
   if (diagnostic) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3676,10 +3676,16 @@ static bool diagnoseAmbiguity(
         assert(fn);
 
         if (fn->getNumParams() == 1) {
+          auto argExpr =
+              simplifyLocatorToAnchor(solution.Fixes.front()->getLocator());
+          assert(argExpr);
+
           const auto &param = fn->getParams()[0];
+          auto argType = solution.simplifyType(cs.getType(argExpr));
+
           DE.diagnose(noteLoc, diag::candidate_has_invalid_argument_at_position,
                       solution.simplifyType(param.getPlainType()),
-                      /*position=*/1, param.isInOut());
+                      /*position=*/1, param.isInOut(), argType);
         } else {
           DE.diagnose(noteLoc, diag::candidate_partial_match,
                       fn->getParamListAsString(fn->getParams()));

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -349,8 +349,8 @@ takeVoidVoidFn { () -> Void in
 }
 
 // <rdar://problem/19997471> Swift: Incorrect compile error when calling a function inside a closure
-func f19997471(_ x: String) {} // expected-note {{candidate expects value of type 'String' for parameter #1}}
-func f19997471(_ x: Int) {}    // expected-note {{candidate expects value of type 'Int' for parameter #1}}
+func f19997471(_ x: String) {} // expected-note {{candidate expects value of type 'String' for parameter #1 (got 'T')}}
+func f19997471(_ x: Int) {}    // expected-note {{candidate expects value of type 'Int' for parameter #1 (got 'T')}}
 
 func someGeneric19997471<T>(_ x: T) {
   takeVoidVoidFn {

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -16,9 +16,9 @@ enum Z {
 
   init() { self = .none }
   init(_ c: UnicodeScalar) { self = .char(c) }
-  // expected-note@-1 2 {{candidate expects value of type 'UnicodeScalar' (aka 'Unicode.Scalar') for parameter #1}}
+  // expected-note@-1 2 {{candidate expects value of type 'UnicodeScalar' (aka 'Unicode.Scalar') for parameter #1 (got 'Z')}}
   init(_ s: String) { self = .string(s) }
-  // expected-note@-1 2 {{candidate expects value of type 'String' for parameter #1}}
+  // expected-note@-1 2 {{candidate expects value of type 'String' for parameter #1 (got 'Z')}}
   init(_ x: Int, _ y: Int) { self = .point(x, y) }
 }
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -399,9 +399,9 @@ enum Color {
   static func rainbow() -> Color {}
   
   static func overload(a : Int) -> Color {} // expected-note {{incorrect labels for candidate (have: '(_:)', expected: '(a:)')}}
-  // expected-note@-1 {{candidate expects value of type 'Int' for parameter #1}}
+  // expected-note@-1 {{candidate expects value of type 'Int' for parameter #1 (got 'Double')}}
   static func overload(b : Int) -> Color {} // expected-note {{incorrect labels for candidate (have: '(_:)', expected: '(b:)')}}
-  // expected-note@-1 {{candidate expects value of type 'Int' for parameter #1}}
+  // expected-note@-1 {{candidate expects value of type 'Int' for parameter #1 (got 'Double')}}
   
   static func frob(_ a : Int, b : inout Int) -> Color {}
   static var svar: Color { return .Red }

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -3,9 +3,9 @@
 func markUsed<T>(_ t: T) {}
 
 func f0(_: Float) -> Float {}
-// expected-note@-1 {{candidate expects value of type 'Float' for parameter #1}}
+// expected-note@-1 {{candidate expects value of type 'Float' for parameter #1 (got 'X')}}
 func f0(_: Int) -> Int {}
-// expected-note@-1 {{candidate expects value of type 'Int' for parameter #1}}
+// expected-note@-1 {{candidate expects value of type 'Int' for parameter #1 (got 'X')}}
 
 func f1(_: Int) {}
 

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -147,8 +147,8 @@ array.withUnsafeBufferPointer {
   // expected-note@-5 {{found candidate with type '(UnsafeMutableRawPointer) -> UnsafeRawPointer'}}
 }
 
-func SR12689_1(_ u: Int) -> String { "" } // expected-note {{found this candidate}} expected-note {{candidate expects value of type 'Int' for parameter #1}}
-func SR12689_1(_ u: String) -> Double { 0 } // expected-note {{found this candidate}} expected-note {{candidate expects value of type 'String' for parameter #1}}
+func SR12689_1(_ u: Int) -> String { "" } // expected-note {{found this candidate}} expected-note {{candidate expects value of type 'Int' for parameter #1 (got 'Double')}}
+func SR12689_1(_ u: String) -> Double { 0 } // expected-note {{found this candidate}} expected-note {{candidate expects value of type 'String' for parameter #1 (got 'Double')}}
 func SR12689_2(_ u: Int) {}
 
 SR12689_2(SR12689_1(1 as Double)) // expected-error {{no exact matches in call to global function 'SR12689_1'}}


### PR DESCRIPTION
Currently ambiguity notes attached to a candidate only mention
expected type and its position. To improve clarify of such notes
it's useful to print argument type as well since it's not always
clear what it is at the first glance at the code.

Resolves: SR-14634
Resolves: rdar://78224323

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
