### PR TITLE
Sema: Avoid an assertion when diagnosing failures in some cases with invalid associated types

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/sr14672.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr14672.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public protocol PublicContent {
+    associatedtype Model
+    init(_ model: Model)
+}
+
+public protocol PublicConvertible {
+    associatedtype Public
+    func toPublic() -> Public
+}
+
+extension PublicConvertible where Public: PublicContent, Public.Model == Self {
+    public func toPublic() -> Public {
+        Public(self)
+    }
+}
+
+extension Array: PublicConvertible where Element: PublicConvertible {
+    public func toPublic() -> [Element.Public] {
+        map { $0.toPublic() }
+    }
+}


### PR DESCRIPTION
The solver's simplifyType() can produce a DependentMemberType with a
concrete or archetype base, if that associated type could not be
resolved during associated type inference.

mapTypeOutOfContext() could assert when given a type that violates
invariants in this manner. Instead, let's directly call subst() here,
providing a conformance lookup function (which will probably end up
returning ErrorTypes).

Fixes https://bugs.swift.org/browse/SR-14672 / rdar://problem/78626943.