### PR TITLE
[5.5][Refactoring] Don't crash when converting a function to async that contains a call to init

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -5349,13 +5349,13 @@ private:
   }
 };
 
-/// Name of a decl if it has one, an empty \c Identifier otherwise.
-static Identifier getDeclName(const Decl *D) {
+/// Base name of a decl if it has one, an empty \c DeclBaseName otherwise.
+static DeclBaseName getDeclName(const Decl *D) {
   if (auto *VD = dyn_cast<ValueDecl>(D)) {
     if (VD->hasName())
-      return VD->getBaseIdentifier();
+      return VD->getBaseName();
   }
-  return Identifier();
+  return DeclBaseName();
 }
 
 class DeclCollector : private SourceEntityWalker {
@@ -5630,7 +5630,7 @@ class AsyncConverter : private SourceEntityWalker {
   llvm::DenseMap<const Decl *, Identifier> Names;
   // Names of decls in each scope, where the first element is the initial scope
   // and the last is the current scope.
-  llvm::SmallVector<llvm::DenseSet<Identifier>, 4> ScopedNames;
+  llvm::SmallVector<llvm::DenseSet<DeclBaseName>, 4> ScopedNames;
   // Mapping of \c BraceStmt -> declarations referenced in that statement
   // without first being declared. These are used to fill the \c ScopeNames
   // map on entering that scope.
@@ -6705,7 +6705,7 @@ private:
   Identifier assignUniqueName(const Decl *D, StringRef BoundName) {
     Identifier Ident;
     if (BoundName.empty()) {
-      BoundName = getDeclName(D).str();
+      BoundName = getDeclName(D).userFacingName();
       if (BoundName.empty())
         return Ident;
     }

--- a/test/refactoring/ConvertAsync/basic.swift
+++ b/test/refactoring/ConvertAsync/basic.swift
@@ -844,3 +844,15 @@ func testPreserveComments3() {
 // PRESERVE-TRAILING-COMMENT-CALL:      let s = await simple()
 // PRESERVE-TRAILING-COMMENT-CALL-NEXT: print(s)
 // PRESERVE-TRAILING-COMMENT-CALL-NOT:  // make sure we pickup this trailing comment if we're converting the function, but not the call
+
+class TestConvertFunctionWithCallToFunctionsWithSpecialName {
+  required init() {}
+  subscript(index: Int) -> Int { return index }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):3
+  static func example() -> Self {
+    let x = self.init()
+    _ = x[1]
+    return x
+  }
+}


### PR DESCRIPTION
Cherry-picks https://github.com/apple/swift/pull/37652 to `release/5.5`.

We were trying to retrieve the name of all function calls in the body using `getBaseIdentifier`. But calls to `init` don’t have a base identifier, just a `DeclBaseName` (which is special). Work with the `DeclBaseName` internally to prevent the crash.

Fixes rdar://78024731 [SR-14637]