### PR TITLE
[test] Update alternative interface framework module interface test to run on both arm64 and x86_64

### DIFF
--- a/test/ModuleInterface/Inputs/DummyFramework.framework/Modules/DummyFramework.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/test/ModuleInterface/Inputs/DummyFramework.framework/Modules/DummyFramework.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -1,0 +1,6 @@
+// swift-interface-format-version: 1.0
+// swift-tools-version: Apple Swift version 5.1 (swiftlang-1100.0.38 clang-1100.0.20.14)
+// swift-module-flags: -target arm64e-apple-macos10.14 -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -O -module-name DummyFramework
+import Swift
+
+mess_mess_mess

--- a/test/ModuleInterface/Inputs/DummyFramework.framework/Modules/DummyFramework.swiftmodule/arm64e.swiftinterface
+++ b/test/ModuleInterface/Inputs/DummyFramework.framework/Modules/DummyFramework.swiftmodule/arm64e.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Apple Swift version 5.2
+// swift-module-flags: -target arm64e-apple-macos10.14 -enable-library-evolution -swift-version 5 -module-name DummyFramework
+import Swift

--- a/test/ModuleInterface/Inputs/DummyFramework.framework/Modules/DummyFramework.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/test/ModuleInterface/Inputs/DummyFramework.framework/Modules/DummyFramework.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,0 +1,6 @@
+// swift-interface-format-version: 1.0
+// swift-tools-version: Apple Swift version 5.1 (swiftlang-1100.0.38 clang-1100.0.20.14)
+// swift-module-flags: -target x86_64-apple-macos10.14 -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -O -module-name DummyFramework
+import Swift
+
+mess_mess_mess

--- a/test/ModuleInterface/Inputs/DummyFramework.framework/Modules/DummyFramework.swiftmodule/x86_64.swiftinterface
+++ b/test/ModuleInterface/Inputs/DummyFramework.framework/Modules/DummyFramework.swiftmodule/x86_64.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Apple Swift version 5.2
+// swift-module-flags: -target x86_64-apple-macos10.14 -enable-library-evolution -swift-version 5 -module-name DummyFramework
+import Swift

--- a/test/ModuleInterface/Inputs/alternative-interfaces/DummyFramework.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/test/ModuleInterface/Inputs/alternative-interfaces/DummyFramework.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-tools-version: Apple Swift version 5.1 (swiftlang-1100.0.38 clang-1100.0.20.14)
+// swift-module-flags: -target arm64e-apple-macos10.14 -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -O -module-name DummyFramework
+import Swift

--- a/test/ModuleInterface/Inputs/alternative-interfaces/DummyFramework.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/test/ModuleInterface/Inputs/alternative-interfaces/DummyFramework.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-tools-version: Apple Swift version 5.1 (swiftlang-1100.0.38 clang-1100.0.20.14)
+// swift-module-flags: -target x86_64-apple-macos10.14 -enable-objc-interop -enable-library-evolution -swift-version 5 -enforce-exclusivity=checked -O -module-name DummyFramework
+import Swift

--- a/test/ModuleInterface/build-alternative-interface-framework.swift
+++ b/test/ModuleInterface/build-alternative-interface-framework.swift
@@ -1,6 +1,11 @@
 // REQUIRES: VENDOR=apple
+
+// Required DummyFramework imported is only built for those two CPU architectures.
+// REQUIRES: CPU=arm64 || CPU=x86_64
+// REQUIRES: OS=macosx
+
 // RUN: %empty-directory(%t/module-cache)
-// RUN: not %target-swift-frontend-typecheck -disable-implicit-concurrency-module-import -target arm64-apple-macosx13.0 -F %S/Inputs %s -module-cache-path %t/module-cache
-// RUN: %target-swift-frontend-typecheck -disable-implicit-concurrency-module-import -target arm64-apple-macosx13.0 -F %S/Inputs %s -module-cache-path %t/module-cache -backup-module-interface-path %S/Inputs/alternative-interfaces
+// RUN: not %target-swift-frontend-typecheck -disable-implicit-concurrency-module-import -target %target-cpu-apple-macosx13.0 -F %S/Inputs %s -module-cache-path %t/module-cache
+// RUN: %target-swift-frontend-typecheck -disable-implicit-concurrency-module-import -target %target-cpu-apple-macosx13.0 -F %S/Inputs %s -module-cache-path %t/module-cache -backup-module-interface-path %S/Inputs/alternative-interfaces
 
 import DummyFramework

--- a/test/ModuleInterface/build-alternative-interface-framework.swift
+++ b/test/ModuleInterface/build-alternative-interface-framework.swift
@@ -1,7 +1,6 @@
 // REQUIRES: VENDOR=apple
 
-// Required DummyFramework imported is only built for those two CPU architectures.
-// REQUIRES: CPU=arm64 || CPU=x86_64
+// Required DummyFramework imported is only built for macOS supported archs (x86_64, arm64, arm64e)
 // REQUIRES: OS=macosx
 
 // RUN: %empty-directory(%t/module-cache)


### PR DESCRIPTION
<!-- What's in this pull request? -->
Running all lit tests on x86 machine cause this test to always fail because it runs a build commands specific for `arm64`. 

```
Command Output (stderr):
--
<unknown>:0: error: could not find module 'Swift' for target 'arm64-apple-macos'; found: x86_64-apple-macos, at: .../build/Ninja-ReleaseAssert/swift-macosx-x86_64/lib/swift/macosx/Swift.swiftmodule
<unknown>:0: error: could not find module 'Swift' for target 'arm64-apple-macos'; found: x86_64-apple-macos, at: .../build/Ninja-ReleaseAssert/swift-macosx-x86_64/lib/swift/macosx/Swift.swiftmodule

--

********************
********************
Failed Tests (1):
  Swift(macosx-x86_64) :: ModuleInterface/build-alternative-interface-framework.swift


Testing Time: 0.55s
  Failed: 1
```

This updates the test to use `-target %target-cpu-...` limited require CPU arch arm64 and x86_64 on macOS and build `DummyModule` Input module for x86_64 as well. 
 
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
This was recently reported on the forums https://forums.swift.org/t/build-alternative-interface-framework-failed-while-running-tests/50499

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
