### PR TITLE
Re-enable actor inheritance from NSObject.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4357,8 +4357,6 @@ ERROR(async_objc_dynamic_self,none,
 ERROR(actor_inheritance,none,
       "%select{actor|distributed actor}0 types do not support inheritance",
       (bool))
-NOTE(actor_inheritance_nsobject,none,
-      "use '@objc' to expose actor %0 to Objective-C", (DeclName))
 
 ERROR(actor_protocol_illegal_inheritance,none,
       "non-actor type %0 cannot conform to the 'Actor' protocol",

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2406,18 +2406,12 @@ public:
 
     if (auto superclass = CD->getSuperclassDecl()) {
       // Actors cannot have superclasses, nor can they be superclasses.
-      if (CD->isActor()) {
+      if (CD->isActor() && !superclass->isNSObject())
         CD->diagnose(diag::actor_inheritance,
                      /*distributed=*/CD->isDistributedActor());
-        if (superclass->isNSObject() && !CD->isDistributedActor()) {
-          CD->diagnose(diag::actor_inheritance_nsobject, CD->getName())
-            .fixItInsert(CD->getAttributeInsertionLoc(/*forModifier=*/false),
-                         "@objc ");
-        }
-      } else if (superclass->isActor()) {
+      else if (superclass->isActor())
         CD->diagnose(diag::actor_inheritance,
                      /*distributed=*/CD->isDistributedActor());
-      }
     }
 
     // Force lowering of stored properties.

--- a/test/Interpreter/actor_class_forbid_objc_assoc_objects.swift
+++ b/test/Interpreter/actor_class_forbid_objc_assoc_objects.swift
@@ -10,7 +10,6 @@
 // UNSUPPORTED: back_deployment_runtime
 
 import ObjectiveC
-import Foundation
 import _Concurrency
 import StdlibUnittest
 
@@ -71,12 +70,26 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
 }
 
 @available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-@objc actor ActorNSObjectSubKlass {}
+actor ActorNSObjectSubKlass : NSObject {}
 
 if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
   Tests.test("no crash when inherit from nsobject")
   .code {
     let x = ActorNSObjectSubKlass()
+    objc_setAssociatedObject(x, "myKey", "myValue", .OBJC_ASSOCIATION_RETAIN)
+  }
+}
+
+@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
+actor ActorNSObjectSubKlassGeneric<T> : NSObject {
+  var state: T
+  init(state: T) { self.state = state }
+}
+
+if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
+  Tests.test("no crash when generic inherit from nsobject")
+  .code {
+    let x = ActorNSObjectSubKlassGeneric(state: 5)
     objc_setAssociatedObject(x, "myKey", "myValue", .OBJC_ASSOCIATION_RETAIN)
   }
 }

--- a/test/ModuleInterface/actor_objc.swift
+++ b/test/ModuleInterface/actor_objc.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-// CHECK-LABEL: @objc public actor SomeActor {
-// CHECK-NOT: @objc override public init()
-@objc public actor SomeActor {
+// CHECK-LABEL: @objc @_inheritsConvenienceInitializers public actor SomeActor : ObjectiveC.NSObject {
+// CHECK: @objc override public init()
+public actor SomeActor: NSObject {
 }

--- a/test/attr/attr_objc_async.swift
+++ b/test/attr/attr_objc_async.swift
@@ -51,10 +51,7 @@ actor class MyActor2 { }
 // expected-error@-1 {{keyword 'class' cannot be used as an identifier here}}
 
 // CHECK: @objc actor MyObjCActor
-@objc actor MyObjCActor { }
+@objc actor MyObjCActor: NSObject { }
 
-@objc actor class MyObjCActor2 {}
+@objc actor class MyObjCActor2: NSObject {}
 // expected-error@-1 {{keyword 'class' cannot be used as an identifier here}}
-
-actor MyObjCActor3: NSObject { } // expected-error{{actor types do not support inheritance}}
-// expected-note@-1{{use '@objc' to expose actor 'MyObjCActor3' to Objective-C}}


### PR DESCRIPTION
For now, it's the only way to get NSObjectProtocol conformance.
Fixes rdar://80476009.
