### PR TITLE
[SILGen] Improve the visibility handling of private setters in key paths

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3507,11 +3507,9 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
   auto isSettableInComponent = [&]() -> bool {
     // For storage we reference by a property descriptor, the descriptor will
     // supply the settability if needed. We only reference it here if the
-    // setter is public.
-    if (shouldUseExternalKeyPathComponent())
-      return storage->isSettable(useDC)
-        && storage->isSetterAccessibleFrom(useDC);
-    return storage->isSettable(storage->getDeclContext());
+    // setter is accessible.
+    return storage->isSettable(useDC)
+      && storage->isSetterAccessibleFrom(useDC);
   };
 
   // We cannot use the same opened archetype in the getter and setter. Therefore

--- a/test/SILGen/keypath_property_descriptors.swift
+++ b/test/SILGen/keypath_property_descriptors.swift
@@ -122,12 +122,12 @@ public struct A {
     set { }
   }
 
-  // PRIVATEIMPORTS-LABEL: sil_property #A.privateSetter (settable_property
+  // PRIVATEIMPORTS-LABEL: sil_property #A.privateSetter (gettable_property
   public private(set) var privateSetter: Int {
     get { return 0 }
     set { }
   }
-  // PRIVATEIMPORTS-LABEL: sil_property #A.fileprivateSetter (settable_property
+  // PRIVATEIMPORTS-LABEL: sil_property #A.fileprivateSetter (gettable_property
   public fileprivate(set) var fileprivateSetter: Int {
     get { return 0 }
     set { }
@@ -158,7 +158,7 @@ public struct FixedLayout {
 public class Foo {}
 extension Array where Element == Foo {
   public class Bar {
-    // NONRESILIENT-LABEL: sil_property #Array.Bar.dontCrash<τ_0_0 where τ_0_0 == Foo> (settable_property $Int
+    // NONRESILIENT-LABEL: sil_property #Array.Bar.dontCrash<τ_0_0 where τ_0_0 == Foo> (gettable_property $Int
     public private(set) var dontCrash : Int {
       get {
         return 10

--- a/test/SILGen/keypaths_multi_file.swift
+++ b/test/SILGen/keypaths_multi_file.swift
@@ -17,13 +17,13 @@ func foo(x: Int) -> KeyPath<A, Int> {
   return \A.x
 }
 
-// A.x setter
-// CHECK-LABEL: sil hidden_external @$s8keypaths1AV1xSivs
-// DEFINITION-LABEL: sil hidden [ossa] @$s8keypaths1AV1xSivs
+// A.x getter
+// CHECK-LABEL: sil hidden_external @$s8keypaths1AV1xSivg
+// DEFINITION-LABEL: sil hidden [ossa] @$s8keypaths1AV1xSivg
 
-// A.subscript setter
-// CHECK-LABEL: sil hidden_external @$s8keypaths1AVyS2icis
-// DEFINITION-LABEL: sil hidden [ossa] @$s8keypaths1AVyS2icis
+// A.subscript getter
+// CHECK-LABEL: sil hidden_external @$s8keypaths1AVyS2icig
+// DEFINITION-LABEL: sil hidden [ossa] @$s8keypaths1AVyS2icig
 
 func bar<T>(_: T) {
   _ = \C<T>.b

--- a/test/stdlib/KeyPathMultiModule.swift
+++ b/test/stdlib/KeyPathMultiModule.swift
@@ -55,7 +55,6 @@ keyPathMultiModule.test("identity across multiple modules") {
     expectEqualWithHashes(A_y_keypath(), \A.y)
     expectEqualWithHashes(A_z_keypath(), \A.z)
     expectEqualWithHashes(A_w_keypath(), \A.w)
-    expectEqualWithHashes(A_v_keypath(), \A.v)
     expectEqualWithHashes(A_immutable_keypath(), \A.immutable)
     expectEqualWithHashes(A_subscript_withGeneric_keypath(index: 0), \A.[withGeneric: 0])
     expectEqualWithHashes(A_subscript_withGeneric_keypath(index: "butt"),


### PR DESCRIPTION
### Background

Resolves SR-6452.

SR-6452 is marked as resolved, however the fact is it is still reproducible using the latest compiler. I'd like to help solve this problem.

### Proposed Solution

I found that the problem is that SILGen creates a setter for the key path, however the setter is not visible when the linker tries to link. I think we should check whether the setter is accessible from the location that creates the key path before generates the key path setter.

It makes sense to me that we should block the access to the setter where the key path is created from a place where the setter is not accessible. The key path should correspond to what the code forming the key path can access.

First PR, I'm not sure if I got it right. @jckarter can you take a look?