### PR TITLE
C++ Interop: improve skipping already imported struct members

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3501,6 +3501,10 @@ namespace {
       SmallVector<ConstructorDecl *, 4> ctors;
       SmallVector<TypeDecl *, 4> nestedTypes;
 
+      // Store the already imported members in a set to avoid importing the same
+      // decls multiple times.
+      SmallPtrSet<clang::Decl *, 16> importedMembers;
+
       // FIXME: Import anonymous union fields and support field access when
       // it is nested in a struct.
 
@@ -3517,6 +3521,12 @@ namespace {
           if (recordDecl->isInjectedClassName()) {
             continue;
           }
+        }
+
+        // If we've already imported this decl & added it to the resulting
+        // struct, skip it so we don't add the same member twice.
+        if (!importedMembers.insert(m->getCanonicalDecl()).second) {
+          continue;
         }
 
         auto nd = dyn_cast<clang::NamedDecl>(m);
@@ -3546,12 +3556,6 @@ namespace {
             continue;
           }
         }
-
-        // If we've already imported this decl, skip it so we don't add the same
-        // member twice.
-        if (Impl.ImportedDecls.find({nd->getCanonicalDecl(), getVersion()}) !=
-            Impl.ImportedDecls.end())
-          continue;
 
         // If we encounter an IndirectFieldDecl, ensure that its parent is
         // importable before attempting to import it because they are dependent

--- a/test/Interop/Cxx/namespace/Inputs/module.modulemap
+++ b/test/Interop/Cxx/namespace/Inputs/module.modulemap
@@ -32,3 +32,8 @@ module TemplatesSecondHeader {
   header "templates-second-header.h"
   requires cplusplus
 }
+
+module TemplatesWithForwardDecl {
+  header "templates-with-forward-decl.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/namespace/Inputs/templates-with-forward-decl.h
+++ b/test/Interop/Cxx/namespace/Inputs/templates-with-forward-decl.h
@@ -1,0 +1,37 @@
+#ifndef TEST_INTEROP_CXX_NAMESPACE_INPUTS_TEMPLATES_WITH_FORWARD_DECL_H
+#define TEST_INTEROP_CXX_NAMESPACE_INPUTS_TEMPLATES_WITH_FORWARD_DECL_H
+
+namespace NS1 {
+
+template <typename T>
+struct Decl;
+
+typedef Decl<int> di;
+
+} // namespace NS1
+
+namespace NS1 {
+
+template <typename T>
+struct ForwardDeclared;
+
+template <typename T>
+struct Decl {
+  typedef T MyInt;
+  ForwardDeclared<T> fwd;
+  const static MyInt intValue = -1;
+};
+
+template <typename T>
+const typename Decl<T>::MyInt Decl<T>::intValue;
+
+} // namespace NS1
+
+namespace NS1 {
+
+template <typename T>
+struct ForwardDeclared {};
+
+} // namespace NS1
+
+#endif // TEST_INTEROP_CXX_NAMESPACE_INPUTS_TEMPLATES_WITH_FORWARD_DECL_H

--- a/test/Interop/Cxx/namespace/templates-with-forward-decl-module-interface.swift
+++ b/test/Interop/Cxx/namespace/templates-with-forward-decl-module-interface.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=TemplatesWithForwardDecl -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK: extension NS1 {
+// CHECK:   struct __CxxTemplateInstN3NS14DeclIiEE {
+// CHECK:     typealias MyInt = Int32
+// CHECK:     var fwd: NS1.__CxxTemplateInstN3NS115ForwardDeclaredIiEE
+// CHECK:     static let intValue: NS1.__CxxTemplateInstN3NS14DeclIiEE.MyInt
+// CHECK:   }
+// CHECK: }


### PR DESCRIPTION
This fixes the issue that prevents `std::string::size_type` from being imported into Swift: `size_type` is imported before its parent struct, and  we're skipping it when importing the struct afterwards.

This is caused by an out-of-line decl for `std::string::npos`:
```cpp
template<class _CharT, class _Traits, class _Allocator>
_LIBCPP_FUNC_VIS
const typename basic_string<_CharT, _Traits, _Allocator>::size_type
               basic_string<_CharT, _Traits, _Allocator>::npos;

```
When importing `npos`, we first import `size_type`, which triggers the issue.