### PR TITLE
benchmarks: fix smoke test run by setting the dynamic library path

### DIFF
--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -31,6 +31,7 @@ import glob
 import logging
 import math
 import os
+import platform
 import re
 import subprocess
 import sys
@@ -54,6 +55,16 @@ class BenchmarkDriver(object):
         Optional parameters are for injecting dependencies -- used for testing.
         """
         self.args = args
+        self.run_env = os.environ.copy()
+        if hasattr(args, 'libdir') and args.libdir:
+            # The benchmark binaries should pick up the built swift libraries
+            # automatically, because their RPATH should point to ../lib/swift
+            # But it does not harm to additionally set the dynamic library path,
+            # e.g. as a workaround to rdar://78584073
+            if platform.system() == "Darwin":
+                self.run_env["DYLD_LIBRARY_PATH"] = args.libdir
+            elif platform.system() == "Linux":
+                self.run_env["LD_LIBRARY_PATH"] = args.libdir
         self._subprocess = _subprocess or subprocess
         self.all_tests = []
         self.test_number = {}
@@ -66,7 +77,8 @@ class BenchmarkDriver(object):
 
     def _invoke(self, cmd):
         return self._subprocess.check_output(
-            cmd, stderr=self._subprocess.STDOUT, universal_newlines=True
+            cmd, stderr=self._subprocess.STDOUT, universal_newlines=True,
+            env=self.run_env
         )
 
     @property

--- a/benchmark/scripts/run_smoke_bench
+++ b/benchmark/scripts/run_smoke_bench
@@ -48,13 +48,14 @@ VERBOSE = False
 class DriverArgs(object):
     """Arguments for BenchmarkDriver."""
 
-    def __init__(self, tests, optimization="O", architecture=None):
+    def __init__(self, benchmark_dir, architecture, platform, optimization="O"):
         """Initialize with path to the build-dir and optimization level."""
         self.benchmarks = None
         self.filters = None
-        self.tests = os.path.join(tests, "bin")
+        self.tests = os.path.join(benchmark_dir, "bin")
         self.optimization = optimization
         self.architecture = architecture
+        self.libdir = os.path.join(benchmark_dir, "lib", "swift", platform)
 
 
 def log(msg):
@@ -165,7 +166,8 @@ def test_opt_levels(args):
                 args.num_samples,
                 args.num_reruns,
                 output_file,
-                args.arch
+                args.arch,
+                args.platform
             ):
                 changes = True
 
@@ -232,7 +234,7 @@ def merge(results, other_results):
 
 def test_performance(
     opt_level, old_dir, new_dir, threshold, num_samples, num_reruns,
-    output_file, arch
+    output_file, arch, platform
 ):
     """Detect performance changes in benchmarks.
 
@@ -242,7 +244,8 @@ def test_performance(
 
     i, unchanged_length_count = 0, 0
     old, new = [
-        BenchmarkDriver(DriverArgs(dir, optimization=opt_level, architecture=arch))
+        BenchmarkDriver(DriverArgs(dir, architecture=arch, platform=platform,
+                                   optimization=opt_level))
         for dir in [old_dir, new_dir]
     ]
     results = [measure(driver, driver.tests, i) for driver in [old, new]]
@@ -382,8 +385,10 @@ performance team (@eeckstein).
 
 
 def check_added(args, output_file=None):
-    old = BenchmarkDriver(DriverArgs(args.oldbuilddir[0], architecture=args.arch))
-    new = BenchmarkDriver(DriverArgs(args.newbuilddir[0], architecture=args.arch))
+    old = BenchmarkDriver(DriverArgs(args.oldbuilddir[0], architecture=args.arch,
+                                     platform=args.platform))
+    new = BenchmarkDriver(DriverArgs(args.newbuilddir[0], architecture=args.arch,
+                                     platform=args.platform))
     added = set(new.tests).difference(set(old.tests))
     new.tests = list(added)
     doctor = BenchmarkDoctor(args, driver=new)

--- a/benchmark/scripts/test_Benchmark_Driver.py
+++ b/benchmark/scripts/test_Benchmark_Driver.py
@@ -186,6 +186,7 @@ class SubprocessMock(Mock):
             stderr=None,
             shell=False,
             universal_newlines=False,
+            env=None
         ):
             return self.record_and_respond(args, stdin, stdout, stderr, shell)
 


### PR DESCRIPTION
This is a workaround for rdar://78584073
