### PR TITLE
[5.5] IRGen: Add the `swiftasync` attribute to the resume function call for await_async_continuation

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -4914,8 +4914,11 @@ IRGenFunction::getFunctionPointerForResumeIntrinsic(llvm::Value *resume) {
   auto *fnTy = llvm::FunctionType::get(
       IGM.VoidTy, {IGM.Int8PtrTy},
       false /*vaargs*/);
+  auto attrs = IGM.constructInitialAttributes();
+  attrs = attrs.addParamAttribute(IGM.getLLVMContext(), 0,
+                                  llvm::Attribute::SwiftAsync);
   auto signature =
-      Signature(fnTy, IGM.constructInitialAttributes(), IGM.SwiftAsyncCC);
+      Signature(fnTy, attrs, IGM.SwiftAsyncCC);
   auto fnPtr = FunctionPointer(
       FunctionPointer::Kind::Function,
       Builder.CreateBitOrPointerCast(resume, fnTy->getPointerTo()),

--- a/test/IRGen/async/get_async_continuation.sil
+++ b/test/IRGen/async/get_async_continuation.sil
@@ -73,7 +73,7 @@ bb0:
 // CHECK:   unreachable
 
 // CHECK: await.async.resume:
-// CHECK:   call { i8* } (i32, i8*, i8*, ...) @llvm.coro.suspend.async{{.*}}({{.*}} @__swift_async_resume_project_context
+// CHECK:   call { i8* } (i32, i8*, i8*, ...) @llvm.coro.suspend.async{{.*}}({{.*}} @__swift_async_resume_project_context{{.*}}@__swift_suspend_dispatch_1
 // CHECK:   [[result_addr_addr:%.*]] = getelementptr inbounds %swift.continuation_context, %swift.continuation_context* [[cont_context]], i32 0, i32 3
 // CHECK:   [[result_addr:%.*]] = load %swift.opaque*, %swift.opaque** [[result_addr_addr]]
 // CHECK:   [[typed_result_addr:%.*]] = bitcast %swift.opaque* [[result_addr]] to i32*
@@ -82,6 +82,12 @@ bb0:
 
 // CHECK: [[result_bb]]:
 // CHECK:   phi i32 [ [[result_value]], %await.async.resume ]
+
+
+// CHECK: define internal swifttailcc void @__swift_suspend_dispatch_1(i8* %0, i8* %1)
+// CHECK-NOT: define
+// CHECK:  musttail call swifttailcc void %{{.*}}(i8* swiftasync %1)
+// CHECK-NEXT:  ret void
 
 sil @async_continuation : $@async () -> () {
 entry:

--- a/test/IRGen/async/get_async_continuation.sil
+++ b/test/IRGen/async/get_async_continuation.sil
@@ -84,9 +84,9 @@ bb0:
 // CHECK:   phi i32 [ [[result_value]], %await.async.resume ]
 
 
-// CHECK: define internal swifttailcc void @__swift_suspend_dispatch_1(i8* %0, i8* %1)
+// CHECK: define {{.*}} void @__swift_suspend_dispatch_1(i8* %0, i8* %1)
 // CHECK-NOT: define
-// CHECK:  musttail call swifttailcc void %{{.*}}(i8* swiftasync %1)
+// CHECK:  tail call swift{{(tail)?}}cc void %{{.*}}(i8* swiftasync %1)
 // CHECK-NEXT:  ret void
 
 sil @async_continuation : $@async () -> () {


### PR DESCRIPTION
Without this we are going to crash (timing dependent) in
withUnsafeContinuation and bridged async objective c calls.

rdar://78031499
