### PR TITLE
[5.5] Fix arg cleanup for objc continuations

### DIFF
--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -37,6 +37,24 @@ ManagedValue ManagedValue::copy(SILGenFunction &SGF, SILLocation loc) const {
   return SGF.emitManagedRValueWithCleanup(buf, lowering);
 }
 
+// Emit an unmanaged copy of this value
+// WARNING: Callers of this API should manage the cleanup of this value!
+ManagedValue ManagedValue::unmanagedCopy(SILGenFunction &SGF,
+                                         SILLocation loc) const {
+  auto &lowering = SGF.getTypeLowering(getType());
+  if (lowering.isTrivial())
+    return *this;
+
+  if (getType().isObject()) {
+    auto copy = SGF.B.emitCopyValueOperation(loc, getValue());
+    return ManagedValue::forUnmanaged(copy);
+  }
+
+  SILValue buf = SGF.emitTemporaryAllocation(loc, getType());
+  SGF.B.createCopyAddr(loc, getValue(), buf, IsNotTake, IsInitialization);
+  return ManagedValue::forUnmanaged(buf);
+}
+
 /// Emit a copy of this value with independent ownership.
 ManagedValue ManagedValue::formalAccessCopy(SILGenFunction &SGF,
                                             SILLocation loc) {

--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -270,6 +270,10 @@ public:
   /// Emit a copy of this value with independent ownership.
   ManagedValue copy(SILGenFunction &SGF, SILLocation loc) const;
 
+  /// Returns an unmanaged copy of this value.
+  /// WARNING: Callers of this API should manage the cleanup of this value!
+  ManagedValue unmanagedCopy(SILGenFunction &SGF, SILLocation loc) const;
+
   /// Emit a copy of this value with independent ownership into the current
   /// formal evaluation scope.
   ManagedValue formalAccessCopy(SILGenFunction &SGF, SILLocation loc);


### PR DESCRIPTION
Current SILGen for objc continuations, can end the lifetime of args
before await_async_continuation.
This PR fixes it by extending the lifetime of the args until await_async_continuation
by creating copies. And then inserts manual cleanup with fix_lifetime + destroy

Fixes rdar://78982371
