### PR TITLE
[Diagnostics] Adjust `Self` conformance check to find non-decl overload choices

### DIFF
--- a/validation-test/Sema/type_checker_crashers_fixed/rdar79268378.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar79268378.swift
@@ -1,0 +1,29 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+struct Result {
+}
+
+func wrapper(_: Result?) {
+}
+
+extension Optional where Wrapped == Result {
+  static func test(_: String) -> Result { Result() }
+}
+
+extension Result {
+  static func test<R: RangeExpression>(_: R) -> Result where R.Bound == Int {
+    Result()
+  }
+}
+
+protocol P {}
+
+struct Value : P {
+  init() {}
+  init<R>(_: R) {}
+}
+
+func example<T1: P, T2: P>(_: T1, _: T2) {
+}
+
+example(Value(), Value(wrapper(.test(0))))


### PR DESCRIPTION
Use `findSelectedOverloadFor` instead of `findResolvedMemberRef`
to cover cases where member is found via base type unwrap, otherwise
conformance constraint would be re-inserted but never re-attempted
which results in a compiler crash.

Resolves: rdar://79268378

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
