### PR TITLE
[5.5][CodeCompletion] Suggest typealias on protocols

### DIFF
--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -148,6 +148,13 @@ static bool isMemberDeclAppliedInternal(const DeclContext *DC, Type BaseTy,
       BaseTy->hasUnresolvedType() || BaseTy->hasError())
     return true;
 
+  if (isa<TypeAliasDecl>(VD) && BaseTy->is<ProtocolType>()) {
+    // The protocol doesn't satisfy its own generic signature (static members
+    // of the protocol are not visible on the protocol itself) but we can still
+    // access typealias declarations on it.
+    return true;
+  }
+
   const GenericContext *genericDecl = VD->getAsGenericContext();
   if (!genericDecl)
     return true;

--- a/test/IDE/complete_protocol_typealias.swift
+++ b/test/IDE/complete_protocol_typealias.swift
@@ -1,0 +1,58 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+protocol MyProto {
+  typealias Content = Int
+}
+func testSimpleInTypeCompletion() -> MyProto.#^SIMPLE_IN_TYPE_COMPLETION^# {}
+// SIMPLE_IN_TYPE_COMPLETION: Begin completions, 3 items
+// SIMPLE_IN_TYPE_COMPLETION-DAG: Decl[TypeAlias]/CurrNominal:        Content[#Int#];
+// SIMPLE_IN_TYPE_COMPLETION-DAG: Keyword/None:                       Protocol[#MyProto.Protocol#];
+// SIMPLE_IN_TYPE_COMPLETION-DAG: Keyword/None:                       Type[#MyProto.Type#];
+// SIMPLE_IN_TYPE_COMPLETION: End completions
+
+func testUnconstrainedUnresolvedMember() {
+  let _: MyProto = .#^UNCONSTRAINED_UNRESOLVED_MEMBER^#
+// UNCONSTRAINED_UNRESOLVED_MEMBER: Begin completions, 1 item
+// UNCONSTRAINED_UNRESOLVED_MEMBER-DAG: Decl[TypeAlias]/CurrNominal:        Content[#Int#];
+// UNCONSTRAINED_UNRESOLVED_MEMBER: End completions
+}
+
+protocol MyOtherProto {
+  associatedtype MyAssocType
+}
+extension MyOtherProto where MyAssocType == String {
+  typealias Content = Int
+}
+
+// `Content` is actually accessible on `MyOtherProto` here, but that seems more like a bug of the language than a feature, so we don't want to promote it in code completion.
+func testConstrainedInTypeCompletion() -> MyOtherProto.#^CONSTRAINED_IN_TYPE_COMPLETION^# {}
+// CONSTRAINED_IN_TYPE_COMPLETION: Begin completions, 3 items
+// CONSTRAINED_IN_TYPE_COMPLETION-DAG: Decl[AssociatedType]/CurrNominal:   MyAssocType;
+// CONSTRAINED_IN_TYPE_COMPLETION-DAG: Keyword/None:                       Protocol[#MyOtherProto.Protocol#];
+// CONSTRAINED_IN_TYPE_COMPLETION-DAG: Keyword/None:                       Type[#MyOtherProto.Type#];
+// CONSTRAINED_IN_TYPE_COMPLETION: End completions
+
+func testConstrainedUnresolvedMember() {
+  let _: MyOtherProto = .#^CONSTRAINED_UNRESOLVED_MEMBER^#
+// CONSTRAINED_UNRESOLVED_MEMBER: Begin completions, 1 item
+// CONSTRAINED_UNRESOLVED_MEMBER-DAG: Decl[AssociatedType]/CurrNominal:   MyAssocType;
+// CONSTRAINED_UNRESOLVED_MEMBER: End completions
+}
+
+protocol ProtoWithGenericTypealias {
+  typealias Storage<T> = Array<T>
+}
+func testGenericInTypeCompletion() -> ProtoWithGenericTypealias.#^GENERIC_IN_TYPE_COMPLETION^# {}
+// GENERIC_IN_TYPE_COMPLETION: Begin completions, 3 items
+// GENERIC_IN_TYPE_COMPLETION-DAG: Decl[TypeAlias]/CurrNominal:        Storage[#Array<T>#];
+// GENERIC_IN_TYPE_COMPLETION-DAG: Keyword/None:                       Protocol[#ProtoWithGenericTypealias.Protocol#];
+// GENERIC_IN_TYPE_COMPLETION-DAG: Keyword/None:                       Type[#ProtoWithGenericTypealias.Type#];
+// GENERIC_IN_TYPE_COMPLETION: End completions
+
+func testGenericUnresolvedMember() {
+  let _: ProtoWithGenericTypealias = .#^GENERIC_UNRESOLVED_MEMBER^#
+// GENERIC_UNRESOLVED_MEMBER: Begin completions, 1 item
+// GENERIC_UNRESOLVED_MEMBER-DAG: Decl[TypeAlias]/CurrNominal:   Storage[#Array<T>#];
+// GENERIC_UNRESOLVED_MEMBER: End completions
+}

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -450,7 +450,10 @@ func testSubType() {
 func testMemberTypealias() {
   var _: MyProtocol = .#^SUBTYPE_2^#
 }
-// SUBTYPE_2-NOT: Begin completions
+// SUBTYPE_2: Begin completions, 2 items
+// SUBTYPE_2-DAG: Decl[TypeAlias]/CurrNominal/TypeRelation[Convertible]: Concrete1[#BaseClass#];
+// SUBTYPE_2-DAG: Decl[TypeAlias]/CurrNominal/TypeRelation[Convertible]: Concrete2[#AnotherTy#];
+// SUBTYPE_2: End completions
 
 enum Generic<T> {
   case contains(content: T)


### PR DESCRIPTION
* **Explanation**: We were never suggesting typealias declarations when completing on a protocol type. Now we are.
* **Scope**: Code completion on protocol types
* **Risk**: Low
* **Testing**: Added regression test
* **Issue**: rdar://78780638
* **Reviewer**: @rintaro (Rintaro Ishizaki) on original PR #38054 
