### PR TITLE
Sema: Allow @objc enums without -enable-objc-interop or importing Foundation

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -925,6 +925,11 @@ static void diagnoseObjCAttrWithoutFoundation(ObjCAttr *attr, Decl *decl,
   if (attr->isImplicit())
     return;
 
+  // @objc enums do not require -enable-objc-interop or Foundation be have been
+  // imported.
+  if (isa<EnumDecl>(decl))
+    return;
+
   auto &ctx = SF->getASTContext();
 
   if (!ctx.LangOpts.EnableObjCInterop) {

--- a/test/IRGen/objc_enum.swift
+++ b/test/IRGen/objc_enum.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+
+// REQUIRES: CPU=x86_64
+
+@objc public enum ExportedToObjC: Int32 {
+  case Foo = -1, Bar, Bas
+}
+
+// CHECK-LABEL: define{{( protected)?( dllexport)?}} swiftcc i32 @"$s9objc_enum0a1_B7_injectAA14ExportedToObjCOyF"()
+// CHECK:         ret i32 -1
+public func objc_enum_inject() -> ExportedToObjC {
+  return .Foo
+}
+
+// CHECK-LABEL: define{{( protected)?( dllexport)?}} swiftcc i64 @"$s9objc_enum0a1_B7_switchySiAA14ExportedToObjCOF"(i32 %0)
+// CHECK:         switch i32 %0, label {{%.*}} [
+// CHECK:           i32 -1, label {{%.*}}
+// CHECK:           i32  0, label {{%.*}}
+// CHECK:           i32  1, label {{%.*}}
+public func objc_enum_switch(_ x: ExportedToObjC) -> Int {
+  switch x {
+  case .Foo:
+    return 0
+  case .Bar:
+    return 1
+  case .Bas:
+    return 2
+  }
+}
+

--- a/test/IRGen/objc_ns_enum.swift
+++ b/test/IRGen/objc_ns_enum.swift
@@ -99,28 +99,6 @@ use_metadata(NSRuncingOptions.mince)
   case Foo = -1, Bar, Bas
 }
 
-// CHECK-LABEL: define hidden swiftcc i64 @"$s12objc_ns_enum0a1_C7_injectAA14ExportedToObjCOyF"()
-// CHECK:         ret i64 -1
-func objc_enum_inject() -> ExportedToObjC {
-  return .Foo
-}
-
-// CHECK-LABEL: define hidden swiftcc i64 @"$s12objc_ns_enum0a1_C7_switchySiAA14ExportedToObjCOF"(i64 %0)
-// CHECK:         switch i64 %0, label {{%.*}} [
-// CHECK:           i64 -1, label {{%.*}}
-// CHECK:           i64  0, label {{%.*}}
-// CHECK:           i64  1, label {{%.*}}
-func objc_enum_switch(_ x: ExportedToObjC) -> Int {
-  switch x {
-  case .Foo:
-    return 0
-  case .Bar:
-    return 1
-  case .Bas:
-    return 2
-  }
-}
-
 @objc class ObjCEnumMethods : NSObject {
   // CHECK: define internal void @"$s12objc_ns_enum15ObjCEnumMethodsC0C2InyyAA010ExportedToD1COFTo"([[OBJC_ENUM_METHODS:.*]]* %0, i8* %1, i64 %2)
   @objc dynamic func enumIn(_ x: ExportedToObjC) {}

--- a/test/SILGen/enum_raw_representable_objc.swift
+++ b/test/SILGen/enum_raw_representable_objc.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -emit-sorted-sil -enable-objc-interop -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
-// RUN: %target-swift-emit-silgen -emit-sorted-sil -enable-objc-interop -disable-objc-attr-requires-foundation-module -enable-library-evolution %s | %FileCheck -check-prefix=CHECK-RESILIENT %s
+// RUN: %target-swift-emit-silgen -emit-sorted-sil %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -emit-sorted-sil -enable-library-evolution %s | %FileCheck -check-prefix=CHECK-RESILIENT %s
 
 #if os(Windows) && arch(x86_64)
 @objc public enum CLike: Int32 {


### PR DESCRIPTION
We used to allow @objc enums on Linux, where Objective-C interop is disabled,
because the check first looked for an import of the Foundation module
(which could be the non-Objective-C corelibs-foundation) before checking
if Objective-C interop was enabled.

Since @objc enums don't actually depend on Foundation or Objective-C and
only have a different layout in IRGen, let's bring back and formalize the
old behavior.

Fixes https://bugs.swift.org/browse/SR-14548 / rdar://problem/77325078.