### PR TITLE
[Concurrency][ABI additive] add options to wait operations

### DIFF
--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -96,14 +96,31 @@ SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 JobPriority
 swift_task_escalate(AsyncTask *task, JobPriority newPriority);
 
-/// Wait for a non-throwing future task to complete.
+/// Wait for a non-throwing future task to complete, passing options.
+///
+/// This can be called from any thread. Its Swift signature is
+///
+/// \code
+/// func swift_task_future_wait_with_options(
+///   on task: _owned Builtin.NativeObject,
+///   options: Builtin.RawPointer?
+/// ) async -> Success
+/// \endcode
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
+void swift_task_future_wait_with_options(
+         OpaqueValue *,
+         SWIFT_ASYNC_CONTEXT AsyncContext *,
+         AsyncTask *,
+         TaskOptionRecord *,
+         TaskContinuationFunction *, AsyncContext *);
+
+/// Wait for a non-throwing future task to complete, passing task options.
 ///
 /// This can be called from any thread. Its Swift signature is
 ///
 /// \code
 /// func swift_task_future_wait(
-///   on task: _owned Builtin.NativeObject,
-///   options: Builtin.RawPointer?
+///   on task: _owned Builtin.NativeObject
 /// ) async -> Success
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
@@ -111,27 +128,45 @@ void swift_task_future_wait(
          OpaqueValue *,
          SWIFT_ASYNC_CONTEXT AsyncContext *,
          AsyncTask *,
-         TaskOptionRecord *,
          TaskContinuationFunction *, AsyncContext *);
+
+/// Wait for a potentially-throwing future task to complete, passing options.
+///
+/// This can be called from any thread. Its Swift signature is
+///
+/// \code
+/// func swift_task_future_wait_throwing_with_options(
+///   on task: _owned Builtin.NativeObject,
+///   options: Builtin.RawPointer?
+/// ) async throws -> Success,
+/// \endcode
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
+void swift_task_future_wait_throwing_with_options(
+  OpaqueValue *,
+  SWIFT_ASYNC_CONTEXT AsyncContext *,
+  AsyncTask *,
+  TaskOptionRecord *,
+  ThrowingTaskFutureWaitContinuationFunction *,
+  AsyncContext *);
 
 /// Wait for a potentially-throwing future task to complete.
 ///
 /// This can be called from any thread. Its Swift signature is
 ///
 /// \code
-/// func swift_task_future_wait_throwing(on task: _owned Builtin.NativeObject)
-///    async throws -> Success
+/// func swift_task_future_wait_throwing(
+///   on task: _owned Builtin.NativeObject
+///  ) async throws -> Success
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
 void swift_task_future_wait_throwing(
   OpaqueValue *,
   SWIFT_ASYNC_CONTEXT AsyncContext *,
   AsyncTask *,
-  TaskOptionRecord *,
   ThrowingTaskFutureWaitContinuationFunction *,
-        AsyncContext *);
+  AsyncContext *);
 
-/// Wait for a readyQueue of a Channel to become non empty.
+/// Wait for a readyQueue of a Channel to become non empty, with task options.
 ///
 /// This can be called from any thread. Its Swift signature is
 ///
@@ -139,7 +174,27 @@ void swift_task_future_wait_throwing(
 /// func swift_taskGroup_wait_next_throwing(
 ///     waitingTask: Builtin.NativeObject, // current task
 ///     group: Builtin.RawPointer,
-///     options: Builtin.RawPointer? // options
+///     options: Builtin.RawPointer?
+/// ) async -> T
+/// \endcode
+SWIFT_EXPORT_FROM(swift_Concurrency)
+SWIFT_CC(swiftasync)
+void swift_taskGroup_wait_next_throwing_with_options(
+    OpaqueValue *resultPointer,
+    SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+    TaskGroup *group,
+    TaskOptionRecord *options,
+    ThrowingTaskFutureWaitContinuationFunction *resumeFn,
+    AsyncContext *callContext);
+
+/// Wait for a readyQueue of a Channel to become non empty.
+///
+/// This can be called from any thread. Its Swift signature is
+///
+/// \code
+/// func swift_taskGroup_wait_next_throwing(
+///   waitingTask: Builtin.NativeObject, // current task
+///   group: Builtin.RawPointer
 /// ) async -> T
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency)
@@ -148,7 +203,6 @@ void swift_taskGroup_wait_next_throwing(
     OpaqueValue *resultPointer,
     SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
     TaskGroup *group,
-    TaskOptionRecord *options,
     ThrowingTaskFutureWaitContinuationFunction *resumeFn,
     AsyncContext *callContext);
 
@@ -278,11 +332,27 @@ using AsyncLetWaitSignature =
 /// ) async -> Success
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
-void swift_asyncLet_wait(
+void swift_asyncLet_wait_with_options(
     OpaqueValue *,
     SWIFT_ASYNC_CONTEXT AsyncContext *,
     AsyncLet *,
     TaskOptionRecord *,
+    TaskContinuationFunction *, AsyncContext *);
+
+/// Wait for a non-throwing async-let to complete.
+///
+/// This can be called from any thread. Its Swift signature is
+///
+/// \code
+/// func swift_asyncLet_wait(
+///     _ asyncLet: _owned Builtin.RawPointer
+/// ) async -> Success
+/// \endcode
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
+void swift_asyncLet_wait(
+    OpaqueValue *,
+    SWIFT_ASYNC_CONTEXT AsyncContext *,
+    AsyncLet *,
     TaskContinuationFunction *, AsyncContext *);
 
 /// Wait for a potentially-throwing async-let to complete.
@@ -296,11 +366,27 @@ void swift_asyncLet_wait(
 /// ) async throws -> Success
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
-void swift_asyncLet_wait_throwing(
+void swift_asyncLet_wait_throwing_with_options(
     OpaqueValue *,
     SWIFT_ASYNC_CONTEXT AsyncContext *,
     AsyncLet *,
     TaskOptionRecord *,
+    ThrowingTaskFutureWaitContinuationFunction *, AsyncContext *);
+
+/// Wait for a potentially-throwing async-let to complete.
+///
+/// This can be called from any thread. Its Swift signature is
+///
+/// \code
+/// func swift_asyncLet_wait_throwing(
+///     _ asyncLet: _owned Builtin.RawPointer
+/// ) async throws -> Success
+/// \endcode
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
+void swift_asyncLet_wait_throwing(
+    OpaqueValue *,
+    SWIFT_ASYNC_CONTEXT AsyncContext *,
+    AsyncLet *,
     ThrowingTaskFutureWaitContinuationFunction *, AsyncContext *);
 
 /// Its Swift signature is
@@ -312,7 +398,17 @@ void swift_asyncLet_wait_throwing(
 /// )
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-void swift_asyncLet_end(AsyncLet *, TaskOptionRecord *);
+void swift_asyncLet_end_with_options(AsyncLet *, TaskOptionRecord *);
+
+/// Its Swift signature is
+///
+/// \code
+/// func swift_asyncLet_end(
+///     _ alet: Builtin.RawPointer
+/// )
+/// \endcode
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_asyncLet_end(AsyncLet *);
 
 /// Returns true if the currently executing AsyncTask has a
 /// 'TaskGroupTaskStatusRecord' present.

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -96,22 +96,23 @@ SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 JobPriority
 swift_task_escalate(AsyncTask *task, JobPriority newPriority);
 
-// TODO: "async let wait" and "async let destroy" would be expressed
-//       similar to like TaskFutureWait;
-
 /// Wait for a non-throwing future task to complete.
 ///
 /// This can be called from any thread. Its Swift signature is
 ///
 /// \code
-/// func swift_task_future_wait(on task: _owned Builtin.NativeObject) async
-///     -> Success
+/// func swift_task_future_wait(
+///   on task: _owned Builtin.NativeObject,
+///   options: Builtin.RawPointer?
+/// ) async -> Success
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
-void swift_task_future_wait(OpaqueValue *,
-         SWIFT_ASYNC_CONTEXT AsyncContext *, AsyncTask *,
-         TaskContinuationFunction *,
-         AsyncContext *);
+void swift_task_future_wait(
+         OpaqueValue *,
+         SWIFT_ASYNC_CONTEXT AsyncContext *,
+         AsyncTask *,
+         TaskOptionRecord *,
+         TaskContinuationFunction *, AsyncContext *);
 
 /// Wait for a potentially-throwing future task to complete.
 ///
@@ -126,8 +127,9 @@ void swift_task_future_wait_throwing(
   OpaqueValue *,
   SWIFT_ASYNC_CONTEXT AsyncContext *,
   AsyncTask *,
+  TaskOptionRecord *,
   ThrowingTaskFutureWaitContinuationFunction *,
-  AsyncContext *);
+        AsyncContext *);
 
 /// Wait for a readyQueue of a Channel to become non empty.
 ///
@@ -136,14 +138,18 @@ void swift_task_future_wait_throwing(
 /// \code
 /// func swift_taskGroup_wait_next_throwing(
 ///     waitingTask: Builtin.NativeObject, // current task
-///     group: Builtin.RawPointer
+///     group: Builtin.RawPointer,
+///     options: Builtin.RawPointer? // options
 /// ) async -> T
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swiftasync)
 void swift_taskGroup_wait_next_throwing(
-    OpaqueValue *resultPointer, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
-    TaskGroup *group, ThrowingTaskFutureWaitContinuationFunction *resumeFn,
+    OpaqueValue *resultPointer,
+    SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+    TaskGroup *group,
+    TaskOptionRecord *options,
+    ThrowingTaskFutureWaitContinuationFunction *resumeFn,
     AsyncContext *callContext);
 
 /// Initialize a `TaskGroup` in the passed `group` memory location.
@@ -267,14 +273,17 @@ using AsyncLetWaitSignature =
 ///
 /// \code
 /// func swift_asyncLet_wait(
-///     _ asyncLet: _owned Builtin.RawPointer
+///     _ asyncLet: _owned Builtin.RawPointer,
+/////   _ options: Builtin.RawPointer?
 /// ) async -> Success
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
-void swift_asyncLet_wait(OpaqueValue *,
-                         SWIFT_ASYNC_CONTEXT AsyncContext *,
-                         AsyncLet *, TaskContinuationFunction *,
-                         AsyncContext *);
+void swift_asyncLet_wait(
+    OpaqueValue *,
+    SWIFT_ASYNC_CONTEXT AsyncContext *,
+    AsyncLet *,
+    TaskOptionRecord *,
+    TaskContinuationFunction *, AsyncContext *);
 
 /// Wait for a potentially-throwing async-let to complete.
 ///
@@ -282,23 +291,28 @@ void swift_asyncLet_wait(OpaqueValue *,
 ///
 /// \code
 /// func swift_asyncLet_wait_throwing(
-///     _ asyncLet: _owned Builtin.RawPointer
+///     _ asyncLet: _owned Builtin.RawPointer,
+///     _ options: Builtin.RawPointer?
 /// ) async throws -> Success
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
-void swift_asyncLet_wait_throwing(OpaqueValue *,
-                                  SWIFT_ASYNC_CONTEXT AsyncContext *,
-                                  AsyncLet *,
-                                  ThrowingTaskFutureWaitContinuationFunction *,
-                                  AsyncContext *);
+void swift_asyncLet_wait_throwing(
+    OpaqueValue *,
+    SWIFT_ASYNC_CONTEXT AsyncContext *,
+    AsyncLet *,
+    TaskOptionRecord *,
+    ThrowingTaskFutureWaitContinuationFunction *, AsyncContext *);
 
 /// Its Swift signature is
 ///
 /// \code
-/// func swift_asyncLet_end(_ alet: Builtin.RawPointer)
+/// func swift_asyncLet_end(
+///     _ alet: Builtin.RawPointer,
+///     _ options: Builtin.RawPointer?
+/// )
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-void swift_asyncLet_end(AsyncLet *alet);
+void swift_asyncLet_end(AsyncLet *, TaskOptionRecord *);
 
 /// Returns true if the currently executing AsyncTask has a
 /// 'TaskGroupTaskStatusRecord' present.

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1690,12 +1690,17 @@ FUNCTION(AsyncLetStart,
          ),
          ATTRS(NoUnwind, ArgMemOnly))
 
-// void swift_asyncLet_end(AsyncLet *alet);
+// void swift_asyncLet_end(
+//      AsyncLet *alet,
+//      TaskOptionRecord *options
+// );
 FUNCTION(EndAsyncLet,
          swift_asyncLet_end, SwiftCC,
          ConcurrencyAvailability,
          RETURNS(VoidTy),
-         ARGS(SwiftAsyncLetPtrTy),
+         ARGS(SwiftAsyncLetPtrTy, // AsyncLet*
+              SwiftTaskOptionRecordPtrTy // options
+         ),
          ATTRS(NoUnwind))
 
 // void swift_taskGroup_initialize(TaskGroup *group);

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1511,9 +1511,25 @@ static ValueDecl *getStartAsyncLet(ASTContext &ctx, Identifier id) {
 }
 
 static ValueDecl *getEndAsyncLet(ASTContext &ctx, Identifier id) {
-  return getBuiltinFunction(ctx, id, _thin,
-                            _parameters(_rawPointer),
-                            _void);
+  ModuleDecl *M = ctx.TheBuiltinModule;
+  DeclContext *DC = &M->getMainFile(FileUnitKind::Builtin);
+  SynthesisContext SC(ctx, DC);
+
+  BuiltinFunctionBuilder builder(ctx);
+
+  // AsyncLet*
+  builder.addParameter(makeConcrete(OptionalType::get(ctx.TheRawPointerType)));
+
+  // TaskOptionRecord*
+  builder.addParameter(makeConcrete(OptionalType::get(ctx.TheRawPointerType)));
+
+  // -> Void
+  builder.setResult(makeConcrete(synthesizeType(SC, _void)));
+  return builder.build(id);
+//  return getBuiltinFunction(ctx, id, _thin,
+//                            _parameters(_rawPointer,
+//                                        makeConcrete(OptionalType::get(ctx.TheRawPointerType))),
+//                            _void);
 }
 
 static ValueDecl *getCreateTaskGroup(ASTContext &ctx, Identifier id) {

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -244,7 +244,9 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
   }
 
   if (Builtin.ID == BuiltinValueKind::EndAsyncLet) {
-    emitEndAsyncLet(IGF, args.claimNext());
+    auto alet = args.claimNext();
+    auto taskOptions = args.claimNext();
+    emitEndAsyncLet(IGF, alet, taskOptions);
     // Ignore a second operand which is inserted by ClosureLifetimeFixup and
     // only used for dependency tracking.
     (void)args.claimAll();

--- a/lib/IRGen/GenConcurrency.cpp
+++ b/lib/IRGen/GenConcurrency.cpp
@@ -204,9 +204,13 @@ llvm::Value *irgen::emitBuiltinStartAsyncLet(IRGenFunction &IGF,
   return alet;
 }
 
-void irgen::emitEndAsyncLet(IRGenFunction &IGF, llvm::Value *alet) {
+void irgen::emitEndAsyncLet(IRGenFunction &IGF,
+                            llvm::Value *alet,
+                            llvm::Value *taskOptions) {
+  IGF.IGM.getEndAsyncLetFn()->dump();
+
   auto *call = IGF.Builder.CreateCall(IGF.IGM.getEndAsyncLetFn(),
-                                      {alet});
+                                      {alet, taskOptions});
   call->setDoesNotThrow();
   call->setCallingConv(IGF.IGM.SwiftCC);
 

--- a/lib/IRGen/GenConcurrency.h
+++ b/lib/IRGen/GenConcurrency.h
@@ -65,7 +65,9 @@ llvm::Value *emitBuiltinStartAsyncLet(IRGenFunction &IGF,
                                       SubstitutionMap subs);
 
 /// Emit the endAsyncLet builtin.
-void emitEndAsyncLet(IRGenFunction &IGF, llvm::Value *alet);
+void emitEndAsyncLet(IRGenFunction &IGF,
+                     llvm::Value *alet,
+                     llvm::Value *taskOptions);
 
 /// Emit the createTaskGroup builtin.
 llvm::Value *emitCreateTaskGroup(IRGenFunction &IGF, SubstitutionMap subs);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2511,17 +2511,22 @@ FunctionPointer::Kind irgen::classifyFunctionPointerKind(SILFunction *fn) {
   // Check for some special cases, which are currently all async:
   if (fn->isAsync()) {
     auto name = fn->getName();
-    if (name.equals("swift_task_future_wait"))
+    if (name.equals("swift_task_future_wait") ||
+        name.equals("swift_task_future_wait_with_options"))
       return SpecialKind::TaskFutureWait;
-    if (name.equals("swift_task_future_wait_throwing"))
+    if (name.equals("swift_task_future_wait_throwing") ||
+        name.equals("swift_task_future_wait_throwing_with_options"))
       return SpecialKind::TaskFutureWaitThrowing;
 
-    if (name.equals("swift_asyncLet_wait"))
+    if (name.equals("swift_asyncLet_wait") ||
+        name.equals("swift_asyncLet_wait_with_options"))
       return SpecialKind::AsyncLetWait;
-    if (name.equals("swift_asyncLet_wait_throwing"))
+    if (name.equals("swift_asyncLet_wait_throwing") ||
+        name.equals("swift_asyncLet_wait_throwing_with_options"))
       return SpecialKind::AsyncLetWaitThrowing;
 
-    if (name.equals("swift_taskGroup_wait_next_throwing"))
+    if (name.equals("swift_taskGroup_wait_next_throwing") ||
+        name.equals("swift_taskGroup_wait_next_throwing_with_options"))
       return SpecialKind::TaskGroupWaitNext;
   }
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1380,12 +1380,17 @@ public:
 
   ManagedValue emitAsyncLetGet(SILLocation loc, SILValue asyncLet);
 
-  ManagedValue emitEndAsyncLet(SILLocation loc, SILValue asyncLet);
+  ManagedValue emitEndAsyncLet(SILLocation loc,
+                               SILValue asyncLet,
+                               SILValue taskOptions);
 
   ManagedValue emitCancelAsyncTask(SILLocation loc, SILValue task);
 
   void completeAsyncLetChildTask(
-      PatternBindingDecl *patternBinding, unsigned index);
+      PatternBindingDecl *patternBinding, unsigned index
+//      ,
+//      SILValue taskOptions
+      );
 
   bool maybeEmitMaterializeForSetThunk(ProtocolConformanceRef conformance,
                                        SILLinkage linkage,
@@ -2104,7 +2109,7 @@ public:
   CleanupHandle enterCancelAsyncTaskCleanup(SILValue task);
 
   // Enter a cleanup to cancel and destroy an AsyncLet as it leaves the scope.
-  CleanupHandle enterAsyncLetCleanup(SILValue alet);
+  CleanupHandle enterAsyncLetCleanup(SILValue alet, SILValue taskOptions);
 
   /// Evaluate an Expr as an lvalue.
   LValue emitLValue(Expr *E, SGFAccessKind accessKind,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2823,7 +2823,16 @@ SILGenFunction::maybeEmitValueOfLocalVarDecl(
     if (var->isAsyncLet() && accessKind != AccessKind::Write) {
       auto patternBinding = var->getParentPatternBinding();
       unsigned index = patternBinding->getPatternEntryIndexForVarDecl(var);
-      completeAsyncLetChildTask(patternBinding, index);
+
+      auto &C = var->getASTContext();
+      SILLocation loc(var);
+      auto taskOptions = B.createManagedOptionalNone(
+          loc, SILType::getOptionalType(SILType::getRawPointerType(C)));
+      // TODO: should we create task option record here and pass to completeAsyncLetChildTask?
+
+      completeAsyncLetChildTask(patternBinding, index
+//                                , taskOptions
+                                );
     }
 
     // If this has an address, return it.  By-value let's have no address.

--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -582,11 +582,11 @@ static bool tryExtendLifetimeToLastUse(
       // alive) as a second operand to the endAsyncLet builtin.
       // This ensures that the closure arguments are kept alive until the
       // endAsyncLet builtin.
-      assert(endAsyncLet->getNumOperands() == 1);
+      assert(endAsyncLet->getNumOperands() == 2);
       SILBuilderWithScope builder(endAsyncLet);
       builder.createBuiltin(endAsyncLet->getLoc(), endAsyncLet->getName(),
         endAsyncLet->getType(), endAsyncLet->getSubstitutions(),
-        {endAsyncLet->getOperand(0), closure});
+        {endAsyncLet->getOperand(0), endAsyncLet->getOperand(1), closure});
       endAsyncLet->eraseFromParent();
     }
     return true;

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -107,7 +107,7 @@ OVERRIDE_TASK(task_create_common, AsyncTaskAndContext,
               (taskCreateFlags, options, futureResultType, function,
                closureContext, initialContextSize))
 
-OVERRIDE_TASK(task_future_wait, void, SWIFT_EXPORT_FROM(swift_Concurrency),
+OVERRIDE_TASK(task_future_wait_with_options, void, SWIFT_EXPORT_FROM(swift_Concurrency),
               SWIFT_CC(swiftasync), swift::,
               (OpaqueValue *result,
                SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
@@ -117,7 +117,16 @@ OVERRIDE_TASK(task_future_wait, void, SWIFT_EXPORT_FROM(swift_Concurrency),
                AsyncContext *callContext),
                (result, callerContext, task, options, resumeFunction, callContext))
 
-OVERRIDE_TASK(task_future_wait_throwing, void,
+OVERRIDE_TASK(task_future_wait, void, SWIFT_EXPORT_FROM(swift_Concurrency),
+              SWIFT_CC(swiftasync), swift::,
+              (OpaqueValue *result,
+               SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+               AsyncTask *task,
+               TaskContinuationFunction *resumeFunction,
+               AsyncContext *callContext),
+               (result, callerContext, task, resumeFunction, callContext))
+
+OVERRIDE_TASK(task_future_wait_throwing_with_options, void,
               SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swiftasync),
               swift::,
               (OpaqueValue *result,
@@ -127,6 +136,16 @@ OVERRIDE_TASK(task_future_wait_throwing, void,
                ThrowingTaskFutureWaitContinuationFunction *resumeFunction,
                AsyncContext *callContext),
               (result, callerContext, task, options, resumeFunction, callContext))
+
+OVERRIDE_TASK(task_future_wait_throwing, void,
+              SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swiftasync),
+              swift::,
+              (OpaqueValue *result,
+               SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+               AsyncTask *task,
+               ThrowingTaskFutureWaitContinuationFunction *resumeFunction,
+               AsyncContext *callContext),
+              (result, callerContext, task, resumeFunction, callContext))
 
 OVERRIDE_TASK(continuation_resume, void, SWIFT_EXPORT_FROM(swift_Concurrency),
               SWIFT_CC(swift), swift::,
@@ -163,7 +182,7 @@ OVERRIDE_TASK(task_asyncMainDrainQueue, void,
               SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift), swift::,
               , )
 
-OVERRIDE_ASYNC_LET(asyncLet_wait, void, SWIFT_EXPORT_FROM(swift_Concurrency),
+OVERRIDE_ASYNC_LET(asyncLet_wait_with_options, void, SWIFT_EXPORT_FROM(swift_Concurrency),
                    SWIFT_CC(swiftasync), swift::,
                    (OpaqueValue *result,
                     SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
@@ -173,7 +192,16 @@ OVERRIDE_ASYNC_LET(asyncLet_wait, void, SWIFT_EXPORT_FROM(swift_Concurrency),
                     AsyncContext *callContext),
                    (result, callerContext, alet, options, resumeFn, callContext))
 
-OVERRIDE_ASYNC_LET(asyncLet_wait_throwing, void,
+OVERRIDE_ASYNC_LET(asyncLet_wait, void, SWIFT_EXPORT_FROM(swift_Concurrency),
+                   SWIFT_CC(swiftasync), swift::,
+                   (OpaqueValue *result,
+                    SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+                    AsyncLet *alet,
+                    TaskContinuationFunction *resumeFn,
+                    AsyncContext *callContext),
+                   (result, callerContext, alet, resumeFn, callContext))
+
+OVERRIDE_ASYNC_LET(asyncLet_wait_throwing_with_options, void,
                    SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swiftasync),
                    swift::,
                    (OpaqueValue *result,
@@ -184,11 +212,27 @@ OVERRIDE_ASYNC_LET(asyncLet_wait_throwing, void,
                     AsyncContext *callContext),
                    (result, callerContext, alet, options, resume, callContext))
 
-OVERRIDE_ASYNC_LET(asyncLet_end, void,
+OVERRIDE_ASYNC_LET(asyncLet_wait_throwing, void,
+                   SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swiftasync),
+                   swift::,
+                   (OpaqueValue *result,
+                    SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+                    AsyncLet *alet,
+                    ThrowingTaskFutureWaitContinuationFunction *resume,
+                    AsyncContext *callContext),
+                   (result, callerContext, alet, resume, callContext))
+
+OVERRIDE_ASYNC_LET(asyncLet_end_with_options, void,
                    SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                    swift::,
                    (AsyncLet *alet, TaskOptionRecord *options),
                    (alet, options))
+
+OVERRIDE_ASYNC_LET(asyncLet_end, void,
+                   SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
+                   swift::,
+                   (AsyncLet *alet),
+                   (alet))
 
 OVERRIDE_TASK_GROUP(taskGroup_initialize, void,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
@@ -203,7 +247,7 @@ OVERRIDE_TASK_GROUP(taskGroup_destroy, void,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                     swift::, (TaskGroup *group), (group))
 
-OVERRIDE_TASK_GROUP(taskGroup_wait_next_throwing, void,
+OVERRIDE_TASK_GROUP(taskGroup_wait_next_throwing_with_options, void,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swiftasync),
                     swift::,
                     (OpaqueValue *resultPointer,
@@ -213,7 +257,18 @@ OVERRIDE_TASK_GROUP(taskGroup_wait_next_throwing, void,
                      ThrowingTaskFutureWaitContinuationFunction *resumeFn,
                      AsyncContext *callContext),
                     (resultPointer, callerContext, _group, options, resumeFn,
-                    callContext))
+                     callContext))
+
+OVERRIDE_TASK_GROUP(taskGroup_wait_next_throwing, void,
+                    SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swiftasync),
+                    swift::,
+                    (OpaqueValue *resultPointer,
+                     SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+                     TaskGroup *_group,
+                     ThrowingTaskFutureWaitContinuationFunction *resumeFn,
+                     AsyncContext *callContext),
+                    (resultPointer, callerContext, _group, resumeFn,
+                     callContext))
 
 OVERRIDE_TASK_GROUP(taskGroup_isEmpty, bool,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -110,19 +110,23 @@ OVERRIDE_TASK(task_create_common, AsyncTaskAndContext,
 OVERRIDE_TASK(task_future_wait, void, SWIFT_EXPORT_FROM(swift_Concurrency),
               SWIFT_CC(swiftasync), swift::,
               (OpaqueValue *result,
-               SWIFT_ASYNC_CONTEXT AsyncContext *callerContext, AsyncTask *task,
+               SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+               AsyncTask *task,
+               TaskOptionRecord *options,
                TaskContinuationFunction *resumeFunction,
                AsyncContext *callContext),
-              (result, callerContext, task, resumeFunction, callContext))
+               (result, callerContext, task, options, resumeFunction, callContext))
 
 OVERRIDE_TASK(task_future_wait_throwing, void,
               SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swiftasync),
               swift::,
               (OpaqueValue *result,
-               SWIFT_ASYNC_CONTEXT AsyncContext *callerContext, AsyncTask *task,
+               SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+               AsyncTask *task,
+               TaskOptionRecord *options,
                ThrowingTaskFutureWaitContinuationFunction *resumeFunction,
                AsyncContext *callContext),
-              (result, callerContext, task, resumeFunction, callContext))
+              (result, callerContext, task, options, resumeFunction, callContext))
 
 OVERRIDE_TASK(continuation_resume, void, SWIFT_EXPORT_FROM(swift_Concurrency),
               SWIFT_CC(swift), swift::,
@@ -162,24 +166,29 @@ OVERRIDE_TASK(task_asyncMainDrainQueue, void,
 OVERRIDE_ASYNC_LET(asyncLet_wait, void, SWIFT_EXPORT_FROM(swift_Concurrency),
                    SWIFT_CC(swiftasync), swift::,
                    (OpaqueValue *result,
-                       SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
-                       AsyncLet *alet, TaskContinuationFunction *resumeFn,
-                       AsyncContext *callContext),
-                   (result, callerContext, alet, resumeFn, callContext))
+                    SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+                    AsyncLet *alet,
+                    TaskOptionRecord *options,
+                    TaskContinuationFunction *resumeFn,
+                    AsyncContext *callContext),
+                   (result, callerContext, alet, options, resumeFn, callContext))
 
 OVERRIDE_ASYNC_LET(asyncLet_wait_throwing, void,
                    SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swiftasync),
                    swift::,
                    (OpaqueValue *result,
-                       SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
-                       AsyncLet *alet,
-                       ThrowingTaskFutureWaitContinuationFunction *resume,
-                       AsyncContext *callContext),
-                   (result, callerContext, alet, resume, callContext))
+                    SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+                    AsyncLet *alet,
+                    TaskOptionRecord *options,
+                    ThrowingTaskFutureWaitContinuationFunction *resume,
+                    AsyncContext *callContext),
+                   (result, callerContext, alet, options, resume, callContext))
 
 OVERRIDE_ASYNC_LET(asyncLet_end, void,
                    SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
-                   swift::, (AsyncLet *alet), (alet))
+                   swift::,
+                   (AsyncLet *alet, TaskOptionRecord *options),
+                   (alet, options))
 
 OVERRIDE_TASK_GROUP(taskGroup_initialize, void,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
@@ -200,9 +209,10 @@ OVERRIDE_TASK_GROUP(taskGroup_wait_next_throwing, void,
                     (OpaqueValue *resultPointer,
                      SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
                      TaskGroup *_group,
+                     TaskOptionRecord *options,
                      ThrowingTaskFutureWaitContinuationFunction *resumeFn,
                      AsyncContext *callContext),
-                    (resultPointer, callerContext, _group, resumeFn,
+                    (resultPointer, callerContext, _group, options, resumeFn,
                     callContext))
 
 OVERRIDE_TASK_GROUP(taskGroup_isEmpty, bool,

--- a/stdlib/public/Concurrency/AsyncLet.cpp
+++ b/stdlib/public/Concurrency/AsyncLet.cpp
@@ -124,30 +124,37 @@ void swift::swift_asyncLet_start(AsyncLet *alet,
 
 SWIFT_CC(swiftasync)
 static void swift_asyncLet_waitImpl(
-    OpaqueValue *result, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
-    AsyncLet *alet, TaskContinuationFunction *resumeFunction,
+    OpaqueValue *result,
+    SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+    AsyncLet *alet,
+    TaskOptionRecord *options,
+    TaskContinuationFunction *resumeFunction,
     AsyncContext *callContext) {
   auto task = alet->getTask();
-  swift_task_future_wait(result, callerContext, task, resumeFunction,
-                         callContext);
+  swift_task_future_wait(result, callerContext, task, options,
+                         resumeFunction, callContext);
 }
 
 SWIFT_CC(swiftasync)
 static void swift_asyncLet_wait_throwingImpl(
-    OpaqueValue *result, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+    OpaqueValue *result,
+    SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
     AsyncLet *alet,
+    TaskOptionRecord *options,
     ThrowingTaskFutureWaitContinuationFunction *resumeFunction,
-    AsyncContext * callContext) {
+    AsyncContext *callContext) {
   auto task = alet->getTask();
-  swift_task_future_wait_throwing(result, callerContext, task, resumeFunction,
-                                  callContext);
+  swift_task_future_wait_throwing(result, callerContext, task, options,
+                                  resumeFunction, callContext);
 }
 
 // =============================================================================
 // ==== end --------------------------------------------------------------------
 
 SWIFT_CC(swift)
-static void swift_asyncLet_endImpl(AsyncLet *alet) {
+static void swift_asyncLet_endImpl(
+    AsyncLet *alet,
+    TaskOptionRecord *options) {
   auto task = alet->getTask();
 
   // Cancel the task as we exit the scope

--- a/stdlib/public/Concurrency/AsyncLet.swift
+++ b/stdlib/public/Concurrency/AsyncLet.swift
@@ -26,7 +26,7 @@ public func _asyncLetStart<T>(
 
 /// Similar to _taskFutureGet but for AsyncLet
 @available(SwiftStdlib 5.5, *)
-@_silgen_name("swift_asyncLet_wait")
+@_silgen_name("swift_asyncLet_wait_with_options")
 public func _asyncLetGet<T>(
   asyncLet: Builtin.RawPointer,
   options:  Builtin.RawPointer?
@@ -34,19 +34,18 @@ public func _asyncLetGet<T>(
 
 ///// Similar to _taskFutureGetThrowing but for AsyncLet
 @available(SwiftStdlib 5.5, *)
-@_silgen_name("swift_asyncLet_wait_throwing")
+@_silgen_name("swift_asyncLet_wait_throwing_with_options")
 public func _asyncLetGetThrowing<T>(
   asyncLet: Builtin.RawPointer,
   options:  Builtin.RawPointer?
 ) async throws -> T
 
 @available(SwiftStdlib 5.5, *)
-@_silgen_name("swift_asyncLet_end")
+@_silgen_name("swift_asyncLet_end_with_options")
 public func _asyncLetEnd(
   asyncLet: Builtin.RawPointer, // TODO: should this take __owned?
   options:  Builtin.RawPointer?
 )
-
 
 @_silgen_name("swift_asyncLet_extractTask")
 func _asyncLetExtractTask(

--- a/stdlib/public/Concurrency/AsyncLet.swift
+++ b/stdlib/public/Concurrency/AsyncLet.swift
@@ -27,17 +27,24 @@ public func _asyncLetStart<T>(
 /// Similar to _taskFutureGet but for AsyncLet
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_asyncLet_wait")
-public func _asyncLetGet<T>(asyncLet: Builtin.RawPointer) async -> T
+public func _asyncLetGet<T>(
+  asyncLet: Builtin.RawPointer,
+  options:  Builtin.RawPointer?
+) async -> T
 
 ///// Similar to _taskFutureGetThrowing but for AsyncLet
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_asyncLet_wait_throwing")
-public func _asyncLetGetThrowing<T>(asyncLet: Builtin.RawPointer) async throws -> T
+public func _asyncLetGetThrowing<T>(
+  asyncLet: Builtin.RawPointer,
+  options:  Builtin.RawPointer?
+) async throws -> T
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_asyncLet_end")
 public func _asyncLetEnd(
-  asyncLet: Builtin.RawPointer // TODO: should this take __owned?
+  asyncLet: Builtin.RawPointer, // TODO: should this take __owned?
+  options:  Builtin.RawPointer?
 )
 
 

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -384,7 +384,6 @@ static void future_adapter(SWIFT_ASYNC_CONTEXT AsyncContext *_context) {
 
 SWIFT_CC(swiftasync)
 static void task_wait_throwing_resume_adapter(SWIFT_ASYNC_CONTEXT AsyncContext *_context) {
-
   auto context = static_cast<TaskFutureWaitAsyncContext *>(_context);
   auto resumeWithError =
       reinterpret_cast<AsyncVoidClosureEntryPoint *>(context->ResumeParent);
@@ -703,6 +702,7 @@ static void swift_task_future_waitImpl(
   OpaqueValue *result,
   SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
   AsyncTask *task,
+  TaskOptionRecord *taskOptions,
   TaskContinuationFunction *resumeFn,
   AsyncContext *callContext) {
   // Suspend the waiting task.
@@ -712,6 +712,8 @@ static void swift_task_future_waitImpl(
 
   // Wait on the future.
   assert(task->isFuture());
+
+  // TODO: check `options` for ExecutorTaskOptionRecord and use it to resume if it was set.
 
   switch (task->waitFuture(waitingTask, callContext, resumeFn, callerContext,
                            result)) {
@@ -757,6 +759,7 @@ SWIFT_CC(swiftasync)
 void swift_task_future_wait_throwingImpl(
     OpaqueValue *result, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
     AsyncTask *task,
+    TaskOptionRecord *taskOptions,
     ThrowingTaskFutureWaitContinuationFunction *resumeFunction,
     AsyncContext *callContext) {
   auto waitingTask = swift_task_getCurrent();

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -698,7 +698,7 @@ SWIFT_CC(swiftasync) static void workaround_function_swift_task_future_waitImpl(
 #endif
 
 SWIFT_CC(swiftasync)
-static void swift_task_future_waitImpl(
+static void swift_task_future_wait_with_optionsImpl(
   OpaqueValue *result,
   SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
   AsyncTask *task,
@@ -739,6 +739,21 @@ static void swift_task_future_waitImpl(
   }
 }
 
+SWIFT_CC(swiftasync)
+static void swift_task_future_waitImpl(
+    OpaqueValue *result,
+    SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+    AsyncTask *task,
+    TaskContinuationFunction *resumeFn,
+    AsyncContext *callContext) {
+  swift_task_future_wait_with_optionsImpl(
+      result,
+      callerContext,
+      task,
+      /*options=*/nullptr,
+      resumeFn, callContext);
+}
+
 #ifdef __ARM_ARCH_7K__
 __attribute__((noinline))
 SWIFT_CC(swiftasync) static void workaround_function_swift_task_future_wait_throwingImpl(
@@ -756,7 +771,7 @@ SWIFT_CC(swiftasync) static void workaround_function_swift_task_future_wait_thro
 #endif
 
 SWIFT_CC(swiftasync)
-void swift_task_future_wait_throwingImpl(
+void swift_task_future_wait_throwing_with_optionsImpl(
     OpaqueValue *result, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
     AsyncTask *task,
     TaskOptionRecord *taskOptions,
@@ -798,6 +813,19 @@ void swift_task_future_wait_throwingImpl(
     return resumeFunction(callerContext, error);
   }
   }
+}
+
+SWIFT_CC(swiftasync)
+void swift_task_future_wait_throwingImpl(
+    OpaqueValue *result, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+    AsyncTask *task,
+    ThrowingTaskFutureWaitContinuationFunction *resumeFunction,
+    AsyncContext *callContext) {
+  swift_task_future_wait_throwing_with_optionsImpl(
+      result, callerContext,
+      task,
+      /*options=*/nullptr,
+      resumeFunction, callContext);
 }
 
 namespace {

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -65,7 +65,7 @@ extension Task {
   /// thrown out of the task will be re-thrown here.
   public var value: Success {
     get async throws {
-      return try await _taskFutureGetThrowing(_task)
+      return try await _taskFutureGetThrowing(_task, options: nil)
     }
   }
 
@@ -138,7 +138,7 @@ extension Task where Failure == Never {
   /// that type itself.
   public var value: Success {
     get async {
-      return await _taskFutureGet(_task)
+      return await _taskFutureGet(_task, options: nil)
     }
   }
 }
@@ -776,11 +776,17 @@ public func _runAsyncMain(_ asyncFun: @escaping () async throws -> ()) {
 //        unreferenced
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_future_wait")
-public func _taskFutureGet<T>(_ task: Builtin.NativeObject) async -> T
+public func _taskFutureGet<T>(
+  _ task: Builtin.NativeObject,
+  options: Builtin.RawPointer?
+) async -> T
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_future_wait_throwing")
-public func _taskFutureGetThrowing<T>(_ task: Builtin.NativeObject) async throws -> T
+public func _taskFutureGetThrowing<T>(
+  _ task: Builtin.NativeObject,
+  options: Builtin.RawPointer?
+) async throws -> T
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_cancel")

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -671,6 +671,7 @@ SWIFT_CC(swiftasync)
 static void swift_taskGroup_wait_next_throwingImpl(
     OpaqueValue *resultPointer, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
     TaskGroup *_group,
+    TaskOptionRecord *options,
     ThrowingTaskFutureWaitContinuationFunction *resumeFunction,
     AsyncContext *rawContext) {
   auto waitingTask = swift_task_getCurrent();

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -667,8 +667,9 @@ SWIFT_CC(swiftasync) static void workaround_function_swift_taskGroup_wait_next_t
 
 // =============================================================================
 // ==== group.next() implementation (wait_next and groupPoll) ------------------
+
 SWIFT_CC(swiftasync)
-static void swift_taskGroup_wait_next_throwingImpl(
+static void swift_taskGroup_wait_next_throwing_with_optionsImpl(
     OpaqueValue *resultPointer, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
     TaskGroup *_group,
     TaskOptionRecord *options,
@@ -706,6 +707,19 @@ static void swift_taskGroup_wait_next_throwingImpl(
     fillGroupNextResult(context, polled);
     return waitingTask->runInFullyEstablishedContext();
   }
+}
+
+SWIFT_CC(swiftasync)
+static void swift_taskGroup_wait_next_throwingImpl(
+    OpaqueValue *resultPointer, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+    TaskGroup *_group,
+    ThrowingTaskFutureWaitContinuationFunction *resumeFunction,
+    AsyncContext *rawContext) {
+  swift_taskGroup_wait_next_throwingImpl(
+      resultPointer, callerContext,
+      _group,
+      resumeFunction,
+      rawContext);
 }
 
 PollResult TaskGroupImpl::poll(AsyncTask *waitingTask) {

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -325,7 +325,7 @@ public struct TaskGroup<ChildTaskResult> {
   public mutating func next() async -> ChildTaskResult? {
     // try!-safe because this function only exists for Failure == Never,
     // and as such, it is impossible to spawn a throwing child task.
-    return try! await _taskGroupWaitNext(group: _group)
+    return try! await _taskGroupWaitNext(group: _group, options: nil)
   }
 
   /// Await all the remaining tasks on this group.
@@ -555,13 +555,13 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   /// It is possible to directly rethrow such error out of a `withTaskGroup` body
   /// function's body, causing all remaining tasks to be implicitly cancelled.
   public mutating func next() async throws -> ChildTaskResult? {
-    return try await _taskGroupWaitNext(group: _group)
+    return try await _taskGroupWaitNext(group: _group, options: nil)
   }
 
   /// - SeeAlso: `next()`
   public mutating func nextResult() async throws -> Result<ChildTaskResult, Failure>? {
     do {
-      guard let success: ChildTaskResult = try await _taskGroupWaitNext(group: _group) else {
+      guard let success: ChildTaskResult = try await _taskGroupWaitNext(group: _group, options: nil) else {
         return nil
       }
 
@@ -749,7 +749,10 @@ func _taskGroupIsCancelled(group: Builtin.RawPointer) -> Bool
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_taskGroup_wait_next_throwing")
-func _taskGroupWaitNext<T>(group: Builtin.RawPointer) async throws -> T?
+func _taskGroupWaitNext<T>(
+  group: Builtin.RawPointer,
+  options: Builtin.RawPointer?
+) async throws -> T?
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_hasTaskGroupStatusRecord")

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -117,19 +117,34 @@ namespace {
 /// The layout of a context to call one of the following functions:
 ///
 ///   @_silgen_name("swift_task_future_wait")
-///   func _taskFutureGet<T>(_ task: Builtin.NativeObject) async -> T
+///   func _taskFutureGet<T>(
+///     _ task: Builtin.NativeObject,
+///     options: Builtin.RawPointer?
+///   ) async -> T
 ///
 ///   @_silgen_name("swift_task_future_wait_throwing")
-///   func _taskFutureGetThrowing<T>(_ task: Builtin.NativeObject) async throws -> T
+///   func _taskFutureGetThrowing<T>(
+///     _ task: Builtin.NativeObject,
+///     options: Builtin.RawPointer?
+///   ) async throws -> T
 ///
 ///   @_silgen_name("swift_asyncLet_wait")
-///   func _asyncLetGet<T>(_ task: Builtin.RawPointer) async -> T
+///   func _asyncLetGet<T>(
+///     _ task: Builtin.RawPointer,
+///     options: Builtin.RawPointer?
+///   ) async -> T
 ///
 ///   @_silgen_name("swift_asyncLet_waitThrowing")
-///   func _asyncLetGetThrowing<T>(_ task: Builtin.RawPointer) async throws -> T
+///   func _asyncLetGetThrowing<T>(
+///     _ task: Builtin.RawPointer,
+///     options: Builtin.RawPointer?
+///   ) async throws -> T
 ///
 ///   @_silgen_name("swift_taskGroup_wait_next_throwing")
-///   func _taskGroupWaitNext<T>(group: Builtin.RawPointer) async throws -> T?
+///   func _taskGroupWaitNext<T>(
+///     group: Builtin.RawPointer,
+///     options: Builtin.RawPointer?
+///   ) async throws -> T?
 ///
 class TaskFutureWaitAsyncContext : public AsyncContext {
 public:

--- a/test/Concurrency/Runtime/async_task_detach.swift
+++ b/test/Concurrency/Runtime/async_task_detach.swift
@@ -24,7 +24,7 @@ struct Boom: Error {}
 @available(SwiftStdlib 5.5, *)
 func test_detach() async {
   let x = X()
-  let h = detach {
+  let h = Task.detached {
     print("inside: \(x)")
   }
   await h.get()
@@ -36,7 +36,7 @@ func test_detach() async {
 @available(SwiftStdlib 5.5, *)
 func test_detach_throw() async {
   let x = X()
-  let h = detach {
+  let h = Task.detached {
     print("inside: \(x)")
     throw Boom()
   }

--- a/test/IRGen/async.swift
+++ b/test/IRGen/async.swift
@@ -17,14 +17,17 @@ public class SomeClass {}
 //public func task_future_wait(_ task: __owned SomeClass) async throws -> Int
 
 @_silgen_name("swift_task_future_wait_throwing")
-public func _taskFutureGetThrowing<T>(_ task: SomeClass) async throws -> T
+public func _taskFutureGetThrowing<T>(
+  _ task: SomeClass,
+  options: SomeClass?
+) async throws -> T
 
 // CHECK: define{{.*}} swift{{(tail)?}}cc void @"$s5async8testThisyyAA9SomeClassCnYaF"(%swift.context* swiftasync %0{{.*}}
 // CHECK-NOT: @swift_task_alloc
 // CHECK: {{(must)?}}tail call swift{{(tail)?}}cc void @swift_task_future_wait_throwing(%swift.opaque* {{.*}}, %swift.context* {{.*}}, %T5async9SomeClassC* {{.*}}, i8* {{.*}}, %swift.context* {{.*}})
 public func testThis(_ task: __owned SomeClass) async {
   do {
-    let _ : Int = try await _taskFutureGetThrowing(task)
+    let _ : Int = try await _taskFutureGetThrowing(task, options: nil)
   } catch _ {
     print("error")
   }

--- a/test/IRGen/async.swift
+++ b/test/IRGen/async.swift
@@ -13,10 +13,12 @@ public func h(_: @Sendable (Int) -> Int) { }
 
 public class SomeClass {}
 
-//@_silgen_name("swift_task_future_wait")
-//public func task_future_wait(_ task: __owned SomeClass) async throws -> Int
-
 @_silgen_name("swift_task_future_wait_throwing")
+public func _taskFutureGetThrowing<T>(
+  _ task: SomeClass
+) async throws -> T
+
+@_silgen_name("swift_task_future_wait_throwing_with_options")
 public func _taskFutureGetThrowing<T>(
   _ task: SomeClass,
   options: SomeClass?
@@ -24,7 +26,7 @@ public func _taskFutureGetThrowing<T>(
 
 // CHECK: define{{.*}} swift{{(tail)?}}cc void @"$s5async8testThisyyAA9SomeClassCnYaF"(%swift.context* swiftasync %0{{.*}}
 // CHECK-NOT: @swift_task_alloc
-// CHECK: {{(must)?}}tail call swift{{(tail)?}}cc void @swift_task_future_wait_throwing(%swift.opaque* {{.*}}, %swift.context* {{.*}}, %T5async9SomeClassC* {{.*}}, i8* {{.*}}, %swift.context* {{.*}})
+// CHECK: {{(must)?}}tail call swift{{(tail)?}}cc void @swift_task_future_wait_throwing_with_options(%swift.opaque* {{.*}}, %swift.context* {{.*}}, %T5async9SomeClassC* {{.*}}, i8* {{.*}}, %swift.context* {{.*}})
 public func testThis(_ task: __owned SomeClass) async {
   do {
     let _ : Int = try await _taskFutureGetThrowing(task, options: nil)

--- a/test/SILGen/async_let.swift
+++ b/test/SILGen/async_let.swift
@@ -27,7 +27,7 @@ func testAsyncLetInt() async -> Int {
   // CHECK: [[ASYNC_LET_START:%.*]] = builtin "startAsyncLet"<Int>([[OPTIONS_ARG]] : $Optional<Builtin.RawPointer>, [[CLOSURE_ARG]] : $@noescape @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <Int>) : $Builtin.RawPointer
   async let i = await getInt()
 
-  // CHECK: [[ASYNC_LET_GET:%.*]] = function_ref @swift_asyncLet_wait : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer, Optional<Builtin.RawPointer>) -> @out τ_0_0
+  // CHECK: [[ASYNC_LET_GET:%.*]] = function_ref @swift_asyncLet_wait_with_options : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer, Optional<Builtin.RawPointer>) -> @out τ_0_0
   // CHECK: [[INT_RESULT:%.*]] = alloc_stack $Int
   // CHECK: apply [[ASYNC_LET_GET]]<Int>([[INT_RESULT]], [[ASYNC_LET_START]], [[TASK_OPTS:%.*]]) : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer, Optional<Builtin.RawPointer>) -> @out τ_0_0
   // CHECK: [[INT_RESULT_VALUE:%.*]] = load [trivial] [[INT_RESULT]] : $*Int
@@ -53,7 +53,7 @@ func testAsyncLetWithThrows(cond: Bool) async throws -> String {
 func testAsyncLetThrows() async throws -> String {
   async let s = try await getStringThrowingly()
 
-  // CHECK: [[ASYNC_LET_WAIT_THROWING:%.*]] = function_ref @swift_asyncLet_wait_throwing : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer, Optional<Builtin.RawPointer>) -> (@out τ_0_0, @error Error)
+  // CHECK: [[ASYNC_LET_WAIT_THROWING:%.*]] = function_ref @swift_asyncLet_wait_throwing_with_options : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer, Optional<Builtin.RawPointer>) -> (@out τ_0_0, @error Error)
   // CHECK: try_apply [[ASYNC_LET_WAIT_THROWING]]<String>
   return try await s
 }
@@ -67,7 +67,7 @@ func testDecomposeAwait(cond: Bool) async -> Int {
   async let (i, s) = await getIntAndString()
 
   if cond {
-    // CHECK: [[ASYNC_LET_GET:%.*]] = function_ref @swift_asyncLet_wait : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer, Optional<Builtin.RawPointer>) -> @out τ_0_0
+    // CHECK: [[ASYNC_LET_GET:%.*]] = function_ref @swift_asyncLet_wait_with_options : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer, Optional<Builtin.RawPointer>) -> @out τ_0_0
     // CHECK: [[TUPLE_RESULT:%.*]] = alloc_stack $(Int, String)
     // CHECK: apply [[ASYNC_LET_GET]]<(Int, String)>([[TUPLE_RESULT]], {{%.*}}, [[TASK_OPTS:%.*]]) : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer, Optional<Builtin.RawPointer>) -> @out τ_0_0
     // CHECK: [[TUPLE_RESULT_VAL:%.*]] = load [take] [[TUPLE_RESULT]] : $*(Int, String)

--- a/test/SILGen/async_let.swift
+++ b/test/SILGen/async_let.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5 -enable-experimental-concurrency -parse-stdlib -sil-verify-all | %FileCheck %s --dump-input always
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5 -enable-experimental-concurrency -parse-stdlib -sil-verify-all | %FileCheck %s --dump-input fail
 // REQUIRES: concurrency
 
 import Swift
@@ -27,14 +27,14 @@ func testAsyncLetInt() async -> Int {
   // CHECK: [[ASYNC_LET_START:%.*]] = builtin "startAsyncLet"<Int>([[OPTIONS_ARG]] : $Optional<Builtin.RawPointer>, [[CLOSURE_ARG]] : $@noescape @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <Int>) : $Builtin.RawPointer
   async let i = await getInt()
 
-  // CHECK: [[ASYNC_LET_GET:%.*]] = function_ref @swift_asyncLet_wait : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer) -> @out τ_0_0
+  // CHECK: [[ASYNC_LET_GET:%.*]] = function_ref @swift_asyncLet_wait : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer, Optional<Builtin.RawPointer>) -> @out τ_0_0
   // CHECK: [[INT_RESULT:%.*]] = alloc_stack $Int
-  // CHECK: apply [[ASYNC_LET_GET]]<Int>([[INT_RESULT]], [[ASYNC_LET_START]]) : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer) -> @out τ_0_0
+  // CHECK: apply [[ASYNC_LET_GET]]<Int>([[INT_RESULT]], [[ASYNC_LET_START]], [[TASK_OPTS:%.*]]) : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer, Optional<Builtin.RawPointer>) -> @out τ_0_0
   // CHECK: [[INT_RESULT_VALUE:%.*]] = load [trivial] [[INT_RESULT]] : $*Int
   // CHECK: assign [[INT_RESULT_VALUE]] to [[I]] : $*Int
   return await i
 
-  // CHECK: [[ASYNC_LET_END:%.*]] = builtin "endAsyncLet"([[ASYNC_LET_START]] : $Builtin.RawPointer) : $()
+  // CHECK: [[ASYNC_LET_END:%.*]] = builtin "endAsyncLet"([[ASYNC_LET_START]] : $Builtin.RawPointer, [[TASK_OPTS:%.*]] : $Optional<Builtin.RawPointer>) : $()
 }
 
 func testAsyncLetWithThrows(cond: Bool) async throws -> String {
@@ -45,6 +45,7 @@ func testAsyncLetWithThrows(cond: Bool) async throws -> String {
     throw SomeError.boom
   }
 
+  _ = await i
   return await s
 }
 
@@ -52,7 +53,7 @@ func testAsyncLetWithThrows(cond: Bool) async throws -> String {
 func testAsyncLetThrows() async throws -> String {
   async let s = try await getStringThrowingly()
 
-  // CHECK: [[ASYNC_LET_WAIT_THROWING:%.*]] = function_ref @swift_asyncLet_wait_throwing : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer) -> (@out τ_0_0, @error Error)
+  // CHECK: [[ASYNC_LET_WAIT_THROWING:%.*]] = function_ref @swift_asyncLet_wait_throwing : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer, Optional<Builtin.RawPointer>) -> (@out τ_0_0, @error Error)
   // CHECK: try_apply [[ASYNC_LET_WAIT_THROWING]]<String>
   return try await s
 }
@@ -66,9 +67,9 @@ func testDecomposeAwait(cond: Bool) async -> Int {
   async let (i, s) = await getIntAndString()
 
   if cond {
-    // CHECK: [[ASYNC_LET_GET:%.*]] = function_ref @swift_asyncLet_wait : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer) -> @out τ_0_0
+    // CHECK: [[ASYNC_LET_GET:%.*]] = function_ref @swift_asyncLet_wait : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer, Optional<Builtin.RawPointer>) -> @out τ_0_0
     // CHECK: [[TUPLE_RESULT:%.*]] = alloc_stack $(Int, String)
-    // CHECK: apply [[ASYNC_LET_GET]]<(Int, String)>([[TUPLE_RESULT]], {{%.*}}) : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer) -> @out τ_0_0
+    // CHECK: apply [[ASYNC_LET_GET]]<(Int, String)>([[TUPLE_RESULT]], {{%.*}}, [[TASK_OPTS:%.*]]) : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer, Optional<Builtin.RawPointer>) -> @out τ_0_0
     // CHECK: [[TUPLE_RESULT_VAL:%.*]] = load [take] [[TUPLE_RESULT]] : $*(Int, String)
     // CHECK: ([[FIRST_VAL:%.*]], [[SECOND_VAL:%.*]]) = destructure_tuple [[TUPLE_RESULT_VAL]] : $(Int, String)
     // CHECK: assign [[FIRST_VAL]] to [[I]] : $*Int

--- a/test/SILOptimizer/closure_lifetime_fixup_concurrency.swift
+++ b/test/SILOptimizer/closure_lifetime_fixup_concurrency.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -sil-verify-all -enable-experimental-concurrency -emit-sil -disable-copy-propagation -I %t -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -sil-verify-all -enable-experimental-concurrency -emit-sil -disable-copy-propagation -I %t -o - | %FileCheck %s --dump-input fail
 // REQUIRES: concurrency
 
 // CHECK-LABEL: sil @$s34closure_lifetime_fixup_concurrency12testAsyncLetyS2SYaF : $@convention(thin) @async (@guaranteed String) -> @owned String {
@@ -7,7 +7,7 @@
 // CHECK:   [[MD:%.*]] = mark_dependence [[PA]]
 // CHECK:   [[CONV:%.*]] = convert_function [[MD]]
 // CHECK:   [[BAL:%.*]] = builtin "startAsyncLet"<String>([[OPT:%.+]] : $Optional<Builtin.RawPointer>, [[CONV]]
-// CHECK:   builtin "endAsyncLet"([[BAL]] : $Builtin.RawPointer, [[MD]]
+// CHECK:   builtin "endAsyncLet"([[BAL]] : $Builtin.RawPointer, [[TASK_OPTS:%.*]] : $Optional<Builtin.RawPointer>, [[MD]]
 // CHECK: } // end sil function '$s34closure_lifetime_fixup_concurrency12testAsyncLetyS2SYaF'
 
 public func testAsyncLet(_ n: String) async -> String {

--- a/unittests/runtime/CompatibilityOverrideConcurrency.cpp
+++ b/unittests/runtime/CompatibilityOverrideConcurrency.cpp
@@ -147,12 +147,12 @@ TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_create_common) {
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_future_wait) {
-  swift_task_future_wait(nullptr, nullptr, nullptr, nullptr, nullptr);
+  swift_task_future_wait(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest,
        test_swift_task_future_wait_throwing) {
-  swift_task_future_wait_throwing(nullptr, nullptr, nullptr, nullptr, nullptr);
+  swift_task_future_wait_throwing(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_continuation_resume) {
@@ -170,15 +170,15 @@ TEST_F(CompatibilityOverrideConcurrencyTest,
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_asyncLet_wait) {
-  swift_asyncLet_wait(nullptr, nullptr, nullptr, nullptr, nullptr);
+  swift_asyncLet_wait(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_asyncLet_wait_throwing) {
-  swift_asyncLet_wait(nullptr, nullptr, nullptr, nullptr, nullptr);
+  swift_asyncLet_wait(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_asyncLet_end) {
-  swift_asyncLet_end(nullptr);
+  swift_asyncLet_end(nullptr, nullptr);
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_taskGroup_initialize) {
@@ -193,10 +193,9 @@ TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_taskGroup_destroy) {
   swift_taskGroup_destroy(nullptr);
 }
 
-TEST_F(CompatibilityOverrideConcurrencyTest,
-       test_swift_taskGroup_wait_next_throwing) {
+TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_taskGroup_wait_next_throwing) {
   swift_taskGroup_wait_next_throwing(nullptr, nullptr, nullptr, nullptr,
-                                     nullptr);
+                                     nullptr, nullptr);
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_taskGroup_isEmpty) {


### PR DESCRIPTION

I may have gotten the ABI compatibility restoration wrong somewhere still. Will continue tomorrow.

Replaces #38102 (which is the ABI breaking version of this PR), and https://github.com/apple/swift/pull/38019
Resolves rdar://78931812