### PR TITLE
[exclusivity] Add support for Task local exclusivity access sets.

### DIFF
--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -279,6 +279,10 @@ public:
   void flagAsSuspended();
   void flagAsSuspended_slow();
 
+  /// Flag that this task is now completed. This normally does not do anything
+  /// but can be used to locally insert logging.
+  void flagAsCompleted();
+
   /// Check whether this task has been cancelled.
   /// Checking this is, of course, inherently race-prone on its own.
   bool isCancelled() const;

--- a/include/swift/Runtime/Exclusivity.h
+++ b/include/swift/Runtime/Exclusivity.h
@@ -91,6 +91,30 @@ void swift_dumpTrackedAccesses();
 
 #endif
 
+/// Called when a task inits, resumes and returns control to caller synchronous
+/// code to update any exclusivity specific state associated with the task.
+///
+/// State is assumed to point to a buffer of memory with
+/// swift_task_threadLocalContextSize bytes that was initialized with
+/// swift_task_initThreadLocalContext.
+///
+/// We describe the algorithm in detail on SwiftTaskThreadLocalContext in
+/// Exclusivity.cpp.
+SWIFT_RUNTIME_EXPORT
+void swift_task_enterThreadLocalContext(char *state);
+
+/// Called when a task suspends and returns control to caller synchronous code
+/// to update any exclusivity specific state associated with the task.
+///
+/// State is assumed to point to a buffer of memory with
+/// swift_task_threadLocalContextSize bytes that was initialized with
+/// swift_task_initThreadLocalContext.
+///
+/// We describe the algorithm in detail on SwiftTaskThreadLocalContext in
+/// Exclusivity.cpp.
+SWIFT_RUNTIME_EXPORT
+void swift_task_exitThreadLocalContext(char *state);
+
 } // end namespace swift
 
 #endif

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -13,11 +13,23 @@
 import Swift
 @_implementationOnly import _SwiftConcurrencyShims
 
+@available(SwiftStdlib 5.5, *)
+@_silgen_name("swift_job_run")
+@usableFromInline
+internal func _swiftJobRun(_ job: UnownedJob,
+                           _ executor: UnownedSerialExecutor) -> ()
+
 /// A job is a unit of scheduleable work.
 @available(SwiftStdlib 5.5, *)
 @frozen
 public struct UnownedJob {
   private var context: Builtin.Job
+
+  @_alwaysEmitIntoClient
+  @inlinable
+  public func _runSynchronously(on executor: UnownedSerialExecutor) {
+      _swiftJobRun(self, executor)
+  }
 }
 
 @available(SwiftStdlib 5.5, *)

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -225,6 +225,8 @@ static void destroyJob(SWIFT_CONTEXT HeapObject *obj) {
 }
 
 AsyncTask::~AsyncTask() {
+  flagAsCompleted();
+
   // For a future, destroy the result.
   if (isFuture()) {
     futureFragment()->destroy();

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -17,13 +17,14 @@
 #ifndef SWIFT_CONCURRENCY_TASKPRIVATE_H
 #define SWIFT_CONCURRENCY_TASKPRIVATE_H
 
-#include "swift/Runtime/Concurrency.h"
-#include "swift/ABI/Task.h"
-#include "swift/ABI/Metadata.h"
-#include "swift/Runtime/Atomic.h"
-#include "swift/Runtime/HeapObject.h"
-#include "swift/Runtime/Error.h"
 #include "Error.h"
+#include "swift/ABI/Metadata.h"
+#include "swift/ABI/Task.h"
+#include "swift/Runtime/Atomic.h"
+#include "swift/Runtime/Concurrency.h"
+#include "swift/Runtime/Error.h"
+#include "swift/Runtime/Exclusivity.h"
+#include "swift/Runtime/HeapObject.h"
 
 #define SWIFT_FATAL_ERROR swift_Concurrency_fatalError
 #include "../runtime/StackAllocator.h"
@@ -282,14 +283,19 @@ struct AsyncTask::PrivateStorage {
   /// Currently one word.
   TaskLocal::Storage Local;
 
+  /// State inside the AsyncTask whose state is only managed by the exclusivity
+  /// runtime in stdlibCore. We zero initialize to provide a safe initial value,
+  /// but actually initialize its bit state to a const global provided by
+  /// libswiftCore so that libswiftCore can control the layout of our initial
+  /// state.
+  uintptr_t ExclusivityAccessSet[2] = {0, 0};
+
   PrivateStorage(JobFlags flags)
-    : Status(ActiveTaskStatus(flags)),
-      Local(TaskLocal::Storage()) {}
+      : Status(ActiveTaskStatus(flags)), Local(TaskLocal::Storage()) {}
 
   PrivateStorage(JobFlags flags, void *slab, size_t slabCapacity)
-    : Status(ActiveTaskStatus(flags)),
-      Allocator(slab, slabCapacity),
-      Local(TaskLocal::Storage()) {}
+      : Status(ActiveTaskStatus(flags)), Allocator(slab, slabCapacity),
+        Local(TaskLocal::Storage()) {}
 
   void complete(AsyncTask *task) {
     // Destroy and deallocate any remaining task local items.
@@ -347,7 +353,10 @@ inline void AsyncTask::flagAsRunning() {
   while (true) {
     assert(!oldStatus.isRunning());
     if (oldStatus.isLocked()) {
-      return flagAsRunning_slow();
+      flagAsRunning_slow();
+      swift_task_enterThreadLocalContext(
+          (char *)&_private().ExclusivityAccessSet[0]);
+      return;
     }
 
     auto newStatus = oldStatus.withRunning(true);
@@ -358,8 +367,11 @@ inline void AsyncTask::flagAsRunning() {
 
     if (_private().Status.compare_exchange_weak(oldStatus, newStatus,
                                                 std::memory_order_relaxed,
-                                                std::memory_order_relaxed))
+                                                std::memory_order_relaxed)) {
+      swift_task_enterThreadLocalContext(
+          (char *)&_private().ExclusivityAccessSet[0]);
       return;
+    }
   }
 }
 
@@ -368,7 +380,10 @@ inline void AsyncTask::flagAsSuspended() {
   while (true) {
     assert(oldStatus.isRunning());
     if (oldStatus.isLocked()) {
-      return flagAsSuspended_slow();
+      flagAsSuspended_slow();
+      swift_task_exitThreadLocalContext(
+          (char *)&_private().ExclusivityAccessSet[0]);
+      return;
     }
 
     auto newStatus = oldStatus.withRunning(false);
@@ -379,8 +394,11 @@ inline void AsyncTask::flagAsSuspended() {
 
     if (_private().Status.compare_exchange_weak(oldStatus, newStatus,
                                                 std::memory_order_relaxed,
-                                                std::memory_order_relaxed))
+                                                std::memory_order_relaxed)) {
+      swift_task_exitThreadLocalContext(
+          (char *)&_private().ExclusivityAccessSet[0]);
       return;
+    }
   }
 }
 

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -384,6 +384,16 @@ inline void AsyncTask::flagAsSuspended() {
   }
 }
 
+// READ ME: This is not a dead function! Do not remove it! This is a function
+// that can be used when debugging locally to instrument when a task actually is
+// dealloced.
+inline void AsyncTask::flagAsCompleted() {
+#if SWIFT_TASK_PRINTF_DEBUG
+  fprintf(stderr, "[%lu] task completed %p\n",
+          _swift_get_thread_id(), this);
+#endif
+}
+
 inline void AsyncTask::localValuePush(const HeapObject *key,
                                       /* +1 */ OpaqueValue *value,
                                       const Metadata *valueType) {

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -62,4 +62,11 @@ VARIABLE(SWIFT_DEBUG_ENABLE_SHARED_CACHE_PROTOCOL_CONFORMANCES, bool, true,
 
 #endif
 
+#ifndef NDEBUG
+
+VARIABLE(SWIFT_DEBUG_RUNTIME_EXCLUSIVITY_LOGGING, bool, false,
+         "Enable the an asserts runtime to emit logging as it works.")
+
+#endif
+
 #undef VARIABLE

--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -171,6 +171,12 @@ class AccessSet {
   Access *Head = nullptr;
 public:
   constexpr AccessSet() {}
+  constexpr AccessSet(Access *Head) : Head(Head) {}
+
+  constexpr operator bool() const { return bool(Head); }
+  constexpr Access *getHead() const { return Head; }
+  void setHead(Access *newHead) { Head = newHead; }
+  constexpr bool isHead(Access *access) const { return Head == access; }
 
   bool insert(Access *access, void *pc, void *pointer, ExclusivityFlags flags) {
     auto action = getAccessAction(flags);
@@ -221,6 +227,32 @@ public:
     }
 
     swift_unreachable("access not found in set");
+  }
+
+  /// Return the parent access of \p childAccess in the list.
+  Access *findParentAccess(Access *childAccess) {
+    auto cur = Head;
+    Access *last = cur;
+    for (cur = cur->getNext(); cur != nullptr;
+         last = cur, cur = cur->getNext()) {
+      assert(last->getNext() == cur);
+      if (cur == childAccess) {
+        return last;
+      }
+    }
+    return nullptr;
+  }
+
+  Access *getTail() const {
+    auto cur = Head;
+    if (!cur)
+      return nullptr;
+
+    while (auto *next = cur->getNext()) {
+      cur = next;
+    }
+    assert(cur != nullptr);
+    return cur;
   }
 
 #ifndef NDEBUG
@@ -394,3 +426,348 @@ void swift::swift_dumpTrackedAccesses() {
 }
 
 #endif
+
+//===----------------------------------------------------------------------===//
+//                            Concurrency Support
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// High Level Algorithm Description
+/// --------------------------------
+///
+/// With the introduction of Concurrency, we add additional requirements to our
+/// exclusivity model:
+///
+/// * We want tasks to have a consistent exclusivity access set across
+///   suspensions/resumptions. This ensures that any exclusive accesses began
+///   before a Task suspended are properly flagged after the Task is resumed
+///   even if the Task is resumed on a different thread.
+///
+/// * If a synchronous code calls a subroutine that creates a set of tasks to
+///   perform work and then blocks, we want the runtime to ensure that the tasks
+///   respect exclusivity accesses from the outside synchronous code.
+///
+/// * We on purpose define exclusive access to the memory from multiple tasks as
+///   undefined behavior since that would be an additional feature that needs to
+///   be specifically designed in the future.
+///
+/// * We assume that an access in synchronous code will never be ended in
+///   asynchronous code.
+///
+/// * We additional require that our design leaves the exclusivity runtime
+///   unaware of any work we are doing here. All it should be aware of is the
+///   current thread local access set and adding/removing from that access set.
+///
+/// We implement these requirements by reserving two pointers in each Task. The
+/// first pointer points at the head access of the linked list of accesses of
+/// the Task and the second pointer points at the end of the linked list of
+/// accesses of the task. We will for the discussion ahead call the first
+/// pointer TaskFirstAccess and the second TaskLastAccess. This allows us to
+/// modify the current TLV single linked list to include/remove the tasks’s
+/// access by updating a few nodes in the linked list when the task is running
+/// and serialize the task’s current access set and restoring to be head the
+/// original synchronous access set head when the task is running. This
+/// naturally fits a push/pop access set sort of schema where every time a task
+/// starts, we push its access set onto the local TLV and then pop it off when
+/// the task is suspended. This ensures that the task gets the current
+/// synchronous set of accesses and other Tasks do not see the accesses of the
+/// specific task providing task isolation.
+///
+/// The cases can be described via the following table:
+///
+/// +------+--------------------+--------------------+--------------------+
+/// | Case | Live Task Accesses | Live Sync Accesses | Live Task Accesses |
+/// |      | When Push          | When Push          | When Pop           |
+/// |------+--------------------+--------------------+--------------------|
+/// |    1 | F                  | F                  | F                  |
+/// |    2 | F                  | F                  | T                  |
+/// |    3 | F                  | T                  | F                  |
+/// |    4 | F                  | T                  | T                  |
+/// |    5 | T                  | F                  | F                  |
+/// |    6 | T                  | F                  | T                  |
+/// |    7 | T                  | T                  | F                  |
+/// |    8 | T                  | T                  | T                  |
+/// +------+--------------------+--------------------+--------------------+
+///
+/// We mark the end of each title below introducing a case with 3 T/F to enable
+/// easy visual matching with the chart
+///
+/// Case 1: Task/Sync do not have initial accesses and no Task accesses are
+/// created while running (F,F,F)
+///
+/// In this case, TBegin and TEnd are both initially nullptr.
+///
+/// When we push, we see that the current exclusivity TLV has a null head and
+/// leave it so. We set TBegin and TEnd as nullptr while running.
+///
+/// When we pop, see that the exclusivity TLV is still nullptr, so we just leave
+/// TBegin and TEnd alone still as nullptr.
+///
+/// This means that code that does not have any exclusive accesses do not have
+/// any runtime impact.
+///
+/// Case 2: Task/Sync do not have initial access, but Task accesses are created
+/// while running (F, F, T)
+///
+/// In this case, TBegin and TEnd are both initially nullptr.
+///
+/// When we push, we see that the current exclusivity TLV has a null head. So,
+/// we leave TBegin and TEnd as nullptr while the task is running.
+///
+/// When we pop, we see that the exclusivity TLV has a non-null head. In that
+/// case, we walk the list to find the last node and update TBegin to point at
+/// the current head, TEnd to point at that last node, and then set the TLV head
+/// to be nullptr.
+///
+/// Case 3: Task does not have initial accesses, but Sync does, and new Task
+/// accesses are not created while running (F, T, F)
+///
+/// In this case, TBegin and TEnd are both initially nullptr.
+///
+/// When we push, we look at the TLV and see our initial synchronous thread was
+/// tracking accesses. In this case, we leave the TLV pointing at the
+/// SyncAccessHead and set TBegin to SyncAccessHead and leave TEnd as nullptr.
+///
+/// When we pop, we see that TBegin (which we know has the old synchronous head
+/// in it) is equal to the TLV so we know that we did not create any new Task
+/// accesses. Then we set TBegin to nullptr and return. NOTE:  TEnd is nullptr
+/// the entire time in this scenario.
+///
+/// Case 4: Task does not have initial accesses, but Sync does, and new Task
+/// accesses are created while running (F, T, T)
+///
+/// In this case, TBegin and TEnd are both initially nullptr. When we push, we
+/// look at the TLV and we see our initial synchronous thread was tracking
+/// accesses. In this case, we leave the TLV pointing at the SyncAccessHead and
+/// set TBegin to SyncAccessHead and leave TEnd as nullptr.
+///
+/// When we pop, we see that the TLV and TBegin differ now. We know that this
+/// means that our task introduced new accesses. So, we search down from the
+/// head of the AccessSet TLV until we find TBegin . The node before TBegin is
+/// our new TEnd pointer. We set TBegin to then have the value of head, TEnd to
+/// be the new TEnd pointer, set TEnd’s next to be nullptr and make head the old
+/// value of TBegin.
+///
+/// Case 5: Task has an initial access set, but Sync does not have initial
+/// accesses and no Task accesses exist after running (T,F,F)
+///
+/// In this case, TBegin and TEnd are both initially set to non-null values.
+/// When we push, we look at the current TLV head and see that the TLV head is
+/// nullptr. We then set TLV head to be TBegin and set TBegin to be nullptr to
+/// signal the original synchronous TLV head was nullptr.
+///
+/// When we pop, we see that TBegin is currently nullptr, so we know the
+/// synchronous access set was empty. We also know that despite us starting with
+/// a task access set, those accesses must have completed while the task was
+/// running since the access set is empty when we pop.
+///
+/// Case 6: Task has initial accesses, sync does not have initial accesss, and
+/// Task access set is modified while running (T, F, T)
+///
+/// In this case, TBegin and TEnd are both initially set to non-null
+/// values. When we push, we look at the current TLV head and see that the TLV
+/// head is nullptr. We then set TLV head to be TBegin and set TBegin to be
+/// nullptr to signal the original synchronous TLV head was nullptr. We have no
+/// requirement on TEnd now in this case but set it to nullptr, to track flags
+/// if we want to in the future in a different runtime.
+///
+/// When we pop, we see that TBegin is currently nullptr, so we know the
+/// synchronous access set was empty. We do not have a way to know how/if we
+/// modified the Task AccessSet, so we walked the list to find the last node. We
+/// then make TBegin head, TEnd the last node, and set the TLV to be nullptr
+/// again.
+///
+/// Case 7: Task has initial accesses, Sync has initial accesses, and new Task
+/// accesses are not created while running (T, T, F)
+///
+/// In this case, TBegin and TEnd are both initially set to non-null values.
+/// When we push, we look at the current TLV head and see that the TLV head is a
+/// valid pointer. We then set TLV head to be the current value of TBegin, make
+/// TEnd->next the old head value and stash the old head value into TBegin. We
+/// have no requirement on TEnd now in this case.
+///
+/// When we pop, we see that TBegin is not nullptr, so we know the synchronous
+/// access set had live accesses. We do not have a way to know how/if we
+/// modified the Task AccessSet, so we walked the list to find TBegin (which is
+/// old sync head).  Noting that the predecessor node of old sync head’s node
+/// will be the end of the task’s current access set, we set TLV to point at the
+/// node we found in TBegin, set TBegin to the current TLV head, set TEnd to
+/// that predecessor node of the current TLV head and set TEnd->next to be
+/// nullptr.
+///
+/// Case 8: Task has initial accesses, Sync does, and Task accesses is modified
+/// while running (T, T, T)
+///
+/// In this case, TBegin and TEnd are both initially set to non-null values.
+///
+/// When we push, we look at the current TLV head and see that the TLV head is
+/// a valid pointer. We then set TLV head to be the current value of TBegin,
+/// make TEnd->next the old head value and stash the old head value into
+/// TBegin. We have no requirement on TEnd now in this case.
+///
+/// When we pop, we see that TBegin is not nullptr, so we know the synchronous
+/// access set had live accesses. We do not have a way to know how/if we
+/// modified the Task AccessSet, so we walked the list to find TBegin (which is
+/// old sync head).  Noting that the predecessor node of old sync head’s node
+/// will be the end of the task’s current access set, we set TLV to point at
+/// the node we found in TBegin, set TBegin to the current TLV head, set TEnd
+/// to that predecessor node of the current TLV head and set TEnd->next to be
+/// nullptr.
+struct SwiftTaskThreadLocalContext {
+  uintptr_t state[2];
+
+  bool hasInitialAccessSet() const {
+    // If state[0] is nullptr, we have an initial access set.
+    return bool(state[0]);
+  }
+
+  Access *getTaskAccessSetHead() const {
+    return reinterpret_cast<Access *>(state[0]);
+  }
+
+  Access *getTaskAccessSetTail() const {
+    return reinterpret_cast<Access *>(state[1]);
+  }
+
+  void setTaskAccessSetHead(Access *newHead) { state[0] = uintptr_t(newHead); }
+
+  void setTaskAccessSetTail(Access *newTail) { state[1] = uintptr_t(newTail); }
+};
+
+} // end anonymous namespace
+
+// See algorithm description on SwiftTaskThreadLocalContext.
+void swift::swift_task_enterThreadLocalContext(char *state) {
+  auto &taskCtx = *reinterpret_cast<SwiftTaskThreadLocalContext *>(state);
+  auto &tlsCtxAccessSet = getTLSContext().accessSet;
+
+  // First handle all of the cases where our task does not start without an
+  // initial access set.
+  //
+  // Handles push cases 1-4.
+  if (!taskCtx.hasInitialAccessSet()) {
+    // In this case, the current synchronous context is not tracking any
+    // accesses. So the tlsCtx and our initial access set are all nullptr, so we
+    // can just return early.
+    //
+    // Handles push cases 1-2.
+    if (!tlsCtxAccessSet) {
+      return;
+    }
+
+    // Ok, our task isn't tracking any task specific accesses, but our tlsCtx
+    // was tracking accesses. Leave the tlsCtx alone at this point and set our
+    // state's begin access to be tlsCtx head. We leave our access set tail as
+    // nullptr.
+    //
+    // Handles push cases 3-4.
+    taskCtx.setTaskAccessSetHead(tlsCtxAccessSet.getHead());
+    return;
+  }
+
+  // At this point, we know that we did have an initial access set. Both access
+  // set pointers are valid.
+  //
+  // Handles push cases 5-8.
+
+  // Now check if our synchronous code had any accesses. If not, we set TBegin,
+  // TEnd to be nullptr and set the tlsCtx to point to TBegin.
+  //
+  // Handles push cases 5-6.
+  if (!bool(tlsCtxAccessSet)) {
+    tlsCtxAccessSet = taskCtx.getTaskAccessSetHead();
+    taskCtx.setTaskAccessSetHead(nullptr);
+    taskCtx.setTaskAccessSetTail(nullptr);
+    return;
+  }
+
+  // In this final case, we found that our task had its own access set and our
+  // tlsCtx did as well. So we then set the Task's head to be the new TLV head,
+  // set tail->next to point at old head and stash oldhead into the task ctx.
+  //
+  // Handles push cases 7-8.
+  auto *oldHead = tlsCtxAccessSet.getHead();
+  auto *tail = taskCtx.getTaskAccessSetTail();
+
+  tlsCtxAccessSet.setHead(taskCtx.getTaskAccessSetHead());
+  tail->setNext(oldHead);
+  taskCtx.setTaskAccessSetHead(oldHead);
+  taskCtx.setTaskAccessSetTail(nullptr);
+}
+
+// See algorithm description on SwiftTaskThreadLocalContext.
+void swift::swift_task_exitThreadLocalContext(char *state) {
+  auto &taskCtx = *reinterpret_cast<SwiftTaskThreadLocalContext *>(state);
+  auto &tlsCtxAccessSet = getTLSContext().accessSet;
+
+  // First check our ctx to see if we were tracking a previous synchronous
+  // head. If we don't then we know that our synchronous thread was not
+  // initially tracking any accesses.
+  //
+  // Handles pop cases 1,2,5,6
+  Access *oldHead = taskCtx.getTaskAccessSetHead();
+  if (!oldHead) {
+    // Then check if we are currently tracking an access set in the TLS. If we
+    // aren't, then we know that either we did not start with a task specific
+    // access set /or/ we did start but all of those accesses ended while the
+    // task was running. In either case, when we pushed initially, we set
+    // TBegin, TEnd to be nullptr already and since oldHead is already nullptr,
+    // we can just exit.
+    //
+    // Handles pop cases 1,5
+    if (!tlsCtxAccessSet) {
+      assert(taskCtx.getTaskAccessSetTail() == nullptr &&
+             "Make sure we set this to nullptr when we pushed");
+      return;
+    }
+
+    // In this case, we did find that we had live accesses. Since we know we
+    // did not start with any synchronous accesses, these accesses must all be
+    // from the given task. So, we first find the tail of the current TLS linked
+    // list, then set the Task access set head to accessSet, the Task accessSet
+    // tail to the TLS linked list tail and set tlsCtx.accessSet to nullptr.
+    //
+    // Handles pop cases 2,6
+    auto *newHead = tlsCtxAccessSet.getHead();
+    auto *newTail = tlsCtxAccessSet.getTail();
+    assert(newTail && "Failed to find tail?!");
+    tlsCtxAccessSet = nullptr;
+    taskCtx.setTaskAccessSetHead(newHead);
+    taskCtx.setTaskAccessSetTail(newTail);
+    return;
+  }
+
+  // Otherwise, we know that we /were/ tracking accesses from a previous
+  // synchronous context. So we need to unmerge our task specific state from the
+  // exclusivity access set.
+  //
+  // Handles pop cases 3,4,7,8.
+
+  // First check if the current head tlsAccess is the same as our oldHead. In
+  // such a case, we do not have new task accesses to update. So just set task
+  // access head/tail to nullptr. The end access should be nullptr.
+  //
+  // Handles pop cases 3.
+  if (tlsCtxAccessSet.getHead() == oldHead) {
+    taskCtx.setTaskAccessSetHead(nullptr);
+    taskCtx.setTaskAccessSetTail(nullptr);
+    return;
+  }
+
+  // Otherwise, we have task specific accesses that we need to serialize into
+  // the task's state. We currently can not tell if the Task actually modified
+  // the task list beyond if the task list is empty. So we have to handle case 7
+  // here (unfortunately).
+  //
+  // NOTE: If we could tell if the Task modified its access set while running,
+  // we could perhaps avoid the search for newEnd.
+  //
+  // Handles pop cases 4,7,8.
+  auto *newHead = tlsCtxAccessSet.getHead();
+  auto *newEnd = tlsCtxAccessSet.findParentAccess(oldHead);
+  tlsCtxAccessSet.setHead(oldHead);
+  newEnd->setNext(nullptr);
+  taskCtx.setTaskAccessSetHead(newHead);
+  taskCtx.setTaskAccessSetTail(newEnd);
+}

--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -27,10 +27,11 @@
 #include "swift/Basic/Lazy.h"
 #include "swift/Runtime/Config.h"
 #include "swift/Runtime/Debug.h"
+#include "swift/Runtime/EnvironmentVariables.h"
 #include "swift/Runtime/Metadata.h"
 #include "swift/Runtime/ThreadLocalStorage.h"
-#include <memory>
 #include <inttypes.h>
+#include <memory>
 #include <stdio.h>
 
 // Pick a return-address strategy
@@ -55,6 +56,16 @@ static const char *getAccessName(ExclusivityFlags flags) {
   default: return "unknown";
   }
 }
+
+// In asserts builds if the environment variable
+// SWIFT_DEBUG_RUNTIME_EXCLUSIVITY_LOGGING is set, emit logging information.
+#ifndef NDEBUG
+
+static inline bool isExclusivityLoggingEnabled() {
+  return runtime::environment::SWIFT_DEBUG_RUNTIME_EXCLUSIVITY_LOGGING();
+}
+
+#endif
 
 SWIFT_ALWAYS_INLINE
 static void reportExclusivityConflict(ExclusivityFlags oldAction, void *oldPC,
@@ -179,6 +190,10 @@ public:
   constexpr bool isHead(Access *access) const { return Head == access; }
 
   bool insert(Access *access, void *pc, void *pointer, ExclusivityFlags flags) {
+#ifndef NDEBUG
+    if (isExclusivityLoggingEnabled())
+      fprintf(stderr, "Inserting new access: %p\n", access);
+#endif
     auto action = getAccessAction(flags);
 
     for (Access *cur = Head; cur != nullptr; cur = cur->getNext()) {
@@ -198,17 +213,33 @@ public:
       // 0 means no backtrace will be printed.
       fatalError(0, "Fatal access conflict detected.\n");
     }
-    if (!isTracking(flags))
+    if (!isTracking(flags)) {
+#ifndef NDEBUG
+      if (isExclusivityLoggingEnabled()) {
+        fprintf(stderr, "  Not tracking!\n");
+      }
+#endif
       return false;
+    }
 
     // Insert to the front of the array so that remove tends to find it faster.
     access->initialize(pc, pointer, Head, action);
     Head = access;
+#ifndef NDEBUG
+    if (isExclusivityLoggingEnabled()) {
+      fprintf(stderr, "  Tracking!\n");
+      swift_dumpTrackedAccesses();
+    }
+#endif
     return true;
   }
 
   void remove(Access *access) {
     assert(Head && "removal from empty AccessSet");
+#ifndef NDEBUG
+    if (isExclusivityLoggingEnabled())
+      fprintf(stderr, "Removing access: %p\n", access);
+#endif
     auto cur = Head;
     // Fast path: stack discipline.
     if (cur == access) {
@@ -419,9 +450,14 @@ char *swift::swift_getOrigOfReplaceable(char **OrigFnPtr) {
 //
 // This is only intended to be used in the debugger.
 void swift::swift_dumpTrackedAccesses() {
-  getTLSContext().accessSet.forEach([](Access *a) {
-      fprintf(stderr, "Access. Pointer: %p. PC: %p. AccessAction: %s\n",
-              a->Pointer, a->PC, getAccessName(a->getAccessAction()));
+  auto &accessSet = getTLSContext().accessSet;
+  if (!accessSet) {
+    fprintf(stderr, "        No Accesses.\n");
+    return;
+  }
+  accessSet.forEach([](Access *a) {
+    fprintf(stderr, "        Access. Pointer: %p. PC: %p. AccessAction: %s\n",
+            a->Pointer, a->PC, getAccessName(a->getAccessAction()));
   });
 }
 
@@ -617,6 +653,15 @@ namespace {
 struct SwiftTaskThreadLocalContext {
   uintptr_t state[2];
 
+#ifndef NDEBUG
+  void dump() {
+    fprintf(stderr,
+            "        SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): "
+            "(%p, %p)\n",
+            (void *)state[0], (void *)state[1]);
+  }
+#endif
+
   bool hasInitialAccessSet() const {
     // If state[0] is nullptr, we have an initial access set.
     return bool(state[0]);
@@ -633,6 +678,25 @@ struct SwiftTaskThreadLocalContext {
   void setTaskAccessSetHead(Access *newHead) { state[0] = uintptr_t(newHead); }
 
   void setTaskAccessSetTail(Access *newTail) { state[1] = uintptr_t(newTail); }
+
+#ifndef NDEBUG
+  const char *getTaskAddress() const {
+    // Constant only used when we have an asserts compiler so that we can output
+    // exactly the header location of the task for FileCheck purposes.
+    //
+    // WARNING: This test will fail if the Task ABI changes. When that happens,
+    // update the offset!
+    //
+    // TODO: This probably will need 32 bit help.
+#if __POINTER_WIDTH__ == 64
+    unsigned taskHeadOffsetFromTaskAccessSet = 128;
+#else
+    unsigned taskHeadOffsetFromTaskAccessSet = 68;
+#endif
+    auto *self = reinterpret_cast<const char *>(this);
+    return self - taskHeadOffsetFromTaskAccessSet;
+  }
+#endif
 };
 
 } // end anonymous namespace
@@ -641,6 +705,29 @@ struct SwiftTaskThreadLocalContext {
 void swift::swift_task_enterThreadLocalContext(char *state) {
   auto &taskCtx = *reinterpret_cast<SwiftTaskThreadLocalContext *>(state);
   auto &tlsCtxAccessSet = getTLSContext().accessSet;
+
+#ifndef NDEBUG
+  if (isExclusivityLoggingEnabled()) {
+    fprintf(stderr,
+            "Entering Thread Local Context. Before Swizzle. Task: %p\n",
+            taskCtx.getTaskAddress());
+    taskCtx.dump();
+    swift_dumpTrackedAccesses();
+  }
+
+  auto logEndState = [&] {
+    if (isExclusivityLoggingEnabled()) {
+      fprintf(stderr,
+              "Entering Thread Local Context. After Swizzle. Task: %p\n",
+              taskCtx.getTaskAddress());
+      taskCtx.dump();
+      swift_dumpTrackedAccesses();
+    }
+  };
+#else
+  // Just a no-op that should inline away.
+  auto logEndState = [] {};
+#endif
 
   // First handle all of the cases where our task does not start without an
   // initial access set.
@@ -653,6 +740,7 @@ void swift::swift_task_enterThreadLocalContext(char *state) {
     //
     // Handles push cases 1-2.
     if (!tlsCtxAccessSet) {
+      logEndState();
       return;
     }
 
@@ -663,6 +751,7 @@ void swift::swift_task_enterThreadLocalContext(char *state) {
     //
     // Handles push cases 3-4.
     taskCtx.setTaskAccessSetHead(tlsCtxAccessSet.getHead());
+    logEndState();
     return;
   }
 
@@ -679,6 +768,7 @@ void swift::swift_task_enterThreadLocalContext(char *state) {
     tlsCtxAccessSet = taskCtx.getTaskAccessSetHead();
     taskCtx.setTaskAccessSetHead(nullptr);
     taskCtx.setTaskAccessSetTail(nullptr);
+    logEndState();
     return;
   }
 
@@ -694,12 +784,39 @@ void swift::swift_task_enterThreadLocalContext(char *state) {
   tail->setNext(oldHead);
   taskCtx.setTaskAccessSetHead(oldHead);
   taskCtx.setTaskAccessSetTail(nullptr);
+  logEndState();
 }
 
 // See algorithm description on SwiftTaskThreadLocalContext.
 void swift::swift_task_exitThreadLocalContext(char *state) {
   auto &taskCtx = *reinterpret_cast<SwiftTaskThreadLocalContext *>(state);
   auto &tlsCtxAccessSet = getTLSContext().accessSet;
+
+#ifndef NDEBUG
+  if (isExclusivityLoggingEnabled()) {
+    fprintf(stderr,
+            "Exiting Thread Local Context. Before Swizzle. Task: %p\n",
+            taskCtx.getTaskAddress());
+    taskCtx.dump();
+    swift_dumpTrackedAccesses();
+  }
+
+  auto logEndState = [&] {
+    if (isExclusivityLoggingEnabled()) {
+      fprintf(stderr,
+              "Exiting Thread Local Context. After Swizzle. Task: %p\n",
+              taskCtx.getTaskAddress());
+      taskCtx.dump();
+      swift_dumpTrackedAccesses();
+    }
+  };
+#else
+  // If we are not compiling with asserts, just use a simple identity function
+  // that should be inlined away.
+  //
+  // TODO: Can we use defer in the runtime?
+  auto logEndState = [] {};
+#endif
 
   // First check our ctx to see if we were tracking a previous synchronous
   // head. If we don't then we know that our synchronous thread was not
@@ -719,6 +836,7 @@ void swift::swift_task_exitThreadLocalContext(char *state) {
     if (!tlsCtxAccessSet) {
       assert(taskCtx.getTaskAccessSetTail() == nullptr &&
              "Make sure we set this to nullptr when we pushed");
+      logEndState();
       return;
     }
 
@@ -735,6 +853,7 @@ void swift::swift_task_exitThreadLocalContext(char *state) {
     tlsCtxAccessSet = nullptr;
     taskCtx.setTaskAccessSetHead(newHead);
     taskCtx.setTaskAccessSetTail(newTail);
+    logEndState();
     return;
   }
 
@@ -752,6 +871,7 @@ void swift::swift_task_exitThreadLocalContext(char *state) {
   if (tlsCtxAccessSet.getHead() == oldHead) {
     taskCtx.setTaskAccessSetHead(nullptr);
     taskCtx.setTaskAccessSetTail(nullptr);
+    logEndState();
     return;
   }
 
@@ -770,4 +890,5 @@ void swift::swift_task_exitThreadLocalContext(char *state) {
   newEnd->setNext(nullptr);
   taskCtx.setTaskAccessSetHead(newHead);
   taskCtx.setTaskAccessSetTail(newEnd);
+  logEndState();
 }

--- a/test/Concurrency/Runtime/custom_executors.swift
+++ b/test/Concurrency/Runtime/custom_executors.swift
@@ -6,6 +6,9 @@
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: use_os_stdlib
 
+// Disabled until test hang can be looked at.
+// UNSUPPORTED: OS=windows-msvc
+
 actor Simple {
   var count = 0
   func report() {

--- a/test/Concurrency/Runtime/exclusivity.swift
+++ b/test/Concurrency/Runtime/exclusivity.swift
@@ -1,0 +1,346 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency -parse-as-library)
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// This test makes sure that:
+//
+// 1. Tasks have separate exclusivity sets.
+// 2. Exercise the pushing/popping of access sets from tasks.
+
+// NOTE: The cases that we are talking about handling below refer to the cases
+// documented in Exclusivity.cpp.
+//
+// NOTE: We test cases that involve custom executors in
+// custom_executors_exclusivity.cpp.
+
+import _Concurrency
+import StdlibUnittest
+
+var global1: Int = 5
+var global2: Int = 6
+var global3: Int = 7
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(CRT)
+import CRT
+#endif
+
+@inlinable
+public func debugLog(_ s: String) {
+    // Only enable this when debugging test failures against an asserts
+    // runtime. Otherwise, the test is noisy and has non-windows
+    // dependencies. We need stderr to ensure proper log output interleaving
+    // with the runtime's own stderr emitted output.
+#if DEBUG_LOGGING
+    fputs(s + "\n", stderr)
+    fflush(stderr)
+#endif
+}
+
+@available(SwiftStdlib 5.5, *)
+@main
+struct Runner {
+    @inline(never)
+    @MainActor
+    static func doSomething() async { }
+
+    @inline(never)
+    @Sendable
+    static func useGlobal(_ x: inout Int) { debugLog("FORCE ACCESS") }
+
+    @MainActor static func main() async {
+        var exclusivityTests = TestSuite("Async Exclusivity")
+
+        // First make sure that if we do not introduce a new task, we still get
+        // our expected conflict.
+        exclusivityTests.test("testSameTaskBlowsUpSinceSameSet") { @MainActor in
+            expectCrashLater(withMessage: "Fatal access conflict detected")
+
+            let callee2 = { @MainActor (_ x: inout Int) -> Void in
+                debugLog("==> Enter callee2")
+                debugLog("Value: x: \(x)")
+                debugLog("==> Exit callee2")
+            }
+
+            // We add an inline never here to make sure that we do not eliminate
+            // the dynamic access after inlining.
+            @MainActor
+            @inline(never)
+            func callee1(_ x: inout Int) async -> () {
+                debugLog("==> Enter callee1")
+
+                // Second access. Same Task so not ok.
+                await callee2(&global1)
+
+                debugLog("==> Exit callee1")
+
+            }
+
+            debugLog("==> Enter Main")
+            // First access begins here.
+            await callee1(&global1)
+            debugLog("==> Exit Main")
+        }
+
+        // Then do a simple test with a single access to make sure that we do
+        // not hit any sccesses b/c we introduced the Task.
+        exclusivityTests.test("testDifferentTasksHaveDifferentExclusivityAccessSets") { @MainActor in
+            let callee2 = { @MainActor (_ x: inout Int) -> Void in
+                debugLog("==> Enter callee2")
+                debugLog("==> Exit callee2")
+            }
+
+            // We add an inline never here to make sure that we do not eliminate
+            // the dynamic access after inlining.
+            @MainActor
+            @inline(never)
+            func callee1(_ x: inout Int) async -> () {
+                debugLog("==> Enter callee1")
+                // This task is what prevents this example from crashing.
+                let handle = Task { @MainActor in
+                    debugLog("==> Enter callee1 Closure")
+                    // Second access. Different Task so it is ok.
+                    await callee2(&global1)
+                    debugLog("==> Exit callee1 Closure")
+                }
+                await handle.value
+                debugLog("==> Exit callee1")
+            }
+
+            debugLog("==> Enter Main")
+            // First access begins here.
+            await callee1(&global1)
+            debugLog("==> Exit Main")
+        }
+
+        // Make sure we correctly handle cases where we have multiple accesses
+        // open at the same time.
+        exclusivityTests.test("testDifferentTasksWith2Accesses") { @MainActor in
+            let callee2 = { @MainActor (_ x: inout Int, _ y: inout Int) -> Void in
+                debugLog("==> Enter callee2")
+                debugLog("==> Exit callee2")
+            }
+
+            // We add an inline never here to make sure that we do not eliminate
+            // the dynamic access after inlining.
+            @MainActor
+            @inline(never)
+            func callee1(_ x: inout Int, _ y: inout Int) async -> () {
+                debugLog("==> Enter callee1")
+                let handle = Task { @MainActor in
+                    debugLog("==> Enter callee1 Closure")
+                    // Second access. Different Task so it is ok.
+                    await callee2(&global1, &global2)
+                    debugLog("==> Exit callee1 Closure")
+                }
+                await handle.value
+                debugLog("==> Exit callee1")
+            }
+
+            debugLog("==> Enter Main")
+            // First access begins here.
+            await callee1(&global1, &global2)
+            debugLog("==> Exit Main")
+        }
+
+        // Make sure we correctly handle cases where we have multiple accesses
+        // open at the same time.
+        exclusivityTests.test("testDifferentTasksWith3Accesses") { @MainActor in
+            let callee2 = { @MainActor (_ x: inout Int, _ y: inout Int, _ z: inout Int) -> Void in
+                debugLog("==> Enter callee2")
+                debugLog("==> Exit callee2")
+            }
+
+            // We add an inline never here to make sure that we do not eliminate
+            // the dynamic access after inlining.
+            @MainActor
+            @inline(never)
+            func callee1(_ x: inout Int, _ y: inout Int, _ z: inout Int) async -> () {
+                debugLog("==> Enter callee1")
+                let handle = Task { @MainActor in
+                    debugLog("==> Enter callee1 Closure")
+                    // Second access. Different Task so it is ok.
+                    await callee2(&global1, &global2, &global3)
+                    debugLog("==> Exit callee1 Closure")
+                }
+                await handle.value
+                debugLog("==> Exit callee1")
+            }
+
+            debugLog("==> Enter Main")
+            // First access begins here.
+            await callee1(&global1, &global2, &global3)
+            debugLog("==> Exit Main")
+        }
+
+        // Now that we have tested our tests with various numbers of accesses,
+        // lets make specific tests for each case in Exclusivity.cpp.
+        //
+        // Case 1: (F, F, F) - No Live Accesses at Task Start, No Live Sync
+        // Accesses When Push, No Live Task Accesses when pop.
+        //
+        // This case is the case where we do not have any accesses in our code
+        // at all or if the task cleans up the tasks before it awaits again. We
+        // test the task cleanup case.
+        exclusivityTests.test("case1") { @MainActor in
+            @inline(never)
+            @Sendable func callee2(_ x: inout Int, _ y: inout Int, _ z: inout Int) -> Void {
+                debugLog("==> Enter callee2")
+                debugLog("==> Exit callee2")
+            }
+
+            // We add an inline never here to make sure that we do not eliminate
+            // the dynamic access after inlining.
+            @MainActor
+            @inline(never)
+            func callee1() async -> () {
+                debugLog("==> Enter callee1")
+                let handle = Task { @MainActor in
+                    debugLog("==> Enter callee1 Closure")
+                    // These accesses end before we await in the task.
+                    do {
+                        callee2(&global1, &global2, &global3)
+                    }
+                    await doSomething()
+                    debugLog("==> Exit callee1 Closure")
+                }
+                await handle.value
+                debugLog("==> Exit callee1")
+            }
+
+            await callee1()
+        }
+
+        // In case 2, our task does not start with any live accesses, but it is
+        // awaited upon after the live access begins. We want to make sure that
+        // we fail here since we properly restored the callee state.
+        exclusivityTests.test("case2") { @MainActor in
+            expectCrashLater(withMessage: "Fatal access conflict detected")
+
+            let callee2 = { @MainActor (_ x: inout Int) -> Void in
+                debugLog("==> Enter callee2")
+                debugLog("==> Exit callee2")
+            }
+
+            // We add an inline never here to make sure that we do not eliminate
+            // the dynamic access after inlining.
+            @MainActor
+            @inline(never)
+            func callee1(_ x: inout Int) async -> () {
+                debugLog("==> Enter callee1")
+                // This task is what prevents this example from crashing.
+                let handle = Task { @MainActor in
+                    debugLog("==> Enter callee1 Closure")
+                    // Second access. Different Task so it is ok.
+                    await callee2(&global1)
+                    debugLog("==> Exit callee1 Closure")
+                }
+                await handle.value
+
+                useGlobal(&global1) // We should crash here.
+
+                debugLog("==> Exit callee1")
+            }
+
+            debugLog("==> Enter Main")
+            // First access begins here.
+            await callee1(&global1)
+            debugLog("==> Exit Main")
+        }
+
+        // In case 5, our task starts with live accesses, but we finish the
+        // accesses before we return. So we do not crash. The key thing is the
+        // access lives over a suspension/resume.
+        exclusivityTests.test("case5") { @MainActor in
+            let callee2 = { @MainActor (_ x: inout Int) -> Void in
+                debugLog("==> Enter callee2")
+                debugLog("==> Exit callee2")
+            }
+
+            // We add an inline never here to make sure that we do not eliminate
+            // the dynamic access after inlining.
+            @MainActor
+            @inline(never)
+            func callee1(_ x: inout Int) async -> () {
+                debugLog("==> Enter callee1")
+                // This task is what prevents this example from crashing.
+                let handle = Task { @MainActor in
+                    debugLog("==> Enter callee1 Closure")
+                    // Second access. Different Task so it is ok.
+                    await callee2(&global1)
+                    debugLog("==> Exit callee1 Closure")
+                }
+                await handle.value
+
+                debugLog("==> Exit callee1")
+            }
+
+            @MainActor
+            @inline(never)
+            func callCallee1() async {
+                await callee1(&global1)
+            }
+
+            debugLog("==> Enter Main")
+            // First access begins here.
+            await callCallee1()
+            useGlobal(&global1) // We should not crash here since we cleaned up
+                                // the access in callCallee1 after we returned
+                                // from the await there.
+            debugLog("==> Exit Main")
+        }
+
+        // In case 6, our task starts with live accesses, and we only finish
+        // some of the accesses before we return. So we want to validate that by
+        // running the same code twice, one testing we can access the pointer we
+        // can fix up and a second that we can not.
+        exclusivityTests.test("case6") { @MainActor in
+            let callee2 = { @MainActor (_ x: inout Int) -> Void in
+                debugLog("==> Enter callee2")
+                debugLog("==> Exit callee2")
+            }
+
+            // We add an inline never here to make sure that we do not eliminate
+            // the dynamic access after inlining.
+            @MainActor
+            @inline(never)
+            func callee1(_ x: inout Int) async -> () {
+                debugLog("==> Enter callee1")
+                // This task is what prevents this example from crashing.
+                let handle = Task { @MainActor in
+                    debugLog("==> Enter callee1 Closure")
+                    // Second access. Different Task so it is ok.
+                    await callee2(&global1)
+                    debugLog("==> Exit callee1 Closure")
+                }
+                await handle.value
+
+                debugLog("==> Exit callee1")
+            }
+
+            @MainActor
+            @inline(never)
+            func callCallee1() async {
+                await callee1(&global1)
+            }
+
+            debugLog("==> Enter Main")
+            // First access begins here.
+            await callCallee1()
+            useGlobal(&global1) // We should not crash here since we cleaned up
+                                // the access in callCallee1 after we returned
+                                // from the await there.
+            debugLog("==> Exit Main")
+        }
+
+        await runAllTestsAsync()
+    }
+}

--- a/test/Concurrency/Runtime/exclusivity_custom_executors.swift
+++ b/test/Concurrency/Runtime/exclusivity_custom_executors.swift
@@ -42,6 +42,7 @@ public func withExclusiveAccess<T, U>(to x: inout T, f: (inout T) -> U) -> U {
     return f(&x)
 }
 
+@available(SwiftStdlib 5.5, *)
 @MainActor @inline(never)
 func withExclusiveAccessAsync<T, U>(to x: inout T, f: (inout T) async -> U) async -> U {
     debugLog("==> Enter 'withExclusiveAccessAsync'")

--- a/test/Concurrency/Runtime/exclusivity_custom_executors.swift
+++ b/test/Concurrency/Runtime/exclusivity_custom_executors.swift
@@ -1,0 +1,632 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch -parse-as-library)
+
+// REQUIRES: concurrency
+// REQUIRES: executable_test
+
+// rdar://76038845
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: use_os_stdlib
+
+// This test makes sure that we properly save/restore access when we
+// synchronously launch a task from a serial executor. The access from the task
+// should be merged into the already created access set while it runs and then
+// unmerged afterwards.
+
+import _Concurrency
+import StdlibUnittest
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(CRT)
+import CRT
+#endif
+
+@inlinable
+public func debugLog(_ s: String) {
+    // Only enable this when debugging test failures against an asserts
+    // runtime. Otherwise, the test is noisy and has non-windows
+    // dependencies. We need stderr to ensure proper log output interleaving
+    // with the runtime's own stderr emitted output.
+#if DEBUG_LOGGING
+    fputs(s + "\n", stderr)
+    fflush(stderr)
+#endif
+}
+
+@inline(never)
+public func withExclusiveAccess<T, U>(to x: inout T, f: (inout T) -> U) -> U {
+    debugLog("==> Enter 'withExclusiveAccess'")
+    defer { debugLog("==> Exit 'withExclusiveAccess'") }
+    return f(&x)
+}
+
+@MainActor @inline(never)
+func withExclusiveAccessAsync<T, U>(to x: inout T, f: (inout T) async -> U) async -> U {
+    debugLog("==> Enter 'withExclusiveAccessAsync'")
+    defer { debugLog("==> Exit 'withExclusiveAccessAsync'") }
+    return await f(&x)
+}
+
+@available(SwiftStdlib 5.5, *)
+public final class MySerialExecutor : SerialExecutor {
+    public init() {
+        debugLog("==> MySerialExecutor: Creating MySerialExecutor!")
+    }
+    public static var sharedSerialExecutor = MySerialExecutor()
+    public static var sharedUnownedExecutor: UnownedSerialExecutor {
+        debugLog("==> MySerialExecutor: Getting Shared Unowned Executor!")
+        return UnownedSerialExecutor(ordinary: sharedSerialExecutor)
+    }
+
+    public func enqueue(_ job: UnownedJob) {
+        debugLog("==> MySerialExecutor: Got an enqueue!")
+        // This is the exclusive access that we are going to be swizzling
+        // in/out.
+        //
+        // Make sure we have 2x synchronized to test.
+        withExclusiveAccess(to: &global2) { _ in
+            withExclusiveAccess(to: &global3) { _ in
+                debugLog("==> MySerialExecutor: Inside access!")
+                job._runSynchronously(on: asUnownedSerialExecutor())
+                debugLog("==> MySerialExecutor: Inside access after run synchronously!")
+            }
+        }
+        debugLog("==> MySerialExecutor: After access, after run synchronously")
+    }
+
+    public func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+        debugLog("==> MySerialExecutor: Getting Unowned Executor!")
+        return UnownedSerialExecutor(ordinary: self)
+    }
+}
+
+/// A singleton actor whose executor is equivalent to the main
+/// dispatch queue.
+@available(SwiftStdlib 5.5, *)
+@globalActor public final actor MyMainActor: Executor {
+    public static let shared = MyMainActor()
+    public let executor = MySerialExecutor()
+
+  @inlinable
+  public nonisolated var unownedExecutor: UnownedSerialExecutor {
+      debugLog("==> MyMainActor: Getting unowned exector!")
+      return executor.asUnownedSerialExecutor()
+  }
+
+  @inlinable
+  public static var sharedUnownedExecutor: UnownedSerialExecutor {
+      debugLog("==> MyMainActor: Getting shared unowned exector!")
+      return MySerialExecutor.sharedUnownedExecutor
+  }
+
+  @inlinable
+  public nonisolated func enqueue(_ job: UnownedJob) {
+      debugLog("==> MyMainActor: enqueuing!")
+      executor.enqueue(job)
+  }
+}
+
+/// An actor that we use to test that after eliminating the synchronous
+/// accesses, we properly deserialize the task access set causing a crash in
+/// unownedExecutor.
+@available(SwiftStdlib 5.5, *)
+@globalActor public final actor MyMainActorWithAccessInUnownedExecAccessor: Executor {
+    public static let shared = MyMainActorWithAccessInUnownedExecAccessor()
+    public let executor = MySerialExecutor()
+
+  @inlinable
+  public nonisolated var unownedExecutor: UnownedSerialExecutor {
+      debugLog("==> MyMainActorWithAccessInUnownedExecAccessor: Getting unowned exector!")
+      withExclusiveAccess(to: &global) { _ in debugLog("Crash!") }
+      return executor.asUnownedSerialExecutor()
+  }
+
+  @inlinable
+  public static var sharedUnownedExecutor: UnownedSerialExecutor {
+      debugLog("==> MyMainActorWithAccessInUnownedExecAccessor: Getting shared unowned exector!")
+      return MySerialExecutor.sharedUnownedExecutor
+  }
+
+  @inlinable
+  public nonisolated func enqueue(_ job: UnownedJob) {
+      debugLog("==> MyMainActorWithAccessInUnownedExecAccessor: enqueuing!")
+      executor.enqueue(job)
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+actor Custom {
+  var count = 0
+
+  func report() async {
+    debugLog("==> Custom: custom.count == \(count)")
+    count += 1
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+@globalActor
+struct CustomActor {
+    static var shared: Custom {
+        debugLog("==> CustomActor: Getting custom!")
+        return Custom()
+    }
+}
+
+public var global: Int = 5
+public var global2: Int = 6
+public var global3: Int = 7
+public var global4: Int = 8
+
+@available(SwiftStdlib 5.5, *)
+@main
+struct Runner {
+    @MainActor static func main() async {
+        var exclusivityTests = TestSuite("Async Exclusivity Custom Executors")
+
+        // As a quick sanity test, make sure that the crash doesn't occur if we
+        // don't have the withExclusiveAccess(to: ) from the case below.
+        exclusivityTests.test("exclusivityAccessesPropagateFromExecutorIntoTasks NoConflict") {
+            @MainActor in
+            debugLog("==> Before handle")
+            let handle = Task { @MyMainActor in
+                debugLog("==> Main: In handle!")
+                debugLog("==> No Crash!")
+                debugLog("==> Main: All done!")
+            }
+            await handle.value
+        }
+
+        // Make sure that we crash here due to the task forming an access to
+        // memory that the executor has exclusive access to.
+        exclusivityTests.test("exclusivityAccessesPropagateFromExecutorIntoTasks Crash") { @MainActor in
+            expectCrashLater(withMessage: "Fatal access conflict detected")
+            debugLog("==> Before handle")
+            let handle = Task { @MyMainActor in
+                debugLog("==> Main: In handle!")
+                withExclusiveAccess(to: &global2) { _ in
+                    debugLog("==> Crash!")
+                }
+                debugLog("==> Main: All done!")
+            }
+            await handle.value
+        }
+
+        // If all of the previous tests passed, then we have basic sanity
+        // done. Lets now test out our cases that involve a live sync access.
+        //
+        // We test cases 3,4,7,8 here. The other cases that do not involve a
+        // custom executor are tested in Runtime/exclusivity.swift.
+
+        // Now that we have tested our tests with various numbers of accesses,
+        // lets make specific tests for each case in Exclusivity.cpp.
+        //
+        // Case 3: (F, T, F) - No Live Accesses at Task Start, Exiting Live Sync
+        // Accesses When Push, No Live Task Accesses when pop.
+        //
+        // This case is the case where we do not have any accesses in our code
+        // at all or if the task cleans up the tasks before it awaits again. We
+        // test the task cleanup case.
+        exclusivityTests.test("case3") { @MainActor in
+            debugLog("==> Before handle")
+            let handle = Task { @MyMainActor in
+                debugLog("==> Main: In handle!")
+                debugLog("==> No Crash!")
+                debugLog("==> Main: All done!")
+
+                withExclusiveAccess(to: &global) { _ in
+                    debugLog("==> Making sure can push/pop access")
+                }
+                // In order to test that we properly hand off the access, we
+                // need to await here.
+                let handle2 = await Task { @CustomActor in
+                    debugLog("==> In inner handle")
+                }
+                await handle2.value
+            }
+            await handle.value
+        }
+
+        // Case 4: (F, T, T). In case 4, our task does not start with a live
+        // access but we have accesses from the outside synchronous context, and
+        // do add new accesses when we pop.
+        exclusivityTests.test("case4") { @MainActor in
+            debugLog("==> Before handle")
+            let handle = Task { @MyMainActor in
+                debugLog("==> Main: In handle!")
+                debugLog("==> No Crash!")
+                debugLog("==> Main: All done!")
+
+                await withExclusiveAccessAsync(to: &global) {
+                    @MyMainActor (x: inout Int) async -> Void in
+                    debugLog("==> Making sure can push/pop access")
+                }
+                // In order to test that we properly hand off the access, we
+                // need to await here.
+                let handle2 = await Task { @CustomActor in
+                    debugLog("==> In inner handle")
+                }
+                await handle2.value
+            }
+            await handle.value
+        }
+
+        // Make sure we crash with the sync access despite mixing in the tasks
+        // accesses.
+        exclusivityTests.test("case4.execaccess.to_sync") { @MainActor in
+            expectCrashLater(withMessage: "Fatal access conflict detected")
+            debugLog("==> Before handle")
+            let handle = Task { @MyMainActor in
+                debugLog("==> Main: In handle!")
+                debugLog("==> No Crash!")
+                debugLog("==> Main: All done!")
+
+                await withExclusiveAccessAsync(to: &global) {
+                    @MyMainActor (x: inout Int) async -> Void in
+                    withExclusiveAccess(to: &global2) { _ in debugLog("CRASH!") }
+                    debugLog("==> Making sure can push/pop access")
+                }
+                // In order to test that we properly hand off the access, we
+                // need to await here.
+                let handle2 = await Task { @CustomActor in
+                    debugLog("==> In inner handle")
+                }
+                await handle2.value
+            }
+            await handle.value
+        }
+
+        // Make sure we do not crash with the sync access despite mixing in the tasks
+        // accesses.
+        exclusivityTests.test("case4.no_crash") { @MainActor in
+            debugLog("==> Before handle")
+            let handle = Task { @MyMainActor in
+                debugLog("==> Main: In handle!")
+                debugLog("==> No Crash!")
+                debugLog("==> Main: All done!")
+
+                await withExclusiveAccessAsync(to: &global) {
+                    @MyMainActor (x: inout Int) async -> Void in
+                    debugLog("==> Making sure can push/pop access")
+                }
+                // In order to test that we properly hand off the access, we
+                // need to await here.
+                let handle2 = await Task { @CustomActor in
+                    debugLog("==> In inner handle")
+                }
+                await handle2.value
+            }
+            await handle.value
+        }
+
+        // This test makes sure that despite us going through case4, that we
+        // properly deserialize the task's access and hit a crash in the
+        // UnownedExecAccessor.
+        exclusivityTests.test("case4.crash_due_to_deserialized_task") { @MainActor in
+            expectCrashLater(withMessage: "Fatal access conflict detected")
+            debugLog("==> Before handle")
+            let handle = Task { @MyMainActorWithAccessInUnownedExecAccessor in
+                debugLog("==> Main: In handle!")
+                debugLog("==> No Crash!")
+                debugLog("==> Main: All done!")
+
+                await withExclusiveAccessAsync(to: &global) {
+                    @MyMainActorWithAccessInUnownedExecAccessor (x: inout Int) async -> Void in
+                    debugLog("==> Making sure can push/pop access")
+                }
+                // In order to test that we properly hand off the access, we
+                // need to await here.
+                let handle2 = await Task { @CustomActor in
+                    debugLog("==> In inner handle")
+                }
+                await handle2.value
+            }
+            await handle.value
+        }
+
+        // Case 7. (T, T, F). In case 7, our task starts with live accesses and
+        // sync accesses, but the live accesses are popped before we return.
+        @Sendable
+        @MyMainActor @inline(never)
+        func withExclusiveAccessAsyncCase7<T, U>(to x: inout T, f: (inout T) async -> U) async -> U {
+            debugLog("==> Enter 'withExclusiveAccessAsyncCase7'")
+            defer { debugLog("==> Exit 'withExclusiveAccessAsyncCase7'") }
+            let t = Task { @MainActor in
+                debugLog("==> Task to force serialization of MyMainActor by using MainActor")
+            }
+            await t.value
+            return await f(&x)
+        }
+
+        exclusivityTests.test("case7") { @MainActor in
+            debugLog("==> Before handle")
+            let handle = Task { @MyMainActor in
+                debugLog("==> Main: In handle!")
+                debugLog("==> No Crash!")
+                debugLog("==> Main: All done!")
+
+                await withExclusiveAccessAsyncCase7(to: &global) {
+                    @MyMainActor (x: inout Int) async -> Void in
+                    debugLog("==> Making sure can push/pop access")
+                }
+
+                // In order to test that we properly hand off the access, we
+                // need to await here.
+                let handle2 = await Task { @CustomActor in
+                    debugLog("==> In inner handle")
+                }
+                await handle2.value
+            }
+            await handle.value
+        }
+
+        @Sendable
+        @MyMainActor @inline(never)
+        func withExclusiveAccessAsyncCase7AccessGlobal<T, U>(to x: inout T, f: (inout T) async -> U) async -> U {
+            debugLog("==> Enter 'withExclusiveAccessAsyncCase7'")
+            defer { debugLog("==> Exit 'withExclusiveAccessAsyncCase7'") }
+            let t = Task { @MainActor in
+                debugLog("==> Task to force serialization of MyMainActor by using MainActor")
+            }
+            await t.value
+
+            // We should crash here since x should also be global and we
+            // properly deserialized.
+
+            withExclusiveAccess(to: &global) { _ in }
+            return await f(&x)
+        }
+
+        // Validate case7 by crashing due to a Task access <-> Task access conflict
+        exclusivityTests.test("case7.crash.taskaccess_taskaccess_conflict") { @MainActor in
+            expectCrashLater(withMessage: "Fatal access conflict detected")
+            debugLog("==> Before handle")
+            let handle = Task { @MyMainActor in
+                debugLog("==> Main: In handle!")
+                debugLog("==> No Crash!")
+                debugLog("==> Main: All done!")
+
+                await withExclusiveAccessAsyncCase7AccessGlobal(to: &global) {
+                    @MyMainActor (x: inout Int) async -> Void in
+                    debugLog("==> Making sure can push/pop access")
+                }
+
+                // In order to test that we properly hand off the access, we
+                // need to await here.
+                let handle2 = await Task { @CustomActor in
+                    debugLog("==> In inner handle")
+                }
+                await handle2.value
+            }
+            await handle.value
+        }
+
+        @Sendable
+        @MyMainActor @inline(never)
+        func withExclusiveAccessAsyncCase7AccessGlobal2<T, U>(to x: inout T, f: (inout T) async -> U) async -> U {
+            debugLog("==> Enter 'withExclusiveAccessAsyncCase7'")
+            defer { debugLog("==> Exit 'withExclusiveAccessAsyncCase7'") }
+            let t = Task { @MainActor in
+                debugLog("==> Task to force serialization of MyMainActor by using MainActor")
+            }
+            await t.value
+
+            // We should crash here since our executor had exclusive access to
+            // global2.
+            withExclusiveAccess(to: &global2) { _ in }
+            return await f(&x)
+        }
+
+        // Validate case7 by crashing due to a Task access <-> Task access conflict
+        exclusivityTests.test("case7.crash.syncaccess_taskaccess_conflict") { @MainActor in
+            expectCrashLater(withMessage: "Fatal access conflict detected")
+            debugLog("==> Before handle")
+            let handle = Task { @MyMainActor in
+                debugLog("==> Main: In handle!")
+                debugLog("==> No Crash!")
+                debugLog("==> Main: All done!")
+
+                await withExclusiveAccessAsyncCase7AccessGlobal2(to: &global) {
+                    @MyMainActor (x: inout Int) async -> Void in
+                    debugLog("==> Making sure can push/pop access")
+                }
+
+                // In order to test that we properly hand off the access, we
+                // need to await here.
+                let handle2 = await Task { @CustomActor in
+                    debugLog("==> In inner handle")
+                }
+                await handle2.value
+            }
+            await handle.value
+        }
+
+        // Case 8. (T, T, T). In case 8, our task starts with live accesses and
+        // sync accesses, and we have remaining live accesses when we return.
+        @Sendable
+        @MyMainActor @inline(never)
+        func withExclusiveAccessAsyncCase8<T, U>(to x: inout T, f: (inout T) async -> U) async -> U {
+            debugLog("==> Enter 'withExclusiveAccessAsyncCase8'")
+            defer { debugLog("==> Exit 'withExclusiveAccessAsyncCase8'") }
+            let t = Task { @MainActor in
+                debugLog("==> Task1 to force serialization of MyMainActor by using MainActor")
+            }
+            await t.value
+
+            await f(&x)
+
+            let t2 = Task { @MainActor in
+                debugLog("==> Task2 to force serialization of MyMainActor by using MainActor")
+            }
+            await t2.value
+
+            return await f(&x)
+        }
+
+        exclusivityTests.test("case8") { @MainActor in
+            debugLog("==> Before handle")
+            let handle = Task { @MyMainActor in
+                debugLog("==> Main: In handle!")
+                debugLog("==> No Crash!")
+                debugLog("==> Main: All done!")
+
+                await withExclusiveAccessAsyncCase8(to: &global) {
+                    @MyMainActor (x: inout Int) async -> Void in
+                    debugLog("==> Making sure can push/pop access")
+                }
+
+                // In order to test that we properly hand off the access, we
+                // need to await here.
+                let handle2 = await Task { @CustomActor in
+                    debugLog("==> In inner handle")
+                }
+                await handle2.value
+            }
+            await handle.value
+        }
+
+        // Case 8. (T, T, T). In case 8, our task starts with live accesses and
+        // sync accesses, and we have remaining live accesses when we return.
+        @Sendable
+        @MyMainActor @inline(never)
+        func withExclusiveAccessAsyncCase8Access<T, U>(to x: inout T, f: (inout T) async -> U) async -> U {
+            debugLog("==> Enter 'withExclusiveAccessAsyncCase8'")
+            defer { debugLog("==> Exit 'withExclusiveAccessAsyncCase8'") }
+            let t = Task { @MainActor in
+                debugLog("==> Task1 to force serialization of MyMainActor by using MainActor")
+            }
+            await t.value
+
+            await f(&x)
+
+            let t2 = Task { @MainActor in
+                debugLog("==> Task2 to force serialization of MyMainActor by using MainActor")
+            }
+            await t2.value
+
+            // This is the time period we are testing works in the positive case.
+
+            return await f(&x)
+        }
+
+        exclusivityTests.test("case8") { @MainActor in
+            debugLog("==> Before handle")
+            let handle = Task { @MyMainActor in
+                debugLog("==> Main: In handle!")
+                debugLog("==> No Crash!")
+                debugLog("==> Main: All done!")
+
+                await withExclusiveAccessAsyncCase8(to: &global) {
+                    @MyMainActor (x: inout Int) async -> Void in
+                    debugLog("==> Making sure can push/pop access")
+                }
+
+                // In order to test that we properly hand off the access, we
+                // need to await here.
+                let handle2 = await Task { @CustomActor in
+                    debugLog("==> In inner handle")
+                }
+                await handle2.value
+            }
+            await handle.value
+        }
+
+        @Sendable
+        @MyMainActor @inline(never)
+        func withExclusiveAccessAsyncCase8AccessGlobal<T, U>(to x: inout T, f: (inout T) async -> U) async -> U {
+            debugLog("==> Enter 'withExclusiveAccessAsyncCase8'")
+            defer { debugLog("==> Exit 'withExclusiveAccessAsyncCase8'") }
+            let t = Task { @MainActor in
+                debugLog("==> Task1 to force serialization of MyMainActor by using MainActor")
+            }
+            await t.value
+
+            await f(&x)
+
+            let t2 = Task { @MainActor in
+                debugLog("==> Task2 to force serialization of MyMainActor by using MainActor")
+            }
+            await t2.value
+            // Make sure we swizzled back in our serialized task state, so we
+            // crash.
+            withExclusiveAccess(to: &global) { _ in
+                debugLog("==> TaskAccess + TaskAccess == Crash!")
+            }
+            return await f(&x)
+        }
+
+        exclusivityTests.test("case8.crash.taskaccess_taskaccess_conflict") { @MainActor in
+            expectCrashLater(withMessage: "Fatal access conflict detected")
+            debugLog("==> Before handle")
+            let handle = Task { @MyMainActor in
+                debugLog("==> Main: In handle!")
+                debugLog("==> No Crash!")
+                debugLog("==> Main: All done!")
+
+                await withExclusiveAccessAsyncCase8AccessGlobal(to: &global) {
+                    @MyMainActor (x: inout Int) async -> Void in
+                    debugLog("==> Making sure can push/pop access")
+                }
+
+                // In order to test that we properly hand off the access, we
+                // need to await here.
+                let handle2 = await Task { @CustomActor in
+                    debugLog("==> In inner handle")
+                }
+                await handle2.value
+            }
+            await handle.value
+        }
+
+        @Sendable
+        @MyMainActor @inline(never)
+        func withExclusiveAccessAsyncCase8AccessGlobal2<T, U>(to x: inout T, f: (inout T) async -> U) async -> U {
+            debugLog("==> Enter 'withExclusiveAccessAsyncCase8'")
+            defer { debugLog("==> Exit 'withExclusiveAccessAsyncCase8'") }
+            let t = Task { @MainActor in
+                debugLog("==> Task1 to force serialization of MyMainActor by using MainActor")
+            }
+            await t.value
+
+            await f(&x)
+
+            let t2 = Task { @MainActor in
+                debugLog("==> Task2 to force serialization of MyMainActor by using MainActor")
+            }
+            await t2.value
+            // Make sure we swizzled back in our serialized task state, so we
+            // crash.
+            withExclusiveAccess(to: &global2) { _ in
+                debugLog("==> SyncAccess + TaskAccess == Crash!")
+            }
+            return await f(&x)
+        }
+
+        exclusivityTests.test("case8.crash.syncaccess_taskaccess_conflict") { @MainActor in
+            expectCrashLater(withMessage: "Fatal access conflict detected")
+            debugLog("==> Before handle")
+            let handle = Task { @MyMainActor in
+                debugLog("==> Main: In handle!")
+                debugLog("==> No Crash!")
+                debugLog("==> Main: All done!")
+
+                await withExclusiveAccessAsyncCase8AccessGlobal2(to: &global) {
+                    @MyMainActor (x: inout Int) async -> Void in
+                    debugLog("==> Making sure can push/pop access")
+                }
+
+                // In order to test that we properly hand off the access, we
+                // need to await here.
+                let handle2 = await Task { @CustomActor in
+                    debugLog("==> In inner handle")
+                }
+                await handle2.value
+            }
+            await handle.value
+        }
+
+        await runAllTestsAsync()
+    }
+}

--- a/test/Concurrency/Runtime/exclusivity_custom_executors.swift
+++ b/test/Concurrency/Runtime/exclusivity_custom_executors.swift
@@ -7,6 +7,9 @@
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: use_os_stdlib
 
+// Disabled until test hang can be looked at.
+// UNSUPPORTED: OS=windows-msvc
+
 // This test makes sure that we properly save/restore access when we
 // synchronously launch a task from a serial executor. The access from the task
 // should be merged into the already created access set while it runs and then

--- a/test/Concurrency/Runtime/exclusivity_custom_executors_filecheck.swift
+++ b/test/Concurrency/Runtime/exclusivity_custom_executors_filecheck.swift
@@ -7,6 +7,9 @@
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: use_os_stdlib
 
+// Disabled until test hang can be looked at.
+// UNSUPPORTED: OS=windows-msvc
+
 // Only enabled if our stdlib has asserts enabled since the exclusivity runtime
 // will only emit logging when the stdlib is compiled with asserts. This is done
 // on purpose since we do not want to ship the runtime with this logging even

--- a/test/Concurrency/Runtime/exclusivity_custom_executors_filecheck.swift
+++ b/test/Concurrency/Runtime/exclusivity_custom_executors_filecheck.swift
@@ -1,0 +1,512 @@
+// RUN: export env %env-SWIFT_DEBUG_RUNTIME_EXCLUSIVITY_LOGGING=1 && \
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch -parse-as-library) 2>&1 | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: executable_test
+
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: use_os_stdlib
+
+// Only enabled if our stdlib has asserts enabled since the exclusivity runtime
+// will only emit logging when the stdlib is compiled with asserts. This is done
+// on purpose since we do not want to ship the runtime with this logging even
+// possible.
+//
+// UNSUPPORTED: swift_stdlib_no_asserts
+
+// This test makes sure that we properly save/restore access when we
+// synchronously launch a task from a serial executor. The access from the task
+// should be merged into the already created access set while it runs and then
+// unmerged afterwards.
+
+import _Concurrency
+import Dispatch
+
+// For fputs, file lock.
+#if canImport(CRT)
+
+import CRT
+
+@inlinable
+public func lockStderr() {
+    _lock_file(stderr)
+}
+@inlinable
+public func unlockStderr() {
+    _unlock_file(stderr)
+}
+
+#else
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+@inlinable
+public func lockStderr() {
+    flockfile(stderr)
+}
+
+@inlinable
+public func unlockStderr() {
+    funlockfile(stderr)
+}
+
+#endif
+
+@inlinable
+public func debugLog(_ s: String) {
+    lockStderr()
+    fputs(s + "\n", stderr)
+    fflush(stderr)
+    unlockStderr()
+}
+
+@inline(never)
+public func withExclusiveAccess<T, U>(to x: inout T, f: (inout T) -> U) -> U {
+    debugLog("==> Enter 'withExclusiveAccess'")
+    defer { debugLog("==> Exit 'withExclusiveAccess'") }
+    return f(&x)
+}
+
+@MainActor @inline(never)
+func withExclusiveAccessAsync<T, U>(to x: inout T, f: (inout T) async -> U) async -> U {
+    debugLog("==> Enter 'withExclusiveAccessAsync'")
+    defer { debugLog("==> Exit 'withExclusiveAccessAsync'") }
+    return await f(&x)
+}
+
+@available(SwiftStdlib 5.5, *)
+public final class MySerialExecutor : SerialExecutor {
+    public init() {
+        debugLog("==> MySerialExecutor: Creating MySerialExecutor!")
+    }
+    public static var sharedSerialExecutor = MySerialExecutor()
+    public static var sharedUnownedExecutor: UnownedSerialExecutor {
+        debugLog("==> MySerialExecutor: Getting Shared Unowned Executor!")
+        return UnownedSerialExecutor(ordinary: sharedSerialExecutor)
+    }
+
+    public func enqueue(_ job: UnownedJob) {
+        debugLog("==> MySerialExecutor: Got an enqueue!")
+        // This is the exclusive access that we are going to be swizzling
+        // in/out.
+        //
+        // Make sure we have 2x synchronized to test.
+        withExclusiveAccess(to: &global2) { _ in
+            withExclusiveAccess(to: &global3) { _ in
+                debugLog("==> MySerialExecutor: Inside access!")
+                job._runSynchronously(on: asUnownedSerialExecutor())
+                debugLog("==> MySerialExecutor: Inside access after run synchronously!")
+            }
+        }
+    }
+
+    public func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+        debugLog("==> MySerialExecutor: Getting Unowned Executor!")
+        return UnownedSerialExecutor(ordinary: self)
+    }
+}
+
+/// A singleton actor whose executor is equivalent to the main
+/// dispatch queue.
+@available(SwiftStdlib 5.5, *)
+@globalActor public final actor MyMainActor: Executor {
+    public static let shared = MyMainActor()
+    public let executor = MySerialExecutor()
+
+    @inlinable
+    public nonisolated var unownedExecutor: UnownedSerialExecutor {
+        debugLog("==> MyMainActor: Getting unowned exector!")
+        return executor.asUnownedSerialExecutor()
+    }
+
+    @inlinable
+    public static var sharedUnownedExecutor: UnownedSerialExecutor {
+        debugLog("==> MyMainActor: Getting shared unowned exector!")
+        return MySerialExecutor.sharedUnownedExecutor
+    }
+
+    @inlinable
+    public nonisolated func enqueue(_ job: UnownedJob) {
+        debugLog("==> MyMainActor: enqueuing!")
+        executor.enqueue(job)
+    }
+}
+
+/// An actor that we use to test that after eliminating the synchronous
+/// accesses, we properly deserialize the task access set causing a crash in
+/// unownedExecutor.
+@available(SwiftStdlib 5.5, *)
+@globalActor public final actor MyMainActorWithAccessInUnownedExecAccessor: Executor {
+    public static let shared = MyMainActorWithAccessInUnownedExecAccessor()
+    public let executor = MySerialExecutor()
+
+    @inlinable
+    public nonisolated var unownedExecutor: UnownedSerialExecutor {
+        debugLog("==> MyMainActorWithAccessInUnownedExecAccessor: Getting unowned exector!")
+        withExclusiveAccess(to: &global) { _ in debugLog("Crash!") }
+        return executor.asUnownedSerialExecutor()
+    }
+
+    @inlinable
+    public static var sharedUnownedExecutor: UnownedSerialExecutor {
+        debugLog("==> MyMainActorWithAccessInUnownedExecAccessor: Getting shared unowned exector!")
+        return MySerialExecutor.sharedUnownedExecutor
+    }
+
+    @inlinable
+    public nonisolated func enqueue(_ job: UnownedJob) {
+        debugLog("==> MyMainActorWithAccessInUnownedExecAccessor: enqueuing!")
+        executor.enqueue(job)
+    }
+}
+
+@available(SwiftStdlib 5.5, *)
+actor Custom {
+    var count = 0
+
+    func report() async {
+        debugLog("==> Custom: custom.count == \(count)")
+        count += 1
+    }
+}
+
+@available(SwiftStdlib 5.5, *)
+@globalActor
+struct CustomActor {
+    static var shared: Custom {
+        debugLog("==> CustomActor: Getting custom!")
+        return Custom()
+    }
+}
+
+public var global: Int = 5
+public var global2: Int = 6
+public var global3: Int = 7
+public var global4: Int = 8
+
+@available(SwiftStdlib 5.5, *)
+@main
+struct Runner {
+
+    // CHECK-LABEL: ==> Enter 'mergeSyncAccessesIntoTaskAccesses'
+    // CHECK: ==> MySerialExecutor: Got an enqueue!
+    // CHECK-NEXT: Inserting new access: [[SYNC_LLNODE_1:0x[0-9a-f]+]]
+    // CHECK-NEXT:   Tracking!
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1:0x[0-9a-f]+]]. PC:
+    // CHECK-NEXT: ==> Enter 'withExclusiveAccess'
+    // CHECK-NEXT: Inserting new access: [[SYNC_LLNODE_2:0x[0-9a-f]+]]
+    // CHECK-NEXT:   Tracking!
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_2:0x[0-9a-f]+]].
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1]]. PC:
+    // CHECK-NEXT: ==> Enter 'withExclusiveAccess'
+    // CHECK-NEXT: ==> MySerialExecutor: Inside access!
+    // CHECK-NEXT: ==> MySerialExecutor: Getting Unowned Executor!
+    // CHECK-NEXT: Entering Thread Local Context. Before Swizzle. Task: [[TASK:0x[0-9a-f]+]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): (0x0, 0x0)
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_2]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1]]. PC:
+    // CHECK-NEXT: Entering Thread Local Context. After Swizzle. Task: [[TASK]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): ([[SYNC_LLNODE_2]], 0x0)
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_2]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1]]. PC:
+    // CHECK: ==> Exit 'mergeSyncAccessesIntoTaskAccesses'
+    @MainActor
+    static func mergeSyncAccessesIntoTaskAccesses() async {
+        debugLog("==> Enter 'mergeSyncAccessesIntoTaskAccesses'")
+        defer { debugLog("==> Exit 'mergeSyncAccessesIntoTaskAccesses'") }
+
+        debugLog("==> Before handle")
+        let handle = Task { @MyMainActor in
+            debugLog("==> Main: In handle!")
+            debugLog("==> No Crash!")
+            debugLog("==> Main: All done!")
+        }
+        await handle.value
+    }
+
+    // If all of the previous tests passed, then we have basic sanity
+    // done. Lets now test out our cases that involve a live sync access.
+    //
+    // We test cases 3,4,7,8 here. The other cases that do not involve a
+    // custom executor are tested in Runtime/exclusivity.swift.
+
+    // Now that we have tested our tests with various numbers of accesses,
+    // lets make specific tests for each case in Exclusivity.cpp.
+    //
+    // Case 3: (F, T, F) - No Live Accesses at Task Start, Exiting Live Sync
+    // Accesses When Push, No Live Task Accesses when pop.
+    //
+    // This case is the case where we do not have any accesses in our code
+    // at all or if the task cleans up the tasks before it awaits again. We
+    // test the task cleanup case.
+
+    // CHECK-LABEL: ==> Enter 'testCase3'
+    // CHECK: ==> MySerialExecutor: Got an enqueue!
+    // CHECK-NEXT: Inserting new access: [[SYNC_LLNODE_1:0x[0-9a-f]+]]
+    // CHECK-NEXT:   Tracking!
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1:0x[0-9a-f]+]].
+    // CHECK-NEXT: ==> Enter 'withExclusiveAccess'
+    // CHECK-NEXT: Inserting new access: [[SYNC_LLNODE_2:0x[0-9a-f]+]]
+    // CHECK-NEXT:   Tracking!
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_2]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1]]. PC:
+    // CHECK: ==> Enter 'withExclusiveAccess'
+    // CHECK: ==> MySerialExecutor: Inside access!
+    // CHECK: ==> MySerialExecutor: Getting Unowned Executor!
+    // CHECK-NEXT: Entering Thread Local Context. Before Swizzle. Task: [[TASK_1:0x[0-9a-f]+]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): (0x0, 0x0)
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_2]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1]]. PC:
+    // CHECK-NEXT: Entering Thread Local Context. After Swizzle. Task: [[TASK_1]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): ([[SYNC_LLNODE_2]], 0x0)
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_2]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1]]. PC:
+    // CHECK: ==> Main: In handle!
+    // CHECK: ==> No Crash!
+    // CHECK: ==> Main: All done!
+    // CHECK: Inserting new access: [[TASK_LLNODE:0x[0-9a-f]+]]
+    // CHECK-NEXT:   Tracking!
+    // CHECK-NEXT:         Access. Pointer: [[TASK_ACCESS:0x[0-9a-f]+]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_2]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1]]. PC:
+    // CHECK-NEXT: ==> Enter 'withExclusiveAccess'
+    // CHECK-NEXT: ==> Making sure can push/pop access
+    // CHECK-NEXT: ==> Exit 'withExclusiveAccess'
+    // CHECK-NEXT: Removing access: [[TASK_LLNODE]]
+    // CHECK: Exiting Thread Local Context. Before Swizzle. Task: [[TASK_1]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): ([[SYNC_LLNODE_2]], 0x0)
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_2]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1]]. PC:
+    // CHECK: Exiting Thread Local Context. After Swizzle. Task: [[TASK_1]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): (0x0, 0x0)
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_2]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1]]. PC:
+    // CHECK: ==> Exit 'testCase3'
+    @MainActor
+    static func testCase3() async {
+        debugLog("==> Enter 'testCase3'")
+        defer { debugLog("==> Exit 'testCase3'") }
+
+        debugLog("==> Before handle")
+        let handle = Task { @MyMainActor in
+            debugLog("==> Main: In handle!")
+            debugLog("==> No Crash!")
+            debugLog("==> Main: All done!")
+
+            withExclusiveAccess(to: &global) { _ in
+                debugLog("==> Making sure can push/pop access")
+            }
+            // In order to test that we properly hand off the access, we
+            // need to await here.
+            let handle2 = await Task { @CustomActor in
+                debugLog("==> In inner handle")
+            }
+            await handle2.value
+        }
+        await handle.value
+    }
+
+    // Case 4: (F, T, T). In case 4, our task does not start with a live
+    // access but we have accesses from the outside synchronous context, and
+    // do add new accesses when we pop.
+    //
+    // CHECK-LABEL: ==> Enter 'testCase4'
+    // CHECK: ==> MySerialExecutor: Got an enqueue!
+    // CHECK-NEXT: Inserting new access: [[SYNC_NODE_1:0x[0-9a-f]+]]
+    // CHECK-NEXT:   Tracking!
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1:0x[0-9a-f]+]]. PC:
+    // CHECK: ==> Enter 'withExclusiveAccess'
+    // CHECK-NEXT: Inserting new access: [[SYNC_NODE_2:0x[0-9a-f]+]]
+    // CHECK-NEXT:   Tracking!
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_2]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1]]. PC:
+    // CHECK: ==> Enter 'withExclusiveAccess'
+    // CHECK: ==> MySerialExecutor: Inside access!
+    // CHECK: ==> MySerialExecutor: Getting Unowned Executor!
+    // CHECK-NEXT: Entering Thread Local Context. Before Swizzle. Task: [[TASK:0x[0-9a-f]+]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): (0x0, 0x0)
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_2]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1]]. PC:
+    // CHECK-NEXT: Entering Thread Local Context. After Swizzle. Task: [[TASK]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): ([[SYNC_NODE_2]], 0x0)
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_2]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1]]. PC:
+    // CHECK: ==> Main: In handle!
+    // CHECK: ==> No Crash!
+    // CHECK: ==> Main: All done!
+    // CHECK: Inserting new access: [[TASK_NODE:0x[0-9a-f]+]]
+    // CHECK-NEXT:   Tracking!
+    // CHECK-NEXT:         Access. Pointer: [[TASK_ACCESS:0x[0-9a-f]+]].
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_2]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1]]. PC:
+    // CHECK-NEXT: Exiting Thread Local Context. Before Swizzle. Task: [[TASK]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): ([[SYNC_NODE_2]], 0x0)
+    // CHECK-NEXT:         Access. Pointer: [[TASK_ACCESS]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_2]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1]]. PC:
+    // CHECK-NEXT: Exiting Thread Local Context. After Swizzle. Task: [[TASK]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): ([[TASK_NODE]], [[TASK_NODE]])
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_2]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1]]. PC:
+    // CHECK: ==> MySerialExecutor: Inside access after run synchronously!
+    // CHECK: ==> Exit 'testCase4'
+    @MainActor
+    static func testCase4() async {
+        debugLog("==> Enter 'testCase4'")
+        defer { debugLog("==> Exit 'testCase4'") }
+
+        debugLog("==> Before handle")
+        let handle = Task { @MyMainActor in
+            debugLog("==> Main: In handle!")
+            debugLog("==> No Crash!")
+            debugLog("==> Main: All done!")
+
+            await withExclusiveAccessAsync(to: &global) {
+                @MyMainActor (x: inout Int) async -> Void in
+                debugLog("==> Making sure can push/pop access")
+            }
+            // In order to test that we properly hand off the access, we
+            // need to await here.
+            let handle2 = await Task { @CustomActor in
+                debugLog("==> In inner handle")
+            }
+            await handle2.value
+        }
+        await handle.value
+    }
+
+    // Case 7. (T, T, F). In case 7, our task starts with live accesses and
+    // sync accesses, but the live accesses are popped before we return.
+    @MyMainActor @inline(never)
+    static func withExclusiveAccessAsyncCase7<T, U>(to x: inout T, f: (inout T) async -> U) async -> U {
+        debugLog("==> Enter 'withExclusiveAccessAsyncCase7'")
+        defer { debugLog("==> Exit 'withExclusiveAccessAsyncCase7'") }
+        let t = Task { @MainActor in
+            debugLog("==> Task to force serialization of MyMainActor by using MainActor")
+        }
+        await t.value
+        return await f(&x)
+    }
+
+    // CHECK-LABEL: ==> Enter 'testCase7'
+    // CHECK: ==> MySerialExecutor: Got an enqueue!
+    // CHECK: ==> MySerialExecutor: Got an enqueue!
+    // CHECK-NEXT: Inserting new access: [[SYNC_NODE_1:0x[0-9a-f]+]]
+    // CHECK-NEXT:   Tracking!
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1:0x[0-9a-f]+]]. PC:
+    // CHECK-NEXT: ==> Enter 'withExclusiveAccess'
+    // CHECK-NEXT: Inserting new access: [[SYNC_NODE_2:0x[0-9a-f]+]]
+    // CHECK-NEXT:   Tracking!
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_2:0x[0-9a-f]+]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1]]. PC:
+    // CHECK: ==> Enter 'withExclusiveAccess'
+    // CHECK: ==> MySerialExecutor: Inside access!
+    // CHECK: ==> MySerialExecutor: Getting Unowned Executor!
+    // CHECK: Entering Thread Local Context. Before Swizzle. Task: [[TASK:0x[0-9a-f]+]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): ([[TASK_NODE:0x[0-9a-f]+]], [[TASK_NODE]])
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_2]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1]]. PC:
+    // CHECK-NEXT: Entering Thread Local Context. After Swizzle. Task: [[TASK]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): ([[SYNC_NODE_2]], 0x0)
+    // CHECK-NEXT:         Access. Pointer: [[TASK_ACCESS:0x[0-9a-f]+]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_2]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1]]. PC:
+    // CHECK: ==> MyMainActor: Getting unowned exector!
+    // CHECK: ==> MySerialExecutor: Getting Unowned Executor!
+    // CHECK: ==> Making sure can push/pop access
+    // CHECK: ==> Exit 'withExclusiveAccessAsyncCase7'
+    // CHECK-NEXT: Removing access: [[TASK_NODE]]
+    // CHECK: Exiting Thread Local Context. Before Swizzle. Task: [[TASK]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): ([[SYNC_NODE_2]], 0x0)
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_2]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1]]. PC:
+    // CHECK: Exiting Thread Local Context. After Swizzle. Task: [[TASK]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): (0x0, 0x0)
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_2]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[SYNC_ACCESS_1]]. PC:
+    // CHECK: ==> Exit 'testCase7'
+    @MainActor
+    static func testCase7() async {
+        debugLog("==> Enter 'testCase7'")
+        defer { debugLog("==> Exit 'testCase7'") }
+
+        debugLog("==> Before handle")
+        let handle = Task { @MyMainActor in
+            debugLog("==> Main: In handle!")
+            debugLog("==> No Crash!")
+            debugLog("==> Main: All done!")
+
+            await withExclusiveAccessAsyncCase7(to: &global) {
+                @MyMainActor (x: inout Int) async -> Void in
+                debugLog("==> Making sure can push/pop access")
+            }
+
+            // In order to test that we properly hand off the access, we
+            // need to await here.
+            let handle2 = await Task { @CustomActor in
+                debugLog("==> In inner handle")
+            }
+            await handle2.value
+        }
+        await handle.value
+    }
+
+    // Case 8. (T, T, T). In case 8, our task starts with live accesses and
+    // sync accesses, and we have remaining live accesses when we return.
+    @MyMainActor @inline(never)
+    static func withExclusiveAccessAsyncCase8<T, U>(to x: inout T, f: (inout T) async -> U) async -> U {
+        debugLog("==> Enter 'withExclusiveAccessAsyncCase8'")
+        defer { debugLog("==> Exit 'withExclusiveAccessAsyncCase8'") }
+        let t = Task { @MainActor in
+            debugLog("==> Task1 to force serialization of MyMainActor by using MainActor")
+        }
+        await t.value
+
+        await f(&x)
+
+        let t2 = Task { @MainActor in
+            debugLog("==> Task2 to force serialization of MyMainActor by using MainActor")
+        }
+        await t2.value
+
+        return await f(&x)
+    }
+
+    @MainActor
+    static func testCase8() async {
+        debugLog("==> Enter 'testCase8'")
+        defer { debugLog("==> Exit 'testCase8'") }
+
+        debugLog("==> Before handle")
+        let handle = Task { @MyMainActor in
+            debugLog("==> Main: In handle!")
+            debugLog("==> No Crash!")
+            debugLog("==> Main: All done!")
+
+            await withExclusiveAccessAsyncCase8(to: &global) {
+                @MyMainActor (x: inout Int) async -> Void in
+                debugLog("==> Making sure can push/pop access")
+            }
+
+            // In order to test that we properly hand off the access, we
+            // need to await here.
+            let handle2 = await Task { @CustomActor in
+                debugLog("==> In inner handle")
+            }
+            await handle2.value
+        }
+        await handle.value
+    }
+
+    @MainActor static func main() async {
+        await mergeSyncAccessesIntoTaskAccesses()
+        await testCase3()
+        await testCase4()
+        await testCase7()
+        await testCase8()
+    }
+}

--- a/test/Concurrency/Runtime/exclusivity_custom_executors_filecheck.swift
+++ b/test/Concurrency/Runtime/exclusivity_custom_executors_filecheck.swift
@@ -71,6 +71,7 @@ public func withExclusiveAccess<T, U>(to x: inout T, f: (inout T) -> U) -> U {
     return f(&x)
 }
 
+@available(SwiftStdlib 5.5, *)
 @MainActor @inline(never)
 func withExclusiveAccessAsync<T, U>(to x: inout T, f: (inout T) async -> U) async -> U {
     debugLog("==> Enter 'withExclusiveAccessAsync'")

--- a/test/Concurrency/Runtime/exclusivity_filecheck.swift
+++ b/test/Concurrency/Runtime/exclusivity_filecheck.swift
@@ -1,0 +1,396 @@
+// RUN: export env %env-SWIFT_DEBUG_RUNTIME_EXCLUSIVITY_LOGGING=1 && \
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency -parse-as-library -Xfrontend -disable-access-control -parse-stdlib) 2>&1 | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+// Only enabled if our stdlib has asserts enabled since the exclusivity runtime
+// will only emit logging when the stdlib is compiled with asserts. This is done
+// on purpose since we do not want to ship the runtime with this logging even
+// possible.
+//
+// UNSUPPORTED: swift_stdlib_no_asserts
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// This test makes sure that:
+//
+// 1. Tasks have separate exclusivity sets.
+// 2. Exercise the pushing/popping of access sets from tasks.
+
+// NOTE: The cases that we are talking about handling below refer to the cases
+// documented in Exclusivity.cpp.
+
+import Swift
+import _Concurrency
+import StdlibUnittest
+
+var global1: Int = 5
+var global2: Int = 6
+var global3: Int = 7
+
+public func nonAsync() {}
+
+// For fputs, file lock.
+#if canImport(CRT)
+
+import CRT
+
+@inlinable
+public func lockStderr() {
+    _lock_file(stderr)
+}
+@inlinable
+public func unlockStderr() {
+    _unlock_file(stderr)
+}
+
+#else
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+func lockStderr() {
+    flockfile(stderr)
+}
+func unlockStderr() {
+    funlockfile(stderr)
+}
+#endif
+
+func printStderr(_ s: String) {
+    lockStderr()
+    fputs(s + "\n", stderr)
+    fflush(stderr)
+    unlockStderr()
+}
+
+@available(SwiftStdlib 5.5, *)
+func printBuiltinTask<Succ, Fail>(_ t: Task<Succ, Fail>) {
+    let p: Builtin.NativeObject = t._task
+    let r: OpaquePointer = OpaquePointer(Builtin.bridgeToRawPointer(p))
+    printStderr("==> Task: \(String(format: "%p", r))")
+}
+
+@available(SwiftStdlib 5.5, *)
+@main
+struct Runner {
+    @MainActor
+    @Sendable
+    @inline(never)
+    static func withExclusiveAccess<T, U>(to x: inout T, f: (inout T) async -> U) async -> U {
+        await f(&x)
+    }
+
+    @inline(never)
+    @MainActor
+    static func doSomething() async { }
+
+    @inline(never)
+    @Sendable
+    static func useGlobal(_ x: inout Int) { printStderr("FORCE ACCESS") }
+
+    // Now that we have tested our tests with various numbers of accesses,
+    // lets make specific tests for each case in Exclusivity.cpp.
+    //
+    // Case 1: (F, F, F) - No Live Accesses at Task Start, No Live Sync
+    // Accesses When Push, No Live Task Accesses when pop.
+    //
+    // This case is the case where we do not have any accesses in our code
+    // at all or if the task cleans up the tasks before it awaits again. We
+    // test the task cleanup case.
+    //
+    // CHECK-LABEL : ==> Enter 'testCase1'
+    //
+    // CHECK-NOT: Inserting new access:
+    // CHECK: ==> Task: [[TASK:0x[0-9a-f]+]]
+    // CHECK-NOT: Inserting new access:
+    //
+    // CHECK: Entering Thread Local Context. Before Swizzle. Task: [[TASK]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): (0x0, 0x0)
+    // CHECK-NEXT:         No Accesses.
+    // CHECK-NOT: Inserting new access:
+    // CHECK: Entering Thread Local Context. After Swizzle. Task: [[TASK]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): (0x0, 0x0)
+    // CHECK-NEXT:         No Accesses.
+    // CHECK-NOT: Inserting new access:
+    // CHECK: ==> Enter callee1 Closure
+    // CHECK-NEXT: Inserting new access: [[LINKED_LIST1:0x[0-9a-z]+]]
+    // CHECK-NEXT:   Tracking!
+    // CHECK-NEXT:         Access. Pointer: [[ACCESS1:0x[0-9a-z]+]]. PC:
+    // CHECK-NEXT: Inserting new access: [[LINKED_LIST2:0x[0-9a-z]+]]
+    // CHECK-NEXT:   Tracking!
+    // CHECK-NEXT:         Access. Pointer: [[ACCESS2:0x[0-9a-z]+]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[ACCESS1]]. PC:
+    // CHECK-NEXT: Inserting new access: [[LINKED_LIST3:0x[0-9a-z]+]]
+    // CHECK-NEXT:   Tracking!
+    // CHECK-NEXT:         Access. Pointer: [[ACCESS3:0x[0-9a-z]+]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[ACCESS2]]. PC:
+    // CHECK-NEXT:         Access. Pointer: [[ACCESS1]]. PC:
+    // CHECK-NEXT: ==> Enter callee2
+    // CHECK-NEXT: ==> Exit callee2
+    // CHECK-NEXT: Removing access: [[LINKED_LIST3]]
+    // CHECK-NEXT: Removing access: [[LINKED_LIST2]]
+    // CHECK-NEXT: Removing access: [[LINKED_LIST1]]
+    //
+    // At this point, we make sure that we properly exit the thread, finishing our test.
+    // CHECK: Exiting Thread Local Context. Before Swizzle. Task: [[TASK]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): (0x0, 0x0)
+    // CHECK-NEXT:         No Accesses.
+    // CHECK: Exiting Thread Local Context. After Swizzle. Task: [[TASK]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): (0x0, 0x0)
+    // CHECK-NEXT:         No Accesses.
+    //
+    // CHECK: ==> Exit 'testCase1'
+    @MainActor static func testCase1() async {
+        @inline(never)
+        @Sendable func callee2(_ x: inout Int, _ y: inout Int, _ z: inout Int) -> Void {
+            printStderr("==> Enter callee2")
+            printStderr("==> Exit callee2")
+        }
+
+        // We add an inline never here to make sure that we do not eliminate
+        // the dynamic access after inlining.
+        @MainActor
+        @inline(never)
+        func callee1() async -> () {
+            printStderr("==> Enter callee1")
+            let handle = Task { @MainActor in
+                printStderr("==> Enter callee1 Closure")
+
+                // These accesses end before we await in the task.
+                do {
+                    callee2(&global1, &global2, &global3)
+                }
+                let handle2 = Task { @MainActor in
+                    printStderr("==> Enter handle2!")
+                    printStderr("==> Exit handle2!")
+                }
+                await handle2.value
+                printStderr("==> Exit callee1 Closure")
+            }
+            printBuiltinTask(handle)
+            await handle.value
+            printStderr("==> Exit callee1")
+        }
+
+        printStderr("==> Enter 'testCase1'")
+        await callee1()
+        printStderr("==> Exit 'testCase1'")
+    }
+
+
+    // Case 2: (F, F, T). In case 2, our task does not start with a live access
+    // and nothing from the outside synchronous context, but does pop with a new
+    // access.
+    //
+    // We use a suspend point and a withExclusiveAccess(to:) to test this.
+    // CHECK-LABEL: ==> Enter 'testCase2'
+    //
+    // CHECK: ==> Task: [[TASK:0x[0-9a-f]+]]
+    //
+    // No accesses when we start.
+    // CHECK: ==> Inner Handle
+    // CHECK-NEXT: Inserting new access: [[LLNODE:0x[0-9a-z]+]]
+    // CHECK-NEXT:   Tracking!
+    // CHECK-NEXT:         Access. Pointer: [[ACCESS:0x[0-9a-z]+]]. PC:
+    // CHECK: Exiting Thread Local Context. Before Swizzle. Task: [[TASK]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): (0x0, 0x0)
+    // CHECK-NEXT:         Access. Pointer: [[ACCESS]]. PC:
+    // CHECK: Exiting Thread Local Context. After Swizzle. Task: [[TASK]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): ([[LLNODE]], [[LLNODE]])
+    // CHECK-NEXT:         No Accesses.
+    //
+    // CHECK: ==> Exit 'testCase2'
+    @MainActor static func testCase2() async {
+        printStderr("==> Enter 'testCase2'")
+
+        let handle = Task { @MainActor in
+            printStderr("==> Inner Handle")
+            await withExclusiveAccess(to: &global1) { @MainActor (x: inout Int) async -> Void in
+                let innerTaskHandle = Task { @MainActor in
+                    printStderr("==> End Inner Task Handle")
+                }
+                await innerTaskHandle.value
+                printStderr("==> After")
+            }
+            printStderr("==> Inner Handle: After exclusive access")
+        }
+        printBuiltinTask(handle)
+        await handle.value
+        printStderr("==> After exclusive access")
+        let handle2 = Task { @MainActor in
+            printStderr("==> Enter handle2!")
+            printStderr("==> Exit handle2!")
+        }
+        await handle2.value
+        printStderr("==> Exit 'testCase2'")
+    }
+
+    // Case 5: (T,F,F). To test case 5, we use with exclusive access to to
+    // create an exclusivity scope that goes over a suspension point. We are
+    // interesting in the case where we return after the suspension point. That
+    // push/pop is going to have our outer task bring in state and end it.
+    //
+    // CHECK-LABEL: ==> Enter 'testCase5'
+    // CHECK: ==> Task: [[TASK:0x[0-9a-f]+]]
+    // CHECK: Inserting new access: [[LLNODE:0x[a-z0-9]+]]
+    // CHECK-NEXT: Tracking!
+    // CHECK-NEXT: Access. Pointer: [[ACCESS:0x[a-z0-9]+]]
+    // CHECK: Exiting Thread Local Context. Before Swizzle. Task: [[TASK]]
+    // CHECK-NEXT: SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): (0x0, 0x0)
+    // CHECK-NEXT: Access. Pointer: [[ACCESS]]. PC:
+    // CHECK: Exiting Thread Local Context. After Swizzle. Task: [[TASK]]
+    // CHECK_NEXT: SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): ([[LLNODE]], [[LLNODE]])
+    // CHECK_NEXT: No Accesses.
+    //
+    // CHECK-NOT: Removing access:
+    // CHECK: ==> End Inner Task Handle
+    // CHECK: ==> After
+    // CHECK: Removing access: [[LLNODE]]
+    // CHECK: ==> After exclusive access
+    // CHECK: Exiting Thread Local Context. Before Swizzle. Task: [[TASK]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): (0x0, 0x0)
+    // CHECK-NEXT:         No Accesses.
+    // CHECK: Exiting Thread Local Context. After Swizzle. Task: [[TASK]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): (0x0, 0x0)
+    // CHECK-NEXT:         No Accesses.
+    //
+    // CHECK: ==> Exit 'testCase5'
+    @MainActor static func testCase5() async {
+        printStderr("==> Enter 'testCase5'")
+
+        let outerHandle = Task { @MainActor in
+          await withExclusiveAccess(to: &global1) { @MainActor (x: inout Int) async -> Void in
+              let innerTaskHandle = Task { @MainActor in
+                  printStderr("==> End Inner Task Handle")
+              }
+              await innerTaskHandle.value
+              printStderr("==> After")
+          }
+          printStderr("==> After exclusive access")
+          let handle2 = Task { @MainActor in
+              printStderr("==> Enter handle2!")
+              printStderr("==> Exit handle2!")
+          }
+          await handle2.value
+        }
+        printBuiltinTask(outerHandle)
+        await outerHandle.value
+        printStderr("==> Exit 'testCase5'")
+    }
+
+    // Case 6: (T, F, T). In case 6, our task starts with live accesses and is
+    // popped with live accesses. There are no sync accesses.
+    //
+    // We test this by looking at the behavior of the runtime after we finish
+    // executing handle2. In this case, we use the logging to validate that the
+    // original task1 accesses are brought back in and when we pop one last time
+    // as we await again, we properly restore the state.
+    //
+    // CHECK-LABEL: ==> Enter 'testCase6'
+    // CHECK: ==> Task: [[TASK1:0x[0-9a-f]+]]
+    // CHECK: Inserting new access: [[TASK1_LLNODE:0x[0-9a-z]+]]
+    // CHECK-NEXT: Tracking!
+    // CHECK-NEXT: Access. Pointer: [[ACCESS1:0x[0-9a-z]+]].
+    // CHECK-NEXT: ==> Enter callee1
+    //
+    // Grab task 2.
+    // CHECK: ==> Task: [[TASK2:0x[0-9a-f]+]]
+    //
+    // CHECK: Exiting Thread Local Context. Before Swizzle. Task: [[TASK1]]
+    // CHECK-NEXT: SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): (0x0, 0x0)
+    // CHECK-NEXT: Access. Pointer: [[ACCESS1]]. PC:
+    // CHECK: Exiting Thread Local Context. After Swizzle. Task: [[TASK1]]
+    // CHECK-NEXT: SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): ([[TASK1_LLNODE]], [[TASK1_LLNODE]])
+    // CHECK-NEXT: No Accesses.
+    //
+    // CHECK: ==> Enter callee1 Closure
+    // CHECK: ==> Exit callee1 Closure
+    //
+    // At this point, TASK2 has died and we will not get further notificatiosn
+    // of it.  But we don't really care about it. What we care about is that we
+    // properly restore task1's state.
+    // CHECK: Entering Thread Local Context. Before Swizzle. Task: [[TASK1]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess):
+    // CHECK-NEXT:         No Accesses.
+    // CHECK: Entering Thread Local Context. After Swizzle. Task: [[TASK1]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): (0x0, 0x0)
+    // CHECK-NEXT:         Access. Pointer:
+    //
+    // We then importantly actually serialize this state again allowing us to
+    // fully test case 2 when we resume from handle2!
+    //
+    // CHECK: ==> Enter handle2!
+    // CHECK-NEXT: ==> Exit handle2!
+    // CHECK: Entering Thread Local Context. Before Swizzle. Task: [[TASK1]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): ([[TASK1_LLNODE]], [[TASK1_LLNODE]])
+    // CHECK-NEXT:         No Accesses.
+    // CHECK: Entering Thread Local Context. After Swizzle. Task: [[TASK1]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): (0x0, 0x0)
+    // CHECK-NEXT:         Access. Pointer: [[ACCESS1]]. PC:
+    //
+    // Then we shuffle back.
+    // CHECK: Exiting Thread Local Context. Before Swizzle. Task: [[TASK1]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): (0x0, 0x0)
+    // CHECK-NEXT:         Access. Pointer: [[ACCESS1]]. PC:
+    // CHECK: Exiting Thread Local Context. After Swizzle. Task: [[TASK1]]
+    // CHECK-NEXT:         SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): ([[TASK1_LLNODE]], [[TASK1_LLNODE]])
+    // CHECK-NEXT:         No Accesses.
+    //
+    // CHECK: ==> Exit 'testCase6'
+    @MainActor static func testCase6() async {
+        let outerHandle = Task { @MainActor in
+            let callee2 = { @MainActor (_ x: inout Int) -> Void in
+                printStderr("==> Enter callee2")
+                printStderr("==> Exit callee2")
+            }
+
+            // We add an inline never here to make sure that we do not eliminate
+            // the dynamic access after inlining.
+            @MainActor
+            @inline(never)
+            func callee1(_ x: inout Int) async -> () {
+                printStderr("==> Enter callee1")
+                // This task is what prevents this example from crashing.
+                let handle = Task { @MainActor in
+                    printStderr("==> Enter callee1 Closure")
+                    // Second access. Different Task so it is ok.
+                    await withExclusiveAccess(to: &global1) {
+                        await callee2(&$0)
+                    }
+                    printStderr("==> Exit callee1 Closure")
+                }
+                printBuiltinTask(handle)
+                await handle.value
+                printStderr("==> callee1 after first await")
+                // Force an await here so we can see that we properly swizzle.
+                let handle2 = Task { @MainActor in
+                    printStderr("==> Enter handle2!")
+                    printStderr("==> Exit handle2!")
+                }
+                await handle2.value
+                printStderr("==> Exit callee1")
+            }
+
+            // First access begins here.
+            await callee1(&global1)
+        }
+        printStderr("==> Enter 'testCase6'")
+        printBuiltinTask(outerHandle)
+        await outerHandle.value
+        printStderr("==> Exit 'testCase6'")
+    }
+
+    @MainActor static func main() async {
+        await testCase1()
+        await testCase2()
+        await testCase5()
+        await testCase6()
+    }
+}


### PR DESCRIPTION
The implemented semantics are that:

1. Tasks have separate exclusivity access sets.
2. Any synchronous context that creates tasks will have its exclusive access set
   merged into the Tasks while the Task is running.

rdar://80492364
