### PR TITLE
[build] Add a new `--cross-compile-build-swift-tools` flag to disable cross-compiling the compiler

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -292,6 +292,7 @@ KNOWN_SETTINGS=(
     cross-compile-install-prefixes                ""                "semicolon-separated list of install prefixes to use for the cross-compiled hosts. The list expands, so if there are more cross-compile hosts than prefixes, unmatched hosts use the last prefix in the list"
     cross-compile-deps-path                       ""                "path for CMake to look for cross-compiled library dependencies, such as libXML2"
     cross-compile-append-host-target-to-destdir   "1"               "turns on appending the host target name of each cross-compiled toolchain to its install-destdir, to keep them separate from the natively-built toolchain"
+    cross-compile-build-swift-tools               "1"               "set to 1 to cross-compile the Swift host tools, like the Swift compiler"
     skip-merge-lipo-cross-compile-tools           ""                "set to skip running merge-lipo after installing cross-compiled host Swift tools"
     coverage-db                                   ""                "If set, coverage database to use when prioritizing testing"
     skip-local-host-install                       ""                "If we are cross-compiling multiple targets, skip an install pass locally if the hosts match"
@@ -1693,6 +1694,12 @@ for host in "${ALL_HOSTS[@]}"; do
                         "${cmake_options[@]}"
                         -DLLVM_TABLEGEN=$(build_directory "${LOCAL_HOST}" llvm)/bin/llvm-tblgen
                         -DSWIFT_INCLUDE_TEST_BINARIES:BOOL=FALSE
+                        -DSWIFT_INCLUDE_TOOLS:BOOL=$(true_false "${CROSS_COMPILE_BUILD_SWIFT_TOOLS}")
+                    )
+                else
+                    cmake_options=(
+                        "${cmake_options[@]}"
+                        -DSWIFT_INCLUDE_TOOLS:BOOL=$(true_false "${BUILD_SWIFT_TOOLS}")
                     )
                 fi
 
@@ -1765,7 +1772,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DSWIFT_NATIVE_LLVM_TOOLS_PATH:STRING="${native_llvm_tools_path}"
                     -DSWIFT_NATIVE_CLANG_TOOLS_PATH:STRING="${native_clang_tools_path}"
                     -DSWIFT_NATIVE_SWIFT_TOOLS_PATH:STRING="${native_swift_tools_path}"
-                    -DSWIFT_INCLUDE_TOOLS:BOOL=$(true_false "${BUILD_SWIFT_TOOLS}")
                     -DSWIFT_BUILD_CLANG_OVERLAYS:BOOL=$(true_false "${BUILD_SWIFT_CLANG_OVERLAYS}")
                     -DSWIFT_BUILD_REMOTE_MIRROR:BOOL=$(true_false "${BUILD_SWIFT_REMOTE_MIRROR}")
                     -DSWIFT_STDLIB_SIL_DEBUGGING:BOOL=$(true_false "${BUILD_SIL_DEBUGGING_STDLIB}")


### PR DESCRIPTION
This is useful when building cross-compilation toolchains where you want the stdlib and corelibs cross-compiled but don't want the Swift compiler cross-compiled too with `--cross-compile-hosts`. This pull demonstrates using the new flag for the Android build presets.

I'm submitting this after discussing cross-compiling the corelibs on [the Android CI](https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/) with @drodriguez, as the easiest way to do so after #33724 is by using `--cross-compile-hosts` but we don't want to cross-compile the Swift compiler too.

To build this, I first had to unpack three Termux packages for Android, `libandroid-spawn`, `libcurl`, and `libxml2` (I also unpacked `libicu` but the Android CI does that differently) [as detailed here](https://github.com/buttaface/swift-android-sdk#building-the-android-sdks), because those libraries are dependencies of `swift-corelibs-foundation`.

I then passed that `swift-android-aarch64-24-sdk` path into this `build-script` invocation with the July 9 trunk source snapshot to build an Android cross-compilation toolchain that includes the corelibs:
```
./swift/utils/build-script -RA --android --android-ndk /home/butta/src/android-ndk-r21e/
--android-arch aarch64 --android-api-level 24
--android-icu-uc /home/butta/swift-android-aarch64-24-sdk/usr/lib/libicuuc.so
--android-icu-uc-include /home/butta/swift-android-aarch64-24-sdk/usr/include/
--android-icu-i18n /home/butta/swift-android-aarch64-24-sdk/usr/lib/libicui18n.so
--android-icu-i18n-include /home/butta/swift-android-aarch64-24-sdk/usr/include/
--android-icu-data /home/butta/swift-android-aarch64-24-sdk/usr/lib/libicudata.so
--xctest --cross-compile-hosts=android-aarch64 --install-swift --install-libdispatch
--install-foundation --install-xctest
--cross-compile-deps-path=/home/butta/swift-android-aarch64-24-sdk
--cross-compile-build-swift-tools=0 --llvm-ninja-targets-for-cross-compile-hosts=help
```
`swift-corelibs-foundation` recently added a dependency on some `posix_spawn` functions on Android, which [as discussed on the forum isn't officially supported before Android API 28](https://forums.swift.org/t/posix-spawnattr-init-on-android-8-1-and-earlier/48106), so I linked against Termux's backported library with these additional patches:
```
diff --git a/swift/stdlib/public/Platform/CMakeLists.txt b/swift/stdlib/public/Platform/CMakeLists.txt
index a7a60a063d9..8894800509a 100644
--- a/swift/stdlib/public/Platform/CMakeLists.txt
+++ b/swift/stdlib/public/Platform/CMakeLists.txt
@@ -99,6 +99,7 @@ foreach(sdk ${SWIFT_SDKS})
         OUTPUT "${glibc_modulemap_out}"
         FLAGS
             "-DCMAKE_SDK=${sdk}"
+            "-DSDK_INCLUDE_PATH=${SWIFT_${sdk}_${arch}_ICU_UC_INCLUDE}"
             "-DGLIBC_INCLUDE_PATH=${SWIFT_SDK_${sdk}_ARCH_${arch}_LIBC_INCLUDE_DIRECTORY}"
             "-DGLIBC_ARCH_INCLUDE_PATH=${SWIFT_SDK_${sdk}_ARCH_${arch}_LIBC_ARCHITECTURE_INCLUDE_DIRECTORY}")
 
@@ -142,6 +143,7 @@ foreach(sdk ${SWIFT_SDKS})
         SOURCE "${glibc_modulemap_source}"
         OUTPUT "${glibc_sysroot_relative_modulemap_out}"
         FLAGS "-DCMAKE_SDK=${sdk}"
+              "-DSDK_INCLUDE_PATH=${SWIFT_${sdk}_${arch}_ICU_UC_INCLUDE}"
               "-DGLIBC_INCLUDE_PATH=${absolute_libc_include_path}"
               "-DGLIBC_ARCH_INCLUDE_PATH=${absolute_libc_arch_include_path}")
 
diff --git a/swift/stdlib/public/Platform/bionic.modulemap.gyb b/swift/stdlib/public/Platform/bionic.modulemap.gyb
index e44f9082653..09a92df50bb 100644
--- a/swift/stdlib/public/Platform/bionic.modulemap.gyb
+++ b/swift/stdlib/public/Platform/bionic.modulemap.gyb
@@ -185,7 +185,7 @@ module SwiftGlibc [system] {
       export *
     }
     module spawn {
-      header "${GLIBC_INCLUDE_PATH}/spawn.h"
+      header "${SDK_INCLUDE_PATH}/spawn.h"
       export *
     }
     module syslog {
diff --git a/swift-corelibs-foundation/Sources/Foundation/CMakeLists.txt b/swift-corelibs-foundation/Sources/Foundation/CMakeLists.txt
index 016bf294..1473f4dc 100644
--- a/swift-corelibs-foundation/Sources/Foundation/CMakeLists.txt
+++ b/swift-corelibs-foundation/Sources/Foundation/CMakeLists.txt
@@ -167,6 +167,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
     $<TARGET_OBJECTS:CoreFoundationResources>)
 elseif(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_options(Foundation PRIVATE "SHELL:-no-toolchain-stdlib-rpath")
+  if(CMAKE_SYSTEM_NAME STREQUAL Android)
+    target_link_libraries(Foundation PRIVATE android-spawn)
+    target_link_directories(Foundation PUBLIC ${CMAKE_FIND_ROOT_PATH}/usr/lib)
+  endif()
 endif()
 
 
```
Alternatively, since the build only fails when linking `plutil` against `libFoundation.a` and we can't run the tests for the cross-compiled corelibs, we could hack out building a static `plutil` or revert the small pull adding that dependency, as done in vgorloff/swift-everywhere-toolchain#116.

@drodriguez, let me know what you think.