### PR TITLE
[NFC] Remove 'isSerialized' from NodePrinter

### DIFF
--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -1702,9 +1702,7 @@ NodePointer NodePrinter::print(NodePointer Node, bool asPrefixContext) {
 
     unsigned lastChildIndex = Node->getNumChildren();
     auto lastChild = Node->getChild(lastChildIndex - 1);
-    bool isSerialized = false;
     if (lastChild->getKind() == Node::Kind::IsSerialized) {
-      isSerialized = true;
       --lastChildIndex;
       lastChild = Node->getChild(lastChildIndex - 1);
     }


### PR DESCRIPTION
'isSerialized' is tracked, but never actually used in NodePrinter::print.

Was introduced in bc119d0d6d74b0f20cf14110177309910bf8bab3.