### PR TITLE
[Swift Next] Updating TYPED_TEST_CASE macro

### DIFF
--- a/unittests/Basic/BlotMapVectorTest.cpp
+++ b/unittests/Basic/BlotMapVectorTest.cpp
@@ -367,7 +367,7 @@ typedef ::testing::Types<
         CtorTester, CtorTester, 4,
         llvm::SmallDenseMap<CtorTester, unsigned, 4, CtorTesterMapInfo>>>
     BlotMapVectorTestTypes;
-TYPED_TEST_CASE(BlotMapVectorTest, BlotMapVectorTestTypes);
+TYPED_TEST_SUITE(BlotMapVectorTest, BlotMapVectorTestTypes, );
 
 // Empty map tests
 TYPED_TEST(BlotMapVectorTest, EmptyIntMapTest) {


### PR DESCRIPTION
LLVM commit d4d80a2903c1d074008cac653cdb0b5fe39b8a00 updated gtest to
1.10. As a result, the macro for TYPED_TEST_CASE was updated to
TYPED_TEST_SUITE and it seems that a var args parameter was added
somewhere in there. As a result, needed to update that and provide an
empty var arg to the BlopMapVectorTest suite.

rdar://80329792