### PR TITLE
[TBDGen] Use default kind for AFPAST SILDeclRef.

### DIFF
--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -468,9 +468,7 @@ std::string LinkEntity::mangleAsString() const {
 
   case Kind::AsyncFunctionPointerAST: {
     std::string Result;
-    Result =
-        SILDeclRef(const_cast<ValueDecl *>(getDecl()), SILDeclRef::Kind::Func)
-            .mangle();
+    Result = SILDeclRef(const_cast<ValueDecl *>(getDecl())).mangle();
     Result.append("Tu");
     return Result;
   }

--- a/test/TBD/rdar80485869.swift
+++ b/test/TBD/rdar80485869.swift
@@ -1,0 +1,7 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -emit-module-path %t/module -emit-tbd -enable-testing
+
+public actor Tom {
+    init() async {
+    }
+}


### PR DESCRIPTION
When adding an AsyncFunctionPointer to the TBD, a LinkEntity of kind AsyncFunctionPointerAST is constructed containing the decl.  That decl is then wrapped in a SILDeclRef which is then mangled.

Previously, the kind of the SILDeclRef was erroneously forced to be Func.  The result was a failure to mangle the TBD symbol for async constructors correctly.

Here, that argument is omitted so that the kind can be determined appropriately by SILDeclRef's constructor.

rdar://80485869
