### PR TITLE
[Async Refactoring] Better handle non-refutable patterns

### DIFF
--- a/include/swift/AST/DiagnosticsRefactoring.def
+++ b/include/swift/AST/DiagnosticsRefactoring.def
@@ -70,5 +70,7 @@ ERROR(callback_multiple_case_items, none, "cannot refactor switch using a case w
 
 ERROR(callback_where_case_item, none, "cannot refactor switch using a case with where clause", ())
 
+ERROR(unknown_callback_case_item, none, "cannot refactor complex case conditions", ())
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -202,6 +202,9 @@ public:
   /// Does this binding declare something that requires storage?
   bool hasStorage() const;
 
+  /// Does this pattern have any mutable 'var' bindings?
+  bool hasAnyMutableBindings() const;
+
   static bool classof(const Pattern *P) { return true; }
 
   //*** Allocation Routines ************************************************/

--- a/include/swift/IDE/SourceEntityWalker.h
+++ b/include/swift/IDE/SourceEntityWalker.h
@@ -73,6 +73,9 @@ public:
   /// Walks the provided Expr.
   /// \returns true if traversal was aborted, false otherwise.
   bool walk(Expr *E);
+  /// Walks the provided Pattern.
+  /// \returns true if traversal was aborted, false otherwise.
+  bool walk(Pattern *P);
   /// Walks the provided ASTNode.
   /// \returns true if traversal was aborted, false otherwise.
   bool walk(ASTNode N);
@@ -100,6 +103,14 @@ public:
   /// This method is called after visiting the children of an expression. If it
   /// returns false, the remaining traversal is terminated and returns failure.
   virtual bool walkToExprPost(Expr *E) { return true; }
+
+  /// This method is called when first visiting a pattern, before walking
+  /// into its children. If it returns false, the subtree is skipped.
+  virtual bool walkToPatternPre(Pattern *P) { return true; }
+
+  /// This method is called after visiting the children of a pattern. If it
+  /// returns false, the remaining traversal is terminated and returns failure.
+  virtual bool walkToPatternPost(Pattern *P) { return true; }
 
   /// This method is called when a ValueDecl is referenced in source. If it
   /// returns false, the remaining traversal is terminated and returns failure.

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -291,6 +291,15 @@ bool Pattern::hasStorage() const {
   return HasStorage;
 }
 
+bool Pattern::hasAnyMutableBindings() const {
+  auto HasMutable = false;
+  forEachVariable([&](VarDecl *VD) {
+    if (!VD->isLet())
+      HasMutable = true;
+  });
+  return HasMutable;
+}
+
 /// Return true if this is a non-resolved ExprPattern which is syntactically
 /// irrefutable.
 static bool isIrrefutableExprPattern(const ExprPattern *EP) {

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -4988,6 +4988,11 @@ private:
     if (!Cond.isValid())
       return None;
 
+    // If the condition involves a refutable pattern, we can't currently handle
+    // it.
+    if (Cond.BindPattern && Cond.BindPattern->isRefutablePattern())
+      return None;
+
     // For certain types of condition, they need to appear in certain lists.
     auto CondType = *Cond.Type;
     switch (CondType) {

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -4534,6 +4534,9 @@ struct CallbackCondition {
   ///   - `case .failure(let bind) = <Subject>`
   ///   - `let bind = try? <Subject>.get()`
   CallbackCondition(const Pattern *P, const Expr *Init) {
+    Init = Init->getSemanticsProvidingExpr();
+    P = P->getSemanticsProvidingPattern();
+
     if (auto *DRE = dyn_cast<DeclRefExpr>(Init)) {
       if (auto *OSP = dyn_cast<OptionalSomePattern>(P)) {
         // `let bind = <Subject>`

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -5326,7 +5326,12 @@ private:
       auto CC = classifyCallbackCondition(
           CallbackCondition(ErrParam, &Items[0]), SuccessNodes,
           /*elseStmt*/ nullptr);
-      if (CC && CC->Path == ConditionPath::FAILURE)
+      if (!CC) {
+        DiagEngine.diagnose(CS->getLoc(), diag::unknown_callback_case_item);
+        return;
+      }
+
+      if (CC->Path == ConditionPath::FAILURE)
         std::swap(Block, OtherBlock);
 
       // We'll be dropping the case, but make sure to keep any attached
@@ -5339,8 +5344,7 @@ private:
         Block->addPossibleCommentLoc(SS->getRBraceLoc());
 
       setNodes(Block, OtherBlock, std::move(SuccessNodes));
-      if (CC)
-        Block->addBinding(*CC, DiagEngine);
+      Block->addBinding(*CC, DiagEngine);
       if (DiagEngine.hadAnyError())
         return;
     }

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -6140,6 +6140,14 @@ private:
     // TODO: Handle Result.get as well
     if (auto *DRE = dyn_cast<DeclRefExpr>(E)) {
       if (auto *D = DRE->getDecl()) {
+        // Look through to the parent var decl if we have one. This ensures we
+        // look at the var in a case stmt's pattern rather than the var that's
+        // implicitly declared in the body.
+        if (auto *VD = dyn_cast<VarDecl>(D)) {
+          if (auto *Parent = VD->getParentVarDecl())
+            D = Parent;
+        }
+
         bool AddPlaceholder = Placeholders.count(D);
         StringRef Name = newNameFor(D, false);
         if (AddPlaceholder || !Name.empty())

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -5474,10 +5474,10 @@ private:
     return shouldWalkInto(S->getSourceRange());
   }
 
-  std::pair<bool, Pattern *> walkToPatternPre(Pattern *P) {
+  bool walkToPatternPre(Pattern *P) override {
     if (P == Target.dyn_cast<Pattern *>())
       AfterTarget = true;
-    return { shouldWalkInto(P->getSourceRange()), P };
+    return shouldWalkInto(P->getSourceRange());
   }
 
   bool shouldWalkInto(SourceRange Range) {

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -4755,22 +4755,87 @@ public:
 /// decls to any patterns they are used in.
 class ClassifiedBlock {
   NodesToPrint Nodes;
-  // closure param -> name
-  llvm::DenseMap<const Decl *, StringRef> BoundNames;
-  // var (ie. from a let binding) -> closure param
-  llvm::DenseMap<const Decl *, const Decl *> Aliases;
-  bool AllLet = true;
+
+  // A mapping of closure params to a list of patterns that bind them.
+  using ParamPatternBindingsMap =
+      llvm::MapVector<const Decl *, TinyPtrVector<const Pattern *>>;
+  ParamPatternBindingsMap ParamPatternBindings;
 
 public:
   const NodesToPrint &nodesToPrint() const { return Nodes; }
 
-  StringRef boundName(const Decl *D) const { return BoundNames.lookup(D); }
+  /// Attempt to retrieve an existing bound name for a closure parameter, or
+  /// an empty string if there's no suitable existing binding.
+  StringRef boundName(const Decl *D) const {
+    // Adopt the same name as the representative single pattern, if it only
+    // binds a single var.
+    if (auto *P = getSinglePatternFor(D)) {
+      if (P->getSingleVar())
+        return P->getBoundName().str();
+    }
+    return StringRef();
+  }
 
-  const llvm::DenseMap<const Decl *, const Decl *> &aliases() const {
+  /// Checks whether a closure parameter can be represented by a single pattern
+  /// that binds it. If the param is only bound by a single pattern, that will
+  /// be returned. If there's a pattern with a single var that binds it, that
+  /// will be returned, preferring a 'let' pattern to prefer out of line
+  /// printing of 'var' patterns.
+  const Pattern *getSinglePatternFor(const Decl *D) const {
+    auto Iter = ParamPatternBindings.find(D);
+    if (Iter == ParamPatternBindings.end())
+      return nullptr;
+
+    const auto &Patterns = Iter->second;
+    if (Patterns.empty())
+      return nullptr;
+    if (Patterns.size() == 1)
+      return Patterns[0];
+
+    // If we have multiple patterns, search for the best single var pattern to
+    // use, preferring a 'let' binding.
+    const Pattern *FirstSingleVar = nullptr;
+    for (auto *P : Patterns) {
+      if (!P->getSingleVar())
+        continue;
+
+      if (!P->hasAnyMutableBindings())
+        return P;
+
+      if (!FirstSingleVar)
+        FirstSingleVar = P;
+    }
+    return FirstSingleVar;
+  }
+
+  /// Retrieve any bound vars that are effectively aliases of a given closure
+  /// parameter.
+  llvm::SmallDenseSet<const Decl *> getAliasesFor(const Decl *D) const {
+    auto Iter = ParamPatternBindings.find(D);
+    if (Iter == ParamPatternBindings.end())
+      return {};
+
+    llvm::SmallDenseSet<const Decl *> Aliases;
+
+    // The single pattern that we replace the decl with is always an alias.
+    if (auto *P = getSinglePatternFor(D)) {
+      if (auto *SingleVar = P->getSingleVar())
+        Aliases.insert(SingleVar);
+    }
+
+    // Any other let bindings we have are also aliases.
+    for (auto *P : Iter->second) {
+      if (auto *SingleVar = P->getSingleVar()) {
+        if (!P->hasAnyMutableBindings())
+          Aliases.insert(SingleVar);
+      }
+    }
     return Aliases;
   }
 
-  bool allLet() const { return AllLet; }
+  const ParamPatternBindingsMap &paramPatternBindings() const {
+    return ParamPatternBindings;
+  }
 
   void addNodesInBraceStmt(BraceStmt *Brace) {
     Nodes.addNodesInBraceStmt(Brace);
@@ -4788,26 +4853,17 @@ public:
 
   void addBinding(const ClassifiedCondition &FromCondition,
                   DiagnosticEngine &DiagEngine) {
-    if (!FromCondition.BindPattern)
+    auto *P = FromCondition.BindPattern;
+    if (!P)
       return;
 
-    if (auto *BP =
-            dyn_cast_or_null<BindingPattern>(FromCondition.BindPattern)) {
-      if (!BP->isLet())
-        AllLet = false;
-    }
-
-    StringRef Name = FromCondition.BindPattern->getBoundName().str();
-    VarDecl *SingleVar = FromCondition.BindPattern->getSingleVar();
-    if (Name.empty() || !SingleVar)
+    // Patterns that don't bind anything aren't interesting.
+    SmallVector<VarDecl *, 2> Vars;
+    P->collectVariables(Vars);
+    if (Vars.empty())
       return;
 
-    auto Res = Aliases.try_emplace(SingleVar, FromCondition.Subject);
-    assert(Res.second && "Should not have seen this var before");
-    (void)Res;
-
-    // Use whichever name comes first
-    BoundNames.try_emplace(FromCondition.Subject, Name);
+    ParamPatternBindings[FromCondition.Subject].push_back(P);
   }
 
   void addAllBindings(const ClassifiedCallbackConditions &FromConditions,
@@ -5660,6 +5716,12 @@ class AsyncConverter : private SourceEntityWalker {
   // call
   bool Hoisting = false;
 
+  /// Whether a pattern is currently being converted.
+  bool ConvertingPattern = false;
+
+  /// A mapping of inline patterns to print for closure parameters.
+  using InlinePatternsToPrint = llvm::DenseMap<const Decl *, const Pattern *>;
+
 public:
   /// Convert a function
   AsyncConverter(SourceFile *SF, SourceManager &SM,
@@ -6010,6 +6072,37 @@ private:
     addRange(LastAddedLoc, Node.getEndLoc(), /*ToEndOfToken=*/true);
   }
 
+  void convertPattern(const Pattern *P) {
+    // Only print semantic patterns. This cleans up the output of the transform
+    // and works around some bogus source locs that can appear with typed
+    // patterns in if let statements.
+    P = P->getSemanticsProvidingPattern();
+
+    // Set up the start of the pattern as the last loc printed to make sure we
+    // accurately fill in the gaps as we customize the printing of sub-patterns.
+    llvm::SaveAndRestore<SourceLoc> RestoreLoc(LastAddedLoc, P->getStartLoc());
+    llvm::SaveAndRestore<bool> RestoreFlag(ConvertingPattern, true);
+
+    walk(const_cast<Pattern *>(P));
+    addRange(LastAddedLoc, P->getEndLoc(), /*ToEndOfToken*/ true);
+  }
+
+  bool walkToPatternPre(Pattern *P) override {
+    // If we're not converting a pattern, there's nothing extra to do.
+    if (!ConvertingPattern)
+      return true;
+
+    // When converting a pattern, don't print the 'let' or 'var' of binding
+    // subpatterns, as they're illegal when nested in PBDs, and we print a
+    // top-level one.
+    if (auto *BP = dyn_cast<BindingPattern>(P)) {
+      return addCustom(BP->getSourceRange(), [&]() {
+        convertPattern(BP->getSubPattern());
+      });
+    }
+    return true;
+  }
+
   bool walkToDeclPre(Decl *D, CharSourceRange Range) override {
     if (isa<PatternBindingDecl>(D)) {
       NestedExprCount++;
@@ -6018,14 +6111,16 @@ private:
 
     // Functions and types already have their names in \c ScopedNames, only
     // variables should need to be renamed.
-    if (isa<VarDecl>(D) && Names.find(D) == Names.end()) {
-      Identifier Ident = assignUniqueName(D, StringRef());
-      if (!Ident.empty()) {
+    if (isa<VarDecl>(D)) {
+      // If we don't already have a name for the var, assign it one. Note that
+      // vars in binding patterns may already have assigned names here.
+      if (Names.find(D) == Names.end()) {
+        auto Ident = assignUniqueName(D, StringRef());
         ScopedNames.back().insert(Ident);
-        addCustom(D->getSourceRange(), [&]() {
-          OS << Ident.str();
-        });
       }
+      addCustom(D->getSourceRange(), [&]() {
+        OS << newNameFor(D);
+      });
     }
 
     // Note we don't walk into any nested local function decls. If we start
@@ -6359,8 +6454,9 @@ private:
         if (!HandlerDesc.willAsyncReturnVoid()) {
           OS << tok::kw_return << " ";
         }
-        addAwaitCall(CE, ArgList.ref(), ClassifiedBlock(), {}, HandlerDesc,
-                     /*AddDeclarations=*/false);
+        InlinePatternsToPrint InlinePatterns;
+        addAwaitCall(CE, ArgList.ref(), ClassifiedBlock(), {}, InlinePatterns,
+                     HandlerDesc, /*AddDeclarations*/ false);
         return;
       }
       // We are not removing the completion handler, so we can call it once the
@@ -6377,8 +6473,10 @@ private:
                                       .str();
           addHoistedNamedCallback(
               CalledFunc, CompletionHandler, HandlerName, [&] {
+                InlinePatternsToPrint InlinePatterns;
                 addAwaitCall(CE, ArgList.ref(), ClassifiedBlock(), {},
-                             HandlerDesc, /*AddDeclarations=*/false);
+                             InlinePatterns, HandlerDesc,
+                             /*AddDeclarations*/ false);
               });
           return;
         }
@@ -6442,14 +6540,18 @@ private:
         return;
       DiagEngine.resetHadAnyError();
 
+      // Note that we don't print any inline patterns here as we just want
+      // assignments to the names in the outer scope.
+      InlinePatternsToPrint InlinePatterns;
+
       // Don't do any unwrapping or placeholder replacement since all params
       // are still valid in the fallback case
-      prepareNames(ClassifiedBlock(), CallbackParams);
+      prepareNames(ClassifiedBlock(), CallbackParams, InlinePatterns);
 
       addFallbackVars(CallbackParams, Blocks);
       addDo();
       addAwaitCall(CE, ArgList.ref(), Blocks.SuccessBlock, SuccessParams,
-                   HandlerDesc, /*AddDeclarations*/ false);
+                   InlinePatterns, HandlerDesc, /*AddDeclarations*/ false);
       addFallbackCatch(ErrParam);
       OS << "\n";
       convertNodes(NodesToPrint::inBraceStmt(CallbackBody));
@@ -6490,19 +6592,26 @@ private:
       addDo();
     }
 
-    prepareNames(Blocks.SuccessBlock, SuccessParams);
+    auto InlinePatterns =
+        getInlinePatternsToPrint(Blocks.SuccessBlock, SuccessParams, Callback);
+
+    prepareNames(Blocks.SuccessBlock, SuccessParams, InlinePatterns);
     preparePlaceholdersAndUnwraps(HandlerDesc, SuccessParams, ErrParam,
                                   /*Success=*/true);
 
     addAwaitCall(CE, ArgList.ref(), Blocks.SuccessBlock, SuccessParams,
-                 HandlerDesc, /*AddDeclarations=*/true);
+                 InlinePatterns, HandlerDesc, /*AddDeclarations*/ true);
+    printOutOfLineBindingPatterns(Blocks.SuccessBlock, InlinePatterns);
     convertNodes(Blocks.SuccessBlock.nodesToPrint());
     clearNames(SuccessParams);
 
     if (RequireDo) {
-      // Always use the ErrParam name if none is bound
+      // We don't use inline patterns for the error path.
+      InlinePatternsToPrint ErrInlinePatterns;
+
+      // Always use the ErrParam name if none is bound.
       prepareNames(Blocks.ErrorBlock, llvm::makeArrayRef(ErrParam),
-                   HandlerDesc.Type != HandlerType::RESULT);
+                   ErrInlinePatterns, HandlerDesc.Type != HandlerType::RESULT);
       preparePlaceholdersAndUnwraps(HandlerDesc, SuccessParams, ErrParam,
                                     /*Success=*/false);
 
@@ -6563,15 +6672,123 @@ private:
     }
   }
 
+  /// Checks whether a binding pattern for a given decl can be printed inline in
+  /// an await call, e.g 'let ((x, y), z) = await foo()', where '(x, y)' is the
+  /// inline pattern.
+  const Pattern *
+  bindingPatternToPrintInline(const Decl *D, const ClassifiedBlock &Block,
+                              const ClosureExpr *CallbackClosure) {
+    // Only currently done for callback closures.
+    if (!CallbackClosure)
+      return nullptr;
+
+    // If we can reduce the pattern bindings down to a single pattern, we may
+    // be able to print it inline.
+    auto *P = Block.getSinglePatternFor(D);
+    if (!P)
+      return nullptr;
+
+    // Patterns that bind a single var are always printed inline.
+    if (P->getSingleVar())
+      return P;
+
+    // If we have a multi-var binding, and the decl being bound is referenced
+    // elsewhere in the block, we cannot print the pattern immediately in the
+    // await call. Instead, we'll print it out of line.
+    auto *Decls = ScopedDecls.getReferencedDecls(CallbackClosure->getBody());
+    assert(Decls);
+    auto NumRefs = Decls->lookup(D);
+    return NumRefs == 1 ? P : nullptr;
+  }
+
+  /// Retrieve a map of patterns to print inline for an array of param decls.
+  InlinePatternsToPrint
+  getInlinePatternsToPrint(const ClassifiedBlock &Block,
+                           ArrayRef<const ParamDecl *> Params,
+                           const ClosureExpr *CallbackClosure) {
+    InlinePatternsToPrint Patterns;
+    for (auto *Param : Params) {
+      if (auto *P = bindingPatternToPrintInline(Param, Block, CallbackClosure))
+        Patterns[Param] = P;
+    }
+    return Patterns;
+  }
+
+  /// Print any out of line binding patterns that could not be printed as inline
+  /// patterns. These typically appear directly after an await call, e.g:
+  /// \code
+  /// let x = await foo()
+  /// let (y, z) = x
+  /// \endcode
+  void
+  printOutOfLineBindingPatterns(const ClassifiedBlock &Block,
+                                const InlinePatternsToPrint &InlinePatterns) {
+    for (auto &Entry : Block.paramPatternBindings()) {
+      auto *D = Entry.first;
+      auto Aliases = Block.getAliasesFor(D);
+
+      for (auto *P : Entry.second) {
+        // If we already printed this as an inline pattern, there's nothing else
+        // to do.
+        if (InlinePatterns.lookup(D) == P)
+          continue;
+
+        // If this is an alias binding, it can be elided.
+        if (auto *SingleVar = P->getSingleVar()) {
+          if (Aliases.contains(SingleVar))
+            continue;
+        }
+
+        auto HasMutable = P->hasAnyMutableBindings();
+        OS << "\n" << (HasMutable ? tok::kw_var : tok::kw_let) << " ";
+        convertPattern(P);
+        OS << " = ";
+        OS << newNameFor(D);
+      }
+    }
+  }
+
+  /// Prints an \c await call to an \c async function, binding any return values
+  /// into variables.
+  ///
+  /// \param CE The call expr to convert.
+  /// \param Args The arguments of the call expr.
+  /// \param SuccessBlock The nodes present in the success block following the
+  /// call.
+  /// \param SuccessParams The success parameters, which will be printed as
+  /// return values.
+  /// \param InlinePatterns A map of patterns that can be printed inline for
+  /// a given param.
+  /// \param HandlerDesc A description of the completion handler.
+  /// \param AddDeclarations Whether or not to add \c let or \c var keywords to
+  /// the return value bindings.
   void addAwaitCall(const CallExpr *CE, ArrayRef<Expr *> Args,
                     const ClassifiedBlock &SuccessBlock,
                     ArrayRef<const ParamDecl *> SuccessParams,
+                    const InlinePatternsToPrint &InlinePatterns,
                     const AsyncHandlerDesc &HandlerDesc, bool AddDeclarations) {
     // Print the bindings to match the completion handler success parameters,
     // making sure to omit in the case of a Void return.
     if (!SuccessParams.empty() && !HandlerDesc.willAsyncReturnVoid()) {
+      auto AllLet = true;
+
+      // Gather the items to print for the variable bindings. This can either be
+      // a param decl, or a pattern that binds it.
+      using DeclOrPattern = llvm::PointerUnion<const Decl *, const Pattern *>;
+      SmallVector<DeclOrPattern, 4> ToPrint;
+      for (auto *Param : SuccessParams) {
+        // Check if we have an inline pattern to print.
+        if (auto *P = InlinePatterns.lookup(Param)) {
+          if (P->hasAnyMutableBindings())
+            AllLet = false;
+          ToPrint.push_back(P);
+          continue;
+        }
+        ToPrint.push_back(Param);
+      }
+
       if (AddDeclarations) {
-        if (SuccessBlock.allLet()) {
+        if (AllLet) {
           OS << tok::kw_let;
         } else {
           OS << tok::kw_var;
@@ -6579,8 +6796,13 @@ private:
         OS << " ";
       }
       // 'res =' or '(res1, res2, ...) ='
-      addTupleOf(SuccessParams, OS,
-                 [&](auto &Param) { OS << newNameFor(Param); });
+      addTupleOf(ToPrint, OS, [&](DeclOrPattern Elt) {
+        if (auto *P = Elt.dyn_cast<const Pattern *>()) {
+          convertPattern(P);
+          return;
+        }
+        OS << newNameFor(Elt.get<const Decl *>());
+      });
       OS << " " << tok::equal << " ";
     }
 
@@ -6675,17 +6897,26 @@ private:
   /// name will be added.
   void prepareNames(const ClassifiedBlock &Block,
                     ArrayRef<const ParamDecl *> Params,
+                    const InlinePatternsToPrint &InlinePatterns,
                     bool AddIfMissing = true) {
     for (auto *PD : Params) {
-      StringRef Name = Block.boundName(PD);
-      if (!Name.empty() || AddIfMissing)
-        assignUniqueName(PD, Name);
-    }
+      // If this param is to be replaced by a pattern that binds multiple
+      // separate vars, it's not actually going to be added to the scope, and
+      // therefore doesn't need naming. This avoids needing to rename a var with
+      // the same name later on in the scope, as it's not actually clashing.
+      if (auto *P = InlinePatterns.lookup(PD)) {
+        if (!P->getSingleVar())
+          continue;
+      }
+      auto Name = Block.boundName(PD);
+      if (Name.empty() && !AddIfMissing)
+        continue;
 
-    for (auto &Entry : Block.aliases()) {
-      auto It = Names.find(Entry.second);
-      assert(It != Names.end() && "Param should already have an entry");
-      Names[Entry.first] = It->second;
+      auto Ident = assignUniqueName(PD, Name);
+
+      // Also propagate the name to any aliases.
+      for (auto *Alias : Block.getAliasesFor(PD))
+        Names[Alias] = Ident;
     }
   }
 

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -4851,8 +4851,7 @@ public:
     Nodes.addNode(Node);
   }
 
-  void addBinding(const ClassifiedCondition &FromCondition,
-                  DiagnosticEngine &DiagEngine) {
+  void addBinding(const ClassifiedCondition &FromCondition) {
     auto *P = FromCondition.BindPattern;
     if (!P)
       return;
@@ -4866,13 +4865,9 @@ public:
     ParamPatternBindings[FromCondition.Subject].push_back(P);
   }
 
-  void addAllBindings(const ClassifiedCallbackConditions &FromConditions,
-                      DiagnosticEngine &DiagEngine) {
-    for (auto &Entry : FromConditions) {
-      addBinding(Entry.second, DiagEngine);
-      if (DiagEngine.hadAnyError())
-        return;
-    }
+  void addAllBindings(const ClassifiedCallbackConditions &FromConditions) {
+    for (auto &Entry : FromConditions)
+      addBinding(Entry.second);
   }
 };
 
@@ -5309,9 +5304,7 @@ private:
     // comments.
     CurrentBlock->addPossibleCommentLoc(Statement->getStartLoc());
 
-    ThenBlock->addAllBindings(CallbackConditions, DiagEngine);
-    if (DiagEngine.hadAnyError())
-      return;
+    ThenBlock->addAllBindings(CallbackConditions);
 
     // TODO: Handle nested ifs
     setNodes(ThenBlock, ElseBlock, std::move(ThenNodesToPrint));
@@ -5400,9 +5393,7 @@ private:
         Block->addPossibleCommentLoc(SS->getRBraceLoc());
 
       setNodes(Block, OtherBlock, std::move(SuccessNodes));
-      Block->addBinding(*CC, DiagEngine);
-      if (DiagEngine.hadAnyError())
-        return;
+      Block->addBinding(*CC);
     }
     // Mark this switch statement as having been transformed.
     HandledSwitches.insert(SS);

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -5807,8 +5807,8 @@ private:
 
   /// Prints a tuple of elements, or a lone single element if only one is
   /// present, using the provided printing function.
-  template <typename T, typename PrintFn>
-  void addTupleOf(ArrayRef<T> Elements, llvm::raw_ostream &OS,
+  template <typename Container, typename PrintFn>
+  void addTupleOf(const Container &Elements, llvm::raw_ostream &OS,
                   PrintFn PrintElt) {
     if (Elements.size() == 1) {
       PrintElt(Elements[0]);
@@ -5909,8 +5909,7 @@ private:
       // cont.resume(returning: (res1, res2, ...))
       OS << ContName << tok::period << "resume" << tok::l_paren;
       OS << "returning" << tok::colon << " ";
-      addTupleOf(llvm::makeArrayRef(SuccessParamNames), OS,
-                 [&](auto Ref) { OS << Ref; });
+      addTupleOf(SuccessParamNames, OS, [&](auto Ref) { OS << Ref; });
       OS << tok::r_paren << "\n";
       break;
     }

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -6416,9 +6416,10 @@ private:
     }
 
     if (DiagEngine.hadAnyError()) {
-      // Can only fallback when the results are params, in which case only
-      // the names are used (defaulted to the names of the params if none)
-      if (HandlerDesc.Type != HandlerType::PARAMS)
+      // For now, only fallback when the results are params with an error param,
+      // in which case only the names are used (defaulted to the names of the
+      // params if none).
+      if (HandlerDesc.Type != HandlerType::PARAMS || !HandlerDesc.HasError)
         return;
       DiagEngine.resetHadAnyError();
 
@@ -6429,7 +6430,7 @@ private:
       addFallbackVars(CallbackParams, Blocks);
       addDo();
       addAwaitCall(CE, ArgList.ref(), Blocks.SuccessBlock, SuccessParams,
-                   HandlerDesc, /*AddDeclarations=*/!HandlerDesc.HasError);
+                   HandlerDesc, /*AddDeclarations*/ false);
       addFallbackCatch(ErrParam);
       OS << "\n";
       convertNodes(NodesToPrint::inBraceStmt(CallbackBody));

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -66,6 +66,7 @@ private:
   Stmt *walkToStmtPost(Stmt *S) override;
 
   std::pair<bool, Pattern *> walkToPatternPre(Pattern *P) override;
+  Pattern *walkToPatternPost(Pattern *P) override;
 
   bool handleImports(ImportDecl *Import);
   bool handleCustomAttributes(Decl *D);
@@ -587,6 +588,9 @@ std::pair<bool, Pattern *> SemaAnnotator::walkToPatternPre(Pattern *P) {
     return { false, nullptr };
   }
 
+  if (!SEWalker.walkToPatternPre(P))
+    return { false, P };
+
   if (P->isImplicit())
     return { true, P };
 
@@ -607,6 +611,16 @@ std::pair<bool, Pattern *> SemaAnnotator::walkToPatternPre(Pattern *P) {
   // subpattern.  The type will be walked as a part of another TypedPattern.
   TP->getSubPattern()->walk(*this);
   return { false, P };
+}
+
+Pattern *SemaAnnotator::walkToPatternPost(Pattern *P) {
+  if (isDone())
+     return nullptr;
+
+  bool Continue = SEWalker.walkToPatternPost(P);
+  if (!Continue)
+    Cancelled = true;
+  return Continue ? P : nullptr;
 }
 
 bool SemaAnnotator::handleCustomAttributes(Decl *D) {
@@ -822,6 +836,11 @@ bool SourceEntityWalker::walk(Stmt *S) {
 bool SourceEntityWalker::walk(Expr *E) {
   SemaAnnotator Annotator(*this);
   return performWalk(Annotator, [&]() { return E->walk(Annotator); });
+}
+
+bool SourceEntityWalker::walk(Pattern *P) {
+  SemaAnnotator Annotator(*this);
+  return performWalk(Annotator, [&]() { return P->walk(Annotator); });
 }
 
 bool SourceEntityWalker::walk(Decl *D) {

--- a/test/refactoring/ConvertAsync/convert_params_single.swift
+++ b/test/refactoring/ConvertAsync/convert_params_single.swift
@@ -372,10 +372,14 @@ withError { res, err in
   if let str2 = res {
     print("got result \(str2)")
   }
+  if case (let str3?) = (res) {
+    print("got result \(str3)")
+  }
   print("after")
 }
 // MULTIBIND: let str = try await withError()
 // MULTIBIND-NEXT: print("before")
+// MULTIBIND-NEXT: print("got result \(str)")
 // MULTIBIND-NEXT: print("got result \(str)")
 // MULTIBIND-NEXT: print("got result \(str)")
 // MULTIBIND-NEXT: print("after")

--- a/test/refactoring/ConvertAsync/convert_pattern.swift
+++ b/test/refactoring/ConvertAsync/convert_pattern.swift
@@ -5,6 +5,432 @@ enum E : Error { case e }
 func anyCompletion(_ completion: (Any?, Error?) -> Void) {}
 func anyResultCompletion(_ completion: (Result<Any?, Error>) -> Void) {}
 
+func stringTupleParam(_ completion: ((String, String)?, Error?) -> Void) {}
+func stringTupleParam() async throws -> (String, String) {}
+
+func stringTupleResult(_ completion: (Result<(String, String), Error>) -> Void) {}
+func stringTupleResult() async throws -> (String, String) {}
+
+func mixedTupleResult(_ completion: (Result<((Int, Float), String), Error>) -> Void) {}
+func mixedTupleResult() async throws -> ((Int, Float), String) {}
+
+func multipleTupleParam(_ completion: ((String, String)?, (Int, Int)?, Error?) -> Void) {}
+func multipleTupleParam() async throws -> ((String, String), (Int, Int)) {}
+
+func testPatterns() async throws {
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=INLINE %s
+  stringTupleParam { strs, err in
+    guard let (str1, str2) = strs else { return }
+    print(str1, str2)
+  }
+
+  // INLINE:      let (str1, str2) = try await stringTupleParam()
+  // INLINE-NEXT: print(str1, str2)
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=INLINE-VAR %s
+  stringTupleParam { strs, err in
+    guard var (str1, str2) = strs else { return }
+    print(str1, str2)
+  }
+
+  // INLINE-VAR:      var (str1, str2) = try await stringTupleParam()
+  // INLINE-VAR-NEXT: print(str1, str2)
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=INLINE-BLANK %s
+  stringTupleParam { strs, err in
+    guard var (_, str2) = strs else { return }
+    print(str2)
+  }
+
+  // INLINE-BLANK:      var (_, str2) = try await stringTupleParam()
+  // INLINE-BLANK-NEXT: print(str2)
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=INLINE-TYPED %s
+  stringTupleParam { strs, err in
+    guard let (str1, str2): (String, String) = strs else { return }
+    print(str1, str2)
+  }
+
+  // INLINE-TYPED:      let (str1, str2) = try await stringTupleParam()
+  // INLINE-TYPED-NEXT: print(str1, str2)
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=INLINE-CASE %s
+  stringTupleParam { strs, err in
+    guard case (let str1, var str2)? = strs else { return }
+    print(str1, str2)
+  }
+
+  // INLINE-CASE:      var (str1, str2) = try await stringTupleParam()
+  // INLINE-CASE-NEXT: print(str1, str2)
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=INLINE-CASE-TYPED %s
+  stringTupleParam { strs, err in
+    guard case let (str1, str2)?: (String, String)? = strs else { return }
+    print(str1, str2)
+  }
+
+  // INLINE-CASE-TYPED:      let (str1, str2) = try await stringTupleParam()
+  // INLINE-CASE-TYPED-NEXT: print(str1, str2)
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=OUT-OF-LINE %s
+  stringTupleParam { strs, err in
+    guard let (str1, str2) = strs else { return }
+    print(str1, str2, strs!)
+  }
+
+  // OUT-OF-LINE:      let strs = try await stringTupleParam()
+  // OUT-OF-LINE-NEXT: let (str1, str2) = strs
+  // OUT-OF-LINE-NEXT: print(str1, str2, strs)
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=OUT-OF-LINE-VAR %s
+  stringTupleParam { strs, err in
+    guard var (str1, _) = strs else { return }
+    str1 = ""
+    print(str1, {strs!})
+  }
+
+  // OUT-OF-LINE-VAR:      let strs = try await stringTupleParam()
+  // OUT-OF-LINE-VAR-NEXT: var (str1, _) = strs
+  // OUT-OF-LINE-VAR-NEXT: str1 = ""
+  // OUT-OF-LINE-VAR-NEXT: print(str1, {strs})
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=OUT-OF-LINE-CASE %s
+  stringTupleParam { strs, err in
+    guard case (let str1, var str2)? = strs else { return }
+    print(str1, str2, strs!)
+  }
+
+  // OUT-OF-LINE-CASE:      let strs = try await stringTupleParam()
+  // OUT-OF-LINE-CASE-NEXT: var (str1, str2) = strs
+  // OUT-OF-LINE-CASE-NEXT: print(str1, str2, strs)
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=FALLBACK %s
+  stringTupleParam { strs, err in
+    guard let (str1, str2) = strs, str1 == "hi" else { fatalError() }
+    print(str1, str2, err)
+  }
+
+  // FALLBACK:      var strs: (String, String)? = nil
+  // FALLBACK-NEXT: var err: Error? = nil
+  // FALLBACK-NEXT: do {
+  // FALLBACK-NEXT:   strs = try await stringTupleParam()
+  // FALLBACK-NEXT: } catch {
+  // FALLBACK-NEXT:   err = error
+  // FALLBACK-NEXT: }
+  // FALLBACK-EMPTY:
+  // FALLBACK-NEXT: guard let (str1, str2) = strs, str1 == "hi" else { fatalError() }
+  // FALLBACK-NEXT: print(str1, str2, err)
+
+  // FIXME: Arguably we should be able to classify everything after the guard as
+  // a success path and avoid the fallback in this case.
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=FALLBACK2 %s
+  stringTupleParam { strs, err in
+    guard let (str1, str2) = strs else { fatalError() }
+    print(str1, str2)
+    if .random(), err == nil {
+      print("yay")
+    } else {
+      print("nay")
+    }
+  }
+
+  // FALLBACK2:      var strs: (String, String)? = nil
+  // FALLBACK2-NEXT: var err: Error? = nil
+  // FALLBACK2-NEXT: do {
+  // FALLBACK2-NEXT:   strs = try await stringTupleParam()
+  // FALLBACK2-NEXT: } catch {
+  // FALLBACK2-NEXT:   err = error
+  // FALLBACK2-NEXT: }
+  // FALLBACK2-EMPTY:
+  // FALLBACK2-NEXT: guard let (str1, str2) = strs else { fatalError() }
+  // FALLBACK2-NEXT: print(str1, str2)
+  // FALLBACK2-NEXT: if .random(), err == nil {
+  // FALLBACK2-NEXT:   print("yay")
+  // FALLBACK2-NEXT: } else {
+  // FALLBACK2-NEXT:   print("nay")
+  // FALLBACK2-NEXT: }
+
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MIXED-BINDINGS %s
+  stringTupleParam { strs, err in
+    guard let x = strs else { return }
+    guard var (str1, str2) = strs else { return }
+    guard var y = strs else { return }
+    guard let z = strs else { return }
+    y = ("hello", "there")
+    print(x, y, z, str1, str2)
+  }
+
+  // Make sure that we
+  // 1. Coalesce the z binding, as it is a let
+  // 2. Preserve the y binding, as it is a var
+  // 3. Print the multi-var binding out of line
+  //
+  // MIXED-BINDINGS:      let x = try await stringTupleParam()
+  // MIXED-BINDINGS-NEXT: var (str1, str2) = x
+  // MIXED-BINDINGS-NEXT: var y = x
+  // MIXED-BINDINGS-NEXT: y = ("hello", "there")
+  // MIXED-BINDINGS-NEXT: print(x, y, x, str1, str2)
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MIXED-BINDINGS2 %s
+  stringTupleParam { strs, err in
+    guard var (str1, str2) = strs else { return }
+    str1 = "hi"
+    guard var x = strs else { return }
+    x = ("hello", "there")
+    print(x, str1, str2)
+  }
+
+  // MIXED-BINDINGS2:      var x = try await stringTupleParam()
+  // MIXED-BINDINGS2-NEXT: var (str1, str2) = x
+  // MIXED-BINDINGS2-NEXT: str1 = "hi"
+  // MIXED-BINDINGS2-NEXT: x = ("hello", "there")
+  // MIXED-BINDINGS2-NEXT: print(x, str1, str2)
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MIXED-BINDINGS3 %s
+  stringTupleParam { strs, err in
+    guard let (str1, str2) = strs else { return }
+    guard let x = strs else { return }
+    print(x, str1, str2)
+  }
+
+  // MIXED-BINDINGS3:      let x = try await stringTupleParam()
+  // MIXED-BINDINGS3-NEXT: let (str1, str2) = x
+  // MIXED-BINDINGS3-NEXT: print(x, str1, str2)
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=ALIAS-BINDINGS %s
+  stringTupleParam { strs, err in
+    guard let x = strs else { return }
+    guard let y = strs else { return }
+    guard let z = strs else { return }
+    print(x, y, z)
+  }
+
+  // ALIAS-BINDINGS:      let x = try await stringTupleParam()
+  // ALIAS-BINDINGS-NEXT: print(x, x, x)
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=ALIAS-BINDINGS2 %s
+  stringTupleParam { strs, err in
+    guard var x = strs else { return }
+    guard var y = strs else { return }
+    guard let z = strs else { return }
+    print(x, y, z)
+  }
+
+  // ALIAS-BINDINGS2:      let z = try await stringTupleParam()
+  // ALIAS-BINDINGS2-NEXT: var x = z
+  // ALIAS-BINDINGS2-NEXT: var y = z
+  // ALIAS-BINDINGS2-NEXT: print(x, y, z)
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=ALIAS-BINDINGS3 %s
+  stringTupleParam { strs, err in
+    guard var x = strs else { return }
+    guard var y = strs else { return }
+    guard var z = strs else { return }
+    print(x, y, z)
+  }
+
+  // ALIAS-BINDINGS3:      var x = try await stringTupleParam()
+  // ALIAS-BINDINGS3-NEXT: var y = x
+  // ALIAS-BINDINGS3-NEXT: var z = x
+  // ALIAS-BINDINGS3-NEXT: print(x, y, z)
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=ALIAS-BINDINGS4 %s
+  stringTupleParam { strs, err in
+    guard var x = strs else { return }
+    guard let y = strs else { return }
+    guard let z = strs else { return }
+    print(x, y, z)
+  }
+
+  // ALIAS-BINDINGS4:      let y = try await stringTupleParam()
+  // ALIAS-BINDINGS4-NEXT: var x = y
+  // ALIAS-BINDINGS4-NEXT: print(x, y, y)
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=ALIAS-BINDINGS5 %s
+  stringTupleParam { strs, err in
+    guard var x = strs else { return }
+    print(x)
+  }
+
+  // ALIAS-BINDINGS5:      var x = try await stringTupleParam()
+  // ALIAS-BINDINGS5-NEXT: print(x)
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=STRING-TUPLE-RESULT %s
+  stringTupleResult { res in
+    switch res {
+    case .success((let x, let y)):
+      print(x, y)
+    case .failure:
+      print("oh no")
+    }
+  }
+  // STRING-TUPLE-RESULT:      do {
+  // STRING-TUPLE-RESULT-NEXT:   let (x, y) = try await stringTupleResult()
+  // STRING-TUPLE-RESULT-NEXT:   print(x, y)
+  // STRING-TUPLE-RESULT-NEXT: } catch {
+  // STRING-TUPLE-RESULT-NEXT:   print("oh no")
+  // STRING-TUPLE-RESULT-NEXT: }
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MIXED-TUPLE-RESULT %s
+  mixedTupleResult { res in
+    if case .failure(let err) = res {
+      print("oh no")
+    }
+    if case .success(((let x, let y), let z)) = res {
+      print("a", x, y, z)
+    }
+    switch res {
+    case .success(let ((x, _), z)):
+      print("b", x, z)
+    case .failure:
+      print("oh no again")
+    }
+  }
+
+  // MIXED-TUPLE-RESULT:      do {
+  // MIXED-TUPLE-RESULT-NEXT:   let res = try await mixedTupleResult()
+  // MIXED-TUPLE-RESULT-NEXT:   let ((x, y), z) = res
+  // MIXED-TUPLE-RESULT-NEXT:   let ((x1, _), z1) = res
+  // MIXED-TUPLE-RESULT-NEXT:   print("a", x, y, z)
+  // MIXED-TUPLE-RESULT-NEXT:   print("b", x, z)
+  // MIXED-TUPLE-RESULT-NEXT: } catch let err {
+  // MIXED-TUPLE-RESULT-NEXT:   print("oh no")
+  // MIXED-TUPLE-RESULT-NEXT:   print("oh no again")
+  // MIXED-TUPLE-RESULT-NEXT: }
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MIXED-TUPLE-RESULT2 %s
+  mixedTupleResult { res in
+    switch res {
+    case .success(((let x, let _), let z)):
+      print(x, z)
+    case .failure(let err):
+      print("oh no \(err)")
+    }
+  }
+
+  // MIXED-TUPLE-RESULT2:      do {
+  // MIXED-TUPLE-RESULT2-NEXT:   let ((x, _), z) = try await mixedTupleResult()
+  // MIXED-TUPLE-RESULT2-NEXT:   print(x, z)
+  // MIXED-TUPLE-RESULT2-NEXT: } catch let err {
+  // MIXED-TUPLE-RESULT2-NEXT:   print("oh no \(err)")
+  // MIXED-TUPLE-RESULT2-NEXT: }
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MIXED-TUPLE-RESULT3 %s
+  mixedTupleResult { res in
+    if let ((_, y), z) = try? res.get() {
+      print(y, z)
+    } else {
+      print("boo")
+    }
+  }
+
+  // MIXED-TUPLE-RESULT3:      do {
+  // MIXED-TUPLE-RESULT3-NEXT:   let ((_, y), z) = try await mixedTupleResult()
+  // MIXED-TUPLE-RESULT3-NEXT:   print(y, z)
+  // MIXED-TUPLE-RESULT3-NEXT: } catch {
+  // MIXED-TUPLE-RESULT3-NEXT:   print("boo")
+  // MIXED-TUPLE-RESULT3-NEXT: }
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MULTIPLE-TUPLE-PARAM %s
+  multipleTupleParam { strs, ints, err in
+    guard let (str1, str2) = strs, let (int1, int2) = ints else {
+      print("ohno")
+      return
+    }
+    print(str1, str2, int1, int2)
+  }
+  // MULTIPLE-TUPLE-PARAM:      do {
+  // MULTIPLE-TUPLE-PARAM-NEXT:   let ((str1, str2), (int1, int2)) = try await multipleTupleParam()
+  // MULTIPLE-TUPLE-PARAM-NEXT:   print(str1, str2, int1, int2)
+  // MULTIPLE-TUPLE-PARAM-NEXT: } catch let err {
+  // MULTIPLE-TUPLE-PARAM-NEXT:   print("ohno")
+  // MULTIPLE-TUPLE-PARAM-NEXT: }
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MULTIPLE-TUPLE-PARAM2 %s
+  multipleTupleParam { strs, ints, err in
+    guard let (str1, str2) = strs, var (int1, int2) = ints else {
+      print("ohno")
+      return
+    }
+    print(str1, str2, int1, int2)
+  }
+  // MULTIPLE-TUPLE-PARAM2:      do {
+  // MULTIPLE-TUPLE-PARAM2-NEXT:   var ((str1, str2), (int1, int2)) = try await multipleTupleParam()
+  // MULTIPLE-TUPLE-PARAM2-NEXT:   print(str1, str2, int1, int2)
+  // MULTIPLE-TUPLE-PARAM2-NEXT: } catch let err {
+  // MULTIPLE-TUPLE-PARAM2-NEXT:   print("ohno")
+  // MULTIPLE-TUPLE-PARAM2-NEXT: }
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MULTIPLE-TUPLE-PARAM3 %s
+  multipleTupleParam { strs, ints, err in
+    guard let (str1, str2) = strs, let (int1, int2) = ints else {
+      print("ohno")
+      return
+    }
+    print(strs!)
+    print(str1, str2, int1, int2)
+  }
+  // MULTIPLE-TUPLE-PARAM3:      do {
+  // MULTIPLE-TUPLE-PARAM3-NEXT:   let (strs, (int1, int2)) = try await multipleTupleParam()
+  // MULTIPLE-TUPLE-PARAM3-NEXT:   let (str1, str2) = strs
+  // MULTIPLE-TUPLE-PARAM3-NEXT:   print(strs)
+  // MULTIPLE-TUPLE-PARAM3-NEXT:   print(str1, str2, int1, int2)
+  // MULTIPLE-TUPLE-PARAM3-NEXT: } catch let err {
+  // MULTIPLE-TUPLE-PARAM3-NEXT:   print("ohno")
+  // MULTIPLE-TUPLE-PARAM3-NEXT: }
+}
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NAME-COLLISION %s
+func testNameCollision(_ completion: () -> Void) {
+  let a = ""
+  stringTupleParam { strs, err in
+    guard let (a, b) = strs else { return }
+    print(a, b)
+  }
+  let b = ""
+  stringTupleParam { strs, err in
+    guard let (a, b) = strs else { return }
+    print(a, b, strs!)
+  }
+  print(a, b)
+  completion()
+}
+
+// TODO: `throws` isn't added to the function declaration
+// NAME-COLLISION:      func testNameCollision() async {
+// NAME-COLLISION-NEXT:   let a = ""
+// NAME-COLLISION-NEXT:   let (a1, b) = try await stringTupleParam()
+// NAME-COLLISION-NEXT:   print(a1, b)
+// NAME-COLLISION-NEXT:   let b1 = ""
+// NAME-COLLISION-NEXT:   let strs = try await stringTupleParam()
+// NAME-COLLISION-NEXT:   let (a2, b2) = strs
+// NAME-COLLISION-NEXT:   print(a2, b2, strs)
+// NAME-COLLISION-NEXT:   print(a, b1)
+// NAME-COLLISION-NEXT:   return
+// NAME-COLLISION-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NAME-COLLISION2 %s
+func testNameCollision2(_ completion: () -> Void) {
+  mixedTupleResult { res in
+    guard case let .success((x, y), z) = res else { return }
+    stringTupleParam { strs, err in
+      if let (x, y) = strs {
+        print("a", x, y)
+      }
+    }
+    print("b", x, y, z)
+  }
+}
+
+// TODO: `throws` isn't added to the function declaration
+// NAME-COLLISION2:      func testNameCollision2() async {
+// NAME-COLLISION2-NEXT:   let ((x, y), z) = try await mixedTupleResult()
+// NAME-COLLISION2-NEXT:   let (x1, y1) = try await stringTupleParam()
+// NAME-COLLISION2-NEXT:   print("a", x1, y1)
+// NAME-COLLISION2-NEXT:   print("b", x, y, z)
+// NAME-COLLISION2-NEXT: }
+
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=TEST-UNHANDLED %s
 anyCompletion { val, err in
   if let x = val {
@@ -118,3 +544,18 @@ anyResultCompletion { res in
     print("oh no")
   }
 }
+
+// Make sure we handle a capture list okay.
+class C {
+  // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=CAPTURE %s
+  func foo() {
+    let _ = { [weak self] in
+      print(self!)
+    }
+  }
+}
+// CAPTURE:      func foo() async {
+// CAPTURE-NEXT:   let _ = { [weak self] in
+// CAPTURE-NEXT:     print(self!)
+// CAPTURE-NEXT:   }
+// CAPTURE-NEXT: }

--- a/test/refactoring/ConvertAsync/convert_pattern.swift
+++ b/test/refactoring/ConvertAsync/convert_pattern.swift
@@ -3,6 +3,7 @@
 enum E : Error { case e }
 
 func anyCompletion(_ completion: (Any?, Error?) -> Void) {}
+func anyResultCompletion(_ completion: (Result<Any?, Error>) -> Void) {}
 
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=TEST-UNHANDLED %s
 anyCompletion { val, err in
@@ -43,3 +44,77 @@ anyCompletion { val, err in
 // TEST-UNHANDLED-NEXT: if case let "" as String = <#x#> {
 // TEST-UNHANDLED-NEXT:   print("g")
 // TEST-UNHANDLED-NEXT: }
+
+// RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+anyResultCompletion { res in
+  switch res {
+  case .success(let unwrapped?):
+    print(unwrapped)
+  case .success(let x):
+    print(x)
+  case .failure:
+    print("oh no")
+  }
+}
+
+// RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+anyResultCompletion { res in
+  switch res {
+  case .success(let str as String):
+    print(str)
+  case .success(let x):
+    print(x)
+  case .failure:
+    print("oh no")
+  }
+}
+
+// RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+anyResultCompletion { res in
+  switch res {
+  case .success(E.e?):
+    print("ee")
+  case .success(let x):
+    print(x)
+  case .failure:
+    print("oh no")
+  }
+}
+
+// RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+anyResultCompletion { res in
+  switch res {
+  case .success("" as String):
+    print("empty string")
+  case .success(let x):
+    print(x)
+  case .failure:
+    print("oh no")
+  }
+}
+
+// FIXME: This should ideally be turned into a 'catch let e as E'.
+// RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+anyResultCompletion { res in
+  switch res {
+  case .success(let a):
+    print(a)
+  case .failure(let e as E):
+    print("oh no e")
+  case .failure:
+    print("oh no")
+  }
+}
+
+// FIXME: This should ideally be turned into a 'catch E.e'.
+// RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+anyResultCompletion { res in
+  switch res {
+  case .success(let a):
+    print(a)
+  case .failure(E.e):
+    print("oh no ee")
+  case .failure:
+    print("oh no")
+  }
+}

--- a/test/refactoring/ConvertAsync/convert_pattern.swift
+++ b/test/refactoring/ConvertAsync/convert_pattern.swift
@@ -293,7 +293,7 @@ func testPatterns() async throws {
   // MIXED-TUPLE-RESULT-NEXT:   let ((x, y), z) = res
   // MIXED-TUPLE-RESULT-NEXT:   let ((x1, _), z1) = res
   // MIXED-TUPLE-RESULT-NEXT:   print("a", x, y, z)
-  // MIXED-TUPLE-RESULT-NEXT:   print("b", x, z)
+  // MIXED-TUPLE-RESULT-NEXT:   print("b", x1, z1)
   // MIXED-TUPLE-RESULT-NEXT: } catch let err {
   // MIXED-TUPLE-RESULT-NEXT:   print("oh no")
   // MIXED-TUPLE-RESULT-NEXT:   print("oh no again")

--- a/test/refactoring/ConvertAsync/convert_pattern.swift
+++ b/test/refactoring/ConvertAsync/convert_pattern.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+
+enum E : Error { case e }
+
+func anyCompletion(_ completion: (Any?, Error?) -> Void) {}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=TEST-UNHANDLED %s
+anyCompletion { val, err in
+  if let x = val {
+    print("a")
+  }
+  if let _ = val {
+    print("b")
+  }
+  if case let x? = val {
+    print("c")
+  }
+  if case let _? = val {
+    print("d")
+  }
+  if case E.e? = val {
+    print("e")
+  }
+  if case (let x as String)? = val {
+    print("f")
+  }
+  if case let "" as String = val {
+    print("g")
+  }
+}
+
+// TEST-UNHANDLED:      let x = try await anyCompletion()
+// TEST-UNHANDLED-NEXT: print("a")
+// TEST-UNHANDLED-NEXT: print("b")
+// TEST-UNHANDLED-NEXT: print("c")
+// TEST-UNHANDLED-NEXT: print("d")
+// TEST-UNHANDLED-NEXT: if case E.e? = <#x#> {
+// TEST-UNHANDLED-NEXT:   print("e")
+// TEST-UNHANDLED-NEXT: }
+// TEST-UNHANDLED-NEXT: if case (let x as String)? = <#x#> {
+// TEST-UNHANDLED-NEXT:   print("f")
+// TEST-UNHANDLED-NEXT: }
+// TEST-UNHANDLED-NEXT: if case let "" as String = <#x#> {
+// TEST-UNHANDLED-NEXT:   print("g")
+// TEST-UNHANDLED-NEXT: }


### PR DESCRIPTION
Keep track of patterns that bind multiple vars and print them out when converting an async call. If the parameter being bound isn't referenced elsewhere, we'll print the pattern inline as e.g:

```
let ((x, y), z) = await foo()
```

Otherwise, if the parameter is referenced elsewhere in the block we'll print the pattern out of line, such as:

```
let (res, z) = await foo()
let (x, y) = res
```

In addition, make sure to print var bindings out of line if there's also a let binding, e.g:

```
let x = await foo()
var y = x
```

This ensures any mutations to `y` doesn't affect `x`. If there's only a single var binding, we'll print it inline.

Finally this PR ensures that refutable patterns and unclassified switch cases are left unhandled rather than being silently added to the success block.

rdar://77802560