### PR TITLE
[5.5][Sema] Use decodeIfPresent for optional enum params in Codable synthesis

### DIFF
--- a/test/stdlib/CodableTests.swift
+++ b/test/stdlib/CodableTests.swift
@@ -597,6 +597,39 @@ class TestCodable : TestCodableSuper {
         }
     }
 
+    // MARK: - Optional
+    func test_Optional_enum_JSON() {
+        enum A: Codable, Equatable {
+            case a(Int?)
+        }
+
+        enum B: Codable, Equatable {
+            case b(Int? = nil)
+        }
+
+        enum C: Codable, Equatable {
+            case c(x: Int?)
+        }
+
+        enum D: Codable, Equatable {
+            case d(x: Int? = nil)
+        }
+
+        expectRoundTripEqualityThroughJSON(for: A.a(1), lineNumber: #line)
+        expectRoundTripEqualityThroughJSON(for: A.a(nil), lineNumber: #line)
+
+        expectRoundTripEqualityThroughJSON(for: B.b(2), lineNumber: #line)
+        expectRoundTripEqualityThroughJSON(for: B.b(nil), lineNumber: #line)
+        expectRoundTripEqualityThroughJSON(for: B.b(), lineNumber: #line)
+
+        expectRoundTripEqualityThroughJSON(for: C.c(x: 3), lineNumber: #line)
+        expectRoundTripEqualityThroughJSON(for: C.c(x: nil), lineNumber: #line)
+
+        expectRoundTripEqualityThroughJSON(for: D.d(x: 4), lineNumber: #line)
+        expectRoundTripEqualityThroughJSON(for: D.d(x: nil), lineNumber: #line)
+        expectRoundTripEqualityThroughJSON(for: D.d(), lineNumber: #line)
+    }
+
     // MARK: - PartialRangeFrom
     func test_PartialRangeFrom_JSON() {
         let value = 0...
@@ -899,6 +932,7 @@ var tests = [
     "test_Locale_Plist" : TestCodable.test_Locale_Plist,
     "test_NSRange_JSON" : TestCodable.test_NSRange_JSON,
     "test_NSRange_Plist" : TestCodable.test_NSRange_Plist,
+    "test_Optional_enum_JSON" : TestCodable.test_Optional_enum_JSON,
     "test_PartialRangeFrom_JSON" : TestCodable.test_PartialRangeFrom_JSON,
     "test_PartialRangeFrom_Plist" : TestCodable.test_PartialRangeFrom_Plist,
     "test_PartialRangeThrough_JSON" : TestCodable.test_PartialRangeThrough_JSON,


### PR DESCRIPTION
- Explanation: The code generation did not use `encodeIfPresent` for optional parameters, causing decoding to fail if the value was absent
- Scope: Synthesis of Codable conformance for enums
- Risk: Low
- Testing: Added regression test
- Issue: rdar://79584261

This code has been refactored on main and the bug is not present there, but it is less risky to do the simple fix here, instead of backporting the refactored code.