### PR TITLE
Disable async availability checking for swift_deletedAsyncMethodError.

### DIFF
--- a/test/Concurrency/concurrency_availability.swift
+++ b/test/Concurrency/concurrency_availability.swift
@@ -7,3 +7,7 @@ func f() async { } // expected-error{{concurrency is only available in}}
 
 actor A { }  // expected-error{{concurrency is only available in}}
 // expected-note@-1{{add @available}}
+
+// Allow this without any availability for Historical Reasons.
+public func swift_deletedAsyncMethodError() async {
+}


### PR DESCRIPTION
Prior versions of the _Concurrency library failed to provide
appropriate availability annotations for
`swift_deletedAsyncMethodError`, which makes them unusable with newer
Swift compilers. Avoid this problem by not checking availability for
this specific API.

Fixes rdar://80967376.
