### PR TITLE
Only force-check actor isolation for nominal types.

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1681,8 +1681,10 @@ public:
       (void) VD->isObjC();
       (void) VD->isDynamic();
 
-      // Check for actor isolation.
-      (void)getActorIsolation(VD);
+      if (isa<NominalTypeDecl>(VD)) {
+        // Check for actor isolation.
+        (void)getActorIsolation(VD);
+      }
 
       // If this is a member of a nominal type, don't allow it to have a name of
       // "Type" or "Protocol" since we reserve the X.Type and X.Protocol


### PR DESCRIPTION
We shouldn't need to force-check actor isolation for other declarations,
and it's causing some problematic cycles that are breaking associated
type inference. Back off on checking actor isolation for now.

Fixes rdar://80476832.
