### PR TITLE
[nfc] `getMembers` -> `lookupDirect` when looking for member `rawValue`.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8252,10 +8252,9 @@ Type TypeBase::getSwiftNewtypeUnderlyingType() {
     return {};
 
   // Underlying type is the type of rawValue
-  for (auto member : structDecl->getMembers())
-    if (auto varDecl = dyn_cast<VarDecl>(member))
-      if (varDecl->getName() == getASTContext().Id_rawValue)
-        return varDecl->getType();
+  auto results = structDecl->lookupDirect(getASTContext().Id_rawValue);
+  if (results.size() && isa<VarDecl>(results.front()))
+    return cast<VarDecl>(results.front())->getType();
 
   return {};
 }

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -92,7 +92,7 @@
 // PRINT-NEXT:  extension CFNewType {
 // PRINT-NEXT:    static let MyCFNewTypeValue: CFNewType
 // PRINT-NEXT:    static let MyCFNewTypeValueUnauditedButConst: CFNewType
-// PRINT-NEXT:    static var MyCFNewTypeValueUnaudited: Unmanaged<CFString>
+// PRINT-NEXT:    static var MyCFNewTypeValueUnaudited: Unmanaged<CFNewType>
 // PRINT-NEXT:  }
 // PRINT-NEXT:  func FooAudited() -> CFNewType
 // PRINT-NEXT:  func FooUnaudited() -> Unmanaged<CFString>


### PR DESCRIPTION
One of many to come.