### PR TITLE
[5.5][Refactoring] Support refactoring for `case let` patterns

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -4580,7 +4580,8 @@ struct CallbackCondition {
   /// }
   /// ```
   CallbackCondition(const Decl *Subject, const CaseLabelItem *CaseItem) {
-    if (auto *EEP = dyn_cast<EnumElementPattern>(CaseItem->getPattern())) {
+    if (auto *EEP = dyn_cast<EnumElementPattern>(
+            CaseItem->getPattern()->getSemanticsProvidingPattern())) {
       // `case .<func>(let <bind>)`
       initFromEnumPattern(Subject, EEP);
     }

--- a/test/refactoring/ConvertAsync/convert_pattern.swift
+++ b/test/refactoring/ConvertAsync/convert_pattern.swift
@@ -272,6 +272,16 @@ func testPatterns() async throws {
   // STRING-TUPLE-RESULT-NEXT:   print("oh no")
   // STRING-TUPLE-RESULT-NEXT: }
 
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=STRING-TUPLE-RESULT %s
+  stringTupleResult { res in
+    switch res {
+    case let .success((x, y)):
+      print(x, y)
+    case .failure:
+      print("oh no")
+    }
+  }
+
   // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MIXED-TUPLE-RESULT %s
   mixedTupleResult { res in
     if case .failure(let err) = res {


### PR DESCRIPTION
* **Explanation**: Previously we only supported `case` patterns that bound with a `let` inside the associated value like `case .success(let value)`. With this change, we also support `case let .success(value)`.
* **Scope**: Async refactoring
* **Risk**: Low
* **Testing**: Added a test to the regression test suite
* **Issue**: rdar://79279846
* **Reviewer**: @hamishknight (Hamish Knight)