### PR TITLE
[Demangler] Fix the name of float vector types in OldDemangler.

### DIFF
--- a/lib/Demangling/OldDemangler.cpp
+++ b/lib/Demangling/OldDemangler.cpp
@@ -1877,7 +1877,7 @@ private:
               return nullptr;
             return Factory.createNode(
                 Node::Kind::BuiltinTypeName,
-                (DemanglerPrinter() << "Builtin.Vec" << elts << "xFloat"
+                (DemanglerPrinter() << "Builtin.Vec" << elts << "xFPIEEE"
                                     << size).str());
           }
           if (Mangled.nextIf('p'))

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -1178,7 +1178,7 @@ void Remangler::mangleBuiltinTypeName(Node *node) {
     auto element = text.substr(splitIdx).substr(1);
     if (element == "RawPointer") {
       Buffer << 'p';
-    } else if (stripPrefix(element, "Float")) {
+    } else if (stripPrefix(element, "FPIEEE")) {
       Buffer << 'f' << element << '_';
     } else if (stripPrefix(element, "Int")) {
       Buffer << 'i' << element << '_';

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -12,8 +12,11 @@ _TtBo ---> Builtin.NativeObject
 _TtBp ---> Builtin.RawPointer
 _TtBt ---> Builtin.SILToken
 _TtBv4Bi8_ ---> Builtin.Vec4xInt8
-_TtBv4Bf16_ ---> Builtin.Vec4xFloat16
+_TtBv4Bf16_ ---> Builtin.Vec4xFPIEEE16
 _TtBv4Bp ---> Builtin.Vec4xRawPointer
+$sBi8_Bv4_ ---> Builtin.Vec4xInt8
+$sBf16_Bv4_ ---> Builtin.Vec4xFPIEEE16
+$sBpBv4_ ---> Builtin.Vec4xRawPointer
 _TtSa ---> Swift.Array
 _TtSb ---> Swift.Bool
 _TtSc ---> Swift.UnicodeScalar

--- a/test/Demangle/Inputs/simplified-manglings.txt
+++ b/test/Demangle/Inputs/simplified-manglings.txt
@@ -5,7 +5,7 @@ _TtBO ---> Builtin.UnknownObject
 _TtBo ---> Builtin.NativeObject
 _TtBp ---> Builtin.RawPointer
 _TtBv4Bi8_ ---> Builtin.Vec4xInt8
-_TtBv4Bf16_ ---> Builtin.Vec4xFloat16
+_TtBv4Bf16_ ---> Builtin.Vec4xFPIEEE16
 _TtBv4Bp ---> Builtin.Vec4xRawPointer
 _TtSa ---> Array
 _TtSb ---> Bool


### PR DESCRIPTION
The `OldDemangler` was still spelling `Builtin.Vec4xFPIEEE16` as `Builtin.Vec4xFloat16`, which meant that feeding its output to the new `Remangler` caused it to fail with "fatal error: unexpected builtin vector type".

rdar://63485806