### PR TITLE
[cxx-interop] Allow function templates with defaulted template type parameters to be called.

### DIFF
--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -865,7 +865,6 @@ ClangTypeConverter::getClangTemplateArguments(
     ArrayRef<Type> genericArgs,
     SmallVectorImpl<clang::TemplateArgument> &templateArgs) {
   assert(templateArgs.size() == 0);
-  assert(genericArgs.size() == templateParams->size());
 
   // Keep track of the types we failed to convert so we can return a useful
   // error.
@@ -874,6 +873,13 @@ ClangTypeConverter::getClangTemplateArguments(
     // Note: all template parameters must be template type parameters. This is
     // verified when we import the Clang decl.
     auto templateParam = cast<clang::TemplateTypeParmDecl>(param);
+    // We must have found a defaulted parameter at the end of the list.
+    if (templateParam->getIndex() >= genericArgs.size()) {
+      templateArgs.push_back(
+          clang::TemplateArgument(templateParam->getDefaultArgument()));
+      continue;
+    }
+
     auto replacement = genericArgs[templateParam->getIndex()];
     auto qualType = convert(replacement);
     if (qualType.isNull()) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -112,10 +112,14 @@ Solution::computeSubstitutions(GenericSignature sig,
 static ConcreteDeclRef generateDeclRefForSpecializedCXXFunctionTemplate(
     ASTContext &ctx, AbstractFunctionDecl *oldDecl, SubstitutionMap subst,
     clang::FunctionDecl *specialized) {
+  FunctionType *newFnType = nullptr;
   // Create a new ParameterList with the substituted type.
-  auto oldFnType =
-      cast<GenericFunctionType>(oldDecl->getInterfaceType().getPointer());
-  auto newFnType = oldFnType->substGenericArgs(subst);
+  if (auto oldFnType = dyn_cast<GenericFunctionType>(
+          oldDecl->getInterfaceType().getPointer())) {
+    newFnType = oldFnType->substGenericArgs(subst);
+  } else {
+    newFnType = cast<FunctionType>(oldDecl->getInterfaceType().getPointer());
+  }
   // The constructor type is a function type as follows:
   //   (CType.Type) -> (Generic) -> CType
   // And a method's function type is as follows:

--- a/test/Interop/Cxx/templates/Inputs/defaulted-template-type-parameter.h
+++ b/test/Interop/Cxx/templates/Inputs/defaulted-template-type-parameter.h
@@ -1,0 +1,61 @@
+#ifndef TEST_INTEROP_CXX_TEMPLATES_INPUTS_DEFAULTED_TEMPLATE_TYPE_PARAMETER_H
+#define TEST_INTEROP_CXX_TEMPLATES_INPUTS_DEFAULTED_TEMPLATE_TYPE_PARAMETER_H
+
+template <class>
+struct ClassTemplate {};
+
+struct X {
+  enum class CtorPicked { dependent, arg, empty } picked;
+
+  // Make sure we don't crash for dependent types.
+  template <class T = void>
+  X(ClassTemplate<T>) : picked(CtorPicked::dependent) {}
+
+  template <class T = void>
+  X(T) : picked(CtorPicked::arg) {}
+
+  template <class = void>
+  X() : picked(CtorPicked::empty) {}
+};
+
+template <class = void>
+void defaultedTemplateTypeParam() {}
+
+template <class T = void>
+void defaultedTemplateTypeParamUsedInArgs(T) {}
+
+template <class T = void>
+T defaultedTemplateTypeParamUsedInReturn() {
+  return 0;
+}
+
+template <class T = void>
+void defaultedTemplateTypeParamAndDefaultedParam(T = 0) {}
+
+template <class T>
+void functionTemplateWithDefaultedParam(T = 0) {}
+
+template <class T = void>
+void defaultedTemplateTypeParamUsedInSignatureAndUnrealtedParam(int, T) {}
+
+template <class = void>
+void defaultedTemplateTypeParamAndUnrealtedParam(int) {}
+
+template <class T = int>
+void overloadedDefaultedTemplate(T) {}
+
+void overloadedDefaultedTemplate(int) {}
+
+template <typename T = int>
+void defaultedTemplateReferenceTypeParam(T &t) {}
+
+template <typename T = int>
+void defaultedTemplatePointerTypeParam(T *t) {}
+
+template <typename T = int>
+void defaultedTemplatePointerReferenceTypeParam(T *&t) {}
+
+template <typename T = int>
+void defaultedTemplatePointerPointerTypeParam(T **t) {}
+
+#endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_DEFAULTED_TEMPLATE_TYPE_PARAMETER_H

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -117,3 +117,8 @@ module LargeClassTemplates {
   header "large-class-templates.h"
   requires cplusplus
 }
+
+module DefaultedTemplateTypeParameter {
+  header "defaulted-template-type-parameter.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/templates/defaulted-template-type-parameter-module-interface.swift
+++ b/test/Interop/Cxx/templates/defaulted-template-type-parameter-module-interface.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=DefaultedTemplateTypeParameter -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK: struct X {
+// CHECK:   init<T>(_: T)
+// CHECK:   init()
+// CHECK: }
+
+// CHECK: func defaultedTemplateTypeParam()
+// CHECK: func defaultedTemplateTypeParamUsedInArgs<T>(_: T)
+// CHECK: func defaultedTemplateTypeParamUsedInReturn<T>() -> T
+// CHECK: func defaultedTemplateTypeParamAndDefaultedParam<T>(_: T)
+// CHECK: func functionTemplateWithDefaultedParam<T>(_: T)
+// CHECK: func defaultedTemplateTypeParamUsedInSignatureAndUnrealtedParam<T>(_: Int32, _: T)
+// CHECK: func defaultedTemplateTypeParamAndUnrealtedParam(_: Int32)
+// CHECK: func overloadedDefaultedTemplate<T>(_: T)
+// CHECK: func overloadedDefaultedTemplate(_: Int32)
+// CHECK: func defaultedTemplateReferenceTypeParam<T>(_ t: UnsafeMutablePointer<T>)
+// The following types aren't imported correctly, but that does not have to do
+// with the fact that the template type paramaters are defaulted.
+// CHECK: func defaultedTemplatePointerTypeParam<T>(_ t: OpaquePointer!)
+// CHECK: func defaultedTemplatePointerReferenceTypeParam<T>(_ t: UnsafeMutablePointer<OpaquePointer?>)
+// CHECK: func defaultedTemplatePointerPointerTypeParam<T>(_ t: UnsafeMutablePointer<OpaquePointer?>!)

--- a/test/Interop/Cxx/templates/defaulted-template-type-parameter.swift
+++ b/test/Interop/Cxx/templates/defaulted-template-type-parameter.swift
@@ -1,0 +1,41 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+//
+// REQUIRES: executable_test
+
+import DefaultedTemplateTypeParameter
+import StdlibUnittest
+
+// The purpose of this test is to make sure that we correctly IRGen these
+// templates and link them. The behavior is not important here (we test that
+// elsewhere).
+var DefaultedTemplateTestSuite = TestSuite("Defaulted Template Type Parameters")
+
+DefaultedTemplateTestSuite.test("Correct ctor picked") {
+  let x1 = X(0)
+  expectEqual(x1.picked, .arg)
+  
+  let x2 = X()
+  expectEqual(x2.picked, .empty)
+}
+
+DefaultedTemplateTestSuite.test("Function with defaulted template type parameters") {
+  defaultedTemplateTypeParam()
+  defaultedTemplateTypeParamUsedInArgs(0)
+  let _: Int = defaultedTemplateTypeParamUsedInReturn()
+  defaultedTemplateTypeParamAndDefaultedParam(0)
+  functionTemplateWithDefaultedParam(0)
+  defaultedTemplateTypeParamUsedInSignatureAndUnrealtedParam(0, 0)
+  defaultedTemplateTypeParamAndUnrealtedParam(0)
+}
+
+DefaultedTemplateTestSuite.test("Overloaded function template is not ambiguous") {
+  overloadedDefaultedTemplate(X())
+  overloadedDefaultedTemplate(0)
+}
+
+DefaultedTemplateTestSuite.test("Pointer types") {
+  var x = 0
+  defaultedTemplateReferenceTypeParam(&x)
+}
+
+runAllTests()


### PR DESCRIPTION
If a defaulted template type parameter is not used in the function's
signature, don't create a corresponding generic argument for that
template type. This allows us to call function templates with defaulted
template type parameters. This is very common in the standard library
for things like enable_if which is used to disable various
functions/overloads with SFINAE.

The biggest part of this change is going forward not all function
templates will be imported as generic functions in Swift. This should
work OK but we may discover there was some logic which only looked for
generic function when dealing with function templates.