### PR TITLE
[Runtime] Resume to the generic executor in the absence of an override.

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -955,7 +955,7 @@ static AsyncTask *swift_continuation_initImpl(ContinuationAsyncContext *context,
   // Set the current executor as the target executor unless there's
   // an executor override.
   if (!flags.hasExecutorOverride())
-    context->ResumeToExecutor = swift_task_getCurrentExecutor();
+    context->ResumeToExecutor = ExecutorRef::generic();
 
   // We can initialize this with a relaxed store because resumption
   // must happen-after this call.


### PR DESCRIPTION
Without this fix, we saw a crash involving URLSession where we'd hit
assertions or corruption in the runtime in various forms:
- Assertion on trying to enqueue work onto a zombie actor.
- job->SchedulerPrivate being overwritten (crash in getNextJobInQueue).
- *(job->SchedulerPrivate) being overwritten (crash in getAsPreprocessedJob
  right after call to getNextJobInQueue).

I haven't been able to create a minimal crashing example yet, but manual
testing shows this does fix the issue.

Fixes rdar://79859254.