### PR TITLE
Revert "Turn on additional musttail checks for swiftc and runtime."

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1193,12 +1193,6 @@ def user_module_version : Separate<["-"], "user-module-version">,
   HelpText<"Module version specified from Swift module authors">,
   MetaVarName<"<vers>">;
 
-// LLVM verification
-def skip_swifttailcc_musttail_check : Flag<["-"], "skip-swifttailcc-musttail-check">,
-  Flags<[HelpHidden, DoesNotAffectIncrementalBuild]>,
-  HelpText<"Skip additional LLVM verification that all tail calls from "
-           "swifttailcc->swifttailcc are marked musttail.">;
-
 // VFS
 
 def vfsoverlay : JoinedOrSeparate<["-"], "vfsoverlay">,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -323,11 +323,6 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
       arguments.push_back("-enable-anonymous-context-mangled-names");
   }
 
-  if (!inputArgs.hasArg(options::OPT_skip_swifttailcc_musttail_check)) {
-    arguments.push_back("-Xllvm");
-    arguments.push_back("-enable-swifttailcc-musttail-check");
-  }
-
   // Pass through any subsystem flags.
   inputArgs.AddAllArgs(arguments, options::OPT_Xllvm);
   inputArgs.AddAllArgs(arguments, options::OPT_Xcc);

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -79,13 +79,6 @@ set(swift_runtime_library_compile_flags ${swift_runtime_compile_flags})
 list(APPEND swift_runtime_library_compile_flags -DswiftCore_EXPORTS)
 list(APPEND swift_runtime_library_compile_flags -I${SWIFT_SOURCE_DIR}/stdlib/include/llvm/Support -I${SWIFT_SOURCE_DIR}/include)
 
-# Check that the runtime is using the async calling convention
-# correctly, and that musttail isn't missed by Clang/LLVM.
-if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
-  list(APPEND swift_runtime_library_compile_flags
-        "-mllvm" "-enable-swifttailcc-musttail-check")
-endif()
-
 set(sdk "${SWIFT_HOST_VARIANT_SDK}")
 if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
   set(static_binary_lnk_file_list)

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -138,12 +138,4 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     swiftCore${SWIFT_PRIMARY_VARIANT_SUFFIX}
     ${PLATFORM_TARGET_LINK_LIBRARIES}
     )
-
-  # Check that the tests are using the async calling convention
-  # correctly, and that musttail isn't missed by Clang/LLVM.
-  if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
-    target_compile_options(SwiftRuntimeTests
-      PUBLIC "-mllvm;-enable-swifttailcc-musttail-check")
-  endif()
-
 endif()


### PR DESCRIPTION
This reverts commit 02551564adc8fab5d14994c12c6993ee6c43fe7f.

Using this flag caused breakage when trying to use upstream LLVM
as well as Clang/LLVM from Xcode 12.5. See SR-14714.