### PR TITLE
[Frontend] Emit incremental compilation info from some emit-module jobs

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -276,8 +276,11 @@ void SourceLookupCache::populateMemberCache(const ModuleDecl &Mod) {
                              "populate-module-class-member-cache");
 
   for (const FileUnit *file : Mod.getFiles()) {
-    auto &SF = *cast<SourceFile>(file);
-    addToMemberCache(SF.getTopLevelDecls());
+    assert(isa<SourceFile>(file) ||
+           isa<SynthesizedFileUnit>(file));
+    SmallVector<Decl *, 8> decls;
+    file->getTopLevelDecls(decls);
+    addToMemberCache(decls);
   }
 
   MemberCachePopulated = true;


### PR DESCRIPTION
Emit the incremental fine-grained information from the emit-module job to improve the emit-module-separately build mode compatibility with incremental compilation. Note that emit-module doesn't usually parses or type-checks non-inlinable function bodies so it may be unaware of some dependencies.