### PR TITLE
[Concurrency] Alternative Task API

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -60,6 +60,7 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   AsyncThrowingMapSequence.swift
   AsyncThrowingPrefixWhileSequence.swift
   PartialAsyncTask.swift
+  SourceCompatibilityShims.swift
   Task.cpp
   Task.swift
   TaskCancellation.swift

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -278,7 +278,3 @@ public func withUnsafeThrowingContinuation<T>(
     fn(UnsafeContinuation<T, Error>($0))
   }
 }
-
-@available(SwiftStdlib 5.5, *)
-@available(*, deprecated, message: "please use UnsafeContination<..., Error>")
-public typealias UnsafeThrowingContinuation<T> = UnsafeContinuation<T, Error>

--- a/stdlib/public/Concurrency/SourceCompatibilityShims.swift
+++ b/stdlib/public/Concurrency/SourceCompatibilityShims.swift
@@ -18,11 +18,17 @@ import Swift
 
 @available(SwiftStdlib 5.5, *)
 extension Task where Success == Never, Failure == Never {
-  @available(*, deprecated, message: "use TaskPriority")
+  @available(*, deprecated, message: "Task.Priority has been removed; use TaskPriority")
   public typealias Priority = TaskPriority
 
-  @available(*, deprecated, message: "use Task")
+  @available(*, deprecated, message: "Task.Handle has been removed; use Task")
   public typealias Handle = _Concurrency.Task
+
+  @available(*, deprecated, message: "Task.CancellationError has been removed; use CancellationError")
+  @_alwaysEmitIntoClient
+  public static func CancellationError() -> _Concurrency.CancellationError {
+    return _Concurrency.CancellationError()
+  }
 }
 
 @available(SwiftStdlib 5.5, *)

--- a/stdlib/public/Concurrency/SourceCompatibilityShims.swift
+++ b/stdlib/public/Concurrency/SourceCompatibilityShims.swift
@@ -1,0 +1,209 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// This file provides source compatibility shims to help migrate code
+// using earlier versions of the concurrency library to the latest syntax.
+//===----------------------------------------------------------------------===//
+
+import Swift
+@_implementationOnly import _SwiftConcurrencyShims
+
+@available(SwiftStdlib 5.5, *)
+extension Task where Success == Never, Failure == Never {
+  @available(*, deprecated, message: "use TaskPriority")
+  public typealias Priority = TaskPriority
+
+  @available(*, deprecated, message: "use Task")
+  public typealias Handle = _Concurrency.Task
+}
+
+@available(SwiftStdlib 5.5, *)
+extension TaskPriority {
+  @available(*, deprecated, message: "unspecified priority will be removed; use nil")
+  public static let unspecified: TaskPriority = .init(rawValue: 0x00)
+}
+
+@available(SwiftStdlib 5.5, *)
+extension Task where Success == Never, Failure == Never {
+  @available(*, deprecated, message: "`Task.withCancellationHandler` has been replaced by `withTaskCancellationHandler` and will be removed shortly.")
+  @_alwaysEmitIntoClient
+  public static func withCancellationHandler<T>(
+    handler: @Sendable () -> (),
+    operation: () async throws -> T
+  ) async rethrows -> T {
+    try await withTaskCancellationHandler(handler: handler, operation: operation)
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+extension Task where Failure == Error {
+  @discardableResult
+  @_alwaysEmitIntoClient
+  @available(*, deprecated, message: "`Task.runDetached` was replaced by `Task.detached` and will be removed shortly.")
+  public static func runDetached(
+    priority: TaskPriority = .unspecified,
+    operation: __owned @Sendable @escaping () async throws -> Success
+  ) -> Task<Success, Failure> {
+    detached(priority: priority, operation: operation)
+  }
+}
+
+@discardableResult
+@available(SwiftStdlib 5.5, *)
+@available(*, deprecated, message: "`detach` was replaced by `Task.detached` and will be removed shortly.")
+@_alwaysEmitIntoClient
+public func detach<T>(
+  priority: TaskPriority? = nil,
+  operation: __owned @Sendable @escaping () async -> T
+) -> Task<T, Never> {
+  Task.detached(priority: priority, operation: operation)
+}
+
+@discardableResult
+@available(SwiftStdlib 5.5, *)
+@available(*, deprecated, message: "`detach` was replaced by `Task.detached` and will be removed shortly.")
+@_alwaysEmitIntoClient
+public func detach<T>(
+  priority: TaskPriority? = nil,
+  operation: __owned @Sendable @escaping () async throws -> T
+) -> Task<T, Error> {
+  Task.detached(priority: priority, operation: operation)
+}
+
+@discardableResult
+@available(SwiftStdlib 5.5, *)
+@available(*, deprecated, message: "`asyncDetached` was replaced by `Task.detached` and will be removed shortly.")
+@_alwaysEmitIntoClient
+public func asyncDetached<T>(
+  priority: TaskPriority? = nil,
+  @_implicitSelfCapture operation: __owned @Sendable @escaping () async -> T
+) -> Task<T, Never> {
+  return Task.detached(priority: priority, operation: operation)
+}
+
+@discardableResult
+@available(SwiftStdlib 5.5, *)
+@available(*, deprecated, message: "`asyncDetached` was replaced by `Task.detached` and will be removed shortly.")
+@_alwaysEmitIntoClient
+public func asyncDetached<T>(
+  priority: TaskPriority? = nil,
+  @_implicitSelfCapture operation: __owned @Sendable @escaping () async throws -> T
+) -> Task<T, Error> {
+  return Task.detached(priority: priority, operation: operation)
+}
+
+@available(SwiftStdlib 5.5, *)
+@available(*, deprecated, message: "`async` was replaced by `Task.init` and will be removed shortly.")
+@discardableResult
+@_alwaysEmitIntoClient
+public func async<T>(
+  priority: TaskPriority? = nil,
+  @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping () async -> T
+) -> Task<T, Never> {
+  .init(priority: priority, operation: operation)
+}
+
+@available(SwiftStdlib 5.5, *)
+@available(*, deprecated, message: "`async` was replaced by `Task.init` and will be removed shortly.")
+@discardableResult
+@_alwaysEmitIntoClient
+public func async<T>(
+  priority: TaskPriority? = nil,
+  @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping () async throws -> T
+) -> Task<T, Error> {
+  .init(priority: priority, operation: operation)
+}
+
+@available(SwiftStdlib 5.5, *)
+extension Task where Success == Never, Failure == Never {
+  @available(*, deprecated, message: "`Task.Group` was replaced by `ThrowingTaskGroup` and `TaskGroup` and will be removed shortly.")
+  public typealias Group<TaskResult> = ThrowingTaskGroup<TaskResult, Error>
+
+  @available(*, deprecated, message: "`Task.withGroup` was replaced by `withThrowingTaskGroup` and `withTaskGroup` and will be removed shortly.")
+  @_alwaysEmitIntoClient
+  public static func withGroup<TaskResult, BodyResult>(
+      resultType: TaskResult.Type,
+      returning returnType: BodyResult.Type = BodyResult.self,
+      body: (inout Task.Group<TaskResult>) async throws -> BodyResult
+  ) async rethrows -> BodyResult {
+    try await withThrowingTaskGroup(of: resultType) { group in
+      try await body(&group)
+    }
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+extension TaskGroup {
+  @available(*, deprecated, renamed: "async(priority:operation:)")
+  @_alwaysEmitIntoClient
+  public mutating func add(
+      priority: TaskPriority? = nil,
+      operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) async -> Bool {
+    return self.asyncUnlessCancelled(priority: priority) {
+      await operation()
+    }
+  }
+
+  @available(*, deprecated, renamed: "async(priority:operation:)")
+  @_alwaysEmitIntoClient
+  public mutating func spawn(
+    priority: TaskPriority? = nil,
+    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) {
+    async(priority: priority, operation: operation)
+  }
+
+  @available(*, deprecated, renamed: "asyncUnlessCancelled(priority:operation:)")
+  @_alwaysEmitIntoClient
+  public mutating func spawnUnlessCancelled(
+    priority: TaskPriority? = nil,
+    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) -> Bool {
+    asyncUnlessCancelled(priority: priority, operation: operation)
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+extension ThrowingTaskGroup {
+  @available(*, deprecated, renamed: "async(priority:operation:)")
+  @_alwaysEmitIntoClient
+  public mutating func add(
+    priority: TaskPriority? = nil,
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) async -> Bool {
+    return self.asyncUnlessCancelled(priority: priority) {
+      try await operation()
+    }
+  }
+
+  @available(*, deprecated, renamed: "async(priority:operation:)")
+  @_alwaysEmitIntoClient
+  public mutating func spawn(
+    priority: TaskPriority? = nil,
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) {
+    async(priority: priority, operation: operation)
+  }
+
+  @available(*, deprecated, renamed: "asyncUnlessCancelled(priority:operation:)")
+  @_alwaysEmitIntoClient
+  public mutating func spawnUnlessCancelled(
+    priority: TaskPriority? = nil,
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) -> Bool {
+    asyncUnlessCancelled(priority: priority, operation: operation)
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+@available(*, deprecated, message: "please use UnsafeContination<..., Error>")
+public typealias UnsafeThrowingContinuation<T> = UnsafeContinuation<T, Error>

--- a/stdlib/public/Concurrency/SourceCompatibilityShims.swift
+++ b/stdlib/public/Concurrency/SourceCompatibilityShims.swift
@@ -165,6 +165,30 @@ extension Task where Success == Never, Failure == Never {
 }
 
 @available(SwiftStdlib 5.5, *)
+extension Task {
+  @available(*, deprecated, message: "get() has been replaced by .value")
+  @_alwaysEmitIntoClient
+  public func get() async throws -> Success {
+    return try await value
+  }
+
+  @available(*, deprecated, message: "getResult() has been replaced by .result")
+  @_alwaysEmitIntoClient
+  public func getResult() async -> Result<Success, Failure>  {
+    return await result
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+extension Task where Failure == Never {
+  @available(*, deprecated, message: "get() has been replaced by .value")
+  @_alwaysEmitIntoClient
+  public func get() async -> Success {
+    return await value
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
 extension TaskGroup {
   @available(*, deprecated, renamed: "async(priority:operation:)")
   @_alwaysEmitIntoClient

--- a/stdlib/public/Concurrency/SourceCompatibilityShims.swift
+++ b/stdlib/public/Concurrency/SourceCompatibilityShims.swift
@@ -34,7 +34,16 @@ extension Task where Success == Never, Failure == Never {
 @available(SwiftStdlib 5.5, *)
 extension TaskPriority {
   @available(*, deprecated, message: "unspecified priority will be removed; use nil")
-  public static let unspecified: TaskPriority = .init(rawValue: 0x00)
+  @_alwaysEmitIntoClient
+  public static var unspecified: TaskPriority {
+    .init(rawValue: 0x00)
+  }
+
+  @available(*, deprecated, message: "userInteractive priority will be removed")
+  @_alwaysEmitIntoClient
+  public static var userInteractive: TaskPriority {
+    .init(rawValue: 0x21)
+  }
 }
 
 @available(SwiftStdlib 5.5, *)
@@ -55,7 +64,7 @@ extension Task where Failure == Error {
   @_alwaysEmitIntoClient
   @available(*, deprecated, message: "`Task.runDetached` was replaced by `Task.detached` and will be removed shortly.")
   public static func runDetached(
-    priority: TaskPriority = .unspecified,
+    priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> Success
   ) -> Task<Success, Failure> {
     detached(priority: priority, operation: operation)

--- a/stdlib/public/Concurrency/SourceCompatibilityShims.swift
+++ b/stdlib/public/Concurrency/SourceCompatibilityShims.swift
@@ -47,6 +47,15 @@ extension TaskPriority {
 }
 
 @available(SwiftStdlib 5.5, *)
+@_alwaysEmitIntoClient
+public func withTaskCancellationHandler<T>(
+  handler: @Sendable () -> (),
+  operation: () async throws -> T
+) async rethrows -> T {
+  try await withTaskCancellationHandler(operation: operation, onCancel: handler)
+}
+
+@available(SwiftStdlib 5.5, *)
 extension Task where Success == Never, Failure == Never {
   @available(*, deprecated, message: "`Task.withCancellationHandler` has been replaced by `withTaskCancellationHandler` and will be removed shortly.")
   @_alwaysEmitIntoClient

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -87,9 +87,26 @@ extension Task {
   /// If the task gets cancelled internally, e.g. by checking for cancellation
   /// and throwing a specific error or using `checkCancellation` the error
   /// thrown out of the task will be re-thrown here.
-  public func get() async throws -> Success {
-    return try await _taskFutureGetThrowing(_task)
+  public var value: Success {
+    get async throws {
+      return try await _taskFutureGetThrowing(_task)
+    }
   }
+
+  /// Wait for the task to complete, returning (or throwing) its result.
+  ///
+  /// ### Priority
+  /// If the task has not completed yet, its priority will be elevated to the
+  /// priority of the current task. Note that this may not be as effective as
+  /// creating the task with the "right" priority to in the first place.
+  ///
+  /// ### Cancellation
+  /// If the awaited on task gets cancelled externally the `get()` will throw
+  /// a cancellation error.
+  ///
+  /// If the task gets cancelled internally, e.g. by checking for cancellation
+  /// and throwing a specific error or using `checkCancellation` the error
+  /// thrown out of the task will be re-thrown here.
 
   /// Wait for the task to complete, returning its `Result`.
   ///
@@ -105,11 +122,13 @@ extension Task {
   /// If the task gets cancelled internally, e.g. by checking for cancellation
   /// and throwing a specific error or using `checkCancellation` the error
   /// thrown out of the task will be re-thrown here.
-  public func getResult() async -> Result<Success, Failure> {
-    do {
-      return .success(try await get())
-    } catch {
-      return .failure(error as! Failure) // as!-safe, guaranteed to be Failure
+  public var result: Result<Success, Failure> {
+    get async {
+      do {
+        return .success(try await get())
+      } catch {
+        return .failure(error as! Failure) // as!-safe, guaranteed to be Failure
+      }
     }
   }
 
@@ -142,8 +161,10 @@ extension Task where Failure == Never {
   /// way than throwing a `CancellationError`, e.g. it could provide a neutral
   /// value of the `Success` type, or encode that cancellation has occurred in
   /// that type itself.
-  public func get() async -> Success {
-    return await _taskFutureGet(_task)
+  public var value: Success {
+    get async {
+      return await _taskFutureGet(_task)
+    }
   }
 }
 

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -848,7 +848,7 @@ public func _runChildTask<T>(
   let currentTask = Builtin.getCurrentAsyncTask()
 
   // Set up the job flags for a new task.
-  var flags = Task.JobFlags()
+  var flags = JobFlags()
   flags.kind = .task
   flags.priority = getJobFlags(currentTask).priority ?? .unspecified
   flags.isFuture = true

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -17,7 +17,15 @@ import Swift
 
 /// A unit of asynchronous work.
 ///
-/// All asynchronous functions run as part of some task.
+/// An instance of `Task` always represents a "detached" task. The instance
+/// can be used to await its completion, cancel the task, etc., The task will
+/// run to completion even if there are no other instances of the `Task`.
+///
+/// `Task` also provides appropriate context-sensitive static functions which
+/// operate on the "current" task, which might either be a detached task or
+/// a child task. Because all such functions are `async` they can only
+/// be invoked as part of an existing task, and therefore are guaranteed to be
+/// effective.
 ///
 /// Only code that's running as part of the task can interact with that task,
 /// by invoking the appropriate context-sensitive static functions which operate
@@ -55,29 +63,199 @@ import Swift
 /// This reflects the fact that a task can be canceled for many reasons,
 /// and additional reasons can accrue during the cancellation process.
 @available(SwiftStdlib 5.5, *)
-public struct Task {
-  // Task instances should not be used as they could be stored away,
-  // and sine some tasks may be task-local allocated such stored away
-  // references could point at already destroyed task memory (!).
-  //
-  // If necessary to obtain a task instance, please use withUnsafeCurrentTask.
+public struct Task<Success, Failure: Error>: Sendable {
+  internal let _task: Builtin.NativeObject
+
+  internal init(_ task: Builtin.NativeObject) {
+    self._task = task
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+extension Task {
+  /// Wait for the task to complete, returning (or throwing) its result.
+  ///
+  /// ### Priority
+  /// If the task has not completed yet, its priority will be elevated to the
+  /// priority of the current task. Note that this may not be as effective as
+  /// creating the task with the "right" priority to in the first place.
+  ///
+  /// ### Cancellation
+  /// If the awaited on task gets cancelled externally the `get()` will throw
+  /// a cancellation error.
+  ///
+  /// If the task gets cancelled internally, e.g. by checking for cancellation
+  /// and throwing a specific error or using `checkCancellation` the error
+  /// thrown out of the task will be re-thrown here.
+  public func get() async throws -> Success {
+    return try await _taskFutureGetThrowing(_task)
+  }
+
+  /// Wait for the task to complete, returning its `Result`.
+  ///
+  /// ### Priority
+  /// If the task has not completed yet, its priority will be elevated to the
+  /// priority of the current task. Note that this may not be as effective as
+  /// creating the task with the "right" priority to in the first place.
+  ///
+  /// ### Cancellation
+  /// If the awaited on task gets cancelled externally the `get()` will throw
+  /// a cancellation error.
+  ///
+  /// If the task gets cancelled internally, e.g. by checking for cancellation
+  /// and throwing a specific error or using `checkCancellation` the error
+  /// thrown out of the task will be re-thrown here.
+  public func getResult() async -> Result<Success, Failure> {
+    do {
+      return .success(try await get())
+    } catch {
+      return .failure(error as! Failure) // as!-safe, guaranteed to be Failure
+    }
+  }
+
+  /// Attempt to cancel the task.
+  ///
+  /// Whether this function has any effect is task-dependent.
+  ///
+  /// For a task to respect cancellation it must cooperatively check for it
+  /// while running. Many tasks will check for cancellation before beginning
+  /// their "actual work", however this is not a requirement nor is it guaranteed
+  /// how and when tasks check for cancellation in general.
+  public func cancel() {
+    Builtin.cancelAsyncTask(_task)
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+extension Task where Failure == Never {
+  /// Wait for the task to complete, returning its result.
+  ///
+  /// If the task hasn't completed,
+  /// its priority increases to that of the current task.
+  /// Note that this might not be as effective as
+  /// creating the task with the correct priority,
+  /// depending on the executor's scheduling details.
+  ///
+  /// ### Cancellation
+  /// The task this refers to may check for cancellation, however
+  /// since it is not-throwing it would have to handle it using some other
+  /// way than throwing a `CancellationError`, e.g. it could provide a neutral
+  /// value of the `Success` type, or encode that cancellation has occurred in
+  /// that type itself.
+  public func get() async -> Success {
+    return await _taskFutureGet(_task)
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+extension Task: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    UnsafeRawPointer(Builtin.bridgeToRawPointer(_task)).hash(into: &hasher)
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+extension Task: Equatable {
+  public static func ==(lhs: Self, rhs: Self) -> Bool {
+    UnsafeRawPointer(Builtin.bridgeToRawPointer(lhs._task)) ==
+      UnsafeRawPointer(Builtin.bridgeToRawPointer(rhs._task))
+  }
 }
 
 // ==== Task Priority ----------------------------------------------------------
 
+/// Task priority may inform decisions an `Executor` makes about how and when
+/// to schedule tasks submitted to it.
+///
+/// ### Priority scheduling
+/// An executor MAY utilize priority information to attempt running higher
+/// priority tasks first, and then continuing to serve lower priority tasks.
+///
+/// The exact semantics of how priority is treated are left up to each
+/// platform and `Executor` implementation.
+///
+/// ### Priority inheritance
+/// Child tasks automatically inherit their parent task's priority.
+///
+/// Detached tasks (created by `detach`) DO NOT inherit task priority,
+/// as they are "detached" from their parent tasks after all.
+///
+/// ### Priority elevation
+/// In some situations the priority of a task must be elevated (or "escalated", "raised"):
+///
+/// - if a `Task` running on behalf of an actor, and a new higher-priority
+///   task is enqueued to the actor, its current task must be temporarily
+///   elevated to the priority of the enqueued task, in order to allow the new
+///   task to be processed at--effectively-- the priority it was enqueued with.
+///   - this DOES NOT affect `Task.currentPriority()`.
+/// - if a task is created with a `Task.Handle`, and a higher-priority task
+///   calls the `await handle.get()` function the priority of this task must be
+///   permanently increased until the task completes.
+///   - this DOES affect `Task.currentPriority()`.
+///
+/// TODO: Define the details of task priority; It is likely to be a concept
+///       similar to Darwin Dispatch's QoS; bearing in mind that priority is not as
+///       much of a thing on other platforms (i.e. server side Linux systems).
 @available(SwiftStdlib 5.5, *)
-extension Task {
+public struct TaskPriority: RawRepresentable, Sendable {
+  public typealias RawValue = Int
+  public var rawValue: Int
 
-  /// The current task's priority.
+  public init(rawValue: Int) {
+    self.rawValue = rawValue
+  }
+
+  public static let userInteractive: TaskPriority = .init(rawValue: 0x21)
+  public static let userInitiated: TaskPriority = .init(rawValue: 0x19)
+  public static let `default`: TaskPriority = .init(rawValue: 0x15)
+  public static let utility: TaskPriority = .init(rawValue: 0x11)
+  public static let background: TaskPriority = .init(rawValue: 0x09)
+}
+
+@available(SwiftStdlib 5.5, *)
+extension TaskPriority: Equatable {
+  public static func == (lhs: TaskPriority, rhs: TaskPriority) -> Bool {
+    lhs.rawValue == rhs.rawValue
+  }
+
+  public static func != (lhs: TaskPriority, rhs: TaskPriority) -> Bool {
+    lhs.rawValue != rhs.rawValue
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+extension TaskPriority: Comparable {
+  public static func < (lhs: TaskPriority, rhs: TaskPriority) -> Bool {
+    lhs.rawValue < rhs.rawValue
+  }
+
+  public static func <= (lhs: TaskPriority, rhs: TaskPriority) -> Bool {
+    lhs.rawValue <= rhs.rawValue
+  }
+
+  public static func > (lhs: TaskPriority, rhs: TaskPriority) -> Bool {
+    lhs.rawValue > rhs.rawValue
+  }
+
+  public static func >= (lhs: TaskPriority, rhs: TaskPriority) -> Bool {
+    lhs.rawValue >= rhs.rawValue
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+extension TaskPriority: Codable { }
+
+@available(SwiftStdlib 5.5, *)
+extension Task where Success == Never, Failure == Never {
+
+  /// Returns the `current` task's priority.
   ///
-  /// If you access this property outside of any task,
-  /// this queries the system to determine the
-  /// priority at which the current function is running.
-  /// If the system can't provide a priority,
-  /// this property's value is `Priority.default`.
+  /// If no current `Task` is available, queries the system to determine the
+  /// priority at which the current function is running. If the system cannot
+  /// provide an appropriate priority, returns `Priority.default`.
   ///
-  /// - SeeAlso: `Task.priority`
-  public static var currentPriority: Priority {
+  /// - SeeAlso: `TaskPriority`
+  public static var currentPriority: TaskPriority {
     withUnsafeCurrentTask { task in
       // If we are running on behalf of a task, use that task's priority.
       if let task = task {
@@ -85,62 +263,15 @@ extension Task {
       }
 
       // Otherwise, query the system.
-      return Task.Priority(rawValue: _getCurrentThreadPriority()) ?? .default
-    }
-  }
-
-  /// The priority of a task.
-  ///
-  /// The executor determines how priority information affects the way tasks are scheduled.
-  /// The behavior varies depending on the executor currently being used.
-  /// Typically, executors attempt to run tasks with a higher priority
-  /// before tasks with a lower priority.
-  /// However, the semantics of how priority is treated are left up to each
-  /// platform and `Executor` implementation.
-  ///
-  /// Child tasks automatically inherit their parent task's priority.
-  ///
-  /// Detached tasks created by `detach(priority:operation:)` don't inherit task priority
-  /// because they aren't attached to the current task.
-  ///
-  /// In some situations the priority of a task is elevated ---
-  /// that is, the task is treated as it if had a higher priority,
-  /// without actually changing the priority of the task:
-  ///
-  /// - If a task runs on behalf of an actor,
-  ///   and a new higher-priority task is enqueued to the actor,
-  ///   then the actor's current task is temporarily elevated
-  ///   to the priority of the enqueued task.
-  ///   This priority elevation allows the new task
-  ///   to be processed at (effectively) the priority it was enqueued with.
-  /// - If a task is created with a `Task.Handle`
-  ///   and a higher-priority task calls the `await handle.get()` method,
-  ///   then the priority of this task increases until the task completes.
-  ///
-  /// In both cases, priority elevation helps you prevent a low-priority task
-  /// blocking the execution of a high priority task,
-  /// which is also known as *priority inversion*.
-  public enum Priority: Int, Comparable {
-    // Values must be same as defined by the internal `JobPriority`.
-    case userInteractive = 0x21
-    case userInitiated   = 0x19
-    case `default`       = 0x15
-    case utility         = 0x11
-    case background      = 0x09
-
-    @available(*, deprecated, message: "unspecified priority will be removed; use nil")
-    case unspecified     = 0x00
-
-    public static func < (lhs: Priority, rhs: Priority) -> Bool {
-      lhs.rawValue < rhs.rawValue
+      return TaskPriority(rawValue: _getCurrentThreadPriority())
     }
   }
 }
 
 @available(SwiftStdlib 5.5, *)
-extension Task.Priority {
+extension TaskPriority {
   /// Downgrade user-interactive to user-initiated.
-  var _downgradeUserInteractive: Task.Priority {
+  var _downgradeUserInteractive: TaskPriority {
     if self == .userInteractive {
       return .userInitiated
     }
@@ -149,502 +280,319 @@ extension Task.Priority {
   }
 }
 
-// ==== Task Handle ------------------------------------------------------------
-
-@available(SwiftStdlib 5.5, *)
-extension Task {
-  /// An affordance to interact with an active task.
-  ///
-  /// You can use a task's handle to wait for its result or cancel the task.
-  ///
-  /// It is not a programming error to drop a handle without awaiting or cancelling it,
-  /// i.e. the task will run regardless of the handle still being present or not.
-  /// Dropping a handle however means losing the ability to await on the task's result
-  /// and losing the ability to cancel it.
-  ///
-  // Implementation notes:
-  // A task handle can ONLY be obtained for a detached task, and as such shares
-  // no lifetime concerns with regards to holding and storing the `_task` with
-  // the `Task` type, which would have also be obtainable for any task, including
-  // a potentially task-local allocated one. I.e. it is always safe to store away
-  // a Task.Handle, yet the same is not true for the "current task" which may be
-  // a async-let created task, at risk of getting destroyed while the reference
-  // lingers around.
-  public struct Handle<Success, Failure: Error>: Sendable {
-    internal let _task: Builtin.NativeObject
-
-    internal init(_ task: Builtin.NativeObject) {
-      self._task = task
-    }
-
-    /// Wait for the task to complete, returning its result or throw an error.
-    ///
-    /// If the task hasn't completed, its priority increases to the
-    /// priority of the current task. Note that this isn't as effective as
-    /// creating the task with the correct priority.
-    ///
-    /// If the task throws an error, this method propogates that error.
-    /// Tasks that respond to cancellation by throwing `Task.CancellationError`
-    /// have that error propogated here upon cancellation.
-    ///
-    /// - Returns: The task's result.
-    public func get() async throws -> Success {
-      return try await _taskFutureGetThrowing(_task)
-    }
-
-    /// Wait for the task to complete, returning its result or its error.
-    ///
-    /// If the task hasn't completed, its priority increases to the
-    /// priority of the current task. Note that this isn't as effective as
-    /// creating the task with the correct priority.
-    ///
-    /// If the task throws an error, this method propogates that error.
-    /// Tasks that respond to cancellation by throwing `Task.CancellationError`
-    /// have that error propogated here upon cancellation.
-    ///
-    /// - Returns: If the task succeeded, `.success`
-    /// with the task's result as the associated value;
-    /// otherwise, `.failure` with the error as the associated value.
-    public func getResult() async -> Result<Success, Failure> {
-      do {
-        return .success(try await get())
-      } catch {
-        return .failure(error as! Failure) // as!-safe, guaranteed to be Failure
-      }
-    }
-
-    /// Attempt to cancel the task.
-    ///
-    /// Whether this function has any effect is task-dependent.
-    ///
-    /// For a task to respect cancellation it must cooperatively check for it
-    /// while running. Many tasks check for cancellation before beginning
-    /// their "actual work"; however, this isn't a requirement nor is it guaranteed
-    /// how and when tasks check for cancellation.
-    public func cancel() {
-      Builtin.cancelAsyncTask(_task)
-    }
-  }
-}
-
-@available(SwiftStdlib 5.5, *)
-extension Task.Handle where Failure == Never {
-
-  /// Wait for the task to complete and return its result.
-  ///
-  /// If the task hasn't completed,
-  /// its priority increases to that of the current task.
-  /// Note that this might not be as effective as
-  /// creating the task with the correct priority,
-  /// depending on the executor's scheduling details.
-  ///
-  /// The task that this handle refers to might check for cancellation.
-  /// However, because this method is nonthrowing,
-  /// the task needs to handle cancellation using an approach like returning `nil`
-  /// instead of throwing an error.
-  public func get() async -> Success {
-    return await _taskFutureGet(_task)
-  }
-  
-}
-
-@available(SwiftStdlib 5.5, *)
-extension Task.Handle: Hashable {
-  public func hash(into hasher: inout Hasher) {
-    UnsafeRawPointer(Builtin.bridgeToRawPointer(_task)).hash(into: &hasher)
-  }
-}
-
-@available(SwiftStdlib 5.5, *)
-extension Task.Handle: Equatable {
-  public static func ==(lhs: Self, rhs: Self) -> Bool {
-    UnsafeRawPointer(Builtin.bridgeToRawPointer(lhs._task)) ==
-      UnsafeRawPointer(Builtin.bridgeToRawPointer(rhs._task))
-  }
-}
-
 // ==== Job Flags --------------------------------------------------------------
 
+/// Flags for schedulable jobs.
+///
+/// This is a port of the C++ FlagSet.
 @available(SwiftStdlib 5.5, *)
-extension Task {
-  /// Flags for schedulable jobs.
-  struct JobFlags {
-    /// Kinds of schedulable jobs.
-    enum Kind: Int32 {
-      case task = 0
+struct JobFlags {
+  /// Kinds of schedulable jobs.
+  enum Kind: Int32 {
+    case task = 0
+  }
+
+  /// The actual bit representation of these flags.
+  var bits: Int32 = 0
+
+  /// The kind of job described by these flags.
+  var kind: Kind {
+    get {
+      Kind(rawValue: bits & 0xFF)!
     }
 
-    /// The actual bit representation of these flags.
-    var bits: Int32 = 0
+    set {
+      bits = (bits & ~0xFF) | newValue.rawValue
+    }
+  }
 
-    /// The kind of job described by these flags.
-    var kind: Kind {
-      get {
-        Kind(rawValue: bits & 0xFF)!
+  /// Whether this is an asynchronous task.
+  var isAsyncTask: Bool { kind == .task }
+
+  /// The priority given to the job.
+  var priority: TaskPriority? {
+    get {
+      let value = (Int(bits) & 0xFF00) >> 8
+
+      if value == 0 {
+        return nil
       }
 
-      set {
-        bits = (bits & ~0xFF) | newValue.rawValue
-      }
+      return TaskPriority(rawValue: value)
     }
 
-    /// Whether this is an asynchronous task.
-    var isAsyncTask: Bool { kind == .task }
+    set {
+      bits = (bits & ~0xFF00) | Int32(((newValue?.rawValue ?? 0) << 8))
+    }
+  }
 
-    /// The priority given to the job.
-    var priority: Priority? {
-      get {
-        Priority(rawValue: (Int(bits) & 0xFF00) >> 8)
-      }
-
-      set {
-        bits = (bits & ~0xFF00) | Int32((newValue?.rawValue ?? 0) << 8)
-      }
+  /// Whether this is a child task.
+  var isChildTask: Bool {
+    get {
+      (bits & (1 << 24)) != 0
     }
 
-    /// Whether this is a child task.
-    var isChildTask: Bool {
-      get {
-        (bits & (1 << 24)) != 0
-      }
-
-      set {
-        if newValue {
-          bits = bits | 1 << 24
-        } else {
-          bits = (bits & ~(1 << 24))
-        }
+    set {
+      if newValue {
+        bits = bits | 1 << 24
+      } else {
+        bits = (bits & ~(1 << 24))
       }
     }
+  }
 
-    /// Whether this is a future.
-    var isFuture: Bool {
-      get {
-        (bits & (1 << 25)) != 0
-      }
-
-      set {
-        if newValue {
-          bits = bits | 1 << 25
-        } else {
-          bits = (bits & ~(1 << 25))
-        }
-      }
+  /// Whether this is a future.
+  var isFuture: Bool {
+    get {
+      (bits & (1 << 25)) != 0
     }
 
-    /// Whether this is a group child.
-    var isGroupChildTask: Bool {
-      get {
-        (bits & (1 << 26)) != 0
-      }
-
-      set {
-        if newValue {
-          bits = bits | 1 << 26
-        } else {
-          bits = (bits & ~(1 << 26))
-        }
+    set {
+      if newValue {
+        bits = bits | 1 << 25
+      } else {
+        bits = (bits & ~(1 << 25))
       }
     }
+  }
 
-    /// Whether this is a task created by an asynchronous operation,
-    /// continuing the work of the synchronous code that invokes it.
-    var isContinuingAsyncTask: Bool {
-      get {
-        (bits & (1 << 27)) != 0
-      }
+  /// Whether this is a group child.
+  var isGroupChildTask: Bool {
+    get {
+      (bits & (1 << 26)) != 0
+    }
 
-      set {
-        if newValue {
-          bits = bits | 1 << 27
-        } else {
-          bits = (bits & ~(1 << 27))
-        }
+    set {
+      if newValue {
+        bits = bits | 1 << 26
+      } else {
+        bits = (bits & ~(1 << 26))
       }
     }
+  }
+
+  /// Whether this is a task created by the 'async' operation, which
+  /// conceptually continues the work of the synchronous code that invokes
+  /// it.
+  var isContinuingAsyncTask: Bool {
+    get {
+      (bits & (1 << 27)) != 0
+    }
+
+    set {
+      if newValue {
+        bits = bits | 1 << 27
+      } else {
+        bits = (bits & ~(1 << 27))
+      }
+    }
+  }
+}
+
+// ==== Task Creation ----------------------------------------------------------
+@available(SwiftStdlib 5.5, *)
+extension Task where Failure == Never {
+  /// Run given `operation` as asynchronously in its own top-level task.
+  ///
+  /// The `async` function should be used when creating asynchronous work
+  /// that operates on behalf of the synchronous function that calls it.
+  /// Like `detach`, the async function creates a separate, top-level task.
+  /// Unlike `detach`, the task creating by `async` inherits the priority and
+  /// actor context of the caller, so the `operation` is treated more like an
+  /// asynchronous extension to the synchronous operation. Additionally, `async`
+  /// does not return a handle to refer to the task.
+  ///
+  /// - Parameters:
+  ///   - priority: priority of the task. If nil, the priority will come from
+  ///     Task.currentPriority.
+  ///   - operation: the operation to execute
+  @discardableResult
+  public init(
+    priority: TaskPriority? = nil,
+    @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping () async -> Success
+  ) {
+    // Set up the job flags for a new task.
+    var flags = JobFlags()
+    flags.kind = .task
+    flags.priority = priority ?? Task<Never, Never>.currentPriority._downgradeUserInteractive
+    flags.isFuture = true
+    flags.isContinuingAsyncTask = true
+
+    // Create the asynchronous task future.
+    let (task, _) = Builtin.createAsyncTaskFuture(Int(flags.bits), operation)
+
+    // Copy all task locals to the newly created task.
+    // We must copy them rather than point to the current task since the new task
+    // is not structured and may out-live the current task.
+    //
+    // WARNING: This MUST be done BEFORE we enqueue the task,
+    // because it acts as-if it was running inside the task and thus does not
+    // take any extra steps to synchronize the task-local operations.
+    _taskLocalsCopy(to: task)
+
+    // Enqueue the resulting job.
+    _enqueueJobGlobal(Builtin.convertTaskToJob(task))
+
+    self._task = task
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+extension Task where Failure == Error {
+  /// Run given `operation` as asynchronously in its own top-level task.
+  ///
+  /// The `async` function should be used when creating asynchronous work
+  /// that operates on behalf of the synchronous function that calls it.
+  /// Like `detach`, the async function creates a separate, top-level task.
+  /// Unlike `detach`, the task creating by `async` inherits the priority and
+  /// actor context of the caller, so the `operation` is treated more like an
+  /// asynchronous extension to the synchronous operation. Additionally, `async`
+  /// does not return a handle to refer to the task.
+  ///
+  /// - Parameters:
+  ///   - priority: priority of the task. If nil, the priority will come from
+  ///     Task.currentPriority.
+  ///   - operation: the operation to execute
+  @discardableResult
+  public init(
+    priority: TaskPriority? = nil,
+    @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping () async throws -> Success
+  ) {
+    // Set up the job flags for a new task.
+    var flags = JobFlags()
+    flags.kind = .task
+    flags.priority = priority ?? Task<Never, Never>.currentPriority._downgradeUserInteractive
+    flags.isFuture = true
+    flags.isContinuingAsyncTask = true
+
+    // Create the asynchronous task future.
+    let (task, _) = Builtin.createAsyncTaskFuture(Int(flags.bits), operation)
+
+    // Copy all task locals to the newly created task.
+    // We must copy them rather than point to the current task since the new task
+    // is not structured and may out-live the current task.
+    //
+    // WARNING: This MUST be done BEFORE we enqueue the task,
+    // because it acts as-if it was running inside the task and thus does not
+    // take any extra steps to synchronize the task-local operations.
+    _taskLocalsCopy(to: task)
+
+    // Enqueue the resulting job.
+    _enqueueJobGlobal(Builtin.convertTaskToJob(task))
+
+    self._task = task
   }
 }
 
 // ==== Detached Tasks ---------------------------------------------------------
-
 @available(SwiftStdlib 5.5, *)
-extension Task {
-
+extension Task where Failure == Never {
+  /// Run given throwing `operation` as part of a new top-level task.
+  ///
+  /// Creating detached tasks should, generally, be avoided in favor of using
+  /// `async` functions, `async let` declarations and `await` expressions - as
+  /// those benefit from structured, bounded concurrency which is easier to reason
+  /// about, as well as automatically inheriting the parent tasks priority,
+  /// task-local storage, deadlines, as well as being cancelled automatically
+  /// when their parent task is cancelled. Detached tasks do not get any of those
+  /// benefits, and thus should only be used when an operation is impossible to
+  /// be modelled with child tasks.
+  ///
+  /// ### Cancellation
+  /// A detached task always runs to completion unless it is explicitly cancelled.
+  /// Specifically, dropping a detached tasks `Task.Handle` does _not_ automatically
+  /// cancel given task.
+  ///
+  /// Cancelling a task must be performed explicitly via `handle.cancel()`.
+  ///
+  /// - Note: it is generally preferable to use child tasks rather than detached
+  ///   tasks. Child tasks automatically carry priorities, task-local state,
+  ///   deadlines and have other benefits resulting from the structured
+  ///   concurrency concepts that they model. Consider using detached tasks only
+  ///   when strictly necessary and impossible to model operations otherwise.
+  ///
+  /// - Parameters:
+  ///   - priority: priority of the task
+  ///   - executor: the executor on which the detached closure should start
+  ///               executing on.
+  ///   - operation: the operation to execute
+  /// - Returns: handle to the task, allowing to `await handle.get()` on the
+  ///     tasks result or `cancel` it. If the operation fails the handle will
+  ///     throw the error the operation has thrown when awaited on.
   @discardableResult
-  @available(*, deprecated, message: "`Task.runDetached` was replaced by `detach` and will be removed shortly.")
-  public static func runDetached<T>(
-    priority: Task.Priority = .unspecified,
-    operation: __owned @Sendable @escaping () async throws -> T
-  ) -> Task.Handle<T, Error> {
-    detach(priority: priority, operation: operation)
+  public static func detached(
+    priority: TaskPriority? = nil,
+    operation: __owned @Sendable @escaping () async -> Success
+  ) -> Task<Success, Failure> {
+    // Set up the job flags for a new task.
+    var flags = JobFlags()
+    flags.kind = .task
+    flags.priority = priority ?? .default
+    flags.isFuture = true
+
+    // Create the asynchronous task future.
+    let (task, _) = Builtin.createAsyncTaskFuture(Int(flags.bits), operation)
+
+    // Enqueue the resulting job.
+    _enqueueJobGlobal(Builtin.convertTaskToJob(task))
+
+    return Task(task)
   }
-
 }
 
-/// Runs the given nonthrowing operation asynchronously
-/// as part of a new top-level task.
-///
-/// Don't use a detached task unless it isn't possible
-/// to model the operation using structured concurrency features like child tasks.
-/// Child tasks inherit the parent task's priority and task-local storage,
-/// and canceling a parent task automatically cancels all of its child tasks.
-/// You need to handle these considerations manually with a detached task.
-///
-/// You need to keep a reference to the task's handle
-/// if you need to cancel it by calling the `Task.Handle.cancel()` method.
-/// Discarding a detached task's handle doesn't implicitly cancel that task,
-/// it only makes it impossible for you to explicitly cancel the task.
-///
-/// - Parameters:
-///   - priority: The priority of the task.
-///   - operation: The operation to perform.
-///
-/// - Returns: A handle to the task.
-@discardableResult
 @available(SwiftStdlib 5.5, *)
-public func detach<T>(
-  priority: Task.Priority = .unspecified,
-  operation: __owned @Sendable @escaping () async -> T
-) -> Task.Handle<T, Never> {
-  // Set up the job flags for a new task.
-  var flags = Task.JobFlags()
-  flags.kind = .task
-  flags.priority = priority
-  flags.isFuture = true
+extension Task where Failure == Error {
+  /// Run given throwing `operation` as part of a new top-level task.
+  ///
+  /// Creating detached tasks should, generally, be avoided in favor of using
+  /// `async` functions, `async let` declarations and `await` expressions - as
+  /// those benefit from structured, bounded concurrency which is easier to reason
+  /// about, as well as automatically inheriting the parent tasks priority,
+  /// task-local storage, deadlines, as well as being cancelled automatically
+  /// when their parent task is cancelled. Detached tasks do not get any of those
+  /// benefits, and thus should only be used when an operation is impossible to
+  /// be modelled with child tasks.
+  ///
+  /// ### Cancellation
+  /// A detached task always runs to completion unless it is explicitly cancelled.
+  /// Specifically, dropping a detached tasks `Task.Handle` does _not_ automatically
+  /// cancel given task.
+  ///
+  /// Cancelling a task must be performed explicitly via `handle.cancel()`.
+  ///
+  /// - Note: it is generally preferable to use child tasks rather than detached
+  ///   tasks. Child tasks automatically carry priorities, task-local state,
+  ///   deadlines and have other benefits resulting from the structured
+  ///   concurrency concepts that they model. Consider using detached tasks only
+  ///   when strictly necessary and impossible to model operations otherwise.
+  ///
+  /// - Parameters:
+  ///   - priority: priority of the task
+  ///   - executor: the executor on which the detached closure should start
+  ///               executing on.
+  ///   - operation: the operation to execute
+  /// - Returns: handle to the task, allowing to `await handle.get()` on the
+  ///     tasks result or `cancel` it. If the operation fails the handle will
+  ///     throw the error the operation has thrown when awaited on.
+  @discardableResult
+  public static func detached(
+    priority: TaskPriority? = nil,
+    operation: __owned @Sendable @escaping () async throws -> Success
+  ) -> Task<Success, Failure> {
+    // Set up the job flags for a new task.
+    var flags = JobFlags()
+    flags.kind = .task
+    flags.priority = priority ?? .default
+    flags.isFuture = true
 
-  // Create the asynchronous task future.
-  let (task, _) = Builtin.createAsyncTaskFuture(Int(flags.bits), operation)
+    // Create the asynchronous task future.
+    let (task, _) = Builtin.createAsyncTaskFuture(Int(flags.bits), operation)
 
-  // Enqueue the resulting job.
-  _enqueueJobGlobal(Builtin.convertTaskToJob(task))
+    // Enqueue the resulting job.
+    _enqueueJobGlobal(Builtin.convertTaskToJob(task))
 
-  return Task.Handle<T, Never>(task)
-}
-
-/// Runs the given throwing operation asynchronously
-/// as part of a new top-level task.
-///
-/// If the operation throws an error, this method propogates that error.
-///
-/// Avoid using a detached task unless it isn't possible
-/// to model the operation using structured concurrency features like child tasks.
-/// Child tasks inherit the parent task's priority and task-local storage,
-/// and canceling a parent task automatically cancels all of its child tasks.
-/// You need to handle these considerations manually with a detached task.
-///
-/// A detached task runs to completion
-/// unless it is explicitly canceled by calling the `Task.Handle.cancel()` method.
-/// Specifically, dropping a detached task's handle
-/// doesn't cancel that task.
-///
-/// - Parameters:
-///   - priority: The priority of the task.
-///   - operation: The operation to perform.
-///
-/// - Returns: A handle to the task.
-@discardableResult
-@available(SwiftStdlib 5.5, *)
-public func detach<T>(
-  priority: Task.Priority = .unspecified,
-  operation: __owned @Sendable @escaping () async throws -> T
-) -> Task.Handle<T, Error> {
-  // Set up the job flags for a new task.
-  var flags = Task.JobFlags()
-  flags.kind = .task
-  flags.priority = priority
-  flags.isFuture = true
-
-  // Create the asynchronous task future.
-  let (task, _) = Builtin.createAsyncTaskFuture(Int(flags.bits), operation)
-
-  // Enqueue the resulting job.
-  _enqueueJobGlobal(Builtin.convertTaskToJob(task))
-
-  return Task.Handle<T, Error>(task)
-}
-
-/// Runs the given nonthrowing operation asynchronously
-/// as part of a new top-level task.
-///
-/// Avoid using a detached task unless it isn't possible
-/// to model the operation using structured concurrency features like child tasks.
-/// Child tasks inherit the parent task's priority and task-local storage,
-/// and canceling a parent task automatically cancels all of its child tasks.
-/// You need to handle these considerations manually with a detached task.
-///
-/// A detached task runs to completion
-/// unless it is explicitly canceled by calling the `Task.Handle.cancel()` method.
-/// Specifically, dropping a detached task's handle
-/// doesn't cancel that task.
-///
-/// - Parameters:
-///   - priority: The priority of the task.
-///   - operation: The operation to perform.
-///
-/// - Returns: A handle to the task.
-@discardableResult
-@available(SwiftStdlib 5.5, *)
-public func asyncDetached<T>(
-  priority: Task.Priority? = nil,
-  @_implicitSelfCapture operation: __owned @Sendable @escaping () async -> T
-) -> Task.Handle<T, Never> {
-  return detach(priority: priority ?? .unspecified, operation: operation)
-}
-
-/// Runs the given throwing operation asynchronously
-/// as part of a new top-level task.
-///
-/// If the operation throws an error, this method propogates that error.
-///
-/// Don't use a detached task unless it isn't possible
-/// to model the operation using structured concurrency features like child tasks.
-/// Child tasks inherit the parent task's priority and task-local storage,
-/// and canceling a parent task automatically cancels all of its child tasks.
-/// You need to handle these considerations manually with a detached task.
-///
-/// A detached task runs to completion
-/// unless it is explicitly canceled by calling the `Task.Handle.cancel()` method.
-/// Specifically, dropping a detached task's handle
-/// doesn't cancel that task.
-///
-/// - Parameters:
-///   - priority: The priority of the task.
-///   - operation: The operation to perform.
-///
-/// - Returns: A handle to the task.
-@discardableResult
-@available(SwiftStdlib 5.5, *)
-public func asyncDetached<T>(
-  priority: Task.Priority? = nil,
-  @_implicitSelfCapture operation: __owned @Sendable @escaping () async throws -> T
-) -> Task.Handle<T, Error> {
-  return detach(priority: priority ?? .unspecified, operation: operation)
-}
-
-// ABI stub while we stage in the new signatures
-/// Runs the given nonthrowing operation asynchronously
-/// as part of a new top-level task on behalf of the current actor.
-///
-/// Use this function when creating asynchronous work
-/// that operates on behalf of the synchronous function that calls it.
-/// Like `detach(priority:operation:)`,
-/// this function creates a separate, top-level task.
-/// Unlike `detach(priority:operation:)`,
-/// the task created by `async(priority:operation:)`
-/// inherits the priority and actor context of the caller,
-/// so the operation is treated more like an asynchronous extension
-/// to the synchronous operation.
-///
-/// - Parameters:
-///   - priority: The priority of the task.
-///     Pass `nil` to use the priority from `Task.currentPriority`.
-///   - operation: The operation to perform.
-///
-/// - Returns: A handle to the task.
-@available(SwiftStdlib 5.5, *)
-@usableFromInline
-func async(
-  priority: Task.Priority,
-  @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping () async -> Void
-) {
-  let adjustedPriority: Task.Priority?
-  if priority == .unspecified {
-    adjustedPriority = nil
-  } else {
-    adjustedPriority = priority
+    return Task(task)
   }
-  let _: Task.Handle = async(priority: adjustedPriority, operation: operation)
-}
-
-/// Runs the given nonthrowing operation asynchronously
-/// as part of a new top-level task on behalf of the current actor.
-///
-/// Use this function when creating asynchronous work
-/// that operates on behalf of the synchronous function that calls it.
-/// Like `detach(priority:operation:)`,
-/// this function creates a separate, top-level task.
-/// Unlike `detach(priority:operation:)`,
-/// the task created by `async(priority:operation:)`
-/// inherits the priority and actor context of the caller,
-/// so the operation is treated more like an asynchronous extension
-/// to the synchronous operation.
-///
-/// - Parameters:
-///   - priority: The priority of the task.
-///     Pass `nil` to use the priority from `Task.currentPriority`.
-///   - operation: The operation to perform.
-///
-/// - Returns: A handle to the task.
-@available(SwiftStdlib 5.5, *)
-@discardableResult
-public func async<T>(
-  priority: Task.Priority? = nil,
-  @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping () async -> T
-) -> Task.Handle<T, Never> {
-  // Set up the job flags for a new task.
-  var flags = Task.JobFlags()
-  flags.kind = .task
-  flags.priority = priority ?? Task.currentPriority._downgradeUserInteractive
-  flags.isFuture = true
-  flags.isContinuingAsyncTask = true
-
-  // Create the asynchronous task future.
-  let (task, _) = Builtin.createAsyncTaskFuture(Int(flags.bits), operation)
-
-  // Copy all task locals to the newly created task.
-  // We must copy them rather than point to the current task since the new task
-  // is not structured and may out-live the current task.
-  //
-  // WARNING: This MUST be done BEFORE we enqueue the task,
-  // because it acts as-if it was running inside the task and thus does not
-  // take any extra steps to synchronize the task-local operations.
-  _taskLocalsCopy(to: task)
-
-  // Enqueue the resulting job.
-  _enqueueJobGlobal(Builtin.convertTaskToJob(task))
-
-  return Task.Handle(task)
-}
-
-/// Runs the given throwing operation asynchronously
-/// as part of a new top-level task on behalf of the current actor.
-///
-/// Use this function when creating asynchronous work
-/// that operates on behalf of the synchronous function that calls it.
-/// Like `detach(priority:operation:)`,
-/// this function creates a separate, top-level task.
-/// Unlike `detach(priority:operation:)`,
-/// the task created by `async(priority:operation:)`
-/// inherits the priority and actor context of the caller,
-/// so the operation is treated more like an asynchronous extension
-/// to the synchronous operation.
-///
-/// - Parameters:
-///   - priority: The priority of the task.
-///     Pass `nil` to use the priority from `Task.currentPriority`.
-///   - operation: The operation to perform.
-///
-/// - Returns: A handle to the task.
-@available(SwiftStdlib 5.5, *)
-@discardableResult
-public func async<T>(
-  priority: Task.Priority? = nil,
-  @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping () async throws -> T
-) -> Task.Handle<T, Error> {
-  // Set up the job flags for a new task.
-  var flags = Task.JobFlags()
-  flags.kind = .task
-  flags.priority = priority ?? Task.currentPriority._downgradeUserInteractive
-  flags.isFuture = true
-  flags.isContinuingAsyncTask = true
-
-  // Create the asynchronous task future.
-  let (task, _) = Builtin.createAsyncTaskFuture(Int(flags.bits), operation)
-
-  // Enqueue the resulting job.
-  _enqueueJobGlobal(Builtin.convertTaskToJob(task))
-
-  return Task.Handle(task)
 }
 
 // ==== Async Handler ----------------------------------------------------------
@@ -661,14 +609,9 @@ func _runAsyncHandler(operation: @escaping () async -> ()) {
 // ==== Async Sleep ------------------------------------------------------------
 
 @available(SwiftStdlib 5.5, *)
-extension Task {
-  /// Suspends the current task
-  /// and waits for at least the given duration before resuming.
-  ///
-  /// This method doesn't guarantee how long the task is suspended.
-  /// Depending on a variety of factors,
-  /// it could be suspended for exactly the given duration,
-  /// or for a longer duration.
+extension Task where Success == Never, Failure == Never {
+  /// Suspends the current task for _at least_ the given duration
+  /// in nanoseconds.
   ///
   /// Calling this method doesn't block the underlying thread.
   ///
@@ -688,7 +631,7 @@ extension Task {
 // ==== Voluntary Suspension -----------------------------------------------------
 
 @available(SwiftStdlib 5.5, *)
-extension Task {
+extension Task where Success == Never, Failure == Never {
 
   /// Suspends the current task and allows other tasks to execute.
   ///
@@ -715,23 +658,8 @@ extension Task {
 
 // ==== UnsafeCurrentTask ------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
-extension Task {
-
-  @available(*, deprecated, message: "`Task.unsafeCurrent` was replaced by `withUnsafeCurrentTask { task in ... }`, and will be removed soon.")
-  public static var unsafeCurrent: UnsafeCurrentTask? { // TODO: remove as soon as possible
-    guard let _task = _getCurrentAsyncTask() else {
-      return nil
-    }
-    // FIXME: This retain seems pretty wrong, however if we don't we WILL crash
-    //        with "destroying a task that never completed" in the task's destroy.
-    //        How do we solve this properly?
-    Builtin.retain(_task)
-    return UnsafeCurrentTask(_task)
-  }
-}
-
-/// Calls a closure with an unsafe handle to current task.
+/// Calls the given closure with the with the "current" task in which this
+/// function was invoked.
 ///
 /// If you call this function from the body of an asynchronous function,
 /// the unsafe task handle passed to the closure is always non-nil
@@ -807,11 +735,11 @@ public struct UnsafeCurrentTask {
 
   /// The current task's priority.
   ///
+  /// - SeeAlso: `TaskPriority`
   /// - SeeAlso: `Task.currentPriority`
-  public var priority: Task.Priority {
+  public var priority: TaskPriority {
     getJobFlags(_task).priority ?? .default
   }
-
 }
 
 @available(SwiftStdlib 5.5, *)
@@ -837,7 +765,7 @@ func _getCurrentAsyncTask() -> Builtin.NativeObject?
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_getJobFlags")
-func getJobFlags(_ task: Builtin.NativeObject) -> Task.JobFlags
+func getJobFlags(_ task: Builtin.NativeObject) -> JobFlags
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_enqueueGlobal")
@@ -955,9 +883,9 @@ func _getCurrentThreadPriority() -> Int
 @usableFromInline
 internal func _runTaskForBridgedAsyncMethod(_ body: @escaping () async -> Void) {
 #if compiler(>=5.5) && $Sendable && $InheritActorContext && $ImplicitSelfCapture
-  async { await body() }
+  Task { await body() }
 #else
-  detach { await body() }
+  Task.runDetached { await body() }
 #endif
 }
 

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -198,17 +198,18 @@ extension Task: Equatable {
 ///       much of a thing on other platforms (i.e. server side Linux systems).
 @available(SwiftStdlib 5.5, *)
 public struct TaskPriority: RawRepresentable, Sendable {
-  public typealias RawValue = Int
-  public var rawValue: Int
+  public typealias RawValue = UInt8
+  public var rawValue: UInt8
 
-  public init(rawValue: Int) {
+  public init(rawValue: UInt8) {
     self.rawValue = rawValue
   }
 
-  public static let userInteractive: TaskPriority = .init(rawValue: 0x21)
-  public static let userInitiated: TaskPriority = .init(rawValue: 0x19)
+  public static let high: TaskPriority = .init(rawValue: 0x19)
+  public static let userInitiated: TaskPriority = high
   public static let `default`: TaskPriority = .init(rawValue: 0x15)
-  public static let utility: TaskPriority = .init(rawValue: 0x11)
+  public static let low: TaskPriority = .init(rawValue: 0x11)
+  public static let utility: TaskPriority = low
   public static let background: TaskPriority = .init(rawValue: 0x09)
 }
 
@@ -263,7 +264,7 @@ extension Task where Success == Never, Failure == Never {
       }
 
       // Otherwise, query the system.
-      return TaskPriority(rawValue: _getCurrentThreadPriority())
+      return TaskPriority(rawValue: UInt8(_getCurrentThreadPriority()))
     }
   }
 }
@@ -318,11 +319,11 @@ struct JobFlags {
         return nil
       }
 
-      return TaskPriority(rawValue: value)
+      return TaskPriority(rawValue: UInt8(value))
     }
 
     set {
-      bits = (bits & ~0xFF00) | Int32(((newValue?.rawValue ?? 0) << 8))
+      bits = (bits & ~0xFF00) | Int32((Int(newValue?.rawValue ?? 0) << 8))
     }
   }
 
@@ -620,7 +621,7 @@ extension Task where Success == Never, Failure == Never {
     let priority = getJobFlags(currentTask).priority ?? Task.currentPriority._downgradeUserInteractive
 
     return await Builtin.withUnsafeContinuation { (continuation: Builtin.RawUnsafeContinuation) -> Void in
-      let job = _taskCreateNullaryContinuationJob(priority: priority.rawValue, continuation: continuation)
+      let job = _taskCreateNullaryContinuationJob(priority: Int(priority.rawValue), continuation: continuation)
       _enqueueJobGlobalWithDelay(duration, job)
     }
   }
@@ -648,7 +649,7 @@ extension Task where Success == Never, Failure == Never {
     let priority = getJobFlags(currentTask).priority ?? Task.currentPriority._downgradeUserInteractive
 
     return await Builtin.withUnsafeContinuation { (continuation: Builtin.RawUnsafeContinuation) -> Void in
-      let job = _taskCreateNullaryContinuationJob(priority: priority.rawValue, continuation: continuation)
+      let job = _taskCreateNullaryContinuationJob(priority: Int(priority.rawValue), continuation: continuation)
       _enqueueJobGlobal(job)
     }
   }

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -17,7 +17,7 @@ import Swift
 
 /// A unit of asynchronous work.
 ///
-/// An instance of `Task` always represents a "detached" task. The instance
+/// An instance of `Task` always represents a top-level task. The instance
 /// can be used to await its completion, cancel the task, etc., The task will
 /// run to completion even if there are no other instances of the `Task`.
 ///
@@ -177,7 +177,7 @@ extension Task: Equatable {
 /// ### Priority inheritance
 /// Child tasks automatically inherit their parent task's priority.
 ///
-/// Detached tasks (created by `detach`) DO NOT inherit task priority,
+/// Detached tasks (created by `Task.detached`) DO NOT inherit task priority,
 /// as they are "detached" from their parent tasks after all.
 ///
 /// ### Priority elevation
@@ -396,11 +396,13 @@ extension Task where Failure == Never {
   ///
   /// The `async` function should be used when creating asynchronous work
   /// that operates on behalf of the synchronous function that calls it.
-  /// Like `detach`, the async function creates a separate, top-level task.
-  /// Unlike `detach`, the task creating by `async` inherits the priority and
-  /// actor context of the caller, so the `operation` is treated more like an
-  /// asynchronous extension to the synchronous operation. Additionally, `async`
-  /// does not return a handle to refer to the task.
+  /// Like `Task.detached`, the async function creates a separate, top-level
+  /// task.
+  ///
+  /// Unlike `Task.detached`, the task creating by the `Task` initializer
+  /// inherits the priority and actor context of the caller, so the `operation`
+  /// is treated more like an asynchronous extension to the synchronous
+  /// operation.
   ///
   /// - Parameters:
   ///   - priority: priority of the task. If nil, the priority will come from
@@ -441,13 +443,11 @@ extension Task where Failure == Never {
 extension Task where Failure == Error {
   /// Run given `operation` as asynchronously in its own top-level task.
   ///
-  /// The `async` function should be used when creating asynchronous work
-  /// that operates on behalf of the synchronous function that calls it.
-  /// Like `detach`, the async function creates a separate, top-level task.
-  /// Unlike `detach`, the task creating by `async` inherits the priority and
+  /// This initializer creates asynchronous work on behalf of the synchronous function that calls it.
+  /// Like `Task.detached`, this initializer creates a separate, top-level task.
+  /// Unlike `Task.detached`, the task created inherits the priority and
   /// actor context of the caller, so the `operation` is treated more like an
-  /// asynchronous extension to the synchronous operation. Additionally, `async`
-  /// does not return a handle to refer to the task.
+  /// asynchronous extension to the synchronous operation.
   ///
   /// - Parameters:
   ///   - priority: priority of the task. If nil, the priority will come from
@@ -500,10 +500,10 @@ extension Task where Failure == Never {
   ///
   /// ### Cancellation
   /// A detached task always runs to completion unless it is explicitly cancelled.
-  /// Specifically, dropping a detached tasks `Task.Handle` does _not_ automatically
+  /// Specifically, dropping a detached tasks `Task` does _not_ automatically
   /// cancel given task.
   ///
-  /// Cancelling a task must be performed explicitly via `handle.cancel()`.
+  /// Cancelling a task must be performed explicitly via `cancel()`.
   ///
   /// - Note: it is generally preferable to use child tasks rather than detached
   ///   tasks. Child tasks automatically carry priorities, task-local state,
@@ -513,10 +513,8 @@ extension Task where Failure == Never {
   ///
   /// - Parameters:
   ///   - priority: priority of the task
-  ///   - executor: the executor on which the detached closure should start
-  ///               executing on.
   ///   - operation: the operation to execute
-  /// - Returns: handle to the task, allowing to `await handle.get()` on the
+  /// - Returns: handle to the task, allowing to `await get()` on the
   ///     tasks result or `cancel` it. If the operation fails the handle will
   ///     throw the error the operation has thrown when awaited on.
   @discardableResult
@@ -784,7 +782,7 @@ public func _asyncMainDrainQueue() -> Never
 @available(SwiftStdlib 5.5, *)
 public func _runAsyncMain(_ asyncFun: @escaping () async throws -> ()) {
 #if os(Windows)
-  detach {
+  Task.detached {
     do {
       try await asyncFun()
       exit(0)
@@ -802,7 +800,7 @@ public func _runAsyncMain(_ asyncFun: @escaping () async throws -> ()) {
     }
   }
 
-  detach {
+  Task.detached {
     await _doMain(asyncFun)
     exit(0)
   }

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -29,8 +29,8 @@ import Swift
 /// This function returns immediately and never suspends.
 @available(SwiftStdlib 5.5, *)
 public func withTaskCancellationHandler<T>(
-  handler: @Sendable () -> (),
-  operation: () async throws -> T
+  operation: () async throws -> T,
+  onCancel handler: @Sendable () -> Void
 ) async rethrows -> T {
   let task = Builtin.getCurrentAsyncTask()
 

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -48,23 +48,9 @@ public func withTaskCancellationHandler<T>(
 
 @available(SwiftStdlib 5.5, *)
 extension Task {
-
-  /// A Boolean value that indicates whether
-  /// the current task should stop executing.
-  ///
-  /// If there is no current task, the value of this property is `false`.
+  /// Returns `true` if the task is cancelled, and should stop executing.
   ///
   /// - SeeAlso: `checkCancellation()`
-  public static var isCancelled: Bool {
-     withUnsafeCurrentTask { task in
-       task?.isCancelled ?? false
-     }
-  }
-
-  /// A Boolean value that indicates whether the task should stop executing.
-  ///
-  /// - SeeAlso: `checkCancellation()`
-  @available(*, deprecated, message: "Storing `Task` instances has been deprecated and will be removed soon. Use the static 'Task.isCancelled' instead.")
   public var isCancelled: Bool {
     withUnsafeCurrentTask { task in
       guard let task = task else {
@@ -74,27 +60,37 @@ extension Task {
       return _taskIsCancelled(task._task)
     }
   }
+}
 
-  /// Throws a cancellation error if the current task was canceled.
+@available(SwiftStdlib 5.5, *)
+extension Task where Success == Never, Failure == Never {
+  /// Returns `true` if the task is cancelled, and should stop executing.
+  ///
+  /// If no current `Task` is available, returns `false`, as outside of a task
+  /// context no task cancellation may be observed.
+  ///
+  /// - SeeAlso: `checkCancellation()`
+  public static var isCancelled: Bool {
+     withUnsafeCurrentTask { task in
+       task?.isCancelled ?? false
+     }
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+extension Task where Success == Never, Failure == Never {
+  /// Check if the task is cancelled and throw an `CancellationError` if it was.
   ///
   /// The error is always an instance of `Task.CancellationError`.
   ///
   /// - SeeAlso: `isCancelled()`
   public static func checkCancellation() throws {
-    if Task.isCancelled {
+    if Task<Never, Never>.isCancelled {
       throw CancellationError()
     }
   }
 
-  @available(*, deprecated, message: "`Task.withCancellationHandler` has been replaced by `withTaskCancellationHandler` and will be removed shortly.")
-  public static func withCancellationHandler<T>(
-    handler: @Sendable () -> (),
-    operation: () async throws -> T
-  ) async rethrows -> T {
-    try await withTaskCancellationHandler(handler: handler, operation: operation)
-  }
-
-  /// The default error thrown by a canceled task.
+  /// The default cancellation thrown when a task is cancelled.
   ///
   /// The `Task.checkCancellation()` method throws this error
   /// if the current task has been canceled.

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -89,17 +89,16 @@ extension Task where Success == Never, Failure == Never {
       throw CancellationError()
     }
   }
+}
 
-  /// The default cancellation thrown when a task is cancelled.
-  ///
-  /// The `Task.checkCancellation()` method throws this error
-  /// if the current task has been canceled.
-  /// You can throw this error in your cancellation-checking code,
-  /// or another more specific error if needed.
-  public struct CancellationError: Error {
-    // no extra information, cancellation is intended to be light-weight
-    public init() {}
-  }
+/// The default cancellation thrown when a task is cancelled.
+///
+/// This error is also thrown automatically by `Task.checkCancellation()`,
+/// if the current task has been cancelled.
+@available(SwiftStdlib 5.5, *)
+public struct CancellationError: Error {
+  // no extra information, cancellation is intended to be light-weight
+  public init() {}
 }
 
 @available(SwiftStdlib 5.5, *)

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -15,25 +15,8 @@ import Swift
 
 // ==== TaskGroup --------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
-extension Task {
-  @available(*, deprecated, message: "`Task.Group` was replaced by `ThrowingTaskGroup` and `TaskGroup` and will be removed shortly.")
-  public typealias Group<TaskResult> = ThrowingTaskGroup<TaskResult, Error>
-
-  @available(*, deprecated, message: "`Task.withGroup` was replaced by `withThrowingTaskGroup` and `withTaskGroup` and will be removed shortly.")
-  public static func withGroup<TaskResult, BodyResult>(
-      resultType: TaskResult.Type,
-      returning returnType: BodyResult.Type = BodyResult.self,
-      body: (inout Task.Group<TaskResult>) async throws -> BodyResult
-  ) async rethrows -> BodyResult {
-    try await withThrowingTaskGroup(of: resultType) { group in
-      try await body(&group)
-    }
-  }
-}
-
-
-/// Starts a new scope in which a dynamic number of tasks can be spawned.
+/// Starts a new task group which provides a scope in which a dynamic number of
+/// tasks may be spawned.
 ///
 /// When the group returns,
 /// it implicitly waits for all spawned tasks to complete.
@@ -237,111 +220,63 @@ public struct TaskGroup<ChildTaskResult> {
     self._group = group
   }
 
-  @available(*, deprecated, message: "`Task.Group.add` has been replaced by `TaskGroup.spawn` or `TaskGroup.spawnUnlessCancelled` and will be removed shortly.")
-  public mutating func add(
-      priority: Task.Priority = .unspecified,
-      operation: __owned @Sendable @escaping () async -> ChildTaskResult
-  ) async -> Bool {
-    return self.spawnUnlessCancelled(priority: priority) {
-      await operation()
-    }
-  }
-
-  // Historical entry point, maintained for ABI compatibility
-  @usableFromInline
-  mutating func spawn(
-    priority: Task.Priority,
-    operation: __owned @Sendable @escaping () async -> ChildTaskResult
-  ) {
-    let optPriority: Task.Priority? = priority
-    spawn(priority: optPriority, operation: operation)
-  }
-
-  /// Adds a child task to the group.
+  /// Add a child task to the group.
+  ///
+  /// ### Error handling
+  /// Operations are allowed to `throw`, in which case the `try await next()`
+  /// invocation corresponding to the failed task will re-throw the given task.
+  ///
+  /// The `add` function will never (re-)throw errors from the `operation`.
+  /// Instead, the corresponding `next()` call will throw the error when necessary.
   ///
   /// - Parameters:
-  ///   - overridingPriority: The priority of the operation task.
-  ///     Omit this parameter or pass `.unspecified`
-  ///     to set the child task's priority to the priority of the group.
-  ///   - operation: The operation to execute as part of the task group.
-  @_alwaysEmitIntoClient
+  ///   - overridingPriority: override priority of the operation task
+  ///   - operation: operation to execute and add to the group
+  /// - Returns:
+  ///   - `true` if the operation was added to the group successfully,
+  ///     `false` otherwise (e.g. because the group `isCancelled`)
   public mutating func async(
-    priority: Task.Priority? = nil,
-    operation: __owned @Sendable @escaping () async -> ChildTaskResult
-  ) {
-    spawn(priority: priority, operation: operation)
-  }
-
-  /// Adds a child task to the group.
-  ///
-  /// - Parameters:
-  ///   - overridingPriority: The priority of the operation task.
-  ///     Omit this parameter or pass `.unspecified`
-  ///     to set the child task's priority to the priority of the group.
-  ///   - operation: The operation to execute as part of the task group.
-  public mutating func spawn(
-    priority: Task.Priority? = nil,
+    priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) {
     _ = _taskGroupAddPendingTask(group: _group, unconditionally: true)
 
     // Set up the job flags for a new task.
-    var flags = Task.JobFlags()
+    var flags = JobFlags()
     flags.kind = .task
     flags.priority = priority
     flags.isFuture = true
     flags.isChildTask = true
     flags.isGroupChildTask = true
-    
+
     // Create the asynchronous task future.
     let (childTask, _) = Builtin.createAsyncTaskGroupFuture(
       Int(flags.bits), _group, operation)
-    
+
     // Attach it to the group's task record in the current task.
     _taskGroupAttachChild(group: _group, child: childTask)
-    
+
     // Enqueue the resulting job.
     _enqueueJobGlobal(Builtin.convertTaskToJob(childTask))
   }
 
-    // Historical entry point, maintained for ABI compatibility
-  @usableFromInline
-  mutating func spawnUnlessCancelled(
-    priority: Task.Priority = .unspecified,
-    operation: __owned @Sendable @escaping () async -> ChildTaskResult
-  ) -> Bool {
-    let optPriority: Task.Priority? = priority
-    return spawnUnlessCancelled(priority: optPriority, operation: operation)
-  }
-
-  /// Adds a child task to the group, unless the group has been canceled.
+  /// Add a child task to the group.
+  ///
+  /// ### Error handling
+  /// Operations are allowed to `throw`, in which case the `try await next()`
+  /// invocation corresponding to the failed task will re-throw the given task.
+  ///
+  /// The `add` function will never (re-)throw errors from the `operation`.
+  /// Instead, the corresponding `next()` call will throw the error when necessary.
   ///
   /// - Parameters:
-  ///   - overridingPriority: The priority of the operation task.
-  ///     Omit this parameter or pass `.unspecified`
-  ///     to set the child task's priority to the priority of the group.
-  ///   - operation: The operation to execute as part of the task group.
-  /// - Returns: `true` if the operation was added to the group successfully;
-  ///   otherwise; `false`.
-  @_alwaysEmitIntoClient
+  ///   - overridingPriority: override priority of the operation task
+  ///   - operation: operation to execute and add to the group
+  /// - Returns:
+  ///   - `true` if the operation was added to the group successfully,
+  ///     `false` otherwise (e.g. because the group `isCancelled`)
   public mutating func asyncUnlessCancelled(
-    priority: Task.Priority? = nil,
-    operation: __owned @Sendable @escaping () async -> ChildTaskResult
-  ) -> Bool {
-    spawnUnlessCancelled(priority: priority, operation: operation)
-  }
-
-  /// Adds a child task to the group, unless the group has been canceled.
-  ///
-  /// - Parameters:
-  ///   - overridingPriority: The priority of the operation task.
-  ///     Omit this parameter or pass `.unspecified`
-  ///     to set the child task's priority to the priority of the group.
-  ///   - operation: The operation to execute as part of the task group.
-  /// - Returns: `true` if the operation was added to the group successfully;
-  ///   otherwise; `false`.
-  public mutating func spawnUnlessCancelled(
-    priority: Task.Priority? = nil,
+    priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) -> Bool {
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
@@ -352,7 +287,7 @@ public struct TaskGroup<ChildTaskResult> {
     }
 
     // Set up the job flags for a new task.
-    var flags = Task.JobFlags()
+    var flags = JobFlags()
     flags.kind = .task
     flags.priority = priority
     flags.isFuture = true
@@ -519,63 +454,30 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
     }
   }
 
-  @available(*, deprecated, message: "`Task.Group.add` has been replaced by `(Throwing)TaskGroup.spawn` or `(Throwing)TaskGroup.spawnUnlessCancelled` and will be removed shortly.")
-  public mutating func add(
-    priority: Task.Priority = .unspecified,
-    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
-  ) async -> Bool {
-    return self.spawnUnlessCancelled(priority: priority) {
-      try await operation()
-    }
-  }
-
-  // Historical entry point for ABI reasons
-  @usableFromInline
-  mutating func spawn(
-    priority: Task.Priority = .unspecified,
-    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
-  ) {
-    let optPriority: Task.Priority? = priority
-    return spawn(priority: optPriority, operation: operation)
-  }
-
-  /// Adds a child task to the group.
+  /// Spawn, unconditionally, a child task in the group.
+  ///
+  /// ### Error handling
+  /// Operations are allowed to `throw`, in which case the `try await next()`
+  /// invocation corresponding to the failed task will re-throw the given task.
   ///
   /// This method doesn't throw an error, even if the child task does.
   /// Instead, corresponding next call to `TaskGroup.next()` rethrows that error.
   ///
   /// - Parameters:
-  ///   - overridingPriority: The priority of the operation task.
-  ///     Omit this parameter or pass `.unspecified`
-  ///     to set the child task's priority to the priority of the group.
-  ///   - operation: The operation to execute as part of the task group.
-  @_alwaysEmitIntoClient
+  ///   - overridingPriority: override priority of the operation task
+  ///   - operation: operation to execute and add to the group
+  /// - Returns:
+  ///   - `true` if the operation was added to the group successfully,
+  ///     `false` otherwise (e.g. because the group `isCancelled`)
   public mutating func async(
-    priority: Task.Priority? = nil,
-    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
-  ) {
-    spawn(priority: priority, operation: operation)
-  }
-
-  /// Adds a child task to the group.
-  ///
-  /// This method doesn't throw an error, even if the child task does.
-  /// Instead, corresponding next call to `TaskGroup.next()` rethrows that error.
-  ///
-  /// - Parameters:
-  ///   - overridingPriority: The priority of the operation task.
-  ///     Omit this parameter or pass `.unspecified`
-  ///     to set the child task's priority to the priority of the group.
-  ///   - operation: The operation to execute as part of the task group.
-  public mutating func spawn(
-    priority: Task.Priority? = nil,
+    priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) {
     // we always add, so no need to check if group was cancelled
     _ = _taskGroupAddPendingTask(group: _group, unconditionally: true)
 
     // Set up the job flags for a new task.
-    var flags = Task.JobFlags()
+    var flags = JobFlags()
     flags.kind = .task
     flags.priority = priority
     flags.isFuture = true
@@ -593,50 +495,23 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
     _enqueueJobGlobal(Builtin.convertTaskToJob(childTask))
   }
 
-  // Historical entry point for ABI reasons
-  @usableFromInline
-  mutating func spawnUnlessCancelled(
-    priority: Task.Priority,
-    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
-  ) -> Bool {
-    let optPriority: Task.Priority? = priority
-    return spawnUnlessCancelled(priority: optPriority, operation: operation)
-  }
-
-  /// Adds a child task to the group, unless the group has been canceled.
+  /// Add a child task to the group.
+  ///
+  /// ### Error handling
+  /// Operations are allowed to `throw`, in which case the `try await next()`
+  /// invocation corresponding to the failed task will re-throw the given task.
   ///
   /// This method doesn't throw an error, even if the child task does.
   /// Instead, the corresponding call to `TaskGroup.next()` rethrows that error.
   ///
   /// - Parameters:
-  ///   - overridingPriority: The priority of the operation task.
-  ///     Omit this parameter or pass `.unspecified`
-  ///     to set the child task's priority to the priority of the group.
-  ///   - operation: The operation to execute as part of the task group.
-  /// - Returns: `true` if the operation was added to the group successfully;
-  ///   otherwise `false`.
-  @_alwaysEmitIntoClient
+  ///   - overridingPriority: override priority of the operation task
+  ///   - operation: operation to execute and add to the group
+  /// - Returns:
+  ///   - `true` if the operation was added to the group successfully,
+  ///     `false` otherwise (e.g. because the group `isCancelled`)
   public mutating func asyncUnlessCancelled(
-    priority: Task.Priority? = nil,
-    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
-  ) -> Bool {
-    spawnUnlessCancelled(priority: priority, operation: operation)
-  }
-
-  /// Adds a child task to the group, unless the group has been canceled.
-  ///
-  /// This method doesn't throw an error, even if the child task does.
-  /// Instead, the corresponding call to `TaskGroup.next()` rethrows that error.
-  ///
-  /// - Parameters:
-  ///   - overridingPriority: The priority of the operation task.
-  ///     Omit this parameter or pass `.unspecified`
-  ///     to set the child task's priority to the priority of the group.
-  ///   - operation: The operation to execute as part of the task group.
-  /// - Returns: `true` if the operation was added to the group successfully;
-  ///   otherwise `false`.
-  public mutating func spawnUnlessCancelled(
-    priority: Task.Priority? = nil,
+    priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) -> Bool {
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
@@ -647,7 +522,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
     }
 
     // Set up the job flags for a new task.
-    var flags = Task.JobFlags()
+    var flags = JobFlags()
     flags.kind = .task
     flags.priority = priority
     flags.isFuture = true

--- a/test/Concurrency/Inputs/ShadowsConcur.swift
+++ b/test/Concurrency/Inputs/ShadowsConcur.swift
@@ -1,5 +1,5 @@
 
-public struct Task {
+public struct UnsafeCurrentTask {
   public var someProperty : String = "123"
   public init() { }
 }

--- a/test/Concurrency/Runtime/async.swift
+++ b/test/Concurrency/Runtime/async.swift
@@ -23,7 +23,7 @@ var asyncTests = TestSuite("Async")
 actor MyActor {
   func synchronous() { }
 
-  func doSomething(expectedPriority: Task.Priority) {
+  func doSomething(expectedPriority: TaskPriority) {
     async {
       synchronous() // okay to be synchronous
       assert(Task.currentPriority == expectedPriority)

--- a/test/Concurrency/Runtime/async_task_priority_current.swift
+++ b/test/Concurrency/Runtime/async_task_priority_current.swift
@@ -13,24 +13,24 @@ import Dispatch
 @available(SwiftStdlib 5.5, *)
 func test_detach() async {
   let a1 = Task.currentPriority
-  print("a1: \(a1)") // CHECK: a1: unspecified
+  print("a1: \(a1)") // CHECK: TaskPriority(rawValue: 21)
 
   // Note: remember to detach using a higher priority, otherwise a lower one
   // might be escalated by the get() and we could see `default` in the detached
   // task.
   await detach(priority: .userInitiated) {
     let a2 = Task.currentPriority
-    print("a2: \(a2)") // CHECK: a2: userInitiated
+    print("a2: \(a2)") // CHECK: a2: TaskPriority(rawValue: 25)
   }.get()
 
   let a3 = Task.currentPriority
-  print("a3: \(a3)") // CHECK: a3: unspecified
+  print("a3: \(a3)") // CHECK: a3: TaskPriority(rawValue: 21)
 }
 
 @available(SwiftStdlib 5.5, *)
 func test_multiple_lo_indirectly_escalated() async {
   @Sendable
-  func loopUntil(priority: Task.Priority) async {
+  func loopUntil(priority: TaskPriority) async {
     while (Task.currentPriority != priority) {
       await Task.sleep(1_000_000_000)
     }

--- a/test/Concurrency/Runtime/executor_deinit3.swift
+++ b/test/Concurrency/Runtime/executor_deinit3.swift
@@ -27,7 +27,7 @@ class Runner {
 @available(SwiftStdlib 5.5, *)
 actor Container {
     var generation = 0
-    var runners = [Int : Task.Handle<Void, Never>]()
+    var runners = [Int : Task<Void, Never>]()
 
     func build(_ n: Int) {
         for _ in 0..<n {

--- a/test/Concurrency/Runtime/task_creation.swift
+++ b/test/Concurrency/Runtime/task_creation.swift
@@ -1,0 +1,47 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch -parse-as-library)
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+enum SomeError: Error {
+  case bad
+}
+
+@available(SwiftStdlib 5.5, *)
+@main struct Main {
+  static func main() async {
+    let condition = false
+
+    let t1 = Task {
+      return 5
+    }
+
+    let t2 = Task { () -> Int in
+      if condition {
+        throw SomeError.bad
+      }
+
+      return 7
+    }
+
+    let t3 = Task.detached {
+      return 9
+    }
+
+    let t4 = Task.detached { () -> Int in
+      if condition {
+        throw SomeError.bad
+      }
+
+      return 11
+    }
+
+    let result = try! await t1.get() + t2.get() + t3.get() + t4.get()
+    assert(result == 32)
+  }
+}

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -208,7 +208,7 @@ struct MyGlobalActor {
 // expected-error@+3{{actor-isolated var 'number' cannot be passed 'inout' to 'async' function call}}
 // expected-error@+2{{var 'number' isolated to global actor 'MyGlobalActor' can not be used 'inout' from a non-isolated context}}
 if #available(SwiftStdlib 5.5, *) {
-let _ = detach { await { (_ foo: inout Int) async in foo += 1 }(&number) }
+let _ = Task.detached { await { (_ foo: inout Int) async in foo += 1 }(&number) }
 }
 
 // attempt to pass global state owned by the global actor to another async function

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -740,7 +740,7 @@ class SomeClassWithInits {
   }
 
   func hasDetached() {
-    detach {
+    Task.detached {
       // okay
       await self.isolated() // expected-warning{{cannot use parameter 'self' with a non-sendable type 'SomeClassWithInits' from concurrently-executed code}}
       self.isolated() // expected-warning{{cannot use parameter 'self' with a non-sendable type 'SomeClassWithInits' from concurrently-executed code}}

--- a/test/Concurrency/async_cancellation.swift
+++ b/test/Concurrency/async_cancellation.swift
@@ -27,7 +27,7 @@ struct SomeFile: Sendable {
 
 @available(SwiftStdlib 5.5, *)
 func test_cancellation_withTaskCancellationHandler(_ anything: Any) async -> PictureData {
-  let handle: Task.Handle<PictureData, Error> = detach {
+  let handle: Task<PictureData, Error> = .init {
     let file = SomeFile()
 
     return await withTaskCancellationHandler(

--- a/test/Concurrency/async_cancellation.swift
+++ b/test/Concurrency/async_cancellation.swift
@@ -30,9 +30,10 @@ func test_cancellation_withTaskCancellationHandler(_ anything: Any) async -> Pic
   let handle: Task<PictureData, Error> = .init {
     let file = SomeFile()
 
-    return await withTaskCancellationHandler(
-      handler: { file.close() }) {
+    return await withTaskCancellationHandler {
       await test_cancellation_guard_isCancelled(file)
+    } onCancel: {
+      file.close()
     }
   }
 

--- a/test/Concurrency/async_task_groups.swift
+++ b/test/Concurrency/async_task_groups.swift
@@ -22,11 +22,11 @@ func asyncThrowsOnCancel() async throws -> Int {
 @available(SwiftStdlib 5.5, *)
 func test_taskGroup_add() async throws -> Int {
   try await withThrowingTaskGroup(of: Int.self) { group in
-    group.spawn {
+    group.async {
       await asyncFunc()
     }
 
-    group.spawn {
+    group.async {
       await asyncFunc()
     }
 
@@ -51,9 +51,9 @@ func boom() async throws -> Int { throw Boom() }
 func first_allMustSucceed() async throws {
 
   let first: Int = try await withThrowingTaskGroup(of: Int.self) { group in
-    group.spawn { await work() }
-    group.spawn { await work() }
-    group.spawn { try await boom() }
+    group.async { await work() }
+    group.async { await work() }
+    group.async { try await boom() }
 
     if let first = try await group.next() {
       return first
@@ -72,9 +72,9 @@ func first_ignoreFailures() async throws {
   @Sendable func boom() async throws -> Int { throw Boom() }
 
   let first: Int = try await withThrowingTaskGroup(of: Int.self) { group in
-    group.spawn { await work() }
-    group.spawn { await work() }
-    group.spawn {
+    group.async { await work() }
+    group.async { await work() }
+    group.async {
       do {
         return try await boom()
       } catch {
@@ -121,7 +121,7 @@ func test_taskGroup_quorum_thenCancel() async {
   func gatherQuorum(followers: [Follower]) async -> Bool {
     try! await withThrowingTaskGroup(of: Vote.self) { group in
       for follower in followers {
-        group.spawn { try await follower.vote() }
+        group.async { try await follower.vote() }
       }
 
       defer {
@@ -192,7 +192,7 @@ extension Collection where Self: Sendable, Element: Sendable, Self.Index: Sendab
       var submitted = 0
 
       func submitNext() async throws {
-        group.spawn { [submitted,i] in
+        group.async { [submitted,i] in
           let value = try await transform(self[i])
           return SendableTuple2(submitted, value)
         }

--- a/test/Concurrency/async_task_groups.swift
+++ b/test/Concurrency/async_task_groups.swift
@@ -16,7 +16,7 @@ func asyncThrowsOnCancel() async throws -> Int {
     await Task.sleep(1_000_000_000)
   }
 
-  throw Task.CancellationError()
+  throw CancellationError()
 }
 
 @available(SwiftStdlib 5.5, *)

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -95,7 +95,7 @@ func test_detached() async throws {
     await someAsyncFunc() // able to call async functions
   }
 
-  let result: String = await handle.get()
+  let result: String = await handle.value
   _ = result
 }
 
@@ -106,7 +106,7 @@ func test_detached_throwing() async -> String {
   }
 
   do {
-    return try await handle.get()
+    return try await handle.value
   } catch {
     print("caught: \(error)")
   }

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -91,7 +91,7 @@ func test_unsafeThrowingContinuations() async throws {
 
 @available(SwiftStdlib 5.5, *)
 func test_detached() async throws {
-  let handle = detach() {
+  let handle = Task.detached {
     await someAsyncFunc() // able to call async functions
   }
 
@@ -101,7 +101,7 @@ func test_detached() async throws {
 
 @available(SwiftStdlib 5.5, *)
 func test_detached_throwing() async -> String {
-  let handle: Task.Handle<String, Error> = detach() {
+  let handle: Task<String, Error> = Task.detached {
     try await someThrowingAsyncFunc() // able to call async functions
   }
 

--- a/test/Concurrency/concurrency_module_shadowing.swift
+++ b/test/Concurrency/concurrency_module_shadowing.swift
@@ -7,9 +7,9 @@
 import ShadowsConcur
 
 @available(SwiftStdlib 5.5, *)
-func f(_ t : Task) -> Bool {
+func f(_ t : UnsafeCurrentTask) -> Bool {
   return t.someProperty == "123"
 }
 
 @available(SwiftStdlib 5.5, *)
-func g(_: _Concurrency.Task) {}
+func g(_: _Concurrency.UnsafeCurrentTask) {}


### PR DESCRIPTION
The `Task` type has oscillated somewhat from being purely a namespace,
to having instances that are used (albeit rarely), back to purely
being a namespace that isn't used for all that many names. Many of the
names that used to be on Task have already been moved out, e.g., for
creating new detached tasks, creating new task groups, adding
cancellation handlers, etc.

Collapse `Task.Handle<Success, Failure>` into `Task<Success, Failure>`.
`Task.Handle` is the type that is most frequently referenced in the
concurrency library, so giving it the short name `Task` is most
appropriate. Replace the top-level async/detach functions with a
`Task` initializer and `Task.detached`, respectively.

The `Task` type can still act as a namespace for static operations
such as, e.g., `Task.isCancelled`. Do this with an extension of the
form:

    extension Task where Success == Never, Failure == Never { ... }

We've been accruing a number of compatibility shims. Move them all
into their own source file, deprecate them, and make them
always-emit-into-client so they don't have any ABI impact.

This also covers other changes that came up in the review:
* Switch `get()` to `value` as an async property
* Switch `getResult()` to `result` as an async property
* Switch order/names of `withTaskCancellationHandler` parameters
* Update names of `TaskPriority` members, and make it a `RawRepresentable` struct

Addresses rdar://78269970