### PR TITLE
[SR-14784][Sema] Make sure we look through optionals on anchor fnType for MissingCallFailure

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3252,7 +3252,8 @@ bool MissingCallFailure::diagnoseAsError() {
     switch (last.getKind()) {
     case ConstraintLocator::ContextualType:
     case ConstraintLocator::ApplyArgToParam: {
-      auto fnType = getType(anchor)->castTo<FunctionType>();
+      auto type = getType(anchor)->lookThroughAllOptionalTypes();
+      auto fnType = type->castTo<FunctionType>();
       emitDiagnostic(diag::missing_nullary_call, fnType->getResult())
           .fixItInsertAfter(insertLoc, "()");
       return true;

--- a/test/Constraints/function.swift
+++ b/test/Constraints/function.swift
@@ -245,3 +245,8 @@ func test_passing_noescape_function_ref_to_generic_parameter() {
     }
   }
 }
+
+// SR-14784
+func SR14784<T>(_ fs: () -> T..., a _ : Int) -> T {
+  fs.first! // expected-error{{function produces expected type 'T'; did you mean to call it with '()'?}} {{11-11=()}}
+}


### PR DESCRIPTION
Just look through optionals here, otherwise we assert on cast in the example of test case

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-14784.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
