### PR TITLE
[5.5][ConstraintSystem] Don't record a mismatch for synthesized arguments

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4460,6 +4460,10 @@ bool ConstraintSystem::repairFailures(
     // a conversion to another function type, see `matchFunctionTypes`.
     if (parentLoc->isForContextualType() ||
         parentLoc->isLastElement<LocatorPathElt::ApplyArgToParam>()) {
+      // If either type has a placeholder, consider this fixed.
+      if (lhs->hasPlaceholder() || rhs->hasPlaceholder())
+        return true;
+
       // If there is a fix associated with contextual conversion or
       // a function type itself, let's ignore argument failure but
       // increase a score.

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -874,3 +874,22 @@ func rdar78623338() {
     // expected-note@-1 {{only concrete types such as structs, enums and classes can conform to protocols}}
   ]
 }
+
+// rdar://78781552 - crash in `getFunctionArgApplyInfo`
+func rdar78781552() {
+  struct Test<Data, Content> where Data : RandomAccessCollection {
+    // expected-note@-1 {{where 'Data' = '(((Int) throws -> Bool) throws -> [Int])?'}}
+    // expected-note@-2 {{'init(data:filter:)' declared here}}
+    // expected-note@-3 {{'Content' declared as parameter to type 'Test'}}
+    var data: [Data]
+    var filter: (Data.Element) -> Content
+  }
+
+  func test(data: [Int]?) {
+    Test(data?.filter)
+    // expected-error@-1 {{generic struct 'Test' requires that '(((Int) throws -> Bool) throws -> [Int])?' conform to 'RandomAccessCollection'}}
+    // expected-error@-2 {{generic parameter 'Content' could not be inferred}} expected-note@-2 {{explicitly specify the generic arguments to fix this issue}}
+    // expected-error@-3 {{cannot convert value of type '(((Int) throws -> Bool) throws -> [Int])?' to expected argument type '[(((Int) throws -> Bool) throws -> [Int])?]'}}
+    // expected-error@-4 {{missing argument for parameter 'filter' in call}}
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/37778

---

- Explanation:

Fixes a crash in type-checker when solver attempts to fix structural problems in synthesized arguments.

Without context synthesized argument would be inferred as a hole,
so let's not record any additional fixes for it if there is no way
to infer it properly from a parameter (which could also be a hole
if it is a generic parameter type).

- Scope: Invalid expressions with synthesized arguments (inferred as holes) that also have structural issues due
               to generic parameters (part of parameter type) being inferred based from other arguments.

- Main Branch PR: https://github.com/apple/swift/pull/37778

- Resolves: rdar://78781552

- Risk: Low

- Reviewed By: @hborla  

- Testing: Regression tests added to the suite

Resolves: rdar://78781552
(cherry picked from commit 9e54006cc60e8e44c7d7f61e3a2f91a7a5a8097d)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
