### PR TITLE
Move prependTopLevelDecl to SynthesizedFileUnit

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -173,18 +173,6 @@ public:
     Decls->push_back(d);
   }
 
-  /// Prepends a declaration to the top-level decls list.
-  ///
-  /// FIXME: This entrypoint exists to support LLDB. Calls to this function are
-  /// always a mistake, and additional uses should not be added.
-  ///
-  /// See rdar://58355191
-  void prependTopLevelDecl(Decl *d) {
-    // Force decl parsing if we haven't already.
-    (void)getTopLevelDecls();
-    Decls->insert(Decls->begin(), d);
-  }
-
   /// Add a hoisted declaration. See Decl::isHoisted().
   void addHoistedDecl(Decl *d);
 

--- a/include/swift/AST/SynthesizedFileUnit.h
+++ b/include/swift/AST/SynthesizedFileUnit.h
@@ -28,7 +28,7 @@ class SynthesizedFileUnit final : public FileUnit {
   SourceFile &SF;
 
   /// Synthesized top level declarations.
-  TinyPtrVector<ValueDecl *> TopLevelDecls;
+  llvm::SmallVector<Decl *, 4> TopLevelDecls;
 
   /// A unique identifier representing this file; used to mark private decls
   /// within the file to keep them from conflicting with other files in the
@@ -42,8 +42,18 @@ public:
   /// Returns the parent source file.
   SourceFile &getSourceFile() const { return SF; }
 
+  /// Prepends a declaration to the top-level decls list.
+  ///
+  /// FIXME: This entrypoint exists to support LLDB. Calls to this function are
+  /// always a mistake, and additional uses should not be added.
+  ///
+  /// See rdar://58355191
+  void prependTopLevelDecl(Decl *d) {
+    TopLevelDecls.insert(TopLevelDecls.begin(), d);
+  }
+
   /// Add a synthesized top-level declaration.
-  void addTopLevelDecl(ValueDecl *D) { TopLevelDecls.push_back(D); }
+  void addTopLevelDecl(Decl *D) { TopLevelDecls.push_back(D); }
 
   virtual void lookupValue(DeclName name, NLKind lookupKind,
                            SmallVectorImpl<ValueDecl *> &result) const override;
@@ -56,7 +66,7 @@ public:
 
   void getTopLevelDecls(SmallVectorImpl<Decl*> &results) const override;
 
-  ArrayRef<ValueDecl *> getTopLevelDecls() const {
+  ArrayRef<Decl *> getTopLevelDecls() const {
     return TopLevelDecls;
   };
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2784,8 +2784,9 @@ void SynthesizedFileUnit::lookupValue(
     DeclName name, NLKind lookupKind,
     SmallVectorImpl<ValueDecl *> &result) const {
   for (auto *decl : TopLevelDecls) {
-    if (decl->getName().matchesRef(name))
-      result.push_back(decl);
+    if (auto *VD = dyn_cast<ValueDecl>(decl))
+      if (VD->getName().matchesRef(name))
+        result.push_back(VD);
   }
 }
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1999,6 +1999,14 @@ public:
     performTypeChecking(*sf);
 
     SourceFileScope scope(SGM, sf);
+    if (auto *SSF = sf->getSynthesizedFile()) {
+      for (Decl *D : SSF->getTopLevelDecls()) {
+        FrontendStatsTracer StatsTracer(SGM.getASTContext().Stats,
+                                        "SILgen-synthesized-decl", D);
+        SGM.visit(D);
+      }
+    }
+    
     for (auto *D : sf->getTopLevelDecls()) {
       FrontendStatsTracer StatsTracer(SGM.getASTContext().Stats,
                                       "SILgen-decl", D);
@@ -2019,14 +2027,6 @@ public:
       if (TD->getDeclContext()->getInnermostSkippedFunctionContext())
         continue;
       SGM.visit(TD);
-    }
-
-    if (auto *SSF = sf->getSynthesizedFile()) {
-      for (Decl *D : SSF->getTopLevelDecls()) {
-        FrontendStatsTracer StatsTracer(SGM.getASTContext().Stats,
-                                        "SILgen-synthesized-decl", D);
-        SGM.visit(D);
-      }
     }
 
     // If the source file contains an artificial main, emit the implicit

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -2021,6 +2021,14 @@ public:
       SGM.visit(TD);
     }
 
+    if (auto *SSF = sf->getSynthesizedFile()) {
+      for (Decl *D : SSF->getTopLevelDecls()) {
+        FrontendStatsTracer StatsTracer(SGM.getASTContext().Stats,
+                                        "SILgen-synthesized-decl", D);
+        SGM.visit(D);
+      }
+    }
+
     // If the source file contains an artificial main, emit the implicit
     // top-level code.
     if (auto *mainDecl = sf->getMainDecl())


### PR DESCRIPTION
Relegate an API built solely for LLDB to synthesized file unit. Once
code completion is no longer using SourceFile::addTopLevelDecl we can
simplify a lot of the AST here.