### PR TITLE
SIL: Fix verifier failure when witness_method's lookup type involves dynamic Self [5.5]

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -3182,7 +3182,7 @@ public:
             "requirement Self parameter must conform to called protocol");
 
     auto lookupType = AMI->getLookupType();
-    if (getOpenedArchetypeOf(lookupType) || isa<DynamicSelfType>(lookupType)) {
+    if (getOpenedArchetypeOf(lookupType) || lookupType->hasDynamicSelfType()) {
       require(AMI->getTypeDependentOperands().size() == 1,
               "Must have a type dependent operand for the opened archetype");
       verifyOpenedArchetype(AMI, lookupType);

--- a/validation-test/compiler_crashers_2_fixed/rdar80296242.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar80296242.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-sil %s
+
+public class C {
+  public func foo() -> Self {
+    let arr = [self]
+
+    bar(arr)
+
+    return self
+  }
+}
+
+@_transparent public func bar<T : Sequence>(_ xs: T) {
+  for x in xs { _ = x }
+}


### PR DESCRIPTION
Fixes rdar://problem/80296242.