### PR TITLE
AST: Don't trigger source location deserialization in request evaluator [5.5]

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -210,9 +210,9 @@ public:
     llvm_unreachable("unexpected AnyFunctionRef representation");
   }
   
-  SourceLoc getLoc() const {
+  SourceLoc getLoc(bool SerializedOK = true) const {
     if (auto afd = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
-      return afd->getLoc();
+      return afd->getLoc(SerializedOK);
     }
     if (auto ce = TheFunction.dyn_cast<AbstractClosureExpr *>()) {
       return ce->getLoc();
@@ -269,7 +269,7 @@ public:
   }
 
   friend SourceLoc extractNearestSourceLoc(AnyFunctionRef fn) {
-    return fn.getLoc();
+    return fn.getLoc(/*SerializedOK=*/false);
   }
 
 private:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8425,7 +8425,7 @@ void swift::simple_display(llvm::raw_ostream &out, AccessorKind kind) {
 }
 
 SourceLoc swift::extractNearestSourceLoc(const Decl *decl) {
-  auto loc = decl->getLoc();
+  auto loc = decl->getLoc(/*SerializedOK=*/false);
   if (loc.isValid())
     return loc;
 


### PR DESCRIPTION
Deserializing a source location will compute the declaration's USR, which
might trigger another request cycle, etc.

Tentative fix for rdar://problem/80546848, but I don't have a test case.