### PR TITLE
Fix a debug info regression introduced with async support. 

### DIFF
--- a/test/DebugInfo/async-lifetime-extension.swift
+++ b/test/DebugInfo/async-lifetime-extension.swift
@@ -10,14 +10,14 @@
 // CHECK-NEXT: entryresume.0:
 // CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[RHS:[0-9]+]], {{.*}}!DIExpression(DW_OP
 // CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[LHS:[0-9]+]], {{.*}}!DIExpression(DW_OP
-// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[N:[0-9]+]], {{.*}}!DIExpression(DW_OP
 // CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[R:[0-9]+]], {{.*}}!DIExpression(DW_OP
+// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[N:[0-9]+]], {{.*}}!DIExpression(DW_OP
 // CHECK-NOT: {{ ret }}
 // CHECK: call void asm sideeffect ""
 // CHECK: ![[RHS]] = !DILocalVariable(name: "rhs"
 // CHECK: ![[LHS]] = !DILocalVariable(name: "lhs"
-// CHECK: ![[N]] = !DILocalVariable(name: "n"
 // CHECK: ![[R]] = !DILocalVariable(name: "retval"
+// CHECK: ![[N]] = !DILocalVariable(name: "n"
 public func fibo(_ n: Int) async -> Int {
   var retval = n
   if retval < 2 { return 1 }

--- a/test/DebugInfo/inlined-generics-basic.swift
+++ b/test/DebugInfo/inlined-generics-basic.swift
@@ -65,8 +65,8 @@ public class C<R> {
     // IR: call {{.*}}3use
 #sourceLocation(file: "f.swift", line: 3)
     g(r)
-    // IR: dbg.declare({{.*}}, metadata ![[GRS_T:[0-9]+]]
-    // IR: dbg.declare({{.*}}, metadata ![[GRS_U:[0-9]+]]
+    // IR: dbg.value({{.*}}, metadata ![[GRS_T:[0-9]+]]
+    // IR: dbg.value({{.*}}, metadata ![[GRS_U:[0-9]+]]
     // IR: call {{.*}}3use
 #sourceLocation(file: "f.swift", line: 4)
     g((r, s))


### PR DESCRIPTION
This patch removes a heuristic to promote all debug intrinsics pointing into
allocas to llvm.dbg.declare() intrinsics and instead more accurate classifies
variables in async contexts by adding the missing cases alloc_box and
alloc_stack cases.

rdar://78977132
