### PR TITLE
[Distributed] 'distributed' decl modifier for swift-syntax

### DIFF
--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -172,7 +172,7 @@ DECL_NODES = [
                        'required', 'static', 'unowned', 'weak', 'private',
                        'fileprivate', 'internal', 'public', 'open',
                        'mutating', 'nonmutating', 'indirect', '__consuming',
-                       'actor', 'async'
+                       'actor', 'async', 'distributed'
                    ]),
              Child('DetailLeftParen', kind='LeftParenToken', is_optional=True),
              Child('Detail', kind='IdentifierToken', is_optional=True),


### PR DESCRIPTION
Add `distributed` keyword to decl modifiers recognized by swift-syntax