### PR TITLE
Link the concurrency runtime against libatomic on Linux

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -29,6 +29,16 @@ if(SWIFT_CONCURRENCY_USES_DISPATCH)
   endif()
 endif()
 
+# Linux requires us to link an atomic library to use atomics.
+# Frustratingly, in many cases this isn't necessary because the
+# sequence is inlined, but we have some code that's just subtle
+# enough to turn into runtime calls.
+if(SWIFT_HOST_VARIANT STREQUAL "Linux")
+  if(SWIFT_HOST_VARIANT_ARCH MATCHES "armv6|armv7|i686")
+    list(APPEND swift_concurrency_link_libraries
+      atomic)
+  endif()
+endif()
 
 add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   ../CompatibilityOverride/CompatibilityOverride.cpp


### PR DESCRIPTION
We mostly get away without this because we're fairly disciplined about using constant memory orderings, and apparently that's usually good enough to get inline accesses and avoid needing to link atomic.  However, we have a few places with the task status atomic that use a non-constant load ordering with `load` and `compare_exchange_weak`, and my recent change to make that atomic a double-word was apparently sufficient on some (but not all) Linux distributions to get the compiler to call the runtime function.  Regardless, we shouldn't be playing around in the margins here: Linux requires us to link libatomic, so we should.