### PR TITLE
Allow LLVM plugins in swift driver

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -54,6 +54,7 @@
 #include "llvm/Support/Host.h"
 #include "llvm/Support/MD5.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/PluginLoader.h"
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/raw_ostream.h"
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

This PR enables the Swift Driver to load LLVM plugins, such as the Enzyme high-performance automatic differentiation toolkit (https://github.com/wsmoses/Enzyme). 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
