### PR TITLE
Print flags of all frontend-integrated tools when -emit-supported-features is passed

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1048,7 +1048,13 @@ static bool printSwiftVersion(const CompilerInvocation &Invocation) {
 
 static void printSingleFrontendOpt(llvm::opt::OptTable &table, options::ID id,
                                    llvm::raw_ostream &OS) {
-  if (table.getOption(id).hasFlag(options::FrontendOption)) {
+  if (table.getOption(id).hasFlag(options::FrontendOption) ||
+      table.getOption(id).hasFlag(options::AutolinkExtractOption) ||
+      table.getOption(id).hasFlag(options::ModuleWrapOption) ||
+      table.getOption(id).hasFlag(options::SwiftIndentOption) ||
+      table.getOption(id).hasFlag(options::SwiftAPIExtractOption) ||
+      table.getOption(id).hasFlag(options::SwiftSymbolGraphExtractOption) ||
+      table.getOption(id).hasFlag(options::SwiftAPIDigesterOption)) {
     auto name = StringRef(table.getOptionName(id));
     if (!name.empty()) {
       OS << "    \"" << name << "\",\n";

--- a/test/Frontend/emit-supported-features.swift
+++ b/test/Frontend/emit-supported-features.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -emit-supported-features %s | %FileCheck %s
 
 // CHECK: "SupportedArguments"
+// CHECK: "abi"
 // CHECK: "emit-module"
 // CHECK: "LastOption"
 // CHECK: "SupportedFeatures"


### PR DESCRIPTION
This includes the following frontend-integrated tools' flags in `-emit-supported-features` output:
- swift-autolink-extract
- swift -modulewrap
- swift-indent
- swift-api-extract
- swift-symbol graph-extract
- swift-api-digester

The motivation is I want to be able to check in swift-driver & SwiftPM tests that certain API digester flags are available. I included the other tools for consistency since I thin having the information could come in handy in the future.