### PR TITLE
Ignore whether a parameter is "isolated" for the purposes of redeclaration

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2688,8 +2688,10 @@ static Type mapSignatureFunctionType(ASTContext &ctx, Type type,
   for (const auto &param : funcTy->getParams()) {
     auto newParamType = mapSignatureParamType(ctx, param.getPlainType());
 
-    // Don't allow overloading by @_nonEphemeral.
-    auto newFlags = param.getParameterFlags().withNonEphemeral(false);
+    // Don't allow overloading by @_nonEphemeral or isolated.
+    auto newFlags = param.getParameterFlags()
+        .withNonEphemeral(false)
+        .withIsolated(false);
 
     // For the 'self' of a method, strip off 'inout'.
     if (isMethod) {

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -90,3 +90,15 @@ struct S: P {
   func k(isolated y: Int) -> Int { return j(isolated: y) }
   func l(isolated _: Int) -> Int { return k(isolated: 0) }
 }
+
+
+// Redeclaration checking
+actor TestActor {
+  func test() { // expected-note{{'test()' previously declared here}}
+  }
+  nonisolated func test() { // expected-error{{invalid redeclaration of 'test()'}}
+  }
+}
+
+func redecl(_: TestActor) { } // expected-note{{'redecl' previously declared here}}
+func redecl(_: isolated TestActor) { } // expected-error{{invalid redeclaration of 'redecl'}}


### PR DESCRIPTION
Overload resolution won't be able to tell them apart, and they're mangled
identically. Fixes rdar://80918858.
