### PR TITLE
[Amendment] SE-0296: Allow overloads that differ only in async

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -228,6 +228,9 @@ struct OverloadSignature {
   /// Whether this is a function.
   unsigned IsFunction : 1;
 
+  /// Whether this is an async function.
+  unsigned IsAsyncFunction : 1;
+
   /// Whether this is a enum element.
   unsigned IsEnumElement : 1;
 
@@ -249,8 +252,9 @@ struct OverloadSignature {
 
   OverloadSignature()
       : UnaryOperator(UnaryOperatorKind::None), IsInstanceMember(false),
-        IsVariable(false), IsFunction(false), InProtocolExtension(false),
-        InExtensionOfGenericType(false), HasOpaqueReturnType(false) { }
+        IsVariable(false), IsFunction(false), IsAsyncFunction(false),
+        InProtocolExtension(false), InExtensionOfGenericType(false),
+        HasOpaqueReturnType(false) { }
 };
 
 /// Determine whether two overload signatures conflict.

--- a/test/ClangImporter/objc_async_conformance.swift
+++ b/test/ClangImporter/objc_async_conformance.swift
@@ -20,12 +20,11 @@ extension C2 {
 }
 
 // a version of C2 that requires both sync and async methods (differing only by
-// completion handler) in ObjC, is not possible to conform to with 'async' in
-// a Swift protocol
+// completion handler) in ObjC.
 class C3 : NSObject, RequiredObserver {}
 extension C3 {
-  func hello() -> Bool { true } // expected-note {{'hello()' previously declared here}}
-  func hello() async -> Bool { true } // expected-error {{invalid redeclaration of 'hello()'}}
+  func hello() -> Bool { true }
+  func hello() async -> Bool { true }
 }
 
 // the only way to conform to 'RequiredObserver' in Swift is to not use 'async'

--- a/test/decl/func/async.swift
+++ b/test/decl/func/async.swift
@@ -6,8 +6,8 @@
 func redecl1() async { } // expected-note{{previously declared here}}
 func redecl1() async throws { } // expected-error{{invalid redeclaration of 'redecl1()'}}
 
-func redecl2() -> String { "" } // expected-note{{previously declared here}}
-func redecl2() async -> String { "" } // expected-error{{invalid redeclaration of 'redecl2()'}}
+func redecl2() -> String { "" } // okay
+func redecl2() async -> String { "" } // okay
 
 // Override checking
 


### PR DESCRIPTION
**Explanation**: Implement the async/await [amendment](https://github.com/apple/swift-evolution/pull/1392) currently under review that allows overloads that differ only in `async` vs. non-`async`.
**Scope**: Only affects programs that have already adopted Swift Concurrency. This loosens the rules around declaring overloads, so it accepts strictly more code that the existing language.
**Radar/SR Issue**: rdar://79788345
**Risk**: Low.
**Testing**: PR testing and CI on main.
**Original PR**: https://github.com/apple/swift/pull/38107
