### PR TITLE
DefiniteInitialization: correctly handle implicit closures in initializers of derived classes.

### DIFF
--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -1065,7 +1065,11 @@ void ElementUseCollector::collectClassSelfUses(SILValue ClassPointer) {
 
   // If we are looking at the init method for a root class, just walk the
   // MUI use-def chain directly to find our uses.
-  if (TheMemory.isRootSelf()) {
+  if (TheMemory.isRootSelf() ||
+  
+      // Also, just visit all users if ClassPointer is a closure argument,
+      // i.e. collectClassSelfUses is called from addClosureElementUses.
+      isa<SILFunctionArgument>(ClassPointer)) {
     collectClassSelfUses(ClassPointer, TheMemory.getType(), EltNumbering);
     return;
   }

--- a/test/SILOptimizer/definite_init_closures.swift
+++ b/test/SILOptimizer/definite_init_closures.swift
@@ -69,4 +69,15 @@ struct Generic<T : P> {
   }
 }
 
+class Base { }
+
+class Derived : Base {
+  var x: Bool
+  var y: Bool
+
+  init(_: Int) {
+    x = false
+    y = true || x
+  }
+}
 


### PR DESCRIPTION
Support for implicit closures was already added in https://github.com/apple/swift/pull/35276:
```
    init() {
      bool_member1 = false
      bool_member2 = false || bool_member1 // implicit closure
    }
```
But this didn't work for initializers of derived classes.

rdar://66420045
