### PR TITLE
[5.5][CSBindings] Don't record variable adjacency for `member chain base` constraint

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1192,8 +1192,6 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
     if (!bindingTypeVar)
       return None;
 
-    AdjacentVars.insert({bindingTypeVar, constraint});
-
     // If current type variable is associated with a code completion token
     // it's possible that it doesn't have enough contextual information
     // to be resolved to anything, so let's note that fact in the potential
@@ -1215,14 +1213,24 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
         assert(kind == AllowedBindingKind::Supertypes);
         SupertypeOf.insert({bindingTypeVar, constraint});
       }
+
+      AdjacentVars.insert({bindingTypeVar, constraint});
       break;
     }
 
     case ConstraintKind::Bind:
     case ConstraintKind::BindParam:
-    case ConstraintKind::Equal:
+    case ConstraintKind::Equal: {
+      EquivalentTo.insert({bindingTypeVar, constraint});
+      AdjacentVars.insert({bindingTypeVar, constraint});
+      break;
+    }
+
     case ConstraintKind::UnresolvedMemberChainBase: {
       EquivalentTo.insert({bindingTypeVar, constraint});
+
+      // Don't record adjacency between base and result types,
+      // this is just an auxiliary contraint to enforce ordering.
       break;
     }
 

--- a/test/Constraints/static_members_on_protocol_in_generic_context.swift
+++ b/test/Constraints/static_members_on_protocol_in_generic_context.swift
@@ -316,3 +316,30 @@ func test_no_warning_about_optional_base() {
 
   test(.warnTest) // Ok and no warning even though the `warnTest` name is shadowed
 }
+
+// rdar://78425221 - invalid defaulting of literal argument when base is inferred from protocol
+
+protocol Style {}
+
+struct FormatString : ExpressibleByStringInterpolation {
+  init(stringLiteral: String) {}
+}
+
+struct Number : ExpressibleByIntegerLiteral {
+  init(integerLiteral: Int) {}
+}
+
+struct TestStyle: Style {
+  public init(format: FormatString)  {
+  }
+}
+
+extension Style where Self == TestStyle {
+  static func formattedString(format: FormatString) -> TestStyle { fatalError() }
+  static func number(_: Number) -> TestStyle { fatalError() }
+}
+
+func acceptStyle<S: Style>(_: S) {}
+
+acceptStyle(.formattedString(format: "hi")) // Ok
+acceptStyle(.number(42)) // Ok


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/37734

---

- Explanation:

This constraint is used to enforce ordering of inference and provide
a starting point for inference of base based on associated generic
constraints. It's an `Equals` constraint with additional semantics
that only apply to unresolved members, which means that there are
no (other) adjacent variables in this case.

- Scope: Expressions that use unresolved member with literal arguments that use static member lookup feature

- Main Branch PR: https://github.com/apple/swift/pull/37734

- Resolves: rdar://78425221

- Risk: Low

- Reviewed By: @hborla  

- Testing: Regression tests added to the suite

Resolves: rdar://78425221
(cherry picked from commit b88114248674aa90076169f4794000217bade579)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
