### PR TITLE
Don't apply "Convert to Trailing Closure" to call with multiple trailing closures

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -3709,7 +3709,7 @@ static CallExpr *findTrailingClosureTarget(
     return nullptr;
   CallExpr *CE = cast<CallExpr>(contexts.back().get<Expr*>());
 
-  if (CE->hasTrailingClosure())
+  if (CE->getUnlabeledTrailingClosureIndex().hasValue())
     // Call expression already has a trailing closure.
     return nullptr;
 

--- a/test/refactoring/TrailingClosure/rdar81106400.swift
+++ b/test/refactoring/TrailingClosure/rdar81106400.swift
@@ -1,0 +1,9 @@
+func lottaClosures(x: () -> Void, y: () -> Void, z: () -> Void) {
+  lottaClosures(x: {}) {} z: {}
+}
+// RUN: not %refactor -trailingclosure -source-filename %s -pos=2:3
+
+func singleClosure(x: () -> Void) {
+  singleClosure {}
+}
+// RUN: not %refactor -trailingclosure -source-filename %s -pos=7:3


### PR DESCRIPTION
The `hasTrailingClosure` method has a super confusing name now, as it doesn't include multiple trailing closures. This is getting fixed in https://github.com/apple/swift/pull/37435, but split out this change to keep that patch as NFC as possible.

Previously we'd perform an invalid transform or hit an assertion failure when attempting to perform the "Convert to Trailing Closure" refactoring action on a call with multiple trailing closures. For now, disallow the transform for a call that already uses trailing closure syntax.

rdar://81106400