### PR TITLE
[Sema][NFC] Add regression test for SR-14533

### DIFF
--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -735,3 +735,14 @@ func rdar55369704() {
     _ = x - Int(s.value) // expected-error {{value of type 'S' has no member 'value'}}
   }
 }
+
+// SR-14533
+struct SR14533 {
+  var xs: [Int] 
+}
+
+func fSR14533(_ s: SR14533) {
+  for (x1, x2) in zip(s.xs, s.ys) {
+    // expected-error@-1{{value of type 'SR14533' has no member 'ys'}}
+  }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
This just add a regression test for SR-14533, was about to start looking at it, but I believe #38235 fixed it :)
Or maybe #38199?

So just adding the test regression test @xedin 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
