### PR TITLE
update_checkout: add a `--skip-tags` option

### DIFF
--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -260,7 +260,7 @@ def update_all_repositories(args, config, scheme_name, cross_repos_pr):
 
 def obtain_additional_swift_sources(pool_args):
     (args, repo_name, repo_info, repo_branch, remote, with_ssh, scheme_name,
-     skip_history, skip_repository_list) = pool_args
+     skip_history, skip_tags, skip_repository_list) = pool_args
 
     env = dict(os.environ)
     env.update({'GIT_TERMINAL_PROMPT': 0})
@@ -270,14 +270,14 @@ def obtain_additional_swift_sources(pool_args):
         print("Cloning '" + repo_name + "'")
 
         if skip_history:
-            shell.run(['git', 'clone',
-                       '--recursive', '--depth', '1', '--branch',
-                       repo_branch, remote, repo_name],
+            shell.run(['git', 'clone', '--recursive', '--depth', '1',
+                       '--branch', repo_branch, remote, repo_name] +
+                      (['--no-tags'] if skip_tags else []),
                       env=env,
                       echo=True)
         else:
-            shell.run(['git', 'clone',
-                       '--recursive', remote, repo_name],
+            shell.run(['git', 'clone', '--recursive', remote, repo_name] +
+                      (['--no-tags'] if skip_tags else []),
                       env=env,
                       echo=True)
         if scheme_name:
@@ -297,7 +297,8 @@ def obtain_additional_swift_sources(pool_args):
 
 
 def obtain_all_additional_swift_sources(args, config, with_ssh, scheme_name,
-                                        skip_history, skip_repository_list):
+                                        skip_history, skip_tags,
+                                        skip_repository_list):
 
     pool_args = []
     with shell.pushd(args.source_root, dry_run=False, echo=False):
@@ -342,7 +343,7 @@ def obtain_all_additional_swift_sources(args, config, with_ssh, scheme_name,
                 continue
 
             pool_args.append([args, repo_name, repo_info, repo_branch, remote,
-                              with_ssh, scheme_name, skip_history,
+                              with_ssh, scheme_name, skip_history, skip_tags,
                               skip_repository_list])
 
     if not pool_args:
@@ -471,6 +472,10 @@ repositories.
         help="Skip histories when obtaining sources",
         action="store_true")
     parser.add_argument(
+        "--skip-tags",
+        help="Skip tags when obtaining sources",
+        action="store_true")
+    parser.add_argument(
         "--skip-repository",
         metavar="DIRECTORY",
         default=[],
@@ -548,6 +553,7 @@ repositories.
     clone = args.clone
     clone_with_ssh = args.clone_with_ssh
     skip_history = args.skip_history
+    skip_tags = args.skip_tags
     scheme = args.scheme
     github_comment = args.github_comment
 
@@ -584,6 +590,7 @@ repositories.
                                                             clone_with_ssh,
                                                             scheme,
                                                             skip_history,
+                                                            skip_tags,
                                                             skip_repo_list)
 
     # Quick check whether somebody is calling update in an empty directory


### PR DESCRIPTION
When fetching the sources, the tags take a very long time due to the
daily tags.  Add an option to skip fetching tags.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
