### PR TITLE
[Swift Rebranch] Fix StringRef API usage

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2028,7 +2028,7 @@ void ASTContext::getVisibleTopLevelModuleNames(
 
   // Sort and unique.
   std::sort(names.begin(), names.end(), [](Identifier LHS, Identifier RHS) {
-    return LHS.str().compare_lower(RHS.str()) < 0;
+    return LHS.str().compare_insensitive(RHS.str()) < 0;
   });
   names.erase(std::unique(names.begin(), names.end()), names.end());
 }

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -115,7 +115,7 @@ bool extractParameterOutline(
     }
 
     auto HeadingContent = HeadingText->getLiteralContent();
-    if (!HeadingContent.rtrim().equals_lower("parameters:")) {
+    if (!HeadingContent.rtrim().equals_insensitive("parameters:")) {
       NormalItems.push_back(Child);
       continue;
     }

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -191,7 +191,7 @@ bool extractSeparatedParams(
     auto ParagraphContent = ParagraphText->getLiteralContent();
     auto PotentialMatch = ParagraphContent.substr(0, ParameterPrefix.size());
 
-    if (!PotentialMatch.startswith_lower(ParameterPrefix)) {
+    if (!PotentialMatch.startswith_insensitive(ParameterPrefix)) {
       NormalItems.push_back(Child);
       continue;
     }

--- a/lib/Basic/StringExtras.cpp
+++ b/lib/Basic/StringExtras.cpp
@@ -392,8 +392,8 @@ static bool matchNameWordToTypeWord(StringRef nameWord, StringRef typeWord) {
     // We can match the suffix of the type so long as everything preceding the
     // match is neither a lowercase letter nor a '_'. This ignores type
     // prefixes for acronyms, e.g., the 'NS' in 'NSURL'.
-    if (typeWord.endswith_lower(nameWord) && 
-        !clang::isLowercase(typeWord[typeWord.size()-nameWord.size()])) {
+    if (typeWord.endswith_insensitive(nameWord) &&
+        !clang::isLowercase(typeWord[typeWord.size() - nameWord.size()])) {
       // Check that everything preceding the match is neither a lowercase letter
       // nor a '_'.
       for (unsigned i = 0, n = nameWord.size(); i != n; ++i) {
@@ -405,7 +405,7 @@ static bool matchNameWordToTypeWord(StringRef nameWord, StringRef typeWord) {
 
     // We can match a prefix so long as everything following the match is
     // a number.
-    if (typeWord.startswith_lower(nameWord)) {
+    if (typeWord.startswith_insensitive(nameWord)) {
       for (unsigned i = nameWord.size(), n = typeWord.size(); i != n; ++i) {
         if (!clang::isDigit(typeWord[i])) return false;
       }

--- a/lib/Basic/StringExtras.cpp
+++ b/lib/Basic/StringExtras.cpp
@@ -45,8 +45,8 @@ bool swift::canBeMemberName(StringRef identifier) {
 }
 
 bool swift::isPreposition(StringRef word) {
-#define PREPOSITION(Word)                       \
-  if (word.equals_lower(#Word))                 \
+#define PREPOSITION(Word)                                                      \
+  if (word.equals_insensitive(#Word))                                          \
     return true;
 #include "PartsOfSpeech.def"
 
@@ -55,11 +55,11 @@ bool swift::isPreposition(StringRef word) {
 
 PartOfSpeech swift::getPartOfSpeech(StringRef word) {
   // FIXME: This implementation is woefully inefficient.
-#define PREPOSITION(Word)                       \
-  if (word.equals_lower(#Word))                 \
+#define PREPOSITION(Word)                                                      \
+  if (word.equals_insensitive(#Word))                                          \
     return PartOfSpeech::Preposition;
-#define VERB(Word)                              \
-  if (word.equals_lower(#Word))                 \
+#define VERB(Word)                                                             \
+  if (word.equals_insensitive(#Word))                                          \
     return PartOfSpeech::Verb;
 #include "PartsOfSpeech.def"
 
@@ -417,7 +417,7 @@ static bool matchNameWordToTypeWord(StringRef nameWord, StringRef typeWord) {
   }
 
   // Check for an exact match.
-  return nameWord.equals_lower(typeWord);
+  return nameWord.equals_insensitive(typeWord);
 }
 
 /// Match the beginning of the name to the given type name.

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1502,13 +1502,13 @@ void CodeCompletionContext::sortCompletionResults(
   // Sort nameCache, and then transform Results to return the pointers in order.
   std::sort(nameCache.begin(), nameCache.end(),
             [](const ResultAndName &LHS, const ResultAndName &RHS) {
-    int Result = StringRef(LHS.name).compare_lower(RHS.name);
-    // If the case insensitive comparison is equal, then secondary sort order
-    // should be case sensitive.
-    if (Result == 0)
-      Result = LHS.name.compare(RHS.name);
-    return Result < 0;
-  });
+              int Result = StringRef(LHS.name).compare_insensitive(RHS.name);
+              // If the case insensitive comparison is equal, then secondary
+              // sort order should be case sensitive.
+              if (Result == 0)
+                Result = LHS.name.compare(RHS.name);
+              return Result < 0;
+            });
 
   llvm::transform(nameCache, Results.begin(),
                   [](const ResultAndName &entry) { return entry.result; });

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -207,8 +207,9 @@ void swift::ide::collectModuleGroups(ModuleDecl *M,
   for (auto File : M->getFiles()) {
     File->collectAllGroups(Into);
   }
-  std::sort(Into.begin(), Into.end(),
-            [](StringRef L, StringRef R) { return L.compare_lower(R) < 0; });
+  std::sort(Into.begin(), Into.end(), [](StringRef L, StringRef R) {
+    return L.compare_insensitive(R) < 0;
+  });
 }
 
 /// Determine whether the given extension has a Clang node that

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -1624,7 +1624,7 @@ public:
       ;
     StringRef ident(identStart, ptr - identStart);
 
-    if (ident.equals_lower("parameter")) {
+    if (ident.equals_insensitive("parameter")) {
       if (numSpaces > 1 || !advanceIf(' '))
         return None;
       while (advanceIf([](char c) { return c != ':'; }))
@@ -1634,7 +1634,7 @@ public:
       return ident;
 
     } else if (advanceIf(':')) {
-      if (ident.equals_lower("parameters") && numSpaces > 1)
+      if (ident.equals_insensitive("parameters") && numSpaces > 1)
         return None;
       auto lowerIdent = ident.lower();
       bool isField = llvm::StringSwitch<bool>(lowerIdent)

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1215,7 +1215,7 @@ llvm::SmallString<32> getTargetDependentLibraryOption(const llvm::Triple &T,
     if (quote)
       buffer += '"';
     buffer += library;
-    if (!library.endswith_lower(".lib"))
+    if (!library.endswith_insensitive(".lib"))
       buffer += ".lib";
     if (quote)
       buffer += '"';

--- a/lib/Markup/AST.cpp
+++ b/lib/Markup/AST.cpp
@@ -341,9 +341,9 @@ swift::markup::MarkupASTNode *swift::markup::createSimpleField(
   if (false) {
 
   }
-#define MARKUP_SIMPLE_FIELD(Id, Keyword, XMLKind) \
-  else if (Tag.compare_lower(#Keyword) == 0) { \
-    return Id::create(MC, Children); \
+#define MARKUP_SIMPLE_FIELD(Id, Keyword, XMLKind)                              \
+  else if (Tag.compare_insensitive(#Keyword) == 0) {                           \
+    return Id::create(MC, Children);                                           \
   }
 #include "swift/Markup/SimpleFields.def"
   llvm_unreachable("Given tag not for any simple markup field");
@@ -353,9 +353,9 @@ bool swift::markup::isAFieldTag(StringRef Tag) {
   if (false) {
 
   }
-#define MARKUP_SIMPLE_FIELD(Id, Keyword, XMLKind) \
-  else if (Tag.compare_lower(#Keyword) == 0) { \
-    return true; \
+#define MARKUP_SIMPLE_FIELD(Id, Keyword, XMLKind)                              \
+  else if (Tag.compare_insensitive(#Keyword) == 0) {                           \
+    return true;                                                               \
   }
 #include "swift/Markup/SimpleFields.def"
   return false;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3459,7 +3459,7 @@ DeclName MissingMemberFailure::findCorrectEnumCaseName(
   auto candidate =
       corrections.getUniqueCandidateMatching([&](ValueDecl *candidate) {
         return (isa<EnumElementDecl>(candidate) &&
-                candidate->getBaseIdentifier().str().equals_lower(
+                candidate->getBaseIdentifier().str().equals_insensitive(
                     memberName.getBaseIdentifier().str()));
       });
   return (candidate ? candidate->getName() : DeclName());

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -756,7 +756,7 @@ bool swift::isSIMDOperator(ValueDecl *value) {
   if (nominal->getName().empty())
     return false;
 
-  return nominal->getName().str().startswith_lower("simd");
+  return nominal->getName().str().startswith_insensitive("simd");
 }
 
 bool DisjunctionStep::shortCircuitDisjunctionAt(

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -625,7 +625,7 @@ static double combinedScore(const Options &options, double matchScore,
 
 static int compareResultName(Item &a, Item &b) {
   // Sort first by filter name (case-insensitive).
-  if (int primary = StringRef(a.name).compare_lower(b.name))
+  if (int primary = StringRef(a.name).compare_insensitive(b.name))
     return primary;
 
   // Next, sort by full description text.

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -541,7 +541,7 @@ void CodeCompletionOrganizer::Impl::addCompletionsWithFilter(
     if (options.fuzzyMatching && filterText.size() >= options.minFuzzyLength) {
       match = pattern.matchesCandidate(completion->getName());
     } else {
-      match = completion->getName().startswith_lower(filterText);
+      match = completion->getName().startswith_insensitive(filterText);
     }
 
     bool isExactMatch = match && completion->getName().equals_lower(filterText);

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -544,7 +544,8 @@ void CodeCompletionOrganizer::Impl::addCompletionsWithFilter(
       match = completion->getName().startswith_insensitive(filterText);
     }
 
-    bool isExactMatch = match && completion->getName().equals_lower(filterText);
+    bool isExactMatch =
+        match && completion->getName().equals_insensitive(filterText);
 
     if (isExactMatch) {
       if (!exactMatch) { // first match

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -302,9 +302,9 @@ static int printDiags();
 static void getSemanticInfo(sourcekitd_variant_t Info, StringRef Filename);
 
 static Optional<int64_t> getReqOptValueAsInt(StringRef Value) {
-  if (Value.equals_lower("true"))
+  if (Value.equals_insensitive("true"))
     return 1;
-  if (Value.equals_lower("false"))
+  if (Value.equals_insensitive("false"))
     return 0;
   int64_t Ret;
   if (Value.find_first_not_of("-0123456789") != StringRef::npos ||

--- a/tools/driver/swift_api_digester_main.cpp
+++ b/tools/driver/swift_api_digester_main.cpp
@@ -196,13 +196,15 @@ class RemovedAddedNodeMatcher : public NodeMatcher, public MatchedNodeListener {
   bool detectFuncToProperty(SDKNode *R, SDKNode *A) {
     if (R->getKind() == SDKNodeKind::DeclFunction) {
       if (A->getKind() == SDKNodeKind::DeclVar) {
-        if (A->getName().compare_lower(R->getName()) == 0) {
+        if (A->getName().compare_insensitive(R->getName()) == 0) {
           R->annotate(NodeAnnotation::GetterToProperty);
         } else if (R->getName().startswith("get") &&
-                   R->getName().substr(3).compare_lower(A->getName()) == 0) {
+                   R->getName().substr(3).compare_insensitive(A->getName()) ==
+                       0) {
           R->annotate(NodeAnnotation::GetterToProperty);
         } else if (R->getName().startswith("set") &&
-                   R->getName().substr(3).compare_lower(A->getName()) == 0) {
+                   R->getName().substr(3).compare_insensitive(A->getName()) ==
+                       0) {
           R->annotate(NodeAnnotation::SetterToProperty);
         } else {
           return false;


### PR DESCRIPTION
This is the same as #38176

`compare_lower` and `equals_lower` were replaced with `compare_insensitive` and `equals_insensitive`, respectively in llvm commits 2e4a2b8430aca6f7aef8100a5ff81ca0328d03f9 and 3eed57e7ef7da5eda765ccc19fd26fb8dfcd8d41.

rdar://79974226