### PR TITLE
Temporarily turn off 2 ObjC related tests.

### DIFF
--- a/test/Interpreter/SDK/objc_bridge_cast.swift
+++ b/test/Interpreter/SDK/objc_bridge_cast.swift
@@ -3,6 +3,9 @@
 
 // REQUIRES: objc_interop
 
+// rdar://79672466 - This test fails on watchsimulator-i386
+// UNSUPPORTED: OS=watchos && CPU=i386
+
 // Test dynamic casts that bridge value types through the runtime.
 
 import Foundation

--- a/test/Interpreter/SDK/objc_dealloc.swift
+++ b/test/Interpreter/SDK/objc_dealloc.swift
@@ -3,6 +3,9 @@
 
 // REQUIRES: objc_interop
 
+// rdar://79672466 - This test fails for watchsimulator-i386
+// UNSUPPORTED: OS=watchos && CPU=i386
+
 import Foundation
 
 // Check that ObjC associated objects are cleaned up when attached to native


### PR DESCRIPTION
These are failing (rdar://79672466); temporarily mark
them unsupported to unblock PR testing.