### PR TITLE
[5.5] Visit ForEachStmt in source order in SemaAnnotator

### DIFF
--- a/test/refactoring/ConvertAsync/basic.swift
+++ b/test/refactoring/ConvertAsync/basic.swift
@@ -856,3 +856,21 @@ class TestConvertFunctionWithCallToFunctionsWithSpecialName {
     return x
   }
 }
+
+// rdar://78781061
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=FOR-IN-WHERE %s
+func testForInWhereRefactoring() {
+  let arr: [String] = []
+  for str in arr where str.count != 0 {
+    simple { res in
+      print(res)
+    }
+  }
+}
+// FOR-IN-WHERE:      func testForInWhereRefactoring() async {
+// FOR-IN-WHERE-NEXT:   let arr: [String] = []
+// FOR-IN-WHERE-NEXT:   for str in arr where str.count != 0 {
+// FOR-IN-WHERE-NEXT:     let res = await simple()
+// FOR-IN-WHERE-NEXT:     print(res)
+// FOR-IN-WHERE-NEXT:   }
+// FOR-IN-WHERE-NEXT: }


### PR DESCRIPTION
A narrower version of https://github.com/apple/swift/pull/37760 that only touches the SemaAnnotator walking logic.

rdar://78781061
