### PR TITLE
[Concurrency] Additional test for Task{} spawned within group

### DIFF
--- a/test/Concurrency/Runtime/async_task_locals_groups.swift
+++ b/test/Concurrency/Runtime/async_task_locals_groups.swift
@@ -79,8 +79,38 @@ func groups() async {
 }
 
 @available(SwiftStdlib 5.5, *)
+func taskInsideGroup() async {
+  Task {
+    print("outside") // CHECK: outside
+    _ = await withTaskGroup(of: Int.self) { group -> Int in
+      print("in group") // CHECK: in group
+      printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (0)
+
+      for _ in 0..<5 {
+        Task {
+          printTaskLocal(TL.$number)
+          print("some task")
+        }
+      }
+
+      return 0
+    }
+  }
+
+  // CHECK: some task
+  // CHECK: some task
+  // CHECK: some task
+  // CHECK: some task
+
+  await Task.sleep(5 * 1_000_000_000)
+
+//  await t.value
+}
+
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await groups()
+    await taskInsideGroup()
   }
 }


### PR DESCRIPTION
Small additional test to check that we don't crash when a unstructured Task is created from a task group.

Technically this touches the copyTo the same way as we do when inside any other task; the group isn't special in any way, but for coverage might as well add it.

Relates to rdar://80692195