### PR TITLE
[5.5][SILGen] Fix a crash when a wrapped property initial value has a re-abstractable type.

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -1117,10 +1117,22 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
         // abstraction level. To undo this, we use a converting
         // initialization and rely on the peephole that optimizes
         // out the redundant conversion.
-        auto loweredResultTy = getLoweredType(origType, substType);
-        auto loweredSubstTy = getLoweredType(substType);
+        SILType loweredResultTy;
+        SILType loweredSubstTy;
 
-        if (loweredResultTy != loweredSubstTy) {
+        // A converting initialization isn't necessary if the member is
+        // a property wrapper. Though the initial value can have a
+        // reabstractable type, the result of the initialization is
+        // always the property wrapper type, which is never reabstractable.
+        bool needsConvertingInit = false;
+        auto *singleVar = varPattern->getSingleVar();
+        if (!(singleVar && singleVar->getOriginalWrappedProperty())) {
+          loweredResultTy = getLoweredType(origType, substType);
+          loweredSubstTy = getLoweredType(substType);
+          needsConvertingInit = loweredResultTy != loweredSubstTy;
+        }
+
+        if (needsConvertingInit) {
           Conversion conversion = Conversion::getSubstToOrig(
               origType, substType,
               loweredResultTy);

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -966,3 +966,18 @@ struct TestAutoclosureComposition {
 
 // CHECK-LABEL: sil_vtable [serialized] TestMyWrapper
 // CHECK: #TestMyWrapper.$useMyWrapper!getter
+
+@propertyWrapper
+struct AutoclosureWrapper<T> {
+  init(wrappedValue: @autoclosure () -> T) {
+    self.wrappedValue = wrappedValue()
+  }
+  var wrappedValue: T
+}
+
+struct TestReabstractableWrappedValue<T1> {
+  struct S<T2> { }
+
+  @AutoclosureWrapper var v: S<T1> = S()
+  init() where T1 == Int { }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/37936

* **Explanation**: For stored property initialization, SILGen will emit the initialization result into a converting initialization if the initialization result and the original property type have different abstraction levels (https://github.com/apple/swift/pull/34255). This code assumed that the initial value of the member and the result of initialization are the same type. This isn't true for property wrappers because the initial value can be the wrapped value type, but the result is always the property wrapper type, so this case would crash in SILGen. Property wrapper types are never reabstractable types anyway, so the converting initialization isn't necessary.
* **Scope**: Limited to property wrappers; the change is to opt out of the converting initialization if the member is a property wrapper.
* **Risk**: Low.
* **Testing**: Added a test case to the suite.
* **Reviewer**: @slavapestov 

Resolves: rdar://77339559