### PR TITLE
[Frontend] Always output the version being compiled for

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1969,6 +1969,8 @@ public:
     auto effective = LangOpts.EffectiveLanguageVersion;
     if (effective != version::Version::getCurrentLanguageVersion()) {
       os << "Compiling with effective version " << effective;
+    } else {
+      os << "Compiling with the current language version";
     }
     os << "\n";
   };

--- a/test/Frontend/crash.swift
+++ b/test/Frontend/crash.swift
@@ -16,6 +16,10 @@
 // CHECK-ALLOW: Program arguments: {{.*}} -experimental-allow-module-with-compiler-errors
 // CHECK-ALLOW: Compiling with effective version
 
+// RUN: not --crash %target-swift-frontend -typecheck -debug-crash-after-parse -experimental-allow-module-with-compiler-errors -swift-version 5 %s 2>&1 | %FileCheck -check-prefix CHECK-CURRENT %s
+// CHECK-CURRENT: Program arguments: {{.*}} -experimental-allow-module-with-compiler-errors
+// CHECK-CURRENT: Compiling with the current language version
+
 func anchor() {}
 anchor()
 


### PR DESCRIPTION
Outputting the effective version in the pretty stack trace was skipped
if the current version was the same as the effective version. This would
result in an empty line, which is somewhat confusing. Output a line
regardless.

Resolves rdar://81140703