### PR TITLE
benchmarks: disable the flaky test_log_file BenchmarkDriver test

### DIFF
--- a/benchmark/scripts/test_Benchmark_Driver.py
+++ b/benchmark/scripts/test_Benchmark_Driver.py
@@ -264,6 +264,7 @@ class TestBenchmarkDriverInitialization(unittest.TestCase):
         self.assertEqual(driver.tests, ["Benchmark3"])
         self.assertEqual(driver.all_tests, ["Benchmark1", "Benchmark2", "Benchmark3"])
 
+    @unittest.skip("comparing against localtime() is flaky. rdar://79701124")
     def test_log_file(self):
         """When swift-repo is set, log is tied to Git branch and revision."""
         self.assertIsNone(


### PR DESCRIPTION
I'm not sure if it makes sense to keep this test around at all.
For now I just disabled it.

rdar://79701124
