### PR TITLE
[CodeCompletion] Fix crasher and missing completion for generic arguments to nested type

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1211,13 +1211,17 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
         SmallVector<TypeRepr *, 8> args;
         SourceLoc LAngleLoc, RAngleLoc;
         auto argStat = parseGenericArguments(args, LAngleLoc, RAngleLoc);
+        Result = makeParserResult(Result | argStat, Result.getPtrOrNull());
         if (argStat.isErrorOrHasCompletion())
           diagnose(LAngleLoc, diag::while_parsing_as_left_angle_bracket);
 
         SyntaxContext->createNodeInPlace(SyntaxKind::SpecializeExpr);
-        Result = makeParserResult(
-            Result, UnresolvedSpecializeExpr::create(
-                        Context, Result.get(), LAngleLoc, args, RAngleLoc));
+        // The result can be empty in error cases.
+        if (!args.empty()) {
+          Result = makeParserResult(
+              Result, UnresolvedSpecializeExpr::create(
+                          Context, Result.get(), LAngleLoc, args, RAngleLoc));
+        }
       }
 
       continue;

--- a/test/IDE/complete_generic_param.swift
+++ b/test/IDE/complete_generic_param.swift
@@ -6,6 +6,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INHERIT6 | %FileCheck %s -check-prefix=INHERIT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_TYPE_PARAM
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=SECOND_GENERIC_TYPE_PARAM | %FileCheck %s -check-prefix=GENERIC_TYPE_PARAM
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_PARAM_ON_NESTED_TYPE_GLOBAL_VAR | %FileCheck %s -check-prefix=GENERIC_PARAM_ON_NESTED_TYPE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_PARAM_ON_NESTED_TYPE_LOCAL_VAR | %FileCheck %s -check-prefix=GENERIC_PARAM_ON_NESTED_TYPE
 
 class C1{}
 protocol P1{}
@@ -45,3 +47,19 @@ _ = Sr14432<SomeType, #^SECOND_GENERIC_TYPE_PARAM^# >()
 // GENERIC_TYPE_PARAM: Begin completions
 // GENERIC_TYPE_PARAM-DAG: Decl[Class]/CurrModule:             C1[#C1#];
 // GENERIC_TYPE_PARAM: End completions
+
+struct Sr14627 {
+  struct Nested<Elements> {
+    init() { fatalError() }
+  }
+}
+
+var sr14627_globalVar = Sr14627.Nested< #^GENERIC_PARAM_ON_NESTED_TYPE_GLOBAL_VAR^#>()
+
+func someFunction() {
+  var sr14627_localVar = Sr14627.Nested< #^GENERIC_PARAM_ON_NESTED_TYPE_LOCAL_VAR^#>()
+}
+
+// GENERIC_PARAM_ON_NESTED_TYPE: Begin completions
+// GENERIC_PARAM_ON_NESTED_TYPE-DAG: Decl[Struct]/CurrModule:            Sr14627[#Sr14627#];
+// GENERIC_PARAM_ON_NESTED_TYPE: End completions


### PR DESCRIPTION
Completing a generic parameter to a nested type `Outer.Nested<#^COMPLETE^#>` crashed when used to initialize a local variable and returned no results when initializing a global variable.

This is because the generic argument parsing logic for nested types inside `parseExprPostfixSuffix` didn’t match that of global types in `parseExprIdentifier`. Make sure they do the same thing semantically.

Fixes rdar://77909679 [SR-14627]