### PR TITLE
Add missing distributed requirement to test

### DIFF
--- a/test/Distributed/distributed_actor_is_experimental.swift
+++ b/test/Distributed/distributed_actor_is_experimental.swift
@@ -1,6 +1,7 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
 // ^^^^ notice the, on purpose, missing '-enable-experimental-distributed'
 // REQUIRES: concurrency
+// REQUIRES: distributed
 
 actor SomeActor {}
 


### PR DESCRIPTION
The distributed_actor_is_experimental.swift test was missing the distributed requirement.