### PR TITLE
Remove (void) call as it is confusing and adds nothing

### DIFF
--- a/stdlib/include/llvm/ADT/STLExtras.h
+++ b/stdlib/include/llvm/ADT/STLExtras.h
@@ -1303,7 +1303,7 @@ template <class Iterator, class RNG>
 void shuffle(Iterator first, Iterator last, RNG &&g) {
   // It would be better to use a std::uniform_int_distribution,
   // but that would be stdlib dependent.
-  for (auto size = last - first; size > 1; ++first, (void)--size)
+  for (auto size = last - first; size > 1; ++first, --size)
     std::iter_swap(first, first + g() % size);
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Usually (void) is used when a return value is discarded or when it comes before a declaration or definition of a function. It has no place here and is unnecessarily confusing.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
