### PR TITLE
MemoryLifetimeVerifier: handle stores of tuples with trivial enums

### DIFF
--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -178,6 +178,12 @@ static bool isTrivialEnumElem(EnumElementDecl *elem, SILType enumType,
         enumType.getEnumElementType(elem, function).isTrivial(*function);
 }
 
+static bool isOrHasEnum(SILType type) {
+  return type.getASTType().findIf([](Type ty) {
+    return ty->getEnumOrBoundGenericEnum() != nullptr;
+  });
+}
+
 bool MemoryLifetimeVerifier::storesTrivialEnum(int locIdx,
                         SILBasicBlock::reverse_iterator start,
                         SILBasicBlock::reverse_iterator end) {
@@ -191,7 +197,7 @@ bool MemoryLifetimeVerifier::storesTrivialEnum(int locIdx,
     if (auto *SI = dyn_cast<StoreInst>(&inst)) {
       const Location *loc = locations.getLocation(SI->getDest());
       if (loc && loc->isSubLocation(locIdx) &&
-          SI->getSrc()->getType().getEnumOrBoundGenericEnum()) {
+          isOrHasEnum(SI->getSrc()->getType())) {
         return SI->getOwnershipQualifier() == StoreOwnershipQualifier::Trivial;
       }
     }

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -464,6 +464,17 @@ bb0(%0 : @owned $T):
   return %r : $()
 }
 
+sil [ossa] @test_store_enum_tuple : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %2 = enum $Optional<T>, #Optional.none!enumelt
+  %3 = tuple (%0 : $Int, %2 : $Optional<T>)
+  %8 = alloc_stack $(Int, Optional<T>)
+  store %3 to [trivial] %8 : $*(Int, Optional<T>)
+  dealloc_stack %8 : $*(Int, Optional<T>)
+  %13 = tuple ()
+  return %13 : $()
+}
+
 sil [ossa] @test_select_enum_addr : $@convention(thin) (@in_guaranteed Optional<T>) -> Builtin.Int1 {
 bb0(%0 : $*Optional<T>):
   %1 = integer_literal $Builtin.Int1, -1


### PR DESCRIPTION
The MemoryLifetimeVerifier issued a false alarm if a tuple with a trivial enum-case (e.g. an Optional nil) is stored to a memory location.

rdar://79781939
