### PR TITLE
[Concurrency] Add an exported symbol on Darwin that contains the frame pointer flag bit for async frames.

### DIFF
--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -673,6 +673,18 @@ void swift_task_reportUnexpectedExecutor(
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 JobPriority swift_task_getCurrentThreadPriority(void);
 
+#ifdef __APPLE__
+/// A magic symbol whose address is the mask to apply to a frame pointer to
+/// signal that it is an async frame. Do not try to read the actual value of
+/// this global, it will crash.
+///
+/// On ARM64_32, the address is only 32 bits, and therefore this value covers
+/// the top 32 bits of the in-memory frame pointer. On other 32-bit platforms,
+/// the bit is not used and the address is always 0.
+SWIFT_EXPORT_FROM(swift_Concurrency)
+struct { char c; } swift_async_extendedFramePointerFlags;
+#endif
+
 }
 
 #pragma clang diagnostic pop

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -34,6 +34,19 @@
 #include <dlfcn.h>
 #endif
 
+#ifdef __APPLE__
+#if __POINTER_WIDTH__ == 64
+asm("\n .globl _swift_async_extendedFramePointerFlags" \
+    "\n _swift_async_extendedFramePointerFlags = 0x1000000000000000");
+#elif __ARM64_ARCH_8_32__
+asm("\n .globl _swift_async_extendedFramePointerFlags" \
+    "\n _swift_async_extendedFramePointerFlags = 0x10000000");
+#else
+asm("\n .globl _swift_async_extendedFramePointerFlags" \
+    "\n _swift_async_extendedFramePointerFlags = 0x0");
+#endif
+#endif // __APPLE__
+
 using namespace swift;
 using FutureFragment = AsyncTask::FutureFragment;
 using TaskGroup = swift::TaskGroup;


### PR DESCRIPTION
The symbol is swift_async_extendedFramePointerFlags. Since the value doesn't need to be dynamically computed, we save a level of indirection by emitting a fake global variable whose address is the value we want, similar to objc_absolute_packed_isa_class_mask.

This bit is mixed in to the frame pointer address stored on the stack to signal that a frame is an async frame. The compiler can emit code that ORs in the address of this symbol to apply the appropriate flag when it doesn't know the flag statically.

rdar://80277146