### PR TITLE
[MiscDiagnostics] Downgrade plain type use error to a warning for certain positions

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -77,7 +77,9 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
     SmallPtrSet<DeclRefExpr*, 4> AlreadyDiagnosedBitCasts;
 
     /// Keep track of the arguments to CallExprs.
-    SmallPtrSet<Expr *, 2> CallArgs;
+    ///  Key -> an argument expression,
+    ///  Value -> a call argument is associated with.
+    llvm::SmallDenseMap<Expr *, Expr *, 2> CallArgs;
 
     bool IsExprStmt;
 
@@ -141,14 +143,14 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
         checkUseOfMetaTypeName(Base);
 
       if (auto *OLE = dyn_cast<ObjectLiteralExpr>(E)) {
-        CallArgs.insert(OLE->getArg());
+        CallArgs.insert({OLE->getArg(), E});
       }
 
       if (auto *SE = dyn_cast<SubscriptExpr>(E))
-        CallArgs.insert(SE->getIndex());
+        CallArgs.insert({SE->getIndex(), E});
 
       if (auto *DSE = dyn_cast<DynamicSubscriptExpr>(E))
-        CallArgs.insert(DSE->getIndex());
+        CallArgs.insert({DSE->getIndex(), E});
 
       if (auto *KPE = dyn_cast<KeyPathExpr>(E)) {
         // raise an error if this KeyPath contains an effectful member.
@@ -156,7 +158,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
 
         for (auto Comp : KPE->getComponents()) {
           if (auto *Arg = Comp.getIndexExpr())
-            CallArgs.insert(Arg);
+            CallArgs.insert({Arg, E});
         }
       }
 
@@ -164,7 +166,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       // function and inspecting the arguments directly.
       if (auto *Call = dyn_cast<ApplyExpr>(E)) {
         // Record call arguments.
-        CallArgs.insert(Call->getArg());
+        CallArgs.insert({Call->getArg(), E});
 
         // Warn about surprising implicit optional promotions.
         checkOptionalPromotions(Call);

--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -433,3 +433,20 @@ func testCallAsFunctionAnyObject(_ x: AnyObject) {
   x() // expected-error {{cannot call value of non-function type 'AnyObject'}}
   x.callAsFunction() // Okay.
 }
+
+// Note: In Swift >= 6 mode this would become an error.
+func test_dynamic_subscript_accepts_type_name_argument() {
+  @objc class A {
+    @objc subscript(a: A.Type) -> Int { get { 42 } }
+  }
+
+  func test(a: AnyObject, optA: AnyObject?) {
+    let _ = a[A] // expected-warning {{expected member name or constructor call after type name}}
+    // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{16-16=()}}
+    // expected-note@-2 {{use '.self' to reference the type object}} {{16-16=.self}}
+
+    let _ = optA?[A] // expected-warning {{expected member name or constructor call after type name}}
+    // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{20-20=()}}
+    // expected-note@-2 {{use '.self' to reference the type object}} {{20-20=.self}}
+  }
+}

--- a/test/Constraints/subscript.swift
+++ b/test/Constraints/subscript.swift
@@ -217,14 +217,19 @@ func rdar61084565() {
   a[] // expected-error {{value of type 'Foo' has no subscripts}}
 }
 
+// Note: In Swift >= 6 mode this would become an error.
 func test_subscript_accepts_type_name_argument() {
   struct A {
     subscript(a: A.Type) -> Int { get { 42 } }
   }
 
-  func test(a: A?) {
-    let _ = a?[A] // expected-error {{expected member name or constructor call after type name}}
-    // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{17-17=()}}
-    // expected-note@-2 {{use '.self' to reference the type object}} {{17-17=.self}}
+  func test(a: A, optA: A?) {
+    let _ = a[A] // expected-warning {{expected member name or constructor call after type name}}
+    // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{16-16=()}}
+    // expected-note@-2 {{use '.self' to reference the type object}} {{16-16=.self}}
+
+    let _ = optA?[A] // expected-warning {{expected member name or constructor call after type name}}
+    // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{20-20=()}}
+    // expected-note@-2 {{use '.self' to reference the type object}} {{20-20=.self}}
   }
 }


### PR DESCRIPTION
In Swift < 6 warn about plain type name passed as an
argument to a subscript, dynamic subscript, or ObjC
literal since it used to be accepted.

Resolves: rdar://80270126

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
