### PR TITLE
[ConstraintSystem] NFC: Print out adjacent type variables to a debug log

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1549,6 +1549,9 @@ void BindingSet::dump(TypeVariableType *typeVar, llvm::raw_ostream &out,
 }
 
 void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
+  PrintOptions PO;
+  PO.PrintTypesForDebugging = true;
+
   out.indent(indent);
   if (isDirectHole())
     out << "hole ";
@@ -1561,15 +1564,17 @@ void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
   auto literalKind = getLiteralKind();
   if (literalKind != LiteralBindingKind::None)
     out << "literal=" << static_cast<int>(literalKind) << " ";
-  if (involvesTypeVariables())
-    out << "involves_type_vars ";
+  if (involvesTypeVariables()) {
+    out << "involves_type_vars=[";
+    interleave(AdjacentVars,
+               [&](const auto *typeVar) { out << typeVar->getString(PO); },
+               [&out]() { out << " "; });
+    out << "] ";
+  }
 
   auto numDefaultable = getNumViableDefaultableBindings();
   if (numDefaultable > 0)
     out << "#defaultable_bindings=" << numDefaultable << " ";
-
-  PrintOptions PO;
-  PO.PrintTypesForDebugging = true;
 
   auto printBinding = [&](const PotentialBinding &binding) {
     auto type = binding.BindingType;


### PR DESCRIPTION
If type variable has any type variables adjacent to it, let's print
them out to make it easier to figure out what inference did.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
