### PR TITLE
[ModuleInterface] Print full type if ambiguous for extensions.

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -195,6 +195,9 @@ struct PrintOptions {
   /// type might be ambiguous.
   bool FullyQualifiedTypesIfAmbiguous = false;
 
+  /// Print fully qualified extended types if ambiguous.
+  bool FullyQualifiedExtendedTypesIfAmbiguous = false;
+
   /// If true, printed module names will use the "exported" name, which may be
   /// different from the regular name.
   ///

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -121,6 +121,8 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
   result.PrintIfConfig = false;
   result.CurrentModule = ModuleToPrint;
   result.FullyQualifiedTypes = true;
+  result.FullyQualifiedTypesIfAmbiguous = true;
+  result.FullyQualifiedExtendedTypesIfAmbiguous = true;
   result.UseExportedModuleNames = true;
   result.AllowNullTypes = false;
   result.SkipImports = true;
@@ -2330,9 +2332,14 @@ void PrintAST::visitImportDecl(ImportDecl *decl) {
 }
 
 static void printExtendedTypeName(Type ExtendedType, ASTPrinter &Printer,
-                                  PrintOptions Options) {
-  Options.FullyQualifiedTypes = false;
-  Options.FullyQualifiedTypesIfAmbiguous = false;
+                                  PrintOptions &Options) {
+  bool OldFullyQualifiedTypesIfAmbiguous =
+    Options.FullyQualifiedTypesIfAmbiguous;
+  Options.FullyQualifiedTypesIfAmbiguous =
+    Options.FullyQualifiedExtendedTypesIfAmbiguous;
+  SWIFT_DEFER {
+    Options.FullyQualifiedTypesIfAmbiguous = OldFullyQualifiedTypesIfAmbiguous;
+  };
 
   // Strip off generic arguments, if any.
   auto Ty = ExtendedType->getAnyNominal()->getDeclaredType();

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -589,10 +589,16 @@ public:
       DeclAttributes::print(printer, printOptions, attrs);
 
       printer << "extension ";
-      PrintOptions typePrintOptions = printOptions;
-      typePrintOptions.FullyQualifiedTypes = false;
-      typePrintOptions.FullyQualifiedTypesIfAmbiguous = false;
-      nominal->getDeclaredType().print(printer, typePrintOptions);
+      {
+        PrintOptions typePrintOptions = printOptions;
+        bool oldFullyQualifiedTypesIfAmbiguous =
+          typePrintOptions.FullyQualifiedTypesIfAmbiguous;
+        typePrintOptions.FullyQualifiedTypesIfAmbiguous =
+          typePrintOptions.FullyQualifiedExtendedTypesIfAmbiguous;
+        nominal->getDeclaredType().print(printer, typePrintOptions);
+        typePrintOptions.FullyQualifiedTypesIfAmbiguous =
+          oldFullyQualifiedTypesIfAmbiguous;
+      }
       printer << " : ";
 
       proto->getDeclaredInterfaceType()->print(printer, printOptions);

--- a/test/ModuleInterface/access-filter.swift
+++ b/test/ModuleInterface/access-filter.swift
@@ -53,7 +53,7 @@ public protocol PublicProto {
   func requirement()
 } // CHECK-NEXT: {{^[}]$}}
 
-// CHECK: extension PublicProto {{[{]$}}
+// CHECK: extension AccessFilter.PublicProto {{[{]$}}
 extension PublicProto {
   // CHECK: public func publicMethod(){{$}}
   public func publicMethod() {}
@@ -64,7 +64,7 @@ extension PublicProto {
   @usableFromInline internal func ufiMethod() {}
 } // CHECK: {{^[}]$}}
 
-// CHECK: {{^}}extension PublicProto {{[{]$}}
+// CHECK: {{^}}extension AccessFilter.PublicProto {{[{]$}}
 public extension PublicProto {
   // CHECK: public func publicExtPublicMethod(){{$}}
   func publicExtPublicMethod() {}
@@ -96,7 +96,7 @@ internal protocol UFIProto {
   func requirement()
 } // CHECK-NEXT: {{^[}]$}}
 
-// CHECK: extension UFIProto {{[{]$}}
+// CHECK: extension AccessFilter.UFIProto {{[{]$}}
 extension UFIProto {
   // CHECK: public func publicMethod(){{$}}
   public func publicMethod() {}
@@ -107,7 +107,7 @@ extension UFIProto {
   @usableFromInline internal func ufiMethod() {}
 } // CHECK: {{^[}]$}}
 
-// CHECK: extension PublicStruct {{[{]$}}
+// CHECK: extension AccessFilter.PublicStruct {{[{]$}}
 extension PublicStruct {
   // CHECK: @_hasInitialValue public static var secretlySettable: Swift.Int {
   // CHECK-NEXT: get
@@ -120,7 +120,7 @@ extension InternalStruct_BAD: PublicProto {
   internal static var dummy: Int { return 0 }
 }
 
-// CHECK: extension UFIStruct : AccessFilter.PublicProto {{[{]$}}
+// CHECK: extension AccessFilter.UFIStruct : AccessFilter.PublicProto {{[{]$}}
 extension UFIStruct: PublicProto {
   // CHECK-NEXT: @usableFromInline
   // CHECK-NEXT: internal typealias Assoc = Swift.Int
@@ -167,12 +167,12 @@ class InternalClass_BAD {
 // CHECK: public struct GenericStruct<T>
 public struct GenericStruct<T> {}
 
-// CHECK: extension GenericStruct where T == AccessFilter.PublicStruct {{[{]$}}
+// CHECK: extension AccessFilter.GenericStruct where T == AccessFilter.PublicStruct {{[{]$}}
 extension GenericStruct where T == AccessFilter.PublicStruct {
   // CHECK-NEXT: public func constrainedToPublicStruct(){{$}}
   public func constrainedToPublicStruct() {}
 } // CHECK-NEXT: {{^[}]$}}
-// CHECK: extension GenericStruct where T == AccessFilter.UFIStruct {{[{]$}}
+// CHECK: extension AccessFilter.GenericStruct where T == AccessFilter.UFIStruct {{[{]$}}
 extension GenericStruct where T == AccessFilter.UFIStruct {
   // CHECK-NEXT: @usableFromInline{{$}}
   // CHECK-NEXT: internal func constrainedToUFIStruct(){{$}}
@@ -182,12 +182,12 @@ extension GenericStruct where T == InternalStruct_BAD {
   @usableFromInline internal func constrainedToInternalStruct_BAD() {}
 }
 
-// CHECK: extension GenericStruct where T == AccessFilter.PublicStruct {{[{]$}}
+// CHECK: extension AccessFilter.GenericStruct where T == AccessFilter.PublicStruct {{[{]$}}
 extension GenericStruct where PublicStruct == T {
   // CHECK-NEXT: public func constrainedToPublicStruct2(){{$}}
   public func constrainedToPublicStruct2() {}
 } // CHECK-NEXT: {{^[}]$}}
-// CHECK: extension GenericStruct where T == AccessFilter.UFIStruct {{[{]$}}
+// CHECK: extension AccessFilter.GenericStruct where T == AccessFilter.UFIStruct {{[{]$}}
 extension GenericStruct where UFIStruct == T {
   // CHECK-NEXT: @usableFromInline{{$}}
   // CHECK-NEXT: internal func constrainedToUFIStruct2(){{$}}
@@ -197,12 +197,12 @@ extension GenericStruct where InternalStruct_BAD == T {
   @usableFromInline internal func constrainedToInternalStruct2_BAD() {}
 }
 
-// CHECK: extension GenericStruct where T : AccessFilter.PublicProto {{[{]$}}
+// CHECK: extension AccessFilter.GenericStruct where T : AccessFilter.PublicProto {{[{]$}}
 extension GenericStruct where T: PublicProto {
   // CHECK-NEXT: public func constrainedToPublicProto(){{$}}
   public func constrainedToPublicProto() {}
 } // CHECK-NEXT: {{^[}]$}}
-// CHECK: extension GenericStruct where T : AccessFilter.UFIProto {{[{]$}}
+// CHECK: extension AccessFilter.GenericStruct where T : AccessFilter.UFIProto {{[{]$}}
 extension GenericStruct where T: UFIProto {
   // CHECK-NEXT: @usableFromInline{{$}}
   // CHECK-NEXT: internal func constrainedToUFIProto(){{$}}
@@ -212,12 +212,12 @@ extension GenericStruct where T: InternalProto_BAD {
   @usableFromInline internal func constrainedToInternalProto_BAD() {}
 }
 
-// CHECK: extension GenericStruct where T : AccessFilter.PublicClass {{[{]$}}
+// CHECK: extension AccessFilter.GenericStruct where T : AccessFilter.PublicClass {{[{]$}}
 extension GenericStruct where T: PublicClass {
   // CHECK-NEXT: public func constrainedToPublicClass(){{$}}
   public func constrainedToPublicClass() {}
 } // CHECK-NEXT: {{^[}]$}}
-// CHECK: extension GenericStruct where T : AccessFilter.UFIClass {{[{]$}}
+// CHECK: extension AccessFilter.GenericStruct where T : AccessFilter.UFIClass {{[{]$}}
 extension GenericStruct where T: UFIClass {
   // CHECK-NEXT: @usableFromInline{{$}}
   // CHECK-NEXT: internal func constrainedToUFIClass(){{$}}
@@ -227,7 +227,7 @@ extension GenericStruct where T: InternalClass_BAD {
   @usableFromInline internal func constrainedToInternalClass_BAD() {}
 }
 
-// CHECK: extension GenericStruct where T : AnyObject {{[{]$}}
+// CHECK: extension AccessFilter.GenericStruct where T : AnyObject {{[{]$}}
 extension GenericStruct where T: AnyObject {
   // CHECK-NEXT: public func constrainedToAnyObject(){{$}}
   public func constrainedToAnyObject() {}
@@ -245,12 +245,12 @@ internal typealias InternalAlias_BAD = PublicAliasBase
 
 internal typealias ReallyInternalAlias_BAD = ReallyInternalAliasBase_BAD
 
-// CHECK: extension GenericStruct where T == AccessFilter.PublicAlias {{[{]$}}
+// CHECK: extension AccessFilter.GenericStruct where T == AccessFilter.PublicAlias {{[{]$}}
 extension GenericStruct where T == PublicAlias {
   // CHECK-NEXT: public func constrainedToPublicAlias(){{$}}
   public func constrainedToPublicAlias() {}
 } // CHECK-NEXT: {{^[}]$}}
-// CHECK: extension GenericStruct where T == AccessFilter.UFIAlias {{[{]$}}
+// CHECK: extension AccessFilter.GenericStruct where T == AccessFilter.UFIAlias {{[{]$}}
 extension GenericStruct where T == UFIAlias {
   // CHECK-NEXT: @usableFromInline{{$}}
   // CHECK-NEXT: internal func constrainedToUFIAlias(){{$}}
@@ -275,7 +275,7 @@ extension GenericStruct: PublicProto where T: InternalProto_BAD {
 
 public struct MultiGenericStruct<First, Second> {}
 
-// CHECK: extension MultiGenericStruct where First == AccessFilter.PublicStruct, Second == AccessFilter.PublicStruct {{[{]$}}
+// CHECK: extension AccessFilter.MultiGenericStruct where First == AccessFilter.PublicStruct, Second == AccessFilter.PublicStruct {{[{]$}}
 extension MultiGenericStruct where First == PublicStruct, Second == PublicStruct {
   // CHECK-NEXT: public func publicPublic(){{$}}
   public func publicPublic() {}

--- a/test/ModuleInterface/conformances.swift
+++ b/test/ModuleInterface/conformances.swift
@@ -33,45 +33,45 @@ public struct A1: PublicProto, PrivateProto {}
 // NEGATIVE-NOT: extension conformances.A2
 public struct A2: PrivateProto, PublicProto {}
 // CHECK: public struct A3 {
-// CHECK-END: extension A3 : conformances.PublicProto {}
+// CHECK-END: extension conformances.A3 : conformances.PublicProto {}
 public struct A3: PublicProto & PrivateProto {}
 // CHECK: public struct A4 {
-// CHECK-END: extension A4 : conformances.PublicProto {}
+// CHECK-END: extension conformances.A4 : conformances.PublicProto {}
 public struct A4: PrivateProto & PublicProto {}
 
 public protocol PublicBaseProto {}
 private protocol PrivateSubProto: PublicBaseProto {}
 
 // CHECK: public struct B1 {
-// CHECK-END: extension B1 : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances.B1 : conformances.PublicBaseProto {}
 public struct B1: PrivateSubProto {}
 // CHECK: public struct B2 : conformances.PublicBaseProto {
 // NEGATIVE-NOT: extension conformances.B2
 public struct B2: PublicBaseProto, PrivateSubProto {}
 // CHECK: public struct B3 {
-// CHECK-END: extension B3 : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances.B3 : conformances.PublicBaseProto {}
 public struct B3: PublicBaseProto & PrivateSubProto {}
 // CHECK: public struct B4 : conformances.PublicBaseProto {
-// NEGATIVE-NOT: extension B4 {
+// NEGATIVE-NOT: extension conformances.B4 {
 // NEGATIVE-NOT: extension conformances.B4
 public struct B4: PublicBaseProto {}
 extension B4: PrivateSubProto {}
 // CHECK: public struct B5 {
-// CHECK: extension B5 : conformances.PublicBaseProto {
-// NEGATIVE-NOT: extension conformances.B5
+// CHECK: extension conformances.B5 : conformances.PublicBaseProto {
+// NEGATIVE-NOT: extension B5
 public struct B5: PrivateSubProto {}
 extension B5: PublicBaseProto {}
 // CHECK: public struct B6 {
-// NEGATIVE-NOT: extension B6 {
-// CHECK: extension B6 : conformances.PublicBaseProto {
-// NEGATIVE-NOT: extension conformances.B6
+// NEGATIVE-NOT: extension conformances.B6 : conformances.PrivateSubProto
+// NEGATIVE-NOT: extension conformances.B6 {
+// CHECK: extension conformances.B6 : conformances.PublicBaseProto {
 public struct B6 {}
 extension B6: PrivateSubProto {}
 extension B6: PublicBaseProto {}
 // CHECK: public struct B7 {
-// CHECK: extension B7 : conformances.PublicBaseProto {
-// NEGATIVE-NOT: extension B7 {
-// NEGATIVE-NOT: extension conformances.B7
+// CHECK: extension conformances.B7 : conformances.PublicBaseProto {
+// NEGATIVE-NOT: extension conformances.B7 : conformances.PrivateSubProto {
+// NEGATIVE-NOT: extension conformances.B7 {
 public struct B7 {}
 extension B7: PublicBaseProto {}
 extension B7: PrivateSubProto {}
@@ -92,7 +92,7 @@ public protocol ConditionallyConformedAgain {}
 extension OuterGeneric: ConditionallyConformed where T: PrivateProto {}
 extension OuterGeneric: ConditionallyConformedAgain where T == PrivateProto {}
 
-// CHECK-END: extension OuterGeneric.Inner : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances.OuterGeneric.Inner : conformances.PublicBaseProto {}
 // CHECK-END: @available(*, unavailable)
 // CHECK-END-NEXT: extension conformances.OuterGeneric.Inner : conformances.ConditionallyConformed, conformances.ConditionallyConformedAgain where T : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
 extension OuterGeneric.Inner: ConditionallyConformed where T: PrivateProto {}
@@ -101,14 +101,14 @@ extension OuterGeneric.Inner: ConditionallyConformedAgain where T == PrivateProt
 private protocol AnotherPrivateSubProto: PublicBaseProto {}
 
 // CHECK: public struct C1 {
-// CHECK-END: extension C1 : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances.C1 : conformances.PublicBaseProto {}
 public struct C1: PrivateSubProto, AnotherPrivateSubProto {}
 // CHECK: public struct C2 {
-// CHECK-END: extension C2 : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances.C2 : conformances.PublicBaseProto {}
 public struct C2: PrivateSubProto & AnotherPrivateSubProto {}
 // CHECK: public struct C3 {
-// NEGATIVE-NOT: extension C3 {
-// CHECK-END: extension C3 : conformances.PublicBaseProto {}
+// NEGATIVE-NOT: extension conformances.C3 {
+// CHECK-END: extension conformances.C3 : conformances.PublicBaseProto {}
 public struct C3: PrivateSubProto {}
 extension C3: AnotherPrivateSubProto {}
 
@@ -122,20 +122,21 @@ public struct D1: PublicSubProto, PrivateSubProto {}
 // NEGATIVE-NOT: extension conformances.D2
 public struct D2: PrivateSubProto, PublicSubProto {}
 // CHECK: public struct D3 {
-// CHECK-END: extension D3 : conformances.PublicBaseProto {}
-// CHECK-END: extension D3 : conformances.PublicSubProto {}
+// CHECK-END: extension conformances.D3 : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances.D3 : conformances.PublicSubProto {}
 public struct D3: PrivateSubProto & PublicSubProto {}
 // CHECK: public struct D4 {
-// CHECK-END: extension D4 : conformances.APublicSubProto {}
-// CHECK-END: extension D4 : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances.D4 : conformances.APublicSubProto {}
+// CHECK-END: extension conformances.D4 : conformances.PublicBaseProto {}
 public struct D4: APublicSubProto & PrivateSubProto {}
 // CHECK: public struct D5 {
-// CHECK: extension D5 : conformances.PublicSubProto {
-// NEGATIVE-NOT: extension conformances.D5
+// NEGATIVE-NOT: extension conformances.D5 : conformances.PrivateSubProto {
+// NEGATIVE-NOT: extension conformances.D5 {
+// CHECK: extension conformances.D5 : conformances.PublicSubProto {
 public struct D5: PrivateSubProto {}
 extension D5: PublicSubProto {}
 // CHECK: public struct D6 : conformances.PublicSubProto {
-// NEGATIVE-NOT: extension D6 {
+// NEGATIVE-NOT: extension conformances.D6 {
 // NEGATIVE-NOT: extension conformances.D6
 public struct D6: PublicSubProto {}
 extension D6: PrivateSubProto {}
@@ -143,27 +144,27 @@ extension D6: PrivateSubProto {}
 private typealias PrivateProtoAlias = PublicProto
 
 // CHECK: public struct E1 {
-// CHECK-END: extension E1 : conformances.PublicProto {}
+// CHECK-END: extension conformances.E1 : conformances.PublicProto {}
 public struct E1: PrivateProtoAlias {}
 
 private typealias PrivateSubProtoAlias = PrivateSubProto
 
 // CHECK: public struct F1 {
-// CHECK-END: extension F1 : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances.F1 : conformances.PublicBaseProto {}
 public struct F1: PrivateSubProtoAlias {}
 
 private protocol ClassConstrainedProto: PublicProto, AnyObject {}
 
 public class G1: ClassConstrainedProto {}
 // CHECK: public class G1 {
-// CHECK-END: extension G1 : conformances.PublicProto {}
+// CHECK-END: extension conformances.G1 : conformances.PublicProto {}
 
 public class Base {}
 private protocol BaseConstrainedProto: Base, PublicProto {}
 
 public class H1: Base, ClassConstrainedProto {}
 // CHECK: public class H1 : conformances.Base {
-// CHECK-END: extension H1 : conformances.PublicProto {}
+// CHECK-END: extension conformances.H1 : conformances.PublicProto {}
 
 public struct MultiGeneric<T, U, V> {}
 extension MultiGeneric: PublicProto where U: PrivateProto {}
@@ -197,32 +198,32 @@ public struct CoolTVType: PrivateSubProto {}
 // CHECK: public struct CoolTVType {
 // CHECK-END: @available(iOS, unavailable)
 // CHECK-END-NEXT: @available(macOS, unavailable)
-// CHECK-END-NEXT: extension CoolTVType : conformances.PublicBaseProto {}
+// CHECK-END-NEXT: extension conformances.CoolTVType : conformances.PublicBaseProto {}
 
 @available(macOS 10.99, *)
 public struct VeryNewMacType: PrivateSubProto {}
 // CHECK: public struct VeryNewMacType {
 // CHECK-END: @available(macOS 10.99, *)
-// CHECK-END-NEXT: extension VeryNewMacType : conformances.PublicBaseProto {}
+// CHECK-END-NEXT: extension conformances.VeryNewMacType : conformances.PublicBaseProto {}
 
 public struct VeryNewMacProto {}
 @available(macOS 10.98, *)
 extension VeryNewMacProto: PrivateSubProto {}
 // CHECK: public struct VeryNewMacProto {
 // CHECK-END: @available(macOS 10.98, *)
-// CHECK-END-NEXT: extension VeryNewMacProto : conformances.PublicBaseProto {}
+// CHECK-END-NEXT: extension conformances.VeryNewMacProto : conformances.PublicBaseProto {}
 
 public struct PrivateProtoConformer {}
 extension PrivateProtoConformer : PrivateProto {
   public var member: Int { return 0 }
 }
 // CHECK: public struct PrivateProtoConformer {
-// CHECK: extension PrivateProtoConformer {
+// CHECK: extension conformances.PrivateProtoConformer {
 // CHECK-NEXT: public var member: Swift.Int {
 // CHECK-NEXT:   get
 // CHECK-NEXT: }
 // CHECK-NEXT: {{^}$}}
-// NEGATIVE-NOT: extension conformances.PrivateProtoConformer
+// NEGATIVE-NOT: extension conformances.PrivateProtoConformer : conformances.PrivateProto {
 
 // NEGATIVE-NOT: extension {{(Swift.)?}}Bool{{.+}}Hashable
 // NEGATIVE-NOT: extension {{(Swift.)?}}Bool{{.+}}Equatable
@@ -238,7 +239,7 @@ public struct NestedAvailabilityOuter {
 
 // CHECK-END: @available(macOS 10.97, iOS 23, *)
 // CHECK-END: @available(tvOS, unavailable)
-// CHECK-END: extension NestedAvailabilityOuter.Inner : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances.NestedAvailabilityOuter.Inner : conformances.PublicBaseProto {}
 
 
 // CHECK-END: @usableFromInline

--- a/test/ModuleInterface/empty-extension.swift
+++ b/test/ModuleInterface/empty-extension.swift
@@ -50,10 +50,10 @@ extension IOIImportedType {
 // CHECK-NOT: funcForAnotherOS
 
 extension NormalImportedType : PublicProto {}
-// CHECK: extension NormalImportedType
+// CHECK: extension Lib.NormalImportedType
 
 extension ExportedType : PublicProto {}
-// CHECK: extension ExportedType
+// CHECK: extension IndirectLib.ExportedType
 
 extension NormalImportedType {
   #if os(macOS)

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -20,7 +20,7 @@ public actor MyActor {
 }
 
 // CHECK: #if compiler(>=5.3) && $Actors
-// CHECK-NEXT: extension MyActor
+// CHECK-NEXT: extension FeatureTest.MyActor
 public extension MyActor {
   // CHECK-NOT: $Actors
   // CHECK: testFunc
@@ -56,7 +56,7 @@ public func globalAsync() async { }
 public protocol MP3: AnyObject, MP { }
 
 // CHECK: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK-NEXT: extension MP2 {
+// CHECK-NEXT: extension FeatureTest.MP2 {
 // CHECK-NEXT: func inMP2
 extension MP2 {
   public func inMP2() { }
@@ -114,12 +114,12 @@ public struct IsRP: RP {
 public func acceptsRP<T: RP>(_: T) { }
 
 // CHECK: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK-NEXT: extension Array : FeatureTest.MP where Element : FeatureTest.MP {
+// CHECK-NEXT: extension Swift.Array : FeatureTest.MP where Element : FeatureTest.MP {
 extension Array: FeatureTest.MP where Element : FeatureTest.MP { }
 // CHECK: }
 
 // CHECK: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK-NEXT: extension OldSchool : Swift.UnsafeSendable {
+// CHECK-NEXT: extension FeatureTest.OldSchool : Swift.UnsafeSendable {
 extension OldSchool: UnsafeSendable { }
 // CHECK-NEXT: }
 
@@ -151,9 +151,9 @@ public func stage(with actor: MyActor) { }
 // CHECK-NEXT: #endif
 public func asyncIsh(@_inheritActorContext operation: @Sendable @escaping () async -> Void) { }
 
-// CHECK-NOT: extension MyActor : Swift.Sendable
+// CHECK-NOT: extension FeatureTest.MyActor : Swift.Sendable
 
 // CHECK: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK-NEXT: extension OldSchool : FeatureTest.MP {
+// CHECK-NEXT: extension FeatureTest.OldSchool : FeatureTest.MP {
 // CHECK-NEXT: #endif
 

--- a/test/ModuleInterface/fixed-layout-property-initializers.swift
+++ b/test/ModuleInterface/fixed-layout-property-initializers.swift
@@ -1,15 +1,15 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t.swiftinterface %s
-// RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix NONRESILIENT --check-prefix COMMON < %t.swiftinterface
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/Test.swiftinterface %s -module-name Test
+// RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix NONRESILIENT --check-prefix COMMON < %t/Test.swiftinterface
 
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t-resilient.swiftinterface -enable-library-evolution %s
-// RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix RESILIENT --check-prefix COMMON < %t-resilient.swiftinterface
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/TestResilient.swiftinterface -enable-library-evolution %s -module-name TestResilient
+// RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix RESILIENT --check-prefix COMMON < %t/TestResilient.swiftinterface
 
-// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule %t.swiftinterface -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule %t/Test.swiftinterface -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -module-name Test -emit-module-interface-path - | %FileCheck %s --check-prefix FROMMODULE --check-prefix NONRESILIENT --check-prefix COMMON
 
-// RUN: %target-swift-frontend -emit-module -o %t/TestResilient.swiftmodule -enable-library-evolution %t-resilient.swiftinterface -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -emit-module -o %t/TestResilient.swiftmodule -enable-library-evolution %t/TestResilient.swiftinterface -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/TestResilient.swiftmodule -module-name TestResilient -enable-library-evolution -emit-module-interface-path - | %FileCheck %s --check-prefix FROMMODULE --check-prefix RESILIENT --check-prefix COMMON
 
 // COMMON: @frozen public struct MyStruct {

--- a/test/ModuleInterface/synthesized.swift
+++ b/test/ModuleInterface/synthesized.swift
@@ -38,21 +38,21 @@ public enum NoRawValueWithExplicitHashable {
 case a, b, c
 } // CHECK: {{^}$}}
 
-// CHECK-LABEL: extension NoRawValueWithExplicitHashable : Swift.Hashable {
+// CHECK-LABEL: extension synthesized.NoRawValueWithExplicitHashable : Swift.Hashable {
 extension NoRawValueWithExplicitHashable : Hashable {
   // CHECK-NEXT: public func foo()
   public func foo() {}
 } // CHECK: {{^}$}}
 
-// CHECK: extension HasRawValue : Swift.Equatable {}
-// CHECK: extension HasRawValue : Swift.Hashable {}
-// CHECK: extension HasRawValue : Swift.RawRepresentable {}
+// CHECK: extension synthesized.HasRawValue : Swift.Equatable {}
+// CHECK: extension synthesized.HasRawValue : Swift.Hashable {}
+// CHECK: extension synthesized.HasRawValue : Swift.RawRepresentable {}
 
-// CHECK: extension ObjCEnum : Swift.Equatable {}
-// CHECK: extension ObjCEnum : Swift.Hashable {}
-// CHECK: extension ObjCEnum : Swift.RawRepresentable {}
+// CHECK: extension synthesized.ObjCEnum : Swift.Equatable {}
+// CHECK: extension synthesized.ObjCEnum : Swift.Hashable {}
+// CHECK: extension synthesized.ObjCEnum : Swift.RawRepresentable {}
 
-// CHECK: extension NoRawValueWithExplicitEquatable : Swift.Hashable {}
+// CHECK: extension synthesized.NoRawValueWithExplicitEquatable : Swift.Hashable {}
 // NEGATIVE-NOT: extension {{.+}}NoRawValueWithExplicitEquatable : Swift.Equatable
 
 // NEGATIVE-NOT: NoRawValueWithExplicitHashable : Swift.Equatable

--- a/test/ModuleInterface/type-shadowing.swift
+++ b/test/ModuleInterface/type-shadowing.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck %s -swift-version 5 -enable-library-evolution -emit-module-interface-path %t/Bakery.swiftinterface -DBAKERY -module-name Bakery
+// RUN: %target-swift-frontend -typecheck %s -swift-version 5 -enable-library-evolution -emit-module-interface-path %t/Home.swiftinterface -DHOME -module-name Home -I %t
+// RUN: %FileCheck %s < %t/Home.swiftinterface
+
+#if BAKERY
+public class Cake {
+    public init(_: ()) {}
+}
+#endif
+
+#if HOME
+import Bakery
+
+struct Cake {
+    public init() {}
+}
+
+extension Bakery.Cake {
+    public convenience init() {}
+}
+#endif
+
+// CHECK: extension Bakery.Cake

--- a/test/ModuleInterface/where-clause.swift
+++ b/test/ModuleInterface/where-clause.swift
@@ -44,7 +44,7 @@ public struct Holder<Value> {
 // CHECK-NEXT: }
 }
 
-// CHECK-NEXT: extension Holder.Transform where Value == Swift.Int {
+// CHECK-NEXT: extension main.Holder.Transform where Value == Swift.Int {
 extension Holder.Transform where Value == Int {
     // CHECK-NEXT: public func negate(_ holder: main.Holder<Value>) -> Result{{$}}
     public func negate(_ holder: Holder<Value>) -> Result {

--- a/test/SPI/experimental_spi_imports_swiftinterface.swift
+++ b/test/SPI/experimental_spi_imports_swiftinterface.swift
@@ -29,5 +29,5 @@
 extension IOIPublicStruct {
   public func foo() {}
 }
-// CHECK-PUBLIC-NOT: IOIPublicStruct
-// CHECK-PRIVATE: @_spi{{.*}} extension IOIPublicStruct
+// CHECK-PUBLIC-NOT: ExperimentalImported.IOIPublicStruct
+// CHECK-PRIVATE: @_spi{{.*}} extension ExperimentalImported.IOIPublicStruct

--- a/test/SPI/private_swiftinterface.swift
+++ b/test/SPI/private_swiftinterface.swift
@@ -73,8 +73,8 @@ public func foo() {}
 }
 
 @_spi(MySPI) public extension SPIClassLocal {
-// CHECK-PRIVATE: @_spi(MySPI) extension SPIClassLocal
-// CHECK-PUBLIC-NOT: extension SPIClassLocal
+// CHECK-PRIVATE: @_spi(MySPI) extension {{.+}}.SPIClassLocal
+// CHECK-PUBLIC-NOT: extension {{.+}}.SPIClassLocal
 
   @_spi(MySPI) func extensionMethod() {}
   // CHECK-PRIVATE: @_spi(MySPI) public func extensionMethod
@@ -110,8 +110,8 @@ private class PrivateClassLocal {}
 // CHECK-PUBLIC-NOT: useOfSPITypeOk
 
 @_spi(LocalSPI) extension SPIClass {
-  // CHECK-PRIVATE: @_spi(LocalSPI) extension SPIClass
-  // CHECK-PUBLIC-NOT: SPIClass
+  // CHECK-PRIVATE: @_spi(LocalSPI) extension SPIHelper.SPIClass
+  // CHECK-PUBLIC-NOT: SPIHelper.SPIClass
 
   @_spi(LocalSPI) public func extensionSPIMethod() {}
   // CHECK-PRIVATE: @_spi(LocalSPI) public func extensionSPIMethod()
@@ -182,7 +182,7 @@ private protocol PrivateConstraint {}
 
 @_spi(LocalSPI)
 extension PublicType: SPIProto2 where T: SPIProto2 {}
-// CHECK-PRIVATE: extension PublicType : {{.*}}.SPIProto2 where T : {{.*}}.SPIProto2
+// CHECK-PRIVATE: extension {{.*}}.PublicType : {{.*}}.SPIProto2 where T : {{.*}}.SPIProto2
 // CHECK-PUBLIC-NOT: _ConstraintThatIsNotPartOfTheAPIOfThisLibrary
 
 public protocol LocalPublicProto {}

--- a/test/SourceKit/CodeComplete/Inputs/parseable-interface/MyPointExtensions.swift
+++ b/test/SourceKit/CodeComplete/Inputs/parseable-interface/MyPointExtensions.swift
@@ -1,4 +1,4 @@
-import MyPoint
+import MyPointModule
 
 public extension MyPoint {
 	var magnitude: Double {

--- a/test/SourceKit/CodeComplete/complete_swiftinterface.swift
+++ b/test/SourceKit/CodeComplete/complete_swiftinterface.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t/modulecache)
 
 // 1) Build .swiftinterface files for MyPoint and MyExtensions, using a non-default module cache path
-// RUN: %target-swift-frontend -emit-module-interface-path %t/MyPoint.swiftinterface -module-name MyPoint -emit-module -o /dev/null %S/Inputs/parseable-interface/MyPoint.swift
+// RUN: %target-swift-frontend -emit-module-interface-path %t/MyPointModule.swiftinterface -module-name MyPointModule -emit-module -o /dev/null %S/Inputs/parseable-interface/MyPoint.swift
 // RUN: %target-swift-frontend -emit-module-interface-path %t/MyPointExtensions.swiftinterface -module-name MyPointExtensions -emit-module -o /dev/null -module-cache-path %t/modulecache -I %t %S/Inputs/parseable-interface/MyPointExtensions.swift
 // RUN: %empty-directory(%t/modulecache)
 
@@ -12,7 +12,7 @@
 // 3) Check completion again with a warm module cache
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=MEMBER -source-filename %s -I %t | %FileCheck %s
 
-import MyPoint
+import MyPointModule
 import MyPointExtensions
 
 let x = MyPoint(x: 1, y: 10.5)


### PR DESCRIPTION
Fixes rdar://79093752.

Not sure why `Options.FullyQualifiedTypesIfAmbiguous` was set to `false` in the first place (I would think that setting should always be true apart from debugging?).