### PR TITLE
[Demangler] Fix for crash in mangleSingleChildNode.

### DIFF
--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -581,13 +581,19 @@ void Remangler::mangleProtocolSelfConformanceDescriptor(Node *node) {
 }
 
 void Remangler::manglePartialApplyForwarder(Node *node) {
-  Buffer << "PA__T";
-  mangleSingleChildNode(node); // global
+  Buffer << "PA";
+  if (node->getNumChildren() == 1) {
+    Buffer << "__T";
+    mangleSingleChildNode(node); // global
+  }
 }
 
 void Remangler::manglePartialApplyObjCForwarder(Node *node) {
-  Buffer << "PAo__T";
-  mangleSingleChildNode(node); // global
+  Buffer << "PAo";
+  if (node->getNumChildren() == 1) {
+    Buffer << "__T";
+    mangleSingleChildNode(node); // global
+  }
 }
 
 void Remangler::mangleMergedFunction(Node *node) {

--- a/test/Demangle/remangle.swift
+++ b/test/Demangle/remangle.swift
@@ -9,6 +9,9 @@ RUN: diff %t.input %t.output
 // CHECK: Swift.(Mystruct in _7B40D7ED6632C2BEA2CA3BFFD57E3435)
 RUN: swift-demangle -remangle-objc-rt '$ss8Mystruct33_7B40D7ED6632C2BEA2CA3BFFD57E3435LLV' | %FileCheck %s
 
+// CHECK-OLD3: Swift.related decl 'H' for partial apply forwarder
+RUN: swift-demangle -remangle-objc-rt '$ssTALHP' | %FileCheck -check-prefix CHECK-OLD3 %s
+
 // CHECK-GENERICEXT: Swift._ContiguousArrayStorage<(extension in Swift):Swift.FlattenSequence<StdlibCollectionUnittest.MinimalBidirectionalCollection<StdlibCollectionUnittest.MinimalBidirectionalCollection<Swift.Int>>>.Index>
 RUN: swift-demangle -remangle-objc-rt '$ss23_ContiguousArrayStorageCys15FlattenSequenceVsE5IndexVy24StdlibCollectionUnittest020MinimalBidirectionalH0VyAIySiGG_GGD' | %FileCheck -check-prefix CHECK-GENERICEXT %s
 


### PR DESCRIPTION
PartialApplyForwarders can apparently have no children in some cases, so avoid calling mangleSingleChildNode() if that happens in order to avoid a crash.

rdar://63678141
