### PR TITLE
Disable standard substitutions when building with "older" _Concurrency module

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1427,9 +1427,19 @@ bool ModuleDecl::isStdlibModule() const {
 }
 
 bool ModuleDecl::hasStandardSubstitutions() const {
-  return !getParent() &&
-      (getName() == getASTContext().StdlibModuleName ||
-       getName() == getASTContext().Id_Concurrency);
+  if (getParent())
+    return false;
+
+  if (getName() == getASTContext().StdlibModuleName)
+    return true;
+
+  // The _Concurrency module gets standard substitutions with "new enough"
+  // versions of the module.
+  if (getName() == getASTContext().Id_Concurrency &&
+      getASTContext().getProtocol(KnownProtocolKind::SerialExecutor))
+    return true;
+
+  return false;
 }
 
 bool ModuleDecl::isSwiftShimsModule() const {


### PR DESCRIPTION
**Explanation**: Detect when a particular SDK is using the older mangling scheme for entities in the _Concurrency model and fall back to that mangling scheme in such cases. This helps smooth over compilation issues with a newer compiler and older SDK.
**Scope**: Only affects builds with older _Concurrency modules
**Radar/SR Issue**:  rdar://79298287
**Risk**: Low.
**Testing**: PR testing and CI on main to avoid regressions for normal configurations; extensive testing of mismatched SDKs/compilers for the problem this is trying to solve.
**Original PR**: https://github.com/apple/swift/pull/38010, but we reverted it from `main` later on because we don't want this hack to persist after Swift 5.5
