### PR TITLE
IRGen: Consistently mangle 'associated type paths' without a generic signature

### DIFF
--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -288,6 +288,10 @@ std::string IRGenMangler::mangleSymbolNameForAssociatedConformanceWitness(
     Buffer << "default associated conformance";
   }
 
+  // appendProtocolConformance() sets CurGenericSignature; clear it out
+  // before calling appendAssociatedTypePath().
+  CurGenericSignature = nullptr;
+
   bool isFirstAssociatedTypeIdentifier = true;
   appendAssociatedTypePath(associatedType, isFirstAssociatedTypeIdentifier);
   appendProtocolName(proto);

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -426,6 +426,11 @@ public:
                                       const ProtocolDecl *Proto) {
     beginMangling();
     appendProtocolConformance(Conformance);
+
+    // appendProtocolConformance() sets CurGenericSignature; clear it out
+    // before calling appendAssociatedTypePath().
+    CurGenericSignature = nullptr;
+
     bool isFirstAssociatedTypeIdentifier = true;
     appendAssociatedTypePath(AssociatedType, isFirstAssociatedTypeIdentifier);
     appendAnyGenericType(Proto);
@@ -444,6 +449,10 @@ public:
   }
 
   void appendAssociatedTypePath(CanType associatedType, bool &isFirst) {
+    // In the mangling format, the "short associated type" optimization is
+    // not performed when mangling an associated type path.
+    assert(!CurGenericSignature && "Caller needs to explicitly clear the signature");
+
     if (auto memberType = dyn_cast<DependentMemberType>(associatedType)) {
       appendAssociatedTypePath(memberType.getBase(), isFirst);
       appendAssociatedTypeName(memberType);

--- a/test/IRGen/associated_type_witness.swift
+++ b/test/IRGen/associated_type_witness.swift
@@ -50,8 +50,8 @@ struct WithUniversal : Assocked {
 //   Witness table for GenericWithUniversal : Assocked.
 // GLOBAL-LABEL: @"$s23associated_type_witness20GenericWithUniversalVyxGAA8AssockedAAWP" = hidden global [4 x i8*] [
 // GLOBAL-SAME:    @"$s23associated_type_witness20GenericWithUniversalVyxGAA8AssockedAAMc"
-// GLOBAL-SAME:    @"associated conformance 23associated_type_witness20GenericWithUniversalVyxGAA8AssockedAA5Assoc_AA1P"
-// GLOBAL-SAME:    @"associated conformance 23associated_type_witness20GenericWithUniversalVyxGAA8AssockedAA5Assoc_AA1Q"
+// GLOBAL-SAME:    @"associated conformance 23associated_type_witness20GenericWithUniversalVyxGAA8AssockedAA5AssocAaEP_AA1P"
+// GLOBAL-SAME:    @"associated conformance 23associated_type_witness20GenericWithUniversalVyxGAA8AssockedAA5AssocAaEP_AA1Q"
 // GLOBAL-SAME:    @"symbolic{{.*}}23associated_type_witness9UniversalV"
 // GLOBAL-SAME:  ]
 struct GenericWithUniversal<T> : Assocked {
@@ -88,8 +88,8 @@ struct Pair<T, U> : P, Q {}
 //   Generic witness table pattern for Computed : Assocked.
 // GLOBAL-LABEL: @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAWp" = internal global [4 x i8*] [
 // GLOBAL-SAME:    @"$s23associated_type_witness8ComputedVyxq_GAA8AssockedAAMc"
-// GLOBAL-SAME:    @"associated conformance 23associated_type_witness8ComputedVyxq_GAA8AssockedAA5Assoc_AA1P"
-// GLOBAL-SAME:    @"associated conformance 23associated_type_witness8ComputedVyxq_GAA8AssockedAA5Assoc_AA1Q"
+// GLOBAL-SAME:    @"associated conformance 23associated_type_witness8ComputedVyxq_GAA8AssockedAA5AssocAaEP_AA1P"
+// GLOBAL-SAME:    @"associated conformance 23associated_type_witness8ComputedVyxq_GAA8AssockedAA5AssocAaEP_AA1Q"
 // GLOBAL-SAME:    @"symbolic{{.*}}23associated_type_witness4PairV{{.*}}"
 // GLOBAL-SAME:  ]
 

--- a/test/IRGen/assoctypepath.swift
+++ b/test/IRGen/assoctypepath.swift
@@ -17,7 +17,7 @@ protocol P {
 protocol Q: P where A: Z {}
 protocol R: Q where A.ZZ: Y {}
 
-// CHECK: define {{.*}} @"$s13assoctypepath1SVyxGAA1RAA1A_2ZZAA1YPWT"
+// CHECK: define {{.*}} @"$s13assoctypepath1SVyxGAA1RAA1AAA1PP_2ZZAA1ZPAA1YPWT"
 
 struct S<T>: R where T: Z, T.ZZ: Y {
 	typealias A = T

--- a/test/IRGen/opaque_result_type_associated_type_conformance_path.swift
+++ b/test/IRGen/opaque_result_type_associated_type_conformance_path.swift
@@ -14,7 +14,7 @@ struct Foo<T: Tubb>: P {
   func foo(_ x: T) -> some Tubb { return x }
 }
 
-// CHECK-LABEL: define {{.*}} @"$s030opaque_result_type_associated_C17_conformance_path3FooVyxGAA1PAA1B_AA4ButtPWT"
+// CHECK-LABEL: define {{.*}} @"$s030opaque_result_type_associated_C17_conformance_path3FooVyxGAA1PAA1AAaEP_AA4ButtPWT"
 // CHECK: [[TUBB_CONFORMANCE:%.*]] = call swiftcc i8** @swift_getOpaqueTypeConformance({{.*}}, i{{.*}} 1)
 // CHECK: [[BUTT_CONFORMANCE_ADDR:%.*]] = getelementptr {{.*}} [[TUBB_CONFORMANCE]], i32 1
 // CHECK: [[BUTT_CONFORMANCE_LOAD:%.*]] = load {{.*}} [[BUTT_CONFORMANCE_ADDR]]

--- a/test/IRGen/same_type_constraints.swift
+++ b/test/IRGen/same_type_constraints.swift
@@ -67,7 +67,7 @@ where Self : CodingType,
   print(Self.ValueType.self)
 }
 
-// OSIZE: define internal swiftcc i8** @"$s21same_type_constraints12GenericKlazzCyxq_GAA1EAA4Data_AA0F4TypePWT"(%swift.type* readnone %"GenericKlazz<T, R>.Data", %swift.type* nocapture readonly %"GenericKlazz<T, R>", i8** nocapture readnone %"GenericKlazz<T, R>.E") [[ATTRS:#[0-9]+]] {
+// OSIZE: define internal swiftcc i8** @"$s21same_type_constraints12GenericKlazzCyxq_GAA1EAA4DataAaEP_AA0F4TypePWT"(%swift.type* readnone %"GenericKlazz<T, R>.Data", %swift.type* nocapture readonly %"GenericKlazz<T, R>", i8** nocapture readnone %"GenericKlazz<T, R>.E") [[ATTRS:#[0-9]+]] {
 // OSIZE: [[ATTRS]] = {{{.*}}noinline
 
 // Check that same-typing two generic parameters together lowers correctly.

--- a/test/Inputs/conditional_conformance_recursive.swift
+++ b/test/Inputs/conditional_conformance_recursive.swift
@@ -19,7 +19,7 @@ protocol P3: P2 where A: P3 { }
 extension Wrapper: P3 where T: P3 { }
 
 // associated type witness table accessor for A : P2 in Wrapper<T>: P2
-// CHECK-LABEL: define internal swiftcc i8** @"$s33conditional_conformance_recursive7WrapperVyxGAA2P2A2aERzrl1A_AaEPWT"
+// CHECK-LABEL: define internal swiftcc i8** @"$s33conditional_conformance_recursive7WrapperVyxGAA2P2A2aERzrl1AAA2P1P_AaEPWT"
 // CHECK: [[CONDITIONAL_REQ_BUFFER:%.*]] = alloca [1 x i8**]
 // CHECK: [[FIRST_REQ:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* [[CONDITIONAL_REQ_BUFFER]]
 // CHECK: call i8** @swift_getWitnessTable


### PR DESCRIPTION
Mangling uses a generic signature is used to shorten member types
to just a name where the protocol is unambiguous.

Unfortunately, in the particular case of 'associated type paths',
the IRGen mangler did not consistently set the right signature.

Sometimes, it would use no signature, and other times it would use
the signature of the concrete conforming type, which is incorrect
because the member type is written relative to the root protocol's
generic signature, `<Self : P>`.

This was caught by some new assertions I'm adding to the rewrite
system.

Note that this changes the mangling of a few symbols, but none
are public in the ABI.