### PR TITLE
Implement differently logic to strip and copy the tvos libraries

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1423,6 +1423,25 @@ function cmake_config_opt() {
     fi
 }
 
+function copy_lib_stripping_architecture() {
+    local source="$1"
+    local dest="$2"
+    local arch="$3"
+
+    # An alternative approach would be to use || to first
+    # attempt the removal of the slice and fall back to the
+    # copy when failing.
+    # However, this would leave unneeded error messages in the logs
+    # that may hinder investigation; in addition, in this scenario
+    # the `call` function seems to not propagate correctly failure
+    # exit codes.
+    if lipo -archs "${source}" | grep -q "${arch}"; then
+        call lipo -remove "${arch}" "${source}" -output "${dest}"
+    else
+        call cp "${source}" "${dest}"
+    fi
+}
+
 function copy_embedded_compiler_rt_builtins_from_darwin_host_toolchain() {
     local clang_dest_dir="$1"
 
@@ -1448,7 +1467,8 @@ function copy_embedded_compiler_rt_builtins_from_darwin_host_toolchain() {
                 if [[ ! -f "${DEST_LIB_PATH}" ]]; then
                     if [[ -f "${HOST_LIB_PATH}" ]]; then
                         if [[ "$OS" == "tvos" ]]; then
-                            call lipo -remove i386 "${HOST_LIB_PATH}" -output "${DEST_LIB_PATH}" || call cp "${HOST_LIB_PATH}" "${DEST_LIB_PATH}"
+                            # This is to avoid strip failures when generating a toolchain
+                            copy_lib_stripping_architecture "${HOST_LIB_PATH}" "${DEST_LIB_PATH}" i386
                         else
                            call cp "${HOST_LIB_PATH}" "${DEST_LIB_PATH}"
                         fi
@@ -1464,7 +1484,8 @@ function copy_embedded_compiler_rt_builtins_from_darwin_host_toolchain() {
                 if [[ ! -f "${DEST_SIM_LIB_PATH}" ]]; then
                     if [[ -f "${HOST_SIM_LIB_PATH}" ]]; then
                         if [[ "$OS" == "tvos" ]]; then
-                            call lipo -remove i386 "${HOST_SIM_LIB_PATH}" -output "${DEST_SIM_LIB_PATH}" || call cp "${HOST_SIM_LIB_PATH}" "${DEST_SIM_LIB_PATH}"
+                            # This is to avoid strip failures when generating a toolchain
+                            copy_lib_stripping_architecture "${HOST_SIM_LIB_PATH}" "${DEST_SIM_LIB_PATH}" i386
                         else
                             call cp "${HOST_SIM_LIB_PATH}" "${DEST_SIM_LIB_PATH}"
                         fi


### PR DESCRIPTION
The previous logic could fail silently to copy the library if the i386
slice is not present in the first place (like it is the case for
`libclang_rt.tvos.a` in Xcode 13.0 beta 1) -- this will avoid errors
like

```
Undefined symbols for architecture arm64:
  "___isPlatformVersionAtLeast", referenced from:
    swift::initializeProtocolLookup() in ImageInspectionMachO.cpp.o
    swift::initializeProtocolConformanceLookup() in
ImageInspectionMachO.cpp.o
    swift::initializeTypeMetadataRecordLookup() in
ImageInspectionMachO.cpp.o
    swift::initializeDynamicReplacementLookup() in
ImageInspectionMachO.cpp.o
```

This is a backport of #38262

Addresses rdar://80209915