### PR TITLE
[LTO] Driver support for -lto_library flag

### DIFF
--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -109,6 +109,8 @@ public:
 
   LTOKind LTOVariant = LTOKind::None;
 
+  std::string LibLTOPath;
+  
   /// Describes if and how the output of compile actions should be
   /// linked together.
   LinkKind LinkAction = LinkKind::None;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -550,10 +550,10 @@ def lto : Joined<["-"], "lto=">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Specify the LTO type to either 'llvm-thin' or 'llvm-full'">;
   
-def lto_library : Separate<["-"], "lto_library">,
+def lto_library : Separate<["-"], "lto-library">,
   Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption,
          SwiftAPIDigesterOption]>,
-  HelpText<"Perform LTO with <lto_library>">, MetaVarName<"<lto_library>">;
+  HelpText<"Perform LTO with <lto-library>">, MetaVarName<"<lto-library>">;
 
 def access_notes_path : Separate<["-"], "access-notes-path">,
   Flags<[FrontendOption, ArgumentIsPath]>,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -551,8 +551,7 @@ def lto : Joined<["-"], "lto=">,
   HelpText<"Specify the LTO type to either 'llvm-thin' or 'llvm-full'">;
   
 def lto_library : Separate<["-"], "lto-library">,
-  Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption,
-         SwiftAPIDigesterOption]>,
+  Flags<[FrontendOption, ArgumentIsPath, NoInteractiveOption]>,
   HelpText<"Perform LTO with <lto-library>">, MetaVarName<"<lto-library>">;
 
 def access_notes_path : Separate<["-"], "access-notes-path">,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -549,6 +549,11 @@ def disable_bridging_pch : Flag<["-"], "disable-bridging-pch">,
 def lto : Joined<["-"], "lto=">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Specify the LTO type to either 'llvm-thin' or 'llvm-full'">;
+  
+def lto_library : Separate<["-"], "lto_library">,
+  Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption,
+         SwiftAPIDigesterOption]>,
+  HelpText<"Perform LTO with <lto_library>">, MetaVarName<"<lto_library>">;
 
 def access_notes_path : Separate<["-"], "access-notes-path">,
   Flags<[FrontendOption, ArgumentIsPath]>,

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -330,6 +330,7 @@ void toolchains::Darwin::addLTOLibArgs(ArgStringList &Arguments,
     // Xcode toolchain.
     StringRef P = llvm::sys::path::parent_path(getDriver().getSwiftProgramPath());
     llvm::SmallString<128> LibLTOPath(P);
+    llvm::sys::path::remove_filename(LibLTOPath); // Remove '/bin'
     llvm::sys::path::append(LibLTOPath, "lib");
     llvm::sys::path::append(LibLTOPath, "libLTO.dylib");
     if (llvm::sys::fs::exists(LibLTOPath)) {

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -321,10 +321,28 @@ toolchains::Darwin::addArgsToLinkARCLite(ArgStringList &Arguments,
 
 void toolchains::Darwin::addLTOLibArgs(ArgStringList &Arguments,
                                        const JobContext &context) const {
-  llvm::SmallString<128> LTOLibPath;
-  if (findXcodeClangLibPath("libLTO.dylib", LTOLibPath)) {
+  if (!context.OI.LibLTOPath.empty()) {
+    // Check for user-specified LTO library.
     Arguments.push_back("-lto_library");
-    Arguments.push_back(context.Args.MakeArgString(LTOLibPath));
+    Arguments.push_back(context.Args.MakeArgString(context.OI.LibLTOPath));
+  } else {
+    // Check for relative libLTO.dylib. This would be the expected behavior in an
+    // Xcode toolchain.
+    StringRef P = llvm::sys::path::parent_path(getDriver().getSwiftProgramPath());
+    llvm::SmallString<128> LibLTOPath(P);
+    llvm::sys::path::append(LibLTOPath, "lib");
+    llvm::sys::path::append(LibLTOPath, "libLTO.dylib");
+    if (llvm::sys::fs::exists(LibLTOPath)) {
+      Arguments.push_back("-lto_library");
+      Arguments.push_back(context.Args.MakeArgString(LibLTOPath));
+    } else {
+      // Use libLTO.dylib from the default toolchain if a relative one does not exist.
+      llvm::SmallString<128> LibLTOPath;
+      if (findXcodeClangLibPath("libLTO.dylib", LibLTOPath)) {
+        Arguments.push_back("-lto_library");
+        Arguments.push_back(context.Args.MakeArgString(LibLTOPath));
+      }
+    }
   }
 }
 

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1448,6 +1448,12 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
       Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
                      A->getAsString(Args), A->getValue());
   }
+  
+  if (const Arg *A = Args.getLastArg(options::OPT_lto_library)) {
+    OI.LibLTOPath = A->getValue();
+  } else {
+    OI.LibLTOPath = "";
+  }
 
   auto CompilerOutputType = OI.LTOVariant != OutputInfo::LTOKind::None
                              ? file_types::TY_LLVM_BC

--- a/test/Driver/link-time-opt-darwin-ld-lib.swift
+++ b/test/Driver/link-time-opt-darwin-ld-lib.swift
@@ -28,12 +28,12 @@
 
 // Check that driver does not see libLTO.dylib as an input
 
-// RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm-full -lto_library /foo/libLTO.dylib -target x86_64-apple-macosx10.9     | %FileCheck %s --check-prefix=CHECK-SIMPLE-LTO-LIB --check-prefix=CHECK-SIMPLE-LTO-LIB-macosx
+// RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm-full -lto-library /foo/libLTO.dylib -target x86_64-apple-macosx10.9     | %FileCheck %s --check-prefix=CHECK-SIMPLE-LTO-LIB --check-prefix=CHECK-SIMPLE-LTO-LIB-macosx
 
 // CHECK-SIMPLE-LTO-LIB: swift
 // CHECK-SIMPLE-LTO-LIB-DAG: -emit-bc
 // CHECK-SIMPLE-LTO-LIB-DAG: -lto=llvm-full
-// CHECK-SIMPLE-LTO-LIB-NOT: -lto_library /foo/libLTO.dylib
+// CHECK-SIMPLE-LTO-LIB-NOT: -lto-library /foo/libLTO.dylib
 // CHECK-SIMPLE-LTO-LIB-DAG: -o [[OBJECTFILE:.*\.bc]]
 
 // CHECK-SIMPLE-LTO-LIB-macosx: ld

--- a/test/Driver/link-time-opt-darwin-ld-lib.swift
+++ b/test/Driver/link-time-opt-darwin-ld-lib.swift
@@ -24,3 +24,18 @@
 // CHECK-SIMPLE-FULL-macosx: ld
 // CHECK-SIMPLE-FULL-macosx-DAG: -lto_library {{.+}}/lib/libLTO.dylib
 // CHECK-SIMPLE-FULL-macosx-DAG: [[OBJECTFILE]]
+
+
+// Check that driver does not see libLTO.dylib as an input
+
+// RUN: %swiftc_driver -driver-print-jobs %S/../Inputs/empty.swift -lto=llvm-full -lto_library /foo/libLTO.dylib -target x86_64-apple-macosx10.9     | %FileCheck %s --check-prefix=CHECK-SIMPLE-LTO-LIB --check-prefix=CHECK-SIMPLE-LTO-LIB-macosx
+
+// CHECK-SIMPLE-LTO-LIB: swift
+// CHECK-SIMPLE-LTO-LIB-DAG: -emit-bc
+// CHECK-SIMPLE-LTO-LIB-DAG: -lto=llvm-full
+// CHECK-SIMPLE-LTO-LIB-NOT: -lto_library /foo/libLTO.dylib
+// CHECK-SIMPLE-LTO-LIB-DAG: -o [[OBJECTFILE:.*\.bc]]
+
+// CHECK-SIMPLE-LTO-LIB-macosx: ld
+// CHECK-SIMPLE-LTO-LIB-macosx-DAG: -lto_library /foo/libLTO.dylib
+// CHECK-SIMPLE-LTO-LIB-macosx-DAG: [[OBJECTFILE]]


### PR DESCRIPTION
This commit adds support for the -lto_library flag, allowing users to specify a custom LTO library on Darwin. This also fixes an issue where the default LTO library is used even if Driver is run from inside an alternate toolchain.

@gottesmm