### PR TITLE
[5.5] Fix SILGen of access to isolated static properties

### DIFF
--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -207,9 +207,9 @@ public:
 /// The only operation on this component is `project`.
 class PhysicalPathComponent : public PathComponent {
   virtual void _anchor() override;
+  Optional<ActorIsolation> ActorIso;
 
 protected:
-  Optional<ActorIsolation> ActorIso;
   PhysicalPathComponent(LValueTypeData typeData, KindTy Kind,
                         Optional<ActorIsolation> actorIso = None)
     : PathComponent(typeData, Kind), ActorIso(actorIso) {
@@ -217,8 +217,16 @@ protected:
   }
 
 public:
-  // Obtains the actor-isolation required for any loads of this component.
-  Optional<ActorIsolation> getActorIsolation() const { return ActorIso; }
+  /// Obtains and consumes the actor-isolation required for any loads of
+  /// this component.
+  Optional<ActorIsolation> takeActorIsolation() {
+    Optional<ActorIsolation> current = ActorIso;
+    ActorIso = None;
+    return current;
+  }
+
+  /// Determines whether this component has any actor-isolation.
+  bool hasActorIsolation() const { return ActorIso.hasValue(); }
 };
 
 inline PhysicalPathComponent &PathComponent::asPhysical() {

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -537,9 +537,13 @@ namespace {
   };
 
   class EndAccessPseudoComponent : public WritebackPseudoComponent {
+  private:
+    ExecutorBreadcrumb ExecutorHop;
   public:
-    EndAccessPseudoComponent(const LValueTypeData &typeData)
-      : WritebackPseudoComponent(typeData) {}
+    EndAccessPseudoComponent(const LValueTypeData &typeData,
+                             ExecutorBreadcrumb &&executorHop)
+      : WritebackPseudoComponent(typeData),
+        ExecutorHop(std::move(executorHop)) {}
 
   private:
     void writeback(SILGenFunction &SGF, SILLocation loc,
@@ -550,6 +554,7 @@ namespace {
 
       assert(base.isLValue());
       SGF.B.createEndAccess(loc, base.getValue(), /*abort*/ false);
+      ExecutorHop.emit(SGF, loc);
     }
 
     void dump(raw_ostream &OS, unsigned indent) const override {
@@ -561,12 +566,18 @@ namespace {
 static SILValue enterAccessScope(SILGenFunction &SGF, SILLocation loc,
                                  SILValue addr, LValueTypeData typeData,
                                  SGFAccessKind accessKind,
-                                 SILAccessEnforcement enforcement) {
+                                 SILAccessEnforcement enforcement,
+                                 Optional<ActorIsolation> actorIso) {
   auto silAccessKind = isReadAccess(accessKind) ? SILAccessKind::Read
                                                 : SILAccessKind::Modify;
 
   assert(SGF.isInFormalEvaluationScope() &&
          "tried to enter access scope without a writeback scope!");
+
+  // Only expecting global-actor isolation here, since there's no base / self.
+  assert(!actorIso || actorIso->isGlobalActor());
+  ExecutorBreadcrumb prevExecutor =
+      SGF.emitHopToTargetActor(loc, actorIso, /*maybeSelf=*/None);
 
   // Enter the access.
   addr = SGF.B.createBeginAccess(loc, addr, silAccessKind, enforcement,
@@ -576,7 +587,8 @@ static SILValue enterAccessScope(SILGenFunction &SGF, SILLocation loc,
   // Push a writeback to end it.
   auto accessedMV = ManagedValue::forLValue(addr);
   std::unique_ptr<LogicalPathComponent>
-    component(new EndAccessPseudoComponent(typeData));
+    component(new EndAccessPseudoComponent(typeData,
+                                              std::move(prevExecutor)));
   pushWriteback(SGF, loc, std::move(component), accessedMV,
                 MaterializedLValue());
 
@@ -586,10 +598,11 @@ static SILValue enterAccessScope(SILGenFunction &SGF, SILLocation loc,
 static ManagedValue enterAccessScope(SILGenFunction &SGF, SILLocation loc,
                                      ManagedValue addr, LValueTypeData typeData,
                                      SGFAccessKind accessKind,
-                                     SILAccessEnforcement enforcement) {
+                                     SILAccessEnforcement enforcement,
+                                     Optional<ActorIsolation> actorIso) {
   return ManagedValue::forLValue(
            enterAccessScope(SGF, loc, addr.getLValueAddress(), typeData,
-                            accessKind, enforcement));
+                            accessKind, enforcement, actorIso));
 }
 
 // Find the base of the formal access at `address`. If the base requires an
@@ -717,8 +730,9 @@ namespace {
     bool IsNonAccessing;
   public:
     RefElementComponent(VarDecl *field, LValueOptions options,
-                        SILType substFieldType, LValueTypeData typeData)
-      : PhysicalPathComponent(typeData, RefElementKind),
+                        SILType substFieldType, LValueTypeData typeData,
+                        Optional<ActorIsolation> actorIso)
+      : PhysicalPathComponent(typeData, RefElementKind, actorIso),
         Field(field), SubstFieldType(substFieldType),
         IsNonAccessing(options.IsNonAccessing) {}
 
@@ -745,7 +759,8 @@ namespace {
       if (!IsNonAccessing && !Field->isLet()) {
         if (auto enforcement = SGF.getDynamicEnforcement(Field)) {
           result = enterAccessScope(SGF, loc, result, getTypeData(),
-                                    getAccessKind(), *enforcement);
+                                    getAccessKind(), *enforcement,
+                                    takeActorIsolation());
         }
       }
 
@@ -761,7 +776,8 @@ namespace {
     unsigned ElementIndex;
   public:
     TupleElementComponent(unsigned elementIndex, LValueTypeData typeData)
-      : PhysicalPathComponent(typeData, TupleElementKind),
+      : PhysicalPathComponent(typeData, TupleElementKind,
+        /*actorIsolation=*/None),
         ElementIndex(elementIndex) {}
 
     virtual bool isLoadingPure() const override { return true; }
@@ -790,8 +806,9 @@ namespace {
     SILType SubstFieldType;
   public:
     StructElementComponent(VarDecl *field, SILType substFieldType,
-                           LValueTypeData typeData)
-      : PhysicalPathComponent(typeData, StructElementKind),
+                           LValueTypeData typeData,
+                           Optional<ActorIsolation> actorIso)
+      : PhysicalPathComponent(typeData, StructElementKind, actorIso),
         Field(field), SubstFieldType(substFieldType) {}
 
     virtual bool isLoadingPure() const override { return true; }
@@ -819,9 +836,9 @@ namespace {
   class ForceOptionalObjectComponent : public PhysicalPathComponent {
     bool isImplicitUnwrap;
   public:
-    ForceOptionalObjectComponent(LValueTypeData typeData,
-                                 bool isImplicitUnwrap)
-      : PhysicalPathComponent(typeData, OptionalObjectKind),
+    ForceOptionalObjectComponent(LValueTypeData typeData, bool isImplicitUnwrap)
+      : PhysicalPathComponent(typeData, OptionalObjectKind,
+        /*actorIsolation=*/None),
         isImplicitUnwrap(isImplicitUnwrap) {}
     
     ManagedValue project(SILGenFunction &SGF, SILLocation loc,
@@ -842,7 +859,8 @@ namespace {
   public:
     OpenOpaqueExistentialComponent(CanArchetypeType openedArchetype,
                                    LValueTypeData typeData)
-      : PhysicalPathComponent(typeData, OpenOpaqueExistentialKind) {
+      : PhysicalPathComponent(typeData, OpenOpaqueExistentialKind,
+        /*actorIsolation=*/None) {
       assert(getSubstFormalType() == openedArchetype);
     }
 
@@ -1017,7 +1035,8 @@ namespace {
 
       SILValue addr = Value.getLValueAddress();
       addr = enterAccessScope(SGF, loc, addr, getTypeData(),
-                              getAccessKind(), *Enforcement);
+                              getAccessKind(), *Enforcement,
+                              takeActorIsolation());
 
       return ManagedValue::forLValue(addr);
     }
@@ -1034,10 +1053,7 @@ namespace {
       } else {
         OS << "unenforced";
       }
-      if (ActorIso) {
-        OS << "requires actor-hop because ";
-        simple_display(OS, *ActorIso);
-      }
+      if (hasActorIsolation()) OS << " requires actor-hop";
       OS << "):\n";
       Value.dump(OS, indent + 2);
     }
@@ -1451,11 +1467,12 @@ namespace {
               backingVar, AccessKind::Write);
         } else if (BaseFormalType->mayHaveSuperclass()) {
           RefElementComponent REC(backingVar, LValueOptions(), varStorageType,
-                                  typeData);
+                                  typeData, /*actorIsolation=*/None);
           proj = std::move(REC).project(SGF, loc, base);
         } else {
           assert(BaseFormalType->getStructOrBoundGenericStruct());
-          StructElementComponent SEC(backingVar, varStorageType, typeData);
+          StructElementComponent SEC(backingVar, varStorageType,
+                                     typeData, /*actorIsolation=*/None);
           proj = std::move(SEC).project(SGF, loc, base);
         }
 
@@ -1782,7 +1799,8 @@ namespace {
 
       // Enter an unsafe access scope for the access.
       addr = enterAccessScope(SGF, loc, addr, getTypeData(), getAccessKind(),
-                              SILAccessEnforcement::Unsafe);
+                              SILAccessEnforcement::Unsafe,
+                              ActorIso);
 
       return addr;
     }
@@ -2087,7 +2105,8 @@ namespace {
     PhysicalKeyPathApplicationComponent(LValueTypeData typeData,
                                         KeyPathTypeKind typeKind,
                                         ManagedValue keyPath)
-      : PhysicalPathComponent(typeData, PhysicalKeyPathApplicationKind),
+      : PhysicalPathComponent(typeData, PhysicalKeyPathApplicationKind,
+                              /*actorIsolation=*/None),
         TypeKind(typeKind), KeyPath(keyPath) {
       assert(typeKind == KPTK_KeyPath ||
              typeKind == KPTK_WritableKeyPath ||
@@ -3274,8 +3293,6 @@ void LValue::addMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
     using MemberStorageAccessEmitter::MemberStorageAccessEmitter;
 
     void emitUsingStorage(LValueTypeData typeData) {
-      assert(!ActorIso);
-
       // For static variables, emit a reference to the global variable backing
       // them.
       // FIXME: This has to be dynamically looked up for classes, and
@@ -3289,7 +3306,7 @@ void LValue::addMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
                                     typeData.getAccessKind(),
                                     AccessStrategy::getStorage(),
                                     FormalRValueType,
-                                    /*actorIsolation=*/None);
+                                    ActorIso);
         return;
       }
 
@@ -3298,10 +3315,12 @@ void LValue::addMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
           SGF.getTypeExpansionContext(), Storage, FormalRValueType);
 
       if (BaseFormalType->mayHaveSuperclass()) {
-        LV.add<RefElementComponent>(Storage, Options, varStorageType, typeData);
+        LV.add<RefElementComponent>(Storage, Options, varStorageType,
+                                    typeData, ActorIso);
       } else {
         assert(BaseFormalType->getStructOrBoundGenericStruct());
-        LV.add<StructElementComponent>(Storage, varStorageType, typeData);
+        LV.add<StructElementComponent>(Storage, varStorageType, typeData,
+                                       ActorIso);
       }
 
       // If the member has weak or unowned storage, convert it away.
@@ -4174,18 +4193,17 @@ RValue SILGenFunction::emitLoadOfLValue(SILLocation loc, LValue &&src,
 
     // If the last component is physical, drill down and load from it.
     if (component.isPhysical()) {
-      auto actorIso = component.asPhysical().getActorIsolation();
-
-      // If the load must happen in the context of an actor, do a hop first.
-      prevExecutor = emitHopToTargetActor(loc, actorIso, /*actorSelf=*/None);
-
       auto projection = std::move(component).project(*this, loc, addr);
       if (projection.getType().isAddress()) {
+        auto actorIso = component.asPhysical().takeActorIsolation();
+
+        // If the load must happen in the context of an actor, do a hop first.
+        prevExecutor = emitHopToTargetActor(loc, actorIso, /*actorSelf=*/None);
         projection =
             emitLoad(loc, projection.getValue(), origFormalType,
                      substFormalType, rvalueTL, C, IsNotTake, isBaseGuaranteed);
       } else if (isReadAccessResultOwned(src.getAccessKind()) &&
-                 !projection.isPlusOne(*this)) {
+          !projection.isPlusOne(*this)) {
         projection = projection.copy(*this, loc);
       }
 
@@ -4198,7 +4216,6 @@ RValue SILGenFunction::emitLoadOfLValue(SILLocation loc, LValue &&src,
 
   // If we hopped to the target's executor, then we need to hop back.
   prevExecutor.emit(*this, loc);
-
   return result;
 }
 

--- a/test/Concurrency/Runtime/async_properties_actor.swift
+++ b/test/Concurrency/Runtime/async_properties_actor.swift
@@ -8,6 +8,21 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
+struct Container {
+    @MainActor static var counter: Int = 10
+    @MainActor static var this: Container?
+
+    var noniso: Int = 20
+
+    static func getCount() async -> Int {
+        return await counter
+    }
+
+    static func getValue() async -> Int? {
+        return await this?.noniso
+    }
+}
+
 @propertyWrapper
 struct SuccessTracker {
     private var _stored: Bool
@@ -142,6 +157,13 @@ actor Tester {
         print("done property wrapper test")
         return true
     }
+
+    func doContainerTest() async -> Bool {
+        var total: Int = 0
+        total += await Container.getCount()
+        total += await Container.getValue() ?? 0
+        return total == 10
+    }
 }
 
 @globalActor
@@ -169,6 +191,10 @@ var expectedResult : Bool {
 
         guard await test.doPropertyWrapperTest() == success else {
             fatalError("fail property wrapper test")
+        }
+
+        guard await test.doContainerTest() == success else {
+            fatalError("fail container test")
         }
 
         // CHECK: done all testing


### PR DESCRIPTION
Explanation: Accesses to actor-isolated static properties, such as those isolated to the MainActor, were being miscompiled, which led to missing synchronization and "hopping" to the main thread.
Risk: Low.
Original PRs: https://github.com/apple/swift/pull/38114
Radar/SR Issue: rdar://78292384
Reviewed By: Konrad Malawski 
Testing: Regression tests are included