### PR TITLE
[SE-0304] Align Task API implementation with the fourth revision of the proposal

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -70,6 +70,7 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   TaskGroup.swift
   TaskLocal.cpp
   TaskLocal.swift
+  TaskSleep.swift
   ThreadSanitizer.cpp
   Mutex.cpp
   AsyncStreamBuffer.swift

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -21,9 +21,6 @@ import Swift
 @frozen
 public struct UnownedJob {
   private var context: Builtin.Job
-
-  /// Starts running the task.
-  public func run() { }
 }
 
 /// A mechanism to interface

--- a/stdlib/public/Concurrency/SourceCompatibilityShims.swift
+++ b/stdlib/public/Concurrency/SourceCompatibilityShims.swift
@@ -190,65 +190,101 @@ extension Task where Failure == Never {
 
 @available(SwiftStdlib 5.5, *)
 extension TaskGroup {
-  @available(*, deprecated, renamed: "async(priority:operation:)")
+  @available(*, deprecated, renamed: "addTask(priority:operation:)")
   @_alwaysEmitIntoClient
   public mutating func add(
       priority: TaskPriority? = nil,
       operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) async -> Bool {
-    return self.asyncUnlessCancelled(priority: priority) {
+    return self.addTaskUnlessCancelled(priority: priority) {
       await operation()
     }
   }
 
-  @available(*, deprecated, renamed: "async(priority:operation:)")
+  @available(*, deprecated, renamed: "addTask(priority:operation:)")
   @_alwaysEmitIntoClient
   public mutating func spawn(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) {
-    async(priority: priority, operation: operation)
+    addTask(priority: priority, operation: operation)
   }
 
-  @available(*, deprecated, renamed: "asyncUnlessCancelled(priority:operation:)")
+  @available(*, deprecated, renamed: "addTaskUnlessCancelled(priority:operation:)")
   @_alwaysEmitIntoClient
   public mutating func spawnUnlessCancelled(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) -> Bool {
-    asyncUnlessCancelled(priority: priority, operation: operation)
+    addTaskUnlessCancelled(priority: priority, operation: operation)
+  }
+
+  @available(*, deprecated, renamed: "addTask(priority:operation:)")
+  @_alwaysEmitIntoClient
+  public mutating func async(
+    priority: TaskPriority? = nil,
+    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) {
+    addTask(priority: priority, operation: operation)
+  }
+
+  @available(*, deprecated, renamed: "addTaskUnlessCancelled(priority:operation:)")
+  @_alwaysEmitIntoClient
+  public mutating func asyncUnlessCancelled(
+    priority: TaskPriority? = nil,
+    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) -> Bool {
+    addTaskUnlessCancelled(priority: priority, operation: operation)
   }
 }
 
 @available(SwiftStdlib 5.5, *)
 extension ThrowingTaskGroup {
-  @available(*, deprecated, renamed: "async(priority:operation:)")
+  @available(*, deprecated, renamed: "addTask(priority:operation:)")
   @_alwaysEmitIntoClient
   public mutating func add(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) async -> Bool {
-    return self.asyncUnlessCancelled(priority: priority) {
+    return self.addTaskUnlessCancelled(priority: priority) {
       try await operation()
     }
   }
 
-  @available(*, deprecated, renamed: "async(priority:operation:)")
+  @available(*, deprecated, renamed: "addTask(priority:operation:)")
   @_alwaysEmitIntoClient
   public mutating func spawn(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) {
-    async(priority: priority, operation: operation)
+    addTask(priority: priority, operation: operation)
   }
 
-  @available(*, deprecated, renamed: "asyncUnlessCancelled(priority:operation:)")
+  @available(*, deprecated, renamed: "addTaskUnlessCancelled(priority:operation:)")
   @_alwaysEmitIntoClient
   public mutating func spawnUnlessCancelled(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) -> Bool {
-    asyncUnlessCancelled(priority: priority, operation: operation)
+    addTaskUnlessCancelled(priority: priority, operation: operation)
+  }
+
+  @available(*, deprecated, renamed: "addTask(priority:operation:)")
+  @_alwaysEmitIntoClient
+  public mutating func async(
+    priority: TaskPriority? = nil,
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) {
+    addTask(priority: priority, operation: operation)
+  }
+
+  @available(*, deprecated, renamed: "addTaskUnlessCancelled(priority:operation:)")
+  @_alwaysEmitIntoClient
+  public mutating func asyncUnlessCancelled(
+    priority: TaskPriority? = nil,
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) -> Bool {
+    addTaskUnlessCancelled(priority: priority, operation: operation)
   }
 }
 

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -641,28 +641,6 @@ func _runAsyncHandler(operation: @escaping () async -> ()) {
   )
 }
 
-// ==== Async Sleep ------------------------------------------------------------
-
-@available(SwiftStdlib 5.5, *)
-extension Task where Success == Never, Failure == Never {
-  /// Suspends the current task for _at least_ the given duration
-  /// in nanoseconds.
-  ///
-  /// Calling this method doesn't block the underlying thread.
-  ///
-  /// - Parameters:
-  ///   - duration: The time to sleep, in nanoseconds.
-  public static func sleep(_ duration: UInt64) async {
-    let currentTask = Builtin.getCurrentAsyncTask()
-    let priority = getJobFlags(currentTask).priority ?? Task.currentPriority._downgradeUserInteractive
-
-    return await Builtin.withUnsafeContinuation { (continuation: Builtin.RawUnsafeContinuation) -> Void in
-      let job = _taskCreateNullaryContinuationJob(priority: Int(priority.rawValue), continuation: continuation)
-      _enqueueJobGlobalWithDelay(duration, job)
-    }
-  }
-}
-
 // ==== Voluntary Suspension -----------------------------------------------------
 
 @available(SwiftStdlib 5.5, *)

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -759,6 +759,11 @@ public struct UnsafeCurrentTask {
   public var priority: TaskPriority {
     getJobFlags(_task).priority ?? .unspecified
   }
+
+  /// Cancel the current task.
+  public func cancel() {
+    _taskCancel(_task)
+  }
 }
 
 @available(SwiftStdlib 5.5, *)

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -217,11 +217,20 @@ public struct TaskPriority: RawRepresentable, Sendable {
   }
 
   public static let high: TaskPriority = .init(rawValue: 0x19)
-  public static let userInitiated: TaskPriority = high
-  public static let `default`: TaskPriority = .init(rawValue: 0x15)
+
+  @_alwaysEmitIntoClient
+  public static var medium: TaskPriority {
+    .init(rawValue: 0x15)
+  }
+
   public static let low: TaskPriority = .init(rawValue: 0x11)
+
+  public static let userInitiated: TaskPriority = high
   public static let utility: TaskPriority = low
   public static let background: TaskPriority = .init(rawValue: 0x09)
+
+  @available(*, deprecated, renamed: "medium")
+  public static let `default`: TaskPriority = .init(rawValue: 0x15)
 }
 
 @available(SwiftStdlib 5.5, *)

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -680,6 +680,7 @@ extension Task where Success == Never, Failure == Never {
   /// the executor immediately resumes execution of the same task.
   /// As such,
   /// this method isn't necessarily a way to avoid resource starvation.
+  @available(*, deprecated, renamed: "suspend()")
   public static func yield() async {
     let currentTask = Builtin.getCurrentAsyncTask()
     let priority = getJobFlags(currentTask).priority ?? Task.currentPriority._downgradeUserInteractive
@@ -688,6 +689,11 @@ extension Task where Success == Never, Failure == Never {
       let job = _taskCreateNullaryContinuationJob(priority: Int(priority.rawValue), continuation: continuation)
       _enqueueJobGlobal(job)
     }
+  }
+
+  @_alwaysEmitIntoClient
+  public static func suspend() async {
+    await yield()
   }
 }
 

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -103,7 +103,7 @@ public struct CancellationError: Error {
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_addCancellationHandler")
-func _taskAddCancellationHandler(handler: @Sendable () -> ()) -> UnsafeRawPointer /*CancellationNotificationStatusRecord*/
+func _taskAddCancellationHandler(handler: () -> Void) -> UnsafeRawPointer /*CancellationNotificationStatusRecord*/
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_removeCancellationHandler")

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -354,7 +354,14 @@ public struct TaskGroup<ChildTaskResult> {
   internal mutating func awaitAllRemainingTasks() async {
     while let _ = await next() {}
   }
-  
+
+  /// Wait for all remaining tasks in the task group to complete before
+  /// returning.
+  @_alwaysEmitIntoClient
+  public mutating func waitForAll() async {
+    await awaitAllRemainingTasks()
+  }
+
   /// A Boolean value that indicates whether the group has any remaining tasks.
   ///
   /// At the start of the body of a `withTaskGroup(of:returning:body:)` call,
@@ -442,6 +449,17 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
         }
       } catch {}
     }
+  }
+
+  public mutating func _waitForAll() async throws {
+    while let _ = try await next() { }
+  }
+
+  /// Wait for all remaining tasks in the task group to complete before
+  /// returning.
+  @_alwaysEmitIntoClient
+  public mutating func waitForAll() async throws {
+    while let _ = try await next() { }
   }
 
   /// Unconditionally create a child task in the group.

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -236,7 +236,7 @@ public struct TaskGroup<ChildTaskResult> {
   ///   - `true` if the operation was added to the group successfully,
   ///     `false` otherwise (e.g. because the group `isCancelled`)
   @_alwaysEmitIntoClient
-  public mutating func async(
+  public mutating func addTask(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) {
@@ -270,7 +270,7 @@ public struct TaskGroup<ChildTaskResult> {
   ///   - `true` if the operation was added to the group successfully,
   ///     `false` otherwise (e.g. because the group `isCancelled`)
   @_alwaysEmitIntoClient
-  public mutating func asyncUnlessCancelled(
+  public mutating func addTaskUnlessCancelled(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) -> Bool {
@@ -460,7 +460,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   ///   - `true` if the operation was added to the group successfully,
   ///     `false` otherwise (e.g. because the group `isCancelled`)
   @_alwaysEmitIntoClient
-  public mutating func async(
+  public mutating func addTask(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) {
@@ -494,7 +494,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   ///   - `true` if the operation was added to the group successfully,
   ///     `false` otherwise (e.g. because the group `isCancelled`)
   @_alwaysEmitIntoClient
-  public mutating func asyncUnlessCancelled(
+  public mutating func addTaskUnlessCancelled(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) -> Bool {

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -451,7 +451,8 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
     }
   }
 
-  public mutating func _waitForAll() async throws {
+  @usableFromInline
+  internal mutating func _waitForAll() async throws {
     while let _ = try await next() { }
   }
 

--- a/stdlib/public/Concurrency/TaskSleep.swift
+++ b/stdlib/public/Concurrency/TaskSleep.swift
@@ -76,7 +76,7 @@ extension Task where Success == Never, Failure == Never {
 
   /// Suspends the current task for _at least_ the given duration
   /// in nanoseconds, unless the task is cancelled. If the task is cancelled,
-  /// throws \c CancellationError.
+  /// throws \c CancellationError without waiting for the duration.
   ///
   /// This function does _not_ block the underlying thread.
   public static func sleep(nanoseconds duration: UInt64) async throws {

--- a/stdlib/public/Concurrency/TaskSleep.swift
+++ b/stdlib/public/Concurrency/TaskSleep.swift
@@ -32,45 +32,164 @@ extension Task where Success == Never, Failure == Never {
   /// sleep(nanoseconds:).
   private typealias SleepContinuation = UnsafeContinuation<(), Error>
 
+  /// Describes the state of a sleep() operation.
+  private enum SleepState {
+    /// The sleep continuation has not yet begun.
+    case notStarted
+
+    // The sleep continuation has been created and is available here.
+    case activeContinuation(SleepContinuation)
+
+    /// The sleep has finished.
+    case finished
+
+    /// The sleep was cancelled.
+    case cancelled
+
+    /// The sleep was cancelled before it even got started.
+    case cancelledBeforeStarted
+
+    /// Decode sleep state from the word of storage.
+    init(word: Builtin.Word) {
+      switch UInt(word) & 0x03 {
+      case 0:
+        let continuationBits = UInt(word) & ~0x03
+        if continuationBits == 0 {
+          self = .notStarted
+        } else {
+          let continuation = unsafeBitCast(
+            continuationBits, to: SleepContinuation.self)
+          self = .activeContinuation(continuation)
+        }
+
+      case 1:
+        self = .finished
+
+      case 2:
+        self = .cancelled
+
+      case 3:
+        self = .cancelledBeforeStarted
+
+      default:
+        fatalError("Bitmask failure")
+      }
+    }
+
+    /// Decode sleep state by loading from the given pointer
+    init(loading wordPtr: UnsafeMutablePointer<Builtin.Word>) {
+      self.init(word: Builtin.atomicload_seqcst_Word(wordPtr._rawValue))
+    }
+
+    /// Encode sleep state into a word of storage.
+    var word: UInt {
+      switch self {
+      case .notStarted:
+        return 0
+
+      case .activeContinuation(let continuation):
+        let continuationBits = unsafeBitCast(continuation, to: UInt.self)
+        return continuationBits
+
+      case .finished:
+        return 1
+
+      case .cancelled:
+        return 2
+
+      case .cancelledBeforeStarted:
+        return 3
+      }
+    }
+  }
+
   /// Called when the sleep(nanoseconds:) operation woke up without being
   /// cancelled.
   private static func onSleepWake(
-      _ wordPtr: UnsafeMutablePointer<Builtin.Word>,
-      _ continuation: UnsafeContinuation<(), Error>
+      _ wordPtr: UnsafeMutablePointer<Builtin.Word>
   ) {
-    // Indicate that we've finished by putting a "1" into the flag word.
-    let (_, won) = Builtin.cmpxchg_seqcst_seqcst_Word(
-        wordPtr._rawValue,
-        UInt(0)._builtinWordValue,
-        UInt(1)._builtinWordValue)
+    while true {
+      let state = SleepState(loading: wordPtr)
+      switch state {
+      case .notStarted:
+        fatalError("Cannot wake before we even started")
 
-    if Bool(_builtinBooleanLiteral: won) {
-      // The sleep finished, invoke the continuation.
-      continuation.resume()
-    } else {
-      // The task was cancelled first, which means the continuation was
-      // called by the cancellation handler. We need to deallocate up the flag
-      // word, because it was left over for this task to complete.
-      wordPtr.deallocate()
+      case .activeContinuation(let continuation):
+        // We have an active continuation, so try to transition to the
+        // "finished" state.
+        let (_, won) = Builtin.cmpxchg_seqcst_seqcst_Word(
+            wordPtr._rawValue,
+            state.word._builtinWordValue,
+            SleepState.finished.word._builtinWordValue)
+        if Bool(_builtinBooleanLiteral: won) {
+          // The sleep finished, so invoke the continuation: we're done.
+          continuation.resume()
+          return
+        }
+
+        // Try again!
+        continue
+
+      case .finished:
+        fatalError("Already finished normally, can't do that again")
+
+      case .cancelled:
+        // The task was cancelled, which means the continuation was
+        // called by the cancellation handler. We need to deallocate the flag
+        // word, because it was left over for this task to complete.
+        wordPtr.deallocate()
+        return
+
+      case .cancelledBeforeStarted:
+        // Nothing to do;
+        return
+      }
     }
   }
 
   /// Called when the sleep(nanoseconds:) operation has been cancelled before
   /// the sleep completed.
   private static func onSleepCancel(
-      _ wordPtr: UnsafeMutablePointer<Builtin.Word>,
-      _ continuation: UnsafeContinuation<(), Error>
+      _ wordPtr: UnsafeMutablePointer<Builtin.Word>
   ) {
-    // Indicate that we've finished by putting a "2" into the flag word.
-    let (_, won) = Builtin.cmpxchg_seqcst_seqcst_Word(
-        wordPtr._rawValue,
-        UInt(0)._builtinWordValue,
-        UInt(2)._builtinWordValue)
+    while true {
+      let state = SleepState(loading: wordPtr)
+      switch state {
+      case .notStarted:
+        // We haven't started yet, so try to transition to the cancelled-before
+        // started state.
+        let (_, won) = Builtin.cmpxchg_seqcst_seqcst_Word(
+            wordPtr._rawValue,
+            state.word._builtinWordValue,
+            SleepState.cancelledBeforeStarted.word._builtinWordValue)
+        if Bool(_builtinBooleanLiteral: won) {
+          return
+        }
 
-    if Bool(_builtinBooleanLiteral: won) {
-      // We recorded the task cancellation before the sleep finished, so
-      // invoke the continuation with a the cancellation error.
-      continuation.resume(throwing: _Concurrency.CancellationError())
+        // Try again!
+        continue
+
+      case .activeContinuation(let continuation):
+        // We have an active continuation, so try to transition to the
+        // "cancelled" state.
+        let (_, won) = Builtin.cmpxchg_seqcst_seqcst_Word(
+            wordPtr._rawValue,
+            state.word._builtinWordValue,
+            SleepState.cancelled.word._builtinWordValue)
+        if Bool(_builtinBooleanLiteral: won) {
+          // We recorded the task cancellation before the sleep finished, so
+          // invoke the continuation with the cancellation error.
+          continuation.resume(throwing: _Concurrency.CancellationError())
+          return
+        }
+
+        // Try again!
+        continue
+
+      case .finished, .cancelled, .cancelledBeforeStarted:
+        // The operation already finished, so there is nothing more to do.
+        return
+      }
     }
   }
 
@@ -80,64 +199,95 @@ extension Task where Success == Never, Failure == Never {
   ///
   /// This function does _not_ block the underlying thread.
   public static func sleep(nanoseconds duration: UInt64) async throws {
-    // If the task was already cancelled, go ahead and throw now.
-    try checkCancellation()
+    // Allocate storage for the storage word.
+    let wordPtr = UnsafeMutablePointer<Builtin.Word>.allocate(capacity: 1)
 
-    // Allocate storage for the flag word and continuation.
-    let wordPtr = UnsafeMutablePointer<Builtin.Word>.allocate(capacity: 2)
-
-    // Initialize the flag word to 0, which means the continuation has not
-    // executed.
+    // Initialize the flag word to "not started", which means the continuation
+    // has neither been created nor completed.
     Builtin.atomicstore_seqcst_Word(
-        wordPtr._rawValue, UInt(0)._builtinWordValue)
-
-    // A pointer to the storage continuation. Also initialize it to zero, to
-    // indicate that there is no continuation.
-    let continuationPtr = wordPtr + 1
-    Builtin.atomicstore_seqcst_Word(
-      continuationPtr._rawValue, UInt(0)._builtinWordValue)
+        wordPtr._rawValue, SleepState.notStarted.word._builtinWordValue)
 
     do {
       // Install a cancellation handler to resume the continuation by
       // throwing CancellationError.
       try await withTaskCancellationHandler {
         let _: () = try await withUnsafeThrowingContinuation { continuation in
-          // Stash the continuation so the cancellation handler can see it.
-          Builtin.atomicstore_seqcst_Word(
-            continuationPtr._rawValue,
-            unsafeBitCast(continuation, to: Builtin.Word.self))
+          while true {
+            let state = SleepState(loading: wordPtr)
+            switch state {
+            case .notStarted:
+              // The word that describes the active continuation state.
+              let continuationWord =
+                SleepState.activeContinuation(continuation).word
 
-          // Create a task that resumes the continuation normally if it
-          // finishes first. Enqueue it directly with the delay, so it fires
-          // when we're done sleeping.
-          let sleepTaskFlags = taskCreateFlags(
-            priority: nil, isChildTask: false, copyTaskLocals: false,
-            inheritContext: false, enqueueJob: false,
-            addPendingGroupTaskUnconditionally: false)
-          let (sleepTask, _) = Builtin.createAsyncTask(sleepTaskFlags) {
-            onSleepWake(wordPtr, continuation)
+              // Try to swap in the continuation word.
+              let (_, won) = Builtin.cmpxchg_seqcst_seqcst_Word(
+                  wordPtr._rawValue,
+                  state.word._builtinWordValue,
+                  continuationWord._builtinWordValue)
+              if !Bool(_builtinBooleanLiteral: won) {
+                // Keep trying!
+                continue
+              }
+
+              // Create a task that resumes the continuation normally if it
+              // finishes first. Enqueue it directly with the delay, so it fires
+              // when we're done sleeping.
+              let sleepTaskFlags = taskCreateFlags(
+                priority: nil, isChildTask: false, copyTaskLocals: false,
+                inheritContext: false, enqueueJob: false,
+                addPendingGroupTaskUnconditionally: false)
+              let (sleepTask, _) = Builtin.createAsyncTask(sleepTaskFlags) {
+                onSleepWake(wordPtr)
+              }
+              _enqueueJobGlobalWithDelay(
+                  duration, Builtin.convertTaskToJob(sleepTask))
+              return
+
+            case .activeContinuation, .finished:
+              fatalError("Impossible to have multiple active continuations")
+
+            case .cancelled:
+              fatalError("Impossible to have cancelled before we began")
+
+            case .cancelledBeforeStarted:
+              // Finish the continuation normally. We'll throw later, after
+              // we clean up.
+              continuation.resume()
+              return
           }
-          _enqueueJobGlobalWithDelay(
-              duration, Builtin.convertTaskToJob(sleepTask))
+        }
         }
       } onCancel: {
-        let continuationWord = continuationPtr.pointee
-        if UInt(continuationWord) != 0 {
-          // Try to cancel, which will resume the continuation by throwing a
-          // CancellationError if the continuation hasn't already been resumed.
-          continuationPtr.withMemoryRebound(
-              to: SleepContinuation.self, capacity: 1) {
-            onSleepCancel(wordPtr, $0.pointee)
-          }
-        }
+        onSleepCancel(wordPtr)
+      }
+
+      // Determine whether we got cancelled before we even started.
+      let cancelledBeforeStarted: Bool
+      switch SleepState(loading: wordPtr) {
+      case .notStarted, .activeContinuation, .cancelled:
+        fatalError("Invalid state for non-cancelled sleep task")
+
+      case .cancelledBeforeStarted:
+        cancelledBeforeStarted = true
+
+      case .finished:
+        cancelledBeforeStarted = false
       }
 
       // We got here without being cancelled, so deallocate the storage for
       // the flag word and continuation.
       wordPtr.deallocate()
+
+      // If we got cancelled before we even started, through the cancellation
+      // error now.
+      if cancelledBeforeStarted {
+        throw _Concurrency.CancellationError()
+      }
     } catch {
       // The task was cancelled; propagate the error. The "on wake" task is
-      // responsible for deallocating the flag word.
+      // responsible for deallocating the flag word and continuation, if it's
+      // still running.
       throw error
     }
   }

--- a/stdlib/public/Concurrency/TaskSleep.swift
+++ b/stdlib/public/Concurrency/TaskSleep.swift
@@ -1,0 +1,144 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import Swift
+@_implementationOnly import _SwiftConcurrencyShims
+
+@available(SwiftStdlib 5.5, *)
+extension Task where Success == Never, Failure == Never {
+  /// Suspends the current task for _at least_ the given duration
+  /// in nanoseconds.
+  ///
+  /// This function does _not_ block the underlying thread.
+  public static func sleep(_ duration: UInt64) async {
+    let currentTask = Builtin.getCurrentAsyncTask()
+    let priority = getJobFlags(currentTask).priority ?? Task.currentPriority._downgradeUserInteractive
+
+    return await Builtin.withUnsafeContinuation { (continuation: Builtin.RawUnsafeContinuation) -> Void in
+      let job = _taskCreateNullaryContinuationJob(priority: Int(priority.rawValue), continuation: continuation)
+      _enqueueJobGlobalWithDelay(duration, job)
+    }
+  }
+
+  /// The type of continuation used in the implementation of
+  /// sleep(nanoseconds:).
+  private typealias SleepContinuation = UnsafeContinuation<(), Error>
+
+  /// Called when the sleep(nanoseconds:) operation woke up without being
+  /// cancelled.
+  private static func onSleepWake(
+      _ wordPtr: UnsafeMutablePointer<Builtin.Word>,
+      _ continuation: UnsafeContinuation<(), Error>
+  ) {
+    // Indicate that we've finished by putting a "1" into the flag word.
+    let (_, won) = Builtin.cmpxchg_seqcst_seqcst_Word(
+        wordPtr._rawValue,
+        UInt(0)._builtinWordValue,
+        UInt(1)._builtinWordValue)
+
+    if Bool(_builtinBooleanLiteral: won) {
+      // The sleep finished, invoke the continuation.
+      continuation.resume()
+    } else {
+      // The task was cancelled first, which means the continuation was
+      // called by the cancellation handler. We need to deallocate up the flag
+      // word, because it was left over for this task to complete.
+      wordPtr.deallocate()
+    }
+  }
+
+  /// Called when the sleep(nanoseconds:) operation has been cancelled before
+  /// the sleep completed.
+  private static func onSleepCancel(
+      _ wordPtr: UnsafeMutablePointer<Builtin.Word>,
+      _ continuation: UnsafeContinuation<(), Error>
+  ) {
+    // Indicate that we've finished by putting a "2" into the flag word.
+    let (_, won) = Builtin.cmpxchg_seqcst_seqcst_Word(
+        wordPtr._rawValue,
+        UInt(0)._builtinWordValue,
+        UInt(2)._builtinWordValue)
+
+    if Bool(_builtinBooleanLiteral: won) {
+      // We recorded the task cancellation before the sleep finished, so
+      // invoke the continuation with a the cancellation error.
+      continuation.resume(throwing: _Concurrency.CancellationError())
+    }
+  }
+
+  /// Suspends the current task for _at least_ the given duration
+  /// in nanoseconds, unless the task is cancelled. If the task is cancelled,
+  /// throws \c CancellationError.
+  ///
+  /// This function does _not_ block the underlying thread.
+  public static func sleep(nanoseconds duration: UInt64) async throws {
+    // If the task was already cancelled, go ahead and throw now.
+    try checkCancellation()
+
+    // Allocate storage for the flag word and continuation.
+    let wordPtr = UnsafeMutablePointer<Builtin.Word>.allocate(capacity: 2)
+
+    // Initialize the flag word to 0, which means the continuation has not
+    // executed.
+    Builtin.atomicstore_seqcst_Word(
+        wordPtr._rawValue, UInt(0)._builtinWordValue)
+
+    // A pointer to the storage continuation. Also initialize it to zero, to
+    // indicate that there is no continuation.
+    let continuationPtr = wordPtr + 1
+    Builtin.atomicstore_seqcst_Word(
+      continuationPtr._rawValue, UInt(0)._builtinWordValue)
+
+    do {
+      // Install a cancellation handler to resume the continuation by
+      // throwing CancellationError.
+      try await withTaskCancellationHandler {
+        let _: () = try await withUnsafeThrowingContinuation { continuation in
+          // Stash the continuation so the cancellation handler can see it.
+          Builtin.atomicstore_seqcst_Word(
+            continuationPtr._rawValue,
+            unsafeBitCast(continuation, to: Builtin.Word.self))
+
+          // Create a task that resumes the continuation normally if it
+          // finishes first. Enqueue it directly with the delay, so it fires
+          // when we're done sleeping.
+          let sleepTaskFlags = taskCreateFlags(
+            priority: nil, isChildTask: false, copyTaskLocals: false,
+            inheritContext: false, enqueueJob: false,
+            addPendingGroupTaskUnconditionally: false)
+          let (sleepTask, _) = Builtin.createAsyncTask(sleepTaskFlags) {
+            onSleepWake(wordPtr, continuation)
+          }
+          _enqueueJobGlobalWithDelay(
+              duration, Builtin.convertTaskToJob(sleepTask))
+        }
+      } onCancel: {
+        let continuationWord = continuationPtr.pointee
+        if UInt(continuationWord) != 0 {
+          // Try to cancel, which will resume the continuation by throwing a
+          // CancellationError if the continuation hasn't already been resumed.
+          continuationPtr.withMemoryRebound(
+              to: SleepContinuation.self, capacity: 1) {
+            onSleepCancel(wordPtr, $0.pointee)
+          }
+        }
+      }
+
+      // We got here without being cancelled, so deallocate the storage for
+      // the flag word and continuation.
+      wordPtr.deallocate()
+    } catch {
+      // The task was cancelled; propagate the error. The "on wake" task is
+      // responsible for deallocating the flag word.
+      throw error
+    }
+  }
+}

--- a/test/Concurrency/Runtime/async_task_sleep_cancel.swift
+++ b/test/Concurrency/Runtime/async_task_sleep_cancel.swift
@@ -19,6 +19,7 @@ import Dispatch
     // CHECK: Starting!
     print("Starting!")
     await testSleepFinished()
+    await testSleepMomentary()
     await testSleepCancelledBeforeStarted()
     await testSleepCancelled()
   }
@@ -35,6 +36,17 @@ import Dispatch
 
     // assert that at least the specified time passed since calling `sleep`
     assert(stop >= (start + .nanoseconds(pause)))
+
+    // CHECK-NEXT: Wakey wakey!
+    print("Wakey wakey!")
+  }
+
+  static func testSleepMomentary() async {
+    // CHECK-NEXT: Testing sleep that completes instantly
+    print("Testing sleep that completes instantly")
+
+    // try! will fail if the task got cancelled (which shouldn't happen).
+    try! await Task.sleep(nanoseconds: 0)
 
     // CHECK-NEXT: Wakey wakey!
     print("Wakey wakey!")

--- a/test/Concurrency/Runtime/async_task_sleep_cancel.swift
+++ b/test/Concurrency/Runtime/async_task_sleep_cancel.swift
@@ -1,0 +1,110 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch -parse-as-library) | %FileCheck %s --dump-input always
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import _Concurrency
+// FIXME: should not depend on Dispatch
+import Dispatch
+
+@available(SwiftStdlib 5.5, *)
+@main struct Main {
+  static let pause = 500_000_000 // 500ms
+
+  static func main() async {
+    // CHECK: Starting!
+    print("Starting!")
+    await testSleepFinished()
+    await testSleepCancelledBeforeStarted()
+    await testSleepCancelled()
+  }
+
+  static func testSleepFinished() async {
+    // CHECK-NEXT: Testing sleep that completes
+    print("Testing sleep that completes")
+    let start = DispatchTime.now()
+
+    // try! will fail if the task got cancelled (which shouldn't happen).
+    try! await Task.sleep(nanoseconds: UInt64(pause))
+
+    let stop = DispatchTime.now()
+
+    // assert that at least the specified time passed since calling `sleep`
+    assert(stop >= (start + .nanoseconds(pause)))
+
+    // CHECK-NEXT: Wakey wakey!
+    print("Wakey wakey!")
+  }
+
+  static func testSleepCancelledBeforeStarted() async {
+    // CHECK-NEXT: Testing sleep that gets cancelled before it starts
+    print("Testing sleep that gets cancelled before it starts")
+    let start = DispatchTime.now()
+
+    let sleepyTask = Task {
+      try await Task.sleep(nanoseconds: UInt64(pause))
+    }
+
+    do {
+      sleepyTask.cancel()
+      try await sleepyTask.value
+
+      fatalError("sleep(nanoseconds:) should have thrown CancellationError")
+    } catch is CancellationError {
+      // CHECK-NEXT: Caught the cancellation error
+      print("Caught the cancellation error")
+
+      let stop = DispatchTime.now()
+
+      // assert that we stopped early.
+      assert(stop < (start + .nanoseconds(pause)))
+    } catch {
+      fatalError("sleep(nanoseconds:) threw some other error: \(error)")
+    }
+
+    // CHECK-NEXT: Cancelled!
+    print("Cancelled!")
+  }
+
+  static func testSleepCancelled() async {
+    // CHECK-NEXT: Testing sleep that gets cancelled before it completes
+    print("Testing sleep that gets cancelled before it completes")
+    let start = DispatchTime.now()
+
+    let sleepyTask = Task {
+      try await Task.sleep(nanoseconds: UInt64(pause))
+    }
+
+    do {
+      let waiterTask = Task {
+        try await sleepyTask.value
+      }
+
+      let cancellerTask = Task {
+        await Task.sleep(UInt64(pause / 2))
+        sleepyTask.cancel()
+      }
+
+      try await waiterTask.value
+
+      fatalError("sleep(nanoseconds:) should have thrown CancellationError")
+    } catch is CancellationError {
+      // CHECK-NEXT: Caught the cancellation error
+      print("Caught the cancellation error")
+
+      let stop = DispatchTime.now()
+
+      // assert that we stopped early.
+      assert(stop < (start + .nanoseconds(pause)))
+    } catch {
+      fatalError("sleep(nanoseconds:) threw some other error: \(error)")
+    }
+
+    // CHECK-NEXT: Cancelled!
+    print("Cancelled!")
+  }
+}

--- a/test/Concurrency/async_task_groups.swift
+++ b/test/Concurrency/async_task_groups.swift
@@ -22,11 +22,11 @@ func asyncThrowsOnCancel() async throws -> Int {
 @available(SwiftStdlib 5.5, *)
 func test_taskGroup_add() async throws -> Int {
   try await withThrowingTaskGroup(of: Int.self) { group in
-    group.async {
+    group.addTask {
       await asyncFunc()
     }
 
-    group.async {
+    group.addTask {
       await asyncFunc()
     }
 
@@ -51,9 +51,9 @@ func boom() async throws -> Int { throw Boom() }
 func first_allMustSucceed() async throws {
 
   let first: Int = try await withThrowingTaskGroup(of: Int.self) { group in
-    group.async { await work() }
-    group.async { await work() }
-    group.async { try await boom() }
+    group.addTask { await work() }
+    group.addTask { await work() }
+    group.addTask { try await boom() }
 
     if let first = try await group.next() {
       return first
@@ -72,9 +72,9 @@ func first_ignoreFailures() async throws {
   @Sendable func boom() async throws -> Int { throw Boom() }
 
   let first: Int = try await withThrowingTaskGroup(of: Int.self) { group in
-    group.async { await work() }
-    group.async { await work() }
-    group.async {
+    group.addTask { await work() }
+    group.addTask { await work() }
+    group.addTask {
       do {
         return try await boom()
       } catch {
@@ -121,7 +121,7 @@ func test_taskGroup_quorum_thenCancel() async {
   func gatherQuorum(followers: [Follower]) async -> Bool {
     try! await withThrowingTaskGroup(of: Vote.self) { group in
       for follower in followers {
-        group.async { try await follower.vote() }
+        group.addTask { try await follower.vote() }
       }
 
       defer {
@@ -192,7 +192,7 @@ extension Collection where Self: Sendable, Element: Sendable, Self.Index: Sendab
       var submitted = 0
 
       func submitNext() async throws {
-        group.async { [submitted,i] in
+        group.addTask { [submitted,i] in
           let value = try await transform(self[i])
           return SendableTuple2(submitted, value)
         }


### PR DESCRIPTION
**Explanation**: Task API changes to align the implementation with the fourth revision of the [SE-0304 "Structured Concurrency](https://github.com/apple/swift-evolution/blob/main/proposals/0304-structured-concurrency.md). Most of the changes are superficial (e.g., renames, trivial additions) and have no ABI impact. The addition of cancellable `Task.sleep(nanoseconds:)` is a bit more involved because there's some subtle atomics manipulations going on, but the changes are limited to new API.
**Scope**: Affects programs that use Swift Concurrency. They'll get new "deprecation" warnings to help them move to the new APIs.
**Radar/SR Issue**: rdar://80339563
**Risk**: Low.
**Testing**: PR testing and CI on main.
**Original PR**: https://github.com/apple/swift/pull/38306
