### PR TITLE
[ConstraintSystem] Store tuple types in the locator when matching element types.

### DIFF
--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -581,6 +581,20 @@ public:
   }
 };
 
+class LocatorPathElt::TupleType : public StoredPointerElement<TypeBase> {
+public:
+  TupleType(Type type)
+      : StoredPointerElement(PathElementKind::TupleType, type.getPointer()) {
+    assert(type->getDesugaredType()->is<swift::TupleType>());
+  }
+
+  Type getType() const { return getStoredPointer(); }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == PathElementKind::TupleType;
+  }
+};
+
 /// Abstract superclass for any kind of tuple element.
 class LocatorPathElt::AnyTupleElement : public StoredIntegerElement<1> {
 protected:

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -164,6 +164,10 @@ SIMPLE_LOCATOR_PATH_ELT(SubscriptMember)
 /// The missing argument synthesized by the solver.
 CUSTOM_LOCATOR_PATH_ELT(SynthesizedArgument)
 
+/// A tuple type, which provides context for subsequent tuple element
+/// path components.
+CUSTOM_LOCATOR_PATH_ELT(TupleType)
+
 /// Tuple elements.
 ABSTRACT_LOCATOR_PATH_ELT(AnyTupleElement)
   /// A tuple element referenced by position.

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3177,7 +3177,7 @@ bool TupleContextualFailure::diagnoseAsError() {
   auto purpose = getContextualTypePurpose();
   if (isNumElementsMismatch())
     diagnostic = diag::tuple_types_not_convertible_nelts;
-  else if ((purpose == CTP_Initialization) && !getContextualType(getAnchor()))
+  else if (purpose == CTP_Unused)
     diagnostic = diag::tuple_types_not_convertible;
   else if (auto diag = getDiagnosticFor(purpose, getToType()))
     diagnostic = *diag;

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -453,26 +453,19 @@ bool AllowTupleTypeMismatch::coalesceAndDiagnose(
     indices.push_back(*tupleFix->Index);
   }
 
-  auto &cs = getConstraintSystem();
   auto *locator = getLocator();
   ContextualTypePurpose purpose;
-  Type fromType;
-  Type toType;
-
-  if (getFromType()->is<TupleType>() && getToType()->is<TupleType>()) {
-    purpose = cs.getContextualTypePurpose(locator->getAnchor());
-    fromType = getFromType();
-    toType = getToType();
-  } else if (auto contextualTypeInfo =
-                 getStructuralTypeContext(solution, locator)) {
-    std::tie(purpose, fromType, toType) = *contextualTypeInfo;
+  if (isExpr<CoerceExpr>(locator->getAnchor())) {
+    purpose = CTP_CoerceOperand;
+  } else if (auto *assignExpr = getAsExpr<AssignExpr>(locator->getAnchor())) {
+    purpose = isa<SubscriptExpr>(assignExpr->getDest()) ? CTP_SubscriptAssignSource
+                                                        : CTP_AssignSource;
   } else {
-    return false;
+    auto &cs = getConstraintSystem();
+    purpose = cs.getContextualTypePurpose(locator->getAnchor());
   }
 
-  TupleContextualFailure failure(solution, purpose,
-                                 fromType->lookThroughAllOptionalTypes(),
-                                 toType->lookThroughAllOptionalTypes(),
+  TupleContextualFailure failure(solution, purpose, getFromType(), getToType(),
                                  indices, locator);
   return failure.diagnose(asNote);
 }

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -63,6 +63,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::WrappedValue:
   case ConstraintLocator::GenericParameter:
   case ConstraintLocator::GenericArgument:
+  case ConstraintLocator::TupleType:
   case ConstraintLocator::NamedTupleElement:
   case ConstraintLocator::TupleElement:
   case ConstraintLocator::ProtocolRequirement:
@@ -355,6 +356,12 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
     case MemberRefBase:
       out << "member reference base";
       break;
+
+    case TupleType: {
+      auto tupleElt = elt.castTo<LocatorPathElt::TupleType>();
+      out << "tuple type '" << tupleElt.getType()->getString(PO) << "'";
+      break;
+    }
 
     case NamedTupleElement: {
       auto tupleElt = elt.castTo<LocatorPathElt::NamedTupleElement>();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4273,6 +4273,10 @@ void constraints::simplifyLocator(ASTNode &anchor,
       path = path.slice(1);
       continue;
 
+   case ConstraintLocator::TupleType:
+      path = path.slice(1);
+      continue;
+
     case ConstraintLocator::NamedTupleElement:
     case ConstraintLocator::TupleElement: {
       // Extract tuple element.

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -573,7 +573,7 @@ func r22263468(_ a : String?) {
   // TODO(diagnostics): This is a regression from diagnosing missing optional unwrap for `a`, we have to
   // re-think the way errors in tuple elements are detected because it's currently impossible to detect
   // exactly what went wrong here and aggregate fixes for different elements at the same time.
-  _ = MyTuple(42, a) // expected-error {{tuple type 'MyTuple' (aka '(Int, String)') is not convertible to tuple type '(Int, String?)'}}
+  _ = MyTuple(42, a) // expected-error {{tuple type '(Int, String?)' is not convertible to tuple type 'MyTuple' (aka '(Int, String)')}}
 }
 
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -576,6 +576,14 @@ func r22263468(_ a : String?) {
   _ = MyTuple(42, a) // expected-error {{tuple type '(Int, String?)' is not convertible to tuple type 'MyTuple' (aka '(Int, String)')}}
 }
 
+// rdar://71829040 - "ambiguous without more context" error for tuple type mismatch.
+func r71829040() {
+  func object(forKey: String) -> Any? { nil }
+
+  let flags: [String: String]
+  // expected-error@+1 {{tuple type '(String, Bool)' is not convertible to tuple type '(String, String)'}}
+  flags = Dictionary(uniqueKeysWithValues: ["keyA", "keyB"].map { ($0, object(forKey: $0) as? Bool ?? false) })
+}
 
 // rdar://22470302 - Crash with parenthesized call result.
 class r22470302Class {


### PR DESCRIPTION
Storing tuple types in the locator provides context for tuple element mismatch diagnostics. Previously, we attempted to compute the full tuple types in diagnostics code with a pile of special cases (in `getStructuralTypeContext` in CSFix.cpp) which caused many "type of expression is ambiguous without more context" error messages for cases that weren't covered.

Note that we can't remove `getStructuralTypeContext` yet because it's still used by function type mismatch diagnostics. We can use the same strategy there of storing the full function type in the locator.

Resolves: rdar://60550072, rdar://71829040, rdar://75325572, [SR-14329](https://bugs.swift.org/browse/SR-14329)