### PR TITLE
[5.5][Concurrency] Fix the call to swift_task_enqueueGlobal_hook.

### DIFF
--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -336,7 +336,7 @@ static void swift_task_enqueueGlobalImpl(Job *job) {
 
 void swift::swift_task_enqueueGlobal(Job *job) {
   if (swift_task_enqueueGlobal_hook)
-    swift_task_enqueueGlobal_hook(job, swift_task_enqueueGlobal);
+    swift_task_enqueueGlobal_hook(job, swift_task_enqueueGlobalImpl);
   else
     swift_task_enqueueGlobalImpl(job);
 }


### PR DESCRIPTION
We pass swift_task_enqueueGlobal as the original implementation, but that would recurse. We need to pass swift_task_enqueueGlobalImpl instead.

rdar://78780136