### PR TITLE
Cleanup handing of task priorities

### DIFF
--- a/stdlib/public/Concurrency/SourceCompatibilityShims.swift
+++ b/stdlib/public/Concurrency/SourceCompatibilityShims.swift
@@ -29,6 +29,12 @@ extension Task where Success == Never, Failure == Never {
   public static func CancellationError() -> _Concurrency.CancellationError {
     return _Concurrency.CancellationError()
   }
+
+  @available(*, deprecated, renamed: "yield()")
+  @_alwaysEmitIntoClient
+  public static func suspend() async {
+    await yield()
+  }
 }
 
 @available(SwiftStdlib 5.5, *)

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -478,14 +478,17 @@ static AsyncTaskAndContext swift_task_create_commonImpl(
 
     if (currentTask)
       jobFlags.setPriority(currentTask->getPriority());
-    else
-      // FIXME: Ideally, this should be setting priority based on
-      // swift_task_getCurrentThreadPriority(). However, that creates
-      // priority differences which lead to different kinds of hangs
-      // Temporarily use Unspecified to work around that.
-      // See also: PR #37939.
-      jobFlags.setPriority(JobPriority::Unspecified);
+    else if (taskCreateFlags.inheritContext())
+      jobFlags.setPriority(swift_task_getCurrentThreadPriority());
   }
+
+  // Adjust user-interactive priorities down to user-initiated.
+  if (jobFlags.getPriority() == JobPriority::UserInteractive)
+    jobFlags.setPriority(JobPriority::UserInitiated);
+
+  // If there is still no job priority, use the default priority.
+  if (jobFlags.getPriority() == JobPriority::Unspecified)
+    jobFlags.setPriority(JobPriority::Default);
 
   // Figure out the size of the header.
   size_t headerSize = sizeof(AsyncTask);

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -490,6 +490,13 @@ static AsyncTaskAndContext swift_task_create_commonImpl(
   if (jobFlags.getPriority() == JobPriority::Unspecified)
     jobFlags.setPriority(JobPriority::Default);
 
+  // FIXME HACK HACK
+  // Work around a bug in the actor runtime where it may drop tasks
+  // (== deadlock) when dealing with different priority levels. To do so,
+  // we normalize all priority levels to "unspecified".
+  jobFlags.setPriority(JobPriority::Unspecified);
+  // FIXME HACK HACK
+
   // Figure out the size of the header.
   size_t headerSize = sizeof(AsyncTask);
   if (parent) {
@@ -1139,11 +1146,15 @@ static NullaryContinuationJob*
 swift_task_createNullaryContinuationJobImpl(
     size_t priority,
     AsyncTask *continuation) {
+  // FIXME HACK HACK
+  // Work around a bug in the actor runtime where it may drop tasks
+  // (== deadlock) when dealing with different priority levels. To do so,
+  // we normalize all priority levels to "unspecified".
   void *allocation =
       swift_task_alloc(sizeof(NullaryContinuationJob));
   auto *job =
       new (allocation) NullaryContinuationJob(
-        swift_task_getCurrent(), static_cast<JobPriority>(priority),
+        swift_task_getCurrent(), JobPriority::Unspecified,
         continuation);
 
   return job;

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -269,7 +269,7 @@ extension Task where Success == Never, Failure == Never {
       }
 
       // Otherwise, query the system.
-      return TaskPriority(rawValue: UInt8(0))
+      return TaskPriority(rawValue: UInt8(_getCurrentThreadPriority()))
     }
   }
 }
@@ -629,11 +629,10 @@ extension Task where Success == Never, Failure == Never {
   ///
   @available(*, deprecated, renamed: "suspend()")
   public static func yield() async {
-    let currentTask = Builtin.getCurrentAsyncTask()
-    let priority = getJobFlags(currentTask).priority ?? Task.currentPriority._downgradeUserInteractive
-
     return await Builtin.withUnsafeContinuation { (continuation: Builtin.RawUnsafeContinuation) -> Void in
-      let job = _taskCreateNullaryContinuationJob(priority: Int(priority.rawValue), continuation: continuation)
+      let job = _taskCreateNullaryContinuationJob(
+          priority: Int(Task.currentPriority.rawValue),
+          continuation: continuation)
       _enqueueJobGlobal(job)
     }
   }
@@ -710,7 +709,8 @@ public struct UnsafeCurrentTask {
   /// - SeeAlso: `TaskPriority`
   /// - SeeAlso: `Task.currentPriority`
   public var priority: TaskPriority {
-    getJobFlags(_task).priority ?? .unspecified
+    getJobFlags(_task).priority ?? TaskPriority(
+        rawValue: UInt8(_getCurrentThreadPriority()))
   }
 
   /// Cancel the current task.

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -627,7 +627,6 @@ extension Task where Success == Never, Failure == Never {
   /// if the task is the highest-priority task in the system, it might go
   /// immediately back to executing.
   ///
-  @available(*, deprecated, renamed: "suspend()")
   public static func yield() async {
     return await Builtin.withUnsafeContinuation { (continuation: Builtin.RawUnsafeContinuation) -> Void in
       let job = _taskCreateNullaryContinuationJob(
@@ -635,11 +634,6 @@ extension Task where Success == Never, Failure == Never {
           continuation: continuation)
       _enqueueJobGlobal(job)
     }
-  }
-
-  @_alwaysEmitIntoClient
-  public static func suspend() async {
-    await yield()
   }
 }
 

--- a/stdlib/public/Concurrency/TaskSleep.swift
+++ b/stdlib/public/Concurrency/TaskSleep.swift
@@ -19,11 +19,10 @@ extension Task where Success == Never, Failure == Never {
   ///
   /// This function does _not_ block the underlying thread.
   public static func sleep(_ duration: UInt64) async {
-    let currentTask = Builtin.getCurrentAsyncTask()
-    let priority = getJobFlags(currentTask).priority ?? Task.currentPriority._downgradeUserInteractive
-
     return await Builtin.withUnsafeContinuation { (continuation: Builtin.RawUnsafeContinuation) -> Void in
-      let job = _taskCreateNullaryContinuationJob(priority: Int(priority.rawValue), continuation: continuation)
+      let job = _taskCreateNullaryContinuationJob(
+          priority: Int(Task.currentPriority.rawValue),
+          continuation: continuation)
       _enqueueJobGlobalWithDelay(duration, job)
     }
   }

--- a/test/Concurrency/Runtime/actor_detach.swift
+++ b/test/Concurrency/Runtime/actor_detach.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency -Xfrontend -disable-availability-checking) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Concurrency/Runtime/async.swift
+++ b/test/Concurrency/Runtime/async.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar79670222
 // RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency -Xfrontend -disable-availability-checking %import-libdispatch)
 
 // REQUIRES: executable_test
@@ -27,7 +26,6 @@ actor MyActor {
   func doSomething(expectedPriority: TaskPriority) {
     async {
       synchronous() // okay to be synchronous
-      assert(Task.currentPriority == expectedPriority)
     }
   }
 }
@@ -38,7 +36,6 @@ if #available(SwiftStdlib 5.5, *) {
   asyncTests.test("Detach") {
     detach(priority: .background) {
       async {
-        assert(Task.currentPriority == .background)
         await actor.doSomething(expectedPriority: .background)
       }
     }
@@ -48,7 +45,6 @@ if #available(SwiftStdlib 5.5, *) {
   asyncTests.test("MainQueue") {
     DispatchQueue.main.async {
       async {
-        assert(Task.currentPriority == .userInitiated)
       }
     }
     sleep(1)
@@ -59,7 +55,6 @@ if #available(SwiftStdlib 5.5, *) {
       async {
 #if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
         // Non-Darwin platforms currently lack qos_class_self().
-        assert(Task.currentPriority == .utility)
 #endif
       }
     }

--- a/test/Concurrency/Runtime/async_task_priority_current.swift
+++ b/test/Concurrency/Runtime/async_task_priority_current.swift
@@ -13,7 +13,7 @@ import Dispatch
 @available(SwiftStdlib 5.5, *)
 func test_detach() async {
   let a1 = Task.currentPriority
-  print("a1: \(a1)") // CHECK: TaskPriority(rawValue: 0)
+  print("a1: \(a1)") // CHECK: TaskPriority(rawValue: 21)
 
   // Note: remember to detach using a higher priority, otherwise a lower one
   // might be escalated by the get() and we could see `default` in the detached
@@ -24,7 +24,7 @@ func test_detach() async {
   }.get()
 
   let a3 = Task.currentPriority
-  print("a3: \(a3)") // CHECK: a3: TaskPriority(rawValue: 0)
+  print("a3: \(a3)") // CHECK: a3: TaskPriority(rawValue: 21)
 }
 
 @available(SwiftStdlib 5.5, *)

--- a/test/Concurrency/Runtime/async_task_priority_current.swift
+++ b/test/Concurrency/Runtime/async_task_priority_current.swift
@@ -13,18 +13,18 @@ import Dispatch
 @available(SwiftStdlib 5.5, *)
 func test_detach() async {
   let a1 = Task.currentPriority
-  print("a1: \(a1)") // CHECK: TaskPriority(rawValue: 21)
+  print("a1: \(a1)") // CHECK: TaskPriority(rawValue:
 
   // Note: remember to detach using a higher priority, otherwise a lower one
   // might be escalated by the get() and we could see `default` in the detached
   // task.
   await detach(priority: .userInitiated) {
     let a2 = Task.currentPriority
-    print("a2: \(a2)") // CHECK: a2: TaskPriority(rawValue: 25)
+    print("a2: \(a2)") // CHECK: a2: TaskPriority(rawValue:
   }.get()
 
   let a3 = Task.currentPriority
-  print("a3: \(a3)") // CHECK: a3: TaskPriority(rawValue: 21)
+  print("a3: \(a3)") // CHECK: a3: TaskPriority(rawValue:
 }
 
 @available(SwiftStdlib 5.5, *)

--- a/unittests/runtime/Actor.cpp
+++ b/unittests/runtime/Actor.cpp
@@ -224,6 +224,8 @@ static AsyncTask *createTaskStoring(JobPriority priority,
 }
 
 TEST(ActorTest, validateTestHarness) {
+#if false
+  // FIXME: Disable due to priority-normalizing hack.
   run([] {
     auto task0 = createTask(JobPriority::Background,
       [](AsyncContext *context) SWIFT_CC(swiftasync) {
@@ -250,6 +252,7 @@ TEST(ActorTest, validateTestHarness) {
     swift_task_enqueueGlobal(task2);
     EXPECT_PROGRESS(0);
   });
+#endif
 }
 
 
@@ -294,6 +297,8 @@ TEST(ActorTest, actorSwitch) {
 }
 
 TEST(ActorTest, actorContention) {
+#if false
+  // FIXME: Disable due to priority-normalizing hack.
   run([] {
     using Context = TupleContext<AsyncTask*, TestActor*>;
     auto actor = createActor();
@@ -360,4 +365,5 @@ TEST(ActorTest, actorContention) {
 
     EXPECT_PROGRESS(0);
   });
+#endif
 }


### PR DESCRIPTION
Compute and propagate task priorities consistently everywhere.

Then, work around a bug in the actor runtime where it may drop tasks
(== deadlock) when dealing with different priority levels. To do so,
we normalize all priority levels to "unspecified". This generalizes and
centralizes existing hack so we can back it out (the last commit)
as soon as we have the complete fix.

Fixes rdar://80989976.