### PR TITLE
[CodeCompletion] Allow unresolved types in Callee analysis

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -682,7 +682,7 @@ static bool collectPossibleCalleesForApply(
       fnType = *fnTypeOpt;
   }
 
-  if (!fnType || fnType->hasUnresolvedType() || fnType->hasError())
+  if (!fnType || fnType->hasError())
     return false;
   fnType = fnType->getWithoutSpecifierType();
 

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -998,3 +998,20 @@ struct Rdar77867723 {
 // OVERLOAD_LABEL2: End completions
   }
 }
+
+struct SR14737<T> {
+  init(arg1: T, arg2: Bool) {}
+}
+extension SR14737 where T == Int {
+  init(arg1: T, onlyInt: Bool) {}
+}
+func test_SR14737() {
+  invalidCallee {
+    SR14737(arg1: true, #^GENERIC_INIT_IN_INVALID^#)
+// FIXME: 'onlyInt' shouldn't be offered because 'arg1' is Bool.
+// GENERIC_INIT_IN_INVALID: Begin completions, 2 items
+// GENERIC_INIT_IN_INVALID-DAG: Pattern/Local/Flair[ArgLabels]:     {#arg2: Bool#}[#Bool#];
+// GENERIC_INIT_IN_INVALID-DAG: Pattern/Local/Flair[ArgLabels]:     {#onlyInt: Bool#}[#Bool#];
+// GENERIC_INIT_IN_INVALID: End completions
+  }
+}


### PR DESCRIPTION
```swift
  struct Generic<T> {
    init(destination: T, isActive: Bool) {  }
  }

  invalid {
    Generic(destination: true, #^COMPLETE^#)
  }
```

In this case, since `invalid { ... }` cannot be type checked, `ExprContextAnalysis` tries to type check `Generic` alone which resolves to bound `Generic` type with an unresolved type. Previously, we used to give up the analysis when seeing unresolved type. That caused mis callee analysis.

rdar://79092374
Fixes #57087
