### PR TITLE
Fix actor init diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1529,7 +1529,7 @@ NOTE(requires_stored_property_inits_here,none,
      "%select{superclass|class}1 %0 requires all stored properties to have "
      "initial values%select{| or use @NSManaged}2", (Type, bool, bool))
 ERROR(class_without_init,none,
-      "class %0 has no initializers", (Type))
+      "%select{class|actor}0 %1 has no initializers", (bool, Type))
 NOTE(note_no_in_class_init_1,none,
      "stored property %0 without initial value prevents synthesized "
      "initializers",

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1225,6 +1225,7 @@ static std::string getFixItStringForDecodable(ClassDecl *CD,
 static void diagnoseClassWithoutInitializers(ClassDecl *classDecl) {
   ASTContext &C = classDecl->getASTContext();
   C.Diags.diagnose(classDecl, diag::class_without_init,
+                   classDecl->isExplicitActor(),
                    classDecl->getDeclaredType());
 
   // HACK: We've got a special case to look out for and diagnose specifically to

--- a/test/Distributed/distributed_actor_is_experimental.swift
+++ b/test/Distributed/distributed_actor_is_experimental.swift
@@ -6,7 +6,7 @@ actor SomeActor {}
 
 @available(SwiftStdlib 5.5, *)
 distributed actor DA {} // expected-error{{'_Distributed' module not imported, required for 'distributed actor'}}
-// expected-error@-1{{class 'DA' has no initializers}}
+// expected-error@-1{{actor 'DA' has no initializers}}
 
 @available(SwiftStdlib 5.5, *)
 distributed actor class DAC {} // expected-error{{distributed' can only be applied to 'actor' definitions, and distributed actor-isolated async functions}}
@@ -24,7 +24,7 @@ actor A {
 
 @available(SwiftStdlib 5.5, *)
 distributed actor DA2 { // expected-error{{'_Distributed' module not imported, required for 'distributed actor'}}
-  // expected-error@-1{{class 'DA2' has no initializers}}
+  // expected-error@-1{{actor 'DA2' has no initializers}}
   func normal() async {}
   distributed func dist() {}
   distributed func distAsync() async {}

--- a/test/Distributed/distributed_missing_import.swift
+++ b/test/Distributed/distributed_missing_import.swift
@@ -6,7 +6,7 @@ actor SomeActor { }
 
 @available(SwiftStdlib 5.5, *)
 distributed actor MissingImportDistributedActor_0 { } // expected-error{{'_Distributed' module not imported, required for 'distributed actor'}}
-// expected-error@-1{{class 'MissingImportDistributedActor_0' has no initializers}}
+// expected-error@-1{{actor 'MissingImportDistributedActor_0' has no initializers}}
 
 let t: ActorTransport // expected-error{{cannot find type 'ActorTransport' in scope}}
 let a: ActorAddress // expected-error{{cannot find type 'ActorAddress' in scope}}

--- a/test/decl/var/default_init.swift
+++ b/test/decl/var/default_init.swift
@@ -51,3 +51,12 @@ func testBadDefaultInit() {
   _ = NotInitializableOptionalStruct() // expected-error {{missing argument for parameter 'opt' in call}}
   _ = NotInitializableOptionalClass() // expected-error {{'NotInitializableOptionalClass' cannot be constructed because it has no accessible initializers}}
 }
+
+// expected-error@+1{{actor 'NotInitializableActor' has no initializers}}
+actor NotInitializableActor {
+
+  // expected-note@+1{{stored property 'a' without initial value prevents synthesized initializers}}
+  var a: Int
+  // expected-note@+1{{stored property 'b' without initial value prevents synthesized initializers}}
+  var b: Float
+}


### PR DESCRIPTION
Instead of referring to the actor as a class that is missing the
initializer, call it an actor.

Fixes: rdar://78774336