### PR TITLE
[build] disable failing Android cross-compilation test on macOS

### DIFF
--- a/validation-test/BuildSystem/android_cross_compile.test
+++ b/validation-test/BuildSystem/android_cross_compile.test
@@ -1,4 +1,5 @@
 # REQUIRES: standalone_build
+# UNSUPPORTED: OS=macosx
 
 # RUN: %empty-directory(%t)
 # RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --libdispatch --cross-compile-hosts=android-aarch64 --skip-local-build --android --android-ndk %t/ndk/ --android-arch aarch64 --android-icu-uc %t/lib/libicuuc.so --android-icu-uc-include %t/include/ --android-icu-i18n %t/lib/libicui18n.so --android-icu-i18n-include %t/include/ --android-icu-data %t/lib/libicudata.so 2>&1 | %FileCheck %s


### PR DESCRIPTION
@shahmishal, this should disable the test failure you saw because of #33724, please let me know if it doesn't.