### PR TITLE
[cmake] Disable swift-cmake tests on non-Darwin platforms.

### DIFF
--- a/validation-test/BuildSystem/CMakeLists.txt
+++ b/validation-test/BuildSystem/CMakeLists.txt
@@ -1,5 +1,7 @@
 
-# Only test this if we found a Swift compiler.
-if (CMAKE_Swift_COMPILER)
+# Only test this if we found a Swift compiler. Currently only enable this test
+# if we build on Darwin since we do not have a host toolchain available when
+# compiling on the bots for Linux meaning this path would not be tested.
+if (CMAKE_Swift_COMPILER AND APPLE)
   add_subdirectory(swift-cmake)
 endif()


### PR DESCRIPTION
The reason why I am doing this is that we do not yet have on all of the
non-Darwin bots swift host toolchain files. So we can't test this code path on
those platforms and thus can not guarantee correctness. The result is that on
those other platforms if someone /does/ have a host toolchain with a swift
binary in it, failures may result breaking other people's builds.