### PR TITLE
[DNM] Add value property to Result

### DIFF
--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -170,6 +170,19 @@ public enum Result<Success, Failure: Error> {
       throw failure
     }
   }
+
+  @inlinable
+  @_alwaysEmitIntoClient
+  public var value: Success {
+    get throws {
+      switch self {
+      case let .success(success):
+        return success
+      case let .failure(failure):
+        throw failure
+      }
+    }
+  }
 }
 
 extension Result where Failure == Swift.Error {

--- a/test/stdlib/Result.swift
+++ b/test/stdlib/Result.swift
@@ -81,20 +81,36 @@ ResultTests.test("Throwing Initialization and Unwrapping") {
   } catch {
     expectUnreachable()
   }
-    
+
   do {
     let unwrapped = try result2.get()
     expectEqual(unwrapped, string)
   } catch {
     expectUnreachable()
   }
-    
+
   // Test unwrapping strongly typed error.
   let result3 = Result<String, Err>.failure(Err.err)
   do {
     _ = try result3.get()
   } catch let error as Err {
     expectEqual(error, Err.err)
+  } catch {
+    expectUnreachable()
+  }
+
+  // Test throwing value property
+  do {
+    _ = try result1.value
+  } catch let error as Err {
+    expectEqual(error, Err.err)
+  } catch {
+    expectUnreachable()
+  }
+
+  do {
+    let unwrapped = try result2.value
+    expectEqual(unwrapped, string)
   } catch {
     expectUnreachable()
   }


### PR DESCRIPTION
[SE-0310](0310-effectful-readonly-properties.md) added throwing properties, and so [SE-0304](https://github.com/apple/swift-evolution/blob/main/proposals/0304-structured-concurrency.md) has a throwing `value` instead of `get()`. This adds a matching equivalent to `Result`.