### PR TITLE
🍒[5.5][Concurrency] Add tsan_release edge on task creation

### DIFF
--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -335,6 +335,8 @@ static void swift_task_enqueueGlobalImpl(Job *job) {
 }
 
 void swift::swift_task_enqueueGlobal(Job *job) {
+  _swift_tsan_release(job);
+
   if (swift_task_enqueueGlobal_hook)
     swift_task_enqueueGlobal_hook(job, swift_task_enqueueGlobalImpl);
   else

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -950,7 +950,7 @@ static void resumeTaskAfterContinuation(AsyncTask *task,
 
   // Make sure TSan knows that the resume call happens-before the task
   // restarting.
-  _swift_tsan_release(task);
+  _swift_tsan_release(static_cast<Job *>(task));
 
   // The status should be either Pending or Awaited.  If it's Awaited,
   // which is probably the most likely option, then we should immediately

--- a/stdlib/public/Concurrency/ThreadSanitizer.cpp
+++ b/stdlib/public/Concurrency/ThreadSanitizer.cpp
@@ -31,12 +31,18 @@ TSanFunc *tsan_acquire, *tsan_release;
 void swift::_swift_tsan_acquire(void *addr) {
   if (tsan_acquire) {
     tsan_acquire(addr);
+#if SWIFT_TASK_PRINTF_DEBUG
+    fprintf(stderr, "[%lu] tsan_acquire on %p\n", _swift_get_thread_id(), addr);
+#endif
   }
 }
 
 void swift::_swift_tsan_release(void *addr) {
   if (tsan_release) {
     tsan_release(addr);
+#if SWIFT_TASK_PRINTF_DEBUG
+    fprintf(stderr, "[%lu] tsan_release on %p\n", _swift_get_thread_id(), addr);
+#endif
   }
 }
 

--- a/test/Concurrency/Runtime/actor_counters.swift
+++ b/test/Concurrency/Runtime/actor_counters.swift
@@ -28,6 +28,12 @@ actor Counter {
     value = value + 1
     return current
   }
+
+  deinit {
+      for i in 0..<value {
+          assert(scratchBuffer[i] == 1)
+      }
+  }
 }
 
 

--- a/test/Sanitizers/tsan/actor_counters.swift
+++ b/test/Sanitizers/tsan/actor_counters.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch -parse-as-library -sanitize=thread) | grep -v "^Worker"
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch -parse-as-library -sanitize=thread)
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
@@ -7,12 +7,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: linux
 // UNSUPPORTED: windows
-
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-import Glibc
-#endif
 
 @available(SwiftStdlib 5.5, *)
 actor Counter {
@@ -66,7 +60,7 @@ func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   for i in 0..<numWorkers {
     workers.append(
       detach { [counters] in
-        usleep(UInt32.random(in: 0..<100) * 1000)
+        await Task.sleep(UInt64.random(in: 0..<100) * 1_000_000)
         await worker(identity: i, counters: counters, numIterations: numIterations)
       }
     )


### PR DESCRIPTION
Explanation: Ensure new tasks that are not immediately scheduled via `swift_task_enqueue()` on creation still get a tsan_release edge once they are eventually scheduled.  Not all task scheduling goes through our `swift_task_enqueue()` funnel, some places call `swift_task_enqueueGlobal()` directly instead. So also add an edge there.
Reviewer: @ktoso @jckarter 
Radar/SR Issue: rdar://78932849
Risk: Small.
Testing: PR testing and CI on main.
Original PR: #38074