### PR TITLE
[Diagnostics] Add `InFlightDiagnostic::warnUntilSwiftVersion` to downgrade errors to warnings

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -22,6 +22,7 @@
 #include "swift/AST/DeclNameLoc.h"
 #include "swift/AST/DiagnosticConsumer.h"
 #include "swift/AST/TypeLoc.h"
+#include "swift/Basic/Version.h"
 #include "swift/Localization/LocalizationFormat.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -528,6 +529,12 @@ namespace swift {
     /// emitted as a warning, but a note will still be emitted as a note.
     InFlightDiagnostic &limitBehavior(DiagnosticBehavior limit);
 
+    /// Limit the diagnostic behavior to warning until the specified version.
+    ///
+    /// This helps stage in fixes for stricter diagnostics as warnings
+    /// until the next major language version.
+    InFlightDiagnostic &warnUntilSwiftVersion(unsigned majorVersion);
+
     /// Wraps this diagnostic in another diagnostic. That is, \p wrapper will be
     /// emitted in place of the diagnostic that otherwise would have been
     /// emitted.
@@ -803,6 +810,10 @@ namespace swift {
     /// Path to diagnostic documentation directory.
     std::string diagnosticDocumentationPath = "";
 
+    /// The Swift language version. This is used to limit diagnostic behavior
+    /// until a specific language version, e.g. Swift 6.
+    version::Version languageVersion;
+
     /// Whether we are actively pretty-printing a declaration as part of
     /// diagnostics.
     bool IsPrettyPrintingDecl = false;
@@ -864,6 +875,8 @@ namespace swift {
     }
 
     bool isPrettyPrintingDecl() const { return IsPrettyPrintingDecl; }
+
+    void setLanguageVersion(version::Version v) { languageVersion = v; }
 
     void setLocalization(StringRef locale, StringRef path) {
       assert(!locale.empty());

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -44,6 +44,10 @@ NOTE(previous_decldef,none,
 NOTE(brace_stmt_suggest_do,none,
      "did you mean to use a 'do' statement?", ())
 
+WARNING(error_in_future_swift_version,none,
+        "%0; this is an error in Swift %1",
+        (DiagnosticInfo *, unsigned))
+
 // Generic disambiguation
 NOTE(while_parsing_as_left_angle_bracket,none,
      "while parsing this '<' as a type parameter bracket", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4728,10 +4728,6 @@ ERROR(invalid_ownership_is_let,none,
 ERROR(ownership_invalid_in_protocols,none,
       "%0 cannot be applied to a property declaration in a protocol",
       (ReferenceOwnership))
-WARNING(ownership_invalid_in_protocols_compat_warning,none,
-      "%0 should not be applied to a property declaration "
-      "in a protocol and will be disallowed in future versions",
-      (ReferenceOwnership))
 
 // required
 ERROR(required_initializer_nonclass,none,

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/DiagnosticsCommon.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/Decl.h"
@@ -321,8 +322,10 @@ InFlightDiagnostic::limitBehavior(DiagnosticBehavior limit) {
 
 InFlightDiagnostic &
 InFlightDiagnostic::warnUntilSwiftVersion(unsigned majorVersion) {
-  if (!Engine->languageVersion.isVersionAtLeast(majorVersion))
-    this->limitBehavior(DiagnosticBehavior::Warning);
+  if (!Engine->languageVersion.isVersionAtLeast(majorVersion)) {
+    limitBehavior(DiagnosticBehavior::Warning)
+      .wrapIn(diag::error_in_future_swift_version, majorVersion);
+  }
 
   return *this;
 }

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -320,6 +320,14 @@ InFlightDiagnostic::limitBehavior(DiagnosticBehavior limit) {
 }
 
 InFlightDiagnostic &
+InFlightDiagnostic::warnUntilSwiftVersion(unsigned majorVersion) {
+  if (!Engine->languageVersion.isVersionAtLeast(majorVersion))
+    this->limitBehavior(DiagnosticBehavior::Warning);
+
+  return *this;
+}
+
+InFlightDiagnostic &
 InFlightDiagnostic::wrapIn(const Diagnostic &wrapper) {
   // Save current active diagnostic into WrappedDiagnostics, ignoring state
   // so we don't get a None return or influence future diagnostics.

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -451,6 +451,8 @@ void CompilerInstance::setUpDiagnosticOptions() {
   }
   Diagnostics.setDiagnosticDocumentationPath(
       Invocation.getDiagnosticOptions().DiagnosticDocumentationPath);
+  Diagnostics.setLanguageVersion(
+      Invocation.getLangOptions().EffectiveLanguageVersion);
   if (!Invocation.getDiagnosticOptions().LocalizationCode.empty()) {
     Diagnostics.setLocalization(
         Invocation.getDiagnosticOptions().LocalizationCode,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3354,10 +3354,9 @@ Type TypeChecker::checkReferenceOwnershipAttr(VarDecl *var, Type type,
   if (PDC && !PDC->isObjC()) {
     // Ownership does not make sense in protocols, except for "weak" on
     // properties of Objective-C protocols.
-    auto D = var->getASTContext().isSwiftVersionAtLeast(5)
-                 ? diag::ownership_invalid_in_protocols
-                 : diag::ownership_invalid_in_protocols_compat_warning;
+    auto D = diag::ownership_invalid_in_protocols;
     Diags.diagnose(attr->getLocation(), D, ownershipKind)
+        .warnUntilSwiftVersion(5)
         .fixItRemove(attr->getRange());
     attr->setInvalid();
   }

--- a/test/Compatibility/ownership_protocol.swift
+++ b/test/Compatibility/ownership_protocol.swift
@@ -4,14 +4,14 @@
 class SomeClass {}
 
 protocol P {
-  // expected-warning@+1 {{'weak' should not be applied to a property declaration in a protocol and will be disallowed in future versions}}
+  // expected-warning@+1 {{'weak' cannot be applied to a property declaration in a protocol; this is an error in Swift 5}}
   weak var foo: SomeClass? { get set }
-  // expected-warning@+1 {{'unowned' should not be applied to a property declaration in a protocol and will be disallowed in future versions}}
+  // expected-warning@+1 {{'unowned' cannot be applied to a property declaration in a protocol; this is an error in Swift 5}}
   unowned var foo2: SomeClass { get set }
-  // expected-warning@+2 {{'weak' should not be applied to a property declaration in a protocol and will be disallowed in future versions}}
+  // expected-warning@+2 {{'weak' cannot be applied to a property declaration in a protocol; this is an error in Swift 5}}
   // expected-error@+1 {{'weak' may only be applied to class and class-bound protocol types, not 'Int'}}
   weak var foo3: Int? { get set }
-  // expected-warning@+2 {{'unowned' should not be applied to a property declaration in a protocol and will be disallowed in future versions}}
+  // expected-warning@+2 {{'unowned' cannot be applied to a property declaration in a protocol; this is an error in Swift 5}}
   // expected-error@+1 {{'unowned' may only be applied to class and class-bound protocol types, not 'Int'}}
   unowned var foo4: Int { get set }
 }

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -467,7 +467,7 @@ protocol ShouldntCrash {
 
 // rdar://problem/18168866
 protocol FirstProtocol {
-    // expected-warning@+1 {{'weak' should not be applied to a property declaration in a protocol and will be disallowed in future versions}}
+    // expected-warning@+1 {{'weak' cannot be applied to a property declaration in a protocol; this is an error in Swift 5}}
     weak var delegate : SecondProtocol? { get } // expected-error{{'weak' must not be applied to non-class-bound 'SecondProtocol'; consider adding a protocol conformance that has a class bound}}
 }
 


### PR DESCRIPTION
 `warnUntilSwiftVersion` limits the diagnostic behavior to a warning until the specified language version. This helper can be used to stage in fixes for stricter diagnostics as warnings until the next major language version.
