### PR TITLE
SIL: Private setters need at least hidden visibility for key paths in more cases.

### DIFF
--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -399,12 +399,12 @@ SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
   auto effectiveAccess = d->getEffectiveAccess();
   
   // Private setter implementations for an internal storage declaration should
-  // be internal as well, so that a dynamically-writable
-  // keypath can be formed from other files.
+  // be at least internal as well, so that a dynamically-writable
+  // keypath can be formed from other files in the same module.
   if (auto accessor = dyn_cast<AccessorDecl>(d)) {
     if (accessor->isSetter()
-       && accessor->getStorage()->getEffectiveAccess() == AccessLevel::Internal)
-      effectiveAccess = AccessLevel::Internal;
+       && accessor->getStorage()->getEffectiveAccess() >= AccessLevel::Internal)
+      effectiveAccess = std::max(effectiveAccess, AccessLevel::Internal);
   }
 
   switch (effectiveAccess) {

--- a/test/SILGen/accessors_testing.swift
+++ b/test/SILGen/accessors_testing.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name accessors %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library -enable-testing -module-name accessors %s | %FileCheck %s
+
+// rdar://78523318: Ensure that private(set) accessors for internal or more
+// visible properties have hidden linkage, because other code inside the module
+// needs to reference the setter to form a key path.
+
+public struct Foo {
+    // CHECK-LABEL: sil hidden [ossa] @$s9accessors3FooV6internSivs
+    private(set) internal var intern: Int {
+        get { return 0 }
+        set {}
+    }
+    // CHECK-LABEL: sil hidden [ossa] @$s9accessors3FooV3pubSivs
+    private(set) public var pub: Int {
+        get { return 0 }
+        set {}
+    }
+
+    public mutating func exercise() {
+        _ = intern
+        _ = pub
+        intern = 0
+        pub = 0
+    }
+}
+


### PR DESCRIPTION
My original fix only addressed the issue for when the property was exactly internal, so
we would still run into problems with keypaths and `private(set)` when `-enable-testing`
is on, or when referring to `public` properties with private setters from the same module.
This generalizes the rule, so that the setter entry point for any property with
at least internal visibility also has at least internal visibility, even if the setter
is semantically less visible. Fixes rdar://78523318.