### PR TITLE
RequirementMachine: Implement GenericSignature::getCanonicalTypeInContext()

### DIFF
--- a/include/swift/AST/RequirementMachine.h
+++ b/include/swift/AST/RequirementMachine.h
@@ -24,6 +24,7 @@ namespace swift {
 class ASTContext;
 class AssociatedTypeDecl;
 class CanType;
+class GenericTypeParamType;
 class LayoutConstraint;
 class ProtocolDecl;
 class Requirement;
@@ -61,6 +62,8 @@ public:
   GenericSignature::RequiredProtocols getRequiredProtocols(Type depType) const;
   bool isConcreteType(Type depType) const;
   bool areSameTypeParameterInContext(Type depType1, Type depType2) const;
+  Type getCanonicalTypeInContext(Type type,
+                      TypeArrayView<GenericTypeParamType> genericParams) const;
 
   void dump(llvm::raw_ostream &out) const;
 };

--- a/include/swift/AST/RequirementMachine.h
+++ b/include/swift/AST/RequirementMachine.h
@@ -49,7 +49,7 @@ class RequirementMachine final {
   void addGenericSignature(CanGenericSignature sig);
 
   bool isComplete() const;
-  void computeCompletion(CanGenericSignature sig);
+  void computeCompletion();
 
 public:
   ~RequirementMachine();

--- a/lib/AST/RequirementMachine/EquivalenceClassMap.cpp
+++ b/lib/AST/RequirementMachine/EquivalenceClassMap.cpp
@@ -50,6 +50,8 @@
 
 #include "swift/AST/Decl.h"
 #include "swift/AST/LayoutConstraint.h"
+#include "swift/AST/Module.h"
+#include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/TypeMatcher.h"
 #include "swift/AST/Types.h"
 #include "llvm/Support/raw_ostream.h"
@@ -511,6 +513,157 @@ void EquivalenceClassMap::addProperty(
                           inducedRules, DebugConcreteUnification);
 }
 
+void EquivalenceClassMap::concretizeNestedTypesFromConcreteParents(
+    SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules) const {
+  for (const auto &equivClass : Map) {
+    if (equivClass->isConcreteType() &&
+        !equivClass->getConformsTo().empty()) {
+      if (DebugConcretizeNestedTypes) {
+        llvm::dbgs() << "^ Concretizing nested types of ";
+        equivClass->dump(llvm::dbgs());
+        llvm::dbgs() << "\n";
+      }
+
+      concretizeNestedTypesFromConcreteParent(
+          equivClass->getKey(),
+          equivClass->ConcreteType->getConcreteType(),
+          equivClass->ConcreteType->getSubstitutions(),
+          equivClass->getConformsTo(),
+          inducedRules);
+    }
+  }
+}
+
+/// If we have an equivalence class T => { conforms_to: [ P ], concrete: Foo },
+/// then for each associated type A of P, we generate a new rule:
+///
+///   T.[P:A].[concrete: Foo.A] => T.[P:A]  (if Foo.A is concrete)
+///   T.[P:A] => T.(Foo.A)                  (if Foo.A is abstract)
+///
+void EquivalenceClassMap::concretizeNestedTypesFromConcreteParent(
+    const MutableTerm &key,
+    CanType concreteType, ArrayRef<Term> substitutions,
+    ArrayRef<const ProtocolDecl *> conformsTo,
+    SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules) const {
+  for (auto *proto : conformsTo) {
+    // FIXME: Either remove the ModuleDecl entirely from conformance lookup,
+    // or pass the correct one down in here.
+    auto *module = proto->getParentModule();
+
+    auto conformance = module->lookupConformance(concreteType,
+                                                 const_cast<ProtocolDecl *>(proto));
+    if (conformance.isInvalid()) {
+      // FIXME: Diagnose conflict
+      if (DebugConcretizeNestedTypes) {
+        llvm::dbgs() << "^^ " << concreteType << " does not conform to "
+                     << proto->getName() << "\n";
+      }
+
+      continue;
+    }
+
+    // FIXME: Maybe this can happen if the concrete type is an
+    // opaque result type?
+    assert(!conformance.isAbstract());
+
+    auto assocTypes = Protos.getProtocolInfo(proto).AssociatedTypes;
+    if (assocTypes.empty())
+      continue;
+
+    auto *concrete = conformance.getConcrete();
+
+    // We might have duplicates in the list due to diamond inheritance.
+    // FIXME: Filter those out further upstream?
+    // FIXME: This should actually be outside of the loop over the conforming protos...
+    llvm::SmallDenseSet<AssociatedTypeDecl *, 4> visited;
+    for (auto *assocType : assocTypes) {
+      if (!visited.insert(assocType).second)
+        continue;
+
+      // Get the actual protocol in case we inherited this associated type.
+      auto *actualProto = assocType->getProtocol();
+      if (actualProto != proto)
+        continue;
+
+      if (DebugConcretizeNestedTypes) {
+        llvm::dbgs() << "^^ " << "Looking up type witness for "
+                     << proto->getName() << ":" << assocType->getName()
+                     << " on " << concreteType << "\n";
+      }
+
+      auto typeWitness = concrete->getTypeWitness(assocType)
+                                 ->getCanonicalType();
+
+      if (DebugConcretizeNestedTypes) {
+        llvm::dbgs() << "^^ " << "Type witness for " << assocType->getName()
+                     << " of " << concreteType << " is " << typeWitness << "\n";
+      }
+
+      auto nestedType = Atom::forAssociatedType(proto, assocType->getName(),
+                                                Context);
+
+      MutableTerm subjectType = key;
+      subjectType.add(nestedType);
+
+      MutableTerm constraintType;
+
+      if (concreteType == typeWitness) {
+        if (DebugConcretizeNestedTypes) {
+          llvm::dbgs() << "^^ Type witness is the same as the concrete type\n";
+        }
+
+        // Add a rule T.[P:A] => T.
+        constraintType = key;
+
+      } else if (typeWitness->isTypeParameter()) {
+        // The type witness is a type parameter of the form τ_0_n.X.Y...Z,
+        // where 'n' is an index into the substitution array.
+        //
+        // Collect zero or more member type names in reverse order.
+        SmallVector<Atom, 3> atoms;
+        while (auto memberType = dyn_cast<DependentMemberType>(typeWitness)) {
+          atoms.push_back(Atom::forName(memberType->getName(), Context));
+          typeWitness = memberType.getBase();
+        }
+
+        // Get the substitution S corresponding to τ_0_n.
+        unsigned index = getGenericParamIndex(typeWitness);
+        constraintType = MutableTerm(substitutions[index]);
+
+        // Add the member type names.
+        std::reverse(atoms.begin(), atoms.end());
+        for (auto atom : atoms)
+          constraintType.add(atom);
+
+        // Add a rule T => S.X.Y...Z.
+
+      } else {
+        // The type witness is a concrete type.
+        constraintType = subjectType;
+
+        // FIXME: Handle dependent member types here
+        SmallVector<Term, 3> result;
+        auto typeWitnessSchema =
+            remapConcreteSubstitutionSchema(typeWitness, substitutions,
+                                            Context.getASTContext(),
+                                            result);
+        constraintType.add(
+            Atom::forConcreteType(
+                typeWitnessSchema, result, Context));
+
+        // Add a rule T.[P:A].[concrete: Foo.A] => T.[P:A].
+
+      }
+
+      inducedRules.emplace_back(subjectType, constraintType);
+      if (DebugConcretizeNestedTypes) {
+        llvm::dbgs() << "^^ Induced rule " << constraintType
+                     << " => " << subjectType << "\n";
+      }
+    }
+  }
+}
+
 void EquivalenceClassMap::dump(llvm::raw_ostream &out) const {
   out << "Equivalence class map: {\n";
   for (const auto &equivClass : Map) {
@@ -580,6 +733,10 @@ RewriteSystem::buildEquivalenceClassMap(EquivalenceClassMap &map,
   for (auto pair : properties) {
     map.addProperty(pair.first, pair.second, inducedRules);
   }
+
+  // We also need to merge concrete type rules with conformance rules, by
+  // concretizing the associated type witnesses of the concrete type.
+  map.concretizeNestedTypesFromConcreteParents(inducedRules);
 
   // Some of the induced rules might be trivial; only count the induced rules
   // where the left hand side is not already equivalent to the right hand side.

--- a/lib/AST/RequirementMachine/EquivalenceClassMap.h
+++ b/lib/AST/RequirementMachine/EquivalenceClassMap.h
@@ -86,6 +86,11 @@ public:
     return ConcreteType.hasValue();
   }
 
+  Type getConcreteType(
+      TypeArrayView<GenericTypeParamType> genericParams,
+      const ProtocolGraph &protos,
+      RewriteContext &ctx) const;
+
   LayoutConstraint getLayoutConstraint() const {
     return Layout;
   }

--- a/lib/AST/RequirementMachine/EquivalenceClassMap.h
+++ b/lib/AST/RequirementMachine/EquivalenceClassMap.h
@@ -108,7 +108,8 @@ class EquivalenceClassMap {
   RewriteContext &Context;
   std::vector<std::unique_ptr<EquivalenceClass>> Map;
   const ProtocolGraph &Protos;
-  bool DebugConcreteUnification = false;
+  unsigned DebugConcreteUnification : 1;
+  unsigned DebugConcretizeNestedTypes : 1;
 
   EquivalenceClass *getEquivalenceClassIfPresent(const MutableTerm &key) const;
   EquivalenceClass *getOrCreateEquivalenceClass(const MutableTerm &key);
@@ -121,14 +122,28 @@ class EquivalenceClassMap {
 public:
   explicit EquivalenceClassMap(RewriteContext &ctx,
                                const ProtocolGraph &protos)
-      : Context(ctx), Protos(protos) {}
+      : Context(ctx), Protos(protos) {
+    DebugConcreteUnification = false;
+    DebugConcretizeNestedTypes = false;
+  }
 
   EquivalenceClass *lookUpEquivalenceClass(const MutableTerm &key) const;
+
+  void dump(llvm::raw_ostream &out) const;
 
   void clear();
   void addProperty(const MutableTerm &key, Atom property,
                    SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules);
-  void dump(llvm::raw_ostream &out) const;
+  void concretizeNestedTypesFromConcreteParents(
+                   SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules) const;
+
+private:
+  void concretizeNestedTypesFromConcreteParent(
+                   const MutableTerm &key,
+                   CanType concreteType,
+                   ArrayRef<Term> substitutions,
+                   ArrayRef<const ProtocolDecl *> conformsTo,
+                   SmallVectorImpl<std::pair<MutableTerm, MutableTerm>> &inducedRules) const;
 };
 
 } // end namespace rewriting

--- a/lib/AST/RequirementMachine/ProtocolGraph.cpp
+++ b/lib/AST/RequirementMachine/ProtocolGraph.cpp
@@ -28,6 +28,11 @@ void ProtocolGraph::visitRequirements(ArrayRef<Requirement> reqs) {
   }
 }
 
+/// Return true if we know about this protocol.
+bool ProtocolGraph::isKnownProtocol(const ProtocolDecl *proto) const {
+  return Info.count(proto) > 0;
+}
+
 /// Look up information about a known protocol.
 const ProtocolInfo &ProtocolGraph::getProtocolInfo(
     const ProtocolDecl *proto) const {

--- a/lib/AST/RequirementMachine/ProtocolGraph.h
+++ b/lib/AST/RequirementMachine/ProtocolGraph.h
@@ -83,6 +83,8 @@ struct ProtocolGraph {
 
   void visitRequirements(ArrayRef<Requirement> reqs);
 
+  bool isKnownProtocol(const ProtocolDecl *proto) const;
+
   const ProtocolInfo &getProtocolInfo(
       const ProtocolDecl *proto) const;
 

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -238,6 +238,8 @@ struct RequirementMachine::Implementation {
         Map(Context, System.getProtocols()) {}
   void verify(const MutableTerm &term);
   void dump(llvm::raw_ostream &out);
+
+  MutableTerm getLongestValidPrefix(const MutableTerm &term);
 };
 
 void RequirementMachine::Implementation::verify(const MutableTerm &term) {
@@ -532,4 +534,181 @@ bool RequirementMachine::areSameTypeParameterInContext(Type depType1,
   Impl->verify(term2);
 
   return (term1 == term2);
+}
+
+MutableTerm
+RequirementMachine::Implementation::getLongestValidPrefix(const MutableTerm &term) {
+  MutableTerm prefix;
+
+  for (auto atom : term) {
+    switch (atom.getKind()) {
+    case Atom::Kind::Name:
+      return prefix;
+
+    case Atom::Kind::Protocol:
+      assert(prefix.empty() &&
+             "Protocol atom can only appear at the start of a type term");
+      if (!System.getProtocols().isKnownProtocol(atom.getProtocol()))
+        return prefix;
+
+      break;
+
+    case Atom::Kind::GenericParam:
+      assert(prefix.empty() &&
+             "Generic parameter atom can only appear at the start of a type term");
+      break;
+
+    case Atom::Kind::AssociatedType: {
+      const auto *equivClass = Map.lookUpEquivalenceClass(prefix);
+      if (!equivClass)
+        return prefix;
+
+      auto conformsTo = equivClass->getConformsTo();
+
+      for (const auto *proto : atom.getProtocols()) {
+        if (!System.getProtocols().isKnownProtocol(proto))
+          return prefix;
+
+        // T.[P:A] is valid iff T conforms to P.
+        if (std::find(conformsTo.begin(), conformsTo.end(), proto)
+              == conformsTo.end())
+          return prefix;
+      }
+
+      break;
+    }
+
+    case Atom::Kind::Layout:
+    case Atom::Kind::Superclass:
+    case Atom::Kind::ConcreteType:
+      llvm_unreachable("Property atom cannot appear in a type term");
+    }
+
+    // This atom is valid, add it to the longest prefix.
+    prefix.add(atom);
+  }
+
+  return prefix;
+}
+
+/// Unlike the other queries, the input type can be any type, not just a
+/// type parameter.
+///
+/// Replaces all structural components that are type parameters with their
+/// most canonical form, which is either a (possibly different)
+/// type parameter, or a concrete type, in which case we recursively
+/// simplify any type parameters appearing in structural positions of
+/// that concrete type as well, and so on.
+Type RequirementMachine::getCanonicalTypeInContext(
+    Type type,
+    TypeArrayView<GenericTypeParamType> genericParams) const {
+  const auto &protos = Impl->System.getProtocols();
+
+  return type.transformRec([&](Type t) -> Optional<Type> {
+    if (!t->isTypeParameter())
+      return None;
+
+    // Get a simplified term T.
+    auto term = Impl->Context.getMutableTermForType(t->getCanonicalType(),
+                                                    /*proto=*/nullptr);
+    Impl->System.simplify(term);
+
+    // We need to handle "purely concrete" member types, eg if I have a
+    // signature <T where T == Foo>, and we're asked to canonicalize the
+    // type T.[P:A] where Foo : A.
+    //
+    // This comes up because we can derive the signature <T where T == Foo>
+    // from a generic signature like <T where T : P>; adding the
+    // concrete requirement 'T == Foo' renders 'T : P' redundant. We then
+    // want to take interface types written against the original signature
+    // and canonicalize them with respect to the derived signature.
+    //
+    // The problem is that T.[P:A] is not a valid term in the rewrite system
+    // for <T where T == Foo>, since we do not have the requirement T : P.
+    //
+    // A more principled solution would build a substitution map when
+    // building a derived generic signature that adds new requirements;
+    // interface types would first be substituted before being canonicalized
+    // in the new signature.
+    //
+    // For now, we handle this with a two-step process; we split a term up
+    // into a longest valid prefix, which must resolve to a concrete type,
+    // and the remaining suffix, which we use to perform a concrete
+    // substitution using subst().
+
+    // In the below, let T be a type term, with T == UV, where U is the
+    // longest valid prefix.
+    //
+    // Note that V can be empty if T is fully valid; we expect this to be
+    // true most of the time.
+    auto prefix = Impl->getLongestValidPrefix(term);
+
+    // Get a type (concrete or dependent) for U.
+    auto prefixType = [&]() -> Type {
+      Impl->verify(prefix);
+
+      auto *equivClass = Impl->Map.lookUpEquivalenceClass(prefix);
+      if (equivClass && equivClass->isConcreteType()) {
+        auto concreteType = equivClass->getConcreteType(genericParams,
+                                                        protos, Impl->Context);
+        if (!concreteType->hasTypeParameter())
+          return concreteType;
+
+        // FIXME: Recursion guard is needed here
+        return getCanonicalTypeInContext(concreteType, genericParams);
+      }
+
+      return Impl->Context.getTypeForTerm(prefix, genericParams, protos);
+    }();
+
+    // If T is already valid, the longest valid prefix U of T is T itself, and
+    // V is empty. Just return the type we computed above.
+    //
+    // This is the only case where U is allowed to be dependent.
+    if (prefix.size() == term.size())
+      return prefixType;
+
+    // If U is not concrete, we have an invalid member type of a dependent
+    // type, which is not valid in this generic signature. Give up.
+    if (prefixType->isTypeParameter()) {
+      llvm::errs() << "Invalid type parameter in getCanonicalTypeInContext()\n";
+      llvm::errs() << "Original type: " << type << "\n";
+      llvm::errs() << "Simplified term: " << term << "\n";
+      llvm::errs() << "Longest valid prefix: " << prefix << "\n";
+      llvm::errs() << "Prefix type: " << prefixType << "\n";
+      llvm::errs() << "\n";
+      dump(llvm::errs());
+      abort();
+    }
+
+    // Compute the type of the unresolved suffix term V, rooted in the
+    // generic parameter τ_0_0.
+    auto origType = Impl->Context.getRelativeTypeForTerm(
+        term, prefix, Impl->System.getProtocols());
+
+    // Substitute τ_0_0 in the above relative type with the concrete type
+    // for U.
+    //
+    // Example: if T == A.B.C and the longest valid prefix is A.B which
+    // maps to a concrete type Foo<Int>, then we have:
+    //
+    // U == A.B
+    // V == C
+    //
+    // prefixType == Foo<Int>
+    // origType   == τ_0_0.C
+    // substType  == Foo<Int>.C
+    //
+    auto substType = origType.subst(
+      [&](SubstitutableType *type) -> Type {
+        assert(cast<GenericTypeParamType>(type)->getDepth() == 0);
+        assert(cast<GenericTypeParamType>(type)->getIndex() == 0);
+
+        return prefixType;
+      },
+      LookUpConformanceInSignature(Impl->Sig.getPointer()));
+
+    // FIXME: Recursion guard is needed here
+    return getCanonicalTypeInContext(substType, genericParams);
+  });
 }

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -133,7 +133,7 @@ Identifier Atom::getName() const {
   return Ptr->Name;
 }
 
-/// Get the single protocol declaration associate with a protocol atom.
+/// Get the single protocol declaration associated with a protocol atom.
 const ProtocolDecl *Atom::getProtocol() const {
   assert(getKind() == Kind::Protocol);
   return Ptr->Proto;

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -580,11 +580,15 @@ public:
   };
 
   std::pair<CompletionResult, unsigned>
-  computeConfluentCompletion(unsigned maxIterations, unsigned maxDepth);
+  computeConfluentCompletion(unsigned maxIterations,
+                             unsigned maxDepth);
 
   void simplifyRightHandSides();
 
-  bool buildEquivalenceClassMap(EquivalenceClassMap &map);
+  std::pair<CompletionResult, unsigned>
+  buildEquivalenceClassMap(EquivalenceClassMap &map,
+                           unsigned maxIterations,
+                           unsigned maxDepth);
 
   void dump(llvm::raw_ostream &out) const;
 

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -434,6 +434,18 @@ public:
                                     const ProtocolDecl *proto);
 
   ASTContext &getASTContext() { return Context; }
+
+  Type getTypeForTerm(Term term,
+                      TypeArrayView<GenericTypeParamType> genericParams,
+                      const ProtocolGraph &protos) const;
+
+  Type getTypeForTerm(const MutableTerm &term,
+                      TypeArrayView<GenericTypeParamType> genericParams,
+                      const ProtocolGraph &protos) const;
+
+  Type getRelativeTypeForTerm(
+                      const MutableTerm &term, const MutableTerm &prefix,
+                      const ProtocolGraph &protos) const;
 };
 
 /// A rewrite rule that replaces occurrences of LHS with RHS.

--- a/lib/AST/RequirementMachine/RewriteSystemCompletion.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystemCompletion.cpp
@@ -446,7 +446,7 @@ RewriteSystem::computeConfluentCompletion(unsigned maxIterations,
   // moving on to overlaps between rules introduced by completion.
   while (!Worklist.empty()) {
     // Check if we've already done too much work.
-    if (steps >= maxIterations)
+    if (Rules.size() > maxIterations)
       return std::make_pair(CompletionResult::MaxIterations, steps);
 
     auto next = Worklist.front();

--- a/lib/AST/RequirementMachine/RewriteSystemCompletion.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystemCompletion.cpp
@@ -202,9 +202,9 @@ Atom RewriteSystem::mergeAssociatedTypes(Atom lhs, Atom rhs) const {
   }
 
   // The two input sets are minimal already, so the merged set
-  // should have at least as many elements as each input set.
-  assert(minimalProtos.size() >= protos.size());
-  assert(minimalProtos.size() >= otherProtos.size());
+  // should have at least as many elements as the smallest
+  // input set.
+  assert(minimalProtos.size() >= std::min(protos.size(), otherProtos.size()));
 
   // The merged set cannot contain more elements than the union
   // of the two sets.

--- a/lib/AST/RequirementMachine/RewriteSystemCompletion.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystemCompletion.cpp
@@ -334,7 +334,7 @@ void RewriteSystem::processMergedAssociatedTypes() {
           // merged type [P1&P2:T] must conform to Q as well. Add a new rule
           // of the form:
           //
-          //   [P1&P2].[Q] => [P1&P2]
+          //   [P1&P2:T].[Q] => [P1&P2:T]
           //
           MutableTerm newLHS;
           newLHS.add(mergedAtom);

--- a/test/Generics/unify_nested_types_1.swift
+++ b/test/Generics/unify_nested_types_1.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift -enable-requirement-machine -debug-requirement-machine 2>&1 | %FileCheck %s
+
+protocol P1 {
+  associatedtype T : P1
+}
+
+protocol P2 {
+  associatedtype T where T == Int
+}
+
+extension Int : P1 {
+  public typealias T = Int
+}
+
+struct G<T : P1 & P2> {}
+
+// Since G.T.T == G.T.T.T == G.T.T.T.T = ... = Int, we tie off the
+// recursion by introducing a same-type requirement G.T.T => G.T.
+
+// CHECK-LABEL: Adding generic signature <τ_0_0 where τ_0_0 : P1, τ_0_0 : P2> {
+// CHECK-LABEL: Rewrite system: {
+// CHECK: - τ_0_0.[P1&P2:T].[concrete: Int] => τ_0_0.[P1&P2:T]
+// CHECK: - [P1&P2:T].T => [P1&P2:T].[P1:T]
+// CHECK: - τ_0_0.[P1&P2:T].[P1:T] => τ_0_0.[P1&P2:T]
+// CHECK: }
+// CHECK: }

--- a/test/Generics/unify_nested_types_2.swift
+++ b/test/Generics/unify_nested_types_2.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift -enable-requirement-machine -debug-requirement-machine 2>&1 | %FileCheck %s
+
+protocol P1 {
+  associatedtype T : P1
+}
+
+protocol P2 {
+  associatedtype T where T == X<U>
+  associatedtype U
+}
+
+extension Int : P1 {
+  public typealias T = Int
+}
+
+struct X<A> : P1 {
+  typealias T = X<A>
+}
+
+struct G<T : P1 & P2> {}
+
+// Since G.T.T == G.T.T.T == G.T.T.T.T = ... = X<T.U>, we tie off the
+// recursion by introducing a same-type requirement G.T.T => G.T.
+
+// CHECK-LABEL: Adding generic signature <τ_0_0 where τ_0_0 : P1, τ_0_0 : P2> {
+// CHECK-LABEL: Rewrite system: {
+// CHECK: - τ_0_0.[P1&P2:T].[concrete: X<τ_0_0> with <τ_0_0.[P2:U]>] => τ_0_0.[P1&P2:T]
+// CHECK: - [P1&P2:T].T => [P1&P2:T].[P1:T]
+// CHECK: - τ_0_0.[P1&P2:T].[P1:T] => τ_0_0.[P1&P2:T]
+// CHECK: }
+// CHECK: }


### PR DESCRIPTION
Builds on https://github.com/apple/swift/pull/38327.

# Nested type unification step

If a type parameter has a protocol conformance and a concrete type, we want to map associated types of the conformance to their concrete type witnesses.

This is implemented as a post-processing pass in the completion procedure that runs after the equivalence class map has been built.

If we have an equivalence class `T => { conforms_to: [ P ], concrete: Foo }`, then for each associated type A of P, we generate a new rule:

    T.[P:A].[concrete: Foo.A] => T.[P:A]  (if Foo.A is concrete)
    T.[P:A] => T.(Foo.A)                  (if Foo.A is abstract)

If this process introduced any new rules, we check for any new overlaps by re-running Knuth-Bendix completion; this may in turn introduce new concrete associated type overlaps, and so on.

The overall completion procedure now alternates between Knuth-Bendix and rebuilding the equivalence class map; the rewrite system is complete when neither step is able to introduce any new rules.

# Canonical type computation

We compute the canonical type by first simplifying the type term, and then checking if it is a concrete type. If there's no concrete type,we convert the simplified term back to an interface type and return that; otherwise, we canonicalize any structural sub-components of the concrete type that contain interface types, and so on.

Due to a quirk of how the existing declaration checker works, we also need to handle "purely concrete" member types, eg if I have a signature `<T where T == Foo>`, and we're asked to canonicalize the type `T.[P:A]` where Foo : A.

This comes up because we can derive the signature `<T where T == Foo>` from a generic signature like `<T where T : P>`; adding the concrete requirement 'T == Foo' renders 'T : P' redundant. We then want to take interface types written against the original signature and canonicalize them with respect to the derived signature.

The problem is that `T.[P:A]` is not a valid term in the rewrite system for `<T where T == Foo>`, since we do not have the requirement T : P.

A more principled solution would build a substitution map when building a derived generic signature that adds new requirements; interface types would first be substituted before being canonicalized in the new signature.

For now, we handle this with a two-step process; we split a term up into a longest valid prefix, which must resolve to a concrete type, and the remaining suffix, which we use to perform a concrete substitution using subst().

# Mapping terms back to interface types

Protocol atoms map to the 'Self' parameter; GenericParam and Name atoms map in the obvious way.

An associated type atom `[P1&P1&...&Pn:A]` has one or more protocols P0...Pn and an identifier 'A'.

We map it back to a AssociatedTypeDecl as follows:

- For each protocol Pn, look for associated types A in Pn itself, and all protocols that Pn refines.

- For each candidate associated type An in protocol Qn where Pn refines Qn, get the associated type anchor An' defined in
  protocol Qn', where Qn refines Qn'.

- Out of all the candidiate pairs (Qn', An'), pick the one where the protocol Qn' is the lowest element according to the linear
  order defined by TypeDecl::compare().

The associated type An' is then the canonical associated type representative of the associated type atom `[P0&...&Pn:A]`.