### PR TITLE
SILGen: fix a crash when assigning a wrapped property in a convenience initializer

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1324,9 +1324,12 @@ namespace {
         if (!initInfo.hasInitFromWrappedValue())
           return false;
 
+        auto *fnDecl = SGF.FunctionDC->getAsDecl();
         bool isAssignmentToSelfParamInInit =
-            IsOnSelfParameter &&
-            isa<ConstructorDecl>(SGF.FunctionDC->getAsDecl());
+            IsOnSelfParameter && isa<ConstructorDecl>(fnDecl) &&
+            // Convenience initializers only contain assignments and not
+            // initializations.
+            !(cast<ConstructorDecl>(fnDecl)->isConvenienceInit());
 
         // Assignment to a wrapped property can only be re-written to initialization for
         // members of `self` in an initializer, and for local variables.

--- a/test/SILOptimizer/di_property_wrappers.swift
+++ b/test/SILOptimizer/di_property_wrappers.swift
@@ -92,6 +92,11 @@ final class IntClass {
      }
      wrapped = 27
   }
+
+  convenience init(withConvenienceInit x: Int) {
+    self.init()
+    self.wrapped = x
+  }
 }
 
 struct RefStruct {
@@ -210,6 +215,13 @@ func testIntClass() {
   let t5 = IntClass(dynamic: true)
   // CHECK-NEXT: 27
   print(t5.wrapped)
+
+  // CHECK-NEXT:   .. init 42
+  // CHECK-NEXT:   .. set 27
+  // CHECK-NEXT:   .. set 123
+  let t6 = IntClass(withConvenienceInit: 123)
+  // CHECK-NEXT: 123
+  print(t6.wrapped)
 }
 
 func testRefStruct() {


### PR DESCRIPTION
Convenience initializers only contain assignments to self, but not initializations.
This case was not handled when deciding between a regular assignment and assign_by_wrapper.

https://bugs.swift.org/browse/SR-14675
rdar://78892507
