### PR TITLE
<rdar://64939529> Convert unnecessary dlsym() calls into direct refs

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -20,6 +20,39 @@
 #include "swift/Basic/Compiler.h"
 #include "swift/Runtime/CMakeConfig.h"
 
+/// SWIFT_RUNTIME_WEAK_IMPORT - Marks a symbol for weak import.
+#if (__has_attribute(weak_import))
+#define SWIFT_RUNTIME_WEAK_IMPORT __attribute__((weak_import))
+#else
+#define SWIFT_RUNTIME_WEAK_IMPORT
+#endif
+
+/// SWIFT_RUNTIME_WEAK_CHECK - Tests if a potentially weakly linked function
+/// is linked into the runtime.  This is useful on Apple platforms where it is
+/// possible that system functions are only available on newer versions.
+#ifdef __clang__
+#define SWIFT_RUNTIME_WEAK_CHECK(x)                                     \
+  _Pragma("clang diagnostic push")                                      \
+  _Pragma("clang diagnostic ignored \"-Wunguarded-availability\"")      \
+  _Pragma("clang diagnostic ignored \"-Wunguarded-availability-new\"")  \
+  (&x)                                                                  \
+  _Pragma("clang diagnostic pop")
+#else
+#define SWIFT_RUNTIME_WEAK_CHECK(x) &x
+#endif
+
+/// SWIFT_RUNTIME_WEAK_USE - Use a potentially weakly imported symbol.
+#ifdef __clang__
+#define SWIFT_RUNTIME_WEAK_USE(x)                                       \
+  _Pragma("clang diagnostic push")                                      \
+  _Pragma("clang diagnostic ignored \"-Wunguarded-availability\"")      \
+  _Pragma("clang diagnostic ignored \"-Wunguarded-availability-new\"")  \
+  (x)                                                                   \
+  _Pragma("clang diagnostic pop")
+#else
+#define SWIFT_RUNTIME_WEAK_USE(x) x
+#endif
+
 /// SWIFT_RUNTIME_LIBRARY_VISIBILITY - If a class marked with this attribute is
 /// linked into a shared library, then the class should be private to the
 /// library and not accessible from outside it.  Can also be used to mark

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -694,24 +694,22 @@ void swift::swift_rootObjCDealloc(HeapObject *self) {
 }
 #endif
 
-#if SWIFT_OBJC_INTEROP
-static bool _check_fast_dealloc() {
-  return dlsym(RTLD_NEXT, "_objc_has_weak_formation_callout") != nullptr;
-}
-#endif
-
 void swift::swift_deallocClassInstance(HeapObject *object,
                                        size_t allocatedSize,
                                        size_t allocatedAlignMask) {
-  
 #if SWIFT_OBJC_INTEROP
   // We need to let the ObjC runtime clean up any associated objects or weak
   // references associated with this object.
-  const bool fastDeallocSupported = SWIFT_LAZY_CONSTANT(_check_fast_dealloc());
+#if !TARGET_OS_SIMULATOR || !__x86_64__
+  const bool fastDeallocSupported = true;
+#else
+  const bool fastDeallocSupported = false;
+#endif
   if (!fastDeallocSupported || !object->refCounts.getPureSwiftDeallocation()) {
     objc_destructInstance((id)object);
   }
 #endif
+
   swift_deallocObject(object, allocatedSize, allocatedAlignMask);
 }
 

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1959,23 +1959,9 @@ getObjCClassByMangledName(const char * _Nonnull typeName,
 
 __attribute__((constructor))
 static void installGetClassHook() {
-  // FIXME: delete this #if and dlsym once we don't
-  // need to build with older libobjc headers
-#if !OBJC_GETCLASSHOOK_DEFINED
-  using objc_hook_getClass =  BOOL(*)(const char * _Nonnull name,
-                                      Class _Nullable * _Nonnull outClass);
-  auto objc_setHook_getClass =
-    (void(*)(objc_hook_getClass _Nonnull,
-             objc_hook_getClass _Nullable * _Nonnull))
-    dlsym(RTLD_DEFAULT, "objc_setHook_getClass");
-#endif
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
-  if (&objc_setHook_getClass) {
-    objc_setHook_getClass(getObjCClassByMangledName, &OldGetClassHook);
+  if (SWIFT_RUNTIME_WEAK_CHECK(objc_setHook_getClass)) {
+    SWIFT_RUNTIME_WEAK_USE(objc_setHook_getClass(getObjCClassByMangledName, &OldGetClassHook));
   }
-#pragma clang diagnostic pop
 }
 
 #endif

--- a/stdlib/public/stubs/Availability.mm
+++ b/stdlib/public/stubs/Availability.mm
@@ -21,7 +21,6 @@
 #include "swift/Runtime/Debug.h"
 #include <TargetConditionals.h>
 #include "../SwiftShims/FoundationShims.h"
-#include <dlfcn.h>
 
 struct os_system_version_s {
     unsigned int major;
@@ -29,13 +28,12 @@ struct os_system_version_s {
     unsigned int patch;
 };
 
+// This is in libSystem, so it's OK to refer to it directly here
+extern "C" int os_system_version_get_current_version(struct os_system_version_s * _Nonnull) SWIFT_RUNTIME_WEAK_IMPORT;
+
 static os_system_version_s getOSVersion() {
-  auto lookup =
-    (int(*)(struct os_system_version_s * _Nonnull))
-    dlsym(RTLD_DEFAULT, "os_system_version_get_current_version");
-  
   struct os_system_version_s vers = { 0, 0, 0 };
-  lookup(&vers);
+  os_system_version_get_current_version(&vers);
   return vers;
 }
 


### PR DESCRIPTION
Added `SWIFT_RUNTIME_WEAK_IMPORT/CHECK/USE` macros.

Everything supports fast dealloc except x86 iOS simulators, so we no longer need to look up `objc_has_weak_formation_callout`.

Added direct references for

    objc_setHook_lazyClassNamer()
    _objc_realizeClassFromSwift()
    objc_setHook_getClass()
    os_system_version_get_current_version()
    _dyld_is_objc_constant()

The idea here is to avoid making `dlsym()` calls, thereby improving performance.