### PR TITLE
[5.5][CodeComplete] Mark results as not recommended if global actor context doesn't match

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2645,9 +2645,14 @@ public:
       break;
     }
     case ActorIsolation::GlobalActor:
-    case ActorIsolation::GlobalActorUnsafe:
-      // TODO: Implement.
+    case ActorIsolation::GlobalActorUnsafe: {
+      auto contextIsolation = getActorIsolationOfContext(
+          const_cast<DeclContext *>(CurrDeclContext));
+      if (contextIsolation != isolation) {
+        implicitlyAsync = true;
+      }
       break;
+    }
     case ActorIsolation::Unspecified:
     case ActorIsolation::Independent:
       return;

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2406,6 +2406,7 @@ namespace {
       return getExplicitGlobalActor(closure);
     }
 
+  public:
     /// Determine the isolation of a particular closure.
     ///
     /// This function assumes that enclosing closures have already had their
@@ -2538,6 +2539,12 @@ void swift::checkPropertyWrapperActorIsolation(
    PatternBindingDecl *binding, Expr *expr) {
   ActorIsolationChecker checker(binding->getDeclContext());
   expr->walk(checker);
+}
+
+ClosureActorIsolation
+swift::determineClosureActorIsolation(AbstractClosureExpr *closure) {
+  ActorIsolationChecker checker(closure->getParent());
+  return checker.determineClosureIsolation(closure);
 }
 
 /// Determine actor isolation solely from attributes.

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -29,6 +29,7 @@ class ActorIsolation;
 class AnyFunctionType;
 class ASTContext;
 class ClassDecl;
+class ClosureActorIsolation;
 class ClosureExpr;
 class ConcreteDeclRef;
 class CustomAttr;
@@ -55,6 +56,16 @@ void checkInitializerActorIsolation(Initializer *init, Expr *expr);
 void checkEnumElementActorIsolation(EnumElementDecl *element, Expr *expr);
 void checkPropertyWrapperActorIsolation(
     PatternBindingDecl *binding, Expr *expr);
+
+/// Determine the isolation of a particular closure.
+///
+/// This forwards to \c ActorIsolationChecker::determineClosureActorIsolation
+/// and thus assumes that enclosing closures have already had their isolation
+/// checked.
+///
+/// This does not set the closure's actor isolation
+ClosureActorIsolation
+determineClosureActorIsolation(AbstractClosureExpr *closure);
 
 /// Describes the kind of operation that introduced the concurrent refernece.
 enum class ConcurrentReferenceKind {

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1946,6 +1946,19 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(Evaluator &evaluator,
   if (auto CE = dyn_cast<ClosureExpr>(DC)) {
     if (CE->getBodyState() == ClosureExpr::BodyState::Parsed) {
       swift::typeCheckASTNodeAtLoc(CE->getParent(), CE->getLoc());
+      // We need the actor isolation of the closure to be set so that we can
+      // annotate results that are on the same global actor.
+      // Since we are evaluating TypeCheckASTNodeAtLocRequest for every closure
+      // from outermost to innermost, we don't want to call checkActorIsolation,
+      // because that would cause actor isolation to be checked multiple times
+      // for nested closures. Instead, call determineClosureActorIsolation
+      // directly and set the closure's actor isolation manually. We can
+      // guarantee of that the actor isolation of enclosing closures have their
+      // isolation checked before nested ones are being checked by the way
+      // TypeCheckASTNodeAtLocRequest is called multiple times, as described
+      // above.
+      auto ActorIsolation = determineClosureActorIsolation(CE);
+      CE->setActorIsolation(ActorIsolation);
       if (CE->getBodyState() != ClosureExpr::BodyState::ReadyForTypeChecking)
         return false;
     }

--- a/test/IDE/complete_global_actorisolation.swift
+++ b/test/IDE/complete_global_actorisolation.swift
@@ -1,0 +1,176 @@
+// REQUIRES: concurrency
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -enable-experimental-concurrency
+
+class MyNonSendable {}
+struct MySendable {}
+
+@globalActor
+actor MyGlobalActor {
+  static var shared = MyGlobalActor()
+}
+
+@globalActor
+actor MyOtherGlobalActor {
+  static var shared = MyOtherGlobalActor()
+}
+
+@MyGlobalActor func globalFuncOnGlobalActor() {}
+
+func takeClosure<T>(_: () async -> T) {}
+
+var otherInstanceOfMyClass = MyClass()
+
+class MyClass {
+  @MyGlobalActor func funcOnGlobalActor() -> Int { return 0 }
+  @MyOtherGlobalActor func funcOnOtherGlobalActor() -> Int { return 0 }
+  func funcSync() -> Int { return 0 }
+  
+  @MyGlobalActor func nonSenableFuncOnGlobalActor(arg: MyNonSendable) -> Int { return 0 }
+  @MyOtherGlobalActor func nonSenableFuncOnOtherGlobalActor(arg: MyNonSendable) -> Int { return 0 }
+
+  @MyGlobalActor var varOnGlobalActor: Int = 0
+  @MyOtherGlobalActor var varOnOtherGlobalActor: Int = 0
+  var varSync: Int = 0
+
+  @MyGlobalActor subscript(onGlobalActor onGlobalActor: Int) -> Int { get { 1 } set { } }
+  @MyOtherGlobalActor subscript(onOtherGlobalActor onOtherGlobalActor: Int) -> Int { get { 1 } set { } }
+  subscript(sync sync: Int) -> Int { get { 1 } set { } }
+}
+
+extension MyClass {
+  @MyGlobalActor func testOnGlobalActor() {
+    let _ = #^IN_FUNC_ON_GLOBAL_ACTOR^#
+// IN_FUNC_ON_GLOBAL_ACTOR: Begin completions
+// IN_FUNC_ON_GLOBAL_ACTOR-DAG: Decl[InstanceMethod]/CurrNominal:   funcOnGlobalActor()[#Int#]; name=funcOnGlobalActor()
+// IN_FUNC_ON_GLOBAL_ACTOR-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: funcOnOtherGlobalActor()[' async'][#Int#]; name=funcOnOtherGlobalActor() async
+// IN_FUNC_ON_GLOBAL_ACTOR-DAG: Decl[InstanceMethod]/CurrNominal:   funcSync()[#Int#]; name=funcSync()
+// IN_FUNC_ON_GLOBAL_ACTOR-DAG: Decl[InstanceMethod]/CurrNominal:   nonSenableFuncOnGlobalActor({#arg: MyNonSendable#})[#Int#]; name=nonSenableFuncOnGlobalActor(arg: MyNonSendable)
+// IN_FUNC_ON_GLOBAL_ACTOR-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: nonSenableFuncOnOtherGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnOtherGlobalActor(arg: MyNonSendable) async
+// IN_FUNC_ON_GLOBAL_ACTOR-DAG: Decl[InstanceVar]/CurrNominal:      varOnGlobalActor[#Int#]; name=varOnGlobalActor
+// IN_FUNC_ON_GLOBAL_ACTOR-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended: varOnOtherGlobalActor[#Int#][' async']; name=varOnOtherGlobalActor async
+// IN_FUNC_ON_GLOBAL_ACTOR-DAG: Decl[InstanceVar]/CurrNominal:      varSync[#Int#]; name=varSync
+// IN_FUNC_ON_GLOBAL_ACTOR: End completions
+
+    let _ = self.#^IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT^#
+// IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT: Begin completions
+// IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   funcOnGlobalActor()[#Int#]; name=funcOnGlobalActor()
+// IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: funcOnOtherGlobalActor()[' async'][#Int#]; name=funcOnOtherGlobalActor() async
+// IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   funcSync()[#Int#]; name=funcSync()
+// IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   nonSenableFuncOnGlobalActor({#arg: MyNonSendable#})[#Int#]; name=nonSenableFuncOnGlobalActor(arg: MyNonSendable)
+// IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: nonSenableFuncOnOtherGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnOtherGlobalActor(arg: MyNonSendable) async
+// IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT-DAG: Decl[InstanceVar]/CurrNominal:      varOnGlobalActor[#Int#]; name=varOnGlobalActor
+// IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended: varOnOtherGlobalActor[#Int#][' async']; name=varOnOtherGlobalActor async
+// IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT-DAG: Decl[InstanceVar]/CurrNominal:      varSync[#Int#]; name=varSync
+// IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT: End completions
+
+    let _ = self#^IN_FUNC_ON_GLOBAL_ACTOR_NODOT^#
+// IN_FUNC_ON_GLOBAL_ACTOR_NODOT: Begin completions
+// IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[InstanceMethod]/CurrNominal:   .funcOnGlobalActor()[#Int#]; name=funcOnGlobalActor()
+// IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: .funcOnOtherGlobalActor()[' async'][#Int#]; name=funcOnOtherGlobalActor() async
+// IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[InstanceMethod]/CurrNominal:   .funcSync()[#Int#]; name=funcSync()
+// IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[InstanceMethod]/CurrNominal:   .nonSenableFuncOnGlobalActor({#arg: MyNonSendable#})[#Int#]; name=nonSenableFuncOnGlobalActor(arg: MyNonSendable)
+// IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: .nonSenableFuncOnOtherGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnOtherGlobalActor(arg: MyNonSendable) async
+// IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[InstanceVar]/CurrNominal:      .varOnGlobalActor[#Int#]; name=varOnGlobalActor
+// IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended: .varOnOtherGlobalActor[#Int#][' async']; name=varOnOtherGlobalActor async
+// IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[InstanceVar]/CurrNominal:      .varSync[#Int#]; name=varSync
+// IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[Subscript]/CurrNominal:        [{#onGlobalActor: Int#}][#Int#]; name=[onGlobalActor: Int]
+// IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[Subscript]/CurrNominal/NotRecommended: [{#onOtherGlobalActor: Int#}][' async'][#Int#]; name=[onOtherGlobalActor: Int] async
+// IN_FUNC_ON_GLOBAL_ACTOR_NODOT-DAG: Decl[Subscript]/CurrNominal:        [{#sync: Int#}][#Int#]; name=[sync: Int]
+// IN_FUNC_ON_GLOBAL_ACTOR_NODOT: End completions
+
+    let _ = otherInstanceOfMyClass.#^IN_FUNC_ON_GLOBAL_ACTOR_OTHER_DOT?check=IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT^#
+    let _ = otherInstanceOfMyClass#^IN_FUNC_ON_GLOBAL_ACTOR_OTHER_NODOT?check=IN_FUNC_ON_GLOBAL_ACTOR_NODOT^#
+  }
+
+  func testInSyncFunc() {
+    let _ = #^IN_SYNC_FUNC^#
+// IN_SYNC_FUNC: Begin completions
+// IN_SYNC_FUNC_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended:   funcOnGlobalActor()[' async'][#Int#]; name=funcOnGlobalActor()
+// IN_SYNC_FUNC_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: funcOnOtherGlobalActor()[' async'][#Int#]; name=funcOnOtherGlobalActor() async
+// IN_SYNC_FUNC_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   funcSync()[#Int#]; name=funcSync()
+// IN_SYNC_FUNC_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended:   nonSenableFuncOnGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnGlobalActor(arg: MyNonSendable)
+// IN_SYNC_FUNC_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: nonSenableFuncOnOtherGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnOtherGlobalActor(arg: MyNonSendable) async
+// IN_SYNC_FUNC_DOT-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended:      varOnGlobalActor[#Int#][' async']; name=varOnGlobalActor
+// IN_SYNC_FUNC_DOT-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended: varOnOtherGlobalActor[#Int#][' async']; name=varOnOtherGlobalActor async
+// IN_SYNC_FUNC_DOT-DAG: Decl[InstanceVar]/CurrNominal:      varSync[#Int#]; name=varSync
+// IN_SYNC_FUNC: End completions
+
+    let _ = self.#^IN_SYNC_FUNC_SELF_DOT^#
+// IN_SYNC_FUNC_SELF_DOT: Begin completions
+// IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended:   funcOnGlobalActor()[' async'][#Int#]; name=funcOnGlobalActor()
+// IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: funcOnOtherGlobalActor()[' async'][#Int#]; name=funcOnOtherGlobalActor() async
+// IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal:   funcSync()[#Int#]; name=funcSync()
+// IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended:   nonSenableFuncOnGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnGlobalActor(arg: MyNonSendable)
+// IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: nonSenableFuncOnOtherGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnOtherGlobalActor(arg: MyNonSendable) async
+// IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended:      varOnGlobalActor[#Int#][' async']; name=varOnGlobalActor
+// IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended: varOnOtherGlobalActor[#Int#][' async']; name=varOnOtherGlobalActor async
+// IN_SYNC_FUNC_SELF_DOT-DAG: Decl[InstanceVar]/CurrNominal:      varSync[#Int#]; name=varSync
+// IN_SYNC_FUNC_SELF_DOT: End completions
+
+    let _ = self#^IN_SYNC_FUNC_NODOT^#
+// IN_SYNC_FUNC_NODOT: Begin completions
+// IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended:   .funcOnGlobalActor()[' async'][#Int#]; name=funcOnGlobalActor()
+// IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: .funcOnOtherGlobalActor()[' async'][#Int#]; name=funcOnOtherGlobalActor() async
+// IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceMethod]/CurrNominal:   .funcSync()[#Int#]; name=funcSync()
+// IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended:   .nonSenableFuncOnGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnGlobalActor(arg: MyNonSendable)
+// IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: .nonSenableFuncOnOtherGlobalActor({#arg: MyNonSendable#})[' async'][#Int#]; name=nonSenableFuncOnOtherGlobalActor(arg: MyNonSendable) async
+// IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended:      .varOnGlobalActor[#Int#][' async']; name=varOnGlobalActor
+// IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended: .varOnOtherGlobalActor[#Int#][' async']; name=varOnOtherGlobalActor async
+// IN_SYNC_FUNC_NODOT-DAG: Decl[InstanceVar]/CurrNominal:      .varSync[#Int#]; name=varSync
+// IN_SYNC_FUNC_NODOT-DAG: Decl[Subscript]/CurrNominal/NotRecommended:        [{#onGlobalActor: Int#}][' async'][#Int#]; name=[onGlobalActor: Int]
+// IN_SYNC_FUNC_NODOT-DAG: Decl[Subscript]/CurrNominal/NotRecommended: [{#onOtherGlobalActor: Int#}][' async'][#Int#]; name=[onOtherGlobalActor: Int] async
+// IN_SYNC_FUNC_NODOT-DAG: Decl[Subscript]/CurrNominal:        [{#sync: Int#}][#Int#]; name=[sync: Int]
+// IN_SYNC_FUNC_NODOT: End completions
+
+    let _ = otherInstanceOfMyClass.#^IN_SYNC_FUNC_OTHER_DOT?check=IN_SYNC_FUNC_SELF_DOT^#
+    let _ = otherInstanceOfMyClass#^IN_SYNC_FUNC_OTHER_NODOT?check=IN_SYNC_FUNC_NODOT^#
+  }
+
+  func testInGlobalActorClosure() {
+    _ = { @MyGlobalActor () -> Void in
+      let _ = otherInstanceOfMyClass.#^IN_CLOSURE_ON_GLOBAL_ACTOR_OTHER_DOT?check=IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT^#
+    }
+  }
+
+  func testInGlobalActorClosureWithoutExplicitAttribute() {
+    let callback: @MyGlobalActor () -> Void
+    callback = {
+      let _ = otherInstanceOfMyClass.#^IN_CLOSURE_ON_GLOBAL_ACTOR_WITHOUT_EXPLICIT_LABEL_OTHER_DOT?check=IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT^#
+    }
+  }
+
+  @MyGlobalActor func testInClosureInGlobalActorFunc() {
+    _ = { () -> Void in
+      let _ = otherInstanceOfMyClass.#^IN_CLOSURE_IN_FUNC_ON_GLOBAL_ACTOR_OTHER_DOT?check=IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT^#
+    }
+  }
+
+  func testInClosureNestedInClosureOnGlobalActorFunc() {
+    _ = { @MyGlobalActor () -> Void in
+      _ = { () -> Void in
+        let _ = otherInstanceOfMyClass.#^IN_CLOSURE_NESTED_IN_CLOSURE_ON_GLOBAL_ACTOR_OTHER_DOT?check=IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT^#
+      }
+    }
+  }
+
+  func testInLocalFunc() {
+    @MyGlobalActor func localFunc() {
+      let _ = otherInstanceOfMyClass.#^IN_LOCAL_FUNC_ON_GLOBAL_ACTOR_OTHER_DOT?check=IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT^#
+    }
+  }
+
+  @MyGlobalActor func testInNestedSingleExpressionClosure() {
+    takeClosure {
+      takeClosure {
+        otherInstanceOfMyClass.#^IN_NESTED_SINGLE_EXPRESSION_CLOSURE_ON_GLBOAL_ACTOR_OTHER_DOT?check=IN_FUNC_ON_GLOBAL_ACTOR_SELF_DOT^#
+      }
+    }
+  }
+}
+
+actor ActorTests {
+  func testInActor() {
+    let _ = otherInstanceOfMyClass.#^IN_ACTOR_OTHER_DOT?check=IN_SYNC_FUNC_SELF_DOT^#
+    let _ = otherInstanceOfMyClass#^IN_ACTOR_OTHER_NODOT?check=IN_SYNC_FUNC_NODOT^#
+  }
+}


### PR DESCRIPTION
* **Explanation**: Annotate cross-actor references to global actors as `async` and mark them as not-recommended if they must be executed on a different actor than the current context is on.
* **Scope**: Code completion of functions marked as executing on a global actor
* **Risk**: Fairly low
* **Testing**: Added regression tests
* **Issue**: rdar://75902598
* **Reviewer**: @rintaro (Rintaro Ishizaki) on original PR #37711