### PR TITLE
[cmake] Rename swift-api-digester to its new name.

### DIFF
--- a/utils/api_checker/CMakeLists.txt
+++ b/utils/api_checker/CMakeLists.txt
@@ -28,6 +28,6 @@ add_custom_command(OUTPUT "${dest}"
 add_custom_target("symlink_abi_checker_data" ALL
                   DEPENDS "${dest}"
                   COMMENT "Symlinking ABI checker baseline data to ${dest}")
-if(TARGET swift-api-digester)
-  add_dependencies(swift-api-digester symlink_abi_checker_data)
+if(TARGET swift-frontend)
+  add_dependencies(swift-frontend symlink_abi_checker_data)
 endif()


### PR DESCRIPTION
In #36381 the swift-api-digester changed from being a standalone tool to
be a symlink of the frontend. With the symlink, the target
swift-api-checker disappeared. In order to keep depending on
symlink_abi_checker_data for the tests, change the mentions of
swift-api-checker to swift-frontend (which is the actual target that
creates the symlink).

This probably is fine when using `build-script` because the script
uses `all` and `symlink_abi_checker_data` target is created
with `ALL`, but it will not be correctly built, if one only does
`swift-test-depends` for building the just the tests.

/cc @rmaz @owenv 