### PR TITLE
[5.5][ClangImporter] Respect -working-directory in the created VFS

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -25,6 +25,9 @@ namespace llvm {
   class Triple;
   class FileCollectorBase;
   template<typename Fn> class function_ref;
+  namespace vfs {
+    class FileSystem;
+  }
 }
 
 namespace clang {
@@ -158,6 +161,7 @@ public:
   static std::unique_ptr<clang::CompilerInvocation>
   createClangInvocation(ClangImporter *importer,
                         const ClangImporterOptions &importerOpts,
+                        llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS,
                         ArrayRef<std::string> invocationArgStrs,
                         std::vector<std::string> *CC1Args = nullptr);
   ClangImporter(const ClangImporter &) = delete;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -63,6 +63,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/CrashRecoveryContext.h"
 #include "llvm/Support/FileCollector.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Memory.h"
 #include "llvm/Support/Path.h"
 #include <algorithm>
@@ -965,11 +966,11 @@ ClangImporter::getClangArguments(ASTContext &ctx) {
   return invocationArgStrs;
 }
 
-std::unique_ptr<clang::CompilerInvocation>
-ClangImporter::createClangInvocation(ClangImporter *importer,
-                                     const ClangImporterOptions &importerOpts,
-                                     ArrayRef<std::string> invocationArgStrs,
-                                     std::vector<std::string> *CC1Args) {
+std::unique_ptr<clang::CompilerInvocation> ClangImporter::createClangInvocation(
+    ClangImporter *importer, const ClangImporterOptions &importerOpts,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS,
+    ArrayRef<std::string> invocationArgStrs,
+    std::vector<std::string> *CC1Args) {
   std::vector<const char *> invocationArgs;
   invocationArgs.reserve(invocationArgStrs.size());
   for (auto &argStr : invocationArgStrs)
@@ -994,7 +995,7 @@ ClangImporter::createClangInvocation(ClangImporter *importer,
                                                  /*owned*/false);
 
   auto CI = clang::createInvocationFromCommandLine(
-      invocationArgs, tempClangDiags, nullptr, false, CC1Args);
+      invocationArgs, tempClangDiags, VFS, false, CC1Args);
 
   if (!CI) {
     return CI;
@@ -1010,12 +1011,12 @@ ClangImporter::createClangInvocation(ClangImporter *importer,
   // to missing files and report the error that clang would throw manually.
   // rdar://77516546 is tracking that the clang importer should be more
   // resilient and provide a module even if there were building it.
-  auto VFS = clang::createVFSFromCompilerInvocation(
+  auto TempVFS = clang::createVFSFromCompilerInvocation(
       *CI, *tempClangDiags,
-      importer->Impl.SwiftContext.SourceMgr.getFileSystem());
+      VFS ? VFS : importer->Impl.SwiftContext.SourceMgr.getFileSystem());
   std::vector<std::string> FilteredModuleMapFiles;
   for (auto ModuleMapFile : CI->getFrontendOpts().ModuleMapFiles) {
-    if (VFS->exists(ModuleMapFile)) {
+    if (TempVFS->exists(ModuleMapFile)) {
       FilteredModuleMapFiles.push_back(ModuleMapFile);
     } else {
       importer->Impl.diagnose(SourceLoc(), diag::module_map_not_found,
@@ -1060,11 +1061,15 @@ ClangImporter::create(ASTContext &ctx,
     }
   }
 
+  // Wrap Swift's FS to allow Clang to override the working directory
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS =
+      llvm::vfs::RedirectingFileSystem::create({}, true,
+                                               *ctx.SourceMgr.getFileSystem());
+
   // Create a new Clang compiler invocation.
   {
-    importer->Impl.Invocation = createClangInvocation(importer.get(),
-                                                      importerOpts,
-                                                      invocationArgStrs);
+    importer->Impl.Invocation = createClangInvocation(
+        importer.get(), importerOpts, VFS, invocationArgStrs);
     if (!importer->Impl.Invocation)
       return nullptr;
   }
@@ -1116,11 +1121,9 @@ ClangImporter::create(ASTContext &ctx,
 
   // Set up the file manager.
   {
-    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS =
-        clang::createVFSFromCompilerInvocation(instance.getInvocation(),
-                                               instance.getDiagnostics(),
-                                               ctx.SourceMgr.getFileSystem());
-    instance.createFileManager(std::move(VFS));
+    VFS = clang::createVFSFromCompilerInvocation(
+        instance.getInvocation(), instance.getDiagnostics(), std::move(VFS));
+    instance.createFileManager(VFS);
   }
 
   // Don't stop emitting messages if we ever can't load a module.

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -215,7 +215,7 @@ void ClangImporter::recordModuleDependencies(
 
     // Ensure the arguments we collected is sufficient to create a Clang
     // invocation.
-    assert(createClangInvocation(this, Opts, allArgs));
+    assert(createClangInvocation(this, Opts, nullptr, allArgs));
 
     std::vector<std::string> swiftArgs;
     // We are using Swift frontend mode.

--- a/test/ClangImporter/MixedSource/broken-modules.swift
+++ b/test/ClangImporter/MixedSource/broken-modules.swift
@@ -18,7 +18,7 @@ import MissingDependencyFromSwift
 // CHECK-NOT: no such module 'MissingDependencyFromSwift'
 
 import MissingDependencyFromClang
-// CHECK: {{.+}}/Inputs/broken-modules/MissingDependencyFromClang.h:1:9: error: module 'Dependency' not found
+// CHECK: {{.+}}{{/|\\}}Inputs{{/|\\}}broken-modules{{/|\\}}MissingDependencyFromClang.h:1:9: error: module 'Dependency' not found
 // CHECK: broken-modules.swift:[[@LINE-2]]:8: error: could not build Objective-C module 'MissingDependencyFromClang'
 // CHECK: error: no such module 'MissingDependencyFromClang'
 

--- a/test/ClangImporter/broken-modules.swift
+++ b/test/ClangImporter/broken-modules.swift
@@ -23,7 +23,7 @@ import ImportsMissingHeader
 // CHECK: <module-includes>:1:9: note: in file included from <module-includes>:1:
 // CHECK-NEXT: #import "{{.*}}ImportsMissingHeader.h"
 
-// CHECK: {{.*}}/Inputs/custom-modules/ImportsMissingHeader.h:1:9: error: 'this-header-does-not-exist.h' file not found
+// CHECK: {{.*}}{{/|\\}}Inputs{{/|\\}}custom-modules{{/|\\}}ImportsMissingHeader.h:1:9: error: 'this-header-does-not-exist.h' file not found
 
 // CHECK-INDIRECT: <module-includes>:1:9: note: in file included from <module-includes>:1:
 // CHECK-INDIRECT-NEXT: #import "{{.*}}ImportsMissingHeaderIndirect.h"

--- a/test/ClangImporter/non-modular-include.swift
+++ b/test/ClangImporter/non-modular-include.swift
@@ -2,7 +2,7 @@
 // RUN: not %target-swift-frontend -enable-objc-interop -typecheck %/s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck --check-prefix=CHECK -check-prefix CHECK-objc %s
 // RUN: not %target-swift-frontend -disable-objc-interop -typecheck %/s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck --check-prefix=CHECK -check-prefix CHECK-native %s
 
-// CHECK: {{.+}}/non-modular{{/|\\}}Foo.framework/Headers{{/|\\}}Foo.h:1:10: error: include of non-modular header inside framework module 'Foo'
+// CHECK: {{.+}}{{/|\\}}non-modular{{/|\\}}Foo.framework{{/|\\}}Headers{{/|\\}}Foo.h:1:10: error: include of non-modular header inside framework module 'Foo'
 // CHECK-objc: error: could not build Objective-C module 'Foo'
 // CHECK-native: error: could not build C module 'Foo'
 // CHECK-NOT: error

--- a/test/ClangImporter/working-directory.swift
+++ b/test/ClangImporter/working-directory.swift
@@ -1,4 +1,12 @@
-// RUN: cd %S/Inputs/ && %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -Xcc -I -Xcc custom-modules %s -dump-clang-diagnostics 2>&1 | %FileCheck %s
+// RUN: %empty-directory(%t/mcp)
+
+// Check that equivalent invocations result in the same module hash
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -Xcc -I -Xcc custom-modules -module-cache-path %t/mcp -Xcc -working-directory -Xcc %S/Inputs/  %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -Xcc -I -Xcc %S/Inputs/custom-modules -module-cache-path %t/mcp %s
+// RUN: find %t/mcp -name "ObjCParseExtras-*.pcm" | count 1
+
+// Check that the working directory is set to the CWD if not explicitly passed
+// RUN: cd %S/Inputs/ && %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -Xcc -I -Xcc custom-modules %s -dump-clang-diagnostics -module-cache-path %t/mcp 2>&1 | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SourceKit/CursorInfo/injected_vfs.swift
+++ b/test/SourceKit/CursorInfo/injected_vfs.swift
@@ -10,7 +10,7 @@ func foo(
 
 // CHECK-CMODULE: key.kind: source.lang.swift.ref.struct
 // CHECK-CMODULE: key.name: "StructDefinedInCModule"
-// CHECK-CMODULE: key.filepath: "{{.*}}/CModule{{/|\\\\}}CModule.h"
+// CHECK-CMODULE: key.filepath: "{{.*}}{{/|\\\\}}CModule{{/|\\\\}}CModule.h"
 
 // CHECK-SWIFTMODULE-REF: key.kind: source.lang.swift.ref.struct
 // CHECK-SWIFTMODULE-REF: key.name: "StructDefinedInSwiftModule"


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/37946

------

Pass a wrapped VFS down into `clang::createInvocationFromCommandLine` so
that the working directory is set and then used in the underlying Clang
`CompilerInstance`.

Fixes the possibility of differing modules hashes when the same
arguments are used in Clang directly vs from the importer.

Resolves rdar://79376364

------

Scope: This fixes possible compilation crashes when Clang's arguments include relative -I paths in combination with -working-directory.

The filesystem passed to Clang (Swift's) had no working directory set, which causes differences in the way paths are built during module loading and hence different module hashes. Due to a separate issue, this can cause an already-finalised module to be rebuilt, causing a use after free and thus a wide variety of crashes.

Ideally we'd enforce the same working directory across Swift and Clang, but for now the FS passed to Clang is a wrapped version of Swift's, which allows setting the CWD separately.

Risk: Low. We're still using Swift's VFS, it's just wrapped and passed to Clang earlier so that the CWD can be set by the Clang driver while it's parsing arguments.

Testing: New test case for relative include path and working directory set vs an absolute include path