### PR TITLE
Use the "nearly divisionless" algorithm on all targets.

### DIFF
--- a/benchmark/single-source/RandomValues.swift
+++ b/benchmark/single-source/RandomValues.swift
@@ -23,10 +23,22 @@ public let RandomValues = [
     tags: [.api], legacyFactor: 100),
   BenchmarkInfo(name: "RandomIntegersLCG", runFunction: run_RandomIntegersLCG,
     tags: [.api]),
+  BenchmarkInfo(name: "RandomInt8Def", runFunction: run_RandomInt8Def,
+    tags: [.api], legacyFactor: 100),
+  BenchmarkInfo(name: "RandomInt8LCG", runFunction: run_RandomInt8LCG,
+    tags: [.api]),
+  BenchmarkInfo(name: "RandomInt64Def", runFunction: run_RandomInt64Def,
+    tags: [.api], legacyFactor: 100),
+  BenchmarkInfo(name: "RandomInt64LCG", runFunction: run_RandomInt64LCG,
+    tags: [.api]),
   BenchmarkInfo(name: "RandomDoubleDef", runFunction: run_RandomDoubleDef,
     tags: [.api], legacyFactor: 100),
   BenchmarkInfo(name: "RandomDoubleLCG", runFunction: run_RandomDoubleLCG,
-    tags: [.api], legacyFactor: 2),
+    tags: [.api]),
+  BenchmarkInfo(name: "RandomDouble01Def", runFunction: run_RandomDouble01Def,
+    tags: [.api], legacyFactor: 100),
+  BenchmarkInfo(name: "RandomDouble01LCG", runFunction: run_RandomDouble01LCG,
+    tags: [.api]),
 ]
 
 /// A linear congruential PRNG.
@@ -49,7 +61,7 @@ public func run_RandomIntegersDef(_ N: Int) {
   for _ in 0 ..< N {
     var x = 0
     for _ in 0 ..< 1_000 {
-      x &+= Int.random(in: 0...10_000)
+      x &+= .random(in: 0...10_000)
     }
     blackHole(x)
   }
@@ -58,10 +70,57 @@ public func run_RandomIntegersDef(_ N: Int) {
 @inline(never)
 public func run_RandomIntegersLCG(_ N: Int) {
   for _ in 0 ..< N {
+    var x = 0
+    var generator = LCRNG(seed: 0)
+    for _ in 0 ..< 100_000 {
+      x &+= .random(in: 0...10_000, using: &generator)
+    }
+    blackHole(x)
+  }
+}
+
+@inline(never)
+public func run_RandomInt8Def(_ N: Int) {
+  for _ in 0 ..< N {
+    var x: Int8 = 0
+    for _ in 0 ..< 1_000 {
+      x &+= .random(in: -65...65)
+    }
+    blackHole(x)
+  }
+}
+
+@inline(never)
+public func run_RandomInt8LCG(_ N: Int) {
+  for _ in 0 ..< N {
+    var x: Int8 = 0
+    var generator = LCRNG(seed: 0)
+    for _ in 0 ..< 100_000 {
+      x &+= .random(in: -65...65, using: &generator)
+    }
+    blackHole(x)
+  }
+}
+
+@inline(never)
+public func run_RandomInt64Def(_ N: Int) {
+  for _ in 0 ..< N {
+    var x: Int64 = 0
+    for _ in 0 ..< 1_000 {
+      x &+= .random(in: -5_000_000_000_000_000_000...5_000_000_000_000_000_000)
+    }
+    blackHole(x)
+  }
+}
+
+@inline(never)
+public func run_RandomInt64LCG(_ N: Int) {
+  for _ in 0 ..< N {
     var x: Int64 = 0
     var generator = LCRNG(seed: 0)
     for _ in 0 ..< 100_000 {
-      x &+= Int64.random(in: 0...10_000, using: &generator)
+      x &+= .random(in: -5_000_000_000_000_000_000...5_000_000_000_000_000_000,
+                    using: &generator)
     }
     blackHole(x)
   }
@@ -72,7 +131,7 @@ public func run_RandomDoubleDef(_ N: Int) {
   for _ in 0 ..< N {
     var x = 0.0
     for _ in 0 ..< 1_000 {
-      x += Double.random(in: -1000...1000)
+      x += .random(in: -1000...1000)
     }
     blackHole(x)
   }
@@ -83,9 +142,33 @@ public func run_RandomDoubleLCG(_ N: Int) {
   for _ in 0 ..< N {
     var x = 0.0
     var generator = LCRNG(seed: 0)
-    for _ in 0 ..< 50_000 {
-      x += Double.random(in: -1000...1000, using: &generator)
+    for _ in 0 ..< 100_000 {
+      x += .random(in: -1000...1000, using: &generator)
     }
     blackHole(x)
   }
 }
+
+@inline(never)
+public func run_RandomDouble01Def(_ N: Int) {
+  for _ in 0 ..< N {
+    var x = 0.0
+    for _ in 0 ..< 1_000 {
+      x += .random(in: 0..<1)
+    }
+    blackHole(x)
+  }
+}
+
+@inline(never)
+public func run_RandomDouble01LCG(_ N: Int) {
+  for _ in 0 ..< N {
+    var x = 0.0
+    var generator = LCRNG(seed: 0)
+    for _ in 0 ..< 100_000 {
+      x += .random(in: 0..<1, using: &generator)
+    }
+    blackHole(x)
+  }
+}
+ 

--- a/benchmark/single-source/RandomValues.swift
+++ b/benchmark/single-source/RandomValues.swift
@@ -35,6 +35,10 @@ public let RandomValues = [
     tags: [.api], legacyFactor: 100),
   BenchmarkInfo(name: "RandomDoubleLCG", runFunction: run_RandomDoubleLCG,
     tags: [.api]),
+  BenchmarkInfo(name: "RandomDoubleOpaqueDef", runFunction: run_RandomDoubleOpaqueDef,
+    tags: [.api], legacyFactor: 100),
+  BenchmarkInfo(name: "RandomDoubleOpaqueLCG", runFunction: run_RandomDoubleOpaqueLCG,
+    tags: [.api]),
   BenchmarkInfo(name: "RandomDouble01Def", runFunction: run_RandomDouble01Def,
     tags: [.api], legacyFactor: 100),
   BenchmarkInfo(name: "RandomDouble01LCG", runFunction: run_RandomDouble01LCG,
@@ -73,7 +77,7 @@ public func run_RandomIntegersLCG(_ N: Int) {
     var x = 0
     var generator = LCRNG(seed: 0)
     for _ in 0 ..< 100_000 {
-      x &+= .random(in: 0...10_000, using: &generator)
+      x &+= .random(in: 0 ... 10_000, using: &generator)
     }
     blackHole(x)
   }
@@ -84,7 +88,7 @@ public func run_RandomInt8Def(_ N: Int) {
   for _ in 0 ..< N {
     var x: Int8 = 0
     for _ in 0 ..< 1_000 {
-      x &+= .random(in: -65...65)
+      x &+= .random(in: -65 ... identity(65))
     }
     blackHole(x)
   }
@@ -96,7 +100,7 @@ public func run_RandomInt8LCG(_ N: Int) {
     var x: Int8 = 0
     var generator = LCRNG(seed: 0)
     for _ in 0 ..< 100_000 {
-      x &+= .random(in: -65...65, using: &generator)
+      x &+= .random(in: -65 ... identity(65), using: &generator)
     }
     blackHole(x)
   }
@@ -107,7 +111,9 @@ public func run_RandomInt64Def(_ N: Int) {
   for _ in 0 ..< N {
     var x: Int64 = 0
     for _ in 0 ..< 1_000 {
-      x &+= .random(in: -5_000_000_000_000_000_000...5_000_000_000_000_000_000)
+      x &+= .random(in:
+        -5_000_000_000_000_000_000 ... identity(5_000_000_000_000_000_000)
+      )
     }
     blackHole(x)
   }
@@ -119,8 +125,10 @@ public func run_RandomInt64LCG(_ N: Int) {
     var x: Int64 = 0
     var generator = LCRNG(seed: 0)
     for _ in 0 ..< 100_000 {
-      x &+= .random(in: -5_000_000_000_000_000_000...5_000_000_000_000_000_000,
-                    using: &generator)
+      x &+= .random(in:
+        -5_000_000_000_000_000_000 ... identity(5_000_000_000_000_000_000),
+        using: &generator
+      )
     }
     blackHole(x)
   }
@@ -131,7 +139,7 @@ public func run_RandomDoubleDef(_ N: Int) {
   for _ in 0 ..< N {
     var x = 0.0
     for _ in 0 ..< 1_000 {
-      x += .random(in: -1000...1000)
+      x += .random(in: -1000 ... 1000)
     }
     blackHole(x)
   }
@@ -143,7 +151,30 @@ public func run_RandomDoubleLCG(_ N: Int) {
     var x = 0.0
     var generator = LCRNG(seed: 0)
     for _ in 0 ..< 100_000 {
-      x += .random(in: -1000...1000, using: &generator)
+      x += .random(in: -1000 ... 1000, using: &generator)
+    }
+    blackHole(x)
+  }
+}
+
+@inline(never)
+public func run_RandomDoubleOpaqueDef(_ N: Int) {
+  for _ in 0 ..< N {
+    var x = 0.0
+    for _ in 0 ..< 1_000 {
+      x += .random(in: -1000 ... identity(1000))
+    }
+    blackHole(x)
+  }
+}
+
+@inline(never)
+public func run_RandomDoubleOpaqueLCG(_ N: Int) {
+  for _ in 0 ..< N {
+    var x = 0.0
+    var generator = LCRNG(seed: 0)
+    for _ in 0 ..< 100_000 {
+      x += .random(in: -1000 ... identity(1000), using: &generator)
     }
     blackHole(x)
   }
@@ -154,7 +185,7 @@ public func run_RandomDouble01Def(_ N: Int) {
   for _ in 0 ..< N {
     var x = 0.0
     for _ in 0 ..< 1_000 {
-      x += .random(in: 0..<1)
+      x += .random(in: 0 ..< 1)
     }
     blackHole(x)
   }
@@ -166,7 +197,7 @@ public func run_RandomDouble01LCG(_ N: Int) {
     var x = 0.0
     var generator = LCRNG(seed: 0)
     for _ in 0 ..< 100_000 {
-      x += .random(in: 0..<1, using: &generator)
+      x += .random(in: 0 ..< 1, using: &generator)
     }
     blackHole(x)
   }

--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -103,17 +103,6 @@ extension RandomNumberGenerator {
     upperBound: T
   ) -> T {
     _precondition(upperBound != 0, "upperBound cannot be zero.")
-#if arch(i386) || arch(arm) || arch(arm64_32) // TODO(FIXME) SR-10912
-    let tmp = (T.max % upperBound) + 1
-    let range = tmp == upperBound ? 0 : tmp
-    var random: T = 0
-
-    repeat {
-      random = next()
-    } while random < range
-
-    return random % upperBound
-#else
     var random: T = next()
     var m = random.multipliedFullWidth(by: upperBound)
     if m.low < upperBound {
@@ -124,7 +113,6 @@ extension RandomNumberGenerator {
       }
     }
     return m.high
-#endif
   }
 }
 


### PR DESCRIPTION
We have multipliedFullWidth available everywhere now, so we don't need to carry around the old implementation on 32b targets.

Also adds a few more benchmarks for random number generation.

Resolves #53302