### PR TITLE
Revert "Disable module_deps_cache_reuse.swift test to unblock CI." and fix the test.

### DIFF
--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -111,7 +111,7 @@ import SubE
 // CHECK-NEXT: "-frontend"
 // CHECK-NEXT: "-only-use-extra-clang-opts"
 // CHECK-NEXT: "-Xcc"
-// CHECK-NEXT: "clang"
+// CHECK-NEXT: "BUILD_DIR/bin/clang"
 // CHECK:      "-fsystem-module",
 // CHECK-NEXT: "-emit-pcm",
 // CHECK-NEXT: "-module-name",

--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -13,9 +13,6 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
-// This test fails in recent Swift CI runs
-// REQUIRES: radar78882565
-
 import C
 import E
 import G


### PR DESCRIPTION
Reverts https://github.com/apple/swift/pull/37792 and fixes the test.

Resolves rdar://78882565