### PR TITLE
build: repair the build with VS2019 16.10.0

### DIFF
--- a/cmake/modules/Libdispatch.cmake
+++ b/cmake/modules/Libdispatch.cmake
@@ -86,6 +86,7 @@ foreach(sdk ${DISPATCH_SDKS})
                           -DCMAKE_INSTALL_LIBDIR=lib
                           -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                           -DCMAKE_LINKER=${CMAKE_LINKER}
+                          -DCMAKE_MT=${CMAKE_MT}
                           -DCMAKE_RANLIB=${CMAKE_RANLIB}
                           -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
                           -DCMAKE_SYSTEM_NAME=${SWIFT_SDK_${sdk}_NAME}


### PR DESCRIPTION
The newest VS2019 release updates CMake to 3.20, which picks up
`llvm-mt` as a preferred manifest tool.  However, we do not build
`llvm-mt` with libxml2 support currently, which prevents the use of the
just built manifest tool for building libdispatch.  Explicitly opt into
using the MSVC manifest-tool.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
