### PR TITLE
[APIDigester] Add a -disable-fail-on-error option

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1362,6 +1362,10 @@ def abort_on_module_fail: Flag<["-", "--"], "abort-on-module-fail">,
   Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
   HelpText<"Abort if a module failed to load">;
 
+def disable_fail_on_error: Flag<["-", "--"], "disable-fail-on-error">,
+  Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
+  HelpText<"Don't exit with a nonzero status if errors are emitted">;
+
 def debug_mapping: Flag<["-", "--"], "debug-mapping">,
   Flags<[NoDriverOption, SwiftAPIDigesterOption]>,
   HelpText<"Dumping information for debug purposes">;

--- a/test/api-digester/serialized-diagnostics.swift
+++ b/test/api-digester/serialized-diagnostics.swift
@@ -5,6 +5,8 @@
 // RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t/color.swiftmodule %S/Inputs/cake_baseline/color.swift -parse-as-library -enable-library-evolution %clang-importer-sdk-nosource -module-name color
 // RUN: not %api-digester -diagnose-sdk -serialize-diagnostics-path %t/result.dia -empty-baseline -I %t %clang-importer-sdk-nosource -module color -abi
 // RUN: c-index-test -read-diagnostics %t/result.dia 2>&1 | %FileCheck %s -check-prefix CHECK-DIA
+// RUN: %api-digester -diagnose-sdk -serialize-diagnostics-path %t/result.dia -empty-baseline -I %t %clang-importer-sdk-nosource -module color -abi -disable-fail-on-error
+// RUN: c-index-test -read-diagnostics %t/result.dia 2>&1 | %FileCheck %s -check-prefix CHECK-DIA
 
 // Ensure the 'api-digester-breaking-change' category is included in the serialized diagnostics file.
 // CHECK-DIA: error: ABI breakage: enum Color is a new API without @available attribute [] [api-digester-breaking-change]

--- a/tools/driver/swift_api_digester_main.cpp
+++ b/tools/driver/swift_api_digester_main.cpp
@@ -2107,13 +2107,13 @@ static void findTypeMemberDiffs(NodePtr leftSDKRoot, NodePtr rightSDKRoot,
 }
 
 static std::unique_ptr<DiagnosticConsumer>
-createDiagConsumer(llvm::raw_ostream &OS, bool &FailOnError,
+createDiagConsumer(llvm::raw_ostream &OS, bool &FailOnError, bool DisableFailOnError,
                    bool CompilerStyleDiags, StringRef SerializedDiagPath) {
   if (!SerializedDiagPath.empty()) {
-    FailOnError = true;
+    FailOnError = !DisableFailOnError;
     return serialized_diagnostics::createConsumer(SerializedDiagPath);
   } else if (CompilerStyleDiags) {
-    FailOnError = true;
+    FailOnError = !DisableFailOnError;
     return std::make_unique<PrintingDiagnosticConsumer>();
   } else {
     FailOnError = false;
@@ -2168,6 +2168,7 @@ static bool readBreakageAllowlist(SDKContext &Ctx, llvm::StringSet<> &lines,
 static int diagnoseModuleChange(SDKContext &Ctx, SDKNodeRoot *LeftModule,
                                 SDKNodeRoot *RightModule, StringRef OutputPath,
                                 llvm::StringSet<> ProtocolReqAllowlist,
+                                bool DisableFailOnError,
                                 bool CompilerStyleDiags,
                                 StringRef SerializedDiagPath,
                                 StringRef BreakageAllowlistPath,
@@ -2192,7 +2193,7 @@ static int diagnoseModuleChange(SDKContext &Ctx, SDKNodeRoot *LeftModule,
                             BreakageAllowlistPath);
   }
   auto pConsumer = std::make_unique<FilteringDiagnosticConsumer>(
-      createDiagConsumer(*OS, FailOnError, CompilerStyleDiags,
+      createDiagConsumer(*OS, FailOnError, DisableFailOnError, CompilerStyleDiags,
                          SerializedDiagPath),
       std::move(allowedBreakages));
   SWIFT_DEFER { pConsumer->finishProcessing(); };
@@ -2214,6 +2215,7 @@ static int diagnoseModuleChange(SDKContext &Ctx, SDKNodeRoot *LeftModule,
 static int diagnoseModuleChange(StringRef LeftPath, StringRef RightPath,
                                 StringRef OutputPath, CheckerOptions Opts,
                                 llvm::StringSet<> ProtocolReqAllowlist,
+                                bool DisableFailOnError,
                                 bool CompilerStyleDiags,
                                 StringRef SerializedDiagPath,
                                 StringRef BreakageAllowlistPath,
@@ -2233,7 +2235,7 @@ static int diagnoseModuleChange(StringRef LeftPath, StringRef RightPath,
   RightCollector.deSerialize(RightPath);
   return diagnoseModuleChange(
       Ctx, LeftCollector.getSDKRoot(), RightCollector.getSDKRoot(), OutputPath,
-      std::move(ProtocolReqAllowlist), CompilerStyleDiags, SerializedDiagPath,
+      std::move(ProtocolReqAllowlist), DisableFailOnError, CompilerStyleDiags, SerializedDiagPath,
       BreakageAllowlistPath, DebugMapping);
 }
 
@@ -2517,6 +2519,7 @@ private:
   std::vector<std::string> PreferInterfaceForModules;
   std::string ResourceDir;
   std::string ModuleCachePath;
+  bool DisableFailOnError;
 
 public:
   SwiftAPIDigesterInvocation(const std::string &ExecPath)
@@ -2618,6 +2621,7 @@ public:
     ResourceDir = ParsedArgs.getLastArgValue(OPT_resource_dir).str();
     ModuleCachePath = ParsedArgs.getLastArgValue(OPT_module_cache_path).str();
     DebugMapping = ParsedArgs.hasArg(OPT_debug_mapping);
+    DisableFailOnError = ParsedArgs.hasArg(OPT_disable_fail_on_error);
 
     CheckerOpts.AvoidLocation = ParsedArgs.hasArg(OPT_avoid_location);
     CheckerOpts.AvoidToolArgs = ParsedArgs.hasArg(OPT_avoid_tool_args);
@@ -2820,21 +2824,21 @@ public:
       case ComparisonInputMode::BothJson: {
         return diagnoseModuleChange(
             SDKJsonPaths[0], SDKJsonPaths[1], OutputFile, CheckerOpts,
-            std::move(protocolAllowlist), CompilerStyleDiags,
+            std::move(protocolAllowlist), DisableFailOnError, CompilerStyleDiags,
             SerializedDiagPath, BreakageAllowlistPath, DebugMapping);
       }
       case ComparisonInputMode::BaselineJson: {
         SDKContext Ctx(CheckerOpts);
         return diagnoseModuleChange(
             Ctx, getBaselineFromJson(Ctx), getSDKRoot(Ctx, false), OutputFile,
-            std::move(protocolAllowlist), CompilerStyleDiags,
+            std::move(protocolAllowlist), DisableFailOnError, CompilerStyleDiags,
             SerializedDiagPath, BreakageAllowlistPath, DebugMapping);
       }
       case ComparisonInputMode::BothLoad: {
         SDKContext Ctx(CheckerOpts);
         return diagnoseModuleChange(
             Ctx, getSDKRoot(Ctx, true), getSDKRoot(Ctx, false), OutputFile,
-            std::move(protocolAllowlist), CompilerStyleDiags,
+            std::move(protocolAllowlist), DisableFailOnError, CompilerStyleDiags,
             SerializedDiagPath, BreakageAllowlistPath, DebugMapping);
       }
       }


### PR DESCRIPTION
By default, when emitting compiler-style diagnostics for breakages, swift-api-digester will exit with a nonzero status if there are any. This change disables that behavior if `-disable-fail-on-error` is passed. The driver can use this to avoid marking the entire build as failed if breaking API/ABI changes are detected.
