### PR TITLE
Copy propagation redesign and the CanonicalizeBorrowScopes utility

### DIFF
--- a/include/swift/Basic/DAGNodeWorklist.h
+++ b/include/swift/Basic/DAGNodeWorklist.h
@@ -1,0 +1,64 @@
+//===--- DAGNodeWorklist.h --------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_DAGNODEWORKLIST_H
+#define SWIFT_BASIC_DAGNODEWORKLIST_H
+
+#include "swift/Basic/LLVM.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+/// Worklist of pointer-like things that have an invalid default value. This not
+/// only avoids duplicates in the worklist, but also avoids revisiting
+/// already-popped nodes. This makes it suitable for DAG traversal. This can
+/// also be used within hybrid worklist/recursive traversal by recording the
+/// size of the worklist at each level of recursion.
+///
+/// The primary API has two methods: intialize() and pop(). Others are provided
+/// for flexibility.
+template <typename T, unsigned SmallSize> struct DAGNodeWorklist {
+  llvm::SmallPtrSet<T, SmallSize> nodeVisited;
+  llvm::SmallVector<T, SmallSize> nodeVector;
+
+  DAGNodeWorklist() = default;
+
+  DAGNodeWorklist(const DAGNodeWorklist &) = delete;
+
+  void initialize(T t) {
+    clear();
+    insert(t);
+  }
+
+  template <typename R> void initializeRange(R &&range) {
+    clear();
+    nodeVisited.insert(range.begin(), range.end());
+    nodeVector.append(range.begin(), range.end());
+  }
+
+  T pop() { return empty() ? T() : nodeVector.pop_back_val(); }
+
+  bool empty() const { return nodeVector.empty(); }
+
+  unsigned size() const { return nodeVector.size(); }
+
+  void clear() {
+    nodeVector.clear();
+    nodeVisited.clear();
+  }
+
+  void insert(T t) {
+    if (nodeVisited.insert(t).second)
+      nodeVector.push_back(t);
+  }
+};
+
+#endif // SWIFT_BASIC_DAGNODEWORKLIST_H

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -467,6 +467,8 @@ public:
   /// For instruction results, this returns getDefiningInstruction(). For
   /// arguments, this returns SILBasicBlock::begin() for the argument's parent
   /// block. Returns nullptr for SILUndef.
+  ///
+  /// FIXME: remove this redundant API from SILValue.
   SILInstruction *getDefiningInsertionPoint();
 
   // Const version of \see getDefiningInsertionPoint.
@@ -603,8 +605,6 @@ public:
 
   /// If this SILValue is a result of an instruction, return its
   /// defining instruction. Returns nullptr otherwise.
-  ///
-  /// FIXME: remove this redundant API from SILValue.
   SILInstruction *getDefiningInstruction() {
     return Value->getDefiningInstruction();
   }

--- a/include/swift/SILOptimizer/Analysis/NonLocalAccessBlockAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/NonLocalAccessBlockAnalysis.h
@@ -88,7 +88,10 @@ protected:
       virtual void verify(NonLocalAccessBlocks *accessBlocks) const override {
         NonLocalAccessBlocks checkAccessBlocks(accessBlocks->function);
         checkAccessBlocks.compute();
-        assert(checkAccessBlocks.accessBlocks == accessBlocks->accessBlocks);
+        assert(llvm::all_of(checkAccessBlocks.accessBlocks,
+                            [&](SILBasicBlock *bb) {
+                              return accessBlocks->accessBlocks.count(bb);
+                            }));
       })
 };
 

--- a/include/swift/SILOptimizer/Utils/CanonicalOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalOSSALifetime.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,52 +10,60 @@
 //
 //===----------------------------------------------------------------------===//
 ///
-/// Canonicalize the copies and destroys of a single owned or guaranteed OSSA
-/// value.
+/// Canonicalize the copies and destroys of a single owned OSSA value.
 ///
 /// This top-level API rewrites the extended OSSA lifetime of a SILValue:
 ///
-///     void canonicalizeValueLifetime(SILValue def, CanonicalOSSALifetime &)
+///     void canonicalizeValueLifetime(SILValue def, CanonicalizeOSSALifetime &)
 ///
-/// The extended lifetime transitively includes the uses of `def` itself along
-/// with the uses of any copies of `def`. Canonicalization provably minimizes
-/// the OSSA lifetime and its copies by rewriting all copies and destroys. Only
-/// consusming uses that are not on the liveness boundary require a copy.
+/// The "extended lifetime" of the references defined by 'def' transitively
+/// includes the uses of 'def' itself along with the uses of any copies of
+/// 'def'. Canonicalization provably minimizes the OSSA lifetime and its copies
+/// by rewriting all copies and destroys. Only consusming uses that are not on
+/// the liveness boundary require a copy.
 ///
-/// Example #1: Handle consuming and nonconsuming uses.
+/// Example #1: The last consuming use ends the reference lifetime.
 ///
 ///     bb0(%arg : @owned $T, %addr : @trivial $*T):
 ///       %copy = copy_value %arg : $T
-///       debug_value %copy : $T
 ///       store %copy to [init] %addr : $*T
-///       debug_value %arg : $T
 ///       debug_value_addr %addr : $*T
 ///       destroy_value %arg : $T
 ///
 /// Will be transformed to:
 ///
 ///     bb0(%arg : @owned $T, %addr : @trivial $*T):
-///       // The original copy is deleted.
-///       debug_value %arg : $T
-///       // A new copy_value is inserted before the consuming store.
-///       %copy = copy_value %arg : $T
 ///       store %copy to [init] %addr : $*T
-///       // The non-consuming use now uses the original value.
-///       debug_value %arg : $T
-///       // A new destroy is inserted after the last use.
+///       debug_value_addr %addr : $*T
+///
+/// Example #2: Destroys are hoisted to the last use. Copies are inserted only
+/// at consumes within the lifetime (to directly satisfy ownership conventions):
+///
+///     bb0(%arg : @owned $T, %addr : @trivial $*T):
+///       %copy1 = copy_value %arg : $T
+///       store %arg to [init] %addr : $*T
+///       %_ = apply %_(%copy1) : $@convention(thin) (@guaranteed T) -> ()
+///       debug_value_addr %addr : $*T
+///       destroy_value %copy1 : $T
+///
+/// Will be transformed to:
+///
+///     bb0(%arg : @owned $T, %addr : @trivial $*T):
+///       %copy1 = copy_value %arg : $T
+///       store %copy1 to [init] %addr : $*T
+///       %_ = apply %_(%arg) : $@convention(thin) (@guaranteed T) -> ()
 ///       destroy_value %arg : $T
 ///       debug_value_addr %addr : $*T
-///       // The original destroy is deleted.
 ///
-/// Example #2: Handle control flow.
+/// Example #3: Handle control flow.
 ///
 ///     bb0(%arg : @owned $T):
 ///       cond_br %_, bb1, bb2
 ///     bb1:
 ///       br bb3
 ///     bb2:
-///       debug_value %arg : $T
 ///       %copy = copy_value %arg : $T
+///       %_ = apply %_(%copy) : $@convention(thin) (@guaranteed T) -> ()
 ///       destroy_value %copy : $T
 ///       br bb3
 ///     bb3:
@@ -69,24 +77,19 @@
 ///       destroy_value %arg : $T
 ///       br bb3
 ///     bb2:
-///       // The original copy is deleted.
-///       debug_value %arg : $T
+///       %_ = apply %_(%arg) : $@convention(thin) (@guaranteed T) -> ()
 ///       destroy_value %arg : $T
 ///       br bb3
 ///     bb2:
 ///       // The original destroy is deleted.
 ///
-/// FIXME: Canonicalization currently bails out if any uses of the def has
-/// OperandOwnership::PointerEscape. Once project_box is protected by a borrow
-/// scope and mark_dependence is associated with an end_dependence,
-/// canonicalization will work everywhere as intended. The intention is to keep
-/// the canonicalization algorithm as simple and robust, leaving the remaining
-/// performance opportunities contingent on fixing the SIL representation.
+/// Pass Requirements:
 ///
-/// FIXME: Canonicalization currently fails to eliminate copies downstream of a
-/// ForwardingBorrow. Aggregates should be fixed to be Reborrow instead of
-/// ForwardingBorrow, then computeCanonicalLiveness() can be fixed to extend
-/// liveness through ForwardingBorrows.
+///   This utility invalidates instructions but both uses and preserves
+///   NonLocalAccessBlockAnalysis.
+///
+///   The use-def walks in this utility, e.g. getCanonicalCopiedDef, assume no
+///   cycles in the data flow graph without a phi.
 ///
 //===----------------------------------------------------------------------===//
 
@@ -105,23 +108,11 @@
 
 namespace swift {
 
-/// Convert this struct_extract into a copy+destructure. Return the destructured
-/// result or invalid SILValue. The caller must delete the extract and its
-/// now-dead copy use.
-///
-/// If a copied-def is a struct-extract, attempt a destructure conversion
-///   %extract = struct_extract %... : $TypeWithSingleOwnershipValue
-///   %copy = copy_value %extract : $OwnershipValue
-/// To:
-///   %copy = copy_value %extract : $TypeWithSingleOwnershipValue
-///   (%extracted,...) = destructure %copy : $TypeWithSingleOwnershipValue
-///
-/// \p instModCallbacks If non-null, this routine uses
-/// InstModCallbacks::{setUseValue,RAUW}() internally to modify code. Otherwise,
-/// just performs standard operations.
-SILValue
-convertExtractToDestructure(StructExtractInst *extract,
-                            InstModCallbacks *instModCallbacks = nullptr);
+extern llvm::Statistic NumCopiesEliminated;
+extern llvm::Statistic NumCopiesGenerated;
+
+/// Insert a copy on this operand. Trace and update stats.
+void copyLiveUse(Operand *use, InstModCallbacks &instModCallbacks);
 
 /// Information about consumes on the extended-lifetime boundary. Consuming uses
 /// within the lifetime are not included--they will consume a copy after
@@ -138,12 +129,6 @@ class CanonicalOSSAConsumeInfo {
   /// Record any debug_value instructions found after a final consume.
   SmallVector<DebugValueInst *, 8> debugAfterConsume;
 
-  /// For borrowed defs, track per-block copies of the borrowed value that only
-  /// have uses outside the borrow scope and will not be removed by
-  /// canonicalization. These copies are effectively distinct OSSA lifetimes
-  /// that should be canonicalized separately.
-  llvm::SmallDenseMap<SILBasicBlock *, CopyValueInst *, 4> persistentCopies;
-
   /// The set of non-destroy consumes that need to be poisoned. This is
   /// determined in two steps. First findOrInsertDestroyInBlock() checks if the
   /// lifetime shrank within the block. Second rewriteCopies() checks if the
@@ -152,13 +137,15 @@ class CanonicalOSSAConsumeInfo {
   SmallPtrSetVector<SILInstruction *, 4> needsPoisonConsumes;
 
 public:
-  bool hasUnclaimedConsumes() const { return !finalBlockConsumes.empty(); }
-
   void clear() {
     finalBlockConsumes.clear();
     debugAfterConsume.clear();
-    persistentCopies.clear();
     needsPoisonConsumes.clear();
+  }
+
+  bool empty() {
+    return finalBlockConsumes.empty() && debugAfterConsume.empty()
+           && needsPoisonConsumes.empty();
   }
 
   void recordNeedsPoison(SILInstruction *consume) {
@@ -173,7 +160,7 @@ public:
     return needsPoisonConsumes.getArrayRef();
   }
 
-  bool hasFinalConsumes() const { return !finalBlockConsumes.empty(); }
+  bool hasUnclaimedConsumes() const { return !finalBlockConsumes.empty(); }
 
   void recordFinalConsume(SILInstruction *inst) {
     assert(!finalBlockConsumes.count(inst->getParent()));
@@ -208,16 +195,6 @@ public:
     return debugAfterConsume;
   }
 
-  bool hasPersistentCopies() const { return !persistentCopies.empty(); }
-
-  bool isPersistentCopy(CopyValueInst *copy) const {
-    auto iter = persistentCopies.find(copy->getParent());
-    if (iter == persistentCopies.end()) {
-      return false;
-    }
-    return iter->second == copy;
-  }
-
   SWIFT_ASSERT_ONLY_DECL(void dump() const LLVM_ATTRIBUTE_USED);
 };
 
@@ -225,19 +202,44 @@ public:
 ///
 /// Allows the allocation of analysis state to be reused across calls to
 /// canonicalizeValueLifetime().
+///
+/// TODO: Move all the private per-definition members into an implementation
+/// class in the .cpp file.
 class CanonicalizeOSSALifetime {
 public:
-  /// Find the original definition of a potentially copied value.
-  static SILValue getCanonicalCopiedDef(SILValue v);
+  /// Find the original definition of a potentially copied value. \p copiedValue
+  /// must be an owned value. It is usually a copy but may also be a destroy.
+  ///
+  /// This single helper specifies the root of an owned extended lifetime. Owned
+  /// extended lifetimes may not overlap. This ensures that canonicalization can
+  /// run as a utility without invalidating instruction worklists in the client,
+  /// as long as the client works on each canonical def independently.
+  ///
+  /// If the source of a copy is guaranteed, then the copy itself is the root of
+  /// an owned extended lifetime. Note that it will also be part of a borrowed
+  /// extended lifetime, which will be canonicalized separately by
+  /// CanonicalizeBorrowScope.
+  ///
+  /// This use-def walk must be consistent with the def-use walks performed
+  /// within the canonicalizeValueLifetime() and canonicalizeBorrowScopes()
+  /// implementations.
+  static SILValue getCanonicalCopiedDef(SILValue v) {
+    while (auto *copy = dyn_cast<CopyValueInst>(v)) {
+      auto def = copy->getOperand();
+      if (def.getOwnershipKind() != OwnershipKind::Owned) {
+        // This guaranteed value cannot be handled, treat the copy as an owned
+        // live range def instead.
+        return copy;
+      }
+      v = def;
+    }
+    return v;
+  }
 
 private:
   /// If true, then debug_value instructions outside of non-debug
   /// liveness may be pruned during canonicalization.
   bool pruneDebugMode;
-
-  /// If true, borrows scopes will be canonicalized allowing copies of
-  /// guaranteed values to be eliminated.
-  bool canonicalizeBorrowMode;
 
   /// If true, then new destroy_value instructions will be poison.
   bool poisonRefsMode;
@@ -247,16 +249,12 @@ private:
   // extendLivenessThroughOverlappingAccess is invoked.
   NonLocalAccessBlocks *accessBlocks = nullptr;
 
-  DominanceAnalysis *dominanceAnalysis;
+  DominanceInfo *domTree;
+
+  InstructionDeleter &deleter;
 
   /// Current copied def for which this state describes the liveness.
   SILValue currentDef;
-
-  /// If an outer copy is created for uses outside the borrow scope
-  CopyValueInst *outerCopy = nullptr;
-
-  /// Cumulatively, have any instructions been modified by canonicalization?
-  bool changed = false;
 
   /// Original points in the CFG where the current value's lifetime is consumed
   /// or destroyed. For guaranteed values it remains empty. A backward walk from
@@ -293,25 +291,17 @@ private:
   /// may be in PrunedLiveness::LiveWithin).
   SmallSetVector<SILBasicBlock *, 8> remnantLiveOutBlocks;
 
-  /// Information about consuming instructions discovered in this caonical OSSA
+  /// Information about consuming instructions discovered in this canonical OSSA
   /// lifetime.
   CanonicalOSSAConsumeInfo consumes;
 
-  /// The callbacks to use when deleting/rauwing instructions.
-  InstModCallbacks instModCallbacks;
-
 public:
-  CanonicalizeOSSALifetime(
-      bool pruneDebugMode, bool canonicalizeBorrowMode, bool poisonRefsMode,
-      NonLocalAccessBlockAnalysis *accessBlockAnalysis,
-      DominanceAnalysis *dominanceAnalysis,
-      InstModCallbacks instModCallbacks = InstModCallbacks())
-      : pruneDebugMode(pruneDebugMode),
-        canonicalizeBorrowMode(canonicalizeBorrowMode),
-        poisonRefsMode(poisonRefsMode),
-        accessBlockAnalysis(accessBlockAnalysis),
-        dominanceAnalysis(dominanceAnalysis),
-        instModCallbacks(instModCallbacks) {}
+  CanonicalizeOSSALifetime(bool pruneDebugMode, bool poisonRefsMode,
+                           NonLocalAccessBlockAnalysis *accessBlockAnalysis,
+                           DominanceInfo *domTree, InstructionDeleter &deleter)
+      : pruneDebugMode(pruneDebugMode), poisonRefsMode(poisonRefsMode),
+        accessBlockAnalysis(accessBlockAnalysis), domTree(domTree),
+        deleter(deleter) {}
 
   SILValue getCurrentDef() const { return currentDef; }
 
@@ -323,7 +313,6 @@ public:
     consumes.clear();
 
     currentDef = def;
-    outerCopy = nullptr;
     liveness.initializeDefBlock(def->getParentBlock());
   }
 
@@ -334,30 +323,21 @@ public:
     remnantLiveOutBlocks.clear();
   }
 
-  bool hasChanged() const { return changed; }
-
-  void setChanged() { changed = true; }
-
-  SILValue createdOuterCopy() const { return outerCopy; }
-
   /// Top-Level API: rewrites copies and destroys within \p def's extended
   /// lifetime. \p lifetime caches transient analysis state across multiple
   /// calls.
   ///
-  /// Return false if the OSSA structure cannot be recognized (with a proper
-  /// OSSA representation this will always return true).
+  /// Return true if any change was made to \p def's extended lifetime. \p def
+  /// itself will not be deleted and no instructions outside of \p def's
+  /// extended lifetime will be affected (only copies and destroys are
+  /// rewritten).
   ///
-  /// Upon returning, isChanged() indicates, cumulatively, whether any SIL
-  /// changes were made.
-  ///
-  /// Upon returning, createdOuterCopy() indicates whether a new copy was
-  /// created for uses outside the borrow scope. To canonicalize the new outer
-  /// lifetime, call this API again on the value defined by the new copy.
+  /// This only deletes instructions within \p def's extended lifetime. Use
+  /// InstructionDeleter::cleanUpDeadInstructions() to recursively delete dead
+  /// operands.
   bool canonicalizeValueLifetime(SILValue def);
 
-  /// Return the inst mod callbacks struct used by this CanonicalizeOSSALifetime
-  /// to pass to other APIs that need to compose with CanonicalizeOSSALifetime.
-  InstModCallbacks getInstModCallbacks() const { return instModCallbacks; }
+  InstModCallbacks &getCallbacks() { return deleter.getCallbacks(); }
 
 protected:
   void recordDebugValue(DebugValueInst *dvi) {
@@ -367,20 +347,6 @@ protected:
   void recordConsumingUse(Operand *use) {
     consumingBlocks.insert(use->getUser()->getParent());
   }
-
-  bool computeBorrowLiveness();
-
-  bool consolidateBorrowScope();
-
-  bool findBorrowScopeUses(llvm::SmallPtrSetImpl<SILInstruction *> &useInsts);
-
-  void filterOuterBorrowUseInsts(
-      llvm::SmallPtrSetImpl<SILInstruction *> &outerUseInsts);
-
-  void rewriteOuterBorrowUsesAndFindConsumes(
-      SILValue incomingValue,
-      llvm::SmallPtrSetImpl<SILInstruction *> &outerUseInsts);
-
   bool computeCanonicalLiveness();
 
   bool endsAccessOverlappingPrunedBoundary(SILInstruction *inst);
@@ -398,29 +364,6 @@ protected:
 
   void injectPoison();
 };
-
-/// Canonicalize the passed in set of defs, eliminating in one batch any that
-/// are not needed given the canonical lifetime of the various underlying owned
-/// value introducers.
-///
-/// On success, returns the invalidation kind that the caller must use to
-/// invalidate analyses. Currently it will only ever return
-/// SILAnalysis::InvalidationKind::Instructions or None.
-///
-/// NOTE: This routine is guaranteed to not invalidate
-/// NonLocalAccessBlockAnalysis, so callers should lock it before invalidating
-/// instructions. E.x.:
-///
-///    accessBlockAnalysis->lockInvalidation();
-///    pass->invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
-///    accessBlockAnalysis->unlockInvalidation();
-///
-/// NOTE: We assume that all \p inputDefs is a set (that is it has no duplicate
-/// elements) and that all values have been generated by running a copy through
-/// CanonicalizeOSSALifetime::getCanonicalCopiedDef(copy)).
-SILAnalysis::InvalidationKind
-canonicalizeOSSALifetimes(CanonicalizeOSSALifetime &canonicalizeLifetime,
-                          ArrayRef<SILValue> inputDefs);
 
 } // end namespace swift
 

--- a/include/swift/SILOptimizer/Utils/CanonicalizeBorrowScope.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeBorrowScope.h
@@ -1,0 +1,155 @@
+//===--- CanonicalizeBorrowScope.h - Canonicalize OSSA borrows --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// This utility canonicalizes borrow scopes by rewriting them to restrict them
+/// to only the uses within the scope. To do this, it hoists forwarding
+/// operations out of the scope. This exposes many useless scopes that can be
+/// deleted, which in turn allows canonicalization of the outer owned values
+/// (via CanonicalizeOSSALifetime).
+///
+/// This does not shrink borrow scopes; it does not rewrite end_borrows.
+///
+/// TODO: A separate utility to shrink borrow scopes should eventually run
+/// before this utility. It should hoist end_borrow up to the latest "destroy
+/// barrier" whenever the scope does not contain a PointerEscape.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_UTILS_CANONICALIZEBORROWSCOPES_H
+#define SWIFT_SILOPTIMIZER_UTILS_CANONICALIZEBORROWSCOPES_H
+
+#include "swift/Basic/DAGNodeWorklist.h"
+#include "swift/Basic/SmallPtrSetVector.h"
+#include "swift/SIL/OwnershipUtils.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
+#include "swift/SILOptimizer/Analysis/NonLocalAccessBlockAnalysis.h"
+#include "swift/SILOptimizer/Utils/InstOptUtils.h"
+#include "swift/SILOptimizer/Utils/PrunedLiveness.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SetVector.h"
+
+namespace swift {
+
+//===----------------------------------------------------------------------===//
+//                       MARK: CanonicalizeBorrowScope
+//===----------------------------------------------------------------------===//
+
+class CanonicalizeBorrowScope {
+public:
+  /// Return true if \p inst is an instructions that forwards ownership is its
+  /// first operand and can be trivially duplicated, sunk to its uses, hoisted
+  /// outside a borrow scope and have it's ownership kind flipped from
+  /// guaranteed to owned if needed, as long as OSSA invariants are preserved.
+  static bool isRewritableOSSAForward(SILInstruction *inst);
+
+  /// Return the root of a borrowed extended lifetime for \p def or invalid.
+  ///
+  /// \p def may be any guaranteed value.
+  static SILValue getCanonicalBorrowedDef(SILValue def);
+
+private:
+  // The borrow that begins this scope.
+  BorrowedValue borrowedValue;
+
+  /// Pruned liveness for the extended live range including copies. For this
+  /// purpose, only consuming instructions are considered "lifetime
+  /// ending". end_borrows do not end a liverange that may include owned copies.
+  PrunedLiveness liveness;
+
+  InstructionDeleter &deleter;
+
+  /// Visited set for general def-use traversal that prevents revisiting values.
+  DAGNodeWorklist<SILValue, 8> defUseWorklist;
+
+  /// Visited set general CFG traversal that prevents revisiting blocks.
+  DAGNodeWorklist<SILBasicBlock *, 8> blockWorklist;
+
+  /// Record any copies outside the borrow scope that were updated. This
+  /// includes the outer copy that us used by outer uses and copies for any
+  /// hoisted forwarding instructions.
+  SmallVector<CopyValueInst *, 4> updatedCopies;
+
+  /// For borrowed defs, track per-block copies of the borrowed value that only
+  /// have uses outside the borrow scope and will not be removed by
+  /// canonicalization. These copies are effectively distinct OSSA lifetimes
+  /// that should be canonicalized separately.
+  llvm::SmallDenseMap<SILBasicBlock *, CopyValueInst *, 4> persistentCopies;
+
+public:
+  CanonicalizeBorrowScope(InstructionDeleter &deleter) : deleter(deleter) {}
+
+  BorrowedValue getBorrowedValue() const { return borrowedValue; }
+
+  const PrunedLiveness &getLiveness() const { return liveness; }
+
+  InstructionDeleter &getDeleter() { return deleter; }
+
+  InstModCallbacks &getCallbacks() { return deleter.getCallbacks(); }
+
+  /// Top-level entry point for canonicalizing a SILFunctionArgument. This is a
+  /// straightforward canonicalization that can be performed as a stand-alone
+  /// utility anywhere.
+  bool canonicalizeFunctionArgument(SILFunctionArgument *arg);
+
+  /// Top-level entry point for canonicalizing any borrow scope.
+  ///
+  /// This creates OSSA compensation code outside the borrow scope. It should
+  /// only be called within copy propagation, which knows how to cleanup any new
+  /// copies outside the borrow scope, along with hoisted forwarding
+  /// instructions, etc.
+  bool canonicalizeBorrowScope(BorrowedValue borrow);
+
+  bool hasPersistentCopies() const { return !persistentCopies.empty(); }
+
+  bool isPersistentCopy(CopyValueInst *copy) const {
+    auto iter = persistentCopies.find(copy->getParent());
+    if (iter == persistentCopies.end()) {
+      return false;
+    }
+    return iter->second == copy;
+  }
+
+  // Get all the copies that inserted during canonicalizeBorrowScopes(). These
+  // are cleared at the next call to canonicalizeBorrowScopes().
+  ArrayRef<CopyValueInst *> getUpdatedCopies() const { return updatedCopies; }
+
+  using OuterUsers = llvm::SmallPtrSet<SILInstruction *, 8>;
+
+  SILValue findDefInBorrowScope(SILValue value);
+
+  template <typename Visitor>
+  bool visitBorrowScopeUses(SILValue innerValue, Visitor &visitor);
+
+  void beginVisitBorrowScopeUses() { defUseWorklist.clear(); }
+
+  void recordOuterCopy(CopyValueInst *copy) { updatedCopies.push_back(copy); }
+
+protected:
+  void initBorrow(BorrowedValue borrow) {
+    assert(liveness.empty() && persistentCopies.empty());
+
+    updatedCopies.clear();
+    borrowedValue = borrow;
+    liveness.initializeDefBlock(borrowedValue->getParentBlock());
+  }
+
+  bool computeBorrowLiveness();
+
+  void filterOuterBorrowUseInsts(OuterUsers &outerUseInsts);
+
+  bool consolidateBorrowScope();
+};
+
+} // namespace swift
+
+#endif // SWIFT_SILOPTIMIZER_UTILS_CANONICALIZEBORROWSCOPES_H

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -68,6 +68,10 @@ NullablePtr<SILInstruction> createDecrementBefore(SILValue ptr,
 /// Get the insertion point after \p val.
 Optional<SILBasicBlock::iterator> getInsertAfterPoint(SILValue val);
 
+/// True if this instruction's only uses are debug_value (in -O mode),
+/// destroy_value, or end-of-scope instruction such as end_borrow.
+bool hasOnlyEndOfScopeOrDestroyUses(SILInstruction *inst);
+
 /// Return the number of @inout arguments passed to the given apply site.
 unsigned getNumInOutArguments(FullApplySite applySite);
 

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -248,11 +248,11 @@ public:
   InstructionDeleter(InstModCallbacks chainedCallbacks = InstModCallbacks())
       : deadInstructions(), iteratorRegistry(chainedCallbacks) {}
 
-  InstModCallbacks &getCallbacks() { return iteratorRegistry.getCallbacks(); }
-
   UpdatingInstructionIteratorRegistry &getIteratorRegistry() {
     return iteratorRegistry;
   }
+
+  InstModCallbacks &getCallbacks() { return iteratorRegistry.getCallbacks(); }
 
   llvm::iterator_range<UpdatingInstructionIterator>
   updatingRange(SILBasicBlock *bb) {
@@ -262,6 +262,12 @@ public:
   llvm::iterator_range<UpdatingReverseInstructionIterator>
   updatingReverseRange(SILBasicBlock *bb) {
     return iteratorRegistry.makeReverseIteratorRange(bb);
+  }
+
+  bool hadCallbackInvocation() const {
+    return const_cast<InstructionDeleter *>(this)
+        ->getCallbacks()
+        .hadCallbackInvocation();
   }
 
   /// If the instruction \p inst is dead, record it so that it can be cleaned

--- a/include/swift/SILOptimizer/Utils/ValueLifetime.h
+++ b/include/swift/SILOptimizer/Utils/ValueLifetime.h
@@ -37,6 +37,14 @@ namespace swift {
 /// Frontier implementation by adding a utility method that populates a vector
 /// of insertion points based on this boundary, where each each
 /// block-terminating lastUser adds an insertion point at each successor block.
+///
+/// Note: A dead live range will have no last users and no boundary
+/// edges. Always check if the definition passed to ValueLifetimeAnalysis is
+/// dead before assuming that this boundary covers all points at which a value
+/// must be destroyed. Normally, a live range with uses will have at least one
+/// lastUser or boundaryEdge. But with infinite loops, it is possible for both
+/// lastUsers and boundaryEdges to be empty even if there are uses within the
+/// loop.
 struct ValueLifetimeBoundary {
   SmallVector<SILInstruction *, 8> lastUsers;
   SmallVector<SILBasicBlock *, 8> boundaryEdges;

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -981,9 +981,8 @@ public:
 
     // Print results.
     auto results = I->getResults();
-    if (results.size() == 1 &&
-        I->isStaticInitializerInst() &&
-        I == &I->getParent()->back()) {
+    if (results.size() == 1 && !I->isDeleted() && I->isStaticInitializerInst()
+        && I == &I->getParent()->back()) {
       *this << "%initval = ";
     } else if (results.size() == 1) {
       ID Name = Ctx.getID(results[0]);
@@ -1011,7 +1010,8 @@ public:
 
     // Maybe print debugging information.
     bool printedSlashes = false;
-    if (Ctx.printDebugInfo() && !I->isStaticInitializerInst()) {
+    if (Ctx.printDebugInfo() && !I->isDeleted()
+        && !I->isStaticInitializerInst()) {
       auto &SM = I->getModule().getASTContext().SourceMgr;
       printDebugLocRef(I->getLoc(), SM);
       printDebugScopeRef(I->getDebugScope(), SM);
@@ -1439,6 +1439,9 @@ public:
 
   void printForwardingOwnershipKind(OwnershipForwardingMixin *inst,
                                     SILValue op) {
+    if (!op)
+      return;
+
     if (inst->getForwardingOwnershipKind() != op.getOwnershipKind()) {
       *this << ", forwarding: @" << inst->getForwardingOwnershipKind();
     }

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -15,8 +15,22 @@
 ///
 /// Because this algorithm rewrites copies and destroys without attempting to
 /// balance the retain count, it is only sound when SIL is in ownership-SSA
-/// form. The pass itself is mostly for testing the underlying functionality
-/// which can also be invoked as a utility for any owned value.
+/// form.
+///
+/// This pass operates independently on each extended lifetime--the lifetime of
+/// an OSSA reference after propagating that reference through all copies. For
+/// owned references, this is a simple process of canonicalization that can be
+/// invoked separately via the CanonicalizeOSSALifetime utility. The
+/// CanonicalizeBorrowScope utility handles borrowed references, but this is
+/// much more involved. It requires coordination to cleanup owned lifetimes
+/// outside the borrow scope after canonicalizing the scope itself.
+///
+/// This pass also coordinates other transformations that affect lifetime
+/// canonicalization:
+///
+/// - converting extract to destructure
+///
+/// - sinking owned forwarding operations
 ///
 /// TODO: Cleanup the resulting SIL by deleting instructions that produce dead
 /// values (after removing its copies).
@@ -25,27 +39,333 @@
 
 #define DEBUG_TYPE "copy-propagation"
 
+#include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SIL/BasicBlockUtils.h"
+#include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/SILUndef.h"
 #include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/CanonicalOSSALifetime.h"
+#include "swift/SILOptimizer/Utils/CanonicalizeBorrowScope.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
+#include "llvm/ADT/SetVector.h"
 
 using namespace swift;
 
+// Canonicalize borrow scopes.
 // This only applies to -O copy-propagation.
 llvm::cl::opt<bool>
     EnableRewriteBorrows("canonical-ossa-rewrite-borrows",
                          llvm::cl::init(false),
                          llvm::cl::desc("Enable rewriting borrow scopes"));
 
+namespace {
+
+/// Worklist of defs to be canonicalized. Defs may be revisited after changing
+/// their uses.
+struct CanonicalDefWorklist {
+  bool canonicalizeBorrows;
+
+  llvm::SmallSetVector<SILValue, 16> ownedValues;
+  llvm::SmallSetVector<SILValue, 16> borrowedValues;
+  // Ideally, ownedForwards is in def-use order.
+  llvm::SmallSetVector<SILInstruction *, 16> ownedForwards;
+
+  CanonicalDefWorklist(bool canonicalizeBorrows)
+      : canonicalizeBorrows(canonicalizeBorrows) {}
+
+  // Update the worklist for the def corresponding to \p copy, which is usually
+  // a CopyValue, but may be any owned value such as the operand of a
+  // DestroyValue (to force lifetime shortening).
+  void updateForCopy(SILValue copy) {
+    SILValue def = copy;
+    // sometimes a destroy_value's operand is not owned.
+    if (def->getOwnershipKind() != OwnershipKind::Owned)
+      return;
+
+    while (true) {
+      def = CanonicalizeOSSALifetime::getCanonicalCopiedDef(def);
+      if (!canonicalizeBorrows) {
+        ownedValues.insert(def);
+        return;
+      }
+      // If the copy's source is guaranteed, find the root of a borrowed
+      // extended lifetime.
+      if (auto *copy = dyn_cast<CopyValueInst>(def)) {
+        if (SILValue borrowDef =
+                CanonicalizeBorrowScope::getCanonicalBorrowedDef(
+                    copy->getOperand())) {
+          borrowedValues.insert(borrowDef);
+          return;
+        }
+      }
+      // Look through hoistable owned forwarding instructions on the
+      // use-def chain.
+      if (SILInstruction *defInst = def->getDefiningInstruction()) {
+        if (CanonicalizeBorrowScope::isRewritableOSSAForward(defInst)) {
+          SILValue forwardedDef = defInst->getOperand(0);
+          if (forwardedDef->getOwnershipKind() == OwnershipKind::Owned) {
+            def = forwardedDef;
+            continue;
+          }
+        }
+      }
+      assert(def->getOwnershipKind() == OwnershipKind::Owned
+             && "getCanonicalCopiedDef returns owned values");
+      // Add any forwarding uses of this owned def. This may include uses that
+      // we looked through above, but may also include other uses.
+      addForwardingUses(def);
+      ownedValues.insert(def);
+      return;
+    }
+  }
+
+  // Add forwarding uses of \p def in def-use order. They will be popped from
+  // the list for sinking in use-def order.
+  void addForwardingUses(SILValue def) {
+    SmallVector<Operand *, 4> useWorklist(def->getUses());
+    while (!useWorklist.empty()) {
+      auto *user = useWorklist.pop_back_val()->getUser();
+      if (auto *copy = dyn_cast<CopyValueInst>(user)) {
+        useWorklist.append(copy->getUses().begin(), copy->getUses().end());
+        continue;
+      }
+      if (!CanonicalizeBorrowScope::isRewritableOSSAForward(user))
+        continue;
+
+      if (!ownedForwards.insert(user))
+        continue;
+
+      for (auto result : user->getResults()) {
+        useWorklist.append(result->getUses().begin(), result->getUses().end());
+      }
+    }
+  }
+
+  void erase(SILInstruction *i) {
+    for (auto result : i->getResults()) {
+      ownedValues.remove(result);
+      borrowedValues.remove(result);
+    }
+    ownedForwards.remove(i);
+  }
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+//                MARK: Convert struct_extract to destructure
+//===----------------------------------------------------------------------===//
+
+/// Convert a struct_extract into a copy + destructure. Return the destructured
+/// result or invalid SILValue. The caller must delete the extract and its
+/// now-dead copy use.
+///
+/// Converts:
+///   %extract = struct_extract %src : $TypeWithSingleOwnershipValue
+///   %copy = copy_value %extract : $OwnershipValue
+/// To:
+///   %copy = copy_value %src : $TypeWithSingleOwnershipValue
+///   (%extracted,...) = destructure %copy : $OwnershipValue
+///
+/// This allows the ownership of '%src' to be forwarded to its member.
+///
+/// This utility runs during copy propagation as a prerequisite to
+/// CanonicalizeBorrowScopes.
+///
+/// TODO: generalize this to handle multiple nondebug uses of the
+/// struct_extract.
+///
+/// TODO: generalize this to handle multiple reference member. At that point, it
+/// may need to have its own analysis.
+static SILValue convertExtractToDestructure(StructExtractInst *extract) {
+  if (!hasOneNonDebugUse(extract))
+    return nullptr;
+
+  if (!extract->isFieldOnlyNonTrivialField())
+    return nullptr;
+
+  auto *extractCopy =
+      dyn_cast<CopyValueInst>(getNonDebugUses(extract).begin()->getUser());
+  if (!extractCopy)
+    return nullptr;
+
+  SILBuilderWithScope builder(extract);
+  auto loc = extract->getLoc();
+  auto *copy = builder.createCopyValue(loc, extract->getOperand());
+  auto *destructure = builder.createDestructureStruct(loc, copy);
+
+  SILValue nonTrivialResult = destructure->getResult(extract->getFieldIndex());
+  assert(!nonTrivialResult->getType().isTrivial(*destructure->getFunction())
+         && "field idx mismatch");
+
+  extractCopy->replaceAllUsesWith(nonTrivialResult);
+  return nonTrivialResult;
+}
+
+/// Push copy_value instructions above their struct_extract operands by
+/// inserting destructures.
+///
+/// For types with a single reference member, converts
+///   src -> struct_extract -> copy
+/// into
+///   src -> copy -> destructure
+///
+/// Returns true if any changes were made. Uses \p deleter for deletion but does
+/// not use callbacks for other modifications.
+static bool convertExtractsToDestructures(CanonicalDefWorklist &copiedDefs,
+                                          InstructionDeleter &deleter) {
+  SmallVector<StructExtractInst *, 4> extracts;
+  auto pushExtract = [&extracts](CopyValueInst *copy) {
+    if (auto *extract = dyn_cast<StructExtractInst>(copy->getOperand())) {
+      if (SILValue(extract).getOwnershipKind() == OwnershipKind::Guaranteed) {
+        extracts.push_back(extract);
+      }
+    }
+  };
+  for (SILValue v : copiedDefs.ownedValues) {
+    auto *copy = dyn_cast<CopyValueInst>(v);
+    if (!copy)
+      continue;
+
+    pushExtract(copy);
+  }
+  bool changed = false;
+  // extracts may grow as copies are added
+  for (unsigned idx = 0; idx < extracts.size(); ++idx) {
+    auto *extract = extracts[idx];
+    SILValue destructuredResult = convertExtractToDestructure(extract);
+    if (!destructuredResult)
+      continue;
+
+    changed = true;
+
+    auto *destructure = cast<DestructureStructInst>(
+        destructuredResult.getDefiningInstruction());
+    auto *newCopy = cast<CopyValueInst>(destructure->getOperand());
+    copiedDefs.updateForCopy(newCopy);
+    pushExtract(newCopy);
+
+    LLVM_DEBUG(llvm::dbgs() << "Destructure Conversion:\n"
+                            << *extract << "  to " << *destructure);
+
+    // Delete both the copy and the extract.
+    deleter.recursivelyDeleteUsersIfDead(extract);
+  }
+  return changed;
+}
+
+//===----------------------------------------------------------------------===//
+//                   MARK: Sink owned forwarding operations
+//===----------------------------------------------------------------------===//
+
+/// Find loop preheaders on the reverse path from useBlock to defBlock. Here, a
+/// preheader is a block on this path with a CFG successor that is the target of
+/// a DFS back edge.
+///
+/// Uses PostOrderAnalysis to identify back edges.
+///
+/// Precondition: defBlock and useBlock are weakly control equivalent
+/// - defBlock dominates useBlock
+/// - useBlock postdominates defBlock
+///
+/// defBlock maybe within an inner loop relative to useBlock.
+static void findPreheadersOnControlEquivalentPath(
+    SILBasicBlock *defBlock, SILBasicBlock *useBlock,
+    PostOrderFunctionInfo *postorder,
+    SmallVectorImpl<SILBasicBlock *> &preheaders) {
+
+  assert(useBlock != defBlock);
+  BasicBlockWorklist worklist(useBlock);
+  while (auto *bb = worklist.pop()) {
+    unsigned rpo = *postorder->getRPONumber(bb);
+    bool hasBackedge =
+        llvm::any_of(bb->getPredecessorBlocks(), [&](SILBasicBlock *pred) {
+          return postorder->getRPONumber(pred) > rpo;
+        });
+    for (auto *pred : bb->getPredecessorBlocks()) {
+      if (hasBackedge && postorder->getRPONumber(pred) < rpo) {
+        preheaders.push_back(pred);
+      }
+
+      // Follow predecessor even if it's a preheader in case of irreducibility.
+      if (pred != defBlock) {
+        worklist.pushIfNotVisited(pred);
+      }
+    }
+  }
+}
+
+/// Sink \p ownedForward to its uses.
+///
+/// Owned forwarding instructions are identified by
+/// CanonicalOSSALifetime::isRewritableOSSAForward().
+///
+/// Assumes that the uses of ownedForward jointly postdominate it (valid OSSA).
+///
+/// TODO: consider cloning into each use block (or loop preheader for blocks
+/// inside loops).
+static bool sinkOwnedForward(SILInstruction *ownedForward,
+                             PostOrderAnalysis *postOrderAnalysis,
+                             DominanceInfo *domTree) {
+  // First find the LCA block to sink this forward without cloning it.
+  SILBasicBlock *lca = nullptr;
+  for (auto result : ownedForward->getResults()) {
+    for (auto *use : result->getUses()) {
+      auto *bb = use->getParentBlock();
+      lca = lca ? domTree->findNearestCommonDominator(lca, bb) : bb;
+    }
+  }
+  // Find any preheader on the path from ownedForward to lca. Consider them uses
+  // and recompute lca.
+  auto *defBB = ownedForward->getParent();
+  if (lca != defBB) {
+    auto *f = defBB->getParent();
+    SmallVector<SILBasicBlock *, 4> preheaders;
+    findPreheadersOnControlEquivalentPath(defBB, lca, postOrderAnalysis->get(f),
+                                          preheaders);
+    for (SILBasicBlock *preheader : preheaders) {
+      lca = domTree->findNearestCommonDominator(lca, preheader);
+    }
+  }
+  // Mark all uses in this LCA block.
+  SmallPtrSet<SILInstruction *, 4> lcaUses;
+  for (auto result : ownedForward->getResults()) {
+    for (auto *use : result->getUses()) {
+      if (use->getParentBlock() != lca)
+        continue;
+
+      lcaUses.insert(use->getUser());
+    }
+  }
+  // Find the position in the LCA before the first use.
+  SILBasicBlock::iterator forwardPos;
+  if (lcaUses.empty()) {
+    forwardPos = lca->getTerminator()->getIterator();
+  } else {
+    // Start at the def or begining of the block and search forward.
+    if (ownedForward->getParent() == lca)
+      forwardPos = std::next(ownedForward->getIterator());
+    else
+      forwardPos = lca->begin();
+    while (!lcaUses.count(&*forwardPos)) {
+      ++forwardPos;
+    }
+  }
+  if (forwardPos == std::next(ownedForward->getIterator()))
+    return false;
+
+  ownedForward->moveBefore(&*forwardPos);
+  return true;
+}
+
 //===----------------------------------------------------------------------===//
 // CopyPropagation: Top-Level Function Transform.
 //===----------------------------------------------------------------------===//
 
 namespace {
+
 class CopyPropagation : public SILFunctionTransform {
   /// True if debug_value instructions should be pruned.
   bool pruneDebug;
@@ -66,138 +386,125 @@ public:
   /// The entry point to this function transformation.
   void run() override;
 };
+
 } // end anonymous namespace
-
-static bool isCopyDead(CopyValueInst *copy, bool pruneDebug) {
-  for (Operand *use : copy->getUses()) {
-    auto *user = use->getUser();
-    if (isa<DestroyValueInst>(user)) {
-      continue;
-    }
-    if (pruneDebug && isa<DebugValueInst>(user)) {
-      continue;
-    }
-    return false;
-  }
-  return true;
-}
-
-static bool isBorrowDead(BeginBorrowInst *borrow) {
-  return llvm::all_of(borrow->getUses(), [](Operand *use) {
-      SILInstruction *user = use->getUser();
-      return isa<EndBorrowInst>(user) || user->isDebugInstruction();
-    });
-}
 
 /// Top-level pass driver.
 void CopyPropagation::run() {
   auto *f = getFunction();
+  auto *postOrderAnalysis = getAnalysis<PostOrderAnalysis>();
   auto *accessBlockAnalysis = getAnalysis<NonLocalAccessBlockAnalysis>();
   auto *dominanceAnalysis = getAnalysis<DominanceAnalysis>();
+  DominanceInfo *domTree = dominanceAnalysis->get(f);
 
-  // Debug label for unit testing.
+  // Label for unit testing with debug output.
   LLVM_DEBUG(llvm::dbgs() << "*** CopyPropagation: " << f->getName() << "\n");
 
   // This algorithm fundamentally assumes ownership.
   if (!f->hasOwnership())
     return;
 
+  CanonicalDefWorklist defWorklist(canonicalizeBorrows);
+  auto callbacks =
+      InstModCallbacks().onDelete([&](SILInstruction *instToDelete) {
+        defWorklist.erase(instToDelete);
+        instToDelete->eraseFromParent();
+      });
+
+  InstructionDeleter deleter(std::move(callbacks));
+  bool changed = false;
+
   // Driver: Find all copied defs.
-  llvm::SmallSetVector<SILValue, 16> copiedDefs;
   for (auto &bb : *f) {
     for (auto &i : bb) {
       if (auto *copy = dyn_cast<CopyValueInst>(&i)) {
-        copiedDefs.insert(
-            CanonicalizeOSSALifetime::getCanonicalCopiedDef(copy));
+        defWorklist.updateForCopy(copy);
       } else if (canonicalizeAll) {
         if (auto *destroy = dyn_cast<DestroyValueInst>(&i)) {
-          copiedDefs.insert(CanonicalizeOSSALifetime::getCanonicalCopiedDef(
-              destroy->getOperand()));
+          defWorklist.updateForCopy(destroy->getOperand());
         }
       }
     }
   }
-  // Push copy_value instructions above their struct_extract operands by
-  // inserting destructures.
-  //
-  // copiedDefs be be modified, but it never shrinks
-  for (unsigned idx = 0; idx < copiedDefs.size(); ++idx) {
-    SILValue def = copiedDefs[idx];
-    auto *copy = dyn_cast<CopyValueInst>(def);
-    if (!copy)
-      continue;
+  // canonicalizer performs all modifications through deleter's callbacks, so we
+  // don't need to explicitly check for changes.
+  CanonicalizeOSSALifetime canonicalizer(pruneDebug, poisonRefs,
+                                         accessBlockAnalysis, domTree, deleter);
+  // For now, only modify forwarding instructions
+  // At -Onone, we do nothing but rewrite copies of owned values.
+  if (canonicalizeBorrows) {
+    // Canonicalize extracts to destructures. struct_extracts are initially part
+    // of the copiedDefs. If the are converted, they are removed from copiedDefs
+    // and the source of the new destructure is added.
+    changed |= convertExtractsToDestructures(defWorklist, deleter);
 
-    auto *extract = dyn_cast<StructExtractInst>(copy->getOperand());
-    if (!extract
-        || SILValue(extract).getOwnershipKind() != OwnershipKind::Guaranteed)
-      continue;
+    // borrowCanonicalizer performs all modifications through deleter's
+    // callbacks, so we don't need to explicitly check for changes.
+    CanonicalizeBorrowScope borrowCanonicalizer(deleter);
+    // The utilities in this loop cannot delete borrows before they are popped
+    // from the worklist.
+    while (true) {
+      while (!defWorklist.ownedForwards.empty()) {
+        SILInstruction *ownedForward = defWorklist.ownedForwards.pop_back_val();
+        // Delete a dead forwarded value before sinking to avoid this pattern:
+        //   %outerVal = destructure_struct %def
+        //   destroy %outerVal           <= delete this destroy now
+        //   destroy %def                <= so we don't delete this one later
+        if (deleter.deleteIfDead(ownedForward)) {
+          LLVM_DEBUG(llvm::dbgs() << "  Deleted " << *ownedForward);
+          continue;
+        }
+        // Canonicalize a forwarded owned value before sinking the forwarding
+        // instruction, and sink the instruction before canonicalizing the owned
+        // value being forwarded. Process 'ownedForwards' in reverse since
+        // they may be chained, and CanonicalizeBorrowScopes pushes them
+        // top-down.
+        for (auto result : ownedForward->getResults()) {
+          canonicalizer.canonicalizeValueLifetime(result);
+        }
+        if (sinkOwnedForward(ownedForward, postOrderAnalysis, domTree)) {
+          changed = true;
+          // Sinking 'ownedForward' may create an opportunity to sink its
+          // operand. This handles chained forwarding instructions that were
+          // pushed onto the list out-of-order.
+          if (SILInstruction *forwardDef =
+                  CanonicalizeOSSALifetime::getCanonicalCopiedDef(
+                      ownedForward->getOperand(0))
+                      ->getDefiningInstruction()) {
+            if (CanonicalizeBorrowScope::isRewritableOSSAForward(forwardDef)) {
+              defWorklist.ownedForwards.insert(forwardDef);
+            }
+          }
+        }
+      }
+      if (defWorklist.borrowedValues.empty())
+        break;
 
-    // Bail-out if we won't rewrite borrows because that currently regresses
-    // Breadcrumbs.MutatedUTF16ToIdx.Mixed/Breadcrumbs.MutatedIdxToUTF16.Mixed.
-    // Also, mandatory copyprop does not need to rewrite destructures.
-    if (!canonicalizeBorrows)
-      continue;
-
-    if (SILValue destructuredResult = convertExtractToDestructure(extract)) {
-      // Remove to-be-deleted instructions from copiedDeds. The extract cannot
-      // be in the copiedDefs set since getCanonicalCopiedDef does not allow a
-      // guaranteed projection to be a canonical def.
-      copiedDefs.remove(copy);
-      --idx; // point back to the current element, which was erased.
-
-      // TODO: unfortunately SetVector has no element replacement.
-      copiedDefs.insert(destructuredResult);
-
-      auto *destructure = cast<DestructureStructInst>(
-          destructuredResult.getDefiningInstruction());
-      auto *newCopy = cast<CopyValueInst>(destructure->getOperand());
-      copiedDefs.insert(
-          CanonicalizeOSSALifetime::getCanonicalCopiedDef(newCopy));
-
-      LLVM_DEBUG(llvm::dbgs() << "Destructure Conversion:\n"
-                              << *extract << "  to " << *destructure);
-      // Delete both the copy and the extract.
-      InstructionDeleter().recursivelyDeleteUsersIfDead(extract);
+      BorrowedValue borrow(defWorklist.borrowedValues.pop_back_val());
+      borrowCanonicalizer.canonicalizeBorrowScope(borrow);
+      for (CopyValueInst *copy : borrowCanonicalizer.getUpdatedCopies()) {
+        defWorklist.updateForCopy(copy);
+      }
+      // Dead borrow scopes must be removed as uses before canonicalizing the
+      // outer copy.
+      if (auto *beginBorrow = dyn_cast<BeginBorrowInst>(borrow.value)) {
+        if (hasOnlyEndOfScopeOrDestroyUses(beginBorrow)) {
+          deleter.recursivelyDeleteUsersIfDead(beginBorrow);
+        }
+      }
     }
+    deleter.cleanupDeadInstructions();
   }
-  // Perform copy propgation for each copied value.
-  CanonicalizeOSSALifetime canonicalizer(pruneDebug, canonicalizeBorrows,
-                                         poisonRefs, accessBlockAnalysis,
-                                         dominanceAnalysis);
-  // Cleanup dead copies. If getCanonicalCopiedDef returns a copy (because the
-  // copy's source operand is unrecgonized), then the copy is itself treated
-  // like a def and may be dead after canonicalization.
-  llvm::SmallVector<SILInstruction *, 4> deadCopies;
-  for (auto &def : copiedDefs) {
-    // Canonicalized this def.
+  // Canonicalize all owned defs.
+  while (!defWorklist.ownedValues.empty()) {
+    SILValue def = defWorklist.ownedValues.pop_back_val();
     canonicalizer.canonicalizeValueLifetime(def);
-
-    if (auto *copy = dyn_cast<CopyValueInst>(def)) {
-      if (isCopyDead(copy, pruneDebug)) {
-        deadCopies.push_back(copy);
-      }
-    }
-    // Dead borrow scopes must be removed as uses before canonicalizing the
-    // outer copy.
-    if (auto *borrow = dyn_cast<BeginBorrowInst>(def)) {
-      if (isBorrowDead(borrow)) {
-        borrow->setOperand(SILUndef::get(borrow->getType(), *f));
-        deadCopies.push_back(borrow);
-      }
-    }
-    // Canonicalize any new outer copy.
-    if (SILValue outerCopy = canonicalizer.createdOuterCopy()) {
-      SILValue outerDef = canonicalizer.getCanonicalCopiedDef(outerCopy);
-      canonicalizer.canonicalizeValueLifetime(outerDef);
-    }
-    // TODO: also canonicalize any lifetime.persistentCopies like separate owned
-    // live ranges.
   }
-  if (canonicalizer.hasChanged() || !deadCopies.empty()) {
-    InstructionDeleter deleter;
-    for (auto *copyOrBorrow : deadCopies) {
-      deleter.recursivelyDeleteUsersIfDead(copyOrBorrow);
-    }
+  // Recursively cleanup dead defs after removing uses.
+  deleter.cleanupDeadInstructions();
+
+  // Invalidate analyses.
+  if (changed || deleter.hadCallbackInvocation()) {
     // Preserves NonLocalAccessBlockAnalysis.
     accessBlockAnalysis->lockInvalidation();
     invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);

--- a/lib/SILOptimizer/Utils/CMakeLists.txt
+++ b/lib/SILOptimizer/Utils/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(swiftSILOptimizer PRIVATE
   CFGOptUtils.cpp
   CanonicalizeInstruction.cpp
   CanonicalOSSALifetime.cpp
+  CanonicalizeBorrowScope.cpp
   CastOptimizer.cpp
   CheckedCastBrJumpThreading.cpp
   ConstantFolding.cpp

--- a/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
@@ -1,0 +1,812 @@
+//===--- CanonicalizeBorrowScope.cpp - Canonicalize OSSA borrow scopes ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// TODO: Enable -canonical-ossa-rewrite-borrows by default (see
+/// CopyPropagation).
+///
+/// TODO: Add support for load_borrows, and reborrows by using persistentCopies.
+///
+/// TODO: Hoist struct/tuple with multiple operands out of borrow scopes if that
+/// ever happens. Consider modeling them as reborrows instead.
+///
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "copy-propagation"
+
+#include "swift/SILOptimizer/Utils/CanonicalizeBorrowScope.h"
+#include "swift/Basic/Defer.h"
+#include "swift/SIL/InstructionUtils.h"
+#include "swift/SIL/OwnershipUtils.h"
+#include "swift/SILOptimizer/Utils/CFGOptUtils.h"
+#include "swift/SILOptimizer/Utils/CanonicalOSSALifetime.h"
+#include "swift/SILOptimizer/Utils/DebugOptUtils.h"
+#include "swift/SILOptimizer/Utils/InstOptUtils.h"
+#include "swift/SILOptimizer/Utils/ValueLifetime.h"
+#include "llvm/ADT/Statistic.h"
+
+using namespace swift;
+
+STATISTIC(NumOuterCopies, "number of copy_value instructions added for a "
+                          "borrow scope");
+
+//===----------------------------------------------------------------------===//
+//                           MARK: Local utilities
+//===----------------------------------------------------------------------===//
+
+static bool hasValueOwnership(SILValue value) {
+  return value.getOwnershipKind() == OwnershipKind::Guaranteed
+         || value.getOwnershipKind() == OwnershipKind::Owned;
+}
+
+/// Delete a chain of unused copies leading to \p v.
+static void deleteCopyChain(SILValue v, InstructionDeleter &deleter) {
+  while (auto *copy = dyn_cast<CopyValueInst>(v)) {
+    if (!onlyHaveDebugUses(copy))
+      break;
+
+    v = copy->getOperand();
+    LLVM_DEBUG(llvm::dbgs() << "  Deleting " << *copy);
+    ++NumCopiesEliminated;
+    deleter.forceDelete(copy);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+//                        MARK: Rewrite borrow scopes
+//===----------------------------------------------------------------------===//
+
+/// Does this instruction forward ownership, and can it be hoisted out of a
+/// borrow scope or sunk to its uses?
+///
+/// Currently requires the first operand to forward ownership.
+///
+/// Handles:
+///   OwnershipForwardingConversionInst (all kinds of ref casts)
+///   OwnershipForwardingMultipleValueInstruction
+///     (DestructureStruct, DestructureTuple)
+///   AllArgOwnershipForwardingSingleValueInst
+///     (Struct, Tuple)
+///   FirstArgOwnershipForwardingSingleValueInst
+///     (Object, Enum, UncheckedEnumData, SelectValue, Open/InitExistentialRef,
+///      MarkDependence)
+///
+/// TODO:
+///   Enum, SelectValue, InitExistential, MarkDependence
+///   Struct, Tuple
+///   SelectEnum, SwitchEnum, CheckCastBranch
+bool CanonicalizeBorrowScope::isRewritableOSSAForward(SILInstruction *inst) {
+  if (!inst->isTriviallyDuplicatable())
+    return false;
+
+  // TODO: check other operands for dominance and even attempt to hoist them.
+  if (inst->getNumOperands() != 1)
+    return false;
+
+  if (isa<OwnershipForwardingConversionInst>(inst)
+      || isa<OwnershipForwardingMultipleValueInstruction>(inst)
+      || isa<AllArgOwnershipForwardingSingleValueInst>(inst)
+      || isa<FirstArgOwnershipForwardingSingleValueInst>(inst)) {
+    Operand *forwardedOper = &inst->getOperandRef(0);
+    // Trivial conversions do not need to be hoisted out of a borrow scope.
+    auto operOwnership = forwardedOper->getOperandOwnership();
+    if (operOwnership == OperandOwnership::TrivialUse)
+      return false;
+    // Don't mess with unowned conversions. They need to be copied immeidately.
+    if (operOwnership != OperandOwnership::ForwardingBorrow
+        && operOwnership != OperandOwnership::ForwardingConsume) {
+      return false;
+    }
+    assert(operOwnership == OperandOwnership::ForwardingBorrow
+           || operOwnership == OperandOwnership::ForwardingConsume);
+
+    // Filter instructions that belong to a Forwarding*ValueInst mixin but
+    // cannot be converted to forward owned value (struct_extract).
+    if (!canOpcodeForwardOwnedValues(forwardedOper))
+      return false;
+
+    return true;
+  }
+  return false;
+}
+
+/// Return the root of a borrowed extended lifetime for \p def or invalid.
+///
+/// \p def may be any guaranteed value.
+SILValue CanonicalizeBorrowScope::getCanonicalBorrowedDef(SILValue def) {
+  while (true) {
+    if (def->getOwnershipKind() != OwnershipKind::Guaranteed)
+      break;
+
+    if (auto borrowedVal = BorrowedValue(def)) {
+      // Any def's that aren't filtered out here must be handled by
+      // computeBorrowLiveness.
+      switch (borrowedVal.kind) {
+      case BorrowedValueKind::Invalid:
+        llvm_unreachable("Using invalid case?!");
+      case BorrowedValueKind::SILFunctionArgument:
+      case BorrowedValueKind::BeginBorrow:
+        return def;
+
+      case BorrowedValueKind::LoadBorrow:
+      case BorrowedValueKind::Phi:
+        break;
+      }
+    }
+    // Look through hoistable guaranteed forwarding instructions on the
+    // use-def chain.
+    SILInstruction *defInst = def->getDefiningInstruction();
+    if (!defInst)
+      break;
+
+    if (!CanonicalizeBorrowScope::isRewritableOSSAForward(defInst))
+      break;
+
+    def = defInst->getOperand(0);
+  }
+  return SILValue();
+}
+
+bool CanonicalizeBorrowScope::computeBorrowLiveness() {
+  switch (borrowedValue.kind) {
+  case BorrowedValueKind::Invalid:
+    llvm_unreachable("Used invalid");
+  case BorrowedValueKind::SILFunctionArgument:
+    // For efficiency, function arguments skip liveness.
+    return true;
+  case BorrowedValueKind::LoadBorrow:
+  case BorrowedValueKind::Phi:
+    // TODO: Canonicalize load_borrow scope and phi once consolidateBorrowScope
+    // can handle persistentCopies.
+    return false;
+  case BorrowedValueKind::BeginBorrow:
+    break;
+  }
+  // Note that there is no need to look through any reborrows. The reborrowed
+  // value is considered a separate lifetime for canonicalization. Any copies of
+  // the reborrowed value will not be rewritten when canonicalizing the current
+  // borrow scope because they are "hidden" behind the reborrow.
+  borrowedValue.visitLocalScopeEndingUses([this](Operand *use) {
+    liveness.updateForUse(use->getUser(), /*lifetimeEnding*/ true);
+    return true;
+  });
+  return true;
+}
+
+/// Return the source of a use within a borrow scope. This is the use-def
+/// equivalent to the logic in visitBorrowScopeUses that recurses through
+/// copies. The use-def and def-use logic must be consistent.
+SILValue CanonicalizeBorrowScope::findDefInBorrowScope(SILValue value) {
+  while (auto *copy = dyn_cast<CopyValueInst>(value)) {
+    if (isPersistentCopy(copy))
+      return copy;
+
+    value = copy->getOperand();
+  }
+  return value;
+}
+
+/// Visit all extended uses within the borrow scope, looking through copies.
+/// Call visitUse for uses which could potentially be outside the borrow scope.
+/// Call visitForwardingUse for hoistable forwarding operations which could
+/// potentially be inside the borrow scope.
+///
+/// The visitor may or may not be able to determine which uses are outside the
+/// scope, but it can filter uses that are definitely within the scope. For
+/// example, guaranteed uses and uses in live-out blocks must be both be within
+/// the scope.
+///
+/// This def-use traversal is similar to findExtendedTransitiveGuaranteedUses(),
+/// however, to cover the canonical lifetime, it looks through copies. It also
+/// considers uses within the introduced borrow scope itself (instead of simply
+/// visiting the scope-ending uses). It does not, however, look into nested
+/// borrow scopes uses, since nested scopes are canonicalized independently.
+///
+/// \p innerValue is either the initial begin_borrow, or a forwarding operation
+/// within the borrow scope.
+template <typename Visitor>
+bool CanonicalizeBorrowScope::visitBorrowScopeUses(SILValue innerValue,
+                                                   Visitor &visitor) {
+  // defUseWorklist is used recursively here.
+  // This avoids revisiting uses in case we ever recurse through
+  // both structs and destructures.
+  unsigned defUseStart = defUseWorklist.size();
+  defUseWorklist.insert(innerValue);
+  while (defUseStart < defUseWorklist.size()) {
+    SILValue value = defUseWorklist.pop();
+    // Gather the uses before updating any of them.
+    // 'value' may be deleted in this loop after rewriting its last use.
+    // 'use' may become invalid after processing its user.
+    SmallVector<Operand *, 4> uses(value->getUses());
+    for (Operand *use : uses) {
+      auto *user = use->getUser();
+      // Incidental uses, such as debug_value may be deleted before they can be
+      // processed. Their user will now be nullptr. This means that value
+      // is dead, so just bail.
+      if (!user)
+        break;
+
+      // Recurse through copies.
+      if (auto *copy = dyn_cast<CopyValueInst>(user)) {
+        if (!isPersistentCopy(copy)) {
+          defUseWorklist.insert(copy);
+          continue;
+        }
+      }
+      // Note: debug_value uses are handled like normal uses here. If they are
+      // inner uses, they remain. If they are outer uses, then they will be
+      // stripped if needed when the outer copy or persistent copy is
+      // canonicalized.
+      switch (use->getOperandOwnership()) {
+      case OperandOwnership::NonUse:
+        break;
+      case OperandOwnership::TrivialUse:
+        llvm_unreachable("this operand cannot handle ownership");
+
+      case OperandOwnership::InteriorPointer:
+      case OperandOwnership::EndBorrow:
+      case OperandOwnership::Reborrow:
+        // Ignore uses that must be within the borrow scope.
+        // Rewriting does not look through reborrowed values--it considers them
+        // part of a separate lifetime.
+        break;
+
+      case OperandOwnership::ForwardingUnowned:
+      case OperandOwnership::PointerEscape:
+        // Pointer escapes are only allowed if they use the guaranteed value,
+        // which means that the escaped value must be confied to the current
+        // borrow scope.
+        if (use->get().getOwnershipKind() != OwnershipKind::Guaranteed)
+          return false;
+        break;
+
+      case OperandOwnership::ForwardingBorrow:
+      case OperandOwnership::ForwardingConsume:
+        if (CanonicalizeBorrowScope::isRewritableOSSAForward(user)) {
+          if (!visitor.visitForwardingUse(use))
+            return false;
+          break;
+        }
+        LLVM_FALLTHROUGH;
+
+      case OperandOwnership::Borrow:
+      case OperandOwnership::InstantaneousUse:
+      case OperandOwnership::UnownedInstantaneousUse:
+      case OperandOwnership::BitwiseEscape:
+      case OperandOwnership::DestroyingConsume:
+        if (!visitor.visitUse(use))
+          return false;
+        break;
+      } // end switch OperandOwnership
+    }
+  } // end def-use traversal
+  return true;
+}
+
+namespace {
+
+using OuterUsers = CanonicalizeBorrowScope::OuterUsers;
+
+/// Find all potential outer uses within a borrow scope.
+///
+/// Implements visitBorrowScopeUses<Visitor>
+class FindBorrowScopeUses {
+  CanonicalizeBorrowScope &scope;
+
+  /// useInsts are the potentially outer use instructions. This set is built up
+  /// recursively. It is pared down to only the outer uses outside this class by
+  /// filterOuterBorrowUseInsts.
+  OuterUsers useInsts;
+
+public:
+  FindBorrowScopeUses(CanonicalizeBorrowScope &scope) : scope(scope) {}
+
+  Optional<OuterUsers> findUses() && {
+    scope.beginVisitBorrowScopeUses();
+    if (!scope.visitBorrowScopeUses(scope.getBorrowedValue().value, *this))
+      return None;
+
+    return std::move(useInsts);
+  }
+
+  bool visitUse(Operand *use) {
+    // A guaranteed use can never be outside this borrow scope
+    if (use->get().getOwnershipKind() == OwnershipKind::Guaranteed)
+      return true;
+    
+    auto *user = use->getUser();
+    if (!isUserInLiveOutBlock(user)) {
+      useInsts.insert(user);
+    }
+    if (auto borrowingOper = BorrowingOperand(use)) {
+      // For borrows, record the scope-ending instructions to outer use
+      // points. Note: The logic in filterOuterBorrowUseInsts that checks
+      // whether a borrow scope is an outer use must visit the same set of uses.
+      borrowingOper.visitExtendedScopeEndingUses([&](Operand *endBorrow) {
+        auto *endInst = endBorrow->getUser();
+        if (!isUserInLiveOutBlock(endInst)) {
+          useInsts.insert(endInst);
+        }
+        return true;
+      });
+    }
+    return true;
+  }
+
+  // Recurse through forwards.
+  bool visitForwardingUse(Operand *use) {
+    auto *user = use->getUser();
+    if (!isUserInLiveOutBlock(user)) {
+      useInsts.insert(user);
+    }
+    for (auto result : user->getResults()) {
+      if (hasValueOwnership(result)) {
+        if (!scope.visitBorrowScopeUses(result, *this))
+          return false;
+      }
+    }
+    return true;
+  }
+
+protected:
+  bool isUserInLiveOutBlock(SILInstruction *user) {
+    return (scope.getLiveness().getBlockLiveness(user->getParent())
+            == PrunedLiveBlocks::LiveOut);
+    return false;
+  };
+};
+
+} // namespace
+
+/// Erase users from \p outerUseInsts that are not within the borrow scope.
+void CanonicalizeBorrowScope::filterOuterBorrowUseInsts(
+    OuterUsers &outerUseInsts) {
+  auto *beginBorrow = cast<BeginBorrowInst>(borrowedValue.value);
+  SmallVector<SILInstruction *, 4> scopeEndingInsts;
+  BorrowedValue(beginBorrow).getLocalScopeEndingInstructions(scopeEndingInsts);
+  blockWorklist.clear();
+  // Remove outer uses that occur before the end of the borrow scope by
+  // reverse iterating from the end_borrow.
+  auto scanBlock = [&](SILBasicBlock *bb, SILBasicBlock::iterator endIter) {
+    auto beginIter = bb->begin();
+    if (bb == beginBorrow->getParent()) {
+      beginIter = std::next(beginBorrow->getIterator());
+    } else {
+      blockWorklist.insert(bb);
+    }
+    for (auto instIter = endIter; instIter != beginIter;) {
+      --instIter;
+      outerUseInsts.erase(&*instIter);
+    }
+  };
+  for (auto *scopeEnd : scopeEndingInsts) {
+    scanBlock(scopeEnd->getParent(), std::next(scopeEnd->getIterator()));
+  }
+  // This worklist is also a visited set, so we never pop the entries.
+  while (auto *bb = blockWorklist.pop()) {
+    for (auto *predBB : bb->getPredecessorBlocks()) {
+      scanBlock(predBB, predBB->end());
+    }
+  }
+}
+
+namespace {
+
+/// Remove redundant copies/destroys within a borrow scope.
+class RewriteInnerBorrowUses {
+  CanonicalizeBorrowScope &scope;
+
+public:
+  RewriteInnerBorrowUses(CanonicalizeBorrowScope &scope): scope(scope) {}
+
+  CanonicalizeBorrowScope &getScope() const { return scope; }
+
+  // Implements visitBorrowScopeUses<Visitor>
+  bool visitUse(Operand *use) {
+    auto *user = use->getUser();
+    SILValue value = use->get();
+    // destroys are never needed within a borrow scope.
+    if (isa<DestroyValueInst>(user)) {
+      scope.getDeleter().forceDelete(user);
+      deleteCopyChain(value, scope.getDeleter());
+      return true;
+    }
+    SILValue def = scope.findDefInBorrowScope(value);
+    if (use->isConsuming()) {
+      // All in-scope consuming uses need a unique copy in the same block.
+      auto *copy = dyn_cast<CopyValueInst>(use->get());
+      if (copy && copy->hasOneUse() && copy->getParent() == user->getParent()) {
+        value = copy->getOperand();
+        copy->setOperand(def);
+      } else {
+        use->set(def);
+        copyLiveUse(use, scope.getCallbacks());
+      }
+      deleteCopyChain(value, scope.getDeleter());
+      return true;
+    }
+    // Non-consuming use.
+    use->set(def);
+    deleteCopyChain(value, scope.getDeleter());
+    return true;
+  }
+
+  // Recurse through forwards.
+  //
+  // Implements visitBorrowScopeUses<Visitor>
+  bool visitForwardingUse(Operand *use) {
+    auto *user = use->getUser();
+    assert(CanonicalizeBorrowScope::isRewritableOSSAForward(user));
+
+    for (auto result : user->getResults()) {
+      if (!hasValueOwnership(result)) {
+        continue;
+      }
+      scope.visitBorrowScopeUses(result, *this);
+    }
+    // Update this operand bypassing any copies.
+    SILValue value = use->get();
+    use->set(scope.findDefInBorrowScope(value));
+    ForwardingOperand(use).setOwnershipKind(OwnershipKind::Guaranteed);
+    deleteCopyChain(value, scope.getDeleter());
+    return true;
+  }
+};
+
+/// Generate copies outside this borrow scope, hoist forwarding operations,
+/// rewrite the operands of uses outside the scope, and record the outer uses
+/// that are consumes.
+///
+/// Each hoisted forwarding operation instantiates a new instance of this
+/// visitor. They are rewritten separately.
+///
+/// Implements visitBorrowScopeUses<Visitor>
+class RewriteOuterBorrowUses {
+  CanonicalizeBorrowScope &scope;
+
+  RewriteInnerBorrowUses &innerRewriter;
+
+  const OuterUsers &outerUseInsts;
+
+  /// Map values inside the borrow scope to cloned-and-copied values outside the
+  /// borrow scope.
+  using InnerToOuterMap = llvm::SmallDenseMap<SILValue, SILValue, 8>;
+  InnerToOuterMap &innerToOuterMap;
+
+  // Outer uses specific to the current incomingValue, including hoisted
+  // forwarding instructions, which are not part of outerUseInsts.
+  SmallVector<Operand *, 4> consumingUses;
+  SmallPtrSet<SILInstruction *, 4> unclaimedConsumingUsers;
+
+  RewriteOuterBorrowUses(RewriteInnerBorrowUses &innerRewriter,
+                         const OuterUsers &outerUseInsts,
+                         InnerToOuterMap &innerToOuterMap)
+    : scope(innerRewriter.getScope()), innerRewriter(innerRewriter),
+      outerUseInsts(outerUseInsts), innerToOuterMap(innerToOuterMap) {}
+
+public:
+  static void rewrite(BeginBorrowInst *beginBorrow,
+                      CanonicalizeBorrowScope &scope,
+                      const OuterUsers &outerUseInsts) {
+
+    SILBuilderWithScope builder(beginBorrow);
+    auto loc = RegularLocation::getAutoGeneratedLocation(beginBorrow->getLoc());
+    auto *outerCopy =
+        createOuterCopy(beginBorrow->getOperand(), builder, loc, scope);
+
+    llvm::SmallDenseMap<SILValue, SILValue, 8> innerToOuterMap;
+    innerToOuterMap[beginBorrow] = outerCopy;
+
+    RewriteInnerBorrowUses innerRewriter(scope);
+    RewriteOuterBorrowUses rewriter(innerRewriter, outerUseInsts,
+                                    innerToOuterMap);
+    scope.beginVisitBorrowScopeUses();
+    auto outerVal = rewriter.recursivelyRewriteOuterUses(beginBorrow);
+    assert(outerVal == outerCopy);
+  }
+
+  // Implements visitBorrowScopeUses<Visitor>
+  bool visitUse(Operand *use) {
+    auto *user = use->getUser();
+    if (outerUseInsts.count(user)) {
+      rewriteOuterUse(use);
+      return true;
+    }
+    // If this use begins a borrow scope, check if any of the scope ending
+    // instructions are outside the current scope (this can happen if any copy
+    // has occured on the def-use chain within the current scope).
+    if (auto borrowingOper = BorrowingOperand(use)) {
+      if (!borrowingOper.visitExtendedScopeEndingUses(
+            [&](Operand *endBorrow) {
+              return !outerUseInsts.count(endBorrow->getUser());
+            })) {
+        rewriteOuterUse(use);
+        return true;
+      }
+    }
+    innerRewriter.visitUse(use);
+    return true;
+  }
+
+  // Recurse through forwards.
+  //
+  // Implements visitBorrowScopeUses<Visitor>
+  bool visitForwardingUse(Operand *use) {
+    auto *user = use->getUser();
+    assert(CanonicalizeBorrowScope::isRewritableOSSAForward(user));
+    if (outerUseInsts.count(user)) {
+      rewriteOuterUse(use);
+      return true;
+    }
+
+    // Process transitive users and add this forwarding operation to
+    // outerUseInsts if any outer uses were found.
+    SILInstruction *outerClone = nullptr;
+    for (auto result : user->getResults()) {
+      if (!hasValueOwnership(result)) {
+        continue;
+      }
+      RewriteOuterBorrowUses rewriter(innerRewriter, outerUseInsts,
+                                      innerToOuterMap);
+      auto outerVal = rewriter.recursivelyRewriteOuterUses(result);
+      if (outerVal)
+        outerClone = outerVal->getDefiningInstruction();
+    }
+    // Record the forwarded operand of this hoisted instruction as an outer use.
+    if (outerClone) {
+      recordOuterUse(&outerClone->getOperandRef(0));
+    }
+    // If it's not already dead, update this operand bypassing any copies.
+    SILValue innerValue = use->get();
+    if (scope.getDeleter().deleteIfDead(user)) {
+      LLVM_DEBUG(llvm::dbgs() << "  Deleted " << *user);
+    } else {
+      use->set(scope.findDefInBorrowScope(use->get()));
+      ForwardingOperand(use).setOwnershipKind(OwnershipKind::Guaranteed);
+    }
+    deleteCopyChain(innerValue, scope.getDeleter());
+    return true;
+  }
+
+protected:
+  // Create a copy for outer uses of the borrow scope introduced by
+  // currentDef. This copy should only be used by outer uses in the same block
+  // as the borrow scope.
+  //
+  // To use an existing outer copy, we could find its earliest consume. But the
+  // new copy will immediately canonicalized and a canonical begin_borrow scope
+  // have no outer uses of its first block.
+  static CopyValueInst *createOuterCopy(SILValue incomingValue,
+                                        SILBuilder &builder, SILLocation loc,
+                                        CanonicalizeBorrowScope &scope) {
+    auto *copy = builder.createCopyValue(loc, incomingValue);
+    scope.getCallbacks().createdNewInst(copy);
+    scope.recordOuterCopy(copy);
+
+    ++NumCopiesGenerated;
+    LLVM_DEBUG(llvm::dbgs() << "  Outer copy " << *copy);
+
+    return copy;
+  }
+
+  SILValue recursivelyRewriteOuterUses(SILValue innerValue) {
+    bool succeed = scope.visitBorrowScopeUses(innerValue, *this);
+    assert(succeed && "should be filtered by FindBorrowScopeUses");
+
+    auto iter = innerToOuterMap.find(innerValue);
+    assert(iter != innerToOuterMap.end());
+    SILValue outerValue = iter->second;
+    cleanupOuterValue(outerValue);
+    return outerValue;
+  }
+
+  void recordOuterUse(Operand *use) {
+    if (use->isLifetimeEnding()) {
+      consumingUses.push_back(use);
+      unclaimedConsumingUsers.insert(use->getUser());
+    }
+  };
+
+  void rewriteOuterUse(Operand *use) {
+    LLVM_DEBUG(llvm::dbgs() << "  Use of outer copy " << *use->getUser());
+
+    SILValue innerValue = use->get();
+    SILValue outerValue = createOuterValues(innerValue);
+
+    use->set(outerValue);
+
+    deleteCopyChain(innerValue, scope.getDeleter());
+
+    recordOuterUse(use);
+  };
+
+  SILValue createOuterValues(SILValue innerValue);
+
+  void cleanupOuterValue(SILValue outerValue);
+};
+
+} // namespace
+
+// Incrementally create a def-use chain outside the current borrow scope for
+// all instructions between currentDef and \p innerValue, where \p innerValue
+// has at least one use outside the borrow scope.
+SILValue RewriteOuterBorrowUses::createOuterValues(SILValue innerValue) {
+  // Poke through the copies just like rewriteOuterBorrowUsesAndFindConsumes
+  // does on the def-use side.
+  while (auto *copy = dyn_cast<CopyValueInst>(innerValue)) {
+    innerValue = copy->getOperand();
+  }
+  auto iter = innerToOuterMap.find(innerValue);
+  if (iter != innerToOuterMap.end()) {
+    return iter->second;
+  }
+  auto *innerInst = innerValue->getDefiningInstruction();
+  assert(CanonicalizeBorrowScope::isRewritableOSSAForward(innerInst));
+  SILValue incomingInnerVal = innerInst->getOperand(0);
+
+  auto incomingOuterVal = createOuterValues(incomingInnerVal);
+
+  auto *insertPt = incomingOuterVal->getNextInstruction();
+  auto *clone = innerInst->clone(insertPt);
+  scope.getCallbacks().createdNewInst(clone);
+  Operand *use = &clone->getOperandRef(0);
+  use->set(incomingOuterVal);
+  ForwardingOperand(use).setOwnershipKind(OwnershipKind::Owned);
+
+  LLVM_DEBUG(llvm::dbgs() << "  Hoisted forward " << *clone);
+
+  for (unsigned idx = 0, endIdx = clone->getNumResults(); idx < endIdx; ++idx) {
+    innerToOuterMap[innerInst->getResult(idx)] = clone->getResult(idx);
+  }
+  return innerToOuterMap[innerValue];
+}
+
+// Insert destroys on the outer copy's or forwarding consume's lifetime
+// frontier, or claim a existing consumes. Insert copies for unclaimed consumes.
+void RewriteOuterBorrowUses::cleanupOuterValue(SILValue outerValue) {
+  // Gather outerValue's transitive ownership uses for ValueLifetimeAnalysis.
+  SmallVector<SILInstruction *, 4> outerUses;
+  for (Operand *use : outerValue->getUses()) {
+    outerUses.push_back(use->getUser());
+    if (auto borrowingOper = BorrowingOperand(use)) {
+      borrowingOper.visitExtendedScopeEndingUses([&](Operand *endBorrow) {
+        outerUses.push_back(endBorrow->getUser());
+        return true;
+      });
+    }
+  }
+  ValueLifetimeAnalysis lifetimeAnalysis(outerValue.getDefiningInstruction(),
+                                         outerUses);
+
+  auto createDestroy = [&](SILBuilder &b, SILLocation loc) {
+      auto *dvi = b.createDestroyValue(loc, outerValue);
+      scope.getCallbacks().createdNewInst(dvi);
+  };
+  if (outerUses.empty()) {
+    SILBuilder b(outerValue->getNextInstruction());
+    createDestroy(b, outerValue.getLoc());
+    return;
+  }
+
+  ValueLifetimeBoundary boundary;
+  lifetimeAnalysis.computeLifetimeBoundary(boundary);
+
+  for (auto *boundaryEdge : boundary.boundaryEdges) {
+    if (DeadEndBlocks::triviallyEndsInUnreachable(boundaryEdge))
+      continue;
+    auto insertPt = boundaryEdge->begin();
+    auto *dvi = SILBuilderWithScope(insertPt).createDestroyValue(
+        insertPt->getLoc(), outerValue);
+    scope.getCallbacks().createdNewInst(dvi);
+  }
+
+  for (SILInstruction *lastUser : boundary.lastUsers) {
+    if (unclaimedConsumingUsers.erase(lastUser))
+      continue;
+
+    SILBuilderWithScope::insertAfter(lastUser, [&](SILBuilder &b) {
+      createDestroy(b, lastUser->getLoc());
+    });
+  }
+  // Add copies for consuming users of outerValue.
+  for (auto *use : consumingUses) {
+    // If the user is still in the unclaimedConsumingUsers set, then it does not
+    // end the outer copy's lifetime and therefore requires a copy. Only one
+    // operand can be claimed as ending the lifetime, so return its user to the
+    // unclaimedConsumingUsers set after skipping the first copy.
+    auto iterAndInserted = unclaimedConsumingUsers.insert(use->getUser());
+    if (!iterAndInserted.second) {
+      copyLiveUse(use, scope.getCallbacks());
+      scope.recordOuterCopy(cast<CopyValueInst>(use->get()));
+    }
+  }
+}
+
+// If this succeeds, then all uses of the borrowed value outside the borrow
+// scope will be rewritten to use an outer copy, and all remaining uses of the
+// borrowed value will be confined to the borrow scope.
+//
+// TODO: Canonicalize multi-block borrow scopes, load_borrow scope, and phi
+// borrow scopes by adding one copy per block to persistentCopies for
+// each block that dominates an outer use.
+bool CanonicalizeBorrowScope::consolidateBorrowScope() {
+  OuterUsers outerUseInsts;
+  if (!isa<SILFunctionArgument>(borrowedValue.value)) {
+    // getCanonicalCopiedDef ensures that if currentDef is a guaranteed value,
+    // then it is a borrow scope introducer.
+    assert(borrowedValue.isLocalScope());
+
+    // Gather all potential outer uses before rewriting any to avoid scanning
+    // any basic block more than once.
+    Optional<OuterUsers> outerUsers = FindBorrowScopeUses(*this).findUses();
+    if (!outerUsers)
+      return false;
+
+    outerUseInsts = std::move(outerUsers).getValue();
+
+    filterOuterBorrowUseInsts(outerUseInsts);
+  }
+  // If there are no outer uses, then canonicalization is a simple matter of
+  // removing all the destroys and rewriting the copies.
+  if (outerUseInsts.empty()) {
+    RewriteInnerBorrowUses innerRewriter(*this);
+    beginVisitBorrowScopeUses(); // reset the def/use worklist
+    bool succeed = visitBorrowScopeUses(borrowedValue.value, innerRewriter);
+    assert(succeed && "should be filtered by FindBorrowScopeUses");
+    return true;
+  }
+  LLVM_DEBUG(llvm::dbgs() << "  Outer uses:\n";
+             for (SILInstruction *inst
+                  : outerUseInsts) { llvm::dbgs() << "    " << *inst; });
+
+  RewriteOuterBorrowUses::rewrite(cast<BeginBorrowInst>(borrowedValue.value),
+                                  *this, outerUseInsts);
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+//                  MARK: Top-Level CanonicalizeBorrowScope
+//===----------------------------------------------------------------------===//
+
+bool CanonicalizeBorrowScope::canonicalizeFunctionArgument(
+    SILFunctionArgument *arg) {
+  LLVM_DEBUG(llvm::dbgs() << "*** Canonicalize Borrow: " << borrowedValue);
+
+  initBorrow(BorrowedValue(arg));
+
+  RewriteInnerBorrowUses innerRewriter(*this);
+  beginVisitBorrowScopeUses(); // reset the def/use worklist
+  bool succeed = visitBorrowScopeUses(borrowedValue.value, innerRewriter);
+  assert(succeed && "should be filtered by FindBorrowScopeUses");
+  return true;
+}
+
+/// Canonicalize a worklist of extended lifetimes. This iterates after rewriting
+/// borrow scopes to handle new outer copies and new owned lifetimes from
+/// forwarding operations.
+bool CanonicalizeBorrowScope::
+canonicalizeBorrowScope(BorrowedValue borrowedValue) {
+  LLVM_DEBUG(llvm::dbgs() << "*** Canonicalize Borrow: " << borrowedValue);
+
+  initBorrow(borrowedValue);
+
+  SWIFT_DEFER { liveness.clear(); };
+
+  if (!computeBorrowLiveness())
+    return false;
+
+  // Set outerCopy and persistentCopies and rewrite uses
+  // outside the scope.
+  if (!consolidateBorrowScope())
+    return false;
+
+  return true;
+}

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -211,7 +211,7 @@ bool swift::isIntermediateRelease(SILInstruction *inst,
   return false;
 }
 
-static bool hasOnlyEndOfScopeOrDestroyUses(SILInstruction *inst) {
+bool swift::hasOnlyEndOfScopeOrDestroyUses(SILInstruction *inst) {
   for (SILValue result : inst->getResults()) {
     for (Operand *use : result->getUses()) {
       SILInstruction *user = use->getUser();

--- a/test/SILOptimizer/copy_propagation.sil
+++ b/test/SILOptimizer/copy_propagation.sil
@@ -32,6 +32,7 @@ sil [ossa] @getOwnedC : $@convention(thin) () -> (@owned C)
 sil [ossa] @takeOwnedC : $@convention(thin) (@owned C) -> ()
 sil [ossa] @takeOwnedCTwice : $@convention(thin) (@owned C, @owned C) -> ()
 sil [ossa] @takeGuaranteedC : $@convention(thin) (@guaranteed C) -> ()
+sil [ossa] @takeGuaranteedAnyObject : $@convention(thin) (@guaranteed AnyObject) -> ()
 
 // -O ignores this because there's no copy_value
 // -Onone hoists the destroy and adds a poison flag.
@@ -342,6 +343,8 @@ bb0:
   br bb1
 
 bb1:
+  %f2 = function_ref @takeGuaranteedAnyObject : $@convention(thin) (@guaranteed AnyObject) -> ()
+  %call = apply %f2(%obj) : $@convention(thin) (@guaranteed AnyObject) -> ()
   destroy_value %copy : $AnyObject
   destroy_value %obj : $AnyObject
   destroy_value %box : ${ var AnyObject }
@@ -392,6 +395,8 @@ bb1:
   br bb2
 
 bb2:
+  %f2 = function_ref @takeGuaranteedAnyObject : $@convention(thin) (@guaranteed AnyObject) -> ()
+  %call = apply %f2(%obj) : $@convention(thin) (@guaranteed AnyObject) -> ()
   destroy_value %copy : $AnyObject
   destroy_value %obj : $AnyObject
   destroy_value %box : ${ var AnyObject }
@@ -435,6 +440,8 @@ bb0:
   br bb1
 
 bb1:
+  %f2 = function_ref @takeGuaranteedAnyObject : $@convention(thin) (@guaranteed AnyObject) -> ()
+  %call = apply %f2(%obj) : $@convention(thin) (@guaranteed AnyObject) -> ()
   destroy_value %copy : $AnyObject
   destroy_value %obj : $AnyObject
   destroy_value %box : ${ var AnyObject }
@@ -484,6 +491,8 @@ bb1:
   br bb2
 
 bb2:
+  %f2 = function_ref @takeGuaranteedAnyObject : $@convention(thin) (@guaranteed AnyObject) -> ()
+  %call = apply %f2(%obj) : $@convention(thin) (@guaranteed AnyObject) -> ()
   destroy_value %copy : $AnyObject
   destroy_value %obj : $AnyObject
   destroy_value %box : ${ var AnyObject }
@@ -527,6 +536,8 @@ bb0:
   br bb1
 
 bb1:
+  %f2 = function_ref @takeGuaranteedAnyObject : $@convention(thin) (@guaranteed AnyObject) -> ()
+  %call = apply %f2(%obj) : $@convention(thin) (@guaranteed AnyObject) -> ()
   destroy_value %copy : $AnyObject
   destroy_value %obj : $AnyObject
   destroy_value %box : ${ var AnyObject }
@@ -577,6 +588,8 @@ bb1:
   br bb2
 
 bb2:
+  %f2 = function_ref @takeGuaranteedAnyObject : $@convention(thin) (@guaranteed AnyObject) -> ()
+  %call = apply %f2(%obj) : $@convention(thin) (@guaranteed AnyObject) -> ()
   destroy_value %copy : $AnyObject
   destroy_value %obj : $AnyObject
   destroy_value %box : ${ var AnyObject }
@@ -622,6 +635,8 @@ bb0:
   br bb1
 
 bb1:
+  %f2 = function_ref @takeGuaranteedAnyObject : $@convention(thin) (@guaranteed AnyObject) -> ()
+  %call = apply %f2(%obj) : $@convention(thin) (@guaranteed AnyObject) -> ()
   destroy_value %obj : $AnyObject
   destroy_value %box : ${ var AnyObject }
   %v = tuple ()

--- a/test/SILOptimizer/copy_propagation_borrow.sil
+++ b/test/SILOptimizer/copy_propagation_borrow.sil
@@ -10,6 +10,8 @@ sil_stage canonical
 
 import Builtin
 
+typealias AnyObject = Builtin.AnyObject
+
 class B { }
 
 class C {
@@ -21,22 +23,34 @@ sil [ossa] @getOwnedC : $@convention(thin) () -> (@owned C)
 sil [ossa] @takeOwnedC : $@convention(thin) (@owned C) -> ()
 sil [ossa] @takeOwnedCTwice : $@convention(thin) (@owned C, @owned C) -> ()
 sil [ossa] @takeGuaranteedC : $@convention(thin) (@guaranteed C) -> ()
+sil [ossa] @accessRawP : $@convention(method) (Builtin.RawPointer) -> ()
 
 struct NativeObjectPair {
   var obj1 : Builtin.NativeObject
   var obj2 : Builtin.NativeObject
 }
 
-class Klass {}
+struct HasObject {
+  var object: C
+}
 
 struct HasObjectAndInt {
-  var object: Klass
+  var object: C
   var value: Builtin.Int64
 }
 
-
 struct Wrapper {
   var hasObject: HasObjectAndInt
+}
+
+struct MultiWrapper {
+  var hasObject0: HasObjects
+  var hasObject1: HasObjects
+}
+
+struct HasObjects {
+  var object0: C
+  var object1: C
 }
 
 struct UInt64 {
@@ -129,6 +143,27 @@ bb0(%0 : @guaranteed $NativeObjectPair):
 // =============================================================================
 // Test consolidateBorrowScope
 // =============================================================================
+
+// Test a basic copy with an outer use.
+//
+// CHECK-LABEL: sil [ossa] @testBorrowOuterUse : $@convention(thin) (@owned C) -> () {
+// CHECK: bb0(%0 : @owned $C):
+// CHECK-NOT: begin_borrow
+// CHECK-NOT: copy
+// CHECK: apply %{{.*}}(%0) : $@convention(thin) (@owned C) -> ()
+// CHECK-NOT: destroy
+// CHECK: } // end sil function 'testBorrowOuterUse'
+sil [ossa] @testBorrowOuterUse : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  %1 = begin_borrow %0 : $C
+  %copy = copy_value %1 : $C
+  end_borrow %1 : $C
+  %f1 = function_ref @takeOwnedC : $@convention(thin) (@owned C) -> ()
+  %call2 = apply %f1(%copy) : $@convention(thin) (@owned C) -> ()
+  destroy_value %0 : $C
+  %99 = tuple ()
+  return %99 : $()
+}
 
 // Remove nested borrow scopes for multiple levels of struct_extracts.
 //
@@ -431,6 +466,77 @@ bb3:
   return %0 : $C
 }
 
+// Test a nested borrow scope that has different inner vs. outer
+// properties on different branches. If any one of the inner borrow's
+// uses are outside the outer borrow, then all of them need to be
+// considered "outer uses". Otherwise, when we cleanup the lifetime of
+// the new outer copy, it won't cover then entire inner borrow scope.
+//
+// CHECK-LABEL: sil [ossa] @testNestedBorrowInsideAndOutsideUse : $@convention(thin) () -> () {
+// CHECK: [[ALLOC:%.*]] = alloc_ref $C
+// CHECK: [[B1:%.*]] = begin_borrow [[ALLOC]] : $C
+// CHECK-NOT: borrow
+// CHECK: bb1:
+// CHECK-NEXT: end_borrow [[B1]] : $C
+// CHECK-NEXT: destroy_value [[ALLOC]] : $C
+// CHECK-NEXT: br bb3
+// CHECK: bb2:
+// CHECK-NEXT: end_borrow %1 : $C
+// CHECK-NEXT: destroy_value %0 : $C
+// CHECK-NEXT: br bb3
+// CHECK: bb3:
+// CHECK-NOT: destroy
+// CHECK-LABEL: } // end sil function 'testNestedBorrowInsideAndOutsideUse'
+sil [ossa] @testNestedBorrowInsideAndOutsideUse : $@convention(thin) () -> () {
+bb0:
+  %alloc = alloc_ref $C
+  %borrow1 = begin_borrow %alloc : $C
+  %copy1 = copy_value %borrow1 : $C
+  %borrow2 = begin_borrow %copy1 : $C
+  %addr = ref_element_addr %borrow2 : $C, #C.a
+  cond_br undef, bb1, bb2
+bb1:
+  // inside use
+  end_borrow %borrow2 : $C
+  destroy_value %copy1 : $C
+  end_borrow %borrow1 : $C
+  br bb3
+bb2:
+  end_borrow %borrow1 : $C
+  // outside use
+  end_borrow %borrow2 : $C
+  destroy_value %copy1 : $C
+  br bb3
+bb3:
+  destroy_value %alloc : $C
+  %99 = tuple ()
+  return %99 : $()
+}
+
+// The ref_to_unmanaged escapes the pointer. consolidateBorrowScopes
+// needs to bail-out even though it's already recursively processing a
+// forwarding operation (destructure_struct).
+//
+// CHECK-LABEL: sil [ossa] @testEscapingForward : $@convention(method) (@guaranteed HasObject) -> () {
+// CHECK:   begin_borrow %0 : $HasObject
+// CHECK:   copy_value
+// CHECK:   destructure_struct
+// CHECK:   end_borrow
+// CHECK:   ref_to_unmanaged
+// CHECK:   destroy_value
+// CHECK-LABEL: } // end sil function 'testEscapingForward'
+sil [ossa] @testEscapingForward : $@convention(method) (@guaranteed HasObject) -> () {
+bb0(%0 : @guaranteed $HasObject):
+  %1 = begin_borrow %0 : $HasObject
+  %2 = copy_value %1 : $HasObject
+  %3 = destructure_struct %2 : $HasObject
+  end_borrow %1 : $HasObject
+  %5 = ref_to_unmanaged %3 : $C to $@sil_unmanaged C
+  destroy_value %3 : $C
+  %7 = tuple ()
+  return %7 : $()
+}
+
 // =============================================================================
 // Test reborrows
 // =============================================================================
@@ -572,15 +678,13 @@ bb3(%borrowphi : @guaranteed $C):
 //   end nested borrow
 //   middle copy -- when consolidating borrow scope,
 //                  its operand is replace with a copy of borrowphi
-//                  then removeed when borrowphi's copy is canonicalized
+//                  then removed when borrowphi's copy is canonicalized
 //   end borrowphi
-//   outer copy -- removeed when borrowphi's copy is canonicalized
+//   outer copy -- removed when borrowphi's copy is canonicalized
 //
 // CHECK-LABEL: sil [ossa] @testNestedReborrowOutsideUse : $@convention(thin) () -> () {
 // CHECK:        [[ALLOC:%.*]] = alloc_ref $C
 // CHECK:      bb3([[BORROWPHI:%.*]] : @guaranteed $C):
-// CHECK-NEXT:   [[COPY:%.*]] = copy_value [[BORROWPHI]] : $C
-// CHECK-NEXT:   destroy_value [[COPY]] : $C
 // CHECK-NEXT:   begin_borrow [[BORROWPHI]] : $C
 // CHECK-NOT:    copy
 // CHECK:        end_borrow
@@ -653,17 +757,29 @@ bb3(%borrow3 : @guaranteed $C, %copy3 : @owned $C):
   return %result : $()
 }
 
+// =============================================================================
+// Test hoisting forwarding instructions out of borrow scopes
+// =============================================================================
+
 // Test conversion from struct_extract to destructure.
+//
+// TODO: Remove the inner borrow scope becaues its outer value is
+// already guaranteed and it only has instantaneous uses. Then shrink
+// the outer borrow scope, hoist the destructure, rewrite the destroy
+// to be of the destructured valud, and finally also remove the dead
+// outer borrow scope. See rdar://79149830 (Shrink borrow scopes in
+// CanonicalizeBorrowScope)
 //
 // CHECK-LABEL: sil [ossa] @testDestructureConversion : $@convention(thin) (@owned Wrapper) -> () {
 // CHECK: bb0(%0 : @owned $Wrapper):
 // CHECK-NOT: copy
-// CHECK:   [[SPLIT:%.*]] = destructure_struct %0 : $Wrapper
+// CHECK:   [[BORROW:%.*]] = begin_borrow %0 : $Wrapper
+// CHECK:   [[SPLIT:%.*]] = destructure_struct [[BORROW]] : $Wrapper
 // CHECK:   [[BORROWINNER:%.*]] = begin_borrow [[SPLIT]] : $HasObjectAndInt
 // CHECK:   debug_value [[BORROWINNER]] : $HasObjectAndInt, let, name "self", argno 1
 // CHECK:   struct_extract [[BORROWINNER]] : $HasObjectAndInt, #HasObjectAndInt.value
 // CHECK:   end_borrow [[BORROWINNER]] : $HasObjectAndInt
-// CHECK:   destroy_value [[SPLIT]] : $HasObjectAndInt
+// CHECK:   destroy_value %0 : $Wrapper
 // CHECK-LABEL: } // end sil function 'testDestructureConversion'
 sil [ossa] @testDestructureConversion : $@convention(thin) (@owned Wrapper) -> () {
 bb0(%0 : @owned $Wrapper):
@@ -684,15 +800,263 @@ bb0(%0 : @owned $Wrapper):
   return %99 : $()
 }
 
-// FIXME: This borrow scope should also be removed:
-//   %11 = begin_borrow %10 : $_StringObject           // users: %17, %16, %13, %11
+// Test two inner forwards with one inner and one outer use.
+// Check that the destroy is removed after sinking the destructure.
+//
+// CHECK-LABEL: sil [ossa] @testForwardBorrow1 : $@convention(thin) (@owned Wrapper) -> () {
+// CHECK:       bb0(%0 : @owned $Wrapper):
+// CHECK-NEXT:   [[BORROW:%.*]] = begin_borrow %0 : $Wrapper
+// CHECK-NEXT:   [[DSIN1:%.*]] = destructure_struct [[BORROW]] : $Wrapper
+// CHECK-NEXT:   ([[DSIN2:%.*]], %{{.*}}) = destructure_struct [[DSIN1]] : $HasObjectAndInt
+// CHECK:        apply %{{.*}}([[DSIN2]]) : $@convention(thin) (@guaranteed C) -> ()
+// CHECK-NEXT:   end_borrow [[BORROW]] : $Wrapper
+// CHECK:        [[DSOUT1:%.*]] = destructure_struct %0 : $Wrapper
+// CHECK-NEXT:   ([[DSOUT2:%.*]], %{{.*}}) = destructure_struct [[DSOUT1]] : $HasObjectAndInt
+// CHECK:        apply %{{.*}}([[DSOUT2]]) : $@convention(thin) (@owned C) -> ()
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
+// CHECK-LABEL: } // end sil function 'testForwardBorrow1'
+sil [ossa] @testForwardBorrow1 : $@convention(thin) (@owned Wrapper) -> () {
+bb0(%0 : @owned $Wrapper):
+  %1 = begin_borrow %0 : $Wrapper
+  %2 = destructure_struct %1 : $Wrapper
+  (%3, %4) = destructure_struct %2 : $HasObjectAndInt
+  %copy3 = copy_value %3 : $C
+  %f1 = function_ref @takeGuaranteedC : $@convention(thin) (@guaranteed C) -> ()
+  %call1 = apply %f1(%3) : $@convention(thin) (@guaranteed C) -> ()
+  end_borrow %1 : $Wrapper
+  %f2 = function_ref @takeOwnedC : $@convention(thin) (@owned C) -> ()
+  %call2 = apply %f2(%copy3) : $@convention(thin) (@owned C) -> ()
+  destroy_value %0 : $Wrapper
+  %99 = tuple ()
+  return %99 : $()
+}
+
+// Test two inner forwards where the copy has both and inner and outer uses.
+//
+// CHECK-LABEL: sil [ossa] @testForwardBorrow2 : $@convention(thin) (@owned Wrapper) -> () {
+// CHECK:       bb0(%0 : @owned $Wrapper):
+// CHECK-NEXT:   [[BORROW:%.*]] = begin_borrow %0 : $Wrapper
+// CHECK-NEXT:   [[DSIN1:%.*]] = destructure_struct [[BORROW]] : $Wrapper
+// CHECK-NEXT:   ([[DSIN2:%.*]], %{{.*}}) = destructure_struct [[DSIN1]] : $HasObjectAndInt
+// CHECK:        apply %{{.*}}([[DSIN2]]) : $@convention(thin) (@guaranteed C) -> ()
+// CHECK-NEXT:   end_borrow [[BORROW]] : $Wrapper
+// CHECK:        [[DSOUT1:%.*]] = destructure_struct %0 : $Wrapper
+// CHECK-NEXT:   ([[DSOUT2:%.*]], %{{.*}}) = destructure_struct [[DSOUT1]] : $HasObjectAndInt
+// CHECK:        apply %{{.*}}([[DSOUT2]]) : $@convention(thin) (@owned C) -> ()
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
+// CHECK-LABEL: } // end sil function 'testForwardBorrow2'
+sil [ossa] @testForwardBorrow2 : $@convention(thin) (@owned Wrapper) -> () {
+bb0(%0 : @owned $Wrapper):
+  %1 = begin_borrow %0 : $Wrapper
+  %2 = destructure_struct %1 : $Wrapper
+  (%3, %4) = destructure_struct %2 : $HasObjectAndInt
+  %copy3 = copy_value %3 : $C
+  %f1 = function_ref @takeGuaranteedC : $@convention(thin) (@guaranteed C) -> ()
+  %call1 = apply %f1(%copy3) : $@convention(thin) (@guaranteed C) -> ()
+  end_borrow %1 : $Wrapper
+  %f2 = function_ref @takeOwnedC : $@convention(thin) (@owned C) -> ()
+  %call2 = apply %f2(%copy3) : $@convention(thin) (@owned C) -> ()
+  destroy_value %0 : $Wrapper
+  %99 = tuple ()
+  return %99 : $()
+}
+
+// Test two inner forwards with no inner use.
+// Remove the borrow and inner forwards.
+//
+// CHECK-LABEL: sil [ossa] @testForwardBorrow3 : $@convention(thin) (@owned Wrapper) -> () {
+// CHECK:       bb0(%0 : @owned $Wrapper):
+// CHECK-NOT:    borrow
+// CHECK-NOT:    copy
+// CHECK:        [[DSOUT1:%.*]] = destructure_struct %0 : $Wrapper
+// CHECK-NEXT:   ([[DSOUT2:%.*]], %{{.*}}) = destructure_struct [[DSOUT1]] : $HasObjectAndInt
+// CHECK-NEXT:   apply %{{.*}}([[DSOUT2]]) : $@convention(thin) (@owned C) -> ()
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
+// CHECK-LABEL: } // end sil function 'testForwardBorrow3'
+sil [ossa] @testForwardBorrow3 : $@convention(thin) (@owned Wrapper) -> () {
+bb0(%0 : @owned $Wrapper):
+  %1 = begin_borrow %0 : $Wrapper
+  %2 = destructure_struct %1 : $Wrapper
+  (%3, %4) = destructure_struct %2 : $HasObjectAndInt
+  %copy3 = copy_value %3 : $C
+  end_borrow %1 : $Wrapper
+  %f = function_ref @takeOwnedC : $@convention(thin) (@owned C) -> ()
+  %call = apply %f(%copy3) : $@convention(thin) (@owned C) -> ()
+  destroy_value %0 : $Wrapper
+  %99 = tuple ()
+  return %99 : $()
+}
+
+// Test an inner forwards with two results where both results are owned
+// but one has no outer uses.
+// Need to create two new destroys in this case.
+//
+//
+// CHECK-LABEL: sil [ossa] @testForwardBorrow4 : $@convention(thin) (@owned MultiWrapper) -> () {
+// CHECK: bb0(%0 : @owned $MultiWrapper):
+// CHECK-NEXT:   (%1, %2) = destructure_struct %0 : $MultiWrapper
+// CHECK-NEXT:   destroy_value %2 : $HasObjects
+// CHECK-NEXT:   ([[VAL:%.*]], %5) = destructure_struct %1 : $HasObjects
+// CHECK-NEXT:   destroy_value %5 : $C
+// CHECK-NOT:    borrow
+// CHECK:        apply %{{.*}}([[VAL]]) : $@convention(thin) (@owned C) -> ()
+// CHECK-NOT:    destroy
+// CHECK-LABEL: } // end sil function 'testForwardBorrow4'
+sil [ossa] @testForwardBorrow4 : $@convention(thin) (@owned MultiWrapper) -> () {
+bb0(%0 : @owned $MultiWrapper):
+  %1 = begin_borrow %0 : $MultiWrapper
+  (%2, %3) = destructure_struct %1 : $MultiWrapper
+  (%4, %5) = destructure_struct %2 : $HasObjects
+  %copy = copy_value %4 : $C
+  end_borrow %1 : $MultiWrapper
+  %f2 = function_ref @takeOwnedC : $@convention(thin) (@owned C) -> ()
+  %call = apply %f2(%copy) : $@convention(thin) (@owned C) -> ()
+  destroy_value %0 : $MultiWrapper
+  %99 = tuple ()
+  return %99 : $()
+}
+
+// Test a nested forwarding.
+// Remove the copy within the outer borrow scope.
+// Remove the copy outside the borrow scopes before the final destructure.
+//
+// TODO: Remove the remaining copy+destructure. It's only use is a
+// borrow before it is destructured again later. This should be done
+// by the SemanticARC pass that normally combines a copied live range
+// with its source live range when the guaranteed uses are within the
+// outer scope. But that analysis needs to "see through" destructures.
+//
+// CHECK-LABEL: sil shared [ossa] @testForwardBorrow5 : $@convention(method) (@owned HasObjectAndInt) -> () {
+// CHECK: bb0(%0 : @owned $HasObjectAndInt):
+// CHECK-NEXT:  %1 = copy_value %0 : $HasObjectAndInt
+// CHECK-NEXT:  (%2, %3) = destructure_struct %1 : $HasObjectAndInt
+// CHECK-NEXT:  %4 = begin_borrow %2 : $C
+// CHECK-NEXT:  %5 = ref_tail_addr %4 : $C, $Builtin.Int8
+// CHECK-NEXT:  %6 = index_addr %5 : $*Builtin.Int8, undef : $Builtin.Word
+// CHECK-NEXT:  %7 = address_to_pointer %6 : $*Builtin.Int8 to $Builtin.RawPointer
+// CHECK-NEXT:  end_borrow %4 : $C
+// CHECK-NEXT:  destroy_value %2 : $C
+// CHECK:       apply %{{.*}}(%7) : $@convention(method) (Builtin.RawPointer) -> ()
+// CHECK-NEXT:  ([[OBJ:%.*]], %{{.*}}) = destructure_struct %0 : $HasObjectAndInt
+// CHECK-NEXT:  [[EXIS:%.*]] = init_existential_ref [[OBJ]] : $C : $C, $AnyObject
+// CHECK-NEXT:  fix_lifetime [[EXIS]] : $AnyObject
+// CHECK-NEXT:  destroy_value [[EXIS]] : $AnyObject
+// CHECK-NOT:   destroy
+// CHECK-LABEL: } // end sil function 'testForwardBorrow5'
+sil shared [ossa] @testForwardBorrow5 : $@convention(method) (@owned HasObjectAndInt) -> () {
+bb0(%0 : @owned $HasObjectAndInt):
+  %1 = begin_borrow %0 : $HasObjectAndInt
+  %2 = struct_extract %1 : $HasObjectAndInt, #HasObjectAndInt.object
+  %3 = copy_value %2 : $C
+  %4 = begin_borrow %3 : $C
+  %5 = ref_tail_addr %4 : $C, $Builtin.Int8
+  end_borrow %1 : $HasObjectAndInt
+  %7 = index_addr %5 : $*Builtin.Int8, undef : $Builtin.Word
+  %8 = address_to_pointer %7 : $*Builtin.Int8 to $Builtin.RawPointer
+  end_borrow %4 : $C
+  destroy_value %3 : $C
+  // function_ref accessRawP
+  %11 = function_ref @accessRawP : $@convention(method) (Builtin.RawPointer) -> ()
+  %12 = apply %11(%8) : $@convention(method) (Builtin.RawPointer) -> ()
+  %13 = copy_value %0 : $HasObjectAndInt
+  (%14, %15) = destructure_struct %13 : $HasObjectAndInt
+  %16 = init_existential_ref %14 : $C : $C, $AnyObject
+  fix_lifetime %16 : $AnyObject
+  destroy_value %16 : $AnyObject
+  destroy_value %0 : $HasObjectAndInt
+  %20 = tuple ()
+  return %20 : $()
+}
+
+// Test removing copies within an outer borrow scope with no outer uses.
+//
+// TODO: The redundant borrow scope should be removed by a SemanticARC pass.
+//
+// CHECK-LABEL: sil [ossa] @testBorrowCopy : $@convention(thin) (@guaranteed C) -> Int64 {
+// CHECK: bb0(%0 : @guaranteed $C):
+// CHECK-NEXT:  %1 = begin_borrow %0 : $C
+// CHECK-NEXT:  %2 = begin_borrow %1 : $C
+// CHECK-NEXT:  %3 = ref_element_addr %2 : $C, #C.a
+// CHECK-NEXT:  %4 = load [trivial] %3 : $*Int64
+// CHECK-NEXT:  end_borrow %2 : $C
+// CHECK-NEXT:  end_borrow %1 : $C
+// CHECK-NEXT:  return %4 : $Int64
+// CHECK-LABEL: } // end sil function 'testBorrowCopy'
+sil [ossa] @testBorrowCopy : $@convention(thin) (@guaranteed C) -> Int64 {
+bb0(%0 : @guaranteed $C):
+  %borrow = begin_borrow %0 : $C
+  %copy = copy_value %borrow : $C
+  %borrow2 = begin_borrow %copy : $C
+  %adr = ref_element_addr %borrow2 : $C, #C.a
+  %val = load [trivial] %adr : $*Int64
+  end_borrow %borrow2 : $C
+  destroy_value %copy : $C
+  end_borrow %borrow : $C
+  return %val : $Int64
+}
+
+// Test removing copies of a guaranteed argument.
+//
+// CHECK-LABEL: sil [ossa] @testCopyArg : $@convention(thin) (@guaranteed C) -> Int64 {
+// CHECK: bb0(%0 : @guaranteed $C):
+// CHECK-NEXT:  %1 = begin_borrow %0 : $C
+// CHECK-NEXT:  %2 = ref_element_addr %1 : $C, #C.a
+// CHECK-NEXT:  %3 = load [trivial] %2 : $*Int64
+// CHECK-NEXT:  end_borrow %1 : $C
+// CHECK-NEXT:  return %3 : $Int64
+// CHECK-LABEL: } // end sil function 'testCopyArg'
+sil [ossa] @testCopyArg : $@convention(thin) (@guaranteed C) -> Int64 {
+bb0(%0 : @guaranteed $C):
+  %copy = copy_value %0 : $C
+  %borrow2 = begin_borrow %copy : $C
+  %adr = ref_element_addr %borrow2 : $C, #C.a
+  %val = load [trivial] %adr : $*Int64
+  end_borrow %borrow2 : $C
+  destroy_value %copy : $C
+  return %val : $Int64
+}
+
+// TODO: Remove this copy inside a borrow scope by shrinking the scope .
+// rdar://79149830 (Shrink borrow scopes in CanonicalizeBorrowScope)
+//
+// Note: shrinking borrow scopes needs to happen even when most borrow
+// scopes are eliminated because some "defined" borrow scopes cannot be removed.
+//
+// CHECK-LABEL: sil [ossa] @testUselessBorrow : $@convention(thin) (@owned HasObject) -> () {
+// CHECK:   [[BORROW:%.*]] = begin_borrow %0 : $HasObject
+// CHECK:   [[ELT:%.*]] = destructure_struct [[BORROW]] : $HasObject
+// CHECK:   [[CP:%.*]] = copy_value [[ELT]] : $C
+// CHECK:   apply %{{.*}}([[CP]]) : $@convention(thin) (@owned C) -> ()
+// CHECK:   end_borrow [[BORROW]] : $HasObject
+// CHECK:   destroy_value %0 : $HasObject
+// CHECK-LABEL: } // end sil function 'testUselessBorrow'
+sil [ossa] @testUselessBorrow : $@convention(thin) (@owned HasObject) -> () {
+bb0(%0 : @owned $HasObject):
+  %borrow = begin_borrow %0 : $HasObject
+  %object = struct_extract %borrow : $HasObject, #HasObject.object
+  %copy = copy_value %object : $C
+  %f = function_ref @takeOwnedC : $@convention(thin) (@owned C) -> ()
+  %call = apply %f(%copy) : $@convention(thin) (@owned C) -> ()
+  end_borrow %borrow : $HasObject
+  destroy_value %0 : $HasObject
+  %20 = tuple ()
+  return %20 : $()
+}
+
+// Test a more complicated/realistic example of useless borrows
+//
+// TODO: Remove this copy inside a borrow scope by shrinking the scope .
+// rdar://79149830 (Shrink borrow scopes in CanonicalizeBorrowScope)
 //
 // It only has one trivial struct_extract. But copy propagation
 // currently only removes completely dead borrows.
 // Removing this borrow scope will unblock removal of the final remaining copy_value:
 //    %_ = copy_value %_ : $String.UTF16View
 //
-// CHECK-LABEL: sil [ossa] @testUselessBorrow : $@convention(thin) (@owned String) -> () {
+// CHECK-LABEL: sil [ossa] @testUselessBorrowString : $@convention(thin) (@owned String) -> () {
 // CHECK: bb0(%0 : @owned $String):
 // CHECK-NEXT:   [[DESTRUCTURE:%.*]] = destructure_struct %0 : $String
 // CHECK-NEXT:   [[UTF16:%.*]] = struct $String.UTF16View ([[DESTRUCTURE]] : $_StringGuts)
@@ -725,8 +1089,8 @@ bb0(%0 : @owned $Wrapper):
 // CHECK:        br bb1
 // CHECK:      bb8:
 // CHECK-NEXT:   destroy_value [[UTF16]] : $String.UTF16View
-// CHECK-LABEL: } // end sil function 'testUselessBorrow'
-sil [ossa] @testUselessBorrow : $@convention(thin) (@owned String) -> () {
+// CHECK-LABEL: } // end sil function 'testUselessBorrowString'
+sil [ossa] @testUselessBorrowString : $@convention(thin) (@owned String) -> () {
 bb0(%0 : @owned $String):
   %1 = begin_borrow %0 : $String
   %2 = struct_extract %1 : $String, #String._guts
@@ -776,3 +1140,23 @@ bb8:
   %30 = tuple ()
   return %30 : $()
 } // end sil function 'testUselessBorrow'
+
+// Test recursively visiting a guaranteed borrow that is copied within
+// the borrow scope and used by a debug_value.
+// The copy_value will be deleted when processing the struct.
+//
+// CHECK-LABEL: sil [ossa] @testCopiedDebugValue : $@convention(method) (@guaranteed String) -> @owned String.UTF16View {
+// CHECK: [[DS:%.*]] = destructure_struct %0 : $String
+// CHECK-NEXT:  [[ST:%.*]] = struct $String.UTF16View ([[DS]] : $_StringGuts)
+// CHECK-NEXT:  [[CP:%.*]] = copy_value [[ST]] : $String.UTF16View
+// CHECK-NEXT:  return [[CP]] : $String.UTF16View
+// CHECK-LABEL: } // end sil function 'testCopiedDebugValue'
+sil [ossa] @testCopiedDebugValue : $@convention(method) (@guaranteed String) -> @owned String.UTF16View {
+bb0(%0 : @guaranteed $String):
+  debug_value %0 : $String, let, name "self", argno 1
+  %2 = destructure_struct %0 : $String
+  %3 = copy_value %2 : $_StringGuts
+  debug_value %3 : $_StringGuts, let, name "guts"
+  %5 = struct $String.UTF16View (%3 : $_StringGuts)
+  return %5 : $String.UTF16View
+}

--- a/test/SILOptimizer/copy_propagation_opaque.sil
+++ b/test/SILOptimizer/copy_propagation_opaque.sil
@@ -394,7 +394,7 @@ bb0(%arg : @owned $T):
 // CHECK-TRACE-LABEL: *** CopyPropagation: testBorrowCopy
 // CHECK-TRACE:  Outer copy          [[OUTERCOPY:%.*]] = copy_value %0 : $T
 // CHECK-TRACE:  Use of outer copy   destroy_value
-// CHECK-TRACE:  Removing   %{{.*}} = copy_value
+// CHECK-TRACE:  Deleting   %{{.*}} = copy_value
 // CHECK-TRACE:  Removing   destroy_value [[OUTERCOPY]] : $T
 // CHECK-TRACE:  Removing   [[OUTERCOPY]] = copy_value %0 : $T
 //

--- a/test/SILOptimizer/sil_combine_apply_ossa.sil
+++ b/test/SILOptimizer/sil_combine_apply_ossa.sil
@@ -1,4 +1,6 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine -sil-combine-disable-alloc-stack-opts | %FileCheck %s
+// RUN: %target-sil-opt -enable-ossa-modules -enable-sil-verify-all %s -sil-combine -sil-combine-disable-alloc-stack-opts | %FileCheck %s
+
+// -enable-ossa-modules happens to enable copy propagation during sil-combine, which these tests rely on.
 
 import Swift
 import Builtin
@@ -516,10 +518,10 @@ sil [ossa] @guaranteed_closure : $@convention(thin) (@guaranteed C) -> ()
 
 // CHECK-LABEL: sil [ossa] @test_guaranteed_closure
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $C):
-// CHECK: [[ARG_COPY:%.*]] = copy_value [[ARG]]
 // CHECK: [[F:%.*]] = function_ref @guaranteed_closure
+// CHECK: [[ARG_COPY:%.*]] = copy_value [[ARG]]
 // CHECK: [[C:%.*]] = partial_apply [callee_guaranteed] [[F]]([[ARG_COPY]])
-// CHECK: apply [[F]]([[ARG]])
+// CHECK: apply [[F]](%0)
 // Don't release the closure context -- it is @callee_guaranteed.
 // CHECK-NOT: destroy_value [[C]] : $@callee_guaranteed () -> ()
 // CHECK-NOT: destroy_value [[C]] : $@callee_guaranteed () -> ()


### PR DESCRIPTION
Think of this as a complete rewrite of functionality that was mostly disabled anyway but is now ready to be enabled.

One incidental functionality change is that more dead code will now be eliminated during the copy propagation pass.

The one big commit is "Copy propagation redesign".

One medium size commit enabled by the big commit is "Simplify lifetime canonicalization in SILCombine".

Both those commits fix the -canonical-ossa-rewrite-borrows mode, which is now ready to be enabled by default.

The big commit is too hard to split into a separate PR, and the small commits are too trivial to be worth a separate PR.

In the big commit, the large amount of code that was deleted from CanonicalOSSALifetime.cpp can just be considered the old implemenation so can be ignored. The implementation in CanonicalizeBorrowScopes.cpp is new. Although it looks like a big diff, it is now *much* easier to review the source itself. The design changes are described in the commit message.
