### PR TITLE
Sema: Typo correction should use GenericSignature and not GenericSignatureBuilder

### DIFF
--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -17,8 +17,8 @@
 #ifndef SWIFT_AST_NAME_LOOKUP_H
 #define SWIFT_AST_NAME_LOOKUP_H
 
-#include "llvm/ADT/SmallVector.h"
 #include "swift/AST/ASTVisitor.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Module.h"
 #include "swift/Basic/Compiler.h"
@@ -26,11 +26,11 @@
 #include "swift/Basic/NullablePtr.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Basic/SourceManager.h"
+#include "llvm/ADT/SmallVector.h"
 
 namespace swift {
 class ASTContext;
 class DeclName;
-class GenericSignatureBuilder;
 class Type;
 class TypeDecl;
 class ValueDecl;
@@ -487,7 +487,7 @@ void lookupVisibleMemberDecls(VisibleDeclConsumer &Consumer,
                               bool includeInstanceMembers,
                               bool includeDerivedRequirements,
                               bool includeProtocolExtensionMembers,
-                              GenericSignatureBuilder *GSB = nullptr);
+                              GenericSignature genericSig = GenericSignature());
 
 namespace namelookup {
 

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -595,7 +595,7 @@ void TypeChecker::performTypoCorrection(DeclContext *DC, DeclRefKind refKind,
                                         Type baseTypeOrNull,
                                         NameLookupOptions lookupOptions,
                                         TypoCorrectionResults &corrections,
-                                        GenericSignatureBuilder *gsb,
+                                        GenericSignature genericSig,
                                         unsigned maxResults) {
   // Disable typo-correction if we won't show the diagnostic anyway or if
   // we've hit our typo correction limit.
@@ -636,7 +636,8 @@ void TypeChecker::performTypoCorrection(DeclContext *DC, DeclRefKind refKind,
     lookupVisibleMemberDecls(consumer, baseTypeOrNull, DC,
                              /*includeInstanceMembers*/true,
                              /*includeDerivedRequirements*/false,
-                             /*includeProtocolExtensionMembers*/true, gsb);
+                             /*includeProtocolExtensionMembers*/true,
+                             genericSig);
   } else {
     lookupVisibleDecls(consumer, DC, /*top level*/ true,
                        corrections.Loc.getBaseNameLoc());

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -193,7 +193,8 @@ Type TypeResolution::resolveDependentMemberType(
   }
 
   assert(stage == TypeResolutionStage::Interface);
-  if (!getGenericSignature())
+  auto genericSig = getGenericSignature();
+  if (!genericSig)
     return ErrorType::get(baseTy);
 
   auto builder = getGenericSignatureBuilder();
@@ -218,7 +219,7 @@ Type TypeResolution::resolveDependentMemberType(
     TypeChecker::performTypoCorrection(DC, DeclRefKind::Ordinary,
                                        MetatypeType::get(baseTy),
                                        defaultMemberLookupOptions,
-                                       corrections, builder);
+                                       corrections, genericSig);
 
     // Check whether we have a single type result.
     auto singleType = cast_or_null<TypeDecl>(

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -23,6 +23,7 @@
 #include "swift/AST/Availability.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/GenericParamList.h"
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/KnownProtocols.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/NameLookup.h"
@@ -42,7 +43,6 @@ class Decl;
 class DeclAttribute;
 class DiagnosticEngine;
 class ExportContext;
-class GenericSignatureBuilder;
 class NominalTypeDecl;
 class NormalProtocolConformance;
 class RootProtocolConformance;
@@ -1109,7 +1109,7 @@ void performTypoCorrection(DeclContext *DC, DeclRefKind refKind,
                            Type baseTypeOrNull,
                            NameLookupOptions lookupOptions,
                            TypoCorrectionResults &corrections,
-                           GenericSignatureBuilder *gsb = nullptr,
+                           GenericSignature genericSig = GenericSignature(),
                            unsigned maxResults = 4);
 
 /// Check if the given decl has a @_semantics attribute that gives it


### PR DESCRIPTION
Typo correction would call directly into the GenericSignatureBuilder
to get a list of all nested types of a type parameter.

Since the time that code was written, higher level APIs were added to
GenericSignature which originally wrapped the GenericSignatureBuilder.

These days when the rewrite system is enabled, the GenericSignature
operations also use the rewrite system, and the long-term goal is
to get rid of GenericSignatureBuilder altogether.