### PR TITLE
[ClangImporter] Reenable the objc_nsmanagedobject.swift test

### DIFF
--- a/test/ClangImporter/objc_nsmanagedobject.swift
+++ b/test/ClangImporter/objc_nsmanagedobject.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -emit-silgen -parse-as-library -o /dev/null -DNO_ERROR %s %S/Inputs/objc_nsmanaged_other.swift
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -emit-silgen -parse-as-library -o /dev/null -DNO_ERROR -primary-file %s %S/Inputs/objc_nsmanaged_other.swift
 
-// REQUIRES: objc_interop, rdar76090045 
+// REQUIRES: objc_interop
 
 import Foundation
 import CoreData


### PR DESCRIPTION
This test was likely broken by issues in the CoreData module installed on the bots. These should now have been fixed, let's try reenabling this test.

rdar://76090045