### PR TITLE
Bump module format version

### DIFF
--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 612; // isolated parameters
+const uint16_t SWIFTMODULE_VERSION_MINOR = 613; // createAsyncTask changed
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///


### PR DESCRIPTION
**Explanation**: Bump the module format version one step because there were some implicit changes (to the types of builtins) that effectively changed the module format, but without a corresponding module format version bump.
**Scope**: Affects all builds in a trivial way; some `.swiftinterfaces` will get recompiled.
**Radar/SR Issue**: rdar://80223362
**Risk**: Low.
**Testing**: PR testing and CI on main.
**Original PR**: None; this problem is unique to the 5.5 branch
