### PR TITLE
[TaskLocals] dont crash checking for taskgroup when in no task

### DIFF
--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -411,6 +411,11 @@ SWIFT_CC(swift)
 static bool swift_task_hasTaskGroupStatusRecordImpl() {
   auto task = swift_task_getCurrent();
 
+  // a group must be in a task, so if we're not in a task...
+  // then, we certainly are not in a group either!
+  if (!task)
+    return false;
+
   Optional<StatusRecordLockRecord> recordLockRecord;
 
   // Acquire the status record lock.

--- a/test/Concurrency/Runtime/async_task_locals_synchronous_bind.swift
+++ b/test/Concurrency/Runtime/async_task_locals_synchronous_bind.swift
@@ -33,7 +33,7 @@ func printTaskLocal<V>(
 // ==== ------------------------------------------------------------------------
 
 @available(SwiftStdlib 5.5, *)
-func synchronous_bind() async {
+func synchronous_bind() {
 
   func synchronous() {
     printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (1111)
@@ -45,14 +45,14 @@ func synchronous_bind() async {
     printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (1111)
   }
 
-  await TL.$number.withValue(1111) {
+  TL.$number.withValue(1111) {
     synchronous()
   }
 }
 
 @available(SwiftStdlib 5.5, *)
 @main struct Main {
-  static func main() async {
-    await synchronous_bind()
+  static func main() {
+    synchronous_bind()
   }
 }


### PR DESCRIPTION
Resolves rdar://78587643

We'd crash when checking if we're in a task group, but no task was available.