### PR TITLE
[TypeChecker] NFC: Make test-case for rdar://19737632 more complex

### DIFF
--- a/validation-test/Sema/type_checker_perf/slow/rdar19737632.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar19737632.swift
@@ -5,6 +5,7 @@ let a = "a"
 let b = "b"
 let c = 42
 let d = 0.0
+let e: Float = 1.0
 
-_ = "a=" + a + ";b=" + b + ";c=" + c + ";d=" + d
+_ = "a=" + a + ";b=" + b + ";c=" + c + ";d=" + d + ";e=" + e
 // expected-error@-1 {{reasonable time}}


### PR DESCRIPTION
Test-case as-is is producing conversion failure on Apple Silicon

Resolves: rdar://79414045

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
