### PR TITLE
[ConstraintSystem] NFC: Use stored result type while generating const…

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4096,10 +4096,9 @@ public:
   /// Generate constraints for the body of the given closure.
   ///
   /// \param closure the closure expression
-  /// \param resultType the closure's result type
   ///
   /// \returns \c true if constraint generation failed, \c false otherwise
-  bool generateConstraints(ClosureExpr *closure, Type resultType);
+  bool generateConstraints(ClosureExpr *closure);
 
   /// Generate constraints for the given (unchecked) expression.
   ///

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -33,15 +33,13 @@ class ClosureConstraintGenerator
 
   ConstraintSystem &cs;
   ClosureExpr *closure;
-  Type closureResultType;
 
 public:
   /// Whether an error was encountered while generating constraints.
   bool hadError = false;
 
-  ClosureConstraintGenerator(ConstraintSystem &cs, ClosureExpr *closure,
-                             Type closureResultType)
-    : cs(cs), closure(closure), closureResultType(closureResultType) { }
+  ClosureConstraintGenerator(ConstraintSystem &cs, ClosureExpr *closure)
+      : cs(cs), closure(closure) {}
 
 private:
   void visitDecl(Decl *decl) {
@@ -95,11 +93,10 @@ private:
 
     // FIXME: Locator should point at the return statement?
     bool hasReturn = hasExplicitResult(closure);
-    cs.addConstraint(
-        ConstraintKind::Conversion, cs.getType(expr),
-        closureResultType,
-        cs.getConstraintLocator(
-           closure, LocatorPathElt::ClosureBody(hasReturn)));
+    cs.addConstraint(ConstraintKind::Conversion, cs.getType(expr),
+                     cs.getClosureType(closure)->getResult(),
+                     cs.getConstraintLocator(
+                         closure, LocatorPathElt::ClosureBody(hasReturn)));
   }
 
 #define UNSUPPORTED_STMT(STMT) void visit##STMT##Stmt(STMT##Stmt *) { \
@@ -127,9 +124,8 @@ private:
 
 }
 
-bool ConstraintSystem::generateConstraints(
-    ClosureExpr *closure, Type resultType) {
-  ClosureConstraintGenerator generator(*this, closure, resultType);
+bool ConstraintSystem::generateConstraints(ClosureExpr *closure) {
+  ClosureConstraintGenerator generator(*this, closure);
   generator.visit(closure->getBody());
   return generator.hadError;
 }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8950,7 +8950,7 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
   // generate constraints for it now.
   auto &ctx = getASTContext();
   if (shouldTypeCheckInEnclosingExpression(closure)) {
-    if (generateConstraints(closure, closureType->getResult()))
+    if (generateConstraints(closure))
       return false;
   } else if (!hasExplicitResult(closure)) {
     // If this closure has an empty body and no explicit result type


### PR DESCRIPTION
…raints for closures

Instead of passing/storing result type to constraint generator,
let's retrieve it from the constraint system when needed.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
