### PR TITLE
[5.5][CSApply] Always map types out of context when setting interface types for wrapped closure parameters.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1066,7 +1066,7 @@ namespace {
         outerParamTypes.push_back(AnyFunctionType::Param(outerParamType,
                                                          Identifier(),
                                                          paramInfo[i].getParameterFlags()));
-        outerParam->setInterfaceType(outerParamType);
+        outerParam->setInterfaceType(outerParamType->mapTypeOutOfContext());
 
         if (fnDecl.getAbstractFunctionDecl())
           argLabels.push_back(innerParam->getArgumentName());
@@ -8171,11 +8171,12 @@ namespace {
 
         if (auto *projectionVar = param->getPropertyWrapperProjectionVar()) {
           projectionVar->setInterfaceType(
-              solution.simplifyType(solution.getType(projectionVar)));
+              solution.simplifyType(solution.getType(projectionVar))->mapTypeOutOfContext());
         }
 
         auto *wrappedValueVar = param->getPropertyWrapperWrappedValueVar();
-        auto wrappedValueType = solution.simplifyType(solution.getType(wrappedValueVar));
+        auto wrappedValueType =
+            solution.simplifyType(solution.getType(wrappedValueVar))->mapTypeOutOfContext();
         wrappedValueVar->setInterfaceType(wrappedValueType->getWithoutSpecifierType());
 
         if (param->hasImplicitPropertyWrapper()) {

--- a/test/Sema/property_wrapper_parameter.swift
+++ b/test/Sema/property_wrapper_parameter.swift
@@ -125,3 +125,9 @@ func testResultBuilderWithImplicitWrapper(@ProjectionWrapper value: String) {
     $value
   }
 }
+
+func takesWrapperClosure<T>(_: ProjectionWrapper<[S<T>]>, closure: (ProjectionWrapper<S<T>>) -> Void) {}
+
+func testGenericPropertyWrapper<U>(@ProjectionWrapper wrappers: [S<U>]) {
+  takesWrapperClosure($wrappers) { $wrapper in }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/38479

* **Explanation**: When using wrapped closure parameters with a generic type, the compiler will produce a bogus error message mentioning a conversion between two generic types that look identical. This happens because the interface type for the closure parameter (and the other synthesized property wrapper variables) mistakenly had archetypes in it because I forgot to call `mapTypeOutOfContext` when setting those interface types in CSApply to map the contextual type to an interface type. This change adds that call to the places where interface types are set for wrapped closure parameters.
* **Scope**: This only affects wrapped closure parameters.
* **Risk**: Very low.
* **Testing**: Added a regression test.
* **Reviewer**: @xedin 

Resolves: rdar://80646669