### PR TITLE
[5.5] SILGen: do not emit hop_to_executor in some objc thunks

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1568,8 +1568,10 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
     if (thunk.hasDecl()) {
       isolation = getActorIsolation(thunk.getDecl());
     }
-    
-    if (isolation) {
+
+    // A hop is only needed in the thunk if it is global-actor isolated.
+    // Native, instance-isolated async methods will hop in the prologue.
+    if (isolation && isolation->isGlobalActor()) {
       emitHopToTargetActor(loc, *isolation, None);
     }
   }

--- a/test/Concurrency/actor_isolation_objc.swift
+++ b/test/Concurrency/actor_isolation_objc.swift
@@ -53,5 +53,15 @@ func outside(a : A) async {
   await a.i() // expected-warning {{no 'async' operations occur within 'await' expression}}
 }
 
+actor Dril: NSObject {
+  // expected-note@+2 {{add 'async' to function 'postSynchronouslyTo(twitter:)' to make it asynchronous}}
+  // expected-error@+1 {{actor-isolated instance method 'postSynchronouslyTo(twitter:)' cannot be @objc}}
+  @objc func postSynchronouslyTo(twitter msg: String) -> Bool {
+    return true
+  }
 
-
+  @MainActor
+  @objc func postFromMainActorTo(twitter msg: String) -> Bool {
+    return true
+  }
+}


### PR DESCRIPTION
Rationale: Async methods that are actor-instance isolated and marked with `@objc` would attempt to emit a `hop_to_executor` in the `@objc` thunk that calls the native method. But, this led to a compiler crash in SILGen because it was not prepared to emit a `hop_to_executor` to `self` in the thunk. There is actually no need to emit a `hop_to_executor` in such a thunk, because the native method, as part of its calling convention, will already emit the same hop in its prologue. The code between the thunk and the native method does not access any isolated state, and is fully-synthesized.
Risk: Low
Risk Detail: This change is very small focused on avoiding an unnecessary compiler crash.
Reward: Medium
Reward Details: Fixes a compiler crash.
Original PR: https://github.com/apple/swift/pull/38552
Issue: rdar://80130628
Code Reviewed By: Joe Groff & Doug Gregor
Testing Details: Regression test is included.