### PR TITLE
[SR-14812] [Build] Fix building with the address sanitizer enabled.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -605,6 +605,13 @@ function(add_swift_host_library name)
   else()
     set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${name})
   endif()
+
+  if(LLVM_USE_SANITIZER STREQUAL "Address")
+    target_compile_options(${name} PRIVATE
+      $<$<COMPILE_LANGUAGE:CXX>:-fsanitize=address>
+      $<$<COMPILE_LANGUAGE:Swift>:-sanitize=address>
+      )
+  endif()
 endfunction()
 
 # Add a module of libswift


### PR DESCRIPTION
Fix a build failure when enable-asan is passed to utils/build-script.

Resolves SR-14812.