### PR TITLE
[Swift Rebranch] Cherry-picking swift changes from next branch

### DIFF
--- a/include/swift/AST/TBDGenRequests.h
+++ b/include/swift/AST/TBDGenRequests.h
@@ -70,7 +70,7 @@ public:
   const TBDGenOptions &getOptions() const { return Opts; }
   TBDGenOptions &getOptions() { return Opts; }
 
-  const llvm::DataLayout &getDataLayout() const;
+  const StringRef getDataLayoutString() const;
   const llvm::Triple &getTarget() const;
 
   bool operator==(const TBDGenDescriptor &other) const;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1170,7 +1170,7 @@ ClangImporter::create(ASTContext &ctx,
   //
   // FIXME: We shouldn't need to do this, the target should be immutable once
   // created. This complexity should be lifted elsewhere.
-  instance.getTarget().adjust(instance.getLangOpts());
+  instance.getTarget().adjust(clangDiags, instance.getLangOpts());
 
   if (importerOpts.Mode == ClangImporterOptions::Modes::EmbedBitcode)
     return importer;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1167,14 +1167,14 @@ makeBitFieldAccessors(ClangImporter::Implementation &Impl,
     
     auto cGetterSelfExpr = new (Ctx) clang::DeclRefExpr(Ctx, cGetterSelf, false,
                                                         recordType,
-                                                        clang::VK_RValue,
+                                                        clang::VK_PRValue,
                                                         clang::SourceLocation());
     auto cGetterExpr = clang::MemberExpr::CreateImplicit(Ctx,
                                                          cGetterSelfExpr,
                                                          /*isarrow=*/ false,
                                                          fieldDecl,
                                                          fieldType,
-                                                         clang::VK_RValue,
+                                                         clang::VK_PRValue,
                                                          clang::OK_BitField);
 
     
@@ -1211,7 +1211,7 @@ makeBitFieldAccessors(ClangImporter::Implementation &Impl,
     
     auto cSetterSelfExpr = new (Ctx) clang::DeclRefExpr(Ctx, cSetterSelf, false,
                                                         recordPointerType,
-                                                        clang::VK_RValue,
+                                                        clang::VK_PRValue,
                                                         clang::SourceLocation());
     
     auto cSetterMemberExpr = clang::MemberExpr::CreateImplicit(Ctx,
@@ -1224,7 +1224,7 @@ makeBitFieldAccessors(ClangImporter::Implementation &Impl,
     
     auto cSetterValueExpr = new (Ctx) clang::DeclRefExpr(Ctx, cSetterValue, false,
                                                          fieldType,
-                                                         clang::VK_RValue,
+                                                         clang::VK_PRValue,
                                                          clang::SourceLocation());
 
     auto cSetterExpr = clang::BinaryOperator::Create(Ctx,
@@ -1232,7 +1232,7 @@ makeBitFieldAccessors(ClangImporter::Implementation &Impl,
                                                      cSetterValueExpr,
                                                      clang::BO_Assign,
                                                      fieldType,
-                                                     clang::VK_RValue,
+                                                     clang::VK_PRValue,
                                                      clang::OK_Ordinary,
                                                      clang::SourceLocation(),
                                                      clang::FPOptionsOverride());

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -3539,7 +3539,7 @@ void Driver::printHelp(bool ShowHidden) const {
   if (!ShowHidden)
     ExcludedFlagsBitmask |= HelpHidden;
 
-  getOpts().PrintHelp(llvm::outs(), Name.c_str(), "Swift compiler",
+  getOpts().printHelp(llvm::outs(), Name.c_str(), "Swift compiler",
                       IncludedFlagsBitmask, ExcludedFlagsBitmask,
                       /*ShowAllAliases*/false);
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -2108,7 +2108,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
       Invocation.getFrontendOptions().PrintHelpHidden ? 0 :
                                                         llvm::opt::HelpHidden;
     std::unique_ptr<llvm::opt::OptTable> Options(createSwiftOptTable());
-    Options->PrintHelp(llvm::outs(), displayName(MainExecutablePath).c_str(),
+    Options->printHelp(llvm::outs(), displayName(MainExecutablePath).c_str(),
                        "Swift frontend", IncludedFlagsBitmask,
                        ExcludedFlagsBitmask, /*ShowAllAliases*/false);
     return finishDiagProcessing(0, /*verifierEnabled*/ false);

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -824,7 +824,7 @@ static void embedBitcode(llvm::Module *M, const IRGenOptions &Opts)
 
   // Save llvm.compiler.used and remove it.
   SmallVector<llvm::Constant*, 2> UsedArray;
-  SmallSet<llvm::GlobalValue*, 4> UsedGlobals;
+  SmallVector<llvm::GlobalValue*, 4> UsedGlobals;
   auto *UsedElementType =
     llvm::Type::getInt8Ty(M->getContext())->getPointerTo(0);
   llvm::GlobalVariable *Used =

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1533,7 +1533,7 @@ bool swift::performLLVM(const IRGenOptions &Opts, ASTContext &Ctx,
 
   auto *Clang = static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
   // Use clang's datalayout.
-  Module->setDataLayout(Clang->getTargetInfo().getDataLayout());
+  Module->setDataLayout(Clang->getTargetInfo().getDataLayoutString());
 
   embedBitcode(Module, Opts);
   if (::performLLVM(Opts, Ctx.Diags, nullptr, nullptr, Module,

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -192,19 +192,18 @@ static void sanityCheckStdlib(IRGenModule &IGM) {
 
 IRGenModule::IRGenModule(IRGenerator &irgen,
                          std::unique_ptr<llvm::TargetMachine> &&target,
-                         SourceFile *SF,
-                         StringRef ModuleName, StringRef OutputFilename,
+                         SourceFile *SF, StringRef ModuleName,
+                         StringRef OutputFilename,
                          StringRef MainInputFilenameForDebugInfo,
                          StringRef PrivateDiscriminator)
-    : LLVMContext(new llvm::LLVMContext()),
-      IRGen(irgen), Context(irgen.SIL.getASTContext()),
+    : LLVMContext(new llvm::LLVMContext()), IRGen(irgen),
+      Context(irgen.SIL.getASTContext()),
       // The LLVMContext (and the IGM itself) will get deleted by the IGMDeleter
       // as long as the IGM is registered with the IRGenerator.
-      ClangCodeGen(createClangCodeGenerator(Context, *LLVMContext,
-                                            irgen.Opts,
+      ClangCodeGen(createClangCodeGenerator(Context, *LLVMContext, irgen.Opts,
                                             ModuleName, PrivateDiscriminator)),
       Module(*ClangCodeGen->GetModule()),
-      DataLayout(irgen.getClangDataLayout()),
+      DataLayout(irgen.getClangDataLayoutString()),
       Triple(irgen.getEffectiveClangTriple()), TargetMachine(std::move(target)),
       silConv(irgen.SIL), OutputFilename(OutputFilename),
       MainInputFilenameForDebugInfo(MainInputFilenameForDebugInfo),
@@ -1750,12 +1749,12 @@ llvm::Triple IRGenerator::getEffectiveClangTriple() {
   return llvm::Triple(CI->getTargetInfo().getTargetOpts().Triple);
 }
 
-const llvm::DataLayout &IRGenerator::getClangDataLayout() {
+const llvm::StringRef IRGenerator::getClangDataLayoutString() {
   return static_cast<ClangImporter *>(
              SIL.getASTContext().getClangModuleLoader())
       ->getTargetInfo()
-      .getDataLayout();
-  }
+      .getDataLayoutString();
+}
 
 TypeExpansionContext IRGenModule::getMaximalTypeExpansionContext() const {
   return TypeExpansionContext::maximal(getSwiftModule(),

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -519,7 +519,7 @@ public:
   /// Return the effective triple used by clang.
   llvm::Triple getEffectiveClangTriple();
 
-  const llvm::DataLayout &getClangDataLayout();
+  const llvm::StringRef getClangDataLayoutString();
 };
 
 class ConstantReference {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -78,6 +78,10 @@ using llvm::BCBlockRAII;
 
 ASTContext &SerializerBase::getASTContext() const { return M->getASTContext(); }
 
+static StringRef withNullAsEmptyStringRef(const char *data) {
+  return StringRef(data ? data : "");
+}
+
 /// Used for static_assert.
 static constexpr bool declIDFitsIn32Bits() {
   using Int32Info = std::numeric_limits<uint32_t>;
@@ -5554,7 +5558,7 @@ void swift::serializeToBuffers(
   std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
   const SILModule *M) {
 
-  assert(!StringRef::withNullAsEmpty(options.OutputPath).empty());
+  assert(!withNullAsEmptyStringRef(options.OutputPath).empty());
   {
     FrontendStatsTracer tracer(getContext(DC).Stats,
                                "Serialization, swiftmodule, to buffer");
@@ -5575,7 +5579,7 @@ void swift::serializeToBuffers(
                         std::move(buf), options.OutputPath);
   }
 
-  if (!StringRef::withNullAsEmpty(options.DocOutputPath).empty()) {
+  if (!withNullAsEmptyStringRef(options.DocOutputPath).empty()) {
     FrontendStatsTracer tracer(getContext(DC).Stats,
                                "Serialization, swiftdoc, to buffer");
     llvm::SmallString<1024> buf;
@@ -5592,7 +5596,7 @@ void swift::serializeToBuffers(
                            std::move(buf), options.DocOutputPath);
   }
 
-  if (!StringRef::withNullAsEmpty(options.SourceInfoOutputPath).empty()) {
+  if (!withNullAsEmptyStringRef(options.SourceInfoOutputPath).empty()) {
     FrontendStatsTracer tracer(getContext(DC).Stats,
                                "Serialization, swiftsourceinfo, to buffer");
     llvm::SmallString<1024> buf;
@@ -5614,12 +5618,12 @@ void swift::serialize(ModuleOrSourceFile DC,
                       const SerializationOptions &options,
                       const SILModule *M,
                       const fine_grained_dependencies::SourceFileDepGraph *DG) {
-  assert(!StringRef::withNullAsEmpty(options.OutputPath).empty());
+  assert(!withNullAsEmptyStringRef(options.OutputPath).empty());
 
   if (StringRef(options.OutputPath) == "-") {
     // Special-case writing to stdout.
     Serializer::writeToStream(llvm::outs(), DC, M, options, DG);
-    assert(StringRef::withNullAsEmpty(options.DocOutputPath).empty());
+    assert(withNullAsEmptyStringRef(options.DocOutputPath).empty());
     return;
   }
 
@@ -5634,7 +5638,7 @@ void swift::serialize(ModuleOrSourceFile DC,
   if (hadError)
     return;
 
-  if (!StringRef::withNullAsEmpty(options.DocOutputPath).empty()) {
+  if (!withNullAsEmptyStringRef(options.DocOutputPath).empty()) {
     (void)withOutputFile(getContext(DC).Diags,
                          options.DocOutputPath,
                          [&](raw_ostream &out) {
@@ -5645,7 +5649,7 @@ void swift::serialize(ModuleOrSourceFile DC,
     });
   }
 
-  if (!StringRef::withNullAsEmpty(options.SourceInfoOutputPath).empty()) {
+  if (!withNullAsEmptyStringRef(options.SourceInfoOutputPath).empty()) {
     (void)withOutputFile(getContext(DC).Diags,
                          options.SourceInfoOutputPath,
                          [&](raw_ostream &out) {

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1565,8 +1565,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       Ty = cast<IntegerLiteralInst>(&SI)->getType();
       break;
     case SILInstructionKind::FloatLiteralInst:
-      cast<IntegerLiteralInst>(&SI)->getValue().toString(Str, 16,
-                                                         /*signed*/ true);
+      cast<FloatLiteralInst>(&SI)->getBits().toString(Str, 16,
+                                                      /*signed*/ true);
       Ty = cast<FloatLiteralInst>(&SI)->getType();
       break;
     }

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -68,7 +68,7 @@ static bool isGlobalOrStaticVar(VarDecl *VD) {
 
 TBDGenVisitor::TBDGenVisitor(const TBDGenDescriptor &desc,
                              APIRecorder &recorder)
-    : TBDGenVisitor(desc.getTarget(), desc.getDataLayout(),
+    : TBDGenVisitor(desc.getTarget(), desc.getDataLayoutString(),
                     desc.getParentModule(), desc.getOptions(), recorder) {}
 
 void TBDGenVisitor::addSymbolInternal(StringRef name, SymbolKind kind,
@@ -390,7 +390,9 @@ void TBDGenVisitor::addSymbol(StringRef name, SymbolSource source,
   if (kind == SymbolKind::ObjectiveCClass) {
     mangled = name;
   } else {
-    llvm::Mangler::getNameWithPrefix(mangled, name, DataLayout);
+    if (!DataLayout)
+      DataLayout = llvm::DataLayout(DataLayoutDescription);
+    llvm::Mangler::getNameWithPrefix(mangled, name, *DataLayout);
   }
 
   addSymbolInternal(mangled, kind, source);

--- a/lib/TBDGen/TBDGenRequests.cpp
+++ b/lib/TBDGen/TBDGenRequests.cpp
@@ -48,10 +48,10 @@ ModuleDecl *TBDGenDescriptor::getParentModule() const {
   return Input.get<FileUnit *>()->getParentModule();
 }
 
-const llvm::DataLayout &TBDGenDescriptor::getDataLayout() const {
+const StringRef TBDGenDescriptor::getDataLayoutString() const {
   auto &ctx = getParentModule()->getASTContext();
   auto *clang = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
-  return clang->getTargetInfo().getDataLayout();
+  return llvm::StringRef(clang->getTargetInfo().getDataLayoutString());
 }
 
 const llvm::Triple &TBDGenDescriptor::getTarget() const {

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -92,7 +92,9 @@ class TBDGenVisitor : public ASTVisitor<TBDGenVisitor> {
   llvm::StringSet<> DuplicateSymbolChecker;
 #endif
 
-  const llvm::DataLayout &DataLayout;
+  Optional<llvm::DataLayout> DataLayout = None;
+  const StringRef DataLayoutDescription;
+
   UniversalLinkageInfo UniversalLinkInfo;
   ModuleDecl *SwiftModule;
   const TBDGenOptions &Opts;
@@ -167,10 +169,10 @@ class TBDGenVisitor : public ASTVisitor<TBDGenVisitor> {
                                   const AutoDiffConfig &config);
 
 public:
-  TBDGenVisitor(const llvm::Triple &target, const llvm::DataLayout &dataLayout,
+  TBDGenVisitor(const llvm::Triple &target, const StringRef dataLayoutString,
                 ModuleDecl *swiftModule, const TBDGenOptions &opts,
                 APIRecorder &recorder)
-      : DataLayout(dataLayout),
+      : DataLayoutDescription(dataLayoutString),
         UniversalLinkInfo(target, opts.HasMultipleIGMs, /*forcePublic*/ false),
         SwiftModule(swiftModule), Opts(opts), recorder(recorder),
         previousInstallNameMap(parsePreviousModuleInstallNameMap()) {}

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -446,6 +446,6 @@ void TestOptions::printHelp(bool ShowHidden) const {
 
   TestOptTable Table;
 
-  Table.PrintHelp(llvm::outs(), "sourcekitd-test [options] <inputs>",
+  Table.printHelp(llvm::outs(), "sourcekitd-test [options] <inputs>",
                   "SourceKit Testing Tool", ShowHidden);
 }

--- a/tools/driver/autolink_extract_main.cpp
+++ b/tools/driver/autolink_extract_main.cpp
@@ -82,7 +82,7 @@ public:
     if (ParsedArgs.getLastArg(OPT_help)) {
       std::string ExecutableName =
           llvm::sys::path::stem(MainExecutablePath).str();
-      Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
+      Table->printHelp(llvm::outs(), ExecutableName.c_str(),
                        "Swift Autolink Extract", options::AutolinkExtractOption,
                        0, /*ShowAllAliases*/false);
       return 1;

--- a/tools/driver/modulewrap_main.cpp
+++ b/tools/driver/modulewrap_main.cpp
@@ -96,7 +96,7 @@ public:
     if (ParsedArgs.getLastArg(OPT_help)) {
       std::string ExecutableName =
           llvm::sys::path::stem(MainExecutablePath).str();
-      Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
+      Table->printHelp(llvm::outs(), ExecutableName.c_str(),
                        "Swift Module Wrapper", options::ModuleWrapOption, 0,
                        /*ShowAllAliases*/false);
       return 1;

--- a/tools/driver/swift_api_digester_main.cpp
+++ b/tools/driver/swift_api_digester_main.cpp
@@ -2655,7 +2655,7 @@ public:
   void printHelp() {
     std::string ExecutableName =
         llvm::sys::path::stem(MainExecutablePath).str();
-    Table->PrintHelp(llvm::outs(), ExecutableName.c_str(), "Swift API Digester",
+    Table->printHelp(llvm::outs(), ExecutableName.c_str(), "Swift API Digester",
                      /*IncludedFlagsBitmask*/ SwiftAPIDigesterOption,
                      /*ExcludedFlagsBitmask*/ 0,
                      /*ShowAllAliases*/ false);

--- a/tools/driver/swift_api_extract_main.cpp
+++ b/tools/driver/swift_api_extract_main.cpp
@@ -65,7 +65,7 @@ public:
     if (ParsedArgs.getLastArg(OPT_help)) {
       std::string ExecutableName =
           llvm::sys::path::stem(MainExecutablePath).str();
-      Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
+      Table->printHelp(llvm::outs(), ExecutableName.c_str(),
                        "Swift API Extract", options::SwiftAPIExtractOption, 0,
                        /*ShowAllAliases*/ false);
       return 1;

--- a/tools/driver/swift_indent_main.cpp
+++ b/tools/driver/swift_indent_main.cpp
@@ -149,7 +149,7 @@ public:
     if (ParsedArgs.getLastArg(OPT_help)) {
       std::string ExecutableName =
           llvm::sys::path::stem(MainExecutablePath).str();
-      Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
+      Table->printHelp(llvm::outs(), ExecutableName.c_str(),
                        "Swift Format Tool", options::SwiftIndentOption, 0,
                        /*ShowAllAliases*/false);
       return 1;

--- a/tools/driver/swift_symbolgraph_extract_main.cpp
+++ b/tools/driver/swift_symbolgraph_extract_main.cpp
@@ -62,7 +62,7 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
   if (ParsedArgs.getLastArg(OPT_help) || Args.empty()) {
     std::string ExecutableName =
         llvm::sys::path::stem(MainExecutablePath).str();
-    Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
+    Table->printHelp(llvm::outs(), ExecutableName.c_str(),
                      "Swift Symbol Graph Extractor",
                      SwiftSymbolGraphExtractOption, 0,
                      /*ShowAllAliases*/ false);

--- a/tools/swift-syntax-parser-test/swift-syntax-parser-test.cpp
+++ b/tools/swift-syntax-parser-test/swift-syntax-parser-test.cpp
@@ -18,9 +18,10 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/LLVMInitialize.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Format.h"
 #include "llvm/Support/MemoryBuffer.h"
-#include "llvm/Support/Timer.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/Timer.h"
 
 using namespace swift;
 using namespace llvm;


### PR DESCRIPTION
This is a mega-merge of the necessary commits from the swift-next branch that were required to get things building.
These changes were merged into the next branch in the following PRs:
- https://github.com/apple/swift/pull/38182
- https://github.com/apple/swift/pull/38134
- https://github.com/apple/swift/pull/38135
- https://github.com/apple/swift/pull/38131
- https://github.com/apple/swift/pull/38136
- https://github.com/apple/swift/pull/38230

This is getting me pretty close to having things building locally. I'm seeing the build failure associated with https://github.com/apple/llvm-project/pull/3060, and still seeing the crashes that were associated with https://github.com/apple/llvm-project/pull/3074 so I think we need to go poke that repo to get much further. I am seeing some additional crashes in the coroutine splitting that 3074 doesn't fix, so we may need additional fixes for that.