### PR TITLE
[ASTWalker] Walk ForEachStmt in source order

### DIFF
--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1563,18 +1563,18 @@ Stmt *Traversal::visitForEachStmt(ForEachStmt *S) {
       return nullptr;
   }
 
-  if (Expr *Where = S->getWhere()) {
-    if ((Where = doIt(Where)))
-      S->setWhere(Where);
-    else
-      return nullptr;
-  }
-
   // The iterator decl is built directly on top of the sequence
   // expression, so don't visit both.
   if (Expr *Sequence = S->getSequence()) {
     if ((Sequence = doIt(Sequence)))
       S->setSequence(Sequence);
+    else
+      return nullptr;
+  }
+
+  if (Expr *Where = S->getWhere()) {
+    if ((Where = doIt(Where)))
+      S->setWhere(Where);
     else
       return nullptr;
   }

--- a/test/refactoring/ConvertAsync/basic.swift
+++ b/test/refactoring/ConvertAsync/basic.swift
@@ -856,3 +856,21 @@ class TestConvertFunctionWithCallToFunctionsWithSpecialName {
     return x
   }
 }
+
+// rdar://78781061
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=FOR-IN-WHERE %s
+func testForInWhereRefactoring() {
+  let arr: [String] = []
+  for str in arr where str.count != 0 {
+    simple { res in
+      print(res)
+    }
+  }
+}
+// FOR-IN-WHERE:      func testForInWhereRefactoring() async {
+// FOR-IN-WHERE-NEXT:   let arr: [String] = []
+// FOR-IN-WHERE-NEXT:   for str in arr where str.count != 0 {
+// FOR-IN-WHERE-NEXT:     let res = await simple()
+// FOR-IN-WHERE-NEXT:     print(res)
+// FOR-IN-WHERE-NEXT:   }
+// FOR-IN-WHERE-NEXT: }


### PR DESCRIPTION
Make sure to visit the sequence expr before the the where clause as the refactoring logic expects nodes to be visited in source order.

rdar://78781061
