### PR TITLE
[SR-4559] Warn when unapplied reference to a function 'self' is referenced in property initialiser

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3756,8 +3756,13 @@ NOTE(add_self_to_type,none,
 WARNING(warn_unqualified_access,none,
         "use of %0 treated as a reference to %1 in %2 %3",
         (Identifier, DescriptiveDeclKind, DescriptiveDeclKind, DeclName))
+WARNING(self_refers_to_method,none,
+       "'self' refers to the method '%0.self', which may be unexpected",
+       (StringRef))
 NOTE(fix_unqualified_access_member,none,
      "use 'self.' to silence this warning", ())
+NOTE(fix_unqualified_access_member_named_self,none,
+     "use '%0.self' to silence this warning", (StringRef))
 NOTE(fix_unqualified_access_top_level,none,
      "use '%0' to reference the %1",
      (StringRef, DescriptiveDeclKind, Identifier))

--- a/test/Parse/self_rebinding.swift
+++ b/test/Parse/self_rebinding.swift
@@ -58,3 +58,61 @@ class MyCls {
         something() // this should still refer `MyCls.something`.
     }
 }
+
+// MARK: fix method called 'self' can be confused with regular 'self' https://bugs.swift.org/browse/SR-4559
+
+func funcThatReturnsSomething(_ any: Any) -> Any {
+    any
+}
+
+struct TypeWithSelfMethod {
+    
+    let property = self // expected-warning {{'self' refers to the method 'TypeWithSelfMethod.self', which may be unexpected}} expected-note{{use 'TypeWithSelfMethod.self' to silence this warning}} {{20-20=TypeWithSelfMethod.}}
+    
+    // Existing warning expected, not confusable
+    let property2 = self() // expected-error {{cannot use instance member 'self' within property initializer; property initializers run before 'self' is available}}
+    
+    let propertyFromClosure: () = {
+        print(self) // expected-warning {{'self' refers to the method 'TypeWithSelfMethod.self', which may be unexpected}} expected-note{{use 'TypeWithSelfMethod.self' to silence this warning}} {{15-15=TypeWithSelfMethod.}}
+    }()
+    
+    let propertyFromFunc = funcThatReturnsSomething(self) // expected-warning {{'self' refers to the method 'TypeWithSelfMethod.self', which may be unexpected}} expected-note{{use 'TypeWithSelfMethod.self' to silence this warning}} {{53-53=TypeWithSelfMethod.}}
+    
+    let propertyFromFunc2 = funcThatReturnsSomething(TypeWithSelfMethod.self) // OK
+    
+    func `self`() {
+        
+    }
+}
+
+/// Test fix_unqualified_access_member_named_self doesn't appear for computed var called `self`
+/// it can't currently be referenced as a static member -- unlike a method with the same name
+struct TypeWithSelfComputedVar {
+    
+    let property = self // expected-error {{cannot use instance member 'self' within property initializer; property initializers run before 'self' is available}}
+    
+    let propertyFromClosure: () = {
+        print(self) // expected-error {{cannot use instance member 'self' within property initializer; property initializers run before 'self' is available}}
+    }()
+    
+    let propertyFromFunc = funcThatReturnsSomething(self) // expected-error {{cannot use instance member 'self' within property initializer; property initializers run before 'self' is available}}
+    
+    var `self`: () {
+        ()
+    }
+}
+
+/// Test fix_unqualified_access_member_named_self doesn't appear appear for property called `self`
+/// it can't currently be referenced as a static member -- unlike a method with the same name
+struct TypeWithSelfProperty {
+    
+    let property = self // expected-error {{cannot use instance member 'self' within property initializer; property initializers run before 'self' is available}}
+    
+    let propertyFromClosure: () = {
+        print(self) // expected-error {{cannot use instance member 'self' within property initializer; property initializers run before 'self' is available}}
+    }()
+    
+    let propertyFromFunc = funcThatReturnsSomething(self) // expected-error {{cannot use instance member 'self' within property initializer; property initializers run before 'self' is available}}
+    
+    let `self`: () = ()
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
A fix to warn when unapplied references to a function called 'self' from are referenced unqualified from property initialisers.

**Update**: have fixed false positive referred to in strikethrough:

~~I'm having an issue though where my error message still shows when the reference is not unapplied. This is not allowed as it uses an instance method from a non-lazy initialiser, so there is no need for the error message I've added. Not sure how best to fix this as I'm brand new to Swift compiler contributions so any ideas would be much appreciated, I've already added a check for unapplied reference before showing the diagnostic. I'm assuming it technically is still treated as an unapplied reference because you can't call the function from a property initialiser, even though I have included the brackets to call it.~~

Resolves #47136