### PR TITLE
[IDE] Show completion results if member is followed by trailing closure

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1170,6 +1170,19 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
           CodeCompletion->completeDotExpr(CCExpr, /*DotLoc=*/TokLoc);
         }
         consumeToken(tok::code_complete);
+
+        // Parse and discard remaining suffixes.
+        // e.g.
+        //   closureReceiver {
+        //     baseExpr.<complete> { $0 }
+        //   }
+        // In this case, we want to consume the trailing closure because
+        // otherwise it will get parsed as a get-set clause on a variable
+        // declared by `baseExpr.<complete>` which is complete garbage.
+        bool hasBindOptional = false;
+        parseExprPostfixSuffix(makeParserResult(CCExpr), isExprBasic,
+                               periodHasKeyPathBehavior, hasBindOptional);
+
         return makeParserCodeCompletionResult(CCExpr);
       }
 

--- a/test/IDE/complete_with_trailing_closure.swift
+++ b/test/IDE/complete_with_trailing_closure.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+public struct ItemWrapper {
+  let content: Int
+}
+
+struct MyArray {
+  func map(transform: (ItemWrapper) -> Int) {}
+}
+
+func sink(receiveValue: (MyArray) -> Void) {
+  fatalError()
+}
+
+func foo() {
+  sink { items in
+    let a = items.#^COMPLETE_WITHOUT_SPACE?check=CHECK^#map{ $0.content }
+    let b = items.#^COMPLETE_WITH_SPACE?check=CHECK^# map{ $0.content }
+    let c = items.#^COMPLETE_WITH_SPACE_AND_PARENS?check=CHECK^# map({ $0.content })
+    let d = items.#^COMPLETE_WITHOUT_SPACE_BUT_PARENS?check=CHECK^#map({ $0.content })
+    let e = items.#^COMPLETE_WITHOUT_MAP?check=CHECK^# { $0.content }
+    let f = items.#^COMPLETE_WITHOUT_MAP_BUT_PARENS?check=CHECK^# ({ $0.content })
+  }
+}
+
+// CHECK: Begin completions, 2 items
+// CHECK-DAG: Keyword[self]/CurrNominal:          self[#MyArray#];
+// CHECK-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: map({#transform: (ItemWrapper) -> Int##(ItemWrapper) -> Int#})[#Void#];
+// CHECK: End completions


### PR DESCRIPTION
When completing `items.#^COMPLETE^# { $0.content }`, we are stopping parsing of the expression after the code completion token and are thus left with `{ $0.content }` in `parseDeclVar`, which interprets the `{` as the start of an accessor clause, wrapping the entire variable in an accessor decl and thus causing code completion to not show any results.

To avoid this issue, consume any postfix expressions after the code completion token and discard them. This assures that the trailing closure gets consumed before it can be interpreted as an accessor decl.

Fixes rdar://77259087 [SR-14544]