### PR TITLE
[5.5] [Concurrency] Deprecate typealias PartialAsyncTask

### DIFF
--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -16,11 +16,7 @@ import Swift
 /// A unit of scheduleable work.
 ///
 /// Unless you're implementing a scheduler,
-/// you don't generally interact with partial tasks directly.
-@available(SwiftStdlib 5.5, *)
-public typealias PartialAsyncTask = UnownedJob
-
-/// A job is a unit of scheduleable work.
+/// you don't generally interact with jobs directly.
 @available(SwiftStdlib 5.5, *)
 @frozen
 public struct UnownedJob {

--- a/stdlib/public/Concurrency/SourceCompatibilityShims.swift
+++ b/stdlib/public/Concurrency/SourceCompatibilityShims.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2020 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -255,3 +255,7 @@ extension ThrowingTaskGroup {
 @available(SwiftStdlib 5.5, *)
 @available(*, deprecated, message: "please use UnsafeContination<..., Error>")
 public typealias UnsafeThrowingContinuation<T> = UnsafeContinuation<T, Error>
+
+@available(SwiftStdlib 5.5, *)
+@available(*, deprecated, renamed: "UnownedJob")
+public typealias PartialAsyncTask = UnownedJob

--- a/test/stdlib/Concurrency.swift
+++ b/test/stdlib/Concurrency.swift
@@ -7,6 +7,8 @@ import _Concurrency
 // Make sure the type shows up
 @available(SwiftStdlib 5.5, *)
 extension PartialAsyncTask {
+  // expected-warning@-1 {{'PartialAsyncTask' is deprecated: renamed to 'UnownedJob'}}
+  // expected-note@-2 {{use 'UnownedJob' instead}}
 }
 @available(SwiftStdlib 5.5, *)
 extension UnownedJob {


### PR DESCRIPTION
Cherry-pick of apple/swift#38042, except that the release/5.5 branch has a more recent documentation comment.

**Explanation:**
Deprecate typealias PartialAsyncTask, and move it into the "SourceCompatibilityShims.swift" file.

**Scope:**
This change should only affect early adopters, assuming that the source compatibility shims will be removed before release.

**Risk:**
None.

**Testing:**
This change includes an updated test, with the expected warning.

**Reviewer:**
Approved by @ktoso (for the main branch).