### PR TITLE
[5.5] Further workaround for priority mishandling in runtime.

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -471,7 +471,12 @@ static AsyncTaskAndContext swift_task_create_commonImpl(
     if (currentTask)
       jobFlags.setPriority(currentTask->getPriority());
     else
-      jobFlags.setPriority(swift_task_getCurrentThreadPriority());
+      // FIXME: Ideally, this should be setting priority based on
+      // swift_task_getCurrentThreadPriority(). However, that creates
+      // priority differences which lead to different kinds of hangs
+      // Temporarily use Unspecified to work around that.
+      // See also: PR #37939.
+      jobFlags.setPriority(JobPriority::Unspecified);
   }
 
   // Figure out the size of the header.


### PR DESCRIPTION
See rdar://79378762, SR-14802, SR-14841, SR-14875.

This doesn't resolve all hangs, such as those occurring
due to explicit usage of priorities and certain other
situations where priorities seem to be causing issues
(rdar://79823345), but it does resolve some cases.

(cherry picked from commit fa406759108100b8111f53155e9e04f433de8997)