### PR TITLE
[5.5][SILGen] Correct generic signature/substitutions of property wrapper generators within a closure.

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2461,7 +2461,10 @@ static CanAnyFunctionType getPropertyWrapperBackingInitializerInterfaceType(
     inputType = interfaceType->getCanonicalType();
   }
 
-  auto sig = DC->getGenericSignatureOfContext();
+  GenericSignature sig;
+  auto *closure = dyn_cast<AbstractClosureExpr>(DC);
+  if (!closure || closure->getCaptureInfo().hasGenericParamCaptures())
+    sig = DC->getGenericSignatureOfContext();
 
   AnyFunctionType::Param param(
       inputType, Identifier(),

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2447,37 +2447,20 @@ static CanAnyFunctionType getStoredPropertyInitializerInterfaceType(
 /// (property-type) -> backing-type.
 static CanAnyFunctionType getPropertyWrapperBackingInitializerInterfaceType(
                                                      TypeConverter &TC,
-                                                     VarDecl *VD) {
+                                                     VarDecl *VD,
+                                                     bool fromWrappedValue) {
   CanType resultType =
       VD->getPropertyWrapperBackingPropertyType()->getCanonicalType();
 
   auto *DC = VD->getInnermostDeclContext();
-  CanType inputType =
-    VD->getPropertyWrapperInitValueInterfaceType()->getCanonicalType();
+  CanType inputType;
+  if (fromWrappedValue) {
+    inputType = VD->getPropertyWrapperInitValueInterfaceType()->getCanonicalType();
+  } else {
+    Type interfaceType = VD->getPropertyWrapperProjectionVar()->getInterfaceType();
+    inputType = interfaceType->getCanonicalType();
+  }
 
-  auto sig = DC->getGenericSignatureOfContext();
-
-  AnyFunctionType::Param param(
-      inputType, Identifier(),
-      ParameterTypeFlags().withValueOwnership(ValueOwnership::Owned));
-  // FIXME: Verify ExtInfo state is correct, not working by accident.
-  CanAnyFunctionType::ExtInfo info;
-  return CanAnyFunctionType::get(getCanonicalSignatureOrNull(sig), {param},
-                                 resultType, info);
-}
-
-static CanAnyFunctionType getPropertyWrapperInitFromProjectedValueInterfaceType(TypeConverter &TC,
-                                                                                VarDecl *VD) {
-  CanType resultType =
-      VD->getPropertyWrapperBackingPropertyType()->getCanonicalType();
-
-  Type interfaceType = VD->getPropertyWrapperProjectionVar()->getInterfaceType();
-  if (interfaceType->hasArchetype())
-    interfaceType = interfaceType->mapTypeOutOfContext();
-
-  CanType inputType = interfaceType->getCanonicalType();
-
-  auto *DC = VD->getInnermostDeclContext();
   auto sig = DC->getGenericSignatureOfContext();
 
   AnyFunctionType::Param param(
@@ -2643,11 +2626,9 @@ CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {
   case SILDeclRef::Kind::StoredPropertyInitializer:
     return getStoredPropertyInitializerInterfaceType(cast<VarDecl>(vd));
   case SILDeclRef::Kind::PropertyWrapperBackingInitializer:
-    return getPropertyWrapperBackingInitializerInterfaceType(*this,
-                                                             cast<VarDecl>(vd));
   case SILDeclRef::Kind::PropertyWrapperInitFromProjectedValue:
-    return getPropertyWrapperInitFromProjectedValueInterfaceType(*this,
-                                                                 cast<VarDecl>(vd));
+    return getPropertyWrapperBackingInitializerInterfaceType(
+        *this, cast<VarDecl>(vd), c.kind == SILDeclRef::Kind::PropertyWrapperBackingInitializer);
   case SILDeclRef::Kind::IVarInitializer:
     return getIVarInitDestroyerInterfaceType(cast<ClassDecl>(vd),
                                              c.isForeign, false);

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2383,6 +2383,7 @@ static CanType removeNoEscape(CanType resultType) {
 
 /// Get the type of a default argument generator, () -> T.
 static CanAnyFunctionType getDefaultArgGeneratorInterfaceType(
+                                                     TypeConverter &TC,
                                                      SILDeclRef c) {
   auto *vd = c.getDecl();
   auto resultTy = getParameterAt(vd,
@@ -2400,14 +2401,7 @@ static CanAnyFunctionType getDefaultArgGeneratorInterfaceType(
   canResultTy = removeNoEscape(canResultTy);
 
   // Get the generic signature from the surrounding context.
-  auto sig = vd->getInnermostDeclContext()->getGenericSignatureOfContext();
-  if (auto *afd = dyn_cast<AbstractFunctionDecl>(vd)) {
-    auto *param = getParameterAt(afd, c.defaultArgIndex);
-    if (param->hasDefaultExpr()) {
-      auto captureInfo = param->getDefaultArgumentCaptureInfo();
-      sig = getEffectiveGenericSignature(afd, captureInfo);
-    }
-  }
+  auto sig = TC.getConstantGenericSignature(c);
 
   // FIXME: Verify ExtInfo state is correct, not working by accident.
   CanAnyFunctionType::ExtInfo info;
@@ -2447,24 +2441,20 @@ static CanAnyFunctionType getStoredPropertyInitializerInterfaceType(
 /// (property-type) -> backing-type.
 static CanAnyFunctionType getPropertyWrapperBackingInitializerInterfaceType(
                                                      TypeConverter &TC,
-                                                     VarDecl *VD,
-                                                     bool fromWrappedValue) {
+                                                     SILDeclRef c) {
+  auto *VD = cast<VarDecl>(c.getDecl());
   CanType resultType =
       VD->getPropertyWrapperBackingPropertyType()->getCanonicalType();
 
-  auto *DC = VD->getInnermostDeclContext();
   CanType inputType;
-  if (fromWrappedValue) {
+  if (c.kind == SILDeclRef::Kind::PropertyWrapperBackingInitializer) {
     inputType = VD->getPropertyWrapperInitValueInterfaceType()->getCanonicalType();
   } else {
     Type interfaceType = VD->getPropertyWrapperProjectionVar()->getInterfaceType();
     inputType = interfaceType->getCanonicalType();
   }
 
-  GenericSignature sig;
-  auto *closure = dyn_cast<AbstractClosureExpr>(DC);
-  if (!closure || closure->getCaptureInfo().hasGenericParamCaptures())
-    sig = DC->getGenericSignatureOfContext();
+  GenericSignature sig = TC.getConstantGenericSignature(c);
 
   AnyFunctionType::Param param(
       inputType, Identifier(),
@@ -2625,13 +2615,12 @@ CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {
     return getGlobalAccessorType(var->getInterfaceType()->getCanonicalType());
   }
   case SILDeclRef::Kind::DefaultArgGenerator:
-    return getDefaultArgGeneratorInterfaceType(c);
+    return getDefaultArgGeneratorInterfaceType(*this, c);
   case SILDeclRef::Kind::StoredPropertyInitializer:
     return getStoredPropertyInitializerInterfaceType(cast<VarDecl>(vd));
   case SILDeclRef::Kind::PropertyWrapperBackingInitializer:
   case SILDeclRef::Kind::PropertyWrapperInitFromProjectedValue:
-    return getPropertyWrapperBackingInitializerInterfaceType(
-        *this, cast<VarDecl>(vd), c.kind == SILDeclRef::Kind::PropertyWrapperBackingInitializer);
+    return getPropertyWrapperBackingInitializerInterfaceType(*this, c);
   case SILDeclRef::Kind::IVarInitializer:
     return getIVarInitDestroyerInterfaceType(cast<ClassDecl>(vd),
                                              c.isForeign, false);
@@ -2667,11 +2656,27 @@ TypeConverter::getConstantGenericSignature(SILDeclRef c) {
     return getEffectiveGenericSignature(
       vd->getInnermostDeclContext(), captureInfo);
   }
+  case SILDeclRef::Kind::PropertyWrapperBackingInitializer:
+  case SILDeclRef::Kind::PropertyWrapperInitFromProjectedValue: {
+    // FIXME: It might be better to compute lowered local captures of
+    // the property wrapper generator directly and collapse this into the
+    // above case. For now, take the generic signature of the enclosing
+    // context.
+    auto *dc = vd->getDeclContext();
+    if (dc->isLocalContext()) {
+      SILDeclRef enclosingDecl;
+      if (auto *closure = dyn_cast<AbstractClosureExpr>(dc)) {
+        enclosingDecl = SILDeclRef(closure);
+      } else {
+        enclosingDecl = SILDeclRef(cast<AbstractFunctionDecl>(dc));
+      }
+      return getConstantGenericSignature(enclosingDecl);
+    }
+    return dc->getGenericSignatureOfContext();
+  }
   case SILDeclRef::Kind::EnumElement:
   case SILDeclRef::Kind::GlobalAccessor:
   case SILDeclRef::Kind::StoredPropertyInitializer:
-  case SILDeclRef::Kind::PropertyWrapperBackingInitializer:
-  case SILDeclRef::Kind::PropertyWrapperInitFromProjectedValue:
     return vd->getDeclContext()->getGenericSignatureOfContext();
   }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5258,9 +5258,15 @@ RValue RValueEmitter::visitAppliedPropertyWrapperExpr(
     break;
   }
 
+  // The property wrapper generator function needs the same substitutions as the
+  // enclosing function or closure. If the parameter is declared in a function, take
+  // the substitutions from the concrete callee. Otherwise, forward the archetypes
+  // from the closure.
   SubstitutionMap subs;
   if (param->getDeclContext()->getAsDecl()) {
     subs = E->getCallee().getSubstitutions();
+  } else {
+    subs = SGF.getForwardingSubstitutionMap();
   }
 
   return SGF.emitApplyOfPropertyWrapperBackingInitializer(

--- a/test/SILGen/default_arguments_local.swift
+++ b/test/SILGen/default_arguments_local.swift
@@ -70,3 +70,16 @@ class ArtClass<T> {
 
   inner()
 }
+
+// CHECK-LABEL: sil hidden [ossa] @$s23default_arguments_local5outeryyxlF : $@convention(thin) <T> (@in_guaranteed T) -> ()
+func outer<T>(_: T) {
+  // CHECK-LABEL: sil private [ossa] @$s23default_arguments_local5outeryyxlF5innerL_yylF : $@convention(thin) <T> () -> ()
+  func inner() { print(T.self) }
+
+  // default argument 0 of hasDefault #1 <A>(x:) in outer<A>(_:)
+  // CHECK-LABEL: sil private [ossa] @$s23default_arguments_local5outeryyxlF10hasDefaultL_1xySi_tlFfA_ : $@convention(thin) <T> () -> Int
+
+  // CHECK-LABEL: sil private [ossa] @$s23default_arguments_local5outeryyxlF10hasDefaultL_1xySi_tlF : $@convention(thin) <T> (Int) -> ()
+  func hasDefault(x: Int = { inner(); return 3 }()) {}
+  hasDefault()
+}

--- a/test/SILGen/property_wrapper_parameter.swift
+++ b/test/SILGen/property_wrapper_parameter.swift
@@ -235,6 +235,27 @@ func genericContext<T>(_: T) where T: P {
 
   // property wrapper init from projected value of $value #1 in closure #2 in implicit closure #2 in genericContext<A>(_:)
   // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14genericContextyyxAA1PRzlFxAA17ProjectionWrapperVySiGcfu0_xAFcfU0_6$valueL_AFvpfW : $@convention(thin) <T where T : P> (ProjectionWrapper<Int>) -> ProjectionWrapper<Int>
+
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14genericContextyyxAA1PRzlF5innerL_1ayAA7WrapperVySiG_tAaCRzlF : $@convention(thin) (Wrapper<Int>) -> ()
+  func inner(@Wrapper a: Int) {}
+
+  // property wrapper backing initializer of a #1 in inner #1 <A>(a:) in genericContext<A>(_:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14genericContextyyxAA1PRzlF5innerL_1ayAA7WrapperVySiG_tAaCRzlFAEL_SivpfP : $@convention(thin) (Int) -> Wrapper<Int>
+
+  inner(a: 1)
+
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14genericContextyyxAA1PRzlF5innerL0_yyAaCRzlF : $@convention(thin) <T where T : P> () -> ()
+  func inner() { _ = T.self }
+
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14genericContextyyxAA1PRzlF5innerL1_1byAA7WrapperVySiG_tAaCRzlF : $@convention(thin) <T where T : P> (Wrapper<Int>) -> ()
+  func inner(@Wrapper b: Int) {
+    inner()
+  }
+
+  // property wrapper backing initializer of b #1 in inner #3 <A>(b:) in genericContext<A>(_:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14genericContextyyxAA1PRzlF5innerL1_1byAA7WrapperVySiG_tAaCRzlFAEL_SivpfP : $@convention(thin) <T where T : P> (Int) -> Wrapper<Int>
+
+  inner(b: 1)
 }
 
 @propertyWrapper

--- a/test/SILGen/property_wrapper_parameter.swift
+++ b/test/SILGen/property_wrapper_parameter.swift
@@ -208,6 +208,35 @@ func testImplicitPropertyWrapper(projection: ProjectionWrapper<Int>) {
   // CHECK: sil private [ossa] @$s26property_wrapper_parameter27testImplicitPropertyWrapper10projectionyAA010ProjectionG0VySiG_tFSi_AFtAFcfu0_Si_AFtAFcfU0_5valueL_Sivg : $@convention(thin) (ProjectionWrapper<Int>) -> Int
 }
 
+protocol P {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter14genericContextyyxAA1PRzlF : $@convention(thin) <T where T : P> (@in_guaranteed T) -> ()
+func genericContext<T>(_: T) where T: P {
+  let _: (ProjectionWrapper<Int>) -> Void = { $value in }
+
+  // implicit closure #1 in genericContext<A>(_:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14genericContextyyxAA1PRzlFyAA17ProjectionWrapperVySiGcfu_ : $@convention(thin) (ProjectionWrapper<Int>) -> ()
+
+  // This property wrapper generator function should _not_ have a generic signature,
+  // because the closure doesn't have one.
+
+  // property wrapper init from projected value of $value #1 in closure #1 in implicit closure #1 in genericContext<A>(_:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14genericContextyyxAA1PRzlFyAA17ProjectionWrapperVySiGcfu_yAFcfU_6$valueL_AFvpfW : $@convention(thin) (ProjectionWrapper<Int>) -> ProjectionWrapper<Int>
+
+  let _: (ProjectionWrapper<Int>) -> T = { $value in
+    fatalError()
+  }
+
+  // implicit closure #2 in genericContext<A>(_:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14genericContextyyxAA1PRzlFxAA17ProjectionWrapperVySiGcfu0_ : $@convention(thin) <T where T : P> (ProjectionWrapper<Int>) -> @out T
+
+  // This property wrapper generator function _should_ have a generic signature, because
+  // the closure does have one.
+
+  // property wrapper init from projected value of $value #1 in closure #2 in implicit closure #2 in genericContext<A>(_:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14genericContextyyxAA1PRzlFxAA17ProjectionWrapperVySiGcfu0_xAFcfU0_6$valueL_AFvpfW : $@convention(thin) <T where T : P> (ProjectionWrapper<Int>) -> ProjectionWrapper<Int>
+}
+
 @propertyWrapper
 public struct PublicWrapper<T> {
   public var wrappedValue: T


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/38323

* **Explanation**: Local functions and closures in generic contexts are emitted without generic signatures if the body doesn't capture any generic parameters. Local generator functions for arguments, including property wrapper argument generators and default argument generators, need to take this into account by computing transitive captures of their local context when deciding whether to propagate the generic signature from context. Otherwise, the compiler will hit an assertion failure in SILGen, or crash in IRGen if the generator requires substitutions that don't match the generic signature of the local context. `TypeConverter::getConstantGenericSignature` does take this into account, so computing the lowered interface type for these generators can simply call this function.
* **Scope**: Limited to local generator functions for property wrappers and default arguments.
* **Risk**: Low.
* **Testing**: Added several regression tests to the suite.
* **Reviewer**: @slavapestov 

Resolves: rdar://79587533