### PR TITLE
[5.5] Link the concurrency runtime against libatomic on Linux and Android

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -29,6 +29,16 @@ if(SWIFT_CONCURRENCY_USES_DISPATCH)
   endif()
 endif()
 
+# Linux requires us to link an atomic library to use atomics.
+# Frustratingly, in many cases this isn't necessary because the
+# sequence is inlined, but we have some code that's just subtle
+# enough to turn into runtime calls.
+if(SWIFT_HOST_VARIANT STREQUAL "Linux")
+  if(SWIFT_HOST_VARIANT_ARCH MATCHES "armv6|armv7|i686")
+    list(APPEND swift_concurrency_link_libraries
+      atomic)
+  endif()
+endif()
 
 add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   ../CompatibilityOverride/CompatibilityOverride.cpp

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -33,11 +33,10 @@ endif()
 # Frustratingly, in many cases this isn't necessary because the
 # sequence is inlined, but we have some code that's just subtle
 # enough to turn into runtime calls.
-if(SWIFT_HOST_VARIANT STREQUAL "Linux")
-  if(SWIFT_HOST_VARIANT_ARCH MATCHES "armv6|armv7|i686")
-    list(APPEND swift_concurrency_link_libraries
-      atomic)
-  endif()
+if(SWIFT_HOST_VARIANT STREQUAL "linux" OR
+   SWIFT_HOST_VARIANT STREQUAL "android")
+  list(APPEND SWIFT_RUNTIME_CONCURRENCY_SWIFT_LINK_FLAGS
+    -latomic)
 endif()
 
 add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB


### PR DESCRIPTION
5.5 version of https://github.com/apple/swift/pull/38501 and https://github.com/apple/swift/pull/38508.  Hopefully unblocks daily toolchains.

Fixes rdar://80799993.