### PR TITLE
[5.5][Sema] Properly handle generics in enum Codable synthesis

### DIFF
--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -1146,8 +1146,9 @@ deriveBodyEncodable_enum_encode(AbstractFunctionDecl *encodeDecl, void *) {
     }
 
     // generate: case .<Case>:
+    auto enumType = funcDC->mapTypeIntoContext(enumDecl->getDeclaredInterfaceType());
     auto pat = new (C) EnumElementPattern(
-        TypeExpr::createImplicit(enumDecl->getDeclaredType(), C), SourceLoc(),
+        TypeExpr::createImplicit(enumType, C), SourceLoc(),
         DeclNameLoc(), DeclNameRef(), elt, subpattern);
     pat->setImplicit();
 

--- a/test/decl/protocol/special/coding/enum_codable_nested_generics.swift
+++ b/test/decl/protocol/special/coding/enum_codable_nested_generics.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Container<Element> {
+    let options: [Option]
+}
+
+extension Container {
+    enum Option {
+        case first (Element)
+        case second (Element)
+    }
+}
+
+extension Container: Codable where Element: Codable {}
+extension Container.Option: Codable where Element: Codable {}


### PR DESCRIPTION
- Explanation: Type was not properly mapped into the function context, leading to type errors when using generics.
- Scope: Codable synthesis for enums
- Reviewer: @ktoso
- Issue: rdar://79916494
- Risk: Small
- Testing: added regression test
- Original PR: N/A

This issue is not present on main, because the code has been refactored, which eliminated the issue before the problem was noticed.