### PR TITLE
[ASTWalker] Don't visit capture list vars twice

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4180,13 +4180,11 @@ public:
 /// Instances of this structure represent elements of the capture list that can
 /// optionally occur in a capture expression.
 struct CaptureListEntry {
-  VarDecl *Var;
-  PatternBindingDecl *Init;
+  PatternBindingDecl *PBD;
 
-  CaptureListEntry(VarDecl *Var, PatternBindingDecl *Init)
-  : Var(Var), Init(Init) {
-  }
+  explicit CaptureListEntry(PatternBindingDecl *PBD);
 
+  VarDecl *getVar() const;
   bool isSimpleSelfCapture() const;
 };
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2496,8 +2496,7 @@ public:
     for (auto capture : E->getCaptureList()) {
       OS << '\n';
       Indent += 2;
-      printRec(capture.Var);
-      printRec(capture.Init);
+      printRec(capture.PBD);
       Indent -= 2;
     }
     printRec(E->getClosureBody());

--- a/lib/AST/ASTScopeLookup.cpp
+++ b/lib/AST/ASTScopeLookup.cpp
@@ -408,7 +408,7 @@ bool PatternEntryInitializerScope::lookupLocalsOrMembers(
 
 bool CaptureListScope::lookupLocalsOrMembers(DeclConsumer consumer) const {
   for (auto &e : expr->getCaptureList()) {
-    if (consumer.consume({e.Var}))
+    if (consumer.consume({e.getVar()}))
       return true;
   }
   return false;

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -802,8 +802,11 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
           else
             return nullptr;
         }
-      } else if (doIt(c.Var) || doIt(c.Init)) {
-        return nullptr;
+      } else {
+        // Note we do not walk c.Var here, as it'll be visited as a part of the
+        // PatternBindingDecl.
+        if (doIt(c.Init))
+          return nullptr;
       }
     }
 

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -796,16 +796,14 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   Expr *visitCaptureListExpr(CaptureListExpr *expr) {
     for (auto c : expr->getCaptureList()) {
       if (Walker.shouldWalkCaptureInitializerExpressions()) {
-        for (auto entryIdx : range(c.Init->getNumPatternEntries())) {
-          if (auto newInit = doIt(c.Init->getInit(entryIdx)))
-            c.Init->setInit(entryIdx, newInit);
+        for (auto entryIdx : range(c.PBD->getNumPatternEntries())) {
+          if (auto newInit = doIt(c.PBD->getInit(entryIdx)))
+            c.PBD->setInit(entryIdx, newInit);
           else
             return nullptr;
         }
       } else {
-        // Note we do not walk c.Var here, as it'll be visited as a part of the
-        // PatternBindingDecl.
-        if (doIt(c.Init))
+        if (doIt(c.PBD))
           return nullptr;
       }
     }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1229,7 +1229,18 @@ UnresolvedSpecializeExpr *UnresolvedSpecializeExpr::create(ASTContext &ctx,
                                              UnresolvedParams, RAngleLoc);
 }
 
+CaptureListEntry::CaptureListEntry(PatternBindingDecl *PBD) : PBD(PBD) {
+  assert(PBD);
+  assert(PBD->getSingleVar() &&
+         "Capture lists only support single-var patterns");
+}
+
+VarDecl *CaptureListEntry::getVar() const {
+  return PBD->getSingleVar();
+}
+
 bool CaptureListEntry::isSimpleSelfCapture() const {
+  auto *Var = getVar();
   auto &ctx = Var->getASTContext();
 
   if (Var->getName() != ctx.Id_self)
@@ -1239,10 +1250,10 @@ bool CaptureListEntry::isSimpleSelfCapture() const {
     if (attr->get() == ReferenceOwnership::Weak)
       return false;
 
-  if (Init->getPatternList().size() != 1)
+  if (PBD->getPatternList().size() != 1)
     return false;
 
-  auto *expr = Init->getInit(0);
+  auto *expr = PBD->getInit(0);
 
   if (auto *DRE = dyn_cast<DeclRefExpr>(expr)) {
     if (auto *VD = dyn_cast<VarDecl>(DRE->getDecl())) {
@@ -1265,7 +1276,7 @@ CaptureListExpr *CaptureListExpr::create(ASTContext &ctx,
   auto *expr = ::new(mem) CaptureListExpr(captureList, closureBody);
 
   for (auto capture : captureList)
-    capture.Var->setParentCaptureList(expr);
+    capture.getVar()->setParentCaptureList(expr);
 
   return expr;
 }

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -2586,18 +2586,17 @@ private:
 
         ListAligner Aligner(SM, TargetLocation, ContextLoc, L, R);
         for (auto &Entry: ParentCapture->getCaptureList()) {
-          if (auto *PBD = Entry.Init) {
-            NodesToSkip.insert(PBD);
-            SourceRange Range = PBD->getSourceRangeIncludingAttrs();
-            Aligner.updateAlignment(Range, PBD);
+          auto *PBD = Entry.PBD;
+          NodesToSkip.insert(PBD);
+          SourceRange Range = PBD->getSourceRangeIncludingAttrs();
+          Aligner.updateAlignment(Range, PBD);
 
-            if (isTargetContext(Range)) {
-              Aligner.setAlignmentIfNeeded(CtxOverride);
-              return IndentContext {
-                Range.Start,
-                !OutdentChecker::hasOutdent(SM, Range, PBD)
-              };
-            }
+          if (isTargetContext(Range)) {
+            Aligner.setAlignmentIfNeeded(CtxOverride);
+            return IndentContext {
+              Range.Start,
+              !OutdentChecker::hasOutdent(SM, Range, PBD)
+            };
           }
         }
         return Aligner.getContextAndSetAlignment(CtxOverride);

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -668,23 +668,6 @@ std::pair<bool, Expr *> ModelASTWalker::walkToExprPre(Expr *E) {
 
     pushStructureNode(SN, Closure);
 
-  } else if (auto *CLE = dyn_cast<CaptureListExpr>(E)) {
-    // The ASTWalker visits captured variables twice, from a `CaptureListEntry` they are visited
-    // from the `VarDecl` and the `PatternBindingDecl` entries.
-    // We take over visitation here to avoid walking the `PatternBindingDecl` ones.
-    for (auto c : CLE->getCaptureList()) {
-      if (auto *VD = c.Var) {
-        // We're skipping over the PatternBindingDecl so we need to handle the
-        // the VarDecl's attributes that we'd normally process visiting the PBD.
-        if (!handleAttrs(VD->getAttrs()))
-          return { false, nullptr };
-        VD->walk(*this);
-      }
-    }
-    if (auto *CE = CLE->getClosureBody())
-      CE->walk(*this);
-    return { false, walkToExprPost(E) };
-
   } else if (auto SE = dyn_cast<SequenceExpr>(E)) {
     // In SequenceExpr, explicit cast expressions (e.g. 'as', 'is') appear
     // twice. Skip pointers we've already seen.

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2651,7 +2651,7 @@ ParserStatus Parser::parseClosureSignatureIfPresent(
           /*VarLoc*/ nameLoc, pattern, /*EqualLoc*/ equalLoc, initializer,
           CurDeclContext);
 
-      auto CLE = CaptureListEntry(VD, PBD);
+      auto CLE = CaptureListEntry(PBD);
       if (CLE.isSimpleSelfCapture())
         VD->setIsSelfParamCapture();
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1569,7 +1569,7 @@ ManagedValue emitCFunctionPointer(SILGenFunction &SGF,
     DebugScope scope(SGF, CleanupLocation(captureList));
     // CaptureListExprs evaluate their bound variables.
     for (auto capture : captureList->getCaptureList())
-      SGF.visit(capture.Init);
+      SGF.visit(capture.PBD);
 
     // Emit the closure body.
     auto *closure = captureList->getClosureBody();
@@ -2417,7 +2417,7 @@ RValue RValueEmitter::visitCaptureListExpr(CaptureListExpr *E, SGFContext C) {
   DebugScope scope(SGF, CleanupLocation(E));
   // CaptureListExprs evaluate their bound variables.
   for (auto capture : E->getCaptureList())
-    SGF.visit(capture.Init);
+    SGF.visit(capture.PBD);
 
   // Then they evaluate to their body.
   return visit(E->getClosureBody(), C);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1568,10 +1568,8 @@ ManagedValue emitCFunctionPointer(SILGenFunction &SGF,
     // Ensure that weak captures are in a separate scope.
     DebugScope scope(SGF, CleanupLocation(captureList));
     // CaptureListExprs evaluate their bound variables.
-    for (auto capture : captureList->getCaptureList()) {
-      SGF.visit(capture.Var);
+    for (auto capture : captureList->getCaptureList())
       SGF.visit(capture.Init);
-    }
 
     // Emit the closure body.
     auto *closure = captureList->getClosureBody();
@@ -2418,10 +2416,8 @@ RValue RValueEmitter::visitCaptureListExpr(CaptureListExpr *E, SGFContext C) {
   // Ensure that weak captures are in a separate scope.
   DebugScope scope(SGF, CleanupLocation(E));
   // CaptureListExprs evaluate their bound variables.
-  for (auto capture : E->getCaptureList()) {
-    SGF.visit(capture.Var);
+  for (auto capture : E->getCaptureList())
     SGF.visit(capture.Init);
-  }
 
   // Then they evaluate to their body.
   return visit(E->getClosureBody(), C);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8108,7 +8108,7 @@ namespace {
       if (auto captureList = dyn_cast<CaptureListExpr>(expr)) {
         // Rewrite captures.
         for (const auto &capture : captureList->getCaptureList()) {
-          (void)rewriteTarget(SolutionApplicationTarget(capture.Init));
+          (void)rewriteTarget(SolutionApplicationTarget(capture.PBD));
         }
       }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3469,7 +3469,7 @@ namespace {
 
         auto &CS = CG.getConstraintSystem();
         for (const auto &capture : captureList->getCaptureList()) {
-          SolutionApplicationTarget target(capture.Init);
+          SolutionApplicationTarget target(capture.PBD);
           if (CS.generateConstraints(target, FreeTypeVariableBinding::Disallow))
             return {false, nullptr};
         }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1179,8 +1179,9 @@ namespace {
 
       // Track the capture contexts for variables.
       if (auto captureList = dyn_cast<CaptureListExpr>(expr)) {
+        auto *closure = captureList->getClosureBody();
         for (const auto &entry : captureList->getCaptureList()) {
-          captureContexts[entry.Var].push_back(captureList->getClosureBody());
+          captureContexts[entry.getVar()].push_back(closure);
         }
       }
 
@@ -1209,11 +1210,11 @@ namespace {
       // Remove the tracked capture contexts.
       if (auto captureList = dyn_cast<CaptureListExpr>(expr)) {
         for (const auto &entry : captureList->getCaptureList()) {
-          auto &contexts = captureContexts[entry.Var];
+          auto &contexts = captureContexts[entry.getVar()];
           assert(contexts.back() == captureList->getClosureBody());
           contexts.pop_back();
           if (contexts.empty())
-            captureContexts.erase(entry.Var);
+            captureContexts.erase(entry.getVar());
         }
       }
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1440,7 +1440,7 @@ void TypeChecker::diagnoseDuplicateBoundVars(Pattern *pattern) {
 void TypeChecker::diagnoseDuplicateCaptureVars(CaptureListExpr *expr) {
   SmallVector<VarDecl *, 2> captureListVars;
   for (auto &capture : expr->getCaptureList())
-    captureListVars.push_back(capture.Var);
+    captureListVars.push_back(capture.getVar());
 
   diagnoseDuplicateDecls(captureListVars);
 }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -101,8 +101,8 @@ namespace {
       if (auto CapE = dyn_cast<CaptureListExpr>(E)) {
         if (isa<AutoClosureExpr>(ParentDC)) {
           for (auto &Cap : CapE->getCaptureList()) {
-            Cap.Init->setDeclContext(ParentDC);
-            Cap.Var->setDeclContext(ParentDC);
+            Cap.PBD->setDeclContext(ParentDC);
+            Cap.getVar()->setDeclContext(ParentDC);
           }
         }
       }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1243,8 +1243,8 @@ namespace {
       if (auto CLE = dyn_cast<CaptureListExpr>(E)) {
         // Make sure to recontextualize any decls in the capture list as well.
         for (auto &CLE : CLE->getCaptureList()) {
-          CLE.Var->setDeclContext(NewDC);
-          CLE.Init->setDeclContext(NewDC);
+          CLE.getVar()->setDeclContext(NewDC);
+          CLE.PBD->setDeclContext(NewDC);
         }
       }
       


### PR DESCRIPTION
Previously we were walking them once when visiting the capture list, and then again as a part of the pattern binding decl. Change the logic to only visit them as a part of their pattern binding decl.

This fixes a bug that's exposed by https://github.com/apple/swift/pull/37720. Because it requires that change to reproduce, I'll be adding the test case there.