### PR TITLE
[Incremental] Adjust test to cope with better remark in new driver

### DIFF
--- a/test/Driver/Dependencies/driver-show-incremental-mutual-fine.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-mutual-fine.swift
@@ -16,4 +16,4 @@
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 // CHECK-THIRD: Queuing (initial): {compile: other.o <= other.swift}
 // CHECK-THIRD-DAG: Queuing because of the initial set: {compile: main.o <= main.swift}
-// CHECK-THIRD-DAG: interface of top-level name 'a' in other.swift -> interface of source file main.swiftdeps
+// CHECK-THIRD-DAG: interface of top-level name 'a' in other.swift -> interface of source file {{from main.swiftdeps in main.swift|main.swiftdeps}}


### PR DESCRIPTION
Unblocks https://ci.swift.org/job/swift-PR-macos/ by adjusting test to cope with the improved remark in https://github.com/apple/swift-driver/pull/728 .