### PR TITLE
Temporarily mark ArraysObjc test unsupported for watchsimulator-i386.

### DIFF
--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -8,9 +8,6 @@
 // RUN: %enable-cow-checking %line-directive %t/main.swift -- %target-run %t/Arrays
 // REQUIRES: executable_test
 
-// FIXME: Test fails for watchsimulator-i386 (rdar://79626782)
-// UNSUPPORTED: CPU=i386 && OS=watchos
-
 import Swift
 import StdlibUnittest
 import StdlibCollectionUnittest

--- a/validation-test/stdlib/ArraysObjc.swift.gyb
+++ b/validation-test/stdlib/ArraysObjc.swift.gyb
@@ -9,7 +9,8 @@
 // REQUIRES: objc_interop
 
 // FIXME: rdar://problem/55944126
-// UNSUPPORTED: CPU=armv7s || CPU=armv7k
+// FIXME: rdar://problem/79626782 (test fails for watchsimulator-i386)
+// UNSUPPORTED: CPU=armv7s || CPU=armv7k || CPU=i386
 
 import Darwin
 import Foundation


### PR DESCRIPTION
Accidentally marked the wrong test as unsupported in #38082.