### PR TITLE
Concurrency: silence some `-Wmicrosoft-extension` warnings (NFC)

### DIFF
--- a/stdlib/public/Concurrency/AsyncLet.cpp
+++ b/stdlib/public/Concurrency/AsyncLet.cpp
@@ -44,7 +44,7 @@ private:
   // TODO: more additional flags here, we can use them for future optimizations.
   //       e.g. "was awaited on" or "needs free"
 
-  friend class AsyncTask;
+  friend class ::swift::AsyncTask;
 
 public:
   explicit AsyncLetImpl(AsyncTask* task)

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -292,7 +292,7 @@ private:
   /// or `nullptr` if no task is currently waiting.
   std::atomic<AsyncTask *> waitQueue;
 
-  friend class AsyncTask;
+  friend class ::swift::AsyncTask;
 
 public:
   explicit TaskGroupImpl()


### PR DESCRIPTION
Explicitly namespace the friend type to avoid the warning.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
