### PR TITLE
🍒[5.5][Concurrency] ban inheriting Actor explicitly by class

### DIFF
--- a/docs/Diagnostics.md
+++ b/docs/Diagnostics.md
@@ -51,6 +51,7 @@ Clang also has a kind of diagnostic called a "remark", which represents informat
   - "...to silence this warning"
   - "...here" (for a purely locational note)
 
+- If possible, it is best to include the name of the type or function that has the error, e.g. "non-actor type 'Nope' cannot ..." is better than "non-actor type cannot ...". It helps developers relate the error message to the specific type the error is about, even if the error would highlight the appropriate line / function in other ways. 
 
 ### Locations and Highlights ###
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4362,6 +4362,10 @@ ERROR(async_objc_dynamic_self,none,
 ERROR(actor_inheritance,none,
       "actor types do not support inheritance", ())
 
+ERROR(actor_protocol_illegal_inheritance,none,
+      "non-actor type %0 cannot conform to the 'Actor' protocol",
+      (DeclName))
+
 // FIXME: This diagnostic was temporarily downgraded from an error because
 // it spuriously triggers when building the Foundation module from its textual
 // swiftinterface. (rdar://78932296)

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5773,6 +5773,15 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
       }
     } else if (proto->isSpecificProtocol(KnownProtocolKind::Sendable)) {
       SendableConformance = conformance;
+    } else if (proto->isSpecificProtocol(KnownProtocolKind::Actor)) {
+      if (auto classDecl = dyn_cast<ClassDecl>(nominal)) {
+        if (!classDecl->isExplicitActor()) {
+          dc->getSelfNominalTypeDecl()
+              ->diagnose(diag::actor_protocol_illegal_inheritance,
+                         dc->getSelfNominalTypeDecl()->getName())
+              .fixItReplace(nominal->getStartLoc(), "actor");
+        }
+      }
     } else if (proto->isSpecificProtocol(
                    KnownProtocolKind::UnsafeSendable)) {
       unsafeSendableConformance = conformance;

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -763,6 +763,20 @@ func outsideSomeClassWithInits() { // expected-note 3 {{add '@MainActor' to make
 // ----------------------------------------------------------------------
 // Actor protocols.
 // ----------------------------------------------------------------------
+
+@available(SwiftStdlib 5.5, *)
+actor A: Actor { // ok
+}
+
+@available(SwiftStdlib 5.5, *)
+class C: Actor, UnsafeSendable {
+  // expected-error@-1{{non-actor type 'C' cannot conform to the 'Actor' protocol}}
+  // expected-warning@-2{{'UnsafeSendable' is deprecated: Use @unchecked Sendable instead}}
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
+    fatalError()
+  }
+}
+
 @available(SwiftStdlib 5.5, *)
 protocol P: Actor {
   func f()

--- a/test/decl/class/actor/basic.swift
+++ b/test/decl/class/actor/basic.swift
@@ -4,8 +4,10 @@
 
 actor MyActor { }
 
-class MyActorSubclass1: MyActor { } // expected-error{{actor types do not support inheritance}}
-// expected-error@-1{{non-final class 'MyActorSubclass1' cannot conform to `Sendable`; use `UnsafeSendable`}}
+class MyActorSubclass1: MyActor { }
+// expected-error@-1{{actor types do not support inheritance}}
+// expected-error@-2{{type 'MyActorSubclass1' cannot conform to the 'Actor' protocol}}
+// expected-error@-3{{non-final class 'MyActorSubclass1' cannot conform to `Sendable`; use `UnsafeSendable`}}
 
 actor MyActorSubclass2: MyActor { } // expected-error{{actor types do not support inheritance}}
 

--- a/test/decl/protocol/special/Actor.swift
+++ b/test/decl/protocol/special/Actor.swift
@@ -42,14 +42,18 @@ actor A7 {
 
 // A non-actor can conform to the Actor protocol, if it does it properly.
 @available(SwiftStdlib 5.5, *)
-class C1: Actor { // expected-error{{non-final class 'C1' cannot conform to `Sendable`; use `UnsafeSendable`}}
+class C1: Actor {
+  // expected-error@-1{{non-actor type 'C1' cannot conform to the 'Actor' protocol}}
+  // expected-error@-2{{non-final class 'C1' cannot conform to `Sendable`; use `UnsafeSendable`}}
   nonisolated var unownedExecutor: UnownedSerialExecutor {
     fatalError("")
   }
 }
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-class C2: Actor { // expected-error{{non-final class 'C2' cannot conform to `Sendable`; use `UnsafeSendable`}}
+class C2: Actor {
+  // expected-error@-1{{non-actor type 'C2' cannot conform to the 'Actor' protocol}}
+  // expected-error@-2{{non-final class 'C2' cannot conform to `Sendable`; use `UnsafeSendable`}}
   // FIXME: this should be an isolation violation
   var unownedExecutor: UnownedSerialExecutor {
     fatalError("")
@@ -57,7 +61,10 @@ class C2: Actor { // expected-error{{non-final class 'C2' cannot conform to `Sen
 }
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-class C3: Actor { // expected-error{{non-final class 'C3' cannot conform to `Sendable`; use `UnsafeSendable`}} expected-error {{type 'C3' does not conform to protocol 'Actor'}}
+class C3: Actor {
+  // expected-error@-1{{type 'C3' does not conform to protocol 'Actor'}}
+  // expected-error@-2{{non-actor type 'C3' cannot conform to the 'Actor' protocol}}
+  // expected-error@-3{{non-final class 'C3' cannot conform to `Sendable`; use `UnsafeSendable`}}
   nonisolated func enqueue(_ job: UnownedJob) { }
 }
 


### PR DESCRIPTION
Explanation: Actors can only be expressed by the `actor` keyword. We still allowed a `class` to conform to `Actor` which is wrong because it cannot declare actor isolated members. This bans classes conforming to the actor protocol.
Reviewer: @DougGregor 
Radar/SR Issue: rdar://79749091
Risk: Small.
Testing: PR testing and CI on main.
Original PR: https://github.com/apple/swift/pull/38050