### PR TITLE
[AutoDiff] State explicit conditional conformances in DifferentiationUnittest.

### DIFF
--- a/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift.gyb
+++ b/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift.gyb
@@ -196,8 +196,7 @@ extension ${Self}: Equatable where T: Equatable {
   }
 }
 
-extension ${Self}: SignedNumeric & Numeric
-where T: SignedNumeric, T == T.Magnitude {
+extension ${Self}: Numeric where T: Numeric {
   public typealias Magnitude = ${Self}<T.Magnitude>
 
   public init?<U>(exactly source: U) where U: BinaryInteger {
@@ -214,6 +213,12 @@ where T: SignedNumeric, T == T.Magnitude {
 
   public static func *= (lhs: inout ${Self}, rhs: ${Self}) {
     lhs = lhs * rhs
+  }
+}
+
+extension ${Self}: SignedNumeric where T: SignedNumeric, T == T.Magnitude {
+  public prefix static func - (operand: ${Self}) -> ${Self} {
+    ${Self}(-operand.value)
   }
 }
 


### PR DESCRIPTION
This fixes verification of emitted swiftinterface files.

```console
error: conditional conformance of type 'Tracked<T>' to protocol 'SignedNumeric' does not imply conformance to inherited protocol 'Numeric'
extension Tracked : Swift.SignedNumeric where T : Swift.SignedNumeric, T == T.Magnitude {
^
```

Resolves rdar://77869183.