### PR TITLE
[5.5] Track whether a task is actively running

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -48,7 +48,7 @@ enum {
   NumWords_DefaultActor = 12,
 
   /// The number of words in a task.
-  NumWords_AsyncTask = 16,
+  NumWords_AsyncTask = 24,
 
   /// The number of words in a task group.
   NumWords_TaskGroup = 32,

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -2211,7 +2211,6 @@ public:
     Kind_width          = 8,
 
     CanThrow            = 8,
-    ShouldNotDeallocate = 9,
 
     // Kind-specific flags should grow down from 31.
 
@@ -2230,18 +2229,6 @@ public:
 
   /// Whether this context is permitted to throw.
   FLAGSET_DEFINE_FLAG_ACCESSORS(CanThrow, canThrow, setCanThrow)
-
-  /// Whether a function should avoid deallocating its context before
-  /// returning.  It should still pass its caller's context to its
-  /// return continuation.
-  ///
-  /// This flag can be set in the caller to optimize context allocation,
-  /// e.g. if the callee's context size is known statically and simply
-  /// allocated as part of the caller's context, or if the callee will
-  /// be called multiple times.
-  FLAGSET_DEFINE_FLAG_ACCESSORS(ShouldNotDeallocate,
-                                shouldNotDeallocateInCallee,
-                                setShouldNotDeallocateInCallee)
 
   /// See AsyncContinuationFlags::isExecutorSwitchForced.
   FLAGSET_DEFINE_FLAG_ACCESSORS(Continuation_IsExecutorSwitchForced,

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -650,6 +650,10 @@ public:
     ErrorResult = error;
   }
 
+  bool isExecutorSwitchForced() const {
+    return Flags.continuation_isExecutorSwitchForced();
+  }
+
   static bool classof(const AsyncContext *context) {
     return context->Flags.getKind() == AsyncContextKind::Continuation;
   }

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -203,7 +203,7 @@ public:
 
   /// Private storage for the use of the runtime.
   struct alignas(2 * alignof(void*)) OpaquePrivateStorage {
-    void *Storage[6];
+    void *Storage[14];
 
     /// Initialize this storage during the creation of a task.
     void initialize(AsyncTask *task);

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -260,7 +260,25 @@ public:
   void runInFullyEstablishedContext() {
     return ResumeTask(ResumeContext); // 'return' forces tail call
   }
-  
+
+  /// Flag that this task is now running.  This can update
+  /// the priority stored in the job flags if the priority has been
+  /// escalated.
+  ///
+  /// Generally this should be done immediately after updating
+  /// ActiveTask.
+  void flagAsRunning();
+  void flagAsRunning_slow();
+
+  /// Flag that this task is now suspended.  This can update the
+  /// priority stored in the job flags if the priority hsa been
+  /// escalated.  Generally this should be done immediately after
+  /// clearing ActiveTask and immediately before enqueuing the task
+  /// somewhere.  TODO: record where the task is enqueued if
+  /// possible.
+  void flagAsSuspended();
+  void flagAsSuspended_slow();
+
   /// Check whether this task has been cancelled.
   /// Checking this is, of course, inherently race-prone on its own.
   bool isCancelled() const;

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -588,6 +588,14 @@ void swift_defaultActor_enqueue(Job *job, DefaultActor *actor);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 AsyncTask *swift_task_suspend();
 
+/// Do a primitive suspension of the current task, as if part of
+/// a continuation, although this does not provide any of the
+/// higher-level continuation semantics.  The current task is returned;
+/// its ResumeFunction and ResumeContext will need to be initialized,
+/// and then it will need to be enqueued or run as a job later.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+AsyncTask *swift_task_suspend();
+
 /// Prepare a continuation in the current task.
 ///
 /// The caller should initialize the Parent, ResumeParent,

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -580,19 +580,27 @@ void swift_defaultActor_deallocateResilient(HeapObject *actor);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_defaultActor_enqueue(Job *job, DefaultActor *actor);
 
+/// Do a primitive suspension of the current task, as if part of
+/// a continuation, although this does not provide any of the
+/// higher-level continuation semantics.  The current task is returned;
+/// its ResumeFunction and ResumeContext will need to be initialized,
+/// and then it will need to be enqueued or run as a job later.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+AsyncTask *swift_task_suspend();
+
 /// Prepare a continuation in the current task.
 ///
 /// The caller should initialize the Parent, ResumeParent,
 /// and NormalResult fields.  This function will initialize the other
-/// fields with appropriate defaaults; the caller may then overwrite
+/// fields with appropriate defaults; the caller may then overwrite
 /// them if desired.
-///
-/// This function is provided as a code-size and runtime-usage
-/// optimization; calling it is not required if code is willing to
-/// do all its work inline.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 AsyncTask *swift_continuation_init(ContinuationAsyncContext *context,
                                    AsyncContinuationFlags flags);
+
+/// Await an initialized continuation.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
+void swift_continuation_await(ContinuationAsyncContext *continuationContext);
 
 /// Resume a task from a non-throwing continuation, given a normal
 /// result which has already been stored into the continuation.

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1582,6 +1582,14 @@ FUNCTION(ContinuationInit,
          ARGS(ContinuationAsyncContextPtrTy, SizeTy),
          ATTRS(NoUnwind))
 
+// void swift_continuation_await(AsyncContext *continuationContext);
+FUNCTION(ContinuationAwait,
+         swift_continuation_await, SwiftAsyncCC,
+         ConcurrencyAvailability,
+         RETURNS(VoidTy),
+         ARGS(ContinuationAsyncContextPtrTy),
+         ATTRS(NoUnwind))
+
 // void swift_continuation_resume(AsyncTask *continuation);
 FUNCTION(ContinuationResume,
          swift_continuation_resume, SwiftCC,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1333,6 +1333,7 @@ public:
   llvm::Constant *getFixLifetimeFn();
   
   llvm::Constant *getFixedClassInitializationFn();
+  llvm::Function *getAwaitAsyncContinuationFn();
 
   /// The constructor used when generating code.
   ///

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -78,10 +78,6 @@ OVERRIDE_ACTOR(job_run, void,
                swift::, (class Job *job, ExecutorRef executor),
                (job, executor))
 
-OVERRIDE_ACTOR(task_getCurrent, AsyncTask *,
-               SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
-               swift::, ,)
-
 OVERRIDE_ACTOR(task_getCurrentExecutor, ExecutorRef,
                SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                swift::, ,)

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -159,6 +159,21 @@ OVERRIDE_TASK(task_asyncMainDrainQueue, void,
               SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift), swift::,
               , )
 
+OVERRIDE_TASK(task_suspend, AsyncTask *,
+              SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
+              swift::, ,)
+
+OVERRIDE_TASK(continuation_init, AsyncTask *,
+              SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
+              swift::, (ContinuationAsyncContext *context,
+                        AsyncContinuationFlags flags),
+              (context, flags))
+
+OVERRIDE_TASK(continuation_await, void,
+              SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swiftasync),
+              swift::, (ContinuationAsyncContext *context),
+              (context))
+
 OVERRIDE_ASYNC_LET(asyncLet_wait, void, SWIFT_EXPORT_FROM(swift_Concurrency),
                    SWIFT_CC(swiftasync), swift::,
                    (OpaqueValue *result,

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -245,7 +245,7 @@ void swift::runJobInEstablishedExecutorContext(Job *job) {
 }
 
 SWIFT_CC(swift)
-static AsyncTask *swift_task_getCurrentImpl() {
+AsyncTask *swift::swift_task_getCurrent() {
   return ActiveTask::get();
 }
 

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -222,10 +222,11 @@ void swift::runJobInEstablishedExecutorContext(Job *job) {
     // Update the active task in the current thread.
     ActiveTask::set(task);
 
-    // FIXME: update the task status to say that it's running
-    // on the current thread.  If the task suspends itself to run
-    // on an actor, it should update the task status appropriately;
-    // we don't need to update it afterwards.
+    // Update the task status to say that it's running on the
+    // current thread.  If the task suspends somewhere, it should
+    // update the task status appropriately; we don't need to update
+    // it afterwards.
+    task->flagAsRunning();
 
     task->runInFullyEstablishedContext();
 
@@ -1790,6 +1791,9 @@ SWIFT_CC(swiftasync)
 static void runOnAssumedThread(AsyncTask *task, ExecutorRef executor,
                                ExecutorTrackingInfo *oldTracking,
                                RunningJobInfo runner) {
+  // Note that this doesn't change the active task and so doesn't
+  // need to either update ActiveTask or flagAsRunning/flagAsSuspended.
+
   // If there's alreaady tracking info set up, just change the executor
   // there and tail-call the task.  We don't want these frames to
   // potentially accumulate linearly.
@@ -1872,6 +1876,7 @@ static void swift_task_switchImpl(SWIFT_ASYNC_CONTEXT AsyncContext *resumeContex
 #if SWIFT_TASK_PRINTF_DEBUG
   fprintf(stderr, "[%p] switch failed, task %p enqueued on executor %p\n", pthread_self(), task, newExecutor.getIdentity());
 #endif
+  task->flagAsSuspended();
   swift_task_enqueue(task, newExecutor);
 }
 

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -93,9 +93,14 @@ func _checkExpectedExecutor(_filenameStart: Builtin.RawPointer,
     _filenameStart, _filenameLength, _filenameIsASCII, _line, _executor)
 }
 
+// This must take a DispatchQueueShim, not something like AnyObject,
+// or else SILGen will emit a retain/release in unoptimized builds,
+// which won't work because DispatchQueues aren't actually
+// Swift-retainable.
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_enqueueOnDispatchQueue")
-internal func _enqueueOnDispatchQueue(_ job: UnownedJob, queue: AnyObject)
+internal func _enqueueOnDispatchQueue(_ job: UnownedJob,
+                                      queue: DispatchQueueShim)
 
 /// Used by the runtime solely for the witness table it produces.
 /// FIXME: figure out some way to achieve that which doesn't generate
@@ -105,13 +110,11 @@ internal func _enqueueOnDispatchQueue(_ job: UnownedJob, queue: AnyObject)
 /// means a dispatch_queue_t, which is not the same as DispatchQueue
 /// on platforms where that is an instance of a wrapper class.
 @available(SwiftStdlib 5.5, *)
-internal class DispatchQueueShim: UnsafeSendable, SerialExecutor {
-  @inlinable
+internal final class DispatchQueueShim: UnsafeSendable, SerialExecutor {
   func enqueue(_ job: UnownedJob) {
     _enqueueOnDispatchQueue(job, queue: self)
   }
 
-  @inlinable
   func asUnownedSerialExecutor() -> UnownedSerialExecutor {
     return UnownedSerialExecutor(ordinary: self)
   }

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -87,6 +87,7 @@ FutureFragment::Status AsyncTask::waitFuture(AsyncTask *waitingTask,
       fprintf(stderr, "[%p] task %p waiting on task %p, completed immediately\n", pthread_self(), waitingTask, this);
 #endif
       _swift_tsan_acquire(static_cast<Job *>(this));
+      if (contextIntialized) waitingTask->flagAsRunning();
       // The task is done; we don't need to wait.
       return queueHead.getStatus();
 
@@ -95,7 +96,7 @@ FutureFragment::Status AsyncTask::waitFuture(AsyncTask *waitingTask,
       fprintf(stderr, "[%p] task %p waiting on task %p, going to sleep\n", pthread_self(), waitingTask, this);
 #endif
       _swift_tsan_release(static_cast<Job *>(waitingTask));
-      // Task is now complete. We'll need to add ourselves to the queue.
+      // Task is not complete. We'll need to add ourselves to the queue.
       break;
     }
 
@@ -107,6 +108,7 @@ FutureFragment::Status AsyncTask::waitFuture(AsyncTask *waitingTask,
       context->successResultPointer = result;
       context->ResumeParent = resumeFn;
       context->Parent = callerContext;
+      waitingTask->flagAsSuspended();
     }
 
     // Put the waiting task at the beginning of the wait queue.
@@ -928,8 +930,16 @@ size_t swift::swift_task_getJobFlags(AsyncTask *task) {
   return task->Flags.getOpaqueValue();
 }
 
-AsyncTask *swift::swift_continuation_init(ContinuationAsyncContext *context,
-                                          AsyncContinuationFlags flags) {
+SWIFT_CC(swift)
+static AsyncTask *swift_task_suspendImpl() {
+  auto task = swift_task_getCurrent();
+  task->flagAsSuspended();
+  return task;
+}
+
+SWIFT_CC(swift)
+static AsyncTask *swift_continuation_initImpl(ContinuationAsyncContext *context,
+                                              AsyncContinuationFlags flags) {
   context->Flags = AsyncContextKind::Continuation;
   if (flags.canThrow()) context->Flags.setCanThrow(true);
   context->ErrorResult = nullptr;
@@ -951,7 +961,61 @@ AsyncTask *swift::swift_continuation_init(ContinuationAsyncContext *context,
   task->ResumeContext = context;
   task->ResumeTask = context->ResumeParent;
 
+  // A preawait immediately suspends the task.
+  if (flags.isPreawaited()) {
+    task->flagAsSuspended();
+  }
+
   return task;
+}
+
+SWIFT_CC(swiftasync)
+static void swift_continuation_awaitImpl(ContinuationAsyncContext *context) {
+#ifndef NDEBUG
+  auto task = swift_task_getCurrent();
+  assert(task && "awaiting continuation without a task");
+  assert(task->ResumeContext == context);
+  assert(task->ResumeTask == context->ResumeParent);
+#endif
+
+  auto &sync = context->AwaitSynchronization;
+
+  auto oldStatus = sync.load(std::memory_order_acquire);
+  assert((oldStatus == ContinuationStatus::Pending ||
+          oldStatus == ContinuationStatus::Resumed) &&
+         "awaiting a corrupt or already-awaited continuation");
+
+  // If the status is already Resumed, we can resume immediately.
+  // Comparing against Pending may be very slightly more compact.
+  if (oldStatus != ContinuationStatus::Pending)
+    // This is fine given how swift_continuation_init sets it up.
+    return context->ResumeParent(context);
+
+  // Load the current task (we alreaady did this in assertions builds).
+#ifdef NDEBUG
+  auto task = swift_task_getCurrent();
+#endif
+
+  // Flag the task as suspended.
+  task->flagAsSuspended();
+
+  // Try to transition to Awaited.
+  bool success =
+    sync.compare_exchange_strong(oldStatus, ContinuationStatus::Awaited,
+                                 /*success*/ std::memory_order_release,
+                                 /*failure*/ std::memory_order_acquire);
+
+  // If that succeeded, we have nothing to do.
+  if (success) return;
+
+  // If it failed, it should be because someone concurrently resumed
+  // (note that the compare-exchange above is strong).
+  assert(oldStatus == ContinuationStatus::Resumed &&
+         "continuation was concurrently corrupted or awaited");
+
+  // Restore the running state of the task and resume it.
+  task->flagAsRunning();
+  return task->runInFullyEstablishedContext();
 }
 
 static void resumeTaskAfterContinuation(AsyncTask *task,

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -629,7 +629,6 @@ static AsyncTaskAndContext swift_task_create_commonImpl(
   // be is the final hop.  Store a signed null instead.
   initialContext->Parent = nullptr;
   initialContext->Flags = AsyncContextKind::Ordinary;
-  initialContext->Flags.setShouldNotDeallocateInCallee(true);
 
   // Attach to the group, if needed.
   if (group) {

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -728,6 +728,9 @@ PollResult TaskGroupImpl::poll(AsyncTask *waitingTask) {
     return result;
   }
 
+  // Have we suspended the task?
+  bool hasSuspended = false;
+
   auto waitHead = waitQueue.load(std::memory_order_acquire);
 
   // ==== 2) Ready task was polled, return with it immediately -----------------
@@ -742,13 +745,12 @@ PollResult TaskGroupImpl::poll(AsyncTask *waitingTask) {
       // Success! We are allowed to poll.
       ReadyQueueItem item;
       bool taskDequeued = readyQueue.dequeue(item);
-      if (!taskDequeued) {
-        result.status = PollStatus::MustWait;
-        result.storage = nullptr;
-        result.successType = nullptr;
-        result.retainedTask = nullptr;
-        mutex.unlock(); // TODO: remove group lock, and use status for synchronization
-        return result;
+      assert(taskDequeued); (void) taskDequeued;
+
+      // We're going back to running the task, so if we suspended before,
+      // we need to flag it as running again.
+      if (hasSuspended) {
+        waitingTask->flagAsRunning();
       }
 
       assert(item.getTask()->isFuture());
@@ -796,6 +798,10 @@ PollResult TaskGroupImpl::poll(AsyncTask *waitingTask) {
   assert(assumed.readyTasks() == 0);
   _swift_tsan_release(static_cast<Job *>(waitingTask));
   while (true) {
+    if (!hasSuspended) {
+      hasSuspended = true;
+      waitingTask->flagAsSuspended();
+    }
     // Put the waiting task at the beginning of the wait queue.
     if (waitQueue.compare_exchange_weak(
         waitHead, waitingTask,

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -20,6 +20,7 @@
 #include "swift/Runtime/Concurrency.h"
 #include "swift/ABI/Task.h"
 #include "swift/ABI/Metadata.h"
+#include "swift/Runtime/Atomic.h"
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Runtime/Error.h"
 #include "../runtime/StackAllocator.h"
@@ -133,32 +134,95 @@ public:
 /// The current state of a task's status records.
 class ActiveTaskStatus {
   enum : uintptr_t {
-    IsCancelled = 0x1,
-    IsLocked = 0x2,
-    RecordMask = ~uintptr_t(IsCancelled | IsLocked)
+    /// The current running priority of the task.
+    PriorityMask = 0xFF,
+
+    /// Has the task been cancelled?
+    IsCancelled = 0x100,
+
+    /// Whether the task status is "locked", meaning that further
+    /// accesses need to wait on the task status record lock
+    IsLocked = 0x200,
+
+    /// Whether the running priority has been escalated above the
+    /// priority recorded in the Job header.
+    IsEscalated = 0x400,
+
+    /// Whether the task is actively running.
+    /// We don't really need to be tracking this in the runtime right
+    /// now, but we will need to eventually track enough information to
+    /// escalate the thread that's running a task, so doing the stores
+    /// necessary to maintain this gives us a more realistic baseline
+    /// for performance.
+    IsRunning = 0x800,
   };
 
-  uintptr_t Value;
+  TaskStatusRecord *Record;
+  uintptr_t Flags;
+
+  ActiveTaskStatus(TaskStatusRecord *record, uintptr_t flags)
+    : Record(record), Flags(flags) {}
 
 public:
-  constexpr ActiveTaskStatus() : Value(0) {}
-  ActiveTaskStatus(TaskStatusRecord *innermostRecord,
-                   bool cancelled, bool locked)
-    : Value(reinterpret_cast<uintptr_t>(innermostRecord)
-                + (locked ? IsLocked : 0)
-                + (cancelled ? IsCancelled : 0)) {}
+#ifdef __GLIBCXX__
+  /// We really don't want to provide this constructor, but in old
+  /// versions of libstdc++, std::atomic<T>::load incorrectly requires
+  /// the type to be default-constructible.
+  ActiveTaskStatus() = default;
+#endif
+
+  constexpr ActiveTaskStatus(JobFlags flags)
+    : Record(nullptr), Flags(uintptr_t(flags.getPriority())) {}
 
   /// Is the task currently cancelled?
-  bool isCancelled() const { return Value & IsCancelled; }
+  bool isCancelled() const { return Flags & IsCancelled; }
+  ActiveTaskStatus withCancelled() const {
+    return ActiveTaskStatus(Record, Flags | IsCancelled);
+  }
+
+  /// Is the task currently running?
+  /// Eventually we'll track this with more specificity, like whether
+  /// it's running on a specific thread, enqueued on a specific actor,
+  /// etc.
+  bool isRunning() const { return Flags & IsRunning; }
+  ActiveTaskStatus withRunning(bool isRunning) const {
+    return ActiveTaskStatus(Record, isRunning ? (Flags | IsRunning)
+                                              : (Flags & ~IsRunning));
+  }
 
   /// Is there an active lock on the cancellation information?
-  bool isLocked() const { return Value & IsLocked; }
+  bool isLocked() const { return Flags & IsLocked; }
+  ActiveTaskStatus withLockingRecord(TaskStatusRecord *lockRecord) const {
+    assert(!isLocked());
+    assert(lockRecord->Parent == Record);
+    return ActiveTaskStatus(lockRecord, Flags | IsLocked);
+  }
+
+  JobPriority getStoredPriority() const {
+    return JobPriority(Flags & PriorityMask);
+  }
+  bool isStoredPriorityEscalated() const {
+    return Flags & IsEscalated;
+  }
+  ActiveTaskStatus withEscalatedPriority(JobPriority priority) const {
+    assert(priority > getStoredPriority());
+    return ActiveTaskStatus(Record,
+                            (Flags & PriorityMask)
+                               | IsEscalated | uintptr_t(priority));
+  }
+  ActiveTaskStatus withoutStoredPriorityEscalation() const {
+    assert(isStoredPriorityEscalated());
+    return ActiveTaskStatus(Record, Flags & ~IsEscalated);
+  }
 
   /// Return the innermost cancellation record.  Code running
   /// asynchronously with this task should not access this record
   /// without having first locked it; see swift_taskCancel.
   TaskStatusRecord *getInnermostRecord() const {
-    return reinterpret_cast<TaskStatusRecord*>(Value & RecordMask);
+    return Record;
+  }
+  ActiveTaskStatus withInnermostRecord(TaskStatusRecord *newRecord) {
+    return ActiveTaskStatus(newRecord, Flags);
   }
 
   static TaskStatusRecord *getStatusRecordParent(TaskStatusRecord *ptr);
@@ -180,8 +244,8 @@ using TaskAllocator = StackAllocator<SlabCapacity>;
 /// Private storage in an AsyncTask object.
 struct AsyncTask::PrivateStorage {
   /// The currently-active information about cancellation.
-  /// Currently one word.
-  std::atomic<ActiveTaskStatus> Status;
+  /// Currently two words.
+  swift::atomic<ActiveTaskStatus> Status;
 
   /// The allocator for the task stack.
   /// Currently 2 words + 8 bytes.
@@ -191,12 +255,12 @@ struct AsyncTask::PrivateStorage {
   /// Currently one word.
   TaskLocal::Storage Local;
 
-  PrivateStorage()
-    : Status(ActiveTaskStatus()),
+  PrivateStorage(JobFlags flags)
+    : Status(ActiveTaskStatus(flags)),
       Local(TaskLocal::Storage()) {}
 
-  PrivateStorage(void *slab, size_t slabCapacity)
-    : Status(ActiveTaskStatus()),
+  PrivateStorage(JobFlags flags, void *slab, size_t slabCapacity)
+    : Status(ActiveTaskStatus(flags)),
       Allocator(slab, slabCapacity),
       Local(TaskLocal::Storage()) {}
 
@@ -224,13 +288,13 @@ AsyncTask::OpaquePrivateStorage::get() const {
   return reinterpret_cast<const PrivateStorage &>(*this);
 }
 inline void AsyncTask::OpaquePrivateStorage::initialize(AsyncTask *task) {
-  new (this) PrivateStorage();
+  new (this) PrivateStorage(task->Flags);
 }
 inline void
 AsyncTask::OpaquePrivateStorage::initializeWithSlab(AsyncTask *task,
                                                     void *slab,
                                                     size_t slabCapacity) {
-  new (this) PrivateStorage(slab, slabCapacity);
+  new (this) PrivateStorage(task->Flags, slab, slabCapacity);
 }
 inline void AsyncTask::OpaquePrivateStorage::complete(AsyncTask *task) {
   get().complete(task);
@@ -249,6 +313,48 @@ inline const AsyncTask::PrivateStorage &AsyncTask::_private() const {
 inline bool AsyncTask::isCancelled() const {
   return _private().Status.load(std::memory_order_relaxed)
                           .isCancelled();
+}
+
+inline void AsyncTask::flagAsRunning() {
+  auto oldStatus = _private().Status.load(std::memory_order_relaxed);
+  while (true) {
+    assert(!oldStatus.isRunning());
+    if (oldStatus.isLocked()) {
+      return flagAsRunning_slow();
+    }
+
+    auto newStatus = oldStatus.withRunning(true);
+    if (newStatus.isStoredPriorityEscalated()) {
+      newStatus = newStatus.withoutStoredPriorityEscalation();
+      Flags.setPriority(oldStatus.getStoredPriority());
+    }
+
+    if (_private().Status.compare_exchange_weak(oldStatus, newStatus,
+                                                std::memory_order_relaxed,
+                                                std::memory_order_relaxed))
+      return;
+  }
+}
+
+inline void AsyncTask::flagAsSuspended() {
+  auto oldStatus = _private().Status.load(std::memory_order_relaxed);
+  while (true) {
+    assert(oldStatus.isRunning());
+    if (oldStatus.isLocked()) {
+      return flagAsSuspended_slow();
+    }
+
+    auto newStatus = oldStatus.withRunning(false);
+    if (newStatus.isStoredPriorityEscalated()) {
+      newStatus = newStatus.withoutStoredPriorityEscalation();
+      Flags.setPriority(oldStatus.getStoredPriority());
+    }
+
+    if (_private().Status.compare_exchange_weak(oldStatus, newStatus,
+                                                std::memory_order_relaxed,
+                                                std::memory_order_relaxed))
+      return;
+  }
 }
 
 inline void AsyncTask::localValuePush(const HeapObject *key,

--- a/test/IRGen/async/get_async_continuation.sil
+++ b/test/IRGen/async/get_async_continuation.sil
@@ -58,22 +58,7 @@ bb0:
 // CHECK: call swiftcc void @not_async_test()
 
 //   Arrive at the await_async_continuation point.
-// CHECK: [[synchronization_addr_before_await:%.*]] = getelementptr inbounds %swift.continuation_context, %swift.continuation_context* [[cont_context]], i32 0, i32 1
-// CHECK: [[first_at_sync_pt:%.*]] = cmpxchg [[INT]]* [[synchronization_addr_before_await]], {{(i64|i32)}} 0, {{(i64|i32)}} 1 release acquire
-// CHECK: [[first_at_sync_pt_bool:%.*]] = extractvalue { {{(i64|i32)}}, i1 } [[first_at_sync_pt]], 1
-// CHECK: br i1 [[first_at_sync_pt_bool]], label %await.async.abort, label %await.async.resume
-
-//  Abort if we are the first to arrive at the await/or continuation point --
-//  we must wait on the other to arrive.
-// CHECK: await.async.abort:
-// CHECK:  br label %coro.end
-
-// CHECK: coro.end:
-// CHECK:   call i1 (i8*, i1, ...) @llvm.coro.end.async(
-// CHECK:   unreachable
-
-// CHECK: await.async.resume:
-// CHECK:   call { i8* } (i32, i8*, i8*, ...) @llvm.coro.suspend.async{{.*}}({{.*}} @__swift_async_resume_project_context{{.*}}@__swift_suspend_dispatch_1
+// CHECK: [[suspend:%.*]] = call { i8* } (i32, i8*, i8*, ...) @llvm.coro.suspend.async.sl_p0i8s(i32 0, i8* [[resume_intrinsic]], i8* bitcast (i8* (i8*)* @__swift_async_resume_project_context to i8*), i8* bitcast (void (%swift.continuation_context*)* @__swift_continuation_await_point to i8*), %swift.continuation_context* [[cont_context]])
 // CHECK:   [[result_addr_addr:%.*]] = getelementptr inbounds %swift.continuation_context, %swift.continuation_context* [[cont_context]], i32 0, i32 3
 // CHECK:   [[result_addr:%.*]] = load %swift.opaque*, %swift.opaque** [[result_addr_addr]]
 // CHECK:   [[typed_result_addr:%.*]] = bitcast %swift.opaque* [[result_addr]] to i32*
@@ -81,12 +66,15 @@ bb0:
 // CHECK:   br label %[[result_bb:[0-9]+]]
 
 // CHECK: [[result_bb]]:
-// CHECK:   phi i32 [ [[result_value]], %await.async.resume ]
+// CHECK:   phi i32 [ [[result_value]], %entry ]
 
+// CHECK: define {{.*}} void @__swift_continuation_await_point(%swift.continuation_context* %0)
+// CHECK:      {{musttail call swifttailcc|tail call swiftcc}} void @swift_continuation_await(%swift.continuation_context* %0)
+// CHECK-NEXT: ret void
 
-// CHECK: define {{.*}} void @__swift_suspend_dispatch_1(i8* %0, i8* %1)
+// CHECK: define {{.*}} void @__swift_suspend_dispatch_1(i8* %0, %swift.context* %1)
 // CHECK-NOT: define
-// CHECK:  tail call swift{{(tail)?}}cc void %{{.*}}(i8* swiftasync %1)
+// CHECK:  tail call swift{{(tail)?}}cc void %{{.*}}(%swift.context* swiftasync %1)
 // CHECK-NEXT:  ret void
 
 sil @async_continuation : $@async () -> () {

--- a/unittests/runtime/Actor.cpp
+++ b/unittests/runtime/Actor.cpp
@@ -162,6 +162,8 @@ template <class Context, class Fn>
 static void parkTask(AsyncTask *task, Context *context, Fn &&fn) {
   auto invoke =
     TaskContinuationFromLambda<Fn, Context>::get(std::move(fn));
+  auto currentTask = swift_task_suspend();
+  EXPECT_EQ(task, currentTask);
   task->ResumeTask = invoke;
   task->ResumeContext = context;
 }

--- a/unittests/runtime/CompatibilityOverrideConcurrency.cpp
+++ b/unittests/runtime/CompatibilityOverrideConcurrency.cpp
@@ -116,10 +116,6 @@ TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_job_run) {
   swift_job_run(nullptr, ExecutorRef::generic());
 }
 
-TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_getCurrent) {
-  swift_task_getCurrent();
-}
-
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_getCurrentExecutor) {
   swift_task_getCurrentExecutor();
 }


### PR DESCRIPTION
Tracking this as a single bit is actually largely uninteresting to the runtime. To handle priority escalation properly, we really need to track this at a finer grain of detail: recording that the task is running on a specific thread, enqueued on a specific actor, or so on. But starting by tracking a single bit is important for two reasons:

First, it's more realistic about the performance overheads of tasks: we're going to be doing this tracking eventually, and the cost of that tracking will be dominated by the atomic access, so doing that access now sets the baseline about right.

Second, it ensures that we've actually got runtime involvement in all the right places to do this tracking.

A propos of the latter: there was no runtime involvement with awaiting a continuation, which is a point at which the task potentially transitions from running to suspended. We must do the tracking as part of this transition, rather than recognizing in the run-loops that a task is still active and treating it as having suspended, because the latter point potentially races with the resumption of the task. To do this, I've had to introduce a runtime function, swift_continuation_await, to do this awaiting rather than inlining the atomic operation on the continuation.

Some related fixes and enhancements are included in this PR; see the commit list for details.

5.5 version of #38386.  I was not able to cherry-pick the final commit, removing the hooking of `swift_task_getCurrent()`, as that work does not appear to be on the 5.5 branch.  @mikeash, is that expected?

rdar://80651166