### PR TITLE
[MiscDiagnostics] NFC: Add an assert that arguments a valid to `.nan`…

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4541,6 +4541,15 @@ static void diagnoseComparisonWithNaN(const Expr *E, const DeclContext *DC) {
       auto *firstArg = BE->getLHS();
       auto *secondArg = BE->getRHS();
 
+      // Make sure that both arguments are valid before doing anything else,
+      // this helps us to debug reports of crashes in `conformsToKnownProtocol`
+      // referencing arguments (rdar://78920375).
+      //
+      // Since this diagnostic should only be run on type-checked AST,
+      // it's unclear what caused one of the arguments to have null type.
+      assert(firstArg->getType() && "Expected valid type for first argument");
+      assert(secondArg->getType() && "Expected valid type for second argument");
+
       // Both arguments must conform to FloatingPoint protocol.
       if (!TypeChecker::conformsToKnownProtocol(firstArg->getType(),
                                                 KnownProtocolKind::FloatingPoint,


### PR DESCRIPTION
… comparison diagnostic

Make sure that both arguments are valid before checking conformance
to `FloatingPoint`. This helps us to debug reports of crashes in
`conformsToKnownProtocol` referencing arguments (rdar://78920375).

Since this diagnostic should only be run on type-checked AST,
it's unclear what caused one of the arguments to have null type.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
