### PR TITLE
Fix reference to in_place_t

### DIFF
--- a/include/swift/Syntax/AbsoluteRawSyntax.h
+++ b/include/swift/Syntax/AbsoluteRawSyntax.h
@@ -16,6 +16,8 @@
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Syntax/RawSyntax.h"
 
+#include "llvm/ADT/STLForwardCompat.h"
+
 namespace swift {
 namespace syntax {
 
@@ -388,8 +390,7 @@ public:
   OptionalStorage(OptionalStorage &&other) = default;
 
   template <class... ArgTypes>
-  explicit OptionalStorage(llvm::optional_detail::in_place_t,
-                           ArgTypes &&...Args)
+  explicit OptionalStorage(llvm::in_place_t, ArgTypes &&...Args)
       : Storage(std::forward<ArgTypes>(Args)...) {}
 
   void reset() { Storage = AbsoluteRawSyntax(nullptr); }

--- a/include/swift/Syntax/SyntaxData.h
+++ b/include/swift/Syntax/SyntaxData.h
@@ -409,8 +409,7 @@ public:
   OptionalStorage(OptionalStorage &&other) = default;
 
   template <class... ArgTypes>
-  explicit OptionalStorage(llvm::optional_detail::in_place_t,
-                           ArgTypes &&...Args)
+  explicit OptionalStorage(llvm::in_place_t, ArgTypes &&...Args)
       : Storage(std::forward<ArgTypes>(Args)...) {}
 
   void reset() { Storage = SyntaxDataRef(AbsoluteRawSyntax(nullptr), nullptr); }


### PR DESCRIPTION
in_place_t was pulled out of optional_detail and moved up to the llvm
namespace.

rdar://78956884