### PR TITLE
Allow AsyncSequence operators to be inlined in their construction

### DIFF
--- a/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
@@ -56,6 +56,7 @@ extension AsyncSequence {
 /// An asynchronous sequence that maps a given closure over the asynchronous
 /// sequence’s elements, omitting results that don't return a value.
 @available(SwiftStdlib 5.5, *)
+@frozen
 public struct AsyncCompactMapSequence<Base: AsyncSequence, ElementOfResult> {
   @usableFromInline
   let base: Base
@@ -63,7 +64,7 @@ public struct AsyncCompactMapSequence<Base: AsyncSequence, ElementOfResult> {
   @usableFromInline
   let transform: (Base.Element) async -> ElementOfResult?
 
-  @usableFromInline
+  @inlinable
   init(
     _ base: Base, 
     transform: @escaping (Base.Element) async -> ElementOfResult?
@@ -84,6 +85,7 @@ extension AsyncCompactMapSequence: AsyncSequence {
   public typealias AsyncIterator = Iterator
 
   /// The iterator that produces elements of the compact map sequence.
+  @frozen
   public struct Iterator: AsyncIteratorProtocol {
     public typealias Element = ElementOfResult
 
@@ -93,7 +95,7 @@ extension AsyncCompactMapSequence: AsyncSequence {
     @usableFromInline
     let transform: (Base.Element) async -> ElementOfResult?
 
-    @usableFromInline
+    @inlinable
     init(
       _ baseIterator: Base.AsyncIterator, 
       transform: @escaping (Base.Element) async -> ElementOfResult?

--- a/stdlib/public/Concurrency/AsyncDropFirstSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropFirstSequence.swift
@@ -49,6 +49,7 @@ extension AsyncSequence {
 /// An asynchronous sequence which omits a specified number of elements from the
 /// base asynchronous sequence, then passes through all remaining elements.
 @available(SwiftStdlib 5.5, *)
+@frozen
 public struct AsyncDropFirstSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -56,7 +57,7 @@ public struct AsyncDropFirstSequence<Base: AsyncSequence> {
   @usableFromInline
   let count: Int
   
-  @usableFromInline 
+  @inlinable 
   init(_ base: Base, dropping count: Int) {
     self.base = base
     self.count = count
@@ -74,6 +75,7 @@ extension AsyncDropFirstSequence: AsyncSequence {
   public typealias AsyncIterator = Iterator
 
   /// The iterator that produces elements of the drop-first sequence.
+  @frozen
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
@@ -81,7 +83,7 @@ extension AsyncDropFirstSequence: AsyncSequence {
     @usableFromInline
     var count: Int
 
-    @usableFromInline
+    @inlinable
     init(_ baseIterator: Base.AsyncIterator, count: Int) {
       self.baseIterator = baseIterator
       self.count = count

--- a/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
@@ -53,6 +53,7 @@ extension AsyncSequence {
 /// given closure returns false, after which it passes through all remaining
 /// elements.
 @available(SwiftStdlib 5.5, *)
+@frozen
 public struct AsyncDropWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -60,7 +61,7 @@ public struct AsyncDropWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let predicate: (Base.Element) async -> Bool
 
-  @usableFromInline
+  @inlinable
   init(
     _ base: Base, 
     predicate: @escaping (Base.Element) async -> Bool
@@ -82,6 +83,7 @@ extension AsyncDropWhileSequence: AsyncSequence {
   public typealias AsyncIterator = Iterator
 
   /// The iterator that produces elements of the drop-while sequence.
+  @frozen
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
@@ -89,7 +91,7 @@ extension AsyncDropWhileSequence: AsyncSequence {
     @usableFromInline
     var predicate: ((Base.Element) async -> Bool)?
 
-    @usableFromInline
+    @inlinable
     init(
       _ baseIterator: Base.AsyncIterator, 
       predicate: @escaping (Base.Element) async -> Bool

--- a/stdlib/public/Concurrency/AsyncFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFilterSequence.swift
@@ -44,6 +44,7 @@ extension AsyncSequence {
 /// An asynchronous sequence that contains, in order, the elements of
 /// the base sequence that satisfy a given predicate.
 @available(SwiftStdlib 5.5, *)
+@frozen
 public struct AsyncFilterSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -51,7 +52,7 @@ public struct AsyncFilterSequence<Base: AsyncSequence> {
   @usableFromInline
   let isIncluded: (Element) async -> Bool
 
-  @usableFromInline
+  @inlinable
   init(
     _ base: Base, 
     isIncluded: @escaping (Base.Element) async -> Bool
@@ -72,6 +73,7 @@ extension AsyncFilterSequence: AsyncSequence {
   public typealias AsyncIterator = Iterator
 
   /// The iterator that produces elements of the filter sequence.
+  @frozen
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
@@ -79,7 +81,7 @@ extension AsyncFilterSequence: AsyncSequence {
     @usableFromInline
     let isIncluded: (Base.Element) async -> Bool
 
-    @usableFromInline
+    @inlinable
     init(
       _ baseIterator: Base.AsyncIterator,
       isIncluded: @escaping (Base.Element) async -> Bool

--- a/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
@@ -50,6 +50,7 @@ extension AsyncSequence {
 /// An asynchronous sequence that concatenates the results of calling a given
 /// transformation with each element of this sequence.
 @available(SwiftStdlib 5.5, *)
+@frozen
 public struct AsyncFlatMapSequence<Base: AsyncSequence, SegmentOfResult: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -57,7 +58,7 @@ public struct AsyncFlatMapSequence<Base: AsyncSequence, SegmentOfResult: AsyncSe
   @usableFromInline
   let transform: (Base.Element) async -> SegmentOfResult
 
-  @usableFromInline
+  @inlinable
   init(
     _ base: Base,
     transform: @escaping (Base.Element) async -> SegmentOfResult
@@ -78,6 +79,7 @@ extension AsyncFlatMapSequence: AsyncSequence {
   public typealias AsyncIterator = Iterator
 
   /// The iterator that produces elements of the flat map sequence.
+  @frozen
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
@@ -91,7 +93,7 @@ extension AsyncFlatMapSequence: AsyncSequence {
     @usableFromInline
     var finished = false
 
-    @usableFromInline
+    @inlinable
     init(
       _ baseIterator: Base.AsyncIterator,
       transform: @escaping (Base.Element) async -> SegmentOfResult

--- a/stdlib/public/Concurrency/AsyncMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncMapSequence.swift
@@ -54,6 +54,7 @@ extension AsyncSequence {
 /// An asynchronous sequence that maps the given closure over the asynchronous
 /// sequence’s elements.
 @available(SwiftStdlib 5.5, *)
+@frozen
 public struct AsyncMapSequence<Base: AsyncSequence, Transformed> {
   @usableFromInline
   let base: Base
@@ -61,7 +62,7 @@ public struct AsyncMapSequence<Base: AsyncSequence, Transformed> {
   @usableFromInline
   let transform: (Base.Element) async -> Transformed
 
-  @usableFromInline
+  @inlinable
   init(
     _ base: Base, 
     transform: @escaping (Base.Element) async -> Transformed
@@ -82,6 +83,7 @@ extension AsyncMapSequence: AsyncSequence {
   public typealias AsyncIterator = Iterator
 
   /// The iterator that produces elements of the map sequence.
+  @frozen
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
@@ -89,7 +91,7 @@ extension AsyncMapSequence: AsyncSequence {
     @usableFromInline
     let transform: (Base.Element) async -> Transformed
 
-    @usableFromInline
+    @inlinable
     init(
       _ baseIterator: Base.AsyncIterator, 
       transform: @escaping (Base.Element) async -> Transformed

--- a/stdlib/public/Concurrency/AsyncPrefixSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixSequence.swift
@@ -49,6 +49,7 @@ extension AsyncSequence {
 /// An asynchronous sequence, up to a specified maximum length,
 /// containing the initial elements of a base asynchronous sequence.
 @available(SwiftStdlib 5.5, *)
+@frozen
 public struct AsyncPrefixSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -56,7 +57,7 @@ public struct AsyncPrefixSequence<Base: AsyncSequence> {
   @usableFromInline
   let count: Int
 
-  @usableFromInline
+  @inlinable
   init(_ base: Base, count: Int) {
     self.base = base
     self.count = count
@@ -74,6 +75,7 @@ extension AsyncPrefixSequence: AsyncSequence {
   public typealias AsyncIterator = Iterator
 
   /// The iterator that produces elements of the prefix sequence.
+  @frozen
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
@@ -81,7 +83,7 @@ extension AsyncPrefixSequence: AsyncSequence {
     @usableFromInline
     var remaining: Int
 
-    @usableFromInline
+    @inlinable
     init(_ baseIterator: Base.AsyncIterator, count: Int) {
       self.baseIterator = baseIterator
       self.remaining = count

--- a/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
@@ -49,6 +49,7 @@ extension AsyncSequence {
 /// An asynchronous sequence, containing the initial, consecutive
 /// elements of the base sequence that satisfy a given predicate.
 @available(SwiftStdlib 5.5, *)
+@frozen
 public struct AsyncPrefixWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -56,7 +57,7 @@ public struct AsyncPrefixWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let predicate: (Base.Element) async -> Bool
 
-  @usableFromInline
+  @inlinable
   init(
     _ base: Base, 
     predicate: @escaping (Base.Element) async -> Bool
@@ -77,6 +78,7 @@ extension AsyncPrefixWhileSequence: AsyncSequence {
   public typealias AsyncIterator = Iterator
 
   /// The iterator that produces elements of the prefix-while sequence.
+  @frozen
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
     var predicateHasFailed = false
@@ -87,7 +89,7 @@ extension AsyncPrefixWhileSequence: AsyncSequence {
     @usableFromInline
     let predicate: (Base.Element) async -> Bool
 
-    @usableFromInline
+    @inlinable
     init(
       _ baseIterator: Base.AsyncIterator, 
       predicate: @escaping (Base.Element) async -> Bool

--- a/stdlib/public/Concurrency/AsyncThrowingCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingCompactMapSequence.swift
@@ -68,6 +68,7 @@ extension AsyncSequence {
 /// An asynchronous sequence that maps an error-throwing closure over the base
 /// sequence’s elements, omitting results that don't return a value.
 @available(SwiftStdlib 5.5, *)
+@frozen
 public struct AsyncThrowingCompactMapSequence<Base: AsyncSequence, ElementOfResult> {
   @usableFromInline
   let base: Base
@@ -75,7 +76,7 @@ public struct AsyncThrowingCompactMapSequence<Base: AsyncSequence, ElementOfResu
   @usableFromInline
   let transform: (Base.Element) async throws -> ElementOfResult?
 
-  @usableFromInline
+  @inlinable
   init(
     _ base: Base, 
     transform: @escaping (Base.Element) async throws -> ElementOfResult?
@@ -96,6 +97,7 @@ extension AsyncThrowingCompactMapSequence: AsyncSequence {
   public typealias AsyncIterator = Iterator
 
   /// The iterator that produces elements of the compact map sequence.
+  @frozen
   public struct Iterator: AsyncIteratorProtocol {
     public typealias Element = ElementOfResult
 
@@ -108,7 +110,7 @@ extension AsyncThrowingCompactMapSequence: AsyncSequence {
     @usableFromInline
     var finished = false
 
-    @usableFromInline
+    @inlinable
     init(
       _ baseIterator: Base.AsyncIterator, 
       transform: @escaping (Base.Element) async throws -> ElementOfResult?

--- a/stdlib/public/Concurrency/AsyncThrowingDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingDropWhileSequence.swift
@@ -66,6 +66,7 @@ extension AsyncSequence {
 /// given error-throwing closure returns false, after which it passes through
 /// all remaining elements.
 @available(SwiftStdlib 5.5, *)
+@frozen
 public struct AsyncThrowingDropWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -73,7 +74,7 @@ public struct AsyncThrowingDropWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let predicate: (Base.Element) async throws -> Bool
 
-  @usableFromInline
+  @inlinable
   init(
     _ base: Base, 
     predicate: @escaping (Base.Element) async throws -> Bool
@@ -94,6 +95,7 @@ extension AsyncThrowingDropWhileSequence: AsyncSequence {
   public typealias AsyncIterator = Iterator
 
   /// The iterator that produces elements of the drop-while sequence.
+  @frozen
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
@@ -107,7 +109,7 @@ extension AsyncThrowingDropWhileSequence: AsyncSequence {
     @usableFromInline
     var doneDropping = false
 
-    @usableFromInline
+    @inlinable
     init(
       _ baseIterator: Base.AsyncIterator, 
       predicate: @escaping (Base.Element) async throws -> Bool

--- a/stdlib/public/Concurrency/AsyncThrowingFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFilterSequence.swift
@@ -56,6 +56,7 @@ extension AsyncSequence {
 /// An asynchronous sequence that contains, in order, the elements of
 /// the base sequence that satisfy the given error-throwing predicate.
 @available(SwiftStdlib 5.5, *)
+@frozen
 public struct AsyncThrowingFilterSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -63,7 +64,7 @@ public struct AsyncThrowingFilterSequence<Base: AsyncSequence> {
   @usableFromInline
   let isIncluded: (Element) async throws -> Bool
 
-  @usableFromInline
+  @inlinable
   init(
     _ base: Base, 
     isIncluded: @escaping (Base.Element) async throws -> Bool
@@ -84,6 +85,7 @@ extension AsyncThrowingFilterSequence: AsyncSequence {
   public typealias AsyncIterator = Iterator
 
   /// The iterator that produces elements of the filter sequence.
+  @frozen
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
@@ -94,7 +96,7 @@ extension AsyncThrowingFilterSequence: AsyncSequence {
     @usableFromInline
     var finished = false
 
-    @usableFromInline
+    @inlinable
     init(
       _ baseIterator: Base.AsyncIterator,
       isIncluded: @escaping (Base.Element) async throws -> Bool

--- a/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
@@ -64,6 +64,7 @@ extension AsyncSequence {
 /// An asynchronous sequence that concatenates the results of calling a given
 /// error-throwing transformation with each element of this sequence.
 @available(SwiftStdlib 5.5, *)
+@frozen
 public struct AsyncThrowingFlatMapSequence<Base: AsyncSequence, SegmentOfResult: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -92,6 +93,7 @@ extension AsyncThrowingFlatMapSequence: AsyncSequence {
   public typealias AsyncIterator = Iterator
 
   /// The iterator that produces elements of the flat map sequence.
+  @frozen
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
     var baseIterator: Base.AsyncIterator

--- a/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
@@ -67,6 +67,7 @@ extension AsyncSequence {
 /// An asynchronous sequence that maps the given error-throwing closure over the
 /// asynchronous sequence’s elements.
 @available(SwiftStdlib 5.5, *)
+@frozen
 public struct AsyncThrowingMapSequence<Base: AsyncSequence, Transformed> {
   @usableFromInline
   let base: Base
@@ -74,7 +75,7 @@ public struct AsyncThrowingMapSequence<Base: AsyncSequence, Transformed> {
   @usableFromInline
   let transform: (Base.Element) async throws -> Transformed
 
-  @usableFromInline
+  @inlinable
   init(
     _ base: Base, 
     transform: @escaping (Base.Element) async throws -> Transformed
@@ -95,6 +96,7 @@ extension AsyncThrowingMapSequence: AsyncSequence {
   public typealias AsyncIterator = Iterator
 
   /// The iterator that produces elements of the map sequence.
+  @frozen
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
     var baseIterator: Base.AsyncIterator
@@ -105,7 +107,7 @@ extension AsyncThrowingMapSequence: AsyncSequence {
     @usableFromInline
     var finished = false
 
-    @usableFromInline
+    @inlinable
     init(
       _ baseIterator: Base.AsyncIterator, 
       transform: @escaping (Base.Element) async throws -> Transformed

--- a/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
@@ -62,6 +62,7 @@ extension AsyncSequence {
 /// elements of the base sequence that satisfy the given error-throwing
 /// predicate.
 @available(SwiftStdlib 5.5, *)
+@frozen
 public struct AsyncThrowingPrefixWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -69,7 +70,7 @@ public struct AsyncThrowingPrefixWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let predicate: (Base.Element) async throws -> Bool
 
-  @usableFromInline
+  @inlinable
   init(
     _ base: Base, 
     predicate: @escaping (Base.Element) async throws -> Bool
@@ -90,6 +91,7 @@ extension AsyncThrowingPrefixWhileSequence: AsyncSequence {
   public typealias AsyncIterator = Iterator
 
   /// The iterator that produces elements of the prefix-while sequence.
+  @frozen
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
     var predicateHasFailed = false
@@ -100,7 +102,7 @@ extension AsyncThrowingPrefixWhileSequence: AsyncSequence {
     @usableFromInline
     let predicate: (Base.Element) async throws -> Bool
 
-    @usableFromInline
+    @inlinable
     init(
       _ baseIterator: Base.AsyncIterator, 
       predicate: @escaping (Base.Element) async throws -> Bool


### PR DESCRIPTION
This grants AsyncSequence a huge perf boost for trivial operator application. Locally this benchmarks initially at about 3 million events per second to afterwards over 30 trillion events per second (this is an artificial speed - it is just reflecting the fact that the pipeline now takes zero time since it is already computed due to inlines)!

Previously the compiler could not see past the initialization and so any application of operators were blocked by the initialization of the operator. Now the initialization is visible and consequently the application can be directly inlined into any code-gen for usage.