### PR TITLE
[AST] Do not verify when allowing compiler errors

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -3674,6 +3674,11 @@ public:
 } // end anonymous namespace
 
 static bool shouldVerifyGivenContext(const ASTContext &ctx) {
+  // Never verify when allowing errors, since the AST can necessarily be
+  // invalid
+  if (ctx.LangOpts.AllowModuleWithCompilerErrors)
+    return false;
+
   using ASTVerifierOverrideKind = LangOptions::ASTVerifierOverrideKind;
   switch (ctx.LangOpts.ASTVerifierOverride) {
   case ASTVerifierOverrideKind::EnableVerifier:

--- a/test/Serialization/AllowErrors/invalid-ifconfig.swift
+++ b/test/Serialization/AllowErrors/invalid-ifconfig.swift
@@ -1,0 +1,8 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -module-name errors -emit-module -o %t/mods/errors.swiftmodule -experimental-skip-all-function-bodies -experimental-allow-module-with-compiler-errors %s
+
+// Performing AST verification would crash here, so check that we don't verify
+// when allowing errors
+#if os(
+struct Anything {


### PR DESCRIPTION
It isn't unexpected to have an invalid AST when allowing errors, so make
sure not to verify the AST in that case.