### PR TITLE
[5.5][CodeCompletion] Migrate key path completion to be solver based

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -5409,6 +5409,7 @@ public:
   /// - a resolved ValueDecl, referring to
   /// - a subscript index expression, which may or may not be resolved
   /// - an optional chaining, forcing, or wrapping component
+  /// - a code completion token
   class Component {
   public:
     enum class Kind: unsigned {
@@ -5423,6 +5424,7 @@ public:
       Identity,
       TupleElement,
       DictionaryKey,
+      CodeCompletion,
     };
   
   private:
@@ -5598,8 +5600,12 @@ public:
                                      SourceLoc loc) {
       return Component(fieldNumber, elementType, loc);
     }
-      
-      
+
+    static Component forCodeCompletion(SourceLoc Loc) {
+      return Component(nullptr, {}, nullptr, {}, {}, Kind::CodeCompletion,
+                       Type(), Loc);
+    }
+
     SourceLoc getLoc() const {
       return Loc;
     }
@@ -5637,6 +5643,7 @@ public:
       case Kind::UnresolvedSubscript:
       case Kind::UnresolvedProperty:
       case Kind::Invalid:
+      case Kind::CodeCompletion:
         return false;
       }
       llvm_unreachable("unhandled kind");
@@ -5657,6 +5664,7 @@ public:
       case Kind::Identity:
       case Kind::TupleElement:
       case Kind::DictionaryKey:
+      case Kind::CodeCompletion:
         return nullptr;
       }
       llvm_unreachable("unhandled kind");
@@ -5677,6 +5685,7 @@ public:
       case Kind::Identity:
       case Kind::TupleElement:
       case Kind::DictionaryKey:
+      case Kind::CodeCompletion:
         llvm_unreachable("no subscript labels for this kind");
       }
       llvm_unreachable("unhandled kind");
@@ -5700,6 +5709,7 @@ public:
       case Kind::Identity:
       case Kind::TupleElement:
       case Kind::DictionaryKey:
+      case Kind::CodeCompletion:
         return {};
       }
       llvm_unreachable("unhandled kind");
@@ -5723,6 +5733,7 @@ public:
       case Kind::Property:
       case Kind::Identity:
       case Kind::TupleElement:
+      case Kind::CodeCompletion:
         llvm_unreachable("no unresolved name for this kind");
       }
       llvm_unreachable("unhandled kind");
@@ -5743,6 +5754,7 @@ public:
       case Kind::Identity:
       case Kind::TupleElement:
       case Kind::DictionaryKey:
+      case Kind::CodeCompletion:
         return false;
       }
       llvm_unreachable("unhandled kind");
@@ -5763,6 +5775,7 @@ public:
       case Kind::Identity:
       case Kind::TupleElement:
       case Kind::DictionaryKey:
+      case Kind::CodeCompletion:
         llvm_unreachable("no decl ref for this kind");
       }
       llvm_unreachable("unhandled kind");
@@ -5783,6 +5796,7 @@ public:
         case Kind::Property:
         case Kind::Subscript:
         case Kind::DictionaryKey:
+        case Kind::CodeCompletion:
           llvm_unreachable("no field number for this kind");
       }
       llvm_unreachable("unhandled kind");

--- a/include/swift/Sema/CodeCompletionTypeChecking.h
+++ b/include/swift/Sema/CodeCompletionTypeChecking.h
@@ -116,6 +116,29 @@ namespace swift {
     void sawSolution(const constraints::Solution &solution) override;
   };
 
+  class KeyPathTypeCheckCompletionCallback
+      : public TypeCheckCompletionCallback {
+  public:
+    struct Result {
+      /// The type on which completion should occur, i.e. a result type of the
+      /// previous component.
+      Type BaseType;
+      /// Whether code completion happens on the key path's root.
+      bool OnRoot;
+    };
+
+  private:
+    KeyPathExpr *KeyPath;
+    SmallVector<Result, 4> Results;
+
+  public:
+    KeyPathTypeCheckCompletionCallback(KeyPathExpr *KeyPath)
+        : KeyPath(KeyPath) {}
+
+    ArrayRef<Result> getResults() const { return Results; }
+
+    void sawSolution(const constraints::Solution &solution) override;
+  };
 }
 
 #endif

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2880,6 +2880,9 @@ public:
         PrintWithColorRAII(OS, IdentifierColor)
           << "  key='" << component.getUnresolvedDeclName() << "'";
         break;
+      case KeyPathExpr::Component::Kind::CodeCompletion:
+        PrintWithColorRAII(OS, ASTNodeColor) << "completion";
+        break;
       }
       PrintWithColorRAII(OS, TypeColor)
         << " type='" << GetTypeOfKeyPathComponent(E, i) << "'";

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1125,6 +1125,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
       case KeyPathExpr::Component::Kind::Identity:
       case KeyPathExpr::Component::Kind::TupleElement:
       case KeyPathExpr::Component::Kind::DictionaryKey:
+      case KeyPathExpr::Component::Kind::CodeCompletion:
         // No subexpr to visit.
         break;
       }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2399,6 +2399,7 @@ void KeyPathExpr::Component::setSubscriptIndexHashableConformances(
   case Kind::Identity:
   case Kind::TupleElement:
   case Kind::DictionaryKey:
+  case Kind::CodeCompletion:
     llvm_unreachable("no hashable conformances for this kind");
   }
 }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -6727,6 +6727,28 @@ void deliverUnresolvedMemberResults(
   deliverCompletionResults(CompletionCtx, Lookup, DC, Consumer);
 }
 
+void deliverKeyPathResults(
+    ArrayRef<KeyPathTypeCheckCompletionCallback::Result> Results,
+    DeclContext *DC, SourceLoc DotLoc,
+    ide::CodeCompletionContext &CompletionCtx,
+    CodeCompletionConsumer &Consumer) {
+  ASTContext &Ctx = DC->getASTContext();
+  CompletionLookup Lookup(CompletionCtx.getResultSink(), Ctx, DC,
+                          &CompletionCtx);
+
+  if (DotLoc.isValid()) {
+    Lookup.setHaveDot(DotLoc);
+  }
+  Lookup.shouldCheckForDuplicates(Results.size() > 1);
+
+  for (auto &Result : Results) {
+    Lookup.setIsSwiftKeyPathExpr(Result.OnRoot);
+    Lookup.getValueExprCompletions(Result.BaseType);
+  }
+
+  deliverCompletionResults(CompletionCtx, Lookup, DC, Consumer);
+}
+
 void deliverDotExprResults(
     ArrayRef<DotExprTypeCheckCompletionCallback::Result> Results,
     Expr *BaseExpr, DeclContext *DC, SourceLoc DotLoc, bool IsInSelector,
@@ -6816,6 +6838,21 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
     addKeywords(CompletionContext.getResultSink(), MaybeFuncBody);
     deliverUnresolvedMemberResults(Lookup.getResults(), CurDeclContext, DotLoc,
                                    CompletionContext, Consumer);
+    return true;
+  }
+  case CompletionKind::KeyPathExprSwift: {
+    assert(CurDeclContext);
+
+    // CodeCompletionCallbacks::completeExprKeyPath takes a \c KeyPathExpr,
+    // so we can safely cast the \c ParsedExpr back to a \c KeyPathExpr.
+    auto KeyPath = cast<KeyPathExpr>(ParsedExpr);
+    KeyPathTypeCheckCompletionCallback Lookup(KeyPath);
+    llvm::SaveAndRestore<TypeCheckCompletionCallback *> CompletionCollector(
+        Context.CompletionCallback, &Lookup);
+    typeCheckContextAt(CurDeclContext, CompletionLoc);
+
+    deliverKeyPathResults(Lookup.getResults(), CurDeclContext, DotLoc,
+                          CompletionContext, Consumer);
     return true;
   }
   default:
@@ -6938,59 +6975,9 @@ void CodeCompletionCallbacksImpl::doneParsing() {
   case CompletionKind::None:
   case CompletionKind::DotExpr:
   case CompletionKind::UnresolvedMember:
+  case CompletionKind::KeyPathExprSwift:
     llvm_unreachable("should be already handled");
     return;
-
-  case CompletionKind::KeyPathExprSwift: {
-    auto KPE = dyn_cast<KeyPathExpr>(ParsedExpr);
-    auto BGT = (*ExprType)->getAs<BoundGenericType>();
-    if (!KPE || !BGT || BGT->getGenericArgs().size() != 2)
-      break;
-    assert(!KPE->isObjC());
-
-    if (DotLoc.isValid())
-      Lookup.setHaveDot(DotLoc);
-
-    bool OnRoot = !KPE->getComponents().front().isValid();
-    Lookup.setIsSwiftKeyPathExpr(OnRoot);
-
-    Type baseType = BGT->getGenericArgs()[OnRoot ? 0 : 1];
-    if (OnRoot && baseType->is<UnresolvedType>()) {
-      // Infer the root type of the keypath from the context type.
-      ExprContextInfo ContextInfo(CurDeclContext, ParsedExpr);
-      for (auto T : ContextInfo.getPossibleTypes()) {
-        if (auto unwrapped = T->getOptionalObjectType())
-          T = unwrapped;
-
-        // If the context type is any of the KeyPath types, use it.
-        if (T->getAnyNominal() && T->getAnyNominal()->getKeyPathTypeKind() &&
-            !T->hasUnresolvedType() && T->is<BoundGenericType>()) {
-          baseType = T->castTo<BoundGenericType>()->getGenericArgs()[0];
-          break;
-        }
-
-        // KeyPath can be used as a function that receives its root type.
-        if (T->is<AnyFunctionType>()) {
-          auto *fnType = T->castTo<AnyFunctionType>();
-          if (fnType->getNumParams() == 1) {
-            const AnyFunctionType::Param &param = fnType->getParams()[0];
-            baseType = param.getParameterType();
-            break;
-          }
-        }
-      }
-    }
-    if (!OnRoot && KPE->getComponents().back().getKind() ==
-                       KeyPathExpr::Component::Kind::OptionalWrap) {
-      // KeyPath expr with '?' (e.g. '\Ty.[0].prop?.another').
-      // Although expected type is optional, we should unwrap it because it's
-      // unwrapped.
-      baseType = baseType->getOptionalObjectType();
-    }
-
-    Lookup.getValueExprCompletions(baseType);
-    break;
-  }
 
   case CompletionKind::StmtOrExpr:
   case CompletionKind::ForEachSequence:

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -494,6 +494,7 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
       case KeyPathExpr::Component::Kind::OptionalForce:
       case KeyPathExpr::Component::Kind::Identity:
       case KeyPathExpr::Component::Kind::DictionaryKey:
+      case KeyPathExpr::Component::Kind::CodeCompletion:
         break;
       }
     }

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -440,6 +440,7 @@ std::pair<bool, Expr*> NameMatcher::walkToExprPre(Expr *E) {
             break;
           case KeyPathExpr::Component::Kind::DictionaryKey:
           case KeyPathExpr::Component::Kind::Invalid:
+          case KeyPathExpr::Component::Kind::CodeCompletion:
             break;
           case KeyPathExpr::Component::Kind::OptionalForce:
           case KeyPathExpr::Component::Kind::OptionalChain:

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3748,6 +3748,7 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
     case KeyPathExpr::Component::Kind::Invalid:
     case KeyPathExpr::Component::Kind::UnresolvedProperty:
     case KeyPathExpr::Component::Kind::UnresolvedSubscript:
+    case KeyPathExpr::Component::Kind::CodeCompletion:
       llvm_unreachable("not resolved");
       break;
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -377,6 +377,7 @@ static bool buildObjCKeyPathString(KeyPathExpr *E,
     case KeyPathExpr::Component::Kind::Invalid:
     case KeyPathExpr::Component::Kind::UnresolvedProperty:
     case KeyPathExpr::Component::Kind::UnresolvedSubscript:
+    case KeyPathExpr::Component::Kind::CodeCompletion:
       // Don't bother building the key path string if the key path didn't even
       // resolve.
       return false;
@@ -4938,7 +4939,8 @@ namespace {
           }
           break;
         }
-        case KeyPathExpr::Component::Kind::Invalid: {
+        case KeyPathExpr::Component::Kind::Invalid:
+        case KeyPathExpr::Component::Kind::CodeCompletion: {
           auto component = origComponent;
           component.setComponentType(leafTy);
           resolvedComponents.push_back(component);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3122,6 +3122,7 @@ namespace {
         if (!rootObjectTy || rootObjectTy->hasError())
           return Type();
 
+        CS.setType(rootRepr, rootObjectTy);
         // Allow \Derived.property to be inferred as \Base.property to
         // simulate a sort of covariant conversion from
         // KeyPath<Derived, T> to KeyPath<Base, T>.
@@ -3143,7 +3144,13 @@ namespace {
         switch (auto kind = component.getKind()) {
         case KeyPathExpr::Component::Kind::Invalid:
           break;
-        
+        case KeyPathExpr::Component::Kind::CodeCompletion:
+          // We don't know what the code completion might resolve to, so we are
+          // creating a new type variable for its result, which might be a hole.
+          base = CS.createTypeVariable(
+              resultLocator,
+              TVO_CanBindToLValue | TVO_CanBindToNoEscape | TVO_CanBindToHole);
+          break;
         case KeyPathExpr::Component::Kind::UnresolvedProperty:
         // This should only appear in resolved ASTs, but we may need to
         // re-type-check the constraints during failure diagnosis.
@@ -3239,7 +3246,8 @@ namespace {
       // If there was an optional chaining component, the end result must be
       // optional.
       if (didOptionalChain) {
-        auto objTy = CS.createTypeVariable(locator, TVO_CanBindToNoEscape);
+        auto objTy = CS.createTypeVariable(locator, TVO_CanBindToNoEscape |
+                                                        TVO_CanBindToHole);
         componentTypeVars.push_back(objTy);
 
         auto optTy = OptionalType::get(objTy);
@@ -3250,8 +3258,8 @@ namespace {
 
       auto baseLocator =
           CS.getConstraintLocator(E, ConstraintLocator::KeyPathValue);
-      auto rvalueBase = CS.createTypeVariable(baseLocator,
-                                              TVO_CanBindToNoEscape);
+      auto rvalueBase = CS.createTypeVariable(
+          baseLocator, TVO_CanBindToNoEscape | TVO_CanBindToHole);
       CS.addConstraint(ConstraintKind::Equal, base, rvalueBase, locator);
 
       // The result is a KeyPath from the root to the end component.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9488,7 +9488,12 @@ ConstraintSystem::simplifyKeyPathConstraint(
     case KeyPathExpr::Component::Kind::Invalid:
     case KeyPathExpr::Component::Kind::Identity:
       break;
-      
+
+    case KeyPathExpr::Component::Kind::CodeCompletion: {
+      anyComponentsUnresolved = true;
+      capability = ReadOnly;
+      break;
+    }
     case KeyPathExpr::Component::Kind::Property:
     case KeyPathExpr::Component::Kind::Subscript:
     case KeyPathExpr::Component::Kind::UnresolvedProperty:

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -509,6 +509,7 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
     case ComponentKind::OptionalWrap:
     case ComponentKind::Identity:
     case ComponentKind::DictionaryKey:
+    case ComponentKind::CodeCompletion:
       // These components don't have any callee associated, so just continue.
       break;
     }

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -1891,6 +1891,15 @@ void PreCheckExpression::resolveKeyPathExpr(KeyPathExpr *KPE) {
             UDE->getName(), UDE->getLoc()));
 
         expr = UDE->getBase();
+      } else if (auto CCE = dyn_cast<CodeCompletionExpr>(expr)) {
+        components.push_back(
+            KeyPathExpr::Component::forCodeCompletion(CCE->getLoc()));
+
+        expr = CCE->getBase();
+        if (!expr) {
+          // We are completing on the key path's base. Stop iterating.
+          return;
+        }
       } else if (auto SE = dyn_cast<SubscriptExpr>(expr)) {
         // .[0] or just plain [0]
         components.push_back(

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2840,6 +2840,7 @@ private:
       case KeyPathExpr::Component::Kind::OptionalForce:
       case KeyPathExpr::Component::Kind::Identity:
       case KeyPathExpr::Component::Kind::DictionaryKey:
+      case KeyPathExpr::Component::Kind::CodeCompletion:
         break;
       }
     }

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -618,7 +618,15 @@ class CompletionContextFinder : public ASTWalker {
 
   /// Stack of all "interesting" contexts up to code completion expression.
   llvm::SmallVector<Context, 4> Contexts;
-  CodeCompletionExpr *CompletionExpr = nullptr;
+
+  /// If we are completing inside an expression, the \c CodeCompletionExpr that
+  /// represents the code completion token.
+
+  /// The AST node that represents the code completion token, either as an
+  /// expression or a KeyPath component.
+  llvm::PointerUnion<CodeCompletionExpr *, const KeyPathExpr::Component *>
+      CompletionNode;
+
   Expr *InitialExpr = nullptr;
   DeclContext *InitialDC;
 
@@ -664,8 +672,17 @@ public:
     }
 
     if (auto *CCE = dyn_cast<CodeCompletionExpr>(E)) {
-      CompletionExpr = CCE;
+      CompletionNode = CCE;
       return std::make_pair(false, nullptr);
+    }
+    if (auto *KeyPath = dyn_cast<KeyPathExpr>(E)) {
+      for (auto &component : KeyPath->getComponents()) {
+        if (component.getKind() ==
+            KeyPathExpr::Component::Kind::CodeCompletion) {
+          CompletionNode = &component;
+          return std::make_pair(false, nullptr);
+        }
+      }
     }
 
     return std::make_pair(true, E);
@@ -691,12 +708,21 @@ public:
   }
 
   bool hasCompletionExpr() const {
-    return CompletionExpr;
+    return CompletionNode.dyn_cast<CodeCompletionExpr *>() != nullptr;
   }
 
   CodeCompletionExpr *getCompletionExpr() const {
-    assert(CompletionExpr);
-    return CompletionExpr;
+    assert(hasCompletionExpr());
+    return CompletionNode.get<CodeCompletionExpr *>();
+  }
+
+  bool hasCompletionKeyPathComponent() const {
+    return CompletionNode.dyn_cast<const KeyPathExpr::Component *>() != nullptr;
+  }
+
+  const KeyPathExpr::Component *getCompletionKeyPathComponent() const {
+    assert(hasCompletionKeyPathComponent());
+    return CompletionNode.get<const KeyPathExpr::Component *>();
   }
 
   struct Fallback {
@@ -710,7 +736,11 @@ public:
   /// of the enclosing context e.g. when completion is an argument
   /// to a call.
   Optional<Fallback> getFallbackCompletionExpr() const {
-    assert(CompletionExpr);
+    if (!hasCompletionExpr()) {
+      // Creating a fallback expression only makes sense if we are completing in
+      // an expression, not when we're completing in a key path.
+      return None;
+    }
 
     Optional<Fallback> fallback;
     bool separatePrecheck = false;
@@ -746,8 +776,8 @@ public:
     if (fallback)
       return fallback;
 
-    if (CompletionExpr->getBase() && CompletionExpr != InitialExpr)
-      return Fallback{CompletionExpr, fallbackDC, separatePrecheck};
+    if (getCompletionExpr()->getBase() && getCompletionExpr() != InitialExpr)
+      return Fallback{getCompletionExpr(), fallbackDC, separatePrecheck};
     return None;
   }
 
@@ -802,7 +832,7 @@ static void filterSolutions(SolutionApplicationTarget &target,
   // the other formed solutions (which require fixes). We should generate enum
   // pattern completions separately, but for now ignore the
   // _OptionalNilComparisonType solution.
-  if (isForPatternMatch(target)) {
+  if (isForPatternMatch(target) && completionExpr) {
     solutions.erase(llvm::remove_if(solutions, [&](const Solution &S) {
       ASTContext &ctx = S.getConstraintSystem().getASTContext();
       if (!S.hasType(completionExpr))
@@ -859,7 +889,8 @@ bool TypeChecker::typeCheckForCodeCompletion(
 
   // If there was no completion expr (e.g. if the code completion location was
   // among tokens that were skipped over during parser error recovery) bail.
-  if (!contextAnalyzer.hasCompletionExpr())
+  if (!contextAnalyzer.hasCompletionExpr() &&
+      !contextAnalyzer.hasCompletionKeyPathComponent())
     return false;
 
   // Interpolation components are type-checked separately.
@@ -905,7 +936,11 @@ bool TypeChecker::typeCheckForCodeCompletion(
     // FIXME: instead of filtering, expose the score and viability to clients.
     // Remove any solutions that both require fixes and have a score that is
     // worse than the best.
-    filterSolutions(target, solutions, contextAnalyzer.getCompletionExpr());
+    CodeCompletionExpr *completionExpr = nullptr;
+    if (contextAnalyzer.hasCompletionExpr()) {
+      completionExpr = contextAnalyzer.getCompletionExpr();
+    }
+    filterSolutions(target, solutions, completionExpr);
 
     // Similarly, if the type-check didn't produce any solutions, fall back
     // to type-checking a sub-expression in isolation.
@@ -1245,4 +1280,56 @@ sawSolution(const constraints::Solution &S) {
 
   bool SingleExprBody = isImplicitSingleExpressionReturn(CS, CompletionExpr);
   Results.push_back({ExpectedTy, SingleExprBody});
+}
+
+void KeyPathTypeCheckCompletionCallback::sawSolution(
+    const constraints::Solution &S) {
+  // Determine the code completion.
+  size_t ComponentIndex = 0;
+  for (auto &Component : KeyPath->getComponents()) {
+    if (Component.getKind() == KeyPathExpr::Component::Kind::CodeCompletion) {
+      break;
+    } else {
+      ComponentIndex++;
+    }
+  }
+  assert(ComponentIndex < KeyPath->getComponents().size() &&
+         "Didn't find a code compleiton component?");
+
+  auto &CS = S.getConstraintSystem();
+  Type BaseType;
+  if (ComponentIndex == 0) {
+    // We are completing on the root and need to extract the key path's root
+    // type.
+    if (KeyPath->getRootType()) {
+      BaseType = S.getResolvedType(KeyPath->getRootType());
+    } else {
+      // The key path doesn't have a root TypeRepr set, so we can't look the key
+      // path's root up through it. Build a constraint locator and look the
+      // root type up through it.
+      // FIXME: Improve the linear search over S.typeBindings when it's possible
+      // to look up type variables by their locators.
+      auto RootLocator =
+          S.getConstraintLocator(KeyPath, {ConstraintLocator::KeyPathRoot});
+      auto BaseVariableType =
+          llvm::find_if(S.typeBindings, [&RootLocator](const auto &Entry) {
+            return Entry.first->getImpl().getLocator() == RootLocator;
+          })->getSecond();
+      BaseType = S.simplifyType(BaseVariableType);
+    }
+  } else {
+    // We are completing after a component. Get the previous component's result
+    // type.
+    BaseType = S.simplifyType(CS.getType(KeyPath, ComponentIndex - 1));
+  }
+
+  // If ExpectedTy is a duplicate of any other result, ignore this solution.
+  if (llvm::any_of(Results, [&](const Result &R) {
+    return R.BaseType->isEqual(BaseType);
+  })) {
+    return;
+  }
+  if (BaseType) {
+    Results.push_back({BaseType, /*OnRoot=*/(ComponentIndex == 0)});
+  }
 }

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -206,6 +206,7 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
     switch (auto kind = component.getKind()) {
     case KeyPathExpr::Component::Kind::Invalid:
     case KeyPathExpr::Component::Kind::Identity:
+    case KeyPathExpr::Component::Kind::CodeCompletion:
       continue;
 
     case KeyPathExpr::Component::Kind::UnresolvedProperty:

--- a/test/IDE/complete_swift_key_path.swift
+++ b/test/IDE/complete_swift_key_path.swift
@@ -32,6 +32,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONTEXT_FUNC_INOUT | %FileCheck %s -check-prefix=PERSONTYPE-DOT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONTEXT_FUNC_VARIADIC | %FileCheck %s -check-prefix=ARRAYTYPE-DOT
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_KEY_PATH_BASE | %FileCheck %s -check-prefix=PERSONTYPE-DOT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_KEY_PATH_RESULT | %FileCheck %s -check-prefix=PERSONTYPE-DOT
+
 class Person {
     var name: String
     var friends: [Person] = []
@@ -177,4 +180,14 @@ func testKeyPathAsFunctions(wrapped: Wrap<Person>) {
   // Same as TYPE_DOT.
   let _ = wrapped.variadic(\.#^CONTEXT_FUNC_VARIADIC^#)
   // Same as ARRAYTYPE_DOT.
+}
+
+func genericKeyPathBase<Root>(to keyPath: ReferenceWritableKeyPath<Root, Person>, on object: Root) {
+  genericKeyPathBase(to: \.#^GENERIC_KEY_PATH_BASE^#, on: Person())
+  // Same as TYPE_DOT.
+}
+
+func genericKeyPathResult<KeyPathResult>(id: KeyPath<Person, KeyPathResult>) {
+  genericKeyPathResult(\.#^GENERIC_KEY_PATH_RESULT^#)
+  // Same as TYPE_DOT.
 }


### PR DESCRIPTION
* **Explanation**: This migrates code completion inside key paths to the new solver-based implementation, using the solutions discovered by the type checker to infer the base on which to complete the next key path component. This fixes issues where code completion wasn’t working in key paths that had a generic base or result (which I believe is a very common case).
* **Scope**: Code completion inside key paths
* **Risk**: Low to medium (this is a fundamental change to how code completion inside key paths works but I feel confident that it’s correct since it’s using the same approach that we use for member completion)
* **Testing**: Added regression tests
* **Issue**: rdar://78779234 and rdar://78779335
* **Reviewer**: @xedin (Pavel Yaskevich) on original PR #38049
