### PR TITLE
[5.5] [SILGen] Used formal type when bridging completion handler arguments.

### DIFF
--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -1379,6 +1379,13 @@ public:
   /// Swift type.
   AbstractionPattern getObjCMethodAsyncCompletionHandlerType(
                                      CanType swiftCompletionHandlerType) const;
+
+  /// If this pattern refers to a foreign ObjC method that was imported as 
+  /// async, return the bridged-back-to-ObjC completion handler type.
+  CanType getObjCMethodAsyncCompletionHandlerForeignType(
+      ForeignAsyncConvention convention,
+      Lowering::TypeConverter &TC
+  ) const;
   
   void dump() const LLVM_ATTRIBUTE_USED;
   void print(raw_ostream &OS) const;

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -661,6 +661,30 @@ AbstractionPattern::getObjCMethodAsyncCompletionHandlerType(
   }
 }
 
+
+CanType AbstractionPattern::getObjCMethodAsyncCompletionHandlerForeignType(
+    ForeignAsyncConvention convention,
+    Lowering::TypeConverter &TC
+) const {
+  auto nativeCHTy = convention.completionHandlerType();
+
+  // Use the abstraction pattern we're lowering against in order to lower
+  // the completion handler type, so we can preserve C/ObjC distinctions that
+  // normally get abstracted away by the importer.
+  auto completionHandlerNativeOrigTy = getObjCMethodAsyncCompletionHandlerType(nativeCHTy);
+  
+  // Bridge the Swift completion handler type back to its
+  // foreign representation.
+  auto foreignCHTy = TC.getLoweredBridgedType(completionHandlerNativeOrigTy,
+                                    nativeCHTy,
+                                    Bridgeability::Full,
+                                    SILFunctionTypeRepresentation::ObjCMethod,
+                                    TypeConverter::ForArgument)
+    ->getCanonicalType();
+
+  return foreignCHTy;
+}
+
 AbstractionPattern
 AbstractionPattern::getFunctionParamType(unsigned index) const {
   switch (getKind()) {

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1676,25 +1676,9 @@ private:
         || NextOrigParamIndex != Foreign.Async->completionHandlerParamIndex())
       return false;
     
-    auto nativeCHTy = Foreign.Async->completionHandlerType();
-
-    // Use the abstraction pattern we're lowering against in order to lower
-    // the completion handler type, so we can preserve C/ObjC distinctions that
-    // normally get abstracted away by the importer.
-    auto completionHandlerNativeOrigTy = TopLevelOrigType
-      .getObjCMethodAsyncCompletionHandlerType(nativeCHTy);
-    
-    // Bridge the Swift completion handler type back to its
-    // foreign representation.
-    auto foreignCHTy = TC.getLoweredBridgedType(completionHandlerNativeOrigTy,
-                                      nativeCHTy,
-                                      Bridgeability::Full,
-                                      SILFunctionTypeRepresentation::ObjCMethod,
-                                      TypeConverter::ForArgument)
-      ->getCanonicalType();
-    
-    auto completionHandlerOrigTy = TopLevelOrigType
-      .getObjCMethodAsyncCompletionHandlerType(foreignCHTy);
+    CanType foreignCHTy = TopLevelOrigType
+      .getObjCMethodAsyncCompletionHandlerForeignType(Foreign.Async.getValue(), TC);
+    auto completionHandlerOrigTy = TopLevelOrigType.getObjCMethodAsyncCompletionHandlerType(foreignCHTy);
     auto completionHandlerTy = TC.getLoweredType(completionHandlerOrigTy,
                                                  foreignCHTy, expansion)
       .getASTType();

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -2784,7 +2784,7 @@ SILType GetAsyncContinuationInstBase::getLoweredResumeType() const {
   auto formalType = getFormalResumeType();
   auto &M = getFunction()->getModule();
   auto c = getFunction()->getTypeExpansionContext();
-  return M.Types.getLoweredType(AbstractionPattern::getOpaque(), formalType, c);
+  return M.Types.getLoweredType(AbstractionPattern(formalType), formalType, c);
 }
 
 ReturnInst::ReturnInst(SILFunction &func, SILDebugLocation debugLoc,

--- a/lib/SILGen/Callee.h
+++ b/lib/SILGen/Callee.h
@@ -23,6 +23,7 @@ namespace Lowering {
 
 class CalleeTypeInfo {
 public:
+  Optional<AbstractionPattern> origFormalType;
   CanSILFunctionType substFnType;
   Optional<AbstractionPattern> origResultType;
   CanType substResultType;
@@ -45,17 +46,18 @@ public:
                  const Optional<ForeignAsyncConvention> &foreignAsync,
                  ImportAsMemberStatus foreignSelf,
                  Optional<SILFunctionTypeRepresentation> overrideRep = None)
-      : substFnType(substFnType), origResultType(origResultType),
-        substResultType(substResultType),
-        foreign{foreignError, foreignAsync, foreignSelf},
+      : origFormalType(llvm::None), substFnType(substFnType),
+        origResultType(origResultType),
+        substResultType(substResultType), foreign{foreignError, foreignAsync,
+                                                  foreignSelf},
         overrideRep(overrideRep) {}
 
   CalleeTypeInfo(CanSILFunctionType substFnType,
                  AbstractionPattern origResultType, CanType substResultType,
                  Optional<SILFunctionTypeRepresentation> overrideRep = None)
-      : substFnType(substFnType), origResultType(origResultType),
-        substResultType(substResultType), foreign(),
-        overrideRep(overrideRep) {}
+      : origFormalType(llvm::None), substFnType(substFnType),
+        origResultType(origResultType), substResultType(substResultType),
+        foreign(), overrideRep(overrideRep) {}
 
   SILFunctionTypeRepresentation getOverrideRep() const {
     return overrideRep.getValueOr(substFnType->getRepresentation());

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -465,8 +465,9 @@ public:
   {
     // Allocate space to receive the resume value when the continuation is
     // resumed.
-    opaqueResumeType = SGF.getLoweredType(AbstractionPattern::getOpaque(),
-                                          calleeTypeInfo.substResultType);
+    opaqueResumeType =
+        SGF.getLoweredType(AbstractionPattern(calleeTypeInfo.substResultType),
+                           calleeTypeInfo.substResultType);
     resumeBuf = SGF.emitTemporaryAllocation(loc, opaqueResumeType);
   }
   

--- a/lib/SILGen/ResultPlan.h
+++ b/lib/SILGen/ResultPlan.h
@@ -49,9 +49,9 @@ public:
   emitForeignErrorArgument(SILGenFunction &SGF, SILLocation loc) {
     return None;
   }
-  
-  virtual ManagedValue
-  emitForeignAsyncCompletionHandler(SILGenFunction &SGF, SILLocation loc) {
+
+  virtual ManagedValue emitForeignAsyncCompletionHandler(
+      SILGenFunction &SGF, AbstractionPattern origFormalType, SILLocation loc) {
     return {};
   }
 };

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -185,10 +185,9 @@ public:
   /// implementation function for an ObjC API that was imported
   /// as `async` in Swift.
   SILFunction *getOrCreateForeignAsyncCompletionHandlerImplFunction(
-                                           CanSILFunctionType blockType,
-                                           CanType continuationTy,
-                                           CanGenericSignature sig,
-                                           ForeignAsyncConvention convention);
+      CanSILFunctionType blockType, CanType continuationTy,
+      AbstractionPattern origFormalType, CanGenericSignature sig,
+      ForeignAsyncConvention convention);
 
   /// Determine whether the given class has any instance variables that
   /// need to be destroyed.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3875,6 +3875,8 @@ RValue CallEmission::applyNormalCall(SGFContext C) {
   // Get the callee type information.
   auto calleeTypeInfo = callee.getTypeInfo(SGF);
 
+  calleeTypeInfo.origFormalType = origFormalType;
+
   // In C language modes, substitute the type of the AbstractionPattern
   // so that we won't see type parameters down when we try to form bridging
   // conversions.
@@ -3892,6 +3894,8 @@ RValue CallEmission::applyNormalCall(SGFContext C) {
   calleeTypeInfo.substResultType = formalType.getResult();
 
   if (selfArg.hasValue() && callSite.hasValue()) {
+    calleeTypeInfo.origFormalType =
+        calleeTypeInfo.origFormalType->getFunctionResultType();
     calleeTypeInfo.origResultType =
       calleeTypeInfo.origResultType->getFunctionResultType();
     calleeTypeInfo.substResultType =
@@ -4382,7 +4386,9 @@ RValue SILGenFunction::emitApply(
     // we left during the first pass.
     auto &completionArgSlot = const_cast<ManagedValue &>(args[completionIndex]);
 
-    completionArgSlot = resultPlan->emitForeignAsyncCompletionHandler(*this, loc);
+    auto origFormalType = *calleeTypeInfo.origFormalType;
+    completionArgSlot = resultPlan->emitForeignAsyncCompletionHandler(
+        *this, origFormalType, loc);
 
   } else if (auto foreignError = calleeTypeInfo.foreign.error) {
     unsigned errorParamIndex =

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -2215,6 +2215,8 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
         foreignError,
         foreignAsync,
         ImportAsMemberStatus());
+    calleeTypeInfo.origFormalType =
+        foreignCI.FormalPattern.getFunctionResultType();
 
     auto init = indirectResult
                 ? useBufferAsTemporary(indirectResult,

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -182,14 +182,27 @@ static const clang::Type *prependParameterType(
   return clangCtx.getPointerType(newFnTy).getTypePtr();
 }
 
-SILFunction *
-SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
-                                         CanSILFunctionType blockType,
-                                         CanType continuationTy,
-                                         CanGenericSignature sig,
-                                         ForeignAsyncConvention convention) {
+SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
+    CanSILFunctionType blockType, CanType continuationTy,
+    AbstractionPattern origFormalType, CanGenericSignature sig,
+    ForeignAsyncConvention convention) {
   // Extract the result and error types from the continuation type.
   auto resumeType = cast<BoundGenericType>(continuationTy).getGenericArgs()[0];
+
+  CanAnyFunctionType completionHandlerOrigTy = [&]() {
+    auto completionHandlerOrigTy =
+        origFormalType.getObjCMethodAsyncCompletionHandlerForeignType(convention, Types);
+    Optional<CanAnyFunctionType> maybeCompletionHandlerOrigTy;
+    if (auto fnTy =
+            dyn_cast<AnyFunctionType>(completionHandlerOrigTy)) {
+      maybeCompletionHandlerOrigTy = fnTy;
+    } else {
+      maybeCompletionHandlerOrigTy = cast<AnyFunctionType>(
+          completionHandlerOrigTy.getOptionalObjectType());
+    }
+    return maybeCompletionHandlerOrigTy.getValue();
+  }();
+  auto blockParams = completionHandlerOrigTy.getParams();
 
   // Build up the implementation function type, which matches the
   // block signature with an added block storage argument that points at the
@@ -208,7 +221,7 @@ SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
       getASTContext(),
       blockType->getClangTypeInfo().getType(),
       getASTContext().getClangTypeForIRGen(blockStorageTy));
-  
+
   auto implTy = SILFunctionType::get(sig,
          blockType->getExtInfo().intoBuilder()
            .withRepresentation(SILFunctionTypeRepresentation::CFunctionPointer)
@@ -356,15 +369,13 @@ SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
         auto resumeArgBuf = SGF.emitTemporaryAllocation(loc,
                                               loweredResumeTy.getAddressType());
 
-        auto prepareArgument = [&](SILValue destBuf, ManagedValue arg) {
+        auto prepareArgument = [&](SILValue destBuf, CanType destFormalType,
+                                   ManagedValue arg, CanType argFormalType) {
           // Convert the ObjC argument to the bridged Swift representation we
           // want.
-          ManagedValue bridgedArg = SGF.emitBridgedToNativeValue(loc,
-                                       arg.copy(SGF, loc),
-                                       arg.getType().getASTType(),
-                                       // FIXME: pass down formal type
-                                       destBuf->getType().getASTType(),
-                                       destBuf->getType().getObjectType());
+          ManagedValue bridgedArg = SGF.emitBridgedToNativeValue(
+              loc, arg.copy(SGF, loc), argFormalType, destFormalType,
+              destBuf->getType().getObjectType());
           // Force-unwrap an argument that comes to us as Optional if it's
           // formally non-optional in the return.
           if (bridgedArg.getType().getOptionalObjectType()
@@ -395,12 +406,22 @@ SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
           for (unsigned i : indices(resumeTuple.getElementTypes())) {
             auto resumeEltBuf = SGF.B.createTupleElementAddr(loc,
                                                              resumeArgBuf, i);
-            prepareArgument(resumeEltBuf, params[paramIndices[i]]);
+            prepareArgument(
+                /*destBuf*/ resumeEltBuf,
+                /*destFormalType*/
+                F->mapTypeIntoContext(resumeTuple.getElementTypes()[i])
+                    ->getCanonicalType(),
+                /*arg*/ params[paramIndices[i]],
+                /*argFormalType*/ blockParams[i].getParameterType());
           }
         } else {
           assert(paramIndices.size() == 1);
           assert(params.size() == 2 + (bool)errorIndex + (bool)flagIndex);
-          prepareArgument(resumeArgBuf, params[paramIndices[0]]);
+          prepareArgument(/*destBuf*/ resumeArgBuf,
+                          /*destFormalType*/
+                          F->mapTypeIntoContext(resumeType)->getCanonicalType(),
+                          /*arg*/ params[paramIndices[0]],
+                          /*argFormalType*/ blockParams[0].getParameterType());
         }
         
         // Resume the continuation with the composed bridged result.

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -399,6 +399,15 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
             continue;
           paramIndices.push_back(index);
         }
+        auto blockParamIndex = [paramIndices](unsigned long i) {
+          // The non-error, non-flag block parameter (formal types of the
+          // completion handler's arguments) indices are the same as the the
+          // parameter (lowered types of the completion handler's arguments)
+          // indices but shifted by 1 corresponding to the fact that the lowered
+          // completion handler has a block_storage argument but the formal type
+          // does not.
+          return paramIndices[i] - 1;
+        };
         if (auto resumeTuple = dyn_cast<TupleType>(resumeType)) {
           assert(paramIndices.size() == resumeTuple->getNumElements());
           assert(params.size() == resumeTuple->getNumElements()
@@ -412,7 +421,8 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
                 F->mapTypeIntoContext(resumeTuple.getElementTypes()[i])
                     ->getCanonicalType(),
                 /*arg*/ params[paramIndices[i]],
-                /*argFormalType*/ blockParams[i].getParameterType());
+                /*argFormalType*/
+                blockParams[blockParamIndex(i)].getParameterType());
           }
         } else {
           assert(paramIndices.size() == 1);
@@ -421,7 +431,8 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
                           /*destFormalType*/
                           F->mapTypeIntoContext(resumeType)->getCanonicalType(),
                           /*arg*/ params[paramIndices[0]],
-                          /*argFormalType*/ blockParams[0].getParameterType());
+                          /*argFormalType*/
+                          blockParams[blockParamIndex(0)].getParameterType());
         }
         
         // Resume the continuation with the composed bridged result.

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -57,6 +57,13 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
 // rdar://73798726
 - (void)getSomeObjectWithCompletionHandler:(nullable void (^)(NSObject *_Nullable x, NSError *_Nullable error))handler;
 
+- (void)performVoid2VoidWithCompletion:(void (^ _Nonnull)(void (^ _Nonnull)(void)))completion;
+- (void)performId2VoidWithCompletion:(void (^ _Nonnull)(void (^ _Nonnull)(id _Nonnull)))completion;
+- (void)performId2IdWithCompletion:(void (^ _Nonnull)(id _Nonnull (^ _Nonnull)(id _Nonnull)))completion;
+- (void)performNSString2NSStringWithCompletion:(void (^ _Nonnull)(NSString * _Nonnull (^ _Nonnull)(NSString * _Nonnull)))completion;
+- (void)performNSString2NSStringNSStringWithCompletion:(void (^ _Nonnull)(NSString * _Nonnull (^ _Nonnull)(NSString * _Nonnull), NSString * _Nonnull))completion;
+- (void)performId2VoidId2VoidWithCompletion:(void (^ _Nonnull)(void (^ _Nonnull)(id _Nonnull), void (^ _Nonnull)(id _Nonnull)))completion;
+
 -(void)oldAPIWithCompletionHandler:(void (^ _Nonnull)(NSString *_Nullable, NSError *_Nullable))handler __attribute__((availability(macosx, deprecated=10.14)));
 
 -(void)someAsyncMethodWithBlock:(void (^ _Nonnull)(NSString *_Nullable, NSError *_Nullable))completionHandler;

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -76,6 +76,13 @@ func testSlowServer(slowServer: SlowServer) async throws {
   let _: NSObject? = try await slowServer.stopRecording()
   let _: NSObject = try await slowServer.someObject()
 
+  let _: () -> Void = await slowServer.performVoid2Void()
+  let _: (Any) -> Void = await slowServer.performId2Void()
+  let _: (Any) -> Any = await slowServer.performId2Id()
+  let _: (String) -> String = await slowServer.performNSString2NSString()
+
+  let _: ((String) -> String, String) = await slowServer.performNSString2NSStringNSString()
+  let _: ((Any) -> Void, (Any) -> Void) = await slowServer.performId2VoidId2Void()
 }
 
 func testGeneric<T: AnyObject>(x: GenericObject<T>) async throws {

--- a/validation-test/compiler_crashers_2_fixed/rdar79383990.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar79383990.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend %s -emit-silgen -disable-availability-checking
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import Foundation
+
+func test(s: NSBackgroundActivityScheduler) async {
+    _ = await s.schedule()
+}


### PR DESCRIPTION
Explanation: When calling ObjC methods from Swift as async methods, a completion handler to be passed to the ObjC method is synthesized by SILGen.  Being called from ObjC, that completion handler receives ObjC types such as ObjCBool and NSString.  On the other hand, the Swift code that is calling-as-async that ObjC method expects native types like Bool and String.  Consequently, part of the completion handler's implementation is to bridge those bridged values to native values.

The utility code for doing this bridging requires the formal type be passed in.  Previously, that foreign type was being retrieved from the lowered type.  For many things (e.g. ObjCBool and NSString), that worked fine.  However, for block types, it did not; the "formal" type that can be obtained from a SILFunctionType is still a SILFunctionType.  And the utility bridging code requires AnyFunctionTypes in order to work.

Here, the formal original native method type is passed down, bridged back to a formal ObjC type, and passed through to the bridging utility code.  Additionally, the abstraction pattern used for unsafe continuations is changed to a type reference from opaque, allowing block arguments not to have bound generic arguments or require an extra thunk.

Issue: rdar://79383990

Original PR: https://github.com/apple/swift/pull/38370 , https://github.com/apple/swift/pull/38785

Testing: New regression tests, Swift CI

Reviewed by: @jckarter

Risk: Low.

Scope: Limited to Swift import of ObjC methods as async functions.
