### PR TITLE
"Defer" blocks are as isolated as their enclosing contexts.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1406,6 +1406,12 @@ namespace {
           }
         }
 
+        // "Defer" blocks are treated as if they are in their enclosing context.
+        if (auto func = dyn_cast<FuncDecl>(dc)) {
+          if (func->isDeferBody())
+            continue;
+        }
+
         // Check isolation of the context itself. We do this separately
         // from the closure check because closures capture specific variables
         // while general isolation is declaration-based.

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -834,3 +834,16 @@ func test_invalid_reference_to_actor_member_without_a_call_note() {
     }
   }
 }
+
+// Actor isolation and "defer"
+actor Counter {
+  var counter: Int = 0
+
+  func next() -> Int {
+    defer {
+      counter = counter + 1
+    }
+
+    return counter
+  }
+}


### PR DESCRIPTION
Fixes a regression I introduced recently, rdar://79200626.
