### PR TITLE
[5.5] Fix for a crash due to performLocalReleaseMotion and performLocalRetainMotion in LLVMARCOptimizer

### DIFF
--- a/lib/LLVMPasses/LLVMARCOpts.cpp
+++ b/lib/LLVMPasses/LLVMARCOpts.cpp
@@ -116,6 +116,12 @@ static bool canonicalizeInputFunction(Function &F, ARCEntryPointBuilder &B,
           ++NumNoopDeleted;
           continue;
         }
+        if (!CI.use_empty()) {
+          // Do not get RC identical value here, could end up with a
+          // crash in replaceAllUsesWith as the type maybe different.
+          CI.replaceAllUsesWith(CI.getArgOperand(0));
+          Changed = true;
+        }
         // Rewrite unknown retains into swift_retains.
         NativeRefs.insert(ArgVal);
         for (auto &X : UnknownObjectRetains[ArgVal]) {
@@ -138,7 +144,12 @@ static bool canonicalizeInputFunction(Function &F, ARCEntryPointBuilder &B,
           ++NumNoopDeleted;
           continue;
         }
-
+        if (!CI.use_empty()) {
+          // Do not get RC identical value here, could end up with a
+          // crash in replaceAllUsesWith as the type maybe different.
+          CI.replaceAllUsesWith(CI.getArgOperand(0));
+          Changed = true;
+        }
         // Have not encountered a strong retain/release. keep it in the
         // unknown retain/release list for now. It might get replaced
         // later.


### PR DESCRIPTION

• Explanation: Fixes a crash due to low level LLVM ARC optimizer in the Swift Compiler. In the pass during canonicalization we are not replacing all uses of the results of swift_retain and swift_unknownObjectRetain. But later in the pass we can optimize such retains, leaving uses without definition or uses not dominated by definitions. 

• Scope of Issue: Compiler crash

• Risk: Low. The fix is low risk because LLVM Compiler has already been doing a similar optimization for @returned attribute. The issue happens only in cases where LLVM Compiler fails to do so. 

• Reviewed By:  Andrew Trick

• Testing: Added unit tests