### PR TITLE
[ConstraintGraph] NFC: Remove flags from inference methods

### DIFF
--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -166,6 +166,10 @@ private:
   /// or equivalence class changes.
   void notifyReferencingVars() const;
 
+  /// Notify all of the type variables referenced by this one about a change.
+  void notifyReferencedVars(
+      llvm::function_ref<void(ConstraintGraphNode &)> notification);
+
   /// }
 
   /// The constraint graph this node belongs to.

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -125,16 +125,16 @@ private:
   /// Infer bindings from the given constraint and notify referenced variables
   /// about its arrival (if requested). This happens every time a new constraint
   /// gets added to a constraint graph node.
-  void introduceToInference(Constraint *constraint, bool notifyReferencedVars);
+  void introduceToInference(Constraint *constraint);
 
   /// Forget about the given constraint. This happens every time a constraint
   /// gets removed for a constraint graph.
-  void retractFromInference(Constraint *constraint, bool notifyReferencedVars);
+  void retractFromInference(Constraint *constraint);
 
   /// Re-evaluate the given constraint. This happens when there are changes
   /// in associated type variables e.g. bound/unbound to/from a fixed type,
   /// equivalence class changes.
-  void reintroduceToInference(Constraint *constraint, bool notifyReferencedVars);
+  void reintroduceToInference(Constraint *constraint);
 
   /// Similar to \c introduceToInference(Constraint *, ...) this method is going
   /// to notify inference that this type variable has been bound to a concrete

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -107,7 +107,14 @@ void ConstraintGraphNode::addConstraint(Constraint *constraint) {
   assert(ConstraintIndex.count(constraint) == 0 && "Constraint re-insertion");
   ConstraintIndex[constraint] = Constraints.size();
   Constraints.push_back(constraint);
-  introduceToInference(constraint, /*notifyFixedBindings=*/true);
+
+  {
+    introduceToInference(constraint);
+
+    notifyReferencedVars([&](ConstraintGraphNode &referencedVar) {
+      referencedVar.introduceToInference(constraint);
+    });
+  }
 }
 
 void ConstraintGraphNode::removeConstraint(Constraint *constraint) {
@@ -119,8 +126,13 @@ void ConstraintGraphNode::removeConstraint(Constraint *constraint) {
   ConstraintIndex.erase(pos);
   assert(Constraints[index] == constraint && "Mismatched constraint");
 
-  retractFromInference(constraint,
-                       /*notifyFixedBindings=*/true);
+  {
+    retractFromInference(constraint);
+
+    notifyReferencedVars([&](ConstraintGraphNode &referencedVar) {
+      referencedVar.retractFromInference(constraint);
+    });
+  }
 
   // If this is the last constraint, just pop it off the list and we're done.
   unsigned lastIndex = Constraints.size()-1;
@@ -160,8 +172,7 @@ void ConstraintGraphNode::notifyReferencingVars() const {
             affectedVar->getImpl().getRepresentative(/*record=*/nullptr);
 
         if (!repr->getImpl().getFixedType(/*record=*/nullptr))
-          CG[repr].reintroduceToInference(constraint,
-                                          /*notifyReferencedVars=*/false);
+          CG[repr].reintroduceToInference(constraint);
       }
     }
   };
@@ -217,7 +228,11 @@ void ConstraintGraphNode::addToEquivalenceClass(
       auto &node = CG[newMember];
 
       for (auto *constraint : node.getConstraints()) {
-        introduceToInference(constraint, /*notifyReferencedVars=*/true);
+        introduceToInference(constraint);
+
+        notifyReferencedVars([&](ConstraintGraphNode &referencedVar) {
+          referencedVar.introduceToInference(constraint);
+        });
       }
 
       node.notifyReferencingVars();
@@ -296,8 +311,7 @@ static bool isUsefulForReferencedVars(Constraint *constraint) {
   }
 }
 
-void ConstraintGraphNode::introduceToInference(Constraint *constraint,
-                                               bool notifyReferencedVars) {
+void ConstraintGraphNode::introduceToInference(Constraint *constraint) {
   if (forRepresentativeVar()) {
     auto fixedType = TypeVar->getImpl().getFixedType(/*record=*/nullptr);
     if (!fixedType)
@@ -305,20 +319,20 @@ void ConstraintGraphNode::introduceToInference(Constraint *constraint,
   } else {
     auto *repr =
         getTypeVariable()->getImpl().getRepresentative(/*record=*/nullptr);
-    CG[repr].introduceToInference(constraint, /*notifyReferencedVars=*/false);
+    CG[repr].introduceToInference(constraint);
   }
 
+  /*
   if (!notifyReferencedVars || !isUsefulForReferencedVars(constraint))
     return;
 
   this->notifyReferencedVars([&](ConstraintGraphNode &referencedVar) {
-    referencedVar.introduceToInference(constraint,
-                                       /*notifyReferencedVars=*/false);
+    referencedVar.introduceToInference(constraint);
   });
+*/
 }
 
-void ConstraintGraphNode::retractFromInference(Constraint *constraint,
-                                               bool notifyReferencedVars) {
+void ConstraintGraphNode::retractFromInference(Constraint *constraint) {
   if (forRepresentativeVar()) {
     auto fixedType = TypeVar->getImpl().getFixedType(/*record=*/nullptr);
     if (!fixedType)
@@ -326,22 +340,22 @@ void ConstraintGraphNode::retractFromInference(Constraint *constraint,
   } else {
     auto *repr =
         getTypeVariable()->getImpl().getRepresentative(/*record=*/nullptr);
-    CG[repr].retractFromInference(constraint, /*notifyReferencedVars=*/false);
+    CG[repr].retractFromInference(constraint);
   }
 
+  /*
   if (!notifyReferencedVars || !isUsefulForReferencedVars(constraint))
     return;
 
   this->notifyReferencedVars([&](ConstraintGraphNode &referencedVar) {
-    referencedVar.retractFromInference(constraint,
-                                       /*notifyReferencedVars=*/false);
+                               referencedVar.retractFromInference(constraint);
   });
+  */
 }
 
-void ConstraintGraphNode::reintroduceToInference(Constraint *constraint,
-                                                 bool notifyReferencedVars) {
-  retractFromInference(constraint, notifyReferencedVars);
-  introduceToInference(constraint, notifyReferencedVars);
+void ConstraintGraphNode::reintroduceToInference(Constraint *constraint) {
+  retractFromInference(constraint);
+  introduceToInference(constraint);
 }
 
 void ConstraintGraphNode::introduceToInference(Type fixedType) {
@@ -367,8 +381,7 @@ void ConstraintGraphNode::introduceToInference(Type fixedType) {
     // all of the constraints that reference bound type variable.
     for (auto *constraint : getConstraints()) {
       if (isUsefulForReferencedVars(constraint))
-        node.reintroduceToInference(constraint,
-                                    /*notifyReferencedVars=*/false);
+        node.reintroduceToInference(constraint);
     }
   }
 }


### PR DESCRIPTION
- Add a `notifyReferencedVars` method to help propagate information to type variables referenced by current one.
- Remove `notifyReferencedVars` flag from all inference related methods and use `notifyReferencedVars` where
   appropriate.
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
