### PR TITLE
[5.5][Sema] Use different solution vectors for `ComponentStep`s created by `DependentComponentSplitterStep`

### DIFF
--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -294,6 +294,11 @@ class DependentComponentSplitterStep final : public SolverStep {
   /// Array containing all of the partial solutions for the parent split.
   MutableArrayRef<SmallVector<Solution, 4>> AllPartialSolutions;
 
+  /// The solutions computed the \c ComponentSteps created for each partial
+  /// solution combinations. Will be merged into the final \c Solutions vector
+  /// in \c resume.
+  std::vector<std::unique_ptr<SmallVector<Solution, 2>>> ContextualSolutions;
+
   /// Take all of the constraints in this component and put them into
   /// \c Constraints.
   void injectConstraints() {

--- a/validation-test/Sema/sr14692.swift
+++ b/validation-test/Sema/sr14692.swift
@@ -1,0 +1,28 @@
+// RUN: %target-typecheck-verify-swift
+
+enum Foo { case foo }
+enum Bar { case bar }
+
+@resultBuilder struct ViewBuilder2 {
+  static func buildBlock(_ content: MyView) -> MyView { fatalError() }
+  static func buildIf(_ content: MyView?) -> MyView { fatalError() }
+}
+
+func makeView(@ViewBuilder2 content: () -> MyView)  { fatalError() }
+
+struct MyView {
+  init() { fatalError() }
+  
+  func qadding(bar: Foo) -> MyView { fatalError() } // expected-note{{incorrect labels for candidate (have: '(_:)', expected: '(bar:)')}}
+  func qadding(foo: Foo) -> MyView  { fatalError() } // expected-note{{incorrect labels for candidate (have: '(_:)', expected: '(foo:)')}}
+}
+
+func testCase() {
+  let array: [Int]? = []
+
+  makeView() {
+    if array?.isEmpty == false {
+      MyView().qadding(.foo) // expected-error{{no exact matches in call to instance method 'qadding'}}
+    }
+  }
+ }


### PR DESCRIPTION
* **Explanation**: 
Currently all `ComponentSteps` created by `DependentComponentSplitterStep` share the same `Solutions` vector. Because of this, the `ComponentStep`s might modify solutions created by previous `ComponentStep`s. Use different `Solutions` vectors for each `ComponentStep` to avoid sharing information between the `ComponentStep`s.
For example, in the added test case the `qadding(bar:)` overload gets added to `Solutions`, it’s score gets reduced by its `ComponentStep` original score, then the `qadding(foo:)` overload gets added to `Solutions` and both solutions have their score decreased by the `OriginalScore` of `qadding(foo:)`’s `ComponentStep`, causing `qadding(bar:)`’s score to underflow.
* **Scope**: Result builder bodies where dependent expressions produce multiple solutions which need to be reconciled
* **Risk**: Low
* **Testing**: Added regression test
* **Issue**: rdar://78780840
* **Reviewer**: @xedin (Pavel Yaskevich) on original PR #37964