### PR TITLE
[Async Refactoring] Add `return` keyword if wrapping `ReturnStmt` is implicit

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -6460,7 +6460,8 @@ private:
       // for the completion handler call, e.g 'return completion(args...)'. In
       // that case, be sure not to add another return.
       auto *parent = getWalker().Parent.getAsStmt();
-      AddedReturnOrThrow = !(parent && isa<ReturnStmt>(parent));
+      AddedReturnOrThrow = !(parent && isa<ReturnStmt>(parent) &&
+                             !cast<ReturnStmt>(parent)->isImplicit());
       if (AddedReturnOrThrow)
         OS << tok::kw_return;
     } else {

--- a/test/refactoring/ConvertAsync/convert_function.swift
+++ b/test/refactoring/ConvertAsync/convert_function.swift
@@ -329,3 +329,14 @@ func withDefaultArg(x: String = "") {
 // DEFAULT-ARG:      convert_function.swift [[# @LINE-3]]:1 -> [[# @LINE-2]]:2
 // DEFAULT-ARG-NOT:  @discardableResult
 // DEFAULT-ARG-NEXT: {{^}}func withDefaultArg(x: String = "") async
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=IMPLICIT-RETURN %s
+func withImplicitReturn(completionHandler: (String) -> Void) {
+  simple {
+    completionHandler($0)
+  }
+}
+// IMPLICIT-RETURN: func withImplicitReturn() async -> String {
+// IMPLICIT-RETURN-NEXT:   let val0 = await simple()
+// IMPLICIT-RETURN-NEXT:   return val0
+// IMPLICIT-RETURN-NEXT: }


### PR DESCRIPTION
Previously, in the following case we were failing to add a `return` keyword inside `withImplicitReturn`.
```
func withImplicitReturn(completionHandler: (String) -> Void) {
  simple {
    completionHandler($0)
  }
}
```

This is because the call of `completionHandler($0)` is wrapped by an implicit `ReturnStmt` and thus we assumed that there was already a `return` keyword present.

Fix this issue by checking if the wrapping `ReturnStmt` is implicit and if it is, add the `return` keyword.

Fixes rdar://80009760