### PR TITLE
[gardening] update copyright year in the benchmark template

### DIFF
--- a/benchmark/scripts/Template.swift
+++ b/benchmark/scripts/Template.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information


### PR DESCRIPTION
That's all it is. Change 2020 to 2021. Because it's July.