### PR TITLE
[CodeCompletion] Don't offer completion names for closure argument names

### DIFF
--- a/test/IDE/complete_concurrency_specifier.swift
+++ b/test/IDE/complete_concurrency_specifier.swift
@@ -43,3 +43,12 @@ _ = { () #^CLOSURE_WITHARROW?check=SPECIFIER^# -> Void in }
 _ = { () async #^CLOSURE_WITHASYNCARROW?check=SPECIFIER_WITHASYNC^# -> Void in }
 _ = { () throws #^CLOSURE_WITHTHROWSARROW?check=SPECIFIER_WITHTHROWS^# -> Void in }
 _ = { () async throws #^CLOSURE_WITHASYNCTHROWSARROW?check=SPECIFIER_WITHASYNCTHROWS^# -> Void in }
+
+_ = { arg #^CLOSURE2?check=SPECIFIER^# in }
+_ = { arg async #^CLOSURE2_WITHASYNC?check=SPECIFIER_WITHASYNC^# in }
+_ = { arg throws #^CLOSURE2_WITHTHROWS?check=SPECIFIER_WITHTHROWS^# in }
+_ = { arg async throws #^CLOSURE2_WITHAASYNCTHROWS?check=SPECIFIER_WITHASYNCTHROWS^# in }
+_ = { arg #^CLOSURE2_WITHARROW?check=SPECIFIER^# -> Void in }
+_ = { arg async #^CLOSURE2_WITHASYNCARROW?check=SPECIFIER_WITHASYNC^# -> Void in }
+_ = { arg throws #^CLOSURE2_WITHTHROWSARROW?check=SPECIFIER_WITHTHROWS^# -> Void in }
+_ = { arg async throws #^CLOSURE2_WITHASYNCTHROWSARROW?check=SPECIFIER_WITHASYNCTHROWS^# -> Void in }

--- a/test/IDE/complete_in_closures.swift
+++ b/test/IDE/complete_in_closures.swift
@@ -385,4 +385,14 @@ func testSignature() {
 
     accept { (arg1: #^PARAMTYPE_1?check=WITH_GLOBAL_DECLS^#) in }
     accept { (arg1: Int, arg2: #^PARAMTYPE_2?check=WITH_GLOBAL_DECLS^#) in }
+
+    accept { [#^CAPTURE_1?check=WITH_GLOBAL_DECLS^#] in }
+    accept { [weak #^CAPTURE_2?check=WITH_GLOBAL_DECLS^#] in }
+    accept { [#^CAPTURE_3?check=EMPTY^# = capture] in }
+    accept { [weak #^CAPTURE_4?check=EMPTY^# = capture] in }
+
+    accept { () -> #^RESULTTYPE_1?check=WITH_GLOBAL_DECLS^# in }
+    accept { arg1, arg2 -> #^RESULTTYPE_2?check=WITH_GLOBAL_DECLS^# in }
+
+    // NOTE: For effects specifiers completion (e.g. '() <HERE> -> Void') see test/IDE/complete_concurrency_specifier.swift
 }

--- a/test/IDE/complete_in_closures.swift
+++ b/test/IDE/complete_in_closures.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
 
-// ERROR_COMMON: found code completion token
-// ERROR_COMMON-NOT: Begin completions
+// EMTPY: Token
+// EMPTY-NOT: Begin completions
 
 //===--- Helper types that are used in this test
 
@@ -194,7 +194,7 @@ acceptsListAndTrailingClosureTVoid(
 
 func getInt() -> Int? { return 0 }
 func testAcceptsTrailingClosureInt1() {
-  acceptsTrailingClosureFooVoid { #^IN_TRAILING_CLOSURE_16?check=WITH_GLOBAL_DECLS^# in
+  acceptsTrailingClosureFooVoid { #^IN_TRAILING_CLOSURE_16?check=EMPTY^# in
     if let myvar = getInt() {
     }
   }
@@ -370,4 +370,19 @@ func testInsideTernaryClosureReturn(test: Bool) -> [String] {
         // SINGLE_TERNARY_EXPR_CLOSURE_CONTEXT-DAG: Keyword[self]/CurrNominal:          .self[#String.Element#]; name=self
         // SINGLE_TERNARY_EXPR_CLOSURE_CONTEXT: End completions
     }
+}
+
+func testSignature() {
+    func accept<T>(_: () -> T) {}
+
+    accept { #^PARAM_BARE_1?check=EMPTY^# in }
+    accept { #^PARAM_BARE_2?check=EMPTY^#, arg2 in }
+    accept { arg1, #^PARAM_BARE_3?check=EMPTY^# in }
+
+    accept { (#^PARAM_PAREN_1?check=EMPTY^#) in }
+    accept { (#^PARAM_PAREN_2?check=EMPTY^#, arg2) in }
+    accept { (arg1, #^PARAM_PAREN_3?check=EMPTY^#) in }
+
+    accept { (arg1: #^PARAMTYPE_1?check=WITH_GLOBAL_DECLS^#) in }
+    accept { (arg1: Int, arg2: #^PARAMTYPE_2?check=WITH_GLOBAL_DECLS^#) in }
 }


### PR DESCRIPTION
Parse a completion token as an empty parameter name (just like `_`) to prevent the parser to parse it as an expression and offer completions for it.

rdar://78798718
