### PR TITLE
Remove a couple of calls to hasComputedGenericSignature()

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1840,13 +1840,9 @@ bool TypeChecker::getDefaultGenericArgumentsString(
     genericParamText << contextTy;
   };
 
-  // FIXME: We can potentially be in the middle of creating a generic signature
-  // if we get here.  Break this cycle.
-  if (typeDecl->hasComputedGenericSignature()) {
-    llvm::interleave(typeDecl->getInnermostGenericParamTypes(),
-                     printGenericParamSummary,
-                     [&] { genericParamText << ", "; });
-  }
+  llvm::interleave(typeDecl->getInnermostGenericParamTypes(),
+                   printGenericParamSummary,
+                   [&] { genericParamText << ", "; });
   
   genericParamText << ">";
   return true;

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -213,13 +213,6 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
     // declared on, it is viable for inference when its conditional
     // requirements are satisfied by those of the conformance context.
     if (!proto) {
-      // FIXME: The extension may not have a generic signature set up yet as
-      // resolving signatures may trigger associated type inference.  This cycle
-      // is now detectable and we should look into untangling it
-      // - see rdar://55263708
-      if (!extension->hasComputedGenericSignature())
-        return true;
-
       // Retrieve the generic signature of the extension.
       const auto extensionSig = extension->getGenericSignature();
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -996,11 +996,17 @@ static void diagnoseUnboundGenericType(Type ty, SourceLoc loc) {
   if (auto unbound = ty->getAs<UnboundGenericType>()) {
     auto *decl = unbound->getDecl();
     {
-      InFlightDiagnostic diag = ctx.Diags.diagnose(loc,
-          diag::generic_type_requires_arguments, ty);
+      // Compute the string before creating a new diagnostic, since
+      // getDefaultGenericArgumentsString() might emit its own
+      // diagnostics.
       SmallString<64> genericArgsToAdd;
-      if (TypeChecker::getDefaultGenericArgumentsString(genericArgsToAdd,
-                                                        decl))
+      bool hasGenericArgsToAdd =
+          TypeChecker::getDefaultGenericArgumentsString(genericArgsToAdd,
+                                                        decl);
+
+      auto diag = ctx.Diags.diagnose(loc,
+          diag::generic_type_requires_arguments, ty);
+      if (hasGenericArgsToAdd)
         diag.fixItInsertAfter(loc, genericArgsToAdd);
     }
 


### PR DESCRIPTION
These no longer seem to do anything. The last remaining caller of hasComputedGenericSignature() is in the GSB, where it enables this code to type check:

```
enum Term<S> where S : Sequence, S.Element == Term {}
```

The generic signature of `Term` becomes `<S where S : Sequence, S.Element == Term<S>>`, which I'm not sure is even supposed to work with our type system model. I'll investigate this example further and remove hasComputedGenericSignature() entirely in a follow-up PR.