### PR TITLE
Local functions can capture "self" as isolated.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1313,10 +1313,10 @@ namespace {
           }
         }
 
-        // "Defer" blocks are treated as if they are in their enclosing context.
-        if (auto func = dyn_cast<FuncDecl>(dc)) {
-          if (func->isDeferBody())
-            continue;
+        if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {
+          // @Sendable functions are nonisolated.
+          if (func->isSendable())
+            return ReferencedActor(var, ReferencedActor::SendableFunction);
         }
 
         // Check isolation of the context itself. We do this separately
@@ -1325,9 +1325,14 @@ namespace {
         switch (auto isolation = getActorIsolationOfContext(dc)) {
         case ActorIsolation::Independent:
         case ActorIsolation::Unspecified:
-          if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {
-            if (func->isSendable())
-              return ReferencedActor(var, ReferencedActor::SendableFunction);
+          // Local functions can capture an isolated parameter.
+          // FIXME: This really should be modeled by getActorIsolationOfContext.
+          if (isa<FuncDecl>(dc) && cast<FuncDecl>(dc)->isLocalCapture()) {
+            // FIXME: Local functions could presumably capture an isolated
+            // parameter that isn't 'self'.
+            if (isPotentiallyIsolated &&
+                (var->isSelfParameter() || var->isSelfParamCapture()))
+              continue;
           }
 
           return ReferencedActor(var, ReferencedActor::NonIsolatedContext);
@@ -1339,12 +1344,6 @@ namespace {
 
         case ActorIsolation::ActorInstance:
         case ActorIsolation::DistributedActorInstance:
-          // FIXME: Local functions could presumably capture an isolated
-          // parameter that isn't'self'.
-          if (isPotentiallyIsolated &&
-              (var->isSelfParameter() || var->isSelfParamCapture()))
-            return ReferencedActor(var, ReferencedActor::Isolated);
-
           break;
         }
       }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -846,4 +846,13 @@ actor Counter {
 
     return counter
   }
+
+  func localNext() -> Int {
+    func doIt() {
+      counter = counter + 1
+    }
+    doIt()
+
+    return counter
+  }
 }


### PR DESCRIPTION
This is a short-term fix to address a regression in actor-isolation
checking. A longer-term fix involves changing the way in which we
model actor isolation so that local functions can be stated to be
isolated to a particular capture, much like closures.

This subsumes my short-sighted fix for "defer".

Fixes rdar://79564012.
