### PR TITLE
Don't Force Closure Capture Computation Early

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2715,7 +2715,6 @@ public:
     } else if (FD->getDeclContext()->isLocalContext()) {
       // Check local function bodies right away.
       (void)FD->getTypecheckedBody();
-      TypeChecker::computeCaptures(FD);
     } else if (shouldSkipBodyTypechecking(FD)) {
       FD->setBodySkipped(FD->getBodySourceRange());
     } else {

--- a/test/expr/capture/local_lazy.swift
+++ b/test/expr/capture/local_lazy.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -emit-silgen -verify %s
+
+struct S {
+  func foo() -> Int {
+    // Make sure the decl context for the autoclosure passed to ?? is deep
+    // enough that it can 'see' the capture of $0 from the outer closure.
+    lazy var nest: (Int) -> Int = { Optional<Int>.none ?? $0 }
+    return nest(1)
+  }
+}
+
+extension S {
+  func bar() -> Int {
+    lazy var nest: (Int) -> Int = { Optional<Int>.none ?? $0 }
+    return nest(1)
+  }
+}


### PR DESCRIPTION
Aside from not being necessary since the act of type checking a function
body should compute these, it can force the computation of closure
captures before any closures inside have been properly recontextualized.
The attached test case demonstrates two kinds of issues that can arise
here:

1) A poorly-contextualized lazy initializer that captures a parameter
   from an enclosing closure cannot actually look up that value because
   its captures cannot 'see' any variables introduced by the closure
   until it has been recontextualized.
2) Any captures therefore go missing and if they survive to SILGen we
   blow up because there aren't any boxes allocated for the captured
   variable.

Computing captures for the enclosing context will get around to force
this for us, so just don't do it.

rdar://79248469