### PR TITLE
[5.5][ConstraintSystem] Bind missing member in pattern match to a hole early

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4878,14 +4878,24 @@ bool ConstraintSystem::repairFailures(
   }
 
   case ConstraintLocator::PatternMatch: {
+    auto *pattern = elt.castTo<LocatorPathElt::PatternMatch>().getPattern();
+    bool isMemberMatch =
+        lhs->is<FunctionType>() && isa<EnumElementPattern>(pattern);
+
+    // If member reference couldn't be resolved, let's allow pattern
+    // to have holes.
+    if (rhs->isPlaceholder() && isMemberMatch) {
+      markAnyTypeVarsAsPotentialHoles(lhs);
+      return true;
+    }
+
     // If either type is a placeholder, consider this fixed.
     if (lhs->isPlaceholder() || rhs->isPlaceholder())
       return true;
 
-    // If the left-hand side is a function type and the pattern is an enum
-    // element pattern, call it a contextual mismatch.
-    auto pattern = elt.castTo<LocatorPathElt::PatternMatch>().getPattern();
-    if (lhs->is<FunctionType>() && isa<EnumElementPattern>(pattern)) {
+    // If member reference didn't match expected pattern,
+    // let's consider that a contextual mismatch.
+    if (isMemberMatch) {
       markAnyTypeVarsAsPotentialHoles(lhs);
       markAnyTypeVarsAsPotentialHoles(rhs);
 
@@ -8189,6 +8199,13 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
           // `key path` constraint can't be retired until all components
           // are simplified.
           addTypeVariableConstraintsToWorkList(memberTypeVar);
+        } else if (locator->isLastElement<LocatorPathElt::PatternMatch>()) {
+          // Let's handle member patterns specifically because they use
+          // equality instead of argument application constraint, so allowing
+          // them to bind member could mean missing valid hole positions in
+          // the pattern.
+          assignFixedType(memberTypeVar,
+                          PlaceholderType::get(getASTContext(), memberTypeVar));
         } else {
           recordPotentialHole(memberTypeVar);
         }

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -728,3 +728,32 @@ struct TuplifiedStructWithInvalidClosure {
     }
   }
 }
+
+// rdar://65667992 - invalid case in enum causes fallback diagnostic
+func test_rdar65667992() {
+  @resultBuilder
+  struct Builder {
+    static func buildBlock<T>(_ t: T) -> T { t }
+    static func buildEither<T>(first: T) -> T { first }
+    static func buildEither<T>(second: T) -> T { second }
+  }
+
+  struct S {}
+
+  enum E {
+    case set(v: Int, choices: [Int])
+    case notSet(choices: [Int])
+  }
+
+  struct MyView {
+    var entry: E
+
+    @Builder var body: S {
+      switch entry { // expected-error {{type 'E' has no member 'unset'}}
+      case .set(_, _): S()
+      case .unset(_): S()
+      default: S()
+      }
+    }
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/38199

--- 

- Explanation:

If lookup failed to find a member for a pattern match, let's bind
type variable representing such member to a hole right away, otherwise
there is a risk of missing other potential hole locations in pattern
function type (arguments + result type) because pattern matching
doesn't use 'applicable function' constraint.

- Scope: pattern matching incorrect members (nonexistent or misspelled name) in case statements.

- Main Branch PR: https://github.com/apple/swift/pull/38199

- Resolves: rdar://65667992

- Risk: Low

- Reviewed By: @hborla  

- Testing: Regression tests added to the suite

Resolves: rdar://65667992
(cherry picked from commit c1d0036b097eb8e48bade20b50888b69946fe708)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
