### PR TITLE
[5.5] ModuleInterface: sanitize arch when interface file name and encoded flags disagree

### DIFF
--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -458,6 +458,10 @@ public:
   }
 };
 
+/// Extract compiler arguments from an interface file buffer.
+bool extractCompilerFlagsFromInterface(StringRef interfacePath,
+                                       StringRef buffer, llvm::StringSaver &ArgSaver,
+                                       SmallVectorImpl<const char *> &SubArgs);
 
 } // end namespace swift
 

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1192,23 +1192,21 @@ bool InterfaceSubContextDelegateImpl::extractSwiftInterfaceVersionAndArgs(
   auto VersRe = getSwiftInterfaceFormatVersionRegex();
   auto CompRe = getSwiftInterfaceCompilerVersionRegex();
   auto FlagRe = getSwiftInterfaceModuleFlagsRegex();
-  SmallVector<StringRef, 1> VersMatches, FlagMatches, CompMatches;
+  SmallVector<StringRef, 1> VersMatches, CompMatches;
 
   if (!VersRe.match(SB, &VersMatches)) {
     diagnose(interfacePath, diagnosticLoc,
              diag::error_extracting_version_from_module_interface);
     return true;
   }
-  if (!FlagRe.match(SB, &FlagMatches)) {
+  if (extractCompilerFlagsFromInterface(interfacePath, SB, ArgSaver, SubArgs)) {
     diagnose(interfacePath, diagnosticLoc,
              diag::error_extracting_version_from_module_interface);
     return true;
   }
   assert(VersMatches.size() == 2);
-  assert(FlagMatches.size() == 2);
   // FIXME We should diagnose this at a location that makes sense:
   auto Vers = swift::version::Version(VersMatches[1], SourceLoc(), &Diags);
-  llvm::cl::TokenizeGNUCommandLine(FlagMatches[1], ArgSaver, SubArgs);
 
   if (CompRe.match(SB, &CompMatches)) {
     assert(CompMatches.size() == 2);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -23,6 +23,7 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Version.h"
 
+#include "llvm/Option/ArgList.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Debug.h"
@@ -30,6 +31,7 @@
 #include "llvm/Support/Host.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/CommandLine.h"
 #include <system_error>
 
 using namespace swift;
@@ -957,6 +959,42 @@ void swift::serialization::diagnoseSerializedASTLoadFailure(
     break;
   }
   }
+}
+
+bool swift::extractCompilerFlagsFromInterface(StringRef interfacePath,
+                                              StringRef buffer,
+                                              llvm::StringSaver &ArgSaver,
+                                              SmallVectorImpl<const char *> &SubArgs) {
+  SmallVector<StringRef, 1> FlagMatches;
+  auto FlagRe = llvm::Regex("^// swift-module-flags:(.*)$", llvm::Regex::Newline);
+  if (!FlagRe.match(buffer, &FlagMatches))
+    return true;
+  assert(FlagMatches.size() == 2);
+  llvm::cl::TokenizeGNUCommandLine(FlagMatches[1], ArgSaver, SubArgs);
+
+  auto intFileName = llvm::sys::path::filename(interfacePath);
+
+  // Sanitize arch if the file name and the encoded flags disagree.
+  // It's a known issue that we are using arm64e interfaces contents for the arm64 target,
+  // meaning the encoded module flags are using -target arm64e-x-x. Fortunately,
+  // we can tell the target arch from the interface file name, so we could sanitize
+  // the target to use by inferring target from the file name.
+  StringRef arm64 = "arm64";
+  StringRef arm64e = "arm64e";
+  if (intFileName.contains(arm64) && !intFileName.contains(arm64e)) {
+    for (unsigned I = 1; I < SubArgs.size(); ++I) {
+      if (strcmp(SubArgs[I - 1], "-target") != 0) {
+        continue;
+      }
+      StringRef triple(SubArgs[I]);
+      if (triple.startswith(arm64e)) {
+        SubArgs[I] = ArgSaver.save((llvm::Twine(arm64) +
+          triple.substr(arm64e.size())).str()).data();
+      }
+    }
+  }
+
+  return false;
 }
 
 bool SerializedModuleLoaderBase::canImportModule(

--- a/test/ModuleInterface/infer-arch-from-file.swift
+++ b/test/ModuleInterface/infer-arch-from-file.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/Bar.swiftmodule)
+// RUN: echo "// swift-interface-format-version: 1.0" > %t/arm64.swiftinterface
+// RUN: echo "// swift-module-flags: -module-name arm64 -target arm64e-apple-macos11.0" >> %t/arm64.swiftinterface
+
+import arm64
+
+// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t -target arm64-apple-macos11.0
+// RUN: %FileCheck %s < %t/deps.json
+
+// CHECK-NOT: arm64e-apple-macos11.0

--- a/test/stdlib/Reflection_objc.swift
+++ b/test/stdlib/Reflection_objc.swift
@@ -9,9 +9,6 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
-// rdar://problem/75006694
-// XFAIL: OS=macosx && CPU=arm64
-
 //
 // DO NOT add more tests to this file.  Add them to test/1_stdlib/Runtime.swift.
 //


### PR DESCRIPTION
It's a known issue that we are using arm64e interfaces contents for the arm64 target,
meaning the encoded module flags are specifying -target arm64e-x-x instead of
-target arm64-x-x. Fortunately, we can tell the target arch from the interface file
name, so we could sanitize the target to use by inferring arch from the file name.

This PR is to test whether the commit can fix a CI issue tracked by rdar://79746530.
