### PR TITLE
Don't try to serialize the initializer of a void wrapped value; it has no source location.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6782,7 +6782,7 @@ ParamDecl::getDefaultValueStringRepresentation(
           if (auto *placeholder = findWrappedValuePlaceholder(parentInit))
             wrappedValue = placeholder->getOriginalWrappedValue();
 
-        if (!wrappedValue) {
+        if (!wrappedValue || !wrappedValue->getSourceRange().isValid()) {
           if (auto type = original->getPropertyWrapperBackingPropertyType()) {
             if (auto nominal = type->getAnyNominal()) {
               scratch.clear();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6782,7 +6782,7 @@ ParamDecl::getDefaultValueStringRepresentation(
           if (auto *placeholder = findWrappedValuePlaceholder(parentInit))
             wrappedValue = placeholder->getOriginalWrappedValue();
 
-        if (!wrappedValue || !wrappedValue->getSourceRange().isValid()) {
+        if (!wrappedValue) {
           if (auto type = original->getPropertyWrapperBackingPropertyType()) {
             if (auto nominal = type->getAnyNominal()) {
               scratch.clear();
@@ -6796,6 +6796,9 @@ ParamDecl::getDefaultValueStringRepresentation(
 
           return ".init()";
         }
+
+        if (!wrappedValue->getSourceRange().isValid())
+          return StringRef();
 
         auto &sourceMgr = getASTContext().SourceMgr;
         return extractInlinableText(sourceMgr, wrappedValue, scratch);

--- a/validation-test/Serialization/rdar80454271.swift
+++ b/validation-test/Serialization/rdar80454271.swift
@@ -1,0 +1,6 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %s
+
+@propertyWrapper public struct W { public var wrappedValue: ()
+public init(wrappedValue: ()) {} }
+public struct S { @W var prop: () }


### PR DESCRIPTION
Extend the special case of no wrapped value to cover a wrapped value with no initializer.