### PR TITLE
[5.5] Turn off async test on ios and watchos

### DIFF
--- a/test/Concurrency/Runtime/async.swift
+++ b/test/Concurrency/Runtime/async.swift
@@ -7,6 +7,10 @@
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib
 
+// rdar://79670222 : This test fails on ios and watchos
+// UNSUPPORTED: OS=ios
+// UNSUPPORTED: OS=watchos
+
 import Dispatch
 import StdlibUnittest
 


### PR DESCRIPTION
This is likely related to the workaround in PR #37939.
See also: rdar://79670222.
