### PR TITLE
[5.5][Diagnostics] Fix requirement note to properly handle layout requirements

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1979,16 +1979,16 @@ NOTE(wrapped_type_satisfies_requirement,none,
      "wrapped type %0 satisfies this requirement; did you mean to unwrap?", (Type))
 NOTE(candidate_types_conformance_requirement,none,
      "candidate requires that %0 conform to %1 "
-     "(requirement specified as %2 == %3%4)",
-     (Type, Type, Type, Type, StringRef))
+     "(requirement specified as %2 : %3)",
+     (Type, Type, Type, Type))
 NOTE(candidate_types_equal_requirement,none,
      "candidate requires that the types %0 and %1 be equivalent "
-     "(requirement specified as %2 == %3%4)",
-     (Type, Type, Type, Type, StringRef))
+     "(requirement specified as %2 == %3)",
+     (Type, Type, Type, Type))
 NOTE(candidate_types_inheritance_requirement,none,
      "candidate requires that %1 inherit from %2 "
-     "(requirement specified as %2 : %3%4)",
-     (Type, Type, Type, Type, StringRef))
+     "(requirement specified as %2 : %3)",
+     (Type, Type, Type, Type))
 NOTE(types_not_equal_requirement,none,
      "requirement specified as %0 == %1%2", (Type, Type, StringRef))
 ERROR(type_is_not_a_class,none,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -388,8 +388,14 @@ bool RequirementFailure::diagnoseAsNote() {
   const auto &req = getRequirement();
   const auto *reqDC = getRequirementDC();
 
+  // Layout requirement doesn't have a second type, let's always
+  // `AnyObject`.
+  auto requirementTy = req.getKind() == RequirementKind::Layout
+                           ? getASTContext().getAnyObjectType()
+                           : req.getSecondType();
+
   emitDiagnosticAt(reqDC->getAsDecl(), getDiagnosticAsNote(), getLHS(),
-                   getRHS(), req.getFirstType(), req.getSecondType(), "");
+                   getRHS(), req.getFirstType(), requirementTy);
   return true;
 }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -231,7 +231,7 @@ protected:
   using PathEltKind = ConstraintLocator::PathElementKind;
   using DiagOnDecl = Diag<DescriptiveDeclKind, DeclName, Type, Type>;
   using DiagInReference = Diag<DescriptiveDeclKind, DeclName, Type, Type, Type>;
-  using DiagAsNote = Diag<Type, Type, Type, Type, StringRef>;
+  using DiagAsNote = Diag<Type, Type, Type, Type>;
 
   /// If this failure associated with one of the conditional requirements,
   /// this field would represent conformance where requirement comes from.

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1254,7 +1254,7 @@ func f11<T : P2>(_ n: T, _ f: @escaping (T) -> T) {}  // expected-note {{where '
 f11(3, f4) // expected-error {{global function 'f11' requires that 'Int' conform to 'P2'}}
 
 let f12: (Int) -> Void = { _ in } // expected-note {{candidate '(Int) -> Void' requires 1 argument, but 2 were provided}}
-func f12<T : P2>(_ n: T, _ f: @escaping (T) -> T) {} // expected-note {{candidate requires that 'Int' conform to 'P2' (requirement specified as 'T' == 'P2')}}
+func f12<T : P2>(_ n: T, _ f: @escaping (T) -> T) {} // expected-note {{candidate requires that 'Int' conform to 'P2' (requirement specified as 'T' : 'P2')}}
 f12(3, f4)// expected-error {{no exact matches in call to global function 'f12'}}
 
 // SR-12242

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -246,3 +246,14 @@ func test_no_hole_propagation() {
     return arguments.reduce(0, +) // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
   }
 }
+
+// rdar://79672230 - crash due to unsatisfied `: AnyObject` requirement
+func rdar79672230() {
+  struct MyType {}
+
+  func test(_ representation: MyType) -> Bool {} // expected-note {{found candidate with type 'MyType'}}
+  func test<T>(_ object: inout T) -> Bool where T : AnyObject {} // expected-note {{candidate requires that 'MyType' conform to 'AnyObject' (requirement specified as 'T' : 'AnyObject')}}
+
+  var t: MyType = MyType()
+  test(&t) // expected-error {{no exact matches in call to local function 'test'}}
+}

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -197,8 +197,8 @@ extension AnotherBazProtocol where BazValue: AnotherBazProtocol {} // ok, does n
 // Protocol extensions with additional requirements
 // ----------------------------------------------------------------------------
 extension P4 where Self.AssocP4 : P1 {
-// expected-note@-1 {{candidate requires that 'Int' conform to 'P1' (requirement specified as 'Self.AssocP4' == 'P1')}}
-// expected-note@-2 {{candidate requires that 'S4aHelper' conform to 'P1' (requirement specified as 'Self.AssocP4' == 'P1')}}
+// expected-note@-1 {{candidate requires that 'Int' conform to 'P1' (requirement specified as 'Self.AssocP4' : 'P1')}}
+// expected-note@-2 {{candidate requires that 'S4aHelper' conform to 'P1' (requirement specified as 'Self.AssocP4' : 'P1')}}
   func extP4a() {
     acceptsP1(reqP4a())
   }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/38111

---

- Explanation:

Layout requirement doesn't have a second type since it's always `AnyObject`,
requirement failure note should handle that, otherwise in no assertion builds
this would crash in diagnostic engine trying to emit the note.

- Scope: Invalid overloaded calls where one of the overload choices fails layout (conformance to `AnyObject`) constraint.

- Main Branch PR: https://github.com/apple/swift/pull/38111

- Resolves: rdar://79672230

- Risk: Low

- Reviewed By: @hborla  

- Testing: Regression tests added to the suite

Resolves: rdar://79672230
(cherry picked from commit 2b58a75f97ece7d63cd73cd2d9b11e56de3a63ac)


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
