### PR TITLE
[5.5][Diagnostics] Adjust `Self` conformance check to find non-decl overload choices

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6312,12 +6312,23 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
         auto requirement = signature->getRequirements()[req->getIndex()];
 
         auto *memberLoc = getConstraintLocator(anchor, path.front());
-        auto *memberRef = findResolvedMemberRef(memberLoc);
+        auto overload = findSelectedOverloadFor(memberLoc);
 
         // To figure out what is going on here we need to wait until
         // member overload is set in the constraint system.
-        if (!memberRef)
+        if (!overload) {
+          // If it's not allowed to generate new constraints
+          // there is no way to control re-activation, so this
+          // check has to fail.
+          if (!flags.contains(TMF_GenerateConstraints))
+            return SolutionKind::Error;
+
           return formUnsolved(/*activate=*/true);
+        }
+
+        auto *memberRef = overload->choice.getDeclOrNull();
+        if (!memberRef)
+          return SolutionKind::Error;
 
         // If this is a `Self` conformance requirement from a static member
         // reference on a protocol metatype, let's produce a tailored diagnostic.

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar79268378.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar79268378.swift
@@ -1,0 +1,29 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+struct Result {
+}
+
+func wrapper(_: Result?) {
+}
+
+extension Optional where Wrapped == Result {
+  static func test(_: String) -> Result { Result() }
+}
+
+extension Result {
+  static func test<R: RangeExpression>(_: R) -> Result where R.Bound == Int {
+    Result()
+  }
+}
+
+protocol P {}
+
+struct Value : P {
+  init() {}
+  init<R>(_: R) {}
+}
+
+func example<T1: P, T2: P>(_: T1, _: T2) {
+}
+
+example(Value(), Value(wrapper(.test(0))))


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/38045

--- 

- Explanation:

Use `findSelectedOverloadFor` instead of `findResolvedMemberRef`
to cover cases where member is found via base type unwrap, otherwise
conformance constraint would be re-inserted but never re-attempted
which results in a compiler crash.

- Scope: Expressions with leading-dot syntax where one of the conformance requirements is not satisfied and member itself is found via unwrap of the optional base type.

- Main Branch PR: https://github.com/apple/swift/pull/38045

- Resolves: rdar://79268378

- Risk: Low

- Reviewed By: @hborla  

- Testing: Regression tests added to the suite

Resolves: rdar://79268378
(cherry picked from commit be6e2fad8c28265068dd4299e72c90c796e771a2)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
