### PR TITLE
ModuleInterface: sanitize arch when interface file name and encoded flags disagree

### DIFF
--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -469,7 +469,8 @@ public:
 };
 
 /// Extract compiler arguments from an interface file buffer.
-bool extractCompilerFlagsFromInterface(StringRef buffer, llvm::StringSaver &ArgSaver,
+bool extractCompilerFlagsFromInterface(StringRef interfacePath,
+                                       StringRef buffer, llvm::StringSaver &ArgSaver,
                                        SmallVectorImpl<const char *> &SubArgs);
 
 /// Extract the user module version number from an interface file.

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1346,7 +1346,7 @@ bool InterfaceSubContextDelegateImpl::extractSwiftInterfaceVersionAndArgs(
              diag::error_extracting_version_from_module_interface);
     return true;
   }
-  if (extractCompilerFlagsFromInterface(SB, ArgSaver, SubArgs)) {
+  if (extractCompilerFlagsFromInterface(interfacePath, SB, ArgSaver, SubArgs)) {
     diagnose(interfacePath, diagnosticLoc,
              diag::error_extracting_version_from_module_interface);
     return true;

--- a/test/ModuleInterface/infer-arch-from-file.swift
+++ b/test/ModuleInterface/infer-arch-from-file.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/Bar.swiftmodule)
+// RUN: echo "// swift-interface-format-version: 1.0" > %t/arm64.swiftinterface
+// RUN: echo "// swift-module-flags: -module-name arm64 -target arm64e-apple-macos11.0" >> %t/arm64.swiftinterface
+
+import arm64
+
+// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t -target arm64-apple-macos11.0
+// RUN: %FileCheck %s < %t/deps.json
+
+// CHECK-NOT: arm64e-apple-macos11.0


### PR DESCRIPTION
It's a known issue that we are using arm64e interfaces contents for the arm64 target,
meaning the encoded module flags are specifying -target arm64e-x-x instead of
-target arm64-x-x. Fortunately, we can tell the target arch from the interface file
name, so we could sanitize the target to use by inferring arch from the file name.