### PR TITLE
Fix BorrowingOperand for branches.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -263,7 +263,12 @@ struct BorrowingOperand {
   BorrowingOperandKind kind;
 
   BorrowingOperand(Operand *op)
-      : op(op), kind(BorrowingOperandKind::get(op->getUser()->getKind())) {}
+      : op(op), kind(BorrowingOperandKind::get(op->getUser()->getKind())) {
+    if (kind == BorrowingOperandKind::Branch
+        && op->get().getOwnershipKind() != OwnershipKind::Guaranteed) {
+      kind = BorrowingOperandKind::Invalid;
+    }
+  }
   BorrowingOperand(const BorrowingOperand &other)
       : op(other.op), kind(other.kind) {}
   BorrowingOperand &operator=(const BorrowingOperand &other) {
@@ -288,6 +293,11 @@ struct BorrowingOperand {
     auto kind = BorrowingOperandKind::get(user->getKind());
     if (!kind)
       return {nullptr, kind};
+
+    if (kind == BorrowingOperandKind::Branch
+        && op->get().getOwnershipKind() != OwnershipKind::Guaranteed) {
+      return {nullptr, BorrowingOperandKind::Invalid};
+    }
     return {op, kind};
   }
 

--- a/lib/SIL/Verifier/LinearLifetimeChecker.cpp
+++ b/lib/SIL/Verifier/LinearLifetimeChecker.cpp
@@ -314,8 +314,9 @@ void State::checkForSameBlockUseAfterFree(Operand *consumingUse,
                        }) == userBlock->end()) {
         continue;
       }
-    } else if (auto borrowingOperand = BorrowingOperand::get(consumingUse)) {
+    } else if (auto borrowingOperand = BorrowingOperand::get(nonConsumingUse)) {
       assert(borrowingOperand.isReborrow());
+      // a reborrow is expected to be consumed by the same phi.
       continue;
     }
 

--- a/test/SIL/ownership-verifier/borrow_scope_introducing_operands_positive.sil
+++ b/test/SIL/ownership-verifier/borrow_scope_introducing_operands_positive.sil
@@ -7,6 +7,10 @@
 
 import Builtin
 
+class C {}
+
+sil @getOwnedC : $@convention(thin) () -> (@owned C)
+
 sil [ossa] @coroutine_callee : $@yield_once (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   yield (), resume bb1, unwind bb2
@@ -171,4 +175,26 @@ bb2:
 bb3:
   %r = tuple ()
   return %r : $()
+}
+
+// Test a reborrow on the same branch as the consume.
+sil [ossa] @testReborrow : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  cond_br undef, bb1, bb2
+bb1:
+  destroy_value %0 : $C
+  %f = function_ref @getOwnedC : $@convention(thin) () -> (@owned C)
+  %owned1 = apply %f() : $@convention(thin) () -> (@owned C)
+  %copy1 = copy_value %owned1 : $C
+  %borrow1 = begin_borrow %copy1 : $C
+  destroy_value %owned1 : $C
+  br bb3(%borrow1 : $C, %copy1 : $C)
+bb2:
+  %borrow2 = begin_borrow %0 : $C
+  br bb3(%borrow2 : $C, %0 : $C)
+bb3(%borrow3 : @guaranteed $C, %copy3 : @owned $C):
+  end_borrow %borrow3 : $C
+  destroy_value %copy3 : $C
+  %result = tuple ()
+  return %result : $()
 }


### PR DESCRIPTION
An owned phi is obviously not a borrowing operand.

