### PR TITLE
[5.5-05142021] [Async Refactoring] Fix crash on recursive AST walk

### DIFF
--- a/include/swift/IDE/SourceEntityWalker.h
+++ b/include/swift/IDE/SourceEntityWalker.h
@@ -18,6 +18,7 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceLoc.h"
 #include "llvm/ADT/PointerUnion.h"
+#include "llvm/Support/SaveAndRestore.h"
 
 namespace clang {
   class Module;
@@ -189,10 +190,7 @@ private:
 
   /// Utility that lets us keep track of an ASTWalker when walking.
   bool performWalk(ASTWalker &W, llvm::function_ref<bool(void)> DoWalk) {
-    Walker = &W;
-    SWIFT_DEFER {
-      Walker = nullptr;
-    };
+    llvm::SaveAndRestore<ASTWalker *> SV(Walker, &W);
     return DoWalk();
   }
 };

--- a/test/refactoring/ConvertAsync/convert_function.swift
+++ b/test/refactoring/ConvertAsync/convert_function.swift
@@ -289,3 +289,23 @@ func testReturnHandling3(_ completion: (String?, Error?) -> Void) {
 // RETURN-HANDLING3:      func testReturnHandling3() async throws -> String {
 // RETURN-HANDLING3-NEXT:   {{^}} return (<#completion#>("", nil)){{$}}
 // RETURN-HANDLING3-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=RDAR78693050 %s
+func rdar78693050(_ completion: () -> Void) {
+  simple { str in
+    print(str)
+  }
+  if .random() {
+    return completion()
+  }
+  completion()
+}
+
+// RDAR78693050:      func rdar78693050() async {
+// RDAR78693050-NEXT:   let str = await simple()
+// RDAR78693050-NEXT:   print(str)
+// RDAR78693050-NEXT:   if .random() {
+// RDAR78693050-NEXT:     return
+// RDAR78693050-NEXT:   }
+// RDAR78693050-NEXT:   return
+// RDAR78693050-NEXT: }


### PR DESCRIPTION
*5.5-05142021 cherry-pick of https://github.com/apple/swift/pull/37715*

---

The async refactoring may perform recursive AST walks in cases such as transforming the body of a hoisted closure. Make sure this can be handled by the logic tracking the ASTWalker in the SourceEntityWalker, such that we don't crash when later converting the call to a completion callback.

rdar://78693050