### PR TITLE
[5.5] [Async Refactoring] Add missing null type check

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -4521,7 +4521,8 @@ struct CallbackCondition {
 
   /// A bool condition expression.
   explicit CallbackCondition(const Expr *E) {
-    if (!E->getType()->isBool())
+    // FIXME: Sema should produce ErrorType.
+    if (!E->getType() || !E->getType()->isBool())
       return;
 
     auto CondType = ConditionType::IS_TRUE;

--- a/test/refactoring/ConvertAsync/convert_invalid.swift
+++ b/test/refactoring/ConvertAsync/convert_invalid.swift
@@ -1,0 +1,14 @@
+func callbackIntWithError(_ completion: (Int8, Error?) -> Void) {}
+
+// rdar://79864182
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=INVALID-COND %s
+callbackIntWithError { x, err in
+  if x {
+    print("ok")
+  }
+}
+// INVALID-COND:      let x = try await callbackIntWithError()
+// INVALID-COND-NEXT: if x {
+// INVALID-COND-NEXT:   print("ok")
+// INVALID-COND-NEXT: }
+


### PR DESCRIPTION
*5.5 cherry-pick of https://github.com/apple/swift/pull/38139*

---

Don't crash if we have a boolean condition without a type, as that may occur in invalid code.

rdar://79864182
