### PR TITLE
[5.5] [SymbolGraph] rename symbol graph files for cross-import overlays

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
@@ -45,6 +45,11 @@ SymbolGraph *SymbolGraphASTWalker::getModuleSymbolGraph(const Decl *D) {
 
   if (this->M.getNameStr().equals(M->getNameStr())) {
     return &MainGraph;
+  } else if (MainGraph.DeclaringModule.hasValue() &&
+      MainGraph.DeclaringModule.getValue()->getNameStr().equals(M->getNameStr())) {
+    // Cross-import overlay modules already appear as "extensions" of their declaring module; we
+    // should put actual extensions of that module into the main graph
+    return &MainGraph;
   }
   auto Found = ExtendedModuleGraphs.find(M->getNameStr());
   if (Found != ExtendedModuleGraphs.end()) {

--- a/lib/SymbolGraphGen/SymbolGraphGen.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphGen.cpp
@@ -25,26 +25,14 @@ namespace {
 int serializeSymbolGraph(SymbolGraph &SG,
                          const SymbolGraphOptions &Options) {
   SmallString<256> FileName;
-  if (SG.DeclaringModule.hasValue()) {
-    // Save a cross-import overlay symbol graph as `MainModule@BystandingModule[@BystandingModule...]@OverlayModule.symbols.json`
-    //
-    // The overlay module's name is added as a disambiguator in case an overlay
-    // declares multiple modules for the same set of imports.
-    FileName.append(SG.DeclaringModule.getValue()->getNameStr());
-    for (auto BystanderModule : SG.BystanderModules) {
-      FileName.push_back('@');
-      FileName.append(BystanderModule.str());
-    }
-    
+  FileName.append(SG.M.getNameStr());
+  if (SG.ExtendedModule.hasValue()) {
     FileName.push_back('@');
-    FileName.append(SG.M.getNameStr());
-  } else {
-    FileName.append(SG.M.getNameStr());
-    
-    if (SG.ExtendedModule.hasValue()) {
-      FileName.push_back('@');
-      FileName.append(SG.ExtendedModule.getValue()->getNameStr());
-    }
+    FileName.append(SG.ExtendedModule.getValue()->getNameStr());
+  } else if (SG.DeclaringModule.hasValue()) {
+    // Treat cross-import overlay modules as "extensions" of their declaring module
+    FileName.push_back('@');
+    FileName.append(SG.DeclaringModule.getValue()->getNameStr());
   }
   FileName.append(".symbols.json");
 

--- a/test/SymbolGraph/Module/CrossImport.swift
+++ b/test/SymbolGraph/Module/CrossImport.swift
@@ -4,7 +4,10 @@
 // RUN: %target-build-swift %s -module-name _A_B -I %t -emit-module -emit-module-path %t/
 // RUN: cp -r %S/Inputs/CrossImport/A.swiftcrossimport %t/
 // RUN: %target-swift-symbolgraph-extract -module-name A -I %t -pretty-print -output-dir %t
-// RUN: %FileCheck %s --input-file %t/A@B@_A_B.symbols.json
+// RUN: %FileCheck %s --input-file %t/_A_B@A.symbols.json --check-prefix CHECK-MOD
+// RUN: %FileCheck %s --input-file %t/_A_B@A.symbols.json --check-prefix CHECK-A
+// RUN: %FileCheck %s --input-file %t/_A_B@B.symbols.json --check-prefix CHECK-MOD
+// RUN: %FileCheck %s --input-file %t/_A_B@B.symbols.json --check-prefix CHECK-B
 
 @_exported import A
 import B
@@ -15,7 +18,26 @@ extension A {
     }
 }
 
-// CHECK: module
-// CHECK-NEXT: "name": "A"
-// CHECK-NEXT: bystanders
-// CHECK-NEXT:   B
+public struct LocalStruct {}
+
+extension LocalStruct {
+    public func someFunc() {}
+}
+
+extension B {
+    public func untransmogrify() -> A {
+        return A(x: self.y)
+    }
+}
+
+// CHECK-MOD: module
+// CHECK-MOD-NEXT: "name": "A"
+// CHECK-MOD-NEXT: bystanders
+// CHECK-MOD-NEXT:   B
+
+// CHECK-A-NOT: s:1BAAV4_A_BE14untransmogrify1AAEVyF
+// CHECK-A-DAG: s:1AAAV4_A_BE12transmogrify1BAEVyF
+// CHECK-A-DAG: s:4_A_B11LocalStructV
+// CHECK-A-DAG: s:4_A_B11LocalStructV8someFuncyyF
+
+// CHECK-B: s:1BAAV4_A_BE14untransmogrify1AAEVyF

--- a/test/SymbolGraph/Module/Inputs/CrossImport/A.swift
+++ b/test/SymbolGraph/Module/Inputs/CrossImport/A.swift
@@ -1,3 +1,7 @@
 public struct A {
     public var x: Int
+
+    public init(x: Int) {
+        self.x = x
+    }
 }


### PR DESCRIPTION
Resolves rdar://79474927

This PR cherry-picks #38039 onto `release/5.5`.

**Change Information**
- Explanation: When generating symbol graphs with `swift-symbolgraph-extract` for a module which declares a cross-import overlay, the file name of the overlay's symbol graphs is changed to accommodate its extensions of other modules' symbols.
- Scope of Issue: Currently, when generating symbol graphs for cross-import overlays, any extensions in the overlay will emit a symbol graph with the same name, overwriting the base symbol graph and losing information for those symbols.
- Risk: Low.
- Automated Testing: The existing lit test, "SymbolGraph/Module/CrossImport", has been updated to exercise this change.