### PR TITLE
[CodeCompletion] Handle "unsafe" global actor isolation

### DIFF
--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -305,6 +305,9 @@ namespace swift {
   /// for a Fix-It that adds a new build* function to a result builder.
   std::tuple<SourceLoc, std::string, Type>
   determineResultBuilderBuildFixItInfo(NominalTypeDecl *builder);
+
+  /// Just a proxy to swift::contextUsesConcurrencyFeatures() from lib/IDE code.
+  bool completionContextUsesConcurrencyFeatures(const DeclContext *dc);
 }
 
 #endif

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -27,6 +27,7 @@
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeVisitor.h"
 #include "swift/AST/ExistentialLayout.h"
+#include "swift/Sema/IDETypeChecking.h"
 
 using namespace swift;
 
@@ -3930,4 +3931,8 @@ AnyFunctionType *swift::applyGlobalActorType(
 
   return FunctionType::get(
       fnType->getParams(), Type(innerFnType), fnType->getExtInfo());
+}
+
+bool swift::completionContextUsesConcurrencyFeatures(const DeclContext *dc) {
+  return contextUsesConcurrencyFeatures(dc);
 }

--- a/test/IDE/complete_globalactorunsafe.swift
+++ b/test/IDE/complete_globalactorunsafe.swift
@@ -1,0 +1,103 @@
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -enable-experimental-concurrency
+
+// SAFE_NOTREC: Begin completions, 2 items
+// SAFE_NOTREC-DAG: Keyword[self]/CurrNominal:          self[#SafelyIsolatedCls#];
+// SAFE_NOTREC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: method()[' async'][#Void#];
+// SAFE_NOTREC: End completions
+
+// UNSAFE_NOTREC: Begin completions, 2 items
+// UNSAFE_NOTREC-DAG: Keyword[self]/CurrNominal:          self[#UnsafelyIsolatedCls#];
+// UNSAFE_NOTREC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: method()[' async'][#Void#];
+// UNSAFE_NOTREC: End completions
+
+// SAFE_OK: Begin completions, 2 items
+// SAFE_OK-DAG: Keyword[self]/CurrNominal:          self[#SafelyIsolatedCls#];
+// SAFE_OK-DAG: Decl[InstanceMethod]/CurrNominal:   method()[' async'][#Void#];
+// SAFE_OK: End completions
+
+// UNSAFE_OK: Begin completions, 2 items
+// UNSAFE_OK-DAG: Keyword[self]/CurrNominal:          self[#UnsafelyIsolatedCls#];
+// UNSAFE_OK-DAG: Decl[InstanceMethod]/CurrNominal:   method()[' async'][#Void#];
+// UNSAFE_OK: End completions
+
+// UNSAFE_OK_SYNC: Begin completions, 2 items
+// UNSAFE_OK_SYNC-DAG: Keyword[self]/CurrNominal:          self[#UnsafelyIsolatedCls#];
+// UNSAFE_OK_SYNC-DAG: Decl[InstanceMethod]/CurrNominal:   method()[#Void#];
+// UNSAFE_OK_SYNC: End completions
+
+@globalActor
+actor MyGlobalActor {
+  static let shared = MyGlobalActor()
+}
+
+@MyGlobalActor(unsafe)
+class UnsafelyIsolatedCls {
+  func method()
+}
+
+@MyGlobalActor
+class SafelyIsolatedCls {
+  func method()
+}
+
+class TestNormal {
+  func testSync(s: SafelyIsolatedCls, u: UnsafelyIsolatedCls) {
+    s.#^IN_METHOD_SYNC_SAFE?check=SAFE_NOTREC^#
+    u.#^IN_METHOD_SYNC_UNSAFE?check=UNSAFE_OK_SYNC^#
+  }
+  func testAsync(s: SafelyIsolatedCls, u: UnsafelyIsolatedCls) async {
+    s.#^IN_METHOD_ASYNC_SAFE?check=SAFE_OK^#
+    u.#^IN_METHOD_ASYNC_UNSAFE?check=UNSAFE_OK^#
+  }
+}
+
+func testSync(s: SafelyIsolatedCls, u: UnsafelyIsolatedCls) {
+  s.#^IN_FUNC_SYNC_SAFE?check=SAFE_NOTREC^#
+  u.#^IN_FUNC_SYNC_UNSAFE?check=UNSAFE_OK_SYNC^#
+}
+func testAsync(s: SafelyIsolatedCls, u: UnsafelyIsolatedCls) async {
+  s.#^IN_FUNC_ASYNC_SAFE?check=SAFE_OK^#
+  u.#^IN_FUNC_ASYNC_UNSAFE?check=UNSAFE_OK^#
+}
+
+func testClosure(s: SafelyIsolatedCls, u: UnsafelyIsolatedCls) {
+    func receiverSync(fn: () -> Void) {}
+    func receiverAsync(fn: () async -> Void) {}
+
+    receiverSync {
+      dummy;
+      s.#^IN_CLOSURE_SYNC_SAFE?check=SAFE_NOTREC^#
+      u.#^IN_CLOSURE_SYNC_UNSAFE?check=UNSAFE_OK_SYNC^#
+    }
+
+    receiverAsync {
+      dummy;
+      s.#^IN_CLOSURE_ASYNC_SAFE?check=SAFE_OK^#
+      u.#^IN_CLOSURE_ASYNC_UNSAFE?check=UNSAFE_OK^#
+    }
+}
+
+actor TestActor {
+  func test(s: SafelyIsolatedCls, u: UnsafelyIsolatedCls) {
+    s.#^IN_ACTOR_SYNC_SAFE?check=SAFE_NOTREC^#
+    u.#^IN_ACTOR_SYNC_UNSAFE?check=UNSAFE_NOTREC^#
+  }
+
+  func testAsync(s: SafelyIsolatedCls, u: UnsafelyIsolatedCls) async {
+    s.#^IN_ACTOR_ASYNC_SAFE?check=SAFE_OK^#
+    u.#^IN_ACTOR_ASYNC_UNSAFE?check=UNSAFE_OK^#
+  }
+}
+
+@MainActor
+class TestMainActorIsolated {
+  func test(s: SafelyIsolatedCls, u: UnsafelyIsolatedCls) {
+    s.#^IN_GLOBALACTOR_SYNC_SAFE?check=SAFE_NOTREC^#
+    u.#^IN_GLOBALACTOR_SYNC_UNSAFE?check=UNSAFE_NOTREC^#
+  }
+
+  func testAsync(s: SafelyIsolatedCls, u: UnsafelyIsolatedCls) async {
+    s.#^IN_GLOBALACTOR_ASYNC_SAFE?check=SAFE_OK^#
+    u.#^IN_GLOBALACTOR_ASYNC_UNSAFE?check=UNSAFE_OK^#
+  }
+}

--- a/test/IDE/complete_globalactorunsafe_strict.swift
+++ b/test/IDE/complete_globalactorunsafe_strict.swift
@@ -1,0 +1,103 @@
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -enable-experimental-concurrency -warn-concurrency
+
+// SAFE_NOTREC: Begin completions, 2 items
+// SAFE_NOTREC-DAG: Keyword[self]/CurrNominal:          self[#SafelyIsolatedCls#];
+// SAFE_NOTREC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: method()[' async'][#Void#];
+// SAFE_NOTREC: End completions
+
+// UNSAFE_NOTREC: Begin completions, 2 items
+// UNSAFE_NOTREC-DAG: Keyword[self]/CurrNominal:          self[#UnsafelyIsolatedCls#];
+// UNSAFE_NOTREC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: method()[' async'][#Void#];
+// UNSAFE_NOTREC: End completions
+
+// SAFE_OK: Begin completions, 2 items
+// SAFE_OK-DAG: Keyword[self]/CurrNominal:          self[#SafelyIsolatedCls#];
+// SAFE_OK-DAG: Decl[InstanceMethod]/CurrNominal:   method()[' async'][#Void#];
+// SAFE_OK: End completions
+
+// UNSAFE_OK: Begin completions, 2 items
+// UNSAFE_OK-DAG: Keyword[self]/CurrNominal:          self[#UnsafelyIsolatedCls#];
+// UNSAFE_OK-DAG: Decl[InstanceMethod]/CurrNominal:   method()[' async'][#Void#];
+// UNSAFE_OK: End completions
+
+// UNSAFE_OK_SYNC: Begin completions, 2 items
+// UNSAFE_OK_SYNC-DAG: Keyword[self]/CurrNominal:          self[#UnsafelyIsolatedCls#];
+// UNSAFE_OK_SYNC-DAG: Decl[InstanceMethod]/CurrNominal:   method()[#Void#];
+// UNSAFE_OK_SYNC: End completions
+
+@globalActor
+actor MyGlobalActor {
+  static let shared = MyGlobalActor()
+}
+
+@MyGlobalActor(unsafe)
+class UnsafelyIsolatedCls {
+  func method()
+}
+
+@MyGlobalActor
+class SafelyIsolatedCls {
+  func method()
+}
+
+class TestNormal {
+  func testSync(s: SafelyIsolatedCls, u: UnsafelyIsolatedCls) {
+    s.#^IN_METHOD_SYNC_SAFE?check=SAFE_NOTREC^#
+    u.#^IN_METHOD_SYNC_UNSAFE?check=UNSAFE_NOTREC^#
+  }
+  func testAsync(s: SafelyIsolatedCls, u: UnsafelyIsolatedCls) async {
+    s.#^IN_METHOD_ASYNC_SAFE?check=SAFE_OK^#
+    u.#^IN_METHOD_ASYNC_UNSAFE?check=UNSAFE_OK^#
+  }
+}
+
+func testSync(s: SafelyIsolatedCls, u: UnsafelyIsolatedCls) {
+  s.#^IN_FUNC_SYNC_SAFE?check=SAFE_NOTREC^#
+  u.#^IN_FUNC_SYNC_UNSAFE?check=UNSAFE_NOTREC^#
+}
+func testAsync(s: SafelyIsolatedCls, u: UnsafelyIsolatedCls) async {
+  s.#^IN_FUNC_ASYNC_SAFE?check=SAFE_OK^#
+  u.#^IN_FUNC_ASYNC_UNSAFE?check=UNSAFE_OK^#
+}
+
+func testClosure(s: SafelyIsolatedCls, u: UnsafelyIsolatedCls) {
+    func receiverSync(fn: () -> Void) {}
+    func receiverAsync(fn: () async -> Void) {}
+
+    receiverSync {
+      dummy;
+      s.#^IN_CLOSURE_SYNC_SAFE?check=SAFE_NOTREC^#
+      u.#^IN_CLOSURE_SYNC_UNSAFE?check=UNSAFE_NOTREC^#
+    }
+
+    receiverAsync {
+      dummy;
+      s.#^IN_CLOSURE_ASYNC_SAFE?check=SAFE_OK^#
+      u.#^IN_CLOSURE_ASYNC_UNSAFE?check=UNSAFE_OK^#
+    }
+}
+
+actor TestActor {
+  func test(s: SafelyIsolatedCls, u: UnsafelyIsolatedCls) {
+    s.#^IN_ACTOR_SYNC_SAFE?check=SAFE_NOTREC^#
+    u.#^IN_ACTOR_SYNC_UNSAFE?check=UNSAFE_NOTREC^#
+  }
+
+  func testAsync(s: SafelyIsolatedCls, u: UnsafelyIsolatedCls) async {
+    s.#^IN_ACTOR_ASYNC_SAFE?check=SAFE_OK^#
+    u.#^IN_ACTOR_ASYNC_UNSAFE?check=UNSAFE_OK^#
+  }
+}
+
+@MainActor
+class TestMainActorIsolated {
+  func test(s: SafelyIsolatedCls, u: UnsafelyIsolatedCls) {
+    s.#^IN_GLOBALACTOR_SYNC_SAFE?check=SAFE_NOTREC^#
+    u.#^IN_GLOBALACTOR_SYNC_UNSAFE?check=UNSAFE_NOTREC^#
+  }
+
+  func testAsync(s: SafelyIsolatedCls, u: UnsafelyIsolatedCls) async {
+    s.#^IN_GLOBALACTOR_ASYNC_SAFE?check=SAFE_OK^#
+    u.#^IN_GLOBALACTOR_ASYNC_UNSAFE?check=UNSAFE_OK^#
+  }
+}

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -757,6 +757,10 @@ static llvm::cl::opt<bool>
 EnableExperimentalConcurrency("enable-experimental-concurrency",
                               llvm::cl::desc("Enable experimental concurrency model"),
                               llvm::cl::init(false));
+static llvm::cl::opt<bool>
+WarnConcurrency("warn-concurrency",
+                llvm::cl::desc("Additional concurrency warnings"),
+                llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
 DisableImplicitConcurrencyImport("disable-implicit-concurrency-module-import",
@@ -3864,6 +3868,9 @@ int main(int argc, char *argv[]) {
   }
   if (options::EnableExperimentalConcurrency) {
     InitInvok.getLangOptions().EnableExperimentalConcurrency = true;
+  }
+  if (options::WarnConcurrency) {
+    InitInvok.getLangOptions().WarnConcurrency = true;
   }
   if (options::DisableImplicitConcurrencyImport) {
     InitInvok.getLangOptions().DisableImplicitConcurrencyModuleImport = true;


### PR DESCRIPTION
For `(unsafe)` global actor isolation, implicit `async` happens only if
* The context adopted concurrency feature
* Not '-warn-concurrency' specified

rdar://80907499
