### PR TITLE
[5.5] [Runtime] Resume to the generic executor in the absence of an override.

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -942,7 +942,7 @@ AsyncTask *swift::swift_continuation_init(ContinuationAsyncContext *context,
   // Set the current executor as the target executor unless there's
   // an executor override.
   if (!flags.hasExecutorOverride())
-    context->ResumeToExecutor = swift_task_getCurrentExecutor();
+    context->ResumeToExecutor = ExecutorRef::generic();
 
   // We can initialize this with a relaxed store because resumption
   // must happen-after this call.


### PR DESCRIPTION
Without this fix, we saw a crash involving URLSession where we'd hit
assertions or corruption in the runtime in various forms:
- Assertion on trying to enqueue work onto a zombie actor.
- job->SchedulerPrivate being overwritten (crash in getNextJobInQueue).
- *(job->SchedulerPrivate) being overwritten (crash in getAsPreprocessedJob
  right after call to getNextJobInQueue).

I haven't been able to create a minimal crashing example yet, but manual
testing shows this does fix the issue.

Fixes rdar://79859254.

(cherry picked from commit d348fd90d4c1b1c889ce7d352d5d8e9c32e5c178)