### PR TITLE
Revert "SILGen: avoid reusing the same opened archetype in keypath setter and getter functions."

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3514,14 +3514,6 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
     return storage->isSettable(storage->getDeclContext());
   };
 
-  // We cannot use the same opened archetype in the getter and setter. Therefore
-  // we create a new one for both the getter and the setter.
-  auto renewOpenedArchetypes = [](SubstitutableType *type) -> Type {
-    if (auto *openedTy = dyn_cast<OpenedArchetypeType>(type))
-      return OpenedArchetypeType::get(openedTy->getOpenedExistentialType());
-    return type;
-  };
-
   if (auto var = dyn_cast<VarDecl>(storage)) {
     CanType componentTy;
     if (!var->getDeclContext()->isTypeContext()) {
@@ -3545,15 +3537,13 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
     auto id = getIdForKeyPathComponentComputedProperty(*this, var,
                                                        strategy);
     auto getter = getOrCreateKeyPathGetter(*this, loc,
-             var, subs.subst(renewOpenedArchetypes,
-                             MakeAbstractConformanceForGenericType()),
+             var, subs,
              needsGenericContext ? genericEnv : nullptr,
              expansion, {}, baseTy, componentTy);
     
     if (isSettableInComponent()) {
       auto setter = getOrCreateKeyPathSetter(*this, loc,
-             var, subs.subst(renewOpenedArchetypes,
-                             MakeAbstractConformanceForGenericType()),
+             var, subs,
              needsGenericContext ? genericEnv : nullptr,
              expansion, {}, baseTy, componentTy);
       return KeyPathPatternComponent::forComputedSettableProperty(id,
@@ -3598,8 +3588,7 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
     
     auto id = getIdForKeyPathComponentComputedProperty(*this, decl, strategy);
     auto getter = getOrCreateKeyPathGetter(*this, loc,
-             decl, subs.subst(renewOpenedArchetypes,
-                              MakeAbstractConformanceForGenericType()),
+             decl, subs,
              needsGenericContext ? genericEnv : nullptr,
              expansion,
              indexTypes,
@@ -3608,8 +3597,7 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
     auto indexPatternsCopy = getASTContext().AllocateCopy(indexPatterns);
     if (isSettableInComponent()) {
       auto setter = getOrCreateKeyPathSetter(*this, loc,
-             decl, subs.subst(renewOpenedArchetypes,
-                              MakeAbstractConformanceForGenericType()),
+             decl, subs,
              needsGenericContext ? genericEnv : nullptr,
              expansion,
              indexTypes,


### PR DESCRIPTION
Reverts https://github.com/apple/swift/pull/36858/commits/e5e28ff4c4a03d41393757b18d3cdc9584b0c67e

There are some crashes (for which we don't have a reproducer, unfortunately), which are caused by this change.

The good thing is that this change is not needed anymore, because it's handled by the more general eecb9fa975c0a83d9cadf0429bcb15a80a6f06b6 "SILModule: track opened archetypes per function.".

The test case for this was added in the original commit (test/stdlib/KeyPath.swift), which is not reverted with this commit.

rdar://79415891
