### PR TITLE
[IDE] Complete enum argument labels in unresolved member completions

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -456,7 +456,8 @@ static void collectPossibleCalleesByQualifiedLookup(
   llvm::DenseMap<std::pair<char, CanType>, size_t> known;
   auto *baseNominal = baseInstanceTy->getAnyNominal();
   for (auto *VD : decls) {
-    if ((!isa<AbstractFunctionDecl>(VD) && !isa<SubscriptDecl>(VD)) ||
+    if ((!isa<AbstractFunctionDecl>(VD) && !isa<SubscriptDecl>(VD) &&
+         !isa<EnumElementDecl>(VD)) ||
         VD->shouldHideFromEditor())
       continue;
     if (!isMemberDeclApplied(&DC, baseInstanceTy, VD))
@@ -479,6 +480,11 @@ static void collectPossibleCalleesByQualifiedLookup(
       } else if (isa<SubscriptDecl>(VD)) {
         if (isOnMetaType != VD->isStatic())
           continue;
+      } else if (isa<EnumElementDecl>(VD)) {
+        if (!isOnMetaType)
+          continue;
+        declaredMemberType =
+            declaredMemberType->castTo<AnyFunctionType>()->getResult();
       }
     }
 

--- a/test/IDE/complete_enum_unresolved_dot_argument_labels.swift
+++ b/test/IDE/complete_enum_unresolved_dot_argument_labels.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=COMPLETE | %FileCheck %s
+
+enum DragState {
+  case inactive
+  case dragging(translation: Int)
+}
+
+func foo() {
+  var state = DragState.inactive
+  state = .dragging(#^COMPLETE^#
+}
+
+// CHECK: Begin completions, 1 item
+// CHECK: Pattern/CurrModule/Flair[ArgLabels]/TypeRelation[Identical]: ['(']{#translation: Int#}[')'][#DragState#];
+// CHECK: End completions


### PR DESCRIPTION
Previously, we weren’t suggesting argument labels of enum elements when doing an unresolved member completion. Treat `EnumElementDecl` similar to static `AbstractFunctionDecl`s to show their argument labels.

Fixes rdar://78780690 [SR-14689]