### PR TITLE
RequirementMachine: Implement some generic signature queries

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -33,6 +33,7 @@ namespace swift {
 class GenericSignatureBuilder;
 class ProtocolConformanceRef;
 class ProtocolType;
+class RequirementMachine;
 class SubstitutionMap;
 class GenericEnvironment;
 
@@ -302,6 +303,9 @@ public:
 
   /// Retrieve the generic signature builder for the given generic signature.
   GenericSignatureBuilder *getGenericSignatureBuilder() const;
+
+  /// Retrieve the requirement machine for the given generic signature.
+  RequirementMachine *getRequirementMachine() const;
 
   /// Returns the generic environment that provides fresh contextual types
   /// (archetypes) that correspond to the interface types in this generic

--- a/include/swift/AST/RequirementMachine.h
+++ b/include/swift/AST/RequirementMachine.h
@@ -13,6 +13,10 @@
 #ifndef SWIFT_REQUIREMENTMACHINE_H
 #define SWIFT_REQUIREMENTMACHINE_H
 
+namespace llvm {
+class raw_ostream;
+}
+
 namespace swift {
 
 class ASTContext;
@@ -53,6 +57,8 @@ public:
   bool requiresClass(Type depType) const;
   LayoutConstraint getLayoutConstraint(Type depType) const;
   bool requiresProtocol(Type depType, const ProtocolDecl *proto) const;
+
+  void dump(llvm::raw_ostream &out) const;
 };
 
 } // end namespace swift

--- a/include/swift/AST/RequirementMachine.h
+++ b/include/swift/AST/RequirementMachine.h
@@ -57,6 +57,7 @@ public:
   bool requiresClass(Type depType) const;
   LayoutConstraint getLayoutConstraint(Type depType) const;
   bool requiresProtocol(Type depType, const ProtocolDecl *proto) const;
+  bool isConcreteType(Type depType) const;
 
   void dump(llvm::raw_ostream &out) const;
 };

--- a/include/swift/AST/RequirementMachine.h
+++ b/include/swift/AST/RequirementMachine.h
@@ -20,6 +20,7 @@ class AssociatedTypeDecl;
 class CanGenericSignature;
 class CanType;
 class GenericSignature;
+class LayoutConstraint;
 class ProtocolDecl;
 class Requirement;
 class Type;
@@ -50,6 +51,7 @@ public:
   ~RequirementMachine();
 
   bool requiresClass(Type depType) const;
+  LayoutConstraint getLayoutConstraint(Type depType) const;
   bool requiresProtocol(Type depType, const ProtocolDecl *proto) const;
 };
 

--- a/include/swift/AST/RequirementMachine.h
+++ b/include/swift/AST/RequirementMachine.h
@@ -22,6 +22,7 @@ class CanType;
 class GenericSignature;
 class ProtocolDecl;
 class Requirement;
+class Type;
 
 /// Wraps a rewrite system with higher-level operations in terms of
 /// generic signatures and interface types.
@@ -47,6 +48,8 @@ class RequirementMachine final {
 
 public:
   ~RequirementMachine();
+
+  bool requiresClass(Type depType) const;
 };
 
 } // end namespace swift

--- a/include/swift/AST/RequirementMachine.h
+++ b/include/swift/AST/RequirementMachine.h
@@ -54,10 +54,12 @@ class RequirementMachine final {
 public:
   ~RequirementMachine();
 
+  // Generic signature queries
   bool requiresClass(Type depType) const;
   LayoutConstraint getLayoutConstraint(Type depType) const;
   bool requiresProtocol(Type depType, const ProtocolDecl *proto) const;
   bool isConcreteType(Type depType) const;
+  bool areSameTypeParameterInContext(Type depType1, Type depType2) const;
 
   void dump(llvm::raw_ostream &out) const;
 };

--- a/include/swift/AST/RequirementMachine.h
+++ b/include/swift/AST/RequirementMachine.h
@@ -50,6 +50,7 @@ public:
   ~RequirementMachine();
 
   bool requiresClass(Type depType) const;
+  bool requiresProtocol(Type depType, const ProtocolDecl *proto) const;
 };
 
 } // end namespace swift

--- a/include/swift/AST/RequirementMachine.h
+++ b/include/swift/AST/RequirementMachine.h
@@ -13,6 +13,8 @@
 #ifndef SWIFT_REQUIREMENTMACHINE_H
 #define SWIFT_REQUIREMENTMACHINE_H
 
+#include "swift/AST/GenericSignature.h"
+
 namespace llvm {
 class raw_ostream;
 }
@@ -21,9 +23,7 @@ namespace swift {
 
 class ASTContext;
 class AssociatedTypeDecl;
-class CanGenericSignature;
 class CanType;
-class GenericSignature;
 class LayoutConstraint;
 class ProtocolDecl;
 class Requirement;
@@ -58,6 +58,7 @@ public:
   bool requiresClass(Type depType) const;
   LayoutConstraint getLayoutConstraint(Type depType) const;
   bool requiresProtocol(Type depType, const ProtocolDecl *proto) const;
+  GenericSignature::RequiredProtocols getRequiredProtocols(Type depType) const;
   bool isConcreteType(Type depType) const;
   bool areSameTypeParameterInContext(Type depType1, Type depType2) const;
 

--- a/include/swift/AST/RequirementMachine.h
+++ b/include/swift/AST/RequirementMachine.h
@@ -43,7 +43,7 @@ class RequirementMachine final {
   void addGenericSignature(CanGenericSignature sig);
 
   bool isComplete() const;
-  void markComplete();
+  void computeCompletion(CanGenericSignature sig);
 
 public:
   ~RequirementMachine();

--- a/include/swift/AST/TypeMatcher.h
+++ b/include/swift/AST/TypeMatcher.h
@@ -195,8 +195,20 @@ class TypeMatcher {
     TRIVIAL_CASE(ModuleType)
     TRIVIAL_CASE(DynamicSelfType)
     TRIVIAL_CASE(ArchetypeType)
-    TRIVIAL_CASE(GenericTypeParamType)
     TRIVIAL_CASE(DependentMemberType)
+
+    bool visitGenericTypeParamType(CanGenericTypeParamType firstType,
+                                   Type secondType,
+                                   Type sugaredFirstType) {
+      /* If the types match, continue. */
+      if (!Matcher.asDerived().alwaysMismatchGenericParams() &&
+          firstType->isEqual(secondType))
+        return true;
+
+      /* Otherwise, let the derived class deal with the mismatch. */
+      return mismatch(firstType.getPointer(), secondType,
+                      sugaredFirstType);
+    }
 
     /// FIXME: Split this out into cases?
     bool visitAnyFunctionType(CanAnyFunctionType firstFunc, Type secondType,
@@ -299,6 +311,8 @@ class TypeMatcher {
 
 #undef TRIVIAL_CASE
   };
+
+  bool alwaysMismatchGenericParams() const { return false; }
 
   ImplClass &asDerived() { return static_cast<ImplClass &>(*this); }
 

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -453,7 +453,7 @@ namespace swift {
 
     /// Maximum iteration count for requirement machine confluent completion
     /// algorithm.
-    unsigned RequirementMachineStepLimit = 1000;
+    unsigned RequirementMachineStepLimit = 2000;
 
     /// Maximum term length for requirement machine confluent completion
     /// algorithm.

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -224,9 +224,11 @@ FRONTEND_STATISTIC(Sema, NumAccessorBodiesSynthesized)
 /// amount of work the requirement machine does analyzing type signatures.
 FRONTEND_STATISTIC(Sema, NumRequirementMachines)
 
-/// Number of requirement machines constructed. Rough proxy for
-/// amount of work the requirement machine does analyzing type signatures.
+/// Number of new rules added by Knuth-Bendix completion procedure.
 FRONTEND_STATISTIC(Sema, NumRequirementMachineCompletionSteps)
+
+/// Number of new rules added by concrete term unification.
+FRONTEND_STATISTIC(Sema, NumRequirementMachineUnifiedConcreteTerms)
 
 /// Number of generic signature builders constructed. Rough proxy for
 /// amount of work the GSB does analyzing type signatures.

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -73,6 +73,7 @@ add_swift_host_library(swiftAST STATIC
   ProtocolConformance.cpp
   RawComment.cpp
   RequirementEnvironment.cpp
+  RequirementMachine/EquivalenceClassMap.cpp
   RequirementMachine/ProtocolGraph.cpp
   RequirementMachine/RequirementMachine.cpp
   RequirementMachine/RewriteSystem.cpp

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -316,6 +316,7 @@ bool GenericSignatureImpl::requiresClass(Type type) const {
       llvm::errs() << "Dependent type: "; type.dump(llvm::errs());
       llvm::errs() << "GenericSignatureBuilder says: " << gsbResult << "\n";
       llvm::errs() << "RequirementMachine says: " << rqmResult << "\n";
+      getRequirementMachine()->dump(llvm::errs());
       abort();
     }
 #endif
@@ -417,6 +418,7 @@ bool GenericSignatureImpl::requiresProtocol(Type type,
       llvm::errs() << "\n";
       llvm::errs() << "GenericSignatureBuilder says: " << gsbResult << "\n";
       llvm::errs() << "RequirementMachine says: " << rqmResult << "\n";
+      getRequirementMachine()->dump(llvm::errs());
       abort();
     }
 #endif
@@ -482,6 +484,7 @@ LayoutConstraint GenericSignatureImpl::getLayoutConstraint(Type type) const {
       llvm::errs() << "\n";
       llvm::errs() << "GenericSignatureBuilder says: " << gsbResult << "\n";
       llvm::errs() << "RequirementMachine says: " << rqmResult << "\n";
+      getRequirementMachine()->dump(llvm::errs());
       abort();
     }
 #endif

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/PrettyStackTrace.h"
+#include "swift/AST/RequirementMachine.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/STLExtras.h"
 #include <functional>
@@ -163,6 +164,17 @@ GenericSignatureImpl::getGenericSignatureBuilder() const {
 
   // generic signature builders are stored on the ASTContext.
   return getASTContext().getOrCreateGenericSignatureBuilder(
+                                             CanGenericSignature(this));
+}
+
+RequirementMachine *
+GenericSignatureImpl::getRequirementMachine() const {
+  // The requirement machine is associated with the canonical signature.
+  if (!isCanonical())
+    return getCanonicalSignature()->getRequirementMachine();
+
+  // Requirement machines are stored on the ASTContext.
+  return getASTContext().getOrCreateRequirementMachine(
                                              CanGenericSignature(this));
 }
 

--- a/lib/AST/RequirementMachine/EquivalenceClassMap.cpp
+++ b/lib/AST/RequirementMachine/EquivalenceClassMap.cpp
@@ -1,0 +1,550 @@
+//===--- EquivalenceClassMap.cpp - Facts about generic parameters ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// In the rewrite system, a conformance requirement 'T : P' is represented as
+// rewrite rule of the form:
+//
+//    T.[P] => T
+//
+// Similarly, layout, superclass, and concrete-type requirements are represented
+// by a rewrite rule of the form:
+//
+//    T.[p] => T
+//
+// Where [p] is a "property atom": [layout: L], [superclass: Foo],
+// [concrete: Bar].
+//
+// Given an arbitrary type T and a property [p], we can check if T satisfies the
+// property by checking if the two terms T.[p] and T reduce to the same term T'.
+// That is, if our rewrite rules allow us to eliminate the [p] suffix, we know
+// the type satisfies [p].
+//
+// However, the question then becomes, given an arbitrary type T, how do we find
+// *all* properties [p] satisfied by T?
+//
+// The trick is that we can take advantage of confluence here.
+//
+// If T.[p] => T', and T => T'', then it must follow that T''.[p] => T'.
+// Furthermore, since T'' is fully reduced, T'' == T'. So T'' == UV for some
+// terms U and V, and there exist be a rewrite rule V.[p] => V' in the system.
+//
+// Therefore, in order to find all [p] satisfied by T, we start by fully reducing
+// T, then we look for rules of the form V.[p] => V' where V is fully reduced,
+// and a suffix of T.
+//
+// This is the idea behind the equivalence class map. We collect all rules of the
+// form V.[p] => V' into a multi-map keyed by V. Then given an arbitrary type T,
+// we can reduce it and look up successive suffixes to find all properties [p]
+// satisfied by T.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/Decl.h"
+#include "swift/AST/LayoutConstraint.h"
+#include "swift/AST/TypeMatcher.h"
+#include "swift/AST/Types.h"
+#include "llvm/Support/raw_ostream.h"
+#include <algorithm>
+#include <vector>
+
+#include "EquivalenceClassMap.h"
+
+using namespace swift;
+using namespace rewriting;
+
+void EquivalenceClass::dump(llvm::raw_ostream &out) const {
+  out << Key << " => {";
+
+  if (!ConformsTo.empty()) {
+    out << " conforms_to: [";
+    bool first = true;
+    for (const auto *proto : ConformsTo) {
+      if (first)
+        first = false;
+      else
+        out << " ";
+      out << proto->getName();
+    }
+    out << "]";
+  }
+
+  if (Layout) {
+    out << " layout: " << Layout;
+  }
+
+  if (Superclass) {
+    out << " superclass: " << *Superclass;
+  }
+
+  if (ConcreteType) {
+    out << " concrete_type: " << *ConcreteType;
+  }
+
+  out << " }";
+}
+
+/// Concrete type terms are written in terms of generic parameter types that
+/// have a depth of 0, and an index into an array of substitution terms.
+///
+/// See RewriteSystemBuilder::getConcreteSubstitutionSchema().
+static unsigned getGenericParamIndex(Type type) {
+  auto *paramTy = type->castTo<GenericTypeParamType>();
+  assert(paramTy->getDepth() == 0);
+  return paramTy->getIndex();
+}
+
+/// Given a concrete type that is a structural sub-component of a concrete
+/// type produced by RewriteSystemBuilder::getConcreteSubstitutionSchema(),
+/// collect the subset of referenced substitutions and renumber the generic
+/// parameters in the type.
+///
+/// For example, suppose we start with the concrete type
+///
+///   Dictionary<τ_0_0, Array<τ_0_1>> with substitutions {X.Y, Z}
+///
+/// We can extract out the structural sub-component Array<τ_0_1>. If we wish
+/// to turn this into a new concrete substitution schema, we call this method
+/// with Array<τ_0_1> and the original substitutions {X.Y, Z}. This will
+/// return the type Array<τ_0_0> and the substitutions {Z}.
+CanType
+remapConcreteSubstitutionSchema(CanType concreteType,
+                                ArrayRef<Term> substitutions,
+                                ASTContext &ctx,
+                                SmallVectorImpl<Term> &result) {
+  assert(!concreteType->isTypeParameter() && "Must have a concrete type here");
+
+  if (!concreteType->hasTypeParameter())
+    return concreteType;
+
+  return CanType(concreteType.transformRec(
+    [&](Type t) -> Optional<Type> {
+      assert(!t->is<DependentMemberType>());
+
+      if (!t->is<GenericTypeParamType>())
+        return None;
+
+      unsigned oldIndex = getGenericParamIndex(t);
+      unsigned newIndex = result.size();
+      result.push_back(substitutions[oldIndex]);
+
+      return CanGenericTypeParamType::get(/*depth=*/0, newIndex, ctx);
+    }));
+}
+
+/// When a type parameter has two concrete types, we have to unify the
+/// type constructor arguments.
+///
+/// For example, suppose that we have two concrete same-type requirements:
+///
+///   T == Foo<X.Y, Z, String>
+///   T == Foo<Int, A.B, W>
+///
+/// These lower to the following two rules:
+///
+///   T.[concrete: Foo<τ_0_0, τ_0_1, String> with {X.Y, Z}]
+///   T.[concrete: Foo<Int, τ_0_0, τ_0_1> with {A.B, W}]
+///
+/// The two concrete type atoms will be added to the equivalence class of 'T',
+/// and we will eventually end up in this method, where we will generate three
+/// induced rules:
+///
+///   X.Y.[concrete: Int] => X.Y
+///   A.B => Z
+///   W.[concrete: String] => W
+///
+/// Returns the left hand side on success (it could also return the right hand
+/// side; since we unified the type constructor arguments, it doesn't matter).
+///
+/// Returns the ErrorType concrete type atom on failure.
+static Atom unifyConcreteTypes(
+    Atom lhs, Atom rhs, RewriteContext &ctx,
+    SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules,
+    bool debug) {
+  auto lhsType = lhs.getConcreteType();
+  auto rhsType = rhs.getConcreteType();
+
+  if (debug) {
+    llvm::dbgs() << "% Unifying " << lhs << " with " << rhs << "\n";
+  }
+
+  class Matcher : public TypeMatcher<Matcher> {
+    ArrayRef<Term> lhsSubstitutions;
+    ArrayRef<Term> rhsSubstitutions;
+    RewriteContext &ctx;
+    SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules;
+    bool debug;
+
+  public:
+    Matcher(ArrayRef<Term> lhsSubstitutions,
+            ArrayRef<Term> rhsSubstitutions,
+            RewriteContext &ctx,
+            SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules,
+            bool debug)
+        : lhsSubstitutions(lhsSubstitutions),
+          rhsSubstitutions(rhsSubstitutions),
+          ctx(ctx), inducedRules(inducedRules), debug(debug) {}
+
+    bool alwaysMismatchGenericParams() const { return true; }
+
+    bool mismatch(TypeBase *firstType, TypeBase *secondType,
+                  Type sugaredFirstType) {
+      if (isa<GenericTypeParamType>(firstType) &&
+          isa<GenericTypeParamType>(secondType)) {
+        // Both sides are type parameters; add a same-type requirement.
+        unsigned lhsIndex = getGenericParamIndex(firstType);
+        unsigned rhsIndex = getGenericParamIndex(secondType);
+        if (lhsSubstitutions[lhsIndex] != rhsSubstitutions[rhsIndex]) {
+          MutableTerm lhsTerm(lhsSubstitutions[lhsIndex]);
+          MutableTerm rhsTerm(rhsSubstitutions[rhsIndex]);
+          if (debug) {
+            llvm::dbgs() << "%% Induced rule " << lhsTerm
+                         << " == " << rhsTerm << "\n";
+          }
+          inducedRules.emplace_back(lhsTerm, rhsTerm);
+        }
+        return true;
+      }
+
+      if (isa<GenericTypeParamType>(firstType) &&
+          !isa<GenericTypeParamType>(secondType)) {
+        // A type parameter is equated with a concrete type; add a concrete
+        // type requirement.
+        unsigned lhsIndex = getGenericParamIndex(firstType);
+        MutableTerm subjectTerm(lhsSubstitutions[lhsIndex]);
+
+        SmallVector<Term, 3> result;
+        auto concreteType = remapConcreteSubstitutionSchema(CanType(secondType),
+                                                            rhsSubstitutions,
+                                                            ctx.getASTContext(),
+                                                            result);
+
+        MutableTerm constraintTerm(subjectTerm);
+        constraintTerm.add(Atom::forConcreteType(concreteType, result, ctx));
+
+        if (debug) {
+          llvm::dbgs() << "%% Induced rule " << subjectTerm
+                       << " == " << constraintTerm << "\n";
+        }
+        inducedRules.emplace_back(subjectTerm, constraintTerm);
+        return true;
+      }
+
+      if (!isa<GenericTypeParamType>(firstType) &&
+          isa<GenericTypeParamType>(secondType)) {
+        // A concrete type is equated with a type parameter; add a concrete
+        // type requirement.
+        unsigned rhsIndex = getGenericParamIndex(secondType);
+        MutableTerm subjectTerm(rhsSubstitutions[rhsIndex]);
+
+        SmallVector<Term, 3> result;
+        auto concreteType = remapConcreteSubstitutionSchema(CanType(firstType),
+                                                            lhsSubstitutions,
+                                                            ctx.getASTContext(),
+                                                            result);
+
+        MutableTerm constraintTerm(subjectTerm);
+        constraintTerm.add(Atom::forConcreteType(concreteType, result, ctx));
+
+        if (debug) {
+          llvm::dbgs() << "%% Induced rule " << subjectTerm
+                       << " == " << constraintTerm << "\n";
+        }
+        inducedRules.emplace_back(subjectTerm, constraintTerm);
+        return true;
+      }
+
+      // Any other kind of type mismatch involves different concrete types on
+      // both sides, which can only happen on invalid input.
+      return false;
+    }
+  };
+
+  Matcher matcher(lhs.getSubstitutions(),
+                  rhs.getSubstitutions(),
+                  ctx, inducedRules, debug);
+  if (!matcher.match(lhsType, rhsType)) {
+    // FIXME: Diagnose the conflict
+    if (debug) {
+      llvm::dbgs() << "%% Concrete type conflict\n";
+    }
+    return Atom::forConcreteType(CanType(ErrorType::get(ctx.getASTContext())),
+                                 {}, ctx);
+  }
+
+  return lhs;
+}
+
+void EquivalenceClass::addProperty(
+    Atom property, RewriteContext &ctx,
+    SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules,
+    bool debug) {
+
+  switch (property.getKind()) {
+  case Atom::Kind::Protocol:
+    ConformsTo.push_back(property.getProtocol());
+    return;
+
+  case Atom::Kind::Layout:
+    if (!Layout)
+      Layout = property.getLayoutConstraint();
+    else
+      Layout = Layout.merge(property.getLayoutConstraint());
+
+    return;
+
+  case Atom::Kind::Superclass: {
+    auto superclass = property.getSuperclass();
+
+    // A superclass requirement implies a layout requirement.
+    auto layout =
+      LayoutConstraint::getLayoutConstraint(
+        superclass->getClassOrBoundGenericClass()->isObjC()
+          ? LayoutConstraintKind::Class
+          : LayoutConstraintKind::NativeClass,
+        ctx.getASTContext());
+    addProperty(Atom::forLayout(layout, ctx), ctx, inducedRules, debug);
+
+    // FIXME: This needs to find the most derived subclass and also call
+    // unifyConcreteTypes()
+    Superclass = property;
+    return;
+  }
+
+  case Atom::Kind::ConcreteType: {
+    if (ConcreteType) {
+      ConcreteType = unifyConcreteTypes(*ConcreteType, property,
+                                        ctx, inducedRules, debug);
+    } else {
+      ConcreteType = property;
+    }
+
+    return;
+  }
+
+  case Atom::Kind::Name:
+  case Atom::Kind::GenericParam:
+  case Atom::Kind::AssociatedType:
+    break;
+  }
+
+  llvm_unreachable("Bad atom kind");
+}
+
+void EquivalenceClass::copyPropertiesFrom(const EquivalenceClass *next,
+                                          RewriteContext &ctx) {
+  // If this is the equivalence class of T and 'next' is the
+  // equivalence class of V, then T := UV for some non-empty U.
+  int prefixLength = Key.size() - next->Key.size();
+  assert(prefixLength > 0);
+  assert(std::equal(Key.begin() + prefixLength, Key.end(),
+                    next->Key.begin()));
+
+  // Conformances and the layout constraint, if any, can be copied over
+  // unmodified.
+  ConformsTo = next->ConformsTo;
+  Layout = next->Layout;
+
+  // If the equivalence class of V has superclass or concrete type
+  // substitutions {X1, ..., Xn}, then the equivalence class of
+  // T := UV should have substitutions {UX1, ..., UXn}.
+  MutableTerm prefix(Key.begin(), Key.begin() + prefixLength);
+
+  if (next->Superclass) {
+    Superclass = next->Superclass->prependPrefixToConcreteSubstitutions(
+        prefix, ctx);
+  }
+
+  if (next->ConcreteType) {
+    ConcreteType = next->ConcreteType->prependPrefixToConcreteSubstitutions(
+        prefix, ctx);
+  }
+}
+
+/// Look for an equivalence class corresponding to the given key, returning nullptr
+/// if one has not been recorded.
+EquivalenceClass *
+EquivalenceClassMap::getEquivalenceClassIfPresent(const MutableTerm &key) const {
+  assert(!key.empty());
+ 
+  for (const auto &equivClass : Map) {
+    int compare = equivClass->getKey().compare(key, Protos);
+    if (compare == 0)
+      return equivClass.get();
+    if (compare > 0)
+      return nullptr;
+  }
+
+  return nullptr;
+}
+
+/// Look for an equivalence class corresponding to a suffix of the given key.
+///
+/// Returns nullptr if no information is known about this key.
+EquivalenceClass *
+EquivalenceClassMap::lookUpEquivalenceClass(const MutableTerm &key) const {
+  if (auto *equivClass = getEquivalenceClassIfPresent(key))
+    return equivClass;
+
+  auto begin = key.begin() + 1;
+  auto end = key.end();
+
+  while (begin != end) {
+    MutableTerm suffix(begin, end);
+
+    if (auto *suffixClass = getEquivalenceClassIfPresent(suffix))
+      return suffixClass;
+
+    ++begin;
+  }
+
+  return nullptr;
+}
+
+/// Look for an equivalence class corresponding to the given key, creating a new
+/// equivalence class if necessary.
+///
+/// This must be called in monotonically non-decreasing key order.
+EquivalenceClass *
+EquivalenceClassMap::getOrCreateEquivalenceClass(const MutableTerm &key) {
+  assert(!key.empty());
+
+  if (!Map.empty()) {
+    const auto &lastEquivClass = Map.back();
+    int compare = lastEquivClass->getKey().compare(key, Protos);
+    if (compare == 0)
+      return lastEquivClass.get();
+
+    assert(compare < 0 && "Must record equivalence classes in sorted order");
+  }
+
+  auto *equivClass = new EquivalenceClass(key);
+
+  // Look for the longest suffix of the key that has an equivalence class,
+  // recording it as the next equivalence class if we find one.
+  //
+  // For example, if our rewrite system contains the following three rules:
+  //
+  //   A.[P] => A
+  //   B.A.[Q] => B.A
+  //   C.A.[R] => C.A
+  //
+  // Then we have three equivalence classes:
+  //
+  //   A => { [P] }
+  //   B.A => { [Q] }
+  //   C.A => { [R] }
+  //
+  // The next equivalence class of both 'B.A' and 'C.A' is 'A'; conceptually,
+  // the set of properties satisfied by 'B.A' is a superset of the properties
+  // satisfied by 'A'; analogously for 'C.A'.
+  //
+  // Since 'A' has no proper suffix with additional properties, the next
+  // equivalence class of 'A' is nullptr.
+  if (auto *next = lookUpEquivalenceClass(key))
+    equivClass->copyPropertiesFrom(next, Context);
+
+  Map.emplace_back(equivClass);
+
+  return equivClass;
+}
+
+void EquivalenceClassMap::clear() {
+  Map.clear();
+}
+
+/// Record a protocol conformance, layout or superclass constraint on the given
+/// key. Must be called in monotonically non-decreasing key order.
+void EquivalenceClassMap::addProperty(
+    const MutableTerm &key, Atom property,
+    SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules) {
+  assert(property.isProperty());
+  auto *equivClass = getOrCreateEquivalenceClass(key);
+  equivClass->addProperty(property, Context,
+                          inducedRules, DebugConcreteUnification);
+}
+
+void EquivalenceClassMap::dump(llvm::raw_ostream &out) const {
+  out << "Equivalence class map: {\n";
+  for (const auto &equivClass : Map) {
+    out << "  ";
+    equivClass->dump(out);
+    out << "\n";
+  }
+  out << "}\n";
+}
+
+/// Build the equivalence class map from all rules of the form T.[p] => T, where
+/// [p] is a property atom.
+///
+/// Returns true if concrete term unification performed while building the map
+/// introduced new rewrite rules; in this case, the completion procedure must
+/// run again.
+bool RewriteSystem::buildEquivalenceClassMap(EquivalenceClassMap &map) {
+  map.clear();
+
+  std::vector<std::pair<MutableTerm, Atom>> properties;
+
+  for (const auto &rule : Rules) {
+    if (rule.isDeleted())
+      continue;
+
+    const auto &lhs = rule.getLHS();
+
+    // Collect all rules of the form T.[p] => T where T is canonical.
+    auto property = lhs.back();
+    if (!property.isProperty())
+      continue;
+
+    MutableTerm key(lhs.begin(), lhs.end() - 1);
+    if (key != rule.getRHS())
+      continue;
+
+#ifndef NDEBUG
+    assert(!simplify(key) &&
+           "Right hand side of a property rule should already be reduced");
+#endif
+
+    properties.emplace_back(key, property);
+  }
+
+  // EquivalenceClassMap::addRule() requires that shorter rules are added
+  // before longer rules, so that it can perform lookups on suffixes and call
+  // EquivalenceClass::copyPropertiesFrom().
+  std::sort(properties.begin(), properties.end(),
+            [&](const std::pair<MutableTerm, Atom> &lhs,
+                const std::pair<MutableTerm, Atom> &rhs) -> bool {
+              return lhs.first.compare(rhs.first, Protos) < 0;
+            });
+
+  // Merging multiple superclass or concrete type rules can induce new rules
+  // to unify concrete type constructor arguments.
+  SmallVector<std::pair<MutableTerm, MutableTerm>, 3> inducedRules;
+
+  for (auto pair : properties) {
+    map.addProperty(pair.first, pair.second, inducedRules);
+  }
+
+  // Some of the induced rules might be trivial; only count the induced rules
+  // where the left hand side is not already equivalent to the right hand side.
+  unsigned addedNewRules = 0;
+  for (auto pair : inducedRules) {
+    if (addRule(pair.first, pair.second))
+      ++addedNewRules;
+  }
+
+  if (auto *stats = Context.getASTContext().Stats) {
+    stats->getFrontendCounters()
+      .NumRequirementMachineUnifiedConcreteTerms += addedNewRules;
+  }
+
+  return addedNewRules > 0;
+}

--- a/lib/AST/RequirementMachine/EquivalenceClassMap.h
+++ b/lib/AST/RequirementMachine/EquivalenceClassMap.h
@@ -1,0 +1,133 @@
+//===--- EquivalenceClassMap.h - Facts about generic parameters -*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// A description of this data structure and its purpose can be found in
+// EquivalenceClassMap.cpp.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_EQUIVALENCECLASSMAP_H
+#define SWIFT_EQUIVALENCECLASSMAP_H
+
+#include "swift/AST/LayoutConstraint.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/TinyPtrVector.h"
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#include "ProtocolGraph.h"
+#include "RewriteSystem.h"
+
+namespace llvm {
+  class raw_ostream;
+}
+
+namespace swift {
+
+class ProtocolDecl;
+
+namespace rewriting {
+
+class MutableTerm;
+class RewriteContext;
+class Term;
+
+/// Stores all rewrite rules of the form T.[p] => T, where [p] is a property atom,
+/// for a single term 'T'.
+class EquivalenceClass {
+  friend class EquivalenceClassMap;
+
+  /// The fully reduced term whose properties are recorded in this equivalence
+  /// class.
+  MutableTerm Key;
+
+  /// All protocols this type conforms to.
+  llvm::TinyPtrVector<const ProtocolDecl *> ConformsTo;
+
+  /// The most specific layout constraint this type satisfies.
+  LayoutConstraint Layout;
+
+  /// The most specific superclass constraint this type satisfies.
+  Optional<Atom> Superclass;
+
+  /// The most specific concrete type constraint this type satisfies.
+  Optional<Atom> ConcreteType;
+
+  explicit EquivalenceClass(const MutableTerm &key) : Key(key) {}
+
+  void addProperty(Atom property,
+                   RewriteContext &ctx,
+                   SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules,
+                   bool debug);
+  void copyPropertiesFrom(const EquivalenceClass *next,
+                          RewriteContext &ctx);
+
+  EquivalenceClass(const EquivalenceClass &) = delete;
+  EquivalenceClass(EquivalenceClass &&) = delete;
+  EquivalenceClass &operator=(const EquivalenceClass &) = delete;
+  EquivalenceClass &operator=(EquivalenceClass &&) = delete;
+
+public:
+  const MutableTerm &getKey() const { return Key; }
+  void dump(llvm::raw_ostream &out) const;
+
+  bool isConcreteType() const {
+    return ConcreteType.hasValue();
+  }
+
+  LayoutConstraint getLayoutConstraint() const {
+    return Layout;
+  }
+
+  ArrayRef<const ProtocolDecl *> getConformsTo() const {
+    return ConformsTo;
+  }
+};
+
+/// Stores all rewrite rules of the form T.[p] => T, where [p] is a property
+/// atom, for all terms 'T'.
+///
+/// Out-of-line methods are documented in EquivalenceClassMap.cpp.
+class EquivalenceClassMap {
+  RewriteContext &Context;
+  std::vector<std::unique_ptr<EquivalenceClass>> Map;
+  const ProtocolGraph &Protos;
+  bool DebugConcreteUnification = false;
+
+  EquivalenceClass *getEquivalenceClassIfPresent(const MutableTerm &key) const;
+  EquivalenceClass *getOrCreateEquivalenceClass(const MutableTerm &key);
+
+  EquivalenceClassMap(const EquivalenceClassMap &) = delete;
+  EquivalenceClassMap(EquivalenceClassMap &&) = delete;
+  EquivalenceClassMap &operator=(const EquivalenceClassMap &) = delete;
+  EquivalenceClassMap &operator=(EquivalenceClassMap &&) = delete;
+
+public:
+  explicit EquivalenceClassMap(RewriteContext &ctx,
+                               const ProtocolGraph &protos)
+      : Context(ctx), Protos(protos) {}
+
+  EquivalenceClass *lookUpEquivalenceClass(const MutableTerm &key) const;
+
+  void clear();
+  void addProperty(const MutableTerm &key, Atom property,
+                   SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules);
+  void dump(llvm::raw_ostream &out) const;
+};
+
+} // end namespace rewriting
+
+} // end namespace swift
+
+#endif

--- a/lib/AST/RequirementMachine/ProtocolGraph.cpp
+++ b/lib/AST/RequirementMachine/ProtocolGraph.cpp
@@ -132,7 +132,7 @@ void ProtocolGraph::computeInheritedAssociatedTypes() {
 void ProtocolGraph::computeInheritedProtocols() {
   // Visit protocols in reverse order, so that if P inherits from Q and
   // Q inherits from R, we first visit R, then Q, then P, ensuring that
-  // R's associated types are added to P's list, etc.
+  // R's inherited protocols are added to P's list, etc.
   for (const auto *proto : llvm::reverse(Protocols)) {
     auto &info = Info[proto];
 

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -336,3 +336,19 @@ void RequirementMachine::computeCompletion(CanGenericSignature sig) {
 bool RequirementMachine::isComplete() const {
   return Impl->Complete;
 }
+
+bool RequirementMachine::requiresClass(Type depType) const {
+  auto term = Impl->Context.getMutableTermForType(depType->getCanonicalType(),
+                                                  /*proto=*/nullptr);
+  Impl->System.simplify(term);
+
+  auto *equivClass = Impl->Map.lookUpEquivalenceClass(term);
+  if (!equivClass)
+    return false;
+
+  if (equivClass->isConcreteType())
+    return false;
+
+  auto layout = equivClass->getLayoutConstraint();
+  return (layout && layout->isClass());
+}

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -186,7 +186,7 @@ void RewriteSystemBuilder::addRequirement(const Requirement &req,
   case RequirementKind::Layout: {
     // A layout requirement T : L becomes a rewrite rule
     //
-    //   T.[L] == T
+    //   T.[layout: L] == T
     constraintTerm = subjectTerm;
     constraintTerm.add(Atom::forLayout(req.getLayoutConstraint(),
                                        Context));

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -85,6 +85,7 @@ void RewriteSystemBuilder::addGenericSignature(CanGenericSignature sig) {
   Protocols.visitRequirements(sig->getRequirements());
   Protocols.computeTransitiveClosure();
   Protocols.computeLinearOrder();
+  Protocols.computeInheritedProtocols();
   Protocols.computeInheritedAssociatedTypes();
 
   // Add rewrite rules for each protocol.

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -352,3 +352,24 @@ bool RequirementMachine::requiresClass(Type depType) const {
   auto layout = equivClass->getLayoutConstraint();
   return (layout && layout->isClass());
 }
+
+bool RequirementMachine::requiresProtocol(Type depType,
+                                          const ProtocolDecl *proto) const {
+  auto term = Impl->Context.getMutableTermForType(depType->getCanonicalType(),
+                                                  /*proto=*/nullptr);
+  Impl->System.simplify(term);
+
+  auto *equivClass = Impl->Map.lookUpEquivalenceClass(term);
+  if (!equivClass)
+    return false;
+
+  if (equivClass->isConcreteType())
+    return false;
+
+  for (auto *otherProto : equivClass->getConformsTo()) {
+    if (otherProto == proto)
+      return true;
+  }
+
+  return false;
+}

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -353,6 +353,18 @@ bool RequirementMachine::requiresClass(Type depType) const {
   return (layout && layout->isClass());
 }
 
+LayoutConstraint RequirementMachine::getLayoutConstraint(Type depType) const {
+  auto term = Impl->Context.getMutableTermForType(depType->getCanonicalType(),
+                                                  /*proto=*/nullptr);
+  Impl->System.simplify(term);
+
+  auto *equivClass = Impl->Map.lookUpEquivalenceClass(term);
+  if (!equivClass)
+    return LayoutConstraint();
+
+  return equivClass->getLayoutConstraint();
+}
+
 bool RequirementMachine::requiresProtocol(Type depType,
                                           const ProtocolDecl *proto) const {
   auto term = Impl->Context.getMutableTermForType(depType->getCanonicalType(),

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -390,6 +390,29 @@ bool RequirementMachine::requiresProtocol(Type depType,
   return false;
 }
 
+GenericSignature::RequiredProtocols
+RequirementMachine::getRequiredProtocols(Type depType) const {
+  auto term = Impl->Context.getMutableTermForType(depType->getCanonicalType(),
+                                                  /*proto=*/nullptr);
+  Impl->System.simplify(term);
+
+  auto *equivClass = Impl->Map.lookUpEquivalenceClass(term);
+  if (!equivClass)
+    return { };
+
+  if (equivClass->isConcreteType())
+    return { };
+
+  GenericSignature::RequiredProtocols result;
+  for (auto *otherProto : equivClass->getConformsTo()) {
+    result.push_back(const_cast<ProtocolDecl *>(otherProto));
+  }
+
+  ProtocolType::canonicalizeProtocols(result);
+
+  return result;
+}
+
 bool RequirementMachine::isConcreteType(Type depType) const {
   auto term = Impl->Context.getMutableTermForType(depType->getCanonicalType(),
                                                   /*proto=*/nullptr);

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -401,3 +401,16 @@ bool RequirementMachine::isConcreteType(Type depType) const {
 
   return equivClass->isConcreteType();
 }
+
+bool RequirementMachine::areSameTypeParameterInContext(Type depType1,
+                                                       Type depType2) const {
+  auto term1 = Impl->Context.getMutableTermForType(depType1->getCanonicalType(),
+                                                   /*proto=*/nullptr);
+  Impl->System.simplify(term1);
+
+  auto term2 = Impl->Context.getMutableTermForType(depType2->getCanonicalType(),
+                                                   /*proto=*/nullptr);
+  Impl->System.simplify(term2);
+
+  return (term1 == term2);
+}

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -389,3 +389,15 @@ bool RequirementMachine::requiresProtocol(Type depType,
 
   return false;
 }
+
+bool RequirementMachine::isConcreteType(Type depType) const {
+  auto term = Impl->Context.getMutableTermForType(depType->getCanonicalType(),
+                                                  /*proto=*/nullptr);
+  Impl->System.simplify(term);
+
+  auto *equivClass = Impl->Map.lookUpEquivalenceClass(term);
+  if (!equivClass)
+    return false;
+
+  return equivClass->isConcreteType();
+}

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -325,8 +325,7 @@ void RequirementMachine::computeCompletion(CanGenericSignature sig) {
   }
 
   if (Context.LangOpts.DebugRequirementMachine) {
-    Impl->System.dump(llvm::dbgs());
-    Impl->Map.dump(llvm::dbgs());
+    dump(llvm::dbgs());
   }
 
   assert(!Impl->Complete);
@@ -335,6 +334,11 @@ void RequirementMachine::computeCompletion(CanGenericSignature sig) {
 
 bool RequirementMachine::isComplete() const {
   return Impl->Complete;
+}
+
+void RequirementMachine::dump(llvm::raw_ostream &out) const {
+  Impl->System.dump(out);
+  Impl->Map.dump(out);
 }
 
 bool RequirementMachine::requiresClass(Type depType) const {

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -885,9 +885,7 @@ MutableTerm RewriteContext::getMutableTermForType(CanType paramType,
 }
 
 void Rule::dump(llvm::raw_ostream &out) const {
-  LHS.dump(out);
-  out << " => ";
-  RHS.dump(out);
+  out << LHS << " => " << RHS;
   if (deleted)
     out << " [deleted]";
 }
@@ -946,11 +944,7 @@ bool RewriteSystem::addRule(MutableTerm lhs, MutableTerm rhs) {
   assert(lhs.compare(rhs, Protos) > 0);
 
   if (DebugAdd) {
-    llvm::dbgs() << "# Adding rule ";
-    lhs.dump(llvm::dbgs());
-    llvm::dbgs() << " => ";
-    rhs.dump(llvm::dbgs());
-    llvm::dbgs() << "\n";
+    llvm::dbgs() << "# Adding rule " << lhs << " => " << rhs << "\n";
   }
 
   unsigned i = Rules.size();
@@ -1001,9 +995,7 @@ bool RewriteSystem::simplify(MutableTerm &term) const {
   bool changed = false;
 
   if (DebugSimplify) {
-    llvm::dbgs() << "= Term ";
-    term.dump(llvm::dbgs());
-    llvm::dbgs() << "\n";
+    llvm::dbgs() << "= Term " << term << "\n";
   }
 
   while (true) {
@@ -1013,16 +1005,12 @@ bool RewriteSystem::simplify(MutableTerm &term) const {
         continue;
 
       if (DebugSimplify) {
-        llvm::dbgs() << "== Rule ";
-        rule.dump(llvm::dbgs());
-        llvm::dbgs() << "\n";
+        llvm::dbgs() << "== Rule " << rule << "\n";
       }
 
       if (rule.apply(term)) {
         if (DebugSimplify) {
-          llvm::dbgs() << "=== Result ";
-          term.dump(llvm::dbgs());
-          llvm::dbgs() << "\n";
+          llvm::dbgs() << "=== Result " << term << "\n";
         }
 
         changed = true;
@@ -1051,9 +1039,7 @@ void RewriteSystem::simplifyRightHandSides() {
 
 #define ASSERT_RULE(expr) \
   if (!(expr)) { \
-    llvm::errs() << "&&& Malformed rewrite rule: "; \
-    rule.dump(llvm::errs()); \
-    llvm::errs() << "\n\n"; \
+    llvm::errs() << "&&& Malformed rewrite rule: " << rule << "\n\n"; \
     dump(llvm::errs()); \
     assert(expr); \
   }
@@ -1107,9 +1093,7 @@ void RewriteSystem::simplifyRightHandSides() {
 void RewriteSystem::dump(llvm::raw_ostream &out) const {
   out << "Rewrite system: {\n";
   for (const auto &rule : Rules) {
-    out << "- ";
-    rule.dump(out);
-    out << "\n";
+    out << "- " << rule << "\n";
   }
   out << "}\n";
 }

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -895,12 +895,6 @@ void RewriteSystem::initialize(
     ProtocolGraph &&graph) {
   Protos = graph;
 
-  // FIXME: Probably this sort is not necessary
-  std::sort(rules.begin(), rules.end(),
-            [&](std::pair<MutableTerm, MutableTerm> lhs,
-                std::pair<MutableTerm, MutableTerm> rhs) -> int {
-              return lhs.first.compare(rhs.first, graph) < 0;
-            });
   for (const auto &rule : rules)
     addRule(rule.first, rule.second);
 }

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -393,9 +393,15 @@ Atom Atom::forConcreteType(CanType type, ArrayRef<Term> substitutions,
 
 /// Linear order on atoms.
 ///
-/// First, we order different kinds as follows:
+/// First, we order different kinds as follows, from smallest to largest:
 ///
-///   AssociatedType < GenericParam < Name < Protocol < Layout
+/// - Protocol
+/// - AssociatedType
+/// - GenericParam
+/// - Name
+/// - Layout
+/// - Superclass
+/// - ConcreteType
 ///
 /// Then we break ties when both atoms have the same kind as follows:
 ///

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -203,6 +203,11 @@ public:
   friend bool operator!=(Atom lhs, Atom rhs) {
     return !(lhs == rhs);
   }
+
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &out, Atom atom) {
+    atom.dump(out);
+    return out;
+  }
 };
 
 /// See the implementation of MutableTerm::checkForOverlap() for a discussion.
@@ -263,6 +268,11 @@ public:
 
   friend bool operator!=(Term lhs, Term rhs) {
     return !(lhs == rhs);
+  }
+
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &out, Term term) {
+    term.dump(out);
+    return out;
   }
 };
 
@@ -357,6 +367,12 @@ public:
                               MutableTerm &v) const;
 
   void dump(llvm::raw_ostream &out) const;
+
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &out,
+                                       const MutableTerm &term) {
+    term.dump(out);
+    return out;
+  }
 };
 
 /// A global object that can be shared by multiple rewrite systems.
@@ -456,6 +472,12 @@ public:
   }
 
   void dump(llvm::raw_ostream &out) const;
+
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &out,
+                                       const Rule &rule) {
+    rule.dump(out);
+    return out;
+  }
 };
 
 /// A term rewrite system for working with types in a generic signature.

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -73,6 +73,17 @@ class Atom final {
 public:
   enum class Kind : uint8_t {
     //////
+    ////// Special atom kind that is both type-like and property-like:
+    //////
+
+    /// When appearing at the start of a term, denotes a nested
+    /// type of a protocol 'Self' type.
+    ///
+    /// When appearing at the end of a term, denotes that the
+    /// term's type conforms to the protocol.
+    Protocol,
+
+    //////
     ////// "Type-like" atom kinds:
     //////
 
@@ -92,13 +103,6 @@ public:
     //////
     ////// "Fact-like" atom kinds:
     //////
-
-    /// When appearing at the start of a term, denotes a nested
-    /// type of a protocol 'Self' type.
-    ///
-    /// When appearing at the end of a term, denotes that the
-    /// term's type conforms to the protocol.
-    Protocol,
 
     /// When appearing at the end of a term, denotes that the
     /// term's type satisfies the layout constraint.

--- a/lib/AST/RequirementMachine/RewriteSystemCompletion.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystemCompletion.cpp
@@ -293,17 +293,12 @@ void RewriteSystem::processMergedAssociatedTypes() {
     // X.[P2:T] => X.[P1&P2:T]
     if (DebugMerge) {
       llvm::dbgs() << "## Associated type merge candidate ";
-      lhs.dump(llvm::dbgs());
-      llvm::dbgs() << " => ";
-      rhs.dump(llvm::dbgs());
-      llvm::dbgs() << "\n";
+      llvm::dbgs() << lhs << " => " << rhs << "\n";
     }
 
     auto mergedAtom = mergeAssociatedTypes(lhs.back(), rhs.back());
     if (DebugMerge) {
-      llvm::dbgs() << "### Merged atom ";
-      mergedAtom.dump(llvm::dbgs());
-      llvm::dbgs() << "\n";
+      llvm::dbgs() << "### Merged atom " << mergedAtom << "\n";
     }
 
     // Build the term X.[P1&P2:T].
@@ -331,9 +326,7 @@ void RewriteSystem::processMergedAssociatedTypes() {
           //
           //   [P2:T].[Q] => [P2:T]
           if (DebugMerge) {
-            llvm::dbgs() << "### Lifting conformance rule ";
-            otherRule.dump(llvm::dbgs());
-            llvm::dbgs() << "\n";
+            llvm::dbgs() << "### Lifting conformance rule " << otherRule << "\n";
           }
 
           // We know that [P1:T] or [P2:T] conforms to Q, therefore the
@@ -462,11 +455,9 @@ RewriteSystem::computeConfluentCompletion(unsigned maxIterations,
 
     if (DebugCompletion) {
       llvm::dbgs() << "$ Check for overlap: (#" << next.first << ") ";
-      lhs.dump(llvm::dbgs());
-      llvm::dbgs() << "\n";
+      llvm::dbgs() << lhs << "\n";
       llvm::dbgs() << "                -vs- (#" << next.second << ") ";
-      rhs.dump(llvm::dbgs());
-      llvm::dbgs() << ":\n";
+      llvm::dbgs() << rhs << ":\n";
     }
 
     auto pair = computeCriticalPair(lhs, rhs);
@@ -483,13 +474,8 @@ RewriteSystem::computeConfluentCompletion(unsigned maxIterations,
     std::tie(first, second) = *pair;
 
     if (DebugCompletion) {
-      llvm::dbgs() << "$$ First term of critical pair is ";
-      first.dump(llvm::dbgs());
-      llvm::dbgs() << "\n";
-
-      llvm::dbgs() << "$$ Second term of critical pair is ";
-      second.dump(llvm::dbgs());
-      llvm::dbgs() << "\n\n";
+      llvm::dbgs() << "$$ First term of critical pair is " << first << "\n";
+      llvm::dbgs() << "$$ Second term of critical pair is " << second << "\n\n";
     }
     unsigned i = Rules.size();
 
@@ -521,9 +507,9 @@ RewriteSystem::computeConfluentCompletion(unsigned maxIterations,
       // If this rule reduces some existing rule, delete the existing rule.
       if (rule.canReduceLeftHandSide(newRule)) {
         if (DebugCompletion) {
-          llvm::dbgs() << "$ Deleting rule ";
-          rule.dump(llvm::dbgs());
-          llvm::dbgs() << "\n";
+          llvm::dbgs() << "$ Deleting rule " << rule << " because "
+                       << "its left hand side contains " << newRule
+                       << "\n";
         }
         rule.markDeleted();
       }

--- a/lib/AST/RequirementMachine/RewriteSystemCompletion.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystemCompletion.cpp
@@ -194,8 +194,9 @@ Atom RewriteSystem::mergeAssociatedTypes(Atom lhs, Atom rhs) const {
               Protos.inheritsFrom(thisProto, newProto));
     };
 
-    if (std::find_if(protos.begin(), protos.end(), inheritsFrom)
-        == protos.end()) {
+    if (std::find_if(minimalProtos.begin(), minimalProtos.end(),
+                     inheritsFrom)
+        == minimalProtos.end()) {
       minimalProtos.push_back(newProto);
     }
   }

--- a/test/Generics/unify_associated_types.swift
+++ b/test/Generics/unify_associated_types.swift
@@ -1,0 +1,38 @@
+// RUN: %target-typecheck-verify-swift -enable-requirement-machine -debug-requirement-machine 2>&1 | %FileCheck %s
+
+struct Foo<A, B> {}
+
+protocol P1 {
+  associatedtype X
+}
+
+protocol P1a {
+  associatedtype T : P1
+}
+
+protocol P2 {
+  associatedtype X
+}
+
+protocol P2a {
+  associatedtype T : P2
+}
+
+struct MergeTest<G : P1a & P2a> {}
+
+// CHECK-LABEL: Adding generic signature <τ_0_0 where τ_0_0 : P1a, τ_0_0 : P2a> {
+// CHECK-LABEL: Rewrite system: {
+// CHECK: - τ_0_0.[P2a:T] => τ_0_0.[P1a&P2a:T]
+// CHECK: - τ_0_0.[P1a:T] => τ_0_0.[P1a&P2a:T]
+// CHECK: - τ_0_0.[P1a&P2a:T].[P1:X] => τ_0_0.[P1a&P2a:T].[P1&P2:X]
+// CHECK: - [P1a&P2a:T].[P2:X] => [P1a&P2a:T].[P1&P2:X]
+// CHECK: - [P1a&P2a:T].[P1:X] => [P1a&P2a:T].[P1&P2:X]
+// CHECK: }
+// CHECK: Equivalence class map: {
+// CHECK:   [P1a&P2a:T] => { conforms_to: [P1 P2] }
+// CHECK:   [P1a:T] => { conforms_to: [P1] }
+// CHECK:   [P2a:T] => { conforms_to: [P2] }
+// CHECK:   τ_0_0 => { conforms_to: [P1a P2a] }
+// CHECK: }
+// CHECK: }
+

--- a/test/Generics/unify_concrete_types_1.swift
+++ b/test/Generics/unify_concrete_types_1.swift
@@ -1,0 +1,32 @@
+// RUN: %target-typecheck-verify-swift -enable-requirement-machine -debug-requirement-machine 2>&1 | %FileCheck %s
+
+struct Foo<A, B> {}
+
+protocol P1 {
+  associatedtype X where X == Foo<Y1, Z1>
+  associatedtype Y1
+  associatedtype Z1
+}
+
+protocol P2 {
+  associatedtype X where X == Foo<Y2, Z2>
+  associatedtype Y2
+  associatedtype Z2
+}
+
+struct MergeTest<G : P1 & P2> {
+  func foo1(x: G.Y1) -> G.Y2 { return x }
+  func foo2(x: G.Z1) -> G.Z2 { return x }
+}
+
+// CHECK-LABEL: Adding generic signature <τ_0_0 where τ_0_0 : P1, τ_0_0 : P2> {
+// CHECK-LABEL: Rewrite system: {
+// CHECK: - τ_0_0.[P2:Y2] => τ_0_0.[P1:Y1]
+// CHECK: - τ_0_0.[P2:Z2] => τ_0_0.[P1:Z1]
+// CHECK: }
+// CHECK-LABEL: Equivalence class map: {
+// CHECK:  [P1:X] => { concrete_type: [concrete: Foo<τ_0_0, τ_0_1> with <[P1:Y1], [P1:Z1]>] }
+// CHECK:  [P2:X] => { concrete_type: [concrete: Foo<τ_0_0, τ_0_1> with <[P2:Y2], [P2:Z2]>] }
+// CHECK:  τ_0_0 => { conforms_to: [P1 P2] }
+// CHECK:  τ_0_0.[P1&P2:X] => { concrete_type: [concrete: Foo<τ_0_0, τ_0_1> with <τ_0_0.[P2:Y2], τ_0_0.[P2:Z2]>] }
+// CHECK: }

--- a/test/Generics/unify_concrete_types_2.swift
+++ b/test/Generics/unify_concrete_types_2.swift
@@ -1,0 +1,39 @@
+// RUN: %target-typecheck-verify-swift -enable-requirement-machine -debug-requirement-machine 2>&1 | %FileCheck %s
+
+struct Foo<A, B> {}
+
+protocol P1 {
+  associatedtype X where X == Foo<Y1, Z1>
+  associatedtype Y1
+  associatedtype Z1
+}
+
+protocol P1a {
+  associatedtype T : P1
+}
+
+protocol P2 {
+  associatedtype X
+  associatedtype Y2
+  associatedtype Z2
+}
+
+protocol P2a {
+  associatedtype T : P2 where T.X == Foo<T.Y2, T.Z2>
+}
+
+struct MergeTest<G : P1a & P2a> {
+  func foo1(x: G.T.Y1) -> G.T.Y2 { return x }
+  func foo2(x: G.T.Z1) -> G.T.Z2 { return x }
+}
+
+// CHECK-LABEL: Adding generic signature <τ_0_0 where τ_0_0 : P1a, τ_0_0 : P2a> {
+// CHECK-LABEL: Rewrite system: {
+// CHECK: - τ_0_0.[P2a:T] => τ_0_0.[P1a&P2a:T]
+// CHECK: - τ_0_0.[P1a:T] => τ_0_0.[P1a&P2a:T]
+// CHECK: - [P1a&P2a:T].[P2:X] => [P1a&P2a:T].[P1&P2:X]
+// CHECK: - [P1a&P2a:T].[P1:X] => [P1a&P2a:T].[P1&P2:X]
+// CHECK: - τ_0_0.[P1a&P2a:T].[P2:Y2] => τ_0_0.[P1a&P2a:T].[P1:Y1]
+// CHECK: - τ_0_0.[P1a&P2a:T].[P2:Z2] => τ_0_0.[P1a&P2a:T].[P1:Z1]
+// CHECK: }
+// CHECK: }


### PR DESCRIPTION
This PR implements the following queries on top of the rewrite system:
* `requiresClass()`
* `getLayoutConstraint()`
* `requiresProtocol()`
* `getRequiredProtocols()`
* `isConcreteType()`
* `areSameTypeParametersInContext()`

All but the last one of the above queries are implemented using the "equivalence class map", which is described below. The `areSameTypeParametersInContext()` query is implemented directly by reducing the left hand side and right hand side, and then comparing the reduced terms for equality.

In asserts builds, the `-enable-requirement-machine` flag cross-checks the result of each query against the old implementation of the query that uses the GSB. In no-asserts builds, the requirement machine result is returned without checking when the flag is enabled.

In both asserts and no-asserts builds, the flag is off by default, and the new code does not run when the flag is not passed in.

# The equivalence class map

In the rewrite system, a conformance requirement `T : P` is represented as rewrite rule of the form:

    T.[P] => T

Similarly, layout, superclass, and concrete-type requirements are represented by a rewrite rule of the form:

    T.[p] => T

Where `[p]` is a "property atom": `[layout: L]`, `[superclass: Foo]`, `[concrete: Bar]`.

Given an arbitrary type T and a property `[p]`, we can check if T satisfies the property by checking if the two terms `T.[p]` and `T` reduce to the same term `T'`. That is, if our rewrite rules allow us to eliminate the `[p]` suffix, we know
the type satisfies `[p]`.

However, the question then becomes, given an arbitrary type T, how do we find *all* properties `[p]` satisfied by T?

The trick is that we can take advantage of confluence here.

If `T.[p] => T'`, and `T => T''`, then it must follow that `T''.[p] => T'`. Furthermore, since `T''` is fully reduced, `T'' == T'`. So `T'' == UV` for some terms U and V, and there exist be a rewrite rule `V.[p] => V'` in the system.

Therefore, in order to find all `[p]` satisfied by T, we start by fully reducing T, then we look for rules of the form `V.[p] => V'` where V is fully reduced, and a suffix of T.

This is the idea behind the equivalence class map. We collect all rules of the form `V.[p] => V'` into a multi-map keyed by V. Then given an arbitrary type T, we can reduce it and look up successive suffixes to find all properties `[p]` satisfied by T.