### PR TITLE
[RemoteMirror] Add new API for getting the type descriptor address.

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -687,7 +687,16 @@ public:
 
     return false;
   }
-  
+
+  /// Returns the address of the nominal type descriptor given a metadata
+  /// address.
+  StoredPointer nominalTypeDescriptorFromMetadata(StoredPointer MetadataAddress) {
+    auto Metadata = readMetadata(MetadataAddress);
+    if (!Metadata)
+      return 0;
+    return super::readAddressOfNominalTypeDescriptor(Metadata, true);
+  }
+
   /// Return a description of the layout of a class instance with the given
   /// metadata as its isa pointer.
   const TypeInfo *

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -136,6 +136,13 @@ uintptr_t
 swift_reflection_metadataForObject(SwiftReflectionContextRef ContextRef,
                                    uintptr_t Object);
 
+/// Returns the nominal type descriptor given the metadata
+SWIFT_REMOTE_MIRROR_LINKAGE
+swift_reflection_ptr_t
+swift_reflection_metadataNominalTypeDescriptor(SwiftReflectionContextRef ContextRef,
+																							 swift_reflection_ptr_t Metadata);
+
+
 /// Returns an opaque type reference for a class or closure context
 /// instance pointer, or NULL if one can't be constructed.
 ///

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -282,6 +282,13 @@ swift_reflection_metadataForObject(SwiftReflectionContextRef ContextRef,
   return *MetadataAddress;
 }
 
+swift_reflection_ptr_t
+swift_reflection_metadataNominalTypeDescriptor(SwiftReflectionContextRef ContextRef,
+                                               swift_reflection_ptr_t MetadataAddress) {
+  auto Context = ContextRef->nativeContext;
+  return Context->nominalTypeDescriptorFromMetadata(MetadataAddress);
+}
+
 swift_typeref_t
 swift_reflection_typeRefForInstance(SwiftReflectionContextRef ContextRef,
                                     uintptr_t Object) {


### PR DESCRIPTION
This will allow the heap tool to work out which binary a dynamically allocated class comes from, by looking up its nominal type descriptor address and then seeing which binary contains that.

Fixes rdar://65742351.