### PR TITLE
GSB: Don't forget to concretize conformances when processing a same-type requirement

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2413,7 +2413,7 @@ void DelayedRequirement::dump(llvm::raw_ostream &out) const {
   case Type:
   case Layout:
     out << ": ";
-      break;
+    break;
 
   case SameType:
     out << " == ";
@@ -5047,6 +5047,9 @@ GenericSignatureBuilder::addSameTypeRequirementBetweenTypeParameters(
                                  equivClass->concreteTypeConstraints.end(),
                                  equivClass2->concreteTypeConstraints.begin(),
                                  equivClass2->concreteTypeConstraints.end());
+
+    for (const auto &conforms : equivClass->conformsTo)
+      (void)resolveConcreteConformance(T1, conforms.first);
   }
 
   // Make T1 the representative of T2, merging the equivalence classes.
@@ -5775,9 +5778,9 @@ void GenericSignatureBuilder::ExplicitRequirement::dump(
 
   out << getSubjectType();
   if (getKind() == RequirementKind::SameType)
-    out << " : ";
-  else
     out << " == ";
+  else
+    out << " : ";
 
   if (auto type = rhs.dyn_cast<Type>())
     out << type;

--- a/test/Generics/rdar79570734.swift
+++ b/test/Generics/rdar79570734.swift
@@ -1,0 +1,20 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+
+public protocol P1 {
+  associatedtype A
+}
+
+public protocol P2 {}
+
+public struct S1: P1 {
+  public typealias A = S2
+}
+
+public struct S2: P2 {}
+
+// CHECK-LABEL: Generic signature: <X, Y where X : P1, Y : P2, Y == X.A>
+public struct G<X: P1, Y: P2> where Y == X.A {}
+
+// CHECK-LABEL: Generic signature: <X, Y where X == S1, Y == S1.A>
+public extension G where X == S1 {}


### PR DESCRIPTION
When merging two type parameters T1 and T2, if T2 had a concrete type
and T1 had conformance requirements, we did not "concretize" the
conformances.

As a result, the conformance requirements were not marked as redundant,
which would cause a crash (no assert build) or assertion failure (in an
assert build) later on inside rebuildSignatureWithoutRedundantRequirements().

Fixes rdar://problem/79570734.