### PR TITLE
[5.5] [SILGen] Precompute "returned" completion handler indices.

### DIFF
--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -255,10 +255,14 @@ SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
       auto continuationVal = SGF.B.createLoad(loc, continuationAddr,
                                            LoadOwnershipQualifier::Trivial);
       auto continuation = ManagedValue::forUnmanaged(continuationVal);
-      
+
       // Check for an error if the convention includes one.
-      auto errorIndex = convention.completionHandlerErrorParamIndex();
-      auto flagIndex = convention.completionHandlerFlagParamIndex();
+      // Increment the error and flag indices if present.  They do not account
+      // for the fact that they are preceded by the block_storage arguments.
+      auto errorIndex = convention.completionHandlerErrorParamIndex().map(
+          [](auto original) { return original + 1; });
+      auto flagIndex = convention.completionHandlerFlagParamIndex().map(
+          [](auto original) { return original + 1; });
 
       FuncDecl *resumeIntrinsic;
 
@@ -266,8 +270,8 @@ SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
       if (errorIndex) {
         resumeIntrinsic = getResumeUnsafeThrowingContinuation();
         auto errorIntrinsic = getResumeUnsafeThrowingContinuationWithError();
-        
-        auto errorArgument = params[*errorIndex + 1];
+
+        auto errorArgument = params[*errorIndex];
         auto someErrorBB = SGF.createBasicBlock(FunctionSection::Postmatter);
         auto noneErrorBB = SGF.createBasicBlock();
         returnBB = SGF.createBasicBlockAfter(noneErrorBB);
@@ -276,8 +280,8 @@ SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
         // Check whether there's an error, based on the presence of a flag
         // parameter. If there is a flag parameter, test it against zero.
         if (flagIndex) {
-          auto flagArgument = params[*flagIndex + 1];
-          
+          auto flagArgument = params[*flagIndex];
+
           // The flag must be an integer type. Get the underlying builtin
           // integer field from it.
           auto builtinFlagArg = SGF.emitUnwrapIntegerResult(loc, flagArgument.getValue());
@@ -372,31 +376,31 @@ SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
           bridgedArg.forwardInto(SGF, loc, destBuf);
         };
 
+        // Collect the indices which correspond to the values to be returned.
+        SmallVector<unsigned long, 4> paramIndices;
+        for (auto index : indices(params)) {
+          // The first index is the block_storage parameter.
+          if (index == 0)
+            continue;
+          if (errorIndex && index == *errorIndex)
+            continue;
+          if (flagIndex && index == *flagIndex)
+            continue;
+          paramIndices.push_back(index);
+        }
         if (auto resumeTuple = dyn_cast<TupleType>(resumeType)) {
+          assert(paramIndices.size() == resumeTuple->getNumElements());
           assert(params.size() == resumeTuple->getNumElements()
                                    + 1 + (bool)errorIndex + (bool)flagIndex);
           for (unsigned i : indices(resumeTuple.getElementTypes())) {
-            unsigned paramI = i;
-            if (errorIndex && paramI >= *errorIndex) {
-              ++paramI;
-            }
-            if (flagIndex && paramI >= *flagIndex) {
-              ++paramI;
-            }
             auto resumeEltBuf = SGF.B.createTupleElementAddr(loc,
                                                              resumeArgBuf, i);
-            prepareArgument(resumeEltBuf, params[paramI + 1]);
+            prepareArgument(resumeEltBuf, params[paramIndices[i]]);
           }
         } else {
+          assert(paramIndices.size() == 1);
           assert(params.size() == 2 + (bool)errorIndex + (bool)flagIndex);
-          unsigned paramI = 0;
-          if (errorIndex && paramI >= *errorIndex) {
-            ++paramI;
-          }
-          if (flagIndex && paramI >= *flagIndex) {
-            ++paramI;
-          }
-          prepareArgument(resumeArgBuf, params[paramI + 1]);
+          prepareArgument(resumeArgBuf, params[paramIndices[0]]);
         }
         
         // Resume the continuation with the composed bridged result.

--- a/test/Interpreter/Inputs/rdar80847020.h
+++ b/test/Interpreter/Inputs/rdar80847020.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+@interface Clazz : NSObject
+-(void)doSomethingMultiResultFlaggyWithCompletionHandler:(void (^)(BOOL, NSString *_Nullable, NSError *_Nullable, NSString *_Nullable))completionHandler __attribute__((swift_async_error(zero_argument, 1)));
+@end
+
+#pragma clang assume_nonnull end

--- a/test/Interpreter/Inputs/rdar80847020.m
+++ b/test/Interpreter/Inputs/rdar80847020.m
@@ -1,0 +1,11 @@
+#include "rdar80847020.h"
+
+#pragma clang assume_nonnull begin
+
+@implementation Clazz
+-(void)doSomethingMultiResultFlaggyWithCompletionHandler:(void (^)(BOOL, NSString *_Nullable, NSError *_Nullable, NSString *_Nullable))completionHandler __attribute__((swift_async_error(zero_argument, 1))) {
+    completionHandler(YES, @"hi", NULL, @"bye");
+}
+@end
+
+#pragma clang assume_nonnull end

--- a/test/Interpreter/rdar80847020.swift
+++ b/test/Interpreter/rdar80847020.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clang %S/Inputs/rdar80847020.m -I %S/Inputs -c -o %t/rdar80847020.o
-// RUN: %target-build-swift -import-objc-header %S/Inputs/rdar80847020.h -Xlinker %t/rdar80847020.o -parse-as-library %s -o %t/a.out
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar80847020.h -Xlinker %t/rdar80847020.o -parse-as-library %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/Interpreter/rdar80847020.swift
+++ b/test/Interpreter/rdar80847020.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar80847020.m -I %S/Inputs -c -o %t/rdar80847020.o
+// RUN: %target-build-swift -import-objc-header %S/Inputs/rdar80847020.h -Xlinker %t/rdar80847020.o -parse-as-library %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+func run(_ s: Clazz) async throws {
+    let res: (String, String) = try await s.doSomethingMultiResultFlaggy()
+    // CHECK: ("hi", "bye")
+    print(res)
+}
+
+@main struct Main {
+  static func main() async throws {
+    try await run(Clazz())
+  }
+}


### PR DESCRIPTION
Explanation: When generating the completion handler that is passed to ObjC methods that are being called as async Swift functions, the parameters taken by the generated completion handler are matched up with the values that are returned from the async function.  Some of the parameters to the completion handler (the block_storage, and the flag and error parameters if present) do not correspond to values to be returned from the function into the calling Swift code.  So it's necessary to avoid matching returned values up with those non-corresponding parameters.

Previously, the matching was done by testing candidate parameter indices against the non-corresponding indices in order while doing the matching.  There were cases where the matching up didn't work out correctly for certain completion handler shapes.  The result was to miscompile certain generated completion handlers.

Here, those to-be-ignored indexes are filtered out first.

Issue: rdar://80847020

Testing: New regression test, Swift CI

Reviewed by: @jckarter

Risk: Low, simplifies existing indexing logic.

Scope: Limited to Swift import of ObjC methods as async functions.
