### PR TITLE
Remove IRGenModule::emitFieldDescriptors

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -1437,7 +1437,7 @@ void IRGenModule::emitFieldDescriptor(const NominalTypeDecl *D) {
 
   if (needsFieldDescriptor) {
     FieldTypeMetadataBuilder builder(*this, D);
-    FieldDescriptors.push_back(builder.emit());
+    builder.emit();
   }
 }
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1153,9 +1153,6 @@ private:
   /// categories.
   SmallVector<ExtensionDecl*, 4> ObjCCategoryDecls;
 
-  /// List of fields descriptors to register in runtime.
-  SmallVector<llvm::GlobalVariable *, 4> FieldDescriptors;
-
   /// Map of Objective-C protocols and protocol references, bitcast to i8*.
   /// The interesting global variables relating to an ObjC protocol.
   struct ObjCProtocolPair {

--- a/test/IRGen/jit_metadata_table.swift
+++ b/test/IRGen/jit_metadata_table.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend %s -emit-ir -use-jit | %FileCheck %s
+
+
+class A{}
+
+// Check that only one copy of the type metadata table is emitted.
+// CHECK: @"\01l_type_metadata_table"
+// CHECK-NOT: @"\01l_type_metadata_table.1"
+
+


### PR DESCRIPTION
<!-- What's in this pull request? -->
When compiling for the JIT, the compiler is inserting pointers to field descriptors at the end of the field descriptor section (as it does for the type section). This breaks iterating over the field descriptors, and seems to be a leftover when the architecture was different. This PR removes those insertions.
