### PR TITLE
[Test] Added missing flag to Interpreter/rdar80847020.swift.

### DIFF
--- a/test/Interpreter/rdar80847020.swift
+++ b/test/Interpreter/rdar80847020.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clang %S/Inputs/rdar80847020.m -I %S/Inputs -c -o %t/rdar80847020.o
-// RUN: %target-build-swift -import-objc-header %S/Inputs/rdar80847020.h -Xlinker %t/rdar80847020.o -parse-as-library %s -o %t/a.out
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar80847020.h -Xlinker %t/rdar80847020.o -parse-as-library %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 


### PR DESCRIPTION
As of https://github.com/apple/swift/pull/38510 -Xfrontend -disable-availability-checking is needed.
