### PR TITLE
[NFC] Add ImportSet::dump() + fix module dumpRef

### DIFF
--- a/include/swift/AST/ImportCache.h
+++ b/include/swift/AST/ImportCache.h
@@ -98,6 +98,8 @@ public:
       return {getTrailingObjects<ImportedModule>(),
               NumTopLevelImports + NumTransitiveImports};
   }
+
+  SWIFT_DEBUG_DUMP;
 };
 
 class alignas(ImportedModule) ImportCache {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1320,9 +1320,11 @@ std::string ValueDecl::printRef() const {
 }
 
 void ValueDecl::dumpRef(raw_ostream &os) const {
-  // Print the context.
-  printContext(os, getDeclContext());
-  os << ".";
+  if (!isa<ModuleDecl>(this)) {
+    // Print the context.
+    printContext(os, getDeclContext());
+    os << ".";
+  }
 
   // Print name.
   getName().printPretty(os);

--- a/lib/AST/ImportCache.cpp
+++ b/lib/AST/ImportCache.cpp
@@ -63,6 +63,24 @@ void ImportSet::Profile(
   }
 }
 
+void ImportSet::dump() const {
+  llvm::errs() << "HasHeaderImportModule: " << HasHeaderImportModule << "\n";
+
+  llvm::errs() << "TopLevelImports:";
+  for (auto import : getTopLevelImports()) {
+    llvm::errs() << "\n- ";
+    simple_display(llvm::errs(), import);
+  }
+  llvm::errs() << "\n";
+
+  llvm::errs() << "TransitiveImports:";
+  for (auto import : getTransitiveImports()) {
+    llvm::errs() << "\n- ";
+    simple_display(llvm::errs(), import);
+  }
+  llvm::errs() << "\n";
+}
+
 static void collectExports(ImportedModule next,
                            SmallVectorImpl<ImportedModule> &stack) {
   SmallVector<ImportedModule, 4> exports;


### PR DESCRIPTION
Some tiny debug utility improvements I'm pulling out of #34556, which is only tangentially related.