### PR TITLE
Constrain `AsyncThrowingStream.init(unfolding:) where Failure == Error`

### DIFF
--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -138,7 +138,7 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
   
   public init(
     unfolding produce: @escaping () async throws -> Element?
-  ) {
+  ) where Failure == Error {
     self.produce = produce
   }
 }


### PR DESCRIPTION
**Explanation**: This PR constrains `AsyncThrowingStream.init(unfolding:)`'s `Failure` to be `Error` in order to prevent `AsyncThrowingStream`s from throwing errors other than their `Failure` type.
**Scope**: Affects new code using the Swift Concurrency model and `AsyncThrowingStream`.
**Radar/SR Issue**: rdar://80970499 / https://bugs.swift.org/browse/SR-14945
**Risk**: Low.
**Testing**: PR testing and CI on main.
