### PR TITLE
Print raw values for C/C++ enums.

### DIFF
--- a/test/stdlib/Reflection_objc.swift
+++ b/test/stdlib/Reflection_objc.swift
@@ -69,8 +69,8 @@ print("ObjC quick look objects:")
 // CHECK-LABEL: ObjC enums:
 print("ObjC enums:")
 
-// CHECK-NEXT: We cannot reflect NSComparisonResult yet
-print("We cannot reflect \(ComparisonResult.orderedAscending) yet")
+// CHECK-NEXT: We cannot properly reflect NSComparisonResult(rawValue: -1) yet
+print("We cannot properly reflect \(ComparisonResult.orderedAscending) yet")
 
 // Don't crash when introspecting framework types such as NSURL.
 // <rdar://problem/16592777>


### PR DESCRIPTION
When printing C/C++ enum values, in lieu of having proper metadata for the enum
type, try to display a raw value (see SR-6550)

rdar://56473712