### PR TITLE
[5.5] [Async Refactoring] Add @discardableResult for defaulted completion

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -4422,6 +4422,14 @@ struct AsyncHandlerParamDesc : public AsyncHandlerDesc {
     OS << tok::r_paren;
   }
 
+  /// Retrieves the parameter decl for the completion handler parameter, or
+  /// \c nullptr if no valid completion parameter is present.
+  const ParamDecl *getHandlerParam() const {
+    if (!isValid())
+      return nullptr;
+    return Func->getParameters()->get(Index);
+  }
+
   bool operator==(const AsyncHandlerParamDesc &Other) const {
     return Handler == Other.Handler && Type == Other.Type &&
            HasError == Other.HasError && Index == Other.Index;
@@ -6292,6 +6300,13 @@ private:
 
   void addFuncDecl(const FuncDecl *FD) {
     auto *Params = FD->getParameters();
+    auto *HandlerParam = TopHandler.getHandlerParam();
+
+    // If the completion handler parameter has a default argument, the async
+    // version is effectively @discardableResult, as not all the callers care
+    // about receiving the completion call.
+    if (HandlerParam && HandlerParam->isDefaultArgument())
+      OS << tok::at_sign << "discardableResult" << "\n";
 
     // First chunk: start -> the parameter to remove (if any)
     SourceLoc LeftEndLoc = Params->getLParenLoc().getAdvancedLoc(1);


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/37882

-----

If the completion handler parameter has a default
argument, mark the resulting async function as
`@discardableResult`, as the caller may not care
about the result.

rdar://79190170