### PR TITLE
[5.5][Diagnostics] Make sure extension type repr is available before using it

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7433,9 +7433,15 @@ bool InvalidMemberRefOnProtocolMetatype::diagnoseAsError() {
   if (auto *whereClause = extension->getTrailingWhereClause()) {
     auto sourceRange = whereClause->getSourceRange();
     note.fixItInsertAfter(sourceRange.End, ", Self == <#Type#> ");
-  } else {
-    auto nameRepr = extension->getExtendedTypeRepr();
-    note.fixItInsertAfter(nameRepr->getEndLoc(), " where Self == <#Type#>");
+  } else if (auto nameRepr = extension->getExtendedTypeRepr()) {
+    // Type repr is not always available so we need to be defensive
+    // about its presence and validity.
+    if (nameRepr->isInvalid())
+      return true;
+
+    if (auto noteLoc = nameRepr->getEndLoc()) {
+      note.fixItInsertAfter(noteLoc, " where Self == <#Type#>");
+    }
   }
 
   return true;


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/37887

--- 

- Explanation:

Before suggesting to add `where Self == ...` condition to the extension
of a protocol involved in a static member lookup, let's check whether
type repr is available and valid.

- Scope: Incorrect expressions that use static member lookup in generic context feature
               but don't have appropriate extension declared (extension with concrete `Self` requirement).

- Main Branch PR: https://github.com/apple/swift/pull/37887

- Resolves: rdar://78097387

- Risk: Low

- Reviewed By: @hborla  

- Testing: Unfortunately no tests have been added because the issue has to do with serialized modules 
                  which is hard to test, but it's just a nullptr check so it shouldn't be a problem.

Resolves: rdar://78097387
(cherry picked from commit a7988b06337642420708745dee67e6c12e2ddda7)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
