### PR TITLE
[5.5][Diagnostics] Correct the insert location of missing return type fix-it.

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5335,8 +5335,17 @@ bool ExtraneousReturnFailure::diagnoseAsError() {
     if (FD->getResultTypeRepr() == nullptr &&
         FD->getParameters()->getStartLoc().isValid() &&
         !FD->getBaseIdentifier().empty()) {
-      auto fixItLoc = Lexer::getLocForEndOfToken(
-          getASTContext().SourceMgr, FD->getParameters()->getEndLoc());
+      // Insert the fix-it after the parameter list, and after any
+      // effects specifiers.
+      SourceLoc loc = FD->getParameters()->getEndLoc();
+      if (auto asyncLoc = FD->getAsyncLoc())
+        loc = asyncLoc;
+
+      if (auto throwsLoc = FD->getThrowsLoc())
+        if (throwsLoc.getOpaquePointerValue() > loc.getOpaquePointerValue())
+          loc = throwsLoc;
+
+      auto fixItLoc = Lexer::getLocForEndOfToken(getASTContext().SourceMgr, loc);
       emitDiagnostic(diag::add_return_type_note)
           .fixItInsert(fixItLoc, " -> <#Return Type#>");
     }

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1205,6 +1205,43 @@ func voidFuncWithNestedVoidFunc() {
   }
 }
 
+func voidFuncWithEffects1() throws {
+  return 1
+  // expected-error@-1 {{unexpected non-void return value in void function}}
+  // expected-note@-2 {{did you mean to add a return type?}}{{35-35= -> <#Return Type#>}}
+}
+
+func voidFuncWithEffects2() async throws {
+  return 1
+  // expected-error@-1 {{unexpected non-void return value in void function}}
+  // expected-note@-2 {{did you mean to add a return type?}}{{41-41= -> <#Return Type#>}}
+}
+
+// expected-error@+1 {{'async' must precede 'throws'}}
+func voidFuncWithEffects3() throws async {
+  return 1
+  // expected-error@-1 {{unexpected non-void return value in void function}}
+  // expected-note@-2 {{did you mean to add a return type?}}{{41-41= -> <#Return Type#>}}
+}
+
+func voidFuncWithEffects4() async {
+  return 1
+  // expected-error@-1 {{unexpected non-void return value in void function}}
+  // expected-note@-2 {{did you mean to add a return type?}}{{34-34= -> <#Return Type#>}}
+}
+
+func voidFuncWithEffects5(_ closure: () throws -> Void) rethrows {
+  return 1
+  // expected-error@-1 {{unexpected non-void return value in void function}}
+  // expected-note@-2 {{did you mean to add a return type?}}{{65-65= -> <#Return Type#>}}
+}
+
+func voidGenericFuncWithEffects<T>(arg: T) async where T: CustomStringConvertible {
+  return 1
+  // expected-error@-1 {{unexpected non-void return value in void function}}
+  // expected-note@-2 {{did you mean to add a return type?}}{{49-49= -> <#Return Type#>}}
+}
+
 // Special cases: These should not offer a note + fix-it
 
 func voidFuncExplicitType() -> Void {


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/38112

* **Explanation**: In 5.5, a new fix-it was added to automatically insert a return type placeholder for a function that mistakenly returns a non-`Void` result from a `Void` function. This fix-it is always inserted after the parameter list, which isn't correct for functions with effects like `throws` and `async`. This change moves the fix-it location to after the effects if they exist.
* **Scope**: This change only affects invalid code that returns a non-`Void` result from a `Void` function.
* **Risk**: Very low.
* **Testing**: Added a handful of diagnostics tests that check the fix-it location.
* **Reviewer**: @xedin @theblixguy

Resolves: rdar://79345188