### PR TITLE
Fix for a crash due to performLocalReleaseMotion and performLocalRetainMotion

### DIFF
--- a/lib/LLVMPasses/LLVMARCOpts.cpp
+++ b/lib/LLVMPasses/LLVMARCOpts.cpp
@@ -116,6 +116,12 @@ static bool canonicalizeInputFunction(Function &F, ARCEntryPointBuilder &B,
           ++NumNoopDeleted;
           continue;
         }
+        if (!CI.use_empty()) {
+          // Do not get RC identical value here, could end up with a
+          // crash in replaceAllUsesWith as the type maybe different.
+          CI.replaceAllUsesWith(CI.getArgOperand(0));
+          Changed = true;
+        }
         // Rewrite unknown retains into swift_retains.
         NativeRefs.insert(ArgVal);
         for (auto &X : UnknownObjectRetains[ArgVal]) {
@@ -138,7 +144,12 @@ static bool canonicalizeInputFunction(Function &F, ARCEntryPointBuilder &B,
           ++NumNoopDeleted;
           continue;
         }
-
+        if (!CI.use_empty()) {
+          // Do not get RC identical value here, could end up with a
+          // crash in replaceAllUsesWith as the type maybe different.
+          CI.replaceAllUsesWith(CI.getArgOperand(0));
+          Changed = true;
+        }
         // Have not encountered a strong retain/release. keep it in the
         // unknown retain/release list for now. It might get replaced
         // later.


### PR DESCRIPTION
In low level LLVMARCOptimizer, during canonicalization we don't rauw the result of RT_Retain and RT_UnknownObjectRetain with its arg similarly to RT_ObjCRetain and RT_BridgeRetain.
And during performLocalReleaseMotion, we assert that we have canonicalized RT_Retain/RT_UnknownObjectRetain.
In a release compiler, if we optimize such an RT_Retain/RT_UnknownObjectRetain with a RT_Release/RT_UnknownObjectRelease, then this can result in a compiler crash

Similarly not rauw'ing, can cause a crash due to performLocalRetainMotion.

Note: This crash may only happen when LLVM fails to optimize these retain calls which are marked with `returned` attribute.

Fixes rdar://79238115

