### PR TITLE
[SR-14638] Using associated value labels in enum case lookup.

### DIFF
--- a/test/Sema/enum_same_case_names.swift
+++ b/test/Sema/enum_same_case_names.swift
@@ -1,0 +1,32 @@
+// RUN: %target-typecheck-verify-swift -parse-stdlib
+// tests the ability to switch over an enum with same named cases that differ in associated value labels and types
+
+struct A {}
+struct C {}
+
+enum B {
+    case a(A)
+    case a(a: A)
+    case a(b: A)
+    case a(c: C)
+}
+
+let a: B = .a(b: A())
+
+switch a {
+case .a(_): break
+case .a(c: _): break
+default: break
+}
+
+switch a {
+case .a(a: _): break
+case .a(c: _): break
+default: break
+}
+
+switch a {
+case .a(b: _): break
+case .a(c: _): break
+default: break
+}


### PR DESCRIPTION
This PR addresses part of the umbrella bug SR-14638.

Specifically SR-12229, SR-11159 and a comment on SR-9014. It does not resolve the issues (Part 2 is needed for the first 2 and Part 3 for the third), but there are cases where the compiler accepts code that it did not before, therefore it might make sense to merge this separately.

I anticipate making 4 PRs in the following order:
- Part 1 (this): Updating the enum case lookup mechanism using associated value labels to reduce ambiguities.
- Part 2: Updating the switch exhaustiveness matching algorithm to support associated value labels (for cases with same labels).
- Part 3: Updating CSSolver to take associated value labels into account - my initial investigation concluded that the solver sees all matching enum cases (base on the case label) as candidates and assigns them the same score, therefore cannot pick the best match and fails with ambiguous result. I believe that updating the scoring mechanism to take associated value labels into account could solve the problem.
- Part 4: Update the mangling method to include associated value labels (most likely only where there would be a conflict with the old method to maintain backwards compatibility).

There is a potential Part 5 regarding whole module optimization. I have been unable to reproduce this issue so far, I am assuming that it might have been already fixed.

#### The idea behind this PR:
For each case in a switch, the compiler performs a lookup of the matching enum case. Currently the compiler disregards the labels of associated values which sometimes leads to ambiguities.

When the original lookup method returns 0 or 1 potential matches, this PR does not change anything.

When the original lookup finds multiple potential matches, it crashes in assert mode and uses the last match in non-assert mode.

The updated method uses the associated value labels to filter the potential matches.
1) When the filter finds 0 results, the lookup fails. The behavior I have observed in the compiler on code that triggered this path is that the compiler produces an ambiguous diagnostic - no exact match found.
2) When the filter finds 1 result, that is a success and that result is used.
3) When the filter still finds multiple results, the original behavior is kept, i.e. crash in assert mode and use last in non-assert mode.

I have collected 12 code samples from the tickets and included a comparison of compiler output in this gist:
https://gist.github.com/jirid/81e44ad7a2d231cab14f3752497fa89f

When I run the default test suite on the main branch on my computer (arm64 mac), I currently get 28 failures. I get the same failures when I run the tests on my branch, therefore I am concluding that the test failures are not related to my changes.

#### I am looking for feedback in the following areas:
- Is the general idea behind the change reasonable and does it preserve the required backwards compatibility?
- Are the assumptions I made valid?
- Is the implementation correct?
- What should be refactored? What does not match the expected code style?
