### PR TITLE
[5.5][CSSimplify] Fix warning check to account that "from" might be less optional than "to" type

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7466,8 +7466,8 @@ SourceRange CheckedCastBaseFailure::getCastRange() const {
   llvm_unreachable("There is no other kind of checked cast!");
 }
 
-std::tuple<Type, Type, unsigned>
-CoercibleOptionalCheckedCastFailure::unwrapedTypes() const {
+std::tuple<Type, Type, int>
+CoercibleOptionalCheckedCastFailure::unwrappedTypes() const {
   SmallVector<Type, 4> fromOptionals;
   SmallVector<Type, 4> toOptionals;
   Type unwrappedFromType =
@@ -7483,8 +7483,7 @@ bool CoercibleOptionalCheckedCastFailure::diagnoseIfExpr() const {
     return false;
 
   Type unwrappedFrom, unwrappedTo;
-  unsigned extraFromOptionals;
-  std::tie(unwrappedFrom, unwrappedTo, extraFromOptionals) = unwrapedTypes();
+  std::tie(unwrappedFrom, unwrappedTo, std::ignore) = unwrappedTypes();
 
   SourceRange diagFromRange = getFromRange();
   SourceRange diagToRange = getToRange();
@@ -7515,8 +7514,8 @@ bool CoercibleOptionalCheckedCastFailure::diagnoseForcedCastExpr() const {
   auto fromType = getFromType();
   auto toType = getToType();
   Type unwrappedFrom, unwrappedTo;
-  unsigned extraFromOptionals;
-  std::tie(unwrappedFrom, unwrappedTo, extraFromOptionals) = unwrapedTypes();
+  int extraFromOptionals;
+  std::tie(unwrappedFrom, unwrappedTo, extraFromOptionals) = unwrappedTypes();
 
   SourceRange diagFromRange = getFromRange();
   SourceRange diagToRange = getToRange();
@@ -7558,8 +7557,7 @@ bool CoercibleOptionalCheckedCastFailure::diagnoseConditionalCastExpr() const {
   auto fromType = getFromType();
   auto toType = getToType();
   Type unwrappedFrom, unwrappedTo;
-  unsigned extraFromOptionals;
-  std::tie(unwrappedFrom, unwrappedTo, extraFromOptionals) = unwrapedTypes();
+  std::tie(unwrappedFrom, unwrappedTo, std::ignore) = unwrappedTypes();
 
   SourceRange diagFromRange = getFromRange();
   SourceRange diagToRange = getToRange();

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2479,7 +2479,7 @@ public:
   bool diagnoseAsError() override;
 
 private:
-  std::tuple<Type, Type, unsigned> unwrapedTypes() const;
+  std::tuple<Type, Type, int> unwrappedTypes() const;
 
   bool diagnoseIfExpr() const;
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6550,7 +6550,9 @@ static ConstraintFix *maybeWarnAboutExtraneousCast(
   if (!castExpr)
     return nullptr;
 
-  unsigned extraOptionals = fromOptionals.size() - toOptionals.size();
+  // "from" could be less optional than "to" e.g. `0 as Any?`, so
+  // we need to store the difference as a signed integer.
+  int extraOptionals = fromOptionals.size() - toOptionals.size();
   // Removing the optionality from to type when the force cast expr is an IUO.
   const auto *const TR = castExpr->getCastTypeRepr();
   if (isExpr<ForcedCheckedCastExpr>(anchor) && TR &&

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar79523605.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar79523605.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend %s -typecheck -verify
+
+func test() -> Any? {
+  0 as! Any? // expected-warning {{forced cast from 'Int' to 'Any?' always succeeds; did you mean to use 'as'?}}
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/38011

---

- Explanation:

While checking whether compiler needs to produce a checked cast warning,
account for the fact that "from" could be less optional than "to" e.g.
`0 as Any?`, so the difference has to be stored as a signed integer
otherwise it's going to underflow and result in a crash or infinite
recursion in the diagnostics.

- Scope: Expressions with coercions to optional types where source type is less optional.

- Main Branch PR: https://github.com/apple/swift/pull/38011

- Resolves: rdar://79523605

- Risk: Low

- Reviewed By: @hborla  

- Testing: Regression tests added to the suite

Resolves: rdar://79523605

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
