### PR TITLE
[5.5] Inject `hop_to_executor` after `self` is fully initialized in unrestricted actor inits

### DIFF
--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -432,7 +432,7 @@ bool DIMemoryObjectInfo::isElementLetProperty(unsigned Element) const {
   return false;
 }
 
-ConstructorDecl *DIMemoryObjectInfo::isActorInitSelf() const {
+ConstructorDecl *DIMemoryObjectInfo::getActorInitSelf() const {
   // is it 'self'?
   if (!MemoryInst->isVar())
     if (auto decl =

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
@@ -166,7 +166,7 @@ public:
 
   /// Returns the initializer if the memory use is 'self' and appears in an
   /// actor's designated initializer. Otherwise, returns nullptr.
-  ConstructorDecl *isActorInitSelf() const;
+  ConstructorDecl *getActorInitSelf() const;
 
   /// True if this memory object is the 'self' of a derived class initializer.
   bool isDerivedClassSelf() const { return MemoryInst->isDerivedClassSelf(); }

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -818,7 +818,7 @@ static void injectHopToExecutorAfter(SILLocation loc,
       if (needsBorrow)
         actor = b.createBeginBorrow(loc, actor);
 
-      b.createHopToExecutor(loc, actor, /*mandatory=*/false);
+      b.createHopToExecutor(loc, actor);
 
       if (needsBorrow)
         b.createEndBorrow(loc, actor);
@@ -967,7 +967,7 @@ void LifetimeChecker::injectActorHops() {
 
     AvailabilitySet inSet(outSet.size());
     auto const &predecessors = block.getPredecessorBlocks();
-    for (const auto &pred : predecessors)
+    for (auto *pred : predecessors)
       inSet.mergeIn(getBlockInfo(pred).OutAvailability);
 
     if (inSet.isAllYes()) {

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -451,6 +451,21 @@ namespace {
     void doIt();
 
   private:
+    /// Injects `hop_to_executor` instructions into the function after
+    /// `self` becomes fully initialized, only if the current function
+    /// is an actor initializer that requires this, and if TheMemory
+    /// corresponds to `self`.
+    void injectActorHops();
+
+    /// Given an initializing block and the live-in availability of TheMemory,
+    /// this function injects a `hop_to_executor` instruction after the
+    /// first non-load use of TheMemory that fully-initializes it.
+    /// An "initializing block" is one that definitely contains a such a
+    /// non-load use, e.g., because its live-in set is *not* all-Yes, but its
+    /// live-out set is all-Yes.
+    void injectActorHopForBlock(SILLocation loc,
+                                SILBasicBlock *initializingBlock,
+                                AvailabilitySet const &liveInAvailability);
 
     void emitSelfConsumedDiagnostic(SILInstruction *Inst);
 
@@ -476,7 +491,6 @@ namespace {
                             bool *FailedSelfUse = nullptr,
                             bool *FullyUninitialized = nullptr);
 
-
     void handleStoreUse(unsigned UseID);
     void handleLoadUse(const DIMemoryUse &Use);
     void handleLoadForTypeOfSelfUse(DIMemoryUse &Use);
@@ -487,12 +501,11 @@ namespace {
     bool diagnoseReturnWithoutInitializingStoredProperties(
         const SILInstruction *Inst, SILLocation loc, const DIMemoryUse &Use);
 
-    /// Returns true iff the use involves 'self' in a restricted kind of
+    /// Returns true iff TheMemory involves 'self' in a restricted kind of
     /// actor initializer. If a non-null Kind pointer was passed in,
     /// then the specific kind of restricted actor initializer will be
     /// written out. Otherwise, the None initializer kind will be written out.
-    bool isRestrictedActorInitSelf(const DIMemoryUse& Use,
-                               ActorInitKind *Kind = nullptr) const;
+    bool isRestrictedActorInitSelf(ActorInitKind *kind = nullptr) const;
 
     void reportIllegalUseForActorInit(const DIMemoryUse &Use,
                                       ActorInitKind ActorKind,
@@ -783,6 +796,155 @@ void LifetimeChecker::diagnoseInitError(const DIMemoryUse &Use,
     diagnose(Module, TheMemory.getLoc(), diag::variable_defined_here, isLet);
 }
 
+/// Injects a hop_to_executor instruction after the specified insertion point.
+static void injectHopToExecutorAfter(SILLocation loc,
+                                     SILBasicBlock::iterator insertPt,
+                                     SILValue actor, bool needsBorrow = true) {
+
+  LLVM_DEBUG(llvm::dbgs() << "hop-injector: inserting hop after " << *insertPt);
+
+  // While insertAfter can handle terminators, it cannot handle ones that lead
+  // to a block with multiple predecessors. I don't expect that a terminator
+  // could initialize a stored property at all: a try_apply passed the property
+  // as an inout would not be a valid use until _after_ the property has been
+  // initialized.
+  assert(!isa<TermInst>(*insertPt) && "unexpected hop-inject after terminator");
+
+  SILBuilderWithScope::insertAfter(&*insertPt, [&](SILBuilder &b) {
+    if (needsBorrow)
+      actor = b.createBeginBorrow(loc, actor);
+
+    b.createHopToExecutor(loc, actor, /*mandatory=*/false);
+
+    if (needsBorrow)
+      b.createEndBorrow(loc, actor);
+  });
+}
+
+void LifetimeChecker::injectActorHopForBlock(
+    SILLocation loc, SILBasicBlock *block,
+    AvailabilitySet const &liveInAvailability) {
+  // Tracks status of each element of TheMemory as we scan through the block,
+  // starting with the initial availability at the block's entry-point.
+  AvailabilitySet localAvail = liveInAvailability;
+
+  auto bbi = block->begin(); // our cursor and eventual insertion-point.
+  const auto bbe = block->end();
+  for (; bbi != bbe; ++bbi) {
+    auto *inst = &*bbi;
+
+    auto result = NonLoadUses.find(inst);
+    if (result == NonLoadUses.end())
+      continue; // not a possible store
+
+    // Mark the tuple elements involved in this use as defined.
+    for (unsigned use : result->second) {
+      auto const &instUse = Uses[use];
+      for (unsigned i = instUse.FirstElement;
+           i < instUse.FirstElement + instUse.NumElements; ++i)
+        localAvail.set(i, DIKind::Yes);
+    }
+
+    // Stop if we found the instruction that initializes TheMemory.
+    if (localAvail.isAllYes())
+      break;
+  }
+
+  // Make sure we found the initializing use of TheMemory.
+  assert(bbi != bbe && "this block is not initializing?");
+
+  injectHopToExecutorAfter(loc, bbi, TheMemory.getUninitializedValue());
+}
+
+void LifetimeChecker::injectActorHops() {
+  auto ctor = TheMemory.getActorInitSelf();
+
+  // Must be `self` within an actor's designated initializer.
+  if (!ctor)
+    return;
+
+  // If the initializer has restricted use of `self`, then no hops are needed.
+  if (isRestrictedActorInitSelf())
+    return;
+
+  // Even if there are no stored properties to initialize, we still need a hop.
+  // We insert this directly after the mark_uninitialized instruction, so
+  // that it happens as early as `self` is available.`
+  if (TheMemory.getNumElements() == 0) {
+    auto *selfDef = TheMemory.getUninitializedValue();
+    return injectHopToExecutorAfter(ctor, selfDef->getIterator(), selfDef);
+  }
+
+  // Returns true iff a block returns normally from the initializer,
+  // which means that it returns `self` in some way (perhaps optional-wrapped).
+  auto returnsSelf = [](SILBasicBlock &block) -> bool {
+    // This check relies on the fact that failable initializers are emitted by
+    // SILGen to perform their return in a fresh block with either:
+    //    1. No non-load uses of `self` (e.g., failing case)
+    //    2. An all-Yes in-availability. (e.g., success case)
+    return block.getTerminator()->getTermKind() == TermKind::ReturnInst;
+  };
+
+  /////
+  // Step 1: Find initializing blocks, which are blocks that contain a store
+  // to TheMemory that fully-initializes it, and build the Map.
+
+  // We determine whether a block is "initializing" by inspecting the "in" and
+  // "out" availability sets of the block. If the block goes from No / Partial
+  // "in" to Yes "out", then some instruction in the block caused TheMemory to
+  // become fully-initialized, so we record that block and its in-availability
+  // to scan the block more precisely later in the next Step.
+  for (auto &block : F) {
+    auto &info = getBlockInfo(&block);
+
+    if (!info.HasNonLoadUse) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "hop-injector: rejecting bb" << block.getDebugID()
+                 << " b/c no non-load uses.\n");
+      continue; // could not be an initializing block.
+    }
+
+    // Determine if this `block` is initializing, that is:
+    //
+    //     InAvailability ≡ merge(OutAvailability(predecessors(block)))
+    //                    ≠ Yes
+    //               AND
+    //     OutAvailability(block) = Yes OR returnsSelf(block)
+    //
+    // A block with no predecessors has in-avail of non-Yes.
+    // A block with no successors has an out-avail of non-Yes, since
+    // availability is not computed for it.
+
+    auto outSet = info.OutAvailability;
+    if (!outSet.isAllYes() && !returnsSelf(block)) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "hop-injector: rejecting bb" << block.getDebugID()
+                 << " b/c non-Yes OUT avail\n");
+      continue; // then this block never sees TheMemory initialized.
+    }
+
+    AvailabilitySet inSet(outSet.size());
+    auto const &predecessors = block.getPredecessorBlocks();
+    for (const auto &pred : predecessors)
+      inSet.mergeIn(getBlockInfo(pred).OutAvailability);
+
+    if (inSet.isAllYes()) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "hop-injector: rejecting bb" << block.getDebugID()
+                 << " b/c all-Yes IN avail\n");
+      continue; // then this block always sees TheMemory initialized.
+    }
+
+    LLVM_DEBUG(llvm::dbgs() << "hop-injector: bb" << block.getDebugID()
+                            << " is initializing block with in-availability: "
+                            << inSet << "\n");
+
+    // Step 2: Scan the initializing block to find the first non-load use that
+    // fully-initializes TheMemory, and insert the hop there.
+    injectActorHopForBlock(ctor, &block, inSet);
+  }
+}
+
 void LifetimeChecker::doIt() {
   // With any escapes tallied up, we can work through all the uses, checking
   // for definitive initialization, promoting loads, rewriting assigns, and
@@ -851,6 +1013,9 @@ void LifetimeChecker::doIt() {
   // If we emitted an error, there is no reason to proceed with load promotion.
   if (!EmittedErrorLocs.empty()) return;
 
+  // Insert hop_to_executor instructions for actor initializers, if needed.
+  injectActorHops();
+
   // If the memory object has nontrivial type, then any destroy/release of the
   // memory object will destruct the memory.  If the memory (or some element
   // thereof) is not initialized on some path, the bad things happen.  Process
@@ -893,7 +1058,7 @@ void LifetimeChecker::handleLoadUse(const DIMemoryUse &Use) {
   if (!isInitializedAtUse(Use, &IsSuperInitComplete, &FailedSelfUse))
     return handleLoadUseFailure(Use, IsSuperInitComplete, FailedSelfUse);
   // Check if it involves 'self' in a restricted actor init.
-  if (isRestrictedActorInitSelf(Use, &ActorKind))
+  if (isRestrictedActorInitSelf(&ActorKind))
     return handleLoadUseFailureForActorInit(Use, ActorKind);
 }
 
@@ -1223,7 +1388,7 @@ void LifetimeChecker::handleInOutUse(const DIMemoryUse &Use) {
   }
 
   // 'self' cannot be passed 'inout' from some kinds of actor initializers.
-  if (isRestrictedActorInitSelf(Use, &ActorKind))
+  if (isRestrictedActorInitSelf(&ActorKind))
     reportIllegalUseForActorInit(Use, ActorKind, "be passed 'inout'",
                                  /*suggestConvenienceInit=*/false);
 
@@ -1399,7 +1564,7 @@ void LifetimeChecker::handleEscapeUse(const DIMemoryUse &Use) {
                          &FullyUninitialized)) {
 
     // no escaping uses of 'self' are allowed in restricted actor inits.
-    if (isRestrictedActorInitSelf(Use, &ActorKind))
+    if (isRestrictedActorInitSelf(&ActorKind))
       reportIllegalUseForActorInit(Use, ActorKind, "be captured by a closure",
                                    /*suggestConvenienceInit=*/true);
 
@@ -1786,18 +1951,17 @@ bool LifetimeChecker::diagnoseReturnWithoutInitializingStoredProperties(
   return true;
 }
 
-bool LifetimeChecker::isRestrictedActorInitSelf(const DIMemoryUse& Use,
-                                            ActorInitKind *Kind) const {
+bool LifetimeChecker::isRestrictedActorInitSelf(ActorInitKind *kind) const {
 
   auto result = [&](ActorInitKind k, bool isRestricted) -> bool {
-    if (Kind)
-      *Kind = k;
+    if (kind)
+      *kind = k;
     return isRestricted;
   };
 
   // Currently: being synchronous, or global-actor isolated, means the actor's
   // self is restricted within the init.
-  if (auto *ctor = TheMemory.isActorInitSelf()) {
+  if (auto *ctor = TheMemory.getActorInitSelf()) {
     if (getActorIsolation(ctor).isGlobalActor())  // global-actor isolated?
       return result(ActorInitKind::GlobalActorIsolated, true);
     else if (!ctor->hasAsync()) // synchronous?

--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -202,6 +202,7 @@ public:
   }
 
   void remove(Access *access) {
+    assert(Head && "removal from empty AccessSet");
     auto cur = Head;
     // Fast path: stack discipline.
     if (cur == access) {

--- a/test/Concurrency/Runtime/actor_init.swift
+++ b/test/Concurrency/Runtime/actor_init.swift
@@ -1,0 +1,69 @@
+// RUN: %target-run-simple-swift(%import-libdispatch -parse-as-library) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+@available(SwiftStdlib 5.5, *)
+actor Number {
+    var val: Int
+    var task: Task<Void, Never>?
+
+    func increment() {
+        print("did increment")
+        val += 1
+    }
+
+    func fib(n: Int) -> Int {
+        if n < 2 {
+            return n
+        }
+        return fib(n: n-1) + fib(n: n-2)
+    }
+
+    init() async {
+        val = 0
+
+        task = Task.detached(priority: .high) { await self.increment() }
+
+        // do some synchronous work
+        let ans = fib(n: 37)
+        guard ans == 24157817 else {
+            fatalError("got ans = \(ans). miscomputation?")
+        }
+
+        // make sure task didn't modify me!
+        guard val == 0 else {
+            fatalError("race!")
+        }
+
+        print("finished init()")
+    }
+
+    init(iterations: Int) async {
+        var iter = iterations
+        repeat {
+            val = iter
+            iter -= 1
+        } while iter > 0
+    }
+}
+
+@available(SwiftStdlib 5.5, *)
+@main struct Main {
+    static func main() async {
+
+        // CHECK:       finished init()
+        // CHECK-NEXT:  did increment
+
+        let n1 = await Number()
+        await n1.task!.value
+
+        let n2 = await Number(iterations: 1000)
+        let val = await n2.val
+        guard val == 1 else {
+            fatalError("wrong val setting! got \(val)")
+        }
+    }
+}
+

--- a/test/SILGen/async_initializer.swift
+++ b/test/SILGen/async_initializer.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -module-name initializers -swift-version 5 -enable-experimental-concurrency | %FileCheck --enable-var-scope %s
+// RUN: %target-swift-frontend -emit-silgen %s -module-name initializers -swift-version 5 -enable-experimental-concurrency | %FileCheck %s --enable-var-scope --implicit-check-not=hop_to_executor
 // REQUIRES: concurrency
 
 // CHECK:       protocol Person {
@@ -57,8 +57,6 @@ enum MyEnum {
 
 actor MyActor {
   // CHECK-DAG:   sil hidden [ossa] @$s12initializers7MyActorCACyYacfc : $@convention(method) @async (@owned MyActor) -> @owned MyActor
-  // CHECK-NOT:     hop_to_executor
-  // CHECK-DAG:   } // end sil function '$s12initializers7MyActorCACyYacfc'
   init() async {}
 }
 
@@ -153,4 +151,48 @@ func makeDog() async {
 // CHECK:        } // end sil function '$s12initializers8makeBirbyyYaF'
 func makeBirb() async {
   _ = await Birb(name: "Chirpy")
+}
+
+actor SomeActor {
+  var x: Int = 0
+
+  // NOTE: during SILGen, we don't expect any hop_to_executors in here.
+  // The implicit check-not covers that for us. The hops are inserted later.
+  init() async {}
+
+  // CHECK-LABEL: sil hidden [ossa] @$s12initializers9SomeActorC10someMethodyyYaF : $@convention(method) @async (@guaranteed SomeActor) -> () {
+  // CHECK:           hop_to_executor {{%[0-9]+}} : $SomeActor
+  // CHECK: } // end sil function '$s12initializers9SomeActorC10someMethodyyYaF'
+  func someMethod() async {}
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s12initializers9makeActorAA04SomeC0CyYaF : $@convention(thin) @async () -> @owned SomeActor {
+// CHECK:         hop_to_executor {{%[0-9]+}} : $MainActor
+// CHECK:         [[INIT:%[0-9]+]] = function_ref @$s12initializers9SomeActorCACyYacfC : $@convention(method) @async (@thick SomeActor.Type) -> @owned SomeActor
+// CHECK:         {{%[0-9]+}} = apply [[INIT]]({{%[0-9]+}}) : $@convention(method) @async (@thick SomeActor.Type) -> @owned SomeActor
+// CHECK:         hop_to_executor {{%[0-9]+}} : $MainActor
+// CHECK: } // end sil function '$s12initializers9makeActorAA04SomeC0CyYaF'
+@MainActor
+func makeActor() async -> SomeActor {
+  return await SomeActor()
+}
+
+// None of the below calls are expected to have a hop before or after the call.
+
+func makeActorFromGeneric() async -> SomeActor {
+  return await SomeActor()
+}
+
+func callActorMethodFromGeneric(a: SomeActor) async {
+  await a.someMethod()
+}
+
+@available(SwiftStdlib 5.5, *)
+func makeActorInTask() async {
+  Task.detached { await SomeActor() }
+}
+
+@available(SwiftStdlib 5.5, *)
+func callActorMethodInTask(a: SomeActor) async {
+  Task.detached { await a.someMethod() }
 }

--- a/test/SILOptimizer/definite_init_actor.swift
+++ b/test/SILOptimizer/definite_init_actor.swift
@@ -1,0 +1,245 @@
+// RUN: %target-swift-frontend -module-name test -swift-version 5 -sil-verify-all -emit-sil %s | %FileCheck --enable-var-scope --implicit-check-not='hop_to_executor' %s
+
+// REQUIRES: concurrency
+
+ enum ActingError<T> : Error {
+   case forgotLine
+   case smuggledValue(T)
+ }
+
+func neverReturn() -> Never { fatalError("quit!") }
+
+actor BoringActor {
+
+    // CHECK-LABEL: sil hidden @$s4test11BoringActorCACyYacfc : $@convention(method) @async (@owned BoringActor) -> @owned BoringActor {
+    // CHECK:   bb0([[SELF:%[0-9]+]] : $BoringActor):
+    // CHECK:       initializeDefaultActor
+    // CHECK-NEXT:  hop_to_executor [[SELF]]
+    // CHECK: } // end sil function '$s4test11BoringActorCACyYacfc'
+    init() async {}
+
+    // CHECK-LABEL: sil hidden @$s4test11BoringActorC4sizeACSi_tYacfc : $@convention(method) @async (Int, @owned BoringActor) -> @owned BoringActor {
+    // CHECK:   bb0({{%[0-9]+}} : $Int, [[SELF:%[0-9]+]] : $BoringActor):
+    // CHECK:       initializeDefaultActor
+    // CHECK-NEXT:  hop_to_executor [[SELF]]
+    // CHECK: } // end sil function '$s4test11BoringActorC4sizeACSi_tYacfc'
+    init(size: Int) async {
+        var sz = size
+        while sz > 0 {
+            print(".")
+            sz -= 1
+        }
+        print("done!")
+    }
+
+    @MainActor
+    init(mainActor: Void) async {}
+
+    // CHECK-LABEL: sil hidden @$s4test11BoringActorC6crashyACSgyt_tYacfc : $@convention(method) @async (@owned BoringActor) -> @owned Optional<BoringActor> {
+    // CHECK:   bb0([[SELF:%[0-9]+]] : $BoringActor):
+    // CHECK:       initializeDefaultActor
+    // CHECK-NEXT:  hop_to_executor [[SELF]]
+    // CHECK: } // end sil function '$s4test11BoringActorC6crashyACSgyt_tYacfc'
+    init!(crashy: Void) async { return nil }
+
+    // CHECK-LABEL: sil hidden @$s4test11BoringActorC5nillyACSgSi_tYacfc : $@convention(method) @async (Int, @owned BoringActor) -> @owned Optional<BoringActor> {
+    // CHECK:   bb0({{%[0-9]+}} : $Int, [[SELF:%[0-9]+]] : $BoringActor):
+    // CHECK:       initializeDefaultActor
+    // CHECK-NEXT:  hop_to_executor [[SELF]]
+    // CHECK: } // end sil function '$s4test11BoringActorC5nillyACSgSi_tYacfc'
+    init?(nilly: Int) async {
+        guard nilly > 0 else { return nil }
+    }
+}
+
+ actor SingleVarActor {
+    var myVar: Int
+
+    // CHECK-LABEL: sil hidden @$s4test14SingleVarActorCACyYacfc : $@convention(method) @async (@owned SingleVarActor) -> @owned SingleVarActor {
+    // CHECK:    bb0([[SELF:%[0-9]+]] : $SingleVarActor):
+    // CHECK:       store {{%[0-9]+}} to [[ACCESS:%[0-9]+]]
+    // CHECK-NEXT:  end_access [[ACCESS]]
+    // CHECK-NEXT:  hop_to_executor [[SELF]] : $SingleVarActor
+    // CHECK:       store {{%[0-9]+}} to {{%[0-9]+}}
+    // CHECK: } // end sil function '$s4test14SingleVarActorCACyYacfc'
+    init() async {
+        myVar = 0
+        myVar = 1
+    }
+
+    // CHECK-LABEL: sil hidden @$s4test14SingleVarActorC10iterationsACSi_tYacfc : $@convention(method) @async (Int, @owned SingleVarActor) -> @owned SingleVarActor {
+    // CHECK:   bb0({{%[0-9]+}} : $Int, [[SELF:%[0-9]+]] : $SingleVarActor):
+    // CHECK:       [[MYVAR_REF:%[0-9]+]] = ref_element_addr [[SELF]] : $SingleVarActor, #SingleVarActor.myVar
+    // CHECK:       [[MYVAR:%[0-9]+]] = begin_access [modify] [dynamic] [[MYVAR_REF]] : $*Int
+    // CHECK:       store {{%[0-9]+}} to [[MYVAR]] : $*Int
+    // CHECK-NEXT:  end_access [[MYVAR]]
+    // CHECK-NEXT:  hop_to_executor [[SELF]] : $SingleVarActor
+    // CHECK: } // end sil function '$s4test14SingleVarActorC10iterationsACSi_tYacfc'
+    init(iterations: Int) async {
+        var iter = iterations
+        repeat {
+            myVar = 0
+            iter -= 1
+        } while iter > 0
+    }
+
+    // CHECK-LABEL: sil hidden @$s4test14SingleVarActorC2b12b2ACSb_SbtYacfc : $@convention(method) @async (Bool, Bool, @owned SingleVarActor) -> @owned SingleVarActor {
+    // CHECK:   bb0({{%[0-9]+}} : $Bool, {{%[0-9]+}} : $Bool, [[SELF:%[0-9]+]] : $SingleVarActor):
+
+    // CHECK:       store {{%[0-9]+}} to [[A1:%[0-9]+]] : $*Int
+    // CHECK-NEXT:  end_access [[A1]]
+    // CHECK-NEXT:  hop_to_executor [[SELF]] : $SingleVarActor
+
+    // CHECK:       store {{%[0-9]+}} to [[A2:%[0-9]+]] : $*Int
+    // CHECK-NEXT:  end_access [[A2]]
+    // CHECK-NEXT:  hop_to_executor [[SELF]] : $SingleVarActor
+
+    // CHECK:       store {{%[0-9]+}} to [[A3:%[0-9]+]] : $*Int
+    // CHECK-NEXT:  end_access [[A3]]
+    // CHECK-NEXT:  hop_to_executor [[SELF]] : $SingleVarActor
+
+    // CHECK: } // end sil function '$s4test14SingleVarActorC2b12b2ACSb_SbtYacfc'
+    init(b1: Bool, b2: Bool) async {
+        if b1 {
+            if b2 {
+                myVar = 0
+            }
+            myVar = 1
+        }
+        myVar = 2
+    }
+ }
+
+actor DefaultInit {
+    var x: DefaultInit?
+    var y: String = ""
+    var z: ActingError<Int> = .smuggledValue(5)
+
+    // CHECK-LABEL: sil hidden @$s4test11DefaultInitCACyYacfc : $@convention(method) @async (@owned DefaultInit) -> @owned DefaultInit {
+    // CHECK:   bb0([[SELF:%[0-9]+]] : $DefaultInit):
+    // CHECK:       store {{%[0-9]+}} to {{%[0-9]+}} : $*ActingError<Int>
+    // CHECK-NEXT:  hop_to_executor [[SELF]] : $DefaultInit
+    // CHECK: } // end sil function '$s4test11DefaultInitCACyYacfc'
+    init() async {}
+
+    // CHECK-LABEL: sil hidden @$s4test11DefaultInitC5nillyACSgSb_tYacfc : $@convention(method) @async (Bool, @owned DefaultInit) -> @owned Optional<DefaultInit> {
+    // CHECK:   bb0({{%[0-9]+}} : $Bool, [[SELF:%[0-9]+]] : $DefaultInit):
+    // CHECK:       store {{%[0-9]+}} to {{%[0-9]+}} : $*ActingError<Int>
+    // CHECK-NEXT:  hop_to_executor [[SELF]] : $DefaultInit
+    // CHECK: } // end sil function '$s4test11DefaultInitC5nillyACSgSb_tYacfc'
+    init?(nilly: Bool) async {
+        guard nilly else { return nil }
+    }
+
+    init(sync: Void) {}
+    @MainActor init(mainActorSync: Void) {}
+}
+
+actor MultiVarActor {
+    var firstVar: Int
+    var secondVar: Float
+
+    // CHECK-LABEL: sil hidden @$s4test13MultiVarActorC10doNotThrowACSb_tYaKcfc : $@convention(method) @async (Bool, @owned MultiVarActor) -> (@owned MultiVarActor, @error Error) {
+    // CHECK:   bb0({{%[0-9]+}} : $Bool, [[SELF:%[0-9]+]] : $MultiVarActor):
+    // CHECK:       [[REF:%[0-9]+]] = ref_element_addr [[SELF]] : $MultiVarActor, #MultiVarActor.firstVar
+    // CHECK:       [[VAR:%[0-9]+]] = begin_access [modify] [dynamic] [[REF]] : $*Int
+    // CHECK:       store {{%[0-9]+}} to [[VAR]] : $*Int
+    // CHECK-NEXT:  end_access [[VAR]]
+    // CHECK-NEXT:  hop_to_executor %1 : $MultiVarActor
+    // CHECK: } // end sil function '$s4test13MultiVarActorC10doNotThrowACSb_tYaKcfc'
+    init(doNotThrow: Bool) async throws {
+        secondVar = 0
+        guard doNotThrow else { throw ActingError<Any>.forgotLine }
+        firstVar = 1
+    }
+
+    // CHECK-LABEL: sil hidden @$s4test13MultiVarActorC10noSuccCaseACSb_tYacfc : $@convention(method) @async (Bool, @owned MultiVarActor) -> @owned MultiVarActor {
+    // CHECK:       store {{%[0-9]+}} to [[A1:%[0-9]+]] : $*Int
+    // CHECK-NEXT:  end_access [[A1]]
+    // CHECK-NEXT:  hop_to_executor {{%[0-9]+}} : $MultiVarActor
+
+    // CHECK:       store {{%[0-9]+}} to [[A2:%[0-9]+]] : $*Int
+    // CHECK-NEXT:  end_access [[A2]]
+    // CHECK-NEXT:  hop_to_executor {{%[0-9]+}} : $MultiVarActor
+    // CHECK: } // end sil function '$s4test13MultiVarActorC10noSuccCaseACSb_tYacfc'
+    init(noSuccCase: Bool) async {
+        secondVar = 0
+        if noSuccCase {
+            firstVar = 1
+        }
+        firstVar = 2
+    }
+
+    // CHECK-LABEL: sil hidden @$s4test13MultiVarActorC10noPredCaseACSb_tYacfc : $@convention(method) @async (Bool, @owned MultiVarActor) -> @owned MultiVarActor {
+    // CHECK:       store {{%[0-9]+}} to [[ACCESS:%[0-9]+]] : $*Int
+    // CHECK-NEXT:  end_access [[ACCESS]]
+    // CHECK-NEXT:  hop_to_executor {{%[0-9]+}} : $MultiVarActor
+    // CHECK: } // end sil function '$s4test13MultiVarActorC10noPredCaseACSb_tYacfc'
+    init(noPredCase: Bool) async {
+        secondVar = 0
+        firstVar = 1
+        if noPredCase {
+            print("hello")
+        }
+        print("hi")
+    }
+
+
+    // Some cases where we do NOT expect a hop to be emitted because they do
+    // not fully-initialize `self`. The implicit check-not flag on this test
+    // ensures that any unexpected hops are caught.
+
+    init?(doesNotFullyInit1: Bool) async {
+        firstVar = 1
+        return nil
+    }
+
+    init(doesNotFullyInit2: Bool) async {
+        firstVar = 1
+        fatalError("I give up!")
+    }
+
+    init(doesNotFullyInit3: Bool) async throws {
+        firstVar = 1
+        throw ActingError<Any>.forgotLine
+    }
+
+    init?(doesNotFullyInit4: Bool) async {
+        firstVar = 1
+        neverReturn()
+    }
+}
+
+@available(SwiftStdlib 5.5, *)
+actor TaskMaster {
+    var task: Task<Void, Never>?
+
+    func sayHello() { print("hello") }
+
+    ////// for the initializer
+    // CHECK-LABEL: @$s4test10TaskMasterCACyYacfc : $@convention(method) @async (@owned TaskMaster) -> @owned TaskMaster {
+    // CHECK:           [[ELM:%[0-9]+]] = ref_element_addr [[SELF:%[0-9]+]] : $TaskMaster, #TaskMaster.task
+    // CHECK:           [[NIL:%[0-9]+]] = enum $Optional<Task<(), Never>>, #Optional.none!enumelt
+    // CHECK:           store [[NIL]] to [[ELM]] : $*Optional<Task<(), Never>>
+    // CHECK-NEXT:      hop_to_executor [[SELF]] : $TaskMaster
+    // CHECK: } // end sil function '$s4test10TaskMasterCACyYacfc'
+    init() async {
+
+        ////// for the closure
+        // CHECK-LABEL: sil private @$s4test10TaskMasterCACyYacfcyyYaYbcfU_ : $@convention(thin) @Sendable @async (@guaranteed TaskMaster) -> () {
+        // CHECK:           hop_to_executor {{%[0-9]+}} : $TaskMaster
+        // CHECK: } // end sil function '$s4test10TaskMasterCACyYacfcyyYaYbcfU_'
+        task = Task.detached { await self.sayHello() }
+    }
+}
+
+actor SomeActor {
+    var x: Int = 0
+
+    // CHECK-LABEL: sil hidden @$s4test9SomeActorCACyYacfc : $@convention(method) @async (@owned SomeActor) -> @owned SomeActor {
+    // CHECK-NOT:       begin_access
+    // CHECK:           store {{%[0-9]+}} to {{%[0-9]+}} : $*Int
+    // CHECK-NEXT:      hop_to_executor {{%[0-9]+}} : $SomeActor
+    // CHECK: } // end sil function '$s4test9SomeActorCACyYacfc'
+    init() async {}
+}


### PR DESCRIPTION
Rationale: The typechecker permits unfettered use of `self` throughout an actor's `async` initializer. This patch brings the implementation of such initializers in line with what the typechecker permits, by actually hopping to `self`'s initializer in order to reserve it. This prevents a possible race with the initializer's body.
Risk: Low
Risk Detail: This change is focused on correcting the code generated by the compiler.
Reward: High
Reward Details: Fixes a miscompile that would lead to a concurrency bug.
Original PR: https://github.com/apple/swift/pull/38215
Issue: rdar://78790683
Code Reviewed By: Konrad Malawski
Testing Details: Regression test is included.