### PR TITLE
[Swift Next] Explicitly include required types

### DIFF
--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_AST_ASTWALKER_H
 #define SWIFT_AST_ASTWALKER_H
 
+#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/PointerUnion.h"
 #include <utility>
 

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -20,6 +20,7 @@
 #include "swift/Basic/EditorPlaceholder.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/Support/TrailingObjects.h"

--- a/include/swift/Basic/BlotSetVector.h
+++ b/include/swift/Basic/BlotSetVector.h
@@ -15,6 +15,7 @@
 
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallVector.h"
 #include <vector>
 

--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -25,6 +25,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/VersionTuple.h"
+#include <array>
 #include <string>
 
 namespace swift {

--- a/include/swift/SIL/Notifications.h
+++ b/include/swift/SIL/Notifications.h
@@ -17,6 +17,7 @@
 #include "swift/Basic/STLExtras.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 #include <memory>
 
 namespace swift {


### PR DESCRIPTION
A bunch of types where the full definition was required broke when `DenseMapInfo.h` was refactored. This file used to include `ArrayRef.h` and `StringRef.h` explicitly, which was transitively passed down to us. After the refactor, these includes were removed, so we don't get the type definitions anymore. I think I got all of them here, but more might be hiding deeper in the build.

rdar://79699826