### PR TITLE
Disable weak reference lifetime warnings by default.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -154,8 +154,12 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   P.addDiagnoseInfiniteRecursion();
   P.addYieldOnceCheck();
   P.addEmitDFDiagnostics();
-  P.addDiagnoseLifetimeIssues();
 
+  // Only issue weak lifetime warnings for users who select object lifetime
+  // optimization. The risk of spurious warnings outweighs the benefits.
+  if (P.getOptions().EnableCopyPropagation) {
+    P.addDiagnoseLifetimeIssues();
+  }
   // Canonical swift requires all non cond_br critical edges to be split.
   P.addSplitNonCondBrCriticalEdges();
 }

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -106,7 +106,7 @@ func test2() {
   weak var w1 : SomeClass?
   _ = w1                // ok: default-initialized
 
-  // expected-warning@+4 {{weak reference will always be nil because the referenced object is deallocated here}}
+  // Note: with -enable-copy-propagation, we also expect: {{weak reference will always be nil because the referenced object is deallocated here}}
   // expected-warning@+3 {{instance will be immediately deallocated because variable 'w2' is 'weak'}}
   // expected-note@+2 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@+1 {{'w2' declared here}}
@@ -1336,7 +1336,7 @@ func testDontDiagnoseUnownedImmediateDeallocationThroughStrong() {
   weak var c1: SomeClass?
   do {
     let tmp = SomeClass()
-    c1 = tmp // expected-warning {{weak reference will always be nil because the referenced object is deallocated here}}
+    c1 = tmp // Note: with -enable-copy-propagation, we also expect: {{weak reference will always be nil because the referenced object is deallocated here}}
   }
 
   unowned let c2: SomeClass
@@ -1347,7 +1347,7 @@ func testDontDiagnoseUnownedImmediateDeallocationThroughStrong() {
 
   weak var c3: SomeClass?
   let c3Tmp = SomeClass()
-  c3 = c3Tmp // expected-warning {{weak reference will always be nil because the referenced object is deallocated here}}
+  c3 = c3Tmp // Note: with -enable-copy-propagation, we also expect: {{weak reference will always be nil because the referenced object is deallocated here}}
 
   unowned let c4: SomeClass
   let c4Tmp = SomeClass()

--- a/test/SILOptimizer/diagnose_lifetime_issues.sil
+++ b/test/SILOptimizer/diagnose_lifetime_issues.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -diagnose-lifetime-issues  -o /dev/null -verify
+// RUN: %target-sil-opt -enable-sil-verify-all %s -diagnose-lifetime-issues -o /dev/null -verify
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/diagnose_lifetime_issues.swift
+++ b/test/SILOptimizer/diagnose_lifetime_issues.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil -enable-copy-propagation %s -o /dev/null -verify
 
 class Delegate {
   func foo() { }

--- a/test/SILOptimizer/diagnose_lifetime_issues_objc.swift
+++ b/test/SILOptimizer/diagnose_lifetime_issues_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil %s -enable-copy-propagation -o /dev/null -verify
 // REQUIRES: objc_interop
 
 import Foundation


### PR DESCRIPTION
Only issue weak lifetime warnings for users who select object lifetime
optimization. The risk of spurious warnings outweighs the benefits.

Although the warnings are generally useful regardless of the level of
optimization, it isn't really critical to issue them unless the optimizer
aggressively shrinks reference lifetimes.

NOTE: Only look at the most recent commit. There is a dependence on a test case introduced by https://github.com/apple/swift/pull/37915

 Fixes rdar://79146338 Xcode warns that "referenced object is
deallocated here" but that object was passed into a method that causes
strong retention)