### PR TITLE
Sema: Reject generic arguments applied to 'Self'  [5.5]

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3649,6 +3649,10 @@ ERROR(not_a_generic_definition,none,
       "cannot specialize a non-generic definition", ())
 ERROR(not_a_generic_type,none,
       "cannot specialize non-generic type %0", (Type))
+ERROR(cannot_specialize_self,none,
+      "cannot specialize 'Self'", ())
+NOTE(specialize_explicit_type_instead,none,
+     "did you mean to explicitly reference %0 instead?", (Type))
 ERROR(type_parameter_count_mismatch,none,
       "generic type %0 specialized with %select{too many|too few}3 type "
       "parameters (got %2, but expected %1)",

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -360,3 +360,20 @@ do {
     }
   }
 }
+
+// https://bugs.swift.org/browse/SR-14731
+struct Generic<T> {
+  func foo() -> Self<Int> {}
+  // expected-error@-1 {{cannot specialize 'Self'}}
+  // expected-note@-2 {{did you mean to explicitly reference 'Generic' instead?}}{{17-21=Generic}}
+}
+
+struct NonGeneric {
+  func foo() -> Self<Int> {}
+  // expected-error@-1 {{cannot specialize 'Self'}}
+}
+
+protocol P {
+  func foo() -> Self<Int>
+  // expected-error@-1 {{cannot specialize non-generic type 'Self'}}
+}


### PR DESCRIPTION
Previously these were simply ignored.

Fixes https://bugs.swift.org/browse/SR-14731 / rdar://problem/79051797.
