### PR TITLE
Use `getOriginalInit` instead of `PatternBindingEntry::hasInitStringRepresentation`

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1576,7 +1576,7 @@ SourceRange PatternBindingEntry::getSourceRange(bool omitAccessors) const {
 bool PatternBindingEntry::hasInitStringRepresentation() const {
   if (InitContextAndFlags.getInt().contains(PatternFlags::IsText))
     return !InitStringRepresentation.empty();
-  return getInit() && getInit()->getSourceRange().isValid();
+  return getOriginalInit() && getOriginalInit()->getSourceRange().isValid();
 }
 
 StringRef PatternBindingEntry::getInitStringRepresentation(

--- a/validation-test/Serialization/rdar80449046.swift
+++ b/validation-test/Serialization/rdar80449046.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %s
+
+@propertyWrapper
+public struct TestWrapper {
+  public var wrappedValue: Int
+  public init(wrappedValue: Int) { self.wrappedValue = wrappedValue }
+}
+
+@frozen public struct Test {
+  @TestWrapper public var x: Int = 42
+}
+


### PR DESCRIPTION
Attempt a fix for serialization (i.e. `-emit-module`) for source code:
```
@propertyWrapper
public struct TestWrapper {
  public var wrappedValue: Int
  public init(wrappedValue: Int) { self.wrappedValue = wrappedValue }
}

@frozen public struct Test {
  @TestWrapper public var x: Int = 42
}
```

rdar://80449046