### PR TITLE
[test] add missing split-file dependency for validation tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -95,7 +95,8 @@ function(get_test_dependencies SDK result_var_name)
       llvm-readelf
       llvm-readobj
       llvm-strings
-      not)
+      not
+      split-file)
   endif()
 
   if(("${SDK}" STREQUAL "IOS") OR


### PR DESCRIPTION
This PR adds a missing LLVM tool dependency to the test suit build dependencies. This is used in the following tests:

```
validation-test/Python/call_swiftc_after_relocate_xdg_cache_home_under.swift
validation-test/BuildSystem/extractsymbols-darwin-symroot-path-filters.test
validation-test/BuildSystem/extractsymbols-default-behaviour.test
```
