### PR TITLE
Check withContiguousStorageIfAvailable before copying byte by byte

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -412,6 +412,16 @@ extension Unsafe${Mutable}RawBufferPointer {
     guard let position = _position else {
       return
     }
+    
+    if source.withContiguousStorageIfAvailable({
+      (buffer: UnsafeBufferPointer<C.Element>) -> Void in
+      if let base = buffer.baseAddress {
+        position.copyMemory(from: base, byteCount: buffer.count)
+      }
+    }) != nil {
+      return
+    }
+
     for (index, byteValue) in source.enumerated() {
       position.storeBytes(
         of: byteValue, toByteOffset: index, as: UInt8.self)

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -421,6 +421,19 @@ UnsafeRawBufferPointerTestSuite.test("copyMemory.overflow") {
       from: UnsafeRawBufferPointer(buffer))
 }
 
+// Use copyBytes without contiguous storage
+UnsafeRawBufferPointerTestSuite.test("copyBytes.withoutContiguouseStorage") {
+  let ranges: [Range<UInt8>] = [0..<2, 1..<3, 2..<4, 3..<5]
+  var array = [UInt8](repeating: 0, count: 2)
+  for range in ranges {
+    array.withUnsafeMutableBytes { byte in
+        byte.copyBytes(from: range)
+    }
+    expectEqual(array.count, range.count)
+    expectEqual(array, Array(range))
+  }
+}
+
 UnsafeRawBufferPointerTestSuite.test("copyBytes.sequence.overflow") {
   var buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }


### PR DESCRIPTION


<!-- What's in this pull request? -->
Check withContiguousStorageIfAvailable before copying byte by byte.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-14886.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
