### PR TITLE
SIL: Allow lowering Optional<T> against a nested type of an opaque result type

### DIFF
--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -322,8 +322,6 @@ bool AbstractionPattern::matchesTuple(CanTupleType substType) {
     auto type = getType();
     if (auto tuple = dyn_cast<TupleType>(type))
       return (tuple->getNumElements() == substType->getNumElements());
-    if (isa<OpaqueTypeArchetypeType>(type))
-      return true;
     return false;
   }
   }
@@ -873,9 +871,7 @@ AbstractionPattern AbstractionPattern::getOptionalObjectType() const {
     return *this;
 
   case Kind::Type:
-    if (isTypeParameter())
-      return AbstractionPattern::getOpaque();
-    if (isa<OpaqueTypeArchetypeType>(getType()))
+    if (isTypeParameterOrOpaqueArchetype())
       return AbstractionPattern::getOpaque();
     return AbstractionPattern(getGenericSignature(),
                               ::getOptionalObjectType(getType()));

--- a/test/SILGen/Inputs/opaque_result_type_nested_optional_other.swift
+++ b/test/SILGen/Inputs/opaque_result_type_nested_optional_other.swift
@@ -1,0 +1,14 @@
+public protocol P {
+    associatedtype A
+}
+
+public func bar<T : P>(_: T) -> T.A {
+    fatalError()
+}
+
+public struct S<A> : P {}
+
+public func foo() -> some P {
+    return S<Int?>()
+}
+

--- a/test/SILGen/opaque_result_type_nested_optional.swift
+++ b/test/SILGen/opaque_result_type_nested_optional.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %S/Inputs/opaque_result_type_nested_optional_other.swift -emit-module-path %t/opaque_result_type_nested_optional_other.swiftmodule -disable-availability-checking
+// RUN: %target-swift-emit-silgen %s -I %t | %FileCheck %s
+
+import opaque_result_type_nested_optional_other
+
+_ = bar(foo())
+
+// CHECK-LABEL: sil [ossa] @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+// CHECK: [[OUTER:%.*]] = alloc_stack $Optional<Int>
+// CHECK: [[UNUSED:%.*]] = alloc_stack $S<Optional<Int>>
+// CHECK: [[INNER:%.*]] = alloc_stack $S<Optional<Int>>
+// CHECK: [[FN:%.*]] = function_ref @$s40opaque_result_type_nested_optional_other3bary1AQzxAA1PRzlF : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0.A
+// CHECK: apply [[FN]]<S<Int?>>([[OUTER]], [[INNER]]) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0.A
+// CHECK: return


### PR DESCRIPTION
Only the root archetype is a OpaqueTypeArchetypeType; the nested types are
NestedArchetypeType. Use the correct predicate here.

Also remove a dead check in tuple lowering; the `isa<OpaqueTypeArchetypeType>()`
check is dominated by isTypeParameterOrOpaqueArchetype() which is always
true if `isa<OpaqueTypeArchetypeType>()` is true anyway.

Fixes rdar://problem/79597666.