### PR TITLE
Update independent-fine.swift

### DIFF
--- a/test/Driver/Dependencies/independent-fine.swift
+++ b/test/Driver/Dependencies/independent-fine.swift
@@ -36,7 +36,9 @@
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // Don't change the priors mod time.
-// RUN: touch -t 201401240006 %t/*.{swift,swiftdeps,json}
+// RUN: touch -t 201401240006 %t/*.swift
+// RUN: touch -t 201401240006 %t/*.swiftdeps
+// RUN: touch -t 201401240006 %t/*.json
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
 
 


### PR DESCRIPTION
Remove bashisms harder.  There was a second instance of a bash specific pattern which breaks the Windows 2017 CI.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
