### PR TITLE
[Test] Add @escaping to async refactoring tests

### DIFF
--- a/test/SourceKit/Refactoring/basic.swift
+++ b/test/SourceKit/Refactoring/basic.swift
@@ -116,7 +116,7 @@ HasInitWithDefaultArgs(y: 45, z: 89)
 func `hasBackticks`(`x`: Int) {}
 `hasBackticks`(`x`:2)
 
-func hasAsyncAlternative(completion: (String?, Error?) -> Void) { }
+func hasAsyncAlternative(completion: @escaping (String?, Error?) -> Void) { }
 func hasCallToAsyncAlternative() {
   hasAsyncAlternative { str, err in print(str!) }
 }

--- a/test/refactoring/ConvertAsync/async_attribute_added.swift
+++ b/test/refactoring/ConvertAsync/async_attribute_added.swift
@@ -1,3 +1,5 @@
+// REQUIRES: concurrency
+
 // RUN: %empty-directory(%t)
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -enable-experimental-concurrency | %FileCheck -check-prefix=SIMPLE %s

--- a/test/refactoring/ConvertAsync/basic.swift
+++ b/test/refactoring/ConvertAsync/basic.swift
@@ -1,3 +1,5 @@
+// REQUIRES: concurrency
+
 // RUN: %empty-directory(%t)
 
 enum CustomError: Error {
@@ -35,7 +37,7 @@ func simple(completion: (String) -> Void) { }
 // ASYNC-SIMPLE-NEXT: func simple() async -> String { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-SIMPLENOLABEL %s
-func simpleWithoutLabel(_ completion: (String) -> Void) { }
+func simpleWithoutLabel(_ completion: @escaping (String) -> Void) { }
 // ASYNC-SIMPLENOLABEL: {
 // ASYNC-SIMPLENOLABEL-NEXT: Task {
 // ASYNC-SIMPLENOLABEL-NEXT: let result = await simpleWithoutLabel()
@@ -45,7 +47,7 @@ func simpleWithoutLabel(_ completion: (String) -> Void) { }
 // ASYNC-SIMPLENOLABEL: func simpleWithoutLabel() async -> String { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-SIMPLEWITHARG %s
-func simpleWithArg(a: Int, completion: (String) -> Void) { }
+func simpleWithArg(a: Int, completion: @escaping (String) -> Void) { }
 // ASYNC-SIMPLEWITHARG: {
 // ASYNC-SIMPLEWITHARG-NEXT: Task {
 // ASYNC-SIMPLEWITHARG-NEXT: let result = await simpleWithArg(a: a)
@@ -55,7 +57,7 @@ func simpleWithArg(a: Int, completion: (String) -> Void) { }
 // ASYNC-SIMPLEWITHARG: func simpleWithArg(a: Int) async -> String { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-MULTIPLERESULTS %s
-func multipleResults(completion: (String, Int) -> Void) { }
+func multipleResults(completion: @escaping (String, Int) -> Void) { }
 // ASYNC-MULTIPLERESULTS: {
 // ASYNC-MULTIPLERESULTS-NEXT: Task {
 // ASYNC-MULTIPLERESULTS-NEXT: let result = await multipleResults()
@@ -65,7 +67,7 @@ func multipleResults(completion: (String, Int) -> Void) { }
 // ASYNC-MULTIPLERESULTS: func multipleResults() async -> (String, Int) { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-NONOPTIONALERROR %s
-func nonOptionalError(completion: (String, Error) -> Void) { }
+func nonOptionalError(completion: @escaping (String, Error) -> Void) { }
 // ASYNC-NONOPTIONALERROR: {
 // ASYNC-NONOPTIONALERROR-NEXT: Task {
 // ASYNC-NONOPTIONALERROR-NEXT: let result = await nonOptionalError()
@@ -75,7 +77,7 @@ func nonOptionalError(completion: (String, Error) -> Void) { }
 // ASYNC-NONOPTIONALERROR: func nonOptionalError() async -> (String, Error) { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-NOPARAMS %s
-func noParams(completion: () -> Void) { }
+func noParams(completion: @escaping () -> Void) { }
 // ASYNC-NOPARAMS: {
 // ASYNC-NOPARAMS-NEXT: Task {
 // ASYNC-NOPARAMS-NEXT: await noParams()
@@ -85,7 +87,7 @@ func noParams(completion: () -> Void) { }
 // ASYNC-NOPARAMS: func noParams() async { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-ERROR %s
-func error(completion: (String?, Error?) -> Void) { }
+func error(completion: @escaping (String?, Error?) -> Void) { }
 // ASYNC-ERROR: {
 // ASYNC-ERROR-NEXT: Task {
 // ASYNC-ERROR-NEXT: do {
@@ -98,7 +100,7 @@ func error(completion: (String?, Error?) -> Void) { }
 // ASYNC-ERROR: func error() async throws -> String { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-ERRORONLY %s
-func errorOnly(completion: (Error?) -> Void) { }
+func errorOnly(completion: @escaping (Error?) -> Void) { }
 // ASYNC-ERRORONLY: {
 // ASYNC-ERRORONLY-NEXT: Task {
 // ASYNC-ERRORONLY-NEXT: do {
@@ -112,7 +114,7 @@ func errorOnly(completion: (Error?) -> Void) { }
 // ASYNC-ERRORONLY: func errorOnly() async throws { }
 
 // RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-ERRORNONOPTIONALRESULT %s
-func errorNonOptionalResult(completion: (String, Error?) -> Void) { }
+func errorNonOptionalResult(completion: @escaping (String, Error?) -> Void) { }
 // ASYNC-ERRORNONOPTIONALRESULT: {
 // ASYNC-ERRORNONOPTIONALRESULT-NEXT: Task {
 // ASYNC-ERRORNONOPTIONALRESULT-NEXT: do {
@@ -126,7 +128,7 @@ func errorNonOptionalResult(completion: (String, Error?) -> Void) { }
 // ASYNC-ERRORNONOPTIONALRESULT: func errorNonOptionalResult() async throws -> String { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-CUSTOMERROR %s
-func customError(completion: (String?, CustomError?) -> Void) { }
+func customError(completion: @escaping (String?, CustomError?) -> Void) { }
 // ASYNC-CUSTOMERROR: {
 // ASYNC-CUSTOMERROR-NEXT: Task {
 // ASYNC-CUSTOMERROR-NEXT: do {
@@ -140,7 +142,7 @@ func customError(completion: (String?, CustomError?) -> Void) { }
 // ASYNC-CUSTOMERROR: func customError() async throws -> String { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-ALIAS %s
-func alias(completion: SomeCallback) { }
+func alias(completion: @escaping SomeCallback) { }
 // ASYNC-ALIAS: {
 // ASYNC-ALIAS-NEXT: Task {
 // ASYNC-ALIAS-NEXT: let result = await alias()
@@ -150,7 +152,7 @@ func alias(completion: SomeCallback) { }
 // ASYNC-ALIAS: func alias() async -> String { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-NESTEDALIAS %s
-func nestedAlias(completion: NestedAliasCallback) { }
+func nestedAlias(completion: @escaping NestedAliasCallback) { }
 // ASYNC-NESTEDALIAS: {
 // ASYNC-NESTEDALIAS-NEXT: Task {
 // ASYNC-NESTEDALIAS-NEXT: let result = await nestedAlias()
@@ -160,7 +162,7 @@ func nestedAlias(completion: NestedAliasCallback) { }
 // ASYNC-NESTEDALIAS: func nestedAlias() async -> String { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-SIMPLERESULT %s
-func simpleResult(completion: (Result<String, Never>) -> Void) { }
+func simpleResult(completion: @escaping (Result<String, Never>) -> Void) { }
 // ASYNC-SIMPLERESULT: {
 // ASYNC-SIMPLERESULT-NEXT: Task {
 // ASYNC-SIMPLERESULT-NEXT: let result = await simpleResult()
@@ -170,7 +172,7 @@ func simpleResult(completion: (Result<String, Never>) -> Void) { }
 // ASYNC-SIMPLERESULT: func simpleResult() async -> String { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-ERRORRESULT %s
-func errorResult(completion: (Result<String, Error>) -> Void) { }
+func errorResult(completion: @escaping (Result<String, Error>) -> Void) { }
 // ASYNC-ERRORRESULT: {
 // ASYNC-ERRORRESULT-NEXT: Task {
 // ASYNC-ERRORRESULT-NEXT: do {
@@ -184,7 +186,7 @@ func errorResult(completion: (Result<String, Error>) -> Void) { }
 // ASYNC-ERRORRESULT: func errorResult() async throws -> String { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-CUSTOMERRORRESULT %s
-func customErrorResult(completion: (Result<String, CustomError>) -> Void) { }
+func customErrorResult(completion: @escaping (Result<String, CustomError>) -> Void) { }
 // ASYNC-CUSTOMERRORRESULT: {
 // ASYNC-CUSTOMERRORRESULT-NEXT: Task {
 // ASYNC-CUSTOMERRORRESULT-NEXT: do {
@@ -198,7 +200,7 @@ func customErrorResult(completion: (Result<String, CustomError>) -> Void) { }
 // ASYNC-CUSTOMERRORRESULT: func customErrorResult() async throws -> String { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-ALIASRESULT %s
-func aliasedResult(completion: SomeResultCallback) { }
+func aliasedResult(completion: @escaping SomeResultCallback) { }
 // ASYNC-ALIASRESULT: {
 // ASYNC-ALIASRESULT-NEXT: Task {
 // ASYNC-ALIASRESULT-NEXT: do {
@@ -212,7 +214,7 @@ func aliasedResult(completion: SomeResultCallback) { }
 // ASYNC-ALIASRESULT: func aliasedResult() async throws -> String { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MANY %s
-func many(_ completion: (String, Int) -> Void) { }
+func many(_ completion: @escaping (String, Int) -> Void) { }
 // MANY: {
 // MANY-NEXT: Task {
 // MANY-NEXT: let result = await many()
@@ -222,7 +224,7 @@ func many(_ completion: (String, Int) -> Void) { }
 // MANY: func many() async -> (String, Int) { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=OPTIONAL-SINGLE %s
-func optionalSingle(completion: (String?) -> Void) { }
+func optionalSingle(completion: @escaping (String?) -> Void) { }
 // OPTIONAL-SINGLE: {
 // OPTIONAL-SINGLE-NEXT: Task {
 // OPTIONAL-SINGLE-NEXT: let result = await optionalSingle()
@@ -232,7 +234,7 @@ func optionalSingle(completion: (String?) -> Void) { }
 // OPTIONAL-SINGLE: func optionalSingle() async -> String? { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MANY-OPTIONAL %s
-func manyOptional(_ completion: (String?, Int?) -> Void) { }
+func manyOptional(_ completion: @escaping (String?, Int?) -> Void) { }
 // MANY-OPTIONAL: {
 // MANY-OPTIONAL-NEXT: Task {
 // MANY-OPTIONAL-NEXT: let result = await manyOptional()
@@ -242,7 +244,7 @@ func manyOptional(_ completion: (String?, Int?) -> Void) { }
 // MANY-OPTIONAL: func manyOptional() async -> (String?, Int?) { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MIXED %s
-func mixed(_ completion: (String?, Int) -> Void) { }
+func mixed(_ completion: @escaping (String?, Int) -> Void) { }
 // MIXED: {
 // MIXED-NEXT: Task {
 // MIXED-NEXT: let result = await mixed()
@@ -251,8 +253,8 @@ func mixed(_ completion: (String?, Int) -> Void) { }
 // MIXED-NEXT: }
 // MIXED: func mixed() async -> (String?, Int) { }
 
-// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
-func mixedOptionalError(_ completion: (String?, Int, Error?) -> Void) { }
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MIXED-OPTIONAL-ERROR %s
+func mixedOptionalError(_ completion: @escaping (String?, Int, Error?) -> Void) { }
 // MIXED-OPTIONAL-ERROR: {
 // MIXED-OPTIONAL-ERROR-NEXT: Task {
 // MIXED-OPTIONAL-ERROR-NEXT: do {
@@ -266,7 +268,7 @@ func mixedOptionalError(_ completion: (String?, Int, Error?) -> Void) { }
 // MIXED-OPTIONAL-ERROR: func mixedOptionalError() async throws -> (String, Int) { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MIXED-ERROR %s
-func mixedError(_ completion: (String?, Int, Error) -> Void) { }
+func mixedError(_ completion: @escaping (String?, Int, Error) -> Void) { }
 // MIXED-ERROR: {
 // MIXED-ERROR-NEXT: Task {
 // MIXED-ERROR-NEXT: let result = await mixedError()
@@ -276,7 +278,7 @@ func mixedError(_ completion: (String?, Int, Error) -> Void) { }
 // MIXED-ERROR: func mixedError() async -> (String?, Int, Error) { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=GENERIC %s
-func generic<T, R>(completion: (T, R) -> Void) { }
+func generic<T, R>(completion: @escaping (T, R) -> Void) { }
 // GENERIC: {
 // GENERIC-NEXT: Task {
 // GENERIC-NEXT: let result: (T, R) = await generic()
@@ -286,7 +288,7 @@ func generic<T, R>(completion: (T, R) -> Void) { }
 // GENERIC: func generic<T, R>() async -> (T, R) { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=GENERIC-RESULT %s
-func genericResult<T>(completion: (T?, Error?) -> Void) where T: Numeric { }
+func genericResult<T>(completion: @escaping (T?, Error?) -> Void) where T: Numeric { }
 // GENERIC-RESULT: {
 // GENERIC-RESULT-NEXT: Task {
 // GENERIC-RESULT-NEXT: do {
@@ -301,7 +303,7 @@ func genericResult<T>(completion: (T?, Error?) -> Void) where T: Numeric { }
 
 // FIXME: This doesn't compile after refactoring because we aren't using the generic argument `E` in the async method (SR-14560)
 // RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=GENERIC-ERROR %s
-func genericError<E>(completion: (String?, E?) -> Void) where E: Error { }
+func genericError<E>(completion: @escaping (String?, E?) -> Void) where E: Error { }
 // GENERIC-ERROR: {
 // GENERIC-ERROR-NEXT: Task {
 // GENERIC-ERROR-NEXT: do {
@@ -315,7 +317,7 @@ func genericError<E>(completion: (String?, E?) -> Void) where E: Error { }
 // GENERIC-ERROR: func genericError<E>() async throws -> String where E: Error { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=OTHER-NAME %s
-func otherName(execute: (String) -> Void) { }
+func otherName(execute: @escaping (String) -> Void) { }
 // OTHER-NAME: {
 // OTHER-NAME-NEXT: Task {
 // OTHER-NAME-NEXT: let result = await otherName()
@@ -325,7 +327,7 @@ func otherName(execute: (String) -> Void) { }
 // OTHER-NAME: func otherName() async -> String { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=DEFAULT_ARGS %s
-func defaultArgs(a: Int, b: Int = 10, completion: (String) -> Void) { }
+func defaultArgs(a: Int, b: Int = 10, completion: @escaping (String) -> Void) { }
 // DEFAULT_ARGS: {
 // DEFAULT_ARGS-NEXT: Task {
 // DEFAULT_ARGS-NEXT: let result = await defaultArgs(a: a, b: b)
@@ -347,21 +349,21 @@ struct MyStruct {
   init() { }
 
   // RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):3
-  init(completion: (String) -> Void) { }
+  init(completion: @escaping (String) -> Void) { }
 
   func retSelf() -> MyStruct { return self }
 
   // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):10 | %FileCheck -check-prefix=MODIFIERS %s
-  public func publicMember(completion: (String) -> Void) { }
+  public func publicMember(completion: @escaping (String) -> Void) { }
   // MODIFIERS: public func publicMember() async -> String { }
 
   // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=STATIC %s
-  static func staticMember(completion: (String) -> Void) { }
+  static func staticMember(completion: @escaping (String) -> Void) { }
   // STATIC: static func staticMember() async -> String { }
 
   // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+2):11 | %FileCheck -check-prefix=DEPRECATED %s
   @available(*, deprecated, message: "Deprecated")
-  private func deprecated(completion: (String) -> Void) { }
+  private func deprecated(completion: @escaping (String) -> Void) { }
   // DEPRECATED: @available(*, deprecated, message: "Deprecated")
   // DEPRECATED-NEXT: private func deprecated() async -> String { }
 }
@@ -370,7 +372,7 @@ func retStruct() -> MyStruct { return MyStruct() }
 protocol MyProtocol {
   // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=PROTO-MEMBER %s
   // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=PROTO-MEMBER %s
-  func protoMember(completion: (String) -> Void)
+  func protoMember(completion: @escaping (String) -> Void)
   // PROTO-MEMBER: func protoMember() async -> String{{$}}
 }
 
@@ -379,55 +381,52 @@ protocol MyProtocol {
 func nonCompletion(a: Int) { }
 // NON-COMPLETION: func nonCompletion(a: Int) async { }
 
+// Converted for now, but we shouldn't count this as a completion handler
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=NON-ESCAPING-COMPLETION %s
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NON-ESCAPING-COMPLETION %s
+func nonEscapingCompletion(completion: (Int) -> Void) { }
+// NON-ESCAPING-COMPLETION: func nonEscapingCompletion() async -> Int { }
+
 // RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+2):1
 // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MULTIPLE-RESULTS %s
-func multipleResults(completion: (Result<String, Error>, Result<String, Error>) -> Void) { }
-// MULTIPLE-RESULTS: func multipleResults(completion: (Result<String, Error>, Result<String, Error>) -> Void) async { }
+func multipleResults(completion: @escaping (Result<String, Error>, Result<String, Error>) -> Void) { }
+// MULTIPLE-RESULTS: func multipleResults(completion: @escaping (Result<String, Error>, Result<String, Error>) -> Void) async { }
 
 // RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+2):1
 // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NOT-LAST %s
-func completionNotLast(completion: (String) -> Void, a: Int) { }
-// NOT-LAST: func completionNotLast(completion: (String) -> Void, a: Int) async { }
+func completionNotLast(completion: @escaping (String) -> Void, a: Int) { }
+// NOT-LAST: func completionNotLast(completion: @escaping (String) -> Void, a: Int) async { }
 
 // RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+2):1
 // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NON-VOID %s
-func nonVoid(completion: (String) -> Void) -> Int { return 0 }
-// NON-VOID: func nonVoid(completion: (String) -> Void) async -> Int { return 0 }
+func nonVoid(completion: @escaping (String) -> Void) -> Int { return 0 }
+// NON-VOID: func nonVoid(completion: @escaping (String) -> Void) async -> Int { return 0 }
 
 // RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+2):1
 // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=COMPLETION-NON-VOID %s
-func completionNonVoid(completion: (String) -> Int) -> Void { }
-// COMPLETION-NON-VOID: func completionNonVoid(completion: (String) -> Int) async -> Void { }
+func completionNonVoid(completion: @escaping (String) -> Int) -> Void { }
+// COMPLETION-NON-VOID: func completionNonVoid(completion: @escaping (String) -> Int) async -> Void { }
 
 // RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+2):1
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1
-func alreadyThrows(completion: (String) -> Void) throws { }
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ALREADY-THROWS %s
+func alreadyThrows(completion: @escaping (String) -> Void) throws { }
+// ALREADY-THROWS: func alreadyThrows(completion: @escaping (String) -> Void) async throws { }
 
 // RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+2):1
 // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=AUTO-CLOSURE %s
-func noParamAutoclosure(completion: @autoclosure () -> Void) { }
-// AUTO-CLOSURE: func noParamAutoclosure(completion: @autoclosure () -> Void) async { }
+func noParamAutoclosure(completion: @escaping @autoclosure () -> Void) { }
+// AUTO-CLOSURE: func noParamAutoclosure(completion: @escaping @autoclosure () -> Void) async { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix BLOCK-CONVENTION %s
-func blockConvention(completion: @convention(block) () -> Void) { }
+func blockConvention(completion: @escaping @convention(block) () -> Void) { }
 // BLOCK-CONVENTION: func blockConvention() async { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix C-CONVENTION %s
-func cConvention(completion: @convention(c) () -> Void) { }
+func cConvention(completion: @escaping @convention(c) () -> Void) { }
 // C-CONVENTION: func cConvention() async { }
 
-// RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix VOID-HANDLER %s
-func voidCompletion(completion: (Void) -> Void) {}
-// VOID-HANDLER: {
-// VOID-HANDLER-NEXT: Task {
-// VOID-HANDLER-NEXT: await voidCompletion()
-// VOID-HANDLER-NEXT: completion(())
-// VOID-HANDLER-NEXT: }
-// VOID-HANDLER-NEXT: }
-// VOID-HANDLER: func voidCompletion() async {}
-
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix OPT-VOID-AND-ERROR-HANDLER %s
-func optVoidAndErrorCompletion(completion: (Void?, Error?) -> Void) {}
+func optVoidAndErrorCompletion(completion: @escaping (Void?, Error?) -> Void) {}
 // OPT-VOID-AND-ERROR-HANDLER: {
 // OPT-VOID-AND-ERROR-HANDLER-NEXT: Task {
 // OPT-VOID-AND-ERROR-HANDLER-NEXT: do {
@@ -441,7 +440,7 @@ func optVoidAndErrorCompletion(completion: (Void?, Error?) -> Void) {}
 // OPT-VOID-AND-ERROR-HANDLER: func optVoidAndErrorCompletion() async throws {}
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix TOO-MUCH-VOID-AND-ERROR-HANDLER %s
-func tooMuchVoidAndErrorCompletion(completion: (Void?, Void?, Error?) -> Void) {}
+func tooMuchVoidAndErrorCompletion(completion: @escaping (Void?, Void?, Error?) -> Void) {}
 // TOO-MUCH-VOID-AND-ERROR-HANDLER: {
 // TOO-MUCH-VOID-AND-ERROR-HANDLER-NEXT: Task {
 // TOO-MUCH-VOID-AND-ERROR-HANDLER-NEXT: do {
@@ -455,7 +454,7 @@ func tooMuchVoidAndErrorCompletion(completion: (Void?, Void?, Error?) -> Void) {
 // TOO-MUCH-VOID-AND-ERROR-HANDLER: func tooMuchVoidAndErrorCompletion() async throws {}
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix VOID-PROPER-AND-ERROR-HANDLER %s
-func tooVoidProperAndErrorCompletion(completion: (Void?, String?, Error?) -> Void) {}
+func tooVoidProperAndErrorCompletion(completion: @escaping (Void?, String?, Error?) -> Void) {}
 // VOID-PROPER-AND-ERROR-HANDLER: {
 // VOID-PROPER-AND-ERROR-HANDLER-NEXT: Task {
 // VOID-PROPER-AND-ERROR-HANDLER-NEXT: do {
@@ -468,8 +467,8 @@ func tooVoidProperAndErrorCompletion(completion: (Void?, String?, Error?) -> Voi
 // VOID-PROPER-AND-ERROR-HANDLER-NEXT: }
 // VOID-PROPER-AND-ERROR-HANDLER: func tooVoidProperAndErrorCompletion() async throws -> (Void, String) {}
 
-// RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
-func voidAndErrorCompletion(completion: (Void, Error?) -> Void) {}
+// RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix VOID-AND-ERROR-HANDLER %s
+func voidAndErrorCompletion(completion: @escaping (Void, Error?) -> Void) {}
 // VOID-AND-ERROR-HANDLER: {
 // VOID-AND-ERROR-HANDLER-NEXT: Task {
 // VOID-AND-ERROR-HANDLER-NEXT: do {
@@ -487,7 +486,7 @@ func voidAndErrorCompletion(completion: (Void, Error?) -> Void) {}
 
 class MyClass {}
 
-func simpleClassParam(completion: (MyClass) -> Void) { }
+func simpleClassParam(completion: @escaping (MyClass) -> Void) { }
 
 // TODO: We cannot check that the refactored code compiles because 'simple' and
 // friends aren't refactored when only invoking the refactoring on this function.
@@ -718,11 +717,11 @@ func testCConvention() {
 func testVoidAndError() {
   // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=VOID-AND-ERROR-CALL %s
   optVoidAndErrorCompletion { v, err in
-    print("opt void and error completion \(v)")
+    print("opt void and error completion \(String(describing: v))")
   }
 }
 // VOID-AND-ERROR-CALL: try await optVoidAndErrorCompletion(){{$}}
-// VOID-AND-ERROR-CALL-NEXT: {{^}}print("opt void and error completion \(<#v#>)"){{$}}
+// VOID-AND-ERROR-CALL-NEXT: {{^}}print("opt void and error completion \(String(describing: <#v#>))"){{$}}
 
 // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=VOID-AND-ERROR-CALL2 %s
 func testVoidAndError2() {

--- a/test/refactoring/ConvertAsync/check_compiles.swift
+++ b/test/refactoring/ConvertAsync/check_compiles.swift
@@ -1,6 +1,8 @@
+// REQUIRES: concurrency
+
 // RUN: %empty-directory(%t)
 
-func simple(completion: () -> Void) { }
+func simple(completion: @escaping () -> Void) { }
 func anything() -> Bool { return true }
 
 // RUN: %swift-frontend -typecheck %s

--- a/test/refactoring/ConvertAsync/convert_async_renames.swift
+++ b/test/refactoring/ConvertAsync/convert_async_renames.swift
@@ -1,12 +1,14 @@
+// REQUIRES: concurrency
+
 // RUN: %empty-directory(%t)
 
-func simple(_ completion: (String) -> Void) { }
+func simple(_ completion: @escaping (String) -> Void) { }
 func simple() async -> String { }
 
-func simpleArg(arg: String, _ completion: (String) -> Void) { }
+func simpleArg(arg: String, _ completion: @escaping (String) -> Void) { }
 func simpleArg(arg: String) async -> String { }
 
-func simpleErr(arg: String, _ completion: (String?, Error?) -> Void) { }
+func simpleErr(arg: String, _ completion: @escaping (String?, Error?) -> Void) { }
 func simpleErr(arg: String) async throws -> String { }
 
 func whatever() -> Bool { return true }

--- a/test/refactoring/ConvertAsync/convert_async_wrapper.swift
+++ b/test/refactoring/ConvertAsync/convert_async_wrapper.swift
@@ -1,3 +1,5 @@
+// REQUIRES: concurrency
+
 // RUN: %empty-directory(%t)
 
 enum CustomError : Error {

--- a/test/refactoring/ConvertAsync/convert_bool.swift
+++ b/test/refactoring/ConvertAsync/convert_bool.swift
@@ -7,9 +7,9 @@
 import Foundation
 import ConvertBoolObjC
 
-func boolWithErr(completion: (Bool, Error?) -> Void) {}
-func multipleBoolWithErr(completion: (String?, Bool, Bool, Error?) -> Void) {}
-func optionalBoolWithErr(completion: (String?, Bool?, Bool, Error?) -> Void) {}
+func boolWithErr(completion: @escaping (Bool, Error?) -> Void) {}
+func multipleBoolWithErr(completion: @escaping (String?, Bool, Bool, Error?) -> Void) {}
+func optionalBoolWithErr(completion: @escaping (String?, Bool?, Bool, Error?) -> Void) {}
 
 // All 7 of the below should generate the same refactoring.
 
@@ -185,7 +185,7 @@ boolWithErr { success, err in
     }
   }
   if !success {
-    for x: Int in [] {
+    for _: Int in [] {
       fatalError("oh no \(err!)")
     }
   }
@@ -212,7 +212,7 @@ boolWithErr { success, err in
 // BOOL-DONT-HANDLE2-NEXT:   }
 // BOOL-DONT-HANDLE2-NEXT: }
 // BOOL-DONT-HANDLE2-NEXT: if !success {
-// BOOL-DONT-HANDLE2-NEXT:   for x: Int in [] {
+// BOOL-DONT-HANDLE2-NEXT:   for _: Int in [] {
 // BOOL-DONT-HANDLE2-NEXT:     fatalError("oh no \(<#err#>!)")
 // BOOL-DONT-HANDLE2-NEXT:   }
 // BOOL-DONT-HANDLE2-NEXT: }
@@ -221,7 +221,7 @@ boolWithErr { success, err in
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -I %S/Inputs -I %t %clang-importer-sdk-nosource | %FileCheck -check-prefix=BOOL-DONT-HANDLE3 %s
 boolWithErr { success, err in
   if !success {
-    fatalError("oh no maybe \(err)")
+    fatalError("oh no maybe \(String(describing: err))")
   }
   print("not err")
 }
@@ -230,7 +230,7 @@ boolWithErr { success, err in
 
 // BOOL-DONT-HANDLE3:      let success = try await boolWithErr()
 // BOOL-DONT-HANDLE3-NEXT: if !success {
-// BOOL-DONT-HANDLE3-NEXT:   fatalError("oh no maybe \(<#err#>)")
+// BOOL-DONT-HANDLE3-NEXT:   fatalError("oh no maybe \(String(describing: <#err#>))")
 // BOOL-DONT-HANDLE3-NEXT: }
 // BOOL-DONT-HANDLE3-NEXT: print("not err")
 
@@ -342,7 +342,7 @@ optionalBoolWithErr { str, optBool, b, err in
     print("d \(err!)")
   }
   if optBool == false {
-    print("e \(err)")
+    print("e \(String(describing: err))")
   }
   if optBool != true {
     print("f \(err!)")
@@ -360,7 +360,7 @@ optionalBoolWithErr { str, optBool, b, err in
 // OPT-BOOL-WITH-ERR-NEXT:   let (str, optBool, b) = try await optionalBoolWithErr()
 // OPT-BOOL-WITH-ERR-NEXT:   print("a \(<#err#>!)")
 // OPT-BOOL-WITH-ERR-NEXT:   if <#optBool#> == false {
-// OPT-BOOL-WITH-ERR-NEXT:     print("e \(<#err#>)")
+// OPT-BOOL-WITH-ERR-NEXT:     print("e \(String(describing: <#err#>))")
 // OPT-BOOL-WITH-ERR-NEXT:   }
 // OPT-BOOL-WITH-ERR-NEXT:   if <#optBool#> != true {
 // OPT-BOOL-WITH-ERR-NEXT:     print("f \(<#err#>!)")
@@ -426,7 +426,7 @@ ClassWithHandlerMethods.secondBoolFlagFailure("") { str, unrelated, failure, err
   if failure && err != nil {
     print("neat")
   }
-  if failure, let err = err {
+  if failure, let _ = err {
     print("neato")
   }
 }

--- a/test/refactoring/ConvertAsync/convert_invalid.swift
+++ b/test/refactoring/ConvertAsync/convert_invalid.swift
@@ -1,4 +1,8 @@
-func callbackIntWithError(_ completion: (Int8, Error?) -> Void) {}
+// REQUIRES: concurrency
+
+// RUN: %empty-directory(%t)
+
+func callbackIntWithError(_ completion: @escaping (Bool, Error?) -> Void) {}
 
 // rdar://79864182
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=INVALID-COND %s
@@ -12,11 +16,10 @@ callbackIntWithError { x, err in
 // INVALID-COND-NEXT:   print("ok")
 // INVALID-COND-NEXT: }
 
-
 func withoutAsyncAlternative(closure: (Int) -> Void) {}
 
 // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=UNKNOWN-ERROR-IN-CONTINUATION %s
-func testUnknownErrorInContinuation(completionHandler: (Int?, Error?) -> Void) {
+func testUnknownErrorInContinuation(completionHandler: @escaping (Int?, Error?) -> Void) {
   withoutAsyncAlternative { theValue in
     completionHandler(theValue, MyUndefinedError())
   }

--- a/test/refactoring/ConvertAsync/convert_params_multi.swift
+++ b/test/refactoring/ConvertAsync/convert_params_multi.swift
@@ -1,6 +1,8 @@
-func manyWithError(_ completion: (String?, Int?, Error?) -> Void) { }
-func mixed(_ completion: (String?, Int) -> Void) { }
-func mixedError(_ completion: (String?, Int, Error?) -> Void) { }
+// REQUIRES: concurrency
+
+func manyWithError(_ completion: @escaping (String?, Int?, Error?) -> Void) { }
+func mixed(_ completion: @escaping (String?, Int) -> Void) { }
+func mixedError(_ completion: @escaping (String?, Int, Error?) -> Void) { }
 
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MANYBOUND %s
 manyWithError { res1, res2, err in

--- a/test/refactoring/ConvertAsync/convert_params_single.swift
+++ b/test/refactoring/ConvertAsync/convert_params_single.swift
@@ -1,6 +1,8 @@
-func withError(_ completion: (String?, Error?) -> Void) { }
-func notOptional(_ completion: (String, Error?) -> Void) { }
-func errorOnly(_ completion: (Error?) -> Void) { }
+// REQUIRES: concurrency
+
+func withError(_ completion: @escaping (String?, Error?) -> Void) { }
+func notOptional(_ completion: @escaping (String, Error?) -> Void) { }
+func errorOnly(_ completion: @escaping (Error?) -> Void) { }
 func test(_ str: String) -> Bool { return false }
 
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNRELATED %s

--- a/test/refactoring/ConvertAsync/convert_pattern.swift
+++ b/test/refactoring/ConvertAsync/convert_pattern.swift
@@ -1,20 +1,22 @@
+// REQUIRES: concurrency
+
 // RUN: %empty-directory(%t)
 
 enum E : Error { case e }
 
-func anyCompletion(_ completion: (Any?, Error?) -> Void) {}
-func anyResultCompletion(_ completion: (Result<Any?, Error>) -> Void) {}
+func anyCompletion(_ completion: @escaping (Any?, Error?) -> Void) {}
+func anyResultCompletion(_ completion: @escaping (Result<Any?, Error>) -> Void) {}
 
-func stringTupleParam(_ completion: ((String, String)?, Error?) -> Void) {}
+func stringTupleParam(_ completion: @escaping ((String, String)?, Error?) -> Void) {}
 func stringTupleParam() async throws -> (String, String) {}
 
-func stringTupleResult(_ completion: (Result<(String, String), Error>) -> Void) {}
+func stringTupleResult(_ completion: @escaping (Result<(String, String), Error>) -> Void) {}
 func stringTupleResult() async throws -> (String, String) {}
 
-func mixedTupleResult(_ completion: (Result<((Int, Float), String), Error>) -> Void) {}
+func mixedTupleResult(_ completion: @escaping (Result<((Int, Float), String), Error>) -> Void) {}
 func mixedTupleResult() async throws -> ((Int, Float), String) {}
 
-func multipleTupleParam(_ completion: ((String, String)?, (Int, Int)?, Error?) -> Void) {}
+func multipleTupleParam(_ completion: @escaping ((String, String)?, (Int, Int)?, Error?) -> Void) {}
 func multipleTupleParam() async throws -> ((String, String), (Int, Int)) {}
 
 func testPatterns() async throws {
@@ -385,7 +387,7 @@ func testPatterns() async throws {
 }
 
 // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NAME-COLLISION %s
-func testNameCollision(_ completion: () -> Void) {
+func testNameCollision(_ completion: @escaping () -> Void) {
   let a = ""
   stringTupleParam { strs, err in
     guard let (a, b) = strs else { return }
@@ -414,7 +416,7 @@ func testNameCollision(_ completion: () -> Void) {
 // NAME-COLLISION-NEXT: }
 
 // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NAME-COLLISION2 %s
-func testNameCollision2(_ completion: () -> Void) {
+func testNameCollision2(_ completion: @escaping () -> Void) {
   mixedTupleResult { res in
     guard case let .success((x, y), z) = res else { return }
     stringTupleParam { strs, err in

--- a/test/refactoring/ConvertAsync/convert_result.swift
+++ b/test/refactoring/ConvertAsync/convert_result.swift
@@ -1,14 +1,16 @@
-func simple(_ completion: (Result<String, Error>) -> Void) { }
-func simpleWithArg(_ arg: Int, _ completion: (Result<String, Error>) -> Void) { }
-func noError(_ completion: (Result<String, Never>) -> Void) { }
+// REQUIRES: concurrency
+
+func simple(_ completion: @escaping (Result<String, Error>) -> Void) { }
+func simpleWithArg(_ arg: Int, _ completion: @escaping (Result<String, Error>) -> Void) { }
+func noError(_ completion: @escaping (Result<String, Never>) -> Void) { }
 func test(_ str: String) -> Bool { return false }
 
 // RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix VOID-RESULT %s
-func voidResult(completion: (Result<Void, Never>) -> Void) {}
+func voidResult(completion: @escaping (Result<Void, Never>) -> Void) {}
 // VOID-RESULT: func voidResult() async {}
 
 // RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix VOID-AND-ERROR-RESULT %s
-func voidAndErrorResult(completion: (Result<Void, Error>) -> Void) {}
+func voidAndErrorResult(completion: @escaping (Result<Void, Error>) -> Void) {}
 // VOID-AND-ERROR-RESULT: func voidAndErrorResult() async throws {}
 
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=SIMPLE %s

--- a/test/refactoring/ConvertAsync/convert_to_continuation.swift
+++ b/test/refactoring/ConvertAsync/convert_to_continuation.swift
@@ -1,21 +1,21 @@
 // RUN: %empty-directory(%t)
 
-func withAsyncAlternative(completionHandler: (Int) -> Void) {}
+func withAsyncAlternative(completionHandler: @escaping (Int) -> Void) {}
 func withAsyncAlternative() async -> Int { return 42 }
-func withAsyncThrowingAlternative(completionHandler: (Int?, Error?) -> Void) {}
+func withAsyncThrowingAlternative(completionHandler: @escaping (Int?, Error?) -> Void) {}
 func withAsyncThrowingAlternative() async throws -> Int { return 42 }
 
-func withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName(closure: (Int) -> Void) {}
-func withoutAsyncAlternativeBecauseOfReturnValue(completionHandler: (Int) -> Void) -> Bool { return true }
-func withoutAsyncAlternativeThrowing(closure: (Int?, Error?) -> Void) {}
-func withoutAsyncAlternativeThrowingWithMultipleResults(closure: (Int?, String?, Error?) -> Void) {}
-func asyncVoidWithoutAlternative(completionHandler2: () -> Void) {}
-func resultWithoutAlternative(completionHandler2: (Result<Int, Error>) -> Void) {}
+func withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName(closure: @escaping (Int) -> Void) {}
+func withoutAsyncAlternativeBecauseOfReturnValue(completionHandler: @escaping (Int) -> Void) -> Bool { return true }
+func withoutAsyncAlternativeThrowing(closure: @escaping (Int?, Error?) -> Void) {}
+func withoutAsyncAlternativeThrowingWithMultipleResults(closure: @escaping (Int?, String?, Error?) -> Void) {}
+func asyncVoidWithoutAlternative(completionHandler2: @escaping () -> Void) {}
+func resultWithoutAlternative(completionHandler2: @escaping (Result<Int, Error>) -> Void) {}
 
 struct MyError: Error {}
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=CREATE-CONTINUATION %s
-func testCreateContinuation(completionHandler: (Int) -> Void) {
+func testCreateContinuation(completionHandler: @escaping (Int) -> Void) {
   withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName {
     completionHandler($0)
   }
@@ -29,7 +29,7 @@ func testCreateContinuation(completionHandler: (Int) -> Void) {
 // CREATE-CONTINUATION-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=CREATE-CONTINUATION-HANDLER-CALL-IN-PARENS %s
-func testCreateContinuationWithCompletionHandlerCallInParens(completionHandler: (Int) -> Void) {
+func testCreateContinuationWithCompletionHandlerCallInParens(completionHandler: @escaping (Int) -> Void) {
   withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName {
     (completionHandler($0))
   }
@@ -43,7 +43,7 @@ func testCreateContinuationWithCompletionHandlerCallInParens(completionHandler: 
 // CREATE-CONTINUATION-HANDLER-CALL-IN-PARENS-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=CREATE-CONTINUATION-BECAUSE-RETURN-VALUE %s
-func testCreateContinuationBecauseOfReturnValue(completionHandler: (Int) -> Void) {
+func testCreateContinuationBecauseOfReturnValue(completionHandler: @escaping (Int) -> Void) {
   _ = withoutAsyncAlternativeBecauseOfReturnValue {
     completionHandler($0)
   }
@@ -57,7 +57,7 @@ func testCreateContinuationBecauseOfReturnValue(completionHandler: (Int) -> Void
 // CREATE-CONTINUATION-BECAUSE-RETURN-VALUE-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=CREATE-CONTINUATION-BECAUSE-RETURN-VALUE-2 %s
-func testCreateContinuationBecauseOfReturnValue2(completionHandler: (Int) -> Void) {
+func testCreateContinuationBecauseOfReturnValue2(completionHandler: @escaping (Int) -> Void) {
   let x = withoutAsyncAlternativeBecauseOfReturnValue {
     completionHandler($0)
   }
@@ -73,7 +73,7 @@ func testCreateContinuationBecauseOfReturnValue2(completionHandler: (Int) -> Voi
 // CREATE-CONTINUATION-BECAUSE-RETURN-VALUE-2-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=CONTINUATION-IN-NESTED-EXPRESSION %s
-func testCompletionHandlerCallInNestedExpression(completionHandler: (Int) -> Void) {
+func testCompletionHandlerCallInNestedExpression(completionHandler: @escaping (Int) -> Void) {
   print(withoutAsyncAlternativeBecauseOfReturnValue {
     completionHandler($0)
   })
@@ -87,7 +87,7 @@ func testCompletionHandlerCallInNestedExpression(completionHandler: (Int) -> Voi
 // CONTINUATION-IN-NESTED-EXPRESSION-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=THROWING-CONTINUATION %s
-func testThrowingContinuation(completionHandler: (Int?, Error?) -> Void) {
+func testThrowingContinuation(completionHandler: @escaping (Int?, Error?) -> Void) {
   withoutAsyncAlternativeThrowing { (theValue, theError) in
     if let theError = theError {
       completionHandler(nil, theError)
@@ -108,7 +108,7 @@ func testThrowingContinuation(completionHandler: (Int?, Error?) -> Void) {
 // THROWING-CONTINUATION-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT %s
-func testThrowingContinuationRelayingErrorAndResult(completionHandler: (Int?, Error?) -> Void) {
+func testThrowingContinuationRelayingErrorAndResult(completionHandler: @escaping (Int?, Error?) -> Void) {
   withoutAsyncAlternativeThrowing { (theValue, theError) in
     completionHandler(theValue, theError)
   }
@@ -129,7 +129,7 @@ func testThrowingContinuationRelayingErrorAndResult(completionHandler: (Int?, Er
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-RESULT-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT %s
-func testThrowingContinuationRelayingErrorAndComplexResult(completionHandler: (Int?, Error?) -> Void) {
+func testThrowingContinuationRelayingErrorAndComplexResult(completionHandler: @escaping (Int?, Error?) -> Void) {
   withoutAsyncAlternativeThrowing { (theValue, theError) in
     completionHandler(theValue.map({ $0 + 1 }), theError)
   }
@@ -150,7 +150,7 @@ func testThrowingContinuationRelayingErrorAndComplexResult(completionHandler: (I
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS %s
-func testThrowingContinuationRelayingErrorAndTwoComplexResults(completionHandler: (Int?, Int?, Error?) -> Void) {
+func testThrowingContinuationRelayingErrorAndTwoComplexResults(completionHandler: @escaping (Int?, Int?, Error?) -> Void) {
   withoutAsyncAlternativeThrowing { (theValue, theError) in
     completionHandler(theValue.map({ $0 + 1 }), theValue.map({ $0 + 2 }), theError)
   }
@@ -174,7 +174,7 @@ func testThrowingContinuationRelayingErrorAndTwoComplexResults(completionHandler
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT: }
 
 // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE %s
-func testThrowingContinuationRelayingErrorAndComplexResultWithTrailingClosure(completionHandler: (Int?, Error?) -> Void) {
+func testThrowingContinuationRelayingErrorAndComplexResultWithTrailingClosure(completionHandler: @escaping (Int?, Error?) -> Void) {
   withoutAsyncAlternativeThrowing { (theValue, theError) in
     completionHandler(theValue.map { $0 + 1 }, theError)
   }
@@ -195,7 +195,7 @@ func testThrowingContinuationRelayingErrorAndComplexResultWithTrailingClosure(co
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=THROWING-CONTINUATION-ALWAYS-RETURNING-ERROR-AND-RESULT %s
-func testAlwaysReturnBothResultAndCompletionHandler(completionHandler: (Int?, Error?) -> Void) {
+func testAlwaysReturnBothResultAndCompletionHandler(completionHandler: @escaping (Int?, Error?) -> Void) {
   withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName { theValue in
     completionHandler(theValue, MyError())
   }
@@ -209,7 +209,7 @@ func testAlwaysReturnBothResultAndCompletionHandler(completionHandler: (Int?, Er
 // THROWING-CONTINUATION-ALWAYS-RETURNING-ERROR-AND-RESULT-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=AMBIGUOUS-CALL-WITH-ALWAYS-NIL-VARIABLE %s
-func testAmbiguousCallToCompletionHandlerWithAlwaysNilVariable(completionHandler: (Int?, Error?) -> Void) {
+func testAmbiguousCallToCompletionHandlerWithAlwaysNilVariable(completionHandler: @escaping (Int?, Error?) -> Void) {
   withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName { theValue in
     let error: Error? = nil
     completionHandler(theValue, error)
@@ -229,7 +229,7 @@ func testAmbiguousCallToCompletionHandlerWithAlwaysNilVariable(completionHandler
 // AMBIGUOUS-CALL-WITH-ALWAYS-NIL-VARIABLE-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=PREVIOUS-COMPLETION-HANDLER-CALL %s
-func testPreviousCompletionHandlerCall(completionHandler: (Int) -> Void) {
+func testPreviousCompletionHandlerCall(completionHandler: @escaping (Int) -> Void) {
   withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName {
     print($0)
   }
@@ -249,7 +249,7 @@ func testPreviousCompletionHandlerCall(completionHandler: (Int) -> Void) {
 // PREVIOUS-COMPLETION-HANDLER-CALL-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=PREVIOUS-ASYNC-CALL %s
-func testPreviousAsyncCall(completionHandler: (Int) -> Void) {
+func testPreviousAsyncCall(completionHandler: @escaping (Int) -> Void) {
   withAsyncAlternative { message in
     print(message)
   }
@@ -268,7 +268,7 @@ func testPreviousAsyncCall(completionHandler: (Int) -> Void) {
 // PREVIOUS-ASYNC-CALL-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=IN-IF-ELSE %s
-func testInIfElse(completionHandler: (Int) -> Void) {
+func testInIfElse(completionHandler: @escaping (Int) -> Void) {
   if true {
     withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName {
       completionHandler($0)
@@ -295,7 +295,7 @@ func testInIfElse(completionHandler: (Int) -> Void) {
 // IN-IF-ELSE-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-AFTER-CONTINUATION %s
-func testAsyncAfterContinuation(completionHandler: (Int) -> Void) {
+func testAsyncAfterContinuation(completionHandler: @escaping (Int) -> Void) {
   withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName {
     completionHandler($0)
   }
@@ -315,7 +315,7 @@ func testAsyncAfterContinuation(completionHandler: (Int) -> Void) {
 // ASYNC-AFTER-CONTINUATION-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=WITHOUT-ASYNC-NESTED-IN-WITHOUT-ASYNC %s
-func testWithoutAsyncAlternativeNestedInWithoutAsyncAlternative(completionHandler: (Int) -> Void) {
+func testWithoutAsyncAlternativeNestedInWithoutAsyncAlternative(completionHandler: @escaping (Int) -> Void) {
   withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName { firstResult in
     withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName { secondResult in
       completionHandler(firstResult + secondResult)
@@ -334,7 +334,7 @@ func testWithoutAsyncAlternativeNestedInWithoutAsyncAlternative(completionHandle
 
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=WITHOUT-ASYNC-NESTED-IN-ASYNC %s
-func testWithoutAsyncAlternativeNestedInAsyncAlternative(completionHandler: (Int) -> Void) {
+func testWithoutAsyncAlternativeNestedInAsyncAlternative(completionHandler: @escaping (Int) -> Void) {
   withAsyncAlternative { firstResult in
     withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName { secondResult in
       completionHandler(firstResult + secondResult)
@@ -351,7 +351,7 @@ func testWithoutAsyncAlternativeNestedInAsyncAlternative(completionHandler: (Int
 // WITHOUT-ASYNC-NESTED-IN-ASYNC-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-NESTED-IN-WITHOUT-ASYNC %s
-func testAsyncAlternativeNestedInWithoutAsyncAlternative(completionHandler: (Int) -> Void) {
+func testAsyncAlternativeNestedInWithoutAsyncAlternative(completionHandler: @escaping (Int) -> Void) {
   withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName { firstResult in
     withAsyncAlternative { secondResult in
       completionHandler(firstResult + secondResult)
@@ -369,7 +369,7 @@ func testAsyncAlternativeNestedInWithoutAsyncAlternative(completionHandler: (Int
 // ASYNC-NESTED-IN-WITHOUT-ASYNC-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=SHADOW-CONT-NAME %s
-func testShadowContName(completionHandler: (Int) -> Void) {
+func testShadowContName(completionHandler: @escaping (Int) -> Void) {
   withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName { continuation in
     completionHandler(continuation)
   }
@@ -383,7 +383,7 @@ func testShadowContName(completionHandler: (Int) -> Void) {
 // SHADOW-CONT-NAME-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=SHADOW-CONT-NAME-2 %s
-func testShadowContName2(completionHandler: (Int) -> Void) {
+func testShadowContName2(completionHandler: @escaping (Int) -> Void) {
   let continuation = 3
   withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName { result in
     completionHandler(result + continuation)
@@ -399,7 +399,7 @@ func testShadowContName2(completionHandler: (Int) -> Void) {
 // SHADOW-CONT-NAME-2-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=VOID-RETURN %s
-func testVoidReturnValue(completionHandler: () -> Void) {
+func testVoidReturnValue(completionHandler: @escaping () -> Void) {
   asyncVoidWithoutAlternative {
     completionHandler()
   }
@@ -413,7 +413,7 @@ func testVoidReturnValue(completionHandler: () -> Void) {
 // VOID-RETURN-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=SIMPLE-RESULT %s
-func testSimpleResult(completionHandler: (Result<Int, Error>) -> Void) {
+func testSimpleResult(completionHandler: @escaping (Result<Int, Error>) -> Void) {
   resultWithoutAlternative { result in
     completionHandler(result)
   }
@@ -427,7 +427,7 @@ func testSimpleResult(completionHandler: (Result<Int, Error>) -> Void) {
 // SIMPLE-RESULT-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=RESULT-FROM-VALUE-AND-ERROR %s
-func testResultFromValueAndError(completionHandler: (Result<Int, Error>) -> Void) {
+func testResultFromValueAndError(completionHandler: @escaping (Result<Int, Error>) -> Void) {
   withoutAsyncAlternativeThrowing { (value, error) in
     if let error = error {
       completionHandler(.failure(error))
@@ -449,7 +449,7 @@ func testResultFromValueAndError(completionHandler: (Result<Int, Error>) -> Void
 // RESULT-FROM-VALUE-AND-ERROR-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MULTIPLE-RETURN-VALUES-AND-ERROR %s
-func testMultipleReturnValuesAndError(completion: (Int?, String?, Error?) -> Void) {
+func testMultipleReturnValuesAndError(completion: @escaping (Int?, String?, Error?) -> Void) {
   withoutAsyncAlternativeThrowingWithMultipleResults { (first, second, error) in 
     completion(first, second, error)
   }
@@ -473,7 +473,7 @@ func testMultipleReturnValuesAndError(completion: (Int?, String?, Error?) -> Voi
 // MULTIPLE-RETURN-VALUES-AND-ERROR-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NON-OPTIONAL-VALUE-FOR-RESULT-AND-ERROR %s
-func testReturnNonOptionalValuesForResultAndError(completion: (Int?, Error?) -> Void) {
+func testReturnNonOptionalValuesForResultAndError(completion: @escaping (Int?, Error?) -> Void) {
   withoutAsyncAlternativeBecauseOfMismatchedCompletionHandlerName { result in
     completion(1, MyError())
   }
@@ -487,7 +487,7 @@ func testReturnNonOptionalValuesForResultAndError(completion: (Int?, Error?) -> 
 // NON-OPTIONAL-VALUE-FOR-RESULT-AND-ERROR-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT %s
-func testMixedOptionalAnNonOptionaResults(completion: (Int?, String?, Error?) -> Void) {
+func testMixedOptionalAnNonOptionaResults(completion: @escaping (Int?, String?, Error?) -> Void) {
   withoutAsyncAlternativeThrowing { (theResult, error) in
     completion(theResult, "hi", nil)
   }
@@ -504,7 +504,7 @@ func testMixedOptionalAnNonOptionaResults(completion: (Int?, String?, Error?) ->
 // MIXED-OPTIONAL-AND-NON-OPTIONAL-RESULT-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=USE-OPTIONAL-RESULT-AFTER-COMPLETION-HANDLER-CALL %s
-func testUseOptionalResultValueAfterCompletionHandlerCall(completion: (Int?, String?, Error?) -> Void) {
+func testUseOptionalResultValueAfterCompletionHandlerCall(completion: @escaping (Int?, String?, Error?) -> Void) {
   withoutAsyncAlternativeThrowing { (theResult, error) in
     completion(theResult, "hi", nil)
     print(theResult.map { $0 + 1 } as Any)
@@ -524,7 +524,7 @@ func testUseOptionalResultValueAfterCompletionHandlerCall(completion: (Int?, Str
 
 // We shouldn't need to unwrap `theResult` twice here, but the example is silly and I don't care too much.
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=PASS-SAME-RESULT-TWICE %s
-func testPassSameResultTwice(completion: (Int?, Int?, Error?) -> Void) {
+func testPassSameResultTwice(completion: @escaping (Int?, Int?, Error?) -> Void) {
   withoutAsyncAlternativeThrowing { (theResult, error) in
     completion(theResult, theResult, nil)
   }
@@ -545,7 +545,7 @@ func testPassSameResultTwice(completion: (Int?, Int?, Error?) -> Void) {
 
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL %s
-func testUseResultAfterAmbiguousCompletionHandlerCall(completion: (Int?, Error?) -> Void) {
+func testUseResultAfterAmbiguousCompletionHandlerCall(completion: @escaping (Int?, Error?) -> Void) {
   withoutAsyncAlternativeThrowing { (theResult, error) in
     completion(theResult, error)
     print(theResult as Any)
@@ -568,7 +568,7 @@ func testUseResultAfterAmbiguousCompletionHandlerCall(completion: (Int?, Error?)
 // USE-RESULT-AFTER-AMBIGUOUS-HANLDER-CALL-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=TWO-COMPLEITON-HANDLER-CALLS %s
-func testTwoCompletionHandlerCalls(completion: (Int?, Error?) -> Void) {
+func testTwoCompletionHandlerCalls(completion: @escaping (Int?, Error?) -> Void) {
   withoutAsyncAlternativeThrowing { (theResult, error) in
     completion(theResult, error)
     completion(theResult, error)

--- a/test/refactoring/ConvertAsync/errors.swift
+++ b/test/refactoring/ConvertAsync/errors.swift
@@ -1,4 +1,6 @@
-func simple(completion: (String?, Error?) -> Void) { }
+// REQUIRES: concurrency
+
+func simple(completion: @escaping (String?, Error?) -> Void) { }
 
 func mismatches() {
   // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3
@@ -16,4 +18,4 @@ func mismatches() {
 }
 
 // RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
-func missingBody(complete: (Int?, Error?) -> Void)
+func missingBody(complete: @escaping (Int?, Error?) -> Void)

--- a/test/refactoring/ConvertAsync/labeled_closure_params.swift
+++ b/test/refactoring/ConvertAsync/labeled_closure_params.swift
@@ -1,7 +1,9 @@
+// REQUIRES: concurrency
+
 // RUN: %empty-directory(%t)
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MULTIPLE-LABELED-RESULTS %s
-func mutlipleLabeledResults(completion: (_ first: String, _ second: String) -> Void) { }
+func mutlipleLabeledResults(completion: @escaping (_ first: String, _ second: String) -> Void) { }
 // MULTIPLE-LABELED-RESULTS: {
 // MULTIPLE-LABELED-RESULTS-NEXT: Task {
 // MULTIPLE-LABELED-RESULTS-NEXT: let result = await mutlipleLabeledResults()
@@ -11,7 +13,7 @@ func mutlipleLabeledResults(completion: (_ first: String, _ second: String) -> V
 // MULTIPLE-LABELED-RESULTS: func mutlipleLabeledResults() async -> (first: String, second: String) { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MIXED-LABELED-RESULTS %s
-func mixedLabeledResult(completion: (_ first: String, String) -> Void) { }
+func mixedLabeledResult(completion: @escaping (_ first: String, String) -> Void) { }
 // MIXED-LABELED-RESULTS: {
 // MIXED-LABELED-RESULTS-NEXT: Task {
 // MIXED-LABELED-RESULTS-NEXT: let result = await mixedLabeledResult()
@@ -21,7 +23,7 @@ func mixedLabeledResult(completion: (_ first: String, String) -> Void) { }
 // MIXED-LABELED-RESULTS: func mixedLabeledResult() async -> (first: String, String) { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=SINGLE-LABELED-RESULT %s
-func singleLabeledResult(completion: (_ first: String) -> Void) { }
+func singleLabeledResult(completion: @escaping (_ first: String) -> Void) { }
 // SINGLE-LABELED-RESULT: {
 // SINGLE-LABELED-RESULT-NEXT: Task {
 // SINGLE-LABELED-RESULT-NEXT: let result = await singleLabeledResult()
@@ -31,7 +33,7 @@ func singleLabeledResult(completion: (_ first: String) -> Void) { }
 // SINGLE-LABELED-RESULT: func singleLabeledResult() async -> String { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=SINGLE-LABELED-RESULT-WITH-ERROR %s
-func singleLabeledResultWithError(completion: (_ first: String?, _ error: Error?) -> Void) { }
+func singleLabeledResultWithError(completion: @escaping (_ first: String?, _ error: Error?) -> Void) { }
 // SINGLE-LABELED-RESULT-WITH-ERROR: {
 // SINGLE-LABELED-RESULT-WITH-ERROR-NEXT: Task {
 // SINGLE-LABELED-RESULT-WITH-ERROR-NEXT: do {
@@ -45,7 +47,7 @@ func singleLabeledResultWithError(completion: (_ first: String?, _ error: Error?
 // SINGLE-LABELED-RESULT-WITH-ERROR: func singleLabeledResultWithError() async throws -> String { }
 
 // RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MULTIPLE-LABELED-RESULT-WITH-ERROR %s
-func multipleLabeledResultWithError(completion: (_ first: String?, _ second: String?, _ error: Error?) -> Void) { }
+func multipleLabeledResultWithError(completion: @escaping (_ first: String?, _ second: String?, _ error: Error?) -> Void) { }
 // MULTIPLE-LABELED-RESULT-WITH-ERROR: {
 // MULTIPLE-LABELED-RESULT-WITH-ERROR-NEXT: Task {
 // MULTIPLE-LABELED-RESULT-WITH-ERROR-NEXT: do {

--- a/test/refactoring/ConvertAsync/path_classification.swift
+++ b/test/refactoring/ConvertAsync/path_classification.swift
@@ -1,6 +1,8 @@
+// REQUIRES: concurrency
+
 // RUN: %empty-directory(%t)
 
-func simpleWithError(completion: (String?, Error?) -> Void) {}
+func simpleWithError(completion: @escaping (String?, Error?) -> Void) {}
 func simpleWithError() async throws -> String {}
 
 func testPathClassification() async throws {

--- a/test/refactoring/ConvertAsync/variable_as_callback.swift
+++ b/test/refactoring/ConvertAsync/variable_as_callback.swift
@@ -1,3 +1,5 @@
+// REQUIRES: concurrency
+
 // RUN: %empty-directory(%t)
 
 enum CustomError: Error {
@@ -7,64 +9,64 @@ enum CustomError: Error {
 
 typealias SomeCallback = (String) -> Void
 
-func simple(completion: (String) -> Void) { }
+func simple(completion: @escaping (String) -> Void) { }
 func simple() async -> String { }
 
-func simpleWithArg(a: Int, completion: (String) -> Void) { }
+func simpleWithArg(a: Int, completion: @escaping (String) -> Void) { }
 func simpleWithArg(a: Int) async -> String { }
 
-func multipleResults(completion: (String, Int) -> Void) { }
+func multipleResults(completion: @escaping (String, Int) -> Void) { }
 func multipleResults() async -> (String, Int) { }
 
-func nonOptionalError(completion: (String, Error) -> Void) { }
+func nonOptionalError(completion: @escaping (String, Error) -> Void) { }
 func nonOptionalError() async -> (String, Error) { }
 
-func noParams(completion: () -> Void) { }
+func noParams(completion: @escaping () -> Void) { }
 func noParams() async { }
 
-func error(completion: (String?, Error?) -> Void) { }
+func error(completion: @escaping (String?, Error?) -> Void) { }
 func error() async throws -> String { }
 
-func errorOnly(completion: (Error?) -> Void) { }
+func errorOnly(completion: @escaping (Error?) -> Void) { }
 func errorOnly() async throws { }
 
-func errorNonOptionalResult(completion: (String, Error?) -> Void) { }
+func errorNonOptionalResult(completion: @escaping (String, Error?) -> Void) { }
 func errorNonOptionalResult() async throws -> String { }
 
-func alias(completion: SomeCallback) { }
+func alias(completion: @escaping SomeCallback) { }
 func alias() async -> String { }
 
-func simpleResult(completion: (Result<String, Never>) -> Void) { }
+func simpleResult(completion: @escaping (Result<String, Never>) -> Void) { }
 func simpleResult() async -> String { }
 
-func errorResult(completion: (Result<String, Error>) -> Void) { }
+func errorResult(completion: @escaping (Result<String, Error>) -> Void) { }
 func errorResult() async throws -> String { }
 
-func customErrorResult(completion: (Result<String, CustomError>) -> Void) { }
+func customErrorResult(completion: @escaping (Result<String, CustomError>) -> Void) { }
 func customErrorResult() async throws -> String { }
 
-func optionalSingle(completion: (String?) -> Void) { }
+func optionalSingle(completion: @escaping (String?) -> Void) { }
 func optionalSingle() async -> String? { }
 
-func manyOptional(_ completion: (String?, Int?) -> Void) { }
+func manyOptional(_ completion: @escaping (String?, Int?) -> Void) { }
 func manyOptional() async -> (String?, Int?) { }
 
-func generic<T, R>(completion: (T, R) -> Void) { }
+func generic<T, R>(completion: @escaping (T, R) -> Void) { }
 func generic<T, R>() async -> (T, R) { }
 
-func genericResult<T>(completion: (T?, Error?) -> Void) where T: Numeric { }
+func genericResult<T>(completion: @escaping (T?, Error?) -> Void) where T: Numeric { }
 func genericResult<T>() async throws -> T where T: Numeric { }
 
-func genericError<E>(completion: (String?, E?) -> Void) where E: Error { }
+func genericError<E>(completion: @escaping (String?, E?) -> Void) where E: Error { }
 func genericError() async throws -> String { }
 
-func defaultArgs(a: Int, b: Int = 10, completion: (String) -> Void) { }
+func defaultArgs(a: Int, b: Int = 10, completion: @escaping (String) -> Void) { }
 func defaultArgs(a: Int, b: Int = 10) async -> String { }
 
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=SIMPLE-WITH-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SIMPLE-WITH %s
-func testSimpleWithVariableCompletionHandler(completionHandler: (String) -> Void) {
+func testSimpleWithVariableCompletionHandler(completionHandler: @escaping (String) -> Void) {
   simple(completion: completionHandler)
 }
 // SIMPLE-WITH-FUNC: func testSimpleWithVariableCompletionHandler() async -> String {
@@ -76,7 +78,7 @@ func testSimpleWithVariableCompletionHandler(completionHandler: (String) -> Void
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=SIMPLE-WITH-ARG-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SIMPLE-WITH-ARG %s
-func testSimpleWithArgVariableCompletionHandler(b: Int, completionHandler: (String) -> Void) {
+func testSimpleWithArgVariableCompletionHandler(b: Int, completionHandler: @escaping (String) -> Void) {
   simpleWithArg(a: b, completion: completionHandler)
 }
 // SIMPLE-WITH-ARG-FUNC: func testSimpleWithArgVariableCompletionHandler(b: Int) async -> String {
@@ -88,7 +90,7 @@ func testSimpleWithArgVariableCompletionHandler(b: Int, completionHandler: (Stri
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=SIMPLE-WITH-CONSTANT-ARG-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SIMPLE-WITH-CONSTANT-ARG %s
-func testSimpleWithConstantArgVariableCompletionHandler(completionHandler: (String) -> Void) {
+func testSimpleWithConstantArgVariableCompletionHandler(completionHandler: @escaping (String) -> Void) {
   simpleWithArg(a: 1, completion: completionHandler)
 }
 // SIMPLE-WITH-CONSTANT-ARG-FUNC: func testSimpleWithConstantArgVariableCompletionHandler() async -> String {
@@ -100,7 +102,7 @@ func testSimpleWithConstantArgVariableCompletionHandler(completionHandler: (Stri
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=MULTIPLE-RESULTS-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=MULTIPLE-RESULTS %s
-func testMultipleResultsVariableCompletionHandler(completionHandler: (String, Int) -> Void) {
+func testMultipleResultsVariableCompletionHandler(completionHandler: @escaping (String, Int) -> Void) {
   multipleResults(completion: completionHandler)
 }
 // MULTIPLE-RESULTS-FUNC: func testMultipleResultsVariableCompletionHandler() async -> (String, Int) {
@@ -112,7 +114,7 @@ func testMultipleResultsVariableCompletionHandler(completionHandler: (String, In
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=NON-OPTIONAL-ERROR-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=NON-OPTIONAL-ERROR %s
-func testNonOptionalErrorVariableCompletionHandler(completionHandler: (String, Error) -> Void) {
+func testNonOptionalErrorVariableCompletionHandler(completionHandler: @escaping (String, Error) -> Void) {
   nonOptionalError(completion: completionHandler)
 }
 // NON-OPTIONAL-ERROR-FUNC: func testNonOptionalErrorVariableCompletionHandler() async -> (String, Error) {
@@ -124,7 +126,7 @@ func testNonOptionalErrorVariableCompletionHandler(completionHandler: (String, E
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=NO-PARAMS-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=NO-PARAMS %s
-func testNoParamsVariableCompletionHandler(completionHandler: () -> Void) {
+func testNoParamsVariableCompletionHandler(completionHandler: @escaping () -> Void) {
   noParams(completion: completionHandler)
 }
 // NO-PARAMS-FUNC: func testNoParamsVariableCompletionHandler() async {
@@ -137,7 +139,7 @@ func testNoParamsVariableCompletionHandler(completionHandler: () -> Void) {
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=ERROR-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ERROR %s
-func testErrorWithVariableCompletionHandler(completionHandler: (String?, Error?) -> Void) {
+func testErrorWithVariableCompletionHandler(completionHandler: @escaping (String?, Error?) -> Void) {
   error(completion: completionHandler)
 }
 // ERROR-FUNC: func testErrorWithVariableCompletionHandler() async throws -> String {
@@ -153,7 +155,7 @@ func testErrorWithVariableCompletionHandler(completionHandler: (String?, Error?)
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=ERROR-ONLY-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ERROR-ONLY %s
-func testErrorOnlyWithVariableCompletionHandler(completionHandler: (Error?) -> Void) {
+func testErrorOnlyWithVariableCompletionHandler(completionHandler: @escaping (Error?) -> Void) {
   errorOnly(completion: completionHandler)
 }
 // ERROR-ONLY-FUNC: func testErrorOnlyWithVariableCompletionHandler() async throws {
@@ -170,7 +172,7 @@ func testErrorOnlyWithVariableCompletionHandler(completionHandler: (Error?) -> V
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1  | %FileCheck -check-prefix=ERROR-NON-OPTIONAL-RESULT-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3  | %FileCheck -check-prefix=ERROR-NON-OPTIONAL-RESULT %s
-func testErrorNonOptionalResultWithVariableCompletionHandler(completionHandler: (String, Error?) -> Void) {
+func testErrorNonOptionalResultWithVariableCompletionHandler(completionHandler: @escaping (String, Error?) -> Void) {
   errorNonOptionalResult(completion: completionHandler)
 }
 // ERROR-NON-OPTIONAL-RESULT-FUNC: func testErrorNonOptionalResultWithVariableCompletionHandler() async throws -> String {
@@ -186,7 +188,7 @@ func testErrorNonOptionalResultWithVariableCompletionHandler(completionHandler: 
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=ALIAS-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ALIAS %s
-func testAliasWithVariableCompletionHandler(completionHandler: SomeCallback) {
+func testAliasWithVariableCompletionHandler(completionHandler: @escaping SomeCallback) {
   alias(completion: completionHandler)
 }
 // ALIAS-FUNC: func testAliasWithVariableCompletionHandler() async -> String {
@@ -198,7 +200,7 @@ func testAliasWithVariableCompletionHandler(completionHandler: SomeCallback) {
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=SIMPLE-RESULT-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SIMPLE-RESULT %s
-func testSimpleResultVariableCompletionHandler(completionHandler: (Result<String, Never>) -> Void) {
+func testSimpleResultVariableCompletionHandler(completionHandler: @escaping (Result<String, Never>) -> Void) {
   simpleResult(completion: completionHandler)
 }
 // SIMPLE-RESULT-FUNC: func testSimpleResultVariableCompletionHandler() async -> String {
@@ -210,7 +212,7 @@ func testSimpleResultVariableCompletionHandler(completionHandler: (Result<String
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=ERROR-RESULT-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=ERROR-RESULT %s
-func testErrorResultVariableCompletionHandler(completionHandler: (Result<String, Error>) -> Void) {
+func testErrorResultVariableCompletionHandler(completionHandler: @escaping (Result<String, Error>) -> Void) {
   errorResult(completion: completionHandler)
 }
 // ERROR-RESULT-FUNC: func testErrorResultVariableCompletionHandler() async throws -> String {
@@ -226,7 +228,7 @@ func testErrorResultVariableCompletionHandler(completionHandler: (Result<String,
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=CUSTOM-ERROR-RESULT-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=CUSTOM-ERROR-RESULT %s
-func testErrorResultVariableCompletionHandler(completionHandler: (Result<String, CustomError>) -> Void) {
+func testErrorResultVariableCompletionHandler(completionHandler: @escaping (Result<String, CustomError>) -> Void) {
   customErrorResult(completion: completionHandler)
 }
 // CUSTOM-ERROR-RESULT-FUNC: func testErrorResultVariableCompletionHandler() async throws -> String {
@@ -242,7 +244,7 @@ func testErrorResultVariableCompletionHandler(completionHandler: (Result<String,
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=OPTIONAL-SINGLE-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=OPTIONAL-SINGLE %s
-func testOptionalSingleVariableCompletionHandler(completionHandler: (String?) -> Void) {
+func testOptionalSingleVariableCompletionHandler(completionHandler: @escaping (String?) -> Void) {
   optionalSingle(completion: completionHandler)
 }
 // OPTIONAL-SINGLE-FUNC: func testOptionalSingleVariableCompletionHandler() async -> String? {
@@ -254,7 +256,7 @@ func testOptionalSingleVariableCompletionHandler(completionHandler: (String?) ->
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=MANY-OPTIONAL-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=MANY-OPTIONAL %s
-func testManyOptionalVariableCompletionHandler(completionHandler: (String?, Int?) -> Void) {
+func testManyOptionalVariableCompletionHandler(completionHandler: @escaping (String?, Int?) -> Void) {
   manyOptional(completionHandler)
 }
 // MANY-OPTIONAL-FUNC: func testManyOptionalVariableCompletionHandler() async -> (String?, Int?) {
@@ -266,7 +268,7 @@ func testManyOptionalVariableCompletionHandler(completionHandler: (String?, Int?
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=GENERIC-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=GENERIC %s
-func testGenericVariableCompletionHandler<T, R>(completionHandler: (T, R) -> Void) {
+func testGenericVariableCompletionHandler<T, R>(completionHandler: @escaping (T, R) -> Void) {
   generic(completion: completionHandler)
 }
 // GENERIC-FUNC: func testGenericVariableCompletionHandler<T, R>() async -> (T, R) {
@@ -278,7 +280,7 @@ func testGenericVariableCompletionHandler<T, R>(completionHandler: (T, R) -> Voi
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=SPECIALIZE-GENERIC-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=SPECIALIZE-GENERIC %s
-func testSpecializeGenericsVariableCompletionHandler(completionHandler: (String, Int) -> Void) {
+func testSpecializeGenericsVariableCompletionHandler(completionHandler: @escaping (String, Int) -> Void) {
   generic(completion: completionHandler)
 }
 // SPECIALIZE-GENERIC-FUNC: func testSpecializeGenericsVariableCompletionHandler() async -> (String, Int) {
@@ -290,7 +292,7 @@ func testSpecializeGenericsVariableCompletionHandler(completionHandler: (String,
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=GENERIC-RESULT-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=GENERIC-RESULT %s
-func testGenericResultVariableCompletionHandler<T>(completionHandler: (T?, Error?) -> Void) where T: Numeric {
+func testGenericResultVariableCompletionHandler<T>(completionHandler: @escaping (T?, Error?) -> Void) where T: Numeric {
   genericResult(completion: completionHandler)
 }
 // GENERIC-RESULT-FUNC: func testGenericResultVariableCompletionHandler<T>() async throws -> T where T: Numeric {
@@ -306,7 +308,7 @@ func testGenericResultVariableCompletionHandler<T>(completionHandler: (T?, Error
 
 // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=GENERIC-ERROR-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=GENERIC-ERROR %s
-func testGenericErrorVariableCompletionHandler<MyGenericError>(completionHandler: (String?, MyGenericError?) -> Void) where MyGenericError: Error {
+func testGenericErrorVariableCompletionHandler<MyGenericError>(completionHandler: @escaping (String?, MyGenericError?) -> Void) where MyGenericError: Error {
   genericError(completion: completionHandler)
 }
 // GENERIC-ERROR-FUNC: func testGenericErrorVariableCompletionHandler<MyGenericError>() async throws -> String where MyGenericError: Error {
@@ -322,7 +324,7 @@ func testGenericErrorVariableCompletionHandler<MyGenericError>(completionHandler
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=DEFAULT-ARGS-FUNC %s
 // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=DEFAULT-ARGS %s
-func testDefaultArgsVariableCompletionHandler(completionHandler: (String) -> Void) {
+func testDefaultArgsVariableCompletionHandler(completionHandler: @escaping (String) -> Void) {
   defaultArgs(a: 5, completion: completionHandler)
 }
 // DEFAULT-ARGS-FUNC: func testDefaultArgsVariableCompletionHandler() async -> String {
@@ -365,7 +367,7 @@ func testVariableAsCompletionHandler() {
 // VARIABLE-AS-COMPLETION-HANDLER-NEXT: complete(result)
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=PRINTING-WRAPPER-FUNC %s
-func testPrintingWrapper(completionHandler: (String) -> Void) {
+func testPrintingWrapper(completionHandler: @escaping (String) -> Void) {
   print("Starting")
   simple(completion: completionHandler)
   print("Operation scheduled")

--- a/test/refactoring/ConvertAsync/void_handler.swift
+++ b/test/refactoring/ConvertAsync/void_handler.swift
@@ -1,0 +1,15 @@
+// REQUIRES: concurrency
+
+// RUN: %empty-directory(%t)
+
+// A (Void) parameter has a warning in Swift, so this function is pulled into
+// its own file
+// RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix VOID-HANDLER %s
+func voidCompletion(completion: @escaping (Void) -> Void) {}
+// VOID-HANDLER: {
+// VOID-HANDLER-NEXT: Task {
+// VOID-HANDLER-NEXT: await voidCompletion()
+// VOID-HANDLER-NEXT: completion(())
+// VOID-HANDLER-NEXT: }
+// VOID-HANDLER-NEXT: }
+// VOID-HANDLER: func voidCompletion() async {}


### PR DESCRIPTION
The async refactorings ignore whether a completion handler had
`@escaping` or not. In preparation of fixing this, fix up all functions
to have `@escaping` for their completion handler parameter.

Also some small miscellaneous fixes in order to reduce the number of
warnings output on test failures and also the addition of `REQUIRES:
concurrency` on all tests.