### PR TITLE
SILGen: do not emit hop_to_executor in some objc thunks

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1569,8 +1569,10 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
     if (thunk.hasDecl()) {
       isolation = getActorIsolation(thunk.getDecl());
     }
-    
-    if (isolation) {
+
+    // A hop is only needed in the thunk if it is global-actor isolated.
+    // Native, instance-isolated async methods will hop in the prologue.
+    if (isolation && isolation->isGlobalActor()) {
       emitHopToTargetActor(loc, *isolation, None);
     }
   }

--- a/test/Concurrency/actor_isolation_objc.swift
+++ b/test/Concurrency/actor_isolation_objc.swift
@@ -42,3 +42,16 @@ actor A {
   func g() { } // expected-note{{add '@objc' to expose this instance method to Objective-C}}
   @objc func h() async { }
 }
+
+actor Dril: NSObject {
+  // expected-note@+2 {{add 'async' to function 'postSynchronouslyTo(twitter:)' to make it asynchronous}}
+  // expected-error@+1 {{actor-isolated instance method 'postSynchronouslyTo(twitter:)' cannot be @objc}}
+  @objc func postSynchronouslyTo(twitter msg: String) -> Bool {
+    return true
+  }
+
+  @MainActor
+  @objc func postFromMainActorTo(twitter msg: String) -> Bool {
+    return true
+  }
+}


### PR DESCRIPTION
This is related to https://github.com/apple/swift/commit/e39dca4dbf26526e03fc91e5ddb7ef08da89bd24

An @objc async thunk does not need to perform a hop_to_executor if the native method is isolated to an actor-instance.

This redundant hop was causing a crash in SILGen with async actor-instance isolated @objc methods declared in an actor, because SILGen was not prepared to add the hop to  to `self` within the @objc thunk.

resolves rdar://80130628
