### PR TITLE
[5.5][Concurrency] Remove libatomic dependency on Concurrency module on Linux

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -33,8 +33,7 @@ endif()
 # Frustratingly, in many cases this isn't necessary because the
 # sequence is inlined, but we have some code that's just subtle
 # enough to turn into runtime calls.
-if(SWIFT_HOST_VARIANT STREQUAL "linux" OR
-   SWIFT_HOST_VARIANT STREQUAL "android")
+if(SWIFT_HOST_VARIANT STREQUAL "android")
   list(APPEND SWIFT_RUNTIME_CONCURRENCY_SWIFT_LINK_FLAGS
     -latomic)
 endif()

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -132,7 +132,7 @@ public:
 } // end anonymous namespace
 
 /// The current state of a task's status records.
-class ActiveTaskStatus {
+class alignas(sizeof(void*) * 2) ActiveTaskStatus {
   enum : uintptr_t {
     /// The current running priority of the task.
     PriorityMask = 0xFF,


### PR DESCRIPTION
Explanation: When using clang with libstdc++ on Linux, the alignment of double-word wide types is not properly determined, causing a dependency on libatomic, when using those types with `std::atomic`. This PR fixes the problem by manually specifying the alignment.

Issue: rdar://80918942

Testing: Build and tests pass again after removing the libatomic dependency

Reviewed by: @DougGregor 

Risk: Low, Linux only and well covered by existing tests

Scope: Linux
