### PR TITLE
[TypeChecker] Implement limited set of conversions between Swift and C pointers

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -362,6 +362,11 @@ ERROR(cannot_convert_argument_value,none,
       "cannot convert value of type %0 to expected argument type %1",
       (Type,Type))
 
+ERROR(cannot_convert_argument_value_for_swift_func,none,
+      "cannot convert value of type %0 to expected argument type %1 "
+      "because %2 %3 was not imported from C header",
+      (Type,Type, DescriptiveDeclKind, DeclName))
+
 NOTE(candidate_has_invalid_argument_at_position,none,
      "candidate expects %select{|in-out }2value of type %0 for parameter #%1 (got %3)",
      (Type, unsigned, bool, Type))

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -336,6 +336,10 @@ enum class FixKind : uint8_t {
   /// resolved.
   SpecifyTypeForPlaceholder,
 
+  /// Allow Swift -> C pointer conversion in an argument position
+  /// of a Swift function.
+  AllowSwiftToCPointerConversion,
+
   /// Allow `weak` declarations to be bound to a non-optional type.
   AllowNonOptionalWeak,
 
@@ -2789,6 +2793,22 @@ public:
   static bool classof(ConstraintFix *fix) {
     return fix->getKind() == FixKind::AllowNonOptionalWeak;
   }
+};
+
+class AllowSwiftToCPointerConversion final : public ConstraintFix {
+  AllowSwiftToCPointerConversion(ConstraintSystem &cs,
+                                 ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AllowSwiftToCPointerConversion, locator) {}
+
+public:
+  std::string getName() const override {
+    return "allow implicit Swift -> C pointer conversion";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static AllowSwiftToCPointerConversion *create(ConstraintSystem &cs,
+                                                ConstraintLocator *locator);
 };
 
 } // end namespace constraints

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -269,6 +269,10 @@ enum class ConversionRestrictionKind {
   /// Implicit conversion from a value of CGFloat type to a value of Double type
   /// via an implicit Double initializer call passing a CGFloat value.
   CGFloatToDouble,
+  /// Implicit conversion between Swift and C pointers:
+  //    - Unsafe[Mutable]RawPointer -> Unsafe[Mutable]Pointer<[U]Int>
+  //    - Unsafe[Mutable]Pointer<Int{8, 16, ...}> -> Unsafe[Mutable]Pointer<UInt{8, 16, ...}>
+  PointerToCPointer,
 };
 
 /// Specifies whether a given conversion requires the creation of a temporary

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -271,7 +271,7 @@ enum class ConversionRestrictionKind {
   CGFloatToDouble,
   /// Implicit conversion between Swift and C pointers:
   //    - Unsafe[Mutable]RawPointer -> Unsafe[Mutable]Pointer<[U]Int>
-  //    - Unsafe[Mutable]Pointer<Int{8, 16, ...}> -> Unsafe[Mutable]Pointer<UInt{8, 16, ...}>
+  //    - Unsafe[Mutable]Pointer<Int{8, 16, ...}> <-> Unsafe[Mutable]Pointer<UInt{8, 16, ...}>
   PointerToCPointer,
 };
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5214,6 +5214,10 @@ public:
   /// as the anchor, and a path to the argument at index `0`.
   ConstraintLocator *getArgumentLocator(Expr *expr);
 
+  /// Determine whether given locator represents an argument to declaration
+  /// imported from C/ObjectiveC.
+  bool isArgumentOfImportedDecl(ConstraintLocatorBuilder locator);
+
   SWIFT_DEBUG_DUMP;
   SWIFT_DEBUG_DUMPER(dump(Expr *));
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4872,6 +4872,12 @@ public: // FIXME: Public for use by static functions.
                                      TypeMatchOptions flags,
                                      ConstraintLocatorBuilder locator);
 
+  /// Simplify a conversion between Swift and C pointers.
+  SolutionKind
+  simplifyPointerToCPointerRestriction(Type type1, Type type2,
+                                       TypeMatchOptions flags,
+                                       ConstraintLocatorBuilder locator);
+
 public:
   /// Simplify the system of constraints, by breaking down complex
   /// constraints into simpler constraints.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6645,7 +6645,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       return result;
     }
     
-    case ConversionRestrictionKind::PointerToPointer: {
+    case ConversionRestrictionKind::PointerToPointer:
+    case ConversionRestrictionKind::PointerToCPointer: {
       TypeChecker::requirePointerArgumentIntrinsics(ctx, expr->getLoc());
       Type unwrappedToTy = toType->getOptionalObjectType();
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6691,6 +6691,7 @@ void NonEphemeralConversionFailure::emitSuggestionNotes() const {
   case ConversionRestrictionKind::ExistentialMetatypeToAnyObject:
   case ConversionRestrictionKind::ProtocolMetatypeToProtocolClass:
   case ConversionRestrictionKind::PointerToPointer:
+  case ConversionRestrictionKind::PointerToCPointer:
   case ConversionRestrictionKind::ArrayUpcast:
   case ConversionRestrictionKind::DictionaryUpcast:
   case ConversionRestrictionKind::SetUpcast:

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7825,3 +7825,17 @@ bool InvalidWeakAttributeUse::diagnoseAsError() {
 
   return true;
 }
+
+bool SwiftToCPointerConversionInInvalidContext::diagnoseAsError() {
+  auto argInfo = getFunctionArgApplyInfo(getLocator());
+  if (!argInfo)
+    return false;
+
+  auto *callee = argInfo->getCallee();
+  auto argType = resolveType(argInfo->getArgType());
+  auto paramType = resolveType(argInfo->getParamType());
+
+  emitDiagnostic(diag::cannot_convert_argument_value_for_swift_func, argType,
+                 paramType, callee->getDescriptiveKind(), callee->getName());
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2607,6 +2607,26 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose situations where Swift -> C pointer implicit conversion
+/// is attempted on a Swift function instead of one imported from C header.
+///
+/// \code
+/// func test(_: UnsafePointer<UInt8>) {}
+///
+/// func pass_ptr(ptr: UnsafeRawPointer) {
+///   test(ptr) // Only okay if `test` was an imported C function.
+/// }
+/// \endcode
+class SwiftToCPointerConversionInInvalidContext final
+    : public FailureDiagnostic {
+public:
+  SwiftToCPointerConversionInInvalidContext(const Solution &solution,
+                                            ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2003,7 +2003,8 @@ AllowNonOptionalWeak *AllowNonOptionalWeak::create(ConstraintSystem &cs,
 
 bool AllowSwiftToCPointerConversion::diagnose(const Solution &solution,
                                               bool asNote) const {
-  return false;
+  SwiftToCPointerConversionInInvalidContext failure(solution, getLocator());
+  return failure.diagnose(asNote);
 }
 
 AllowSwiftToCPointerConversion *

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2000,3 +2000,14 @@ AllowNonOptionalWeak *AllowNonOptionalWeak::create(ConstraintSystem &cs,
                                                    ConstraintLocator *locator) {
   return new (cs.getAllocator()) AllowNonOptionalWeak(cs, locator);
 }
+
+bool AllowSwiftToCPointerConversion::diagnose(const Solution &solution,
+                                              bool asNote) const {
+  return false;
+}
+
+AllowSwiftToCPointerConversion *
+AllowSwiftToCPointerConversion::create(ConstraintSystem &cs,
+                                       ConstraintLocator *locator) {
+  return new (cs.getAllocator()) AllowSwiftToCPointerConversion(cs, locator);
+}

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5894,7 +5894,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
             //
             // Do some light verification before recording restriction to
             // avoid allocating constraints for obviously invalid cases.
-            if (type1IsPointer && !type1IsOptional && !type2IsOptional &&
+            if (type1IsPointer && optionalityMatches &&
                 isArgumentOfImportedDecl(locator)) {
               // UnsafeRawPointer -> UnsafePointer<[U]Int8>
               if (type1PointerKind == PTK_UnsafeRawPointer &&
@@ -11157,8 +11157,12 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
 
     PointerTypeKind swiftPtrKind, cPtrKind;
 
-    auto swiftPtr = type1->getAnyPointerElementType(swiftPtrKind);
-    auto cPtr = type2->getAnyPointerElementType(cPtrKind);
+    auto swiftPtr =
+        type1->lookThroughAllOptionalTypes()->getAnyPointerElementType(
+            swiftPtrKind);
+
+    auto cPtr = type2->lookThroughAllOptionalTypes()->getAnyPointerElementType(
+        cPtrKind);
 
     // Unsafe[Mutable]RawPointer -> Unsafe[Mutable]Pointer<[U]Int8>
     if (swiftPtrKind == PTK_UnsafeRawPointer ||

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11385,6 +11385,10 @@ ConstraintSystem::SolutionKind
 ConstraintSystem::simplifyPointerToCPointerRestriction(
     Type type1, Type type2, TypeMatchOptions flags,
     ConstraintLocatorBuilder locator) {
+  // Make sure that solutions with implicit pointer conversions
+  // are always worse than the ones without them.
+  increaseScore(SK_ImplicitValueConversion);
+
   auto &ctx = getASTContext();
 
   PointerTypeKind swiftPtrKind, cPtrKind;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11927,6 +11927,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AddSendableAttribute:
   case FixKind::DropThrowsAttribute:
   case FixKind::DropAsyncAttribute:
+  case FixKind::AllowSwiftToCPointerConversion:
     llvm_unreachable("handled elsewhere");
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5888,6 +5888,43 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                                    ConversionRestrictionKind::PointerToPointer);
               }
             }
+
+            // If both sides are non-optional pointers let's check whether
+            // this argument supports Swift -> C pointer conversions.
+            //
+            // Do some light verification before recording restriction to
+            // avoid allocating constraints for obviously invalid cases.
+            if (type1IsPointer && !type1IsOptional && !type2IsOptional &&
+                isArgumentOfImportedDecl(locator)) {
+              // UnsafeRawPointer -> UnsafePointer<[U]Int8>
+              if (type1PointerKind == PTK_UnsafeRawPointer &&
+                  pointerKind == PTK_UnsafePointer) {
+                conversionsOrFixes.push_back(
+                    ConversionRestrictionKind::PointerToCPointer);
+              }
+
+              // UnsafeMutableRawPointer -> Unsafe[Mutable]Pointer<[U]Int8>
+              if (type1PointerKind == PTK_UnsafeMutableRawPointer &&
+                  (pointerKind == PTK_UnsafePointer ||
+                   pointerKind == PTK_UnsafeMutablePointer)) {
+                conversionsOrFixes.push_back(
+                    ConversionRestrictionKind::PointerToCPointer);
+              }
+
+              // Unsafe[Mutable]Pointer -> Unsafe[Mutable]Pointer
+              if (type1PointerKind == PTK_UnsafePointer &&
+                  pointerKind == PTK_UnsafePointer) {
+                conversionsOrFixes.push_back(
+                    ConversionRestrictionKind::PointerToCPointer);
+              }
+
+              if (type1PointerKind == PTK_UnsafeMutablePointer &&
+                  (pointerKind == PTK_UnsafePointer ||
+                   pointerKind == PTK_UnsafeMutablePointer)) {
+                conversionsOrFixes.push_back(
+                    ConversionRestrictionKind::PointerToCPointer);
+              }
+            }
           }
           break;
 
@@ -11116,7 +11153,77 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
   }
 
   case ConversionRestrictionKind::PointerToCPointer: {
-    return SolutionKind::Error; // not yet implemented
+    auto &ctx = getASTContext();
+
+    PointerTypeKind swiftPtrKind, cPtrKind;
+
+    auto swiftPtr = type1->getAnyPointerElementType(swiftPtrKind);
+    auto cPtr = type2->getAnyPointerElementType(cPtrKind);
+
+    // Unsafe[Mutable]RawPointer -> Unsafe[Mutable]Pointer<[U]Int8>
+    if (swiftPtrKind == PTK_UnsafeRawPointer ||
+        swiftPtrKind == PTK_UnsafeMutableRawPointer) {
+      // Since it's a C pointer on parameter side it would always
+      // be fully resolved.
+      if (cPtr->isInt8() || cPtr->isUInt8())
+        return SolutionKind::Solved;
+    } else {
+      // Unsafe[Mutable]Pointer<T> -> Unsafe[Mutable]Pointer<[U]Int8>
+      if (cPtr->isInt8() || cPtr->isUInt8()) {
+        // <T> can default to the type of C pointer.
+        addConstraint(
+            ConstraintKind::Defaultable, swiftPtr, cPtr,
+            locator.withPathElement(LocatorPathElt::GenericArgument(0)));
+        return SolutionKind::Solved;
+      }
+
+      auto elementLoc =
+          locator.withPathElement(LocatorPathElt::GenericArgument(0));
+
+      // Unsafe[Mutable]Pointer<Int{8, 16, ...}> <->
+      // Unsafe[Mutable]Pointer<UInt{8, 16, ...}>
+
+      if (swiftPtr->isInt() || swiftPtr->isUInt()) {
+        addConstraint(ConstraintKind::Equal, cPtr,
+                      swiftPtr->isUInt() ? ctx.getIntType() : ctx.getUIntType(),
+                      elementLoc);
+        return SolutionKind::Solved;
+      }
+
+      if (swiftPtr->isInt8() || swiftPtr->isUInt8()) {
+        addConstraint(ConstraintKind::Equal, cPtr,
+                      swiftPtr->isUInt8() ? ctx.getInt8Type()
+                                          : ctx.getUInt8Type(),
+                      elementLoc);
+        return SolutionKind::Solved;
+      }
+
+      if (swiftPtr->isInt16() || swiftPtr->isUInt16()) {
+        addConstraint(ConstraintKind::Equal, cPtr,
+                      swiftPtr->isUInt16() ? ctx.getInt16Type()
+                                           : ctx.getUInt16Type(),
+                      elementLoc);
+        return SolutionKind::Solved;
+      }
+
+      if (swiftPtr->isInt32() || swiftPtr->isUInt32()) {
+        addConstraint(ConstraintKind::Equal, cPtr,
+                      swiftPtr->isUInt32() ? ctx.getInt32Type()
+                                           : ctx.getUInt32Type(),
+                      elementLoc);
+        return SolutionKind::Solved;
+      }
+
+      if (swiftPtr->isInt64() || swiftPtr->isUInt64()) {
+        addConstraint(ConstraintKind::Equal, cPtr,
+                      swiftPtr->isUInt64() ? ctx.getInt64Type()
+                                           : ctx.getUInt64Type(),
+                      elementLoc);
+        return SolutionKind::Solved;
+      }
+    }
+
+    return SolutionKind::Error;
   }
 
   // T < U or T is bridged to V where V < U ===> Array<T> <c Array<U>

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11114,7 +11114,11 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
 
     return matchPointerBaseTypes(ptr1, ptr2);
   }
-    
+
+  case ConversionRestrictionKind::PointerToCPointer: {
+    return SolutionKind::Error; // not yet implemented
+  }
+
   // T < U or T is bridged to V where V < U ===> Array<T> <c Array<U>
   case ConversionRestrictionKind::ArrayUpcast: {
     Type baseType1 = *isArrayType(type1);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5889,13 +5889,12 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
               }
             }
 
-            // If both sides are non-optional pointers let's check whether
+            // If both sides are non-optional pointers, let's check whether
             // this argument supports Swift -> C pointer conversions.
             //
             // Do some light verification before recording restriction to
             // avoid allocating constraints for obviously invalid cases.
-            if (type1IsPointer && optionalityMatches &&
-                isArgumentOfImportedDecl(locator)) {
+            if (type1IsPointer && !type1IsOptional && !type2IsOptional) {
               // UnsafeRawPointer -> UnsafePointer<[U]Int8>
               if (type1PointerKind == PTK_UnsafeRawPointer &&
                   pointerKind == PTK_UnsafePointer) {
@@ -11385,6 +11384,12 @@ ConstraintSystem::SolutionKind
 ConstraintSystem::simplifyPointerToCPointerRestriction(
     Type type1, Type type2, TypeMatchOptions flags,
     ConstraintLocatorBuilder locator) {
+  // If this is not an imported function, let's not proceed with this
+  // conversion.
+  if (!isArgumentOfImportedDecl(locator)) {
+    return SolutionKind::Error;
+  }
+
   // Make sure that solutions with implicit pointer conversions
   // are always worse than the ones without them.
   increaseScore(SK_ImplicitValueConversion);

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -546,6 +546,8 @@ StringRef swift::constraints::getName(ConversionRestrictionKind kind) {
     return "[inout-to-pointer]";
   case ConversionRestrictionKind::PointerToPointer:
     return "[pointer-to-pointer]";
+  case ConversionRestrictionKind::PointerToCPointer:
+    return "[pointer-to-c-pointer]";
   case ConversionRestrictionKind::ArrayUpcast:
     return "[array-upcast]";
   case ConversionRestrictionKind::DictionaryUpcast:

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5129,6 +5129,7 @@ ConstraintSystem::isConversionEphemeral(ConversionRestrictionKind conversion,
   case ConversionRestrictionKind::ExistentialMetatypeToAnyObject:
   case ConversionRestrictionKind::ProtocolMetatypeToProtocolClass:
   case ConversionRestrictionKind::PointerToPointer:
+  case ConversionRestrictionKind::PointerToCPointer:
   case ConversionRestrictionKind::ArrayUpcast:
   case ConversionRestrictionKind::DictionaryUpcast:
   case ConversionRestrictionKind::SetUpcast:

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4999,6 +4999,22 @@ bool constraints::isArgumentOfReferenceEqualityOperator(
          isOperatorArgument(locator, "!==");
 }
 
+bool ConstraintSystem::isArgumentOfImportedDecl(
+    ConstraintLocatorBuilder locator) {
+  auto last = locator.last();
+  if (!(last && last->is<LocatorPathElt::ApplyArgToParam>()))
+    return false;
+
+  auto *application = getCalleeLocator(getConstraintLocator(locator));
+
+  auto overload = findSelectedOverloadFor(application);
+  if (!(overload && overload->choice.isDecl()))
+    return false;
+
+  auto *choice = overload->choice.getDecl();
+  return choice->hasClangNode();
+}
+
 ConversionEphemeralness
 ConstraintSystem::isConversionEphemeral(ConversionRestrictionKind conversion,
                                         ConstraintLocatorBuilder locator) {

--- a/test/Constraints/Inputs/c_pointer_conversions.h
+++ b/test/Constraints/Inputs/c_pointer_conversions.h
@@ -2,39 +2,46 @@
 
 #include "stdint.h"
 
-/*
-void doit(NSArray<NSCopying> *array);
-NSArray<NSCopying> *gimmeArray(void);
-*/
-
 void char_ptr_func(char *  _Nonnull buffer);
 void const_char_ptr_func(const char *  _Nonnull buffer);
 
+void opt_char_ptr_func(char * _Nullable buffer);
+void const_opt_char_ptr_func(const char * _Nullable buffer);
+
 void unsigned_char_ptr_func(unsigned char * _Nonnull buffer);
 void const_unsigned_char_ptr_func(const unsigned char * _Nonnull buffer);
+
+void opt_unsigned_char_ptr_func(char * _Nullable buffer);
+void const_opt_unsigned_char_ptr_func(const char * _Nullable buffer);
 
 void int_16_ptr_func(int16_t * _Nonnull buffer);
 void int_32_ptr_func(int32_t * _Nonnull buffer);
 void int_64_ptr_func(int64_t * _Nonnull buffer);
 
+void opt_int_16_ptr_func(int16_t * _Nullable buffer);
+void opt_int_32_ptr_func(int32_t * _Nullable buffer);
+void opt_int_64_ptr_func(int64_t * _Nullable buffer);
+
 void const_int_16_ptr_func(const int16_t * _Nonnull buffer);
 void const_int_32_ptr_func(const int32_t * _Nonnull buffer);
 void const_int_64_ptr_func(const int64_t * _Nonnull buffer);
+
+void const_opt_int_16_ptr_func(const int16_t * _Nullable buffer);
+void const_opt_int_32_ptr_func(const int32_t * _Nullable buffer);
+void const_opt_int_64_ptr_func(const int64_t * _Nullable buffer);
 
 void uint_16_ptr_func(uint16_t * _Nonnull buffer);
 void uint_32_ptr_func(uint32_t * _Nonnull buffer);
 void uint_64_ptr_func(uint64_t * _Nonnull buffer);
 
+void opt_uint_16_ptr_func(uint16_t * _Nullable buffer);
+void opt_uint_32_ptr_func(uint32_t * _Nullable buffer);
+void opt_uint_64_ptr_func(uint64_t * _Nullable buffer);
+
 void const_uint_16_ptr_func(const uint16_t * _Nonnull buffer);
 void const_uint_32_ptr_func(const uint32_t * _Nonnull buffer);
 void const_uint_64_ptr_func(const uint64_t * _Nonnull buffer);
 
-/*
-@interface LinkDescriptor
-@end
-
-@interface Test
-- (BOOL)f:(NSArray<LinkDescriptor *> * _Nonnull)descriptors error:(NSError * __autoreleasing * __nullable)error;
-- (void)f:(NSArray<LinkDescriptor *> * _Nonnull)descriptors completion:(nullable void (^)(BOOL success, NSError * _Nullable error))completion;
-@end
-*/
+void const_opt_uint_16_ptr_func(const uint16_t * _Nullable buffer);
+void const_opt_uint_32_ptr_func(const uint32_t * _Nullable buffer);
+void const_opt_uint_64_ptr_func(const uint64_t * _Nullable buffer);

--- a/test/Constraints/Inputs/c_pointer_conversions.h
+++ b/test/Constraints/Inputs/c_pointer_conversions.h
@@ -1,0 +1,40 @@
+@import Foundation;
+
+#include "stdint.h"
+
+/*
+void doit(NSArray<NSCopying> *array);
+NSArray<NSCopying> *gimmeArray(void);
+*/
+
+void char_ptr_func(char *  _Nonnull buffer);
+void const_char_ptr_func(const char *  _Nonnull buffer);
+
+void unsigned_char_ptr_func(unsigned char * _Nonnull buffer);
+void const_unsigned_char_ptr_func(const unsigned char * _Nonnull buffer);
+
+void int_16_ptr_func(int16_t * _Nonnull buffer);
+void int_32_ptr_func(int32_t * _Nonnull buffer);
+void int_64_ptr_func(int64_t * _Nonnull buffer);
+
+void const_int_16_ptr_func(const int16_t * _Nonnull buffer);
+void const_int_32_ptr_func(const int32_t * _Nonnull buffer);
+void const_int_64_ptr_func(const int64_t * _Nonnull buffer);
+
+void uint_16_ptr_func(uint16_t * _Nonnull buffer);
+void uint_32_ptr_func(uint32_t * _Nonnull buffer);
+void uint_64_ptr_func(uint64_t * _Nonnull buffer);
+
+void const_uint_16_ptr_func(const uint16_t * _Nonnull buffer);
+void const_uint_32_ptr_func(const uint32_t * _Nonnull buffer);
+void const_uint_64_ptr_func(const uint64_t * _Nonnull buffer);
+
+/*
+@interface LinkDescriptor
+@end
+
+@interface Test
+- (BOOL)f:(NSArray<LinkDescriptor *> * _Nonnull)descriptors error:(NSError * __autoreleasing * __nullable)error;
+- (void)f:(NSArray<LinkDescriptor *> * _Nonnull)descriptors completion:(nullable void (^)(BOOL success, NSError * _Nullable error))completion;
+@end
+*/

--- a/test/Constraints/swift_to_c_pointer_conversions.swift.gyb
+++ b/test/Constraints/swift_to_c_pointer_conversions.swift.gyb
@@ -1,0 +1,116 @@
+// %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -import-objc-header %S/Inputs/overloaded_async_method.h %s -typecheck -verify
+
+// RUN: %empty-directory(%t)
+
+// RUN: %gyb %s -o %t/swift_to_c_pointer_conversions.swift
+
+// RUN: %line-directive %t/swift_to_c_pointer_conversions.swift -- %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -import-objc-header %S/Inputs/c_pointer_conversions.h %t/swift_to_c_pointer_conversions.swift -typecheck -verify
+
+func test_raw_ptr(ptr: UnsafeRawPointer) {
+  char_ptr_func(ptr) // expected-error {{}}
+  unsigned_char_ptr_func(ptr) // expected-error {{}}
+
+  const_char_ptr_func(ptr) // Ok
+  const_unsigned_char_ptr_func(ptr) // Ok
+
+  % for Size in ['16', '32', '64']:
+    int_${Size}_ptr_func(ptr) // expected-error {{}}
+    uint_${Size}_ptr_func(ptr) // expected-error {{}}
+
+    const_int_${Size}_ptr_func(ptr) // expected-error {{}}
+    const_uint_${Size}_ptr_func(ptr) // expected-error {{}}
+  % end
+}
+
+func test_mutable_raw_pointer(ptr: UnsafeMutableRawPointer) {
+  char_ptr_func(ptr) // Ok
+  unsigned_char_ptr_func(ptr) // Ok
+
+  const_char_ptr_func(ptr) // Ok
+  const_unsigned_char_ptr_func(ptr) // Ok
+
+  % for Size in ['16', '32', '64']:
+    int_${Size}_ptr_func(ptr) // expected-error {{}}
+    uint_${Size}_ptr_func(ptr) // expected-error {{}}
+
+    const_int_${Size}_ptr_func(ptr) // expected-error {{}}
+    const_uint_${Size}_ptr_func(ptr) // expected-error {{}}
+  % end
+}
+
+%for TestPtrSize in ['16', '32', '64']:
+// Immutable pointers can be converted only to their immutable (regardless of sign) counterparts.
+func test_${TestPtrSize}_bit_ptrs(sptr: UnsafePointer<Int${TestPtrSize}>,
+                                  uptr: UnsafePointer<UInt${TestPtrSize}>) {
+  char_ptr_func(sptr) // expected-error {{}}
+  char_ptr_func(uptr) // expected-error {{}}
+
+  const_char_ptr_func(sptr) // Ok
+  const_char_ptr_func(uptr) // Ok
+
+  unsigned_char_ptr_func(sptr) // expected-error {{}}
+  unsigned_char_ptr_func(uptr) // expected-error {{}}
+
+  const_unsigned_char_ptr_func(sptr) // Ok
+  const_unsigned_char_ptr_func(uptr) // Ok
+
+% for pointer in ['sptr', 'uptr']:
+  % for Size in ['16', '32', '64']:
+
+    % if Size == TestPtrSize:
+      int_${TestPtrSize}_ptr_func(${pointer}) // expected-error {{}}
+      uint_${TestPtrSize}_ptr_func(${pointer}) // expected-error {{}}
+
+      const_int_${TestPtrSize}_ptr_func(${pointer}) // Ok
+      const_uint_${TestPtrSize}_ptr_func(${pointer}) // Ok
+    % else:
+      int_${Size}_ptr_func(${pointer}) // expected-error {{}}
+      uint_${Size}_ptr_func(${pointer}) // expected-error {{}}
+
+      const_int_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
+      const_uint_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
+    % end
+  % end
+% end
+}
+
+% end
+
+%for TestPtrSize in ['16', '32', '64']:
+// Mutable pointers can be converted to both immutable and mutable pointers when
+// passed to C/ObjC imported functions.
+func test_mutable_${TestPtrSize}_bit_ptrs(sptr: UnsafeMutablePointer<Int${TestPtrSize}>,
+                                          uptr: UnsafeMutablePointer<UInt${TestPtrSize}>) {
+  char_ptr_func(sptr) // Ok
+  char_ptr_func(uptr) // Ok
+
+  const_char_ptr_func(sptr) // Ok
+  const_char_ptr_func(uptr) // Ok
+
+  unsigned_char_ptr_func(sptr) // Ok
+  unsigned_char_ptr_func(uptr) // Ok
+
+  const_unsigned_char_ptr_func(sptr) // Ok
+  const_unsigned_char_ptr_func(uptr) // Ok
+
+% for pointer in ['sptr', 'uptr']:
+  % for Size in ['16', '32', '64']:
+
+    % if Size == TestPtrSize:
+      int_${TestPtrSize}_ptr_func(${pointer}) // Ok
+      uint_${TestPtrSize}_ptr_func(${pointer}) // Ok
+
+      const_int_${TestPtrSize}_ptr_func(${pointer}) // Ok
+      const_uint_${TestPtrSize}_ptr_func(${pointer}) // Ok
+    % else:
+      int_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
+      uint_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
+
+      const_int_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
+      const_uint_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
+    % end
+  % end
+% end
+}
+
+% end

--- a/test/Constraints/swift_to_c_pointer_conversions.swift.gyb
+++ b/test/Constraints/swift_to_c_pointer_conversions.swift.gyb
@@ -38,7 +38,7 @@ func test_mutable_raw_pointer(ptr: UnsafeMutableRawPointer) {
   % end
 }
 
-%for TestPtrSize in ['16', '32', '64']:
+%for TestPtrSize in ['8', '16', '32', '64']:
 // Immutable pointers can be converted only to their immutable (regardless of sign) counterparts.
 func test_${TestPtrSize}_bit_ptrs(sptr: UnsafePointer<Int${TestPtrSize}>,
                                   uptr: UnsafePointer<UInt${TestPtrSize}>,
@@ -112,7 +112,7 @@ func test_${TestPtrSize}_bit_ptrs(sptr: UnsafePointer<Int${TestPtrSize}>,
 
 % end
 
-%for TestPtrSize in ['16', '32', '64']:
+%for TestPtrSize in ['8', '16', '32', '64']:
 // Mutable pointers can be converted to both immutable and mutable pointers when
 // passed to C/ObjC imported functions.
 func test_mutable_${TestPtrSize}_bit_ptrs(sptr: UnsafeMutablePointer<Int${TestPtrSize}>,

--- a/test/Constraints/swift_to_c_pointer_conversions.swift.gyb
+++ b/test/Constraints/swift_to_c_pointer_conversions.swift.gyb
@@ -6,6 +6,8 @@
 
 // RUN: %line-directive %t/swift_to_c_pointer_conversions.swift -- %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -import-objc-header %S/Inputs/c_pointer_conversions.h %t/swift_to_c_pointer_conversions.swift -typecheck -verify
 
+// REQUIRES: objc_interop
+
 func test_raw_ptr(ptr: UnsafeRawPointer) {
   char_ptr_func(ptr) // expected-error {{}}
   unsigned_char_ptr_func(ptr) // expected-error {{}}

--- a/test/Constraints/swift_to_c_pointer_conversions.swift.gyb
+++ b/test/Constraints/swift_to_c_pointer_conversions.swift.gyb
@@ -1,5 +1,3 @@
-// %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -import-objc-header %S/Inputs/overloaded_async_method.h %s -typecheck -verify
-
 // RUN: %empty-directory(%t)
 
 // RUN: %gyb %s -o %t/swift_to_c_pointer_conversions.swift
@@ -235,4 +233,13 @@ func test_raw_ptr_optional_to_optional_conversion(
       const_opt_uint_${Size}_ptr_func(${Ptr}) // expected-error {{}}
     % end
   % end
+}
+
+// Check that implicit conversions don't make expressions ambiguous
+func test_overloaded_ref_is_not_ambiguous() {
+  func overloaded_func() -> UnsafeRawPointer { fatalError() }
+  func overloaded_func() -> UnsafePointer<Int8> { fatalError() }
+
+  const_char_ptr_func(overloaded_func()) // Ok
+  const_opt_char_ptr_func(overloaded_func()) // Ok
 }

--- a/test/Constraints/swift_to_c_pointer_conversions.swift.gyb
+++ b/test/Constraints/swift_to_c_pointer_conversions.swift.gyb
@@ -41,18 +41,29 @@ func test_mutable_raw_pointer(ptr: UnsafeMutableRawPointer) {
 %for TestPtrSize in ['16', '32', '64']:
 // Immutable pointers can be converted only to their immutable (regardless of sign) counterparts.
 func test_${TestPtrSize}_bit_ptrs(sptr: UnsafePointer<Int${TestPtrSize}>,
-                                  uptr: UnsafePointer<UInt${TestPtrSize}>) {
-  char_ptr_func(sptr) // expected-error {{}}
-  char_ptr_func(uptr) // expected-error {{}}
+                                  uptr: UnsafePointer<UInt${TestPtrSize}>,
+                                 osptr: UnsafePointer<Int${TestPtrSize}>?,
+                                 ouptr: UnsafePointer<UInt${TestPtrSize}>?) {
+  % for pointer in ['sptr', 'uptr']:
+    char_ptr_func(${pointer}) // expected-error {{}}
+    opt_char_ptr_func(${pointer}) // expected-error {{}}
 
-  const_char_ptr_func(sptr) // Ok
-  const_char_ptr_func(uptr) // Ok
+    const_char_ptr_func(${pointer}) // Ok
+    const_opt_char_ptr_func(${pointer}) // Ok
 
-  unsigned_char_ptr_func(sptr) // expected-error {{}}
-  unsigned_char_ptr_func(uptr) // expected-error {{}}
+    unsigned_char_ptr_func(${pointer}) // expected-error {{}}
+    unsigned_opt_char_ptr_func(${pointer}) // expected-error {{}}
 
-  const_unsigned_char_ptr_func(sptr) // Ok
-  const_unsigned_char_ptr_func(uptr) // Ok
+    const_unsigned_char_ptr_func(${pointer}) // Ok
+    const_opt_unsigned_char_ptr_func(${pointer}) // Ok
+  % end
+
+  % for pointer in ['osptr', 'ouptr']:
+    opt_char_ptr_func(${pointer}) // expected-error {{}}
+    const_opt_char_ptr_func(${pointer}) // Ok
+    unsigned_opt_char_ptr_func(${pointer}) // expected-error {{}}
+    const_opt_unsigned_char_ptr_func(${pointer}) // Ok
+  % end
 
 % for pointer in ['sptr', 'uptr']:
   % for Size in ['16', '32', '64']:
@@ -60,18 +71,43 @@ func test_${TestPtrSize}_bit_ptrs(sptr: UnsafePointer<Int${TestPtrSize}>,
     % if Size == TestPtrSize:
       int_${TestPtrSize}_ptr_func(${pointer}) // expected-error {{}}
       uint_${TestPtrSize}_ptr_func(${pointer}) // expected-error {{}}
+      opt_int_${TestPtrSize}_ptr_func(${pointer}) // expected-error {{}}
+      opt_uint_${TestPtrSize}_ptr_func(${pointer}) // expected-error {{}}
 
       const_int_${TestPtrSize}_ptr_func(${pointer}) // Ok
       const_uint_${TestPtrSize}_ptr_func(${pointer}) // Ok
+      const_opt_int_${TestPtrSize}_ptr_func(${pointer}) // Ok
+      const_opt_uint_${TestPtrSize}_ptr_func(${pointer}) // Ok
     % else:
       int_${Size}_ptr_func(${pointer}) // expected-error {{}}
       uint_${Size}_ptr_func(${pointer}) // expected-error {{}}
+      opt_int_${Size}_ptr_func(${pointer}) // expected-error {{}}
+      opt_uint_${Size}_ptr_func(${pointer}) // expected-error {{}}
 
       const_int_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
       const_uint_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
+      const_opt_int_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
+      const_opt_uint_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
     % end
   % end
 % end
+
+
+  % for pointer in ['osptr', 'ouptr']:
+    % for Size in ['16', '32', '64']:
+      % if Size == TestPtrSize:
+        opt_int_${TestPtrSize}_ptr_func(${pointer}) // expected-error {{}}
+        opt_uint_${TestPtrSize}_ptr_func(${pointer}) // expected-error {{}}
+        const_opt_int_${TestPtrSize}_ptr_func(${pointer}) // Ok
+        const_opt_uint_${TestPtrSize}_ptr_func(${pointer}) // Ok
+      % else:
+        opt_int_${Size}_ptr_func(${pointer}) // expected-error {{}}
+        opt_uint_${Size}_ptr_func(${pointer}) // expected-error {{}}
+        const_opt_int_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
+        const_opt_uint_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
+      % end
+    % end
+  % end
 }
 
 % end
@@ -80,18 +116,29 @@ func test_${TestPtrSize}_bit_ptrs(sptr: UnsafePointer<Int${TestPtrSize}>,
 // Mutable pointers can be converted to both immutable and mutable pointers when
 // passed to C/ObjC imported functions.
 func test_mutable_${TestPtrSize}_bit_ptrs(sptr: UnsafeMutablePointer<Int${TestPtrSize}>,
-                                          uptr: UnsafeMutablePointer<UInt${TestPtrSize}>) {
-  char_ptr_func(sptr) // Ok
-  char_ptr_func(uptr) // Ok
+                                          uptr: UnsafeMutablePointer<UInt${TestPtrSize}>,
+                                         osptr: UnsafeMutablePointer<Int${TestPtrSize}>?,
+                                         ouptr: UnsafeMutablePointer<UInt${TestPtrSize}>?) {
+  % for pointer in ['sptr', 'uptr']:
+    char_ptr_func(${pointer}) // Ok
+    opt_char_ptr_func(${pointer}) // Ok
 
-  const_char_ptr_func(sptr) // Ok
-  const_char_ptr_func(uptr) // Ok
+    const_char_ptr_func(${pointer}) // Ok
+    const_opt_char_ptr_func(${pointer}) // Ok
 
-  unsigned_char_ptr_func(sptr) // Ok
-  unsigned_char_ptr_func(uptr) // Ok
+    unsigned_char_ptr_func(${pointer}) // Ok
+    opt_unsigned_char_ptr_func(${pointer}) // Ok
 
-  const_unsigned_char_ptr_func(sptr) // Ok
-  const_unsigned_char_ptr_func(uptr) // Ok
+    const_unsigned_char_ptr_func(${pointer}) // Ok
+    const_opt_unsigned_char_ptr_func(${pointer}) // Ok
+  % end
+
+  % for pointer in ['osptr', 'ouptr']:
+    opt_char_ptr_func(${pointer}) // Ok
+    const_opt_char_ptr_func(${pointer}) // Ok
+    opt_unsigned_char_ptr_func(${pointer}) // Ok
+    const_opt_unsigned_char_ptr_func(${pointer}) // Ok
+  % end
 
 % for pointer in ['sptr', 'uptr']:
   % for Size in ['16', '32', '64']:
@@ -99,18 +146,91 @@ func test_mutable_${TestPtrSize}_bit_ptrs(sptr: UnsafeMutablePointer<Int${TestPt
     % if Size == TestPtrSize:
       int_${TestPtrSize}_ptr_func(${pointer}) // Ok
       uint_${TestPtrSize}_ptr_func(${pointer}) // Ok
+      opt_int_${TestPtrSize}_ptr_func(${pointer}) // Ok
+      opt_uint_${TestPtrSize}_ptr_func(${pointer}) // Ok
 
       const_int_${TestPtrSize}_ptr_func(${pointer}) // Ok
       const_uint_${TestPtrSize}_ptr_func(${pointer}) // Ok
+      const_opt_int_${TestPtrSize}_ptr_func(${pointer}) // Ok
+      const_opt_uint_${TestPtrSize}_ptr_func(${pointer}) // Ok
     % else:
       int_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
       uint_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
+      opt_int_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
+      opt_uint_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
 
       const_int_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
       const_uint_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
+      const_opt_int_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
+      const_opt_uint_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
     % end
   % end
-% end
+  % end
+
+  % for pointer in ['osptr', 'ouptr']:
+    % for Size in ['16', '32', '64']:
+      % if Size == TestPtrSize:
+        opt_int_${TestPtrSize}_ptr_func(${pointer}) // Ok
+        opt_uint_${TestPtrSize}_ptr_func(${pointer}) // Ok
+        const_opt_int_${TestPtrSize}_ptr_func(${pointer}) // Ok
+        const_opt_uint_${TestPtrSize}_ptr_func(${pointer}) // Ok
+      % else:
+        opt_int_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
+        opt_uint_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
+        const_opt_int_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
+        const_opt_uint_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
+     % end
+    % end
+  % end
 }
 
 % end
+
+func test_raw_ptr_value_to_optional_promotion(
+  riptr: UnsafeRawPointer,
+  rmptr: UnsafeMutableRawPointer) {
+  opt_char_ptr_func(riptr) // expected-error {{}}
+  const_opt_char_ptr_func(riptr) // Ok
+
+  opt_char_ptr_func(rmptr) // Ok
+  const_opt_char_ptr_func(rmptr) // Ok
+
+  opt_unsigned_char_ptr_func(riptr) // expected-error {{}}
+  const_opt_unsigned_char_ptr_func(riptr) // Ok
+
+  opt_unsigned_char_ptr_func(rmptr) // Ok
+  const_opt_unsigned_char_ptr_func(rmptr) // Ok
+
+  % for Ptr in ['riptr', 'rmptr']:
+    % for Size in ['16', '32', '64']:
+      opt_int_${Size}_ptr_func(${Ptr}) // expected-error {{}}
+      opt_uint_${Size}_ptr_func(${Ptr}) // expected-error {{}}
+
+      const_opt_int_${Size}_ptr_func(${Ptr}) // expected-error {{}}
+      const_opt_uint_${Size}_ptr_func(${Ptr}) // expected-error {{}}
+    % end
+  % end
+}
+
+func test_raw_ptr_optional_to_optional_conversion(
+  riptr: UnsafeRawPointer?,
+  rmptr: UnsafeMutableRawPointer?) {
+  opt_char_ptr_func(riptr) // expected-error {{}}
+  const_opt_char_ptr_func(riptr) // Ok
+
+  opt_char_ptr_func(rmptr) // Ok
+  const_opt_char_ptr_func(rmptr) // Ok
+
+  opt_unsigned_char_ptr_func(rmptr) // Ok
+  const_opt_unsigned_char_ptr_func(rmptr) // Ok
+
+  % for Ptr in ['riptr', 'rmptr']:
+    % for Size in ['16', '32', '64']:
+      opt_int_${Size}_ptr_func(${Ptr}) // expected-error {{}}
+      opt_uint_${Size}_ptr_func(${Ptr}) // expected-error {{}}
+
+      const_opt_int_${Size}_ptr_func(${Ptr}) // expected-error {{}}
+      const_opt_uint_${Size}_ptr_func(${Ptr}) // expected-error {{}}
+    % end
+  % end
+}

--- a/test/Constraints/swift_to_c_pointer_conversions.swift.gyb
+++ b/test/Constraints/swift_to_c_pointer_conversions.swift.gyb
@@ -243,3 +243,29 @@ func test_overloaded_ref_is_not_ambiguous() {
   const_char_ptr_func(overloaded_func()) // Ok
   const_opt_char_ptr_func(overloaded_func()) // Ok
 }
+
+func test_tailored_diagnostic(ptr: UnsafeRawPointer, tptr: UnsafePointer<Int8>) {
+  func swift_uint8_func(_: UnsafePointer<UInt8>) {}
+  func swift_int8_func(_: UnsafePointer<Int8>) {}
+  func opt_arg_func(_: UnsafePointer<Int8>?) {}
+
+  swift_uint8_func(ptr)
+  // expected-error@-1 {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'UnsafePointer<UInt8>' because local function 'swift_uint8_func' was not imported from C header}}
+  swift_uint8_func(tptr)
+  // expected-error@-1 {{cannot convert value of type 'UnsafePointer<Int8>' to expected argument type 'UnsafePointer<UInt8>' because local function 'swift_uint8_func' was not imported from C header}}
+
+  swift_int8_func(ptr)
+  // expected-error@-1 {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'UnsafePointer<Int8>' because local function 'swift_int8_func' was not imported from C header}}
+  swift_int8_func(tptr) // Ok
+
+  opt_arg_func(ptr)
+  // expected-error@-1 {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'UnsafePointer<Int8>?' because local function 'opt_arg_func' was not imported from C header}}
+  opt_arg_func(tptr) // Ok
+
+  let optrS8: UnsafePointer<Int8>? = nil
+  let optrU8: UnsafePointer<UInt8>? = nil
+
+  opt_arg_func(optrS8) // Ok
+  opt_arg_func(optrU8)
+  // expected-error@-1 {{cannot convert value of type 'UnsafePointer<UInt8>?' to expected argument type 'UnsafePointer<Int8>?' because local function 'opt_arg_func' was not imported from C header}}
+}

--- a/test/Constraints/swift_to_c_pointer_conversions_sil.swift
+++ b/test/Constraints/swift_to_c_pointer_conversions_sil.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -import-objc-header %S/Inputs/c_pointer_conversions.h %s -emit-sil -verify | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+
+// Check that implicit conversions don't make expressions ambiguous
+func test_overloaded_ref_is_not_ambiguous() {
+  func overloaded_func() -> UnsafeRawPointer { fatalError() }
+  func overloaded_func() -> UnsafePointer<Int8> { fatalError() }
+
+  func overloaded_mutable_func() -> UnsafeMutableRawPointer { fatalError() }
+  func overloaded_mutable_func() -> UnsafeMutablePointer<Int8> { fatalError() }
+
+  // CHECK: function_ref @$s34swift_to_c_pointer_conversions_sil36test_overloaded_ref_is_not_ambiguousyyF0G5_funcL0_SPys4Int8VGyF
+  // CHECK-NEXT: apply
+  const_char_ptr_func(overloaded_func()) // Ok
+  // CHECK: function_ref @$s34swift_to_c_pointer_conversions_sil36test_overloaded_ref_is_not_ambiguousyyF0G5_funcL0_SPys4Int8VGyF
+  // CHECK-NEXT: apply
+  const_opt_char_ptr_func(overloaded_func()) // Ok
+
+  // CHECK: function_ref @$s34swift_to_c_pointer_conversions_sil36test_overloaded_ref_is_not_ambiguousyyF0G13_mutable_funcL0_Spys4Int8VGyF
+  // CHECK-NEXT: apply
+  char_ptr_func(overloaded_mutable_func()) // Ok
+
+  // CHECK: function_ref @$s34swift_to_c_pointer_conversions_sil36test_overloaded_ref_is_not_ambiguousyyF0G13_mutable_funcL0_Spys4Int8VGyF
+  // CHECK-NEXT: apply
+  const_char_ptr_func(overloaded_mutable_func()) // Ok (picks UnsafeMutablePointer using implicit conversion)
+
+  // CHECK: function_ref @$s34swift_to_c_pointer_conversions_sil36test_overloaded_ref_is_not_ambiguousyyF0G13_mutable_funcL0_Spys4Int8VGyF
+  // CHECK-NEXT: apply
+  opt_char_ptr_func(overloaded_mutable_func()) // Ok
+
+  // CHECK: function_ref @$s34swift_to_c_pointer_conversions_sil36test_overloaded_ref_is_not_ambiguousyyF0G13_mutable_funcL0_Spys4Int8VGyF
+  // CHECK-NEXT: apply
+  const_opt_char_ptr_func(overloaded_mutable_func()) // Ok
+}

--- a/test/stdlib/UnsafePointerDiagnostics.swift
+++ b/test/stdlib/UnsafePointerDiagnostics.swift
@@ -79,12 +79,12 @@ func unsafePointerConversionAvailability(
   _ = UnsafeMutablePointer<Int>(rp) // expected-error {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'UnsafeMutablePointer<Int>'}}
   _ = UnsafeMutablePointer<Int>(mrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'UnsafeMutablePointer<Int>'}}
   _ = UnsafeMutablePointer<Int>(orp) // expected-error {{cannot convert value of type 'UnsafeRawPointer?' to expected argument type 'UnsafeMutablePointer<Int>'}}
-  _ = UnsafeMutablePointer<Int>(omrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer?' to expected argument type 'UnsafeMutablePointer<Int>'}}
+  _ = UnsafeMutablePointer<Int>(omrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'UnsafeMutablePointer<Int>'}}
 
   _ = UnsafePointer<Int>(rp)  // expected-error {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'UnsafePointer<Int>'}}
   _ = UnsafePointer<Int>(mrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'UnsafePointer<Int>'}}
-  _ = UnsafePointer<Int>(orp)  // expected-error {{cannot convert value of type 'UnsafeRawPointer?' to expected argument type 'UnsafePointer<Int>'}}
-  _ = UnsafePointer<Int>(omrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer?' to expected argument type 'UnsafePointer<Int>'}}
+  _ = UnsafePointer<Int>(orp)  // expected-error {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'UnsafePointer<Int>'}}
+  _ = UnsafePointer<Int>(omrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'UnsafePointer<Int>'}}
 
   _ = UnsafePointer<Int>(ups) // expected-error {{cannot convert value of type 'UnsafePointer<String>' to expected argument type 'UnsafePointer<Int>'}}
   // expected-note@-1 {{arguments to generic parameter 'Pointee' ('String' and 'Int') are expected to be equal}}


### PR DESCRIPTION
Allow following pointer conversions in argument positions to C/ObjC imported calls:

- Allow implicit conversion to `Unsafe[Mutable]Pointer<UInt8>` or
   `Unsafe[Mutable]Pointer<Int8>` when the argument type is either
   `Unsafe[Mutable]Pointer<T>` or `Unsafe[Mutable]RawPointer`.

- Allow implicit conversion between signed and unsigned variants of trivial integer types:
  e.g. `Unsafe[Mutable]Pointer<Int64>` to/from `Unsafe[Mutable]Pointer<UInt64>`

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves: SR-10246

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
