### PR TITLE
[CMake] Remove a bogus include

### DIFF
--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -144,7 +144,6 @@ endif()
 # built and cause link failures for mismatches. Without linking that library,
 # we get link failures regardless, so instead, this just disables the checks.
 add_compile_definitions($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1>)
-include_directories(BEFORE ${CMAKE_PROJECT_SOURCE_DIR}/include)
 
 set(SWIFT_STDLIB_LIBRARY_BUILD_TYPES)
 if(SWIFT_BUILD_DYNAMIC_STDLIB)


### PR DESCRIPTION
`CMAKE_PROJECT_SOURCE_DIR` is not set to anything so this line adds an absolute `/include` include directory.