### PR TITLE
[Runtime] Set fastDeallocSupported to false on i386 simulators.

### DIFF
--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -700,10 +700,10 @@ void swift::swift_deallocClassInstance(HeapObject *object,
 #if SWIFT_OBJC_INTEROP
   // We need to let the ObjC runtime clean up any associated objects or weak
   // references associated with this object.
-#if !TARGET_OS_SIMULATOR || !__x86_64__
-  const bool fastDeallocSupported = true;
-#else
+#if TARGET_OS_SIMULATOR && (__x86_64__ || __i386__)
   const bool fastDeallocSupported = false;
+#else
+  const bool fastDeallocSupported = true;
 #endif
   if (!fastDeallocSupported || !object->refCounts.getPureSwiftDeallocation()) {
     objc_destructInstance((id)object);

--- a/test/Interpreter/SDK/objc_bridge_cast.swift
+++ b/test/Interpreter/SDK/objc_bridge_cast.swift
@@ -3,9 +3,6 @@
 
 // REQUIRES: objc_interop
 
-// rdar://79672466 - This test fails on watchsimulator-i386
-// UNSUPPORTED: OS=watchos && CPU=i386
-
 // Test dynamic casts that bridge value types through the runtime.
 
 import Foundation

--- a/test/Interpreter/SDK/objc_dealloc.swift
+++ b/test/Interpreter/SDK/objc_dealloc.swift
@@ -3,9 +3,6 @@
 
 // REQUIRES: objc_interop
 
-// rdar://79672466 - This test fails for watchsimulator-i386
-// UNSUPPORTED: OS=watchos && CPU=i386
-
 import Foundation
 
 // Check that ObjC associated objects are cleaned up when attached to native


### PR DESCRIPTION
The conditional should have been "Intel simulators" but it was actually "x86-64 simulators." The i386 simulator doesn't have the weak formation callout, which causes it to miss cleaning up associated objects when the Swift runtime thinks it does.

rdar://79672466