### PR TITLE
Fix -no-clang-module-breadcrumbs when calling inline functions

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -113,7 +113,7 @@ static clang::CodeGenerator *createClangCodeGenerator(ASTContext &Context,
     break;
   case IRGenDebugInfoLevel::ASTTypes:
   case IRGenDebugInfoLevel::DwarfTypes:
-    CGO.DebugTypeExtRefs = true;
+    CGO.DebugTypeExtRefs = !Opts.DisableClangModuleSkeletonCUs;
     CGO.setDebugInfo(clang::codegenoptions::DebugInfoKind::FullDebugInfo);
     break;
   }

--- a/test/DebugInfo/ClangModuleBreadcrumbs.swift
+++ b/test/DebugInfo/ClangModuleBreadcrumbs.swift
@@ -7,6 +7,8 @@
 import ClangModule.SubModule
 import OtherClangModule.SubModule
 
+let _ = someFunc(0)
+
 // Check for Clang module breadcrumbs.
 // CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99}},{{.*}} producer: "{{.*}}Swift
 // CHECK-SAME:           ClangModule
@@ -14,6 +16,10 @@ import OtherClangModule.SubModule
 
 // CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99}}, {{.*}} producer: "{{.*}}Swift
 // CHECK-SAME:           OtherClangModule
+// CHECK-SAME:           dwoId:
+
+// CHECK: !DICompileUnit(language: DW_LANG_{{ObjC|C99}},{{.*}} producer: "{{.*}}clang
+// CHECK-SAME:           ClangModule
 // CHECK-SAME:           dwoId:
 
 // NONE: DICompileUnit({{.*}}

--- a/test/DebugInfo/Inputs/ClangModule.h
+++ b/test/DebugInfo/Inputs/ClangModule.h
@@ -1,3 +1,5 @@
 struct Foo {};
 
 typedef struct Foo s_Foo;
+
+static __inline__ __attribute__((always_inline)) int someFunc(int x) { return x; }


### PR DESCRIPTION
This PR disables the codegen option `DebugTypeExtRefs` when the `-no-clang-module-breadcrumbs` flag is used. This prevents clang adding references to pcm files in the debug info when calling inline functions.

Resolves SR-13275.
