### PR TITLE
[unittest] Add /usr/lib/swift to the rpath of unit test executables

### DIFF
--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -40,7 +40,9 @@ function(add_swift_unittest test_dirname)
   endif()
 
   if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-    # Add an @rpath to the swift library directory.
+    # Add an @rpath to the swift library directory
+    # and one to the OS dylibs we require but
+    # are not building ourselves (e.g Foundation overlay)
     set_target_properties(${test_dirname} PROPERTIES
       BUILD_RPATH "${SWIFT_LIBRARY_OUTPUT_INTDIR}/swift/macosx;${SWIFT_DARWIN_STDLIB_INSTALL_NAME_DIR}")
     # Force all the swift libraries to be found via rpath.
@@ -86,5 +88,4 @@ function(add_swift_unittest test_dirname)
     endif()
   endif()
 endfunction()
-
 

--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -42,7 +42,7 @@ function(add_swift_unittest test_dirname)
   if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
     # Add an @rpath to the swift library directory.
     set_target_properties(${test_dirname} PROPERTIES
-      BUILD_RPATH ${SWIFT_LIBRARY_OUTPUT_INTDIR}/swift/macosx)
+      BUILD_RPATH "${SWIFT_LIBRARY_OUTPUT_INTDIR}/swift/macosx;${SWIFT_DARWIN_STDLIB_INSTALL_NAME_DIR}")
     # Force all the swift libraries to be found via rpath.
     add_custom_command(TARGET "${test_dirname}" POST_BUILD
       COMMAND "${SWIFT_SOURCE_DIR}/utils/swift-rpathize.py"


### PR DESCRIPTION
As a postprocessing step for unittest executables, `utils/swift-rpathize.py` unconditionally rewrites the install name of any library linked from /usr/lib/swift to be `@rpath`-relative, in an effort to load the just-built libraries instead of the OS-supplied ones.

This works great for dylibs like libswiftCore.dylib that are built as part of the toolchain, but `/usr/lib/swift` also includes a huge number of overlay dylibs that are no longer part of this repository. These dylibs must ~always be loaded from the OS location.

In order to prevent load-time issues, we need to add /usr/lib/swift to the rpath, so any libraries that we haven’t built will be picked up from there.

We could also do this by extending swift-rpathize.py with an allow (or deny) list, but keeping the list up to date would generate a bunch of maintenance work we could do without.

rdar://76915582