### PR TITLE
[TaskLocal] copyTo must initializeWithCopy the task local value

### DIFF
--- a/stdlib/public/Concurrency/TaskLocal.cpp
+++ b/stdlib/public/Concurrency/TaskLocal.cpp
@@ -224,7 +224,7 @@ void TaskLocal::Item::copyTo(AsyncTask *target) {
   assert(target && "TaskLocal item attempt to copy to null target task!");
 
   auto item = Item::createLink(target, this->key, this->valueType);
-  valueType->vw_initializeWithTake(item->getStoragePtr(), this->getStoragePtr());
+  valueType->vw_initializeWithCopy(item->getStoragePtr(), this->getStoragePtr());
 
   /// A `copyTo` may ONLY be invoked BEFORE the task is actually scheduled,
   /// so right now we can safely copy the value into the task without additional


### PR DESCRIPTION
I think this is might be the solution to both rdar://79528413 as well as https://forums.swift.org/t/swift-5-5-cant-get-task-local-value-in-async/49641

When we copy values to an unstructured task, we must also increase the refcount of it. 
I need to check with folks if this is the right way to do it.

This may not be the only issue here, but I'll get back to this on monday to dig deeper.