### PR TITLE
Sema: Check conditional availability earlier in conformance checking [5.5]

### DIFF
--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -1385,7 +1385,7 @@ protocol ProtocolWithRequirementMentioningUnavailable {
 
 protocol HasMethodF {
   associatedtype T
-  func f(_ p: T) // expected-note 4{{protocol requirement here}}
+  func f(_ p: T) // expected-note 3{{protocol requirement here}}
 }
 
 class TriesToConformWithFunctionIntroducedOn10_51 : HasMethodF {
@@ -1499,17 +1499,14 @@ extension TakesClassAvailableOn10_51_B : HasTakesClassAvailableOn10_51 {
 }
 
 
-// We do not want potential unavailability to play a role in picking a witness for a
-// protocol requirement. Rather, the witness should be chosen, regardless of its
-// potential unavailability, and then it should be diagnosed if it is less available
-// than the protocol requires.
-class TestAvailabilityDoesNotAffectWitnessCandidacy : HasMethodF {
-  // Test that we choose the more specialized witness even though it is
-  // less available than the protocol requires and there is a less specialized
-  // witness that has suitable availability.
+// We want conditional availability to play a role in picking a witness for a
+// protocol requirement.
+class TestAvailabilityAffectsWitnessCandidacy : HasMethodF {
+  // Test that we choose the less specialized witness, because the more specialized
+  // witness is conditionally unavailable.
 
   @available(OSX, introduced: 10.51)
-  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available in macOS 10.50.0 and newer}}
+  func f(_ p: Int) { }
 
   func f<T>(_ p: T) { }
 }

--- a/test/Sema/conformance_availability_disambiguate.swift
+++ b/test/Sema/conformance_availability_disambiguate.swift
@@ -1,0 +1,43 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+public protocol Potato {
+  func eat()
+}
+
+public protocol Fried {}
+
+extension Potato {
+  public func eat() {}
+}
+
+@available(macOS 100, *)
+extension Potato where Self : Fried {
+  public func eat() {}
+}
+
+// We ought to pick the unconstrained Potato.eat(), not
+// the one from the extension, because the extension has
+// narrower availability than the conformance.
+public struct CurlyFries : Potato, Fried {}
+
+public struct TaterTots {}
+
+// This conformance on the other hand should use the
+// constrained Potato.eat(), since the generic signature
+// is more specific than the unconstrained protocol
+// extension.
+@available(macOS 100, *)
+extension TaterTots : Potato, Fried {}
+
+// We FileCheck the SILGen output to verify that the correct
+// witnesses were chosen above.
+
+// CHECK-LABEL: sil shared [transparent] [thunk] @$s37conformance_availability_disambiguate10CurlyFriesVAA6PotatoA2aDP3eatyyFTW : $@convention(witness_method: Potato) (@in_guaranteed CurlyFries) -> () {
+// CHECK: function_ref @$s37conformance_availability_disambiguate6PotatoPAAE3eatyyF : $@convention(method) <τ_0_0 where τ_0_0 : Potato> (@in_guaranteed τ_0_0) -> ()
+// CHECK: return
+
+// sil shared [transparent] [thunk] @$s37conformance_availability_disambiguate9TaterTotsVAA6PotatoA2aDP3eatyyFTW : $@convention(witness_method: Potato) (@in_guaranteed TaterTots) -> () {
+// CHECK: function_ref @$s37conformance_availability_disambiguate6PotatoPA2A5FriedRzrlE3eatyyF : $@convention(method) <τ_0_0 where τ_0_0 : Fried, τ_0_0 : Potato> (@in_guaranteed τ_0_0) -> ()
+// CHECK: return


### PR DESCRIPTION
We would only check conditional availability once we had committed
to a best witness. Instead, let's use this information to disambiguate
among multiple best witnesses, if we have them.

Access control and unconditional unavailability are still only
checked once the witness is chosen.

Fixes rdar://problem/77259046.