### PR TITLE
RequirementMachine: Preliminary support for superclass and concrete type requirements

### DIFF
--- a/include/swift/AST/RequirementMachine.h
+++ b/include/swift/AST/RequirementMachine.h
@@ -23,14 +23,6 @@ class GenericSignature;
 class ProtocolDecl;
 class Requirement;
 
-namespace rewriting {
-
-class Term;
-
-Term getTermForType(CanType paramType, const ProtocolDecl *proto);
-
-} // end namespace rewriting
-
 /// Wraps a rewrite system with higher-level operations in terms of
 /// generic signatures and interface types.
 class RequirementMachine final {

--- a/include/swift/AST/RewriteSystem.h
+++ b/include/swift/AST/RewriteSystem.h
@@ -181,6 +181,10 @@ public:
 
   int compare(Atom other, const ProtocolGraph &protos) const;
 
+  Atom transformConcreteSubstitutions(
+      llvm::function_ref<Term(Term)> fn,
+      RewriteContext &ctx) const;
+
   Atom prependPrefixToConcreteSubstitutions(
       const MutableTerm &prefix,
       RewriteContext &ctx) const;
@@ -246,6 +250,14 @@ public:
   static Term get(const MutableTerm &term, RewriteContext &ctx);
 
   void dump(llvm::raw_ostream &out) const;
+
+  friend bool operator==(Term lhs, Term rhs) {
+    return lhs.Ptr == rhs.Ptr;
+  }
+
+  friend bool operator!=(Term lhs, Term rhs) {
+    return !(lhs == rhs);
+  }
 };
 
 /// A term is a sequence of one or more atoms.
@@ -499,6 +511,8 @@ public:
   void initialize(std::vector<std::pair<MutableTerm, MutableTerm>> &&rules,
                   ProtocolGraph &&protos);
 
+  Atom simplifySubstitutionsInSuperclassOrConcreteAtom(Atom atom) const;
+
   bool addRule(MutableTerm lhs, MutableTerm rhs);
 
   bool simplify(MutableTerm &term) const;
@@ -518,6 +532,8 @@ public:
   CompletionResult computeConfluentCompletion(
       unsigned maxIterations,
       unsigned maxDepth);
+
+  void simplifyRightHandSides();
 
   void dump(llvm::raw_ostream &out) const;
 

--- a/include/swift/AST/RewriteSystem.h
+++ b/include/swift/AST/RewriteSystem.h
@@ -18,6 +18,7 @@
 #include "swift/AST/LayoutConstraint.h"
 #include "swift/AST/ProtocolGraph.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/Statistic.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/SmallVector.h"
@@ -352,7 +353,10 @@ class RewriteContext final {
   RewriteContext &operator=(RewriteContext &&) = delete;
 
 public:
-  RewriteContext() {}
+  /// Statistical counters.
+  UnifiedStatsReporter *Stats;
+
+  RewriteContext(UnifiedStatsReporter *stats) : Stats(stats) {}
 
   Term getTermForType(CanType paramType,
                       const ProtocolDecl *proto);
@@ -420,6 +424,7 @@ public:
 ///
 /// Out-of-line methods are documented in RewriteSystem.cpp.
 class RewriteSystem final {
+  /// Rewrite context for memory allocation.
   RewriteContext &Context;
 
   /// The rules added so far, including rules from our client, as well

--- a/include/swift/AST/RewriteSystem.h
+++ b/include/swift/AST/RewriteSystem.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_REWRITESYSTEM_H
 #define SWIFT_REWRITESYSTEM_H
 
+#include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/LayoutConstraint.h"
@@ -350,14 +351,20 @@ class RewriteContext final {
   RewriteContext &operator=(const RewriteContext &) = delete;
   RewriteContext &operator=(RewriteContext &&) = delete;
 
+  ASTContext &Context;
+
 public:
   /// Statistical counters.
   UnifiedStatsReporter *Stats;
 
-  RewriteContext(UnifiedStatsReporter *stats) : Stats(stats) {}
+  RewriteContext(ASTContext &ctx) : Context(ctx), Stats(ctx.Stats) {}
 
-  MutableTerm getTermForType(CanType paramType,
-                             const ProtocolDecl *proto);
+  Term getTermForType(CanType paramType, const ProtocolDecl *proto);
+
+  MutableTerm getMutableTermForType(CanType paramType,
+                                    const ProtocolDecl *proto);
+
+  ASTContext &getASTContext() { return Context; }
 };
 
 /// A rewrite rule that replaces occurrences of LHS with RHS.

--- a/include/swift/AST/RewriteSystem.h
+++ b/include/swift/AST/RewriteSystem.h
@@ -376,7 +376,6 @@ public:
   const Term &getRHS() const { return RHS; }
 
   bool apply(Term &term) const {
-    assert(!deleted);
     return term.rewriteSubTerm(LHS, RHS);
   }
 
@@ -451,12 +450,14 @@ class RewriteSystem final {
   unsigned DebugSimplify : 1;
   unsigned DebugAdd : 1;
   unsigned DebugMerge : 1;
+  unsigned DebugCompletion : 1;
 
 public:
   explicit RewriteSystem(RewriteContext &ctx) : Context(ctx) {
     DebugSimplify = false;
     DebugAdd = false;
     DebugMerge = false;
+    DebugCompletion = false;
   }
 
   RewriteSystem(const RewriteSystem &) = delete;

--- a/include/swift/AST/RewriteSystem.h
+++ b/include/swift/AST/RewriteSystem.h
@@ -125,6 +125,11 @@ private:
 public:
   Kind getKind() const;
 
+  bool isSuperclassOrConcreteType() const {
+    auto kind = getKind();
+    return (kind == Kind::Superclass || kind == Kind::ConcreteType);
+  }
+
   Identifier getName() const;
 
   const ProtocolDecl *getProtocol() const;
@@ -175,6 +180,10 @@ public:
                               RewriteContext &ctx);
 
   int compare(Atom other, const ProtocolGraph &protos) const;
+
+  Atom prependPrefixToConcreteSubstitutions(
+      const MutableTerm &prefix,
+      RewriteContext &ctx) const;
 
   void dump(llvm::raw_ostream &out) const;
 
@@ -274,6 +283,10 @@ public:
 
   void add(Atom atom) {
     Atoms.push_back(atom);
+  }
+
+  void append(Term other) {
+    Atoms.append(other.begin(), other.end());
   }
 
   void append(const MutableTerm &other) {

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1414,7 +1414,7 @@ private:
 
 public:
   // Separate caching.
-  bool isCached() const;
+  bool isCached() const { return true; }
 
   /// Abstract generic signature requests never have source-location info.
   SourceLoc getNearestLoc() const {
@@ -1449,7 +1449,7 @@ private:
 
 public:
   // Separate caching.
-  bool isCached() const;
+  bool isCached() const { return true; }
 
   /// Inferred generic signature requests don't have source-location info.
   SourceLoc getNearestLoc() const {

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -220,6 +220,14 @@ FRONTEND_STATISTIC(Sema, NumAccessorsSynthesized)
 /// Number of synthesized accessor bodies.
 FRONTEND_STATISTIC(Sema, NumAccessorBodiesSynthesized)
 
+/// Number of requirement machines constructed. Rough proxy for
+/// amount of work the requirement machine does analyzing type signatures.
+FRONTEND_STATISTIC(Sema, NumRequirementMachines)
+
+/// Number of requirement machines constructed. Rough proxy for
+/// amount of work the requirement machine does analyzing type signatures.
+FRONTEND_STATISTIC(Sema, NumRequirementMachineCompletionSteps)
+
 /// Number of generic signature builders constructed. Rough proxy for
 /// amount of work the GSB does analyzing type signatures.
 FRONTEND_STATISTIC(Sema, NumGenericSignatureBuilders)

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -8738,14 +8738,6 @@ void GenericSignatureBuilder::verifyGenericSignaturesInModule(
     verifyGenericSignature(context, canGenericSig);
   }
 }
-
-bool AbstractGenericSignatureRequest::isCached() const {
-  return true;
-}
-
-bool InferredGenericSignatureRequest::isCached() const {
-  return true;
-}
       
 /// Check whether the inputs to the \c AbstractGenericSignatureRequest are
 /// all canonical.

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -8308,7 +8308,7 @@ static void checkGenericSignature(CanGenericSignature canSig,
         assert(compareDependentTypes(firstType, secondType) < 0 &&
                "Out-of-order type parameters in same-type constraint");
       } else {
-        assert(canSig->isCanonicalTypeInContext(secondType) &&
+        assert(canSig->isCanonicalTypeInContext(secondType, builder) &&
                "Concrete same-type isn't canonical in its own context");
       }
       break;

--- a/lib/AST/ProtocolGraph.cpp
+++ b/lib/AST/ProtocolGraph.cpp
@@ -158,7 +158,7 @@ void ProtocolGraph::computeInheritedProtocols() {
   }
 }
 
-/// Recursively compute the 'depth' of e protocol, which is inductively defined
+/// Recursively compute the 'depth' of a protocol, which is inductively defined
 /// as one greater than the depth of all inherited protocols, with a protocol
 /// that does not inherit any other protocol having a depth of one.
 unsigned ProtocolGraph::computeProtocolDepth(const ProtocolDecl *proto) {

--- a/lib/AST/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine.cpp
@@ -207,11 +207,12 @@ struct RequirementMachine::Implementation {
   RewriteSystem System;
   bool Complete = false;
 
-  Implementation() : System(Context) {}
+  Implementation(ASTContext &ctx)
+    : Context(ctx.Stats), System(Context) {}
 };
 
 RequirementMachine::RequirementMachine(ASTContext &ctx) : Context(ctx) {
-  Impl = new Implementation();
+  Impl = new Implementation(ctx);
 }
 
 RequirementMachine::~RequirementMachine() {
@@ -222,6 +223,9 @@ void RequirementMachine::addGenericSignature(CanGenericSignature sig) {
   PrettyStackTraceGenericSignature debugStack("building rewrite system for", sig);
 
   auto *Stats = Context.Stats;
+
+  if (Stats)
+    ++Stats->getFrontendCounters().NumRequirementMachines;
 
   FrontendStatsTracer tracer(Stats, "build-rewrite-system");
 

--- a/lib/AST/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine.cpp
@@ -35,7 +35,7 @@ struct RewriteSystemBuilder {
   bool Debug;
 
   ProtocolGraph Protocols;
-  std::vector<std::pair<Term, Term>> Rules;
+  std::vector<std::pair<MutableTerm, MutableTerm>> Rules;
 
   RewriteSystemBuilder(RewriteContext &ctx, bool debug)
     : Context(ctx), Debug(debug) {}
@@ -88,11 +88,11 @@ void RewriteSystemBuilder::addGenericSignature(CanGenericSignature sig) {
 /// named T".
 void RewriteSystemBuilder::addAssociatedType(const AssociatedTypeDecl *type,
                                              const ProtocolDecl *proto) {
-  Term lhs;
+  MutableTerm lhs;
   lhs.add(Atom::forProtocol(proto, Context));
   lhs.add(Atom::forName(type->getName(), Context));
 
-  Term rhs;
+  MutableTerm rhs;
   rhs.add(Atom::forAssociatedType(proto, type->getName(), Context));
 
   Rules.emplace_back(lhs, rhs);

--- a/lib/AST/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine.cpp
@@ -31,12 +31,14 @@ namespace {
 /// of a generic signature, and all protocol requirement signatures from all
 /// transitively-referenced protocols.
 struct RewriteSystemBuilder {
-  ASTContext &Context;
+  RewriteContext &Context;
+  bool Debug;
 
   ProtocolGraph Protocols;
   std::vector<std::pair<Term, Term>> Rules;
 
-  RewriteSystemBuilder(ASTContext &ctx) : Context(ctx) {}
+  RewriteSystemBuilder(RewriteContext &ctx, bool debug)
+    : Context(ctx), Debug(debug) {}
   void addGenericSignature(CanGenericSignature sig);
   void addAssociatedType(const AssociatedTypeDecl *type,
                          const ProtocolDecl *proto);
@@ -59,7 +61,7 @@ void RewriteSystemBuilder::addGenericSignature(CanGenericSignature sig) {
 
   // Add rewrite rules for each protocol.
   for (auto *proto : Protocols.Protocols) {
-    if (Context.LangOpts.DebugRequirementMachine) {
+    if (Debug) {
       llvm::dbgs() << "protocol " << proto->getName() << " {\n";
     }
 
@@ -78,7 +80,7 @@ void RewriteSystemBuilder::addGenericSignature(CanGenericSignature sig) {
     for (auto req : info.Requirements)
       addRequirement(req.getCanonical(), proto);
 
-    if (Context.LangOpts.DebugRequirementMachine) {
+    if (Debug) {
       llvm::dbgs() << "}\n";
     }
   }
@@ -97,11 +99,11 @@ void RewriteSystemBuilder::addGenericSignature(CanGenericSignature sig) {
 void RewriteSystemBuilder::addAssociatedType(const AssociatedTypeDecl *type,
                                              const ProtocolDecl *proto) {
   Term lhs;
-  lhs.add(Atom::forProtocol(proto));
-  lhs.add(Atom::forName(type->getName()));
+  lhs.add(Atom::forProtocol(proto, Context));
+  lhs.add(Atom::forName(type->getName(), Context));
 
   Term rhs;
-  rhs.add(Atom::forAssociatedType(proto, type->getName()));
+  rhs.add(Atom::forAssociatedType(proto, type->getName(), Context));
 
   Rules.emplace_back(lhs, rhs);
 }
@@ -117,12 +119,14 @@ void RewriteSystemBuilder::addInheritedAssociatedType(
                                                 const AssociatedTypeDecl *type,
                                                 const ProtocolDecl *inherited,
                                                 const ProtocolDecl *proto) {
+  assert(inherited != proto);
+
   Term lhs;
-  lhs.add(Atom::forProtocol(proto));
-  lhs.add(Atom::forAssociatedType(inherited, type->getName()));
+  lhs.add(Atom::forProtocol(proto, Context));
+  lhs.add(Atom::forAssociatedType(inherited, type->getName(), Context));
 
   Term rhs;
-  rhs.add(Atom::forAssociatedType(proto, type->getName()));
+  rhs.add(Atom::forAssociatedType(proto, type->getName(), Context));
 
   Rules.emplace_back(lhs, rhs);
 }
@@ -138,14 +142,14 @@ void RewriteSystemBuilder::addInheritedAssociatedType(
 /// protocol atom.
 void RewriteSystemBuilder::addRequirement(const Requirement &req,
                                           const ProtocolDecl *proto) {
-  if (Context.LangOpts.DebugRequirementMachine) {
+  if (Debug) {
     llvm::dbgs() << "+ ";
     req.dump(llvm::dbgs());
     llvm::dbgs() << "\n";
   }
 
   auto subjectType = CanType(req.getFirstType());
-  auto subjectTerm = getTermForType(subjectType, proto);
+  auto subjectTerm = Context.getTermForType(subjectType, proto);
 
   switch (req.getKind()) {
   case RequirementKind::Conformance: {
@@ -157,7 +161,7 @@ void RewriteSystemBuilder::addRequirement(const Requirement &req,
     auto *proto = req.getProtocolDecl();
 
     auto constraintTerm = subjectTerm;
-    constraintTerm.add(Atom::forProtocol(proto));
+    constraintTerm.add(Atom::forProtocol(proto, Context));
 
     Rules.emplace_back(subjectTerm, constraintTerm);
     break;
@@ -172,7 +176,8 @@ void RewriteSystemBuilder::addRequirement(const Requirement &req,
     //
     //   T.[L] == T
     auto constraintTerm = subjectTerm;
-    constraintTerm.add(Atom::forLayout(req.getLayoutConstraint()));
+    constraintTerm.add(Atom::forLayout(req.getLayoutConstraint(),
+                                       Context));
 
     Rules.emplace_back(subjectTerm, constraintTerm);
     break;
@@ -188,7 +193,7 @@ void RewriteSystemBuilder::addRequirement(const Requirement &req,
     if (!otherType->isTypeParameter())
       break;
 
-    auto otherTerm = getTermForType(otherType, proto);
+    auto otherTerm = Context.getTermForType(otherType, proto);
 
     Rules.emplace_back(subjectTerm, otherTerm);
     break;
@@ -196,48 +201,13 @@ void RewriteSystemBuilder::addRequirement(const Requirement &req,
   }
 }
 
-/// Map an interface type to a term.
-///
-/// If \p proto is null, this is a term relative to a generic
-/// parameter in a top-level signature. The term is rooted in a generic
-/// parameter atom.
-///
-/// If \p proto is non-null, this is a term relative to a protocol's
-/// 'Self' type. The term is rooted in a protocol atom.
-///
-/// The bound associated types in the interface type are ignored; the
-/// resulting term consists entirely of a root atom followed by zero
-/// or more name atoms.
-Term swift::rewriting::getTermForType(CanType paramType,
-                                      const ProtocolDecl *proto) {
-  assert(paramType->isTypeParameter());
-
-  // Collect zero or more nested type names in reverse order.
-  SmallVector<Atom, 3> atoms;
-  while (auto memberType = dyn_cast<DependentMemberType>(paramType)) {
-    atoms.push_back(Atom::forName(memberType->getName()));
-    paramType = memberType.getBase();
-  }
-
-  // Add the root atom at the end.
-  if (proto) {
-    assert(proto->getSelfInterfaceType()->isEqual(paramType));
-    atoms.push_back(Atom::forProtocol(proto));
-  } else {
-    atoms.push_back(Atom::forGenericParam(cast<GenericTypeParamType>(paramType)));
-  }
-
-  std::reverse(atoms.begin(), atoms.end());
-
-  return Term(atoms);
-}
-
 /// We use the PIMPL pattern to avoid creeping header dependencies.
 struct RequirementMachine::Implementation {
+  RewriteContext Context;
   RewriteSystem System;
   bool Complete = false;
 
-  Implementation() {}
+  Implementation() : System(Context) {}
 };
 
 RequirementMachine::RequirementMachine(ASTContext &ctx) : Context(ctx) {
@@ -261,7 +231,8 @@ void RequirementMachine::addGenericSignature(CanGenericSignature sig) {
 
   // Collect the top-level requirements, and all transtively-referenced
   // protocol requirement signatures.
-  RewriteSystemBuilder builder(Context);
+  RewriteSystemBuilder builder(Impl->Context,
+                               Context.LangOpts.DebugRequirementMachine);
   builder.addGenericSignature(sig);
 
   // Add the initial set of rewrite rules to the rewrite system, also

--- a/lib/AST/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine.cpp
@@ -39,7 +39,7 @@ struct RewriteSystemBuilder {
 
   CanType getConcreteSubstitutionSchema(CanType concreteType,
                                         const ProtocolDecl *proto,
-                                        SmallVector<Term> &result);
+                                        SmallVectorImpl<Term> &result);
 
   RewriteSystemBuilder(RewriteContext &ctx, bool debug)
     : Context(ctx), Debug(debug) {}
@@ -62,7 +62,7 @@ struct RewriteSystemBuilder {
 CanType
 RewriteSystemBuilder::getConcreteSubstitutionSchema(CanType concreteType,
                                                     const ProtocolDecl *proto,
-                                                    SmallVector<Term> &result) {
+                                                    SmallVectorImpl<Term> &result) {
   if (!concreteType->hasTypeParameter())
     return concreteType;
 
@@ -172,7 +172,7 @@ void RewriteSystemBuilder::addRequirement(const Requirement &req,
     //   T.[superclass: C<X, Y>] => T
     auto otherType = CanType(req.getSecondType());
 
-    SmallVector<Term> substitutions;
+    SmallVector<Term, 1> substitutions;
     otherType = getConcreteSubstitutionSchema(otherType, proto,
                                               substitutions);
 
@@ -200,7 +200,7 @@ void RewriteSystemBuilder::addRequirement(const Requirement &req,
       // rewrite rule
       //
       //   T.[concrete: C<X, Y>] => T
-      SmallVector<Term> substitutions;
+      SmallVector<Term, 1> substitutions;
       otherType = getConcreteSubstitutionSchema(otherType, proto,
                                                 substitutions);
 

--- a/lib/AST/RewriteSystem.cpp
+++ b/lib/AST/RewriteSystem.cpp
@@ -173,18 +173,26 @@ Atom Atom::forLayout(LayoutConstraint layout,
 ///
 /// * For layout atoms, we use LayoutConstraint::compare().
 int Atom::compare(Atom other, const ProtocolGraph &graph) const {
+  // Exit early if the atoms are equal.
+  if (Ptr == other.Ptr)
+    return 0;
+
   auto kind = getKind();
   auto otherKind = other.getKind();
 
   if (kind != otherKind)
     return int(kind) < int(otherKind) ? -1 : 1;
 
+  int result = 0;
+
   switch (kind) {
   case Kind::Name:
-    return getName().compare(other.getName());
+    result = getName().compare(other.getName());
+    break;
 
   case Kind::Protocol:
-    return graph.compareProtocols(getProtocol(), other.getProtocol());
+    result = graph.compareProtocols(getProtocol(), other.getProtocol());
+    break;
 
   case Kind::AssociatedType: {
     auto protos = getProtocols();
@@ -200,7 +208,8 @@ int Atom::compare(Atom other, const ProtocolGraph &graph) const {
         return result;
     }
 
-    return getName().compare(other.getName());
+    result = getName().compare(other.getName());
+    break;
   }
 
   case Kind::GenericParam: {
@@ -213,15 +222,16 @@ int Atom::compare(Atom other, const ProtocolGraph &graph) const {
     if (param->getIndex() != otherParam->getIndex())
       return param->getIndex() < otherParam->getIndex() ? -1 : 1;
 
-    return 0;
+    break;
   }
 
-  case Kind::Layout: {
-    return getLayoutConstraint().compare(other.getLayoutConstraint());
-  }
+  case Kind::Layout:
+    result = getLayoutConstraint().compare(other.getLayoutConstraint());
+    break;
   }
 
-  llvm_unreachable("Bad atom kind");
+  assert(result != 0 && "Two distinct atoms should not compare equal");
+  return result;
 }
 
 /// Print the atom using our mnemonic representation.

--- a/lib/AST/RewriteSystem.cpp
+++ b/lib/AST/RewriteSystem.cpp
@@ -488,6 +488,52 @@ int Atom::compare(Atom other, const ProtocolGraph &graph) const {
   return result;
 }
 
+/// For a superclass or concrete type atom
+///
+///   [concrete: Foo<X1, ..., Xn>]
+///   [superclass: Foo<X1, ..., Xn>]
+///
+/// Return a new atom where the prefix T is prepended to each of the
+/// substitutions:
+///
+///   [concrete: Foo<T.X1, ..., T.Xn>]
+///   [superclass: Foo<T.X1, ..., T.Xn>]
+///
+/// Asserts if this is not a superclass or concrete type atom.
+Atom Atom::prependPrefixToConcreteSubstitutions(
+    const MutableTerm &prefix,
+    RewriteContext &ctx) const {
+  assert(isSuperclassOrConcreteType());
+
+  if (prefix.empty())
+    return *this;
+
+  SmallVector<Term, 2> substitutions;
+  for (auto term : getSubstitutions()) {
+    MutableTerm mutTerm;
+    mutTerm.append(prefix);
+    mutTerm.append(term);
+
+    substitutions.push_back(Term::get(mutTerm, ctx));
+  }
+
+  switch (getKind()) {
+  case Kind::Superclass:
+    return Atom::forSuperclass(getSuperclass(), substitutions, ctx);
+  case Kind::ConcreteType:
+    return Atom::forConcreteType(getConcreteType(), substitutions, ctx);
+
+  case Kind::GenericParam:
+  case Kind::Name:
+  case Kind::Protocol:
+  case Kind::AssociatedType:
+  case Kind::Layout:
+    break;
+  }
+
+  llvm_unreachable("Bad atom kind");
+}
+
 /// Print the atom using our mnemonic representation.
 void Atom::dump(llvm::raw_ostream &out) const {
   auto dumpSubstitutions = [&]() {
@@ -1285,6 +1331,11 @@ RewriteSystem::computeCriticalPair(const Rule &lhs, const Rule &rhs) const {
 
   case OverlapKind::Second: {
     // lhs == TU -> X, rhs == UV -> Y.
+
+    if (v.back().isSuperclassOrConcreteType()) {
+      v.back() = v.back().prependPrefixToConcreteSubstitutions(
+          t, Context);
+    }
 
     // Compute the term XV.
     MutableTerm xv;

--- a/lib/AST/RewriteSystem.cpp
+++ b/lib/AST/RewriteSystem.cpp
@@ -865,6 +865,11 @@ void MutableTerm::dump(llvm::raw_ostream &out) const {
   }
 }
 
+Term RewriteContext::getTermForType(CanType paramType,
+                                    const ProtocolDecl *proto) {
+  return Term::get(getMutableTermForType(paramType, proto), *this);
+}
+
 /// Map an interface type to a term.
 ///
 /// If \p proto is null, this is a term relative to a generic
@@ -877,8 +882,8 @@ void MutableTerm::dump(llvm::raw_ostream &out) const {
 /// The bound associated types in the interface type are ignored; the
 /// resulting term consists entirely of a root atom followed by zero
 /// or more name atoms.
-MutableTerm RewriteContext::getTermForType(CanType paramType,
-                                           const ProtocolDecl *proto) {
+MutableTerm RewriteContext::getMutableTermForType(CanType paramType,
+                                                  const ProtocolDecl *proto) {
   assert(paramType->isTypeParameter());
 
   // Collect zero or more nested type names in reverse order.

--- a/test/Generics/recursive_conformances.swift
+++ b/test/Generics/recursive_conformances.swift
@@ -1,0 +1,61 @@
+// RUN: %target-typecheck-verify-swift -enable-requirement-machine
+
+// Make sure the requirement machine can compute a confluent
+// completion in examples where we merge two associated types
+// with the same name, both having recursive conformance
+// requirements.
+
+// Merged two cycles of length 1:
+//
+// P1 -> P1 -> P1 -> ...
+// P2 -> P2 -> P2 -> ...
+protocol P1 {
+  associatedtype T : P1
+}
+
+protocol P2 {
+  associatedtype T : P2
+}
+
+struct S<T : P1 & P2> {}
+
+// Merged a cycle of length 2 with a cycle of length 3
+//
+// P1a -> P1b -> P1a -> P1b -> P1a -> P1b -> ...
+// P2a -> P2b -> P2c -> P2a -> P2b -> P2c -> ...
+protocol P1a {
+  associatedtype T : P1b
+}
+
+protocol P1b {
+  associatedtype T : P1a
+}
+
+protocol P2a {
+  associatedtype T : P2b
+}
+
+protocol P2b {
+  associatedtype T : P2c
+}
+
+protocol P2c {
+  associatedtype T : P2a
+}
+
+struct SS<T : P1a & P2a> {}
+
+// Merged two cycles of length 1 via an inherited associated type
+protocol Base {
+  associatedtype T : Base // expected-note {{'T' declared here}}
+}
+
+// Base     -> Base     -> Base     -> ...
+// Derived1 -> Derived1 -> Derived1 -> ...
+protocol Derived1 : Base {
+  associatedtype T : Derived1 // expected-warning {{redeclaration of associated type 'T' from protocol 'Base' is better expressed as a 'where' clause on the protocol}}
+}
+
+// Base     -> Base     -> Base     -> ...
+// Derived2 -> Derived2 -> Derived2 -> ...
+protocol Derived2 : Base where T : Derived2 {}


### PR DESCRIPTION
Add new kinds of atoms representing superclass and concrete type requirements, and generate rewrite rules from these requirements when they appear in a generic signature.

Conceptually, we want to represent a concrete type requirement `T == Foo<Int, Y.Z>` as a rewrite rule:

    T.[concrete: Foo<Int, Y.Z>] => T

What we really want is for the arguments to the type constructor `Foo<>` to be a mix of other concrete types or rewriting terms (in this case, `Int' and `Y.Z`), but we can't squeeze that into the representation of `Type`, and defining a parallel set of type constructors for all parametrizable types would not be feasible (not only do we have bound generic types, but also function types with varying levels of complexity, metatypes, tuples, ...).

The solution I came up with is to replace each subterm with a fresh generic parameter. All of these generic parameters have a depth of 0 and an index into a "substitution list" which is an array of terms. So in reality, `[concrete: Foo<Int, Y.Z>]` is stored as follows:

    [concrete: Foo<Int, τ_0_0> with {Y.Z}]

This PR adds some support for these atoms in the completion procedure. Namely, when computing an overlap, if we have two rules `TU -> X` and `UV -> Y` and `V` ends with a superclass or concrete type atom, we prepend `T` to the concrete substitutions in the atom.

However, there is another missing step that is coming in the next PR: unification of type constructor arguments when the same type is subject to multiple superclass or concrete type requirements.