### PR TITLE
[SE-0302] Implement '@unchecked Sendable' syntax.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -987,7 +987,8 @@ public:
                  ProtocolDecl *protocol,
                  SourceLoc loc,
                  DeclContext *dc,
-                 ProtocolConformanceState state);
+                 ProtocolConformanceState state,
+                 bool isUnchecked);
 
   /// Produce a self-conformance for the given protocol.
   SelfProtocolConformance *

--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -17,6 +17,7 @@
 #include "swift/Basic/QuotedString.h"
 #include "swift/Basic/UUID.h"
 #include "swift/AST/Identifier.h"
+#include "swift/AST/Decl.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/DenseSet.h"
@@ -351,8 +352,9 @@ void printEnumElementsAsCases(
     llvm::DenseSet<EnumElementDecl *> &UnhandledElements,
     llvm::raw_ostream &OS);
 
-void getInheritedForPrinting(const Decl *decl, const PrintOptions &options,
-                             llvm::SmallVectorImpl<TypeLoc> &Results);
+void getInheritedForPrinting(
+  const Decl *decl, const PrintOptions &options,
+  llvm::SmallVectorImpl<InheritedEntry> &Results);
 
 StringRef getAccessorKindString(AccessorKind value);
 

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -55,6 +55,7 @@ TYPE_ATTR(differentiable)
 TYPE_ATTR(noDerivative)
 TYPE_ATTR(async)
 TYPE_ATTR(Sendable)
+TYPE_ATTR(unchecked)
 
 // SIL-specific attributes
 TYPE_ATTR(block_storage)

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4490,15 +4490,16 @@ ERROR(concurrent_value_class_mutable_property,none,
       (DeclName, DescriptiveDeclKind, DeclName))
 ERROR(concurrent_value_outside_source_file,none,
       "conformance to 'Sendable' must occur in the same source file as "
-      "%0 %1; use 'UnsafeSendable' for retroactive conformance",
+      "%0 %1; use '@unchecked Sendable' for retroactive conformance",
       (DescriptiveDeclKind, DeclName))
 ERROR(concurrent_value_nonfinal_class,none,
       "non-final class %0 cannot conform to `Sendable`; "
-      "use `UnsafeSendable`", (DeclName))
+      "use `@unchecked Sendable`", (DeclName))
 ERROR(concurrent_value_inherit,none,
       "`Sendable` class %1 cannot inherit from another class"
       "%select{| other than 'NSObject'}0",
       (bool, DeclName))
+
 
 ERROR(actorindependent_let,none,
       "'@actorIndependent' is meaningless on 'let' declarations because "
@@ -4510,6 +4511,13 @@ ERROR(actorindependent_mutable_storage,none,
 ERROR(actorindependent_local_var,none,
       "'@actorIndependent' can not be applied to local variables",
       ())
+
+WARNING(unchecked_conformance_not_special,none,
+      "@unchecked conformance to %0 has no meaning", (Type))
+ERROR(unchecked_not_inheritance_clause,none,
+      "'unchecked' attribute only applies in inheritance clauses", ())
+ERROR(unchecked_not_existential,none,
+      "'unchecked' attribute cannot apply to non-protocol type %0", (Type))
 
 ERROR(nonisolated_let,none,
       "'nonisolated' is meaningless on 'let' declarations because "

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -503,6 +503,19 @@ void filterForDiscriminator(SmallVectorImpl<Result> &results,
 
 } // end namespace namelookup
 
+/// Describes an inherited nominal entry.
+struct InheritedNominalEntry : Located<NominalTypeDecl *> {
+  /// The location of the "unchecked" attribute, if present.
+  SourceLoc uncheckedLoc;
+
+  InheritedNominalEntry() { }
+
+  InheritedNominalEntry(
+    NominalTypeDecl *item, SourceLoc loc,
+    SourceLoc uncheckedLoc
+  ) : Located(item, loc), uncheckedLoc(uncheckedLoc) { }
+};
+
 /// Retrieve the set of nominal type declarations that are directly
 /// "inherited" by the given declaration at a particular position in the
 /// list of "inherited" types.
@@ -511,7 +524,7 @@ void filterForDiscriminator(SmallVectorImpl<Result> &results,
 /// AnyObject type, set \c anyObject true.
 void getDirectlyInheritedNominalTypeDecls(
     llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl,
-    unsigned i, llvm::SmallVectorImpl<Located<NominalTypeDecl *>> &result,
+    unsigned i, llvm::SmallVectorImpl<InheritedNominalEntry> &result,
     bool &anyObject);
 
 /// Retrieve the set of nominal type declarations that are directly
@@ -519,7 +532,7 @@ void getDirectlyInheritedNominalTypeDecls(
 /// and splitting out the components of compositions.
 ///
 /// If we come across the AnyObject type, set \c anyObject true.
-SmallVector<Located<NominalTypeDecl *>, 4> getDirectlyInheritedNominalTypeDecls(
+SmallVector<InheritedNominalEntry, 4> getDirectlyInheritedNominalTypeDecls(
     llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl,
     bool &anyObject);
 

--- a/include/swift/AST/TypeLoc.h
+++ b/include/swift/AST/TypeLoc.h
@@ -29,7 +29,7 @@ class TypeRepr;
 
 /// TypeLoc - Provides source location information for a parsed type.
 /// A TypeLoc is stored in AST nodes which use an explicitly written type.
-class alignas(1 << TypeReprAlignInBits) TypeLoc final {
+class alignas(1 << TypeReprAlignInBits) TypeLoc {
   Type Ty;
   TypeRepr *TyR = nullptr;
 

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -135,6 +135,10 @@ public:
   SourceLoc getEndLoc() const;
   SourceRange getSourceRange() const;
 
+  /// Find an @unchecked attribute and return its source location, or return
+  /// an invalid source location if there is no such attribute.
+  SourceLoc findUncheckedAttrLoc() const;
+
   /// Is this type grammatically a type-simple?
   inline bool isSimple() const; // bottom of this file
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1119,7 +1119,7 @@ public:
 
   ParserResult<ImportDecl> parseDeclImport(ParseDeclOptions Flags,
                                            DeclAttributes &Attributes);
-  ParserStatus parseInheritance(SmallVectorImpl<TypeLoc> &Inherited,
+  ParserStatus parseInheritance(SmallVectorImpl<InheritedEntry> &Inherited,
                                 bool allowClassRequirement,
                                 bool allowAnyObject);
   ParserStatus parseDeclItem(bool &PreviousHadSemi,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2085,7 +2085,8 @@ ASTContext::getConformance(Type conformingType,
                            ProtocolDecl *protocol,
                            SourceLoc loc,
                            DeclContext *dc,
-                           ProtocolConformanceState state) {
+                           ProtocolConformanceState state,
+                           bool isUnchecked) {
   assert(dc->isTypeContext());
 
   llvm::FoldingSetNodeID id;
@@ -2101,7 +2102,8 @@ ASTContext::getConformance(Type conformingType,
   // Build a new normal protocol conformance.
   auto result
     = new (*this, AllocationArena::Permanent)
-      NormalProtocolConformance(conformingType, protocol, loc, dc, state);
+        NormalProtocolConformance(
+          conformingType, protocol, loc, dc, state,isUnchecked);
   normalConformances.InsertNode(result, insertPos);
 
   return result;

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -601,11 +601,12 @@ namespace {
         PrintWithColorRAII(OS, DeclModifierColor) << " trailing_semi";
     }
 
-    void printInherited(ArrayRef<TypeLoc> Inherited) {
+    void printInherited(ArrayRef<InheritedEntry> Inherited) {
       if (Inherited.empty())
         return;
       OS << " inherits: ";
-      interleave(Inherited, [&](TypeLoc Super) { Super.getType().print(OS); },
+      interleave(Inherited,
+                 [&](InheritedEntry Super) { Super.getType().print(OS); },
                  [&] { OS << ", "; });
     }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1004,18 +1004,6 @@ public:
     ASTVisitor::visit(D);
 
     if (haveFeatureChecks) {
-      // If we guarded a marker protocol, print an alternative typealias
-      // for Any.
-      if (auto proto = dyn_cast<ProtocolDecl>(D)) {
-        if (proto->isMarkerProtocol()) {
-          Printer.printNewline();
-          Printer << "#else";
-          Printer.printNewline();
-          printAccess(proto);
-          Printer << "typealias " << proto->getName() << " = Any";
-        }
-      }
-
       printCompatibilityFeatureChecksPost(Printer);
     }
 
@@ -1824,7 +1812,7 @@ bool ShouldPrintChecker::shouldPrint(const Decl *D,
     auto Ext = cast<ExtensionDecl>(D);
     // If the extension doesn't add protocols or has no members that we should
     // print then skip printing it.
-    SmallVector<TypeLoc, 8> ProtocolsToPrint;
+    SmallVector<InheritedEntry, 8> ProtocolsToPrint;
     getInheritedForPrinting(Ext, Options, ProtocolsToPrint);
     if (ProtocolsToPrint.empty()) {
       bool HasMemberToPrint = false;
@@ -2242,15 +2230,18 @@ void PrintAST::printInherited(const Decl *decl) {
   if (!Options.PrintInherited) {
     return;
   }
-  SmallVector<TypeLoc, 6> TypesToPrint;
+  SmallVector<InheritedEntry, 6> TypesToPrint;
   getInheritedForPrinting(decl, Options, TypesToPrint);
   if (TypesToPrint.empty())
     return;
 
   Printer << " : ";
 
-  interleave(TypesToPrint, [&](TypeLoc TL) {
-    printTypeLoc(TL);
+  interleave(TypesToPrint, [&](InheritedEntry inherited) {
+    if (inherited.isUnchecked)
+      Printer << "@unchecked ";
+
+    printTypeLoc(inherited);
   }, [&]() {
     Printer << ", ";
   });
@@ -2520,60 +2511,6 @@ static bool usesFeatureAsyncAwait(Decl *decl) {
 }
 
 static bool usesFeatureMarkerProtocol(Decl *decl) {
-  // Check an inheritance clause for a marker protocol.
-  auto checkInherited = [&](ArrayRef<TypeLoc> inherited) -> bool {
-    for (const auto &inheritedEntry : inherited) {
-      if (auto inheritedType = inheritedEntry.getType()) {
-        if (inheritedType->isExistentialType()) {
-          auto layout = inheritedType->getExistentialLayout();
-          for (ProtocolType *protoTy : layout.getProtocols()) {
-            if (protoTy->getDecl()->isMarkerProtocol())
-              return true;
-          }
-        }
-      }
-    }
-
-    return false;
-  };
-
-  // Check generic requirements for a marker protocol.
-  auto checkRequirements = [&](ArrayRef<Requirement> requirements) -> bool {
-    for (const auto &req: requirements) {
-      if (req.getKind() == RequirementKind::Conformance &&
-          req.getSecondType()->castTo<ProtocolType>()->getDecl()
-              ->isMarkerProtocol())
-        return true;
-    }
-
-    return false;
-  };
-
-  if (auto proto = dyn_cast<ProtocolDecl>(decl)) {
-    if (proto->isMarkerProtocol())
-      return true;
-
-    // Swift.Error and Swift.CodingKey "don't" use the marker protocol.
-    if (proto->isSpecificProtocol(KnownProtocolKind::Error) ||
-        proto->isSpecificProtocol(KnownProtocolKind::CodingKey)) {
-      return false;
-    }
-
-    if (checkInherited(proto->getInherited()))
-      return true;
-
-    if (checkRequirements(proto->getRequirementSignature()))
-      return true;
-  }
-
-  if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
-    if (checkRequirements(ext->getGenericRequirements()))
-      return true;
-
-    if (checkInherited(ext->getInherited()))
-      return true;
-  }
-
   return false;
 }
 
@@ -2650,7 +2587,7 @@ static bool usesFeatureRethrowsProtocol(
     return false;
 
   // Check an inheritance clause for a marker protocol.
-  auto checkInherited = [&](ArrayRef<TypeLoc> inherited) -> bool {
+  auto checkInherited = [&](ArrayRef<InheritedEntry> inherited) -> bool {
     for (const auto &inheritedEntry : inherited) {
       if (auto inheritedType = inheritedEntry.getType()) {
         if (inheritedType->isExistentialType()) {
@@ -5809,9 +5746,10 @@ void swift::printEnumElementsAsCases(
 }
 
 void
-swift::getInheritedForPrinting(const Decl *decl, const PrintOptions &options,
-                               llvm::SmallVectorImpl<TypeLoc> &Results) {
-  ArrayRef<TypeLoc> inherited;
+swift::getInheritedForPrinting(
+    const Decl *decl, const PrintOptions &options,
+    llvm::SmallVectorImpl<InheritedEntry> &Results) {
+  ArrayRef<InheritedEntry> inherited;
   if (auto td = dyn_cast<TypeDecl>(decl)) {
     inherited = td->getInherited();
   } else if (auto ed = dyn_cast<ExtensionDecl>(decl)) {
@@ -5819,29 +5757,22 @@ swift::getInheritedForPrinting(const Decl *decl, const PrintOptions &options,
   }
 
   // Collect explicit inherited types.
-  for (auto TL: inherited) {
-    if (auto ty = TL.getType()) {
+  for (auto entry: inherited) {
+    if (auto ty = entry.getType()) {
       bool foundUnprintable = ty.findIf([&](Type subTy) {
         if (auto aliasTy = dyn_cast<TypeAliasType>(subTy.getPointer()))
           return !options.shouldPrint(aliasTy->getDecl());
         if (auto NTD = subTy->getAnyNominal()) {
           if (!options.shouldPrint(NTD))
             return true;
-
-          if (auto PD = dyn_cast<ProtocolDecl>(NTD)) {
-            // Marker protocols are unprintable on concrete types, but they're
-            // okay on extension declarations and protocols.
-            if (PD->isMarkerProtocol() && !isa<ExtensionDecl>(decl) &&
-                !isa<ProtocolDecl>(decl))
-              return true;
-          }
         }
         return false;
       });
       if (foundUnprintable)
         continue;
     }
-    Results.push_back(TL);
+
+    Results.push_back(entry);
   }
 
   // Collect synthesized conformances.
@@ -5859,7 +5790,8 @@ swift::getInheritedForPrinting(const Decl *decl, const PrintOptions &options,
           isa<EnumDecl>(decl) &&
           cast<EnumDecl>(decl)->hasRawType())
         continue;
-      Results.push_back(TypeLoc::withoutLoc(proto->getDeclaredInterfaceType()));
+      Results.push_back({TypeLoc::withoutLoc(proto->getDeclaredInterfaceType()),
+                      /*isUnchecked=*/false});
     }
   }
 }

--- a/lib/AST/ConformanceLookupTable.h
+++ b/lib/AST/ConformanceLookupTable.h
@@ -85,6 +85,9 @@ class ConformanceLookupTable {
   class ConformanceSource {
     llvm::PointerIntPair<void *, 2, ConformanceEntryKind> Storage;
 
+    /// The location of the "unchecked" attribute, if there is one.
+    SourceLoc uncheckedLoc;
+
     ConformanceSource(void *ptr, ConformanceEntryKind kind) 
       : Storage(ptr, kind) { }
 
@@ -123,6 +126,14 @@ class ConformanceLookupTable {
       return ConformanceSource(typeDecl, ConformanceEntryKind::Synthesized);
     }
 
+    /// Return a new conformance source with the given location of "@unchecked".
+    ConformanceSource withUncheckedLoc(SourceLoc uncheckedLoc) {
+      ConformanceSource result(*this);
+      if (uncheckedLoc.isValid())
+        result.uncheckedLoc = uncheckedLoc;
+      return result;
+    }
+
     /// Retrieve the kind of conformance formed from this source.
     ConformanceEntryKind getKind() const { return Storage.getInt(); }
 
@@ -147,6 +158,11 @@ class ConformanceLookupTable {
       }
 
       llvm_unreachable("Unhandled ConformanceEntryKind in switch.");
+    }
+
+    /// The location of the @unchecked attribute, if any.
+    SourceLoc getUncheckedLoc() const {
+      return uncheckedLoc;
     }
 
     /// For an inherited conformance, retrieve the class declaration

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1157,9 +1157,15 @@ NominalTypeDecl::takeConformanceLoaderSlow() {
   return { contextInfo->loader, contextInfo->allConformancesData };
 }
 
+InheritedEntry::InheritedEntry(const TypeLoc &typeLoc)
+    : TypeLoc(typeLoc), isUnchecked(false) {
+  if (auto typeRepr = typeLoc.getTypeRepr())
+    isUnchecked = typeRepr->findUncheckedAttrLoc().isValid();
+}
+
 ExtensionDecl::ExtensionDecl(SourceLoc extensionLoc,
                              TypeRepr *extendedType,
-                             ArrayRef<TypeLoc> inherited,
+                             ArrayRef<InheritedEntry> inherited,
                              DeclContext *parent,
                              TrailingWhereClause *trailingWhereClause)
   : GenericContext(DeclContextKind::ExtensionDecl, parent, nullptr),
@@ -1176,7 +1182,7 @@ ExtensionDecl::ExtensionDecl(SourceLoc extensionLoc,
 
 ExtensionDecl *ExtensionDecl::create(ASTContext &ctx, SourceLoc extensionLoc,
                                      TypeRepr *extendedType,
-                                     ArrayRef<TypeLoc> inherited,
+                                     ArrayRef<InheritedEntry> inherited,
                                      DeclContext *parent,
                                      TrailingWhereClause *trailingWhereClause,
                                      ClangNode clangNode) {
@@ -3881,7 +3887,7 @@ bool NominalTypeDecl::isActor() const {
 
 GenericTypeDecl::GenericTypeDecl(DeclKind K, DeclContext *DC,
                                  Identifier name, SourceLoc nameLoc,
-                                 ArrayRef<TypeLoc> inherited,
+                                 ArrayRef<InheritedEntry> inherited,
                                  GenericParamList *GenericParams) :
     GenericContext(DeclContextKind::GenericTypeDecl, DC, GenericParams),
     TypeDecl(K, DC, name, nameLoc, inherited) {}
@@ -4091,7 +4097,7 @@ AssociatedTypeDecl *AssociatedTypeDecl::getAssociatedTypeAnchor() const {
 
 EnumDecl::EnumDecl(SourceLoc EnumLoc,
                      Identifier Name, SourceLoc NameLoc,
-                     ArrayRef<TypeLoc> Inherited,
+                     ArrayRef<InheritedEntry> Inherited,
                      GenericParamList *GenericParams, DeclContext *Parent)
   : NominalTypeDecl(DeclKind::Enum, Parent, Name, NameLoc, Inherited,
                     GenericParams),
@@ -4115,7 +4121,7 @@ void EnumDecl::setRawType(Type rawType) {
 }
 
 StructDecl::StructDecl(SourceLoc StructLoc, Identifier Name, SourceLoc NameLoc,
-                       ArrayRef<TypeLoc> Inherited,
+                       ArrayRef<InheritedEntry> Inherited,
                        GenericParamList *GenericParams, DeclContext *Parent)
   : NominalTypeDecl(DeclKind::Struct, Parent, Name, NameLoc, Inherited,
                     GenericParams),
@@ -4233,7 +4239,7 @@ VarDecl *NominalTypeDecl::getGlobalActorInstance() const {
 }
 
 ClassDecl::ClassDecl(SourceLoc ClassLoc, Identifier Name, SourceLoc NameLoc,
-                     ArrayRef<TypeLoc> Inherited,
+                     ArrayRef<InheritedEntry> Inherited,
                      GenericParamList *GenericParams, DeclContext *Parent,
                      bool isActor)
   : NominalTypeDecl(DeclKind::Class, Parent, Name, NameLoc, Inherited,
@@ -4738,7 +4744,7 @@ bool EnumDecl::hasCircularRawValue() const {
 
 ProtocolDecl::ProtocolDecl(DeclContext *DC, SourceLoc ProtocolLoc,
                            SourceLoc NameLoc, Identifier Name,
-                           ArrayRef<TypeLoc> Inherited,
+                           ArrayRef<InheritedEntry> Inherited,
                            TrailingWhereClause *TrailingWhere)
     : NominalTypeDecl(DeclKind::Protocol, DC, Name, NameLoc, Inherited,
                       nullptr),

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4166,8 +4166,9 @@ static ConstraintResult visitInherited(
   ASTContext &ctx = typeDecl ? typeDecl->getASTContext()
                              : extDecl->getASTContext();
   auto &evaluator = ctx.evaluator;
-  ArrayRef<TypeLoc> inheritedTypes = typeDecl ? typeDecl->getInherited()
-                                              : extDecl->getInherited();
+  ArrayRef<InheritedEntry> inheritedTypes =
+      typeDecl ? typeDecl->getInherited()
+               : extDecl->getInherited();
   for (unsigned index : indices(inheritedTypes)) {
     Type inheritedType
       = evaluateOrDefault(evaluator,

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2486,7 +2486,8 @@ GenericParamListRequest::evaluate(Evaluator &evaluator, GenericContext *value) c
     // is implemented.
     if (auto *proto = ext->getExtendedProtocolDecl()) {
       auto protoType = proto->getDeclaredInterfaceType();
-      TypeLoc selfInherited[1] = { TypeLoc::withoutLoc(protoType) };
+      InheritedEntry selfInherited[1] = {
+        InheritedEntry(TypeLoc::withoutLoc(protoType)) };
       genericParams->getParams().front()->setInherited(
         ctx.AllocateCopy(selfInherited));
     }
@@ -2506,7 +2507,8 @@ GenericParamListRequest::evaluate(Evaluator &evaluator, GenericContext *value) c
     auto selfDecl = new (ctx) GenericTypeParamDecl(
         proto, selfId, SourceLoc(), /*depth=*/0, /*index=*/0);
     auto protoType = proto->getDeclaredInterfaceType();
-    TypeLoc selfInherited[1] = { TypeLoc::withoutLoc(protoType) };
+    InheritedEntry selfInherited[1] = {
+      InheritedEntry(TypeLoc::withoutLoc(protoType)) };
     selfDecl->setInherited(ctx.AllocateCopy(selfInherited));
     selfDecl->setImplicit();
 
@@ -2662,15 +2664,7 @@ void swift::getDirectlyInheritedNominalTypeDecls(
   if (TypeRepr *typeRepr = typeDecl ? typeDecl->getInherited()[i].getTypeRepr()
                                     : extDecl->getInherited()[i].getTypeRepr()){
     loc = typeRepr->getLoc();
-
-    // Dig out the @unchecked attribute, if it's present.
-    while (auto attrTypeRepr = dyn_cast<AttributedTypeRepr>(typeRepr)) {
-      if (attrTypeRepr->getAttrs().has(TAK_unchecked)) {
-        uncheckedLoc = attrTypeRepr->getAttrs().getLoc(TAK_unchecked);
-      }
-
-      typeRepr = attrTypeRepr->getTypeRepr();
-    }
+    uncheckedLoc = typeRepr->findUncheckedAttrLoc();
   }
 
   // Form the result.

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2636,7 +2636,7 @@ CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
 
 void swift::getDirectlyInheritedNominalTypeDecls(
     llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl,
-    unsigned i, llvm::SmallVectorImpl<Located<NominalTypeDecl *>> &result,
+    unsigned i, llvm::SmallVectorImpl<InheritedNominalEntry> &result,
     bool &anyObject) {
   auto typeDecl = decl.dyn_cast<const TypeDecl *>();
   auto extDecl = decl.dyn_cast<const ExtensionDecl *>();
@@ -2658,18 +2658,28 @@ void swift::getDirectlyInheritedNominalTypeDecls(
   // FIXME: This is a hack. We need cooperation from
   // InheritedDeclsReferencedRequest to make this work.
   SourceLoc loc;
+  SourceLoc uncheckedLoc;
   if (TypeRepr *typeRepr = typeDecl ? typeDecl->getInherited()[i].getTypeRepr()
                                     : extDecl->getInherited()[i].getTypeRepr()){
     loc = typeRepr->getLoc();
+
+    // Dig out the @unchecked attribute, if it's present.
+    while (auto attrTypeRepr = dyn_cast<AttributedTypeRepr>(typeRepr)) {
+      if (attrTypeRepr->getAttrs().has(TAK_unchecked)) {
+        uncheckedLoc = attrTypeRepr->getAttrs().getLoc(TAK_unchecked);
+      }
+
+      typeRepr = attrTypeRepr->getTypeRepr();
+    }
   }
 
   // Form the result.
   for (auto nominal : nominalTypes) {
-    result.push_back({nominal, loc});
+    result.push_back({nominal, loc, uncheckedLoc});
   }
 }
 
-SmallVector<Located<NominalTypeDecl *>, 4>
+SmallVector<InheritedNominalEntry, 4>
 swift::getDirectlyInheritedNominalTypeDecls(
     llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl,
     bool &anyObject) {
@@ -2679,7 +2689,7 @@ swift::getDirectlyInheritedNominalTypeDecls(
   // Gather results from all of the inherited types.
   unsigned numInherited = typeDecl ? typeDecl->getInherited().size()
                                    : extDecl->getInherited().size();
-  SmallVector<Located<NominalTypeDecl *>, 4> result;
+  SmallVector<InheritedNominalEntry, 4> result;
   for (unsigned i : range(numInherited)) {
     getDirectlyInheritedNominalTypeDecls(decl, i, result, anyObject);
   }
@@ -2705,7 +2715,7 @@ swift::getDirectlyInheritedNominalTypeDecls(
       if (!req.getFirstType()->isEqual(protoSelfTy))
         continue;
 
-      result.emplace_back(req.getProtocolDecl(), loc);
+      result.emplace_back(req.getProtocolDecl(), loc, SourceLoc());
     }
     return result;
   }
@@ -2715,7 +2725,7 @@ swift::getDirectlyInheritedNominalTypeDecls(
   anyObject |= selfBounds.anyObject;
 
   for (auto inheritedNominal : selfBounds.decls)
-    result.emplace_back(inheritedNominal, loc);
+    result.emplace_back(inheritedNominal, loc, SourceLoc());
 
   return result;
 }

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1350,6 +1350,9 @@ static ProtocolConformance *findSynthesizedSendableConformance(
   if (concrete->getDeclContext() != dc)
     return nullptr;
 
+  if (isa<InheritedProtocolConformance>(concrete))
+    return nullptr;
+
   auto normal = concrete->getRootNormalConformance();
   if (!normal || normal->getSourceKind() != ConformanceEntryKind::Synthesized)
     return nullptr;

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -80,6 +80,19 @@ void *TypeRepr::operator new(size_t Bytes, const ASTContext &C,
   return C.Allocate(Bytes, Alignment);
 }
 
+SourceLoc TypeRepr::findUncheckedAttrLoc() const {
+  auto typeRepr = this;
+  while (auto attrTypeRepr = dyn_cast<AttributedTypeRepr>(typeRepr)) {
+    if (attrTypeRepr->getAttrs().has(TAK_unchecked)) {
+      return attrTypeRepr->getAttrs().getLoc(TAK_unchecked);
+    }
+
+    typeRepr = attrTypeRepr->getTypeRepr();
+  }
+
+  return SourceLoc();
+}
+
 DeclNameRef ComponentIdentTypeRepr::getNameRef() const {
   if (IdOrDecl.is<DeclNameRef>())
     return IdOrDecl.get<DeclNameRef>();

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9915,7 +9915,8 @@ void ClangImporter::Implementation::loadAllConformances(
     auto conformance = SwiftContext.getConformance(
         dc->getDeclaredInterfaceType(),
         protocol, SourceLoc(), dc,
-        ProtocolConformanceState::Incomplete);
+        ProtocolConformanceState::Incomplete,
+        protocol->isSpecificProtocol(KnownProtocolKind::Sendable));
     conformance->setLazyLoader(this, /*context*/0);
     conformance->setState(ProtocolConformanceState::Complete);
     Conformances.push_back(conformance);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3080,8 +3080,9 @@ namespace {
                          Impl.importIdentifier(decl->getIdentifier()));
 
         // Add protocol declarations to the enum declaration.
-        SmallVector<TypeLoc, 2> inheritedTypes;
-        inheritedTypes.push_back(TypeLoc::withoutLoc(underlyingType));
+        SmallVector<InheritedEntry, 2> inheritedTypes;
+        inheritedTypes.push_back(
+            InheritedEntry(TypeLoc::withoutLoc(underlyingType)));
         enumDecl->setInherited(C.AllocateCopy(inheritedTypes));
 
         if (errorWrapper) {
@@ -5140,7 +5141,7 @@ namespace {
     // declaration.
     void importObjCProtocols(Decl *decl,
                              const clang::ObjCProtocolList &clangProtocols,
-                             SmallVectorImpl<TypeLoc> &inheritedTypes);
+                             SmallVectorImpl<InheritedEntry> &inheritedTypes);
 
     // Returns None on error. Returns nullptr if there is no type param list to
     // import or we suppress its import, as in the case of NSArray, NSSet, and
@@ -5210,7 +5211,7 @@ namespace {
       // Create the extension declaration and record it.
       objcClass->addExtension(result);
       Impl.ImportedDecls[{decl, getVersion()}] = result;
-      SmallVector<TypeLoc, 4> inheritedTypes;
+      SmallVector<InheritedEntry, 4> inheritedTypes;
       importObjCProtocols(result, decl->getReferencedProtocols(),
                           inheritedTypes);
       result->setInherited(Impl.SwiftContext.AllocateCopy(inheritedTypes));
@@ -5416,7 +5417,7 @@ namespace {
       Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = result;
 
       // Import protocols this protocol conforms to.
-      SmallVector<TypeLoc, 4> inheritedTypes;
+      SmallVector<InheritedEntry, 4> inheritedTypes;
       importObjCProtocols(result, decl->getReferencedProtocols(),
                           inheritedTypes);
       result->setInherited(Impl.SwiftContext.AllocateCopy(inheritedTypes));
@@ -5566,7 +5567,7 @@ namespace {
       }
 
       // If this Objective-C class has a supertype, import it.
-      SmallVector<TypeLoc, 4> inheritedTypes;
+      SmallVector<InheritedEntry, 4> inheritedTypes;
       Type superclassType;
       if (decl->getSuperClass()) {
         clang::QualType clangSuperclassType =
@@ -6007,7 +6008,7 @@ SwiftDeclConverter::importCFClassType(const clang::TypedefNameDecl *decl,
   addObjCAttribute(theClass, None);
 
   if (superclass) {
-    SmallVector<TypeLoc, 4> inheritedTypes;
+    SmallVector<InheritedEntry, 4> inheritedTypes;
     inheritedTypes.push_back(TypeLoc::withoutLoc(superclass));
     theClass->setInherited(Impl.SwiftContext.AllocateCopy(inheritedTypes));
   }
@@ -7777,7 +7778,7 @@ void SwiftDeclConverter::addProtocols(
 
 void SwiftDeclConverter::importObjCProtocols(
     Decl *decl, const clang::ObjCProtocolList &clangProtocols,
-    SmallVectorImpl<TypeLoc> &inheritedTypes) {
+    SmallVectorImpl<InheritedEntry> &inheritedTypes) {
   SmallVector<ProtocolDecl *, 4> protocols;
   llvm::SmallPtrSet<ProtocolDecl *, 4> knownProtocols;
   if (auto nominal = dyn_cast<NominalTypeDecl>(decl)) {
@@ -7791,7 +7792,9 @@ void SwiftDeclConverter::importObjCProtocols(
             Impl.importDecl(*cp, getActiveSwiftVersion()))) {
       addProtocols(proto, protocols, knownProtocols);
       inheritedTypes.push_back(
-        TypeLoc::withoutLoc(proto->getDeclaredInterfaceType()));
+        InheritedEntry(
+          TypeLoc::withoutLoc(proto->getDeclaredInterfaceType()),
+          /*isUnchecked=*/false));
     }
   }
 
@@ -7820,7 +7823,7 @@ Optional<GenericParamList *> SwiftDeclConverter::importObjCGenericParams(
     // nested.
 
     // Import parameter constraints.
-    SmallVector<TypeLoc, 1> inherited;
+    SmallVector<InheritedEntry, 1> inherited;
     if (objcGenericParam->hasExplicitBound()) {
       assert(!objcGenericParam->getUnderlyingType().isNull());
       auto clangBound = objcGenericParam->getUnderlyingType()

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/ModuleNameLookup.h"
 #include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/TypeRepr.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/ModuleInterfaceSupport.h"
@@ -302,7 +303,7 @@ class InheritedProtocolCollector {
 
   using AvailableAttrList = TinyPtrVector<const AvailableAttr *>;
   using ProtocolAndAvailability =
-    std::pair<ProtocolDecl *, AvailableAttrList>;
+    std::tuple<ProtocolDecl *, AvailableAttrList, bool /*isUnchecked*/>;
 
   /// Protocols that will be included by the ASTPrinter without any extra work.
   SmallVector<ProtocolDecl *, 8> IncludedProtocols;
@@ -339,30 +340,23 @@ class InheritedProtocolCollector {
   }
 
   static bool canPrintProtocolTypeNormally(Type type, const Decl *D) {
-    if (!isPublicOrUsableFromInline(type))
-      return false;
-
-    // Extensions and protocols can print marker protocols.
-    if (isa<ExtensionDecl>(D) || isa<ProtocolDecl>(D))
-      return true;
-
-    ExistentialLayout layout = type->getExistentialLayout();
-    for (ProtocolType *protoTy : layout.getProtocols()) {
-      if (protoTy->getDecl()->isMarkerProtocol())
-        return false;
-    }
-
-    return true;
+    return isPublicOrUsableFromInline(type);
   }
-  
+
+  static bool isUncheckedConformance(ProtocolConformance *conformance) {
+    if (auto normal = conformance->getRootNormalConformance())
+      return normal->isUnchecked();
+    return false;
+  }
+
   /// For each type in \p directlyInherited, classify the protocols it refers to
   /// as included for printing or not, and record them in the appropriate
   /// vectors.
-  void recordProtocols(ArrayRef<TypeLoc> directlyInherited, const Decl *D,
-                       bool skipSynthesized = false) {
+  void recordProtocols(ArrayRef<InheritedEntry> directlyInherited,
+                       const Decl *D, bool skipSynthesized = false) {
     Optional<AvailableAttrList> availableAttrs;
 
-    for (TypeLoc inherited : directlyInherited) {
+    for (InheritedEntry inherited : directlyInherited) {
       Type inheritedTy = inherited.getType();
       if (!inheritedTy || !inheritedTy->isExistentialType())
         continue;
@@ -374,7 +368,8 @@ class InheritedProtocolCollector {
           IncludedProtocols.push_back(protoTy->getDecl());
         else
           ExtraProtocols.push_back({protoTy->getDecl(),
-                                    getAvailabilityAttrs(D, availableAttrs)});
+                                    getAvailabilityAttrs(D, availableAttrs),
+                                    inherited.isUnchecked});
       }
       // FIXME: This ignores layout constraints, but currently we don't support
       // any of those besides 'AnyObject'.
@@ -392,7 +387,8 @@ class InheritedProtocolCollector {
         if (conf->getSourceKind() != ConformanceEntryKind::Synthesized)
           continue;
         ExtraProtocols.push_back({conf->getProtocol(),
-                                  getAvailabilityAttrs(D, availableAttrs)});
+                                  getAvailabilityAttrs(D, availableAttrs),
+                                  isUncheckedConformance(conf)});
       }
     }
   }
@@ -424,7 +420,7 @@ public:
   ///
   /// \sa recordProtocols
   static void collectProtocols(PerTypeMap &map, const Decl *D) {
-    ArrayRef<TypeLoc> directlyInherited;
+    ArrayRef<InheritedEntry> directlyInherited;
     const NominalTypeDecl *nominal;
     const IterableDeclContext *memberContext;
 
@@ -550,7 +546,10 @@ public:
     // of a protocol rather than the maximally available case.
     SmallVector<ProtocolAndAvailability, 16> protocolsToPrint;
     for (const auto &protoAndAvailability : ExtraProtocols) {
-      protoAndAvailability.first->walkInheritedProtocols(
+      auto proto = std::get<0>(protoAndAvailability);
+      auto availability = std::get<1>(protoAndAvailability);
+      auto isUnchecked = std::get<2>(protoAndAvailability);
+      proto->walkInheritedProtocols(
           [&](ProtocolDecl *inherited) -> TypeWalker::Action {
         if (!handledProtocols.insert(inherited).second)
           return TypeWalker::Action::SkipChildren;
@@ -569,7 +568,8 @@ public:
 
         if (isPublicOrUsableFromInline(inherited) &&
             conformanceDeclaredInModule(M, nominal, inherited)) {
-          protocolsToPrint.push_back({inherited, protoAndAvailability.second});
+          protocolsToPrint.push_back({inherited, availability, isUnchecked});
+
           return TypeWalker::Action::SkipChildren;
         }
 
@@ -581,15 +581,16 @@ public:
 
     for (const auto &protoAndAvailability : protocolsToPrint) {
       StreamPrinter printer(out);
-      ProtocolDecl *proto = protoAndAvailability.first;
+      auto proto = std::get<0>(protoAndAvailability);
+      auto availability = std::get<1>(protoAndAvailability);
+      auto isUnchecked = std::get<2>(protoAndAvailability);
 
       bool haveFeatureChecks = printOptions.PrintCompatibilityFeatureChecks &&
         printCompatibilityFeatureChecksPre(printer, proto);
 
       // FIXME: Shouldn't this be an implicit conversion?
       TinyPtrVector<const DeclAttribute *> attrs;
-      attrs.insert(attrs.end(), protoAndAvailability.second.begin(),
-                   protoAndAvailability.second.end());
+      attrs.insert(attrs.end(), availability.begin(), availability.end());
       auto spiAttributes = proto->getAttrs().getAttributes<SPIAccessControlAttr>();
       attrs.insert(attrs.end(), spiAttributes.begin(), spiAttributes.end());
       DeclAttributes::print(printer, printOptions, attrs);
@@ -606,6 +607,9 @@ public:
           oldFullyQualifiedTypesIfAmbiguous;
       }
       printer << " : ";
+
+      if (isUnchecked)
+        printer << "@unchecked ";
 
       proto->getDeclaredInterfaceType()->print(printer, printOptions);
 

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -367,9 +367,10 @@ class InheritedProtocolCollector {
         if (canPrintNormally)
           IncludedProtocols.push_back(protoTy->getDecl());
         else
-          ExtraProtocols.push_back({protoTy->getDecl(),
+          ExtraProtocols.push_back(
+            ProtocolAndAvailability(protoTy->getDecl(),
                                     getAvailabilityAttrs(D, availableAttrs),
-                                    inherited.isUnchecked});
+                                    inherited.isUnchecked));
       }
       // FIXME: This ignores layout constraints, but currently we don't support
       // any of those besides 'AnyObject'.
@@ -386,9 +387,10 @@ class InheritedProtocolCollector {
       for (auto *conf : localConformances) {
         if (conf->getSourceKind() != ConformanceEntryKind::Synthesized)
           continue;
-        ExtraProtocols.push_back({conf->getProtocol(),
+        ExtraProtocols.push_back(
+          ProtocolAndAvailability(conf->getProtocol(),
                                   getAvailabilityAttrs(D, availableAttrs),
-                                  isUncheckedConformance(conf)});
+                                  isUncheckedConformance(conf)));
       }
     }
   }
@@ -568,8 +570,8 @@ public:
 
         if (isPublicOrUsableFromInline(inherited) &&
             conformanceDeclaredInModule(M, nominal, inherited)) {
-          protocolsToPrint.push_back({inherited, availability, isUnchecked});
-
+          protocolsToPrint.push_back(
+            ProtocolAndAvailability(inherited, availability, isUnchecked));
           return TypeWalker::Action::SkipChildren;
         }
 

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -2048,7 +2048,7 @@ private:
   }
 
   Optional<IndentContext>
-  getIndentContextFromInherits(ArrayRef<TypeLoc> Inherits,
+  getIndentContextFromInherits(ArrayRef<InheritedEntry> Inherits,
                                SourceLoc ContextLoc) {
     if (Inherits.empty())
       return None;

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -254,7 +254,7 @@ struct SynthesizedExtensionAnalyzer::Implementation {
   InfoMap(collectSynthesizedExtensionInfo(AllGroups)) {}
 
   unsigned countInherits(ExtensionDecl *ED) {
-    SmallVector<TypeLoc, 4> Results;
+    SmallVector<InheritedEntry, 4> Results;
     getInheritedForPrinting(ED, Options, Results);
     return Results.size();
   }

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -3276,7 +3276,7 @@ class AddEquatableContext {
   SourceLoc StartLoc;
 
   /// Array of all inherited protocols' locations
-  ArrayRef<TypeLoc> ProtocolsLocations;
+  ArrayRef<InheritedEntry> ProtocolsLocations;
 
   /// Array of all conformed protocols
   SmallVector<swift::ProtocolDecl *, 2> Protocols;

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2461,7 +2461,7 @@ ClassDecl *IRGenModule::getObjCRuntimeBaseClass(Identifier name,
 
   // Make a really fake-looking class.
   auto SwiftRootClass = new (Context) ClassDecl(SourceLoc(), name, SourceLoc(),
-                                           ArrayRef<TypeLoc>(),
+                                           ArrayRef<InheritedEntry>(),
                                            /*generics*/ nullptr,
                                            Context.TheBuiltinModule,
                                            /*isActor*/false);

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -617,7 +617,8 @@ private:
 
   bool reportRelatedRef(ValueDecl *D, SourceLoc Loc, bool isImplicit, SymbolRoleSet Relations, Decl *Related);
   bool reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet Relations, Decl *Related);
-  bool reportInheritedTypeRefs(ArrayRef<TypeLoc> Inherited, Decl *Inheritee);
+  bool reportInheritedTypeRefs(
+      ArrayRef<InheritedEntry> Inherited, Decl *Inheritee);
   NominalTypeDecl *getTypeLocAsNominalTypeDecl(const TypeLoc &Ty);
 
   bool reportPseudoGetterDecl(VarDecl *D) {
@@ -998,7 +999,7 @@ bool IndexSwiftASTWalker::reportRelatedRef(ValueDecl *D, SourceLoc Loc, bool isI
   return !Cancelled;
 }
 
-bool IndexSwiftASTWalker::reportInheritedTypeRefs(ArrayRef<TypeLoc> Inherited, Decl *Inheritee) {
+bool IndexSwiftASTWalker::reportInheritedTypeRefs(ArrayRef<InheritedEntry> Inherited, Decl *Inheritee) {
   for (auto Base : Inherited) {
     if (!reportRelatedTypeRef(Base, (SymbolRoleSet) SymbolRole::RelationBaseOf, Inheritee))
       return false;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4826,9 +4826,9 @@ ParserResult<ImportDecl> Parser::parseDeclImport(ParseDeclOptions Flags,
 ///     'class'
 ///     type-identifier
 /// \endverbatim
-ParserStatus Parser::parseInheritance(SmallVectorImpl<TypeLoc> &Inherited,
-                                      bool allowClassRequirement,
-                                      bool allowAnyObject) {
+ParserStatus Parser::parseInheritance(
+    SmallVectorImpl<InheritedEntry> &Inherited,
+    bool allowClassRequirement, bool allowAnyObject) {
   SyntaxParsingContext InheritanceContext(SyntaxContext,
                                           SyntaxKind::TypeInheritanceClause);
 
@@ -4888,8 +4888,10 @@ ParserStatus Parser::parseInheritance(SmallVectorImpl<TypeLoc> &Inherited,
 
       // Add 'AnyObject' to the inherited list.
       Inherited.push_back(
-        new (Context) SimpleIdentTypeRepr(DeclNameLoc(classLoc), DeclNameRef(
-                                          Context.getIdentifier("AnyObject"))));
+        InheritedEntry(
+            new (Context) SimpleIdentTypeRepr(
+                DeclNameLoc(classLoc),
+                DeclNameRef(Context.getIdentifier("AnyObject")))));
       continue;
     }
 
@@ -4898,7 +4900,7 @@ ParserStatus Parser::parseInheritance(SmallVectorImpl<TypeLoc> &Inherited,
 
     // Record the type if its a single type.
     if (ParsedTypeResult.isNonNull())
-      Inherited.push_back(ParsedTypeResult.get());
+      Inherited.push_back(InheritedEntry(ParsedTypeResult.get()));
   } while (HasNextType);
 
   return Status;
@@ -5213,7 +5215,7 @@ Parser::parseDeclExtension(ParseDeclOptions Flags, DeclAttributes &Attributes) {
   status |= extendedType;
 
   // Parse optional inheritance clause.
-  SmallVector<TypeLoc, 2> Inherited;
+  SmallVector<InheritedEntry, 2> Inherited;
   if (Tok.is(tok::colon))
     status |= parseInheritance(Inherited,
                                /*allowClassRequirement=*/false,
@@ -5651,7 +5653,7 @@ ParserResult<TypeDecl> Parser::parseDeclAssociatedType(Parser::ParseDeclOptions 
   
   // Parse optional inheritance clause.
   // FIXME: Allow class requirements here.
-  SmallVector<TypeLoc, 2> Inherited;
+  SmallVector<InheritedEntry, 2> Inherited;
   if (Tok.is(tok::colon))
     Status |= parseInheritance(Inherited,
                                /*allowClassRequirement=*/false,
@@ -7237,7 +7239,7 @@ ParserResult<EnumDecl> Parser::parseDeclEnum(ParseDeclOptions Flags,
 
   // Parse optional inheritance clause within the context of the enum.
   if (Tok.is(tok::colon)) {
-    SmallVector<TypeLoc, 2> Inherited;
+    SmallVector<InheritedEntry, 2> Inherited;
     Status |= parseInheritance(Inherited,
                                /*allowClassRequirement=*/false,
                                /*allowAnyObject=*/false);
@@ -7512,7 +7514,7 @@ ParserResult<StructDecl> Parser::parseDeclStruct(ParseDeclOptions Flags,
 
   // Parse optional inheritance clause within the context of the struct.
   if (Tok.is(tok::colon)) {
-    SmallVector<TypeLoc, 2> Inherited;
+    SmallVector<InheritedEntry, 2> Inherited;
     Status |= parseInheritance(Inherited,
                                /*allowClassRequirement=*/false,
                                /*allowAnyObject=*/false);
@@ -7606,7 +7608,7 @@ ParserResult<ClassDecl> Parser::parseDeclClass(ParseDeclOptions Flags,
 
   // Parse optional inheritance clause within the context of the class.
   if (Tok.is(tok::colon)) {
-    SmallVector<TypeLoc, 2> Inherited;
+    SmallVector<InheritedEntry, 2> Inherited;
     Status |= parseInheritance(Inherited,
                                /*allowClassRequirement=*/false,
                                /*allowAnyObject=*/false);
@@ -7703,7 +7705,7 @@ parseDeclProtocol(ParseDeclOptions Flags, DeclAttributes &Attributes) {
   DebuggerContextChange DCC (*this);
   
   // Parse optional inheritance clause.
-  SmallVector<TypeLoc, 4> InheritedProtocols;
+  SmallVector<InheritedEntry, 4> InheritedProtocols;
   SourceLoc colonLoc;
   if (Tok.is(tok::colon)) {
     colonLoc = Tok.getLoc();

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -78,7 +78,7 @@ Parser::parseGenericParametersBeforeWhere(SourceLoc LAngleLoc,
     }
 
     // Parse the ':' followed by a type.
-    SmallVector<TypeLoc, 1> Inherited;
+    SmallVector<InheritedEntry, 1> Inherited;
     if (Tok.is(tok::colon)) {
       (void)consumeToken();
       ParserResult<TypeRepr> Ty;
@@ -101,7 +101,7 @@ Parser::parseGenericParametersBeforeWhere(SourceLoc LAngleLoc,
         return makeParserCodeCompletionStatus();
 
       if (Ty.isNonNull())
-        Inherited.push_back(Ty.get());
+        Inherited.push_back({Ty.get()});
     }
 
     // We always create generic type parameters with an invalid depth.

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3016,7 +3016,7 @@ bool ContextualFailure::tryProtocolConformanceFixIt(
     for (auto protocol : missingProtocols) {
       auto conformance = NormalProtocolConformance(
           nominal->getDeclaredType(), protocol, SourceLoc(), nominal,
-          ProtocolConformanceState::Incomplete);
+          ProtocolConformanceState::Incomplete, /*isUnchecked=*/false);
       ConformanceChecker checker(getASTContext(), &conformance,
                                  missingWitnesses);
       checker.resolveValueWitnesses();

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -125,8 +125,9 @@ static EnumDecl *addImplicitCodingKeys_enum(EnumDecl *target) {
   // enum cases based on those case names.
   auto *codingKeyProto = C.getProtocol(KnownProtocolKind::CodingKey);
   auto codingKeyType = codingKeyProto->getDeclaredInterfaceType();
-  TypeLoc protoTypeLoc[1] = {TypeLoc::withoutLoc(codingKeyType)};
-  ArrayRef<TypeLoc> inherited = C.AllocateCopy(protoTypeLoc);
+  InheritedEntry protoTypeLoc[1] = {
+    InheritedEntry(TypeLoc::withoutLoc(codingKeyType))};
+  ArrayRef<InheritedEntry> inherited = C.AllocateCopy(protoTypeLoc);
 
   llvm::SmallVector<EnumDecl *, 4> codingKeys;
 

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -160,8 +160,8 @@ static EnumDecl *addImplicitCaseCodingKeys(EnumDecl *target,
 
   auto *codingKeyProto = C.getProtocol(KnownProtocolKind::CodingKey);
   auto codingKeyType = codingKeyProto->getDeclaredInterfaceType();
-  TypeLoc protoTypeLoc[1] = {TypeLoc::withoutLoc(codingKeyType)};
-  ArrayRef<TypeLoc> inherited = C.AllocateCopy(protoTypeLoc);
+  InheritedEntry protoTypeLoc[1] = {InheritedEntry(TypeLoc::withoutLoc(codingKeyType))};
+  ArrayRef<InheritedEntry> inherited = C.AllocateCopy(protoTypeLoc);
 
   // Only derive if this case exist in the CodingKeys enum
   auto *codingKeyCase =
@@ -222,8 +222,8 @@ static EnumDecl *addImplicitCodingKeys(NominalTypeDecl *target) {
   // enum cases based on those var names.
   auto *codingKeyProto = C.getProtocol(KnownProtocolKind::CodingKey);
   auto codingKeyType = codingKeyProto->getDeclaredInterfaceType();
-  TypeLoc protoTypeLoc[1] = {TypeLoc::withoutLoc(codingKeyType)};
-  ArrayRef<TypeLoc> inherited = C.AllocateCopy(protoTypeLoc);
+  InheritedEntry protoTypeLoc[1] = {InheritedEntry(TypeLoc::withoutLoc(codingKeyType))};
+  ArrayRef<InheritedEntry> inherited = C.AllocateCopy(protoTypeLoc);
 
   auto *enumDecl = new (C) EnumDecl(SourceLoc(), C.Id_CodingKeys, SourceLoc(),
                                     inherited, nullptr, target);

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -424,10 +424,10 @@ getOrSynthesizeTangentVectorStruct(DerivedConformance &derived, Identifier id) {
       tvDesiredProtos.insert(req.getProtocolDecl());
     }
   }
-  SmallVector<TypeLoc, 4> tvDesiredProtoTypeLocs;
+  SmallVector<InheritedEntry, 4> tvDesiredProtoInherited;
   for (auto *p : tvDesiredProtos)
-    tvDesiredProtoTypeLocs.push_back(
-      TypeLoc::withoutLoc(p->getDeclaredInterfaceType()));
+    tvDesiredProtoInherited.push_back(
+      InheritedEntry(TypeLoc::withoutLoc(p->getDeclaredInterfaceType())));
 
   // Cache original members and their associated types for later use.
   SmallVector<VarDecl *, 8> diffProperties;
@@ -436,7 +436,7 @@ getOrSynthesizeTangentVectorStruct(DerivedConformance &derived, Identifier id) {
   auto synthesizedLoc = derived.ConformanceDecl->getEndLoc();
   auto *structDecl =
       new (C) StructDecl(synthesizedLoc, C.Id_TangentVector, synthesizedLoc,
-                         /*Inherited*/ C.AllocateCopy(tvDesiredProtoTypeLocs),
+                         /*Inherited*/ C.AllocateCopy(tvDesiredProtoInherited),
                          /*GenericParams*/ {}, parentDC);
   structDecl->setBraces({synthesizedLoc, synthesizedLoc});
   structDecl->setImplicit();

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -341,7 +341,7 @@ static ValueDecl *deriveDifferentiable_move(DerivedConformance &derived) {
 ///
 /// Precondition: `decl` is a nominal type decl or an extension decl.
 void getInheritedProtocols(Decl *decl, SmallPtrSetImpl<ProtocolDecl *> &protos) {
-  ArrayRef<TypeLoc> inheritedTypeLocs;
+  ArrayRef<InheritedEntry> inheritedTypeLocs;
   if (auto *nominalDecl = dyn_cast<NominalTypeDecl>(decl))
     inheritedTypeLocs = nominalDecl->getInherited();
   else if (auto *extDecl = dyn_cast<ExtensionDecl>(decl))

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3561,7 +3561,6 @@ bool swift::checkSendableConformance(
   switch (getActorIsolation(nominal)) {
   case ActorIsolation::Unspecified:
   case ActorIsolation::ActorInstance:
-  case ActorIsolation::DistributedActorInstance:
   case ActorIsolation::Independent:
     break;
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3571,19 +3571,6 @@ bool swift::checkSendableConformance(
       return true;
   }
 
-  // Global-actor-isolated types can be Sendable. We do not check the
-  // instance properties.
-  switch (getActorIsolation(nominal)) {
-  case ActorIsolation::Unspecified:
-  case ActorIsolation::ActorInstance:
-  case ActorIsolation::Independent:
-    break;
-
-  case ActorIsolation::GlobalActor:
-  case ActorIsolation::GlobalActorUnsafe:
-    return false;
-  }
-
   if (classDecl) {
     // An non-final class cannot conform to `Sendable`.
     if (!classDecl->isSemanticallyFinal()) {
@@ -3662,7 +3649,7 @@ NormalProtocolConformance *GetImplicitSendableRequest::evaluate(
   }
 
   // Local function to form the implicit conformance.
-  auto formConformance = [&]() -> NormalProtocolConformance * {
+  auto formConformance = [&](bool isUnchecked) -> NormalProtocolConformance * {
     ASTContext &ctx = nominal->getASTContext();
     auto proto = ctx.getProtocol(KnownProtocolKind::Sendable);
     if (!proto)
@@ -3670,7 +3657,7 @@ NormalProtocolConformance *GetImplicitSendableRequest::evaluate(
 
     auto conformance = ctx.getConformance(
         nominal->getDeclaredInterfaceType(), proto, nominal->getLoc(),
-        nominal, ProtocolConformanceState::Complete);
+        nominal, ProtocolConformanceState::Complete, isUnchecked);
     conformance->setSourceKindAndImplyingConformance(
         ConformanceEntryKind::Synthesized, nullptr);
 
@@ -3695,7 +3682,7 @@ NormalProtocolConformance *GetImplicitSendableRequest::evaluate(
     }
 
     // Form the implicit conformance to Sendable.
-    return formConformance();
+    return formConformance(/*isUnchecked=*/true);
   }
 
   // Only structs and enums can get implicit Sendable conformances by
@@ -3720,7 +3707,7 @@ NormalProtocolConformance *GetImplicitSendableRequest::evaluate(
           nominal, nominal, SendableCheck::Implicit))
     return nullptr;
 
-  return formConformance();
+  return formConformance(/*isUnchecked=*/false);
 }
 
 AnyFunctionType *swift::applyGlobalActorType(

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -237,7 +237,7 @@ enum class SendableCheck {
   /// protocols that added Sendable after-the-fact.
   ImpliedByStandardProtocol,
 
-  /// Implicit conformance to Sendable for structs and enums.
+  /// Implicit conformance to Sendable.
   Implicit,
 };
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -73,7 +73,7 @@ using namespace swift;
 static void checkInheritanceClause(
     llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> declUnion) {
   const DeclContext *DC;
-  ArrayRef<TypeLoc> inheritedClause;
+  ArrayRef<InheritedEntry> inheritedClause;
   const ExtensionDecl *ext = nullptr;
   const TypeDecl *typeDecl = nullptr;
   const Decl *decl;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1858,6 +1858,13 @@ static void diagnoseConformanceImpliedByConditionalConformance(
       .fixItInsert(loc, differentFixit);
 }
 
+/// Determine whether there are additional semantic checks for conformance
+/// to the given protocol. This should return true when @unchecked can be
+/// used to disable those semantic checks.
+static bool hasAdditionalSemanticChecks(ProtocolDecl *proto) {
+  return proto->isSpecificProtocol(KnownProtocolKind::Sendable);
+}
+
 /// Determine whether the type \c T conforms to the protocol \c Proto,
 /// recording the complete witness table if it does.
 ProtocolConformance *MultiConformanceChecker::
@@ -2058,6 +2065,13 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
     }
     conformance->setInvalid();
     return conformance;
+  }
+
+  // Complain about the use of @unchecked for protocols that don't have
+  // additional semantic checks.
+  if (conformance->isUnchecked() && !hasAdditionalSemanticChecks(Proto)) {
+    C.Diags.diagnose(
+      ComplainLoc, diag::unchecked_conformance_not_special, ProtoType);
   }
 
   bool impliedDisablesMissingWitnessFixits = false;
@@ -5766,7 +5780,7 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
   MultiConformanceChecker groupChecker(Context);
 
   ProtocolConformance *SendableConformance = nullptr;
-  ProtocolConformance *unsafeSendableConformance = nullptr;
+  bool sendableConformanceIsUnchecked = false;
   ProtocolConformance *errorConformance = nullptr;
   ProtocolConformance *codingKeyConformance = nullptr;
   bool anyInvalid = false;
@@ -5797,6 +5811,11 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
       }
     } else if (proto->isSpecificProtocol(KnownProtocolKind::Sendable)) {
       SendableConformance = conformance;
+
+      if (auto normal = conformance->getRootNormalConformance()) {
+        if (normal->isUnchecked())
+          sendableConformanceIsUnchecked = true;
+      }
     } else if (proto->isSpecificProtocol(KnownProtocolKind::Actor)) {
       if (auto classDecl = dyn_cast<ClassDecl>(nominal)) {
         if (!classDecl->isExplicitActor()) {
@@ -5808,7 +5827,7 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
       }
     } else if (proto->isSpecificProtocol(
                    KnownProtocolKind::UnsafeSendable)) {
-      unsafeSendableConformance = conformance;
+      sendableConformanceIsUnchecked = true;
     } else if (proto->isSpecificProtocol(KnownProtocolKind::Error)) {
       errorConformance = conformance;
     } else if (proto->isSpecificProtocol(KnownProtocolKind::CodingKey)) {
@@ -5817,7 +5836,7 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
   }
 
   // Check constraints of Sendable.
-  if (SendableConformance && !unsafeSendableConformance) {
+  if (SendableConformance && !sendableConformanceIsUnchecked) {
     SendableCheck check = SendableCheck::Explicit;
     if (errorConformance || codingKeyConformance)
       check = SendableCheck::ImpliedByStandardProtocol;

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -45,13 +45,15 @@ Type InheritedTypeRequest::evaluate(
   switch (stage) {
   case TypeResolutionStage::Structural:
     resolution =
-        TypeResolution::forStructural(dc, None, /*unboundTyOpener*/ nullptr,
+        TypeResolution::forStructural(dc, TypeResolverContext::Inherited,
+                                      /*unboundTyOpener*/ nullptr,
                                       /*placeholderHandler*/ nullptr);
     break;
 
   case TypeResolutionStage::Interface:
     resolution =
-        TypeResolution::forInterface(dc, None, /*unboundTyOpener*/ nullptr,
+        TypeResolution::forInterface(dc, TypeResolverContext::Inherited,
+                                     /*unboundTyOpener*/ nullptr,
                                      /*placeholderHandler*/ nullptr);
     break;
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2659,6 +2659,20 @@ TypeResolver::resolveAttributedType(TypeAttributes &attrs, TypeRepr *repr,
     }
   }
 
+  if (attrs.has(TAK_unchecked)) {
+    if (!options.is(TypeResolverContext::Inherited) ||
+        getDeclContext()->getSelfProtocolDecl()) {
+      diagnoseInvalid(repr, attrs.getLoc(TAK_unchecked),
+                      diag::unchecked_not_inheritance_clause);
+    } else if (!ty->isExistentialType()) {
+      diagnoseInvalid(repr, attrs.getLoc(TAK_unchecked),
+                      diag::unchecked_not_existential, ty);
+    }
+
+    // Nothing to record in the type. Just clear the attribute.
+    attrs.clearAttribute(TAK_unchecked);
+  }
+
   for (unsigned i = 0; i != TypeAttrKind::TAK_Count; ++i)
     if (attrs.has((TypeAttrKind)i)) {
       diagnoseInvalid(repr, attrs.getLoc((TypeAttrKind)i),
@@ -3677,6 +3691,7 @@ NeverNullType TypeResolver::resolveImplicitlyUnwrappedOptionalType(
   case TypeResolverContext::EditorPlaceholderExpr:
   case TypeResolverContext::AbstractFunctionDecl:
   case TypeResolverContext::ClosureExpr:
+  case TypeResolverContext::Inherited:
     doDiag = true;
     break;
   }

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -131,6 +131,9 @@ enum class TypeResolverContext : uint8_t {
 
   /// Whether this is the type of an editor placeholder.
   EditorPlaceholderExpr,
+
+  /// Whether this is an "inherited" type.
+  Inherited,
 };
 
 /// Options that determine how type resolution should work.
@@ -212,6 +215,7 @@ public:
     case Context::GenericRequirement:
     case Context::ImmediateOptionalTypeArgument:
     case Context::AbstractFunctionDecl:
+    case Context::Inherited:
       return false;
     }
     llvm_unreachable("unhandled kind");

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -623,7 +623,8 @@ Expected<NormalProtocolConformance *> ModuleFile::readNormalConformanceChecked(
   NormalProtocolConformanceLayout::readRecord(scratch, protoID,
                                               contextID, typeCount,
                                               valueCount, conformanceCount,
-                                              isUnchecked, rawIDs);
+                                              isUnchecked,
+                                              rawIDs);
 
   ASTContext &ctx = getContext();
   auto doOrError = getDeclContextChecked(contextID);
@@ -647,7 +648,6 @@ Expected<NormalProtocolConformance *> ModuleFile::readNormalConformanceChecked(
   auto conformance = ctx.getConformance(conformingType, proto, SourceLoc(), dc,
                                         ProtocolConformanceState::Incomplete,
                                         isUnchecked);
-
   // Record this conformance.
   if (conformanceEntry.isComplete())
     return conformance;
@@ -2453,14 +2453,19 @@ class DeclDeserializer {
 
   void handleInherited(llvm::PointerUnion<TypeDecl *, ExtensionDecl *> decl,
                        ArrayRef<uint64_t> rawInheritedIDs) {
-    SmallVector<TypeLoc, 2> inheritedTypes;
+    SmallVector<InheritedEntry, 2> inheritedTypes;
     for (auto rawID : rawInheritedIDs) {
-      auto maybeType = MF.getTypeChecked(rawID);
+      // The low bit indicates "@unchecked".
+      bool isUnchecked = rawID & 0x01;
+      TypeID typeID = rawID >> 1;
+
+      auto maybeType = MF.getTypeChecked(typeID);
       if (!maybeType) {
         llvm::consumeError(maybeType.takeError());
         continue;
       }
-      inheritedTypes.push_back(TypeLoc::withoutLoc(MF.getType(rawID)));
+      inheritedTypes.push_back(
+          InheritedEntry(TypeLoc::withoutLoc(maybeType.get()), isUnchecked));
     }
 
     auto inherited = ctx.AllocateCopy(inheritedTypes);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -611,7 +611,7 @@ Expected<NormalProtocolConformance *> ModuleFile::readNormalConformanceChecked(
 
   DeclID protoID;
   DeclContextID contextID;
-  unsigned valueCount, typeCount, conformanceCount;
+  unsigned valueCount, typeCount, conformanceCount, isUnchecked;
   ArrayRef<uint64_t> rawIDs;
   SmallVector<uint64_t, 16> scratch;
 
@@ -623,7 +623,7 @@ Expected<NormalProtocolConformance *> ModuleFile::readNormalConformanceChecked(
   NormalProtocolConformanceLayout::readRecord(scratch, protoID,
                                               contextID, typeCount,
                                               valueCount, conformanceCount,
-                                              rawIDs);
+                                              isUnchecked, rawIDs);
 
   ASTContext &ctx = getContext();
   auto doOrError = getDeclContextChecked(contextID);
@@ -645,7 +645,8 @@ Expected<NormalProtocolConformance *> ModuleFile::readNormalConformanceChecked(
   ++NumNormalProtocolConformancesLoaded;
 
   auto conformance = ctx.getConformance(conformingType, proto, SourceLoc(), dc,
-                                        ProtocolConformanceState::Incomplete);
+                                        ProtocolConformanceState::Incomplete,
+                                        isUnchecked);
 
   // Record this conformance.
   if (conformanceEntry.isComplete())
@@ -6300,7 +6301,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
 
   DeclID protoID;
   DeclContextID contextID;
-  unsigned valueCount, typeCount, conformanceCount;
+  unsigned valueCount, typeCount, conformanceCount, isUnchecked;
   ArrayRef<uint64_t> rawIDs;
   SmallVector<uint64_t, 16> scratch;
 
@@ -6312,7 +6313,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
   NormalProtocolConformanceLayout::readRecord(scratch, protoID,
                                               contextID, typeCount,
                                               valueCount, conformanceCount,
-                                              rawIDs);
+                                              isUnchecked, rawIDs);
 
   // Read requirement signature conformances.
   const ProtocolDecl *proto = conformance->getProtocol();

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 613; // createAsyncTask changed
+const uint16_t SWIFTMODULE_VERSION_MINOR = 617; // @unchecked Sendable
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1638,6 +1638,7 @@ namespace decls_block {
     BCVBR<5>, // type mapping count
     BCVBR<5>, // value mapping count
     BCVBR<5>, // requirement signature conformance count
+    BCFixed<1>, // unchecked
     BCArray<DeclIDField>
     // The array contains type witnesses, then value witnesses.
     // Requirement signature conformances follow, then the substitution records

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 617; // @unchecked Sendable
+const uint16_t SWIFTMODULE_VERSION_MINOR = 618; // inherited entries
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3045,6 +3045,24 @@ public:
   /// If this gets referenced, we forgot to handle a decl.
   void visitDecl(const Decl *) = delete;
 
+  /// Add all of the inherited entries to the result vector.
+  ///
+  /// \returns the number of entries added.
+  unsigned addInherited(ArrayRef<InheritedEntry> inheritedEntries,
+                        SmallVectorImpl<TypeID> &result) {
+    for (const auto &inherited : inheritedEntries) {
+      assert(!inherited.getType() || !inherited.getType()->hasArchetype());
+      TypeID typeRef = S.addTypeRef(inherited.getType());
+
+      // Encode "unchecked" in the low bit.
+      typeRef = (typeRef << 1) | (inherited.isUnchecked ? 0x01 : 0x00);
+
+      result.push_back(typeRef);
+    }
+
+    return inheritedEntries.size();
+  }
+
   void visitExtensionDecl(const ExtensionDecl *extension) {
     using namespace decls_block;
 
@@ -3068,11 +3086,8 @@ public:
                           ConformanceLookupKind::All);
 
     SmallVector<TypeID, 8> inheritedAndDependencyTypes;
-    for (auto inherited : extension->getInherited()) {
-      assert(!inherited.getType() || !inherited.getType()->hasArchetype());
-      inheritedAndDependencyTypes.push_back(S.addTypeRef(inherited.getType()));
-    }
-    size_t numInherited = inheritedAndDependencyTypes.size();
+    size_t numInherited = addInherited(
+        extension->getInherited(), inheritedAndDependencyTypes);
 
     llvm::SmallSetVector<Type, 4> dependencies;
     collectDependenciesFromType(
@@ -3306,10 +3321,8 @@ public:
                           ConformanceLookupKind::All);
 
     SmallVector<TypeID, 4> inheritedAndDependencyTypes;
-    for (auto inherited : theStruct->getInherited()) {
-      assert(!inherited.getType() || !inherited.getType()->hasArchetype());
-      inheritedAndDependencyTypes.push_back(S.addTypeRef(inherited.getType()));
-    }
+    unsigned numInherited = addInherited(
+        theStruct->getInherited(), inheritedAndDependencyTypes);
 
     llvm::SmallSetVector<Type, 4> dependencyTypes;
     for (Requirement req : theStruct->getGenericRequirements()) {
@@ -3332,7 +3345,7 @@ public:
                                             theStruct->getGenericSignature()),
                              rawAccessLevel,
                              conformances.size(),
-                             theStruct->getInherited().size(),
+                             numInherited,
                              inheritedAndDependencyTypes);
 
 
@@ -3351,10 +3364,8 @@ public:
                           ConformanceLookupKind::All);
 
     SmallVector<TypeID, 4> inheritedAndDependencyTypes;
-    for (auto inherited : theEnum->getInherited()) {
-      assert(!inherited.getType() || !inherited.getType()->hasArchetype());
-      inheritedAndDependencyTypes.push_back(S.addTypeRef(inherited.getType()));
-    }
+    unsigned numInherited = addInherited(
+        theEnum->getInherited(), inheritedAndDependencyTypes);
 
     llvm::SmallSetVector<Type, 4> dependencyTypes;
     for (const EnumElementDecl *nextElt : theEnum->getAllElements()) {
@@ -3390,7 +3401,7 @@ public:
                             S.addTypeRef(theEnum->getRawType()),
                             rawAccessLevel,
                             conformances.size(),
-                            theEnum->getInherited().size(),
+                            numInherited,
                             inheritedAndDependencyTypes);
 
     writeGenericParams(theEnum->getGenericParams());
@@ -3409,10 +3420,8 @@ public:
                           ConformanceLookupKind::NonInherited);
 
     SmallVector<TypeID, 4> inheritedAndDependencyTypes;
-    for (auto inherited : theClass->getInherited()) {
-      assert(!inherited.getType() || !inherited.getType()->hasArchetype());
-      inheritedAndDependencyTypes.push_back(S.addTypeRef(inherited.getType()));
-    }
+    unsigned numInherited = addInherited(
+        theClass->getInherited(), inheritedAndDependencyTypes);
 
     llvm::SmallSetVector<Type, 4> dependencyTypes;
     if (theClass->hasSuperclass()) {
@@ -3450,7 +3459,7 @@ public:
                             S.addTypeRef(theClass->getSuperclass()),
                             rawAccessLevel,
                             conformances.size(),
-                            theClass->getInherited().size(),
+                            numInherited,
                             inheritedAndDependencyTypes);
 
     writeGenericParams(theClass->getGenericParams());
@@ -3467,10 +3476,13 @@ public:
     SmallVector<TypeID, 4> inheritedAndDependencyTypes;
     llvm::SmallSetVector<Type, 4> dependencyTypes;
 
+    unsigned numInherited = addInherited(
+        proto->getInherited(), inheritedAndDependencyTypes);
+
+    // Separately collect inherited protocol types as dependencies.
     for (auto element : proto->getInherited()) {
       auto elementType = element.getType();
       assert(!elementType || !elementType->hasArchetype());
-      inheritedAndDependencyTypes.push_back(S.addTypeRef(elementType));
       if (elementType && elementType->is<ProtocolType>())
         dependencyTypes.insert(elementType);
     }
@@ -3498,7 +3510,7 @@ public:
                                  ->requiresClass(),
                                proto->isObjC(),
                                proto->existentialTypeSupported(),
-                               rawAccessLevel, proto->getInherited().size(),
+                               rawAccessLevel, numInherited,
                                inheritedAndDependencyTypes);
 
     writeGenericParams(proto->getGenericParams());

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1475,6 +1475,7 @@ void Serializer::writeASTBlockEntity(
                                               numTypeWitnesses,
                                               numValueWitnesses,
                                               numSignatureConformances,
+                                              conformance->isUnchecked(),
                                               data);
 
   // Write requirement signature conformances.

--- a/test/Concurrency/concurrency_warnings.swift
+++ b/test/Concurrency/concurrency_warnings.swift
@@ -8,7 +8,7 @@ class GlobalCounter {
 let rs = GlobalCounter()
 var globalInt = 17 // expected-note 2{{var declared here}}
 
-class MyError: Error { // expected-warning{{non-final class 'MyError' cannot conform to `Sendable`; use `UnsafeSendable`}}
+class MyError: Error { // expected-warning{{non-final class 'MyError' cannot conform to `Sendable`; use `@unchecked Sendable`}}
   var storage = 0 // expected-warning{{stored property 'storage' of 'Sendable'-conforming class 'MyError' is mutable}}
 }
 

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -253,11 +253,11 @@ final class C2: Sendable {
 
 class C3 { }
 
-class C4: C3, UnsafeSendable { // expected-warning{{'UnsafeSendable' is deprecated: Use @unchecked Sendable instead}}
+class C4: C3, @unchecked Sendable {
   var y: Int = 0 // okay
 }
 
-class C5: UnsafeSendable { // expected-warning{{'UnsafeSendable' is deprecated: Use @unchecked Sendable instead}}
+class C5: @unchecked Sendable {
   var x: Int = 0 // okay
 }
 
@@ -267,20 +267,39 @@ class C6: C5 {
 
 final class C7<T>: Sendable { }
 
-class C9: Sendable { } // expected-error{{non-final class 'C9' cannot conform to `Sendable`; use `UnsafeSendable`}}
+class C9: Sendable { } // expected-error{{non-final class 'C9' cannot conform to `Sendable`; use `@unchecked Sendable`}}
 
 // ----------------------------------------------------------------------
-// UnsafeSendable disabling checking
+// @unchecked Sendable disabling checking
 // ----------------------------------------------------------------------
-struct S11: UnsafeSendable { // expected-warning{{'UnsafeSendable' is deprecated: Use @unchecked Sendable instead}}
+struct S11: @unchecked Sendable {
   var nc: NotConcurrent // okay
 }
 
-struct S12<T>: UnsafeSendable { // expected-warning{{'UnsafeSendable' is deprecated: Use @unchecked Sendable instead}}
+struct S12<T>: @unchecked Sendable {
   var nc: T // okay
 }
 
-enum E11<T>: UnsafeSendable { // expected-warning{{'UnsafeSendable' is deprecated: Use @unchecked Sendable instead}}
+enum E11<T>: @unchecked Sendable {
+  case payload(NotConcurrent) // okay
+  case other(T) // okay
+}
+
+class C11 { }
+
+class C12: @unchecked C11 { } // expected-error{{'unchecked' attribute cannot apply to non-protocol type 'C11'}}
+
+protocol P { }
+
+protocol Q: @unchecked Sendable { } // expected-error{{'unchecked' attribute only applies in inheritance clauses}}
+
+typealias TypeAlias1 = @unchecked P // expected-error{{'unchecked' attribute only applies in inheritance clauses}}
+
+
+// ----------------------------------------------------------------------
+// UnsafeSendable historical name
+// ----------------------------------------------------------------------
+enum E12<T>: UnsafeSendable { // expected-warning{{'UnsafeSendable' is deprecated: Use @unchecked Sendable instead}}
   case payload(NotConcurrent) // okay
   case other(T) // okay
 }

--- a/test/ModuleInterface/actor_isolation.swift
+++ b/test/ModuleInterface/actor_isolation.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface -module-name Test -enable-experimental-concurrency %s
 // RUN: %FileCheck %s < %t/Test.swiftinterface
+// RUN: %FileCheck %s -check-prefix SYNTHESIZED < %t/Test.swiftinterface
 // RUN: %target-swift-frontend -typecheck-module-from-interface -module-name Test %t/Test.swiftinterface
 
 // RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-module-interface-path %t/TestFromModule.swiftinterface -module-name Test -enable-experimental-concurrency
@@ -38,3 +39,25 @@ public class C2 { }
 
 // CHECK: @{{(Test.)?}}SomeGlobalActor public class C2
 public class C3: C2 { }
+
+// CHECK: public class C4 : Swift.UnsafeSendable
+public class C4: UnsafeSendable { }
+
+// CHECK: public class C5 : @unchecked Swift.Sendable
+public class C5: @unchecked Sendable { }
+
+public class C6 { }
+
+// CHECK: extension {{(Test.)?}}C6 : @unchecked Swift.Sendable
+extension C6: @unchecked Sendable { }
+
+public class C7 { }
+
+// CHECK: extension {{(Test.)?}}C7 : Swift.UnsafeSendable
+extension C7: UnsafeSendable { }
+
+// FIXME: Work around a bug where module printing depends on the "synthesized"
+// bit in conformances which is not serialized and not present in the textual
+// form.
+
+// SYNTHESIZED: extension Test.C2 : Swift.Sendable {}

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -34,35 +34,26 @@ public extension MyActor {
 // CHECK-NEXT: #endif
 public func globalAsync() async { }
 
-// CHECK: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK-NEXT: public protocol MP {
+// CHECK: @_marker public protocol MP {
 // CHECK-NEXT: }
-// CHECK-NEXT: #else
-// CHECK-NEXT: public typealias MP = Any
-// CHECK-NEXT: #endif
 @_marker public protocol MP { }
 
-// CHECK: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK-NEXT: @_marker public protocol MP2 : FeatureTest.MP {
+// CHECK: @_marker public protocol MP2 : FeatureTest.MP {
 // CHECK-NEXT: }
-// CHECK-NEXT: #else
-// CHECK-NEXT: public typealias MP2 = Any
-// CHECK-NEXT: #endif
 @_marker public protocol MP2: MP { }
 
-// CHECK: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK-NEXT: public protocol MP3 : AnyObject, FeatureTest.MP {
+// CHECK-NOT: #if compiler(>=5.3) && $MarkerProtocol
+// CHECK: public protocol MP3 : AnyObject, FeatureTest.MP {
 // CHECK-NEXT: }
 public protocol MP3: AnyObject, MP { }
 
-// CHECK: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK-NEXT: extension FeatureTest.MP2 {
+// CHECK: extension FeatureTest.MP2 {
 // CHECK-NEXT: func inMP2
 extension MP2 {
   public func inMP2() { }
 }
 
-// CHECK: class OldSchool {
+// CHECK: class OldSchool : FeatureTest.MP {
 public class OldSchool: MP {
   // CHECK: #if compiler(>=5.3) && $AsyncAwait
   // CHECK-NEXT: takeClass()
@@ -70,7 +61,7 @@ public class OldSchool: MP {
   public func takeClass() async { }
 }
 
-// CHECK: class OldSchool2 {
+// CHECK: class OldSchool2 : FeatureTest.MP {
 public class OldSchool2: MP {
   // CHECK: #if compiler(>=5.3) && $AsyncAwait
   // CHECK-NEXT: takeClass()
@@ -113,13 +104,13 @@ public struct IsRP: RP {
 // CHECK-NEXT: public func acceptsRP
 public func acceptsRP<T: RP>(_: T) { }
 
-// CHECK: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK-NEXT: extension Swift.Array : FeatureTest.MP where Element : FeatureTest.MP {
+// CHECK-NOT: #if compiler(>=5.3) && $MarkerProtocol
+// CHECK: extension Swift.Array : FeatureTest.MP where Element : FeatureTest.MP {
 extension Array: FeatureTest.MP where Element : FeatureTest.MP { }
 // CHECK: }
 
-// CHECK: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK-NEXT: extension FeatureTest.OldSchool : Swift.UnsafeSendable {
+// CHECK-NOT: #if compiler(>=5.3) && $MarkerProtocol
+// CHECK: extension FeatureTest.OldSchool : Swift.UnsafeSendable {
 extension OldSchool: UnsafeSendable { }
 // CHECK-NEXT: }
 
@@ -152,8 +143,3 @@ public func stage(with actor: MyActor) { }
 public func asyncIsh(@_inheritActorContext operation: @Sendable @escaping () async -> Void) { }
 
 // CHECK-NOT: extension FeatureTest.MyActor : Swift.Sendable
-
-// CHECK: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK-NEXT: extension FeatureTest.OldSchool : FeatureTest.MP {
-// CHECK-NEXT: #endif
-

--- a/test/decl/class/actor/basic.swift
+++ b/test/decl/class/actor/basic.swift
@@ -7,7 +7,7 @@ actor MyActor { }
 class MyActorSubclass1: MyActor { }
 // expected-error@-1{{actor types do not support inheritance}}
 // expected-error@-2{{type 'MyActorSubclass1' cannot conform to the 'Actor' protocol}}
-// expected-error@-3{{non-final class 'MyActorSubclass1' cannot conform to `Sendable`; use `UnsafeSendable`}}
+// expected-error@-3{{non-final class 'MyActorSubclass1' cannot conform to `Sendable`; use `@unchecked Sendable`}}
 
 actor MyActorSubclass2: MyActor { } // expected-error{{actor types do not support inheritance}}
 

--- a/test/decl/protocol/special/Actor.swift
+++ b/test/decl/protocol/special/Actor.swift
@@ -44,7 +44,7 @@ actor A7 {
 @available(SwiftStdlib 5.5, *)
 class C1: Actor {
   // expected-error@-1{{non-actor type 'C1' cannot conform to the 'Actor' protocol}}
-  // expected-error@-2{{non-final class 'C1' cannot conform to `Sendable`; use `UnsafeSendable`}}
+  // expected-error@-2{{non-final class 'C1' cannot conform to `Sendable`; use `@unchecked Sendable`}}
   nonisolated var unownedExecutor: UnownedSerialExecutor {
     fatalError("")
   }
@@ -53,7 +53,7 @@ class C1: Actor {
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 class C2: Actor {
   // expected-error@-1{{non-actor type 'C2' cannot conform to the 'Actor' protocol}}
-  // expected-error@-2{{non-final class 'C2' cannot conform to `Sendable`; use `UnsafeSendable`}}
+  // expected-error@-2{{non-final class 'C2' cannot conform to `Sendable`; use `@unchecked Sendable`}}
   // FIXME: this should be an isolation violation
   var unownedExecutor: UnownedSerialExecutor {
     fatalError("")
@@ -64,7 +64,7 @@ class C2: Actor {
 class C3: Actor {
   // expected-error@-1{{type 'C3' does not conform to protocol 'Actor'}}
   // expected-error@-2{{non-actor type 'C3' cannot conform to the 'Actor' protocol}}
-  // expected-error@-3{{non-final class 'C3' cannot conform to `Sendable`; use `UnsafeSendable`}}
+  // expected-error@-3{{non-final class 'C3' cannot conform to `Sendable`; use `@unchecked Sendable`}}
   nonisolated func enqueue(_ job: UnownedJob) { }
 }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -538,7 +538,7 @@ static void passConforms(const ValueDecl *D, DocInfoConsumer &Consumer) {
     return;
   Consumer.handleConformsToEntity(EntInfo);
 }
-static void passInherits(ArrayRef<TypeLoc> InheritedTypes,
+static void passInherits(ArrayRef<InheritedEntry> InheritedTypes,
                          DocInfoConsumer &Consumer) {
   for (auto Inherited : InheritedTypes) {
     if (!Inherited.getType())
@@ -552,7 +552,7 @@ static void passInherits(ArrayRef<TypeLoc> InheritedTypes,
     if (auto ProtoComposition
                = Inherited.getType()->getAs<ProtocolCompositionType>()) {
       for (auto T : ProtoComposition->getMembers())
-        passInherits(TypeLoc::withoutLoc(T), Consumer);
+        passInherits(InheritedEntry(TypeLoc::withoutLoc(T)), Consumer);
       continue;
     }
 
@@ -615,9 +615,9 @@ static void reportRelated(ASTContext &Ctx, const Decl *D,
     // Otherwise, report the inheritance of the type alias itself.
     passInheritsAndConformancesForValueDecl(TAD, Consumer);
   } else if (const auto *TD = dyn_cast<TypeDecl>(D)) {
-    llvm::SmallVector<TypeLoc, 4> AllInherits;
-    getInheritedForPrinting(TD, PrintOptions(), AllInherits);
-    passInherits(AllInherits, Consumer);
+    llvm::SmallVector<InheritedEntry, 4> AllInheritsForPrinting;
+    getInheritedForPrinting(TD, PrintOptions(), AllInheritsForPrinting);
+    passInherits(AllInheritsForPrinting, Consumer);
     passConforms(TD->getSatisfiedProtocolRequirements(/*Sorted=*/true),
                  Consumer);
   } else if (auto *VD = dyn_cast<ValueDecl>(D)) {


### PR DESCRIPTION
**Explanation**: Implement support for `@unchecked Sendable` conformances, a part of [SE-0302 "`Sendable and` `@Sendable` closures"](https://github.com/apple/swift-evolution/blob/main/proposals/0302-concurrent-value-and-concurrent-closures.md) that had previously be implemented in a different way (an `UnsafeSendable` protocol). 
**Scope**: Introduces new syntax, which should not affect any existing code.
**Radar/SR Issue**: rdar://78269000.
**Risk**: Low.
**Testing**: PR testing and CI on main.
**Original PR**:  https://github.com/apple/swift/pull/38343