### PR TITLE
[5.5] SIL: Private setters need at least hidden visibility for key paths in more cases.

### DIFF
--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -367,12 +367,12 @@ SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
   auto effectiveAccess = d->getEffectiveAccess();
   
   // Private setter implementations for an internal storage declaration should
-  // be internal as well, so that a dynamically-writable
-  // keypath can be formed from other files.
+  // be at least internal as well, so that a dynamically-writable
+  // keypath can be formed from other files in the same module.
   if (auto accessor = dyn_cast<AccessorDecl>(d)) {
     if (accessor->isSetter()
-       && accessor->getStorage()->getEffectiveAccess() == AccessLevel::Internal)
-      effectiveAccess = AccessLevel::Internal;
+       && accessor->getStorage()->getEffectiveAccess() >= AccessLevel::Internal)
+      effectiveAccess = std::max(effectiveAccess, AccessLevel::Internal);
   }
 
   switch (effectiveAccess) {

--- a/test/SILGen/accessors_testing.swift
+++ b/test/SILGen/accessors_testing.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name accessors %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library -enable-testing -module-name accessors %s | %FileCheck %s
+
+// rdar://78523318: Ensure that private(set) accessors for internal or more
+// visible properties have hidden linkage, because other code inside the module
+// needs to reference the setter to form a key path.
+
+public struct Foo {
+    // CHECK-LABEL: sil hidden [ossa] @$s9accessors3FooV6internSivs
+    private(set) internal var intern: Int {
+        get { return 0 }
+        set {}
+    }
+    // CHECK-LABEL: sil hidden [ossa] @$s9accessors3FooV3pubSivs
+    private(set) public var pub: Int {
+        get { return 0 }
+        set {}
+    }
+
+    public mutating func exercise() {
+        _ = intern
+        _ = pub
+        intern = 0
+        pub = 0
+    }
+}
+


### PR DESCRIPTION
Explanation: Forming a key path to a public (or internal with `-enable-testing`) property with a `private(set)` setter from another file in the same module would hit linker errors, because the private setter's symbol was not exposed to the key path literals from other files. This was previously fixed for declarations with effective internal visibility, but would break when testing was enabled, or when the getter was public.

Issue: rdar://78523318

Testing: Test case from Radar; Swift CI

Reviewed by: @slavapestov 

Risk: Low, generalizes an existing fix to cover more cases

Scope: Improves an existing bug fix. Some users are experiencing this as a regression because they enable testing and their code breaks again after receiving the initial fix.