### PR TITLE
Concurrency: add Windows support to `SWIFT_TASK_PRINTF_DEBUG`

### DIFF
--- a/stdlib/public/Concurrency/AsyncLet.cpp
+++ b/stdlib/public/Concurrency/AsyncLet.cpp
@@ -163,7 +163,8 @@ static void swift_asyncLet_endImpl(AsyncLet *alet) {
   assert(parent && "async-let must have a parent task");
 
 #if SWIFT_TASK_PRINTF_DEBUG
-  fprintf(stderr, "[%p] async let end of task %p, parent: %p\n", pthread_self(), task, parent);
+  fprintf(stderr, "[%lu] async let end of task %p, parent: %p\n",
+          _swift_get_thread_id(), task, parent);
 #endif
   _swift_task_dealloc_specific(parent, task);
 }

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -27,10 +27,34 @@
 #define SWIFT_FATAL_ERROR swift_Concurrency_fatalError
 #include "../runtime/StackAllocator.h"
 
+#if HAVE_PTHREAD_H
+#include <pthread.h>
+#endif
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#define VC_EXTRA_LEAN
+#define NOMINMAX
+#include <Windows.h>
+#endif
+
 namespace swift {
 
 // Uncomment to enable helpful debug spew to stderr
 //#define SWIFT_TASK_PRINTF_DEBUG 1
+
+#if defined(_WIN32)
+using ThreadID = decltype(GetCurrentThreadId());
+#else
+using ThreadID = decltype(pthread_self());
+#endif
+
+inline ThreadID _swift_get_thread_id() {
+#if defined(_WIN32)
+  return GetCurrentThreadId();
+#else
+  return pthread_self();
+#endif
+}
 
 class AsyncTask;
 class TaskGroup;


### PR DESCRIPTION
`pthread_self` is not portable to all platforms.  Introduce a
`_swift_get_current_thread_id` to abstract over accessing the current
thread ID.  On Windows, the thread ID and thread handle are two separate
entities, unlike POSIX threads which treats them the same.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
