### PR TITLE
[CodeCompletion] Report solutions from the result builder transform

### DIFF
--- a/include/swift/Sema/CodeCompletionTypeChecking.h
+++ b/include/swift/Sema/CodeCompletionTypeChecking.h
@@ -36,9 +36,21 @@ namespace swift {
 
   class TypeCheckCompletionCallback {
   public:
-    /// Called for each solution produced while  type-checking an expression
+    /// Called for each solution produced while type-checking an expression
     /// that the code completion expression participates in.
     virtual void sawSolution(const constraints::Solution &solution) = 0;
+
+    /// Type checking produced a solution that may or may not contain the type
+    /// of the code completion's base.
+    /// This is being used when type checking result builders. Type checking
+    /// result builders might skip entire expressions if type checking fails,
+    /// thus the code completion expression might have no type set.
+    /// FIXME: Remove this, once type checking result builders no longer skips
+    /// expressions.
+    virtual void sawPotentialSolution(const constraints::Solution &solution) = 0;
+
+    /// True if a \c sawSolution callback was received.
+    virtual bool gotCallback() const = 0;
     virtual ~TypeCheckCompletionCallback() {}
   };
 
@@ -75,13 +87,14 @@ namespace swift {
 
     /// True if at least one solution was passed via the \c sawSolution
     /// callback.
-    bool gotCallback() const { return GotCallback; }
+    bool gotCallback() const override { return GotCallback; }
 
     /// Typecheck the code completion expression in isolation, calling
     /// \c sawSolution for each solution formed.
     void fallbackTypeCheck();
 
     void sawSolution(const constraints::Solution &solution) override;
+    void sawPotentialSolution(const constraints::Solution &solution) override;
   };
 
   /// Used to collect and store information needed to perform unresolved member
@@ -107,13 +120,14 @@ namespace swift {
 
     /// True if at least one solution was passed via the \c sawSolution
     /// callback.
-    bool gotCallback() const { return GotCallback; }
+    bool gotCallback() const override { return GotCallback; }
 
     /// Typecheck the code completion expression in its outermost expression
     /// context, calling \c sawSolution for each solution formed.
     void fallbackTypeCheck(DeclContext *DC);
 
     void sawSolution(const constraints::Solution &solution) override;
+    void sawPotentialSolution(const constraints::Solution &solution) override;
   };
 
 }

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4842,13 +4842,21 @@ public:
                                  = FreeTypeVariableBinding::Disallow,
                                  bool allowFixes = false);
 
-  /// Construct and solve a system of constraints based on the given expression
-  /// and its contextual information.
+  /// Solve a constraint system, for which constraints have already been
+  /// constructed for code completion.
   ///
   /// This method is designed to be used for code completion which means that
   /// it doesn't mutate given expression, even if there is a single valid
   /// solution, and constraint solver is allowed to produce partially correct
   /// solutions. Such solutions can have any number of holes in them.
+  ///
+  /// \param solutions The solutions produced for the given target without
+  /// filtering.
+  void solveForCodeCompletion(SmallVectorImpl<Solution> &solutions);
+
+  /// Construct a constraint system for the expression in \p target and solve it
+  /// for code completion using \c solveForCodeCompletion, using \p target's
+  /// contextual type.
   ///
   /// \param target The expression involved in code completion.
   ///
@@ -4857,8 +4865,8 @@ public:
   ///
   /// \returns `false` if this call fails (e.g. pre-check or constraint
   /// generation fails), `true` otherwise.
-  bool solveForCodeCompletion(SolutionApplicationTarget &target,
-                              SmallVectorImpl<Solution> &solutions);
+  bool generateConstraintsAndSolveForCodeCompletionExpr(
+      SolutionApplicationTarget &target, SmallVectorImpl<Solution> &solutions);
 
 private:
   /// Solve the system of constraints.

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -26,6 +26,7 @@
 #include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/TypeCheckRequests.h"
+#include "swift/Sema/CodeCompletionTypeChecking.h"
 #include "swift/Sema/ConstraintSystem.h"
 #include "swift/Sema/SolutionResult.h"
 #include "llvm/ADT/DenseMap.h"
@@ -1604,7 +1605,12 @@ Optional<BraceStmt *> TypeChecker::applyResultBuilderBodyTransform(
   }
   }
 
+  auto &Context = func->getASTContext();
   ConstraintSystemOptions options = ConstraintSystemFlags::AllowFixes;
+  if (Context.CompletionCallback) {
+    options |= ConstraintSystemFlags::SuppressDiagnostics;
+    options |= ConstraintSystemFlags::ForCodeCompletion;
+  }
   auto resultInterfaceTy = func->getResultInterfaceType();
   auto resultContextType = func->mapTypeIntoContext(resultInterfaceTy);
 
@@ -1625,6 +1631,20 @@ Optional<BraceStmt *> TypeChecker::applyResultBuilderBodyTransform(
           cs.getConstraintLocator(func->getBody()))) {
     if (result->isFailure())
       return nullptr;
+  }
+
+  if (Context.CompletionCallback) {
+    SmallVector<Solution, 4> solutions;
+    cs.solveForCodeCompletion(solutions);
+    // filterSolutionsForCodeCompletion only needs the completionExpr if
+    // the solution application target is a pattern expr. Since it's not, we
+    // can just pass nullptr here.
+    filterSolutionsForCodeCompletion(SolutionApplicationTarget(func), solutions,
+                                     /*completionExpr=*/nullptr);
+    for (auto &solution : solutions) {
+      Context.CompletionCallback->sawPotentialSolution(solution);
+    }
+    return None;
   }
 
   // Solve the constraint system.

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -41,6 +41,7 @@
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/LocalContext.h"
 #include "swift/Parse/Parser.h"
+#include "swift/Sema/CodeCompletionTypeChecking.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "swift/Syntax/TokenKinds.h"
 #include "llvm/ADT/DenseMap.h"
@@ -1926,6 +1927,14 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(Evaluator &evaluator,
         // Wire up the function body now.
         func->setBody(*optBody, AbstractFunctionDecl::BodyKind::TypeChecked);
         return false;
+      }
+      if (ctx.CompletionCallback && ctx.CompletionCallback->gotCallback()) {
+        // We failed to typecheck the result builder but saw a solution for the
+        // code completion token. This probably happened because there was an
+        // error that didn't affect the code completion position. This is fine
+        // for the purpose of code completion. No need to go to the fallback
+        // case described below.
+        return true;
       }
       // FIXME: We failed to apply the result builder transform. Fall back to
       // just type checking the node that contains the code completion token.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -555,6 +555,11 @@ FunctionType *getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
                                           DeclRefKind refKind,
                                           ConcreteDeclRef &refdDecl);
 
+void filterSolutionsForCodeCompletion(
+    const constraints::SolutionApplicationTarget &target,
+    SmallVectorImpl<constraints::Solution> &solutions,
+    CodeCompletionExpr *completionExpr);
+
 /// Type check the given expression and provide results back to code completion
 /// via specified callback.
 ///


### PR DESCRIPTION
Previously, we never reported any solutions through the `sawSolution` callback when applying the result builder transform. This caused us to always end up in the `fallbackTypeCheck` case for code completion, effectively type checking the constraint system twice.

With this change, we call `sawSolution` from the result builder transform, reducing the type code completion takes in SR-14651 from ~2.1s to ~1.4s (measured using `swift-ide-test` with assertions enabled).

Fixes rdar://78297973 [SR-14651]
Resolves rdar://77673447