### PR TITLE
Use a decent sentinel value for reference poison

### DIFF
--- a/stdlib/public/SwiftShims/System.h
+++ b/stdlib/public/SwiftShims/System.h
@@ -76,8 +76,8 @@
 // This is not ABI per-se but does stay in-sync with LLDB. If it becomes
 // out-of-sync, then users won't see a friendly diagnostic when inspecting
 // references past their lifetime.
-#define SWIFT_ABI_DEFAULT_REFERENCE_POISON_DEBUG_VALUE_32 0x00000880U
-#define SWIFT_ABI_DEFAULT_REFERENCE_POISON_DEBUG_VALUE_64 0x0000000000000880ULL
+#define SWIFT_ABI_DEFAULT_REFERENCE_POISON_DEBUG_VALUE_32 0x00000440U
+#define SWIFT_ABI_DEFAULT_REFERENCE_POISON_DEBUG_VALUE_64 0x0000000000000440ULL
 
 /*********************************** i386 *************************************/
 

--- a/test/IRGen/debug_poison.swift
+++ b/test/IRGen/debug_poison.swift
@@ -37,7 +37,7 @@ private func useOptionalK(_: K?) -> Int {
 // CHECK: store %T12debug_poison1KC* [[REF]], %T12debug_poison1KC** %b.debug
 // CHECK: [[Y:%.*]] = call {{.*}} [[INT]] @"$s12debug_poison4use{{.*}}"(%T12debug_poison1KC* [[REF]])
 // CHECK: call void {{.*}} @swift_release {{.*}} [[REF]]
-// CHECK: store %T12debug_poison1KC* inttoptr ([[INT]] 2176 to %T12debug_poison1KC*), %T12debug_poison1KC** %b.debug
+// CHECK: store %T12debug_poison1KC* inttoptr ([[INT]] 1088 to %T12debug_poison1KC*), %T12debug_poison1KC** %b.debug
 // CHECK: store [[INT]] [[Y]], [[INT]]* %y.debug
 // CHECK: call {{.*}} void @"$s12debug_poison6useIntyySiF"([[INT]] [[Y]])
 public func testPoisonRef() {
@@ -56,7 +56,7 @@ public func testPoisonRef() {
 // CHECK: [[Y:%.*]] = call {{.*}} [[INT]] @"$s12debug_poison12useOptionalK{{.*}}"([[INT]] [[REF]])
 // CHECK: call void @swift_release
 // CHECK: [[NIL:%.*]] = icmp eq [[INT]] [[REF]], 0
-// CHECK: [[POISON:%.*]] = select i1 [[NIL]], [[INT]] [[REF]], [[INT]] 2176
+// CHECK: [[POISON:%.*]] = select i1 [[NIL]], [[INT]] [[REF]], [[INT]] 1088
 // CHECK: store [[INT]] [[POISON]], [[INT]]* %b.debug
 // CHECK: store [[INT]] [[Y]], [[INT]]* %y.debug
 // CHECK: call {{.*}} void @"$s12debug_poison6useIntyySiF"([[INT]] [[Y]])
@@ -80,7 +80,7 @@ public func testPoisonOptionalRef() {
 // CHECK: call {{.*}} void @"$s12debug_poison6useAnyyyypF"(
 // CHECK: call void @swift_{{unknownObjectRelease|release}}(%[[REFTY]]* [[REF]]) #1
 // CHECK: [[GEP1:%.*]] = getelementptr inbounds %T12debug_poison1PP, %T12debug_poison1PP* %b.debug, i32 0, i32 0
-// CHECK: store %[[REFTY]]* inttoptr ([[INT]] 2176 to %[[REFTY]]*), %[[REFTY]]** [[GEP1]]
+// CHECK: store %[[REFTY]]* inttoptr ([[INT]] 1088 to %[[REFTY]]*), %[[REFTY]]** [[GEP1]]
 // CHECK: call {{.*}} void @"$s12debug_poison7useNoneyyF"()
 public func testPoisonExistential() {
   let b: P = D()
@@ -102,7 +102,7 @@ public func testPoisonExistential() {
 // CHECK: call {{.*}} void @"$s12debug_poison6useAnyyyypF"(
 // CHECK: call void @swift_{{unknownObjectRelease|release}}(%[[REFTY]]* [[REF]]) #1
 // CHECK: [[GEP1:%.*]] = getelementptr inbounds %T12debug_poison1Q_Xl, %T12debug_poison1Q_Xl* %b.debug, i32 0, i32 0
-// CHECK: store %[[REFTY]]* inttoptr ([[INT]] 2176 to %[[REFTY]]*), %[[REFTY]]** [[GEP1]]
+// CHECK: store %[[REFTY]]* inttoptr ([[INT]] 1088 to %[[REFTY]]*), %[[REFTY]]** [[GEP1]]
 // CHECK: call {{.*}} void @"$s12debug_poison7useNoneyyF"()
 public func testPoisonComposite() {
   let b: Q & AnyObject = E()


### PR DESCRIPTION
Only relevant for -Xfrontend -enable-copy-propagation in debug builds.
It's only an experimental mode for now for shrinking lifetimes while
providing lldb an easy way to report a friendly error.

Goals:
- two repetitive digits that don't look like garbage
- less than a page, so it can never be a real pointer
- reserve as many low bits as possible so it can't be a tagged pointer
- not used by any other memory smashers

0x440 is 64-byte aligned which is plenty for any conceivable object
allocator.
