### PR TITLE
[CSApply] Always map types out of context when setting interface types for wrapped closure parameters.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1067,7 +1067,7 @@ namespace {
         outerParamTypes.push_back(AnyFunctionType::Param(outerParamType,
                                                          Identifier(),
                                                          paramInfo[i].getParameterFlags()));
-        outerParam->setInterfaceType(outerParamType);
+        outerParam->setInterfaceType(outerParamType->mapTypeOutOfContext());
 
         if (fnDecl.getAbstractFunctionDecl())
           argLabels.push_back(innerParam->getArgumentName());
@@ -8151,11 +8151,12 @@ namespace {
 
         if (auto *projectionVar = param->getPropertyWrapperProjectionVar()) {
           projectionVar->setInterfaceType(
-              solution.simplifyType(solution.getType(projectionVar)));
+              solution.simplifyType(solution.getType(projectionVar))->mapTypeOutOfContext());
         }
 
         auto *wrappedValueVar = param->getPropertyWrapperWrappedValueVar();
-        auto wrappedValueType = solution.simplifyType(solution.getType(wrappedValueVar));
+        auto wrappedValueType =
+            solution.simplifyType(solution.getType(wrappedValueVar))->mapTypeOutOfContext();
         wrappedValueVar->setInterfaceType(wrappedValueType->getWithoutSpecifierType());
 
         if (param->hasImplicitPropertyWrapper()) {

--- a/test/Sema/property_wrapper_parameter.swift
+++ b/test/Sema/property_wrapper_parameter.swift
@@ -125,3 +125,9 @@ func testResultBuilderWithImplicitWrapper(@ProjectionWrapper value: String) {
     $value
   }
 }
+
+func takesWrapperClosure<T>(_: ProjectionWrapper<[S<T>]>, closure: (ProjectionWrapper<S<T>>) -> Void) {}
+
+func testGenericPropertyWrapper<U>(@ProjectionWrapper wrappers: [S<U>]) {
+  takesWrapperClosure($wrappers) { $wrapper in }
+}


### PR DESCRIPTION
Interface types should never contain archetypes, but I forgot to call `mapTypeOutOfContext` when setting interfaces types for wrapped closure parameters in CSApply. Without this change, the compiler will produce a bogus error message, or fail an assertion in an asserts build.

Resolves: rdar://80646669