### PR TITLE
[5.5] Restrict uses of 'self' in actor initializers

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -168,6 +168,18 @@ ERROR(variable_defer_use_uninit,none,
 ERROR(self_closure_use_uninit,none,
       "'self' captured by a closure before all members were initialized", ())
 
+/// false == sync; true == global-actor isolated
+ERROR(self_use_actor_init,none,
+      "this use of actor 'self' %select{can only|cannot}0 appear in "
+      "%select{an async|a global-actor isolated}0 initializer",
+      (bool))
+ERROR(self_disallowed_actor_init,none,
+      "actor 'self' %select{can only|cannot}0 %1 from "
+      "%select{an async|a global-actor isolated}0 initializer",
+      (bool, StringRef))
+
+
+
 
 ERROR(variable_addrtaken_before_initialized,none,
       "address of %select{variable|constant}1 '%0' taken before it is"

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -177,6 +177,10 @@ ERROR(self_disallowed_actor_init,none,
       "actor 'self' %select{can only|cannot}0 %1 from "
       "%select{an async|a global-actor isolated}0 initializer",
       (bool, StringRef))
+NOTE(actor_convenience_init,none,
+     "convenience initializers allow non-isolated use of 'self' once "
+     "initialized",
+     ())
 
 
 

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -432,6 +432,23 @@ bool DIMemoryObjectInfo::isElementLetProperty(unsigned Element) const {
   return false;
 }
 
+ConstructorDecl *DIMemoryObjectInfo::isActorInitSelf() const {
+  // is it 'self'?
+  if (!MemoryInst->isVar())
+    if (auto decl =
+        dyn_cast_or_null<ClassDecl>(getASTType()->getAnyNominal()))
+      // is it for an actor?
+      if (decl->isActor())
+        if (auto *silFn = MemoryInst->getFunction())
+          // is it a designated initializer?
+          if (auto *ctor = dyn_cast_or_null<ConstructorDecl>(
+                            silFn->getDeclContext()->getAsDecl()))
+            if (ctor->isDesignatedInit())
+              return ctor;
+
+  return nullptr;
+}
+
 //===----------------------------------------------------------------------===//
 //                        DIMemoryUse Implementation
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
@@ -164,6 +164,10 @@ public:
     return false;
   }
 
+  /// Returns the initializer if the memory use is 'self' and appears in an
+  /// actor's designated initializer. Otherwise, returns nullptr.
+  ConstructorDecl *isActorInitSelf() const;
+
   /// True if this memory object is the 'self' of a derived class initializer.
   bool isDerivedClassSelf() const { return MemoryInst->isDerivedClassSelf(); }
 

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -384,6 +384,13 @@ namespace {
 
   using BlockStates = BasicBlockData<LiveOutBlockState>;
 
+  enum class ActorInitKind {
+    None,           // not an actor init
+    Plain,          // synchronous, not isolated to global-actor
+    PlainAsync,     // asynchronous, not isolated to global-actor
+    GlobalActorIsolated  // isolated to global-actor (sync or async).
+  };
+
   /// LifetimeChecker - This is the main heavy lifting for definite
   /// initialization checking of a memory object.
   class LifetimeChecker {
@@ -479,6 +486,20 @@ namespace {
 
     bool diagnoseReturnWithoutInitializingStoredProperties(
         const SILInstruction *Inst, SILLocation loc, const DIMemoryUse &Use);
+
+    /// Returns true iff the use involves 'self' in a restricted kind of
+    /// actor initializer. If a non-null Kind pointer was passed in,
+    /// then the specific kind of restricted actor initializer will be
+    /// written out. Otherwise, the None initializer kind will be written out.
+    bool isRestrictedActorInitSelf(const DIMemoryUse& Use,
+                               ActorInitKind *Kind = nullptr) const;
+
+    void reportIllegalUseForActorInit(const DIMemoryUse &Use,
+                                      ActorInitKind ActorKind,
+                                      StringRef ProblemDesc) const;
+
+    void handleLoadUseFailureForActorInit(const DIMemoryUse &Use,
+                                          ActorInitKind ActorKind) const;
 
     void handleLoadUseFailure(const DIMemoryUse &Use,
                               bool SuperInitDone,
@@ -866,9 +887,13 @@ void LifetimeChecker::doIt() {
 
 void LifetimeChecker::handleLoadUse(const DIMemoryUse &Use) {
   bool IsSuperInitComplete, FailedSelfUse;
+  ActorInitKind ActorKind = ActorInitKind::None;
   // If the value is not definitively initialized, emit an error.
   if (!isInitializedAtUse(Use, &IsSuperInitComplete, &FailedSelfUse))
     return handleLoadUseFailure(Use, IsSuperInitComplete, FailedSelfUse);
+  // Check if it involves 'self' in a restricted actor init.
+  if (isRestrictedActorInitSelf(Use, &ActorKind))
+    return handleLoadUseFailureForActorInit(Use, ActorKind);
 }
 
 static void replaceValueMetatypeInstWithMetatypeArgument(
@@ -1177,6 +1202,7 @@ static FullApplySite findApply(SILInstruction *I, bool &isSelfParameter) {
 
 void LifetimeChecker::handleInOutUse(const DIMemoryUse &Use) {
   bool IsSuperInitDone, FailedSelfUse;
+  ActorInitKind ActorKind = ActorInitKind::None;
 
   // inout uses are generally straight-forward: the memory must be initialized
   // before the "address" is passed as an l-value.
@@ -1194,6 +1220,10 @@ void LifetimeChecker::handleInOutUse(const DIMemoryUse &Use) {
     diagnoseInitError(Use, diagID);
     return;
   }
+
+  // 'self' cannot be passed 'inout' from some kinds of actor initializers.
+  if (isRestrictedActorInitSelf(Use, &ActorKind))
+    reportIllegalUseForActorInit(Use, ActorKind, "be passed 'inout'");
 
   // One additional check: 'let' properties may never be passed inout, because
   // they are only allowed to have their initial value set, not a subsequent
@@ -1357,12 +1387,19 @@ static bool isLoadForReturn(SingleValueInstruction *loadInst) {
 }
 
 void LifetimeChecker::handleEscapeUse(const DIMemoryUse &Use) {
+
   // The value must be fully initialized at all escape points.  If not, diagnose
   // the error.
   bool SuperInitDone, FailedSelfUse, FullyUninitialized;
+  ActorInitKind ActorKind = ActorInitKind::None;
 
   if (isInitializedAtUse(Use, &SuperInitDone, &FailedSelfUse,
                          &FullyUninitialized)) {
+
+    // no escaping uses of 'self' are allowed in restricted actor inits.
+    if (isRestrictedActorInitSelf(Use, &ActorKind))
+      reportIllegalUseForActorInit(Use, ActorKind, "be captured by a closure");
+
     return;
   }
 
@@ -1744,6 +1781,89 @@ bool LifetimeChecker::diagnoseReturnWithoutInitializingStoredProperties(
   }
 
   return true;
+}
+
+bool LifetimeChecker::isRestrictedActorInitSelf(const DIMemoryUse& Use,
+                                            ActorInitKind *Kind) const {
+
+  auto result = [&](ActorInitKind k, bool isRestricted) -> bool {
+    if (Kind)
+      *Kind = k;
+    return isRestricted;
+  };
+
+  // Currently: being synchronous, or global-actor isolated, means the actor's
+  // self is restricted within the init.
+  if (auto *ctor = TheMemory.isActorInitSelf()) {
+    if (getActorIsolation(ctor).isGlobalActor())  // global-actor isolated?
+      return result(ActorInitKind::GlobalActorIsolated, true);
+    else if (!ctor->hasAsync()) // synchronous?
+      return result(ActorInitKind::Plain, true);
+    else
+      return result(ActorInitKind::PlainAsync, false);
+  }
+
+  return result(ActorInitKind::None, false);
+}
+
+void LifetimeChecker::reportIllegalUseForActorInit(
+                                           const DIMemoryUse &Use,
+                                           ActorInitKind ActorKind,
+                                           StringRef ProblemDesc) const {
+  switch(ActorKind) {
+  case ActorInitKind::None:
+  case ActorInitKind::PlainAsync:
+    llvm::report_fatal_error("this actor init is never problematic!");
+
+  case ActorInitKind::Plain:
+    diagnose(Module, Use.Inst->getLoc(), diag::self_disallowed_actor_init,
+             false, ProblemDesc);
+    break;
+
+  case ActorInitKind::GlobalActorIsolated:
+    diagnose(Module, Use.Inst->getLoc(), diag::self_disallowed_actor_init,
+             true, ProblemDesc);
+    break;
+  }
+}
+
+void LifetimeChecker::handleLoadUseFailureForActorInit(
+                                           const DIMemoryUse &Use,
+                                           ActorInitKind ActorKind) const {
+  assert(TheMemory.isAnyInitSelf());
+  SILInstruction *Inst = Use.Inst;
+
+  // While enum instructions have no side-effects, they do wrap-up `self`
+  // such that it can escape our analysis. So, enum instruction uses are only
+  // acceptable if the enum is part of a specific pattern of usage that is
+  // generated for a failable initializer.
+  if (auto *enumInst = dyn_cast<EnumInst>(Inst)) {
+    if (isFailableInitReturnUseOfEnum(enumInst))
+      return;
+
+    // Otherwise, if the use has no possibility of side-effects, then its OK.
+  } else if (!Inst->mayHaveSideEffects()) {
+    return;
+
+  // While loads can have side-effects, we are not concerned by them here.
+  } else if (isa<LoadInst>(Inst)) {
+    return;
+  }
+
+  // Everything else is disallowed!
+  switch(ActorKind) {
+  case ActorInitKind::None:
+  case ActorInitKind::PlainAsync:
+    llvm::report_fatal_error("this actor init is never problematic!");
+
+  case ActorInitKind::Plain:
+    diagnose(Module, Use.Inst->getLoc(), diag::self_use_actor_init, false);
+    break;
+
+  case ActorInitKind::GlobalActorIsolated:
+    diagnose(Module, Use.Inst->getLoc(), diag::self_use_actor_init, true);
+    break;
+  }
 }
 
 /// Check and diagnose various failures when a load use is not fully

--- a/test/Concurrency/Runtime/actor_keypaths.swift
+++ b/test/Concurrency/Runtime/actor_keypaths.swift
@@ -9,12 +9,27 @@
 actor Page {
     let initialNumWords : Int
 
-    @actorIndependent(unsafe)
-    var numWords : Int
+    private let numWordsMem: UnsafeMutablePointer<Int>
 
-    init(_ words : Int) {
-        numWords = words
+    nonisolated
+    var numWords : Int {
+      get { numWordsMem.pointee }
+      set { numWordsMem.pointee = newValue }
+    }
+
+    private init(withWords words : Int) {
         initialNumWords = words
+        numWordsMem = .allocate(capacity: 1)
+        numWordsMem.initialize(to: words)
+    }
+
+    convenience init(_ words: Int) {
+        self.init(withWords: words)
+        numWords = words
+    }
+
+    deinit {
+      numWordsMem.deallocate()
     }
 }
 
@@ -29,7 +44,7 @@ actor Book {
         pages = stack
     }
 
-    @actorIndependent
+    nonisolated
     subscript(_ page : Int) -> Page {
         return pages[page]
     }

--- a/test/Concurrency/actor_definite_init.swift
+++ b/test/Concurrency/actor_definite_init.swift
@@ -49,7 +49,10 @@ actor Convenient {
         guard val > 0 else { throw BogusError.blah }
         self.x = 10
         say(msg: "hello?")  // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
         Task { self }       // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
     }
 
     init(asyncThrowyDesignated val: Int) async throws {
@@ -95,15 +98,26 @@ actor MyActor {
 
     func helloWorld() {}
 
+    convenience init(ci1 c: Bool) {
+        self.init(i1: c)
+        Task { self }
+        callMethod(self)
+    }
+
     init(i1 c:  Bool) {
         self.x = 0
         _ = self.x
         self.y = self.x
 
         Task { self }     // expected-error{{actor 'self' can only be captured by a closure from an async initializer}}
+                          // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
 
         self.helloWorld() // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                          // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
         callMethod(self) // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                         // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
         passInout(&self.x) // expected-error{{actor 'self' can only be passed 'inout' from an async initializer}}
 
         self.x = self.y
@@ -115,9 +129,13 @@ actor MyActor {
         _ = self.hax
 
         _ = computedProp    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
         computedProp = 1    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
 
         Task { // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+               // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
             _ = await self.hax
             await self.helloWorld()
         }
@@ -129,9 +147,14 @@ actor MyActor {
         self.y = self.x
 
         Task { self }     // expected-error{{actor 'self' can only be captured by a closure from an async initializer}}
+                          // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
 
         self.helloWorld() // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                          // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
         callMethod(self) // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                         // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
         passInout(&self.x) // expected-error{{actor 'self' can only be passed 'inout' from an async initializer}}
 
         self.x = self.y
@@ -140,9 +163,13 @@ actor MyActor {
         _ = self.hax
 
         _ = computedProp    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
         computedProp = 1    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
 
         Task { // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+               // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
             _ = await self.hax
             await self.helloWorld()
         }
@@ -154,9 +181,14 @@ actor MyActor {
         self.y = self.x
 
         Task { self }     // expected-error{{actor 'self' can only be captured by a closure from an async initializer}}
+                          // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
 
         self.helloWorld() // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                          // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
         callMethod(self) // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                         // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
         passInout(&self.x) // expected-error{{actor 'self' can only be passed 'inout' from an async initializer}}
 
         self.x = self.y
@@ -165,9 +197,13 @@ actor MyActor {
         _ = self.hax
 
         _ = computedProp    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
         computedProp = 1    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
 
         Task { // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+               // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
             _ = await self.hax
             await self.helloWorld()
         }
@@ -179,9 +215,14 @@ actor MyActor {
         self.y = self.x
 
         Task { self }     // expected-error{{actor 'self' cannot be captured by a closure from a global-actor isolated initializer}}
+                          // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
 
         self.helloWorld() // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+                          // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
         callMethod(self) // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+                         // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
         passInout(&self.x) // expected-error{{actor 'self' cannot be passed 'inout' from a global-actor isolated initializer}}
 
         self.x = self.y
@@ -190,9 +231,13 @@ actor MyActor {
         _ = self.hax
 
         _ = computedProp    // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
         computedProp = 1    // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
 
         Task { // expected-error {{actor 'self' cannot be captured by a closure from a global-actor isolated initializer}}
+               // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
             _ = await self.hax
             await self.helloWorld()
         }
@@ -228,9 +273,14 @@ actor MyActor {
         self.y = self.x
 
         Task { self }     // expected-error{{actor 'self' cannot be captured by a closure from a global-actor isolated initializer}}
+                          // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
 
         self.helloWorld() // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+                          // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
         callMethod(self) // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+                         // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
         passInout(&self.x) // expected-error{{actor 'self' cannot be passed 'inout' from a global-actor isolated initializer}}
 
         self.x = self.y
@@ -239,9 +289,13 @@ actor MyActor {
         _ = self.hax
 
         _ = computedProp    // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
         computedProp = 1    // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
 
         Task { // expected-error {{actor 'self' cannot be captured by a closure from a global-actor isolated initializer}}
+               // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
             _ = await self.hax
             await self.helloWorld()
         }
@@ -257,6 +311,7 @@ actor X {
     init(v1 start: Int) {
         self.counter = start
         Task { await self.setCounter(start + 1) } // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+                                                  // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
 
         if self.counter != start {
             fatalError("where's my protection?")
@@ -319,8 +374,10 @@ actor EscapeArtist {
         let unchainedSelf = self
 
         unchainedSelf.nonisolated() // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+                                    // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
 
         let _ = { unchainedSelf.nonisolated() } // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+                                                // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
     }
 
     init(attempt5: Bool) {
@@ -336,6 +393,7 @@ actor EscapeArtist {
             self.nonisolated()
         }
         fn()    // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+                // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
     }
 
     func isolatedMethod() { x += 1 }

--- a/test/Concurrency/actor_definite_init.swift
+++ b/test/Concurrency/actor_definite_init.swift
@@ -1,0 +1,343 @@
+// RUN: %target-swift-frontend -parse-as-library -emit-sil -verify %s
+
+// REQUIRES: concurrency
+
+enum BogusError: Error {
+    case blah
+}
+
+@available(SwiftStdlib 5.5, *)
+actor Convenient {
+    var x: Int
+    var y: Convenient?
+
+    init(val: Int) {
+        self.x = val
+    }
+
+    convenience init(bigVal: Int) {
+        if bigVal < 0 {
+            self.init(val: 0)
+            say(msg: "hello from actor!")
+        }
+        say(msg: "said this too early!") // expected-error {{'self' used before 'self.init' call or assignment to 'self'}}
+        self.init(val: bigVal)
+
+        Task { await self.mutateIsolatedState() }
+    }
+
+    convenience init!(biggerVal1 biggerVal: Int) {
+        guard biggerVal < 1234567 else { return nil }
+        self.init(bigVal: biggerVal)
+        say(msg: "hello?")
+    }
+
+    @MainActor
+    convenience init?(biggerVal2 biggerVal: Int) async {
+        guard biggerVal < 1234567 else { return nil }
+        self.init(bigVal: biggerVal)
+        say(msg: "hello?")
+        await mutateIsolatedState()
+    }
+
+    convenience init() async {
+        self.init(val: 10)
+        await mutateIsolatedState()
+    }
+
+    init(throwyDesignated val: Int) throws {
+        guard val > 0 else { throw BogusError.blah }
+        self.x = 10
+        say(msg: "hello?")  // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+        Task { self }       // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+    }
+
+    init(asyncThrowyDesignated val: Int) async throws {
+        guard val > 0 else { throw BogusError.blah }
+        self.x = 10
+        say(msg: "hello?")
+        Task { self }
+    }
+
+    convenience init(throwyConvenient val: Int) throws {
+        try self.init(throwyDesignated: val)
+        say(msg: "hello?")
+        Task { self }
+    }
+
+    func mutateIsolatedState() {
+        self.y = self
+    }
+
+    nonisolated func say(msg: String) {
+        print(msg)
+    }
+}
+
+func randomInt() -> Int { return 4 }
+
+@available(SwiftStdlib 5.5, *)
+func callMethod(_ a: MyActor) {}
+
+@available(SwiftStdlib 5.5, *)
+func passInout<T>(_ a: inout T) {}
+
+@available(SwiftStdlib 5.5, *)
+actor MyActor {
+    var x: Int
+    var y: Int
+    var hax: MyActor?
+
+    var computedProp : Int {
+        get { 0 }
+        set { }
+    }
+
+    func helloWorld() {}
+
+    init(i1 c:  Bool) {
+        self.x = 0
+        _ = self.x
+        self.y = self.x
+
+        Task { self }     // expected-error{{actor 'self' can only be captured by a closure from an async initializer}}
+
+        self.helloWorld() // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        callMethod(self) // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        passInout(&self.x) // expected-error{{actor 'self' can only be passed 'inout' from an async initializer}}
+
+        self.x = self.y
+        self.x = randomInt()
+        (_, _) = (self.x, self.y)
+        _ = self.x == 0
+
+        self.hax = self     // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        _ = self.hax
+
+        _ = computedProp    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        computedProp = 1    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+
+        Task { // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+            _ = await self.hax
+            await self.helloWorld()
+        }
+    }
+
+    init?(i1_nil c:  Bool) {
+        self.x = 0
+        guard c else { return nil }
+        self.y = self.x
+
+        Task { self }     // expected-error{{actor 'self' can only be captured by a closure from an async initializer}}
+
+        self.helloWorld() // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        callMethod(self) // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        passInout(&self.x) // expected-error{{actor 'self' can only be passed 'inout' from an async initializer}}
+
+        self.x = self.y
+
+        self.hax = self     // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        _ = self.hax
+
+        _ = computedProp    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        computedProp = 1    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+
+        Task { // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+            _ = await self.hax
+            await self.helloWorld()
+        }
+    }
+
+    init!(i1_boom c:  Bool) {
+        self.x = 0
+        guard c else { return nil }
+        self.y = self.x
+
+        Task { self }     // expected-error{{actor 'self' can only be captured by a closure from an async initializer}}
+
+        self.helloWorld() // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        callMethod(self) // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        passInout(&self.x) // expected-error{{actor 'self' can only be passed 'inout' from an async initializer}}
+
+        self.x = self.y
+
+        self.hax = self     // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        _ = self.hax
+
+        _ = computedProp    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        computedProp = 1    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+
+        Task { // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+            _ = await self.hax
+            await self.helloWorld()
+        }
+    }
+
+    @MainActor
+    init(i2 c:  Bool) {
+        self.x = 0
+        self.y = self.x
+
+        Task { self }     // expected-error{{actor 'self' cannot be captured by a closure from a global-actor isolated initializer}}
+
+        self.helloWorld() // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+        callMethod(self) // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+        passInout(&self.x) // expected-error{{actor 'self' cannot be passed 'inout' from a global-actor isolated initializer}}
+
+        self.x = self.y
+
+        self.hax = self     // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+        _ = self.hax
+
+        _ = computedProp    // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+        computedProp = 1    // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+
+        Task { // expected-error {{actor 'self' cannot be captured by a closure from a global-actor isolated initializer}}
+            _ = await self.hax
+            await self.helloWorld()
+        }
+    }
+
+    init(i3 c:  Bool) async {
+        self.x = 0
+        self.y = self.x
+
+        Task { self }
+
+        self.helloWorld()
+        callMethod(self)
+        passInout(&self.x)
+
+        self.x = self.y
+
+        self.hax = self
+        _ = Optional.some(self)
+
+        _ = computedProp
+        computedProp = 1
+
+        Task {
+            _ = await self.hax
+            await self.helloWorld()
+        }
+    }
+
+    @MainActor
+    init(i4 c:  Bool) async {
+        self.x = 0
+        self.y = self.x
+
+        Task { self }     // expected-error{{actor 'self' cannot be captured by a closure from a global-actor isolated initializer}}
+
+        self.helloWorld() // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+        callMethod(self) // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+        passInout(&self.x) // expected-error{{actor 'self' cannot be passed 'inout' from a global-actor isolated initializer}}
+
+        self.x = self.y
+
+        self.hax = self     // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+        _ = self.hax
+
+        _ = computedProp    // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+        computedProp = 1    // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+
+        Task { // expected-error {{actor 'self' cannot be captured by a closure from a global-actor isolated initializer}}
+            _ = await self.hax
+            await self.helloWorld()
+        }
+    }
+
+}
+
+
+@available(SwiftStdlib 5.5, *)
+actor X {
+    var counter: Int
+
+    init(v1 start: Int) {
+        self.counter = start
+        Task { await self.setCounter(start + 1) } // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+
+        if self.counter != start {
+            fatalError("where's my protection?")
+        }
+    }
+
+    func setCounter(_ x : Int) {
+        self.counter = x
+    }
+}
+
+struct CardboardBox<T> {
+    public let item: T
+}
+
+
+@available(SwiftStdlib 5.5, *)
+var globalVar: EscapeArtist?
+
+@available(SwiftStdlib 5.5, *)
+actor EscapeArtist {
+    var x: Int
+
+    init(attempt1: Bool) {
+        self.x = 0
+
+        globalVar = self    // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+        Task { await globalVar!.isolatedMethod() }
+
+        if self.x == 0 {
+            fatalError("race detected.")
+        }
+    }
+
+    init(attempt2: Bool) {
+        self.x = 0
+
+        let wrapped: EscapeArtist? = .some(self)    // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+        let selfUnchained = wrapped!
+
+        Task { await selfUnchained.isolatedMethod() }
+        if self.x == 0 {
+            fatalError("race detected.")
+        }
+    }
+
+    init(attempt3: Bool) {
+        self.x = 0
+
+        // expected-warning@+2 {{variable 'unchainedSelf' was never mutated; consider changing to 'let' constant}}
+        // expected-error@+1 {{this use of actor 'self' can only appear in an async initializer}}
+        var unchainedSelf = self
+
+        unchainedSelf.nonisolated()
+    }
+
+    init(attempt4: Bool) {
+        self.x = 0
+
+        let unchainedSelf = self
+
+        unchainedSelf.nonisolated() // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+
+        let _ = { unchainedSelf.nonisolated() } // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+    }
+
+    init(attempt5: Bool) {
+        self.x = 0
+
+        let box = CardboardBox(item: self) // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+        box.item.nonisolated()
+    }
+
+    init(attempt6: Bool) {
+        self.x = 0
+        func fn() {
+            self.nonisolated()
+        }
+        fn()    // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+    }
+
+    func isolatedMethod() { x += 1 }
+    nonisolated func nonisolated() {}
+}

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -696,21 +696,72 @@ extension SomeClassInActor.ID {
 }
 
 // ----------------------------------------------------------------------
-// Initializers
+// Initializers (through typechecking only)
 // ----------------------------------------------------------------------
 @available(SwiftStdlib 5.5, *)
 actor SomeActorWithInits {
   var mutableState: Int = 17
   var otherMutableState: Int
 
-  init() {
+  init(i1: Bool) {
     self.mutableState = 42
     self.otherMutableState = 17
 
     self.isolated()
+    self.nonisolated()
   }
 
-  func isolated() { }
+  init(i2: Bool) async {
+    self.mutableState = 0
+    self.otherMutableState = 1
+
+    self.isolated()
+    self.nonisolated()
+  }
+
+  convenience init(i3: Bool) {
+    self.init(i1: i3)
+    self.isolated()     // expected-error{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context}}
+    self.nonisolated()
+  }
+
+  convenience init(i4: Bool) async {
+    self.init(i1: i4)
+    await self.isolated()
+    self.nonisolated()
+  }
+
+  @MainActor init(i5: Bool) {
+    self.mutableState = 42
+    self.otherMutableState = 17
+
+    self.isolated()
+    self.nonisolated()
+  }
+
+  @MainActor init(i6: Bool) async {
+    self.mutableState = 42
+    self.otherMutableState = 17
+
+    self.isolated()
+    self.nonisolated()
+  }
+
+  @MainActor convenience init(i7: Bool) {
+    self.init(i1: i7)
+    self.isolated()     // expected-error{{actor-isolated instance method 'isolated()' can not be referenced from the main actor}}
+    self.nonisolated()
+  }
+
+  @MainActor convenience init(i8: Bool) async {
+    self.init(i1: i8)
+    await self.isolated()
+    self.nonisolated()
+  }
+
+
+  func isolated() { } // expected-note 2 {{calls to instance method 'isolated()' from outside of its actor context are implicitly asynchronous}}
+  nonisolated func nonisolated() {}
 }
 
 @available(SwiftStdlib 5.5, *)


### PR DESCRIPTION
Explanation: Actor initializers permit races due to unrestricted use of 'self', and this radar plugs that hole by rejecting unsafe uses of 'self'.
Risk: Low. Any developers that have written non-trivial code in an actor's initializer will be affected by a source break. This primarily would be early adopters of actors, and will _not_ affect any uses of @MainActor.
Original PRs: https://github.com/apple/swift/pull/37075 and https://github.com/apple/swift/pull/38096
Radar/SR Issue: rdar://78790369
Reviewed By: Konrad Malawski
Testing: Regression tests are included