### PR TITLE
[Diagnostics] Offer 'is' replacement for unused 'if let' expression with optional operand

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2893,7 +2893,20 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
                       !initExpr->isImplicit()) {
                     noParens = isIsTest = true;
                   }
-                  
+                  // In cases where the value is optional, the cast expr is
+                  // wrapped inside OptionalEvaluationExpr. Unwrap it to get
+                  // ConditionalCheckedCastExpr.
+                  if (auto oeExpr =
+                          dyn_cast<OptionalEvaluationExpr>(initExpr)) {
+                    if (auto ccExpr = dyn_cast<ConditionalCheckedCastExpr>(
+                            oeExpr->getSubExpr())) {
+                      if (!ccExpr->isImplicit()) {
+                        initExpr = ccExpr;
+                        noParens = isIsTest = true;
+                      }
+                    }
+                  }
+
                   auto diagIF = Diags.diagnose(var->getLoc(),
                                                diag::pbd_never_used_stmtcond,
                                             var->getName());

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2888,21 +2888,27 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
                   
                   // If the subexpr is an "as?" cast, we can rewrite it to
                   // be an "is" test.
-                  bool isIsTest = false;
-                  if (isa<ConditionalCheckedCastExpr>(initExpr) &&
-                      !initExpr->isImplicit()) {
-                    noParens = isIsTest = true;
+                  ConditionalCheckedCastExpr *CCE = nullptr;
+
+                  // initExpr can be wrapped inside parens or try expressions.
+                  if (auto ccExpr = dyn_cast<ConditionalCheckedCastExpr>(
+                          initExpr->getValueProvidingExpr())) {
+                    if (!ccExpr->isImplicit()) {
+                      CCE = ccExpr;
+                      noParens = true;
+                    }
                   }
+
                   // In cases where the value is optional, the cast expr is
                   // wrapped inside OptionalEvaluationExpr. Unwrap it to get
                   // ConditionalCheckedCastExpr.
-                  if (auto oeExpr =
-                          dyn_cast<OptionalEvaluationExpr>(initExpr)) {
+                  if (auto oeExpr = dyn_cast<OptionalEvaluationExpr>(
+                          initExpr->getValueProvidingExpr())) {
                     if (auto ccExpr = dyn_cast<ConditionalCheckedCastExpr>(
-                            oeExpr->getSubExpr())) {
+                            oeExpr->getSubExpr()->getValueProvidingExpr())) {
                       if (!ccExpr->isImplicit()) {
-                        initExpr = ccExpr;
-                        noParens = isIsTest = true;
+                        CCE = ccExpr;
+                        noParens = true;
                       }
                     }
                   }
@@ -2914,10 +2920,9 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
                   diagIF.fixItReplaceChars(introducerLoc,
                                            initExpr->getStartLoc(),
                                            &"("[noParens]);
-                  
-                  if (isIsTest) {
+
+                  if (CCE) {
                     // If this was an "x as? T" check, rewrite it to "x is T".
-                    auto CCE = cast<ConditionalCheckedCastExpr>(initExpr);
                     diagIF.fixItReplace(SourceRange(CCE->getLoc(),
                                                     CCE->getQuestionLoc()),
                                         "is");

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -540,7 +540,7 @@ func testVariablesBoundInPatterns() {
     break
   }
 }
-// Tests fix to SR-1464
+// Tests fix to SR-14646
 func testUselessCastWithInvalidParam(foo: Any?) -> Int {
   class Foo { }
   if let bar = foo as? Foo { return 42 } // expected-warning {{value 'bar' was defined but never used; consider replacing with boolean test}} {{6-16=}} {{20-23=is}}

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -330,6 +330,11 @@ func test(_ a : Int?, b : Any) {
   if let x = b as? Int {  // expected-warning {{value 'x' was defined but never used; consider replacing with boolean test}} {{6-14=}} {{16-19=is}}
   }
 
+  // SR-14646. Special case, turn this into an 'is' test with optional value. 
+  let bb: Any? = 3
+  if let bbb = bb as? Int {  // expected-warning {{value 'bbb' was defined but never used; consider replacing with boolean test}} {{6-16=}} {{19-22=is}}
+  }
+
   // SR-1112
 
   let xxx: Int? = 0
@@ -356,7 +361,7 @@ let optionalString: String? = "check"
 if let string = optionalString {}  // expected-warning {{value 'string' was defined but never used; consider replacing with boolean test}} {{4-17=}} {{31-31= != nil}}
 
 let optionalAny: Any? = "check"
-if let string = optionalAny as? String {} // expected-warning {{value 'string' was defined but never used; consider replacing with boolean test}} {{4-17=(}} {{39-39=) != nil}}
+if let string = optionalAny as? String {} // expected-warning {{value 'string' was defined but never used; consider replacing with boolean test}} {{4-17=}} {{29-32=is}}
 
 // Due to the complexities of global variable tracing, these will not generate warnings
 let unusedVariable = ""
@@ -503,4 +508,10 @@ func testVariablesBoundInPatterns() {
   case let .optional(b: .none): // expected-warning {{'let' pattern has no effect; sub-pattern didn't bind any variables}} {{8-12=}}
     break
   }
+}
+// Tests fix to SR-1464
+func testUselessCastWithInvalidParam(foo: Any?) -> Int {
+  class Foo { }
+  if let bar = foo as? Foo { return 42 } // expected-warning {{value 'bar' was defined but never used; consider replacing with boolean test}} {{6-16=}} {{20-23=is}}
+  else { return 54 }
 }

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -332,11 +332,42 @@ func test(_ a : Int?, b : Any) {
 
   // SR-14646. Special case, turn this into an 'is' test with optional value. 
   let bb: Any? = 3
-  if let bbb = bb as? Int {  // expected-warning {{value 'bbb' was defined but never used; consider replacing with boolean test}} {{6-16=}} {{19-22=is}}
-  }
+  if let bbb = bb as? Int {}  // expected-warning {{value 'bbb' was defined but never used; consider replacing with boolean test}} {{6-16=}} {{19-22=is}}
+  if let bbb = (bb) as? Int {}  // expected-warning {{value 'bbb' was defined but never used; consider replacing with boolean test}} {{6-16=}} {{21-24=is}}
+
+  func aa() -> Any? { return 1 }
+  if let aaa = aa() as? Int {} // expected-warning {{value 'aaa' was defined but never used; consider replacing with boolean test}} {{6-16=}} {{21-24=is}}
+  if let aaa = (aa()) as? Int {} // expected-warning {{value 'aaa' was defined but never used; consider replacing with boolean test}} {{6-16=}} {{23-26=is}}
+
+  func bb() -> Any { return 1 }
+  if let aaa = aa() as? Int {} // expected-warning {{value 'aaa' was defined but never used; consider replacing with boolean test}} {{6-16=}} {{21-24=is}}
+  if let aaa = (aa()) as? Int {} // expected-warning {{value 'aaa' was defined but never used; consider replacing with boolean test}} {{6-16=}} {{23-26=is}}
+
+
+  func throwingAA() throws -> Any? { return 1 }
+  do {
+    if let aaa = try! throwingAA() as? Int {} // expected-warning {{value 'aaa' was defined but never used; consider replacing with boolean test}} {{8-18=}} {{36-39=is}}
+    if let aaa = (try! throwingAA()) as? Int {} // expected-warning {{value 'aaa' was defined but never used; consider replacing with boolean test}} {{8-18=}} {{38-41=is}}
+    if let aaa = try throwingAA() as? Int {} // expected-warning {{value 'aaa' was defined but never used; consider replacing with boolean test}} {{8-18=}} {{35-38=is}}
+    if let aaa = (try throwingAA()) as? Int {} // expected-warning {{value 'aaa' was defined but never used; consider replacing with boolean test}} {{8-18=}} {{37-40=is}}
+  } catch { }
+  if let aaa = try? throwingAA() as? Int {} // expected-warning {{value 'aaa' was defined but never used; consider replacing with boolean test}} {{6-16=(}} {{41-41=) != nil}}
+  if let aaa = (try? throwingAA()) as? Int {} // expected-warning {{value 'aaa' was defined but never used; consider replacing with boolean test}} {{6-16=}} {{36-39=is}}
+  
+  func throwingBB() throws -> Any { return 1 }
+  do { 
+    if let bbb = try! throwingBB() as? Int {} // expected-warning {{value 'bbb' was defined but never used; consider replacing with boolean test}} {{8-18=}} {{36-39=is}}
+    if let bbb = (try! throwingBB()) as? Int {} // expected-warning {{value 'bbb' was defined but never used; consider replacing with boolean test}} {{8-18=}} {{38-41=is}}
+    if let bbb = try throwingBB() as? Int {} // expected-warning {{value 'bbb' was defined but never used; consider replacing with boolean test}} {{8-18=}} {{35-38=is}}
+    if let bbb = (try throwingBB()) as? Int {} // expected-warning {{value 'bbb' was defined but never used; consider replacing with boolean test}} {{8-18=}} {{37-40=is}}
+  } catch { }
+  if let bbb = try? throwingBB() as? Int {} // expected-warning {{value 'bbb' was defined but never used; consider replacing with boolean test}} {{6-16=(}} {{41-41=) != nil}}
+  if let bbb = (try? throwingBB()) as? Int {} // expected-warning {{value 'bbb' was defined but never used; consider replacing with boolean test}} {{6-16=}} {{36-39=is}}
+
+  let cc: (Any?, Any) = (1, 2)
+  if let (cc1, cc2) = cc as? (Int, Int) {} // expected-warning {{immutable value 'cc1' was never used; consider replacing with '_' or removing it}} expected-warning {{immutable value 'cc2' was never used; consider replacing with '_' or removing it}}
 
   // SR-1112
-
   let xxx: Int? = 0
 
   if let yyy = xxx { } // expected-warning{{with boolean test}} {{6-16=}} {{19-19= != nil}}

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -59,8 +59,8 @@ if let x = foo() {
 
 var opt: Int? = .none
 
-if let x = opt {} // expected-warning {{value 'x' was defined but never used; consider replacing with boolean test}}
-if var x = opt {} // expected-warning {{value 'x' was defined but never used; consider replacing with boolean test}}
+if let x = opt {} // expected-warning {{value 'x' was defined but never used; consider replacing with boolean test}} {{4-12=}} {{15-15= != nil}}
+if var x = opt {} // expected-warning {{value 'x' was defined but never used; consider replacing with boolean test}} {{4-12=}} {{15-15= != nil}}
 
 // <rdar://problem/20800015> Fix error message for invalid if-let
 let someInteger = 1


### PR DESCRIPTION
```
let foo: Any? = 42 as Int

// current fix-it: Replace 'let bar = foo as? Int' with '(foo as? Int) != nil'
// better fix-it: Replace 'let bar = foo as? Int' with 'foo is Int'

if let bar = foo as? Int { 
    print("'foo' is of type 'Int'")
}
```
Currently, the above code does not produce the better fix-it for replacing the expression with `is` because the expression was wrapped inside `OptionalEvaluationExpr`.

This PR enables optional typed values to produce `is` replacement fixit. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-14646](https://bugs.swift.org/browse/SR-14646)