### PR TITLE
[5.5] Fix actor init diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1526,7 +1526,7 @@ NOTE(requires_stored_property_inits_here,none,
      "%select{superclass|class}1 %0 requires all stored properties to have "
      "initial values%select{| or use @NSManaged}2", (Type, bool, bool))
 ERROR(class_without_init,none,
-      "class %0 has no initializers", (Type))
+      "%select{class|actor}0 %1 has no initializers", (bool, Type))
 NOTE(note_no_in_class_init_1,none,
      "stored property %0 without initial value prevents synthesized "
      "initializers",

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1218,6 +1218,7 @@ static std::string getFixItStringForDecodable(ClassDecl *CD,
 static void diagnoseClassWithoutInitializers(ClassDecl *classDecl) {
   ASTContext &C = classDecl->getASTContext();
   C.Diags.diagnose(classDecl, diag::class_without_init,
+                   classDecl->isExplicitActor(),
                    classDecl->getDeclaredType());
 
   // HACK: We've got a special case to look out for and diagnose specifically to

--- a/test/decl/var/default_init.swift
+++ b/test/decl/var/default_init.swift
@@ -51,3 +51,12 @@ func testBadDefaultInit() {
   _ = NotInitializableOptionalStruct() // expected-error {{missing argument for parameter 'opt' in call}}
   _ = NotInitializableOptionalClass() // expected-error {{'NotInitializableOptionalClass' cannot be constructed because it has no accessible initializers}}
 }
+
+// expected-error@+1{{actor 'NotInitializableActor' has no initializers}}
+actor NotInitializableActor {
+
+  // expected-note@+1{{stored property 'a' without initial value prevents synthesized initializers}}
+  var a: Int
+  // expected-note@+1{{stored property 'b' without initial value prevents synthesized initializers}}
+  var b: Float
+}


### PR DESCRIPTION
**Explanation:** Fix initializer diagnostic to say "actor" when referencing an actor rather than "class" all of the time.
**Scope:** 
**Radar/SR Issue:** rdar://78774336
**Risk:** Very Low
**Testing:** PR testing and CI on main -- added test to verify error message.
**Original PR:** https://github.com/apple/swift/pull/37880
**Reviewers:** Holly Borla, and Konrad reviewed and approved this PR.