### PR TITLE
Strip i386 arch from tvOS simulator lib

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1447,7 +1447,11 @@ function copy_embedded_compiler_rt_builtins_from_darwin_host_toolchain() {
                 DEST_LIB_PATH="${DEST_BUILTINS_DIR}/${LIB_NAME}"
                 if [[ ! -f "${DEST_LIB_PATH}" ]]; then
                     if [[ -f "${HOST_LIB_PATH}" ]]; then
-                        call cp "${HOST_LIB_PATH}" "${DEST_LIB_PATH}"
+                        if [[ "$OS" == "tvos" ]]; then
+                            call lipo -remove i386 "${HOST_LIB_PATH}" -output "${DEST_LIB_PATH}" || call cp "${HOST_LIB_PATH}" "${DEST_LIB_PATH}"
+                        else
+                           call cp "${HOST_LIB_PATH}" "${DEST_LIB_PATH}"
+                        fi
                     elif [[ "${VERBOSE_BUILD}" ]]; then
                         echo "no file exists at ${HOST_LIB_PATH}"
                     fi
@@ -1459,7 +1463,11 @@ function copy_embedded_compiler_rt_builtins_from_darwin_host_toolchain() {
                 DEST_SIM_LIB_PATH="${DEST_BUILTINS_DIR}/${SIM_LIB_NAME}"
                 if [[ ! -f "${DEST_SIM_LIB_PATH}" ]]; then
                     if [[ -f "${HOST_SIM_LIB_PATH}" ]]; then
-                        call cp "${HOST_SIM_LIB_PATH}" "${DEST_SIM_LIB_PATH}"
+                        if [[ "$OS" == "tvos" ]]; then
+                            call lipo -remove i386 "${HOST_SIM_LIB_PATH}" -output "${DEST_SIM_LIB_PATH}" || call cp "${HOST_SIM_LIB_PATH}" "${DEST_SIM_LIB_PATH}"
+                        else
+                            call cp "${HOST_SIM_LIB_PATH}" "${DEST_SIM_LIB_PATH}"
+                        fi
                     elif [[ -f "${HOST_LIB_PATH}" ]]; then
                         # The simulator .a might not exist if the host
                         # Xcode is old. In that case, copy over the


### PR DESCRIPTION
(cherry picked from commit a8ae401d0a2f2313b4f8254d94682dcce73e7af8)

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
