### PR TITLE
runtime: annotate `_environ` DLL storage, exclude in WinRT

### DIFF
--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -122,8 +122,18 @@ OnceToken_t swift::runtime::environment::initializeToken;
 extern "C" char **environ;
 #define ENVIRON environ
 #elif defined(_WIN32)
+// `_environ` is DLL-imported unless we are linking against the static C runtime
+// (via `/MT` or `/MTd`).
+#if defined(_DLL)
+extern "C" __declspec(dllimport) char **_environ;
+#else
 extern "C" char **_environ;
+#endif
+// `_environ` is unavailable in the Windows Runtime environment.
+// https://docs.microsoft.com/en-us/cpp/c-runtime-library/environ-wenviron?view=msvc-160
+#if !defined(_WINRT_DLL)
 #define ENVIRON _environ
+#endif
 #endif
 
 #ifdef ENVIRON


### PR DESCRIPTION
`_environ` is meant to be DLL imported when linking against the C
runtime dynamically (`/MD` or `/MDd`).  However, when building for
the Windows Runtime environment, we cannot support the use of `_environ`
and thus disable the support for that.  `_WINRT_DLL` identifies the
combination of `/ZW` and `/LD` or `/LDd`.  Windows Runtime builds cannot
be executables (and obviously not static libraries as they are not
executable), and thus we properly disable `ENVIRON` in all Windows
Runtime builds.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
