### PR TITLE
C++ Interop: import const methods as non-mutating

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -236,6 +236,8 @@ public:
   instantiateCXXFunctionTemplate(ASTContext &ctx,
                                  clang::FunctionTemplateDecl *func,
                                  SubstitutionMap subst) = 0;
+
+  virtual bool isCXXMethodMutating(const clang::CXXMethodDecl *method) = 0;
 };
 
 /// Describes a C++ template instantiation error.

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -486,6 +486,8 @@ public:
   instantiateCXXFunctionTemplate(ASTContext &ctx,
                                  clang::FunctionTemplateDecl *func,
                                  SubstitutionMap subst) override;
+
+  bool isCXXMethodMutating(const clang::CXXMethodDecl *method) override;
 };
 
 ImportDecl *createImportDecl(ASTContext &Ctx, DeclContext *DC, ClangNode ClangN,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4322,3 +4322,8 @@ ClangImporter::instantiateCXXClassTemplate(
   return dyn_cast_or_null<StructDecl>(
       Impl.importDecl(ctsd, Impl.CurrentVersion));
 }
+
+bool ClangImporter::isCXXMethodMutating(const clang::CXXMethodDecl *method) {
+  return isa<clang::CXXConstructorDecl>(method) || !method->isConst() ||
+         method->getParent()->hasMutableFields();
+}

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4177,10 +4177,10 @@ namespace {
             selfIdx = None;
           } else {
             selfIdx = 0;
-            // Workaround until proper const support is handled: Force
-            // everything to be mutating. This implicitly makes the parameter
-            // indirect.
-            selfIsInOut = true;
+            // If the method is imported as mutating, this implicitly makes the
+            // parameter indirect.
+            selfIsInOut = Impl.SwiftContext.getClangModuleLoader()
+                              ->isCXXMethodMutating(mdecl);
           }
         }
       }
@@ -7589,23 +7589,24 @@ SwiftDeclConverter::importAccessor(const clang::ObjCMethodDecl *clangAccessor,
   return accessor;
 }
 
-static InOutExpr *
-createInOutSelfExpr(AccessorDecl *accessorDecl) {
+static Expr *createSelfExpr(AccessorDecl *accessorDecl) {
   ASTContext &ctx = accessorDecl->getASTContext();
 
-  auto inoutSelfDecl = accessorDecl->getImplicitSelfDecl();
-  auto inoutSelfRefExpr =
-      new (ctx) DeclRefExpr(inoutSelfDecl, DeclNameLoc(),
-                            /*implicit=*/ true);
-  inoutSelfRefExpr->setType(LValueType::get(inoutSelfDecl->getInterfaceType()));
+  auto selfDecl = accessorDecl->getImplicitSelfDecl();
+  auto selfRefExpr = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
+                                           /*implicit*/ true);
 
-  auto inoutSelfExpr =
-      new (ctx) InOutExpr(SourceLoc(),
-                          inoutSelfRefExpr,
-                          accessorDecl->mapTypeIntoContext(
-                              inoutSelfDecl->getValueInterfaceType()),
-                          /*isImplicit=*/ true);
-  inoutSelfExpr->setType(InOutType::get(inoutSelfDecl->getInterfaceType()));
+  if (!accessorDecl->isMutating()) {
+    selfRefExpr->setType(selfDecl->getInterfaceType());
+    return selfRefExpr;
+  }
+  selfRefExpr->setType(LValueType::get(selfDecl->getInterfaceType()));
+
+  auto inoutSelfExpr = new (ctx) InOutExpr(
+      SourceLoc(), selfRefExpr,
+      accessorDecl->mapTypeIntoContext(selfDecl->getValueInterfaceType()),
+      /*isImplicit*/ true);
+  inoutSelfExpr->setType(InOutType::get(selfDecl->getInterfaceType()));
   return inoutSelfExpr;
 }
 
@@ -7623,7 +7624,7 @@ createParamRefExpr(AccessorDecl *accessorDecl, unsigned index) {
 
 static CallExpr *
 createAccessorImplCallExpr(FuncDecl *accessorImpl,
-                           InOutExpr *inoutSelfExpr,
+                           Expr *selfExpr,
                            DeclRefExpr *keyRefExpr) {
   ASTContext &ctx = accessorImpl->getASTContext();
 
@@ -7634,9 +7635,7 @@ createAccessorImplCallExpr(FuncDecl *accessorImpl,
   accessorImplExpr->setType(accessorImpl->getInterfaceType());
 
   auto accessorImplDotCallExpr =
-      new (ctx) DotSyntaxCallExpr(accessorImplExpr,
-                                  SourceLoc(),
-                                  inoutSelfExpr);
+      new (ctx) DotSyntaxCallExpr(accessorImplExpr, SourceLoc(), selfExpr);
   accessorImplDotCallExpr->setType(accessorImpl->getMethodInterfaceType());
   accessorImplDotCallExpr->setThrows(false);
 
@@ -7656,14 +7655,13 @@ synthesizeSubscriptGetterBody(AbstractFunctionDecl *afd, void *context) {
 
   ASTContext &ctx = getterDecl->getASTContext();
 
-  InOutExpr *inoutSelfExpr = createInOutSelfExpr(getterDecl);
+  Expr *selfExpr = createSelfExpr(getterDecl);
   DeclRefExpr *keyRefExpr = createParamRefExpr(getterDecl, 0);
 
   Type elementTy = getterDecl->getResultInterfaceType();
 
-  auto *getterImplCallExpr = createAccessorImplCallExpr(getterImpl,
-                                                        inoutSelfExpr,
-                                                        keyRefExpr);
+  auto *getterImplCallExpr =
+      createAccessorImplCallExpr(getterImpl, selfExpr, keyRefExpr);
 
   // This default handles C++'s operator[] that returns a value type.
   Expr *propertyExpr = getterImplCallExpr;
@@ -7709,14 +7707,13 @@ synthesizeSubscriptSetterBody(AbstractFunctionDecl *afd, void *context) {
 
   ASTContext &ctx = setterDecl->getASTContext();
 
-  InOutExpr *inoutSelfExpr = createInOutSelfExpr(setterDecl);
+  Expr *selfExpr = createSelfExpr(setterDecl);
   DeclRefExpr *valueParamRefExpr = createParamRefExpr(setterDecl, 0);
   DeclRefExpr *keyParamRefExpr = createParamRefExpr(setterDecl, 1);
 
   Type elementTy = valueParamRefExpr->getDecl()->getInterfaceType();
 
-  auto *setterImplCallExpr = createAccessorImplCallExpr(setterImpl,
-                                                        inoutSelfExpr,
+  auto *setterImplCallExpr = createAccessorImplCallExpr(setterImpl, selfExpr,
                                                         keyParamRefExpr);
 
   VarDecl *pointeePropertyDecl = ctx.getPointerPointeePropertyDecl(PTK_UnsafeMutablePointer);

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1880,9 +1880,12 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
 
       param->setInterfaceType(parentType.getType());
 
-      // Workaround until proper const support is handled: Force everything to
-      // be mutating. This implicitly makes the parameter indirect.
-      param->setSpecifier(ParamSpecifier::InOut);
+      if (SwiftContext.getClangModuleLoader()->isCXXMethodMutating(CMD)) {
+        // This implicitly makes the parameter indirect.
+        param->setSpecifier(ParamSpecifier::InOut);
+      } else {
+        param->setSpecifier(ParamSpecifier::Default);
+      }
 
       parameters.push_back(param);
     }

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2846,18 +2846,31 @@ public:
 class CXXMethodConventions : public CFunctionTypeConventions {
   using super = CFunctionTypeConventions;
   const clang::CXXMethodDecl *TheDecl;
+  bool isMutating;
 
 public:
-  CXXMethodConventions(const clang::CXXMethodDecl *decl)
+  CXXMethodConventions(const clang::CXXMethodDecl *decl, bool isMutating)
       : CFunctionTypeConventions(
             ConventionsKind::CXXMethod,
             decl->getType()->castAs<clang::FunctionType>()),
-        TheDecl(decl) {}
+        TheDecl(decl), isMutating(isMutating) {}
   ParameterConvention
   getIndirectSelfParameter(const AbstractionPattern &type) const override {
-    if (TheDecl->isConst())
+    llvm_unreachable(
+        "cxx functions do not have a Swift self parameter; "
+        "foreign self parameter is handled in getIndirectParameter");
+  }
+
+  ParameterConvention
+  getIndirectParameter(unsigned int index, const AbstractionPattern &type,
+                       const TypeLowering &substTL) const override {
+    // `self` is the last parameter.
+    if (index == TheDecl->getNumParams()) {
+      if (isMutating)
+        return ParameterConvention::Indirect_Inout;
       return ParameterConvention::Indirect_In_Guaranteed;
-    return ParameterConvention::Indirect_Inout;
+    }
+    return super::getIndirectParameter(index, type, substTL);
   }
   ResultConvention getResult(const TypeLowering &resultTL) const override {
     if (isa<clang::CXXConstructorDecl>(TheDecl)) {
@@ -2909,7 +2922,9 @@ static CanSILFunctionType getSILFunctionTypeForClangDecl(
     AbstractionPattern origPattern = method->isOverloadedOperator() ?
         AbstractionPattern::getCXXOperatorMethod(origType, method, foreignInfo.Self):
         AbstractionPattern::getCXXMethod(origType, method, foreignInfo.Self);
-    auto conventions = CXXMethodConventions(method);
+    bool isMutating =
+        TC.Context.getClangModuleLoader()->isCXXMethodMutating(method);
+    auto conventions = CXXMethodConventions(method, isMutating);
     return getSILFunctionType(TC, TypeExpansionContext::minimal(), origPattern,
                               substInterfaceType, extInfoBuilder, conventions,
                               foreignInfo, constant, constant, None,

--- a/test/ClangImporter/cxx_interop_ir.swift
+++ b/test/ClangImporter/cxx_interop_ir.swift
@@ -1,4 +1,7 @@
 // RUN: %target-swiftxx-frontend -module-name cxx_ir -I %S/Inputs/custom-modules -emit-ir -o - -primary-file %s | %FileCheck %s
+//
+// We can't yet call member functions correctly on Windows (SR-13129).
+// XFAIL: OS=windows-msvc
 
 import CXXInterop
 
@@ -40,9 +43,10 @@ func basicMethods(a: UnsafeMutablePointer<Methods>) -> Int32 {
 }
 
 // CHECK-LABEL: define hidden swiftcc i32 @"$s6cxx_ir17basicMethodsConst1as5Int32VSpySo0D0VG_tF"(i8* %0)
-// CHECK: [[THIS_PTR1:%.*]] = bitcast i8* %0 to %TSo7MethodsV*
+// CHECK: [[THIS_PTR1:%.*]] = alloca %TSo7MethodsV, align 8
 // CHECK: [[THIS_PTR2:%.*]] = bitcast %TSo7MethodsV* [[THIS_PTR1]] to %class.Methods*
-// CHECK: [[RESULT:%.*]] = call {{(signext )?}}i32 @{{_ZNK7Methods17SimpleConstMethodEi|"\?SimpleConstMethod@Methods@@QEBAHH@Z"}}(%class.Methods* [[THIS_PTR2]], i32{{( signext)?}} 3)
+// CHECK: [[THIS_PTR3:%.*]] = bitcast %TSo7MethodsV* [[THIS_PTR1]] to %class.Methods*
+// CHECK: [[RESULT:%.*]] = call {{(signext )?}}i32 @{{_ZNK7Methods17SimpleConstMethodEi|"\?SimpleConstMethod@Methods@@QEBAHH@Z"}}(%class.Methods* [[THIS_PTR3]], i32{{( signext)?}} 3)
 // CHECK: ret i32 [[RESULT]]
 func basicMethodsConst(a: UnsafeMutablePointer<Methods>) -> Int32 {
   return a.pointee.SimpleConstMethod(3)

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -48,6 +48,11 @@ module MemberVariables {
   requires cplusplus
 }
 
+module MutableMembers {
+  header "mutable-members.h"
+  requires cplusplus
+}
+
 module ProtocolConformance {
   header "protocol-conformance.h"
   requires cplusplus

--- a/test/Interop/Cxx/class/Inputs/mutable-members.h
+++ b/test/Interop/Cxx/class/Inputs/mutable-members.h
@@ -1,0 +1,21 @@
+#ifndef TEST_INTEROP_CXX_CLASS_INPUTS_MUTABLE_MEMBERS_H
+#define TEST_INTEROP_CXX_CLASS_INPUTS_MUTABLE_MEMBERS_H
+
+struct HasPublicMutableMember {
+  mutable int a = 0;
+
+  int foo() const {
+    a++;
+    return a;
+  }
+};
+
+struct HasPrivateMutableMember {
+private:
+  mutable int a = 0;
+
+public:
+  void bar() const { a++; }
+};
+
+#endif // TEST_INTEROP_CXX_CLASS_INPUTS_MUTABLE_MEMBERS_H

--- a/test/Interop/Cxx/class/mutable-members-module-interface.swift
+++ b/test/Interop/Cxx/class/mutable-members-module-interface.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=MutableMembers -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK: struct HasPublicMutableMember {
+// CHECK:   var a: Int32
+// CHECK:   mutating func foo() -> Int32
+// CHECK: }
+
+// CHECK: struct HasPrivateMutableMember {
+// CHECK:   mutating func bar()
+// CHECK: }

--- a/test/Interop/Cxx/class/mutable-members-typechecker.swift
+++ b/test/Interop/Cxx/class/mutable-members-typechecker.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop
+
+import MutableMembers
+
+let obj = HasPublicMutableMember(a: 42) // expected-note {{change 'let' to 'var' to make it mutable}}
+let i = obj.foo() // expected-error {{cannot use mutating member on immutable value: 'obj' is a 'let' constant}}

--- a/test/Interop/Cxx/class/mutable-members.swift
+++ b/test/Interop/Cxx/class/mutable-members.swift
@@ -1,0 +1,16 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+//
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import MutableMembers
+
+var MembersTestSuite = TestSuite("MembersTestSuite")
+
+MembersTestSuite.test("MutableMembers") {
+  var obj = HasPublicMutableMember(a: 1)
+  expectEqual(obj.foo(), 2)
+  expectEqual(obj.foo(), 3)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -20,26 +20,26 @@
 // CHECK: struct ReadWriteIntArray {
 // CHECK:   struct NestedIntArray {
 // CHECK:     @available(*, unavailable, message: "use subscript")
-// CHECK:     mutating func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>
+// CHECK:     func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>
 
-// CHECK:     subscript(x: Int32) -> Int32 { mutating get }
+// CHECK:     subscript(x: Int32) -> Int32 { get }
 // CHECK:   }
 
 // CHECK:   @available(*, unavailable, message: "use subscript")
-// CHECK:   mutating func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>
+// CHECK:   func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>
 
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   mutating func __operatorSubscript(_ x: Int32) -> UnsafeMutablePointer<Int32>
 
-// CHECK:   subscript(x: Int32) -> Int32 { mutating get set }
+// CHECK:   subscript(x: Int32) -> Int32
 // CHECK: }
 
 
 // CHECK: struct ReadOnlyIntArray {
 // CHECK:   @available(*, unavailable, message: "use subscript")
-// CHECK:   mutating func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>
+// CHECK:   func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>
 
-// CHECK:   subscript(x: Int32) -> Int32 { mutating get }
+// CHECK:   subscript(x: Int32) -> Int32 { get }
 // CHECK: }
 
 
@@ -53,7 +53,7 @@
 
 // CHECK: struct DifferentTypesArray {
 // CHECK:   @available(*, unavailable, message: "use subscript")
-// CHECK:   mutating func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>
+// CHECK:   func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>
 
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   mutating func __operatorSubscript(_ x: Int32) -> UnsafeMutablePointer<Int32>
@@ -62,14 +62,14 @@
 // CHECK:   mutating func __operatorSubscript(_ x: Bool) -> UnsafeMutablePointer<Bool>
 
 // CHECK:   @available(*, unavailable, message: "use subscript")
-// CHECK:   mutating func __operatorSubscriptConst(_ x: Bool) -> UnsafePointer<Bool>
+// CHECK:   func __operatorSubscriptConst(_ x: Bool) -> UnsafePointer<Bool>
 
 // CHECK:   @available(*, unavailable, message: "use subscript")
-// CHECK:   mutating func __operatorSubscriptConst(_ x: Double) -> UnsafePointer<Double>
+// CHECK:   func __operatorSubscriptConst(_ x: Double) -> UnsafePointer<Double>
 
-// CHECK:   subscript(x: Int32) -> Int32 { mutating get set }
-// CHECK:   subscript(x: Bool) -> Bool { mutating get set }
-// CHECK:   subscript(x: Double) -> Double { mutating get }
+// CHECK:   subscript(x: Int32) -> Int32
+// CHECK:   subscript(x: Bool) -> Bool
+// CHECK:   subscript(x: Double) -> Double { get }
 // CHECK: }
 
 
@@ -80,9 +80,9 @@
 // CHECK:   mutating func __operatorSubscript(_ i: Int32) -> UnsafeMutablePointer<Double>
 
 // CHECK:   @available(*, unavailable, message: "use subscript")
-// CHECK:   mutating func __operatorSubscriptConst(_ i: Int32) -> UnsafePointer<Double>
+// CHECK:   func __operatorSubscriptConst(_ i: Int32) -> UnsafePointer<Double>
 
-// CHECK:   subscript(i: Int32) -> Double { mutating get set }
+// CHECK:   subscript(i: Int32) -> Double
 // CHECK: }
 // CHECK: typealias TemplatedDoubleArray = __CxxTemplateInst14TemplatedArrayIdE
 
@@ -93,29 +93,29 @@
 
 // CHECK: struct IntArrayByVal {
 // CHECK:   @available(*, unavailable, message: "use subscript")
-// CHECK:   mutating func __operatorSubscriptConst(_ x: Int32) -> Int32
-// CHECK:   subscript(x: Int32) -> Int32 { mutating get }
+// CHECK:   func __operatorSubscriptConst(_ x: Int32) -> Int32
+// CHECK:   subscript(x: Int32) -> Int32 { get }
 // CHECK: }
 
 // CHECK: struct NonTrivialIntArrayByVal {
 // CHECK:   @available(*, unavailable, message: "use subscript")
-// CHECK:   mutating func __operatorSubscriptConst(_ x: Int32) -> Int32
-// CHECK:   subscript(x: Int32) -> Int32 { mutating get }
+// CHECK:   func __operatorSubscriptConst(_ x: Int32) -> Int32
+// CHECK:   subscript(x: Int32) -> Int32 { get }
 // CHECK: }
 
 // CHECK: struct DifferentTypesArrayByVal {
 // CHECK:   @available(*, unavailable, message: "use subscript")
-// CHECK:   mutating func __operatorSubscriptConst(_ x: Int32) -> Int32
+// CHECK:   func __operatorSubscriptConst(_ x: Int32) -> Int32
 
 // CHECK:   @available(*, unavailable, message: "use subscript")
-// CHECK:   mutating func __operatorSubscriptConst(_ x: Bool) -> Bool
+// CHECK:   func __operatorSubscriptConst(_ x: Bool) -> Bool
 
 // CHECK:   @available(*, unavailable, message: "use subscript")
-// CHECK:   mutating func __operatorSubscriptConst(_ x: Double) -> Double
+// CHECK:   func __operatorSubscriptConst(_ x: Double) -> Double
 
 // CHECK:   subscript(x: Int32) -> Int32 { mutating get }
 // CHECK:   subscript(x: Bool) -> Bool { mutating get }
-// CHECK:   subscript(x: Double) -> Double { mutating get }
+// CHECK:   subscript(x: Double) -> Double { get }
 // CHECK: }
 
 
@@ -157,8 +157,8 @@
 // CHECK: }
 // CHECK: struct ConstOpPtrByVal {
 // CHECK:   @available(*, unavailable, message: "use subscript")
-// CHECK:   mutating func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>!
-// CHECK:   subscript(x: Int32) -> UnsafePointer<Int32>! { mutating get }
+// CHECK:   func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>!
+// CHECK:   subscript(x: Int32) -> UnsafePointer<Int32>! { get }
 // CHECK: }
 // CHECK: struct ConstPtrByVal {
 // CHECK:   @available(*, unavailable, message: "use subscript")

--- a/test/Interop/Cxx/operators/member-inline-silgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-silgen.swift
@@ -33,22 +33,18 @@ public func call(_ wrapper: inout AddressOnlyIntWrapper) -> Int32 { wrapper() }
 
 // CHECK: sil [clang AddressOnlyIntWrapper.callAsFunction] [[NAME]] : $@convention(c) (@inout AddressOnlyIntWrapper) -> Int32
 
-public func index(_ arr: inout ReadOnlyIntArray, _ arg: Int32) -> Int32 { arr[arg] }
+public func index(_ arr: ReadOnlyIntArray, _ arg: Int32) -> Int32 { arr[arg] }
 
-// CHECK: sil @$s4main5indexys5Int32VSo16ReadOnlyIntArrayVz_ADtF : $@convention(thin) (@inout ReadOnlyIntArray, Int32) -> Int32 {
+// CHECK: sil @$s4main5indexys5Int32VSo16ReadOnlyIntArrayV_ADtF : $@convention(thin) (@in_guaranteed ReadOnlyIntArray, Int32) -> Int32 {
 // CHECK: bb0([[ARR:%.*]] : $*ReadOnlyIntArray, [[INDEX:%.*]] : $Int32):
-// CHECK:   [[ARRACCESS:%.*]] = begin_access [modify] [static] [[ARR]] : $*ReadOnlyIntArray
-// CHECK:   [[ARRACCESS2:%.*]] = begin_access [modify] [static] [[ARRACCESS]] : $*ReadOnlyIntArray
-// CHECK:   [[OP:%.*]] = function_ref [[READCLASSNAME:@(_ZNK16ReadOnlyIntArrayixEi|\?\?AReadOnlyIntArray@@QEBAAEBHH@Z)]] : $@convention(c) (@inout ReadOnlyIntArray, Int32) -> UnsafePointer<Int32>
-// CHECK:   [[PTR:%.*]] = apply [[OP]]([[ARRACCESS2]], [[INDEX]]) : $@convention(c) (@inout ReadOnlyIntArray, Int32) -> UnsafePointer<Int32>
-// CHECK: } // end sil function '$s4main5indexys5Int32VSo16ReadOnlyIntArrayVz_ADtF'
+// CHECK:   [[OP:%.*]] = function_ref [[READCLASSNAME:@(_ZNK16ReadOnlyIntArrayixEi|\?\?AReadOnlyIntArray@@QEBAAEBHH@Z)]] : $@convention(c) (@in ReadOnlyIntArray, Int32) -> UnsafePointer<Int32>
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[ARRACCESS:%.*]], [[INDEX]]) : $@convention(c) (@in ReadOnlyIntArray, Int32) -> UnsafePointer<Int32>
+// CHECK: } // end sil function '$s4main5indexys5Int32VSo16ReadOnlyIntArrayV_ADtF'
 
-// CHECK: sil shared [transparent] @$sSo16ReadOnlyIntArrayVys5Int32VADcig : $@convention(method) (Int32, @inout ReadOnlyIntArray) -> Int32 {
+// CHECK: sil shared [transparent] @$sSo16ReadOnlyIntArrayVys5Int32VADcig : $@convention(method) (Int32, @in_guaranteed ReadOnlyIntArray) -> Int32 {
 // CHECK: bb0([[INDEX:%.*]] : $Int32, [[SELF:%.*]] : $*ReadOnlyIntArray):
-// CHECK:   [[SELFACCESS:%.*]] = begin_access [modify] [static] [[SELF]] : $*ReadOnlyIntArray
-// CHECK:   [[OP:%.*]] = function_ref [[READCLASSNAME]] : $@convention(c) (@inout ReadOnlyIntArray, Int32) -> UnsafePointer<Int32>
-// CHECK:   [[PTR:%.*]] = apply [[OP]]([[SELFACCESS]], [[INDEX]]) : $@convention(c) (@inout ReadOnlyIntArray, Int32) -> UnsafePointer<Int32>
-// CHECK:   end_access [[SELFACCESS]] : $*ReadOnlyIntArray
+// CHECK:   [[OP:%.*]] = function_ref [[READCLASSNAME]] : $@convention(c) (@in ReadOnlyIntArray, Int32) -> UnsafePointer<Int32>
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[SELFACCESS:%.*]], [[INDEX]]) : $@convention(c) (@in ReadOnlyIntArray, Int32) -> UnsafePointer<Int32>
 // CHECK:   [[PTR2:%.*]] = struct_extract [[PTR]] : $UnsafePointer<Int32>, #UnsafePointer._rawValue
 // CHECK:   pointer_to_address [[PTR2]] : $Builtin.RawPointer to [strict] $*Int32
 // CHECK: } // end sil function '$sSo16ReadOnlyIntArrayVys5Int32VADcig'
@@ -77,18 +73,14 @@ public func index(_ arr: inout NonTrivialIntArrayByVal, _ arg: Int32, _ val: Int
 
 // CHECK: sil @$s4main5indexys5Int32VSo23NonTrivialIntArrayByValVz_A2DtF : $@convention(thin) (@inout NonTrivialIntArrayByVal, Int32, Int32) -> Int32 {
 // CHECK: bb0([[ARR:%.*]] : $*NonTrivialIntArrayByVal, [[INDEX:%.*]] : $Int32, [[NEWVALUE:%.*]] : $Int32):
-// CHECK:   [[ARRACCESS:%.*]] = begin_access [modify] [static] [[ARR]] : $*NonTrivialIntArrayByVal
-// CHECK:   [[ARRACCESS2:%.*]] = begin_access [modify] [static] [[ARRACCESS]] : $*NonTrivialIntArrayByVal
-// CHECK:   [[OP:%.*]] = function_ref [[READWRITECLASSNAMEBYVAL:@(_ZNK23NonTrivialIntArrayByValixEi|\?\?ANonTrivialIntArrayByVal@@QEBAHH@Z)]] : $@convention(c) (@inout NonTrivialIntArrayByVal, Int32) -> Int32
-// CHECK:   [[PTR:%.*]] = apply [[OP]]([[ARRACCESS2]], [[INDEX]]) : $@convention(c) (@inout NonTrivialIntArrayByVal, Int32) -> Int32
+// CHECK:   [[OP:%.*]] = function_ref [[READWRITECLASSNAMEBYVAL:@(_ZNK23NonTrivialIntArrayByValixEi|\?\?ANonTrivialIntArrayByVal@@QEBAHH@Z)]] : $@convention(c) (@in NonTrivialIntArrayByVal, Int32) -> Int32
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[ARRACCESS:%.*]], [[INDEX]]) : $@convention(c) (@in NonTrivialIntArrayByVal, Int32) -> Int32
 // CHECK: } // end sil function '$s4main5indexys5Int32VSo23NonTrivialIntArrayByValVz_A2DtF'
 
-// CHECK: sil shared [transparent] @$sSo23NonTrivialIntArrayByValVys5Int32VADcig : $@convention(method) (Int32, @inout NonTrivialIntArrayByVal) -> Int32 {
+// CHECK: sil shared [transparent] @$sSo23NonTrivialIntArrayByValVys5Int32VADcig : $@convention(method) (Int32, @in_guaranteed NonTrivialIntArrayByVal) -> Int32 {
 // CHECK: bb0([[NEWVALUE:%.*]] : $Int32, [[INDEX:%.*]] : $*NonTrivialIntArrayByVal):
-// CHECK:   [[SELFACCESS:%.*]] = begin_access [modify] [static] [[INDEX]] : $*NonTrivialIntArrayByVal
-// CHECK:   [[OP:%.*]] = function_ref [[READWRITECLASSNAMEBYVAL]] : $@convention(c) (@inout NonTrivialIntArrayByVal, Int32) -> Int32
-// CHECK:   [[PTR:%.*]] = apply [[OP]]([[SELFACCESS]], [[NEWVALUE]]) : $@convention(c) (@inout NonTrivialIntArrayByVal, Int32) -> Int32
-// CHECK:   end_access [[SELFACCESS]] : $*NonTrivialIntArrayByVal
+// CHECK:   [[OP:%.*]] = function_ref [[READWRITECLASSNAMEBYVAL]] : $@convention(c) (@in NonTrivialIntArrayByVal, Int32) -> Int32
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[SELFACCESS:%.*]], [[NEWVALUE]]) : $@convention(c) (@in NonTrivialIntArrayByVal, Int32) -> Int32
 // CHECK: } // end sil function '$sSo23NonTrivialIntArrayByValVys5Int32VADcig
 
 public func index(_ arr: inout PtrByVal, _ arg: Int32, _ val: Int32) -> Int32 { arr[arg]![0] }
@@ -142,21 +134,17 @@ public func index(_ arr: inout PtrToPtr, _ arg: Int32, _ val: Int32) -> Int32 { 
 // CHECK:   end_access [[SELFACCESS]] : $*PtrToPtr
 // CHECK: } // end sil function '$sSo05PtrToA0VySpySpys5Int32VGSgGSgADcig
 
-public func index(_ arr: inout ConstOpPtrByVal, _ arg: Int32, _ val: Int32) -> Int32 { arr[arg]![0] }
-// CHECK: sil @$s4main5indexys5Int32VSo15ConstOpPtrByValVz_A2DtF : $@convention(thin) (@inout ConstOpPtrByVal, Int32, Int32) -> Int32 {
-// CHECK: bb0([[ARR:%.*]] : $*ConstOpPtrByVal, [[INDEX:%.*]] : $Int32, [[NEWVALUE:%.*]] : $Int32):
-// CHECK:   [[ARRACCESS:%.*]] = begin_access [modify] [static] [[ARR]] : $*ConstOpPtrByVal
-// CHECK:   [[ARRACCESS2:%.*]] = begin_access [modify] [static] [[ARRACCESS]] : $*ConstOpPtrByVal
-// CHECK:   [[OP:%.*]] = function_ref [[CONSTOPPTRBYVAL:@(_ZNK15ConstOpPtrByValixEi|\?\?AConstOpPtrByVal@@QEBAPEBHH@Z)]] : $@convention(c) (@inout ConstOpPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>
-// CHECK:   [[PTR:%.*]] = apply [[OP]]([[ARRACCESS2]], [[INDEX]]) : $@convention(c) (@inout ConstOpPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>
-// CHECK: } // end sil function '$s4main5indexys5Int32VSo15ConstOpPtrByValVz_A2DtF'
+public func index(_ arr: ConstOpPtrByVal, _ arg: Int32, _ val: Int32) -> Int32 { arr[arg]![0] }
+// CHECK: sil @$s4main5indexys5Int32VSo15ConstOpPtrByValV_A2DtF : $@convention(thin) (ConstOpPtrByVal, Int32, Int32) -> Int32 {
+// CHECK: bb0([[ARR:%.*]] : $ConstOpPtrByVal, [[INDEX:%.*]] : $Int32, [[NEWVALUE:%.*]] : $Int32):
+// CHECK:   [[OP:%.*]] = function_ref [[CONSTOPPTRBYVAL:@(_ZNK15ConstOpPtrByValixEi|\?\?AConstOpPtrByVal@@QEBAPEBHH@Z)]] : $@convention(c) (@in ConstOpPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[ARRACCESS2:%.*]], [[INDEX]]) : $@convention(c) (@in ConstOpPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>
+// CHECK: } // end sil function '$s4main5indexys5Int32VSo15ConstOpPtrByValV_A2DtF'
 
-// CHECK: sil shared [transparent] @$sSo15ConstOpPtrByValVySPys5Int32VGSgADcig : $@convention(method) (Int32, @inout ConstOpPtrByVal) -> Optional<UnsafePointer<Int32>> {
-// CHECK: bb0([[NEWVALUE:%.*]] : $Int32, [[INDEX:%.*]] : $*ConstOpPtrByVal):
-// CHECK:   [[SELFACCESS:%.*]] = begin_access [modify] [static] [[INDEX]] : $*ConstOpPtrByVal
-// CHECK:   [[OP:%.*]] = function_ref [[CONSTOPPTRBYVAL]] : $@convention(c) (@inout ConstOpPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>
-// CHECK:   [[PTR:%.*]] = apply [[OP]]([[SELFACCESS]], [[NEWVALUE]]) : $@convention(c) (@inout ConstOpPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>
-// CHECK:   end_access [[SELFACCESS]] : $*ConstOpPtrByVal
+// CHECK: sil shared [transparent] @$sSo15ConstOpPtrByValVySPys5Int32VGSgADcig : $@convention(method) (Int32, ConstOpPtrByVal) -> Optional<UnsafePointer<Int32>> {
+// CHECK: bb0([[NEWVALUE:%.*]] : $Int32, [[INDEX:%.*]] : $ConstOpPtrByVal):
+// CHECK:   [[OP:%.*]] = function_ref [[CONSTOPPTRBYVAL]] : $@convention(c) (@in ConstOpPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[SELFACCESS:%.*]], [[NEWVALUE]]) : $@convention(c) (@in ConstOpPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>
 // CHECK: } // end sil function '$sSo15ConstOpPtrByValVySPys5Int32VGSgADcig
 
 public func index(_ arr: inout ConstPtrByVal, _ arg: Int32, _ val: Int32) -> Int32 { arr[arg]![0] }
@@ -176,12 +164,12 @@ public func index(_ arr: inout ConstPtrByVal, _ arg: Int32, _ val: Int32) -> Int
 // CHECK:   end_access [[SELFACCESS]] : $*ConstPtrByVal
 // CHECK: } // end sil function '$sSo13ConstPtrByValVySPys5Int32VGSgADcig
 
-// CHECK: sil [clang ReadOnlyIntArray.__operatorSubscriptConst] [[READCLASSNAME]] : $@convention(c) (@inout ReadOnlyIntArray, Int32) -> UnsafePointer<Int32>
+// CHECK: sil [clang ReadOnlyIntArray.__operatorSubscriptConst] [[READCLASSNAME]] : $@convention(c) (@in ReadOnlyIntArray, Int32) -> UnsafePointer<Int32>
 // CHECK: sil [clang ReadWriteIntArray.__operatorSubscript] [[READWRITECLASSNAME]] : $@convention(c) (@inout ReadWriteIntArray, Int32) -> UnsafeMutablePointer<Int32>
-// CHECK: sil [clang NonTrivialIntArrayByVal.__operatorSubscriptConst] [[READWRITECLASSNAMEBYVAL]] : $@convention(c) (@inout NonTrivialIntArrayByVal, Int32) -> Int32
+// CHECK: sil [clang NonTrivialIntArrayByVal.__operatorSubscriptConst] [[READWRITECLASSNAMEBYVAL]] : $@convention(c) (@in NonTrivialIntArrayByVal, Int32) -> Int32
 
 // CHECK: sil [clang PtrByVal.__operatorSubscript] [[PTRBYVAL]] : $@convention(c) (@inout PtrByVal, Int32) -> Optional<UnsafeMutablePointer<Int32>>
 // CHECK: sil [clang RefToPtr.__operatorSubscript] [[REFTOPTR]] : $@convention(c) (@inout RefToPtr, Int32) -> UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int32>>>
 // CHECK: sil [clang PtrToPtr.__operatorSubscript] [[PTRTOPTR]] : $@convention(c) (@inout PtrToPtr, Int32) -> Optional<UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int32>>>>
-// CHECK: sil [clang ConstOpPtrByVal.__operatorSubscriptConst] [[CONSTOPPTRBYVAL]] : $@convention(c) (@inout ConstOpPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>
+// CHECK: sil [clang ConstOpPtrByVal.__operatorSubscriptConst] [[CONSTOPPTRBYVAL]] : $@convention(c) (@in ConstOpPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>
 // CHECK: sil [clang ConstPtrByVal.__operatorSubscriptConst] [[CONSTPTRBYVAL]] : $@convention(c) (@inout ConstPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -56,7 +56,7 @@ OperatorsTestSuite.test("ReadWriteIntArray.subscript (inline)") {
 }
 
 OperatorsTestSuite.test("ReadOnlyIntArray.subscript (inline)") {
-  var arr = ReadOnlyIntArray(1)
+  let arr = ReadOnlyIntArray(1)
 
   let result0 = arr[0]
   let result2 = arr[2]
@@ -80,7 +80,7 @@ OperatorsTestSuite.test("WriteOnlyIntArray.subscript (inline)") {
 }
 
 OperatorsTestSuite.test("DifferentTypesArray.subscript (inline)") {
-  var arr = DifferentTypesArray()
+  let arr = DifferentTypesArray()
 
   let resultInt: Int32 = arr[2]
   let resultDouble: Double = arr[0.1]

--- a/test/Interop/Cxx/operators/member-out-of-line-silgen.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line-silgen.swift
@@ -5,12 +5,10 @@
 
 import MemberOutOfLine
 
-public func add(_ lhs: inout LoadableIntWrapper, _ rhs: LoadableIntWrapper) -> LoadableIntWrapper { lhs + rhs }
+public func add(_ lhs: LoadableIntWrapper, _ rhs: LoadableIntWrapper) -> LoadableIntWrapper { lhs + rhs }
 
-// CHECK: bb0([[LHS:%.*]] : $*LoadableIntWrapper, [[RHS:%.*]] : $LoadableIntWrapper):
-// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [static] [[LHS]] : $*LoadableIntWrapper
-// CHECK:   [[FUNC:%.*]] = function_ref [[NAME:@_ZNK18LoadableIntWrapperplES_]] : $@convention(c) (@inout LoadableIntWrapper, LoadableIntWrapper) -> LoadableIntWrapper
-// CHECK:   apply [[FUNC]]([[ACCESS]], [[RHS]]) : $@convention(c) (@inout LoadableIntWrapper, LoadableIntWrapper) -> LoadableIntWrapper
-// CHECK:   end_access [[ACCESS]] : $*LoadableIntWrapper
+// CHECK: bb0([[LHS:%.*]] : $LoadableIntWrapper, [[RHS:%.*]] : $LoadableIntWrapper):
+// CHECK:   [[FUNC:%.*]] = function_ref [[NAME:@_ZNK18LoadableIntWrapperplES_]] : $@convention(c) (@in LoadableIntWrapper, LoadableIntWrapper) -> LoadableIntWrapper
+// CHECK:   apply [[FUNC]]([[ACCESS:%.*]], [[RHS]]) : $@convention(c) (@in LoadableIntWrapper, LoadableIntWrapper) -> LoadableIntWrapper
 
-// CHECK: sil [clang LoadableIntWrapper."+"] [[NAME]] : $@convention(c) (@inout LoadableIntWrapper, LoadableIntWrapper) -> LoadableIntWrapper
+// CHECK: sil [clang LoadableIntWrapper."+"] [[NAME]] : $@convention(c) (@in LoadableIntWrapper, LoadableIntWrapper) -> LoadableIntWrapper

--- a/test/Interop/Cxx/operators/member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line.swift
@@ -15,7 +15,7 @@ import StdlibUnittest
 var OperatorsTestSuite = TestSuite("Operators")
 
 OperatorsTestSuite.test("LoadableIntWrapper.plus (out-of-line)") {
-  var lhs = LoadableIntWrapper(value: 42)
+  let lhs = LoadableIntWrapper(value: 42)
   let rhs = LoadableIntWrapper(value: 23)
 
   let result = lhs + rhs
@@ -24,7 +24,7 @@ OperatorsTestSuite.test("LoadableIntWrapper.plus (out-of-line)") {
 }
 
 OperatorsTestSuite.test("LoadableIntWrapper.call (out-of-line)") {
-  var wrapper = LoadableIntWrapper(value: 42)
+  let wrapper = LoadableIntWrapper(value: 42)
 
   let resultNoArgs = wrapper()
   let resultOneArg = wrapper(23)
@@ -36,7 +36,7 @@ OperatorsTestSuite.test("LoadableIntWrapper.call (out-of-line)") {
 }
 
 OperatorsTestSuite.test("AddressOnlyIntWrapper.call (out-of-line)") {
-  var wrapper = AddressOnlyIntWrapper(42)
+  let wrapper = AddressOnlyIntWrapper(42)
 
   let resultNoArgs = wrapper()
   let resultOneArg = wrapper(23)

--- a/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
@@ -2,8 +2,8 @@
 
 import NonMemberInline
 
-var lhs = LoadableIntWrapper(value: 42)
-var rhs = LoadableIntWrapper(value: 23)
+let lhs = LoadableIntWrapper(value: 42)
+let rhs = LoadableIntWrapper(value: 23)
 
 let resultPlus = lhs + rhs
 let resultMinus = lhs - rhs

--- a/test/Interop/Cxx/templates/canonical-types-module-interface.swift
+++ b/test/Interop/Cxx/templates/canonical-types-module-interface.swift
@@ -4,13 +4,13 @@
 // CHECK-NEXT:   var t: IntWrapper
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(t: IntWrapper)
-// CHECK-NEXT:   mutating func getValuePlusArg(_ arg: Int32) -> Int32
+// CHECK-NEXT:   func getValuePlusArg(_ arg: Int32) -> Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct IntWrapper {
 // CHECK-NEXT:   var value: Int32
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(value: Int32)
-// CHECK-NEXT:   mutating func getValue() -> Int32
+// CHECK-NEXT:   func getValue() -> Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: typealias WrappedMagicNumberA = __CxxTemplateInst12MagicWrapperI10IntWrapperE
 // CHECK-NEXT: typealias WrappedMagicNumberB = __CxxTemplateInst12MagicWrapperI10IntWrapperE

--- a/test/Interop/Cxx/templates/member-templates-module-interface.swift
+++ b/test/Interop/Cxx/templates/member-templates-module-interface.swift
@@ -6,8 +6,8 @@
 // CHECK:   mutating func addAll<T, U>(_ a: Int32, _ b: T, _ c: U) -> Int32
 // CHECK:   mutating func passThrough<T>(_ val: T) -> T
 // CHECK:   mutating func passThroughConst<T>(_ val: T) -> T
-// CHECK:   mutating func passThroughOnConst<T>(_ val: T) -> T
-// CHECK:   mutating func passThroughConstOnConst<T>(_ val: T) -> T
+// CHECK:   func passThroughOnConst<T>(_ val: T) -> T
+// CHECK:   func passThroughConstOnConst<T>(_ val: T) -> T
 // CHECK:   mutating func doNothingConstRef<T>(_ val: UnsafePointer<T>)
 // CHECK:   mutating func make42Ref<T>(_ val: UnsafeMutablePointer<T>)
 // CHECK: }

--- a/test/Interop/Cxx/templates/not-pre-defined-class-template-module-interface.swift
+++ b/test/Interop/Cxx/templates/not-pre-defined-class-template-module-interface.swift
@@ -4,12 +4,12 @@
 // CHECK-NEXT:   var t: IntWrapper
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(t: IntWrapper)
-// CHECK-NEXT:   mutating func getValuePlusArg(_ arg: Int32) -> Int32
+// CHECK-NEXT:   func getValuePlusArg(_ arg: Int32) -> Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct IntWrapper {
 // CHECK-NEXT:   var value: Int32
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(value: Int32)
-// CHECK-NEXT:   mutating func getValue() -> Int32
+// CHECK-NEXT:   func getValue() -> Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: typealias MagicallyWrappedIntWithoutDefinition = __CxxTemplateInst12MagicWrapperI10IntWrapperE

--- a/test/Interop/Cxx/templates/partially-pre-defined-class-template-silgen.swift
+++ b/test/Interop/Cxx/templates/partially-pre-defined-class-template-silgen.swift
@@ -4,7 +4,7 @@ import PartiallyPreDefinedClassTemplate
 
 public func getWrappedMagicInt() -> CInt {
   let myInt = IntWrapper(value: 21)
-  var magicInt = PartiallyPreDefinedMagicallyWrappedInt(t: myInt)
+  let magicInt = PartiallyPreDefinedMagicallyWrappedInt(t: myInt)
   return magicInt.getValuePlusArg(32)
 }
 
@@ -13,9 +13,9 @@ public func getWrappedMagicInt() -> CInt {
 // CHECK: [[INT_WRAPPER:%.*]] = struct $IntWrapper ([[_:%.*]] : $Int32)
 // CHECK: [[_:%.*]] = struct $__CxxTemplateInst12MagicWrapperI10IntWrapperE ([[INT_WRAPPER]] : $IntWrapper)
 // CHECK: // function_ref {{_ZNK12MagicWrapperI10IntWrapperE15getValuePlusArgEi|\?getValuePlusArg@\?\$MagicWrapper@UIntWrapper@@@@QEBAHH@Z}}
-// CHECK: [[_:%.*]] = function_ref @{{_ZNK12MagicWrapperI10IntWrapperE15getValuePlusArgEi|\?getValuePlusArg@\?\$MagicWrapper@UIntWrapper@@@@QEBAHH@Z}} : $@convention(c) (@inout __CxxTemplateInst12MagicWrapperI10IntWrapperE, Int32) -> Int32
+// CHECK: [[_:%.*]] = function_ref @{{_ZNK12MagicWrapperI10IntWrapperE15getValuePlusArgEi|\?getValuePlusArg@\?\$MagicWrapper@UIntWrapper@@@@QEBAHH@Z}} : $@convention(c) (@in __CxxTemplateInst12MagicWrapperI10IntWrapperE, Int32) -> Int32
 
 // CHECK: // {{_ZNK12MagicWrapperI10IntWrapperE15getValuePlusArgEi|\?getValuePlusArg@\?\$MagicWrapper@UIntWrapper@@@@QEBAHH@Z}}
 // CHECK: MagicWrapper<IntWrapper>::getValuePlusArg
 
-// CHECK: sil [clang __CxxTemplateInst12MagicWrapperI10IntWrapperE.getValuePlusArg] @{{_ZNK12MagicWrapperI10IntWrapperE15getValuePlusArgEi|\?getValuePlusArg@\?\$MagicWrapper@UIntWrapper@@@@QEBAHH@Z}} : $@convention(c) (@inout __CxxTemplateInst12MagicWrapperI10IntWrapperE, Int32) -> Int32
+// CHECK: sil [clang __CxxTemplateInst12MagicWrapperI10IntWrapperE.getValuePlusArg] @{{_ZNK12MagicWrapperI10IntWrapperE15getValuePlusArgEi|\?getValuePlusArg@\?\$MagicWrapper@UIntWrapper@@@@QEBAHH@Z}} : $@convention(c) (@in __CxxTemplateInst12MagicWrapperI10IntWrapperE, Int32) -> Int32

--- a/test/Interop/Cxx/templates/using-directive-module-interface.swift
+++ b/test/Interop/Cxx/templates/using-directive-module-interface.swift
@@ -4,12 +4,12 @@
 // CHECK-NEXT:   var t: IntWrapper
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(t: IntWrapper)
-// CHECK-NEXT:   mutating func getValuePlusArg(_ arg: Int32) -> Int32
+// CHECK-NEXT:   func getValuePlusArg(_ arg: Int32) -> Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct IntWrapper {
 // CHECK-NEXT:   var value: Int32
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(value: Int32)
-// CHECK-NEXT:   mutating func getValue() -> Int32
+// CHECK-NEXT:   func getValue() -> Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: typealias UsingWrappedMagicNumber = __CxxTemplateInst12MagicWrapperI10IntWrapperE


### PR DESCRIPTION
This change makes ClangImporter import some C++ member functions as non-mutating, given that they satisfy two requirements:
* the function itself is declared as `const`
* the parent struct doesn't contain any `mutable` members

`get` accessors of subscript operators are now also imported as non-mutating if the C++ `operator[]` satisfies the requirements above.

In the future we should allow annotating a C++ method as `mutating` explicitly, to make it possible to preserve the correct behavior for methods that are declared `const`, but mutate the object anyway, for example via `const_cast`.

Fixes SR-12795.