### PR TITLE
[CodeCompletion] Annotate override completions

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -86,6 +86,20 @@ enum class PrintStructureKind {
   TupleElement,
   NumberLiteral,
   StringLiteral,
+  /// ' = defaultValue'.
+  DefaultArgumentClause,
+  /// '<T, U: Requirement>'.
+  DeclGenericParameterClause,
+  /// 'where T: Collection, T.Element: Equtable'.
+  DeclGenericRequirementClause,
+  /// ' async throws'.
+  EffectsSpecifiers,
+  /// ' -> ResultTy' or ': ResultTy'.
+  DeclResultTypeClause,
+  /// '(a: Int, b param: String)' in function declarations.
+  FunctionParameterList,
+  /// '@attribute ParamTy...' in parameter declarations.
+  FunctionParameterType,
 };
 
 /// An abstract class used to print an AST.

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -132,6 +132,14 @@ public:
     Equal,
     Whitespace,
 
+    /// The first chunk of a whole generic parameter clause.
+    /// E.g '<T, C: Collection>'
+    GenericParameterClauseBegin,
+
+    /// The first chunk of a generic quirement clause.
+    /// E.g. 'where T: Collection, T.Element == Int'
+    GenericRequirementClauseBegin,
+
     /// The first chunk of a substring that describes the parameter for a
     /// generic type.
     GenericParameterBegin,
@@ -194,6 +202,30 @@ public:
     /// desired.
     OptionalMethodCallTail,
 
+    /// The first chunk of a substring that describes the single parameter
+    /// declaration for a parameter clause.
+    ParameterDeclBegin,
+
+    ParameterDeclExternalName,
+
+    ParameterDeclLocalName,
+
+    ParameterDeclColon,
+
+    ParameterDeclTypeBegin,
+
+    /// Default argument clause for parameter declarations.
+    DefaultArgumentClauseBegin,
+
+    /// First chunk for effect specifiers. i.e. 'async' and 'throws'.
+    EffectsSpecifierClauseBegin,
+
+    /// First chunk for result type clause i.e. ' -> ResultTy' or ': ResultTy'.
+    DeclResultTypeClauseBegin,
+
+    /// First chunk for attribute and modifier list i.e. 'override public'
+    AttributeAndModifierListBegin,
+
     /// Specifies the type of the whole entity that is returned in this code
     /// completion result.  For example, for variable references it is the
     /// variable type, for function calls it is the return type.
@@ -219,7 +251,15 @@ public:
            Kind == ChunkKind::GenericParameterBegin ||
            Kind == ChunkKind::OptionalBegin ||
            Kind == ChunkKind::CallArgumentTypeBegin ||
-           Kind == ChunkKind::TypeAnnotationBegin;
+           Kind == ChunkKind::TypeAnnotationBegin ||
+           Kind == ChunkKind::ParameterDeclBegin ||
+           Kind == ChunkKind::ParameterDeclTypeBegin ||
+           Kind == ChunkKind::DefaultArgumentClauseBegin ||
+           Kind == ChunkKind::GenericParameterClauseBegin ||
+           Kind == ChunkKind::EffectsSpecifierClauseBegin ||
+           Kind == ChunkKind::DeclResultTypeClauseBegin ||
+           Kind == ChunkKind::GenericRequirementClauseBegin ||
+           Kind == ChunkKind::AttributeAndModifierListBegin;
   }
 
   static bool chunkHasText(ChunkKind Kind) {
@@ -249,11 +289,14 @@ public:
            Kind == ChunkKind::CallArgumentName ||
            Kind == ChunkKind::CallArgumentInternalName ||
            Kind == ChunkKind::CallArgumentColon ||
-           Kind == ChunkKind::DeclAttrParamColon ||
-           Kind == ChunkKind::DeclAttrParamKeyword ||
            Kind == ChunkKind::CallArgumentType ||
            Kind == ChunkKind::CallArgumentClosureType ||
            Kind == ChunkKind::CallArgumentClosureExpr ||
+           Kind == ChunkKind::ParameterDeclExternalName ||
+           Kind == ChunkKind::ParameterDeclLocalName ||
+           Kind == ChunkKind::ParameterDeclColon ||
+           Kind == ChunkKind::DeclAttrParamColon ||
+           Kind == ChunkKind::DeclAttrParamKeyword ||
            Kind == ChunkKind::GenericParameterName ||
            Kind == ChunkKind::DynamicLookupMethodCallTail ||
            Kind == ChunkKind::OptionalMethodCallTail ||
@@ -1062,6 +1105,7 @@ class PrintingCodeCompletionConsumer
   llvm::raw_ostream &OS;
   bool IncludeKeywords;
   bool IncludeComments;
+  bool IncludeSourceText;
   bool PrintAnnotatedDescription;
   bool RequiresSourceFileInfo = false;
 
@@ -1069,10 +1113,12 @@ public:
  PrintingCodeCompletionConsumer(llvm::raw_ostream &OS,
                                 bool IncludeKeywords = true,
                                 bool IncludeComments = true,
+                                bool IncludeSourceText = false,
                                 bool PrintAnnotatedDescription = false)
      : OS(OS),
        IncludeKeywords(IncludeKeywords),
        IncludeComments(IncludeComments),
+       IncludeSourceText(IncludeSourceText),
        PrintAnnotatedDescription(PrintAnnotatedDescription) {}
 
   void handleResults(CodeCompletionContext &context) override;

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -375,13 +375,15 @@ CodeCompletionString *CodeCompletionString::create(llvm::BumpPtrAllocator &Alloc
 }
 
 void CodeCompletionString::print(raw_ostream &OS) const {
+
   unsigned PrevNestingLevel = 0;
+  SmallVector<StringRef, 3> closeTags;
+
   auto chunks = getChunks();
   for (auto I = chunks.begin(), E = chunks.end(); I != E; ++I) {
-    bool AnnotatedTextChunk = false;
-
-    if (I->getNestingLevel() < PrevNestingLevel) {
-      OS << "#}";
+    while (I->endsPreviousNestedGroup(PrevNestingLevel)) {
+      OS << closeTags.pop_back_val();
+      --PrevNestingLevel;
     }
     switch (I->getKind()) {
     using ChunkKind = Chunk::ChunkKind;
@@ -411,57 +413,53 @@ void CodeCompletionString::print(raw_ostream &OS) const {
     case ChunkKind::BaseName:
     case ChunkKind::TypeIdSystem:
     case ChunkKind::TypeIdUser:
-      AnnotatedTextChunk = I->isAnnotation();
-      LLVM_FALLTHROUGH;
     case ChunkKind::CallArgumentName:
-    case ChunkKind::CallArgumentInternalName:
     case ChunkKind::CallArgumentColon:
-    case ChunkKind::DeclAttrParamColon:
     case ChunkKind::CallArgumentType:
-    case ChunkKind::CallArgumentClosureType:
+    case ChunkKind::ParameterDeclExternalName:
+    case ChunkKind::ParameterDeclLocalName:
+    case ChunkKind::ParameterDeclColon:
+    case ChunkKind::DeclAttrParamColon:
     case ChunkKind::GenericParameterName:
-      if (AnnotatedTextChunk)
-        OS << "['";
-      else if (I->getKind() == ChunkKind::CallArgumentInternalName)
-        OS << "(";
-      else if (I->getKind() == ChunkKind::CallArgumentClosureType)
-        OS << "##";
-      for (char Ch : I->getText()) {
-        if (Ch == '\n')
-          OS << "\\n";
-        else
-          OS << Ch;
-      }
-      if (AnnotatedTextChunk)
-        OS << "']";
-      else if (I->getKind() == ChunkKind::CallArgumentInternalName)
-        OS << ")";
+      if (I->isAnnotation())
+        OS << "['" << I->getText() << "']";
+      else
+        OS << I->getText();
+      break;
+    case ChunkKind::CallArgumentInternalName:
+      OS << "(" << I->getText() << ")";
+      break;
+    case ChunkKind::CallArgumentClosureType:
+      OS << "##" << I->getText();
       break;
     case ChunkKind::OptionalBegin:
     case ChunkKind::CallArgumentBegin:
-    case ChunkKind::CallArgumentTypeBegin:
     case ChunkKind::GenericParameterBegin:
       OS << "{#";
+      closeTags.emplace_back("#}");
       break;
     case ChunkKind::DynamicLookupMethodCallTail:
     case ChunkKind::OptionalMethodCallTail:
       OS << I->getText();
       break;
-    case ChunkKind::TypeAnnotationBegin: {
+    case ChunkKind::GenericParameterClauseBegin:
+    case ChunkKind::GenericRequirementClauseBegin:
+    case ChunkKind::CallArgumentTypeBegin:
+    case ChunkKind::DefaultArgumentClauseBegin:
+    case ChunkKind::ParameterDeclBegin:
+    case ChunkKind::EffectsSpecifierClauseBegin:
+    case ChunkKind::DeclResultTypeClauseBegin:
+    case ChunkKind::ParameterDeclTypeBegin:
+    case ChunkKind::AttributeAndModifierListBegin:
+      assert(I->getNestingLevel() == PrevNestingLevel + 1);
+      closeTags.emplace_back("");
+      break;
+    case ChunkKind::TypeAnnotationBegin:
       OS << "[#";
-      ++I;
-      auto level = I->getNestingLevel();
-      for (; I != E && !I->endsPreviousNestedGroup(level); ++I)
-        if (I->hasText())
-          OS << I->getText();
-      --I;
-      OS << "#]";
-      continue;
-    }
+      closeTags.emplace_back("#]");
+      break;
     case ChunkKind::TypeAnnotation:
-      OS << "[#";
-      OS << I->getText();
-      OS << "#]";
+      OS << "[#" << I->getText() << "#]";
       break;
     case ChunkKind::CallArgumentClosureExpr:
       OS << " {" << I->getText() << "|}";
@@ -473,13 +471,89 @@ void CodeCompletionString::print(raw_ostream &OS) const {
     PrevNestingLevel = I->getNestingLevel();
   }
   while (PrevNestingLevel > 0) {
-    OS << "#}";
+    OS << closeTags.pop_back_val();
     --PrevNestingLevel;
   }
+
+  assert(closeTags.empty());
 }
 
 void CodeCompletionString::dump() const {
-  print(llvm::errs());
+  llvm::raw_ostream &OS = llvm::errs();
+
+  OS << "Chunks: \n";
+  for (auto &chunk : getChunks()) {
+    OS << "- ";
+    for (unsigned i = 0, e = chunk.getNestingLevel(); i != e; ++i)
+      OS << "| ";
+    OS << "(";
+
+    switch (chunk.getKind()) {
+#define CASE(K) case Chunk::ChunkKind::K: OS << #K; break;
+    CASE(AccessControlKeyword)
+    CASE(DeclAttrKeyword)
+    CASE(DeclAttrParamKeyword)
+    CASE(OverrideKeyword)
+    CASE(EffectsSpecifierKeyword)
+    CASE(DeclIntroducer)
+    CASE(Keyword)
+    CASE(Attribute)
+    CASE(Text)
+    CASE(BaseName)
+    CASE(OptionalBegin)
+    CASE(LeftParen)
+    CASE(RightParen)
+    CASE(LeftBracket)
+    CASE(RightBracket)
+    CASE(LeftAngle)
+    CASE(RightAngle)
+    CASE(Dot)
+    CASE(Ellipsis)
+    CASE(Comma)
+    CASE(ExclamationMark)
+    CASE(QuestionMark)
+    CASE(Ampersand)
+    CASE(Equal)
+    CASE(Whitespace)
+    CASE(GenericParameterClauseBegin)
+    CASE(GenericRequirementClauseBegin)
+    CASE(GenericParameterBegin)
+    CASE(GenericParameterName)
+    CASE(CallArgumentBegin)
+    CASE(CallArgumentName)
+    CASE(CallArgumentInternalName)
+    CASE(CallArgumentColon)
+    CASE(DeclAttrParamColon)
+    CASE(CallArgumentType)
+    CASE(CallArgumentTypeBegin)
+    CASE(TypeIdSystem)
+    CASE(TypeIdUser)
+    CASE(CallArgumentClosureType)
+    CASE(CallArgumentClosureExpr)
+    CASE(DynamicLookupMethodCallTail)
+    CASE(OptionalMethodCallTail)
+    CASE(ParameterDeclBegin)
+    CASE(ParameterDeclExternalName)
+    CASE(ParameterDeclLocalName)
+    CASE(ParameterDeclColon)
+    CASE(ParameterDeclTypeBegin)
+    CASE(DefaultArgumentClauseBegin)
+    CASE(EffectsSpecifierClauseBegin)
+    CASE(DeclResultTypeClauseBegin)
+    CASE(AttributeAndModifierListBegin)
+    CASE(TypeAnnotation)
+    CASE(TypeAnnotationBegin)
+    CASE(BraceStmtWithCursor)
+    }
+    if (chunk.isAnnotation())
+      OS << " [annotation]";
+    if (chunk.hasText()) {
+      OS << " \"";
+      OS.write_escaped(chunk.getText());
+      OS << "\"";
+    }
+    OS << ")\n";
+  }
 }
 
 CodeCompletionDeclKind
@@ -863,22 +937,104 @@ void CodeCompletionResultBuilder::setAssociatedDecl(const Decl *D) {
 }
 
 namespace {
-class AnnotatedTypePrinter : public ASTPrinter {
+
+/// 'ASTPrinter' printing to 'CodeCompletionString' with appropriate ChunkKind.
+/// This is mainly used for printing types and override completions.
+class CodeCompletionStringPrinter : public ASTPrinter {
+protected:
   using ChunkKind = CodeCompletionString::Chunk::ChunkKind;
+
+private:
   CodeCompletionResultBuilder &Builder;
   SmallString<16> Buffer;
   ChunkKind CurrChunkKind = ChunkKind::Text;
   ChunkKind NextChunkKind = ChunkKind::Text;
+  SmallVector<PrintStructureKind, 2> StructureStack;
+  unsigned int TypeDepth = 0;
+  bool InPreamble = false;
 
-  Optional<ChunkKind> getChunkKindForPrintNameContext(PrintNameContext context) {
+  bool isCurrentStructureKind(PrintStructureKind Kind) const {
+    return !StructureStack.empty() && StructureStack.back() == Kind;
+  }
+
+  bool isInType() const {
+    return TypeDepth > 0;
+  }
+
+  Optional<ChunkKind>
+  getChunkKindForPrintNameContext(PrintNameContext context) const {
     switch (context) {
     case PrintNameContext::Keyword:
+      if(isCurrentStructureKind(PrintStructureKind::EffectsSpecifiers)) {
+        return ChunkKind::EffectsSpecifierKeyword;
+      }
       return ChunkKind::Keyword;
+    case PrintNameContext::IntroducerKeyword:
+      return ChunkKind::DeclIntroducer;
     case PrintNameContext::Attribute:
       return ChunkKind::Attribute;
+    case PrintNameContext::FunctionParameterExternal:
+      if (isInType()) {
+        return None;
+      }
+      return ChunkKind::ParameterDeclExternalName;
+    case PrintNameContext::FunctionParameterLocal:
+      if (isInType()) {
+        return None;
+      }
+      return ChunkKind::ParameterDeclLocalName;
     default:
       return None;
     }
+  }
+
+  Optional<ChunkKind>
+  getChunkKindForStructureKind(PrintStructureKind Kind) const {
+    switch (Kind) {
+    case PrintStructureKind::FunctionParameter:
+      if (isInType()) {
+        return None;
+      }
+      return ChunkKind::ParameterDeclBegin;
+    case PrintStructureKind::DefaultArgumentClause:
+      return ChunkKind::DefaultArgumentClauseBegin;
+    case PrintStructureKind::DeclGenericParameterClause:
+      return ChunkKind::GenericParameterClauseBegin;
+    case PrintStructureKind::DeclGenericRequirementClause:
+      return ChunkKind::GenericRequirementClauseBegin;
+    case PrintStructureKind::EffectsSpecifiers:
+      return ChunkKind::EffectsSpecifierClauseBegin;
+    case PrintStructureKind::DeclResultTypeClause:
+      return ChunkKind::DeclResultTypeClauseBegin;
+    case PrintStructureKind::FunctionParameterType:
+      return ChunkKind::ParameterDeclTypeBegin;
+    default:
+      return None;
+    }
+  }
+
+  void startNestedGroup(ChunkKind Kind) {
+    flush();
+    Builder.CurrentNestingLevel++;
+    Builder.addSimpleChunk(Kind);
+  }
+
+  void endNestedGroup() {
+    flush();
+    Builder.CurrentNestingLevel--;
+  }
+
+protected:
+  void setNextChunkKind(ChunkKind Kind) {
+    NextChunkKind = Kind;
+  }
+
+public:
+  CodeCompletionStringPrinter(CodeCompletionResultBuilder &Builder) : Builder(Builder) {}
+
+  ~CodeCompletionStringPrinter() {
+    // Flush the remainings.
+    flush();
   }
 
   void flush() {
@@ -888,15 +1044,38 @@ class AnnotatedTypePrinter : public ASTPrinter {
     Buffer.clear();
   }
 
-public:
-  AnnotatedTypePrinter(CodeCompletionResultBuilder &Builder) : Builder(Builder) {}
-
-  ~AnnotatedTypePrinter() {
-    // Flush the remainings.
-    flush();
+  /// Start \c AttributeAndModifierListBegin group. This must be called before
+  /// any attributes/modifiers printed to the output when printing an override
+  /// compleion.
+  void startPreamble() {
+    assert(!InPreamble);
+    startNestedGroup(ChunkKind::AttributeAndModifierListBegin);
+    InPreamble = true;
   }
 
+  /// End the current \c AttributeAndModifierListBegin group if it's still open.
+  /// This is automatically called before the main part of the signature.
+  void endPremable() {
+    if (!InPreamble)
+      return;
+    InPreamble = false;
+    endNestedGroup();
+  }
+
+  /// Implement \c ASTPrinter .
+public:
   void printText(StringRef Text) override {
+    // Detect ': ' and ', ' in parameter clauses.
+    // FIXME: Is there a better way?
+    if (isCurrentStructureKind(PrintStructureKind::FunctionParameter) &&
+        Text == ": ") {
+      setNextChunkKind(ChunkKind::ParameterDeclColon);
+    } else if (
+        isCurrentStructureKind(PrintStructureKind::FunctionParameterList) &&
+        Text == ", ") {
+      setNextChunkKind(ChunkKind::Comma);
+    }
+
     if (CurrChunkKind != NextChunkKind) {
       // If the next desired kind is different from the current buffer, flush
       // the current buffer.
@@ -918,14 +1097,49 @@ public:
     NextChunkKind = ChunkKind::Text;
   }
 
+  void printDeclLoc(const Decl *D) override {
+    endPremable();
+    setNextChunkKind(ChunkKind::BaseName);
+  }
+
+  void printDeclNameEndLoc(const Decl *D) override {
+    setNextChunkKind(ChunkKind::Text);
+  }
+
   void printNamePre(PrintNameContext context) override {
+    if (context == PrintNameContext::IntroducerKeyword)
+      endPremable();
     if (auto Kind = getChunkKindForPrintNameContext(context))
-      NextChunkKind = *Kind;
+      setNextChunkKind(*Kind);
   }
 
   void printNamePost(PrintNameContext context) override {
-    if (auto Kind = getChunkKindForPrintNameContext(context))
-      NextChunkKind = ChunkKind::Text;
+    if (getChunkKindForPrintNameContext(context))
+      setNextChunkKind(ChunkKind::Text);
+  }
+
+  void printTypePre(const TypeLoc &TL) override {
+    ++TypeDepth;
+  }
+
+  void printTypePost(const TypeLoc &TL) override {
+    assert(TypeDepth > 0);
+    --TypeDepth;
+  }
+
+  void printStructurePre(PrintStructureKind Kind, const Decl *D) override {
+    StructureStack.push_back(Kind);
+
+    if (auto chunkKind = getChunkKindForStructureKind(Kind))
+      startNestedGroup(*chunkKind);
+  }
+
+  void printStructurePost(PrintStructureKind Kind, const Decl *D) override {
+    if (getChunkKindForStructureKind(Kind))
+      endNestedGroup();
+
+    assert(Kind == StructureStack.back());
+    StructureStack.pop_back();
   }
 };
 } // namespcae
@@ -1015,8 +1229,11 @@ void CodeCompletionResultBuilder::addCallArgument(
     PO.setBaseType(ContextTy);
   if (shouldAnnotateResults()) {
     withNestedGroup(ChunkKind::CallArgumentTypeBegin, [&]() {
-      AnnotatedTypePrinter printer(*this);
+      CodeCompletionStringPrinter printer(*this);
+      auto TL = TypeLoc::withoutLoc(Ty);
+      printer.printTypePre(TL);
       Ty->print(printer, PO);
+      printer.printTypePost(TL);
     });
   } else {
     std::string TypeName = Ty->getString(PO);
@@ -1027,8 +1244,8 @@ void CodeCompletionResultBuilder::addCallArgument(
   // function type.
   Ty = Ty->lookThroughAllOptionalTypes();
   if (auto AFT = Ty->getAs<AnyFunctionType>()) {
-    // If this is a closure type, add ChunkKind::CallParameterClosureType or
-    // ChunkKind::CallParameterClosureExpr for labeled trailing closures.
+    // If this is a closure type, add ChunkKind::CallArgumentClosureType or
+    // ChunkKind::CallArgumentClosureExpr for labeled trailing closures.
     PrintOptions PO;
     PO.PrintFunctionRepresentationAttrs =
       PrintOptions::FunctionRepresentationMode::None;
@@ -1095,8 +1312,11 @@ void CodeCompletionResultBuilder::addTypeAnnotation(Type T, PrintOptions PO,
   if (shouldAnnotateResults()) {
     withNestedGroup(CodeCompletionString::Chunk::ChunkKind::TypeAnnotationBegin,
                     [&]() {
-                      AnnotatedTypePrinter printer(*this);
+                      CodeCompletionStringPrinter printer(*this);
+                      auto TL = TypeLoc::withoutLoc(T);
+                      printer.printTypePre(TL);
                       T->print(printer, PO);
+                      printer.printTypePost(TL);
                       if (!suffix.empty())
                         printer.printText(suffix);
                     });
@@ -1391,12 +1611,21 @@ MutableArrayRef<CodeCompletionResult *> CodeCompletionContext::takeResults() {
 Optional<unsigned> CodeCompletionString::getFirstTextChunkIndex(
     bool includeLeadingPunctuation) const {
   for (auto i : indices(getChunks())) {
-    auto &C = getChunks()[i];
+    const Chunk &C = getChunks()[i];
     switch (C.getKind()) {
     using ChunkKind = Chunk::ChunkKind;
     case ChunkKind::Text:
+      // Skip white-space only chunks.
+      if (C.getText().find_first_not_of(" \r\n") == StringRef::npos)
+        continue;
+      return i;
     case ChunkKind::CallArgumentName:
     case ChunkKind::CallArgumentInternalName:
+    case ChunkKind::ParameterDeclExternalName:
+    case ChunkKind::ParameterDeclLocalName:
+    case ChunkKind::ParameterDeclColon:
+    case ChunkKind::GenericParameterClauseBegin:
+    case ChunkKind::GenericRequirementClauseBegin:
     case ChunkKind::GenericParameterName:
     case ChunkKind::LeftParen:
     case ChunkKind::LeftBracket:
@@ -1409,6 +1638,11 @@ Optional<unsigned> CodeCompletionString::getFirstTextChunkIndex(
     case ChunkKind::TypeIdSystem:
     case ChunkKind::TypeIdUser:
     case ChunkKind::CallArgumentBegin:
+    case ChunkKind::DefaultArgumentClauseBegin:
+    case ChunkKind::ParameterDeclBegin:
+    case ChunkKind::EffectsSpecifierClauseBegin:
+    case ChunkKind::DeclResultTypeClauseBegin:
+    case ChunkKind::AttributeAndModifierListBegin:
       return i;
     case ChunkKind::Dot:
     case ChunkKind::ExclamationMark:
@@ -1430,10 +1664,11 @@ Optional<unsigned> CodeCompletionString::getFirstTextChunkIndex(
     case ChunkKind::DeclIntroducer:
     case ChunkKind::CallArgumentColon:
     case ChunkKind::CallArgumentTypeBegin:
-    case ChunkKind::DeclAttrParamColon:
     case ChunkKind::CallArgumentType:
     case ChunkKind::CallArgumentClosureType:
     case ChunkKind::CallArgumentClosureExpr:
+    case ChunkKind::ParameterDeclTypeBegin:
+    case ChunkKind::DeclAttrParamColon:
     case ChunkKind::OptionalBegin:
     case ChunkKind::GenericParameterBegin:
     case ChunkKind::DynamicLookupMethodCallTail:
@@ -3251,7 +3486,9 @@ public:
       if (Builder.shouldAnnotateResults()) {
         Builder.withNestedGroup(
             CodeCompletionString::Chunk::ChunkKind::TypeAnnotationBegin, [&] {
-              AnnotatedTypePrinter printer(Builder);
+              CodeCompletionStringPrinter printer(Builder);
+              auto TL = TypeLoc::withoutLoc(AnnotationTy);
+              printer.printTypePre(TL);
               if (IsImplicitlyCurriedInstanceMethod) {
                 auto *FnType = AnnotationTy->castTo<AnyFunctionType>();
                 AnyFunctionType::printParams(FnType->getParams(), printer,
@@ -3264,6 +3501,7 @@ public:
               if (AnnotationTy->isVoid())
                 AnnotationTy = Ctx.getVoidDecl()->getDeclaredInterfaceType();
               AnnotationTy.print(printer, PO);
+              printer.printTypePost(TL);
             });
       } else {
         llvm::SmallString<32> TypeStr;
@@ -5154,14 +5392,16 @@ public:
            !CurrDeclContext->getSelfProtocolDecl();
   }
 
-  void addAccessControl(const ValueDecl *VD,
+  /// Add an access modifier (i.e. `public`) to \p Builder is necessary.
+  /// Returns \c true if the modifier is actually added, \c false otherwise.
+  bool addAccessControl(const ValueDecl *VD,
                         CodeCompletionResultBuilder &Builder) {
     auto CurrentNominal = CurrDeclContext->getSelfNominalTypeDecl();
     assert(CurrentNominal);
 
     auto AccessOfContext = CurrentNominal->getFormalAccess();
     if (AccessOfContext < AccessLevel::Public)
-      return;
+      return false;
 
     auto Access = VD->getFormalAccess();
     // Use the greater access between the protocol requirement and the witness.
@@ -5193,8 +5433,11 @@ public:
 
     Access = std::min(Access, AccessOfContext);
     // Only emit 'public', not needed otherwise.
-    if (Access >= AccessLevel::Public)
-      Builder.addAccessControlKeyword(Access);
+    if (Access < AccessLevel::Public)
+      return false;
+
+    Builder.addAccessControlKeyword(Access);
+    return true;
   }
 
   /// Return type if the result type if \p VD should be represented as opaque
@@ -5271,73 +5514,75 @@ public:
                         DynamicLookupInfo dynamicLookupInfo,
                         CodeCompletionResultBuilder &Builder,
                         bool hasDeclIntroducer) {
-    class DeclPrinter : public StreamPrinter {
+    Type opaqueResultType = getOpaqueResultType(VD, Reason, dynamicLookupInfo);
+
+    class DeclPrinter : public CodeCompletionStringPrinter {
       Type OpaqueBaseTy;
 
     public:
-      using StreamPrinter::StreamPrinter;
+      DeclPrinter(CodeCompletionResultBuilder &Builder, Type OpaqueBaseTy)
+          : CodeCompletionStringPrinter(Builder), OpaqueBaseTy(OpaqueBaseTy) { }
 
-      Optional<unsigned> NameOffset;
-
-      DeclPrinter(raw_ostream &OS, Type OpaqueBaseTy)
-          : StreamPrinter(OS), OpaqueBaseTy(OpaqueBaseTy) {}
-
-      void printDeclLoc(const Decl *D) override {
-        if (!NameOffset.hasValue())
-          NameOffset = OS.tell();
-      }
-
-      // As for FuncDecl, SubscriptDecl, and VarDecl,
+      // As for FuncDecl, SubscriptDecl, and VarDecl, substitute the result type
+      // with 'OpaqueBaseTy' if specified.
       void printDeclResultTypePre(ValueDecl *VD, TypeLoc &TL) override {
         if (!OpaqueBaseTy.isNull()) {
-          OS << "some ";
+          setNextChunkKind(ChunkKind::Keyword);
+          printText("some ");
+          setNextChunkKind(ChunkKind::Text);
           TL = TypeLoc::withoutLoc(OpaqueBaseTy);
         }
+        CodeCompletionStringPrinter::printDeclResultTypePre(VD, TL);
       }
     };
 
-    llvm::SmallString<256> DeclStr;
-    unsigned NameOffset = 0;
-    {
-      llvm::raw_svector_ostream OS(DeclStr);
-      DeclPrinter Printer(
-          OS, getOpaqueResultType(VD, Reason, dynamicLookupInfo));
-      PrintOptions Options;
-      if (auto transformType = CurrDeclContext->getDeclaredTypeInContext())
-        Options.setBaseType(transformType);
-      Options.SkipUnderscoredKeywords = true;
-      Options.PrintImplicitAttrs = false;
-      Options.ExclusiveAttrList.push_back(TAK_escaping);
-      Options.ExclusiveAttrList.push_back(TAK_autoclosure);
-      Options.PrintOverrideKeyword = false;
-      Options.PrintPropertyAccessors = false;
-      Options.PrintSubscriptAccessors = false;
-      Options.PrintStaticKeyword = !hasStaticOrClass;
-      VD->print(Printer, Options);
-      NameOffset = Printer.NameOffset.getValue();
+    DeclPrinter Printer(Builder, opaqueResultType);
+    Printer.startPreamble();
+
+    bool modifierAdded = false;
+
+    // 'public' if needed.
+    modifierAdded |= !hasAccessModifier && addAccessControl(VD, Builder);
+
+    // 'override' if needed
+    if (missingOverride(Reason)) {
+      Builder.addOverrideKeyword();
+      modifierAdded |= true;
     }
 
-    if (!hasDeclIntroducer && !hasAccessModifier)
-      addAccessControl(VD, Builder);
-
-    if (missingOverride(Reason)) {
-      if (!hasDeclIntroducer)
-        Builder.addOverrideKeyword();
-      else {
-        auto dist = Ctx.SourceMgr.getByteDistance(
-            introducerLoc, Ctx.SourceMgr.getCodeCompletionLoc());
-        if (dist <= CodeCompletionResult::MaxNumBytesToErase) {
-          Builder.setNumBytesToErase(dist);
-          Builder.addOverrideKeyword();
-          Builder.addDeclIntroducer(DeclStr.str().substr(0, NameOffset));
-        }
+    // Erase existing introducer (e.g. 'func') if any modifiers are added.
+    if (hasDeclIntroducer && modifierAdded) {
+      auto dist = Ctx.SourceMgr.getByteDistance(
+          introducerLoc, Ctx.SourceMgr.getCodeCompletionLoc());
+      if (dist <= CodeCompletionResult::MaxNumBytesToErase) {
+        Builder.setNumBytesToErase(dist);
+        hasDeclIntroducer = false;
       }
     }
 
-    if (!hasDeclIntroducer && NameOffset != 0)
-      Builder.addDeclIntroducer(DeclStr.str().substr(0, NameOffset));
+    PrintOptions PO;
+    if (auto transformType = CurrDeclContext->getDeclaredTypeInContext())
+      PO.setBaseType(transformType);
+    PO.PrintPropertyAccessors = false;
+    PO.PrintSubscriptAccessors = false;
 
-    Builder.addTextChunk(DeclStr.str().substr(NameOffset));
+    PO.SkipUnderscoredKeywords = true;
+    PO.PrintImplicitAttrs = false;
+    PO.ExclusiveAttrList.push_back(TAK_escaping);
+    PO.ExclusiveAttrList.push_back(TAK_autoclosure);
+    // Print certain modifiers only when the introducer is not written.
+    // Otherwise, the user can add it after the completion.
+    if (!hasDeclIntroducer) {
+      PO.ExclusiveAttrList.push_back(DAK_Nonisolated);
+    }
+
+    PO.PrintAccess = false;
+    PO.PrintOverrideKeyword = false;
+    PO.PrintSelfAccessKindKeyword = false;
+
+    PO.PrintStaticKeyword = !hasStaticOrClass && !hasDeclIntroducer;
+    PO.SkipIntroducerKeywords = hasDeclIntroducer;
+    VD->print(Printer, PO);
   }
 
   void addMethodOverride(const FuncDecl *FD, DeclVisibilityKind Reason,
@@ -5390,10 +5635,10 @@ public:
         CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
     Builder.setAssociatedDecl(ATD);
     if (!hasTypealiasIntroducer && !hasAccessModifier)
-      addAccessControl(ATD, Builder);
+      (void)addAccessControl(ATD, Builder);
     if (!hasTypealiasIntroducer)
       Builder.addDeclIntroducer("typealias ");
-    Builder.addTextChunk(ATD->getName().str());
+    Builder.addBaseName(ATD->getName().str());
     Builder.addTextChunk(" = ");
     Builder.addSimpleNamedParameter("Type");
   }
@@ -5408,8 +5653,11 @@ public:
         CodeCompletionResult::ExpectedTypeRelation::NotApplicable);
     Builder.setAssociatedDecl(CD);
 
+    CodeCompletionStringPrinter printer(Builder);
+    printer.startPreamble();
+
     if (!hasAccessModifier)
-      addAccessControl(CD, Builder);
+      (void)addAccessControl(CD, Builder);
 
     if (missingOverride(Reason) && CD->isDesignatedInit() && !CD->isRequired())
       Builder.addOverrideKeyword();
@@ -5433,20 +5681,19 @@ public:
       default: break;
       }
     }
-
-    llvm::SmallString<256> DeclStr;
     if (needRequired)
-      DeclStr += "required ";
+      Builder.addRequiredKeyword();
+
     {
-      llvm::raw_svector_ostream OS(DeclStr);
       PrintOptions Options;
       if (auto transformType = CurrDeclContext->getDeclaredTypeInContext())
         Options.setBaseType(transformType);
       Options.PrintImplicitAttrs = false;
       Options.SkipAttributes = true;
-      CD->print(OS, Options);
+      CD->print(printer, Options);
     }
-    Builder.addTextChunk(DeclStr);
+    printer.flush();
+
     Builder.addBraceStmtWithCursor();
   }
 
@@ -7482,6 +7729,16 @@ void PrintingCodeCompletionConsumer::handleResults(
 
     OS << "; name=";
     printCodeCompletionResultFilterName(*Result, OS);
+
+    if (IncludeSourceText) {
+      OS << "; sourcetext=";
+      SmallString<64> buf;
+      {
+        llvm::raw_svector_ostream bufOS(buf);
+        printCodeCompletionResultSourceText(*Result, bufOS);
+      }
+      OS.write_escaped(buf);
+    }
 
     StringRef comment = Result->getBriefDocComment();
     if (IncludeComments && !comment.empty()) {

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -26,7 +26,7 @@ class Module;
 }
 
 namespace {
-class AnnotatedTypePrinter;
+class CodeCompletionStringPrinter;
 }
 
 namespace swift {
@@ -71,7 +71,7 @@ struct ExpectedTypeContext {
 };
 
 class CodeCompletionResultBuilder {
-  friend AnnotatedTypePrinter;
+  friend CodeCompletionStringPrinter;
   
   CodeCompletionResultSink &Sink;
   CodeCompletionResult::ResultKind Kind;
@@ -193,6 +193,12 @@ public:
           "open ");
       break;
     }
+  }
+
+  void addRequiredKeyword() {
+    addChunkWithTextNoCopy(
+        CodeCompletionString::Chunk::ChunkKind::AccessControlKeyword,
+        "required ");
   }
 
   void addOverrideKeyword() {

--- a/lib/IDE/CodeCompletionResultPrinter.cpp
+++ b/lib/IDE/CodeCompletionResultPrinter.cpp
@@ -21,6 +21,14 @@ using namespace swift;
 using namespace swift::ide;
 
 using ChunkKind = CodeCompletionString::Chunk::ChunkKind;
+using ChunkIter = ArrayRef<CodeCompletionString::Chunk>::iterator;
+
+/// Advance \p i to just the past the group \i currently points.
+void skipToEndOfCurrentNestedGroup(ChunkIter &i, const ChunkIter e) {
+  auto level = i->getNestingLevel();
+  assert(i != e);
+  do { ++i; } while (i != e && !i->endsPreviousNestedGroup(level));
+}
 
 void swift::ide::printCodeCompletionResultDescription(
     const CodeCompletionResult &result,
@@ -33,7 +41,8 @@ void swift::ide::printCodeCompletionResultDescription(
   int TextSize = 0;
   if (FirstTextChunk.hasValue()) {
     auto Chunks = str->getChunks().slice(*FirstTextChunk);
-    for (auto I = Chunks.begin(), E = Chunks.end(); I != E; ++I) {
+    auto I = Chunks.begin(), E = Chunks.end();
+    while (I != E) {
       const auto &C = *I;
 
       using ChunkKind = CodeCompletionString::Chunk::ChunkKind;
@@ -41,23 +50,41 @@ void swift::ide::printCodeCompletionResultDescription(
       if (C.is(ChunkKind::TypeAnnotation) ||
           C.is(ChunkKind::CallArgumentClosureType) ||
           C.is(ChunkKind::CallArgumentClosureExpr) ||
-          C.is(ChunkKind::Whitespace))
-        continue;
-
-      // Skip TypeAnnotation group.
-      if (C.is(ChunkKind::TypeAnnotationBegin)) {
-        auto level = I->getNestingLevel();
-        do { ++I; } while (I != E && !I->endsPreviousNestedGroup(level));
-        --I;
+          C.is(ChunkKind::DeclIntroducer) ||
+          C.is(ChunkKind::Whitespace)) {
+        ++I;
         continue;
       }
 
-      if (isOperator && C.is(ChunkKind::CallArgumentType))
+      // Skip the attribute/modifier list.
+      if (I->is(ChunkKind::AttributeAndModifierListBegin)) {
+        skipToEndOfCurrentNestedGroup(I, E);
         continue;
+      }
+
+      // Skip the declaration introducer and the following ' '.
+      if (I->is(ChunkKind::DeclIntroducer)) {
+        ++I;
+        continue;
+      }
+      if (I->is(ChunkKind::Text) && I->getText() == " " &&
+          I != Chunks.begin() && (I-1)->is(ChunkKind::DeclIntroducer)) {
+        ++I;
+        continue;
+      }
+
+      // Skip TypeAnnotation group.
+      if (C.is(ChunkKind::TypeAnnotationBegin)) {
+        skipToEndOfCurrentNestedGroup(I, E);
+        continue;
+      }
+
+      if (isOperator && C.is(ChunkKind::CallArgumentType)) {
+        ++I;
+        continue;
+      }
       if (isOperator && C.is(ChunkKind::CallArgumentTypeBegin)) {
-        auto level = I->getNestingLevel();
-        do { ++I; } while (I != E && !I->endsPreviousNestedGroup(level));
-        --I;
+        skipToEndOfCurrentNestedGroup(I, E);
         continue;
       }
       
@@ -65,6 +92,7 @@ void swift::ide::printCodeCompletionResultDescription(
         TextSize += C.getText().size();
         OS << C.getText();
       }
+      ++I;
     }
   }
   assert((TextSize > 0) &&
@@ -123,6 +151,12 @@ class AnnotatingResultPrinter {
     case ChunkKind::CallArgumentInternalName:
       printWithTag("callarg.param", C.getText());
       break;
+    case ChunkKind::ParameterDeclExternalName:
+      printWithTag("param.label", C.getText());
+      break;
+    case ChunkKind::ParameterDeclLocalName:
+      printWithTag("param.param", C.getText());
+      break;
     case ChunkKind::TypeAnnotation:
     case ChunkKind::CallArgumentClosureType:
     case ChunkKind::CallArgumentClosureExpr:
@@ -135,29 +169,34 @@ class AnnotatingResultPrinter {
     }
   }
 
-  void printCallArg(ArrayRef<CodeCompletionString::Chunk> chunks) {
-    OS << "<callarg>";
-    for (auto i = chunks.begin(), e = chunks.end(); i != e; ++i) {
-      using ChunkKind = CodeCompletionString::Chunk::ChunkKind;
+  /// Print the current chunk group \p i currently points. Advances \p i to
+  /// just past the group.
+  void printNestedGroup(StringRef tag, ChunkIter &i, const ChunkIter e) {
+    if (!tag.empty())
+      OS << "<" << tag << ">";
 
+    assert(i != e && !i->hasText() &&
+           CodeCompletionString::Chunk::chunkStartsNestedGroup(i->getKind()));
+    auto nestingLevel = i->getNestingLevel();
+
+    // Skip the "Begin" chunk.
+    ++i;
+
+    while (i != e && !i->endsPreviousNestedGroup(nestingLevel)) {
       if (i->is(ChunkKind::CallArgumentTypeBegin)) {
-        OS << "<callarg.type>";
-        auto nestingLevel = i->getNestingLevel();
-        ++i;
-        for (; i != e; ++i) {
-          if (i->endsPreviousNestedGroup(nestingLevel))
-            break;
-          if (i->hasText())
-            printTextChunk(*i);
-        }
-        OS << "</callarg.type>";
-        if (i == e)
-          break;
+        printNestedGroup("callarg.type", i, e);
+        continue;
       }
-
+      if (i->is(ChunkKind::ParameterDeclTypeBegin)) {
+        printNestedGroup("param.type", i, e);
+        continue;
+      }
       printTextChunk(*i);
+      ++i;
     }
-    OS << "</callarg>";
+
+    if (!tag.empty())
+      OS << "</" << tag << ">";
   }
 
 public:
@@ -170,31 +209,55 @@ public:
     auto FirstTextChunk = str->getFirstTextChunkIndex(leadingPunctuation);
     if (FirstTextChunk.hasValue()) {
       auto chunks = str->getChunks().slice(*FirstTextChunk);
-      for (auto i = chunks.begin(), e = chunks.end(); i != e; ++i) {
-        using ChunkKind = CodeCompletionString::Chunk::ChunkKind;
+      auto i = chunks.begin(), e = chunks.end();
+      while (i != e) {
+
+        // Skip the attribute/modifier list.
+        if (i->is(ChunkKind::AttributeAndModifierListBegin)) {
+          skipToEndOfCurrentNestedGroup(i, e);
+          continue;
+        }
+
+        // Skip the declaration introducer and the following ' '.
+        if (i->is(ChunkKind::DeclIntroducer)) {
+          ++i;
+          continue;
+        }
+        if (i->is(ChunkKind::Text) && i->getText() == " " &&
+            i != chunks.begin() && (i-1)->is(ChunkKind::DeclIntroducer)) {
+          ++i;
+          continue;
+        }
 
         // Skip the type annotation.
         if (i->is(ChunkKind::TypeAnnotationBegin)) {
-          auto level = i->getNestingLevel();
-          do { ++i; } while (i != e && !i->endsPreviousNestedGroup(level));
-          --i;
+          skipToEndOfCurrentNestedGroup(i, e);
           continue;
         }
 
         // Print call argument group.
         if (i->is(ChunkKind::CallArgumentBegin)) {
-          auto start = i;
-          auto level = i->getNestingLevel();
-          do { ++i; } while (i != e && !i->endsPreviousNestedGroup(level));
-          if (!isOperator)
-            printCallArg({start, i});
-          --i;
+          if (isOperator) {
+            // Don't print call argument clause for operators.
+            skipToEndOfCurrentNestedGroup(i, e);
+            continue;
+          }
+          printNestedGroup("callarg", i, e);
+          continue;
+        }
+        // Print call argument group.
+        if (i->is(ChunkKind::ParameterDeclBegin)) {
+          printNestedGroup("param", i, e);
           continue;
         }
 
-        if (isOperator && i->is(ChunkKind::CallArgumentType))
+        if (isOperator && i->is(ChunkKind::CallArgumentType)) {
+          ++i;
           continue;
+        }
+
         printTextChunk(*i);
+        ++i;
       }
     }
   }
@@ -202,20 +265,20 @@ public:
   void printTypeName(const CodeCompletionResult &result) {
     auto Chunks = result.getCompletionString()->getChunks();
 
-    for (auto i = Chunks.begin(), e = Chunks.end(); i != e; ++i) {
-
-      if (i->is(CodeCompletionString::Chunk::ChunkKind::TypeAnnotation))
+    auto i = Chunks.begin(), e = Chunks.end();
+    while (i != e) {
+      if (i->is(ChunkKind::TypeAnnotation)) {
         OS << i->getText();
-
-      if (i->is(CodeCompletionString::Chunk::ChunkKind::TypeAnnotationBegin)) {
-        auto nestingLevel = i->getNestingLevel();
         ++i;
-        for (; i != e && !i->endsPreviousNestedGroup(nestingLevel); ++i) {
-          if (i->hasText())
-            printTextChunk(*i);
-        }
-        --i;
+        continue;
       }
+      if (i->is(ChunkKind::TypeAnnotationBegin)) {
+        printNestedGroup("", i, e);
+        continue;
+      }
+
+      // Ignore others.
+      ++i;
     }
   }
 };
@@ -229,25 +292,31 @@ void swift::ide::printCodeCompletionResultDescriptionAnnotated(
   printer.printDescription(Result, leadingPunctuation);
 }
 
-
 void swift::ide::printCodeCompletionResultTypeName(const CodeCompletionResult &Result,
                                                    llvm::raw_ostream &OS) {
   auto Chunks = Result.getCompletionString()->getChunks();
+  auto i = Chunks.begin(), e = Chunks.end();
 
-  for (auto i = Chunks.begin(), e = Chunks.end(); i != e; ++i) {
-
-    if (i->is(CodeCompletionString::Chunk::ChunkKind::TypeAnnotation))
+  while (i != e) {
+    if (i->is(CodeCompletionString::Chunk::ChunkKind::TypeAnnotation)) {
       OS << i->getText();
+      ++i;
+      continue;
+    }
 
     if (i->is(CodeCompletionString::Chunk::ChunkKind::TypeAnnotationBegin)) {
       auto nestingLevel = i->getNestingLevel();
       ++i;
-      for (; i != e && !i->endsPreviousNestedGroup(nestingLevel); ++i) {
+      while (i != e && !i->endsPreviousNestedGroup(nestingLevel)) {
         if (i->hasText())
           OS << i->getText();
+        ++i;
       }
-      --i;
+      continue;
     }
+
+    // Ignore others.
+    ++i;
   }
 }
 
@@ -389,7 +458,8 @@ void swift::ide::printCodeCompletionResultFilterName(
   auto FirstTextChunk = str->getFirstTextChunkIndex();
   if (FirstTextChunk.hasValue()) {
     auto chunks = str->getChunks().slice(*FirstTextChunk);
-    for (auto i = chunks.begin(), e = chunks.end(); i != e; ++i) {
+    auto i = chunks.begin(), e = chunks.end();
+    while (i != e) {
       auto &C = *i;
 
       if (C.is(ChunkKind::BraceStmtWithCursor))
@@ -407,34 +477,53 @@ void swift::ide::printCodeCompletionResultFilterName(
       case ChunkKind::CallArgumentClosureType:
       case ChunkKind::CallArgumentClosureExpr:
       case ChunkKind::CallArgumentType:
+      case ChunkKind::ParameterDeclLocalName:
       case ChunkKind::DeclAttrParamColon:
       case ChunkKind::Comma:
       case ChunkKind::Whitespace:
       case ChunkKind::Ellipsis:
       case ChunkKind::Ampersand:
       case ChunkKind::OptionalMethodCallTail:
+      case ChunkKind::DeclIntroducer:
+        ++i;
         continue;
       case ChunkKind::CallArgumentTypeBegin:
-      case ChunkKind::TypeAnnotationBegin: {
+      case ChunkKind::ParameterDeclTypeBegin:
+      case ChunkKind::TypeAnnotationBegin:
+      case ChunkKind::DefaultArgumentClauseBegin:
+      case ChunkKind::GenericParameterClauseBegin:
+      case ChunkKind::EffectsSpecifierClauseBegin:
+      case ChunkKind::GenericRequirementClauseBegin:
+      case ChunkKind::DeclResultTypeClauseBegin:
+      case ChunkKind::AttributeAndModifierListBegin: {
         // Skip call parameter type or type annotation structure.
-        auto nestingLevel = C.getNestingLevel();
-        do {
-          ++i;
-        } while (i != e && !i->endsPreviousNestedGroup(nestingLevel));
-        --i;
+        skipToEndOfCurrentNestedGroup(i, e);
         continue;
       }
       case ChunkKind::CallArgumentColon:
+      case ChunkKind::ParameterDeclColon:
         // Since we don't add the type, also don't add the space after ':'.
         if (shouldPrint)
           OS << ":";
+        ++i;
         continue;
+      case ChunkKind::Text:
+        // Ignore " " after call argument labels.
+        if (i->getText() == " " && i != chunks.begin() &&
+            ((i-1)->is(ChunkKind::CallArgumentName) ||
+             (i-1)->is(ChunkKind::ParameterDeclExternalName) ||
+             (i-1)->is(ChunkKind::DeclIntroducer))) {
+          ++i;
+          continue;
+        }
+        break;
       default:
         break;
       }
 
       if (C.hasText() && shouldPrint)
         OS << C.getText();
+      ++i;
     }
   }
 }

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -70,17 +70,28 @@ static std::string toInsertableString(CodeCompletionResult *Result) {
     case CodeCompletionString::Chunk::ChunkKind::CallArgumentName:
     case CodeCompletionString::Chunk::ChunkKind::CallArgumentInternalName:
     case CodeCompletionString::Chunk::ChunkKind::CallArgumentColon:
-    case CodeCompletionString::Chunk::ChunkKind::DeclAttrParamKeyword:
-    case CodeCompletionString::Chunk::ChunkKind::DeclAttrParamColon:
     case CodeCompletionString::Chunk::ChunkKind::CallArgumentType:
     case CodeCompletionString::Chunk::ChunkKind::CallArgumentClosureType:
-    case CodeCompletionString::Chunk::ChunkKind::OptionalBegin:
     case CodeCompletionString::Chunk::ChunkKind::CallArgumentBegin:
     case CodeCompletionString::Chunk::ChunkKind::CallArgumentTypeBegin:
+    case CodeCompletionString::Chunk::ChunkKind::ParameterDeclBegin:
+    case CodeCompletionString::Chunk::ChunkKind::ParameterDeclExternalName:
+    case CodeCompletionString::Chunk::ChunkKind::ParameterDeclLocalName:
+    case CodeCompletionString::Chunk::ChunkKind::ParameterDeclColon:
+    case CodeCompletionString::Chunk::ChunkKind::ParameterDeclTypeBegin:
+    case CodeCompletionString::Chunk::ChunkKind::DefaultArgumentClauseBegin:
+    case CodeCompletionString::Chunk::ChunkKind::GenericParameterClauseBegin:
+    case CodeCompletionString::Chunk::ChunkKind::GenericRequirementClauseBegin:
+    case CodeCompletionString::Chunk::ChunkKind::DeclAttrParamKeyword:
+    case CodeCompletionString::Chunk::ChunkKind::DeclAttrParamColon:
+    case CodeCompletionString::Chunk::ChunkKind::OptionalBegin:
     case CodeCompletionString::Chunk::ChunkKind::GenericParameterBegin:
     case CodeCompletionString::Chunk::ChunkKind::GenericParameterName:
+    case CodeCompletionString::Chunk::ChunkKind::EffectsSpecifierClauseBegin:
+    case CodeCompletionString::Chunk::ChunkKind::DeclResultTypeClauseBegin:
     case CodeCompletionString::Chunk::ChunkKind::TypeAnnotation:
     case CodeCompletionString::Chunk::ChunkKind::TypeAnnotationBegin:
+    case CodeCompletionString::Chunk::ChunkKind::AttributeAndModifierListBegin:
       return Str;
 
     case CodeCompletionString::Chunk::ChunkKind::CallArgumentClosureExpr:

--- a/test/IDE/complete_annotation.swift
+++ b/test/IDE/complete_annotation.swift
@@ -8,6 +8,7 @@
 // RUN: %swift-ide-test -code-completion -code-completion-annotate-results -source-filename %s -code-completion-token=CALLARG | %FileCheck %s --check-prefix=CALLARG
 // RUN: %swift-ide-test -code-completion -code-completion-annotate-results -source-filename %s -code-completion-token=GENERIC | %FileCheck %s --check-prefix=GENERIC
 // RUN: %swift-ide-test -code-completion -code-completion-annotate-results -source-filename %s -code-completion-token=WHERE | %FileCheck %s --check-prefix=WHERE
+// RUN: %swift-ide-test -code-completion -code-completion-annotate-results -source-filename %s -code-completion-token=OVERRIDE -code-completion-sourcetext | %FileCheck %s --check-prefix=OVERRIDE
 
 struct MyStruct {
   init(x: Int) {}
@@ -138,3 +139,24 @@ struct TestGenericParamAnnotations<T> {
 // WHERE-DAG: Decl[Struct]/Local:                 <name>TestGenericParamAnnotations</name>;
 // WHERE-DAG: Keyword[Self]/CurrNominal:          <keyword>Self</keyword>;
 // WHERE: End completions
+
+protocol BaseP {
+  func protoMethod() -> @convention(c) (UInt8) -> Void
+  var value: MyStruct
+}
+class BaseC {
+  func baseMethodAsync(x: Int) async -> Int { }
+  func genericAsyncThrowsConstraint<T, U>(x: T) async throws -> U.Element where U: Collection, U.Element == Int {}
+  subscript(index: Int) -> (Int) -> Int { }
+}
+class DerivedC: BaseC, BaseP {
+  #^OVERRIDE^#
+// OVERRIDE-DAG: Keyword[func]/None:                 <keyword>func</keyword>; typename=; name=func; sourcetext=func
+// OVERRIDE-DAG: Decl[InstanceMethod]/Super:         <name>protoMethod</name>() -&gt; (<typeid.sys>UInt8</typeid.sys>) -&gt; <typeid.sys>Void</typeid.sys>; typename=; name=protoMethod(); sourcetext=func protoMethod() -> (UInt8) -> Void {\n<#code#>\n}
+// OVERRIDE-DAG: Decl[InstanceVar]/Super:            <name>value</name>: <typeid.user>MyStruct</typeid.user>; typename=; name=value; sourcetext=var value: MyStruct
+// OVERRIDE-DAG: Decl[InstanceMethod]/Super:         <name>baseMethodAsync</name>(<param><param.label>x</param.label>: <param.type><typeid.sys>Int</typeid.sys></param.type></param>) <keyword>async</keyword> -&gt; <typeid.sys>Int</typeid.sys>; typename=; name=baseMethodAsync(x:); sourcetext=override func baseMethodAsync(x: Int) async -> Int {\n<#code#>\n}
+// OVERRIDE-DAG: Decl[InstanceMethod]/Super:         <name>genericAsyncThrowsConstraint</name>&lt;T, U&gt;(<param><param.label>x</param.label>: <param.type><typeid.user>T</typeid.user></param.type></param>) <keyword>async</keyword> <keyword>throws</keyword> -&gt; <typeid.user>U</typeid.user>.<typeid.sys>Element</typeid.sys> <keyword>where</keyword> <typeid.user>U</typeid.user> : <typeid.sys>Collection</typeid.sys>, <typeid.user>U</typeid.user>.<typeid.sys>Element</typeid.sys> == <typeid.sys>Int</typeid.sys>; typename=; name=genericAsyncThrowsConstraint(x:); sourcetext=override func genericAsyncThrowsConstraint<T, U>(x: T) async throws -> U.Element where U : Collection, U.Element == Int {\n<#code#>\n}
+
+// OVERRIDE-DAG: Decl[Subscript]/Super:              <name>subscript</name>(<param><param.param>index</param.param>: <param.type><typeid.sys>Int</typeid.sys></param.type></param>) -&gt; (<typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Int</typeid.sys>; typename=; name=subscript(:); sourcetext=override subscript(index: Int) -> (Int) -> Int {\n<#code#>\n}
+// OVERRIDE-DAG: Decl[Constructor]/Super:            <name>init</name>(); typename=; name=init(); sourcetext=override init() {\n<#code#>\n}
+}

--- a/test/IDE/complete_annotation_concurrency.swift
+++ b/test/IDE/complete_annotation_concurrency.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -code-completion-annotate-results -code-completion-sourcetext -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+// REQUIRES: concurrency
+
+public protocol MyActorProto: Actor {
+    public nonisolated func nonIsolatedFunc()
+}
+
+public actor MyActor1: MyActorProto {
+  #^CONFORM_ACTORPROTO_WITHOUTINTRO^#
+// CONFORM_ACTORPROTO_WITHOUTINTRO: Begin completions
+// CONFORM_ACTORPROTO_WITHOUTINTRO-DAG: Decl[InstanceMethod]/Super:         <name>nonIsolatedFunc</name>(); typename=; name=nonIsolatedFunc(); sourcetext=public nonisolated func nonIsolatedFunc() {\n<#code#>\n}
+// CONFORM_ACTORPROTO_WITHOUTINTRO: End completions
+}
+
+public actor MyActor2: MyActorProto {
+  public func #^CONFORM_ACTORPROTO_WITHINTROACCESS^#
+// NOTE: 'nonisolated' is missing, but the user can add it after the completion.
+// CONFORM_ACTORPROTO_WITHINTROACCESS: Begin completions
+// CONFORM_ACTORPROTO_WITHINTROACCESS-DAG: Decl[InstanceMethod]/Super:         <name>nonIsolatedFunc</name>(); typename=; name=nonIsolatedFunc(); sourcetext=nonIsolatedFunc() {\n<#code#>\n}
+// CONFORM_ACTORPROTO_WITHINTROACCESS: End completions
+}
+
+public actor MyActor3: MyActorProto {
+  func #^CONFORM_ACTORPROTO_WITHINTRO^#
+// NOTE: Since missing 'public' is super common, code completion automatically add it.
+// CONFORM_ACTORPROTO_WITHINTRO: Begin completions
+// CONFORM_ACTORPROTO_WITHINTRO-DAG: Decl[InstanceMethod]/Super/Erase[5]: <name>nonIsolatedFunc</name>(); typename=; name=nonIsolatedFunc(); sourcetext=public nonisolated func nonIsolatedFunc() {\n<#code#>\n}
+// CONFORM_ACTORPROTO_WITHINTRO: End completions
+}

--- a/test/IDE/complete_member_decls_from_parent_decl_context.swift
+++ b/test/IDE/complete_member_decls_from_parent_decl_context.swift
@@ -600,13 +600,13 @@ class SR627_BaseClass<T> {
 class SR627_Subclass: SR627_BaseClass<String> {
   #^SR627_SUBCLASS^#
 // SR627_SUBCLASS: Begin completions
-// SR627_SUBCLASS-DAG: Decl[InstanceMethod]/Super:         override func myFunction(_ x: String) -> String? {|}; name=myFunction(_ x: String) -> String?
+// SR627_SUBCLASS-DAG: Decl[InstanceMethod]/Super:         override func myFunction(_ x: String) -> String? {|}; name=myFunction(_:)
 // SR627_SUBCLASS: End completions
 }
 
 class SR627_SubSubclass: SR627_Subclass {
   #^SR627_SUB_SUBCLASS^#
   // SR627_SUB_SUBCLASS: Begin completions
-  // SR627_SUB_SUBCLASS-DAG: Decl[InstanceMethod]/Super:         override func myFunction(_ x: String) -> String? {|}; name=myFunction(_ x: String) -> String?
+  // SR627_SUB_SUBCLASS-DAG: Decl[InstanceMethod]/Super:         override func myFunction(_ x: String) -> String? {|}; name=myFunction(_:)
   // SR627_SUB_SUBCLASS: End completions
 }

--- a/test/IDE/complete_override.swift
+++ b/test/IDE/complete_override.swift
@@ -260,12 +260,12 @@ extension TestProtocol_PA {
 }
 
 // PROTOCOL_PA_EXT: Begin completions
-// PROTOCOL_PA_EXT-DAG: Decl[Constructor]/Super:            init(fromProtocolA: Int) {|}; name=init(fromProtocolA: Int)
+// PROTOCOL_PA_EXT-DAG: Decl[Constructor]/Super:            init(fromProtocolA: Int) {|}; name=init(fromProtocolA:)
 // PROTOCOL_PA_EXT-DAG: Decl[InstanceMethod]/Super:         func protoAFunc() {|}; name=protoAFunc()
 // PROTOCOL_PA_EXT-DAG: Decl[InstanceMethod]/Super:         func protoAFuncOptional() {|}; name=protoAFuncOptional()
-// PROTOCOL_PA_EXT-DAG: Decl[Subscript]/Super:              subscript(a: TagPA) -> Int {|}; name=subscript(a: TagPA) -> Int
-// PROTOCOL_PA_EXT-DAG: Decl[InstanceVar]/Super:            var protoAVarRW: Int; name=protoAVarRW: Int
-// PROTOCOL_PA_EXT-DAG: Decl[InstanceVar]/Super:            var protoAVarRO: Int; name=protoAVarRO: Int
+// PROTOCOL_PA_EXT-DAG: Decl[Subscript]/Super:              subscript(a: TagPA) -> Int {|}; name=subscript(:)
+// PROTOCOL_PA_EXT-DAG: Decl[InstanceVar]/Super:            var protoAVarRW: Int; name=protoAVarRW
+// PROTOCOL_PA_EXT-DAG: Decl[InstanceVar]/Super:            var protoAVarRO: Int; name=protoAVarRO
 // PROTOCOL_PA_EXT: End completions
 
 class OuterNominal : ProtocolA {
@@ -294,7 +294,7 @@ class OmitKW1 : ProtocolA {
 // OMIT_KEYWORD1-NOT:    Decl[Constructor]
 // OMIT_KEYWORD1-DAG:    Decl[InstanceMethod]/Super:         func protoAFunc() {|}; name=protoAFunc(){{$}}
 // OMIT_KEYWORD1-DAG:    Decl[InstanceMethod]/Super:         func protoAFuncOptional() {|}; name=protoAFuncOptional(){{$}}
-// OMIT_KEYWORD1-DAG:    Decl[Subscript]/Super:              subscript(a: TagPA) -> Int {|}; name=subscript(a: TagPA) -> Int
+// OMIT_KEYWORD1-DAG:    Decl[Subscript]/Super:              subscript(a: TagPA) -> Int {|}; name=subscript(:)
 // OMIT_KEYWORD1-DAG:    Decl[InstanceVar]/Super:            var protoAVarRW: Int{{; name=.+$}}
 // OMIT_KEYWORD1-NOT:    Decl[Constructor]
 // OMIT_KEYWORD1: End completions
@@ -411,10 +411,10 @@ class TestClassWithThrows : HasThrowing, HasThrowingProtocol {
   #^HAS_THROWING?keywords=false^#
 }
 // HAS_THROWING: Begin completions
-// HAS_THROWING-DAG: Decl[InstanceMethod]/Super:         func foo() throws {|}; name=foo() throws
-// HAS_THROWING-DAG: Decl[InstanceMethod]/Super:         override func bar() throws {|}; name=bar() throws
-// HAS_THROWING-DAG: Decl[InstanceMethod]/Super:         override func baz(x: @escaping () throws -> ()) rethrows {|}; name=baz(x: {{(@escaping )?}}() throws -> ()) rethrows
-// HAS_THROWING-DAG: Decl[Constructor]/Super:            override init() throws {|}; name=init() throws
+// HAS_THROWING-DAG: Decl[InstanceMethod]/Super:         func foo() throws {|}; name=foo()
+// HAS_THROWING-DAG: Decl[InstanceMethod]/Super:         override func bar() throws {|}; name=bar()
+// HAS_THROWING-DAG: Decl[InstanceMethod]/Super:         override func baz(x: @escaping () throws -> ()) rethrows {|}; name=baz(x:)
+// HAS_THROWING-DAG: Decl[Constructor]/Super:            override init() throws {|}; name=init()
 // HAS_THROWING: End completions
 
 protocol P0
@@ -576,37 +576,37 @@ class Override26 : OverrideBase, OverrideP {
 }
 
 // MODIFIER1: Begin completions, 10 items
-// MODIFIER1-DAG: Decl[Constructor]/Super:            required init(p: Int) {|}; name=required init(p: Int)
+// MODIFIER1-DAG: Decl[Constructor]/Super:            required init(p: Int) {|}; name=init(p:)
 // MODIFIER1-DAG: Decl[StaticMethod]/Super:           override class func classMethod() {|}; name=classMethod()
-// MODIFIER1-DAG: Decl[StaticVar]/Super:              override class var classVar: Int; name=classVar: Int
-// MODIFIER1-DAG: Decl[StaticVar]/Super:              override class var classGetOnlyVar: Int; name=classGetOnlyVar: Int
+// MODIFIER1-DAG: Decl[StaticVar]/Super:              override class var classVar: Int; name=classVar
+// MODIFIER1-DAG: Decl[StaticVar]/Super:              override class var classGetOnlyVar: Int; name=classGetOnlyVar
 // MODIFIER1-DAG: Decl[InstanceMethod]/Super:         override func defaultMethod() {|}; name=defaultMethod()
 // MODIFIER1-DAG: Decl[InstanceMethod]/Super:         override func openMethod() {|}; name=openMethod()
-// MODIFIER1-DAG: Decl[InstanceVar]/Super:            override var varDecl: Int; name=varDecl: Int
-// MODIFIER1-DAG: Decl[Constructor]/Super:            override init(x: Int) {|}; name=init(x: Int)
-// MODIFIER1-DAG: Decl[Constructor]/Super:            required init(a: Int) {|}; name=required init(a: Int)
+// MODIFIER1-DAG: Decl[InstanceVar]/Super:            override var varDecl: Int; name=varDecl
+// MODIFIER1-DAG: Decl[Constructor]/Super:            override init(x: Int) {|}; name=init(x:)
+// MODIFIER1-DAG: Decl[Constructor]/Super:            required init(a: Int) {|}; name=init(a:)
 // MODIFIER1-DAG: Decl[AssociatedType]/Super:         typealias Assoc = {#(Type)#}; name=Assoc =
 // MODIFIER1: End completions
 
 // MODIFIER2: Begin completions, 6 items
-// MODIFIER2-DAG: Decl[StaticVar]/Super:              override class var classVar: Int; name=classVar: Int
-// MODIFIER2-DAG: Decl[StaticVar]/Super:              override class var classGetOnlyVar: Int; name=classGetOnlyVar: Int
+// MODIFIER2-DAG: Decl[StaticVar]/Super:              override class var classVar: Int; name=classVar
+// MODIFIER2-DAG: Decl[StaticVar]/Super:              override class var classGetOnlyVar: Int; name=classGetOnlyVar
 // MODIFIER2-DAG: Decl[StaticMethod]/Super:           override class func classMethod() {|}; name=classMethod()
 // MODIFIER2-DAG: Decl[InstanceMethod]/Super:         override func defaultMethod() {|}; name=defaultMethod()
 // MODIFIER2-DAG: Decl[InstanceMethod]/Super:         override func openMethod() {|}; name=openMethod()
-// MODIFIER2-DAG: Decl[InstanceVar]/Super:            override var varDecl: Int; name=varDecl: Int
+// MODIFIER2-DAG: Decl[InstanceVar]/Super:            override var varDecl: Int; name=varDecl
 // MODIFIER2: End completions
 
 // MODIFIER4: Begin completions, 3 items
-// MODIFIER4-DAG: Decl[Constructor]/Super:            init(p: Int) {|}; name=init(p: Int)
-// MODIFIER4-DAG: Decl[Constructor]/Super:            override init(x: Int) {|}; name=init(x: Int)
-// MODIFIER4-DAG: Decl[Constructor]/Super:            init(a: Int) {|}; name=init(a: Int)
+// MODIFIER4-DAG: Decl[Constructor]/Super:            init(p: Int) {|}; name=init(p:)
+// MODIFIER4-DAG: Decl[Constructor]/Super:            override init(x: Int) {|}; name=init(x:)
+// MODIFIER4-DAG: Decl[Constructor]/Super:            init(a: Int) {|}; name=init(a:)
 // MODIFIER4: End completions
 
 // MODIFIER5: Begin completions, 3 items
-// MODIFIER5-DAG: Decl[Constructor]/Super:            required init(p: Int) {|}; name=required init(p: Int)
-// MODIFIER5-DAG: Decl[Constructor]/Super:            override init(x: Int) {|}; name=init(x: Int)
-// MODIFIER5-DAG: Decl[Constructor]/Super:            required init(a: Int) {|}; name=required init(a: Int)
+// MODIFIER5-DAG: Decl[Constructor]/Super:            required init(p: Int) {|}; name=init(p:)
+// MODIFIER5-DAG: Decl[Constructor]/Super:            override init(x: Int) {|}; name=init(x:)
+// MODIFIER5-DAG: Decl[Constructor]/Super:            required init(a: Int) {|}; name=init(a:)
 // MODIFIER5: End completions
 
 // MODIFIER6: Begin completions, 1 items
@@ -614,14 +614,14 @@ class Override26 : OverrideBase, OverrideP {
 // MODIFIER6: End completions
 
 // MODIFIER7: Begin completions, 8 items
-// MODIFIER7-DAG: Decl[StaticVar]/Super:              class var classVar: Int; name=classVar: Int
-// MODIFIER7-DAG: Decl[StaticVar]/Super:              class var classGetOnlyVar: Int; name=classGetOnlyVar: Int
+// MODIFIER7-DAG: Decl[StaticVar]/Super:              class var classVar: Int; name=classVar
+// MODIFIER7-DAG: Decl[StaticVar]/Super:              class var classGetOnlyVar: Int; name=classGetOnlyVar
 // MODIFIER7-DAG: Decl[StaticMethod]/Super:           class func classMethod() {|}; name=classMethod()
 // MODIFIER7-DAG: Decl[InstanceMethod]/Super:         func defaultMethod() {|}; name=defaultMethod()
-// MODIFIER7-DAG: Decl[InstanceVar]/Super:            var varDecl: Int; name=varDecl: Int
+// MODIFIER7-DAG: Decl[InstanceVar]/Super:            var varDecl: Int; name=varDecl
 // MODIFIER7-DAG: Decl[InstanceMethod]/Super:         func openMethod() {|}; name=openMethod()
-// MODIFIER7-DAG: Decl[Constructor]/Super:            init(x: Int) {|}; name=init(x: Int)
-// MODIFIER7-DAG: Decl[Constructor]/Super:            required init(a: Int) {|}; name=required init(a: Int)
+// MODIFIER7-DAG: Decl[Constructor]/Super:            init(x: Int) {|}; name=init(x:)
+// MODIFIER7-DAG: Decl[Constructor]/Super:            required init(a: Int) {|}; name=init(a:)
 // MODIFIER7: End completions
 
 // MODIFIER8: Begin completions, 2 items
@@ -630,23 +630,23 @@ class Override26 : OverrideBase, OverrideP {
 // MODIFIER8: End completions
 
 // MODIFIER9: Begin completions, 1 items
-// MODIFIER9-DAG: Decl[InstanceVar]/Super/Erase[4]:   override var varDecl: Int; name=varDecl: Int
+// MODIFIER9-DAG: Decl[InstanceVar]/Super/Erase[4]:   override var varDecl: Int; name=varDecl
 // MODIFIER9: End completions
 
 // MODIFIER12: Begin completions, 1 items
-// MODIFIER12-DAG: Decl[InstanceVar]/Super:           varDecl: Int; name=varDecl: Int
+// MODIFIER12-DAG: Decl[InstanceVar]/Super:           varDecl: Int; name=varDecl
 // MODIFIER12: End completions
 
 // MODIFIER13-NOT: Begin completions
 
 // MODIFIER15: Begin completions, 2 items
-// MODIFIER15-DAG: Decl[StaticVar]/Super/Erase[4]:    override var classVar: Int; name=classVar: Int
-// MODIFIER15-DAG: Decl[StaticVar]/Super/Erase[4]:    override var classGetOnlyVar: Int; name=classGetOnlyVar: Int
+// MODIFIER15-DAG: Decl[StaticVar]/Super/Erase[4]:    override var classVar: Int; name=classVar
+// MODIFIER15-DAG: Decl[StaticVar]/Super/Erase[4]:    override var classGetOnlyVar: Int; name=classGetOnlyVar
 // MODIFIER15: End completions
 
 // MODIFIER17: Begin completions, 2 items
-// MODIFIER17-DAG: Decl[StaticVar]/Super:             classVar: Int; name=classVar: Int
-// MODIFIER17-DAG: Decl[StaticVar]/Super:             classGetOnlyVar: Int; name=classGetOnlyVar: Int
+// MODIFIER17-DAG: Decl[StaticVar]/Super:             classVar: Int; name=classVar
+// MODIFIER17-DAG: Decl[StaticVar]/Super:             classGetOnlyVar: Int; name=classGetOnlyVar
 // MODIFIER17: End completions
 
 // MODIFIER21: Begin completions, 1 items
@@ -659,14 +659,14 @@ class Override26 : OverrideBase, OverrideP {
 
 // MODIFIER23: Begin completions, 3 items
 // MODIFIER23-DAG: Decl[StaticMethod]/Super:          override func classMethod() {|}; name=classMethod()
-// MODIFIER23-DAG: Decl[StaticVar]/Super:             override var classVar: Int; name=classVar: Int
-// MODIFIER23-DAG: Decl[StaticVar]/Super:             override var classGetOnlyVar: Int; name=classGetOnlyVar: Int
+// MODIFIER23-DAG: Decl[StaticVar]/Super:             override var classVar: Int; name=classVar
+// MODIFIER23-DAG: Decl[StaticVar]/Super:             override var classGetOnlyVar: Int; name=classGetOnlyVar
 // MODIFIER23: End completions
 
 // MODIFIER24: Begin completions, 3 items
 // MODIFIER24-DAG: Decl[StaticMethod]/Super:          func classMethod() {|}; name=classMethod()
-// MODIFIER24-DAG: Decl[StaticVar]/Super:             var classVar: Int; name=classVar: Int
-// MODIFIER24-DAG: Decl[StaticVar]/Super:             var classGetOnlyVar: Int; name=classGetOnlyVar: Int
+// MODIFIER24-DAG: Decl[StaticVar]/Super:             var classVar: Int; name=classVar
+// MODIFIER24-DAG: Decl[StaticVar]/Super:             var classGetOnlyVar: Int; name=classGetOnlyVar
 // MODIFIER24: End completions
 
 protocol RequiredP {
@@ -683,15 +683,15 @@ struct RequiredS : RequiredP {
 }
 
 // PROTOINIT_NORM: Begin completions, 1 items
-// PROTOINIT_NORM-DAG: required init(p: Int) {|}; name=required init(p: Int)
+// PROTOINIT_NORM-DAG: required init(p: Int) {|}; name=init(p:)
 // PROTOINIT_NORM: End completions
 
 // PROTOINIT_FINAL: Begin completions, 1 items
-// PROTOINIT_FINAL-DAG: init(p: Int) {|}; name=init(p: Int)
+// PROTOINIT_FINAL-DAG: init(p: Int) {|}; name=init(p:)
 // PROTOINIT_FINAL: End completions
 
 // PROTOINIT_STRUCT: Begin completions, 1 items
-// PROTOINIT_STRUCT-DAG: init(p: Int) {|}; name=init(p: Int)
+// PROTOINIT_STRUCT-DAG: init(p: Int) {|}; name=init(p:)
 // PROTOINIT_STRUCT: End completions
 
 protocol AssocAndMethod {
@@ -736,7 +736,7 @@ struct SynthesizedConformance3: Hashable {
   #^OVERRIDE_SYNTHESIZED_3?keywords=false^#
 // FIXME: Where did Equatable.(==) go?
 // OVERRIDE_SYNTHESIZED_3: Begin completions, 2 items
-// OVERRIDE_SYNTHESIZED_3-DAG: Decl[InstanceVar]/Super/IsSystem:       var hashValue: Int; name=hashValue: Int
+// OVERRIDE_SYNTHESIZED_3-DAG: Decl[InstanceVar]/Super/IsSystem:       var hashValue: Int; name=hashValue
 // OVERRIDE_SYNTHESIZED_3-DAG: Decl[InstanceMethod]/Super/IsSystem:    func hash(into hasher: inout Hasher) {|}
 }
 

--- a/test/IDE/complete_override_access_control_class.swift
+++ b/test/IDE/complete_override_access_control_class.swift
@@ -92,26 +92,26 @@ public class TestPublicAD : ProtocolAPrivate, ProtocolD {
 }
 
 // TEST_PRIVATE_AD: Begin completions, 6 items
-// TEST_PRIVATE_AD-DAG: Decl[InstanceMethod]/Super:         override func baseAFunc(x: TagPA) {|}; name=baseAFunc(x: TagPA)
-// TEST_PRIVATE_AD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPA) -> Int {|}; name=subscript(a: TagPA) -> Int
-// TEST_PRIVATE_AD-DAG: Decl[InstanceVar]/Super:            override var baseAVarRW: TagPA; name=baseAVarRW: TagPA
+// TEST_PRIVATE_AD-DAG: Decl[InstanceMethod]/Super:         override func baseAFunc(x: TagPA) {|}; name=baseAFunc(x:)
+// TEST_PRIVATE_AD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPA) -> Int {|}; name=subscript(:)
+// TEST_PRIVATE_AD-DAG: Decl[InstanceVar]/Super:            override var baseAVarRW: TagPA; name=baseAVarRW
 // TEST_PRIVATE_AD-DAG: Decl[InstanceMethod]/Super:         override func colliding() {|}; name=colliding()
-// TEST_PRIVATE_AD-DAG: Decl[InstanceMethod]/Super:         override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric<T>(x: T)
-// TEST_PRIVATE_AD-DAG: Decl[Constructor]/Super:            override init(fromBase: TagPA) {|}; name=init(fromBase: TagPA)
+// TEST_PRIVATE_AD-DAG: Decl[InstanceMethod]/Super:         override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric(x:)
+// TEST_PRIVATE_AD-DAG: Decl[Constructor]/Super:            override init(fromBase: TagPA) {|}; name=init(fromBase:)
 // TEST_PRIVATE_AD: End completions
 
 // TEST_INTERNAL_AD: Begin completions, 6 items
-// TEST_INTERNAL_AD-DAG: Decl[InstanceMethod]/Super:         override func baseAFunc(x: TagPA) {|}; name=baseAFunc(x: TagPA)
-// TEST_INTERNAL_AD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPA) -> Int {|}; name=subscript(a: TagPA) -> Int
-// TEST_INTERNAL_AD-DAG: Decl[InstanceVar]/Super:            override var baseAVarRW: TagPA; name=baseAVarRW: TagPA
+// TEST_INTERNAL_AD-DAG: Decl[InstanceMethod]/Super:         override func baseAFunc(x: TagPA) {|}; name=baseAFunc(x:)
+// TEST_INTERNAL_AD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPA) -> Int {|}; name=subscript(:)
+// TEST_INTERNAL_AD-DAG: Decl[InstanceVar]/Super:            override var baseAVarRW: TagPA; name=baseAVarRW
 // TEST_INTERNAL_AD-DAG: Decl[InstanceMethod]/Super:         override func colliding() {|}; name=colliding()
-// TEST_INTERNAL_AD-DAG: Decl[InstanceMethod]/Super:         override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric<T>(x: T)
-// TEST_INTERNAL_AD-DAG: Decl[Constructor]/Super:            override init(fromBase: TagPA) {|}; name=init(fromBase: TagPA)
+// TEST_INTERNAL_AD-DAG: Decl[InstanceMethod]/Super:         override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric(x:)
+// TEST_INTERNAL_AD-DAG: Decl[Constructor]/Super:            override init(fromBase: TagPA) {|}; name=init(fromBase:)
 // TEST_INTERNAL_AD: End completions
 
 // TEST_PUBLIC_AD: Begin completions, 2 items
 // TEST_PUBLIC_AD-DAG: Decl[InstanceMethod]/Super:         public func colliding() {|}; name=colliding()
-// TEST_PUBLIC_AD-DAG: Decl[InstanceMethod]/Super:         public func collidingGeneric<T>(x: T) {|}; name=collidingGeneric<T>(x: T)
+// TEST_PUBLIC_AD-DAG: Decl[InstanceMethod]/Super:         public func collidingGeneric<T>(x: T) {|}; name=collidingGeneric(x:)
 // TEST_PUBLIC_AD: End completions
 
 private class TestPrivateBD : BaseBInternal, ProtocolD {
@@ -129,30 +129,30 @@ public class TestPublicBD : BaseBInternal, ProtocolD {
 }
 
 // TEST_PRIVATE_BD: Begin completions, 6 items
-// TEST_PRIVATE_BD-DAG: Decl[InstanceMethod]/Super:         override func baseBFunc(x: TagPB) {|}; name=baseBFunc(x: TagPB)
-// TEST_PRIVATE_BD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPB) -> Int {|}; name=subscript(a: TagPB) -> Int
-// TEST_PRIVATE_BD-DAG: Decl[InstanceVar]/Super:            override var baseBVarRW: TagPB; name=baseBVarRW: TagPB
+// TEST_PRIVATE_BD-DAG: Decl[InstanceMethod]/Super:         override func baseBFunc(x: TagPB) {|}; name=baseBFunc(x:)
+// TEST_PRIVATE_BD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPB) -> Int {|}; name=subscript(:)
+// TEST_PRIVATE_BD-DAG: Decl[InstanceVar]/Super:            override var baseBVarRW: TagPB; name=baseBVarRW
 // TEST_PRIVATE_BD-DAG: Decl[InstanceMethod]/Super:         override func colliding() {|}; name=colliding()
-// TEST_PRIVATE_BD-DAG: Decl[InstanceMethod]/Super:         override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric<T>(x: T)
-// TEST_PRIVATE_BD-DAG: Decl[Constructor]/Super:            override init(fromBaseB: TagPB) {|}; name=init(fromBaseB: TagPB)
+// TEST_PRIVATE_BD-DAG: Decl[InstanceMethod]/Super:         override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric(x:)
+// TEST_PRIVATE_BD-DAG: Decl[Constructor]/Super:            override init(fromBaseB: TagPB) {|}; name=init(fromBaseB:)
 // TEST_PRIVATE_BD: End completions
 
 // TEST_INTERNAL_BD: Begin completions, 6 items
-// TEST_INTERNAL_BD-DAG: Decl[InstanceMethod]/Super:         override func baseBFunc(x: TagPB) {|}; name=baseBFunc(x: TagPB)
-// TEST_INTERNAL_BD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPB) -> Int {|}; name=subscript(a: TagPB) -> Int
-// TEST_INTERNAL_BD-DAG: Decl[InstanceVar]/Super:            override var baseBVarRW: TagPB; name=baseBVarRW: TagPB
+// TEST_INTERNAL_BD-DAG: Decl[InstanceMethod]/Super:         override func baseBFunc(x: TagPB) {|}; name=baseBFunc(x:)
+// TEST_INTERNAL_BD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPB) -> Int {|}; name=subscript(:)
+// TEST_INTERNAL_BD-DAG: Decl[InstanceVar]/Super:            override var baseBVarRW: TagPB; name=baseBVarRW
 // TEST_INTERNAL_BD-DAG: Decl[InstanceMethod]/Super:         override func colliding() {|}; name=colliding()
-// TEST_INTERNAL_BD-DAG: Decl[InstanceMethod]/Super:         override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric<T>(x: T)
-// TEST_INTERNAL_BD-DAG: Decl[Constructor]/Super:            override init(fromBaseB: TagPB) {|}; name=init(fromBaseB: TagPB)
+// TEST_INTERNAL_BD-DAG: Decl[InstanceMethod]/Super:         override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric(x:)
+// TEST_INTERNAL_BD-DAG: Decl[Constructor]/Super:            override init(fromBaseB: TagPB) {|}; name=init(fromBaseB:)
 // TEST_INTERNAL_BD: End completions
 
 // TEST_PUBLIC_BD: Begin completions, 6 items
-// TEST_PUBLIC_BD-DAG: Decl[InstanceMethod]/Super:         override func baseBFunc(x: TagPB) {|}; name=baseBFunc(x: TagPB)
-// TEST_PUBLIC_BD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPB) -> Int {|}; name=subscript(a: TagPB) -> Int
-// TEST_PUBLIC_BD-DAG: Decl[InstanceVar]/Super:            override var baseBVarRW: TagPB; name=baseBVarRW: TagPB
+// TEST_PUBLIC_BD-DAG: Decl[InstanceMethod]/Super:         override func baseBFunc(x: TagPB) {|}; name=baseBFunc(x:)
+// TEST_PUBLIC_BD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPB) -> Int {|}; name=subscript(:)
+// TEST_PUBLIC_BD-DAG: Decl[InstanceVar]/Super:            override var baseBVarRW: TagPB; name=baseBVarRW
 // TEST_PUBLIC_BD-DAG: Decl[InstanceMethod]/Super:         public override func colliding() {|}; name=colliding()
-// TEST_PUBLIC_BD-DAG: Decl[InstanceMethod]/Super:         public override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric<T>(x: T)
-// TEST_PUBLIC_BD-DAG: Decl[Constructor]/Super:            override init(fromBaseB: TagPB) {|}; name=init(fromBaseB: TagPB)
+// TEST_PUBLIC_BD-DAG: Decl[InstanceMethod]/Super:         public override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric(x:)
+// TEST_PUBLIC_BD-DAG: Decl[Constructor]/Super:            override init(fromBaseB: TagPB) {|}; name=init(fromBaseB:)
 // TEST_PUBLIC_BD: End completions
 
 private class TestPrivateCD : BaseCPublic, ProtocolD {
@@ -170,29 +170,29 @@ public class TestPublicCD : BaseCPublic, ProtocolD {
 }
 
 // TEST_PRIVATE_CD: Begin completions, 6 items
-// TEST_PRIVATE_CD-DAG: Decl[InstanceMethod]/Super:         override func baseCFunc(x: TagPC) {|}; name=baseCFunc(x: TagPC)
-// TEST_PRIVATE_CD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPC) -> Int {|}; name=subscript(a: TagPC) -> Int
-// TEST_PRIVATE_CD-DAG: Decl[InstanceVar]/Super:            override var baseCVarRW: TagPC; name=baseCVarRW: TagPC
+// TEST_PRIVATE_CD-DAG: Decl[InstanceMethod]/Super:         override func baseCFunc(x: TagPC) {|}; name=baseCFunc(x:)
+// TEST_PRIVATE_CD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPC) -> Int {|}; name=subscript(:)
+// TEST_PRIVATE_CD-DAG: Decl[InstanceVar]/Super:            override var baseCVarRW: TagPC; name=baseCVarRW
 // TEST_PRIVATE_CD-DAG: Decl[InstanceMethod]/Super:         override func colliding() {|}; name=colliding()
-// TEST_PRIVATE_CD-DAG: Decl[InstanceMethod]/Super:         override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric<T>(x: T)
-// TEST_PRIVATE_CD-DAG: Decl[Constructor]/Super:            override init(fromBaseC: TagPC) {|}; name=init(fromBaseC: TagPC)
+// TEST_PRIVATE_CD-DAG: Decl[InstanceMethod]/Super:         override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric(x:)
+// TEST_PRIVATE_CD-DAG: Decl[Constructor]/Super:            override init(fromBaseC: TagPC) {|}; name=init(fromBaseC:)
 // TEST_PRIVATE_CD: End completions
 
 // TEST_INTERNAL_CD: Begin completions, 6 items
-// TEST_INTERNAL_CD-DAG: Decl[InstanceMethod]/Super:         override func baseCFunc(x: TagPC) {|}; name=baseCFunc(x: TagPC)
-// TEST_INTERNAL_CD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPC) -> Int {|}; name=subscript(a: TagPC) -> Int
-// TEST_INTERNAL_CD-DAG: Decl[InstanceVar]/Super:            override var baseCVarRW: TagPC; name=baseCVarRW: TagPC
+// TEST_INTERNAL_CD-DAG: Decl[InstanceMethod]/Super:         override func baseCFunc(x: TagPC) {|}; name=baseCFunc(x:)
+// TEST_INTERNAL_CD-DAG: Decl[Subscript]/Super:              override subscript(a: TagPC) -> Int {|}; name=subscript(:)
+// TEST_INTERNAL_CD-DAG: Decl[InstanceVar]/Super:            override var baseCVarRW: TagPC; name=baseCVarRW
 // TEST_INTERNAL_CD-DAG: Decl[InstanceMethod]/Super:         override func colliding() {|}; name=colliding()
-// TEST_INTERNAL_CD-DAG: Decl[InstanceMethod]/Super:         override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric<T>(x: T)
-// TEST_INTERNAL_CD-DAG: Decl[Constructor]/Super:            override init(fromBaseC: TagPC) {|}; name=init(fromBaseC: TagPC)
+// TEST_INTERNAL_CD-DAG: Decl[InstanceMethod]/Super:         override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric(x:)
+// TEST_INTERNAL_CD-DAG: Decl[Constructor]/Super:            override init(fromBaseC: TagPC) {|}; name=init(fromBaseC:)
 // TEST_INTERNAL_CD: End completions
 
 // TEST_PUBLIC_CD: Begin completions, 6 items
-// TEST_PUBLIC_CD-DAG: Decl[InstanceMethod]/Super:         public override func baseCFunc(x: TagPC) {|}; name=baseCFunc(x: TagPC)
-// TEST_PUBLIC_CD-DAG: Decl[Subscript]/Super:              public override subscript(a: TagPC) -> Int {|}; name=subscript(a: TagPC) -> Int
-// TEST_PUBLIC_CD-DAG: Decl[InstanceVar]/Super:            public override var baseCVarRW: TagPC; name=baseCVarRW: TagPC
+// TEST_PUBLIC_CD-DAG: Decl[InstanceMethod]/Super:         public override func baseCFunc(x: TagPC) {|}; name=baseCFunc(x:)
+// TEST_PUBLIC_CD-DAG: Decl[Subscript]/Super:              public override subscript(a: TagPC) -> Int {|}; name=subscript(:)
+// TEST_PUBLIC_CD-DAG: Decl[InstanceVar]/Super:            public override var baseCVarRW: TagPC; name=baseCVarRW
 // TEST_PUBLIC_CD-DAG: Decl[InstanceMethod]/Super:         public override func colliding() {|}; name=colliding()
-// TEST_PUBLIC_CD-DAG: Decl[InstanceMethod]/Super:         public override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric<T>(x: T)
-// TEST_PUBLIC_CD-DAG: Decl[Constructor]/Super:            public override init(fromBaseC: TagPC) {|}; name=init(fromBaseC: TagPC)
+// TEST_PUBLIC_CD-DAG: Decl[InstanceMethod]/Super:         public override func collidingGeneric<T>(x: T) {|}; name=collidingGeneric(x:)
+// TEST_PUBLIC_CD-DAG: Decl[Constructor]/Super:            public override init(fromBaseC: TagPC) {|}; name=init(fromBaseC:)
 // TEST_PUBLIC_CD: End completions
 

--- a/test/SourceKit/CodeComplete/complete_override.swift.response
+++ b/test/SourceKit/CodeComplete/complete_override.swift.response
@@ -82,7 +82,7 @@
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
-      key.name: "f(getMe a: Int, b: Double)",
+      key.name: "f(getMe:b:)",
       key.sourcetext: "override func f(getMe a: Int, b: Double) {\n<#code#>\n}",
       key.description: "f(getMe a: Int, b: Double)",
       key.typename: "",


### PR DESCRIPTION
Implement `CodeCompletionStringPrinter` to print override completion item to `CodeCompletionResultBuilder` with appropriate `ChunkKind`. Added various group `ChunkKind` for differentiating `description`, `name`, and `sourcetext`.

* "description" for override completion is now annotatable
* "description" don't include attributes and decl introducer, but it includes generic parameters, effects specifiers, result type clause, and where clauses
* "name" now only include the name and the parameter clause
* "sourcetext" should be unchanged

rdar://63835352