### PR TITLE
Revert "Revert "Revert "Disable module_deps_cache_reuse.swift test to unblock CI." and fix the test.""

### DIFF
--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -13,9 +13,6 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
-// This test fails in recent Swift CI runs
-// REQUIRES: radar78882565
-
 import C
 import E
 import G
@@ -115,6 +112,8 @@ import SubE
 // CHECK-NEXT: "-only-use-extra-clang-opts"
 // CHECK-NEXT: "-Xcc"
 // CHECK-NEXT: "clang"
+// CHECK-NEXT: "-Xcc"
+// CHECK-NEXT: "-fsyntax-only",
 // CHECK:      "-fsystem-module",
 // CHECK-NEXT: "-emit-pcm",
 // CHECK-NEXT: "-module-name",


### PR DESCRIPTION
And also make the test's pattern-matching of the problematic line a bit more robust. 