### PR TITLE
[5.5] [CS] Don't bail out of CollectVarRefs early

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2518,10 +2518,8 @@ namespace {
         std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
           // If there are any error expressions in this closure
           // it wouldn't be possible to infer its type.
-          if (isa<ErrorExpr>(expr)) {
+          if (isa<ErrorExpr>(expr))
             hasErrorExprs = true;
-            return {false, nullptr};
-          }
 
           // Retrieve type variables from references to var decls.
           if (auto *declRef = dyn_cast<DeclRefExpr>(expr)) {

--- a/validation-test/IDE/crashers_2_fixed/sr14709.swift
+++ b/validation-test/IDE/crashers_2_fixed/sr14709.swift
@@ -1,0 +1,47 @@
+// RUN: %swift-ide-test --code-completion --source-filename %s --code-completion-token=CC
+
+struct Listing {}
+
+protocol View2 {}
+
+extension View2 {
+  @available(macOS 10.15, *)
+  func onTapGesturf(perform action: () -> Void) -> some View2 { fatalError() }
+}
+
+@resultBuilder struct ViewBuilder2 {
+  static func buildBlock() -> Never { fatalError() }
+  static func buildBlock<Content>(_ content: Content) -> Content where Content : View2 { fatalError() }
+}
+
+struct HStack2<Content> : View2 {
+  init(@ViewBuilder2 content: () -> Content) { fatalError() }
+}
+
+struct ItemImage2 : View2 {
+  init(path: String) {}
+}
+
+struct ForEach2<Data, Content>: View2 {
+  init(_ data: [Listing], @ViewBuilder2 content: (Data) -> Content) {}
+}
+
+
+struct TodayNookazonSection {
+
+  let listings: [Listing]
+
+  @available(macOS 10.15, *)
+  @ViewBuilder2 var body: some View2 {
+    ForEach2(listings) { listing in
+      HStack2 {
+        HStack2 {
+          ItemImage2(path#^CC^#: "abc")
+        }
+        .onTapGesturf {
+          listing
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
*5.5 cherry-pick of https://github.com/apple/swift/pull/38542*

---

Upon encountering an ErrorExpr, we were previously bailing from the walk. However, for multi-statement closures, that could result in us missing some variable references required to connect to the closure to its enclosing context. Make sure to continue walking to catch those cases.

SR-14709
rdar://78781677