### PR TITLE
[5.5] Eat -experimental-emit-module-separately

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -579,6 +579,10 @@ def experimental_cxx_stdlib :
   Separate<["-"], "experimental-cxx-stdlib">,
   HelpText<"C++ standard library to use; forwarded to Clang's -stdlib flag">;
 
+def experimental_emit_module_separately:
+  Flag<["-"], "experimental-emit-module-separately">,
+  Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
+  HelpText<"Schedule a swift module emission job instead of a merge-modules job (new Driver only)">;
 
 // Diagnostic control options
 def suppress_warnings : Flag<["-"], "suppress-warnings">,

--- a/test/Driver/emit_module_separately.swift
+++ b/test/Driver/emit_module_separately.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: touch %t/file1.swift %t/file2.swift %t/file3.swift
+// RUN: echo 'public func main() {}' >%t/main.swift
+//
+// RUN: %target-swiftc_driver -driver-skip-execution -c -emit-module -module-name main -driver-print-jobs %s -experimental-emit-module-separately %t/file1.swift %t/file2.swift %t/file3.swift %t/main.swift 2>^1 | %FileCheck -check-prefix NORMAL %s
+// RUN: %target-swiftc_driver -driver-skip-execution -c -emit-module -module-name main -driver-print-jobs -incremental %s -experimental-emit-module-separately %t/file1.swift %t/file2.swift %t/file3.swift %t/main.swift 2>^1 | %FileCheck -check-prefix INCREMENTAL %s
+
+// Just test that we eat this argument. Only the new driver knows what to do
+// here. The legacy driver will just fall back to a merge-modules job as usual.
+// NORMAL: swift
+// NORMAL-NOT: -experimental-emit-module-separately
+
+// INCREMENTAL: swift
+// INCREMENTAL: -merge-modules
+// INCREMENTAL-NOT: -experimental-emit-module-separately


### PR DESCRIPTION
Cherry picked from #38609 

-------

SourceKit invokes the legacy driver. Providing this flag in the IDE
means the command lines SourceKit forms to run semantic requests in the
editor are all invalid.

Teach the legacy driver to eat this flag.

rdar://80811565