### PR TITLE
[5.5] [PrintAsObjC] Make async completions _Nonnull

### DIFF
--- a/lib/PrintAsObjC/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.cpp
@@ -594,7 +594,7 @@ private:
       if (asyncConvention &&
           i == asyncConvention->completionHandlerParamIndex()) {
         os << piece << ":(";
-        print(asyncConvention->completionHandlerType(), None);
+        print(asyncConvention->completionHandlerType(), OTK_None);
         os << ")completionHandler";
         continue;
       }

--- a/test/PrintAsObjC/async.swift
+++ b/test/PrintAsObjC/async.swift
@@ -19,13 +19,13 @@ import Foundation
 
 // CHECK-LABEL: @interface BarClass : NSObject
 @objc @objcMembers class BarClass: NSObject {
-  // CHECK: (void)doSomethingBigWithCompletionHandler:(void (^)(NSInteger))completionHandler;
+  // CHECK: (void)doSomethingBigWithCompletionHandler:(void (^ _Nonnull)(NSInteger))completionHandler;
   func doSomethingBig() async -> Int { 0 }
 
-  // CHECK: - (void)longRunningWithString:(NSString * _Nonnull)string completionHandler:(void (^)(BarClass * _Nullable, NSError * _Nullable))completionHandler;
+  // CHECK: - (void)longRunningWithString:(NSString * _Nonnull)string completionHandler:(void (^ _Nonnull)(BarClass * _Nullable, NSError * _Nullable))completionHandler;
   func longRunning(string: String) async throws -> BarClass { return self }
 
-  // CHECK: - (void)magicTupleReturnWithCompletionHandler:(void (^)(BarClass * _Nonnull, NSInteger))completionHandler;
+  // CHECK: - (void)magicTupleReturnWithCompletionHandler:(void (^ _Nonnull)(BarClass * _Nonnull, NSInteger))completionHandler;
   func magicTupleReturn() async -> (BarClass, Int) { return (self, 0) }
 }
 // CHECK: @end


### PR DESCRIPTION
Cherry-pick of #38595 to release/5.5:

> When we printed `async` methods, we did not print a nullability annotation on the `completionHandler` parameter. This commit adds `_Nonnull`, which matches the generated SIL.
>
> Fixes rdar://80989714.