### PR TITLE
[Concurrency ABI] Add standard substitutions for _Concurrency types.

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -466,6 +466,7 @@ Types
   KNOWN-TYPE-KIND ::= 'a'                    // Swift.Array
   KNOWN-TYPE-KIND ::= 'B'                    // Swift.BinaryFloatingPoint
   KNOWN-TYPE-KIND ::= 'b'                    // Swift.Bool
+  KNOWN-TYPE-KIND ::= 'c' KNOWN-TYPE-KIND-2  // Second set of standard types
   KNOWN-TYPE-KIND ::= 'D'                    // Swift.Dictionary
   KNOWN-TYPE-KIND ::= 'd'                    // Swift.Float64
   KNOWN-TYPE-KIND ::= 'E'                    // Swift.Encodable
@@ -510,6 +511,25 @@ Types
   KNOWN-TYPE-KIND ::= 'y'                    // Swift.StringProtocol
   KNOWN-TYPE-KIND ::= 'Z'                    // Swift.SignedInteger
   KNOWN-TYPE-KIND ::= 'z'                    // Swift.BinaryInteger
+
+  KNOWN-TYPE-KIND-2 ::= 'A'        // Swift.Actor
+  KNOWN-TYPE-KIND-2 ::= 'C'        // Swift.CheckedContinuation
+  KNOWN-TYPE-KIND-2 ::= 'c'        // Swift.UnsafeContinuation
+  KNOWN-TYPE-KIND-2 ::= 'E'        // Swift.CancellationError
+  KNOWN-TYPE-KIND-2 ::= 'e'        // Swift.UnownedSerialExecutor
+  KNOWN-TYPE-KIND-2 ::= 'F'        // Swift.Executor
+  KNOWN-TYPE-KIND-2 ::= 'f'        // Swift.SerialExecutor
+  KNOWN-TYPE-KIND-2 ::= 'G'        // Swift.TaskGroup
+  KNOWN-TYPE-KIND-2 ::= 'g'        // Swift.ThrowingTaskGroup
+  KNOWN-TYPE-KIND-2 ::= 'I'        // Swift.AsyncIteratorProtocol
+  KNOWN-TYPE-KIND-2 ::= 'i'        // Swift.AsyncSequence
+  KNOWN-TYPE-KIND-2 ::= 'J'        // Swift.UnownedJob
+  KNOWN-TYPE-KIND-2 ::= 'M'        // Swift.MainActor
+  KNOWN-TYPE-KIND-2 ::= 'P'        // Swift.TaskPriority
+  KNOWN-TYPE-KIND-2 ::= 'S'        // Swift.AsyncStream
+  KNOWN-TYPE-KIND-2 ::= 's'        // Swift.AsyncThrowingStream
+  KNOWN-TYPE-KIND-2 ::= 'T'        // Swift.Task
+  KNOWN-TYPE-KIND-2 ::= 't'        // Swift.UnsafeCurrentTask
 
   protocol ::= context decl-name
   protocol ::= standard-substitutions

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -729,6 +729,9 @@ public:
   /// \returns true if this module is the "swift" standard library module.
   bool isStdlibModule() const;
 
+  /// \returns true if this module has standard substitutions for mangling.
+  bool hasStandardSubstitutions() const;
+
   /// \returns true if this module is the "SwiftShims" module;
   bool isSwiftShimsModule() const;
 

--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -494,7 +494,7 @@ protected:
   NodePointer pushMultiSubstitutions(int RepeatCount, size_t SubstIdx);
   NodePointer createSwiftType(Node::Kind typeKind, const char *name);
   NodePointer demangleStandardSubstitution();
-  NodePointer createStandardSubstitution(char Subst);
+  NodePointer createStandardSubstitution(char Subst, bool SecondLevel);
   NodePointer demangleLocalIdentifier();
 
   NodePointer popModule();

--- a/include/swift/Demangling/StandardTypesMangling.def
+++ b/include/swift/Demangling/StandardTypesMangling.def
@@ -12,7 +12,12 @@
 
 /// STANDARD_TYPE(KIND, MANGLING, TYPENAME)
 ///   The 1-character MANGLING for a known TYPENAME of KIND.
-
+///
+/// STANDARD_TYPE_2(KIND, MANGLING, TYPENAME)
+///   The 1-character MANGLING for a known TYPENAME of KIND that is in the
+///   second level of standard types, all of which are mangled with the form
+///   Sc<MANGLING>.
+///
 /// OBJC_INTEROP_STANDARD_TYPE(KIND, MANGLING, TYPENAME)
 ///   The 1-character MANGLING for a known TYPENAME of KIND, for a type that's
 ///   only available with ObjC interop enabled.
@@ -21,6 +26,7 @@
 #define OBJC_INTEROP_STANDARD_TYPE(KIND, MANGLING, TYPENAME) \
   STANDARD_TYPE(KIND, MANGLING, TYPENAME)
 #endif
+
 
 OBJC_INTEROP_STANDARD_TYPE(Structure, A, AutoreleasingUnsafeMutablePointer)
 STANDARD_TYPE(Structure, a, Array)
@@ -73,5 +79,25 @@ STANDARD_TYPE(Protocol, y, StringProtocol)
 STANDARD_TYPE(Protocol, Z, SignedInteger)
 STANDARD_TYPE(Protocol, z, BinaryInteger)
 
+STANDARD_TYPE_2(Protocol, A, Actor)
+STANDARD_TYPE_2(Structure, C, CheckedContinuation)
+STANDARD_TYPE_2(Structure, c, UnsafeContinuation)
+STANDARD_TYPE_2(Structure, E, CancellationError)
+STANDARD_TYPE_2(Structure, e, UnownedSerialExecutor)
+STANDARD_TYPE_2(Protocol, F, Executor)
+STANDARD_TYPE_2(Protocol, f, SerialExecutor)
+STANDARD_TYPE_2(Structure, G, TaskGroup)
+STANDARD_TYPE_2(Structure, g, ThrowingTaskGroup)
+STANDARD_TYPE_2(Protocol, I, AsyncIteratorProtocol)
+STANDARD_TYPE_2(Protocol, i, AsyncSequence)
+STANDARD_TYPE_2(Structure, J, UnownedJob)
+STANDARD_TYPE_2(Class, M, MainActor)
+STANDARD_TYPE_2(Structure, P, TaskPriority)
+STANDARD_TYPE_2(Structure, S, AsyncStream)
+STANDARD_TYPE_2(Structure, s, AsyncThrowingStream)
+STANDARD_TYPE_2(Structure, T, Task)
+STANDARD_TYPE_2(Structure, t, UnsafeCurrentTask)
+
 #undef STANDARD_TYPE
 #undef OBJC_INTEROP_STANDARD_TYPE
+#undef STANDARD_TYPE_2

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -1060,6 +1060,15 @@ ASTBuilder::findTypeDecl(DeclContext *dc,
     result = candidate;
   }
 
+  // If we looked into the standard library module, but didn't find anything,
+  // try the _Concurrency module, which is also mangled into the Swift module.
+  if (!result && !dc->getParent() && module->isStdlibModule()) {
+    ASTContext &ctx = module->getASTContext();
+    if (auto concurrencyModule = ctx.getLoadedModule(ctx.Id_Concurrency)) {
+      return findTypeDecl(concurrencyModule, name, privateDiscriminator, kind);
+    }
+  }
+
   return result;
 }
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1407,6 +1407,12 @@ bool ModuleDecl::isStdlibModule() const {
   return !getParent() && getName() == getASTContext().StdlibModuleName;
 }
 
+bool ModuleDecl::hasStandardSubstitutions() const {
+  return !getParent() &&
+      (getName() == getASTContext().StdlibModuleName ||
+       getName() == getASTContext().Id_Concurrency);
+}
+
 bool ModuleDecl::isSwiftShimsModule() const {
   return !getParent() && getName() == getASTContext().SwiftShimsModuleName;
 }

--- a/lib/Basic/Mangler.cpp
+++ b/lib/Basic/Mangler.cpp
@@ -223,13 +223,14 @@ void Mangler::mangleSubstitution(unsigned Idx) {
     return appendOperator("A", Index(Idx - 26));
   }
 
-  char Subst = Idx + 'A';
+  char SubstChar = Idx + 'A';
+  StringRef Subst(&SubstChar, 1);
   if (SubstMerging.tryMergeSubst(*this, Subst, /*isStandardSubst*/ false)) {
 #ifndef NDEBUG
     ++mergedSubsts;
 #endif
   } else {
-    appendOperator("A", StringRef(&Subst, 1));
+    appendOperator("A", Subst);
   }
 }
 

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -949,7 +949,9 @@ NodePointer Demangler::demangleStandardSubstitution() {
       int RepeatCount = demangleNatural();
       if (RepeatCount > SubstitutionMerging::MaxRepeatCount)
         return nullptr;
-      if (NodePointer Nd = createStandardSubstitution(nextChar())) {
+      bool secondLevelSubstitution = nextIf('c');
+      if (NodePointer Nd = createStandardSubstitution(
+              nextChar(), secondLevelSubstitution)) {
         while (RepeatCount-- > 1) {
           pushNode(Nd);
         }
@@ -960,10 +962,16 @@ NodePointer Demangler::demangleStandardSubstitution() {
   }
 }
 
-NodePointer Demangler::createStandardSubstitution(char Subst) {
+NodePointer Demangler::createStandardSubstitution(
+    char Subst, bool SecondLevel) {
 #define STANDARD_TYPE(KIND, MANGLING, TYPENAME)                   \
-  if (Subst == #MANGLING[0]) {                                    \
-    return createSwiftType(Node::Kind::KIND, #TYPENAME);      \
+  if (!SecondLevel && Subst == #MANGLING[0]) {                    \
+    return createSwiftType(Node::Kind::KIND, #TYPENAME);          \
+  }
+
+#define STANDARD_TYPE_2(KIND, MANGLING, TYPENAME)                   \
+  if (SecondLevel && Subst == #MANGLING[0]) {                    \
+    return createSwiftType(Node::Kind::KIND, #TYPENAME);          \
   }
 
 #include "swift/Demangling/StandardTypesMangling.def"

--- a/lib/Demangling/ManglingUtils.cpp
+++ b/lib/Demangling/ManglingUtils.cpp
@@ -66,14 +66,19 @@ std::string Mangle::translateOperator(StringRef Op) {
   return Encoded;
 }
 
-char Mangle::getStandardTypeSubst(StringRef TypeName) {
+llvm::Optional<StringRef> Mangle::getStandardTypeSubst(StringRef TypeName) {
 #define STANDARD_TYPE(KIND, MANGLING, TYPENAME)      \
   if (TypeName == #TYPENAME) {                       \
-    return #MANGLING[0];                             \
+    return StringRef(#MANGLING);                     \
+  }
+
+#define STANDARD_TYPE_2(KIND, MANGLING, TYPENAME)    \
+  if (TypeName == #TYPENAME) {                       \
+    return StringRef("c" #MANGLING);                 \
   }
 
 #include "swift/Demangling/StandardTypesMangling.def"
 
-  return 0;
+  return llvm::None;
 }
 

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -350,7 +350,8 @@ bool Remangler::trySubstitution(Node *node, SubstitutionEntry &entry,
     mangleIndex(Idx - 26);
     return true;
   }
-  char Subst = Idx + 'A';
+  char SubstChar = Idx + 'A';
+  StringRef Subst(&SubstChar, 1);
   if (!SubstMerging.tryMergeSubst(*this, Subst, /*isStandardSubst*/ false)) {
     Buffer << 'A' << Subst;
   }
@@ -371,6 +372,7 @@ void Remangler::mangleIdentifierImpl(Node *node, bool isOperator) {
 
 bool Remangler::mangleStandardSubstitution(Node *node) {
   if (node->getKind() != Node::Kind::Structure
+      && node->getKind() != Node::Kind::Class
       && node->getKind() != Node::Kind::Enum
       && node->getKind() != Node::Kind::Protocol)
     return false;
@@ -384,9 +386,9 @@ bool Remangler::mangleStandardSubstitution(Node *node) {
   if (node->getChild(1)->getKind() != Node::Kind::Identifier)
     return false;
 
-  if (char Subst = getStandardTypeSubst(node->getChild(1)->getText())) {
-    if (!SubstMerging.tryMergeSubst(*this, Subst, /*isStandardSubst*/ true)) {
-      Buffer << 'S' << Subst;
+  if (auto Subst = getStandardTypeSubst(node->getChild(1)->getText())) {
+    if (!SubstMerging.tryMergeSubst(*this, *Subst, /*isStandardSubst*/ true)) {
+      Buffer << 'S' << *Subst;
     }
     return true;
   }

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -97,7 +97,7 @@ IRGenMangler::withSymbolicReferences(IRGenModule &IGM,
       // The short-substitution types in the standard library have compact
       // manglings already, and the runtime ought to have a lookup table for
       // them. Symbolic referencing would be wasteful.
-      if (type->getModuleContext()->isStdlibModule()
+      if (type->getModuleContext()->hasStandardSubstitutions()
           && Mangle::getStandardTypeSubst(type->getName().str())) {
         return false;
       }

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -673,6 +673,10 @@ _searchTypeMetadataRecords(TypeMetadataPrivateState &T,
 #define STANDARD_TYPE(KIND, MANGLING, TYPENAME) \
   extern "C" const ContextDescriptor DESCRIPTOR_MANGLING(MANGLING, DESCRIPTOR_MANGLING_SUFFIX(KIND));
 
+// FIXME: When the _Concurrency library gets merged into the Standard Library,
+// we will be able to reference those symbols directly as well.
+#define STANDARD_TYPE_2(KIND, MANGLING, TYPENAME)
+
 #if !SWIFT_OBJC_INTEROP
 # define OBJC_INTEROP_STANDARD_TYPE(KIND, MANGLING, TYPENAME)
 #endif
@@ -703,6 +707,9 @@ _findContextDescriptor(Demangle::NodePointer node,
     if (name.equals(#TYPENAME)) { \
       return &DESCRIPTOR_MANGLING(MANGLING, DESCRIPTOR_MANGLING_SUFFIX(KIND)); \
     }
+  // FIXME: When the _Concurrency library gets merged into the Standard Library,
+  // we will be able to reference those symbols directly as well.
+#define STANDARD_TYPE_2(KIND, MANGLING, TYPENAME)
 #if !SWIFT_OBJC_INTEROP
 # define OBJC_INTEROP_STANDARD_TYPE(KIND, MANGLING, TYPENAME)
 #endif

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -403,3 +403,5 @@ $s4test3fooyyS2f_SfYkztYjrXEF ---> test.foo(@differentiable(reverse) (Swift.Floa
 $s4test3fooyyS2f_SfYkntYjrXEF ---> test.foo(@differentiable(reverse) (Swift.Float, __owned @noDerivative Swift.Float) -> Swift.Float) -> ()
 $s4test3fooyyS2f_SfYktYjrXEF ---> test.foo(@differentiable(reverse) (Swift.Float, @noDerivative Swift.Float) -> Swift.Float) -> ()
 $s4test3fooyyS2f_SfYktYaYbYjrXEF ---> test.foo(@differentiable(reverse) @Sendable (Swift.Float, @noDerivative Swift.Float) async -> Swift.Float) -> ()
+$sScA ---> Swift.Actor
+$sScGySiG ---> Swift.TaskGroup<Swift.Int>

--- a/test/IRGen/async/builtin_executor.sil
+++ b/test/IRGen/async/builtin_executor.sil
@@ -54,7 +54,7 @@ bb0(%0 : $MyDefaultActor):
 sil @test_build_custom_actor : $(@guaranteed MyCustomActor) -> Builtin.Executor {
 bb0(%0 : $MyCustomActor):
   // CHECK:      [[T0:%.*]] = ptrtoint %T4test13MyCustomActorC* %0 to [[INT]]
-  // CHECK-NEXT: [[T1:%.*]] = call i8** @"$s4test13MyCustomActorCACs14SerialExecutorAAWl"()
+  // CHECK-NEXT: [[T1:%.*]] = call i8** @"$s4test13MyCustomActorCACScfAAWl"()
   // CHECK-NEXT: [[T2:%.*]] = ptrtoint i8** [[T1]] to [[INT]]
   // CHECK:      [[ONE:%.*]] = insertvalue { [[INT]], [[INT]] } undef, [[INT]] [[T0]], 0
   // CHECK-NEXT: [[TWO:%.*]] = insertvalue { [[INT]], [[INT]] } [[ONE]], [[INT]] [[T2]], 1


### PR DESCRIPTION
Introduce a second level of standard substitutions to the mangling,
all of the form `Sc<character>`, and use it to provide standard
substitutions for most of the _Concurrency types.

This is a precursor to rdar://78269642 and a good mangling-size
optimization in its own right.
