### PR TITLE
[SR-14761] Improve diagnostic for implicitly overridden init()

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -627,7 +627,9 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current) const {
     // Thwart attempts to override the same declaration more than once.
     const auto *currentOverride = current->getOverriddenDecl();
     const auto *otherOverride = other->getOverriddenDecl();
-    if (currentOverride && currentOverride == otherOverride) {
+    const auto *otherInit = dyn_cast<ConstructorDecl>(other);
+    if (currentOverride && currentOverride == otherOverride &&
+        !(otherInit && otherInit->isImplicit())) {
       current->diagnose(diag::multiple_override, current->getName());
       other->diagnose(diag::multiple_override_prev, other->getName());
       current->setInvalid();

--- a/test/decl/init/basic_init.swift
+++ b/test/decl/init/basic_init.swift
@@ -22,15 +22,15 @@ class InitClass {
   @objc dynamic init(bar: Int) {}
 }
 class InitSubclass: InitClass {}
-// expected-note@-1{{'init(baz:)' previously overridden here}}
-// expected-note@-2{{'init(bar:)' previously overridden here}}
+// expected-note@-1{{implicit initializer 'init(baz:)' declared here}}
+// expected-note@-2{{implicit initializer 'init(bar:)' declared here}}
 extension InitSubclass {
   convenience init(arg: Bool) {} // expected-error{{non-@objc initializer 'init(arg:)' declared in 'InitClass' cannot be overridden from extension}}
   convenience override init(baz: Int) {}
-  // expected-error@-1 {{'init(baz:)' has already been overridden}}
+  // expected-error@-1 {{initializer 'init(baz:)' with Objective-C selector 'initWithBaz:' conflicts with implicit initializer 'init(baz:)' with the same Objective-C selector}}
   // expected-error@-2 {{cannot override a non-dynamic class declaration from an extension}}
   convenience override init(bar: Int) {}
-  // expected-error@-1 {{'init(bar:)' has already been overridden}}
+  // expected-error@-1 {{initializer 'init(bar:)' with Objective-C selector 'initWithBar:' conflicts with implicit initializer 'init(bar:)' with the same Objective-C selector}}
 }
 
 struct InitStruct {

--- a/test/decl/objc_redeclaration.swift
+++ b/test/decl/objc_redeclaration.swift
@@ -60,5 +60,11 @@ extension DummyClass {
   @objc func nsstringProperty2() -> Int { return 0 } // expected-error{{method 'nsstringProperty2()' with Objective-C selector 'nsstringProperty2' conflicts with getter for 'nsstringProperty2' with the same Objective-C selector}}
 }
 
+open class MyObject: NSObject {} // expected-note{{implicit initializer 'init()' declared here}}
+
+extension MyObject {
+    public override convenience init() {} // expected-error{{initializer 'init()' with Objective-C selector 'init' conflicts with implicit initializer 'init()' with the same Objective-C selector}}
+}
+
 // FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: 'nsstringProperty2' previously declared here


### PR DESCRIPTION
Provide more detailed diagnostic message when implicitly synthesized @objc initializer in subclass was overridden inside the subclass' extension

Resolves SR-14761