### PR TITLE
[IRGen][DebugInfo] Use attached SILLocation for generating debug location for variable declaration

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -192,7 +192,8 @@ public:
   void emitVariableDeclaration(IRBuilder &Builder,
                                ArrayRef<llvm::Value *> Storage,
                                DebugTypeInfo Ty, const SILDebugScope *DS,
-                               ValueDecl *VarDecl, SILDebugVariable VarInfo,
+                               Optional<SILLocation> VarLoc,
+                               SILDebugVariable VarInfo,
                                IndirectionKind = DirectValue,
                                ArtificialKind = RealValue);
   void emitDbgIntrinsic(IRBuilder &Builder, llvm::Value *Storage,
@@ -2331,7 +2332,7 @@ void IRGenDebugInfoImpl::emitArtificialFunction(IRBuilder &Builder,
 
 void IRGenDebugInfoImpl::emitVariableDeclaration(
     IRBuilder &Builder, ArrayRef<llvm::Value *> Storage, DebugTypeInfo DbgTy,
-    const SILDebugScope *DS, ValueDecl *VarDecl, SILDebugVariable VarInfo,
+    const SILDebugScope *DS, Optional<SILLocation> VarLoc, SILDebugVariable VarInfo,
     IndirectionKind Indirection, ArtificialKind Artificial) {
   assert(DS && "variable has no scope");
 
@@ -2347,7 +2348,7 @@ void IRGenDebugInfoImpl::emitVariableDeclaration(
 
   auto *Scope = dyn_cast_or_null<llvm::DILocalScope>(getOrCreateScope(DS));
   assert(Scope && "variable has no local scope");
-  auto Loc = getFilenameAndLocation(*this, VarDecl);
+  auto Loc = getStartLocation(VarLoc);
 
   // FIXME: this should be the scope of the type's declaration.
   // If this is an argument, attach it to the current function scope.
@@ -2541,7 +2542,7 @@ void IRGenDebugInfoImpl::emitTypeMetadata(IRGenFunction &IGF,
       Metadata->getType(), Size(CI.getTargetInfo().getPointerWidth(0)),
       Alignment(CI.getTargetInfo().getPointerAlign(0)));
   emitVariableDeclaration(IGF.Builder, Metadata, DbgTy, IGF.getDebugScope(),
-                          nullptr, {OS.str().str(), 0, false},
+                          {}, {OS.str().str(), 0, false},
                           // swift.type is already a pointer type,
                           // having a shadow copy doesn't add another
                           // layer of indirection.
@@ -2639,10 +2640,10 @@ void IRGenDebugInfo::emitArtificialFunction(IRBuilder &Builder,
 
 void IRGenDebugInfo::emitVariableDeclaration(
     IRBuilder &Builder, ArrayRef<llvm::Value *> Storage, DebugTypeInfo Ty,
-    const SILDebugScope *DS, ValueDecl *VarDecl, SILDebugVariable VarInfo,
+    const SILDebugScope *DS, Optional<SILLocation> VarLoc, SILDebugVariable VarInfo,
     IndirectionKind Indirection, ArtificialKind Artificial) {
   static_cast<IRGenDebugInfoImpl *>(this)->emitVariableDeclaration(
-      Builder, Storage, Ty, DS, VarDecl, VarInfo, Indirection, Artificial);
+      Builder, Storage, Ty, DS, VarLoc, VarInfo, Indirection, Artificial);
 }
 
 void IRGenDebugInfo::emitDbgIntrinsic(IRBuilder &Builder, llvm::Value *Storage,

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -141,7 +141,8 @@ public:
   void emitVariableDeclaration(IRBuilder &Builder,
                                ArrayRef<llvm::Value *> Storage,
                                DebugTypeInfo Ty, const SILDebugScope *DS,
-                               ValueDecl *VarDecl, SILDebugVariable VarInfo,
+                               Optional<SILLocation> VarLoc,
+                               SILDebugVariable VarInfo,
                                IndirectionKind Indirection = DirectValue,
                                ArtificialKind Artificial = RealValue);
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1056,7 +1056,8 @@ public:
   template <typename StorageType>
   void emitDebugVariableDeclaration(StorageType Storage, DebugTypeInfo Ty,
                                     SILType SILTy, const SILDebugScope *DS,
-                                    VarDecl *VarDecl, SILDebugVariable VarInfo,
+                                    SILLocation VarLoc,
+                                    SILDebugVariable VarInfo,
                                     IndirectionKind Indirection) {
     // TODO: fix demangling for C++ types (SR-13223).
     if (swift::TypeBase *ty = SILTy.getASTType().getPointer()) {
@@ -1072,10 +1073,10 @@ public:
     assert(IGM.DebugInfo && "debug info not enabled");
     if (VarInfo.ArgNo) {
       PrologueLocation AutoRestore(IGM.DebugInfo.get(), Builder);
-      IGM.DebugInfo->emitVariableDeclaration(Builder, Storage, Ty, DS, VarDecl,
+      IGM.DebugInfo->emitVariableDeclaration(Builder, Storage, Ty, DS, VarLoc,
                                              VarInfo, Indirection);
     } else
-      IGM.DebugInfo->emitVariableDeclaration(Builder, Storage, Ty, DS, VarDecl,
+      IGM.DebugInfo->emitVariableDeclaration(Builder, Storage, Ty, DS, VarLoc,
                                              VarInfo, Indirection);
   }
 
@@ -4596,7 +4597,7 @@ void IRGenSILFunction::emitErrorResultVar(CanSILFunctionType FnTy,
       ErrorResultSlot->getType(), IGM.getPointerSize(),
       IGM.getPointerAlignment());
   IGM.DebugInfo->emitVariableDeclaration(Builder, Storage, DbgTy,
-                                         getDebugScope(), nullptr, *Var,
+                                         getDebugScope(), {}, *Var,
                                          IndirectValue, ArtificialValue);
 }
 
@@ -4757,7 +4758,7 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
     InCoroContext(*CurSILFn, *i) ? CoroDirectValue : DirectValue;
 
   emitDebugVariableDeclaration(Copy, DbgTy, SILTy, i->getDebugScope(),
-                               i->getDecl(), *VarInfo, Indirection);
+                               i->getLoc(), *VarInfo, Indirection);
 }
 
 void IRGenSILFunction::visitDebugValueAddrInst(DebugValueAddrInst *i) {
@@ -4805,7 +4806,7 @@ void IRGenSILFunction::visitDebugValueAddrInst(DebugValueAddrInst *i) {
   // intrinsic.
   emitDebugVariableDeclaration(
       emitShadowCopyIfNeeded(Addr, i->getDebugScope(), *VarInfo, IsAnonymous),
-      DbgTy, SILType(), i->getDebugScope(), Decl, *VarInfo, Indirection);
+      DbgTy, SILType(), i->getDebugScope(), i->getLoc(), *VarInfo, Indirection);
 }
 
 void IRGenSILFunction::visitFixLifetimeInst(swift::FixLifetimeInst *i) {
@@ -5152,7 +5153,8 @@ void IRGenSILFunction::emitDebugInfoForAllocStack(AllocStackInst *i,
 
   bindArchetypes(DbgTy.getType());
   if (IGM.DebugInfo)
-    emitDebugVariableDeclaration(addr, DbgTy, SILTy, DS, Decl, *VarInfo,
+    emitDebugVariableDeclaration(addr, DbgTy, SILTy, DS,
+                                 i->getLoc(), *VarInfo,
                                  Indirection);
 }
 
@@ -5366,7 +5368,7 @@ void IRGenSILFunction::visitAllocBoxInst(swift::AllocBoxInst *i) {
     return;
 
   IGM.DebugInfo->emitVariableDeclaration(
-      Builder, Storage, DbgTy, i->getDebugScope(), Decl, *VarInfo,
+      Builder, Storage, DbgTy, i->getDebugScope(), i->getLoc(), *VarInfo,
       InCoroContext(*CurSILFn, *i) ? CoroIndirectValue : IndirectValue);
 }
 

--- a/test/DebugInfo/debug_variable.sil
+++ b/test/DebugInfo/debug_variable.sil
@@ -1,0 +1,25 @@
+// RUN: %target-swiftc_driver -g -emit-ir %s | %FileCheck %s
+sil_stage canonical
+
+import Builtin
+import Swift
+
+sil_scope 2 { loc "simple.swift":1:2 parent @test_debug_value : $@convention(thin) (Int) -> () }
+
+// SR-14868: Incorrect source location on `llvm.dbg.declare` when the input
+// is SIL file.
+
+// CHECK: @test_debug_value
+// CHECK-SAME: !dbg ![[FUNC_DI:[0-9]+]]
+sil hidden @test_debug_value : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  // CHECK:      @llvm.dbg.declare(metadata i{{[0-9]+}}*
+  // CHECK-SAME:                   metadata ![[VAR_DI:[0-9]+]]
+  // CHECK-SAME:                   ), !dbg ![[LOC_DI:[0-9]+]]
+  debug_value %0 : $Int, let, name "x", argno 1, loc "simple.swift":3:4, scope 2
+  %1 = tuple ()
+  return %1 : $()
+}
+
+// CHECK: ![[VAR_DI]] = !DILocalVariable(name: "x", arg: 1
+// CHECK: ![[LOC_DI]] = !DILocation(line: 3, column: 4, scope: ![[FUNC_DI]]


### PR DESCRIPTION
Currently IRGen requires the AST node of a variable declaration to generate debug location. However, this will fail if the input is SIL due to the lack of AST reconstruction. Plus, it's unnecessary since we can just use the `SILLocation` attached on `debug_value` (and its friends) SIL instruction to generate the correct LLVM debug metadata. This patch implement the said solution.

Resolves SR-14868