### PR TITLE
[TypeChecker] NFC: Add a test-case for `for-each` with `where` clause

### DIFF
--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -514,3 +514,9 @@ func rdar64157451() {
     if case .foo(let v as DoeNotExist) = e {} // expected-error {{cannot find type 'DoeNotExist' in scope}}
   }
 }
+
+// rdar://80797176 - circular reference incorrectly diagnosed while reaching for a type of a pattern.
+func rdar80797176 () {
+  for x: Int in [1, 2] where x.bitWidth == 32 { // Ok
+  }
+}


### PR DESCRIPTION

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
