### PR TITLE
[SourceKit] Determine correctly whether typed  variables in `if/guard/while-let`-statements have explicit type annotations

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5806,11 +5806,24 @@ void VarDecl::setNamingPattern(NamedPattern *Pat) {
 }
 
 TypeRepr *VarDecl::getTypeReprOrParentPatternTypeRepr() const {
-  if (auto *param = dyn_cast<ParamDecl>(this))
-    return param->getTypeRepr();
+  if (auto *Param = dyn_cast<ParamDecl>(this))
+    return Param->getTypeRepr();
 
-  if (auto *parentPattern = dyn_cast_or_null<TypedPattern>(getParentPattern()))
-    return parentPattern->getTypeRepr();
+  auto *ParentPattern = getParentPattern();
+
+  if (auto *TyPattern = dyn_cast_or_null<TypedPattern>(ParentPattern))
+    return TyPattern->getTypeRepr();
+
+  // Handle typed if/guard/while-let as a special case (e.g. `if let x: Int
+  // = Optional.some(4)`), since the `TypedPattern` is not the top-level
+  // pattern here - instead it is an implicit `OptionalSomePattern`
+  if (auto *SomePattern =
+          dyn_cast_or_null<OptionalSomePattern>(ParentPattern)) {
+    if (auto *TyPattern =
+            dyn_cast<TypedPattern>(SomePattern->getSubPattern())) {
+      return TyPattern->getTypeRepr();
+    }
+  }
 
   return nullptr;
 }

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -808,20 +808,6 @@ public:
       auto TyOffset = getTypeOffset(Buffer.str());
       bool HasExplicitType =
           VD->getTypeReprOrParentPatternTypeRepr() != nullptr;
-      // Handle typed if/guard/while-let as a special case (e.g. `if let x: Int
-      // = Optional.some(4)`), since the `TypedPattern` is not the top-level
-      // pattern here - instead it is an implicit `OptionalSomePattern`
-      if (!HasExplicitType) {
-        if (auto *somePattern =
-                dyn_cast_or_null<OptionalSomePattern>(VD->getParentPattern())) {
-          if (somePattern->isImplicit()) {
-            if (auto *typedPattern =
-                    dyn_cast<TypedPattern>(somePattern->getSubPattern())) {
-              HasExplicitType = typedPattern->getTypeRepr() != nullptr;
-            }
-          }
-        }
-      }
       // Add the type information to the result list.
       Results.emplace_back(VarOffset, VarLength, HasExplicitType, TyOffset);
     }

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -808,6 +808,20 @@ public:
       auto TyOffset = getTypeOffset(Buffer.str());
       bool HasExplicitType =
           VD->getTypeReprOrParentPatternTypeRepr() != nullptr;
+      // Handle typed if/guard/while-let as a special case (e.g. `if let x: Int
+      // = Optional.some(4)`), since the `TypedPattern` is not the top-level
+      // pattern here - instead it is an implicit `OptionalSomePattern`
+      if (!HasExplicitType) {
+        if (auto *somePattern =
+                dyn_cast_or_null<OptionalSomePattern>(VD->getParentPattern())) {
+          if (somePattern->isImplicit()) {
+            if (auto *typedPattern =
+                    dyn_cast<TypedPattern>(somePattern->getSubPattern())) {
+              HasExplicitType = typedPattern->getTypeRepr() != nullptr;
+            }
+          }
+        }
+      }
       // Add the type information to the result list.
       Results.emplace_back(VarOffset, VarLength, HasExplicitType, TyOffset);
     }

--- a/test/SourceKit/VariableType/case.swift
+++ b/test/SourceKit/VariableType/case.swift
@@ -1,0 +1,21 @@
+if case let x? = Optional.some(5) {}
+if case let y: Int? = Optional.some(5) {}
+guard case let z: String? = Optional.some("a") else { fatalError() }
+while case let w: String? = Optional.some("b") {}
+
+enum Pair<U, V> {
+  case pair(U, V)
+}
+
+switch Pair.pair(Optional.some(0), "test") {
+case .pair(let u, var v):
+  break
+}
+
+// RUN: %sourcekitd-test -req=collect-var-type %s -- %s | %FileCheck %s
+// CHECK: (1:13, 1:14): Int (explicit type: 0)
+// CHECK: (2:13, 2:14): Int? (explicit type: 1)
+// CHECK: (3:16, 3:17): String? (explicit type: 1)
+// CHECK: (4:16, 4:17): String? (explicit type: 1)
+// CHECK: (11:16, 11:17): Int? (explicit type: 0)
+// CHECK: (11:23, 11:24): String (explicit type: 0)

--- a/test/SourceKit/VariableType/if-let.swift
+++ b/test/SourceKit/VariableType/if-let.swift
@@ -1,0 +1,17 @@
+guard var opt: Int = .some(23) else { fatalError() }
+
+func foo() {
+  guard let x = .some("abc") else { return }
+  guard let y: String = .some("def") else { return }
+
+  if let z: Int = .some(4) {}
+
+  while var w: Int = .some(5) {}
+}
+
+// RUN: %sourcekitd-test -req=collect-var-type %s -- %s | %FileCheck %s
+// CHECK: (1:11, 1:14): Int (explicit type: 1)
+// CHECK: (4:13, 4:14): String (explicit type: 0)
+// CHECK: (5:13, 5:14): String (explicit type: 1)
+// CHECK: (7:10, 7:11): Int (explicit type: 1)
+// CHECK: (9:13, 9:14): Int (explicit type: 1)


### PR DESCRIPTION
As noted in https://github.com/apple/sourcekit-lsp/pull/408#issuecomment-867802689, `if/guard/while-let`s are currently (incorrectly) always reported as having no explicit type annotation as the `TypedPattern` is not the top-level-pattern in such declarations. Consider the following example:

```swift
if let x: Int = Optional.some(4) {}
```

Here we get the following AST:

```
(if_stmt ...
  (pattern
    (pattern_optional_some implicit type='Int?'  <--- this node prevents the current mechanism from discovering the type annotation
      (pattern_typed type='Int'
        (pattern_let implicit type='Int'
          (pattern_named type='Int' 'x'))
        (type_ident
          (component id='Int' bind=Swift.(file).Int))))
    (call_expr ...))
  (brace_stmt ...))
```

`sourcekitd-test` therefore reports `(explicit type: 0)` despite an explicit annotation being present:

```
<VariableTypes>
(1:8, 1:9): Int (explicit type: 0)
</VariableTypes>
```

This PR fixes the issue by including an implicitly generated `OptionalSomePattern` as a special case in `VariableTypeCollector` and also adds tests to verify that these cases are handled correctly.

cc @ahoppen 