### PR TITLE
Re-enable async debuginfo tests on arm64e.

### DIFF
--- a/test/DebugInfo/async-let-await.swift
+++ b/test/DebugInfo/async-let-await.swift
@@ -2,7 +2,6 @@
 // RUN:    -module-name M -enable-experimental-concurrency \
 // RUN:    -parse-as-library | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: concurrency
-// UNSUPPORTED: CPU=arm64e
 
 public func getVegetables() async -> [String] {
   return ["leek", "carrot"]  

--- a/test/DebugInfo/async-lifetime-extension.swift
+++ b/test/DebugInfo/async-lifetime-extension.swift
@@ -3,8 +3,6 @@
 // RUN:    | %FileCheck %s --check-prefix=CHECK
 // REQUIRES: concurrency
 
-// UNSUPPORTED: CPU=arm64e
-
 // Test that lifetime extension preserves a dbg.declare for "n" in the resume
 // funclet.
 

--- a/test/DebugInfo/async-local-var.swift
+++ b/test/DebugInfo/async-local-var.swift
@@ -3,8 +3,6 @@
 // RUN:    | %FileCheck %s --check-prefix=CHECK
 // REQUIRES: concurrency
 
-// UNSUPPORTED: CPU=arm64e
-
 func getString() async -> String {
   return ""
 }


### PR DESCRIPTION
The underlying LLVM issue has since been addressed.

rdar://75766760