### PR TITLE
GSB: Remove a couple of well-formedness assertions [5.5]

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -8468,18 +8468,10 @@ static void checkGenericSignature(CanGenericSignature canSig,
       break;
 
     case RequirementKind::SameType: {
-      auto isCanonicalAnchor = [&](Type type) {
-        if (auto *dmt = type->getAs<DependentMemberType>())
-          return canSig->isCanonicalTypeInContext(dmt->getBase(), builder);
-        return type->is<GenericTypeParamType>();
-      };
-
       auto firstType = reqt.getFirstType();
       auto secondType = reqt.getSecondType();
-      assert(isCanonicalAnchor(firstType));
 
       if (reqt.getSecondType()->isTypeParameter()) {
-        assert(isCanonicalAnchor(secondType));
         assert(compareDependentTypes(firstType, secondType) < 0 &&
                "Out-of-order type parameters in same-type constraint");
       } else {

--- a/test/Prototypes/BigInt.swift
+++ b/test/Prototypes/BigInt.swift
@@ -18,8 +18,6 @@
 
 // See rdar://problem/65251059
 // UNSUPPORTED: windows
-// rdar://problem/65015626
-// XFAIL: asserts
 
 import StdlibUnittest
 #if canImport(Darwin)


### PR DESCRIPTION
The underlying issue here won't be fixed in 5.4 and 5.5, so remove the
asserts to avoid allowing code in no-asserts builds that is rejected in
asserts builds.

Any code that builds with this assert commented out might fall victim
to an ABI break once the bug with same-type requirement minimization
is actually fixed.

"Fixes" https://bugs.swift.org/browse/SR-14776.