### PR TITLE
[Diagnostics] Add diagnostic note when using nonexistent carrot operator

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -876,6 +876,9 @@ ERROR(unspaced_unary_operator,none,
 ERROR(nonexistent_power_operator,none,
       "no operator '**' is defined; did you mean 'pow(_:_:)'?",
       ())
+NOTE(misused_carrot_operator, none,
+      "did you mean to use 'pow(_:_:)'?",
+      ())
 
 ERROR(cannot_find_in_scope,none,
       "cannot %select{find|find operator}1 %0 in scope", (DeclNameRef, bool))

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -238,6 +238,27 @@ static bool diagnoseRangeOperatorMisspell(DiagnosticEngine &Diags,
   return false;
 }
 
+static void diagnoseMisusedCarrotOperator(DiagnosticEngine &Diags,
+                                          UnresolvedDeclRefExpr *UDRE,
+                                          DeclContext *DC) {
+  auto name = UDRE->getName().getBaseIdentifier();
+  if (!(name.isOperator() && name.is("^")))
+    return;
+
+  DC = DC->getModuleScopeContext();
+
+  auto &ctx = DC->getASTContext();
+  DeclNameRef powerName(ctx.getIdentifier("pow"));
+
+  // Look if 'pow(_:_:)' exists within current context.
+  auto lookUp = TypeChecker::lookupUnqualified(DC, powerName, UDRE->getLoc(),
+                                               defaultUnqualifiedLookupOptions);
+  if (lookUp) {
+    Diags.diagnose(UDRE->getLoc(), diag::misused_carrot_operator)
+        .highlight(UDRE->getSourceRange());
+  }
+}
+
 static bool diagnoseNonexistentPowerOperator(DiagnosticEngine &Diags,
                                              UnresolvedDeclRefExpr *UDRE,
                                              DeclContext *DC) {
@@ -482,6 +503,8 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
       }
     }
   }
+
+  diagnoseMisusedCarrotOperator(Context.Diags, UDRE, DC);
 
   if (!Lookup) {
     // If we failed lookup of an operator, check to see if this is a range

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -429,4 +429,5 @@ func testNonexistentPowerOperatorWithPowFunctionOutOfScope() {
   let y: Double = 3.0
   let z: Double = x**y // expected-error {{cannot find operator '**' in scope}}
   let w: Double = a(x**2.0) // expected-error {{cannot find operator '**' in scope}}
+  _ = x^y // expected-error {{binary operator '^' cannot be applied to two 'Double' operands}}
 }

--- a/test/decl/operator/declared_power_operator.swift
+++ b/test/decl/operator/declared_power_operator.swift
@@ -9,6 +9,7 @@ func testDeclaredPowerOperator() {
   let y: Double = 3.0
   _ = 2.0**2.0 // no error
   _ = x**y // no error
+  _ = x^y // no error
 }
 
 func testDeclaredPowerOperatorWithIncompatibleType() { 

--- a/test/decl/operator/power_operator_imported.swift
+++ b/test/decl/operator/power_operator_imported.swift
@@ -8,4 +8,5 @@ func testNonexistentPowerOperatorWithPowFunctionInScope() {
   let y: Double = 3.0
   let z: Double = x**y // expected-error {{no operator '**' is defined; did you mean 'pow(_:_:)'?}}
   let w: Double = a(x**2.0) // expected-error {{no operator '**' is defined; did you mean 'pow(_:_:)'?}}
+  let _: Double = x^y // expected-error {{binary operator '^' cannot be applied to two 'Double' operands}} expected-note {{did you mean to use 'pow(_:_:)'?}}
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
```
import Foundation
let x: Double = 3.0
let y: Double = exp(x^2.0)
```
The above code produces the following error. 
```
tmp.swift:4:22: error: referencing operator function '^' on 'SIMD' requires that 'CGFloat' conform to 'SIMD'
let y: Double = exp(x^2.0)

Swift.SIMD:1:11: note: where 'Self' = 'CGFloat'
extension SIMD where Self.Scalar : FixedWidthInteger {
```

While it correctly finds a candidate operator function from Swift.SIMD, this is not really what users generally look for. 
When `^` operator does not exist, in addition to doing lookups, this PR adds a diagnostic note to use `pow(_:_:)`.

I'm not sure if this is the best approach here. But I thought that overriding lookups is dangerous, and only producing a note was appropriate here. 

This PR is similar to https://github.com/apple/swift/pull/35933

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-14095](https://bugs.swift.org/browse/SR-14095)
