### PR TITLE
test: attempt to repair the test on Windows

### DIFF
--- a/test/Driver/Dependencies/independent-fine.swift
+++ b/test/Driver/Dependencies/independent-fine.swift
@@ -15,7 +15,9 @@
 // CHECK-SECOND-NOT: Handled
 
 // Don't change the priors mod time.
-// RUN: touch -t 201401240006 %t/*.{swift,swiftdeps,json}
+// RUN: touch -t 201401240006 %t/*.swift
+// RUN: touch -t 201401240006 %t/*.swiftdeps
+// RUN: touch -t 201401240006 %t/*.json
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // RUN: touch -t 201401240007 %t/main.swift


### PR DESCRIPTION
PR #38356 regressed the Windows (2017) CI.  This attempts to remove the bashisms from the test to repair the test on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
