### PR TITLE
[CSGen] Don't apply one-way requirement to typed patterns

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2246,7 +2246,7 @@ namespace {
         Type subPatternType = getTypeForPattern(
             subPattern,
             locator.withPathElement(LocatorPathElt::PatternMatch(subPattern)),
-            openedType, bindPatternVarsOneWay);
+            openedType, /*bindPatternVarsOneWay*/false);
 
         if (!subPatternType)
           return Type();

--- a/validation-test/Sema/type_checker_crashers_fixed/sr14893.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/sr14893.swift
@@ -1,0 +1,29 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5
+
+// REQUIRES: OS=macosx
+
+enum Category {
+case first
+}
+
+protocol View {}
+
+extension View {
+  func test(_ tag: Category) -> some View {
+    Image()
+  }
+}
+
+@resultBuilder struct ViewBuilder {
+  static func buildBlock<Content>(_ content: Content) -> Content where Content : View { fatalError() }
+}
+
+struct Image : View {
+}
+
+struct MyView {
+  @ViewBuilder var body: some View {
+    let icon: Category! = Category.first // expected-error {{using '!' is not allowed here; perhaps '?' was intended?}} {{23-24=?}}
+    Image().test(icon)
+  }
+}


### PR DESCRIPTION
Typed patterns are represented by a name and a fixed contextual
type, let's not use intermediary type variable and one-way constraint
as its type because that variable would be bound right away to
contextual type. Also setting type of a variable declaration
to a type variable when contextual type is IUO doesn't play well
with overload resolution because it expects an optional type for
declarations with IUO attribute.

Resolves: rdar://80271666

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
