### PR TITLE
[5.5][Refactoring] Only rename variables in capture lists once

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -654,7 +654,22 @@ private:
   Action startSourceEntity(const IndexSymbol &symbol) override {
     if (symbol.USR == USR) {
       if (auto loc = indexSymbolToRenameLoc(symbol, newName)) {
-        locations.push_back(std::move(*loc));
+        // Inside capture lists like `{ [test] in }`, 'test' refers to both the
+        // newly declared, captured variable and the referenced variable it is
+        // initialized from. Make sure to only rename it once.
+        auto existingLoc = llvm::find_if(locations, [&](RenameLoc searchLoc) {
+          return searchLoc.Line == loc->Line && searchLoc.Column == loc->Column;
+        });
+        if (existingLoc == locations.end()) {
+          locations.push_back(std::move(*loc));
+        } else {
+          assert(existingLoc->OldName == loc->OldName &&
+                 existingLoc->NewName == loc->NewName &&
+                 existingLoc->IsFunctionLike == loc->IsFunctionLike &&
+                 existingLoc->IsNonProtocolType ==
+                     existingLoc->IsNonProtocolType &&
+                 "Asked to do a different rename for the same location?");
+        }
       }
     }
     return IndexDataConsumer::Continue;

--- a/test/refactoring/rename/Outputs/local/captured_variable.swift.expected
+++ b/test/refactoring/rename/Outputs/local/captured_variable.swift.expected
@@ -9,8 +9,8 @@ func test1() {
 }
 
 func test2(arg1: Int?, arg2: (Int, String)?) {
-  if let xRenamed = arg1 {
-    print(xRenamed)
+  if let x = arg1 {
+    print(x)
   } else if let (x, y) = arg2 {
     print(x, y)
   }
@@ -48,10 +48,10 @@ func test5(_ x: Int) {
 }
 
 func testCaputreVariable() {
-  let capturedVariable = 0
+  let capturedVariableRenamed = 0
 
-  _ = { [capturedVariable] in
-    print(capturedVariable)
+  _ = { [capturedVariableRenamed] in
+    print(capturedVariableRenamed)
   }
 }
 

--- a/test/refactoring/rename/Outputs/local/casebind_1.swift.expected
+++ b/test/refactoring/rename/Outputs/local/casebind_1.swift.expected
@@ -47,3 +47,11 @@ func test5(_ x: Int) {
   print(x)
 }
 
+func testCaputreVariable() {
+  let capturedVariable = 0
+
+  _ = { [capturedVariable] in
+    print(capturedVariable)
+  }
+}
+

--- a/test/refactoring/rename/Outputs/local/casebind_2.swift.expected
+++ b/test/refactoring/rename/Outputs/local/casebind_2.swift.expected
@@ -47,3 +47,11 @@ func test5(_ x: Int) {
   print(x)
 }
 
+func testCaputreVariable() {
+  let capturedVariable = 0
+
+  _ = { [capturedVariable] in
+    print(capturedVariable)
+  }
+}
+

--- a/test/refactoring/rename/Outputs/local/catch_1.swift.expected
+++ b/test/refactoring/rename/Outputs/local/catch_1.swift.expected
@@ -47,3 +47,11 @@ func test5(_ x: Int) {
   print(x)
 }
 
+func testCaputreVariable() {
+  let capturedVariable = 0
+
+  _ = { [capturedVariable] in
+    print(capturedVariable)
+  }
+}
+

--- a/test/refactoring/rename/Outputs/local/catch_2.swift.expected
+++ b/test/refactoring/rename/Outputs/local/catch_2.swift.expected
@@ -47,3 +47,11 @@ func test5(_ x: Int) {
   print(x)
 }
 
+func testCaputreVariable() {
+  let capturedVariable = 0
+
+  _ = { [capturedVariable] in
+    print(capturedVariable)
+  }
+}
+

--- a/test/refactoring/rename/Outputs/local/ifbind_2.swift.expected
+++ b/test/refactoring/rename/Outputs/local/ifbind_2.swift.expected
@@ -47,3 +47,11 @@ func test5(_ x: Int) {
   print(x)
 }
 
+func testCaputreVariable() {
+  let capturedVariable = 0
+
+  _ = { [capturedVariable] in
+    print(capturedVariable)
+  }
+}
+

--- a/test/refactoring/rename/Outputs/local/localvar_1.swift.expected
+++ b/test/refactoring/rename/Outputs/local/localvar_1.swift.expected
@@ -47,3 +47,11 @@ func test5(_ x: Int) {
   print(x)
 }
 
+func testCaputreVariable() {
+  let capturedVariable = 0
+
+  _ = { [capturedVariable] in
+    print(capturedVariable)
+  }
+}
+

--- a/test/refactoring/rename/Outputs/local/localvar_2.swift.expected
+++ b/test/refactoring/rename/Outputs/local/localvar_2.swift.expected
@@ -47,3 +47,11 @@ func test5(_ x: Int) {
   print(x)
 }
 
+func testCaputreVariable() {
+  let capturedVariable = 0
+
+  _ = { [capturedVariable] in
+    print(capturedVariable)
+  }
+}
+

--- a/test/refactoring/rename/Outputs/local/param_1.swift.expected
+++ b/test/refactoring/rename/Outputs/local/param_1.swift.expected
@@ -47,3 +47,11 @@ func test5(_ xRenamed: Int) {
   print(x)
 }
 
+func testCaputreVariable() {
+  let capturedVariable = 0
+
+  _ = { [capturedVariable] in
+    print(capturedVariable)
+  }
+}
+

--- a/test/refactoring/rename/Outputs/local/param_2.swift.expected
+++ b/test/refactoring/rename/Outputs/local/param_2.swift.expected
@@ -47,3 +47,11 @@ func test5(_ x: Int) {
   print(xRenamed)
 }
 
+func testCaputreVariable() {
+  let capturedVariable = 0
+
+  _ = { [capturedVariable] in
+    print(capturedVariable)
+  }
+}
+

--- a/test/refactoring/rename/local.swift
+++ b/test/refactoring/rename/local.swift
@@ -47,6 +47,14 @@ func test5(_ x: Int) {
   print(x)
 }
 
+func testCaputreVariable() {
+  let capturedVariable = 0
+
+  _ = { [capturedVariable] in
+    print(capturedVariable)
+  }
+}
+
 // RUN: %empty-directory(%t.result)
 // RUN: %refactor -rename -source-filename %s -pos=3:9 -new-name="xRenamed" >> %t.result/localvar_1.swift
 // RUN: %refactor -rename -source-filename %s -pos=7:11 -new-name="xRenamed" >> %t.result/localvar_2.swift
@@ -68,3 +76,5 @@ func test5(_ x: Int) {
 // RUN: %refactor -rename -source-filename %s -pos=47:9 -new-name="xRenamed" >> %t.result/param_2.swift
 // RUN: diff -u %S/Outputs/local/param_1.swift.expected %t.result/param_1.swift
 // RUN: diff -u %S/Outputs/local/param_2.swift.expected %t.result/param_2.swift
+// RUN: %refactor -rename -source-filename %s -pos=51:7 -new-name="capturedVariableRenamed" >> %t.result/captured_variable.swift
+// RUN: diff -u %S/Outputs/local/captured_variable.swift.expected %t.result/captured_variable.swift


### PR DESCRIPTION
* **Explanation**: Inside capture lists like `{ [test] in }`, `test` refers to both the newly declared, captured variable and the referenced variable it is initialized from. We currently try to rename it twice, yielding invalid, confusing results. Make sure to only record this situation once
* **Scope**: Global rename of symbols that have two AST nodes pointing to the same location
* **Risk**: Low
* **Testing**: Added regression test
* **Issue**: rdar://78522816
* **Reviewer**: Argyrios Kyrtzidis (@akyrtzi) on original PR #38331 