### PR TITLE
Fixup The Cross Build of SwiftSyntax

### DIFF
--- a/utils/build-parser-lib
+++ b/utils/build-parser-lib
@@ -169,6 +169,7 @@ class Builder(object):
             "-DSWIFT_HOST_VARIANT=" + self.host,
             "-DSWIFT_HOST_VARIANT_SDK=" + host_sdk,
             "-DSWIFT_HOST_VARIANT_ARCH=" + self.arch,
+            "-DCMAKE_Swift_COMPILER_TARGET=" + host_triple,
             "-DCMAKE_C_FLAGS=" + llvm_c_flags,
             "-DCMAKE_CXX_FLAGS=" + llvm_c_flags,
         ]


### PR DESCRIPTION
Propagate DCMAKE_Swift_COMPILER_TARGET with the host architecture of the
variant we're trying to build so CMake will forward the correct -arch - which is to say, the triple of the host we're trying to build against,
not the machine that it's building on currently.

Resolves rdar://80383591, SR-14904