### PR TITLE
[Async Refactoring] Add parens around custom error cast

### DIFF
--- a/test/refactoring/ConvertAsync/basic.swift
+++ b/test/refactoring/ConvertAsync/basic.swift
@@ -133,7 +133,7 @@ func customError(completion: (String?, CustomError?) -> Void) { }
 // ASYNC-CUSTOMERROR-NEXT: let result = try await customError()
 // ASYNC-CUSTOMERROR-NEXT: completion(result, nil)
 // ASYNC-CUSTOMERROR-NEXT: } catch {
-// ASYNC-CUSTOMERROR-NEXT: completion(nil, error as! CustomError)
+// ASYNC-CUSTOMERROR-NEXT: completion(nil, (error as! CustomError))
 // ASYNC-CUSTOMERROR-NEXT: }
 // ASYNC-CUSTOMERROR-NEXT: }
 // ASYNC-CUSTOMERROR-NEXT: }
@@ -308,7 +308,7 @@ func genericError<E>(completion: (String?, E?) -> Void) where E: Error { }
 // GENERIC-ERROR-NEXT: let result: String = try await genericError()
 // GENERIC-ERROR-NEXT: completion(result, nil)
 // GENERIC-ERROR-NEXT: } catch {
-// GENERIC-ERROR-NEXT: completion(nil, error as! E)
+// GENERIC-ERROR-NEXT: completion(nil, (error as! E))
 // GENERIC-ERROR-NEXT: }
 // GENERIC-ERROR-NEXT: }
 // GENERIC-ERROR-NEXT: }

--- a/test/refactoring/ConvertAsync/variable_as_callback.swift
+++ b/test/refactoring/ConvertAsync/variable_as_callback.swift
@@ -317,7 +317,7 @@ func testGenericErrorVariableCompletionHandler<MyGenericError>(completionHandler
 // GENERIC-ERROR-NEXT:   let result: String = try await genericError()
 // GENERIC-ERROR-NEXT:   completionHandler(result, nil)
 // GENERIC-ERROR-NEXT: } catch {
-// GENERIC-ERROR-NEXT:   completionHandler(nil, error as! MyGenericError)
+// GENERIC-ERROR-NEXT:   completionHandler(nil, (error as! MyGenericError))
 // GENERIC-ERROR-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=DEFAULT-ARGS-FUNC %s


### PR DESCRIPTION
When passing a forwarded error to a `CustomError?` completion handler parameter, wrap the cast in a set of parentheses to silence a warning in the refactored code.

rdar://80409905