### PR TITLE
🍒 [CI] Disable tests that depend on symbolication

### DIFF
--- a/test/Sanitizers/symbolication.swift
+++ b/test/Sanitizers/symbolication.swift
@@ -5,6 +5,10 @@
 // REQUIRES: asan_runtime
 // REQUIRES: VENDOR=apple
 
+// rdar://80274830 ([Swift CI] Sanitizer report symbolication fails because we fail to start atos, sanbox issue?)
+// REQUIRES: 80274830
+// Might be related/same issue as below
+
 // rdar://75365575 (Failing to start atos external symbolizer)
 // UNSUPPORTED: OS=watchos
 

--- a/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
@@ -10,6 +10,10 @@
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib
 
+// rdar://80274830 ([Swift CI] Sanitizer report symbolication fails because we fail to start atos, sanbox issue?)
+// REQUIRES: 80274830
+// Might be related/same issue as below
+
 // rdar://75365575 (Failing to start atos external symbolizer)
 // UNSUPPORTED: OS=watchos
 


### PR DESCRIPTION
After upgrading the OS and Xcode on the CI nodes sanitizer report
symbolication fails because we fail to start atos.  This might be a
sandboxing issue.

Radar-Id: rdar://80274830

(cherry picked from commit 4af32360cab35093f445da766ad80e2e7a1a31c4)
