### PR TITLE
Revert "[SILGen] Used formal type when bridging completion handler arguments."

### DIFF
--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -1378,13 +1378,6 @@ public:
   /// Swift type.
   AbstractionPattern getObjCMethodAsyncCompletionHandlerType(
                                      CanType swiftCompletionHandlerType) const;
-
-  /// If this pattern refers to a foreign ObjC method that was imported as 
-  /// async, return the bridged-back-to-ObjC completion handler type.
-  CanType getObjCMethodAsyncCompletionHandlerForeignType(
-      ForeignAsyncConvention convention,
-      Lowering::TypeConverter &TC
-  ) const;
   
   void dump() const LLVM_ATTRIBUTE_USED;
   void print(raw_ostream &OS) const;

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -662,30 +662,6 @@ AbstractionPattern::getObjCMethodAsyncCompletionHandlerType(
   llvm_unreachable("covered switch");
 }
 
-
-CanType AbstractionPattern::getObjCMethodAsyncCompletionHandlerForeignType(
-    ForeignAsyncConvention convention,
-    Lowering::TypeConverter &TC
-) const {
-  auto nativeCHTy = convention.completionHandlerType();
-
-  // Use the abstraction pattern we're lowering against in order to lower
-  // the completion handler type, so we can preserve C/ObjC distinctions that
-  // normally get abstracted away by the importer.
-  auto completionHandlerNativeOrigTy = getObjCMethodAsyncCompletionHandlerType(nativeCHTy);
-  
-  // Bridge the Swift completion handler type back to its
-  // foreign representation.
-  auto foreignCHTy = TC.getLoweredBridgedType(completionHandlerNativeOrigTy,
-                                    nativeCHTy,
-                                    Bridgeability::Full,
-                                    SILFunctionTypeRepresentation::ObjCMethod,
-                                    TypeConverter::ForArgument)
-    ->getCanonicalType();
-
-  return foreignCHTy;
-}
-
 AbstractionPattern
 AbstractionPattern::getFunctionParamType(unsigned index) const {
   switch (getKind()) {

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1674,9 +1674,25 @@ private:
         || NextOrigParamIndex != Foreign.Async->completionHandlerParamIndex())
       return false;
     
-    CanType foreignCHTy = TopLevelOrigType
-      .getObjCMethodAsyncCompletionHandlerForeignType(Foreign.Async.getValue(), TC);
-    auto completionHandlerOrigTy = TopLevelOrigType.getObjCMethodAsyncCompletionHandlerType(foreignCHTy);
+    auto nativeCHTy = Foreign.Async->completionHandlerType();
+
+    // Use the abstraction pattern we're lowering against in order to lower
+    // the completion handler type, so we can preserve C/ObjC distinctions that
+    // normally get abstracted away by the importer.
+    auto completionHandlerNativeOrigTy = TopLevelOrigType
+      .getObjCMethodAsyncCompletionHandlerType(nativeCHTy);
+    
+    // Bridge the Swift completion handler type back to its
+    // foreign representation.
+    auto foreignCHTy = TC.getLoweredBridgedType(completionHandlerNativeOrigTy,
+                                      nativeCHTy,
+                                      Bridgeability::Full,
+                                      SILFunctionTypeRepresentation::ObjCMethod,
+                                      TypeConverter::ForArgument)
+      ->getCanonicalType();
+    
+    auto completionHandlerOrigTy = TopLevelOrigType
+      .getObjCMethodAsyncCompletionHandlerType(foreignCHTy);
     auto completionHandlerTy = TC.getLoweredType(completionHandlerOrigTy,
                                                  foreignCHTy, expansion)
       .getASTType();

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -2822,7 +2822,7 @@ SILType GetAsyncContinuationInstBase::getLoweredResumeType() const {
   auto formalType = getFormalResumeType();
   auto &M = getFunction()->getModule();
   auto c = getFunction()->getTypeExpansionContext();
-  return M.Types.getLoweredType(AbstractionPattern(formalType), formalType, c);
+  return M.Types.getLoweredType(AbstractionPattern::getOpaque(), formalType, c);
 }
 
 ReturnInst::ReturnInst(SILFunction &func, SILDebugLocation debugLoc,

--- a/lib/SILGen/Callee.h
+++ b/lib/SILGen/Callee.h
@@ -23,7 +23,6 @@ namespace Lowering {
 
 class CalleeTypeInfo {
 public:
-  Optional<AbstractionPattern> origFormalType;
   CanSILFunctionType substFnType;
   Optional<AbstractionPattern> origResultType;
   CanType substResultType;
@@ -46,18 +45,17 @@ public:
                  const Optional<ForeignAsyncConvention> &foreignAsync,
                  ImportAsMemberStatus foreignSelf,
                  Optional<SILFunctionTypeRepresentation> overrideRep = None)
-      : origFormalType(llvm::None), substFnType(substFnType),
-        origResultType(origResultType),
-        substResultType(substResultType), foreign{foreignError, foreignAsync,
-                                                  foreignSelf},
+      : substFnType(substFnType), origResultType(origResultType),
+        substResultType(substResultType),
+        foreign{foreignError, foreignAsync, foreignSelf},
         overrideRep(overrideRep) {}
 
   CalleeTypeInfo(CanSILFunctionType substFnType,
                  AbstractionPattern origResultType, CanType substResultType,
                  Optional<SILFunctionTypeRepresentation> overrideRep = None)
-      : origFormalType(llvm::None), substFnType(substFnType),
-        origResultType(origResultType), substResultType(substResultType),
-        foreign(), overrideRep(overrideRep) {}
+      : substFnType(substFnType), origResultType(origResultType),
+        substResultType(substResultType), foreign(),
+        overrideRep(overrideRep) {}
 
   SILFunctionTypeRepresentation getOverrideRep() const {
     return overrideRep.getValueOr(substFnType->getRepresentation());

--- a/lib/SILGen/ResultPlan.h
+++ b/lib/SILGen/ResultPlan.h
@@ -49,9 +49,9 @@ public:
   emitForeignErrorArgument(SILGenFunction &SGF, SILLocation loc) {
     return None;
   }
-
-  virtual ManagedValue emitForeignAsyncCompletionHandler(
-      SILGenFunction &SGF, AbstractionPattern origFormalType, SILLocation loc) {
+  
+  virtual ManagedValue
+  emitForeignAsyncCompletionHandler(SILGenFunction &SGF, SILLocation loc) {
     return {};
   }
 };

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -182,9 +182,10 @@ public:
   /// implementation function for an ObjC API that was imported
   /// as `async` in Swift.
   SILFunction *getOrCreateForeignAsyncCompletionHandlerImplFunction(
-      CanSILFunctionType blockType, CanType continuationTy,
-      AbstractionPattern origFormalType, CanGenericSignature sig,
-      ForeignAsyncConvention convention);
+                                           CanSILFunctionType blockType,
+                                           CanType continuationTy,
+                                           CanGenericSignature sig,
+                                           ForeignAsyncConvention convention);
 
   /// Determine whether the given class has any instance variables that
   /// need to be destroyed.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3894,8 +3894,6 @@ RValue CallEmission::applyNormalCall(SGFContext C) {
   // Get the callee type information.
   auto calleeTypeInfo = callee.getTypeInfo(SGF);
 
-  calleeTypeInfo.origFormalType = origFormalType;
-
   // In C language modes, substitute the type of the AbstractionPattern
   // so that we won't see type parameters down when we try to form bridging
   // conversions.
@@ -3913,8 +3911,6 @@ RValue CallEmission::applyNormalCall(SGFContext C) {
   calleeTypeInfo.substResultType = formalType.getResult();
 
   if (selfArg.hasValue() && callSite.hasValue()) {
-    calleeTypeInfo.origFormalType =
-        calleeTypeInfo.origFormalType->getFunctionResultType();
     calleeTypeInfo.origResultType =
       calleeTypeInfo.origResultType->getFunctionResultType();
     calleeTypeInfo.substResultType =
@@ -4405,9 +4401,7 @@ RValue SILGenFunction::emitApply(
     // we left during the first pass.
     auto &completionArgSlot = const_cast<ManagedValue &>(args[completionIndex]);
 
-    auto origFormalType = *calleeTypeInfo.origFormalType;
-    completionArgSlot = resultPlan->emitForeignAsyncCompletionHandler(
-        *this, origFormalType, loc);
+    completionArgSlot = resultPlan->emitForeignAsyncCompletionHandler(*this, loc);
 
   } else if (auto foreignError = calleeTypeInfo.foreign.error) {
     unsigned errorParamIndex =

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -2389,8 +2389,6 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
         foreignError,
         foreignAsync,
         ImportAsMemberStatus());
-    calleeTypeInfo.origFormalType =
-        foreignCI.FormalPattern.getFunctionResultType();
 
     auto init = indirectResult
                 ? useBufferAsTemporary(indirectResult,

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -188,27 +188,14 @@ static const clang::Type *prependParameterType(
   return clangCtx.getPointerType(newFnTy).getTypePtr();
 }
 
-SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
-    CanSILFunctionType blockType, CanType continuationTy,
-    AbstractionPattern origFormalType, CanGenericSignature sig,
-    ForeignAsyncConvention convention) {
+SILFunction *
+SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
+                                         CanSILFunctionType blockType,
+                                         CanType continuationTy,
+                                         CanGenericSignature sig,
+                                         ForeignAsyncConvention convention) {
   // Extract the result and error types from the continuation type.
   auto resumeType = cast<BoundGenericType>(continuationTy).getGenericArgs()[0];
-
-  CanAnyFunctionType completionHandlerOrigTy = [&]() {
-    auto completionHandlerOrigTy =
-        origFormalType.getObjCMethodAsyncCompletionHandlerForeignType(convention, Types);
-    Optional<CanAnyFunctionType> maybeCompletionHandlerOrigTy;
-    if (auto fnTy =
-            dyn_cast<AnyFunctionType>(completionHandlerOrigTy)) {
-      maybeCompletionHandlerOrigTy = fnTy;
-    } else {
-      maybeCompletionHandlerOrigTy = cast<AnyFunctionType>(
-          completionHandlerOrigTy.getOptionalObjectType());
-    }
-    return maybeCompletionHandlerOrigTy.getValue();
-  }();
-  auto blockParams = completionHandlerOrigTy.getParams();
 
   // Build up the implementation function type, which matches the
   // block signature with an added block storage argument that points at the
@@ -227,7 +214,7 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
       getASTContext(),
       blockType->getClangTypeInfo().getType(),
       getASTContext().getClangTypeForIRGen(blockStorageTy));
-
+  
   auto implTy = SILFunctionType::get(sig,
          blockType->getExtInfo().intoBuilder()
            .withRepresentation(SILFunctionTypeRepresentation::CFunctionPointer)
@@ -374,13 +361,15 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
         auto resumeArgBuf = SGF.emitTemporaryAllocation(loc,
                                               loweredResumeTy.getAddressType());
 
-        auto prepareArgument = [&](SILValue destBuf, CanType destFormalType,
-                                   ManagedValue arg, CanType argFormalType) {
+        auto prepareArgument = [&](SILValue destBuf, ManagedValue arg) {
           // Convert the ObjC argument to the bridged Swift representation we
           // want.
-          ManagedValue bridgedArg = SGF.emitBridgedToNativeValue(
-              loc, arg.copy(SGF, loc), argFormalType, destFormalType,
-              destBuf->getType().getObjectType());
+          ManagedValue bridgedArg = SGF.emitBridgedToNativeValue(loc,
+                                       arg.copy(SGF, loc),
+                                       arg.getType().getASTType(),
+                                       // FIXME: pass down formal type
+                                       destBuf->getType().getASTType(),
+                                       destBuf->getType().getObjectType());
           // Force-unwrap an argument that comes to us as Optional if it's
           // formally non-optional in the return.
           if (bridgedArg.getType().getOptionalObjectType()
@@ -411,22 +400,12 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
           for (unsigned i : indices(resumeTuple.getElementTypes())) {
             auto resumeEltBuf = SGF.B.createTupleElementAddr(loc,
                                                              resumeArgBuf, i);
-            prepareArgument(
-                /*destBuf*/ resumeEltBuf,
-                /*destFormalType*/
-                F->mapTypeIntoContext(resumeTuple.getElementTypes()[i])
-                    ->getCanonicalType(),
-                /*arg*/ params[paramIndices[i]],
-                /*argFormalType*/ blockParams[i].getParameterType());
+            prepareArgument(resumeEltBuf, params[paramIndices[i]]);
           }
         } else {
           assert(paramIndices.size() == 1);
           assert(params.size() == 2 + (bool)errorIndex + (bool)flagIndex);
-          prepareArgument(/*destBuf*/ resumeArgBuf,
-                          /*destFormalType*/
-                          F->mapTypeIntoContext(resumeType)->getCanonicalType(),
-                          /*arg*/ params[paramIndices[0]],
-                          /*argFormalType*/ blockParams[0].getParameterType());
+          prepareArgument(resumeArgBuf, params[paramIndices[0]]);
         }
         
         // Resume the continuation with the composed bridged result.

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -57,13 +57,6 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
 // rdar://73798726
 - (void)getSomeObjectWithCompletionHandler:(nullable void (^)(NSObject *_Nullable x, NSError *_Nullable error))handler;
 
-- (void)performVoid2VoidWithCompletion:(void (^ _Nonnull)(void (^ _Nonnull)(void)))completion;
-- (void)performId2VoidWithCompletion:(void (^ _Nonnull)(void (^ _Nonnull)(id _Nonnull)))completion;
-- (void)performId2IdWithCompletion:(void (^ _Nonnull)(id _Nonnull (^ _Nonnull)(id _Nonnull)))completion;
-- (void)performNSString2NSStringWithCompletion:(void (^ _Nonnull)(NSString * _Nonnull (^ _Nonnull)(NSString * _Nonnull)))completion;
-- (void)performNSString2NSStringNSStringWithCompletion:(void (^ _Nonnull)(NSString * _Nonnull (^ _Nonnull)(NSString * _Nonnull), NSString * _Nonnull))completion;
-- (void)performId2VoidId2VoidWithCompletion:(void (^ _Nonnull)(void (^ _Nonnull)(id _Nonnull), void (^ _Nonnull)(id _Nonnull)))completion;
-
 -(void)oldAPIWithCompletionHandler:(void (^ _Nonnull)(NSString *_Nullable, NSError *_Nullable))handler __attribute__((availability(macosx, deprecated=10.14)));
 
 -(void)someAsyncMethodWithBlock:(void (^ _Nonnull)(NSString *_Nullable, NSError *_Nullable))completionHandler;

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -76,13 +76,6 @@ func testSlowServer(slowServer: SlowServer) async throws {
   let _: NSObject? = try await slowServer.stopRecording()
   let _: NSObject = try await slowServer.someObject()
 
-  let _: () -> Void = await slowServer.performVoid2Void()
-  let _: (Any) -> Void = await slowServer.performId2Void()
-  let _: (Any) -> Any = await slowServer.performId2Id()
-  let _: (String) -> String = await slowServer.performNSString2NSString()
-
-  let _: ((String) -> String, String) = await slowServer.performNSString2NSStringNSString()
-  let _: ((Any) -> Void, (Any) -> Void) = await slowServer.performId2VoidId2Void()
 }
 
 func testGeneric<T: AnyObject>(x: GenericObject<T>) async throws {

--- a/validation-test/compiler_crashers_2_fixed/rdar79383990.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar79383990.swift
@@ -1,9 +1,0 @@
-// RUN: %target-swift-frontend %s -emit-silgen -disable-availability-checking
-// REQUIRES: objc_interop
-// REQUIRES: OS=macosx
-
-import Foundation
-
-func test(s: NSBackgroundActivityScheduler) async {
-    _ = await s.schedule()
-}


### PR DESCRIPTION
See if it is responsible for https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-16_04/17012/.