### PR TITLE
[5.5] [SymbolGraph] add sourceOrigin info for all protocol implementations

### DIFF
--- a/lib/SymbolGraphGen/Edge.cpp
+++ b/lib/SymbolGraphGen/Edge.cpp
@@ -79,10 +79,9 @@ void Edge::serialize(llvm::json::OStream &OS) const {
     }
     
     const ValueDecl *InheritingDecl = nullptr;
-    if (const auto *ID = Source.getDeclInheritingDocs()) {
-      if (Target.getSymbolDecl() == ID || Source.getSynthesizedBaseTypeDecl())
-        InheritingDecl = ID;
-    }
+    if (const auto *ID = Source.getDeclInheritingDocs())
+      InheritingDecl = ID;
+
 
     if (!InheritingDecl && Source.getSynthesizedBaseTypeDecl())
       InheritingDecl = Source.getSymbolDecl();

--- a/lib/SymbolGraphGen/Edge.cpp
+++ b/lib/SymbolGraphGen/Edge.cpp
@@ -36,6 +36,15 @@ const ValueDecl *getForeignProtocolRequirement(const ValueDecl *VD, const Module
     requirements.pop();
   }
 }
+
+const ValueDecl *getProtocolRequirement(const ValueDecl *VD) {
+  auto reqs = VD->getSatisfiedProtocolRequirements();
+
+  if (!reqs.empty())
+    return reqs.front();
+  else
+    return nullptr;
+}
 } // end anonymous namespace
 
 void Edge::serialize(llvm::json::OStream &OS) const {
@@ -82,7 +91,6 @@ void Edge::serialize(llvm::json::OStream &OS) const {
     if (const auto *ID = Source.getDeclInheritingDocs())
       InheritingDecl = ID;
 
-
     if (!InheritingDecl && Source.getSynthesizedBaseTypeDecl())
       InheritingDecl = Source.getSymbolDecl();
 
@@ -90,7 +98,12 @@ void Edge::serialize(llvm::json::OStream &OS) const {
       if (const auto *ID = getForeignProtocolRequirement(Source.getSymbolDecl(), &Graph->M))
         InheritingDecl = ID;
     }
-    
+
+    if (!InheritingDecl) {
+      if (const auto *ID = getProtocolRequirement(Source.getSymbolDecl()))
+        InheritingDecl = ID;
+    }
+
     // If our source symbol is a inheriting decl, write in information about
     // where it's inheriting docs from.
     if (InheritingDecl) {

--- a/test/SymbolGraph/Relationships/Synthesized/InheritedDocs.swift
+++ b/test/SymbolGraph/Relationships/Synthesized/InheritedDocs.swift
@@ -7,6 +7,7 @@
 // RUN: %FileCheck %s --input-file %t/InheritedDocs.symbols.json --check-prefixes BONUS
 // RUN: %FileCheck %s --input-file %t/InheritedDocs.symbols.json --check-prefixes BONUS-DOCS
 // RUN: %FileCheck %s --input-file %t/InheritedDocs.symbols.json --check-prefixes EXTRA
+// RUN: %FileCheck %s --input-file %t/InheritedDocs.symbols.json --check-prefixes LOCAL
 
 // RUN: %target-swift-symbolgraph-extract -module-name InheritedDocs -I %t -pretty-print -output-dir %t -skip-inherited-docs
 // RUN: %FileCheck %s --input-file %t/InheritedDocs.symbols.json --check-prefixes CHECK,SKIP
@@ -14,6 +15,7 @@
 // RUN: %FileCheck %s --input-file %t/InheritedDocs.symbols.json --check-prefixes BONUS
 // RUN: %FileCheck %s --input-file %t/InheritedDocs.symbols.json --check-prefixes BONUS-SKIP
 // RUN: %FileCheck %s --input-file %t/InheritedDocs.symbols.json --check-prefixes EXTRA
+// RUN: %FileCheck %s --input-file %t/InheritedDocs.symbols.json --check-prefixes LOCAL
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name InheritedDocs -emit-module -emit-module-path %t/InheritedDocs.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/ -skip-inherited-docs
@@ -56,10 +58,21 @@
 // EXTRA-NEXT:        "identifier": "s:13InheritedDocs1PPAAE9extraFuncyyF"
 // EXTRA-NEXT:        "displayName": "P.extraFunc()"
 
+// local implementations of a local protocol still need to a relation to that protocol
+
+// LOCAL:      "source": "s:13InheritedDocs1SV9localFuncyyF"
+// LOCAL-NEXT:      "target": "s:13InheritedDocs1SV"
+// LOCAL-NEXT:      "sourceOrigin"
+// LOCAL-NEXT:        "identifier": "s:13InheritedDocs1PP9localFuncyyF"
+// LOCAL-NEXT:        "displayName": "P.localFunc()"
+
 /// Protocol P
 public protocol P {
     /// Some Function
     func someFunc()
+
+    /// It's a local function!
+    func localFunc()
 }
 
 public extension P {
@@ -72,4 +85,5 @@ public extension P {
 }
 
 public struct S: P {
+    public func localFunc() {}
 }

--- a/test/SymbolGraph/Relationships/Synthesized/InheritedDocs.swift
+++ b/test/SymbolGraph/Relationships/Synthesized/InheritedDocs.swift
@@ -8,6 +8,7 @@
 // RUN: %FileCheck %s --input-file %t/InheritedDocs.symbols.json --check-prefixes BONUS-DOCS
 // RUN: %FileCheck %s --input-file %t/InheritedDocs.symbols.json --check-prefixes EXTRA
 // RUN: %FileCheck %s --input-file %t/InheritedDocs.symbols.json --check-prefixes LOCAL
+// RUN: %FileCheck %s --input-file %t/InheritedDocs.symbols.json --check-prefixes SUPER
 
 // RUN: %target-swift-symbolgraph-extract -module-name InheritedDocs -I %t -pretty-print -output-dir %t -skip-inherited-docs
 // RUN: %FileCheck %s --input-file %t/InheritedDocs.symbols.json --check-prefixes CHECK,SKIP
@@ -16,6 +17,7 @@
 // RUN: %FileCheck %s --input-file %t/InheritedDocs.symbols.json --check-prefixes BONUS-SKIP
 // RUN: %FileCheck %s --input-file %t/InheritedDocs.symbols.json --check-prefixes EXTRA
 // RUN: %FileCheck %s --input-file %t/InheritedDocs.symbols.json --check-prefixes LOCAL
+// RUN: %FileCheck %s --input-file %t/InheritedDocs.symbols.json --check-prefixes SUPER
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name InheritedDocs -emit-module -emit-module-path %t/InheritedDocs.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/ -skip-inherited-docs
@@ -60,11 +62,19 @@
 
 // local implementations of a local protocol still need to a relation to that protocol
 
-// LOCAL:      "source": "s:13InheritedDocs1SV9localFuncyyF"
+// LOCAL:           "source": "s:13InheritedDocs1SV9localFuncyyF"
 // LOCAL-NEXT:      "target": "s:13InheritedDocs1SV"
 // LOCAL-NEXT:      "sourceOrigin"
 // LOCAL-NEXT:        "identifier": "s:13InheritedDocs1PP9localFuncyyF"
 // LOCAL-NEXT:        "displayName": "P.localFunc()"
+
+// ...both with and without docs
+
+// SUPER:           "source": "s:13InheritedDocs1SV9superFuncyyF"
+// SUPER-NEXT:      "target": "s:13InheritedDocs1SV"
+// SUPER-NEXT:      "sourceOrigin"
+// SUPER-NEXT:        "identifier": "s:13InheritedDocs1PP9superFuncyyF"
+// SUPER-NEXT:        "displayName": "P.superFunc()"
 
 /// Protocol P
 public protocol P {
@@ -73,6 +83,8 @@ public protocol P {
 
     /// It's a local function!
     func localFunc()
+
+    func superFunc()
 }
 
 public extension P {
@@ -86,4 +98,6 @@ public extension P {
 
 public struct S: P {
     public func localFunc() {}
+
+    public func superFunc() {}
 }


### PR DESCRIPTION
Resolves rdar://78680450

This PR ports https://github.com/apple/swift/pull/37777 to the `release/5.5` branch.

**Change Information**

* Explanation: Adds `sourceOrigin` information for symbols that implement protocol requirements when the protocol and the implementation are in the same module.
* Scope of issue: Currently, the `sourceOrigin` field in the symbol graph's relationships only appears when a symbol is synthesized, or when the protocol being implemented was defined in a different module. When a symbol is implementing a locally-defined protocol and also inherits docs, there is currently no way to relate the implementation to the symbol that defined the docs it's inheriting.
* Risk: Low. The added code only adds a new field in more places.
* Automated Testing: The lit test "SymbolGraph/Relationships/Synthesized/InheritedDocs" has been updated to exercise this situation.