### PR TITLE
[Distributed] fix all distributed *runtime* tests; they are currently not running on CI

### DIFF
--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -126,13 +126,16 @@ extension DistributedActor {
 public protocol ActorIdentity: Sendable, Hashable, Codable {}
 
 @available(SwiftStdlib 5.5, *)
-public struct AnyActorIdentity: ActorIdentity, @unchecked Sendable {
+public struct AnyActorIdentity: ActorIdentity, @unchecked Sendable, CustomStringConvertible {
   @usableFromInline let _hashInto: (inout Hasher) -> ()
   @usableFromInline let _equalTo: (Any) -> Bool
   @usableFromInline let _encodeTo: (Encoder) throws -> ()
+  @usableFromInline let _description: () -> String
 
   public init<ID>(_ identity: ID) where ID: ActorIdentity {
-    _hashInto = { hasher in identity.hash(into: &hasher) }
+    _hashInto = { hasher in identity
+        .hash(into: &hasher)
+    }
     _equalTo = { other in
       guard let rhs = other as? ID else {
         return false
@@ -141,6 +144,9 @@ public struct AnyActorIdentity: ActorIdentity, @unchecked Sendable {
     }
     _encodeTo = { encoder in
       try identity.encode(to: encoder)
+    }
+    _description = { () in
+      "\(identity)"
     }
   }
 
@@ -156,6 +162,10 @@ public struct AnyActorIdentity: ActorIdentity, @unchecked Sendable {
 
   public func encode(to encoder: Encoder) throws {
     try _encodeTo(encoder)
+  }
+
+  public var description: String {
+    "\(Self.self)(\(self._description()))"
   }
 
   public func hash(into hasher: inout Hasher) {

--- a/test/Distributed/Runtime/distributed_actor_deinit.swift
+++ b/test/Distributed/Runtime/distributed_actor_deinit.swift
@@ -7,7 +7,7 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// REQUIRES: radar78290608
+// REQUIRES: rdar78290608
 
 import _Distributed
 
@@ -97,27 +97,27 @@ func test() {
 
   _ = DA(transport: transport)
   // CHECK: assign type:DA, address:[[ADDRESS:.*]]
-  // CHECK: ready actor:main.DA, address:[[ADDRESS]]
-  // CHECK: resign address:[[ADDRESS]]
+  // CHECK: ready actor:main.DA, address:AnyActorIdentity(ActorAddress(address: "xxx"))
+  // CHECK: resign address:AnyActorIdentity(ActorAddress(address: "xxx"))
 
   _ = DA_userDefined(transport: transport)
   // CHECK: assign type:DA_userDefined, address:[[ADDRESS:.*]]
-  // CHECK: ready actor:main.DA_userDefined, address:[[ADDRESS]]
-  // CHECK: resign address:[[ADDRESS]]
+  // CHECK: ready actor:main.DA_userDefined, address:AnyActorIdentity(ActorAddress(address: "xxx"))
+  // CHECK: resign address:AnyActorIdentity(ActorAddress(address: "xxx"))
 
   // resign must happen as the _last thing_ after user-deinit completed
   _ = DA_userDefined2(transport: transport)
   // CHECK: assign type:DA_userDefined2, address:[[ADDRESS:.*]]
-  // CHECK: ready actor:main.DA_userDefined2, address:[[ADDRESS]]
-  // CHECK: Deinitializing [[ADDRESS]]
-  // CHECK-NEXT: resign address:[[ADDRESS]]
+  // CHECK: ready actor:main.DA_userDefined2, address:AnyActorIdentity(ActorAddress(address: "xxx"))
+  // CHECK: Deinitializing AnyActorIdentity(ActorAddress(address: "xxx"))
+  // CHECK-NEXT: resign address:AnyActorIdentity(ActorAddress(address: "xxx"))
 
   // resign must happen as the _last thing_ after user-deinit completed
   _ = DA_state(transport: transport)
   // CHECK: assign type:DA_state, address:[[ADDRESS:.*]]
-  // CHECK: ready actor:main.DA_state, address:[[ADDRESS]]
-  // CHECK: Deinitializing [[ADDRESS]]
-  // CHECK-NEXT: resign address:[[ADDRESS]]
+  // CHECK: ready actor:main.DA_state, address:AnyActorIdentity(ActorAddress(address: "xxx"))
+  // CHECK: Deinitializing AnyActorIdentity(ActorAddress(address: "xxx"))
+  // CHECK-NEXT: resign address:AnyActorIdentity(ActorAddress(address: "xxx"))
 
   // a remote actor should not resign it's address, it was never "assigned" it
   print("before")

--- a/test/Distributed/Runtime/distributed_actor_init_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_init_local.swift
@@ -8,7 +8,7 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// REQUIRES: radar78290608
+// REQUIRES: rdar78290608
 
 import _Distributed
 
@@ -28,29 +28,29 @@ struct ActorAddress: ActorIdentity {
 
 @available(SwiftStdlib 5.5, *)
 struct FakeTransport: ActorTransport {
-  func resolve<Act>(address: ActorAddress, as actorType: Act.Type)
-    throws -> ActorResolved<Act> where Act: DistributedActor {
-    fatalError()
+  func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
+    fatalError("not implemented:\(#function)")
   }
 
-  func assignIdentity<Act>(
-    _ actorType: Act.Type
-  ) -> ActorAddress where Act : DistributedActor {
-    let address = ActorAddress(parse: "xxx")
-    print("assign type:\(actorType), address:\(address)")
-    return address
+  func resolve<Act>(_ identity: Act.ID, as actorType: Act.Type)
+      throws -> ActorResolved<Act>
+      where Act: DistributedActor {
+    fatalError("not implemented:\(#function)")
   }
 
-  public func actorReady<Act>(
-    _ actor: Act
-  ) where Act: DistributedActor {
-    print("ready actor:\(actor), address:\(actor.id)")
+  func assignIdentity<Act>(_ actorType: Act.Type) -> AnyActorIdentity
+      where Act: DistributedActor {
+    let id = ActorAddress(parse: "xxx")
+    print("assign type:\(actorType), id:\(id)")
+    return .init(id)
   }
 
-  public func resignIdentity(
-    _ address: ActorAddress
-  ) {
-    print("ready address:\(address)")
+  func actorReady<Act>(_ actor: Act) where Act: DistributedActor {
+    print("ready actor:\(actor), id:\(actor.id)")
+  }
+
+  func resignIdentity(_ id: AnyActorIdentity) {
+    print("ready id:\(id)")
   }
 }
 
@@ -61,8 +61,8 @@ func test() {
   let transport = FakeTransport()
 
   _ = LocalWorker(transport: transport)
-  // CHECK: assign type:LocalWorker, address:[[ADDRESS:.*]]
-  // CHECK: ready actor:main.LocalWorker, address:[[ADDRESS]]
+  // CHECK: assign type:LocalWorker, id:[[ID:.*]]
+  // CHECK: ready actor:main.LocalWorker, id:AnyActorIdentity([[ID]])
 }
 
 @available(SwiftStdlib 5.5, *)

--- a/test/Distributed/Runtime/distributed_actor_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_local.swift
@@ -8,7 +8,7 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// REQUIRES: radar78290608
+// REQUIRES: rdar78290608
 
 import _Distributed
 
@@ -17,6 +17,10 @@ distributed actor SomeSpecificDistributedActor {
 
   distributed func hello() async throws {
      print("hello from \(self.id)")
+  }
+
+  distributed func echo(int: Int) async throws -> Int {
+    int
   }
 }
 
@@ -41,25 +45,23 @@ struct ActorAddress: ActorIdentity {
 
 @available(SwiftStdlib 5.5, *)
 struct FakeTransport: ActorTransport {
-
   func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
-    fatalError()
+    fatalError("not implemented \(#function)")
   }
 
-  func resolve<Act>(identity: Act.ID, as actorType: Act.Type)
-    throws -> ActorResolved<Act>
+  func resolve<Act>(_ identity: Act.ID, as actorType: Act.Type) throws -> ActorResolved<Act>
       where Act: DistributedActor {
-    fatalError()
+    return .makeProxy
   }
 
   func assignIdentity<Act>(_ actorType: Act.Type) -> AnyActorIdentity
       where Act: DistributedActor {
-    ActorAddress(parse: "")
+    .init(ActorAddress(parse: ""))
   }
 
   public func actorReady<Act>(_ actor: Act)
       where Act: DistributedActor {
-    fatalError()
+    print("\(#function):\(actor)")
   }
 
   func resignIdentity(_ id: AnyActorIdentity) {}
@@ -73,7 +75,7 @@ func test_initializers() {
   let transport = FakeTransport()
 
   _ = SomeSpecificDistributedActor(transport: transport)
-  _ = try! SomeSpecificDistributedActor.resolve(address, using: transport)
+  _ = try! SomeSpecificDistributedActor(resolve: .init(address), using: transport)
 }
 
 @available(SwiftStdlib 5.5, *)

--- a/test/Distributed/Runtime/distributed_no_transport_boom.swift
+++ b/test/Distributed/Runtime/distributed_no_transport_boom.swift
@@ -9,7 +9,7 @@
 // REQUIRES: concurrency
 // REQUIRES: distributed
 
-// REQUIRES: radar78290608
+// REQUIRES: rdar78290608
 
 import _Distributed
 
@@ -32,24 +32,30 @@ struct ActorAddress: ActorIdentity {
 
 @available(SwiftStdlib 5.5, *)
 struct FakeTransport: ActorTransport {
-  func resolve<Act>(address: ActorAddress, as actorType: Act.Type)
-    throws -> ActorResolved<Act> where Act: DistributedActor {
-    return .makeProxy
+  func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
+    fatalError("not implemented:\(#function)")
   }
 
-  func assignIdentity<Act>(
-    _ actorType: Act.Type
-  ) -> ActorAddress where Act : DistributedActor {
-    ActorAddress(parse: "")
+  func resolve<Act>(_ identity: Act.ID, as actorType: Act.Type)
+  throws -> ActorResolved<Act>
+      where Act: DistributedActor {
+    .makeProxy
   }
 
-  public func actorReady<Act>(
-    _ actor: Act
-  ) where Act: DistributedActor {}
+  func assignIdentity<Act>(_ actorType: Act.Type) -> AnyActorIdentity
+      where Act: DistributedActor {
+    let id = ActorAddress(parse: "xxx")
+    print("assign type:\(actorType), id:\(id)")
+    return .init(id)
+  }
 
-  public func resignIdentity(
-    _ address: ActorAddress
-  ) {}
+  func actorReady<Act>(_ actor: Act) where Act: DistributedActor {
+    print("ready actor:\(actor), id:\(actor.id)")
+  }
+
+  func resignIdentity(_ id: AnyActorIdentity) {
+    print("ready id:\(id)")
+  }
 }
 
 // ==== Execute ----------------------------------------------------------------
@@ -59,9 +65,10 @@ func test_remote() async {
   let address = ActorAddress(parse: "")
   let transport = FakeTransport()
 
-  let remote = try! SomeSpecificDistributedActor(resolve: address, using: transport)
+  let remote = try! SomeSpecificDistributedActor(resolve: .init(address), using: transport)
   _ = try! await remote.hello() // let it crash!
-  // CHECK: SOURCE_DIR/test/Distributed/Runtime/distributed_no_transport_boom.swift:16: Fatal error: Invoked remote placeholder function '_remote_hello' on remote distributed actor of type 'main.SomeSpecificDistributedActor'. Configure an appropriate 'ActorTransport' for this actor to resolve this error (e.g. by depending on some specific transport library).
+
+  // CHECK: SOURCE_DIR/test/Distributed/Runtime/distributed_no_transport_boom.swift:18: Fatal error: Invoked remote placeholder function '_remote_hello' on remote distributed actor of type 'main.SomeSpecificDistributedActor'. Configure an appropriate 'ActorTransport' for this actor to resolve this error (e.g. by depending on some specific transport library).
 }
 
 @available(SwiftStdlib 5.5, *)


### PR DESCRIPTION
These have an issue on some specific CI configuration so they are currently disabled on CI.

They pass again all locally though:

```
Passed Tests (7):
  Swift(macosx-x86_64) :: Distributed/Runtime/distributed_actor_remote_functions.swift
  Swift(macosx-x86_64) :: Distributed/Runtime/distributed_actor_deinit.swift
  Swift(macosx-x86_64) :: Distributed/Runtime/distributed_actor_isRemote.swift
  Swift(macosx-x86_64) :: Distributed/Runtime/distributed_actor_dynamic_remote_func.swift
  Swift(macosx-x86_64) :: Distributed/Runtime/distributed_no_transport_boom.swift
  Swift(macosx-x86_64) :: Distributed/Runtime/distributed_actor_init_local.swift
  Swift(macosx-x86_64) :: Distributed/Runtime/distributed_actor_local.swift
```


Tests blocked by rdar://78290608
