### PR TITLE
[Parse] give more useful errors for forget 'do' keyword.

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -963,6 +963,8 @@ public:
   /// \returns \c true if there was a parsing error.
   bool parseTopLevelSIL();
 
+  bool isStartOfGetSetAccessor();
+
   /// Flags that control the parsing of declarations.
   enum ParseDeclFlags {
     PD_Default              = 0,

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -89,9 +89,9 @@ func test13811882() {
 // <rdar://problem/21544303> QoI: "Unexpected trailing closure" should have a fixit to insert a 'do' statement
 // <https://bugs.swift.org/browse/SR-3671>
 func r21544303() {
-  var inSubcall = true
-  {
-  }  // expected-error {{computed property must have accessors specified}}
+  var inSubcall = true 
+  {  // expected-error {{closure expression is unused}} expected-note {{did you mean to use a 'do' statement?}}
+  }  
   inSubcall = false
 
   // This is a problem, but isn't clear what was intended.

--- a/test/expr/closure/let.swift
+++ b/test/expr/closure/let.swift
@@ -11,3 +11,9 @@ func foo() {
   _ = { x = 0 }() // expected-error{{'x' is a 'let'}}
   _ = { frob(x: x); x = 0 }() // expected-error 2 {{'x' is a 'let'}}
 }
+
+let a: Int 
+{ 1 } // expected-error{{'let' declarations cannot be computed properties}}
+
+let b: Int = 1
+{ didSet { print("didSet") } } // expected-error{{'let' declarations cannot be observing properties}}


### PR DESCRIPTION
[Parse] give more useful errors for forget 'do' keyword.

Resolves SR-14836.


