### PR TITLE
Disable standard substitutions when building with "older" _Concurrency module

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1428,9 +1428,19 @@ bool ModuleDecl::isStdlibModule() const {
 }
 
 bool ModuleDecl::hasStandardSubstitutions() const {
-  return !getParent() &&
-      (getName() == getASTContext().StdlibModuleName ||
-       getName() == getASTContext().Id_Concurrency);
+  if (getParent())
+    return false;
+
+  if (getName() == getASTContext().StdlibModuleName)
+    return true;
+
+  // The _Concurrency module gets standard substitutions with "new enough"
+  // versions of the module.
+  if (getName() == getASTContext().Id_Concurrency &&
+      getASTContext().getProtocol(KnownProtocolKind::SerialExecutor))
+    return true;
+
+  return false;
 }
 
 bool ModuleDecl::isSwiftShimsModule() const {


### PR DESCRIPTION
To smooth over an ABI transition, disable the standard substitutions
for the _Concurrency module within the AST mangler when the
_Concurrency module we are using predates custom executors. This is a
short-term hack that should be removed when we settle the ABI.

Addresses rdar://79298287.
