### PR TITLE
Fix usage strings when printing help for frontend tools

### DIFF
--- a/tools/driver/autolink_extract_main.cpp
+++ b/tools/driver/autolink_extract_main.cpp
@@ -80,9 +80,7 @@ public:
     }
 
     if (ParsedArgs.getLastArg(OPT_help)) {
-      std::string ExecutableName =
-          llvm::sys::path::stem(MainExecutablePath).str();
-      Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
+      Table->PrintHelp(llvm::outs(), "swift autolink-extract",
                        "Swift Autolink Extract", options::AutolinkExtractOption,
                        0, /*ShowAllAliases*/false);
       return 1;

--- a/tools/driver/modulewrap_main.cpp
+++ b/tools/driver/modulewrap_main.cpp
@@ -93,9 +93,7 @@ public:
     }
 
     if (ParsedArgs.getLastArg(OPT_help)) {
-      std::string ExecutableName =
-          llvm::sys::path::stem(MainExecutablePath).str();
-      Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
+      Table->PrintHelp(llvm::outs(), "swift -modulewrap",
                        "Swift Module Wrapper", options::ModuleWrapOption, 0,
                        /*ShowAllAliases*/false);
       return 1;

--- a/tools/driver/swift_api_digester_main.cpp
+++ b/tools/driver/swift_api_digester_main.cpp
@@ -2650,9 +2650,7 @@ public:
   }
 
   void printHelp() {
-    std::string ExecutableName =
-        llvm::sys::path::stem(MainExecutablePath).str();
-    Table->PrintHelp(llvm::outs(), ExecutableName.c_str(), "Swift API Digester",
+    Table->PrintHelp(llvm::outs(), "swift api-digester", "Swift API Digester",
                      /*IncludedFlagsBitmask*/ SwiftAPIDigesterOption,
                      /*ExcludedFlagsBitmask*/ 0,
                      /*ShowAllAliases*/ false);

--- a/tools/driver/swift_api_extract_main.cpp
+++ b/tools/driver/swift_api_extract_main.cpp
@@ -63,9 +63,7 @@ public:
     }
 
     if (ParsedArgs.getLastArg(OPT_help)) {
-      std::string ExecutableName =
-          llvm::sys::path::stem(MainExecutablePath).str();
-      Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
+      Table->PrintHelp(llvm::outs(), "swift api-extract",
                        "Swift API Extract", options::SwiftAPIExtractOption, 0,
                        /*ShowAllAliases*/ false);
       return 1;

--- a/tools/driver/swift_symbolgraph_extract_main.cpp
+++ b/tools/driver/swift_symbolgraph_extract_main.cpp
@@ -60,9 +60,7 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
   auto MainExecutablePath = llvm::sys::fs::getMainExecutable(Argv0, MainAddr);
 
   if (ParsedArgs.getLastArg(OPT_help) || Args.empty()) {
-    std::string ExecutableName =
-        llvm::sys::path::stem(MainExecutablePath).str();
-    Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
+    Table->PrintHelp(llvm::outs(), "swift symbolgraph-extract",
                      "Swift Symbol Graph Extractor",
                      SwiftSymbolGraphExtractOption, 0,
                      /*ShowAllAliases*/ false);


### PR DESCRIPTION
This PR updates the USAGE: string in the help text of various frontend tools. Currently, these all use `llvm::sys::fs::getMainExecutablePath` and print `USAGE: swift-frontend`, which can be confusing. Instead, just hardcode the command that can be used to run each tool.
