### PR TITLE
Conform Never to Identifiable

### DIFF
--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -34,6 +34,11 @@ extension Never: Error {}
 
 extension Never: Equatable, Comparable, Hashable {}
 
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+extension Never: Identifiable {
+  public var id: Never { fatalError() }
+}
+
 //===----------------------------------------------------------------------===//
 // Standardized aliases
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -36,7 +36,9 @@ extension Never: Equatable, Comparable, Hashable {}
 
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 extension Never: Identifiable {
-  public var id: Never { fatalError() }
+  public var id: Never {
+    switch self {}
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -70,5 +70,6 @@ Protocol CodingKey has added inherited protocol Sendable
 Protocol CodingKey has generic signature change from <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomStringConvertible> to <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomStringConvertible, Self : Swift.Sendable>
 Protocol Error has added inherited protocol Sendable
 Protocol Error has generic signature change from to <Self : Swift.Sendable>
+Enum Never has added a conformance to an existing protocol Identifiable
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)


### PR DESCRIPTION
Incorporating into `main` as part of evolution review discussion. This can be reverted if the Core team decides to not accept this change.

rdar://75988520