### PR TITLE
[Tests] Fix redundant protocol conformance test for remote cases.

### DIFF
--- a/test/multifile/protocol-conformance-redundant.swift
+++ b/test/multifile/protocol-conformance-redundant.swift
@@ -3,7 +3,7 @@
 // RUN: %target-build-swift-dylib(%t/%target-library-name(Ext)) -module-name Ext -emit-module -emit-module-path %t/Ext.swiftmodule -I%t -L%t -lDef %S/Inputs/protocol-conformance-redundant-ext.swift
 // RUN: %target-build-swift -I%t -L%t -lDef -o %t/main %target-rpath(%t) %s
 // RUN: %target-codesign %t/main %t/%target-library-name(Def) %t/%target-library-name(Ext)
-// RUN: %target-run %t/main %t/%target-library-name(Ext) 2>&1 | %FileCheck %s
+// RUN: %target-run %t/main %t/%target-library-name(Def) %t/%target-library-name(Ext) 2>&1 | %FileCheck %s
 
 // REQUIRES: executable_test
 // XFAIL: windows


### PR DESCRIPTION
Apparently it's necessary to list all the files used in `%target-run`, otherwise when we're running the tests remotely on a device, they might not be copied.

rdar://80283113
