### PR TITLE
[IRGen] Don't emit unused enum tag value witnesses for certain generic enum VWTs.

### DIFF
--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -968,21 +968,33 @@ static void addValueWitness(IRGenModule &IGM, ConstantStructBuilder &B,
   }
 
   case ValueWitness::GetEnumTagSinglePayload: {
-    if (boundGenericCharacteristics)
+    if (boundGenericCharacteristics) {
       if (auto *enumDecl = boundGenericCharacteristics->concreteType
                                .getEnumOrBoundGenericEnum())
         if (IGM.getMetadataLayout(enumDecl).hasPayloadSizeOffset())
           return B.add(llvm::ConstantExpr::getBitCast(
               IGM.getGetMultiPayloadEnumTagSinglePayloadFn(), IGM.Int8PtrTy));
+    } else {
+      if (auto *enumDecl = concreteType.getEnumOrBoundGenericEnum())
+        if (IGM.getMetadataLayout(enumDecl).hasPayloadSizeOffset()) {
+          return B.addNullPointer(IGM.Int8PtrTy);
+        }
+    }
     goto standard;
   }
   case ValueWitness::StoreEnumTagSinglePayload: {
-    if (boundGenericCharacteristics)
+    if (boundGenericCharacteristics) {
       if (auto *enumDecl = boundGenericCharacteristics->concreteType
                                .getEnumOrBoundGenericEnum())
         if (IGM.getMetadataLayout(enumDecl).hasPayloadSizeOffset())
           return B.add(llvm::ConstantExpr::getBitCast(
               IGM.getStoreMultiPayloadEnumTagSinglePayloadFn(), IGM.Int8PtrTy));
+    } else {
+      if (auto *enumDecl = concreteType.getEnumOrBoundGenericEnum())
+        if (IGM.getMetadataLayout(enumDecl).hasPayloadSizeOffset()) {
+          return B.addNullPointer(IGM.Int8PtrTy);
+        }
+    }
     goto standard;
   }
 


### PR DESCRIPTION
When swift_initEnumMetadataMultiPayload is called, the
getEnumTagSinglePayload and storeEnumTagSinglePayload value witnesses
are unconditionally overwritten and replaced with runtime functions:

```
  // Unconditionally overwrite the enum-tag witnesses.
  // The compiler does not generate meaningful enum-tag witnesses for
  // enums in this state.
  vwtable->getEnumTagSinglePayload = swift_getMultiPayloadEnumTagSinglePayload;
  vwtable->storeEnumTagSinglePayload =
      swift_storeMultiPayloadEnumTagSinglePayload;
```

Consequently, enums in this state do not need these value witnesses to
be emitted.  Skip their emission to save on code-size.
