### PR TITLE
We don't need the default implementation of RNG.next() to be ABI

### DIFF
--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -71,6 +71,7 @@ extension RandomNumberGenerator {
   // unsigned integer will be used, recursing infinitely and probably blowing
   // the stack.
   @available(*, unavailable)
+  @_alwaysEmitIntoClient
   public mutating func next() -> UInt64 { fatalError() }
   
   /// Returns a value from a uniform, independent distribution of binary data.


### PR DESCRIPTION
Make it @_aEIC so that we're not stuck with it forever if we get a better solution someday.