### PR TITLE
[SE-0314] `AsyncStream` and `AsyncThrowingStream` Updates

### DIFF
--- a/stdlib/public/Concurrency/AsyncStream.cpp
+++ b/stdlib/public/Concurrency/AsyncStream.cpp
@@ -1,0 +1,39 @@
+//===--- AsyncStream.cpp - Multi-resume locking interface -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Mutex.h"
+
+namespace swift {
+// return the size in words for the given mutex primitive
+extern "C"
+size_t _swift_async_stream_lock_size() {
+  size_t words = sizeof(MutexHandle) / sizeof(void *);
+  if (words < 1) { return 1; }
+  return words;
+}
+
+extern "C"
+void _swift_async_stream_lock_init(MutexHandle &lock) {
+  MutexPlatformHelper::init(lock);
+}
+
+extern "C"
+void _swift_async_stream_lock_lock(MutexHandle &lock) {
+  MutexPlatformHelper::lock(lock);
+}
+
+extern "C"
+void _swift_async_stream_lock_unlock(MutexHandle &lock) {
+  MutexPlatformHelper::unlock(lock);
+}
+
+};

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -1,0 +1,188 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+/// An ordered, asynchronously generated sequence of elements.
+///
+/// AsyncStream is an interface type to adapt from code producing values to an
+/// asynchronous context iterating them. This is itended to be used to allow
+/// callback or delegation based APIs to participate with async/await.
+///
+/// When values are produced from a non async/await source there is a
+/// consideration that must be made on behavioral characteristics of how that
+/// production of values interacts with the iteration. AsyncStream offers a
+/// initialization strategy that provides a method of yielding values into
+/// iteration.
+///
+/// AsyncStream can be initialized with the option to buffer to a given limit.
+/// The default value for this limit is Int.max. The buffering is only for
+/// values that have yet to be consumed by iteration. Values can be yielded in
+/// case to the continuation passed into the build closure. That continuation
+/// is Sendable, in that it is intended to be used from concurrent contexts
+/// external to the iteration of the AsyncStream.
+///
+/// A trivial use case producing values from a detached task would work as such:
+///
+///     let digits = AsyncStream(Int.self) { continuation in
+///       detach {
+///         for digit in 0..<10 {
+///           continuation.yield(digit)
+///         }
+///         continuation.finish()
+///       }
+///     }
+///
+///     for await digit in digits {
+///       print(digit)
+///     }
+///
+@available(SwiftStdlib 5.5, *)
+public struct AsyncStream<Element> {
+  public struct Continuation: Sendable {
+    public enum Termination {
+      case finished
+      case cancelled
+    }
+
+    let storage: _Storage
+
+    /// Resume the task awaiting the next iteration point by having it return
+    /// nomally from its suspension point or buffer the value if no awaiting
+    /// next iteration is active.
+    ///
+    /// - Parameter value: The value to yield from the continuation.
+    ///
+    /// This can be called more than once and returns to the caller immediately
+    /// without blocking for any awaiting consuption from the iteration.
+    public func yield(_ value: __owned Element) {
+      storage.yield(value)
+    }
+
+    /// Resume the task awaiting the next iteration point by having it return
+    /// nil which signifies the end of the iteration.
+    ///
+    /// Calling this function more than once is idempotent; i.e. finishing more
+    /// than once does not alter the state beyond the requirements of
+    /// AsyncSequence; which claims that all values past a terminal state are
+    /// nil.
+    public func finish() {
+      storage.finish()
+    }
+
+    /// A callback to invoke when iteration of a AsyncStream is cancelled.
+    ///
+    /// If an `onTermination` callback is set, when iteration of a AsyncStream is
+    /// cancelled via task cancellation that callback is invoked. The callback
+    /// is disposed of after any terminal state is reached.
+    ///
+    /// Cancelling an active iteration will first invoke the onTermination callback
+    /// and then resume yeilding nil. This means that any cleanup state can be
+    /// emitted accordingly in the cancellation handler
+    public var onTermination: (@Sendable (Termination) -> Void)? {
+      get {
+        return storage.getOnTermination()
+      }
+      nonmutating set {
+        storage.setOnTermination(newValue)
+      }
+    }
+  }
+
+  let produce: () async -> Element?
+
+  /// Construct a AsyncStream buffering given an Element type.
+  ///
+  /// - Parameter elementType: The type the AsyncStream will produce.
+  /// - Parameter maxBufferedElements: The maximum number of elements to
+  ///   hold in the buffer past any checks for continuations being resumed.
+  /// - Parameter build: The work associated with yielding values to the AsyncStream.
+  ///
+  /// The maximum number of pending elements limited by dropping the oldest
+  /// value when a new value comes in if the buffer would excede the limit
+  /// placed upon it. By default this limit is unlimited.
+  ///
+  /// The build closure passes in a Continuation which can be used in
+  /// concurrent contexts. It is thread safe to send and finish; all calls are
+  /// to the continuation are serialized, however calling this from multiple
+  /// concurrent contexts could result in out of order delivery.
+  public init(
+    _ elementType: Element.Type = Element.self,
+    maxBufferedElements limit: Int = .max,
+    _ build: (Continuation) -> Void
+  ) {
+    let storage: _Storage = .create(limit: limit)
+    produce = storage.next
+    build(Continuation(storage: storage))
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+extension AsyncStream: AsyncSequence {
+  /// The asynchronous iterator for iterating a AsyncStream.
+  ///
+  /// This type is specificially not Sendable. It is not intended to be used
+  /// from multiple concurrent contexts. Any such case that next is invoked
+  /// concurrently and contends with another call to next is a programmer error
+  /// and will fatalError.
+  public struct Iterator: AsyncIteratorProtocol {
+    let produce: () async -> Element?
+
+    /// The next value from the AsyncStream.
+    ///
+    /// When next returns nil this signifies the end of the AsyncStream. Any such
+    /// case that next is invoked concurrently and contends with another call to
+    /// next is a programmer error and will fatalError.
+    ///
+    /// If the task this iterator is running in is canceled while next is
+    /// awaiting a value, this will terminate the AsyncStream and next may return nil
+    /// immediately (or will return nil on subseuqent calls)
+    public mutating func next() async -> Element? {
+      await produce()
+    }
+  }
+
+  /// Construct an iterator.
+  public func makeAsyncIterator() -> Iterator {
+    return Iterator(produce: produce)
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+extension AsyncStream.Continuation {
+  /// Resume the task awaiting the next iteration point by having it return
+  /// normally from its suspension point or buffer the value if no awaiting
+  /// next iteration is active.
+  ///
+  /// - Parameter result: A result to yield from the continuation.
+  ///
+  /// This can be called more than once and returns to the caller immediately
+  /// without blocking for any awaiting consuption from the iteration.
+  public func yield(
+    with result: Result<Element, Never>
+  ) {
+    switch result {
+      case .success(let val):
+        storage.yield(val)
+    }
+  }
+
+  /// Resume the task awaiting the next iteration point by having it return
+  /// normally from its suspension point or buffer the value if no awaiting
+  /// next iteration is active where the `Element` is `Void`.
+  ///
+  /// This can be called more than once and returns to the caller immediately
+  /// without blocking for any awaiting consuption from the iteration.
+  public func yield() where Element == Void {
+    storage.yield(())
+  }
+}

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -49,9 +49,49 @@ import Swift
 @available(SwiftStdlib 5.5, *)
 public struct AsyncStream<Element> {
   public struct Continuation: Sendable {
+    /// Indication of the type of termination informed to
+    /// `onTermination`.
     public enum Termination {
+      
+      /// The stream was finished via the `finish` method
       case finished
+      
+      /// The stream was cancelled
       case cancelled
+    }
+    
+    /// A result of yielding values.
+    public enum YieldResult {
+      
+      /// When a value is successfully enqueued, either buffered
+      /// or immediately consumed to resume a pending call to next
+      /// and a count of remaining slots available in the buffer at
+      /// the point in time of yielding. Note: transacting upon the
+      /// remaining count is only valid when then calls to yield are
+      /// mutually exclusive.
+      case enqueued(remaining: Int)
+      
+      /// Yielding resulted in not buffering an element because the
+      /// buffer was full. The element is the dropped value.
+      case dropped(Element)
+      
+      /// Indication that the continuation was yielded when the
+      /// stream was already in a terminal state: either by cancel or
+      /// by finishing.
+      case terminated
+    }
+    
+    /// A strategy that handles exhaustion of a buffer’s capacity.
+    public enum BufferingPolicy {
+      case unbounded
+      
+      /// When the buffer is full, discard the newly received element.
+      /// This enforces keeping the specified amount of oldest values.
+      case bufferingOldest(Int)
+      
+      /// When the buffer is full, discard the oldest element in the buffer.
+      /// This enforces keeping the specified amount of newest values.
+      case bufferingNewest(Int)
     }
 
     let storage: _Storage
@@ -64,7 +104,8 @@ public struct AsyncStream<Element> {
     ///
     /// This can be called more than once and returns to the caller immediately
     /// without blocking for any awaiting consuption from the iteration.
-    public func yield(_ value: __owned Element) {
+    @discardableResult
+    public func yield(_ value: __owned Element) -> YieldResult {
       storage.yield(value)
     }
 
@@ -85,9 +126,9 @@ public struct AsyncStream<Element> {
     /// cancelled via task cancellation that callback is invoked. The callback
     /// is disposed of after any terminal state is reached.
     ///
-    /// Cancelling an active iteration will first invoke the onTermination callback
-    /// and then resume yeilding nil. This means that any cleanup state can be
-    /// emitted accordingly in the cancellation handler
+    /// Cancelling an active iteration will first invoke the onTermination 
+    /// callback and then resume yeilding nil. This means that any cleanup state
+    /// can be emitted accordingly in the cancellation handler.
     public var onTermination: (@Sendable (Termination) -> Void)? {
       get {
         return storage.getOnTermination()
@@ -105,7 +146,8 @@ public struct AsyncStream<Element> {
   /// - Parameter elementType: The type the AsyncStream will produce.
   /// - Parameter maxBufferedElements: The maximum number of elements to
   ///   hold in the buffer past any checks for continuations being resumed.
-  /// - Parameter build: The work associated with yielding values to the AsyncStream.
+  /// - Parameter build: The work associated with yielding values to the 
+  ///   AsyncStream.
   ///
   /// The maximum number of pending elements limited by dropping the oldest
   /// value when a new value comes in if the buffer would excede the limit
@@ -117,12 +159,33 @@ public struct AsyncStream<Element> {
   /// concurrent contexts could result in out of order delivery.
   public init(
     _ elementType: Element.Type = Element.self,
-    maxBufferedElements limit: Int = .max,
+    bufferingPolicy limit: Continuation.BufferingPolicy = .unbounded,
     _ build: (Continuation) -> Void
   ) {
     let storage: _Storage = .create(limit: limit)
-    produce = storage.next
+    self.init(unfolding: storage.next)
     build(Continuation(storage: storage))
+  }
+
+  
+  public init(
+    unfolding produce: @escaping () async -> Element?, 
+    onCancel: (@Sendable () -> Void)? = nil
+  ) {
+    let storage: _AsyncStreamCriticalStorage<Optional<() async -> Element?>>
+      = .create(produce)
+    self.produce = {
+      return await Task.withCancellationHandler {
+        storage.value = nil
+        onCancel?()
+      } operation: {
+        guard let result = await storage.value?() else {
+          storage.value = nil
+          return nil
+        }
+        return result
+      }
+    }
   }
 }
 
@@ -139,13 +202,13 @@ extension AsyncStream: AsyncSequence {
 
     /// The next value from the AsyncStream.
     ///
-    /// When next returns nil this signifies the end of the AsyncStream. Any such
-    /// case that next is invoked concurrently and contends with another call to
-    /// next is a programmer error and will fatalError.
+    /// When next returns nil this signifies the end of the AsyncStream. Any 
+    /// such case that next is invoked concurrently and contends with another 
+    /// call to next is a programmer error and will fatalError.
     ///
     /// If the task this iterator is running in is canceled while next is
-    /// awaiting a value, this will terminate the AsyncStream and next may return nil
-    /// immediately (or will return nil on subseuqent calls)
+    /// awaiting a value, this will terminate the AsyncStream and next may 
+    /// return nil immediately (or will return nil on subseuqent calls)
     public mutating func next() async -> Element? {
       await produce()
     }
@@ -167,12 +230,13 @@ extension AsyncStream.Continuation {
   ///
   /// This can be called more than once and returns to the caller immediately
   /// without blocking for any awaiting consuption from the iteration.
+  @discardableResult
   public func yield(
     with result: Result<Element, Never>
-  ) {
+  ) -> YieldResult {
     switch result {
       case .success(let val):
-        storage.yield(val)
+        return storage.yield(val)
     }
   }
 
@@ -182,7 +246,8 @@ extension AsyncStream.Continuation {
   ///
   /// This can be called more than once and returns to the caller immediately
   /// without blocking for any awaiting consuption from the iteration.
-  public func yield() where Element == Void {
-    storage.yield(())
+  @discardableResult
+  public func yield() -> YieldResult where Element == Void {
+    return storage.yield(())
   }
 }

--- a/stdlib/public/Concurrency/AsyncStreamBuffer.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBuffer.swift
@@ -1,0 +1,405 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+@_silgen_name("_swift_async_stream_lock_size")
+func _lockWordCount() -> Int
+
+@_silgen_name("_swift_async_stream_lock_init")
+func _lockInit(_ ptr: UnsafeRawPointer)
+
+@_silgen_name("_swift_async_stream_lock_lock")
+func _lock(_ ptr: UnsafeRawPointer)
+
+@_silgen_name("_swift_async_stream_lock_unlock")
+func _unlock(_ ptr: UnsafeRawPointer)
+
+@available(SwiftStdlib 5.5, *)
+extension AsyncStream {
+  internal final class _Storage: UnsafeSendable {
+    typealias TerminationHandler = @Sendable (Continuation.Termination) -> Void
+
+    struct State {
+      var continuation: UnsafeContinuation<Element?, Never>?
+      var pending = _Deque<Element>()
+      let limit: Int
+      var onTermination: TerminationHandler?
+      var terminal: Bool = false
+
+      init(limit: Int) {
+        self.limit = limit
+      }
+    }
+    // Stored as a singular structured assignment for initialization
+    var state: State
+
+    private init(_doNotCallMe: ()) {
+      fatalError("Storage must be initialized by create")
+    }
+
+    deinit {
+      state.onTermination?(.cancelled)
+    }
+
+    private func lock() {
+      let ptr =
+        UnsafeRawPointer(Builtin.projectTailElems(self, UnsafeRawPointer.self))
+      _lock(ptr)
+    }
+
+    private func unlock() {
+      let ptr =
+        UnsafeRawPointer(Builtin.projectTailElems(self, UnsafeRawPointer.self))
+      _unlock(ptr)
+    }
+
+    func getOnTermination() -> TerminationHandler? {
+      lock()
+      let handler = state.onTermination
+      unlock()
+      return handler
+    }
+
+    func setOnTermination(_ newValue: TerminationHandler?) {
+      lock()
+      withExtendedLifetime(state.onTermination) {
+        state.onTermination = newValue
+        unlock()
+      }
+    }
+
+    func cancel() {
+      lock()
+      // swap out the handler before we invoke it to prevent double cancel
+      let handler = state.onTermination
+      state.onTermination = nil
+      unlock()
+      
+      handler?(.cancelled) // handler must be invoked before yielding nil for termination
+
+      finish()
+    }
+
+    func yield(_ value: __owned Element) {
+      lock()
+      let limit = state.limit
+      if let continuation = state.continuation {
+        let count = state.pending.count
+        if count > 0 {
+          if !state.terminal && count < limit {
+            state.pending.append(value)
+          }
+          state.continuation = nil
+          let toSend = state.pending.removeFirst()
+          unlock()
+          continuation.resume(returning: toSend)
+        } else if state.terminal {
+          state.continuation = nil
+          unlock()
+          continuation.resume(returning: nil)
+        } else {
+          state.continuation = nil
+          unlock()
+          continuation.resume(returning: value)
+        }
+      } else {
+        if !state.terminal && ((limit == .max) || (state.pending.count < limit)) {
+          state.pending.append(value)
+        }
+        unlock()
+      }
+    }
+    
+    func finish() {
+      lock()
+      let handler = state.onTermination
+      state.onTermination = nil
+      state.terminal = true
+
+      if let continuation = state.continuation {
+        if state.pending.count > 0 {
+          state.continuation = nil
+          let toSend = state.pending.removeFirst()
+          unlock()
+          handler?(.finished)
+          continuation.resume(returning: toSend)
+        } else if state.terminal {
+          state.continuation = nil
+          unlock()
+          handler?(.finished)
+          continuation.resume(returning: nil)
+        } else {
+          unlock()
+          handler?(.finished)
+        }
+      } else {
+        if state.limit == 0 {
+          state.pending.removeFirst()
+        }
+        unlock()
+        handler?(.finished)
+      }
+    }
+
+    func next(_ continuation: UnsafeContinuation<Element?, Never>) {
+      lock()
+      if state.continuation == nil {
+        if state.pending.count > 0 {
+          let toSend = state.pending.removeFirst()
+          unlock()
+          continuation.resume(returning: toSend)
+        } else if state.terminal {
+          unlock()
+          continuation.resume(returning: nil)
+        } else {
+          state.continuation = continuation
+          unlock()
+        }
+      } else {
+        unlock()
+        fatalError("attempt to await next() on more than one task")
+      }
+    }
+    
+    func next() async -> Element? {
+      await withTaskCancellationHandler { [cancel] in
+        cancel()
+      } operation: {
+        await withUnsafeContinuation {
+          next($0)
+        }
+      }
+    }
+
+    static func create(limit: Int) -> _Storage {
+      let minimumCapacity = _lockWordCount()
+      let storage = Builtin.allocWithTailElems_1(
+        _Storage.self,
+          minimumCapacity._builtinWordValue,
+          UnsafeRawPointer.self
+      )
+
+      let state =
+        UnsafeMutablePointer<State>(Builtin.addressof(&storage.state))
+      state.initialize(to: State(limit: limit))
+      let ptr = UnsafeRawPointer(
+        Builtin.projectTailElems(storage, UnsafeRawPointer.self))
+      _lockInit(ptr)
+      return storage
+    }
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+extension AsyncThrowingStream {
+  internal final class _Storage: UnsafeSendable {
+    typealias TerminationHandler = @Sendable (Continuation.Termination) -> Void
+    enum Terminal {
+      case finished
+      case failed(Error)
+    }
+    
+    struct State {
+      var continuation: UnsafeContinuation<Element?, Error>?
+      var pending = _Deque<Element>()
+      let limit: Int
+      var onTermination: TerminationHandler?
+      var terminal: Terminal?
+
+      init(limit: Int) {
+        self.limit = limit
+      }
+    }
+    // Stored as a singular structured assignment for initialization
+    var state: State
+
+    private init(_doNotCallMe: ()) {
+      fatalError("Storage must be initialized by create")
+    }
+
+    deinit {
+      state.onTermination?(.cancelled)
+    }
+
+    private func lock() {
+      let ptr =
+        UnsafeRawPointer(Builtin.projectTailElems(self, UnsafeRawPointer.self))
+      _lock(ptr)
+    }
+
+    private func unlock() {
+      let ptr =
+        UnsafeRawPointer(Builtin.projectTailElems(self, UnsafeRawPointer.self))
+      _unlock(ptr)
+    }
+
+    func getOnTermination() -> TerminationHandler? {
+      lock()
+      let handler = state.onTermination
+      unlock()
+      return handler
+    }
+
+    func setOnTermination(_ newValue: TerminationHandler?) {
+      lock()
+      withExtendedLifetime(state.onTermination) {
+        state.onTermination = newValue
+        unlock()
+      }
+    }
+
+    func cancel() {
+      lock()
+      // swap out the handler before we invoke it to prevent double cancel
+      let handler = state.onTermination
+      state.onTermination = nil
+      unlock()
+      
+      handler?(.cancelled) // handler must be invoked before yielding nil for termination
+
+      finish()
+    }
+
+    func yield(_ value: __owned Element) {
+      lock()
+      let limit = state.limit
+      if let continuation = state.continuation {
+        let count = state.pending.count
+        if count > 0 {
+          if state.terminal == nil && count < limit {
+            state.pending.append(value)
+          }
+          state.continuation = nil
+          let toSend = state.pending.removeFirst()
+          unlock()
+          continuation.resume(returning: toSend)
+        } else if let terminal = state.terminal {
+          state.continuation = nil
+          state.terminal = .finished
+          unlock()
+          switch terminal {
+          case .finished:
+            continuation.resume(returning: nil)
+          case .failed(let error):
+            continuation.resume(throwing: error)
+          }
+        } else {
+          state.continuation = nil
+          unlock()
+          continuation.resume(returning: value)
+        }
+      } else {
+        if state.terminal == nil && ((limit == .max) || (state.pending.count < limit)) {
+          state.pending.append(value)
+        }
+        unlock()
+      }
+    }
+    
+    func finish(throwing error: __owned Error? = nil) {
+      lock()
+      let handler = state.onTermination
+      state.onTermination = nil
+      if state.terminal == nil {
+        if let failure = error {
+          state.terminal = .failed(failure)
+        } else {
+          state.terminal = .finished
+        }
+      }
+
+      if let continuation = state.continuation {
+        if state.pending.count > 0 {
+          state.continuation = nil
+          let toSend = state.pending.removeFirst()
+          unlock()
+          handler?(.finished(error))
+          continuation.resume(returning: toSend)
+        } else if let terminal = state.terminal {
+          state.continuation = nil
+          unlock()
+          handler?(.finished(error))
+          switch terminal {
+          case .finished:
+            continuation.resume(returning: nil)
+          case .failed(let error):
+            continuation.resume(throwing: error)
+          }
+        } else {
+          unlock()
+          handler?(.finished(error))
+        }
+      } else {
+        if state.limit == 0 {
+          state.pending.removeFirst()
+        }
+        unlock()
+        handler?(.finished(error))
+      }
+    }
+
+    func next(_ continuation: UnsafeContinuation<Element?, Error>) {
+      lock()
+      if state.continuation == nil {
+        if state.pending.count > 0 {
+          let toSend = state.pending.removeFirst()
+          unlock()
+          continuation.resume(returning: toSend)
+        } else if let terminal = state.terminal {
+          state.terminal = .finished
+          unlock()
+          switch terminal {
+          case .finished:
+            continuation.resume(returning: nil)
+          case .failed(let error):
+            continuation.resume(throwing: error)
+          }
+        } else {
+          state.continuation = continuation
+          unlock()
+        }
+      } else {
+        unlock()
+        fatalError("attempt to await next() on more than one task")
+      }
+    }
+    
+    func next() async throws -> Element? {
+      try await withTaskCancellationHandler { [cancel] in
+        cancel()
+      } operation: {
+        try await withUnsafeThrowingContinuation {
+          next($0)
+        }
+      }
+    }
+
+    static func create(limit: Int) -> _Storage {
+      let minimumCapacity = _lockWordCount()
+      let storage = Builtin.allocWithTailElems_1(
+        _Storage.self,
+          minimumCapacity._builtinWordValue,
+          UnsafeRawPointer.self
+      )
+
+      let state =
+        UnsafeMutablePointer<State>(Builtin.addressof(&storage.state))
+      state.initialize(to: State(limit: limit))
+      let ptr = UnsafeRawPointer(
+        Builtin.projectTailElems(storage, UnsafeRawPointer.self))
+      _lockInit(ptr)
+      return storage
+    }
+  }
+}
+

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -1,0 +1,149 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+@available(SwiftStdlib 5.5, *)
+public struct AsyncThrowingStream<Element> {
+  public struct Continuation: Sendable {
+    public enum Termination {
+      case finished(Error?)
+      case cancelled
+    }
+
+    let storage: _Storage
+
+    /// Resume the task awaiting the next iteration point by having it return
+    /// normally from its suspension point or buffer the value if no awaiting
+    /// next iteration is active.
+    ///
+    /// - Parameter value: The value to yield from the continuation.
+    ///
+    /// This can be called more than once and returns to the caller immediately
+    /// without blocking for any awaiting consumption from the iteration.
+    public func yield(_ value: __owned Element) {
+      storage.yield(value)
+    }
+
+    /// Resume the task awaiting the next iteration point by having it return
+    /// nil or throw which signifies the end of the iteration.
+    ///
+    /// - Parameter error: The error to throw or nil to signify termination.
+    ///
+    /// Calling this function more than once is idempotent; i.e. finishing more
+    /// than once does not alter the state beyond the requirements of
+    /// AsyncSequence; which claims that all values past a terminal state are
+    /// nil.
+    public func finish(throwing error: __owned Error? = nil) {
+      storage.finish(throwing: error)
+    }
+
+    /// A callback to invoke when iteration of a AsyncThrowingStream is cancelled.
+    ///
+    /// If an `onTermination` callback is set, when iteration of a AsyncStream is
+    /// cancelled via task cancellation that callback is invoked. The callback
+    /// is disposed of after any terminal state is reached.
+    ///
+    /// Cancelling an active iteration will first invoke the onTermination callback
+    /// and then resume yeilding nil. This means that any cleanup state can be
+    /// emitted accordingly in the cancellation handler
+    public var onTermination: (@Sendable (Termination) -> Void)? {
+      get {
+        return storage.getOnTermination()
+      }
+      nonmutating set {
+        storage.setOnTermination(newValue)
+      }
+    }
+  }
+
+  let produce: () async throws -> Element?
+
+  /// Construct a AsyncThrowingStream buffering given an Element type.
+  ///
+  /// - Parameter elementType: The type the AsyncStream will produce.
+  /// - Parameter maxBufferedElements: The maximum number of elements to
+  ///   hold in the buffer past any checks for continuations being resumed.
+  /// - Parameter build: The work associated with yielding values to the AsyncStream.
+  ///
+  /// The maximum number of pending elements limited by dropping the oldest
+  /// value when a new value comes in if the buffer would excede the limit
+  /// placed upon it. By default this limit is unlimited.
+  ///
+  /// The build closure passes in a Continuation which can be used in
+  /// concurrent contexts. It is thread safe to send and finish; all calls
+  /// to the continuation are serialized, however calling this from multiple
+  /// concurrent contexts could result in out of order delivery.
+  public init(
+    _ elementType: Element.Type = Element.self,
+    maxBufferedElements limit: Int = .max,
+    _ build: (Continuation) -> Void
+  ) {
+    let storage: _Storage = .create(limit: limit)
+    produce = storage.next
+    build(Continuation(storage: storage))
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+extension AsyncThrowingStream: AsyncSequence {
+  /// The asynchronous iterator for iterating a AsyncThrowingStream.
+  ///
+  /// This type is specificially not Sendable. It is not intended to be used
+  /// from multiple concurrent contexts. Any such case that next is invoked
+  /// concurrently and contends with another call to next is a programmer error
+  /// and will fatalError.
+  public struct Iterator: AsyncIteratorProtocol {
+    let produce: () async throws -> Element?
+
+    public mutating func next() async throws -> Element? {
+      return try await produce()
+    }
+  }
+
+  /// Construct an iterator.
+  public func makeAsyncIterator() -> Iterator {
+    return Iterator(produce: produce)
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+extension AsyncThrowingStream.Continuation {
+  /// Resume the task awaiting the next iteration point by having it return
+  /// normally from its suspension point or buffer the value if no awaiting
+  /// next iteration is active.
+  ///
+  /// - Parameter result: A result to yield from the continuation.
+  ///
+  /// This can be called more than once and returns to the caller immediately
+  /// without blocking for any awaiting consuption from the iteration.
+  public func yield<Failure: Error>(
+    with result: Result<Element, Failure>
+  ) {
+    switch result {
+      case .success(let val):
+        storage.yield(val)
+      case .failure(let err):
+        storage.finish(throwing: err)
+    }
+  }
+
+  /// Resume the task awaiting the next iteration point by having it return
+  /// normally from its suspension point or buffer the value if no awaiting
+  /// next iteration is active where the `Element` is `Void`.
+  ///
+  /// This can be called more than once and returns to the caller immediately
+  /// without blocking for any awaiting consuption from the iteration.
+  public func yield() where Element == Void {
+    storage.yield(())
+  }
+}

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -13,11 +13,51 @@
 import Swift
 
 @available(SwiftStdlib 5.5, *)
-public struct AsyncThrowingStream<Element> {
+public struct AsyncThrowingStream<Element, Failure: Error> {
   public struct Continuation: Sendable {
+    /// Indication of the type of termination informed to
+    /// `onTermination`.
     public enum Termination {
-      case finished(Error?)
+      
+      /// The stream was finished via the `finish` method
+      case finished(Failure?)
+      
+      /// The stream was cancelled
       case cancelled
+    }
+    
+    /// A result of yielding values.
+    public enum YieldResult {
+      
+      /// When a value is successfully enqueued, either buffered
+      /// or immediately consumed to resume a pending call to next
+      /// and a count of remaining slots available in the buffer at
+      /// the point in time of yielding. Note: transacting upon the
+      /// remaining count is only valid when then calls to yield are
+      /// mutually exclusive.
+      case enqueued(remaining: Int)
+      
+      /// Yielding resulted in not buffering an element because the
+      /// buffer was full. The element is the dropped value.
+      case dropped(Element)
+      
+      /// Indication that the continuation was yielded when the
+      /// stream was already in a terminal state: either by cancel or
+      /// by finishing.
+      case terminated
+    }
+    
+    /// A strategy that handles exhaustion of a buffer’s capacity.
+    public enum BufferingPolicy {
+      case unbounded
+      
+      /// When the buffer is full, discard the newly received element.
+      /// This enforces keeping the specified amount of oldest values.
+      case bufferingOldest(Int)
+      
+      /// When the buffer is full, discard the oldest element in the buffer.
+      /// This enforces keeping the specified amount of newest values.
+      case bufferingNewest(Int)
     }
 
     let storage: _Storage
@@ -30,7 +70,8 @@ public struct AsyncThrowingStream<Element> {
     ///
     /// This can be called more than once and returns to the caller immediately
     /// without blocking for any awaiting consumption from the iteration.
-    public func yield(_ value: __owned Element) {
+    @discardableResult
+    public func yield(_ value: __owned Element) -> YieldResult {
       storage.yield(value)
     }
 
@@ -43,19 +84,20 @@ public struct AsyncThrowingStream<Element> {
     /// than once does not alter the state beyond the requirements of
     /// AsyncSequence; which claims that all values past a terminal state are
     /// nil.
-    public func finish(throwing error: __owned Error? = nil) {
+    public func finish(throwing error: __owned Failure? = nil) {
       storage.finish(throwing: error)
     }
 
-    /// A callback to invoke when iteration of a AsyncThrowingStream is cancelled.
+    /// A callback to invoke when iteration of a AsyncThrowingStream is 
+    /// cancelled.
     ///
-    /// If an `onTermination` callback is set, when iteration of a AsyncStream is
-    /// cancelled via task cancellation that callback is invoked. The callback
-    /// is disposed of after any terminal state is reached.
+    /// If an `onTermination` callback is set, when iteration of a AsyncStream 
+    /// is cancelled via task cancellation that callback is invoked. The
+    /// callback is disposed of after any terminal state is reached.
     ///
-    /// Cancelling an active iteration will first invoke the onTermination callback
-    /// and then resume yeilding nil. This means that any cleanup state can be
-    /// emitted accordingly in the cancellation handler
+    /// Cancelling an active iteration will first invoke the onTermination 
+    /// callback and then resume yeilding nil. This means that any cleanup state
+    /// can be emitted accordingly in the cancellation handler
     public var onTermination: (@Sendable (Termination) -> Void)? {
       get {
         return storage.getOnTermination()
@@ -73,7 +115,8 @@ public struct AsyncThrowingStream<Element> {
   /// - Parameter elementType: The type the AsyncStream will produce.
   /// - Parameter maxBufferedElements: The maximum number of elements to
   ///   hold in the buffer past any checks for continuations being resumed.
-  /// - Parameter build: The work associated with yielding values to the AsyncStream.
+  /// - Parameter build: The work associated with yielding values to the 
+  ///   AsyncStream.
   ///
   /// The maximum number of pending elements limited by dropping the oldest
   /// value when a new value comes in if the buffer would excede the limit
@@ -85,12 +128,18 @@ public struct AsyncThrowingStream<Element> {
   /// concurrent contexts could result in out of order delivery.
   public init(
     _ elementType: Element.Type = Element.self,
-    maxBufferedElements limit: Int = .max,
+    bufferingPolicy limit: Continuation.BufferingPolicy = .unbounded,
     _ build: (Continuation) -> Void
-  ) {
+  ) where Failure == Error {
     let storage: _Storage = .create(limit: limit)
-    produce = storage.next
+    self.init(unfolding: storage.next)
     build(Continuation(storage: storage))
+  }
+  
+  public init(
+    unfolding produce: @escaping () async throws -> Element?
+  ) {
+    self.produce = produce
   }
 }
 
@@ -126,14 +175,16 @@ extension AsyncThrowingStream.Continuation {
   ///
   /// This can be called more than once and returns to the caller immediately
   /// without blocking for any awaiting consuption from the iteration.
-  public func yield<Failure: Error>(
+  @discardableResult
+  public func yield(
     with result: Result<Element, Failure>
-  ) {
+  ) -> YieldResult where Failure == Error {
     switch result {
-      case .success(let val):
-        storage.yield(val)
-      case .failure(let err):
-        storage.finish(throwing: err)
+    case .success(let val):
+      return storage.yield(val)
+    case .failure(let err):
+      storage.finish(throwing: err)
+      return .terminated
     }
   }
 
@@ -143,7 +194,8 @@ extension AsyncThrowingStream.Continuation {
   ///
   /// This can be called more than once and returns to the caller immediately
   /// without blocking for any awaiting consuption from the iteration.
-  public func yield() where Element == Void {
+  @discardableResult
+  public func yield() -> YieldResult where Element == Void {
     storage.yield(())
   }
 }

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -79,6 +79,7 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   AsyncThrowingStream.swift
   AsyncStream.cpp
   Deque.swift
+  YieldingContinuation.swift
   ${swift_concurrency_objc_sources}
 
   SWIFT_MODULE_DEPENDS_LINUX Glibc

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -74,6 +74,11 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   TaskLocal.swift
   ThreadSanitizer.cpp
   Mutex.cpp
+  AsyncStreamBuffer.swift
+  AsyncStream.swift
+  AsyncThrowingStream.swift
+  AsyncStream.cpp
+  Deque.swift
   ${swift_concurrency_objc_sources}
 
   SWIFT_MODULE_DEPENDS_LINUX Glibc

--- a/stdlib/public/Concurrency/Deque.swift
+++ b/stdlib/public/Concurrency/Deque.swift
@@ -1,0 +1,410 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+@available(SwiftStdlib 5.5, *)
+struct _Deque<Element> {
+  internal struct _UnsafeHandle {
+    let _header: UnsafeMutablePointer<_Storage._Header>
+    let _elements: UnsafeMutablePointer<Element>?
+
+    init(
+      header: UnsafeMutablePointer<_Storage._Header>,
+      elements: UnsafeMutablePointer<Element>?,
+      isMutable: Bool
+    ) {
+      self._header = header
+      self._elements = elements
+    }
+    
+    var header: _Storage._Header {
+      _header.pointee
+    }
+    
+    var capacity: Int {
+      _header.pointee.capacity
+    }
+    
+    var count: Int {
+      get { _header.pointee.count }
+      nonmutating set { _header.pointee.count = newValue }
+    }
+    
+    internal func slot(after slot: Int) -> Int {
+      assert(slot < capacity)
+      let position = slot + 1
+      if position >= capacity {
+        return 0
+      }
+      return position
+    }
+
+    
+    internal func slot(_ slot: Int, offsetBy delta: Int) -> Int {
+      assert(slot <= capacity)
+      let position = slot + delta
+      if delta >= 0 {
+        if position >= capacity { return position - capacity }
+      } else {
+        if position < 0 { return position + capacity }
+      }
+      return position
+    }
+    
+    internal var endSlot: Int {
+      slot(startSlot, offsetBy: count)
+    }
+    
+    internal func uncheckedAppend(_ element: Element) {
+      assert(count < capacity)
+      ptr(at: endSlot).initialize(to: element)
+      count += 1
+    }
+    
+    internal func uncheckedRemoveFirst() -> Element {
+      assert(count > 0)
+      let result = ptr(at: startSlot).move()
+      startSlot = slot(after: startSlot)
+      count -= 1
+      return result
+    }
+    
+    internal func uncheckedRemoveFirstIfPresent() -> Element? {
+      if count > 0 {
+        let result = ptr(at: startSlot).move()
+        startSlot = slot(after: startSlot)
+        count -= 1
+        return result
+      } else {
+        return nil
+      }
+    }
+    
+    struct _UnsafeWrappedBuffer {
+      internal let first: UnsafeBufferPointer<Element>
+
+      internal let second: UnsafeBufferPointer<Element>?
+
+      internal init(
+        _ first: UnsafeBufferPointer<Element>,
+        _ second: UnsafeBufferPointer<Element>? = nil
+      ) {
+        self.first = first
+        self.second = second
+        assert(first.count > 0 || second == nil)
+      }
+
+      internal init(
+        start: UnsafePointer<Element>,
+        count: Int
+      ) {
+        self.init(UnsafeBufferPointer(start: start, count: count))
+      }
+      
+      internal init(
+        first start1: UnsafePointer<Element>,
+        count count1: Int,
+        second start2: UnsafePointer<Element>,
+        count count2: Int
+      ) {
+        self.init(UnsafeBufferPointer(start: start1, count: count1),
+                  UnsafeBufferPointer(start: start2, count: count2))
+      }
+
+      internal var count: Int { first.count + (second?.count ?? 0) }
+    }
+    
+    internal struct _UnsafeMutableWrappedBuffer {
+      internal let first: UnsafeMutableBufferPointer<Element>
+
+      internal let second: UnsafeMutableBufferPointer<Element>?
+
+      internal init(
+        _ first: UnsafeMutableBufferPointer<Element>,
+        _ second: UnsafeMutableBufferPointer<Element>? = nil
+      ) {
+        self.first = first
+        self.second = second?.count == 0 ? nil : second
+        assert(first.count > 0 || second == nil)
+      }
+
+      internal init(
+        start: UnsafeMutablePointer<Element>,
+        count: Int
+      ) {
+        self.init(UnsafeMutableBufferPointer(start: start, count: count))
+      }
+
+      internal init(
+        first start1: UnsafeMutablePointer<Element>,
+        count count1: Int,
+        second start2: UnsafeMutablePointer<Element>,
+        count count2: Int
+      ) {
+        self.init(UnsafeMutableBufferPointer(start: start1, count: count1),
+                  UnsafeMutableBufferPointer(start: start2, count: count2))
+      }
+
+      internal init(mutating buffer: _UnsafeWrappedBuffer) {
+        self.init(.init(mutating: buffer.first),
+                  buffer.second.map { .init(mutating: $0) })
+      }
+    }
+    
+    internal func segments() -> _UnsafeWrappedBuffer {
+      let wrap = capacity - startSlot
+      if count <= wrap {
+        return .init(start: ptr(at: startSlot), count: count)
+      }
+      return .init(first: ptr(at: startSlot), count: wrap,
+                   second: ptr(at: .zero), count: count - wrap)
+    }
+    
+    internal func mutableSegments() -> _UnsafeMutableWrappedBuffer {
+      return .init(mutating: segments())
+    }
+    
+    var startSlot: Int {
+      get { _header.pointee.startSlot }
+      nonmutating set { _header.pointee.startSlot = newValue }
+    }
+    
+    func ptr(at slot: Int) -> UnsafeMutablePointer<Element> {
+      assert(slot >= 0 && slot <= capacity)
+      return _elements! + slot
+    }
+
+    @discardableResult
+    func initialize(
+      at start: Int,
+      from source: UnsafeBufferPointer<Element>
+    ) -> Int {
+      assert(start + source.count <= capacity)
+      guard source.count > 0 else { return start }
+      ptr(at: start).initialize(from: source.baseAddress!, count: source.count)
+      return start + source.count
+    }
+    
+    @discardableResult
+    func moveInitialize(
+      at start: Int,
+      from source: UnsafeMutableBufferPointer<Element>
+    ) -> Int {
+      assert(start + source.count <= capacity)
+      guard source.count > 0 else { return start }
+      ptr(at: start).moveInitialize(from: source.baseAddress!, count: source.count)
+      return start + source.count
+    }
+    
+    internal func copyElements() -> _Storage {
+      let object = _Storage._DequeBuffer.create(
+        minimumCapacity: capacity,
+        makingHeaderWith: { _ in header })
+      let result = _Storage(_buffer: ManagedBufferPointer(unsafeBufferObject: object))
+      guard self.count > 0 else { return result }
+      result.update { target in
+        let source = self.segments()
+        target.initialize(at: startSlot, from: source.first)
+        if let second = source.second {
+          target.initialize(at: 0, from: second)
+        }
+      }
+      return result
+    }
+    
+    internal func moveElements(minimumCapacity: Int) -> _Storage {
+      let count = self.count
+      assert(minimumCapacity >= count)
+      let object = _Storage._DequeBuffer.create(
+        minimumCapacity: minimumCapacity,
+        makingHeaderWith: {
+          _Storage._Header(
+            capacity: $0.capacity,
+            count: count,
+            startSlot: .zero)
+        })
+      let result = _Storage(_buffer: ManagedBufferPointer(unsafeBufferObject: object))
+      guard count > 0 else { return result }
+      result.update { target in
+        let source = self.mutableSegments()
+        let next = target.moveInitialize(at: .zero, from: source.first)
+        if let second = source.second {
+          target.moveInitialize(at: next, from: second)
+        }
+      }
+      self.count = 0
+      return result
+    }
+  }
+  
+  enum _Storage {
+    internal struct _Header {
+      var capacity: Int
+
+      var count: Int
+
+      var startSlot: Int
+
+      init(capacity: Int, count: Int, startSlot: Int) {
+        self.capacity = capacity
+        self.count = count
+        self.startSlot = startSlot
+      }
+    }
+    
+    internal typealias _Buffer = ManagedBufferPointer<_Header, Element>
+
+    case empty
+    case buffer(_Buffer)
+    
+    internal class _DequeBuffer: ManagedBuffer<_Header, Element> {
+      deinit {
+        self.withUnsafeMutablePointers { header, elements in
+          let capacity = header.pointee.capacity
+          let count = header.pointee.count
+          let startSlot = header.pointee.startSlot
+
+          if startSlot + count <= capacity {
+            (elements + startSlot).deinitialize(count: count)
+          } else {
+            let firstRegion = capacity - startSlot
+            (elements + startSlot).deinitialize(count: firstRegion)
+            elements.deinitialize(count: count - firstRegion)
+          }
+        }
+      }
+    }
+    
+    internal init(_buffer: _Buffer) {
+      self = .buffer(_buffer)
+    }
+    
+    internal init() {
+      self = .empty
+    }
+    
+    internal init(_ object: _DequeBuffer) {
+      self.init(_buffer: _Buffer(unsafeBufferObject: object))
+    }
+    
+    internal var capacity: Int {
+      switch self {
+      case .empty: return 0
+      case .buffer(let buffer):
+        return buffer.withUnsafeMutablePointerToHeader { $0.pointee.capacity }
+      }
+      
+    }
+    
+    internal mutating func ensure(
+      minimumCapacity: Int
+    ) {
+      if _slowPath(capacity < minimumCapacity) {
+        _ensure(minimumCapacity: minimumCapacity)
+      }
+    }
+    
+    internal static var growthFactor: Double { 1.5 }
+
+    internal func _growCapacity(
+      to minimumCapacity: Int
+    ) -> Int {
+      return Swift.max(Int((Self.growthFactor * Double(capacity)).rounded(.up)),
+                       minimumCapacity)
+    }
+    
+    internal mutating func _ensure(
+      minimumCapacity: Int
+    ) {
+      if capacity >= minimumCapacity {
+        self = self.read { $0.copyElements() }
+      } else {
+        let minimumCapacity = _growCapacity(to: minimumCapacity)
+        self = self.update { source in
+          source.moveElements(minimumCapacity: minimumCapacity)
+        }
+      }
+    }
+    
+    internal var count: Int {
+      switch self {
+      case .empty: return 0
+      case .buffer(let buffer):
+        return buffer.withUnsafeMutablePointerToHeader { $0.pointee.count }
+      }
+      
+    }
+    
+    internal func read<R>(_ body: (_UnsafeHandle) throws -> R) rethrows -> R {
+      switch self {
+      case .empty:
+        var header = _Header(capacity: 0, count: 0, startSlot: 0)
+        return try withUnsafeMutablePointer(to: &header) { headerPtr in
+          return try body(_UnsafeHandle(header: headerPtr, elements: nil, isMutable: false))
+        }
+      case .buffer(let buffer):
+        return try buffer.withUnsafeMutablePointers { header, elements in
+          let handle = _UnsafeHandle(header: header,
+                                     elements: elements,
+                                     isMutable: false)
+          return try body(handle)
+        }
+      }
+      
+    }
+    
+    internal func update<R>(_ body: (_UnsafeHandle) throws -> R) rethrows -> R {
+      switch self {
+      case .empty:
+        var header = _Header(capacity: 0, count: 0, startSlot: 0)
+        return try withUnsafeMutablePointer(to: &header) { headerPtr in
+          return try body(_UnsafeHandle(header: headerPtr, elements: nil, isMutable: false))
+        }
+      case .buffer(let buffer):
+        return try buffer.withUnsafeMutablePointers { header, elements in
+          let handle = _UnsafeHandle(header: header,
+                                     elements: elements,
+                                     isMutable: true)
+          return try body(handle)
+        }
+      }
+    }
+  }
+  
+
+  internal var _storage: _Storage
+  
+  init() {
+    _storage = _Storage()
+  }
+  
+  var count: Int { _storage.count }
+  
+  mutating func append(_ newElement: Element) {
+    _storage.ensure(minimumCapacity: _storage.count + 1)
+    _storage.update {
+      $0.uncheckedAppend(newElement)
+    }
+  }
+  
+  @discardableResult
+  mutating func removeFirst() -> Element {
+    return _storage.update { $0.uncheckedRemoveFirst() }
+  }
+  
+  @discardableResult
+  mutating func removeFirstIfPresent() -> Element? {
+    return _storage.update { $0.uncheckedRemoveFirstIfPresent() }
+  }
+}
+

--- a/stdlib/public/Concurrency/YieldingContinuation.swift
+++ b/stdlib/public/Concurrency/YieldingContinuation.swift
@@ -1,0 +1,200 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+internal final class _YieldingContinuationStorage: UnsafeSendable {
+  var continuation: Builtin.RawUnsafeContinuation?
+}
+
+@available(SwiftStdlib 5.5, *)
+@available(*, deprecated, message: "`YieldingContinuation` was replaced by `AsyncStream` and will be removed shortly.")
+public struct YieldingContinuation<Element, Failure: Error>: Sendable {
+  let storage = _YieldingContinuationStorage()
+
+  /// Construct a YieldingContinuation.
+  ///
+  /// This continuation type can be called more than once, unlike the unsafe and
+  /// checked counterparts. Each call to the yielding functions will resume any
+  /// awaiter on the next function. This type is inherently sendable and can
+  /// safely be used and stored in multiple task contexts.
+  public init() { }
+
+  /// Construct a YieldingContinuation with specific types including a failure.
+  ///
+  /// This continuation type can be called more than once, unlike the unsafe and
+  /// checked counterparts. Each call to the yielding functions will resume any
+  /// awaiter on the next function. This type is inherently sendable and can
+  /// safely be used and stored in multiple task contexts.
+  public init(yielding: Element.Type, throwing: Failure.Type) { }
+
+  internal func _extract() -> UnsafeContinuation<Element, Error>? {
+    let raw = Builtin.atomicrmw_xchg_acqrel_Word(
+      Builtin.addressof(&storage.continuation),
+      UInt(bitPattern: 0)._builtinWordValue)
+    return unsafeBitCast(raw, to: UnsafeContinuation<Element, Error>?.self)
+  }
+
+  internal func _inject(
+    _ continuation: UnsafeContinuation<Element, Error>
+  ) -> UnsafeContinuation<Element, Error>? {
+    let rawContinuation = unsafeBitCast(continuation, to: Builtin.Word.self)
+    let raw = Builtin.atomicrmw_xchg_acqrel_Word(
+      Builtin.addressof(&storage.continuation), rawContinuation)
+    return unsafeBitCast(raw, to: UnsafeContinuation<Element, Error>?.self)
+  }
+  
+  /// Resume the task awaiting next by having it return normally from its 
+  /// suspension point.
+  ///
+  /// - Parameter value: The value to return from an awaiting call to next.
+  ///
+  /// Unlike other continuations `YieldingContinuation` may resume more than
+  /// once. However if there are no potential awaiting calls to `next` this
+  /// function will return false, indicating that the caller needs to decide how
+  /// the behavior should be handled.
+  public func yield(_ value: __owned Element) -> Bool {
+    if let continuation = _extract() {
+      continuation.resume(returning: value)
+      return true
+    }
+    return false
+  }
+  
+  /// Resume the task awaiting the continuation by having it throw an error
+  /// from its suspension point.
+  ///
+  /// - Parameter error: The error to throw from an awaiting call to next.
+  ///
+  /// Unlike other continuations `YieldingContinuation` may resume more than
+  /// once. However if there are no potential awaiting calls to `next` this
+  /// function will return false, indicating that the caller needs to decide how
+  /// the behavior should be handled.
+  public func yield(throwing error: __owned Failure) -> Bool {
+    if let continuation = _extract() {
+      continuation.resume(throwing: error)
+      return true
+    }
+    return false
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+extension YieldingContinuation where Failure == Error {
+  /// Await a resume from a call to a yielding function.
+  ///
+  /// - Return: The element that was yielded or a error that was thrown.
+  ///
+  /// When multiple calls are awaiting a produced value from next any call to
+  /// yield will resume all awaiting calls to next with that value. 
+  @available(*, deprecated, message: "`YieldingContinuation` was replaced by `AsyncStream` and will be removed shortly.")
+  public func next() async throws -> Element {
+    var existing: UnsafeContinuation<Element, Error>?
+    do {
+      let result = try await withUnsafeThrowingContinuation {
+        (continuation: UnsafeContinuation<Element, Error>) in
+        existing = _inject(continuation)
+      }
+      existing?.resume(returning: result)
+      return result
+    } catch {
+      existing?.resume(throwing: error)
+      throw error
+    }
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+extension YieldingContinuation where Failure == Never {
+  /// Construct a YieldingContinuation with a specific Element type.
+  ///
+  /// This continuation type can be called more than once, unlike the unsafe and
+  /// checked counterparts. Each call to the yielding functions will resume any
+  /// awaiter on the next function. This type is inherently sendable and can
+  /// safely be used and stored in multiple task contexts.
+  @available(*, deprecated, message: "`YieldingContinuation` was replaced by `AsyncStream` and will be removed shortly.")
+  public init(yielding: Element.Type) { }
+
+  /// Await a resume from a call to a yielding function.
+  ///
+  /// - Return: The element that was yielded.
+  @available(*, deprecated, message: "`YieldingContinuation` was replaced by `AsyncStream` and will be removed shortly.")
+  public func next() async -> Element {
+    var existing: UnsafeContinuation<Element, Error>?
+    let result = try! await withUnsafeThrowingContinuation {
+      (continuation: UnsafeContinuation<Element, Error>) in
+      existing = _inject(continuation)
+    }
+    existing?.resume(returning: result)
+    return result
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+extension YieldingContinuation {
+  /// Resume the task awaiting the continuation by having it either
+  /// return normally or throw an error based on the state of the given
+  /// `Result` value.
+  ///
+  /// - Parameter result: A value to either return or throw from the
+  ///   continuation.
+  ///
+  /// Unlike other continuations `YieldingContinuation` may resume more than
+  /// once. However if there are no potential awaiting calls to `next` this
+  /// function will return false, indicating that the caller needs to decide how
+  /// the behavior should be handled.
+  @available(*, deprecated, message: "`YieldingContinuation` was replaced by `AsyncStream` and will be removed shortly.")
+  public func yield<Er: Error>(
+    with result: Result<Element, Er>
+  ) -> Bool where Failure == Error {
+    switch result {
+      case .success(let val):
+        return self.yield(val)
+      case .failure(let err):
+        return self.yield(throwing: err)
+    }
+  }
+  
+  /// Resume the task awaiting the continuation by having it either
+  /// return normally or throw an error based on the state of the given
+  /// `Result` value.
+  ///
+  /// - Parameter result: A value to either return or throw from the
+  ///   continuation.
+  ///
+  /// Unlike other continuations `YieldingContinuation` may resume more than
+  /// once. However if there are no potential awaiting calls to `next` this
+  /// function will return false, indicating that the caller needs to decide how
+  /// the behavior should be handled.
+  @available(*, deprecated, message: "`YieldingContinuation` was replaced by `AsyncStream` and will be removed shortly.")
+  public func yield(with result: Result<Element, Failure>) -> Bool {
+    switch result {
+      case .success(let val):
+        return self.yield(val)
+      case .failure(let err):
+        return self.yield(throwing: err)
+    }
+  }
+  
+  /// Resume the task awaiting the continuation by having it return normally
+  /// from its suspension point.
+  ///
+  /// Unlike other continuations `YieldingContinuation` may resume more than
+  /// once. However if there are no potential awaiting calls to `next` this
+  /// function will return false, indicating that the caller needs to decide how
+  /// the behavior should be handled.
+  @available(*, deprecated, message: "`YieldingContinuation` was replaced by `AsyncStream` and will be removed shortly.")
+  public func yield() -> Bool where Element == Void {
+    return self.yield(())
+  }
+}
+

--- a/test/Concurrency/Runtime/async_stream.swift
+++ b/test/Concurrency/Runtime/async_stream.swift
@@ -1,0 +1,461 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch -parse-as-library)
+
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+// UNSUPPORTED: use_os_stdlib
+
+// https://bugs.swift.org/browse/SR-14466
+// UNSUPPORTED: OS=windows-msvc
+
+import _Concurrency
+import StdlibUnittest
+import Dispatch
+
+struct SomeError: Error, Equatable {
+  var value = Int.random(in: 0..<100)
+}
+
+var tests = TestSuite("AsyncStream")
+
+@main struct Main {
+  static func main() async {
+    if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+      final class Expectation: UnsafeSendable {
+        var fulfilled = false
+      }
+
+      tests.test("yield with no awaiting next") {
+        let series = AsyncStream(String.self) { continuation in
+          continuation.yield("hello")
+        }
+      }
+
+      tests.test("yield with no awaiting next throwing") {
+        let series = AsyncThrowingStream(String.self) { continuation in
+          continuation.yield("hello")
+        }
+      }
+
+      tests.test("yield with awaiting next") {
+        let series = AsyncStream(String.self) { continuation in
+          continuation.yield("hello")
+        }
+        var iterator = series.makeAsyncIterator()
+        expectEqual(await iterator.next(), "hello")
+      }
+
+      tests.test("yield with awaiting next throwing") {
+        let series = AsyncThrowingStream(String.self) { continuation in
+          continuation.yield("hello")
+        }
+        var iterator = series.makeAsyncIterator()
+        do {
+          expectEqual(try await iterator.next(), "hello")
+        } catch {
+          expectUnreachable("unexpected error thrown")
+        }
+      }
+
+      tests.test("yield with awaiting next 2") {
+        let series = AsyncStream(String.self) { continuation in
+          continuation.yield("hello")
+          continuation.yield("world")
+        }
+        var iterator = series.makeAsyncIterator()
+        expectEqual(await iterator.next(), "hello")
+        expectEqual(await iterator.next(), "world")
+      }
+
+      tests.test("yield with awaiting next 2 throwing") {
+        let series = AsyncThrowingStream(String.self) { continuation in
+          continuation.yield("hello")
+          continuation.yield("world")
+        }
+        var iterator = series.makeAsyncIterator()
+        do {
+          expectEqual(try await iterator.next(), "hello")
+          expectEqual(try await iterator.next(), "world")
+        } catch {
+          expectUnreachable("unexpected error thrown")
+        }
+      }
+
+      tests.test("yield with awaiting next 2 and finish") {
+        let series = AsyncStream(String.self) { continuation in
+          continuation.yield("hello")
+          continuation.yield("world")
+          continuation.finish()
+        }
+        var iterator = series.makeAsyncIterator()
+        expectEqual(await iterator.next(), "hello")
+        expectEqual(await iterator.next(), "world")
+        expectEqual(await iterator.next(), nil)
+      }
+
+      tests.test("yield with awaiting next 2 and finish throwing") {
+        let series = AsyncThrowingStream(String.self) { continuation in
+          continuation.yield("hello")
+          continuation.yield("world")
+          continuation.finish()
+        }
+        var iterator = series.makeAsyncIterator()
+        do {
+          expectEqual(try await iterator.next(), "hello")
+          expectEqual(try await iterator.next(), "world")
+          expectEqual(try await iterator.next(), nil)
+        } catch {
+          expectUnreachable("unexpected error thrown")
+        }
+      }
+
+      tests.test("yield with awaiting next 2 and throw") {
+        let thrownError = SomeError()
+        let series = AsyncThrowingStream(String.self) { continuation in
+          continuation.yield("hello")
+          continuation.yield("world")
+          continuation.finish(throwing: thrownError)
+        }
+        var iterator = series.makeAsyncIterator()
+        do {
+          expectEqual(try await iterator.next(), "hello")
+          expectEqual(try await iterator.next(), "world")
+          try await iterator.next()
+          expectUnreachable("expected thrown error")
+        } catch {
+          if let failure = error as? SomeError {
+            expectEqual(failure, thrownError)
+          } else {
+            expectUnreachable("unexpected error type")
+          }
+        }
+      }
+
+      tests.test("yield with no awaiting next detached") {
+        let series = AsyncStream(String.self) { continuation in
+          detach {
+            continuation.yield("hello")
+          }
+        }
+      }
+
+      tests.test("yield with no awaiting next detached throwing") {
+        let series = AsyncThrowingStream(String.self) { continuation in
+          detach {
+            continuation.yield("hello")
+          }
+        }
+      }
+
+      tests.test("yield with awaiting next detached") {
+        let series = AsyncStream(String.self) { continuation in
+          detach {
+            continuation.yield("hello")
+          }
+        }
+        var iterator = series.makeAsyncIterator()
+        expectEqual(await iterator.next(), "hello")
+      }
+
+      tests.test("yield with awaiting next detached throwing") {
+        let series = AsyncThrowingStream(String.self) { continuation in
+          detach {
+            continuation.yield("hello")
+          }
+        }
+        var iterator = series.makeAsyncIterator()
+        do {
+          expectEqual(try await iterator.next(), "hello")
+        } catch {
+          expectUnreachable("unexpected error thrown")
+        }
+      }
+
+      tests.test("yield with awaiting next 2 detached") {
+        let series = AsyncStream(String.self) { continuation in
+          detach {
+            continuation.yield("hello")
+            continuation.yield("world")
+          }
+        }
+        var iterator = series.makeAsyncIterator()
+        expectEqual(await iterator.next(), "hello")
+        expectEqual(await iterator.next(), "world")
+      }
+
+      tests.test("yield with awaiting next 2 detached throwing") {
+        let series = AsyncThrowingStream(String.self) { continuation in
+          detach {
+            continuation.yield("hello")
+            continuation.yield("world")
+          }
+        }
+        var iterator = series.makeAsyncIterator()
+        do {
+          expectEqual(try await iterator.next(), "hello")
+          expectEqual(try await iterator.next(), "world")
+        } catch {
+          expectUnreachable("unexpected error thrown")
+        }
+      }
+
+      tests.test("yield with awaiting next 2 and finish detached") {
+        let series = AsyncStream(String.self) { continuation in
+          detach {
+            continuation.yield("hello")
+            continuation.yield("world")
+            continuation.finish()
+          }
+        }
+        var iterator = series.makeAsyncIterator()
+        expectEqual(await iterator.next(), "hello")
+        expectEqual(await iterator.next(), "world")
+        expectEqual(await iterator.next(), nil)
+      }
+
+      tests.test("yield with awaiting next 2 and finish detached throwing") {
+        let series = AsyncThrowingStream(String.self) { continuation in
+          detach {
+            continuation.yield("hello")
+            continuation.yield("world")
+            continuation.finish()
+          }
+        }
+        var iterator = series.makeAsyncIterator()
+        do {
+          expectEqual(try await iterator.next(), "hello")
+          expectEqual(try await iterator.next(), "world")
+          expectEqual(try await iterator.next(), nil)
+        } catch {
+          expectUnreachable("unexpected error thrown")
+        }
+      }
+
+      tests.test("yield with awaiting next 2 and throw detached") {
+        let thrownError = SomeError()
+        let series = AsyncThrowingStream(String.self) { continuation in
+          detach {
+            continuation.yield("hello")
+            continuation.yield("world")
+            continuation.finish(throwing: thrownError)
+          }
+        }
+        var iterator = series.makeAsyncIterator()
+        do {
+          expectEqual(try await iterator.next(), "hello")
+          expectEqual(try await iterator.next(), "world")
+          try await iterator.next()
+          expectUnreachable("expected thrown error")
+        } catch {
+          if let failure = error as? SomeError {
+            expectEqual(failure, thrownError)
+          } else {
+            expectUnreachable("unexpected error type")
+          }
+        }
+      }
+
+      tests.test("yield with awaiting next 2 and finish detached with value after finish") {
+        let series = AsyncStream(String.self) { continuation in
+          detach {
+            continuation.yield("hello")
+            continuation.yield("world")
+            continuation.finish()
+            continuation.yield("This should not be emitted")
+          }
+        }
+        var iterator = series.makeAsyncIterator()
+        expectEqual(await iterator.next(), "hello")
+        expectEqual(await iterator.next(), "world")
+        expectEqual(await iterator.next(), nil)
+        expectEqual(await iterator.next(), nil)
+      }
+
+      tests.test("yield with awaiting next 2 and finish detached with value after finish throwing") {
+        let series = AsyncThrowingStream(String.self) { continuation in
+          detach {
+            continuation.yield("hello")
+            continuation.yield("world")
+            continuation.finish()
+            continuation.yield("This should not be emitted")
+          }
+        }
+        var iterator = series.makeAsyncIterator()
+        do {
+          expectEqual(try await iterator.next(), "hello")
+          expectEqual(try await iterator.next(), "world")
+          expectEqual(try await iterator.next(), nil)
+          expectEqual(try await iterator.next(), nil)
+        } catch {
+          expectUnreachable("unexpected error thrown")
+        }
+      }
+
+      tests.test("yield with awaiting next 2 and finish detached with throw after finish throwing") {
+        let thrownError = SomeError()
+        let series = AsyncThrowingStream(String.self) { continuation in
+          detach {
+            continuation.yield("hello")
+            continuation.yield("world")
+            continuation.finish()
+            continuation.finish(throwing: thrownError)
+          }
+        }
+        var iterator = series.makeAsyncIterator()
+        do {
+          expectEqual(try await iterator.next(), "hello")
+          expectEqual(try await iterator.next(), "world")
+          expectEqual(try await iterator.next(), nil)
+          expectEqual(try await iterator.next(), nil)
+        } catch {
+          expectUnreachable("unexpected error thrown")
+        }
+      }
+
+      tests.test("yield with awaiting next 2 and finish with throw after finish throwing") {
+        let thrownError = SomeError()
+        let series = AsyncThrowingStream(String.self) { continuation in
+          continuation.yield("hello")
+          continuation.yield("world")
+          continuation.finish()
+          continuation.finish(throwing: thrownError)
+        }
+        var iterator = series.makeAsyncIterator()
+        do {
+          expectEqual(try await iterator.next(), "hello")
+          expectEqual(try await iterator.next(), "world")
+          expectEqual(try await iterator.next(), nil)
+          expectEqual(try await iterator.next(), nil)
+        } catch {
+          expectUnreachable("unexpected error thrown")
+        }
+      }
+
+      tests.test("cancellation behavior on deinit with no values being awaited") {
+        let expectation = Expectation()
+
+        func scopedLifetime(_ expectation: Expectation) {
+          let series = AsyncStream(String.self) { continuation in
+            continuation.onTermination = { @Sendable _ in expectation.fulfilled = true }
+          }
+        }
+        
+        scopedLifetime(expectation)
+
+        expectTrue(expectation.fulfilled)
+      }
+
+      tests.test("termination behavior on deinit with no values being awaited") {
+        let expectation = Expectation()
+
+        func scopedLifetime(_ expectation: Expectation) {
+          let series = AsyncStream(String.self) { continuation in
+            continuation.onTermination = { @Sendable _ in expectation.fulfilled = true }
+            continuation.finish()
+          }
+        }
+        
+        scopedLifetime(expectation)
+
+        expectTrue(expectation.fulfilled)
+      }
+
+      tests.test("cancellation behavior on deinit with no values being awaited") {
+        let expectation = Expectation()
+
+        func scopedLifetime(_ expectation: Expectation) {
+          let series = AsyncStream(String.self) { continuation in
+            continuation.onTermination = { @Sendable terminal in
+              switch terminal {
+              case .cancelled:
+                expectation.fulfilled = true
+              default: break
+              }
+            }
+          }
+        }
+        
+        scopedLifetime(expectation)
+
+        expectTrue(expectation.fulfilled)
+      }
+
+      tests.test("cancellation behavior on deinit with no values being awaited throwing") {
+        let expectation = Expectation()
+
+        func scopedLifetime(_ expectation: Expectation) {
+          let series = AsyncThrowingStream(String.self) { continuation in
+            continuation.onTermination = { @Sendable terminal in
+              switch terminal {
+              case .cancelled:
+                expectation.fulfilled = true
+              default: break
+              }
+            }
+          }
+        }
+        
+        scopedLifetime(expectation)
+
+        expectTrue(expectation.fulfilled)
+      }
+
+      tests.test("cancellation behavior of value emitted in handler") {
+        let ready = DispatchSemaphore(value: 0)
+        let done = DispatchSemaphore(value: 0)
+        let task = detach {
+          let series = AsyncStream(String.self) { continuation in
+            continuation.onTermination = { @Sendable _ in continuation.yield("Hit cancel") }
+          }
+          ready.signal()
+          var iterator = series.makeAsyncIterator()
+          let first = await iterator.next()
+          expectEqual(first, "Hit cancel")
+          let second = await iterator.next()
+          expectEqual(second, nil)
+          done.signal()
+        }
+        ready.wait()
+        task.cancel()
+        let result = done.wait(timeout: DispatchTime(uptimeNanoseconds: DispatchTime.now().uptimeNanoseconds + 1_000_000_000))
+        switch result {
+        case .timedOut:
+          expectFalse(true, "Timeout when awaiting finished state")
+        default: break
+        }
+      }
+
+      tests.test("cancellation behavior of value emitted in handler throwing") {
+        let ready = DispatchSemaphore(value: 0)
+        let done = DispatchSemaphore(value: 0)
+        let task = detach {
+          let series = AsyncThrowingStream(String.self) { continuation in
+            continuation.onTermination = { @Sendable _ in continuation.yield("Hit cancel") }
+          }
+          ready.signal()
+          var iterator = series.makeAsyncIterator()
+          do {
+            let first = try await iterator.next()
+            expectEqual(first, "Hit cancel")
+            let second = try await iterator.next()
+            expectEqual(second, nil)
+          } catch {
+            expectUnreachable("unexpected error thrown")
+          }
+          done.signal()
+        }
+        ready.wait()
+        task.cancel()
+        let result = done.wait(timeout: DispatchTime(uptimeNanoseconds: DispatchTime.now().uptimeNanoseconds + 1_000_000_000))
+        switch result {
+        case .timedOut:
+          expectFalse(true, "Timeout when awaiting finished state")
+        default: break
+        }
+      }
+
+      await runAllTestsAsync()
+    }
+  }
+}
+
+


### PR DESCRIPTION
This is an update from the discussion for changes to the AsyncStream and AsyncThrowingStream types.

* added `YieldResult` to express the action of yielding’s impact, either something is enqueued, dropped or the continuation is already terminated
* added `init(unfolding: @escaping () async -> Element?)` to offer an initializer for unfolding to handle back-pressure based APIs.
* made `AsyncThrowingStream` generic on Failure but the initializers only afford for creation `where Failure == Error`
* initialization now takes a buffering policy to both restrict the buffer size as well as configure how elements are dropped

This restores YieldingContinuiation for now to support any potential adopters in development and steer them to the replacement AsyncStream.

The main branch counterpart is: https://github.com/apple/swift/pull/37971