### PR TITLE
[Swift Next] VK_RValue -> VK_PRValue

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1167,14 +1167,14 @@ makeBitFieldAccessors(ClangImporter::Implementation &Impl,
     
     auto cGetterSelfExpr = new (Ctx) clang::DeclRefExpr(Ctx, cGetterSelf, false,
                                                         recordType,
-                                                        clang::VK_RValue,
+                                                        clang::VK_PRValue,
                                                         clang::SourceLocation());
     auto cGetterExpr = clang::MemberExpr::CreateImplicit(Ctx,
                                                          cGetterSelfExpr,
                                                          /*isarrow=*/ false,
                                                          fieldDecl,
                                                          fieldType,
-                                                         clang::VK_RValue,
+                                                         clang::VK_PRValue,
                                                          clang::OK_BitField);
 
     
@@ -1211,7 +1211,7 @@ makeBitFieldAccessors(ClangImporter::Implementation &Impl,
     
     auto cSetterSelfExpr = new (Ctx) clang::DeclRefExpr(Ctx, cSetterSelf, false,
                                                         recordPointerType,
-                                                        clang::VK_RValue,
+                                                        clang::VK_PRValue,
                                                         clang::SourceLocation());
     
     auto cSetterMemberExpr = clang::MemberExpr::CreateImplicit(Ctx,
@@ -1224,7 +1224,7 @@ makeBitFieldAccessors(ClangImporter::Implementation &Impl,
     
     auto cSetterValueExpr = new (Ctx) clang::DeclRefExpr(Ctx, cSetterValue, false,
                                                          fieldType,
-                                                         clang::VK_RValue,
+                                                         clang::VK_PRValue,
                                                          clang::SourceLocation());
 
     auto cSetterExpr = clang::BinaryOperator::Create(Ctx,
@@ -1232,7 +1232,7 @@ makeBitFieldAccessors(ClangImporter::Implementation &Impl,
                                                      cSetterValueExpr,
                                                      clang::BO_Assign,
                                                      fieldType,
-                                                     clang::VK_RValue,
+                                                     clang::VK_PRValue,
                                                      clang::OK_Ordinary,
                                                      clang::SourceLocation(),
                                                      clang::FPOptionsOverride());


### PR DESCRIPTION
Clang updated the naming in commit
aef5d8fdc7d0d348125d5ecf4a13be5888eb1654 in order to be more consistent
with c++11 category naming.

rdar://79799704