### PR TITLE
Ignore whether a parameter is "isolated" for the purposes of redeclaration

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2688,8 +2688,10 @@ static Type mapSignatureFunctionType(ASTContext &ctx, Type type,
   for (const auto &param : funcTy->getParams()) {
     auto newParamType = mapSignatureParamType(ctx, param.getPlainType());
 
-    // Don't allow overloading by @_nonEphemeral.
-    auto newFlags = param.getParameterFlags().withNonEphemeral(false);
+    // Don't allow overloading by @_nonEphemeral or isolated.
+    auto newFlags = param.getParameterFlags()
+        .withNonEphemeral(false)
+        .withIsolated(false);
 
     // For the 'self' of a method, strip off 'inout'.
     if (isMethod) {

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -90,3 +90,15 @@ struct S: P {
   func k(isolated y: Int) -> Int { return j(isolated: y) }
   func l(isolated _: Int) -> Int { return k(isolated: 0) }
 }
+
+
+// Redeclaration checking
+actor TestActor {
+  func test() { // expected-note{{'test()' previously declared here}}
+  }
+  nonisolated func test() { // expected-error{{invalid redeclaration of 'test()'}}
+  }
+}
+
+func redecl(_: TestActor) { } // expected-note{{'redecl' previously declared here}}
+func redecl(_: isolated TestActor) { } // expected-error{{invalid redeclaration of 'redecl'}}


### PR DESCRIPTION
**Explanation**: [SE-0313](https://github.com/apple/swift-evolution/blob/main/proposals/0313-actor-isolation-control.md) doesn't permit overloading based on `isolated` parameters (including `nonisolated` methods on an actor). Teach the type checker to report such erroneous overloads rather than waiting for later compiler passes.
**Scope**: Affects new code using the Swift Concurrency model that would already have failed to compile, but at a later stage.
**Radar/SR Issue**: rdar://80918858.
**Risk**: Low.
**Testing**: PR testing and CI on main.
**Original PR**:  https://github.com/apple/swift/pull/38563
