### PR TITLE
StringOptimization: optimize interpolated C strings.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -347,6 +347,12 @@ void addFunctionPasses(SILPassPipelinePlan &P,
     P.addCOWArrayOpts();
     P.addDCE();
     P.addSwiftArrayPropertyOpt();
+    
+    // This string optimization can catch additional opportunities, which are
+    // exposed once optimized String interpolations (from the high-level string
+    // optimization) are cleaned up. But before the mid-level inliner inlines
+    // semantic calls.
+    P.addStringOptimization();
   }
 
   // Run the devirtualizer, specializer, and inliner. If any of these

--- a/test/SILOptimizer/c_string_optimization.swift
+++ b/test/SILOptimizer/c_string_optimization.swift
@@ -32,5 +32,25 @@ public func testStringConstantForCFunction() {
   puts("Hello " + "world!")
 }
 
+// CHECK-LABEL: sil [noinline] @$s4test0A17TypeInterpolationyyF
+// CHECK-NOT: apply
+// CHECK:    [[L:%[0-9]+]] = string_literal utf8 "String"
+// CHECK-NOT: apply
+// CHECK:    [[P:%[0-9]+]] = struct $UnsafePointer<Int8> ([[L]] : $Builtin.RawPointer)
+// CHECK-NOT: apply
+// CHECK:    [[O:%[0-9]+]] = enum $Optional<UnsafePointer<Int8>>, #Optional.some!enumelt, [[P]]
+// CHECK-NOT: apply
+// CHECK:    [[F:%[0-9]+]] = function_ref @puts
+// CHECK:    apply [[F]]([[O]])
+// CHECK: } // end sil function '$s4test0A17TypeInterpolationyyF'
+@inline(never)
+public func testTypeInterpolation() {
+  puts("\(String.self)")
+}
+
 // CHECK-OUTPUT: Hello world!
 testStringConstantForCFunction()
+
+// CHECK-OUTPUT: String
+testTypeInterpolation()
+

--- a/test/SILOptimizer/string_optimization.sil
+++ b/test/SILOptimizer/string_optimization.sil
@@ -245,12 +245,45 @@ bb0:
   %6 = metatype $@thin String.Type
   %7 = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
   %8 = apply %7(%3, %4, %5, %6) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %d = struct $DefaultStringInterpolation (%8 : $String)
+  %e = struct_extract %d : $DefaultStringInterpolation, #DefaultStringInterpolation._storage
   %9 = function_ref @string_getUTF8CString : $@convention(method) (@guaranteed String) -> @owned ContiguousArray<Int8>
-  %10 = apply %9(%8) : $@convention(method) (@guaranteed String) -> @owned ContiguousArray<Int8>
+  %10 = apply %9(%e) : $@convention(method) (@guaranteed String) -> @owned ContiguousArray<Int8>
   %11 = struct_extract %10 : $ContiguousArray<Int8>, #ContiguousArray._buffer
   %12 = struct_extract %11 : $_ContiguousArrayBuffer<Int8>, #_ContiguousArrayBuffer._storage
   %13 = ref_tail_addr %12 : $__ContiguousArrayStorageBase, $Int8
   %14 = address_to_pointer %13 : $*Int8 to $Builtin.RawPointer
   return %14 : $Builtin.RawPointer
+}
+
+// CHECK-LABEL: sil @test_interpolated_cstring
+// CHECK:       apply
+// CHECK:       [[S:%[0-9]+]] = string_literal utf8 "a"
+// CHECK:       return [[S]]
+// CHECK:     } // end sil function 'test_interpolated_cstring'
+sil @test_interpolated_cstring : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %3 = string_literal utf8 "a"
+  %4 = integer_literal $Builtin.Word, 1
+  %5 = integer_literal $Builtin.Int1, -1
+  %6 = metatype $@thin String.Type
+  %7 = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %8 = apply %7(%3, %4, %5, %6) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %d = struct $DefaultStringInterpolation (%8 : $String)
+  %f = function_ref @$sSS19stringInterpolationSSs013DefaultStringB0V_tcfC : $@convention(method) (@owned DefaultStringInterpolation, @thin String.Type) -> @owned String
+  %a = apply %f(%d, %6) : $@convention(method) (@owned DefaultStringInterpolation, @thin String.Type) -> @owned String
+  %9 = function_ref @string_getUTF8CString : $@convention(method) (@guaranteed String) -> @owned ContiguousArray<Int8>
+  %10 = apply %9(%a) : $@convention(method) (@guaranteed String) -> @owned ContiguousArray<Int8>
+  %11 = struct_extract %10 : $ContiguousArray<Int8>, #ContiguousArray._buffer
+  %12 = struct_extract %11 : $_ContiguousArrayBuffer<Int8>, #_ContiguousArrayBuffer._storage
+  %13 = ref_tail_addr %12 : $__ContiguousArrayStorageBase, $Int8
+  %14 = address_to_pointer %13 : $*Int8 to $Builtin.RawPointer
+  return %14 : $Builtin.RawPointer
+}
+
+sil public_external [readonly] @$sSS19stringInterpolationSSs013DefaultStringB0V_tcfC : $@convention(method) (@owned DefaultStringInterpolation, @thin String.Type) -> @owned String {
+bb0(%0 : $DefaultStringInterpolation, %1 : $@thin String.Type):
+  %2 = struct_extract %0 : $DefaultStringInterpolation, #DefaultStringInterpolation._storage
+  return %2 : $String
 }
 


### PR DESCRIPTION
Optimize code like:
```
   puts("\(String.self)")
```
Optimizing string interpolation and optimizing C-strings are both done in StringOptimization.
A second run of the StringOptimization is needed in the pipeline to optimize such code, because the result of the interpolation-optimization must be cleaned up so that the C-String optimization can kick in.

Also, StringOptimization must handle `struct_extract(struct(literal))`, where the struct_extract may be in a called function.
To solve a phase ordering problem with inlining String semantics and inlining the `String(stringInterpolation: DefaultStringInterpolation)` constructor, we do a simple analysis of the callee. Doing this simple "interprocedural" analysis avoids relying on inlining that String constructor.

rdar://79723829
