### PR TITLE
[5.5] We don't need the unavailable default implementation of RNG.next() to…

### DIFF
--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -71,6 +71,7 @@ extension RandomNumberGenerator {
   // unsigned integer will be used, recursing infinitely and probably blowing
   // the stack.
   @available(*, unavailable)
+  @_alwaysEmitIntoClient
   public mutating func next() -> UInt64 { fatalError() }
   
   /// Returns a value from a uniform, independent distribution of binary data.


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/38272 for 5.5. Note that if we do not take this for some reason, we also will need to back that change out from main.