### PR TITLE
[CodeCompletion] NFC: rename `CallParameter*` to `CallArgument*`

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -138,29 +138,32 @@ public:
     /// Generic type parameter name.
     GenericParameterName,
 
-    /// The first chunk of a substring that describes the parameter for a
+    /// The first chunk of a substring that describes the argument for a
     /// function call.
-    CallParameterBegin,
-    /// Function call parameter name.
-    CallParameterName,
-    /// Function call parameter internal / local name.  If the parameter has no
-    /// formal API name, it can still have a local name which can be useful
-    /// for display purposes.
+    CallArgumentBegin,
+
+    /// Function call argument label.
+    CallArgumentName,
+
+    /// Function parameter internal / local name for an call argument. If the
+    /// parameter has no formal API name, it can still have a local name which
+    /// can be useful for display purposes.
     ///
     /// This chunk should not be inserted into the editor buffer.
-    CallParameterInternalName,
-    /// A colon between parameter name and value.  Should be inserted in the
-    /// editor buffer if the preceding CallParameterName was inserted.
-    CallParameterColon,
+    CallArgumentInternalName,
+
+    /// A colon between argument name and value.  Should be inserted in the
+    /// editor buffer if the preceding CallArgumentName was inserted.
+    CallArgumentColon,
 
     /// A colon between parameter name and value. Used in decl attribute.
     DeclAttrParamColon,
 
-    /// Required parameter type.
-    CallParameterType,
+    /// Required argument type.
+    CallArgumentType,
 
-    /// Parameter type tag for annotated results.
-    CallParameterTypeBegin,
+    /// Argument type tag for annotated results.
+    CallArgumentTypeBegin,
 
     /// System type name.
     TypeIdSystem,
@@ -168,15 +171,15 @@ public:
     /// Non-system type name.
     TypeIdUser,
 
-    /// Desugared closure parameter type. This can be used to get the
-    /// closure type if CallParameterType is a TypeAliasType.
-    CallParameterClosureType,
+    /// Desugared closure argument type. This can be used to get the
+    /// closure type if CallArgumentType is a TypeAliasType.
+    CallArgumentClosureType,
 
-    /// An expanded closure expression for the value of a parameter, including
+    /// An expanded closure expression for the value of an argument, including
     /// the left and right braces and possible signature. The preferred
     /// position to put the cursor after the completion result is inserted
     /// into the editor buffer is between the braces.
-    CallParameterClosureExpr,
+    CallArgumentClosureExpr,
 
     /// A placeholder for \c ! or \c ? in a call to a method found by dynamic
     /// lookup.
@@ -212,10 +215,10 @@ public:
   };
 
   static bool chunkStartsNestedGroup(ChunkKind Kind) {
-    return Kind == ChunkKind::CallParameterBegin ||
+    return Kind == ChunkKind::CallArgumentBegin ||
            Kind == ChunkKind::GenericParameterBegin ||
            Kind == ChunkKind::OptionalBegin ||
-           Kind == ChunkKind::CallParameterTypeBegin ||
+           Kind == ChunkKind::CallArgumentTypeBegin ||
            Kind == ChunkKind::TypeAnnotationBegin;
   }
 
@@ -243,14 +246,14 @@ public:
            Kind == ChunkKind::Ampersand ||
            Kind == ChunkKind::Equal ||
            Kind == ChunkKind::Whitespace ||
-           Kind == ChunkKind::CallParameterName ||
-           Kind == ChunkKind::CallParameterInternalName ||
-           Kind == ChunkKind::CallParameterColon ||
+           Kind == ChunkKind::CallArgumentName ||
+           Kind == ChunkKind::CallArgumentInternalName ||
+           Kind == ChunkKind::CallArgumentColon ||
            Kind == ChunkKind::DeclAttrParamColon ||
            Kind == ChunkKind::DeclAttrParamKeyword ||
-           Kind == ChunkKind::CallParameterType ||
-           Kind == ChunkKind::CallParameterClosureType ||
-           Kind == ChunkKind::CallParameterClosureExpr ||
+           Kind == ChunkKind::CallArgumentType ||
+           Kind == ChunkKind::CallArgumentClosureType ||
+           Kind == ChunkKind::CallArgumentClosureExpr ||
            Kind == ChunkKind::GenericParameterName ||
            Kind == ChunkKind::DynamicLookupMethodCallTail ||
            Kind == ChunkKind::OptionalMethodCallTail ||

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -411,18 +411,18 @@ void CodeCompletionString::print(raw_ostream &OS) const {
     case ChunkKind::TypeIdUser:
       AnnotatedTextChunk = I->isAnnotation();
       LLVM_FALLTHROUGH;
-    case ChunkKind::CallParameterName:
-    case ChunkKind::CallParameterInternalName:
-    case ChunkKind::CallParameterColon:
+    case ChunkKind::CallArgumentName:
+    case ChunkKind::CallArgumentInternalName:
+    case ChunkKind::CallArgumentColon:
     case ChunkKind::DeclAttrParamColon:
-    case ChunkKind::CallParameterType:
-    case ChunkKind::CallParameterClosureType:
+    case ChunkKind::CallArgumentType:
+    case ChunkKind::CallArgumentClosureType:
     case ChunkKind::GenericParameterName:
       if (AnnotatedTextChunk)
         OS << "['";
-      else if (I->getKind() == ChunkKind::CallParameterInternalName)
+      else if (I->getKind() == ChunkKind::CallArgumentInternalName)
         OS << "(";
-      else if (I->getKind() == ChunkKind::CallParameterClosureType)
+      else if (I->getKind() == ChunkKind::CallArgumentClosureType)
         OS << "##";
       for (char Ch : I->getText()) {
         if (Ch == '\n')
@@ -432,12 +432,12 @@ void CodeCompletionString::print(raw_ostream &OS) const {
       }
       if (AnnotatedTextChunk)
         OS << "']";
-      else if (I->getKind() == ChunkKind::CallParameterInternalName)
+      else if (I->getKind() == ChunkKind::CallArgumentInternalName)
         OS << ")";
       break;
     case ChunkKind::OptionalBegin:
-    case ChunkKind::CallParameterBegin:
-    case ChunkKind::CallParameterTypeBegin:
+    case ChunkKind::CallArgumentBegin:
+    case ChunkKind::CallArgumentTypeBegin:
     case ChunkKind::GenericParameterBegin:
       OS << "{#";
       break;
@@ -461,7 +461,7 @@ void CodeCompletionString::print(raw_ostream &OS) const {
       OS << I->getText();
       OS << "#]";
       break;
-    case ChunkKind::CallParameterClosureExpr:
+    case ChunkKind::CallArgumentClosureExpr:
       OS << " {" << I->getText() << "|}";
       break;
     case ChunkKind::BraceStmtWithCursor:
@@ -924,20 +924,14 @@ public:
 };
 } // namespcae
 
-void CodeCompletionResultBuilder::addCallParameter(Identifier Name,
-                                                   Identifier LocalName,
-                                                   Type Ty,
-                                                   Type ContextTy,
-                                                   bool IsVarArg,
-                                                   bool IsInOut,
-                                                   bool IsIUO,
-                                                   bool isAutoClosure,
-                                                   bool useUnderscoreLabel,
-                                                   bool isLabeledTrailingClosure) {
+void CodeCompletionResultBuilder::addCallArgument(
+    Identifier Name, Identifier LocalName, Type Ty, Type ContextTy,
+    bool IsVarArg, bool IsInOut, bool IsIUO, bool isAutoClosure,
+    bool useUnderscoreLabel, bool isLabeledTrailingClosure) {
   ++CurrentNestingLevel;
   using ChunkKind = CodeCompletionString::Chunk::ChunkKind;
 
-  addSimpleChunk(ChunkKind::CallParameterBegin);
+  addSimpleChunk(ChunkKind::CallArgumentBegin);
 
   if (shouldAnnotateResults()) {
     if (!Name.empty() || !LocalName.empty()) {
@@ -945,48 +939,48 @@ void CodeCompletionResultBuilder::addCallParameter(Identifier Name,
 
       if (!Name.empty()) {
         addChunkWithText(
-            CodeCompletionString::Chunk::ChunkKind::CallParameterName,
+            CodeCompletionString::Chunk::ChunkKind::CallArgumentName,
             escapeKeyword(Name.str(), false, EscapedKeyword));
 
         if (!LocalName.empty() && Name != LocalName) {
           addChunkWithTextNoCopy(ChunkKind::Text, " ");
           getLastChunk().setIsAnnotation();
-          addChunkWithText(ChunkKind::CallParameterInternalName,
+          addChunkWithText(ChunkKind::CallArgumentInternalName,
               escapeKeyword(LocalName.str(), false, EscapedKeyword));
           getLastChunk().setIsAnnotation();
         }
       } else {
         assert(!LocalName.empty());
-        addChunkWithTextNoCopy(ChunkKind::CallParameterName, "_");
+        addChunkWithTextNoCopy(ChunkKind::CallArgumentName, "_");
         getLastChunk().setIsAnnotation();
         addChunkWithTextNoCopy(ChunkKind::Text, " ");
         getLastChunk().setIsAnnotation();
-        addChunkWithText(ChunkKind::CallParameterInternalName,
+        addChunkWithText(ChunkKind::CallArgumentInternalName,
             escapeKeyword(LocalName.str(), false, EscapedKeyword));
       }
-      addChunkWithTextNoCopy(ChunkKind::CallParameterColon, ": ");
+      addChunkWithTextNoCopy(ChunkKind::CallArgumentColon, ": ");
     }
   } else {
     if (!Name.empty()) {
       llvm::SmallString<16> EscapedKeyword;
       addChunkWithText(
-          CodeCompletionString::Chunk::ChunkKind::CallParameterName,
+          CodeCompletionString::Chunk::ChunkKind::CallArgumentName,
           escapeKeyword(Name.str(), false, EscapedKeyword));
       addChunkWithTextNoCopy(
-          CodeCompletionString::Chunk::ChunkKind::CallParameterColon, ": ");
+          CodeCompletionString::Chunk::ChunkKind::CallArgumentColon, ": ");
     } else if (useUnderscoreLabel) {
       addChunkWithTextNoCopy(
-          CodeCompletionString::Chunk::ChunkKind::CallParameterName, "_");
+          CodeCompletionString::Chunk::ChunkKind::CallArgumentName, "_");
       addChunkWithTextNoCopy(
-          CodeCompletionString::Chunk::ChunkKind::CallParameterColon, ": ");
+          CodeCompletionString::Chunk::ChunkKind::CallArgumentColon, ": ");
     } else if (!LocalName.empty()) {
       // Use local (non-API) parameter name if we have nothing else.
       llvm::SmallString<16> EscapedKeyword;
       addChunkWithText(
-          CodeCompletionString::Chunk::ChunkKind::CallParameterInternalName,
+          CodeCompletionString::Chunk::ChunkKind::CallArgumentInternalName,
             escapeKeyword(LocalName.str(), false, EscapedKeyword));
       addChunkWithTextNoCopy(
-          CodeCompletionString::Chunk::ChunkKind::CallParameterColon, ": ");
+          CodeCompletionString::Chunk::ChunkKind::CallArgumentColon, ": ");
     }
   }
 
@@ -1014,13 +1008,13 @@ void CodeCompletionResultBuilder::addCallParameter(Identifier Name,
   if (ContextTy)
     PO.setBaseType(ContextTy);
   if (shouldAnnotateResults()) {
-    withNestedGroup(ChunkKind::CallParameterTypeBegin, [&]() {
+    withNestedGroup(ChunkKind::CallArgumentTypeBegin, [&]() {
       AnnotatedTypePrinter printer(*this);
       Ty->print(printer, PO);
     });
   } else {
     std::string TypeName = Ty->getString(PO);
-    addChunkWithText(ChunkKind::CallParameterType, TypeName);
+    addChunkWithText(ChunkKind::CallArgumentType, TypeName);
   }
 
   // Look through optional types and type aliases to find out if we have
@@ -1069,12 +1063,12 @@ void CodeCompletionResultBuilder::addCallParameter(Identifier Name,
         OS << " in";
 
       addChunkWithText(
-         CodeCompletionString::Chunk::ChunkKind::CallParameterClosureExpr,
+         CodeCompletionString::Chunk::ChunkKind::CallArgumentClosureExpr,
          OS.str());
     } else {
       // Add the closure type.
       addChunkWithText(
-          CodeCompletionString::Chunk::ChunkKind::CallParameterClosureType,
+          CodeCompletionString::Chunk::ChunkKind::CallArgumentClosureType,
           AFT->getString(PO));
     }
   }
@@ -1381,8 +1375,8 @@ Optional<unsigned> CodeCompletionString::getFirstTextChunkIndex(
     switch (C.getKind()) {
     using ChunkKind = Chunk::ChunkKind;
     case ChunkKind::Text:
-    case ChunkKind::CallParameterName:
-    case ChunkKind::CallParameterInternalName:
+    case ChunkKind::CallArgumentName:
+    case ChunkKind::CallArgumentInternalName:
     case ChunkKind::GenericParameterName:
     case ChunkKind::LeftParen:
     case ChunkKind::LeftBracket:
@@ -1394,7 +1388,7 @@ Optional<unsigned> CodeCompletionString::getFirstTextChunkIndex(
     case ChunkKind::BaseName:
     case ChunkKind::TypeIdSystem:
     case ChunkKind::TypeIdUser:
-    case ChunkKind::CallParameterBegin:
+    case ChunkKind::CallArgumentBegin:
       return i;
     case ChunkKind::Dot:
     case ChunkKind::ExclamationMark:
@@ -1414,12 +1408,12 @@ Optional<unsigned> CodeCompletionString::getFirstTextChunkIndex(
     case ChunkKind::OverrideKeyword:
     case ChunkKind::EffectsSpecifierKeyword:
     case ChunkKind::DeclIntroducer:
-    case ChunkKind::CallParameterColon:
-    case ChunkKind::CallParameterTypeBegin:
+    case ChunkKind::CallArgumentColon:
+    case ChunkKind::CallArgumentTypeBegin:
     case ChunkKind::DeclAttrParamColon:
-    case ChunkKind::CallParameterType:
-    case ChunkKind::CallParameterClosureType:
-    case ChunkKind::CallParameterClosureExpr:
+    case ChunkKind::CallArgumentType:
+    case ChunkKind::CallArgumentClosureType:
+    case ChunkKind::CallArgumentClosureExpr:
     case ChunkKind::OptionalBegin:
     case ChunkKind::GenericParameterBegin:
     case ChunkKind::DynamicLookupMethodCallTail:
@@ -2810,11 +2804,11 @@ public:
       if (auto typeContext = CurrDeclContext->getInnermostTypeContext())
         contextTy = typeContext->getDeclaredTypeInContext();
 
-      Builder.addCallParameter(argName, bodyName,
-                               eraseArchetypes(paramTy, genericSig), contextTy,
-                               isVariadic, isInOut, isIUO, isAutoclosure,
-                               /*useUnderscoreLabel=*/false,
-                               /*isLabeledTrailingClosure=*/false);
+      Builder.addCallArgument(argName, bodyName,
+                              eraseArchetypes(paramTy, genericSig), contextTy,
+                              isVariadic, isInOut, isIUO, isAutoclosure,
+                              /*useUnderscoreLabel=*/false,
+                              /*isLabeledTrailingClosure=*/false);
 
       modifiedBuilder = true;
       NeedComma = true;
@@ -4192,7 +4186,7 @@ public:
     Type contextTy;
     if (auto typeContext = CurrDeclContext->getInnermostTypeContext())
       contextTy = typeContext->getDeclaredTypeInContext();
-    builder.addCallParameter(Identifier(), RHSType, contextTy);
+    builder.addCallArgument(Identifier(), RHSType, contextTy);
     addTypeAnnotation(builder, resultType);
   }
 
@@ -4217,7 +4211,7 @@ public:
       Type contextTy;
       if (auto typeContext = CurrDeclContext->getInnermostTypeContext())
         contextTy = typeContext->getDeclaredTypeInContext();
-      builder.addCallParameter(Identifier(), RHSType, contextTy);
+      builder.addCallArgument(Identifier(), RHSType, contextTy);
     }
     if (resultType)
       addTypeAnnotation(builder, resultType);
@@ -4476,13 +4470,13 @@ public:
       addFromProto(LK::ColorLiteral, [&](Builder &builder) {
         builder.addBaseName("#colorLiteral");
         builder.addLeftParen();
-        builder.addCallParameter(context.getIdentifier("red"), floatType);
+        builder.addCallArgument(context.getIdentifier("red"), floatType);
         builder.addComma();
-        builder.addCallParameter(context.getIdentifier("green"), floatType);
+        builder.addCallArgument(context.getIdentifier("green"), floatType);
         builder.addComma();
-        builder.addCallParameter(context.getIdentifier("blue"), floatType);
+        builder.addCallArgument(context.getIdentifier("blue"), floatType);
         builder.addComma();
-        builder.addCallParameter(context.getIdentifier("alpha"), floatType);
+        builder.addCallArgument(context.getIdentifier("alpha"), floatType);
         builder.addRightParen();
       });
 
@@ -4490,7 +4484,7 @@ public:
       addFromProto(LK::ImageLiteral, [&](Builder &builder) {
         builder.addBaseName("#imageLiteral");
         builder.addLeftParen();
-        builder.addCallParameter(context.getIdentifier("resourceName"),
+        builder.addCallArgument(context.getIdentifier("resourceName"),
                                  stringType);
         builder.addRightParen();
       });
@@ -4690,12 +4684,12 @@ public:
           // FIXME: SemanticContextKind::Local is not correct.
           // Use 'None' (and fix prioritization) or introduce a new context.
           SemanticContextKind::Local, {});
-      Builder.addCallParameter(Arg->getLabel(), Identifier(),
-                               Arg->getPlainType(), ContextType,
-                               Arg->isVariadic(), Arg->isInOut(),
-                               /*isIUO=*/false, Arg->isAutoClosure(),
-                               /*useUnderscoreLabel=*/true,
-                               isLabeledTrailingClosure);
+      Builder.addCallArgument(Arg->getLabel(), Identifier(),
+                              Arg->getPlainType(), ContextType,
+                              Arg->isVariadic(), Arg->isInOut(),
+                              /*isIUO=*/false, Arg->isAutoClosure(),
+                              /*useUnderscoreLabel=*/true,
+                              isLabeledTrailingClosure);
       Builder.addFlair(CodeCompletionFlairBit::ArgumentLabels);
       auto Ty = Arg->getPlainType();
       if (Arg->isInOut()) {

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -390,39 +390,39 @@ public:
 
   void addCallParameterColon() {
     addChunkWithText(CodeCompletionString::Chunk::ChunkKind::
-                     CallParameterColon, ": ");
+                     CallArgumentColon, ": ");
   }
 
   void addSimpleNamedParameter(StringRef name) {
-    withNestedGroup(CodeCompletionString::Chunk::ChunkKind::CallParameterBegin, [&] {
+    withNestedGroup(CodeCompletionString::Chunk::ChunkKind::CallArgumentBegin, [&] {
       // Use internal, since we don't want the name to be outside the
       // placeholder.
       addChunkWithText(
-          CodeCompletionString::Chunk::ChunkKind::CallParameterInternalName,
+          CodeCompletionString::Chunk::ChunkKind::CallArgumentInternalName,
           name);
     });
   }
 
   void addSimpleTypedParameter(StringRef Annotation, bool IsVarArg = false) {
-    withNestedGroup(CodeCompletionString::Chunk::ChunkKind::CallParameterBegin, [&] {
+    withNestedGroup(CodeCompletionString::Chunk::ChunkKind::CallArgumentBegin, [&] {
       addChunkWithText(
-          CodeCompletionString::Chunk::ChunkKind::CallParameterType,
+          CodeCompletionString::Chunk::ChunkKind::CallArgumentType,
           Annotation);
       if (IsVarArg)
         addEllipsis();
     });
   }
 
-  void addCallParameter(Identifier Name, Identifier LocalName, Type Ty,
-                        Type ContextTy, bool IsVarArg, bool IsInOut, bool IsIUO,
-                        bool isAutoClosure, bool useUnderscoreLabel,
-                        bool isLabeledTrailingClosure);
+  void addCallArgument(Identifier Name, Identifier LocalName, Type Ty,
+                       Type ContextTy, bool IsVarArg, bool IsInOut, bool IsIUO,
+                       bool isAutoClosure, bool useUnderscoreLabel,
+                       bool isLabeledTrailingClosure);
 
-  void addCallParameter(Identifier Name, Type Ty, Type ContextTy = Type()) {
-    addCallParameter(Name, Identifier(), Ty, ContextTy,
-                     /*IsVarArg=*/false, /*IsInOut=*/false, /*isIUO=*/false,
-                     /*isAutoClosure=*/false, /*useUnderscoreLabel=*/false,
-                     /*isLabeledTrailingClosure=*/false);
+  void addCallArgument(Identifier Name, Type Ty, Type ContextTy = Type()) {
+    addCallArgument(Name, Identifier(), Ty, ContextTy,
+                    /*IsVarArg=*/false, /*IsInOut=*/false, /*isIUO=*/false,
+                    /*isAutoClosure=*/false, /*useUnderscoreLabel=*/false,
+                    /*isLabeledTrailingClosure=*/false);
   }
 
   void addGenericParameter(StringRef Name) {

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -67,23 +67,23 @@ static std::string toInsertableString(CodeCompletionResult *Result) {
         Str += C.getText();
       break;
 
-    case CodeCompletionString::Chunk::ChunkKind::CallParameterName:
-    case CodeCompletionString::Chunk::ChunkKind::CallParameterInternalName:
-    case CodeCompletionString::Chunk::ChunkKind::CallParameterColon:
+    case CodeCompletionString::Chunk::ChunkKind::CallArgumentName:
+    case CodeCompletionString::Chunk::ChunkKind::CallArgumentInternalName:
+    case CodeCompletionString::Chunk::ChunkKind::CallArgumentColon:
     case CodeCompletionString::Chunk::ChunkKind::DeclAttrParamKeyword:
     case CodeCompletionString::Chunk::ChunkKind::DeclAttrParamColon:
-    case CodeCompletionString::Chunk::ChunkKind::CallParameterType:
-    case CodeCompletionString::Chunk::ChunkKind::CallParameterClosureType:
+    case CodeCompletionString::Chunk::ChunkKind::CallArgumentType:
+    case CodeCompletionString::Chunk::ChunkKind::CallArgumentClosureType:
     case CodeCompletionString::Chunk::ChunkKind::OptionalBegin:
-    case CodeCompletionString::Chunk::ChunkKind::CallParameterBegin:
-    case CodeCompletionString::Chunk::ChunkKind::CallParameterTypeBegin:
+    case CodeCompletionString::Chunk::ChunkKind::CallArgumentBegin:
+    case CodeCompletionString::Chunk::ChunkKind::CallArgumentTypeBegin:
     case CodeCompletionString::Chunk::ChunkKind::GenericParameterBegin:
     case CodeCompletionString::Chunk::ChunkKind::GenericParameterName:
     case CodeCompletionString::Chunk::ChunkKind::TypeAnnotation:
     case CodeCompletionString::Chunk::ChunkKind::TypeAnnotationBegin:
       return Str;
 
-    case CodeCompletionString::Chunk::ChunkKind::CallParameterClosureExpr:
+    case CodeCompletionString::Chunk::ChunkKind::CallArgumentClosureExpr:
       Str += " {";
       Str += C.getText();
       break;

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -242,14 +242,14 @@ static void getResultStructure(
   for (; i < chunks.size(); ++i) {
     auto C = chunks[i];
     if (C.is(ChunkKind::TypeAnnotation) ||
-        C.is(ChunkKind::CallParameterClosureType) ||
-        C.is(ChunkKind::CallParameterClosureExpr) ||
+        C.is(ChunkKind::CallArgumentClosureType) ||
+        C.is(ChunkKind::CallArgumentClosureExpr) ||
         C.is(ChunkKind::Whitespace))
       continue;
 
     if (C.is(ChunkKind::LeftParen) || C.is(ChunkKind::LeftBracket) ||
         C.is(ChunkKind::BraceStmtWithCursor) ||
-        C.is(ChunkKind::CallParameterBegin))
+        C.is(ChunkKind::CallArgumentBegin))
       break;
 
     if (C.hasText())
@@ -263,15 +263,15 @@ static void getResultStructure(
   for (; i < chunks.size(); ++i) {
     auto &C = chunks[i];
     if (C.is(ChunkKind::TypeAnnotation) ||
-        C.is(ChunkKind::CallParameterClosureType) ||
-        C.is(ChunkKind::CallParameterClosureExpr) ||
+        C.is(ChunkKind::CallArgumentClosureType) ||
+        C.is(ChunkKind::CallArgumentClosureExpr) ||
         C.is(ChunkKind::Whitespace))
       continue;
 
     if (C.is(ChunkKind::BraceStmtWithCursor))
       break;
 
-    if (C.is(ChunkKind::CallParameterBegin)) {
+    if (C.is(ChunkKind::CallArgumentBegin)) {
       CodeCompletionInfo::ParameterStructure param;
 
       ++i;
@@ -280,23 +280,23 @@ static void getResultStructure(
       for (; i < chunks.size(); ++i) {
         if (chunks[i].endsPreviousNestedGroup(C.getNestingLevel()))
           break;
-        if (chunks[i].is(ChunkKind::CallParameterClosureType) ||
-            chunks[i].is(ChunkKind::CallParameterClosureExpr))
+        if (chunks[i].is(ChunkKind::CallArgumentClosureType) ||
+            chunks[i].is(ChunkKind::CallArgumentClosureExpr))
           continue;
-        if (isOperator && chunks[i].is(ChunkKind::CallParameterType))
+        if (isOperator && chunks[i].is(ChunkKind::CallArgumentType))
           continue;
 
         // Parameter name
-        if (chunks[i].is(ChunkKind::CallParameterName) ||
-            chunks[i].is(ChunkKind::CallParameterInternalName)) {
+        if (chunks[i].is(ChunkKind::CallArgumentName) ||
+            chunks[i].is(ChunkKind::CallArgumentInternalName)) {
           param.name.begin = textSize;
           param.isLocalName =
-              chunks[i].is(ChunkKind::CallParameterInternalName);
+              chunks[i].is(ChunkKind::CallArgumentInternalName);
           inName = true;
         }
 
         // Parameter type
-        if (chunks[i].is(ChunkKind::CallParameterType)) {
+        if (chunks[i].is(ChunkKind::CallArgumentType)) {
           unsigned start = textSize;
           unsigned prev = i - 1; // if i == 0, prev = ~0u.
 
@@ -307,7 +307,7 @@ static void getResultStructure(
           }
 
           // Combine the whitespace after ':' into the type name.
-          if (prev != ~0u && chunks[prev].is(ChunkKind::CallParameterColon))
+          if (prev != ~0u && chunks[prev].is(ChunkKind::CallArgumentColon))
             start -= 1;
 
           param.afterColon.begin = start;


### PR DESCRIPTION
Since these chunks are for call sites, the correct term is "argument".

(Subset of #38453)