### PR TITLE
🍒[TaskLocal] copyTo must initializeWithCopy the task local value

### DIFF
--- a/stdlib/public/Concurrency/TaskLocal.cpp
+++ b/stdlib/public/Concurrency/TaskLocal.cpp
@@ -223,7 +223,7 @@ void TaskLocal::Item::copyTo(AsyncTask *target) {
   assert(target && "TaskLocal item attempt to copy to null target task!");
 
   auto item = Item::createLink(target, this->key, this->valueType);
-  valueType->vw_initializeWithTake(item->getStoragePtr(), this->getStoragePtr());
+  valueType->vw_initializeWithCopy(item->getStoragePtr(), this->getStoragePtr());
 
   /// A `copyTo` may ONLY be invoked BEFORE the task is actually scheduled,
   /// so right now we can safely copy the value into the task without additional


### PR DESCRIPTION
Explanation: When we create a `Task{}` it is unstructured and thus we must retain the new value in case it's a class. We previously did initialize the value in the new task with `Take`  but instead should do with `Copy` so the class remains alive as long as the other unstructured task is alive. Not doing this can result in referring to released memory at runtime.
Reviewer: @DougGregor @jckarter ?
Radar/SR Issue: rdar://79528413
Risk: Small.
Testing: PR testing and CI on main.
Original PR: https://github.com/apple/swift/pull/37988