### PR TITLE
[5.5][build] explicitly set OSX_ARCHITECTURES for targets in stdlib

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -2035,6 +2035,16 @@ function(add_swift_target_library name)
           list(APPEND THIN_INPUT_TARGETS ${VARIANT_NAME})
         endif()
       endif()
+
+      if(sdk IN_LIST SWIFT_APPLE_PLATFORMS)
+        # In the past, we relied on unsetting globally
+        # CMAKE_OSX_ARCHITECTURES to ensure that CMake would
+        # not add the -arch flag
+        # This is no longer the case when running on Apple Silicon,
+        # when CMake will enforce a default (see
+        # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5291)
+        set_property(TARGET ${VARIANT_NAME} PROPERTY OSX_ARCHITECTURES "${arch}")
+      endif()
     endforeach()
 
     # Configure module-only targets
@@ -2473,6 +2483,14 @@ function(add_swift_target_executable name)
       endif()
 
       if(${sdk} IN_LIST SWIFT_APPLE_PLATFORMS)
+        # In the past, we relied on unsetting globally
+        # CMAKE_OSX_ARCHITECTURES to ensure that CMake would
+        # not add the -arch flag
+        # This is no longer the case when running on Apple Silicon,
+        # when CMake will enforce a default (see
+        # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5291)
+        set_property(TARGET ${VARIANT_NAME} PROPERTY OSX_ARCHITECTURES "${arch}")
+
         add_custom_command_target(unused_var2
          COMMAND "codesign" "-f" "-s" "-" "${SWIFT_RUNTIME_OUTPUT_INTDIR}/${VARIANT_NAME}"
          CUSTOM_TARGET_NAME "${VARIANT_NAME}_signed"


### PR DESCRIPTION
Our custom build code already sets the architecture of compilation
commands by different means, and so far we were relying on setting
`CMAKE_OSX_ARCHITECTURES` to an empty value to avoid CMake doing the
same.

However, on Apple Silicon, CMake 3.19+ enforces a default value in this
scenario
(https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5291/diffs),
and this would result in the inability to compile code for x86_64.

Cherry-pick of #38415, #38444

Addresses SR-14035, rdar://80699579