### PR TITLE
Disable async availability checking for swift_deletedAsyncMethodError.

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2568,6 +2568,13 @@ public:
     return AFD->getResilienceExpansion() != ResilienceExpansion::Minimal;
   }
 
+  /// FIXME: This is an egregious hack to turn off availability checking
+  /// for specific functions that were missing availability in older versions
+  /// of existing libraries that we must nonethess still support.
+  static bool hasHistoricallyWrongAvailability(FuncDecl *func) {
+    return func->getName().isCompoundName("swift_deletedAsyncMethodError", { });
+  }
+
   void visitFuncDecl(FuncDecl *FD) {
     // Force these requests in case they emit diagnostics.
     (void) FD->getInterfaceType();
@@ -2612,7 +2619,8 @@ public:
 
     checkImplementationOnlyOverride(FD);
 
-    if (FD->getAsyncLoc().isValid())
+    if (FD->getAsyncLoc().isValid() &&
+        !hasHistoricallyWrongAvailability(FD))
       TypeChecker::checkConcurrencyAvailability(FD->getAsyncLoc(), FD);
     
     if (requiresDefinition(FD) && !FD->hasBody()) {

--- a/test/Concurrency/concurrency_availability.swift
+++ b/test/Concurrency/concurrency_availability.swift
@@ -7,3 +7,7 @@ func f() async { } // expected-error{{concurrency is only available in}}
 
 actor A { }  // expected-error{{concurrency is only available in}}
 // expected-note@-1{{add @available}}
+
+// Allow this without any availability for Historical Reasons.
+public func swift_deletedAsyncMethodError() async {
+}


### PR DESCRIPTION
**Explanation**: Prior versions of the _Concurrency library failed to provide appropriate availability annotations for
`swift_deletedAsyncMethodError`, which makes them unusable with newer Swift compilers. Avoid this problem by not checking availability for this specific API.
**Scope**: Affects all Swift code using an older _Concurrency library with a newer Swift compiler.
**Radar/SR Issue**: rdar://80967376
**Risk**: Low.
**Testing**: PR testing and CI on main.
**Original PR**:  https://github.com/apple/swift/pull/38571
