### PR TITLE
Gate async-main behind experimental flag

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -286,6 +286,9 @@ namespace swift {
     /// Enable experimental concurrency model.
     bool EnableExperimentalConcurrency = false;
 
+    /// Enable experimental async main.
+    bool EnableExperimentalAsyncMain = false;
+
     /// Enable experimental support for additional opaque return type features,
     /// i.e. named opaque return types (with 'where' clause support), and opaque
     /// types in nested position within the function return type.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -441,6 +441,10 @@ def enable_experimental_opaque_return_types :
   Flag<["-"], "enable-experimental-opaque-return-types">,
   HelpText<"Enable experimental extensions to opaque return type support">;
 
+def enable_experimental_async_main :
+  Flag<["-"], "enable-experimental-async-main">,
+  HelpText<"Enable experimental extension for asynchronous main function">;
+
 def enable_deserialization_recovery :
   Flag<["-"], "enable-deserialization-recovery">,
   HelpText<"Attempt to recover from missing xrefs (etc) in swiftmodules">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -422,6 +422,10 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalConcurrency |=
     Args.hasArg(OPT_enable_experimental_concurrency);
 
+  Opts.EnableExperimentalAsyncMain |=
+      Args.hasArg(OPT_enable_experimental_async_main) |
+      Args.hasArg(OPT_enable_experimental_concurrency);
+
   Opts.EnableExperimentalOpaqueReturnTypes |=
       Args.hasArg(OPT_enable_experimental_opaque_return_types);
 

--- a/test/Concurrency/Runtime/effectful_properties.swift
+++ b/test/Concurrency/Runtime/effectful_properties.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-parse-as-library %import-libdispatch) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-async-main -parse-as-library %import-libdispatch) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/IRGen/async/run-call-resilient-protocolinstance-void-to-void.swift
+++ b/test/IRGen/async/run-call-resilient-protocolinstance-void-to-void.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -Xfrontend -enable-experimental-async-main -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
 // RUN: %target-codesign %t/%target-library-name(PrintShims)
 // RUN: %target-build-swift-dylib(%t/%target-library-name(ResilientProtocol)) %S/Inputs/protocol-1instance-void_to_void.swift -Xfrontend -enable-experimental-concurrency -g -module-name ResilientProtocol -emit-module -emit-module-path %t/ResilientProtocol.swiftmodule
 // RUN: %target-codesign %t/%target-library-name(ResilientProtocol)

--- a/test/Interpreter/async_resilience.swift
+++ b/test/Interpreter/async_resilience.swift
@@ -1,13 +1,13 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_async)) -enable-library-evolution %S/Inputs/resilient_async.swift -emit-module -emit-module-path %t/resilient_async.swiftmodule -module-name resilient_async
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_async)) -Xfrontend -enable-experimental-async-main -enable-library-evolution %S/Inputs/resilient_async.swift -emit-module -emit-module-path %t/resilient_async.swiftmodule -module-name resilient_async
 // RUN: %target-codesign %t/%target-library-name(resilient_async)
 
-// RUN: %target-build-swift -parse-as-library %s -lresilient_async -I %t -L %t -o %t/main %target-rpath(%t)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-async-main -parse-as-library %s -lresilient_async -I %t -L %t -o %t/main %target-rpath(%t)
 // RUN: %target-codesign %t/main
 
 // Introduce a defaulted protocol method.
-// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_async)) -enable-library-evolution %S/Inputs/resilient_async2.swift -emit-module -emit-module-path %t/resilient_async.swiftmodule -module-name resilient_async
+// RUN: %target-build-swift-dylib(%t/%target-library-name(resilient_async)) -Xfrontend -enable-experimental-async-main -enable-library-evolution %S/Inputs/resilient_async2.swift -emit-module -emit-module-path %t/resilient_async.swiftmodule -module-name resilient_async
 // RUN: %target-codesign %t/%target-library-name(resilient_async)
 
 // RUN: %target-run %t/main %t/%target-library-name(resilient_async)


### PR DESCRIPTION
The behavior of async main hasn't gone through the evolution process yet and isn't really what we want for a few reasons. I had thrown something down that had been gated on `enable-experimental-concurrency` a while ago, but it seems to have come out from behind that flag.

You can use the async main with the `-enable-experimental-concurrency` flag or, `-enable-experimental-async-main`.

For clarity, when I refer to async-main, I mean the following structure:
```swift
@main struct Main {
  static func main() async { 
    // ...
  }
}
```

rdar://80696842