### PR TITLE
[Utils] Make sure to write the rewritten file in refactor-check-compiles

### DIFF
--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -527,8 +527,7 @@ class SourceEditTextConsumer : public SourceEditConsumer {
   llvm::raw_ostream &OS;
 
 public:
-  SourceEditTextConsumer(llvm::raw_ostream &OS);
-
+  SourceEditTextConsumer(llvm::raw_ostream &OS) : OS(OS) {}
   void accept(SourceManager &SM, RegionType RegionType,
               ArrayRef<Replacement> Replacements) override;
 };
@@ -544,13 +543,14 @@ public:
   void accept(SourceManager &SM, RegionType RegionType, ArrayRef<Replacement> Replacements) override;
 };
 
-class DuplicatingSourceEditConsumer : public SourceEditConsumer {
-  SourceEditConsumer *ConsumerA;
-  SourceEditConsumer *ConsumerB;
+/// Broadcasts `accept` to all `Consumers`
+class BroadcastingSourceEditConsumer : public SourceEditConsumer {
+  ArrayRef<std::unique_ptr<SourceEditConsumer>> Consumers;
 
 public:
-  DuplicatingSourceEditConsumer(SourceEditConsumer *ConsumerA,
-                                SourceEditConsumer *ConsumerB);
+  BroadcastingSourceEditConsumer(
+      ArrayRef<std::unique_ptr<SourceEditConsumer>> Consumers)
+      : Consumers(Consumers) {}
   void accept(SourceManager &SM, RegionType RegionType,
               ArrayRef<Replacement> Replacements) override;
 };

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -1017,9 +1017,6 @@ accept(SourceManager &SM, RegionType Type, ArrayRef<Replacement> Replacements) {
   }
 }
 
-swift::ide::SourceEditTextConsumer::
-SourceEditTextConsumer(llvm::raw_ostream &OS) : OS(OS) { }
-
 void swift::ide::SourceEditTextConsumer::
 accept(SourceManager &SM, RegionType Type, ArrayRef<Replacement> Replacements) {
   for (const auto &Replacement: Replacements) {
@@ -1116,15 +1113,12 @@ accept(SourceManager &SM, RegionType RegionType,
   }
 }
 
-swift::ide::DuplicatingSourceEditConsumer::DuplicatingSourceEditConsumer(
-    SourceEditConsumer *ConsumerA, SourceEditConsumer *ConsumerB)
-    : ConsumerA(ConsumerA), ConsumerB(ConsumerB) {}
-
-void swift::ide::DuplicatingSourceEditConsumer::accept(
+void swift::ide::BroadcastingSourceEditConsumer::accept(
     SourceManager &SM, RegionType RegionType,
     ArrayRef<Replacement> Replacements) {
-  ConsumerA->accept(SM, RegionType, Replacements);
-  ConsumerB->accept(SM, RegionType, Replacements);
+  for (auto &Consumer : Consumers) {
+    Consumer->accept(SM, RegionType, Replacements);
+  }
 }
 
 bool swift::ide::isFromClang(const Decl *D) {

--- a/test/refactoring/ConvertAsync/check_compiles.swift
+++ b/test/refactoring/ConvertAsync/check_compiles.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+
+func simple(completion: () -> Void) { }
+func anything() -> Bool { return true }
+
+// RUN: %swift-frontend -typecheck %s
+// RUN: not %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):6
+func cannotCompile() {
+  simple {
+    if anything() {
+      return
+    }
+  }
+}

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -413,34 +413,36 @@ int main(int argc, char *argv[]) {
   RefactoringConfig.Range = Range;
   RefactoringConfig.PreferredName = options::NewName;
   std::string Error;
-  std::unique_ptr<SourceEditConsumer> pConsumer;
+
+  StringRef RewrittenOutputFile = options::RewrittenOutputFile;
+  if (RewrittenOutputFile.empty())
+    RewrittenOutputFile = "-";
+  std::error_code EC;
+  llvm::raw_fd_ostream RewriteStream(RewrittenOutputFile, EC);
+  if (RewriteStream.has_error()) {
+    llvm::errs() << "Could not open rewritten output file";
+    return 1;
+  }
+
+  SmallVector<std::unique_ptr<SourceEditConsumer>> Consumers;
+  if (!options::RewrittenOutputFile.empty() ||
+      options::DumpIn == options::DumpType::REWRITTEN) {
+    Consumers.emplace_back(new SourceEditOutputConsumer(
+        SF->getASTContext().SourceMgr, BufferID, RewriteStream));
+  }
   switch (options::DumpIn) {
   case options::DumpType::REWRITTEN:
-    pConsumer.reset(new SourceEditOutputConsumer(SF->getASTContext().SourceMgr,
-                                                 BufferID, llvm::outs()));
+    // Already added
     break;
   case options::DumpType::JSON:
-    pConsumer.reset(new SourceEditJsonConsumer(llvm::outs()));
+    Consumers.emplace_back(new SourceEditJsonConsumer(llvm::outs()));
     break;
   case options::DumpType::TEXT:
-    if (options::RewrittenOutputFile.empty()) {
-      pConsumer.reset(new SourceEditTextConsumer(llvm::outs()));
-    } else {
-      std::error_code EC;
-      static llvm::raw_fd_ostream FileStream(options::RewrittenOutputFile, EC,
-                                             llvm::sys::fs::OF_None);
-      if (FileStream.has_error() || EC) {
-        llvm::errs() << "Could not open rewritten output file";
-        return 1;
-      }
-      pConsumer.reset(new DuplicatingSourceEditConsumer(
-          new SourceEditTextConsumer(llvm::outs()),
-          new SourceEditOutputConsumer(SF->getASTContext().SourceMgr, BufferID,
-                                       FileStream)));
-    }
+    Consumers.emplace_back(new SourceEditTextConsumer(llvm::outs()));
     break;
   }
 
-  return refactorSwiftModule(CI.getMainModule(), RefactoringConfig, *pConsumer,
-                             PrintDiags);
+  BroadcastingSourceEditConsumer BroadcastConsumer(Consumers);
+  return refactorSwiftModule(CI.getMainModule(), RefactoringConfig,
+                             BroadcastConsumer, PrintDiags);
 }

--- a/utils/refactor-check-compiles.py
+++ b/utils/refactor-check-compiles.py
@@ -92,6 +92,7 @@ def main():
         '-rewritten-output-file', temp_file_path,
         '-pos', args.pos
     ] + extra_refactor_args, desc='producing edit').decode("utf-8")
+    sys.stdout.write(dump_text_output)
 
     run_cmd([
         args.swift_frontend,
@@ -99,7 +100,6 @@ def main():
         temp_file_path,
         '-disable-availability-checking'
     ] + extra_frontend_args, desc='checking that rewritten file compiles')
-    sys.stdout.write(dump_text_output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`ClangFileRewriterHelper` only outputs the rewritten buffer when it's
destroyed, but the consumers were never being freed. Cleanup the
lifetime management of the stream and consumers so that they're properly
destroyed.

Rename `DuplicatingSourceEditConsumer` to
`BroadcastingSourceEditConsumer` to better describe its purpose.
