### PR TITLE
[cmake] Work around a bug in the swift-driver by passing host side libraries from LLVMSupport to linker jobs via a -Xlinker flag.

### DIFF
--- a/tools/libSwiftSyntaxParser/CMakeLists.txt
+++ b/tools/libSwiftSyntaxParser/CMakeLists.txt
@@ -9,7 +9,8 @@ set(LLVM_EXPORTED_SYMBOL_FILE
 
 add_swift_host_library(libSwiftSyntaxParser SHARED
   c-include-check.c
-  libSwiftSyntaxParser.cpp)
+  libSwiftSyntaxParser.cpp
+  LLVM_LINK_COMPONENTS support)
 if(NOT SWIFT_BUILT_STANDALONE AND NOT CMAKE_C_COMPILER_ID MATCHES Clang)
   add_dependencies(libSwiftSyntaxParser clang)
 endif()

--- a/tools/swift-refactor/CMakeLists.txt
+++ b/tools/swift-refactor/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_swift_host_tool(swift-refactor
   swift-refactor.cpp
   SWIFT_COMPONENT tools
+  LLVM_LINK_COMPONENTS support
 )
 target_link_libraries(swift-refactor
                       PRIVATE


### PR DESCRIPTION
Clang and Swift both support this so we can do this until the actual fix lands
in a host toolchain to unblock ErikE.

The specific problem is the swift driver should just push tbd files through to
the linker, but it treats it as an input file. I am going to be putting a fix
into 5.5. This patch in the mean time filters out the tbd files in cmake. This
is a temporary fix.