### PR TITLE
[5.5] [IDE] Fix another GenericFunctionType subst crasher

### DIFF
--- a/lib/IDE/ConformingMethodList.cpp
+++ b/lib/IDE/ConformingMethodList.cpp
@@ -129,22 +129,20 @@ void ConformingMethodListCallbacks::getMatchingMethods(
     /// Returns true if \p VD is a instance method whose return type conforms
     /// to the requested protocols.
     bool isMatchingMethod(ValueDecl *VD) {
-      if (!isa<FuncDecl>(VD))
+      auto *FD = dyn_cast<FuncDecl>(VD);
+      if (!FD)
         return false;
-      if (VD->isStatic() || VD->isOperator())
-        return false;
-
-      auto declTy = T->getTypeOfMember(CurModule, VD);
-      if (declTy->is<ErrorType>())
+      if (FD->isStatic() || FD->isOperator())
         return false;
 
-      // Strip '(Self.Type) ->' and parameters.
-      declTy = declTy->castTo<AnyFunctionType>()->getResult();
-      declTy = declTy->castTo<AnyFunctionType>()->getResult();
+      auto resultTy = T->getTypeOfMember(CurModule, FD,
+                                         FD->getResultInterfaceType());
+      if (resultTy->is<ErrorType>())
+        return false;
 
       // The return type conforms to any of the requested protocols.
       for (auto Proto : ExpectedTypes) {
-        if (CurModule->conformsToProtocol(declTy, Proto))
+        if (CurModule->conformsToProtocol(resultTy, Proto))
           return true;
       }
 

--- a/test/IDE/conforming-methods-generic.swift
+++ b/test/IDE/conforming-methods-generic.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-ide-test -conforming-methods -source-filename %s -code-completion-token=CM1 -module-name MyModule -conforming-methods-expected-types '$s8MyModule6TargetPD' | %FileCheck %s -check-prefix=SI
+// RUN: %target-swift-ide-test -conforming-methods -source-filename %s -code-completion-token=CM2 -module-name MyModule -conforming-methods-expected-types '$s8MyModule6TargetPD' | %FileCheck %s -check-prefix=SF
+
+protocol Target {}
+struct Concrete : Target {}
+
+struct S<T> {
+  func returnsAnything<U>() -> U { fatalError() }
+}
+
+extension S where T == Int {
+  func returnsConcrete<U>(_ x: U) -> Concrete { fatalError() }
+}
+
+func test(si: S<Int>, sf: S<Float>) {
+  si.#^CM1^#
+  // SI:      -----BEGIN CONFORMING METHOD LIST-----
+  // SI-NEXT: - TypeName: S<Int>
+  // SI-NEXT: - Members:
+  // SI-NEXT:    - Name: returnsConcrete(_:)
+  // SI-NEXT:      TypeName: Concrete
+  // SI-NEXT: -----END CONFORMING METHOD LIST-----
+
+  sf.#^CM2^#
+  // SF:      -----BEGIN CONFORMING METHOD LIST-----
+  // SF-NEXT: - TypeName: S<Float>
+  // SF-NEXT: - Members: []
+  // SF-NEXT: -----END CONFORMING METHOD LIST-----
+}

--- a/test/IDE/conforming-methods-rdar77259607.swift
+++ b/test/IDE/conforming-methods-rdar77259607.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-ide-test -conforming-methods -source-filename %s -code-completion-token=CC
+
+protocol MyView {}
+
+extension MyView {
+  func foo<Content>() -> Content? {
+    return nil#^CC^#
+  }
+}


### PR DESCRIPTION
*5.5 cherry-pick of the first commit in https://github.com/apple/swift/pull/38503*

---

When matching methods for the conforming types SourceKit request, we were using the method's interface type in a call to `TypeBase::getTypeOfMember`, which could lead to crashes when calling `subst` with a GenericFunctionType. Instead, pass the result type only, as that's all we want anyway.

rdar://77259607
