### PR TITLE
[CI][Linux] Fix TSan libdispatch CI configuration

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
+++ b/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
@@ -43,7 +43,9 @@ class TSanLibDispatch(cmake_product.CMakeProduct):
 
     def build(self, host_target):
         """Build TSan runtime (compiler-rt)."""
-        rt_source_dir = join_path(self.source_dir, os.pardir, 'compiler-rt')
+        # Fixup source dir for CMake: <root>/tsan-libdispatch-test -> <root>/llvm-project/compiler-rt
+        self.source_dir = join_path(self.source_dir, os.pardir, 'llvm-project', 'compiler-rt')
+
         toolchain_path = join_path(self.args.install_destdir, 'usr')
         clang = join_path(toolchain_path, 'bin', 'clang')
         clangxx = join_path(toolchain_path, 'bin', 'clang++')

--- a/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
+++ b/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
@@ -12,6 +12,7 @@
 
 import os
 
+from . import cmake_product
 from . import cmark
 from . import foundation
 from . import libcxx
@@ -19,7 +20,6 @@ from . import libdispatch
 from . import libicu
 from . import llbuild
 from . import llvm
-from . import product
 from . import swift
 from . import swiftpm
 from . import xctest
@@ -30,7 +30,7 @@ def join_path(*paths):
     return os.path.abspath(os.path.join(*paths))
 
 
-class TSanLibDispatch(product.Product):
+class TSanLibDispatch(cmake_product.CMakeProduct):
     @classmethod
     def product_source_name(cls):
         return "tsan-libdispatch-test"
@@ -53,28 +53,18 @@ class TSanLibDispatch(product.Product):
         clang = join_path(toolchain_path, 'bin', 'clang')
         clangxx = join_path(toolchain_path, 'bin', 'clang++')
 
-        config_cmd = [
-            'cmake',
-            '-GNinja',
-            '-DCMAKE_PREFIX_PATH=%s' % toolchain_path,
-            '-DCMAKE_C_COMPILER=%s' % clang,
-            '-DCMAKE_CXX_COMPILER=%s' % clangxx,
-            '-DCMAKE_BUILD_TYPE=Release',
-            '-DLLVM_ENABLE_ASSERTIONS=ON',
-            '-DCOMPILER_RT_INCLUDE_TESTS=ON',
-            '-DCOMPILER_RT_BUILD_XRAY=OFF',
-            '-DCOMPILER_RT_INTERCEPT_LIBDISPATCH=ON',
-            '-DCOMPILER_RT_LIBDISPATCH_INSTALL_PATH=%s' % toolchain_path,
-            rt_source_dir]
-        build_cmd = ['ninja', 'tsan']
+        self.cmake_options.define('CMAKE_PREFIX_PATH', toolchain_path)
+        self.cmake_options.define('CMAKE_C_COMPILER', clang)
+        self.cmake_options.define('CMAKE_CXX_COMPILER', clangxx)
+        self.cmake_options.define('CMAKE_BUILD_TYPE', 'Release')
+        self.cmake_options.define('LLVM_ENABLE_ASSERTIONS', 'ON')
+        self.cmake_options.define('COMPILER_RT_DEBUG', 'ON')
+        self.cmake_options.define('COMPILER_RT_INCLUDE_TESTS', 'ON')
+        self.cmake_options.define('COMPILER_RT_BUILD_XRAY', 'OFF')
+        self.cmake_options.define('COMPILER_RT_INTERCEPT_LIBDISPATCH', 'ON')
+        self.cmake_options.define('COMPILER_RT_LIBDISPATCH_INSTALL_PATH', toolchain_path)
 
-        # Always rebuild TSan runtime
-        shell.rmtree(self.build_dir)
-        shell.makedirs(self.build_dir)
-
-        with shell.pushd(self.build_dir):
-            shell.call(config_cmd)
-            shell.call(build_cmd)
+        self.build_with_cmake(['tsan'], 'Release', [])
 
     def should_test(self, host_target):
         return True

--- a/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
+++ b/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
@@ -13,16 +13,11 @@
 import os
 
 from . import cmake_product
-from . import cmark
 from . import foundation
 from . import libcxx
 from . import libdispatch
 from . import libicu
-from . import llbuild
 from . import llvm
-from . import swift
-from . import swiftpm
-from . import xctest
 from .. import shell
 
 
@@ -85,13 +80,8 @@ class TSanLibDispatch(cmake_product.CMakeProduct):
 
     @classmethod
     def get_dependencies(cls):
-        return [cmark.CMark,
-                llvm.LLVM,
+        return [llvm.LLVM,
                 libcxx.LibCXX,
                 libicu.LibICU,
-                swift.Swift,
                 libdispatch.LibDispatch,
-                foundation.Foundation,
-                xctest.XCTest,
-                llbuild.LLBuild,
-                swiftpm.SwiftPM]
+                foundation.Foundation]


### PR DESCRIPTION
Fix the TSan libdispatch CI configuration for Linux by adopting
`CMakeProduct`.

The configuration has been broken for a while due to a cmake error:
```
CMake Error at CMakeLists.txt:6 (cmake_minimum_required):
  CMake 3.13.4 or higher is required.  You are running version 3.10.2
```
https://ci.swift.org/job/oss-swift-tsan-libdispatch-linux-ubuntu-18_04

rdar://79800820
