### PR TITLE
libswift readme spelling - Briding to Bridging

### DIFF
--- a/libswift/README.md
+++ b/libswift/README.md
@@ -70,7 +70,7 @@ No yet implemented instruction classes are mapped to a "placeholder" instruction
 
 ## The Optimizer
 
-Similar to SIL, the optimizer also uses a small bridging layer (`OptimizerBriding.h`).
+Similar to SIL, the optimizer also uses a small bridging layer (`OptimizerBridging.h`).
 Passes are registered in `registerSwiftPasses()`, called from `initializeLibSwift()`.
 The C++ PassManager can then call a _libwift_ pass like any other `SILFunctionTransform` pass.
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Spelling iibswift README