### PR TITLE
Fix `-latomic` linking condition, include android

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -33,11 +33,10 @@ endif()
 # Frustratingly, in many cases this isn't necessary because the
 # sequence is inlined, but we have some code that's just subtle
 # enough to turn into runtime calls.
-if(SWIFT_HOST_VARIANT STREQUAL "Linux")
-  if(SWIFT_HOST_VARIANT_ARCH MATCHES "armv6|armv7|i686")
-    list(APPEND swift_concurrency_link_libraries
-      atomic)
-  endif()
+if(SWIFT_HOST_VARIANT STREQUAL "linux" OR
+   SWIFT_HOST_VARIANT STREQUAL "android")
+  list(APPEND SWIFT_RUNTIME_CONCURRENCY_SWIFT_LINK_FLAGS
+    -latomic)
 endif()
 
 add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB


### PR DESCRIPTION
#38501 was copy-and-pasting a condition that seems to have been wrong.  I've left the original code in place and just fixed this site.  I've also removed the architecture conditions — I think this is necessary on all arches — and by @buttaface's request I've added Android to the condition.