### PR TITLE
[AutoDiff] [SR-14625] Fix for subset parameters thunk over-consume

### DIFF
--- a/test/AutoDiff/compiler_crashers_fixed/sr14625-over-consume-in-subset-parameters-thunk.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr14625-over-consume-in-subset-parameters-thunk.swift
@@ -1,0 +1,31 @@
+// RUN: %target-build-swift %s
+
+// SR-14625: An over-consume in a subset parameters thunk detected after
+// enabling OSSA.
+
+import _Differentiation
+
+struct Type2: Differentiable {
+  var test1: Double
+
+  @differentiable(reverse)
+  public init(test1: Double) {
+    self.test1 = test1
+  }
+}
+
+struct Type1: Differentiable {
+  var test1: Double
+  var test3: [Type2]
+
+  @differentiable(reverse)
+  public init(test1: Double, test3: [Type2]) {
+    self.test1 = test1
+    self.test3 = test3
+  }
+}
+
+@differentiable(reverse)
+func ingestValue(val1: Double, val2: Double) -> Type1 {
+  return Type1(test1: val1 * val2, test3: [])
+}


### PR DESCRIPTION
Ownership SSA was enabled for the remaining Differentiation-generated thunks in PR #37054. This exposed an over-consume in certain cases of subset parameters thunks, leading to compilation assertion failures across a large Swift-autodiff-based physics simulation codebase.

This patch attempts to detect and correct for those over-consumes, while preventing leaks in other cases, and includes a simple test case that had triggered the over-consume on compilation.

Resolves [SR-14625](https://bugs.swift.org/browse/SR-14625).