### PR TITLE
Pass sanitizer flags to swift driver

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -98,7 +98,7 @@ function(_add_host_variant_swift_sanitizer_flags target)
     elseif (LLVM_USE_SANITIZER STREQUAL "Leaks")
       # Not supported
     else()
-      message(FATAL_ERROR "Unsupported value of LLVM_USE_SANITIZER: ${LLVM_USE_SANITIZER}")
+      message(SEND_ERROR "unsupported value for LLVM_USE_SANITIZER: ${LLVM_USE_SANITIZER}")
     endif()
 
     target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:Swift>:${_Swift_SANITIZER_FLAGS}>)

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -75,6 +75,41 @@ function(_set_target_prefix_and_suffix target kind sdk)
   endif()
 endfunction()
 
+function(_add_host_variant_swift_sanitizer_flags target)
+  if (LLVM_USE_SANITIZER)
+    if (LLVM_ON_UNIX)
+
+      if (LLVM_USE_SANITIZER STREQUAL "Address")
+        set(_Swift_SANITIZER_FLAGS "-sanitize=address")
+      elseif (LLVM_USE_SANITIZER STREQUAL "HWAddress")
+        # Not supported?
+      elseif (LLVM_USE_SANITIZER MATCHES "Memory(WithOrigins)?")
+        # Not supported
+        if(LLVM_USE_SANITIZER STREQUAL "MemoryWithOrigins")
+          # Not supported
+        endif()
+      elseif (LLVM_USE_SANITIZER STREQUAL "Undefined")
+        set(_Swift_SANITIZER_FLAGS "-sanitize=undefined")
+      elseif (LLVM_USE_SANITIZER STREQUAL "Thread")
+        set(_Swift_SANITIZER_FLAGS "-sanitize=thread")
+      elseif (LLVM_USE_SANITIZER STREQUAL "DataFlow")
+        # Not supported
+      elseif (LLVM_USE_SANITIZER STREQUAL "Address;Undefined" OR
+              LLVM_USE_SANITIZER STREQUAL "Undefined;Address")
+        set(_Swift_SANITIZER_FLAGS "-sanitize=address -sanitize=undefined")
+      elseif (LLVM_USE_SANITIZER STREQUAL "Leaks")
+        # Not supported
+      else()
+        message(FATAL_ERROR "Unsupported value of LLVM_USE_SANITIZER: ${LLVM_USE_SANITIZER}")
+      endif()
+
+      target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:Swift>:${_Swift_SANITIZER_FLAGS}>)
+    else ()
+      # TODO (etcwilde): Pass sanitizer flags to swiftc on windows
+    endif ()
+  endif ()
+endfunction()
+
 # Usage:
 # _add_host_variant_c_compile_link_flags(name)
 function(_add_host_variant_c_compile_link_flags name)
@@ -100,6 +135,8 @@ function(_add_host_variant_c_compile_link_flags name)
       MACCATALYST_BUILD_FLAVOR ""
       DEPLOYMENT_VERSION "${DEPLOYMENT_VERSION}")
     target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:Swift>:-target;${target}>)
+
+   _add_host_variant_swift_sanitizer_flags(${name})
   endif()
 
   set(_sysroot

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -77,36 +77,31 @@ endfunction()
 
 function(_add_host_variant_swift_sanitizer_flags target)
   if (LLVM_USE_SANITIZER)
-    if (LLVM_ON_UNIX)
-
-      if (LLVM_USE_SANITIZER STREQUAL "Address")
-        set(_Swift_SANITIZER_FLAGS "-sanitize=address")
-      elseif (LLVM_USE_SANITIZER STREQUAL "HWAddress")
-        # Not supported?
-      elseif (LLVM_USE_SANITIZER MATCHES "Memory(WithOrigins)?")
+    if (LLVM_USE_SANITIZER STREQUAL "Address")
+      set(_Swift_SANITIZER_FLAGS "-sanitize=address")
+    elseif (LLVM_USE_SANITIZER STREQUAL "HWAddress")
+      # Not supported?
+    elseif (LLVM_USE_SANITIZER MATCHES "Memory(WithOrigins)?")
+      # Not supported
+      if(LLVM_USE_SANITIZER STREQUAL "MemoryWithOrigins")
         # Not supported
-        if(LLVM_USE_SANITIZER STREQUAL "MemoryWithOrigins")
-          # Not supported
-        endif()
-      elseif (LLVM_USE_SANITIZER STREQUAL "Undefined")
-        set(_Swift_SANITIZER_FLAGS "-sanitize=undefined")
-      elseif (LLVM_USE_SANITIZER STREQUAL "Thread")
-        set(_Swift_SANITIZER_FLAGS "-sanitize=thread")
-      elseif (LLVM_USE_SANITIZER STREQUAL "DataFlow")
-        # Not supported
-      elseif (LLVM_USE_SANITIZER STREQUAL "Address;Undefined" OR
-              LLVM_USE_SANITIZER STREQUAL "Undefined;Address")
-        set(_Swift_SANITIZER_FLAGS "-sanitize=address -sanitize=undefined")
-      elseif (LLVM_USE_SANITIZER STREQUAL "Leaks")
-        # Not supported
-      else()
-        message(FATAL_ERROR "Unsupported value of LLVM_USE_SANITIZER: ${LLVM_USE_SANITIZER}")
       endif()
+    elseif (LLVM_USE_SANITIZER STREQUAL "Undefined")
+      set(_Swift_SANITIZER_FLAGS "-sanitize=undefined")
+    elseif (LLVM_USE_SANITIZER STREQUAL "Thread")
+      set(_Swift_SANITIZER_FLAGS "-sanitize=thread")
+    elseif (LLVM_USE_SANITIZER STREQUAL "DataFlow")
+      # Not supported
+    elseif (LLVM_USE_SANITIZER STREQUAL "Address;Undefined" OR
+            LLVM_USE_SANITIZER STREQUAL "Undefined;Address")
+      set(_Swift_SANITIZER_FLAGS "-sanitize=address -sanitize=undefined")
+    elseif (LLVM_USE_SANITIZER STREQUAL "Leaks")
+      # Not supported
+    else()
+      message(FATAL_ERROR "Unsupported value of LLVM_USE_SANITIZER: ${LLVM_USE_SANITIZER}")
+    endif()
 
-      target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:Swift>:${_Swift_SANITIZER_FLAGS}>)
-    else ()
-      # TODO (etcwilde): Pass sanitizer flags to swiftc on windows
-    endif ()
+    target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:Swift>:${_Swift_SANITIZER_FLAGS}>)
   endif ()
 endfunction()
 

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -76,33 +76,33 @@ function(_set_target_prefix_and_suffix target kind sdk)
 endfunction()
 
 function(_add_host_variant_swift_sanitizer_flags target)
-  if (LLVM_USE_SANITIZER)
-    if (LLVM_USE_SANITIZER STREQUAL "Address")
+  if(LLVM_USE_SANITIZER)
+    if(LLVM_USE_SANITIZER STREQUAL "Address")
       set(_Swift_SANITIZER_FLAGS "-sanitize=address")
-    elseif (LLVM_USE_SANITIZER STREQUAL "HWAddress")
+    elseif(LLVM_USE_SANITIZER STREQUAL "HWAddress")
       # Not supported?
-    elseif (LLVM_USE_SANITIZER MATCHES "Memory(WithOrigins)?")
+    elseif(LLVM_USE_SANITIZER MATCHES "Memory(WithOrigins)?")
       # Not supported
       if(LLVM_USE_SANITIZER STREQUAL "MemoryWithOrigins")
         # Not supported
       endif()
-    elseif (LLVM_USE_SANITIZER STREQUAL "Undefined")
+    elseif(LLVM_USE_SANITIZER STREQUAL "Undefined")
       set(_Swift_SANITIZER_FLAGS "-sanitize=undefined")
-    elseif (LLVM_USE_SANITIZER STREQUAL "Thread")
+    elseif(LLVM_USE_SANITIZER STREQUAL "Thread")
       set(_Swift_SANITIZER_FLAGS "-sanitize=thread")
-    elseif (LLVM_USE_SANITIZER STREQUAL "DataFlow")
+    elseif(LLVM_USE_SANITIZER STREQUAL "DataFlow")
       # Not supported
-    elseif (LLVM_USE_SANITIZER STREQUAL "Address;Undefined" OR
-            LLVM_USE_SANITIZER STREQUAL "Undefined;Address")
+    elseif(LLVM_USE_SANITIZER STREQUAL "Address;Undefined" OR
+           LLVM_USE_SANITIZER STREQUAL "Undefined;Address")
       set(_Swift_SANITIZER_FLAGS "-sanitize=address -sanitize=undefined")
-    elseif (LLVM_USE_SANITIZER STREQUAL "Leaks")
+    elseif(LLVM_USE_SANITIZER STREQUAL "Leaks")
       # Not supported
     else()
       message(SEND_ERROR "unsupported value for LLVM_USE_SANITIZER: ${LLVM_USE_SANITIZER}")
     endif()
 
     target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:Swift>:${_Swift_SANITIZER_FLAGS}>)
-  endif ()
+  endif()
 endfunction()
 
 # Usage:


### PR DESCRIPTION
This patch fixes the part of the build system where we aren't passing
the sanitizer flags to swift, so the linker isn't linking against the
sanitizer libraries.

This should work on Windows. I'm frustrated enough with Windows that I'm just going to call it a night. compnerd, if you see something that is out of place, please let me know.

rdar://79313476