### PR TITLE
[5.5][ConstraintSystem] Simplify relational constraints with the same depe…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5185,6 +5185,12 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       llvm_unreachable("type variables should have already been handled by now");
 
     case TypeKind::DependentMember: {
+      // If types are identical, let's consider this constraint solved
+      // even though they are dependent members, they would be resolved
+      // to the same concrete type.
+      if (desugar1->isEqual(desugar2))
+        return getTypeMatchSuccess();
+
       // If one of the dependent member types has no type variables,
       // this comparison is effectively illformed, because dependent
       // member couldn't be simplified down to the actual type, and

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -858,3 +858,19 @@ func rdar56212087() {
 
   setValue(foo("", ""), forKey: "") // Ok (T is inferred as a `String` instead of `Any?`)
 }
+
+// rdar://78623338 - crash due to leftover inactive constraints
+func rdar78623338() {
+  func any<T : Sequence>(_ sequence: T) -> AnySequence<T.Element> {
+    // expected-note@-1 {{required by local function 'any' where 'T' = '() -> ReversedCollection<(ClosedRange<Int>)>'}}
+    AnySequence(sequence.makeIterator)
+  }
+
+  let _ = [
+    any(0...3),
+    // TODO: It should be possible to suggest making a call to `reserved` here but we don't have machinery to do so
+    //       at the moment because there is no way to go from a requirement to the underlying argument/parameter location.
+    any((1...3).reversed) // expected-error {{type '() -> ReversedCollection<(ClosedRange<Int>)>' cannot conform to 'Sequence'}}
+    // expected-note@-1 {{only concrete types such as structs, enums and classes can conform to protocols}}
+  ]
+}


### PR DESCRIPTION
…ndent member type on both sides

Cherry-pick of https://github.com/apple/swift/pull/37699

---

- Explanation:

If relational constraint has the same dependent member type on both
sides e.g. `$T1.Element == $T1.Element` allow its simplification,
since inference of `$T1` results in dependent member being resolved
to the same concrete type. Otherwise constraint system would be left
with this constraint in inactive state if `$T1` couldn't be resolved
which results in a crash.

- Scope: Invalid expressions with same-type requirements on dependent members e.g.
               passing a member reference instead of forming a call to a parameter that has
               conformance requirements.

- Main Branch PR: https://github.com/apple/swift/pull/37699

- Resolves: rdar://78623338

- Risk: Low

- Reviewed By: @hborla  

- Testing: Regression tests added to the suite

Resolves: rdar://78623338
(cherry picked from commit 1c3d685fd8b7cb2bf49437e7a8583e9e677b06d4)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
