### PR TITLE
[sil] Add a dump method for operand for use in the debugger.

### DIFF
--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -1050,6 +1050,11 @@ public:
   SILBasicBlock *getParentBlock() const;
   SILFunction *getParentFunction() const;
 
+  LLVM_ATTRIBUTE_DEPRECATED(
+      void dump() const LLVM_ATTRIBUTE_USED,
+      "Dump the operand's state. Only for use in the debugger!");
+  void print(llvm::raw_ostream &os) const;
+
 private:
   void removeFromCurrent() {
     if (!Back)

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -347,6 +347,16 @@ bool Operand::isConsuming() const {
   return get().getOwnershipKind() != OwnershipKind::None;
 }
 
+void Operand::dump() const { print(llvm::dbgs()); }
+
+void Operand::print(llvm::raw_ostream &os) const {
+  os << "Operand.\n"
+        "Owner: "
+     << *Owner << "Value: " << get() << '\n'
+     << "Operand Number: " << getOperandNumber()
+     << "Is Type Dependent: " << (isTypeDependent() ? "yes" : "no");
+}
+
 //===----------------------------------------------------------------------===//
 //                             OperandConstraint
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
It dumps the instruction, the value, the operand number, and whether or not the
operand is a type dependent operand.

NFC.