### PR TITLE
AST: Make sure that an opaque type descriptor is weak-linked if its naming declaration is [5.5]

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -889,6 +889,9 @@ AvailabilityContext Decl::getAvailabilityForLinkage() const {
   if (auto *accessor = dyn_cast<AccessorDecl>(this))
     return accessor->getStorage()->getAvailabilityForLinkage();
 
+  if (auto *opaqueTypeDecl = dyn_cast<OpaqueTypeDecl>(this))
+    return opaqueTypeDecl->getNamingDecl()->getAvailabilityForLinkage();
+
   if (auto *ext = dyn_cast<ExtensionDecl>(this))
     if (auto *nominal = ext->getExtendedNominal())
       return nominal->getAvailabilityForLinkage();
@@ -913,6 +916,9 @@ bool Decl::isAlwaysWeakImported() const {
 
   if (auto *accessor = dyn_cast<AccessorDecl>(this))
     return accessor->getStorage()->isAlwaysWeakImported();
+
+  if (auto *opaqueTypeDecl = dyn_cast<OpaqueTypeDecl>(this))
+    return opaqueTypeDecl->getNamingDecl()->isAlwaysWeakImported();
 
   if (auto *ext = dyn_cast<ExtensionDecl>(this))
     if (auto *nominal = ext->getExtendedNominal())

--- a/test/IRGen/Inputs/weak_availability_opaque_result_type_helper.swift
+++ b/test/IRGen/Inputs/weak_availability_opaque_result_type_helper.swift
@@ -1,0 +1,12 @@
+public protocol P {
+    func blah()
+}
+
+public struct S : P {
+    public func blah() {}
+}
+
+extension P {
+    @available(macOS 100, *)
+    @_weakLinked public func someAPI() -> some P { return S() }
+}

--- a/test/IRGen/Inputs/weak_import_opaque_result_type_helper.swift
+++ b/test/IRGen/Inputs/weak_import_opaque_result_type_helper.swift
@@ -1,0 +1,11 @@
+public protocol P {
+    func blah()
+}
+
+public struct S : P {
+    public func blah() {}
+}
+
+extension P {
+    @_weakLinked public func someAPI() -> some P { return S() }
+}

--- a/test/IRGen/weak_availability_opaque_result_type.swift
+++ b/test/IRGen/weak_availability_opaque_result_type.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/weak_availability_opaque_result_type_helper.swiftmodule -parse-as-library %S/Inputs/weak_availability_opaque_result_type_helper.swift -enable-library-evolution
+// RUN: %target-swift-frontend -disable-type-layout -primary-file %s -I %t -emit-ir | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+import weak_availability_opaque_result_type_helper
+
+func useWeakImportedOpaqueResultType<T : P>(_ p: T) {
+  if #available(macOS 100, *) {
+    p.someAPI().blah()
+  }
+}
+
+// CHECK-LABEL: @"$s43weak_availability_opaque_result_type_helper1PPAAE7someAPIQryFQOMQ" = extern_weak global %swift.type_descriptor
+// CHECK-LABEL: declare extern_weak {{.+}} void @"$s43weak_availability_opaque_result_type_helper1PPAAE7someAPIQryF"

--- a/test/IRGen/weak_import_opaque_result_type.swift
+++ b/test/IRGen/weak_import_opaque_result_type.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/weak_import_opaque_result_type_helper.swiftmodule -parse-as-library %S/Inputs/weak_import_opaque_result_type_helper.swift -enable-library-evolution -disable-availability-checking
+// RUN: %target-swift-frontend -disable-type-layout -disable-availability-checking -primary-file %s -I %t -emit-ir | %FileCheck %s
+
+// UNSUPPORTED: OS=windows-msvc
+
+import weak_import_opaque_result_type_helper
+
+func useWeakImportedOpaqueResultType<T : P>(_ p: T) {
+  p.someAPI().blah()
+}
+
+// CHECK-LABEL: @"$s37weak_import_opaque_result_type_helper1PPAAE7someAPIQryFQOMQ" = extern_weak global %swift.type_descriptor
+// CHECK-LABEL: declare extern_weak {{.+}} void @"$s37weak_import_opaque_result_type_helper1PPAAE7someAPIQryF"


### PR DESCRIPTION
Fixes rdar://problem/80584212.