### PR TITLE
[Swift Next] Fix call to `collectUsedGlobalVariables`

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -824,7 +824,7 @@ static void embedBitcode(llvm::Module *M, const IRGenOptions &Opts)
 
   // Save llvm.compiler.used and remove it.
   SmallVector<llvm::Constant*, 2> UsedArray;
-  SmallSet<llvm::GlobalValue*, 4> UsedGlobals;
+  SmallVector<llvm::GlobalValue*, 4> UsedGlobals;
   auto *UsedElementType =
     llvm::Type::getInt8Ty(M->getContext())->getPointerTo(0);
   llvm::GlobalVariable *Used =


### PR DESCRIPTION
LLVM commit 3adb89bb9f8e73c82787babb2f877fece7394770 updated the API of
this function to take a reference to a `SmallVectorImpl` instead of a
set to ensure that it behaves deterministically.

rdar://79802393