### PR TITLE
[5.5][Runtime] Fix protocol conformance checks on pure ObjC classes.

### DIFF
--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -175,6 +175,11 @@ static MetadataResponse getSuperclassForMaybeIncompleteMetadata(
     // always fully set up, so we can just skip it and fetch the Subclass field.
     if (classMetadata->isTypeMetadata() && classMetadata->isArtificialSubclass())
       return {classMetadata->Superclass, MetadataState::Complete};
+
+    // Pure ObjC classes are already set up, and the code below will not be
+    // happy with them.
+    if (!classMetadata->isTypeMetadata())
+      return {classMetadata->Superclass, MetadataState::Complete};
 #endif
 
   MetadataState metadataState;


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/38318 to 5.5.

The getSuperclassForMaybeIncompleteMetadata function assumes Swift metadata, and can malfunction strangely when given a pure ObjC class. This is rare, as we usually get the Swift wrapper metadata instead, but possible when using calls like objc_copyClassList.

Fix this by checking for isTypeMetadata before doing anything that assumes Swift-metadata-ness.

rdar://80336030