### PR TITLE
test: enable some Concurrency tests on Windows

### DIFF
--- a/test/Concurrency/Runtime/async_task_handle_cancellation.swift
+++ b/test/Concurrency/Runtime/async_task_handle_cancellation.swift
@@ -7,13 +7,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// This test is flaky on VS2017 (unknown reasons)
-// UNSUPPORTED: MSVC_VER=15.0
-
-// This test is failing on windows. SR-14447.
-//
-// UNSUPPORTED: OS=windows-msvc
-
 @available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {

--- a/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
@@ -7,8 +7,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// UNSUPPORTED: OS=windows-msvc
-
 struct Boom: Error {}
 struct IgnoredBoom: Error {}
 

--- a/test/Concurrency/Runtime/cancellation_handler.swift
+++ b/test/Concurrency/Runtime/cancellation_handler.swift
@@ -5,13 +5,14 @@
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
-// UNSUPPORTED: OS=windows-msvc
 
 // for sleep
 #if canImport(Darwin)
     import Darwin
 #elseif canImport(Glibc)
     import Glibc
+#elseif os(Windows)
+    import WinSDK
 #endif
 
 class Canary {
@@ -30,7 +31,11 @@ if #available(SwiftStdlib 5.5, *) {
     }
   }
   task.cancel()
+#if os(Windows)
+  Sleep(1 * 1000)
+#else
   sleep(1)
+#endif
   detach {
     await Task.withCancellationHandler {
         print("Task was cancelled!")
@@ -39,7 +44,11 @@ if #available(SwiftStdlib 5.5, *) {
         print("Running the operation...")
     }
   }
+#if os(Windows)
+  Sleep(10 * 1000)
+#else
   sleep(10)
+#endif
 } else {
   // Fake prints to satisfy FileCheck.
   print("Canary")

--- a/test/Concurrency/Runtime/checked_continuation.swift
+++ b/test/Concurrency/Runtime/checked_continuation.swift
@@ -5,8 +5,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// UNSUPPORTED: OS=windows-msvc
-
 import _Concurrency
 import StdlibUnittest
 

--- a/test/Concurrency/Runtime/custom_executors.swift
+++ b/test/Concurrency/Runtime/custom_executors.swift
@@ -3,7 +3,6 @@
 // REQUIRES: concurrency
 // REQUIRES: executable_test
 
-// UNSUPPORTED: OS=windows-msvc
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: use_os_stdlib
 


### PR DESCRIPTION
This enables a few Concurrency tests that should be passing on Windows
(at least do so locally).

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
