### PR TITLE
[Sema] Fix two assertion failures/crashes in solver-based key-path completion

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1293,6 +1293,10 @@ public:
 
   bool hasType(ASTNode node) const;
 
+  /// Returns \c true if the \p ComponentIndex-th component in \p KP has a type
+  /// associated with it.
+  bool hasType(const KeyPathExpr *KP, unsigned ComponentIndex) const;
+
   /// Retrieve the type of the given node, as recorded in this solution.
   Type getType(ASTNode node) const;
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8899,6 +8899,11 @@ bool Solution::hasType(ASTNode node) const {
   return cs.hasType(node);
 }
 
+bool Solution::hasType(const KeyPathExpr *KP, unsigned ComponentIndex) const {
+  auto &cs = getConstraintSystem();
+  return cs.hasType(KP, ComponentIndex);
+}
+
 Type Solution::getType(ASTNode node) const {
   auto result = nodeTypes.find(node);
   if (result != nodeTypes.end())

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3233,7 +3233,7 @@ namespace {
           break;
         }
         case KeyPathExpr::Component::Kind::Identity:
-          continue;
+          break;
         case KeyPathExpr::Component::Kind::DictionaryKey:
           llvm_unreachable("DictionaryKey only valid in #keyPath");
           break;

--- a/test/IDE/complete_swift_key_path.swift
+++ b/test/IDE/complete_swift_key_path.swift
@@ -35,6 +35,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_KEY_PATH_BASE | %FileCheck %s -check-prefix=PERSONTYPE-DOT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_KEY_PATH_RESULT | %FileCheck %s -check-prefix=PERSONTYPE-DOT
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=COMPLETE_AFTER_SELF | %FileCheck %s -check-prefix=OBJ-NODOT
 class Person {
     var name: String
     var friends: [Person] = []
@@ -190,4 +191,8 @@ func genericKeyPathBase<Root>(to keyPath: ReferenceWritableKeyPath<Root, Person>
 func genericKeyPathResult<KeyPathResult>(id: KeyPath<Person, KeyPathResult>) {
   genericKeyPathResult(\.#^GENERIC_KEY_PATH_RESULT^#)
   // Same as TYPE_DOT.
+}
+
+func completeAfterSelf(people: [Person]) {
+  people.map(\.self#^COMPLETE_AFTER_SELF^#)
 }

--- a/test/IDE/complete_swift_key_path.swift
+++ b/test/IDE/complete_swift_key_path.swift
@@ -36,6 +36,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_KEY_PATH_RESULT | %FileCheck %s -check-prefix=PERSONTYPE-DOT
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=COMPLETE_AFTER_SELF | %FileCheck %s -check-prefix=OBJ-NODOT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_RESULT_BUILDER | %FileCheck %s -check-prefix=PERSONTYPE-DOT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_MULTI_STMT_CLOSURE | %FileCheck %s -check-prefix=PERSONTYPE-DOT
+
 class Person {
     var name: String
     var friends: [Person] = []
@@ -195,4 +198,33 @@ func genericKeyPathResult<KeyPathResult>(id: KeyPath<Person, KeyPathResult>) {
 
 func completeAfterSelf(people: [Person]) {
   people.map(\.self#^COMPLETE_AFTER_SELF^#)
+}
+
+func inResultBuilder() {
+  protocol View2 {}
+
+  @resultBuilder public struct ViewBuilder2 {
+    public static func buildBlock<Content>(_ content: Content) -> Content where Content : View2 { fatalError() }
+    public static func buildIf<Content>(_ content: Content?) -> Content? where Content : View2 { fatalError() }
+  }
+
+  struct VStack2<Content>: View2 {
+    init(@ViewBuilder2 view: () -> Content) {}
+  }
+
+  @ViewBuilder2 var body: some View2 {
+    VStack2 {
+      if true {
+        var people: [Person] = []
+        people.map(\.#^IN_RESULT_BUILDER^#)
+      }
+    }
+  }
+}
+
+func inMultiStmtClosure(closure: () -> Void) {
+  inMultiStmtClosure {
+    var people: [Person] = []
+    people.map(\.#^IN_MULTI_STMT_CLOSURE^#)
+  }
 }


### PR DESCRIPTION
This fixes two assertion failures/crashes in the solver-based key path completion I introduced in #38049, which were found by the stress tester.

## Record type of identity key paths in the constraint system

If we are completing e.g. `\.self.#^COMPLETE^#` we use the type of `self` as the base type for the completion. In order to retrieve that, we need to record the type.

Fixes rdar://80271346 [SR-14887]

## Check completion key path component to determine if completion node was type checked in multi expression closure

To check whether the code completion node was type checked in a multi statement closure, we were assuming that we had a code completion *expression* and not considering that we could also complete in a key path component. When applicable, check if the completion key path component has a type to determine if the completion node was type checked as part of a multi-statement closure.

Resolves rdar://80271598 [SR-14891]