### PR TITLE
[ClangImporter] Respect -working-directory in the created VFS

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -25,6 +25,9 @@ namespace llvm {
   class Triple;
   class FileCollectorBase;
   template<typename Fn> class function_ref;
+  namespace vfs {
+    class FileSystem;
+  }
 }
 
 namespace clang {
@@ -158,6 +161,7 @@ public:
   static std::unique_ptr<clang::CompilerInvocation>
   createClangInvocation(ClangImporter *importer,
                         const ClangImporterOptions &importerOpts,
+                        llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS,
                         ArrayRef<std::string> invocationArgStrs,
                         std::vector<std::string> *CC1Args = nullptr);
   ClangImporter(const ClangImporter &) = delete;

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -215,7 +215,7 @@ void ClangImporter::recordModuleDependencies(
 
     // Ensure the arguments we collected is sufficient to create a Clang
     // invocation.
-    assert(createClangInvocation(this, Opts, allArgs));
+    assert(createClangInvocation(this, Opts, nullptr, allArgs));
 
     std::vector<std::string> swiftArgs;
     // We are using Swift frontend mode.

--- a/test/ClangImporter/MixedSource/broken-modules.swift
+++ b/test/ClangImporter/MixedSource/broken-modules.swift
@@ -18,7 +18,7 @@ import MissingDependencyFromSwift
 // CHECK-NOT: no such module 'MissingDependencyFromSwift'
 
 import MissingDependencyFromClang
-// CHECK: {{.+}}/Inputs/broken-modules/MissingDependencyFromClang.h:1:9: error: module 'Dependency' not found
+// CHECK: {{.+}}{{/|\\}}Inputs{{/|\\}}broken-modules{{/|\\}}MissingDependencyFromClang.h:1:9: error: module 'Dependency' not found
 // CHECK: broken-modules.swift:[[@LINE-2]]:8: error: could not build Objective-C module 'MissingDependencyFromClang'
 // CHECK: error: no such module 'MissingDependencyFromClang'
 

--- a/test/ClangImporter/broken-modules.swift
+++ b/test/ClangImporter/broken-modules.swift
@@ -23,7 +23,7 @@ import ImportsMissingHeader
 // CHECK: <module-includes>:1:9: note: in file included from <module-includes>:1:
 // CHECK-NEXT: #import "{{.*}}ImportsMissingHeader.h"
 
-// CHECK: {{.*}}/Inputs/custom-modules/ImportsMissingHeader.h:1:9: error: 'this-header-does-not-exist.h' file not found
+// CHECK: {{.*}}{{/|\\}}Inputs{{/|\\}}custom-modules{{/|\\}}ImportsMissingHeader.h:1:9: error: 'this-header-does-not-exist.h' file not found
 
 // CHECK-INDIRECT: <module-includes>:1:9: note: in file included from <module-includes>:1:
 // CHECK-INDIRECT-NEXT: #import "{{.*}}ImportsMissingHeaderIndirect.h"

--- a/test/ClangImporter/non-modular-include.swift
+++ b/test/ClangImporter/non-modular-include.swift
@@ -2,7 +2,7 @@
 // RUN: not %target-swift-frontend -enable-objc-interop -typecheck %/s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck --check-prefix=CHECK -check-prefix CHECK-objc %s
 // RUN: not %target-swift-frontend -disable-objc-interop -typecheck %/s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck --check-prefix=CHECK -check-prefix CHECK-native %s
 
-// CHECK: {{.+}}/non-modular{{/|\\}}Foo.framework/Headers{{/|\\}}Foo.h:1:10: error: include of non-modular header inside framework module 'Foo'
+// CHECK: {{.+}}{{/|\\}}non-modular{{/|\\}}Foo.framework{{/|\\}}Headers{{/|\\}}Foo.h:1:10: error: include of non-modular header inside framework module 'Foo'
 // CHECK-objc: error: could not build Objective-C module 'Foo'
 // CHECK-native: error: could not build C module 'Foo'
 // CHECK-NOT: error

--- a/test/ClangImporter/working-directory.swift
+++ b/test/ClangImporter/working-directory.swift
@@ -1,4 +1,12 @@
-// RUN: cd %S/Inputs/ && %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -Xcc -I -Xcc custom-modules %s -dump-clang-diagnostics 2>&1 | %FileCheck %s
+// RUN: %empty-directory(%t/mcp)
+
+// Check that equivalent invocations result in the same module hash
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -Xcc -I -Xcc custom-modules -module-cache-path %t/mcp -Xcc -working-directory -Xcc %S/Inputs/  %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -Xcc -I -Xcc %S/Inputs/custom-modules -module-cache-path %t/mcp %s
+// RUN: find %t/mcp -name "ObjCParseExtras-*.pcm" | count 1
+
+// Check that the working directory is set to the CWD if not explicitly passed
+// RUN: cd %S/Inputs/ && %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -Xcc -I -Xcc custom-modules %s -dump-clang-diagnostics -module-cache-path %t/mcp 2>&1 | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SourceKit/CursorInfo/injected_vfs.swift
+++ b/test/SourceKit/CursorInfo/injected_vfs.swift
@@ -10,7 +10,7 @@ func foo(
 
 // CHECK-CMODULE: key.kind: source.lang.swift.ref.struct
 // CHECK-CMODULE: key.name: "StructDefinedInCModule"
-// CHECK-CMODULE: key.filepath: "{{.*}}/CModule{{/|\\\\}}CModule.h"
+// CHECK-CMODULE: key.filepath: "{{.*}}{{/|\\\\}}CModule{{/|\\\\}}CModule.h"
 
 // CHECK-SWIFTMODULE-REF: key.kind: source.lang.swift.ref.struct
 // CHECK-SWIFTMODULE-REF: key.name: "StructDefinedInSwiftModule"


### PR DESCRIPTION
Pass a wrapped VFS down into `clang::createInvocationFromCommandLine` so
that the working directory is set and then used in the underlying Clang
`CompilerInstance`.

Fixes the possibility of differing modules hashes when the same
arguments are used in Clang directly vs from the importer.

Resolves rdar://79376364