### PR TITLE
[Async Refactoring] Split ambiguous (error + success) completion handler calls into success and error case

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -6111,8 +6111,7 @@ private:
 
         // fatalError(...)
         OS << "fatalError" << tok::l_paren;
-        OS << "\"Expected non-nil success param '" << Name;
-        OS << "' for nil error\"";
+        OS << "\"Expected non-nil result '" << Name << "' for nil error\"";
         OS << tok::r_paren << "\n";
 
         // End guard.
@@ -6903,8 +6902,7 @@ private:
         }
         OS << ' ' << tok::kw_else << ' ' << tok::l_brace << '\n';
         OS << "fatalError" << tok::l_paren;
-        OS << "\"Expected non-nil success argument '" << ArgName;
-        OS << "' for nil error\"";
+        OS << "\"Expected non-nil result '" << ArgName << "' for nil error\"";
         OS << tok::r_paren << '\n';
         OS << tok::r_brace << '\n';
       }

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -6902,7 +6902,11 @@ private:
         }
         OS << ' ' << tok::kw_else << ' ' << tok::l_brace << '\n';
         OS << "fatalError" << tok::l_paren;
-        OS << "\"Expected non-nil result '" << ArgName << "' for nil error\"";
+        OS << "\"Expected non-nil result ";
+        if (ArgName.str() != "result") {
+          OS << "'" << ArgName << "' ";
+        }
+        OS << "in the non-error case\"";
         OS << tok::r_paren << '\n';
         OS << tok::r_brace << '\n';
       }

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -4268,17 +4268,51 @@ struct AsyncHandlerDesc {
     return nullptr;
   }
 
+  /// Returns \c true if the call to the completion handler contains possibly
+  /// non-nil values for both the success and error parameters, e.g.
+  /// \code
+  ///   completion(result, error)
+  /// \endcode
+  /// This can only happen if the completion handler is a params handler.
+  bool isAmbiguousCallToParamHandler(const CallExpr *CE) const {
+    if (!HasError || Type != HandlerType::PARAMS) {
+      // Only param handlers with an error can pass both an error AND a result.
+      return false;
+    }
+    auto Args = callArgs(CE).ref();
+    if (!isa<NilLiteralExpr>(Args.back())) {
+      // We've got an error parameter. If any of the success params is not nil,
+      // the call is ambiguous.
+      for (auto &Arg : Args.drop_back()) {
+        if (!isa<NilLiteralExpr>(Arg)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   /// Given a call to the `Handler`, extract the expressions to be returned or
   /// thrown, taking care to remove the `.success`/`.failure` if it's a
   /// `RESULT` handler type.
-  HandlerResult extractResultArgs(const CallExpr *CE) const {
+  /// If the call is ambiguous (contains potentially non-nil arguments to both
+  /// the result and the error parameters), the \p ReturnErrorArgsIfAmbiguous
+  /// determines whether the success or error parameters are passed.
+  HandlerResult extractResultArgs(const CallExpr *CE,
+                                  bool ReturnErrorArgsIfAmbiguous) const {
     auto ArgList = callArgs(CE);
     auto Args = ArgList.ref();
 
     if (Type == HandlerType::PARAMS) {
-      // If there's an error parameter and the user isn't passing nil to it,
-      // assume this is the error path.
-      if (HasError && !isa<NilLiteralExpr>(Args.back()))
+      bool IsErrorResult;
+      if (isAmbiguousCallToParamHandler(CE)) {
+        IsErrorResult = ReturnErrorArgsIfAmbiguous;
+      } else {
+        // If there's an error parameter and the user isn't passing nil to it,
+        // assume this is the error path.
+        IsErrorResult = (HasError && !isa<NilLiteralExpr>(Args.back()));
+      }
+      if (IsErrorResult)
         return HandlerResult(Args.back(), true);
 
       // We can drop the args altogether if they're just Void.
@@ -6360,9 +6394,10 @@ private:
     } else if (CallExpr *CE = TopHandler.getAsHandlerCall(E)) {
       if (Scopes.back().isWrappedInContination()) {
         return addCustom(E->getSourceRange(),
-                         [&]() { addHandlerCallToContinuation(CE); });
+                         [&]() { convertHandlerToContinuationResume(CE); });
       } else if (NestedExprCount == 0) {
-        return addCustom(E->getSourceRange(), [&]() { addHandlerCall(CE); });
+        return addCustom(E->getSourceRange(),
+                         [&]() { convertHandlerToReturnOrThrows(CE); });
       }
     } else if (auto *CE = dyn_cast<CallExpr>(E)) {
       // Try and hoist a call's completion handler. Don't do so if
@@ -6588,14 +6623,137 @@ private:
 
   void addDo() { OS << tok::kw_do << " " << tok::l_brace << "\n"; }
 
-  void addHandlerCall(const CallExpr *CE) {
-    assert(TopHandler.getAsHandlerCall(const_cast<CallExpr *>(CE)) == CE &&
-           "addHandlerCall must be used with a call to the TopHandler's "
-           "completion handler");
-    auto Exprs = TopHandler.extractResultArgs(CE);
+  /// Assuming that \p Result represents an error result to completion handler,
+  /// returns \c true if the error has already been handled through a
+  /// 'try await'.
+  bool isErrorAlreadyHandled(HandlerResult Result) {
+    assert(Result.isError());
+    assert(Result.args().size() == 1 &&
+           "There should only be one error parameter");
+    // We assume that the error has already been handled if its variable
+    // declaration doesn't exist anymore, which is the case if it's in
+    // Placeholders but not in Unwraps (if it's in Placeholders and Unwraps
+    // an optional Error has simply been promoted to a non-optional Error).
+    if (auto DRE = dyn_cast<DeclRefExpr>(Result.args().back())) {
+      if (Placeholders.count(DRE->getDecl()) &&
+          !Unwraps.count(DRE->getDecl())) {
+        return true;
+      }
+    }
+    return false;
+  }
 
+  /// Returns \c true if the source representation of \p E can be interpreted
+  /// as an expression returning an Optional value.
+  bool isExpressionOptional(Expr *E) {
+    if (isa<InjectIntoOptionalExpr>(E)) {
+      // E is downgrading a non-Optional result to an Optional. Its source
+      // representation isn't Optional.
+      return false;
+    }
+    if (auto DRE = dyn_cast<DeclRefExpr>(E)) {
+      if (Unwraps.count(DRE->getDecl())) {
+        // E has been promoted to a non-Optional value. It can't be used as an
+        // Optional anymore.
+        return false;
+      }
+    }
+    if (!E->getType().isNull() && E->getType()->isOptional()) {
+      return true;
+    }
+    // We couldn't determine the type. Assume non-Optional.
+    return false;
+  }
+
+  /// Converts a call \p CE to a completion handler. Depending on the call it
+  /// will be interpreted as a call that's returning a success result, an error
+  /// or, if the call is completely ambiguous, adds an if-let that checks if the
+  /// error is \c nil at runtime and dispatches to the success or error case
+  /// depending on it.
+  /// \p AddConvertedHandlerCall needs to add the converted version of the
+  /// completion handler. Depending on the given \c HandlerResult, it must be
+  /// intepreted as a success or error call.
+  /// \p AddConvertedErrorCall must add the converted equivalent of returning an
+  /// error. The passed \c StringRef contains the name of a variable that is of
+  /// type 'Error'.
+  void convertHandlerCall(
+      const CallExpr *CE,
+      llvm::function_ref<void(HandlerResult)> AddConvertedHandlerCall,
+      llvm::function_ref<void(StringRef)> AddConvertedErrorCall) {
+    auto Result =
+        TopHandler.extractResultArgs(CE, /*ReturnErrorArgsIfAmbiguous=*/true);
+    if (!TopHandler.isAmbiguousCallToParamHandler(CE)) {
+      if (Result.isError()) {
+        if (!isErrorAlreadyHandled(Result)) {
+          // If the error has already been handled, we don't need to add another
+          // throwing call.
+          AddConvertedHandlerCall(Result);
+        }
+      } else {
+        AddConvertedHandlerCall(Result);
+      }
+    } else {
+      assert(Result.isError() && "If the call was ambiguous, we should have "
+                                 "retrieved its error representation");
+      assert(Result.args().size() == 1 &&
+             "There should only be one error parameter");
+      Expr *ErrorExpr = Result.args().back();
+      if (isErrorAlreadyHandled(Result)) {
+        // The error has already been handled, interpret the call as a success
+        // call.
+        auto SuccessExprs = TopHandler.extractResultArgs(
+            CE, /*ReturnErrorArgsIfAmbiguous=*/false);
+        AddConvertedHandlerCall(SuccessExprs);
+      } else if (!isExpressionOptional(ErrorExpr)) {
+        // The error is never nil. No matter what the success param is, we
+        // interpret it as an error call.
+        AddConvertedHandlerCall(Result);
+      } else {
+        // The call was truly ambiguous. Add an
+        // if let error = <convert error arg> {
+        //   throw error // or equivalent
+        // } else {
+        //   <interpret call as success call>
+        // }
+        auto SuccessExprs = TopHandler.extractResultArgs(
+            CE, /*ReturnErrorArgsIfAmbiguous=*/false);
+
+        // The variable 'error' is only available in the 'if let' scope, so we
+        // don't need to create a new unique one.
+        StringRef ErrorName = "error";
+        OS << tok::kw_if << ' ' << tok::kw_let << ' ' << ErrorName << ' '
+           << tok::equal << ' ';
+        convertNode(ErrorExpr, /*StartOverride=*/{}, /*ConvertCalls=*/false);
+        OS << ' ' << tok::l_brace << '\n';
+        AddConvertedErrorCall(ErrorName);
+        OS << tok::r_brace << ' ' << tok::kw_else << ' ' << tok::l_brace
+           << '\n';
+        AddConvertedHandlerCall(SuccessExprs);
+        OS << '\n' << tok::r_brace;
+      }
+    }
+  }
+
+  /// Convert a call \p CE to a completion handler to its 'return' or 'throws'
+  /// equivalent.
+  void convertHandlerToReturnOrThrows(const CallExpr *CE) {
+    return convertHandlerCall(
+        CE,
+        [&](HandlerResult Exprs) {
+          convertHandlerToReturnOrThrowsImpl(CE, Exprs);
+        },
+        [&](StringRef ErrorName) {
+          OS << tok::kw_throw << ' ' << ErrorName << '\n';
+        });
+  }
+
+  /// Convert the call \p CE to a completion handler to its 'return' or 'throws'
+  /// equivalent, where \p Result determines whether the call should be
+  /// interpreted as an error or success call.
+  void convertHandlerToReturnOrThrowsImpl(const CallExpr *CE,
+                                          HandlerResult Result) {
     bool AddedReturnOrThrow = true;
-    if (!Exprs.isError()) {
+    if (!Result.isError()) {
       // It's possible the user has already written an explicit return statement
       // for the completion handler call, e.g 'return completion(args...)'. In
       // that case, be sure not to add another return.
@@ -6611,12 +6769,40 @@ private:
       OS << tok::kw_throw;
     }
 
-    ArrayRef<Expr *> Args = Exprs.args();
+    ArrayRef<Expr *> Args = Result.args();
     if (!Args.empty()) {
       if (AddedReturnOrThrow)
-        OS << " ";
+        OS << ' ';
       unsigned I = 0;
       addTupleOf(Args, OS, [&](Expr *Elt) {
+        // Special case: If the completion handler is a params handler that
+        // takes an error, we could pass arguments to it without unwrapping
+        // them. E.g.
+        //   simpleWithError { (res: String?, error: Error?) in
+        //     completion(res, nil)
+        //   }
+        // But after refactoring `simpleWithError` to an async function we have
+        //   let res: String = await simple()
+        // and `res` is no longer an `Optional`. Thus it's in `Placeholders` and
+        // `Unwraps` and any reference to it will be replaced by a placeholder
+        // unless it is wrapped in an unwrapping expression. This would cause us
+        // to create `return <#res# >`.
+        // Under our assumption that either the error or the result parameter
+        // are non-nil, the above call to the completion handler is equivalent
+        // to
+        //   completion(res!, nil)
+        // which correctly yields
+        //   return res
+        // Synthesize the force unwrap so that we get the expected results.
+        if (TopHandler.getHandlerType() == HandlerType::PARAMS &&
+            TopHandler.HasError) {
+          if (auto DRE = dyn_cast<DeclRefExpr>(Elt)) {
+            auto D = DRE->getDecl();
+            if (Unwraps.count(D)) {
+              Elt = new (getASTContext()) ForceValueExpr(Elt, SourceLoc());
+            }
+          }
+        }
         // Can't just add the range as we need to perform replacements
         convertNode(Elt, /*StartOverride=*/CE->getArgumentLabelLoc(I),
                     /*ConvertCalls=*/false);
@@ -6625,22 +6811,36 @@ private:
     }
   }
 
-  /// Assuming that \p CE is a call to \c TopHandler's completion handler and
-  /// that the current scope is wrapped in a continuation, replace it with a
-  /// call to the continuation.
-  void addHandlerCallToContinuation(const CallExpr *CE) {
-    assert(TopHandler.getAsHandlerCall(const_cast<CallExpr *>(CE)) == CE &&
-           "addHandlerCallToContinuation must be used with a call to the "
-           "TopHandler's completion handler");
+  /// Convert a call \p CE to a completion handler to resumes of the
+  /// continuation that's currently on top of the stack.
+  void convertHandlerToContinuationResume(const CallExpr *CE) {
+    return convertHandlerCall(
+        CE,
+        [&](HandlerResult Exprs) {
+          convertHandlerToContinuationResumeImpl(CE, Exprs);
+        },
+        [&](StringRef ErrorName) {
+          Identifier ContinuationName = Scopes.back().ContinuationName;
+          OS << ContinuationName << tok::period << "resume" << tok::l_paren
+             << "throwing" << tok::colon << ' ' << ErrorName;
+          OS << tok::r_paren << '\n';
+        });
+  }
+
+  /// Convert a call \p CE to a completion handler to resumes of the
+  /// continuation that's currently on top of the stack.
+  /// \p Result determines whether the call should be interpreted as a success
+  /// or error call.
+  void convertHandlerToContinuationResumeImpl(const CallExpr *CE,
+                                              HandlerResult Result) {
     assert(Scopes.back().isWrappedInContination());
 
     std::vector<Expr *> Args;
     StringRef ResumeArgumentLabel;
     switch (TopHandler.getHandlerType()) {
     case HandlerType::PARAMS: {
-      auto Exprs = TopHandler.extractResultArgs(CE);
-      Args = Exprs.args();
-      if (!Exprs.isError()) {
+      Args = Result.args();
+      if (!Result.isError()) {
         ResumeArgumentLabel = "returning";
       } else {
         ResumeArgumentLabel = "throwing";
@@ -6656,16 +6856,85 @@ private:
       llvm_unreachable("Invalid top handler");
     }
 
+    // A vector in which each argument of Result has an entry. If the entry is
+    // not empty then that argument has been unwrapped using 'guard let' into
+    // a variable with that name.
+    SmallVector<Identifier, 4> ArgNames;
+    ArgNames.reserve(Args.size());
+
+    /// When unwrapping a result argument \p Arg into a variable using
+    /// 'guard let' return a suitable name for the unwrapped variable.
+    /// \p ArgIndex is the index of \p Arg in the results passed to the
+    /// completion handler.
+    auto GetSuitableNameForGuardUnwrap = [&](Expr *Arg,
+                                             unsigned ArgIndex) -> Identifier {
+      // If Arg is a DeclRef, use its name for the guard unwrap.
+      // guard let myVar1 = myVar.
+      if (auto DRE = dyn_cast<DeclRefExpr>(Arg)) {
+        return createUniqueName(DRE->getDecl()->getBaseIdentifier().str());
+      } else if (auto IIOE = dyn_cast<InjectIntoOptionalExpr>(Arg)) {
+        if (auto DRE = dyn_cast<DeclRefExpr>(IIOE->getSubExpr())) {
+          return createUniqueName(DRE->getDecl()->getBaseIdentifier().str());
+        }
+      }
+      if (Args.size() == 1) {
+        // We only have a single result. 'result' seems a resonable name.
+        return createUniqueName("result");
+      } else {
+        // We are returning a tuple. Name the result elements 'result' +
+        // index in tuple.
+        return createUniqueName("result" + std::to_string(ArgIndex));
+      }
+    };
+
+    unsigned ArgIndex = 0;
+    for (auto Arg : Args) {
+      Identifier ArgName;
+      if (isExpressionOptional(Arg) && TopHandler.HasError) {
+        ArgName = GetSuitableNameForGuardUnwrap(Arg, ArgIndex);
+        Scopes.back().Names.insert(ArgName);
+        OS << tok::kw_guard << ' ' << tok::kw_let << ' ' << ArgName << ' '
+           << tok::equal << ' ';
+        convertNode(Arg, /*StartOverride=*/CE->getArgumentLabelLoc(ArgIndex),
+                    /*ConvertCalls=*/false);
+        if (auto CE = dyn_cast<CallExpr>(Arg)) {
+          if (CE->hasTrailingClosure()) {
+            // If the argument is a call with trailing closure, the generated
+            // guard statement does not compile.
+            // e.g. 'guard let result1 = value.map { $0 + 1 } else { ... }'
+            // doesn't compile.
+            // Adding a '.self' at the end makes the code compile (although it
+            // will still issue a warning about a trailing closure use inside a
+            // guard condition).
+            OS << tok::period << tok::kw_self;
+          }
+        }
+        OS << ' ' << tok::kw_else << ' ' << tok::l_brace << '\n';
+        OS << "fatalError" << tok::l_paren;
+        OS << "\"Expected non-nil success argument '" << ArgName;
+        OS << "' for nil error\"";
+        OS << tok::r_paren << '\n';
+        OS << tok::r_brace << '\n';
+      }
+      ArgNames.push_back(ArgName);
+      ArgIndex++;
+    }
+
     Identifier ContName = Scopes.back().ContinuationName;
     OS << ContName << tok::period << "resume" << tok::l_paren
        << ResumeArgumentLabel << tok::colon << ' ';
 
-    unsigned I = 0;
+    ArgIndex = 0;
     addTupleOf(Args, OS, [&](Expr *Elt) {
-      // Can't just add the range as we need to perform replacements
-      convertNode(Elt, /*StartOverride=*/CE->getArgumentLabelLoc(I),
-                  /*ConvertCalls=*/false);
-      I++;
+      Identifier ArgName = ArgNames[ArgIndex];
+      if (!ArgName.empty()) {
+        OS << ArgName;
+      } else {
+        // Can't just add the range as we need to perform replacements
+        convertNode(Elt, /*StartOverride=*/CE->getArgumentLabelLoc(ArgIndex),
+                    /*ConvertCalls=*/false);
+      }
+      ArgIndex++;
     });
     OS << tok::r_paren;
   }
@@ -6834,7 +7103,8 @@ private:
     if (ErrorNodes.size() == 1) {
       auto Node = ErrorNodes[0];
       if (auto *HandlerCall = TopHandler.getAsHandlerCall(Node)) {
-        auto Res = TopHandler.extractResultArgs(HandlerCall);
+        auto Res = TopHandler.extractResultArgs(
+            HandlerCall, /*ReturnErrorArgsIfAmbiguous=*/true);
         if (Res.args().size() == 1) {
           // Skip if we have the param itself or the name it's bound to
           auto *SingleDecl = Res.args()[0]->getReferencedDecl().getDecl();

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -6082,17 +6082,9 @@ private:
         OS << *ErrName << " " << tok::equal << " " << *ErrName << " ";
         OS << tok::l_brace << "\n";
         for (auto Idx : indices(SuccessParamNames)) {
-          auto &Name = SuccessParamNames[Idx];
           auto ParamTy = SuccessParams[Idx].getParameterType();
           if (!HandlerDesc.shouldUnwrap(ParamTy))
             continue;
-
-          // assert(res == nil, "Expected nil-success param 'res' for non-nil
-          //                     error")
-          OS << "assert" << tok::l_paren << Name << " == " << tok::kw_nil;
-          OS << tok::comma << " \"Expected nil success param '" << Name;
-          OS << "' for non-nil error\"";
-          OS << tok::r_paren << "\n";
         }
 
         // continuation.resume(throwing: err)

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -6634,7 +6634,7 @@ private:
            "TopHandler's completion handler");
     assert(Scopes.back().isWrappedInContination());
 
-    ArrayRef<Expr *> Args;
+    std::vector<Expr *> Args;
     StringRef ResumeArgumentLabel;
     switch (TopHandler.getHandlerType()) {
     case HandlerType::PARAMS: {

--- a/test/refactoring/ConvertAsync/convert_async_wrapper.swift
+++ b/test/refactoring/ConvertAsync/convert_async_wrapper.swift
@@ -85,7 +85,6 @@ func foo6(_ completion: @escaping (String?, Error?) -> Void) {}
 // FOO6-NEXT:   return try await withCheckedThrowingContinuation { continuation in
 // FOO6-NEXT:     foo6() { result, error in
 // FOO6-NEXT:       if let error = error {
-// FOO6-NEXT:         assert(result == nil, "Expected nil success param 'result' for non-nil error")
 // FOO6-NEXT:         continuation.resume(throwing: error)
 // FOO6-NEXT:         return
 // FOO6-NEXT:       }
@@ -104,7 +103,6 @@ func foo7(_ completion: @escaping (String?, Int, Error?) -> Void) {}
 // FOO7-NEXT:   return try await withCheckedThrowingContinuation { continuation in
 // FOO7-NEXT:     foo7() { result1, result2, error in
 // FOO7-NEXT:       if let error = error {
-// FOO7-NEXT:         assert(result1 == nil, "Expected nil success param 'result1' for non-nil error")
 // FOO7-NEXT:         continuation.resume(throwing: error)
 // FOO7-NEXT:         return
 // FOO7-NEXT:       }
@@ -123,8 +121,6 @@ func foo8(_ completion: @escaping (String?, Int?, Error?) -> Void) {}
 // FOO8-NEXT:   return try await withCheckedThrowingContinuation { continuation in
 // FOO8-NEXT:     foo8() { result1, result2, error in
 // FOO8-NEXT:       if let error = error {
-// FOO8-NEXT:         assert(result1 == nil, "Expected nil success param 'result1' for non-nil error")
-// FOO8-NEXT:         assert(result2 == nil, "Expected nil success param 'result2' for non-nil error")
 // FOO8-NEXT:         continuation.resume(throwing: error)
 // FOO8-NEXT:         return
 // FOO8-NEXT:       }

--- a/test/refactoring/ConvertAsync/convert_async_wrapper.swift
+++ b/test/refactoring/ConvertAsync/convert_async_wrapper.swift
@@ -89,7 +89,7 @@ func foo6(_ completion: @escaping (String?, Error?) -> Void) {}
 // FOO6-NEXT:         return
 // FOO6-NEXT:       }
 // FOO6-NEXT:       guard let result = result else {
-// FOO6-NEXT:         fatalError("Expected non-nil success param 'result' for nil error")
+// FOO6-NEXT:         fatalError("Expected non-nil result 'result' for nil error")
 // FOO6-NEXT:       }
 // FOO6-NEXT:       continuation.resume(returning: result)
 // FOO6-NEXT:     }
@@ -107,7 +107,7 @@ func foo7(_ completion: @escaping (String?, Int, Error?) -> Void) {}
 // FOO7-NEXT:         return
 // FOO7-NEXT:       }
 // FOO7-NEXT:       guard let result1 = result1 else {
-// FOO7-NEXT:         fatalError("Expected non-nil success param 'result1' for nil error")
+// FOO7-NEXT:         fatalError("Expected non-nil result 'result1' for nil error")
 // FOO7-NEXT:       }
 // FOO7-NEXT:       continuation.resume(returning: (result1, result2))
 // FOO7-NEXT:     }
@@ -125,10 +125,10 @@ func foo8(_ completion: @escaping (String?, Int?, Error?) -> Void) {}
 // FOO8-NEXT:         return
 // FOO8-NEXT:       }
 // FOO8-NEXT:       guard let result1 = result1 else {
-// FOO8-NEXT:         fatalError("Expected non-nil success param 'result1' for nil error")
+// FOO8-NEXT:         fatalError("Expected non-nil result 'result1' for nil error")
 // FOO8-NEXT:       }
 // FOO8-NEXT:       guard let result2 = result2 else {
-// FOO8-NEXT:         fatalError("Expected non-nil success param 'result2' for nil error")
+// FOO8-NEXT:         fatalError("Expected non-nil result 'result2' for nil error")
 // FOO8-NEXT:       }
 // FOO8-NEXT:       continuation.resume(returning: (result1, result2))
 // FOO8-NEXT:     }

--- a/test/refactoring/ConvertAsync/convert_function.swift
+++ b/test/refactoring/ConvertAsync/convert_function.swift
@@ -10,6 +10,9 @@ func simpleErr(arg: String, _ completion: (String?, Error?) -> Void) { }
 func simpleRes(arg: String, _ completion: (Result<String, Error>) -> Void) { }
 func run(block: () -> Bool) -> Bool { return false }
 
+func makeOptionalError() -> Error? { return nil }
+func makeOptionalString() -> String? { return nil }
+
 // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NESTED %s
 func nested() {
   simple {
@@ -295,6 +298,27 @@ func testReturnHandling3(_ completion: (String?, Error?) -> Void) {
 // RETURN-HANDLING3-NEXT:   {{^}} return ""{{$}}
 // RETURN-HANDLING3-NEXT: }
 
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=RETURN-HANDLING4 %s
+func testReturnHandling4(_ completion: (String?, Error?) -> Void) {
+  simpleErr(arg: "xxx") { str, err in
+    if str != nil {
+      completion(str, err)
+      return
+    }
+    print("some error stuff")
+    completion(str, err)
+  }
+}
+// RETURN-HANDLING4:      func testReturnHandling4() async throws -> String {
+// RETURN-HANDLING4-NEXT:   do {
+// RETURN-HANDLING4-NEXT:     let str = try await simpleErr(arg: "xxx")
+// RETURN-HANDLING4-NEXT:     return str
+// RETURN-HANDLING4-NEXT:   } catch let err {
+// RETURN-HANDLING4-NEXT:     print("some error stuff")
+// RETURN-HANDLING4-NEXT:     throw err
+// RETURN-HANDLING4-NEXT:   }
+// RETURN-HANDLING4-NEXT: }
+
 // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=RDAR78693050 %s
 func rdar78693050(_ completion: () -> Void) {
   simple { str in
@@ -343,3 +367,233 @@ func withImplicitReturn(completionHandler: (String) -> Void) {
 // IMPLICIT-RETURN-NEXT:   let val0 = await simple()
 // IMPLICIT-RETURN-NEXT:   return val0
 // IMPLICIT-RETURN-NEXT: }
+
+// This code doesn't compile after refactoring because we can't return `nil` from the async function. 
+// But there's not much else we can do here.
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NIL-RESULT-AND-NIL-ERROR %s
+func nilResultAndNilError(completion: (String?, Error?) -> Void) {
+  completion(nil, nil)
+}
+// NIL-RESULT-AND-NIL-ERROR:      func nilResultAndNilError() async throws -> String {
+// NIL-RESULT-AND-NIL-ERROR-NEXT:   return nil
+// NIL-RESULT-AND-NIL-ERROR-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NIL-RESULT-AND-OPTIONAL-RELAYED-ERROR %s
+func nilResultAndOptionalRelayedError(completion: (String?, Error?) -> Void) {
+  simpleErr(arg: "test") { (res, err) in
+    completion(nil, err)
+  }
+}
+// NIL-RESULT-AND-OPTIONAL-RELAYED-ERROR:      func nilResultAndOptionalRelayedError() async throws -> String {
+// NIL-RESULT-AND-OPTIONAL-RELAYED-ERROR-NEXT:   let res = try await simpleErr(arg: "test")
+// NIL-RESULT-AND-OPTIONAL-RELAYED-ERROR-EMPTY:
+// NIL-RESULT-AND-OPTIONAL-RELAYED-ERROR-NEXT: }
+
+// This code doesn't compile after refactoring because we can't throw an optional error returned from makeOptionalError().
+// But it's not clear what the intended result should be either.
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NIL-RESULT-AND-OPTIONAL-COMPLEX-ERROR %s
+func nilResultAndOptionalComplexError(completion: (String?, Error?) -> Void) {
+  completion(nil, makeOptionalError())
+}
+// NIL-RESULT-AND-OPTIONAL-COMPLEX-ERROR:      func nilResultAndOptionalComplexError() async throws -> String {
+// NIL-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:   throw makeOptionalError()
+// NIL-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NIL-RESULT-AND-NON-OPTIONAL-ERROR %s
+func nilResultAndNonOptionalError(completion: (String?, Error?) -> Void) {
+  completion(nil, CustomError.Bad)
+}
+// NIL-RESULT-AND-NON-OPTIONAL-ERROR:      func nilResultAndNonOptionalError() async throws -> String {
+// NIL-RESULT-AND-NON-OPTIONAL-ERROR-NEXT:   throw CustomError.Bad
+// NIL-RESULT-AND-NON-OPTIONAL-ERROR-NEXT: }
+
+// In this case, we are previously ignoring the error returned from simpleErr but are rethrowing it in the refactored case. 
+// That's probably fine although it changes semantics.
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=OPTIONAL-RELAYED-RESULT-AND-NIL-ERROR %s
+func optionalRelayedResultAndNilError(completion: (String?, Error?) -> Void) {
+  simpleErr(arg: "test") { (res, err) in
+    completion(res, nil)
+  }
+}
+// OPTIONAL-RELAYED-RESULT-AND-NIL-ERROR:      func optionalRelayedResultAndNilError() async throws -> String {
+// OPTIONAL-RELAYED-RESULT-AND-NIL-ERROR-NEXT:   let res = try await simpleErr(arg: "test")
+// OPTIONAL-RELAYED-RESULT-AND-NIL-ERROR-NEXT:   return res
+// OPTIONAL-RELAYED-RESULT-AND-NIL-ERROR-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-RELAYED-ERROR %s
+func optionalRelayedResultAndOptionalRelayedError(completion: (String?, Error?) -> Void) {
+  simpleErr(arg: "test") { (res, err) in
+    completion(res, err)
+  }
+}
+// OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-RELAYED-ERROR:      func optionalRelayedResultAndOptionalRelayedError() async throws -> String {
+// OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-RELAYED-ERROR-NEXT:   let res = try await simpleErr(arg: "test")
+// OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-RELAYED-ERROR-NEXT:   return res
+// OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-RELAYED-ERROR-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-COMPLEX-ERROR %s
+func optionalRelayedResultAndOptionalComplexError(completion: (String?, Error?) -> Void) {
+  simpleErr(arg: "test") { (res, err) in
+    completion(res, makeOptionalError())
+  }
+}
+// OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-COMPLEX-ERROR:      func optionalRelayedResultAndOptionalComplexError() async throws -> String {
+// OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:   let res = try await simpleErr(arg: "test")
+// OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:   if let error = makeOptionalError() {
+// OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:     throw error
+// OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:   } else {
+// OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:     return res
+// OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:   }
+// OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=OPTIONAL-RELAYED-RESULT-AND-NON-OPTIONAL-ERROR %s
+func optionalRelayedResultAndNonOptionalError(completion: (String?, Error?) -> Void) {
+  simpleErr(arg: "test") { (res, err) in
+    completion(res, CustomError.Bad)
+  }
+}
+// OPTIONAL-RELAYED-RESULT-AND-NON-OPTIONAL-ERROR:      func optionalRelayedResultAndNonOptionalError() async throws -> String {
+// OPTIONAL-RELAYED-RESULT-AND-NON-OPTIONAL-ERROR-NEXT:   let res = try await simpleErr(arg: "test")
+// OPTIONAL-RELAYED-RESULT-AND-NON-OPTIONAL-ERROR-NEXT:   throw CustomError.Bad
+// OPTIONAL-RELAYED-RESULT-AND-NON-OPTIONAL-ERROR-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NON-OPTIONAL-RELAYED-RESULT-AND-NIL-ERROR %s
+func nonOptionalRelayedResultAndNilError(completion: (String?, Error?) -> Void) {
+  simple { res in
+    completion(res, nil)
+  }
+}
+// NON-OPTIONAL-RELAYED-RESULT-AND-NIL-ERROR:      func nonOptionalRelayedResultAndNilError() async throws -> String {
+// NON-OPTIONAL-RELAYED-RESULT-AND-NIL-ERROR-NEXT:   let res = await simple()
+// NON-OPTIONAL-RELAYED-RESULT-AND-NIL-ERROR-NEXT:   return res
+// NON-OPTIONAL-RELAYED-RESULT-AND-NIL-ERROR-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NON-OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-COMPLEX-ERROR %s
+func nonOptionalRelayedResultAndOptionalComplexError(completion: (String?, Error?) -> Void) {
+  simple { res in
+    completion(res, makeOptionalError())
+  }
+}
+// NON-OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-COMPLEX-ERROR:      func nonOptionalRelayedResultAndOptionalComplexError() async throws -> String {
+// NON-OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:   let res = await simple()
+// NON-OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:   if let error = makeOptionalError() {
+// NON-OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:     throw error
+// NON-OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:   } else {
+// NON-OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:     return res
+// NON-OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:   }
+// NON-OPTIONAL-RELAYED-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NON-OPTIONAL-RELAYED-RESULT-AND-NON-OPTIONAL-ERROR %s
+func nonOptionalRelayedResultAndNonOptionalError(completion: (String?, Error?) -> Void) {
+  simple { res in
+    completion(res, CustomError.Bad)
+  }
+}
+// NON-OPTIONAL-RELAYED-RESULT-AND-NON-OPTIONAL-ERROR:      func nonOptionalRelayedResultAndNonOptionalError() async throws -> String {
+// NON-OPTIONAL-RELAYED-RESULT-AND-NON-OPTIONAL-ERROR-NEXT:   let res = await simple()
+// NON-OPTIONAL-RELAYED-RESULT-AND-NON-OPTIONAL-ERROR-NEXT:   throw CustomError.Bad
+// NON-OPTIONAL-RELAYED-RESULT-AND-NON-OPTIONAL-ERROR-NEXT: }
+
+// The refactored code doesn't compile because we can't return an optional String from the async function. 
+// But it's not clear what the intended result should be either, because `error` is always `nil`.
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=OPTIONAL-COMPLEX-RESULT-AND-NIL-ERROR %s
+func optionalComplexResultAndNilError(completion: (String?, Error?) -> Void) {
+  completion(makeOptionalString(), nil)
+}
+// OPTIONAL-COMPLEX-RESULT-AND-NIL-ERROR:      func optionalComplexResultAndNilError() async throws -> String {
+// OPTIONAL-COMPLEX-RESULT-AND-NIL-ERROR-NEXT:   return makeOptionalString()
+// OPTIONAL-COMPLEX-RESULT-AND-NIL-ERROR-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=OPTIONAL-COMPLEX-RESULT-AND-OPTIONAL-RELAYED-ERROR %s
+func optionalComplexResultAndOptionalRelayedError(completion: (String?, Error?) -> Void) {
+  simpleErr(arg: "test") { (res, err) in
+    completion(makeOptionalString(), err)
+  }
+}
+// OPTIONAL-COMPLEX-RESULT-AND-OPTIONAL-RELAYED-ERROR:      func optionalComplexResultAndOptionalRelayedError() async throws -> String {
+// OPTIONAL-COMPLEX-RESULT-AND-OPTIONAL-RELAYED-ERROR-NEXT:   let res = try await simpleErr(arg: "test")
+// OPTIONAL-COMPLEX-RESULT-AND-OPTIONAL-RELAYED-ERROR-NEXT:   return makeOptionalString()
+// OPTIONAL-COMPLEX-RESULT-AND-OPTIONAL-RELAYED-ERROR-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=OPTIONAL-COMPLEX-RESULT-AND-OPTIONAL-COMPLEX-ERROR %s
+func optionalComplexResultAndOptionalComplexError(completion: (String?, Error?) -> Void) {
+  completion(makeOptionalString(), makeOptionalError())
+}
+// OPTIONAL-COMPLEX-RESULT-AND-OPTIONAL-COMPLEX-ERROR:      func optionalComplexResultAndOptionalComplexError() async throws -> String {
+// OPTIONAL-COMPLEX-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:   if let error = makeOptionalError() {
+// OPTIONAL-COMPLEX-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:     throw error
+// OPTIONAL-COMPLEX-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:   } else {
+// OPTIONAL-COMPLEX-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:     return makeOptionalString()
+// OPTIONAL-COMPLEX-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:   }
+// OPTIONAL-COMPLEX-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=OPTIONAL-COMPLEX-RESULT-AND-NON-OPTIONAL-ERROR %s
+func optionalComplexResultAndNonOptionalError(completion: (String?, Error?) -> Void) {
+  completion(makeOptionalString(), CustomError.Bad)
+}
+// OPTIONAL-COMPLEX-RESULT-AND-NON-OPTIONAL-ERROR:      func optionalComplexResultAndNonOptionalError() async throws -> String {
+// OPTIONAL-COMPLEX-RESULT-AND-NON-OPTIONAL-ERROR-NEXT:   throw CustomError.Bad
+// OPTIONAL-COMPLEX-RESULT-AND-NON-OPTIONAL-ERROR-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NON-OPTIONAL-RESULT-AND-NIL-ERROR %s
+func nonOptionalResultAndNilError(completion: (String?, Error?) -> Void) {
+  completion("abc", nil)
+}
+// NON-OPTIONAL-RESULT-AND-NIL-ERROR:      func nonOptionalResultAndNilError() async throws -> String {
+// NON-OPTIONAL-RESULT-AND-NIL-ERROR-NEXT:   return "abc"
+// NON-OPTIONAL-RESULT-AND-NIL-ERROR-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NON-OPTIONAL-RESULT-AND-OPTIONAL-RELAYED-ERROR %s
+func nonOptionalResultAndOptionalRelayedError(completion: (String?, Error?) -> Void) {
+  simpleErr(arg: "test") { (res, err) in
+    completion("abc", err)
+  }
+}
+// NON-OPTIONAL-RESULT-AND-OPTIONAL-RELAYED-ERROR:      func nonOptionalResultAndOptionalRelayedError() async throws -> String {
+// NON-OPTIONAL-RESULT-AND-OPTIONAL-RELAYED-ERROR-NEXT:   let res = try await simpleErr(arg: "test")
+// NON-OPTIONAL-RESULT-AND-OPTIONAL-RELAYED-ERROR-NEXT:   return "abc"
+// NON-OPTIONAL-RESULT-AND-OPTIONAL-RELAYED-ERROR-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NON-OPTIONAL-RESULT-AND-OPTIONAL-COMPLEX-ERROR %s
+func nonOptionalResultAndOptionalComplexError(completion: (String?, Error?) -> Void) {
+  completion("abc", makeOptionalError())
+}
+// NON-OPTIONAL-RESULT-AND-OPTIONAL-COMPLEX-ERROR:      func nonOptionalResultAndOptionalComplexError() async throws -> String {
+// NON-OPTIONAL-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:   if let error = makeOptionalError() {
+// NON-OPTIONAL-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:     throw error
+// NON-OPTIONAL-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:   } else {
+// NON-OPTIONAL-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:     return "abc"
+// NON-OPTIONAL-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT:   }
+// NON-OPTIONAL-RESULT-AND-OPTIONAL-COMPLEX-ERROR-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NON-OPTIONAL-RESULT-AND-NON-OPTIONAL-ERROR %s
+func nonOptionalResultAndNonOptionalError(completion: (String?, Error?) -> Void) {
+  completion("abc", CustomError.Bad)
+}
+// NON-OPTIONAL-RESULT-AND-NON-OPTIONAL-ERROR:      func nonOptionalResultAndNonOptionalError() async throws -> String {
+// NON-OPTIONAL-RESULT-AND-NON-OPTIONAL-ERROR-NEXT:   throw CustomError.Bad
+// NON-OPTIONAL-RESULT-AND-NON-OPTIONAL-ERROR-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=WRAP-COMPLETION-CALL-IN-PARENS %s
+func wrapCompletionCallInParenthesis(completion: (String?, Error?) -> Void) {
+  simpleErr(arg: "test") { (res, err) in
+    (completion(res, err))
+  }
+}
+// WRAP-COMPLETION-CALL-IN-PARENS:      func wrapCompletionCallInParenthesis() async throws -> String {
+// WRAP-COMPLETION-CALL-IN-PARENS-NEXT:   let res = try await simpleErr(arg: "test")
+// WRAP-COMPLETION-CALL-IN-PARENS-NEXT:   return res
+// WRAP-COMPLETION-CALL-IN-PARENS-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=TWO-COMPLETION-HANDLER-CALLS %s
+func twoCompletionHandlerCalls(completion: (String?, Error?) -> Void) {
+  simpleErr(arg: "test") { (res, err) in
+    completion(res, err)
+    completion(res, err)
+  }
+}
+// TWO-COMPLETION-HANDLER-CALLS:      func twoCompletionHandlerCalls() async throws -> String {
+// TWO-COMPLETION-HANDLER-CALLS-NEXT:   let res = try await simpleErr(arg: "test")
+// TWO-COMPLETION-HANDLER-CALLS-NEXT:   return res
+// TWO-COMPLETION-HANDLER-CALLS-NEXT:   return res
+// TWO-COMPLETION-HANDLER-CALLS-NEXT: }

--- a/test/refactoring/ConvertAsync/convert_invalid.swift
+++ b/test/refactoring/ConvertAsync/convert_invalid.swift
@@ -12,3 +12,19 @@ callbackIntWithError { x, err in
 // INVALID-COND-NEXT:   print("ok")
 // INVALID-COND-NEXT: }
 
+
+func withoutAsyncAlternative(closure: (Int) -> Void) {}
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=UNKNOWN-ERROR-IN-CONTINUATION %s
+func testUnknownErrorInContinuation(completionHandler: (Int?, Error?) -> Void) {
+  withoutAsyncAlternative { theValue in
+    completionHandler(theValue, MyUndefinedError())
+  }
+}
+// UNKNOWN-ERROR-IN-CONTINUATION:      func testUnknownErrorInContinuation() async throws -> Int {
+// UNKNOWN-ERROR-IN-CONTINUATION-NEXT:   return try await withCheckedThrowingContinuation { continuation in 
+// UNKNOWN-ERROR-IN-CONTINUATION-NEXT:     withoutAsyncAlternative { theValue in
+// UNKNOWN-ERROR-IN-CONTINUATION-NEXT:       continuation.resume(throwing: MyUndefinedError())
+// UNKNOWN-ERROR-IN-CONTINUATION-NEXT:     }
+// UNKNOWN-ERROR-IN-CONTINUATION-NEXT:   }
+// UNKNOWN-ERROR-IN-CONTINUATION-NEXT: }

--- a/test/refactoring/ConvertAsync/convert_to_continuation.swift
+++ b/test/refactoring/ConvertAsync/convert_to_continuation.swift
@@ -120,7 +120,7 @@ func testThrowingContinuationRelayingErrorAndResult(completionHandler: (Int?, Er
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:         continuation.resume(throwing: error)
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:       } else {
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:         guard let theValue1 = theValue else {
-// THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:           fatalError("Expected non-nil result 'theValue1' for nil error")
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:           fatalError("Expected non-nil result 'theValue1' in the non-error case")
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:         }
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:         continuation.resume(returning: theValue1)
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:       }
@@ -141,7 +141,7 @@ func testThrowingContinuationRelayingErrorAndComplexResult(completionHandler: (I
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:         continuation.resume(throwing: error)
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:       } else {
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:         guard let result = theValue.map({ $0 + 1 }) else {
-// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:           fatalError("Expected non-nil result 'result' for nil error")
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:           fatalError("Expected non-nil result in the non-error case")
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:         }
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:         continuation.resume(returning: result)
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:       }
@@ -162,10 +162,10 @@ func testThrowingContinuationRelayingErrorAndTwoComplexResults(completionHandler
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:         continuation.resume(throwing: error)
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:       } else {
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:         guard let result0 = theValue.map({ $0 + 1 }) else {
-// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:           fatalError("Expected non-nil result 'result0' for nil error")
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:           fatalError("Expected non-nil result 'result0' in the non-error case")
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:         }
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:         guard let result1 = theValue.map({ $0 + 2 }) else {
-// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:           fatalError("Expected non-nil result 'result1' for nil error")
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:           fatalError("Expected non-nil result 'result1' in the non-error case")
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:         }
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:         continuation.resume(returning: (result0, result1))
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:       }
@@ -186,7 +186,7 @@ func testThrowingContinuationRelayingErrorAndComplexResultWithTrailingClosure(co
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:         continuation.resume(throwing: error)
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:       } else {
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:         guard let result = theValue.map { $0 + 1 }.self else {
-// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:           fatalError("Expected non-nil result 'result' for nil error")
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:           fatalError("Expected non-nil result in the non-error case")
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:         }
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:         continuation.resume(returning: result)
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:       }
@@ -461,10 +461,10 @@ func testMultipleReturnValuesAndError(completion: (Int?, String?, Error?) -> Voi
 // MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:         continuation.resume(throwing: error)
 // MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:       } else {
 // MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:         guard let first1 = first else {
-// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:           fatalError("Expected non-nil result 'first1' for nil error")
+// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:           fatalError("Expected non-nil result 'first1' in the non-error case")
 // MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:         }
 // MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:         guard let second1 = second else {
-// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:           fatalError("Expected non-nil result 'second1' for nil error")
+// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:           fatalError("Expected non-nil result 'second1' in the non-error case")
 // MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:         }
 // MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:         continuation.resume(returning: (first1, second1))
 // MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:       }
@@ -496,7 +496,7 @@ func testMixedOptionalAnNonOptionaResults(completion: (Int?, String?, Error?) ->
 // MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:   return try await withCheckedThrowingContinuation { continuation in 
 // MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:     withoutAsyncAlternativeThrowing { (theResult, error) in
 // MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:       guard let theResult1 = theResult else {
-// MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:         fatalError("Expected non-nil result 'theResult1' for nil error")
+// MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:         fatalError("Expected non-nil result 'theResult1' in the non-error case")
 // MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:       }
 // MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:       continuation.resume(returning: (theResult1, "hi"))
 // MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:     }
@@ -514,7 +514,7 @@ func testUseOptionalResultValueAfterCompletionHandlerCall(completion: (Int?, Str
 // USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:   return try await withCheckedThrowingContinuation { continuation in 
 // USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:     withoutAsyncAlternativeThrowing { (theResult, error) in
 // USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:       guard let theResult1 = theResult else {
-// USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:         fatalError("Expected non-nil result 'theResult1' for nil error")
+// USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:         fatalError("Expected non-nil result 'theResult1' in the non-error case")
 // USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:       }
 // USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:       continuation.resume(returning: (theResult1, "hi"))
 // USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:       print(theResult.map { $0 + 1 } as Any)
@@ -533,10 +533,10 @@ func testPassSameResultTwice(completion: (Int?, Int?, Error?) -> Void) {
 // PASS-SAME-RESULT-TWICE-NEXT:   return try await withCheckedThrowingContinuation { continuation in 
 // PASS-SAME-RESULT-TWICE-NEXT:     withoutAsyncAlternativeThrowing { (theResult, error) in
 // PASS-SAME-RESULT-TWICE-NEXT:       guard let theResult1 = theResult else {
-// PASS-SAME-RESULT-TWICE-NEXT:         fatalError("Expected non-nil result 'theResult1' for nil error")
+// PASS-SAME-RESULT-TWICE-NEXT:         fatalError("Expected non-nil result 'theResult1' in the non-error case")
 // PASS-SAME-RESULT-TWICE-NEXT:       }
 // PASS-SAME-RESULT-TWICE-NEXT:       guard let theResult2 = theResult else {
-// PASS-SAME-RESULT-TWICE-NEXT:         fatalError("Expected non-nil result 'theResult2' for nil error")
+// PASS-SAME-RESULT-TWICE-NEXT:         fatalError("Expected non-nil result 'theResult2' in the non-error case")
 // PASS-SAME-RESULT-TWICE-NEXT:       }
 // PASS-SAME-RESULT-TWICE-NEXT:       continuation.resume(returning: (theResult1, theResult2))
 // PASS-SAME-RESULT-TWICE-NEXT:     }
@@ -558,7 +558,7 @@ func testUseResultAfterAmbiguousCompletionHandlerCall(completion: (Int?, Error?)
 // USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:         continuation.resume(throwing: error)
 // USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:       } else {
 // USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:         guard let theResult1 = theResult else {
-// USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:           fatalError("Expected non-nil result 'theResult1' for nil error")
+// USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:           fatalError("Expected non-nil result 'theResult1' in the non-error case")
 // USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:         }
 // USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:         continuation.resume(returning: theResult1)
 // USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:       }
@@ -581,7 +581,7 @@ func testTwoCompletionHandlerCalls(completion: (Int?, Error?) -> Void) {
 // TWO-COMPLEITON-HANDLER-CALLS-NEXT:         continuation.resume(throwing: error)
 // TWO-COMPLEITON-HANDLER-CALLS-NEXT:       } else {
 // TWO-COMPLEITON-HANDLER-CALLS-NEXT:         guard let theResult1 = theResult else {
-// TWO-COMPLEITON-HANDLER-CALLS-NEXT:           fatalError("Expected non-nil result 'theResult1' for nil error")
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:           fatalError("Expected non-nil result 'theResult1' in the non-error case")
 // TWO-COMPLEITON-HANDLER-CALLS-NEXT:         }
 // TWO-COMPLEITON-HANDLER-CALLS-NEXT:         continuation.resume(returning: theResult1)
 // TWO-COMPLEITON-HANDLER-CALLS-NEXT:       }
@@ -589,7 +589,7 @@ func testTwoCompletionHandlerCalls(completion: (Int?, Error?) -> Void) {
 // TWO-COMPLEITON-HANDLER-CALLS-NEXT:         continuation.resume(throwing: error)
 // TWO-COMPLEITON-HANDLER-CALLS-NEXT:       } else {
 // TWO-COMPLEITON-HANDLER-CALLS-NEXT:         guard let theResult2 = theResult else {
-// TWO-COMPLEITON-HANDLER-CALLS-NEXT:           fatalError("Expected non-nil result 'theResult2' for nil error")
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:           fatalError("Expected non-nil result 'theResult2' in the non-error case")
 // TWO-COMPLEITON-HANDLER-CALLS-NEXT:         }
 // TWO-COMPLEITON-HANDLER-CALLS-NEXT:         continuation.resume(returning: theResult2)
 // TWO-COMPLEITON-HANDLER-CALLS-NEXT:       }

--- a/test/refactoring/ConvertAsync/convert_to_continuation.swift
+++ b/test/refactoring/ConvertAsync/convert_to_continuation.swift
@@ -8,9 +8,11 @@ func withAsyncThrowingAlternative() async throws -> Int { return 42 }
 func withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName(closure: (Int) -> Void) {}
 func withoutAsyncAlternativeBecauseOfReturnValue(completionHandler: (Int) -> Void) -> Bool { return true }
 func withoutAsyncAlternativeThrowing(closure: (Int?, Error?) -> Void) {}
+func withoutAsyncAlternativeThrowingWithMultipleResults(closure: (Int?, String?, Error?) -> Void) {}
 func asyncVoidWithoutAlternative(completionHandler2: () -> Void) {}
 func resultWithoutAlternative(completionHandler2: (Result<Int, Error>) -> Void) {}
 
+struct MyError: Error {}
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=CREATE-CONTINUATION %s
 func testCreateContinuation(completionHandler: (Int) -> Void) {
@@ -105,8 +107,7 @@ func testThrowingContinuation(completionHandler: (Int?, Error?) -> Void) {
 // THROWING-CONTINUATION-NEXT:   }
 // THROWING-CONTINUATION-NEXT: }
 
-// We can't relay both the result and the error through the continuation. Converting the following results in a compiler error complaining that theError (of type Error?) can't be passed to `continuation.resume(throwing)`.
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT %s
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT %s
 func testThrowingContinuationRelayingErrorAndResult(completionHandler: (Int?, Error?) -> Void) {
   withoutAsyncAlternativeThrowing { (theValue, theError) in
     completionHandler(theValue, theError)
@@ -115,11 +116,117 @@ func testThrowingContinuationRelayingErrorAndResult(completionHandler: (Int?, Er
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT:      func testThrowingContinuationRelayingErrorAndResult() async throws -> Int {
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:   return try await withCheckedThrowingContinuation { continuation in 
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:     withoutAsyncAlternativeThrowing { (theValue, theError) in
-// THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:       continuation.resume(throwing: theError)
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:       if let error = theError {
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:         continuation.resume(throwing: error)
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:       } else {
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:         guard let theValue1 = theValue else {
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:           fatalError("Expected non-nil success argument 'theValue1' for nil error")
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:         }
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:         continuation.resume(returning: theValue1)
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:       }
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:     }
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:   }
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT: }
 
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT %s
+func testThrowingContinuationRelayingErrorAndComplexResult(completionHandler: (Int?, Error?) -> Void) {
+  withoutAsyncAlternativeThrowing { (theValue, theError) in
+    completionHandler(theValue.map({ $0 + 1 }), theError)
+  }
+}
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT:      func testThrowingContinuationRelayingErrorAndComplexResult() async throws -> Int {
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:   return try await withCheckedThrowingContinuation { continuation in 
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:     withoutAsyncAlternativeThrowing { (theValue, theError) in
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:       if let error = theError {
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:         continuation.resume(throwing: error)
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:       } else {
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:         guard let result = theValue.map({ $0 + 1 }) else {
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:           fatalError("Expected non-nil success argument 'result' for nil error")
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:         }
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:         continuation.resume(returning: result)
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:       }
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:     }
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:   }
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT: }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS %s
+func testThrowingContinuationRelayingErrorAndTwoComplexResults(completionHandler: (Int?, Int?, Error?) -> Void) {
+  withoutAsyncAlternativeThrowing { (theValue, theError) in
+    completionHandler(theValue.map({ $0 + 1 }), theValue.map({ $0 + 2 }), theError)
+  }
+}
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS:      func testThrowingContinuationRelayingErrorAndTwoComplexResults() async throws -> (Int, Int) {
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:   return try await withCheckedThrowingContinuation { continuation in 
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:     withoutAsyncAlternativeThrowing { (theValue, theError) in
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:       if let error = theError {
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:         continuation.resume(throwing: error)
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:       } else {
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:         guard let result0 = theValue.map({ $0 + 1 }) else {
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:           fatalError("Expected non-nil success argument 'result0' for nil error")
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:         }
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:         guard let result1 = theValue.map({ $0 + 2 }) else {
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:           fatalError("Expected non-nil success argument 'result1' for nil error")
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:         }
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:         continuation.resume(returning: (result0, result1))
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:       }
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:     }
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:   }
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE %s
+func testThrowingContinuationRelayingErrorAndComplexResultWithTrailingClosure(completionHandler: (Int?, Error?) -> Void) {
+  withoutAsyncAlternativeThrowing { (theValue, theError) in
+    completionHandler(theValue.map { $0 + 1 }, theError)
+  }
+}
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE:      func testThrowingContinuationRelayingErrorAndComplexResultWithTrailingClosure() async throws -> Int {
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:   return try await withCheckedThrowingContinuation { continuation in 
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:     withoutAsyncAlternativeThrowing { (theValue, theError) in
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:       if let error = theError {
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:         continuation.resume(throwing: error)
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:       } else {
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:         guard let result = theValue.map { $0 + 1 }.self else {
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:           fatalError("Expected non-nil success argument 'result' for nil error")
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:         }
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:         continuation.resume(returning: result)
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:       }
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:     }
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:   }
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT: }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=THROWING-CONTINUATION-ALWAYS-RETURNING-ERROR-AND-RESULT %s
+func testAlwaysReturnBothResultAndCompletionHandler(completionHandler: (Int?, Error?) -> Void) {
+  withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName { theValue in
+    completionHandler(theValue, MyError())
+  }
+}
+// THROWING-CONTINUATION-ALWAYS-RETURNING-ERROR-AND-RESULT:      func testAlwaysReturnBothResultAndCompletionHandler() async throws -> Int {
+// THROWING-CONTINUATION-ALWAYS-RETURNING-ERROR-AND-RESULT-NEXT:   return try await withCheckedThrowingContinuation { continuation in 
+// THROWING-CONTINUATION-ALWAYS-RETURNING-ERROR-AND-RESULT-NEXT:     withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName { theValue in
+// THROWING-CONTINUATION-ALWAYS-RETURNING-ERROR-AND-RESULT-NEXT:       continuation.resume(throwing: MyError())
+// THROWING-CONTINUATION-ALWAYS-RETURNING-ERROR-AND-RESULT-NEXT:     }
+// THROWING-CONTINUATION-ALWAYS-RETURNING-ERROR-AND-RESULT-NEXT:   }
+// THROWING-CONTINUATION-ALWAYS-RETURNING-ERROR-AND-RESULT-NEXT: }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=AMBIGUOUS-CALL-WITH-ALWAYS-NIL-VARIABLE %s
+func testAmbiguousCallToCompletionHandlerWithAlwaysNilVariable(completionHandler: (Int?, Error?) -> Void) {
+  withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName { theValue in
+    let error: Error? = nil
+    completionHandler(theValue, error)
+  }
+}
+// AMBIGUOUS-CALL-WITH-ALWAYS-NIL-VARIABLE:      func testAmbiguousCallToCompletionHandlerWithAlwaysNilVariable() async throws -> Int {
+// AMBIGUOUS-CALL-WITH-ALWAYS-NIL-VARIABLE-NEXT:   return try await withCheckedThrowingContinuation { continuation in 
+// AMBIGUOUS-CALL-WITH-ALWAYS-NIL-VARIABLE-NEXT:     withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName { theValue in
+// AMBIGUOUS-CALL-WITH-ALWAYS-NIL-VARIABLE-NEXT:       let error: Error? = nil
+// AMBIGUOUS-CALL-WITH-ALWAYS-NIL-VARIABLE-NEXT:       if let error = error {
+// AMBIGUOUS-CALL-WITH-ALWAYS-NIL-VARIABLE-NEXT:         continuation.resume(throwing: error)
+// AMBIGUOUS-CALL-WITH-ALWAYS-NIL-VARIABLE-NEXT:       } else {
+// AMBIGUOUS-CALL-WITH-ALWAYS-NIL-VARIABLE-NEXT:         continuation.resume(returning: theValue)
+// AMBIGUOUS-CALL-WITH-ALWAYS-NIL-VARIABLE-NEXT:       }
+// AMBIGUOUS-CALL-WITH-ALWAYS-NIL-VARIABLE-NEXT:     }
+// AMBIGUOUS-CALL-WITH-ALWAYS-NIL-VARIABLE-NEXT:   }
+// AMBIGUOUS-CALL-WITH-ALWAYS-NIL-VARIABLE-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=PREVIOUS-COMPLETION-HANDLER-CALL %s
 func testPreviousCompletionHandlerCall(completionHandler: (Int) -> Void) {
@@ -341,6 +448,154 @@ func testResultFromValueAndError(completionHandler: (Result<Int, Error>) -> Void
 // RESULT-FROM-VALUE-AND-ERROR-NEXT:   }
 // RESULT-FROM-VALUE-AND-ERROR-NEXT: }
 
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MULTIPLE-RETURN-VALUES-AND-ERROR %s
+func testMultipleReturnValuesAndError(completion: (Int?, String?, Error?) -> Void) {
+  withoutAsyncAlternativeThrowingWithMultipleResults { (first, second, error) in 
+    completion(first, second, error)
+  }
+}
+// MULTIPLE-RETURN-VALUES-AND-ERROR:      func testMultipleReturnValuesAndError() async throws -> (Int, String) {
+// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:   return try await withCheckedThrowingContinuation { continuation in 
+// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:     withoutAsyncAlternativeThrowingWithMultipleResults { (first, second, error) in 
+// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:       if let error = error {
+// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:         continuation.resume(throwing: error)
+// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:       } else {
+// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:         guard let first1 = first else {
+// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:           fatalError("Expected non-nil success argument 'first1' for nil error")
+// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:         }
+// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:         guard let second1 = second else {
+// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:           fatalError("Expected non-nil success argument 'second1' for nil error")
+// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:         }
+// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:         continuation.resume(returning: (first1, second1))
+// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:       }
+// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:     }
+// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:   }
+// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT: }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NON-OPTIONAL-VALUE-FOR-RESULT-AND-ERROR %s
+func testReturnNonOptionalValuesForResultAndError(completion: (Int?, Error?) -> Void) {
+  withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName { result in
+    completion(1, MyError())
+  }
+}
+// NON-OPTIONAL-VALUE-FOR-RESULT-AND-ERROR:      func testReturnNonOptionalValuesForResultAndError() async throws -> Int {
+// NON-OPTIONAL-VALUE-FOR-RESULT-AND-ERROR-NEXT:   return try await withCheckedThrowingContinuation { continuation in 
+// NON-OPTIONAL-VALUE-FOR-RESULT-AND-ERROR-NEXT:     withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName { result in
+// NON-OPTIONAL-VALUE-FOR-RESULT-AND-ERROR-NEXT:       continuation.resume(throwing: MyError())
+// NON-OPTIONAL-VALUE-FOR-RESULT-AND-ERROR-NEXT:     }
+// NON-OPTIONAL-VALUE-FOR-RESULT-AND-ERROR-NEXT:   }
+// NON-OPTIONAL-VALUE-FOR-RESULT-AND-ERROR-NEXT: }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT %s
+func testMixedOptionalAnNonOptionaResults(completion: (Int?, String?, Error?) -> Void) {
+  withoutAsyncAlternativeThrowing { (theResult, error) in
+    completion(theResult, "hi", nil)
+  }
+}
+// MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT:      func testMixedOptionalAnNonOptionaResults() async throws -> (Int, String) {
+// MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:   return try await withCheckedThrowingContinuation { continuation in 
+// MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:     withoutAsyncAlternativeThrowing { (theResult, error) in
+// MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:       guard let theResult1 = theResult else {
+// MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:         fatalError("Expected non-nil success argument 'theResult1' for nil error")
+// MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:       }
+// MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:       continuation.resume(returning: (theResult1, "hi"))
+// MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:     }
+// MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:   }
+// MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT: }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL %s
+func testUseOptionalResultValueAfterCompletionHandlerCall(completion: (Int?, String?, Error?) -> Void) {
+  withoutAsyncAlternativeThrowing { (theResult, error) in
+    completion(theResult, "hi", nil)
+    print(theResult.map { $0 + 1 } as Any)
+  }
+}
+// USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL:      func testUseOptionalResultValueAfterCompletionHandlerCall() async throws -> (Int, String) {
+// USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:   return try await withCheckedThrowingContinuation { continuation in 
+// USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:     withoutAsyncAlternativeThrowing { (theResult, error) in
+// USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:       guard let theResult1 = theResult else {
+// USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:         fatalError("Expected non-nil success argument 'theResult1' for nil error")
+// USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:       }
+// USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:       continuation.resume(returning: (theResult1, "hi"))
+// USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:       print(theResult.map { $0 + 1 } as Any)
+// USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:     }
+// USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:   }
+// USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT: }
+
+// We shouldn't need to unwrap `theResult` twice here, but the example is silly and I don't care too much.
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=PASS-SAME-RESULT-TWICE %s
+func testPassSameResultTwice(completion: (Int?, Int?, Error?) -> Void) {
+  withoutAsyncAlternativeThrowing { (theResult, error) in
+    completion(theResult, theResult, nil)
+  }
+}
+// PASS-SAME-RESULT-TWICE:      func testPassSameResultTwice() async throws -> (Int, Int) {
+// PASS-SAME-RESULT-TWICE-NEXT:   return try await withCheckedThrowingContinuation { continuation in 
+// PASS-SAME-RESULT-TWICE-NEXT:     withoutAsyncAlternativeThrowing { (theResult, error) in
+// PASS-SAME-RESULT-TWICE-NEXT:       guard let theResult1 = theResult else {
+// PASS-SAME-RESULT-TWICE-NEXT:         fatalError("Expected non-nil result 'theResult1' for nil error")
+// PASS-SAME-RESULT-TWICE-NEXT:       }
+// PASS-SAME-RESULT-TWICE-NEXT:       guard let theResult2 = theResult else {
+// PASS-SAME-RESULT-TWICE-NEXT:         fatalError("Expected non-nil result 'theResult2' for nil error")
+// PASS-SAME-RESULT-TWICE-NEXT:       }
+// PASS-SAME-RESULT-TWICE-NEXT:       continuation.resume(returning: (theResult1, theResult2))
+// PASS-SAME-RESULT-TWICE-NEXT:     }
+// PASS-SAME-RESULT-TWICE-NEXT:   }
+// PASS-SAME-RESULT-TWICE-NEXT: }
+
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL %s
+func testUseResultAfterAmbiguousCompletionHandlerCall(completion: (Int?, Error?) -> Void) {
+  withoutAsyncAlternativeThrowing { (theResult, error) in
+    completion(theResult, error)
+    print(theResult as Any)
+  }
+}
+// USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL:      func testUseResultAfterAmbiguousCompletionHandlerCall() async throws -> Int {
+// USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:   return try await withCheckedThrowingContinuation { continuation in 
+// USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:     withoutAsyncAlternativeThrowing { (theResult, error) in
+// USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:       if let error = error {
+// USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:         continuation.resume(throwing: error)
+// USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:       } else {
+// USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:         guard let theResult1 = theResult else {
+// USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:           fatalError("Expected non-nil result 'theResult1' for nil error")
+// USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:         }
+// USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:         continuation.resume(returning: theResult1)
+// USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:       }
+// USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:       print(theResult as Any)
+// USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:     }
+// USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT:   }
+// USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT: }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=TWO-COMPLEITON-HANDLER-CALLS %s
+func testTwoCompletionHandlerCalls(completion: (Int?, Error?) -> Void) {
+  withoutAsyncAlternativeThrowing { (theResult, error) in
+    completion(theResult, error)
+    completion(theResult, error)
+  }
+}
+// TWO-COMPLEITON-HANDLER-CALLS:      func testTwoCompletionHandlerCalls() async throws -> Int {
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:   return try await withCheckedThrowingContinuation { continuation in 
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:     withoutAsyncAlternativeThrowing { (theResult, error) in
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:       if let error = error {
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:         continuation.resume(throwing: error)
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:       } else {
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:         guard let theResult1 = theResult else {
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:           fatalError("Expected non-nil result 'theResult1' for nil error")
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:         }
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:         continuation.resume(returning: theResult1)
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:       }
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:       if let error = error {
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:         continuation.resume(throwing: error)
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:       } else {
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:         guard let theResult2 = theResult else {
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:           fatalError("Expected non-nil result 'theResult2' for nil error")
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:         }
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:         continuation.resume(returning: theResult2)
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:       }
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:     }
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT:   }
+// TWO-COMPLEITON-HANDLER-CALLS-NEXT: }
 
 
 // Reduced version of https://twitter.com/peterfriese/status/1397835146133479428
@@ -383,7 +638,7 @@ func testDataTask(_ completion: @escaping (Int?) -> Void) {
   }
   dataTask.resume()
 }
-// URL-SESSION:      func testDataTask() async -> Int?
+// URL-SESSION:      func testDataTask() async -> Int? {
 // URL-SESSION-NEXT:   return await withCheckedContinuation { continuation in
 // URL-SESSION-NEXT:     let dataTask1 = URLSession.shared.dataTask { (data, error) in
 // URL-SESSION-NEXT:       guard let data1 = data else {

--- a/test/refactoring/ConvertAsync/convert_to_continuation.swift
+++ b/test/refactoring/ConvertAsync/convert_to_continuation.swift
@@ -120,7 +120,7 @@ func testThrowingContinuationRelayingErrorAndResult(completionHandler: (Int?, Er
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:         continuation.resume(throwing: error)
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:       } else {
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:         guard let theValue1 = theValue else {
-// THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:           fatalError("Expected non-nil success argument 'theValue1' for nil error")
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:           fatalError("Expected non-nil result 'theValue1' for nil error")
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:         }
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:         continuation.resume(returning: theValue1)
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT:       }
@@ -141,7 +141,7 @@ func testThrowingContinuationRelayingErrorAndComplexResult(completionHandler: (I
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:         continuation.resume(throwing: error)
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:       } else {
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:         guard let result = theValue.map({ $0 + 1 }) else {
-// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:           fatalError("Expected non-nil success argument 'result' for nil error")
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:           fatalError("Expected non-nil result 'result' for nil error")
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:         }
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:         continuation.resume(returning: result)
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT:       }
@@ -162,10 +162,10 @@ func testThrowingContinuationRelayingErrorAndTwoComplexResults(completionHandler
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:         continuation.resume(throwing: error)
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:       } else {
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:         guard let result0 = theValue.map({ $0 + 1 }) else {
-// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:           fatalError("Expected non-nil success argument 'result0' for nil error")
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:           fatalError("Expected non-nil result 'result0' for nil error")
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:         }
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:         guard let result1 = theValue.map({ $0 + 2 }) else {
-// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:           fatalError("Expected non-nil success argument 'result1' for nil error")
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:           fatalError("Expected non-nil result 'result1' for nil error")
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:         }
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:         continuation.resume(returning: (result0, result1))
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:       }
@@ -186,7 +186,7 @@ func testThrowingContinuationRelayingErrorAndComplexResultWithTrailingClosure(co
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:         continuation.resume(throwing: error)
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:       } else {
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:         guard let result = theValue.map { $0 + 1 }.self else {
-// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:           fatalError("Expected non-nil success argument 'result' for nil error")
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:           fatalError("Expected non-nil result 'result' for nil error")
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:         }
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:         continuation.resume(returning: result)
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:       }
@@ -461,10 +461,10 @@ func testMultipleReturnValuesAndError(completion: (Int?, String?, Error?) -> Voi
 // MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:         continuation.resume(throwing: error)
 // MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:       } else {
 // MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:         guard let first1 = first else {
-// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:           fatalError("Expected non-nil success argument 'first1' for nil error")
+// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:           fatalError("Expected non-nil result 'first1' for nil error")
 // MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:         }
 // MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:         guard let second1 = second else {
-// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:           fatalError("Expected non-nil success argument 'second1' for nil error")
+// MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:           fatalError("Expected non-nil result 'second1' for nil error")
 // MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:         }
 // MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:         continuation.resume(returning: (first1, second1))
 // MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT:       }
@@ -496,7 +496,7 @@ func testMixedOptionalAnNonOptionaResults(completion: (Int?, String?, Error?) ->
 // MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:   return try await withCheckedThrowingContinuation { continuation in 
 // MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:     withoutAsyncAlternativeThrowing { (theResult, error) in
 // MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:       guard let theResult1 = theResult else {
-// MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:         fatalError("Expected non-nil success argument 'theResult1' for nil error")
+// MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:         fatalError("Expected non-nil result 'theResult1' for nil error")
 // MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:       }
 // MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:       continuation.resume(returning: (theResult1, "hi"))
 // MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT:     }
@@ -514,7 +514,7 @@ func testUseOptionalResultValueAfterCompletionHandlerCall(completion: (Int?, Str
 // USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:   return try await withCheckedThrowingContinuation { continuation in 
 // USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:     withoutAsyncAlternativeThrowing { (theResult, error) in
 // USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:       guard let theResult1 = theResult else {
-// USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:         fatalError("Expected non-nil success argument 'theResult1' for nil error")
+// USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:         fatalError("Expected non-nil result 'theResult1' for nil error")
 // USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:       }
 // USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:       continuation.resume(returning: (theResult1, "hi"))
 // USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL-NEXT:       print(theResult.map { $0 + 1 } as Any)


### PR DESCRIPTION
Previously, when a completion handler call had arguments for both the success and error parameters, we were always interpreting it as an error call. In case the error argument was an `Optional`, this could cause us to generate code that didn't compile, because we `throw`ed the `Error?` or passed it to `continuation.resume(throwing)`, both of which didn't work.

We now generate an `if let` statement that checks if the error is `nil`. If it is, the error is thrown. Otherwise, we interpret the call as a success call and return the result.

## Example 1 (convert to continuation)
### Base Code
```swift
func test(completionHandler: (Int?, Error?) -> Void) {
  withoutAsyncAlternativeThrowing { (theValue, theError) in
    completionHandler(theValue, theError)
  }
}
```
### Old Refactoring Result
```swift
func test() async throws -> Int {
  return try await withCheckedThrowingContinuation { continuation in
    withoutAsyncAlternativeThrowing { (theValue, theError) in
      continuation.resume(throwing: theError) // error: Argument type 'Error?' does not conform to expected type 'Error'
    }
  }
}
```
### New Refactoring Result
```swift
func testThrowingContinuationRelayingErrorAndResult() async throws -> Int {
  return try await withCheckedThrowingContinuation { continuation in 
    withoutAsyncAlternativeThrowing { (theValue, theError) in
      if let error = theError {
        continuation.resume(throwing: error)
      } else {
        guard let theValue = theValue else {
          fatalError("Expected non-nil success argument 'theValue' for nil error")
        }
        continuation.resume(returning: theValue)
      }
    }
  }
}
```

## Example 2 (convert to async/await)
### Base Code
```swift
func test(completion: (String?, Error?) -> Void) {
  simpleErr() { (res, err) in
    completion(res, err)
  }
}
```
### Old Refactoring Result
```swift
func test() async throws -> String {
  let res = try await simpleErr()
  throw <#err#>
}
```
### New Refactoring Result
```swift
func test() async throws -> String {
  let res = try await simpleErr()
  return res
}
```