### PR TITLE
[CodeCompletion] Fix issue causing the completion status to not be set correctly for pattern completion

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -1138,7 +1138,7 @@ ParserResult<Pattern> Parser::parsePattern() {
       // code complete anything here -- we expect an identifier.
       consumeToken(tok::code_complete);
     }
-    return nullptr;
+    return makeParserCodeCompletionStatus();
     
   case tok::kw_var:
   case tok::kw_let: {

--- a/test/IDE/complete_override.swift
+++ b/test/IDE/complete_override.swift
@@ -757,3 +757,13 @@ class SynthesizedConformance5: SynthesizedConformance2 {
 // OVERRIDE_SYNTHESIZED_5-DAG: Decl[Constructor]/Super:                required init(from decoder: Decoder) throws {|};
 // FIXME: 'required init(from decoder: Decoder)' is suggested twice
 }
+
+protocol ProtocolSr14687 {
+  var value: Int { get }
+}
+struct StructSr14687: ProtocolSr14687 {
+  let foo = val, #^MULTI_VAR_DECL_OVERRIDE^#
+// MULTI_VAR_DECL_OVERRIDE:     Begin completions, 1 items
+// MULTI_VAR_DECL_OVERRIDE-DAG: Decl[InstanceVar]/Super:            value: Int;
+// MULTI_VAR_DECL_OVERRIDE:     End completions
+}

--- a/validation-test/IDE/crashers_2_fixed/sr14687.swift
+++ b/validation-test/IDE/crashers_2_fixed/sr14687.swift
@@ -1,0 +1,5 @@
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token=COMPLETE
+
+class Foo {
+  let searchSubject = Bar<String, #^COMPLETE^#
+}


### PR DESCRIPTION
We weren’t setting the code completion token status correctly when parsing patterns with code completion tokens.

Because of this, in the added test case, the `searchSubject` gets added as a member of `Foo` twice - once in the first pass and once in the second pass, causing an assertion failure.

Fixes rdar://80575116 [SR-14687]