### PR TITLE
[ConstraintSystem] Simplify relational constraints with the same depe…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5182,6 +5182,12 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       llvm_unreachable("type variables should have already been handled by now");
 
     case TypeKind::DependentMember: {
+      // If types are identical, let's consider this constraint solved
+      // even though they are dependent members, they would be resolved
+      // to the same concrete type.
+      if (desugar1->isEqual(desugar2))
+        return getTypeMatchSuccess();
+
       // If one of the dependent member types has no type variables,
       // this comparison is effectively illformed, because dependent
       // member couldn't be simplified down to the actual type, and

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -870,3 +870,19 @@ func test_ternary_operator_with_regular_conformance_to_literal_protocol() {
 
   bug(true ? test(0) : test(42)) // Ok - type is `CGFloat` for 0 and 42
 }
+
+// rdar://78623338 - crash due to leftover inactive constraints
+func rdar78623338() {
+  func any<T : Sequence>(_ sequence: T) -> AnySequence<T.Element> {
+    // expected-note@-1 {{required by local function 'any' where 'T' = '() -> ReversedCollection<(ClosedRange<Int>)>'}}
+    AnySequence(sequence.makeIterator)
+  }
+
+  let _ = [
+    any(0...3),
+    // TODO: It should be possible to suggest making a call to `reserved` here but we don't have machinery to do so
+    //       at the moment because there is no way to go from a requirement to the underlying argument/parameter location.
+    any((1...3).reversed) // expected-error {{type '() -> ReversedCollection<(ClosedRange<Int>)>' cannot conform to 'Sequence'}}
+    // expected-note@-1 {{only concrete types such as structs, enums and classes can conform to protocols}}
+  ]
+}


### PR DESCRIPTION
…ndent member type on both sides

If relational constraint has the same dependent member type on both
sides e.g. `$T1.Element == $T1.Element` allow its simplification,
since inference of `$T1` results in dependent member being resolved
to the same concrete type. Otherwise constraint system would be left
with this constraint in inactive state if `$T1` couldn't be resolved
which results in a crash.

Resolves: rdar://78623338

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
