### PR TITLE
[rebranch] Add missing ArrayRef.h include

### DIFF
--- a/include/swift/Basic/MultiMapCache.h
+++ b/include/swift/Basic/MultiMapCache.h
@@ -14,6 +14,7 @@
 #define SWIFT_BASIC_MULTIMAPCACHE_H
 
 #include "swift/Basic/LLVM.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 
 namespace swift {


### PR DESCRIPTION
makeArrayRef was being included through an import an DenseMap.h ->
DenseMapInfo.h -> ArrayRef.h. That was broken fairly recently.

(cherry picked from commit fe2b3c6021583f34b7c5833cebc2f439e10e6f35)