### PR TITLE
[5.5] Fix taskWait function family calls on arm64e

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2623,7 +2623,16 @@ public:
     assert(currentResumeFn == nullptr);
     currentResumeFn =
         IGF.Builder.CreateIntrinsicCall(llvm::Intrinsic::coro_async_resume, {});
-    return currentResumeFn;
+    auto signedResumeFn = currentResumeFn;
+    // Sign the task resume function with the C function pointer schema.
+    if (auto schema = IGF.IGM.getOptions().PointerAuth.FunctionPointers) {
+      // TODO: use the Clang type for TaskContinuationFunction*
+      // to make this work with type diversity.
+      auto authInfo =
+          PointerAuthInfo::emit(IGF, schema, nullptr, PointerAuthEntity());
+      signedResumeFn = emitPointerAuthSign(IGF, signedResumeFn, authInfo);
+    }
+    return signedResumeFn;
   }
 
 


### PR DESCRIPTION
The function pointer we pass to the task_wait functions needs to be
signed.

rdar://79561582