### PR TITLE
[Diagnostics] Make sure extension type repr is available before using it

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1315,6 +1315,9 @@ public:
   bool alreadyBoundToNominal() const { return NextExtension.getInt(); }
 
   /// Retrieve the extended type definition as written in the source, if it exists.
+  ///
+  /// Repr would not be available if the extension was been loaded
+  /// from a serialized module.
   TypeRepr *getExtendedTypeRepr() const { return ExtendedTypeRepr; }
                               
   /// Retrieve the set of protocols that this type inherits (i.e,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7432,9 +7432,15 @@ bool InvalidMemberRefOnProtocolMetatype::diagnoseAsError() {
   if (auto *whereClause = extension->getTrailingWhereClause()) {
     auto sourceRange = whereClause->getSourceRange();
     note.fixItInsertAfter(sourceRange.End, ", Self == <#Type#> ");
-  } else {
-    auto nameRepr = extension->getExtendedTypeRepr();
-    note.fixItInsertAfter(nameRepr->getEndLoc(), " where Self == <#Type#>");
+  } else if (auto nameRepr = extension->getExtendedTypeRepr()) {
+    // Type repr is not always available so we need to be defensive
+    // about its presence and validity.
+    if (nameRepr->isInvalid()))
+      return true;
+
+    if (auto noteLoc = nameRepr->getEndLoc()) {
+      note.fixItInsertAfter(noteLoc, " where Self == <#Type#>");
+    }
   }
 
   return true;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7435,7 +7435,7 @@ bool InvalidMemberRefOnProtocolMetatype::diagnoseAsError() {
   } else if (auto nameRepr = extension->getExtendedTypeRepr()) {
     // Type repr is not always available so we need to be defensive
     // about its presence and validity.
-    if (nameRepr->isInvalid()))
+    if (nameRepr->isInvalid())
       return true;
 
     if (auto noteLoc = nameRepr->getEndLoc()) {


### PR DESCRIPTION
Before suggesting to add `where Self == ...` condition to the extension
of a protocol involved in a static member lookup, let's check whether
type repr is available and valid. It might not be available when e.g. extension
was loaded from a serialized module.

Resolves: rdar://78097387

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
