### PR TITLE
[SymbolGraph] do not synthesize subclass methods

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.h
+++ b/lib/SymbolGraphGen/SymbolGraph.h
@@ -146,15 +146,6 @@ struct SymbolGraph {
   void recordConformanceSynthesizedMemberRelationships(Symbol S);
 
   /**
-   If a declaration has members by subclassing, record a symbol with a
-   "synthesized" USR to disambiguate from the superclass's real implementation.
-
-   This makes it more convenient
-   to curate symbols on a subclass's documentation.
-   */
-  void recordSuperclassSynthesizedMemberRelationships(Symbol S);
-
-  /**
    Record InheritsFrom relationships for every class from which the
    declaration inherits.
    */

--- a/test/SymbolGraph/Relationships/Synthesized/SuperclassImplementation.swift
+++ b/test/SymbolGraph/Relationships/Synthesized/SuperclassImplementation.swift
@@ -3,15 +3,24 @@
 // RUN: %target-swift-symbolgraph-extract -module-name SuperclassImplementation -I %t -pretty-print -output-dir %t
 // RUN: %FileCheck %s --input-file %t/SuperclassImplementation.symbols.json
 
+// This test references code that has been removed. The implementation that synthesized superclass
+// methods was inconsistent; it failed to generate symbols for superclasses from another module.
+// From a symbol-relation perspective, the `inheritsFrom` relation from a subclass to its superclass
+// still exists, which already implies that all of the superclass's methods are available on the
+// subclass. The synthesized methods for subclasses were removed to provide consistency between
+// superclasses from the same module and those from a different one. If the implementation is
+// brought back, ensure that it consistently adds synthesized methods for superclasses from
+// different modules.
+
 public class Base {
   public init() {}
   public func foo() {}
 }
 
 public class Derived: Base {
-  // CHECK-DAG: "precise": "s:24SuperclassImplementation4BaseC3fooyyF::SYNTHESIZED::s:24SuperclassImplementation7DerivedC"
+  // CHECK-NOT: "precise": "s:24SuperclassImplementation4BaseC3fooyyF::SYNTHESIZED::s:24SuperclassImplementation7DerivedC"
 }
 
 public class DerivedDerived: Derived {
-  // CHECK-DAG: "precise": "s:24SuperclassImplementation4BaseC3fooyyF::SYNTHESIZED::s:24SuperclassImplementation07DerivedC0C"
+  // CHECK-NOT: "precise": "s:24SuperclassImplementation4BaseC3fooyyF::SYNTHESIZED::s:24SuperclassImplementation07DerivedC0C"
 }


### PR DESCRIPTION
Resolves rdar://80091081

The current implementation for synthesizing subclass methods is inconsistent - it only works when the superclass is in the same module as the subclass. Since the `inheritsFrom` relation already implies that all the superclass methods are available to the subclass, this PR removes the generation of synthesized subclass methods from the symbol graph entirely.