### PR TITLE
[Runtime] Detect and log redundant subclass/superclass conformances.

### DIFF
--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -906,10 +906,20 @@ swift_conformsToProtocolImpl(const Metadata *const type,
   const WitnessTable *foundWitness = nullptr;
   const Metadata *foundType = nullptr;
   for (auto searchType : iterateMaybeIncompleteSuperclasses(type)) {
-    foundWitness = foundWitnesses.lookup(searchType);
-    if (foundWitness) {
-      foundType = searchType;
-      break;
+    const WitnessTable *witness = foundWitnesses.lookup(searchType);
+    if (witness) {
+      if (!foundType) {
+        foundWitness = witness;
+        foundType = searchType;
+      } else {
+        swift::warning(RuntimeErrorFlagNone,
+                       "Warning: '%s' conforms to protocol '%s', but it also "
+                       "inherits conformance from '%s'.  Relying on a "
+                       "particular conformance is undefined behaviour.\n",
+                       foundType->getDescription()->Name.get(),
+                       protocol->Name.get(),
+                       searchType->getDescription()->Name.get());
+      }
     }
   }
 

--- a/test/multifile/Inputs/protocol-conformance-redundant-def.swift
+++ b/test/multifile/Inputs/protocol-conformance-redundant-def.swift
@@ -1,0 +1,7 @@
+public protocol Hello {
+  func hello()
+}
+
+open class Super {
+  public init() {}
+}

--- a/test/multifile/Inputs/protocol-conformance-redundant-ext.swift
+++ b/test/multifile/Inputs/protocol-conformance-redundant-ext.swift
@@ -1,0 +1,7 @@
+import Def
+
+extension Super : Hello {
+  public func hello() {
+    print("Hello")
+  }
+}

--- a/test/multifile/protocol-conformance-redundant.swift
+++ b/test/multifile/protocol-conformance-redundant.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Def)) -module-name Def -emit-module -emit-module-path %t/Def.swiftmodule %S/Inputs/protocol-conformance-redundant-def.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Ext)) -module-name Ext -emit-module -emit-module-path %t/Ext.swiftmodule -I%t -L%t -lDef %S/Inputs/protocol-conformance-redundant-ext.swift
+// RUN: %target-build-swift -I%t -L%t -lDef -o %t/main %target-rpath(%t) %s
+// RUN: %target-codesign %t/main %t/%target-library-name(Def) %t/%target-library-name(Ext)
+// RUN: %target-run %t/main %t/%target-library-name(Ext) 2>&1 | %FileCheck %s
+
+// REQUIRES: executable_test
+// XFAIL: windows
+
+// CHECK: Warning: 'Sub' conforms to protocol 'Hello', but it also inherits conformance from 'Super'.  Relying on a particular conformance is undefined behaviour.
+// CHECK: Hello
+
+import StdlibUnittest
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#else
+#error("Unsupported platform")
+#endif
+
+import Def
+
+let dylibPath = CommandLine.arguments.last!
+let openRes = dlopen(dylibPath, RTLD_NOW|RTLD_LOCAL)
+assert(openRes != nil, "unable to open extension dylib")
+
+class Sub : Super, Hello {
+  func hello() {
+    print("Hello")
+  }
+}
+
+let s = Sub() as AnyObject as! Hello
+
+s.hello()
+


### PR DESCRIPTION
When we rely on a protocol conformance, and the type in question has multiple conformances to that protocol in its inheritance chain, emit a runtime warning.

It's quite tricky to cause this problem - you need a type in one dylib that is extended to conform to a protocol in another dylib, subclassed in another module and then some subclass has protocol conformance added as well.  If they're in
the same module, the compiler will give an error and prevent the problem completely.

rdar://73364629
