### PR TITLE
[Test] Disable Interpreter/SDK/objc_bridge_cast.swift and Interpreter/SDK/objc_dealloc.swift.

### DIFF
--- a/test/Interpreter/SDK/objc_bridge_cast.swift
+++ b/test/Interpreter/SDK/objc_bridge_cast.swift
@@ -2,6 +2,7 @@
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop
+// REQUIRES: rdar80079617
 
 // Test dynamic casts that bridge value types through the runtime.
 

--- a/test/Interpreter/SDK/objc_dealloc.swift
+++ b/test/Interpreter/SDK/objc_dealloc.swift
@@ -2,6 +2,7 @@
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop
+// REQUIRES: rdar80079617
 
 import Foundation
 


### PR DESCRIPTION
These tests are failing intermittently. Disabling them to keep PR testing happy while we figure out why.

rdar://80079617