### PR TITLE
[5.5-05142021] Fix ClassDecl::isRootDefaultActor to use the maximal resilience expansion

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8093,7 +8093,7 @@ bool ClassDecl::hasExplicitCustomActorMethods() const {
 }
 
 bool ClassDecl::isRootDefaultActor() const {
-  return isRootDefaultActor(getModuleContext(), ResilienceExpansion::Minimal);
+  return isRootDefaultActor(getModuleContext(), ResilienceExpansion::Maximal);
 }
 
 bool ClassDecl::isRootDefaultActor(ModuleDecl *M,

--- a/test/IRGen/actor_class.swift
+++ b/test/IRGen/actor_class.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-ir %s -swift-version 5 -enable-experimental-concurrency | %IRGenFileCheck %s
+// RUN: %target-swift-frontend -enable-library-evolution -emit-ir %s -swift-version 5 -enable-experimental-concurrency | %IRGenFileCheck %s
 // REQUIRES: concurrency
 
 


### PR DESCRIPTION


Otherwise, we fail to emit default actor layout fields and intialization
and deintialization routine calls.

Meaning that actors in resilient libraries are broken.

rdar://78622313