### PR TITLE
[ModuleInterface] Fix implementation-only imported type leak in indirect conformance

### DIFF
--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -562,7 +562,8 @@ public:
           return TypeWalker::Action::Continue;
 
         if (isPublicOrUsableFromInline(inherited) &&
-            conformanceDeclaredInModule(M, nominal, inherited)) {
+            conformanceDeclaredInModule(M, nominal, inherited) &&
+            !M->isImportedImplementationOnly(inherited->getParentModule())) {
           protocolsToPrint.push_back({inherited, protoAndAvailability.second});
           return TypeWalker::Action::SkipChildren;
         }

--- a/test/ModuleInterface/indirect-conformance-implementation-only.swift
+++ b/test/ModuleInterface/indirect-conformance-implementation-only.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -emit-module %t/SecretLib.swift -o %t/SecretLib.swiftmodule
+// RUN: %target-swift-frontend -emit-module %t/Client.swift -I %t -emit-module-interface-path %t/Client.swiftinterface -enable-library-evolution -swift-version 5
+
+/// The indirect conformance of `s` to `_p` should not be printed. (rdar://78718838)
+// RUN: cat %t/Client.swiftinterface | %FileCheck %s
+// CHECK-NOT: SecretLib
+
+// BEGIN SecretLib.swift
+public protocol _p {}
+public struct _s : _p {}
+
+// BEGIN Client.swift
+@_implementationOnly import SecretLib
+protocol p : _p {}
+public struct s : p {}
+public func test(s1 : s) {}


### PR DESCRIPTION
Indirect conformances are printed when the middle protocol is internal and not present in the swiftinterface. This logic didn't previously check for implementation-only imports, likely because type-checking usually forbids it. Let's still protect this use case as we are considering relaxing this type-checking restriction in the future and it can currently be used with workarounds like this one.

rdar://78718838