### PR TITLE
[5.5] Mark async_stream.swift as an executable_test

### DIFF
--- a/test/Concurrency/Runtime/async_stream.swift
+++ b/test/Concurrency/Runtime/async_stream.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: concurrency
 // REQUIRES: libdispatch
+// REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 
 // https://bugs.swift.org/browse/SR-14466


### PR DESCRIPTION
This is present in main but not in release/5.5, and is causing [failures in the oss-swift-5.5_tools-RA_stdlib-DA_test-device-non_executable bot](https://ci.swift.org/view/Dashboard/job/oss-swift-5.5_tools-RA_stdlib-DA_test-device-non_executable/70).