### PR TITLE
When running with the interpreter on Darwin, force the usage of the just built, stdlib when running the frontend.

### DIFF
--- a/test/Interpreter/process_arguments.swift
+++ b/test/Interpreter/process_arguments.swift
@@ -1,7 +1,7 @@
-// RUN: %swift -interpret %s | %FileCheck %s -check-prefix=CHECK-NONE
-// RUN: %swift -interpret %s -Onone -g | %FileCheck %s -check-prefix=CHECK-NONE
-// RUN: %swift -interpret %s -Onone -g -- | %FileCheck %s -check-prefix=CHECK-NONE
-// RUN: %swift -interpret %s -Onone -g -- a b c | %FileCheck %s -check-prefix=CHECK-THREE
+// RUN: %target-jit-run -interpret %s | %FileCheck %s -check-prefix=CHECK-NONE
+// RUN: %target-jit-run -interpret %s -Onone -g | %FileCheck %s -check-prefix=CHECK-NONE
+// RUN: %target-jit-run -interpret %s -Onone -g -- | %FileCheck %s -check-prefix=CHECK-NONE
+// RUN: %target-jit-run -interpret %s -Onone -g -- a b c | %FileCheck %s -check-prefix=CHECK-THREE
 
 // REQUIRES: swift_interpreter
 

--- a/test/Interpreter/protocol_lookup_jit.swift
+++ b/test/Interpreter/protocol_lookup_jit.swift
@@ -1,5 +1,5 @@
 // Test protocol_lookup.swift in JIT mode.
-// RUN: %swift -interpret %S/protocol_lookup.swift | %FileCheck %S/protocol_lookup.swift
+// RUN: %target-jit-run %S/protocol_lookup.swift | %FileCheck %S/protocol_lookup.swift
 // REQUIRES: executable_test
 
 // REQUIRES: swift_interpreter

--- a/test/Serialization/operator.swift
+++ b/test/Serialization/operator.swift
@@ -2,8 +2,9 @@
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_operator.swift
 // RUN: llvm-bcanalyzer %t/def_operator.swiftmodule | %FileCheck %s
 // RUN: %target-swift-frontend -typecheck -I%t %s
-// RUN: %target-swift-frontend -interpret -I %t -DINTERP %s | %FileCheck --check-prefix=OUTPUT %s
-
+//
+// Run with the interpreter using the proper filecheck pattern.
+// RUN: %target-jit-run -I %t -DINTERP %s | %FileCheck --check-prefix=OUTPUT %s
 // REQUIRES: swift_interpreter
 
 // FIXME: iOS doesn't work because this test needs the interpreter to handle 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -207,7 +207,7 @@ if lit_config.params.get('disable_unittests', None) is not None:
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
 
-# test_exec_root: The root path where tests should be run.
+# swift_obj_root: The path to the swift build root.
 swift_obj_root = getattr(config, 'swift_obj_root', None)
 
 # cmake. The path to the cmake executable we used to configure swift.
@@ -1799,12 +1799,6 @@ if sftp_server_path:
 config.substitutions.append(('%sftp-server',
                              sftp_server_path or 'no-sftp-server'))
 
-subst_target_jit_run = ""
-if 'swift_interpreter' in config.available_features:
-    subst_target_jit_run = (
-        "%s -interpret %s" %
-        (config.target_swift_frontend, sdk_overlay_link_path))
-
 subst_target_repl_run_simple_swift = ""
 if 'swift_repl' in config.available_features:
     subst_target_repl_run_simple_swift = (
@@ -1890,6 +1884,17 @@ if not kIsWindows:
 			"LD_LIBRARY_PATH='{0}:{1}' " # Linux option
 			"SIMCTL_CHILD_DYLD_LIBRARY_PATH='{0}' " # Simulator option
 			.format(all_stdlib_path, libdispatch_path)) + config.target_run
+
+subst_target_jit_prefix = ""
+if platform.system() == 'Darwin' and config.target_run:
+   subst_target_jit_prefix = config.target_run
+
+subst_target_jit_run = ""
+if 'swift_interpreter' in config.available_features:
+    subst_target_jit_run = (
+        "%s %s -interpret %s" %
+        (subst_target_jit_prefix,
+         config.target_swift_frontend, sdk_overlay_link_path))
 
 if not getattr(config, 'target_run_simple_swift', None):
     config.target_run_simple_swift_parameterized = SubstituteCaptures(
@@ -2080,10 +2085,14 @@ config.substitutions.append(('%target-swift-reflection-test', config.target_swif
 
 config.substitutions.append(('%target-swift-reflection-dump', '{} {} {}'.format(config.swift_reflection_dump, '-arch', run_cpu)))
 config.substitutions.append(('%target-swiftc_driver', config.target_swiftc_driver))
+
 config.substitutions.append(('%target-swift-remoteast-test-with-sdk',
-                             '%s -sdk %r' %
-                               (config.swift_remoteast_test, config.variant_sdk)))
-config.substitutions.append(('%target-swift-remoteast-test', config.swift_remoteast_test))
+                             '%s %s -sdk %r' %
+                             (subst_target_jit_prefix,
+                              config.swift_remoteast_test, config.variant_sdk)))
+config.substitutions.append(('%target-swift-remoteast-test',
+                             '%s %s' % (subst_target_jit_prefix,
+                                        config.swift_remoteast_test)))
 
 if hasattr(config, 'target_swift_autolink_extract'):
     config.available_features.add('autolink-extract')


### PR DESCRIPTION
This is because we currently JIT in process resulting in weirdness around
swift-frontend wanting to link against the host stdlib and the exec swift code
wanting to link against the target stdlib. For now, we work around this by just
saying in that case we will force swift-frontend to use the just built runtime
so we are consistent. The only potential problem is that a bug in the just built
runtime may now cause these tests to fail. But overall, that would suggest a
problem we may want to catch in it of itself, so the work around I think makes
sense until JITing is done in a separate process (which I think is the right fix).

rdar://78768013
