### PR TITLE
[5.5][CSGen] Always record types of variables introduced by named patterns

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2216,6 +2216,8 @@ namespace {
         // If we have a type to ascribe to the variable, do so now.
         if (oneWayVarType)
           CS.setType(var, oneWayVarType);
+        else
+          CS.setType(var, varType);
 
         return setType(varType);
       }

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -514,3 +514,9 @@ func rdar64157451() {
     if case .foo(let v as DoeNotExist) = e {} // expected-error {{cannot find type 'DoeNotExist' in scope}}
   }
 }
+
+// rdar://80797176 - circular reference diagnosed while reaching for a type of a pattern.
+func rdar80797176 () {
+  for x: Int in [1, 2] where x.bitWidth == 32 { // Ok
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/38511

---

- Explanation:

Fixes circularity error produced for a valid code.

Follow-up for https://github.com/apple/swift/pull/38320

Typed patterns no longer use an intermediary type variable,
which created a problem for references to variables declared
inside of a pattern because their types weren't recorded in
constraint system.

- Scope: Statements with conditions that declare variables and use `where` clauses that reference them e.g. `for` loops.

- Main Branch PR: https://github.com/apple/swift/pull/38511

- Resolves: rdar://80797176

- Risk: Low

- Reviewed By: @hborla  

- Testing: Regression tests added to the suite

Resolves: rdar://80797176

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
