### PR TITLE
AST: Use availability to disambiguate multiple overlapping conformances

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -618,6 +618,10 @@ public:
   /// is also included.
   unsigned getSemanticDepth() const;
 
+  /// Returns if this extension is always available on the current deployment
+  /// target. Used for conformance lookup disambiguation.
+  bool isAlwaysAvailableConformanceContext() const;
+
   /// \returns true if traversal was aborted, false otherwise.
   bool walkContext(ASTWalker &Walker);
 

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -529,6 +529,18 @@ ConformanceLookupTable::Ordering ConformanceLookupTable::compareConformances(
                                    ConformanceEntry *lhs,
                                    ConformanceEntry *rhs,
                                    bool &diagnoseSuperseded) {
+  // If only one of the conformances is unconditionally available on the
+  // current deployment target, pick that one.
+  //
+  // FIXME: Conformance lookup should really depend on source location for
+  // this to be 100% correct.
+  if (lhs->getDeclContext()->isAlwaysAvailableConformanceContext() !=
+      rhs->getDeclContext()->isAlwaysAvailableConformanceContext()) {
+    return (lhs->getDeclContext()->isAlwaysAvailableConformanceContext()
+            ? Ordering::Before
+            : Ordering::After);
+  }
+
   // If one entry is fixed and the other is not, we have our answer.
   if (lhs->isFixed() != rhs->isFixed()) {
     // If the non-fixed conformance is not replaceable, we have a failure to

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1305,3 +1305,22 @@ static bool isSpecializeExtensionContext(const DeclContext *dc) {
 bool DeclContext::isInSpecializeExtensionContext() const {
    return isSpecializeExtensionContext(this);
 }
+
+bool DeclContext::isAlwaysAvailableConformanceContext() const {
+  auto *ext = dyn_cast<ExtensionDecl>(this);
+  if (ext == nullptr)
+    return true;
+
+  if (AvailableAttr::isUnavailable(ext))
+    return false;
+
+  auto &ctx = getASTContext();
+
+  AvailabilityContext conformanceAvailability{
+      AvailabilityInference::availableRange(ext, ctx)};
+
+  auto deploymentTarget =
+      AvailabilityContext::forDeploymentTarget(ctx);
+
+  return deploymentTarget.isContainedIn(conformanceAvailability);
+}

--- a/test/Sema/Inputs/conformance_availability_overlapping_other.swift
+++ b/test/Sema/Inputs/conformance_availability_overlapping_other.swift
@@ -1,0 +1,15 @@
+public protocol P {}
+
+public struct HasUnavailableConformance {}
+
+@available(*, unavailable)
+extension HasUnavailableConformance : P {}
+
+public struct HasConditionallyAvailableConformance {}
+
+@available(macOS 100, *)
+extension HasConditionallyAvailableConformance : P {}
+
+public struct HasAlwaysAvailableConformance {}
+
+extension HasAlwaysAvailableConformance : P {}

--- a/test/Sema/conformance_availability_overlapping.swift
+++ b/test/Sema/conformance_availability_overlapping.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %S/Inputs/conformance_availability_overlapping_other.swift -emit-module-path %t/conformance_availability_overlapping_other.swiftmodule
+// RUN: %target-typecheck-verify-swift -I %t
+
+// REQUIRES: OS=macosx
+
+import conformance_availability_overlapping_other
+
+extension HasUnavailableConformance : P {}
+
+extension HasConditionallyAvailableConformance : P {}
+
+extension HasAlwaysAvailableConformance : P {}
+// expected-warning@-1 {{conformance of 'HasAlwaysAvailableConformance' to protocol 'P' was already stated in the type's module 'conformance_availability_overlapping_other'}}
+
+struct G<T : P> {}
+
+// None of these should produce a warning about an unavailable conformance.
+func usesConformance(_: G<HasUnavailableConformance>) {}
+func usesConformance(_: G<HasConditionallyAvailableConformance>) {}
+func usesConformance(_: G<HasAlwaysAvailableConformance>) {}


### PR DESCRIPTION
If a conformance is found in an imported module as well as the current module,
and one of the two conformances is conditionally unavailable on the current
deployment target, pick the one that is always available.

Fixes <rdar://problem/78633800>.