### PR TITLE
[5.5][Sema] Revert temporary downgrade of diagnostic on misplaced unownedExecutor

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4370,10 +4370,7 @@ ERROR(actor_protocol_illegal_inheritance,none,
       "non-actor type %0 cannot conform to the 'Actor' protocol",
       (DeclName))
 
-// FIXME: This diagnostic was temporarily downgraded from an error because
-// it spuriously triggers when building the Foundation module from its textual
-// swiftinterface. (rdar://78932296)
-WARNING(unowned_executor_outside_actor,none,
+ERROR(unowned_executor_outside_actor,none,
       "'unownedExecutor' can only be implemented within the main "
       "definition of an actor", ())
 ERROR(override_implicit_unowned_executor,none,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4584,10 +4584,7 @@ void ConformanceChecker::resolveValueWitnesses() {
           Adoptee->getClassOrBoundGenericClass() &&
           Adoptee->getClassOrBoundGenericClass()->isActor()) {
         witness->diagnose(diag::unowned_executor_outside_actor);
-        // FIXME: This diagnostic was temporarily downgraded from an error to a
-        // warning because it spuriously triggers when building the Foundation
-        // module from its textual swiftinterface. (rdar://78932296)
-        //return;
+        return;
       }
 
       // Objective-C checking for @objc requirements.


### PR DESCRIPTION
(Cherry-picked from #38214)

In #37823, we downgraded this error to a warning unblock support for building Swift with Xcode 13 & on macOS Monterey.

@rjmccall fixed the underlying problem in #37846, so this terrible workaround can be safely reverted now.

rdar://78932296