### PR TITLE
[IRGen] `swift_getFunctionTypeMetadataGlobalActor` has concurrency availability

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -600,7 +600,7 @@ FUNCTION(GetFunctionMetadataDifferentiable,
 //                                          const Metadata *globalActor);
 FUNCTION(GetFunctionMetadataGlobalActor,
          swift_getFunctionTypeMetadataGlobalActor,
-         C_CC, AlwaysAvailable,
+         C_CC, ConcurrencyAvailability,
          RETURNS(TypeMetadataPtrTy),
          ARGS(SizeTy,
               SizeTy,

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -758,7 +758,7 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
   case Kind::DispatchThunkAllocatorAsyncFunctionPointer:
   case Kind::PartialApplyForwarderAsyncFunctionPointer:
     return getUnderlyingEntityForAsyncFunctionPointer()
-        .getLinkage(ForDefinition);
+        .getLinkage(forDefinition);
   case Kind::KnownAsyncFunctionPointer:
     return SILLinkage::PublicExternal;
   case Kind::PartialApplyForwarder:

--- a/test/Concurrency/Runtime/class_resilience.swift
+++ b/test/Concurrency/Runtime/class_resilience.swift
@@ -16,7 +16,6 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // XFAIL: windows
-// XFAIL: linux
 // XFAIL: openbsd
 
 import StdlibUnittest

--- a/test/IRGen/async/weak_availability.swift
+++ b/test/IRGen/async/weak_availability.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -enable-implicit-dynamic -target %target-cpu-apple-macosx11 -Onone -emit-ir %s | %FileCheck --check-prefix=MAYBE-AVAILABLE %s
+// REQUIRES: OS=macosx && CPU=x86_64
+
+@available(macOS 12.0, *)
+public func f<S: AsyncSequence>(_ s: S) async throws -> Any.Type {
+  for try await _ in s { }
+
+  typealias Fn = @MainActor () -> S.Element
+  return Fn.self
+}
+
+// MAYBE-AVAILABLE: @"$sScI4next7ElementQzSgyYaKFTjTu" = extern_weak global
+// MAYBE-AVAILABLE: declare{{.*}} extern_weak{{.*}} @swift_getFunctionTypeMetadataGlobalActor


### PR DESCRIPTION
Fix two problems in IRGen where we were not correctly weak-importing them:
* `swift_getFunctionTypeMetadataGlobalActor` was not marked as having concurrency availability
* Async function pointer references weren't propagating weak-imports properly

Fixes rdar://79674106.
