### PR TITLE
[Swift Next] Fix TargetInfo::adjust call

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1170,7 +1170,7 @@ ClangImporter::create(ASTContext &ctx,
   //
   // FIXME: We shouldn't need to do this, the target should be immutable once
   // created. This complexity should be lifted elsewhere.
-  instance.getTarget().adjust(instance.getLangOpts());
+  instance.getTarget().adjust(clangDiags, instance.getLangOpts());
 
   if (importerOpts.Mode == ClangImporterOptions::Modes::EmbedBitcode)
     return importer;


### PR DESCRIPTION
`TargetInfo::adjust` now takes the diagnostic engine in addition to the language options.

rdar://79979694