### PR TITLE
ABIChecker: diagnose missing convenience inits only when checking source compatibility

### DIFF
--- a/test/api-digester/Outputs/Cake-abi.txt
+++ b/test/api-digester/Outputs/Cake-abi.txt
@@ -107,6 +107,5 @@ cake: Var RequiementChanges.addedVar has been added as a protocol requirement
 /* Class Inheritance Change */
 cake: Class SubGenericClass has changed its super class from cake.GenericClass<cake.P1> to cake.GenericClass<cake.P2>
 cake: Class SuperClassRemoval has removed its super class cake.C3
-cake: Class SuperClassRemoval no longer inherits convenience inits from its superclass
 cake: Constructor AddingNewDesignatedInit.init(_:) has been added as a designated initializer to an open class
 cake: Constructor ClassWithMissingDesignatedInits.init() has been added as a designated initializer to an open class

--- a/tools/driver/swift_api_digester_main.cpp
+++ b/tools/driver/swift_api_digester_main.cpp
@@ -610,7 +610,8 @@ void swift::ide::api::SDKNodeDeclType::diagnose(SDKNode *Right) {
 
     // It's not safe to stop inheriting convenience inits, it changes
     // the set of initializers that are available.
-    if (inheritsConvenienceInitializers() &&
+    if (!Ctx.checkingABI() &&
+        inheritsConvenienceInitializers() &&
         !R->inheritsConvenienceInitializers())
       R->emitDiag(R->getLoc(), diag::not_inheriting_convenience_inits);
     break;


### PR DESCRIPTION
rdar://76790246
