### PR TITLE
[Swift Next] Fix `PrintName` calls -> `printNext`

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -3539,7 +3539,7 @@ void Driver::printHelp(bool ShowHidden) const {
   if (!ShowHidden)
     ExcludedFlagsBitmask |= HelpHidden;
 
-  getOpts().PrintHelp(llvm::outs(), Name.c_str(), "Swift compiler",
+  getOpts().printHelp(llvm::outs(), Name.c_str(), "Swift compiler",
                       IncludedFlagsBitmask, ExcludedFlagsBitmask,
                       /*ShowAllAliases*/false);
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -2102,7 +2102,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
       Invocation.getFrontendOptions().PrintHelpHidden ? 0 :
                                                         llvm::opt::HelpHidden;
     std::unique_ptr<llvm::opt::OptTable> Options(createSwiftOptTable());
-    Options->PrintHelp(llvm::outs(), displayName(MainExecutablePath).c_str(),
+    Options->printHelp(llvm::outs(), displayName(MainExecutablePath).c_str(),
                        "Swift frontend", IncludedFlagsBitmask,
                        ExcludedFlagsBitmask, /*ShowAllAliases*/false);
     return finishDiagProcessing(0, /*verifierEnabled*/ false);

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -446,6 +446,6 @@ void TestOptions::printHelp(bool ShowHidden) const {
 
   TestOptTable Table;
 
-  Table.PrintHelp(llvm::outs(), "sourcekitd-test [options] <inputs>",
+  Table.printHelp(llvm::outs(), "sourcekitd-test [options] <inputs>",
                   "SourceKit Testing Tool", ShowHidden);
 }

--- a/tools/driver/autolink_extract_main.cpp
+++ b/tools/driver/autolink_extract_main.cpp
@@ -82,7 +82,7 @@ public:
     if (ParsedArgs.getLastArg(OPT_help)) {
       std::string ExecutableName =
           llvm::sys::path::stem(MainExecutablePath).str();
-      Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
+      Table->printHelp(llvm::outs(), ExecutableName.c_str(),
                        "Swift Autolink Extract", options::AutolinkExtractOption,
                        0, /*ShowAllAliases*/false);
       return 1;

--- a/tools/driver/modulewrap_main.cpp
+++ b/tools/driver/modulewrap_main.cpp
@@ -95,7 +95,7 @@ public:
     if (ParsedArgs.getLastArg(OPT_help)) {
       std::string ExecutableName =
           llvm::sys::path::stem(MainExecutablePath).str();
-      Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
+      Table->printHelp(llvm::outs(), ExecutableName.c_str(),
                        "Swift Module Wrapper", options::ModuleWrapOption, 0,
                        /*ShowAllAliases*/false);
       return 1;

--- a/tools/driver/swift_api_digester_main.cpp
+++ b/tools/driver/swift_api_digester_main.cpp
@@ -2649,7 +2649,7 @@ public:
   void printHelp() {
     std::string ExecutableName =
         llvm::sys::path::stem(MainExecutablePath).str();
-    Table->PrintHelp(llvm::outs(), ExecutableName.c_str(), "Swift API Digester",
+    Table->printHelp(llvm::outs(), ExecutableName.c_str(), "Swift API Digester",
                      /*IncludedFlagsBitmask*/ SwiftAPIDigesterOption,
                      /*ExcludedFlagsBitmask*/ 0,
                      /*ShowAllAliases*/ false);

--- a/tools/driver/swift_api_extract_main.cpp
+++ b/tools/driver/swift_api_extract_main.cpp
@@ -65,7 +65,7 @@ public:
     if (ParsedArgs.getLastArg(OPT_help)) {
       std::string ExecutableName =
           llvm::sys::path::stem(MainExecutablePath).str();
-      Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
+      Table->printHelp(llvm::outs(), ExecutableName.c_str(),
                        "Swift API Extract", options::SwiftAPIExtractOption, 0,
                        /*ShowAllAliases*/ false);
       return 1;

--- a/tools/driver/swift_indent_main.cpp
+++ b/tools/driver/swift_indent_main.cpp
@@ -149,7 +149,7 @@ public:
     if (ParsedArgs.getLastArg(OPT_help)) {
       std::string ExecutableName =
           llvm::sys::path::stem(MainExecutablePath).str();
-      Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
+      Table->printHelp(llvm::outs(), ExecutableName.c_str(),
                        "Swift Format Tool", options::SwiftIndentOption, 0,
                        /*ShowAllAliases*/false);
       return 1;

--- a/tools/driver/swift_symbolgraph_extract_main.cpp
+++ b/tools/driver/swift_symbolgraph_extract_main.cpp
@@ -62,7 +62,7 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
   if (ParsedArgs.getLastArg(OPT_help) || Args.empty()) {
     std::string ExecutableName =
         llvm::sys::path::stem(MainExecutablePath).str();
-    Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
+    Table->printHelp(llvm::outs(), ExecutableName.c_str(),
                      "Swift Symbol Graph Extractor",
                      SwiftSymbolGraphExtractOption, 0,
                      /*ShowAllAliases*/ false);


### PR DESCRIPTION
`OptTable::PrintName` was renamed `printName` in LLVM commit f1e2d5851bf86.

rdar://79976797