### PR TITLE
[CodeCompletion] Add decl context dependent 'Flair' to decl keywords 

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -417,6 +417,13 @@ enum class CodeCompletionFlairBit: uint8_t {
 
   /// Argument label and type. i.e. 'label: <#Ty#>'.
   ArgumentLabels = 1 << 2,
+
+  /// E.g. decl introducer or modifiers ('enum', 'protocol', 'public', etc.) at
+  /// top-level.
+  CommonKeywordAtCurrentPosition = 1 << 3,
+
+  /// E.g. type decl introducer ('enum', 'class', etc.) in a function body.
+  RareKeywordAtCurrentPosition = 1 << 4,
 };
 
 using CodeCompletionFlair = OptionSet<CodeCompletionFlairBit>;

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -708,9 +708,6 @@ void CodeCompletionResult::printPrefix(raw_ostream &OS) const {
   case SemanticContextKind::None:
     Prefix.append("None");
     break;
-  case SemanticContextKind::ExpressionSpecific:
-    Prefix.append("ExprSpecific");
-    break;
   case SemanticContextKind::Local:
     Prefix.append("Local");
     break;
@@ -731,6 +728,19 @@ void CodeCompletionResult::printPrefix(raw_ostream &OS) const {
     if (!ModuleName.empty())
       Prefix.append((Twine("[") + ModuleName + "]").str());
     break;
+  }
+  if (getFlair().toRaw()) {
+    Prefix.append("/Flair[");
+    bool isFirstFlair = true;
+#define PRINT_FLAIR(KIND, NAME) \
+    if (getFlair().contains(CodeCompletionFlairBit::KIND)) { \
+      if (isFirstFlair) { isFirstFlair = false; } \
+      else { Prefix.append(","); } \
+      Prefix.append(NAME); \
+    }
+    PRINT_FLAIR(ExpressionSpecific, "ExprSpecific");
+    PRINT_FLAIR(SuperChain, "SuperChain");
+    Prefix.append("]");
   }
   if (NotRecommended)
     Prefix.append("/NotRecommended");
@@ -1294,7 +1304,7 @@ CodeCompletionResult *CodeCompletionResultBuilder::takeResult() {
     }
 
     return new (*Sink.Allocator) CodeCompletionResult(
-        SemanticContext, IsArgumentLabels, NumBytesToErase, CCS, AssociatedDecl,
+        SemanticContext, Flair, IsArgumentLabels, NumBytesToErase, CCS, AssociatedDecl,
         ModuleName, NotRecReason, copyString(*Sink.Allocator, BriefComment),
         copyAssociatedUSRs(*Sink.Allocator, AssociatedDecl),
         copyArray(*Sink.Allocator, CommentWords), ExpectedTypeRelation);
@@ -1303,21 +1313,21 @@ CodeCompletionResult *CodeCompletionResultBuilder::takeResult() {
   case CodeCompletionResult::ResultKind::Keyword:
     return new (*Sink.Allocator)
         CodeCompletionResult(
-          KeywordKind, SemanticContext, IsArgumentLabels, NumBytesToErase,
+          KeywordKind, SemanticContext, Flair, IsArgumentLabels, NumBytesToErase,
           CCS, ExpectedTypeRelation,
           copyString(*Sink.Allocator, BriefDocComment));
 
   case CodeCompletionResult::ResultKind::BuiltinOperator:
   case CodeCompletionResult::ResultKind::Pattern:
     return new (*Sink.Allocator) CodeCompletionResult(
-        Kind, SemanticContext, IsArgumentLabels, NumBytesToErase, CCS,
+        Kind, SemanticContext, Flair, IsArgumentLabels, NumBytesToErase, CCS,
         ExpectedTypeRelation, CodeCompletionOperatorKind::None,
         copyString(*Sink.Allocator, BriefDocComment));
 
   case CodeCompletionResult::ResultKind::Literal:
     assert(LiteralKind.hasValue());
     return new (*Sink.Allocator)
-        CodeCompletionResult(*LiteralKind, SemanticContext, IsArgumentLabels,
+        CodeCompletionResult(*LiteralKind, SemanticContext, Flair, IsArgumentLabels,
                              NumBytesToErase, CCS, ExpectedTypeRelation);
   }
 
@@ -2180,9 +2190,6 @@ public:
       return SemanticContextKind::Local;
 
     case DeclVisibilityKind::MemberOfCurrentNominal:
-      if (IsSuperRefExpr &&
-          CurrentMethod && CurrentMethod->getOverriddenDecl() == D)
-        return SemanticContextKind::ExpressionSpecific;
       return SemanticContextKind::CurrentNominal;
 
     case DeclVisibilityKind::MemberOfProtocolConformedToByCurrentNominal:
@@ -2644,7 +2651,7 @@ public:
       Builder.addAnnotatedAsync();
 
     if (isUnresolvedMemberIdealType(VarType))
-      Builder.setSemanticContext(SemanticContextKind::ExpressionSpecific);
+      Builder.addFlair(CodeCompletionFlairBit::ExpressionSpecific);
   }
 
   static bool hasInterestingDefaultValues(const AbstractFunctionDecl *func) {
@@ -2782,7 +2789,10 @@ public:
     if (ParentKind != StmtKind::If && ParentKind != StmtKind::Guard)
       return;
     CodeCompletionResultBuilder Builder(Sink, CodeCompletionResult::ResultKind::Keyword,
-      SemanticContextKind::ExpressionSpecific, expectedTypeContext);
+      // FIXME: SemanticContextKind::Local is not correct.
+      // Use 'None' (and fix prioritization) or introduce a new context.
+      SemanticContextKind::Local, expectedTypeContext);
+    Builder.addFlair(CodeCompletionFlairBit::ExpressionSpecific);
     Builder.addBaseName("available");
     Builder.addLeftParen();
     Builder.addSimpleTypedParameter("Platform", /*IsVarArg=*/true);
@@ -3072,6 +3082,10 @@ public:
       setClangDeclKeywords(FD, Pairs, Builder);
       Builder.setAssociatedDecl(FD);
 
+      if (IsSuperRefExpr && CurrentMethod &&
+          CurrentMethod->getOverriddenDecl() == FD)
+        Builder.addFlair(CodeCompletionFlairBit::SuperChain);
+
       if (NotRecommended)
         Builder.setNotRecommended(*NotRecommended);
 
@@ -3161,7 +3175,7 @@ public:
           ResultType, expectedTypeContext, CurrDeclContext));
 
       if (isUnresolvedMemberIdealType(ResultType))
-        Builder.setSemanticContext(SemanticContextKind::ExpressionSpecific);
+        Builder.addFlair(CodeCompletionFlairBit::ExpressionSpecific);
 
       if (!IsImplicitlyCurriedInstanceMethod &&
           expectedTypeContext.requiresNonVoid() &&
@@ -3215,6 +3229,11 @@ public:
           expectedTypeContext);
       setClangDeclKeywords(CD, Pairs, Builder);
       Builder.setAssociatedDecl(CD);
+
+      if (IsSuperRefExpr && CurrentMethod &&
+          CurrentMethod->getOverriddenDecl() == CD)
+        Builder.addFlair(CodeCompletionFlairBit::SuperChain);
+
       if (needInit) {
         assert(addName.empty());
         addLeadingDot(Builder);
@@ -3458,11 +3477,13 @@ public:
     CommandWordsPairs Pairs;
     CodeCompletionResultBuilder Builder(
         Sink, CodeCompletionResult::ResultKind::Declaration,
-        HasTypeContext ? SemanticContextKind::ExpressionSpecific
-                       : getSemanticContext(EED, Reason, dynamicLookupInfo),
+        getSemanticContext(EED, Reason, dynamicLookupInfo),
         expectedTypeContext);
     Builder.setAssociatedDecl(EED);
     setClangDeclKeywords(EED, Pairs, Builder);
+    if (HasTypeContext)
+      Builder.addFlair(CodeCompletionFlairBit::ExpressionSpecific);
+
     addLeadingDot(Builder);
     addValueBaseName(Builder, EED->getBaseIdentifier());
 
@@ -3486,7 +3507,7 @@ public:
     addTypeAnnotation(Builder, EnumType, EED->getGenericSignatureOfContext());
 
     if (isUnresolvedMemberIdealType(EnumType))
-      Builder.setSemanticContext(SemanticContextKind::ExpressionSpecific);
+      Builder.addFlair(CodeCompletionFlairBit::ExpressionSpecific);
   }
 
   void addKeyword(StringRef Name, Type TypeAnnotation = Type(),
@@ -4579,13 +4600,17 @@ public:
         continue;
       CodeCompletionResultBuilder Builder(
           Sink, CodeCompletionResult::ResultKind::Pattern,
-          SemanticContextKind::ExpressionSpecific, {});
+          // FIXME: SemanticContextKind::Local is not correct.
+          // Use 'None' (and fix prioritization) or introduce a new context.
+          SemanticContextKind::Local, {});
       Builder.addCallParameter(Arg->getLabel(), Identifier(),
                                Arg->getPlainType(), ContextType,
                                Arg->isVariadic(), Arg->isInOut(),
                                /*isIUO=*/false, Arg->isAutoClosure(),
                                /*useUnderscoreLabel=*/true,
                                isLabeledTrailingClosure);
+      Builder.setIsArgumentLabels();
+      Builder.addFlair(CodeCompletionFlairBit::ExpressionSpecific);
       auto Ty = Arg->getPlainType();
       if (Arg->isInOut()) {
         Ty = InOutType::get(Ty);
@@ -6202,12 +6227,16 @@ static void addPlatformConditions(CodeCompletionResultSink &Sink) {
               consumer) {
         CodeCompletionResultBuilder Builder(
             Sink, CodeCompletionResult::ResultKind::Pattern,
-            SemanticContextKind::ExpressionSpecific, {});
+            // FIXME: SemanticContextKind::CurrentModule is not correct.
+            // Use 'None' (and fix prioritization) or introduce a new context.
+            SemanticContextKind::CurrentModule, {});
+        Builder.addFlair(CodeCompletionFlairBit::ExpressionSpecific);
         Builder.addBaseName(Name);
         Builder.addLeftParen();
         consumer(Builder);
         Builder.addRightParen();
       };
+
   addWithName("os", [](CodeCompletionResultBuilder &Builder) {
     Builder.addSimpleNamedParameter("name");
   });
@@ -6248,7 +6277,10 @@ static void addConditionalCompilationFlags(ASTContext &Ctx,
     // TODO: Should we filter out some flags?
     CodeCompletionResultBuilder Builder(
         Sink, CodeCompletionResult::ResultKind::Keyword,
-        SemanticContextKind::ExpressionSpecific, {});
+        // FIXME: SemanticContextKind::CurrentModule is not correct.
+        // Use 'None' (and fix prioritization) or introduce a new context.
+        SemanticContextKind::CurrentModule, {});
+    Builder.addFlair(CodeCompletionFlairBit::ExpressionSpecific);
     Builder.addTextChunk(Flag);
   }
 }

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -226,9 +226,10 @@ static bool readCachedModule(llvm::MemoryBuffer *in,
     }
 
     CodeCompletionResult *result = nullptr;
+    CodeCompletionFlair Flair;
     if (kind == CodeCompletionResult::Declaration) {
       result = new (*V.Sink.Allocator) CodeCompletionResult(
-          context, /*IsArgumentLabels=*/false, numBytesToErase, string,
+          context, Flair, /*IsArgumentLabels=*/false, numBytesToErase, string,
           declKind, isSystem, moduleName, notRecommended, briefDocComment,
           copyArray(*V.Sink.Allocator, ArrayRef<StringRef>(assocUSRs)),
           copyArray(*V.Sink.Allocator,
@@ -236,7 +237,7 @@ static bool readCachedModule(llvm::MemoryBuffer *in,
           CodeCompletionResult::Unknown, opKind);
     } else {
       result = new (*V.Sink.Allocator)
-          CodeCompletionResult(kind, context, /*IsArgumentLabels=*/false,
+          CodeCompletionResult(kind, context, Flair, /*IsArgumentLabels=*/false,
                                numBytesToErase, string,
                                CodeCompletionResult::NotApplicable, opKind);
     }

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -226,10 +226,9 @@ static bool readCachedModule(llvm::MemoryBuffer *in,
     }
 
     CodeCompletionResult *result = nullptr;
-    CodeCompletionFlair Flair;
     if (kind == CodeCompletionResult::Declaration) {
       result = new (*V.Sink.Allocator) CodeCompletionResult(
-          context, Flair, /*IsArgumentLabels=*/false, numBytesToErase, string,
+          context, CodeCompletionFlair(), numBytesToErase, string,
           declKind, isSystem, moduleName, notRecommended, briefDocComment,
           copyArray(*V.Sink.Allocator, ArrayRef<StringRef>(assocUSRs)),
           copyArray(*V.Sink.Allocator,
@@ -237,7 +236,7 @@ static bool readCachedModule(llvm::MemoryBuffer *in,
           CodeCompletionResult::Unknown, opKind);
     } else {
       result = new (*V.Sink.Allocator)
-          CodeCompletionResult(kind, context, Flair, /*IsArgumentLabels=*/false,
+          CodeCompletionResult(kind, context,  CodeCompletionFlair(),
                                numBytesToErase, string,
                                CodeCompletionResult::NotApplicable, opKind);
     }
@@ -342,7 +341,7 @@ static void writeCachedModule(llvm::raw_ostream &out,
   {
     endian::Writer LE(results, little);
     for (CodeCompletionResult *R : V.Sink.Results) {
-      assert(!R->isArgumentLabels() && "Argument labels should not be cached");
+      assert(!R->getFlair().toRaw() && "Any flairs should not be cached");
       assert(R->getNotRecommendedReason() !=
              CodeCompletionResult::NotRecommendedReason::InvalidAsyncContext &&
              "InvalidAsyncContext is decl context specific, cannot be cached");

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -76,6 +76,7 @@ class CodeCompletionResultBuilder {
   CodeCompletionResultSink &Sink;
   CodeCompletionResult::ResultKind Kind;
   SemanticContextKind SemanticContext;
+  CodeCompletionFlair Flair;
   unsigned NumBytesToErase = 0;
   const Decl *AssociatedDecl = nullptr;
   Optional<CodeCompletionLiteralKind> LiteralKind;
@@ -153,6 +154,10 @@ public:
 
   void setSemanticContext(SemanticContextKind Kind) {
     SemanticContext = Kind;
+  }
+
+  void addFlair(CodeCompletionFlair Options) {
+    Flair |= Options;
   }
 
   void setIsArgumentLabels(bool Flag = true) {

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -88,7 +88,6 @@ class CodeCompletionResultBuilder {
   ExpectedTypeContext declTypeContext;
   CodeCompletionResult::ExpectedTypeRelation ExpectedTypeRelation =
       CodeCompletionResult::Unknown;
-  bool IsArgumentLabels = false;
   bool Cancelled = false;
   ArrayRef<std::pair<StringRef, StringRef>> CommentWords;
   CodeCompletionResult::NotRecommendedReason NotRecReason =
@@ -158,10 +157,6 @@ public:
 
   void addFlair(CodeCompletionFlair Options) {
     Flair |= Options;
-  }
-
-  void setIsArgumentLabels(bool Flag = true) {
-    IsArgumentLabels = Flag;
   }
 
   void

--- a/test/IDE/complete_after_super.swift
+++ b/test/IDE/complete_after_super.swift
@@ -145,13 +145,13 @@ class SuperDerivedA : SuperBaseA {
   init (a: Float) {
     super.init#^CONSTRUCTOR_SUPER_INIT_1^#
 // CONSTRUCTOR_SUPER_INIT_1: Begin completions
-// CONSTRUCTOR_SUPER_INIT_1-DAG: Decl[Constructor]/CurrNominal: ()[#SuperBaseA#]; name=()
+// CONSTRUCTOR_SUPER_INIT_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ()[#SuperBaseA#]; name=()
 // CONSTRUCTOR_SUPER_INIT_1: End completions
   }
   init (b: Float) {
     super.init(#^CONSTRUCTOR_SUPER_INIT_PAREN_1^#
 // CONSTRUCTOR_SUPER_INIT_PAREN_1: Begin completions, 1 items
-// CONSTRUCTOR_SUPER_INIT_PAREN_1: Decl[Constructor]/CurrNominal: ['('][')'][#SuperBaseA#]; name=
+// CONSTRUCTOR_SUPER_INIT_PAREN_1: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['('][')'][#SuperBaseA#]; name=
 // CONSTRUCTOR_SUPER_INIT_PAREN_1: End completions
   }
 

--- a/test/IDE/complete_after_super.swift
+++ b/test/IDE/complete_after_super.swift
@@ -123,7 +123,7 @@ class SuperDerivedA : SuperBaseA {
   init() {
     super#^CONSTRUCTOR_SUPER_NO_DOT_1?check=COMMON_BASE_A_NO_DOT;check=CONSTRUCTOR_SUPER_NO_DOT_1^#
 // CONSTRUCTOR_SUPER_NO_DOT_1: Begin completions, 8 items
-// CONSTRUCTOR_SUPER_NO_DOT_1-DAG: Decl[Constructor]/ExprSpecific: .init()[#SuperBaseA#]{{; name=.+$}}
+// CONSTRUCTOR_SUPER_NO_DOT_1-DAG: Decl[Constructor]/CurrNominal/Flair[SuperChain]: .init()[#SuperBaseA#]{{; name=.+$}}
 // CONSTRUCTOR_SUPER_NO_DOT_1: End completions
   }
 
@@ -291,7 +291,7 @@ class SuperDerivedB : SuperBaseB {
   init() {
     super#^CONSTRUCTOR_SUPER_NO_DOT_2?check=COMMON_BASE_B_NO_DOT;check=CONSTRUCTOR_SUPER_NO_DOT_2^#
 // CONSTRUCTOR_SUPER_NO_DOT_2: Begin completions, 10 items
-// CONSTRUCTOR_SUPER_NO_DOT_2-DAG: Decl[Constructor]/ExprSpecific: .init()[#SuperBaseB#]{{; name=.+$}}
+// CONSTRUCTOR_SUPER_NO_DOT_2-DAG: Decl[Constructor]/CurrNominal/Flair[SuperChain]: .init()[#SuperBaseB#]{{; name=.+$}}
 // CONSTRUCTOR_SUPER_NO_DOT_2-DAG: Decl[Constructor]/CurrNominal: .init({#a: Double#})[#SuperBaseB#]{{; name=.+$}}
 // CONSTRUCTOR_SUPER_NO_DOT_2-DAG: Decl[Constructor]/CurrNominal: .init({#int: Int#})[#SuperBaseB#]{{; name=.+$}}
 // CONSTRUCTOR_SUPER_NO_DOT_2: End completions
@@ -302,7 +302,7 @@ class SuperDerivedB : SuperBaseB {
 // CONSTRUCTOR_SUPER_DOT_2: Begin completions, 9 items
 // CONSTRUCTOR_SUPER_DOT_2-DAG: Decl[Constructor]/CurrNominal: init()[#SuperBaseB#]{{; name=.+$}}
 // CONSTRUCTOR_SUPER_DOT_2-DAG: Decl[Constructor]/CurrNominal: init({#a: Double#})[#SuperBaseB#]{{; name=.+$}}
-// CONSTRUCTOR_SUPER_DOT_2-DAG: Decl[Constructor]/ExprSpecific: init({#int: Int#})[#SuperBaseB#]{{; name=.+$}}
+// CONSTRUCTOR_SUPER_DOT_2-DAG: Decl[Constructor]/CurrNominal/Flair[SuperChain]: init({#int: Int#})[#SuperBaseB#]{{; name=.+$}}
 // CONSTRUCTOR_SUPER_DOT_2: End completions
   }
 
@@ -365,7 +365,7 @@ class SemanticContextDerived1 : SemanticContextBase1 {
     super.#^SEMANTIC_CONTEXT_OVERRIDDEN_DECL_2?check=SEMANTIC_CONTEXT_OVERRIDDEN_DECL_2;check=NO_SUPER_DECLS^#
 // SEMANTIC_CONTEXT_OVERRIDDEN_DECL_2: Begin completions
 // SEMANTIC_CONTEXT_OVERRIDDEN_DECL_2-NEXT: Decl[Constructor]/CurrNominal:    init()[#SemanticContextBase1#]{{; name=.+$}}
-// SEMANTIC_CONTEXT_OVERRIDDEN_DECL_2-NEXT: Decl[Constructor]/ExprSpecific:    init({#a: Int#})[#SemanticContextBase1#]{{; name=.+$}}
+// SEMANTIC_CONTEXT_OVERRIDDEN_DECL_2-NEXT: Decl[Constructor]/CurrNominal/Flair[SuperChain]:    init({#a: Int#})[#SemanticContextBase1#]{{; name=.+$}}
 // SEMANTIC_CONTEXT_OVERRIDDEN_DECL_2-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc1()[#Void#]{{; name=.+$}}
 // SEMANTIC_CONTEXT_OVERRIDDEN_DECL_2-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc1({#(a): Int#})[#Void#]{{; name=.+$}}
 // SEMANTIC_CONTEXT_OVERRIDDEN_DECL_2-NEXT: End completions
@@ -379,7 +379,7 @@ class SemanticContextDerived1 : SemanticContextBase1 {
 
     super.#^SEMANTIC_CONTEXT_OVERRIDDEN_DECL_4?check=SEMANTIC_CONTEXT_OVERRIDDEN_DECL_4;check=NO_SUPER_DECLS;check=NO_CONSTRUCTORS^#
 // SEMANTIC_CONTEXT_OVERRIDDEN_DECL_4: Begin completions
-// SEMANTIC_CONTEXT_OVERRIDDEN_DECL_4-NEXT: Decl[InstanceMethod]/ExprSpecific: instanceFunc1()[#Void#]{{; name=.+$}}
+// SEMANTIC_CONTEXT_OVERRIDDEN_DECL_4-NEXT: Decl[InstanceMethod]/CurrNominal/Flair[SuperChain]: instanceFunc1()[#Void#]{{; name=.+$}}
 // SEMANTIC_CONTEXT_OVERRIDDEN_DECL_4-NEXT: Decl[InstanceMethod]/CurrNominal:  instanceFunc1({#(a): Int#})[#Void#]{{; name=.+$}}
 // SEMANTIC_CONTEXT_OVERRIDDEN_DECL_4-NEXT: End completions
   }
@@ -387,7 +387,7 @@ class SemanticContextDerived1 : SemanticContextBase1 {
     super.#^SEMANTIC_CONTEXT_OVERRIDDEN_DECL_5?check=SEMANTIC_CONTEXT_OVERRIDDEN_DECL_5;check=NO_SUPER_DECLS;check=NO_CONSTRUCTORS^#
 // SEMANTIC_CONTEXT_OVERRIDDEN_DECL_5: Begin completions
 // SEMANTIC_CONTEXT_OVERRIDDEN_DECL_5-NEXT: Decl[InstanceMethod]/CurrNominal:  instanceFunc1()[#Void#]{{; name=.+$}}
-// SEMANTIC_CONTEXT_OVERRIDDEN_DECL_5-NEXT: Decl[InstanceMethod]/ExprSpecific: instanceFunc1({#(a): Int#})[#Void#]{{; name=.+$}}
+// SEMANTIC_CONTEXT_OVERRIDDEN_DECL_5-NEXT: Decl[InstanceMethod]/CurrNominal/Flair[SuperChain]: instanceFunc1({#(a): Int#})[#Void#]{{; name=.+$}}
 // SEMANTIC_CONTEXT_OVERRIDDEN_DECL_5-NEXT: End completions
   }
 }
@@ -417,6 +417,37 @@ class Closures : SuperBaseA {
   }
 }
 
+class SuperBaseC {
+  init(x: Int) {}
+  func foo() {}
+  func bar() {}
+}
+class SuperDerivedC1: SuperBaseC {}
+class SuperDerivedC2: SuperDerivedC1 {
+  init(x: Int) {
+    super.#^OVERRIDE_2HOP_INIT1^#
+// OVERRIDE_2HOP_INIT1: Begin completions, 3 items
+// OVERRIDE_2HOP_INIT1-DAG: Decl[Constructor]/CurrNominal/Flair[SuperChain]: init({#x: Int#})[#SuperDerivedC1#];
+// OVERRIDE_2HOP_INIT1-DAG: Decl[InstanceMethod]/Super:         foo()[#Void#];
+// OVERRIDE_2HOP_INIT1-DAG: Decl[InstanceMethod]/Super:         bar()[#Void#];
+// OVERRIDE_2HOP_INIT1: End completions
+  }
+  init(y: Int) {
+    super.#^OVERRIDE_2HOP_INIT2^#
+// OVERRIDE_2HOP_INIT2: Begin completions, 3 items
+// OVERRIDE_2HOP_INIT2-DAG: Decl[Constructor]/CurrNominal:      init({#x: Int#})[#SuperDerivedC1#];
+// OVERRIDE_2HOP_INIT2-DAG: Decl[InstanceMethod]/Super:         foo()[#Void#];
+// OVERRIDE_2HOP_INIT2-DAG: Decl[InstanceMethod]/Super:         bar()[#Void#];
+// OVERRIDE_2HOP_INIT2: End completions
+  }
+  override func foo() {
+    super.#^OVERRIDE_2HOP_METHOD^#
+// OVERRIDE_2HOP_METHOD: Begin completions, 2 items
+// OVERRIDE_2HOP_METHOD-DAG: Decl[InstanceMethod]/Super/Flair[SuperChain]: foo()[#Void#];
+// OVERRIDE_2HOP_METHOD-DAG: Decl[InstanceMethod]/Super:         bar()[#Void#];
+// OVERRIDE_2HOP_METHOD: End completions
+  }
+}
 
 //===--- Code completion for 'super' keyword itself.
 

--- a/test/IDE/complete_ambiguous.swift
+++ b/test/IDE/complete_ambiguous.swift
@@ -286,32 +286,32 @@ func testMissingArgs() {
   trailing(x: 2) { .#^MISSINGARG_TRAILING^# }
 
   // MISSINGARG_INLINE: Begin completions, 14 items
-  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: foo[#Foo#]; name=foo
+  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: foo[#Foo#]; name=foo
   // MISSINGARG_INLINE-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Foo#})[#(into: inout Hasher) -> Void#]; name=hash(self: Foo)
-  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: bar[#Bar#]; name=bar
+  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bar[#Bar#]; name=bar
   // MISSINGARG_INLINE-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Bar#})[#(into: inout Hasher) -> Void#]; name=hash(self: Bar)
-  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: bop[#Bop#]; name=bop
+  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bop[#Bop#]; name=bop
   // MISSINGARG_INLINE-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Bop#})[#(into: inout Hasher) -> Void#]; name=hash(self: Bop)
-  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: bix[#Bix#]; name=bix
+  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bix[#Bix#]; name=bix
   // MISSINGARG_INLINE-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Bix#})[#(into: inout Hasher) -> Void#]; name=hash(self: Bix)
-  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: boy[#Boy#]; name=boy
+  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: boy[#Boy#]; name=boy
   // MISSINGARG_INLINE-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Boy#})[#(into: inout Hasher) -> Void#]; name=hash(self: Boy)
-  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: blu[#Blu#]; name=blu
+  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: blu[#Blu#]; name=blu
   // MISSINGARG_INLINE-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Blu#})[#(into: inout Hasher) -> Void#]; name=hash(self: Blu)
-  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: baz[#Baz#]; name=baz
+  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: baz[#Baz#]; name=baz
   // MISSINGARG_INLINE-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Baz#})[#(into: inout Hasher) -> Void#]; name=hash(self: Baz)
   // MISSINGARG_INLINE: End completions
 
   // MISSINGARG_TRAILING: Begin completions, 10 items
-  // MISSINGARG_TRAILING-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: foo[#Foo#]; name=foo
+  // MISSINGARG_TRAILING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: foo[#Foo#]; name=foo
   // MISSINGARG_TRAILING-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Foo#})[#(into: inout Hasher) -> Void#]; name=hash(self: Foo)
-  // MISSINGARG_TRAILING-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: bar[#Bar#]; name=bar
+  // MISSINGARG_TRAILING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bar[#Bar#]; name=bar
   // MISSINGARG_TRAILING-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Bar#})[#(into: inout Hasher) -> Void#]; name=hash(self: Bar)
-  // MISSINGARG_TRAILING-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: bop[#Bop#]; name=bop
+  // MISSINGARG_TRAILING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bop[#Bop#]; name=bop
   // MISSINGARG_TRAILING-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Bop#})[#(into: inout Hasher) -> Void#]; name=hash(self: Bop)
-  // MISSINGARG_TRAILING-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: bix[#Bix#]; name=bix
+  // MISSINGARG_TRAILING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bix[#Bix#]; name=bix
   // MISSINGARG_TRAILING-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Bix#})[#(into: inout Hasher) -> Void#]; name=hash(self: Bix)
-  // MISSINGARG_TRAILING-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: boy[#Boy#]; name=boy
+  // MISSINGARG_TRAILING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: boy[#Boy#]; name=boy
   // MISSINGARG_TRAILING-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Boy#})[#(into: inout Hasher) -> Void#]; name=hash(self: Boy)
   // MISSINGARG_TRAILING: End completions
 }
@@ -453,7 +453,7 @@ func testBestSolutionFilter() {
 }
 
 // BEST_SOLUTION_FILTER: Begin completions
-// BEST_SOLUTION_FILTER-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]: enumElem[#Enum123#]{{; name=.+$}}
+// BEST_SOLUTION_FILTER-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: enumElem[#Enum123#]{{; name=.+$}}
 // BEST_SOLUTION_FILTER-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Enum123#})[#(into: inout Hasher) -> Void#]{{; name=.+$}}
 // BEST_SOLUTION_FILTER-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Identical]: nil[#Enum123?#]{{; name=.+$}}
 // BEST_SOLUTION_FILTER-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: none[#Optional<Enum123>#]{{; name=.+$}}

--- a/test/IDE/complete_annotation.swift
+++ b/test/IDE/complete_annotation.swift
@@ -31,8 +31,8 @@ func testGlobal() {
 }
 // GLOBAL_EXPR: Begin completions
 // GLOBAL_EXPR-DAG: Decl[Struct]/CurrModule:            <name>MyStruct</name>; typename=<typeid.user>MyStruct</typeid.user>;
-// GLOBAL_EXPR-DAG: Keyword[class]/None:                <keyword>class</keyword>; typename=;
-// GLOBAL_EXPR-DAG: Keyword[enum]/None:                 <keyword>enum</keyword>; typename=;
+// GLOBAL_EXPR-DAG: Keyword[class]/None/Flair[RareKeyword]: <keyword>class</keyword>; typename=;
+// GLOBAL_EXPR-DAG: Keyword[enum]/None/Flair[RareKeyword]: <keyword>enum</keyword>; typename=;
 // GLOBAL_EXPR-DAG: Keyword[if]/None:                   <keyword>if</keyword>; typename=;
 // GLOBAL_EXPR-DAG: Keyword[guard]/None:                <keyword>guard</keyword>; typename=;
 // GLOBAL_EXPR-DAG: Keyword[try]/None:                  <keyword>try</keyword>; typename=;

--- a/test/IDE/complete_annotation.swift
+++ b/test/IDE/complete_annotation.swift
@@ -99,12 +99,12 @@ func testImplicitMember() -> MyStruct {
 }
 // EXPR_IMPLICITMEMBER: Begin completions, 7 items
 // EXPR_IMPLICITMEMBER-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: <name>init</name>(<callarg><callarg.label>x</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>); typename=<typeid.user>MyStruct</typeid.user>;
-// EXPR_IMPLICITMEMBER-DAG: Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: <name>instance</name>; typename=<typeid.user>MyStruct</typeid.user>;
+// EXPR_IMPLICITMEMBER-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: <name>instance</name>; typename=<typeid.user>MyStruct</typeid.user>;
 // EXPR_IMPLICITMEMBER-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: <name>labelNameParamName</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>self</callarg.param>: <callarg.type><typeid.user>MyStruct</typeid.user></callarg.type></callarg>); typename=(label: (<keyword>inout</keyword> <typeid.sys>Int</typeid.sys>) <keyword>throws</keyword> -&gt; <typeid.user>MyStruct</typeid.user>) -&gt; <typeid.sys>Void</typeid.sys>;
 // EXPR_IMPLICITMEMBER-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: <name>labelName</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>self</callarg.param>: <callarg.type><typeid.user>MyStruct</typeid.user></callarg.type></callarg>); typename=(label: (<attribute>@autoclosure</attribute> () -&gt; <typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Void</typeid.sys>;
 // EXPR_IMPLICITMEMBER-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: <name>sameName</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>self</callarg.param>: <callarg.type><typeid.user>MyStruct</typeid.user></callarg.type></callarg>); typename=(label: <keyword>inout</keyword> <typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Void</typeid.sys>;
 // EXPR_IMPLICITMEMBER-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: <name>paramName</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>self</callarg.param>: <callarg.type><typeid.user>MyStruct</typeid.user></callarg.type></callarg>); typename=(<typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Void</typeid.sys>;
-// EXPR_IMPLICITMEMBER-DAG: Decl[StaticMethod]/ExprSpecific/TypeRelation[Identical]: <name>create</name>(<callarg><callarg.label>x</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>); typename=<typeid.user>MyStruct</typeid.user>;
+// EXPR_IMPLICITMEMBER-DAG: Decl[StaticMethod]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: <name>create</name>(<callarg><callarg.label>x</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>); typename=<typeid.user>MyStruct</typeid.user>;
 // EXPR_IMPLICITMEMBER: End completions
 
 func testArgument() -> MyStruct {
@@ -112,7 +112,7 @@ func testArgument() -> MyStruct {
   foo(x: 1, #^CALLARG^#
 }
 // CALLARG: Begin completions, 1 items
-// CALLARG-DAG: Pattern/ExprSpecific:               <callarg><callarg.label>y</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>; typename=<typeid.sys>Int</typeid.sys>
+// CALLARG-DAG: Pattern/Local/Flair[ExprSpecific]:               <callarg><callarg.label>y</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>; typename=<typeid.sys>Int</typeid.sys>
 // CALLARG: End completions
 
 struct TestArchetypeAnnotations<T> {

--- a/test/IDE/complete_annotation.swift
+++ b/test/IDE/complete_annotation.swift
@@ -112,7 +112,7 @@ func testArgument() -> MyStruct {
   foo(x: 1, #^CALLARG^#
 }
 // CALLARG: Begin completions, 1 items
-// CALLARG-DAG: Pattern/Local/Flair[ExprSpecific]:               <callarg><callarg.label>y</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>; typename=<typeid.sys>Int</typeid.sys>
+// CALLARG-DAG: Pattern/Local/Flair[ArgLabels]:               <callarg><callarg.label>y</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>; typename=<typeid.sys>Int</typeid.sys>
 // CALLARG: End completions
 
 struct TestArchetypeAnnotations<T> {

--- a/test/IDE/complete_assignment.swift
+++ b/test/IDE/complete_assignment.swift
@@ -128,8 +128,8 @@ func f2() {
 	}
 
 // ASSIGN_5: Begin completions, 3 items
-// ASSIGN_5-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     case2[#D1#]; name=case2
-// ASSIGN_5-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     case1[#D1#]; name=case1
+// ASSIGN_5-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     case2[#D1#]; name=case2
+// ASSIGN_5-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     case1[#D1#]; name=case1
 // ASSIGN_5-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]:     hash({#(self): D1#})[#(into: inout Hasher) -> Void#]; name=hash(self: D1)
 
 	func f6() {
@@ -137,8 +137,8 @@ func f2() {
 	  d = .#^ASSIGN_6^#
 	}
 // ASSIGN_6: Begin completions, 3 items
-// ASSIGN_6-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     case3[#D2#]; name=case3
-// ASSIGN_6-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     case4[#D2#]; name=case4
+// ASSIGN_6-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     case3[#D2#]; name=case3
+// ASSIGN_6-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     case4[#D2#]; name=case4
 // ASSIGN_6-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]:     hash({#(self): D2#})[#(into: inout Hasher) -> Void#]; name=hash(self: D2)
 
   func f7 (C : C2) {

--- a/test/IDE/complete_asyncannotation.swift
+++ b/test/IDE/complete_asyncannotation.swift
@@ -19,19 +19,19 @@ struct HasAsyncMembers {
 func testGlobalFuncAsync() async {
   globalFuncAsync#^CHECK_globalFuncAsync^#
 // CHECK_globalFuncAsync: Begin completions
-// CHECK_globalFuncAsync-DAG: Decl[FreeFunction]/CurrModule: ()[' async'][#Void#]; name=() async
+// CHECK_globalFuncAsync-DAG: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]: ()[' async'][#Void#]; name=() async
 // CHECK_globalFuncAsync: End completions
 }
 func testGlobalFuncAsyncThrows() async {
   globalFuncAsyncThrows#^CHECK_globalFuncAsyncThrows^#
 // CHECK_globalFuncAsyncThrows: Begin completions
-// CHECK_globalFuncAsyncThrows-DAG: Decl[FreeFunction]/CurrModule: ()[' async'][' throws'][#Void#]; name=() async throws
+// CHECK_globalFuncAsyncThrows-DAG: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]: ()[' async'][' throws'][#Void#]; name=() async throws
 // CHECK_globalFuncAsyncThrows: End completions
 }
 func testGlobalFuncAsyncRethrows() async {
   globalFuncAsyncRethrows#^CHECK_globalFuncAsyncRethrows^#
 // CHECK_globalFuncAsyncRethrows: Begin completions
-// CHECK_globalFuncAsyncRethrows-DAG: Decl[FreeFunction]/CurrModule: ({#(x): () async throws -> ()##() async throws -> ()#})[' async'][' rethrows'][#Void#]; name=(x: () async throws -> ()) async rethrows
+// CHECK_globalFuncAsyncRethrows-DAG: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]: ({#(x): () async throws -> ()##() async throws -> ()#})[' async'][' rethrows'][#Void#]; name=(x: () async throws -> ()) async rethrows
 // CHECK_globalFuncAsyncRethrows: End completions
 }
 func testAsyncMembers(_ x: HasAsyncMembers) async {
@@ -46,28 +46,28 @@ func testAsyncMembers(_ x: HasAsyncMembers) async {
 func testMemberAsync(_ x: HasAsyncMembers) async {
   x.memberAsync#^CHECK_memberAsync^#
 // CHECK_memberAsync: Begin completions
-// CHECK_memberAsync-DAG: Decl[InstanceMethod]/CurrNominal: ()[' async'][#Void#]; name=() async
+// CHECK_memberAsync-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ()[' async'][#Void#]; name=() async
 // CHECK_memberAsync: End completions
 }
 func testMemberAsyncThrows(_ x: HasAsyncMembers) async {
   x.memberAsyncThrows#^CHECK_memberAsyncThrows^#
 // CHECK_memberAsyncThrows: Begin completions
-// CHECK_memberAsyncThrows-DAG: Decl[InstanceMethod]/CurrNominal: ()[' async'][' throws'][#Void#]; name=() async throws
+// CHECK_memberAsyncThrows-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ()[' async'][' throws'][#Void#]; name=() async throws
 // CHECK_memberAsyncThrows: End completions
 }
 func testMemberAsyncRethrows(_ x: HasAsyncMembers) async {
   x.memberAsyncRethrows#^CHECK_memberAsyncRethrows^#
 // CHECK_memberAsyncRethrows: Begin completions
-// CHECK_memberAsyncRethrows-DAG: Decl[InstanceMethod]/CurrNominal: ({#(x): () async throws -> ()##() async throws -> ()#})[' async'][' rethrows'][#Void#]; name=(x: () async throws -> ()) async rethrows
+// CHECK_memberAsyncRethrows-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ({#(x): () async throws -> ()##() async throws -> ()#})[' async'][' rethrows'][#Void#]; name=(x: () async throws -> ()) async rethrows
 // CHECK_memberAsyncRethrows: End completions
 }
 
 func testAsyncIntiializers() async {
   HasAsyncMembers(#^CHECK_initializers^#
 // CHECK_initializers: Begin completions
-// CHECK_initializers-DAG: Decl[Constructor]/CurrNominal:      ['('][')'][' async'][#HasAsyncMembers#]; name= async
-// CHECK_initializers-DAG: Decl[Constructor]/CurrNominal:      ['(']{#withAsync: Int#}[')'][' async'][#HasAsyncMembers#]; name=withAsync: Int async
-// CHECK_initializers-DAG: Decl[Constructor]/CurrNominal:      ['(']{#withAsyncThrows: Int#}[')'][' async'][' throws'][#HasAsyncMembers#]; name=withAsyncThrows: Int async throws
-// CHECK_initializers-DAG: Decl[Constructor]/CurrNominal:      ['(']{#withAsyncRethrows: () async throws -> Void##() async throws -> Void#}[')'][' async'][' rethrows'][#HasAsyncMembers#]; name=withAsyncRethrows: () async throws -> Void async rethrows
+// CHECK_initializers-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['('][')'][' async'][#HasAsyncMembers#]; name= async
+// CHECK_initializers-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['(']{#withAsync: Int#}[')'][' async'][#HasAsyncMembers#]; name=withAsync: Int async
+// CHECK_initializers-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['(']{#withAsyncThrows: Int#}[')'][' async'][' throws'][#HasAsyncMembers#]; name=withAsyncThrows: Int async throws
+// CHECK_initializers-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['(']{#withAsyncRethrows: () async throws -> Void##() async throws -> Void#}[')'][' async'][' rethrows'][#HasAsyncMembers#]; name=withAsyncRethrows: () async throws -> Void async rethrows
 // CHECK_initializers: End completions
 }

--- a/test/IDE/complete_at_eof_in_call_1.swift
+++ b/test/IDE/complete_at_eof_in_call_1.swift
@@ -4,7 +4,7 @@
 // Don't add any tests at the end of the file!
 //
 // A: Begin completions
-// A-DAG: Decl[FreeFunction]/CurrModule:               ['(']{#(x): Int#}[')'][#Void#]{{; name=.+$}}
+// A-DAG: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]: ['(']{#(x): Int#}[')'][#Void#]{{; name=.+$}}
 // A: End completions
 func f(_ x: Int) {}
 f(#^A^#

--- a/test/IDE/complete_at_eof_in_call_no_newline_1.swift
+++ b/test/IDE/complete_at_eof_in_call_no_newline_1.swift
@@ -4,7 +4,7 @@
 // Don't add any tests at the end of the file!
 //
 // A: Begin completions
-// A-DAG: Decl[FreeFunction]/CurrModule:               ['(']{#(x): Int#}[')'][#Void#]{{; name=.+$}}
+// A-DAG: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]: ['(']{#(x): Int#}[')'][#Void#]{{; name=.+$}}
 // A: End completions
 func f(_ x: Int) {}
 f(#^A^#

--- a/test/IDE/complete_at_top_level.swift
+++ b/test/IDE/complete_at_top_level.swift
@@ -125,9 +125,9 @@ func resyncParser7() {}
 var topLevelVar2 = FooStruct#^TOP_LEVEL_VAR_INIT_2^#
 // TOP_LEVEL_VAR_INIT_2: Begin completions
 // TOP_LEVEL_VAR_INIT_2-NEXT: Decl[InstanceMethod]/CurrNominal: .instanceFunc({#(self): FooStruct#})[#(Int) -> Void#]{{; name=.+$}}
-// TOP_LEVEL_VAR_INIT_2-NEXT: Decl[Constructor]/CurrNominal: ()[#FooStruct#]{{; name=.+$}}
-// TOP_LEVEL_VAR_INIT_2-NEXT: Decl[Constructor]/CurrNominal: ({#instanceVar: Int#})[#FooStruct#]{{; name=.+$}}
-// TOP_LEVEL_VAR_INIT_2-NEXT: Decl[Constructor]/CurrNominal: ()[#FooStruct#]{{; name=.+$}}
+// TOP_LEVEL_VAR_INIT_2-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ()[#FooStruct#]{{; name=.+$}}
+// TOP_LEVEL_VAR_INIT_2-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ({#instanceVar: Int#})[#FooStruct#]{{; name=.+$}}
+// TOP_LEVEL_VAR_INIT_2-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ()[#FooStruct#]{{; name=.+$}}
 // TOP_LEVEL_VAR_INIT_2-NEXT: Keyword[self]/CurrNominal: .self[#FooStruct.Type#]; name=self
 // TOP_LEVEL_VAR_INIT_2-NEXT: Keyword/CurrNominal:       .Type[#FooStruct.Type#]; name=Type
 // TOP_LEVEL_VAR_INIT_2-NEXT: End completions
@@ -327,7 +327,7 @@ func resyncParserB14() {}
 var stringInterp = "\(#^STRING_INTERP_3?check=STRING_INTERP^#)"
 _ = "" + "\(#^STRING_INTERP_4?check=STRING_INTERP^#)" + ""
 // STRING_INTERP: Begin completions
-// STRING_INTERP-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: ['(']{#(value): T#}[')'][#Void#];
+// STRING_INTERP-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]/IsSystem: ['(']{#(value): T#}[')'][#Void#];
 // STRING_INTERP-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: FooStruct[#FooStruct#]; name=FooStruct
 // STRING_INTERP-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Invalid]: fooFunc1()[#Void#];
 // STRING_INTERP-DAG: Decl[FreeFunction]/CurrModule: optStr()[#String?#];

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -76,18 +76,18 @@ class C1 {
 }
 
 // ARG-NAME1: Begin completions, 2 items
-// ARG-NAME1-DAG: Pattern/ExprSpecific: {#b1: Int?#}[#Int?#];
-// ARG-NAME1-DAG: Pattern/ExprSpecific: {#b2: Int?#}[#Int?#];
+// ARG-NAME1-DAG: Pattern/Local/Flair[ExprSpecific]: {#b1: Int?#}[#Int?#];
+// ARG-NAME1-DAG: Pattern/Local/Flair[ExprSpecific]: {#b2: Int?#}[#Int?#];
 
 // ARG-NAME2: Begin completions, 1 items
-// ARG-NAME2-DAG: Pattern/ExprSpecific: {#b: Int#}[#Int#];
+// ARG-NAME2-DAG: Pattern/Local/Flair[ExprSpecific]: {#b: Int#}[#Int#];
 
 // ARG-NAME3: Begin completions, 1 items
-// ARG-NAME3-DAG: Pattern/ExprSpecific: {#b: String?#}[#String?#];
+// ARG-NAME3-DAG: Pattern/Local/Flair[ExprSpecific]: {#b: String?#}[#String?#];
 
 // ARG-NAME4: Begin completions, 2 items
-// ARG-NAME4-DAG: Pattern/ExprSpecific: {#b1: String#}[#String#];
-// ARG-NAME4-DAG: Pattern/ExprSpecific: {#b2: String#}[#String#];
+// ARG-NAME4-DAG: Pattern/Local/Flair[ExprSpecific]: {#b1: String#}[#String#];
+// ARG-NAME4-DAG: Pattern/Local/Flair[ExprSpecific]: {#b2: String#}[#String#];
 // ARG-NAME4: End completions
 
 // EXPECT_OINT: Begin completions
@@ -269,7 +269,7 @@ extension C3 {
 // HASERROR2: End completions
 
 // HASERROR3: Begin completions
-// HASERROR3-DAG: Pattern/ExprSpecific: {#b1: <<error type>>#}[#<<error type>>#];
+// HASERROR3-DAG: Pattern/Local/Flair[ExprSpecific]: {#b1: <<error type>>#}[#<<error type>>#];
 // HASERROR3: End completions
 
 // HASERROR4: Begin completions
@@ -503,9 +503,9 @@ func testTupleShuffle() {
 // SHUFFLE_2-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: s2[#String#]; name=s2
 
 // SHUFFLE_3: Begin completions, 4 items
-// SHUFFLE_3-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     foo[#SimpleEnum#]; name=foo
-// SHUFFLE_3-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     bar[#SimpleEnum#]; name=bar
-// SHUFFLE_3-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     baz[#SimpleEnum#]; name=baz
+// SHUFFLE_3-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     foo[#SimpleEnum#]; name=foo
+// SHUFFLE_3-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     bar[#SimpleEnum#]; name=bar
+// SHUFFLE_3-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     baz[#SimpleEnum#]; name=baz
 // SHUFFLE_3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]:     hash({#(self): SimpleEnum#})[#(into: inout Hasher) -> Void#]; name=hash(self: SimpleEnum)
 
 
@@ -530,12 +530,12 @@ func testSubscript(obj: HasSubscript, intValue: Int, strValue: String) {
 // SUBSCRIPT_1_DOT: Begin completions
 // SUBSCRIPT_1_DOT-NOT: i1
 // SUBSCRIPT_1_DOT-NOT: s1
-// SUBSCRIPT_1_DOT-DAG: Decl[StaticVar]/ExprSpecific/IsSystem/TypeRelation[Identical]: max[#Int#]; name=max
-// SUBSCRIPT_1_DOT-DAG: Decl[StaticVar]/ExprSpecific/IsSystem/TypeRelation[Identical]: min[#Int#]; name=min
+// SUBSCRIPT_1_DOT-DAG: Decl[StaticVar]/Super/Flair[ExprSpecific]/IsSystem/TypeRelation[Identical]: max[#Int#]; name=max
+// SUBSCRIPT_1_DOT-DAG: Decl[StaticVar]/Super/Flair[ExprSpecific]/IsSystem/TypeRelation[Identical]: min[#Int#]; name=min
 
   let _ = obj[42, #^SUBSCRIPT_2^#
 // SUBSCRIPT_2: Begin completions, 1 items
-// SUBSCRIPT_2-NEXT: Pattern/ExprSpecific: {#default: String#}[#String#];
+// SUBSCRIPT_2-NEXT: Pattern/Local/Flair[ExprSpecific]: {#default: String#}[#String#];
 
   let _ = obj[42, .#^SUBSCRIPT_2_DOT^#
 // Note: we still provide completions despite the missing label - there's a fixit to add it in later.
@@ -622,14 +622,14 @@ func testStaticMemberCall() {
 
   let _ = TestStaticMemberCall.create2(1, #^STATIC_METHOD_SECOND^#)
 // STATIC_METHOD_SECOND: Begin completions, 3 items
-// STATIC_METHOD_SECOND: Pattern/ExprSpecific: {#arg2: Int#}[#Int#];
-// STATIC_METHOD_SECOND: Pattern/ExprSpecific: {#arg3: Int#}[#Int#];
-// STATIC_METHOD_SECOND: Pattern/ExprSpecific: {#arg4: Int#}[#Int#];
+// STATIC_METHOD_SECOND: Pattern/Local/Flair[ExprSpecific]: {#arg2: Int#}[#Int#];
+// STATIC_METHOD_SECOND: Pattern/Local/Flair[ExprSpecific]: {#arg3: Int#}[#Int#];
+// STATIC_METHOD_SECOND: Pattern/Local/Flair[ExprSpecific]: {#arg4: Int#}[#Int#];
 // STATIC_METHOD_SECOND: End completions
 
   let _ = TestStaticMemberCall.create2(1, arg3: 2, #^STATIC_METHOD_SKIPPED^#)
 // STATIC_METHOD_SKIPPED: Begin completions, 1 item
-// STATIC_METHOD_SKIPPED: Pattern/ExprSpecific: {#arg4: Int#}[#Int#];
+// STATIC_METHOD_SKIPPED: Pattern/Local/Flair[ExprSpecific]: {#arg4: Int#}[#Int#];
 // STATIC_METHOD_SKIPPED: End completions
 
   let _ = TestStaticMemberCall.createOverloaded(#^STATIC_METHOD_OVERLOADED^#)
@@ -659,14 +659,14 @@ func testImplicitMember() {
 
   let _: TestStaticMemberCall = .create2(1, #^IMPLICIT_MEMBER_SECOND^#)
 // IMPLICIT_MEMBER_SECOND: Begin completions, 3 items
-// IMPLICIT_MEMBER_SECOND: Pattern/ExprSpecific: {#arg2: Int#}[#Int#];
-// IMPLICIT_MEMBER_SECOND: Pattern/ExprSpecific: {#arg3: Int#}[#Int#];
-// IMPLICIT_MEMBER_SECOND: Pattern/ExprSpecific: {#arg4: Int#}[#Int#];
+// IMPLICIT_MEMBER_SECOND: Pattern/Local/Flair[ExprSpecific]: {#arg2: Int#}[#Int#];
+// IMPLICIT_MEMBER_SECOND: Pattern/Local/Flair[ExprSpecific]: {#arg3: Int#}[#Int#];
+// IMPLICIT_MEMBER_SECOND: Pattern/Local/Flair[ExprSpecific]: {#arg4: Int#}[#Int#];
 // IMPLICIT_MEMBER_SECOND: End completions
 
   let _: TestStaticMemberCall = .create2(1, arg3: 2, #^IMPLICIT_MEMBER_SKIPPED^#)
 // IMPLICIT_MEMBER_SKIPPED: Begin completions, 1 item
-// IMPLICIT_MEMBER_SKIPPED: Pattern/ExprSpecific: {#arg4: Int#}[#Int#];
+// IMPLICIT_MEMBER_SKIPPED: Pattern/Local/Flair[ExprSpecific]: {#arg4: Int#}[#Int#];
 // IMPLICIT_MEMBER_SKIPPED: End completions
 
   let _: TestStaticMemberCall = .createOverloaded(#^IMPLICIT_MEMBER_OVERLOADED^#)
@@ -771,31 +771,31 @@ func testPamrameterFlags(_: Int, inoutArg: inout Int, autoclosureArg: @autoclosu
   var intVal = 1
   testPamrameterFlags(intVal, #^ARG_PARAMFLAG_INOUT^#)
 // ARG_PARAMFLAG_INOUT: Begin completions, 1 items
-// ARG_PARAMFLAG_INOUT-DAG: Pattern/ExprSpecific: {#inoutArg: &Int#}[#inout Int#]; name=inoutArg:
+// ARG_PARAMFLAG_INOUT-DAG: Pattern/Local/Flair[ExprSpecific]: {#inoutArg: &Int#}[#inout Int#]; name=inoutArg:
 // ARG_PARAMFLAG_INOUT: End completions
 
   testPamrameterFlags(intVal, inoutArg: &intVal, #^ARG_PARAMFLAG_AUTOCLOSURE^#)
 // ARG_PARAMFLAG_AUTOCLOSURE: Begin completions, 1 items
-// ARG_PARAMFLAG_AUTOCLOSURE-DAG: Pattern/ExprSpecific: {#autoclosureArg: Int#}[#Int#];
+// ARG_PARAMFLAG_AUTOCLOSURE-DAG: Pattern/Local/Flair[ExprSpecific]: {#autoclosureArg: Int#}[#Int#];
 // ARG_PARAMFLAG_AUTOCLOSURE: End completions
 
   testPamrameterFlags(intVal, inoutArg: &intVal, autoclosureArg: intVal, #^ARG_PARAMFLAG_IUO^#)
 // ARG_PARAMFLAG_IUO: Begin completions, 1 items
-// ARG_PARAMFLAG_IUO-DAG: Pattern/ExprSpecific: {#iuoArg: Int?#}[#Int?#];
+// ARG_PARAMFLAG_IUO-DAG: Pattern/Local/Flair[ExprSpecific]: {#iuoArg: Int?#}[#Int?#];
 // ARG_PARAMFLAG_IUO: End completions
 
   testPamrameterFlags(intVal, inoutArg: &intVal, autoclosureArg: intVal, iuoArg: intVal, #^ARG_PARAMFLAG_VARIADIC^#)
 // ARG_PARAMFLAG_VARIADIC: Begin completions, 1 items
-// ARG_PARAMFLAG_VARIADIC-DAG: Pattern/ExprSpecific: {#variadicArg: Int...#}[#Int#];
+// ARG_PARAMFLAG_VARIADIC-DAG: Pattern/Local/Flair[ExprSpecific]: {#variadicArg: Int...#}[#Int#];
 // ARG_PARAMFLAG_VARIADIC: End completions
 }
 
 func testTupleElement(arg: (SimpleEnum, SimpleEnum)) {
   testTupleElement(arg: (.foo, .#^TUPLEELEM_1^#))
 // TUPLEELEM_1: Begin completions, 4 items
-// TUPLEELEM_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     foo[#SimpleEnum#]; name=foo
-// TUPLEELEM_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     bar[#SimpleEnum#]; name=bar
-// TUPLEELEM_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     baz[#SimpleEnum#]; name=baz
+// TUPLEELEM_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     foo[#SimpleEnum#]; name=foo
+// TUPLEELEM_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     bar[#SimpleEnum#]; name=bar
+// TUPLEELEM_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     baz[#SimpleEnum#]; name=baz
 // TUPLEELEM_1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]:     hash({#(self): SimpleEnum#})[#(into: inout Hasher) -> Void#]; name=hash(self: SimpleEnum)
 // TUPLEELEM_1: End completions
   testTupleElement(arg: (.foo, .bar, .#^TUPLEELEM_2^#))
@@ -813,9 +813,9 @@ func testKeyPathThunkInBase() {
 
     foo(\.value).testFunc(.#^KEYPATH_THUNK_BASE^#)
 // KEYPATH_THUNK_BASE: Begin completions, 4 items
-// KEYPATH_THUNK_BASE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     foo[#SimpleEnum#]; name=foo
-// KEYPATH_THUNK_BASE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     bar[#SimpleEnum#]; name=bar
-// KEYPATH_THUNK_BASE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     baz[#SimpleEnum#]; name=baz
+// KEYPATH_THUNK_BASE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     foo[#SimpleEnum#]; name=foo
+// KEYPATH_THUNK_BASE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     bar[#SimpleEnum#]; name=bar
+// KEYPATH_THUNK_BASE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     baz[#SimpleEnum#]; name=baz
 // KEYPATH_THUNK_BASE-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]:     hash({#(self): SimpleEnum#})[#(into: inout Hasher) -> Void#]; name=hash(self: SimpleEnum)
 // KEYPATH_THUNK_BASE: End completions
 }
@@ -828,8 +828,8 @@ func testVariadic(_ arg: Any..., option1: Int = 0, option2: String = 1) {
 // VARIADIC_1: End completions
     testVariadic(1, #^VARIADIC_2^#)
 // VARIADIC_2: Begin completions
-// VARIADIC_2-DAG: Pattern/ExprSpecific:          {#option1: Int#}[#Int#];
-// VARIADIC_2-DAG: Pattern/ExprSpecific:          {#option2: String#}[#String#];
+// VARIADIC_2-DAG: Pattern/Local/Flair[ExprSpecific]:          {#option1: Int#}[#Int#];
+// VARIADIC_2-DAG: Pattern/Local/Flair[ExprSpecific]:          {#option2: String#}[#String#];
 // VARIADIC_2-DAG: Decl[GlobalVar]/CurrModule:    i1[#Int#];
 // VARIADIC_2: End completions
     testVariadic(1, 2, #^VARIADIC_3?check=VARIADIC_2^#)
@@ -842,7 +842,7 @@ func testLabelsInSelfDotInit() {
     convenience init() {
       self.init(a: 1, #^LABEL_IN_SELF_DOT_INIT^#)
 // LABEL_IN_SELF_DOT_INIT: Begin completions, 1 item
-// LABEL_IN_SELF_DOT_INIT-DAG: Pattern/ExprSpecific:               {#b: Int#}[#Int#]
+// LABEL_IN_SELF_DOT_INIT-DAG: Pattern/Local/Flair[ExprSpecific]:               {#b: Int#}[#Int#]
 // LABEL_IN_SELF_DOT_INIT: End completions
     }
   }
@@ -855,7 +855,7 @@ func testMissingRequiredParameter() {
   func test(c: C) {
     c.foo(y: 1, #^MISSING_REQUIRED_PARAM^#)
 // MISSING_REQUIRED_PARAM: Begin completions, 1 item
-// MISSING_REQUIRED_PARAM-DAG: Pattern/ExprSpecific:               {#z: Int#}[#Int#]
+// MISSING_REQUIRED_PARAM-DAG: Pattern/Local/Flair[ExprSpecific]:               {#z: Int#}[#Int#]
 // MISSING_REQUIRED_PARAM: End completions
   }
 }
@@ -867,7 +867,7 @@ func testAfterVariadic() {
   func test(c: C) {
     c.foo(x: 10, 20, 30, y: 40, #^NAMED_PARAMETER_WITH_LEADING_VARIADIC^#)
 // NAMED_PARAMETER_WITH_LEADING_VARIADIC: Begin completions, 1 item
-// NAMED_PARAMETER_WITH_LEADING_VARIADIC-DAG: Pattern/ExprSpecific:               {#z: Int#}[#Int#]
+// NAMED_PARAMETER_WITH_LEADING_VARIADIC-DAG: Pattern/Local/Flair[ExprSpecific]:               {#z: Int#}[#Int#]
 // NAMED_PARAMETER_WITH_LEADING_VARIADIC: End completions
   }
 }
@@ -921,17 +921,17 @@ func testCompleteLabelAfterVararg() {
   private func test(value: Rdar76355192) {
     value.test("test", xArg: #^COMPLETE_AFTER_VARARG^#)
     // COMPLETE_AFTER_VARARG: Begin completions
-    // COMPLETE_AFTER_VARARG-NOT: Pattern/ExprSpecific:               {#yArg: Foo...#}[#Foo#];
-    // COMPLETE_AFTER_VARARG-NOT: Pattern/ExprSpecific:               {#zArg: Foo...#}[#Foo#];
+    // COMPLETE_AFTER_VARARG-NOT: Pattern/Local/Flair[ExprSpecific]:               {#yArg: Foo...#}[#Foo#];
+    // COMPLETE_AFTER_VARARG-NOT: Pattern/Local/Flair[ExprSpecific]:               {#zArg: Foo...#}[#Foo#];
     // COMPLETE_AFTER_VARARG: End completions
     value.test("test", xArg: .bar, #^COMPLETE_AFTER_VARARG_WITH_PREV_PARAM^#)
     // COMPLETE_AFTER_VARARG_WITH_PREV_PARAM: Begin completions
-    // COMPLETE_AFTER_VARARG_WITH_PREV_PARAM-DAG: Pattern/ExprSpecific:               {#yArg: Foo...#}[#Foo#];
-    // COMPLETE_AFTER_VARARG_WITH_PREV_PARAM-DAG: Pattern/ExprSpecific:               {#zArg: Foo...#}[#Foo#];
+    // COMPLETE_AFTER_VARARG_WITH_PREV_PARAM-DAG: Pattern/Local/Flair[ExprSpecific]:               {#yArg: Foo...#}[#Foo#];
+    // COMPLETE_AFTER_VARARG_WITH_PREV_PARAM-DAG: Pattern/Local/Flair[ExprSpecific]:               {#zArg: Foo...#}[#Foo#];
     // COMPLETE_AFTER_VARARG_WITH_PREV_PARAM: End completions
     value.test("test", xArg: .bar, .#^COMPLETE_MEMBER_IN_VARARG^#)
     // COMPLETE_MEMBER_IN_VARARG: Begin completions, 2 items
-    // COMPLETE_MEMBER_IN_VARARG-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: bar[#Foo#];
+    // COMPLETE_MEMBER_IN_VARARG-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bar[#Foo#];
     // COMPLETE_MEMBER_IN_VARARG-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Foo#})[#(into: inout Hasher) -> Void#];
     // COMPLETE_MEMBER_IN_VARARG: End completions
   }
@@ -944,25 +944,25 @@ func testCompleteLabelAfterVararg() {
     value.test(foo, #^COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG^#)
     // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG: Begin completions
     // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: foo[#Foo#];
-    // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG-DAG: Pattern/ExprSpecific:               {#yArg: Baz#}[#Baz#];
+    // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG-DAG: Pattern/Local/Flair[ExprSpecific]:               {#yArg: Baz#}[#Baz#];
     // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG: End completions
 
     // The leading dot completion tests that have picked the right type for the argument
     value.test(foo, .#^COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG_DOT^#)
     // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG_DOT: Begin completions, 2 items
-    // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG_DOT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: bar[#Foo#];
+    // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG_DOT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bar[#Foo#];
     // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG_DOT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Foo#})[#(into: inout Hasher) -> Void#];
     // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG_DOT: End completions
 
     value.test(foo, yArg: #^COMPLETE_ARG_AFTER_VARARG^#)
     // COMPLETE_ARG_AFTER_VARARG: Begin completions
     // COMPLETE_ARG_AFTER_VARARG-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: baz[#Baz#];
-    // COMPLETE_ARG_AFTER_VARARG-NOT: Pattern/ExprSpecific:               {#yArg: Baz#}[#Baz#];
+    // COMPLETE_ARG_AFTER_VARARG-NOT: Pattern/Local/Flair[ExprSpecific]:               {#yArg: Baz#}[#Baz#];
     // COMPLETE_ARG_AFTER_VARARG: End completions
 
     value.test(foo, yArg: .#^COMPLETE_ARG_AFTER_VARARG_DOT^#)
     // COMPLETE_ARG_AFTER_VARARG_DOT: Begin completions, 2 items
-    // COMPLETE_ARG_AFTER_VARARG_DOT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: bazCase[#Baz#];
+    // COMPLETE_ARG_AFTER_VARARG_DOT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bazCase[#Baz#];
     // COMPLETE_ARG_AFTER_VARARG_DOT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Baz#})[#(into: inout Hasher) -> Void#];
     // COMPLETE_ARG_AFTER_VARARG_DOT: End completions
   }
@@ -975,7 +975,7 @@ func testGenericConstructor() {
 
   _ = TextField(label: "Encoded", #^GENERIC_INITIALIZER^#)
 // GENERIC_INITIALIZER: Begin completions, 1 item
-// GENERIC_INITIALIZER-DAG: Pattern/ExprSpecific:               {#text: String#}[#String#]
+// GENERIC_INITIALIZER-DAG: Pattern/Local/Flair[ExprSpecific]:               {#text: String#}[#String#]
 // GENERIC_INITIALIZER: End completions
 }
 
@@ -987,14 +987,14 @@ struct Rdar77867723 {
   func test1 {
     self.fn(ccc: .up, #^OVERLOAD_LABEL1^#)
 // OVERLOAD_LABEL1: Begin completions, 1 items
-// OVERLOAD_LABEL1-DAG: Pattern/ExprSpecific:               {#ddd: Horizontal#}[#Horizontal#];
+// OVERLOAD_LABEL1-DAG: Pattern/Local/Flair[ExprSpecific]:               {#ddd: Horizontal#}[#Horizontal#];
 // OVERLOAD_LABEL1: End completions
   }
   func test2 {
     self.fn(eee: .up, #^OVERLOAD_LABEL2^#)
 // OVERLOAD_LABEL2: Begin completions, 2 items
-// OVERLOAD_LABEL2-DAG: Pattern/ExprSpecific:               {#bbb: Vertical#}[#Vertical#];
-// OVERLOAD_LABEL2-DAG: Pattern/ExprSpecific:               {#ddd: Horizontal#}[#Horizontal#];
+// OVERLOAD_LABEL2-DAG: Pattern/Local/Flair[ExprSpecific]:               {#bbb: Vertical#}[#Vertical#];
+// OVERLOAD_LABEL2-DAG: Pattern/Local/Flair[ExprSpecific]:               {#ddd: Horizontal#}[#Horizontal#];
 // OVERLOAD_LABEL2: End completions
   }
 }

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -76,18 +76,18 @@ class C1 {
 }
 
 // ARG-NAME1: Begin completions, 2 items
-// ARG-NAME1-DAG: Pattern/Local/Flair[ExprSpecific]: {#b1: Int?#}[#Int?#];
-// ARG-NAME1-DAG: Pattern/Local/Flair[ExprSpecific]: {#b2: Int?#}[#Int?#];
+// ARG-NAME1-DAG: Pattern/Local/Flair[ArgLabels]: {#b1: Int?#}[#Int?#];
+// ARG-NAME1-DAG: Pattern/Local/Flair[ArgLabels]: {#b2: Int?#}[#Int?#];
 
 // ARG-NAME2: Begin completions, 1 items
-// ARG-NAME2-DAG: Pattern/Local/Flair[ExprSpecific]: {#b: Int#}[#Int#];
+// ARG-NAME2-DAG: Pattern/Local/Flair[ArgLabels]: {#b: Int#}[#Int#];
 
 // ARG-NAME3: Begin completions, 1 items
-// ARG-NAME3-DAG: Pattern/Local/Flair[ExprSpecific]: {#b: String?#}[#String?#];
+// ARG-NAME3-DAG: Pattern/Local/Flair[ArgLabels]: {#b: String?#}[#String?#];
 
 // ARG-NAME4: Begin completions, 2 items
-// ARG-NAME4-DAG: Pattern/Local/Flair[ExprSpecific]: {#b1: String#}[#String#];
-// ARG-NAME4-DAG: Pattern/Local/Flair[ExprSpecific]: {#b2: String#}[#String#];
+// ARG-NAME4-DAG: Pattern/Local/Flair[ArgLabels]: {#b1: String#}[#String#];
+// ARG-NAME4-DAG: Pattern/Local/Flair[ArgLabels]: {#b2: String#}[#String#];
 // ARG-NAME4: End completions
 
 // EXPECT_OINT: Begin completions
@@ -235,15 +235,15 @@ class C3 {
 // NEGATIVE_OVERLOAD4-NOT: Decl[Class]{{.*}} C2
 
 // OVERLOAD5: Begin completions
-// OVERLOAD5-DAG: Decl[FreeFunction]/CurrModule:      ['(']{#(a): C1#}, {#b1: C2#}[')'][#Void#]; name=a: C1, b1: C2
-// OVERLOAD5-DAG: Decl[FreeFunction]/CurrModule:      ['(']{#(a): C2#}, {#b2: C1#}[')'][#Void#]; name=a: C2, b2: C1
+// OVERLOAD5-DAG: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]:      ['(']{#(a): C1#}, {#b1: C2#}[')'][#Void#]; name=a: C1, b1: C2
+// OVERLOAD5-DAG: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]:      ['(']{#(a): C2#}, {#b2: C1#}[')'][#Void#]; name=a: C2, b2: C1
 // OVERLOAD5-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: C1I[#C1#]; name=C1I
 // OVERLOAD5-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: C2I[#C2#]; name=C2I
 // OVERLOAD5: End completions
 
 // OVERLOAD6: Begin completions
-// OVERLOAD6-DAG: Decl[InstanceMethod]/CurrNominal:   ['(']{#(a1): C1#}, {#b1: C2#}[')'][#Void#]; name=a1: C1, b1: C2
-// OVERLOAD6-DAG: Decl[InstanceMethod]/CurrNominal:   ['(']{#a2: C2#}, {#b2: C1#}[')'][#Void#]; name=a2: C2, b2: C1
+// OVERLOAD6-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:   ['(']{#(a1): C1#}, {#b1: C2#}[')'][#Void#]; name=a1: C1, b1: C2
+// OVERLOAD6-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:   ['(']{#a2: C2#}, {#b2: C1#}[')'][#Void#]; name=a2: C2, b2: C1
 // OVERLOAD6-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: C1I[#C1#]; name=C1I
 // OVERLOAD6-DAG: Decl[InstanceVar]/CurrNominal:      C2I[#C2#]; name=C2I
 // OVERLOAD6: End completions
@@ -260,7 +260,7 @@ extension C3 {
 }
 
 // HASERROR1: Begin completions
-// HASERROR1-DAG: Decl[InstanceMethod]/CurrNominal: ['(']{#a1: C1#}, {#b1: <<error type>>#}[')'][#Int#];
+// HASERROR1-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ['(']{#a1: C1#}, {#b1: <<error type>>#}[')'][#Int#];
 // HASERROR1: End completions
 
 // HASERROR2: Begin completions
@@ -269,7 +269,7 @@ extension C3 {
 // HASERROR2: End completions
 
 // HASERROR3: Begin completions
-// HASERROR3-DAG: Pattern/Local/Flair[ExprSpecific]: {#b1: <<error type>>#}[#<<error type>>#];
+// HASERROR3-DAG: Pattern/Local/Flair[ArgLabels]: {#b1: <<error type>>#}[#<<error type>>#];
 // HASERROR3: End completions
 
 // HASERROR4: Begin completions
@@ -404,7 +404,7 @@ func firstArg(arg1 arg1: Int, arg2: Int) {}
 func testArg1Name1() {
   firstArg(#^FIRST_ARG_NAME_1?check=FIRST_ARG_NAME_PATTERN^#
 }
-// FIRST_ARG_NAME_PATTERN: Decl[FreeFunction]/CurrModule: ['(']{#arg1: Int#}, {#arg2: Int#}[')'][#Void#];
+// FIRST_ARG_NAME_PATTERN: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]: ['(']{#arg1: Int#}, {#arg2: Int#}[')'][#Void#];
 func testArg2Name1() {
   firstArg(#^FIRST_ARG_NAME_2?check=FIRST_ARG_NAME_PATTERN^#)
 }
@@ -452,7 +452,7 @@ public func fopen() -> TestBoundGeneric1! { fatalError() }
 func other() {
   _ = fopen(#^CALLARG_IUO^#)
 // CALLARG_IUO: Begin completions, 1 items
-// CALLARG_IUO: Decl[FreeFunction]/CurrModule: ['('][')'][#TestBoundGeneric1!#]; name=
+// CALLARG_IUO: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]: ['('][')'][#TestBoundGeneric1!#]; name=
 // CALLARG_IUO: End completions
 }
 
@@ -535,7 +535,7 @@ func testSubscript(obj: HasSubscript, intValue: Int, strValue: String) {
 
   let _ = obj[42, #^SUBSCRIPT_2^#
 // SUBSCRIPT_2: Begin completions, 1 items
-// SUBSCRIPT_2-NEXT: Pattern/Local/Flair[ExprSpecific]: {#default: String#}[#String#];
+// SUBSCRIPT_2-NEXT: Pattern/Local/Flair[ArgLabels]: {#default: String#}[#String#];
 
   let _ = obj[42, .#^SUBSCRIPT_2_DOT^#
 // Note: we still provide completions despite the missing label - there's a fixit to add it in later.
@@ -590,8 +590,8 @@ class TestImplicitlyCurriedSelf {
     TestImplicitlyCurriedSelf.foo(#^CURRIED_SELF_3?check=CURRIED_SELF_1^#
 
 // CURRIED_SELF_1: Begin completions, 2 items
-// CURRIED_SELF_1-DAG: Decl[InstanceMethod]/CurrNominal: ['(']{#(self): TestImplicitlyCurriedSelf#}[')'][#(Int) -> ()#]{{; name=.+$}}
-// CURRIED_SELF_1-DAG: Decl[InstanceMethod]/CurrNominal: ['(']{#(self): TestImplicitlyCurriedSelf#}[')'][#(Int, Int) -> ()#]{{; name=.+$}}
+// CURRIED_SELF_1-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ['(']{#(self): TestImplicitlyCurriedSelf#}[')'][#(Int) -> ()#]{{; name=.+$}}
+// CURRIED_SELF_1-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ['(']{#(self): TestImplicitlyCurriedSelf#}[')'][#(Int, Int) -> ()#]{{; name=.+$}}
 // CURRIED_SELF_1: End completions
   }
 }
@@ -609,70 +609,70 @@ class TestStaticMemberCall {
 func testStaticMemberCall() {
   let _ = TestStaticMemberCall.create1(#^STATIC_METHOD_AFTERPAREN_1^#)
 // STATIC_METHOD_AFTERPAREN_1: Begin completions, 1 items
-// STATIC_METHOD_AFTERPAREN_1: Decl[StaticMethod]/CurrNominal:     ['(']{#arg1: Int#}[')'][#TestStaticMemberCall#]; name=arg1: Int
+// STATIC_METHOD_AFTERPAREN_1: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]:     ['(']{#arg1: Int#}[')'][#TestStaticMemberCall#]; name=arg1: Int
 // STATIC_METHOD_AFTERPAREN_1: End completions
 
   let _ = TestStaticMemberCall.create2(#^STATIC_METHOD_AFTERPAREN_2^#)
 // STATIC_METHOD_AFTERPAREN_2: Begin completions
-// STATIC_METHOD_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/TypeRelation[Identical]: ['(']{#(arg1): Int#}[')'][#TestStaticMemberCall#];
-// STATIC_METHOD_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/TypeRelation[Identical]: ['(']{#(arg1): Int#}, {#arg2: Int#}, {#arg3: Int#}, {#arg4: Int#}[')'][#TestStaticMemberCall#];
+// STATIC_METHOD_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Identical]: ['(']{#(arg1): Int#}[')'][#TestStaticMemberCall#];
+// STATIC_METHOD_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Identical]: ['(']{#(arg1): Int#}, {#arg2: Int#}, {#arg3: Int#}, {#arg4: Int#}[')'][#TestStaticMemberCall#];
 // STATIC_METHOD_AFTERPAREN_2-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem/TypeRelation[Identical]: Int[#Int#];
 // STATIC_METHOD_AFTERPAREN_2-DAG: Literal[Integer]/None/TypeRelation[Identical]: 0[#Int#];
 // STATIC_METHOD_AFTERPAREN_2: End completions
 
   let _ = TestStaticMemberCall.create2(1, #^STATIC_METHOD_SECOND^#)
 // STATIC_METHOD_SECOND: Begin completions, 3 items
-// STATIC_METHOD_SECOND: Pattern/Local/Flair[ExprSpecific]: {#arg2: Int#}[#Int#];
-// STATIC_METHOD_SECOND: Pattern/Local/Flair[ExprSpecific]: {#arg3: Int#}[#Int#];
-// STATIC_METHOD_SECOND: Pattern/Local/Flair[ExprSpecific]: {#arg4: Int#}[#Int#];
+// STATIC_METHOD_SECOND: Pattern/Local/Flair[ArgLabels]: {#arg2: Int#}[#Int#];
+// STATIC_METHOD_SECOND: Pattern/Local/Flair[ArgLabels]: {#arg3: Int#}[#Int#];
+// STATIC_METHOD_SECOND: Pattern/Local/Flair[ArgLabels]: {#arg4: Int#}[#Int#];
 // STATIC_METHOD_SECOND: End completions
 
   let _ = TestStaticMemberCall.create2(1, arg3: 2, #^STATIC_METHOD_SKIPPED^#)
 // STATIC_METHOD_SKIPPED: Begin completions, 1 item
-// STATIC_METHOD_SKIPPED: Pattern/Local/Flair[ExprSpecific]: {#arg4: Int#}[#Int#];
+// STATIC_METHOD_SKIPPED: Pattern/Local/Flair[ArgLabels]: {#arg4: Int#}[#Int#];
 // STATIC_METHOD_SKIPPED: End completions
 
   let _ = TestStaticMemberCall.createOverloaded(#^STATIC_METHOD_OVERLOADED^#)
 // STATIC_METHOD_OVERLOADED: Begin completions, 2 items
-// STATIC_METHOD_OVERLOADED-DAG: Decl[StaticMethod]/CurrNominal:     ['(']{#arg1: Int#}[')'][#TestStaticMemberCall#]; name=arg1: Int
-// STATIC_METHOD_OVERLOADED-DAG: Decl[StaticMethod]/CurrNominal:     ['(']{#arg1: String#}[')'][#String#]; name=arg1: String
+// STATIC_METHOD_OVERLOADED-DAG: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]:     ['(']{#arg1: Int#}[')'][#TestStaticMemberCall#]; name=arg1: Int
+// STATIC_METHOD_OVERLOADED-DAG: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]:     ['(']{#arg1: String#}[')'][#String#]; name=arg1: String
 // STATIC_METHOD_OVERLOADED: End completions
 }
 func testImplicitMember() {
   let _: TestStaticMemberCall = .create1(#^IMPLICIT_MEMBER_AFTERPAREN_1^#)
 // IMPLICIT_MEMBER_AFTERPAREN_1: Begin completions, 1 items
-// IMPLICIT_MEMBER_AFTERPAREN_1: Decl[StaticMethod]/CurrNominal/TypeRelation[Identical]: ['(']{#arg1: Int#}[')'][#TestStaticMemberCall#]; name=arg1: Int
+// IMPLICIT_MEMBER_AFTERPAREN_1: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Identical]: ['(']{#arg1: Int#}[')'][#TestStaticMemberCall#]; name=arg1: Int
 // IMPLICIT_MEMBER_AFTERPAREN_1: End completions
 
   let _: TestStaticMemberCall = .create2(#^IMPLICIT_MEMBER_AFTERPAREN_2^#)
 // IMPLICIT_MEMBER_AFTERPAREN_2: Begin completions
-// IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/TypeRelation[Identical]: ['(']{#(arg1): Int#}[')'][#TestStaticMemberCall#];
-// IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/TypeRelation[Identical]: ['(']{#(arg1): Int#}, {#arg2: Int#}, {#arg3: Int#}, {#arg4: Int#}[')'][#TestStaticMemberCall#];
+// IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Identical]: ['(']{#(arg1): Int#}[')'][#TestStaticMemberCall#];
+// IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Identical]: ['(']{#(arg1): Int#}, {#arg2: Int#}, {#arg3: Int#}, {#arg4: Int#}[')'][#TestStaticMemberCall#];
 // IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem/TypeRelation[Identical]: Int[#Int#];
 // IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Literal[Integer]/None/TypeRelation[Identical]: 0[#Int#];
 // IMPLICIT_MEMBER_AFTERPAREN_2: End completions
 
   let _: TestStaticMemberCall? = .create1(#^IMPLICIT_MEMBER_AFTERPAREN_3^#)
 // IMPLICIT_MEMBER_AFTERPAREN_3: Begin completions, 1 items
-// IMPLICIT_MEMBER_AFTERPAREN_3: Decl[StaticMethod]/CurrNominal/TypeRelation[Convertible]: ['(']{#arg1: Int#}[')'][#TestStaticMemberCall#]; name=arg1: Int
+// IMPLICIT_MEMBER_AFTERPAREN_3: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Convertible]: ['(']{#arg1: Int#}[')'][#TestStaticMemberCall#]; name=arg1: Int
 // IMPLICIT_MEMBER_AFTERPAREN_3: End completions
 
   let _: TestStaticMemberCall = .create2(1, #^IMPLICIT_MEMBER_SECOND^#)
 // IMPLICIT_MEMBER_SECOND: Begin completions, 3 items
-// IMPLICIT_MEMBER_SECOND: Pattern/Local/Flair[ExprSpecific]: {#arg2: Int#}[#Int#];
-// IMPLICIT_MEMBER_SECOND: Pattern/Local/Flair[ExprSpecific]: {#arg3: Int#}[#Int#];
-// IMPLICIT_MEMBER_SECOND: Pattern/Local/Flair[ExprSpecific]: {#arg4: Int#}[#Int#];
+// IMPLICIT_MEMBER_SECOND: Pattern/Local/Flair[ArgLabels]: {#arg2: Int#}[#Int#];
+// IMPLICIT_MEMBER_SECOND: Pattern/Local/Flair[ArgLabels]: {#arg3: Int#}[#Int#];
+// IMPLICIT_MEMBER_SECOND: Pattern/Local/Flair[ArgLabels]: {#arg4: Int#}[#Int#];
 // IMPLICIT_MEMBER_SECOND: End completions
 
   let _: TestStaticMemberCall = .create2(1, arg3: 2, #^IMPLICIT_MEMBER_SKIPPED^#)
 // IMPLICIT_MEMBER_SKIPPED: Begin completions, 1 item
-// IMPLICIT_MEMBER_SKIPPED: Pattern/Local/Flair[ExprSpecific]: {#arg4: Int#}[#Int#];
+// IMPLICIT_MEMBER_SKIPPED: Pattern/Local/Flair[ArgLabels]: {#arg4: Int#}[#Int#];
 // IMPLICIT_MEMBER_SKIPPED: End completions
 
   let _: TestStaticMemberCall = .createOverloaded(#^IMPLICIT_MEMBER_OVERLOADED^#)
 // IMPLICIT_MEMBER_OVERLOADED: Begin completions, 2 items
-// IMPLICIT_MEMBER_OVERLOADED: Decl[StaticMethod]/CurrNominal/TypeRelation[Identical]: ['(']{#arg1: Int#}[')'][#TestStaticMemberCall#]; name=arg1: Int
-// IMPLICIT_MEMBER_OVERLOADED: Decl[StaticMethod]/CurrNominal:     ['(']{#arg1: String#}[')'][#String#]; name=arg1: String
+// IMPLICIT_MEMBER_OVERLOADED: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Identical]: ['(']{#arg1: Int#}[')'][#TestStaticMemberCall#]; name=arg1: Int
+// IMPLICIT_MEMBER_OVERLOADED: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]:     ['(']{#arg1: String#}[')'][#String#]; name=arg1: String
 // IMPLICIT_MEMBER_OVERLOADED: End completions
 }
 func testImplicitMemberInArrayLiteral() {
@@ -726,7 +726,7 @@ struct Wrap<T> {
 func testGenricMethodOnGenericOfArchetype<Wrapped>(value: Wrap<Wrapped>) {
   value.method(#^ARCHETYPE_GENERIC_1^#)
 // ARCHETYPE_GENERIC_1: Begin completions
-// ARCHETYPE_GENERIC_1: Decl[InstanceMethod]/CurrNominal:   ['(']{#(fn): (Wrapped) -> U##(Wrapped) -> U#}[')'][#Wrap<U>#];
+// ARCHETYPE_GENERIC_1: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:   ['(']{#(fn): (Wrapped) -> U##(Wrapped) -> U#}[')'][#Wrap<U>#];
 }
 
 struct TestHasErrorAutoclosureParam {
@@ -736,7 +736,7 @@ struct TestHasErrorAutoclosureParam {
   func test() {
     hasErrorAutoclosureParam(#^PARAM_WITH_ERROR_AUTOCLOSURE^#
 // PARAM_WITH_ERROR_AUTOCLOSURE: Begin completions, 1 items
-// PARAM_WITH_ERROR_AUTOCLOSURE: Decl[InstanceMethod]/CurrNominal:   ['(']{#value: <<error type>>#}[')'][#Void#];
+// PARAM_WITH_ERROR_AUTOCLOSURE: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:   ['(']{#value: <<error type>>#}[')'][#Void#];
 // PARAM_WITH_ERROR_AUTOCLOSURE: End completions
   }
 }
@@ -750,9 +750,9 @@ struct MyType<T> {
 func testTypecheckedOverloaded<T>(value: MyType<T>) {
   value.overloaded(#^TYPECHECKED_OVERLOADED^#)
 // TYPECHECKED_OVERLOADED: Begin completions
-// TYPECHECKED_OVERLOADED-DAG: Decl[InstanceMethod]/CurrNominal:   ['('][')'][#Void#];
-// TYPECHECKED_OVERLOADED-DAG: Decl[InstanceMethod]/CurrNominal:   ['(']{#(int): Int#}[')'][#Void#];
-// TYPECHECKED_OVERLOADED-DAG: Decl[InstanceMethod]/CurrNominal:   ['(']{#name: String#}, {#value: String#}[')'][#Void#];
+// TYPECHECKED_OVERLOADED-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:   ['('][')'][#Void#];
+// TYPECHECKED_OVERLOADED-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:   ['(']{#(int): Int#}[')'][#Void#];
+// TYPECHECKED_OVERLOADED-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:   ['(']{#name: String#}, {#value: String#}[')'][#Void#];
 // TYPECHECKED_OVERLOADED: End completions
 }
 
@@ -763,30 +763,30 @@ func testTypecheckedTypeExpr() {
   MyType(#^TYPECHECKED_TYPEEXPR^#
 }
 // TYPECHECKED_TYPEEXPR: Begin completions
-// TYPECHECKED_TYPEEXPR: Decl[Constructor]/CurrNominal:      ['(']{#arg1: String#}, {#arg2: _#}[')'][#MyType<_>#]; name=arg1: String, arg2: _
-// TYPECHECKED_TYPEEXPR: Decl[Constructor]/CurrNominal:      ['(']{#(intVal): Int#}[')'][#MyType<Int>#]; name=intVal: Int
+// TYPECHECKED_TYPEEXPR: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#arg1: String#}, {#arg2: _#}[')'][#MyType<_>#]; name=arg1: String, arg2: _
+// TYPECHECKED_TYPEEXPR: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#(intVal): Int#}[')'][#MyType<Int>#]; name=intVal: Int
 // TYPECHECKED_TYPEEXPR: End completions
 
 func testPamrameterFlags(_: Int, inoutArg: inout Int, autoclosureArg: @autoclosure () -> Int, iuoArg: Int!, variadicArg: Int...) {
   var intVal = 1
   testPamrameterFlags(intVal, #^ARG_PARAMFLAG_INOUT^#)
 // ARG_PARAMFLAG_INOUT: Begin completions, 1 items
-// ARG_PARAMFLAG_INOUT-DAG: Pattern/Local/Flair[ExprSpecific]: {#inoutArg: &Int#}[#inout Int#]; name=inoutArg:
+// ARG_PARAMFLAG_INOUT-DAG: Pattern/Local/Flair[ArgLabels]: {#inoutArg: &Int#}[#inout Int#]; name=inoutArg:
 // ARG_PARAMFLAG_INOUT: End completions
 
   testPamrameterFlags(intVal, inoutArg: &intVal, #^ARG_PARAMFLAG_AUTOCLOSURE^#)
 // ARG_PARAMFLAG_AUTOCLOSURE: Begin completions, 1 items
-// ARG_PARAMFLAG_AUTOCLOSURE-DAG: Pattern/Local/Flair[ExprSpecific]: {#autoclosureArg: Int#}[#Int#];
+// ARG_PARAMFLAG_AUTOCLOSURE-DAG: Pattern/Local/Flair[ArgLabels]: {#autoclosureArg: Int#}[#Int#];
 // ARG_PARAMFLAG_AUTOCLOSURE: End completions
 
   testPamrameterFlags(intVal, inoutArg: &intVal, autoclosureArg: intVal, #^ARG_PARAMFLAG_IUO^#)
 // ARG_PARAMFLAG_IUO: Begin completions, 1 items
-// ARG_PARAMFLAG_IUO-DAG: Pattern/Local/Flair[ExprSpecific]: {#iuoArg: Int?#}[#Int?#];
+// ARG_PARAMFLAG_IUO-DAG: Pattern/Local/Flair[ArgLabels]: {#iuoArg: Int?#}[#Int?#];
 // ARG_PARAMFLAG_IUO: End completions
 
   testPamrameterFlags(intVal, inoutArg: &intVal, autoclosureArg: intVal, iuoArg: intVal, #^ARG_PARAMFLAG_VARIADIC^#)
 // ARG_PARAMFLAG_VARIADIC: Begin completions, 1 items
-// ARG_PARAMFLAG_VARIADIC-DAG: Pattern/Local/Flair[ExprSpecific]: {#variadicArg: Int...#}[#Int#];
+// ARG_PARAMFLAG_VARIADIC-DAG: Pattern/Local/Flair[ArgLabels]: {#variadicArg: Int...#}[#Int#];
 // ARG_PARAMFLAG_VARIADIC: End completions
 }
 
@@ -823,13 +823,13 @@ func testKeyPathThunkInBase() {
 func testVariadic(_ arg: Any..., option1: Int = 0, option2: String = 1) {
     testVariadic(#^VARIADIC_1^#)
 // VARIADIC_1: Begin completions
-// VARIADIC_1-DAG: Decl[FreeFunction]/CurrModule: ['(']{#(arg): Any...#}, {#option1: Int#}, {#option2: String#}[')'][#Void#];
+// VARIADIC_1-DAG: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]: ['(']{#(arg): Any...#}, {#option1: Int#}, {#option2: String#}[')'][#Void#];
 // VARIADIC_1-DAG: Decl[GlobalVar]/CurrModule:    i1[#Int#];
 // VARIADIC_1: End completions
     testVariadic(1, #^VARIADIC_2^#)
 // VARIADIC_2: Begin completions
-// VARIADIC_2-DAG: Pattern/Local/Flair[ExprSpecific]:          {#option1: Int#}[#Int#];
-// VARIADIC_2-DAG: Pattern/Local/Flair[ExprSpecific]:          {#option2: String#}[#String#];
+// VARIADIC_2-DAG: Pattern/Local/Flair[ArgLabels]:          {#option1: Int#}[#Int#];
+// VARIADIC_2-DAG: Pattern/Local/Flair[ArgLabels]:          {#option2: String#}[#String#];
 // VARIADIC_2-DAG: Decl[GlobalVar]/CurrModule:    i1[#Int#];
 // VARIADIC_2: End completions
     testVariadic(1, 2, #^VARIADIC_3?check=VARIADIC_2^#)
@@ -842,7 +842,7 @@ func testLabelsInSelfDotInit() {
     convenience init() {
       self.init(a: 1, #^LABEL_IN_SELF_DOT_INIT^#)
 // LABEL_IN_SELF_DOT_INIT: Begin completions, 1 item
-// LABEL_IN_SELF_DOT_INIT-DAG: Pattern/Local/Flair[ExprSpecific]:               {#b: Int#}[#Int#]
+// LABEL_IN_SELF_DOT_INIT-DAG: Pattern/Local/Flair[ArgLabels]:               {#b: Int#}[#Int#]
 // LABEL_IN_SELF_DOT_INIT: End completions
     }
   }
@@ -855,7 +855,7 @@ func testMissingRequiredParameter() {
   func test(c: C) {
     c.foo(y: 1, #^MISSING_REQUIRED_PARAM^#)
 // MISSING_REQUIRED_PARAM: Begin completions, 1 item
-// MISSING_REQUIRED_PARAM-DAG: Pattern/Local/Flair[ExprSpecific]:               {#z: Int#}[#Int#]
+// MISSING_REQUIRED_PARAM-DAG: Pattern/Local/Flair[ArgLabels]:               {#z: Int#}[#Int#]
 // MISSING_REQUIRED_PARAM: End completions
   }
 }
@@ -867,7 +867,7 @@ func testAfterVariadic() {
   func test(c: C) {
     c.foo(x: 10, 20, 30, y: 40, #^NAMED_PARAMETER_WITH_LEADING_VARIADIC^#)
 // NAMED_PARAMETER_WITH_LEADING_VARIADIC: Begin completions, 1 item
-// NAMED_PARAMETER_WITH_LEADING_VARIADIC-DAG: Pattern/Local/Flair[ExprSpecific]:               {#z: Int#}[#Int#]
+// NAMED_PARAMETER_WITH_LEADING_VARIADIC-DAG: Pattern/Local/Flair[ArgLabels]:               {#z: Int#}[#Int#]
 // NAMED_PARAMETER_WITH_LEADING_VARIADIC: End completions
   }
 }
@@ -876,25 +876,25 @@ func testClosurePlaceholderContainsInternalParameterNamesIfPresentInSiganture() 
   func sort(callback: (_ left: Int, _ right: Int) -> Bool) {}
   sort(#^CLOSURE_PARAM_WITH_INTERNAL_NAME^#)
 // CLOSURE_PARAM_WITH_INTERNAL_NAME: Begin completions, 1 item
-// CLOSURE_PARAM_WITH_INTERNAL_NAME-DAG: Decl[FreeFunction]/Local:           ['(']{#callback: (Int, Int) -> Bool##(_ left: Int, _ right: Int) -> Bool#}[')'][#Void#];
+// CLOSURE_PARAM_WITH_INTERNAL_NAME-DAG: Decl[FreeFunction]/Local/Flair[ArgLabels]:           ['(']{#callback: (Int, Int) -> Bool##(_ left: Int, _ right: Int) -> Bool#}[')'][#Void#];
 // CLOSURE_PARAM_WITH_INTERNAL_NAME: End completions
 
   func sortWithParensAroundClosureType(callback: ((_ left: Int, _ right: Int) -> Bool)) {}
   sortWithParensAroundClosureType(#^CLOSURE_PARAM_WITH_PARENS^#)
 // CLOSURE_PARAM_WITH_PARENS: Begin completions, 1 item
-// CLOSURE_PARAM_WITH_PARENS-DAG: Decl[FreeFunction]/Local:           ['(']{#callback: ((Int, Int) -> Bool)##(_ left: Int, _ right: Int) -> Bool#}[')'][#Void#];
+// CLOSURE_PARAM_WITH_PARENS-DAG: Decl[FreeFunction]/Local/Flair[ArgLabels]:           ['(']{#callback: ((Int, Int) -> Bool)##(_ left: Int, _ right: Int) -> Bool#}[')'][#Void#];
 // CLOSURE_PARAM_WITH_PARENS: End completions
 
   func sortWithOptionalClosureType(callback: ((_ left: Int, _ right: Int) -> Bool)?) {}
   sortWithOptionalClosureType(#^OPTIONAL_CLOSURE_PARAM^#)
 // OPTIONAL_CLOSURE_PARAM: Begin completions, 1 item
-// OPTIONAL_CLOSURE_PARAM-DAG: Decl[FreeFunction]/Local:           ['(']{#callback: ((Int, Int) -> Bool)?##(_ left: Int, _ right: Int) -> Bool#}[')'][#Void#];
+// OPTIONAL_CLOSURE_PARAM-DAG: Decl[FreeFunction]/Local/Flair[ArgLabels]:           ['(']{#callback: ((Int, Int) -> Bool)?##(_ left: Int, _ right: Int) -> Bool#}[')'][#Void#];
 // OPTIONAL_CLOSURE_PARAM: End completions
 
   func sortWithEscapingClosureType(callback: @escaping (_ left: Int, _ right: Int) -> Bool) {}
   sortWithEscapingClosureType(#^ESCAPING_OPTIONAL_CLOSURE_PARAM^#)
 // ESCAPING_OPTIONAL_CLOSURE_PARAM: Begin completions, 1 item
-// ESCAPING_OPTIONAL_CLOSURE_PARAM-DAG: Decl[FreeFunction]/Local:           ['(']{#callback: (Int, Int) -> Bool##(_ left: Int, _ right: Int) -> Bool#}[')'][#Void#];
+// ESCAPING_OPTIONAL_CLOSURE_PARAM-DAG: Decl[FreeFunction]/Local/Flair[ArgLabels]:           ['(']{#callback: (Int, Int) -> Bool##(_ left: Int, _ right: Int) -> Bool#}[')'][#Void#];
 // ESCAPING_OPTIONAL_CLOSURE_PARAM: End completions
 }
 
@@ -902,7 +902,7 @@ func testClosurePlaceholderPrintsTypesOnlyIfNoInternalParameterNamesExist() {
   func sort(callback: (Int, Int) -> Bool) {}
   sort(#^COMPLETE_CLOSURE_PARAM_WITHOUT_INTERNAL_NAMES^#)
 // COMPLETE_CLOSURE_PARAM_WITHOUT_INTERNAL_NAMES: Begin completions, 1 item
-// COMPLETE_CLOSURE_PARAM_WITHOUT_INTERNAL_NAMES-DAG: Decl[FreeFunction]/Local:           ['(']{#callback: (Int, Int) -> Bool##(Int, Int) -> Bool#}[')'][#Void#];
+// COMPLETE_CLOSURE_PARAM_WITHOUT_INTERNAL_NAMES-DAG: Decl[FreeFunction]/Local/Flair[ArgLabels]:           ['(']{#callback: (Int, Int) -> Bool##(Int, Int) -> Bool#}[')'][#Void#];
 // COMPLETE_CLOSURE_PARAM_WITHOUT_INTERNAL_NAMES: End completions
 }
 
@@ -921,13 +921,13 @@ func testCompleteLabelAfterVararg() {
   private func test(value: Rdar76355192) {
     value.test("test", xArg: #^COMPLETE_AFTER_VARARG^#)
     // COMPLETE_AFTER_VARARG: Begin completions
-    // COMPLETE_AFTER_VARARG-NOT: Pattern/Local/Flair[ExprSpecific]:               {#yArg: Foo...#}[#Foo#];
-    // COMPLETE_AFTER_VARARG-NOT: Pattern/Local/Flair[ExprSpecific]:               {#zArg: Foo...#}[#Foo#];
+    // COMPLETE_AFTER_VARARG-NOT: Pattern/Local/Flair[ArgLabels]:               {#yArg: Foo...#}[#Foo#];
+    // COMPLETE_AFTER_VARARG-NOT: Pattern/Local/Flair[ArgLabels]:               {#zArg: Foo...#}[#Foo#];
     // COMPLETE_AFTER_VARARG: End completions
     value.test("test", xArg: .bar, #^COMPLETE_AFTER_VARARG_WITH_PREV_PARAM^#)
     // COMPLETE_AFTER_VARARG_WITH_PREV_PARAM: Begin completions
-    // COMPLETE_AFTER_VARARG_WITH_PREV_PARAM-DAG: Pattern/Local/Flair[ExprSpecific]:               {#yArg: Foo...#}[#Foo#];
-    // COMPLETE_AFTER_VARARG_WITH_PREV_PARAM-DAG: Pattern/Local/Flair[ExprSpecific]:               {#zArg: Foo...#}[#Foo#];
+    // COMPLETE_AFTER_VARARG_WITH_PREV_PARAM-DAG: Pattern/Local/Flair[ArgLabels]:               {#yArg: Foo...#}[#Foo#];
+    // COMPLETE_AFTER_VARARG_WITH_PREV_PARAM-DAG: Pattern/Local/Flair[ArgLabels]:               {#zArg: Foo...#}[#Foo#];
     // COMPLETE_AFTER_VARARG_WITH_PREV_PARAM: End completions
     value.test("test", xArg: .bar, .#^COMPLETE_MEMBER_IN_VARARG^#)
     // COMPLETE_MEMBER_IN_VARARG: Begin completions, 2 items
@@ -944,7 +944,7 @@ func testCompleteLabelAfterVararg() {
     value.test(foo, #^COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG^#)
     // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG: Begin completions
     // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: foo[#Foo#];
-    // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG-DAG: Pattern/Local/Flair[ExprSpecific]:               {#yArg: Baz#}[#Baz#];
+    // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG-DAG: Pattern/Local/Flair[ArgLabels]:               {#yArg: Baz#}[#Baz#];
     // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG: End completions
 
     // The leading dot completion tests that have picked the right type for the argument
@@ -957,7 +957,7 @@ func testCompleteLabelAfterVararg() {
     value.test(foo, yArg: #^COMPLETE_ARG_AFTER_VARARG^#)
     // COMPLETE_ARG_AFTER_VARARG: Begin completions
     // COMPLETE_ARG_AFTER_VARARG-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: baz[#Baz#];
-    // COMPLETE_ARG_AFTER_VARARG-NOT: Pattern/Local/Flair[ExprSpecific]:               {#yArg: Baz#}[#Baz#];
+    // COMPLETE_ARG_AFTER_VARARG-NOT: Pattern/Local/Flair[ArgLabels]:               {#yArg: Baz#}[#Baz#];
     // COMPLETE_ARG_AFTER_VARARG: End completions
 
     value.test(foo, yArg: .#^COMPLETE_ARG_AFTER_VARARG_DOT^#)
@@ -975,7 +975,7 @@ func testGenericConstructor() {
 
   _ = TextField(label: "Encoded", #^GENERIC_INITIALIZER^#)
 // GENERIC_INITIALIZER: Begin completions, 1 item
-// GENERIC_INITIALIZER-DAG: Pattern/Local/Flair[ExprSpecific]:               {#text: String#}[#String#]
+// GENERIC_INITIALIZER-DAG: Pattern/Local/Flair[ArgLabels]:               {#text: String#}[#String#]
 // GENERIC_INITIALIZER: End completions
 }
 
@@ -987,14 +987,14 @@ struct Rdar77867723 {
   func test1 {
     self.fn(ccc: .up, #^OVERLOAD_LABEL1^#)
 // OVERLOAD_LABEL1: Begin completions, 1 items
-// OVERLOAD_LABEL1-DAG: Pattern/Local/Flair[ExprSpecific]:               {#ddd: Horizontal#}[#Horizontal#];
+// OVERLOAD_LABEL1-DAG: Pattern/Local/Flair[ArgLabels]:               {#ddd: Horizontal#}[#Horizontal#];
 // OVERLOAD_LABEL1: End completions
   }
   func test2 {
     self.fn(eee: .up, #^OVERLOAD_LABEL2^#)
 // OVERLOAD_LABEL2: Begin completions, 2 items
-// OVERLOAD_LABEL2-DAG: Pattern/Local/Flair[ExprSpecific]:               {#bbb: Vertical#}[#Vertical#];
-// OVERLOAD_LABEL2-DAG: Pattern/Local/Flair[ExprSpecific]:               {#ddd: Horizontal#}[#Horizontal#];
+// OVERLOAD_LABEL2-DAG: Pattern/Local/Flair[ArgLabels]:               {#bbb: Vertical#}[#Vertical#];
+// OVERLOAD_LABEL2-DAG: Pattern/Local/Flair[ArgLabels]:               {#ddd: Horizontal#}[#Horizontal#];
 // OVERLOAD_LABEL2: End completions
   }
 }

--- a/test/IDE/complete_call_as_function.swift
+++ b/test/IDE/complete_call_as_function.swift
@@ -39,7 +39,7 @@ func testCallAsFunction(add: Adder, addTy: Adder.Type) {
 
   let _ = add(x: 12, #^INSTANCE_ARG2^#)
 // INSTANCE_ARG2: Begin completions, 1 items
-// INSTANCE_ARG2: Pattern/ExprSpecific:               {#y: Int#}[#Int#];
+// INSTANCE_ARG2: Pattern/Local/Flair[ExprSpecific]:               {#y: Int#}[#Int#];
 // INSTANCE_ARG2: End completions
 
   let _ = addTy#^METATYPE_NO_DOT^#;
@@ -104,13 +104,13 @@ func testCallAsFunctionOverloaded(fn: Functor) {
 
   fn(h: .left, #^OVERLOADED_ARG2_LABEL^#)
 //OVERLOADED_ARG2_LABEL: Begin completions, 1 item
-//OVERLOADED_ARG2_LABEL-DAG: Pattern/ExprSpecific:               {#v: Functor.Vertical#}[#Functor.Vertical#];
+//OVERLOADED_ARG2_LABEL-DAG: Pattern/Local/Flair[ExprSpecific]:               {#v: Functor.Vertical#}[#Functor.Vertical#];
 //OVERLOADED_ARG2_LABEL: End completions
 
   fn(h: .left, v: .#^OVERLOADED_ARG2_VALUE^#)
 //OVERLOADED_ARG2_VALUE: Begin completions, 3 items
-//OVERLOADED_ARG2_VALUE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: up[#Functor.Vertical#];
-//OVERLOADED_ARG2_VALUE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: down[#Functor.Vertical#];
+//OVERLOADED_ARG2_VALUE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: up[#Functor.Vertical#];
+//OVERLOADED_ARG2_VALUE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: down[#Functor.Vertical#];
 //OVERLOADED_ARG2_VALUE-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Functor.Vertical#})[#(into: inout Hasher) -> Void#];
 //OVERLOADED_ARG2_VALUE: End completions
 }

--- a/test/IDE/complete_call_as_function.swift
+++ b/test/IDE/complete_call_as_function.swift
@@ -22,7 +22,7 @@ func testCallAsFunction(add: Adder, addTy: Adder.Type) {
   let _ = add#^INSTANCE_NO_DOT^#;
 // INSTANCE_NO_DOT: Begin completions, 3 items
 // INSTANCE_NO_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   .callAsFunction({#x: Int#}, {#y: Int#})[#Int#];
-// INSTANCE_NO_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   ({#x: Int#}, {#y: Int#})[#Int#];
+// INSTANCE_NO_DOT-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:   ({#x: Int#}, {#y: Int#})[#Int#];
 // INSTANCE_NO_DOT-DAG: Keyword[self]/CurrNominal:          .self[#Adder#];
 // INSTANCE_NO_DOT: End completions
 
@@ -34,12 +34,12 @@ func testCallAsFunction(add: Adder, addTy: Adder.Type) {
 
   let _ = add(#^INSTANCE_PAREN^#)
 // INSTANCE_PAREN: Begin completions, 1 items
-// INSTANCE_PAREN-DAG: Decl[InstanceMethod]/CurrNominal:   ['(']{#x: Int#}, {#y: Int#}[')'][#Int#];
+// INSTANCE_PAREN-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:   ['(']{#x: Int#}, {#y: Int#}[')'][#Int#];
 // INSTANCE_PAREN: End completions
 
   let _ = add(x: 12, #^INSTANCE_ARG2^#)
 // INSTANCE_ARG2: Begin completions, 1 items
-// INSTANCE_ARG2: Pattern/Local/Flair[ExprSpecific]:               {#y: Int#}[#Int#];
+// INSTANCE_ARG2: Pattern/Local/Flair[ArgLabels]:               {#y: Int#}[#Int#];
 // INSTANCE_ARG2: End completions
 
   let _ = addTy#^METATYPE_NO_DOT^#;
@@ -67,7 +67,7 @@ func testCallAsFunction(add: Adder, addTy: Adder.Type) {
   let _ = Adder#^TYPEEXPR_NO_DOT^#;
 // TYPEEXPR_NO_DOT: Begin completions, 4 items
 // TYPEEXPR_NO_DOT-NOT: {#x: Int#}, {#y: Int#}
-// TYPEEXPR_NO_DOT-DAG: Decl[Constructor]/CurrNominal:      ({#base: Int#})[#Adder#]; name=(base: Int)
+// TYPEEXPR_NO_DOT-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#base: Int#})[#Adder#]; name=(base: Int)
 // TYPEEXPR_NO_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   .callAsFunction({#(self): Adder#})[#(x: Int, y: Int) -> Int#];
 // TYPEEXPR_NO_DOT-DAG: Keyword[self]/CurrNominal:          .self[#Adder.Type#];
 // TYPEEXPR_NO_DOT-DAG: Keyword/CurrNominal:                .Type[#Adder.Type#];
@@ -85,7 +85,7 @@ func testCallAsFunction(add: Adder, addTy: Adder.Type) {
   let _ = Adder(#^TYPEEXPR_PAREN^#)
 // TYPEEXPR_PAREN: Begin completions, 1 items
 // TYPEEXPR_PAREN-NOT: {#x: Int#}, {#y: Int#}
-// TYPEEXPR_PAREN-DAG: Decl[Constructor]/CurrNominal:      ['(']{#base: Int#}[')'][#Adder#];
+// TYPEEXPR_PAREN-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#base: Int#}[')'][#Adder#];
 // TYPEEXPR_PAREN: End completions
 }
 
@@ -98,13 +98,13 @@ struct Functor {
 func testCallAsFunctionOverloaded(fn: Functor) {
   fn(#^OVERLOADED_PAREN^#)
 //OVERLOADED_PAREN: Begin completions, 2 items
-//OVERLOADED_PAREN-DAG: Decl[InstanceMethod]/CurrNominal:   ['(']{#h: Functor.Horizontal#}, {#v: Functor.Vertical#}[')'][#Void#];
-//OVERLOADED_PAREN-DAG: Decl[InstanceMethod]/CurrNominal:   ['(']{#v: Functor.Vertical#}, {#h: Functor.Horizontal#}[')'][#Void#];
+//OVERLOADED_PAREN-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:   ['(']{#h: Functor.Horizontal#}, {#v: Functor.Vertical#}[')'][#Void#];
+//OVERLOADED_PAREN-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:   ['(']{#v: Functor.Vertical#}, {#h: Functor.Horizontal#}[')'][#Void#];
 //OVERLOADED_PAREN: End completions
 
   fn(h: .left, #^OVERLOADED_ARG2_LABEL^#)
 //OVERLOADED_ARG2_LABEL: Begin completions, 1 item
-//OVERLOADED_ARG2_LABEL-DAG: Pattern/Local/Flair[ExprSpecific]:               {#v: Functor.Vertical#}[#Functor.Vertical#];
+//OVERLOADED_ARG2_LABEL-DAG: Pattern/Local/Flair[ArgLabels]:               {#v: Functor.Vertical#}[#Functor.Vertical#];
 //OVERLOADED_ARG2_LABEL: End completions
 
   fn(h: .left, v: .#^OVERLOADED_ARG2_VALUE^#)

--- a/test/IDE/complete_call_pattern_heuristics.swift
+++ b/test/IDE/complete_call_pattern_heuristics.swift
@@ -27,7 +27,7 @@ func testConstructor() {
 // CONSTRUCTOR: Begin completions
 // CONSTRUCTOR-NOT: Pattern/{{.*}}
 // CONSTRUCTOR-NOT: Decl[Constructor]
-// CONSTRUCTOR: Pattern/Local/Flair[ExprSpecific]: {#a: Int#}[#Int#]
+// CONSTRUCTOR: Pattern/Local/Flair[ArgLabels]: {#a: Int#}[#Int#]
 // CONSTRUCTOR-NOT: Pattern/{{.*}}
 // CONSTRUCTOR-NOT: Decl[Constructor]
 // CONSTRUCTOR: End completions
@@ -38,7 +38,7 @@ func testArg2Name3() {
   firstArg(#^LABELED_FIRSTARG^#,
 // LABELED_FIRSTARG: Begin completions
 // LABELED_FIRSTARG-NOT: ['(']{#arg1: Int#}, {#arg2: Int#}[')'][#Void#];
-// LABELED_FIRSTARG-DAG: Pattern/Local/Flair[ExprSpecific]: {#arg1: Int#}[#Int#];
+// LABELED_FIRSTARG-DAG: Pattern/Local/Flair[ArgLabels]: {#arg1: Int#}[#Int#];
 // LABELED_FIRSTARG-NOT: ['(']{#arg1: Int#}, {#arg2: Int#}[')'][#Void#];
 // LABELED_FIRSTARG: End completions
 

--- a/test/IDE/complete_call_pattern_heuristics.swift
+++ b/test/IDE/complete_call_pattern_heuristics.swift
@@ -27,7 +27,7 @@ func testConstructor() {
 // CONSTRUCTOR: Begin completions
 // CONSTRUCTOR-NOT: Pattern/{{.*}}
 // CONSTRUCTOR-NOT: Decl[Constructor]
-// CONSTRUCTOR: Pattern/ExprSpecific: {#a: Int#}[#Int#]
+// CONSTRUCTOR: Pattern/Local/Flair[ExprSpecific]: {#a: Int#}[#Int#]
 // CONSTRUCTOR-NOT: Pattern/{{.*}}
 // CONSTRUCTOR-NOT: Decl[Constructor]
 // CONSTRUCTOR: End completions
@@ -38,7 +38,7 @@ func testArg2Name3() {
   firstArg(#^LABELED_FIRSTARG^#,
 // LABELED_FIRSTARG: Begin completions
 // LABELED_FIRSTARG-NOT: ['(']{#arg1: Int#}, {#arg2: Int#}[')'][#Void#];
-// LABELED_FIRSTARG-DAG: Pattern/ExprSpecific: {#arg1: Int#}[#Int#];
+// LABELED_FIRSTARG-DAG: Pattern/Local/Flair[ExprSpecific]: {#arg1: Int#}[#Int#];
 // LABELED_FIRSTARG-NOT: ['(']{#arg1: Int#}, {#arg2: Int#}[')'][#Void#];
 // LABELED_FIRSTARG: End completions
 

--- a/test/IDE/complete_concurrency_keyword.swift
+++ b/test/IDE/complete_concurrency_keyword.swift
@@ -22,7 +22,7 @@ enum Namespace {
 func testFunc() {
   #^STMT^#
 // STMT: Begin completions
-// STMT-DAG: Keyword/None:                       actor; name=actor
+// STMT-DAG: Keyword/None/Flair[RareKeyword]:    actor; name=actor
 // STMT-DAG: Keyword/None:                       await; name=await
 // STMT: End completion
 }

--- a/test/IDE/complete_constrained.swift
+++ b/test/IDE/complete_constrained.swift
@@ -118,9 +118,9 @@ struct Vegetarian: EatsFruit, EatsVegetables { }
 func testVegetarian(chef: Chef<Vegetarian>) {
   chef.cook(.#^CONDITIONAL_OVERLOAD_ARG^#)
 // CONDITIONAL_OVERLOAD_ARG: Begin completions, 4 items
-// CONDITIONAL_OVERLOAD_ARG-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:    apple[#Fruit#]; name=apple
+// CONDITIONAL_OVERLOAD_ARG-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:    apple[#Fruit#]; name=apple
 // CONDITIONAL_OVERLOAD_ARG-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]:    hash({#(self): Fruit#})[#(into: inout Hasher) -> Void#]; name=hash(self: Fruit)
-// CONDITIONAL_OVERLOAD_ARG-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:    broccoli[#Vegetable#]; name=broccoli
+// CONDITIONAL_OVERLOAD_ARG-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:    broccoli[#Vegetable#]; name=broccoli
 // CONDITIONAL_OVERLOAD_ARG-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]:    hash({#(self): Vegetable#})[#(into: inout Hasher) -> Void#]; name=hash(self: Vegetable)
 // CONDITIONAL_OVERLOAD_ARG: End completions
 
@@ -131,7 +131,7 @@ func testVegetarian(chef: Chef<Vegetarian>) {
 // Note: 'eat' is from an inapplicable constrained extension. We complete as if the user intends to addess that later
 //       (e.g. by adding the missing 'Meat' conformance to 'Vegetarian' - clearly not the intention here - but replace 'Meat' with 'Equatable').
 // CONDITIONAL_INAPPLICABLE_ARG: Begin completions, 2 items
-// CONDITIONAL_INAPPLICABLE_ARG-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: chicken[#Meat#]; name=chicken
+// CONDITIONAL_INAPPLICABLE_ARG-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: chicken[#Meat#]; name=chicken
 // CONDITIONAL_INAPPLICABLE_ARG-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Meat#})[#(into: inout Hasher) -> Void#]; name=hash(self: Meat)
 // CONDITIONAL_INAPPLICABLE_ARG: End completions
 }

--- a/test/IDE/complete_constructor.swift
+++ b/test/IDE/complete_constructor.swift
@@ -13,7 +13,7 @@ struct ImplicitConstructors1 {
 func testImplicitConstructors1() {
   ImplicitConstructors1#^IMPLICIT_CONSTRUCTORS_1^#
 // IMPLICIT_CONSTRUCTORS_1: Begin completions, 3 items
-// IMPLICIT_CONSTRUCTORS_1-DAG: Decl[Constructor]/CurrNominal: ()[#ImplicitConstructors1#]{{; name=.+$}}
+// IMPLICIT_CONSTRUCTORS_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ()[#ImplicitConstructors1#]{{; name=.+$}}
 // IMPLICIT_CONSTRUCTORS_1-DAG: Keyword[self]/CurrNominal:     .self[#ImplicitConstructors1.Type#]; name=self
 // IMPLICIT_CONSTRUCTORS_1-DAG: Keyword/CurrNominal:           .Type[#ImplicitConstructors1.Type#]; name=Type
 // IMPLICIT_CONSTRUCTORS_1: End completions
@@ -21,7 +21,7 @@ func testImplicitConstructors1() {
 func testImplicitConstructors1P() {
   ImplicitConstructors1(#^IMPLICIT_CONSTRUCTORS_1P^#
 // IMPLICIT_CONSTRUCTORS_1P: Begin completions, 1 items
-// IMPLICIT_CONSTRUCTORS_1P: Decl[Constructor]/CurrNominal: ['('][')'][#ImplicitConstructors1#]; name=
+// IMPLICIT_CONSTRUCTORS_1P: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['('][')'][#ImplicitConstructors1#]; name=
 // IMPLICIT_CONSTRUCTORS_1P: End completions
 }
 
@@ -32,9 +32,9 @@ struct ImplicitConstructors2 {
 func testImplicitConstructors2() {
   ImplicitConstructors2#^IMPLICIT_CONSTRUCTORS_2^#
 // IMPLICIT_CONSTRUCTORS_2: Begin completions, 5 items
-// IMPLICIT_CONSTRUCTORS_2-DAG: Decl[Constructor]/CurrNominal: ()[#ImplicitConstructors2#]{{; name=.+$}}
-// IMPLICIT_CONSTRUCTORS_2-DAG: Decl[Constructor]/CurrNominal: ({#instanceVar: Int#})[#ImplicitConstructors2#]{{; name=.+$}}
-// IMPLICIT_CONSTRUCTORS_2-DAG: Decl[Constructor]/CurrNominal: ()[#ImplicitConstructors2#]{{; name=.+$}}
+// IMPLICIT_CONSTRUCTORS_2-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ()[#ImplicitConstructors2#]{{; name=.+$}}
+// IMPLICIT_CONSTRUCTORS_2-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ({#instanceVar: Int#})[#ImplicitConstructors2#]{{; name=.+$}}
+// IMPLICIT_CONSTRUCTORS_2-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ()[#ImplicitConstructors2#]{{; name=.+$}}
 // IMPLICIT_CONSTRUCTORS_2-DAG: Keyword[self]/CurrNominal:     .self[#ImplicitConstructors2.Type#]; name=self
 // IMPLICIT_CONSTRUCTORS_2-DAG: Keyword/CurrNominal:           .Type[#ImplicitConstructors2.Type#]; name=Type
 // IMPLICIT_CONSTRUCTORS_2: End completions
@@ -42,9 +42,9 @@ func testImplicitConstructors2() {
 func testImplicitConstructors2P() {
   ImplicitConstructors2(#^IMPLICIT_CONSTRUCTORS_2P^#
 // IMPLICIT_CONSTRUCTORS_2P: Begin completions, 3 items
-// IMPLICIT_CONSTRUCTORS_2P-DAG: Decl[Constructor]/CurrNominal: ['('][')'][#ImplicitConstructors2#]; name=
-// IMPLICIT_CONSTRUCTORS_2P-DAG: Decl[Constructor]/CurrNominal: ['(']{#instanceVar: Int#}[')'][#ImplicitConstructors2#]{{; name=.+$}}
-// IMPLICIT_CONSTRUCTORS_2P-DAG: Decl[Constructor]/CurrNominal: ['('][')'][#ImplicitConstructors2#]; name=
+// IMPLICIT_CONSTRUCTORS_2P-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['('][')'][#ImplicitConstructors2#]; name=
+// IMPLICIT_CONSTRUCTORS_2P-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['(']{#instanceVar: Int#}[')'][#ImplicitConstructors2#]{{; name=.+$}}
+// IMPLICIT_CONSTRUCTORS_2P-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['('][')'][#ImplicitConstructors2#]; name=
 // IMPLICIT_CONSTRUCTORS_2P: End completions
 }
 
@@ -57,9 +57,9 @@ struct ExplicitConstructors1 {
 func testExplicitConstructors1() {
   ExplicitConstructors1#^EXPLICIT_CONSTRUCTORS_1^#
 // EXPLICIT_CONSTRUCTORS_1: Begin completions, 5 items
-// EXPLICIT_CONSTRUCTORS_1-DAG: Decl[Constructor]/CurrNominal: ()[#ExplicitConstructors1#]{{; name=.+$}}
-// EXPLICIT_CONSTRUCTORS_1-DAG: Decl[Constructor]/CurrNominal: ({#a: Int#})[#ExplicitConstructors1#]{{; name=.+$}}
-// EXPLICIT_CONSTRUCTORS_1-DAG: Decl[Constructor]/CurrNominal: ({#a: Int#}, {#b: Float#})[#ExplicitConstructors1#]{{; name=.+$}}
+// EXPLICIT_CONSTRUCTORS_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ()[#ExplicitConstructors1#]{{; name=.+$}}
+// EXPLICIT_CONSTRUCTORS_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ({#a: Int#})[#ExplicitConstructors1#]{{; name=.+$}}
+// EXPLICIT_CONSTRUCTORS_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ({#a: Int#}, {#b: Float#})[#ExplicitConstructors1#]{{; name=.+$}}
 // EXPLICIT_CONSTRUCTORS_1-DAG: Keyword[self]/CurrNominal: .self[#ExplicitConstructors1.Type#]; name=self
 // EXPLICIT_CONSTRUCTORS_1-DAG: Keyword/CurrNominal:       .Type[#ExplicitConstructors1.Type#]; name=Type
 // EXPLICIT_CONSTRUCTORS_1: End completions
@@ -67,18 +67,18 @@ func testExplicitConstructors1() {
 func testExplicitConstructors1P() {
   ExplicitConstructors1(#^EXPLICIT_CONSTRUCTORS_1P^#
 // EXPLICIT_CONSTRUCTORS_1P: Begin completions
-// EXPLICIT_CONSTRUCTORS_1P-NEXT: Decl[Constructor]/CurrNominal: ['('][')'][#ExplicitConstructors1#]; name=
-// EXPLICIT_CONSTRUCTORS_1P-NEXT: Decl[Constructor]/CurrNominal: ['(']{#a: Int#}[')'][#ExplicitConstructors1#]{{; name=.+$}}
-// EXPLICIT_CONSTRUCTORS_1P-NEXT: Decl[Constructor]/CurrNominal: ['(']{#a: Int#}, {#b: Float#}[')'][#ExplicitConstructors1#]{{; name=.+$}}
+// EXPLICIT_CONSTRUCTORS_1P-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['('][')'][#ExplicitConstructors1#]; name=
+// EXPLICIT_CONSTRUCTORS_1P-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['(']{#a: Int#}[')'][#ExplicitConstructors1#]{{; name=.+$}}
+// EXPLICIT_CONSTRUCTORS_1P-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['(']{#a: Int#}, {#b: Float#}[')'][#ExplicitConstructors1#]{{; name=.+$}}
 // EXPLICIT_CONSTRUCTORS_1P-NEXT: End completions
 }
 
 ExplicitConstructors1#^EXPLICIT_CONSTRUCTORS_2^#
 
 // EXPLICIT_CONSTRUCTORS_2: Begin completions, 5 items
-// EXPLICIT_CONSTRUCTORS_2-DAG: Decl[Constructor]/CurrNominal: ()[#ExplicitConstructors1#]
-// EXPLICIT_CONSTRUCTORS_2-DAG: Decl[Constructor]/CurrNominal: ({#a: Int#})[#ExplicitConstructors1#]
-// EXPLICIT_CONSTRUCTORS_2-DAG: Decl[Constructor]/CurrNominal: ({#a: Int#}, {#b: Float#})[#ExplicitConstructors1#]
+// EXPLICIT_CONSTRUCTORS_2-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ()[#ExplicitConstructors1#]
+// EXPLICIT_CONSTRUCTORS_2-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ({#a: Int#})[#ExplicitConstructors1#]
+// EXPLICIT_CONSTRUCTORS_2-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ({#a: Int#}, {#b: Float#})[#ExplicitConstructors1#]
 // EXPLICIT_CONSTRUCTORS_2-DAG: Keyword[self]/CurrNominal:     .self[#ExplicitConstructors1.Type#]; name=self
 // EXPLICIT_CONSTRUCTORS_2-DAG: Keyword/CurrNominal:           .Type[#ExplicitConstructors1.Type#]; name=Type
 // EXPLICIT_CONSTRUCTORS_2: End completions
@@ -86,8 +86,8 @@ ExplicitConstructors1#^EXPLICIT_CONSTRUCTORS_2^#
 ExplicitConstructors1(#^EXPLICIT_CONSTRUCTORS_2P^#
 
 // EXPLICIT_CONSTRUCTORS_2P: Begin completions
-// EXPLICIT_CONSTRUCTORS_2P-DAG: Decl[Constructor]/CurrNominal: ['(']{#a: Int#}[')'][#ExplicitConstructors1#]
-// EXPLICIT_CONSTRUCTORS_2P-DAG: Decl[Constructor]/CurrNominal: ['(']{#a: Int#}, {#b: Float#}[')'][#ExplicitConstructors1#]
+// EXPLICIT_CONSTRUCTORS_2P-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['(']{#a: Int#}[')'][#ExplicitConstructors1#]
+// EXPLICIT_CONSTRUCTORS_2P-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['(']{#a: Int#}, {#b: Float#}[')'][#ExplicitConstructors1#]
 // EXPLICIT_CONSTRUCTORS_2P: End completions
 
 
@@ -100,8 +100,8 @@ struct ExplicitConstructors3 {
 func testExplicitConstructors3P() {
   ExplicitConstructors3(#^EXPLICIT_CONSTRUCTORS_3P^#
 // EXPLICIT_CONSTRUCTORS_3P: Begin completions
-// EXPLICIT_CONSTRUCTORS_3P-DAG: Decl[Constructor]/CurrNominal: ['(']{#(a): Int#}[')'][#ExplicitConstructors3#]{{; name=.+$}}
-// EXPLICIT_CONSTRUCTORS_3P-DAG: Decl[Constructor]/CurrNominal: ['(']{#a: Int#}, {#b: Float#}[')'][#ExplicitConstructors3#]{{; name=.+$}}
+// EXPLICIT_CONSTRUCTORS_3P-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['(']{#(a): Int#}[')'][#ExplicitConstructors3#]{{; name=.+$}}
+// EXPLICIT_CONSTRUCTORS_3P-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['(']{#a: Int#}, {#b: Float#}[')'][#ExplicitConstructors3#]{{; name=.+$}}
 // EXPLICIT_CONSTRUCTORS_3P: End completions
 }
 
@@ -114,8 +114,8 @@ struct ExplicitConstructorsSelector1 {
 func testExplicitConstructorsSelector1() {
   ExplicitConstructorsSelector1#^EXPLICIT_CONSTRUCTORS_SELECTOR_1^#
 // EXPLICIT_CONSTRUCTORS_SELECTOR_1: Begin completions, 4 items
-// EXPLICIT_CONSTRUCTORS_SELECTOR_1-DAG: Decl[Constructor]/CurrNominal: ({#int: Int#})[#ExplicitConstructorsSelector1#]{{; name=.+$}}
-// EXPLICIT_CONSTRUCTORS_SELECTOR_1-DAG: Decl[Constructor]/CurrNominal: ({#int: Int#}, {#andFloat: Float#})[#ExplicitConstructorsSelector1#]{{; name=.+$}}
+// EXPLICIT_CONSTRUCTORS_SELECTOR_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ({#int: Int#})[#ExplicitConstructorsSelector1#]{{; name=.+$}}
+// EXPLICIT_CONSTRUCTORS_SELECTOR_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ({#int: Int#}, {#andFloat: Float#})[#ExplicitConstructorsSelector1#]{{; name=.+$}}
 // EXPLICIT_CONSTRUCTORS_SELECTOR_1-DAG: Keyword[self]/CurrNominal:     .self[#ExplicitConstructorsSelector1.Type#]; name=self
 // EXPLICIT_CONSTRUCTORS_SELECTOR_1-DAG: Keyword/CurrNominal:           .Type[#ExplicitConstructorsSelector1.Type#]; name=Type
 // EXPLICIT_CONSTRUCTORS_SELECTOR_1: End completions
@@ -142,10 +142,10 @@ struct ExplicitConstructorsSelector2 {
 func testExplicitConstructorsSelector2() {
   ExplicitConstructorsSelector2#^EXPLICIT_CONSTRUCTORS_SELECTOR_2^#
 // EXPLICIT_CONSTRUCTORS_SELECTOR_2: Begin completions, 6 items
-// EXPLICIT_CONSTRUCTORS_SELECTOR_2-DAG: Decl[Constructor]/CurrNominal: ({#noArgs: ()#})[#ExplicitConstructorsSelector2#]{{; name=.+$}}
-// EXPLICIT_CONSTRUCTORS_SELECTOR_2-DAG: Decl[Constructor]/CurrNominal: ({#(a): Int#})[#ExplicitConstructorsSelector2#]{{; name=.+$}}
-// EXPLICIT_CONSTRUCTORS_SELECTOR_2-DAG: Decl[Constructor]/CurrNominal: ({#(a): Int#}, {#withFloat: Float#})[#ExplicitConstructorsSelector2#]{{; name=.+$}}
-// EXPLICIT_CONSTRUCTORS_SELECTOR_2-DAG: Decl[Constructor]/CurrNominal: ({#int: Int#}, {#(b): Float#})[#ExplicitConstructorsSelector2#]{{; name=.+$}}
+// EXPLICIT_CONSTRUCTORS_SELECTOR_2-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ({#noArgs: ()#})[#ExplicitConstructorsSelector2#]{{; name=.+$}}
+// EXPLICIT_CONSTRUCTORS_SELECTOR_2-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ({#(a): Int#})[#ExplicitConstructorsSelector2#]{{; name=.+$}}
+// EXPLICIT_CONSTRUCTORS_SELECTOR_2-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ({#(a): Int#}, {#withFloat: Float#})[#ExplicitConstructorsSelector2#]{{; name=.+$}}
+// EXPLICIT_CONSTRUCTORS_SELECTOR_2-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ({#int: Int#}, {#(b): Float#})[#ExplicitConstructorsSelector2#]{{; name=.+$}}
 // EXPLICIT_CONSTRUCTORS_SELECTOR_2-DAG: Keyword[self]/CurrNominal:     .self[#ExplicitConstructorsSelector2.Type#]; name=self
 // EXPLICIT_CONSTRUCTORS_SELECTOR_2-DAG: Keyword/CurrNominal:           .Type[#ExplicitConstructorsSelector2.Type#]; name=Type
 // EXPLICIT_CONSTRUCTORS_SELECTOR_2: End completions
@@ -173,8 +173,8 @@ func testExplicitConstructorsBaseDerived1() {
   ExplicitConstructorsDerived1#^EXPLICIT_CONSTRUCTORS_BASE_DERIVED_1^#
 }
 // EXPLICIT_CONSTRUCTORS_BASE_DERIVED_1: Begin completions, 4 items
-// EXPLICIT_CONSTRUCTORS_BASE_DERIVED_1-DAG: Decl[Constructor]/CurrNominal:  ()[#ExplicitConstructorsDerived1#]{{; name=.+$}}
-// EXPLICIT_CONSTRUCTORS_BASE_DERIVED_1-DAG: Decl[Constructor]/CurrNominal:  ({#a: Int#})[#ExplicitConstructorsDerived1#]{{; name=.+$}}
+// EXPLICIT_CONSTRUCTORS_BASE_DERIVED_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:  ()[#ExplicitConstructorsDerived1#]{{; name=.+$}}
+// EXPLICIT_CONSTRUCTORS_BASE_DERIVED_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:  ({#a: Int#})[#ExplicitConstructorsDerived1#]{{; name=.+$}}
 // EXPLICIT_CONSTRUCTORS_BASE_DERIVED_1-DAG: Keyword[self]/CurrNominal:     .self[#ExplicitConstructorsDerived1.Type#]; name=self
 // EXPLICIT_CONSTRUCTORS_BASE_DERIVED_1-DAG: Keyword/CurrNominal:           .Type[#ExplicitConstructorsDerived1.Type#]; name=Type
 // EXPLICIT_CONSTRUCTORS_BASE_DERIVED_1: End completions
@@ -234,16 +234,16 @@ struct ExplicitConstructorsDerived3 {
 func testHaveRParen1() {
   ImplicitConstructors1(#^HAVE_RPAREN_1^#)
 // HAVE_RPAREN_1: Begin completions, 1 items
-// HAVE_RPAREN_1: Decl[Constructor]/CurrNominal: ['('][')'][#ImplicitConstructors1#]; name=
+// HAVE_RPAREN_1: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['('][')'][#ImplicitConstructors1#]; name=
 // HAVE_RPAREN_1: End completions
 }
 
 func testHaveRParen2() {
   ImplicitConstructors2(#^HAVE_RPAREN_2^#)
 // HAVE_RPAREN_2: Begin completions, 3 items
-// HAVE_RPAREN_2-DAG: Decl[Constructor]/CurrNominal: ['('][')'][#ImplicitConstructors2#]; name=
-// HAVE_RPAREN_2-DAG: Decl[Constructor]/CurrNominal: ['(']{#instanceVar: Int#}[')'][#ImplicitConstructors2#]{{; name=.+$}}
-// HAVE_RPAREN_2-DAG: Decl[Constructor]/CurrNominal: ['('][')'][#ImplicitConstructors2#]; name=
+// HAVE_RPAREN_2-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['('][')'][#ImplicitConstructors2#]; name=
+// HAVE_RPAREN_2-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['(']{#instanceVar: Int#}[')'][#ImplicitConstructors2#]{{; name=.+$}}
+// HAVE_RPAREN_2-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['('][')'][#ImplicitConstructors2#]; name=
 // HAVE_RPAREN_2: End completions
 }
 
@@ -265,8 +265,8 @@ func testHasDefaultInitFromProtocol() {
   ConformsToProtDefaultInit.#^DEFAULT_INIT_FROM_PROT_DOT?check=DEFAULT_INIT_FROM_PROT^#
   ConformsToProtDefaultInit(#^DEFAULT_INIT_FROM_PROT_PAREN?check=DEFAULT_INIT_FROM_PROT^#
 
-// DEFAULT_INIT_FROM_PROT-DAG: Decl[Constructor]/CurrNominal:  {{.+}}{#bar: Int#}
-// DEFAULT_INIT_FROM_PROT-DAG: Decl[Constructor]/Super:        {{.+}}{#foo: Int#}
+// DEFAULT_INIT_FROM_PROT-DAG: Decl[Constructor]/CurrNominal{{.*}}:  {{.+}}{#bar: Int#}
+// DEFAULT_INIT_FROM_PROT-DAG: Decl[Constructor]/Super{{.*}}:        {{.+}}{#foo: Int#}
 }
 
 class WithAlias1 {
@@ -277,14 +277,14 @@ typealias Alias1 = WithAlias1
 func testWithAlias1() {
   Alias1#^WITH_ALIAS_1^#
 }
-// WITH_ALIAS_1: Decl[Constructor]/CurrNominal:      ({#working: Int#})[#Alias1#];
+// WITH_ALIAS_1: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#working: Int#})[#Alias1#];
 
 struct ClosureInInit1 {
   struct S {init(_: Int) {}}
   var prop1: S = {
     return S(#^CLOSURE_IN_INIT_1^#
   }
-// CLOSURE_IN_INIT_1: Decl[Constructor]/CurrNominal{{(/TypeRelation\[Identical\])?}}:      ['(']{#Int#}[')'][#S#];
+// CLOSURE_IN_INIT_1: Decl[Constructor]/CurrNominal/Flair[ArgLabels]{{(/TypeRelation\[Identical\])?}}:      ['(']{#Int#}[')'][#S#];
   var prop2: S = {
     return S(#^CLOSURE_IN_INIT_2?check=CLOSURE_IN_INIT_1^#
   }()
@@ -312,9 +312,9 @@ public class AvailableTest {
 func testAvailable() {
   let _ = AvailableTest(#^AVAILABLE_1^#
 // AVAILABLE_1: Begin completions, 3 items
-// AVAILABLE_1-DAG: Decl[Constructor]/CurrNominal:      ['(']{#opt: Int#}[')'][#AvailableTest?#]; name=opt: Int
-// AVAILABLE_1-DAG: Decl[Constructor]/CurrNominal:      ['(']{#normal1: Int#}[')'][#AvailableTest#]; name=normal1: Int
-// AVAILABLE_1-DAG: Decl[Constructor]/CurrNominal:      ['(']{#normal2: Int#}[')'][#AvailableTest#]; name=normal2: Int
+// AVAILABLE_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#opt: Int#}[')'][#AvailableTest?#]; name=opt: Int
+// AVAILABLE_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#normal1: Int#}[')'][#AvailableTest#]; name=normal1: Int
+// AVAILABLE_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#normal2: Int#}[')'][#AvailableTest#]; name=normal2: Int
 // AVAILABLE_1: End completions
 
   let _ = AvailableTest.init(#^AVAILABLE_2?check=AVAILABLE_1^#
@@ -336,8 +336,8 @@ func testDependentTypeInClosure() {
 
   let _ = DependentTypeInClosure(#^DEPENDENT_IN_CLOSURE_1^#)
 // DEPENDENT_IN_CLOSURE_1: Begin completions
-// DEPENDENT_IN_CLOSURE_1-DAG: Decl[Constructor]/CurrNominal:      ['(']{#(arg): _#}, {#fn: (_.Content) -> Void##(_.Content) -> Void#}[')'][#DependentTypeInClosure<_>#];
-// DEPENDENT_IN_CLOSURE_1-DAG: Decl[Constructor]/CurrNominal:      ['(']{#arg: _#}, {#fn: () -> _.Content##() -> _.Content#}[')'][#DependentTypeInClosure<_>#];
+// DEPENDENT_IN_CLOSURE_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#(arg): _#}, {#fn: (_.Content) -> Void##(_.Content) -> Void#}[')'][#DependentTypeInClosure<_>#];
+// DEPENDENT_IN_CLOSURE_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#arg: _#}, {#fn: () -> _.Content##() -> _.Content#}[')'][#DependentTypeInClosure<_>#];
 // DEPENDENT_IN_CLOSURE_1: End completions
 
   let _ = DependentTypeInClosure.#^DEPENDENT_IN_CLOSURE_2^#
@@ -357,7 +357,7 @@ extension InitWithUnresolved where Self.Data: Comparable {
 func testInitWithUnresolved() {
   let _ = InitWithUnresolved(#^INIT_WITH_UNRESOLVEDTYPE_1^#
 // INIT_WITH_UNRESOLVEDTYPE_1: Begin completions, 2 items
-// INIT_WITH_UNRESOLVEDTYPE_1-DAG: Decl[Constructor]/CurrNominal:      ['(']{#arg: _#}, {#fn: (_.Content) -> Void##(_.Content) -> Void#}[')'][#InitWithUnresolved<_>#];
-// INIT_WITH_UNRESOLVEDTYPE_1-DAG: Decl[Constructor]/CurrNominal:      ['(']{#arg2: _#}[')'][#InitWithUnresolved<_>#];
+// INIT_WITH_UNRESOLVEDTYPE_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#arg: _#}, {#fn: (_.Content) -> Void##(_.Content) -> Void#}[')'][#InitWithUnresolved<_>#];
+// INIT_WITH_UNRESOLVEDTYPE_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#arg2: _#}[')'][#InitWithUnresolved<_>#];
 // INIT_WITH_UNRESOLVEDTYPE_1: End completions
 }

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -165,7 +165,7 @@ func rdar22834017() {
   Foo(#^RDAR_22834017^#)
 }
 // RDAR_22834017: Begin completions, 1 items
-// RDAR_22834017: Decl[Constructor]/CurrNominal:      ['(']{#a: <<error type>>#}, {#b: <<error type>>#}, {#c: <<error type>>#}[')'][#Foo#];
+// RDAR_22834017: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#a: <<error type>>#}, {#b: <<error type>>#}, {#c: <<error type>>#}[')'][#Foo#];
 // RDAR_22834017: End completions
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RDAR_23173692 | %FileCheck %s -check-prefix=RDAR_23173692
@@ -300,7 +300,7 @@ func test_28188259(x: ((Int) -> Void) -> Void) {
   x({_ in }#^RDAR_28188259^#)
 }
 // RDAR_28188259: Begin completions
-// RDAR_28188259-DAG: Pattern/CurrModule:                 ({#Int#})[#Void#]; name=(Int)
+// RDAR_28188259-DAG: Pattern/CurrModule/Flair[ArgLabels]: ({#Int#})[#Void#]; name=(Int)
 // RDAR_28188259-DAG: Keyword[self]/CurrNominal:          .self[#(Int) -> ()#]; name=self
 // RDAR_28188259: End completions
 

--- a/test/IDE/complete_default_arguments.swift
+++ b/test/IDE/complete_default_arguments.swift
@@ -66,16 +66,16 @@ func testDefaultArgs2() {
   freeFuncWithDefaultArgs1#^DEFAULT_ARGS_2^#
 }
 // DEFAULT_ARGS_2: Begin completions
-// DEFAULT_ARGS_2-DAG: Decl[FreeFunction]/CurrModule:      ({#(a): Int#})[#Void#]{{; name=.+$}}
-// DEFAULT_ARGS_2-DAG: Decl[FreeFunction]/CurrModule:      ({#(a): Int#}, {#b: Int#})[#Void#]{{; name=.+$}}
+// DEFAULT_ARGS_2-DAG: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]:      ({#(a): Int#})[#Void#]{{; name=.+$}}
+// DEFAULT_ARGS_2-DAG: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]:      ({#(a): Int#}, {#b: Int#})[#Void#]{{; name=.+$}}
 // DEFAULT_ARGS_2: End completions
 
 func testDefaultArgs3() {
   freeFuncWithDefaultArgs3#^DEFAULT_ARGS_3^#
 }
 // DEFAULT_ARGS_3: Begin completions
-// DEFAULT_ARGS_3-DAG: Decl[FreeFunction]/CurrModule:      ()[#Void#]{{; name=.+$}}
-// DEFAULT_ARGS_3-DAG: Decl[FreeFunction]/CurrModule:      ({#a: Int#})[#Void#]{{; name=.+$}}
+// DEFAULT_ARGS_3-DAG: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]:      ()[#Void#]{{; name=.+$}}
+// DEFAULT_ARGS_3-DAG: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]:      ({#a: Int#})[#Void#]{{; name=.+$}}
 // DEFAULT_ARGS_3: End completions
 
 func testDefaultArgs4(_ x: A) {
@@ -90,8 +90,8 @@ func testDefaultArgs5(_ x: A) {
   x.methodWithDefaultArgs1#^DEFAULT_ARGS_5^#
 }
 // DEFAULT_ARGS_5: Begin completions
-// DEFAULT_ARGS_5-DAG: Decl[InstanceMethod]/CurrNominal:      ()[#Void#]{{; name=.+$}}
-// DEFAULT_ARGS_5-DAG: Decl[InstanceMethod]/CurrNominal:      ({#a: Int#})[#Void#]{{; name=.+$}}
+// DEFAULT_ARGS_5-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:      ()[#Void#]{{; name=.+$}}
+// DEFAULT_ARGS_5-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:      ({#a: Int#})[#Void#]{{; name=.+$}}
 // DEFAULT_ARGS_5: End completions
 
 func testDefaultArgs6() {
@@ -107,8 +107,8 @@ func testDefaultArgs7() {
   B#^DEFAULT_ARGS_7^#
 }
 // DEFAULT_ARGS_7: Begin completions
-// DEFAULT_ARGS_7-DAG: Decl[Constructor]/CurrNominal:      ()[#B#]{{; name=.+$}}
-// DEFAULT_ARGS_7-DAG: Decl[Constructor]/CurrNominal:      ({#a: Int#})[#B#]{{; name=.+$}}
+// DEFAULT_ARGS_7-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ()[#B#]{{; name=.+$}}
+// DEFAULT_ARGS_7-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#a: Int#})[#B#]{{; name=.+$}}
 // DEFAULT_ARGS_7: End completions
 
 func testDefaultArgs8(_ x: C1) {

--- a/test/IDE/complete_dynamic_lookup.swift
+++ b/test/IDE/complete_dynamic_lookup.swift
@@ -463,7 +463,7 @@ func testAnyObject11_(_ dl: AnyObject) {
   dl.returnsObjcClass!(#^DL_FUNC_NAME_PAREN_1^#
 }
 // DL_FUNC_NAME_PAREN_1: Begin completions
-// DL_FUNC_NAME_PAREN_1-DAG: Decl[InstanceMethod]/CurrNominal: ['(']{#(i): Int#}[')'][#TopLevelObjcClass#]{{; name=.+$}}
+// DL_FUNC_NAME_PAREN_1-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ['(']{#(i): Int#}[')'][#TopLevelObjcClass#]{{; name=.+$}}
 // DL_FUNC_NAME_PAREN_1: End completions
 
 func testAnyObject12(_ dl: AnyObject) {
@@ -475,7 +475,7 @@ func testAnyObject13(_ dl: AnyObject) {
   dl.returnsObjcClass!#^DL_FUNC_NAME_BANG_1^#
 }
 // DL_FUNC_NAME_BANG_1: Begin completions
-// DL_FUNC_NAME_BANG_1-NEXT: Decl[InstanceMethod]/CurrNominal: ({#(i): Int#})[#TopLevelObjcClass#]
+// DL_FUNC_NAME_BANG_1-NEXT: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ({#(i): Int#})[#TopLevelObjcClass#]
 // DL_FUNC_NAME_BANG_1-NEXT: Keyword[self]/CurrNominal: .self[#(Int) -> TopLevelObjcClass#]; name=self
 // DL_FUNC_NAME_BANG_1-NEXT: End completions
 

--- a/test/IDE/complete_enum_elements.swift
+++ b/test/IDE/complete_enum_elements.swift
@@ -14,9 +14,9 @@ enum FooEnum: CaseIterable {
 }
 
 // FOO_ENUM_TYPE_CONTEXT: Begin completions
-// FOO_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: .Foo1[#FooEnum#]{{; name=.+$}}
-// FOO_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: .Foo2[#FooEnum#]{{; name=.+$}}
-// FOO_ENUM_TYPE_CONTEXT-DAG: Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: .alias1[#FooEnum#]; name=alias1
+// FOO_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: .Foo1[#FooEnum#]{{; name=.+$}}
+// FOO_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: .Foo2[#FooEnum#]{{; name=.+$}}
+// FOO_ENUM_TYPE_CONTEXT-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: .alias1[#FooEnum#]; name=alias1
 // FOO_ENUM_TYPE_CONTEXT: End completions
 
 // FOO_ENUM_NO_DOT: Begin completions
@@ -53,9 +53,9 @@ enum FooEnum: CaseIterable {
 // FOO_ENUM_DOT_CONTEXT-NEXT: End completions
 
 // FOO_ENUM_DOT_ELEMENTS: Begin completions, 6 items
-// FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: Foo1[#FooEnum#]{{; name=.+$}}
-// FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: Foo2[#FooEnum#]{{; name=.+$}}
-// FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: alias1[#FooEnum#]; name=alias1
+// FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Foo1[#FooEnum#]{{; name=.+$}}
+// FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Foo2[#FooEnum#]{{; name=.+$}}
+// FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: alias1[#FooEnum#]; name=alias1
 // FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): FooEnum#})[#(into: inout Hasher) -> Void#]; name=hash(self: FooEnum)
 // FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[TypeAlias]/CurrNominal: AllCases[#[FooEnum]#]; name=AllCases
 // FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[StaticVar]/CurrNominal:        allCases[#[FooEnum]#]; name=allCases
@@ -202,8 +202,8 @@ enum QuxEnum : Int {
 }
 
 // QUX_ENUM_TYPE_CONTEXT: Begin completions
-// QUX_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: .Qux1[#QuxEnum#]{{; name=.+$}}
-// QUX_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: .Qux2[#QuxEnum#]{{; name=.+$}}
+// QUX_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: .Qux1[#QuxEnum#]{{; name=.+$}}
+// QUX_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: .Qux2[#QuxEnum#]{{; name=.+$}}
 // QUX_ENUM_TYPE_CONTEXT: End completions
 
 // QUX_ENUM_NO_DOT: Begin completions, 7 items
@@ -364,16 +364,16 @@ func testWithInvalid1() {
 // UNRESOLVED_1:  Begin completions
 // UNRESOLVED_1-NOT:  Baz
 // UNRESOLVED_1-NOT:  Bar
-// UNRESOLVED_1-DAG:  Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     Qux1[#QuxEnum#]; name=Qux1
-// UNRESOLVED_1-DAG:  Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     Qux2[#QuxEnum#]; name=Qux2
+// UNRESOLVED_1-DAG:  Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     Qux1[#QuxEnum#]; name=Qux1
+// UNRESOLVED_1-DAG:  Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     Qux2[#QuxEnum#]; name=Qux2
 // UNRESOLVED_1-NOT:  Okay
 }
 
 func testUnqualified1(x: QuxEnum) {
   _ = x == .Qux1 || x == .#^UNRESOLVED_2^#Qux2
   // UNRESOLVED_2: Begin completions
-  // UNRESOLVED_2-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     Qux1[#QuxEnum#]; name=Qux1
-  // UNRESOLVED_2-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     Qux2[#QuxEnum#]; name=Qux2
+  // UNRESOLVED_2-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     Qux1[#QuxEnum#]; name=Qux1
+  // UNRESOLVED_2-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     Qux2[#QuxEnum#]; name=Qux2
   // UNRESOLVED_2-DAG: Decl[TypeAlias]/CurrNominal:                                RawValue[#Int#]; name=RawValue
   // UNRESOLVED_2-DAG: Decl[Constructor]/CurrNominal:                              init({#rawValue: Int#})[#QuxEnum?#]; name=init(rawValue: Int)
   // UNRESOLVED_2-DAG: Decl[InstanceMethod]/Super/IsSystem/TypeRelation[Invalid]:  hash({#(self): QuxEnum#})[#(into: inout Hasher) -> Void#]; name=hash(self: QuxEnum)

--- a/test/IDE/complete_enum_elements.swift
+++ b/test/IDE/complete_enum_elements.swift
@@ -210,7 +210,7 @@ enum QuxEnum : Int {
 // QUX_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:    .Qux1[#QuxEnum#]{{; name=.+$}}
 // QUX_ENUM_NO_DOT-NEXT: Decl[EnumElement]/CurrNominal:    .Qux2[#QuxEnum#]{{; name=.+$}}
 // QUX_ENUM_NO_DOT-NEXT: Decl[TypeAlias]/CurrNominal:      .RawValue[#Int#]{{; name=.+$}}
-// QUX_ENUM_NO_DOT-NEXT: Decl[Constructor]/CurrNominal:    ({#rawValue: Int#})[#QuxEnum?#]{{; name=.+$}}
+// QUX_ENUM_NO_DOT-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:    ({#rawValue: Int#})[#QuxEnum?#]{{; name=.+$}}
 // QUX_ENUM_NO_DOT-NEXT: Decl[InstanceMethod]/Super/IsSystem: .hash({#(self): QuxEnum#})[#(into: inout Hasher) -> Void#]{{; name=.+$}}
 // QUX_ENUM_NO_DOT-NEXT: Keyword[self]/CurrNominal:        .self[#QuxEnum.Type#]; name=self
 // QUX_ENUM_NO_DOT-NEXT: Keyword/CurrNominal:              .Type[#QuxEnum.Type#]; name=Type

--- a/test/IDE/complete_exception.swift
+++ b/test/IDE/complete_exception.swift
@@ -124,7 +124,7 @@ func test004() {
 func test005() {
   do {} catch Error4.E2#^CATCH3^#
 // CATCH3: Begin completions
-// CATCH3: Pattern/CurrModule:               ({#Int32#})[#Error4#]{{; name=.+$}}
+// CATCH3: Pattern/CurrModule/Flair[ArgLabels]:               ({#Int32#})[#Error4#]{{; name=.+$}}
 // CATCH3: End completions
 }
 

--- a/test/IDE/complete_expr_after_paren.swift
+++ b/test/IDE/complete_expr_after_paren.swift
@@ -40,20 +40,20 @@ class MyClass: Base, MyProtocol {
 func testConstructer() {
   MyClass(#^INITIALIZER^#)
 // INITIALIZER: Begin completions, 4 items
-// INITIALIZER-DAG: Decl[Constructor]/CurrNominal:      ['(']{#init1: Int#}[')'][#MyClass#];
-// INITIALIZER-DAG: Decl[Constructor]/CurrNominal:      ['(']{#init2: Int#}[')'][#MyClass#];
-// INITIALIZER-DAG: Decl[Constructor]/CurrNominal:      ['(']{#init3: Int#}[')'][#MyClass#];
-// INITIALIZER-DAG: Decl[Constructor]/CurrNominal:      ['(']{#init4: Int#}[')'][#MyClass#];
+// INITIALIZER-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#init1: Int#}[')'][#MyClass#];
+// INITIALIZER-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#init2: Int#}[')'][#MyClass#];
+// INITIALIZER-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#init3: Int#}[')'][#MyClass#];
+// INITIALIZER-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#init4: Int#}[')'][#MyClass#];
 // INITIALIZER: End completions
 }
 
 func testMethod(obj: MyClass) {
   obj.method(#^METHOD^#)
 // METHOD: Begin completions, 4 items
-// METHOD-DAG: Decl[InstanceMethod]/CurrNominal:   ['(']{#method1: Int#}[')'][#Void#];
-// METHOD-DAG: Decl[InstanceMethod]/CurrNominal:   ['(']{#method2: Int#}[')'][#Void#];
-// METHOD-DAG: Decl[InstanceMethod]/CurrNominal:   ['(']{#method3: Int#}[')'][#Void#];
-// METHOD-DAG: Decl[InstanceMethod]/CurrNominal:   ['(']{#method4: Int#}[')'][#Void#];
+// METHOD-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:   ['(']{#method1: Int#}[')'][#Void#];
+// METHOD-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:   ['(']{#method2: Int#}[')'][#Void#];
+// METHOD-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:   ['(']{#method3: Int#}[')'][#Void#];
+// METHOD-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:   ['(']{#method4: Int#}[')'][#Void#];
 // METHOD: End completions
 }
 
@@ -73,8 +73,8 @@ struct MyStruct: HasUnavailable {
 func testUnavailable(val: MyStruct) {
   val.method(#^AVAILABILITY^#)
 // AVAILABILITY: Begin completions, 2 items
-// AVAILABILITY-DAG: Decl[InstanceMethod]/CurrNominal:   ['(']{#method2: Int#}[')'][#Void#];
-// AVAILABILITY-DAG: Decl[InstanceMethod]/Super:         ['(']{#method1: Int#}[')'][#Void#];
+// AVAILABILITY-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:   ['(']{#method2: Int#}[')'][#Void#];
+// AVAILABILITY-DAG: Decl[InstanceMethod]/Super/Flair[ArgLabels]:         ['(']{#method1: Int#}[')'][#Void#];
 // AVAILABILITY: End completions
 }
 
@@ -85,7 +85,7 @@ struct TestStatic {
 func testStaticFunc() {
   TestStatic.method(#^STATIC^#)
 // STATIC: Begin completions
-// STATIC-DAG: Decl[StaticMethod]/CurrNominal:     ['(']{#(self): TestStatic#}[')'][#() -> Void#];
-// STATIC-DAG: Decl[InstanceMethod]/CurrNominal:   ['(']{#(self): TestStatic#}[')'][#() -> Void#];
+// STATIC-DAG: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]:     ['(']{#(self): TestStatic#}[')'][#() -> Void#];
+// STATIC-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:   ['(']{#(self): TestStatic#}[')'][#() -> Void#];
 // STATIC: End completions
 }

--- a/test/IDE/complete_from_clang_framework.swift
+++ b/test/IDE/complete_from_clang_framework.swift
@@ -230,7 +230,7 @@ func testCompleteModuleQualifiedBar1() {
 func testCompleteFunctionCall1() {
   fooFunc1#^FUNCTION_CALL_1^#
 // FUNCTION_CALL_1: Begin completions
-// FUNCTION_CALL_1-NEXT: Decl[FreeFunction]/OtherModule[Foo]: ({#(a): Int32#})[#Int32#]{{; name=.+$}}
+// FUNCTION_CALL_1-NEXT: Decl[FreeFunction]/OtherModule[Foo]/Flair[ArgLabels]: ({#(a): Int32#})[#Int32#]{{; name=.+$}}
 // FUNCTION_CALL_1-NEXT: Keyword[self]/CurrNominal: .self[#(Int32) -> Int32#]; name=self
 // FUNCTION_CALL_1-NEXT: End completions
 }
@@ -238,7 +238,7 @@ func testCompleteFunctionCall1() {
 func testCompleteFunctionCall2() {
   fooFunc1AnonymousParam#^FUNCTION_CALL_2^#
 // FUNCTION_CALL_2: Begin completions
-// FUNCTION_CALL_2-NEXT: Decl[FreeFunction]/OtherModule[Foo]: ({#Int32#})[#Int32#]{{; name=.+$}}
+// FUNCTION_CALL_2-NEXT: Decl[FreeFunction]/OtherModule[Foo]/Flair[ArgLabels]: ({#Int32#})[#Int32#]{{; name=.+$}}
 // FUNCTION_CALL_2-NEXT: Keyword[self]/CurrNominal: .self[#(Int32) -> Int32#]; name=self
 // FUNCTION_CALL_2-NEXT: End completions
 }
@@ -246,8 +246,8 @@ func testCompleteFunctionCall2() {
 func testCompleteStructMembers1() {
   FooStruct1#^CLANG_STRUCT_MEMBERS_1^#
 // CLANG_STRUCT_MEMBERS_1: Begin completions
-// CLANG_STRUCT_MEMBERS_1-NEXT: Decl[Constructor]/CurrNominal: ()[#FooStruct1#]{{; name=.+$}}
-// CLANG_STRUCT_MEMBERS_1-NEXT: Decl[Constructor]/CurrNominal: ({#x: Int32#}, {#y: Double#})[#FooStruct1#]{{; name=.+$}}
+// CLANG_STRUCT_MEMBERS_1-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ()[#FooStruct1#]{{; name=.+$}}
+// CLANG_STRUCT_MEMBERS_1-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ({#x: Int32#}, {#y: Double#})[#FooStruct1#]{{; name=.+$}}
 // CLANG_STRUCT_MEMBERS_1-NEXT: Keyword[self]/CurrNominal: .self[#FooStruct1.Type#]; name=self
 // CLANG_STRUCT_MEMBERS_1-NEXT: Keyword/CurrNominal: .Type[#FooStruct1.Type#]; name=Type
 // CLANG_STRUCT_MEMBERS_1-NEXT: End completions
@@ -261,12 +261,12 @@ func testCompleteClassMembers1() {
 // CLANG_CLASS_MEMBERS_1-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooBaseInstanceFunc0({#(self): FooClassBase#})[#() -> Void#]{{; name=.+$}}
 // CLANG_CLASS_MEMBERS_1-NEXT: Decl[StaticMethod]/CurrNominal:     .fooBaseInstanceFunc1({#(anObject): Any!#})[#FooClassBase!#]{{; name=.+$}}
 // CLANG_CLASS_MEMBERS_1-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooBaseInstanceFunc1({#(self): FooClassBase#})[#(Any?) -> FooClassBase?#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[Constructor]/CurrNominal:      ()[#FooClassBase!#]
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[Constructor]/CurrNominal:      ({#float: Float#})[#FooClassBase!#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_1-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ()[#FooClassBase!#]
+// CLANG_CLASS_MEMBERS_1-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#float: Float#})[#FooClassBase!#]{{; name=.+$}}
 // CLANG_CLASS_MEMBERS_1-NEXT: Decl[StaticMethod]/CurrNominal:     .fooBaseInstanceFuncOverridden()[#Void#]{{; name=.+$}}
 // CLANG_CLASS_MEMBERS_1-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooBaseInstanceFuncOverridden({#(self): FooClassBase#})[#() -> Void#]{{; name=.+$}}
 // CLANG_CLASS_MEMBERS_1-NEXT: Decl[StaticMethod]/CurrNominal:     .fooBaseClassFunc0()[#Void#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[Constructor]/CurrNominal:      ({#(x): Int32#})[#FooClassBase!#]
+// CLANG_CLASS_MEMBERS_1-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#(x): Int32#})[#FooClassBase!#]
 // CLANG_CLASS_MEMBERS_1-NEXT: Decl[StaticMethod]/CurrNominal:     ._internalMeth3()[#Any!#]
 // CLANG_CLASS_MEMBERS_1-NEXT: Decl[InstanceMethod]/CurrNominal:   ._internalMeth3({#(self): FooClassBase#})[#() -> Any?#]
 // CLANG_CLASS_MEMBERS_1-NEXT: Decl[StaticMethod]/CurrNominal:     ._internalMeth2()[#Any!#]
@@ -289,8 +289,8 @@ func testCompleteClassMembers2() {
 // CLANG_CLASS_MEMBERS_2-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooInstanceFunc2({#(self): FooClassDerived#})[#(Int32, withB: Int32) -> Void#]{{; name=.+$}}
 // CLANG_CLASS_MEMBERS_2-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooBaseInstanceFuncOverridden({#(self): FooClassDerived#})[#() -> Void#]{{; name=.+$}}
 // CLANG_CLASS_MEMBERS_2-NEXT: Decl[StaticMethod]/CurrNominal:     .fooClassFunc0()[#Void#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[Constructor]/CurrNominal:      ()[#FooClassDerived!#]
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[Constructor]/CurrNominal:      ({#float: Float#})[#FooClassDerived!#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_2-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ()[#FooClassDerived!#]
+// CLANG_CLASS_MEMBERS_2-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#float: Float#})[#FooClassDerived!#]{{; name=.+$}}
 // CLANG_CLASS_MEMBERS_2-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooProtoFunc({#(self): FooClassDerived#})[#() -> Void#]{{; name=.+$}}
 // CLANG_CLASS_MEMBERS_2-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooProtoFuncWithExtraIndentation1({#(self): FooClassDerived#})[#() -> Void#]{{; name=.+$}}
 // CLANG_CLASS_MEMBERS_2-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooProtoFuncWithExtraIndentation2({#(self): FooClassDerived#})[#() -> Void#]{{; name=.+$}}

--- a/test/IDE/complete_from_swift_module.swift
+++ b/test/IDE/complete_from_swift_module.swift
@@ -103,7 +103,7 @@ func testCompleteModuleQualified3() {
   foo_swift_module.BarGenericSwiftStruct1#^MODULE_QUALIFIED_3^#
 }
 // MODULE_QUALIFIED_3: Begin completions
-// MODULE_QUALIFIED_3-NEXT: Decl[Constructor]/CurrNominal: ({#t: _#})[#BarGenericSwiftStruct1<_>#]; name=(t: _)
+// MODULE_QUALIFIED_3-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ({#t: _#})[#BarGenericSwiftStruct1<_>#]; name=(t: _)
 // MODULE_QUALIFIED_3-NEXT: Decl[InstanceMethod]/CurrNominal: .bar1InstanceFunc({#(self): BarGenericSwiftStruct1<_>#})[#() -> Void#]; name=bar1InstanceFunc(self: BarGenericSwiftStruct1<_>)
 // MODULE_QUALIFIED_3: End completions
 
@@ -111,7 +111,7 @@ func testCompleteModuleQualified4() {
   foo_swift_module.BarGenericSwiftStruct2#^MODULE_QUALIFIED_4^#
 }
 // MODULE_QUALIFIED_4: Begin completions
-// MODULE_QUALIFIED_4-NEXT: Decl[Constructor]/CurrNominal: ({#t: _#}, {#u: _#})[#BarGenericSwiftStruct2<_, _>#]; name=(t: _, u: _)
+// MODULE_QUALIFIED_4-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ({#t: _#}, {#u: _#})[#BarGenericSwiftStruct2<_, _>#]; name=(t: _, u: _)
 // MODULE_QUALIFIED_4-NEXT: Decl[InstanceMethod]/CurrNominal: .bar2InstanceFunc({#(self): BarGenericSwiftStruct2<_, _>#})[#() -> Void#]; name=bar2InstanceFunc(self: BarGenericSwiftStruct2<_, _>)
 // MODULE_QUALIFIED_4-NEXT: Keyword[self]/CurrNominal: .self[#BarGenericSwiftStruct2<_, _>.Type#]; name=self
 // MODULE_QUALIFIED_4-NEXT: Keyword/CurrNominal: .Type[#BarGenericSwiftStruct2<_, _>.Type#]; name=Type

--- a/test/IDE/complete_from_swiftonly_systemmodule.swift
+++ b/test/IDE/complete_from_swiftonly_systemmodule.swift
@@ -73,6 +73,6 @@ func test(value: SomeValue) {
 
   let _ = SomeValue(#^INITIALIZER^#
 // INITIALIZER: Begin completions, 1 items
-// INITIALIZER-DAG: Decl[Constructor]/CurrNominal/IsSystem: ['(']{#public: Int#}[')'][#SomeValue#];
+// INITIALIZER-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]/IsSystem: ['(']{#public: Int#}[')'][#SomeValue#];
 // INITIALIZER: End completions
 }

--- a/test/IDE/complete_in_closures.swift
+++ b/test/IDE/complete_in_closures.swift
@@ -312,8 +312,8 @@ func testIIFE() {
   }()
 }
 // IN_IIFE_1: Begin completions
-// IN_IIFE_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: north[#SomeEnum#]
-// IN_IIFE_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: south[#SomeEnum#]
+// IN_IIFE_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: north[#SomeEnum#]
+// IN_IIFE_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: south[#SomeEnum#]
 
 extension Error {
   var myErrorNumber: Int { return 0 }

--- a/test/IDE/complete_in_result_builder.swift
+++ b/test/IDE/complete_in_result_builder.swift
@@ -105,9 +105,9 @@ func testPatternMatching() {
     let x = Letters.b
     if case .#^COMPLETE_PATTERN_MATCHING_IN_IF?check=COMPLETE_CASE^# = x {
 // COMPLETE_CASE: Begin completions
-// COMPLETE_CASE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: a[#Letters#];
-// COMPLETE_CASE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: b[#Letters#];
-// COMPLETE_CASE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: c[#Letters#];
+// COMPLETE_CASE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: a[#Letters#];
+// COMPLETE_CASE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: b[#Letters#];
+// COMPLETE_CASE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: c[#Letters#];
 // COMPLETE_CASE: End completions
     }
   }

--- a/test/IDE/complete_in_result_builder.swift
+++ b/test/IDE/complete_in_result_builder.swift
@@ -149,7 +149,7 @@ func testCompleteFunctionArgumentLabels() {
   @TupleBuilder<String> var x1 {
     StringFactory.makeString(#^FUNCTION_ARGUMENT_LABEL^#)
     // FUNCTION_ARGUMENT_LABEL: Begin completions, 1 item
-    // FUNCTION_ARGUMENT_LABEL: Decl[StaticMethod]/CurrNominal:     ['(']{#x: String#}[')'][#String#];
+    // FUNCTION_ARGUMENT_LABEL: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]: ['(']{#x: String#}[')'][#String#];
     // FUNCTION_ARGUMENT_LABEL: End completions
   }
 }

--- a/test/IDE/complete_init.swift
+++ b/test/IDE/complete_init.swift
@@ -144,5 +144,5 @@ typealias CAlias = C
 
 var CAliasInstance = CAlias(#^ALIAS_CONSTRUCTOR_0^#
 // rdar://18586415
-// ALIAS_CONSTRUCTOR_0: Decl[Constructor]/CurrNominal:      ['(']{#x: A#}[')'][#CAlias#];
-// ALIAS_CONSTRUCTOR_0: Decl[Constructor]/CurrNominal:      ['(']{#y: A#}[')'][#CAlias#];
+// ALIAS_CONSTRUCTOR_0: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#x: A#}[')'][#CAlias#];
+// ALIAS_CONSTRUCTOR_0: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#y: A#}[')'][#CAlias#];

--- a/test/IDE/complete_init_inherited.swift
+++ b/test/IDE/complete_init_inherited.swift
@@ -15,9 +15,9 @@ class A {
 }
 
 // TEST_A: Begin completions
-// TEST_A-NEXT: Decl[Constructor]/CurrNominal:      ({#int: Int#})[#A#]{{; name=.+$}}
-// TEST_A-NEXT: Decl[Constructor]/CurrNominal:      ({#double: Double#})[#A#]{{; name=.+$}}
-// TEST_A-NEXT: Decl[Constructor]/CurrNominal:      ({#float: Float#})[#A#]{{; name=.+$}}
+// TEST_A-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#int: Int#})[#A#]{{; name=.+$}}
+// TEST_A-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#double: Double#})[#A#]{{; name=.+$}}
+// TEST_A-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#float: Float#})[#A#]{{; name=.+$}}
 // TEST_A-NEXT: Keyword[self]/CurrNominal:          .self[#A.Type#]; name=self
 // TEST_A-NEXT: Keyword/CurrNominal:                .Type[#A.Type#]; name=Type
 // TEST_A-NEXT: End completions
@@ -29,9 +29,9 @@ class B : A {
 }
 
 // TEST_B: Begin completions
-// TEST_B-NEXT: Decl[Constructor]/CurrNominal:      ({#int: Int#})[#B#]{{; name=.+$}}
-// TEST_B-NEXT: Decl[Constructor]/CurrNominal:      ({#double: Double#})[#B#]{{; name=.+$}}
-// TEST_B-NEXT: Decl[Constructor]/Super:            ({#float: Float#})[#A#]{{; name=.+$}}
+// TEST_B-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#int: Int#})[#B#]{{; name=.+$}}
+// TEST_B-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#double: Double#})[#B#]{{; name=.+$}}
+// TEST_B-NEXT: Decl[Constructor]/Super/Flair[ArgLabels]:            ({#float: Float#})[#A#]{{; name=.+$}}
 // TEST_B-NEXT: Keyword[self]/CurrNominal:          .self[#B.Type#]; name=self
 // TEST_B-NEXT: Keyword/CurrNominal: .Type[#B.Type#]; name=Type
 // TEST_B-NEXT: End completions
@@ -47,8 +47,8 @@ class C : B {
 }
 
 // TEST_C: Begin completions
-// TEST_C-NEXT: Decl[Constructor]/CurrNominal:      ({#int: Int#})[#C#]{{; name=.+$}}
-// TEST_C-NEXT: Decl[Constructor]/CurrNominal:      ({#c: C#})[#C#]{{; name=.+$}}
+// TEST_C-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#int: Int#})[#C#]{{; name=.+$}}
+// TEST_C-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#c: C#})[#C#]{{; name=.+$}}
 // TEST_C-NEXT: Keyword[self]/CurrNominal:          .self[#C.Type#]; name=self
 // TEST_C-NEXT: Keyword/CurrNominal:                .Type[#C.Type#]; name=Type
 // TEST_C-NEXT: End completions
@@ -65,9 +65,9 @@ class D : C {
 }
 
 // TEST_D: Begin completions
-// TEST_D-NEXT: Decl[Constructor]/CurrNominal:      ({#d: D#})[#D#]{{; name=.+$}}
-// TEST_D-NEXT: Decl[Constructor]/CurrNominal:      ({#int: Int#})[#D#]{{; name=.+$}}
-// TEST_D-NEXT: Decl[Constructor]/Super:            ({#c: C#})[#C#]{{; name=.+$}}
+// TEST_D-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#d: D#})[#D#]{{; name=.+$}}
+// TEST_D-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#int: Int#})[#D#]{{; name=.+$}}
+// TEST_D-NEXT: Decl[Constructor]/Super/Flair[ArgLabels]:            ({#c: C#})[#C#]{{; name=.+$}}
 // TEST_D-NEXT: Keyword[self]/CurrNominal:          .self[#D.Type#]; name=self
 // TEST_D-NEXT: Keyword/CurrNominal:                .Type[#D.Type#]; name=Type
 // TEST_D-NEXT: End completions
@@ -76,9 +76,9 @@ class D : C {
 // TEST_D_DOT-NEXT: Decl[Constructor]/CurrNominal:  init({#int: Int#})[#D#]; name=init(int: Int)
 // TEST_D_DOT-NEXT: Decl[Constructor]/Super:        init({#c: C#})[#C#]; name=init(c: C)
 
-// TEST_D_PAREN: Decl[Constructor]/CurrNominal:       ['(']{#d: D#}[')'][#D#]; name=d: D
-// TEST_D_PAREN-NEXT: Decl[Constructor]/CurrNominal:  ['(']{#int: Int#}[')'][#D#]; name=int: Int
-// TEST_D_PAREN-NEXT: Decl[Constructor]/Super:  ['(']{#c: C#}[')'][#C#]; name=c: C
+// TEST_D_PAREN: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:       ['(']{#d: D#}[')'][#D#]; name=d: D
+// TEST_D_PAREN-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:  ['(']{#int: Int#}[')'][#D#]; name=int: Int
+// TEST_D_PAREN-NEXT: Decl[Constructor]/Super/Flair[ArgLabels]:  ['(']{#c: C#}[')'][#C#]; name=c: C
 
 func testA() {
   A#^TEST_A^#
@@ -108,8 +108,8 @@ class R74233797Derived : R74233797Base {
 func testR74233797() {
     R74233797Derived(#^METATYPE_CONVERSION^#)
 // METATYPE_CONVERSION: Begin completions
-// METATYPE_CONVERSION-DAG: Decl[Constructor]/CurrNominal: ['(']{#sub: Bool#}[')'][#R74233797Derived#];
-// METATYPE_CONVERSION-DAG: Decl[Constructor]/CurrNominal: ['('][')'][#R74233797Derived#];
-// METATYPE_CONVERSION-DAG: Decl[Constructor]/Super: ['(']{#(test): Bool#}[')'][#R74233797Base#];
+// METATYPE_CONVERSION-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['(']{#sub: Bool#}[')'][#R74233797Derived#];
+// METATYPE_CONVERSION-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['('][')'][#R74233797Derived#];
+// METATYPE_CONVERSION-DAG: Decl[Constructor]/Super/Flair[ArgLabels]: ['(']{#(test): Bool#}[')'][#R74233797Base#];
 // METATYPE_CONVERSION: End completions
 }

--- a/test/IDE/complete_invalid_result_builder.swift
+++ b/test/IDE/complete_invalid_result_builder.swift
@@ -55,6 +55,6 @@ test {
 }
 
 // MYENUM_MEMBERS: Begin completions
-// MYENUM_MEMBERS-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: a[#MyEnum#]; name=a
-// MYENUM_MEMBERS-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: b[#MyEnum#]; name=b
+// MYENUM_MEMBERS-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: a[#MyEnum#]; name=a
+// MYENUM_MEMBERS-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: b[#MyEnum#]; name=b
 // MYENUM_MEMBERS: End completions 

--- a/test/IDE/complete_keywords.swift
+++ b/test/IDE/complete_keywords.swift
@@ -26,6 +26,7 @@
 // KW_DECL-DAG: Keyword/None: override{{; name=.+$}}
 // KW_DECL-DAG: Keyword/None: postfix{{; name=.+$}}
 // KW_DECL-DAG: Keyword/None: prefix{{; name=.+$}}
+// KW_DECL_DAG: Keyword[precedencegroup]: precedencegroup{{; name=.+$}}
 // KW_DECL-DAG: Keyword[private]/None: private{{; name=.+$}}
 // KW_DECL-DAG: Keyword[protocol]/None: protocol{{; name=.+$}}
 // KW_DECL-DAG: Keyword[public]/None: public{{; name=.+$}}
@@ -39,38 +40,185 @@
 // KW_DECL-DAG: Keyword/None: weak{{; name=.+$}}
 // KW_DECL: End completions
 
+// KW_DECL_PROTOCOL: Begin completions
+// KW_DECL_PROTOCOL-DAG: Keyword[class]/None/Flair[RareKeyword]: class{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword/None: convenience{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword[deinit]/None: deinit{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword/None: dynamic{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword[enum]/None/Flair[RareKeyword]: enum{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword[extension]/None/Flair[RareKeyword]: extension{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword/None: final{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword[func]/None: func{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword[import]/None/Flair[RareKeyword]: import{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword/None: infix{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword[init]/None: init{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword[internal]/None: internal{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword/None: lazy{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword[let]/None: let{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword/None: mutating{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword/None: nonmutating{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword[operator]/None/Flair[RareKeyword]: operator{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword/None: optional{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword/None: override{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword/None: postfix{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword/None: prefix{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword[precedencegroup]/None/Flair[RareKeyword]: precedencegroup{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword[private]/None: private{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword[protocol]/None/Flair[RareKeyword]: protocol{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword[public]/None: public{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword/None: required{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword[static]/None: static{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword[struct]/None/Flair[RareKeyword]: struct{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword[subscript]/None: subscript{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword[typealias]/None: typealias{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword/None: unowned{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword[var]/None: var{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword/None: weak{{; name=.+$}}
+// KW_DECL_PROTOCOL: End completions
+
+// KW_DECL_TYPECONTEXT: Begin completions
+// KW_DECL_TYPECONTEXT-DAG: Keyword[class]/None: class{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword/None: convenience{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword[deinit]/None: deinit{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword/None: dynamic{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword[enum]/None: enum{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword[extension]/None/Flair[RareKeyword]: extension{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword/None: final{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword[func]/None: func{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword[import]/None/Flair[RareKeyword]: import{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword/None: infix{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword[init]/None: init{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword[internal]/None: internal{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword/None: lazy{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword[let]/None: let{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword/None: mutating{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword/None: nonmutating{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword[operator]/None/Flair[RareKeyword]: operator{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword/None: optional{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword/None: override{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword/None: postfix{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword/None: prefix{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword[precedencegroup]/None/Flair[RareKeyword]: precedencegroup{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword[private]/None: private{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword[protocol]/None/Flair[RareKeyword]: protocol{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword[public]/None: public{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword/None: required{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword[static]/None: static{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword[struct]/None: struct{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword[subscript]/None: subscript{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword[typealias]/None: typealias{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword/None: unowned{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword[var]/None: var{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword/None: weak{{; name=.+$}}
+// KW_DECL_TYPECONTEXT: End completions
+
+
+// KW_DECL_STMT_TOPLEVEL: Begin completions
+//
+// Declaration keywords.
+//
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[class]/None: class{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: convenience{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[deinit]/None: deinit{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: dynamic{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[enum]/None: enum{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[extension]/None: extension{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: final{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[func]/None: func{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[import]/None: import{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: infix{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[init]/None: init{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[internal]/None: internal{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: lazy{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[let]/None: let{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: mutating{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: nonmutating{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[operator]/None: operator{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: optional{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: override{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: postfix{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[precedencegroup]/None: precedencegroup{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: prefix{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[private]/None: private{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[protocol]/None: protocol{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[public]/None: public{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: required{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[static]/None: static{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[struct]/None: struct{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[subscript]/None: subscript{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[typealias]/None: typealias{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: unowned{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[var]/None: var{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: weak{{; name=.+$}}
+//
+// Statement keywords.
+//
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[if]/None: if{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[do]/None: do{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[else]/None: else{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[for]/None: for{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[in]/None: in{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[while]/None: while{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[break]/None: break{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[continue]/None: continue{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[fallthrough]/None: fallthrough{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[switch]/None: switch{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[case]/None: case{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[default]/None: default{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[where]/None: where{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[catch]/None: catch{{; name=.+$}}
+//
+// Misc.
+//
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[throw]/None: throw{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[try]/None: try{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[try]/None: try!{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[try]/None: try?{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[#function]/None{{(/TypeRelation\[Identical\])?}}: #function[#String#]{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[#file]/None{{(/TypeRelation\[Identical\])?}}: #file[#String#]{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[#line]/None{{(/TypeRelation\[Identical\])?}}: #line[#Int#]{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[#column]/None{{(/TypeRelation\[Identical\])?}}: #column[#Int#]{{; name=.+$}}
+//
+// Literals
+//
+// KW_DECL_STMT_TOPLEVEL-DAG: Literal[Boolean]/None: false[#Bool#]{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Literal[Boolean]/None: true[#Bool#]{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Literal[Nil]/None: nil{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL: End completions
+
 // KW_DECL_STMT: Begin completions
 //
 // Declaration keywords.
 //
-// KW_DECL_STMT-DAG: Keyword[class]/None: class{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword/None: convenience{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[deinit]/None: deinit{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword/None: dynamic{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[enum]/None: enum{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[extension]/None: extension{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword/None: final{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[class]/None/Flair[RareKeyword]: class{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword/None/Flair[RareKeyword]: convenience{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[deinit]/None/Flair[RareKeyword]: deinit{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword/None/Flair[RareKeyword]: dynamic{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[enum]/None/Flair[RareKeyword]: enum{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[extension]/None/Flair[RareKeyword]: extension{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword/None/Flair[RareKeyword]: final{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword[func]/None: func{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[import]/None: import{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword/None: infix{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[init]/None: init{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[internal]/None: internal{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword/None: lazy{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[import]/None/Flair[RareKeyword]: import{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword/None/Flair[RareKeyword]: infix{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[init]/None/Flair[RareKeyword]: init{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[internal]/None/Flair[RareKeyword]: internal{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword/None/Flair[RareKeyword]: lazy{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword[let]/None: let{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword/None: mutating{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword/None: nonmutating{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[operator]/None: operator{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword/None: optional{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword/None: override{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword/None: postfix{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword/None: prefix{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[private]/None: private{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[protocol]/None: protocol{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[public]/None: public{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword/None: required{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[static]/None: static{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[struct]/None: struct{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[subscript]/None: subscript{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[operator]/None/Flair[RareKeyword]: operator{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword/None/Flair[RareKeyword]: optional{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword/None/Flair[RareKeyword]: override{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword/None/Flair[RareKeyword]: postfix{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[precedencegroup]/None/Flair[RareKeyword]: precedencegroup{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword/None/Flair[RareKeyword]: prefix{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[private]/None/Flair[RareKeyword]: private{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[protocol]/None/Flair[RareKeyword]: protocol{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[public]/None/Flair[RareKeyword]: public{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword/None/Flair[RareKeyword]: required{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[static]/None/Flair[RareKeyword]: static{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[struct]/None/Flair[RareKeyword]: struct{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[subscript]/None/Flair[RareKeyword]: subscript{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword[typealias]/None: typealias{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword/None: unowned{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword[var]/None: var{{; name=.+$}}
@@ -154,7 +302,7 @@
 // KW_EXPR_NEG-NOT: Keyword{{.*}}break
 // KW_EXPR_NEG: End completions
 
-#^TOP_LEVEL_1?check=KW_DECL_STMT;check=KW_NO_RETURN^#
+#^TOP_LEVEL_1?check=KW_DECL_STMT_TOPLEVEL;check=KW_NO_RETURN^#
 
 for _ in 1...10 {
   #^TOP_LEVEL_2?check=KW_DECL_STMT;check=KW_NO_RETURN^#
@@ -225,43 +373,43 @@ struct InInit {
 }
 
 struct InStruct {
-  #^IN_NOMINAL_DECL_1?check=KW_DECL^#
+  #^IN_NOMINAL_DECL_1?check=KW_DECL_TYPECONTEXT^#
 }
 
 enum InEnum {
-  #^IN_NOMINAL_DECL_2?check=KW_DECL^#
+  #^IN_NOMINAL_DECL_2?check=KW_DECL_TYPECONTEXT^#
 }
 
 class InClass {
-  #^IN_NOMINAL_DECL_3?check=KW_DECL^#
+  #^IN_NOMINAL_DECL_3?check=KW_DECL_TYPECONTEXT^#
 }
 
 protocol InProtocol {
-  #^IN_NOMINAL_DECL_4?check=KW_DECL^#
+  #^IN_NOMINAL_DECL_4?check=KW_DECL_PROTOCOL^#
 }
 
 struct AfterOtherKeywords1 {
-  public #^IN_NOMINAL_DECL_5?check=KW_DECL^#
+  public #^IN_NOMINAL_DECL_5?check=KW_DECL_TYPECONTEXT^#
 }
 
 struct AfterOtherKeywords2 {
-  mutating #^IN_NOMINAL_DECL_6?check=KW_DECL^#
+  mutating #^IN_NOMINAL_DECL_6?check=KW_DECL_TYPECONTEXT^#
 }
 
 class AfterOtherKeywords3 {
-  override #^IN_NOMINAL_DECL_7?check=KW_DECL^#
+  override #^IN_NOMINAL_DECL_7?check=KW_DECL_TYPECONTEXT^#
 }
 
 class AfterOtherKeywords4 {
-  public override #^IN_NOMINAL_DECL_8?check=KW_DECL^#
+  public override #^IN_NOMINAL_DECL_8?check=KW_DECL_TYPECONTEXT^#
 }
 
 extension InStruct {
-  #^IN_NOMINAL_DECL_9?check=KW_DECL^#
+  #^IN_NOMINAL_DECL_9?check=KW_DECL_TYPECONTEXT^#
 }
 
 extension InProtocol {
-  #^IN_NOMINAL_DECL_10?check=KW_DECL^#
+  #^IN_NOMINAL_DECL_10?check=KW_DECL_TYPECONTEXT^#
 }
 
 class SuperSuperClass {
@@ -343,4 +491,16 @@ func testContextualType() {
 // CONTEXT_STATICSTRING-DAG: Keyword[#column]/None:              #column[#Int#]; name=#column
 // CONTEXT_STATICSTRING-DAG: Keyword[#dsohandle]/None:           #dsohandle[#UnsafeRawPointer#]; name=#dsohandle
 // CONTEXT_STATICSTRING: End completions
+}
+
+class Base {
+  func foo() {}
+}
+class Derivied: Base {
+  override func foo() {
+    #^OVERRIDE^#
+// OVERRIDE: Begin completions
+// OVERRIDE-DAG: Keyword[super]/CurrNominal/Flair[CommonKeyword]: super[#Base#]; name=super
+// OVERRIDE: End completions
+  }
 }

--- a/test/IDE/complete_keywords_library.swift
+++ b/test/IDE/complete_keywords_library.swift
@@ -1,0 +1,57 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -parse-as-library
+
+#^TOPLEVEL^#
+
+// TOPLEVEL: Begin completions
+// TOPLEVEL-DAG: Keyword[associatedtype]/None:       associatedtype; name=associatedtype
+// TOPLEVEL-DAG: Keyword[class]/None/Flair[CommonKeyword]: class; name=class
+// TOPLEVEL-DAG: Keyword[deinit]/None:               deinit; name=deinit
+// TOPLEVEL-DAG: Keyword[enum]/None/Flair[CommonKeyword]: enum; name=enum
+// TOPLEVEL-DAG: Keyword[extension]/None/Flair[CommonKeyword]: extension; name=extension
+// TOPLEVEL-DAG: Keyword[func]/None:                 func; name=func
+// TOPLEVEL-DAG: Keyword[import]/None:               import; name=import
+// TOPLEVEL-DAG: Keyword[init]/None:                 init; name=init
+// TOPLEVEL-DAG: Keyword[inout]/None:                inout; name=inout
+// TOPLEVEL-DAG: Keyword[operator]/None:             operator; name=operator
+// TOPLEVEL-DAG: Keyword[precedencegroup]/None:      precedencegroup; name=precedencegroup
+// TOPLEVEL-DAG: Keyword[protocol]/None/Flair[CommonKeyword]: protocol; name=protocol
+// TOPLEVEL-DAG: Keyword[struct]/None/Flair[CommonKeyword]: struct; name=struct
+// TOPLEVEL-DAG: Keyword[subscript]/None:            subscript; name=subscript
+// TOPLEVEL-DAG: Keyword[typealias]/None:            typealias; name=typealias
+// TOPLEVEL-DAG: Keyword[fileprivate]/None:          fileprivate; name=fileprivate
+// TOPLEVEL-DAG: Keyword[internal]/None:             internal; name=internal
+// TOPLEVEL-DAG: Keyword[private]/None:              private; name=private
+// TOPLEVEL-DAG: Keyword[public]/None:               public; name=public
+// TOPLEVEL-DAG: Keyword[static]/None:               static; name=static
+// TOPLEVEL-DAG: Keyword/None:                       final; name=final
+// TOPLEVEL-DAG: Keyword/None:                       required; name=required
+// TOPLEVEL-DAG: Keyword/None:                       optional; name=optional
+// TOPLEVEL-DAG: Keyword/None:                       lazy; name=lazy
+// TOPLEVEL-DAG: Keyword/None:                       dynamic; name=dynamic
+// TOPLEVEL-DAG: Keyword/None:                       infix; name=infix
+// TOPLEVEL-DAG: Keyword/None:                       prefix; name=prefix
+// TOPLEVEL-DAG: Keyword/None:                       postfix; name=postfix
+// TOPLEVEL-DAG: Keyword/None:                       mutating; name=mutating
+// TOPLEVEL-DAG: Keyword/None:                       nonmutating; name=nonmutating
+// TOPLEVEL-DAG: Keyword/None:                       convenience; name=convenience
+// TOPLEVEL-DAG: Keyword/None:                       override; name=override
+// TOPLEVEL-DAG: Keyword/None:                       open; name=open
+// TOPLEVEL-DAG: Keyword/None:                       weak; name=weak
+// TOPLEVEL-DAG: Keyword/None:                       unowned; name=unowned
+// TOPLEVEL-DAG: Keyword/None:                       indirect; name=indirect
+// TOPLEVEL-DAG: Keyword/None:                       nonisolated; name=nonisolated
+// TOPLEVEL-DAG: Keyword[defer]/None:                defer; name=defer
+// TOPLEVEL-DAG: Keyword[if]/None:                   if; name=if
+// TOPLEVEL-DAG: Keyword[guard]/None:                guard; name=guard
+// TOPLEVEL-DAG: Keyword[do]/None:                   do; name=do
+// TOPLEVEL-DAG: Keyword[repeat]/None:               repeat; name=repeat
+// TOPLEVEL-DAG: Keyword[else]/None:                 else; name=else
+// TOPLEVEL-DAG: Keyword[for]/None:                  for; name=for
+// TOPLEVEL-DAG: Keyword[in]/None:                   in; name=in
+// TOPLEVEL-DAG: Keyword[while]/None:                while; name=while
+// TOPLEVEL-DAG: Keyword[break]/None:                break; name=break
+// TOPLEVEL-DAG: Keyword[continue]/None:             continue; name=continue
+// TOPLEVEL-DAG: Keyword[fallthrough]/None:          fallthrough; name=fallthrough
+// TOPLEVEL-DAG: Keyword[switch]/None:               switch; name=switch
+// TOPLEVEL: End completions

--- a/test/IDE/complete_multibracestmt.swift
+++ b/test/IDE/complete_multibracestmt.swift
@@ -33,7 +33,7 @@ func test(pred: Bool) {
 }
 
 // CHECK: Begin completions, 3 items
-// CHECK-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: bar[#E#]; name=bar
-// CHECK-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: foo[#E#]; name=foo
+// CHECK-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bar[#E#]; name=bar
+// CHECK-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: foo[#E#]; name=foo
 // CHECK-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): E#})[#(into: inout Hasher) -> Void#]; name=hash(self: E)
 // CHECK: End completions

--- a/test/IDE/complete_multifile.swift
+++ b/test/IDE/complete_multifile.swift
@@ -51,7 +51,7 @@ struct HasWrapped {
 func testStructDefaultInit() {
   Point(#^POINT_PAREN^#
 // POINT_PAREN: Begin completions, 1 items
-// POINT_PAREN-DAG: Decl[Constructor]/CurrNominal:      ['(']{#x: Int#}, {#y: Int#}[')'][#Point#];
+// POINT_PAREN-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#x: Int#}, {#y: Int#}[')'][#Point#];
 // POINT_PAREN: End completions
   func sync() {}
   Point.#^POINT_DOT^#

--- a/test/IDE/complete_multiple_trailingclosure.swift
+++ b/test/IDE/complete_multiple_trailingclosure.swift
@@ -26,11 +26,11 @@ func testGlobalFunc() {
     { 1 } #^GLOBALFUNC_SAMELINE^#
     #^GLOBALFUNC_NEWLINE^#
 // GLOBALFUNC_SAMELINE: Begin completions, 1 items
-// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: () -> String {|}#}[#() -> String#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ArgLabels]: {#fn2: () -> String {|}#}[#() -> String#];
 // GLOBALFUNC_SAMELINE: End completions
 
 // GLOBALFUNC_NEWLINE: Begin completions
-// FIXME-GLOBALFUNC_NEWLINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: () -> String {|}#}[#() -> String#];
+// FIXME-GLOBALFUNC_NEWLINE-DAG: Pattern/Local/Flair[ArgLabels]: {#fn2: () -> String {|}#}[#() -> String#];
 // GLOBALFUNC_NEWLINE: End completions
 
   globalFunc1()
@@ -55,14 +55,14 @@ func testMethod(value: MyStruct) {
   } #^METHOD_SAMELINE^#
   #^METHOD_NEWLINE^#
 // METHOD_SAMELINE: Begin completions, 4 items
-// METHOD_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: (() -> String)? {|}#}[#(() -> String)?#];
+// METHOD_SAMELINE-DAG: Pattern/Local/Flair[ArgLabels]:     {#fn2: (() -> String)? {|}#}[#(() -> String)?#];
 // METHOD_SAMELINE-DAG: Decl[InstanceMethod]/CurrNominal:   .enumFunc()[#Void#];
 // METHOD_SAMELINE-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]/IsSystem: [' ']+ {#SimpleEnum#}[#SimpleEnum#];
 // METHOD_SAMELINE-DAG: Keyword[self]/CurrNominal:          .self[#SimpleEnum#];
 // METHOD_SAMELINE: End completions
 
 // METHOD_NEWLINE: Begin completions
-// FIXME-METHOD_NEWLINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: (() -> String)? {|}#}[#(() -> String)?#];
+// FIXME-METHOD_NEWLINE-DAG: Pattern/Local/Flair[ArgLabels]: {#fn2: (() -> String)? {|}#}[#(() -> String)?#];
 // METHOD_NEWLINE-DAG: Keyword[class]/None:                class;
 // METHOD_NEWLINE-DAG: Keyword[if]/None:                   if;
 // METHOD_NEWLINE-DAG: Keyword[try]/None:                  try;
@@ -86,15 +86,15 @@ func testOverloadedInit() {
   #^INIT_OVERLOADED_NEWLINE^#
 
 // INIT_OVERLOADED_SAMELINE: Begin completions, 4 items
-// INIT_OVERLOADED_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: () -> String {|}#}[#() -> String#];
-// INIT_OVERLOADED_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn3: () -> String {|}#}[#() -> String#];
+// INIT_OVERLOADED_SAMELINE-DAG: Pattern/Local/Flair[ArgLabels]:     {#fn2: () -> String {|}#}[#() -> String#];
+// INIT_OVERLOADED_SAMELINE-DAG: Pattern/Local/Flair[ArgLabels]:     {#fn3: () -> String {|}#}[#() -> String#];
 // INIT_OVERLOADED_SAMELINE-DAG: Decl[InstanceMethod]/CurrNominal:   .testStructMethod()[#Void#];
 // INIT_OVERLOADED_SAMELINE-DAG: Keyword[self]/CurrNominal:          .self[#TestStruct#];
 // INIT_OVERLOADED_SAMELINE: End completions
 
 // INIT_OVERLOADED_NEWLINE: Begin completions
-// FIXME-INIT_OVERLOADED_NEWLINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: () -> String {|}#}[#() -> String#];
-// FIXME-INIT_OVERLOADED_NEWLINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn3: () -> String {|}#}[#() -> String#];
+// FIXME-INIT_OVERLOADED_NEWLINE-DAG: Pattern/Local/Flair[ArgLabels]: {#fn2: () -> String {|}#}[#() -> String#];
+// FIXME-INIT_OVERLOADED_NEWLINE-DAG: Pattern/Local/Flair[ArgLabels]: {#fn3: () -> String {|}#}[#() -> String#];
 // INIT_OVERLOADED_NEWLINE-DAG: Keyword[class]/None:                class;
 // INIT_OVERLOADED_NEWLINE-DAG: Keyword[if]/None:                   if;
 // INIT_OVERLOADED_NEWLINE-DAG: Keyword[try]/None:                  try;
@@ -113,15 +113,15 @@ func testOptionalInit() {
   #^INIT_OPTIONAL_NEWLINE^#
 
 // INIT_OPTIONAL_SAMELINE: Begin completions, 4 items
-// INIT_OPTIONAL_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: () -> String {|}#}[#() -> String#];
-// INIT_OPTIONAL_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn3: () -> String {|}#}[#() -> String#];
+// INIT_OPTIONAL_SAMELINE-DAG: Pattern/Local/Flair[ArgLabels]:     {#fn2: () -> String {|}#}[#() -> String#];
+// INIT_OPTIONAL_SAMELINE-DAG: Pattern/Local/Flair[ArgLabels]:     {#fn3: () -> String {|}#}[#() -> String#];
 // INIT_OPTIONAL_SAMELINE-DAG: Decl[InstanceMethod]/CurrNominal:   .testStructMethod()[#Void#];
 // INIT_OPTIONAL_SAMELINE-DAG: Keyword[self]/CurrNominal:          .self[#TestStruct2#];
 // INIT_OPTIONAL_SAMELINE: End completions
 
 // INIT_OPTIONAL_NEWLINE: Begin completions
-// FIXME-INIT_OPTIONAL_NEWLINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: () -> String {|}#}[#() -> String#];
-// FIXME-INIT_OPTIONAL_NEWLINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn3: () -> String {|}#}[#() -> String#];
+// FIXME-INIT_OPTIONAL_NEWLINE-DAG: Pattern/Local/Flair[ArgLabels]: {#fn2: () -> String {|}#}[#() -> String#];
+// FIXME-INIT_OPTIONAL_NEWLINE-DAG: Pattern/Local/Flair[ArgLabels]: {#fn3: () -> String {|}#}[#() -> String#];
 // INIT_OPTIONAL_NEWLINE-DAG: Keyword[class]/None:                class;
 // INIT_OPTIONAL_NEWLINE-DAG: Keyword[if]/None:                   if;
 // INIT_OPTIONAL_NEWLINE-DAG: Keyword[try]/None:                  try;
@@ -141,11 +141,11 @@ func testOptionalInit() {
   #^INIT_REQUIRED_NEWLINE_1^#
 
 // INIT_REQUIRED_SAMELINE_1: Begin completions, 1 items
-// INIT_REQUIRED_SAMELINE_1-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: () -> String {|}#}[#() -> String#];
+// INIT_REQUIRED_SAMELINE_1-DAG: Pattern/Local/Flair[ArgLabels]:               {#fn2: () -> String {|}#}[#() -> String#];
 // INIT_REQUIRED_SAMELINE_1: End completions
 
 // INIT_REQUIRED_NEWLINE_1: Begin completions
-// FIXME-INIT_REQUIRED_NEWLINE_1-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: () -> String {|}#}[#() -> String#];
+// FIXME-INIT_REQUIRED_NEWLINE_1-DAG: Pattern/Local/Flair[ArgLabels]:               {#fn2: () -> String {|}#}[#() -> String#];
 // INIT_REQUIRED_NEWLINE_1: End completions
 
   // missing 'fn3'.
@@ -157,11 +157,11 @@ func testOptionalInit() {
   #^INIT_REQUIRED_NEWLINE_2^#
 
 // INIT_REQUIRED_SAMELINE_2: Begin completions, 1 items
-// INIT_REQUIRED_SAMELINE_2-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn3: () -> String {|}#}[#() -> String#];
+// INIT_REQUIRED_SAMELINE_2-DAG: Pattern/Local/Flair[ArgLabels]:               {#fn3: () -> String {|}#}[#() -> String#];
 // INIT_REQUIRED_SAMELINE_2: End completions
 
 // INIT_REQUIRED_NEWLINE_2: Begin completions
-// FIXME-INIT_REQUIRED_NEWLINE_2-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn3: () -> String {|}#}[#() -> String#];
+// FIXME-INIT_REQUIRED_NEWLINE_2-DAG: Pattern/Local/Flair[ArgLabels]:               {#fn3: () -> String {|}#}[#() -> String#];
 // INIT_REQUIRED_NEWLINE_2: End completions
 
   // Call is completed.
@@ -207,7 +207,7 @@ func testFallbackPostfix() {
 // the stage at which we complete argument labels, so we can't rule it out for
 // now (SR-14450).
 // INIT_FALLBACK_1: Begin completions, 3 items
-// INIT_FALLBACK_1-DAG: Pattern/Local/Flair[ExprSpecific]:               {#arg3: () -> _ {|}#}[#() -> _#]
+// INIT_FALLBACK_1-DAG: Pattern/Local/Flair[ArgLabels]:     {#arg3: () -> _ {|}#}[#() -> _#]
 // INIT_FALLBACK_1-DAG: Decl[InstanceMethod]/CurrNominal:   .testStructMethod()[#Void#];
 // INIT_FALLBACK_1-DAG: Keyword[self]/CurrNominal:          .self[#MyStruct4<Int>#];
 // INIT_FALLBACK_1: End completions
@@ -230,14 +230,14 @@ struct TestNominalMember: P {
   #^MEMBERDECL_NEWLINE^#
 
 // MEMBERDECL_SAMELINE: Begin completions, 4 items
-// MEMBERDECL_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: (() -> String)? {|}#}[#(() -> String)?#]; name=fn2: (() -> String)?
+// MEMBERDECL_SAMELINE-DAG: Pattern/Local/Flair[ArgLabels]:     {#fn2: (() -> String)? {|}#}[#(() -> String)?#]; name=fn2: (() -> String)?
 // MEMBERDECL_SAMELINE-DAG: Decl[InstanceMethod]/CurrNominal:   .enumFunc()[#Void#]; name=enumFunc()
 // MEMBERDECL_SAMELINE-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]/IsSystem: [' ']+ {#SimpleEnum#}[#SimpleEnum#]; name=+ SimpleEnum
 // MEMBERDECL_SAMELINE-DAG: Keyword[self]/CurrNominal:          .self[#SimpleEnum#]; name=self
 // MEMBERDECL_SAMELINE: End completions
 
 // MEMBERDECL_NEWLINE: Begin completions
-// FIXME-MEMBERDECL_NEWLINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: (() -> String)? {|}#}[#(() -> String)?#]; name=fn2: (() -> String)?
+// FIXME-MEMBERDECL_NEWLINE-DAG: Pattern/Local/Flair[ArgLabels]: {#fn2: (() -> String)? {|}#}[#(() -> String)?#]; name=fn2: (() -> String)?
 // MEMBERDECL_NEWLINE-DAG: Keyword[enum]/None:                 enum; name=enum
 // MEMBERDECL_NEWLINE-DAG: Keyword[func]/None:                 func; name=func
 // MEMBERDECL_NEWLINE-DAG: Keyword[private]/None:              private; name=private
@@ -254,8 +254,8 @@ func testInitializedVarDecl() {
     #^INITIALIZED_VARDECL_NEWLINE^#
 // INITIALIZED_VARDECL_SAMELINE: Begin completions, 4 items
 // INITIALIZED_VARDECL_SAMELINE-NOT: localVal
-// INITIALIZED_VARDECL_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: () -> String {|}#}[#() -> String#];
-// INITIALIZED_VARDECL_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn3: () -> String {|}#}[#() -> String#];
+// INITIALIZED_VARDECL_SAMELINE-DAG: Pattern/Local/Flair[ArgLabels]:     {#fn2: () -> String {|}#}[#() -> String#];
+// INITIALIZED_VARDECL_SAMELINE-DAG: Pattern/Local/Flair[ArgLabels]:     {#fn3: () -> String {|}#}[#() -> String#];
 // INITIALIZED_VARDECL_SAMELINE-DAG: Decl[InstanceMethod]/CurrNominal:   .testStructMethod()[#Void#];
 // INITIALIZED_VARDECL_SAMELINE-DAG: Keyword[self]/CurrNominal:          .self[#TestStruct#];
 // INITIALIZED_VARDECL_SAMELINE-NOT: localVal

--- a/test/IDE/complete_multiple_trailingclosure.swift
+++ b/test/IDE/complete_multiple_trailingclosure.swift
@@ -63,7 +63,7 @@ func testMethod(value: MyStruct) {
 
 // METHOD_NEWLINE: Begin completions
 // FIXME-METHOD_NEWLINE-DAG: Pattern/Local/Flair[ArgLabels]: {#fn2: (() -> String)? {|}#}[#(() -> String)?#];
-// METHOD_NEWLINE-DAG: Keyword[class]/None:                class;
+// METHOD_NEWLINE-DAG: Keyword[class]/None/Flair[RareKeyword]: class;
 // METHOD_NEWLINE-DAG: Keyword[if]/None:                   if;
 // METHOD_NEWLINE-DAG: Keyword[try]/None:                  try;
 // METHOD_NEWLINE-DAG: Decl[LocalVar]/Local:               value[#MyStruct#]; name=value
@@ -95,7 +95,7 @@ func testOverloadedInit() {
 // INIT_OVERLOADED_NEWLINE: Begin completions
 // FIXME-INIT_OVERLOADED_NEWLINE-DAG: Pattern/Local/Flair[ArgLabels]: {#fn2: () -> String {|}#}[#() -> String#];
 // FIXME-INIT_OVERLOADED_NEWLINE-DAG: Pattern/Local/Flair[ArgLabels]: {#fn3: () -> String {|}#}[#() -> String#];
-// INIT_OVERLOADED_NEWLINE-DAG: Keyword[class]/None:                class;
+// INIT_OVERLOADED_NEWLINE-DAG: Keyword[class]/None/Flair[RareKeyword]: class;
 // INIT_OVERLOADED_NEWLINE-DAG: Keyword[if]/None:                   if;
 // INIT_OVERLOADED_NEWLINE-DAG: Keyword[try]/None:                  try;
 // INIT_OVERLOADED_NEWLINE-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
@@ -122,7 +122,7 @@ func testOptionalInit() {
 // INIT_OPTIONAL_NEWLINE: Begin completions
 // FIXME-INIT_OPTIONAL_NEWLINE-DAG: Pattern/Local/Flair[ArgLabels]: {#fn2: () -> String {|}#}[#() -> String#];
 // FIXME-INIT_OPTIONAL_NEWLINE-DAG: Pattern/Local/Flair[ArgLabels]: {#fn3: () -> String {|}#}[#() -> String#];
-// INIT_OPTIONAL_NEWLINE-DAG: Keyword[class]/None:                class;
+// INIT_OPTIONAL_NEWLINE-DAG: Keyword[class]/None/Flair[RareKeyword]: class;
 // INIT_OPTIONAL_NEWLINE-DAG: Keyword[if]/None:                   if;
 // INIT_OPTIONAL_NEWLINE-DAG: Keyword[try]/None:                  try;
 // INIT_OPTIONAL_NEWLINE-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
@@ -182,7 +182,7 @@ func testOptionalInit() {
 // INIT_REQUIRED_NEWLINE_3: Begin completions
 // INIT_REQUIRED_NEWLINE_3-NOT: name=fn2
 // INIT_REQUIRED_NEWLINE_3-NOT: name=fn3
-// INIT_REQUIRED_NEWLINE_3-DAG: Keyword[class]/None:                class;
+// INIT_REQUIRED_NEWLINE_3-DAG: Keyword[class]/None/Flair[RareKeyword]: class;
 // INIT_REQUIRED_NEWLINE_3-DAG: Keyword[if]/None:                   if;
 // INIT_REQUIRED_NEWLINE_3-DAG: Keyword[try]/None:                  try;
 // INIT_REQUIRED_NEWLINE_3-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct

--- a/test/IDE/complete_multiple_trailingclosure.swift
+++ b/test/IDE/complete_multiple_trailingclosure.swift
@@ -26,11 +26,11 @@ func testGlobalFunc() {
     { 1 } #^GLOBALFUNC_SAMELINE^#
     #^GLOBALFUNC_NEWLINE^#
 // GLOBALFUNC_SAMELINE: Begin completions, 1 items
-// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {|}#}[#() -> String#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: () -> String {|}#}[#() -> String#];
 // GLOBALFUNC_SAMELINE: End completions
 
 // GLOBALFUNC_NEWLINE: Begin completions
-// FIXME-GLOBALFUNC_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {|}#}[#() -> String#];
+// FIXME-GLOBALFUNC_NEWLINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: () -> String {|}#}[#() -> String#];
 // GLOBALFUNC_NEWLINE: End completions
 
   globalFunc1()
@@ -55,14 +55,14 @@ func testMethod(value: MyStruct) {
   } #^METHOD_SAMELINE^#
   #^METHOD_NEWLINE^#
 // METHOD_SAMELINE: Begin completions, 4 items
-// METHOD_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn2: (() -> String)? {|}#}[#(() -> String)?#];
+// METHOD_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: (() -> String)? {|}#}[#(() -> String)?#];
 // METHOD_SAMELINE-DAG: Decl[InstanceMethod]/CurrNominal:   .enumFunc()[#Void#];
 // METHOD_SAMELINE-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]/IsSystem: [' ']+ {#SimpleEnum#}[#SimpleEnum#];
 // METHOD_SAMELINE-DAG: Keyword[self]/CurrNominal:          .self[#SimpleEnum#];
 // METHOD_SAMELINE: End completions
 
 // METHOD_NEWLINE: Begin completions
-// FIXME-METHOD_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: (() -> String)? {|}#}[#(() -> String)?#];
+// FIXME-METHOD_NEWLINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: (() -> String)? {|}#}[#(() -> String)?#];
 // METHOD_NEWLINE-DAG: Keyword[class]/None:                class;
 // METHOD_NEWLINE-DAG: Keyword[if]/None:                   if;
 // METHOD_NEWLINE-DAG: Keyword[try]/None:                  try;
@@ -86,15 +86,15 @@ func testOverloadedInit() {
   #^INIT_OVERLOADED_NEWLINE^#
 
 // INIT_OVERLOADED_SAMELINE: Begin completions, 4 items
-// INIT_OVERLOADED_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {|}#}[#() -> String#];
-// INIT_OVERLOADED_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {|}#}[#() -> String#];
+// INIT_OVERLOADED_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: () -> String {|}#}[#() -> String#];
+// INIT_OVERLOADED_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn3: () -> String {|}#}[#() -> String#];
 // INIT_OVERLOADED_SAMELINE-DAG: Decl[InstanceMethod]/CurrNominal:   .testStructMethod()[#Void#];
 // INIT_OVERLOADED_SAMELINE-DAG: Keyword[self]/CurrNominal:          .self[#TestStruct#];
 // INIT_OVERLOADED_SAMELINE: End completions
 
 // INIT_OVERLOADED_NEWLINE: Begin completions
-// FIXME-INIT_OVERLOADED_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {|}#}[#() -> String#];
-// FIXME-INIT_OVERLOADED_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {|}#}[#() -> String#];
+// FIXME-INIT_OVERLOADED_NEWLINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: () -> String {|}#}[#() -> String#];
+// FIXME-INIT_OVERLOADED_NEWLINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn3: () -> String {|}#}[#() -> String#];
 // INIT_OVERLOADED_NEWLINE-DAG: Keyword[class]/None:                class;
 // INIT_OVERLOADED_NEWLINE-DAG: Keyword[if]/None:                   if;
 // INIT_OVERLOADED_NEWLINE-DAG: Keyword[try]/None:                  try;
@@ -113,15 +113,15 @@ func testOptionalInit() {
   #^INIT_OPTIONAL_NEWLINE^#
 
 // INIT_OPTIONAL_SAMELINE: Begin completions, 4 items
-// INIT_OPTIONAL_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {|}#}[#() -> String#];
-// INIT_OPTIONAL_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {|}#}[#() -> String#];
+// INIT_OPTIONAL_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: () -> String {|}#}[#() -> String#];
+// INIT_OPTIONAL_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn3: () -> String {|}#}[#() -> String#];
 // INIT_OPTIONAL_SAMELINE-DAG: Decl[InstanceMethod]/CurrNominal:   .testStructMethod()[#Void#];
 // INIT_OPTIONAL_SAMELINE-DAG: Keyword[self]/CurrNominal:          .self[#TestStruct2#];
 // INIT_OPTIONAL_SAMELINE: End completions
 
 // INIT_OPTIONAL_NEWLINE: Begin completions
-// FIXME-INIT_OPTIONAL_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {|}#}[#() -> String#];
-// FIXME-INIT_OPTIONAL_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {|}#}[#() -> String#];
+// FIXME-INIT_OPTIONAL_NEWLINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: () -> String {|}#}[#() -> String#];
+// FIXME-INIT_OPTIONAL_NEWLINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn3: () -> String {|}#}[#() -> String#];
 // INIT_OPTIONAL_NEWLINE-DAG: Keyword[class]/None:                class;
 // INIT_OPTIONAL_NEWLINE-DAG: Keyword[if]/None:                   if;
 // INIT_OPTIONAL_NEWLINE-DAG: Keyword[try]/None:                  try;
@@ -141,11 +141,11 @@ func testOptionalInit() {
   #^INIT_REQUIRED_NEWLINE_1^#
 
 // INIT_REQUIRED_SAMELINE_1: Begin completions, 1 items
-// INIT_REQUIRED_SAMELINE_1-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {|}#}[#() -> String#];
+// INIT_REQUIRED_SAMELINE_1-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: () -> String {|}#}[#() -> String#];
 // INIT_REQUIRED_SAMELINE_1: End completions
 
 // INIT_REQUIRED_NEWLINE_1: Begin completions
-// FIXME-INIT_REQUIRED_NEWLINE_1-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {|}#}[#() -> String#];
+// FIXME-INIT_REQUIRED_NEWLINE_1-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: () -> String {|}#}[#() -> String#];
 // INIT_REQUIRED_NEWLINE_1: End completions
 
   // missing 'fn3'.
@@ -157,11 +157,11 @@ func testOptionalInit() {
   #^INIT_REQUIRED_NEWLINE_2^#
 
 // INIT_REQUIRED_SAMELINE_2: Begin completions, 1 items
-// INIT_REQUIRED_SAMELINE_2-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {|}#}[#() -> String#];
+// INIT_REQUIRED_SAMELINE_2-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn3: () -> String {|}#}[#() -> String#];
 // INIT_REQUIRED_SAMELINE_2: End completions
 
 // INIT_REQUIRED_NEWLINE_2: Begin completions
-// FIXME-INIT_REQUIRED_NEWLINE_2-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {|}#}[#() -> String#];
+// FIXME-INIT_REQUIRED_NEWLINE_2-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn3: () -> String {|}#}[#() -> String#];
 // INIT_REQUIRED_NEWLINE_2: End completions
 
   // Call is completed.
@@ -207,7 +207,7 @@ func testFallbackPostfix() {
 // the stage at which we complete argument labels, so we can't rule it out for
 // now (SR-14450).
 // INIT_FALLBACK_1: Begin completions, 3 items
-// INIT_FALLBACK_1-DAG: Pattern/ExprSpecific:               {#arg3: () -> _ {|}#}[#() -> _#]
+// INIT_FALLBACK_1-DAG: Pattern/Local/Flair[ExprSpecific]:               {#arg3: () -> _ {|}#}[#() -> _#]
 // INIT_FALLBACK_1-DAG: Decl[InstanceMethod]/CurrNominal:   .testStructMethod()[#Void#];
 // INIT_FALLBACK_1-DAG: Keyword[self]/CurrNominal:          .self[#MyStruct4<Int>#];
 // INIT_FALLBACK_1: End completions
@@ -230,14 +230,14 @@ struct TestNominalMember: P {
   #^MEMBERDECL_NEWLINE^#
 
 // MEMBERDECL_SAMELINE: Begin completions, 4 items
-// MEMBERDECL_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn2: (() -> String)? {|}#}[#(() -> String)?#]; name=fn2: (() -> String)?
+// MEMBERDECL_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: (() -> String)? {|}#}[#(() -> String)?#]; name=fn2: (() -> String)?
 // MEMBERDECL_SAMELINE-DAG: Decl[InstanceMethod]/CurrNominal:   .enumFunc()[#Void#]; name=enumFunc()
 // MEMBERDECL_SAMELINE-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]/IsSystem: [' ']+ {#SimpleEnum#}[#SimpleEnum#]; name=+ SimpleEnum
 // MEMBERDECL_SAMELINE-DAG: Keyword[self]/CurrNominal:          .self[#SimpleEnum#]; name=self
 // MEMBERDECL_SAMELINE: End completions
 
 // MEMBERDECL_NEWLINE: Begin completions
-// FIXME-MEMBERDECL_NEWLINE-DAG: Pattern/ExprSpecific:               {#fn2: (() -> String)? {|}#}[#(() -> String)?#]; name=fn2: (() -> String)?
+// FIXME-MEMBERDECL_NEWLINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: (() -> String)? {|}#}[#(() -> String)?#]; name=fn2: (() -> String)?
 // MEMBERDECL_NEWLINE-DAG: Keyword[enum]/None:                 enum; name=enum
 // MEMBERDECL_NEWLINE-DAG: Keyword[func]/None:                 func; name=func
 // MEMBERDECL_NEWLINE-DAG: Keyword[private]/None:              private; name=private
@@ -254,8 +254,8 @@ func testInitializedVarDecl() {
     #^INITIALIZED_VARDECL_NEWLINE^#
 // INITIALIZED_VARDECL_SAMELINE: Begin completions, 4 items
 // INITIALIZED_VARDECL_SAMELINE-NOT: localVal
-// INITIALIZED_VARDECL_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn2: () -> String {|}#}[#() -> String#];
-// INITIALIZED_VARDECL_SAMELINE-DAG: Pattern/ExprSpecific:               {#fn3: () -> String {|}#}[#() -> String#];
+// INITIALIZED_VARDECL_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn2: () -> String {|}#}[#() -> String#];
+// INITIALIZED_VARDECL_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]:               {#fn3: () -> String {|}#}[#() -> String#];
 // INITIALIZED_VARDECL_SAMELINE-DAG: Decl[InstanceMethod]/CurrNominal:   .testStructMethod()[#Void#];
 // INITIALIZED_VARDECL_SAMELINE-DAG: Keyword[self]/CurrNominal:          .self[#TestStruct#];
 // INITIALIZED_VARDECL_SAMELINE-NOT: localVal

--- a/test/IDE/complete_multiple_trailingclosure_signatures.swift
+++ b/test/IDE/complete_multiple_trailingclosure_signatures.swift
@@ -16,13 +16,13 @@ func test() {
     { 1 } #^GLOBALFUNC_SAMELINE^#
 
 // GLOBALFUNC_SAMELINE: Begin completions
-// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]: {#fn2:  () -> Void {|}#}[#() -> Void#];
-// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]: {#fn3:  (Int) -> Void {<#Int#> in|}#}[#(Int) -> Void#];
-// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]: {#fn4:  (Int, String) -> Void {<#Int#>, <#String#> in|}#}[#(Int, String) -> Void#];
-// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]: {#fn5:  (Int, String) -> Int {<#Int#>, <#String#> in|}#}[#(Int, String) -> Int#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ArgLabels]: {#fn2:  () -> Void {|}#}[#() -> Void#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ArgLabels]: {#fn3:  (Int) -> Void {<#Int#> in|}#}[#(Int) -> Void#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ArgLabels]: {#fn4:  (Int, String) -> Void {<#Int#>, <#String#> in|}#}[#(Int, String) -> Void#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ArgLabels]: {#fn5:  (Int, String) -> Int {<#Int#>, <#String#> in|}#}[#(Int, String) -> Int#];
 // FIXME: recover names
-// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]: {#fn6:  (Int, String) -> Int {a, b in|}#}[#(Int, String) -> Int#];
-// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]: {#fn7:  (inout Int) -> Void {<#inout Int#> in|}#}[#(inout Int) -> Void#];
-// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]: {#fn8:  (Int...) -> Void {<#Int...#> in|}#}[#(Int...) -> Void#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ArgLabels]: {#fn6:  (Int, String) -> Int {a, b in|}#}[#(Int, String) -> Int#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ArgLabels]: {#fn7:  (inout Int) -> Void {<#inout Int#> in|}#}[#(inout Int) -> Void#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ArgLabels]: {#fn8:  (Int...) -> Void {<#Int...#> in|}#}[#(Int...) -> Void#];
 // GLOBALFUNC_SAMELINE: End completions
 }

--- a/test/IDE/complete_multiple_trailingclosure_signatures.swift
+++ b/test/IDE/complete_multiple_trailingclosure_signatures.swift
@@ -16,13 +16,13 @@ func test() {
     { 1 } #^GLOBALFUNC_SAMELINE^#
 
 // GLOBALFUNC_SAMELINE: Begin completions
-// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific: {#fn2:  () -> Void {|}#}[#() -> Void#];
-// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific: {#fn3:  (Int) -> Void {<#Int#> in|}#}[#(Int) -> Void#];
-// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific: {#fn4:  (Int, String) -> Void {<#Int#>, <#String#> in|}#}[#(Int, String) -> Void#];
-// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific: {#fn5:  (Int, String) -> Int {<#Int#>, <#String#> in|}#}[#(Int, String) -> Int#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]: {#fn2:  () -> Void {|}#}[#() -> Void#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]: {#fn3:  (Int) -> Void {<#Int#> in|}#}[#(Int) -> Void#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]: {#fn4:  (Int, String) -> Void {<#Int#>, <#String#> in|}#}[#(Int, String) -> Void#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]: {#fn5:  (Int, String) -> Int {<#Int#>, <#String#> in|}#}[#(Int, String) -> Int#];
 // FIXME: recover names
-// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific: {#fn6:  (Int, String) -> Int {a, b in|}#}[#(Int, String) -> Int#];
-// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific: {#fn7:  (inout Int) -> Void {<#inout Int#> in|}#}[#(inout Int) -> Void#];
-// GLOBALFUNC_SAMELINE-DAG: Pattern/ExprSpecific: {#fn8:  (Int...) -> Void {<#Int...#> in|}#}[#(Int...) -> Void#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]: {#fn6:  (Int, String) -> Int {a, b in|}#}[#(Int, String) -> Int#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]: {#fn7:  (inout Int) -> Void {<#inout Int#> in|}#}[#(inout Int) -> Void#];
+// GLOBALFUNC_SAMELINE-DAG: Pattern/Local/Flair[ExprSpecific]: {#fn8:  (Int...) -> Void {<#Int...#> in|}#}[#(Int...) -> Void#];
 // GLOBALFUNC_SAMELINE: End completions
 }

--- a/test/IDE/complete_operators.swift
+++ b/test/IDE/complete_operators.swift
@@ -192,7 +192,7 @@ func testInfix11() {
 }
 
 // INFIX_11: Begin completions, 3 items
-// INFIX_11-DAG: Decl[Constructor]/CurrNominal:      ()[#S2#]; name=()
+// INFIX_11-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ()[#S2#]; name=()
 // INFIX_11-DAG: Keyword[self]/CurrNominal:          .self[#S2.Type#]; name=self
 // INFIX_11-DAG: Keyword/CurrNominal:                .Type[#S2.Type#]; name=Type
 // INFIX_11: End completions
@@ -230,7 +230,7 @@ func testInfix16<T: P where T.T == S2>() {
 }
 
 // INFIX_16: Begin completions, 2 items
-// INFIX_16-NEXT: Decl[InstanceMethod]/CurrNominal: ({#(self): P#})[#() -> S2#]; name=(self: P)
+// INFIX_16-NEXT: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ({#(self): P#})[#() -> S2#]; name=(self: P)
 // INFIX_16-NEXT: Keyword[self]/CurrNominal:        .self[#(T) -> () -> S2#]; name=self
 // INFIX_16: End completions
 
@@ -274,7 +274,7 @@ func testInfix22() {
   E.B#^INFIX_22^#
 }
 // INFIX_22: Begin completions, 2 items
-// INFIX_22-NEXT: Pattern/CurrModule:               ({#S2#})[#E#]; name=(S2)
+// INFIX_22-NEXT: Pattern/CurrModule/Flair[ArgLabels]:               ({#S2#})[#E#]; name=(S2)
 // INFIX_22: End completions
 
 func testSpace(x: S2) {

--- a/test/IDE/complete_pound_directive.swift
+++ b/test/IDE/complete_pound_directive.swift
@@ -47,20 +47,20 @@ class C {
 
 // CONDITION: Begin completions
 // CONDITION-NOT: globalVar
-// CONDITION-DAG: Pattern/ExprSpecific:               os({#(name)#}); name=os(name)
-// CONDITION-DAG: Pattern/ExprSpecific:               arch({#(name)#}); name=arch(name)
-// CONDITION-DAG: Pattern/ExprSpecific:               canImport({#(module)#}); name=canImport(module)
-// CONDITION-DAG: Pattern/ExprSpecific:               targetEnvironment(simulator); name=targetEnvironment(simulator)
-// CONDITION-DAG: Pattern/ExprSpecific:               swift(>={#(version)#}); name=swift(>=version)
-// CONDITION-DAG: Pattern/ExprSpecific:               swift(<{#(version)#}); name=swift(<version)
-// CONDITION-DAG: Pattern/ExprSpecific:               compiler(>={#(version)#}); name=compiler(>=version)
-// CONDITION-DAG: Pattern/ExprSpecific:               compiler(<{#(version)#}); name=compiler(<version)
+// CONDITION-DAG: Pattern/CurrModule/Flair[ExprSpecific]:               os({#(name)#}); name=os(name)
+// CONDITION-DAG: Pattern/CurrModule/Flair[ExprSpecific]:               arch({#(name)#}); name=arch(name)
+// CONDITION-DAG: Pattern/CurrModule/Flair[ExprSpecific]:               canImport({#(module)#}); name=canImport(module)
+// CONDITION-DAG: Pattern/CurrModule/Flair[ExprSpecific]:               targetEnvironment(simulator); name=targetEnvironment(simulator)
+// CONDITION-DAG: Pattern/CurrModule/Flair[ExprSpecific]:               swift(>={#(version)#}); name=swift(>=version)
+// CONDITION-DAG: Pattern/CurrModule/Flair[ExprSpecific]:               swift(<{#(version)#}); name=swift(<version)
+// CONDITION-DAG: Pattern/CurrModule/Flair[ExprSpecific]:               compiler(>={#(version)#}); name=compiler(>=version)
+// CONDITION-DAG: Pattern/CurrModule/Flair[ExprSpecific]:               compiler(<{#(version)#}); name=compiler(<version)
 // CONDITION-DAG: Keyword[true]/None:                 true[#Bool#]; name=true
 // CONDITION-DAG: Keyword[false]/None:                false[#Bool#]; name=false
 // CONDITION-NOT: globalVar
 
-// WITHFLAG: Keyword/ExprSpecific:               FOO; name=FOO
-// WITHFLAG: Keyword/ExprSpecific:               BAR; name=BAR
+// WITHFLAG: Keyword/CurrModule/Flair[ExprSpecific]:               FOO; name=FOO
+// WITHFLAG: Keyword/CurrModule/Flair[ExprSpecific]:               BAR; name=BAR
 
 // NOFLAG-NOT: FOO 
 // NOFLAG-NOT: BAR

--- a/test/IDE/complete_pound_selector.swift
+++ b/test/IDE/complete_pound_selector.swift
@@ -72,7 +72,7 @@ class Subclass : NSObject {
 
 
 // CHECK-AFTER_POUND-NOT: selector
-// CHECK-AFTER_POUND: Keyword/ExprSpecific:               available({#Platform...#}, *); name=available(Platform..., *)
+// CHECK-AFTER_POUND: Keyword/Local/Flair[ExprSpecific]:               available({#Platform...#}, *); name=available(Platform..., *)
 
 // CHECK-CONTEXT_SELECTOR: Keyword/None/TypeRelation[Identical]: #selector({#@objc method#})[#Selector#]; name=#selector(@objc method)
 

--- a/test/IDE/complete_pound_statement.swift
+++ b/test/IDE/complete_pound_statement.swift
@@ -53,5 +53,5 @@ class C3 {
   }
 }
 
-// AVAILABLE: Keyword/ExprSpecific:               available({#Platform...#}, *); name=available(Platform..., *)
+// AVAILABLE: Keyword/Local/Flair[ExprSpecific]:               available({#Platform...#}, *); name=available(Platform..., *)
 // AVAILABLE1-NOT: available({#Platform...#}, *)

--- a/test/IDE/complete_property_delegate_attribute.swift
+++ b/test/IDE/complete_property_delegate_attribute.swift
@@ -35,8 +35,8 @@ struct TestStruct {
   @MyStruct(arg1: .#^ARG_MyEnum_DOT^#
   var test3
 // ARG_MyEnum_DOT: Begin completions, 3 items
-// ARG_MyEnum_DOT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     east[#MyEnum#]; name=east
-// ARG_MyEnum_DOT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     west[#MyEnum#]; name=west
+// ARG_MyEnum_DOT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     east[#MyEnum#]; name=east
+// ARG_MyEnum_DOT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     west[#MyEnum#]; name=west
 // ARG_MyEnum_DOT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): MyEnum#})[#(into: inout Hasher) -> Void#];
 // ARG_MyEnum_DOT: End completions
 

--- a/test/IDE/complete_property_delegate_attribute.swift
+++ b/test/IDE/complete_property_delegate_attribute.swift
@@ -21,8 +21,8 @@ struct TestStruct {
   @MyStruct(#^AFTER_PAREN^#
   var test1
 // AFTER_PAREN: Begin completions, 2 items
-// AFTER_PAREN-DAG: Decl[Constructor]/CurrNominal:      ['(']{#wrappedValue: MyEnum#}[')'][#MyStruct#]; name=wrappedValue: MyEnum
-// AFTER_PAREN-DAG: Decl[Constructor]/CurrNominal:      ['(']{#arg1: MyEnum#}, {#arg2: Int#}[')'][#MyStruct#]; name=arg1: MyEnum, arg2: Int
+// AFTER_PAREN-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#wrappedValue: MyEnum#}[')'][#MyStruct#]; name=wrappedValue: MyEnum
+// AFTER_PAREN-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#arg1: MyEnum#}, {#arg2: Int#}[')'][#MyStruct#]; name=arg1: MyEnum, arg2: Int
 // AFTER_PAREN: End completions
 
   @MyStruct(arg1: #^ARG_MyEnum_NODOT^#

--- a/test/IDE/complete_rdar75200217.swift
+++ b/test/IDE/complete_rdar75200217.swift
@@ -31,5 +31,5 @@ func deserializeName(_ data: Array<UInt16>, flag: Bool) {
 }
 
 // CHECK: Begin completions
-// CHECK-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: utf8[#Encoding#];
+// CHECK-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: utf8[#Encoding#];
 // CHECK: End completions

--- a/test/IDE/complete_single_expression_return.swift
+++ b/test/IDE/complete_single_expression_return.swift
@@ -53,7 +53,7 @@ struct TestSingleExprClosureRetUnresolved {
 
 // TestSingleExprClosureRetUnresolved: Begin completions
 // TestSingleExprClosureRetUnresolved-NOT: notMine
-// TestSingleExprClosureRetUnresolved: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: myEnum[#MyEnum#];
+// TestSingleExprClosureRetUnresolved: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: myEnum[#MyEnum#];
 // TestSingleExprClosureRetUnresolved-NOT: notMine
 // TestSingleExprClosureRetUnresolved: End completions
 }
@@ -108,7 +108,7 @@ struct TestSingleExprClosureUnresolved {
 }
 // TestSingleExprClosureUnresolved: Begin completions
 // TestSingleExprClosureUnresolved-NOT: notMine
-// TestSingleExprClosureUnresolved: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: myEnum[#MyEnum#];
+// TestSingleExprClosureUnresolved: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: myEnum[#MyEnum#];
 // TestSingleExprClosureUnresolved-NOT: notMine
 // TestSingleExprClosureUnresolved: End completions
 
@@ -223,7 +223,7 @@ struct TestSingleExprFuncUnresolved {
 
 // TestSingleExprFuncUnresolved: Begin completions
 // TestSingleExprFuncUnresolved-NOT: notMine
-// TestSingleExprFuncUnresolved: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: myEnum[#MyEnum#];
+// TestSingleExprFuncUnresolved: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: myEnum[#MyEnum#];
 // TestSingleExprFuncUnresolved-NOT: notMine
 // TestSingleExprFuncUnresolved: End completions
 }
@@ -333,7 +333,7 @@ struct TestSingleExprAccessorUnresolved {
 
 // TestSingleExprAccessorUnresolved: Begin completions
 // TestSingleExprAccessorUnresolved-NOT: notMine
-// TestSingleExprAccessorUnresolved: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: myEnum[#MyEnum#];
+// TestSingleExprAccessorUnresolved: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: myEnum[#MyEnum#];
 // TestSingleExprAccessorUnresolved-NOT: notMine
 // TestSingleExprAccessorUnresolved: End completions
 }
@@ -485,7 +485,7 @@ struct TestSingleExprSubscriptUnresolved {
 
 // TestSingleExprSubscriptUnresolved: Begin completions
 // TestSingleExprSubscriptUnresolved-NOT: notMine
-// TestSingleExprSubscriptUnresolved: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: myEnum[#MyEnum#];
+// TestSingleExprSubscriptUnresolved: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: myEnum[#MyEnum#];
 // TestSingleExprSubscriptUnresolved-NOT: notMine
 // TestSingleExprSubscriptUnresolved: End completions
 }
@@ -590,7 +590,7 @@ enum TopLevelEnum {
   case foo
 }
 
-// TopLevelEnum: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: foo[#TopLevelEnum#];
+// TopLevelEnum: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: foo[#TopLevelEnum#];
 
 var testAccessorUnresolvedTopLevel: TopLevelEnum {
   .#^testAccessorUnresolvedTopLevel?check=TopLevelEnum^#

--- a/test/IDE/complete_sr13271.swift
+++ b/test/IDE/complete_sr13271.swift
@@ -48,7 +48,7 @@ func test() {
     .#^B^#
   }
 // B: Begin completions, 2 items
-// B-DAG: Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: baz[#B#]; name=baz
+// B-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: baz[#B#]; name=baz
 // B-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init()[#B#]; name=init()
 // B: End completions
 }

--- a/test/IDE/complete_stmt_controlling_expr.swift
+++ b/test/IDE/complete_stmt_controlling_expr.swift
@@ -421,7 +421,7 @@ func testSwitchCaseWhereExprIJ1(_ fooObject: FooStruct) {
 enum A { case aaa }
 enum B { case bbb }
 // UNRESOLVED_B-NOT: aaa
-// UNRESOLVED_B: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]:     bbb[#B#]; name=bbb
+// UNRESOLVED_B: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     bbb[#B#]; name=bbb
 // UNRESOLVED_B-NOT: aaa
 
 struct AA {

--- a/test/IDE/complete_string_interpolation.swift
+++ b/test/IDE/complete_string_interpolation.swift
@@ -34,24 +34,24 @@ var messenger = Messenger()
 func testMessenger(intVal: Int, fltVal: Float) {
   messenger.send("  \(intVal, format: .#^OVERLOAD_INT^#) ")
 // OVERLOAD_INT: Begin completions, 3 items
-// OVERLOAD_INT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: decimal[#MsgInterpolation.IntFormat#];
-// OVERLOAD_INT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: hex[#MsgInterpolation.IntFormat#];
+// OVERLOAD_INT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: decimal[#MsgInterpolation.IntFormat#];
+// OVERLOAD_INT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: hex[#MsgInterpolation.IntFormat#];
 // OVERLOAD_INT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): MsgInterpolation.IntFormat#})[#(into: inout Hasher) -> Void#];
 // OVERLOAD_INT: End completions
 
   messenger.send("  \(5, format: .#^OVERLOAD_INTLITERAL^#, extraneousArg: 10) ")
 // OVERLOAD_INTLITERAL: Begin completions, 5 items
-// OVERLOAD_INTLITERAL-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: decimal[#MsgInterpolation.IntFormat#];
-// OVERLOAD_INTLITERAL-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: hex[#MsgInterpolation.IntFormat#];
+// OVERLOAD_INTLITERAL-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: decimal[#MsgInterpolation.IntFormat#];
+// OVERLOAD_INTLITERAL-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: hex[#MsgInterpolation.IntFormat#];
 // OVERLOAD_INTLITERAL-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): MsgInterpolation.IntFormat#})[#(into: inout Hasher) -> Void#];
-// OVERLOAD_INTLITERAL-DAG: Decl[StaticMethod]/ExprSpecific/TypeRelation[Identical]: precision({#Int#})[#MsgInterpolation.FloatFormat#];
-// OVERLOAD_INTLITERAL-DAG: Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: hex[#MsgInterpolation.FloatFormat#];
+// OVERLOAD_INTLITERAL-DAG: Decl[StaticMethod]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: precision({#Int#})[#MsgInterpolation.FloatFormat#];
+// OVERLOAD_INTLITERAL-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: hex[#MsgInterpolation.FloatFormat#];
 // OVERLOAD_INTLITERAL: End completions
 
   messenger.send("  \(fltVal, format: .#^OVERLOAD_FLT^#) ")
   messenger.send("  \(5.0, format: .#^OVERLOAD_FLTLITERAL^#) ")
 // OVERLOAD_FLT: Begin completions, 2 items
-// OVERLOAD_FLT-DAG: Decl[StaticMethod]/ExprSpecific/TypeRelation[Identical]: precision({#Int#})[#MsgInterpolation.FloatFormat#];
-// OVERLOAD_FLT-DAG: Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: hex[#MsgInterpolation.FloatFormat#];
+// OVERLOAD_FLT-DAG: Decl[StaticMethod]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: precision({#Int#})[#MsgInterpolation.FloatFormat#];
+// OVERLOAD_FLT-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: hex[#MsgInterpolation.FloatFormat#];
 // OVERLOAD_FLT: End completions
 }

--- a/test/IDE/complete_subscript.swift
+++ b/test/IDE/complete_subscript.swift
@@ -94,12 +94,12 @@ func test2<U>(value: MyStruct<U>) {
 
   let _ = MyStruct<U>[42, #^METATYPE_LABEL^#
 // METATYPE_LABEL: Begin completions, 1 items
-// METATYPE_LABEL-DAG: Pattern/ExprSpecific: {#static: U#}[#U#];
+// METATYPE_LABEL-DAG: Pattern/Local/Flair[ExprSpecific]: {#static: U#}[#U#];
 // METATYPE_LABEL: End completions
 
   let _ = value[42, #^INSTANCE_LABEL^#
 // INSTANCE_LABEL: Begin completions, 1 items
-// INSTANCE_LABEL-DAG: Pattern/ExprSpecific: {#instance: U#}[#U#];
+// INSTANCE_LABEL-DAG: Pattern/Local/Flair[ExprSpecific]: {#instance: U#}[#U#];
 // INSTANCE_LABEL: End completions
 }
 

--- a/test/IDE/complete_subscript.swift
+++ b/test/IDE/complete_subscript.swift
@@ -31,27 +31,27 @@ func test1() {
   let _ = MyStruct #^METATYPE_UNRESOLVED^#
 // METATYPE_UNRESOLVED: Begin completions, 4 items
 // METATYPE_UNRESOLVED-DAG: Decl[Subscript]/CurrNominal:        [{#(x): Int#}, {#static: _#}][#MyStruct<_>#];
-// METATYPE_UNRESOLVED-DAG: Decl[Constructor]/CurrNominal:      ()[#MyStruct<_>#];
+// METATYPE_UNRESOLVED-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ()[#MyStruct<_>#];
 // METATYPE_UNRESOLVED-DAG: Keyword[self]/CurrNominal:          .self[#MyStruct<_>.Type#];
 // METATYPE_UNRESOLVED-DAG: Keyword/CurrNominal:                .Type[#MyStruct<_>.Type#];
 // METATYPE_UNRESOLVED: End completions
 
   let _ = MyStruct[#^METATYPE_UNRESOLVED_BRACKET^#
 // METATYPE_UNRESOLVED_BRACKET: Begin completions
-// METATYPE_UNRESOLVED_BRACKET-DAG: Decl[Subscript]/CurrNominal:        ['[']{#(x): Int#}, {#static: _#}[']'][#MyStruct<_>#];
+// METATYPE_UNRESOLVED_BRACKET-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]:        ['[']{#(x): Int#}, {#static: _#}[']'][#MyStruct<_>#];
 // METATYPE_UNRESOLVED_BRACKET: End completions
 
   let _ = MyStruct<Int> #^METATYPE_INT^#
 // METATYPE_INT: Begin completions, 4 items
 // METATYPE_INT-DAG: Decl[Subscript]/CurrNominal:        [{#(x): Int#}, {#static: Int#}][#MyStruct<Int>#];
-// METATYPE_INT-DAG: Decl[Constructor]/CurrNominal:      ()[#MyStruct<Int>#];
+// METATYPE_INT-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ()[#MyStruct<Int>#];
 // METATYPE_INT-DAG: Keyword[self]/CurrNominal:          .self[#MyStruct<Int>.Type#];
 // METATYPE_INT-DAG: Keyword/CurrNominal:                .Type[#MyStruct<Int>.Type#];
 // METATYPE_INT: End completions
 
   let _ = MyStruct<Int>[#^METATYPE_INT_BRACKET^#
 // METATYPE_INT_BRACKET: Begin completions
-// METATYPE_INT_BRACKET-DAG: Decl[Subscript]/CurrNominal:        ['[']{#(x): Int#}, {#static: Int#}[']'][#MyStruct<Int>#];
+// METATYPE_INT_BRACKET-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]:        ['[']{#(x): Int#}, {#static: Int#}[']'][#MyStruct<Int>#];
 // METATYPE_INT_BRACKET: End completions
 
   let _ = MyStruct<Int>()#^INSTANCE_INT^#
@@ -62,22 +62,22 @@ func test1() {
 
   let _ = MyStruct<Int>()[#^INSTANCE_INT_BRACKET^#
 // INSTANCE_INT_BRACKET: Begin completions
-// INSTANCE_INT_BRACKET-DAG: Decl[Subscript]/CurrNominal:        ['[']{#(x): Int#}, {#instance: Int#}[']'][#Int#];
-// INSTANCE_INT_BRACKET-DAG: Pattern/CurrModule:                 ['[']{#keyPath: KeyPath<MyStruct<Int>, Value>#}[']'][#Value#];
+// INSTANCE_INT_BRACKET-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]:        ['[']{#(x): Int#}, {#instance: Int#}[']'][#Int#];
+// INSTANCE_INT_BRACKET-DAG: Pattern/CurrModule/Flair[ArgLabels]:                 ['[']{#keyPath: KeyPath<MyStruct<Int>, Value>#}[']'][#Value#];
 // INSTANCE_INT_BRACKET: End completions
 }
 func test2<U>(value: MyStruct<U>) {
   let _ = MyStruct<U>#^METATYPE_ARCHETYPE^#
 // METATYPE_ARCHETYPE: Begin completions, 4 items
 // METATYPE_ARCHETYPE-DAG: Decl[Subscript]/CurrNominal:        [{#(x): Int#}, {#static: U#}][#MyStruct<U>#];
-// METATYPE_ARCHETYPE-DAG: Decl[Constructor]/CurrNominal:      ()[#MyStruct<U>#];
+// METATYPE_ARCHETYPE-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ()[#MyStruct<U>#];
 // METATYPE_ARCHETYPE-DAG: Keyword[self]/CurrNominal:          .self[#MyStruct<U>.Type#];
 // METATYPE_ARCHETYPE-DAG: Keyword/CurrNominal:                .Type[#MyStruct<U>.Type#];
 // METATYPE_ARCHETYPE: End completions
 
   let _ = MyStruct<U>[#^METATYPE_ARCHETYPE_BRACKET^#
 // METATYPE_ARCHETYPE_BRACKET: Begin completions
-// METATYPE_ARCHETYPE_BRACKET-DAG: Decl[Subscript]/CurrNominal:        ['[']{#(x): Int#}, {#static: U#}[']'][#MyStruct<U>#];
+// METATYPE_ARCHETYPE_BRACKET-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]:        ['[']{#(x): Int#}, {#static: U#}[']'][#MyStruct<U>#];
 // METATYPE_ARCHETYPE_BRACKET: End completions
 
   let _ = value #^INSTANCE_ARCHETYPE^#
@@ -88,18 +88,18 @@ func test2<U>(value: MyStruct<U>) {
 
   let _ = value[#^INSTANCE_ARCHETYPE_BRACKET^#
 // INSTANCE_ARCHETYPE_BRACKET: Begin completions
-// INSTANCE_ARCHETYPE_BRACKET-DAG: Decl[Subscript]/CurrNominal:        ['[']{#(x): Int#}, {#instance: U#}[']'][#Int#];
-// INSTANCE_ARCHETYPE_BRACKET-DAG: Pattern/CurrModule:                 ['[']{#keyPath: KeyPath<MyStruct<U>, Value>#}[']'][#Value#];
+// INSTANCE_ARCHETYPE_BRACKET-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]:        ['[']{#(x): Int#}, {#instance: U#}[']'][#Int#];
+// INSTANCE_ARCHETYPE_BRACKET-DAG: Pattern/CurrModule/Flair[ArgLabels]:                 ['[']{#keyPath: KeyPath<MyStruct<U>, Value>#}[']'][#Value#];
 // INSTANCE_ARCHETYPE_BRACKET: End completions
 
   let _ = MyStruct<U>[42, #^METATYPE_LABEL^#
 // METATYPE_LABEL: Begin completions, 1 items
-// METATYPE_LABEL-DAG: Pattern/Local/Flair[ExprSpecific]: {#static: U#}[#U#];
+// METATYPE_LABEL-DAG: Pattern/Local/Flair[ArgLabels]: {#static: U#}[#U#];
 // METATYPE_LABEL: End completions
 
   let _ = value[42, #^INSTANCE_LABEL^#
 // INSTANCE_LABEL: Begin completions, 1 items
-// INSTANCE_LABEL-DAG: Pattern/Local/Flair[ExprSpecific]: {#instance: U#}[#U#];
+// INSTANCE_LABEL-DAG: Pattern/Local/Flair[ArgLabels]: {#instance: U#}[#U#];
 // INSTANCE_LABEL: End completions
 }
 
@@ -114,28 +114,28 @@ class Derived: Base {
   func testInstance() {
     let _ = self[#^SELF_IN_INSTANCEMETHOD^#]
 // SELF_IN_INSTANCEMETHOD: Begin completions, 3 items
-// SELF_IN_INSTANCEMETHOD-DAG: Decl[Subscript]/CurrNominal: ['[']{#derivedInstance: Int#}[']'][#Int#];
-// SELF_IN_INSTANCEMETHOD-DAG: Decl[Subscript]/Super:       ['[']{#instance: Int#}[']'][#Int#];
-// SELF_IN_INSTANCEMETHOD-DAG: Pattern/CurrModule:          ['[']{#keyPath: KeyPath<Derived, Value>#}[']'][#Value#];
+// SELF_IN_INSTANCEMETHOD-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]: ['[']{#derivedInstance: Int#}[']'][#Int#];
+// SELF_IN_INSTANCEMETHOD-DAG: Decl[Subscript]/Super/Flair[ArgLabels]:       ['[']{#instance: Int#}[']'][#Int#];
+// SELF_IN_INSTANCEMETHOD-DAG: Pattern/CurrModule/Flair[ArgLabels]:          ['[']{#keyPath: KeyPath<Derived, Value>#}[']'][#Value#];
 // SELF_IN_INSTANCEMETHOD: End completions
 
     let _ = super[#^SUPER_IN_INSTANCEMETHOD^#]
 // SUPER_IN_INSTANCEMETHOD: Begin completions, 2 items
-// SUPER_IN_INSTANCEMETHOD-DAG: Decl[Subscript]/CurrNominal: ['[']{#instance: Int#}[']'][#Int#];
-// SUPER_IN_INSTANCEMETHOD-DAG: Pattern/CurrModule:          ['[']{#keyPath: KeyPath<Base, Value>#}[']'][#Value#];
+// SUPER_IN_INSTANCEMETHOD-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]: ['[']{#instance: Int#}[']'][#Int#];
+// SUPER_IN_INSTANCEMETHOD-DAG: Pattern/CurrModule/Flair[ArgLabels]:          ['[']{#keyPath: KeyPath<Base, Value>#}[']'][#Value#];
 // SUPER_IN_INSTANCEMETHOD: End completions
   }
 
   static func testStatic() {
     let _ = self[#^SELF_IN_STATICMETHOD^#]
 // SELF_IN_STATICMETHOD: Begin completions, 2 items
-// SELF_IN_STATICMETHOD-DAG: Decl[Subscript]/CurrNominal: ['[']{#derivedStatic: Int#}[']'][#Int#];
-// SELF_IN_STATICMETHOD-DAG: Decl[Subscript]/Super:       ['[']{#static: Int#}[']'][#Int#];
+// SELF_IN_STATICMETHOD-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]: ['[']{#derivedStatic: Int#}[']'][#Int#];
+// SELF_IN_STATICMETHOD-DAG: Decl[Subscript]/Super/Flair[ArgLabels]:       ['[']{#static: Int#}[']'][#Int#];
 // SELF_IN_STATICMETHOD: End completions
 
     let _ = super[#^SUPER_IN_STATICMETHOD^#]
 // SUPER_IN_STATICMETHOD: Begin completions, 1 items
-// SUPER_IN_STATICMETHOD-DAG: Decl[Subscript]/CurrNominal: ['[']{#static: Int#}[']'][#Int#];
+// SUPER_IN_STATICMETHOD-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]: ['[']{#static: Int#}[']'][#Int#];
 // SUPER_IN_STATICMETHOD: End completions
   }
 }
@@ -146,14 +146,14 @@ struct MyStruct1<X: Comparable> {
 func testSubscriptCallSig<T>(val: MyStruct1<T>) {
   val[#^LABELED_SUBSCRIPT^#
 // LABELED_SUBSCRIPT: Begin completions, 2 items
-// LABELED_SUBSCRIPT-DAG: Decl[Subscript]/CurrNominal:        ['[']{#idx1: Int#}, {#idx2: Comparable#}[']'][#Int!#];
-// LABELED_SUBSCRIPT-DAG: Pattern/CurrModule:                 ['[']{#keyPath: KeyPath<MyStruct1<T>, Value>#}[']'][#Value#];
+// LABELED_SUBSCRIPT-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]:        ['[']{#idx1: Int#}, {#idx2: Comparable#}[']'][#Int!#];
+// LABELED_SUBSCRIPT-DAG: Pattern/CurrModule/Flair[ArgLabels]:                 ['[']{#keyPath: KeyPath<MyStruct1<T>, Value>#}[']'][#Value#];
 // LABELED_SUBSCRIPT: End completions
 }
 
 func testSubcscriptTuple(val: (x: Int, String)) {
   val[#^TUPLE^#]
 // TUPLE: Begin completions, 1 items
-// TUPLE-DAG: Pattern/CurrModule:                 ['[']{#keyPath: KeyPath<(x: Int, String), Value>#}[']'][#Value#];
+// TUPLE-DAG: Pattern/CurrModule/Flair[ArgLabels]:                 ['[']{#keyPath: KeyPath<(x: Int, String), Value>#}[']'][#Value#];
 // TUPLE: End completions
 }

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -98,9 +98,9 @@ class C2 {
 // UNRESOLVED_1:  Begin completions
 // UNRESOLVED_1-NOT:  SomeEnum1
 // UNRESOLVED_1-NOT:  SomeEnum2
-// UNRESOLVED_1-DAG:  Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: Option1[#SomeOptions1#]; name=Option1
-// UNRESOLVED_1-DAG:  Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: Option2[#SomeOptions1#]; name=Option2
-// UNRESOLVED_1-DAG:  Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: Option3[#SomeOptions1#]; name=Option3
+// UNRESOLVED_1-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option1[#SomeOptions1#]; name=Option1
+// UNRESOLVED_1-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option2[#SomeOptions1#]; name=Option2
+// UNRESOLVED_1-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option3[#SomeOptions1#]; name=Option3
 // UNRESOLVED_1-DAG:  Decl[StaticVar]/CurrNominal:        NotOption[#Int#]; name=NotOption
 // UNRESOLVED_1-NOT:  NotStaticOption
 }
@@ -115,9 +115,9 @@ class C3 {
 // UNRESOLVED_2:  Begin completions
 // UNRESOLVED_2-NOT:  SomeEnum1
 // UNRESOLVED_2-NOT:  SomeEnum2
-// UNRESOLVED_2-DAG:  Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: Option4[#SomeOptions2#]; name=Option4
-// UNRESOLVED_2-DAG:  Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: Option5[#SomeOptions2#]; name=Option5
-// UNRESOLVED_2-DAG:  Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: Option6[#SomeOptions2#]; name=Option6
+// UNRESOLVED_2-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option4[#SomeOptions2#]; name=Option4
+// UNRESOLVED_2-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option5[#SomeOptions2#]; name=Option5
+// UNRESOLVED_2-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option6[#SomeOptions2#]; name=Option6
 // UNRESOLVED_2-NOT:  Not
 }
 
@@ -145,15 +145,15 @@ class C4 {
 
 // Exhaustive to make sure we don't include `SomeOptions1`, `SomeOptions2`, `none` or `some` entries.
 // UNRESOLVED_3: Begin completions, 3 items
-// UNRESOLVED_3-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: North[#SomeEnum1#]; name=North
-// UNRESOLVED_3-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: South[#SomeEnum1#]; name=South
+// UNRESOLVED_3-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: North[#SomeEnum1#]; name=North
+// UNRESOLVED_3-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: South[#SomeEnum1#]; name=South
 // UNRESOLVED_3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): SomeEnum1#})[#(into: inout Hasher) -> Void#]; name=hash(self: SomeEnum1)
 // UNRESOLVED_3: End completions
 
 // Exhaustive to make sure we don't include `init({#(some):` or `init({#nilLiteral:` entries
 // UNRESOLVED_3_OPT: Begin completions, 9 items
-// UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]: North[#SomeEnum1#];
-// UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]: South[#SomeEnum1#];
+// UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: North[#SomeEnum1#];
+// UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: South[#SomeEnum1#];
 // UNRESOLVED_3_OPT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): SomeEnum1#})[#(into: inout Hasher) -> Void#];
 // UNRESOLVED_3_OPT-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Identical]: nil[#SomeEnum1?#]; name=nil
 // UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: none[#Optional<SomeEnum1>#]; name=none
@@ -165,8 +165,8 @@ class C4 {
 
 // Exhaustive to make sure we don't include `init({#(some):` or `init({#nilLiteral:` entries
 // UNRESOLVED_3_OPTOPTOPT: Begin completions, 9 items
-// UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]: North[#SomeEnum1#];
-// UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]: South[#SomeEnum1#];
+// UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: North[#SomeEnum1#];
+// UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: South[#SomeEnum1#];
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): SomeEnum1#})[#(into: inout Hasher) -> Void#];
 // UNRESOLVED_3_OPTOPTOPT-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Identical]: nil[#SomeEnum1???#]; name=nil
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: none[#Optional<SomeEnum1??>#]; name=none
@@ -186,8 +186,8 @@ extension Optional where Wrapped == Somewhere {
 func testOptionalWithCustomExtension() {
   var _: Somewhere? = .#^UNRESOLVED_OPT_4^#
 // UNRESOLVED_OPT_4: Begin completions, 11 items
-// UNRESOLVED_OPT_4-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]:     earth[#Somewhere#];
-// UNRESOLVED_OPT_4-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]:     mars[#Somewhere#];
+// UNRESOLVED_OPT_4-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     earth[#Somewhere#];
+// UNRESOLVED_OPT_4-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     mars[#Somewhere#];
 // UNRESOLVED_OPT_4-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Somewhere#})[#(into: inout Hasher) -> Void#];
 // UNRESOLVED_OPT_4-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Identical]: nil[#Somewhere?#]; name=nil
 // UNRESOLVED_OPT_4-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: none[#Optional<Somewhere>#]; name=none
@@ -229,9 +229,9 @@ Container.EnumTaker1(.#^UNRESOLVED_20?check=UNRESOLVED_3^#
 func parserSync() {}
 
 // UNRESOLVED_4: Begin completions
-// UNRESOLVED_4-DAG: Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: Option1[#SomeOptions1#]; name=Option1
-// UNRESOLVED_4-DAG: Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: Option2[#SomeOptions1#]; name=Option2
-// UNRESOLVED_4-DAG: Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: Option3[#SomeOptions1#]; name=Option3
+// UNRESOLVED_4-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option1[#SomeOptions1#]; name=Option1
+// UNRESOLVED_4-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option2[#SomeOptions1#]; name=Option2
+// UNRESOLVED_4-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option3[#SomeOptions1#]; name=Option3
 // UNRESOLVED_4-NOT: Option4
 // UNRESOLVED_4-NOT: Option5
 // UNRESOLVED_4-NOT: Option6
@@ -307,8 +307,8 @@ func testAvail1(_ x: EnumAvail1) {
 }
 // ENUM_AVAIL_1: Begin completions, 3 items
 // ENUM_AVAIL_1-NOT: AAA
-// ENUM_AVAIL_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: aaa[#EnumAvail1#];
-// ENUM_AVAIL_1-DAG: Decl[EnumElement]/ExprSpecific/NotRecommended/TypeRelation[Identical]: BBB[#EnumAvail1#];
+// ENUM_AVAIL_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: aaa[#EnumAvail1#];
+// ENUM_AVAIL_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/NotRecommended/TypeRelation[Identical]: BBB[#EnumAvail1#];
 // ENUM_AVAIL_1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): EnumAvail1#})[#(into: inout Hasher) -> Void#];
 // ENUM_AVAIL_1-NOT: AAA
 // ENUM_AVAIL_1: End completions
@@ -318,8 +318,8 @@ func testAvail2(_ x: OptionsAvail1) {
 }
 // OPTIONS_AVAIL_1: Begin completions
 // OPTIONS_AVAIL_1-NOT: AAA
-// OPTIONS_AVAIL_1-DAG: Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: aaa[#OptionsAvail1#];
-// OPTIONS_AVAIL_1-DAG: Decl[StaticVar]/ExprSpecific/NotRecommended/TypeRelation[Identical]: BBB[#OptionsAvail1#];
+// OPTIONS_AVAIL_1-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: aaa[#OptionsAvail1#];
+// OPTIONS_AVAIL_1-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/NotRecommended/TypeRelation[Identical]: BBB[#OptionsAvail1#];
 // OPTIONS_AVAIL_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init({#rawValue: Int#})[#OptionsAvail1#]
 // OPTIONS_AVAIL_1-NOT: AAA
 // OPTIONS_AVAIL_1: End completions
@@ -334,7 +334,7 @@ func testWithLiteral1() {
   let s: S
   _ = s.takeEnum(thing: .#^WITH_LITERAL_1^#, other: 1.0)
 // WITH_LITERAL_1: Begin completions, 2 items
-// WITH_LITERAL_1-NEXT: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: myCase[#S.MyEnum#];
+// WITH_LITERAL_1-NEXT: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: myCase[#S.MyEnum#];
 // WITH_LITERAL_1-NEXT: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): S.MyEnum#})[#(into: inout Hasher) -> Void#];
 // WITH_LITERAL_1-NEXT: End completions
 }
@@ -359,7 +359,7 @@ func testWithLiteral3() {
     func test(s: S) {
       _ = s.takeEnum(thing: .#^WITH_LITERAL_3^#, other: 1.0)
 // WITH_LITERAL_3: Begin completions, 2 items
-// WITH_LITERAL_3-NEXT: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: myCase[#MyEnum#];
+// WITH_LITERAL_3-NEXT: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: myCase[#MyEnum#];
 // WITH_LITERAL_3-NEXT: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): MyEnum#})[#(into: inout Hasher) -> Void#];
 // WITH_LITERAL_3-NEXT: End completions
     }
@@ -376,9 +376,9 @@ func enumFromOtherFile() -> EnumFromOtherFile {
   return .#^OTHER_FILE_1^# // Don't crash.
 }
 // OTHER_FILE_1: Begin completions
-// OTHER_FILE_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: b({#String#})[#EnumFromOtherFile#];
-// OTHER_FILE_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: a({#Int#})[#EnumFromOtherFile#];
-// OTHER_FILE_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: c[#EnumFromOtherFile#];
+// OTHER_FILE_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: b({#String#})[#EnumFromOtherFile#];
+// OTHER_FILE_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: a({#Int#})[#EnumFromOtherFile#];
+// OTHER_FILE_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: c[#EnumFromOtherFile#];
 // OTHER_FILE_1: End completions
 
 struct NonOptSet {
@@ -397,11 +397,11 @@ func testNonOptSet() {
   x = .#^NON_OPT_SET_1^#
 }
 // NON_OPT_SET_1: Begin completions, 6 items
-// NON_OPT_SET_1-DAG: Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]:    a[#NonOptSet#]
+// NON_OPT_SET_1-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:    a[#NonOptSet#]
 // NON_OPT_SET_1-DAG: Decl[StaticVar]/CurrNominal:        wrongType[#Int#];
 // NON_OPT_SET_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]:  init({#x: Int#}, {#y: Int#})[#NonOptSet#]
 // NON_OPT_SET_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]:  init()[#NonOptSet#]
-// NON_OPT_SET_1-DAG: Decl[StaticMethod]/ExprSpecific/TypeRelation[Identical]: b()[#NonOptSet#]
+// NON_OPT_SET_1-DAG: Decl[StaticMethod]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: b()[#NonOptSet#]
 // NON_OPT_SET_1-DAG: Decl[InstanceMethod]/CurrNominal: notStatic({#(self): NonOptSet#})[#() -> NonOptSet#];
 // NON_OPT_SET_1: End completions
 
@@ -420,8 +420,8 @@ func testInStringInterpolation() {
   let y = "enum: \(.#^STRING_INTERPOLATION_INVALID?check=NOCRASH^#)" // Dont'crash.
 }
 // STRING_INTERPOLATION_1: Begin completions
-// STRING_INTERPOLATION_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: foo[#MyEnum#];
-// STRING_INTERPOLATION_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: bar[#MyEnum#];
+// STRING_INTERPOLATION_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: foo[#MyEnum#];
+// STRING_INTERPOLATION_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bar[#MyEnum#];
 // STRING_INTERPOLATION_1: End completions
 
 class BaseClass {
@@ -471,15 +471,15 @@ switch Generic<Int>.empty {
 case let .#^GENERIC_4?check=GENERIC_1_INT^#
 }
 // GENERIC_1_INT: Begin completions
-// GENERIC_1_INT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: contains({#content: Int#})[#Generic<Int>#];
-// GENERIC_1_INT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: empty[#Generic<Int>#];
-// GENERIC_1_INT-DAG: Decl[StaticMethod]/ExprSpecific/TypeRelation[Identical]: create({#Int#})[#Generic<Int>#];
+// GENERIC_1_INT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: contains({#content: Int#})[#Generic<Int>#];
+// GENERIC_1_INT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: empty[#Generic<Int>#];
+// GENERIC_1_INT-DAG: Decl[StaticMethod]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: create({#Int#})[#Generic<Int>#];
 // GENERIC_1_INT: End completions
 
 // GENERIC_1_U: Begin completions
-// GENERIC_1_U-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: contains({#content: U#})[#Generic<U>#];
-// GENERIC_1_U-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: empty[#Generic<U>#];
-// GENERIC_1_U-DAG: Decl[StaticMethod]/ExprSpecific/TypeRelation[Identical]: create({#U#})[#Generic<U>#];
+// GENERIC_1_U-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: contains({#content: U#})[#Generic<U>#];
+// GENERIC_1_U-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: empty[#Generic<U>#];
+// GENERIC_1_U-DAG: Decl[StaticMethod]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: create({#U#})[#Generic<U>#];
 // GENERIC_1_U: End completions
 
 struct HasCreator {
@@ -505,11 +505,11 @@ struct HasOverloaded {
 func testOverload(val: HasOverloaded) {
   let _ = val.takeEnum(.#^OVERLOADED_METHOD_1^#)
 // OVERLOADED_METHOD_1: Begin completions, 6 items
-// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: South[#SomeEnum1#]; name=South
-// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: North[#SomeEnum1#]; name=North
+// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: South[#SomeEnum1#]; name=South
+// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: North[#SomeEnum1#]; name=North
 // OVERLOADED_METHOD_1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): SomeEnum1#})[#(into: inout Hasher) -> Void#];
-// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: East[#SomeEnum2#]; name=East
-// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: West[#SomeEnum2#]; name=West
+// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: East[#SomeEnum2#]; name=East
+// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: West[#SomeEnum2#]; name=West
 // OVERLOADED_METHOD_1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): SomeEnum2#})[#(into: inout Hasher) -> Void#];
 // OVERLOADED_METHOD_1: End completions
 
@@ -527,7 +527,7 @@ func receiveHasStatic<T: HasStatic>(x: T)  {}
 func testingGenericParam1<T: HasStatic>(x: inout T, fn: (T) -> Void) -> T {
   x = .#^GENERICPARAM_1^#
 // GENERICPARAM_1: Begin completions, 1 items
-// GENERICPARAM_1: Decl[StaticVar]/{{ExprSpecific|CurrNominal}}/TypeRelation[Identical]: instance[#HasStatic#]; name=instance
+// GENERICPARAM_1: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: instance[#HasStatic#]; name=instance
 // GENERICPARAM_1: End completions
 
   /* Parser sync. */;
@@ -669,11 +669,11 @@ func testClosureReturnTypeForOverloaded() {
     .#^OVERLOADED_CLOSURE_RETURN^#
   }
 // OVERLOADED_CLOSURE_RETURN: Begin completions, 6 items
-// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: South[#SomeEnum1#];
-// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: North[#SomeEnum1#];
+// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: South[#SomeEnum1#];
+// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: North[#SomeEnum1#];
 // OVERLOADED_CLOSURE_RETURN-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): SomeEnum1#})[#(into: inout Hasher) -> Void#];
-// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: East[#SomeEnum2#];
-// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: West[#SomeEnum2#];
+// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: East[#SomeEnum2#];
+// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: West[#SomeEnum2#];
 // OVERLOADED_CLOSURE_RETURN-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): SomeEnum2#})[#(into: inout Hasher) -> Void#];
 // OVERLOADED_CLOSURE_RETURN: End completions
 }
@@ -706,8 +706,8 @@ func testSameType() {
   testSugarType(.#^SUGAR_TYPE^#
 // Ensure results aren't duplicated.
 // SUGAR_TYPE: Begin completions, 9 items
-// SUGAR_TYPE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: South[#SomeEnum1#];
-// SUGAR_TYPE-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: North[#SomeEnum1#];
+// SUGAR_TYPE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: South[#SomeEnum1#];
+// SUGAR_TYPE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: North[#SomeEnum1#];
 // SUGAR_TYPE-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): SomeEnum1#})[#(into: inout Hasher) -> Void#];
 // SUGAR_TYPE-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Identical]: nil[#SomeEnum1?#];
 // SUGAR_TYPE-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: none[#Optional<SomeEnum1>#];

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -301,9 +301,9 @@ var fooObject: FooStruct
 // FOO_STRUCT_NO_DOT-NEXT: Decl[StaticMethod]/CurrNominal:   .overloadedStaticFunc1()[#Double#]{{; name=.+$}}
 // FOO_STRUCT_NO_DOT-NEXT: Decl[StaticMethod]/CurrNominal:   .overloadedStaticFunc2({#(x): Int#})[#Int#]{{; name=.+$}}
 // FOO_STRUCT_NO_DOT-NEXT: Decl[StaticMethod]/CurrNominal:   .overloadedStaticFunc2({#(x): Double#})[#Int#]{{; name=.+$}}
-// FOO_STRUCT_NO_DOT-NEXT: Decl[Constructor]/CurrNominal:    ()[#FooStruct#]{{; name=.+$}}
-// FOO_STRUCT_NO_DOT-NEXT: Decl[Constructor]/CurrNominal:    ({#lazyInstanceVar: Int?#}, {#instanceVar: Int#})[#FooStruct#]{{; name=.+$}}
-// FOO_STRUCT_NO_DOT-NEXT: Decl[Constructor]/CurrNominal:    ()[#FooStruct#]{{; name=.+$}}
+// FOO_STRUCT_NO_DOT-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:    ()[#FooStruct#]{{; name=.+$}}
+// FOO_STRUCT_NO_DOT-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:    ({#lazyInstanceVar: Int?#}, {#instanceVar: Int#})[#FooStruct#]{{; name=.+$}}
+// FOO_STRUCT_NO_DOT-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:    ()[#FooStruct#]{{; name=.+$}}
 // FOO_STRUCT_NO_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: .extFunc0({#(self): &FooStruct#})[#() -> Void#]{{; name=.+$}}
 // FOO_STRUCT_NO_DOT-NEXT: Decl[StaticVar]/CurrNominal:      .extStaticProp[#Int#]{{; name=.+$}}
 // FOO_STRUCT_NO_DOT-NEXT: Decl[StaticMethod]/CurrNominal:   .extStaticFunc0()[#Void#]{{; name=.+$}}
@@ -373,37 +373,37 @@ func testMetatypeCompletionsWithoutDot() {
 func testImplicitlyCurriedFunc(_ fs: inout FooStruct) {
   FooStruct.instanceFunc0(&fs)#^IMPLICITLY_CURRIED_FUNC_0^#
 // IMPLICITLY_CURRIED_FUNC_0: Begin completions
-// IMPLICITLY_CURRIED_FUNC_0-NEXT: Decl[InstanceMethod]/CurrNominal: ()[#Void#]{{; name=.+$}}
+// IMPLICITLY_CURRIED_FUNC_0-NEXT: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ()[#Void#]{{; name=.+$}}
 // IMPLICITLY_CURRIED_FUNC_0-NEXT: Keyword[self]/CurrNominal: .self[#() -> ()#]; name=self
 // IMPLICITLY_CURRIED_FUNC_0-NEXT: End completions
 
   FooStruct.instanceFunc1(&fs)#^IMPLICITLY_CURRIED_FUNC_1^#
 // IMPLICITLY_CURRIED_FUNC_1: Begin completions
-// IMPLICITLY_CURRIED_FUNC_1-NEXT: Decl[InstanceMethod]/CurrNominal: ({#(a): Int#})[#Void#]{{; name=.+$}}
+// IMPLICITLY_CURRIED_FUNC_1-NEXT: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ({#(a): Int#})[#Void#]{{; name=.+$}}
 // IMPLICITLY_CURRIED_FUNC_1-NEXT: Keyword[self]/CurrNominal: .self[#(Int) -> ()#]; name=self
 // IMPLICITLY_CURRIED_FUNC_1-NEXT: End completions
 
   FooStruct.instanceFunc2(&fs)#^IMPLICITLY_CURRIED_FUNC_2^#
 // IMPLICITLY_CURRIED_FUNC_2: Begin completions
-// IMPLICITLY_CURRIED_FUNC_2-NEXT: Decl[InstanceMethod]/CurrNominal: ({#(a): Int#}, {#b: &Double#})[#Void#]{{; name=.+$}}
+// IMPLICITLY_CURRIED_FUNC_2-NEXT: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ({#(a): Int#}, {#b: &Double#})[#Void#]{{; name=.+$}}
 // IMPLICITLY_CURRIED_FUNC_2-NEXT: Keyword[self]/CurrNominal: .self[#(Int, inout Double) -> ()#]; name=self
 // IMPLICITLY_CURRIED_FUNC_2-NEXT: End completions
 
   FooStruct.varargInstanceFunc0(&fs)#^IMPLICITLY_CURRIED_VARARG_FUNC_0^#
 // IMPLICITLY_CURRIED_VARARG_FUNC_0: Begin completions
-// IMPLICITLY_CURRIED_VARARG_FUNC_0-NEXT: Decl[InstanceMethod]/CurrNominal: ({#(v): Int...#})[#Void#]{{; name=.+$}}
+// IMPLICITLY_CURRIED_VARARG_FUNC_0-NEXT: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ({#(v): Int...#})[#Void#]{{; name=.+$}}
 // IMPLICITLY_CURRIED_VARARG_FUNC_0-NEXT: Keyword[self]/CurrNominal: .self[#(Int...) -> ()#]; name=self
 // IMPLICITLY_CURRIED_VARARG_FUNC_0-NEXT: End completions
 
   FooStruct.varargInstanceFunc1(&fs)#^IMPLICITLY_CURRIED_VARARG_FUNC_1^#
 // IMPLICITLY_CURRIED_VARARG_FUNC_1: Begin completions
-// IMPLICITLY_CURRIED_VARARG_FUNC_1-NEXT: Decl[InstanceMethod]/CurrNominal: ({#(a): Float#}, {#v: Int...#})[#Void#]{{; name=.+$}}
+// IMPLICITLY_CURRIED_VARARG_FUNC_1-NEXT: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ({#(a): Float#}, {#v: Int...#})[#Void#]{{; name=.+$}}
 // IMPLICITLY_CURRIED_VARARG_FUNC_1-NEXT: Keyword[self]/CurrNominal: .self[#(Float, Int...) -> ()#]; name=self
 // IMPLICITLY_CURRIED_VARARG_FUNC_1-NEXT: End completions
 
   FooStruct.varargInstanceFunc2(&fs)#^IMPLICITLY_CURRIED_VARARG_FUNC_2^#
 // IMPLICITLY_CURRIED_VARARG_FUNC_2: Begin completions
-// IMPLICITLY_CURRIED_VARARG_FUNC_2-NEXT: Decl[InstanceMethod]/CurrNominal: ({#(a): Float#}, {#b: Double#}, {#v: Int...#})[#Void#]{{; name=.+$}}
+// IMPLICITLY_CURRIED_VARARG_FUNC_2-NEXT: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ({#(a): Float#}, {#b: Double#}, {#v: Int...#})[#Void#]{{; name=.+$}}
 // IMPLICITLY_CURRIED_VARARG_FUNC_2-NEXT: Keyword[self]/CurrNominal: .self[#(Float, Double, Int...) -> ()#]; name=self
 // IMPLICITLY_CURRIED_VARARG_FUNC_2-NEXT: End completions
 
@@ -539,7 +539,7 @@ func testInsideFunctionCall1() {
   var a = FooStruct()
   a.instanceFunc0(#^INSIDE_FUNCTION_CALL_1^#
 // INSIDE_FUNCTION_CALL_1: Begin completions, 1 items
-// INSIDE_FUNCTION_CALL_1: Decl[InstanceMethod]/CurrNominal: ['('][')'][#Void#]; name=
+// INSIDE_FUNCTION_CALL_1: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ['('][')'][#Void#]; name=
 // INSIDE_FUNCTION_CALL_1: End completions
 }
 
@@ -547,7 +547,7 @@ func testInsideFunctionCall2() {
   var a = FooStruct()
   a.instanceFunc1(#^INSIDE_FUNCTION_CALL_2^#
 // INSIDE_FUNCTION_CALL_2: Begin completions
-// INSIDE_FUNCTION_CALL_2-DAG: Decl[InstanceMethod]/CurrNominal: ['(']{#(a): Int#}[')'][#Void#]{{; name=.+$}}
+// INSIDE_FUNCTION_CALL_2-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ['(']{#(a): Int#}[')'][#Void#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_2-DAG: Decl[GlobalVar]/CurrModule: fooObject[#FooStruct#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_2: End completions
 }
@@ -561,7 +561,7 @@ func testInsideFunctionCall4() {
   var a = FooStruct()
   a.instanceFunc2(#^INSIDE_FUNCTION_CALL_4^#
 // INSIDE_FUNCTION_CALL_4: Begin completions
-// INSIDE_FUNCTION_CALL_4-DAG: Decl[InstanceMethod]/CurrNominal: ['(']{#(a): Int#}, {#b: &Double#}[')'][#Void#]{{; name=.+$}}
+// INSIDE_FUNCTION_CALL_4-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ['(']{#(a): Int#}, {#b: &Double#}[')'][#Void#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_4-DAG: Decl[GlobalVar]/CurrModule: fooObject[#FooStruct#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_4: End completions
 }
@@ -569,7 +569,7 @@ func testInsideFunctionCall4() {
 func testInsideFunctionCall5() {
   FooStruct().instanceFunc2(42, #^INSIDE_FUNCTION_CALL_5^#
 // INSIDE_FUNCTION_CALL_5: Begin completions
-// INSIDE_FUNCTION_CALL_5-DAG: Pattern/Local/Flair[ExprSpecific]: {#b: &Double#}[#inout Double#];
+// INSIDE_FUNCTION_CALL_5-DAG: Pattern/Local/Flair[ArgLabels]: {#b: &Double#}[#inout Double#];
 // INSIDE_FUNCTION_CALL_5: End completions
 }
 
@@ -577,7 +577,7 @@ func testInsideFunctionCall6() {
   var a = FooStruct()
   a.instanceFunc7(#^INSIDE_FUNCTION_CALL_6^#
 // INSIDE_FUNCTION_CALL_6: Begin completions
-// INSIDE_FUNCTION_CALL_6-NEXT: Decl[InstanceMethod]/CurrNominal: ['(']{#a: Int#}[')'][#Void#]{{; name=.+$}}
+// INSIDE_FUNCTION_CALL_6-NEXT: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ['(']{#a: Int#}[')'][#Void#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_6-NEXT: End completions
 }
 
@@ -585,21 +585,21 @@ func testInsideFunctionCall7() {
   var a = FooStruct()
   a.instanceFunc8(#^INSIDE_FUNCTION_CALL_7^#
 // INSIDE_FUNCTION_CALL_7: Begin completions
-// INSIDE_FUNCTION_CALL_7: Decl[InstanceMethod]/CurrNominal: ['(']{#(a): (Int, Int)#}[')'][#Void#]{{; name=.+$}}
+// INSIDE_FUNCTION_CALL_7: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ['(']{#(a): (Int, Int)#}[')'][#Void#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_7: End completions
 }
 
 func testInsideFunctionCall8(_ x: inout FooStruct) {
   x.instanceFunc0(#^INSIDE_FUNCTION_CALL_8^#)
 // INSIDE_FUNCTION_CALL_8: Begin completions
-// INSIDE_FUNCTION_CALL_8: Decl[InstanceMethod]/CurrNominal: ['('][')'][#Void#]; name=
+// INSIDE_FUNCTION_CALL_8: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ['('][')'][#Void#]; name=
 // INSIDE_FUNCTION_CALL_8: End completions
 }
 func testInsideFunctionCall9(_ x: inout FooStruct) {
   x.instanceFunc1(#^INSIDE_FUNCTION_CALL_9^#)
 // Annotated ')'
 // INSIDE_FUNCTION_CALL_9: Begin completions
-// INSIDE_FUNCTION_CALL_9-DAG: Decl[InstanceMethod]/CurrNominal: ['(']{#(a): Int#}[')'][#Void#]{{; name=.+$}}
+// INSIDE_FUNCTION_CALL_9-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ['(']{#(a): Int#}[')'][#Void#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_9-DAG: Decl[GlobalVar]/CurrModule: fooObject[#FooStruct#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_9: End completions
 }
@@ -607,14 +607,14 @@ func testInsideFunctionCall10(_ x: inout FooStruct) {
   x.instanceFunc2(#^INSIDE_FUNCTION_CALL_10^#)
 // Annotated ')'
 // INSIDE_FUNCTION_CALL_10: Begin completions
-// INSIDE_FUNCTION_CALL_10-DAG: Decl[InstanceMethod]/CurrNominal: ['(']{#(a): Int#}, {#b: &Double#}[')'][#Void#]{{; name=.+$}}
+// INSIDE_FUNCTION_CALL_10-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ['(']{#(a): Int#}, {#b: &Double#}[')'][#Void#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_10-DAG: Decl[GlobalVar]/CurrModule: fooObject[#FooStruct#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_10: End completions
 }
 func testInsideFunctionCall11(_ x: inout FooStruct) {
   x.instanceFunc2(#^INSIDE_FUNCTION_CALL_11?check=INSIDE_FUNCTION_CALL_4^#,
 // INSIDE_FUNCTION_CALL_11-NOT: Pattern/{{.*}}:{{.*}}({{.*}}{#Int#}
-// INSIDE_FUNCTION_CALL_11B: Decl[InstanceMethod]/CurrNominal: ['(']{#Int#}, {#b: &Double#}[')'][#Void#];
+// INSIDE_FUNCTION_CALL_11B: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ['(']{#Int#}, {#b: &Double#}[')'][#Void#];
 }
 func testInsideFunctionCall12(_ x: inout FooStruct) {
   x.instanceFunc2(#^INSIDE_FUNCTION_CALL_12?check=INSIDE_FUNCTION_CALL_4^#<#placeholder#>
@@ -625,7 +625,7 @@ func testInsideVarargFunctionCall1() {
   var a = FooStruct()
   a.varargInstanceFunc0(#^INSIDE_VARARG_FUNCTION_CALL_1^#
 // INSIDE_VARARG_FUNCTION_CALL_1: Begin completions
-// INSIDE_VARARG_FUNCTION_CALL_1-DAG: Decl[InstanceMethod]/CurrNominal: ['(']{#(v): Int...#}[')'][#Void#]{{; name=.+$}}
+// INSIDE_VARARG_FUNCTION_CALL_1-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ['(']{#(v): Int...#}[')'][#Void#]{{; name=.+$}}
 // INSIDE_VARARG_FUNCTION_CALL_1-DAG: Decl[GlobalVar]/CurrModule: fooObject[#FooStruct#]{{; name=.+$}}
 // INSIDE_VARARG_FUNCTION_CALL_1: End completions
 }
@@ -656,7 +656,7 @@ func testInsideOverloadedFunctionCall1() {
 func testInsideFunctionCallOnClassInstance1(_ a: FooClass) {
   a.fooClassInstanceFunc1(#^INSIDE_FUNCTION_CALL_ON_CLASS_INSTANCE_1^#
 // INSIDE_FUNCTION_CALL_ON_CLASS_INSTANCE_1: Begin completions
-// INSIDE_FUNCTION_CALL_ON_CLASS_INSTANCE_1-DAG: Decl[InstanceMethod]/CurrNominal:       ['(']{#(a): Int#}[')'][#Void#]{{; name=.+$}}
+// INSIDE_FUNCTION_CALL_ON_CLASS_INSTANCE_1-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:       ['(']{#(a): Int#}[')'][#Void#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_ON_CLASS_INSTANCE_1-DAG: Decl[GlobalVar]/CurrModule: fooObject[#FooStruct#]{{; name=.+$}}
 // INSIDE_FUNCTION_CALL_ON_CLASS_INSTANCE_1: End completions
 }
@@ -672,14 +672,14 @@ var funcTypeVarsObject: FuncTypeVars
 func testFuncTypeVars() {
   funcTypeVarsObject.funcVar1#^VF1^#
 // VF1: Begin completions
-// VF1-NEXT: Pattern/CurrModule: ()[#Double#]{{; name=.+$}}
+// VF1-NEXT: Pattern/CurrModule/Flair[ArgLabels]: ()[#Double#]{{; name=.+$}}
 // VF1-NEXT: BuiltinOperator/None:         = {#() -> Double##() -> Double#}[#Void#]
 // VF1-NEXT: Keyword[self]/CurrNominal:    .self[#() -> Double#]; name=self
 // VF1-NEXT: End completions
 
   funcTypeVarsObject.funcVar2#^VF2^#
 // VF2: Begin completions
-// VF2-NEXT: Pattern/CurrModule: ({#Int#})[#Double#]{{; name=.+$}}
+// VF2-NEXT: Pattern/CurrModule/Flair[ArgLabels]: ({#Int#})[#Double#]{{; name=.+$}}
 // VF2-NEXT: BuiltinOperator/None:         = {#(Int) -> Double##(_ a: Int) -> Double#}[#Void#]
 // VF2-NEXT: Keyword[self]/CurrNominal:    .self[#(Int) -> Double#]; name=self
 // VF2-NEXT: End completions
@@ -947,8 +947,8 @@ func testFuncParenPattern1(_ fpp: FuncParenPattern) {
 func testFuncParenPattern2(_ fpp: FuncParenPattern) {
   FuncParenPattern#^FUNC_PAREN_PATTERN_2^#
 // FUNC_PAREN_PATTERN_2: Begin completions
-// FUNC_PAREN_PATTERN_2-NEXT: Decl[Constructor]/CurrNominal: ({#Int#})[#FuncParenPattern#]{{; name=.+$}}
-// FUNC_PAREN_PATTERN_2-NEXT: Decl[Constructor]/CurrNominal: ({#(Int, Int)#})[#FuncParenPattern#]{{; name=.+$}}
+// FUNC_PAREN_PATTERN_2-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ({#Int#})[#FuncParenPattern#]{{; name=.+$}}
+// FUNC_PAREN_PATTERN_2-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ({#(Int, Int)#})[#FuncParenPattern#]{{; name=.+$}}
 // FUNC_PAREN_PATTERN_2-NEXT: Decl[InstanceMethod]/CurrNominal: .instanceFunc({#(self): &FuncParenPattern#})[#(Int) -> Void#]{{; name=.+$}}
 // FUNC_PAREN_PATTERN_2-NEXT: Keyword[self]/CurrNominal: .self[#FuncParenPattern.Type#]; name=self
 // FUNC_PAREN_PATTERN_2-NEXT: Keyword/CurrNominal: .Type[#FuncParenPattern.Type#]; name=Type
@@ -958,7 +958,7 @@ func testFuncParenPattern2(_ fpp: FuncParenPattern) {
 func testFuncParenPattern3(_ fpp: inout FuncParenPattern) {
   fpp.instanceFunc#^FUNC_PAREN_PATTERN_3^#
 // FUNC_PAREN_PATTERN_3: Begin completions
-// FUNC_PAREN_PATTERN_3-NEXT: Decl[InstanceMethod]/CurrNominal: ({#Int#})[#Void#]{{; name=.+$}}
+// FUNC_PAREN_PATTERN_3-NEXT: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ({#Int#})[#Void#]{{; name=.+$}}
 // FUNC_PAREN_PATTERN_3-NEXT: Keyword[self]/CurrNominal: .self[#(Int) -> ()#]; name=self
 // FUNC_PAREN_PATTERN_3-NEXT: End completions
 }
@@ -1018,8 +1018,8 @@ func testResolveGenericParams1() {
 
   FooGenericStruct<FooStruct>#^RESOLVE_GENERIC_PARAMS_1_STATIC^#
 // RESOLVE_GENERIC_PARAMS_1_STATIC: Begin completions
-// RESOLVE_GENERIC_PARAMS_1_STATIC-NEXT: Decl[Constructor]/CurrNominal:    ()[#FooGenericStruct<FooStruct>#]; name=()
-// RESOLVE_GENERIC_PARAMS_1_STATIC-NEXT: Decl[Constructor]/CurrNominal:    ({#t: FooStruct#})[#FooGenericStruct<FooStruct>#]{{; name=.+$}}
+// RESOLVE_GENERIC_PARAMS_1_STATIC-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:    ()[#FooGenericStruct<FooStruct>#]; name=()
+// RESOLVE_GENERIC_PARAMS_1_STATIC-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:    ({#t: FooStruct#})[#FooGenericStruct<FooStruct>#]{{; name=.+$}}
 // RESOLVE_GENERIC_PARAMS_1_STATIC-NEXT: Decl[InstanceMethod]/CurrNominal: .fooVoidInstanceFunc1({#(self): &FooGenericStruct<FooStruct>#})[#(FooStruct) -> Void#]{{; name=.+$}}
 // RESOLVE_GENERIC_PARAMS_1_STATIC-NEXT: Decl[InstanceMethod]/CurrNominal: .fooTInstanceFunc1({#(self): &FooGenericStruct<FooStruct>#})[#(FooStruct) -> FooStruct#]{{; name=.+$}}
 // RESOLVE_GENERIC_PARAMS_1_STATIC-NEXT: Decl[InstanceMethod]/CurrNominal: .fooUInstanceFunc1({#(self): &FooGenericStruct<FooStruct>#})[#(U) -> U#]{{; name=.+$}}
@@ -1046,8 +1046,8 @@ func testResolveGenericParams2<Foo : FooProtocol>(_ foo: Foo) {
 
   FooGenericStruct<Foo>#^RESOLVE_GENERIC_PARAMS_2_STATIC^#
 // RESOLVE_GENERIC_PARAMS_2_STATIC: Begin completions
-// RESOLVE_GENERIC_PARAMS_2_STATIC-NEXT: Decl[Constructor]/CurrNominal:    ()[#FooGenericStruct<FooProtocol>#]; name=()
-// RESOLVE_GENERIC_PARAMS_2_STATIC-NEXT: Decl[Constructor]/CurrNominal:    ({#t: FooProtocol#})[#FooGenericStruct<FooProtocol>#]{{; name=.+$}}
+// RESOLVE_GENERIC_PARAMS_2_STATIC-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:    ()[#FooGenericStruct<FooProtocol>#]; name=()
+// RESOLVE_GENERIC_PARAMS_2_STATIC-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:    ({#t: FooProtocol#})[#FooGenericStruct<FooProtocol>#]{{; name=.+$}}
 // RESOLVE_GENERIC_PARAMS_2_STATIC-NEXT: Decl[InstanceMethod]/CurrNominal: .fooVoidInstanceFunc1({#(self): &FooGenericStruct<FooProtocol>#})[#(FooProtocol) -> Void#]{{; name=.+$}}
 // RESOLVE_GENERIC_PARAMS_2_STATIC-NEXT: Decl[InstanceMethod]/CurrNominal: .fooTInstanceFunc1({#(self): &FooGenericStruct<FooProtocol>#})[#(FooProtocol) -> FooProtocol#]{{; name=.+$}}
 // RESOLVE_GENERIC_PARAMS_2_STATIC-NEXT: Decl[InstanceMethod]/CurrNominal: .fooUInstanceFunc1({#(self): &FooGenericStruct<FooProtocol>#})[#(U) -> U#]{{; name=.+$}}
@@ -1076,8 +1076,8 @@ struct TestResolveGenericParams3_4<T> {
 
     FooGenericStruct<FooStruct>#^RESOLVE_GENERIC_PARAMS_3_STATIC^#
 // RESOLVE_GENERIC_PARAMS_3_STATIC: Begin completions, 12 items
-// RESOLVE_GENERIC_PARAMS_3_STATIC-NEXT: Decl[Constructor]/CurrNominal:    ()[#FooGenericStruct<FooStruct>#]; name=()
-// RESOLVE_GENERIC_PARAMS_3_STATIC-NEXT: Decl[Constructor]/CurrNominal:    ({#t: FooStruct#})[#FooGenericStruct<FooStruct>#]{{; name=.+$}}
+// RESOLVE_GENERIC_PARAMS_3_STATIC-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:    ()[#FooGenericStruct<FooStruct>#]; name=()
+// RESOLVE_GENERIC_PARAMS_3_STATIC-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:    ({#t: FooStruct#})[#FooGenericStruct<FooStruct>#]{{; name=.+$}}
 // RESOLVE_GENERIC_PARAMS_3_STATIC-NEXT: Decl[InstanceMethod]/CurrNominal: .fooVoidInstanceFunc1({#(self): &FooGenericStruct<FooStruct>#})[#(FooStruct) -> Void#]{{; name=.+$}}
 // RESOLVE_GENERIC_PARAMS_3_STATIC-NEXT: Decl[InstanceMethod]/CurrNominal: .fooTInstanceFunc1({#(self): &FooGenericStruct<FooStruct>#})[#(FooStruct) -> FooStruct#]{{; name=.+$}}
 // RESOLVE_GENERIC_PARAMS_3_STATIC-NEXT: Decl[InstanceMethod]/CurrNominal: .fooUInstanceFunc1({#(self): &FooGenericStruct<FooStruct>#})[#(U) -> U#]{{; name=.+$}}
@@ -1104,8 +1104,8 @@ struct TestResolveGenericParams3_4<T> {
 
     FooGenericStruct<T>#^RESOLVE_GENERIC_PARAMS_4_STATIC^#
 // RESOLVE_GENERIC_PARAMS_4_STATIC: Begin completions
-// RESOLVE_GENERIC_PARAMS_4_STATIC-NEXT: Decl[Constructor]/CurrNominal:    ()[#FooGenericStruct<T>#]; name=()
-// RESOLVE_GENERIC_PARAMS_4_STATIC-NEXT: Decl[Constructor]/CurrNominal:    ({#t: T#})[#FooGenericStruct<T>#]{{; name=.+$}}
+// RESOLVE_GENERIC_PARAMS_4_STATIC-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:    ()[#FooGenericStruct<T>#]; name=()
+// RESOLVE_GENERIC_PARAMS_4_STATIC-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:    ({#t: T#})[#FooGenericStruct<T>#]{{; name=.+$}}
 // RESOLVE_GENERIC_PARAMS_4_STATIC-NEXT: Decl[InstanceMethod]/CurrNominal: .fooVoidInstanceFunc1({#(self): &FooGenericStruct<T>#})[#(T) -> Void#]{{; name=.+$}}
 // RESOLVE_GENERIC_PARAMS_4_STATIC-NEXT: Decl[InstanceMethod]/CurrNominal: .fooTInstanceFunc1({#(self): &FooGenericStruct<T>#})[#(T) -> T#]{{; name=.+$}}
 // RESOLVE_GENERIC_PARAMS_4_STATIC-NEXT: Decl[InstanceMethod]/CurrNominal: .fooUInstanceFunc1({#(self): &FooGenericStruct<T>#})[#(U) -> U#]{{; name=.+$}}
@@ -1132,8 +1132,8 @@ struct TestResolveGenericParams3_4<T> {
 
     FooGenericStruct<U>#^RESOLVE_GENERIC_PARAMS_5_STATIC^#
 // RESOLVE_GENERIC_PARAMS_5_STATIC: Begin completions
-// RESOLVE_GENERIC_PARAMS_5_STATIC-NEXT: Decl[Constructor]/CurrNominal:    ()[#FooGenericStruct<U>#]; name=()
-// RESOLVE_GENERIC_PARAMS_5_STATIC-NEXT: Decl[Constructor]/CurrNominal:    ({#t: U#})[#FooGenericStruct<U>#]{{; name=.+$}}
+// RESOLVE_GENERIC_PARAMS_5_STATIC-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:    ()[#FooGenericStruct<U>#]; name=()
+// RESOLVE_GENERIC_PARAMS_5_STATIC-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:    ({#t: U#})[#FooGenericStruct<U>#]{{; name=.+$}}
 // RESOLVE_GENERIC_PARAMS_5_STATIC-NEXT: Decl[InstanceMethod]/CurrNominal: .fooVoidInstanceFunc1({#(self): &FooGenericStruct<U>#})[#(U) -> Void#]{{; name=.+$}}
 // RESOLVE_GENERIC_PARAMS_5_STATIC-NEXT: Decl[InstanceMethod]/CurrNominal: .fooTInstanceFunc1({#(self): &FooGenericStruct<U>#})[#(U) -> U#]{{; name=.+$}}
 // RESOLVE_GENERIC_PARAMS_5_STATIC-NEXT: Decl[InstanceMethod]/CurrNominal: .fooUInstanceFunc1({#(self): &FooGenericStruct<U>#})[#(U) -> U#]{{; name=.+$}}
@@ -1617,7 +1617,7 @@ func testProtExtInit1() {
 }
 
 // PROTOCOL_EXT_INIT_1: Begin completions
-// PROTOCOL_EXT_INIT_1: Decl[Constructor]/{{Super|CurrNominal}}: ['(']{#x: Int#}[')'][#Concrete1#]{{; name=.+$}}
+// PROTOCOL_EXT_INIT_1: Decl[Constructor]/{{Super|CurrNominal}}/Flair[ArgLabels]: ['(']{#x: Int#}[')'][#Concrete1#]{{; name=.+$}}
 // PROTOCOL_EXT_INIT_1: End completions
 
 func testProtExtInit2<S: P4 where S.T : P1>() {
@@ -1631,10 +1631,10 @@ func testProtExtInit2<S: P4 where S.T : P1>() {
   sTy.init(#^PROTOCOL_EXT_INIT_5^#
 }
 
-// PROTOCOL_EXT_INIT_2: Decl[Constructor]/CurrNominal: ['(']{#x: Int#}[')'][#P4#]{{; name=.+$}}
+// PROTOCOL_EXT_INIT_2: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['(']{#x: Int#}[')'][#P4#]{{; name=.+$}}
 // PROTOCOL_EXT_INIT_3: Decl[Constructor]/CurrNominal: init({#x: Int#})[#P4#]{{; name=.+$}}
-// PROTOCOL_EXT_INIT_4: Decl[Constructor]/CurrNominal: ({#x: Int#})[#P4#]{{; name=.+$}}
-// PROTOCOL_EXT_INIT_5: Decl[Constructor]/CurrNominal: ['(']{#x: Int#}[')'][#P4#]{{; name=.+$}}
+// PROTOCOL_EXT_INIT_4: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ({#x: Int#})[#P4#]{{; name=.+$}}
+// PROTOCOL_EXT_INIT_5: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['(']{#x: Int#}[')'][#P4#]{{; name=.+$}}
 
 extension P4 where Self.T == OnlyMe {
   final func test1() {
@@ -1746,14 +1746,14 @@ func testThrows001() {
   globalFuncThrows#^THROWS1^#
 
 // THROWS1: Begin completions
-// THROWS1: Decl[FreeFunction]/CurrModule: ()[' throws'][#Void#]; name=() throws
+// THROWS1: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]: ()[' throws'][#Void#]; name=() throws
 // THROWS1: End completions
 }
 func testThrows002() {
   globalFuncRethrows#^THROWS2^#
 
 // THROWS2: Begin completions
-// THROWS2: Decl[FreeFunction]/CurrModule: ({#(x): () throws -> ()##() throws -> ()#})[' rethrows'][#Void#]; name=(x: () throws -> ()) rethrows
+// THROWS2: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]: ({#(x): () throws -> ()##() throws -> ()#})[' rethrows'][#Void#]; name=(x: () throws -> ()) rethrows
 // THROWS2: End completions
 }
 func testThrows003(_ x: HasThrowingMembers) {
@@ -1767,19 +1767,19 @@ func testThrows003(_ x: HasThrowingMembers) {
 func testThrows004(_ x: HasThrowingMembers) {
   x.memberThrows#^MEMBER_THROWS2^#
 // MEMBER_THROWS2: Begin completions
-// MEMBER_THROWS2: Decl[InstanceMethod]/CurrNominal: ()[' throws'][#Void#]; name=() throws
+// MEMBER_THROWS2: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ()[' throws'][#Void#]; name=() throws
 // MEMBER_THROWS2: End completions
 }
 func testThrows005(_ x: HasThrowingMembers) {
   x.memberRethrows#^MEMBER_THROWS3^#
 // MEMBER_THROWS3: Begin completions
-// MEMBER_THROWS3: Decl[InstanceMethod]/CurrNominal: ({#(x): () throws -> ()##() throws -> ()#})[' rethrows'][#Void#]; name=(x: () throws -> ()) rethrows
+// MEMBER_THROWS3: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ({#(x): () throws -> ()##() throws -> ()#})[' rethrows'][#Void#]; name=(x: () throws -> ()) rethrows
 // MEMBER_THROWS3: End completions
 }
 func testThrows006() {
   HasThrowingMembers(#^INIT_THROWS1^#
 // INIT_THROWS1: Begin completions
-// INIT_THROWS1: Decl[Constructor]/CurrNominal:      ['(']{#x: () throws -> ()##() throws -> ()#}[')'][' rethrows'][#HasThrowingMembers#]
+// INIT_THROWS1: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#x: () throws -> ()##() throws -> ()#}[')'][' rethrows'][#HasThrowingMembers#]
 // INIT_THROWS1: End completions
 }
 
@@ -1986,7 +1986,7 @@ func wrapSuccess<T>(_ onSuccess: @escaping (T) -> Void) -> (T, Bool) -> Void {
 func testWrapSuccess(promise: Int, seal: Resolver<Void>) {
   wrapSuccess(seal.fulfill)#^COMPLETE_CALL_RESULT^#
   // COMPLETE_CALL_RESULT: Begin completions
-  // COMPLETE_CALL_RESULT: Pattern/CurrModule:                 ({#Void#}, {#Bool#})[#Void#]; name=(Void, Bool)
+  // COMPLETE_CALL_RESULT: Pattern/CurrModule/Flair[ArgLabels]:                 ({#Void#}, {#Bool#})[#Void#]; name=(Void, Bool)
   // COMPLETE_CALL_RESULT: End completions
 }
 

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -569,7 +569,7 @@ func testInsideFunctionCall4() {
 func testInsideFunctionCall5() {
   FooStruct().instanceFunc2(42, #^INSIDE_FUNCTION_CALL_5^#
 // INSIDE_FUNCTION_CALL_5: Begin completions
-// INSIDE_FUNCTION_CALL_5-DAG: Pattern/ExprSpecific: {#b: &Double#}[#inout Double#];
+// INSIDE_FUNCTION_CALL_5-DAG: Pattern/Local/Flair[ExprSpecific]: {#b: &Double#}[#inout Double#];
 // INSIDE_FUNCTION_CALL_5: End completions
 }
 

--- a/test/IDE/complete_vararg.swift
+++ b/test/IDE/complete_vararg.swift
@@ -54,17 +54,17 @@ func testFreeFunc() {
   freeFunc2(#^FREE_FUNC_2^#
 }
 // FREE_FUNC_1: Begin completions, 1 items
-// FREE_FUNC_1: Decl[FreeFunction]/CurrModule: ['(']{#x: Int...#}[')'][#Void#]{{; name=.+$}}
+// FREE_FUNC_1: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]: ['(']{#x: Int...#}[')'][#Void#]{{; name=.+$}}
 // FREE_FUNC_1: End completions
 // FREE_FUNC_2: Begin completions, 1 items
-// FREE_FUNC_2: Decl[FreeFunction]/CurrModule: ['(']{#x: Int#}, {#y: Int...#}[')'][#Void#]{{; name=.+$}}
+// FREE_FUNC_2: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]: ['(']{#x: Int#}, {#y: Int...#}[')'][#Void#]{{; name=.+$}}
 // FREE_FUNC_2: End completions
 
 func testInit() {
   let c =C(#^INIT_1^#
 }
 // INIT_1: Begin completions, 1 items
-// INIT_1: Decl[Constructor]/CurrNominal:      ['(']{#x: Int...#}[')'][#C#]{{; name=.+$}}
+// INIT_1: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ['(']{#x: Int...#}[')'][#C#]{{; name=.+$}}
 // INIT_1: End completions
 
 func testMethod() {
@@ -72,10 +72,10 @@ func testMethod() {
   obj.method2(#^METHOD_2^#
 }
 // METHOD_1: Begin completions, 1 items
-// METHOD_1: Decl[InstanceMethod]/CurrNominal: ['(']{#x: Int...#}[')'][#Void#]{{; name=.+$}}
+// METHOD_1: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ['(']{#x: Int...#}[')'][#Void#]{{; name=.+$}}
 // METHOD_1: End completions
 // METHOD_2: Begin completions, 1 items
-// METHOD_2: Decl[InstanceMethod]/CurrNominal: ['(']{#x: Int#}, {#y: Int...#}[')'][#Void#]{{; name=.+$}}
+// METHOD_2: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ['(']{#x: Int#}, {#y: Int...#}[')'][#Void#]{{; name=.+$}}
 // METHOD_2: End completions
 
 func testSubscript() {
@@ -89,7 +89,7 @@ func testGenericFreeFunc() {
   genericFreeFunc1(#^GENERIC_FREE_FUNC_1^#
 }
 // GENERIC_FREE_FUNC_1: Begin completions, 1 items
-// GENERIC_FREE_FUNC_1: Decl[FreeFunction]/CurrModule: ['(']{#t: T...#}[')'][#Void#]{{; name=.+$}}
+// GENERIC_FREE_FUNC_1: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]: ['(']{#t: T...#}[')'][#Void#]{{; name=.+$}}
 // GENERIC_FREE_FUNC_1: End completions
 
 
@@ -97,5 +97,5 @@ func testInterestingType() {
   interestingType1(#^INTERESTING_TYPE_1^#
 }
 // INTERESTING_TYPE_1: Begin completions, 1 items
-// INTERESTING_TYPE_1: Decl[FreeFunction]/CurrModule: ['(']{#x: (Int, (Int, String))...#}[')'][#Void#]{{; name=.+$}}
+// INTERESTING_TYPE_1: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]: ['(']{#x: (Int, (Int, String))...#}[')'][#Void#]{{; name=.+$}}
 // INTERESTING_TYPE_1: End completions

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletion.h
@@ -26,6 +26,7 @@ using swift::ide::CodeCompletionDeclKind;
 using swift::ide::CodeCompletionKeywordKind;
 using swift::ide::CodeCompletionLiteralKind;
 using swift::ide::SemanticContextKind;
+using swift::ide::CodeCompletionFlair;
 using swift::ide::CodeCompletionString;
 using SwiftResult = swift::ide::CodeCompletionResult;
 using swift::ide::CompletionKind;
@@ -126,6 +127,7 @@ class CompletionBuilder {
   bool modified = false;
   Completion::ExpectedTypeRelation typeRelation;
   SemanticContextKind semanticContext;
+  CodeCompletionFlair flair;
   CodeCompletionString *completionString;
   llvm::SmallVector<char, 64> originalName;
   void *customKind = nullptr;
@@ -150,6 +152,10 @@ public:
   void setSemanticContext(SemanticContextKind kind) {
     modified = true;
     semanticContext = kind;
+  }
+  void setFlair(CodeCompletionFlair value) {
+    modified = true;
+    flair = value;
   }
 
   void setPopularityFactor(PopularityFactor val) { popularityFactor = val; }

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -155,7 +155,7 @@ bool SourceKit::CodeCompletion::addCustomCompletions(
     CodeCompletion::SwiftResult swiftResult(
         CodeCompletion::SwiftResult::ResultKind::Pattern,
         SemanticContextKind::Local, CodeCompletionFlairBit::ExpressionSpecific,
-        /*IsArgumentLabels=*/false, /*NumBytesToErase=*/0, completionString,
+        /*NumBytesToErase=*/0, completionString,
         CodeCompletionResult::ExpectedTypeRelation::Unknown);
 
     CompletionBuilder builder(sink, swiftResult);
@@ -660,12 +660,10 @@ static ResultBucket getResultBucket(Item &item, bool hasRequiredTypes,
   if (!skipMetaGroups) {
     auto flair = completion->getFlair();
     if (flair.contains(CodeCompletionFlairBit::ExpressionSpecific) ||
-        flair.contains(CodeCompletionFlairBit::SuperChain))
+        flair.contains(CodeCompletionFlairBit::SuperChain) ||
+        flair.contains(CodeCompletionFlairBit::ArgumentLabels))
       return ResultBucket::ExpressionSpecific;
   }
-
-  if (completion->isArgumentLabels() && !skipMetaGroups)
-    return ResultBucket::ExpressionSpecific;
 
   if (completion->isOperator())
     return ResultBucket::Operator;
@@ -1169,15 +1167,13 @@ Completion *CompletionBuilder::finish() {
 
     if (current.getKind() == SwiftResult::Declaration) {
       base = SwiftResult(
-          semanticContext, flair, current.isArgumentLabels(),
-          current.getNumBytesToErase(), completionString,
+          semanticContext, flair, current.getNumBytesToErase(), completionString,
           current.getAssociatedDeclKind(), current.isSystem(),
           current.getModuleName(), current.getNotRecommendedReason(),
           current.getBriefDocComment(), current.getAssociatedUSRs(),
           current.getDeclKeywords(), typeRelation, opKind);
     } else {
       base = SwiftResult(current.getKind(), semanticContext, flair,
-                         current.isArgumentLabels(),
                          current.getNumBytesToErase(), completionString,
                          typeRelation, opKind);
     }

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
@@ -66,8 +66,7 @@ extendCompletions(ArrayRef<SwiftResult *> swiftResults, CompletionSink &sink,
                   SwiftCompletionInfo &info,
                   const NameToPopularityMap *nameToPopularity,
                   const Options &options, Completion *prefix = nullptr,
-                  Optional<SemanticContextKind> overrideContext = None,
-                  Optional<SemanticContextKind> overrideOperatorContext = None);
+                  bool clearFlair = false);
 
 bool addCustomCompletions(CompletionSink &sink,
                           std::vector<Completion *> &completions,

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -921,7 +921,6 @@ static void transformAndForwardResults(
         CodeCompletion::SwiftResult::ResultKind::BuiltinOperator,
         SemanticContextKind::CurrentNominal,
         CodeCompletionFlairBit::ExpressionSpecific,
-        /*IsArgumentLabels=*/false,
         exactMatch ? exactMatch->getNumBytesToErase() : 0, completionString,
         CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -492,23 +492,28 @@ bool SwiftToSourceKitCompletionAdapter::handleResult(
   static UIdent CCCtxCurrentModule("source.codecompletion.context.thismodule");
   static UIdent CCCtxOtherModule("source.codecompletion.context.othermodule");
 
-  switch (Result->getSemanticContext()) {
-  case SemanticContextKind::None:
-    Info.SemanticContext = CCCtxNone; break;
-  case SemanticContextKind::ExpressionSpecific:
-    Info.SemanticContext = CCCtxExpressionSpecific; break;
-  case SemanticContextKind::Local:
-    Info.SemanticContext = CCCtxLocal; break;
-  case SemanticContextKind::CurrentNominal:
-    Info.SemanticContext = CCCtxCurrentNominal; break;
-  case SemanticContextKind::Super:
-    Info.SemanticContext = CCCtxSuper; break;
-  case SemanticContextKind::OutsideNominal:
-    Info.SemanticContext = CCCtxOutsideNominal; break;
-  case SemanticContextKind::CurrentModule:
-    Info.SemanticContext = CCCtxCurrentModule; break;
-  case SemanticContextKind::OtherModule:
-    Info.SemanticContext = CCCtxOtherModule; break;
+
+  if (Result->getFlair().contains(CodeCompletionFlairBit::ExpressionSpecific) ||
+      Result->getFlair().contains(CodeCompletionFlairBit::SuperChain)) {
+    // NOTE: `CCCtxExpressionSpecific` is to maintain compatibility.
+    Info.SemanticContext = CCCtxExpressionSpecific;
+  } else {
+    switch (Result->getSemanticContext()) {
+    case SemanticContextKind::None:
+      Info.SemanticContext = CCCtxNone; break;
+    case SemanticContextKind::Local:
+      Info.SemanticContext = CCCtxLocal; break;
+    case SemanticContextKind::CurrentNominal:
+      Info.SemanticContext = CCCtxCurrentNominal; break;
+    case SemanticContextKind::Super:
+      Info.SemanticContext = CCCtxSuper; break;
+    case SemanticContextKind::OutsideNominal:
+      Info.SemanticContext = CCCtxOutsideNominal; break;
+    case SemanticContextKind::CurrentModule:
+      Info.SemanticContext = CCCtxCurrentModule; break;
+    case SemanticContextKind::OtherModule:
+      Info.SemanticContext = CCCtxOtherModule; break;
+    }
   }
 
   static UIdent CCTypeRelNotApplicable("source.codecompletion.typerelation.notapplicable");
@@ -914,14 +919,16 @@ static void transformAndForwardResults(
         CodeCompletionString::create(innerSink.allocator, chunks);
     CodeCompletion::SwiftResult paren(
         CodeCompletion::SwiftResult::ResultKind::BuiltinOperator,
-        SemanticContextKind::ExpressionSpecific, /*IsArgumentLabels=*/false,
+        SemanticContextKind::CurrentNominal,
+        CodeCompletionFlairBit::ExpressionSpecific,
+        /*IsArgumentLabels=*/false,
         exactMatch ? exactMatch->getNumBytesToErase() : 0, completionString,
         CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
 
     SwiftCompletionInfo info;
     std::vector<Completion *> extended =
         extendCompletions(&paren, innerSink, info, nameToPopularity, options,
-                          exactMatch, SemanticContextKind::ExpressionSpecific);
+                          exactMatch);
     assert(extended.size() == 1);
     return extended.front();
   };
@@ -1002,11 +1009,11 @@ static void transformAndForwardResults(
       auto topResults = filterInnerResults(results, options.addInnerResults,
                                            options.addInnerOperators, hasDot,
                                            hasQDot, hasInit, rules);
-      // FIXME: Overriding the default to context "None" is a hack so that they
-      // won't overwhelm other results that also match the filter text.
+      // FIXME: Clearing the flair (and semantic context) is a hack so that
+      // they won't overwhelm other results that also match the filter text.
       innerResults = extendCompletions(
           topResults, innerSink, info, nameToPopularity, options, exactMatch,
-          SemanticContextKind::None, SemanticContextKind::None);
+          /*clearFlair=*/true);
     });
 
     auto *inputBuf = session->getBuffer();

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -266,6 +266,12 @@ static llvm::cl::list<std::string>
 BuildConfigs("D", llvm::cl::desc("Conditional compilation flags"),
              llvm::cl::cat(Category));
 
+static llvm::cl::opt<bool>
+ParseAsLibrary("parse-as-library",
+               llvm::cl::desc("Parse '-source-filename' as a library source file"),
+               llvm::cl::cat(Category),
+               llvm::cl::init(false));
+
 static llvm::cl::opt<std::string>
 SDK("sdk", llvm::cl::desc("path to the SDK to build against"),
     llvm::cl::cat(Category));
@@ -3885,6 +3891,10 @@ int main(int argc, char *argv[]) {
   if (!options::AccessNotesPath.empty()) {
     InitInvok.getFrontendOptions().AccessNotesPath =
         options::AccessNotesPath[options::AccessNotesPath.size()-1];
+  }
+  if (options::ParseAsLibrary) {
+    InitInvok.getFrontendOptions().InputMode =
+        swift::FrontendOptions::ParseInputMode::SwiftLibrary;
   }
   InitInvok.getClangImporterOptions().PrecompiledHeaderOutputDir =
     options::PCHOutputDir;

--- a/validation-test/IDE/crashers_2_fixed/sr14494.swift
+++ b/validation-test/IDE/crashers_2_fixed/sr14494.swift
@@ -32,6 +32,6 @@ struct BottomMenu: MyView {
 }
 
 // CHECK: Begin completions, 2 items
-// CHECK: Decl[StaticVar]/ExprSpecific/TypeRelation[Identical]: center[#MyAlignment#]; name=center
+// CHECK: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: center[#MyAlignment#]; name=center
 // CHECK: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init()[#MyAlignment#]; name=init()
 // CHECK: End completions


### PR DESCRIPTION
Based on #37563 

Introduce `CommonKeywordAtCurrentPosition` and `RareKeywordAtCurrentPosition`

* `super` in a  overriding decl is "common".
* type decl introducers (e.g. `struct`, `enum`) at top-level in library files are "common"
* type decl introducers in `protocol` are invalid, hence "rare"
* top-level only decl introducer (e.g. `import`, `extension`) are invalid at non-top-level, hence "rare"
* nested types in function bodies are "rare"
* member only decls (e.g. `subscript`, `deinit`) are invalid in function body, hence "rare"
* some modifiers (e.g. `public`, `private`, `override`) are invalid for local decls, hence "rare"

rdar://77934651