### PR TITLE
[SILGen] Fix a crash when a wrapped property initial value has a re-abstractable type.

### DIFF
--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -967,3 +967,18 @@ struct TestAutoclosureComposition {
 
 // CHECK-LABEL: sil_vtable [serialized] TestMyWrapper
 // CHECK: #TestMyWrapper.$useMyWrapper!getter
+
+@propertyWrapper
+struct AutoclosureWrapper<T> {
+  init(wrappedValue: @autoclosure () -> T) {
+    self.wrappedValue = wrappedValue()
+  }
+  var wrappedValue: T
+}
+
+struct TestReabstractableWrappedValue<T1> {
+  struct S<T2> { }
+
+  @AutoclosureWrapper var v: S<T1> = S()
+  init() where T1 == Int { }
+}


### PR DESCRIPTION
Never use a converting initialization when emitting member initializers if the member is a property wrapper.

This code assumes that the initial value of the member and the result of initialization are the same type (but differing in abstraction level). This isn't true for property wrappers because the initial value can be the wrapped value type, but the result is always the property wrapper type. Property wrapper types are never reabstractable types anyway, so the converting initialization isn't necessary.

Resolves: rdar://77339559