### PR TITLE
[build] add option to not build stdlib when cross compiling

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -580,6 +580,11 @@ def create_argument_parser():
                 'module-only targets on Darwin platforms. These targets are '
                 'in addition to the full library targets.')
 
+    option(['--skip-build-stdlib-when-cross-compiling'],
+           toggle_false('build_stdlib_when_cross_compiling'),
+           help='Don\'t build the standard library when building '
+                'the Swift compiler for the cross compile hosts')
+
     # -------------------------------------------------------------------------
     in_group('Options to select projects')
 

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -91,6 +91,7 @@ EXPECTED_DEFAULTS = {
     'build_swift_driver': False,
     'build_early_swift_driver': True,
     'build_swiftsyntax': False,
+    'build_stdlib_when_cross_compiling': True,
     'build_libparser_only': False,
     'build_skstresstester': False,
     'build_swiftformat': False,
@@ -654,6 +655,8 @@ EXPECTED_OPTIONS = [
     StrOption('--stdlib-deployment-targets'),
     StrOption('--swift-darwin-module-archs'),
     StrOption('--swift-darwin-supported-archs'),
+    DisableOption('--skip-build-stdlib-when-cross-compiling',
+                  dest='build_stdlib_when_cross_compiling'),
 
     PathOption('--android-deploy-device-path'),
     PathOption('--android-icu-i18n'),

--- a/utils/swift_build_support/swift_build_support/host_specific_configuration.py
+++ b/utils/swift_build_support/swift_build_support/host_specific_configuration.py
@@ -22,6 +22,23 @@ class HostSpecificConfiguration(object):
     """Configuration information for an individual host."""
 
     @staticmethod
+    def _compute_stdlib_targets_cross_compilation(host_target, args):
+        # This is a host we are building as part of
+        # cross-compiling, so we only need the target itself.
+        stdlib_targets_to_configure = [host_target]
+        if (hasattr(args, 'stdlib_deployment_targets')):
+            # there are some build configs that expect
+            # not to be building the stdlib for the target
+            # since it will be provided by different means
+            stdlib_targets_to_build = set(
+                stdlib_targets_to_configure).intersection(
+                set(args.stdlib_deployment_targets))
+        else:
+            stdlib_targets_to_build = set(stdlib_targets_to_configure)
+
+        return (stdlib_targets_to_configure, stdlib_targets_to_build)
+
+    @staticmethod
     def _compute_stdlib_targets(host_target, args):
         # Compute the set of deployment targets to configure/build.
         if host_target == args.host_target:
@@ -35,18 +52,9 @@ class HostSpecificConfiguration(object):
                     args.build_stdlib_deployment_targets).intersection(
                     set(args.stdlib_deployment_targets))
         else:
-            # Otherwise, this is a host we are building as part of
-            # cross-compiling, so we only need the target itself.
-            stdlib_targets_to_configure = [host_target]
-            if (hasattr(args, 'stdlib_deployment_targets')):
-                # there are some build configs that expect
-                # not to be building the stdlib for the target
-                # since it will be provided by different means
-                stdlib_targets_to_build = set(
-                    stdlib_targets_to_configure).intersection(
-                    set(args.stdlib_deployment_targets))
-            else:
-                stdlib_targets_to_build = set(stdlib_targets_to_configure)
+            (stdlib_targets_to_configure, stdlib_targets_to_build) = \
+                HostSpecificConfiguration._compute_stdlib_targets_cross_compilation(
+                    host_target, args)
 
         if (hasattr(args, 'stdlib_deployment_targets') and
                 args.stdlib_deployment_targets == []):

--- a/utils/swift_build_support/swift_build_support/host_specific_configuration.py
+++ b/utils/swift_build_support/swift_build_support/host_specific_configuration.py
@@ -26,7 +26,11 @@ class HostSpecificConfiguration(object):
         # This is a host we are building as part of
         # cross-compiling, so we only need the target itself.
         stdlib_targets_to_configure = [host_target]
-        if (hasattr(args, 'stdlib_deployment_targets')):
+        if (hasattr(args, 'build_stdlib_when_cross_compiling') and
+                not args.build_stdlib_when_cross_compiling):
+            stdlib_targets_to_configure = []
+            stdlib_targets_to_build = []
+        elif (hasattr(args, 'stdlib_deployment_targets')):
             # there are some build configs that expect
             # not to be building the stdlib for the target
             # since it will be provided by different means

--- a/utils/swift_build_support/swift_build_support/host_specific_configuration.py
+++ b/utils/swift_build_support/swift_build_support/host_specific_configuration.py
@@ -21,9 +21,8 @@ class HostSpecificConfiguration(object):
 
     """Configuration information for an individual host."""
 
-    def __init__(self, host_target, args):
-        """Initialize for the given `host_target`."""
-
+    @staticmethod
+    def _compute_stdlib_targets(host_target, args):
         # Compute the set of deployment targets to configure/build.
         if host_target == args.host_target:
             # This host is the user's desired product, so honor the requested
@@ -53,6 +52,14 @@ class HostSpecificConfiguration(object):
                 args.stdlib_deployment_targets == []):
             stdlib_targets_to_configure = []
             stdlib_targets_to_build = []
+
+        return (stdlib_targets_to_configure, stdlib_targets_to_build)
+
+    def __init__(self, host_target, args):
+        """Initialize for the given `host_target`."""
+
+        (stdlib_targets_to_configure, stdlib_targets_to_build) = \
+            HostSpecificConfiguration._compute_stdlib_targets(host_target, args)
 
         # Compute derived information from the arguments.
         #

--- a/utils/swift_build_support/tests/test_host_specific_configuration.py
+++ b/utils/swift_build_support/tests/test_host_specific_configuration.py
@@ -101,6 +101,32 @@ class ToolchainTestCase(unittest.TestCase):
 
         self.assertEqual(len(hsc.swift_stdlib_build_targets), 0)
 
+    def test_test_should_configure_and_build_when_cross_compiling_macos(self):
+        args = self.default_args()
+        args.build_osx = True
+        args.build_stdlib_when_cross_compiling = True
+        args.host_target = 'macosx-x86_64'
+        args.stdlib_deployment_targets = ['macosx-x86_64', 'macosx-arm64']
+
+        hsc = HostSpecificConfiguration('macosx-arm64', args)
+
+        self.assertEqual(len(hsc.sdks_to_configure), 1)
+        self.assertEqual(len(hsc.swift_stdlib_build_targets), 1)
+        self.assertIn('swift-test-stdlib-macosx-arm64',
+                      hsc.swift_stdlib_build_targets)
+
+    def test_should_skip_stdlib_when_cross_compiling_if_told_so_macos(self):
+        args = self.default_args()
+        args.build_osx = True
+        args.build_stdlib_when_cross_compiling = False
+        args.host_target = 'macosx-x86_64'
+        args.stdlib_deployment_targets = ['macosx-x86_64', 'macosx-arm64']
+
+        hsc = HostSpecificConfiguration('macosx-arm64', args)
+
+        self.assertEqual(len(hsc.sdks_to_configure), 0)
+        self.assertEqual(len(hsc.swift_stdlib_build_targets), 0)
+
     def generate_should_skip_building_platform(
             host_target, sdk_name, build_target, build_arg_name):
         def test(self):


### PR DESCRIPTION
This would be needed to avoid rebuilding the stdlib a second time in
certain internal configuration, reducing the overall build times.

Take this opportunity to extract into separate functions the code to calculate the stdlib targets to configure and build.

Addresses rdar://78111750