### PR TITLE
[test] ensure allocation test also runs on 32-bit architectures

### DIFF
--- a/test/stdlib/UnsafeRawPointer.swift
+++ b/test/stdlib/UnsafeRawPointer.swift
@@ -238,7 +238,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("absurd.allocation.misaligned") {
 
 UnsafeMutableRawPointerExtraTestSuite.test("absurd.allocation.gargantuan") {
   expectCrashLater()
-  let mustFail = UnsafeMutableRawPointer.allocate(byteCount: 400000000000000000,
+  let mustFail = UnsafeMutableRawPointer.allocate(byteCount: Int.max,
                                                   alignment: 0)
   expectUnreachable()
 }


### PR DESCRIPTION
Fix a test which inadvertently excludes 32-bit architectures.
(introduced in https://github.com/apple/swift/pull/38424)