### PR TITLE
[Dependency Scanning] Do not include `-target` in `extraPCMArgs` when scanning an interface

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -232,6 +232,7 @@ void ClangImporter::recordModuleDependencies(
     while(It != allArgs.end()) {
       StringRef arg = *It;
       // Remove the -target arguments because we should use the target triple
+      // specified with `-clang-target` on the scanner invocation, or
       // from the depending Swift modules.
       if (arg == "-target") {
         It += 2;
@@ -252,6 +253,16 @@ void ClangImporter::recordModuleDependencies(
       swiftArgs.push_back("-Xclang");
       swiftArgs.push_back("-Xcc");
       swiftArgs.push_back(clangArg);
+    }
+
+    // If the scanner is invoked with '-clang-target', ensure this is the target
+    // used to build this PCM.
+    if (Impl.SwiftContext.LangOpts.ClangTarget.hasValue()) {
+      llvm::Triple triple = Impl.SwiftContext.LangOpts.ClangTarget.getValue();
+      swiftArgs.push_back("-Xcc");
+      swiftArgs.push_back("-target");
+      swiftArgs.push_back("-Xcc");
+      swiftArgs.push_back(triple.str());
     }
 
     // Swift frontend action: -emit-pcm

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1049,11 +1049,16 @@ identifyMainModuleDependencies(CompilerInstance &instance) {
        instance.getASTContext()
            .LangOpts.EffectiveLanguageVersion.asAPINotesVersionString())
           .str();
+
   // Compute the dependencies of the main module.
-  auto mainDependencies = ModuleDependencies::forMainSwiftModule(
-      {// ExtraPCMArgs
-       "-Xcc", "-target", "-Xcc",
-       instance.getASTContext().LangOpts.Target.str(), "-Xcc", apinotesVer});
+  std::vector<StringRef> ExtraPCMArgs = {
+    "-Xcc", apinotesVer
+  };
+  if (!instance.getASTContext().LangOpts.ClangTarget.hasValue())
+    ExtraPCMArgs.insert(ExtraPCMArgs.begin(),
+                        {"-Xcc", "-target", "-Xcc",
+                         instance.getASTContext().LangOpts.Target.str()});
+  auto mainDependencies = ModuleDependencies::forMainSwiftModule(ExtraPCMArgs);
 
   // Compute Implicit dependencies of the main module
   {

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/clang-module-cache
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
 
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
 // Check the contents of the JSON output
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %FileCheck -check-prefix CHECK_NO_CLANG_TARGET %s < %t/deps.json
 
 // Check the contents of the JSON output
 // RUN: %FileCheck %s -check-prefix CHECK-NO-SEARCH-PATHS < %t/deps.json
@@ -22,7 +22,12 @@
 
 // Ensure that round-trip serialization does not affect result
 // RUN: %target-swift-frontend -scan-dependencies -test-dependency-scan-cache-serialization -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %FileCheck -check-prefix CHECK_NO_CLANG_TARGET %s < %t/deps.json
+
+// Ensure that scanning with `-clang-target` makes sure that Swift modules' respecitve PCM-dependency-build-argument sets do not contain target triples.
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps_clang_target.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -clang-target %target-cpu-apple-macosx10.14
+// Check the contents of the JSON output
+// RUN: %FileCheck -check-prefix CHECK_CLANG_TARGET %s < %t/deps_clang_target.json
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
@@ -178,10 +183,13 @@ import SubE
 // CHECK: "-swift-version"
 // CHECK: "5"
 // CHECK: ],
-// CHECK" "extraPcmArgs": [
-// CHECK"   "-target",
-// CHECK"   "-fapinotes-swift-version=5"
-// CHECK" ]
+// CHECK_NO_CLANG_TARGET: "extraPcmArgs": [
+// CHECK_NO_CLANG_TARGET-NEXT:   "-Xcc",
+// CHECK_NO_CLANG_TARGET-NEXT:   "-target",
+// CHECK_CLANG_TARGET: "extraPcmArgs": [
+// CHECK_CLANG_TARGET-NEXT:   "-Xcc",
+// CHECK_CLANG_TARGET-NEXT:   "-fapinotes-swift-version={{.*}}"
+// CHECK_CLANG_TARGET-NEXT:   ]
 
 /// --------Swift module Swift
 // CHECK-LABEL: "modulePath": "Swift.swiftmodule",


### PR DESCRIPTION
https://github.com/apple/swift/pull/37774 (related to rdar://72480261) has made it so that the target of built clang modules (even downstream from Swift interface dependencies) can be consistent with that of the main module. This means that when building transitive Clang dependencies of the main module, they will always have a matching triple to the main module itself (ensured with `-clang-target`). This means we no longer have to report the target triple in the set of `extraPCMArgs` which encode an interface-specific requirement for building its dependencies.

When no -clang-target is specified on the scanner invocation (if the driver was invoked with `-disable-clang-target`, for example, preserve existing behavior.