### PR TITLE
[Distributed] minimal, remove accidental cpp include in CodeSynthesis.cpp

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -20,6 +20,7 @@
 #include "TypeCheckDecl.h"
 #include "TypeCheckObjC.h"
 #include "TypeCheckType.h"
+#include "TypeCheckDistributed.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/Availability.h"
 #include "swift/AST/Expr.h"
@@ -35,7 +36,6 @@
 #include "swift/Sema/ConstraintSystem.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"
-#include "CodeSynthesisDistributedActor.cpp" // FIXME: remove this!!!
 using namespace swift;
 
 const bool IsImplicit = true;

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "TypeCheckDistributed.h"
+
 #include "CodeSynthesis.h"
 
 #include "TypeChecker.h"
@@ -426,7 +428,6 @@ static void collectNonOveriddenDistributedActorInits(
 
 /// For a distributed actor, automatically define initializers
 /// that match the DistributedActor requirements.
-// TODO: inheritance is tricky here?
 static void addImplicitDistributedActorConstructors(ClassDecl *decl) {
   // Bail out if not a distributed actor definition.
   if (!decl->isDistributedActor())
@@ -716,7 +717,7 @@ static void addImplicitRemoteActorFunctions(ClassDecl *decl) {
 /******************************************************************************/
 
 /// Entry point for adding all computed members to a distributed actor decl.
-static void addImplicitDistributedActorMembersToClass(ClassDecl *decl) {
+void swift::addImplicitDistributedActorMembersToClass(ClassDecl *decl) {
   // Bail out if not a distributed actor definition.
   if (!decl->isDistributedActor())
     return;

--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -31,5 +31,5 @@ bool DerivedConformance::canDeriveDistributedActor(
 // ==== ------------------------------------------------------------------------
 
 ValueDecl *DerivedConformance::deriveDistributedActor(ValueDecl *requirement) {
- return nullptr;
+  return nullptr;
 }

--- a/lib/Sema/TypeCheckDistributed.h
+++ b/lib/Sema/TypeCheckDistributed.h
@@ -52,6 +52,10 @@ void checkDistributedActorConstructor(ClassDecl *decl, ConstructorDecl *ctor);
 
 bool checkDistributedFunction(FuncDecl *decl, bool diagnose);
 
+/// Synthesis of members which are not directly driven filling in protocol requirements,
+/// such as the default local and resolve constructors, and `_remote_` function stubs.
+void addImplicitDistributedActorMembersToClass(ClassDecl *decl);
+
 }
 
 


### PR DESCRIPTION
Trivial removal of very bad bad #include of a cpp file.

This will be followed up by a bigger cleanup, but let's fix the cpp include right away.

Distributed synthesis cannot be fully driven by the "protocol requirement" synthesis so it'll need a bigger refactor I think...