### PR TITLE
[Clang importer] Import Swift declaration modifiers from swift_attr.

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -75,8 +75,8 @@ NOTE(unresolvable_clang_decl_is_a_framework_bug,none,
      "please report this issue to the owners of '%0'",
      (StringRef))
 
-WARNING(clang_swift_attr_without_at,none,
-        "Swift attribute '%0' does not start with '@'", (StringRef))
+WARNING(clang_swift_attr_unhandled,none,
+        "Ignoring unknown Swift attribute or modifier '%0'", (StringRef))
 
 WARNING(implicit_bridging_header_imported_from_module,none,
         "implicit import of bridging header '%0' via module %1 "

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1004,7 +1004,8 @@ public:
 
   /// Parse the optional modifiers before a declaration.
   bool parseDeclModifierList(DeclAttributes &Attributes, SourceLoc &StaticLoc,
-                             StaticSpellingKind &StaticSpelling);
+                             StaticSpellingKind &StaticSpelling,
+                             bool isFromClangAttribute = false);
 
   /// Parse an availability attribute of the form
   /// @available(*, introduced: 1.0, deprecated: 3.1).

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3554,7 +3554,8 @@ ParserStatus Parser::parseDeclAttributeList(DeclAttributes &Attributes) {
 //      'distributed'
 bool Parser::parseDeclModifierList(DeclAttributes &Attributes,
                                    SourceLoc &StaticLoc,
-                                   StaticSpellingKind &StaticSpelling) {
+                                   StaticSpellingKind &StaticSpelling,
+                                   bool isFromClangAttribute) {
   SyntaxParsingContext ListContext(SyntaxContext, SyntaxKind::ModifierList);
   bool isError = false;
   bool hasModifier = false;
@@ -3622,7 +3623,8 @@ bool Parser::parseDeclModifierList(DeclAttributes &Attributes,
 
       SyntaxParsingContext ModContext(SyntaxContext,
                                       SyntaxKind::DeclModifier);
-      isError |= parseNewDeclAttribute(Attributes, /*AtLoc=*/{}, Kind);
+      isError |= parseNewDeclAttribute(
+          Attributes, /*AtLoc=*/{}, Kind, isFromClangAttribute);
       hasModifier = true;
       continue;
     }

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -121,6 +121,9 @@ actor MySubclassCheckingSwiftAttributes : ProtocolWithSwiftAttributes {
     syncMethod() // expected-error{{ctor-isolated instance method 'syncMethod()' can not be referenced from a non-isolated context}}
   }
 
+  nonisolated func nonisolatedMethod() {
+  }
+
   @MainActor func mainActorMethod() {
     syncMethod() // expected-error{{actor-isolated instance method 'syncMethod()' can not be referenced from the main actor}}
   }

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -98,6 +98,7 @@ import _Concurrency
 
 // CHECK-LABEL: protocol ProtocolWithSwiftAttributes {
 // CHECK-NEXT: nonisolated func independentMethod()
+// CHECK-NEXT: nonisolated func nonisolatedMethod()
 // CHECK-NEXT: {{^}} @objc @MainActor func mainActorMethod()
 // CHECK-NEXT: {{^}} @objc @MainActor func uiActorMethod()
 // CHECK-NEXT: {{^}} @objc optional func missingAtAttributeMethod()

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -96,6 +96,7 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
 
 @protocol ProtocolWithSwiftAttributes
 -(void)independentMethod __attribute__((__swift_attr__("@actorIndependent")));
+-(void)nonisolatedMethod __attribute__((__swift_attr__("nonisolated")));
 -(void)mainActorMethod __attribute__((__swift_attr__("@MainActor")));
 -(void)uiActorMethod __attribute__((__swift_attr__("@UIActor")));
 


### PR DESCRIPTION
In addition to importing Swift attributes spelled with the C
`__attribute__((swift_attr("...")))`, also import declaration modifiers,
including `nonisolated`.

Fixes rdar://79402200.
