### PR TITLE
[5.5][Sema] Properly handle missing coding keys in enum Codable synthesis

### DIFF
--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -488,6 +488,15 @@ static bool validateCaseCodingKeysEnum(const DerivedConformance &derived,
                           ? addImplicitCaseCodingKeys(
                               enumDecl, elementDecl, codingKeysEnum)
                           : caseCodingKeysDecls.front();
+
+  if (!result) {
+    // There is no coding key defined for this element,
+    // which is okay, because not all elements have to
+    // be considered for serialization. Attempts to
+    // en-/decode them will be handled at runtime.
+    return true;
+  }
+
   auto *codingKeysTypeDecl = dyn_cast<TypeDecl>(result);
   if (!codingKeysTypeDecl) {
     result->diagnose(diag::codable_codingkeys_type_is_not_an_enum_here,

--- a/test/decl/protocol/special/coding/enum_codable_exclude_element.swift
+++ b/test/decl/protocol/special/coding/enum_codable_exclude_element.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift
+
+ enum EnumWithExcludedElement : Codable {
+     case x
+     case y
+
+     enum CodingKeys: CodingKey {
+         case x
+     }
+ }


### PR DESCRIPTION
- Explanation: We were missing a check for the case where a custom CodingKeys enum is defined and is missing a key for an existing case. It is allowed to do that, but because of the missing check, we ran into a segfault.
- Scope: Enum codable synthesis
- Main Branch PR: #38210 
- Issue: rdar://79671408
- Risk: Low
- Reviewed By: @ktoso 
- Testing: added regression tests

