### PR TITLE
[5.5] Runtime: Workaround armv7k code lowering bug

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -690,6 +690,22 @@ swift::swift_task_create_group_future(
       initialContextSize);
 }
 
+#ifdef __ARM_ARCH_7K__
+__attribute__((noinline))
+SWIFT_CC(swiftasync) static void workaround_function_swift_task_future_waitImpl(
+    OpaqueValue *result, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+    AsyncTask *task, TaskContinuationFunction resumeFunction,
+    AsyncContext *callContext) {
+  // Make sure we don't eliminate calls to this function.
+  asm volatile("" // Do nothing.
+               :  // Output list, empty.
+               : "r"(result), "r"(callerContext), "r"(task) // Input list.
+               : // Clobber list, empty.
+  );
+  return;
+}
+#endif
+
 SWIFT_CC(swiftasync)
 static void swift_task_future_waitImpl(
   OpaqueValue *result,
@@ -709,7 +725,12 @@ static void swift_task_future_waitImpl(
                            result)) {
   case FutureFragment::Status::Executing:
     // The waiting task has been queued on the future.
+#ifdef __ARM_ARCH_7K__
+    return workaround_function_swift_task_future_waitImpl(
+        result, callerContext, task, resumeFn, callContext);
+#else
     return;
+#endif
 
   case FutureFragment::Status::Success: {
     // Run the task with a successful result.
@@ -723,6 +744,22 @@ static void swift_task_future_waitImpl(
     fatalError(0, "future reported an error, but wait cannot throw");
   }
 }
+
+#ifdef __ARM_ARCH_7K__
+__attribute__((noinline))
+SWIFT_CC(swiftasync) static void workaround_function_swift_task_future_wait_throwingImpl(
+    OpaqueValue *result, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+    AsyncTask *task, ThrowingTaskFutureWaitContinuationFunction resumeFunction,
+    AsyncContext *callContext) {
+  // Make sure we don't eliminate calls to this function.
+  asm volatile("" // Do nothing.
+               :  // Output list, empty.
+               : "r"(result), "r"(callerContext), "r"(task) // Input list.
+               : // Clobber list, empty.
+  );
+  return;
+}
+#endif
 
 SWIFT_CC(swiftasync)
 void swift_task_future_wait_throwingImpl(
@@ -744,7 +781,12 @@ void swift_task_future_wait_throwingImpl(
                            result)) {
   case FutureFragment::Status::Executing:
     // The waiting task has been queued on the future.
+#ifdef __ARM_ARCH_7K__
+    return workaround_function_swift_task_future_wait_throwingImpl(
+        result, callerContext, task, resumeFunction, callContext);
+#else
     return;
+#endif
 
   case FutureFragment::Status::Success: {
     auto future = task->futureFragment();

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -648,6 +648,23 @@ task_group_wait_resume_adapter(SWIFT_ASYNC_CONTEXT AsyncContext *_context) {
   return resumeWithError(context->Parent, context->errorResult);
 }
 
+#ifdef __ARM_ARCH_7K__
+__attribute__((noinline))
+SWIFT_CC(swiftasync) static void workaround_function_swift_taskGroup_wait_next_throwingImpl(
+    OpaqueValue *result, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+    TaskGroup *_group,
+    ThrowingTaskFutureWaitContinuationFunction resumeFunction,
+    AsyncContext *callContext) {
+  // Make sure we don't eliminate calls to this function.
+  asm volatile("" // Do nothing.
+               :  // Output list, empty.
+               : "r"(result), "r"(callerContext), "r"(_group) // Input list.
+               : // Clobber list, empty.
+  );
+  return;
+}
+#endif
+
 // =============================================================================
 // ==== group.next() implementation (wait_next and groupPoll) ------------------
 SWIFT_CC(swiftasync)
@@ -675,7 +692,12 @@ static void swift_taskGroup_wait_next_throwingImpl(
   case PollStatus::MustWait:
     // The waiting task has been queued on the channel,
     // there were pending tasks so it will be woken up eventually.
+#ifdef __ARM_ARCH_7K__
+    return workaround_function_swift_taskGroup_wait_next_throwingImpl(
+        resultPointer, callerContext, _group, resumeFunction, rawContext);
+#else
     return;
+#endif
 
   case PollStatus::Empty:
   case PollStatus::Error:


### PR DESCRIPTION
This is to workaround a bug in llvm's codegen when emitting the
callee-pop stack adjustment on a regular return from a swiftasync
function (vs. a tail call).
    
Without the workaround we fail to emit (in the right place) the callee-pop stack adjustment
leading to a mis-aligned stack on return.
    
    ```
      pop     {r7, pc}
      add     sp, #16
    ```
    
Workaround for rdar://79726989

This got exposed by the recent runtime ABI change (https://github.com/apple/swift/pull/37866) which added two more parameters leading to parameters being passed on the stack which makes the stack adjustment necessary.