### PR TITLE
llvm_execute_on_thread API was removed

### DIFF
--- a/tools/SourceKit/lib/Support/Concurrency-libdispatch.cpp
+++ b/tools/SourceKit/lib/Support/Concurrency-libdispatch.cpp
@@ -15,6 +15,7 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/Threading.h"
+#include "llvm/Support/thread.h"
 
 #include <dispatch/dispatch.h>
 #include <Block.h>
@@ -103,8 +104,9 @@ static void executeBlock(void *Data) {
 }
 
 static void executeOnLargeStackThread(void *Data) {
-  static const size_t ThreadStackSize = 8 << 20; // 8 MB.
-  llvm::llvm_execute_on_thread(executeBlock, Data, ThreadStackSize);
+  static const unsigned ThreadStackSize = 8 << 20; // 8 MB.
+  llvm::thread Thread(llvm::Optional<unsigned>(ThreadStackSize), executeBlock, Data);
+  Thread.join();
 }
 
 static std::pair<void *, WorkQueue::DispatchFn>

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -30,6 +30,7 @@
 #include "llvm/Support/Regex.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/Threading.h"
+#include "llvm/Support/thread.h"
 #include "llvm/Support/raw_ostream.h"
 #include <fstream>
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
@@ -206,7 +207,8 @@ static void skt_main(skt_args *args);
 int main(int argc, const char **argv) {
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
     skt_args args = {argc, argv, 0};
-    llvm::llvm_execute_on_thread((void (*)(void *))skt_main, &args);
+    llvm::thread thread((void (*)(void *))skt_main, &args);
+    thread.join();
     exit(args.ret);
   });
 


### PR DESCRIPTION
The llvm_execute_on_thread API was removed and replaced with a thread
type in llvm commit 48c68a630e06666101c16aa371f9202a4a53438b. Replacing
calls.

rdar://80333906