### PR TITLE
Revert "Disable `module_deps_cache_reuse.swift ` test to unblock CI."

### DIFF
--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -13,9 +13,6 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
-// This test fails in recent Swift CI runs
-// REQUIRES: radar78882565
-
 import C
 import E
 import G


### PR DESCRIPTION
Reverts apple/swift#37792

Re-enables the test. 