### PR TITLE
[5.5][CSBindings] Overload variable shouldn't be delayed by its application

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1399,7 +1399,18 @@ void PotentialBindings::infer(Constraint *constraint) {
   }
 
   case ConstraintKind::ApplicableFunction:
-  case ConstraintKind::DynamicCallableApplicableFunction:
+  case ConstraintKind::DynamicCallableApplicableFunction: {
+    auto overloadTy = constraint->getSecondType();
+    // If current type variable represents an overload set
+    // being applied to the arguments, it can't be delayed
+    // by application constraints, because it doesn't
+    // depend on argument/result types being resolved first.
+    if (overloadTy->isEqual(TypeVar))
+      break;
+
+    LLVM_FALLTHROUGH;
+  }
+
   case ConstraintKind::BindOverload: {
     DelayedBy.push_back(constraint);
     break;

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1132,3 +1132,34 @@ func rdar76058892() {
     }
   }
 }
+
+// rdar://78917861 - Invalid generic type parameter inference
+
+func rdar78917861() {
+  class Cell {}
+  class MyCell : Cell {}
+
+  class DataCollection<D, C: Cell> {
+  }
+
+  class MyCollection {
+    typealias DataType = String
+    typealias CellType = MyCell
+
+    var data: DataCollection<DataType, CellType>
+
+    init() {
+      self.data = DataCollection<DataType, CellType>()
+    }
+  }
+
+  class Test {
+    let collection = MyCollection()
+
+    lazy var prop: DataCollection = {
+      collection.data // Ok
+      // Since contextual type `DataCollection` doesn't specify generic parameters they have to be inferred
+      // but that has to wait until the closure is resolved because types can flow both ways
+    }()
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/37835

---

- Explanation:

When inference is determining bindings of a type variable that represents
an overload set (e.g. member or operator reference), let's not consider
it as delayed due to presence of `ApplicableFunction` constraint since
argument/result type inference depends on overload set but not vice versa.

- Scope: Some single-statement closure expressions that have contextual type that doesn't explicitly specify generic parameters.

- Main Branch PR: https://github.com/apple/swift/pull/37835

- Resolves: rdar://78917861

- Risk: Low

- Reviewed By: @hborla  

- Testing: Regression tests added to the suite

Resolves: rdar://78917861
(cherry picked from commit 81ff342f4e1531e4e27a988467d23b67d08d048c)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
