### PR TITLE
[Build] Pass '--reconfigure' to build-script-impl

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -778,6 +778,9 @@ class BuildScriptInvocation(object):
         if args.dry_run:
             impl_args += ["--dry-run"]
 
+        if args.reconfigure:
+            impl_args += ["--reconfigure"]
+
         if args.clang_profile_instr_use:
             impl_args += [
                 "--clang-profile-instr-use=%s" %

--- a/validation-test/BuildSystem/reconfigure-passed-to-build-script-impl.test
+++ b/validation-test/BuildSystem/reconfigure-passed-to-build-script-impl.test
@@ -1,0 +1,7 @@
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --reconfigure --verbose 2>&1| %FileCheck %s
+
+# REQUIRES: standalone_build
+
+# CHECK: build-script-impl{{.*}} --reconfigure


### PR DESCRIPTION
We recently started using the flag in build-script and forgot to pass it on the build-script-impl
