### PR TITLE
[ConstraintSystem] Record produced types incrementally

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5369,6 +5369,9 @@ public:
   TypeVariableBinding(TypeVariableType *typeVar, PotentialBinding &binding)
       : TypeVar(typeVar), Binding(binding) {}
 
+  TypeVariableType *getTypeVariable() const { return TypeVar; }
+  Type getType() const { return Binding.BindingType; }
+
   bool isDefaultable() const { return Binding.isDefaultableBinding(); }
 
   bool hasDefaultedProtocol() const {

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1705,10 +1705,6 @@ bool TypeVarBindingProducer::computeNext() {
     const auto type = binding.BindingType;
     assert(!type->hasError());
 
-    // After our first pass, note that we've explored these types.
-    if (NumTries == 0)
-      ExploredTypes.insert(type->getCanonicalType());
-
     // If we have a protocol with a default type, look for alternative
     // types to the default.
     if (NumTries == 0 && binding.hasDefaultedLiteralProtocol()) {


### PR DESCRIPTION
Allow type variable binding producer to record types as they
are being produced. Otherwise it could be possible to re-discover
already explored types during `computeNext()` which leads to
duplicate bindings e.g. inferring fallback `Void` for a closure
result type when `Void` was already inferred as a direct/transitive
binding.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
