### PR TITLE
[Swift-next] Update filesystem API usage

### DIFF
--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -2166,7 +2166,7 @@ void SwiftDeclCollector::deSerialize(StringRef Filename) {
 // Serialize the content of all roots to a given file using JSON format.
 void SwiftDeclCollector::serialize(StringRef Filename, SDKNode *Root) {
   std::error_code EC;
-  llvm::raw_fd_ostream fs(Filename, EC, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream fs(Filename, EC, llvm::sys::fs::OF_None);
   json::Output yout(fs);
   yout << Root;
 }
@@ -2259,7 +2259,7 @@ int swift::ide::api::dumpSDKContent(const CompilerInvocation &InitInvok,
 int swift::ide::api::deserializeSDKDump(StringRef dumpPath, StringRef OutputPath,
     CheckerOptions Opts) {
   std::error_code EC;
-  llvm::raw_fd_ostream FS(OutputPath, EC, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream FS(OutputPath, EC, llvm::sys::fs::OF_None);
   if (!fs::exists(dumpPath)) {
     llvm::errs() << dumpPath << " does not exist\n";
     return 1;

--- a/lib/Basic/FileSystem.cpp
+++ b/lib/Basic/FileSystem.cpp
@@ -146,7 +146,7 @@ std::error_code swift::atomicallyWritingToFile(
 
     if (!OS.hasValue()) {
       std::error_code error;
-      OS.emplace(outputPath, error, fs::F_None);
+      OS.emplace(outputPath, error, fs::OF_None);
       if (error) {
         return error;
       }

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -251,7 +251,7 @@ public:
     SmallString<256> Path(Dirname);
     llvm::sys::path::append(Path, Filename);
     std::error_code EC;
-    raw_fd_ostream Stream(Path, EC, fs::F_Append | fs::F_Text);
+    raw_fd_ostream Stream(Path, EC, fs::OF_Append | fs::OF_Text);
     if (EC) {
       llvm::errs() << "Error opening profile file '"
                    << Path << "' for writing\n";
@@ -688,7 +688,7 @@ UnifiedStatsReporter::~UnifiedStatsReporter()
   }
 
   std::error_code EC;
-  raw_fd_ostream ostream(StatsFilename, EC, fs::F_Append | fs::F_Text);
+  raw_fd_ostream ostream(StatsFilename, EC, fs::OF_Append | fs::OF_Text);
   if (EC) {
     llvm::errs() << "Error opening -stats-output-dir file '"
                  << StatsFilename << "' for writing\n";
@@ -726,7 +726,7 @@ UnifiedStatsReporter::flushTracesAndProfiles() {
 
   if (FrontendStatsEvents && SourceMgr) {
     std::error_code EC;
-    raw_fd_ostream tstream(TraceFilename, EC, fs::F_Append | fs::F_Text);
+    raw_fd_ostream tstream(TraceFilename, EC, fs::OF_Append | fs::OF_Text);
     if (EC) {
       llvm::errs() << "Error opening -trace-stats-events file '"
                    << TraceFilename << "' for writing\n";

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1140,7 +1140,7 @@ bool swift::dependencies::scanDependencies(CompilerInstance &instance) {
   const FrontendOptions &opts = instance.getInvocation().getFrontendOptions();
   std::string path = opts.InputsAndOutputs.getSingleOutputFilename();
   std::error_code EC;
-  llvm::raw_fd_ostream out(path, EC, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream out(path, EC, llvm::sys::fs::OF_None);
   if (out.has_error() || EC) {
     Context.Diags.diagnose(SourceLoc(), diag::error_opening_output, path,
                            EC.message());
@@ -1182,7 +1182,7 @@ bool swift::dependencies::prescanDependencies(CompilerInstance &instance) {
   const FrontendOptions &opts = instance.getInvocation().getFrontendOptions();
   std::string path = opts.InputsAndOutputs.getSingleOutputFilename();
   std::error_code EC;
-  llvm::raw_fd_ostream out(path, EC, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream out(path, EC, llvm::sys::fs::OF_None);
   // `-scan-dependencies` invocations use a single new instance
   // of a module cache
   ModuleDependenciesCache cache;
@@ -1232,7 +1232,7 @@ bool swift::dependencies::batchScanDependencies(
   for (; ientries != batchInput->end() and iresults != batchScanResults.end();
        ++ientries, ++iresults) {
     std::error_code EC;
-    llvm::raw_fd_ostream out((*ientries).outputPath, EC, llvm::sys::fs::F_None);
+    llvm::raw_fd_ostream out((*ientries).outputPath, EC, llvm::sys::fs::OF_None);
     if ((*iresults).getError())
       return true;
 
@@ -1264,7 +1264,7 @@ bool swift::dependencies::batchPrescanDependencies(
        ientries != batchInput->end() and iresults != batchPrescanResults.end();
        ++ientries, ++iresults) {
     std::error_code EC;
-    llvm::raw_fd_ostream out((*ientries).outputPath, EC, llvm::sys::fs::F_None);
+    llvm::raw_fd_ostream out((*ientries).outputPath, EC, llvm::sys::fs::OF_None);
     if ((*iresults).getError())
       return true;
 

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -1614,7 +1614,7 @@ static void writeCompilationRecord(StringRef path, StringRef argsHash,
   llvm::sys::fs::rename(path, path + "~");
 
   std::error_code error;
-  llvm::raw_fd_ostream out(path, error, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream out(path, error, llvm::sys::fs::OF_None);
   if (out.has_error()) {
     // FIXME: How should we report this error?
     out.clear_error();
@@ -1718,7 +1718,7 @@ static bool writeFilelistIfNecessary(const Job *job, const ArgList &args,
       return true;
 
     std::error_code error;
-    llvm::raw_fd_ostream out(filelistInfo.path, error, llvm::sys::fs::F_None);
+    llvm::raw_fd_ostream out(filelistInfo.path, error, llvm::sys::fs::OF_None);
     if (out.has_error()) {
       out.clear_error();
       diags.diagnose(SourceLoc(), diag::error_unable_to_make_temporary_file,
@@ -1826,7 +1826,7 @@ Compilation::Result Compilation::performSingleCommand(const Job *Cmd) {
 static bool writeAllSourcesFile(DiagnosticEngine &diags, StringRef path,
                                 ArrayRef<InputPair> inputFiles) {
   std::error_code error;
-  llvm::raw_fd_ostream out(path, error, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream out(path, error, llvm::sys::fs::OF_None);
   if (out.has_error()) {
     out.clear_error();
     diags.diagnose(SourceLoc(), diag::error_unable_to_make_temporary_file,
@@ -1923,7 +1923,7 @@ void Compilation::addDependencyPathOrCreateDummy(
   } else if (!depPath.empty()) {
     // Create dummy empty file
     std::error_code EC;
-    llvm::raw_fd_ostream(depPath, EC, llvm::sys::fs::F_None);
+    llvm::raw_fd_ostream(depPath, EC, llvm::sys::fs::OF_None);
   }
 }
 

--- a/lib/Driver/Job.cpp
+++ b/lib/Driver/Job.cpp
@@ -464,7 +464,7 @@ void Job::printSummary(raw_ostream &os) const {
 bool Job::writeArgsToResponseFile() const {
   assert(hasResponseFile());
   std::error_code EC;
-  llvm::raw_fd_ostream OS(ResponseFile->path, EC, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream OS(ResponseFile->path, EC, llvm::sys::fs::OF_None);
   if (EC) {
     return true;
   }

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -209,7 +209,7 @@ static void autoApplyFixes(SourceManager &SM, unsigned BufferID,
 
   std::error_code error;
   llvm::raw_fd_ostream outs(memBuffer->getBufferIdentifier(), error,
-                            llvm::sys::fs::OpenFlags::F_None);
+                            llvm::sys::fs::OpenFlags::OF_None);
   if (!error)
     outs << Result;
 }

--- a/lib/Frontend/SerializedDiagnosticConsumer.cpp
+++ b/lib/Frontend/SerializedDiagnosticConsumer.cpp
@@ -133,7 +133,7 @@ public:
     std::error_code EC;
     std::unique_ptr<llvm::raw_fd_ostream> OS;
     OS.reset(new llvm::raw_fd_ostream(State->SerializedDiagnosticsPath, EC,
-                                      llvm::sys::fs::F_None));
+                                      llvm::sys::fs::OF_None));
     if (EC) {
       // Create a temporary diagnostics engine to print the error to stderr.
       SourceManager dummyMgr;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -127,7 +127,7 @@ static std::unique_ptr<llvm::raw_fd_ostream>
 getFileOutputStream(StringRef OutputFilename, ASTContext &Ctx) {
   std::error_code errorCode;
   auto os = std::make_unique<llvm::raw_fd_ostream>(
-              OutputFilename, errorCode, llvm::sys::fs::F_None);
+              OutputFilename, errorCode, llvm::sys::fs::OF_None);
   if (errorCode) {
     Ctx.Diags.diagnose(SourceLoc(), diag::error_opening_output,
                        OutputFilename, errorCode.message());
@@ -249,7 +249,7 @@ private:
     std::unique_ptr<llvm::raw_fd_ostream> OS;
     OS.reset(new llvm::raw_fd_ostream(FixitsOutputPath,
                                       EC,
-                                      llvm::sys::fs::F_None));
+                                      llvm::sys::fs::OF_None));
     if (EC) {
       // Create a temporary diagnostics engine to print the error to stderr.
       SourceManager dummyMgr;
@@ -718,7 +718,7 @@ static bool writeLdAddCFileIfNeeded(CompilerInstance &Instance) {
   auto ldSymbols =
       getPublicSymbols(TBDGenDescriptor::forModule(module, tbdOpts));
   std::error_code EC;
-  llvm::raw_fd_ostream OS(Path, EC, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream OS(Path, EC, llvm::sys::fs::OF_None);
   if (EC) {
     Instance.getDiags().diagnose(SourceLoc(), diag::error_opening_output, Path,
                                  EC.message());
@@ -1062,7 +1062,7 @@ static bool printSwiftFeature(CompilerInstance &instance) {
   const FrontendOptions &opts = invocation.getFrontendOptions();
   std::string path = opts.InputsAndOutputs.getSingleOutputFilename();
   std::error_code EC;
-  llvm::raw_fd_ostream out(path, EC, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream out(path, EC, llvm::sys::fs::OF_None);
 
   if (out.has_error() || EC) {
     context.Diags.diagnose(SourceLoc(), diag::error_opening_output, path,

--- a/lib/FrontendTool/ImportedModules.cpp
+++ b/lib/FrontendTool/ImportedModules.cpp
@@ -47,7 +47,7 @@ bool swift::emitImportedModules(ModuleDecl *mainModule,
   auto &Context = mainModule->getASTContext();
   std::string path = opts.InputsAndOutputs.getSingleOutputFilename();
   std::error_code EC;
-  llvm::raw_fd_ostream out(path, EC, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream out(path, EC, llvm::sys::fs::OF_None);
 
   if (out.has_error() || EC) {
     Context.Diags.diagnose(SourceLoc(), diag::error_opening_output, path,

--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -707,7 +707,7 @@ bool swift::emitLoadedModuleTraceIfNeeded(ModuleDecl *mainModule,
   if (loadedModuleTracePath.empty())
     return false;
   std::error_code EC;
-  llvm::raw_fd_ostream out(loadedModuleTracePath, EC, llvm::sys::fs::F_Append);
+  llvm::raw_fd_ostream out(loadedModuleTracePath, EC, llvm::sys::fs::OF_Append);
 
   if (out.has_error() || EC) {
     ctxt.Diags.diagnose(SourceLoc(), diag::error_opening_output,

--- a/lib/FrontendTool/MakeStyleDependencies.cpp
+++ b/lib/FrontendTool/MakeStyleDependencies.cpp
@@ -97,7 +97,7 @@ bool swift::emitMakeDependenciesIfNeeded(DiagnosticEngine &diags,
     return false;
 
   std::error_code EC;
-  llvm::raw_fd_ostream out(dependenciesFilePath, EC, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream out(dependenciesFilePath, EC, llvm::sys::fs::OF_None);
 
   if (out.has_error() || EC) {
     diags.diagnose(SourceLoc(), diag::error_opening_output,

--- a/lib/FrontendTool/TBD.cpp
+++ b/lib/FrontendTool/TBD.cpp
@@ -44,7 +44,7 @@ static std::vector<StringRef> sortSymbols(llvm::StringSet<> &symbols) {
 bool swift::writeTBD(ModuleDecl *M, StringRef OutputFilename,
                      const TBDGenOptions &Opts) {
   std::error_code EC;
-  llvm::raw_fd_ostream OS(OutputFilename, EC, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream OS(OutputFilename, EC, llvm::sys::fs::OF_None);
   if (EC) {
     M->getASTContext().Diags.diagnose(SourceLoc(), diag::error_opening_output,
                                       OutputFilename, EC.message());

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -526,7 +526,7 @@ bool swift::performLLVM(const IRGenOptions &Opts,
   if (!OutputFilename.empty()) {
     // Try to open the output file.  Clobbering an existing file is fine.
     // Open in binary mode if we're doing binary output.
-    llvm::sys::fs::OpenFlags OSFlags = llvm::sys::fs::F_None;
+    llvm::sys::fs::OpenFlags OSFlags = llvm::sys::fs::OF_None;
     std::error_code EC;
     RawOS.emplace(OutputFilename, EC, OSFlags);
 

--- a/lib/Localization/LocalizationFormat.cpp
+++ b/lib/Localization/LocalizationFormat.cpp
@@ -76,7 +76,7 @@ void SerializedLocalizationWriter::insert(swift::DiagID id,
 bool SerializedLocalizationWriter::emit(llvm::StringRef filePath) {
   assert(llvm::sys::path::extension(filePath) == ".db");
   std::error_code error;
-  llvm::raw_fd_ostream OS(filePath, error, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream OS(filePath, error, llvm::sys::fs::OF_None);
   if (OS.has_error()) {
     return true;
   }

--- a/lib/Migrator/MigrationState.cpp
+++ b/lib/Migrator/MigrationState.cpp
@@ -35,7 +35,7 @@ std::string MigrationState::getOutputText() const {
 static bool quickDumpText(StringRef OutFilename, StringRef Text) {
   std::error_code Error;
   llvm::raw_fd_ostream FileOS(OutFilename,
-                              Error, llvm::sys::fs::F_Text);
+                              Error, llvm::sys::fs::OF_Text);
   if (FileOS.has_error()) {
     return true;
   }

--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -385,7 +385,7 @@ bool Migrator::emitRemap() const {
 
   std::error_code Error;
   llvm::raw_fd_ostream FileOS(RemapPath,
-                              Error, llvm::sys::fs::F_Text);
+                              Error, llvm::sys::fs::OF_Text);
   if (FileOS.has_error()) {
     return true;
   }
@@ -406,7 +406,7 @@ bool Migrator::emitMigratedFile() const {
 
   std::error_code Error;
   llvm::raw_fd_ostream FileOS(OutFilename,
-                              Error, llvm::sys::fs::F_Text);
+                              Error, llvm::sys::fs::OF_Text);
   if (FileOS.has_error()) {
     return true;
   }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2620,7 +2620,7 @@ void SILFunction::dump() const {
 
 void SILFunction::dump(const char *FileName) const {
   std::error_code EC;
-  llvm::raw_fd_ostream os(FileName, EC, llvm::sys::fs::OpenFlags::F_None);
+  llvm::raw_fd_ostream os(FileName, EC, llvm::sys::fs::OpenFlags::OF_None);
   print(os);
 }
 
@@ -2869,7 +2869,7 @@ void SILModule::dump(bool Verbose) const {
 void SILModule::dump(const char *FileName, bool Verbose,
                      bool PrintASTDecls) const {
   std::error_code EC;
-  llvm::raw_fd_ostream os(FileName, EC, llvm::sys::fs::OpenFlags::F_None);
+  llvm::raw_fd_ostream os(FileName, EC, llvm::sys::fs::OpenFlags::OF_None);
   SILPrintContext Ctx(os, Verbose);
   print(Ctx, getSwiftModule(), PrintASTDecls);
 }

--- a/lib/SIL/Utils/SILRemarkStreamer.cpp
+++ b/lib/SIL/Utils/SILRemarkStreamer.cpp
@@ -60,7 +60,7 @@ SILRemarkStreamer::create(SILModule &silModule) {
   auto &diagEngine = silModule.getASTContext().Diags;
   std::error_code errorCode;
   auto file = std::make_unique<llvm::raw_fd_ostream>(filename, errorCode,
-                                                     llvm::sys::fs::F_None);
+                                                     llvm::sys::fs::OF_None);
   if (errorCode) {
     diagEngine.diagnose(SourceLoc(), diag::cannot_open_file, filename,
                         errorCode.message());

--- a/lib/SILOptimizer/Analysis/CallerAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/CallerAnalysis.cpp
@@ -447,7 +447,7 @@ void CallerAnalysis::dump() const { print(llvm::errs()); }
 void CallerAnalysis::print(const char *filePath) const {
   using namespace llvm::sys;
   std::error_code error;
-  llvm::raw_fd_ostream fileOutputStream(filePath, error, fs::F_Text);
+  llvm::raw_fd_ostream fileOutputStream(filePath, error, fs::OF_Text);
   if (error) {
     llvm::errs() << "Failed to open path \"" << filePath << "\" for writing.!";
     llvm_unreachable("default error handler");

--- a/lib/SILOptimizer/UtilityPasses/SILDebugInfoGenerator.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SILDebugInfoGenerator.cpp
@@ -114,7 +114,7 @@ class SILDebugInfoGenerator : public SILModuleTransform {
 
       std::error_code EC;
       llvm::raw_fd_ostream OutFile(FileName, EC,
-                                   llvm::sys::fs::OpenFlags::F_None);
+                                   llvm::sys::fs::OpenFlags::OF_None);
       assert(!OutFile.has_error() && !EC && "Can't write SIL debug file");
 
       PrintContext Ctx(OutFile);

--- a/lib/SILOptimizer/Utils/OptimizerStatsUtils.cpp
+++ b/lib/SILOptimizer/Utils/OptimizerStatsUtils.cpp
@@ -558,7 +558,7 @@ llvm::raw_ostream &stats_os() {
       // Try to open the file.
       std::error_code EC;
       auto fd_stream = std::make_unique<llvm::raw_fd_ostream>(
-          SILStatsOutputFile, EC, llvm::sys::fs::OpenFlags::F_Text);
+          SILStatsOutputFile, EC, llvm::sys::fs::OpenFlags::OF_Text);
       if (!fd_stream->has_error() && !EC) {
         stats_output_stream = {fd_stream.release(),
                                [](llvm::raw_ostream *d) { delete d; }};

--- a/tools/driver/autolink_extract_main.cpp
+++ b/tools/driver/autolink_extract_main.cpp
@@ -223,7 +223,7 @@ int autolink_extract_main(ArrayRef<const char *> Args, const char *Argv0,
 
   std::string OutputFilename = Invocation.getOutputFilename();
   std::error_code EC;
-  llvm::raw_fd_ostream OutOS(OutputFilename, EC, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream OutOS(OutputFilename, EC, llvm::sys::fs::OF_None);
   if (OutOS.has_error() || EC) {
     Instance.getDiags().diagnose(SourceLoc(), diag::error_opening_output,
                                  OutputFilename, EC.message());

--- a/tools/driver/swift_api_digester_main.cpp
+++ b/tools/driver/swift_api_digester_main.cpp
@@ -2183,7 +2183,7 @@ static int diagnoseModuleChange(SDKContext &Ctx, SDKNodeRoot *LeftModule,
   std::unique_ptr<llvm::raw_ostream> FileOS;
   if (!OutputPath.empty()) {
     std::error_code EC;
-    FileOS.reset(new llvm::raw_fd_ostream(OutputPath, EC, llvm::sys::fs::F_None));
+    FileOS.reset(new llvm::raw_fd_ostream(OutputPath, EC, llvm::sys::fs::OF_None));
     OS = FileOS.get();
   }
   bool FailOnError;
@@ -2328,7 +2328,7 @@ static int generateMigrationScript(StringRef LeftPath, StringRef RightPath,
 
   auto &typeMemberDiffs = Ctx.getTypeMemberDiffs();
   std::error_code EC;
-  llvm::raw_fd_ostream Fs(DiffPath, EC, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream Fs(DiffPath, EC, llvm::sys::fs::OF_None);
   removeRedundantAndSort(AllItems);
   removeRedundantAndSort(typeMemberDiffs);
   removeRedundantAndSort(AllNoEscapingFuncs);
@@ -2374,7 +2374,7 @@ static int deserializeDiffItems(APIDiffItemStore &Store, StringRef DiffPath,
     StringRef OutputPath) {
   Store.addStorePath(DiffPath);
   std::error_code EC;
-  llvm::raw_fd_ostream FS(OutputPath, EC, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream FS(OutputPath, EC, llvm::sys::fs::OF_None);
   APIDiffItemStore::serialize(FS, Store.getAllDiffItems());
   return 0;
 }
@@ -2382,7 +2382,7 @@ static int deserializeDiffItems(APIDiffItemStore &Store, StringRef DiffPath,
 static int deserializeNameCorrection(APIDiffItemStore &Store,
                                      StringRef OutputPath) {
   std::error_code EC;
-  llvm::raw_fd_ostream FS(OutputPath, EC, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream FS(OutputPath, EC, llvm::sys::fs::OF_None);
   std::set<NameCorrectionInfo> Result;
   for (auto *Item: Store.getAllDiffItems()) {
     if (auto *CI = dyn_cast<CommonDiffItem>(Item)) {

--- a/tools/driver/swift_indent_main.cpp
+++ b/tools/driver/swift_indent_main.cpp
@@ -220,7 +220,7 @@ public:
         Destination = Filename;
       else
         Destination = OutputFilename;
-      llvm::raw_fd_ostream out(Destination, EC, llvm::sys::fs::F_None);
+      llvm::raw_fd_ostream out(Destination, EC, llvm::sys::fs::OF_None);
       if (out.has_error() || EC) {
         Diags.diagnose(SourceLoc(), diag::error_opening_output, Filename,
                        EC.message());

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -356,7 +356,7 @@ int main(int argc, char **argv) {
       SILMod->print(llvm::outs(), CI.getMainModule(), SILOpts, !DisableASTDump);
     } else {
       std::error_code EC;
-      llvm::raw_fd_ostream OS(OutputFile, EC, llvm::sys::fs::F_None);
+      llvm::raw_fd_ostream OS(OutputFile, EC, llvm::sys::fs::OF_None);
       if (EC) {
         llvm::errs() << "while opening '" << OutputFile << "': " << EC.message()
                      << '\n';

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -179,7 +179,7 @@ int main(int argc, char **argv) {
     return 1;
 
   std::error_code EC;
-  llvm::raw_fd_ostream outStream(OutputFilename, EC, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream outStream(OutputFilename, EC, llvm::sys::fs::OF_None);
   if (outStream.has_error() || EC) {
     CI.getDiags().diagnose(SourceLoc(), diag::error_opening_output,
                            OutputFilename, EC.message());

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -601,7 +601,7 @@ int main(int argc, char **argv) {
       SILMod->print(llvm::outs(), CI.getMainModule(), SILOpts, !DisableASTDump);
     } else {
       std::error_code EC;
-      llvm::raw_fd_ostream OS(OutputFile, EC, llvm::sys::fs::F_None);
+      llvm::raw_fd_ostream OS(OutputFile, EC, llvm::sys::fs::OF_None);
       if (EC) {
         llvm::errs() << "while opening '" << OutputFile << "': "
                      << EC.message() << '\n';

--- a/tools/swift-def-to-yaml-converter/swift-def-to-yaml-converter.cpp
+++ b/tools/swift-def-to-yaml-converter/swift-def-to-yaml-converter.cpp
@@ -83,7 +83,7 @@ int main(int argc, char *argv[]) {
 
   std::error_code error;
   llvm::raw_fd_ostream OS(LocalizedFilePath.str(), error,
-                          llvm::sys::fs::F_None);
+                          llvm::sys::fs::OF_None);
 
   if (OS.has_error() || error) {
     llvm::errs() << "Error has occurred while trying to write to "

--- a/tools/swift-llvm-opt/LLVMOpt.cpp
+++ b/tools/swift-llvm-opt/LLVMOpt.cpp
@@ -283,7 +283,7 @@ int main(int argc, char **argv) {
 
   std::error_code EC;
   Out.reset(
-      new llvm::ToolOutputFile(OutputFilename, EC, llvm::sys::fs::F_None));
+      new llvm::ToolOutputFile(OutputFilename, EC, llvm::sys::fs::OF_None));
   if (EC) {
     llvm::errs() << EC.message() << '\n';
     return 1;

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -724,7 +724,7 @@ int doSerializeRawTree(const char *MainExecutablePath,
     if (!options::OutputFilename.empty()) {
       std::error_code errorCode;
       llvm::raw_fd_ostream os(options::OutputFilename, errorCode,
-                              llvm::sys::fs::F_None);
+                              llvm::sys::fs::OF_None);
       assert(!errorCode && "Couldn't open output file");
       swift::json::Output out(os);
       out << *Root;
@@ -738,7 +738,7 @@ int doSerializeRawTree(const char *MainExecutablePath,
     if (!options::DiagsOutputFilename.empty()) {
       std::error_code errorCode;
       llvm::raw_fd_ostream os(options::DiagsOutputFilename, errorCode,
-                              llvm::sys::fs::F_None);
+                              llvm::sys::fs::OF_None);
       if (errorCode) {
         llvm::errs() << "error opening file '" << options::DiagsOutputFilename
           << "': " << errorCode.message() << '\n';
@@ -762,7 +762,7 @@ int doDeserializeRawTree(const char *MainExecutablePath,
   auto Buffer = llvm::MemoryBuffer::getFile(InputFile);
   std::error_code errorCode;
   auto os = std::make_unique<llvm::raw_fd_ostream>(
-              OutputFileName, errorCode, llvm::sys::fs::F_None);
+              OutputFileName, errorCode, llvm::sys::fs::OF_None);
   swift::json::SyntaxDeserializer deserializer(llvm::MemoryBufferRef(*(Buffer.get())));
   deserializer.getSourceFileSyntax()->print(*os);
 

--- a/unittests/Basic/FileSystemTest.cpp
+++ b/unittests/Basic/FileSystemTest.cpp
@@ -39,7 +39,7 @@ TEST(FileSystem, MoveFileIfDifferentEmpty) {
   path::append(sourceFile, "source.txt");
   {
     std::error_code error;
-    llvm::raw_fd_ostream emptyOut(sourceFile, error, fs::F_None);
+    llvm::raw_fd_ostream emptyOut(sourceFile, error, fs::OF_None);
     ASSERT_NO_ERROR(error);
   }
 
@@ -63,7 +63,7 @@ TEST(FileSystem, MoveFileIfDifferentEmpty) {
   // Test 2: Move empty over empty.
   {
     std::error_code error;
-    llvm::raw_fd_ostream emptyOut(destFile, error, fs::F_None);
+    llvm::raw_fd_ostream emptyOut(destFile, error, fs::OF_None);
     ASSERT_NO_ERROR(error);
   }
 
@@ -84,7 +84,7 @@ TEST(FileSystem, MoveFileIfDifferentEmpty) {
   // Test 3: Move empty over non-empty.
   {
     std::error_code error;
-    llvm::raw_fd_ostream nonEmptyOut(destFile, error, fs::F_None);
+    llvm::raw_fd_ostream nonEmptyOut(destFile, error, fs::OF_None);
     ASSERT_NO_ERROR(error);
     nonEmptyOut << "a";
   }
@@ -123,7 +123,7 @@ TEST(FileSystem, MoveFileIfDifferentNonEmpty) {
   path::append(sourceFile, "source.txt");
   {
     std::error_code error;
-    llvm::raw_fd_ostream sourceOut(sourceFile, error, fs::F_None);
+    llvm::raw_fd_ostream sourceOut(sourceFile, error, fs::OF_None);
     sourceOut << "original";
     ASSERT_NO_ERROR(error);
   }
@@ -148,7 +148,7 @@ TEST(FileSystem, MoveFileIfDifferentNonEmpty) {
   // Test 2: Move source over empty.
   {
     std::error_code error;
-    llvm::raw_fd_ostream emptyOut(destFile, error, fs::F_None);
+    llvm::raw_fd_ostream emptyOut(destFile, error, fs::OF_None);
     ASSERT_NO_ERROR(error);
   }
 
@@ -168,7 +168,7 @@ TEST(FileSystem, MoveFileIfDifferentNonEmpty) {
   // Test 3: Move source over non-empty-but-different.
   {
     std::error_code error;
-    llvm::raw_fd_ostream nonEmptyOut(destFile, error, fs::F_None);
+    llvm::raw_fd_ostream nonEmptyOut(destFile, error, fs::OF_None);
     ASSERT_NO_ERROR(error);
     nonEmptyOut << "different";
   }
@@ -188,7 +188,7 @@ TEST(FileSystem, MoveFileIfDifferentNonEmpty) {
   // Test 4: Move source over identical.
   {
     std::error_code error;
-    llvm::raw_fd_ostream nonEmptyOut(destFile, error, fs::F_None);
+    llvm::raw_fd_ostream nonEmptyOut(destFile, error, fs::OF_None);
     ASSERT_NO_ERROR(error);
     nonEmptyOut << "original";
   }
@@ -233,7 +233,7 @@ TEST(FileSystem, MoveFileIfDifferentNonExistent) {
 
   {
     std::error_code error;
-    llvm::raw_fd_ostream emptyOut(destFile, error, fs::F_None);
+    llvm::raw_fd_ostream emptyOut(destFile, error, fs::OF_None);
     ASSERT_NO_ERROR(error);
   }
 
@@ -254,7 +254,7 @@ TEST(FileSystem, MoveFileIfDifferentInvalid) {
   path::append(sourceFile, "source.txt");
   {
     std::error_code error;
-    llvm::raw_fd_ostream emptyOut(sourceFile, error, fs::F_None);
+    llvm::raw_fd_ostream emptyOut(sourceFile, error, fs::OF_None);
     ASSERT_NO_ERROR(error);
   }
 

--- a/unittests/Localization/LocalizationTest.h
+++ b/unittests/Localization/LocalizationTest.h
@@ -87,7 +87,7 @@ public:
 protected:
   static bool convertDefIntoYAML(std::string outputPath) {
     std::error_code error;
-    llvm::raw_fd_ostream OS(outputPath, error, llvm::sys::fs::F_None);
+    llvm::raw_fd_ostream OS(outputPath, error, llvm::sys::fs::OF_None);
     if (OS.has_error() || error)
       return true;
 


### PR DESCRIPTION
Commit `3302af9d4c39642bebe64dd60a3aa162fefc44b2` from llvm-project removed the compatibility `F_None` filesystem mode from the enum, so we have to update to `OF_None`.

Also have issues with F_Append and F_Text being updated to `OF_Append` and `OF_Text` respectively that were fixed in this patch.

rdar://79639268