### PR TITLE
[SwiftSyntax] Change helper to use `TokenSyntax`

### DIFF
--- a/utils/gyb_syntax_support/kinds.py
+++ b/utils/gyb_syntax_support/kinds.py
@@ -59,6 +59,6 @@ def syntax_buildable_default_init_value(child, token):
     if child.is_optional:
         return " = nil"
     elif token and token.text:
-        return " = Tokens.`%s`" % lowercase_first_word(token.name)
+        return " = TokenSyntax.`%s`" % lowercase_first_word(token.name)
     else:
         return ""


### PR DESCRIPTION
Moving to `TokenSyntax` as then we can use dot notation in https://github.com/apple/swift-syntax/pull/293