### PR TITLE
[cmake] Fix a few issues around swift cmake support build/test

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -624,8 +624,7 @@ function(add_swift_host_tool executable)
   _add_host_variant_c_compile_flags(${executable})
   _add_host_variant_link_flags(${executable})
   _add_host_variant_c_compile_link_flags(${executable})
-  target_link_directories(${executable} PRIVATE
-    ${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR})
+
   # Force executables linker language to be CXX so that we do not link using the
   # host toolchain swiftc.
   set_target_properties(${executable} PROPERTIES LINKER_LANGUAGE CXX)

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -477,7 +477,17 @@ function(add_swift_host_library name)
   endif()
 
   add_library(${name} ${libkind} ${ASHL_SOURCES})
-  add_dependencies(${name} ${LLVM_COMMON_DEPENDS})
+
+  # Respect LLVM_COMMON_DEPENDS if it is set.
+  #
+  # LLVM_COMMON_DEPENDS if a global variable set in ./lib that provides targets
+  # such as swift-syntax or tblgen that all LLVM/Swift based tools depend on. If
+  # we don't have it defined, then do not add the dependency since some parts of
+  # swift host tools do not interact with LLVM/Swift tools and do not define
+  # LLVM_COMMON_DEPENDS.
+  if (LLVM_COMMON_DEPENDS)
+    add_dependencies(${name} ${LLVM_COMMON_DEPENDS})
+  endif()
   if (NOT ASHL_PURE_SWIFT)
     llvm_update_compile_flags(${name})
   endif()
@@ -628,7 +638,17 @@ function(add_swift_host_tool executable)
   # Force executables linker language to be CXX so that we do not link using the
   # host toolchain swiftc.
   set_target_properties(${executable} PROPERTIES LINKER_LANGUAGE CXX)
-  add_dependencies(${executable} ${LLVM_COMMON_DEPENDS})
+
+  # Respect LLVM_COMMON_DEPENDS if it is set.
+  #
+  # LLVM_COMMON_DEPENDS if a global variable set in ./lib that provides targets
+  # such as swift-syntax or tblgen that all LLVM/Swift based tools depend on. If
+  # we don't have it defined, then do not add the dependency since some parts of
+  # swift host tools do not interact with LLVM/Swift tools and do not define
+  # LLVM_COMMON_DEPENDS.
+  if (LLVM_COMMON_DEPENDS)
+    add_dependencies(${executable} ${LLVM_COMMON_DEPENDS})
+  endif()
 
   set_target_properties(${executable} PROPERTIES
     FOLDER "Swift executables")

--- a/validation-test/BuildSystem/swift-cmake/CMakeLists.txt
+++ b/validation-test/BuildSystem/swift-cmake/CMakeLists.txt
@@ -1,18 +1,3 @@
-# In the absence of fine grained tablegen dependencies we need to ensure that
-# Swift's libraries all build after the LLVM & Clang tablegen-generated headers
-# are generated. When building out-of-tree (as with build-script) LLVM & Clang's
-# CMake configuration files create these targets as dummies so we can safely
-# depend on them directly here (See: SR-6026)
-# LLVM_COMMON_DEPENDS is a construct from the LLVM build system. It is a special
-# purpose variable that provides common dependencies for all libraries, and
-# executables generated when it is set. CMake's scoping rules enforce that these
-# new dependencies will only be added to targets created under Swift's lib
-# directory.
-list(APPEND LLVM_COMMON_DEPENDS intrinsics_gen clang-tablegen-targets)
-
-# Add generated libSyntax headers to global dependencies.
-list(APPEND LLVM_COMMON_DEPENDS swift-syntax-generated-headers)
-list(APPEND LLVM_COMMON_DEPENDS swift-parse-syntax-generated-headers)
 
 add_swift_host_library(TestCPPLib
   STATIC


### PR DESCRIPTION
Specifically I did the following:

1. add_swift_host_tool was adding a -L flag for the just built runtime to host code (before the -L to the host runtime!). This is incorrect and caused us to have a race that sometimes resulted in us mixing/matching binary artifacts and other weirdness.
2. I changed add_swift_host_library and add_swift_host_tool to not assume that the subdirectory we are in defines LLVM_COMMON_DEPENDS and to instead just respect it if it is set. The reason I did this is philosophically I don't think that things that do not depend on LLVM libraries (like my swift-cmake tests which are really simple) should have to define LLVM_COMMON_DEPENDS and also it makes it so that swift-cmake is no longer dependent on specific tools being built (like swift syntax) which causes these tests to not be built if the tools are not built. This test is meant to make sure that swift host side toolchain can build simple swift libraries and smoke out any errors, not actually depend on the tools we build.