### PR TITLE
build: explicitly use MSVC's manifest tool on Windows

### DIFF
--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -180,6 +180,7 @@ cmake^
     -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%^
     -DCMAKE_C_COMPILER=cl^
     -DCMAKE_CXX_COMPILER=cl^
+    -DCMAKE_MT=mt^
     -DCMAKE_INSTALL_PREFIX:PATH=%install_directory%^
     -DLLVM_DEFAULT_TARGET_TRIPLE=x86_64-unknown-windows-msvc^
     -DLLVM_ENABLE_PDB:BOOL=YES^
@@ -222,6 +223,7 @@ cmake^
     -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%^
     -DCMAKE_C_COMPILER=cl^
     -DCMAKE_CXX_COMPILER=cl^
+    -DCMAKE_MT=mt^
     -DCMAKE_CXX_FLAGS:STRING="/GS- /Oy"^
     -DCMAKE_EXE_LINKER_FLAGS:STRING=/INCREMENTAL:NO^
     -DCMAKE_SHARED_LINKER_FLAGS:STRING=/INCREMENTAL:NO^
@@ -245,6 +247,7 @@ cmake^
     -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%^
     -DCMAKE_C_COMPILER=cl^
     -DCMAKE_CXX_COMPILER=cl^
+    -DCMAKE_MT=mt^
     -DCMAKE_INSTALL_PREFIX:PATH=%install_directory%^
     -DClang_DIR:PATH=%build_root%\llvm\lib\cmake\clang^
     -DSWIFT_PATH_TO_CMARK_BUILD:PATH=%build_root%\cmark^
@@ -303,6 +306,7 @@ cmake^
     -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%^
     -DCMAKE_C_COMPILER=cl^
     -DCMAKE_CXX_COMPILER=cl^
+    -DCMAKE_MT=mt^
     -DCMAKE_INSTALL_PREFIX:PATH=%install_directory%^
     -DLLVM_DIR:PATH=%build_root%\llvm\lib\cmake\llvm^
     -DClang_DIR:PATH=%build_root%\llvm\lib\cmake\clang^
@@ -335,6 +339,7 @@ cmake^
     -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%^
     -DCMAKE_C_COMPILER=clang-cl^
     -DCMAKE_CXX_COMPILER=clang-cl^
+    -DCMAKE_MT=mt^
     -DCMAKE_Swift_COMPILER=swiftc^
     -DSwift_DIR:PATH=%build_root%\swift\lib\cmake\swift^
     -DCMAKE_INSTALL_PREFIX:PATH=%install_directory%^


### PR DESCRIPTION
Explicitly opt into the Microsoft manifest tool to be resilient against
future CMake releases which prefer `llvm-mt` when building with clang
(including clang-cl).  This should ensure that we do not get broken with
the update to VS2019 16.10 and CMake 3.20.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
