### PR TITLE
[5.5][Async Refactoring] Get semantics providing expr to decide if call is to completion handler

### DIFF
--- a/test/refactoring/ConvertAsync/convert_function.swift
+++ b/test/refactoring/ConvertAsync/convert_function.swift
@@ -287,15 +287,12 @@ func testReturnHandling2(completion: @escaping (String) -> ()) {
 // RETURN-HANDLING2-NEXT:   }
 // RETURN-HANDLING2-NEXT: }
 
-// FIXME: We should arguably be able to handle transforming this completion handler call (rdar://78011350).
-// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=RETURN-HANDLING3 %s
+// RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=RETURN-HANDLING3 %s
 func testReturnHandling3(_ completion: (String?, Error?) -> Void) {
   return (completion("", nil))
 }
 // RETURN-HANDLING3:      func testReturnHandling3() async throws -> String {
-// RETURN-HANDLING3-NEXT:   return try await withCheckedThrowingContinuation { continuation in  
-// RETURN-HANDLING3-NEXT:     (continuation.resume(returning: ""))
-// RETURN-HANDLING3-NEXT:   }
+// RETURN-HANDLING3-NEXT:   {{^}} return ""{{$}}
 // RETURN-HANDLING3-NEXT: }
 
 // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=RDAR78693050 %s

--- a/test/refactoring/ConvertAsync/convert_to_continuation.swift
+++ b/test/refactoring/ConvertAsync/convert_to_continuation.swift
@@ -26,6 +26,20 @@ func testCreateContinuation(completionHandler: (Int) -> Void) {
 // CREATE-CONTINUATION-NEXT:   }
 // CREATE-CONTINUATION-NEXT: }
 
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=CREATE-CONTINUATION-HANDLER-CALL-IN-PARENS %s
+func testCreateContinuationWithCompletionHandlerCallInParens(completionHandler: (Int) -> Void) {
+  withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName {
+    (completionHandler($0))
+  }
+}
+// CREATE-CONTINUATION-HANDLER-CALL-IN-PARENS:      func testCreateContinuationWithCompletionHandlerCallInParens() async -> Int {
+// CREATE-CONTINUATION-HANDLER-CALL-IN-PARENS-NEXT:   return await withCheckedContinuation { continuation in 
+// CREATE-CONTINUATION-HANDLER-CALL-IN-PARENS-NEXT:     withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName {
+// CREATE-CONTINUATION-HANDLER-CALL-IN-PARENS-NEXT:       continuation.resume(returning: $0)
+// CREATE-CONTINUATION-HANDLER-CALL-IN-PARENS-NEXT:     }
+// CREATE-CONTINUATION-HANDLER-CALL-IN-PARENS-NEXT:   }
+// CREATE-CONTINUATION-HANDLER-CALL-IN-PARENS-NEXT: }
+
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=CREATE-CONTINUATION-BECAUSE-RETURN-VALUE %s
 func testCreateContinuationBecauseOfReturnValue(completionHandler: (Int) -> Void) {
   _ = withoutAsyncAlternativeBecauseOfReturnValue {


### PR DESCRIPTION
* **Explanation**: Use `getSemanticsProvidingExpr` to decide whether an expression is a call to a completion handler. This resolves an issue where a completion handler would not be converted if it was wrapped in parenthesis
* **Scope**: Async refactoring of calls that are wrapped in an identity expression like parentheses or a trailing `.self`
* **Risk**: Low
* **Testing**: Added regression test
* **Issue**: rdar://78011350
* **Reviewer**: @hamishknight (Hamish Knight) on original PR #38261 

## Example
### Orignal code
```swift
func test(_ completion: (String?, Error?) -> Void) {
  return (completion("", nil))
}
```
### Old Refactoring Result
```swift
func test() async throws -> String {
  return (<#completion#>("", nil))
}
```
### New Refactoring Result
```swift
func test() async throws -> String {
  return ""
}
```