### PR TITLE
[WIP][Concurrency] introduce options to wait operations

### DIFF
--- a/include/swift/ABI/TaskOptions.h
+++ b/include/swift/ABI/TaskOptions.h
@@ -80,14 +80,14 @@ class TaskGroupTaskOptionRecord : public TaskOptionRecord {
 /// executor should be used instead, most often this may mean the global
 /// concurrent executor, or the enclosing actor's executor.
 class ExecutorTaskOptionRecord : public TaskOptionRecord {
-  ExecutorRef *Executor;
+  ExecutorRef Executor;
 
 public:
-  ExecutorTaskOptionRecord(ExecutorRef *executor)
+  ExecutorTaskOptionRecord(ExecutorRef executor)
     : TaskOptionRecord(TaskOptionRecordKind::Executor),
       Executor(executor) {}
 
-  ExecutorRef *getExecutor() const {
+  ExecutorRef getExecutor() const {
     return Executor;
   }
 };

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -130,12 +130,16 @@ swift_task_escalate(AsyncTask *task, JobPriority newPriority);
 /// This can be called from any thread. Its Swift signature is
 ///
 /// \code
-/// func swift_task_future_wait(on task: _owned Builtin.NativeObject) async
-///     -> Success
+/// func swift_task_future_wait(
+///     on task: _owned Builtin.NativeObject,
+///     options: Builtin.RawPointer?
+/// ) async -> Success
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
 void swift_task_future_wait(OpaqueValue *,
-         SWIFT_ASYNC_CONTEXT AsyncContext *, AsyncTask *,
+         SWIFT_ASYNC_CONTEXT AsyncContext *,
+         AsyncTask *,
+         TaskOptionRecord *options,
          TaskContinuationFunction *,
          AsyncContext *);
 
@@ -144,14 +148,17 @@ void swift_task_future_wait(OpaqueValue *,
 /// This can be called from any thread. Its Swift signature is
 ///
 /// \code
-/// func swift_task_future_wait_throwing(on task: _owned Builtin.NativeObject)
-///    async throws -> Success
+/// func swift_task_future_wait_throwing(
+///     on task: _owned Builtin.NativeObject,
+///     options: Builtin.RawPointer?
+/// ) async throws -> Success
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
 void swift_task_future_wait_throwing(
   OpaqueValue *,
   SWIFT_ASYNC_CONTEXT AsyncContext *,
   AsyncTask *,
+  TaskOptionRecord *options,
   ThrowingTaskFutureWaitContinuationFunction *,
   AsyncContext *);
 
@@ -161,16 +168,18 @@ void swift_task_future_wait_throwing(
 ///
 /// \code
 /// func swift_taskGroup_wait_next_throwing(
-///     waitingTask: Builtin.NativeObject, // current task
-///     group: Builtin.RawPointer
+///     group: Builtin.RawPointer,
+///     options: Builtin.RawPointer?
 /// ) async -> T
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swiftasync)
 void swift_taskGroup_wait_next_throwing(
-    OpaqueValue *resultPointer, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
-    TaskGroup *group, ThrowingTaskFutureWaitContinuationFunction *resumeFn,
-    AsyncContext *callContext);
+    OpaqueValue *resultPointer,
+    SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+    TaskGroup *group,
+    TaskOptionRecord *options,
+    ThrowingTaskFutureWaitContinuationFunction *resumeFn, AsyncContext *callContext);
 
 /// Initialize a `TaskGroup` in the passed `group` memory location.
 /// The caller is responsible for retaining and managing the group's lifecycle.
@@ -285,7 +294,8 @@ void swift_asyncLet_start(AsyncLet *alet,
 using AsyncLetWaitSignature =
     SWIFT_CC(swiftasync)
     void(OpaqueValue *,
-         SWIFT_ASYNC_CONTEXT AsyncContext *, AsyncTask *, Metadata *);
+        TaskOptionRecord *options,
+        SWIFT_ASYNC_CONTEXT AsyncContext *, AsyncTask *, Metadata *);
 
 /// Wait for a non-throwing async-let to complete.
 ///
@@ -294,13 +304,15 @@ using AsyncLetWaitSignature =
 /// \code
 /// func swift_asyncLet_wait(
 ///     _ asyncLet: _owned Builtin.RawPointer
+///     options: Builtin.RawPointer?
 /// ) async -> Success
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
 void swift_asyncLet_wait(OpaqueValue *,
                          SWIFT_ASYNC_CONTEXT AsyncContext *,
-                         AsyncLet *, TaskContinuationFunction *,
-                         AsyncContext *);
+                         AsyncLet *,
+                         TaskOptionRecord *options,
+                         TaskContinuationFunction *, AsyncContext *);
 
 /// Wait for a potentially-throwing async-let to complete.
 ///
@@ -308,13 +320,15 @@ void swift_asyncLet_wait(OpaqueValue *,
 ///
 /// \code
 /// func swift_asyncLet_wait_throwing(
-///     _ asyncLet: _owned Builtin.RawPointer
+///     _ asyncLet: _owned Builtin.RawPointer,
+///     options: Builtin.RawPointer?
 /// ) async throws -> Success
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
 void swift_asyncLet_wait_throwing(OpaqueValue *,
                                   SWIFT_ASYNC_CONTEXT AsyncContext *,
                                   AsyncLet *,
+                                  TaskOptionRecord *options,
                                   ThrowingTaskFutureWaitContinuationFunction *,
                                   AsyncContext *);
 

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1167,12 +1167,12 @@ void SILGenFunction::emitPatternBinding(PatternBindingDecl *PBD,
       // If we can statically detect some option needs to be passed, e.g.
       // an executor preference, we'd construct the appropriate option here and
       // pass it to the async let start.
-      auto options = B.createManagedOptionalNone(
+      auto taskOptions = B.createManagedOptionalNone(
           loc, SILType::getOptionalType(SILType::getRawPointerType(C)));
 
       alet = emitAsyncLetStart(
           loc,
-          options.forward(*this), // options is B.createManagedOptionalNone
+          taskOptions.forward(*this),
           init->getType(),
           emitRValue(init).getScalarValue()
         ).forward(*this);

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -110,19 +110,23 @@ OVERRIDE_TASK(task_create_group_future_common, AsyncTaskAndContext, , , ,
 OVERRIDE_TASK(task_future_wait, void, SWIFT_EXPORT_FROM(swift_Concurrency),
               SWIFT_CC(swiftasync), swift::,
               (OpaqueValue *result,
-               SWIFT_ASYNC_CONTEXT AsyncContext *callerContext, AsyncTask *task,
+               SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+               AsyncTask *task,
+               TaskOptionRecord *options,
                TaskContinuationFunction *resumeFunction,
                AsyncContext *callContext),
-              (result, callerContext, task, resumeFunction, callContext))
+              (result, callerContext, task, options, resumeFunction, callContext))
 
 OVERRIDE_TASK(task_future_wait_throwing, void,
               SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swiftasync),
               swift::,
               (OpaqueValue *result,
-               SWIFT_ASYNC_CONTEXT AsyncContext *callerContext, AsyncTask *task,
+               SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+               AsyncTask *task,
+               TaskOptionRecord *options,
                ThrowingTaskFutureWaitContinuationFunction *resumeFunction,
                AsyncContext *callContext),
-              (result, callerContext, task, resumeFunction, callContext))
+              (result, callerContext, task, options, resumeFunction, callContext))
 
 OVERRIDE_TASK(continuation_resume, void, SWIFT_EXPORT_FROM(swift_Concurrency),
               SWIFT_CC(swift), swift::,
@@ -175,9 +179,10 @@ OVERRIDE_ASYNC_LET(asyncLet_wait, void, SWIFT_EXPORT_FROM(swift_Concurrency),
                    SWIFT_CC(swiftasync), swift::,
                    (OpaqueValue *result,
                        SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
-                       AsyncLet *alet, TaskContinuationFunction *resumeFn,
-                       AsyncContext *callContext),
-                   (result, callerContext, alet, resumeFn, callContext))
+                       AsyncLet *alet,
+                       TaskOptionRecord *options,
+                       TaskContinuationFunction *resumeFn, AsyncContext *callContext),
+                   (result, callerContext, alet, options, resumeFn, callContext))
 
 OVERRIDE_ASYNC_LET(asyncLet_wait_throwing, void,
                    SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swiftasync),
@@ -185,9 +190,10 @@ OVERRIDE_ASYNC_LET(asyncLet_wait_throwing, void,
                    (OpaqueValue *result,
                        SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
                        AsyncLet *alet,
+                       TaskOptionRecord *options,
                        ThrowingTaskFutureWaitContinuationFunction *resume,
                        AsyncContext *callContext),
-                   (result, callerContext, alet, resume, callContext))
+                   (result, callerContext, alet, options, resume, callContext))
 
 OVERRIDE_ASYNC_LET(asyncLet_end, void,
                    SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
@@ -212,10 +218,11 @@ OVERRIDE_TASK_GROUP(taskGroup_wait_next_throwing, void,
                     (OpaqueValue *resultPointer,
                      SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
                      TaskGroup *_group,
+                     TaskOptionRecord *options,
                      ThrowingTaskFutureWaitContinuationFunction *resumeFn,
                      AsyncContext *callContext),
-                    (resultPointer, callerContext, _group, resumeFn,
-                    callContext))
+                    (resultPointer, callerContext, _group, options,
+                     resumeFn, callContext))
 
 OVERRIDE_TASK_GROUP(taskGroup_isEmpty, bool,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),

--- a/stdlib/public/Concurrency/AsyncLet.cpp
+++ b/stdlib/public/Concurrency/AsyncLet.cpp
@@ -130,22 +130,24 @@ static void swift_asyncLet_startImpl(AsyncLet *alet,
 SWIFT_CC(swiftasync)
 static void swift_asyncLet_waitImpl(
     OpaqueValue *result, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
-    AsyncLet *alet, TaskContinuationFunction *resumeFunction,
-    AsyncContext *callContext) {
+    AsyncLet *alet,
+    TaskOptionRecord *options,
+    TaskContinuationFunction *resumeFunction, AsyncContext *callContext) {
   auto task = alet->getTask();
-  swift_task_future_wait(result, callerContext, task, resumeFunction,
-                         callContext);
+  swift_task_future_wait(result, callerContext, task, options,
+                         resumeFunction, callContext);
 }
 
 SWIFT_CC(swiftasync)
 static void swift_asyncLet_wait_throwingImpl(
     OpaqueValue *result, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
     AsyncLet *alet,
+    TaskOptionRecord *options,
     ThrowingTaskFutureWaitContinuationFunction *resumeFunction,
     AsyncContext * callContext) {
   auto task = alet->getTask();
-  swift_task_future_wait_throwing(result, callerContext, task, resumeFunction,
-                                  callContext);
+  swift_task_future_wait_throwing(result, callerContext, task, options,
+                                  resumeFunction, callContext);
 }
 
 // =============================================================================

--- a/stdlib/public/Concurrency/AsyncLet.swift
+++ b/stdlib/public/Concurrency/AsyncLet.swift
@@ -27,12 +27,18 @@ public func _asyncLetStart<T>(
 /// Similar to _taskFutureGet but for AsyncLet
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_asyncLet_wait")
-public func _asyncLetGet<T>(asyncLet: Builtin.RawPointer) async -> T
+public func _asyncLetGet<T>(
+  asyncLet: Builtin.RawPointer,
+  options: Builtin.RawPointer?
+) async -> T
 
 ///// Similar to _taskFutureGetThrowing but for AsyncLet
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_asyncLet_wait_throwing")
-public func _asyncLetGetThrowing<T>(asyncLet: Builtin.RawPointer) async throws -> T
+public func _asyncLetGetThrowing<T>(
+  asyncLet: Builtin.RawPointer,
+  options: Builtin.RawPointer?
+) async throws -> T
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_asyncLet_end")

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -724,12 +724,15 @@ static void swift_task_future_waitImpl(
   OpaqueValue *result,
   SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
   AsyncTask *task,
+  TaskOptionRecord *options,
   TaskContinuationFunction *resumeFn,
   AsyncContext *callContext) {
   // Suspend the waiting task.
   auto waitingTask = swift_task_getCurrent();
   waitingTask->ResumeTask = task_future_wait_resume_adapter;
   waitingTask->ResumeContext = callContext;
+
+  // TODO: check `options` for ExecutorTaskOptionRecord and use it to resume if it was set.
 
   // Wait on the future.
   assert(task->isFuture());
@@ -755,8 +758,10 @@ static void swift_task_future_waitImpl(
 
 SWIFT_CC(swiftasync)
 void swift_task_future_wait_throwingImpl(
-    OpaqueValue *result, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+    OpaqueValue *result,
+    SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
     AsyncTask *task,
+    TaskOptionRecord *options,
     ThrowingTaskFutureWaitContinuationFunction *resumeFunction,
     AsyncContext *callContext) {
   auto waitingTask = swift_task_getCurrent();

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -650,11 +650,14 @@ SWIFT_CC(swiftasync)
 static void swift_taskGroup_wait_next_throwingImpl(
     OpaqueValue *resultPointer, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
     TaskGroup *_group,
+    TaskOptionRecord *options,
     ThrowingTaskFutureWaitContinuationFunction *resumeFunction,
     AsyncContext *rawContext) {
   auto waitingTask = swift_task_getCurrent();
   waitingTask->ResumeTask = task_group_wait_resume_adapter;
   waitingTask->ResumeContext = rawContext;
+
+  // TODO: check `options` for ExecutorTaskOptionRecord and use it to resume if it was set.
 
   auto context = static_cast<TaskFutureWaitAsyncContext *>(rawContext);
   context->ResumeParent =

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -335,7 +335,7 @@ public struct TaskGroup<ChildTaskResult> {
   public mutating func next() async -> ChildTaskResult? {
     // try!-safe because this function only exists for Failure == Never,
     // and as such, it is impossible to spawn a throwing child task.
-    return try! await _taskGroupWaitNext(group: _group)
+    return try! await _taskGroupWaitNext(group: _group, options: nil)
   }
 
   /// Await all the remaining tasks on this group.
@@ -576,13 +576,13 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   /// It is possible to directly rethrow such error out of a `withTaskGroup` body
   /// function's body, causing all remaining tasks to be implicitly cancelled.
   public mutating func next() async throws -> ChildTaskResult? {
-    return try await _taskGroupWaitNext(group: _group)
+    return try await _taskGroupWaitNext(group: _group, options: nil)
   }
 
   /// - SeeAlso: `next()`
   public mutating func nextResult() async throws -> Result<ChildTaskResult, Failure>? {
     do {
-      guard let success: ChildTaskResult = try await _taskGroupWaitNext(group: _group) else {
+      guard let success: ChildTaskResult = try await _taskGroupWaitNext(group: _group, options: nil) else {
         return nil
       }
 
@@ -777,7 +777,10 @@ func _taskGroupIsCancelled(group: Builtin.RawPointer) -> Bool
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_taskGroup_wait_next_throwing")
-func _taskGroupWaitNext<T>(group: Builtin.RawPointer) async throws -> T?
+func _taskGroupWaitNext<T>(
+  group: Builtin.RawPointer,
+  options: Builtin.RawPointer?
+) async throws -> T?
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_hasTaskGroupStatusRecord")

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -120,19 +120,34 @@ namespace {
 /// The layout of a context to call one of the following functions:
 ///
 ///   @_silgen_name("swift_task_future_wait")
-///   func _taskFutureGet<T>(_ task: Builtin.NativeObject) async -> T
+///   func _taskFutureGet<T>(
+///       _ task: Builtin.NativeObject,
+///       options: Builtin.RawPointer?
+///   ) async -> T
 ///
 ///   @_silgen_name("swift_task_future_wait_throwing")
-///   func _taskFutureGetThrowing<T>(_ task: Builtin.NativeObject) async throws -> T
+///   func _taskFutureGetThrowing<T>(
+///       _ task: Builtin.NativeObject,
+///       options: Builtin.RawPointer?
+///   ) async throws -> T
 ///
 ///   @_silgen_name("swift_asyncLet_wait")
-///   func _asyncLetGet<T>(_ task: Builtin.RawPointer) async -> T
+///   func _asyncLetGet<T>(
+///       _ task: Builtin.RawPointer,
+///       options: Builtin.RawPointer?
+///   ) async -> T
 ///
 ///   @_silgen_name("swift_asyncLet_waitThrowing")
-///   func _asyncLetGetThrowing<T>(_ task: Builtin.RawPointer) async throws -> T
+///   func _asyncLetGetThrowing<T>(
+///       _ task: Builtin.RawPointer,
+///       options: Builtin.RawPointer?
+///   ) async throws -> T
 ///
 ///   @_silgen_name("swift_taskGroup_wait_next_throwing")
-///   func _taskGroupWaitNext<T>(group: Builtin.RawPointer) async throws -> T?
+///   func _taskGroupWaitNext<T>(
+///       group: Builtin.RawPointer,
+///       options: Builtin.RawPointer?
+///   ) async throws -> T?
 ///
 class TaskFutureWaitAsyncContext : public AsyncContext {
 public:

--- a/test/IRGen/async.swift
+++ b/test/IRGen/async.swift
@@ -17,7 +17,7 @@ public class SomeClass {}
 //public func task_future_wait(_ task: __owned SomeClass) async throws -> Int
 
 @_silgen_name("swift_task_future_wait_throwing")
-public func _taskFutureGetThrowing<T>(_ task: SomeClass) async throws -> T
+public func _taskFutureGetThrowing<T>(_ task: SomeClass, options: ) async throws -> T
 
 // CHECK: define{{.*}} swift{{(tail)?}}cc void @"$s5async8testThisyyAA9SomeClassCnYaF"(%swift.context* swiftasync %0{{.*}}
 // CHECK-NOT: @swift_task_alloc

--- a/test/SILGen/async_let.swift
+++ b/test/SILGen/async_let.swift
@@ -25,11 +25,12 @@ func testAsyncLetInt() async -> Int {
   // CHECK: [[ESCAPING_CLOSURE:%.*]] = convert_function [[REABSTRACT_CLOSURE]] : $@async @callee_guaranteed () -> (@out Int, @error Error) to $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <Int>
   // CHECK: [[CLOSURE_ARG:%.*]] = convert_escape_to_noescape [not_guaranteed] [[ESCAPING_CLOSURE]] : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <Int> to $@noescape @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <Int>
   // CHECK: [[ASYNC_LET_START:%.*]] = builtin "startAsyncLet"<Int>([[OPTIONS_ARG]] : $Optional<Builtin.RawPointer>, [[CLOSURE_ARG]] : $@noescape @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <Int>) : $Builtin.RawPointer
+  // CHECK: [[TASK_OPTIONS:%.*]] = enum $Optional<Builtin.RawPointer>, #Optional.none!enumelt
   async let i = await getInt()
 
-  // CHECK: [[ASYNC_LET_GET:%.*]] = function_ref @swift_asyncLet_wait : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer) -> @out τ_0_0
+  // CHECK: [[ASYNC_LET_GET:%.*]] = function_ref @swift_asyncLet_wait : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer, Optional<Builtin.RawPointer>) -> @out τ_0_0
   // CHECK: [[INT_RESULT:%.*]] = alloc_stack $Int
-  // CHECK: apply [[ASYNC_LET_GET]]<Int>([[INT_RESULT]], [[ASYNC_LET_START]]) : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer) -> @out τ_0_0
+  // CHECK: apply [[ASYNC_LET_GET]]<Int>([[INT_RESULT]], [[ASYNC_LET_START]], [[TASK_OPTIONS]]) : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer, Optional<Builtin.RawPointer>) -> @out τ_0_0
   // CHECK: [[INT_RESULT_VALUE:%.*]] = load [trivial] [[INT_RESULT]] : $*Int
   // CHECK: assign [[INT_RESULT_VALUE]] to [[I]] : $*Int
   return await i
@@ -52,7 +53,7 @@ func testAsyncLetWithThrows(cond: Bool) async throws -> String {
 func testAsyncLetThrows() async throws -> String {
   async let s = try await getStringThrowingly()
 
-  // CHECK: [[ASYNC_LET_WAIT_THROWING:%.*]] = function_ref @swift_asyncLet_wait_throwing : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer) -> (@out τ_0_0, @error Error)
+  // CHECK: [[ASYNC_LET_WAIT_THROWING:%.*]] = function_ref @swift_asyncLet_wait_throwing : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer, Optional<Builtin.RawPointer>) -> (@out τ_0_0, @error Error)
   // CHECK: try_apply [[ASYNC_LET_WAIT_THROWING]]<String>
   return try await s
 }
@@ -66,9 +67,9 @@ func testDecomposeAwait(cond: Bool) async -> Int {
   async let (i, s) = await getIntAndString()
 
   if cond {
-    // CHECK: [[ASYNC_LET_GET:%.*]] = function_ref @swift_asyncLet_wait : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer) -> @out τ_0_0
+    // CHECK: [[ASYNC_LET_GET:%.*]] = function_ref @swift_asyncLet_wait : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer, Optional<Builtin.RawPointer>) -> @out τ_0_0
     // CHECK: [[TUPLE_RESULT:%.*]] = alloc_stack $(Int, String)
-    // CHECK: apply [[ASYNC_LET_GET]]<(Int, String)>([[TUPLE_RESULT]], {{%.*}}) : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer) -> @out τ_0_0
+    // CHECK: apply [[ASYNC_LET_GET]]<(Int, String)>([[TUPLE_RESULT]], {{%.*}}) : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer, Optional<Builtin.RawPointer>) -> @out τ_0_0
     // CHECK: [[TUPLE_RESULT_VAL:%.*]] = load [take] [[TUPLE_RESULT]] : $*(Int, String)
     // CHECK: ([[FIRST_VAL:%.*]], [[SECOND_VAL:%.*]]) = destructure_tuple [[TUPLE_RESULT_VAL]] : $(Int, String)
     // CHECK: assign [[FIRST_VAL]] to [[I]] : $*Int

--- a/unittests/runtime/CompatibilityOverrideConcurrency.cpp
+++ b/unittests/runtime/CompatibilityOverrideConcurrency.cpp
@@ -153,12 +153,13 @@ TEST_F(CompatibilityOverrideConcurrencyTest,
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_future_wait) {
-  swift_task_future_wait(nullptr, nullptr, nullptr, nullptr, nullptr);
+  swift_task_future_wait(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest,
        test_swift_task_future_wait_throwing) {
-  swift_task_future_wait_throwing(nullptr, nullptr, nullptr, nullptr, nullptr);
+  swift_task_future_wait_throwing(nullptr, nullptr, nullptr, nullptr, nullptr,
+                                  nullptr);
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_continuation_resume) {
@@ -180,11 +181,11 @@ TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_asyncLet_start) {
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_asyncLet_wait) {
-  swift_asyncLet_wait(nullptr, nullptr, nullptr, nullptr, nullptr);
+  swift_asyncLet_wait(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_asyncLet_wait_throwing) {
-  swift_asyncLet_wait(nullptr, nullptr, nullptr, nullptr, nullptr);
+  swift_asyncLet_wait_throwing(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_asyncLet_end) {
@@ -206,7 +207,7 @@ TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_taskGroup_destroy) {
 TEST_F(CompatibilityOverrideConcurrencyTest,
        test_swift_taskGroup_wait_next_throwing) {
   swift_taskGroup_wait_next_throwing(nullptr, nullptr, nullptr, nullptr,
-                                     nullptr);
+                                     nullptr, nullptr);
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_taskGroup_isEmpty) {


### PR DESCRIPTION
This a planned ABI-breaking change.

Similar to https://github.com/apple/swift/pull/37885 [Concurrency] Introduce TaskOptionRecord for spawn options but for all the wait operations.

This is a bit more tricky and I'm still tracking down all spots this needs slight fixes.

