### PR TITLE
[5.5][CodeCompletion] Revert migration of key path completion to solver-based

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -5409,7 +5409,6 @@ public:
   /// - a resolved ValueDecl, referring to
   /// - a subscript index expression, which may or may not be resolved
   /// - an optional chaining, forcing, or wrapping component
-  /// - a code completion token
   class Component {
   public:
     enum class Kind: unsigned {
@@ -5424,7 +5423,6 @@ public:
       Identity,
       TupleElement,
       DictionaryKey,
-      CodeCompletion,
     };
   
   private:
@@ -5600,12 +5598,8 @@ public:
                                      SourceLoc loc) {
       return Component(fieldNumber, elementType, loc);
     }
-
-    static Component forCodeCompletion(SourceLoc Loc) {
-      return Component(nullptr, {}, nullptr, {}, {}, Kind::CodeCompletion,
-                       Type(), Loc);
-    }
-
+      
+      
     SourceLoc getLoc() const {
       return Loc;
     }
@@ -5643,7 +5637,6 @@ public:
       case Kind::UnresolvedSubscript:
       case Kind::UnresolvedProperty:
       case Kind::Invalid:
-      case Kind::CodeCompletion:
         return false;
       }
       llvm_unreachable("unhandled kind");
@@ -5664,7 +5657,6 @@ public:
       case Kind::Identity:
       case Kind::TupleElement:
       case Kind::DictionaryKey:
-      case Kind::CodeCompletion:
         return nullptr;
       }
       llvm_unreachable("unhandled kind");
@@ -5685,7 +5677,6 @@ public:
       case Kind::Identity:
       case Kind::TupleElement:
       case Kind::DictionaryKey:
-      case Kind::CodeCompletion:
         llvm_unreachable("no subscript labels for this kind");
       }
       llvm_unreachable("unhandled kind");
@@ -5709,7 +5700,6 @@ public:
       case Kind::Identity:
       case Kind::TupleElement:
       case Kind::DictionaryKey:
-      case Kind::CodeCompletion:
         return {};
       }
       llvm_unreachable("unhandled kind");
@@ -5733,7 +5723,6 @@ public:
       case Kind::Property:
       case Kind::Identity:
       case Kind::TupleElement:
-      case Kind::CodeCompletion:
         llvm_unreachable("no unresolved name for this kind");
       }
       llvm_unreachable("unhandled kind");
@@ -5754,7 +5743,6 @@ public:
       case Kind::Identity:
       case Kind::TupleElement:
       case Kind::DictionaryKey:
-      case Kind::CodeCompletion:
         return false;
       }
       llvm_unreachable("unhandled kind");
@@ -5775,7 +5763,6 @@ public:
       case Kind::Identity:
       case Kind::TupleElement:
       case Kind::DictionaryKey:
-      case Kind::CodeCompletion:
         llvm_unreachable("no decl ref for this kind");
       }
       llvm_unreachable("unhandled kind");
@@ -5796,7 +5783,6 @@ public:
         case Kind::Property:
         case Kind::Subscript:
         case Kind::DictionaryKey:
-        case Kind::CodeCompletion:
           llvm_unreachable("no field number for this kind");
       }
       llvm_unreachable("unhandled kind");

--- a/include/swift/Sema/CodeCompletionTypeChecking.h
+++ b/include/swift/Sema/CodeCompletionTypeChecking.h
@@ -116,29 +116,6 @@ namespace swift {
     void sawSolution(const constraints::Solution &solution) override;
   };
 
-  class KeyPathTypeCheckCompletionCallback
-      : public TypeCheckCompletionCallback {
-  public:
-    struct Result {
-      /// The type on which completion should occur, i.e. a result type of the
-      /// previous component.
-      Type BaseType;
-      /// Whether code completion happens on the key path's root.
-      bool OnRoot;
-    };
-
-  private:
-    KeyPathExpr *KeyPath;
-    SmallVector<Result, 4> Results;
-
-  public:
-    KeyPathTypeCheckCompletionCallback(KeyPathExpr *KeyPath)
-        : KeyPath(KeyPath) {}
-
-    ArrayRef<Result> getResults() const { return Results; }
-
-    void sawSolution(const constraints::Solution &solution) override;
-  };
 }
 
 #endif

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1293,10 +1293,6 @@ public:
 
   bool hasType(ASTNode node) const;
 
-  /// Returns \c true if the \p ComponentIndex-th component in \p KP has a type
-  /// associated with it.
-  bool hasType(const KeyPathExpr *KP, unsigned ComponentIndex) const;
-
   /// Retrieve the type of the given node, as recorded in this solution.
   Type getType(ASTNode node) const;
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2880,9 +2880,6 @@ public:
         PrintWithColorRAII(OS, IdentifierColor)
           << "  key='" << component.getUnresolvedDeclName() << "'";
         break;
-      case KeyPathExpr::Component::Kind::CodeCompletion:
-        PrintWithColorRAII(OS, ASTNodeColor) << "completion";
-        break;
       }
       PrintWithColorRAII(OS, TypeColor)
         << " type='" << GetTypeOfKeyPathComponent(E, i) << "'";

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1125,7 +1125,6 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
       case KeyPathExpr::Component::Kind::Identity:
       case KeyPathExpr::Component::Kind::TupleElement:
       case KeyPathExpr::Component::Kind::DictionaryKey:
-      case KeyPathExpr::Component::Kind::CodeCompletion:
         // No subexpr to visit.
         break;
       }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2399,7 +2399,6 @@ void KeyPathExpr::Component::setSubscriptIndexHashableConformances(
   case Kind::Identity:
   case Kind::TupleElement:
   case Kind::DictionaryKey:
-  case Kind::CodeCompletion:
     llvm_unreachable("no hashable conformances for this kind");
   }
 }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -6727,28 +6727,6 @@ void deliverUnresolvedMemberResults(
   deliverCompletionResults(CompletionCtx, Lookup, DC, Consumer);
 }
 
-void deliverKeyPathResults(
-    ArrayRef<KeyPathTypeCheckCompletionCallback::Result> Results,
-    DeclContext *DC, SourceLoc DotLoc,
-    ide::CodeCompletionContext &CompletionCtx,
-    CodeCompletionConsumer &Consumer) {
-  ASTContext &Ctx = DC->getASTContext();
-  CompletionLookup Lookup(CompletionCtx.getResultSink(), Ctx, DC,
-                          &CompletionCtx);
-
-  if (DotLoc.isValid()) {
-    Lookup.setHaveDot(DotLoc);
-  }
-  Lookup.shouldCheckForDuplicates(Results.size() > 1);
-
-  for (auto &Result : Results) {
-    Lookup.setIsSwiftKeyPathExpr(Result.OnRoot);
-    Lookup.getValueExprCompletions(Result.BaseType);
-  }
-
-  deliverCompletionResults(CompletionCtx, Lookup, DC, Consumer);
-}
-
 void deliverDotExprResults(
     ArrayRef<DotExprTypeCheckCompletionCallback::Result> Results,
     Expr *BaseExpr, DeclContext *DC, SourceLoc DotLoc, bool IsInSelector,
@@ -6838,21 +6816,6 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
     addKeywords(CompletionContext.getResultSink(), MaybeFuncBody);
     deliverUnresolvedMemberResults(Lookup.getResults(), CurDeclContext, DotLoc,
                                    CompletionContext, Consumer);
-    return true;
-  }
-  case CompletionKind::KeyPathExprSwift: {
-    assert(CurDeclContext);
-
-    // CodeCompletionCallbacks::completeExprKeyPath takes a \c KeyPathExpr,
-    // so we can safely cast the \c ParsedExpr back to a \c KeyPathExpr.
-    auto KeyPath = cast<KeyPathExpr>(ParsedExpr);
-    KeyPathTypeCheckCompletionCallback Lookup(KeyPath);
-    llvm::SaveAndRestore<TypeCheckCompletionCallback *> CompletionCollector(
-        Context.CompletionCallback, &Lookup);
-    typeCheckContextAt(CurDeclContext, CompletionLoc);
-
-    deliverKeyPathResults(Lookup.getResults(), CurDeclContext, DotLoc,
-                          CompletionContext, Consumer);
     return true;
   }
   default:
@@ -6975,9 +6938,59 @@ void CodeCompletionCallbacksImpl::doneParsing() {
   case CompletionKind::None:
   case CompletionKind::DotExpr:
   case CompletionKind::UnresolvedMember:
-  case CompletionKind::KeyPathExprSwift:
     llvm_unreachable("should be already handled");
     return;
+
+  case CompletionKind::KeyPathExprSwift: {
+    auto KPE = dyn_cast<KeyPathExpr>(ParsedExpr);
+    auto BGT = (*ExprType)->getAs<BoundGenericType>();
+    if (!KPE || !BGT || BGT->getGenericArgs().size() != 2)
+      break;
+    assert(!KPE->isObjC());
+
+    if (DotLoc.isValid())
+      Lookup.setHaveDot(DotLoc);
+
+    bool OnRoot = !KPE->getComponents().front().isValid();
+    Lookup.setIsSwiftKeyPathExpr(OnRoot);
+
+    Type baseType = BGT->getGenericArgs()[OnRoot ? 0 : 1];
+    if (OnRoot && baseType->is<UnresolvedType>()) {
+      // Infer the root type of the keypath from the context type.
+      ExprContextInfo ContextInfo(CurDeclContext, ParsedExpr);
+      for (auto T : ContextInfo.getPossibleTypes()) {
+        if (auto unwrapped = T->getOptionalObjectType())
+          T = unwrapped;
+
+        // If the context type is any of the KeyPath types, use it.
+        if (T->getAnyNominal() && T->getAnyNominal()->getKeyPathTypeKind() &&
+            !T->hasUnresolvedType() && T->is<BoundGenericType>()) {
+          baseType = T->castTo<BoundGenericType>()->getGenericArgs()[0];
+          break;
+        }
+
+        // KeyPath can be used as a function that receives its root type.
+        if (T->is<AnyFunctionType>()) {
+          auto *fnType = T->castTo<AnyFunctionType>();
+          if (fnType->getNumParams() == 1) {
+            const AnyFunctionType::Param &param = fnType->getParams()[0];
+            baseType = param.getParameterType();
+            break;
+          }
+        }
+      }
+    }
+    if (!OnRoot && KPE->getComponents().back().getKind() ==
+                       KeyPathExpr::Component::Kind::OptionalWrap) {
+      // KeyPath expr with '?' (e.g. '\Ty.[0].prop?.another').
+      // Although expected type is optional, we should unwrap it because it's
+      // unwrapped.
+      baseType = baseType->getOptionalObjectType();
+    }
+
+    Lookup.getValueExprCompletions(baseType);
+    break;
+  }
 
   case CompletionKind::StmtOrExpr:
   case CompletionKind::ForEachSequence:

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -494,7 +494,6 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
       case KeyPathExpr::Component::Kind::OptionalForce:
       case KeyPathExpr::Component::Kind::Identity:
       case KeyPathExpr::Component::Kind::DictionaryKey:
-      case KeyPathExpr::Component::Kind::CodeCompletion:
         break;
       }
     }

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -440,7 +440,6 @@ std::pair<bool, Expr*> NameMatcher::walkToExprPre(Expr *E) {
             break;
           case KeyPathExpr::Component::Kind::DictionaryKey:
           case KeyPathExpr::Component::Kind::Invalid:
-          case KeyPathExpr::Component::Kind::CodeCompletion:
             break;
           case KeyPathExpr::Component::Kind::OptionalForce:
           case KeyPathExpr::Component::Kind::OptionalChain:

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -659,26 +659,21 @@ ParserResult<Expr> Parser::parseExprKeyPath() {
   if (rootResult.isNull() && pathResult.isNull())
     return nullptr;
 
+  auto keypath =
+      new (Context) KeyPathExpr(backslashLoc, rootResult.getPtrOrNull(),
+                                pathResult.getPtrOrNull(), hasLeadingDot);
+
   // Handle code completion.
   if ((Tok.is(tok::code_complete) && !Tok.isAtStartOfLine()) ||
       (Tok.is(tok::period) && peekToken().isAny(tok::code_complete))) {
     SourceLoc DotLoc;
     consumeIf(tok::period, DotLoc);
-
-    // Add the code completion expression to the path result.
-    CodeCompletionExpr *CC = new (Context)
-        CodeCompletionExpr(pathResult.getPtrOrNull(), Tok.getLoc());
-    auto keypath = new (Context)
-        KeyPathExpr(backslashLoc, rootResult.getPtrOrNull(), CC, hasLeadingDot);
     if (CodeCompletion)
       CodeCompletion->completeExprKeyPath(keypath, DotLoc);
     consumeToken(tok::code_complete);
     return makeParserCodeCompletionResult(keypath);
   }
 
-  auto keypath =
-      new (Context) KeyPathExpr(backslashLoc, rootResult.getPtrOrNull(),
-                                pathResult.getPtrOrNull(), hasLeadingDot);
   return makeParserResult(parseStatus, keypath);
 }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3736,7 +3736,6 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
     case KeyPathExpr::Component::Kind::Invalid:
     case KeyPathExpr::Component::Kind::UnresolvedProperty:
     case KeyPathExpr::Component::Kind::UnresolvedSubscript:
-    case KeyPathExpr::Component::Kind::CodeCompletion:
       llvm_unreachable("not resolved");
       break;
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8920,11 +8920,6 @@ bool Solution::hasType(ASTNode node) const {
   return cs.hasType(node);
 }
 
-bool Solution::hasType(const KeyPathExpr *KP, unsigned ComponentIndex) const {
-  auto &cs = getConstraintSystem();
-  return cs.hasType(KP, ComponentIndex);
-}
-
 Type Solution::getType(ASTNode node) const {
   auto result = nodeTypes.find(node);
   if (result != nodeTypes.end())

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -377,7 +377,6 @@ static bool buildObjCKeyPathString(KeyPathExpr *E,
     case KeyPathExpr::Component::Kind::Invalid:
     case KeyPathExpr::Component::Kind::UnresolvedProperty:
     case KeyPathExpr::Component::Kind::UnresolvedSubscript:
-    case KeyPathExpr::Component::Kind::CodeCompletion:
       // Don't bother building the key path string if the key path didn't even
       // resolve.
       return false;
@@ -4939,8 +4938,7 @@ namespace {
           }
           break;
         }
-        case KeyPathExpr::Component::Kind::Invalid:
-        case KeyPathExpr::Component::Kind::CodeCompletion: {
+        case KeyPathExpr::Component::Kind::Invalid: {
           auto component = origComponent;
           component.setComponentType(leafTy);
           resolvedComponents.push_back(component);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3232,7 +3232,7 @@ namespace {
           break;
         }
         case KeyPathExpr::Component::Kind::Identity:
-          break;
+          continue;
         case KeyPathExpr::Component::Kind::DictionaryKey:
           llvm_unreachable("DictionaryKey only valid in #keyPath");
           break;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9511,12 +9511,7 @@ ConstraintSystem::simplifyKeyPathConstraint(
     case KeyPathExpr::Component::Kind::Invalid:
     case KeyPathExpr::Component::Kind::Identity:
       break;
-
-    case KeyPathExpr::Component::Kind::CodeCompletion: {
-      anyComponentsUnresolved = true;
-      capability = ReadOnly;
-      break;
-    }
+      
     case KeyPathExpr::Component::Kind::Property:
     case KeyPathExpr::Component::Kind::Subscript:
     case KeyPathExpr::Component::Kind::UnresolvedProperty:

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -509,7 +509,6 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
     case ComponentKind::OptionalWrap:
     case ComponentKind::Identity:
     case ComponentKind::DictionaryKey:
-    case ComponentKind::CodeCompletion:
       // These components don't have any callee associated, so just continue.
       break;
     }

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -1891,15 +1891,6 @@ void PreCheckExpression::resolveKeyPathExpr(KeyPathExpr *KPE) {
             UDE->getName(), UDE->getLoc()));
 
         expr = UDE->getBase();
-      } else if (auto CCE = dyn_cast<CodeCompletionExpr>(expr)) {
-        components.push_back(
-            KeyPathExpr::Component::forCodeCompletion(CCE->getLoc()));
-
-        expr = CCE->getBase();
-        if (!expr) {
-          // We are completing on the key path's base. Stop iterating.
-          return;
-        }
       } else if (auto SE = dyn_cast<SubscriptExpr>(expr)) {
         // .[0] or just plain [0]
         components.push_back(

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2840,7 +2840,6 @@ private:
       case KeyPathExpr::Component::Kind::OptionalForce:
       case KeyPathExpr::Component::Kind::Identity:
       case KeyPathExpr::Component::Kind::DictionaryKey:
-      case KeyPathExpr::Component::Kind::CodeCompletion:
         break;
       }
     }

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -618,15 +618,7 @@ class CompletionContextFinder : public ASTWalker {
 
   /// Stack of all "interesting" contexts up to code completion expression.
   llvm::SmallVector<Context, 4> Contexts;
-
-  /// If we are completing inside an expression, the \c CodeCompletionExpr that
-  /// represents the code completion token.
-
-  /// The AST node that represents the code completion token, either as an
-  /// expression or a KeyPath component.
-  llvm::PointerUnion<CodeCompletionExpr *, const KeyPathExpr::Component *>
-      CompletionNode;
-
+  CodeCompletionExpr *CompletionExpr = nullptr;
   Expr *InitialExpr = nullptr;
   DeclContext *InitialDC;
 
@@ -672,17 +664,8 @@ public:
     }
 
     if (auto *CCE = dyn_cast<CodeCompletionExpr>(E)) {
-      CompletionNode = CCE;
+      CompletionExpr = CCE;
       return std::make_pair(false, nullptr);
-    }
-    if (auto *KeyPath = dyn_cast<KeyPathExpr>(E)) {
-      for (auto &component : KeyPath->getComponents()) {
-        if (component.getKind() ==
-            KeyPathExpr::Component::Kind::CodeCompletion) {
-          CompletionNode = &component;
-          return std::make_pair(false, nullptr);
-        }
-      }
     }
 
     return std::make_pair(true, E);
@@ -708,21 +691,12 @@ public:
   }
 
   bool hasCompletionExpr() const {
-    return CompletionNode.dyn_cast<CodeCompletionExpr *>() != nullptr;
+    return CompletionExpr;
   }
 
   CodeCompletionExpr *getCompletionExpr() const {
-    assert(hasCompletionExpr());
-    return CompletionNode.get<CodeCompletionExpr *>();
-  }
-
-  bool hasCompletionKeyPathComponent() const {
-    return CompletionNode.dyn_cast<const KeyPathExpr::Component *>() != nullptr;
-  }
-
-  const KeyPathExpr::Component *getCompletionKeyPathComponent() const {
-    assert(hasCompletionKeyPathComponent());
-    return CompletionNode.get<const KeyPathExpr::Component *>();
+    assert(CompletionExpr);
+    return CompletionExpr;
   }
 
   struct Fallback {
@@ -736,11 +710,7 @@ public:
   /// of the enclosing context e.g. when completion is an argument
   /// to a call.
   Optional<Fallback> getFallbackCompletionExpr() const {
-    if (!hasCompletionExpr()) {
-      // Creating a fallback expression only makes sense if we are completing in
-      // an expression, not when we're completing in a key path.
-      return None;
-    }
+    assert(CompletionExpr);
 
     Optional<Fallback> fallback;
     bool separatePrecheck = false;
@@ -776,8 +746,8 @@ public:
     if (fallback)
       return fallback;
 
-    if (getCompletionExpr()->getBase() && getCompletionExpr() != InitialExpr)
-      return Fallback{getCompletionExpr(), fallbackDC, separatePrecheck};
+    if (CompletionExpr->getBase() && CompletionExpr != InitialExpr)
+      return Fallback{CompletionExpr, fallbackDC, separatePrecheck};
     return None;
   }
 
@@ -832,7 +802,7 @@ static void filterSolutions(SolutionApplicationTarget &target,
   // the other formed solutions (which require fixes). We should generate enum
   // pattern completions separately, but for now ignore the
   // _OptionalNilComparisonType solution.
-  if (isForPatternMatch(target) && completionExpr) {
+  if (isForPatternMatch(target)) {
     solutions.erase(llvm::remove_if(solutions, [&](const Solution &S) {
       ASTContext &ctx = S.getConstraintSystem().getASTContext();
       if (!S.hasType(completionExpr))
@@ -889,8 +859,7 @@ bool TypeChecker::typeCheckForCodeCompletion(
 
   // If there was no completion expr (e.g. if the code completion location was
   // among tokens that were skipped over during parser error recovery) bail.
-  if (!contextAnalyzer.hasCompletionExpr() &&
-      !contextAnalyzer.hasCompletionKeyPathComponent())
+  if (!contextAnalyzer.hasCompletionExpr())
     return false;
 
   // Interpolation components are type-checked separately.
@@ -936,11 +905,7 @@ bool TypeChecker::typeCheckForCodeCompletion(
     // FIXME: instead of filtering, expose the score and viability to clients.
     // Remove any solutions that both require fixes and have a score that is
     // worse than the best.
-    CodeCompletionExpr *completionExpr = nullptr;
-    if (contextAnalyzer.hasCompletionExpr()) {
-      completionExpr = contextAnalyzer.getCompletionExpr();
-    }
-    filterSolutions(target, solutions, completionExpr);
+    filterSolutions(target, solutions, contextAnalyzer.getCompletionExpr());
 
     // Similarly, if the type-check didn't produce any solutions, fall back
     // to type-checking a sub-expression in isolation.
@@ -1280,56 +1245,4 @@ sawSolution(const constraints::Solution &S) {
 
   bool SingleExprBody = isImplicitSingleExpressionReturn(CS, CompletionExpr);
   Results.push_back({ExpectedTy, SingleExprBody});
-}
-
-void KeyPathTypeCheckCompletionCallback::sawSolution(
-    const constraints::Solution &S) {
-  // Determine the code completion.
-  size_t ComponentIndex = 0;
-  for (auto &Component : KeyPath->getComponents()) {
-    if (Component.getKind() == KeyPathExpr::Component::Kind::CodeCompletion) {
-      break;
-    } else {
-      ComponentIndex++;
-    }
-  }
-  assert(ComponentIndex < KeyPath->getComponents().size() &&
-         "Didn't find a code compleiton component?");
-
-  auto &CS = S.getConstraintSystem();
-  Type BaseType;
-  if (ComponentIndex == 0) {
-    // We are completing on the root and need to extract the key path's root
-    // type.
-    if (KeyPath->getRootType()) {
-      BaseType = S.getResolvedType(KeyPath->getRootType());
-    } else {
-      // The key path doesn't have a root TypeRepr set, so we can't look the key
-      // path's root up through it. Build a constraint locator and look the
-      // root type up through it.
-      // FIXME: Improve the linear search over S.typeBindings when it's possible
-      // to look up type variables by their locators.
-      auto RootLocator =
-          S.getConstraintLocator(KeyPath, {ConstraintLocator::KeyPathRoot});
-      auto BaseVariableType =
-          llvm::find_if(S.typeBindings, [&RootLocator](const auto &Entry) {
-            return Entry.first->getImpl().getLocator() == RootLocator;
-          })->getSecond();
-      BaseType = S.simplifyType(BaseVariableType);
-    }
-  } else {
-    // We are completing after a component. Get the previous component's result
-    // type.
-    BaseType = S.simplifyType(CS.getType(KeyPath, ComponentIndex - 1));
-  }
-
-  // If ExpectedTy is a duplicate of any other result, ignore this solution.
-  if (llvm::any_of(Results, [&](const Result &R) {
-    return R.BaseType->isEqual(BaseType);
-  })) {
-    return;
-  }
-  if (BaseType) {
-    Results.push_back({BaseType, /*OnRoot=*/(ComponentIndex == 0)});
-  }
 }

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -622,10 +622,10 @@ class CompletionContextFinder : public ASTWalker {
   /// If we are completing inside an expression, the \c CodeCompletionExpr that
   /// represents the code completion token.
 
-  /// The AST node that represents the code completion token, either as a
-  /// \c CodeCompletionExpr or a \c KeyPathExpr which contains a code completion
-  /// component.
-  llvm::PointerUnion<CodeCompletionExpr *, const KeyPathExpr *> CompletionNode;
+  /// The AST node that represents the code completion token, either as an
+  /// expression or a KeyPath component.
+  llvm::PointerUnion<CodeCompletionExpr *, const KeyPathExpr::Component *>
+      CompletionNode;
 
   Expr *InitialExpr = nullptr;
   DeclContext *InitialDC;
@@ -679,13 +679,10 @@ public:
       for (auto &component : KeyPath->getComponents()) {
         if (component.getKind() ==
             KeyPathExpr::Component::Kind::CodeCompletion) {
-          CompletionNode = KeyPath;
+          CompletionNode = &component;
           return std::make_pair(false, nullptr);
         }
       }
-      // Code completion in key paths is modelled by a code completion component
-      // Don't walk the key path's parsed expressions.
-      return std::make_pair(false, E);
     }
 
     return std::make_pair(true, E);
@@ -720,33 +717,12 @@ public:
   }
 
   bool hasCompletionKeyPathComponent() const {
-    return CompletionNode.dyn_cast<const KeyPathExpr *>() != nullptr;
+    return CompletionNode.dyn_cast<const KeyPathExpr::Component *>() != nullptr;
   }
 
-  /// If we are completing in a key path, returns the \c KeyPath that contains
-  /// the code completion component.
-  const KeyPathExpr *getKeyPathContainingCompletionComponent() const {
+  const KeyPathExpr::Component *getCompletionKeyPathComponent() const {
     assert(hasCompletionKeyPathComponent());
-    return CompletionNode.get<const KeyPathExpr *>();
-  }
-
-  /// If we are completing in a key path, returns the index at which the key
-  /// path has the code completion component.
-  size_t getKeyPathCompletionComponentIndex() const {
-    assert(hasCompletionKeyPathComponent());
-    size_t ComponentIndex = 0;
-    auto Components =
-        getKeyPathContainingCompletionComponent()->getComponents();
-    for (auto &Component : Components) {
-      if (Component.getKind() == KeyPathExpr::Component::Kind::CodeCompletion) {
-        break;
-      } else {
-        ComponentIndex++;
-      }
-    }
-    assert(ComponentIndex < Components.size() &&
-           "No completion component in the key path?");
-    return ComponentIndex;
+    return CompletionNode.get<const KeyPathExpr::Component *>();
   }
 
   struct Fallback {
@@ -977,27 +953,20 @@ bool TypeChecker::typeCheckForCodeCompletion(
     if (contextAnalyzer.locatedInMultiStmtClosure()) {
       auto &solution = solutions.front();
 
-      bool HasTypeForCompletionNode = false;
-      if (completionExpr) {
-        HasTypeForCompletionNode = solution.hasType(completionExpr);
-      } else {
-        assert(contextAnalyzer.hasCompletionKeyPathComponent());
-        HasTypeForCompletionNode = solution.hasType(
-            contextAnalyzer.getKeyPathContainingCompletionComponent(),
-            contextAnalyzer.getKeyPathCompletionComponentIndex());
+      if (solution.hasType(contextAnalyzer.getCompletionExpr())) {
+        llvm::for_each(solutions, callback);
+        return CompletionResult::Ok;
       }
 
-      if (!HasTypeForCompletionNode) {
-        // At this point we know the code completion node wasn't checked with
-        // the closure's surrounding context, so can defer to regular
-        // type-checking for the current call to typeCheckExpression. If that
-        // succeeds we will get a second call to typeCheckExpression for the
-        // body of the closure later and can gather completions then. If it
-        // doesn't we rely on the fallback typechecking in the subclasses of
-        // TypeCheckCompletionCallback that considers in isolation a
-        // sub-expression of the closure that contains the completion location.
-        return CompletionResult::NotApplicable;
-      }
+      // At this point we know the code completion expression wasn't checked
+      // with the closure's surrounding context, so can defer to regular type-
+      // checking for the current call to typeCheckExpression. If that succeeds
+      // we will get a second call to typeCheckExpression for the body of the
+      // closure later and can gather completions then. If it doesn't we rely
+      // on the fallback typechecking in the subclasses of
+      // TypeCheckCompletionCallback that considers in isolation a
+      // sub-expression of the closure that contains the completion location.
+      return CompletionResult::NotApplicable;
     }
 
     llvm::for_each(solutions, callback);

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -206,7 +206,6 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
     switch (auto kind = component.getKind()) {
     case KeyPathExpr::Component::Kind::Invalid:
     case KeyPathExpr::Component::Kind::Identity:
-    case KeyPathExpr::Component::Kind::CodeCompletion:
       continue;
 
     case KeyPathExpr::Component::Kind::UnresolvedProperty:

--- a/test/IDE/complete_swift_key_path.swift
+++ b/test/IDE/complete_swift_key_path.swift
@@ -35,7 +35,6 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_KEY_PATH_BASE | %FileCheck %s -check-prefix=PERSONTYPE-DOT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_KEY_PATH_RESULT | %FileCheck %s -check-prefix=PERSONTYPE-DOT
 
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=COMPLETE_AFTER_SELF | %FileCheck %s -check-prefix=OBJ-NODOT
 class Person {
     var name: String
     var friends: [Person] = []
@@ -191,8 +190,4 @@ func genericKeyPathBase<Root>(to keyPath: ReferenceWritableKeyPath<Root, Person>
 func genericKeyPathResult<KeyPathResult>(id: KeyPath<Person, KeyPathResult>) {
   genericKeyPathResult(\.#^GENERIC_KEY_PATH_RESULT^#)
   // Same as TYPE_DOT.
-}
-
-func completeAfterSelf(people: [Person]) {
-  people.map(\.self#^COMPLETE_AFTER_SELF^#)
 }

--- a/test/IDE/complete_swift_key_path.swift
+++ b/test/IDE/complete_swift_key_path.swift
@@ -32,9 +32,6 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONTEXT_FUNC_INOUT | %FileCheck %s -check-prefix=PERSONTYPE-DOT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONTEXT_FUNC_VARIADIC | %FileCheck %s -check-prefix=ARRAYTYPE-DOT
 
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_KEY_PATH_BASE | %FileCheck %s -check-prefix=PERSONTYPE-DOT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_KEY_PATH_RESULT | %FileCheck %s -check-prefix=PERSONTYPE-DOT
-
 class Person {
     var name: String
     var friends: [Person] = []
@@ -180,14 +177,4 @@ func testKeyPathAsFunctions(wrapped: Wrap<Person>) {
   // Same as TYPE_DOT.
   let _ = wrapped.variadic(\.#^CONTEXT_FUNC_VARIADIC^#)
   // Same as ARRAYTYPE_DOT.
-}
-
-func genericKeyPathBase<Root>(to keyPath: ReferenceWritableKeyPath<Root, Person>, on object: Root) {
-  genericKeyPathBase(to: \.#^GENERIC_KEY_PATH_BASE^#, on: Person())
-  // Same as TYPE_DOT.
-}
-
-func genericKeyPathResult<KeyPathResult>(id: KeyPath<Person, KeyPathResult>) {
-  genericKeyPathResult(\.#^GENERIC_KEY_PATH_RESULT^#)
-  // Same as TYPE_DOT.
 }

--- a/test/IDE/complete_swift_key_path.swift
+++ b/test/IDE/complete_swift_key_path.swift
@@ -36,9 +36,6 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_KEY_PATH_RESULT | %FileCheck %s -check-prefix=PERSONTYPE-DOT
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=COMPLETE_AFTER_SELF | %FileCheck %s -check-prefix=OBJ-NODOT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_RESULT_BUILDER | %FileCheck %s -check-prefix=PERSONTYPE-DOT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_MULTI_STMT_CLOSURE | %FileCheck %s -check-prefix=PERSONTYPE-DOT
-
 class Person {
     var name: String
     var friends: [Person] = []
@@ -198,33 +195,4 @@ func genericKeyPathResult<KeyPathResult>(id: KeyPath<Person, KeyPathResult>) {
 
 func completeAfterSelf(people: [Person]) {
   people.map(\.self#^COMPLETE_AFTER_SELF^#)
-}
-
-func inResultBuilder() {
-  protocol View2 {}
-
-  @resultBuilder public struct ViewBuilder2 {
-    public static func buildBlock<Content>(_ content: Content) -> Content where Content : View2 { fatalError() }
-    public static func buildIf<Content>(_ content: Content?) -> Content? where Content : View2 { fatalError() }
-  }
-
-  struct VStack2<Content>: View2 {
-    init(@ViewBuilder2 view: () -> Content) {}
-  }
-
-  @ViewBuilder2 var body: some View2 {
-    VStack2 {
-      if true {
-        var people: [Person] = []
-        people.map(\.#^IN_RESULT_BUILDER^#)
-      }
-    }
-  }
-}
-
-func inMultiStmtClosure(closure: () -> Void) {
-  inMultiStmtClosure {
-    var people: [Person] = []
-    people.map(\.#^IN_MULTI_STMT_CLOSURE^#)
-  }
 }


### PR DESCRIPTION
* **Explanation**: #38178 migrated key-path completion to the new solver-based approach, looking to improve code completion of key paths in generic contexts. When the stress tester started running again, it found some issues, which were fixed by #38300. Recently, the stress tester found more another crash around key path completion and I judge the risk of the change too be too for 5.5 now.
* **Scope**: Code completion inside key paths
* **Risk**: Low (this restores the old key path completion behavior with known missing completions but no known crashes)
* **Testing**: Swift CI is running the test suite before the PRs
* **Issue**: rdar://80474233
* **Reviewer**: @xedin (Pavel Yaskevich)