### PR TITLE
[cmake] Disable libswift and cmake tests when building using the Xcode generator.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1042,7 +1042,11 @@ if(SWIFT_INCLUDE_TOOLS)
   # "libswift" must come before "tools".
   # It adds libswift module names to the global property "libswift_modules"
   # which is used in add_swift_host_tool for the lldb workaround.
-  add_subdirectory(libswift)
+  #
+  # NOTE: We do not currently support libswift with the Xcode generator.
+  if (NOT CMAKE_GENERATOR STREQUAL "Xcode")
+    add_subdirectory(libswift)
+  endif()
 
   # Always include this after including stdlib/!
   # Refer to the large comment above the add_subdirectory(stdlib) call.

--- a/validation-test/BuildSystem/CMakeLists.txt
+++ b/validation-test/BuildSystem/CMakeLists.txt
@@ -3,5 +3,8 @@
 # if we build on Darwin since we do not have a host toolchain available when
 # compiling on the bots for Linux meaning this path would not be tested.
 if (CMAKE_Swift_COMPILER AND APPLE)
-  add_subdirectory(swift-cmake)
+  # We do not support this with the Xcode generator currently.
+  if (NOT CMAKE_GENERATOR STREQUAL "Xcode")
+    add_subdirectory(swift-cmake)
+  endif()
 endif()


### PR DESCRIPTION
We should re-enable this once it is clear that there aren't issues with the
Xcode generator/host side swift cmake. The Ninja generator (the default) still
is enabled.

----

Patch inspired by this thread: https://forums.swift.org/t/cpplib-log-error-when-building-with-xcode/49550/8