### PR TITLE
[Parse] Don't skip '}' when recovering from 'default' outside 'switch'

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -512,12 +512,12 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
 }
 
 /// Recover from a 'case' or 'default' outside of a 'switch' by consuming up to
-/// the next ':'.
+/// the next ':' or '}'.
 static ParserResult<Stmt> recoverFromInvalidCase(Parser &P) {
   assert(P.Tok.is(tok::kw_case) || P.Tok.is(tok::kw_default)
          && "not case or default?!");
   P.diagnose(P.Tok, diag::case_outside_of_switch, P.Tok.getText());
-  P.skipUntil(tok::colon);
+  P.skipUntil(tok::colon, tok::r_brace);
   // FIXME: Return an ErrorStmt?
   return nullptr;
 }

--- a/validation-test/IDE/crashers_2_fixed/rdar78781163.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar78781163.swift
@@ -1,0 +1,9 @@
+// RUN: %swift-ide-test -code-completion -code-completion-token=COMPLETE -source-filename %s
+
+class C {
+    func foo() {
+        #^COMPLETE^#
+        default
+    }
+    func bar() {}
+}


### PR DESCRIPTION
That caused assertion failures in code completion.

rdar://78781163
