### PR TITLE
[AutoDiff] [SR-14218] Correctly propagate tangent vectors of inout parameters from functions with multiple basic blocks

### DIFF
--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -2053,7 +2053,7 @@ bool PullbackCloner::Implementation::run() {
   // This vector will contain all indirect parameter adjoint buffers.
   SmallVector<SILValue, 4> indParamAdjoints;
   // This vector will identify the locations where initialization is needed.
-  SmallVector<bool, 8> outputsToInitialize;
+  SmallBitVector outputsToInitialize;
 
   auto conv = getOriginal().getConventions();
   auto origParams = getOriginal().getArgumentsWithoutIndirectResults();

--- a/test/AutoDiff/validation-test/inout_control_flow.swift
+++ b/test/AutoDiff/validation-test/inout_control_flow.swift
@@ -1,6 +1,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// Would fail due to unavailability of swift_autoDiffCreateLinearMapContext.
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 import StdlibUnittest
 import _Differentiation
 

--- a/test/AutoDiff/validation-test/inout_control_flow.swift
+++ b/test/AutoDiff/validation-test/inout_control_flow.swift
@@ -11,13 +11,14 @@ struct Model: Differentiable {
   var first: Float = 3
   var second: Float = 1
 
-  mutating func outer(){
+  mutating func outer() {
     inner()
   }
 
   mutating func inner() {
     self.second = self.first
 
+    // Dummy no-op if block, required to introduce control flow.
     let x = 5
     if x < 50 {}
   }
@@ -53,6 +54,7 @@ struct Model2<T: NumericDifferentiable>: Differentiable {
 func adjust<T: NumericDifferentiable>(model: inout Model2<T>, multiplier: T) {
   model.first = model.second * multiplier
 
+  // Dummy no-op if block, required to introduce control flow.
   let x = 5
   if x < 50 {}
 }
@@ -75,6 +77,7 @@ InoutControlFlowTests.test("InoutParameterWithControlFlow") {
 func adjust2<T: NumericDifferentiable>(multiplier: T, model: inout Model2<T>) {
   model.first = model.second * multiplier
 
+  // Dummy no-op if block, required to introduce control flow.
   let x = 5
   if x < 50 {}
 }

--- a/test/AutoDiff/validation-test/inout_control_flow.swift
+++ b/test/AutoDiff/validation-test/inout_control_flow.swift
@@ -1,0 +1,96 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import _Differentiation
+
+var InoutControlFlowTests = TestSuite("InoutControlFlow")
+
+// SR-14218
+struct Model: Differentiable {
+  var first: Float = 3
+  var second: Float = 1
+
+  mutating func outer(){
+    inner()
+  }
+
+  mutating func inner() {
+    self.second = self.first
+
+    let x = 5
+    if x < 50 {}
+  }
+}
+
+@differentiable(reverse)
+func loss(model: Model) -> Float{
+  var model = model
+  model.outer()
+  return model.second
+}
+
+InoutControlFlowTests.test("MutatingBeforeControlFlow") {
+  var model = Model()
+  let grad = gradient(at: model, of: loss)
+  expectEqual(1, grad.first)
+  expectEqual(0, grad.second)
+}
+
+// SR-14053
+protocol NumericDifferentiable : Numeric, Differentiable {
+  @differentiable(reverse) static func *(lhs: Self, rhs: Self) -> Self
+}
+
+extension Float: NumericDifferentiable {}
+
+struct Model2<T: NumericDifferentiable>: Differentiable {
+  var first: T
+  var second: T
+}
+
+@differentiable(reverse)
+func adjust<T: NumericDifferentiable>(model: inout Model2<T>, multiplier: T) {
+  model.first = model.second * multiplier
+
+  let x = 5
+  if x < 50 {}
+}
+
+@differentiable(reverse)
+func loss2(model: Model2<Float>, multiplier: Float) -> Float {
+  var model = model
+  adjust(model: &model, multiplier: multiplier)
+  return model.first
+}
+
+InoutControlFlowTests.test("InoutParameterWithControlFlow") {
+  var model = Model2<Float>(first: 1, second: 3)
+  let grad = gradient(at: model, 5.0, of: loss2)
+  expectEqual(0, grad.0.first)
+  expectEqual(5, grad.0.second)
+}
+
+@differentiable(reverse)
+func adjust2<T: NumericDifferentiable>(multiplier: T, model: inout Model2<T>) {
+  model.first = model.second * multiplier
+
+  let x = 5
+  if x < 50 {}
+}
+
+@differentiable(reverse)
+func loss3(model: Model2<Float>, multiplier: Float) -> Float {
+  var model = model
+  adjust2(multiplier: multiplier, model: &model)
+  return model.first
+}
+
+InoutControlFlowTests.test("LaterInoutParameterWithControlFlow") {
+  var model = Model2<Float>(first: 1, second: 3)
+  let grad = gradient(at: model, 5.0, of: loss3)
+  expectEqual(0, grad.0.first)
+  expectEqual(5, grad.0.second)
+}
+
+runAllTests()


### PR DESCRIPTION
Pullback generation for functions featuring active inout parameters and multiple basic blocks currently does not correctly propagate tangent vectors for the inout parameters. Changes to the tangent vectors of the inout parameters are not being copied back at the end of pullbacks involving control flow. As a workaround, to get correct tangent vectors you currently need to manually copy tangent vectors to an outside holding variable, then manually copy those tangent vectors back in before the function call site.

This pull request adds the missing copies of tangent vectors for inout parameters at the end of pullbacks, leading to correct tangent vectors around functions using inout parameters and control flow. Tests have been added for common permutations of these functions that previously produced incorrect tangent vectors.

In one large differentiable physics simulator with a complex model, this eliminates 80 lines of code for manual tangent vector copies. It also improves gradient descent throughput by 80% due to the removal of overhead from these explicit tangent vector copies.

Most of the credit for this fix belongs to @dan-zheng, who provided the original code to correctly copy these tangent vectors and worked with me to refine the fix.

Resolves [SR-14053](https://bugs.swift.org/browse/SR-14053) and [SR-14218](https://bugs.swift.org/browse/SR-14218).