### PR TITLE
[exclusivity] Split out of Exclusivity.cpp FunctionReplacement and the Global TLSContext.

### DIFF
--- a/include/swift/Runtime/Exclusivity.h
+++ b/include/swift/Runtime/Exclusivity.h
@@ -40,25 +40,6 @@ SWIFT_RUNTIME_EXPORT
 void swift_beginAccess(void *pointer, ValueBuffer *buffer,
                        ExclusivityFlags flags, void *pc);
 
-/// Loads the replacement function pointer from \p ReplFnPtr and returns the
-/// replacement function if it should be called.
-/// Returns null if the original function (which is passed in \p CurrFn) should
-/// be called.
-#ifdef __APPLE__
-__attribute__((weak_import))
-#endif
-SWIFT_RUNTIME_EXPORT
-char *swift_getFunctionReplacement(char **ReplFnPtr, char *CurrFn);
-
-/// Returns the original function of a replaced function, which is loaded from
-/// \p OrigFnPtr.
-/// This function is called from a replacement function to call the original
-/// function.
-#ifdef __APPLE__
-__attribute__((weak_import))
-#endif
-SWIFT_RUNTIME_EXPORT
-char *swift_getOrigOfReplaceable(char **OrigFnPtr);
 
 /// Stop dynamically tracking an access.
 SWIFT_RUNTIME_EXPORT

--- a/include/swift/Runtime/FunctionReplacement.h
+++ b/include/swift/Runtime/FunctionReplacement.h
@@ -1,0 +1,42 @@
+//===--- FunctionReplacement.h --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_FUNCTIONREPLACEMENT_H
+#define SWIFT_RUNTIME_FUNCTIONREPLACEMENT_H
+
+#include "swift/Runtime/Config.h"
+
+namespace swift {
+
+/// Loads the replacement function pointer from \p ReplFnPtr and returns the
+/// replacement function if it should be called.
+/// Returns null if the original function (which is passed in \p CurrFn) should
+/// be called.
+#ifdef __APPLE__
+__attribute__((weak_import))
+#endif
+SWIFT_RUNTIME_EXPORT char *
+swift_getFunctionReplacement(char **ReplFnPtr, char *CurrFn);
+
+/// Returns the original function of a replaced function, which is loaded from
+/// \p OrigFnPtr.
+/// This function is called from a replacement function to call the original
+/// function.
+#ifdef __APPLE__
+__attribute__((weak_import))
+#endif
+SWIFT_RUNTIME_EXPORT char *
+swift_getOrigOfReplaceable(char **OrigFnPtr);
+
+} // namespace swift
+
+#endif

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -45,6 +45,7 @@ set(swift_runtime_sources
     ExistentialContainer.cpp
     Float16Support.cpp
     FoundationSupport.cpp
+    FunctionReplacement.cpp
     Heap.cpp
     HeapObject.cpp
     ImageInspectionCommon.cpp
@@ -65,7 +66,8 @@ set(swift_runtime_sources
     RefCount.cpp
     ReflectionMirror.cpp
     RuntimeInvocationsTracking.cpp
-    SwiftDtoa.cpp)
+    SwiftDtoa.cpp
+    SwiftTLSContext.cpp)
 
 # Acknowledge that the following sources are known.
 set(LLVM_OPTIONAL_SOURCES

--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -25,15 +25,16 @@
 
 #include "swift/Runtime/Exclusivity.h"
 #include "../SwiftShims/Visibility.h"
+#include "SwiftTLSContext.h"
 #include "swift/Basic/Lazy.h"
 #include "swift/Runtime/Config.h"
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/EnvironmentVariables.h"
 #include "swift/Runtime/Metadata.h"
 #include "swift/Runtime/ThreadLocalStorage.h"
-#include <inttypes.h>
+#include <cinttypes>
+#include <cstdio>
 #include <memory>
-#include <stdio.h>
 
 // Pick a return-address strategy
 #if __GNUC__
@@ -47,6 +48,7 @@
 #endif
 
 using namespace swift;
+using namespace swift::runtime;
 
 bool swift::_swift_disableExclusivityChecking = false;
 
@@ -150,275 +152,94 @@ static void reportExclusivityConflict(ExclusivityFlags oldAction, void *oldPC,
   _swift_reportToDebugger(RuntimeErrorFlagFatal, message, &details);
 }
 
-namespace {
-
-/// A single access that we're tracking.
-///
-/// The following inputs are accepted by the begin_access runtime entry
-/// point. This table show the action performed by the current runtime to
-/// convert those inputs into stored fields in the Access scratch buffer.
-///
-/// Pointer | Runtime     | Access | PC    | Reported| Access
-/// Argument| Behavior    | Pointer| Arg   | PC      | PC
-/// -------- ------------- -------- ------- --------- ----------
-/// null    | [trap or missing enforcement]
-/// nonnull | [nontracked]| null   | null  | caller  | [discard]
-/// nonnull | [nontracked]| null   | valid | <same>  | [discard]
-/// nonnull | [tracked]   | <same> | null  | caller  | caller
-/// nonnull | [tracked]   | <same> | valid | <same>  | <same>
-///
-/// [nontracked] means that the Access scratch buffer will not be added to the
-/// runtime's list of tracked accesses. However, it may be passed to a
-/// subsequent call to end_unpaired_access. The null Pointer field then
-/// identifies the Access record as nontracked.
-///
-/// The runtime owns the contents of the scratch buffer, which is allocated by
-/// the compiler but otherwise opaque. The runtime may later reuse the Pointer
-/// or PC fields or any spare bits for additional flags, and/or a pointer to
-/// out-of-line storage.
-struct Access {
-  void *Pointer;
-  void *PC;
-  uintptr_t NextAndAction;
-
-  enum : uintptr_t {
-    ActionMask = (uintptr_t)ExclusivityFlags::ActionMask,
-    NextMask = ~ActionMask
-  };
-
-  Access *getNext() const {
-    return reinterpret_cast<Access*>(NextAndAction & NextMask);
+bool AccessSet::insert(Access *access, void *pc, void *pointer,
+                       ExclusivityFlags flags) {
+#ifndef NDEBUG
+  if (isExclusivityLoggingEnabled()) {
+    withLoggingLock(
+        [&]() { fprintf(stderr, "Inserting new access: %p\n", access); });
   }
+#endif
+  auto action = getAccessAction(flags);
 
-  void setNext(Access *next) {
-    NextAndAction =
-      reinterpret_cast<uintptr_t>(next) | (NextAndAction & ActionMask);
+  for (Access *cur = Head; cur != nullptr; cur = cur->getNext()) {
+    // Ignore accesses to different values.
+    if (cur->Pointer != pointer)
+      continue;
+
+    // If both accesses are reads, it's not a conflict.
+    if (action == ExclusivityFlags::Read && action == cur->getAccessAction())
+      continue;
+
+    // Otherwise, it's a conflict.
+    reportExclusivityConflict(cur->getAccessAction(), cur->PC, flags, pc,
+                              pointer);
+
+    // 0 means no backtrace will be printed.
+    fatalError(0, "Fatal access conflict detected.\n");
   }
-
-  ExclusivityFlags getAccessAction() const {
-    return ExclusivityFlags(NextAndAction & ActionMask);
-  }
-
-  void initialize(void *pc, void *pointer, Access *next,
-                  ExclusivityFlags action) {
-    Pointer = pointer;
-    PC = pc;
-    NextAndAction = reinterpret_cast<uintptr_t>(next) | uintptr_t(action);
-  }
-};
-
-static_assert(sizeof(Access) <= sizeof(ValueBuffer) &&
-              alignof(Access) <= alignof(ValueBuffer),
-              "Access doesn't fit in a value buffer!");
-
-/// A set of accesses that we're tracking.  Just a singly-linked list.
-class AccessSet {
-  Access *Head = nullptr;
-public:
-  constexpr AccessSet() {}
-  constexpr AccessSet(Access *Head) : Head(Head) {}
-
-  constexpr operator bool() const { return bool(Head); }
-  constexpr Access *getHead() const { return Head; }
-  void setHead(Access *newHead) { Head = newHead; }
-  constexpr bool isHead(Access *access) const { return Head == access; }
-
-  bool insert(Access *access, void *pc, void *pointer, ExclusivityFlags flags) {
+  if (!isTracking(flags)) {
 #ifndef NDEBUG
     if (isExclusivityLoggingEnabled()) {
-      withLoggingLock(
-          [&]() { fprintf(stderr, "Inserting new access: %p\n", access); });
+      withLoggingLock([&]() { fprintf(stderr, "  Not tracking!\n"); });
     }
 #endif
-    auto action = getAccessAction(flags);
-
-    for (Access *cur = Head; cur != nullptr; cur = cur->getNext()) {
-      // Ignore accesses to different values.
-      if (cur->Pointer != pointer)
-        continue;
-
-      // If both accesses are reads, it's not a conflict.
-      if (action == ExclusivityFlags::Read &&
-          action == cur->getAccessAction())
-        continue;
-
-      // Otherwise, it's a conflict.
-      reportExclusivityConflict(cur->getAccessAction(), cur->PC,
-                                flags, pc, pointer);
-
-      // 0 means no backtrace will be printed.
-      fatalError(0, "Fatal access conflict detected.\n");
-    }
-    if (!isTracking(flags)) {
-#ifndef NDEBUG
-      if (isExclusivityLoggingEnabled()) {
-        withLoggingLock([&]() { fprintf(stderr, "  Not tracking!\n"); });
-      }
-#endif
-      return false;
-    }
-
-    // Insert to the front of the array so that remove tends to find it faster.
-    access->initialize(pc, pointer, Head, action);
-    Head = access;
-#ifndef NDEBUG
-    if (isExclusivityLoggingEnabled()) {
-      withLoggingLock([&]() {
-        fprintf(stderr, "  Tracking!\n");
-        swift_dumpTrackedAccesses();
-      });
-    }
-#endif
-    return true;
+    return false;
   }
 
-  void remove(Access *access) {
-    assert(Head && "removal from empty AccessSet");
+  // Insert to the front of the array so that remove tends to find it faster.
+  access->initialize(pc, pointer, Head, action);
+  Head = access;
 #ifndef NDEBUG
-    if (isExclusivityLoggingEnabled()) {
-      withLoggingLock(
-          [&]() { fprintf(stderr, "Removing access: %p\n", access); });
-    }
+  if (isExclusivityLoggingEnabled()) {
+    withLoggingLock([&]() {
+      fprintf(stderr, "  Tracking!\n");
+      swift_dumpTrackedAccesses();
+    });
+  }
 #endif
-    auto cur = Head;
-    // Fast path: stack discipline.
+  return true;
+}
+
+void AccessSet::remove(Access *access) {
+  assert(Head && "removal from empty AccessSet");
+#ifndef NDEBUG
+  if (isExclusivityLoggingEnabled()) {
+    withLoggingLock(
+        [&]() { fprintf(stderr, "Removing access: %p\n", access); });
+  }
+#endif
+  auto cur = Head;
+  // Fast path: stack discipline.
+  if (cur == access) {
+    Head = cur->getNext();
+    return;
+  }
+
+  Access *last = cur;
+  for (cur = cur->getNext(); cur != nullptr; last = cur, cur = cur->getNext()) {
+    assert(last->getNext() == cur);
     if (cur == access) {
-      Head = cur->getNext();
+      last->setNext(cur->getNext());
       return;
     }
-
-    Access *last = cur;
-    for (cur = cur->getNext(); cur != nullptr;
-         last = cur, cur = cur->getNext()) {
-      assert(last->getNext() == cur);
-      if (cur == access) {
-        last->setNext(cur->getNext());
-        return;
-      }
-    }
-
-    swift_unreachable("access not found in set");
   }
 
-  /// Return the parent access of \p childAccess in the list.
-  Access *findParentAccess(Access *childAccess) {
-    auto cur = Head;
-    Access *last = cur;
-    for (cur = cur->getNext(); cur != nullptr;
-         last = cur, cur = cur->getNext()) {
-      assert(last->getNext() == cur);
-      if (cur == childAccess) {
-        return last;
-      }
-    }
-    return nullptr;
-  }
-
-  Access *getTail() const {
-    auto cur = Head;
-    if (!cur)
-      return nullptr;
-
-    while (auto *next = cur->getNext()) {
-      cur = next;
-    }
-    assert(cur != nullptr);
-    return cur;
-  }
+  swift_unreachable("access not found in set");
+}
 
 #ifndef NDEBUG
-  /// Only available with asserts. Intended to be used with
-  /// swift_dumpTrackedAccess().
-  void forEach(std::function<void (Access *)> action) {
-    for (auto *iter = Head; iter != nullptr; iter = iter->getNext()) {
-      action(iter);
-    }
+/// Only available with asserts. Intended to be used with
+/// swift_dumpTrackedAccess().
+void AccessSet::forEach(std::function<void(Access *)> action) {
+  for (auto *iter = Head; iter != nullptr; iter = iter->getNext()) {
+    action(iter);
   }
+}
 #endif
-};
-
-class SwiftTLSContext {
-public:
-  /// The set of tracked accesses.
-  AccessSet accessSet;
-
-  // The "implicit" boolean parameter which is passed to a dynamically
-  // replaceable function.
-  // If true, the original function should be executed instead of the
-  // replacement function.
-  bool CallOriginalOfReplacedFunction = false;
-};
-
-} // end anonymous namespace
 
 // Each of these cases should define a function with this prototype:
 //   AccessSets &getAllSets();
-
-#ifdef SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
-
-static SwiftTLSContext &getTLSContext() {
-  static SwiftTLSContext TLSContext;
-  return TLSContext;
-}
-
-#elif SWIFT_TLS_HAS_RESERVED_PTHREAD_SPECIFIC
-// Use the reserved TSD key if possible.
-
-static SwiftTLSContext &getTLSContext() {
-  SwiftTLSContext *ctx = static_cast<SwiftTLSContext*>(
-    SWIFT_THREAD_GETSPECIFIC(SWIFT_RUNTIME_TLS_KEY));
-  if (ctx)
-    return *ctx;
-  
-  static OnceToken_t setupToken;
-  SWIFT_ONCE_F(setupToken, [](void *) {
-    pthread_key_init_np(SWIFT_RUNTIME_TLS_KEY, [](void *pointer) {
-      delete static_cast<SwiftTLSContext*>(pointer);
-    });
-  }, nullptr);
-  
-  ctx = new SwiftTLSContext();
-  SWIFT_THREAD_SETSPECIFIC(SWIFT_RUNTIME_TLS_KEY, ctx);
-  return *ctx;
-}
-
-#elif __has_feature(cxx_thread_local)
-// Second choice is direct language support for thread-locals.
-
-static thread_local SwiftTLSContext TLSContext;
-
-static SwiftTLSContext &getTLSContext() {
-  return TLSContext;
-}
-
-#else
-// Use the platform thread-local data API.
-
-static __swift_thread_key_t createSwiftThreadKey() {
-  __swift_thread_key_t key;
-  int result = SWIFT_THREAD_KEY_CREATE(&key, [](void *pointer) {
-    delete static_cast<SwiftTLSContext*>(pointer);
-  });
-
-  if (result != 0) {
-    fatalError(0, "couldn't create thread key for exclusivity: %s\n",
-               strerror(result));
-  }
-  return key;
-}
-
-static SwiftTLSContext &getTLSContext() {
-  static __swift_thread_key_t key = createSwiftThreadKey();
-
-  SwiftTLSContext *ctx = static_cast<SwiftTLSContext*>(SWIFT_THREAD_GETSPECIFIC(key));
-  if (!ctx) {
-    ctx = new SwiftTLSContext();
-    SWIFT_THREAD_SETSPECIFIC(key, ctx);
-  }
-  return *ctx;
-}
-
-#endif
 
 /// Begin tracking a dynamic access.
 ///
@@ -442,7 +263,7 @@ void swift::swift_beginAccess(void *pointer, ValueBuffer *buffer,
   if (!pc)
     pc = get_return_address();
 
-  if (!getTLSContext().accessSet.insert(access, pc, pointer, flags))
+  if (!SwiftTLSContext::get().accessSet.insert(access, pc, pointer, flags))
     access->Pointer = nullptr;
 }
 
@@ -457,31 +278,7 @@ void swift::swift_endAccess(ValueBuffer *buffer) {
     return;
   }
 
-  getTLSContext().accessSet.remove(access);
-}
-
-char *swift::swift_getFunctionReplacement(char **ReplFnPtr, char *CurrFn) {
-  char *ReplFn = *ReplFnPtr;
-  char *RawReplFn = ReplFn;
-
-#if SWIFT_PTRAUTH
-  RawReplFn = ptrauth_strip(RawReplFn, ptrauth_key_function_pointer);
-#endif
-  if (RawReplFn == CurrFn)
-    return nullptr;
-
-  SwiftTLSContext &ctx = getTLSContext();
-  if (ctx.CallOriginalOfReplacedFunction) {
-    ctx.CallOriginalOfReplacedFunction = false;
-    return nullptr;
-  }
-  return ReplFn;
-}
-
-char *swift::swift_getOrigOfReplaceable(char **OrigFnPtr) {
-  char *OrigFn = *OrigFnPtr;
-  getTLSContext().CallOriginalOfReplacedFunction = true;
-  return OrigFn;
+  SwiftTLSContext::get().accessSet.remove(access);
 }
 
 #ifndef NDEBUG
@@ -490,7 +287,7 @@ char *swift::swift_getOrigOfReplaceable(char **OrigFnPtr) {
 //
 // This is only intended to be used in the debugger.
 void swift::swift_dumpTrackedAccesses() {
-  auto &accessSet = getTLSContext().accessSet;
+  auto &accessSet = SwiftTLSContext::get().accessSet;
   if (!accessSet) {
     fprintf(stderr, "        No Accesses.\n");
     return;
@@ -744,7 +541,7 @@ struct SwiftTaskThreadLocalContext {
 // See algorithm description on SwiftTaskThreadLocalContext.
 void swift::swift_task_enterThreadLocalContext(char *state) {
   auto &taskCtx = *reinterpret_cast<SwiftTaskThreadLocalContext *>(state);
-  auto &tlsCtxAccessSet = getTLSContext().accessSet;
+  auto &tlsCtxAccessSet = SwiftTLSContext::get().accessSet;
 
 #ifndef NDEBUG
   if (isExclusivityLoggingEnabled()) {
@@ -834,7 +631,7 @@ void swift::swift_task_enterThreadLocalContext(char *state) {
 // See algorithm description on SwiftTaskThreadLocalContext.
 void swift::swift_task_exitThreadLocalContext(char *state) {
   auto &taskCtx = *reinterpret_cast<SwiftTaskThreadLocalContext *>(state);
-  auto &tlsCtxAccessSet = getTLSContext().accessSet;
+  auto &tlsCtxAccessSet = SwiftTLSContext::get().accessSet;
 
 #ifndef NDEBUG
   if (isExclusivityLoggingEnabled()) {

--- a/stdlib/public/runtime/ExclusivityPrivate.h
+++ b/stdlib/public/runtime/ExclusivityPrivate.h
@@ -1,0 +1,139 @@
+//===--- ExclusivityPrivate.h ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_EXCLUSIVITYPRIVATE_H
+#define SWIFT_RUNTIME_EXCLUSIVITYPRIVATE_H
+
+#include "swift/Runtime/Exclusivity.h"
+#include "swift/Runtime/Metadata.h"
+#include <cinttypes>
+
+namespace swift {
+namespace runtime {
+
+/// A single access that we're tracking.
+///
+/// The following inputs are accepted by the begin_access runtime entry
+/// point. This table show the action performed by the current runtime to
+/// convert those inputs into stored fields in the Access scratch buffer.
+///
+/// Pointer | Runtime     | Access | PC    | Reported| Access
+/// Argument| Behavior    | Pointer| Arg   | PC      | PC
+/// -------- ------------- -------- ------- --------- ----------
+/// null    | [trap or missing enforcement]
+/// nonnull | [nontracked]| null   | null  | caller  | [discard]
+/// nonnull | [nontracked]| null   | valid | <same>  | [discard]
+/// nonnull | [tracked]   | <same> | null  | caller  | caller
+/// nonnull | [tracked]   | <same> | valid | <same>  | <same>
+///
+/// [nontracked] means that the Access scratch buffer will not be added to the
+/// runtime's list of tracked accesses. However, it may be passed to a
+/// subsequent call to end_unpaired_access. The null Pointer field then
+/// identifies the Access record as nontracked.
+///
+/// The runtime owns the contents of the scratch buffer, which is allocated by
+/// the compiler but otherwise opaque. The runtime may later reuse the Pointer
+/// or PC fields or any spare bits for additional flags, and/or a pointer to
+/// out-of-line storage.
+struct Access {
+  void *Pointer;
+  void *PC;
+  uintptr_t NextAndAction;
+
+  enum : uintptr_t {
+    ActionMask = (uintptr_t)ExclusivityFlags::ActionMask,
+    NextMask = ~ActionMask
+  };
+
+  Access *getNext() const {
+    return reinterpret_cast<Access *>(NextAndAction & NextMask);
+  }
+
+  void setNext(Access *next) {
+    NextAndAction =
+        reinterpret_cast<uintptr_t>(next) | (NextAndAction & ActionMask);
+  }
+
+  ExclusivityFlags getAccessAction() const {
+    return ExclusivityFlags(NextAndAction & ActionMask);
+  }
+
+  void initialize(void *pc, void *pointer, Access *next,
+                  ExclusivityFlags action) {
+    Pointer = pointer;
+    PC = pc;
+    NextAndAction = reinterpret_cast<uintptr_t>(next) | uintptr_t(action);
+  }
+};
+
+static_assert(sizeof(Access) <= sizeof(ValueBuffer) &&
+                  alignof(Access) <= alignof(ValueBuffer),
+              "Access doesn't fit in a value buffer!");
+
+/// A set of accesses that we're tracking.  Just a singly-linked list.
+///
+/// NOTE: Please keep all implementations of methods of AccessSet within
+/// Exclusivity.cpp. We want this to ensure that when compiled in the runtime
+/// directly, the definitions of these methods are immediately available in that
+/// file for inlining.
+class AccessSet {
+  Access *Head = nullptr;
+
+public:
+  constexpr AccessSet() {}
+  constexpr AccessSet(Access *Head) : Head(Head) {}
+
+  constexpr operator bool() const { return bool(Head); }
+  constexpr Access *getHead() const { return Head; }
+  void setHead(Access *newHead) { Head = newHead; }
+  constexpr bool isHead(Access *access) const { return Head == access; }
+
+  bool insert(Access *access, void *pc, void *pointer, ExclusivityFlags flags);
+  void remove(Access *access);
+
+  /// Return the parent access of \p childAccess in the list.
+  Access *findParentAccess(Access *childAccess) const {
+    auto cur = Head;
+    Access *last = cur;
+    for (cur = cur->getNext(); cur != nullptr;
+         last = cur, cur = cur->getNext()) {
+      assert(last->getNext() == cur);
+      if (cur == childAccess) {
+        return last;
+      }
+    }
+    return nullptr;
+  }
+
+  Access *getTail() const {
+    auto cur = Head;
+    if (!cur)
+      return nullptr;
+
+    while (auto *next = cur->getNext()) {
+      cur = next;
+    }
+    assert(cur != nullptr);
+    return cur;
+  }
+
+#ifndef NDEBUG
+  /// Only available with asserts. Intended to be used with
+  /// swift_dumpTrackedAccess().
+  void forEach(std::function<void(Access *)> action);
+#endif
+};
+
+} // namespace runtime
+} // namespace swift
+
+#endif

--- a/stdlib/public/runtime/FunctionReplacement.cpp
+++ b/stdlib/public/runtime/FunctionReplacement.cpp
@@ -1,0 +1,41 @@
+//===--- FunctionReplacement.cpp ------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/FunctionReplacement.h"
+#include "SwiftTLSContext.h"
+
+using namespace swift;
+using namespace swift::runtime;
+
+char *swift::swift_getFunctionReplacement(char **ReplFnPtr, char *CurrFn) {
+  char *ReplFn = *ReplFnPtr;
+  char *RawReplFn = ReplFn;
+
+#if SWIFT_PTRAUTH
+  RawReplFn = ptrauth_strip(RawReplFn, ptrauth_key_function_pointer);
+#endif
+  if (RawReplFn == CurrFn)
+    return nullptr;
+
+  auto &ctx = SwiftTLSContext::get();
+  if (ctx.CallOriginalOfReplacedFunction) {
+    ctx.CallOriginalOfReplacedFunction = false;
+    return nullptr;
+  }
+  return ReplFn;
+}
+
+char *swift::swift_getOrigOfReplaceable(char **OrigFnPtr) {
+  char *OrigFn = *OrigFnPtr;
+  SwiftTLSContext::get().CallOriginalOfReplacedFunction = true;
+  return OrigFn;
+}

--- a/stdlib/public/runtime/SwiftTLSContext.cpp
+++ b/stdlib/public/runtime/SwiftTLSContext.cpp
@@ -1,0 +1,91 @@
+//===--- SwiftTLSContext.cpp ----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "SwiftTLSContext.h"
+#include "swift/Basic/Lazy.h"
+#include "swift/Runtime/Once.h"
+#include "swift/Runtime/ThreadLocalStorage.h"
+
+using namespace swift;
+using namespace swift::runtime;
+
+#ifdef SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
+
+SwiftTLSContext &SwiftTLSContext::get() {
+  static SwiftTLSContext TLSContext;
+  return TLSContext;
+}
+
+#elif SWIFT_TLS_HAS_RESERVED_PTHREAD_SPECIFIC
+// Use the reserved TSD key if possible.
+
+SwiftTLSContext &SwiftTLSContext::get() {
+  SwiftTLSContext *ctx = static_cast<SwiftTLSContext *>(
+      SWIFT_THREAD_GETSPECIFIC(SWIFT_RUNTIME_TLS_KEY));
+  if (ctx)
+    return *ctx;
+
+  static OnceToken_t setupToken;
+  SWIFT_ONCE_F(
+      setupToken,
+      [](void *) {
+        pthread_key_init_np(SWIFT_RUNTIME_TLS_KEY, [](void *pointer) {
+          delete static_cast<SwiftTLSContext *>(pointer);
+        });
+      },
+      nullptr);
+
+  ctx = new SwiftTLSContext();
+  SWIFT_THREAD_SETSPECIFIC(SWIFT_RUNTIME_TLS_KEY, ctx);
+  return *ctx;
+}
+
+#elif __has_feature(cxx_thread_local)
+// Second choice is direct language support for thread-locals.
+
+namespace {
+
+static thread_local SwiftTLSContext TLSContext;
+
+} // anonymous namespace
+
+SwiftTLSContext &SwiftTLSContext::get() { return TLSContext; }
+
+#else
+// Use the platform thread-local data API.
+
+static __swift_thread_key_t createSwiftThreadKey() {
+  __swift_thread_key_t key;
+  int result = SWIFT_THREAD_KEY_CREATE(&key, [](void *pointer) {
+    delete static_cast<SwiftTLSContext *>(pointer);
+  });
+
+  if (result != 0) {
+    fatalError(0, "couldn't create thread key for exclusivity: %s\n",
+               strerror(result));
+  }
+  return key;
+}
+
+static SwiftTLSContext &getTLSContext() {
+  static __swift_thread_key_t key = createSwiftThreadKey();
+
+  SwiftTLSContext *ctx =
+      static_cast<SwiftTLSContext *>(SWIFT_THREAD_GETSPECIFIC(key));
+  if (!ctx) {
+    ctx = new SwiftTLSContext();
+    SWIFT_THREAD_SETSPECIFIC(key, ctx);
+  }
+  return *ctx;
+}
+
+#endif

--- a/stdlib/public/runtime/SwiftTLSContext.h
+++ b/stdlib/public/runtime/SwiftTLSContext.h
@@ -1,0 +1,38 @@
+//===--- SwiftTLSContext.h ------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_SWIFTTLSCONTEXT_H
+#define SWIFT_RUNTIME_SWIFTTLSCONTEXT_H
+
+#include "ExclusivityPrivate.h"
+
+namespace swift {
+namespace runtime {
+
+class SwiftTLSContext {
+public:
+  /// The set of tracked accesses.
+  AccessSet accessSet;
+
+  // The "implicit" boolean parameter which is passed to a dynamically
+  // replaceable function.
+  // If true, the original function should be executed instead of the
+  // replacement function.
+  bool CallOriginalOfReplacedFunction = false;
+
+  static SwiftTLSContext &get();
+};
+
+} // namespace runtime
+} // namespace swift
+
+#endif

--- a/stdlib/toolchain/CompatibilityDynamicReplacements/DynamicReplaceable.cpp
+++ b/stdlib/toolchain/CompatibilityDynamicReplacements/DynamicReplaceable.cpp
@@ -17,8 +17,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/Runtime/Once.h"
 #include "swift/Runtime/Exclusivity.h"
+#include "swift/Runtime/FunctionReplacement.h"
+#include "swift/Runtime/Once.h"
 #include "swift/Runtime/ThreadLocalStorage.h"
 
 using namespace swift;


### PR DESCRIPTION
Some notes:

1. Even though I refactored out AccessSet/Access from Exclusivity.cpp ->
ExclusivityPrivate.h, I left the actual implementations of insert/remove in
Exclusivity.cpp to allow for the most aggressive optimization for use in
Exclusivity.cpp without exposing a bunch of internal details to other parts of
the runtime. Smaller routines like getHead() and manipulating the linked list
directly I left as methods that can be used by other parts of the runtime. I am
going to use these methods to enable backwards deployment of exclusivity support
for concurrency.

2. I moved function replacements out of the Exclusivity header/cpp files since
it has nothing to do with Exclusivity beyond taking advantage of the TLS context
that we are already using.
