### PR TITLE
GSB: Set HadAnyError in two more places

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -8146,6 +8146,8 @@ void GenericSignatureBuilder::enumerateRequirements(
                                RequirementRHS rhs) {
     if (auto req = createRequirement(kind, depTy, rhs, genericParams))
       requirements.push_back(*req);
+    else
+      Impl->HadAnyError = true;
   };
 
   // Collect all non-same type requirements.
@@ -8489,6 +8491,8 @@ GenericSignature GenericSignatureBuilder::rebuildSignatureWithoutRedundantRequir
       auto newReq = stripBoundDependentMemberTypes(*optReq);
       newBuilder.addRequirement(newReq, getRebuiltSource(req.getSource()),
                                 nullptr);
+    } else {
+      Impl->HadAnyError = true;
     }
   }
 

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -49,12 +49,13 @@ public struct S<A: P> where A.T == S<A> { // expected-error {{circular reference
 // expected-note@-3 {{while resolving type 'S<A>'}}
   func f(a: A.T) {
     g(a: id(t: a)) // `a` has error type which is diagnosed as circular reference
+    // expected-error@-1 {{conflicting arguments to generic parameter 'T' ('A.T' (associated type of protocol 'P') vs. 'S<A>')}}
     _ = A.T.self
   }
 
   func g(a: S<A>) {
     f(a: id(t: a))
-    // expected-error@-1 {{cannot convert value of type 'S<A>' to expected argument type 'A.T'}}
+    // expected-error@-1 {{conflicting arguments to generic parameter 'T' ('S<A>' vs. 'A.T' (associated type of protocol 'P'))}}
     _ = S<A>.self
   }
 


### PR DESCRIPTION
If we don't set this flag, we can end up making an invalid GSB into
the canonical builder for some signature. This was caught by
requirement machine cross-checking on the compiler_crashers suite.