### PR TITLE
[Demangler] Fix NULL dereference on malformed mangled class name.

### DIFF
--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -2639,7 +2639,8 @@ NodePointer Demangler::demangleAutoDiffSelfReorderingReabstractionThunk() {
   addChild(result, popNode(Node::Kind::DependentGenericSignature));
   result = addChild(result, popNode(Node::Kind::Type));
   result = addChild(result, popNode(Node::Kind::Type));
-  result->reverseChildren();
+  if (result)
+    result->reverseChildren();
   result = addChild(result, demangleAutoDiffFunctionKind());
   return result;
 }

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -414,3 +414,4 @@ $s4test10returnsOptyxycSgxyScMYccSglF ---> test.returnsOpt<A>((@Swift.MainActor 
 $s1t10globalFuncyyAA7MyActorCYiF ---> t.globalFunc(isolated t.MyActor) -> ()
 $sSIxip6foobarP ---> foobar in Swift.DefaultIndices.subscript : A
 $s13__lldb_expr_110$10016c2d8yXZ1B10$10016c2e0LLC ---> __lldb_expr_1.(unknown context at $10016c2d8).(B in $10016c2e0)
+$s__TJO ---> $s__TJO


### PR DESCRIPTION
The (invalid) type name `'__TJO'` caused a `NULL` dereference.  Fix that and add a test case.

rdar://80602920
