### PR TITLE
[5.4][IRGen] Disable pre-specialization for 32-bit ARM on Linux

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1609,7 +1609,8 @@ bool IRGenModule::useDllStorage() { return ::useDllStorage(Triple); }
 
 bool IRGenModule::shouldPrespecializeGenericMetadata() {
   auto canPrespecializeTarget =
-      (Triple.isOSDarwin() || Triple.isTvOS() || Triple.isOSLinux());
+      (Triple.isOSDarwin() || Triple.isTvOS() ||
+       (Triple.isOSLinux() && !(Triple.isARM() && Triple.isArch32Bit())));
   if (canPrespecializeTarget && isStandardLibrary()) {
     return true;
   }


### PR DESCRIPTION
- Explanation: This is a temporary workaround for segfaults we observed in TargetMetadata, caused by invalid pointers. It fixes those issues on [linux armv7](https://github.com/uraimo/buildSwiftOnARM/issues/66#issuecomment-850936420) and [Android armv7](https://github.com/uraimo/buildSwiftOnARM/issues/66#issuecomment-850880885), cherry-pick of #36658.

- Scope: Only affects generating metadata for linux armv7 platforms.

- SR Issue - none

- Risk: None, only affects linux/Android armv7 and not the main platforms.

- Testing: Several packages have been built and tested on linux and Android armv7 with this pull applied, including those that were failing before this pull and work now.

- Reviewer: @drexin wrote this patch, @nate-chandler wrote the relevant runtime metadata code.