### PR TITLE
[5.5] [CodeCompletion] Use substGenericArgs in getTypeOfMember

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3513,7 +3513,8 @@ public:
                               
   /// Substitute the given generic arguments into this generic
   /// function type and return the resulting non-generic type.
-  FunctionType *substGenericArgs(SubstitutionMap subs);
+  FunctionType *substGenericArgs(SubstitutionMap subs,
+                                 SubstOptions options = None);
   FunctionType *substGenericArgs(llvm::function_ref<Type(Type)> substFn) const;
 
   void Profile(llvm::FoldingSetNodeID &ID) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3657,9 +3657,10 @@ bool SILFunctionType::hasSameExtInfoAs(const SILFunctionType *otherFn) {
 }
 
 FunctionType *
-GenericFunctionType::substGenericArgs(SubstitutionMap subs) {
+GenericFunctionType::substGenericArgs(SubstitutionMap subs,
+                                      SubstOptions options) {
   return substGenericArgs(
-    [=](Type t) { return t.subst(subs); });
+    [=](Type t) { return t.subst(subs, options); });
 }
 
 FunctionType *GenericFunctionType::substGenericArgs(

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2601,9 +2601,16 @@ public:
         // For everything else, substitute in the base type.
         auto Subs = MaybeNominalType->getMemberSubstitutionMap(CurrModule, VD);
 
-        // Pass in DesugarMemberTypes so that we see the actual
-        // concrete type witnesses instead of type alias types.
-        T = T.subst(Subs, SubstFlags::DesugarMemberTypes);
+        // For a GenericFunctionType, we only want to substitute the
+        // param/result types, as otherwise we might end up with a bad generic
+        // signature if there are UnresolvedTypes present in the base type. Note
+        // we pass in DesugarMemberTypes so that we see the actual concrete type
+        // witnesses instead of type alias types.
+        if (auto *GFT = T->getAs<GenericFunctionType>()) {
+          T = GFT->substGenericArgs(Subs, SubstFlags::DesugarMemberTypes);
+        } else {
+          T = T.subst(Subs, SubstFlags::DesugarMemberTypes);
+        }
       }
     }
 

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -389,3 +389,23 @@ struct StructWithCallAsFunction: HasCallAsFunctionRequirement {
 }
 // CRASH_CALL_AS_FUNCTION: Begin completion
 // CRASH_CALL_AS_FUNCTION: End completions
+
+// rdar://80635105
+protocol P_80635105 {
+  associatedtype T
+}
+struct S_80635105<T> {}
+extension S_80635105 : P_80635105 {}
+extension P_80635105 {
+  func foo<U : P_80635105>(_ x: U.T) where U == Self.T {}
+}
+
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=RDAR_80635105 -source-filename=%s | %FileCheck %s -check-prefix=RDAR_80635105
+func test_80635105() {
+  let fn = { x in
+    S_80635105.#^RDAR_80635105^#
+    // RDAR_80635105: Begin completions
+    // RDAR_80635105: Decl[InstanceMethod]/Super: foo({#(self): S_80635105<_>#})[#(P_80635105.T) -> Void#]; name=foo
+    // RDAR_80635105: End completions
+  }
+}


### PR DESCRIPTION
*5.5 cherry-pick of https://github.com/apple/swift/pull/38447*

---

For a GenericFunctionType, use `substGenericArgs` instead of `subst`, as the latter would form a bad generic signature if there were UnresolvedTypes present in the base type, causing the GSB to blow up when attempting to canonicalize it.

rdar://80635105
