### PR TITLE
[5.5][Diagnostics] Ignore result type failures if one side is a hole

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4277,8 +4277,7 @@ bool ConstraintSystem::repairFailures(
     // it's going to be diagnosed by specialized fix which deals
     // with generic argument mismatches.
     if (matchKind == ConstraintKind::BindToPointerType) {
-      auto *member = rhs->getAs<DependentMemberType>();
-      if (!(member && member->getBase()->hasPlaceholder()))
+      if (!rhs->isPlaceholder())
         break;
     }
 
@@ -4619,6 +4618,12 @@ bool ConstraintSystem::repairFailures(
   }
 
   case ConstraintLocator::FunctionResult: {
+    if (lhs->isPlaceholder() || rhs->isPlaceholder()) {
+      markAnyTypeVarsAsPotentialHoles(lhs);
+      markAnyTypeVarsAsPotentialHoles(rhs);
+      return true;
+    }
+
     auto *loc = getConstraintLocator(anchor, {path.begin(), path.end() - 1});
     // If this is a mismatch between contextual type and (trailing)
     // closure with explicitly specified result type let's record it
@@ -4639,6 +4644,7 @@ bool ConstraintSystem::repairFailures(
         break;
       }
     }
+
     // Handle function result coerce expression wrong type conversion.
     if (isExpr<CoerceExpr>(anchor)) {
       auto *fix =

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2967,6 +2967,10 @@ Type ConstraintSystem::simplifyTypeImpl(Type type,
       // Simplify the base.
       Type newBase = simplifyTypeImpl(depMemTy->getBase(), getFixedTypeFn);
 
+      if (newBase->isPlaceholder()) {
+        return PlaceholderType::get(getASTContext(), depMemTy);
+      }
+
       // If nothing changed, we're done.
       if (newBase.getPointer() == depMemTy->getBase().getPointer())
         return type;

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -893,3 +893,28 @@ func rdar78781552() {
     // expected-error@-4 {{missing argument for parameter 'filter' in call}}
   }
 }
+
+// rdar://79757320 - failured to produce a diagnostic when unresolved dependent member is used in function result position
+
+protocol R_79757320 {
+  associatedtype In
+  associatedtype Out
+}
+
+func rdar79757320() {
+  struct Value<W> {
+    init(_: W) {}
+
+    func formatted() -> String { "" }
+    func formatted<T : R_79757320>(_: T) -> T.Out where T.In == Value<W> { fatalError() }
+  }
+
+  struct Container {
+    var value: String
+  }
+
+  // FIXME: There has to be a way to propagate holes that makes it easy to suppress failures caused by missing members.
+  _ = Container(value: Value(42).formatted(.S(a: .a, b: .b(0)))) // expected-error {{type 'R_79757320' has no member 'S'}}
+  // expected-error@-1 {{cannot infer contextual base in reference to member 'a'}}
+  // expected-error@-2 {{cannot infer contextual base in reference to member 'b'}}
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/38235

---

- Explanation:

Fixes a situation where the type-checker failed to produce a diagnostic.

If one of the sides in a application result conversion is a hole
it could only mean that the fix has been recorded earlier (at the
point where hole was introduced) and failure at function result
position could be safely ignored.

- Scope: Incorrect calls where result cannot be inferred and contextual type is represented by a dependent member type.

- Main Branch PR: https://github.com/apple/swift/pull/38235

- Resolves: rdar://79757320

- Risk: Low

- Reviewed By: @hborla  

- Testing: Regression tests added to the suite

Resolves: rdar://79757320

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
