### PR TITLE
[Runtime] Static constructors and destructors should be an error here.

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -41,16 +41,18 @@ endif()
 
 # C++ code in the runtime and standard library should generally avoid
 # introducing static constructors or destructors.
-check_cxx_compiler_flag("-Werror -Wglobal-constructors" CXX_SUPPORTS_GLOBAL_CONSTRUCTORS_WARNING)
+check_cxx_compiler_flag("-Wglobal-constructors -Werror=global-constructors" CXX_SUPPORTS_GLOBAL_CONSTRUCTORS_WARNING)
 if(CXX_SUPPORTS_GLOBAL_CONSTRUCTORS_WARNING)
-  list(APPEND SWIFT_RUNTIME_CORE_CXX_FLAGS "-Wglobal-constructors")
+  list(APPEND SWIFT_RUNTIME_CORE_CXX_FLAGS "-Wglobal-constructors"
+    "-Werror=global-constructors")
 endif()
 
 # C++ code in the runtime and standard library should generally avoid
 # introducing static constructors or destructors.
-check_cxx_compiler_flag("-Wexit-time-destructors" CXX_SUPPORTS_EXIT_TIME_DESTRUCTORS_WARNING)
+check_cxx_compiler_flag("-Wexit-time-destructors -Werror=exit-time-destructors" CXX_SUPPORTS_EXIT_TIME_DESTRUCTORS_WARNING)
 if(CXX_SUPPORTS_EXIT_TIME_DESTRUCTORS_WARNING)
-  list(APPEND SWIFT_RUNTIME_CORE_CXX_FLAGS "-Wexit-time-destructors")
+  list(APPEND SWIFT_RUNTIME_CORE_CXX_FLAGS "-Wexit-time-destructors"
+    "-Werror=exit-time-destructors")
 endif()
 
 add_subdirectory(SwiftShims)


### PR DESCRIPTION
Except for a handful of places we know about, there should be no static constructors or destructors in the runtime; they're undesirable because they inflate start up or shut down times, and in the case of destructors we can't even guarantee that they will actually run (e.g. if the program declares that it supports fast termination, they just won't).

It should be OK to change the warnings to errors as a result.

rdar://80965245