### PR TITLE
Remove unused fields in FrontendOptions.

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -182,12 +182,6 @@ public:
   /// the module.
   bool CheckOnoneSupportCompleteness = false;
 
-  /// If set, dumps wall time taken to check each function body to llvm::errs().
-  bool DebugTimeFunctionBodies = false;
-
-  /// If set, dumps wall time taken to check each expression.
-  bool DebugTimeExpressionTypeChecking = false;
-
   /// The path to which we should output statistics files.
   std::string StatsOutputDir;
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Setting the values of `DebugTimeFunctionBodies` and `DebugTimeExpressionTypeChecking` in `FrontendOptions`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-14453.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
