### PR TITLE
[Swift next] Add Format.h to swift-syntax-parser-test

### DIFF
--- a/tools/swift-syntax-parser-test/swift-syntax-parser-test.cpp
+++ b/tools/swift-syntax-parser-test/swift-syntax-parser-test.cpp
@@ -18,9 +18,10 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/LLVMInitialize.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Format.h"
 #include "llvm/Support/MemoryBuffer.h"
-#include "llvm/Support/Timer.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/Timer.h"
 
 using namespace swift;
 using namespace llvm;


### PR DESCRIPTION
Something happened so that's not being transitively included. Adding it
in explicitly. Also fixed the include ordering according to clang-format.

rdar://79799865