### PR TITLE
RequirementMachine: miscellaneous fixes and improvements

### DIFF
--- a/include/swift/AST/RequirementMachine.h
+++ b/include/swift/AST/RequirementMachine.h
@@ -23,14 +23,6 @@ class GenericSignature;
 class ProtocolDecl;
 class Requirement;
 
-namespace rewriting {
-
-class Term;
-
-Term getTermForType(CanType paramType, const ProtocolDecl *proto);
-
-} // end namespace rewriting
-
 /// Wraps a rewrite system with higher-level operations in terms of
 /// generic signatures and interface types.
 class RequirementMachine final {

--- a/include/swift/AST/RewriteSystem.h
+++ b/include/swift/AST/RewriteSystem.h
@@ -18,6 +18,7 @@
 #include "swift/AST/LayoutConstraint.h"
 #include "swift/AST/ProtocolGraph.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/Statistic.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/SmallVector.h"
@@ -352,7 +353,10 @@ class RewriteContext final {
   RewriteContext &operator=(RewriteContext &&) = delete;
 
 public:
-  RewriteContext() {}
+  /// Statistical counters.
+  UnifiedStatsReporter *Stats;
+
+  RewriteContext(UnifiedStatsReporter *stats) : Stats(stats) {}
 
   Term getTermForType(CanType paramType,
                       const ProtocolDecl *proto);
@@ -420,6 +424,7 @@ public:
 ///
 /// Out-of-line methods are documented in RewriteSystem.cpp.
 class RewriteSystem final {
+  /// Rewrite context for memory allocation.
   RewriteContext &Context;
 
   /// The rules added so far, including rules from our client, as well

--- a/include/swift/AST/RewriteSystem.h
+++ b/include/swift/AST/RewriteSystem.h
@@ -376,7 +376,6 @@ public:
   const Term &getRHS() const { return RHS; }
 
   bool apply(Term &term) const {
-    assert(!deleted);
     return term.rewriteSubTerm(LHS, RHS);
   }
 
@@ -451,12 +450,14 @@ class RewriteSystem final {
   unsigned DebugSimplify : 1;
   unsigned DebugAdd : 1;
   unsigned DebugMerge : 1;
+  unsigned DebugCompletion : 1;
 
 public:
   explicit RewriteSystem(RewriteContext &ctx) : Context(ctx) {
     DebugSimplify = false;
     DebugAdd = false;
     DebugMerge = false;
+    DebugCompletion = false;
   }
 
   RewriteSystem(const RewriteSystem &) = delete;

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -428,7 +428,7 @@ namespace swift {
         ASTVerifierOverrideKind::NoOverride;
 
     /// Whether the new experimental generics implementation is enabled.
-    bool EnableRequirementMachine = false;
+    bool EnableRequirementMachine = true;
 
     /// Enables debugging output from the requirement machine.
     bool DebugRequirementMachine = false;

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -220,6 +220,14 @@ FRONTEND_STATISTIC(Sema, NumAccessorsSynthesized)
 /// Number of synthesized accessor bodies.
 FRONTEND_STATISTIC(Sema, NumAccessorBodiesSynthesized)
 
+/// Number of requirement machines constructed. Rough proxy for
+/// amount of work the requirement machine does analyzing type signatures.
+FRONTEND_STATISTIC(Sema, NumRequirementMachines)
+
+/// Number of requirement machines constructed. Rough proxy for
+/// amount of work the requirement machine does analyzing type signatures.
+FRONTEND_STATISTIC(Sema, NumRequirementMachineCompletionSteps)
+
 /// Number of generic signature builders constructed. Rough proxy for
 /// amount of work the GSB does analyzing type signatures.
 FRONTEND_STATISTIC(Sema, NumGenericSignatureBuilders)

--- a/lib/AST/ProtocolGraph.cpp
+++ b/lib/AST/ProtocolGraph.cpp
@@ -158,7 +158,7 @@ void ProtocolGraph::computeInheritedProtocols() {
   }
 }
 
-/// Recursively compute the 'depth' of e protocol, which is inductively defined
+/// Recursively compute the 'depth' of a protocol, which is inductively defined
 /// as one greater than the depth of all inherited protocols, with a protocol
 /// that does not inherit any other protocol having a depth of one.
 unsigned ProtocolGraph::computeProtocolDepth(const ProtocolDecl *proto) {

--- a/lib/AST/ProtocolGraph.cpp
+++ b/lib/AST/ProtocolGraph.cpp
@@ -158,7 +158,7 @@ void ProtocolGraph::computeInheritedProtocols() {
   }
 }
 
-/// Recursively compute the 'depth' of a protocol, which is inductively defined
+/// Recursively compute the 'depth' of  protocol, which is inductively defined
 /// as one greater than the depth of all inherited protocols, with a protocol
 /// that does not inherit any other protocol having a depth of one.
 unsigned ProtocolGraph::computeProtocolDepth(const ProtocolDecl *proto) {

--- a/lib/AST/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine.cpp
@@ -207,11 +207,12 @@ struct RequirementMachine::Implementation {
   RewriteSystem System;
   bool Complete = false;
 
-  Implementation() : System(Context) {}
+  Implementation(ASTContext &ctx)
+    : Context(ctx.Stats), System(Context) {}
 };
 
 RequirementMachine::RequirementMachine(ASTContext &ctx) : Context(ctx) {
-  Impl = new Implementation();
+  Impl = new Implementation(ctx);
 }
 
 RequirementMachine::~RequirementMachine() {
@@ -222,6 +223,9 @@ void RequirementMachine::addGenericSignature(CanGenericSignature sig) {
   PrettyStackTraceGenericSignature debugStack("building rewrite system for", sig);
 
   auto *Stats = Context.Stats;
+
+  if (Stats)
+    ++Stats->getFrontendCounters().NumRequirementMachines;
 
   FrontendStatsTracer tracer(Stats, "build-rewrite-system");
 

--- a/lib/AST/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine.cpp
@@ -31,12 +31,14 @@ namespace {
 /// of a generic signature, and all protocol requirement signatures from all
 /// transitively-referenced protocols.
 struct RewriteSystemBuilder {
-  ASTContext &Context;
+  RewriteContext &Context;
+  bool Debug;
 
   ProtocolGraph Protocols;
   std::vector<std::pair<Term, Term>> Rules;
 
-  RewriteSystemBuilder(ASTContext &ctx) : Context(ctx) {}
+  RewriteSystemBuilder(RewriteContext &ctx, bool debug)
+    : Context(ctx), Debug(debug) {}
   void addGenericSignature(CanGenericSignature sig);
   void addAssociatedType(const AssociatedTypeDecl *type,
                          const ProtocolDecl *proto);
@@ -59,7 +61,7 @@ void RewriteSystemBuilder::addGenericSignature(CanGenericSignature sig) {
 
   // Add rewrite rules for each protocol.
   for (auto *proto : Protocols.Protocols) {
-    if (Context.LangOpts.DebugRequirementMachine) {
+    if (Debug) {
       llvm::dbgs() << "protocol " << proto->getName() << " {\n";
     }
 
@@ -78,7 +80,7 @@ void RewriteSystemBuilder::addGenericSignature(CanGenericSignature sig) {
     for (auto req : info.Requirements)
       addRequirement(req.getCanonical(), proto);
 
-    if (Context.LangOpts.DebugRequirementMachine) {
+    if (Debug) {
       llvm::dbgs() << "}\n";
     }
   }
@@ -97,11 +99,11 @@ void RewriteSystemBuilder::addGenericSignature(CanGenericSignature sig) {
 void RewriteSystemBuilder::addAssociatedType(const AssociatedTypeDecl *type,
                                              const ProtocolDecl *proto) {
   Term lhs;
-  lhs.add(Atom::forProtocol(proto));
-  lhs.add(Atom::forName(type->getName()));
+  lhs.add(Atom::forProtocol(proto, Context));
+  lhs.add(Atom::forName(type->getName(), Context));
 
   Term rhs;
-  rhs.add(Atom::forAssociatedType(proto, type->getName()));
+  rhs.add(Atom::forAssociatedType(proto, type->getName(), Context));
 
   Rules.emplace_back(lhs, rhs);
 }
@@ -117,12 +119,14 @@ void RewriteSystemBuilder::addInheritedAssociatedType(
                                                 const AssociatedTypeDecl *type,
                                                 const ProtocolDecl *inherited,
                                                 const ProtocolDecl *proto) {
+  assert(inherited != proto);
+
   Term lhs;
-  lhs.add(Atom::forProtocol(proto));
-  lhs.add(Atom::forAssociatedType(inherited, type->getName()));
+  lhs.add(Atom::forProtocol(proto, Context));
+  lhs.add(Atom::forAssociatedType(inherited, type->getName(), Context));
 
   Term rhs;
-  rhs.add(Atom::forAssociatedType(proto, type->getName()));
+  rhs.add(Atom::forAssociatedType(proto, type->getName(), Context));
 
   Rules.emplace_back(lhs, rhs);
 }
@@ -138,14 +142,14 @@ void RewriteSystemBuilder::addInheritedAssociatedType(
 /// protocol atom.
 void RewriteSystemBuilder::addRequirement(const Requirement &req,
                                           const ProtocolDecl *proto) {
-  if (Context.LangOpts.DebugRequirementMachine) {
+  if (Debug) {
     llvm::dbgs() << "+ ";
     req.dump(llvm::dbgs());
     llvm::dbgs() << "\n";
   }
 
   auto subjectType = CanType(req.getFirstType());
-  auto subjectTerm = getTermForType(subjectType, proto);
+  auto subjectTerm = Context.getTermForType(subjectType, proto);
 
   switch (req.getKind()) {
   case RequirementKind::Conformance: {
@@ -157,7 +161,7 @@ void RewriteSystemBuilder::addRequirement(const Requirement &req,
     auto *proto = req.getProtocolDecl();
 
     auto constraintTerm = subjectTerm;
-    constraintTerm.add(Atom::forProtocol(proto));
+    constraintTerm.add(Atom::forProtocol(proto, Context));
 
     Rules.emplace_back(subjectTerm, constraintTerm);
     break;
@@ -172,7 +176,8 @@ void RewriteSystemBuilder::addRequirement(const Requirement &req,
     //
     //   T.[L] == T
     auto constraintTerm = subjectTerm;
-    constraintTerm.add(Atom::forLayout(req.getLayoutConstraint()));
+    constraintTerm.add(Atom::forLayout(req.getLayoutConstraint(),
+                                       Context));
 
     Rules.emplace_back(subjectTerm, constraintTerm);
     break;
@@ -188,7 +193,7 @@ void RewriteSystemBuilder::addRequirement(const Requirement &req,
     if (!otherType->isTypeParameter())
       break;
 
-    auto otherTerm = getTermForType(otherType, proto);
+    auto otherTerm = Context.getTermForType(otherType, proto);
 
     Rules.emplace_back(subjectTerm, otherTerm);
     break;
@@ -196,48 +201,13 @@ void RewriteSystemBuilder::addRequirement(const Requirement &req,
   }
 }
 
-/// Map an interface type to a term.
-///
-/// If \p proto is null, this is a term relative to a generic
-/// parameter in a top-level signature. The term is rooted in a generic
-/// parameter atom.
-///
-/// If \p proto is non-null, this is a term relative to a protocol's
-/// 'Self' type. The term is rooted in a protocol atom.
-///
-/// The bound associated types in the interface type are ignored; the
-/// resulting term consists entirely of a root atom followed by zero
-/// or more name atoms.
-Term swift::rewriting::getTermForType(CanType paramType,
-                                      const ProtocolDecl *proto) {
-  assert(paramType->isTypeParameter());
-
-  // Collect zero or more nested type names in reverse order.
-  SmallVector<Atom, 3> atoms;
-  while (auto memberType = dyn_cast<DependentMemberType>(paramType)) {
-    atoms.push_back(Atom::forName(memberType->getName()));
-    paramType = memberType.getBase();
-  }
-
-  // Add the root atom at the end.
-  if (proto) {
-    assert(proto->getSelfInterfaceType()->isEqual(paramType));
-    atoms.push_back(Atom::forProtocol(proto));
-  } else {
-    atoms.push_back(Atom::forGenericParam(cast<GenericTypeParamType>(paramType)));
-  }
-
-  std::reverse(atoms.begin(), atoms.end());
-
-  return Term(atoms);
-}
-
 /// We use the PIMPL pattern to avoid creeping header dependencies.
 struct RequirementMachine::Implementation {
+  RewriteContext Context;
   RewriteSystem System;
   bool Complete = false;
 
-  Implementation() {}
+  Implementation() : System(Context) {}
 };
 
 RequirementMachine::RequirementMachine(ASTContext &ctx) : Context(ctx) {
@@ -261,7 +231,8 @@ void RequirementMachine::addGenericSignature(CanGenericSignature sig) {
 
   // Collect the top-level requirements, and all transtively-referenced
   // protocol requirement signatures.
-  RewriteSystemBuilder builder(Context);
+  RewriteSystemBuilder builder(Impl->Context,
+                               Context.LangOpts.DebugRequirementMachine);
   builder.addGenericSignature(sig);
 
   // Add the initial set of rewrite rules to the rewrite system, also

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -798,7 +798,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.EnableRequirementMachine = Args.hasFlag(
       OPT_enable_requirement_machine,
-      OPT_disable_requirement_machine, /*default=*/false);
+      OPT_disable_requirement_machine, /*default=*/true);
 
   Opts.DebugRequirementMachine = Args.hasArg(
       OPT_debug_requirement_machine);

--- a/test/Generics/recursive_conformances.swift
+++ b/test/Generics/recursive_conformances.swift
@@ -1,0 +1,61 @@
+// RUN: %target-typecheck-verify-swift -enable-requirement-machine
+
+// Make sure the requirement machine can compute a confluent
+// completion in examples where we merge two associated types
+// with the same name, both having recursive conformance
+// requirements.
+
+// Merged two cycles of length 1:
+//
+// P1 -> P1 -> P1 -> ...
+// P2 -> P2 -> P2 -> ...
+protocol P1 {
+  associatedtype T : P1
+}
+
+protocol P2 {
+  associatedtype T : P2
+}
+
+struct S<T : P1 & P2> {}
+
+// Merged a cycle of length 2 with a cycle of length 3
+//
+// P1a -> P1b -> P1a -> P1b -> P1a -> P1b -> ...
+// P2a -> P2b -> P2c -> P2a -> P2b -> P2c -> ...
+protocol P1a {
+  associatedtype T : P1b
+}
+
+protocol P1b {
+  associatedtype T : P1a
+}
+
+protocol P2a {
+  associatedtype T : P2b
+}
+
+protocol P2b {
+  associatedtype T : P2c
+}
+
+protocol P2c {
+  associatedtype T : P2a
+}
+
+struct SS<T : P1a & P2a> {}
+
+// Merged two cycles of length 1 via an inherited associated type
+protocol Base {
+  associatedtype T : Base // expected-note {{'T' declared here}}
+}
+
+// Base     -> Base     -> Base     -> ...
+// Derived1 -> Derived1 -> Derived1 -> ...
+protocol Derived1 : Base {
+  associatedtype T : Derived1 // expected-warning {{redeclaration of associated type 'T' from protocol 'Base' is better expressed as a 'where' clause on the protocol}}
+}
+
+// Base     -> Base     -> Base     -> ...
+// Derived2 -> Derived2 -> Derived2 -> ...
+protocol Derived2 : Base where T : Derived2 {}


### PR DESCRIPTION
Atoms are now uniqued in a new `RewriteContext`. For now, there is one `RewriteContext` per requirement machine, but shortly it will become global.

Also, there is a fix to the completion procedure; we were not considering all overlaps due to a logic error concerning the processing of deleted rules.

Finally, add some statistical counters and a small test case.