### PR TITLE
Revert "ClangImporter: run Clang with a proper executable path"

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -629,10 +629,6 @@ namespace swift {
   /// Options for controlling the behavior of the Clang importer.
   class ClangImporterOptions final {
   public:
-    /// The path to the Clang compiler executable.
-    /// Used to detect the default include paths.
-    std::string clangPath = "clang";
-
     /// The module cache path which the Clang importer should use.
     std::string ModuleCachePath;
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -953,7 +953,7 @@ ClangImporter::getClangArguments(ASTContext &ctx) {
   std::vector<std::string> invocationArgStrs;
   // Clang expects this to be like an actual command line. So we need to pass in
   // "clang" for argv[0]
-  invocationArgStrs.push_back(ctx.ClangImporterOpts.clangPath);
+  invocationArgStrs.push_back("clang");
   switch (ctx.ClangImporterOpts.Mode) {
   case ClangImporterOptions::Modes::Normal:
   case ClangImporterOptions::Modes::PrecompiledModule:

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -259,7 +259,6 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_swift_version);
   inputArgs.AddLastArg(arguments, options::OPT_enforce_exclusivity_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_stats_output_dir);
-  inputArgs.AddLastArg(arguments, options::OPT_tools_directory);
   inputArgs.AddLastArg(arguments, options::OPT_trace_stats_events);
   inputArgs.AddLastArg(arguments, options::OPT_profile_stats_events);
   inputArgs.AddLastArg(arguments, options::OPT_profile_stats_entities);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -66,11 +66,6 @@ void CompilerInvocation::setMainExecutablePath(StringRef Path) {
       Path, FrontendOpts.UseSharedResourceFolder, LibPath);
   setRuntimeResourcePath(LibPath.str());
 
-  llvm::SmallString<128> clangPath(Path);
-  llvm::sys::path::remove_filename(clangPath);
-  llvm::sys::path::append(clangPath, "clang");
-  ClangImporterOpts.clangPath = std::string(clangPath);
-
   llvm::SmallString<128> DiagnosticDocsPath(Path);
   llvm::sys::path::remove_filename(DiagnosticDocsPath); // Remove /swift
   llvm::sys::path::remove_filename(DiagnosticDocsPath); // Remove /bin
@@ -940,18 +935,6 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
                                    DiagnosticEngine &Diags,
                                    StringRef workingDirectory) {
   using namespace options;
-
-  if (const Arg *a = Args.getLastArg(OPT_tools_directory)) {
-    // If a custom tools directory is specified, try to find Clang there.
-    // This is useful when the Swift executable is located in a different
-    // directory than the Clang/LLVM executables, for example, when building
-    // the Swift project itself.
-    llvm::SmallString<128> clangPath(a->getValue());
-    llvm::sys::path::append(clangPath, "clang");
-    if (llvm::sys::fs::exists(clangPath)) {
-      Opts.clangPath = std::string(clangPath);
-    }
-  }
 
   if (const Arg *A = Args.getLastArg(OPT_module_cache_path)) {
     Opts.ModuleCachePath = A->getValue();

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -403,8 +403,6 @@ function(_compile_swift_files
   compute_library_subdir(library_subdir
     "${library_subdir_sdk}" "${SWIFTFILE_ARCHITECTURE}")
 
-  list(APPEND swift_flags "-tools-directory" "${SWIFT_NATIVE_CLANG_TOOLS_PATH}")
-
   # If we have a custom module cache path, use it.
   if (SWIFT_MODULE_CACHE_PATH)
     list(APPEND swift_flags "-module-cache-path" "${SWIFT_MODULE_CACHE_PATH}")

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -122,7 +122,7 @@ import SubE
 // CHECK-NEXT: "-frontend"
 // CHECK-NEXT: "-only-use-extra-clang-opts"
 // CHECK-NEXT: "-Xcc"
-// CHECK-NEXT: "BUILD_DIR/bin/clang"
+// CHECK-NEXT: "clang"
 // CHECK:      "-fsystem-module",
 // CHECK-NEXT: "-emit-pcm",
 // CHECK-NEXT: "-module-name",

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -277,11 +277,6 @@ static llvm::cl::list<std::string>
 SwiftVersion("swift-version", llvm::cl::desc("Swift version"),
              llvm::cl::cat(Category));
 
-static llvm::cl::opt<std::string>
-ToolsDirectory("tools-directory",
-               llvm::cl::desc("Path to external executables (ld, clang, binutils)"),
-               llvm::cl::cat(Category));
-
 static llvm::cl::list<std::string>
 ModuleCachePath("module-cache-path", llvm::cl::desc("Clang module cache path"),
                 llvm::cl::cat(Category));
@@ -3881,12 +3876,6 @@ int main(int argc, char *argv[]) {
       if (auto actual = swiftVersion.getValue().getEffectiveLanguageVersion())
         InitInvok.getLangOptions().EffectiveLanguageVersion = actual.getValue();
     }
-  }
-  if (!options::ToolsDirectory.empty()) {
-    SmallString<128> toolsDir(options::ToolsDirectory);
-    llvm::sys::path::append(toolsDir, "clang");
-    InitInvok.getClangImporterOptions().clangPath =
-        std::string(toolsDir);
   }
   if (!options::ModuleCachePath.empty()) {
     // Honor the *last* -module-cache-path specified.


### PR DESCRIPTION
Reverts apple/swift#36749

This is causing the standalone swift-stdlib builds to break and is blocking the Windows nightlies.