### PR TITLE
mark some switches as covered (NFCI)

### DIFF
--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -377,6 +377,7 @@ public:
     case SILArgumentConvention::Indirect_Out:
       llvm_unreachable("partial_apply cannot have an @out operand");
     }
+    llvm_unreachable("covered switch");
   }
 
   /// Return true if 'self' is an applied argument.
@@ -454,7 +455,9 @@ public:
     case ApplySiteKind::PartialApplyInst:
       return ApplyOptions();
     }
+    llvm_unreachable("covered switch");
   }
+
   /// Return whether the given apply is of a formally-throwing function
   /// which is statically known not to throw.
   bool isNonThrowing() const {

--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -290,6 +290,7 @@ struct DebugVarCarryingInst {
     case Kind::AllocBox:
       return cast<AllocBoxInst>(inst)->getDecl();
     }
+    llvm_unreachable("covered switch");
   }
 
   Optional<SILDebugVariable> getVarInfo() const {
@@ -305,6 +306,7 @@ struct DebugVarCarryingInst {
     case Kind::AllocBox:
       return cast<AllocBoxInst>(inst)->getVarInfo();
     }
+    llvm_unreachable("covered switch");
   }
 };
 

--- a/include/swift/SIL/DynamicCasts.h
+++ b/include/swift/SIL/DynamicCasts.h
@@ -168,6 +168,7 @@ public:
     return SILDynamicCastInst(cast<ID>(inst));
 #include "swift/SIL/SILNodes.def"
     }
+    llvm_unreachable("covered switch");
   }
 
   SILDynamicCastKind getKind() const {
@@ -359,6 +360,7 @@ public:
     case SILDynamicCastKind::UnconditionalCheckedCastValueInst:
       return cast<UnconditionalCheckedCastValueInst>(inst)->getSourceLoweredType();
     }
+    llvm_unreachable("covered switch");
   }
 
   CanType getTargetFormalType() const {

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -464,6 +464,7 @@ public:
     case AccessedStorage::Tail:
       return getObject();
     }
+    llvm_unreachable("covered switch");
   }
 
   /// Visit all access roots. If any roots are visited then the original memory

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -752,6 +752,7 @@ struct InteriorPointerOperand {
       return InteriorPointerOperand(op, kind);
     }
     }
+    llvm_unreachable("covered switch");
   }
 
   /// Return the end scope of all borrow introducers of the parent value of this
@@ -1035,6 +1036,7 @@ struct OwnedValueIntroducer {
     case OwnedValueIntroducerKind::AllocRefInit:
       return false;
     }
+    llvm_unreachable("covered switch");
   }
 
   bool operator==(const OwnedValueIntroducer &other) const {

--- a/include/swift/SIL/SILLocation.h
+++ b/include/swift/SIL/SILLocation.h
@@ -207,6 +207,7 @@ private:
     case FilenameAndLocationKind:
       llvm_unreachable("location type has no AST node");
     }
+    llvm_unreachable("covered switch");
   }
 
   /// Returns true if the location has a separate AST node for debugging.
@@ -300,6 +301,7 @@ public:
     case FilenameAndLocationKind: return storage.filePositionLoc == nullptr;;
     case SourceLocKind:           return storage.sourceLoc.isInvalid();
     }
+    llvm_unreachable("covered switch");
   }
   explicit operator bool() const { return !isNull(); }
 
@@ -313,6 +315,7 @@ public:
     case FilenameAndLocationKind:
       return false;
     }
+    llvm_unreachable("covered switch");
   }
 
   /// Returns true if this location came from a SIL file.

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -875,6 +875,7 @@ inline OwnershipConstraint OperandOwnership::getOwnershipConstraint() {
   case OperandOwnership::Reborrow:
     return {OwnershipKind::Guaranteed, UseLifetimeConstraint::LifetimeEnding};
   }
+  llvm_unreachable("covered switch");
 }
 
 /// Return true if this use can accept Unowned values.
@@ -900,6 +901,7 @@ inline bool canAcceptUnownedValue(OperandOwnership operandOwnership) {
   case OperandOwnership::Reborrow:
     return false;
   }
+  llvm_unreachable("covered switch");
 }
 
 /// Return the OperandOwnership for a forwarded operand when the forwarding

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -391,6 +391,7 @@ llvm::StringRef swift::getFeatureName(Feature feature) {
   case Feature::FeatureName: return #FeatureName;
 #include "swift/Basic/Features.def"
   }
+  llvm_unreachable("covered switch");
 }
 
 DiagnosticBehavior LangOptions::getAccessNoteFailureLimit() const {
@@ -405,4 +406,5 @@ DiagnosticBehavior LangOptions::getAccessNoteFailureLimit() const {
   case AccessNoteDiagnosticBehavior::ErrorOnFailureRemarkOnSuccess:
     return DiagnosticBehavior::Error;
   }
+  llvm_unreachable("covered switch");
 }

--- a/lib/IRGen/Callee.h
+++ b/lib/IRGen/Callee.h
@@ -228,6 +228,7 @@ namespace irgen {
           // future.
           return false;
         }
+        llvm_unreachable("covered switch");
       }
 
       friend bool operator==(Kind lhs, Kind rhs) {

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2712,7 +2712,7 @@ FunctionPointer irgen::emitVirtualMethodValue(IRGenFunction &IGF,
                                       signature);
   }
   }
-  
+  llvm_unreachable("covered switch");
 }
 
 FunctionPointer

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2950,6 +2950,7 @@ namespace {
                                  swift::irgen::ConstantReference::Direct);
       }
       }
+      llvm_unreachable("covered switch");
     }
 
     void addValueWitnessTable() {
@@ -3008,6 +3009,7 @@ namespace {
       case ClassMetadataStrategy::Fixed:
         return false;
       }
+      llvm_unreachable("covered switch");
     }
 
     void addSuperclass() {

--- a/lib/IRGen/NecessaryBindings.h
+++ b/lib/IRGen/NecessaryBindings.h
@@ -94,6 +94,7 @@ public:
     case Kind::AsyncFunction:
       return RequirementsVector[i];
     }
+    llvm_unreachable("covered switch");
   }
 
   ProtocolConformanceRef

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -661,6 +661,7 @@ AbstractionPattern::getObjCMethodAsyncCompletionHandlerType(
   case Kind::ObjCCompletionHandlerArgumentsType:
     swift_unreachable("not appropriate for this kind");
   }
+  llvm_unreachable("covered switch");
 }
 
 AbstractionPattern

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -431,6 +431,7 @@ static OperandOwnership getFunctionArgOwnership(SILArgumentConvention argConv,
   case SILArgumentConvention::Indirect_InoutAliasable:
     llvm_unreachable("Illegal convention for non-address types");
   }
+  llvm_unreachable("covered switch");
 }
 
 OperandOwnership
@@ -511,6 +512,7 @@ OperandOwnership OperandOwnershipClassifier::visitReturnInst(ReturnInst *i) {
   case OwnershipKind::Owned:
     return OperandOwnership::ForwardingConsume;
   }
+  llvm_unreachable("covered switch");
 }
 
 OperandOwnership OperandOwnershipClassifier::visitAssignInst(AssignInst *i) {

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -156,6 +156,7 @@ StringRef OwnershipKind::asString() const {
   case OwnershipKind::None:
     return "none";
   }
+  llvm_unreachable("covered switch");
 }
 
 //===----------------------------------------------------------------------===//
@@ -389,6 +390,7 @@ StringRef OperandOwnership::asString() const {
   case OperandOwnership::Reborrow:
     return "reborrow";
   }
+  llvm_unreachable("covered switch");
 }
 
 llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,

--- a/lib/SIL/Utils/OptimizationRemark.cpp
+++ b/lib/SIL/Utils/OptimizationRemark.cpp
@@ -158,6 +158,7 @@ static SourceLoc getLocForPresentation(SILLocation loc,
   case SourceLocPresentationKind::EndRange:
     return loc.getEndSourceLoc();
   }
+  llvm_unreachable("covered switch");
 }
 
 /// The user has passed us an instruction that for some reason has a source loc

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -447,6 +447,7 @@ BorrowedValue BorrowingOperand::getBorrowIntroducingUserResult() {
     return BorrowedValue(bi->getDestBB()->getArgument(op->getOperandNumber()));
   }
   }
+  llvm_unreachable("covered switch");
 }
 
 void BorrowingOperand::getImplicitUses(

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1927,6 +1927,7 @@ buildBuiltinLiteralArgs(SILGenFunction &SGF, SGFContext C,
   case MagicIdentifierLiteralExpr::DSOHandle:
     llvm_unreachable("handled elsewhere");
   }
+  llvm_unreachable("covered switch");
 }
 
 static inline PreparedArguments buildBuiltinLiteralArgs(SILGenFunction &SGF,

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -1036,6 +1036,7 @@ emitMemberInit(SILGenFunction &SGF, VarDecl *selfDecl, Pattern *pattern) {
 #include "swift/AST/PatternNodes.def"
     llvm_unreachable("Refutable pattern in stored property pattern binding");
   }
+  llvm_unreachable("covered switch");
 }
 
 static std::pair<AbstractionPattern, CanType>

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2695,6 +2695,7 @@ static AccessKind mapAccessKind(SGFAccessKind accessKind) {
   case SGFAccessKind::ReadWrite:
     return AccessKind::ReadWrite;
   }
+  llvm_unreachable("covered switch");
 }
 
 void LValue::addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -666,6 +666,7 @@ Optional<SILValue> SILGenFunction::emitExecutor(
   case ActorIsolation::GlobalActorUnsafe:
     return emitLoadGlobalActorExecutor(isolation.getGlobalActor());
   }
+  llvm_unreachable("covered switch");
 }
 
 void SILGenFunction::emitPreconditionCheckExpectedExecutor(

--- a/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
+++ b/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
@@ -283,6 +283,7 @@ static SILValue convertIntroducerToGuaranteed(OwnedValueIntroducer introducer) {
   case OwnedValueIntroducerKind::AllocRefInit:
     return SILValue();
   }
+  llvm_unreachable("covered switch");
 }
 
 void OwnershipLiveRange::convertJoinedLiveRangePhiToGuaranteed(

--- a/lib/SILOptimizer/Utils/CanonicalOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalOSSALifetime.cpp
@@ -666,6 +666,7 @@ endsAccessOverlappingPrunedBoundary(SILInstruction *inst) {
     return domInfo->properlyDominates(beginAccess->getParent(),
                                       getCurrentDef()->getParentBlock());
   }
+  llvm_unreachable("covered switch");
 }
 
 // Find all overlapping access scopes and extend pruned liveness to cover them:
@@ -1208,6 +1209,7 @@ bool CanonicalizeOSSALifetime::canonicalizeValueLifetime(SILValue def) {
     consumes.clear();
     return true;
   }
+  llvm_unreachable("covered switch");
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -616,6 +616,7 @@ SemanticFunctionLevel swift::getSemanticFunctionLevel(SILFunction *function) {
     return SemanticFunctionLevel::Transient;
 
   } // end switch
+  llvm_unreachable("covered switch");
 }
 
 /// Return true if \p apply calls into an optimizable semantic function from

--- a/lib/SILOptimizer/Utils/PrunedLiveness.cpp
+++ b/lib/SILOptimizer/Utils/PrunedLiveness.cpp
@@ -66,6 +66,7 @@ PrunedLiveBlocks::IsLive PrunedLiveBlocks::updateForUse(SILInstruction *user) {
     return getBlockLiveness(bb);
   }
   }
+  llvm_unreachable("covered switch");
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -108,6 +108,7 @@ toStableDifferentiabilityKind(swift::DifferentiabilityKind kind) {
   case swift::DifferentiabilityKind::Linear:
     return (unsigned)serialization::DifferentiabilityKind::Linear;
   }
+  llvm_unreachable("covered switch");
 }
 
 namespace {


### PR DESCRIPTION
Unfortunately, MSVC does not detect covered switches as clang.  Mark
some of the switches as covered to avoid an unnecessary warning from
MSVC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
