### PR TITLE
[5.5] Fix asserts and crashes caused by skipping function bodies or allowing errors

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5173,7 +5173,9 @@ bool Parser::delayParsingDeclList(SourceLoc LBLoc, SourceLoc &RBLoc,
   if (Tok.is(tok::r_brace)) {
     RBLoc = consumeToken();
   } else {
-    RBLoc = Tok.getLoc();
+    // Non-delayed parsing would set the RB location to the LB if it is missing,
+    // match that behaviour here
+    RBLoc = LBLoc;
     error = true;
   }
   return error;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4505,6 +4505,9 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
             skipAttr = true;
           } else
             return deserialized.takeError();
+        } else if (!deserialized.get() && MF.allowCompilerErrors()) {
+          // Serialized an invalid attribute, just skip it when allowing errors
+          skipAttr = true;
         } else {
           auto *TE = TypeExpr::createImplicit(deserialized.get(), ctx);
           auto custom = CustomAttr::create(ctx, SourceLoc(), TE, isImplicit);

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1440,7 +1440,8 @@ void Serializer::writeASTBlockEntity(
       data.push_back(addDeclRef(req));
       data.push_back(addDeclRef(witness.getDecl()));
       assert(witness.getDecl() || req->getAttrs().hasAttribute<OptionalAttr>()
-             || req->getAttrs().isUnavailable(req->getASTContext()));
+             || req->getAttrs().isUnavailable(req->getASTContext())
+             || allowCompilerErrors());
 
       // If there is no witness, we're done.
       if (!witness.getDecl()) return;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3913,6 +3913,9 @@ public:
     using namespace decls_block;
     verifyAttrSerializable(dtor);
 
+    if (S.allowCompilerErrors() && dtor->isInvalid())
+      return;
+
     auto contextID = S.addDeclContextRef(dtor->getDeclContext());
 
     unsigned abbrCode = S.DeclTypeAbbrCodes[DestructorLayout::Code];

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1992,6 +1992,8 @@ getStableSelfAccessKind(swift::SelfAccessKind MM) {
 # define DECL(KIND, PARENT)\
 LLVM_ATTRIBUTE_UNUSED \
 static void verifyAttrSerializable(const KIND ## Decl *D) {\
+  if (D->Decl::getASTContext().LangOpts.AllowModuleWithCompilerErrors)\
+    return;\
   for (auto Attr : D->getAttrs()) {\
     assert(Attr->canAppearOnDecl(D) && "attribute cannot appear on a " #KIND);\
   }\

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4148,6 +4148,13 @@ public:
   }
 
   void visitUnresolvedType(const UnresolvedType *) {
+    // If for some reason we have an unresolved type while compiling with
+    // errors, just serialize an ErrorType and continue.
+    if (S.getASTContext().LangOpts.AllowModuleWithCompilerErrors) {
+      visitErrorType(
+          cast<ErrorType>(ErrorType::get(S.getASTContext()).getPointer()));
+      return;
+    }
     llvm_unreachable("should not serialize an UnresolvedType");
   }
 

--- a/validation-test/Parse/delayed-members-open-if.swift
+++ b/validation-test/Parse/delayed-members-open-if.swift
@@ -1,0 +1,4 @@
+// RUN: not %target-swift-frontend -typecheck -experimental-skip-all-function-bodies %s
+
+#if os(
+struct Anything {

--- a/validation-test/Parse/delayed-members-open-prop-scope.swift
+++ b/validation-test/Parse/delayed-members-open-prop-scope.swift
@@ -1,0 +1,6 @@
+// RUN: not %target-swift-frontend -typecheck -experimental-skip-all-function-bodies %s
+
+struct A {
+  let prop: Int = {
+
+struct B {

--- a/validation-test/Serialization/AllowErrors/invalid-attr-refs.swift
+++ b/validation-test/Serialization/AllowErrors/invalid-attr-refs.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -module-name errors -emit-module -o %t/errors.swiftmodule -experimental-allow-module-with-compiler-errors %s
+
+// Property wrappers are invalid on top level code, check allowing errors
+// does not crash
+
+@propertyWrapper
+public struct Wrapper<T> {
+  public var wrappedValue: T
+  public init() {}
+}
+@Wrapper
+public var topLevelVar: Int = 10

--- a/validation-test/Serialization/AllowErrors/invalid-attr.swift
+++ b/validation-test/Serialization/AllowErrors/invalid-attr.swift
@@ -1,0 +1,9 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -module-name errors -emit-module -o %t/errors.swiftmodule -experimental-allow-module-with-compiler-errors %s
+
+// @discardableResult is not allowed on a struct, make sure we don't crash
+// when allowing errors
+
+@discardableResult
+struct SomeStruct {}

--- a/validation-test/Serialization/AllowErrors/invalid-deinit.swift
+++ b/validation-test/Serialization/AllowErrors/invalid-deinit.swift
@@ -1,0 +1,8 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -module-name errors -emit-module -o %t/errors.swiftmodule -experimental-allow-module-with-compiler-errors %s
+
+// deinit is only valid on a class, make sure we don't crash when allowing
+// errors
+
+deinit {}

--- a/validation-test/Serialization/AllowErrors/invalid-witness.swift
+++ b/validation-test/Serialization/AllowErrors/invalid-witness.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -module-name errors -emit-module -o %t/errors.swiftmodule -experimental-allow-module-with-compiler-errors %s
+
+public protocol SomeProto {
+  init(from: SomeProto)
+}
+
+struct A {}
+struct B: SomeProto {
+  let a: A
+}
+
+let thing = B(a: A())

--- a/validation-test/Serialization/AllowErrors/unresolved-type.swift
+++ b/validation-test/Serialization/AllowErrors/unresolved-type.swift
@@ -1,0 +1,12 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -module-name errors -emit-module -o %t/errors.swiftmodule -experimental-allow-module-with-compiler-errors %s
+
+protocol SomeProto {}
+
+extension SomeProto {
+    func someFunc(arg:
+
+enum SomeEnum {
+    case a
+}


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/37701

-----

Fixes various crashes exposed by the stress tester when either skipping function bodies or allowing errors.