### PR TITLE
[5.5] Skip running benchmarks in nightly toolchain

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1297,8 +1297,8 @@ mixin-preset=
 # SKIP LLDB TESTS (67923799)
 skip-test-lldb
 
-# SKIP Building benchmarks (79788142)
-skip-build-benchmarks
+# SKIP testing benchmarks (79788142)
+skip-test-benchmarks
 
 [preset: buildbot_osx_package,use_os_runtime]
 mixin-preset=


### PR DESCRIPTION
(cherry picked from commit 19fe81b6272521e96ae872dd834158dfce93f482)
