### PR TITLE
[Swift CI] Re-enable sanitizer symbolication tests

### DIFF
--- a/test/Sanitizers/symbolication.swift
+++ b/test/Sanitizers/symbolication.swift
@@ -5,10 +5,6 @@
 // REQUIRES: asan_runtime
 // REQUIRES: VENDOR=apple
 
-// rdar://80274830 ([Swift CI] Sanitizer report symbolication fails because we fail to start atos, sanbox issue?)
-// REQUIRES: 80274830
-// Might be related/same issue as below
-
 // rdar://75365575 (Failing to start atos external symbolizer)
 // UNSUPPORTED: OS=watchos
 

--- a/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
@@ -10,10 +10,6 @@
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib
 
-// rdar://80274830 ([Swift CI] Sanitizer report symbolication fails because we fail to start atos, sanbox issue?)
-// REQUIRES: 80274830
-// Might be related/same issue as below
-
 // rdar://75365575 (Failing to start atos external symbolizer)
 // UNSUPPORTED: OS=watchos
 


### PR DESCRIPTION
We updated the Swift CI nodes to a version of Xcode that includes the
fix for a regression in atos that broke sanitizer report symbolication.

Regression: rdar://79151503 (If atos is handed a dSYM, it should find the binary rather than erring)
Fix:        rdar://80345994 (Regression: atos -p <pid> exits immediately)

Radar-Id: rdar://80274830