### PR TITLE
[5.5][Concurrency] Reserve two more words in Job.

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -45,7 +45,7 @@ enum {
 
   /// The number of words (in addition to the heap-object header)
   /// in a default actor.
-  NumWords_DefaultActor = 10,
+  NumWords_DefaultActor = 12,
 
   /// The number of words in a task.
   NumWords_AsyncTask = 16,

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -71,6 +71,8 @@ public:
   // Derived classes can use this to store a Job Id.
   uint32_t Id = 0;
 
+  void *Reserved[2] = {};
+
   // We use this union to avoid having to do a second indirect branch
   // when resuming an asynchronous task, which we expect will be the
   // common case.
@@ -127,10 +129,10 @@ public:
 
 // The compiler will eventually assume these.
 #if SWIFT_POINTER_IS_8_BYTES
-static_assert(sizeof(Job) == 6 * sizeof(void*),
+static_assert(sizeof(Job) == 8 * sizeof(void*),
               "Job size is wrong");
 #else
-static_assert(sizeof(Job) == 8 * sizeof(void*),
+static_assert(sizeof(Job) == 10 * sizeof(void*),
               "Job size is wrong");
 #endif
 static_assert(alignof(Job) == 2 * alignof(void*),
@@ -200,7 +202,7 @@ public:
 
   /// Private storage for the use of the runtime.
   struct alignas(2 * alignof(void*)) OpaquePrivateStorage {
-    void *Storage[8];
+    void *Storage[6];
 
     /// Initialize this storage during the creation of a task.
     void initialize(AsyncTask *task);

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -612,6 +612,7 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
     Int8PtrTy, Int8PtrTy, // Job.SchedulerPrivate
     Int32Ty,              // Job.Flags
     Int32Ty,              // Job.ID
+    Int8PtrTy, Int8PtrTy, // Reserved
     FunctionPtrTy,        // Job.RunJob/Job.ResumeTask
     SwiftContextPtrTy,    // Task.ResumeContext
     IntPtrTy              // Task.Status
@@ -632,6 +633,7 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
     Int8PtrTy, Int8PtrTy, // SchedulerPrivate
     Int32Ty,              // flags
     Int32Ty,              // ID
+    Int8PtrTy, Int8PtrTy, // Reserved
     FunctionPtrTy,        // RunJob/ResumeTask
   });
   SwiftJobPtrTy = SwiftJobTy->getPointerTo(DefaultAS);

--- a/test/IRGen/actor_class.swift
+++ b/test/IRGen/actor_class.swift
@@ -3,7 +3,7 @@
 
 
 // CHECK: %T11actor_class7MyClassC = type <{ %swift.refcounted, %swift.defaultactor, %TSi }>
-// CHECK: %swift.defaultactor = type { [10 x i8*] }
+// CHECK: %swift.defaultactor = type { [12 x i8*] }
 
 // CHECK-objc-LABEL: @"$s11actor_class7MyClassCMm" = global
 // CHECK-objc-SAME: @"OBJC_METACLASS_$__TtCs12_SwiftObject{{(.ptrauth)?}}"
@@ -15,13 +15,13 @@
 //   Flags: uses Swift refcounting
 // CHECK-SAME: i32 2,
 //   Instance size
-// CHECK-64-SAME: i32 104,
-// CHECK-32-SAME: i32 52,
+ // CHECK-64-SAME: i32 120,
+// CHECK-32-SAME: i32 60,
 //   Alignment mask
 // CHECK-64-SAME: i16 15,
 // CHECK-32-SAME: i16 7,
 //   Field offset for 'x'
-// CHECK-objc-SAME: [[INT]] {{48|96}},
+// CHECK-objc-SAME: [[INT]] {{56|112}},
 
 // Type descriptor.
 // CHECK-LABEL: @"$s11actor_class9ExchangerCMn" = {{.*}}constant

--- a/test/IRGen/actor_class_objc.swift
+++ b/test/IRGen/actor_class_objc.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 // CHECK: %T16actor_class_objc7MyClassC = type <{ %swift.refcounted, %swift.defaultactor, %TSi }>
-// CHECK: %swift.defaultactor = type { [10 x i8*] }
+// CHECK: %swift.defaultactor = type { [12 x i8*] }
 
 // CHECK-LABEL: @"OBJC_METACLASS_$__TtC16actor_class_objc7MyClass" = global
 //   Metaclass is an instance of the root class.
@@ -20,14 +20,14 @@ import Foundation
 //   Flags: uses Swift refcounting
 // CHECK-SAME: i32 2,
 //   Instance size
-// CHECK-64-SAME: i32 104,
-// CHECK-32-SAME: i32 52,
+// CHECK-64-SAME: i32 120,
+// CHECK-32-SAME: i32 60,
 //   Alignment mask
 // CHECK-64-SAME: i16 15,
 // CHECK-32-SAME: i16 7,
 //   Field offset for 'x'
-// CHECK-64-SAME: i64 96,
-// CHECK-32-SAME: i32 48,
+// CHECK-64-SAME: i64 112,
+// CHECK-32-SAME: i32 56,
 
 public actor MyClass: NSObject {
   public var x: Int

--- a/test/IRGen/async/builtins.sil
+++ b/test/IRGen/async/builtins.sil
@@ -63,7 +63,7 @@ bb0(%0 : $Int, %1: @guaranteed $@async @callee_owned @substituted <τ_0_0> () ->
 sil hidden [ossa] @resume_nonthrowing_continuation : $(@in Builtin.NativeObject, Builtin.RawUnsafeContinuation) -> () {
 bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.RawUnsafeContinuation):
   // CHECK:      [[CONT:%.*]] = bitcast i8* %1 to %swift.task*
-  // CHECK-NEXT: [[CONTEXT_SLOT:%.*]] = getelementptr inbounds %swift.task, %swift.task* [[CONT]], i32 0, i32 6
+  // CHECK-NEXT: [[CONTEXT_SLOT:%.*]] = getelementptr inbounds %swift.task, %swift.task* [[CONT]], i32 0, i32 8
   // CHECK-NEXT: [[CONTEXT_OPAQUE:%.*]] = load %swift.context*, %swift.context** [[CONTEXT_SLOT]], align
   // CHECK-NEXT: [[CONTEXT:%.*]] = bitcast %swift.context* [[CONTEXT_OPAQUE]] to %swift.continuation_context*
   // CHECK-NEXT: [[RESULT_ADDR_SLOT:%.*]] = getelementptr inbounds %swift.continuation_context, %swift.continuation_context* [[CONTEXT]], i32 0, i32 3
@@ -82,7 +82,7 @@ bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.RawUnsafeContinuation):
 sil hidden [ossa] @resume_throwing_continuation : $(@in Builtin.NativeObject, Builtin.RawUnsafeContinuation) -> () {
 bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.RawUnsafeContinuation):
   // CHECK:      [[CONT:%.*]] = bitcast i8* %1 to %swift.task*
-  // CHECK-NEXT: [[CONTEXT_SLOT:%.*]] = getelementptr inbounds %swift.task, %swift.task* [[CONT]], i32 0, i32 6
+  // CHECK-NEXT: [[CONTEXT_SLOT:%.*]] = getelementptr inbounds %swift.task, %swift.task* [[CONT]], i32 0, i32 8
   // CHECK-NEXT: [[CONTEXT_OPAQUE:%.*]] = load %swift.context*, %swift.context** [[CONTEXT_SLOT]], align
   // CHECK-NEXT: [[CONTEXT:%.*]] = bitcast %swift.context* [[CONTEXT_OPAQUE]] to %swift.continuation_context*
   // CHECK-NEXT: [[RESULT_ADDR_SLOT:%.*]] = getelementptr inbounds %swift.continuation_context, %swift.continuation_context* [[CONTEXT]], i32 0, i32 3


### PR DESCRIPTION
Keep Task the same size by pulling two words out of OpaquePrivateStorage.

rdar://79313908
(cherry picked from commit 6d514c235d726839adddbc115fbb8cb87c682aad)