### PR TITLE
[5.5][runtime] Improve detection of memory allocation failures

### DIFF
--- a/include/swift/Basic/Malloc.h
+++ b/include/swift/Basic/Malloc.h
@@ -34,11 +34,11 @@ inline void *AlignedAlloc(size_t size, size_t align) {
   if (align < sizeof(void*))
     align = sizeof(void*);
   
-  void *r;
 #if defined(_WIN32)
-  r = _aligned_malloc(size, align);
+  void *r = _aligned_malloc(size, align);
   assert(r && "_aligned_malloc failed");
 #else
+  void *r = nullptr;
   int res = posix_memalign(&r, align, size);
   assert(res == 0 && "posix_memalign failed");
   (void)res; // Silence the unused variable warning.

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -263,15 +263,21 @@ extension Unsafe${Mutable}RawBufferPointer: RandomAccessCollection { }
 
 extension Unsafe${Mutable}RawBufferPointer {
 %  if mutable:
-  /// Returns a newly allocated buffer with the given size, in bytes.
+  /// Allocates uninitialized memory with the specified size and alignment.
   ///
-  /// The memory referenced by the new buffer is allocated, but not
-  /// initialized.
+  /// You are in charge of managing the allocated memory. Be sure to deallocate
+  /// any memory that you manually allocate.
+  ///
+  /// The allocated memory is not bound to any specific type and must be bound
+  /// before performing any typed operations. If you are using the memory for
+  /// a specific type, allocate memory using the
+  /// `UnsafeMutablePointerBuffer.allocate(capacity:)` static method instead.
   ///
   /// - Parameters:
-  ///   - byteCount: The number of bytes to allocate.
+  ///   - byteCount: The number of bytes to allocate. `byteCount` must not be
+  ///     negative.
   ///   - alignment: The alignment of the new region of allocated memory, in
-  ///     bytes.
+  ///     bytes. `alignment` must be a whole power of 2.
   /// - Returns: A buffer pointer to a newly allocated region of memory aligned 
   ///     to `alignment`.
   @inlinable

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -600,7 +600,7 @@ public struct UnsafeMutableRawPointer: _Pointer, Sendable {
   /// - Parameters:
   ///   - byteCount: The number of bytes to allocate. `byteCount` must not be negative.
   ///   - alignment: The alignment of the new region of allocated memory, in
-  ///     bytes.
+  ///     bytes. `alignment` must be a whole power of 2.
   /// - Returns: A pointer to a newly allocated region of memory. The memory is
   ///   allocated, but not initialized.
   @inlinable

--- a/test/stdlib/UnsafeRawPointer.swift
+++ b/test/stdlib/UnsafeRawPointer.swift
@@ -229,4 +229,18 @@ UnsafeMutableRawPointerExtraTestSuite.test("moveInitialize:from:") {
   check(Check.RightOverlap)
 }
 
+UnsafeMutableRawPointerExtraTestSuite.test("absurd.allocation.misaligned") {
+  expectCrashLater()
+  let mustFail = UnsafeMutableRawPointer.allocate(byteCount: 1024,
+                                                  alignment: 19)
+  expectUnreachable()
+}
+
+UnsafeMutableRawPointerExtraTestSuite.test("absurd.allocation.gargantuan") {
+  expectCrashLater()
+  let mustFail = UnsafeMutableRawPointer.allocate(byteCount: 400000000000000000,
+                                                  alignment: 0)
+  expectUnreachable()
+}
+
 runAllTests()

--- a/test/stdlib/UnsafeRawPointer.swift
+++ b/test/stdlib/UnsafeRawPointer.swift
@@ -238,7 +238,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("absurd.allocation.misaligned") {
 
 UnsafeMutableRawPointerExtraTestSuite.test("absurd.allocation.gargantuan") {
   expectCrashLater()
-  let mustFail = UnsafeMutableRawPointer.allocate(byteCount: 400000000000000000,
+  let mustFail = UnsafeMutableRawPointer.allocate(byteCount: Int.max,
                                                   alignment: 0)
   expectUnreachable()
 }


### PR DESCRIPTION
- `posix_memalign` doesn't write to its pointer-to-pointer parameter when it fails, so `AlignedAlloc` ended up returning stack detritus in that case. The variable is now properly initialized in order to avoid that.

- update documentation of `UMRP.allocate()` to specify the requirement for powers-of-2 alignment.
- update documentation fo `UMRBP.allocate()` to be as good as `UMRP`'s version.

Resolves rdar://80504684 and rdar://79314903
Cherry-picked from https://github.com/apple/swift/pull/38424