### PR TITLE
Revert "[update-checkout] Update `swift/next` to `next` for llvm-project"

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -214,11 +214,11 @@
         },
         "next" : {
             "aliases": ["next", "master-next",
-                        "next",
+                        "swift/next",
                         "stable-next", "upstream",
                         "next-upstream", "upstream-with-swift"],
             "repos": {
-                "llvm-project": "next",
+                "llvm-project": "swift/next",
                 "swift": "next",
                 "cmark": "main",
                 "llbuild": "main",


### PR DESCRIPTION
Reverts apple/swift#38538