### PR TITLE
ModuleInterface: skip printing the override keyword if the overriden decl is skipped

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -747,6 +747,10 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     // implication. Thus we can skip them.
     if (auto *VD = dyn_cast<ValueDecl>(D)) {
       if (auto *BD = VD->getOverriddenDecl()) {
+        // If the overriden decl won't be printed, printing override will fail
+        // the build of the interface file.
+        if (!Options.shouldPrint(BD))
+          return false;
         if (!BD->hasClangNode() &&
             !BD->getFormalAccessScope(VD->getDeclContext(),
                                       /*treatUsableFromInlineAsPublic*/ true)

--- a/test/ModuleInterface/skip-override-spi.swift
+++ b/test/ModuleInterface/skip-override-spi.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/inputs)
+// RUN: %empty-directory(%t/modulecache)
+// RUN: echo "public class HideyHole { @_spi(Private) public init() {} }" > %t/Foo.swift
+// RUN: echo "public class StashyCache: HideyHole {}" >> %t/Foo.swift
+
+// RUN: %target-swift-frontend -emit-module -emit-module-interface-path %t/inputs/Foo.swiftinterface %t/Foo.swift -module-name Foo
+
+// RUN: %target-swift-frontend -emit-module-path %t/Bar.swiftmodule -enable-library-evolution -enable-objc-interop -disable-objc-attr-requires-foundation-module -module-name Bar %s -I %t/inputs -disable-availability-checking -module-cache-path %t/modulecache
+
+import Foo


### PR DESCRIPTION
rdar://80918826
