### PR TITLE
Fix Potential Use-After-Free of Temporary Twine

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1938,8 +1938,8 @@ OverlayFileContents::load(std::unique_ptr<llvm::MemoryBuffer> input,
     return error;
 
   if (contents.version > 1) {
-    auto message = Twine("key 'version' has invalid value: ") + Twine(contents.version);
-    errorMessages.push_back(message.str());
+    std::string message = (Twine("key 'version' has invalid value: ") + Twine(contents.version)).str();
+    errorMessages.emplace_back(std::move(message));
     return make_error_code(std::errc::result_out_of_range);
   }
 


### PR DESCRIPTION
Twine is non-owning and the lifetime of the result ends at the semicolon
here unless it is consumed into an owning abstraction. Convert to
a std::string first then insert that into the buffer here.

Not a big deal since this is along a catastrophic error path.

Noticed by inspection after some internal discussion of Twine's ownership model.