### PR TITLE
[documentation] make `customPlaygroundQuickLook` availability message match reality

### DIFF
--- a/stdlib/public/core/MigrationSupport.swift
+++ b/stdlib/public/core/MigrationSupport.swift
@@ -237,7 +237,7 @@ extension String {
 }
 
 extension String.UnicodeScalarView: _CustomPlaygroundQuickLookable {
-  @available(swift, deprecated: 4.2/*, obsoleted: 5.0*/, message: "UnicodeScalarView.customPlaygroundQuickLook will be removed in Swift 5.0")
+  @available(swift, deprecated: 4.2/*, obsoleted: 5.0*/, message: "UnicodeScalarView.customPlaygroundQuickLook will be removed in a future Swift version")
   public var customPlaygroundQuickLook: _PlaygroundQuickLook {
     return .text(description)
   }
@@ -256,14 +256,14 @@ public typealias UnicodeScalar = Unicode.Scalar
 
 
 extension String.UTF16View: _CustomPlaygroundQuickLookable {
-  @available(swift, deprecated: 4.2/*, obsoleted: 5.0*/, message: "UTF16View.customPlaygroundQuickLook will be removed in Swift 5.0")
+  @available(swift, deprecated: 4.2/*, obsoleted: 5.0*/, message: "UTF16View.customPlaygroundQuickLook will be removed in a future Swift version")
   public var customPlaygroundQuickLook: _PlaygroundQuickLook {
     return .text(description)
   }
 }
 
 extension String.UTF8View: _CustomPlaygroundQuickLookable {
-  @available(swift, deprecated: 4.2/*, obsoleted: 5.0*/, message: "UTF8View.customPlaygroundQuickLook will be removed in Swift 5.0")
+  @available(swift, deprecated: 4.2/*, obsoleted: 5.0*/, message: "UTF8View.customPlaygroundQuickLook will be removed in a future Swift version")
   public var customPlaygroundQuickLook: _PlaygroundQuickLook {
     return .text(description)
   }
@@ -310,7 +310,7 @@ extension Substring {
 }
 
 extension Substring: _CustomPlaygroundQuickLookable {
-  @available(swift, deprecated: 4.2/*, obsoleted: 5.0*/, message: "Substring.customPlaygroundQuickLook will be removed in Swift 5.0")
+  @available(swift, deprecated: 4.2/*, obsoleted: 5.0*/, message: "Substring.customPlaygroundQuickLook will be removed in a future Swift version")
   public var customPlaygroundQuickLook: _PlaygroundQuickLook {
     return String(self).customPlaygroundQuickLook
   }


### PR DESCRIPTION
All other instances of the customPlaygroundQuickLook availability message already mentioned "a future Swift version" rather than "Swift 5.0". (See the output of `find stdlib -name *.swift -exec egrep -H available\.+customPlaygroundQuickLook {} \;` from the repo top level)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
No SR.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
