### PR TITLE
DeadObjectElimination: use InstructionDeleter to solve the instruction iterator invalidation problem

### DIFF
--- a/test/SILOptimizer/dead_alloc_elim.sil
+++ b/test/SILOptimizer/dead_alloc_elim.sil
@@ -164,7 +164,6 @@ sil @trivial_destructor_load : $@convention(thin) () -> () {
 //
 // CHECK-LABEL: sil @trivial_destructor_store_into : $@convention(thin) () -> () {
 // CHECK: bb0
-// CHECK-NEXT: integer_literal
 // CHECK-NEXT: tuple
 // CHECK-NEXT: return
 sil @trivial_destructor_store_into : $@convention(thin) () -> () {


### PR DESCRIPTION
This simplifies the instruction iteration in `processFunction()`.

This change looks larger than it actually is, because I had to move a large function within the file.
