### PR TITLE
[IRGen] Fix crashes involving ObjC generic params

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3979,7 +3979,7 @@ public:
   /// Returns true if the decl uses the Objective-C generics model.
   ///
   /// This is true of imported Objective-C classes.
-  bool usesObjCGenericsModel() const {
+  bool isTypeErasedGenericClass() const {
     return hasClangNode() && isGenericContext() && isObjC();
   }
   

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2919,7 +2919,8 @@ bool ValueDecl::isObjCDynamicInGenericClass() const {
   if (!classDecl)
     return false;
 
-  return classDecl->isGenericContext() && !classDecl->usesObjCGenericsModel();
+  return classDecl->isGenericContext()
+             && !classDecl->isTypeErasedGenericClass();
 }
 
 bool ValueDecl::shouldUseObjCMethodReplacement() const {
@@ -4190,7 +4191,7 @@ bool NominalTypeDecl::isTypeErasedGenericClass() const {
   // ObjC classes are type erased.
   // TODO: Unless they have magic methods...
   if (auto clas = dyn_cast<ClassDecl>(this))
-    return clas->hasClangNode() && clas->isGenericContext();
+    return clas->isTypeErasedGenericClass();
   return false;
 }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3003,7 +3003,8 @@ Type ArchetypeType::getExistentialType() const {
     constraintTypes.push_back(proto->getDeclaredInterfaceType());
   }
   return ProtocolCompositionType::get(
-     const_cast<ArchetypeType*>(this)->getASTContext(), constraintTypes, false);
+     const_cast<ArchetypeType*>(this)->getASTContext(), constraintTypes,
+                                      requiresClass());
 }
 
 PrimaryArchetypeType::PrimaryArchetypeType(const ASTContext &Ctx,

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -85,7 +85,7 @@ llvm::cl::opt<bool> UseBasicDynamicReplacement(
     llvm::cl::desc("Basic implementation of dynamic replacement"));
 
 namespace {
-  
+
 /// Add methods, properties, and protocol conformances from a JITed extension
 /// to an ObjC class using the ObjC runtime.
 ///
@@ -119,8 +119,8 @@ public:
                                              /*allow uninitialized*/ false);
     classMetadata = Builder.CreateBitCast(classMetadata, IGM.ObjCClassPtrTy);
     metaclassMetadata = IGM.getAddrOfMetaclassObject(
-                                       origTy.getClassOrBoundGenericClass(),
-                                                         NotForDefinition);
+                          dyn_cast_or_null<ClassDecl>(origTy->getAnyNominal()),
+                          NotForDefinition);
     metaclassMetadata = llvm::ConstantExpr::getBitCast(metaclassMetadata,
                                                    IGM.ObjCClassPtrTy);
 

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -418,7 +418,7 @@ void PolymorphicConvention::considerParameter(SILParameterInfo param,
         // sources of metadata.
         CanType objTy = metatypeTy.getInstanceType();
         if (auto classDecl = objTy->getClassOrBoundGenericClass())
-          if (classDecl->usesObjCGenericsModel())
+          if (classDecl->isTypeErasedGenericClass())
             return;
 
         considerNewTypeSource(MetadataSource::Kind::Metadata,

--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -197,6 +197,11 @@ namespace irgen {
       /// Metadata is derived from the Self witness table parameter
       /// passed via the WitnessMethod convention.
       SelfWitnessTable,
+
+      /// Metadata is obtained directly from the FixedType indicated. Used with
+      /// Objective-C generics, where the actual argument is erased at runtime
+      /// and its existential bound is used instead.
+      ErasedTypeMetadata,
     };
 
     static bool requiresSourceIndex(Kind kind) {
@@ -205,14 +210,23 @@ namespace irgen {
               kind == Kind::GenericLValueMetadata);
     }
 
+    static bool requiresFixedType(Kind kind) {
+      return (kind == Kind::ErasedTypeMetadata);
+    }
+
     enum : unsigned { InvalidSourceIndex = ~0U };
 
   private:
     /// The kind of source this is.
     Kind TheKind;
 
-    /// The parameter index, for ClassPointer and Metadata sources.
-    unsigned Index;
+    /// For ClassPointer, Metadata, and GenericLValueMetadata, the source index;
+    /// for ErasedTypeMetadata, the type; for others, Index should be set to
+    /// InvalidSourceIndex.
+    union {
+      unsigned Index;
+      CanType FixedType;
+    };
 
   public:
     CanType Type;
@@ -220,7 +234,7 @@ namespace irgen {
     MetadataSource(Kind kind, CanType type)
       : TheKind(kind), Index(InvalidSourceIndex), Type(type)
     {
-      assert(!requiresSourceIndex(kind));
+      assert(!requiresSourceIndex(kind) && !requiresFixedType(kind));
     }
 
 
@@ -230,11 +244,21 @@ namespace irgen {
       assert(index != InvalidSourceIndex);
     }
 
+    MetadataSource(Kind kind, CanType type, CanType fixedType)
+      : TheKind(kind), FixedType(fixedType), Type(type) {
+      assert(requiresFixedType(kind));
+    }
+
     Kind getKind() const { return TheKind; }
 
     unsigned getParamIndex() const {
       assert(requiresSourceIndex(getKind()));
       return Index;
+    }
+
+    CanType getFixedType() const {
+      assert(requiresFixedType(getKind()));
+      return FixedType;
     }
   };
 

--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -217,12 +217,21 @@ namespace irgen {
   public:
     CanType Type;
 
-    MetadataSource(Kind kind, unsigned index, CanType type)
+    MetadataSource(Kind kind, CanType type)
+      : TheKind(kind), Index(InvalidSourceIndex), Type(type)
+    {
+      assert(!requiresSourceIndex(kind));
+    }
+
+
+    MetadataSource(Kind kind, CanType type, unsigned index)
       : TheKind(kind), Index(index), Type(type) {
-      assert(index != InvalidSourceIndex || !requiresSourceIndex(kind));
+      assert(requiresSourceIndex(kind));
+      assert(index != InvalidSourceIndex);
     }
 
     Kind getKind() const { return TheKind; }
+
     unsigned getParamIndex() const {
       assert(requiresSourceIndex(getKind()));
       return Index;

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -1118,6 +1118,10 @@ public:
       case irgen::MetadataSource::Kind::Metadata:
         Root = SourceBuilder.createMetadataCapture(Source.getParamIndex());
         break;
+
+      case irgen::MetadataSource::Kind::ErasedTypeMetadata:
+        // Fixed in the function body
+        break;
       }
 
       // The metadata might be reached via a non-trivial path (eg,

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -3411,7 +3411,7 @@ llvm::Value *irgen::emitClassHeapMetadataRef(IRGenFunction &IGF, CanType type,
                                              bool allowUninitialized) {
   assert(request.canResponseStatusBeIgnored() &&
          "emitClassHeapMetadataRef only supports satisfied requests");
-  assert(type->mayHaveSuperclass());
+  assert(type->mayHaveSuperclass() || type->isTypeErasedGenericClassType());
 
   // Archetypes may or may not be ObjC classes and need unwrapping to get at
   // the class object.
@@ -3426,7 +3426,7 @@ llvm::Value *irgen::emitClassHeapMetadataRef(IRGenFunction &IGF, CanType type,
     return classPtr;
   }
   
-  if (ClassDecl *theClass = type->getClassOrBoundGenericClass()) {
+  if (ClassDecl *theClass = dyn_cast_or_null<ClassDecl>(type->getAnyNominal())) {
     if (!hasKnownSwiftMetadata(IGF.IGM, theClass)) {
       llvm::Value *result =
         emitObjCHeapMetadataRef(IGF, theClass, allowUninitialized);

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1766,7 +1766,7 @@ static bool isPseudogeneric(SILDeclRef c) {
   if (!dc) return false;
 
   auto classDecl = dc->getSelfClassDecl();
-  return (classDecl && classDecl->usesObjCGenericsModel());
+  return (classDecl && classDecl->isTypeErasedGenericClass());
 }
 
 /// Update the result type given the foreign error convention that we will be

--- a/lib/SIL/Utils/DynamicCasts.cpp
+++ b/lib/SIL/Utils/DynamicCasts.cpp
@@ -603,12 +603,12 @@ swift::classifyDynamicCast(ModuleDecl *M,
     if (targetClass) {
       // Imported Objective-C generics don't check the generic parameters, which
       // are lost at runtime.
-      if (sourceClass->usesObjCGenericsModel()) {
+      if (sourceClass->isTypeErasedGenericClass()) {
       
         if (sourceClass == targetClass)
           return DynamicCastFeasibility::WillSucceed;
         
-        if (targetClass->usesObjCGenericsModel()) {
+        if (targetClass->isTypeErasedGenericClass()) {
           // If both classes are ObjC generics, the cast may succeed if the
           // classes are related, irrespective of their generic parameters.
 

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -4030,7 +4030,7 @@ public:
       require(instClass,
               "upcast must convert a class metatype to a class metatype");
       
-      if (instClass->usesObjCGenericsModel()) {
+      if (instClass->isTypeErasedGenericClass()) {
         require(instClass->getDeclaredTypeInContext()
                   ->isBindableToSuperclassOf(opInstTy),
                 "upcast must cast to a superclass or an existential metatype");
@@ -4063,7 +4063,7 @@ public:
     auto ToClass = ToTy.getClassOrBoundGenericClass();
     require(ToClass,
             "upcast must convert a class instance to a class type");
-      if (ToClass->usesObjCGenericsModel()) {
+      if (ToClass->isTypeErasedGenericClass()) {
         require(ToClass->getDeclaredTypeInContext()
                   ->isBindableToSuperclassOf(FromTy.getASTType()),
                 "upcast must cast to a superclass or an existential metatype");

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -108,7 +108,7 @@ public:
         // don't need to visit them.
         if (ObjC) {
           if (auto clas = dyn_cast_or_null<ClassDecl>(ty->getAnyNominal())) {
-            if (clas->usesObjCGenericsModel()) {
+            if (clas->isTypeErasedGenericClass()) {
               return Action::SkipChildren;
             }
           }
@@ -530,7 +530,7 @@ public:
         return false;
 
       if (auto clas = dyn_cast_or_null<ClassDecl>(toTy->getAnyNominal())) {
-        if (clas->usesObjCGenericsModel()) {
+        if (clas->isTypeErasedGenericClass()) {
           return false;
         }
       }
@@ -658,7 +658,7 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
   // their context.
   if (AFD && finder.hasGenericParamCaptures()) {
     if (auto Clas = AFD->getParent()->getSelfClassDecl()) {
-      if (Clas->usesObjCGenericsModel()) {
+      if (Clas->isTypeErasedGenericClass()) {
         AFD->diagnose(diag::objc_generic_extension_using_type_parameter);
 
         // If it's possible, suggest adding @objc.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1857,7 +1857,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   // classes. This may be necessary to force-fit ObjC APIs that depend on
   // covariance, or for APIs where the generic parameter annotations in the
   // ObjC headers are inaccurate.
-  if (clas && clas->usesObjCGenericsModel()) {
+  if (clas && clas->isTypeErasedGenericClass()) {
     if (fromType->getClassOrBoundGenericClass() == clas)
       return CheckedCastKind::ValueCast;
   }

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -553,7 +553,7 @@ static bool checkObjCInExtensionContext(const ValueDecl *value,
                 ->getModuleContext()
                 ->isImplicitDynamicEnabled())
           return false;
-        if (!classDecl->usesObjCGenericsModel()) {
+        if (!classDecl->isTypeErasedGenericClass()) {
           softenIfAccessNote(value, reason.getAttr(),
             value->diagnose(diag::objc_in_generic_extension,
                             classDecl->isGeneric())

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1993,7 +1993,7 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
     if (auto ext = dyn_cast<ExtensionDecl>(DC)) {
       if (auto classDecl = ext->getSelfClassDecl()) {
         if (classDecl->isGenericContext()) {
-          if (!classDecl->usesObjCGenericsModel()) {
+          if (!classDecl->isTypeErasedGenericClass()) {
             C.Diags.diagnose(ComplainLoc,
                              diag::objc_protocol_in_generic_extension,
                              classDecl->isGeneric(), T, ProtoType);
@@ -2014,7 +2014,7 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
     // types for any obj-c ones.
     while (nestedType) {
       if (auto clas = nestedType->getClassOrBoundGenericClass()) {
-        if (clas->usesObjCGenericsModel()) {
+        if (clas->isTypeErasedGenericClass()) {
           C.Diags.diagnose(ComplainLoc,
                            diag::objc_generics_cannot_conditionally_conform, T,
                            ProtoType);
@@ -3014,7 +3014,7 @@ bool ConformanceChecker::checkObjCTypeErasedGenerics(
   auto classDecl = Adoptee->getClassOrBoundGenericClass();
   if (!classDecl) return false;
 
-  if (!classDecl->usesObjCGenericsModel()) return false;
+  if (!classDecl->isTypeErasedGenericClass()) return false;
 
   // Concrete types are okay.
   if (!type->getCanonicalType()->hasTypeParameter()) return false;

--- a/test/IRGen/Inputs/usr/include/Gizmo.h
+++ b/test/IRGen/Inputs/usr/include/Gizmo.h
@@ -166,3 +166,6 @@ __attribute__((swift_name("OuterType.InnerType")))
 
 @interface ObjcGenericClass<__covariant SectionType>
 @end
+
+@interface FungingArray <Element: id<NSFunging>> : NSObject
+@end

--- a/test/IRGen/objc_extensions_jit.swift
+++ b/test/IRGen/objc_extensions_jit.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop %s -emit-ir -disable-objc-attr-requires-foundation-module -use-jit | %FileCheck %s
+
+import Foundation
+import objc_generics
+
+extension NSString {
+  func fn() {}
+}
+
+extension GenericClass {
+  @objc func fn() {}
+}
+
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} private void @runtime_registration
+// CHECK-NOT: @__swift_instantiateConcreteTypeFromMangledName
+// CHECK: ret void

--- a/test/Interpreter/objc_extensions.swift
+++ b/test/Interpreter/objc_extensions.swift
@@ -62,3 +62,27 @@ let z: AnyObject = NSObject()
 
 // CHECK: 123
 print(z.sillyMethod())
+
+// Category on an ObjC generic class using a type-pinning parameter, including
+// a cast to an existential metatype
+@objc protocol CacheNameDefaulting {
+  static var defaultCacheName: String { get }
+}
+extension OuterClass.InnerClass: CacheNameDefaulting {
+  static var defaultCacheName: String { "InnerClasses" }
+}
+
+extension NSCache {
+  @objc convenience init(ofObjects objectTy: ObjectType.Type, forKeys keyTy: KeyType.Type) {
+    self.init()
+
+    if let defaultNameTy = objectTy as? CacheNameDefaulting.Type {
+      self.name = defaultNameTy.defaultCacheName
+    }
+  }
+}
+
+let cache = NSCache(ofObjects: OuterClass.InnerClass.self, forKeys: NSString.self)
+
+// CHECK: InnerClasses
+print(cache.name)


### PR DESCRIPTION
Sema allows you to pass type-pinning parameters into an extension of an Objective-C generic class, but IRGen did not properly handle erasing these types to existential types in runtime metadata. This commit corrects that mistake.

Fixes rdar://80708693.