### PR TITLE
Re-working async-main

### DIFF
--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -156,8 +156,11 @@ struct SILDeclRef {
     /// The main entry-point function. This may reference a SourceFile for a
     /// top-level main, or a decl for e.g an @main decl.
     EntryPoint,
+
+    /// The asynchronous main entry-point function.
+    AsyncEntryPoint,
   };
-  
+
   /// The AST node represented by this SILDeclRef.
   Loc loc;
   /// The Kind of this SILDeclRef.
@@ -230,6 +233,9 @@ struct SILDeclRef {
 
   /// Produces a SILDeclRef for a synthetic main entry-point such as @main.
   static SILDeclRef getMainDeclEntryPoint(ValueDecl *decl);
+
+  /// Produces a SILDeclRef for the synthesized async main entry-point
+  static SILDeclRef getAsyncMainDeclEntryPoint(ValueDecl *decl);
 
   /// Produces a SILDeclRef for the entry-point of a main FileUnit.
   static SILDeclRef getMainFileEntryPoint(FileUnit *file);

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -474,6 +474,7 @@ namespace {
       case SILDeclRef::Kind::PropertyWrapperBackingInitializer:
       case SILDeclRef::Kind::PropertyWrapperInitFromProjectedValue:
       case SILDeclRef::Kind::EntryPoint:
+      case SILDeclRef::Kind::AsyncEntryPoint:
         llvm_unreachable("Method does not have a selector");
 
       case SILDeclRef::Kind::Destroyer:

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2526,6 +2526,9 @@ static CanSILFunctionType getNativeSILFunctionType(
     case SILDeclRef::Kind::Deallocator:
       return getSILFunctionTypeForConventions(DeallocatorConventions());
 
+    case SILDeclRef::Kind::AsyncEntryPoint:
+      return getSILFunctionTypeForConventions(
+          DefaultConventions(NormalParameterConvention::Guaranteed));
     case SILDeclRef::Kind::EntryPoint:
       llvm_unreachable("Handled by getSILFunctionTypeForAbstractCFunction");
     }
@@ -3071,6 +3074,7 @@ static ObjCSelectorFamily getObjCSelectorFamily(SILDeclRef c) {
   case SILDeclRef::Kind::PropertyWrapperBackingInitializer:
   case SILDeclRef::Kind::PropertyWrapperInitFromProjectedValue:
   case SILDeclRef::Kind::EntryPoint:
+  case SILDeclRef::Kind::AsyncEntryPoint:
     llvm_unreachable("Unexpected Kind of foreign SILDeclRef");
   }
 
@@ -3343,6 +3347,8 @@ TypeConverter::getDeclRefRepresentation(SILDeclRef c) {
     case SILDeclRef::Kind::IVarDestroyer:
       return SILFunctionTypeRepresentation::Method;
 
+    case SILDeclRef::Kind::AsyncEntryPoint:
+      return SILFunctionTypeRepresentation::Thin;
     case SILDeclRef::Kind::EntryPoint:
       return SILFunctionTypeRepresentation::CFunctionPointer;
   }
@@ -4170,6 +4176,7 @@ static AbstractFunctionDecl *getBridgedFunction(SILDeclRef declRef) {
   case SILDeclRef::Kind::IVarInitializer:
   case SILDeclRef::Kind::IVarDestroyer:
   case SILDeclRef::Kind::EntryPoint:
+  case SILDeclRef::Kind::AsyncEntryPoint:
     return nullptr;
   }
   llvm_unreachable("bad SILDeclRef kind");

--- a/lib/SIL/IR/SILLocation.cpp
+++ b/lib/SIL/IR/SILLocation.cpp
@@ -42,7 +42,7 @@ SourceLoc SILLocation::getSourceLoc() const {
 
   // Don't crash if the location is a FilenameAndLocation.
   // TODO: this is a workaround until rdar://problem/25225083 is implemented.
-  if (isFilenameAndLocation())
+  if (getStorageKind() == FilenameAndLocationKind)
     return SourceLoc();
 
   return getSourceLoc(getPrimaryASTNode());

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -316,6 +316,7 @@ void SILDeclRef::print(raw_ostream &OS) const {
   switch (kind) {
   case SILDeclRef::Kind::Func:
   case SILDeclRef::Kind::EntryPoint:
+  case SILDeclRef::Kind::AsyncEntryPoint:
     break;
   case SILDeclRef::Kind::Allocator:
     OS << "!allocator";

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1039,6 +1039,7 @@ void SILGenModule::emitFunctionDefinition(SILDeclRef constant, SILFunction *f) {
     postEmitFunction(constant, f);
     return;
   }
+  case SILDeclRef::Kind::AsyncEntryPoint:
   case SILDeclRef::Kind::EntryPoint: {
     f->setBare(IsBare);
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -338,24 +338,15 @@ SILGenModule::getConformanceToBridgedStoredNSError(SILLocation loc, Type type) {
   return SwiftModule->lookupConformance(type, proto);
 }
 
-static FuncDecl *lookupConcurrencyIntrinsic(ASTContext &C,
-                                            Optional<FuncDecl*> &cache,
-                                            StringRef name) {
+static FuncDecl *lookupIntrinsic(ModuleDecl &module,
+                                 Optional<FuncDecl *> &cache, Identifier name) {
   if (cache)
     return *cache;
-  
-  auto *module = C.getLoadedModule(C.Id_Concurrency);
-  if (!module) {
-    cache = nullptr;
-    return nullptr;
-  }
-  
-  SmallVector<ValueDecl *, 1> decls;
-  module->lookupQualified(module,
-                     DeclNameRef(C.getIdentifier(name)),
-                     NL_QualifiedDefault | NL_IncludeUsableFromInline,
-                     decls);
 
+  SmallVector<ValueDecl *, 1> decls;
+  module.lookupQualified(&module, DeclNameRef(name),
+                         NL_QualifiedDefault | NL_IncludeUsableFromInline,
+                         decls);
   if (decls.size() != 1) {
     cache = nullptr;
     return nullptr;
@@ -363,6 +354,18 @@ static FuncDecl *lookupConcurrencyIntrinsic(ASTContext &C,
   auto func = dyn_cast<FuncDecl>(decls[0]);
   cache = func;
   return func;
+}
+
+static FuncDecl *lookupConcurrencyIntrinsic(ASTContext &C,
+                                            Optional<FuncDecl *> &cache,
+                                            StringRef name) {
+  auto *module = C.getLoadedModule(C.Id_Concurrency);
+  if (!module) {
+    cache = nullptr;
+    return nullptr;
+  }
+
+  return lookupIntrinsic(*module, cache, C.getIdentifier(name));
 }
 
 FuncDecl *

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -131,6 +131,11 @@ public:
   Optional<FuncDecl*> ResumeUnsafeThrowingContinuationWithError;
   Optional<FuncDecl*> CheckExpectedExecutor;
 
+  Optional<FuncDecl *> AsyncMainDrainQueue;
+  Optional<FuncDecl *> GetMainExecutor;
+  Optional<FuncDecl *> SwiftJobRun;
+  Optional<FuncDecl *> ExitFunc;
+
 public:
   SILGenModule(SILModule &M, ModuleDecl *SM);
 
@@ -516,6 +521,15 @@ public:
   FuncDecl *getRunTaskForBridgedAsyncMethod();
   /// Retrieve the _Concurrency._checkExpectedExecutor intrinsic.
   FuncDecl *getCheckExpectedExecutor();
+
+  /// Retrieve the _Concurrency._asyncMainDrainQueue intrinsic.
+  FuncDecl *getAsyncMainDrainQueue();
+  /// Retrieve the _Concurrency._getMainExecutor intrinsic.
+  FuncDecl *getGetMainExecutor();
+  /// Retrieve the _Concurrency._swiftJobRun intrinsic.
+  FuncDecl *getSwiftJobRun();
+  // Retrieve the _SwiftConcurrencyShims.exit intrinsic.
+  FuncDecl *getExit();
 
   SILFunction *getKeyPathProjectionCoroutine(bool isReadAccess,
                                              KeyPathTypeKind typeKind);

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1402,9 +1402,10 @@ emitFunctionArgumentForAsyncTaskEntryPoint(SILGenFunction &SGF,
 }
 
 // Emit SIL for the named builtin: createAsyncTask.
-static ManagedValue emitBuiltinCreateAsyncTask(
-    SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
-    ArrayRef<ManagedValue> args, SGFContext C) {
+ManagedValue emitBuiltinCreateAsyncTask(SILGenFunction &SGF, SILLocation loc,
+                                        SubstitutionMap subs,
+                                        ArrayRef<ManagedValue> args,
+                                        SGFContext C) {
   ASTContext &ctx = SGF.getASTContext();
   auto flags = args[0].forward(SGF);
 

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -868,23 +868,14 @@ void SILGenFunction::emitAsyncMainThreadStart(SILDeclRef entryPoint) {
 
   B.setInsertionPoint(entryBlock);
 
-  /// Generates a reinterpret_cast for converting
-  /// Builtin.Job -> UnownedJob
-  /// Builtin.Executor -> UnownedSerialExecutor
-  /// These are used by _swiftJobRun, which, ABI-wise, could take
-  /// Builtin.Job or Builtin.Executor, but doesn't.
-  auto createExplodyCastForCall =
-      [this, &moduleLoc](SILValue originalValue, FuncDecl *jobRunFuncDecl,
-                         uint32_t paramIndex) -> SILValue {
-    // The type coming from the _swiftJobRun function
-    Type apiType = jobRunFuncDecl->getParameters()->get(paramIndex)->getType();
-    SILType apiSILType =
-        SILType::getPrimitiveObjectType(apiType->getCanonicalType());
+  auto wrapCallArgs = [this, &moduleLoc](SILValue originalValue, FuncDecl *fd,
+                            uint32_t paramIndex) -> SILValue {
+    Type parameterType = fd->getParameters()->get(paramIndex)->getType();
+    SILType paramSILType = SILType::getPrimitiveObjectType(parameterType->getCanonicalType());
     // If the types are the same, we don't need to do anything!
-    if (apiSILType == originalValue->getType())
+    if (paramSILType == originalValue->getType())
       return originalValue;
-    return this->B.createUncheckedReinterpretCast(moduleLoc, originalValue,
-                                                  apiSILType);
+    return this->B.createStruct(moduleLoc, paramSILType, originalValue);
   };
 
   // Call CreateAsyncTask
@@ -929,7 +920,7 @@ void SILGenFunction::emitAsyncMainThreadStart(SILDeclRef entryPoint) {
       moduleLoc,
       ctx.getIdentifier(getBuiltinName(BuiltinValueKind::ConvertTaskToJob)),
       JobType, {}, {task});
-  jobResult = createExplodyCastForCall(jobResult, swiftJobRunFuncDecl, 0);
+  jobResult = wrapCallArgs(jobResult, swiftJobRunFuncDecl, 0);
 
   // Get main executor
   FuncDecl *getMainExecutorFuncDecl = SGM.getGetMainExecutor();
@@ -939,7 +930,7 @@ void SILGenFunction::emitAsyncMainThreadStart(SILDeclRef entryPoint) {
   SILValue getMainExeutorFunc =
       B.createFunctionRefFor(moduleLoc, getMainExeutorSILFunc);
   SILValue mainExecutor = B.createApply(moduleLoc, getMainExeutorFunc, {}, {});
-  mainExecutor = createExplodyCastForCall(mainExecutor, swiftJobRunFuncDecl, 1);
+  mainExecutor = wrapCallArgs(mainExecutor, swiftJobRunFuncDecl, 1);
 
   // Run first part synchronously
   B.createApply(moduleLoc, swiftJobRunFunc, {}, {jobResult, mainExecutor});

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -900,6 +900,7 @@ void SILGenFunction::emitAsyncMainThreadStart(SILDeclRef entryPoint) {
 
   // Emit the CreateAsyncTask builtin
   TaskCreateFlags taskCreationFlagMask(0);
+  taskCreationFlagMask.setInheritContext(true);
   SILValue taskFlags =
       emitWrapIntegerLiteral(moduleLoc, getLoweredType(ctx.getIntType()),
                              taskCreationFlagMask.getOpaqueValue());

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -141,6 +141,7 @@ DeclName SILGenModule::getMagicFunctionName(SILDeclRef ref) {
   case SILDeclRef::Kind::EnumElement:
     return getMagicFunctionName(cast<EnumElementDecl>(ref.getDecl())
                                   ->getDeclContext());
+  case SILDeclRef::Kind::AsyncEntryPoint:
   case SILDeclRef::Kind::EntryPoint:
     auto *file = ref.getDecl()->getDeclContext()->getParentSourceFile();
     return getMagicFunctionName(file);

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -19,6 +19,7 @@
 #include "RValue.h"
 #include "SILGenFunctionBuilder.h"
 #include "Scope.h"
+#include "swift/ABI/MetadataValues.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/FileUnit.h"
@@ -563,14 +564,26 @@ void SILGenFunction::emitClosure(AbstractClosureExpr *ace) {
   emitEpilog(ace);
 }
 
+ManagedValue emitBuiltinCreateAsyncTask(SILGenFunction &SGF, SILLocation loc,
+                                        SubstitutionMap subs,
+                                        ArrayRef<ManagedValue> args,
+                                        SGFContext C);
+
 void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
   // Create the argc and argv arguments.
   auto entry = B.getInsertionBB();
   auto paramTypeIter = F.getConventions()
                            .getParameterSILTypes(getTypeExpansionContext())
                            .begin();
-  SILValue argc = entry->createFunctionArgument(*paramTypeIter);
-  SILValue argv = entry->createFunctionArgument(*std::next(paramTypeIter));
+
+  SILValue argc;
+  SILValue argv;
+  const bool isAsyncFunc =
+      isa<FuncDecl>(mainDecl) && static_cast<FuncDecl *>(mainDecl)->hasAsync();
+  if (!isAsyncFunc) {
+    argc = entry->createFunctionArgument(*paramTypeIter);
+    argv = entry->createFunctionArgument(*std::next(paramTypeIter));
+  }
 
   switch (mainDecl->getArtificialMainKind()) {
   case ArtificialMainKind::UIApplicationMain: {
@@ -777,13 +790,32 @@ void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
     auto builtinInt32Type = SILType::getBuiltinIntegerType(32, getASTContext());
 
     auto *exitBlock = createBasicBlock();
-    B.setInsertionPoint(exitBlock);
     SILValue exitCode =
         exitBlock->createPhiArgument(builtinInt32Type, OwnershipKind::None);
-    auto returnType = F.getConventions().getSingleSILResultType(B.getTypeExpansionContext());
-    if (exitCode->getType() != returnType)
-      exitCode = B.createStruct(moduleLoc, returnType, exitCode);
-    B.createReturn(moduleLoc, exitCode);
+    B.setInsertionPoint(exitBlock);
+
+    if (!mainFunc->hasAsync()) {
+      auto returnType = F.getConventions().getSingleSILResultType(
+          B.getTypeExpansionContext());
+      if (exitCode->getType() != returnType)
+        exitCode = B.createStruct(moduleLoc, returnType, exitCode);
+      B.createReturn(moduleLoc, exitCode);
+    } else {
+      FuncDecl *exitFuncDecl = SGM.getExit();
+      assert(exitFuncDecl && "Failed to find exit function declaration");
+      SILFunction *exitSILFunc = SGM.getFunction(
+          SILDeclRef(exitFuncDecl, SILDeclRef::Kind::Func, /*isForeign*/ true),
+          NotForDefinition);
+
+      SILFunctionType &funcType =
+          *exitSILFunc->getLoweredType().getAs<SILFunctionType>();
+      SILType retType = SILType::getPrimitiveObjectType(
+          funcType.getParameters().front().getInterfaceType());
+      exitCode = B.createStruct(moduleLoc, retType, exitCode);
+      SILValue exitCall = B.createFunctionRef(moduleLoc, exitSILFunc);
+      B.createApply(moduleLoc, exitCall, {}, {exitCode});
+      B.createUnreachable(moduleLoc);
+    }
 
     if (mainFunc->hasThrows()) {
       auto *successBlock = createBasicBlock();
@@ -819,6 +851,107 @@ void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
     return;
   }
   }
+}
+
+void SILGenFunction::emitAsyncMainThreadStart(SILDeclRef entryPoint) {
+  auto moduleLoc = RegularLocation::getModuleLocation();
+  auto *entryBlock = B.getInsertionBB();
+  auto paramTypeIter = F.getConventions()
+                           .getParameterSILTypes(getTypeExpansionContext())
+                           .begin();
+
+  entryBlock->createFunctionArgument(*paramTypeIter);            // argc
+  entryBlock->createFunctionArgument(*std::next(paramTypeIter)); // argv
+
+  // Lookup necessary functions
+  swift::ASTContext &ctx = entryPoint.getDecl()->getASTContext();
+
+  B.setInsertionPoint(entryBlock);
+
+  /// Generates a reinterpret_cast for converting
+  /// Builtin.Job -> UnownedJob
+  /// Builtin.Executor -> UnownedSerialExecutor
+  /// These are used by _swiftJobRun, which, ABI-wise, could take
+  /// Builtin.Job or Builtin.Executor, but doesn't.
+  auto createExplodyCastForCall =
+      [this, &moduleLoc](SILValue originalValue, FuncDecl *jobRunFuncDecl,
+                         uint32_t paramIndex) -> SILValue {
+    // The type coming from the _swiftJobRun function
+    Type apiType = jobRunFuncDecl->getParameters()->get(paramIndex)->getType();
+    SILType apiSILType =
+        SILType::getPrimitiveObjectType(apiType->getCanonicalType());
+    // If the types are the same, we don't need to do anything!
+    if (apiSILType == originalValue->getType())
+      return originalValue;
+    return this->B.createUncheckedReinterpretCast(moduleLoc, originalValue,
+                                                  apiSILType);
+  };
+
+  // Call CreateAsyncTask
+  FuncDecl *builtinDecl = cast<FuncDecl>(getBuiltinValueDecl(
+      getASTContext(),
+      ctx.getIdentifier(getBuiltinName(BuiltinValueKind::CreateAsyncTask))));
+
+  auto subs = SubstitutionMap::get(builtinDecl->getGenericSignature(),
+                                   {TupleType::getEmpty(ctx)},
+                                   ArrayRef<ProtocolConformanceRef>{});
+
+  SILValue mainFunctionRef = emitGlobalFunctionRef(moduleLoc, entryPoint);
+
+  // Emit the CreateAsyncTask builtin
+  TaskCreateFlags taskCreationFlagMask(0);
+  SILValue taskFlags =
+      emitWrapIntegerLiteral(moduleLoc, getLoweredType(ctx.getIntType()),
+                             taskCreationFlagMask.getOpaqueValue());
+
+  SILValue task =
+      emitBuiltinCreateAsyncTask(*this, moduleLoc, subs,
+                                 {ManagedValue::forUnmanaged(taskFlags),
+                                  ManagedValue::forUnmanaged(mainFunctionRef)},
+                                 {})
+          .forward(*this);
+  DestructureTupleInst *structure = B.createDestructureTuple(moduleLoc, task);
+  task = structure->getResult(0);
+
+  // Get swiftJobRun
+  FuncDecl *swiftJobRunFuncDecl = SGM.getSwiftJobRun();
+  SILFunction *swiftJobRunSILFunc =
+      SGM.getFunction(SILDeclRef(swiftJobRunFuncDecl, SILDeclRef::Kind::Func),
+                      NotForDefinition);
+  SILValue swiftJobRunFunc =
+      B.createFunctionRefFor(moduleLoc, swiftJobRunSILFunc);
+
+  // Convert task to job
+  SILType JobType = SILType::getPrimitiveObjectType(
+      getBuiltinType(ctx, "Job")->getCanonicalType());
+  SILValue jobResult = B.createBuiltin(
+      moduleLoc,
+      ctx.getIdentifier(getBuiltinName(BuiltinValueKind::ConvertTaskToJob)),
+      JobType, {}, {task});
+  jobResult = createExplodyCastForCall(jobResult, swiftJobRunFuncDecl, 0);
+
+  // Get main executor
+  FuncDecl *getMainExecutorFuncDecl = SGM.getGetMainExecutor();
+  SILFunction *getMainExeutorSILFunc = SGM.getFunction(
+      SILDeclRef(getMainExecutorFuncDecl, SILDeclRef::Kind::Func),
+      NotForDefinition);
+  SILValue getMainExeutorFunc =
+      B.createFunctionRefFor(moduleLoc, getMainExeutorSILFunc);
+  SILValue mainExecutor = B.createApply(moduleLoc, getMainExeutorFunc, {}, {});
+  mainExecutor = createExplodyCastForCall(mainExecutor, swiftJobRunFuncDecl, 1);
+
+  // Run first part synchronously
+  B.createApply(moduleLoc, swiftJobRunFunc, {}, {jobResult, mainExecutor});
+
+  // Start Main loop!
+  FuncDecl *drainQueueFuncDecl = SGM.getAsyncMainDrainQueue();
+  SILFunction *drainQueueSILFunc = SGM.getFunction(
+      SILDeclRef(drainQueueFuncDecl, SILDeclRef::Kind::Func), NotForDefinition);
+  SILValue drainQueueFunc =
+      B.createFunctionRefFor(moduleLoc, drainQueueSILFunc);
+  B.createApply(moduleLoc, drainQueueFunc, {}, {});
+  B.createUnreachable(moduleLoc);
+  return;
 }
 
 void SILGenFunction::emitGeneratorFunction(SILDeclRef function, Expr *value,

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -638,6 +638,9 @@ public:
   /// application based on a main type and optionally a main type.
   void emitArtificialTopLevel(Decl *mainDecl);
 
+  /// Generate code into @main for starting the async main on the main thread.
+  void emitAsyncMainThreadStart(SILDeclRef entryPoint);
+
   /// Generates code for a class deallocating destructor. This
   /// calls the destroying destructor and then deallocates 'self'.
   void emitDeallocatingDestructor(DestructorDecl *dd);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1888,41 +1888,29 @@ synthesizeMainBody(AbstractFunctionDecl *fn, void *arg) {
   Expr *returnedExpr;
 
   if (mainFunction->hasAsync()) {
-    // Pass main into _runAsyncMain(_ asyncFunc: () async throws -> ())
-    // Resulting $main looks like:
-    // $main() { _runAsyncMain(main) }
+    // Ensure that the concurrency module is loaded
     auto *concurrencyModule = context.getLoadedModule(context.Id_Concurrency);
     if (!concurrencyModule) {
       context.Diags.diagnose(mainFunction->getAsyncLoc(),
                              diag::async_main_no_concurrency);
       auto result = new (context) ErrorExpr(mainFunction->getSourceRange());
-      SmallVector<ASTNode, 1> stmts;
-      stmts.push_back(result);
-      auto body = BraceStmt::create(context, SourceLoc(), stmts,
-                                    SourceLoc(), /*Implicit*/true);
-
+      ASTNode stmts[] = {result};
+      auto body = BraceStmt::create(context, SourceLoc(), stmts, SourceLoc(),
+                                    /*Implicit*/ true);
       return std::make_pair(body, /*typechecked*/true);
     }
 
-    SmallVector<ValueDecl *, 1> decls;
-    concurrencyModule->lookupQualified(
-        concurrencyModule,
-        DeclNameRef(context.getIdentifier("_runAsyncMain")),
-        NL_QualifiedDefault | NL_IncludeUsableFromInline,
-        decls);
-    assert(!decls.empty() && "Failed to find _runAsyncMain");
-    FuncDecl *runner = cast<FuncDecl>(decls[0]);
-
-    auto asyncRunnerDeclRef = ConcreteDeclRef(runner, substitutionMap);
-
-    DeclRefExpr *funcExpr = new (context) DeclRefExpr(asyncRunnerDeclRef,
-                                                      DeclNameLoc(),
-                                                      /*implicit=*/true);
-    funcExpr->setType(runner->getInterfaceType());
-    auto *argList =
-        ArgumentList::forImplicitUnlabeled(context, {memberRefExpr});
-    auto *callExpr = CallExpr::createImplicit(context, funcExpr, argList);
-    returnedExpr = callExpr;
+    // $main() async { await main() }
+    Expr *awaitExpr =
+        new (context) AwaitExpr(callExpr->getLoc(), callExpr,
+                                context.TheEmptyTupleType, /*implicit*/ true);
+    if (mainFunction->hasThrows()) {
+      // $main() async throws { try await main() }
+      awaitExpr =
+          new (context) TryExpr(callExpr->getLoc(), awaitExpr,
+                                context.TheEmptyTupleType, /*implicit*/ true);
+    }
+    returnedExpr = awaitExpr;
   } else if (mainFunction->hasThrows()) {
     auto *tryExpr = new (context) TryExpr(
         callExpr->getLoc(), callExpr, context.TheEmptyTupleType, /*implicit=*/true);
@@ -2039,7 +2027,7 @@ SynthesizeMainFunctionRequest::evaluate(Evaluator &evaluator,
       DeclName(context, DeclBaseName(context.Id_MainEntryPoint),
                ParameterList::createEmpty(context)),
       /*NameLoc=*/SourceLoc(),
-      /*Async=*/false,
+      /*Async=*/mainFunction->hasAsync(),
       /*Throws=*/mainFunction->hasThrows(),
       /*GenericParams=*/nullptr, ParameterList::createEmpty(context),
       /*FnRetType=*/TupleType::getEmpty(context), declContext);
@@ -2501,7 +2489,7 @@ static FuncDecl *findSimilarAccessor(DeclNameRef replacedVarName,
   }
 
   assert(!isa<FuncDecl>(results[0]));
-  
+
   auto *origStorage = cast<AbstractStorageDecl>(results[0]);
   if (forDynamicReplacement && !origStorage->isDynamic()) {
     Diags.diagnose(attr->getLocation(),

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -753,7 +753,11 @@ func _enqueueJobGlobalWithDelay(_ delay: UInt64, _ task: Builtin.Job)
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_asyncMainDrainQueue")
-public func _asyncMainDrainQueue() -> Never
+internal func _asyncMainDrainQueue() -> Never
+
+@available(SwiftStdlib 5.5, *)
+@_silgen_name("swift_task_getMainExecutor")
+internal func _getMainExecutor() -> Builtin.Executor
 
 @available(SwiftStdlib 5.5, *)
 public func _runAsyncMain(@_unsafeSendable _ asyncFun: @escaping () async throws -> ()) {

--- a/test/Concurrency/Runtime/async_task_priority_current.swift
+++ b/test/Concurrency/Runtime/async_task_priority_current.swift
@@ -18,9 +18,18 @@ extension TaskPriority: CustomStringConvertible {
 }
 
 @available(SwiftStdlib 5.5, *)
+@main struct Main {
+  static func main() async {
+    print("main priority: \(Task.currentPriority)") // CHECK: main priority: TaskPriority(rawValue: [[#MAIN_PRIORITY:]])
+    await test_detach()
+    await test_multiple_lo_indirectly_escalated()
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
 func test_detach() async {
   let a1 = Task.currentPriority
-  print("a1: \(a1)") // CHECK: TaskPriority(rawValue: 25)
+  print("a1: \(a1)") // CHECK: a1: TaskPriority(rawValue: [[#MAIN_PRIORITY]])
 
   // Note: remember to detach using a higher priority, otherwise a lower one
   // might be escalated by the get() and we could see `default` in the detached
@@ -30,8 +39,15 @@ func test_detach() async {
     print("a2: \(a2)") // CHECK: a2: TaskPriority(rawValue: 25)
   }.get()
 
-  let a3 = Task.currentPriority
-  print("a3: \(a3)") // CHECK: a3: TaskPriority(rawValue: 25)
+  await detach(priority: .default) {
+    let a3 = Task.currentPriority
+    // The priority of 'a3' may either be 21 (default) or elevated to that of
+    // the main function, whichever is greater.
+    print("a3: \(a3)") // CHECK: a3: TaskPriority(rawValue: [[#max(MAIN_PRIORITY,21)]]
+  }.get()
+
+  let a4 = Task.currentPriority
+  print("a4: \(a4)") // CHECK: a4: TaskPriority(rawValue: [[#MAIN_PRIORITY]])
 }
 
 @available(SwiftStdlib 5.5, *)
@@ -66,10 +82,4 @@ func test_multiple_lo_indirectly_escalated() async {
   print("default done") // CHECK: default done
 }
 
-@available(SwiftStdlib 5.5, *)
-@main struct Main {
-  static func main() async {
-    await test_detach()
-    await test_multiple_lo_indirectly_escalated()
-  }
-}
+

--- a/test/Concurrency/Runtime/async_task_priority_current.swift
+++ b/test/Concurrency/Runtime/async_task_priority_current.swift
@@ -20,7 +20,7 @@ extension TaskPriority: CustomStringConvertible {
 @available(SwiftStdlib 5.5, *)
 func test_detach() async {
   let a1 = Task.currentPriority
-  print("a1: \(a1)") // CHECK: TaskPriority(rawValue: 21)
+  print("a1: \(a1)") // CHECK: TaskPriority(rawValue: 25)
 
   // Note: remember to detach using a higher priority, otherwise a lower one
   // might be escalated by the get() and we could see `default` in the detached
@@ -31,7 +31,7 @@ func test_detach() async {
   }.get()
 
   let a3 = Task.currentPriority
-  print("a3: \(a3)") // CHECK: a3: TaskPriority(rawValue: 21)
+  print("a3: \(a3)") // CHECK: a3: TaskPriority(rawValue: 25)
 }
 
 @available(SwiftStdlib 5.5, *)

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -dump-ast  -disable-availability-checking -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-AST
+// RUN: %target-swift-frontend -emit-sil -disable-availability-checking -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-SIL
 // RUN: %target-build-swift  -Xfrontend -disable-availability-checking -Xfrontend -parse-as-library %s -o %t_binary
 // RUN: %target-run %t_binary | %FileCheck %s --check-prefix=CHECK-EXEC
 
@@ -15,29 +15,67 @@ func asyncFunc() async {
 }
 
 @main struct MyProgram {
-  static func main() async {
+  static func main() async throws {
     await asyncFunc()
   }
 }
 
 // CHECK-EXEC: Hello World!
 
-// CHECK-AST-LABEL: "main()" interface
-// CHECK-AST:       (await_expr type='()'
-// CHECK-AST-NEXT:    (call_expr type='()'
-// CHECK-AST-NEXT:       (declref_expr type='() async -> ()'
-// CHECK-AST-SAME:        decl=async_main.(file).asyncFunc()@
+// static MyProgram.main()
+// CHECK-SIL-LABEL: sil hidden @$s10async_main9MyProgramV0B0yyYaKFZ : $@convention(method) @async (@thin MyProgram.Type) -> @error Error
 
-// CHECK-AST-LABEL: (func_decl implicit "$main()" interface
-// CHECK-AST:       (brace_stmt
-// CHECK-AST-NEXT:    (return_stmt implicit
-// CHECK-AST-NEXT:      (call_expr implicit type='()'
-// CHECK-AST-NEXT:        (declref_expr implicit
-// CHECK-AST-SAME:             type='(@escaping () async throws -> ()) -> ()'
-// CHECK-AST-SAME:             decl=_Concurrency.(file)._runAsyncMain
-// CHECK-AST-SAME:             function_ref=single
-// CHECK-AST-NEXT:        (argument_list
-// CHECK-AST-NEXT:          (argument
-// CHECK-AST-NEXT:            (function_conversion_expr implicit type='() async throws -> ()'
-// CHECK-AST-NEXT:            (dot_syntax_call_expr
-// CHECK-AST-NEXT:            (autoclosure_expr implicit type='(MyProgram.Type) -> () async -> ()'
+
+// static MyProgram.$main()
+// CHECK-SIL-LABEL: sil hidden @$s10async_main9MyProgramV5$mainyyYaKFZ : $@convention(method) @async (@thin MyProgram.Type) -> @error Error
+
+
+// async_Main
+// CHECK-SIL_LABEL: sil hidden @async_Main : $@convention(thin) @async () -> () {
+// call main
+// CHECK-SIL:  %0 = metatype $@thin MyProgram.Type             // user: %2
+// CHECK-SIL-NEXT:  // function_ref static MyProgram.$main()
+// CHECK-SIL-NEXT:  %1 = function_ref @$s10async_main9MyProgramV5$mainyyYaKFZ : $@convention(method) @async (@thin MyProgram.Type) -> @error Error // user: %2
+// CHECK-SIL-NEXT:  try_apply %1(%0) : $@convention(method) @async (@thin MyProgram.Type) -> @error Error, normal bb1, error bb2 // id: %2
+
+// unwrap error and exit or explode
+// CHECK-SIL: bb1(%3 : $()):
+// CHECK-SIL-NEXT:  %4 = integer_literal $Builtin.Int32, 0
+// CHECK-SIL-NEXT:  %5 = struct $Int32 (%4 : $Builtin.Int32)
+// CHECK-SIL-NEXT:  // function_ref exit
+// CHECK-SIL-NEXT:  %6 = function_ref @exit : $@convention(c) (Int32) -> Never
+// CHECK-SIL-NEXT:  %7 = apply %6(%5) : $@convention(c) (Int32) -> Never
+// CHECK-SIL-NEXT:  unreachable
+
+// CHECK-SIL: bb2(%9 : $Error):
+// CHECK-SIL-NEXT:  %10 = builtin "errorInMain"(%9 : $Error) : $()
+// CHECK-SIL-NEXT:  unreachable
+
+// main
+// CHECK-SIL-LABEL: sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+
+// CHECK-SIL:       // function_ref async_Main
+// CHECK-SIL-NEXT:  %2 = function_ref @async_Main : $@convention(thin) @async () -> ()
+// CHECK-SIL-NEXT:  %3 = integer_literal $Builtin.Int64, 21
+// CHECK-SIL-NEXT:  %4 = struct $Int (%3 : $Builtin.Int64)
+// CHECK-SIL-NEXT:  %5 = metatype $@thick ().Type
+// CHECK-SIL-NEXT:  %6 = init_existential_metatype %5 : $@thick ().Type, $@thick Any.Type
+// CHECK-SIL-NEXT:  // function_ref thunk for @escaping @convention(thin) @async () -> ()
+// CHECK-SIL-NEXT:  %7 = function_ref @$sIetH_yts5Error_pIegHrzo_TR : $@convention(thin) @async (@convention(thin) @async () -> ()) -> (@out (), @error Error)
+// CHECK-SIL-NEXT:  %8 = partial_apply [callee_guaranteed] %7(%2) : $@convention(thin) @async (@convention(thin) @async () -> ()) -> (@out (), @error Error)
+// CHECK-SIL-NEXT:  %9 = convert_function %8 : $@async @callee_guaranteed () -> (@out (), @error Error) to $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>
+// CHECK-SIL-NEXT:  %10 = builtin "createAsyncTask"<()>(%4 : $Int, %6 : $@thick Any.Type, %9 : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>) : $(Builtin.NativeObject, Builtin.RawPointer)
+// CHECK-SIL-NEXT:  %11 = tuple_extract %10 : $(Builtin.NativeObject, Builtin.RawPointer), 0
+// CHECK-SIL-NEXT:  // function_ref swift_job_run
+// CHECK-SIL-NEXT:  %12 = function_ref @swift_job_run : $@convention(thin) (UnownedJob, UnownedSerialExecutor) -> ()
+// CHECK-SIL-NEXT:  %13 = builtin "convertTaskToJob"(%11 : $Builtin.NativeObject) : $Builtin.Job
+// CHECK-SIL-NEXT:  %14 = unchecked_trivial_bit_cast %13 : $Builtin.Job to $UnownedJob
+// CHECK-SIL-NEXT:  // function_ref swift_task_getMainExecutor
+// CHECK-SIL-NEXT:  %15 = function_ref @swift_task_getMainExecutor : $@convention(thin) () -> Builtin.Executor
+// CHECK-SIL-NEXT:  %16 = apply %15() : $@convention(thin) () -> Builtin.Executor
+// CHECK-SIL-NEXT:  %17 = unchecked_trivial_bit_cast %16 : $Builtin.Executor to $UnownedSerialExecutor
+// CHECK-SIL-NEXT:  %18 = apply %12(%14, %17) : $@convention(thin) (UnownedJob, UnownedSerialExecutor) -> ()
+// CHECK-SIL-NEXT:  // function_ref swift_task_asyncMainDrainQueue
+// CHECK-SIL-NEXT:  %19 = function_ref @swift_task_asyncMainDrainQueue : $@convention(thin) () -> Never
+// CHECK-SIL-NEXT:  %20 = apply %19() : $@convention(thin) () -> Never
+// CHECK-SIL-NEXT:  unreachable

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -56,7 +56,7 @@ func asyncFunc() async {
 
 // CHECK-SIL:       // function_ref async_Main
 // CHECK-SIL-NEXT:  %2 = function_ref @async_Main : $@convention(thin) @async () -> ()
-// CHECK-SIL-NEXT:  %3 = integer_literal $Builtin.Int64, 21
+// CHECK-SIL-NEXT:  %3 = integer_literal $Builtin.Int64, 2048
 // CHECK-SIL-NEXT:  %4 = struct $Int (%3 : $Builtin.Int64)
 // CHECK-SIL-NEXT:  %5 = metatype $@thick ().Type
 // CHECK-SIL-NEXT:  %6 = init_existential_metatype %5 : $@thick ().Type, $@thick Any.Type

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -69,11 +69,11 @@ func asyncFunc() async {
 // CHECK-SIL-NEXT:  // function_ref swift_job_run
 // CHECK-SIL-NEXT:  %12 = function_ref @swift_job_run : $@convention(thin) (UnownedJob, UnownedSerialExecutor) -> ()
 // CHECK-SIL-NEXT:  %13 = builtin "convertTaskToJob"(%11 : $Builtin.NativeObject) : $Builtin.Job
-// CHECK-SIL-NEXT:  %14 = unchecked_trivial_bit_cast %13 : $Builtin.Job to $UnownedJob
+// CHECK-SIL-NEXT:  %14 = struct $UnownedJob (%13 : $Builtin.Job)
 // CHECK-SIL-NEXT:  // function_ref swift_task_getMainExecutor
 // CHECK-SIL-NEXT:  %15 = function_ref @swift_task_getMainExecutor : $@convention(thin) () -> Builtin.Executor
 // CHECK-SIL-NEXT:  %16 = apply %15() : $@convention(thin) () -> Builtin.Executor
-// CHECK-SIL-NEXT:  %17 = unchecked_trivial_bit_cast %16 : $Builtin.Executor to $UnownedSerialExecutor
+// CHECK-SIL-NEXT:  %17 = struct $UnownedSerialExecutor (%16 : $Builtin.Executor)
 // CHECK-SIL-NEXT:  %18 = apply %12(%14, %17) : $@convention(thin) (UnownedJob, UnownedSerialExecutor) -> ()
 // CHECK-SIL-NEXT:  // function_ref swift_task_asyncMainDrainQueue
 // CHECK-SIL-NEXT:  %19 = function_ref @swift_task_asyncMainDrainQueue : $@convention(thin) () -> Never


### PR DESCRIPTION
I've been working on changing the behavior of the async-main function a little bit, as well as getting the bits implemented in the compiler rather than in the standard library. This will allow us to change things later without needing to update the standard library dramatically.

The issues with the current implementation of the async-main is in the interaction between Swift and ObjC. The current implementation has an implicit suspension point before main ever gets to run. If folks have enqueued things in a static constructor in ObjC, those will get enqueued before the main task does, so their tasks will run before main. This is not desirable.

This doesn't quite work yet. If it were written in Swift, the current implementation would look something like 

```swift
struct Main {
  static func main() async throws { }
}

public func baseMain() -> Never {
  let flags = _taskCreateFlags(...)
  let (task, _) = Builtin.CreateAsynTask(flags, Main.main())
  _swiftJobRun(task)
  _asyncMainDrainQueue()
}
```

Unfortunately, unless you put an `exit` and an `_exitInMain` in your main function, this results in a program that never finishes since we get stuck draining the main queue.

What we really want is something more like

```swift
struct Main {
  @MainActor
  static func main() async throws { }
}

@MainActor
public func baseMain() -> Never {
  let wrappedMain = { @MainActor () async -> () in
    do {
       try Main.main()
    catch {
        _errorInMain(error)
    }
  }

  let flags = _taskCreateFlags(...)
  let (task, _) = Builtin.CreateAsynTask(flags, wrappedMain)
  _swiftJobRun(task)
  _asyncMainDrainQueue()
}
```

I still need to figure out how to create a separate thunk to wrap the call to the actual main function in.
I'm just putting this up to start getting eyes on it.

rdar://80027250