### PR TITLE
[5.5][Parse] Don't skip '}' when recovering from 'default' outside 'switch'

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -512,12 +512,12 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
 }
 
 /// Recover from a 'case' or 'default' outside of a 'switch' by consuming up to
-/// the next ':'.
+/// the next ':' or '}'.
 static ParserResult<Stmt> recoverFromInvalidCase(Parser &P) {
   assert(P.Tok.is(tok::kw_case) || P.Tok.is(tok::kw_default)
          && "not case or default?!");
   P.diagnose(P.Tok, diag::case_outside_of_switch, P.Tok.getText());
-  P.skipUntil(tok::colon);
+  P.skipUntil(tok::colon, tok::r_brace);
   // FIXME: Return an ErrorStmt?
   return nullptr;
 }

--- a/validation-test/IDE/crashers_2_fixed/rdar78781163.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar78781163.swift
@@ -1,0 +1,9 @@
+// RUN: %swift-ide-test -code-completion -code-completion-token=COMPLETE -source-filename %s
+
+class C {
+    func foo() {
+        #^COMPLETE^#
+        default
+    }
+    func bar() {}
+}


### PR DESCRIPTION
Cherry-pick #38036 into `release/5.5`

* **Explanation**: Fixes an assertion failure in code completion. Previously, when the parser finds `case` or `default` outside `switch` statement, it skips to the next `:` or EOF ignoring the end of the function body (i.e. `}`). This behavior is not only undesirable for the error recovery, but causes an assertion failure in code completion.
* **Scope**: Parser recovery for `case`/`default` outside `switch`
* **Risk**: Low
* **Testing**: Added regression test cases for code completion
* **Issue**: rdar://78781163
* **Reviewer**: Alex Hoppen (@ahoppen)