### PR TITLE
[5.5] [Concurrency] Deprecate Task.sleep(_:) in favor of Task.sleep(nanoseconds:).

### DIFF
--- a/stdlib/public/Concurrency/TaskSleep.swift
+++ b/stdlib/public/Concurrency/TaskSleep.swift
@@ -14,10 +14,7 @@ import Swift
 
 @available(SwiftStdlib 5.5, *)
 extension Task where Success == Never, Failure == Never {
-  /// Suspends the current task for _at least_ the given duration
-  /// in nanoseconds.
-  ///
-  /// This function does _not_ block the underlying thread.
+  @available(*, deprecated, renamed: "Task.sleep(nanoseconds:)")
   public static func sleep(_ duration: UInt64) async {
     let currentTask = Builtin.getCurrentAsyncTask()
     let priority = getJobFlags(currentTask).priority ?? Task.currentPriority._downgradeUserInteractive

--- a/test/Concurrency/async_task_groups.swift
+++ b/test/Concurrency/async_task_groups.swift
@@ -13,7 +13,7 @@ func asyncThrowsOnCancel() async throws -> Int {
   // terrible suspend-spin-loop -- do not do this
   // only for purposes of demonstration
   while Task.isCancelled {
-    await Task.sleep(1_000_000_000)
+    try? await Task.sleep(nanoseconds: 1_000_000_000)
   }
 
   throw CancellationError()


### PR DESCRIPTION
main PR: https://github.com/apple/swift/pull/38477