### PR TITLE
Update recursion-limit.swift

### DIFF
--- a/test/Demangle/recursion-limit.swift
+++ b/test/Demangle/recursion-limit.swift
@@ -1,10 +1,10 @@
 ; This is not really a Swift source file: -*- Text -*-
 
 RUN: swift-demangle < %S/Inputs/bigtype.txt 2>&1 > %t.check
-RUN: diff -u %S/Inputs/bigtype-demangle.txt %t.check
+RUN: %diff -u %S/Inputs/bigtype-demangle.txt %t.check
 
 RUN: swift-demangle -remangle-new < %S/Inputs/bigtype.txt > %t.check 2>&1 || true
-RUN: diff -u %S/Inputs/bigtype-remangle.txt %t.check
+RUN: %diff -u %S/Inputs/bigtype-remangle.txt %t.check
 
 RUN: swift-demangle -remangle-objc-rt < %S/Inputs/bigtype.txt > %t.check 2>&1 || true
-RUN: diff -u %S/Inputs/bigtype-objcrt.txt %t.check
+RUN: %diff -u %S/Inputs/bigtype-objcrt.txt %t.check


### PR DESCRIPTION
Use the `%diff` substitution to ensure that `--strip-trailing-cr` is used as appropriate to ignore line endings.  This should repair the Windows builders.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
