### PR TITLE
[ASTPrinter] Intorduce 'IntroducerKeyword' name kind

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -48,6 +48,8 @@ enum class PrintNameContext {
   Normal,
   /// Keyword context, where no keywords are escaped.
   Keyword,
+  /// Keyword for introducing a declarations e.g. 'func', 'struct'.
+  IntroducerKeyword,
   /// Type member context, e.g. properties or enum cases.
   TypeMember,
   /// Generic parameter context, where 'Self' is not escaped.
@@ -214,6 +216,17 @@ public:
     callPrintNamePre(PrintNameContext::Keyword);
     *this << name;
     printNamePost(PrintNameContext::Keyword);
+    *this << Suffix;
+  }
+
+  void printIntroducerKeyword(StringRef name,
+                              const PrintOptions &Opts,
+                              StringRef Suffix = "") {
+    if (Opts.SkipIntroducerKeywords)
+      return;
+    callPrintNamePre(PrintNameContext::IntroducerKeyword);
+    *this << name;
+    printNamePost(PrintNameContext::IntroducerKeyword);
     *this << Suffix;
   }
 

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -346,6 +346,10 @@ struct PrintOptions {
   /// Whether to print 'static' or 'class' on static decls.
   bool PrintStaticKeyword = true;
 
+  /// Whether to print 'mutating', 'nonmutating', or '__consuming' keyword on
+  /// specified decls.
+  bool PrintSelfAccessKindKeyword = true;
+
   /// Whether to print 'override' keyword on overridden decls.
   bool PrintOverrideKeyword = true;
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -476,6 +476,7 @@ static bool escapeKeywordInContext(StringRef keyword, PrintNameContext context){
   case PrintNameContext::Attribute:
     return isKeyword;
   case PrintNameContext::Keyword:
+  case PrintNameContext::IntroducerKeyword:
     return false;
 
   case PrintNameContext::ClassDynamicSelf:
@@ -877,7 +878,7 @@ private:
   bool shouldPrintPattern(const Pattern *P);
   void printPatternType(const Pattern *P);
   void printAccessors(const AbstractStorageDecl *ASD);
-  void printMutabilityModifiersIfNeeded(const FuncDecl *FD);
+  void printSelfAccessKindModifiersIfNeeded(const FuncDecl *FD);
   void printMembersOfDecl(Decl * NTD, bool needComma = false,
                           bool openBracket = true, bool closeBracket = true);
   void printMembers(ArrayRef<Decl *> members, bool needComma = false,
@@ -1143,6 +1144,7 @@ void PrintAST::printAttributes(const Decl *D) {
   if (isa<FuncDecl>(D)) {
     Options.ExcludeAttrList.push_back(DAK_Mutating);
     Options.ExcludeAttrList.push_back(DAK_NonMutating);
+    Options.ExcludeAttrList.push_back(DAK_Consuming);
   }
 
   D->getAttrs().print(Printer, Options, D);
@@ -1291,10 +1293,9 @@ void PrintAST::printPattern(const Pattern *pattern) {
     break;
 
   case PatternKind::Binding:
-    if (!Options.SkipIntroducerKeywords)
-      Printer << (cast<BindingPattern>(pattern)->isLet() ? tok::kw_let
-                                                         : tok::kw_var)
-              << " ";
+    Printer.printIntroducerKeyword(
+        cast<BindingPattern>(pattern)->isLet() ? "let" : "var",
+        Options, " ");
     printPattern(cast<BindingPattern>(pattern)->getSubPattern());
   }
 }
@@ -1901,16 +1902,27 @@ void PrintAST::printBodyIfNecessary(const AbstractFunctionDecl *decl) {
   printBraceStmt(decl->getBody(), /*newlineIfEmpty*/!isa<AccessorDecl>(decl));
 }
 
-void PrintAST::printMutabilityModifiersIfNeeded(const FuncDecl *FD) {
+void PrintAST::printSelfAccessKindModifiersIfNeeded(const FuncDecl *FD) {
+  if (!Options.PrintSelfAccessKindKeyword)
+    return;
+
   const auto *AD = dyn_cast<AccessorDecl>(FD);
 
-  if (FD->isMutating()) {
-    if (AD == nullptr || AD->isAssumedNonMutating())
-      if (!Options.excludeAttrKind(DAK_Mutating))
-        Printer.printKeyword("mutating", Options, " ");
-  } else if (AD && AD->isExplicitNonMutating() &&
-             !Options.excludeAttrKind(DAK_Mutating)) {
-    Printer.printKeyword("nonmutating", Options, " ");
+  switch (FD->getSelfAccessKind()) {
+  case SelfAccessKind::Mutating:
+    if ((!AD || AD->isAssumedNonMutating()) &&
+        !Options.excludeAttrKind(DAK_Mutating))
+      Printer.printKeyword("mutating", Options, " ");
+    break;
+  case SelfAccessKind::NonMutating:
+    if (AD && AD->isExplicitNonMutating() &&
+        !Options.excludeAttrKind(DAK_NonMutating))
+      Printer.printKeyword("nonmutating", Options, " ");
+    break;
+  case SelfAccessKind::Consuming:
+    if (!Options.excludeAttrKind(DAK_Consuming))
+      Printer.printKeyword("__consuming", Options, " ");
+    break;
   }
 }
 
@@ -2037,7 +2049,7 @@ void PrintAST::printAccessors(const AbstractStorageDecl *ASD) {
       return true;
     if (!PrintAccessorBody) {
       Printer << " ";
-      printMutabilityModifiersIfNeeded(Accessor);
+      printSelfAccessKindModifiersIfNeeded(Accessor);
 
       Printer.printKeyword(getAccessorLabel(Accessor->getAccessorKind()), Options);
 
@@ -2271,7 +2283,7 @@ static void getModuleEntities(ImportDecl *Import,
 
 void PrintAST::visitImportDecl(ImportDecl *decl) {
   printAttributes(decl);
-  Printer << tok::kw_import << " ";
+  Printer.printIntroducerKeyword("import", Options, " ");
 
   switch (decl->getImportKind()) {
   case ImportKind::Module:
@@ -2391,7 +2403,7 @@ void PrintAST::printSynthesizedExtension(Type ExtendedType,
   if (Options.BracketOptions.shouldOpenExtension(ExtDecl)) {
     printDocumentationComment(ExtDecl);
     printAttributes(ExtDecl);
-    Printer << tok::kw_extension << " ";
+    Printer.printIntroducerKeyword("extension", Options, " ");
 
     printExtendedTypeName(TypeLoc::withoutLoc(ExtendedType));
     printInherited(ExtDecl);
@@ -2429,7 +2441,7 @@ void PrintAST::printExtension(ExtensionDecl *decl) {
   if (Options.BracketOptions.shouldOpenExtension(decl)) {
     printDocumentationComment(decl);
     printAttributes(decl);
-    Printer << "extension ";
+    Printer.printIntroducerKeyword("extension", Options, " ");
     recordDeclLoc(decl, [&]{
       // We cannot extend sugared types.
       Type extendedType = decl->getExtendedType();
@@ -2961,8 +2973,7 @@ void PrintAST::visitTypeAliasDecl(TypeAliasDecl *decl) {
   printDocumentationComment(decl);
   printAttributes(decl);
   printAccess(decl);
-  if (!Options.SkipIntroducerKeywords)
-    Printer << tok::kw_typealias << " ";
+  Printer.printIntroducerKeyword("typealias", Options, " ");
   printContextIfNeeded(decl);
   recordDeclLoc(decl,
     [&]{
@@ -3005,8 +3016,7 @@ void PrintAST::visitGenericTypeParamDecl(GenericTypeParamDecl *decl) {
 void PrintAST::visitAssociatedTypeDecl(AssociatedTypeDecl *decl) {
   printDocumentationComment(decl);
   printAttributes(decl);
-  if (!Options.SkipIntroducerKeywords)
-    Printer << tok::kw_associatedtype << " ";
+  Printer.printIntroducerKeyword("associatedtype", Options, " ");
   recordDeclLoc(decl,
     [&]{
       Printer.printName(decl->getName(), PrintNameContext::TypeMember);
@@ -3035,8 +3045,7 @@ void PrintAST::visitEnumDecl(EnumDecl *decl) {
     printSourceRange(CharSourceRange(Ctx.SourceMgr, decl->getStartLoc(),
                               decl->getBraces().Start.getAdvancedLoc(-1)), Ctx);
   } else {
-    if (!Options.SkipIntroducerKeywords)
-      Printer << tok::kw_enum << " ";
+    Printer.printIntroducerKeyword("enum", Options, " ");
     printContextIfNeeded(decl);
     recordDeclLoc(decl,
       [&]{
@@ -3063,8 +3072,7 @@ void PrintAST::visitStructDecl(StructDecl *decl) {
     printSourceRange(CharSourceRange(Ctx.SourceMgr, decl->getStartLoc(),
                               decl->getBraces().Start.getAdvancedLoc(-1)), Ctx);
   } else {
-    if (!Options.SkipIntroducerKeywords)
-      Printer << tok::kw_struct << " ";
+    Printer.printIntroducerKeyword("struct", Options, " ");
     printContextIfNeeded(decl);
     recordDeclLoc(decl,
       [&]{
@@ -3091,13 +3099,8 @@ void PrintAST::visitClassDecl(ClassDecl *decl) {
     printSourceRange(CharSourceRange(Ctx.SourceMgr, decl->getStartLoc(),
                               decl->getBraces().Start.getAdvancedLoc(-1)), Ctx);
   } else {
-    if (!Options.SkipIntroducerKeywords) {
-      if (decl->isExplicitActor()) {
-        Printer.printKeyword("actor", Options, " ");
-      } else {
-        Printer << tok::kw_class << " ";
-      }
-    }
+    Printer.printIntroducerKeyword(
+        decl->isExplicitActor() ? "actor" : "class", Options, " ");
     printContextIfNeeded(decl);
     recordDeclLoc(decl,
       [&]{
@@ -3126,8 +3129,7 @@ void PrintAST::visitProtocolDecl(ProtocolDecl *decl) {
     printSourceRange(CharSourceRange(Ctx.SourceMgr, decl->getStartLoc(),
                               decl->getBraces().Start.getAdvancedLoc(-1)), Ctx);
   } else {
-    if (!Options.SkipIntroducerKeywords)
-      Printer << tok::kw_protocol << " ";
+    Printer.printIntroducerKeyword("protocol", Options, " ");
     printContextIfNeeded(decl);
     recordDeclLoc(decl,
       [&]{
@@ -3207,20 +3209,12 @@ void PrintAST::visitVarDecl(VarDecl *decl) {
     Printer << "@_hasStorage ";
   printAttributes(decl);
   printAccess(decl);
-  if (!Options.SkipIntroducerKeywords) {
-    if (decl->isStatic() && Options.PrintStaticKeyword)
-      printStaticKeyword(decl->getCorrectStaticSpelling());
-    if (decl->getKind() == DeclKind::Var
-        || Options.PrintParameterSpecifiers) {
-      // Map all non-let specifiers to 'var'.  This is not correct, but
-      // SourceKit relies on this for info about parameter decls.
-      if (decl->isLet())
-        Printer << tok::kw_let;
-      else
-        Printer << tok::kw_var;
-
-      Printer << " ";
-    }
+  if (decl->isStatic() && Options.PrintStaticKeyword)
+    printStaticKeyword(decl->getCorrectStaticSpelling());
+  if (decl->getKind() == DeclKind::Var || Options.PrintParameterSpecifiers) {
+    // Map all non-let specifiers to 'var'.  This is not correct, but
+    // SourceKit relies on this for info about parameter decls.
+    Printer.printIntroducerKeyword(decl->isLet() ? "let" : "var", Options, " ");
   }
   printContextIfNeeded(decl);
   recordDeclLoc(decl,
@@ -3431,10 +3425,8 @@ void PrintAST::visitAccessorDecl(AccessorDecl *decl) {
   printDocumentationComment(decl);
   printAttributes(decl);
   // Explicitly print 'mutating' and 'nonmutating' if needed.
-  printMutabilityModifiersIfNeeded(decl);
-  if (decl->isConsuming()) {
-    Printer.printKeyword("__consuming", Options, " ");
-  }
+  printSelfAccessKindModifiersIfNeeded(decl);
+
   switch (auto kind = decl->getAccessorKind()) {
   case AccessorKind::Get:
   case AccessorKind::Address:
@@ -3492,16 +3484,12 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
                                                SourceRange(StartLoc, EndLoc));
     printSourceRange(Range, Ctx);
   } else {
-    if (!Options.SkipIntroducerKeywords) {
-      if (decl->isStatic() && Options.PrintStaticKeyword)
-        printStaticKeyword(decl->getCorrectStaticSpelling());
+    if (decl->isStatic() && Options.PrintStaticKeyword)
+      printStaticKeyword(decl->getCorrectStaticSpelling());
 
-      printMutabilityModifiersIfNeeded(decl);
-      if (decl->isConsuming() && !decl->getAttrs().hasAttribute<ConsumingAttr>()) {
-        Printer.printKeyword("__consuming", Options, " ");
-      }
-      Printer << tok::kw_func << " ";
-    }
+    printSelfAccessKindModifiersIfNeeded(decl);
+    Printer.printIntroducerKeyword("func", Options, " ");
+
     printContextIfNeeded(decl);
     recordDeclLoc(decl,
       [&]{ // Name
@@ -3659,7 +3647,7 @@ void PrintAST::visitEnumCaseDecl(EnumCaseDecl *decl) {
     printDocumentationComment(elems[0]);
     printAttributes(elems[0]);
   }
-  Printer << tok::kw_case << " ";
+  Printer.printIntroducerKeyword("case", Options, " ");
 
   llvm::interleave(elems.begin(), elems.end(),
     [&](EnumElementDecl *elt) {
@@ -3673,7 +3661,7 @@ void PrintAST::visitEnumElementDecl(EnumElementDecl *decl) {
   // In cases where there is no parent EnumCaseDecl (such as imported or
   // deserialized elements), print the element independently.
   printAttributes(decl);
-  Printer << tok::kw_case << " ";
+  Printer.printIntroducerKeyword("case", Options, " ");
   printEnumElement(decl);
 }
 
@@ -3681,8 +3669,7 @@ void PrintAST::visitSubscriptDecl(SubscriptDecl *decl) {
   printDocumentationComment(decl);
   printAttributes(decl);
   printAccess(decl);
-  if (!Options.SkipIntroducerKeywords && decl->isStatic() &&
-      Options.PrintStaticKeyword)
+  if (decl->isStatic() && Options.PrintStaticKeyword)
     printStaticKeyword(decl->getCorrectStaticSpelling());
   printContextIfNeeded(decl);
   recordDeclLoc(decl, [&]{
@@ -3782,7 +3769,7 @@ void PrintAST::visitDestructorDecl(DestructorDecl *decl) {
 
 void PrintAST::visitInfixOperatorDecl(InfixOperatorDecl *decl) {
   Printer.printKeyword("infix", Options, " ");
-  Printer << tok::kw_operator << " ";
+  Printer.printIntroducerKeyword("operator", Options, " ");
   recordDeclLoc(decl,
     [&]{
       Printer.printName(decl->getName());
@@ -3801,7 +3788,7 @@ void PrintAST::visitInfixOperatorDecl(InfixOperatorDecl *decl) {
 }
 
 void PrintAST::visitPrecedenceGroupDecl(PrecedenceGroupDecl *decl) {
-  Printer << tok::kw_precedencegroup << " ";
+  Printer.printIntroducerKeyword("precedencegroup", Options, " ");
   recordDeclLoc(decl,
     [&]{
       Printer.printName(decl->getName());
@@ -3861,7 +3848,7 @@ void PrintAST::visitPrecedenceGroupDecl(PrecedenceGroupDecl *decl) {
 
 void PrintAST::visitPrefixOperatorDecl(PrefixOperatorDecl *decl) {
   Printer.printKeyword("prefix", Options, " ");
-  Printer << tok::kw_operator << " ";
+  Printer.printIntroducerKeyword("operator", Options, " ");
   recordDeclLoc(decl,
     [&]{
       Printer.printName(decl->getName());
@@ -3879,7 +3866,7 @@ void PrintAST::visitPrefixOperatorDecl(PrefixOperatorDecl *decl) {
 
 void PrintAST::visitPostfixOperatorDecl(PostfixOperatorDecl *decl) {
   Printer.printKeyword("postfix", Options, " ");
-  Printer << tok::kw_operator << " ";
+  Printer.printIntroducerKeyword("operator", Options, " ");
   recordDeclLoc(decl,
     [&]{
       Printer.printName(decl->getName());

--- a/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
+++ b/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
@@ -96,6 +96,7 @@ void
 DeclarationFragmentPrinter::printNamePre(PrintNameContext Context) {
   switch (Context) {
   case PrintNameContext::Keyword:
+  case PrintNameContext::IntroducerKeyword:
     openFragment(FragmentKind::Keyword);
     break;
   case PrintNameContext::GenericParameter:

--- a/test/SourceKit/CursorInfo/cursor_relatedname.swift
+++ b/test/SourceKit/CursorInfo/cursor_relatedname.swift
@@ -1,0 +1,32 @@
+struct S {
+    mutating func foo(x: Int) {}
+    __consuming func foo(x: String) {}
+}
+
+// RUN: %sourcekitd-test -req=cursor -pos=2:19 %s -- %s -module-name MyMod | %FileCheck -check-prefix=CHECK1 %s
+
+// CHECK1: source.lang.swift.decl.function.method.instance (2:19-2:30)
+// CHECK1: foo(x:)
+// CHECK1: s:5MyMod1SV3foo1xySi_tF
+// CHECK1: source.lang.swift
+// CHECK1: (inout S) -> (Int) -> ()
+// CHECK1: $s1xySi_tcD
+// CHECK1: <Declaration>mutating func foo(x: <Type usr="s:Si">Int</Type>)</Declaration>
+// CHECK1: <decl.function.method.instance><syntaxtype.keyword>mutating</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr="s:Si">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>
+// CHECK1: RELATED BEGIN
+// CHECK1: <RelatedName usr="s:5MyMod1SV3foo1xySS_tF">foo(x: String)</RelatedName>
+// CHECK1: RELATED END
+
+// RUN: %sourcekitd-test -req=cursor -pos=3:22 %s -- %s -module-name MyMod | %FileCheck -check-prefix=CHECK2 %s
+ 
+// CHECK2: source.lang.swift.decl.function.method.instance (3:22-3:36)
+// CHECK2: foo(x:)
+// CHECK2: s:5MyMod1SV3foo1xySS_tF
+// CHECK2: source.lang.swift
+// CHECK2: (__owned S) -> (String) -> ()
+// CHECK2: $s1xySS_tcD
+// CHECK2: <Declaration>func foo(x: <Type usr="s:SS">String</Type>)</Declaration>
+// CHECK2: <decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr="s:SS">String</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>
+// CHECK2: RELATED BEGIN
+// CHECK2: <RelatedName usr="s:5MyMod1SV3foo1xySi_tF">foo(x: Int)</RelatedName>
+// CHECK2: RELATED END

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -6481,7 +6481,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.extension.class,
     key.offset: 5964,
     key.length: 61,
-    key.fully_annotated_decl: "<decl.extension.class>extension <decl.name><ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.name></decl.extension.class>",
+    key.fully_annotated_decl: "<decl.extension.class><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.name></decl.extension.class>",
     key.extends: {
       key.kind: source.lang.swift.ref.class,
       key.name: "FooClassBase",
@@ -6502,7 +6502,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.extension.class,
     key.offset: 6026,
     key.length: 97,
-    key.fully_annotated_decl: "<decl.extension.class>extension <decl.name><ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.name></decl.extension.class>",
+    key.fully_annotated_decl: "<decl.extension.class><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.name></decl.extension.class>",
     key.extends: {
       key.kind: source.lang.swift.ref.class,
       key.name: "FooClassBase",
@@ -6531,7 +6531,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.extension.class,
     key.offset: 6124,
     key.length: 61,
-    key.fully_annotated_decl: "<decl.extension.class>extension <decl.name><ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.name></decl.extension.class>",
+    key.fully_annotated_decl: "<decl.extension.class><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.name></decl.extension.class>",
     key.extends: {
       key.kind: source.lang.swift.ref.class,
       key.name: "FooClassBase",

--- a/test/SourceKit/DocSupport/doc_source_file.swift.response
+++ b/test/SourceKit/DocSupport/doc_source_file.swift.response
@@ -1960,7 +1960,7 @@
     key.kind: source.lang.swift.decl.extension.class,
     key.offset: 649,
     key.length: 112,
-    key.fully_annotated_decl: "<decl.extension.class>extension <decl.name><ref.class usr=\"s:4main2CCC\">CC</ref.class></decl.name> : <ref.protocol usr=\"s:4main4ProtP\">Prot</ref.protocol></decl.extension.class>",
+    key.fully_annotated_decl: "<decl.extension.class><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.class usr=\"s:4main2CCC\">CC</ref.class></decl.name> : <ref.protocol usr=\"s:4main4ProtP\">Prot</ref.protocol></decl.extension.class>",
     key.conforms: [
       {
         key.kind: source.lang.swift.ref.protocol,

--- a/test/SourceKit/DocSupport/doc_swift_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_swift_module.swift.response
@@ -2028,7 +2028,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.doc.full_as_xml: "<Other><Name></Name><Declaration>@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)\nextension C1</Declaration><CommentParts><Abstract><Para>some comments</Para></Abstract></CommentParts></Other>",
     key.offset: 473,
     key.length: 37,
-    key.fully_annotated_decl: "<decl.extension.class>extension <decl.name><ref.class usr=\"s:4cake2C1C\">C1</ref.class></decl.name></decl.extension.class>",
+    key.fully_annotated_decl: "<decl.extension.class><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.class usr=\"s:4cake2C1C\">C1</ref.class></decl.name></decl.extension.class>",
     key.extends: {
       key.kind: source.lang.swift.ref.class,
       key.name: "C1",
@@ -2071,7 +2071,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.kind: source.lang.swift.decl.extension.class,
     key.offset: 512,
     key.length: 105,
-    key.fully_annotated_decl: "<decl.extension.class>extension <decl.name><ref.class usr=\"s:4cake2C1C\">C1</ref.class></decl.name> : <ref.protocol usr=\"s:4cake2P4P\">P4</ref.protocol></decl.extension.class>",
+    key.fully_annotated_decl: "<decl.extension.class><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.class usr=\"s:4cake2C1C\">C1</ref.class></decl.name> : <ref.protocol usr=\"s:4cake2P4P\">P4</ref.protocol></decl.extension.class>",
     key.conforms: [
       {
         key.kind: source.lang.swift.ref.protocol,
@@ -2311,7 +2311,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.kind: source.lang.swift.decl.extension.protocol,
     key.offset: 1075,
     key.length: 54,
-    key.fully_annotated_decl: "<decl.extension.protocol>extension <decl.name><ref.protocol usr=\"s:4cake1PP\">P</ref.protocol></decl.name></decl.extension.protocol>",
+    key.fully_annotated_decl: "<decl.extension.protocol><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.protocol usr=\"s:4cake1PP\">P</ref.protocol></decl.name></decl.extension.protocol>",
     key.extends: {
       key.kind: source.lang.swift.ref.protocol,
       key.name: "P",
@@ -2415,7 +2415,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.kind: source.lang.swift.decl.extension.protocol,
     key.offset: 1314,
     key.length: 53,
-    key.fully_annotated_decl: "<decl.extension.protocol>extension <decl.name><ref.protocol usr=\"s:4cake2P6P\">P6</ref.protocol></decl.name></decl.extension.protocol>",
+    key.fully_annotated_decl: "<decl.extension.protocol><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.protocol usr=\"s:4cake2P6P\">P6</ref.protocol></decl.name></decl.extension.protocol>",
     key.extends: {
       key.kind: source.lang.swift.ref.protocol,
       key.name: "P6",
@@ -2478,7 +2478,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.kind: source.lang.swift.decl.extension.protocol,
     key.offset: 1473,
     key.length: 79,
-    key.fully_annotated_decl: "<decl.extension.protocol>extension <decl.name><ref.protocol usr=\"s:4cake4ProtP\">Prot</ref.protocol></decl.name></decl.extension.protocol>",
+    key.fully_annotated_decl: "<decl.extension.protocol><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.protocol usr=\"s:4cake4ProtP\">Prot</ref.protocol></decl.name></decl.extension.protocol>",
     key.extends: {
       key.kind: source.lang.swift.ref.protocol,
       key.name: "Prot",
@@ -2522,7 +2522,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
     ],
     key.offset: 1554,
     key.length: 63,
-    key.fully_annotated_decl: "<decl.extension.protocol>extension <decl.name><ref.protocol usr=\"s:4cake4ProtP\">Prot</ref.protocol></decl.name> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:4cake4ProtPAASi7ElementRtzrlE4Selfxmfp\">Self</ref.generic_type_param>.<ref.associatedtype usr=\"s:4cake4ProtP7ElementQa\">Element</ref.associatedtype> == <ref.struct usr=\"s:Si\">Int</ref.struct></decl.generic_type_requirement></decl.extension.protocol>",
+    key.fully_annotated_decl: "<decl.extension.protocol><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.protocol usr=\"s:4cake4ProtP\">Prot</ref.protocol></decl.name> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:4cake4ProtPAASi7ElementRtzrlE4Selfxmfp\">Self</ref.generic_type_param>.<ref.associatedtype usr=\"s:4cake4ProtP7ElementQa\">Element</ref.associatedtype> == <ref.struct usr=\"s:Si\">Int</ref.struct></decl.generic_type_requirement></decl.extension.protocol>",
     key.extends: {
       key.kind: source.lang.swift.ref.protocol,
       key.name: "Prot",

--- a/test/SourceKit/DocSupport/doc_swift_module1.swift.response
+++ b/test/SourceKit/DocSupport/doc_swift_module1.swift.response
@@ -780,7 +780,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
     key.kind: source.lang.swift.decl.extension.protocol,
     key.offset: 186,
     key.length: 35,
-    key.fully_annotated_decl: "<decl.extension.protocol>extension <decl.name><ref.protocol usr=\"s:5cake19InitProtoP\">InitProto</ref.protocol></decl.name></decl.extension.protocol>",
+    key.fully_annotated_decl: "<decl.extension.protocol><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.protocol usr=\"s:5cake19InitProtoP\">InitProto</ref.protocol></decl.name></decl.extension.protocol>",
     key.extends: {
       key.kind: source.lang.swift.ref.protocol,
       key.name: "InitProto",
@@ -959,7 +959,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
     key.kind: source.lang.swift.decl.extension.protocol,
     key.offset: 531,
     key.length: 118,
-    key.fully_annotated_decl: "<decl.extension.protocol>extension <decl.name><ref.protocol usr=\"s:5cake12P2P\">P2</ref.protocol></decl.name></decl.extension.protocol>",
+    key.fully_annotated_decl: "<decl.extension.protocol><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.protocol usr=\"s:5cake12P2P\">P2</ref.protocol></decl.name></decl.extension.protocol>",
     key.extends: {
       key.kind: source.lang.swift.ref.protocol,
       key.name: "P2",
@@ -1038,7 +1038,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
     ],
     key.offset: 651,
     key.length: 64,
-    key.fully_annotated_decl: "<decl.extension.protocol>extension <decl.name><ref.protocol usr=\"s:5cake12P2P\">P2</ref.protocol></decl.name> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:5cake12P2PA2A2P3RzrlE4Selfxmfp\">Self</ref.generic_type_param> : <ref.protocol usr=\"s:5cake12P3P\">P3</ref.protocol></decl.generic_type_requirement></decl.extension.protocol>",
+    key.fully_annotated_decl: "<decl.extension.protocol><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.protocol usr=\"s:5cake12P2P\">P2</ref.protocol></decl.name> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:5cake12P2PA2A2P3RzrlE4Selfxmfp\">Self</ref.generic_type_param> : <ref.protocol usr=\"s:5cake12P3P\">P3</ref.protocol></decl.generic_type_requirement></decl.extension.protocol>",
     key.extends: {
       key.kind: source.lang.swift.ref.protocol,
       key.name: "P2",
@@ -1091,7 +1091,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
     ],
     key.offset: 757,
     key.length: 45,
-    key.fully_annotated_decl: "<decl.extension.struct>extension <decl.name><ref.struct usr=\"s:SD\">Dictionary</ref.struct>.<ref.struct usr=\"s:SD4KeysV\">Keys</ref.struct></decl.name></decl.extension.struct>",
+    key.fully_annotated_decl: "<decl.extension.struct><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.struct usr=\"s:SD\">Dictionary</ref.struct>.<ref.struct usr=\"s:SD4KeysV\">Keys</ref.struct></decl.name></decl.extension.struct>",
     key.extends: {
       key.kind: source.lang.swift.ref.struct,
       key.name: "Keys",
@@ -1120,7 +1120,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
     ],
     key.offset: 804,
     key.length: 66,
-    key.fully_annotated_decl: "<decl.extension.struct>extension <decl.name><ref.struct usr=\"s:SD\">Dictionary</ref.struct>.<ref.struct usr=\"s:SD4KeysV\">Keys</ref.struct></decl.name> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:SD4KeysV5cake1AC2P1RzrlE3Keyxmfp\">Key</ref.generic_type_param> : <ref.protocol usr=\"s:5cake12P1P\">P1</ref.protocol></decl.generic_type_requirement></decl.extension.struct>",
+    key.fully_annotated_decl: "<decl.extension.struct><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.struct usr=\"s:SD\">Dictionary</ref.struct>.<ref.struct usr=\"s:SD4KeysV\">Keys</ref.struct></decl.name> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:SD4KeysV5cake1AC2P1RzrlE3Keyxmfp\">Key</ref.generic_type_param> : <ref.protocol usr=\"s:5cake12P1P\">P1</ref.protocol></decl.generic_type_requirement></decl.extension.struct>",
     key.extends: {
       key.kind: source.lang.swift.ref.struct,
       key.name: "Keys",

--- a/test/SourceKit/DocSupport/doc_swift_module_class_extension.swift.response
+++ b/test/SourceKit/DocSupport/doc_swift_module_class_extension.swift.response
@@ -449,7 +449,7 @@ extension P8 where Self.T : module_with_class_extension.E {
     ],
     key.offset: 62,
     key.length: 48,
-    key.fully_annotated_decl: "<decl.extension.class>extension <decl.name><ref.class usr=\"s:27module_with_class_extension1CC\">C</ref.class></decl.name> : <ref.protocol usr=\"s:27module_with_class_extension2P8P\">P8</ref.protocol></decl.extension.class>",
+    key.fully_annotated_decl: "<decl.extension.class><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.class usr=\"s:27module_with_class_extension1CC\">C</ref.class></decl.name> : <ref.protocol usr=\"s:27module_with_class_extension2P8P\">P8</ref.protocol></decl.extension.class>",
     key.conforms: [
       {
         key.kind: source.lang.swift.ref.protocol,
@@ -472,7 +472,7 @@ extension P8 where Self.T : module_with_class_extension.E {
     ],
     key.offset: 112,
     key.length: 87,
-    key.fully_annotated_decl: "<decl.extension.class>extension <decl.name><ref.class usr=\"s:27module_with_class_extension1CC\">C</ref.class></decl.name> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:27module_with_class_extension1CCA2A1DCRbzlE1Txmfp\">T</ref.generic_type_param> : <ref.class usr=\"s:27module_with_class_extension1DC\">D</ref.class></decl.generic_type_requirement></decl.extension.class>",
+    key.fully_annotated_decl: "<decl.extension.class><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.class usr=\"s:27module_with_class_extension1CC\">C</ref.class></decl.name> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:27module_with_class_extension1CCA2A1DCRbzlE1Txmfp\">T</ref.generic_type_param> : <ref.class usr=\"s:27module_with_class_extension1DC\">D</ref.class></decl.generic_type_requirement></decl.extension.class>",
     key.extends: {
       key.kind: source.lang.swift.ref.class,
       key.name: "C",
@@ -584,7 +584,7 @@ extension P8 where Self.T : module_with_class_extension.E {
     ],
     key.offset: 344,
     key.length: 48,
-    key.fully_annotated_decl: "<decl.extension.class>extension <decl.name><ref.class usr=\"s:27module_with_class_extension1FC\">F</ref.class></decl.name> : <ref.protocol usr=\"s:27module_with_class_extension2P8P\">P8</ref.protocol></decl.extension.class>",
+    key.fully_annotated_decl: "<decl.extension.class><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.class usr=\"s:27module_with_class_extension1FC\">F</ref.class></decl.name> : <ref.protocol usr=\"s:27module_with_class_extension2P8P\">P8</ref.protocol></decl.extension.class>",
     key.conforms: [
       {
         key.kind: source.lang.swift.ref.protocol,
@@ -625,7 +625,7 @@ extension P8 where Self.T : module_with_class_extension.E {
     ],
     key.offset: 433,
     key.length: 77,
-    key.fully_annotated_decl: "<decl.extension.protocol>extension <decl.name><ref.protocol usr=\"s:27module_with_class_extension2P8P\">P8</ref.protocol></decl.name> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:27module_with_class_extension2P8PA2A1DC1TRczrlE4Selfxmfp\">Self</ref.generic_type_param>.<ref.associatedtype usr=\"s:27module_with_class_extension2P8P1TQa\">T</ref.associatedtype> : <ref.class usr=\"s:27module_with_class_extension1DC\">D</ref.class></decl.generic_type_requirement></decl.extension.protocol>",
+    key.fully_annotated_decl: "<decl.extension.protocol><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.protocol usr=\"s:27module_with_class_extension2P8P\">P8</ref.protocol></decl.name> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:27module_with_class_extension2P8PA2A1DC1TRczrlE4Selfxmfp\">Self</ref.generic_type_param>.<ref.associatedtype usr=\"s:27module_with_class_extension2P8P1TQa\">T</ref.associatedtype> : <ref.class usr=\"s:27module_with_class_extension1DC\">D</ref.class></decl.generic_type_requirement></decl.extension.protocol>",
     key.extends: {
       key.kind: source.lang.swift.ref.protocol,
       key.name: "P8",
@@ -651,7 +651,7 @@ extension P8 where Self.T : module_with_class_extension.E {
     ],
     key.offset: 512,
     key.length: 77,
-    key.fully_annotated_decl: "<decl.extension.protocol>extension <decl.name><ref.protocol usr=\"s:27module_with_class_extension2P8P\">P8</ref.protocol></decl.name> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:27module_with_class_extension2P8PA2A1EC1TRczrlE4Selfxmfp\">Self</ref.generic_type_param>.<ref.associatedtype usr=\"s:27module_with_class_extension2P8P1TQa\">T</ref.associatedtype> : <ref.class usr=\"s:27module_with_class_extension1EC\">E</ref.class></decl.generic_type_requirement></decl.extension.protocol>",
+    key.fully_annotated_decl: "<decl.extension.protocol><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.protocol usr=\"s:27module_with_class_extension2P8P\">P8</ref.protocol></decl.name> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:27module_with_class_extension2P8PA2A1EC1TRczrlE4Selfxmfp\">Self</ref.generic_type_param>.<ref.associatedtype usr=\"s:27module_with_class_extension2P8P1TQa\">T</ref.associatedtype> : <ref.class usr=\"s:27module_with_class_extension1EC\">E</ref.class></decl.generic_type_requirement></decl.extension.protocol>",
     key.extends: {
       key.kind: source.lang.swift.ref.protocol,
       key.name: "P8",

--- a/test/SourceKit/DocSupport/doc_system_module_underscored.swift.response
+++ b/test/SourceKit/DocSupport/doc_system_module_underscored.swift.response
@@ -1057,7 +1057,7 @@ protocol Other1 {
     ],
     key.offset: 209,
     key.length: 185,
-    key.fully_annotated_decl: "<decl.extension.struct>extension <decl.name><ref.struct usr=\"s:16UnderscoredProto1AV\">A</ref.struct></decl.name> : <ref.protocol usr=\"s:16UnderscoredProto01_A6Proto2P\">_UnderscoredProto2</ref.protocol> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:16UnderscoredProto1AVAASSRszlE1Txmfp\">T</ref.generic_type_param> == <ref.struct usr=\"s:SS\">String</ref.struct></decl.generic_type_requirement></decl.extension.struct>",
+    key.fully_annotated_decl: "<decl.extension.struct><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.struct usr=\"s:16UnderscoredProto1AV\">A</ref.struct></decl.name> : <ref.protocol usr=\"s:16UnderscoredProto01_A6Proto2P\">_UnderscoredProto2</ref.protocol> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:16UnderscoredProto1AVAASSRszlE1Txmfp\">T</ref.generic_type_param> == <ref.struct usr=\"s:SS\">String</ref.struct></decl.generic_type_requirement></decl.extension.struct>",
     key.conforms: [
       {
         key.kind: source.lang.swift.ref.protocol,
@@ -1527,7 +1527,7 @@ protocol Other1 {
     ],
     key.offset: 1393,
     key.length: 59,
-    key.fully_annotated_decl: "<decl.extension.struct>extension <decl.name><ref.struct usr=\"s:16UnderscoredProto1DV\">D</ref.struct></decl.name> : <ref.protocol usr=\"s:16UnderscoredProto05_SomeB0P\">_SomeProto</ref.protocol> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:16UnderscoredProto1DVAASQRzrlE1Txmfp\">T</ref.generic_type_param> : <ref.protocol usr=\"s:SQ\">Equatable</ref.protocol></decl.generic_type_requirement></decl.extension.struct>",
+    key.fully_annotated_decl: "<decl.extension.struct><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.struct usr=\"s:16UnderscoredProto1DV\">D</ref.struct></decl.name> : <ref.protocol usr=\"s:16UnderscoredProto05_SomeB0P\">_SomeProto</ref.protocol> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:16UnderscoredProto1DVAASQRzrlE1Txmfp\">T</ref.generic_type_param> : <ref.protocol usr=\"s:SQ\">Equatable</ref.protocol></decl.generic_type_requirement></decl.extension.struct>",
     key.conforms: [
       {
         key.kind: source.lang.swift.ref.protocol,

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -352,6 +352,7 @@ private:
         return ExternalParamNameTag;
       return "tuple.element.argument_label";
     case PrintNameContext::Keyword:
+    case PrintNameContext::IntroducerKeyword:
       return SyntaxKeywordTag;
     case PrintNameContext::GenericParameter:
       return GenericParamNameTag;
@@ -1058,6 +1059,8 @@ fillSymbolInfo(CursorSymbolInfo &Symbol, const DeclInfo &DInfo,
       // differentiate them.
       PrintOptions PO;
       PO.SkipAttributes = true;
+      PO.PrintStaticKeyword = false;
+      PO.PrintSelfAccessKindKeyword = false;
       PO.SkipIntroducerKeywords = true;
       PO.ArgAndParamPrinting =
           PrintOptions::ArgAndParamPrintingMode::ArgumentOnly;


### PR DESCRIPTION
For more fine grained annotations. For now, it's handled as the same as `Keyword` name kind.

Fix an issue where `extension` wasn't marked as "keyword".

Also, move `static` priting out of `SkipIntroducerKeywords` guard because 'static' is not an declaration introducer.

(Preparation for #38453)