### PR TITLE
Disable `module_deps_cache_reuse.swift ` test to unblock CI.

### DIFF
--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -13,6 +13,9 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
+// This test fails in recent Swift CI runs
+// REQUIRES: radar78882565
+
 import C
 import E
 import G


### PR DESCRIPTION
This test is failing in recent Swift CI runs:
https://ci.swift.org/job/swift-PR-macos-smoke-test/29578/console