### PR TITLE
RequirementMachine: Fix use-after-free detected by ASAN

### DIFF
--- a/lib/AST/RequirementMachine/RewriteSystemCompletion.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystemCompletion.cpp
@@ -312,6 +312,10 @@ void RewriteSystem::processMergedAssociatedTypes() {
     // Add the rule X.[P1:T] => X.[P1&P2:T].
     addRule(rhs, mergedTerm);
 
+    // Collect new rules here so that we're not adding rules while iterating
+    // over the rules list.
+    SmallVector<std::pair<MutableTerm, MutableTerm>, 2> inducedRules;
+
     // Look for conformance requirements on [P1:T] and [P2:T].
     for (const auto &otherRule : Rules) {
       const auto &otherLHS = otherRule.getLHS();
@@ -343,10 +347,14 @@ void RewriteSystem::processMergedAssociatedTypes() {
           MutableTerm newRHS;
           newRHS.add(mergedAtom);
 
-          addRule(newLHS, newRHS);
+          inducedRules.emplace_back(newLHS, newRHS);
         }
       }
     }
+
+    // Now add the new rules.
+    for (const auto &pair : inducedRules)
+      addRule(pair.first, pair.second);
   }
 
   MergedAssociatedTypes.clear();


### PR DESCRIPTION
We're adding new rules to the Rules list while iterating over it, which
is not good.