### PR TITLE
[NFC-ish] Overhaul ASTDumper

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2438,6 +2438,9 @@ public:
   llvm::iterator_range<iterator> getCustomAttrs() const {
     return llvm::make_range(iterator(CustomAttrs), iterator());
   }
+
+  void print(llvm::raw_ostream &OS) const;
+  void print(ASTPrinter &Printer, const PrintOptions &Options) const;
 };
 
 void simple_display(llvm::raw_ostream &out, const DeclAttribute *attr);

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6776,6 +6776,8 @@ enum class CtorInitializerKind {
   Factory
 };
 
+StringRef getCtorInitializerKindString(CtorInitializerKind value);
+
 /// Specifies the kind of initialization call performed within the body
 /// of the constructor, e.g., self.init or super.init.
 enum class BodyInitKind {

--- a/include/swift/AST/ExtInfo.h
+++ b/include/swift/AST/ExtInfo.h
@@ -281,6 +281,9 @@ template <typename Repr> constexpr bool shouldStoreClangType(Repr repr) {
   llvm_unreachable("Unhandled SILFunctionTypeRepresentation.");
 }
 
+StringRef
+getSILFunctionTypeRepresentationString(SILFunctionTypeRepresentation value);
+
 // MARK: - ASTExtInfoBuilder
 /// A builder type for creating an \c ASTExtInfo.
 ///

--- a/include/swift/AST/Import.h
+++ b/include/swift/AST/Import.h
@@ -56,6 +56,9 @@ inline bool isScopedImportKind(ImportKind importKind) {
   return importKind != ImportKind::Module;
 }
 
+StringRef getImportKindString(ImportKind importKind);
+Optional<StringRef> getImportKindKeyword(ImportKind importKind);
+
 /// Possible attributes for imports in source files.
 enum class ImportFlags {
   /// The imported module is exposed to anyone who imports the parent module.

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -368,6 +368,10 @@ struct PrintOptions {
   /// Whether we are printing part of SIL body.
   bool PrintInSILBody = false;
 
+  /// Whether we should print an @opened(...) attr on archetypes. Ignored and
+  /// treated as `true` if PrintForSIL is set.
+  bool PrintOpenedTypeAttr = false;
+
   /// Whether to use an empty line to separate two members in a single decl.
   bool EmptyLineBetweenMembers = false;
 

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -135,8 +135,6 @@ public:
   void dump(llvm::raw_ostream &out, unsigned indent = 0,
             bool details = true) const;
 
-  void print(llvm::raw_ostream &out) const;
-
   bool operator==(ProtocolConformanceRef other) const {
     return Union == other.Union;
   }

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2561,6 +2561,8 @@ enum class MetatypeRepresentation : char {
   Last_MetatypeRepresentation = ObjC
 };
 
+StringRef getMetatypeRepresentationString(MetatypeRepresentation value);
+
 /// AnyMetatypeType - A common parent class of MetatypeType and
 /// ExistentialMetatypeType.
 class AnyMetatypeType : public TypeBase {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -583,7 +583,7 @@ public:
 
 
 
-static StringRef
+StringRef swift::
 getSILFunctionTypeRepresentationString(SILFunctionType::Representation value) {
   switch (value) {
   case SILFunctionType::Representation::Thick: return "thick";
@@ -655,8 +655,8 @@ StringRef swift::getReadWriteImplKindName(ReadWriteImplKind kind) {
   llvm_unreachable("bad kind");
 }
 
-static StringRef getImportKindString(ImportKind value) {
-  switch (value) {
+StringRef swift::getImportKindString(ImportKind importKind) {
+  switch (importKind) {
   case ImportKind::Module: return "module";
   case ImportKind::Type: return "type";
   case ImportKind::Struct: return "struct";
@@ -666,8 +666,16 @@ static StringRef getImportKindString(ImportKind value) {
   case ImportKind::Var: return "var";
   case ImportKind::Func: return "func";
   }
-  
+
   llvm_unreachable("Unhandled ImportKind in switch.");
+}
+
+Optional<StringRef> swift::getImportKindKeyword(ImportKind importKind) {
+  switch (importKind) {
+  case ImportKind::Module: return None;
+  case ImportKind::Type: return StringRef("typealias");
+  default: return getImportKindString(importKind);
+  }
 }
 
 static StringRef
@@ -717,11 +725,11 @@ static StringRef getAccessSemanticsString(AccessSemantics value) {
 
   llvm_unreachable("Unhandled AccessSemantics in switch.");
 }
-static StringRef getMetatypeRepresentationString(MetatypeRepresentation value) {
+StringRef swift::getMetatypeRepresentationString(MetatypeRepresentation value) {
   switch (value) {
     case MetatypeRepresentation::Thin: return "thin";
     case MetatypeRepresentation::Thick: return "thick";
-    case MetatypeRepresentation::ObjC: return "@objc";
+    case MetatypeRepresentation::ObjC: return "objc_metatype";
   }
 
   llvm_unreachable("Unhandled MetatypeRepresentation in switch.");
@@ -735,7 +743,7 @@ getStringLiteralExprEncodingString(StringLiteralExpr::Encoding value) {
 
   llvm_unreachable("Unhandled StringLiteral in switch.");
 }
-static StringRef getCtorInitializerKindString(CtorInitializerKind value) {
+StringRef swift::getCtorInitializerKindString(CtorInitializerKind value) {
   switch (value) {
     case CtorInitializerKind::Designated: return "designated";
     case CtorInitializerKind::Convenience: return "convenience";
@@ -744,15 +752,6 @@ static StringRef getCtorInitializerKindString(CtorInitializerKind value) {
   }
 
   llvm_unreachable("Unhandled CtorInitializerKind in switch.");
-}
-static StringRef getAssociativityString(Associativity value) {
-  switch (value) {
-    case Associativity::None: return "none";
-    case Associativity::Left: return "left";
-    case Associativity::Right: return "right";
-  }
-
-  llvm_unreachable("Unhandled Associativity in switch.");
 }
 
 void ASTNodeDumper::printNodeAccessSemantics(AccessSemantics semantics) {
@@ -1360,7 +1359,7 @@ namespace {
       auto dump = printCommon(PGD, "precedence_group_decl", Label);
 
       dump.printNodeName(PGD->getName());
-      dump.printFlag(getAssociativityString(PGD->getAssociativity()),
+      dump.printFlag(getAssociativitySpelling(PGD->getAssociativity()),
                      "associativity");
       dump.printFlag(PGD->isAssignment(), "assignment");
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -172,6 +172,11 @@ class ASTNodeDumper {
 
   raw_ostream &os() {
     assert(Dumper && "printing from inactive ASTNodeDumper");
+
+    // Dumper->Indent is briefly less-than during construction and destruction.
+    assert(Dumper->Indent <= IndentChildren &&
+              "printing from parent ASTNodeDumper");
+    
     return Dumper->OS;
   }
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -196,6 +196,7 @@ public:
   }
 
   ASTNodeDumper child(const char *Name, StringRef Label, TerminalColor Color) {
+    *OS << '\n';
     return ASTNodeDumper(Ctx, *OS, *Delegate, IndentChildren,
                          Name, Label, Color);
   }
@@ -224,7 +225,6 @@ public:
   void printRec(ArrayRef<T> elems, StringRef Label) {
     auto childDump = child("array", Label, ExprModifierColor);
     for (auto elt : elems) {
-      childDump << "\n";
       childDump.printRec(elt, "");
     }
   }
@@ -577,7 +577,6 @@ namespace {
 
     void visitParenPattern(ParenPattern *P, StringRef Label) {
       auto dump = printCommon(P, "pattern_paren", Label);
-      dump << '\n';
       dump.printRec(P->getSubPattern());
     }
 
@@ -592,10 +591,8 @@ namespace {
                  },
                  [&] { dump << ","; });
 
-      for (auto &elt : P->getElements()) {
-        dump << '\n';
+      for (auto &elt : P->getElements())
         dump.printRec(elt.getPattern());
-      }
     }
     void visitNamedPattern(NamedPattern *P, StringRef Label) {
       auto dump = printCommon(P, "pattern_named", Label);
@@ -606,10 +603,8 @@ namespace {
     }
     void visitTypedPattern(TypedPattern *P, StringRef Label) {
       auto dump = printCommon(P, "pattern_typed", Label);
-      dump << '\n';
       dump.printRec(P->getSubPattern());
       if (auto *repr = P->getTypeRepr()) {
-        dump << '\n';
         dump.printRec(repr);
       }
     }
@@ -619,7 +614,6 @@ namespace {
       dump << ' ' << getCheckedCastKindName(P->getCastKind()) << ' ';
       P->getCastType().print(dump.getOS());
       if (auto sub = P->getSubPattern()) {
-        dump << '\n';
         dump.printRec(sub);
       }
     }
@@ -633,7 +627,6 @@ namespace {
     }
     void visitBindingPattern(BindingPattern *P, StringRef Label) {
       auto dump = printCommon(P, P->isLet() ? "pattern_let" : "pattern_var", Label);
-      dump << '\n';
       dump.printRec(P->getSubPattern());
     }
     void visitEnumElementPattern(EnumElementPattern *P, StringRef Label) {
@@ -642,13 +635,11 @@ namespace {
       P->getParentType().print(dump.colored(TypeColor).getOS());
       dump.colored(IdentifierColor) << '.' << P->getName();
       if (P->hasSubPattern()) {
-        dump << '\n';
         dump.printRec(P->getSubPattern());
       }
     }
     void visitOptionalSomePattern(OptionalSomePattern *P, StringRef Label) {
       auto dump = printCommon(P, "pattern_optional_some", Label);
-      dump << '\n';
       dump.printRec(P->getSubPattern());
     }
     void visitBoolPattern(BoolPattern *P, StringRef Label) {
@@ -908,10 +899,8 @@ namespace {
         break;
       }
 
-      for (Decl *D : IDC->getMembers()) {
-        dump << '\n';
+      for (Decl *D : IDC->getMembers())
         dump.printRec(D);
-      }
     }
 
     void visitSourceFile(const SourceFile &SF, StringRef Label) {
@@ -923,7 +912,6 @@ namespace {
           if (D->isImplicit())
             continue;
 
-          dump << '\n';
           dump.printRec(D);
         }
       }
@@ -956,10 +944,8 @@ namespace {
     }
 
     void printAccessors(ASTNodeDumper &dump, AbstractStorageDecl *D) {
-      for (auto accessor : D->getAllAccessors()) {
-        dump << "\n";
+      for (auto accessor : D->getAllAccessors())
         dump.printRec(accessor);
-      }
     }
 
     void visitParamDecl(ParamDecl *PD, StringRef Label) {
@@ -1002,18 +988,14 @@ namespace {
           dump.colored(CapturesColor).getOS());
       }
 
-      if (auto init = PD->getStructuralDefaultExpr()) {
-        dump << '\n';
+      if (auto init = PD->getStructuralDefaultExpr())
         dump.printRec(init, "expression");
-      }
     }
 
     void visitEnumCaseDecl(EnumCaseDecl *ECD, StringRef Label) {
       auto dump = printCommon(ECD, "enum_case_decl", Label);
-      for (EnumElementDecl *D : ECD->getElements()) {
-        dump << '\n';
+      for (EnumElementDecl *D : ECD->getElements())
         dump.printRec(D);
-      }
     }
 
     void visitEnumDecl(EnumDecl *ED, StringRef Label) {
@@ -1023,10 +1005,8 @@ namespace {
 
     void visitEnumElementDecl(EnumElementDecl *EED, StringRef Label) {
       auto dump = printCommon(EED, "enum_element_decl", Label);
-      if (auto *paramList = EED->getParameterList()) {
-        dump << "\n";
+      if (auto *paramList = EED->getParameterList())
         dump.printRec(paramList);
-      }
     }
 
     void visitStructDecl(StructDecl *SD, StringRef Label) {
@@ -1045,21 +1025,13 @@ namespace {
       auto dump = printCommon(PBD, "pattern_binding_decl", Label);
 
       for (auto idx : range(PBD->getNumPatternEntries())) {
-        dump << '\n';
         auto childDump = dump.child("pattern_entry", "", PatternColor);
 
-        childDump << '\n';
         childDump.printRec(PBD->getPattern(idx), "pattern");
-
-        if (PBD->getOriginalInit(idx)) {
-          childDump << '\n';
+        if (PBD->getOriginalInit(idx))
           childDump.printRec(PBD->getOriginalInit(idx), "original_init");
-        }
-
-        if (PBD->getInit(idx)) {
-          childDump << '\n';
+        if (PBD->getInit(idx))
           childDump.printRec(PBD->getInit(idx), "processed_init");
-        }
       }
     }
 
@@ -1089,29 +1061,24 @@ namespace {
 
       dump.printNodeRange(params->getSourceRange());
 
-      for (auto P : *params) {
-        dump << '\n';
+      for (auto P : *params)
         dump.printRec(P);
-      }
     }
 
     void printAbstractFunctionDecl(ASTNodeDumper &dump,
                                    AbstractFunctionDecl *D) {
       if (auto fac = D->getForeignAsyncConvention()) {
-        dump << '\n';
         auto childDump = dump.child("foreign_async", "", DeclModifierColor);
         childDump.print(fac->completionHandlerParamIndex(),
                         "completion_handler_param_index");
         if (auto errorParamIndex = fac->completionHandlerErrorParamIndex())
           childDump.print(*errorParamIndex, "error_param_index");
 
-        if (auto type = fac->completionHandlerType()) {
+        if (auto type = fac->completionHandlerType())
           childDump.print(type, "completion_handler_type");
-        }
       }
 
       if (auto fec = D->getForeignErrorConvention()) {
-        dump << '\n';
         auto childDump = dump.child("foreign_error", "", DeclModifierColor);
         childDump.print(getForeignErrorConventionKindString(fec->getKind()),
                         "kind");
@@ -1130,31 +1097,22 @@ namespace {
           childDump.print(fec->getResultType(), "result_type");
       }
 
-      if (auto *P = D->getImplicitSelfDecl()) {
-        dump << '\n';
+      if (auto *P = D->getImplicitSelfDecl())
         dump.printRec(P, "self");
-      }
 
-      dump << '\n';
       dump.printRec(D->getParameters());
 
       if (auto FD = dyn_cast<FuncDecl>(D)) {
         if (FD->getResultTypeRepr()) {
-          dump << '\n';
           dump.printRec(FD->getResultTypeRepr(), "result");
-          if (auto opaque = FD->getOpaqueResultTypeDecl()) {
-            dump << '\n';
+          if (auto opaque = FD->getOpaqueResultTypeDecl())
             dump.printRec(opaque, "opaque_result_decl");
-          }
         }
       }
-      if (D->hasSingleExpressionBody()) {
-        dump << '\n';
+      if (D->hasSingleExpressionBody())
         dump.printRec(D->getSingleExpressionBody(), "single_expression_body");
-      } else if (auto Body = D->getBody(/*canSynthesize=*/false)) {
-        dump << '\n';
+      else if (auto Body = D->getBody(/*canSynthesize=*/false))
         dump.printRec(Body, "body");
-      }
     }
 
     LLVM_NODISCARD ASTNodeDumper
@@ -1194,49 +1152,26 @@ namespace {
 
     void visitTopLevelCodeDecl(TopLevelCodeDecl *TLCD, StringRef Label) {
       auto dump = printCommon(TLCD, "top_level_code_decl", Label);
-      if (TLCD->getBody()) {
-        dump << "\n";
+      if (TLCD->getBody())
         dump.printRec(TLCD->getBody());
-      }
     }
     
-    void printASTNodes(ASTNodeDumper &parentDump,
-                       const ArrayRef<ASTNode> &Elements, const char *Name,
-                       StringRef Label) {
-      auto dump = parentDump.child(Name, Label, ASTNodeColor);
-      for (auto Elt : Elements) {
-        dump << '\n';
-        if (auto *SubExpr = Elt.dyn_cast<Expr*>())
-          dump.printRec(SubExpr);
-        else if (auto *SubStmt = Elt.dyn_cast<Stmt*>())
-          dump.printRec(SubStmt);
-        else
-          dump.printRec(Elt.get<Decl*>());
-      }
-    }
-
     void visitIfConfigDecl(IfConfigDecl *ICD, StringRef Label) {
       auto dump = printCommon(ICD, "if_config_decl", Label);
       for (auto &Clause : ICD->getClauses()) {
-        dump << '\n';
         auto childDump = dump.child((Clause.Cond ? "#if:" : "#else:"), "",
                                     StmtColor);
-        if (Clause.isActive)
-          childDump.colored(DeclModifierColor) << " active";
-        if (Clause.Cond) {
-          childDump << "\n";
-          childDump.printRec(Clause.Cond);
-        }
+        childDump.printFlag(Clause.isActive, "active", DeclModifierColor);
 
-        dump << '\n';
-        printASTNodes(childDump, Clause.Elements, "", "elements");
+        if (Clause.Cond)
+          childDump.printRec(Clause.Cond);
+        childDump.printRec(Clause.Elements, "elements");
       }
     }
 
     void visitPoundDiagnosticDecl(PoundDiagnosticDecl *PDD, StringRef Label) {
       auto dump = printCommon(PDD, "pound_diagnostic_decl", Label);
       dump.print(PDD->isError() ? "error" : "warning", "kind");
-      dump << "\n";
       dump.printRec(PDD->getMessage());
     }
 
@@ -1251,7 +1186,7 @@ namespace {
       auto printRelations =
           [&](StringRef label, ArrayRef<PrecedenceGroupDecl::Relation> rels) {
         if (rels.empty()) return;
-        dump << '\n';
+
         auto childDump = dump.child("groups", label, DeclModifierColor);
         childDump << rels[0].Name;
         for (auto &rel : rels.slice(1))
@@ -1264,7 +1199,6 @@ namespace {
     void printOperatorIdentifiers(ASTNodeDumper &dump, OperatorDecl *OD) {
       auto identifiers = OD->getIdentifiers();
       for (auto index : indices(identifiers)) {
-        dump << "\n";
         auto childDump = dump.child("identifier", llvm::utostr(index),
                                     DeclModifierColor);
         childDump.print(identifiers[index].Item);
@@ -1512,33 +1446,25 @@ public:
   void visitBraceStmt(BraceStmt *S, StringRef Label) {
     auto dump = printCommon(S, "brace_stmt", Label);
 
-    for (auto Elt : S->getElements()) {
-      dump << '\n';
+    for (auto Elt : S->getElements())
       dump.printRec(Elt);
-    }
   }
 
   void visitReturnStmt(ReturnStmt *S, StringRef Label) {
     auto dump = printCommon(S, "return_stmt", Label);
-    if (S->hasResult()) {
-      dump << '\n';
+    if (S->hasResult())
       dump.printRec(S->getResult());
-    }
   }
 
   void visitYieldStmt(YieldStmt *S, StringRef Label) {
     auto dump = printCommon(S, "yield_stmt", Label);
-    for (auto yield : S->getYields()) {
-      dump << '\n';
+    for (auto yield : S->getYields())
       dump.printRec(yield);
-    }
   }
 
   void visitDeferStmt(DeferStmt *S, StringRef Label) {
     auto dump = printCommon(S, "defer_stmt", Label);
-    dump << '\n';
     dump.printRec(S->getTempDecl());
-    dump << '\n';
     dump.printRec(S->getCallExpr());
   }
 
@@ -1546,79 +1472,52 @@ public:
     auto dump = printCommon(S, "if_stmt", Label);
 
     dump.printRec(S->getCond(), "conditions");
-
-    dump << '\n';
     dump.printRec(S->getThenStmt(), "then_body");
-
-    if (S->getElseStmt()) {
-      dump << '\n';
+    if (S->getElseStmt())
       dump.printRec(S->getElseStmt(), "else_body");
-    }
   }
 
   void visitGuardStmt(GuardStmt *S, StringRef Label) {
     auto dump = printCommon(S, "guard_stmt", Label);
     dump.printRec(S->getCond(), "conditions");
-    dump << '\n';
     dump.printRec(S->getBody(), "else_body");
   }
 
   void visitDoStmt(DoStmt *S, StringRef Label) {
     auto dump = printCommon(S, "do_stmt", Label);
-    dump << '\n';
     dump.printRec(S->getBody(), "body");
   }
 
   void visitWhileStmt(WhileStmt *S, StringRef Label) {
     auto dump = printCommon(S, "while_stmt", Label);
     dump.printRec(S->getCond(), "conditions");
-    dump << '\n';
     dump.printRec(S->getBody(), "body");
   }
 
   void visitRepeatWhileStmt(RepeatWhileStmt *S, StringRef Label) {
     auto dump = printCommon(S, "repeat_while_stmt", Label);
-    dump << '\n';
     dump.printRec(S->getBody(), "body");
-    dump << '\n';
     dump.printRec(S->getCond(), "condition");
   }
 
   void visitForEachStmt(ForEachStmt *S, StringRef Label) {
     auto dump = printCommon(S, "for_each_stmt", Label);
 
-    dump << '\n';
     dump.printRec(S->getPattern(), "pattern");
-
-    if (S->getWhere()) {
-      dump << '\n';
+    if (S->getWhere())
       dump.printRec(S->getWhere(), "where_clause");
-    }
-
-    dump << '\n';
     dump.printRec(S->getSequence(), "sequence");
 
-    if (S->getIteratorVar()) {
-      dump << '\n';
+    if (S->getIteratorVar())
       dump.printRec(S->getIteratorVar(), "iterator_var");
-    }
-
-    if (S->getIteratorVarRef()) {
-      dump << '\n';
+    if (S->getIteratorVarRef())
       dump.printRec(S->getIteratorVarRef(), "iterator_var_ref");
-    }
 
-    if (S->getConvertElementExpr()) {
-      dump << '\n';
+    if (S->getConvertElementExpr())
       dump.printRec(S->getConvertElementExpr(), "convert_element_expr");
-    }
-
-    if (S->getElementExpr()) {
-      dump << '\n';
+    if (S->getElementExpr())
       dump.printRec(S->getElementExpr(), "element_expr");
-    }
 
-    dump << '\n';
     dump.printRec(S->getBody(), "body");
   }
 
@@ -1637,36 +1536,28 @@ public:
   void visitSwitchStmt(SwitchStmt *S, StringRef Label) {
     auto dump = printCommon(S, "switch_stmt", Label);
 
-    dump << '\n';
     dump.printRec(S->getSubjectExpr(), "subject");
-
     dump.printRec(S->getRawCases(), "cases");
   }
 
   void visitCaseStmt(CaseStmt *S, StringRef Label) {
     auto dump = printCommon(S, "case_stmt", Label);
+
     dump.printFlag(S->hasUnknownAttr(), "@unknown");
 
     if (S->hasCaseBodyVariables())
       dump.printRec(S->getCaseBodyVariables(), "case_body_variables");
 
     for (const auto &LabelItem : S->getCaseLabelItems()) {
-      dump << '\n';
       auto childDump = dump.child("case_label_item", "", StmtColor);
       childDump.printFlag(LabelItem.isDefault(), "default");
 
-      if (auto *CasePattern = LabelItem.getPattern()) {
-        childDump << '\n';
+      if (auto *CasePattern = LabelItem.getPattern())
         childDump.printRec(CasePattern, "pattern");
-      }
-
-      if (auto *Guard = LabelItem.getGuardExpr()) {
-        childDump << '\n';
+      if (auto *Guard = LabelItem.getGuardExpr())
         childDump.printRec(const_cast<Expr *>(Guard), "where_clause");
-      }
     }
 
-    dump << '\n';
     dump.printRec(S->getBody(), "body");
   }
 
@@ -1676,7 +1567,6 @@ public:
 
   void visitThrowStmt(ThrowStmt *S, StringRef Label) {
     auto dump = printCommon(S, "throw_stmt", Label);
-    dump << '\n';
     dump.printRec(S->getSubExpr());
   }
 
@@ -1684,16 +1574,13 @@ public:
     auto dump = printCommon(S, "pound_assert", Label);
     dump.print(QuotedString(S->getMessage()), "message");
 
-    dump << "\n";
     dump.printRec(S->getCondition());
   }
 
   void visitDoCatchStmt(DoCatchStmt *S, StringRef Label) {
     auto dump = printCommon(S, "do_catch_stmt", Label);
 
-    dump << '\n';
     dump.printRec(S->getBody(), "do_body");
-
     dump.printRec(S->getCatches(), "catch_clauses");
   }
 };
@@ -1707,9 +1594,7 @@ void ASTNodeDumper::printRec(StmtConditionElement C, StringRef Label) {
 
   case StmtConditionElement::CK_PatternBinding: {
     auto dump = child("pattern", Label, PatternColor);
-    dump << "\n";
     dump.printRec(C.getPattern());
-    dump << "\n";
     dump.printRec(C.getInitializer());
     break;
   }
@@ -1814,12 +1699,8 @@ public:
   }
 
   void printSemanticExpr(ASTNodeDumper &dump, Expr *semanticExpr) {
-    if (semanticExpr == nullptr) {
-      return;
-    }
-    
-    dump << '\n';
-    dump.printRec(semanticExpr, "semantic_expr");
+    if (semanticExpr)
+      dump.printRec(semanticExpr, "semantic_expr");
   }
 
   void visitErrorExpr(ErrorExpr *E, StringRef Label) {
@@ -1828,10 +1709,8 @@ public:
 
   void visitCodeCompletionExpr(CodeCompletionExpr *E, StringRef Label) {
     auto dump = printCommon(E, "code_completion_expr", Label);
-    if (E->getBase()) {
-      dump << '\n';
+    if (E->getBase())
       dump.printRec(E->getBase());
-    }
   }
 
   void visitNilLiteralExpr(NilLiteralExpr *E, StringRef Label) {
@@ -1903,7 +1782,6 @@ public:
     dump.printDeclRef(E->getBuilderInit(), "builder_init", LiteralValueColor);
     dump.printDeclRef(E->getInitializer(), "result_init", LiteralValueColor);
 
-    dump << "\n";
     dump.printRec(E->getAppendingExpr());
   }
   void visitMagicIdentifierLiteralExpr(MagicIdentifierLiteralExpr *E, StringRef Label) {
@@ -1927,7 +1805,6 @@ public:
     dump.printDeclRef(E->getInitializer(), "initializer", LiteralValueColor);
     printArgumentLabels(dump, E->getArgumentLabels());
 
-    dump << "\n";
     dump.printRec(E->getArg());
   }
 
@@ -1972,7 +1849,6 @@ public:
                ExprModifierColor);
 
     for (auto D : E->getDecls()) {
-      dump << "\n";
       auto childDump = dump.child("candidate", "", DeclModifierColor);
       childDump.printDeclRef(D, "decl");
     }
@@ -1989,11 +1865,9 @@ public:
   void visitUnresolvedSpecializeExpr(UnresolvedSpecializeExpr *E, StringRef Label) {
     auto dump = printCommon(E, "unresolved_specialize_expr", Label);
 
-    dump << '\n';
     dump.printRec(E->getSubExpr());
 
     for (TypeLoc T : E->getUnresolvedParams()) {
-      dump << '\n';
       dump.printRec(T.getTypeRepr());
     }
   }
@@ -2009,7 +1883,6 @@ public:
 
     dump.printFlag(E->isSuper(), "super");
 
-    dump << '\n';
     dump.printRec(E->getBase());
   }
 
@@ -2017,8 +1890,6 @@ public:
     auto dump = printCommon(E, "dynamic_member_ref_expr", Label);
 
     dump.printDeclRef(E->getMember(), "decl");
-
-    dump << '\n';
     dump.printRec(E->getBase());
   }
 
@@ -2032,31 +1903,23 @@ public:
 
   void visitDotSelfExpr(DotSelfExpr *E, StringRef Label) {
     auto dump = printCommon(E, "dot_self_expr", Label);
-
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
   void visitParenExpr(ParenExpr *E, StringRef Label) {
     auto dump = printCommon(E, "paren_expr", Label);
 
     dump.printFlag(E->hasTrailingClosure(), "trailing-closure");
-
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitAwaitExpr(AwaitExpr *E, StringRef Label) {
     auto dump = printCommon(E, "await_expr", Label);
-
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitUnresolvedMemberChainResultExpr(UnresolvedMemberChainResultExpr *E,
                                             StringRef Label){
     auto dump = printCommon(E, "unresolved_member_chain_expr", Label);
-
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
@@ -2075,7 +1938,6 @@ public:
     }
 
     for (unsigned i = 0, e = E->getNumElements(); i != e; ++i) {
-      dump << '\n';
       if (E->getElement(i))
         dump.printRec(E->getElement(i));
       else
@@ -2088,10 +1950,8 @@ public:
 
     dump.printDeclRef(E->getInitializer(), "initializer", LiteralValueColor);
 
-    for (auto elt : E->getElements()) {
-      dump << '\n';
+    for (auto elt : E->getElements())
       dump.printRec(elt);
-    }
   }
 
   void visitDictionaryExpr(DictionaryExpr *E, StringRef Label) {
@@ -2099,10 +1959,8 @@ public:
 
     dump.printDeclRef(E->getInitializer(), "initializer", LiteralValueColor);
 
-    for (auto elt : E->getElements()) {
-      dump << '\n';
+    for (auto elt : E->getElements())
       dump.printRec(elt);
-    }
   }
 
   void visitSubscriptExpr(SubscriptExpr *E, StringRef Label) {
@@ -2116,20 +1974,14 @@ public:
       dump.printDeclRef(E->getDecl(), "decl");
     printArgumentLabels(dump, E->getArgumentLabels());
 
-    dump << '\n';
     dump.printRec(E->getBase(), "base");
-
-    dump << '\n';
     dump.printRec(E->getIndex(), "index");
   }
 
   void visitKeyPathApplicationExpr(KeyPathApplicationExpr *E, StringRef Label) {
     auto dump = printCommon(E, "keypath_application_expr", Label);
 
-    dump << '\n';
     dump.printRec(E->getBase(), "base");
-
-    dump << '\n';
     dump.printRec(E->getKeyPath(), "key_path");
   }
 
@@ -2139,10 +1991,7 @@ public:
     dump.printDeclRef(E->getMember(), "decl");
     printArgumentLabels(dump, E->getArgumentLabels());
 
-    dump << '\n';
     dump.printRec(E->getBase(), "base");
-
-    dump << '\n';
     dump.printRec(E->getIndex(), "index");
   }
 
@@ -2153,10 +2002,8 @@ public:
     dump.print(getFunctionRefKindStr(E->getFunctionRefKind()), "function_ref",
                ExprModifierColor);
 
-    if (E->getBase()) {
-      dump << '\n';
+    if (E->getBase())
       dump.printRec(E->getBase(), "base");
-    }
   }
 
   void visitTupleElementExpr(TupleElementExpr *E, StringRef Label) {
@@ -2164,7 +2011,6 @@ public:
 
     dump.print(E->getFieldNumber(), "index", IdentifierColor);
 
-    dump << '\n';
     dump.printRec(E->getBase(), "base");
   }
 
@@ -2172,37 +2018,29 @@ public:
     auto dump = printCommon(E, "destructure_tuple_expr", Label);
 
     dump.printRec(E->getDestructuredElements(), "destructured");
-
-    dump << "\n";
     dump.printRec(E->getSubExpr());
-
-    dump << "\n";
     dump.printRec(E->getResultExpr());
   }
 
   void visitUnresolvedTypeConversionExpr(UnresolvedTypeConversionExpr *E, StringRef Label) {
     auto dump = printCommon(E, "unresolvedtype_conversion_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitFunctionConversionExpr(FunctionConversionExpr *E, StringRef Label) {
     auto dump = printCommon(E, "function_conversion_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitCovariantFunctionConversionExpr(CovariantFunctionConversionExpr *E,
                                             StringRef Label) {
     auto dump = printCommon(E, "covariant_function_conversion_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitCovariantReturnConversionExpr(CovariantReturnConversionExpr *E,
                                           StringRef Label) {
     auto dump = printCommon(E, "covariant_return_conversion_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
@@ -2210,13 +2048,11 @@ public:
       ImplicitlyUnwrappedFunctionConversionExpr *E, StringRef Label) {
     auto dump = printCommon(E, "implicitly_unwrapped_function_conversion_expr",
                             Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitUnderlyingToOpaqueExpr(UnderlyingToOpaqueExpr *E, StringRef Label) {
     auto dump = printCommon(E, "underlying_to_opaque_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
@@ -2224,16 +2060,12 @@ public:
     auto dump = printCommon(E, "erasure_expr", Label);
 
     dump.printRec(E->getConformances(), "conformances");
-
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitAnyHashableErasureExpr(AnyHashableErasureExpr *E, StringRef Label) {
     auto dump = printCommon(E, "any_hashable_erasure_expr", Label);
-    dump << '\n';
     dump.printRec(E->getConformance());
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
@@ -2242,32 +2074,26 @@ public:
     auto dump = printCommon(E, "conditional_bridge_from_objc_expr", Label);
 
     dump.printDeclRef(E->getConversion(), "conversion");
-
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitBridgeFromObjCExpr(BridgeFromObjCExpr *E, StringRef Label) {
     auto dump = printCommon(E, "bridge_from_objc_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitBridgeToObjCExpr(BridgeToObjCExpr *E, StringRef Label) {
     auto dump = printCommon(E, "bridge_to_objc_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitLoadExpr(LoadExpr *E, StringRef Label) {
     auto dump = printCommon(E, "load_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitMetatypeConversionExpr(MetatypeConversionExpr *E, StringRef Label) {
     auto dump = printCommon(E, "metatype_conversion_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
@@ -2275,178 +2101,144 @@ public:
                                            StringRef Label) {
     auto dump = printCommon(E, "collection_upcast_expr", Label);
 
-    dump << '\n';
     dump.printRec(E->getSubExpr());
-
-    if (auto keyConversion = E->getKeyConversion()) {
-      dump << '\n';
+    if (auto keyConversion = E->getKeyConversion())
       dump.printRec(keyConversion.Conversion, "key_conversion");
-    }
-
-    if (auto valueConversion = E->getValueConversion()) {
-      dump << '\n';
+    if (auto valueConversion = E->getValueConversion())
       dump.printRec(valueConversion.Conversion, "value_conversion");
-    }
   }
 
   void visitDerivedToBaseExpr(DerivedToBaseExpr *E, StringRef Label) {
     auto dump = printCommon(E, "derived_to_base_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitArchetypeToSuperExpr(ArchetypeToSuperExpr *E, StringRef Label) {
     auto dump = printCommon(E, "archetype_to_super_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitInjectIntoOptionalExpr(InjectIntoOptionalExpr *E, StringRef Label) {
     auto dump = printCommon(E, "inject_into_optional", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitClassMetatypeToObjectExpr(ClassMetatypeToObjectExpr *E,
                                       StringRef Label) {
     auto dump = printCommon(E, "class_metatype_to_object", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitExistentialMetatypeToObjectExpr(ExistentialMetatypeToObjectExpr *E,
                                             StringRef Label) {
     auto dump = printCommon(E, "existential_metatype_to_object", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitProtocolMetatypeToObjectExpr(ProtocolMetatypeToObjectExpr *E,
                                          StringRef Label) {
     auto dump = printCommon(E, "protocol_metatype_to_object", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitInOutToPointerExpr(InOutToPointerExpr *E, StringRef Label) {
     auto dump = printCommon(E, "inout_to_pointer", Label);
     dump.printFlag(E->isNonAccessing(), "nonaccessing");
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitArrayToPointerExpr(ArrayToPointerExpr *E, StringRef Label) {
     auto dump = printCommon(E, "array_to_pointer", Label);
     dump.printFlag(E->isNonAccessing(), "nonaccessing");
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitStringToPointerExpr(StringToPointerExpr *E, StringRef Label) {
     auto dump = printCommon(E, "string_to_pointer", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitPointerToPointerExpr(PointerToPointerExpr *E, StringRef Label) {
     auto dump = printCommon(E, "pointer_to_pointer", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitForeignObjectConversionExpr(ForeignObjectConversionExpr *E, StringRef Label) {
     auto dump = printCommon(E, "foreign_object_conversion", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitUnevaluatedInstanceExpr(UnevaluatedInstanceExpr *E, StringRef Label) {
     auto dump = printCommon(E, "unevaluated_instance", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitDifferentiableFunctionExpr(DifferentiableFunctionExpr *E, StringRef Label) {
     auto dump = printCommon(E, "differentiable_function", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitLinearFunctionExpr(LinearFunctionExpr *E, StringRef Label) {
     auto dump = printCommon(E, "linear_function", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitDifferentiableFunctionExtractOriginalExpr(
       DifferentiableFunctionExtractOriginalExpr *E, StringRef Label) {
     auto dump = printCommon(E, "differentiable_function_extract_original", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitLinearFunctionExtractOriginalExpr(
       LinearFunctionExtractOriginalExpr *E, StringRef Label) {
     auto dump = printCommon(E, "linear_function_extract_original", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitLinearToDifferentiableFunctionExpr(
       LinearToDifferentiableFunctionExpr *E, StringRef Label) {
     auto dump = printCommon(E, "linear_to_differentiable_function", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitInOutExpr(InOutExpr *E, StringRef Label) {
     auto dump = printCommon(E, "inout_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitVarargExpansionExpr(VarargExpansionExpr *E, StringRef Label) {
     auto dump = printCommon(E, "vararg_expansion_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitForceTryExpr(ForceTryExpr *E, StringRef Label) {
     auto dump = printCommon(E, "force_try_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitOptionalTryExpr(OptionalTryExpr *E, StringRef Label) {
     auto dump = printCommon(E, "optional_try_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitTryExpr(TryExpr *E, StringRef Label) {
     auto dump = printCommon(E, "try_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitSequenceExpr(SequenceExpr *E, StringRef Label) {
     auto dump = printCommon(E, "sequence_expr", Label);
-    for (unsigned i = 0, e = E->getNumElements(); i != e; ++i) {
-      dump << '\n';
+    for (unsigned i = 0, e = E->getNumElements(); i != e; ++i)
       dump.printRec(E->getElement(i));
-    }
   }
 
   void visitCaptureListExpr(CaptureListExpr *E, StringRef Label) {
     auto dump = printCommon(E, "capture_list", Label);
     {
       auto childDump = dump.child("captures", "", CapturesColor);
-      for (auto capture : E->getCaptureList()) {
-        childDump << '\n';
+      for (auto capture : E->getCaptureList())
         childDump.printRec(capture.PBD);
-      }
     }
-    dump << '\n';
     dump.printRec(E->getClosureBody(), "body");
   }
 
@@ -2499,30 +2291,21 @@ public:
     dump.printFlag(E->inheritsActorContext(), "inherits_actor_context",
                    ClosureModifierColor);
 
-    if (E->getParameters()) {
-      dump << '\n';
+    if (E->getParameters())
       dump.printRec(E->getParameters());
-    }
-
-    dump << '\n';
     dump.printRec(E->getBody(), "body");
   }
 
   void visitAutoClosureExpr(AutoClosureExpr *E, StringRef Label) {
     auto dump = printClosure(E, "autoclosure_expr", Label);
 
-    if (E->getParameters()) {
-      dump << '\n';
+    if (E->getParameters())
       dump.printRec(E->getParameters());
-    }
-
-    dump << '\n';
     dump.printRec(E->getSingleExpressionBody(), "single_expr_body");
   }
 
   void visitDynamicTypeExpr(DynamicTypeExpr *E, StringRef Label) {
     auto dump = printCommon(E, "metatype_expr", Label);
-    dump << '\n';
     dump.printRec(E->getBase(), "base");
   }
 
@@ -2536,19 +2319,14 @@ public:
     auto dump = printCommon(E, "property_wrapper_value_placeholder_expr",
                             Label);
 
-    dump << '\n';
     dump.printRec(E->getOpaqueValuePlaceholder(), "opaque_value_placeholder");
-
-    if (auto *value = E->getOriginalWrappedValue()) {
-      dump << '\n';
+    if (auto *value = E->getOriginalWrappedValue())
       dump.printRec(value, "original_wrapped_value");
-    }
   }
 
   void visitAppliedPropertyWrapperExpr(AppliedPropertyWrapperExpr *E,
                                        StringRef Label) {
     auto dump = printCommon(E, "applied_property_wrapper_expr", Label);
-    dump << '\n';
     dump.printRec(E->getValue());
   }
 
@@ -2579,10 +2357,7 @@ public:
     if (auto call = dyn_cast<CallExpr>(E))
       printArgumentLabels(dump, call->getArgumentLabels());
 
-    dump << '\n';
     dump.printRec(E->getFn(), "fn");
-
-    dump << '\n';
     dump.printRec(E->getArg(), "arg");
   }
 
@@ -2604,11 +2379,10 @@ public:
   void visitConstructorRefCallExpr(ConstructorRefCallExpr *E, StringRef Label) {
     printApplyExpr(E, "constructor_ref_call_expr", Label);
   }
+
   void visitDotSyntaxBaseIgnoredExpr(DotSyntaxBaseIgnoredExpr *E, StringRef Label) {
     auto dump = printCommon(E, "dot_syntax_base_ignored", Label);
-    dump << '\n';
     dump.printRec(E->getLHS());
-    dump << '\n';
     dump.printRec(E->getRHS());
   }
 
@@ -2626,7 +2400,6 @@ public:
       E->getCastType().print(dump.getOS());
     dump << "'";
 
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
@@ -2652,34 +2425,25 @@ public:
     dump.printFlag(E->getAsyncLoc().isValid(), "async");
     dump.printFlag(E->getThrowsLoc().isValid(), "throws");
 
-    dump << '\n';
     dump.printRec(E->getArgsExpr(), "args");
-
-    dump << '\n';
     dump.printRec(E->getResultExpr(), "result");
   }
 
   void visitRebindSelfInConstructorExpr(RebindSelfInConstructorExpr *E, StringRef Label) {
     auto dump = printCommon(E, "rebind_self_in_constructor_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitIfExpr(IfExpr *E, StringRef Label) {
     auto dump = printCommon(E, "if_expr", Label);
-    dump << '\n';
     dump.printRec(E->getCondExpr(), "condition");
-    dump << '\n';
     dump.printRec(E->getThenExpr(), "then_expr");
-    dump << '\n';
     dump.printRec(E->getElseExpr(), "else_expr");
   }
 
   void visitAssignExpr(AssignExpr *E, StringRef Label) {
     auto dump = printCommon(E, "assign_expr", Label);
-    dump << '\n';
     dump.printRec(E->getDest(), "dest");
-    dump << '\n';
     dump.printRec(E->getSrc(), "src");
   }
 
@@ -2687,13 +2451,11 @@ public:
     auto dump = printCommon(E, "enum_is_case_expr", Label);
     dump.printNodeName(E->getEnumElement());
 
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitUnresolvedPatternExpr(UnresolvedPatternExpr *E, StringRef Label) {
     auto dump = printCommon(E, "unresolved_pattern_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubPattern());
   }
 
@@ -2701,13 +2463,11 @@ public:
     auto dump = printCommon(E, "bind_optional_expr", Label);
     dump.print(E->getDepth(), "depth");
 
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitOptionalEvaluationExpr(OptionalEvaluationExpr *E, StringRef Label) {
     auto dump = printCommon(E, "optional_evaluation_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
@@ -2716,20 +2476,14 @@ public:
     dump.printFlag(E->isForceOfImplicitlyUnwrappedOptional(),
                    "implicit_iuo_unwrap", ExprModifierColor);
 
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
   void visitOpenExistentialExpr(OpenExistentialExpr *E, StringRef Label) {
     auto dump = printCommon(E, "open_existential_expr", Label);
 
-    dump << '\n';
     dump.printRec(E->getOpaqueValue(), "opaque_value");
-
-    dump << '\n';
     dump.printRec(E->getExistentialValue(), "existential_value");
-
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
@@ -2737,13 +2491,8 @@ public:
                                          StringRef Label) {
     auto dump = printCommon(E, "make_temporarily_escapable_expr", Label);
 
-    dump << '\n';
     dump.printRec(E->getOpaqueValue(), "opaque_value");
-
-    dump << '\n';
     dump.printRec(E->getNonescapingClosureValue(), "nonescaping_closure_value");
-
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
@@ -2755,21 +2504,16 @@ public:
 
     auto *TyR = E->getPlaceholderTypeRepr();
     auto *ExpTyR = E->getTypeForExpansion();
-    if (TyR) {
-      dump << '\n';
+    if (TyR)
       dump.printRec(TyR, "placeholder_type_repr");
-    }
-    if (ExpTyR && ExpTyR != TyR) {
-      dump << '\n';
+    if (ExpTyR && ExpTyR != TyR)
       dump.printRec(ExpTyR, "type_for_expansion");
-    }
 
     printSemanticExpr(dump, E->getSemanticExpr());
   }
 
   void visitLazyInitializerExpr(LazyInitializerExpr *E, StringRef Label) {
     auto dump = printCommon(E, "lazy_initializer_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
@@ -2778,7 +2522,6 @@ public:
     dump.print(getObjCSelectorExprKindString(E->getSelectorKind()), "kind");
     dump.printDeclRef(E->getMethod(), "decl");
 
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
@@ -2787,12 +2530,10 @@ public:
     dump.printFlag(E->isObjC(), "objc");
 
     {
-      dump << '\n';
       auto childDump = dump.child("", "components", ExprColor);
       for (unsigned i : indices(E->getComponents())) {
         Optional<ASTNodeDumper> grandchildDump;
         auto &component = E->getComponents()[i];
-        childDump << '\n';
         switch (component.getKind()) {
         case KeyPathExpr::Component::Kind::Invalid:
           grandchildDump = childDump.child("", "invalid", ASTNodeColor);
@@ -2856,26 +2597,19 @@ public:
         grandchildDump->print(getTypeOfKeyPathComponent(E, i), "type",
                               TypeColor);
         if (auto indexExpr = component.getIndexExpr()) {
-          *grandchildDump << '\n';
           grandchildDump->printRec(indexExpr);
         }
       }
     }
 
-    if (auto stringLiteral = E->getObjCStringLiteralExpr()) {
-      dump << '\n';
+    if (auto stringLiteral = E->getObjCStringLiteralExpr())
       dump.printRec(stringLiteral, "objc_string_literal");
-    }
 
     if (!E->isObjC()) {
-      if (auto root = E->getParsedRoot()) {
-        dump << "\n";
+      if (auto root = E->getParsedRoot())
         dump.printRec(root, "parsed_root");
-      }
-      if (auto path = E->getParsedPath()) {
-        dump << "\n";
+      if (auto path = E->getParsedPath())
         dump.printRec(path, "parsed_path");
-      }
     }
   }
 
@@ -2885,7 +2619,6 @@ public:
 
   void visitOneWayExpr(OneWayExpr *E, StringRef Label) {
     auto dump = printCommon(E, "one_way_expr", Label);
-    dump << '\n';
     dump.printRec(E->getSubExpr());
   }
 
@@ -2896,10 +2629,7 @@ public:
     auto dump = printCommon(E, "tap_expr", Label);
     dump.printDeclRef(E->getVar(), "var");
 
-    dump << '\n';
     dump.printRec(E->getSubExpr(), "initializer");
-
-    dump << '\n';
     dump.printRec(E->getBody(), "body");
   }
 };
@@ -2968,16 +2698,13 @@ public:
     dump.printLabel("attrs");
     T->printAttrs(dump.getOS());
 
-    dump << '\n';
     dump.printRec(T->getTypeRepr());
   }
 
   void visitIdentTypeRepr(IdentTypeRepr *T, StringRef Label) {
     auto dump = printCommon("type_ident", Label);
     for (auto comp : T->getComponentRange()) {
-      dump << '\n';
       auto childDump = dump.child("component", "", TypeReprColor);
-
       childDump.printNodeName(comp->getNameRef());
 
       if (comp->isBound())
@@ -2985,12 +2712,9 @@ public:
       else
         childDump.print("none", "bind", DeclColor);
 
-      if (auto GenIdT = dyn_cast<GenericIdentTypeRepr>(comp)) {
-        for (auto genArg : GenIdT->getGenericArgs()) {
-          childDump << '\n';
+      if (auto GenIdT = dyn_cast<GenericIdentTypeRepr>(comp))
+        for (auto genArg : GenIdT->getGenericArgs())
           childDump.printRec(genArg);
-        }
-      }
     }
   }
 
@@ -2999,24 +2723,18 @@ public:
     dump.printFlag(T->isAsync(), "async");
     dump.printFlag(T->isThrowing(), "throws");
 
-    dump << '\n';
     dump.printRec(T->getArgsTypeRepr(), "arg_type");
-
-    dump << '\n';
     dump.printRec(T->getResultTypeRepr(), "result_type");
   }
 
   void visitArrayTypeRepr(ArrayTypeRepr *T, StringRef Label) {
     auto dump = printCommon("type_array", Label);
-    dump << '\n';
     dump.printRec(T->getBase(), "element");
   }
 
   void visitDictionaryTypeRepr(DictionaryTypeRepr *T, StringRef Label) {
     auto dump = printCommon("type_dictionary", Label);
-    dump << '\n';
     dump.printRec(T->getKey(), "key_type");
-    dump << '\n';
     dump.printRec(T->getValue(), "value_type");
   }
 
@@ -3024,7 +2742,6 @@ public:
     auto dump = printCommon("type_tuple", Label);
 
     for (auto elem : T->getElements()) {
-      dump << '\n';
       if (elem.Name.empty())
         dump.printRec(elem.Type);
       else
@@ -3034,64 +2751,53 @@ public:
 
   void visitCompositionTypeRepr(CompositionTypeRepr *T, StringRef Label) {
     auto dump = printCommon("type_composite", Label);
-    for (auto elem : T->getTypes()) {
-      dump << '\n';
+    for (auto elem : T->getTypes())
       dump.printRec(elem);
-    }
   }
 
   void visitMetatypeTypeRepr(MetatypeTypeRepr *T, StringRef Label) {
     auto dump = printCommon("type_metatype", Label);
-    dump << '\n';
     dump.printRec(T->getBase(), "instance_type");
   }
 
   void visitProtocolTypeRepr(ProtocolTypeRepr *T, StringRef Label) {
     auto dump = printCommon("type_protocol", Label);
-    dump << '\n';
     dump.printRec(T->getBase());
   }
 
   void visitInOutTypeRepr(InOutTypeRepr *T, StringRef Label) {
     auto dump = printCommon("type_inout", Label);
-    dump << '\n';
     dump.printRec(T->getBase());
   }
   
   void visitSharedTypeRepr(SharedTypeRepr *T, StringRef Label) {
     auto dump = printCommon("type_shared", Label);
-    dump << '\n';
     dump.printRec(T->getBase());
   }
 
   void visitOwnedTypeRepr(OwnedTypeRepr *T, StringRef Label) {
     auto dump = printCommon("type_owned", Label);
-    dump << '\n';
     dump.printRec(T->getBase());
   }
 
   void visitIsolatedTypeRepr(IsolatedTypeRepr *T, StringRef Label) {
     auto dump = printCommon("isolated", Label);
-    dump << '\n';
     dump.printRec(T->getBase());
   }
 
   void visitOptionalTypeRepr(OptionalTypeRepr *T, StringRef Label) {
     auto dump = printCommon("type_optional", Label);
-    dump << '\n';
     dump.printRec(T->getBase());
   }
 
   void visitImplicitlyUnwrappedOptionalTypeRepr(
       ImplicitlyUnwrappedOptionalTypeRepr *T, StringRef Label) {
     auto dump = printCommon("type_implicitly_unwrapped_optional", Label);
-    dump << '\n';
     dump.printRec(T->getBase());
   }
 
   void visitOpaqueReturnTypeRepr(OpaqueReturnTypeRepr *T, StringRef Label) {
     auto dump = printCommon("type_opaque_return", Label);
-    dump << '\n';
     dump.printRec(T->getConstraint());
   }
 
@@ -3113,7 +2819,6 @@ public:
 
     auto dump = printCommon("type_fixed", Label);
     dump.printNodeLocation(T->getLoc());
-    dump << '\n';
     dump.printRec(Ty, "fixed_type");
   }
 
@@ -3122,19 +2827,14 @@ public:
 
     ArrayRef<SILBoxTypeReprField> Fields = T->getFields();
     for (unsigned i = 0, end = Fields.size(); i != end; ++i) {
-      dump << '\n';
       auto childDump = dump.child("sil_box_field", "", TypeReprColor);
-
       childDump.printFlag(Fields[i].isMutable(), "mutable");
 
-      childDump << '\n';
       childDump.printRec(Fields[i].getFieldType());
     }
 
-    for (auto genArg : T->getGenericArguments()) {
-      dump << '\n';
+    for (auto genArg : T->getGenericArguments())
       dump.printRec(genArg);
-    }
   }
 };
 
@@ -4063,29 +3763,37 @@ void StableSerializationPath::dump(llvm::raw_ostream &os) const {
 }
 
 void ASTNodeDumper::printRec(Decl *D, StringRef Label) {
+  *OS << '\n';
   PrintDecl(Ctx, *OS, *Delegate, IndentChildren).visit(D, Label);
 }
 void ASTNodeDumper::printRec(Expr *E, StringRef Label) {
+  *OS << '\n';
   PrintExpr(Ctx, *OS, *Delegate, IndentChildren).visit(E, Label);
 }
 void ASTNodeDumper::printRec(Stmt *S, StringRef Label) {
+  *OS << '\n';
   PrintStmt(Ctx, *OS, *Delegate, IndentChildren).visit(S, Label);
 }
 void ASTNodeDumper::printRec(TypeRepr *T, StringRef Label) {
+  *OS << '\n';
   PrintTypeRepr(Ctx, *OS, *Delegate, IndentChildren).visit(T, Label);
 }
 void ASTNodeDumper::printRec(const Pattern *P, StringRef Label) {
+  *OS << '\n';
   PrintPattern(Ctx, *OS, *Delegate, IndentChildren)
       .visit(const_cast<Pattern *>(P), Label);
 }
 void ASTNodeDumper::printRec(Type Ty, StringRef Label) {
+  *OS << '\n';
   PrintType(Ctx, *OS, *Delegate, IndentChildren)
       .visit(Ty, Label);
 }
 void ASTNodeDumper::printRec(ParameterList *PL, StringRef Label) {
+  *OS << '\n';
   PrintDecl(Ctx, *OS, *Delegate, IndentChildren).printParameterList(PL, Label);
 }
 void ASTNodeDumper::printRec(ProtocolConformanceRef conf, StringRef Label) {
+  *OS << '\n';
   llvm::SmallPtrSet<const ProtocolConformance *, 8> visited;
   dumpProtocolConformanceRefRec(conf, *OS, IndentChildren, Label, visited);
 }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2926,10 +2926,8 @@ public:
   }
 
   void visitNamedOpaqueReturnTypeRepr(NamedOpaqueReturnTypeRepr *T, StringRef Label) {
-    printCommon("type_named_opaque_return", Label);
-    OS << '\n';
-    printRec(T->getBase());
-    printCommonPost();
+    auto dump = printCommon("type_named_opaque_return", Label);
+    dump.printRec(T->getBase());
   }
 
   void visitPlaceholderTypeRepr(PlaceholderTypeRepr *T, StringRef Label) {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4162,6 +4162,18 @@ void Pattern::print(llvm::raw_ostream &OS, const PrintOptions &Options) const {
 }
 
 //===----------------------------------------------------------------------===//
+//  Expr Printing
+//===----------------------------------------------------------------------===//
+
+void Expr::print(ASTPrinter &Printer, const PrintOptions &Opts) const {
+  // FIXME: Fully use the ASTPrinter.
+  llvm::SmallString<128> Str;
+  llvm::raw_svector_ostream OS(Str);
+  dump(OS);
+  Printer << OS.str();
+}
+
+//===----------------------------------------------------------------------===//
 //  Type Printing
 //===----------------------------------------------------------------------===//
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -5209,7 +5209,7 @@ public:
   }
 
   void visitOpenedArchetypeType(OpenedArchetypeType *T) {
-    if (Options.PrintForSIL)
+    if (Options.PrintForSIL || Options.PrintOpenedTypeAttr)
       Printer << "@opened(\"" << T->getOpenedExistentialID() << "\") ";
     visit(T->getOpenedExistentialType());
   }
@@ -5455,34 +5455,6 @@ void GenericSignature::print(ASTPrinter &Printer,
 void GenericSignature::dump() const {
   print(llvm::errs());
   llvm::errs() << '\n';
-}
-
-void Requirement::dump() const {
-  dump(llvm::errs());
-  llvm::errs() << '\n';
-}
-void Requirement::dump(raw_ostream &out) const {
-  switch (getKind()) {
-  case RequirementKind::Conformance:
-    out << "conforms_to: ";
-    break;
-  case RequirementKind::Layout:
-    out << "layout: ";
-    break;
-  case RequirementKind::Superclass:
-    out << "superclass: ";
-    break;
-  case RequirementKind::SameType:
-    out << "same_type: ";
-    break;
-  }
-
-  if (getFirstType())
-    out << getFirstType() << " ";
-  if (getKind() != RequirementKind::Layout && getSecondType())
-    out << getSecondType();
-  else if (getLayoutConstraint())
-    out << getLayoutConstraint();
 }
 
 void Requirement::print(raw_ostream &os, const PrintOptions &opts) const {

--- a/lib/AST/ConcreteDeclRef.cpp
+++ b/lib/AST/ConcreteDeclRef.cpp
@@ -47,7 +47,7 @@ ConcreteDeclRef ConcreteDeclRef::getOverriddenDecl() const {
 
 void ConcreteDeclRef::dump(raw_ostream &os) const {
   if (!getDecl()) {
-    os << "**NULL**";
+    os << "<<null>>";
     return;
   }
 

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -500,18 +500,7 @@ void swift::simple_display(
 
 void swift::simple_display(
   llvm::raw_ostream &out, const CtorInitializerKind initKind) {
-  out << "{ ";
-  switch (initKind) {
-  case CtorInitializerKind::Designated:
-    out << "designated"; break;
-  case CtorInitializerKind::Convenience:
-    out << "convenience"; break;
-  case CtorInitializerKind::ConvenienceFactory:
-    out << "convenience_factory"; break;
-  case CtorInitializerKind::Factory:
-    out << "factory"; break;
-  }
-  out << " }";
+  out << "{ " << getCtorInitializerKindString(initKind) << " }";
 }
 
 void swift::simple_display(llvm::raw_ostream &os, PropertyWrapperMutability m) {

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -129,18 +129,25 @@ void AttributedTypeRepr::printImpl(ASTPrinter &Printer,
 }
 
 void AttributedTypeRepr::printAttrs(llvm::raw_ostream &OS) const {
+  getAttrs().print(OS);
+}
+
+void TypeAttributes::print(llvm::raw_ostream &OS) const {
   StreamPrinter Printer(OS);
-  printAttrs(Printer, PrintOptions());
+  print(Printer, PrintOptions());
 }
 
 void AttributedTypeRepr::printAttrs(ASTPrinter &Printer,
                                     const PrintOptions &Options) const {
-  const TypeAttributes &Attrs = getAttrs();
+  getAttrs().print(Printer, Options);
+}
 
+void TypeAttributes::print(ASTPrinter &Printer,
+                           const PrintOptions &Options) const {
   auto hasAttr = [&](TypeAttrKind K) -> bool {
     if (Options.excludeAttrKind(K))
       return false;
-    return Attrs.has(K);
+    return has(K);
   };
 
   if (hasAttr(TAK_autoclosure))
@@ -153,7 +160,7 @@ void AttributedTypeRepr::printAttrs(ASTPrinter &Printer,
   if (hasAttr(TAK_differentiable)) {
     Printer.callPrintStructurePre(PrintStructureKind::BuiltinAttribute);
     Printer.printAttrName("@differentiable");
-    switch (Attrs.differentiabilityKind) {
+    switch (differentiabilityKind) {
     case DifferentiabilityKind::Normal:
       break;
     case DifferentiabilityKind::Forward:
@@ -177,11 +184,11 @@ void AttributedTypeRepr::printAttrs(ASTPrinter &Printer,
   if (hasAttr(TAK_thick))
     Printer.printSimpleAttr("@thick") << " ";
 
-  if (hasAttr(TAK_convention) && Attrs.hasConvention()) {
+  if (hasAttr(TAK_convention) && hasConvention()) {
     Printer.callPrintStructurePre(PrintStructureKind::BuiltinAttribute);
     Printer.printAttrName("@convention");
     SmallString<32> convention;
-    Attrs.getConventionArguments(convention);
+    getConventionArguments(convention);
     Printer << "(" << convention << ")";
     Printer.printStructurePost(PrintStructureKind::BuiltinAttribute);
     Printer << " ";

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -397,7 +397,7 @@ static void printGenericSpecializationInfo(
     OS << '>';
     OS << " conformances <";
     interleave(Subs.getConformances(),
-               [&](ProtocolConformanceRef conf) { conf.print(OS); },
+               [&](ProtocolConformanceRef conf) { conf.dump(OS); },
                [&] { OS << ", ";});
     OS << '>';
   };

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -812,29 +812,6 @@ static bool isNominalImportKind(ImportKind kind) {
   llvm_unreachable("unhandled kind");
 }
 
-static const char *getImportKindString(ImportKind kind) {
-  switch (kind) {
-  case ImportKind::Module:
-    llvm_unreachable("module imports do not bring in decls");
-  case ImportKind::Type:
-    return "typealias";
-  case ImportKind::Struct:
-    return "struct";
-  case ImportKind::Class:
-    return "class";
-  case ImportKind::Enum:
-    return "enum";
-  case ImportKind::Protocol:
-    return "protocol";
-  case ImportKind::Var:
-    return "var";
-  case ImportKind::Func:
-    return "func";
-  }
-
-  llvm_unreachable("Unhandled ImportKind in switch.");
-}
-
 ArrayRef<ValueDecl *>
 ScopedImportLookupRequest::evaluate(Evaluator &evaluator,
                                     ImportDecl *import) const {
@@ -903,16 +880,16 @@ ScopedImportLookupRequest::evaluate(Evaluator &evaluator,
           typealias->getDescriptiveKind(),
           TypeAliasType::get(typealias, Type(), SubstitutionMap(),
                              typealias->getUnderlyingType()),
-          getImportKindString(importKind)));
+          *getImportKindKeyword(importKind)));
     } else {
       emittedDiag.emplace(ctx.Diags.diagnose(
           importLoc, diag::imported_decl_is_wrong_kind,
-          accessPath.front().Item, getImportKindString(importKind),
+          accessPath.front().Item, *getImportKindKeyword(importKind),
           static_cast<unsigned>(*actualKind)));
     }
 
     emittedDiag->fixItReplace(SourceRange(import->getKindLoc()),
-                              getImportKindString(*actualKind));
+                              *getImportKindKeyword(*actualKind));
     emittedDiag->flush();
 
     if (decls.size() == 1)

--- a/test/AutoDiff/Parse/differentiable_func_type.swift
+++ b/test/AutoDiff/Parse/differentiable_func_type.swift
@@ -2,39 +2,39 @@
 
 // expected-warning @+1 {{'@differentiable' has been renamed to '@differentiable(reverse)'}} {{23-23=(reverse)}}
 let a: @differentiable (Float) -> Float // okay
-// CHECK: (pattern_named 'a'
+// CHECK: (pattern_named "a"
 // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
 let b: @differentiable(reverse) (Float) -> Float // okay
-// CHECK: (pattern_named 'b'
+// CHECK: (pattern_named "b"
 // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
 let c: @differentiable(reverse) (Float, @noDerivative Float) -> Float // okay
-// CHECK: (pattern_named 'c'
+// CHECK: (pattern_named "c"
 // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 // CHECK-NEXT:  (type_function
-// CHECK-NEXT:    (type_tuple
+// CHECK-NEXT:    (arg_type=type_tuple
 // CHECK-NEXT:      (type_ident
-// CHECK-NEXT:        (component id='Float' bind=none))
+// CHECK-NEXT:        (component "Float" bind=none))
 // CHECK-NEXT:      (type_attributed attrs=@noDerivative
 // CHECK-NEXT:        (type_ident
-// CHECK-NEXT:          (component id='Float' bind=none)))
-// CHECK-NEXT:    (type_ident
-// CHECK-NEXT:      (component id='Float' bind=none)))))
+// CHECK-NEXT:          (component "Float" bind=none)))
+// CHECK-NEXT:    (result_type=type_ident
+// CHECK-NEXT:      (component "Float" bind=none)))))
 
 let d: @differentiable(reverse) (Float) throws -> Float // okay
-// CHECK: (pattern_named 'd'
+// CHECK: (pattern_named "d"
 // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
 let e: @differentiable(reverse) (Float) throws -> Float // okay
-// CHECK: (pattern_named 'e'
+// CHECK: (pattern_named "e"
 // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
 // Generic type test.
 struct A<T> {
   func foo() {
     let local: @differentiable(reverse) (T) -> T // okay
-    // CHECK: (pattern_named 'local'
+    // CHECK: (pattern_named "local"
     // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
   }
 }
@@ -52,28 +52,28 @@ let d: @differentiable(notValidArg) (Float) -> Float
 struct B {
   struct linear {}
   let propertyB1: @differentiable(reverse) (linear) -> Float // okay
-  // CHECK: (pattern_named 'propertyB1'
+  // CHECK: (pattern_named "propertyB1"
   // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
   let propertyB2: @differentiable(reverse) (linear) -> linear // okay
-  // CHECK: (pattern_named 'propertyB2'
+  // CHECK: (pattern_named "propertyB2"
   // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
   let propertyB3: @differentiable(reverse) (linear, linear) -> linear // okay
-  // CHECK: (pattern_named 'propertyB3'
+  // CHECK: (pattern_named "propertyB3"
   // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
   let propertyB4: @differentiable(reverse) (linear, Float) -> linear // okay
-  // CHECK: (pattern_named 'propertyB4'
+  // CHECK: (pattern_named "propertyB4"
   // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
   let propertyB5: @differentiable(reverse) (Float, linear) -> linear // okay
-  // CHECK: (pattern_named 'propertyB5'
+  // CHECK: (pattern_named "propertyB5"
   // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
   let propertyB6: @differentiable(reverse) (linear, linear, Float, linear)
     -> Float // okay
-  // CHECK: (pattern_named 'propertyB6'
+  // CHECK: (pattern_named "propertyB6"
   // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
   // expected-error @+1 {{expected ')' in '@differentiable' attribute}}
@@ -84,21 +84,21 @@ struct B {
 struct C {
   typealias reverse = (C) -> C
   let propertyC1: @differentiable(reverse) (reverse) -> Float // okay
-  // CHECK: (pattern_named 'propertyC1'
+  // CHECK: (pattern_named "propertyC1"
   // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
   let propertyC2: @differentiable(reverse) (reverse) -> reverse // okay
-  // CHECK: (pattern_named 'propertyC2'
+  // CHECK: (pattern_named "propertyC2"
   // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
   let propertyC3: @differentiable(reverse) reverse // okay
-  // CHECK: (pattern_named 'propertyC3'
+  // CHECK: (pattern_named "propertyC3"
   // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 
   let propertyC4: reverse // okay
-  // CHECK: (pattern_named 'propertyC4'
+  // CHECK: (pattern_named "propertyC4"
 
   let propertyC6: @differentiable(reverse) @convention(c) reverse // okay
-  // CHECK: (pattern_named 'propertyC6'
+  // CHECK: (pattern_named "propertyC6"
   // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 }

--- a/test/AutoDiff/Parse/differentiable_func_type.swift
+++ b/test/AutoDiff/Parse/differentiable_func_type.swift
@@ -3,20 +3,20 @@
 // expected-warning @+1 {{'@differentiable' has been renamed to '@differentiable(reverse)'}} {{23-23=(reverse)}}
 let a: @differentiable (Float) -> Float // okay
 // CHECK: (pattern_named "a"
-// CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+// CHECK-NEXT: (type_attributed attrs='@differentiable(reverse)'
 
 let b: @differentiable(reverse) (Float) -> Float // okay
 // CHECK: (pattern_named "b"
-// CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+// CHECK-NEXT: (type_attributed attrs='@differentiable(reverse)'
 
 let c: @differentiable(reverse) (Float, @noDerivative Float) -> Float // okay
 // CHECK: (pattern_named "c"
-// CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+// CHECK-NEXT: (type_attributed attrs='@differentiable(reverse)'
 // CHECK-NEXT:  (type_function
 // CHECK-NEXT:    (arg_type=type_tuple
 // CHECK-NEXT:      (type_ident
 // CHECK-NEXT:        (component "Float" unbound))
-// CHECK-NEXT:      (type_attributed attrs=@noDerivative
+// CHECK-NEXT:      (type_attributed attrs='@noDerivative'
 // CHECK-NEXT:        (type_ident
 // CHECK-NEXT:          (component "Float" unbound)))
 // CHECK-NEXT:    (result_type=type_ident
@@ -24,18 +24,18 @@ let c: @differentiable(reverse) (Float, @noDerivative Float) -> Float // okay
 
 let d: @differentiable(reverse) (Float) throws -> Float // okay
 // CHECK: (pattern_named "d"
-// CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+// CHECK-NEXT: (type_attributed attrs='@differentiable(reverse)'
 
 let e: @differentiable(reverse) (Float) throws -> Float // okay
 // CHECK: (pattern_named "e"
-// CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+// CHECK-NEXT: (type_attributed attrs='@differentiable(reverse)'
 
 // Generic type test.
 struct A<T> {
   func foo() {
     let local: @differentiable(reverse) (T) -> T // okay
     // CHECK: (pattern_named "local"
-    // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+    // CHECK-NEXT: (type_attributed attrs='@differentiable(reverse)'
   }
 }
 
@@ -53,28 +53,28 @@ struct B {
   struct linear {}
   let propertyB1: @differentiable(reverse) (linear) -> Float // okay
   // CHECK: (pattern_named "propertyB1"
-  // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+  // CHECK-NEXT: (type_attributed attrs='@differentiable(reverse)'
 
   let propertyB2: @differentiable(reverse) (linear) -> linear // okay
   // CHECK: (pattern_named "propertyB2"
-  // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+  // CHECK-NEXT: (type_attributed attrs='@differentiable(reverse)'
 
   let propertyB3: @differentiable(reverse) (linear, linear) -> linear // okay
   // CHECK: (pattern_named "propertyB3"
-  // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+  // CHECK-NEXT: (type_attributed attrs='@differentiable(reverse)'
 
   let propertyB4: @differentiable(reverse) (linear, Float) -> linear // okay
   // CHECK: (pattern_named "propertyB4"
-  // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+  // CHECK-NEXT: (type_attributed attrs='@differentiable(reverse)'
 
   let propertyB5: @differentiable(reverse) (Float, linear) -> linear // okay
   // CHECK: (pattern_named "propertyB5"
-  // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+  // CHECK-NEXT: (type_attributed attrs='@differentiable(reverse)'
 
   let propertyB6: @differentiable(reverse) (linear, linear, Float, linear)
     -> Float // okay
   // CHECK: (pattern_named "propertyB6"
-  // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+  // CHECK-NEXT: (type_attributed attrs='@differentiable(reverse)'
 
   // expected-error @+1 {{expected ')' in '@differentiable' attribute}}
   let propertyB7: @differentiable(reverse (linear) -> Float
@@ -85,20 +85,20 @@ struct C {
   typealias reverse = (C) -> C
   let propertyC1: @differentiable(reverse) (reverse) -> Float // okay
   // CHECK: (pattern_named "propertyC1"
-  // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+  // CHECK-NEXT: (type_attributed attrs='@differentiable(reverse)'
 
   let propertyC2: @differentiable(reverse) (reverse) -> reverse // okay
   // CHECK: (pattern_named "propertyC2"
-  // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+  // CHECK-NEXT: (type_attributed attrs='@differentiable(reverse)'
 
   let propertyC3: @differentiable(reverse) reverse // okay
   // CHECK: (pattern_named "propertyC3"
-  // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+  // CHECK-NEXT: (type_attributed attrs='@differentiable(reverse)'
 
   let propertyC4: reverse // okay
   // CHECK: (pattern_named "propertyC4"
 
   let propertyC6: @differentiable(reverse) @convention(c) reverse // okay
   // CHECK: (pattern_named "propertyC6"
-  // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
+  // CHECK-NEXT: (type_attributed attrs='@differentiable(reverse)
 }

--- a/test/AutoDiff/Parse/differentiable_func_type.swift
+++ b/test/AutoDiff/Parse/differentiable_func_type.swift
@@ -15,12 +15,12 @@ let c: @differentiable(reverse) (Float, @noDerivative Float) -> Float // okay
 // CHECK-NEXT:  (type_function
 // CHECK-NEXT:    (arg_type=type_tuple
 // CHECK-NEXT:      (type_ident
-// CHECK-NEXT:        (component "Float" bind=none))
+// CHECK-NEXT:        (component "Float" unbound))
 // CHECK-NEXT:      (type_attributed attrs=@noDerivative
 // CHECK-NEXT:        (type_ident
-// CHECK-NEXT:          (component "Float" bind=none)))
+// CHECK-NEXT:          (component "Float" unbound)))
 // CHECK-NEXT:    (result_type=type_ident
-// CHECK-NEXT:      (component "Float" bind=none)))))
+// CHECK-NEXT:      (component "Float" unbound)))))
 
 let d: @differentiable(reverse) (Float) throws -> Float // okay
 // CHECK: (pattern_named "d"

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -26,7 +26,7 @@ func asyncFunc() async {
 // CHECK-AST:       (single_expression_body=await_expr type='()'
 // CHECK-AST-NEXT:    (call_expr type='()'
 // CHECK-AST-NEXT:       (fn=declref_expr type='() async -> ()'
-// CHECK-AST-SAME:        decl=async_main.(file).asyncFunc()@
+// CHECK-AST-SAME:        decl='async_main.(file).asyncFunc()@
 
 // CHECK-AST-LABEL: (func_decl implicit "$main()" interface
 // CHECK-AST:       (body=brace_stmt
@@ -34,7 +34,7 @@ func asyncFunc() async {
 // CHECK-AST-NEXT:      (call_expr implicit type='()'
 // CHECK-AST-NEXT:        (fn=declref_expr implicit
 // CHECK-AST-SAME:             type='(@escaping () async throws -> ()) -> ()'
-// CHECK-AST-SAME:             decl=_Concurrency.(file)._runAsyncMain
+// CHECK-AST-SAME:             decl='_Concurrency.(file)._runAsyncMain
 // CHECK-AST-SAME:             function_ref=single
 // CHECK-AST-NEXT:        (arg=paren_expr implicit type='(() async throws -> ())'
 // CHECK-AST-NEXT:          (function_conversion_expr implicit type='() async throws -> ()'

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -25,18 +25,18 @@ func asyncFunc() async {
 // CHECK-AST-LABEL: "main()" interface
 // CHECK-AST:       (single_expression_body=await_expr type='()'
 // CHECK-AST-NEXT:    (call_expr type='()'
-// CHECK-AST-NEXT:       (declref_expr type='() async -> ()'
+// CHECK-AST-NEXT:       (fn=declref_expr type='() async -> ()'
 // CHECK-AST-SAME:        decl=async_main.(file).asyncFunc()@
 
 // CHECK-AST-LABEL: (func_decl implicit "$main()" interface
 // CHECK-AST:       (body=brace_stmt
 // CHECK-AST-NEXT:    (return_stmt implicit
 // CHECK-AST-NEXT:      (call_expr implicit type='()'
-// CHECK-AST-NEXT:        (declref_expr implicit
+// CHECK-AST-NEXT:        (fn=declref_expr implicit
 // CHECK-AST-SAME:             type='(@escaping () async throws -> ()) -> ()'
 // CHECK-AST-SAME:             decl=_Concurrency.(file)._runAsyncMain
 // CHECK-AST-SAME:             function_ref=single
-// CHECK-AST-NEXT:        (paren_expr implicit type='(() async throws -> ())'
+// CHECK-AST-NEXT:        (arg=paren_expr implicit type='(() async throws -> ())'
 // CHECK-AST-NEXT:          (function_conversion_expr implicit type='() async throws -> ()'
 // CHECK-AST-NEXT:          (dot_syntax_call_expr
-// CHECK-AST-NEXT:          (autoclosure_expr implicit type='(MyProgram.Type) -> () async -> ()'
+// CHECK-AST-NEXT:          (fn=autoclosure_expr implicit type='(MyProgram.Type) -> () async -> ()'

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -23,13 +23,13 @@ func asyncFunc() async {
 // CHECK-EXEC: Hello World!
 
 // CHECK-AST-LABEL: "main()" interface
-// CHECK-AST:       (await_expr type='()'
+// CHECK-AST:       (single_expression_body=await_expr type='()'
 // CHECK-AST-NEXT:    (call_expr type='()'
 // CHECK-AST-NEXT:       (declref_expr type='() async -> ()'
 // CHECK-AST-SAME:        decl=async_main.(file).asyncFunc()@
 
 // CHECK-AST-LABEL: (func_decl implicit "$main()" interface
-// CHECK-AST:       (brace_stmt
+// CHECK-AST:       (body=brace_stmt
 // CHECK-AST-NEXT:    (return_stmt implicit
 // CHECK-AST-NEXT:      (call_expr implicit type='()'
 // CHECK-AST-NEXT:        (declref_expr implicit

--- a/test/Concurrency/closure_isolation.swift
+++ b/test/Concurrency/closure_isolation.swift
@@ -17,32 +17,32 @@ extension MyActor {
   func testClosureIsolation() async {
     // CHECK: acceptClosure
     // CHECK: closure_expr
-    // CHECK: actor-isolated
+    // CHECK: actor_isolated
     acceptClosure { self.syncMethod() }
 
     // CHECK: acceptSendableClosure
     // CHECK: closure_expr
-    // CHECK-NOT: actor-isolated
+    // CHECK-NOT: actor_isolated
     acceptSendableClosure { print(self) }
 
     // CHECK: acceptAsyncClosure
     // CHECK: closure_expr
-    // CHECK-SAME: actor-isolated=closure_isolation.(file).MyActor extension.testClosureIsolation().self
+    // CHECK-SAME: actor_isolated=closure_isolation.(file).MyActor extension.testClosureIsolation().self
     acceptAsyncClosure { await method() }
 
     // CHECK: acceptAsyncClosure
     // CHECK: closure_expr
-    // CHECK-NOT: actor-isolated
+    // CHECK-NOT: actor_isolated
     acceptAsyncClosure { () async in print() }
 
     // CHECK: acceptEscapingAsyncClosure
     // CHECK: closure_expr
-    // CHECK: actor-isolated
+    // CHECK: actor_isolated
     acceptEscapingAsyncClosure { self.syncMethod() }
 
     // CHECK: acceptEscapingAsyncClosure
     // CHECK: closure_expr
-    // CHECK: actor-isolated
+    // CHECK: actor_isolated
     acceptEscapingAsyncClosure { () async in print(self) }
   }
 }
@@ -62,21 +62,21 @@ func someAsyncFunc() async { }
 @SomeGlobalActor func someGlobalActorFunc() async {
   // CHECK: acceptAsyncClosure
   // CHECK: closure_expr
-  // CHECK-SAME: global-actor-isolated=SomeGlobalActor
+  // CHECK-SAME: global_actor_isolated=SomeGlobalActor
   acceptAsyncClosure { await someAsyncFunc() }
 
   // CHECK: acceptAsyncClosure
   // CHECK: closure_expr
-  // CHECK-SAME: global-actor-isolated=SomeGlobalActor
+  // CHECK-SAME: global_actor_isolated=SomeGlobalActor
   acceptAsyncClosure { () async in print("hello") }
 
   // CHECK: acceptEscapingAsyncClosure
   // CHECK: closure_expr
-  // CHECK: actor-isolated
+  // CHECK: actor_isolated
   acceptEscapingAsyncClosure { await someAsyncFunc() }
 
   // CHECK: acceptEscapingAsyncClosure
   // CHECK: closure_expr
-  // CHECK: actor-isolated
+  // CHECK: actor_isolated
   acceptEscapingAsyncClosure { () async in print("hello") }
 }

--- a/test/Concurrency/closure_isolation.swift
+++ b/test/Concurrency/closure_isolation.swift
@@ -27,7 +27,7 @@ extension MyActor {
 
     // CHECK: acceptAsyncClosure
     // CHECK: closure_expr
-    // CHECK-SAME: actor_isolated=closure_isolation.(file).MyActor extension.testClosureIsolation().self
+    // CHECK-SAME: actor_isolated='closure_isolation.(file).MyActor extension.testClosureIsolation().self@
     acceptAsyncClosure { await method() }
 
     // CHECK: acceptAsyncClosure
@@ -62,12 +62,12 @@ func someAsyncFunc() async { }
 @SomeGlobalActor func someGlobalActorFunc() async {
   // CHECK: acceptAsyncClosure
   // CHECK: closure_expr
-  // CHECK-SAME: global_actor_isolated=SomeGlobalActor
+  // CHECK-SAME: global_actor_isolated='SomeGlobalActor'
   acceptAsyncClosure { await someAsyncFunc() }
 
   // CHECK: acceptAsyncClosure
   // CHECK: closure_expr
-  // CHECK-SAME: global_actor_isolated=SomeGlobalActor
+  // CHECK-SAME: global_actor_isolated='SomeGlobalActor'
   acceptAsyncClosure { () async in print("hello") }
 
   // CHECK: acceptEscapingAsyncClosure

--- a/test/Constraints/interpolation_segments.swift
+++ b/test/Constraints/interpolation_segments.swift
@@ -6,7 +6,7 @@
 // has been assigned a type variable, but the calls inside the body have not.
 
 // CHECK: ---Initial constraints for the given expression---
-// CHECK: (interpolated_string_literal_expr type='$T
+// CHECK: (src=interpolated_string_literal_expr type='$T
 // CHECK-NOT: (call_expr implicit type='$T
 // CHECK: ---Solution---
 

--- a/test/DWARFImporter/basic.swift
+++ b/test/DWARFImporter/basic.swift
@@ -23,10 +23,10 @@ import ObjCModule
 
 let pureSwift = Int32(42)
 // FAIL-NOT:  var_decl
-// CHECK:     var_decl "pureSwift" {{.*}} type='Int32'
-// SWIFTONLY: var_decl "pureSwift" {{.*}} type='Int32' 
+// CHECK:     var_decl "pureSwift" type='Int32'
+// SWIFTONLY: var_decl "pureSwift" type='Int32' 
 
 let point = Point(x: 1, y: 2)
-// CHECK:     var_decl "point" {{.*}} type='Point'
+// CHECK:     var_decl "point" type='Point'
 // SWIFTONLY-NOT: var_decl "point"
 

--- a/test/Frontend/debug-generic-signatures.swift
+++ b/test/Frontend/debug-generic-signatures.swift
@@ -32,9 +32,9 @@ protocol P3 {
 }
 
 // CHECK-LABEL: StructDecl name=Basic
-// CHECK: (normal_conformance type=Basic protocol=P1
-// CHECK-NEXT: (assoc_type req=A type=Int)
-// CHECK-NEXT: (value req=f() witness=main.(file).Basic.f()@{{.*}}))
+// CHECK: (normal_conformance type='Basic' protocol='main.(file).P1@
+// CHECK-NEXT: (assoc_type "A" type='Int')
+// CHECK-NEXT: (value "f()" witness='main.(file).Basic.f()@{{.*}}'))
 struct Basic: P1 {
     typealias A = Int
     func f() -> Int { fatalError() }
@@ -43,11 +43,11 @@ struct Basic: P1 {
 // Recursive conformances should have finite output.
 
 // CHECK-LABEL: StructDecl name=Recur
-// CHECK-NEXT: (normal_conformance type=Recur protocol=P2
-// CHECK-NEXT:   (assoc_type req=A type=Recur)
-// CHECK-NEXT:   (assoc_type req=B type=Recur)
-// CHECK-NEXT:   (normal_conformance type=Recur protocol=P2 (details printed above))
-// CHECK-NEXT:   (normal_conformance type=Recur protocol=P2 (details printed above)))
+// CHECK-NEXT: (normal_conformance type='Recur' protocol='main.(file).P2@
+// CHECK-NEXT:   (assoc_type "A" type='Recur')
+// CHECK-NEXT:   (assoc_type "B" type='Recur')
+// CHECK-NEXT:   (sig_conf=normal_conformance type='Recur' protocol='main.(file).P2@{{[^']*}}' <<details printed above>>)
+// CHECK-NEXT:   (sig_conf=normal_conformance type='Recur' protocol='main.(file).P2@{{[^']*}}' <<details printed above>>))
 struct Recur: P2 {
     typealias A = Recur
     typealias B = Recur
@@ -56,15 +56,15 @@ struct Recur: P2 {
 // The full information about a conformance doesn't need to be printed twice.
 
 // CHECK-LABEL: StructDecl name=NonRecur
-// CHECK-NEXT: (normal_conformance type=NonRecur protocol=P2
-// CHECK-NEXT:   (assoc_type req=A type=Recur)
-// CHECK-NEXT:   (assoc_type req=B type=Recur)
-// CHECK-NEXT:   (normal_conformance type=Recur protocol=P2
-// CHECK-NEXT:     (assoc_type req=A type=Recur)
-// CHECK-NEXT:     (assoc_type req=B type=Recur)
-// CHECK-NEXT:     (normal_conformance type=Recur protocol=P2 (details printed above))
-// CHECK-NEXT:     (normal_conformance type=Recur protocol=P2 (details printed above)))
-// CHECK-NEXT:   (normal_conformance type=Recur protocol=P2 (details printed above)))
+// CHECK-NEXT: (normal_conformance type='NonRecur' protocol='main.(file).P2@
+// CHECK-NEXT:   (assoc_type "A" type='Recur')
+// CHECK-NEXT:   (assoc_type "B" type='Recur')
+// CHECK-NEXT:   (sig_conf=normal_conformance type='Recur' protocol='main.(file).P2@
+// CHECK-NEXT:     (assoc_type "A" type='Recur')
+// CHECK-NEXT:     (assoc_type "B" type='Recur')
+// CHECK-NEXT:     (sig_conf=normal_conformance type='Recur' protocol='main.(file).P2@{{[^']*}}' <<details printed above>>)
+// CHECK-NEXT:     (sig_conf=normal_conformance type='Recur' protocol='main.(file).P2@{{[^']*}}' <<details printed above>>)
+// CHECK-NEXT:   (sig_conf=normal_conformance type='Recur' protocol='main.(file).P2@{{[^']*}}' <<details printed above>>)
 struct NonRecur: P2 {
     typealias A = Recur
     typealias B = Recur
@@ -77,10 +77,10 @@ struct NonRecur: P2 {
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Generic
 struct Generic<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Generic
-// CHECK-NEXT: (normal_conformance type=Generic<T> protocol=P1
-// CHECK-NEXT:   (assoc_type req=A type=T)
-// CHECK-NEXT:   (value req=f() witness=main.(file).Generic extension.f()@{{.*}})
-// CHECK-NEXT:   conforms_to: T P1)
+// CHECK-NEXT: (normal_conformance type='Generic<T>' protocol='main.(file).P1@
+// CHECK-NEXT:   (assoc_type "A" type='T')
+// CHECK-NEXT:   (value "f()" witness='main.(file).Generic extension.f()@{{.*}}')
+// CHECK-NEXT:   (conditional=requirement 'T' conforms_to 'P1')
 extension Generic: P1 where T: P1 {
     typealias A = T
     func f() -> T { fatalError() }
@@ -94,13 +94,13 @@ extension Generic: P1 where T: P1 {
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Super
 class Super<T, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Super
-// CHECK-NEXT: (normal_conformance type=Super<T, U> protocol=P2
-// CHECK-NEXT:   (assoc_type req=A type=T)
-// CHECK-NEXT:   (assoc_type req=B type=T)
-// CHECK-NEXT:   (abstract_conformance protocol=P2)
-// CHECK-NEXT:   (abstract_conformance protocol=P2)
-// CHECK-NEXT:   conforms_to: T P2
-// CHECK-NEXT:   conforms_to: U P2)
+// CHECK-NEXT: (normal_conformance type='Super<T, U>' protocol='main.(file).P2@
+// CHECK-NEXT:   (assoc_type "A" type='T')
+// CHECK-NEXT:   (assoc_type "B" type='T')
+// CHECK-NEXT:   (sig_conf=abstract_conformance protocol='main.(file).P2@{{[^']*}}')
+// CHECK-NEXT:   (sig_conf=abstract_conformance protocol='main.(file).P2@{{[^']*}}')
+// CHECK-NEXT:   (conditional=requirement 'T' conforms_to 'P2')
+// CHECK-NEXT:   (conditional=requirement 'U' conforms_to 'P2'))
 extension Super: P2 where T: P2, U: P2 {
     typealias A = T
     typealias B = T
@@ -108,55 +108,55 @@ extension Super: P2 where T: P2, U: P2 {
 
 // Inherited/specialized conformances.
 // CHECK-LABEL: ClassDecl name=Sub
-// CHECK-NEXT: (inherited_conformance type=Sub protocol=P2
-// CHECK-NEXT:   (specialized_conformance type=Super<NonRecur, Recur> protocol=P2
-// CHECK-NEXT:      (substitution_map generic_signature=<T, U where T : P2, U : P2>
-// CHECK-NEXT:         (substitution T -> NonRecur)
-// CHECK-NEXT:         (substitution U -> Recur)
-// CHECK-NEXT:         (conformance type=T
-// CHECK-NEXT:            (normal_conformance type=NonRecur protocol=P2
-// CHECK-NEXT:              (assoc_type req=A type=Recur)
-// CHECK-NEXT:              (assoc_type req=B type=Recur)
-// CHECK-NEXT:              (normal_conformance type=Recur protocol=P2
-// CHECK-NEXT:                (assoc_type req=A type=Recur)
-// CHECK-NEXT:                (assoc_type req=B type=Recur)
-// CHECK-NEXT:                (normal_conformance type=Recur protocol=P2 (details printed above))
-// CHECK-NEXT:                (normal_conformance type=Recur protocol=P2 (details printed above)))
-// CHECK-NEXT:              (normal_conformance type=Recur protocol=P2 (details printed above))))
-// CHECK-NEXT:         (conformance type=U
-// CHECK-NEXT:            (normal_conformance type=Recur protocol=P2 (details printed above))))
-// CHECK-NEXT:     (conditional requirements unable to be computed)
-// CHECK-NEXT:     (normal_conformance type=Super<T, U> protocol=P2
-// CHECK-NEXT:       (assoc_type req=A type=T)
-// CHECK-NEXT:       (assoc_type req=B type=T)
-// CHECK-NEXT:       (abstract_conformance protocol=P2)
-// CHECK-NEXT:       (abstract_conformance protocol=P2)
-// CHECK-NEXT:       conforms_to: T P2
-// CHECK-NEXT:       conforms_to: U P2)))
+// CHECK-NEXT: (inherited_conformance type='Sub' protocol='main.(file).P2@
+// CHECK-NEXT:   (specialized_conformance type='Super<NonRecur, Recur>' protocol='main.(file).P2@
+// CHECK-NEXT:      (substitution_map generic_signature='<T, U where T : P2, U : P2>'
+// CHECK-NEXT:         (substitution generic_param='T' replacement_type='NonRecur')
+// CHECK-NEXT:         (substitution generic_param='U' replacement_type='Recur')
+// CHECK-NEXT:         (conformance type='T'
+// CHECK-NEXT:            (normal_conformance type='NonRecur' protocol='main.(file).P2@
+// CHECK-NEXT:              (assoc_type "A" type='Recur')
+// CHECK-NEXT:              (assoc_type "B" type='Recur')
+// CHECK-NEXT:              (sig_conf=normal_conformance type='Recur' protocol='main.(file).P2@
+// CHECK-NEXT:                (assoc_type "A" type='Recur')
+// CHECK-NEXT:                (assoc_type "B" type='Recur')
+// CHECK-NEXT:                (sig_conf=normal_conformance type='Recur' protocol='main.(file).P2@{{[^']*}}' <<details printed above>>)
+// CHECK-NEXT:                (sig_conf=normal_conformance type='Recur' protocol='main.(file).P2@{{[^']*}}' <<details printed above>>))
+// CHECK-NEXT:              (sig_conf=normal_conformance type='Recur' protocol='main.(file).P2@{{[^']*}}' <<details printed above>>)))
+// CHECK-NEXT:         (conformance type='U'
+// CHECK-NEXT:            (normal_conformance type='Recur' protocol='main.(file).P2@{{[^']*}}' <<details printed above>>)))
+// CHECK-NEXT:     (conditional=<<requirements unable to be computed>>)
+// CHECK-NEXT:     (normal_conformance type='Super<T, U>' protocol='main.(file).P2@
+// CHECK-NEXT:       (assoc_type "A" type='T')
+// CHECK-NEXT:       (assoc_type "B" type='T')
+// CHECK-NEXT:       (sig_conf=abstract_conformance protocol='main.(file).P2@{{[^']*}}')
+// CHECK-NEXT:       (sig_conf=abstract_conformance protocol='main.(file).P2@{{[^']*}}')
+// CHECK-NEXT:       (conditional=requirement 'T' conforms_to 'P2')
+// CHECK-NEXT:       (conditional=requirement 'U' conforms_to 'P2'))))
 class Sub: Super<NonRecur, Recur> {}
 
 // Specialization of a recursive conformance should be okay: recursion detection
 // should work through SubstitutionMaps.
 
 // CHECK-LABEL: StructDecl name=RecurGeneric
-// CHECK-NEXT: (normal_conformance type=RecurGeneric<T> protocol=P3
-// CHECK-NEXT:   (assoc_type req=A type=RecurGeneric<T>)
-// CHECK-NEXT:   (normal_conformance type=RecurGeneric<T> protocol=P3 (details printed above)))
+// CHECK-NEXT: (normal_conformance type='RecurGeneric<T>' protocol='main.(file).P3@
+// CHECK-NEXT:   (assoc_type "A" type='RecurGeneric<T>')
+// CHECK-NEXT:   (sig_conf=normal_conformance type='RecurGeneric<T>' protocol='main.(file).P3@{{[^']*}}' <<details printed above>>))
 struct RecurGeneric<T: P3>: P3 {
     typealias A = RecurGeneric<T>
 }
 
 // CHECK-LABEL: StructDecl name=Specialize
-// CHECK-NEXT: (normal_conformance type=Specialize protocol=P3
-// CHECK-NEXT:   (assoc_type req=A type=RecurGeneric<Specialize>)
-// CHECK-NEXT:   (specialized_conformance type=Specialize.A protocol=P3
-// CHECK-NEXT:     (substitution_map generic_signature=<T where T : P3>
-// CHECK-NEXT:       (substitution T -> Specialize)
-// CHECK-NEXT:       (conformance type=T
-// CHECK-NEXT:         (normal_conformance type=Specialize protocol=P3 (details printed above))))
-// CHECK-NEXT:     (normal_conformance type=RecurGeneric<T> protocol=P3
-// CHECK-NEXT:       (assoc_type req=A type=RecurGeneric<T>)
-// CHECK-NEXT:       (normal_conformance type=RecurGeneric<T> protocol=P3 (details printed above)))))
+// CHECK-NEXT: (normal_conformance type='Specialize' protocol='main.(file).P3@
+// CHECK-NEXT:   (assoc_type "A" type='RecurGeneric<Specialize>')
+// CHECK-NEXT:   (sig_conf=specialized_conformance type='Specialize.A' protocol='main.(file).P3@
+// CHECK-NEXT:     (substitution_map generic_signature='<T where T : P3>'
+// CHECK-NEXT:       (substitution generic_param='T' replacement_type='Specialize')
+// CHECK-NEXT:       (conformance type='T'
+// CHECK-NEXT:         (normal_conformance type='Specialize' protocol='main.(file).P3@{{[^']*}}' <<details printed above>>)))
+// CHECK-NEXT:     (normal_conformance type='RecurGeneric<T>' protocol='main.(file).P3@
+// CHECK-NEXT:       (assoc_type "A" type='RecurGeneric<T>')
+// CHECK-NEXT:       (sig_conf=normal_conformance type='RecurGeneric<T>' protocol='main.(file).P3@{{[^']*}}' <<details printed above>>))))
 struct Specialize: P3 {
     typealias A = RecurGeneric<Specialize>
 }

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -18,9 +18,9 @@ func foo(_ n: Int) -> Int {
 // CHECK-AST-LABEL: (func_decl{{.*}}"bar()"
 func bar() {
   // CHECK: (body=brace_stmt
-  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}'{{.*}} name=foo
-  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}'{{.*}} name=foo
-  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}'{{.*}} name=foo
+  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}'{{.*}} "foo"
+  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}'{{.*}} "foo"
+  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}'{{.*}} "foo"
   // CHECK-AST: (body=brace_stmt
   // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
   // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
@@ -58,21 +58,21 @@ enum TrailingSemi {
 // CHECK-AST-LABEL:   (func_decl{{.*}}"generic(_:)" <T : Hashable> interface type='<T where T : Hashable> (T) -> ()' access=internal captures=(<generic> )
 func generic<T: Hashable>(_: T) {}
 // CHECK-AST:       (pattern_binding_decl
-// CHECK-AST:         (declref_expr type='(Int) -> ()' location={{.*}} range={{.*}} decl=main.(file).generic@{{.*}} [with (substitution_map generic_signature=<T where T : Hashable> (substitution T -> Int))] function_ref=unapplied))
+// CHECK-AST:         (processed_init=declref_expr type='(Int) -> ()' location={{.*}} range={{.*}} decl=main.(file).generic@{{.*}} [with (substitution_map generic_signature=<T where T : Hashable> (substitution T -> Int))] function_ref=unapplied))
 let _: (Int) -> () = generic
 
 // Closures should be marked as escaping or not.
 func escaping(_: @escaping (Int) -> Int) {}
 escaping({ $0 })
-// CHECK-AST:        (declref_expr type='(@escaping (Int) -> Int) -> ()'
-// CHECK-AST-NEXT:        (paren_expr
-// CHECK-AST-NEXT:          (closure_expr type='(Int) -> Int' {{.*}} discriminator=0 escaping single-expression
+// CHECK-AST:        (fn=declref_expr type='(@escaping (Int) -> Int) -> ()'
+// CHECK-AST-NEXT:        (arg=paren_expr
+// CHECK-AST-NEXT:          (closure_expr type='(Int) -> Int' {{.*}} discriminator=0 escaping single_expr
 
 func nonescaping(_: (Int) -> Int) {}
 nonescaping({ $0 })
-// CHECK-AST:        (declref_expr type='((Int) -> Int) -> ()'
-// CHECK-AST-NEXT:        (paren_expr
-// CHECK-AST-NEXT:          (closure_expr type='(Int) -> Int' {{.*}} discriminator=1 single-expression
+// CHECK-AST:        (fn=declref_expr type='((Int) -> Int) -> ()'
+// CHECK-AST-NEXT:        (arg=paren_expr
+// CHECK-AST-NEXT:          (closure_expr type='(Int) -> Int' {{.*}} discriminator=1 single_expr
 
 // CHECK-LABEL: (struct_decl range=[{{.+}}] "MyStruct")
 struct MyStruct {}
@@ -83,11 +83,11 @@ enum MyEnum {
     // CHECK-LABEL: (enum_case_decl range=[{{.+}}]
     // CHECK-NEXT:    (enum_element_decl range=[{{.+}}]  "foo(x:)"
     // CHECK-NEXT:      (parameter_list range=[{{.+}}]
-    // CHECK-NEXT:         (parameter "x" apiName=x)))
+    // CHECK-NEXT:         (parameter range=[{{.+}}] "x" type='<null type>' api_name=x)))
     // CHECK-NEXT:     (enum_element_decl range=[{{.+}}] "bar"))
     // CHECK-NEXT:  (enum_element_decl range=[{{.+}}] "foo(x:)"
     // CHECK-NEXT:    (parameter_list range=[{{.+}}]
-    // CHECK-NEXT:      (parameter "x" apiName=x)))
+    // CHECK-NEXT:      (parameter range=[{{.+}}] "x" type='<null type>' api_name=x)))
     // CHECK-NEXT:  (enum_element_decl range=[{{.+}}] "bar"))
     case foo(x: MyStruct), bar
 }
@@ -97,28 +97,28 @@ enum MyEnum {
 // CHECK-NEXT:      (sequence_expr type='<null>'
 // CHECK-NEXT:        (discard_assignment_expr type='<null>'{{.*}})
 // CHECK-NEXT:        (assign_expr type='<null>'
-// CHECK-NEXT:          (<<null>>)
-// CHECK-NEXT:          (<<null>>))
+// CHECK-NEXT:          (dest=<<null>>)
+// CHECK-NEXT:          (src=<<null>>))
 // CHECK-NEXT:        (closure_expr type='<null>'{{.*}} discriminator={{[0-9]+}}
 // CHECK-NEXT:          (parameter_list range=[{{.+}}]
-// CHECK-NEXT:            (parameter "v"))
-// CHECK-NEXT:          (brace_stmt range=[{{.+}}])))))
+// CHECK-NEXT:            (parameter range=[{{.+}}] "v" type='<null type>'))
+// CHECK-NEXT:          (body=brace_stmt range=[{{.+}}])))))
 _ = { (v: MyEnum) in }
 
 // CHECK-LABEL: (struct_decl range=[{{.+}}] "SelfParam"
 struct SelfParam {
 
   // CHECK-LABEL: (func_decl range=[{{.+}}] "createOptional()" type
-  // CHECK-NEXT:    (self=parameter "self")
+  // CHECK-NEXT:    (self=parameter implicit range=[{{.+}}] "self" type='<null type>')
   // CHECK-NEXT:    (parameter_list range=[{{.+}}])
   // CHECK-NEXT:    (result=type_optional
   // CHECK-NEXT:      (type_ident
-  // CHECK-NEXT:        (component id='SelfParam' bind=none)))
+  // CHECK-NEXT:        (component "SelfParam" bind=none)))
   static func createOptional() -> SelfParam? {
 
     // CHECK-LABEL: (single_expression_body=call_expr type='<null>'{{.*}} arg_labels=
-    // CHECK-NEXT:    (unresolved_decl_ref_expr type='<null>'{{.*}} name=SelfParam function_ref=unapplied)
-    // CHECK-NEXT:    (tuple_expr type='()'{{.*}}))
+    // CHECK-NEXT:    (fn=unresolved_decl_ref_expr type='<null>'{{.*}} "SelfParam" function_ref=unapplied)
+    // CHECK-NEXT:    (arg=tuple_expr type='()'{{.*}}))
     SelfParam()
   }
 }

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -55,7 +55,7 @@ enum TrailingSemi {
 };
 
 // The substitution map for a declref should be relatively unobtrustive.
-// CHECK-AST-LABEL:   (func_decl{{.*}}"generic(_:)" <T : Hashable> interface type='<T where T : Hashable> (T) -> ()' access=internal captures=(<generic> )
+// CHECK-AST-LABEL:   (func_decl{{.*}}"generic(_:)" '<T : Hashable>' interface type='<T where T : Hashable> (T) -> ()' access=internal override=() captures=(<generic> )
 func generic<T: Hashable>(_: T) {}
 // CHECK-AST:       (pattern_binding_decl
 // CHECK-AST:         (processed_init=declref_expr type='(Int) -> ()' location={{.*}} range={{.*}} decl='main.(file).generic@{{.*}} [with (substitution_map generic_signature=<T where T : Hashable> T='Int')]' function_ref=unapplied))

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -6,10 +6,10 @@
 func foo(_ n: Int) -> Int {
   // CHECK:   (body=brace_stmt
   // CHECK:     (return_stmt
-  // CHECK:       (integer_literal_expr type='<null type>'{{.*}} value=42 {{.*}})))
+  // CHECK:       (integer_literal_expr type='<null type>'{{.*}} 42 {{.*}})))
   // CHECK-AST: (body=brace_stmt
   // CHECK-AST:   (return_stmt
-  // CHECK-AST:     (integer_literal_expr type='{{[^']+}}' {{.*}} value=42 {{.*}})
+  // CHECK-AST:     (integer_literal_expr type='{{[^']+}}' {{.*}} 42 {{.*}})
     return 42
 }
 
@@ -22,9 +22,9 @@ func bar() {
   // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}'{{.*}} "foo"
   // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}'{{.*}} "foo"
   // CHECK-AST: (body=brace_stmt
-  // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
-  // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
-  // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
+  // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl='main.(file).foo@
+  // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl='main.(file).foo@
+  // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl='main.(file).foo@
   foo foo foo
 }
 
@@ -58,7 +58,7 @@ enum TrailingSemi {
 // CHECK-AST-LABEL:   (func_decl{{.*}}"generic(_:)" <T : Hashable> interface type='<T where T : Hashable> (T) -> ()' access=internal captures=(<generic> )
 func generic<T: Hashable>(_: T) {}
 // CHECK-AST:       (pattern_binding_decl
-// CHECK-AST:         (processed_init=declref_expr type='(Int) -> ()' location={{.*}} range={{.*}} decl=main.(file).generic@{{.*}} [with (substitution_map generic_signature=<T where T : Hashable> (substitution T -> Int))] function_ref=unapplied))
+// CHECK-AST:         (processed_init=declref_expr type='(Int) -> ()' location={{.*}} range={{.*}} decl='main.(file).generic@{{.*}} [with (substitution_map generic_signature=<T where T : Hashable> (substitution T -> Int))]' function_ref=unapplied))
 let _: (Int) -> () = generic
 
 // Closures should be marked as escaping or not.
@@ -74,46 +74,46 @@ nonescaping({ $0 })
 // CHECK-AST-NEXT:        (arg=paren_expr
 // CHECK-AST-NEXT:          (closure_expr type='(Int) -> Int' {{.*}} discriminator=1 single_expr
 
-// CHECK-LABEL: (struct_decl range=[{{.+}}] "MyStruct")
+// CHECK-LABEL: (struct_decl range='[{{.+}}]' "MyStruct")
 struct MyStruct {}
 
-// CHECK-LABEL: (enum_decl range=[{{.+}}] "MyEnum"
+// CHECK-LABEL: (enum_decl range='[{{.+}}]' "MyEnum"
 enum MyEnum {
 
-    // CHECK-LABEL: (enum_case_decl range=[{{.+}}]
-    // CHECK-NEXT:    (enum_element_decl range=[{{.+}}]  "foo(x:)"
-    // CHECK-NEXT:      (parameter_list range=[{{.+}}]
-    // CHECK-NEXT:         (parameter range=[{{.+}}] "x" type='<null type>' api_name="x")))
-    // CHECK-NEXT:     (enum_element_decl range=[{{.+}}] "bar"))
-    // CHECK-NEXT:  (enum_element_decl range=[{{.+}}] "foo(x:)"
-    // CHECK-NEXT:    (parameter_list range=[{{.+}}]
-    // CHECK-NEXT:      (parameter range=[{{.+}}] "x" type='<null type>' api_name="x")))
-    // CHECK-NEXT:  (enum_element_decl range=[{{.+}}] "bar"))
+    // CHECK-LABEL: (enum_case_decl range='[{{.+}}]'
+    // CHECK-NEXT:    (enum_element_decl range='[{{.+}}]' "foo(x:)"
+    // CHECK-NEXT:      (parameter_list range='[{{.+}}]'
+    // CHECK-NEXT:         (parameter range='[{{.+}}]' "x" type='<null type>' api_name="x")))
+    // CHECK-NEXT:     (enum_element_decl range='[{{.+}}]' "bar"))
+    // CHECK-NEXT:  (enum_element_decl range='[{{.+}}]' "foo(x:)"
+    // CHECK-NEXT:    (parameter_list range='[{{.+}}]'
+    // CHECK-NEXT:      (parameter range='[{{.+}}]' "x" type='<null type>' api_name="x")))
+    // CHECK-NEXT:  (enum_element_decl range='[{{.+}}]' "bar"))
     case foo(x: MyStruct), bar
 }
 
-// CHECK-LABEL: (top_level_code_decl range=[{{.+}}]
-// CHECK-NEXT:    (brace_stmt implicit range=[{{.+}}]
+// CHECK-LABEL: (top_level_code_decl range='[{{.+}}]'
+// CHECK-NEXT:    (brace_stmt implicit range='[{{.+}}]'
 // CHECK-NEXT:      (sequence_expr type='<null type>'
 // CHECK-NEXT:        (discard_assignment_expr type='<null type>'{{.*}})
 // CHECK-NEXT:        (assign_expr type='<null type>'
 // CHECK-NEXT:          (dest=<<null>>)
 // CHECK-NEXT:          (src=<<null>>))
 // CHECK-NEXT:        (closure_expr type='<null type>'{{.*}} discriminator={{[0-9]+}}
-// CHECK-NEXT:          (parameter_list range=[{{.+}}]
-// CHECK-NEXT:            (parameter range=[{{.+}}] "v" type='<null type>'))
-// CHECK-NEXT:          (body=brace_stmt range=[{{.+}}])))))
+// CHECK-NEXT:          (parameter_list range='[{{.+}}]'
+// CHECK-NEXT:            (parameter range='[{{.+}}]' "v" type='<null type>'))
+// CHECK-NEXT:          (body=brace_stmt range='[{{.+}}]')))))
 _ = { (v: MyEnum) in }
 
-// CHECK-LABEL: (struct_decl range=[{{.+}}] "SelfParam"
+// CHECK-LABEL: (struct_decl range='[{{.+}}]' "SelfParam"
 struct SelfParam {
 
-  // CHECK-LABEL: (func_decl range=[{{.+}}] "createOptional()" type
-  // CHECK-NEXT:    (self=parameter implicit range=[{{.+}}] "self" type='<null type>')
-  // CHECK-NEXT:    (parameter_list range=[{{.+}}])
+  // CHECK-LABEL: (func_decl range='[{{.+}}]' "createOptional()" type
+  // CHECK-NEXT:    (self=parameter implicit range='[{{.+}}]' "self" type='<null type>')
+  // CHECK-NEXT:    (parameter_list range='[{{.+}}]')
   // CHECK-NEXT:    (result=type_optional
   // CHECK-NEXT:      (type_ident
-  // CHECK-NEXT:        (component "SelfParam" bind=none)))
+  // CHECK-NEXT:        (component "SelfParam" unbound)))
   static func createOptional() -> SelfParam? {
 
     // CHECK-LABEL: (single_expression_body=call_expr type='<null type>'{{.*}} arg_labels=

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -38,8 +38,8 @@ enum TrailingSemi {
   case A,B;
 
   // CHECK-LABEL: (subscript_decl{{.*}}trailing_semi
-  // CHECK-NOT:   (func_decl{{.*}}trailing_semi 'anonymous @ {{.*}}' get_for=subscript(_:)
-  // CHECK:       (accessor_decl{{.*}}'anonymous @ {{.*}}' get_for=subscript(_:)
+  // CHECK-NOT:   (func_decl{{.*}}trailing_semi get_for="subscript(_:)"
+  // CHECK:       (accessor_decl{{.*}} get_for="subscript(_:)"
   subscript(x: Int) -> Int {
     // CHECK-LABEL: (pattern_binding_decl{{.*}}trailing_semi
     // CHECK-NOT:   (var_decl{{.*}}trailing_semi "y"

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -58,7 +58,7 @@ enum TrailingSemi {
 // CHECK-AST-LABEL:   (func_decl{{.*}}"generic(_:)" <T : Hashable> interface type='<T where T : Hashable> (T) -> ()' access=internal captures=(<generic> )
 func generic<T: Hashable>(_: T) {}
 // CHECK-AST:       (pattern_binding_decl
-// CHECK-AST:         (processed_init=declref_expr type='(Int) -> ()' location={{.*}} range={{.*}} decl='main.(file).generic@{{.*}} [with (substitution_map generic_signature=<T where T : Hashable> (substitution T -> Int))]' function_ref=unapplied))
+// CHECK-AST:         (processed_init=declref_expr type='(Int) -> ()' location={{.*}} range={{.*}} decl='main.(file).generic@{{.*}} [with (substitution_map generic_signature=<T where T : Hashable> T='Int')]' function_ref=unapplied))
 let _: (Int) -> () = generic
 
 // Closures should be marked as escaping or not.

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -6,7 +6,7 @@
 func foo(_ n: Int) -> Int {
   // CHECK:   (body=brace_stmt
   // CHECK:     (return_stmt
-  // CHECK:       (integer_literal_expr type='<null>'{{.*}} value=42 {{.*}})))
+  // CHECK:       (integer_literal_expr type='<null type>'{{.*}} value=42 {{.*}})))
   // CHECK-AST: (body=brace_stmt
   // CHECK-AST:   (return_stmt
   // CHECK-AST:     (integer_literal_expr type='{{[^']+}}' {{.*}} value=42 {{.*}})
@@ -83,23 +83,23 @@ enum MyEnum {
     // CHECK-LABEL: (enum_case_decl range=[{{.+}}]
     // CHECK-NEXT:    (enum_element_decl range=[{{.+}}]  "foo(x:)"
     // CHECK-NEXT:      (parameter_list range=[{{.+}}]
-    // CHECK-NEXT:         (parameter range=[{{.+}}] "x" type='<null type>' api_name=x)))
+    // CHECK-NEXT:         (parameter range=[{{.+}}] "x" type='<null type>' api_name="x")))
     // CHECK-NEXT:     (enum_element_decl range=[{{.+}}] "bar"))
     // CHECK-NEXT:  (enum_element_decl range=[{{.+}}] "foo(x:)"
     // CHECK-NEXT:    (parameter_list range=[{{.+}}]
-    // CHECK-NEXT:      (parameter range=[{{.+}}] "x" type='<null type>' api_name=x)))
+    // CHECK-NEXT:      (parameter range=[{{.+}}] "x" type='<null type>' api_name="x")))
     // CHECK-NEXT:  (enum_element_decl range=[{{.+}}] "bar"))
     case foo(x: MyStruct), bar
 }
 
 // CHECK-LABEL: (top_level_code_decl range=[{{.+}}]
 // CHECK-NEXT:    (brace_stmt implicit range=[{{.+}}]
-// CHECK-NEXT:      (sequence_expr type='<null>'
-// CHECK-NEXT:        (discard_assignment_expr type='<null>'{{.*}})
-// CHECK-NEXT:        (assign_expr type='<null>'
+// CHECK-NEXT:      (sequence_expr type='<null type>'
+// CHECK-NEXT:        (discard_assignment_expr type='<null type>'{{.*}})
+// CHECK-NEXT:        (assign_expr type='<null type>'
 // CHECK-NEXT:          (dest=<<null>>)
 // CHECK-NEXT:          (src=<<null>>))
-// CHECK-NEXT:        (closure_expr type='<null>'{{.*}} discriminator={{[0-9]+}}
+// CHECK-NEXT:        (closure_expr type='<null type>'{{.*}} discriminator={{[0-9]+}}
 // CHECK-NEXT:          (parameter_list range=[{{.+}}]
 // CHECK-NEXT:            (parameter range=[{{.+}}] "v" type='<null type>'))
 // CHECK-NEXT:          (body=brace_stmt range=[{{.+}}])))))
@@ -116,8 +116,8 @@ struct SelfParam {
   // CHECK-NEXT:        (component "SelfParam" bind=none)))
   static func createOptional() -> SelfParam? {
 
-    // CHECK-LABEL: (single_expression_body=call_expr type='<null>'{{.*}} arg_labels=
-    // CHECK-NEXT:    (fn=unresolved_decl_ref_expr type='<null>'{{.*}} "SelfParam" function_ref=unapplied)
+    // CHECK-LABEL: (single_expression_body=call_expr type='<null type>'{{.*}} arg_labels=
+    // CHECK-NEXT:    (fn=unresolved_decl_ref_expr type='<null type>'{{.*}} "SelfParam" function_ref=unapplied)
     // CHECK-NEXT:    (arg=tuple_expr type='()'{{.*}}))
     SelfParam()
   }

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -55,10 +55,10 @@ enum TrailingSemi {
 };
 
 // The substitution map for a declref should be relatively unobtrustive.
-// CHECK-AST-LABEL:   (func_decl{{.*}}"generic(_:)" '<T : Hashable>' interface type='<T where T : Hashable> (T) -> ()' access=internal override=() captures=(<generic> )
+// CHECK-AST-LABEL:   (func_decl{{.*}}"generic(_:)" '<T : Hashable>' interface_type='<T where T : Hashable> (T) -> ()' access=internal override=() captures=(<generic> )
 func generic<T: Hashable>(_: T) {}
 // CHECK-AST:       (pattern_binding_decl
-// CHECK-AST:         (processed_init=declref_expr type='(Int) -> ()' location={{.*}} range={{.*}} decl='main.(file).generic@{{.*}} [with (substitution_map generic_signature=<T where T : Hashable> T='Int')]' function_ref=unapplied))
+// CHECK-AST:         (processed_init=declref_expr type='(Int) -> ()' location={{.*}} range={{.*}} decl='main.(file).generic@{{.*}} [with (substitution_map generic_signature='<T where T : Hashable>' T='Int')]' function_ref=unapplied))
 let _: (Int) -> () = generic
 
 // Closures should be marked as escaping or not.

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -6,7 +6,7 @@
 func foo(_ n: Int) -> Int {
   // CHECK:   (body=brace_stmt
   // CHECK:     (return_stmt
-  // CHECK:       (integer_literal_expr type='<null>' value=42 {{.*}})))
+  // CHECK:       (integer_literal_expr type='<null>'{{.*}} value=42 {{.*}})))
   // CHECK-AST: (body=brace_stmt
   // CHECK-AST:   (return_stmt
   // CHECK-AST:     (integer_literal_expr type='{{[^']+}}' {{.*}} value=42 {{.*}})
@@ -18,9 +18,9 @@ func foo(_ n: Int) -> Int {
 // CHECK-AST-LABEL: (func_decl{{.*}}"bar()"
 func bar() {
   // CHECK: (body=brace_stmt
-  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}' name=foo
-  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}' name=foo
-  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}' name=foo
+  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}'{{.*}} name=foo
+  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}'{{.*}} name=foo
+  // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}'{{.*}} name=foo
   // CHECK-AST: (body=brace_stmt
   // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
   // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
@@ -95,11 +95,11 @@ enum MyEnum {
 // CHECK-LABEL: (top_level_code_decl range=[{{.+}}]
 // CHECK-NEXT:    (brace_stmt implicit range=[{{.+}}]
 // CHECK-NEXT:      (sequence_expr type='<null>'
-// CHECK-NEXT:        (discard_assignment_expr type='<null>')
+// CHECK-NEXT:        (discard_assignment_expr type='<null>'{{.*}})
 // CHECK-NEXT:        (assign_expr type='<null>'
 // CHECK-NEXT:          (<<null>>)
 // CHECK-NEXT:          (<<null>>))
-// CHECK-NEXT:        (closure_expr type='<null>' discriminator={{[0-9]+}}
+// CHECK-NEXT:        (closure_expr type='<null>'{{.*}} discriminator={{[0-9]+}}
 // CHECK-NEXT:          (parameter_list range=[{{.+}}]
 // CHECK-NEXT:            (parameter "v"))
 // CHECK-NEXT:          (brace_stmt range=[{{.+}}])))))
@@ -116,8 +116,8 @@ struct SelfParam {
   // CHECK-NEXT:        (component id='SelfParam' bind=none)))
   static func createOptional() -> SelfParam? {
 
-    // CHECK-LABEL: (single_expression_body=call_expr type='<null>' arg_labels=
-    // CHECK-NEXT:    (unresolved_decl_ref_expr type='<null>' name=SelfParam function_ref=unapplied)
+    // CHECK-LABEL: (single_expression_body=call_expr type='<null>'{{.*}} arg_labels=
+    // CHECK-NEXT:    (unresolved_decl_ref_expr type='<null>'{{.*}} name=SelfParam function_ref=unapplied)
     // CHECK-NEXT:    (tuple_expr type='()'{{.*}}))
     SelfParam()
   }

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -4,10 +4,10 @@
 // CHECK-LABEL: (func_decl{{.*}}"foo(_:)"
 // CHECK-AST-LABEL: (func_decl{{.*}}"foo(_:)"
 func foo(_ n: Int) -> Int {
-  // CHECK:   (brace_stmt
+  // CHECK:   (body=brace_stmt
   // CHECK:     (return_stmt
   // CHECK:       (integer_literal_expr type='<null>' value=42 {{.*}})))
-  // CHECK-AST: (brace_stmt
+  // CHECK-AST: (body=brace_stmt
   // CHECK-AST:   (return_stmt
   // CHECK-AST:     (integer_literal_expr type='{{[^']+}}' {{.*}} value=42 {{.*}})
     return 42
@@ -17,11 +17,11 @@ func foo(_ n: Int) -> Int {
 // CHECK-LABEL: (func_decl{{.*}}"bar()"
 // CHECK-AST-LABEL: (func_decl{{.*}}"bar()"
 func bar() {
-  // CHECK: (brace_stmt
+  // CHECK: (body=brace_stmt
   // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}' name=foo
   // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}' name=foo
   // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}' name=foo
-  // CHECK-AST: (brace_stmt
+  // CHECK-AST: (body=brace_stmt
   // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
   // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
   // CHECK-AST-NEXT:   (declref_expr type='{{[^']+}}' {{.*}} decl=main.(file).foo
@@ -97,8 +97,8 @@ enum MyEnum {
 // CHECK-NEXT:      (sequence_expr type='<null>'
 // CHECK-NEXT:        (discard_assignment_expr type='<null>')
 // CHECK-NEXT:        (assign_expr type='<null>'
-// CHECK-NEXT:          (**NULL EXPRESSION**)
-// CHECK-NEXT:          (**NULL EXPRESSION**))
+// CHECK-NEXT:          (<<null>>)
+// CHECK-NEXT:          (<<null>>))
 // CHECK-NEXT:        (closure_expr type='<null>' discriminator={{[0-9]+}}
 // CHECK-NEXT:          (parameter_list range=[{{.+}}]
 // CHECK-NEXT:            (parameter "v"))
@@ -109,15 +109,14 @@ _ = { (v: MyEnum) in }
 struct SelfParam {
 
   // CHECK-LABEL: (func_decl range=[{{.+}}] "createOptional()" type
-  // CHECK-NEXT:    (parameter "self")
+  // CHECK-NEXT:    (self=parameter "self")
   // CHECK-NEXT:    (parameter_list range=[{{.+}}])
-  // CHECK-NEXT:    (result
-  // CHECK-NEXT:      (type_optional
-  // CHECK-NEXT:        (type_ident
-  // CHECK-NEXT:          (component id='SelfParam' bind=none))))
+  // CHECK-NEXT:    (result=type_optional
+  // CHECK-NEXT:      (type_ident
+  // CHECK-NEXT:        (component id='SelfParam' bind=none)))
   static func createOptional() -> SelfParam? {
 
-    // CHECK-LABEL: (call_expr type='<null>' arg_labels=
+    // CHECK-LABEL: (single_expression_body=call_expr type='<null>' arg_labels=
     // CHECK-NEXT:    (unresolved_decl_ref_expr type='<null>' name=SelfParam function_ref=unapplied)
     // CHECK-NEXT:    (tuple_expr type='()'{{.*}}))
     SelfParam()

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -38,8 +38,8 @@ enum TrailingSemi {
   case A,B;
 
   // CHECK-LABEL: (subscript_decl{{.*}}trailing_semi
-  // CHECK-NOT:   (func_decl{{.*}}trailing_semi 'anonname={{.*}}' get_for=subscript(_:)
-  // CHECK:       (accessor_decl{{.*}}'anonname={{.*}}' get_for=subscript(_:)
+  // CHECK-NOT:   (func_decl{{.*}}trailing_semi 'anonymous @ {{.*}}' get_for=subscript(_:)
+  // CHECK:       (accessor_decl{{.*}}'anonymous @ {{.*}}' get_for=subscript(_:)
   subscript(x: Int) -> Int {
     // CHECK-LABEL: (pattern_binding_decl{{.*}}trailing_semi
     // CHECK-NOT:   (var_decl{{.*}}trailing_semi "y"

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -19,8 +19,8 @@ func takes_P5<X: P5>(_: X) {}
 
 struct Free<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Free
-// CHECK-NEXT: (normal_conformance type=Free<T> protocol=P2
-// CHECK-NEXT:   conforms_to: T P1)
+// CHECK-NEXT: (normal_conformance type='Free<T>' protocol='conditional_conformances.(file).P2@
+// CHECK-NEXT:   (conditional=requirement 'T' conforms_to 'P1'))
 extension Free: P2 where T: P1 {} 
 // expected-note@-1 {{requirement from conditional conformance of 'Free<U>' to 'P2'}} 
 // expected-note@-2 {{requirement from conditional conformance of 'Free<T>' to 'P2'}}
@@ -34,8 +34,8 @@ func free_bad<U>(_: U) {
 struct Constrained<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Constrained
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Constrained
-// CHECK-NEXT: (normal_conformance type=Constrained<T> protocol=P2
-// CHECK-NEXT:   conforms_to: T P3)
+// CHECK-NEXT: (normal_conformance type='Constrained<T>' protocol='conditional_conformances.(file).P2@
+// CHECK-NEXT:   (conditional=requirement 'T' conforms_to 'P3'))
 extension Constrained: P2 where T: P3 {} // expected-note {{requirement from conditional conformance of 'Constrained<U>' to 'P2'}}
 func constrained_good<U: P1 & P3>(_: U) {
     takes_P2(Constrained<U>())
@@ -47,20 +47,20 @@ func constrained_bad<U: P1>(_: U) {
 struct RedundantSame<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSame
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSame
-// CHECK-NEXT: (normal_conformance type=RedundantSame<T> protocol=P2)
+// CHECK-NEXT: (normal_conformance type='RedundantSame<T>' protocol='conditional_conformances.(file).P2@{{[^']*}}')
 extension RedundantSame: P2 where T: P1 {}
 
 struct RedundantSuper<T: P4> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSuper
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSuper
-// CHECK-NEXT: (normal_conformance type=RedundantSuper<T> protocol=P2)
+// CHECK-NEXT: (normal_conformance type='RedundantSuper<T>' protocol='conditional_conformances.(file).P2@{{[^']*}}')
 extension RedundantSuper: P2 where T: P1 {}
 
 struct OverlappingSub<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=OverlappingSub
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=OverlappingSub
-// CHECK-NEXT: (normal_conformance type=OverlappingSub<T> protocol=P2
-// CHECK-NEXT:   conforms_to: T P4)
+// CHECK-NEXT: (normal_conformance type='OverlappingSub<T>' protocol='conditional_conformances.(file).P2
+// CHECK-NEXT:   (conditional=requirement 'T' conforms_to 'P4'))
 extension OverlappingSub: P2 where T: P4 {} // expected-note {{requirement from conditional conformance of 'OverlappingSub<U>' to 'P2'}}
 func overlapping_sub_good<U: P4>(_: U) {
     takes_P2(OverlappingSub<U>())
@@ -73,8 +73,8 @@ func overlapping_sub_bad<U: P1>(_: U) {
 struct SameType<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=SameType
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=SameType
-// CHECK-NEXT: (normal_conformance type=SameType<T> protocol=P2
-// CHECK-NEXT:   same_type: T Int)
+// CHECK-NEXT: (normal_conformance type='SameType<T>' protocol='conditional_conformances.(file).P2@
+// CHECK-NEXT:   (conditional=requirement 'T' same_type 'Int'))
 extension SameType: P2 where T == Int {}
 // expected-note@-1 {{requirement from conditional conformance of 'SameType<U>' to 'P2'}}
 // expected-note@-2 {{requirement from conditional conformance of 'SameType<Float>' to 'P2'}}
@@ -90,8 +90,8 @@ func same_type_bad<U>(_: U) {
 struct SameTypeGeneric<T, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=SameTypeGeneric
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=SameTypeGeneric
-// CHECK-NEXT: (normal_conformance type=SameTypeGeneric<T, U> protocol=P2
-// CHECK-NEXT:   same_type: T U)
+// CHECK-NEXT: (normal_conformance type='SameTypeGeneric<T, U>' protocol='conditional_conformances.(file).P2@
+// CHECK-NEXT:   (conditional=requirement 'T' same_type 'U'))
 extension SameTypeGeneric: P2 where T == U {}
 // expected-note@-1 {{requirement from conditional conformance of 'SameTypeGeneric<U, Int>' to 'P2'}}
 // expected-note@-2 {{requirement from conditional conformance of 'SameTypeGeneric<Int, Float>' to 'P2'}}
@@ -116,9 +116,9 @@ func same_type_bad<U, V>(_: U, _: V) {
 struct Infer<T, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Infer
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Infer
-// CHECK-NEXT: (normal_conformance type=Infer<T, U> protocol=P2
-// CHECK-NEXT:   same_type: T Constrained<U>
-// CHECK-NEXT:   conforms_to:  U P1)
+// CHECK-NEXT: (normal_conformance type='Infer<T, U>' protocol='conditional_conformances.(file).P2@
+// CHECK-NEXT:   (conditional=requirement 'T' same_type 'Constrained<U>')
+// CHECK-NEXT:   (conditional=requirement 'U' conforms_to 'P1'))
 extension Infer: P2 where T == Constrained<U> {}
 // expected-note@-1 2 {{requirement from conditional conformance of 'Infer<Constrained<U>, V>' to 'P2'}}
 func infer_good<U: P1>(_: U) {
@@ -135,8 +135,8 @@ func infer_bad<U: P1, V>(_: U, _: V) {
 struct InferRedundant<T, U: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InferRedundant
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InferRedundant
-// CHECK-NEXT: (normal_conformance type=InferRedundant<T, U> protocol=P2
-// CHECK-NEXT:   same_type: T Constrained<U>)
+// CHECK-NEXT: (normal_conformance type='InferRedundant<T, U>' protocol='conditional_conformances.(file).P2@
+// CHECK-NEXT:   (conditional=requirement 'T' same_type 'Constrained<U>'))
 extension InferRedundant: P2 where T == Constrained<U> {}
 func infer_redundant_good<U: P1>(_: U) {
     takes_P2(InferRedundant<Constrained<U>, U>())
@@ -156,8 +156,8 @@ class C3: C2 {}
 struct ClassFree<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassFree
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassFree
-// CHECK-NEXT: (normal_conformance type=ClassFree<T> protocol=P2
-// CHECK-NEXT:   superclass: T C1)
+// CHECK-NEXT: (normal_conformance type='ClassFree<T>' protocol='conditional_conformances.(file).P2@
+// CHECK-NEXT:   (conditional=requirement 'T' superclass 'C1'))
 extension ClassFree: P2 where T: C1 {} // expected-note {{requirement from conditional conformance of 'ClassFree<U>' to 'P2'}}
 func class_free_good<U: C1>(_: U) {
     takes_P2(ClassFree<U>())
@@ -170,8 +170,8 @@ func class_free_bad<U>(_: U) {
 struct ClassMoreSpecific<T: C1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassMoreSpecific
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassMoreSpecific
-// CHECK-NEXT: (normal_conformance type=ClassMoreSpecific<T> protocol=P2
-// CHECK-NEXT:   superclass: T C3)
+// CHECK-NEXT: (normal_conformance type='ClassMoreSpecific<T>' protocol='conditional_conformances.(file).P2@
+// CHECK-NEXT:   (conditional=requirement 'T' superclass 'C3'))
 extension ClassMoreSpecific: P2 where T: C3 {} // expected-note {{requirement from conditional conformance of 'ClassMoreSpecific<U>' to 'P2'}}
 func class_more_specific_good<U: C3>(_: U) {
     takes_P2(ClassMoreSpecific<U>())
@@ -185,7 +185,7 @@ func class_more_specific_bad<U: C1>(_: U) {
 struct ClassLessSpecific<T: C3> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassLessSpecific
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassLessSpecific
-// CHECK-NEXT: (normal_conformance type=ClassLessSpecific<T> protocol=P2)
+// CHECK-NEXT: (normal_conformance type='ClassLessSpecific<T>' protocol='conditional_conformances.(file).P2@{{[^']*}}')
 extension ClassLessSpecific: P2 where T: C1 {}
 
 
@@ -208,15 +208,15 @@ func subclass_bad() {
 struct InheritEqual<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual
-// CHECK-NEXT:  (normal_conformance type=InheritEqual<T> protocol=P2
-// CHECK-NEXT:    conforms_to: T P1)
+// CHECK-NEXT: (normal_conformance type='InheritEqual<T>' protocol='conditional_conformances.(file).P2@
+// CHECK-NEXT:    (conditional=requirement 'T' conforms_to 'P1'))
 extension InheritEqual: P2 where T: P1 {} // expected-note {{requirement from conditional conformance of 'InheritEqual<U>' to 'P2'}}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual
-// CHECK-NEXT:  (normal_conformance type=InheritEqual<T> protocol=P5
-// CHECK-NEXT:    (normal_conformance type=InheritEqual<T> protocol=P2
-// CHECK-NEXT:      conforms_to: T P1)
-// CHECK-NEXT:    conforms_to: T P1)
+// CHECK-NEXT:  (normal_conformance type='InheritEqual<T>' protocol='conditional_conformances.(file).P5@
+// CHECK-NEXT:    (sig_conf=normal_conformance type='InheritEqual<T>' protocol='conditional_conformances.(file).P2@
+// CHECK-NEXT:      (conditional=requirement 'T' conforms_to 'P1'))
+// CHECK-NEXT:    (conditional=requirement 'T' conforms_to 'P1'))
 extension InheritEqual: P5 where T: P1 {} // expected-note {{requirement from conditional conformance of 'InheritEqual<U>' to 'P5'}}
 func inheritequal_good<U: P1>(_: U) {
   takes_P2(InheritEqual<U>())
@@ -238,15 +238,15 @@ extension InheritLess: P5 {} // expected-error{{type 'T' does not conform to pro
 struct InheritMore<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore
-// CHECK-NEXT:  (normal_conformance type=InheritMore<T> protocol=P2
-// CHECK-NEXT:    conforms_to: T P1)
+// CHECK-NEXT:  (normal_conformance type='InheritMore<T>' protocol='conditional_conformances.(file).P2@
+// CHECK-NEXT:    (conditional=requirement 'T' conforms_to 'P1'))
 extension InheritMore: P2 where T: P1 {} // expected-note {{requirement from conditional conformance of 'InheritMore<U>' to 'P2'}}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore
-// CHECK-NEXT:  (normal_conformance type=InheritMore<T> protocol=P5
-// CHECK-NEXT:    (normal_conformance type=InheritMore<T> protocol=P2
-// CHECK-NEXT:      conforms_to: T P1)
-// CHECK-NEXT:    conforms_to: T P4)
+// CHECK-NEXT:  (normal_conformance type='InheritMore<T>' protocol='conditional_conformances.(file).P5@
+// CHECK-NEXT:    (sig_conf=normal_conformance type='InheritMore<T>' protocol='conditional_conformances.(file).P2@
+// CHECK-NEXT:      (conditional=requirement 'T' conforms_to 'P1'))
+// CHECK-NEXT:    (conditional=requirement 'T' conforms_to 'P4'))
 extension InheritMore: P5 where T: P4 {} // expected-note 2 {{requirement from conditional conformance of 'InheritMore<U>' to 'P5'}}
 func inheritequal_good_good<U: P4>(_: U) {
   takes_P2(InheritMore<U>())
@@ -327,15 +327,15 @@ extension TwoDisjointConformances: P2 where T == String {}
 struct RedundancyOrderDependenceGood<T: P1, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceGood
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceGood
-// CHECK-NEXT: (normal_conformance type=RedundancyOrderDependenceGood<T, U> protocol=P2
-// CHECK-NEXT:   same_type: T U)
+// CHECK-NEXT: (normal_conformance type='RedundancyOrderDependenceGood<T, U>' protocol='conditional_conformances.(file).P2@
+// CHECK-NEXT:   (conditional=requirement 'T' same_type 'U'))
 extension RedundancyOrderDependenceGood: P2 where U: P1, T == U {}
 struct RedundancyOrderDependenceBad<T, U: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceBad
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceBad
-// CHECK-NEXT: (normal_conformance type=RedundancyOrderDependenceBad<T, U> protocol=P2
-// CHECK-NEXT:   conforms_to: T P1
-// CHECK-NEXT:   same_type: T U)
+// CHECK-NEXT: (normal_conformance type='RedundancyOrderDependenceBad<T, U>' protocol='conditional_conformances.(file).P2@
+// CHECK-NEXT:   (conditional=requirement 'T' conforms_to 'P1')
+// CHECK-NEXT:   (conditional=requirement 'T' same_type 'U'))
 extension RedundancyOrderDependenceBad: P2 where T: P1, T == U {}
 
 // Checking of conditional requirements for existential conversions.

--- a/test/ImportResolution/import-resolution-overload.swift
+++ b/test/ImportResolution/import-resolution-overload.swift
@@ -60,7 +60,7 @@ extension HasFooSub {
 func testHasFooSub(_ hfs: HasFooSub) -> Int {
   // CHECK: return_stmt
   // CHECK-NOT: func_decl
-  // CHECK: member_ref_expr{{.*}}decl=overload_vars.(file).HasFoo.foo
+  // CHECK: member_ref_expr{{.*}}decl='overload_vars.(file).HasFoo.foo [with
   return hfs.foo
 }
 
@@ -72,7 +72,7 @@ extension HasBar {
 func testHasBar(_ hb: HasBar) -> Int {
   // CHECK: return_stmt
   // CHECK-NOT: func_decl
-  // CHECK: member_ref_expr{{.*}}decl=overload_vars.(file).HasBar.bar
+  // CHECK: member_ref_expr{{.*}}decl='overload_vars.(file).HasBar.bar [with
   return hb.bar
 }
 

--- a/test/Parse/if_expr.swift
+++ b/test/Parse/if_expr.swift
@@ -1,41 +1,41 @@
 // RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
 
-// CHECK: (func_decl{{.*}}"r13756261(_:_:)"
+// CHECK-LABEL: (func_decl{{.*}}"r13756261(_:_:)"
 func r13756261(_ x: Bool, _ y: Int) -> Int {
   // CHECK: (if_expr
-  // CHECK:   (declref_expr
-  // CHECK:   (if_expr
-  // CHECK:     (declref_expr
-  // CHECK:     (if_expr
-  // CHECK:       (declref_expr
-  // CHECK:       (declref_expr
+  // CHECK:   (then_expr=declref_expr
+  // CHECK:   (else_expr=if_expr
+  // CHECK:     (then_expr=declref_expr
+  // CHECK:     (else_expr=if_expr
+  // CHECK:       (then_expr=declref_expr
+  // CHECK:       (else_expr=declref_expr
   return (x) ? y : (x) ? y : (x) ? y : y
 }
 
-// CHECK: (func_decl{{.*}}"r13756221(_:_:)"
+// CHECK-LABEL: (func_decl{{.*}}"r13756221(_:_:)"
 func r13756221(_ x: Bool, _ y: Int) -> Int {
   // CHECK: (if_expr
-  // CHECK:   (declref_expr
-  // CHECK:   (if_expr
-  // CHECK:     (declref_expr
-  // CHECK:     (if_expr
-  // CHECK:       (declref_expr
-  // CHECK:       (declref_expr
+  // CHECK:   (then_expr=declref_expr
+  // CHECK:   (else_expr=if_expr
+  // CHECK:     (then_expr=declref_expr
+  // CHECK:     (else_expr=if_expr
+  // CHECK:       (then_expr=declref_expr
+  // CHECK:       (else_expr=declref_expr
   return (x) ? y
        : (x) ? y
        : (x) ? y
        : y
 }
 
-// CHECK: (func_decl{{.*}}"telescoping_if(_:_:)"
+// CHECK-LABEL: (func_decl{{.*}}"telescoping_if(_:_:)"
 func telescoping_if(_ x: Bool, _ y: Int) -> Int {
   // CHECK: (if_expr
-  // CHECK:   (if_expr
-  // CHECK:     (if_expr
-  // CHECK:       (declref_expr
-  // CHECK:       (declref_expr
-  // CHECK:     (declref_expr
-  // CHECK:   (declref_expr
+  // CHECK:   (then_expr=if_expr
+  // CHECK:     (then_expr=if_expr
+  // CHECK:       (then_expr=declref_expr
+  // CHECK:       (else_expr=declref_expr
+  // CHECK:     (else_expr=declref_expr
+  // CHECK:   (else_expr=declref_expr
   return (x) ? (x) ? (x) ? y : y : y : y
 }
 
@@ -60,20 +60,20 @@ func +>> (x: Bool, y: Bool) -> Bool {}
 func +<< (x: Bool, y: Bool) -> Bool {}
 func +== (x: Bool, y: Bool) -> Bool {}
 
-// CHECK: (func_decl{{.*}}"prec_above(_:_:_:)"
+// CHECK-LABEL: (func_decl{{.*}}"prec_above(_:_:_:)"
 func prec_above(_ x: Bool, _ y: Bool, _ z: Bool) -> Bool {
   // (x +>> y) ? (y +>> z) : ((x +>> y) ? (y +>> z) : (x +>> y))
   // CHECK: (if_expr
-  // CHECK:   (binary_expr
-  // CHECK:   (binary_expr
-  // CHECK:   (if_expr
-  // CHECK:     (binary_expr
-  // CHECK:     (binary_expr
-  // CHECK:     (binary_expr
+  // CHECK:   (condition=binary_expr
+  // CHECK:   (then_expr=binary_expr
+  // CHECK:   (else_expr=if_expr
+  // CHECK:     (condition=binary_expr
+  // CHECK:     (then_expr=binary_expr
+  // CHECK:     (else_expr=binary_expr
   return x +>> y ? y +>> z : x +>> y ? y +>> z : x +>> y
 }
 
-// CHECK: (func_decl{{.*}}"prec_below(_:_:_:)"
+// CHECK-LABEL: (func_decl{{.*}}"prec_below(_:_:_:)"
 func prec_below(_ x: Bool, _ y: Bool, _ z: Bool) -> Bool {
   // The middle arm of the ternary is max-munched, so this is:
   // ((x +<< (y ? (y +<< z) : x)) +<< (y ? (y +<< z) : x)) +<< y
@@ -82,32 +82,32 @@ func prec_below(_ x: Bool, _ y: Bool, _ z: Bool) -> Bool {
   // CHECK:     (binary_expr
   // CHECK:       (declref_expr
   // CHECK:       (if_expr
-  // CHECK:         (binary_expr
-  // CHECK:         (declref_expr
+  // CHECK:         (then_expr=binary_expr
+  // CHECK:         (else_expr=declref_expr
   // CHECK:     (if_expr
-  // CHECK:       (binary_expr
-  // CHECK:       (declref_expr
+  // CHECK:       (then_expr=binary_expr
+  // CHECK:       (else_expr=declref_expr
   // CHECK:   (declref_expr
   return x +<< y ? y +<< z : x +<< y ? y +<< z : x +<< y
 }
 
-// CHECK: (func_decl{{.*}}"prec_equal(_:_:_:)"
+// CHECK-LABEL: (func_decl{{.*}}"prec_equal(_:_:_:)"
 func prec_equal(_ x: Bool, _ y: Bool, _ z: Bool) -> Bool {
   // The middle arm of the ternary is max-munched, so this is:
   // x +== (y ? (y +== z) : (x +== (y ? (y +== z) : (x +== y))))
   // CHECK: (binary_expr
   // CHECK:   (declref_expr
   // CHECK:   (if_expr
-  // CHECK:     (binary_expr
+  // CHECK:     (then_expr=binary_expr
   // CHECK:       (declref_expr
   // CHECK:       (declref_expr
-  // CHECK:     (binary_expr
+  // CHECK:     (else_expr=binary_expr
   // CHECK:       (declref_expr
   // CHECK:       (if_expr
-  // CHECK:         (binary_expr
+  // CHECK:         (then_expr=binary_expr
   // CHECK:           (declref_expr
   // CHECK:           (declref_expr
-  // CHECK:         (binary_expr
+  // CHECK:         (else_expr=binary_expr
   // CHECK:           (declref_expr
   // CHECK:           (declref_expr
   return x +== y ? y +== z : x +== y ? y +== z : x +== y

--- a/test/Parse/multiline_normalize_newline.swift
+++ b/test/Parse/multiline_normalize_newline.swift
@@ -1,38 +1,44 @@
 // RUN: %target-swift-frontend -dump-parse %s | %FileCheck %s
 
 // CR
-_ = """"""
-//CHECK: string_literal_expr {{.*}} value=""
-
-_ = """  test  """
-//CHECK: string_literal_expr {{.*}} value="test"
-
-// CR+LF
 _ = """
-    """
-//CHECK: string_literal_expr {{.*}} value=""
+"""
+//CHECK: string_literal_expr {{.*}} "" encoding=utf8
 
 _ = """
   test
   """
-//CHECK: string_literal_expr {{.*}} value="test"
+//CHECK: string_literal_expr {{.*}} "test" encoding=utf8
 
 // CR+LF
 _ = """
     """
-//CHECK: string_literal_expr {{.*}} value=""
+//CHECK: string_literal_expr {{.*}} "" encoding=utf8
+
+_ = """
+  test
+  """
+//CHECK: string_literal_expr {{.*}} "test" encoding=utf8
+
+// CR+LF
+_ = """
+    """
+//CHECK: string_literal_expr {{.*}} "" encoding=utf8
 _ = """
   test
   test
   """
-//CHECK: string_literal_expr {{.*}} value="test\ntest"
+//CHECK: string_literal_expr {{.*}} "test\ntest" encoding=utf8
 
 // LF+CR
 _ = """
-    foo
-    foo
-    """
-//CHECK: string_literal_expr {{.*}} value="\nfoo\n\nfoo\n"
+
+    foo
+
+    foo
+
+    """
+//CHECK: string_literal_expr {{.*}} "\nfoo\n\nfoo\n" encoding=utf8
 
 // LF+CR+LF
 _ = """
@@ -42,29 +48,32 @@ _ = """
     foo
 
     """
-//CHECK: string_literal_expr {{.*}} value="\nfoo\n\nfoo\n"
+//CHECK: string_literal_expr {{.*}} "\nfoo\n\nfoo\n" encoding=utf8
 
 // Mixed no-indent.
 _ = """
 <LF
-<LF<CR
+<LF
+<CR
 <CR+LF
 """
-//CHECK: string_literal_expr {{.*}} value="<LF\n<LF\n<CR\n<CR+LF"
+//CHECK: string_literal_expr {{.*}} "<LF\n<LF\n<CR\n<CR+LF" encoding=utf8
 
 // Mixed indent.
 _ = """
 	 <LF
-	 <LF	 <CR
+	 <LF
+	 <CR
 	 <CR+LF
 	 """
-//CHECK: string_literal_expr {{.*}} value="<LF\n<LF\n<CR\n<CR+LF"
+//CHECK: string_literal_expr {{.*}} "<LF\n<LF\n<CR\n<CR+LF" encoding=utf8
 
 // Empty line CR, CR+LF, LF.
 _ = """
    foo
-
+
+
 
    bar
    """
-//CHECK: string_literal_expr {{.*}} value="foo\n\n\n\nbar"
+//CHECK: string_literal_expr {{.*}} "foo\n\n\n\nbar" encoding=utf8

--- a/test/Parse/source_locs.swift
+++ b/test/Parse/source_locs.swift
@@ -6,6 +6,6 @@ func string_interpolation() {
 }
 
 // RUN: not %target-swift-frontend -dump-ast %/s | %FileCheck %s
-// CHECK: (interpolated_string_literal_expr {{.*}} trailing_quote_loc=SOURCE_DIR/test/Parse/source_locs.swift:4:12 {{.*}}
-// CHECK: (editor_placeholder_expr type='()' {{.*}} trailing_angle_bracket_loc=SOURCE_DIR/test/Parse/source_locs.swift:5:9
+// CHECK: (interpolated_string_literal_expr {{.*}} trailing_quote_loc='SOURCE_DIR/test/Parse/source_locs.swift:4:12' {{.*}}
+// CHECK: (editor_placeholder_expr type='()' {{.*}} trailing_angle_bracket_loc='SOURCE_DIR/test/Parse/source_locs.swift:5:9'
 

--- a/test/SILOptimizer/inline_generics.sil
+++ b/test/SILOptimizer/inline_generics.sil
@@ -149,7 +149,7 @@ sil_vtable MyNumber {}
 // CHECK-LABEL: sil @test_inlining : $@convention(objc_method) (@owned MyNumber) -> () {
 // CHECK-NOT: Generic specialization information for call-site dootherstuff <MyNumber & SomeProto> conformances <(abstract_conformance protocol=OtherProto)>
 // CHECK: Generic specialization information
-// CHECK: (normal_conformance type=MyObject protocol=OtherProto)
+// CHECK: (normal_conformance type='MyObject' protocol='main.(file).OtherProto@
 // CHECK: end sil function 'test_inlining'
 
 sil @test_inlining : $@convention(objc_method) (@owned MyNumber) -> () {

--- a/test/SILOptimizer/sil_combine_concrete_existential.sil
+++ b/test/SILOptimizer/sil_combine_concrete_existential.sil
@@ -667,8 +667,8 @@ sil @callee2 : $@convention(thin) <τ_0_0 where τ_0_0 : SubscriptionViewControl
 // CHECK:   [[T5:%.*]] = function_ref @callee2 : $@convention(thin) <τ_0_0 where τ_0_0 : SubscriptionViewControllerDelegate> (@in τ_0_0, @thick SubscriptionViewControllerBuilder.Type) -> @owned SubscriptionViewControllerBuilder
 // CHECK:   [[T6:%.*]] = alloc_stack $@opened("E4D92D2A-8893-11EA-9C89-ACDE48001122") ResourceKitProtocol
 // CHECK:   copy_addr [[T4]] to [initialization] [[T6]] : $*@opened("E4D92D2A-8893-11EA-9C89-ACDE48001122") ResourceKitProtocol
-// CHECK: Generic specialization information for call-site callee2 <ResourceKitProtocol> conformances <(inherited_conformance type=ResourceKitProtocol protocol=SubscriptionViewControllerDelegate
-// CHECK:  (normal_conformance type=MyObject protocol=SubscriptionViewControllerDelegate))>:
+// CHECK: Generic specialization information for call-site callee2 <ResourceKitProtocol> conformances <(inherited_conformance type='@opened("{{[^"]+}}") ResourceKitProtocol' protocol='main.(file).SubscriptionViewControllerDelegate@
+// CHECK:  (normal_conformance type='MyObject' protocol='main.(file).SubscriptionViewControllerDelegate@{{[^']*}}'))>:
 // CHECK:   apply [[T5]]<@opened("E4D92D2A-8893-11EA-9C89-ACDE48001122") ResourceKitProtocol>([[T6]], [[T1]])
 
 sil @test_opend_archeype_concrete_conformance_substitution : $@convention(method) (@guaranteed ResourceKitProtocol, @guaranteed ViewController) -> () {

--- a/test/Sema/dynamic_self_implicit_conversions.swift
+++ b/test/Sema/dynamic_self_implicit_conversions.swift
@@ -55,7 +55,7 @@ class B: A {
 func testOnExistential(arg: P & A) {
   // FIXME: This could be a single conversion.
   // CHECK: function_conversion_expr implicit type='() -> A & P' location={{.*}}.swift:[[@LINE+2]]
-  // CHECK-NEXT: covariant_function_conversion_expr implicit type='() -> A & P' location={{.*}}.swift:[[@LINE+1]]
+  // CHECK-NEXT: covariant_function_conversion_expr implicit type='() -> @opened("{{[^"]*}}") A & P' location={{.*}}.swift:[[@LINE+1]]
   _ = arg.method
 }
 

--- a/test/Sema/type_eraser.swift
+++ b/test/Sema/type_eraser.swift
@@ -12,7 +12,7 @@ struct ConcreteP: P, Hashable {}
 // CHECK-LABEL: testBasic
 dynamic func testBasic() -> some P {
   // CHECK: underlying_to_opaque_expr{{.*}}'some P'
-  // CHECK-NEXT: call_expr implicit type='AnyP'{{.*}}arg_labels=erasing:
+  // CHECK-NEXT: call_expr implicit type='AnyP'{{.*}}arg_labels='erasing:'
   // CHECK: call_expr type='ConcreteP'
   ConcreteP()
 }
@@ -21,7 +21,7 @@ dynamic func testBasic() -> some P {
 typealias AliasForP = P
 dynamic func testTypeAlias() -> some AliasForP {
   // CHECK: underlying_to_opaque_expr{{.*}}'some P'
-  // CHECK-NEXT: call_expr implicit type='AnyP'{{.*}}arg_labels=erasing:
+  // CHECK-NEXT: call_expr implicit type='AnyP'{{.*}}arg_labels='erasing:'
   // CHECK: call_expr type='ConcreteP'
   ConcreteP()
 }
@@ -64,7 +64,7 @@ class TestResultBuilder {
   @Builder dynamic var testTransformFnBody: some P {
     // CHECK: return_stmt
     // CHECK-NEXT: underlying_to_opaque_expr implicit type='some P'
-    // CHECK-NEXT: call_expr implicit type='AnyP'{{.*}}arg_labels=erasing:
+    // CHECK-NEXT: call_expr implicit type='AnyP'{{.*}}arg_labels='erasing:'
     // CHECK: declref_expr implicit type='@lvalue ConcreteP'
     ConcreteP()
   }
@@ -75,7 +75,7 @@ class TestResultBuilder {
   // CHECK-LABEL: testClosureBuilder
   dynamic var testClosureBuilder: some P {
     // CHECK: underlying_to_opaque_expr implicit type='some P'
-    // CHECK-NEXT: call_expr implicit type='AnyP'{{.*}}arg_labels=erasing:
+    // CHECK-NEXT: call_expr implicit type='AnyP'{{.*}}arg_labels='erasing:'
     // CHECK: closure_expr type='() -> ConcreteP'
     takesBuilder {
       // CHECK: return_stmt
@@ -89,7 +89,7 @@ class TestResultBuilder {
 class DynamicReplacement {
   dynamic func testDynamicReplaceable() -> some P {
     // CHECK: underlying_to_opaque_expr implicit type='some P'
-    // CHECK-NEXT: call_expr implicit type='AnyP'{{.*}}arg_labels=erasing:
+    // CHECK-NEXT: call_expr implicit type='AnyP'{{.*}}arg_labels='erasing:'
     // CHECK: call_expr type='ConcreteP'
     ConcreteP()
   }
@@ -103,7 +103,7 @@ extension DynamicReplacement {
     print("not single expr return")
     // CHECK: return_stmt
     // CHECK-NEXT: underlying_to_opaque_expr implicit type='some P'
-    // CHECK-NEXT: call_expr implicit type='AnyP'{{.*}}arg_labels=erasing:
+    // CHECK-NEXT: call_expr implicit type='AnyP'{{.*}}arg_labels='erasing:'
     // CHECK: call_expr type='ConcreteP'
     return ConcreteP()
   }

--- a/test/Sema/type_eraser.swift
+++ b/test/Sema/type_eraser.swift
@@ -37,7 +37,7 @@ func testNoDynamic() -> some P {
 dynamic func testNoOpaque() -> P {
   // CHECK: erasure_expr implicit type='P'
   // CHECK-NEXT: conformances=array
-  // CHECK-NEXT: normal_conformance type=ConcreteP protocol=P
+  // CHECK-NEXT: normal_conformance type='ConcreteP' protocol='type_eraser.(file).P@
   // CHECK-NEXT: call_expr type='ConcreteP'
   ConcreteP()
 }

--- a/test/Sema/type_eraser.swift
+++ b/test/Sema/type_eraser.swift
@@ -36,6 +36,7 @@ func testNoDynamic() -> some P {
 // CHECK-LABEL: testNoOpaque
 dynamic func testNoOpaque() -> P {
   // CHECK: erasure_expr implicit type='P'
+  // CHECK-NEXT: conformances=array
   // CHECK-NEXT: normal_conformance type=ConcreteP protocol=P
   // CHECK-NEXT: call_expr type='ConcreteP'
   ConcreteP()

--- a/test/attr/ApplicationMain/attr_main_throws.swift
+++ b/test/attr/ApplicationMain/attr_main_throws.swift
@@ -7,7 +7,7 @@ struct MyBase {
   }
 }
 
-// CHECK-AST: (func_decl implicit "$main()" interface type='(MyBase.Type) -> () throws -> ()' access=internal type
+// CHECK-AST: (func_decl implicit "$main()" interface type='(MyBase.Type) -> () throws -> ()' access=internal override=() type
 // CHECK-AST-NEXT:  (self=parameter implicit "self" type='<null type>')
 // CHECK-AST-NEXT:  (parameter_list)
 // CHECK-AST-NEXT:  (body=brace_stmt implicit

--- a/test/attr/ApplicationMain/attr_main_throws.swift
+++ b/test/attr/ApplicationMain/attr_main_throws.swift
@@ -8,7 +8,7 @@ struct MyBase {
 }
 
 // CHECK-AST: (func_decl implicit "$main()" interface type='(MyBase.Type) -> () throws -> ()' access=internal type
-// CHECK-AST-NEXT:  (self=parameter "self")
+// CHECK-AST-NEXT:  (self=parameter implicit "self" type='<null type>')
 // CHECK-AST-NEXT:  (parameter_list)
 // CHECK-AST-NEXT:  (body=brace_stmt implicit
 // CHECK-AST-NEXT:    (return_stmt implicit

--- a/test/attr/ApplicationMain/attr_main_throws.swift
+++ b/test/attr/ApplicationMain/attr_main_throws.swift
@@ -7,7 +7,7 @@ struct MyBase {
   }
 }
 
-// CHECK-AST: (func_decl implicit "$main()" interface type='(MyBase.Type) -> () throws -> ()' access=internal override=() type
+// CHECK-AST: (func_decl implicit "$main()" interface_type='(MyBase.Type) -> () throws -> ()' access=internal override=() type
 // CHECK-AST-NEXT:  (self=parameter implicit "self" type='<null type>')
 // CHECK-AST-NEXT:  (parameter_list)
 // CHECK-AST-NEXT:  (body=brace_stmt implicit

--- a/test/attr/ApplicationMain/attr_main_throws.swift
+++ b/test/attr/ApplicationMain/attr_main_throws.swift
@@ -8,9 +8,9 @@ struct MyBase {
 }
 
 // CHECK-AST: (func_decl implicit "$main()" interface type='(MyBase.Type) -> () throws -> ()' access=internal type
-// CHECK-AST-NEXT:  (parameter "self")
+// CHECK-AST-NEXT:  (self=parameter "self")
 // CHECK-AST-NEXT:  (parameter_list)
-// CHECK-AST-NEXT:  (brace_stmt implicit
+// CHECK-AST-NEXT:  (body=brace_stmt implicit
 // CHECK-AST-NEXT:    (return_stmt implicit
 // CHECK-AST-NEXT:      (try_expr implicit
 // CHECK-AST-NEXT:        (call_expr implicit type='()'

--- a/test/attr/attr_native_dynamic.swift
+++ b/test/attr/attr_native_dynamic.swift
@@ -2,30 +2,30 @@
 
 struct Strukt {
   // CHECK: (struct_decl {{.*}} "Strukt"
-  // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" type='Int' interface type='Int' access=internal dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
-  // CHECK: (accessor_decl {{.*}} get_for="dynamicStorageOnlyVar" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} set_for="dynamicStorageOnlyVar" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} _modify_for="dynamicStorageOnlyVar" {{.*}} access=internal{{$}}
+  // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" type='Int' interface type='Int' access=internal override=() dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
+  // CHECK: (accessor_decl {{.*}} get_for="dynamicStorageOnlyVar" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="dynamicStorageOnlyVar" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="dynamicStorageOnlyVar" {{.*}} access=internal override=(){{$}}
   dynamic var dynamicStorageOnlyVar : Int = 0
 
-  // CHECK: (var_decl {{.*}} "computedVar" type='Int' interface type='Int' access=internal dynamic readImpl=getter immutable
-  // CHECK: (accessor_decl {{.*}} get_for="computedVar" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (var_decl {{.*}} "computedVar" type='Int' interface type='Int' access=internal override=() dynamic readImpl=getter immutable
+  // CHECK: (accessor_decl {{.*}} get_for="computedVar" {{.*}} access=internal override=() dynamic{{$}}
   dynamic var computedVar : Int {
     return 0
   }
 
-  // CHECK: (var_decl {{.*}} "computedVar2" type='Int' interface type='Int' access=internal dynamic readImpl=getter immutable
-  // CHECK: (accessor_decl {{.*}} get_for="computedVar2" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (var_decl {{.*}} "computedVar2" type='Int' interface type='Int' access=internal override=() dynamic readImpl=getter immutable
+  // CHECK: (accessor_decl {{.*}} get_for="computedVar2" {{.*}} access=internal override=() dynamic{{$}}
   dynamic var computedVar2 : Int {
     get {
       return 0
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarGetterSetter" type='Int' interface type='Int' access=internal dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} get_for="computedVarGetterSetter" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} set_for="computedVarGetterSetter" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarGetterSetter" {{.*}} access=internal{{$}}
+  // CHECK: (var_decl {{.*}} "computedVarGetterSetter" type='Int' interface type='Int' access=internal override=() dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
+  // CHECK: (accessor_decl {{.*}} get_for="computedVarGetterSetter" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="computedVarGetterSetter" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarGetterSetter" {{.*}} access=internal override=(){{$}}
   dynamic var computedVarGetterSetter : Int {
     get {
       return 0
@@ -34,10 +34,10 @@ struct Strukt {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarGetterModify" type='Int' interface type='Int' access=internal dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} get_for="computedVarGetterModify" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarGetterModify" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} set_for="computedVarGetterModify" {{.*}} access=internal{{$}}
+  // CHECK: (var_decl {{.*}} "computedVarGetterModify" type='Int' interface type='Int' access=internal override=() dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
+  // CHECK: (accessor_decl {{.*}} get_for="computedVarGetterModify" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarGetterModify" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="computedVarGetterModify" {{.*}} access=internal override=(){{$}}
   dynamic var computedVarGetterModify : Int {
     get {
       return 0
@@ -46,11 +46,11 @@ struct Strukt {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarReadSet" type='Int' interface type='Int' access=internal dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} _read_for="computedVarReadSet" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} set_for="computedVarReadSet" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} get_for="computedVarReadSet" {{.*}} access=internal{{$}}
-  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarReadSet" {{.*}} access=internal{{$}}
+  // CHECK: (var_decl {{.*}} "computedVarReadSet" type='Int' interface type='Int' access=internal override=() dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
+  // CHECK: (accessor_decl {{.*}} _read_for="computedVarReadSet" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="computedVarReadSet" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="computedVarReadSet" {{.*}} access=internal override=(){{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarReadSet" {{.*}} access=internal override=(){{$}}
   dynamic var computedVarReadSet : Int {
     _read {
     }
@@ -58,11 +58,11 @@ struct Strukt {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarReadModify" type='Int' interface type='Int' access=internal dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} _read_for="computedVarReadModify" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarReadModify" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} get_for="computedVarReadModify" {{.*}} access=internal{{$}}
-  // CHECK: (accessor_decl {{.*}} set_for="computedVarReadModify" {{.*}} access=internal{{$}}
+  // CHECK: (var_decl {{.*}} "computedVarReadModify" type='Int' interface type='Int' access=internal override=() dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
+  // CHECK: (accessor_decl {{.*}} _read_for="computedVarReadModify" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarReadModify" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="computedVarReadModify" {{.*}} access=internal override=(){{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="computedVarReadModify" {{.*}} access=internal override=(){{$}}
   dynamic var computedVarReadModify : Int {
     _read {
     }
@@ -70,25 +70,25 @@ struct Strukt {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "storedWithObserver" type='Int' interface type='Int' access=internal dynamic readImpl=stored writeImpl=stored_with_observers readWriteImpl=stored_with_didset
-  // CHECK: (accessor_decl {{.*}} didSet_for="storedWithObserver" {{.*}} access=private dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} get_for="storedWithObserver" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} set_for="storedWithObserver" {{.*}} access=internal{{$}}
-  // CHECK: (accessor_decl {{.*}} _modify_for="storedWithObserver" {{.*}} access=internal{{$}}
+  // CHECK: (var_decl {{.*}} "storedWithObserver" type='Int' interface type='Int' access=internal override=() dynamic readImpl=stored writeImpl=stored_with_observers readWriteImpl=stored_with_didset
+  // CHECK: (accessor_decl {{.*}} didSet_for="storedWithObserver" {{.*}} access=private override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="storedWithObserver" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="storedWithObserver" {{.*}} access=internal override=(){{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="storedWithObserver" {{.*}} access=internal override=(){{$}}
   dynamic var storedWithObserver : Int {
     didSet {
     }
   }
 
-  // CHECK: (func_decl {{.*}} access=internal dynamic
+  // CHECK: (func_decl {{.*}} access=internal override=() dynamic
   dynamic func aMethod(arg: Int) -> Int {
     return arg
   }
 
-  // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal{{$}}
+  // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal override=() dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
+  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal override=(){{$}}
   dynamic subscript(_ index: Int) -> Int {
     get {
       return 1
@@ -97,10 +97,10 @@ struct Strukt {
     }
   }
 
-  // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal{{$}}
+  // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal override=() dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
+  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal override=(){{$}}
   dynamic subscript(_ index: Float) -> Int {
     get {
       return 1
@@ -109,11 +109,11 @@ struct Strukt {
     }
   }
 
-  // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} _read_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal{{$}}
-  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal{{$}}
+  // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal override=() dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
+  // CHECK: (accessor_decl {{.*}} _read_for="subscript(_:)" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal override=(){{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal override=(){{$}}
   dynamic subscript(_ index: Double) -> Int {
     _read {
     }
@@ -121,11 +121,11 @@ struct Strukt {
     }
   }
 
-  // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} _read_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal{{$}}
-  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal{{$}}
+  // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal override=() dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
+  // CHECK: (accessor_decl {{.*}} _read_for="subscript(_:)" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal override=(){{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal override=(){{$}}
   dynamic subscript(_ index: Strukt) -> Int {
     _read {
     }
@@ -136,30 +136,30 @@ struct Strukt {
 
 class Klass {
   // CHECK: (class_decl {{.*}} "Klass"
-  // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" type='Int' interface type='Int' access=internal dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
-  // CHECK: (accessor_decl {{.*}} get_for="dynamicStorageOnlyVar" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} set_for="dynamicStorageOnlyVar" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} _modify_for="dynamicStorageOnlyVar" {{.*}} access=internal{{$}}
+  // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" type='Int' interface type='Int' access=internal override=() dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
+  // CHECK: (accessor_decl {{.*}} get_for="dynamicStorageOnlyVar" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="dynamicStorageOnlyVar" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="dynamicStorageOnlyVar" {{.*}} access=internal override=(){{$}}
   dynamic var dynamicStorageOnlyVar : Int = 0
 
-  // CHECK: (var_decl {{.*}} "computedVar" type='Int' interface type='Int' access=internal dynamic readImpl=getter immutable
-  // CHECK: (accessor_decl {{.*}} get_for="computedVar" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (var_decl {{.*}} "computedVar" type='Int' interface type='Int' access=internal override=() dynamic readImpl=getter immutable
+  // CHECK: (accessor_decl {{.*}} get_for="computedVar" {{.*}} access=internal override=() dynamic{{$}}
   dynamic var computedVar : Int {
     return 0
   }
 
-  // CHECK: (var_decl {{.*}} "computedVar2" type='Int' interface type='Int' access=internal dynamic readImpl=getter immutable
-  // CHECK: (accessor_decl {{.*}} get_for="computedVar2" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (var_decl {{.*}} "computedVar2" type='Int' interface type='Int' access=internal override=() dynamic readImpl=getter immutable
+  // CHECK: (accessor_decl {{.*}} get_for="computedVar2" {{.*}} access=internal override=() dynamic{{$}}
   dynamic var computedVar2 : Int {
     get {
       return 0
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarGetterSetter" type='Int' interface type='Int' access=internal dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} get_for="computedVarGetterSetter" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} set_for="computedVarGetterSetter" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarGetterSetter" {{.*}} access=internal{{$}}
+  // CHECK: (var_decl {{.*}} "computedVarGetterSetter" type='Int' interface type='Int' access=internal override=() dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
+  // CHECK: (accessor_decl {{.*}} get_for="computedVarGetterSetter" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="computedVarGetterSetter" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarGetterSetter" {{.*}} access=internal override=(){{$}}
   dynamic var computedVarGetterSetter : Int {
     get {
       return 0
@@ -168,10 +168,10 @@ class Klass {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarGetterModify" type='Int' interface type='Int' access=internal dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} get_for="computedVarGetterModify" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarGetterModify" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} set_for="computedVarGetterModify" {{.*}} access=internal{{$}}
+  // CHECK: (var_decl {{.*}} "computedVarGetterModify" type='Int' interface type='Int' access=internal override=() dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
+  // CHECK: (accessor_decl {{.*}} get_for="computedVarGetterModify" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarGetterModify" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="computedVarGetterModify" {{.*}} access=internal override=(){{$}}
   dynamic var computedVarGetterModify : Int {
     get {
       return 0
@@ -180,11 +180,11 @@ class Klass {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarReadSet" type='Int' interface type='Int' access=internal dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} _read_for="computedVarReadSet" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} set_for="computedVarReadSet" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} get_for="computedVarReadSet" {{.*}} access=internal{{$}}
-  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarReadSet" {{.*}} access=internal{{$}}
+  // CHECK: (var_decl {{.*}} "computedVarReadSet" type='Int' interface type='Int' access=internal override=() dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
+  // CHECK: (accessor_decl {{.*}} _read_for="computedVarReadSet" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="computedVarReadSet" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="computedVarReadSet" {{.*}} access=internal override=(){{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarReadSet" {{.*}} access=internal override=(){{$}}
   dynamic var computedVarReadSet : Int {
     _read {
     }
@@ -192,18 +192,18 @@ class Klass {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarReadModify" type='Int' interface type='Int' access=internal dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} _read_for="computedVarReadModify" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarReadModify" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} get_for="computedVarReadModify" {{.*}} access=internal{{$}}
-  // CHECK: (accessor_decl {{.*}} set_for="computedVarReadModify" {{.*}} access=internal{{$}}
+  // CHECK: (var_decl {{.*}} "computedVarReadModify" type='Int' interface type='Int' access=internal override=() dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
+  // CHECK: (accessor_decl {{.*}} _read_for="computedVarReadModify" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarReadModify" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="computedVarReadModify" {{.*}} access=internal override=(){{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="computedVarReadModify" {{.*}} access=internal override=(){{$}}
   dynamic var computedVarReadModify : Int {
     _read {
     }
     _modify {
     }
   }
-  // CHECK: (func_decl {{.*}} "aMethod(arg:)" {{.*}} access=internal dynamic
+  // CHECK: (func_decl {{.*}} "aMethod(arg:)" {{.*}} access=internal override=() dynamic
   dynamic func aMethod(arg: Int) -> Int {
     return arg
   }
@@ -213,11 +213,11 @@ class Klass {
     return 3
   }
 
-  // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=addressor writeImpl=mutable_addressor readWriteImpl=mutable_addressor
-  // CHECK: (accessor_decl {{.*}} unsafeAddress_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} unsafeMutableAddress_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal{{$}}
-  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal{{$}}
+  // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal override=() dynamic readImpl=addressor writeImpl=mutable_addressor readWriteImpl=mutable_addressor
+  // CHECK: (accessor_decl {{.*}} unsafeAddress_for="subscript(_:)" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} unsafeMutableAddress_for="subscript(_:)" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal override=(){{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal override=(){{$}}
   dynamic subscript(_ index: Int) -> Int {
     unsafeAddress {
       fatalError()
@@ -227,11 +227,11 @@ class Klass {
     }
   }
 
-  // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=getter writeImpl=mutable_addressor readWriteImpl=mutable_addressor
-  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} unsafeMutableAddress_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal{{$}}
-  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal{{$}}
+  // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal override=() dynamic readImpl=getter writeImpl=mutable_addressor readWriteImpl=mutable_addressor
+  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} unsafeMutableAddress_for="subscript(_:)" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal override=(){{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal override=(){{$}}
   dynamic subscript(_ index: Float) -> Int {
     get {
       return 1
@@ -241,12 +241,12 @@ class Klass {
     }
   }
 
-  // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=read_coroutine writeImpl=mutable_addressor readWriteImpl=mutable_addressor
-  // CHECK: (accessor_decl {{.*}} _read_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} unsafeMutableAddress_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal{{$}}
-  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal{{$}}
-  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal{{$}}
+  // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal override=() dynamic readImpl=read_coroutine writeImpl=mutable_addressor readWriteImpl=mutable_addressor
+  // CHECK: (accessor_decl {{.*}} _read_for="subscript(_:)" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} unsafeMutableAddress_for="subscript(_:)" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal override=(){{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal override=(){{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal override=(){{$}}
   dynamic subscript(_ index: Double) -> Int {
     _read {
     }
@@ -255,11 +255,11 @@ class Klass {
     }
   }
 
-  // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=addressor writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} unsafeAddress_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal{{$}}
-  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal{{$}}
+  // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal override=() dynamic readImpl=addressor writeImpl=setter readWriteImpl=materialize_to_temporary
+  // CHECK: (accessor_decl {{.*}} unsafeAddress_for="subscript(_:)" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal override=(){{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal override=(){{$}}
   dynamic subscript(_ index: Int8) -> Int {
     unsafeAddress {
       fatalError()
@@ -268,11 +268,11 @@ class Klass {
     }
   }
 
-  // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=addressor writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} unsafeAddress_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
-  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal{{$}}
-  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal{{$}}
+  // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal override=() dynamic readImpl=addressor writeImpl=modify_coroutine readWriteImpl=modify_coroutine
+  // CHECK: (accessor_decl {{.*}} unsafeAddress_for="subscript(_:)" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal override=() dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal override=(){{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal override=(){{$}}
   dynamic subscript(_ index: Int16) -> Int {
     unsafeAddress {
       fatalError()

--- a/test/attr/attr_native_dynamic.swift
+++ b/test/attr/attr_native_dynamic.swift
@@ -2,19 +2,19 @@
 
 struct Strukt {
   // CHECK: (struct_decl {{.*}} "Strukt"
-  // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" type='Int' interface type='Int' access=internal override=() dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
+  // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" type='Int' interface_type='Int' access=internal override=() dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
   // CHECK: (accessor_decl {{.*}} get_for="dynamicStorageOnlyVar" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} set_for="dynamicStorageOnlyVar" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} _modify_for="dynamicStorageOnlyVar" {{.*}} access=internal override=(){{$}}
   dynamic var dynamicStorageOnlyVar : Int = 0
 
-  // CHECK: (var_decl {{.*}} "computedVar" type='Int' interface type='Int' access=internal override=() dynamic readImpl=getter immutable
+  // CHECK: (var_decl {{.*}} "computedVar" type='Int' interface_type='Int' access=internal override=() dynamic readImpl=getter immutable
   // CHECK: (accessor_decl {{.*}} get_for="computedVar" {{.*}} access=internal override=() dynamic{{$}}
   dynamic var computedVar : Int {
     return 0
   }
 
-  // CHECK: (var_decl {{.*}} "computedVar2" type='Int' interface type='Int' access=internal override=() dynamic readImpl=getter immutable
+  // CHECK: (var_decl {{.*}} "computedVar2" type='Int' interface_type='Int' access=internal override=() dynamic readImpl=getter immutable
   // CHECK: (accessor_decl {{.*}} get_for="computedVar2" {{.*}} access=internal override=() dynamic{{$}}
   dynamic var computedVar2 : Int {
     get {
@@ -22,7 +22,7 @@ struct Strukt {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarGetterSetter" type='Int' interface type='Int' access=internal override=() dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
+  // CHECK: (var_decl {{.*}} "computedVarGetterSetter" type='Int' interface_type='Int' access=internal override=() dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
   // CHECK: (accessor_decl {{.*}} get_for="computedVarGetterSetter" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} set_for="computedVarGetterSetter" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} _modify_for="computedVarGetterSetter" {{.*}} access=internal override=(){{$}}
@@ -34,7 +34,7 @@ struct Strukt {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarGetterModify" type='Int' interface type='Int' access=internal override=() dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
+  // CHECK: (var_decl {{.*}} "computedVarGetterModify" type='Int' interface_type='Int' access=internal override=() dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
   // CHECK: (accessor_decl {{.*}} get_for="computedVarGetterModify" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} _modify_for="computedVarGetterModify" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} set_for="computedVarGetterModify" {{.*}} access=internal override=(){{$}}
@@ -46,7 +46,7 @@ struct Strukt {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarReadSet" type='Int' interface type='Int' access=internal override=() dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
+  // CHECK: (var_decl {{.*}} "computedVarReadSet" type='Int' interface_type='Int' access=internal override=() dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
   // CHECK: (accessor_decl {{.*}} _read_for="computedVarReadSet" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} set_for="computedVarReadSet" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} get_for="computedVarReadSet" {{.*}} access=internal override=(){{$}}
@@ -58,7 +58,7 @@ struct Strukt {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarReadModify" type='Int' interface type='Int' access=internal override=() dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
+  // CHECK: (var_decl {{.*}} "computedVarReadModify" type='Int' interface_type='Int' access=internal override=() dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
   // CHECK: (accessor_decl {{.*}} _read_for="computedVarReadModify" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} _modify_for="computedVarReadModify" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} get_for="computedVarReadModify" {{.*}} access=internal override=(){{$}}
@@ -70,7 +70,7 @@ struct Strukt {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "storedWithObserver" type='Int' interface type='Int' access=internal override=() dynamic readImpl=stored writeImpl=stored_with_observers readWriteImpl=stored_with_didset
+  // CHECK: (var_decl {{.*}} "storedWithObserver" type='Int' interface_type='Int' access=internal override=() dynamic readImpl=stored writeImpl=stored_with_observers readWriteImpl=stored_with_didset
   // CHECK: (accessor_decl {{.*}} didSet_for="storedWithObserver" {{.*}} access=private override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} get_for="storedWithObserver" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} set_for="storedWithObserver" {{.*}} access=internal override=(){{$}}
@@ -136,19 +136,19 @@ struct Strukt {
 
 class Klass {
   // CHECK: (class_decl {{.*}} "Klass"
-  // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" type='Int' interface type='Int' access=internal override=() dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
+  // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" type='Int' interface_type='Int' access=internal override=() dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
   // CHECK: (accessor_decl {{.*}} get_for="dynamicStorageOnlyVar" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} set_for="dynamicStorageOnlyVar" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} _modify_for="dynamicStorageOnlyVar" {{.*}} access=internal override=(){{$}}
   dynamic var dynamicStorageOnlyVar : Int = 0
 
-  // CHECK: (var_decl {{.*}} "computedVar" type='Int' interface type='Int' access=internal override=() dynamic readImpl=getter immutable
+  // CHECK: (var_decl {{.*}} "computedVar" type='Int' interface_type='Int' access=internal override=() dynamic readImpl=getter immutable
   // CHECK: (accessor_decl {{.*}} get_for="computedVar" {{.*}} access=internal override=() dynamic{{$}}
   dynamic var computedVar : Int {
     return 0
   }
 
-  // CHECK: (var_decl {{.*}} "computedVar2" type='Int' interface type='Int' access=internal override=() dynamic readImpl=getter immutable
+  // CHECK: (var_decl {{.*}} "computedVar2" type='Int' interface_type='Int' access=internal override=() dynamic readImpl=getter immutable
   // CHECK: (accessor_decl {{.*}} get_for="computedVar2" {{.*}} access=internal override=() dynamic{{$}}
   dynamic var computedVar2 : Int {
     get {
@@ -156,7 +156,7 @@ class Klass {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarGetterSetter" type='Int' interface type='Int' access=internal override=() dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
+  // CHECK: (var_decl {{.*}} "computedVarGetterSetter" type='Int' interface_type='Int' access=internal override=() dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
   // CHECK: (accessor_decl {{.*}} get_for="computedVarGetterSetter" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} set_for="computedVarGetterSetter" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} _modify_for="computedVarGetterSetter" {{.*}} access=internal override=(){{$}}
@@ -168,7 +168,7 @@ class Klass {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarGetterModify" type='Int' interface type='Int' access=internal override=() dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
+  // CHECK: (var_decl {{.*}} "computedVarGetterModify" type='Int' interface_type='Int' access=internal override=() dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
   // CHECK: (accessor_decl {{.*}} get_for="computedVarGetterModify" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} _modify_for="computedVarGetterModify" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} set_for="computedVarGetterModify" {{.*}} access=internal override=(){{$}}
@@ -180,7 +180,7 @@ class Klass {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarReadSet" type='Int' interface type='Int' access=internal override=() dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
+  // CHECK: (var_decl {{.*}} "computedVarReadSet" type='Int' interface_type='Int' access=internal override=() dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
   // CHECK: (accessor_decl {{.*}} _read_for="computedVarReadSet" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} set_for="computedVarReadSet" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} get_for="computedVarReadSet" {{.*}} access=internal override=(){{$}}
@@ -192,7 +192,7 @@ class Klass {
     }
   }
 
-  // CHECK: (var_decl {{.*}} "computedVarReadModify" type='Int' interface type='Int' access=internal override=() dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
+  // CHECK: (var_decl {{.*}} "computedVarReadModify" type='Int' interface_type='Int' access=internal override=() dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
   // CHECK: (accessor_decl {{.*}} _read_for="computedVarReadModify" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} _modify_for="computedVarReadModify" {{.*}} access=internal override=() dynamic{{$}}
   // CHECK: (accessor_decl {{.*}} get_for="computedVarReadModify" {{.*}} access=internal override=(){{$}}
@@ -285,12 +285,12 @@ class Klass {
 class SubKlass : Klass {
 
   // CHECK: (class_decl {{.*}} "SubKlass"
-  // CHECK: (func_decl {{.*}} "aMethod(arg:)" interface type='(SubKlass) -> (Int) -> Int' access=internal {{.*}} dynamic
+  // CHECK: (func_decl {{.*}} "aMethod(arg:)" interface_type='(SubKlass) -> (Int) -> Int' access=internal {{.*}} dynamic
   override dynamic func aMethod(arg: Int) -> Int {
    return 23
   }
 
-  // CHECK: (func_decl {{.*}} "anotherMethod()" interface type='(SubKlass) -> () -> Int' access=internal {{.*}} dynamic
+  // CHECK: (func_decl {{.*}} "anotherMethod()" interface_type='(SubKlass) -> () -> Int' access=internal {{.*}} dynamic
   override dynamic func anotherMethod() -> Int {
    return 23
   }

--- a/test/attr/attr_native_dynamic.swift
+++ b/test/attr/attr_native_dynamic.swift
@@ -3,19 +3,19 @@
 struct Strukt {
   // CHECK: (struct_decl {{.*}} "Strukt"
   // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" type='Int' interface type='Int' access=internal dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=dynamicStorageOnlyVar
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set_for=dynamicStorageOnlyVar
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=dynamicStorageOnlyVar
+  // CHECK: (accessor_decl {{.*}} get_for="dynamicStorageOnlyVar" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="dynamicStorageOnlyVar" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="dynamicStorageOnlyVar" {{.*}} access=internal{{$}}
   dynamic var dynamicStorageOnlyVar : Int = 0
 
   // CHECK: (var_decl {{.*}} "computedVar" type='Int' interface type='Int' access=internal dynamic readImpl=getter immutable
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=computedVar
+  // CHECK: (accessor_decl {{.*}} get_for="computedVar" {{.*}} access=internal dynamic{{$}}
   dynamic var computedVar : Int {
     return 0
   }
 
   // CHECK: (var_decl {{.*}} "computedVar2" type='Int' interface type='Int' access=internal dynamic readImpl=getter immutable
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=computedVar2
+  // CHECK: (accessor_decl {{.*}} get_for="computedVar2" {{.*}} access=internal dynamic{{$}}
   dynamic var computedVar2 : Int {
     get {
       return 0
@@ -23,9 +23,9 @@ struct Strukt {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarGetterSetter" type='Int' interface type='Int' access=internal dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=computedVarGetterSetter
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set_for=computedVarGetterSetter
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=computedVarGetterSetter
+  // CHECK: (accessor_decl {{.*}} get_for="computedVarGetterSetter" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="computedVarGetterSetter" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarGetterSetter" {{.*}} access=internal{{$}}
   dynamic var computedVarGetterSetter : Int {
     get {
       return 0
@@ -35,9 +35,9 @@ struct Strukt {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarGetterModify" type='Int' interface type='Int' access=internal dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=computedVarGetterModify
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify_for=computedVarGetterModify
-  // CHECK: (accessor_decl {{.*}} access=internal set_for=computedVarGetterModify
+  // CHECK: (accessor_decl {{.*}} get_for="computedVarGetterModify" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarGetterModify" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="computedVarGetterModify" {{.*}} access=internal{{$}}
   dynamic var computedVarGetterModify : Int {
     get {
       return 0
@@ -47,10 +47,10 @@ struct Strukt {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarReadSet" type='Int' interface type='Int' access=internal dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read_for=computedVarReadSet
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set_for=computedVarReadSet
-  // CHECK: (accessor_decl {{.*}} access=internal get_for=computedVarReadSet
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=computedVarReadSet
+  // CHECK: (accessor_decl {{.*}} _read_for="computedVarReadSet" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="computedVarReadSet" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="computedVarReadSet" {{.*}} access=internal{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarReadSet" {{.*}} access=internal{{$}}
   dynamic var computedVarReadSet : Int {
     _read {
     }
@@ -59,10 +59,10 @@ struct Strukt {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarReadModify" type='Int' interface type='Int' access=internal dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read_for=computedVarReadModify
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify_for=computedVarReadModify
-  // CHECK: (accessor_decl {{.*}} access=internal get_for=computedVarReadModify
-  // CHECK: (accessor_decl {{.*}} access=internal set_for=computedVarReadModify
+  // CHECK: (accessor_decl {{.*}} _read_for="computedVarReadModify" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarReadModify" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="computedVarReadModify" {{.*}} access=internal{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="computedVarReadModify" {{.*}} access=internal{{$}}
   dynamic var computedVarReadModify : Int {
     _read {
     }
@@ -71,10 +71,10 @@ struct Strukt {
   }
 
   // CHECK: (var_decl {{.*}} "storedWithObserver" type='Int' interface type='Int' access=internal dynamic readImpl=stored writeImpl=stored_with_observers readWriteImpl=stored_with_didset
-  // CHECK: (accessor_decl {{.*}}access=private dynamic didSet_for=storedWithObserver
-  // CHECK: (accessor_decl {{.*}}access=internal dynamic get_for=storedWithObserver
-  // CHECK: (accessor_decl {{.*}}access=internal set_for=storedWithObserver
-  // CHECK: (accessor_decl {{.*}}access=internal _modify_for=storedWithObserver
+  // CHECK: (accessor_decl {{.*}} didSet_for="storedWithObserver" {{.*}} access=private dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="storedWithObserver" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="storedWithObserver" {{.*}} access=internal{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="storedWithObserver" {{.*}} access=internal{{$}}
   dynamic var storedWithObserver : Int {
     didSet {
     }
@@ -86,9 +86,9 @@ struct Strukt {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal{{$}}
   dynamic subscript(_ index: Int) -> Int {
     get {
       return 1
@@ -98,9 +98,9 @@ struct Strukt {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal set_for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal{{$}}
   dynamic subscript(_ index: Float) -> Int {
     get {
       return 1
@@ -110,10 +110,10 @@ struct Strukt {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal get_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal set_for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} _read_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal{{$}}
   dynamic subscript(_ index: Double) -> Int {
     _read {
     }
@@ -122,10 +122,10 @@ struct Strukt {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal get_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} _read_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal{{$}}
   dynamic subscript(_ index: Strukt) -> Int {
     _read {
     }
@@ -137,19 +137,19 @@ struct Strukt {
 class Klass {
   // CHECK: (class_decl {{.*}} "Klass"
   // CHECK: (var_decl {{.*}} "dynamicStorageOnlyVar" type='Int' interface type='Int' access=internal dynamic readImpl=stored writeImpl=stored readWriteImpl=stored
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=dynamicStorageOnlyVar
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set_for=dynamicStorageOnlyVar
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=dynamicStorageOnlyVar
+  // CHECK: (accessor_decl {{.*}} get_for="dynamicStorageOnlyVar" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="dynamicStorageOnlyVar" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="dynamicStorageOnlyVar" {{.*}} access=internal{{$}}
   dynamic var dynamicStorageOnlyVar : Int = 0
 
   // CHECK: (var_decl {{.*}} "computedVar" type='Int' interface type='Int' access=internal dynamic readImpl=getter immutable
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=computedVar
+  // CHECK: (accessor_decl {{.*}} get_for="computedVar" {{.*}} access=internal dynamic{{$}}
   dynamic var computedVar : Int {
     return 0
   }
 
   // CHECK: (var_decl {{.*}} "computedVar2" type='Int' interface type='Int' access=internal dynamic readImpl=getter immutable
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=computedVar2
+  // CHECK: (accessor_decl {{.*}} get_for="computedVar2" {{.*}} access=internal dynamic{{$}}
   dynamic var computedVar2 : Int {
     get {
       return 0
@@ -157,9 +157,9 @@ class Klass {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarGetterSetter" type='Int' interface type='Int' access=internal dynamic readImpl=getter writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=computedVarGetterSetter
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set_for=computedVarGetterSetter
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=computedVarGetterSetter
+  // CHECK: (accessor_decl {{.*}} get_for="computedVarGetterSetter" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="computedVarGetterSetter" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarGetterSetter" {{.*}} access=internal{{$}}
   dynamic var computedVarGetterSetter : Int {
     get {
       return 0
@@ -169,9 +169,9 @@ class Klass {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarGetterModify" type='Int' interface type='Int' access=internal dynamic readImpl=getter writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=computedVarGetterModify
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify_for=computedVarGetterModify
-  // CHECK: (accessor_decl {{.*}} access=internal set_for=computedVarGetterModify
+  // CHECK: (accessor_decl {{.*}} get_for="computedVarGetterModify" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarGetterModify" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="computedVarGetterModify" {{.*}} access=internal{{$}}
   dynamic var computedVarGetterModify : Int {
     get {
       return 0
@@ -181,10 +181,10 @@ class Klass {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarReadSet" type='Int' interface type='Int' access=internal dynamic readImpl=read_coroutine writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read_for=computedVarReadSet
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set_for=computedVarReadSet
-  // CHECK: (accessor_decl {{.*}} access=internal get_for=computedVarReadSet
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=computedVarReadSet
+  // CHECK: (accessor_decl {{.*}} _read_for="computedVarReadSet" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="computedVarReadSet" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="computedVarReadSet" {{.*}} access=internal{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarReadSet" {{.*}} access=internal{{$}}
   dynamic var computedVarReadSet : Int {
     _read {
     }
@@ -193,10 +193,10 @@ class Klass {
   }
 
   // CHECK: (var_decl {{.*}} "computedVarReadModify" type='Int' interface type='Int' access=internal dynamic readImpl=read_coroutine writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read_for=computedVarReadModify
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify_for=computedVarReadModify
-  // CHECK: (accessor_decl {{.*}} access=internal get_for=computedVarReadModify
-  // CHECK: (accessor_decl {{.*}} access=internal set_for=computedVarReadModify
+  // CHECK: (accessor_decl {{.*}} _read_for="computedVarReadModify" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="computedVarReadModify" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="computedVarReadModify" {{.*}} access=internal{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="computedVarReadModify" {{.*}} access=internal{{$}}
   dynamic var computedVarReadModify : Int {
     _read {
     }
@@ -214,10 +214,10 @@ class Klass {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=addressor writeImpl=mutable_addressor readWriteImpl=mutable_addressor
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeAddress_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeMutableAddress_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal get_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal set_for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} unsafeAddress_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} unsafeMutableAddress_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal{{$}}
   dynamic subscript(_ index: Int) -> Int {
     unsafeAddress {
       fatalError()
@@ -228,10 +228,10 @@ class Klass {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=getter writeImpl=mutable_addressor readWriteImpl=mutable_addressor
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic get_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeMutableAddress_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal set_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} unsafeMutableAddress_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal{{$}}
   dynamic subscript(_ index: Float) -> Int {
     get {
       return 1
@@ -242,11 +242,11 @@ class Klass {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=read_coroutine writeImpl=mutable_addressor readWriteImpl=mutable_addressor
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _read_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeMutableAddress_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal get_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal set_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} _read_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} unsafeMutableAddress_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal{{$}}
   dynamic subscript(_ index: Double) -> Int {
     _read {
     }
@@ -256,10 +256,10 @@ class Klass {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=addressor writeImpl=setter readWriteImpl=materialize_to_temporary
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeAddress_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic set_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal get_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal _modify_for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} unsafeAddress_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal{{$}}
   dynamic subscript(_ index: Int8) -> Int {
     unsafeAddress {
       fatalError()
@@ -269,10 +269,10 @@ class Klass {
   }
 
   // CHECK: (subscript_decl {{.*}} "subscript(_:)" {{.*}} access=internal dynamic readImpl=addressor writeImpl=modify_coroutine readWriteImpl=modify_coroutine
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic unsafeAddress_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal dynamic _modify_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal get_for=subscript(_:)
-  // CHECK: (accessor_decl {{.*}} access=internal set_for=subscript(_:)
+  // CHECK: (accessor_decl {{.*}} unsafeAddress_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} _modify_for="subscript(_:)" {{.*}} access=internal dynamic{{$}}
+  // CHECK: (accessor_decl {{.*}} get_for="subscript(_:)" {{.*}} access=internal{{$}}
+  // CHECK: (accessor_decl {{.*}} set_for="subscript(_:)" {{.*}} access=internal{{$}}
   dynamic subscript(_ index: Int16) -> Int {
     unsafeAddress {
       fatalError()

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2309,11 +2309,13 @@ class ClassThrows1 {
 @objc // access-note-move{{ImplicitClassThrows1}}
 class ImplicitClassThrows1 {
   // CHECK: @objc func methodReturnsVoid() throws
-  // CHECK-DUMP: func_decl{{.*}}"methodReturnsVoid()"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP: func_decl{{.*}}"methodReturnsVoid()"{{.*}}
+  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=0 param_type=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> result_type=ObjCBool)
   func methodReturnsVoid() throws { }
 
   // CHECK: @objc func methodReturnsObjCClass() throws -> Class_ObjC1
-  // CHECK-DUMP: func_decl{{.*}}"methodReturnsObjCClass()" {{.*}}foreign_error=NilResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>
+  // CHECK-DUMP: func_decl{{.*}}"methodReturnsObjCClass()" {{.*}}
+  // CHECK-DUMP-NEXT: (foreign_error kind=NilResult unowned param_index=0 param_type=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>)
   func methodReturnsObjCClass() throws -> Class_ObjC1 {
     return Class_ObjC1()
   }
@@ -2328,11 +2330,13 @@ class ImplicitClassThrows1 {
   func methodReturnsOptionalObjCClass() throws -> Class_ObjC1? { return nil }
 
   // CHECK: @objc func methodWithTrailingClosures(_ s: String, fn1: @escaping ((Int) -> Int), fn2: @escaping (Int) -> Int, fn3: @escaping (Int) -> Int)
-  // CHECK-DUMP: func_decl{{.*}}"methodWithTrailingClosures(_:fn1:fn2:fn3:)"{{.*}}foreign_error=ZeroResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP: func_decl{{.*}}"methodWithTrailingClosures(_:fn1:fn2:fn3:)"{{.*}}
+  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=1 param_type=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> result_type=ObjCBool)
   func methodWithTrailingClosures(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int, fn3: @escaping (Int) -> Int) throws { }
 
   // CHECK: @objc init(degrees: Double) throws
-  // CHECK-DUMP: constructor_decl{{.*}}"init(degrees:)"{{.*}}foreign_error=NilResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>
+  // CHECK-DUMP: constructor_decl{{.*}}"init(degrees:)"{{.*}}
+  // CHECK-DUMP-NEXT: (foreign_error kind=NilResult unowned param_index=1 param_type=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>)
   init(degrees: Double) throws { }
 
   // CHECK: {{^}} func methodReturnsBridgedValueType() throws -> NSRange
@@ -2359,7 +2363,8 @@ class ImplicitClassThrows1 {
 @objc // access-note-move{{SubclassImplicitClassThrows1}}
 class SubclassImplicitClassThrows1 : ImplicitClassThrows1 {
   // CHECK: @objc override func methodWithTrailingClosures(_ s: String, fn1: @escaping ((Int) -> Int), fn2: @escaping ((Int) -> Int), fn3: @escaping ((Int) -> Int))
-  // CHECK-DUMP: func_decl{{.*}}"methodWithTrailingClosures(_:fn1:fn2:fn3:)"{{.*}}foreign_error=ZeroResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP: func_decl{{.*}}"methodWithTrailingClosures(_:fn1:fn2:fn3:)"{{.*}}
+  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=1 param_type=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> result_type=ObjCBool)
   override func methodWithTrailingClosures(_ s: String, fn1: (@escaping (Int) -> Int), fn2: (@escaping (Int) -> Int), fn3: (@escaping (Int) -> Int)) throws { }
 }
 
@@ -2408,20 +2413,24 @@ class ThrowsObjCName {
   @objc(method7) // bad-access-note-move{{ThrowsObjCName.method7(x:)}} expected-error{{'@objc' method name provides names for 0 arguments, but method has 2 parameters (including the error parameter)}}
   func method7(x: Int) throws { }
 
-  // CHECK-DUMP: func_decl{{.*}}"method8(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=2,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP: func_decl{{.*}}"method8(_:fn1:fn2:)"{{.*}}
+  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=2 param_type=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> result_type=ObjCBool)
   @objc(method8:fn1:error:fn2:) // access-note-move{{ThrowsObjCName.method8(_:fn1:fn2:)}}
   func method8(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 
-  // CHECK-DUMP: func_decl{{.*}}"method9(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP: func_decl{{.*}}"method9(_:fn1:fn2:)"{{.*}}
+  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=0 param_type=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> result_type=ObjCBool)
   @objc(method9AndReturnError:s:fn1:fn2:) // access-note-move{{ThrowsObjCName.method9(_:fn1:fn2:)}}
   func method9(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 }
 
 class SubclassThrowsObjCName : ThrowsObjCName {
-  // CHECK-DUMP: func_decl{{.*}}"method8(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=2,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP: func_decl{{.*}}"method8(_:fn1:fn2:)"{{.*}}
+  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=2 param_type=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> result_type=ObjCBool)
   override func method8(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 
-  // CHECK-DUMP: func_decl{{.*}}"method9(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP: func_decl{{.*}}"method9(_:fn1:fn2:)"{{.*}}
+  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=0 param_type=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> result_type=ObjCBool)
   override func method9(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 }
 

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2310,12 +2310,12 @@ class ClassThrows1 {
 class ImplicitClassThrows1 {
   // CHECK: @objc func methodReturnsVoid() throws
   // CHECK-DUMP: func_decl{{.*}}"methodReturnsVoid()"{{.*}}
-  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=0 param_type=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> result_type=ObjCBool)
+  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=0 param_type='Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>' result_type='ObjCBool')
   func methodReturnsVoid() throws { }
 
   // CHECK: @objc func methodReturnsObjCClass() throws -> Class_ObjC1
   // CHECK-DUMP: func_decl{{.*}}"methodReturnsObjCClass()" {{.*}}
-  // CHECK-DUMP-NEXT: (foreign_error kind=NilResult unowned param_index=0 param_type=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>)
+  // CHECK-DUMP-NEXT: (foreign_error kind=NilResult unowned param_index=0 param_type='Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>')
   func methodReturnsObjCClass() throws -> Class_ObjC1 {
     return Class_ObjC1()
   }
@@ -2331,12 +2331,12 @@ class ImplicitClassThrows1 {
 
   // CHECK: @objc func methodWithTrailingClosures(_ s: String, fn1: @escaping ((Int) -> Int), fn2: @escaping (Int) -> Int, fn3: @escaping (Int) -> Int)
   // CHECK-DUMP: func_decl{{.*}}"methodWithTrailingClosures(_:fn1:fn2:fn3:)"{{.*}}
-  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=1 param_type=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> result_type=ObjCBool)
+  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=1 param_type='Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>' result_type='ObjCBool')
   func methodWithTrailingClosures(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int, fn3: @escaping (Int) -> Int) throws { }
 
   // CHECK: @objc init(degrees: Double) throws
   // CHECK-DUMP: constructor_decl{{.*}}"init(degrees:)"{{.*}}
-  // CHECK-DUMP-NEXT: (foreign_error kind=NilResult unowned param_index=1 param_type=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>)
+  // CHECK-DUMP-NEXT: (foreign_error kind=NilResult unowned param_index=1 param_type='Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>')
   init(degrees: Double) throws { }
 
   // CHECK: {{^}} func methodReturnsBridgedValueType() throws -> NSRange
@@ -2364,7 +2364,7 @@ class ImplicitClassThrows1 {
 class SubclassImplicitClassThrows1 : ImplicitClassThrows1 {
   // CHECK: @objc override func methodWithTrailingClosures(_ s: String, fn1: @escaping ((Int) -> Int), fn2: @escaping ((Int) -> Int), fn3: @escaping ((Int) -> Int))
   // CHECK-DUMP: func_decl{{.*}}"methodWithTrailingClosures(_:fn1:fn2:fn3:)"{{.*}}
-  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=1 param_type=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> result_type=ObjCBool)
+  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=1 param_type='Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>' result_type='ObjCBool')
   override func methodWithTrailingClosures(_ s: String, fn1: (@escaping (Int) -> Int), fn2: (@escaping (Int) -> Int), fn3: (@escaping (Int) -> Int)) throws { }
 }
 
@@ -2414,23 +2414,23 @@ class ThrowsObjCName {
   func method7(x: Int) throws { }
 
   // CHECK-DUMP: func_decl{{.*}}"method8(_:fn1:fn2:)"{{.*}}
-  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=2 param_type=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> result_type=ObjCBool)
+  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=2 param_type='Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>' result_type='ObjCBool')
   @objc(method8:fn1:error:fn2:) // access-note-move{{ThrowsObjCName.method8(_:fn1:fn2:)}}
   func method8(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 
   // CHECK-DUMP: func_decl{{.*}}"method9(_:fn1:fn2:)"{{.*}}
-  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=0 param_type=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> result_type=ObjCBool)
+  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=0 param_type='Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>' result_type='ObjCBool')
   @objc(method9AndReturnError:s:fn1:fn2:) // access-note-move{{ThrowsObjCName.method9(_:fn1:fn2:)}}
   func method9(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 }
 
 class SubclassThrowsObjCName : ThrowsObjCName {
   // CHECK-DUMP: func_decl{{.*}}"method8(_:fn1:fn2:)"{{.*}}
-  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=2 param_type=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> result_type=ObjCBool)
+  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=2 param_type='Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>' result_type='ObjCBool')
   override func method8(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 
   // CHECK-DUMP: func_decl{{.*}}"method9(_:fn1:fn2:)"{{.*}}
-  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=0 param_type=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>> result_type=ObjCBool)
+  // CHECK-DUMP-NEXT: (foreign_error kind=ZeroResult unowned param_index=0 param_type='Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>' result_type='ObjCBool')
   override func method9(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 }
 

--- a/test/attr/attr_objc_async.swift
+++ b/test/attr/attr_objc_async.swift
@@ -9,11 +9,13 @@ import Foundation
 // CHECK: class MyClass
 class MyClass {
   // CHECK: @objc func doBigJob() async -> Int
-  // CHECK-DUMP: func_decl{{.*}}doBigJob{{.*}}foreign_async=@convention(block) (Int) -> (),completion_handler_param=0
+  // CHECK-DUMP: func_decl{{.*}}doBigJob{{.*}}
+  // CHECK-DUMP-NEXT: (foreign_async completion_handler_param_index=0 completion_handler_type=@convention(block) (Int) -> ()
   @objc func doBigJob() async -> Int { return 0 }
 
   // CHECK: @objc func doBigJobOrFail(_: Int) async throws -> (AnyObject, Int)
-  // CHECK-DUMP: func_decl{{.*}}doBigJobOrFail{{.*}}foreign_async=@convention(block) (Optional<AnyObject>, Int, Optional<Error>) -> (),completion_handler_param=1,error_param=2
+  // CHECK-DUMP: func_decl{{.*}}doBigJobOrFail{{.*}}
+  // CHECK-DUMP-NEXT: (foreign_async completion_handler_param_index=1 error_param_index=2 completion_handler_type=@convention(block) (Optional<AnyObject>, Int, Optional<Error>) -> ()
   @objc func doBigJobOrFail(_: Int) async throws -> (AnyObject, Int) { return (self, 0) }
 
   @objc func takeAnAsync(_ fn: () async -> Int) { } // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
@@ -28,11 +30,13 @@ class MyClass {
 // CHECK: actor MyActor
 actor MyActor {
   // CHECK: @objc func doBigJob() async -> Int
-  // CHECK-DUMP: func_decl{{.*}}doBigJob{{.*}}foreign_async=@convention(block) (Int) -> (),completion_handler_param=0
+  // CHECK-DUMP: func_decl{{.*}}doBigJob{{.*}}
+  // CHECK-DUMP-NEXT: (foreign_async completion_handler_param_index=0 completion_handler_type=@convention(block) (Int) -> ()
   @objc func doBigJob() async -> Int { return 0 }
 
   // CHECK: @objc func doBigJobOrFail(_: Int) async throws -> (AnyObject, Int)
-  // CHECK-DUMP: func_decl{{.*}}doBigJobOrFail{{.*}}foreign_async=@convention(block) (Optional<AnyObject>, Int, Optional<Error>) -> (),completion_handler_param=1,error_param=2
+  // CHECK-DUMP: func_decl{{.*}}doBigJobOrFail{{.*}}
+  // CHECK-DUMP-NEXT: (foreign_async completion_handler_param_index=1 error_param_index=2 completion_handler_type=@convention(block) (Optional<AnyObject>, Int, Optional<Error>) -> ()
   @objc func doBigJobOrFail(_: Int) async throws -> (AnyObject, Int) { return (self, 0) }
   // expected-warning@-1{{cannot call function returning non-sendable type '(AnyObject, Int)' across actors}}
 

--- a/test/attr/attr_objc_async.swift
+++ b/test/attr/attr_objc_async.swift
@@ -10,12 +10,12 @@ import Foundation
 class MyClass {
   // CHECK: @objc func doBigJob() async -> Int
   // CHECK-DUMP: func_decl{{.*}}doBigJob{{.*}}
-  // CHECK-DUMP-NEXT: (foreign_async completion_handler_param_index=0 completion_handler_type=@convention(block) (Int) -> ()
+  // CHECK-DUMP-NEXT: (foreign_async completion_handler_param_index=0 completion_handler_type='@convention(block) (Int) -> ()'
   @objc func doBigJob() async -> Int { return 0 }
 
   // CHECK: @objc func doBigJobOrFail(_: Int) async throws -> (AnyObject, Int)
   // CHECK-DUMP: func_decl{{.*}}doBigJobOrFail{{.*}}
-  // CHECK-DUMP-NEXT: (foreign_async completion_handler_param_index=1 error_param_index=2 completion_handler_type=@convention(block) (Optional<AnyObject>, Int, Optional<Error>) -> ()
+  // CHECK-DUMP-NEXT: (foreign_async completion_handler_param_index=1 error_param_index=2 completion_handler_type='@convention(block) (Optional<AnyObject>, Int, Optional<Error>) -> ()'
   @objc func doBigJobOrFail(_: Int) async throws -> (AnyObject, Int) { return (self, 0) }
 
   @objc func takeAnAsync(_ fn: () async -> Int) { } // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
@@ -31,12 +31,12 @@ class MyClass {
 actor MyActor {
   // CHECK: @objc func doBigJob() async -> Int
   // CHECK-DUMP: func_decl{{.*}}doBigJob{{.*}}
-  // CHECK-DUMP-NEXT: (foreign_async completion_handler_param_index=0 completion_handler_type=@convention(block) (Int) -> ()
+  // CHECK-DUMP-NEXT: (foreign_async completion_handler_param_index=0 completion_handler_type='@convention(block) (Int) -> ()'
   @objc func doBigJob() async -> Int { return 0 }
 
   // CHECK: @objc func doBigJobOrFail(_: Int) async throws -> (AnyObject, Int)
   // CHECK-DUMP: func_decl{{.*}}doBigJobOrFail{{.*}}
-  // CHECK-DUMP-NEXT: (foreign_async completion_handler_param_index=1 error_param_index=2 completion_handler_type=@convention(block) (Optional<AnyObject>, Int, Optional<Error>) -> ()
+  // CHECK-DUMP-NEXT: (foreign_async completion_handler_param_index=1 error_param_index=2 completion_handler_type='@convention(block) (Optional<AnyObject>, Int, Optional<Error>) -> ()'
   @objc func doBigJobOrFail(_: Int) async throws -> (AnyObject, Int) { return (self, 0) }
   // expected-warning@-1{{cannot call function returning non-sendable type '(AnyObject, Int)' across actors}}
 

--- a/test/decl/protocol/associated_type_overrides.swift
+++ b/test/decl/protocol/associated_type_overrides.swift
@@ -5,7 +5,6 @@ protocol P1 {
 }
 
 // CHECK-LABEL: (protocol{{.*}}"P2"
-// CHECK-NEXT: (generic_sig
 // CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden_protos=('P1')))
 protocol P2 : P1 {
   associatedtype A
@@ -16,14 +15,12 @@ protocol P3 {
 }
 
 // CHECK-LABEL: (protocol{{.*}}"P4"
-// CHECK-NEXT: (generic_sig
 // CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden_protos=('P2' 'P3')))
 protocol P4 : P2, P3 {
   associatedtype A
 }
 
 // CHECK-LABEL: (protocol{{.*}}"P5"
-// CHECK-NEXT: (generic_sig
 // CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden_protos=('P4')))
 protocol P5 : P4, P2 {
   associatedtype A

--- a/test/decl/protocol/associated_type_overrides.swift
+++ b/test/decl/protocol/associated_type_overrides.swift
@@ -5,6 +5,7 @@ protocol P1 {
 }
 
 // CHECK-LABEL: (protocol{{.*}}"P2"
+// CHECK-NEXT: (generic_sig
 // CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden=P1))
 protocol P2 : P1 {
   associatedtype A
@@ -15,12 +16,14 @@ protocol P3 {
 }
 
 // CHECK-LABEL: (protocol{{.*}}"P4"
+// CHECK-NEXT: (generic_sig
 // CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden=P2, P3))
 protocol P4 : P2, P3 {
   associatedtype A
 }
 
 // CHECK-LABEL: (protocol{{.*}}"P5"
+// CHECK-NEXT: (generic_sig
 // CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden=P4))
 protocol P5 : P4, P2 {
   associatedtype A

--- a/test/decl/protocol/associated_type_overrides.swift
+++ b/test/decl/protocol/associated_type_overrides.swift
@@ -6,7 +6,7 @@ protocol P1 {
 
 // CHECK-LABEL: (protocol{{.*}}"P2"
 // CHECK-NEXT: (generic_sig
-// CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden=P1))
+// CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden_protos=('P1')))
 protocol P2 : P1 {
   associatedtype A
 }
@@ -17,14 +17,14 @@ protocol P3 {
 
 // CHECK-LABEL: (protocol{{.*}}"P4"
 // CHECK-NEXT: (generic_sig
-// CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden=P2, P3))
+// CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden_protos=('P2' 'P3')))
 protocol P4 : P2, P3 {
   associatedtype A
 }
 
 // CHECK-LABEL: (protocol{{.*}}"P5"
 // CHECK-NEXT: (generic_sig
-// CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden=P4))
+// CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden_protos=('P4')))
 protocol P5 : P4, P2 {
   associatedtype A
 }

--- a/test/decl/protocol/override.swift
+++ b/test/decl/protocol/override.swift
@@ -17,7 +17,7 @@ protocol P0 {
 // CHECK: protocol{{.*}}"P1"
 protocol P1: P0 {
   // CHECK: associated_type_decl
-  // CHECK-SAME: overridden=P0
+  // CHECK-SAME: overridden_protos=('P0')
   associatedtype A
 
   // CHECK: func_decl{{.*}}foo(){{.*}}Self : P1{{.*}}override={{.*}}P0.foo
@@ -25,7 +25,7 @@ protocol P1: P0 {
 
   // CHECK: var_decl
   // CHECK-SAME: "prop"
-  // CHECK-SAME: override=override.(file).P0.prop
+  // CHECK-SAME: override=('override.(file).P0.prop@{{[^']+}}')
   var prop: A { get }
 }
 
@@ -42,30 +42,31 @@ protocol P2 {
 protocol P3: P1, P2 {
   // CHECK: associated_type_decl
   // CHECK-SAME: "A"
-  // CHECK-SAME: override=override.(file).P1.A
-  // CHECK-SAME: override.(file).P2.A
+  // CHECK-SAME: override=(
+  // CHECK-SAME: 'override.(file).P1.A@
+  // CHECK-SAME: 'override.(file).P2.A@
   associatedtype A
 
-  // CHECK: func_decl{{.*}}foo(){{.*}}Self : P3{{.*}}override={{.*}}P2.foo{{.*,.*}}P1.foo
+  // CHECK: func_decl{{.*}}foo(){{.*}}Self : P3{{.*}}override=('{{.*}}P2.foo{{.*' '.*}}P1.foo
   func foo()
 
   // CHECK: var_decl
   // CHECK-SAME: "prop"
-  // CHECK-SAME: override=override.(file).P2.prop
-  // CHECK-SAME: override.(file).P1.prop
+  // CHECK-SAME: override=(
+  // CHECK-SAME: 'override.(file).P2.prop@
+  // CHECK-SAME: 'override.(file).P1.prop@
   var prop: A { get }
 }
 
 // CHECK: protocol{{.*}}"P4"
 protocol P4: P0 {
   // CHECK: func_decl{{.*}}foo(){{.*}}Self : P4
-  // CHECK-NOT: override=
-  // CHECK-SAME: )
+  // CHECK-SAME: override=()
   func foo() -> Int
 
   // CHECK: var_decl
   // CHECK-SAME: "prop"
-  // CHECK-NOT: override=
+  // CHECK-SAME: override=()
   // CHECK-SAME: immutable
   var prop: Int { get }
 }
@@ -73,13 +74,12 @@ protocol P4: P0 {
 // CHECK: protocol{{.*}}"P5"
 protocol P5: P0 where Self.A == Int {
   // CHECK: func_decl{{.*}}foo(){{.*}}Self : P5
-  // CHECK-NOT: override=
-  // CHECK-SAME: )
+  // CHECK-SAME: override=()
   func foo() -> Int
 
   // CHECK: var_decl
   // CHECK-SAME: "prop"
-  // CHECK-SAME: override=override.(file).P0.prop
+  // CHECK-SAME: override=('override.(file).P0.prop@
   var prop: Int { get }
 }
 
@@ -91,7 +91,7 @@ protocol P6: P0 {
 
   // CHECK: var_decl
   // CHECK-SAME: "prop"
-  // CHECK-SAME: override=override.(file).P0.prop
+  // CHECK-SAME: override=('override.(file).P0.prop@
   override var prop: A { get }
 }
 
@@ -109,20 +109,18 @@ protocol P7: P0 {
 protocol P8: P0 {
   // CHECK: associated_type_decl
   // CHECK-SAME: "A"
-  // CHECK-NOT: override
-  // CHECK-SAME: )
+  // CHECK-SAME: override=()
   @_nonoverride
   associatedtype A
 
   // CHECK: func_decl{{.*}}foo(){{.*}}Self : P8
-  // CHECK-NOT: override=
-  // CHECK-SAME: )
+  // CHECK-SAME: override=()
   @_nonoverride
   func foo()
 
   // CHECK: var_decl
   // CHECK-SAME: "prop"
-  // CHECK-NOT: override=
+  // CHECK-SAME: override=()
   // CHECK-SAME: immutable
   @_nonoverride
   var prop: A { get }
@@ -140,13 +138,11 @@ protocol SubtypingP0 {
 // CHECK: protocol{{.*}}"SubtypingP1"
 protocol SubtypingP1: SubtypingP0 {
   // CHECK: constructor_decl{{.*}}Self : SubtypingP1
-  // CHECK-NOT: override=
-  // CHECK-SAME: designated
+  // CHECK-SAME: override=()
   init()
 
   // CHECK: func_decl{{.*}}foo(){{.*}}Self : SubtypingP1
-  // CHECK-NOT: override=
-  // CHECK-SAME: )
+  // CHECK-SAME: override=()
   func foo() -> Derived
 }
 

--- a/test/decl/protocol/req/existentials_covariant_erasure.swift
+++ b/test/decl/protocol/req/existentials_covariant_erasure.swift
@@ -34,11 +34,11 @@ do {
     let x5 = pc.lotsOfSelfFunc
     let x6 = pc.lotsOfSelfProp
 
-    // CHECK: (pattern_named type='((P) -> Void, (P?) -> Void, ([P]) -> Void, ([Array<P>?]) -> Void) -> [String : () -> P]' 'x1')
-    // CHECK: (pattern_named type='((P) -> Void, (P?) -> Void, ([P]) -> Void, ([Array<P>?]) -> Void) -> [String : () -> P]' 'x2')
-    // CHECK: (pattern_named type='((P & Q) -> Void, ((P & Q)?) -> Void, ([P & Q]) -> Void, ([Array<P & Q>?]) -> Void) -> [String : () -> P & Q]' 'x3')
-    // CHECK: (pattern_named type='((P & Q) -> Void, ((P & Q)?) -> Void, ([P & Q]) -> Void, ([Array<P & Q>?]) -> Void) -> [String : () -> P & Q]' 'x4')
-    // CHECK: (pattern_named type='((C & P) -> Void, ((C & P)?) -> Void, ([C & P]) -> Void, ([Array<C & P>?]) -> Void) -> [String : () -> C & P]' 'x5')
-    // CHECK: (pattern_named type='((C & P) -> Void, ((C & P)?) -> Void, ([C & P]) -> Void, ([Array<C & P>?]) -> Void) -> [String : () -> C & P]' 'x6')
+    // CHECK: (pattern=pattern_named type='((P) -> Void, (P?) -> Void, ([P]) -> Void, ([Array<P>?]) -> Void) -> [String : () -> P]' "x1")
+    // CHECK: (pattern=pattern_named type='((P) -> Void, (P?) -> Void, ([P]) -> Void, ([Array<P>?]) -> Void) -> [String : () -> P]' "x2")
+    // CHECK: (pattern=pattern_named type='((P & Q) -> Void, ((P & Q)?) -> Void, ([P & Q]) -> Void, ([Array<P & Q>?]) -> Void) -> [String : () -> P & Q]' "x3")
+    // CHECK: (pattern=pattern_named type='((P & Q) -> Void, ((P & Q)?) -> Void, ([P & Q]) -> Void, ([Array<P & Q>?]) -> Void) -> [String : () -> P & Q]' "x4")
+    // CHECK: (pattern=pattern_named type='((C & P) -> Void, ((C & P)?) -> Void, ([C & P]) -> Void, ([Array<C & P>?]) -> Void) -> [String : () -> C & P]' "x5")
+    // CHECK: (pattern=pattern_named type='((C & P) -> Void, ((C & P)?) -> Void, ([C & P]) -> Void, ([Array<C & P>?]) -> Void) -> [String : () -> C & P]' "x6")
   }
 }

--- a/test/decl/var/property_wrappers_synthesis.swift
+++ b/test/decl/var/property_wrappers_synthesis.swift
@@ -26,8 +26,9 @@ struct UseWrapper<T: DefaultInit> {
   var wrapped = T()
 
   // CHECK: pattern_binding_decl implicit
-  // CHECK-NEXT: pattern_typed implicit type='Wrapper<T>'
-  // CHECK-NEXT: pattern_named implicit type='Wrapper<T>' '_wrapped'
+  // CHECK-NEXT: (pattern_entry
+  // CHECK-NEXT: (pattern=pattern_typed implicit type='Wrapper<T>'
+  // CHECK-NEXT: (pattern_named implicit type='Wrapper<T>' "_wrapped"
   // CHECK: constructor_ref_call_expr
   // CHECK-NEXT: declref_expr{{.*}}Wrapper.init(wrappedValue:)
   init() { }

--- a/test/decl/var/property_wrappers_synthesis.swift
+++ b/test/decl/var/property_wrappers_synthesis.swift
@@ -13,13 +13,13 @@ protocol DefaultInit {
 struct UseWrapper<T: DefaultInit> {
   // CHECK: var_decl{{.*}}"wrapped"
 
-  // CHECK: accessor_decl{{.*}}get_for=wrapped
+  // CHECK: accessor_decl{{.*}}get_for="wrapped"
   // CHECK: member_ref_expr{{.*}}UseWrapper._wrapped
 
-  // CHECK: accessor_decl{{.*}}set_for=wrapped
+  // CHECK: accessor_decl{{.*}}set_for="wrapped"
   // CHECK: member_ref_expr{{.*}}UseWrapper._wrapped
 
-  // CHECK: accessor_decl{{.*}}_modify_for=wrapped
+  // CHECK: accessor_decl{{.*}}_modify_for="wrapped"
   // CHECK: yield_stmt
   // CHECK: member_ref_expr{{.*}}Wrapper.wrappedValue
   @Wrapper
@@ -37,7 +37,7 @@ struct UseWrapper<T: DefaultInit> {
 struct UseWillSetDidSet {
   // CHECK: var_decl{{.*}}"z"
 
-  // CHECK: accessor_decl{{.*}}set_for=z
+  // CHECK: accessor_decl{{.*}}set_for="z"
   // CHECK: member_ref_expr{{.*}}UseWillSetDidSet._z
   @Wrapper
   var z: Int {
@@ -82,10 +82,10 @@ struct Observable<Value> {
 class MyObservedType {
   @Observable var observedProperty = 17
 
-  // CHECK: accessor_decl{{.*}}get_for=observedProperty
+  // CHECK: accessor_decl{{.*}}get_for="observedProperty"
   // CHECK:   subscript_expr implicit type='@lvalue Int' decl={{.*}}.Observable.subscript(_enclosingInstance:wrapped:storage:)
 
-  // CHECK: accessor_decl{{.*}}set_for=observedProperty
+  // CHECK: accessor_decl{{.*}}set_for="observedProperty"
   // CHECK:   subscript_expr implicit type='@lvalue Int' decl={{.*}}.Observable.subscript(_enclosingInstance:wrapped:storage:)
 }
 

--- a/test/expr/capture/dynamic_self.swift
+++ b/test/expr/capture/dynamic_self.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
 
-// CHECK: func_decl{{.*}}"clone()" interface type='(Android) -> () -> Self'
+// CHECK: func_decl{{.*}}"clone()" interface_type='(Android) -> () -> Self'
 
 class Android {
   func clone() -> Self {

--- a/test/expr/capture/generic_params.swift
+++ b/test/expr/capture/generic_params.swift
@@ -2,7 +2,7 @@
 
 func doSomething<T>(_ t: T) {}
 
-// CHECK: func_decl{{.*}}"outerGeneric(t:x:)" <T> interface type='<T> (t: T, x: AnyObject) -> ()'
+// CHECK: func_decl{{.*}}"outerGeneric(t:x:)" '<T>' interface type='<T> (t: T, x: AnyObject) -> ()'
 
 func outerGeneric<T>(t: T, x: AnyObject) {
   // Simple case -- closure captures outer generic parameter
@@ -20,7 +20,7 @@ func outerGeneric<T>(t: T, x: AnyObject) {
 
   // Nested generic functions always capture outer generic parameters, even if
   // they're not mentioned in the function body
-  // CHECK: func_decl{{.*}}"innerGeneric(u:)" <U> interface type='<T, U> (u: U) -> ()' {{.*}} captures=(<generic> )
+  // CHECK: func_decl{{.*}}"innerGeneric(u:)" '<U>' interface type='<T, U> (u: U) -> ()' {{.*}} captures=(<generic> )
   func innerGeneric<U>(u: U) {}
 
   // Make sure we look through typealiases

--- a/test/expr/capture/generic_params.swift
+++ b/test/expr/capture/generic_params.swift
@@ -2,7 +2,7 @@
 
 func doSomething<T>(_ t: T) {}
 
-// CHECK: func_decl{{.*}}"outerGeneric(t:x:)" '<T>' interface type='<T> (t: T, x: AnyObject) -> ()'
+// CHECK: func_decl{{.*}}"outerGeneric(t:x:)" '<T>' interface_type='<T> (t: T, x: AnyObject) -> ()'
 
 func outerGeneric<T>(t: T, x: AnyObject) {
   // Simple case -- closure captures outer generic parameter
@@ -20,13 +20,13 @@ func outerGeneric<T>(t: T, x: AnyObject) {
 
   // Nested generic functions always capture outer generic parameters, even if
   // they're not mentioned in the function body
-  // CHECK: func_decl{{.*}}"innerGeneric(u:)" '<U>' interface type='<T, U> (u: U) -> ()' {{.*}} captures=(<generic> )
+  // CHECK: func_decl{{.*}}"innerGeneric(u:)" '<U>' interface_type='<T, U> (u: U) -> ()' {{.*}} captures=(<generic> )
   func innerGeneric<U>(u: U) {}
 
   // Make sure we look through typealiases
   typealias TT = (a: T, b: T)
 
-  // CHECK: func_decl{{.*}}"localFunction(tt:)" interface type='<T> (tt: TT) -> ()' {{.*}} captures=(<generic> )
+  // CHECK: func_decl{{.*}}"localFunction(tt:)" interface_type='<T> (tt: TT) -> ()' {{.*}} captures=(<generic> )
   func localFunction(tt: TT) {}
 
   // CHECK: closure_expr type='(TT) -> ()' {{.*}} captures=(<generic> )

--- a/test/expr/capture/generic_params.swift
+++ b/test/expr/capture/generic_params.swift
@@ -6,11 +6,11 @@ func doSomething<T>(_ t: T) {}
 
 func outerGeneric<T>(t: T, x: AnyObject) {
   // Simple case -- closure captures outer generic parameter
-  // CHECK: closure_expr type='() -> ()' {{.*}} discriminator=0 captures=(<generic> t<direct>) escaping  single-expression
+  // CHECK: closure_expr type='() -> ()' {{.*}} discriminator=0 captures=(<generic> t<direct>) escaping  single_expr
   _ = { doSomething(t) }
 
   // Special case -- closure does not capture outer generic parameters
-  // CHECK: closure_expr type='() -> ()' {{.*}} discriminator=1 captures=(x<direct>) escaping single-expression
+  // CHECK: closure_expr type='() -> ()' {{.*}} discriminator=1 captures=(x<direct>) escaping single_expr
   _ = { doSomething(x) }
 
   // Special case -- closure captures outer generic parameter, but it does not

--- a/test/expr/capture/top-level-guard.swift
+++ b/test/expr/capture/top-level-guard.swift
@@ -20,7 +20,7 @@ func function() {
   _ = x
 }
 
-// CHECK-LABEL: (closure_expr
+// CHECK-LABEL: (original_init=closure_expr
 // CHECK: location={{.*}}top-level-guard.swift:[[@LINE+3]]
 // CHECK: captures=(x<direct>)
 // CHECK: (var_decl{{.*}}"closure"
@@ -28,9 +28,9 @@ let closure: () -> Void = {
   _ = x
 }
 
-// CHECK-LABEL: (capture_list
+// CHECK-LABEL: (original_init=capture_list
 // CHECK: location={{.*}}top-level-guard.swift:[[@LINE+5]]
-// CHECK: (closure_expr
+// CHECK: (body=closure_expr
 // CHECK: location={{.*}}top-level-guard.swift:[[@LINE+3]]
 // CHECK: captures=(x<direct>)
 // CHECK: (var_decl{{.*}}"closureCapture"

--- a/test/expr/capture/top-level-guard.swift
+++ b/test/expr/capture/top-level-guard.swift
@@ -15,7 +15,7 @@ guard let x = Optional(0) else { fatalError() }
 // CHECK: (top_level_code_decl
 _ = 0 // intervening code
 
-// CHECK-LABEL: (func_decl{{.*}}"function()" interface type='() -> ()' access=internal captures=(x<direct>)
+// CHECK-LABEL: (func_decl{{.*}}"function()" interface type='() -> ()' access=internal override=() captures=(x<direct>)
 func function() {
   _ = x
 }
@@ -39,7 +39,7 @@ let closureCapture: () -> Void = { [x] in
 }
 
 // CHECK-LABEL: (defer_stmt
-// CHECK-NEXT: (func_decl{{.*}}implicit "$defer()" interface type='() -> ()' access=fileprivate captures=(x<direct><noescape>)
+// CHECK-NEXT: (func_decl{{.*}}implicit "$defer()" interface type='() -> ()' access=fileprivate override=() captures=(x<direct><noescape>)
 defer {
   _ = x
 }

--- a/test/expr/capture/top-level-guard.swift
+++ b/test/expr/capture/top-level-guard.swift
@@ -15,7 +15,7 @@ guard let x = Optional(0) else { fatalError() }
 // CHECK: (top_level_code_decl
 _ = 0 // intervening code
 
-// CHECK-LABEL: (func_decl{{.*}}"function()" interface type='() -> ()' access=internal override=() captures=(x<direct>)
+// CHECK-LABEL: (func_decl{{.*}}"function()" interface_type='() -> ()' access=internal override=() captures=(x<direct>)
 func function() {
   _ = x
 }
@@ -39,7 +39,7 @@ let closureCapture: () -> Void = { [x] in
 }
 
 // CHECK-LABEL: (defer_stmt
-// CHECK-NEXT: (func_decl{{.*}}implicit "$defer()" interface type='() -> ()' access=fileprivate override=() captures=(x<direct><noescape>)
+// CHECK-NEXT: (func_decl{{.*}}implicit "$defer()" interface_type='() -> ()' access=fileprivate override=() captures=(x<direct><noescape>)
 defer {
   _ = x
 }

--- a/test/expr/cast/array_downcast_Foundation.swift
+++ b/test/expr/cast/array_downcast_Foundation.swift
@@ -51,7 +51,7 @@ func testDowncastOptionalObjectConditional(obj: AnyObject?!) -> [String]?? {
   // CHECK-NEXT: (optional_evaluation_expr implicit type='[String]?'
   // CHECK-NEXT: (inject_into_optional implicit type='[String]?'
   // CHECK-NEXT: (bind_optional_expr implicit type='[String]'
-  // CHECK-NEXT: (conditional_checked_cast_expr type='[String]?' {{.*value_cast}} writtenType='[String]?'
+  // CHECK-NEXT: (conditional_checked_cast_expr type='[String]?' {{.*value_cast}} written_type=[String]?
   // CHECK-NEXT: (bind_optional_expr implicit type='AnyObject'
   // CHECK-NEXT: (bind_optional_expr implicit type='AnyObject?'
   // CHECK-NEXT: (declref_expr type='AnyObject??'

--- a/test/expr/cast/array_downcast_Foundation.swift
+++ b/test/expr/cast/array_downcast_Foundation.swift
@@ -51,7 +51,7 @@ func testDowncastOptionalObjectConditional(obj: AnyObject?!) -> [String]?? {
   // CHECK-NEXT: (optional_evaluation_expr implicit type='[String]?'
   // CHECK-NEXT: (inject_into_optional implicit type='[String]?'
   // CHECK-NEXT: (bind_optional_expr implicit type='[String]'
-  // CHECK-NEXT: (conditional_checked_cast_expr type='[String]?' {{.*value_cast}} written_type=[String]?
+  // CHECK-NEXT: (conditional_checked_cast_expr type='[String]?' {{.*value_cast}} written_type='[String]?'
   // CHECK-NEXT: (bind_optional_expr implicit type='AnyObject'
   // CHECK-NEXT: (bind_optional_expr implicit type='AnyObject?'
   // CHECK-NEXT: (declref_expr type='AnyObject??'

--- a/test/expr/delayed-ident/optional_overload.swift
+++ b/test/expr/delayed-ident/optional_overload.swift
@@ -36,12 +36,12 @@ let _: SR13815? = .sr13815_2()
 let _: SR13815? = .init(SR13815())
 let _: SR13815? = .init(overloaded: ())
 // If members exist on Optional and Wrapped, always choose the one on optional
-// CHECK: declref_expr {{.*}} location={{.*}}optional_overload.swift:37
-// CHECK-SAME: decl=optional_overload.(file).Optional extension.init(overloaded:)
+// CHECK: declref_expr {{.*}} location='{{.*}}optional_overload.swift:37:
+// CHECK-SAME: decl='optional_overload.(file).Optional extension.init(overloaded:)@
 let _: SR13815? = .sr13815_overload
 // Should choose the overload from Optional even if the Wrapped overload would otherwise have a better score
-// CHECK: member_ref_expr {{.*}} location={{.*}}optional_overload.swift:41
-// CHECK-SAME: decl=optional_overload.(file).Optional extension.sr13815_overload
+// CHECK: member_ref_expr {{.*}} location='{{.*}}optional_overload.swift:41:
+// CHECK-SAME: decl='optional_overload.(file).Optional extension.sr13815_overload@
 let _: SR13815? = .init(failable: ())
 let _: SR13815? = .sr13815_3()
 let _: SR13815? = .p_SR13815


### PR DESCRIPTION
This PR pretty much rips apart ASTDumper.cpp and puts it back together again in a way that is much less ad-hoc and hopefully easier to maintain.

The primary goal here is to reduce iostream boilerplate and get rid of persistent formatting bugs (e.g. missing parens, misplaced newlines, ambiguous field delimiting). This part is already yielding some benefits; for instance, fields are now generally single-quoted unless you specifically opt out of that by calling a different printing function.

I hope to eventually reach a place where AST dumps are consistent enough to be machine-parseable (or perhaps even where we can hook up an alternate JSON-dumping backend to ASTDumper or something). We're not at that point yet because there are still parts of the file where we're printing to the underlying `raw_ostream` directly, but we're getting there.

There are still a few things I'd like to do, e.g. move the `range` and `location` fields to the end of the line so that more useful/compact info appears closer to the front of the line.

This PR is "NFC-ish" because it only affects the output of `-dump-parse` and `-dump-ast`, which are used in some tests but are not a supported feature of the compiler.

Because test coverage on the AST dumper is very thin, this may cause some regressions in dumping behavior. That's why it's a draft PR. (Also 'cause I'm not done yet.)