### PR TITLE
[5.5][Diagnostics] Diagnose ambiguous solutions with warnings like regular ambiguities

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3760,6 +3760,16 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
     }
   }
 
+  // If there either no fixes at all or all of the are warnings,
+  // let's diagnose this as regular ambiguity.
+  if (llvm::all_of(solutions, [](const Solution &solution) {
+        return llvm::all_of(solution.Fixes, [](const ConstraintFix *fix) {
+          return fix->isWarning();
+        });
+      })) {
+    return diagnoseAmbiguity(solutions);
+  }
+
   // Algorithm is as follows:
   //
   // a. Aggregate all of the available fixes based on callee locator;

--- a/test/stdlib/UnsafePointerDiagnostics_warning.swift
+++ b/test/stdlib/UnsafePointerDiagnostics_warning.swift
@@ -201,10 +201,10 @@ func unsafePointerInitEphemeralConversions() {
   // expected-note@-2 {{use the 'withUnsafeMutableBytes' method on Array in order to explicitly convert argument to buffer pointer valid for a defined scope}}
 
   // FIXME: This is currently ambiguous.
-  _ = OpaquePointer(&foo) // expected-error {{no exact matches in call to initializer}}
+  _ = OpaquePointer(&foo) // expected-error {{ambiguous use of 'init(_:)'}}
 
   // FIXME: This is currently ambiguous.
-  _ = OpaquePointer(&arr) // expected-error {{no exact matches in call to initializer}}
+  _ = OpaquePointer(&arr) // expected-error {{ambiguous use of 'init(_:)'}}
 
   _ = OpaquePointer(arr) // expected-warning {{initialization of 'OpaquePointer' results in a dangling pointer}}
   // expected-note@-1 {{implicit argument conversion from '[Int]' to 'UnsafeRawPointer' produces a pointer valid only for the duration of the call to 'init(_:)'}}

--- a/validation-test/Sema/type_checker_crashers_fixed/sr14817.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/sr14817.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift
+
+@resultBuilder
+struct MyResultBuilder {
+  static func buildBlock(_ elements: Int...) -> Int { fatalError() }
+}
+
+struct VariableDecl2 {
+  init( // expected-note {{found this candidate}}
+    paramClosure: () -> Int? = { nil },
+    paramInt: Int,
+    @MyResultBuilder paramResultBuilder: () -> Int? = { nil }
+  ) { fatalError() }
+
+  init( // expected-note {{found this candidate}}
+    paramInt: Int,
+    paramClosure: () -> Int? = { nil },
+    @MyResultBuilder paramResultBuilder: () -> Int? = { nil }
+  ) {
+    fatalError()
+  }
+}
+
+let buildable = VariableDecl2(paramInt: 1) { // expected-error {{ambiguous use of 'init'}}
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/38328

---

- Explanation:

Fixes an issue in the solver where it would accept one of the solutions
for an ambiguous expression, which results in a crash later in the pipeline.

If solutions either have no fixes at all or all of them are warnings,
let's use `diagnoseAmbiguity` to diagnose such cases as-if there are
no fixes at all.

- Scope: Ambiguous expressions where some of the solutions have warnings and others do not.

- Main Branch PR: https://github.com/apple/swift/pull/38328

- Resolves: rdar://79657350

- Risk: Low

- Reviewed By: @hborla  

- Testing: Regression tests added to the suite

Resolves: rdar://79657350
(cherry picked from commit d1e12785edf24e697acb0baa28547f1810b0df28)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
