### PR TITLE
[Runtime] Fix crash in protocol conformance checks on KVO artificial subclasses.

### DIFF
--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -169,6 +169,14 @@ static MetadataResponse getSuperclassForMaybeIncompleteMetadata(
   if (!classMetadata)
     return {_swift_class_getSuperclass(metadata), MetadataState::Complete};
 
+#if SWIFT_OBJC_INTEROP
+    // Artificial subclasses are not valid type metadata and
+    // tryGetCompleteMetadataNonblocking will crash on them. However, they're
+    // always fully set up, so we can just skip it and fetch the Subclass field.
+    if (classMetadata->isTypeMetadata() && classMetadata->isArtificialSubclass())
+      return {classMetadata->Superclass, MetadataState::Complete};
+#endif
+
   MetadataState metadataState;
   if (knownMetadataState)
     metadataState = *knownMetadataState;

--- a/test/Casting/Casts.swift
+++ b/test/Casting/Casts.swift
@@ -983,6 +983,16 @@ CastsTests.test("Do not overuse __SwiftValue") {
 }
 #endif
 
+#if _runtime(_ObjC)
+CastsTests.test("Artificial subclass protocol conformance") {
+  class SwiftClass: NSObject {}
+  let subclass: AnyClass = objc_allocateClassPair(SwiftClass.self,
+                                                  "ArtificialSwiftSubclass", 0)!
+  objc_registerClassPair(subclass)
+  expectFalse(subclass is P.Type)
+}
+#endif
+
 CastsTests.test("Do not overuse __SwiftValue (non-ObjC)") {
   struct Bar {}
   // This should succeed because this is what __SwiftValue boxing is for


### PR DESCRIPTION
tryGetCompleteMetadataNonblocking crashes on artificial subclasses due to the NULL type descriptor. Explicitly check for artificial subclasses in getSuperclassForMaybeIncompleteMetadata and immediately return their Superclass field. Artificial subclasses are always fully initialized so we don't need to do anything special for them.

rdar://72583931