### PR TITLE
ClangImporter: run Clang with a proper executable path (pt 2)

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -642,6 +642,10 @@ namespace swift {
   /// Options for controlling the behavior of the Clang importer.
   class ClangImporterOptions final {
   public:
+    /// The path to the Clang compiler executable.
+    /// Used to detect the default include paths.
+    std::string clangPath = "clang";
+
     /// The module cache path which the Clang importer should use.
     std::string ModuleCachePath;
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -957,7 +957,7 @@ ClangImporter::getClangArguments(ASTContext &ctx) {
   std::vector<std::string> invocationArgStrs;
   // Clang expects this to be like an actual command line. So we need to pass in
   // "clang" for argv[0]
-  invocationArgStrs.push_back("clang");
+  invocationArgStrs.push_back(ctx.ClangImporterOpts.clangPath);
   switch (ctx.ClangImporterOpts.Mode) {
   case ClangImporterOptions::Modes::Normal:
   case ClangImporterOptions::Modes::PrecompiledModule:

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -263,6 +263,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_swift_version);
   inputArgs.AddLastArg(arguments, options::OPT_enforce_exclusivity_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_stats_output_dir);
+  inputArgs.AddLastArg(arguments, options::OPT_tools_directory);
   inputArgs.AddLastArg(arguments, options::OPT_trace_stats_events);
   inputArgs.AddLastArg(arguments, options::OPT_profile_stats_events);
   inputArgs.AddLastArg(arguments, options::OPT_profile_stats_entities);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -66,6 +66,11 @@ void CompilerInvocation::setMainExecutablePath(StringRef Path) {
       Path, FrontendOpts.UseSharedResourceFolder, LibPath);
   setRuntimeResourcePath(LibPath.str());
 
+  llvm::SmallString<128> clangPath(Path);
+  llvm::sys::path::remove_filename(clangPath);
+  llvm::sys::path::append(clangPath, "clang");
+  ClangImporterOpts.clangPath = std::string(clangPath);
+
   llvm::SmallString<128> DiagnosticDocsPath(Path);
   llvm::sys::path::remove_filename(DiagnosticDocsPath); // Remove /swift
   llvm::sys::path::remove_filename(DiagnosticDocsPath); // Remove /bin
@@ -951,6 +956,18 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
                                    DiagnosticEngine &Diags,
                                    StringRef workingDirectory) {
   using namespace options;
+
+  if (const Arg *a = Args.getLastArg(OPT_tools_directory)) {
+    // If a custom tools directory is specified, try to find Clang there.
+    // This is useful when the Swift executable is located in a different
+    // directory than the Clang/LLVM executables, for example, when building
+    // the Swift project itself.
+    llvm::SmallString<128> clangPath(a->getValue());
+    llvm::sys::path::append(clangPath, "clang");
+    if (llvm::sys::fs::exists(clangPath)) {
+      Opts.clangPath = std::string(clangPath);
+    }
+  }
 
   if (const Arg *A = Args.getLastArg(OPT_module_cache_path)) {
     Opts.ModuleCachePath = A->getValue();

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -403,6 +403,10 @@ function(_compile_swift_files
   compute_library_subdir(library_subdir
     "${library_subdir_sdk}" "${SWIFTFILE_ARCHITECTURE}")
 
+  if(NOT "${SWIFT_NATIVE_CLANG_TOOLS_PATH}" STREQUAL "")
+    list(APPEND swift_flags "-tools-directory" "${SWIFT_NATIVE_CLANG_TOOLS_PATH}")
+  endif()
+
   # If we have a custom module cache path, use it.
   if (SWIFT_MODULE_CACHE_PATH)
     list(APPEND swift_flags "-module-cache-path" "${SWIFT_MODULE_CACHE_PATH}")

--- a/test/Interop/Cxx/stdlib/Inputs/fake-toolchain/include/c++/v1/fake-toolchain.h
+++ b/test/Interop/Cxx/stdlib/Inputs/fake-toolchain/include/c++/v1/fake-toolchain.h
@@ -1,0 +1,10 @@
+#ifndef TEST_INTEROP_CXX_STDLIB_INPUTS_FAKE_TOOLCHAIN_H
+#define TEST_INTEROP_CXX_STDLIB_INPUTS_FAKE_TOOLCHAIN_H
+
+namespace FakeNamespace {
+
+void foo(int x) {}
+
+}; // namespace FakeNamespace
+
+#endif

--- a/test/Interop/Cxx/stdlib/Inputs/fake-toolchain/include/c++/v1/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/fake-toolchain/include/c++/v1/module.modulemap
@@ -1,0 +1,4 @@
+module FakeToolchain [system] {
+  header "fake-toolchain.h"
+  export *
+}

--- a/test/Interop/Cxx/stdlib/fake-toolchain-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/fake-toolchain-module-interface.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=FakeToolchain -tools-directory %S/Inputs/fake-toolchain/bin -source-filename=x -enable-cxx-interop -Xcc -stdlib=libc++ | %FileCheck %s
+
+// Clang driver on Windows doesn't support -stdlib=libc++
+// XFAIL: OS=windows-msvc
+
+// CHECK: extension FakeNamespace {
+// CHECK:   static func foo(_ x: Int32)
+// CHECK: }

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -122,7 +122,7 @@ import SubE
 // CHECK-NEXT: "-frontend"
 // CHECK-NEXT: "-only-use-extra-clang-opts"
 // CHECK-NEXT: "-Xcc"
-// CHECK-NEXT: "clang"
+// CHECK-NEXT: "BUILD_DIR/bin/clang"
 // CHECK:      "-fsystem-module",
 // CHECK-NEXT: "-emit-pcm",
 // CHECK-NEXT: "-module-name",

--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -111,7 +111,7 @@ import SubE
 // CHECK-NEXT: "-frontend"
 // CHECK-NEXT: "-only-use-extra-clang-opts"
 // CHECK-NEXT: "-Xcc"
-// CHECK-NEXT: "clang"
+// CHECK-NEXT: "BUILD_DIR/bin/clang"
 // CHECK-NEXT: "-Xcc"
 // CHECK-NEXT: "-fsyntax-only",
 // CHECK:      "-fsystem-module",

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -283,6 +283,11 @@ static llvm::cl::list<std::string>
 SwiftVersion("swift-version", llvm::cl::desc("Swift version"),
              llvm::cl::cat(Category));
 
+static llvm::cl::opt<std::string>
+ToolsDirectory("tools-directory",
+               llvm::cl::desc("Path to external executables (ld, clang, binutils)"),
+               llvm::cl::cat(Category));
+
 static llvm::cl::list<std::string>
 ModuleCachePath("module-cache-path", llvm::cl::desc("Clang module cache path"),
                 llvm::cl::cat(Category));
@@ -3882,6 +3887,12 @@ int main(int argc, char *argv[]) {
       if (auto actual = swiftVersion.getValue().getEffectiveLanguageVersion())
         InitInvok.getLangOptions().EffectiveLanguageVersion = actual.getValue();
     }
+  }
+  if (!options::ToolsDirectory.empty()) {
+    SmallString<128> toolsDir(options::ToolsDirectory);
+    llvm::sys::path::append(toolsDir, "clang");
+    InitInvok.getClangImporterOptions().clangPath =
+        std::string(toolsDir);
   }
   if (!options::ModuleCachePath.empty()) {
     // Honor the *last* -module-cache-path specified.


### PR DESCRIPTION
This change re-applies https://github.com/apple/swift/pull/36749 after it has been reverted in https://github.com/apple/swift/pull/37805 because of a broken standalone stdlib build.

This time let's not try to pass a `-tools-directory` argument to the Swift compiler in CMake if `SWIFT_NATIVE_CLANG_TOOLS_PATH` is not defined.