### PR TITLE
Global actor defer 5.5

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3133,7 +3133,6 @@ ActorIsolation ActorIsolationRequest::evaluate(
       switch (auto enclosingIsolation =
                   getActorIsolationOfContext(func->getDeclContext())) {
       case ActorIsolation::ActorInstance:
-      case ActorIsolation::DistributedActorInstance:
       case ActorIsolation::Independent:
       case ActorIsolation::Unspecified:
         // Do nothing.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3126,6 +3126,26 @@ ActorIsolation ActorIsolationRequest::evaluate(
     return inferred;
   };
 
+  // If this is a "defer" function body, inherit the global actor isolation
+  // from its context.
+  if (auto func = dyn_cast<FuncDecl>(value)) {
+    if (func->isDeferBody()) {
+      switch (auto enclosingIsolation =
+                  getActorIsolationOfContext(func->getDeclContext())) {
+      case ActorIsolation::ActorInstance:
+      case ActorIsolation::DistributedActorInstance:
+      case ActorIsolation::Independent:
+      case ActorIsolation::Unspecified:
+        // Do nothing.
+        break;
+
+      case ActorIsolation::GlobalActor:
+      case ActorIsolation::GlobalActorUnsafe:
+        return inferredIsolation(enclosingIsolation);
+      }
+    }
+  }
+
   // If the declaration overrides another declaration, it must have the same
   // actor isolation.
   if (auto overriddenValue = value->getOverriddenDecl()) {

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -552,3 +552,17 @@ func acceptAsyncSendableClosureInheriting<T>(@_inheritActorContext _: @Sendable 
     await onlyOnMainActor() // expected-warning{{no 'async' operations occur within 'await' expression}}
   }
 }
+
+
+// defer bodies inherit global actor-ness
+@MainActor
+var statefulThingy: Bool = false
+
+@MainActor
+func useFooInADefer() -> String {
+  defer {
+    statefulThingy = true
+  }
+
+  return "hello"
+}


### PR DESCRIPTION
Explanation: `defer` blocks within a global-actor-isolated context were not themselves global-actor-isolated, which made them unusable within most `@MainActor` code. Make them global-actor-isolated if their context is.
Scope: Accepts some new code using Swift Concurrency that was previously rejected erroneously.
Radar/SR Issue: rdar://80799233
Risk: Low.
Testing: PR testing and CI on main.
Original PR: https://github.com/apple/swift/pull/38481