### PR TITLE
Fix an assert in collectUses when handling unknown index offsets.

### DIFF
--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -1256,7 +1256,7 @@ int AccessPathDefUseTraversal::getPathOffset(const DFSEntry &dfs) const {
 bool AccessPathDefUseTraversal::checkAndUpdateOffset(DFSEntry &dfs) {
   int pathOffset = getPathOffset(dfs);
   if (dfs.offset == AccessPath::UnknownOffset) {
-    if (pathOffset > 0) {
+    if (pathOffset != 0) {
       // Pop the offset from the expected path; there should only be
       // one. Continue matching subobject indices even after seeing an unknown
       // offset. A subsequent mismatching subobject index is still considered


### PR DESCRIPTION
AccessPathDefUseTraversal accumulates the offsets that it has seen on
the def-use walk while visiting index_addr and casts.

This is quite tricky because either the AccessPath being matched or
the def-use chain could contain unknown offsets. We need to correctly
classify all cases as either an exact, inner, or overlapping match.

For SIL like this

 %91 = integer_literal $Builtin.Int64, 0
 %113 = builtin "truncOrBitCast_Int64_Word"(%91 : $Builtin.Int64) : $Builtin.Word
 %115 = index_addr %114 : $*MyStruct, %113 : $Builtin.Word
 %119 = struct_element_addr %115 : $*MyStruct, #MyStruct.klass

We have Path: (@Unknown,#0)

There are two issues

(1) When AccessPathDefUseTraversal::checkAndUpdateOffset visits the
struct_element_addr, it fails to pop the unknown offset from the
expected path but continues trying to handle the struct_element_addr
and hits an assert.

That's probably as simple as fixing

<    if (pathOffset > 0) {

to be

<    if (pathOffset != 0) {

(2) If the builtin "truncOrBitCast_Int64_Word" comes from a literal,
we should not treat it as an unknown offset (given that the literal is
within the size of a word).

We should change the test case above to be a truly unknown offset to
test issue #1. Then add the test case as-is to
accesspath_uses_ossa.sil to test that the constant offset is recognized.

Those can be separate fixes.
