### PR TITLE
[Clang importer] Import Swift declaration modifiers from swift_attr.

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -75,8 +75,8 @@ NOTE(unresolvable_clang_decl_is_a_framework_bug,none,
      "please report this issue to the owners of '%0'",
      (StringRef))
 
-WARNING(clang_swift_attr_without_at,none,
-        "Swift attribute '%0' does not start with '@'", (StringRef))
+WARNING(clang_swift_attr_unhandled,none,
+        "Ignoring unknown Swift attribute or modifier '%0'", (StringRef))
 
 WARNING(implicit_bridging_header_imported_from_module,none,
         "implicit import of bridging header '%0' via module %1 "

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -996,7 +996,8 @@ public:
 
   /// Parse the optional modifiers before a declaration.
   bool parseDeclModifierList(DeclAttributes &Attributes, SourceLoc &StaticLoc,
-                             StaticSpellingKind &StaticSpelling);
+                             StaticSpellingKind &StaticSpelling,
+                             bool isFromClangAttribute = false);
 
   /// Parse an availability attribute of the form
   /// @available(*, introduced: 1.0, deprecated: 3.1).

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8672,19 +8672,28 @@ void ClangImporter::Implementation::importAttributes(
       // Prime the lexer.
       parser.consumeTokenWithoutFeedingReceiver();
 
+      bool hadError = false;
       SourceLoc atLoc;
       if (parser.consumeIf(tok::at_sign, atLoc)) {
-        (void)parser.parseDeclAttribute(
+        hadError = parser.parseDeclAttribute(
             MappedDecl->getAttrs(), atLoc, initContext,
-            /*isFromClangAttribute=*/true);
+            /*isFromClangAttribute=*/true).isError();
       } else {
-        // Complain about the missing '@'.
+        SourceLoc staticLoc;
+        StaticSpellingKind staticSpelling;
+        hadError = parser.parseDeclModifierList(
+            MappedDecl->getAttrs(), staticLoc, staticSpelling,
+            /*isFromClangAttribute=*/true);
+      }
+
+      if (hadError) {
+        // Complain about the unhandled attribute or modifier.
         auto &clangSrcMgr = getClangASTContext().getSourceManager();
         ClangSourceBufferImporter &bufferImporter =
           getBufferImporterForDiagnostics();
         SourceLoc attrLoc = bufferImporter.resolveSourceLocation(
           clangSrcMgr, swiftAttr->getLocation());
-        diagnose(attrLoc, diag::clang_swift_attr_without_at,
+        diagnose(attrLoc, diag::clang_swift_attr_unhandled,
                  swiftAttr->getAttribute());
       }
       continue;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3582,7 +3582,8 @@ ParserStatus Parser::parseDeclAttributeList(DeclAttributes &Attributes) {
 //      'actor'
 bool Parser::parseDeclModifierList(DeclAttributes &Attributes,
                                    SourceLoc &StaticLoc,
-                                   StaticSpellingKind &StaticSpelling) {
+                                   StaticSpellingKind &StaticSpelling,
+                                   bool isFromClangAttribute) {
   SyntaxParsingContext ListContext(SyntaxContext, SyntaxKind::ModifierList);
   bool isError = false;
   bool hasModifier = false;
@@ -3650,7 +3651,8 @@ bool Parser::parseDeclModifierList(DeclAttributes &Attributes,
 
       SyntaxParsingContext ModContext(SyntaxContext,
                                       SyntaxKind::DeclModifier);
-      isError |= parseNewDeclAttribute(Attributes, /*AtLoc=*/{}, Kind);
+      isError |= parseNewDeclAttribute(
+          Attributes, /*AtLoc=*/{}, Kind, isFromClangAttribute);
       hasModifier = true;
       continue;
     }

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -121,6 +121,9 @@ actor MySubclassCheckingSwiftAttributes : ProtocolWithSwiftAttributes {
     syncMethod() // expected-error{{ctor-isolated instance method 'syncMethod()' can not be referenced from a non-isolated context}}
   }
 
+  nonisolated func nonisolatedMethod() {
+  }
+
   @MainActor func mainActorMethod() {
     syncMethod() // expected-error{{actor-isolated instance method 'syncMethod()' can not be referenced from the main actor}}
   }

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -98,6 +98,7 @@ import _Concurrency
 
 // CHECK-LABEL: protocol ProtocolWithSwiftAttributes {
 // CHECK-NEXT: @actorIndependent func independentMethod()
+// CHECK-NEXT: nonisolated func nonisolatedMethod()
 // CHECK-NEXT: {{^}} @objc @MainActor func mainActorMethod()
 // CHECK-NEXT: {{^}} @objc @MainActor func uiActorMethod()
 // CHECK-NEXT: {{^}} @objc optional func missingAtAttributeMethod()

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -96,6 +96,7 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
 
 @protocol ProtocolWithSwiftAttributes
 -(void)independentMethod __attribute__((__swift_attr__("@actorIndependent")));
+-(void)nonisolatedMethod __attribute__((__swift_attr__("nonisolated")));
 -(void)mainActorMethod __attribute__((__swift_attr__("@MainActor")));
 -(void)uiActorMethod __attribute__((__swift_attr__("@UIActor")));
 


### PR DESCRIPTION
**Explanation**: Allows Swift declaration modifiers to be added via Clang's `__attribute__((swift_attr("...")))`. This is important for `nonisolated`, so that Objective-C declaration can be marked as `nonisolated`.
**Scope**: Only changes the mapping of the Clang attribute into Swift, for a syntax that is currently unused.
**Radar/SR Issue**: rdar://79402200
**Risk**: Low.
**Testing**: PR testing and CI on main.
**Original PR**: https://github.com/apple/swift/pull/37970
