### PR TITLE
[Swift next] Construct DataLayout from string

### DIFF
--- a/include/swift/AST/TBDGenRequests.h
+++ b/include/swift/AST/TBDGenRequests.h
@@ -70,7 +70,7 @@ public:
   const TBDGenOptions &getOptions() const { return Opts; }
   TBDGenOptions &getOptions() { return Opts; }
 
-  const llvm::DataLayout &getDataLayout() const;
+  const StringRef getDataLayoutString() const;
   const llvm::Triple &getTarget() const;
 
   bool operator==(const TBDGenDescriptor &other) const;

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1533,7 +1533,7 @@ bool swift::performLLVM(const IRGenOptions &Opts, ASTContext &Ctx,
 
   auto *Clang = static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
   // Use clang's datalayout.
-  Module->setDataLayout(Clang->getTargetInfo().getDataLayout());
+  Module->setDataLayout(Clang->getTargetInfo().getDataLayoutString());
 
   embedBitcode(Module, Opts);
   if (::performLLVM(Opts, Ctx.Diags, nullptr, nullptr, Module,

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -192,19 +192,18 @@ static void sanityCheckStdlib(IRGenModule &IGM) {
 
 IRGenModule::IRGenModule(IRGenerator &irgen,
                          std::unique_ptr<llvm::TargetMachine> &&target,
-                         SourceFile *SF,
-                         StringRef ModuleName, StringRef OutputFilename,
+                         SourceFile *SF, StringRef ModuleName,
+                         StringRef OutputFilename,
                          StringRef MainInputFilenameForDebugInfo,
                          StringRef PrivateDiscriminator)
-    : LLVMContext(new llvm::LLVMContext()),
-      IRGen(irgen), Context(irgen.SIL.getASTContext()),
+    : LLVMContext(new llvm::LLVMContext()), IRGen(irgen),
+      Context(irgen.SIL.getASTContext()),
       // The LLVMContext (and the IGM itself) will get deleted by the IGMDeleter
       // as long as the IGM is registered with the IRGenerator.
-      ClangCodeGen(createClangCodeGenerator(Context, *LLVMContext,
-                                            irgen.Opts,
+      ClangCodeGen(createClangCodeGenerator(Context, *LLVMContext, irgen.Opts,
                                             ModuleName, PrivateDiscriminator)),
       Module(*ClangCodeGen->GetModule()),
-      DataLayout(irgen.getClangDataLayout()),
+      DataLayout(irgen.getClangDataLayoutString()),
       Triple(irgen.getEffectiveClangTriple()), TargetMachine(std::move(target)),
       silConv(irgen.SIL), OutputFilename(OutputFilename),
       MainInputFilenameForDebugInfo(MainInputFilenameForDebugInfo),
@@ -1750,12 +1749,12 @@ llvm::Triple IRGenerator::getEffectiveClangTriple() {
   return llvm::Triple(CI->getTargetInfo().getTargetOpts().Triple);
 }
 
-const llvm::DataLayout &IRGenerator::getClangDataLayout() {
+const llvm::StringRef IRGenerator::getClangDataLayoutString() {
   return static_cast<ClangImporter *>(
              SIL.getASTContext().getClangModuleLoader())
       ->getTargetInfo()
-      .getDataLayout();
-  }
+      .getDataLayoutString();
+}
 
 TypeExpansionContext IRGenModule::getMaximalTypeExpansionContext() const {
   return TypeExpansionContext::maximal(getSwiftModule(),

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -519,7 +519,7 @@ public:
   /// Return the effective triple used by clang.
   llvm::Triple getEffectiveClangTriple();
 
-  const llvm::DataLayout &getClangDataLayout();
+  const llvm::StringRef getClangDataLayoutString();
 };
 
 class ConstantReference {

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -68,7 +68,7 @@ static bool isGlobalOrStaticVar(VarDecl *VD) {
 
 TBDGenVisitor::TBDGenVisitor(const TBDGenDescriptor &desc,
                              APIRecorder &recorder)
-    : TBDGenVisitor(desc.getTarget(), desc.getDataLayout(),
+    : TBDGenVisitor(desc.getTarget(), desc.getDataLayoutString(),
                     desc.getParentModule(), desc.getOptions(), recorder) {}
 
 void TBDGenVisitor::addSymbolInternal(StringRef name, SymbolKind kind,
@@ -390,7 +390,9 @@ void TBDGenVisitor::addSymbol(StringRef name, SymbolSource source,
   if (kind == SymbolKind::ObjectiveCClass) {
     mangled = name;
   } else {
-    llvm::Mangler::getNameWithPrefix(mangled, name, DataLayout);
+    if (!DataLayout)
+      DataLayout = llvm::DataLayout(DataLayoutDescription);
+    llvm::Mangler::getNameWithPrefix(mangled, name, *DataLayout);
   }
 
   addSymbolInternal(mangled, kind, source);

--- a/lib/TBDGen/TBDGenRequests.cpp
+++ b/lib/TBDGen/TBDGenRequests.cpp
@@ -48,10 +48,10 @@ ModuleDecl *TBDGenDescriptor::getParentModule() const {
   return Input.get<FileUnit *>()->getParentModule();
 }
 
-const llvm::DataLayout &TBDGenDescriptor::getDataLayout() const {
+const StringRef TBDGenDescriptor::getDataLayoutString() const {
   auto &ctx = getParentModule()->getASTContext();
   auto *clang = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
-  return clang->getTargetInfo().getDataLayout();
+  return llvm::StringRef(clang->getTargetInfo().getDataLayoutString());
 }
 
 const llvm::Triple &TBDGenDescriptor::getTarget() const {

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -92,7 +92,9 @@ class TBDGenVisitor : public ASTVisitor<TBDGenVisitor> {
   llvm::StringSet<> DuplicateSymbolChecker;
 #endif
 
-  const llvm::DataLayout &DataLayout;
+  Optional<llvm::DataLayout> DataLayout = None;
+  const StringRef DataLayoutDescription;
+
   UniversalLinkageInfo UniversalLinkInfo;
   ModuleDecl *SwiftModule;
   const TBDGenOptions &Opts;
@@ -167,10 +169,10 @@ class TBDGenVisitor : public ASTVisitor<TBDGenVisitor> {
                                   const AutoDiffConfig &config);
 
 public:
-  TBDGenVisitor(const llvm::Triple &target, const llvm::DataLayout &dataLayout,
+  TBDGenVisitor(const llvm::Triple &target, const StringRef dataLayoutString,
                 ModuleDecl *swiftModule, const TBDGenOptions &opts,
                 APIRecorder &recorder)
-      : DataLayout(dataLayout),
+      : DataLayoutDescription(dataLayoutString),
         UniversalLinkInfo(target, opts.HasMultipleIGMs, /*forcePublic*/ false),
         SwiftModule(swiftModule), Opts(opts), recorder(recorder),
         previousInstallNameMap(parsePreviousModuleInstallNameMap()) {}


### PR DESCRIPTION
Clang stopped returning the datalayout object, instead constructing it
on the fly from the string representation.

rdar://79799819