### PR TITLE
Temporarily turn off async test for iphonesimulator-x86_64.

### DIFF
--- a/test/Concurrency/Runtime/async.swift
+++ b/test/Concurrency/Runtime/async.swift
@@ -7,6 +7,9 @@
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib
 
+// rdar://79670222 : This test fails on iphonesimulator-x86_64
+// UNSUPPORTED: OS=ios && CPU=x86_64
+
 import Dispatch
 import StdlibUnittest
 


### PR DESCRIPTION
This may be related to the workaround in PR #37939.
See also: rdar://79670222.