### PR TITLE
Revert "Begin untangling GenericEnvironment from GenericSignatureBuilder"

### DIFF
--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -76,21 +76,15 @@ class alignas(1 << DeclAlignInBits) GenericEnvironment final
   /// generic signature.
   ArrayRef<Type> getContextTypes() const;
 
-  explicit GenericEnvironment(GenericSignature signature);
+  GenericEnvironment(GenericSignature signature,
+                     GenericSignatureBuilder *builder);
 
   friend ArchetypeType;
   friend GenericSignatureBuilder;
   
-  GenericSignatureBuilder *getGenericSignatureBuilder() const;
+  GenericSignatureBuilder *getGenericSignatureBuilder() const { return Builder; }
 
   friend QueryInterfaceTypeSubstitutions;
-
-  Type getOrCreateArchetypeFromInterfaceType(Type depType);
-
-  /// Retrieve the mapping for the given generic parameter, if present.
-  ///
-  /// This is only useful when lazily populating a generic environment.
-  Optional<Type> getMappingIfPresent(GenericParamKey key) const;
 
 public:
   GenericSignature getGenericSignature() const {
@@ -102,11 +96,17 @@ public:
   /// Create a new, "incomplete" generic environment that will be populated
   /// by calls to \c addMapping().
   static
-  GenericEnvironment *getIncomplete(GenericSignature signature);
+  GenericEnvironment *getIncomplete(GenericSignature signature,
+                                    GenericSignatureBuilder *builder);
 
   /// Add a mapping of a generic parameter to a specific type (which may be
   /// an archetype)
   void addMapping(GenericParamKey key, Type contextType);
+
+  /// Retrieve the mapping for the given generic parameter, if present.
+  ///
+  /// This is only useful when lazily populating a generic environment.
+  Optional<Type> getMappingIfPresent(GenericParamKey key) const;
 
   /// Make vanilla new/delete illegal.
   void *operator new(size_t Bytes) = delete;
@@ -151,8 +151,6 @@ public:
   mapConformanceRefIntoContext(Type conformingType,
                                ProtocolConformanceRef conformance) const;
 
-  /// Returns a substitution map that sends every generic parameter to its
-  /// corresponding archetype in this generic environment.
   SubstitutionMap getForwardingSubstitutionMap() const;
 
   void dump(raw_ostream &os) const;

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -228,14 +228,23 @@ public:
 
     /// Lookup a nested type with the given name within this equivalence
     /// class.
+    ///
+    /// \param otherConcreteTypes If non-null, will be filled in the all of the
+    /// concrete types we found (other than the result) with the same name.
     TypeDecl *lookupNestedType(
                    GenericSignatureBuilder &builder,
-                   Identifier name);
+                   Identifier name,
+                   SmallVectorImpl<TypeDecl *> *otherConcreteTypes = nullptr);
 
     /// Retrieve the "anchor" type that canonically describes this equivalence
     /// class, for use in the canonical type.
     Type getAnchor(GenericSignatureBuilder &builder,
                    TypeArrayView<GenericTypeParamType> genericParams);
+
+    /// Retrieve (or build) the contextual type corresponding to
+    /// this equivalence class within the given generic environment.
+    Type getTypeInContext(GenericSignatureBuilder &builder,
+                          GenericEnvironment *genericEnv);
 
     /// Dump a debugging representation of this equivalence class,
     void dump(llvm::raw_ostream &out,
@@ -259,7 +268,7 @@ public:
       unsigned numConformancesPresent;
       CanType superclassPresent;
       CanType concreteTypePresent;
-      TypeDecl *type;
+      llvm::TinyPtrVector<TypeDecl *> types;
     };
 
     /// Cached nested-type information, which contains the best declaration

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -18,8 +18,6 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/GenericSignatureBuilder.h"
 #include "swift/AST/ProtocolConformance.h"
-#include "swift/Basic/Defer.h"
-#include "GenericSignatureBuilderImpl.h"
 
 using namespace swift;
 
@@ -48,22 +46,13 @@ GenericEnvironment::getGenericParams() const {
   return Signature->getGenericParams();
 }
 
-GenericEnvironment::GenericEnvironment(GenericSignature signature)
-  : Signature(signature)
+GenericEnvironment::GenericEnvironment(GenericSignature signature,
+                                       GenericSignatureBuilder *builder)
+  : Signature(signature), Builder(builder)
 {
   // Clear out the memory that holds the context types.
   std::uninitialized_fill(getContextTypes().begin(), getContextTypes().end(),
                           Type());
-}
-
-GenericSignatureBuilder *GenericEnvironment::getGenericSignatureBuilder() const {
-  if (Builder)
-    return Builder;
-
-  const_cast<GenericEnvironment *>(this)->Builder
-      = Signature->getGenericSignatureBuilder();
-
-  return Builder;
 }
 
 void GenericEnvironment::addMapping(GenericParamKey key,
@@ -75,9 +64,7 @@ void GenericEnvironment::addMapping(GenericParamKey key,
   assert(genericParams[index] == key && "Bad generic parameter");
 
   // Add the mapping from the generic parameter to the context type.
-  assert(getContextTypes()[index].isNull() ||
-         getContextTypes()[index]->is<ErrorType>() &&
-         "Already recoded this mapping");
+  assert(getContextTypes()[index].isNull() && "Already recoded this mapping");
   getContextTypes()[index] = contextType;
 }
 
@@ -120,116 +107,6 @@ Type TypeBase::mapTypeOutOfContext() {
     SubstFlags::AllowLoweredTypes);
 }
 
-Type
-GenericEnvironment::getOrCreateArchetypeFromInterfaceType(Type depType) {
-  auto &builder = *getGenericSignatureBuilder();
-  auto &ctx = builder.getASTContext();
-
-  auto resolved =
-    builder.maybeResolveEquivalenceClass(
-                                  depType,
-                                  ArchetypeResolutionKind::CompleteWellFormed,
-                                  /*wantExactPotentialArchetype=*/false);
-  if (!resolved)
-    return ErrorType::get(depType);
-
-  if (auto concrete = resolved.getAsConcreteType()) {
-    return mapTypeIntoContext(concrete,
-                              builder.getLookupConformanceFn());
-  }
-
-  auto *equivClass = resolved.getEquivalenceClass(builder);
-
-  auto genericParams = getGenericParams();
-  Type anchor = equivClass->getAnchor(builder, genericParams);
-
-  // First, write an ErrorType to the location where this type is cached,
-  // to catch re-entrant lookups that might arise from an invalid generic
-  // signature (eg, <X where X == Array<X>>).
-  ArchetypeType *parentArchetype = nullptr;
-  GenericTypeParamType *genericParam = nullptr;
-  if (auto depMemTy = anchor->getAs<DependentMemberType>()) {
-    parentArchetype =
-      getOrCreateArchetypeFromInterfaceType(depMemTy->getBase())
-        ->getAs<ArchetypeType>();
-    if (!parentArchetype)
-      return ErrorType::get(depMemTy);
-
-    auto name = depMemTy->getName();
-    if (auto type = parentArchetype->getNestedTypeIfKnown(name))
-      return *type;
-
-    parentArchetype->registerNestedType(name, ErrorType::get(ctx));
-  } else {
-    genericParam = anchor->castTo<GenericTypeParamType>();
-    if (auto type = getMappingIfPresent(genericParam))
-      return *type;
-    addMapping(genericParam, ErrorType::get(ctx));
-  }
-
-  Type result;
-
-  // If this equivalence class is mapped to a concrete type, produce that
-  // type.
-  if (equivClass->concreteType) {
-    result = mapTypeIntoContext(equivClass->concreteType,
-                                builder.getLookupConformanceFn());
-  } else {
-    // Substitute into the superclass.
-    Type superclass = equivClass->superclass;
-    if (superclass && superclass->hasTypeParameter()) {
-      superclass = mapTypeIntoContext(superclass,
-                                      builder.getLookupConformanceFn());
-      if (superclass->is<ErrorType>())
-        superclass = Type();
-    }
-
-    // Collect the protocol conformances for the archetype.
-    SmallVector<ProtocolDecl *, 4> protos;
-    for (const auto &conforms : equivClass->conformsTo) {
-      auto proto = conforms.first;
-
-      if (!equivClass->isConformanceSatisfiedBySuperclass(proto))
-        protos.push_back(proto);
-    }
-
-    if (parentArchetype) {
-      auto *depMemTy = anchor->castTo<DependentMemberType>();
-      result = NestedArchetypeType::getNew(ctx, parentArchetype, depMemTy,
-                                           protos, superclass,
-                                           equivClass->layout);
-    } else {
-      result = PrimaryArchetypeType::getNew(ctx, this, genericParam,
-                                            protos, superclass,
-                                            equivClass->layout);
-    }
-  }
-
-  // Cache the new archetype for future lookups.
-  if (auto depMemTy = anchor->getAs<DependentMemberType>()) {
-    parentArchetype->registerNestedType(depMemTy->getName(), result);
-  } else {
-    addMapping(genericParam, result);
-  }
-
-  return result;
-}
-
-void ArchetypeType::resolveNestedType(
-                                    std::pair<Identifier, Type> &nested) const {
-  Type interfaceType = getInterfaceType();
-  Type memberInterfaceType =
-      DependentMemberType::get(interfaceType, nested.first);
-
-  Type result = getGenericEnvironment()->getOrCreateArchetypeFromInterfaceType(
-      memberInterfaceType);
-
-  assert(!nested.second ||
-         nested.second->isEqual(result) ||
-         nested.second->is<ErrorType>());
-  nested.second = result;
-}
-
 Type QueryInterfaceTypeSubstitutions::operator()(SubstitutableType *type) const{
   if (auto gp = type->getAs<GenericTypeParamType>()) {
     // Find the index into the parallel arrays of generic parameters and
@@ -243,18 +120,24 @@ Type QueryInterfaceTypeSubstitutions::operator()(SubstitutableType *type) const{
       return Type();
 
     // If the context type isn't already known, lazily create it.
-    auto mutableSelf = const_cast<GenericEnvironment *>(self);
-    Type &contextType = mutableSelf->getContextTypes()[index];
-    if (contextType)
-      return contextType;
+    Type contextType = self->getContextTypes()[index];
+    if (!contextType) {
+      assert(self->Builder &&"Missing generic signature builder for lazy query");
+      auto equivClass =
+        self->Builder->resolveEquivalenceClass(
+                                  type,
+                                  ArchetypeResolutionKind::CompleteWellFormed);
 
-    auto result = mutableSelf->getOrCreateArchetypeFromInterfaceType(type);
+      auto mutableSelf = const_cast<GenericEnvironment *>(self);
+      contextType = equivClass->getTypeInContext(*mutableSelf->Builder,
+                                                 mutableSelf);
 
-    assert (!contextType ||
-            contextType->isEqual(result) ||
-            contextType->is<ErrorType>());
-    contextType = result;
-    return result;
+      // FIXME: Redundant mapping from key -> index.
+      if (self->getContextTypes()[index].isNull())
+        mutableSelf->addMapping(key, contextType);
+    }
+
+    return contextType;
   }
 
   return Type();

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -247,8 +247,9 @@ CanGenericSignature GenericSignatureImpl::getCanonicalSignature() const {
 
 GenericEnvironment *GenericSignatureImpl::getGenericEnvironment() const {
   if (GenericEnv == nullptr) {
+    auto *builder = getGenericSignatureBuilder();
     const auto impl = const_cast<GenericSignatureImpl *>(this);
-    impl->GenericEnv = GenericEnvironment::getIncomplete(this);
+    impl->GenericEnv = GenericEnvironment::getIncomplete(this, builder);
   }
 
   return GenericEnv;

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2020,16 +2020,36 @@ static void lookupConcreteNestedType(NominalTypeDecl *decl,
     concreteDecls.push_back(cast<TypeDecl>(member));
 }
 
-static TypeDecl *findBestConcreteNestedType(SmallVectorImpl<TypeDecl *> &concreteDecls) {
-  return *std::min_element(concreteDecls.begin(), concreteDecls.end(),
-                           [](TypeDecl *type1, TypeDecl *type2) {
-                             return TypeDecl::compare(type1, type2) < 0;
-                           });
+static auto findBestConcreteNestedType(SmallVectorImpl<TypeDecl *> &concreteDecls) {
+  return std::min_element(concreteDecls.begin(), concreteDecls.end(),
+                          [](TypeDecl *type1, TypeDecl *type2) {
+                            return TypeDecl::compare(type1, type2) < 0;
+                          });
 }
 
 TypeDecl *EquivalenceClass::lookupNestedType(
                              GenericSignatureBuilder &builder,
-                             Identifier name) {
+                             Identifier name,
+                             SmallVectorImpl<TypeDecl *> *otherConcreteTypes) {
+  // Populates the result structures from the given cache entry.
+  auto populateResult = [&](const CachedNestedType &cache) -> TypeDecl * {
+    if (otherConcreteTypes)
+      otherConcreteTypes->clear();
+
+    // If there aren't any types in the cache, we're done.
+    if (cache.types.empty()) return nullptr;
+
+    // The first type in the cache is always the final result.
+    // Collect the rest in the concrete-declarations list, if needed.
+    if (otherConcreteTypes) {
+      for (auto type : ArrayRef<TypeDecl *>(cache.types).slice(1)) {
+        otherConcreteTypes->push_back(type);
+      }
+    }
+
+    return cache.types.front();
+  };
+
   // If we have a cached value that is up-to-date, use that.
   auto cached = nestedTypeNameCache.find(name);
   if (cached != nestedTypeNameCache.end() &&
@@ -2039,7 +2059,7 @@ TypeDecl *EquivalenceClass::lookupNestedType(
       (!concreteType ||
         cached->second.concreteTypePresent == concreteType->getCanonicalType())) {
     ++NumNestedTypeCacheHits;
-    return cached->second.type;
+    return populateResult(cached->second);
   }
 
   // Cache miss; go compute the result.
@@ -2092,16 +2112,24 @@ TypeDecl *EquivalenceClass::lookupNestedType(
   entry.concreteTypePresent =
     concreteType ? concreteType->getCanonicalType() : CanType();
   if (bestAssocType) {
-    entry.type = bestAssocType;
+    entry.types.push_back(bestAssocType);
+    entry.types.insert(entry.types.end(),
+                       concreteDecls.begin(), concreteDecls.end());
     assert(bestAssocType->getOverriddenDecls().empty() &&
            "Lookup should never keep a non-anchor associated type");
   } else if (!concreteDecls.empty()) {
     // Find the best concrete type.
-    entry.type = findBestConcreteNestedType(concreteDecls);
+    auto bestConcreteTypeIter = findBestConcreteNestedType(concreteDecls);
+
+    // Put the best concrete type first; the rest will follow.
+    entry.types.push_back(*bestConcreteTypeIter);
+    entry.types.insert(entry.types.end(),
+                       concreteDecls.begin(), bestConcreteTypeIter);
+    entry.types.insert(entry.types.end(),
+                       bestConcreteTypeIter + 1, concreteDecls.end());
   }
 
-  nestedTypeNameCache[name] = entry;
-  return entry.type;
+  return populateResult((nestedTypeNameCache[name] = std::move(entry)));
 }
 
 static Type getSugaredDependentType(Type type,
@@ -2167,6 +2195,127 @@ Type EquivalenceClass::getAnchor(
 #endif
 
   return substAnchor();
+}
+
+Type EquivalenceClass::getTypeInContext(GenericSignatureBuilder &builder,
+                                        GenericEnvironment *genericEnv) {
+  auto genericParams = genericEnv->getGenericParams();
+
+  // The anchor descr
+  Type anchor = getAnchor(builder, genericParams);
+
+  // If this equivalence class is mapped to a concrete type, produce that
+  // type.
+  if (concreteType) {
+    if (recursiveConcreteType)
+      return ErrorType::get(anchor);
+
+    // Prevent recursive substitution.
+    this->recursiveConcreteType = true;
+    SWIFT_DEFER {
+      this->recursiveConcreteType = false;
+    };
+
+    return genericEnv->mapTypeIntoContext(concreteType,
+                                          builder.getLookupConformanceFn());
+  }
+
+  // Local function to check whether we have a generic parameter that has
+  // already been recorded
+  auto getAlreadyRecoveredGenericParam = [&]() -> Type {
+    auto genericParam = anchor->getAs<GenericTypeParamType>();
+    if (!genericParam) return Type();
+
+    auto type = genericEnv->getMappingIfPresent(genericParam);
+    if (!type) return Type();
+
+    // We already have a mapping for this generic parameter in the generic
+    // environment. Return it.
+    return *type;
+  };
+
+  AssociatedTypeDecl *assocType = nullptr;
+  ArchetypeType *parentArchetype = nullptr;
+  if (auto depMemTy = anchor->getAs<DependentMemberType>()) {
+    // Resolve the equivalence class of the parent.
+    auto parentEquivClass =
+      builder.resolveEquivalenceClass(
+                          depMemTy->getBase(),
+                          ArchetypeResolutionKind::CompleteWellFormed);
+    if (!parentEquivClass)
+      return ErrorType::get(anchor);
+
+    // Map the parent type into this context.
+    parentArchetype =
+      parentEquivClass->getTypeInContext(builder, genericEnv)
+                      ->castTo<ArchetypeType>();
+
+    // If we already have a nested type with this name, return it.
+    assocType = depMemTy->getAssocType();
+    if (auto nested =
+          parentArchetype->getNestedTypeIfKnown(assocType->getName())) {
+      return *nested;
+    }
+
+    // We will build the archetype below.
+  } else if (auto result = getAlreadyRecoveredGenericParam()) {
+    // Return already-contextualized generic type parameter.
+    return result;
+  }
+
+  // Substitute into the superclass.
+  Type superclass = this->recursiveSuperclassType ? Type() : this->superclass;
+  if (superclass && superclass->hasTypeParameter()) {
+    // Prevent recursive substitution.
+    this->recursiveSuperclassType = true;
+    SWIFT_DEFER {
+      this->recursiveSuperclassType = false;
+    };
+
+    superclass = genericEnv->mapTypeIntoContext(
+                                            superclass,
+                                            builder.getLookupConformanceFn());
+    if (superclass->is<ErrorType>())
+      superclass = Type();
+
+    // We might have recursively recorded the archetype; if so, return early.
+    // FIXME: This should be detectable before we end up building archetypes.
+    if (auto result = getAlreadyRecoveredGenericParam())
+      return result;
+  }
+
+  // Build a new archetype.
+
+  // Collect the protocol conformances for the archetype.
+  SmallVector<ProtocolDecl *, 4> protos;
+  for (const auto &conforms : conformsTo) {
+    auto proto = conforms.first;
+
+    if (!isConformanceSatisfiedBySuperclass(proto))
+      protos.push_back(proto);
+  }
+
+  ArchetypeType *archetype;
+  ASTContext &ctx = builder.getASTContext();
+  if (parentArchetype) {
+    // Create a nested archetype.
+    auto *depMemTy = anchor->castTo<DependentMemberType>();
+    archetype = NestedArchetypeType::getNew(ctx, parentArchetype, depMemTy,
+                                            protos, superclass, layout);
+
+    // Register this archetype with its parent.
+    parentArchetype->registerNestedType(assocType->getName(), archetype);
+  } else {
+    // Create a top-level archetype.
+    auto genericParam = anchor->castTo<GenericTypeParamType>();
+    archetype = PrimaryArchetypeType::getNew(ctx, genericEnv, genericParam,
+                                             protos, superclass, layout);
+
+    // Register the archetype with the generic environment.
+    genericEnv->addMapping(genericParam, archetype);
+  }
+
+  return archetype;
 }
 
 void EquivalenceClass::dump(llvm::raw_ostream &out,
@@ -2703,6 +2852,38 @@ PotentialArchetype *PotentialArchetype::getOrCreateNestedType(
   }
 
   return resultPA;
+}
+
+void ArchetypeType::resolveNestedType(
+                                    std::pair<Identifier, Type> &nested) const {
+  auto genericEnv = getGenericEnvironment();
+  auto &builder = *genericEnv->getGenericSignatureBuilder();
+
+  Type interfaceType = getInterfaceType();
+  Type memberInterfaceType =
+    DependentMemberType::get(interfaceType, nested.first);
+  auto resolved =
+    builder.maybeResolveEquivalenceClass(
+                                  memberInterfaceType,
+                                  ArchetypeResolutionKind::CompleteWellFormed,
+                                  /*wantExactPotentialArchetype=*/false);
+  if (!resolved) {
+    nested.second = ErrorType::get(interfaceType);
+    return;
+  }
+
+  Type result;
+  if (auto concrete = resolved.getAsConcreteType()) {
+    result = concrete;
+  } else {
+    auto *equivClass = resolved.getEquivalenceClass(builder);
+    result = equivClass->getTypeInContext(builder, genericEnv);
+  }
+
+  assert(!nested.second ||
+         nested.second->isEqual(result) ||
+         (nested.second->hasError() && result->hasError()));
+  nested.second = result;
 }
 
 Type GenericSignatureBuilder::PotentialArchetype::getDependentType(
@@ -3648,7 +3829,8 @@ ResolvedType GenericSignatureBuilder::maybeResolveEquivalenceClass(
           if (concreteDecls.empty())
             return ResolvedType::forUnresolved(nullptr);
 
-          concreteDecl = findBestConcreteNestedType(concreteDecls);
+          auto bestConcreteTypeIter = findBestConcreteNestedType(concreteDecls);
+          concreteDecl = *bestConcreteTypeIter;
         }
       }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3472,7 +3472,7 @@ void ArchetypeType::registerNestedType(Identifier name, Type nested) {
          "Unable to find nested type?");
   assert(!found->second ||
          found->second->isEqual(nested) ||
-         found->second->is<ErrorType>());
+         (found->second->hasError() && nested->hasError()));
   found->second = nested;
 }
 

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/GenericSignatureBuilder.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/SourceFile.h"


### PR DESCRIPTION
Reverts apple/swift#38384

This regressed the windows builder and introduced an invalid access:
```
Assertion failed: Ptr && "Cannot dereference a null Type!", file C:\Users\swift-ci\jenkins\workspace\swift-PR-windows\swift\include\swift/AST/Type.h, line 220
```