### PR TITLE
Result init by async throws closure

### DIFF
--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -185,7 +185,10 @@ extension Result where Failure == Swift.Error {
       self = .failure(error)
     }
   }
-  
+  /// Creates a new result by evaluating a async throwing closure, capturing the
+  /// returned value as a success, or any thrown error as a failure.
+  ///
+  /// - Parameter body: A async throwing closure to evaluate.
   public init (catching body: () async throws -> Success) async {
         do {
             self = .success(try await body())

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -185,6 +185,14 @@ extension Result where Failure == Swift.Error {
       self = .failure(error)
     }
   }
+  
+  public init (catching body: () async throws -> Success) async {
+        do {
+            self = .success(try await body())
+        }catch {
+            self = .failure(error)
+        }
+    }
 }
 
 extension Result: Equatable where Success: Equatable, Failure: Equatable { }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Add async support to Result, using with await

```swift
let result = await Result {
 try await asyncFunction()
}
```



<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
