### PR TITLE
Implement projectExistentialAndUnwrapClass (main)

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -92,7 +92,7 @@ class ReflectionContext
   using super = remote::MetadataReader<Runtime, TypeRefBuilder>;
   using super::readMetadata;
   using super::readObjCClassName;
-
+  using super::readResolvedPointerValue;
   std::unordered_map<typename super::StoredPointer, const TypeInfo *> Cache;
 
   /// All buffers we need to keep around long term. This will automatically free them
@@ -789,6 +789,52 @@ public:
     }
   }
 
+  llvm::Optional<std::pair<const TypeRef *, RemoteAddress>>
+  getDynamicTypeAndAddressClassExistential(RemoteAddress ExistentialAddress) {
+    auto PointerValue =
+        readResolvedPointerValue(ExistentialAddress.getAddressData());
+    if (!PointerValue)
+      return {};
+    auto Result = readMetadataFromInstance(*PointerValue);
+    if (!Result)
+      return {};
+    auto TypeResult = readTypeFromMetadata(Result.getValue());
+    if (!TypeResult)
+      return {};
+    return {{std::move(TypeResult), RemoteAddress(*PointerValue)}};
+  }
+
+  llvm::Optional<std::pair<const TypeRef *, RemoteAddress>>
+  getDynamicTypeAndAddressErrorExistential(RemoteAddress ExistentialAddress,
+                                           bool *IsBridgedError = nullptr) {
+    auto Result = readMetadataAndValueErrorExistential(ExistentialAddress);
+    if (!Result)
+      return {};
+
+    auto TypeResult =
+        readTypeFromMetadata(Result->MetadataAddress.getAddressData());
+    if (!TypeResult)
+      return {};
+
+    if (IsBridgedError)
+      *IsBridgedError = Result->IsBridgedError;
+
+    return {{TypeResult, Result->PayloadAddress}};
+  }
+
+  llvm::Optional<std::pair<const TypeRef *, RemoteAddress>>
+  getDynamicTypeAndAddressOpaqueExistential(RemoteAddress ExistentialAddress) {
+    auto Result = readMetadataAndValueOpaqueExistential(ExistentialAddress);
+    if (!Result)
+      return {};
+
+    auto TypeResult =
+        readTypeFromMetadata(Result->MetadataAddress.getAddressData());
+    if (!TypeResult)
+      return {};
+    return {{std::move(TypeResult), Result->PayloadAddress}};
+  }
+
   bool projectExistential(RemoteAddress ExistentialAddress,
                           const TypeRef *ExistentialTR,
                           const TypeRef **OutInstanceTR,
@@ -850,6 +896,75 @@ public:
       return false;
     }
   }
+  /// A version of `projectExistential` tailored for LLDB.
+  /// This version dereferences the resulting TypeRef if it wraps
+  /// a class type, it also dereferences the input `ExistentialAddress` before
+  /// attempting to find its dynamic type and address when dealing with error
+  /// existentials.
+  llvm::Optional<std::pair<const TypeRef *, RemoteAddress>>
+  projectExistentialAndUnwrapClass(RemoteAddress ExistentialAddress,
+                                   const TypeRef &ExistentialTR) {
+    auto IsClass = [](const TypeRef *TypeResult) {
+      // When the existential wraps a class type, LLDB expects that the
+      // address returned is the class instance itself and not the address
+      // of the reference.
+      bool IsClass = TypeResult->getKind() == TypeRefKind::ForeignClass ||
+                     TypeResult->getKind() == TypeRefKind::ObjCClass;
+      if (auto *nominal = llvm::dyn_cast<NominalTypeRef>(TypeResult))
+        IsClass = nominal->isClass();
+      else if (auto *boundGeneric =
+                   llvm::dyn_cast<BoundGenericTypeRef>(TypeResult))
+        IsClass = boundGeneric->isClass();
+      return IsClass;
+    };
+
+    auto DereferenceAndSet = [&](RemoteAddress &Address) {
+      auto PointerValue = readResolvedPointerValue(Address.getAddressData());
+      if (!PointerValue)
+        return false;
+      Address = RemoteAddress(*PointerValue);
+      return true;
+    };
+
+    auto ExistentialRecordTI = getRecordTypeInfo(&ExistentialTR, nullptr);
+    if (!ExistentialRecordTI)
+      return {};
+
+    switch (ExistentialRecordTI->getRecordKind()) {
+    case RecordKind::ClassExistential:
+      return getDynamicTypeAndAddressClassExistential(ExistentialAddress);
+    case RecordKind::ErrorExistential: {
+      // LLDB stores the address of the error pointer.
+      if (!DereferenceAndSet(ExistentialAddress))
+        return {};
+
+      bool IsBridgedError = false;
+      auto Pair = getDynamicTypeAndAddressErrorExistential(ExistentialAddress,
+                                                           &IsBridgedError);
+      if (!Pair)
+        return {};
+
+      if (!IsBridgedError && IsClass(std::get<const TypeRef *>(*Pair)))
+        if (!DereferenceAndSet(std::get<RemoteAddress>(*Pair)))
+          return {};
+
+      return Pair;
+    }
+    case RecordKind::OpaqueExistential: {
+      auto Pair = getDynamicTypeAndAddressOpaqueExistential(ExistentialAddress);
+      if (!Pair)
+        return {};
+
+      if (IsClass(std::get<const TypeRef *>(*Pair)))
+        if (!DereferenceAndSet(std::get<RemoteAddress>(*Pair)))
+          return {};
+
+      return Pair;
+    }
+    default:
+      return {};
+    }
+  }
 
   /// Projects the value of an enum.
   ///
@@ -887,6 +1002,12 @@ public:
     } else {
       return getBuilder().getTypeConverter().getTypeInfo(TR, ExternalTypeInfo);
     }
+  }
+
+  const RecordTypeInfo *getRecordTypeInfo(const TypeRef *TR,
+                              remote::TypeInfoProvider *ExternalTypeInfo) {
+    auto *TypeInfo = getTypeInfo(TR, ExternalTypeInfo);
+    return dyn_cast_or_null<const RecordTypeInfo>(TypeInfo);
   }
 
   /// Iterate the protocol conformance cache tree rooted at NodePtr, calling

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -247,6 +247,19 @@ int swift_reflection_projectExistential(SwiftReflectionContextRef ContextRef,
                                         swift_typeref_t *OutInstanceTypeRef,
                                         swift_addr_t *OutStartOfInstanceData);
 
+/// Like swift_reflection_projectExistential, with 2 differences:
+///
+/// - When dealing with an error existential, this version will dereference 
+///   the ExistentialAddress before proceeding.
+/// - After setting OutInstanceTypeRef and OutStartOfInstanceData this version
+///   may derefence and set OutStartOfInstanceData if OutInstanceTypeRef is a 
+///   class TypeRef.
+SWIFT_REMOTE_MIRROR_LINKAGE
+int swift_reflection_projectExistentialAndUnwrapClass(
+    SwiftReflectionContextRef ContextRef, swift_addr_t ExistentialAddress,
+    swift_typeref_t ExistentialTypeRef, swift_typeref_t *OutInstanceTypeRef,
+    swift_addr_t *OutStartOfInstanceData);
+
 /// Projects the value of an enum.
 ///
 /// Takes the address and typeref for an enum and determines the

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -571,6 +571,23 @@ int swift_reflection_projectExistential(SwiftReflectionContextRef ContextRef,
   return Success;
 }
 
+int swift_reflection_projectExistentialAndUnwrapClass(SwiftReflectionContextRef ContextRef,
+                                        swift_addr_t ExistentialAddress,
+                                        swift_typeref_t ExistentialTypeRef,
+                                        swift_typeref_t *InstanceTypeRef,
+                                        swift_addr_t *StartOfInstanceData) {
+  auto Context = ContextRef->nativeContext;
+  auto ExistentialTR = reinterpret_cast<const TypeRef *>(ExistentialTypeRef);
+  auto RemoteExistentialAddress = RemoteAddress(ExistentialAddress);
+  auto Pair = Context->projectExistentialAndUnwrapClass(
+      RemoteExistentialAddress, *ExistentialTR);
+  if (!Pair.hasValue())
+    return false;
+  *InstanceTypeRef = reinterpret_cast<swift_typeref_t>(std::get<const TypeRef *>(*Pair));
+  *StartOfInstanceData = std::get<RemoteAddress>(*Pair).getAddressData();
+
+  return true;
+}
 int swift_reflection_projectEnumValue(SwiftReflectionContextRef ContextRef,
                                       swift_addr_t EnumAddress,
                                       swift_typeref_t EnumTypeRef,

--- a/stdlib/tools/swift-reflection-test/messages.h
+++ b/stdlib/tools/swift-reflection-test/messages.h
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 static const char *REQUEST_INSTANCE_KIND = "k\n";
+static const char *REQUEST_SHOULD_UNWRAP_CLASS_EXISTENTIAL = "u\n";
 static const char *REQUEST_INSTANCE_ADDRESS = "i\n";
 static const char *REQUEST_REFLECTION_INFO = "r\n";
 static const char *REQUEST_IMAGES = "m\n";

--- a/validation-test/Reflection/existentials.swift
+++ b/validation-test/Reflection/existentials.swift
@@ -71,6 +71,8 @@ reflect(any: mc)
 // CHECK-64: Mangled name: $s12existentials7MyClassCyS2iG
 // CHECK-64: Demangled name: existentials.MyClass<Swift.Int, Swift.Int>
 
+// CHECK-64: Start of instance data: [[ADDR:0x[0-9a-fA-F]+]]
+
 // CHECK-32: Reflecting an existential.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
 // CHECK-32:        Type reference:
@@ -81,6 +83,40 @@ reflect(any: mc)
 // CHECK-32: (reference kind=strong refcounting=native)
 // CHECK-32: Mangled name: $s12existentials7MyClassCyS2iG
 // CHECK-32: Demangled name: existentials.MyClass<Swift.Int, Swift.Int>
+
+// CHECK-32: Start of instance data: [[ADDR:0x[0-9a-fA-F]+]]
+
+// Reflect and unwrap class existential should print the exact same info,
+// EXCEPT for the start of instance data address.
+reflect(any: mc, shouldUnwrapClassExistential: true)
+
+// CHECK-64: Reflecting an existential and unwrapping class.
+// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-64:         Type reference:
+// CHECK-64:         (bound_generic_class existentials.MyClass
+// CHECK-64-NEXT:    (struct Swift.Int)
+// CHECK-64-NEXT:    (struct Swift.Int))
+// CHECK-64: Type info:
+// CHECK-64: (reference kind=strong refcounting=native)
+// CHECK-64: Mangled name: $s12existentials7MyClassCyS2iG
+// CHECK-64: Demangled name: existentials.MyClass<Swift.Int, Swift.Int>
+
+// CHECK-64: Start of instance data: 
+// CHECK-64-NOT: ![[ADDR]]
+
+// CHECK-32: Reflecting an existential and unwrapping class.
+// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-32:        Type reference:
+// CHECK-32:        (bound_generic_class existentials.MyClass
+// CHECK-32-NEXT:   (struct Swift.Int)
+// CHECK-32-NEXT:   (struct Swift.Int))
+// CHECK-32: Type info:
+// CHECK-32: (reference kind=strong refcounting=native)
+// CHECK-32: Mangled name: $s12existentials7MyClassCyS2iG
+// CHECK-32: Demangled name: existentials.MyClass<Swift.Int, Swift.Int>
+
+// CHECK-32: Start of instance data: 
+// CHECK-32-NOT: ![[ADDR]]
 
 // This value fits in the 3-word buffer in the container.
 var smallStruct = MyStruct(x: 1, y: 2, z: 3)
@@ -111,6 +147,9 @@ reflect(any: smallStruct)
 // CHECK-64-NEXT:   Mangled name:  $s12existentials8MyStructVyS3iG
 // CHECK-64-NEXT:   Demangled name:  existentials.MyStruct<Swift.Int, Swift.Int, Swift.Int>
 
+// CHECK-64: Start of instance data: [[ADDR:0x[0-9a-fA-F]+]]
+
+
 // CHECK-32: Reflecting an existential.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
 // CHECK-32:        Type reference:
@@ -135,6 +174,66 @@ reflect(any: smallStruct)
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 // CHECK-32-NEXT:   Mangled name:  $s12existentials8MyStructVyS3iG
 // CHECK-32-NEXT:   Demangled name:  existentials.MyStruct<Swift.Int, Swift.Int, Swift.Int>
+
+// CHECK-32: Start of instance data: [[ADDR:0x[0-9a-fA-F]+]]
+
+reflect(any: smallStruct, shouldUnwrapClassExistential: true)
+
+// CHECK-64: Reflecting an existential and unwrapping class.
+// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-64:        Type reference:
+// CHECK-64:        (bound_generic_struct existentials.MyStruct
+// CHECK-64-NEXT:   (struct Swift.Int)
+// CHECK-64-NEXT:   (struct Swift.Int)
+// CHECK-64-NEXT:   (struct Swift.Int))
+
+// CHECK-64:        Type info:
+// CHECK-64:        (struct size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:   (field name=x offset=0
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:       (field name=_value offset=0
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-64-NEXT:   (field name=y offset=8
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:       (field name=_value offset=0
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-64-NEXT:   (field name=z offset=16
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:       (field name=_value offset=0
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
+// CHECK-64-NEXT:   Mangled name:  $s12existentials8MyStructVyS3iG
+// CHECK-64-NEXT:   Demangled name:  existentials.MyStruct<Swift.Int, Swift.Int, Swift.Int>
+
+// CHECK-64: Start of instance data: 
+// CHECK-64-NOT: ![[ADDR]]
+
+// CHECK-32: Reflecting an existential and unwrapping class.
+// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-32:        Type reference:
+// CHECK-32:        (bound_generic_struct existentials.MyStruct
+// CHECK-32-NEXT:   (struct Swift.Int)
+// CHECK-32-NEXT:   (struct Swift.Int)
+// CHECK-32-NEXT:   (struct Swift.Int))
+
+// CHECK-32:        Type info:
+// CHECK-32:        (struct size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32-NEXT:   (field name=x offset=0
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32-NEXT:       (field name=_value offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-32-NEXT:   (field name=y offset=4
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32-NEXT:       (field name=_value offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-32-NEXT:   (field name=z offset=8
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32-NEXT:       (field name=_value offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
+// CHECK-32-NEXT:   Mangled name:  $s12existentials8MyStructVyS3iG
+// CHECK-32-NEXT:   Demangled name:  existentials.MyStruct<Swift.Int, Swift.Int, Swift.Int>
+
+// CHECK-32: Start of instance data: 
+// CHECK-32-NOT: ![[ADDR]]
 
 // This value will be copied into a heap buffer, with a
 // pointer to it in the existential.
@@ -204,6 +303,9 @@ reflect(any: largeStruct)
 // CHECK-64-NEXT:   Mangled name: $s12existentials8MyStructVySi_S2itSi_S2itSi_S2itG
 // CHECK-64-NEXT:   Demangled name: existentials.MyStruct<(Swift.Int, Swift.Int, Swift.Int), (Swift.Int, Swift.Int, Swift.Int), (Swift.Int, Swift.Int, Swift.Int)>
 
+// CHECK-64: Start of instance data: [[ADDR:0x[0-9a-fA-F]+]]
+
+
 // CHECK-32: Reflecting an existential.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
 // CHECK-32:        Type reference:
@@ -266,6 +368,142 @@ reflect(any: largeStruct)
 // CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))))
 // CHECK-32-NEXT:   Mangled name: $s12existentials8MyStructVySi_S2itSi_S2itSi_S2itG
 // CHECK-32-NEXT:   Demangled name: existentials.MyStruct<(Swift.Int, Swift.Int, Swift.Int), (Swift.Int, Swift.Int, Swift.Int), (Swift.Int, Swift.Int, Swift.Int)>
+
+// CHECK-32: Start of instance data: [[ADDR:0x[0-9a-fA-F]+]]
+
+reflect(any: largeStruct, shouldUnwrapClassExistential: true)
+
+// CHECK-64: Reflecting an existential and unwrapping class.
+// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-64:        Type reference:
+// CHECK-64:        (bound_generic_struct existentials.MyStruct
+// CHECK-64-NEXT:   (tuple
+// CHECK-64-NEXT:     (struct Swift.Int)
+// CHECK-64-NEXT:     (struct Swift.Int)
+// CHECK-64-NEXT:     (struct Swift.Int))
+// CHECK-64-NEXT:   (tuple
+// CHECK-64-NEXT:     (struct Swift.Int)
+// CHECK-64-NEXT:     (struct Swift.Int)
+// CHECK-64-NEXT:     (struct Swift.Int))
+// CHECK-64-NEXT:   (tuple
+// CHECK-64-NEXT:     (struct Swift.Int)
+// CHECK-64-NEXT:     (struct Swift.Int)
+// CHECK-64-NEXT:     (struct Swift.Int)))
+// CHECK-64: Type info:
+// CHECK-64-NEXT: (struct size=72 alignment=8 stride=72 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:   (field name=x offset=0
+// CHECK-64-NEXT:     (tuple size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:       (field offset=0
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:           (field name=_value offset=0
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-64-NEXT:       (field offset=8
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:           (field name=_value offset=0
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-64-NEXT:       (field offset=16
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:           (field name=_value offset=0
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-64-NEXT:   (field name=y offset=24
+// CHECK-64-NEXT:     (tuple size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:       (field offset=0
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:           (field name=_value offset=0
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-64-NEXT:       (field offset=8
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:           (field name=_value offset=0
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-64-NEXT:       (field offset=16
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:           (field name=_value offset=0
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-64-NEXT:   (field name=z offset=48
+// CHECK-64-NEXT:     (tuple size=24 alignment=8 stride=24 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:       (field offset=0
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:           (field name=_value offset=0
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-64-NEXT:       (field offset=8
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:           (field name=_value offset=0
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-64-NEXT:       (field offset=16
+// CHECK-64-NEXT:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:           (field name=_value offset=0
+// CHECK-64-NEXT:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))))
+// CHECK-64-NEXT:   Mangled name: $s12existentials8MyStructVySi_S2itSi_S2itSi_S2itG
+// CHECK-64-NEXT:   Demangled name: existentials.MyStruct<(Swift.Int, Swift.Int, Swift.Int), (Swift.Int, Swift.Int, Swift.Int), (Swift.Int, Swift.Int, Swift.Int)>
+
+// CHECK-64: Start of instance data: 
+// CHECK-64-NOT: ![[ADDR]]
+
+// CHECK-32: Reflecting an existential and unwrapping class.
+// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-32:        Type reference:
+// CHECK-32:        (bound_generic_struct existentials.MyStruct
+// CHECK-32-NEXT:   (tuple
+// CHECK-32-NEXT:     (struct Swift.Int)
+// CHECK-32-NEXT:     (struct Swift.Int)
+// CHECK-32-NEXT:     (struct Swift.Int))
+// CHECK-32-NEXT:   (tuple
+// CHECK-32-NEXT:     (struct Swift.Int)
+// CHECK-32-NEXT:     (struct Swift.Int)
+// CHECK-32-NEXT:     (struct Swift.Int))
+// CHECK-32-NEXT:   (tuple
+// CHECK-32-NEXT:     (struct Swift.Int)
+// CHECK-32-NEXT:     (struct Swift.Int)
+// CHECK-32-NEXT:     (struct Swift.Int)))
+// CHECK-32:        Type info:
+// CHECK-32:        (struct size=36 alignment=4 stride=36 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32-NEXT:   (field name=x offset=0
+// CHECK-32-NEXT:     (tuple size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32-NEXT:       (field offset=0
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32-NEXT:           (field name=_value offset=0
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-32-NEXT:       (field offset=4
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32-NEXT:           (field name=_value offset=0
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-32-NEXT:       (field offset=8
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32-NEXT:           (field name=_value offset=0
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-32-NEXT:   (field name=y offset=12
+// CHECK-32-NEXT:     (tuple size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32-NEXT:       (field offset=0
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32-NEXT:           (field name=_value offset=0
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-32-NEXT:       (field offset=4
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32-NEXT:           (field name=_value offset=0
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-32-NEXT:       (field offset=8
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32-NEXT:           (field name=_value offset=0
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK-32-NEXT:   (field name=z offset=24
+// CHECK-32-NEXT:     (tuple size=12 alignment=4 stride=12 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32-NEXT:       (field offset=0
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32-NEXT:           (field name=_value offset=0
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-32-NEXT:       (field offset=4
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32-NEXT:           (field name=_value offset=0
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK-32-NEXT:       (field offset=8
+// CHECK-32-NEXT:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32-NEXT:           (field name=_value offset=0
+// CHECK-32-NEXT:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))))
+// CHECK-32-NEXT:   Mangled name: $s12existentials8MyStructVySi_S2itSi_S2itSi_S2itG
+// CHECK-32-NEXT:   Demangled name: existentials.MyStruct<(Swift.Int, Swift.Int, Swift.Int), (Swift.Int, Swift.Int, Swift.Int), (Swift.Int, Swift.Int, Swift.Int)>
+
+// CHECK-32: Start of instance data: 
+// CHECK-32-NOT: ![[ADDR]]
 
 // Function type:
 reflect(any: {largeStruct})
@@ -346,6 +584,8 @@ reflect(any: he)
 // CHECK-64-NEXT:   Mangled name: $s12existentials8HasErrorV
 // CHECK-64-NEXT:   Demangled name: existentials.HasError
 
+// CHECK-64: Start of instance data: [[ADDR:0x[0-9a-fA-F]+]]
+
 // CHECK-32: Reflecting an existential.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
 // CHECK-32: Type reference:
@@ -382,7 +622,91 @@ reflect(any: he)
 // CHECK-32-NEXT:   Mangled name: $s12existentials8HasErrorV
 // CHECK-32-NEXT:   Demangled name: existentials.HasError
 
-reflect(error: MyError())
+// CHECK-32: Start of instance data: [[ADDR:0x[0-9a-fA-F]+]]
+
+
+reflect(any: he, shouldUnwrapClassExistential: true)
+
+// CHECK-64: Reflecting an existential and unwrapping class.
+// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F+]}}
+// CHECK-64: Type reference:
+// CHECK-64: (struct existentials.HasError)
+
+// CHECK-64:        Type info:
+// CHECK-64:        (struct size=144 alignment=8 stride=144
+// CHECK-64-NEXT:   (field name=singleError offset=0
+// CHECK-64-NEXT:     (error_existential size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
+// CHECK-64-NEXT:       (field name=error offset=0
+// CHECK-64-NEXT:         (reference kind=strong refcounting=unknown))))
+// CHECK-64-NEXT:   (field name=errorInComposition offset=8
+// CHECK-64-NEXT:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
+// CHECK-64-NEXT:       (field name=metadata offset=24
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))
+// CHECK-64-NEXT:       (field name=wtable offset=32
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))
+// CHECK-64-NEXT:       (field name=wtable offset=40
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))
+// CHECK-64-NEXT:   (field name=customError offset=56
+// CHECK-64-NEXT:     (opaque_existential size=40 alignment=8 stride=40 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
+// CHECK-64-NEXT:       (field name=metadata offset=24
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))
+// CHECK-64-NEXT:       (field name=wtable offset=32
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))))
+// CHECK-64-NEXT:   (field name=customErrorInComposition offset=96
+// CHECK-64-NEXT:     (opaque_existential size=48 alignment=8 stride=48 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
+// CHECK-64-NEXT:       (field name=metadata offset=24
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))
+// CHECK-64-NEXT:       (field name=wtable offset=32
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1))
+// CHECK-64-NEXT:       (field name=wtable offset=40
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=1 bitwise_takable=1)))))
+// CHECK-64-NEXT:   Mangled name: $s12existentials8HasErrorV
+// CHECK-64-NEXT:   Demangled name: existentials.HasError
+
+// CHECK-64: Start of instance data: 
+// CHECK-64-NOT: ![[ADDR]]
+
+// CHECK-32: Reflecting an existential and unwrapping class.
+// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-32: Type reference:
+// CHECK-32: (struct existentials.HasError)
+
+// CHECK-32:        Type info:
+// CHECK-32:        (struct size=72 alignment=4 stride=72 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32-NEXT:   (field name=singleError offset=0
+// CHECK-32-NEXT:     (error_existential size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32-NEXT:       (field name=error offset=0
+// CHECK-32-NEXT:         (reference kind=strong refcounting=unknown))))
+// CHECK-32-NEXT:   (field name=errorInComposition offset=4
+// CHECK-32-NEXT:     (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32-NEXT:       (field name=metadata offset=12
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
+// CHECK-32-NEXT:       (field name=wtable offset=16
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))
+// CHECK-32-NEXT:       (field name=wtable offset=20
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))
+// CHECK-32-NEXT:   (field name=customError offset=28
+// CHECK-32-NEXT:     (opaque_existential size=20 alignment=4 stride=20 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32-NEXT:       (field name=metadata offset=12
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
+// CHECK-32-NEXT:       (field name=wtable offset=16
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))))
+// CHECK-32-NEXT:   (field name=customErrorInComposition offset=48
+// CHECK-32-NEXT:     (opaque_existential size=24 alignment=4 stride=24 num_extra_inhabitants=4096 bitwise_takable=1
+// CHECK-32-NEXT:       (field name=metadata offset=12
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=4096 bitwise_takable=1))
+// CHECK-32-NEXT:       (field name=wtable offset=16
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1))
+// CHECK-32-NEXT:       (field name=wtable offset=20
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=1 bitwise_takable=1)))))
+// CHECK-32-NEXT:   Mangled name: $s12existentials8HasErrorV
+// CHECK-32-NEXT:   Demangled name: existentials.HasError
+
+// CHECK-32: Start of instance data: 
+// CHECK-32-NOT: ![[ADDR]]
+
+let error = MyError()
+reflect(error: error)
 
 // CHECK-64: Reflecting an error existential.
 // CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
@@ -398,6 +722,8 @@ reflect(error: MyError())
 // CHECK-64-NEXT:   Mangled name: $s12existentials7MyErrorV
 // CHECK-64-NEXT:   Demangled name: existentials.MyError
 
+// CHECK-64: Start of instance data: [[ADDR:0x[0-9a-fA-F]+]]
+
 // CHECK-32: Reflecting an error existential.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
 // CHECK-32: Type reference:
@@ -411,5 +737,42 @@ reflect(error: MyError())
 // CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
 // CHECK-32-NEXT:   Mangled name: $s12existentials7MyErrorV
 // CHECK-32-NEXT:   Demangled name: existentials.MyError
+
+// CHECK-32: Start of instance data: [[ADDR:0x[0-9a-fA-F]+]]
+
+reflectUnwrappingClassExistential(error: error)
+// CHECK-64: Reflecting an error existential and unwrapping class.
+// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-64: Type reference:
+// CHECK-64: (struct existentials.MyError)
+
+// CHECK-64:        Type info:
+// CHECK-64:        (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:   (field name=i offset=0
+// CHECK-64-NEXT:     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-64-NEXT:       (field name=_value offset=0
+// CHECK-64-NEXT:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))
+// CHECK-64-NEXT:   Mangled name: $s12existentials7MyErrorV
+// CHECK-64-NEXT:   Demangled name: existentials.MyError
+
+// CHECK-64: Start of instance data: 
+// CHECK-64-NOT: ![[ADDR]]
+
+// CHECK-32: Reflecting an error existential and unwrapping class.
+// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-32: Type reference:
+// CHECK-32: (struct existentials.MyError)
+
+// CHECK-32:        Type info:
+// CHECK-32:        (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32-NEXT:   (field name=i offset=0
+// CHECK-32-NEXT:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK-32-NEXT:       (field name=_value offset=0
+// CHECK-32-NEXT:         (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))
+// CHECK-32-NEXT:   Mangled name: $s12existentials7MyErrorV
+// CHECK-32-NEXT:   Demangled name: existentials.MyError
+
+// CHECK-32: Start of instance data: 
+// CHECK-32-NOT: ![[ADDR]]
 
 doneReflecting()


### PR DESCRIPTION
Implement a version of projectExistential tailored for LLDB. There are 2
differences when projecting existentials for LLDB:

1 - When it comes to existentials, LLDB stores the address of the error
    pointer, which must be dereferenced.
2 - When the existential wraps a class type, LLDB expects the address
    returned is the class instance itself and not the address of the
    reference.

This patch also adapts the swift reflection test machinery to test
projectExistentialAndUnwrapClass as well. This is done by exposing
the new functionality from swift reflection test.  It is tested in
existentials.swift, and ensures that the typeref information is
exactly the same as what is expected from projectExistential,
except the out address.

(cherry picked from commit 55e971e06750c3ba29722d558cc5400298f6bdaf)

