### PR TITLE
always build the dummy libswift with Xcode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,9 +191,10 @@ set(SWIFT_TOOLS_ENABLE_LTO OFF CACHE STRING "Build Swift tools with LTO. One
     option only affects the tools that run on the host (the compiler), and has
     no effect on the target libraries (the standard library and the runtime).")
 
-option(SWIFT_TOOLS_ENABLE_LIBSWIFT
-  "Enable building libswift and linking libswift into the compiler itself."
-  FALSE)
+# NOTE: We do not currently support building libswift with the Xcode generator.
+cmake_dependent_option(SWIFT_TOOLS_ENABLE_LIBSWIFT
+  "Enable building libswift and linking libswift into the compiler itself." FALSE
+  "NOT CMAKE_GENERATOR STREQUAL \"Xcode\"" FALSE)
 
 # The following only works with the Ninja generator in CMake >= 3.0.
 set(SWIFT_PARALLEL_LINK_JOBS "" CACHE STRING
@@ -1060,9 +1061,7 @@ if(SWIFT_INCLUDE_TOOLS)
   # which is used in add_swift_host_tool for the lldb workaround.
   #
   # NOTE: We do not currently support libswift with the Xcode generator.
-  if (NOT CMAKE_GENERATOR STREQUAL "Xcode")
-    add_subdirectory(libswift)
-  endif()
+  add_subdirectory(libswift)
 
   # Always include this after including stdlib/!
   # Refer to the large comment above the add_subdirectory(stdlib) call.


### PR DESCRIPTION
When https://github.com/apple/swift/pull/37994 disabled building libswift with Xcode, it broke building the tools that linked against it, since the library was no longer available to link against. This PR updates the CMake script to force building the "dummy" libswift when using Xcode, so that there's something to link against.