### PR TITLE
[stdlib] fix an indexing inconsistency

### DIFF
--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1150,7 +1150,7 @@ extension Sequence {
   ) -> (Iterator, UnsafeMutableBufferPointer<Element>.Index) {
     var it = self.makeIterator()
     guard var ptr = buffer.baseAddress else { return (it, buffer.startIndex) }
-    for idx in buffer.startIndex..<buffer.count {
+    for idx in buffer.indices {
       guard let x = it.next() else {
         return (it, idx)
       }

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1140,16 +1140,16 @@ extension Sequence {
   @inlinable
   public __consuming func _copyContents(
     initializing buffer: UnsafeMutableBufferPointer<Element>
-  ) -> (Iterator,UnsafeMutableBufferPointer<Element>.Index) {
+  ) -> (Iterator, UnsafeMutableBufferPointer<Element>.Index) {
     return _copySequenceContents(initializing: buffer)
   }
 
   @_alwaysEmitIntoClient
   internal __consuming func _copySequenceContents(
     initializing buffer: UnsafeMutableBufferPointer<Element>
-  ) -> (Iterator,UnsafeMutableBufferPointer<Element>.Index) {
+  ) -> (Iterator, UnsafeMutableBufferPointer<Element>.Index) {
     var it = self.makeIterator()
-    guard var ptr = buffer.baseAddress else { return (it,buffer.startIndex) }
+    guard var ptr = buffer.baseAddress else { return (it, buffer.startIndex) }
     for idx in buffer.startIndex..<buffer.count {
       guard let x = it.next() else {
         return (it, idx)
@@ -1157,7 +1157,7 @@ extension Sequence {
       ptr.initialize(to: x)
       ptr += 1
     }
-    return (it,buffer.endIndex)
+    return (it, buffer.endIndex)
   }
     
   @inlinable


### PR DESCRIPTION
<!-- What's in this pull request? -->
This iteration ranged from `buffer.startIndex` until `buffer.count`, rather than `buffer.endIndex`.
The latter is more coherent with the indexing model, even though the former happens to work.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
No SR.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
