### PR TITLE
[Concurrency] Deprecate typealias PartialAsyncTask

### DIFF
--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -12,10 +12,6 @@
 
 import Swift
 @_implementationOnly import _SwiftConcurrencyShims
-
-/// TODO: remove this before shipping
-@available(SwiftStdlib 5.5, *)
-public typealias PartialAsyncTask = UnownedJob
 
 /// A job is a unit of scheduleable work.
 @available(SwiftStdlib 5.5, *)

--- a/stdlib/public/Concurrency/SourceCompatibilityShims.swift
+++ b/stdlib/public/Concurrency/SourceCompatibilityShims.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -255,3 +255,7 @@ extension ThrowingTaskGroup {
 @available(SwiftStdlib 5.5, *)
 @available(*, deprecated, message: "please use UnsafeContination<..., Error>")
 public typealias UnsafeThrowingContinuation<T> = UnsafeContinuation<T, Error>
+
+@available(SwiftStdlib 5.5, *)
+@available(*, deprecated, renamed: "UnownedJob")
+public typealias PartialAsyncTask = UnownedJob

--- a/test/stdlib/Concurrency.swift
+++ b/test/stdlib/Concurrency.swift
@@ -8,6 +8,8 @@ import _Concurrency
 // short-term source compatibility)
 @available(SwiftStdlib 5.5, *)
 extension PartialAsyncTask {
+  // expected-warning@-1 {{'PartialAsyncTask' is deprecated: renamed to 'UnownedJob'}}
+  // expected-note@-2 {{use 'UnownedJob' instead}}
 }
 @available(SwiftStdlib 5.5, *)
 extension UnownedJob {


### PR DESCRIPTION
Deprecate typealias PartialAsyncTask, and move it into the "SourceCompatibilityShims.swift" file.