### PR TITLE
[build-script] Use a toolchain file and always cross compile cmark.

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/cmark.py
+++ b/utils/swift_build_support/swift_build_support/products/cmark.py
@@ -10,8 +10,6 @@
 #
 # ----------------------------------------------------------------------------
 
-from build_swift.build_swift.wrappers import xcrun
-
 from . import cmake_product
 from . import earlyswiftdriver
 
@@ -61,20 +59,12 @@ class CMark(cmake_product.CMakeProduct):
            host_target.startswith("appletv") or \
            host_target.startswith("watch"):
 
-            cmake_os_sysroot = xcrun.sdk_path(platform)
-
-            cmake_osx_deployment_target = ''
-            if platform == "macosx":
-                cmake_osx_deployment_target = self.args.darwin_deployment_version_osx
-
             common_c_flags = ' '.join(self.common_cross_c_flags(platform, arch))
 
             self.cmake_options.define('CMAKE_C_FLAGS', common_c_flags)
             self.cmake_options.define('CMAKE_CXX_FLAGS', common_c_flags)
-            self.cmake_options.define('CMAKE_OSX_SYSROOT:PATH', cmake_os_sysroot)
-            self.cmake_options.define('CMAKE_OSX_DEPLOYMENT_TARGET',
-                                      cmake_osx_deployment_target)
-            self.cmake_options.define('CMAKE_OSX_ARCHITECTURES', arch)
+            toolchain_file = self.generate_darwin_toolchain_file(platform, arch)
+            self.cmake_options.define('CMAKE_TOOLCHAIN_FILE:PATH', toolchain_file)
 
         self.build_with_cmake(["all"], self.args.cmark_build_variant, [])
 

--- a/validation-test/BuildSystem/cmark_crosscompile_using_toolchain_always.test
+++ b/validation-test/BuildSystem/cmark_crosscompile_using_toolchain_always.test
@@ -1,0 +1,9 @@
+# REQUIRES: standalone_build
+# REQUIRES: OS=macosx
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --cmake %cmake --skip-build-llvm --skip-build-swift 2>&1 | %FileCheck %s
+
+# CHECK: DRY_RUN! Writing Toolchain file to path:{{.*}}BuildScriptToolchain.cmake
+# CHECK: cmake {{.*}}-DCMAKE_TOOLCHAIN_FILE:PATH={{.*}}BuildScriptToolchain.cmake {{.*}}cmark


### PR DESCRIPTION
NOTE: We still build for the host platform always, but even in that case within
cmark itself, we are cross compiling it.
