### PR TITLE
[CMake] Disable swift-cmake tests if tools are not being built

### DIFF
--- a/validation-test/BuildSystem/CMakeLists.txt
+++ b/validation-test/BuildSystem/CMakeLists.txt
@@ -2,6 +2,6 @@
 # Only test this if we found a Swift compiler. Currently only enable this test
 # if we build on Darwin since we do not have a host toolchain available when
 # compiling on the bots for Linux meaning this path would not be tested.
-if (CMAKE_Swift_COMPILER AND APPLE)
+if (CMAKE_Swift_COMPILER AND APPLE AND SWIFT_INCLUDE_TOOLS)
   add_subdirectory(swift-cmake)
 endif()


### PR DESCRIPTION
The `swift-cmake` depends on `swift-syntax-generated-headers` which is only being built if the compiler (aka. `SWIFT_INCLUDE_TOOLS`) is being built. If a build only contains the stdlib, the test fails to configure. Disable it when `SWIFT_INCLUDE_TOOLS` is not true.