### PR TITLE
[Incremental Imports] Fix tests to avoid priors modTime changes

### DIFF
--- a/test/Driver/Dependencies/independent-fine.swift
+++ b/test/Driver/Dependencies/independent-fine.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar80485272
 // main | other
 
 // RUN: %empty-directory(%t)
@@ -15,7 +14,8 @@
 
 // CHECK-SECOND-NOT: Handled
 
-// RUN: touch -t 201401240006 %t/*
+// Don't change the priors mod time.
+// RUN: touch -t 201401240006 %t/*.{swift,swiftdeps,json}
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // RUN: touch -t 201401240007 %t/main.swift
@@ -33,7 +33,8 @@
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
-// RUN: touch -t 201401240006 %t/*
+// Don't change the priors mod time.
+// RUN: touch -t 201401240006 %t/*.{swift,swiftdeps,json}
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
 
 

--- a/test/Driver/Dependencies/independent-parseable-fine.swift
+++ b/test/Driver/Dependencies/independent-parseable-fine.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar80485272
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/independent-fine/* %t
 // RUN: touch -t 201401240005 %t/*
@@ -26,7 +25,8 @@
 // CHECK-SECOND-DAG: "{{(.\\/)?}}main.swift"
 // CHECK-SECOND: {{^}$}}
 
-// RUN: touch -t 201401240006 %t/*
+// Don't mess with the priors
+// RUN: touch -t 201401240006 %t/*.{swift,swiftdeps,json}
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 
@@ -74,6 +74,6 @@
 // CHECK-SECOND-MULTI-DAG: "{{(.\\/)?}}other.swift"
 // CHECK-SECOND-MULTI: {{^}$}}
 
-// RUN: touch -t 201401240006 %t/*
+// RUN: touch -t 201401240006 %t/*.{swift,swiftdeps,json}
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
 

--- a/test/Driver/Dependencies/one-way-external-delete-fine.swift
+++ b/test/Driver/Dependencies/one-way-external-delete-fine.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar80485272
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/one-way-external-fine/* %t
 // RUN: touch -t 201401240005 %t/*
@@ -14,7 +13,8 @@
 // CHECK-SECOND-NOT: Handled
 
 
-// RUN: touch -t 201401240005 %t/*
+// Don't change the .priors mod time
+// RUN: touch -t 201401240005 %t/*{swift,swiftdeps,json}
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: rm %t/other1-external
@@ -31,7 +31,8 @@
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents  ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 
-// RUN: touch -t 201401240005 %t/*
+// Don't change the .priors mod time
+// RUN: touch -t 201401240005 %t/*{swift,swiftdeps,json}
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: rm %t/main1-external

--- a/test/Driver/Dependencies/one-way-external-fine.swift
+++ b/test/Driver/Dependencies/one-way-external-fine.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar80485272
 /// other ==> main
 /// "./main1-external" ==> main
 /// "./main2-external" ==> main
@@ -19,8 +18,8 @@
 
 // CHECK-SECOND-NOT: Handled
 
-
-// RUN: touch -t 201401240005 %t/*
+// Don't change the .priors mod time
+// RUN: touch -t 201401240005 %t/*{swift,swiftdeps,json}
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: touch -t 203704010005 %t/other1-external
@@ -29,14 +28,16 @@
 // CHECK-THIRD-DAG: Handled other.swift
 // CHECK-THIRD-DAG: Handled main.swift
 
-// RUN: touch -t 201401240005 %t/*
+// Don't change the .priors mod time
+// RUN: touch -t 201401240005 %t/*{swift,swiftdeps,json}
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: touch -t 203704010005 %t/other2-external
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents  ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-THIRD %s
 
 
-// RUN: touch -t 201401240005 %t/*
+// Don't change the .priors mod time
+// RUN: touch -t 201401240005 %t/*{swift,swiftdeps,json}
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: touch -t 203704010005 %t/main1-external
@@ -46,7 +47,8 @@
 // CHECK-FOURTH: Handled main.swift
 // CHECK-FOURTH-NOT: Handled other.swift
 
-// RUN: touch -t 201401240005 %t/*
+// Don't change the .priors mod time
+// RUN: touch -t 201401240005 %t/*{swift,swiftdeps,json}
 // RUN: touch -t 201401240006 %t/*.o
 // RUN: touch -t 201401240004 %t/*-external
 // RUN: touch -t 203704010005 %t/main2-external


### PR DESCRIPTION
A new safeguard for incremental imports relies on the mod-time of the priors being consistent with that in the build record.

Update the tests to work with that safeguard.

fixes rdar://80485272