### PR TITLE
Disable `earlyswiftdriver` on non-Darwin hosts

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import, unicode_literals
 
 import multiprocessing
 import os
+import platform
 
 import android.adb.commands
 
@@ -193,6 +194,13 @@ def _apply_default_arguments(args):
         args.test_swiftformat = False
         args.test_swiftevolve = False
         args.test_toolchainbenchmarks = False
+
+    # `earlyswiftdriver` is only supported on Darwin, for now,
+    # because Linux toolchains are not yet able to build it because it depends
+    # on Foundation's .cmake files which are not shipped as a part of the Linux
+    # toolchain.
+    if platform.system() != 'Darwin':
+        args.build_early_swift_driver = False
 
     # --test implies --test-early-swift-driver
     # (unless explicitly skipped with `--skip-test-early-swift-driver`)

--- a/utils/build_swift/tests/build_swift/test_driver_arguments.py
+++ b/utils/build_swift/tests/build_swift/test_driver_arguments.py
@@ -587,8 +587,12 @@ class TestDriverArgumentParser(unittest.TestCase):
         self.assertTrue(namespace.test)
 
     def test_implied_defaults_test_early_swift_driver(self):
-        namespace = self.parse_default_args(['--test'])
-        self.assertTrue(namespace.test_early_swift_driver)
+        if platform.system() == 'Darwin':
+            namespace = self.parse_default_args(['--test'])
+            self.assertTrue(namespace.test_early_swift_driver)
+        else:
+            namespace = self.parse_default_args(['--test'])
+            self.assertFalse(namespace.test_early_swift_driver)
 
     def test_implied_defaults_test_no_early_swift_driver(self):
         namespace = self.parse_default_args(['--test --skip-early-swift-driver'])

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -10,6 +10,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import multiprocessing
+import platform
 
 from build_swift import argparse
 from build_swift import defaults
@@ -89,7 +90,7 @@ EXPECTED_DEFAULTS = {
     'build_swift_stdlib_unittest_extra': False,
     'build_swiftpm': False,
     'build_swift_driver': False,
-    'build_early_swift_driver': True,
+    'build_early_swift_driver': (platform.system() == "Darwin"),
     'build_swiftsyntax': False,
     'build_libparser_only': False,
     'build_skstresstester': False,

--- a/validation-test/BuildSystem/infer_dumps_deps_if_verbose_build_non_darwin.test
+++ b/validation-test/BuildSystem/infer_dumps_deps_if_verbose_build_non_darwin.test
@@ -1,6 +1,5 @@
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# REQUIRES: OS=macosx
 # RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --verbose-build --dry-run --infer --swiftpm --cmake %cmake 2>&1 | %FileCheck %s
 
 # REQUIRES: standalone_build
@@ -9,18 +8,12 @@
 #
 # CHECK: -- Build Graph Inference --
 # CHECK: Initial Product List:
-# CHECK:     earlyswiftdriver
 # CHECK:     llvm
 # CHECK:     swift
 # CHECK: Final Build Order:
-# CHECK:     earlyswiftdriver
 # CHECK:     cmark
 # CHECK:     llvm
 # CHECK:     swift
-
-# Ensure early SwiftDriver is built first
-#
-# CHECK: --- Building earlyswiftdriver ---
 
 # Build and install the SwiftPM dependencies first.
 #

--- a/validation-test/BuildSystem/test_early_swift_driver_and_infer.swift
+++ b/validation-test/BuildSystem/test_early_swift_driver_and_infer.swift
@@ -1,4 +1,5 @@
 # REQUIRES: standalone_build
+# REQUIRES: OS=macosx
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t

--- a/validation-test/BuildSystem/test_early_swift_driver_and_test.test
+++ b/validation-test/BuildSystem/test_early_swift_driver_and_test.test
@@ -1,4 +1,5 @@
 # REQUIRES: standalone_build
+# REQUIRES: OS=macosx
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t


### PR DESCRIPTION
Host toolchains on Linux are not yet capable of building the driver because it depends on the presence of Foundation .cmake files which are not shipped as part of the Linux toolchain.
