### PR TITLE
[build] don't run strip for libclang_rt.tvossim.a

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3186,8 +3186,14 @@ for host in "${ALL_HOSTS[@]}"; do
 
         # Strip executables, shared libraries and static libraries in
         # `host_install_destdir`.
+        # We exclude on purpose libclang_rt.tvossim.a since
+        # 1) strip will fail parsing that in Xcode 13.0b1 (rdar://80098850)
+        # 2) that library is copied from the Xcode installation,
+        # and it is already stripped
         find "${CURRENT_INSTALL_DIR}${CURRENT_PREFIX}/" \
-          '(' -perm -0111 -or -name "*.a" ')' -type f -print | \
+          '(' -perm -0111 -or -name "*.a" ')' \|
+          -not -name 'libclang_rt.tvossim.a' \|
+          -type f -print | \
           xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool strip) -S
 
         # Codesign dylibs after strip tool

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3191,8 +3191,8 @@ for host in "${ALL_HOSTS[@]}"; do
         # 2) that library is copied from the Xcode installation,
         # and it is already stripped
         find "${CURRENT_INSTALL_DIR}${CURRENT_PREFIX}/" \
-          '(' -perm -0111 -or -name "*.a" ')' \|
-          -not -name 'libclang_rt.tvossim.a' \|
+          '(' -perm -0111 -or -name "*.a" ')' \
+          -not -name 'libclang_rt.tvossim.a' \
           -type f -print | \
           xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool strip) -S
 


### PR DESCRIPTION
1) strip will fail parsing that in Xcode 13.0b1
2) that library is copied from the Xcode installation
and it is already stripped

Addresses rdar://80098850