### PR TITLE
C++ Interop: avoid adding static members to the value constructor

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1399,6 +1399,9 @@ createValueConstructor(ClangImporter::Implementation &Impl,
   // Construct the set of parameters from the list of members.
   SmallVector<ParamDecl *, 8> valueParameters;
   for (auto var : members) {
+    if (var->isStatic())
+      continue;
+
     bool generateParamName = wantCtorParamNames;
 
     if (var->hasClangNode()) {

--- a/test/Interop/Cxx/static/Inputs/static-member-var.h
+++ b/test/Interop/Cxx/static/Inputs/static-member-var.h
@@ -37,6 +37,12 @@ public:
   constexpr static float definedInlineFromMethod = getFloatValue();
 };
 
+class WithStaticAndInstanceMember {
+public:
+  int myInstance;
+  static int myStatic;
+};
+
 class ClassA {
 public:
   static int notUniqueName;

--- a/test/Interop/Cxx/static/static-member-var-module-interface.swift
+++ b/test/Interop/Cxx/static/static-member-var-module-interface.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=StaticMemberVar -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK: struct WithStaticAndInstanceMember {
+// CHECK-NEXT:   static var myStatic: Int32
+// CHECK-NEXT:   var myInstance: Int32
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   init(myInstance: Int32)
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/static/static-member-var.swift
+++ b/test/Interop/Cxx/static/static-member-var.swift
@@ -90,4 +90,9 @@ StaticMemberVarTestSuite.test("no-collisions") {
   expectEqual(169, ClassB.notUniqueName)
 }
 
+StaticMemberVarTestSuite.test("init-struct-with-static-member") {
+  let obj = WithStaticAndInstanceMember(myInstance: 123)
+  expectEqual(123, obj.myInstance)
+}
+
 runAllTests()


### PR DESCRIPTION
Value constructors for C++ structs shouldn't try to initialize static members of the struct.

For example:
```cpp
class WithStaticAndInstanceMember {
public:
  int myInstance;
  static int myStatic;
};
```
The value constructor should be `init(myInstance: Int32)`, not `init(myInstance: Int32, myStatic: Int32)`.