### PR TITLE
Short-circuit `GlobalActorAttributeRequest` attempting to get the Source Location of a serialized decl.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -301,7 +301,18 @@ GlobalActorAttributeRequest::evaluate(
   if (auto decl = subject.dyn_cast<Decl *>()) {
     dc = decl->getDeclContext();
     declAttrs = &decl->getAttrs();
-    loc = decl->getLoc();
+    // HACK: `getLoc`, when querying the attr from  a serialized decl,
+    // dependning on deserialization order, may launch into arbitrary
+    // type-checking when querying interface types of such decls. Which,
+    // in turn, may do things like query (to print) USRs. This ends up being
+    // prone to request evaluator cycles.
+    //
+    // Because this only applies to serialized decls, we can be confident
+    // that they already went through this type-checking as primaries, so,
+    // for now, to avoid cycles, we simply ignore the locs on serialized decls
+    // only.
+    // This is a workaround for rdar://79563942
+    loc = decl->getLoc(/* SerializedOK */ false);
   } else {
     auto closure = subject.get<ClosureExpr *>();
     dc = closure;

--- a/test/Serialization/Inputs/actor_bar.swift
+++ b/test/Serialization/Inputs/actor_bar.swift
@@ -1,0 +1,1 @@
+public actor Bar {}

--- a/test/Serialization/actor-attr-query-cycle.swift
+++ b/test/Serialization/actor-attr-query-cycle.swift
@@ -1,0 +1,12 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -o %t/a.swiftmodule -emit-module-source-info-path %t/a.swiftsourceinfo -primary-file %s %S/Inputs/actor_bar.swift -module-name Foo
+// RUN: %target-swift-frontend -emit-module -o %t/b.swiftmodule -emit-module-source-info-path %t/b.swiftsourceinfo -primary-file %S/Inputs/actor_bar.swift %s -module-name Foo
+// RUN: %target-swift-frontend -merge-modules -emit-module -o %t/Foo.swiftmodule  -emit-module-source-info-path %t/Foo.swiftsourceinfo %t/a.swiftmodule %t/b.swiftmodule -module-name Foo
+
+extension Bar {
+  @MainActor
+  func bar() async throws -> Int {
+    return 42
+  }
+}


### PR DESCRIPTION
When querying the attr from  a serialized decl, dependning on deserialization order, getting its source-location may launch into arbitrary type-checking when querying interface types of such decls. Which, in turn, may do things like query (to print) USRs. This ends up being prone to request evaluator cycles.

Because this only applies to serialized decls, we can be confident that they already fell through this checking as primaries, so, for now, to avoid cycles, we simply ignore the source location on serialized decls only.

Long-term, we are planning to remove the `merge-modules` jobs, which will help with not having to deal with this scenario.
Alternatively, we would need to ensure that at decl deserialization time we cache the `GlobalActorAttributeRequest` when we see this attribute, but this would require further surgery to either serialization format or the `GlobalActorAttr` model, because such caching requires access to the `DeclID` of the global actor being referenced, which is not currently easily accessible.

Resolves rdar://79563942
