### PR TITLE
C++ Interop: tweak subscript operator tests

### DIFF
--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -147,7 +147,11 @@ private:
 
 struct NonTrivialIntArrayByVal {
   NonTrivialIntArrayByVal(int first) { values[0] = first; }
-  NonTrivialIntArrayByVal(const NonTrivialIntArrayByVal &other) {}
+  NonTrivialIntArrayByVal(const NonTrivialIntArrayByVal &other) {
+    for (int i = 0; i < 5; i++)
+      values[i] = other.values[i];
+  }
+
   int operator[](int x) const { return values[x]; }
 
   // For testing purposes.

--- a/test/Interop/Cxx/operators/Inputs/member-out-of-line.h
+++ b/test/Interop/Cxx/operators/Inputs/member-out-of-line.h
@@ -31,7 +31,10 @@ public:
 
 struct NonTrivialIntArrayByVal {
   NonTrivialIntArrayByVal(int first) { values[0] = first; }
-  NonTrivialIntArrayByVal(const NonTrivialIntArrayByVal &other) {}
+  NonTrivialIntArrayByVal(const NonTrivialIntArrayByVal &other) {
+    for (int i = 0; i < 5; i++)
+      values[i] = other.values[i];
+  }
   int operator[](int x);
 
   // For testing purposes.


### PR DESCRIPTION
C++ structs that define a non-default copy constructor should actually copy their members in the copy constructor:
Swift might copy the struct around, and if it does so after the `setValueAtIndex` call, the modification of `NonTrivialIntArrayByVal::values` won't propagate to the copied struct and these tests no longer pass:
• `Interop/Cxx/operators/member-inline.swift`
• `Interop/Cxx/operators/member-out-of-line.swift`

The tests are currently passing on the main branch despite this, but they might fail after a seemingly unrelated change (which is how I discovered this).