### PR TITLE
[5.5][ResultBuilders] Allow pre-check to look into single-statement closures

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1872,12 +1872,8 @@ public:
           E, DC, /*replaceInvalidRefsWithErrors=*/true);
       HasError |= transaction.hasErrors();
 
-      if (!HasError) {
-        E->forEachChildExpr([&](Expr *expr) {
-          HasError |= isa<ErrorExpr>(expr);
-          return HasError ? nullptr : expr;
-        });
-      }
+      if (!HasError)
+        HasError |= containsErrorExpr(E);
 
       if (SuppressDiagnostics)
         transaction.abort();
@@ -1897,6 +1893,29 @@ public:
 
     // Otherwise, recurse into the statement normally.
     return std::make_pair(true, S);
+  }
+
+  /// Check whether given expression (including single-statement
+  /// closures) contains `ErrorExpr` as one of its sub-expressions.
+  bool containsErrorExpr(Expr *expr) {
+    bool hasError = false;
+
+    expr->forEachChildExpr([&](Expr *expr) -> Expr * {
+      hasError |= isa<ErrorExpr>(expr);
+      if (hasError)
+        return nullptr;
+
+      if (auto *closure = dyn_cast<ClosureExpr>(expr)) {
+        if (shouldTypeCheckInEnclosingExpression(closure)) {
+          hasError |= containsErrorExpr(closure->getSingleExpressionBody());
+          return hasError ? nullptr : expr;
+        }
+      }
+
+      return expr;
+    });
+
+    return hasError;
   }
 
   /// Ignore patterns.

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -727,4 +727,13 @@ struct TuplifiedStructWithInvalidClosure {
       42
     }
   }
+
+  @TupleBuilder var nestedErrorsDiagnosedByParser: some Any {
+    tuplify(true) { _ in
+      tuplify { _ in
+        self. // expected-error {{expected member name following '.'}}
+      }
+      42
+    }
+  }
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/38177

---

- Explanation:

While determining whether result builder body is correct, allow
pre-check phase to look into single-statement closures because
their bodies participate in type-check and would fail constraint
generation if they contain `ErrorExpr`s, so it's better to determine
that the body is invalid early and skip result builder application.

- Scope: Result builder bodies with single-statement closures containing error expressions previously diagnosed by the parser.

- Main Branch PR: https://github.com/apple/swift/pull/38177

- Resolves: rdar://79746785

- Risk: Low

- Reviewed By: @hborla  

- Testing: Regression tests added to the suite

Resolves: rdar://79746785
(cherry picked from commit 3374500da8b058b4a2806d7bd368d7b83dddba77)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
