### PR TITLE
[NFC] Refactor `getRenameDecl` to use the request evaluator

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -774,7 +774,6 @@ public:
   void collectBasicSourceFileInfo(
       llvm::function_ref<void(const BasicSourceFileInfo &)> callback) const;
 
-public:
   /// Retrieve a fingerprint value that summarizes the contents of this module.
   ///
   /// This interface hash a of a module is guaranteed to change if the interface
@@ -786,6 +785,15 @@ public:
   /// coarse-grained, way of determining when top-level changes to a module's
   /// contents have been made.
   Fingerprint getFingerprint() const;
+
+  /// Returns an approximation of whether the given module could be
+  /// redistributed and consumed by external clients.
+  ///
+  /// FIXME: The scope of this computation should be limited entirely to
+  /// RenamedDeclRequest. Unfortunately, it has been co-opted to support the
+  /// \c SerializeOptionsForDebugging hack. Once this information can be
+  /// transferred from module files to the dSYMs, remove this.
+  bool isExternallyConsumed() const;
 
   SourceRange getSourceRange() const { return SourceRange(); }
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3003,6 +3003,23 @@ public:
   bool isCached() const { return true; }
 };
 
+class RenamedDeclRequest
+    : public SimpleRequest<RenamedDeclRequest,
+                           ValueDecl *(const ValueDecl *, const AvailableAttr *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  ValueDecl *evaluate(Evaluator &evaluator, const ValueDecl *attached,
+                      const AvailableAttr *attr) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 void simple_display(llvm::raw_ostream &out, Type value);
 void simple_display(llvm::raw_ostream &out, const TypeRepr *TyR);
 void simple_display(llvm::raw_ostream &out, ImplicitMemberAction action);

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -334,3 +334,6 @@ SWIFT_REQUEST(TypeChecker, GetImplicitSendableRequest,
 SWIFT_REQUEST(TypeChecker, AsyncAlternativeRequest,
               AbstractFunctionDecl *(AbstractFunctionDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, RenamedDeclRequest,
+               ValueDecl *(const ValueDecl *),
+               Cached, NoLocationInfo)

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -403,15 +403,6 @@ public:
   SerializationOptions
   computeSerializationOptions(const SupplementaryOutputPaths &outs,
                               const ModuleDecl *module) const;
-
-  /// Returns an approximation of whether the given module could be
-  /// redistributed and consumed by external clients.
-  ///
-  /// FIXME: The scope of this computation should be limited entirely to
-  /// PrintAsObjC. Unfortunately, it has been co-opted to support the
-  /// \c SerializeOptionsForDebugging hack. Once this information can be
-  /// transferred from module files to the dSYMs, remove this.
-  bool isModuleExternallyConsumed(const ModuleDecl *mod) const;
 };
 
 /// A class which manages the state and execution of the compiler.

--- a/include/swift/PrintAsObjC/PrintAsObjC.h
+++ b/include/swift/PrintAsObjC/PrintAsObjC.h
@@ -25,8 +25,7 @@ namespace swift {
   /// header.
   ///
   /// Returns true on error.
-  bool printAsObjC(raw_ostream &out, ModuleDecl *M, StringRef bridgingHeader,
-                   AccessLevel minRequiredAccess);
+  bool printAsObjC(raw_ostream &out, ModuleDecl *M, StringRef bridgingHeader);
 }
 
 #endif

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2118,30 +2118,3 @@ CompilerInvocation::setUpInputForSILTool(
   }
   return fileBufOrErr;
 }
-
-bool CompilerInvocation::isModuleExternallyConsumed(
-    const ModuleDecl *mod) const {
-  // Modules for executables aren't expected to be consumed by other modules.
-  // This picks up all kinds of entrypoints, including script mode,
-  // @UIApplicationMain and @NSApplicationMain.
-  if (mod->hasEntryPoint()) {
-    return false;
-  }
-
-  // If an implicit Objective-C header was needed to construct this module, it
-  // must be the product of a library target.
-  if (!getFrontendOptions().ImplicitObjCHeaderPath.empty()) {
-    return false;
-  }
-
-  // App extensions are special beasts because they build without entrypoints
-  // like library targets, but they behave like executable targets because
-  // their associated modules are not suitable for distribution.
-  if (mod->getASTContext().LangOpts.EnableAppExtensionRestrictions) {
-    return false;
-  }
-
-  // FIXME: This is still a lousy approximation of whether the module file will
-  // be externally consumed.
-  return true;
-}

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -180,7 +180,7 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
   // the public.
   serializationOpts.SerializeOptionsForDebugging =
       opts.SerializeOptionsForDebugging.getValueOr(
-          !isModuleExternallyConsumed(module));
+          !module->isExternallyConsumed());
 
   serializationOpts.DisableCrossModuleIncrementalInfo =
       opts.DisableCrossModuleIncrementalBuild;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -174,14 +174,12 @@ static bool writeSIL(SILModule &SM, const PrimarySpecificPaths &PSPs,
 ///
 /// \see swift::printAsObjC
 static bool printAsObjCIfNeeded(StringRef outputPath, ModuleDecl *M,
-                                StringRef bridgingHeader, bool moduleIsPublic) {
+                                StringRef bridgingHeader) {
   if (outputPath.empty())
     return false;
   return withOutputFile(M->getDiags(), outputPath,
                         [&](raw_ostream &out) -> bool {
-    auto requiredAccess = moduleIsPublic ? AccessLevel::Public
-                                         : AccessLevel::Internal;
-    return printAsObjC(out, M, bridgingHeader, requiredAccess);
+    return printAsObjC(out, M, bridgingHeader);
   });
 }
 
@@ -853,8 +851,7 @@ static bool emitAnyWholeModulePostTypeCheckSupplementaryOutputs(
     }
     hadAnyError |= printAsObjCIfNeeded(
         Invocation.getObjCHeaderOutputPathForAtMostOnePrimary(),
-        Instance.getMainModule(), BridgingHeaderPathForPrint,
-        Invocation.isModuleExternallyConsumed(Instance.getMainModule()));
+        Instance.getMainModule(), BridgingHeaderPathForPrint);
   }
 
   // Only want the header if there's been any errors, ie. there's not much

--- a/lib/PrintAsObjC/ModuleContentsWriter.cpp
+++ b/lib/PrintAsObjC/ModuleContentsWriter.cpp
@@ -598,6 +598,8 @@ public:
 void
 swift::printModuleContentsAsObjC(raw_ostream &os,
                                  llvm::SmallPtrSetImpl<ImportModuleTy> &imports,
-                                 ModuleDecl &M, AccessLevel minRequiredAccess) {
-  ModuleWriter(os, imports, M, minRequiredAccess).write();
+                                 ModuleDecl &M) {
+  auto requiredAccess = M.isExternallyConsumed() ? AccessLevel::Public
+                                                 : AccessLevel::Internal;
+  ModuleWriter(os, imports, M, requiredAccess).write();
 }

--- a/lib/PrintAsObjC/ModuleContentsWriter.h
+++ b/lib/PrintAsObjC/ModuleContentsWriter.h
@@ -27,11 +27,11 @@ class ModuleDecl;
 
 using ImportModuleTy = PointerUnion<ModuleDecl*, const clang::Module*>;
 
-/// Prints the declarations of \p M to \p os, filtering by \p minRequiredAccess
-/// and collecting imports in \p imports along the way.
+/// Prints the declarations of \p M to \p os and collecting imports in
+/// \p imports along the way.
 void printModuleContentsAsObjC(raw_ostream &os,
                                llvm::SmallPtrSetImpl<ImportModuleTy> &imports,
-                               ModuleDecl &M, AccessLevel minRequiredAccess);
+                               ModuleDecl &M);
 
 } // end namespace swift
 

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -383,14 +383,13 @@ static void writeEpilogue(raw_ostream &os) {
 }
 
 bool swift::printAsObjC(raw_ostream &os, ModuleDecl *M,
-                        StringRef bridgingHeader,
-                        AccessLevel minRequiredAccess) {
+                        StringRef bridgingHeader) {
   llvm::PrettyStackTraceString trace("While generating Objective-C header");
 
   SmallPtrSet<ImportModuleTy, 8> imports;
   std::string moduleContentsBuf;
   llvm::raw_string_ostream moduleContents{moduleContentsBuf};
-  printModuleContentsAsObjC(moduleContents, imports, *M, minRequiredAccess);
+  printModuleContentsAsObjC(moduleContents, imports, *M);
   std::string macroGuard = (llvm::Twine(M->getNameStr().upper()) + "_SWIFT_H").str();
   writePrologue(os, M->getASTContext(), macroGuard);
   writeImports(os, imports, *M, bridgingHeader);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -34,9 +34,11 @@
 #include "swift/AST/PropertyWrappers.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/StorageImpl.h"
+#include "swift/AST/SwiftNameTranslation.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/Types.h"
 #include "swift/Parse/Lexer.h"
+#include "swift/Parse/Parser.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "clang/Basic/CharInfo.h"
 #include "llvm/ADT/STLExtras.h"
@@ -5867,4 +5869,113 @@ AbstractFunctionDecl *AsyncAlternativeRequest::evaluate(
 
     return candidates.front();
   }
+}
+
+static bool renameCouldMatch(const ValueDecl *original,
+                             const ValueDecl *candidate,
+                             bool originalIsObjCVisible,
+                             AccessLevel minAccess) {
+  // Kinds have to match
+  if (candidate->getKind() != original->getKind())
+    return false;
+
+  // Instance can't match static/class function
+  if (candidate->isInstanceMember() != original->isInstanceMember())
+    return false;
+
+  // If the original is ObjC visible then the rename must be as well
+  if (originalIsObjCVisible &&
+      !objc_translation::isVisibleToObjC(candidate, minAccess))
+    return false;
+
+  // @available is intended for public interfaces, so an implementation-only
+  // decl shouldn't match
+  if (candidate->getAttrs().hasAttribute<ImplementationOnlyAttr>())
+    return false;
+
+  return true;
+}
+
+static bool parametersMatch(const AbstractFunctionDecl *a,
+                            const AbstractFunctionDecl *b) {
+  auto aParams = a->getParameters();
+  auto bParams = b->getParameters();
+
+  if (aParams->size() != bParams->size())
+    return false;
+
+  for (auto index : indices(*aParams)) {
+    auto aParamType = aParams->get(index)->getType();
+    auto bParamType = bParams->get(index)->getType();
+    if (!aParamType->matchesParameter(bParamType, TypeMatchOptions()))
+      return false;
+  }
+  return true;
+}
+
+ValueDecl *RenamedDeclRequest::evaluate(Evaluator &evaluator,
+                                        const ValueDecl *attached,
+                                        const AvailableAttr *attr) const {
+  if (attr->Rename.empty())
+    return nullptr;
+
+  auto declContext = attached->getDeclContext();
+  ASTContext &astContext = attached->getASTContext();
+  auto renamedParsedDeclName = parseDeclName(attr->Rename);
+  auto renamedDeclName = renamedParsedDeclName.formDeclNameRef(astContext);
+
+  if (isa<ClassDecl>(attached) || isa<ProtocolDecl>(attached)) {
+    if (!renamedParsedDeclName.ContextName.empty()) {
+      return nullptr;
+    }
+    SmallVector<ValueDecl *, 1> decls;
+    declContext->lookupQualified(declContext->getParentModule(),
+                                 renamedDeclName.withoutArgumentLabels(),
+                                 NL_OnlyTypes,
+                                 decls);
+    if (decls.size() == 1)
+      return decls[0];
+    return nullptr;
+  }
+
+  TypeDecl *typeDecl = declContext->getSelfNominalTypeDecl();
+
+  SmallVector<ValueDecl *, 4> lookupResults;
+  declContext->lookupQualified(typeDecl->getDeclaredInterfaceType(),
+                               renamedDeclName, NL_QualifiedDefault,
+                               lookupResults);
+
+  auto minAccess = AccessLevel::Private;
+  if (attached->getModuleContext()->isExternallyConsumed())
+    minAccess = AccessLevel::Public;
+  bool attachedIsObjcVisible =
+      objc_translation::isVisibleToObjC(attached, minAccess);
+
+  if (lookupResults.size() == 1) {
+    auto candidate = lookupResults[0];
+    if (!renameCouldMatch(attached, candidate, attachedIsObjcVisible,
+                          minAccess))
+      return nullptr;
+    return candidate;
+  }
+
+  ValueDecl *renamedDecl = nullptr;
+  for (auto candidate : lookupResults) {
+    if (!renameCouldMatch(attached, candidate, attachedIsObjcVisible,
+                          minAccess))
+      continue;
+
+    if (isa<AbstractFunctionDecl>(candidate) &&
+        !parametersMatch(cast<AbstractFunctionDecl>(attached),
+                         cast<AbstractFunctionDecl>(candidate)))
+        continue;
+
+    if (renamedDecl) {
+      // Don't allow ambiguous matches
+      renamedDecl = nullptr;
+      break;
+    }
+    renamedDecl = candidate;
+  }
+  return renamedDecl;
 }


### PR DESCRIPTION
Move `getRenameDecl` from `PrintAsObjC` into its own request so that
other components can re-use this functionality.