### PR TITLE
Fix SILGen of access to isolated static properties

### DIFF
--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -207,9 +207,9 @@ public:
 /// The only operation on this component is `project`.
 class PhysicalPathComponent : public PathComponent {
   virtual void _anchor() override;
+  Optional<ActorIsolation> ActorIso;
 
 protected:
-  Optional<ActorIsolation> ActorIso;
   PhysicalPathComponent(LValueTypeData typeData, KindTy Kind,
                         Optional<ActorIsolation> actorIso = None)
     : PathComponent(typeData, Kind), ActorIso(actorIso) {
@@ -217,8 +217,16 @@ protected:
   }
 
 public:
-  // Obtains the actor-isolation required for any loads of this component.
-  Optional<ActorIsolation> getActorIsolation() const { return ActorIso; }
+  /// Obtains and consumes the actor-isolation required for any loads of
+  /// this component.
+  Optional<ActorIsolation> takeActorIsolation() {
+    Optional<ActorIsolation> current = ActorIso;
+    ActorIso = None;
+    return current;
+  }
+
+  /// Determines whether this component has any actor-isolation.
+  bool hasActorIsolation() const { return ActorIso.hasValue(); }
 };
 
 inline PhysicalPathComponent &PathComponent::asPhysical() {

--- a/test/Concurrency/Runtime/async_properties_actor.swift
+++ b/test/Concurrency/Runtime/async_properties_actor.swift
@@ -8,6 +8,21 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
+struct Container {
+    @MainActor static var counter: Int = 10
+    @MainActor static var this: Container?
+
+    var noniso: Int = 20
+
+    static func getCount() async -> Int {
+        return await counter
+    }
+
+    static func getValue() async -> Int? {
+        return await this?.noniso
+    }
+}
+
 @propertyWrapper
 struct SuccessTracker {
     private var _stored: Bool
@@ -142,6 +157,13 @@ actor Tester {
         print("done property wrapper test")
         return true
     }
+
+    func doContainerTest() async -> Bool {
+        var total: Int = 0
+        total += await Container.getCount()
+        total += await Container.getValue() ?? 0
+        return total == 10
+    }
 }
 
 @globalActor
@@ -169,6 +191,10 @@ var expectedResult : Bool {
 
         guard await test.doPropertyWrapperTest() == success else {
             fatalError("fail property wrapper test")
+        }
+
+        guard await test.doContainerTest() == success else {
+            fatalError("fail container test")
         }
 
         // CHECK: done all testing


### PR DESCRIPTION
When accessing a static property isolated to a
global-actor, such as MainActor, a `hop_to_executor`
was not being emitted. This was caught by an assertion
I had left to catch such cases, but of course in release
builds this will lead to incorrect SIL, etc.

- [x] Fix basic access of a simple stored property
- [x] Fix access of an optional reference type with chained lookup.
- [x] Prevent emission of double-hop on standard access of static global (the `getCount` case).

Resolves rdar://78292384