### PR TITLE
Ignore All 'Unreachable' Decls That Don't Carry Expressions

### DIFF
--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -330,9 +330,10 @@ void StmtEmitter::visitBraceStmt(BraceStmt *S) {
           continue;
         }
       } else if (auto D = ESD.dyn_cast<Decl*>()) {
-        // Local type declarations are not unreachable because they can appear
-        // after the declared type has already been used.
-        if (isa<TypeDecl>(D))
+        // Local declarations aren't unreachable - only their usages can be. To
+        // that end, we only care about pattern bindings since their
+        // initializer expressions can be unreachable.
+        if (!isa<PatternBindingDecl>(D))
           continue;
       }
       

--- a/test/SILGen/unreachable_code.swift
+++ b/test/SILGen/unreachable_code.swift
@@ -154,4 +154,5 @@ func sr13639() -> Int {
     // CHECK: sil private @$s16unreachable_code7sr13639SiyF3FooL_V7fooFuncyyF : $@convention(method) (Foo) -> ()
     func fooFunc() {}
   }
+  func appendix() {} // no-warning
 }


### PR DESCRIPTION
We were just ignoring types here, but local functions don't matter. In
fact, if a local decl survives to SILGen, we only really care if it
carries some expression or statement itself - so pattern bindings are
the real stars here.

Re-resolves rdar://76269551 and SR-14449