### PR TITLE
[Swift Next] Fix SIL writing

### DIFF
--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1565,8 +1565,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       Ty = cast<IntegerLiteralInst>(&SI)->getType();
       break;
     case SILInstructionKind::FloatLiteralInst:
-      cast<IntegerLiteralInst>(&SI)->getValue().toString(Str, 16,
-                                                         /*signed*/ true);
+      cast<FloatLiteralInst>(&SI)->getValue().toString(Str, 16,
+                                                       /*signed*/ true);
       Ty = cast<FloatLiteralInst>(&SI)->getType();
       break;
     }

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1565,8 +1565,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       Ty = cast<IntegerLiteralInst>(&SI)->getType();
       break;
     case SILInstructionKind::FloatLiteralInst:
-      cast<FloatLiteralInst>(&SI)->getValue().toString(Str, 16,
-                                                       /*signed*/ true);
+      cast<FloatLiteralInst>(&SI)->getBits().toString(Str, 16,
+                                                      /*signed*/ true);
       Ty = cast<FloatLiteralInst>(&SI)->getType();
       break;
     }


### PR DESCRIPTION
Accidentally broke some things fixing the `llvm::APInt::toString`. This fixes the cast and the call to `getBits` instead of `getValue`.

rdar://79884946