### PR TITLE
[SE-0306] Ban "class" methods and properties in actors.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1595,10 +1595,12 @@ SourceRange PatternBindingDecl::getSourceRange() const {
 }
 
 static StaticSpellingKind getCorrectStaticSpellingForDecl(const Decl *D) {
-  if (!D->getDeclContext()->getSelfClassDecl())
-    return StaticSpellingKind::KeywordStatic;
+  if (auto classDecl = D->getDeclContext()->getSelfClassDecl()) {
+    if (!classDecl->isActor())
+      return StaticSpellingKind::KeywordClass;
+  }
 
-  return StaticSpellingKind::KeywordClass;
+  return StaticSpellingKind::KeywordStatic;
 }
 
 StaticSpellingKind PatternBindingDecl::getCorrectStaticSpelling() const {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2003,6 +2003,14 @@ public:
       }
     }
 
+    // Reject "class" methods on actors.
+    if (SD->getStaticSpelling() == StaticSpellingKind::KeywordClass &&
+        SD->getDeclContext()->getSelfClassDecl() &&
+        SD->getDeclContext()->getSelfClassDecl()->isActor()) {
+      SD->diagnose(diag::class_subscript_not_in_class, false)
+          .fixItReplace(SD->getStaticLoc(), "static");
+    }
+
     // Now check all the accessors.
     SD->visitEmittedAccessors([&](AccessorDecl *accessor) {
       visit(accessor);

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2645,6 +2645,14 @@ public:
       }
     }
 
+    // Reject "class" methods on actors.
+    if (StaticSpelling == StaticSpellingKind::KeywordClass &&
+        FD->getDeclContext()->getSelfClassDecl() &&
+        FD->getDeclContext()->getSelfClassDecl()->isActor()) {
+      FD->diagnose(diag::class_func_not_in_class, false)
+          .fixItReplace(FD->getStaticLoc(), "static");
+    }
+
     // Member functions need some special validation logic.
     if (FD->getDeclContext()->isTypeContext()) {
       if (FD->isOperator() && !isMemberOperator(FD, nullptr)) {

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -219,6 +219,14 @@ PatternBindingEntryRequest::evaluate(Evaluator &eval,
     }
   }
 
+  // Reject "class" methods on actors.
+  if (StaticSpelling == StaticSpellingKind::KeywordClass &&
+      binding->getDeclContext()->getSelfClassDecl() &&
+      binding->getDeclContext()->getSelfClassDecl()->isActor()) {
+    binding->diagnose(diag::class_var_not_in_class, false)
+        .fixItReplace(binding->getStaticLoc(), "static");
+  }
+
   // Check the pattern.
   auto contextualPattern =
       ContextualPattern::forPatternBindingDecl(binding, entryNumber);

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -71,7 +71,7 @@ actor MyActor: MySuperActor { // expected-error{{actor types do not support inhe
     return self.name // expected-error{{property 'name' isolated to global actor 'MainActor' can not be referenced from actor 'MyActor' in a synchronous context}}
   }
 
-  class func synchronousClass() { }
+  static func synchronousClass() { }
   static func synchronousStatic() { }
 
   func synchronous() -> String { text.first ?? "nothing" } // expected-note 9{{calls to instance method 'synchronous()' from outside of its actor context are implicitly asynchronous}}

--- a/test/decl/class/actor/basic.swift
+++ b/test/decl/class/actor/basic.swift
@@ -44,4 +44,7 @@ actor A2 {
 extension A2 {
   class func h2() { } // expected-error{{class methods are only allowed within classes; use 'static' to declare a static method}}
   static func i2() { } // okay
+
+  class subscript(i: Int) -> Int { i } // expected-error{{class subscripts are only allowed within classes; use 'static' to declare a static subscript}}
+  static subscript(s: String) -> String { s }
 }

--- a/test/decl/class/actor/basic.swift
+++ b/test/decl/class/actor/basic.swift
@@ -27,3 +27,21 @@ actor public class BarbraStreisand {}
 public actor struct JulieAndrews {}
 // expected-error@+1{{keyword 'public' cannot be used as an identifier here}}
 actor public enum TomHanks {}
+
+open actor A1 { } // expected-error{{only classes and overridable class members can be declared 'open'; use 'public'}}
+
+actor A2 {
+  required init() { } // expected-error{{'required' initializer in non-class type 'A2'}}
+  open func f() { } // expected-error{{only classes and overridable class members can be declared 'open'; use 'public'}}
+
+  final func g() { } // okay for now
+  class func h() { } // expected-error{{class methods are only allowed within classes; use 'static' to declare a static method}}
+  static func i() { } // okay
+
+  class var someProp: Int { 0 } // expected-error{{class properties are only allowed within classes; use 'static' to declare a static property}}
+}
+
+extension A2 {
+  class func h2() { } // expected-error{{class methods are only allowed within classes; use 'static' to declare a static method}}
+  static func i2() { } // okay
+}


### PR DESCRIPTION
**Explanation**: Ban `class` methods, properties, and subscripts within an actor. Instead, require `static` like we do for structs and enums. 
**Scope**: Affects a small number of actors.
**Radar/SR Issue**: rdar://80285441
**Risk**: Low.
**Testing**: PR testing and CI on main.
**Original PR**: https://github.com/apple/swift/pull/38298
