### PR TITLE
[SR-14720][Sema] Improve assign escapeness mismatch diagnostic for function type parameters

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3890,6 +3890,13 @@ ERROR(converting_noattrfunc_to_type,none,
       "converting %select{non-escaping|non-concurrent function}0 value to %1 "
       "may %select{allow it to escape|introduce data races}0",
       (unsigned, Type))
+ERROR(converting_noattrfunc_contravariant_parameter_position,none,
+      "converting escaping to non-escaping functions of type %2 in parameter position "
+      "#%0 of function type member %1 is not allowed",
+      (unsigned, Identifier, Type))
+NOTE(add_explicit_escaping,none,
+     "add explicit @escaping to function parameter #%0",
+     (unsigned))
 
 ERROR(converting_func_loses_global_actor,none,
       "converting function value of type %0 to %1 loses global actor %2",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3890,10 +3890,9 @@ ERROR(converting_noattrfunc_to_type,none,
       "converting %select{non-escaping|non-concurrent function}0 value to %1 "
       "may %select{allow it to escape|introduce data races}0",
       (unsigned, Type))
-ERROR(converting_noattrfunc_contravariant_parameter_position,none,
-      "converting escaping to non-escaping functions of type %2 in parameter position "
-      "#%0 of function type %3 %1 is not allowed",
-      (unsigned, Identifier, Type, DescriptiveDeclKind))
+NOTE(escape_expected_at_parameter_position,none,
+     "parameter #%0 expects escaping value of type %1",
+     (unsigned, Type))
 NOTE(add_explicit_escaping,none,
      "add explicit @escaping to function parameter #%0",
      (unsigned))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3892,8 +3892,8 @@ ERROR(converting_noattrfunc_to_type,none,
       (unsigned, Type))
 ERROR(converting_noattrfunc_contravariant_parameter_position,none,
       "converting escaping to non-escaping functions of type %2 in parameter position "
-      "#%0 of function type member %1 is not allowed",
-      (unsigned, Identifier, Type))
+      "#%0 of function type %3 %1 is not allowed",
+      (unsigned, Identifier, Type, DescriptiveDeclKind))
 NOTE(add_explicit_escaping,none,
      "add explicit @escaping to function parameter #%0",
      (unsigned))

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -740,6 +740,11 @@ private:
   /// argument, or trying to assign it to a variable which expects @escaping
   /// or @Sendable function.
   bool diagnoseParameterUse() const;
+
+  /// Emit a tailored diagnostic for a no-escape/espace mismatch for function
+  /// arguments where the mismatch has to take into account that a
+  /// function type subtype relation in the parameter position is contravariant.
+  bool diagnoseFunctionParameterEscapenessMismatch(AssignExpr *) const;
 };
 
 /// Diagnose failure where a global actor attribute is dropped when

--- a/test/Constraints/function_conversion.swift
+++ b/test/Constraints/function_conversion.swift
@@ -57,9 +57,9 @@ func twoFns(_ f: (Int) -> Int, _ g: @escaping (Int) -> Int) {
 takesAny(consumeNoEscape)
 takesAny(consumeEscaping)
 
-var noEscapeParam: ((Int) -> Int) -> () = consumeNoEscape
+var noEscapeParam: ((Int) -> Int) -> () = consumeNoEscape // expected-note {{add explicit @escaping to function parameter}}{{21-21=@escaping }}
 var escapingParam: (@escaping (Int) -> Int) -> () = consumeEscaping
-noEscapeParam = escapingParam // expected-error {{converting non-escaping value to '(Int) -> Int' may allow it to escape}}
+noEscapeParam = escapingParam // expected-error {{converting escaping to non-escaping functions of type '(Int) -> Int' in parameter position #0 of function type var 'noEscapeParam' is not allowed}}
 
 escapingParam = takesAny
 noEscapeParam = takesAny // expected-error {{converting non-escaping value to 'Any' may allow it to escape}}

--- a/test/Constraints/function_conversion.swift
+++ b/test/Constraints/function_conversion.swift
@@ -59,7 +59,8 @@ takesAny(consumeEscaping)
 
 var noEscapeParam: ((Int) -> Int) -> () = consumeNoEscape // expected-note {{add explicit @escaping to function parameter}}{{21-21=@escaping }}
 var escapingParam: (@escaping (Int) -> Int) -> () = consumeEscaping
-noEscapeParam = escapingParam // expected-error {{converting escaping to non-escaping functions of type '(Int) -> Int' in parameter position #0 of function type var 'noEscapeParam' is not allowed}}
+noEscapeParam = escapingParam // expected-error {{cannot assign value of type '(@escaping (Int) -> Int) -> ()' to type '((Int) -> Int) -> ()'}}
+// expected-note@-1{{parameter #0 expects escaping value of type '(Int) -> Int'}}
 
 escapingParam = takesAny
 noEscapeParam = takesAny // expected-error {{converting non-escaping value to 'Any' may allow it to escape}}

--- a/test/attr/attr_escaping.swift
+++ b/test/attr/attr_escaping.swift
@@ -153,7 +153,7 @@ class FooClass {
   }
   var computedEscaping : (@escaping ()->Int)->Void {
     get { return stored! }
-    set(newValue) { stored = newValue } // expected-error{{converting escaping to non-escaping functions of type '() -> Int' in parameter position #0 of function type member 'stored' is not allowed}}
+    set(newValue) { stored = newValue } // expected-error{{converting escaping to non-escaping functions of type '() -> Int' in parameter position #0 of function type property 'stored' is not allowed}}
   }
 }
 
@@ -231,6 +231,8 @@ extension SR_9760 {
 func foo<T>(_ x: @escaping T) {} // expected-error 1{{@escaping attribute only applies to function types}}
 
 // SR-14720
+var global: ((() -> Void) -> Void)? = nil // expected-note {{add explicit @escaping to function parameter #0}} {{15-15=@escaping }}
+
 class SR14720 {
   let ok: (@escaping () -> Void) -> Void // OK
   let callback: (() -> Void) -> Void // expected-note {{add explicit @escaping to function parameter #0}} {{18-18=@escaping }}
@@ -239,19 +241,23 @@ class SR14720 {
   let callbackOpt: ((() -> Void) -> Void)? // expected-note{{add explicit @escaping to function parameter #0}} {{22-22=@escaping }}
 
   init(f: @escaping (@escaping() -> Void) -> Void) {
-    self.callback = f // expected-error{{converting escaping to non-escaping functions of type '() -> Void' in parameter position #0 of function type member 'callback' is not allowed}}
+    self.callback = f // expected-error{{converting escaping to non-escaping functions of type '() -> Void' in parameter position #0 of function type property 'callback' is not allowed}}
     self.ok = f // Ok
   }
 
   init(af: @escaping (@escaping() -> Void) -> Void) {
-    self.callbackOpt = af // expected-error{{converting escaping to non-escaping functions of type '() -> Void' in parameter position #0 of function type member 'callbackOpt' is not allowed}}
+    self.callbackOpt = af // expected-error{{converting escaping to non-escaping functions of type '() -> Void' in parameter position #0 of function type property 'callbackOpt' is not allowed}}
+  }
+
+  init(ag: @escaping (@escaping() -> Void) -> Void) {
+    global = ag // expected-error{{converting escaping to non-escaping functions of type '() -> Void' in parameter position #0 of function type var 'global' is not allowed}}
   }
 
   init(a: @escaping (@escaping () -> Void) -> Void) {
-    self.callbackAuto = a // expected-error{{converting escaping to non-escaping functions of type '() -> Void' in parameter position #0 of function type member 'callbackAuto' is not allowed}}
+    self.callbackAuto = a // expected-error{{converting escaping to non-escaping functions of type '() -> Void' in parameter position #0 of function type property 'callbackAuto' is not allowed}}
   }
 
   init(f: @escaping (() -> Void, @escaping() -> Void) -> Void) {
-    self.callback1 = f // expected-error{{converting escaping to non-escaping functions of type '() -> Void' in parameter position #1 of function type member 'callback1' is not allowed}}
+    self.callback1 = f // expected-error{{converting escaping to non-escaping functions of type '() -> Void' in parameter position #1 of function type property 'callback1' is not allowed}}
   }
 }

--- a/test/attr/attr_escaping.swift
+++ b/test/attr/attr_escaping.swift
@@ -153,7 +153,8 @@ class FooClass {
   }
   var computedEscaping : (@escaping ()->Int)->Void {
     get { return stored! }
-    set(newValue) { stored = newValue } // expected-error{{converting escaping to non-escaping functions of type '() -> Int' in parameter position #0 of function type property 'stored' is not allowed}}
+    set(newValue) { stored = newValue } // expected-error{{cannot assign value of type '(@escaping () -> Int) -> Void' to type '(() -> Int) -> Void'}}
+    // expected-note@-1{{parameter #0 expects escaping value of type '() -> Int'}}
   }
 }
 
@@ -241,23 +242,28 @@ class SR14720 {
   let callbackOpt: ((() -> Void) -> Void)? // expected-note{{add explicit @escaping to function parameter #0}} {{22-22=@escaping }}
 
   init(f: @escaping (@escaping() -> Void) -> Void) {
-    self.callback = f // expected-error{{converting escaping to non-escaping functions of type '() -> Void' in parameter position #0 of function type property 'callback' is not allowed}}
+    self.callback = f // expected-error{{cannot assign value of type '(@escaping () -> Void) -> Void' to type '(() -> Void) -> Void'}}
+    // expected-note@-1{{parameter #0 expects escaping value of type '() -> Void'}}
     self.ok = f // Ok
   }
 
   init(af: @escaping (@escaping() -> Void) -> Void) {
-    self.callbackOpt = af // expected-error{{converting escaping to non-escaping functions of type '() -> Void' in parameter position #0 of function type property 'callbackOpt' is not allowed}}
+    self.callbackOpt = af // expected-error{{cannot assign value of type '(@escaping () -> Void) -> Void' to type '(() -> Void) -> Void'}}
+    // expected-note@-1{{parameter #0 expects escaping value of type '() -> Void'}}  
   }
 
   init(ag: @escaping (@escaping() -> Void) -> Void) {
-    global = ag // expected-error{{converting escaping to non-escaping functions of type '() -> Void' in parameter position #0 of function type var 'global' is not allowed}}
+    global = ag // expected-error{{cannot assign value of type '(@escaping () -> Void) -> Void' to type '(() -> Void) -> Void'}}
+    // expected-note@-1{{parameter #0 expects escaping value of type '() -> Void'}}
   }
 
   init(a: @escaping (@escaping () -> Void) -> Void) {
-    self.callbackAuto = a // expected-error{{converting escaping to non-escaping functions of type '() -> Void' in parameter position #0 of function type property 'callbackAuto' is not allowed}}
+    self.callbackAuto = a // expected-error{{cannot assign value of type '(@escaping () -> Void) -> Void' to type '(@autoclosure () -> Void) -> Void'}}
+    // expected-note@-1{{parameter #0 expects escaping value of type '() -> Void'}}
   }
 
   init(f: @escaping (() -> Void, @escaping() -> Void) -> Void) {
-    self.callback1 = f // expected-error{{converting escaping to non-escaping functions of type '() -> Void' in parameter position #1 of function type property 'callback1' is not allowed}}
+    self.callback1 = f // expected-error{{cannot assign value of type '(() -> Void, @escaping () -> Void) -> Void' to type '(() -> Void, () -> Void) -> Void'}}
+    // expected-note@-1{{parameter #1 expects escaping value of type '() -> Void'}}
   }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
This adds a tailored diagnostics for when escapeness mismatch is on the function parameter of another function type in an assign expr.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-14720.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
