### PR TITLE
[APIDigester] Lift the requirement that -sdk must be present

### DIFF
--- a/tools/driver/swift_api_digester_main.cpp
+++ b/tools/driver/swift_api_digester_main.cpp
@@ -2365,10 +2365,6 @@ static void setSDKPath(CompilerInvocation &InitInvok, bool IsBaseline,
       InitInvok.setSDKPath(SDK.str());
     } else if (const char *SDKROOT = getenv("SDKROOT")) {
       InitInvok.setSDKPath(SDKROOT);
-    } else {
-      llvm::errs() << "Provide '-sdk <path>' option or run with 'xcrun -sdk <..>\
-      swift-api-digester'\n";
-      exit(1);
     }
   }
 }


### PR DESCRIPTION
This should let SwiftPM use the same SDK path computation for swiftc and swift-api-digester on Linux. I _think_ it's safe to lift this restriction, but it's possible I missed something