### PR TITLE
Fix tab size for Emacs users.

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -16,7 +16,6 @@
         (set (make-local-variable 'swift-project-directory)
          this-directory)
         )
-  (tab-width . 2)
   (fill-column . 80)
   (c-file-style . "swift"))
  (c++-mode


### PR DESCRIPTION
For some reason `.dir-locals.el` was setting `tab-width` to 2.  That's a Really Bad Idea, because if somehow (as happened in my case) `indent-tabs-mode` was `'t` instead of `nil` like it should have been, Emacs will insert tabs instead of spaces, and it'll *look* like it's doing the right thing when it really isn't.
