### PR TITLE
Revert "Diagnose the implicit use of self in nested closures."

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1509,31 +1509,14 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
             Closures.push_back(ACE);
         }
 
-    static bool isEnclosingSelfReference(VarDecl *var,
-                                   const AbstractClosureExpr *inClosure) {
-      if (var->isSelfParameter())
-        return true;
-
-      // Capture variables have a DC of the parent function.
-      if (inClosure && var->isSelfParamCapture() &&
-          var->getDeclContext() != inClosure->getParent())
-        return true;
-
-      return false;
-    }
-
     /// Return true if this is an implicit reference to self which is required
     /// to be explicit in an escaping closure. Metatype references and value
     /// type references are excluded.
-    static bool isImplicitSelfParamUseLikelyToCauseCycle(Expr *E,
-                                   const AbstractClosureExpr *inClosure) {
+    static bool isImplicitSelfParamUseLikelyToCauseCycle(Expr *E) {
       auto *DRE = dyn_cast<DeclRefExpr>(E);
 
-      if (!DRE || !DRE->isImplicit())
-        return false;
-
-      auto var = dyn_cast<VarDecl>(DRE->getDecl());
-      if (!var || !isEnclosingSelfReference(var, inClosure))
+      if (!DRE || !DRE->isImplicit() || !isa<VarDecl>(DRE->getDecl()) ||
+          !cast<VarDecl>(DRE->getDecl())->isSelfParameter())
         return false;
 
       // Defensive check for type. If the expression doesn't have type here, it
@@ -1616,7 +1599,7 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
       
       SourceLoc memberLoc = SourceLoc();
       if (auto *MRE = dyn_cast<MemberRefExpr>(E))
-        if (isImplicitSelfParamUseLikelyToCauseCycle(MRE->getBase(), ACE)) {
+        if (isImplicitSelfParamUseLikelyToCauseCycle(MRE->getBase())) {
           auto baseName = MRE->getMember().getDecl()->getBaseName();
           memberLoc = MRE->getLoc();
           Diags.diagnose(memberLoc,
@@ -1626,7 +1609,7 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
 
       // Handle method calls with a specific diagnostic + fixit.
       if (auto *DSCE = dyn_cast<DotSyntaxCallExpr>(E))
-        if (isImplicitSelfParamUseLikelyToCauseCycle(DSCE->getBase(), ACE) &&
+        if (isImplicitSelfParamUseLikelyToCauseCycle(DSCE->getBase()) &&
             isa<DeclRefExpr>(DSCE->getFn())) {
           auto MethodExpr = cast<DeclRefExpr>(DSCE->getFn());
           memberLoc = DSCE->getLoc();
@@ -1641,7 +1624,7 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
       }
       
       // Catch any other implicit uses of self with a generic diagnostic.
-      if (isImplicitSelfParamUseLikelyToCauseCycle(E, ACE))
+      if (isImplicitSelfParamUseLikelyToCauseCycle(E))
         Diags.diagnose(E->getLoc(), diag::implicit_use_of_self_in_closure);
 
       return { true, E };

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -151,7 +151,6 @@ func anonymousClosureArgsInClosureWithArgs() {
 
 func doStuff(_ fn : @escaping () -> Int) {}
 func doVoidStuff(_ fn : @escaping () -> ()) {}
-func doVoidStuffNonEscaping(_ fn: () -> ()) {}
 
 // <rdar://problem/16193162> Require specifying self for locations in code where strong reference cycles are likely
 class ExplicitSelfRequiredTest {
@@ -527,65 +526,5 @@ class SR3186 {
     // expected-warning@+1{{capture 'self' was never used}}
     let v = sr3186 { f in { [unowned self, f] x in x != 1000 ? f(x + 1) : "success" } }(0)
     print("\(v)")
-  }
-}
-
-// Apply the explicit 'self' rule even if it referrs to a capture, if
-// we're inside a nested closure
-class SR14120 {
-  func operation() {}
-
-  func test1() {
-    doVoidStuff { [self] in
-      operation()
-    }
-  }
-
-  func test2() {
-    doVoidStuff { [self] in
-      doVoidStuff {
-        // expected-error@+3 {{call to method 'operation' in closure requires explicit use of 'self'}}
-        // expected-note@-2 {{capture 'self' explicitly to enable implicit 'self' in this closure}}
-        // expected-note@+1 {{reference 'self.' explicitly}}
-        operation()
-      }
-    }
-  }
-
-  func test3() {
-    doVoidStuff { [self] in
-      doVoidStuff { [self] in
-        operation()
-      }
-    }
-  }
-
-  func test4() {
-    doVoidStuff { [self] in
-      doVoidStuff {
-        self.operation()
-      }
-    }
-  }
-
-  func test5() {
-    doVoidStuff { [self] in
-      doVoidStuffNonEscaping {
-        operation()
-      }
-    }
-  }
-
-  func test6() {
-    doVoidStuff { [self] in
-      doVoidStuff { [self] in
-        doVoidStuff {
-          // expected-error@+3 {{call to method 'operation' in closure requires explicit use of 'self'}}
-          // expected-note@-2 {{capture 'self' explicitly to enable implicit 'self' in this closure}}
-          // expected-note@+1 {{reference 'self.' explicitly}}
-          operation()
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
**Explanation**: Revert a change that starting rejecting nested closures that implicitly used nested `self`. We found and fixed a bug where Swift was allowing code to elide the explicit `self` capture in nested closures. However, lots of code seems to depend on this loophole, so we're rolling it back for now.
**Scope**: Allows ill-formed code that was allowed in Swift 5.4.
**Radar/SR Issue**:  rdar://78962922
**Risk**: Low.
**Testing**: PR testing and CI on main.
**Original PR**: None; we're reverting on the 5.5 branch only.
