### PR TITLE
Don’t crash from circular swift_name attributes

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -67,6 +67,13 @@ WARNING(inconsistent_swift_name,none,
         (bool, StringRef, StringRef, DeclName, StringRef, DeclName,
          StringRef))
 
+WARNING(swift_name_circular_context_import,none,
+        "cycle detected while resolving '%0' in swift_name attribute for '%1'",
+        (StringRef, StringRef))
+NOTE(swift_name_circular_context_import_other,none,
+     "while resolving '%0' in swift_name attribute for '%1'",
+     (StringRef, StringRef))
+
 WARNING(unresolvable_clang_decl,none,
         "imported declaration '%0' could not be mapped to '%1'",
         (StringRef, StringRef))

--- a/test/ClangImporter/Inputs/custom-modules/ObjCIRExtras.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCIRExtras.h
@@ -72,4 +72,11 @@ int global_int SWIFT_NAME(GlobalInt);
 @compatibility_alias SwiftGenericNameAlias SwiftGenericNameTest;
 @compatibility_alias SwiftConstrGenericNameAlias SwiftConstrGenericNameTest;
 
+SWIFT_NAME(CircularName.Inner) @interface CircularName : NSObject @end
+
+SWIFT_NAME(MutuallyCircularNameB.Inner) @interface MutuallyCircularNameA : NSObject @end
+SWIFT_NAME(MutuallyCircularNameA.Inner) @interface MutuallyCircularNameB : NSObject @end
+
+void circularFriends(CircularName*, MutuallyCircularNameA*);
+
 #pragma clang assume_nonnull end


### PR DESCRIPTION
If a swift_name attribute’s context referred to the same declaration it was attached to, or a different declaration whose own swift_name referred to the current one, we would recurse infinitely and eventually overflow the stack. This commit makes us instead detect the cycle, diagnose it with a warning, and drop the affected declaration.

Fixes rdar://79370809.