### PR TITLE
Local functions can capture "self" as isolated.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1457,10 +1457,10 @@ namespace {
           }
         }
 
-        // "Defer" blocks are treated as if they are in their enclosing context.
-        if (auto func = dyn_cast<FuncDecl>(dc)) {
-          if (func->isDeferBody())
-            continue;
+        if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {
+          // @Sendable functions are nonisolated.
+          if (func->isSendable())
+            return ReferencedActor(var, ReferencedActor::SendableFunction);
         }
 
         // Check isolation of the context itself. We do this separately
@@ -1469,9 +1469,14 @@ namespace {
         switch (auto isolation = getActorIsolationOfContext(dc)) {
         case ActorIsolation::Independent:
         case ActorIsolation::Unspecified:
-          if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {
-            if (func->isSendable())
-              return ReferencedActor(var, ReferencedActor::SendableFunction);
+          // Local functions can capture an isolated parameter.
+          // FIXME: This really should be modeled by getActorIsolationOfContext.
+          if (isa<FuncDecl>(dc) && cast<FuncDecl>(dc)->isLocalCapture()) {
+            // FIXME: Local functions could presumably capture an isolated
+            // parameter that isn't 'self'.
+            if (isPotentiallyIsolated &&
+                (var->isSelfParameter() || var->isSelfParamCapture()))
+              continue;
           }
 
           return ReferencedActor(var, ReferencedActor::NonIsolatedContext);
@@ -1482,12 +1487,6 @@ namespace {
               var, isolation.getGlobalActor());
 
         case ActorIsolation::ActorInstance:
-          // FIXME: Local functions could presumably capture an isolated
-          // parameter that isn't'self'.
-          if (isPotentiallyIsolated &&
-              (var->isSelfParameter() || var->isSelfParamCapture()))
-            return ReferencedActor(var, ReferencedActor::Isolated);
-
           break;
         }
       }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -857,4 +857,13 @@ actor Counter {
 
     return counter
   }
+
+  func localNext() -> Int {
+    func doIt() {
+      counter = counter + 1
+    }
+    doIt()
+
+    return counter
+  }
 }


### PR DESCRIPTION
**Explanation**: Address a recent regression in actor-isolation checking that treated local functions within actor-isolated functions as non-isolated.
**Scope**: Only affects new code using actors and local functions.
**Radar/SR Issue**:  rdar://79564012
**Risk**: Low.
**Testing**: PR testing and CI on main.
**Original PR**: https://github.com/apple/swift/pull/38010
