### PR TITLE
Introduce fake symbols that were present with the old concurrency ABI.

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -58,6 +58,7 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   AsyncThrowingMapSequence.swift
   AsyncThrowingPrefixWhileSequence.swift
   GlobalActor.swift
+  LinkCompatibilityShims.cpp
   MainActor.swift
   PartialAsyncTask.swift
   SourceCompatibilityShims.swift

--- a/stdlib/public/Concurrency/LinkCompatibilityShims.cpp
+++ b/stdlib/public/Concurrency/LinkCompatibilityShims.cpp
@@ -12,7 +12,7 @@
 // This file provides link compatibility shims to work through some ABI
 // changes.
 //===----------------------------------------------------------------------===//
-#include "../public/SwiftShims/Visibility.h"
+#include "swift/Runtime/Config.h"
 
 #define OLD_SYMBOL(NAME) \
   SWIFT_EXPORT_FROM(swift_Concurrency) extern "C" void const * const NAME = nullptr;

--- a/stdlib/public/Concurrency/LinkCompatibilityShims.cpp
+++ b/stdlib/public/Concurrency/LinkCompatibilityShims.cpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// This file provides link compatibility shims to work through some ABI
+// changes.
+//===----------------------------------------------------------------------===//
+#include "../public/SwiftShims/Visibility.h"
+
+#define OLD_SYMBOL(NAME) \
+  SWIFT_EXPORT_FROM(swift_Concurrency) extern "C" void const * const NAME = nullptr;
+
+OLD_SYMBOL($ss4TaskV6HandleVMn)
+OLD_SYMBOL($ss4TaskV8PriorityOMa)
+OLD_SYMBOL($ss4TaskV8PriorityO11unspecifiedyA2DmFWC)
+OLD_SYMBOL($ss6detach8priority9operations4TaskV6HandleVy_xs5NeverOGAE8PriorityO_xyYaYbcntlF)
+OLD_SYMBOL($ss6detach8priority9operations4TaskV6HandleVy_xs5NeverOGAE8PriorityO_xyYaYbcntlFfA_)
+OLD_SYMBOL($ss18UnsafeContinuationVMn)
+


### PR DESCRIPTION
The concurrency ABI has shifted considerably, including renaming many
symbols. However, there remain some existing libraries that link
against these symbols and aren't necessarily immediately rebuilt. Add
some "fake" symbols for the ones that we need, so those existing
libraries can link against a new `_Concurrency` library... even though
the resulting binary would not be able to execute. This is a grotesque
hack and a stop-gap.

Speculative fix for rdar://79298287.
