### PR TITLE
[5.5] fix weak reference lifetime warnings and disable by default

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -154,8 +154,12 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   P.addDiagnoseInfiniteRecursion();
   P.addYieldOnceCheck();
   P.addEmitDFDiagnostics();
-  P.addDiagnoseLifetimeIssues();
 
+  // Only issue weak lifetime warnings for users who select object lifetime
+  // optimization. The risk of spurious warnings outweighs the benefits.
+  if (P.getOptions().EnableCopyPropagation) {
+    P.addDiagnoseLifetimeIssues();
+  }
   // Canonical swift requires all non cond_br critical edges to be split.
   P.addSplitNonCondBrCriticalEdges();
 }

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -106,7 +106,7 @@ func test2() {
   weak var w1 : SomeClass?
   _ = w1                // ok: default-initialized
 
-  // expected-warning@+4 {{weak reference will always be nil because the referenced object is deallocated here}}
+  // Note: with -enable-copy-propagation, we also expect: {{weak reference will always be nil because the referenced object is deallocated here}}
   // expected-warning@+3 {{instance will be immediately deallocated because variable 'w2' is 'weak'}}
   // expected-note@+2 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@+1 {{'w2' declared here}}
@@ -1336,7 +1336,7 @@ func testDontDiagnoseUnownedImmediateDeallocationThroughStrong() {
   weak var c1: SomeClass?
   do {
     let tmp = SomeClass()
-    c1 = tmp // expected-warning {{weak reference will always be nil because the referenced object is deallocated here}}
+    c1 = tmp // Note: with -enable-copy-propagation, we also expect: {{weak reference will always be nil because the referenced object is deallocated here}}
   }
 
   unowned let c2: SomeClass
@@ -1347,7 +1347,7 @@ func testDontDiagnoseUnownedImmediateDeallocationThroughStrong() {
 
   weak var c3: SomeClass?
   let c3Tmp = SomeClass()
-  c3 = c3Tmp // expected-warning {{weak reference will always be nil because the referenced object is deallocated here}}
+  c3 = c3Tmp // Note: with -enable-copy-propagation, we also expect: {{weak reference will always be nil because the referenced object is deallocated here}}
 
   unowned let c4: SomeClass
   let c4Tmp = SomeClass()

--- a/test/SILOptimizer/diagnose_lifetime_issues.sil
+++ b/test/SILOptimizer/diagnose_lifetime_issues.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -diagnose-lifetime-issues  -o /dev/null -verify
+// RUN: %target-sil-opt -enable-sil-verify-all %s -diagnose-lifetime-issues -o /dev/null -verify
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/diagnose_lifetime_issues.sil
+++ b/test/SILOptimizer/diagnose_lifetime_issues.sil
@@ -1,0 +1,121 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -diagnose-lifetime-issues  -o /dev/null -verify
+
+import Builtin
+import Swift
+
+enum FakeOptional<T> {
+case none
+case some(T)
+}
+
+class Delegate {
+  func foo() { }
+}
+
+class MyDelegate : Delegate {}
+
+final class Container {
+  weak var delegate: Delegate?
+  var strongRef: Delegate
+
+  func callDelegate()
+
+  func strongDelegate(d: Delegate)
+}
+
+class WeakCycle {
+  weak var c: WeakCycle?
+}
+
+sil [ossa] @$s24diagnose_lifetime_issues10MyDelegateCACycfC : $@convention(method) (@thick MyDelegate.Type) -> @owned MyDelegate
+sil [ossa] @$s24diagnose_lifetime_issues14strongDelegate1dyAA0D0C_tF : $@convention(method) (@guaranteed Delegate, @guaranteed Container) -> ()
+
+// Test a warning for a reference that is copied, cast, and assigned
+// to an enum before it is assigned to a weak reference.
+sil [ossa] @testCastWarn : $@convention(thin) (@guaranteed Container) -> () {
+bb0(%0 : @guaranteed $Container):
+  debug_value %0 : $Container, let, name "container", argno 1
+  %2 = metatype $@thick MyDelegate.Type
+  // function_ref MyDelegate.__allocating_init()
+  %3 = function_ref @$s24diagnose_lifetime_issues10MyDelegateCACycfC : $@convention(method) (@thick MyDelegate.Type) -> @owned MyDelegate
+
+  // This is the owned allocation.
+  %4 = apply %3(%2) : $@convention(method) (@thick MyDelegate.Type) -> @owned MyDelegate
+  %11 = copy_value %4 : $MyDelegate
+
+  // This upcast+enum is not an escape.
+  %12 = upcast %11 : $MyDelegate to $Delegate
+  %13 = enum $Optional<Delegate>, #Optional.some!enumelt, %12 : $Delegate
+  %14 = ref_element_addr %0 : $Container, #Container.delegate
+  %15 = begin_access [modify] [dynamic] %14 : $*@sil_weak Optional<Delegate>
+
+  // This is the weak assignment.
+  store_weak %13 to %15 : $*@sil_weak Optional<Delegate> // expected-warning {{weak reference will always be nil because the referenced object is deallocated here}}
+  destroy_value %13 : $Optional<Delegate>
+  end_access %15 : $*@sil_weak Optional<Delegate>
+  destroy_value %4 : $MyDelegate
+  %20 = tuple ()
+  return %20 : $()
+}
+
+// Test that a reference that escapes within a borrow scope has no warning.
+sil hidden [ossa] @testBorrowNoWarn : $@convention(thin) (@guaranteed Container) -> () {
+// %0 "container"
+bb0(%0 : @guaranteed $Container):
+  debug_value %0 : $Container, let, name "container", argno 1
+  %2 = metatype $@thick MyDelegate.Type
+  // function_ref MyDelegate.__allocating_init()
+  %3 = function_ref @$s24diagnose_lifetime_issues10MyDelegateCACycfC : $@convention(method) (@thick MyDelegate.Type) -> @owned MyDelegate
+
+  // This is the owned allocation.
+  %4 = apply %3(%2) : $@convention(method) (@thick MyDelegate.Type) -> @owned MyDelegate
+  debug_value %4 : $MyDelegate, let, name "delegate"
+  %6 = begin_borrow %4 : $MyDelegate
+  %7 = upcast %6 : $MyDelegate to $Delegate
+  // function_ref Container.strongDelegate(d:)
+  %8 = function_ref @$s24diagnose_lifetime_issues14strongDelegate1dyAA0D0C_tF : $@convention(method) (@guaranteed Delegate, @guaranteed Container) -> ()
+
+  // This apply is an escape.
+  %9 = apply %8(%7, %0) : $@convention(method) (@guaranteed Delegate, @guaranteed Container) -> ()
+  end_borrow %6 : $MyDelegate
+  %11 = copy_value %4 : $MyDelegate
+  %12 = upcast %11 : $MyDelegate to $Delegate
+  %13 = enum $Optional<Delegate>, #Optional.some!enumelt, %12 : $Delegate
+  %14 = ref_element_addr %0 : $Container, #Container.delegate
+  %15 = begin_access [modify] [dynamic] %14 : $*@sil_weak Optional<Delegate>
+
+  // This is the weak assignment.
+  store_weak %13 to %15 : $*@sil_weak Optional<Delegate>
+  destroy_value %13 : $Optional<Delegate>
+  end_access %15 : $*@sil_weak Optional<Delegate>
+  destroy_value %4 : $MyDelegate
+  %20 = tuple ()
+  return %20 : $()
+}
+
+// Helper for testReturnsAfterStore
+sil hidden [ossa] @testStoresWeakly : $@convention(method) (@owned WeakCycle) -> @owned WeakCycle {
+bb0(%0 : @owned $WeakCycle):
+  %18 = begin_borrow %0 : $WeakCycle
+  %19 = copy_value %0 : $WeakCycle
+  %20 = enum $Optional<WeakCycle>, #Optional.some!enumelt, %19 : $WeakCycle
+  %21 = ref_element_addr %18 : $WeakCycle, #WeakCycle.c
+  %22 = begin_access [modify] [dynamic] %21 : $*@sil_weak Optional<WeakCycle>
+  store_weak %20 to %22 : $*@sil_weak Optional<WeakCycle>
+  destroy_value %20 : $Optional<WeakCycle>
+  end_access %22 : $*@sil_weak Optional<WeakCycle>
+  end_borrow %18 : $WeakCycle
+  %27 = copy_value %0 : $WeakCycle
+  destroy_value %0 : $WeakCycle
+  return %27 : $WeakCycle
+}
+
+// Test no warning for a value returned after a weak store.
+sil hidden [exact_self_class] [ossa] @testReturnsAfterStore : $@convention(method) (@thick WeakCycle.Type) -> @owned WeakCycle {
+bb0(%0 : $@thick WeakCycle.Type):
+  %1 = alloc_ref $WeakCycle
+
+  %2 = function_ref @testStoresWeakly : $@convention(method) (@owned WeakCycle) -> @owned WeakCycle
+  %3 = apply %2(%1) : $@convention(method) (@owned WeakCycle) -> @owned WeakCycle
+  return %3 : $WeakCycle
+}

--- a/test/SILOptimizer/diagnose_lifetime_issues.swift
+++ b/test/SILOptimizer/diagnose_lifetime_issues.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil -enable-copy-propagation %s -o /dev/null -verify
 
 class Delegate {
   func foo() { }

--- a/test/SILOptimizer/diagnose_lifetime_issues_objc.swift
+++ b/test/SILOptimizer/diagnose_lifetime_issues_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil %s -enable-copy-propagation -o /dev/null -verify
 // REQUIRES: objc_interop
 
 import Foundation


### PR DESCRIPTION
Fix weak reference lifetime warnings, making them more precise and avoiding spurious warnings. Adding logic to this pass and increasing precision adds risk, so disable the warnings by default.

Only issue weak lifetime warnings for users who select object lifetime
optimization. The risk of spurious warnings outweighs the benefits.

Although the warnings are generally useful regardless of the level of
optimization, it isn't really critical to issue them unless the optimizer
aggressively shrinks reference lifetimes.

Fixes rdar://79146338 Xcode warns that "referenced object is
deallocated here" but that object was passed into a method that causes
strong retention)