### PR TITLE
[stdlib] NFC: Un-XFAIL test/stdlib/Reflection_objc.swift on arm64

### DIFF
--- a/test/stdlib/Reflection_objc.swift
+++ b/test/stdlib/Reflection_objc.swift
@@ -9,9 +9,6 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
-// rdar://problem/75006694
-// XFAIL: OS=macosx && CPU=arm64
-
 //
 // DO NOT add more tests to this file.  Add them to test/1_stdlib/Runtime.swift.
 //


### PR DESCRIPTION
Resolves: rdar://75006694

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
