### PR TITLE
Revert "Disable standard substitutions when building with "older" _Concurrency module"

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1428,19 +1428,9 @@ bool ModuleDecl::isStdlibModule() const {
 }
 
 bool ModuleDecl::hasStandardSubstitutions() const {
-  if (getParent())
-    return false;
-
-  if (getName() == getASTContext().StdlibModuleName)
-    return true;
-
-  // The _Concurrency module gets standard substitutions with "new enough"
-  // versions of the module.
-  if (getName() == getASTContext().Id_Concurrency &&
-      getASTContext().getProtocol(KnownProtocolKind::SerialExecutor))
-    return true;
-
-  return false;
+  return !getParent() &&
+      (getName() == getASTContext().StdlibModuleName ||
+       getName() == getASTContext().Id_Concurrency);
 }
 
 bool ModuleDecl::isSwiftShimsModule() const {


### PR DESCRIPTION
Reverts apple/swift#37923. We need a more comprehensive solution for this