### PR TITLE
[SourceKit] Disable failing test til it can be fixed.

### DIFF
--- a/test/SourceKit/CodeComplete/complete_sort_order.swift
+++ b/test/SourceKit/CodeComplete/complete_sort_order.swift
@@ -1,3 +1,5 @@
+// REQUIRES: rdar80729544
+
 func foo(a a: String) {}
 func foo(a a: Int) {}
 func foo(b b: Int) {}


### PR DESCRIPTION
Summary:
In https://ci.swift.org/job/oss-swift_tools-R_stdlib-RD_test-simulator/6238/ , swift/test/SourceKit/CodeComplete/complete_sort_order.swift failed. Disable for now.

rdar://80729544

Excerpted error:

/Volumes/swift-ci/jenkins/workspace/oss-swift_tools-R_stdlib-RD_test-simulator/swift/test/SourceKit/CodeComplete/complete_sort_order.swift:20:17: error: NAME_SORTED: expected string not found in input
// NAME_SORTED: key.description: "foo(a: String)"
                ^
<stdin>:2475:32: note: scanning from here
 key.description: "foo(a: Int)",
                               ^
<stdin>:2487:2: note: possible intended match here
 key.description: "foo(b: Int)",
 ^