### PR TITLE
[Sema]  Fix constantness diagnostics for single expression closures

### DIFF
--- a/test/Sema/diag_constantness_check.swift
+++ b/test/Sema/diag_constantness_check.swift
@@ -361,3 +361,66 @@ func testConstructorAnnotation(x: Int) {
   let _ = ConstructorTest(x)
     // expected-error@-1 {{argument must be an integer literal}}
 }
+
+// Test closure expressions
+
+func funcAcceptingClosure<T>(_ x: () -> T) -> T {
+  return x()
+}
+
+func normalFunction() {}
+
+@_semantics("oslog.requires_constant_arguments")
+func constantArgumentFunctionReturningIntCollection(_ constArg: Int) -> Array<Int> {
+  return [constArg, constArg, constArg]
+}
+
+@_semantics("oslog.requires_constant_arguments")
+func constantArgumentFunctionReturningInt(_ constArg: Int) -> Int {
+  return constArg
+}
+
+func testCallsWithinClosures(s: String, x: Int) {
+  funcAcceptingClosure {
+    constantArgumentFunction(s)
+    // expected-error@-1 {{argument must be a string literal}}
+  }
+  funcAcceptingClosure {
+    constantArgumentFunction(s)
+    // expected-error@-1 {{argument must be a string literal}}
+    constantArgumentFunction(s)
+    // expected-error@-1 {{argument must be a string literal}}
+  }
+  funcAcceptingClosure {
+    funcAcceptingClosure {
+      constantArgumentFunction(s)
+        // expected-error@-1 {{argument must be a string literal}}
+    }
+  }
+  funcAcceptingClosure {
+    normalFunction()
+    funcAcceptingClosure {
+      constantArgumentFunction(s)
+        // expected-error@-1 {{argument must be a string literal}}
+    }
+  }
+  let _ =
+    funcAcceptingClosure {
+      constantArgumentFunctionReturningIntCollection(x)
+        // expected-error@-1 {{argument must be an integer literal}}
+    }
+    .filter { $0 > 0 }
+    .map { $0 + 1 }
+  let _ =
+    funcAcceptingClosure {
+      constantArgumentFunctionReturningInt(x)
+        // expected-error@-1 {{argument must be an integer literal}}
+    } + 10 * x
+  let _ = { constantArgumentFunctionReturningIntCollection(x) }
+    // expected-error@-1 {{argument must be an integer literal}}
+  funcAcceptingClosure {
+    constantArgumentFunction(1)
+    constantArgumentFunction("string literal")
+    constantArgumentFunction("string with a single interpolation \(x)")
+  }
+}

--- a/test/Sema/diag_constantness_check_os_log.swift
+++ b/test/Sema/diag_constantness_check_os_log.swift
@@ -185,3 +185,44 @@ func testLogMessageWrappingDiagnostics() {
   _osLogTestHelper(nonConstantFunction("key", fallback: "A literal message"))
     // expected-error@-1{{argument must be a string interpolation}}
 }
+
+// Test closure expressions
+
+func funcAcceptingClosure<T>(_ x: () -> T) -> T {
+  return x()
+}
+
+func normalFunction() {}
+
+func testCallsWithinClosures(formatOpt: OSLogIntegerFormatting) {
+  funcAcceptingClosure {
+    _osLogTestHelper("Minimum integer value: \(Int.min, format: formatOpt)")
+      // expected-error@-1 {{argument must be a static method or property of 'OSLogIntegerFormatting'}}
+  }
+  funcAcceptingClosure {
+    _osLogTestHelper("Minimum integer value: \(Int.min, format: formatOpt)")
+      // expected-error@-1 {{argument must be a static method or property of 'OSLogIntegerFormatting'}}
+    _osLogTestHelper("Maximum integer value: \(Int.max, format: formatOpt)")
+      // expected-error@-1 {{argument must be a static method or property of 'OSLogIntegerFormatting'}}
+  }
+  funcAcceptingClosure {
+    funcAcceptingClosure {
+      _osLogTestHelper("Minimum integer value: \(Int.min, format: formatOpt)")
+        // expected-error@-1 {{argument must be a static method or property of 'OSLogIntegerFormatting'}}
+    }
+  }
+  funcAcceptingClosure {
+    normalFunction()
+    funcAcceptingClosure {
+      _osLogTestHelper("Minimum integer value: \(Int.min, format: formatOpt)")
+        // expected-error@-1 {{argument must be a static method or property of 'OSLogIntegerFormatting'}}
+    }
+  }
+  funcAcceptingClosure {
+    _osLogTestHelper("Minimum integer value: \(Int.min, format: .hex)")
+  }
+  funcAcceptingClosure {
+    _osLogTestHelper("Minimum integer value: \(Int.min, format: .hex)")
+    _osLogTestHelper("Maximum integer value: \(Int.max, privacy: .public)")
+  }
+}


### PR DESCRIPTION
Due to the way miscellaneous diagnostics work with closure bodies, the
function argument constantness sema check does not produce proper
diagnostics for single-expression closures. This change fixes the
problem by having the ASTWalker manually walk in the closure body
if it is a single expression.

rdar://65577070

