### PR TITLE
[5.5][stdlib] fix an accidental recursion bug involving Collection

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1044,6 +1044,18 @@ extension Collection where SubSequence == Slice<Self> {
   }
 }
 
+extension Collection {
+  // This unavailable default implementation of `subscript(bounds: Range<_>)`
+  // prevents incomplete Collection implementations from satisfying the
+  // protocol through the use of the generic convenience implementation
+  // `subscript<R: RangeExpression>(r: R)`. If that were the case, at
+  // runtime the generic implementation would call itself
+  // in an infinite recursion because of the absence of a better option.
+  @available(*, unavailable)
+  @_alwaysEmitIntoClient
+  public subscript(bounds: Range<Index>) -> SubSequence { fatalError() }
+}
+
 extension Collection where SubSequence == Self {
   /// Removes and returns the first element of the collection.
   ///

--- a/validation-test/stdlib/CollectionDiagnostics.swift
+++ b/validation-test/stdlib/CollectionDiagnostics.swift
@@ -135,6 +135,25 @@ struct RangeReplaceableCollection_SubSequence_IsDefaulted : RangeReplaceableColl
   }
 }
 
+//
+// A Collection that does not use `Slice<Self>` as its SubSequence should
+// require its own implementation of the Range<Index> subscript getter.
+// The only valid default implementation of that Collection requirement
+// returns `Slice<Self>`.
+//
+
+// expected-error@+2 {{type 'CollectionWithNonDefaultSubSequence' does not conform to protocol 'Collection'}}
+// expected-error@+1 {{unavailable subscript 'subscript(_:)' was used to satisfy a requirement of protocol 'Collection'}}
+struct CollectionWithNonDefaultSubSequence: Collection {
+  public var startIndex: Int
+  public var endIndex: Int
+
+  public typealias SubSequence = Self
+
+  public func index(after i: Int) -> Int { i+1 }
+  public subscript(position: Int) -> Int { position }
+}
+
 // FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: possibly intended match
 // <unknown>:0: error: unexpected note produced: possibly intended match


### PR DESCRIPTION
This is a cherry-pick of https://github.com/apple/swift/pull/38161 to the 5.5 branch.  
Note that if this is not merged for some reason, we may also need to back out that change.

- adds a default implementation of Collection’s subscript(bounds: Range<_>) with the most general signature possible
- it is marked unavailable in order to prevent the infinite recursion bug reported in SR-14848
- Collections whose SubSequence is Slice<Self> still get the proper default.

Resolves SR-14848 (rdar://79891982)
