### PR TITLE
Documentation: Correct placement of doc comments in AsyncSequence

### DIFF
--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -15,7 +15,7 @@ import Swift
 
 /// Common protocol to which all actors conform.
 ///
-/// The Actor protocol generalizes over all actor types. Actor types
+/// The `Actor` protocol generalizes over all actor types. Actor types
 /// implicitly conform to this protocol.
 @available(SwiftStdlib 5.5, *)
 public protocol Actor: AnyObject, Sendable {
@@ -53,7 +53,7 @@ public func _defaultActorDestroy(_ actor: AnyObject)
 internal func _enqueueOnMain(_ job: UnownedJob)
 
 /// A singleton actor whose executor is equivalent to 
-/// DispatchQueue.main, which is the main dispatch queue.
+/// `DispatchQueue.main`, which is the main dispatch queue.
 @available(SwiftStdlib 5.5, *)
 @globalActor public final actor MainActor: SerialExecutor {
   public static let shared = MainActor()

--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -52,8 +52,8 @@ public func _defaultActorDestroy(_ actor: AnyObject)
 @usableFromInline
 internal func _enqueueOnMain(_ job: UnownedJob)
 
-/// A singleton actor whose executor is equivalent to 
-/// `DispatchQueue.main`, which is the main dispatch queue.
+/// A singleton actor whose executor is equivalent to the main
+/// dispatch queue.
 @available(SwiftStdlib 5.5, *)
 @globalActor public final actor MainActor: SerialExecutor {
   public static let shared = MainActor()

--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -15,7 +15,7 @@ import Swift
 
 /// Common protocol to which all actors conform.
 ///
-/// The \c Actor protocol generalizes over all actor types. Actor types
+/// The Actor protocol generalizes over all actor types. Actor types
 /// implicitly conform to this protocol.
 @available(SwiftStdlib 5.5, *)
 public protocol Actor: AnyObject, Sendable {
@@ -53,7 +53,7 @@ public func _defaultActorDestroy(_ actor: AnyObject)
 internal func _enqueueOnMain(_ job: UnownedJob)
 
 /// A singleton actor whose executor is equivalent to 
-/// \c DispatchQueue.main, which is the main dispatch queue.
+/// DispatchQueue.main, which is the main dispatch queue.
 @available(SwiftStdlib 5.5, *)
 @globalActor public final actor MainActor: SerialExecutor {
   public static let shared = MainActor()

--- a/stdlib/public/Concurrency/AsyncSequence.swift
+++ b/stdlib/public/Concurrency/AsyncSequence.swift
@@ -74,7 +74,8 @@ import Swift
 @available(SwiftStdlib 5.5, *)
 @rethrows
 public protocol AsyncSequence {
-  /// The type of asynchronous iterator produced by this asynchronous sequence.
+  /// The type of asynchronous iterator that produces elements of this
+  /// asynchronous sequence.
   associatedtype AsyncIterator: AsyncIteratorProtocol where AsyncIterator.Element == Element
   /// The type of element produced by this asynchronous sequence.
   associatedtype Element

--- a/stdlib/public/Concurrency/AsyncSequence.swift
+++ b/stdlib/public/Concurrency/AsyncSequence.swift
@@ -74,14 +74,15 @@ import Swift
 @available(SwiftStdlib 5.5, *)
 @rethrows
 public protocol AsyncSequence {
-  /// The type of element produced by this asynchronous sequence.
+    /// The type of asynchronous iterator produced by this asynchronous sequence.
   associatedtype AsyncIterator: AsyncIteratorProtocol where AsyncIterator.Element == Element
-  /// Creates the asynchronous iterator that produces elements of this
-  /// asynchronous sequence.
-  ///
-  /// - Returns: An instance of the `AsyncIterator` type used to produce
-  /// elements of the asynchronous sequence.
+    /// The type of element produced by this asynchronous sequence.
   associatedtype Element
+    /// Creates the asynchronous iterator that produces elements of this
+    /// asynchronous sequence.
+    ///
+    /// - Returns: An instance of the `AsyncIterator` type used to produce
+    /// elements of the asynchronous sequence.
   __consuming func makeAsyncIterator() -> AsyncIterator
 }
 

--- a/stdlib/public/Concurrency/AsyncSequence.swift
+++ b/stdlib/public/Concurrency/AsyncSequence.swift
@@ -74,15 +74,15 @@ import Swift
 @available(SwiftStdlib 5.5, *)
 @rethrows
 public protocol AsyncSequence {
-    /// The type of asynchronous iterator produced by this asynchronous sequence.
+  /// The type of asynchronous iterator produced by this asynchronous sequence.
   associatedtype AsyncIterator: AsyncIteratorProtocol where AsyncIterator.Element == Element
-    /// The type of element produced by this asynchronous sequence.
+  /// The type of element produced by this asynchronous sequence.
   associatedtype Element
-    /// Creates the asynchronous iterator that produces elements of this
-    /// asynchronous sequence.
-    ///
-    /// - Returns: An instance of the `AsyncIterator` type used to produce
-    /// elements of the asynchronous sequence.
+  /// Creates the asynchronous iterator that produces elements of this
+  /// asynchronous sequence.
+  ///
+  /// - Returns: An instance of the `AsyncIterator` type used to produce
+  /// elements of the asynchronous sequence.
   __consuming func makeAsyncIterator() -> AsyncIterator
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Correct placement of documentation comments for:

- `AsyncSequence.AsyncIterator`
- `AsyncSequence.Element`
- `AsyncSequence.makeAsyncIterator()`

Also remove stray "\c" sequence in doc comments for `Actor` and `MainActor`.

This PR only affects documentation comments.
