### PR TITLE
[5.5] fix parsing of `isolated` as an argument label

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -556,6 +556,29 @@ public:
   /// Return the next token that will be installed by \c consumeToken.
   const Token &peekToken();
 
+  /// Consumes K tokens within a backtracking scope before calling \c f and
+  /// providing it with the backtracking scope. Unless if the backtracking is
+  /// explicitly cancelled, the parser's token state is restored after \c f
+  /// returns.
+  ///
+  /// \param K The number of tokens ahead to skip. Zero is the current token.
+  /// \param f The function to apply after skipping K tokens ahead.
+  ///          The value returned by \c f will be returned by \c peekToken
+  ///           after the parser is rolled back.
+  /// \returns the value returned by \c f
+  /// \note When calling, you may need to specify the \c Val type
+  ///       explicitly as a type parameter.
+  template <typename Val>
+  Val lookahead(unsigned char K,
+                llvm::function_ref<Val(CancellableBacktrackingScope &)> f) {
+    CancellableBacktrackingScope backtrackScope(*this);
+
+    for (unsigned char i = 0; i < K; ++i)
+      consumeToken();
+
+    return f(backtrackScope);
+  }
+
   /// Consume a token that we created on the fly to correct the original token
   /// stream from lexer.
   void consumeExtraToken(Token K);

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -171,12 +171,15 @@ bool Parser::startsParameterName(bool isClosure) {
       return true;
 
     // "isolated" can be an argument label, but it's also a contextual keyword,
-    // so look ahead one more token see if we have a ':' that would indicate
-    // that this is an argument label.
-    BacktrackingScope backtrackScope(*this);
-    consumeToken();
-    consumeToken();
-    return Tok.is(tok::colon);
+    // so look ahead one more token (two total) see if we have a ':' that would
+    // indicate that this is an argument label.
+    return lookahead<bool>(2, [&](CancellableBacktrackingScope &) {
+      if (Tok.is(tok::colon))
+        return true; // isolated :
+
+      // isolated x :
+      return Tok.canBeArgumentLabel() && nextTok.is(tok::colon);
+    });
   }
 
   if (isOptionalToken(nextTok)
@@ -259,14 +262,30 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
            Tok.isContextualKeyword("__shared") ||
            Tok.isContextualKeyword("__owned") ||
            Tok.isContextualKeyword("isolated")) {
+
       if (Tok.isContextualKeyword("isolated")) {
+        // did we already find an 'isolated' type modifier?
         if (param.IsolatedLoc.isValid()) {
           diagnose(Tok, diag::parameter_specifier_repeated)
-            .fixItRemove(Tok.getLoc());
+              .fixItRemove(Tok.getLoc());
           consumeToken();
-        } else {
-          param.IsolatedLoc = consumeToken();
+          continue;
         }
+
+        // is this 'isolated' token the identifier of an argument label?
+        bool partOfArgumentLabel = lookahead<bool>(1, [&](CancellableBacktrackingScope &) {
+          if (Tok.is(tok::colon))
+            return true;  // isolated :
+
+          // isolated x :
+          return Tok.canBeArgumentLabel() && peekToken().is(tok::colon);
+        });
+
+        if (partOfArgumentLabel)
+          break;
+
+        // consume 'isolated' as type modifier
+        param.IsolatedLoc = consumeToken();
         continue;
       }
 
@@ -303,7 +322,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
       diagnose(Tok, diag::parameter_let_var_as_attr, Tok.getText())
         .fixItReplace(Tok.getLoc(), "`" + Tok.getText().str() + "`");
     }
-    
+
     if (startsParameterName(isClosure)) {
       // identifier-or-none for the first name
       param.FirstNameLoc = consumeArgumentLabel(param.FirstName,
@@ -432,7 +451,7 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         status.setIsParseError();
       }
     }
-                        
+
     // '...'?
     if (Tok.isEllipsis()) {
       Tok.setKind(tok::ellipsis);


### PR DESCRIPTION
Rationale: This PR fixes a regression in parsing `isolated` in the position of an argument label.
Risk: Low
Reward: Medium
Reward Details: Prevents a narrow, unintentional source break.
Original PR: https://github.com/apple/swift/pull/38422
Issue: rdar://80300022
Code Reviewed By: Konrad Malawski
Testing Details: Regression test is included.