### PR TITLE
[NFC] Add a fast type checker test for rdar://74853403.

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/rdar74853403.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar74853403.swift
@@ -1,0 +1,14 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asan
+
+func makeString(_ strings: [String]) -> String { "" }
+func makeString(_ string: String) -> String { "" }
+
+func test(message: inout String, d: [String: String]?) {
+  message += d.map {
+    $0.reduce("") {
+      $0 + makeString($1.key) + "" + makeString($1.value) + "" + makeString($1.key) + ""
+    }
+  } ?? ""
+}
+


### PR DESCRIPTION
Thanks to @xedin's recent optimization to propagate contextual types for closures into closure bodies, this is super fast now. The solver statistics are impressive:

```
---Solver statistics---
Total number of scopes explored: 131
Maximum depth reached while exploring solutions: 21
```

Resolves: rdar://74853403