### PR TITLE
[cmake] On Darwin, teach add_swift_host_tool how to find swift's SDK/compat libs, fix the rpath of tools, and add tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1061,6 +1061,7 @@ endif()
 
 if(SWIFT_INCLUDE_TESTS)
   add_subdirectory(test)
+  add_subdirectory(validation-test)
   add_subdirectory(unittests)
 endif()
 if(SWIFT_INCLUDE_DOCS)

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -180,7 +180,8 @@ function(_add_host_variant_c_compile_flags target)
         target_compile_options(${target} PRIVATE -g)
       endif()
     else()
-      target_compile_options(${target} PRIVATE -g0)
+      target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:-g0>)
+      target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:Swift>:-gnone>)
     endif()
   endif()
 
@@ -633,6 +634,19 @@ function(add_swift_host_tool executable)
       JOB_POOL_LINK swift_link_job_pool)
   endif()
   if(${SWIFT_HOST_VARIANT_SDK} IN_LIST SWIFT_APPLE_PLATFORMS)
+    # If we found a swift compiler and are going to use swift code in swift
+    # host side tools but link with clang, add the appropriate -L paths so we
+    # find all of the necessary swift libraries on Darwin.
+    if (CMAKE_Swift_COMPILER)
+      # Add in the SDK directory for the host platform and add an rpath.
+      target_link_directories(${executable} PRIVATE
+        ${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_PATH}/usr/lib/swift)
+      # Add in the toolchain directory so we can grab compatibility libraries
+      get_filename_component(TOOLCHAIN_BIN_DIR ${CMAKE_Swift_COMPILER} DIRECTORY)
+      get_filename_component(TOOLCHAIN_LIB_DIR "${TOOLCHAIN_BIN_DIR}/../lib/swift/macosx" ABSOLUTE)
+      target_link_directories(${executable} PUBLIC ${TOOLCHAIN_LIB_DIR})
+    endif()
+
     # Lists of rpaths that we are going to add to our executables.
     #
     # Please add each rpath separately below to the list, explaining why you are
@@ -644,8 +658,8 @@ function(add_swift_host_tool executable)
     # contain swift content.
     list(APPEND RPATH_LIST "@executable_path/../lib")
 
-    # Also include the swift specific resource dir in our rpath.
-    list(APPEND RPATH_LIST "@executable_path/../lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
+    # Also include the abi stable system stdlib in our rpath.
+    list(APPEND RPATH_LIST "/usr/lib/swift")
 
     set_target_properties(${executable} PROPERTIES
       BUILD_WITH_INSTALL_RPATH YES

--- a/validation-test/BuildSystem/CMakeLists.txt
+++ b/validation-test/BuildSystem/CMakeLists.txt
@@ -1,0 +1,5 @@
+
+# Only test this if we found a Swift compiler.
+if (CMAKE_Swift_COMPILER)
+  add_subdirectory(swift-cmake)
+endif()

--- a/validation-test/BuildSystem/swift-cmake/CMakeLists.txt
+++ b/validation-test/BuildSystem/swift-cmake/CMakeLists.txt
@@ -1,0 +1,47 @@
+# In the absence of fine grained tablegen dependencies we need to ensure that
+# Swift's libraries all build after the LLVM & Clang tablegen-generated headers
+# are generated. When building out-of-tree (as with build-script) LLVM & Clang's
+# CMake configuration files create these targets as dummies so we can safely
+# depend on them directly here (See: SR-6026)
+# LLVM_COMMON_DEPENDS is a construct from the LLVM build system. It is a special
+# purpose variable that provides common dependencies for all libraries, and
+# executables generated when it is set. CMake's scoping rules enforce that these
+# new dependencies will only be added to targets created under Swift's lib
+# directory.
+list(APPEND LLVM_COMMON_DEPENDS intrinsics_gen clang-tablegen-targets)
+
+# Add generated libSyntax headers to global dependencies.
+list(APPEND LLVM_COMMON_DEPENDS swift-syntax-generated-headers)
+list(APPEND LLVM_COMMON_DEPENDS swift-parse-syntax-generated-headers)
+
+add_swift_host_library(TestCPPLib
+  STATIC
+  CPPLib.cpp)
+
+add_swift_host_library(TestPureSwiftSharedLib
+  SHARED
+  PURE_SWIFT
+  Klass.swift)
+target_link_libraries(TestPureSwiftSharedLib PRIVATE TestCPPLib)
+target_link_options(TestPureSwiftSharedLib PRIVATE "SHELL:-import-objc-header ${CMAKE_CURRENT_SOURCE_DIR}/CPPLib.h")
+
+add_swift_host_library(TestPureSwiftStaticLib
+  STATIC
+  PURE_SWIFT
+  Klass.swift)
+target_link_libraries(TestPureSwiftStaticLib PRIVATE TestCPPLib)
+target_compile_options(TestPureSwiftStaticLib PRIVATE "SHELL:-import-objc-header ${CMAKE_CURRENT_SOURCE_DIR}/CPPLib.h")
+
+add_swift_host_tool(TestCPPToolLinkSwiftSharedLib
+  CPPTool.cpp
+  SWIFT_COMPONENT testsuite-tools
+  )
+target_link_libraries(TestCPPToolLinkSwiftSharedLib PRIVATE TestPureSwiftSharedLib)
+
+add_swift_host_tool(TestCPPToolLinkSwiftStaticLib
+  CPPTool.cpp
+  SWIFT_COMPONENT testsuite-tools
+  )
+target_link_libraries(TestCPPToolLinkSwiftStaticLib
+  PRIVATE
+  TestPureSwiftStaticLib)

--- a/validation-test/BuildSystem/swift-cmake/CPPLib.cpp
+++ b/validation-test/BuildSystem/swift-cmake/CPPLib.cpp
@@ -1,0 +1,9 @@
+
+#include <cstdio>
+#include "CPPLib.h"
+
+extern "C" {
+  void CPPLib_log() {
+    printf("I am in cpplib log!\n");
+  }
+}

--- a/validation-test/BuildSystem/swift-cmake/CPPLib.h
+++ b/validation-test/BuildSystem/swift-cmake/CPPLib.h
@@ -1,0 +1,13 @@
+
+#ifndef SWIFT_TEST_CPPLIB
+#define SWIFT_TEST_CPPLIB
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void CPPLib_log();
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/validation-test/BuildSystem/swift-cmake/CPPTool.cpp
+++ b/validation-test/BuildSystem/swift-cmake/CPPTool.cpp
@@ -1,0 +1,26 @@
+//===--- CPPTool.cpp ------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// Calls a method from one of the swift libraries.
+///
+//===----------------------------------------------------------------------===//
+
+#include <cstdio>
+
+extern "C" {
+  int doSomething();
+}
+
+int main(int argc, char *argv[]) {
+  printf("doSomething: %d\n", doSomething());
+  return 0;
+}

--- a/validation-test/BuildSystem/swift-cmake/Klass.swift
+++ b/validation-test/BuildSystem/swift-cmake/Klass.swift
@@ -1,0 +1,19 @@
+// This isn't a test but lit wants to treat it as a test! Make it exit -1 to
+// make sure lit doesn't run this file and add a REQUIRES line so we actually
+// never do that.
+//
+// RUN: exit -1
+// REQUIRES: not_a_test
+
+public class Klass {}
+
+public func useKlass(_ k: Klass) {}
+
+@_cdecl("doSomething")
+public func doSomething() -> Int {
+    CPPLib_log()
+    let x: Int = 34
+    // Make sure we link against SwiftCore.
+    print("Swift is going to return \(34)")
+    return x
+}

--- a/validation-test/BuildSystem/swift-cmake/RunCPPTools.test
+++ b/validation-test/BuildSystem/swift-cmake/RunCPPTools.test
@@ -1,0 +1,11 @@
+# REQUIRES: standalone_build,OS=macosx
+
+# Test that makes sure when we link in a pure swift shared lib into a cxx tool
+# that we set rpaths right and thus can run the test.
+
+# RUN: %swift_obj_root/bin/TestCPPToolLinkSwiftSharedLib | %FileCheck %s
+# RUN: %swift_obj_root/bin/TestCPPToolLinkSwiftStaticLib | %FileCheck %s
+
+# CHECK: I am in cpplib log!
+# CHECK: Swift is going to return 34
+# CHECK: doSomething: 34

--- a/validation-test/CMakeLists.txt
+++ b/validation-test/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+add_subdirectory(BuildSystem)


### PR DESCRIPTION
There are three things going on here (note all on Darwin):

1. If one compiles a swift static library and links the static library into a
   cxx executable, the cxx executable will need the -L flags to find the
   appropriate libraries in the SDK/toolchain.

2. I fixed an rpath issue where due to old code I didn't understand/propagated
   forward, we were setting the rpath to be the -L directory in the appropriate
   SDK. After reasoning about this a little bit I realized that this was code
   that was actually intended to be used for target libraries (for which the
   given rpath would be correct). On the host side though on Darwin, we want to
   use the rpath for the standard stabilized stdlib on the system.

3. I added Build System Unittests to ensure that this keeps on working. I also
   added test cases that I should have added before. I just had never thought
   about how to test this and I realized this method would work and would
   prevent regressions while I am waiting for a new swiftc with driver fixes to
   land.
