### PR TITLE
OSSA: migrate & organize simplify-cfg tests

### DIFF
--- a/include/swift/SIL/BasicBlockUtils.h
+++ b/include/swift/SIL/BasicBlockUtils.h
@@ -87,6 +87,10 @@ public:
   /// Used to determine if we need to verify a DeadEndBlocks.
   bool isComputed() const { return didComputeValue; }
 
+  /// Add any (new) blocks that are backward-reachable from \p reachableBB to
+  /// the set of reachable blocks.
+  void updateForReachableBlock(SILBasicBlock *reachableBB);
+
   const SILFunction *getFunction() const { return f; }
   
   /// Performs a simple check if \p block (or its single successor) ends in an
@@ -95,6 +99,9 @@ public:
   /// This handles the common case of failure-handling blocks, which e.g.
   /// contain a call to fatalError().
   static bool triviallyEndsInUnreachable(SILBasicBlock *block);
+
+protected:
+  void propagateNewlyReachableBlocks(unsigned startIdx);
 };
 
 /// Compute joint-postdominating set for \p dominatingBlock and \p

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -183,7 +183,7 @@ public:
 
   /// Return the terminator instruction for which this argument is a result,
   /// otherwise return nullptr.
-  TermInst *getTerminatorForResultArg() const;
+  TermInst *getTerminatorForResult() const;
 
   /// Return the SILArgumentKind of this argument.
   SILArgumentKind getKind() const {
@@ -299,7 +299,7 @@ public:
 
   /// Return the terminator instruction for which this argument is a result,
   /// otherwise return nullptr.
-  TermInst *getTerminatorForResultArg() const;
+  TermInst *getTerminatorForResult() const;
 
   static bool classof(const SILInstruction *) = delete;
   static bool classof(const SILUndef *) = delete;
@@ -445,10 +445,10 @@ inline TermInst *SILArgument::getSingleTerminator() const {
   llvm_unreachable("Covered switch is not covered?!");
 }
 
-inline TermInst *SILArgument::getTerminatorForResultArg() const {
+inline TermInst *SILArgument::getTerminatorForResult() const {
   switch (getKind()) {
   case SILArgumentKind::SILPhiArgument:
-    return cast<SILPhiArgument>(this)->getTerminatorForResultArg();
+    return cast<SILPhiArgument>(this)->getTerminatorForResult();
   case SILArgumentKind::SILFunctionArgument:
     return nullptr;
   }

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -203,7 +203,8 @@ SILLinkage getSpecializedLinkage(SILFunction *f, SILLinkage linkage);
 /// function \p Fn.
 bool tryCheckedCastBrJumpThreading(
     SILFunction *fn, DominanceInfo *dt,
-    SmallVectorImpl<SILBasicBlock *> &blocksForWorklist);
+    SmallVectorImpl<SILBasicBlock *> &blocksForWorklist,
+    bool EnableOSSARewriteTerminator);
 
 /// A utility for deleting one or more instructions belonging to a function, and
 /// cleaning up any dead code resulting from deleting those instructions. Use

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -34,6 +34,7 @@
 namespace swift {
 
 class DominanceInfo;
+class DeadEndBlocks;
 template <class T> class NullablePtr;
 
 /// Transform a Use Range (Operand*) into a User Range (SILInstruction *)
@@ -202,7 +203,7 @@ SILLinkage getSpecializedLinkage(SILFunction *f, SILLinkage linkage);
 /// Tries to perform jump-threading on all checked_cast_br instruction in
 /// function \p Fn.
 bool tryCheckedCastBrJumpThreading(
-    SILFunction *fn, DominanceInfo *dt,
+    SILFunction *fn, DominanceInfo *dt, DeadEndBlocks *deBlocks,
     SmallVectorImpl<SILBasicBlock *> &blocksForWorklist,
     bool EnableOSSARewriteTerminator);
 

--- a/lib/SIL/IR/SILArgument.cpp
+++ b/lib/SIL/IR/SILArgument.cpp
@@ -316,7 +316,7 @@ TermInst *SILPhiArgument::getSingleTerminator() const {
   return const_cast<SILBasicBlock *>(predBlock)->getTerminator();
 }
 
-TermInst *SILPhiArgument::getTerminatorForResultArg() const {
+TermInst *SILPhiArgument::getTerminatorForResult() const {
   if (auto *termInst = getSingleTerminator()) {
     if (!isa<BranchInst>(termInst) && !isa<CondBranchInst>(termInst))
       return termInst;

--- a/lib/SIL/Utils/BasicBlockUtils.cpp
+++ b/lib/SIL/Utils/BasicBlockUtils.cpp
@@ -368,6 +368,15 @@ void swift::mergeBasicBlockWithSingleSuccessor(SILBasicBlock *BB,
 //                              DeadEndBlocks
 //===----------------------------------------------------------------------===//
 
+// Propagate the reachability up the control flow graph.
+void DeadEndBlocks::propagateNewlyReachableBlocks(unsigned startIdx) {
+  for (unsigned idx = startIdx; idx < reachableBlocks.size(); ++idx) {
+    const SILBasicBlock *bb = reachableBlocks[idx];
+    for (SILBasicBlock *predBB : bb->getPredecessorBlocks())
+      reachableBlocks.insert(predBB);
+  }
+}
+
 void DeadEndBlocks::compute() {
   assert(reachableBlocks.empty() && "Computed twice");
 
@@ -379,13 +388,19 @@ void DeadEndBlocks::compute() {
     if (TI->isFunctionExiting())
       reachableBlocks.insert(&BB);
   }
-  // Propagate the reachability up the control flow graph.
-  unsigned Idx = 0;
-  while (Idx < reachableBlocks.size()) {
-    const SILBasicBlock *BB = reachableBlocks[Idx++];
-    for (SILBasicBlock *Pred : BB->getPredecessorBlocks())
-      reachableBlocks.insert(Pred);
+  propagateNewlyReachableBlocks(0);
+}
+
+void DeadEndBlocks::updateForReachableBlock(SILBasicBlock *reachableBB) {
+  if (!didComputeValue)
+    return;
+
+  assert(reachableBlocks.count(reachableBB));
+  unsigned numReachable = reachableBlocks.size();
+  for (SILBasicBlock *predBB : reachableBB->getPredecessorBlocks()) {
+    reachableBlocks.insert(predBB);
   }
+  propagateNewlyReachableBlocks(numReachable);
 }
 
 bool DeadEndBlocks::triviallyEndsInUnreachable(SILBasicBlock *block) {

--- a/lib/SIL/Utils/BasicBlockUtils.cpp
+++ b/lib/SIL/Utils/BasicBlockUtils.cpp
@@ -174,7 +174,8 @@ void swift::getEdgeArgs(TermInst *T, unsigned edgeIdx, SILBasicBlock *newEdgeBB,
     if (!succBB->getNumArguments())
       return;
     args.push_back(newEdgeBB->createPhiArgument(
-        succBB->getArgument(0)->getType(), OwnershipKind::Owned));
+        succBB->getArgument(0)->getType(),
+        succBB->getArgument(0)->getOwnershipKind()));
     return;
   }
 
@@ -186,7 +187,8 @@ void swift::getEdgeArgs(TermInst *T, unsigned edgeIdx, SILBasicBlock *newEdgeBB,
     if (!succBB->getNumArguments())
       return;
     args.push_back(newEdgeBB->createPhiArgument(
-        succBB->getArgument(0)->getType(), OwnershipKind::Owned));
+        succBB->getArgument(0)->getType(),
+        succBB->getArgument(0)->getOwnershipKind()));
     return;
   }
 

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1032,6 +1032,13 @@ bool SimplifyCFG::tryJumpThreading(BranchInst *BI) {
   auto *DestBB = BI->getDestBB();
   auto *SrcBB = BI->getParent();
   TermInst *destTerminator = DestBB->getTerminator();
+  if (Fn.hasOwnership()) {
+    if (llvm::any_of(DestBB->getArguments(), [this](SILValue op) {
+          return !op->getType().isTrivial(Fn);
+        })) {
+      return false;
+   }
+  }
   // If the destination block ends with a return, we don't want to duplicate it.
   // We want to maintain the canonical form of a single return where possible.
   if (destTerminator->isFunctionExiting())

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1029,12 +1029,6 @@ static bool hasInjectedEnumAtEndOfBlock(SILBasicBlock *block, SILValue enumAddr)
 /// tryJumpThreading - Check to see if it looks profitable to duplicate the
 /// destination of an unconditional jump into the bottom of this block.
 bool SimplifyCFG::tryJumpThreading(BranchInst *BI) {
-  // TODO: OSSA phi support. Even if all block arguments are trivial,
-  // jump-threading may require creation of guaranteed phis, which may require
-  // creation of nested borrow scopes.
-  if (Fn.hasOwnership())
-    return false;
-
   auto *DestBB = BI->getDestBB();
   auto *SrcBB = BI->getParent();
   TermInst *destTerminator = DestBB->getTerminator();

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -57,6 +57,11 @@ llvm::cl::opt<bool> EnableOSSARewriteTerminator(
         "Enable OSSA simplify-cfg with non-trivial terminator rewriting "
         "(staging)."));
 
+llvm::cl::opt<bool> IsInfiniteJumpThreadingBudget(
+    "sil-infinite-jump-threading-budget",
+    llvm::cl::desc(
+        "Use infinite budget for jump threading. Useful for testing purposes"));
+
 STATISTIC(NumBlocksDeleted, "Number of unreachable blocks removed");
 STATISTIC(NumBlocksMerged, "Number of blocks merged together");
 STATISTIC(NumJumpThreads, "Number of jumps threaded");
@@ -1068,7 +1073,7 @@ bool SimplifyCFG::tryJumpThreading(BranchInst *BI) {
   // major second order simplifications.  Here we only do it if there are
   // "constant" arguments to the branch or if we know how to fold something
   // given the duplication.
-  int ThreadingBudget = 0;
+  int ThreadingBudget = IsInfiniteJumpThreadingBudget ? INT_MAX : 0;
 
   for (unsigned i : indices(BI->getArgs())) {
     SILValue Arg = BI->getArg(i);

--- a/test/SILOptimizer/simplify-cfg-debugonly.sil
+++ b/test/SILOptimizer/simplify-cfg-debugonly.sil
@@ -8,7 +8,7 @@ import Swift
 import Builtin
 import Swift
 
-protocol OtherKlass : class {}
+protocol OtherKlass : AnyObject {}
 
 class Klass {}
 

--- a/test/SILOptimizer/simplify_bb_args.sil
+++ b/test/SILOptimizer/simplify_bb_args.sil
@@ -1,0 +1,77 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -simplify-bb-args -sroa-bb-args -enable-ossa-simplify-cfg -enable-ossa-rewriteterminator | %FileCheck %s
+
+// OSSA form of simplify_cfg_args_crash.sil.
+
+// Depends on the temporary test options: -enable-ossa-simplify-cfg -enable-ossa-rewriteterminator
+//
+// REQUIRES: EnableOSSASimplifyCFG
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+enum E {
+	case A
+	case B
+}
+
+// Check that we don't crash in simplifyToSelectValue (rdar://problem/20037686)
+
+// CHECK-LABEL: @test
+sil public [ossa] @test : $@convention(thin) (Builtin.Int64, @inout E) -> () {
+
+bb0(%0 : $Builtin.Int64, %x : $*E):
+  %1 = integer_literal $Builtin.Int64, 0
+  %2 = builtin "cmp_eq_Int64"(%0 : $Builtin.Int64, %1 : $Builtin.Int64) : $Builtin.Int1 // user: %473
+  cond_br %2, bb3a, bb1
+
+bb1:
+  %4 = enum $E, #E.A!enumelt
+  br bb2(%4 : $E)
+
+bb2(%6 : $E):
+  store %6 to [trivial] %x : $*E
+  br bb3
+
+bb3a:
+  br bb3
+
+bb3:                                           // Preds: bb0 bb409
+  %8 = tuple ()                                // user: %4307
+  return %8 : $()                              // id: %4307
+}
+
+// Verify that we do not crash in argument splitting (rdar://problem/25008398).
+
+class C {
+  @_hasStorage let x: Builtin.Int32
+  init()
+}
+
+struct Pair {
+  @_hasStorage let first: C
+  @_hasStorage let second: C
+}
+
+// CHECK-LABEL: @simplify_args_crash
+sil [ossa] @simplify_args_crash : $@convention(thin) (@guaranteed Pair) -> () {
+bb0(%1 : @guaranteed $Pair):
+  // CHECK: [[SECOND:%.*]] = struct_extract %0 : $Pair, #Pair.second
+  // CHECK: [[FIRST:%.*]] = struct_extract %0 : $Pair, #Pair.first
+  // CHECK: br bb1([[FIRST]] : $C, [[SECOND]] : $C)
+  %2 = begin_borrow %1 : $Pair
+  br bb1(%2 : $Pair)
+
+// CHECK: bb1([[FIRST2:%.*]] : $C, [[SECOND2:%.*]] : $C):
+bb1(%3 : @guaranteed $Pair):
+  // CHECK: [[STRUCT:%.*]] = struct $Pair ([[FIRST2]] : $C, [[SECOND2]] : $C)
+  // CHECK: [[SECOND3:%.*]] = struct_extract [[STRUCT]] : $Pair, #Pair.second
+  // CHECK: [[FIRST3:%.*]] = struct_extract [[STRUCT]] : $Pair, #Pair.first
+  // CHECK: br bb1([[FIRST3]] : $C, [[SECOND3]] : $C)
+  br bb2
+
+bb2:
+  br bb1(%3 : $Pair)
+}

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -1,5 +1,4 @@
 // RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
-// FIXME: Update for select_enum change.
 
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also

--- a/test/SILOptimizer/simplify_cfg_and_combine_ossa.sil
+++ b/test/SILOptimizer/simplify_cfg_and_combine_ossa.sil
@@ -1,6 +1,6 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -simplify-cfg -sil-combine -simplify-cfg -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -simplify-cfg -enable-ossa-simplify-cfg -sil-combine -simplify-cfg -sil-combine | %FileCheck %s
 
-// These require both SimplifyCFG and SILCombine
+// These tests require both SimplifyCFG and SILCombine
 
 sil_stage canonical
 
@@ -12,13 +12,13 @@ sil @external_f2 : $@convention(thin) () -> ()
 sil @external_f3 : $@convention(thin) () -> ()
 sil @external_f4 : $@convention(thin) () -> ()
 
-// CHECK-LABEL: sil @select_enum_dominance_simplification : $@convention(thin) (Optional<Int32>) -> () {
+// CHECK-LABEL: sil [ossa] @select_enum_dominance_simplification : $@convention(thin) (Optional<Int32>) -> () {
 // CHECK-NOT: external_f2
 // CHECK-NOT: external_f4
 // CHECK: bb3:
 // CHECK-NEXT: tuple
 // CHECK-NEXT: return
-sil @select_enum_dominance_simplification : $@convention(thin) (Optional<Int32>) -> () {
+sil [ossa] @select_enum_dominance_simplification : $@convention(thin) (Optional<Int32>) -> () {
 bb0(%0 : $Optional<Int32>):
   %t = integer_literal $Builtin.Int1, 1
   %f = integer_literal $Builtin.Int1, 0
@@ -58,18 +58,18 @@ bb7:
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil @switch_enum_dominates_select_enum : $@convention(thin) (Optional<Int32>) -> () {
+// CHECK-LABEL: sil [ossa] @switch_enum_dominates_select_enum : $@convention(thin) (Optional<Int32>) -> () {
 // CHECK-NOT: external_f2
 // CHECK: bb3:
 // CHECK-NEXT: tuple
 // CHECK-NEXT: return
-sil @switch_enum_dominates_select_enum : $@convention(thin) (Optional<Int32>) -> () {
+sil [ossa] @switch_enum_dominates_select_enum : $@convention(thin) (Optional<Int32>) -> () {
 bb0(%0 : $Optional<Int32>):
   %t = integer_literal $Builtin.Int1, 1
   %f = integer_literal $Builtin.Int1, 0
   switch_enum %0 : $Optional<Int32>, case #Optional.none!enumelt: bb4, case #Optional.some!enumelt: bb1
 
-bb1:
+bb1(%arg1 : $Int32):
   %c = select_enum %0 : $Optional<Int32>, case #Optional.none!enumelt: %f, case #Optional.some!enumelt: %t : $Builtin.Int1
   cond_br %c, bb2, bb3
 
@@ -93,18 +93,18 @@ bb5:
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil @switch_enum_dominates_select_enum2 : $@convention(thin) (Optional<Int32>) -> Builtin.Int32 {
+// CHECK-LABEL: sil [ossa] @switch_enum_dominates_select_enum2 : $@convention(thin) (Optional<Int32>) -> Builtin.Int32 {
 // CHECK-DAG: [[L2:%[0-9]+]] = integer_literal {{.*}}, 2
 // CHECK-DAG: [[L1:%[0-9]+]] = integer_literal {{.*}}, 1
 // CHECK: [[R:%[0-9]+]] = select_enum %0 : $Optional<Int32>, case #Optional.none!enumelt: [[L2]], case #Optional.some!enumelt: [[L1]]
 // CHECK-NEXT: return [[R]]
-sil @switch_enum_dominates_select_enum2 : $@convention(thin) (Optional<Int32>) -> Builtin.Int32 {
+sil [ossa] @switch_enum_dominates_select_enum2 : $@convention(thin) (Optional<Int32>) -> Builtin.Int32 {
 bb0(%0 : $Optional<Int32>):
   %i1 = integer_literal $Builtin.Int32, 1
   %i0 = integer_literal $Builtin.Int32, 0
   switch_enum %0 : $Optional<Int32>, case #Optional.none!enumelt: bb2, case #Optional.some!enumelt: bb1
 
-bb1:
+bb1(%arg1 : $Int32):
   %c = select_enum %0 : $Optional<Int32>, case #Optional.none!enumelt: %i0, case #Optional.some!enumelt: %i1 : $Builtin.Int32
   br bb3(%c : $Builtin.Int32)
 
@@ -117,16 +117,19 @@ bb3(%r : $Builtin.Int32):
 }
 
 
-// CHECK-LABEL: sil @cond_br_dominates_cond_fail : $@convention(thin) (Builtin.Int1) -> () {
+// CHECK-LABEL: sil [ossa] @cond_br_dominates_cond_fail : $@convention(thin) (Builtin.Int1) -> () {
 // CHECK: bb0(%0 : $Builtin.Int1):
 // CHECK-NEXT: tuple
 // CHECK-NEXT: return
-sil @cond_br_dominates_cond_fail : $@convention(thin) (Builtin.Int1) -> () {
+sil [ossa] @cond_br_dominates_cond_fail : $@convention(thin) (Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1):
-  cond_br %0, bb2, bb1
+  cond_br %0, bb2a, bb1
 
 bb1:
   cond_fail %0 : $Builtin.Int1
+  br bb2
+
+bb2a:
   br bb2
 
 bb2:
@@ -134,12 +137,12 @@ bb2:
   return %r : $()
 }
 
-/// CHECK-LABEL: sil @select_enum_dominates_switch_enum : $@convention(thin) (Int32) -> Int32 {
+/// CHECK-LABEL: sil [ossa] @select_enum_dominates_switch_enum : $@convention(thin) (Int32) -> Int32 {
 /// The select_enum dominates the switch_enum and knows exactly which element will be
 /// selected.  So this test ensures we can remove the switch_enum
 /// CHECK-NOT: switch_enum
 /// CHECK: return
-sil @select_enum_dominates_switch_enum : $@convention(thin) (Int32) -> Int32 {
+sil [ossa] @select_enum_dominates_switch_enum : $@convention(thin) (Int32) -> Int32 {
 bb0(%0 : $Int32):
   %1 = integer_literal $Builtin.Int32, 0          // users: %5, %9, %9
   %2 = integer_literal $Builtin.Int1, -1          // users: %7, %37
@@ -175,7 +178,7 @@ bb4:                                              // Preds: bb1
 bb5:                                              // Preds: bb3
   switch_enum %18 : $Optional<Int32>, case #Optional.some!enumelt: bb6, case #Optional.none!enumelt: bb7 // id: %29
 
-bb6:                                              // Preds: bb5
+bb6(%arg6 : $Int32):                                              // Preds: bb5
   %30 = unchecked_enum_data %18 : $Optional<Int32>, #Optional.some!enumelt // user: %31
   %31 = struct_extract %30 : $Int32, #Int32._value // user: %34
   %33 = integer_literal $Builtin.Int1, 0          // user: %34
@@ -192,14 +195,14 @@ bb8:                                              // Preds: bb3
   return %39 : $Int32                             // id: %40
 }
 
-/// CHECK-LABEL: sil @select_enum_dominates_switch_enum2 : $@convention(thin) (Int32) -> Int32 {
+/// CHECK-LABEL: sil [ossa] @select_enum_dominates_switch_enum2 : $@convention(thin) (Int32) -> Int32 {
 /// The select_enum dominates the switch_enum and knows exactly which element will be
 /// selected.
 /// In this case, the switch is reached when the select_enum is false.  Given that the switch
 /// only has 2 elements, we know that the other element must be selected.
 /// CHECK-NOT: switch_enum
 /// CHECK: return
-sil @select_enum_dominates_switch_enum2 : $@convention(thin) (Int32) -> Int32 {
+sil [ossa] @select_enum_dominates_switch_enum2 : $@convention(thin) (Int32) -> Int32 {
 bb0(%0 : $Int32):
   %1 = integer_literal $Builtin.Int32, 0           // users: %5, %9, %9
   %2 = integer_literal $Builtin.Int1, -1          // users: %7, %37
@@ -235,9 +238,8 @@ bb4:                                              // Preds: bb1
 bb5:                                              // Preds: bb3
   switch_enum %18 : $Optional<Int32>, case #Optional.some!enumelt: bb6, case #Optional.none!enumelt: bb7 // id: %29
 
-bb6:                                              // Preds: bb5
-  %30 = unchecked_enum_data %18 : $Optional<Int32>, #Optional.some!enumelt // user: %31
-  %31 = struct_extract %30 : $Int32, #Int32._value     // user: %34
+bb6(%arg6 : $Int32):                                              // Preds: bb5
+  %31 = struct_extract %arg6 : $Int32, #Int32._value     // user: %34
   %33 = integer_literal $Builtin.Int1, 0          // user: %34
   %34 = builtin "smul_with_overflow_Int32"(%10 : $Builtin.Int32, %31 : $Builtin.Int32, %33 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1) // user: %35
   %35 = tuple_extract %34 : $(Builtin.Int32, Builtin.Int1), 0 // user: %36

--- a/test/SILOptimizer/simplify_cfg_args_ossa.sil
+++ b/test/SILOptimizer/simplify_cfg_args_ossa.sil
@@ -1,9 +1,11 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -simplify-cfg | %FileCheck %s
 
 sil_stage raw
 
 import Builtin
 import Swift
+
+class A {}
 
 sil_global private @globalinit_token11 : $Builtin.Word
 

--- a/test/SILOptimizer/simplify_cfg_args_ossa_disabled.sil
+++ b/test/SILOptimizer/simplify_cfg_args_ossa_disabled.sil
@@ -1,10 +1,10 @@
-// RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -simplify-cfg | %FileCheck %s
+//
+// REQUIRES: EnableOSSASimplifyCFG
 //
 // These tests case are converted to OSSA form, but aren't yet
-// optimized in OSSA mode. Move them to simplify_cfg_ossa.sil when
+// optimized in OSSA mode. Move them to simplify_cfg_args_ossa.sil when
 // they are enabled.
-//
-// REQUIRES: disabled
 
 class A {}
 

--- a/test/SILOptimizer/simplify_cfg_checkcast.sil
+++ b/test/SILOptimizer/simplify_cfg_checkcast.sil
@@ -1,6 +1,11 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -jumpthread-simplify-cfg -enable-ossa-simplify-cfg -enable-ossa-rewriteterminator | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -jumpthread-simplify-cfg -enable-ossa-simplify-cfg -enable-ossa-rewriteterminator -debug-only=sil-simplify-cfg 2>&1 | %FileCheck %s --check-prefix=CHECK-TRACE
+//
+// REQUIRES: EnableOSSASimplifyCFG
 
-// TODO: replace all the XCHECK lines with CHECK lines
+// FIXME: When OSSA optimization is complete, convert XCHECK to CHECK lines
+
+// FIXME: which of these tests actually require -jumpthread-simplify-cfg instead of -simplify-cfg?
 
 sil_stage canonical
 
@@ -12,6 +17,8 @@ class Klass {
    deinit
   init()
 }
+
+protocol OtherKlass : AnyObject {}
 
 sil [ossa] @consume_klass : $@convention(thin) (@owned Klass) -> ()
 sil [ossa] @use_klass : $@convention(thin) (@guaranteed Klass) -> ()
@@ -42,29 +49,29 @@ sil [ossa] @_TFC3ccb4Base6middlefS0_FT_T_ : $@convention(method) (@guaranteed Ba
 // CHECK-LABEL: sil [ossa] @redundant_checked_cast_br
 sil [ossa] @redundant_checked_cast_br : $@convention(method) (@guaranteed Base) -> () {
 bb0(%0 : @guaranteed $Base):
-// XCHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+// CHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   %1 = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-// XCHECK: checked_cast_br [exact] %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
+// CHECK: checked_cast_br [exact] %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
   checked_cast_br [exact] %0 : $Base to Base, bb2, bb7
 
-// XCHECK: bb1
+// CHECK: bb1
 bb1:
   %3 = tuple ()
   return %3 : $()
 
 bb2(%5 : @guaranteed $Base):
-// XCHECK: [[SUCCESS]]
+// CHECK: [[SUCCESS]]
   %7 = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
 // XCHECK-NOT: checked_cast_br
   checked_cast_br [exact] %0 : $Base to Base, bb3, bb5
-// XCHECK: [[INNER:%.*]] = function_ref @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
-// XCHECK: apply [[INNER]]
-// XCHECK: br bb1
+// CHECK: [[INNER:%.*]] = function_ref @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
+// CHECK: apply [[INNER]]
+// CHECK: br bb1
 
 bb3(%9 : @guaranteed $Base):
-// XCHECK: [[FAIL]]
-// XCHECK-NOT: function-ref
-// XCHECK: apply [[METHOD]]
+// CHECK: [[FAIL]]
+// CHECK-NOT: function-ref
+// CHECK: apply [[METHOD]]
 
   %10 = function_ref @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
   %11 = apply %10(%0) : $@convention(method) (@guaranteed Base) -> ()
@@ -88,31 +95,31 @@ bb7(%defaultBB0 : @guaranteed $Base):
 
 // CHECK-LABEL: sil [ossa] @redundant_checked_cast_br_owned
 sil [ossa] @redundant_checked_cast_br_owned : $@convention(method) (@guaranteed Base) -> () {
-// XCHECK: [[COPY:%.*]] = copy_value %0
-// XCHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-// XCHECK: checked_cast_br [exact] [[COPY]] : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
+// CHECK: [[COPY:%.*]] = copy_value %0
+// CHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+// CHECK: checked_cast_br [exact] [[COPY]] : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
 bb0(%0 : @guaranteed $Base):
   %copy = copy_value %0 : $Base
   %1 = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   checked_cast_br [exact] %copy : $Base to Base, bb2, bb7
 
-// XCHECK: bb1
+// CHECK: bb1
 bb1:
   %3 = tuple ()
   return %3 : $()
 
-// XCHECK: [[SUCCESS]]([[SUCCESSARG:%.*]] : @owned $Base)
+// CHECK: [[SUCCESS]]([[SUCCESSARG:%.*]] : @owned $Base)
 // XCHECK-NOT: checked_cast_br
 // XCHECK: [[INNER:%.*]] = function_ref @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
 // XCHECK: apply [[INNER]]([[SUCCESSARG]])
-// XCHECK: br bb1
+// CHECK: br bb1
 bb2(%5 : @owned $Base):
   %7 = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   checked_cast_br [exact] %5 : $Base to Base, bb3, bb5
 
-// XCHECK: [[FAIL]]([[FAILARG:%.*]] : @owned $Base)
-// XCHECK-NOT: function-ref
-// XCHECK: apply [[METHOD]]([[FAILARG]])
+// CHECK: [[FAIL]]([[FAILARG:%.*]] : @owned $Base)
+// CHECK-NOT: function-ref
+// CHECK: apply [[METHOD]]([[FAILARG]])
 bb3(%9 : @owned $Base):
   %10 = function_ref @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
   %11 = apply %10(%9) : $@convention(method) (@guaranteed Base) -> ()
@@ -140,22 +147,22 @@ bb7(%defaultBB0 : @owned $Base):
 // CHECK-LABEL: sil [ossa] @not_redundant_checked_cast_br : $@convention(method) (@guaranteed Base) -> () {
 sil [ossa] @not_redundant_checked_cast_br : $@convention(method) (@guaranteed Base) -> () {
 bb0(%0 : @guaranteed $Base):
-// XCHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+// CHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   %1 = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-// XCHECK: checked_cast_br [exact] %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
+// CHECK: checked_cast_br [exact] %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
   checked_cast_br [exact] %0 : $Base to Base, bb2, bb7
 
-// XCHECK: bb1:
-// XCHECK: tuple ()
-// XCHECK: return
+// CHECK: bb1:
+// CHECK: tuple ()
+// CHECK: return
 
 bb1:
   %3 = tuple ()
   return %3 : $()
 
 bb2(%5 : @guaranteed $Base):
-// XCHECK: [[SUCCESS]]
-// XCHECK: [[METHOD2:%.*]] = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+// CHECK: [[SUCCESS]]
+// CHECK: [[METHOD2:%.*]] = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   %7 = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   %8 = apply %7(%0) : $@convention(method) (@guaranteed Base) -> ()
   br bb4
@@ -178,16 +185,16 @@ bb6(%17 : $()):
   br bb1
 
 bb7(%10a : @guaranteed $Base):
-// XCHECK: checked_cast_br [exact] %0 : $Base to Derived
+// CHECK: checked_cast_br [exact] %0 : $Base to Derived
   checked_cast_br [exact] %0 : $Base to Derived, bb3, bb5
 }
 
 // CHECK-LABEL: sil [ossa] @failing_checked_cast_br
 sil [ossa] @failing_checked_cast_br : $@convention(method) (@guaranteed Base) -> () {
 bb0(%0 : @guaranteed $Base):
-// XCHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+// CHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   %1 = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-// XCHECK: checked_cast_br [exact] %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
+// CHECK: checked_cast_br [exact] %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
   checked_cast_br [exact] %0 : $Base to Base, bb2, bb7
 
 // CHECK-LABEL: bb1
@@ -196,15 +203,15 @@ bb1:
   return %3 : $()
 
 bb2(%5 : @guaranteed $Base):
-// XCHECK: [[SUCCESS]]([[SUCCESSARG:%.*]] : @guaranteed $Base)
-// XCHECK: [[METHOD2:%.*]] = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+// CHECK: [[SUCCESS]]([[SUCCESSARG:%.*]] : @guaranteed $Base)
+// CHECK: [[METHOD2:%.*]] = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   %7 = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
 // XCHECK-NOT: checked_cast_br [exact] %0 : $Base to Derived
 // XCHECK: apply [[METHOD2]]([[SUCCESSARG]])
 // Check that checked_cast_br [exact] was replaced by a branch to the failure BB of the checked_cast_br.
 // This is because bb2 is reached via the success branch of the checked_cast_br [exact] from bb0.
 // It means that the exact dynamic type of %0 is $Base. Thus it cannot be $Derived.
-// XCHECK: br bb1
+// CHECK: br bb1
   checked_cast_br [exact] %5 : $Base to Derived, bb3, bb5
 
 bb3(%9 : @guaranteed $Derived):
@@ -230,9 +237,9 @@ bb7(%anotherDefaultPayload : @guaranteed $Base):
 
 // CHECK-LABEL: sil [ossa] @failing_checked_cast_br_owned
 sil [ossa] @failing_checked_cast_br_owned : $@convention(method) (@guaranteed Base) -> () {
-// XCHECK: [[COPY:%.*]] = copy_value %0
-// XCHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
-// XCHECK: checked_cast_br [exact] [[COPY]] : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
+// CHECK: [[COPY:%.*]] = copy_value %0
+// CHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+// CHECK: checked_cast_br [exact] [[COPY]] : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
 bb0(%0 : @guaranteed $Base):
   %copy = copy_value %0 : $Base
   %1 = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
@@ -243,14 +250,14 @@ bb1:
   %3 = tuple ()
   return %3 : $()
 
-// XCHECK: [[SUCCESS]]([[SUCCESSARG:%.*]] : @owned $Base)
-// XCHECK: [[METHOD2:%.*]] = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+// CHECK: [[SUCCESS]]([[SUCCESSARG:%.*]] : @owned $Base)
+// CHECK: [[METHOD2:%.*]] = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
 // XCHECK-NOT: checked_cast_br [exact] %0 : $Base to Derived
 // XCHECK: apply [[METHOD2]]([[SUCCESSARG]])
 // Check that checked_cast_br [exact] was replaced by a branch to the failure BB of the checked_cast_br.
 // This is because bb2 is reached via the success branch of the checked_cast_br [exact] from bb0.
 // It means that the exact dynamic type of %0 is $Base. Thus it cannot be $Derived.
-// XCHECK: br bb1
+// CHECK: br bb1
 bb2(%5 : @owned $Base):
   %7 = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
   checked_cast_br [exact] %5 : $Base to Derived, bb3, bb5
@@ -283,13 +290,13 @@ bb7(%anotherDefaultPayload : @owned $Base):
 sil [ossa] @unknown2 : $@convention(thin) () -> ()
 
 // CHECK-LABEL: no_checked_cast_br_threading_with_alloc_ref_stack
-// XCHECK: checked_cast_br
-// XCHECK: apply
-// XCHECK: apply
-// XCHECK: checked_cast_br
-// XCHECK: apply
-// XCHECK: apply
-// XCHECK: return
+// CHECK: checked_cast_br
+// CHECK: apply
+// CHECK: apply
+// CHECK: checked_cast_br
+// CHECK: apply
+// CHECK: apply
+// CHECK: return
 sil [ossa] @no_checked_cast_br_threading_with_alloc_ref_stack : $@convention(method) (@guaranteed Base) -> () {
 bb0(%0 : @guaranteed $Base):
   %fu = function_ref @unknown : $@convention(thin) () -> ()
@@ -379,4 +386,82 @@ bb11:
   %20 = tuple ()
   return %20 : $()
 
+}
+
+// Verify that checked-cast jump-threading kicks in and generates verifiable SIL.
+//
+// CHECK-TRACE-LABEL: ### Run SimplifyCFG on $testCheckCastJumpThread
+// XCHECK-TRACE: Condition is the same if reached over {{.*}} parent @$testCheckCastJumpThread : $@convention(thin) (@guaranteed Klass) -> @owned OtherKlass }
+// XCHECK-TRACE-NEXT: bb3(%{{.*}} : $OtherKlass):
+// XCHECK-TRACE-NEXT:   br bb5(%{{.*}} : $Klass)
+sil shared [ossa] @$testCheckCastJumpThread : $@convention(thin) (@guaranteed Klass) -> @owned OtherKlass {
+bb0(%0 : @guaranteed $Klass):
+  %1 = function_ref @get_klass : $@convention(thin) () -> @owned Klass
+  %2 = integer_literal $Builtin.Int64, 1
+  %3 = apply %1() : $@convention(thin) () -> @owned Klass
+  %4 = copy_value %3 : $Klass
+  checked_cast_br %3 : $Klass to OtherKlass, bb1, bb2
+
+bb1(%5 : $OtherKlass):
+  destroy_value %5 : $OtherKlass
+  %6 = integer_literal $Builtin.Int1, -1
+  br bb3(%6 : $Builtin.Int1)
+
+bb2(%7 : @owned $Klass):
+  destroy_value %7 : $Klass
+  %8 = integer_literal $Builtin.Int1, 0
+  br bb3(%8 : $Builtin.Int1)
+
+bb3(%10 : $Builtin.Int1):
+  cond_br %10, bb5, bb6
+
+bb4:
+  unreachable
+
+bb5:
+  br bb7(%4 : $Klass)
+
+bb6:
+  destroy_value %4 : $Klass
+  br bb10(%2 : $Builtin.Int64)
+
+bb7(%16 : @owned $Klass):
+  checked_cast_br %16 : $Klass to OtherKlass, bb9, bb8
+
+bb8(%18 : $Klass):
+  destroy_value %18 : $Klass
+  br bb4
+
+bb9(%20 : $OtherKlass):
+  return %20 : $OtherKlass
+
+bb10(%22 : $Builtin.Int64):
+  %23 = apply %1() : $@convention(thin) () -> @owned Klass
+  %24 = copy_value %23 : $Klass
+  checked_cast_br %23 : $Klass to OtherKlass, bb11, bb12
+
+bb11(%25 : $OtherKlass):
+  %26 = integer_literal $Builtin.Int1, -1
+  br bb13(%26 : $Builtin.Int1)
+
+bb12(%27 : @owned $Klass):
+  destroy_value %27 : $Klass
+  %28 = integer_literal $Builtin.Int1, 0
+  br bb13(%28 : $Builtin.Int1)
+
+bb13(%30 : $Builtin.Int1):
+  cond_br %30, bb14, bb15
+
+bb14:
+  br bb7(%24 : $Klass)
+
+bb15:
+  destroy_value %24 : $Klass
+  cond_br undef, bb16, bb17
+
+bb16:
+  br bb4
+
+bb17:
+  br bb10(undef : $Builtin.Int64)
 }

--- a/test/SILOptimizer/simplify_cfg_checkcast_jumpthread.sil
+++ b/test/SILOptimizer/simplify_cfg_checkcast_jumpthread.sil
@@ -1,0 +1,382 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
+
+// TODO: replace all the XCHECK lines with CHECK lines
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+class Klass {
+  var a: Int
+   deinit
+  init()
+}
+
+sil [ossa] @consume_klass : $@convention(thin) (@owned Klass) -> ()
+sil [ossa] @use_klass : $@convention(thin) (@guaranteed Klass) -> ()
+sil [ossa] @get_klass : $@convention(thin) () -> @owned Klass
+
+sil [ossa] @unknown : $@convention(thin) () -> ()
+
+struct KlassWrapper {
+  var k: Klass
+}
+
+class Base {
+  @inline(never) func inner()
+  func middle()
+  func outer()
+}
+class Derived : Base {
+  override func inner()
+  @inline(never) final override func middle()
+}
+
+class Final : Derived {
+}
+
+sil [ossa] @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
+sil [ossa] @_TFC3ccb4Base6middlefS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
+
+// CHECK-LABEL: sil [ossa] @redundant_checked_cast_br
+sil [ossa] @redundant_checked_cast_br : $@convention(method) (@guaranteed Base) -> () {
+bb0(%0 : @guaranteed $Base):
+// XCHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+  %1 = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+// XCHECK: checked_cast_br [exact] %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
+  checked_cast_br [exact] %0 : $Base to Base, bb2, bb7
+
+// XCHECK: bb1
+bb1:
+  %3 = tuple ()
+  return %3 : $()
+
+bb2(%5 : @guaranteed $Base):
+// XCHECK: [[SUCCESS]]
+  %7 = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+// XCHECK-NOT: checked_cast_br
+  checked_cast_br [exact] %0 : $Base to Base, bb3, bb5
+// XCHECK: [[INNER:%.*]] = function_ref @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
+// XCHECK: apply [[INNER]]
+// XCHECK: br bb1
+
+bb3(%9 : @guaranteed $Base):
+// XCHECK: [[FAIL]]
+// XCHECK-NOT: function-ref
+// XCHECK: apply [[METHOD]]
+
+  %10 = function_ref @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
+  %11 = apply %10(%0) : $@convention(method) (@guaranteed Base) -> ()
+  br bb4
+
+bb4:
+  %13 = tuple ()
+  br bb6(%13 : $())
+
+bb5(%defaultBB2 : @guaranteed $Base):
+  %15 = apply %7(%0) : $@convention(method) (@guaranteed Base) -> ()
+  br bb4
+
+bb6(%17 : $()):
+  br bb1
+
+bb7(%defaultBB0 : @guaranteed $Base):
+  %19 = apply %1(%0) : $@convention(method) (@guaranteed Base) -> ()
+  br bb1
+}
+
+// CHECK-LABEL: sil [ossa] @redundant_checked_cast_br_owned
+sil [ossa] @redundant_checked_cast_br_owned : $@convention(method) (@guaranteed Base) -> () {
+// XCHECK: [[COPY:%.*]] = copy_value %0
+// XCHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+// XCHECK: checked_cast_br [exact] [[COPY]] : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
+bb0(%0 : @guaranteed $Base):
+  %copy = copy_value %0 : $Base
+  %1 = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+  checked_cast_br [exact] %copy : $Base to Base, bb2, bb7
+
+// XCHECK: bb1
+bb1:
+  %3 = tuple ()
+  return %3 : $()
+
+// XCHECK: [[SUCCESS]]([[SUCCESSARG:%.*]] : @owned $Base)
+// XCHECK-NOT: checked_cast_br
+// XCHECK: [[INNER:%.*]] = function_ref @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
+// XCHECK: apply [[INNER]]([[SUCCESSARG]])
+// XCHECK: br bb1
+bb2(%5 : @owned $Base):
+  %7 = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+  checked_cast_br [exact] %5 : $Base to Base, bb3, bb5
+
+// XCHECK: [[FAIL]]([[FAILARG:%.*]] : @owned $Base)
+// XCHECK-NOT: function-ref
+// XCHECK: apply [[METHOD]]([[FAILARG]])
+bb3(%9 : @owned $Base):
+  %10 = function_ref @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
+  %11 = apply %10(%9) : $@convention(method) (@guaranteed Base) -> ()
+  destroy_value %9 : $Base
+  br bb4
+
+bb4:
+  %13 = tuple ()
+  br bb6(%13 : $())
+
+bb5(%defaultBB2 : @owned $Base):
+  %15 = apply %7(%defaultBB2) : $@convention(method) (@guaranteed Base) -> ()
+  destroy_value %defaultBB2 : $Base
+  br bb4
+
+bb6(%17 : $()):
+  br bb1
+
+bb7(%defaultBB0 : @owned $Base):
+  %19 = apply %1(%defaultBB0) : $@convention(method) (@guaranteed Base) -> ()
+  destroy_value %defaultBB0 : $Base
+  br bb1
+}
+
+// CHECK-LABEL: sil [ossa] @not_redundant_checked_cast_br : $@convention(method) (@guaranteed Base) -> () {
+sil [ossa] @not_redundant_checked_cast_br : $@convention(method) (@guaranteed Base) -> () {
+bb0(%0 : @guaranteed $Base):
+// XCHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+  %1 = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+// XCHECK: checked_cast_br [exact] %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
+  checked_cast_br [exact] %0 : $Base to Base, bb2, bb7
+
+// XCHECK: bb1:
+// XCHECK: tuple ()
+// XCHECK: return
+
+bb1:
+  %3 = tuple ()
+  return %3 : $()
+
+bb2(%5 : @guaranteed $Base):
+// XCHECK: [[SUCCESS]]
+// XCHECK: [[METHOD2:%.*]] = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+  %7 = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+  %8 = apply %7(%0) : $@convention(method) (@guaranteed Base) -> ()
+  br bb4
+
+bb3(%9 : @guaranteed $Derived):
+  %10 = function_ref @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
+  %11 = apply %10(%0) : $@convention(method) (@guaranteed Base) -> ()
+  br bb4
+
+bb4:
+  %13 = tuple ()
+  br bb6(%13 : $())
+
+bb5(%9a : @guaranteed $Base):
+  %14 = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+  %15 = apply %14(%0) : $@convention(method) (@guaranteed Base) -> ()
+  br bb4
+
+bb6(%17 : $()):
+  br bb1
+
+bb7(%10a : @guaranteed $Base):
+// XCHECK: checked_cast_br [exact] %0 : $Base to Derived
+  checked_cast_br [exact] %0 : $Base to Derived, bb3, bb5
+}
+
+// CHECK-LABEL: sil [ossa] @failing_checked_cast_br
+sil [ossa] @failing_checked_cast_br : $@convention(method) (@guaranteed Base) -> () {
+bb0(%0 : @guaranteed $Base):
+// XCHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+  %1 = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+// XCHECK: checked_cast_br [exact] %0 : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
+  checked_cast_br [exact] %0 : $Base to Base, bb2, bb7
+
+// CHECK-LABEL: bb1
+bb1:
+  %3 = tuple ()
+  return %3 : $()
+
+bb2(%5 : @guaranteed $Base):
+// XCHECK: [[SUCCESS]]([[SUCCESSARG:%.*]] : @guaranteed $Base)
+// XCHECK: [[METHOD2:%.*]] = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+  %7 = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+// XCHECK-NOT: checked_cast_br [exact] %0 : $Base to Derived
+// XCHECK: apply [[METHOD2]]([[SUCCESSARG]])
+// Check that checked_cast_br [exact] was replaced by a branch to the failure BB of the checked_cast_br.
+// This is because bb2 is reached via the success branch of the checked_cast_br [exact] from bb0.
+// It means that the exact dynamic type of %0 is $Base. Thus it cannot be $Derived.
+// XCHECK: br bb1
+  checked_cast_br [exact] %5 : $Base to Derived, bb3, bb5
+
+bb3(%9 : @guaranteed $Derived):
+  %10 = function_ref @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
+  %11 = apply %10(%0) : $@convention(method) (@guaranteed Base) -> ()
+  br bb4
+
+bb4:
+  %13 = tuple ()
+  br bb6(%13 : $())
+
+bb5(%9o : @guaranteed $Base):
+  %15 = apply %7(%9o) : $@convention(method) (@guaranteed Base) -> ()
+  br bb4
+
+bb6(%17 : $()):
+  br bb1
+
+bb7(%anotherDefaultPayload : @guaranteed $Base):
+  %19 = apply %1(%0) : $@convention(method) (@guaranteed Base) -> ()
+  br bb1
+}
+
+// CHECK-LABEL: sil [ossa] @failing_checked_cast_br_owned
+sil [ossa] @failing_checked_cast_br_owned : $@convention(method) (@guaranteed Base) -> () {
+// XCHECK: [[COPY:%.*]] = copy_value %0
+// XCHECK: [[METHOD:%.*]] = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+// XCHECK: checked_cast_br [exact] [[COPY]] : $Base to Base, [[SUCCESS:bb[0-9]+]], [[FAIL:bb[0-9]+]]
+bb0(%0 : @guaranteed $Base):
+  %copy = copy_value %0 : $Base
+  %1 = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+  checked_cast_br [exact] %copy : $Base to Base, bb2, bb7
+
+// CHECK-LABEL: bb1
+bb1:
+  %3 = tuple ()
+  return %3 : $()
+
+// XCHECK: [[SUCCESS]]([[SUCCESSARG:%.*]] : @owned $Base)
+// XCHECK: [[METHOD2:%.*]] = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+// XCHECK-NOT: checked_cast_br [exact] %0 : $Base to Derived
+// XCHECK: apply [[METHOD2]]([[SUCCESSARG]])
+// Check that checked_cast_br [exact] was replaced by a branch to the failure BB of the checked_cast_br.
+// This is because bb2 is reached via the success branch of the checked_cast_br [exact] from bb0.
+// It means that the exact dynamic type of %0 is $Base. Thus it cannot be $Derived.
+// XCHECK: br bb1
+bb2(%5 : @owned $Base):
+  %7 = class_method %0 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+  checked_cast_br [exact] %5 : $Base to Derived, bb3, bb5
+
+bb3(%9 : @owned $Derived):
+  %upcast = upcast %9 : $Derived to $Base
+  %10 = function_ref @_TFC3ccb4Base5innerfS0_FT_T_ : $@convention(method) (@guaranteed Base) -> ()
+  %11 = apply %10(%upcast) : $@convention(method) (@guaranteed Base) -> ()
+  destroy_value %upcast : $Base
+  br bb4
+
+bb4:
+  %13 = tuple ()
+  br bb6(%13 : $())
+
+bb5(%9o : @owned $Base):
+  %15 = apply %7(%9o) : $@convention(method) (@guaranteed Base) -> ()
+  destroy_value %9o : $Base
+  br bb4
+
+bb6(%17 : $()):
+  br bb1
+
+bb7(%anotherDefaultPayload : @owned $Base):
+  %19 = apply %1(%0) : $@convention(method) (@guaranteed Base) -> ()
+  destroy_value %anotherDefaultPayload : $Base
+  br bb1
+}
+
+sil [ossa] @unknown2 : $@convention(thin) () -> ()
+
+// CHECK-LABEL: no_checked_cast_br_threading_with_alloc_ref_stack
+// XCHECK: checked_cast_br
+// XCHECK: apply
+// XCHECK: apply
+// XCHECK: checked_cast_br
+// XCHECK: apply
+// XCHECK: apply
+// XCHECK: return
+sil [ossa] @no_checked_cast_br_threading_with_alloc_ref_stack : $@convention(method) (@guaranteed Base) -> () {
+bb0(%0 : @guaranteed $Base):
+  %fu = function_ref @unknown : $@convention(thin) () -> ()
+  %fu2 = function_ref @unknown2 : $@convention(thin) () -> ()
+  checked_cast_br [exact] %0 : $Base to Base, bb1, bb2
+
+bb1(%1 : @guaranteed $Base):
+  apply %fu() : $@convention(thin) () -> ()
+  br bb3
+
+bb2(%1a : @guaranteed $Base):
+  apply %fu2() : $@convention(thin) () -> ()
+  br bb3
+
+bb3:
+  %a = alloc_ref [stack] $Base
+  checked_cast_br [exact] %0 : $Base to Base, bb4, bb5
+
+bb4(%2 : @guaranteed $Base):
+  apply %fu() : $@convention(thin) () -> ()
+  br bb6
+
+bb5(%2a : @guaranteed $Base):
+  apply %fu2() : $@convention(thin) () -> ()
+  br bb6
+
+bb6:
+  dealloc_ref [stack] %a : $Base
+  %r = tuple()
+  return %r : $()
+}
+
+// Test a redundant checked_cast_br that has success, failure paths, and unknown paths.
+//
+// TODO: this is currently a bailout.
+//
+//!!! CHECKME
+sil [ossa] @redundant_checked_cast_br_joined_success_fail_unknown : $@convention(method) (@guaranteed Base) -> () {
+bb0(%0 : @guaranteed $Base):
+  %middle = class_method %0 : $Base, #Base.middle : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+  checked_cast_br [exact] %0 : $Base to Base, bb1, bb4
+
+bb1(%successBB0 : @guaranteed $Base):
+  cond_br undef, bb2, bb3
+
+bb2:
+  %successBB0call2 = apply %middle(%successBB0) : $@convention(method) (@guaranteed Base) -> ()
+  %successBB0borrow2 = begin_borrow %successBB0 : $Base
+  br bb8(%successBB0borrow2 : $Base)
+
+bb3:
+  %successBB0call3 = apply %middle(%successBB0) : $@convention(method) (@guaranteed Base) -> ()
+  %successBB0borrow3 = begin_borrow %successBB0 : $Base
+  br bb7(%successBB0borrow3 : $Base)
+
+bb4(%failBB0 : @guaranteed $Base):
+  cond_br undef, bb5, bb6
+
+bb5:
+  %failBB0call5 = apply %middle(%failBB0) : $@convention(method) (@guaranteed Base) -> ()
+  %failBB0borrow5 = begin_borrow %failBB0 : $Base
+  br bb7(%failBB0borrow5 : $Base)
+
+bb6:
+  %failBB0call6 = apply %middle(%failBB0) : $@convention(method) (@guaranteed Base) -> ()
+  %failBB0borrow6 = begin_borrow %failBB0 : $Base
+  br bb8(%failBB0borrow6 : $Base)
+
+bb7(%unknown : @guaranteed $Base):
+  %unknownCall = apply %middle(%unknown) : $@convention(method) (@guaranteed Base) -> ()
+  br bb8(%unknown : $Base)
+
+bb8(%joined : @guaranteed $Base):
+  %joinedCall = apply %middle(%joined) : $@convention(method) (@guaranteed Base) -> ()
+  checked_cast_br [exact] %joined : $Base to Base, bb9, bb10
+
+bb9(%successBB7 : @guaranteed $Base):
+  %successBB7call8 = apply %middle(%successBB7) : $@convention(method) (@guaranteed Base) -> ()
+  br bb11
+
+bb10(%failBB7 : @guaranteed $Base):
+  %failBB7call8 = apply %middle(%failBB7) : $@convention(method) (@guaranteed Base) -> ()
+  br bb11
+
+bb11:
+  end_borrow %joined : $Base
+  %20 = tuple ()
+  return %20 : $()
+
+}

--- a/test/SILOptimizer/simplify_cfg_dom_jumpthread.sil
+++ b/test/SILOptimizer/simplify_cfg_dom_jumpthread.sil
@@ -1,0 +1,468 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
+
+// Test dominator-based jump-threading with OSSA. This requires
+// -jumpthread-simplify-cfg to enable dominator-based
+// jump-threading.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+// Includes an OSSA form of a test from simplify_cfg_opaque.sil
+// ...along with new OSSA test cases.
+
+class C {
+  @_hasStorage @_hasInitialValue var field: Int { get set }
+  init()
+
+  func method() -> Any
+  func f() -> FakeOptional<T>
+}
+
+sil @getC : $@convention(thin) () -> C
+
+// Test multiple uses and cloned allocation.
+//
+// project_box and struct_extract_addr will be sunk into three
+// different blocks, but only once per block.
+struct S {
+  @_hasStorage @_hasInitialValue var x: Int { get set }
+  init(x: Int = 0)
+  init()
+}
+sil @doNothing : $@convention(thin) (@inout Int) -> ()
+
+enum FakeOptional<T> {
+case some(T)
+case none
+}
+
+struct T {
+    let s: S
+}
+
+enum E {
+	case A
+	case B
+	case C
+}
+
+class Base { }
+
+class Derived1 : Base { }
+
+class Derived2 : Base { }
+
+// Test that jump threading sinks a
+// ref_tail_addr->index_addr->struct_element_addr chain and generates
+// a phi for the index_addr's index operand.
+//
+// The retain on separate paths followed by a merged release, and
+// target block with a conditional branch are necessary just to get
+// jump threading to kick in.
+//
+// CHECK-LABEL: sil @testJumpThreadIndex : $@convention(thin) (__ContiguousArrayStorageBase, Builtin.Int64) -> Builtin.Int32 {
+// CHECK: bb0(%0 : $__ContiguousArrayStorageBase, %1 : $Builtin.Int64):
+// CHECK:   cond_br undef, bb2, bb1
+// CHECK: bb1:
+// CHECK:   apply
+// CHECK:   strong_retain
+// CHECK:   strong_release
+// CHECK:   [[IDX2:%.*]] = builtin "truncOrBitCast_Int64_Word"(%1 : $Builtin.Int64) : $Builtin.Word
+// CHECK:   br bb3([[IDX2]] : $Builtin.Word)
+// CHECK: bb2:
+// CHECK:   apply
+// CHECK:   strong_retain
+// CHECK:   strong_release
+// CHECK:   [[IDX1:%.*]] = builtin "truncOrBitCast_Int64_Word"(%1 : $Builtin.Int64) : $Builtin.Word
+// CHECK:   br bb3([[IDX1]] : $Builtin.Word)
+// CHECK: bb3([[PHI:%.*]] : $Builtin.Word):
+// CHECK:   [[TAIL:%.*]] = ref_tail_addr %0 : $__ContiguousArrayStorageBase, $Int32
+// CHECK:   [[ELT:%.*]] = index_addr [[TAIL]] : $*Int32, %14 : $Builtin.Word
+// CHECK:   [[ADR:%.*]] = struct_element_addr [[ELT]] : $*Int32, #Int32._value
+// CHECK:   load [[ADR]] : $*Builtin.Int32
+// CHECK:   cond_br undef, bb4, bb5
+// CHECK-LABEL: } // end sil function 'testJumpThreadIndex'
+sil @testJumpThreadIndex : $@convention(thin) (__ContiguousArrayStorageBase, Builtin.Int64) -> Builtin.Int32 {
+bb0(%0 : $__ContiguousArrayStorageBase, %1 : $Builtin.Int64):
+  %f = function_ref @getC : $@convention(thin) () -> C
+  cond_br undef, bb1, bb2
+
+bb1:
+  %c1 = apply %f() : $@convention(thin) ()->C
+  strong_retain %c1 : $C
+  br bb3(%c1 : $C)
+
+bb2:
+  %c2 = apply %f() : $@convention(thin) ()->C
+  strong_retain %c2 : $C
+  br bb3(%c2 : $C)
+
+bb3(%arg : $C):
+  strong_release %arg : $C
+  %tail = ref_tail_addr %0 : $__ContiguousArrayStorageBase, $Int32
+  %idx = builtin "truncOrBitCast_Int64_Word"(%1 : $Builtin.Int64) : $Builtin.Word
+  %elt = index_addr %tail : $*Int32, %idx : $Builtin.Word
+  %adr = struct_element_addr %elt : $*Int32, #Int32._value
+  br bb4
+
+bb4:
+  %val = load %adr : $*Builtin.Int32
+  cond_br undef, bb4, bb5
+
+bb5:
+  return %val : $Builtin.Int32
+}
+
+// CHECK-LABEL: sil @testMultiUse : $@convention(method) (Bool, @inout Int) -> () {
+// CHECK: bb0(%0 : $Bool, %1 : $*Int):
+// CHECK:   cond_br %{{.*}}, bb1, bb2
+// CHECK: bb1:
+// CHECK:   apply %{{.*}}(%1) : $@convention(thin) (@inout Int) -> ()
+// CHECK:   [[ALLOC2:%.*]] = alloc_box ${ var S }, var, name "s"
+// CHECK:   [[PROJ2:%.*]] = project_box [[ALLOC2]] : ${ var S }, 0
+// CHECK:   [[ADR2:%.*]] = struct_element_addr [[PROJ2]] : $*S, #S.x
+// CHECK:   store %{{.*}} to [[ADR2]] : $*Int
+// CHECK:   apply %{{.*}}([[ADR2]]) : $@convention(thin) (@inout Int) -> ()
+// CHECK:   br bb3([[ALLOC2]] : ${ var S })
+// CHECK: bb2:
+// CHECK:   [[ALLOC1:%.*]] = alloc_box ${ var S }, var, name "s"
+// CHECK:   [[PROJ1:%.*]] = project_box [[ALLOC1]] : ${ var S }, 0
+// CHECK:   [[ADR1:%.*]] = struct_element_addr [[PROJ1]] : $*S, #S.x
+// CHECK:   store %{{.*}} to [[ADR1]] : $*Int
+// CHECK:   br bb3([[ALLOC1]] : ${ var S })
+// CHECK: bb3([[BOXARG:%.*]] : ${ var S }):
+// CHECK:   [[PROJ3:%.*]] = project_box [[BOXARG]] : ${ var S }, 0
+// CHECK:   [[ADR3:%.*]] = struct_element_addr [[PROJ3]] : $*S, #S.x
+// CHECK:   apply %{{.*}}([[ADR3]]) : $@convention(thin) (@inout Int) -> ()
+// CHECK:   release_value [[BOXARG]] : ${ var S }
+// CHECK-LABEL: } // end sil function 'testMultiUse'
+sil @testMultiUse : $@convention(method) (Bool, @inout Int) -> () {
+bb0(%0 : $Bool, %1 : $*Int):
+  %bool = struct_extract %0 : $Bool, #Bool._value
+  cond_br %bool, bb1, bb2
+
+bb1:
+  %f1 = function_ref @doNothing : $@convention(thin) (@inout Int) -> ()
+  %call1 = apply %f1(%1) : $@convention(thin) (@inout Int) -> ()
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %box3 = alloc_box ${ var S }, var, name "s"
+  %proj3 = project_box %box3 : ${ var S }, 0
+  %adr3 = struct_element_addr %proj3 : $*S, #S.x
+  cond_br %bool, bb4, bb5
+
+bb4:
+  %i4 = load %1 : $*Int
+  store %i4 to %adr3 : $*Int
+  %f2 = function_ref @doNothing : $@convention(thin) (@inout Int) -> ()
+  %call2 = apply %f2(%adr3) : $@convention(thin) (@inout Int) -> ()
+  br bb6
+
+bb5:
+  %i5 = load %1 : $*Int
+  store %i5 to %adr3 : $*Int
+  br bb6
+
+bb6:
+  %f6 = function_ref @doNothing : $@convention(thin) (@inout Int) -> ()
+  %call6 = apply %f6(%adr3) : $@convention(thin) (@inout Int) -> ()
+  release_value %box3 : ${ var S }
+  %z = tuple ()
+  return %z : $()
+}
+
+// CHECK-LABEL: sil @test_jump_threading
+// CHECK: bb5(%{{[0-9]+}} : $Builtin.Int64):
+// CHECK-NEXT: br bb1
+sil @test_jump_threading : $@convention(thin)  (Builtin.Int1) -> () {
+bb0(%0 : $Builtin.Int1):
+  cond_br %0, bb2, bb3
+
+// Blocks are handled from last to first. Block bb1 is placed here so that its argument
+// is not optimized before jump threading is done in bb2 and bb3.
+bb1(%i4 : $Builtin.Int64):
+  %f3 = function_ref @get_condition : $@convention(thin)  (Builtin.Int64) -> Builtin.Int1
+  %c1 = apply %f3(%i3) : $@convention(thin)  (Builtin.Int64) -> Builtin.Int1
+  %i5 = integer_literal $Builtin.Int64, 27
+  cond_br %c1, bb1(%i5 : $Builtin.Int64), bb5
+
+bb2:
+  %f1 = function_ref @get_int1 : $@convention(thin)  () -> Builtin.Int64
+  %i1 = apply %f1() : $@convention(thin)  () -> Builtin.Int64
+  br bb4(%i1 : $Builtin.Int64)
+
+bb3:
+  %f2 = function_ref @get_int1 : $@convention(thin)  () -> Builtin.Int64
+  %i2 = apply %f2() : $@convention(thin)  () -> Builtin.Int64
+  br bb4(%i2 : $Builtin.Int64)
+
+// Jump threading must not be done for this block because the argument %i3 is also
+// used in bb1.
+bb4(%i3 : $Builtin.Int64):
+  br bb1(%i3 : $Builtin.Int64)
+
+bb5:
+  %r1 = tuple ()
+  return %r1 : $()
+
+}
+
+sil @get_int1 : $@convention(thin)  () -> Builtin.Int64
+sil @get_int2 : $@convention(thin)  () -> Builtin.Int64
+sil @get_condition : $@convention(thin)  (Builtin.Int64) -> Builtin.Int1
+
+
+public final class AA {
+}
+public final class BB {
+  @_hasStorage internal weak final var n:  BB!
+  @_hasStorage internal final var o: AA!
+}
+
+// Test that SimplifyCFG does not hang when compiling an infinite loop with switch_enum.
+// CHECK-LABEL: test_inifite_loop
+sil hidden @test_inifite_loop : $@convention(method) (@owned BB) -> () {
+bb0(%0 : $BB):
+  %31 = enum $Optional<BB>, #Optional.some!enumelt, %0 : $BB
+  br bb4(%31 : $Optional<BB>)
+
+bb4(%36 : $Optional<BB>):
+  switch_enum %36 : $Optional<BB>, case #Optional.some!enumelt: bb6, default bb5
+
+bb5:
+  br bb7
+
+bb6:
+  %39 = unchecked_enum_data %36 : $Optional<BB>, #Optional.some!enumelt
+  %40 = ref_element_addr %39 : $BB, #BB.o
+  %41 = load %40 : $*Optional<AA>
+  release_value %41 : $Optional<AA>
+  br bb7
+
+bb7:
+  switch_enum %36 : $Optional<BB>, case #Optional.none!enumelt: bb8, case #Optional.some!enumelt: bb9
+
+bb8:
+  br bb4(%36 : $Optional<BB>)
+
+bb9:
+  %48 = unchecked_enum_data %36 : $Optional<BB>, #Optional.some!enumelt
+  %49 = ref_element_addr %48 : $BB, #BB.n
+  %50 = load_weak %49 : $*@sil_weak Optional<BB>
+  release_value %36 : $Optional<BB>
+  switch_enum %50 : $Optional<BB>, case #Optional.some!enumelt: bb11, case #Optional.none!enumelt: bb10
+
+bb10:
+  br bb4(%50 : $Optional<BB>)
+
+bb11:
+  %54 = unchecked_enum_data %50 : $Optional<BB>, #Optional.some!enumelt
+  %55 = ref_to_raw_pointer %54 : $BB to $Builtin.RawPointer
+  %56 = ref_to_raw_pointer %0 : $BB to $Builtin.RawPointer
+  %57 = builtin "cmp_eq_RawPointer"(%55 : $Builtin.RawPointer, %56 : $Builtin.RawPointer) : $Builtin.Int1
+  cond_br %57, bb13, bb12
+
+bb12:
+  br bb4(%50 : $Optional<BB>)
+
+bb13:
+  release_value %50 : $Optional<BB>
+  strong_release %0 : $BB
+  %65 = tuple ()
+  return %65 : $()
+}
+
+sil @some_function : $@convention(thin) (AA) -> Optional<AA>
+
+// Another test for checking that SimplifyCFG does not hang.
+// CHECK-LABEL: test_other_infinite_loop
+sil hidden @test_other_infinite_loop : $@convention(method) (@owned AA) -> () {
+bb0(%5 : $AA):
+  strong_retain %5 : $AA
+  %6 = enum $Optional<AA>, #Optional.some!enumelt, %5 : $AA
+  br bb1(%6 : $Optional<AA>)
+
+bb1(%8 : $Optional<AA>):
+  retain_value %8 : $Optional<AA>
+  switch_enum %8 : $Optional<AA>, case #Optional.some!enumelt: bb3, default bb2
+
+bb2:
+  release_value %8 : $Optional<AA>
+  br bb6
+
+bb3:
+  cond_br undef, bb4, bb5
+
+bb4:
+  %85 = tuple ()
+  return %85 : $()
+
+bb5:
+  br bb6
+
+bb6:
+  switch_enum %8 : $Optional<AA>, case #Optional.none!enumelt: bb7, default bb8
+
+bb7:
+  br bb9(%8 : $Optional<AA>)
+
+bb8:
+  %23 = unchecked_enum_data %8 : $Optional<AA>, #Optional.some!enumelt
+  strong_retain %23 : $AA
+  %25 = function_ref @some_function : $@convention(thin) (AA) -> Optional<AA>
+  %26 = apply %25(%23) : $@convention(thin) (AA) -> Optional<AA>
+  strong_release %23 : $AA
+  br bb9(%26 : $Optional<AA>)
+
+bb9(%29 : $Optional<AA>):
+  release_value %8 : $Optional<AA>
+  br bb1(%29 : $Optional<AA>)
+
+}
+
+// -----------------------------------------------------------------------------
+// Test jump-threading through a non-pure address producer.
+//
+// BB3 cannot (currently) be cloned because the block cloner does not
+// know how to sink address producers unless they are pure address
+// projections. init_existential_addr is not a pure projection. It's
+// address is transitively used outside bb3 via %17 =
+// tuple_element_addr. Test that cloning is inhibited. If cloning did
+// happen, then it would either need to sink init_existential_addr, or
+// SSA would be incorrectly updated.
+
+// Make BB3 is not jump-threaded. And init_existential_addr is not cloned
+//
+// CHECK-LABEL: sil hidden @nonPureAddressProducer : $@convention(method) (@guaranteed C) -> @out Any {
+// CHECK: bb0(%0 : $*Any, %1 : $C):
+// CHECK:   switch_enum %{{.*}} : $FakeOptional<T>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
+// CHECK: bb3(%{{.*}} : $FakeOptional<Int64>):
+// CHECK:   init_existential_addr %0 : $*Any, $(FakeOptional<Int64>, FakeOptional<S>)
+// CHECK:   switch_enum %{{.*}} : $FakeOptional<T>, case #FakeOptional.some!enumelt: bb4, case #FakeOptional.none!enumelt: bb6
+// CHECK-LABEL: } // end sil function 'nonPureAddressProducer'
+sil hidden @nonPureAddressProducer : $@convention(method) (@guaranteed C) -> @out Any {
+bb0(%0 : $*Any, %1 : $C):
+  %3 = class_method %1 : $C, #C.f : (C) -> () -> FakeOptional<T>, $@convention(method) (@guaranteed C) -> FakeOptional<T>
+  %4 = apply %3(%1) : $@convention(method) (@guaranteed C) -> FakeOptional<T>
+  switch_enum %4 : $FakeOptional<T>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
+
+bb1:
+  %7 = integer_literal $Builtin.Int64, 1
+  %8 = struct $Int64 (%7 : $Builtin.Int64)
+  %9 = enum $FakeOptional<Int64>, #FakeOptional.some!enumelt, %8 : $Int64
+  br bb3(%9 : $FakeOptional<Int64>)
+
+bb2:
+  %11 = enum $FakeOptional<Int64>, #FakeOptional.none!enumelt
+  br bb3(%11 : $FakeOptional<Int64>)
+
+bb3(%13 : $FakeOptional<Int64>):
+  %15 = init_existential_addr %0 : $*Any, $(FakeOptional<Int64>, FakeOptional<S>)
+  %16 = tuple_element_addr %15 : $*(FakeOptional<Int64>, FakeOptional<S>), 0
+  %17 = tuple_element_addr %15 : $*(FakeOptional<Int64>, FakeOptional<S>), 1
+  store %13 to %16 : $*FakeOptional<Int64>
+  switch_enum %4 : $FakeOptional<T>, case #FakeOptional.some!enumelt: bb4, case #FakeOptional.none!enumelt: bb6
+
+bb4(%20 : $T):
+  %21 = struct_extract %20 : $T, #T.s
+  %22 = enum $FakeOptional<S>, #FakeOptional.some!enumelt, %21 : $S
+  store %22 to %17 : $*FakeOptional<S>
+  br bb5
+
+bb5:
+  %25 = tuple ()
+  return %25 : $()
+
+bb6:
+  %27 = enum $FakeOptional<S>, #FakeOptional.none!enumelt
+  store %27 to %17 : $*FakeOptional<S>
+  br bb5
+}
+
+// -----------------------------------------------------------------------------
+// Test select_enum correctness
+// -----------------------------------------------------------------------------
+
+// Two select_enum instructions must not be considered as the same "condition",
+// even if they have the same enum operand.
+// This test checks that SimplifyCFG does not remove a dominated terminator with
+// such a condition.
+
+// CHECK-LABEL: sil @test_checked_cast_br
+// CHECK: select_enum
+// CHECK: checked_cast_br
+// CHECK: integer_literal $Builtin.Int64, 1
+// CHECK: select_enum
+// CHECK: checked_cast_br
+// CHECK: integer_literal $Builtin.Int64, 2
+// CHECK: integer_literal $Builtin.Int64, 3
+// CHECK: return
+sil @test_checked_cast_br : $@convention(thin) (E, @owned Base, @owned Base, @owned Base, @owned Base) -> Builtin.Int64 {
+bb0(%0 : $E, %1 : $Base, %2 : $Base, %3 : $Base, %4 : $Base):
+  %s1 = select_enum %0 : $E, case #E.A!enumelt: %1, default %2 : $Base
+  checked_cast_br %s1 : $Base to Derived1, bb1, bb2
+
+bb1(%a1 : $Derived1):
+  %i1 = integer_literal $Builtin.Int64, 1
+  br bb5(%i1 : $Builtin.Int64)
+
+bb2:
+  %s2 = select_enum %0 : $E, case #E.B!enumelt: %3, default %4 : $Base
+  checked_cast_br %s2 : $Base to Derived1, bb3, bb4
+
+bb3(%a2 : $Derived1):
+  %i2 = integer_literal $Builtin.Int64, 2
+  br bb5(%i2 : $Builtin.Int64)
+
+bb4:
+  %i3 = integer_literal $Builtin.Int64, 3
+  br bb5(%i3 : $Builtin.Int64)
+
+bb5(%a3 : $Builtin.Int64):
+  return %a3 : $Builtin.Int64
+}
+
+// CHECK-LABEL: sil @test_cond_br
+// CHECK: select_enum
+// CHECK: cond_br
+// CHECK: integer_literal $Builtin.Int64, 1
+// CHECK: select_enum
+// CHECK: cond_br
+// CHECK: integer_literal $Builtin.Int64, 2
+// CHECK: integer_literal $Builtin.Int64, 3
+// CHECK: return
+sil @test_cond_br : $@convention(thin) (E, @owned Base, @owned Base, @owned Base, @owned Base) -> Builtin.Int64 {
+bb0(%0 : $E, %1 : $Base, %2 : $Base, %3 : $Base, %4 : $Base):
+  %t1 = integer_literal $Builtin.Int1, -1
+  %f1 = integer_literal $Builtin.Int1, 0
+  %s1 = select_enum %0 : $E, case #E.A!enumelt: %t1, default %f1 : $Builtin.Int1
+  cond_br %s1, bb1, bb2
+
+bb1:
+  %i1 = integer_literal $Builtin.Int64, 1
+  br bb5(%i1 : $Builtin.Int64)
+
+bb2:
+  %s2 = select_enum %0 : $E, case #E.B!enumelt: %t1, default %f1 : $Builtin.Int1
+  cond_br %s2, bb3, bb4
+
+bb3:
+  %i2 = integer_literal $Builtin.Int64, 2
+  br bb5(%i2 : $Builtin.Int64)
+
+bb4:
+  %i3 = integer_literal $Builtin.Int64, 3
+  br bb5(%i3 : $Builtin.Int64)
+
+bb5(%a3 : $Builtin.Int64):
+  return %a3 : $Builtin.Int64
+}
+
+// -----------------------------------------------------------------------------

--- a/test/SILOptimizer/simplify_cfg_dominators.sil
+++ b/test/SILOptimizer/simplify_cfg_dominators.sil
@@ -1,5 +1,11 @@
 // RUN: %target-sil-opt -enable-sil-verify-all %s -simplify-cfg | %FileCheck %s
 
+// Tests dominator-based simplification with OSSA. This does not
+// require -jumpthread-simplify-cfg, which enabled jump-threading
+// within dominator-based simplification.
+
+// Includes the OSSA form of tests from simplify_cfg_unique_values.sil.
+
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/simplify_cfg_opaque.sil
+++ b/test/SILOptimizer/simplify_cfg_opaque.sil
@@ -1,4 +1,8 @@
-// RUN: %target-sil-opt -enable-sil-opaque-values -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-opaque-values -enable-sil-verify-all %s -jumpthread-simplify-cfg -enable-ossa-rewriteterminator | %FileCheck %s
+
+// REQUIRES: EnableOSSASimplifyCFG
+
+// FIXME: Convert XCHECK to CHECK
 
 sil_stage canonical
 
@@ -6,31 +10,43 @@ protocol P {}
 
 // Test jump threading into a destination block terminated by checked_cast_value_br.
 //
-// CHECK-LABEL: sil @testJumpThread : $@convention(thin) (Any, Any) -> () {
-// CHECK: bb0(%0 : $Any, %1 : $Any):
+// CHECK-LABEL: sil [ossa] @testJumpThread : $@convention(thin) (@owned Any, @owned Any) -> () {
+// CHECK: bb0(%0 : @owned $Any, %1 : @owned $Any):
 // CHECK:   cond_br undef, bb1, bb2
 // CHECK: bb1:
-// CHECK:   retain_value %0 : $Any
-// CHECK:   release_value %0 : $Any
-// CHECK:   checked_cast_value_br Any in %0 : $Any to P
-// CHECK: bb2:
-// CHECK:   checked_cast_value_br Any in %1 : $Any to P
+// CHECK:   destroy_value %0 : $Any
+// CHECK:   destroy_value %1 : $Any
+// XCHECK:   checked_cast_value_br Any in %0 : $Any to P
+// XCHECK: bb2:
+// XCHECK:   destroy_value %0 : $Any
+// XCHECK:   destroy_value %1 : $Any
+// XCHECK:   checked_cast_value_br Any in %1 : $Any to P
 // CHECK-LABEL: } // end sil function 'testJumpThread'
-sil @testJumpThread : $@convention(thin) (Any, Any) -> () {
-bb0(%0 : $Any, %1 : $Any):
+sil [ossa] @testJumpThread : $@convention(thin) (@owned Any, @owned Any) -> () {
+bb0(%0 : @owned $Any, %1 : @owned $Any):
   cond_br undef, bb1, bb2
+
 bb1:
-  retain_value %0 : $Any // force jump-threading
-  br bb6(%0 : $Any)
+  %2 = copy_value %0 : $Any // force jump-threading?
+  br bb6(%2 : $Any)
+
 bb2:
-  br bb6(%1 : $Any)
-bb6(%any : $Any):
-  release_value %any : $Any // force jump-threading
+  %3 = copy_value %1 : $Any
+  br bb6(%3 : $Any)
+
+bb6(%any : @owned $Any):
+  destroy_value %0 : $Any
+  destroy_value %1 : $Any
   checked_cast_value_br Any in %any : $Any to P, bb7, bb8
+
 bb7(%p : $P):
+  destroy_value %p : $P
   br bb9
-bb8:
+
+bb8(%fail : $Any):
+  destroy_value %fail : $Any
   br bb9
+
 bb9:
   %999 = tuple ()
   return %999 : $()

--- a/test/SILOptimizer/simplify_cfg_ossa.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa.sil
@@ -1,5 +1,7 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -simplify-cfg | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -simplify-cfg -enable-ossa-simplify-cfg | %FileCheck %s
 
+// OSSA form of tests from simplify_cfg.sil and simplify_cfg_simple.sil.
+//
 // Test miscellaneous SimplifyCFG optimization from simplifyBlocks.
 //
 // Does not include:
@@ -13,6 +15,7 @@
 sil_stage canonical
 
 import Builtin
+import Swift
 
 ///////////////////////
 // Type Declarations //
@@ -54,6 +57,27 @@ struct NonTrivial {
 ///////////
 // Tests //
 ///////////
+
+// CHECK-LABEL: sil @simple_test : $@convention(thin) () -> () {
+// CHECK: bb0:
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+// CHECK: } // end sil function 'simple_test'
+sil @simple_test : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int1, -1
+  cond_br %0, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %9999 = tuple ()
+  return %9999 : $()
+}
 
 // CHECK-LABEL: sil [ossa] @test_dead_block :
 // CHECK-NEXT: bb0:
@@ -543,9 +567,6 @@ bb0:
 bb1:
   br bb1
 }
-
-import Builtin
-import Swift
 
 // CHECK-LABEL: @dead_loop
 // CHECK-NOT: br bb

--- a/test/SILOptimizer/simplify_cfg_ossa.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa.sil
@@ -1,4 +1,11 @@
-// RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -simplify-cfg | %FileCheck %s
+
+// Test miscellaneous SimplifyCFG optimization from simplifyBlocks.
+//
+// Does not include:
+// - tryJumpThreading.
+// - dominatorBasedSimplify
+// - CheckedCastBranchJumpThreading
 
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also
@@ -6,7 +13,6 @@
 sil_stage canonical
 
 import Builtin
-import Swift
 
 ///////////////////////
 // Type Declarations //
@@ -40,6 +46,10 @@ struct FakeBool {
 }
 
 sil [ossa] @dummy : $@convention(thin) () -> FakeBool
+
+struct NonTrivial {
+  var object: AnyObject
+}
 
 ///////////
 // Tests //
@@ -1695,24 +1705,24 @@ bb16:
   br bb8(%65 : $TestEnm)
 }
 
-sil [ossa] @print : $@convention(thin) (@guaranteed String) -> ()
-sil [ossa] @yield_string : $@yield_once @convention(thin) () -> @yields @guaranteed String
+sil [ossa] @print : $@convention(thin) (@guaranteed NonTrivial) -> ()
+sil [ossa] @yield_string : $@yield_once @convention(thin) () -> @yields @guaranteed NonTrivial
 
-sil [ossa] @dont_clone_begin_apply : $(Builtin.Int1, @guaranteed String) -> () {
-bb0(%condition : $Builtin.Int1, %arg : @guaranteed $String):
-  %print = function_ref @print : $@convention(thin) (@guaranteed String) -> ()
+sil [ossa] @dont_clone_begin_apply : $(Builtin.Int1, @guaranteed NonTrivial) -> () {
+bb0(%condition : $Builtin.Int1, %arg : @guaranteed $NonTrivial):
+  %print = function_ref @print : $@convention(thin) (@guaranteed NonTrivial) -> ()
   cond_br %condition, bb1, bb2
 bb1:
-  apply %print(%arg) : $@convention(thin) (@guaranteed String) -> ()
+  apply %print(%arg) : $@convention(thin) (@guaranteed NonTrivial) -> ()
   br bb3
 bb2:
   br bb3
 bb3:
-  %yield_string = function_ref @yield_string : $@yield_once @convention(thin) () -> @yields @guaranteed String
-  (%yield, %token) = begin_apply %yield_string() : $@yield_once @convention(thin) () -> @yields @guaranteed String
+  %yield_string = function_ref @yield_string : $@yield_once @convention(thin) () -> @yields @guaranteed NonTrivial
+  (%yield, %token) = begin_apply %yield_string() : $@yield_once @convention(thin) () -> @yields @guaranteed NonTrivial
   cond_br %condition, bb4, bb5
 bb4:
-  apply %print(%yield) : $@convention(thin) (@guaranteed String) -> ()
+  apply %print(%yield) : $@convention(thin) (@guaranteed NonTrivial) -> ()
   br bb6
 bb5:
   br bb6

--- a/test/SILOptimizer/simplify_cfg_ossa_disabled.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_disabled.sil
@@ -1,10 +1,18 @@
 // RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
 //
 // These tests case are converted to OSSA form, but aren't yet
-// optimized in OSSA mode. Move them to simplify_cfg_ossa.sil when
-// they are enabled.
+// optimized in OSSA mode. Move them to one of these files when
+// they are enabled:
+// - simplify_cfg_ossa.sil
+// - simplify_cfg_simplejumpthread.sil
+// - simplify_cfg_checkcast.sil
+// - simplify_cfg_domjumpthread.sil
 //
-// REQUIRES: disabled
+// REQUIRES: EnableOSSASimplifyCFG
+
+sil_stage canonical
+
+import Builtin
 
 class C {}
 
@@ -47,60 +55,6 @@ bb5:
 
 bb6(%14 : $FakeBool):
   return %14 : $FakeBool
-}
-
-// func testThread2(a : Int32) -> Int32 {
-//   enum b = (a ? _true : _false)
-//   if b == _true { return 42 } else { return 17 }
-//
-
-/// CHECK-LABEL: sil [ossa] @testThread2
-/// CHECK: bb0([[COND:%.*]] : {{.*}}):
-/// CHECK: cond_br [[COND]], bb1, bb2
-/// CHECK: bb1:
-/// CHECK:  integer_literal $Builtin.Int64, 42
-/// CHeCK:  br bb3
-/// CHECK: bb2:
-/// CHECK:  integer_literal $Builtin.Int64, 17
-/// CHECK:  br bb3
-/// CHECK: bb3
-/// CHECK:  return
-
-sil [ossa] @testThread2 : $@convention(thin) (Builtin.Int1) -> Int64 {
-bb0(%0 : $Builtin.Int1):
-  %t = integer_literal $Builtin.Int1, 1
-  %f = integer_literal $Builtin.Int1, 0
-  cond_br %0, bb1, bb2
-
-bb1:                                              // Preds: bb0
-  %4 = enum $BoolLike, #BoolLike.true_!enumelt    // user: %5
-  br bb3(%4 : $BoolLike)                          // id: %5
-
-bb2:                                              // Preds: bb0
-  %8 = enum $BoolLike, #BoolLike.false_!enumelt   // user: %9
-  br bb3(%8 : $BoolLike)                          // id: %9
-
-bb3(%6 : $BoolLike):                              // Preds: bb3 bb1
-  %100 = select_enum %6 : $BoolLike, case #BoolLike.true_!enumelt: %t, case #BoolLike.false_!enumelt: %f : $Builtin.Int1
-  br bb4                                          // id: %7
-
-bb4:                                              // Preds: bb2
-  cond_br %100, bb5, bb6                          // id: %10
-
-bb5:                                              // Preds: bb4
-  %11 = metatype $@thin Int64.Type
-  %12 = integer_literal $Builtin.Int64, 42        // user: %13
-  %13 = struct $Int64 (%12 : $Builtin.Int64)      // user: %14
-  br bb7(%13 : $Int64)                            // id: %14
-
-bb6:                                              // Preds: bb4
-  %15 = metatype $@thin Int64.Type
-  %16 = integer_literal $Builtin.Int64, 17        // user: %17
-  %17 = struct $Int64 (%16 : $Builtin.Int64)      // user: %18
-  br bb7(%17 : $Int64)                            // id: %18
-
-bb7(%19 : $Int64):                                // Preds: bb6 bb5
-  return %19 : $Int64                             // id: %21
 }
 
 // func testThread3(a : Int32) -> Int32 {

--- a/test/SILOptimizer/simplify_cfg_simple_jumpthread.sil
+++ b/test/SILOptimizer/simplify_cfg_simple_jumpthread.sil
@@ -1,0 +1,123 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -simplify-cfg | %FileCheck %s
+
+// Tests tryJumpThreading with OSSA. This does not require
+// -jumpthread-simplify-cfg, which is only for dominator-based
+// jump-threading.
+
+// Includes the OSSA form of tests from simplify_cfg_simple.sil,
+// simplify_cfg_opaque.sil, and simplify_cfg_address_phi.sil.
+// ...and new OSSA test cases.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+class C {
+  @_hasStorage @_hasInitialValue var field: Int { get set }
+  init()
+}
+
+sil @getC : $@convention(thin) () -> C
+
+protocol P {}
+
+// Test that debug_value_addr is not unnecessarilly lost during address projection sinking.
+public class CC<R> {
+  let r : R
+  init(_ _r: R) { r = _r }
+}
+
+sil @useAny : $@convention(thin) <V> (@in_guaranteed V) -> ()
+
+// Test that jump threading sinks a ref_element_addr, generating a
+// non-address phi for its operand.
+//
+// The retain on separate paths followed by a merged release, and
+// target block with a conditional branch are necessary just to get
+// jump threading to kick in.
+//
+// CHECK-LABEL: sil @testJumpThreadRefEltLoop : $@convention(thin) () -> () {
+// CHECK: bb0
+// CHECK:   function_ref @getC : $@convention(thin) () -> C
+// CHECK:   cond_br undef, bb1, bb2
+// CHECK: bb1:
+// CHECK:   [[C1:%.*]] = apply %0() : $@convention(thin) () -> C
+// CHECK:   strong_retain [[C1]] : $C
+// CHECK:   strong_release [[C1]] : $C
+// CHECK:   br bb3([[C1]] : $C)
+// CHECK: bb2:
+// CHECK:   [[C2:%.*]] = apply %0() : $@convention(thin) () -> C
+// CHECK:   strong_retain [[C2]] : $C
+// CHECK:   strong_release [[C2]] : $C
+// CHECK:   br bb3([[C2]] : $C)
+// CHECK: bb3([[PHI:%.*]] : $C):
+// CHECK:   [[ADR:%.*]] = ref_element_addr [[PHI]] : $C, #C.field
+// CHECK:   begin_access [read] [dynamic] [[ADR]] : $*Int
+// CHECK:   load
+// CHECK:   end_access
+// CHECK-LABEL: } // end sil function 'testJumpThreadRefEltLoop'
+sil @testJumpThreadRefEltLoop : $@convention(thin) () -> () {
+bb0:
+  %f = function_ref @getC : $@convention(thin) () -> C
+  cond_br undef, bb1, bb2
+
+bb1:
+  %c1 = apply %f() : $@convention(thin) ()->C
+  strong_retain %c1 : $C
+  br bb3(%c1 : $C)
+
+bb2:
+  %c2 = apply %f() : $@convention(thin) ()->C
+  strong_retain %c2 : $C
+  br bb3(%c2 : $C)
+
+bb3(%arg : $C):
+  strong_release %arg : $C
+  %18 = ref_element_addr %arg : $C, #C.field
+  br bb4
+
+bb4:
+  %19 = begin_access [read] [dynamic] %18 : $*Int
+  %20 = load %19 : $*Int
+  end_access %19 : $*Int
+  cond_br undef, bb4, bb5
+
+bb5:
+  %z = tuple ()
+  return %z : $()
+}
+
+// CHECK-LABEL: sil @testDebugValue : $@convention(method) <R><S> (@in_guaranteed S, @guaranteed CC<R>, Bool) -> () {
+// CHECK: debug_value_addr %0 : $*S, let, name "u"
+// CHECK: apply %{{.*}}<S>(%0) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+// CHECK: [[FIELD:%.*]] = ref_element_addr %1 : $CC<R>, #CC.r
+// CHECK: debug_value_addr [[FIELD]] : $*R, let, name "u"
+// CHECK: apply %{{.*}}<R>([[FIELD]]) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+// CHECK-LABEL: } // end sil function 'testDebugValue'
+sil @testDebugValue : $@convention(method) <R><S> (@in_guaranteed S, @guaranteed CC<R>, Bool) -> () {
+bb0(%0 : $*S, %1 : $CC<R>, %2 : $Bool):
+  %bool = struct_extract %2 : $Bool, #Bool._value
+  cond_br %bool, bb1, bb2
+
+bb1:
+  debug_value_addr %0 : $*S, let, name "u"
+  %f1 = function_ref @useAny : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %call1 = apply %f1<S>(%0) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  br bb2
+
+bb2:
+  %field = ref_element_addr %1 : $CC<R>, #CC.r
+  debug_value_addr %field : $*R, let, name "t"
+  cond_br %bool, bb3, bb4
+
+bb3:
+  debug_value_addr %field : $*R, let, name "u"
+  %f2 = function_ref @useAny : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %call2 = apply %f2<R>(%field) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  br bb4
+
+bb4:
+  %z = tuple ()
+  return %z : $()
+}

--- a/test/SILOptimizer/simplify_cfg_stress_ossa.sil
+++ b/test/SILOptimizer/simplify_cfg_stress_ossa.sil
@@ -12,12 +12,12 @@ sil @sink : $@convention(thin) (Int64, Int64, Int64, Int64) -> ()
 
 // Check if SimplifyCFG can optimize this function in reasonable time.
 
-// CHECK-LABEL: sil @testit
+// CHECK-LABEL: sil [ossa] @testit
 
 // Check if there are not too many basic blocks generated.
 // CHECK-NOT: bb1000:
 
-sil @testit : $@convention(thin) (Int64, Int64, Int64, Int64, Int64, Int64) -> () {
+sil [ossa] @testit : $@convention(thin) (Int64, Int64, Int64, Int64, Int64, Int64) -> () {
 bb0(%0 : $Int64, %1 : $Int64, %2 : $Int64, %3 : $Int64, %4 : $Int64, %5 : $Int64):
   %12 = integer_literal $Builtin.Int64, 2
   %13 = struct_extract %0 : $Int64, #Int64._value

--- a/test/SILOptimizer/simplify_cfg_trivial_jumpthread.sil
+++ b/test/SILOptimizer/simplify_cfg_trivial_jumpthread.sil
@@ -1,0 +1,135 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -simplify-cfg -enable-ossa-simplify-cfg | %FileCheck %s
+
+// Tests tryJumpThreading with OSSA for trivial branch and terminator
+// arguments. This does not require -jumpthread-simplify-cfg, which
+// is only for dominator-based jump-threading.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+internal enum Enum {
+  case one
+  case two
+}
+
+enum BoolLike { case true_, false_ }
+
+// Test that SimplifyCFG::simplifyBlocks, tryJumpThreading does not
+// perform unbounded loop peeling.
+//
+// rdar://73357726 ([SR-14068]: Compiling with optimisation runs indefinitely for grpc-swift)
+// CHECK-LABEL: sil [ossa] @testInfinitePeeling : $@convention(method) (Builtin.Int64, Enum) -> () {
+//
+// There is only one switch_enum blocks, and it is no longer in a loop.
+// CHECK: bb0(%0 : $Builtin.Int64, %1 : $Enum):
+// CHECK:   switch_enum %1 : $Enum, case #Enum.one!enumelt: bb4, case #Enum.two!enumelt: bb1
+// CHECK: bb1:
+// CHECK:   br bb5
+// CHECK: bb2:
+// CHECK:   br bb6
+//
+// CHECK: bb3:
+// CHECK:   br bb5
+//
+// This is the cond_br block after jump-threading.
+// CHECK: bb4:
+// CHECK:   cond_br %{{.*}}, bb3, bb2
+//
+// The original loop has been removed here.
+// CHECK: bb5:
+// CHECK:   br bb6
+//
+// CHECK: bb6:
+// CHECK:   return
+// CHECK-LABEL: } // end sil function 'testInfinitePeeling'
+sil [ossa] @testInfinitePeeling : $@convention(method) (Builtin.Int64, Enum) -> () {
+bb0(%0 : $Builtin.Int64, %1 : $Enum):
+  %2 = integer_literal $Builtin.Int64, 99999999
+  br bb1(%0 : $Builtin.Int64, %1 : $Enum)
+
+bb1(%4 : $Builtin.Int64, %5 : $Enum):
+  switch_enum %5 : $Enum, case #Enum.one!enumelt: bb4, default bb5
+
+bb2(%7 : $Builtin.Int64, %8 : $Enum):
+  %9 = builtin "cmp_slt_Int64"(%2 : $Builtin.Int64, %7 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %9, bb3, bb6
+
+bb3:
+  br bb1(%7 : $Builtin.Int64, %8 : $Enum)
+
+bb4:
+  %12 = integer_literal $Builtin.Int64, 1
+  %13 = integer_literal $Builtin.Int1, -1
+  %14 = builtin "sadd_with_overflow_Int64"(%4 : $Builtin.Int64, %12 : $Builtin.Int64, %13 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %15 = tuple_extract %14 : $(Builtin.Int64, Builtin.Int1), 0
+  %16 = enum $Enum, #Enum.two!enumelt
+  br bb2(%15 : $Builtin.Int64, %16 : $Enum)
+
+bb5(%17 : $Enum):
+  br bb2(%2 : $Builtin.Int64, %17 : $Enum)
+
+bb6:
+  %19 = tuple ()
+  return %19 : $()
+}
+
+class C {
+  @_hasStorage @_hasInitialValue var field: Int { get set }
+  init()
+}
+
+// func testThread2(a : Int32) -> Int32 {
+//   enum b = (a ? _true : _false)
+//   if b == _true { return 42 } else { return 17 }
+//
+
+/// CHECK-LABEL: sil [ossa] @testThread2
+/// CHECK: bb0([[COND:%.*]] : {{.*}}):
+/// CHECK: cond_br [[COND]], bb1, bb2
+/// CHECK: bb1:
+/// CHECK:  integer_literal $Builtin.Int64, 42
+/// CHeCK:  br bb3
+/// CHECK: bb2:
+/// CHECK:  integer_literal $Builtin.Int64, 17
+/// CHECK:  br bb3
+/// CHECK: bb3
+/// CHECK:  return
+
+sil [ossa] @testThread2 : $@convention(thin) (Builtin.Int1) -> Int64 {
+bb0(%0 : $Builtin.Int1):
+  %t = integer_literal $Builtin.Int1, 1
+  %f = integer_literal $Builtin.Int1, 0
+  cond_br %0, bb1, bb2
+
+bb1:                                              // Preds: bb0
+  %4 = enum $BoolLike, #BoolLike.true_!enumelt    // user: %5
+  br bb3(%4 : $BoolLike)                          // id: %5
+
+bb2:                                              // Preds: bb0
+  %8 = enum $BoolLike, #BoolLike.false_!enumelt   // user: %9
+  br bb3(%8 : $BoolLike)                          // id: %9
+
+bb3(%6 : $BoolLike):                              // Preds: bb3 bb1
+  %100 = select_enum %6 : $BoolLike, case #BoolLike.true_!enumelt: %t, case #BoolLike.false_!enumelt: %f : $Builtin.Int1
+  br bb4                                          // id: %7
+
+bb4:                                              // Preds: bb2
+  cond_br %100, bb5, bb6                          // id: %10
+
+bb5:                                              // Preds: bb4
+  %11 = metatype $@thin Int64.Type
+  %12 = integer_literal $Builtin.Int64, 42        // user: %13
+  %13 = struct $Int64 (%12 : $Builtin.Int64)      // user: %14
+  br bb7(%13 : $Int64)                            // id: %14
+
+bb6:                                              // Preds: bb4
+  %15 = metatype $@thin Int64.Type
+  %16 = integer_literal $Builtin.Int64, 17        // user: %17
+  %17 = struct $Int64 (%16 : $Builtin.Int64)      // user: %18
+  br bb7(%17 : $Int64)                            // id: %18
+
+bb7(%19 : $Int64):                                // Preds: bb6 bb5
+  return %19 : $Int64                             // id: %21
+}

--- a/test/SILOptimizer/simplify_cfg_tryapply.sil
+++ b/test/SILOptimizer/simplify_cfg_tryapply.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -simplify-cfg | %FileCheck %s
 
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also

--- a/test/SILOptimizer/simplify_switch_enum_objc_ossa.sil
+++ b/test/SILOptimizer/simplify_switch_enum_objc_ossa.sil
@@ -1,0 +1,457 @@
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all %s -simplify-cfg | %FileCheck %s
+
+// Just make sure that we do not infinite loop when compiling without block merging.
+//
+// RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -simplify-cfg -simplify-cfg-simplify-unconditional-branches=0
+
+// REQUIRES: objc_interop
+
+import Swift
+import Foundation
+
+class Test : NSObject {
+  @objc var other : Test? { get set }
+}
+
+
+// CHECK-LABEL: sil hidden @one_call : $@convention(thin) (@guaranteed Optional<Test>, @guaranteed Optional<Test>) -> () {
+// CHECK: bb0([[ARG0:%.*]] : $Optional<Test>, [[ARG1:%.*]] : $Optional<Test>):
+// CHECK:   switch_enum [[ARG0]] : $Optional<Test>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb3
+// CHECK: bb1([[ARG0_PAYLOAD:%.*]] : $Test):
+// CHECK:   [[ARG1_PAYLOAD:%.*]] = unchecked_ref_cast [[ARG1]] : $Optional<Test> to $Test
+// CHECK:   [[GETTER:%.*]] = objc_method [[ARG1_PAYLOAD]] : $Test, #Test.other!getter.foreign
+// CHECK:   [[RESULT:%.*]] = apply [[GETTER]]([[ARG1_PAYLOAD]])
+// CHECK:   [[SETTER:%.*]] = objc_method [[ARG0_PAYLOAD]] : $Test, #Test.other!setter.foreign : (Test) -> (Test?) -> (), $@convention(objc_method) (Optional<Test>, Test) -> ()
+// CHECK:   apply [[SETTER]]([[RESULT]], [[ARG0_PAYLOAD]])
+// CHECK:   br bb2
+// CHECK: bb2:
+// CHECK:   return
+// CHECK: bb3:
+// CHECK:   br bb2
+// CHECK: }
+
+sil hidden @one_call : $@convention(thin) (@guaranteed Optional<Test>, @guaranteed Optional<Test>) -> () {
+bb0(%0 : $Optional<Test>, %1 : $Optional<Test>):
+  retain_value %0 : $Optional<Test>
+  switch_enum %0 : $Optional<Test>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb6
+
+bb1(%6 : $Test):
+  retain_value %1 : $Optional<Test>
+  switch_enum %1 : $Optional<Test>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb5
+
+bb2(%9 : $Test):
+  %10 = objc_method %9 : $Test, #Test.other!getter.foreign : (Test) -> () -> Test?, $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  %11 = apply %10(%9) : $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  strong_release %9 : $Test
+  br bb3(%11 : $Optional<Test>)
+
+bb3(%14 : $Optional<Test>):
+  %15 = objc_method %6 : $Test, #Test.other!setter.foreign : (Test) -> (Test?) -> (), $@convention(objc_method) (Optional<Test>, Test) -> ()
+  %16 = apply %15(%14, %6) : $@convention(objc_method) (Optional<Test>, Test) -> ()
+  release_value %14 : $Optional<Test>
+  strong_release %6 : $Test
+  %19 = tuple ()
+  br bb4
+
+bb4:
+  %23 = tuple ()
+  return %23 : $()
+
+bb5:
+  %25 = enum $Optional<Test>, #Optional.none!enumelt
+  br bb3(%25 : $Optional<Test>)
+
+bb6:
+  br bb4
+}
+
+// CHECK-LABEL: sil hidden @one_call2 : $@convention(thin) (@guaranteed Optional<Test>, @guaranteed Optional<Test>) -> () {
+// CHECK: bb0([[ARG0:%.*]] : $Optional<Test>, [[ARG1:%.*]] : $Optional<Test>):
+// CHECK:   switch_enum [[ARG0]] : $Optional<Test>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb3
+// CHECK: bb1([[ARG0_PAYLOAD:%.*]] : $Test):
+// CHECK:   [[ARG1_PAYLOAD:%.*]] = unchecked_ref_cast [[ARG1]] : $Optional<Test> to $Test
+// CHECK:   [[GETTER:%.*]] = objc_method [[ARG1_PAYLOAD]] : $Test, #Test.other!getter.foreign
+// CHECK:   [[RESULT:%.*]] = apply [[GETTER]]([[ARG1_PAYLOAD]])
+// CHECK:   [[SETTER:%.*]] = objc_method [[ARG0_PAYLOAD]] : $Test, #Test.other!setter.foreign : (Test) -> (Test?) -> (), $@convention(objc_method) (Optional<Test>, Test) -> ()
+// CHECK:   apply [[SETTER]]([[RESULT]], [[ARG0_PAYLOAD]])
+// CHECK:   br bb2
+// CHECK: bb2:
+// CHECK:   return
+// CHECK: bb3:
+// CHECK:   br bb2
+// CHECK: }
+
+sil hidden @one_call2 : $@convention(thin) (@guaranteed Optional<Test>, @guaranteed Optional<Test>) -> () {
+bb0(%0 : $Optional<Test>, %1 : $Optional<Test>):
+  retain_value %0 : $Optional<Test>
+  switch_enum %0 : $Optional<Test>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb6
+
+bb1(%6 : $Test):
+  retain_value %1 : $Optional<Test>
+  switch_enum %1 : $Optional<Test>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb5
+
+bb2:
+  %9 = unchecked_enum_data %1 : $Optional<Test>, #Optional.some!enumelt
+  %10 = objc_method %9 : $Test, #Test.other!getter.foreign : (Test) -> () -> Test?, $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  %11 = apply %10(%9) : $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  strong_release %9 : $Test
+  br bb3(%11 : $Optional<Test>)
+
+bb3(%14 : $Optional<Test>):
+  %15 = objc_method %6 : $Test, #Test.other!setter.foreign : (Test) -> (Test?) -> (), $@convention(objc_method) (Optional<Test>, Test) -> ()
+  %16 = apply %15(%14, %6) : $@convention(objc_method) (Optional<Test>, Test) -> ()
+  release_value %14 : $Optional<Test>
+  strong_release %6 : $Test
+  %19 = tuple ()
+  br bb4
+
+bb4:
+  %23 = tuple ()
+  return %23 : $()
+
+bb5:
+  %25 = enum $Optional<Test>, #Optional.none!enumelt
+  br bb3(%25 : $Optional<Test>)
+
+bb6:
+  br bb4
+}
+sil @some_sideeffect : $@convention(thin) () -> ()
+
+// CHECK-LABEL: sil hidden @sideeffect
+// CHECK: switch_enum
+// CHECK: switch_enum
+// CHECK: }
+sil hidden @sideeffect : $@convention(thin) (@guaranteed Optional<Test>, @guaranteed Optional<Test>) -> () {
+bb0(%0 : $Optional<Test>, %1 : $Optional<Test>):
+  retain_value %0 : $Optional<Test>
+  switch_enum %0 : $Optional<Test>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb6
+
+bb1(%6 : $Test):
+  retain_value %1 : $Optional<Test>
+  switch_enum %1 : $Optional<Test>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb5
+
+bb2(%9 : $Test):
+  %10 = objc_method %9 : $Test, #Test.other!getter.foreign : (Test) -> () -> Test?, $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  %11 = apply %10(%9) : $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  strong_release %9 : $Test
+  %12 = function_ref @some_sideeffect : $@convention(thin) () -> ()
+  apply %12() : $@convention(thin) () -> ()
+  br bb3(%11 : $Optional<Test>)
+
+bb3(%14 : $Optional<Test>):
+  %15 = objc_method %6 : $Test, #Test.other!setter.foreign : (Test) -> (Test?) -> (), $@convention(objc_method) (Optional<Test>, Test) -> ()
+  %16 = apply %15(%14, %6) : $@convention(objc_method) (Optional<Test>, Test) -> ()
+  release_value %14 : $Optional<Test>
+  strong_release %6 : $Test
+  %19 = tuple ()
+  br bb4
+
+bb4:
+  %23 = tuple ()
+  return %23 : $()
+
+bb5:
+  %25 = enum $Optional<Test>, #Optional.none!enumelt
+  br bb3(%25 : $Optional<Test>)
+
+bb6:
+  br bb4
+}
+
+// CHECK-LABEL: sil hidden @sideeffect2
+// CHECK: switch_enum
+// CHECK: switch_enum
+// CHECK: }
+sil hidden @sideeffect2 : $@convention(thin) (@guaranteed Optional<Test>, @guaranteed Optional<Test>) -> () {
+bb0(%0 : $Optional<Test>, %1 : $Optional<Test>):
+  retain_value %0 : $Optional<Test>
+  switch_enum %0 : $Optional<Test>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb6
+
+bb1(%6 : $Test):
+  retain_value %1 : $Optional<Test>
+  switch_enum %1 : $Optional<Test>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb5
+
+bb2(%9 : $Test):
+  %10 = objc_method %9 : $Test, #Test.other!getter.foreign : (Test) -> () -> Test?, $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  %11 = apply %10(%9) : $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  strong_release %9 : $Test
+  br bb3(%11 : $Optional<Test>)
+
+bb3(%14 : $Optional<Test>):
+  %15 = objc_method %6 : $Test, #Test.other!setter.foreign : (Test) -> (Test?) -> (), $@convention(objc_method) (Optional<Test>, Test) -> ()
+  %16 = apply %15(%14, %6) : $@convention(objc_method) (Optional<Test>, Test) -> ()
+  release_value %14 : $Optional<Test>
+  strong_release %6 : $Test
+  %19 = tuple ()
+  br bb4
+
+bb4:
+  %23 = tuple ()
+  return %23 : $()
+
+bb5:
+  %12 = function_ref @some_sideeffect : $@convention(thin) () -> ()
+  apply %12() : $@convention(thin) () -> ()
+  %25 = enum $Optional<Test>, #Optional.none!enumelt
+  br bb3(%25 : $Optional<Test>)
+
+bb6:
+  br bb4
+}
+
+// CHECK-LABEL: sil hidden @not_on_optional
+// CHECK: switch_enum
+// CHECK: switch_enum
+// CHECK: }
+sil hidden @not_on_optional : $@convention(thin) (@guaranteed Optional<Test>, @guaranteed Optional<Test>) -> () {
+bb0(%0 : $Optional<Test>, %1 : $Optional<Test>):
+  retain_value %0 : $Optional<Test>
+  switch_enum %0 : $Optional<Test>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb6
+
+bb1(%6 : $Test):
+  retain_value %1 : $Optional<Test>
+  switch_enum %1 : $Optional<Test>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb5
+
+bb2(%9 : $Test):
+  %10 = objc_method %9 : $Test, #Test.other!getter.foreign : (Test) -> () -> Test?, $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  %11 = apply %10(%6) : $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  strong_release %9 : $Test
+  br bb3(%11 : $Optional<Test>)
+
+bb3(%14 : $Optional<Test>):
+  %15 = objc_method %6 : $Test, #Test.other!setter.foreign : (Test) -> (Test?) -> (), $@convention(objc_method) (Optional<Test>, Test) -> ()
+  %16 = apply %15(%14, %6) : $@convention(objc_method) (Optional<Test>, Test) -> ()
+  release_value %14 : $Optional<Test>
+  strong_release %6 : $Test
+  %19 = tuple ()
+  br bb4
+
+bb4:
+  %23 = tuple ()
+  return %23 : $()
+
+bb5:
+  %25 = enum $Optional<Test>, #Optional.none!enumelt
+  br bb3(%25 : $Optional<Test>)
+
+bb6:
+  br bb4
+}
+
+// CHECK-LABEL: sil hidden @forwards_wrong_value
+// CHECK: switch_enum
+// CHECK: switch_enum
+// CHECK: }
+sil hidden @forwards_wrong_value : $@convention(thin) (@guaranteed Optional<Test>, @guaranteed Optional<Test>) -> () {
+bb0(%0 : $Optional<Test>, %1 : $Optional<Test>):
+  retain_value %0 : $Optional<Test>
+  switch_enum %0 : $Optional<Test>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb6
+
+bb1(%6 : $Test):
+  retain_value %1 : $Optional<Test>
+  switch_enum %1 : $Optional<Test>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb5
+
+bb2(%9 : $Test):
+  %10 = objc_method %9 : $Test, #Test.other!getter.foreign : (Test) -> () -> Test?, $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  %11 = apply %10(%9) : $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  strong_release %9 : $Test
+  br bb3(%0 : $Optional<Test>)
+
+bb3(%14 : $Optional<Test>):
+  %15 = objc_method %6 : $Test, #Test.other!setter.foreign : (Test) -> (Test?) -> (), $@convention(objc_method) (Optional<Test>, Test) -> ()
+  %16 = apply %15(%14, %6) : $@convention(objc_method) (Optional<Test>, Test) -> ()
+  release_value %14 : $Optional<Test>
+  strong_release %6 : $Test
+  %19 = tuple ()
+  br bb4
+
+bb4:
+  %23 = tuple ()
+  return %23 : $()
+
+bb5:
+  %25 = enum $Optional<Test>, #Optional.none!enumelt
+  br bb3(%25 : $Optional<Test>)
+
+bb6:
+  br bb4
+}
+
+// CHECK-LABEL: sil hidden @forwards_wrong_value2
+// CHECK: switch_enum
+// CHECK: switch_enum
+// CHECK: }
+sil hidden @forwards_wrong_value2 : $@convention(thin) (@guaranteed Optional<Test>, @guaranteed Optional<Test>) -> () {
+bb0(%0 : $Optional<Test>, %1 : $Optional<Test>):
+  retain_value %0 : $Optional<Test>
+  switch_enum %0 : $Optional<Test>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb6
+
+bb1(%6 : $Test):
+  retain_value %1 : $Optional<Test>
+  switch_enum %1 : $Optional<Test>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb5
+
+bb2(%9 : $Test):
+  %10 = objc_method %9 : $Test, #Test.other!getter.foreign : (Test) -> () -> Test?, $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  %11 = apply %10(%9) : $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  strong_release %9 : $Test
+  br bb3(%11 : $Optional<Test>)
+
+bb3(%14 : $Optional<Test>):
+  %15 = objc_method %6 : $Test, #Test.other!setter.foreign : (Test) -> (Test?) -> (), $@convention(objc_method) (Optional<Test>, Test) -> ()
+  %16 = apply %15(%14, %6) : $@convention(objc_method) (Optional<Test>, Test) -> ()
+  release_value %14 : $Optional<Test>
+  strong_release %6 : $Test
+  %19 = tuple ()
+  br bb4
+
+bb4:
+  %23 = tuple ()
+  return %23 : $()
+
+bb5:
+  br bb3(%0 : $Optional<Test>)
+
+bb6:
+  br bb4
+}
+
+// CHECK-LABEL: sil hidden @two_chained_calls
+// CHECK: bb0([[ARG0:%.*]] : $Optional<Test>, [[ARG1:%.*]] : $Optional<Test>):
+// CHECK: switch_enum [[ARG0]]
+// CHECK: bb1([[ARG0_PAYLOAD:%.*]] : $Test):
+// CHECK:   [[PAYLOAD:%.*]] = unchecked_ref_cast [[ARG1]]
+// CHECK:   [[METH:%.*]] = objc_method [[PAYLOAD]] : $Test, #Test.other!getter.foreign
+// CHECK:   [[RESULT:%.*]] = apply [[METH]]([[PAYLOAD]])
+// CHECK:   [[PAYLOAD2:%.*]] = unchecked_ref_cast [[RESULT]]
+// CHECK:   [[METH2:%.*]] = objc_method [[PAYLOAD2]] : $Test, #Test.other!getter.foreign
+// CHECK:   [[RESULT2:%.*]] = apply [[METH2]]([[PAYLOAD2]])
+// CHECK:   [[SETTER:%.*]] = objc_method [[ARG0_PAYLOAD]] : $Test, #Test.other!setter.foreign
+// CHECK:   apply [[SETTER]]([[RESULT2]], [[ARG0_PAYLOAD]]) : $@convention(objc_method) (Optional<Test>, Test) -> ()
+// CHECK:   br bb2
+// CHECK: bb2:
+// CHECK:   return
+// CHECK: bb3:
+// CHECK:   br bb2
+// CHECK: }
+
+sil hidden @two_chained_calls : $@convention(thin) (@guaranteed Optional<Test>, @guaranteed Optional<Test>) -> () {
+bb0(%0 : $Optional<Test>, %1 : $Optional<Test>):
+  retain_value %0 : $Optional<Test>
+  switch_enum %0 : $Optional<Test>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb9
+
+bb1(%6 : $Test):
+  retain_value %1 : $Optional<Test>
+  switch_enum %1 : $Optional<Test>, case #Optional.some!enumelt: bb3, case #Optional.none!enumelt: bb2
+
+bb2:
+  br bb8
+
+bb3(%10 : $Test):
+  %11 = objc_method %10 : $Test, #Test.other!getter.foreign : (Test) -> () -> Test?, $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  %12 = apply %11(%10) : $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  switch_enum %12 : $Optional<Test>, case #Optional.none!enumelt: bb4, case #Optional.some!enumelt: bb5
+
+bb4:
+  release_value %12 : $Optional<Test>
+  strong_release %10 : $Test
+  br bb8
+
+bb5:
+  %17 = unchecked_enum_data %12 : $Optional<Test>, #Optional.some!enumelt
+  strong_retain %17 : $Test
+  release_value %12 : $Optional<Test>
+  strong_release %10 : $Test
+  %21 = objc_method %17 : $Test, #Test.other!getter.foreign : (Test) -> () -> Test?, $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  %22 = apply %21(%17) : $@convention(objc_method) (Test) -> @autoreleased Optional<Test>
+  strong_release %17 : $Test
+  br bb6(%22 : $Optional<Test>)
+
+bb6(%25 : $Optional<Test>):
+  %26 = objc_method %6 : $Test, #Test.other!setter.foreign : (Test) -> (Test?) -> (), $@convention(objc_method) (Optional<Test>, Test) -> ()
+  %27 = apply %26(%25, %6) : $@convention(objc_method) (Optional<Test>, Test) -> ()
+  release_value %25 : $Optional<Test>
+  strong_release %6 : $Test
+  br bb7
+
+bb7:
+  %31 = tuple ()
+  return %31 : $()
+
+bb8:
+  %33 = enum $Optional<Test>, #Optional.none!enumelt
+  br bb6(%33 : $Optional<Test>)
+
+bb9:
+  br bb7
+}
+
+sil @infinite_loop_get_optional_nsobject : $@convention(thin) () -> @autoreleased Optional<NSObject>
+sil @infinite_loop_get_superview : $@convention(thin) (NSObject) -> @autoreleased Optional<NSObject>
+
+// Just make sure we do not infinite loop here when looking for successors.
+// CHECK-LABEL: sil @infinite_loop_1 : $@convention(thin) () -> @owned Optional<NSObject> {
+// CHECK: } // end sil function 'infinite_loop_1'
+sil @infinite_loop_1 : $@convention(thin) () -> @owned Optional<NSObject> {
+bb0:
+  %13 = function_ref @infinite_loop_get_optional_nsobject : $@convention(thin) () -> @autoreleased Optional<NSObject>
+  %14 = apply %13() : $@convention(thin) () -> @autoreleased Optional<NSObject>
+  br bb1(%14 : $Optional<NSObject>)
+
+bb1(%16 : $Optional<NSObject>):
+  retain_value %16 : $Optional<NSObject>
+  switch_enum %16 : $Optional<NSObject>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb5
+
+bb2(%19 : $NSObject):
+  release_value %16 : $Optional<NSObject>
+  %21 = enum $Optional<NSObject>, #Optional.none!enumelt
+  release_value %16 : $Optional<NSObject>
+  return %21 : $Optional<NSObject>
+
+bb3:
+  %24 = unchecked_enum_data %16 : $Optional<NSObject>, #Optional.some!enumelt
+  strong_retain %24 : $NSObject
+  %26 = function_ref @infinite_loop_get_superview : $@convention(thin) (NSObject) -> @autoreleased Optional<NSObject>
+  %27 = apply %26(%24) : $@convention(thin) (NSObject) -> @autoreleased Optional<NSObject>
+  strong_release %24 : $NSObject
+  release_value %16 : $Optional<NSObject>
+  br bb1(%27 : $Optional<NSObject>)
+
+bb4:
+  release_value %16 : $Optional<NSObject>
+  br bb1(%16 : $Optional<NSObject>)
+
+bb5:
+  release_value %16 : $Optional<NSObject>
+  switch_enum %16 : $Optional<NSObject>, case #Optional.none!enumelt: bb4, default bb3
+}
+
+// Just make sure that we do not infinite loop here.
+//
+// CHECK-LABEL: sil @infinite_loop_2 : $@convention(thin) () -> @owned Optional<NSObject> {
+// CHECK: } // end sil function 'infinite_loop_2'
+sil @infinite_loop_2 : $@convention(thin) () -> @owned Optional<NSObject> {
+bb0:
+  %0 = function_ref @infinite_loop_get_optional_nsobject : $@convention(thin) () -> @autoreleased Optional<NSObject>
+  %1 = apply %0() : $@convention(thin) () -> @autoreleased Optional<NSObject>
+  br bb1(%1 : $Optional<NSObject>)
+
+bb1(%3 : $Optional<NSObject>):
+  switch_enum %3 : $Optional<NSObject>, case #Optional.some!enumelt: bb3, case #Optional.none!enumelt: bb2
+
+bb2:
+  br bb5(%3 : $Optional<NSObject>)
+
+bb3(%7 : $NSObject):
+  br bb4(%3 : $Optional<NSObject>)
+
+bb4(%9 : $Optional<NSObject>):
+  %11 = enum $Optional<NSObject>, #Optional.none!enumelt
+  return %11 : $Optional<NSObject>
+
+bb5(%14 : $Optional<NSObject>):
+  br bb6
+
+bb6:
+  br bb5(%14 : $Optional<NSObject>)
+}


### PR DESCRIPTION
Migrate all the simplify-cfg tests to OSSA and organize them by functionality for staging and debugging sanity (there were a massive number of disorganized tests for this pass).

This PR also adds some basic support for handling trivial block arguments just so that most tests will pass.

This is work in progress. We still need to enable some of the tests and add more tests for OSSA functionality before completely turning on the pass.

I'm merging incrementally now so anyone can make progress. This has been sitting on a branch for 4 months.

This introduces two temporary testing flags. -enable-ossa-simplifycfg and -enable-ossa-jumpthread-simplifycfg. They allow running simplify-cfg test cases without affecting regular compilation. The flags will be removed as soon as we have enough test coverage to confidently enable these parts of simplify-cfg that are still guarded by the flag.

The following test files still need to be enabled
simplify_bb_args.sil
simplify_cfg_args_ossa_disabled.sil
simplify_cfg_checkcast.sil
simplify_cfg_ossa_disabled.sil