### PR TITLE
include comments on SPI symbols when they're in symbol graphs

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -28,6 +28,7 @@
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/Located.h"
 #include "swift/Basic/Malloc.h"
+#include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "clang/AST/DeclTemplate.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
@@ -231,6 +232,7 @@ class ASTContext final {
   ASTContext(LangOptions &langOpts, TypeCheckerOptions &typeckOpts,
              SearchPathOptions &SearchPathOpts,
              ClangImporterOptions &ClangImporterOpts,
+             symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts,
              SourceManager &SourceMgr,
              DiagnosticEngine &Diags);
 
@@ -246,6 +248,7 @@ public:
   static ASTContext *get(LangOptions &langOpts, TypeCheckerOptions &typeckOpts,
                          SearchPathOptions &SearchPathOpts,
                          ClangImporterOptions &ClangImporterOpts,
+                         symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts,
                          SourceManager &SourceMgr, DiagnosticEngine &Diags);
   ~ASTContext();
 
@@ -266,6 +269,9 @@ public:
 
   /// The clang importer options used by this AST context.
   ClangImporterOptions &ClangImporterOpts;
+
+  /// The symbol graph generation options used by this AST context.
+  symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts;
 
   /// The source manager object.
   SourceManager &SourceMgr;

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -41,6 +41,7 @@
 #include "swift/Serialization/Validation.h"
 #include "swift/Subsystems.h"
 #include "swift/TBDGen/TBDGen.h"
+#include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Option/ArgList.h"
@@ -86,6 +87,7 @@ class CompilerInvocation {
   TypeCheckerOptions TypeCheckerOpts;
   FrontendOptions FrontendOpts;
   ClangImporterOptions ClangImporterOpts;
+  symbolgraphgen::SymbolGraphOptions SymbolGraphOpts;
   SearchPathOptions SearchPathOpts;
   DiagnosticOptions DiagnosticOpts;
   MigratorOptions MigratorOpts;
@@ -255,6 +257,11 @@ public:
   ClangImporterOptions &getClangImporterOptions() { return ClangImporterOpts; }
   const ClangImporterOptions &getClangImporterOptions() const {
     return ClangImporterOpts;
+  }
+
+  symbolgraphgen::SymbolGraphOptions &getSymbolGraphOptions() { return SymbolGraphOpts; }
+  const symbolgraphgen::SymbolGraphOptions &getSymbolGraphOptions() const {
+    return SymbolGraphOpts;
   }
 
   SearchPathOptions &getSearchPathOptions() { return SearchPathOpts; }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -53,6 +53,7 @@
 #include "swift/Basic/StringExtras.h"
 #include "swift/Strings.h"
 #include "swift/Subsystems.h"
+#include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "swift/Syntax/References.h"
 #include "swift/Syntax/SyntaxArena.h"
 #include "clang/AST/Type.h"
@@ -579,6 +580,7 @@ ASTContext *ASTContext::get(LangOptions &langOpts,
                             TypeCheckerOptions &typeckOpts,
                             SearchPathOptions &SearchPathOpts,
                             ClangImporterOptions &ClangImporterOpts,
+                            symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts,
                             SourceManager &SourceMgr,
                             DiagnosticEngine &Diags) {
   // If more than two data structures are concatentated, then the aggregate
@@ -593,17 +595,19 @@ ASTContext *ASTContext::get(LangOptions &langOpts,
   new (impl) Implementation();
   return new (mem)
       ASTContext(langOpts, typeckOpts, SearchPathOpts, ClangImporterOpts,
-                 SourceMgr, Diags);
+                 SymbolGraphOpts, SourceMgr, Diags);
 }
 
 ASTContext::ASTContext(LangOptions &langOpts, TypeCheckerOptions &typeckOpts,
                        SearchPathOptions &SearchPathOpts,
                        ClangImporterOptions &ClangImporterOpts,
+                       symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts,
                        SourceManager &SourceMgr, DiagnosticEngine &Diags)
   : LangOpts(langOpts),
     TypeCheckerOpts(typeckOpts),
     SearchPathOpts(SearchPathOpts),
     ClangImporterOpts(ClangImporterOpts),
+    SymbolGraphOpts(SymbolGraphOpts),
     SourceMgr(SourceMgr), Diags(Diags),
     evaluator(Diags, langOpts),
     TheBuiltinModule(createBuiltinModule(*this)),

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -585,8 +585,8 @@ ToolChain::constructInvocation(const CompileJobAction &job,
   if (context.OI.CompilerMode == OutputInfo::Mode::SingleCompile) {
     context.Args.AddLastArg(Arguments, options::OPT_emit_symbol_graph);
     context.Args.AddLastArg(Arguments, options::OPT_emit_symbol_graph_dir);
-    context.Args.AddLastArg(Arguments, options::OPT_include_spi_symbols);
   }
+  context.Args.AddLastArg(Arguments, options::OPT_include_spi_symbols);
 
   return II;
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -18,6 +18,7 @@
 #include "swift/Option/Options.h"
 #include "swift/Option/SanitizerOptions.h"
 #include "swift/Strings.h"
+#include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Triple.h"
 #include "llvm/Option/Arg.h"
@@ -1019,6 +1020,28 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
   return false;
 }
 
+static void ParseSymbolGraphArgs(symbolgraphgen::SymbolGraphOptions &Opts,
+                                 ArgList &Args,
+                                 DiagnosticEngine &Diags,
+                                 LangOptions &LangOpts) {
+  using namespace options;
+
+  if (const Arg *A = Args.getLastArg(OPT_emit_symbol_graph_dir)) {
+    Opts.OutputDir = A->getValue();
+  }
+
+  Opts.Target = LangOpts.Target;
+
+  Opts.SkipInheritedDocs = Args.hasArg(OPT_skip_inherited_docs);
+  Opts.IncludeSPISymbols = Args.hasArg(OPT_include_spi_symbols);
+
+  // default values for generating symbol graphs during a build
+  Opts.MinimumAccessLevel = AccessLevel::Public;
+  Opts.PrettyPrint = false;
+  Opts.EmitSynthesizedMembers = true;
+  Opts.PrintMessages = false;
+}
+
 static bool ParseSearchPathArgs(SearchPathOptions &Opts,
                                 ArgList &Args,
                                 DiagnosticEngine &Diags,
@@ -1972,6 +1995,8 @@ bool CompilerInvocation::parseArgs(
                              workingDirectory)) {
     return true;
   }
+
+  ParseSymbolGraphArgs(SymbolGraphOpts, ParsedArgs, Diags, LangOpts);
 
   if (ParseSearchPathArgs(SearchPathOpts, ParsedArgs, Diags,
                           workingDirectory)) {

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -223,6 +223,7 @@ bool CompilerInstance::setUpASTContextIfNeeded() {
       Invocation.getLangOptions(), Invocation.getTypeCheckerOptions(),
       Invocation.getSearchPathOptions(),
       Invocation.getClangImporterOptions(),
+      Invocation.getSymbolGraphOptions(),
       SourceMgr, Diagnostics));
   registerParseRequestFunctions(Context->evaluator);
   registerTypeCheckerRequestFunctions(Context->evaluator);

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -29,6 +29,7 @@
 #include "swift/Parse/PersistentParserState.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
 #include "swift/Subsystems.h"
+#include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "clang/AST/ASTContext.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -330,9 +331,10 @@ bool CompletionInstance::performCachedOperationIfPossible(
   SearchPathOptions searchPathOpts = CI.getASTContext().SearchPathOpts;
   DiagnosticEngine tmpDiags(tmpSM);
   ClangImporterOptions clangOpts;
+  symbolgraphgen::SymbolGraphOptions symbolOpts;
   std::unique_ptr<ASTContext> tmpCtx(
-      ASTContext::get(langOpts, typeckOpts, searchPathOpts, clangOpts, tmpSM,
-                      tmpDiags));
+      ASTContext::get(langOpts, typeckOpts, searchPathOpts, clangOpts,
+                      symbolOpts, tmpSM, tmpDiags));
   registerParseRequestFunctions(tmpCtx->evaluator);
   registerIDERequestFunctions(tmpCtx->evaluator);
   registerTypeCheckerRequestFunctions(tmpCtx->evaluator);

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -29,6 +29,7 @@
 #include "swift/Parse/ParseSILSupport.h"
 #include "swift/Parse/SyntaxParseActions.h"
 #include "swift/Parse/SyntaxParsingContext.h"
+#include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "swift/Syntax/RawSyntax.h"
 #include "swift/Syntax/TokenSyntax.h"
 #include "swift/SyntaxParse/SyntaxTreeCreator.h"
@@ -1219,6 +1220,7 @@ struct ParserUnit::Implementation {
   TypeCheckerOptions TypeCheckerOpts;
   SearchPathOptions SearchPathOpts;
   ClangImporterOptions clangImporterOpts;
+  symbolgraphgen::SymbolGraphOptions symbolGraphOpts;
   DiagnosticEngine Diags;
   ASTContext &Ctx;
   SourceFile *SF;
@@ -1231,7 +1233,7 @@ struct ParserUnit::Implementation {
       : SPActions(std::move(spActions)), LangOpts(Opts),
         TypeCheckerOpts(TyOpts), Diags(SM),
         Ctx(*ASTContext::get(LangOpts, TypeCheckerOpts, SearchPathOpts,
-                             clangImporterOpts, SM, Diags)) {
+                             clangImporterOpts, symbolGraphOpts, SM, Diags)) {
     auto parsingOpts = SourceFile::getDefaultParsingOptions(LangOpts);
     parsingOpts |= ParsingFlags::DisableDelayedBodies;
     parsingOpts |= ParsingFlags::DisablePoundIfEvaluation;

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -341,8 +341,8 @@ static bool shouldIncludeDecl(Decl *D, bool ExcludeDoubleUnderscore) {
       return false;
   }
 
-  // Skip SPI decls.
-  if (D->isSPI())
+  // Skip SPI decls, unless we're generating a symbol graph with SPI information.
+  if (D->isSPI() && !D->getASTContext().SymbolGraphOpts.IncludeSPISymbols)
     return false;
 
   if (auto *ED = dyn_cast<ExtensionDecl>(D)) {

--- a/test/SymbolGraph/Symbols/Mixins/SPI.swift
+++ b/test/SymbolGraph/Symbols/Mixins/SPI.swift
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -module-name SPI -emit-module -emit-module-path %t/
+// RUN: %target-build-swift %s -module-name SPI -emit-module -emit-module-path %t/SPI.swiftmodule -include-spi-symbols
 // RUN: %target-swift-symbolgraph-extract -module-name SPI -I %t -pretty-print -output-dir %t -include-spi-symbols
 // RUN: %FileCheck %s --input-file %t/SPI.symbols.json --check-prefix SPI
+// RUN: %FileCheck %s --input-file %t/SPI.symbols.json --check-prefix SPIDOC
 
 // RUN: %target-swift-symbolgraph-extract -module-name SPI -I %t -pretty-print -output-dir %t
 // RUN: %FileCheck %s --input-file %t/SPI.symbols.json --check-prefix NOSPI
@@ -9,11 +10,13 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name SPI -emit-module -emit-module-path %t/SPI.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/ -include-spi-symbols -v
 // RUN: %FileCheck %s --input-file %t/SPI.symbols.json --check-prefix SPI-COMPILE
+// RUN: %FileCheck %s --input-file %t/SPI.symbols.json --check-prefix SPIDOC
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name SPI -emit-module -emit-module-path %t/SPI.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/
 // RUN: %FileCheck %s --input-file %t/SPI.symbols.json --check-prefix NOSPI-COMPILE
 
+/// This is some struct, there
 @_spi(SPI) public struct SomeStruct {}
 
 // SPI: "precise": "s:3SPI10SomeStructV"
@@ -23,3 +26,5 @@
 
 // SPI-COMPILE: s:3SPI10SomeStructV
 // NOSPI-COMPILE-NOT: s:3SPI10SomeStructV
+
+// SPIDOC: This is some struct, there

--- a/tools/driver/modulewrap_main.cpp
+++ b/tools/driver/modulewrap_main.cpp
@@ -26,6 +26,7 @@
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/TypeLowering.h"
 #include "swift/Subsystems.h"
+#include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Bitstream/BitstreamReader.h"
 #include "llvm/Option/ArgList.h"
@@ -177,9 +178,10 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
   TypeCheckerOptions TypeCheckOpts;
   LangOptions LangOpts;
   ClangImporterOptions ClangImporterOpts;
+  symbolgraphgen::SymbolGraphOptions SymbolGraphOpts;
   LangOpts.Target = Invocation.getTargetTriple();
   ASTContext &ASTCtx = *ASTContext::get(LangOpts, TypeCheckOpts, SearchPathOpts,
-                                        ClangImporterOpts, SrcMgr,
+                                        ClangImporterOpts, SymbolGraphOpts, SrcMgr,
                                         Instance.getDiags());
   registerParseRequestFunctions(ASTCtx.evaluator);
   registerTypeCheckerRequestFunctions(ASTCtx.evaluator);

--- a/unittests/AST/TestContext.cpp
+++ b/unittests/AST/TestContext.cpp
@@ -36,7 +36,8 @@ static Decl *createOptionalType(ASTContext &ctx, SourceFile *fileForLookups,
 
 TestContext::TestContext(ShouldDeclareOptionalTypes optionals)
     : Ctx(*ASTContext::get(LangOpts, TypeCheckerOpts, SearchPathOpts,
-                           ClangImporterOpts, SourceMgr, Diags)) {
+                           ClangImporterOpts, SymbolGraphOpts,
+                           SourceMgr, Diags)) {
   registerParseRequestFunctions(Ctx.evaluator);
   registerTypeCheckerRequestFunctions(Ctx.evaluator);
   auto stdlibID = Ctx.getIdentifier(STDLIB_NAME);

--- a/unittests/AST/TestContext.h
+++ b/unittests/AST/TestContext.h
@@ -16,6 +16,7 @@
 #include "swift/AST/SourceFile.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/SourceManager.h"
+#include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 
 #include "llvm/Support/Host.h"
 
@@ -32,6 +33,7 @@ public:
   TypeCheckerOptions TypeCheckerOpts;
   SearchPathOptions SearchPathOpts;
   ClangImporterOptions ClangImporterOpts;
+  symbolgraphgen::SymbolGraphOptions SymbolGraphOpts;
   SourceManager SourceMgr;
   DiagnosticEngine Diags;
 

--- a/unittests/ClangImporter/ClangImporterTests.cpp
+++ b/unittests/ClangImporter/ClangImporterTests.cpp
@@ -6,6 +6,7 @@
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
@@ -72,11 +73,12 @@ TEST(ClangImporterTest, emitPCHInMemory) {
   swift::TypeCheckerOptions typeckOpts;
   INITIALIZE_LLVM();
   swift::SearchPathOptions searchPathOpts;
+  swift::symbolgraphgen::SymbolGraphOptions symbolGraphOpts;
   swift::SourceManager sourceMgr;
   swift::DiagnosticEngine diags(sourceMgr);
   std::unique_ptr<ASTContext> context(
       ASTContext::get(langOpts, typeckOpts, searchPathOpts, options,
-                      sourceMgr, diags));
+                      symbolGraphOpts, sourceMgr, diags));
   auto importer = ClangImporter::create(*context);
 
   std::string PCH = createFilename(cache, "bridging.h.pch");

--- a/unittests/FrontendTool/ModuleLoadingTests.cpp
+++ b/unittests/FrontendTool/ModuleLoadingTests.cpp
@@ -17,6 +17,7 @@
 #include "swift/Frontend/ModuleInterfaceLoader.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/Serialization/Validation.h"
+#include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/VirtualFileSystem.h"
 
@@ -100,10 +101,11 @@ protected:
     langOpts.Target = llvm::Triple(llvm::sys::getDefaultTargetTriple());
     SearchPathOptions searchPathOpts;
     ClangImporterOptions clangImpOpts;
+    symbolgraphgen::SymbolGraphOptions symbolGraphOpts;
     SILOptions silOpts;
     auto ctx =
         ASTContext::get(langOpts, typeckOpts, searchPathOpts, clangImpOpts,
-                        sourceMgr, diags);
+                        symbolGraphOpts, sourceMgr, diags);
 
     ctx->addModuleInterfaceChecker(
       std::make_unique<ModuleInterfaceCheckerImpl>(*ctx, cacheDir,

--- a/unittests/Sema/SemaFixture.cpp
+++ b/unittests/Sema/SemaFixture.cpp
@@ -30,7 +30,8 @@ using namespace swift::constraints::inference;
 
 SemaTest::SemaTest()
     : Context(*ASTContext::get(LangOpts, TypeCheckerOpts, SearchPathOpts,
-                               ClangImporterOpts, SourceMgr, Diags)) {
+                               ClangImporterOpts, SymbolGraphOpts,
+                               SourceMgr, Diags)) {
   INITIALIZE_LLVM();
 
   registerParseRequestFunctions(Context.evaluator);

--- a/unittests/Sema/SemaFixture.h
+++ b/unittests/Sema/SemaFixture.h
@@ -20,6 +20,7 @@
 #include "swift/Basic/Platform.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Sema/ConstraintSystem.h"
+#include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Host.h"
@@ -39,6 +40,7 @@ public:
   TypeCheckerOptions TypeCheckerOpts;
   SearchPathOptions SearchPathOpts;
   ClangImporterOptions ClangImporterOpts;
+  symbolgraphgen::SymbolGraphOptions SymbolGraphOpts;
   SourceManager SourceMgr;
   DiagnosticEngine Diags;
 


### PR DESCRIPTION
While #37640 added the ability to include SPI symbols in a symbol graph, they were missing doc comments because those comments were being filtered out. This PR wires the `-include-spi-symbols` flag into LangOptions, so that it can be checked when serializing doc comments for SPI symbols.