### PR TITLE
Make derived hashValue/hash(into:) nonisolated.

### DIFF
--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -550,6 +550,12 @@ deriveHashable_hashInto(
   hashDecl->copyFormalAccessFrom(derived.Nominal,
                                  /*sourceIsParentContext=*/true);
 
+  // The derived hash(into:) for an actor must be non-isolated.
+  if (derived.Nominal->isActor() ||
+      getActorIsolation(derived.Nominal) == ActorIsolation::GlobalActor) {
+    hashDecl->getAttrs().add(new (C) NonisolatedAttr(/*IsImplicit*/true));
+  }
+
   derived.addMembersToConformanceContext({hashDecl});
 
   return hashDecl;
@@ -904,10 +910,9 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
   hashValueDecl->copyFormalAccessFrom(derived.Nominal,
                                       /*sourceIsParentContext*/ true);
 
-  if (derived.Nominal->isDistributedActor()) {
-    // While distributed actors implement hash(into:) explicitly, the hashValue
-    // is still synthesized as usual. We must make it nonisolated in order
-    // for the hashValue to be able to witness the protocol requirement.
+  // The derived hashValue of an actor must be nonisolated.
+  if (derived.Nominal->isActor() ||
+      getActorIsolation(derived.Nominal) == ActorIsolation::GlobalActor) {
     hashValueDecl->getAttrs().add(new (C) NonisolatedAttr(/*IsImplicit*/true));
   }
 

--- a/test/decl/protocol/conforms/actor_derived.swift
+++ b/test/decl/protocol/conforms/actor_derived.swift
@@ -1,0 +1,30 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: concurrency
+
+@available(SwiftStdlib 5.5, *)
+actor A1: Hashable {
+  nonisolated func hash(into hasher: inout Hasher) { }
+  static func ==(lhs: A1, rhs: A1) -> Bool { true }
+}
+
+@available(SwiftStdlib 5.5, *)
+actor A2: Hashable {
+  nonisolated var hashValue: Int { 0 } // expected-warning{{'Hashable.hashValue' is deprecated as a protocol requirement; conform type 'A2' to 'Hashable' by implementing 'hash(into:)' instead}}
+  static func ==(lhs: A2, rhs: A2) -> Bool { true }
+}
+
+
+@available(SwiftStdlib 5.5, *)
+@MainActor
+class C1: Hashable {
+  nonisolated func hash(into hasher: inout Hasher) { }
+  nonisolated static func ==(lhs: C1, rhs: C1) -> Bool { true }
+}
+
+@available(SwiftStdlib 5.5, *)
+@MainActor
+class C2: Hashable {
+  nonisolated var hashValue: Int { 0 } // expected-warning{{'Hashable.hashValue' is deprecated as a protocol requirement; conform type 'C2' to 'Hashable' by implementing 'hash(into:)' instead}}
+  nonisolated static func ==(lhs: C2, rhs: C2) -> Bool { true }
+}
+

--- a/test/decl/protocol/special/Actor.swift
+++ b/test/decl/protocol/special/Actor.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
 // REQUIRES: concurrency
 
-// Synthesis of for actores.
+// Synthesis of conformances for actors.
 
 @available(SwiftStdlib 5.5, *)
 actor A1 {


### PR DESCRIPTION
Fixes rdar://80424527.
