### PR TITLE
Add support for opaque result types in structural positions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1862,6 +1862,11 @@ WARNING(spi_attribute_on_import_of_public_module,none,
 ERROR(opaque_type_invalid_constraint,none,
       "an 'opaque' type must specify only 'Any', 'AnyObject', protocols, "
       "and/or a base class", ())
+NOTE(opaque_of_optional_rewrite,none,
+      "did you mean to write an optional of an 'opaque' type?", ())
+ERROR(more_than_one_opaque_type,none,
+      "%0 contains multiple 'opaque' types, but only one 'opaque' type is "
+      "supported", (TypeRepr*))
 ERROR(inferred_opaque_type,none,
       "property definition has inferred type %0, involving the 'some' "
       "return type of another declaration", (Type))
@@ -4060,9 +4065,6 @@ WARNING(trailing_closure_requires_parens,none,
         " statement; pass as a parenthesized argument to silence this warning",
         ())
 
-ERROR(opaque_type_var_no_init,none,
-      "property declares an opaque return type, but has no initializer "
-      "expression from which to infer an underlying type", ())
 ERROR(opaque_type_no_underlying_type_candidates,none,
       "function declares an opaque return type, but has no return statements "
       "in its body from which to infer an underlying type", ())
@@ -4074,6 +4076,9 @@ NOTE(opaque_type_underlying_type_candidate_here,none,
 ERROR(opaque_type_self_referential_underlying_type,none,
       "function opaque return type was inferred as %0, which defines the "
       "opaque type in terms of itself", (Type))
+ERROR(opaque_type_var_no_init,none,
+      "property declares an opaque return type, but has no initializer "
+      "expression from which to infer an underlying type", ())
 ERROR(opaque_type_var_no_underlying_type,none,
       "property declares an opaque return type, but cannot infer the "
       "underlying type from its initializer expression", ())

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3193,8 +3193,9 @@ public:
   }
 };
 
-
-/// Use an opaque type to abstract a value of the underlying concrete type.
+/// Use an opaque type to abstract a value of the underlying concrete type,
+/// possibly nested inside other types. E.g. can perform coversions "T --->
+/// (opaque type)" and "S<T> ---> S<(opaque type)>".
 class UnderlyingToOpaqueExpr : public ImplicitConversionExpr {
 public:
   UnderlyingToOpaqueExpr(Expr *subExpr, Type ty)

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -150,6 +150,20 @@ public:
     return walk(walker);
   }
 
+  /// Look through the given type and its children to find a type for
+  /// which the given predicate returns true.
+  ///
+  /// \param pred A predicate function object. It should return true if the
+  /// given type node satisfies the criteria.
+  ///
+  /// \returns true if the predicate returns true for the given type or any of
+  /// its children.
+  bool findIf(llvm::function_ref<bool(TypeRepr *)> pred);
+
+  /// Check recursively whether this type repr or any of its decendants are
+  /// opaque return type reprs.
+  bool hasOpaque();
+
   //*** Allocation Routines ************************************************/
 
   void *operator new(size_t bytes, const ASTContext &C,
@@ -1108,9 +1122,9 @@ private:
 /// A TypeRepr for a type with a generic parameter list of named opaque return
 /// types.
 ///
-/// This can occur only as the return type of a function declaration, to specify
-/// subtypes which should be abstracted from callers, given a set of generic
-/// constraints that the concrete types satisfy:
+/// This can occur only as the return type of a function declaration, or the
+/// type of a property, to specify types which should be abstracted from
+/// callers, given a set of generic constraints that the concrete types satisfy:
 ///
 /// func foo() -> <T: Collection> T { return [1] }
 class NamedOpaqueReturnTypeRepr : public TypeRepr {

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5472,8 +5472,6 @@ class OpaqueTypeArchetypeType final : public ArchetypeType,
   GenericEnvironment *Environment;
   
 public:
-  /// Get
-
   /// Get an opaque archetype representing the underlying type of the given
   /// opaque type decl's opaque param with ordinal `ordinal`. For example, in
   /// `(some P, some Q)`, `some P`'s type param would have ordinal 0 and `some

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5472,13 +5472,15 @@ class OpaqueTypeArchetypeType final : public ArchetypeType,
   GenericEnvironment *Environment;
   
 public:
-  /// Get 
-  
+  /// Get
+
   /// Get an opaque archetype representing the underlying type of the given
-  /// opaque type decl.
-  static OpaqueTypeArchetypeType *get(OpaqueTypeDecl *Decl,
+  /// opaque type decl's opaque param with ordinal `ordinal`. For example, in
+  /// `(some P, some Q)`, `some P`'s type param would have ordinal 0 and `some
+  /// Q`'s type param would have ordinal 1.
+  static OpaqueTypeArchetypeType *get(OpaqueTypeDecl *Decl, unsigned ordinal,
                                       SubstitutionMap Substitutions);
-  
+
   OpaqueTypeDecl *getDecl() const {
     return OpaqueDecl;
   }
@@ -5509,7 +5511,7 @@ public:
   ///
   /// then the underlying type of `some P` would be ordinal 0, and `some Q` would be ordinal 1.
   unsigned getOrdinal() const {
-    // TODO: multiple opaque types
+    // TODO [OPAQUE SUPPORT]: multiple opaque types
     return 0;
   }
   

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -154,9 +154,6 @@ enum class ConstraintKind : char {
   /// The first type is a function type, the second is the function's
   /// result type.
   FunctionResult,
-  /// The first type is a type that's a candidate to be the underlying type of
-  /// the second opaque archetype.
-  OpaqueUnderlyingType,
   /// The first type will be equal to the second type, but only when the
   /// second type has been fully determined (and mapped down to a concrete
   /// type). At that point, this constraint will be treated like an `Equal`
@@ -604,7 +601,6 @@ public:
     case ConstraintKind::DynamicCallableApplicableFunction:
     case ConstraintKind::BindOverload:
     case ConstraintKind::OptionalObject:
-    case ConstraintKind::OpaqueUnderlyingType:
     case ConstraintKind::OneWayEqual:
     case ConstraintKind::OneWayBindParam:
     case ConstraintKind::DefaultClosureType:

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -785,6 +785,19 @@ public:
   }
 };
 
+class LocatorPathElt::OpenedOpaqueArchetype final
+    : public StoredPointerElement<OpaqueTypeDecl> {
+public:
+  OpenedOpaqueArchetype(OpaqueTypeDecl *decl)
+      : StoredPointerElement(PathElementKind::OpenedOpaqueArchetype, decl) {}
+
+  OpaqueTypeDecl *getDecl() const { return getStoredPointer(); }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::OpenedOpaqueArchetype;
+  }
+};
+
 class LocatorPathElt::KeyPathDynamicMember final : public StoredPointerElement<NominalTypeDecl> {
 public:
   KeyPathDynamicMember(NominalTypeDecl *keyPathDecl)

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -134,6 +134,10 @@ SIMPLE_LOCATOR_PATH_ELT(MemberRefBase)
 /// base of the locator.
 CUSTOM_LOCATOR_PATH_ELT(OpenedGeneric)
 
+/// This is referring to a type produced by opening an opaque type archetype
+/// type at the base of the locator.
+CUSTOM_LOCATOR_PATH_ELT(OpenedOpaqueArchetype)
+
 /// An optional payload.
 SIMPLE_LOCATOR_PATH_ELT(OptionalPayload)
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4726,16 +4726,10 @@ public:
 
   /// Apply the given result builder to the closure expression.
   ///
-  /// \param bodyResultType The type which the body of the result builder
-  /// evaluates to, with all opaque archetype types un-opened.
-  /// \param openedBodyResultType The type which the body of the result builder
-  /// evalutes to, with all opaque archetype types opened.
-  ///
   /// \returns \c None when the result builder cannot be applied at all,
   /// otherwise the result of applying the result builder.
   Optional<TypeMatchResult>
   matchResultBuilder(AnyFunctionRef fn, Type builderType, Type bodyResultType,
-                     Type openedBodyResultType,
                      ConstraintKind bodyResultConstraintKind,
                      ConstraintLocatorBuilder locator);
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -792,7 +792,7 @@ struct AppliedBuilderTransform {
   Type builderType;
 
   /// The result type of the body, to which the returned expression will be
-  /// converted.
+  /// converted. Opaque types should be unopened.
   Type bodyResultType;
 
   /// An expression whose value has been recorded for later use.
@@ -3318,9 +3318,8 @@ public:
                      bool isFavored = false);
 
   /// Add the appropriate constraint for a contextual conversion.
-  void addContextualConversionConstraint(
-      Expr *expr, Type conversionType, ContextualTypePurpose purpose,
-      bool isOpaqueReturnType);
+  void addContextualConversionConstraint(Expr *expr, Type conversionType,
+                                         ContextualTypePurpose purpose);
 
   /// Convenience function to pass an \c ArrayRef to \c addJoinConstraint
   Type addJoinConstraint(ConstraintLocator *locator,
@@ -3855,6 +3854,12 @@ public:
   ///
   /// \returns The opened type, or \c type if there are no archetypes in it.
   Type openType(Type type, OpenedTypeMap &replacements);
+
+  /// "Open" an opaque archetype type.
+  Type openOpaqueType(Type type, ConstraintLocatorBuilder locator);
+
+  /// Recurse over the given type and open any opaque archetype types.
+  Type openOpaqueTypeRec(Type type, ConstraintLocatorBuilder locator);
 
   /// "Open" the given function type.
   ///
@@ -4593,12 +4598,6 @@ private:
                                           TypeMatchOptions flags,
                                           ConstraintLocatorBuilder locator);
 
-  /// Attempt to simplify an OpaqueUnderlyingType constraint.
-  SolutionKind simplifyOpaqueUnderlyingTypeConstraint(Type type1,
-                                              Type type2,
-                                              TypeMatchOptions flags,
-                                              ConstraintLocatorBuilder locator);
-  
   /// Attempt to simplify the BridgingConversion constraint.
   SolutionKind simplifyBridgingConstraint(Type type1,
                                          Type type2,
@@ -4727,12 +4726,18 @@ public:
 
   /// Apply the given result builder to the closure expression.
   ///
+  /// \param bodyResultType The type which the body of the result builder
+  /// evaluates to, with all opaque archetype types un-opened.
+  /// \param openedBodyResultType The type which the body of the result builder
+  /// evalutes to, with all opaque archetype types opened.
+  ///
   /// \returns \c None when the result builder cannot be applied at all,
   /// otherwise the result of applying the result builder.
-  Optional<TypeMatchResult> matchResultBuilder(
-      AnyFunctionRef fn, Type builderType, Type bodyResultType,
-      ConstraintKind bodyResultConstraintKind,
-      ConstraintLocatorBuilder locator);
+  Optional<TypeMatchResult>
+  matchResultBuilder(AnyFunctionRef fn, Type builderType, Type bodyResultType,
+                     Type openedBodyResultType,
+                     ConstraintKind bodyResultConstraintKind,
+                     ConstraintLocatorBuilder locator);
 
   /// Matches a wrapped or projected value parameter type to its backing
   /// property wrapper type by applying the property wrapper.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4159,9 +4159,12 @@ DependentMemberType *DependentMemberType::get(Type base,
 }
 
 OpaqueTypeArchetypeType *
-OpaqueTypeArchetypeType::get(OpaqueTypeDecl *Decl,
-                             SubstitutionMap Substitutions)
-{
+OpaqueTypeArchetypeType::get(OpaqueTypeDecl *Decl, unsigned ordinal,
+                             SubstitutionMap Substitutions) {
+  // TODO [OPAQUE SUPPORT]: multiple opaque types
+  assert(ordinal == 0 && "we only support one 'some' type per composite type");
+  auto opaqueParamType = Decl->getUnderlyingInterfaceType();
+
   // TODO: We could attempt to preserve type sugar in the substitution map.
   // Currently archetypes are assumed to be always canonical in many places,
   // though, so doing so would require fixing those places.
@@ -4237,8 +4240,8 @@ OpaqueTypeArchetypeType::get(OpaqueTypeDecl *Decl,
     }
   }
 #else
-  // Assert that there are no same type constraints on the underlying type
-  // or its associated types.
+  // Assert that there are no same type constraints on the opaque type or its
+  // associated types.
   //
   // This should not be possible until we add where clause support, with the
   // exception of generic base class constraints (handled below).
@@ -4247,7 +4250,7 @@ OpaqueTypeArchetypeType::get(OpaqueTypeDecl *Decl,
   for (auto reqt :
                 Decl->getOpaqueInterfaceGenericSignature().getRequirements()) {
     auto reqtBase = reqt.getFirstType()->getRootGenericParam();
-    if (reqtBase->isEqual(Decl->getUnderlyingInterfaceType())) {
+    if (reqtBase->isEqual(opaqueParamType)) {
       assert(reqt.getKind() != RequirementKind::SameType
              && "supporting where clauses on opaque types requires correctly "
                 "setting up the generic environment for "
@@ -4264,9 +4267,8 @@ OpaqueTypeArchetypeType::get(OpaqueTypeDecl *Decl,
         std::move(newRequirements)},
       nullptr);
 
-  auto opaqueInterfaceTy = Decl->getUnderlyingInterfaceType();
-  auto layout = signature->getLayoutConstraint(opaqueInterfaceTy);
-  auto superclass = signature->getSuperclassBound(opaqueInterfaceTy);
+  auto layout = signature->getLayoutConstraint(opaqueParamType);
+  auto superclass = signature->getSuperclassBound(opaqueParamType);
   #if !DO_IT_CORRECTLY
     // Ad-hoc substitute the generic parameters of the superclass.
     // If we correctly applied the substitutions to the generic signature
@@ -4275,25 +4277,24 @@ OpaqueTypeArchetypeType::get(OpaqueTypeDecl *Decl,
       superclass = superclass.subst(Substitutions);
     }
   #endif
-  const auto protos = signature->getRequiredProtocols(opaqueInterfaceTy);
+  const auto protos = signature->getRequiredProtocols(opaqueParamType);
 
   auto mem = ctx.Allocate(
     OpaqueTypeArchetypeType::totalSizeToAlloc<ProtocolDecl *, Type, LayoutConstraint>(
       protos.size(), superclass ? 1 : 0, layout ? 1 : 0),
       alignof(OpaqueTypeArchetypeType),
       arena);
-  
-  auto newOpaque = ::new (mem) OpaqueTypeArchetypeType(Decl, Substitutions,
-                                                    properties,
-                                                    opaqueInterfaceTy,
-                                                    protos, superclass, layout);
-  
+
+  auto newOpaque = ::new (mem)
+      OpaqueTypeArchetypeType(Decl, Substitutions, properties, opaqueParamType,
+                              protos, superclass, layout);
+
   // Create a generic environment and bind the opaque archetype to the
   // opaque interface type from the decl's signature.
   auto *env = GenericEnvironment::getIncomplete(signature);
-  env->addMapping(GenericParamKey(opaqueInterfaceTy), newOpaque);
+  env->addMapping(GenericParamKey(opaqueParamType), newOpaque);
   newOpaque->Environment = env;
-  
+
   // Look up the insertion point in the folding set again in case something
   // invalidated it above.
   {
@@ -4303,7 +4304,7 @@ OpaqueTypeArchetypeType::get(OpaqueTypeDecl *Decl,
     assert(!existing && "race to create opaque archetype?!");
     set.InsertNode(newOpaque, insertPos);
   }
-  
+
   return newOpaque;
 }
 

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -262,7 +262,7 @@ Type ASTBuilder::resolveOpaqueType(NodePointer opaqueDescriptor,
     auto opaqueDecl = parentModule->lookupOpaqueResultType(mangledName);
     if (!opaqueDecl)
       return Type();
-    // TODO: multiple opaque types
+    // TODO [OPAQUE SUPPORT]: multiple opaque types
     assert(ordinal == 0 && "not implemented");
     if (ordinal != 0)
       return Type();
@@ -275,7 +275,7 @@ Type ASTBuilder::resolveOpaqueType(NodePointer opaqueDescriptor,
     SubstitutionMap subs = createSubstitutionMapFromGenericArgs(
         opaqueDecl->getGenericSignature(), allArgs,
         LookUpConformanceInModule(parentModule));
-    return OpaqueTypeArchetypeType::get(opaqueDecl, subs);
+    return OpaqueTypeArchetypeType::get(opaqueDecl, ordinal, subs);
   }
   
   // TODO: named opaque types

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2834,7 +2834,11 @@ TypeRepr *ValueDecl::getOpaqueResultTypeRepr() const {
     returnRepr = SD->getElementTypeRepr();
   }
 
-  return returnRepr && returnRepr->hasOpaque() ? returnRepr : nullptr;
+  if (returnRepr && returnRepr->hasOpaque()) {
+    return returnRepr;
+  } else {
+    return nullptr;
+  }
 }
 
 OpaqueTypeDecl *ValueDecl::getOpaqueResultTypeDecl() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2809,7 +2809,7 @@ void ValueDecl::setOverriddenDecls(ArrayRef<ValueDecl *> overridden) {
   request.cacheResult(overriddenVec);
 }
 
-OpaqueReturnTypeRepr *ValueDecl::getOpaqueResultTypeRepr() const {
+TypeRepr *ValueDecl::getOpaqueResultTypeRepr() const {
   TypeRepr *returnRepr = nullptr;
   if (auto *VD = dyn_cast<VarDecl>(this)) {
     if (auto *P = VD->getParentPattern()) {
@@ -2834,7 +2834,7 @@ OpaqueReturnTypeRepr *ValueDecl::getOpaqueResultTypeRepr() const {
     returnRepr = SD->getElementTypeRepr();
   }
 
-  return dyn_cast_or_null<OpaqueReturnTypeRepr>(returnRepr);
+  return returnRepr && returnRepr->hasOpaque() ? returnRepr : nullptr;
 }
 
 OpaqueTypeDecl *ValueDecl::getOpaqueResultTypeDecl() const {
@@ -7547,16 +7547,16 @@ void AbstractFunctionDecl::setParameters(ParameterList *BodyParams) {
 }
 
 OpaqueTypeDecl::OpaqueTypeDecl(ValueDecl *NamingDecl,
-                               GenericParamList *GenericParams,
-                               DeclContext *DC,
+                               GenericParamList *GenericParams, DeclContext *DC,
                                GenericSignature OpaqueInterfaceGenericSignature,
+                               OpaqueReturnTypeRepr *UnderlyingInterfaceRepr,
                                GenericTypeParamType *UnderlyingInterfaceType)
-  : GenericTypeDecl(DeclKind::OpaqueType, DC, Identifier(), SourceLoc(), {},
-                    GenericParams),
-    NamingDecl(NamingDecl),
-    OpaqueInterfaceGenericSignature(OpaqueInterfaceGenericSignature),
-    UnderlyingInterfaceType(UnderlyingInterfaceType)
-{
+    : GenericTypeDecl(DeclKind::OpaqueType, DC, Identifier(), SourceLoc(), {},
+                      GenericParams),
+      NamingDecl(NamingDecl),
+      OpaqueInterfaceGenericSignature(OpaqueInterfaceGenericSignature),
+      UnderlyingInterfaceRepr(UnderlyingInterfaceRepr),
+      UnderlyingInterfaceType(UnderlyingInterfaceType) {
   // Always implicit.
   setImplicit();
 }
@@ -7574,6 +7574,15 @@ bool OpaqueTypeDecl::isOpaqueReturnTypeOfFunction(
   }
 
   return false;
+}
+
+unsigned OpaqueTypeDecl::getAnonymousOpaqueParamOrdinal(
+    OpaqueReturnTypeRepr *repr) const {
+  // TODO [OPAQUE SUPPORT]: we will need to generalize here when we allow
+  // multiple "some" types.
+  assert(UnderlyingInterfaceRepr &&
+         "can't do opaque param lookup without underlying interface repr");
+  return repr == UnderlyingInterfaceRepr ? 0 : -1;
 }
 
 Identifier OpaqueTypeDecl::getOpaqueReturnTypeIdentifier() const {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4708,7 +4708,7 @@ case TypeKind::Id:
          return newSubs[index];
        },
        LookUpConformanceInModule(opaque->getDecl()->getModuleContext()));
-    return OpaqueTypeArchetypeType::get(opaque->getDecl(),
+    return OpaqueTypeArchetypeType::get(opaque->getDecl(), opaque->getOrdinal(),
                                         newSubMap);
   }
   case TypeKind::NestedArchetype: {

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -168,7 +168,8 @@ bool Parser::startsParameterName(bool isClosure) {
   // If the next token can be an argument label, we might have a name.
   if (nextTok.canBeArgumentLabel()) {
     // If the first name wasn't "isolated", we're done.
-    if (!Tok.isContextualKeyword("isolated"))
+    if (!Tok.isContextualKeyword("isolated") &&
+        !Tok.isContextualKeyword("some"))
       return true;
 
     // "isolated" can be an argument label, but it's also a contextual keyword,

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1038,13 +1038,6 @@ ParserResult<TypeRepr> Parser::parseTypeTupleBody() {
       Backtracking.emplace(*this);
       ObsoletedInOutLoc = consumeToken(tok::kw_inout);
     }
-                                    
-    // If the label is "some", this could end up being an opaque type
-    // description if there's `some <identifier>` without a following colon,
-    // so we may need to backtrack as well.
-    if (Tok.isContextualKeyword("some")) {
-      Backtracking.emplace(*this);
-    }
 
     // If the tuple element starts with a potential argument label followed by a
     // ':' or another potential argument label, then the identifier is an

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1657,12 +1657,9 @@ Optional<BraceStmt *> TypeChecker::applyResultBuilderBodyTransform(
   // Build a constraint system in which we can check the body of the function.
   ConstraintSystem cs(func, options);
 
-  auto openedResultContextType = cs.openOpaqueTypeRec(
-      resultContextType, cs.getConstraintLocator(
-                             func, ConstraintLocator::ResultBuilderBodyResult));
   if (auto result = cs.matchResultBuilder(
-          func, builderType, resultContextType, openedResultContextType,
-          resultConstraintKind, cs.getConstraintLocator(func->getBody()))) {
+          func, builderType, resultContextType, resultConstraintKind,
+          cs.getConstraintLocator(func->getBody()))) {
     if (result->isFailure())
       return nullptr;
   }
@@ -1721,7 +1718,6 @@ Optional<BraceStmt *> TypeChecker::applyResultBuilderBodyTransform(
 Optional<ConstraintSystem::TypeMatchResult>
 ConstraintSystem::matchResultBuilder(AnyFunctionRef fn, Type builderType,
                                      Type bodyResultType,
-                                     Type openedBodyResultType,
                                      ConstraintKind bodyResultConstraintKind,
                                      ConstraintLocatorBuilder locator) {
   auto builder = builderType->getAnyNominal();
@@ -1848,8 +1844,8 @@ ConstraintSystem::matchResultBuilder(AnyFunctionRef fn, Type builderType,
   }
 
   // Bind the body result type to the type of the transformed expression.
-  addConstraint(bodyResultConstraintKind, transformedType, openedBodyResultType,
-                locator);
+  addConstraint(bodyResultConstraintKind, transformedType,
+                openOpaqueTypeRec(bodyResultType, locator), locator);
   return getTypeMatchSuccess();
 }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7274,10 +7274,14 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     return cs.cacheType(new (ctx) UnresolvedTypeConversionExpr(expr, toType));
 
   // Use an opaque type to abstract a value of the underlying concrete type.
-  if (toType->getAs<OpaqueTypeArchetypeType>()) {
+  // The full check here would be that `toType` and `fromType` are structually
+  // equal except in any position where `toType` has an opaque archetype. The
+  // below is just an approximate check since the above would be expensive to
+  // verify and still relies on the type checker ensuing `fromType` is
+  // compatible with any opaque archetypes.
+  if (toType->hasOpaqueArchetype())
     return cs.cacheType(new (ctx) UnderlyingToOpaqueExpr(expr, toType));
-  }
-  
+
   llvm_unreachable("Unhandled coercion");
 }
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1338,7 +1338,6 @@ void PotentialBindings::infer(Constraint *constraint) {
   case ConstraintKind::KeyPath:
   case ConstraintKind::FunctionInput:
   case ConstraintKind::FunctionResult:
-  case ConstraintKind::OpaqueUnderlyingType:
     // Constraints from which we can't do anything.
     break;
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1708,15 +1708,20 @@ namespace {
       auto contextualType = CS.getContextualType(expr);
 
       auto joinElementTypes = [&](Optional<Type> elementType) {
+        auto openedElementType = elementType.map(
+            [&](Type type) { return CS.openOpaqueTypeRec(type, locator); });
+
         const auto elements = expr->getElements();
         unsigned index = 0;
 
         using Iterator = decltype(elements)::iterator;
-        CS.addJoinConstraint<Iterator>(locator, elements.begin(), elements.end(),
-                                       elementType, [&](const auto it) {
-          auto *locator = CS.getConstraintLocator(expr, LocatorPathElt::TupleElement(index++));
-          return std::make_pair(CS.getType(*it), locator);
-        });
+        CS.addJoinConstraint<Iterator>(
+            locator, elements.begin(), elements.end(), openedElementType,
+            [&](const auto it) {
+              auto *locator = CS.getConstraintLocator(
+                  expr, LocatorPathElt::TupleElement(index++));
+              return std::make_pair(CS.getType(*it), locator);
+            });
       };
 
       // If a contextual type exists for this expression, apply it directly.
@@ -1824,16 +1829,15 @@ namespace {
 
       auto locator = CS.getConstraintLocator(expr);
       auto contextualType = CS.getContextualType(expr);
-      Type contextualDictionaryType = nullptr;
-      Type contextualDictionaryKeyType = nullptr;
-      Type contextualDictionaryValueType = nullptr;
-      
-      // If a contextual type exists for this expression, apply it directly.
+      auto openedType = CS.openOpaqueTypeRec(contextualType, locator);
+
+      // If a contextual type exists for this expression and is a dictionary
+      // type, apply it directly.
       Optional<std::pair<Type, Type>> dictionaryKeyValue;
-      if (contextualType &&
-          (dictionaryKeyValue = ConstraintSystem::isDictionaryType(contextualType))) {
-        // Is the contextual type a dictionary type?
-        contextualDictionaryType = contextualType;
+      if (openedType && (dictionaryKeyValue =
+                             ConstraintSystem::isDictionaryType(openedType))) {
+        Type contextualDictionaryKeyType;
+        Type contextualDictionaryValueType;
         std::tie(contextualDictionaryKeyType,
                  contextualDictionaryValueType) = *dictionaryKeyValue;
         
@@ -1841,11 +1845,10 @@ namespace {
         TupleTypeElt tupleElts[2] = { TupleTypeElt(contextualDictionaryKeyType),
                                       TupleTypeElt(contextualDictionaryValueType) };
         Type contextualDictionaryElementType = TupleType::get(tupleElts, C);
-        
-        CS.addConstraint(ConstraintKind::LiteralConformsTo, contextualType,
-                         dictionaryProto->getDeclaredInterfaceType(),
-                         locator);
-        
+
+        CS.addConstraint(ConstraintKind::LiteralConformsTo, openedType,
+                         dictionaryProto->getDeclaredInterfaceType(), locator);
+
         unsigned index = 0;
         for (auto element : expr->getElements()) {
           CS.addConstraint(ConstraintKind::Conversion,
@@ -1854,10 +1857,10 @@ namespace {
                            CS.getConstraintLocator(
                                expr, LocatorPathElt::TupleElement(index++)));
         }
-        
-        return contextualDictionaryType;
+
+        return openedType;
       }
-      
+
       auto dictionaryTy = CS.createTypeVariable(locator,
                                                 TVO_PrefersSubtypeBinding |
                                                 TVO_CanBindToNoEscape);
@@ -2031,6 +2034,8 @@ namespace {
       }
 
       auto extInfo = CS.closureEffects(closure);
+      auto resultLocator =
+          CS.getConstraintLocator(closure, ConstraintLocator::ClosureResult);
 
       // Closure expressions always have function type. In cases where a
       // parameter or return type is omitted, a fresh type variable is used to
@@ -2044,9 +2049,7 @@ namespace {
 
           const auto resolvedTy = resolveTypeReferenceInExpression(
               closure->getExplicitResultTypeRepr(),
-              TypeResolverContext::InExpression,
-              CS.getConstraintLocator(closure,
-                                      ConstraintLocator::ClosureResult));
+              TypeResolverContext::InExpression, resultLocator);
           if (resolvedTy)
             return resolvedTy;
         }
@@ -2062,9 +2065,9 @@ namespace {
         // If this is a multi-statement closure, let's mark result
         // as potential hole right away.
         return Type(CS.createTypeVariable(
-            CS.getConstraintLocator(closure, ConstraintLocator::ClosureResult),
-            shouldTypeCheckInEnclosingExpression(closure) ? 0
-                                                          : TVO_CanBindToHole));
+            resultLocator, shouldTypeCheckInEnclosingExpression(closure)
+                               ? 0
+                               : TVO_CanBindToHole));
       }();
 
       // For a non-async function type, add the global actor if present.
@@ -2237,7 +2240,8 @@ namespace {
         // Look through reference storage types.
         type = type->getReferenceStorageReferent();
 
-        Type openedType = CS.replaceInferableTypesWithTypeVars(type, locator);
+        Type replacedType = CS.replaceInferableTypesWithTypeVars(type, locator);
+        Type openedType = CS.openOpaqueTypeRec(replacedType, locator);
         assert(openedType);
 
         auto *subPattern = cast<TypedPattern>(pattern)->getSubPattern();
@@ -2254,7 +2258,13 @@ namespace {
         CS.addConstraint(
             ConstraintKind::Conversion, subPatternType, openedType,
             locator.withPathElement(LocatorPathElt::PatternMatch(pattern)));
-        return setType(openedType);
+
+        // FIXME [OPAQUE SUPPORT]: the distinction between where we want opaque
+        // types in opened vs. un-unopened form is *very* tricky. The pattern
+        // ultimately needs the un-opened type and it gets this from the set
+        // type of the expression.
+        CS.setType(pattern, replacedType);
+        return openedType;
       }
 
       case PatternKind::Tuple: {
@@ -3818,9 +3828,7 @@ bool ConstraintSystem::generateConstraints(
     // If there is a type that we're expected to convert to, add the conversion
     // constraint.
     if (Type convertType = target.getExprConversionType()) {
-      // Determine whether we know more about the contextual type.
       ContextualTypePurpose ctp = target.getExprContextualTypePurpose();
-      bool isOpaqueReturnType = target.infersOpaqueReturnType();
       auto *convertTypeLocator =
           getConstraintLocator(expr, LocatorPathElt::ContextualType(ctp));
 
@@ -3860,8 +3868,7 @@ bool ConstraintSystem::generateConstraints(
         });
       }
 
-      addContextualConversionConstraint(expr, convertType, ctp,
-                                        isOpaqueReturnType);
+      addContextualConversionConstraint(expr, convertType, ctp);
     }
 
     // For an initialization target, generate constraints for the pattern.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "CSDiagnostics.h"
+#include "swift/AST/ASTPrinter.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericEnvironment.h"
@@ -28,8 +29,8 @@
 #include "swift/AST/SourceFile.h"
 #include "swift/Basic/StringExtras.h"
 #include "swift/ClangImporter/ClangModule.h"
-#include "swift/Sema/ConstraintSystem.h"
 #include "swift/Sema/CSFix.h"
+#include "swift/Sema/ConstraintSystem.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Support/Compiler.h"
@@ -1620,7 +1621,6 @@ ConstraintSystem::matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
     subKind = ConstraintKind::Conversion;
     break;
 
-  case ConstraintKind::OpaqueUnderlyingType:
   case ConstraintKind::Bind:
   case ConstraintKind::BindParam:
   case ConstraintKind::BindToPointerType:
@@ -1765,7 +1765,6 @@ static bool matchFunctionRepresentations(FunctionType::ExtInfo einfo1,
     }
     return true;
 
-  case ConstraintKind::OpaqueUnderlyingType:
   case ConstraintKind::BridgingConversion:
   case ConstraintKind::ApplicableFunction:
   case ConstraintKind::DynamicCallableApplicableFunction:
@@ -2167,7 +2166,6 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   case ConstraintKind::Conversion:
   case ConstraintKind::ArgumentConversion:
   case ConstraintKind::OperatorArgumentConversion:
-  case ConstraintKind::OpaqueUnderlyingType:
     subKind = ConstraintKind::Subtype;
     break;
 
@@ -5156,7 +5154,6 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       return formUnsolvedResult();
     }
 
-    case ConstraintKind::OpaqueUnderlyingType:
     case ConstraintKind::ApplicableFunction:
     case ConstraintKind::DynamicCallableApplicableFunction:
     case ConstraintKind::BindOverload:
@@ -8950,10 +8947,12 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
   assignFixedType(typeVar, closureType, closureLocator);
 
   // If there is a result builder to apply, do so now.
+  auto openedClosureResultType =
+      openOpaqueTypeRec(closureType->getResult(), closureLocator);
   if (resultBuilderType) {
     if (auto result = matchResultBuilder(
             closure, resultBuilderType, closureType->getResult(),
-            ConstraintKind::Conversion, locator)) {
+            openedClosureResultType, ConstraintKind::Conversion, locator)) {
       return result->isSuccess();
     }
   }
@@ -9039,36 +9038,6 @@ ConstraintSystem::simplifyDynamicTypeOfConstraint(
   // It's definitely not either kind of metatype, so we can
   // report failure right away.
   return SolutionKind::Error;
-}
-
-ConstraintSystem::SolutionKind
-ConstraintSystem::simplifyOpaqueUnderlyingTypeConstraint(Type type1, Type type2,
-                                             TypeMatchOptions flags,
-                                             ConstraintLocatorBuilder locator) {
-  // Open the second type, which must be an opaque archetype, to try to
-  // infer the first type using its constraints.
-  auto opaque2 = type2->castTo<OpaqueTypeArchetypeType>();
-
-  // Open the generic signature of the opaque decl, and bind the "outer" generic
-  // params to our context. The remaining axes of freedom on the type variable
-  // corresponding to the underlying type should be the constraints on the
-  // underlying return type.
-  OpenedTypeMap replacements;
-  openGeneric(DC, opaque2->getBoundSignature(), locator, replacements);
-
-  auto underlyingTyVar = openType(opaque2->getInterfaceType(),
-                                  replacements);
-  assert(underlyingTyVar);
-  
-  for (auto param : DC->getGenericSignatureOfContext().getGenericParams()) {
-    addConstraint(ConstraintKind::Bind,
-                  openType(param, replacements),
-                  DC->mapTypeIntoContext(param),
-                  locator);
-  }
-
-  addConstraint(ConstraintKind::Equal, type1, underlyingTyVar, locator);
-  return getTypeMatchSuccess();
 }
 
 ConstraintSystem::SolutionKind
@@ -11706,10 +11675,6 @@ ConstraintSystem::addConstraintImpl(ConstraintKind kind, Type first,
   case ConstraintKind::OperatorArgumentConversion:
     return addArgumentConversionConstraintImpl(kind, first, second, locator);
 
-  case ConstraintKind::OpaqueUnderlyingType:
-    return simplifyOpaqueUnderlyingTypeConstraint(first, second,
-                                                  subflags, locator);
-
   case ConstraintKind::BridgingConversion:
     return simplifyBridgingConstraint(first, second, subflags, locator);
 
@@ -11992,8 +11957,7 @@ void ConstraintSystem::addConstraint(ConstraintKind kind, Type first,
 }
 
 void ConstraintSystem::addContextualConversionConstraint(
-    Expr *expr, Type conversionType, ContextualTypePurpose purpose,
-    bool isOpaqueReturnType) {
+    Expr *expr, Type conversionType, ContextualTypePurpose purpose) {
   if (conversionType.isNull())
     return;
 
@@ -12002,11 +11966,13 @@ void ConstraintSystem::addContextualConversionConstraint(
   switch (purpose) {
   case CTP_ReturnStmt:
   case CTP_ReturnSingleExpr:
-  case CTP_Initialization:
-    if (isOpaqueReturnType)
-      constraintKind = ConstraintKind::OpaqueUnderlyingType;
+  case CTP_Initialization: {
+    if (conversionType->is<OpaqueTypeArchetypeType>())
+      constraintKind = ConstraintKind::Equal;
+    // Alternatively, we might have a nested opaque archetype, e.g. `(some P)?`.
+    // In that case, we want `ConstraintKind::Conversion`.
     break;
-
+  }
   case CTP_CallArgument:
     constraintKind = ConstraintKind::ArgumentConversion;
     break;
@@ -12042,8 +12008,9 @@ void ConstraintSystem::addContextualConversionConstraint(
   // Add the constraint.
   auto *convertTypeLocator =
       getConstraintLocator(expr, LocatorPathElt::ContextualType(purpose));
-  addConstraint(constraintKind, getType(expr), conversionType,
-                convertTypeLocator, /*isFavored*/ true);
+  auto openedType = openOpaqueTypeRec(conversionType, convertTypeLocator);
+  addConstraint(constraintKind, getType(expr), openedType, convertTypeLocator,
+                /*isFavored*/ true);
 }
 
 void ConstraintSystem::addFixConstraint(ConstraintFix *fix, ConstraintKind kind,
@@ -12112,8 +12079,7 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
   case ConstraintKind::Subtype:
   case ConstraintKind::Conversion:
   case ConstraintKind::ArgumentConversion:
-  case ConstraintKind::OperatorArgumentConversion:
-  case ConstraintKind::OpaqueUnderlyingType: {
+  case ConstraintKind::OperatorArgumentConversion: {
     // Relational constraints.
 
     // If there is a fix associated with this constraint, apply it.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8947,12 +8947,10 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
   assignFixedType(typeVar, closureType, closureLocator);
 
   // If there is a result builder to apply, do so now.
-  auto openedClosureResultType =
-      openOpaqueTypeRec(closureType->getResult(), closureLocator);
   if (resultBuilderType) {
     if (auto result = matchResultBuilder(
             closure, resultBuilderType, closureType->getResult(),
-            openedClosureResultType, ConstraintKind::Conversion, locator)) {
+            ConstraintKind::Conversion, locator)) {
       return result->isSuccess();
     }
   }

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -65,7 +65,6 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
   case ConstraintKind::OptionalObject:
   case ConstraintKind::FunctionInput:
   case ConstraintKind::FunctionResult:
-  case ConstraintKind::OpaqueUnderlyingType:
   case ConstraintKind::OneWayEqual:
   case ConstraintKind::OneWayBindParam:
   case ConstraintKind::UnresolvedMemberChainBase:
@@ -142,7 +141,6 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
   case ConstraintKind::Disjunction:
   case ConstraintKind::FunctionInput:
   case ConstraintKind::FunctionResult:
-  case ConstraintKind::OpaqueUnderlyingType:
   case ConstraintKind::OneWayEqual:
   case ConstraintKind::OneWayBindParam:
   case ConstraintKind::DefaultClosureType:
@@ -274,7 +272,6 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
   case ConstraintKind::Defaultable:
   case ConstraintKind::FunctionInput:
   case ConstraintKind::FunctionResult:
-  case ConstraintKind::OpaqueUnderlyingType:
   case ConstraintKind::OneWayEqual:
   case ConstraintKind::OneWayBindParam:
   case ConstraintKind::DefaultClosureType:
@@ -357,7 +354,6 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
   case ConstraintKind::BindToPointerType: Out << " bind to pointer "; break;
   case ConstraintKind::Subtype: Out << " subtype "; break;
   case ConstraintKind::Conversion: Out << " conv "; break;
-  case ConstraintKind::OpaqueUnderlyingType: Out << " underlying type of opaque "; break;
   case ConstraintKind::BridgingConversion: Out << " bridging conv "; break;
   case ConstraintKind::ArgumentConversion: Out << " arg conv "; break;
   case ConstraintKind::OperatorArgumentConversion:
@@ -611,7 +607,6 @@ gatherReferencedTypeVars(Constraint *constraint,
   case ConstraintKind::SelfObjectOfProtocol:
   case ConstraintKind::FunctionInput:
   case ConstraintKind::FunctionResult:
-  case ConstraintKind::OpaqueUnderlyingType:
   case ConstraintKind::OneWayEqual:
   case ConstraintKind::OneWayBindParam:
   case ConstraintKind::DefaultClosureType:

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -60,6 +60,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::DynamicType:
   case ConstraintLocator::SubscriptMember:
   case ConstraintLocator::OpenedGeneric:
+  case ConstraintLocator::OpenedOpaqueArchetype:
   case ConstraintLocator::WrappedValue:
   case ConstraintLocator::GenericParameter:
   case ConstraintLocator::GenericArgument:
@@ -416,6 +417,10 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
     }
     case OpenedGeneric:
       out << "opened generic";
+      break;
+
+    case OpenedOpaqueArchetype:
+      out << "opened opaque archetype";
       break;
 
     case ConditionalRequirement: {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -844,6 +844,43 @@ Type ConstraintSystem::openType(Type type, OpenedTypeMap &replacements) {
     });
 }
 
+Type ConstraintSystem::openOpaqueType(Type type,
+                                      ConstraintLocatorBuilder locator) {
+  auto opaque = type->castTo<OpaqueTypeArchetypeType>();
+  auto opaqueLocator = locator.withPathElement(
+      LocatorPathElt::OpenedOpaqueArchetype(opaque->getDecl()));
+
+  // Open the generic signature of the opaque decl, and bind the "outer" generic
+  // params to our context. The remaining axes of freedom on the type variable
+  // corresponding to the underlying type should be the constraints on the
+  // underlying return type.
+  OpenedTypeMap replacements;
+  openGeneric(DC, opaque->getBoundSignature(), opaqueLocator, replacements);
+
+  auto underlyingTyVar = openType(opaque->getInterfaceType(), replacements);
+  assert(underlyingTyVar);
+
+  for (auto param : DC->getGenericSignatureOfContext().getGenericParams()) {
+    addConstraint(ConstraintKind::Bind, openType(param, replacements),
+                  DC->mapTypeIntoContext(param), opaqueLocator);
+  }
+
+  return underlyingTyVar;
+}
+
+Type ConstraintSystem::openOpaqueTypeRec(Type type,
+                                         ConstraintLocatorBuilder locator) {
+  // Early return for efficiency
+  if (!(type && type->hasOpaqueArchetype()))
+    return type;
+
+  return type.transform([&](Type type) -> Type {
+    if (type->is<OpaqueTypeArchetypeType>())
+      return openOpaqueType(type, locator);
+    return type;
+  });
+}
+
 FunctionType *ConstraintSystem::openFunctionType(
        AnyFunctionType *funcType,
        ConstraintLocatorBuilder locator,
@@ -5379,23 +5416,11 @@ bool SolutionApplicationTarget::infersOpaqueReturnType() const {
   assert(kind == Kind::expression);
   switch (expression.contextualPurpose) {
   case CTP_Initialization:
-    if (Type convertType = expression.convertType.getType()) {
-      return convertType->is<OpaqueTypeArchetypeType>();
-    }
-    return false;
-
   case CTP_ReturnStmt:
   case CTP_ReturnSingleExpr:
-    if (Type convertType = expression.convertType.getType()) {
-      if (auto opaqueType = convertType->getAs<OpaqueTypeArchetypeType>()) {
-        auto dc = getDeclContext();
-        if (auto func = dyn_cast<AbstractFunctionDecl>(dc)) {
-          return opaqueType->getDecl()->isOpaqueReturnTypeOfFunction(func);
-        }
-      }
-    }
+    if (Type convertType = expression.convertType.getType())
+      return convertType->hasOpaqueArchetype();
     return false;
-
   default:
     return false;
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -870,8 +870,9 @@ Type ConstraintSystem::openOpaqueType(Type type,
 
 Type ConstraintSystem::openOpaqueTypeRec(Type type,
                                          ConstraintLocatorBuilder locator) {
-  // Early return for efficiency
-  if (!(type && type->hasOpaqueArchetype()))
+  // Early return if `type` is `NULL` or if there are no opaque archetypes (in
+  // which case there is certainly nothing for us to do).
+  if (!type || !type->hasOpaqueArchetype())
     return type;
 
   return type.transform([&](Type type) -> Type {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2650,11 +2650,13 @@ public:
 /// An AST walker that determines the underlying type of an opaque return decl
 /// from its associated function body.
 class OpaqueUnderlyingTypeChecker : public ASTWalker {
+  using Candidate = std::pair<Expr *, Type>;
+
   ASTContext &Ctx;
   AbstractFunctionDecl *Implementation;
   OpaqueTypeDecl *OpaqueDecl;
   BraceStmt *Body;
-  SmallVector<std::pair<Expr*, Type>, 4> Candidates;
+  SmallVector<Candidate, 4> Candidates;
 
   bool HasInvalidReturn = false;
 
@@ -2685,24 +2687,15 @@ public:
       Implementation->diagnose(diag::opaque_type_no_underlying_type_candidates);
       return;
     }
-    
+
     // Check whether all of the underlying type candidates match up.
-    auto opaqueTypeInContext =
-      Implementation->mapTypeIntoContext(OpaqueDecl->getDeclaredInterfaceType());
+    // TODO [OPAQUE SUPPORT]: multiple opaque types
     Type underlyingType = Candidates.front().second;
-    
-    bool mismatch = false;
-    for (auto otherCandidate : llvm::makeArrayRef(Candidates).slice(1)) {
-      // Disregard tautological candidates.
-      if (otherCandidate.second->isEqual(opaqueTypeInContext))
-        continue;
-        
-      if (!underlyingType->isEqual(otherCandidate.second)) {
-        mismatch = true;
-        break;
-      }
-    }
-    
+    bool mismatch =
+        std::any_of(Candidates.begin() + 1, Candidates.end(),
+                    [&](Candidate &otherCandidate) {
+                      return !underlyingType->isEqual(otherCandidate.second);
+                    });
     if (mismatch) {
       Implementation->diagnose(
           diag::opaque_type_mismatched_underlying_type_candidates);
@@ -2716,6 +2709,8 @@ public:
     
     // The underlying type can't be defined recursively
     // in terms of the opaque type itself.
+    auto opaqueTypeInContext = Implementation->mapTypeIntoContext(
+        OpaqueDecl->getDeclaredInterfaceType());
     auto isSelfReferencing = underlyingType.findIf([&](Type t) -> bool {
       return t->isEqual(opaqueTypeInContext);
     });
@@ -2747,14 +2742,11 @@ public:
   
   std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
     if (auto underlyingToOpaque = dyn_cast<UnderlyingToOpaqueExpr>(E)) {
-      assert(E->getType()->isEqual(
-       Implementation->mapTypeIntoContext(OpaqueDecl->getDeclaredInterfaceType()))
-             && "unexpected opaque type in function body");
-      
       Candidates.push_back(std::make_pair(underlyingToOpaque->getSubExpr(),
                                   underlyingToOpaque->getSubExpr()->getType()));
+      return {false, E};
     }
-    return std::make_pair(false, E);
+    return {true, E};
   }
 
   std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -13,14 +13,16 @@
 // This file implements support for generics.
 //
 //===----------------------------------------------------------------------===//
-#include "TypeChecker.h"
 #include "TypeCheckProtocol.h"
 #include "TypeCheckType.h"
+#include "TypeChecker.h"
+#include "swift/AST/ASTWalker.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericEnvironment.h"
-#include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/GenericSignatureBuilder.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeResolutionStage.h"
 #include "swift/AST/Types.h"
@@ -77,6 +79,29 @@ TypeChecker::gatherGenericParamBindingsText(
   return result.str().str();
 }
 
+// An alias to avoid repeating the `SmallVector`'s size parameter.
+using CollectedOpaqueReprs = SmallVector<OpaqueReturnTypeRepr *, 2>;
+
+/// Walk `repr` recursively, collecting any `OpaqueReturnTypeRepr`s.
+static CollectedOpaqueReprs collectOpaqueReturnTypeReprs(TypeRepr *repr) {
+  class Walker : public ASTWalker {
+    CollectedOpaqueReprs &Reprs;
+
+  public:
+    explicit Walker(CollectedOpaqueReprs &reprs) : Reprs(reprs) {}
+
+    bool walkToTypeReprPre(TypeRepr *repr) override {
+      if (auto opaqueRepr = dyn_cast<OpaqueReturnTypeRepr>(repr))
+        Reprs.push_back(opaqueRepr);
+      return true;
+    }
+  };
+
+  CollectedOpaqueReprs reprs;
+  repr->walk(Walker(reprs));
+  return reprs;
+}
+
 //
 // Generic functions
 //
@@ -109,7 +134,15 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
     {
       llvm::raw_string_ostream out(result);
       out << "associatedtype " << placeholder << ": ";
-      repr->getConstraint()->print(out);
+      // FIXME [OPAQUE SUPPORT]: to produce the right associate type for the
+      // replacement in general, we would need to recurse into the type repr and
+      // replace every `OpaqueReturnType` with its 'base'. Things get trickier
+      // when we allow named opaque return types.
+      if (isa<OpaqueReturnTypeRepr>(repr)) {
+        cast<OpaqueReturnTypeRepr>(repr)->getConstraint()->print(out);
+      } else {
+        out << "<#type#>";
+      }
       out << "\n";
     }
 
@@ -120,7 +153,7 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
 
     return nullptr;
   }
-  
+
   // Check the availability of the opaque type runtime support.
   if (!ctx.LangOpts.DisableAvailabilityChecking) {
     auto runningOS =
@@ -136,67 +169,96 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
     }
   }
 
-  // Try to resolve the constraint repr. It should be some kind of existential
-  // type. Pass along the error type if resolving the repr failed.
-  auto constraintType = TypeResolution::forInterface(
-                            dc, TypeResolverContext::GenericRequirement,
-                            // Unbound generics and placeholders are meaningless
-                            // in opaque types.
-                            /*unboundTyOpener*/ nullptr,
-                            /*placeholderHandler*/ nullptr)
-                            .resolveType(repr->getConstraint());
-
-  if (constraintType->hasError())
-    return nullptr;
-  
-  // Error out if the constraint type isn't a class or existential type.
-  if (!constraintType->getClassOrBoundGenericClass()
-      && !constraintType->isExistentialType()) {
-    ctx.Diags.diagnose(repr->getConstraint()->getLoc(),
-                       diag::opaque_type_invalid_constraint);
-    return nullptr;
-  }
-  
-  if (constraintType->hasArchetype())
-    constraintType = constraintType->mapTypeOutOfContext();
-
   // Create a generic signature for the opaque environment. This is the outer
-  // generic signature with an added generic parameter representing the opaque
-  // type and its interface constraints.
+  // generic signature with an added generic parameters representing the opaque
+  // types and their interface constraints.
   auto originatingDC = originatingDecl->getInnermostDeclContext();
-  unsigned returnTypeDepth = 0;
   auto outerGenericSignature = originatingDC->getGenericSignatureOfContext();
-  
-  if (outerGenericSignature) {
-    returnTypeDepth =
-               outerGenericSignature.getGenericParams().back()->getDepth() + 1;
-  }
-  
-  auto returnTypeParam = GenericTypeParamType::get(returnTypeDepth, 0, ctx);
+  unsigned opaqueSignatureDepth =
+      outerGenericSignature
+          ? outerGenericSignature.getGenericParams().back()->getDepth() + 1
+          : 0;
 
   SmallVector<GenericTypeParamType *, 2> genericParamTypes;
-  genericParamTypes.push_back(returnTypeParam);
-
   SmallVector<Requirement, 2> requirements;
-  if (constraintType->getClassOrBoundGenericClass()) {
-    requirements.push_back(Requirement(RequirementKind::Superclass,
-                                       returnTypeParam, constraintType));
-  } else {
-    auto constraints = constraintType->getExistentialLayout();
-    if (auto superclass = constraints.getSuperclass()) {
-      requirements.push_back(Requirement(RequirementKind::Superclass,
-                                         returnTypeParam, superclass));
+
+  auto opaqueReprs = collectOpaqueReturnTypeReprs(repr);
+  if (opaqueReprs.size() > 1) {
+    ctx.Diags.diagnose(repr->getLoc(), diag::more_than_one_opaque_type, repr);
+    return nullptr;
+  }
+
+  // TODO [OPAQUE SUPPORT]: right now we only allow one structural 'some' type,
+  // but *very* soon we will allow more than one such type.
+  for (unsigned i = 0; i < opaqueReprs.size(); ++i) {
+    auto *currentRepr = opaqueReprs[i];
+
+    // Usually, we resolve the opaque constraint and bail if it isn't a class or
+    // existential type (see below). However, in this case we know we will fail,
+    // so we can bail early and provide a better diagnostic.
+    if (auto *optionalRepr =
+            dyn_cast<OptionalTypeRepr>(currentRepr->getConstraint())) {
+      std::string buf;
+      llvm::raw_string_ostream stream(buf);
+      stream << "(some " << optionalRepr->getBase() << ")?";
+
+      ctx.Diags.diagnose(currentRepr->getLoc(),
+                         diag::opaque_type_invalid_constraint);
+      ctx.Diags
+          .diagnose(currentRepr->getLoc(), diag::opaque_of_optional_rewrite)
+          .fixItReplaceChars(currentRepr->getStartLoc(),
+                             currentRepr->getEndLoc(), stream.str());
+      return nullptr;
     }
-    for (auto protocol : constraints.getProtocols()) {
-      requirements.push_back(Requirement(RequirementKind::Conformance,
-                                         returnTypeParam, protocol));
+
+    auto *paramType = GenericTypeParamType::get(opaqueSignatureDepth, i, ctx);
+    genericParamTypes.push_back(paramType);
+
+    // Try to resolve the constraint repr in the parent decl context. It should
+    // be some kind of existential type. Pass along the error type if resolving
+    // the repr failed.
+    auto constraintType = TypeResolution::forInterface(
+                              dc, TypeResolverContext::GenericRequirement,
+                              // Unbound generics and placeholders are
+                              // meaningless in opaque types.
+                              /*unboundTyOpener*/ nullptr,
+                              /*placeholderHandler*/ nullptr)
+                              .resolveType(currentRepr->getConstraint());
+
+    if (constraintType->hasError())
+      return nullptr;
+
+    // Error out if the constraint type isn't a class or existential type.
+    if (!constraintType->getClassOrBoundGenericClass() &&
+        !constraintType->isExistentialType()) {
+      ctx.Diags.diagnose(currentRepr->getLoc(),
+                         diag::opaque_type_invalid_constraint);
+      return nullptr;
     }
-    if (auto layout = constraints.getLayoutConstraint()) {
-      requirements.push_back(Requirement(RequirementKind::Layout,
-                                         returnTypeParam, layout));
+
+    if (constraintType->hasArchetype())
+      constraintType = constraintType->mapTypeOutOfContext();
+
+    if (constraintType->getClassOrBoundGenericClass()) {
+      requirements.push_back(
+          Requirement(RequirementKind::Superclass, paramType, constraintType));
+    } else {
+      auto constraints = constraintType->getExistentialLayout();
+      if (auto superclass = constraints.getSuperclass()) {
+        requirements.push_back(
+            Requirement(RequirementKind::Superclass, paramType, superclass));
+      }
+      for (auto protocol : constraints.getProtocols()) {
+        requirements.push_back(
+            Requirement(RequirementKind::Conformance, paramType, protocol));
+      }
+      if (auto layout = constraints.getLayoutConstraint()) {
+        requirements.push_back(
+            Requirement(RequirementKind::Layout, paramType, layout));
+      }
     }
   }
-  
+
   auto interfaceSignature = evaluateOrDefault(
       ctx.evaluator,
       AbstractGenericSignatureRequest{
@@ -214,23 +276,22 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
     ? originatingGenericContext->getGenericParams()
     : nullptr;
 
-  auto opaqueDecl = new (ctx) OpaqueTypeDecl(originatingDecl,
-                                             genericParams,
-                                             parentDC,
-                                             interfaceSignature,
-                                             returnTypeParam);
+  auto opaqueDecl = new (ctx)
+      OpaqueTypeDecl(originatingDecl, genericParams, parentDC,
+                     interfaceSignature, opaqueReprs[0], genericParamTypes[0]);
   opaqueDecl->copyFormalAccessFrom(originatingDecl);
   if (auto originatingSig = originatingDC->getGenericSignatureOfContext()) {
     opaqueDecl->setGenericSignature(originatingSig);
   }
-  
-  // The declared interface type is an opaque ArchetypeType.
-  SubstitutionMap subs;
-  if (outerGenericSignature) {
-    subs = outerGenericSignature->getIdentitySubstitutionMap();
-  }
-  auto opaqueTy = OpaqueTypeArchetypeType::get(opaqueDecl, subs);
-  auto metatype = MetatypeType::get(opaqueTy);
+
+  // Resolving in the context of `opaqueDecl` allows type resolution to create
+  // opaque archetypes where needed
+  auto interfaceType =
+      TypeResolution::forInterface(opaqueDecl, TypeResolverContext::None,
+                                   /*unboundTyOpener*/ nullptr,
+                                   /*placeholderHandler*/ nullptr)
+          .resolveType(repr);
+  auto metatype = MetatypeType::get(interfaceType);
   opaqueDecl->setInterfaceType(metatype);
   return opaqueDecl;
 }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -243,19 +243,9 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
       requirements.push_back(
           Requirement(RequirementKind::Superclass, paramType, constraintType));
     } else {
-      auto constraints = constraintType->getExistentialLayout();
-      if (auto superclass = constraints.getSuperclass()) {
-        requirements.push_back(
-            Requirement(RequirementKind::Superclass, paramType, superclass));
-      }
-      for (auto protocol : constraints.getProtocols()) {
-        requirements.push_back(
-            Requirement(RequirementKind::Conformance, paramType, protocol));
-      }
-      if (auto layout = constraints.getLayoutConstraint()) {
-        requirements.push_back(
-            Requirement(RequirementKind::Layout, paramType, layout));
-      }
+      // In this case, the constraint type is an existential
+      requirements.push_back(
+          Requirement(RequirementKind::Conformance, paramType, constraintType));
     }
   }
 

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -707,7 +707,7 @@ static Type validateTypedPattern(TypedPattern *TP, TypeResolution resolution) {
   // property definition.
   auto &Context = resolution.getASTContext();
   auto *Repr = TP->getTypeRepr();
-  if (Repr && isa<OpaqueReturnTypeRepr>(Repr)) {
+  if (Repr && Repr->hasOpaque()) {
     auto named = dyn_cast<NamedPattern>(
                            TP->getSubPattern()->getSemanticsProvidingPattern());
     if (!named) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3458,9 +3458,10 @@ public:
       return cast<OpaqueTypeDecl>(declOrOffset.get());
       
     // Create the decl.
-    auto opaqueDecl =
-      new (ctx) OpaqueTypeDecl(nullptr, nullptr, declContext,
-                               interfaceSig, interfaceType);
+    auto opaqueDecl = new (ctx)
+        OpaqueTypeDecl(/*NamingDecl*/ nullptr,
+                       /*GenericParams*/ nullptr, declContext, interfaceSig,
+                       /*UnderlyingInterfaceTypeRepr*/ nullptr, interfaceType);
     declOrOffset = opaqueDecl;
 
     auto namingDecl = cast<ValueDecl>(MF.getDecl(namingDeclID));
@@ -3489,7 +3490,8 @@ public:
     if (genericSig) {
       subs = genericSig->getIdentitySubstitutionMap();
     }
-    auto opaqueTy = OpaqueTypeArchetypeType::get(opaqueDecl, subs);
+    // TODO [OPAQUE SUPPORT]: multiple opaque types
+    auto opaqueTy = OpaqueTypeArchetypeType::get(opaqueDecl, 0, subs);
     auto metatype = MetatypeType::get(opaqueTy);
     opaqueDecl->setInterfaceType(metatype);
     return opaqueDecl;
@@ -5491,7 +5493,9 @@ public:
     if (!subsOrError)
       return subsOrError.takeError();
 
-    return OpaqueTypeArchetypeType::get(opaqueDecl, subsOrError.get());
+    // TODO [OPAQUE SUPPORT]: to support multiple opaque types we will probably
+    // have to serialize the ordinal, which is always 0 for now
+    return OpaqueTypeArchetypeType::get(opaqueDecl, 0, subsOrError.get());
   }
       
   Expected<Type> deserializeNestedArchetypeType(ArrayRef<uint64_t> scratch,

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -657,7 +657,10 @@ struct MyView {
     } // expected-error {{expected identifier after '.' expression}}
   }
 
-  @TupleBuilder var invalidCaseWithoutDot: some P {
+  // FIXME [OPAQUE SUPPORT]: We definitely need a better error that doesn't
+  // include 'τ_0_0'. This error comes from generating a
+  // `DefaultGenericArgument` fix in `TypeVariableBinding::fixForHole`.
+  @TupleBuilder var invalidCaseWithoutDot: some P { // expected-error {{generic parameter 'τ_0_0' could not be inferred}}
     switch Optional.some(1) {
     case none: 42 // expected-error {{cannot find 'none' in scope}}
     case .some(let x):
@@ -685,7 +688,7 @@ do {
 struct TuplifiedStructWithInvalidClosure {
   var condition: Bool
 
-  @TupleBuilder var unknownParameter: some Any {
+  @TupleBuilder var unknownParameter: some Any { // expected-error {{generic parameter 'τ_0_0' could not be inferred}}
     if let cond = condition {
       let _ = { (arg: UnknownType) in // expected-error {{cannot find type 'UnknownType' in scope}}
       }
@@ -695,7 +698,7 @@ struct TuplifiedStructWithInvalidClosure {
     }
   }
 
-  @TupleBuilder var unknownResult: some Any {
+  @TupleBuilder var unknownResult: some Any { // expected-error {{generic parameter 'τ_0_0' could not be inferred}}
     if let cond = condition {
       let _ = { () -> UnknownType in // expected-error {{cannot find type 'UnknownType' in scope}}
       }
@@ -705,7 +708,7 @@ struct TuplifiedStructWithInvalidClosure {
     }
   }
 
-  @TupleBuilder var multipleLevelsDeep: some Any {
+  @TupleBuilder var multipleLevelsDeep: some Any { // expected-error {{generic parameter 'τ_0_0' could not be inferred}}
     if let cond = condition {
       switch MyError.boom {
       case .boom:

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -657,10 +657,7 @@ struct MyView {
     } // expected-error {{expected identifier after '.' expression}}
   }
 
-  // FIXME [OPAQUE SUPPORT]: We definitely need a better error that doesn't
-  // include 'τ_0_0'. This error comes from generating a
-  // `DefaultGenericArgument` fix in `TypeVariableBinding::fixForHole`.
-  @TupleBuilder var invalidCaseWithoutDot: some P { // expected-error {{generic parameter 'τ_0_0' could not be inferred}}
+  @TupleBuilder var invalidCaseWithoutDot: some P {
     switch Optional.some(1) {
     case none: 42 // expected-error {{cannot find 'none' in scope}}
     case .some(let x):
@@ -688,7 +685,7 @@ do {
 struct TuplifiedStructWithInvalidClosure {
   var condition: Bool
 
-  @TupleBuilder var unknownParameter: some Any { // expected-error {{generic parameter 'τ_0_0' could not be inferred}}
+  @TupleBuilder var unknownParameter: some Any {
     if let cond = condition {
       let _ = { (arg: UnknownType) in // expected-error {{cannot find type 'UnknownType' in scope}}
       }
@@ -698,7 +695,7 @@ struct TuplifiedStructWithInvalidClosure {
     }
   }
 
-  @TupleBuilder var unknownResult: some Any { // expected-error {{generic parameter 'τ_0_0' could not be inferred}}
+  @TupleBuilder var unknownResult: some Any {
     if let cond = condition {
       let _ = { () -> UnknownType in // expected-error {{cannot find type 'UnknownType' in scope}}
       }
@@ -708,7 +705,7 @@ struct TuplifiedStructWithInvalidClosure {
     }
   }
 
-  @TupleBuilder var multipleLevelsDeep: some Any { // expected-error {{generic parameter 'τ_0_0' could not be inferred}}
+  @TupleBuilder var multipleLevelsDeep: some Any {
     if let cond = condition {
       switch MyError.boom {
       case .boom:

--- a/test/Constraints/result_builder_infer.swift
+++ b/test/Constraints/result_builder_infer.swift
@@ -66,6 +66,13 @@ struct TupleMe: Tupled {
   }
 }
 
+struct TupleMeStructural: Tupled {
+  var tuple: (some Any, Int) {
+    "hello"
+    0
+  }
+}
+
 // Witness is separated from the context declaring conformance, so don't infer
 // the result builder.
 struct DoNotTupleMe {

--- a/test/decl/var/property_wrappers_opaque.swift
+++ b/test/decl/var/property_wrappers_opaque.swift
@@ -3,7 +3,7 @@
 protocol P { }
 
 @propertyWrapper
-struct WrapperWithDefaultInit<T> {
+struct WrapperWithDefaultInit<T> { // expected-note3{{'T' declared as parameter to type 'WrapperWithDefaultInit'}}
   private var stored: T?
 
   var wrappedValue: T {
@@ -18,10 +18,10 @@ struct WrapperWithDefaultInit<T> {
 
 // FB7699647 - crash with opaque result type and property wrappers.
 struct FB7699647 {
-  @WrapperWithDefaultInit var property: some P // expected-error{{property declares an opaque return type, but cannot infer the underlying type from its initializer expression}}
-  @WrapperWithDefaultInit() var otherProperty: some P // expected-error{{property declares an opaque return type, but cannot infer the underlying type from its initializer expression}}
+  @WrapperWithDefaultInit var property: some P // expected-error{{generic parameter 'T' could not be inferred}} expected-error{{property declares an opaque return type, but cannot infer the underlying type from its initializer expression}}
+  @WrapperWithDefaultInit() var otherProperty: some P // expected-error{{generic parameter 'T' could not be inferred}}
 }
 
 struct FB7699647b {
-  @WrapperWithDefaultInit var property: some P // expected-error{{property declares an opaque return type, but cannot infer the underlying type from its initializer expression}}
+  @WrapperWithDefaultInit var property: some P // expected-error{{generic parameter 'T' could not be inferred}} expected-error{{property declares an opaque return type, but cannot infer the underlying type from its initializer expression}}
 }

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -10,7 +10,7 @@ extension String: P, Q { func paul() {}; mutating func priscilla() {}; func quin
 extension Array: P, Q { func paul() {}; mutating func priscilla() {}; func quinn() {} }
 
 class C {}
-class D: C, P, Q { func paul() {}; func priscilla() {}; func quinn() {} }
+class D: C, P, Q { func paul() {}; func priscilla() {}; func quinn() {}; func d() {} }
 
 let property: some P = 1
 let deflessLet: some P // expected-error{{has no initializer}} {{educational-notes=opaque-type-inference}}
@@ -75,17 +75,89 @@ struct Test {
 
 let zingle = {() -> some P in 1 } // expected-error{{'some' types are only implemented}}
 
+// Structural positions
+
+struct S1<T> {
+  var x: T
+}
+struct S2<T, U> {
+  var x: T
+  var y: U
+}
+struct R1<T: P> {
+  var x: T
+}
+struct R2<T: P, U: Q> {
+  var x: T
+  var y: U
+}
+
+// TODO: cases that we should support, but don't yet:
+//
+// WARNING: using '!' is not allowed here; treating this as '?' instead
+// func asUnwrappedOptionalBase() -> (some P)! { return 1 }
+//
+// ERROR: generic parameter 'τ_0_0' could not be inferred
+// func asHOFRetRet() -> () -> some P { return { 1 } }
+//
+// ERROR: function declares an opaque return type, but has no return statements in its body from which to infer an underlying type
+// func asHOFRetArg() -> (some P) -> () { return { (x: String) -> () in } }
+//
+// ERROR: 'some' types are only implemented for the declared type of properties and subscripts and the return type of functions
+// let x = { () -> some P in return ConcreteP() }
+
+func twoOpaqueTypes() -> (some P, some P) { return (1, 2) } // expected-error{{only one 'opaque' type is supported}}
+func asTupleElemBad() -> (P, some Q) { return (1, C()) } // expected-note{{opaque return type declared here}} expected-error{{requires that 'C' conform to 'Q'}}
+
+func asTupleElem() -> (P, some Q) { return (1, 2) }
+func asArrayElem() -> [some P] { return [1] }
+func asOptionalBase() -> (some P)? { return 1 }
+
+let asTupleElemLet: (P, some Q) = (1, 2)
+let asArrayElemLet: [some P] = [1]
+let asOptionalBaseLet: (some P)? = 1
+
+func asUnconstrainedGeneric1() -> S1<some P> { return S1(x: 1) }
+func asUnconstrainedGeneric2() -> S2<P, some Q> { return S2(x: 1, y: 2) }
+func asConstrainedGeneric1() -> R1<some P> { return R1(x: 1) }
+func asConstrainedGeneric2() -> R2<Int, some Q> { return R2(x: 1, y: 2) }
+func asNestedGenericDirect() -> S1<S1<some P>> { return S1(x: S1(x: 1)) }
+func asNestedGenericIndirect() -> S1<S1<(Int, some P)>> { return S1(x: S1(x: (1, 2))) }
+
+let asUnconstrainedGeneric2Let: S2<P, some Q> = S2(x: 1, y: 2)
+let asNestedGenericIndirectLet: S1<S1<(Int, some P)>> = S1(x: S1(x: (1, 2)))
+
+// Tests an interesting SILGen case. For the underlying opaque type, we have to
+// use the generic calling convention for closures.
+func funcToAnyOpaqueCoercion() -> S1<some Any> {
+  let f: () -> () = {}
+  return S1(x: f)
+}
+
+// TODO: We should give better error messages here. The opaque types have
+// underlying types 'Int' and 'String', but the return statments have underlying
+// types '(Int, Int)' and '(String, Int)'.
+func structuralMismatchedReturnTypes(_ x: Bool, _ y: Int, _ z: String) -> (some P, Int) { // expected-error{{do not have matching underlying types}}
+  if x {
+    return (y, 1) // expected-note{{return statement has underlying type 'Int'}}
+  } else {
+    return (z, 1) // expected-note{{return statement has underlying type 'String'}}
+  }
+}
+
+func structuralMemberLookupBad() {
+  var tup: (some P, Int) = (1, 1)
+  tup.0.paul();
+  tup.0.d(); // expected-error{{value of type 'some P' has no member 'd'}}
+}
+
 // Invalid positions
 
 typealias Foo = some P // expected-error{{'some' types are only implemented}}
 
 func blibble(blobble: some P) {} // expected-error{{'some' types are only implemented}}
-
-let blubble: () -> some P = { 1 } // expected-error{{'some' types are only implemented}}
-
 func blib() -> P & some Q { return 1 } // expected-error{{'some' should appear at the beginning}}
-func blab() -> (P, some Q) { return (1, 2) } // expected-error{{'some' types are only implemented}}
-func blob() -> (some P) -> P { return { $0 } } // expected-error{{'some' types are only implemented}}
+func blab() -> some P? { return 1 } // expected-error{{must specify only}} expected-note{{did you mean to write an optional of an 'opaque' type?}}
 func blorb<T: some P>(_: T) { } // expected-error{{'some' types are only implemented}}
 func blub<T>() -> T where T == some P { return 1 } // expected-error{{'some' types are only implemented}} expected-error{{cannot convert}}
 


### PR DESCRIPTION
Currently, we only support opaque result types as top level level types, e.g. `some P` is allowed but not `(some P)?`. This branch adds support for opaque result types in structural type positions.