### PR TITLE
[Parser] Allow closures with custom attributes and capture lists.

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1209,15 +1209,25 @@ public:
 
   //===--------------------------------------------------------------------===//
   // Type Parsing
-  
+
+  enum class ParseTypeReason {
+    /// Any type parsing context.
+    Unspecified,
+
+    /// Whether the type is for a closure attribute.
+    CustomAttribute,
+  };
+
   ParserResult<TypeRepr> parseType();
-  ParserResult<TypeRepr> parseType(Diag<> MessageID,
-                                   bool IsSILFuncDecl = false);
+  ParserResult<TypeRepr> parseType(
+      Diag<> MessageID,
+      ParseTypeReason reason = ParseTypeReason::Unspecified);
 
   ParserResult<TypeRepr>
-    parseTypeSimpleOrComposition(Diag<> MessageID);
+    parseTypeSimpleOrComposition(Diag<> MessageID, ParseTypeReason reason);
 
-  ParserResult<TypeRepr> parseTypeSimple(Diag<> MessageID);
+  ParserResult<TypeRepr> parseTypeSimple(
+      Diag<> MessageID, ParseTypeReason reason);
 
   /// Parse layout constraint.
   LayoutConstraint parseLayoutConstraint(Identifier LayoutConstraintID);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2860,7 +2860,7 @@ ParserResult<CustomAttr> Parser::parseCustomAttribute(
   SyntaxContext->setCreateSyntax(SyntaxKind::CustomAttribute);
 
   // Parse a custom attribute.
-  auto type = parseType(diag::expected_type);
+  auto type = parseType(diag::expected_type, ParseTypeReason::CustomAttribute);
   if (type.hasCodeCompletion() || type.isNull()) {
     if (Tok.is(tok::l_paren) && isCustomAttributeArgument())
       skipSingle();

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -374,7 +374,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
       }
 
       if (isBareType && paramContext == ParameterContextKind::EnumElement) {
-        auto type = parseType(diag::expected_parameter_type, false);
+        auto type = parseType(diag::expected_parameter_type);
         status |= type;
         param.Type = type.getPtrOrNull();
         param.FirstName = Identifier();
@@ -389,7 +389,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         // the user is about to type the parameter label and we shouldn't
         // suggest types.
         SourceLoc typeStartLoc = Tok.getLoc();
-        auto type = parseType(diag::expected_parameter_type, false);
+        auto type = parseType(diag::expected_parameter_type);
         status |= type;
         param.Type = type.getPtrOrNull();
 

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -157,7 +157,8 @@ LayoutConstraint Parser::parseLayoutConstraint(Identifier LayoutConstraintID) {
 ///     type-simple '!'
 ///     type-collection
 ///     type-array
-ParserResult<TypeRepr> Parser::parseTypeSimple(Diag<> MessageID) {
+ParserResult<TypeRepr> Parser::parseTypeSimple(
+    Diag<> MessageID, ParseTypeReason reason) {
   ParserResult<TypeRepr> ty;
 
   if (Tok.is(tok::kw_inout) ||
@@ -242,10 +243,8 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(Diag<> MessageID) {
         continue;
       }
       // Parse legacy array types for migration.
-      if (Tok.is(tok::l_square)) {
+      if (Tok.is(tok::l_square) && reason != ParseTypeReason::CustomAttribute)
         ty = parseTypeArray(ty.get());
-        continue;
-      }
     }
     break;
   }
@@ -329,8 +328,8 @@ ParserResult<TypeRepr> Parser::parseSILBoxType(GenericParamList *generics,
 ///   type-function:
 ///     type-composition 'async'? 'throws'? '->' type
 ///
-ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
-                                         bool IsSILFuncDecl) {
+ParserResult<TypeRepr> Parser::parseType(
+    Diag<> MessageID, ParseTypeReason reason) {
   // Start a context for creating type syntax.
   SyntaxParsingContext TypeParsingContext(SyntaxContext,
                                           SyntaxContextKind::Type);
@@ -369,7 +368,7 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
     return parseSILBoxType(generics, attrs);
   }
 
-  ParserResult<TypeRepr> ty = parseTypeSimpleOrComposition(MessageID);
+  ParserResult<TypeRepr> ty = parseTypeSimpleOrComposition(MessageID, reason);
   status |= ParserStatus(ty);
   if (ty.isNull())
     return status;
@@ -762,7 +761,7 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclBaseType) {
 ///     'some'? type-simple
 ///     type-composition '&' type-simple
 ParserResult<TypeRepr>
-Parser::parseTypeSimpleOrComposition(Diag<> MessageID) {
+Parser::parseTypeSimpleOrComposition(Diag<> MessageID, ParseTypeReason reason) {
   SyntaxParsingContext SomeTypeContext(SyntaxContext, SyntaxKind::SomeType);
   // Check for the opaque modifier.
   // This is only semantically allowed in certain contexts, but we parse it
@@ -786,7 +785,7 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID) {
   
   SyntaxParsingContext CompositionContext(SyntaxContext, SyntaxContextKind::Type);
   // Parse the first type
-  ParserResult<TypeRepr> FirstType = parseTypeSimple(MessageID);
+  ParserResult<TypeRepr> FirstType = parseTypeSimple(MessageID, reason);
   if (FirstType.isNull())
     return FirstType;
   if (!Tok.isContextualPunctuator("&")) {
@@ -844,7 +843,7 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID) {
 
     // Parse next type.
     ParserResult<TypeRepr> ty =
-      parseTypeSimple(diag::expected_identifier_for_type);
+      parseTypeSimple(diag::expected_identifier_for_type, reason);
     if (ty.hasCodeCompletion())
       return makeParserCodeCompletionResult<TypeRepr>();
     Status |= ty;

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1259,8 +1259,7 @@ bool SILParser::parseSILType(SILType &Result,
       TypeAttributes::Convention::makeSwiftConvention("thin");
   }
 
-  ParserResult<TypeRepr> TyR = P.parseType(diag::expected_sil_type,
-                                           /*isSILFuncDecl*/ IsFuncDecl);
+  ParserResult<TypeRepr> TyR = P.parseType(diag::expected_sil_type);
 
   if (TyR.isNull())
     return true;

--- a/test/Concurrency/global_actor_function_types.swift
+++ b/test/Concurrency/global_actor_function_types.swift
@@ -33,7 +33,7 @@ func someSlowOperation() async -> Int { 5 }
 
 func acceptOnSomeGlobalActor<T>(_: @SomeGlobalActor () -> T) { }
 
-func testClosures() async {
+func testClosures(i: Int) async {
   // Global actors on synchronous closures become part of the type
   let cl1 = { @SomeGlobalActor in
     onSomeGlobalActor()
@@ -45,6 +45,10 @@ func testClosures() async {
     await someSlowOperation()
   }
   let _: Double = cl2 // expected-error{{cannot convert value of type '() async -> Int' to specified type 'Double'}}
+
+  let cl3 = { @SomeGlobalActor [i] in
+    print(i + onSomeGlobalActor())
+  }
 
   // okay to be explicit
   acceptOnSomeGlobalActor { @SomeGlobalActor in

--- a/test/Syntax/Outputs/round_trip_invalid.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_invalid.swift.withkinds
@@ -9,7 +9,7 @@
 // RUN: %swift-syntax-test -deserialize-raw-tree -input-source-filename %t.dump -output-filename %t
 // RUN: diff -u %s %t
 
-let <PatternBinding><IdentifierPattern>strings</IdentifierPattern><TypeAnnotation>: [<SimpleTypeIdentifier>Strin</SimpleTypeIdentifier>[<UnresolvedPatternExpr><IdentifierPattern>g</IdentifierPattern></UnresolvedPatternExpr>]?</TypeAnnotation></PatternBinding></VariableDecl><FunctionDecl>
+let <PatternBinding><IdentifierPattern>strings</IdentifierPattern><TypeAnnotation>: [<SimpleTypeIdentifier>Strin</SimpleTypeIdentifier>[<UnresolvedPatternExpr><IdentifierPattern>g</IdentifierPattern></UnresolvedPatternExpr>]</TypeAnnotation></PatternBinding></VariableDecl>?<FunctionDecl>
 
 // Function body without closing brace token.
 func foo<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSignature><CodeBlock>{<VariableDecl>


### PR DESCRIPTION
**Explanation**: Parse closures with both a custom attribute (e.g., `@MainActor`) and a capture list without complaining about Swift 1.0 beta 1 array type syntax.
**Scope**: Affects new code making use of concurrency.
**Radar/SR Issue**:  rdar://77303587
**Risk**: Low.
**Testing**: PR testing and CI on main.
**Original PR**: https://github.com/apple/swift/pull/37986