### PR TITLE
[5.5] Don't emit a bogus diagnostic when processing an old actor declaration

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4569,10 +4569,12 @@ void ConformanceChecker::resolveValueWitnesses() {
         return;
 
       // Ensure that Actor.unownedExecutor is implemented within the
-      // actor class itself.
+      // actor class itself.  But if this somehow resolves to the
+      // requirement, ignore it.
       if (requirement->getName().isSimpleName(C.Id_unownedExecutor) &&
           Proto->isSpecificProtocol(KnownProtocolKind::Actor) &&
           DC != witness->getDeclContext() &&
+          !isa<ProtocolDecl>(witness->getDeclContext()) &&
           Adoptee->getClassOrBoundGenericClass() &&
           Adoptee->getClassOrBoundGenericClass()->isActor()) {
         witness->diagnose(diag::unowned_executor_outside_actor);

--- a/test/ModuleInterface/Inputs/OldActor.swiftinterface
+++ b/test/ModuleInterface/Inputs/OldActor.swiftinterface
@@ -1,0 +1,15 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -enable-library-evolution -module-name OldActor -enable-experimental-concurrency
+import Swift
+import _Concurrency
+
+#if compiler(>=5.3) && $Actors
+@available(SwiftStdlib 5.5, *)
+public actor Monk {
+  public init()
+  deinit
+  public func method()
+  // Lacks an unownedExecutor property
+}
+#endif
+

--- a/test/ModuleInterface/actor_old_compat.swift
+++ b/test/ModuleInterface/actor_old_compat.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/OldActor.framework/Modules/OldActor.swiftmodule
+// RUN: %target-swift-frontend -emit-module -module-name OldActor %S/Inputs/OldActor.swiftinterface -o %t/OldActor.framework/Modules/OldActor.swiftmodule/%module-target-triple.swiftmodule
+// RUN: %target-swift-frontend -F %t -enable-experimental-concurrency -typecheck -verify %s
+
+// RUNX: cp -r %S/Inputs/OldActor.framework %t/
+// RUNX: %{python} %S/../CrossImport/Inputs/rewrite-module-triples.py %t %module-target-triple
+
+// REQUIRES: concurrency
+
+import OldActor
+
+@available(SwiftStdlib 5.5, *)
+extension Monk {
+  public func test() async {
+    method()
+  }
+}


### PR DESCRIPTION
This seems to only happen when parsing swiftinterfaces, but I've written this to be more generally defensive.

rdar://78233377

5.5 version of #37846.