### PR TITLE
[Syntax] Make `PostfixIfConfigExpr.base` optional

### DIFF
--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -599,8 +599,22 @@ func foo<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSigna
 ##"<StringSegment>abc </StringSegment><ExpressionSegment>\##(<TupleExprElement><IdentifierExpr>foo</IdentifierExpr></TupleExprElement>)</ExpressionSegment><StringSegment></StringSegment>"##</StringLiteralExpr><PostfixIfConfigExpr><FunctionCallExpr><IdentifierExpr>
 
 foo</IdentifierExpr>()</FunctionCallExpr><IfConfigDecl><IfConfigClause>
-#if <BooleanLiteralExpr>true</BooleanLiteralExpr><ForcedValueExpr><FunctionCallExpr><OptionalChainingExpr><MemberAccessExpr>
+#if <IdentifierExpr>COND1</IdentifierExpr><ForcedValueExpr><FunctionCallExpr><OptionalChainingExpr><MemberAccessExpr>
   .bar</MemberAccessExpr>?</OptionalChainingExpr>()</FunctionCallExpr>!</ForcedValueExpr></IfConfigClause><IfConfigClause>
+#elseif <IdentifierExpr>COND2</IdentifierExpr><MemberAccessExpr><PostfixIfConfigExpr><IfConfigDecl><IfConfigClause>
+  #if <BooleanLiteralExpr>true</BooleanLiteralExpr><FunctionCallExpr><MemberAccessExpr>
+    .call</MemberAccessExpr>()</FunctionCallExpr></IfConfigClause><IfConfigClause>
+  #elseif <BooleanLiteralExpr>true</BooleanLiteralExpr><PostfixIfConfigExpr><IfConfigDecl><IfConfigClause>
+    #if <BooleanLiteralExpr>true</BooleanLiteralExpr><MemberAccessExpr>
+      .other</MemberAccessExpr></IfConfigClause>
+    #endif</IfConfigDecl></PostfixIfConfigExpr></IfConfigClause><IfConfigClause>
+  #else<PostfixIfConfigExpr><FunctionCallExpr><MemberAccessExpr>
+    .before</MemberAccessExpr>()</FunctionCallExpr><IfConfigDecl><IfConfigClause>
+    #if <BooleanLiteralExpr>true</BooleanLiteralExpr><FunctionCallExpr><MemberAccessExpr>
+      .after</MemberAccessExpr>()</FunctionCallExpr></IfConfigClause>
+    #endif</IfConfigDecl></PostfixIfConfigExpr></IfConfigClause>
+  #endif</IfConfigDecl></PostfixIfConfigExpr>
+  .member</MemberAccessExpr></IfConfigClause><IfConfigClause>
 #else<FunctionCallExpr><MemberAccessExpr>
   .baz</MemberAccessExpr>() <ClosureExpr>{}</ClosureExpr></FunctionCallExpr></IfConfigClause>
 #endif</IfConfigDecl></PostfixIfConfigExpr>

--- a/test/Syntax/round_trip_parse_gen.swift
+++ b/test/Syntax/round_trip_parse_gen.swift
@@ -599,8 +599,22 @@ func foo() {}
 ##"abc \##(foo)"##
 
 foo()
-#if true
+#if COND1
   .bar?()!
+#elseif COND2
+  #if true
+    .call()
+  #elseif true
+    #if true
+      .other
+    #endif
+  #else
+    .before()
+    #if true
+      .after()
+    #endif
+  #endif
+  .member
 #else
   .baz() {}
 #endif

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -597,7 +597,7 @@ EXPR_NODES = [
     # postfix '#if' expession
     Node('PostfixIfConfigExpr', kind='Expr',
          children=[
-             Child('Base', kind='Expr'),
+             Child('Base', kind='Expr', is_optional=True),
              Child('Config', kind='IfConfigDecl'),
          ]),
 


### PR DESCRIPTION
For nested `#if ... #endf` in postfix if-config expression, like:
```swift
  baseExpr
    #if COND1
      #if COND2
        .member
      #endif
    #endif
```
Consider the inner `#if` be a postfix if-config expression with a 'nil' base expression.

https://bugs.swift.org/browse/SR-14929
rdar://80688328