### PR TITLE
[5.5][MiscDiagnostics] Downgrade plain type use error to a warning for certain positions

### DIFF
--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -433,3 +433,20 @@ func testCallAsFunctionAnyObject(_ x: AnyObject) {
   x() // expected-error {{cannot call value of non-function type 'AnyObject'}}
   x.callAsFunction() // Okay.
 }
+
+// Note: In Swift >= 6 mode this would become an error.
+func test_dynamic_subscript_accepts_type_name_argument() {
+  @objc class A {
+    @objc subscript(a: A.Type) -> Int { get { 42 } }
+  }
+
+  func test(a: AnyObject, optA: AnyObject?) {
+    let _ = a[A] // expected-warning {{expected member name or constructor call after type name}}
+    // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{16-16=()}}
+    // expected-note@-2 {{use '.self' to reference the type object}} {{16-16=.self}}
+
+    let _ = optA?[A] // expected-warning {{expected member name or constructor call after type name}}
+    // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{20-20=()}}
+    // expected-note@-2 {{use '.self' to reference the type object}} {{20-20=.self}}
+  }
+}

--- a/test/Constraints/subscript.swift
+++ b/test/Constraints/subscript.swift
@@ -216,3 +216,19 @@ func rdar61084565() {
   let a = Foo()
   a[] // expected-error {{value of type 'Foo' has no subscripts}}
 }
+
+// Note: In Swift >= 6 mode this would become an error.
+func test_subscript_accepts_type_name_argument() {
+  struct A {
+    subscript(a: A.Type) -> Int { get { 42 } }
+  }
+
+  func test(a: A, optA: A?) {
+    let _ = a[A] // expected-warning {{expected member name or constructor call after type name}}
+    // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{16-16=()}}
+    // expected-note@-2 {{use '.self' to reference the type object}} {{16-16=.self}}
+    let _ = optA?[A] // expected-warning {{expected member name or constructor call after type name}}
+    // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{20-20=()}}
+    // expected-note@-2 {{use '.self' to reference the type object}} {{20-20=.self}}
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/38291

---

- Explanation:

In Swift < 6 warn about plain type name passed as an
argument to a subscript, dynamic subscript, or ObjC
literal since it used to be accepted.

- Scope: Subscripts, dynamic subscripts and ObjC literal expression where one of the arguments is a plain type e.g. `A` without `.self` or initializer call.

- Main Branch PR: https://github.com/apple/swift/pull/38291

- Resolves: rdar://80270126

- Risk: Low

- Reviewed By: @hborla  

- Testing: Regression tests added to the suite

Resolves: rdar://80270126

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
