### PR TITLE
[IDE] Fix name range of wildcard declarations

### DIFF
--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -125,11 +125,15 @@ bool SemaAnnotator::walkToDeclPre(Decl *D) {
   bool IsExtension = false;
 
   if (auto *VD = dyn_cast<ValueDecl>(D)) {
-    if (VD->hasName() && !VD->isImplicit()) {
+    if (!VD->isImplicit()) {
       SourceManager &SM = VD->getASTContext().SourceMgr;
-      NameLen = VD->getBaseName().userFacingName().size();
-      if (Loc.isValid() && SM.extractText({Loc, 1}) == "`")
-        NameLen += 2;
+      if (VD->hasName()) {
+        NameLen = VD->getBaseName().userFacingName().size();
+        if (Loc.isValid() && SM.extractText({Loc, 1}) == "`")
+          NameLen += 2;
+      } else if (Loc.isValid() && SM.extractText({Loc, 1}) == "_") {
+        NameLen = 1;
+      }
     }
 
     auto ReportParamList = [&](ParameterList *PL) {

--- a/test/SourceKit/VariableType/basic.swift
+++ b/test/SourceKit/VariableType/basic.swift
@@ -19,6 +19,8 @@ func foo() {
   var local = 5
 }
 
+let `else` = 3
+
 // RUN: %sourcekitd-test -req=collect-var-type %s -- %s | %FileCheck %s
 // CHECK: (1:5, 1:6): Int (explicit type: 1)
 // CHECK: (2:5, 2:6): String (explicit type: 0)
@@ -30,3 +32,4 @@ func foo() {
 // CHECK: (14:7, 14:8): [Int : Int] (explicit type: 1)
 // CHECK: (15:7, 15:8): (Int) -> Int (explicit type: 1)
 // CHECK: (19:7, 19:12): Int (explicit type: 0)
+// CHECK: (22:5, 22:11): Int (explicit type: 0)

--- a/test/SourceKit/VariableType/params.swift
+++ b/test/SourceKit/VariableType/params.swift
@@ -8,9 +8,13 @@ let z = { (param: String) in
   param.count
 }
 
+let w: (String, Int) -> Void = { (_, x) in }
+
 // RUN: %sourcekitd-test -req=collect-var-type %s -- %s | %FileCheck %s
 // CHECK: (1:10, 1:15): Int (explicit type: 1)
 // CHECK: (5:5, 5:6): (String) -> Void (explicit type: 1)
 // CHECK: (5:29, 5:34): String (explicit type: 0)
 // CHECK: (7:5, 7:6): (String) -> Int (explicit type: 0)
 // CHECK: (7:12, 7:17): String (explicit type: 1)
+// CHECK: (11:35, 11:36): String (explicit type: 0)
+// CHECK: (11:38, 11:39): Int (explicit type: 0)

--- a/test/SourceKit/VariableType/unnamed.swift
+++ b/test/SourceKit/VariableType/unnamed.swift
@@ -1,0 +1,10 @@
+let = 2
+let : Int = 4
+
+let x: (String) -> Void = { (: String) in }
+
+// RUN: %sourcekitd-test -req=collect-var-type %s -- %s | %FileCheck %s
+// CHECK: <VariableTypes>
+// CHECK-NEXT: (4:5, 4:6): (String) -> Void (explicit type: 1)
+// CHECK-NEXT: </VariableTypes>
+


### PR DESCRIPTION
Visiting a wildcard variable declaration (e.g. `let _ = 4`) with `SourceEntityWalker::walkToDeclPre(Decl *, CharSourceRange)` currently yields a range of length zero, whereas e.g. `let x = 4` yields a range of length 1.

The motivating use case for having a length-1-range here instead is to provide an accurate inlay type hint after the variable identifier, see https://github.com/apple/sourcekit-lsp/pull/408#issuecomment-867802689 for details

This PR therefore fixes the issue by defaulting to length 1 if the declaration doesn't have a name and an underscore occurs at the corresponding location in the source file.

cc @ahoppen