### PR TITLE
Update .clang-format for YAML 1.2.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,2 @@
 BasedOnStyle: LLVM
-AlwaysBreakTemplateDeclarations: Yes
+AlwaysBreakTemplateDeclarations: true


### PR DESCRIPTION
YAML 1.2 seems to have removed some implicit typing rules, such
as treating Yes as true.