### PR TITLE
Implement ReflectionContext::addImage with section finder

### DIFF
--- a/include/swift/ABI/ObjectFile.h
+++ b/include/swift/ABI/ObjectFile.h
@@ -31,7 +31,7 @@ public:
 };
 
 /// Responsible for providing the Mach-O reflection section identifiers.
-class SwiftObjectFileFormatMachO : SwiftObjectFileFormat {
+class SwiftObjectFileFormatMachO : public SwiftObjectFileFormat {
 public:
   llvm::StringRef getSectionName(ReflectionSectionKind section) override {
     switch (section) {
@@ -53,7 +53,7 @@ public:
 };
 
 /// Responsible for providing the ELF reflection section identifiers.
-class SwiftObjectFileFormatELF : SwiftObjectFileFormat {
+class SwiftObjectFileFormatELF : public SwiftObjectFileFormat {
 public:
   llvm::StringRef getSectionName(ReflectionSectionKind section) override {
     switch (section) {
@@ -75,7 +75,7 @@ public:
 };
 
 /// Responsible for providing the COFF reflection section identifiers
-class SwiftObjectFileFormatCOFF : SwiftObjectFileFormat {
+class SwiftObjectFileFormatCOFF : public SwiftObjectFileFormat {
 public:
   llvm::StringRef getSectionName(ReflectionSectionKind section) override {
     switch (section) {


### PR DESCRIPTION
Implement a version of addImage that takes in a closure responsible
for finding the sections of interest. This allows for the registration
of metadata even in situations where the object file is not complete
(for example, when generated by the JIT).