### PR TITLE
[SyntaxModel] Correctly annotate unlabelled unary args

### DIFF
--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -484,8 +484,12 @@ CharSourceRange innerCharSourceRangeFromSourceRange(const SourceManager &SM,
   return CharSourceRange(SM, SRS, (SR.End != SR.Start) ? SR.End : SRS);
 }
 
-CharSourceRange parameterNameRangeOfCallArg(const TupleExpr *TE,
+CharSourceRange parameterNameRangeOfCallArg(const Expr *ArgListExpr,
                                             const Expr *Arg) {
+  if (isa<ParenExpr>(ArgListExpr))
+    return CharSourceRange();
+
+  auto *TE = cast<TupleExpr>(ArgListExpr);
   if (!TE->hasElementNameLocs() || !TE->hasElementNames())
     return CharSourceRange();
 
@@ -547,12 +551,11 @@ std::pair<bool, Expr *> ModelASTWalker::walkToExprPre(Expr *E) {
   if (isVisitedBefore(E))
     return {false, E};
 
-  auto addCallArgExpr = [&](Expr *Elem, TupleExpr *ParentTupleExpr) {
-    if (isa<DefaultArgumentExpr>(Elem) ||
-        !isCurrentCallArgExpr(ParentTupleExpr))
+  auto addCallArgExpr = [&](Expr *Elem, Expr *ArgListExpr) {
+    if (isa<DefaultArgumentExpr>(Elem) || !isCurrentCallArgExpr(ArgListExpr))
       return;
 
-    CharSourceRange NR = parameterNameRangeOfCallArg(ParentTupleExpr, Elem);
+    CharSourceRange NR = parameterNameRangeOfCallArg(ArgListExpr, Elem);
     SyntaxStructureNode SN;
     SN.Kind = SyntaxStructureKind::Argument;
     SN.NameRange = NR;
@@ -568,9 +571,9 @@ std::pair<bool, Expr *> ModelASTWalker::walkToExprPre(Expr *E) {
     pushStructureNode(SN, Elem);
   };
 
-  if (auto *ParentTupleExpr = dyn_cast_or_null<TupleExpr>(Parent.getAsExpr())) {
-    // the argument value is a tuple expression already, we can just extract it
-    addCallArgExpr(E, ParentTupleExpr);
+  if (auto *ParentExpr = Parent.getAsExpr()) {
+    if (isa<TupleExpr>(ParentExpr) || isa<ParenExpr>(ParentExpr))
+      addCallArgExpr(E, ParentExpr);
   }
 
   if (E->isImplicit())

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -571,12 +571,6 @@ std::pair<bool, Expr *> ModelASTWalker::walkToExprPre(Expr *E) {
   if (auto *ParentTupleExpr = dyn_cast_or_null<TupleExpr>(Parent.getAsExpr())) {
     // the argument value is a tuple expression already, we can just extract it
     addCallArgExpr(E, ParentTupleExpr);
-  } else if (auto *ParentOptionalExpr = dyn_cast_or_null<OptionalEvaluationExpr>(Parent.getAsExpr())) {
-    // if an argument value is an optional expression, we should extract the
-    // argument from the subexpression
-    if (auto *ParentTupleExpr = dyn_cast_or_null<TupleExpr>(ParentOptionalExpr->getSubExpr())) {
-      addCallArgExpr(E, ParentTupleExpr);
-    }
   }
 
   if (E->isImplicit())

--- a/test/IDE/structure.swift
+++ b/test/IDE/structure.swift
@@ -221,7 +221,7 @@ class SubscriptTest {
   // CHECK:   return 0
   // CHECK: }
   // CHECK: set(<param>value</param>) {
-  // CHECK:   <call><name>print</name>(value)</call>
+  // CHECK:   <call><name>print</name>(<arg>value</arg>)</call>
   // CHECK: }</subscript>
 }
 
@@ -319,16 +319,16 @@ thirdCall("""
   }())
   """)
 """)
-// CHECK: <call><name>thirdCall</name>("""
+// CHECK: <call><name>thirdCall</name>(<arg>"""
 // CHECK-NEXT: \("""
 // CHECK-NEXT:   \(<call><name><closure><brace>{
 // CHECK-NEXT:   return <call><name>a</name>()</call>
 // CHECK-NEXT:   }</brace></closure></name>()</call>)
 // CHECK-NEXT:   """)
-// CHECK-NEXT: """)</call>
+// CHECK-NEXT: """</arg>)</call>
 
 fourthCall(a: @escaping () -> Int)
 // CHECK: <call><name>fourthCall</name>(<arg><name>a</name>: @escaping () -> Int</arg>)</call>
 
-// CHECK: <call><name>foo</name> <closure><brace>{ [unowned <lvar><name>self</name></lvar>, <lvar><name>x</name></lvar>] in _ }</brace></closure></call>
+// CHECK: <call><name>foo</name> <arg><closure><brace>{ [unowned <lvar><name>self</name></lvar>, <lvar><name>x</name></lvar>] in _ }</brace></closure></arg></call>
 foo { [unowned self, x] in _ }

--- a/test/SourceKit/DocumentStructure/structure.swift.empty.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.empty.response
@@ -1643,7 +1643,18 @@
       key.nameoffset: 2669,
       key.namelength: 5,
       key.bodyoffset: 2675,
-      key.bodylength: 8
+      key.bodylength: 8,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.expr.argument,
+          key.offset: 2675,
+          key.length: 8,
+          key.nameoffset: 0,
+          key.namelength: 0,
+          key.bodyoffset: 2675,
+          key.bodylength: 8
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.protocol,

--- a/test/SourceKit/DocumentStructure/structure.swift.foobar.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.foobar.response
@@ -1643,7 +1643,18 @@
       key.nameoffset: 2669,
       key.namelength: 5,
       key.bodyoffset: 2675,
-      key.bodylength: 8
+      key.bodylength: 8,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.expr.argument,
+          key.offset: 2675,
+          key.length: 8,
+          key.nameoffset: 0,
+          key.namelength: 0,
+          key.bodyoffset: 2675,
+          key.bodylength: 8
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.protocol,

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -1643,7 +1643,18 @@
       key.nameoffset: 2669,
       key.namelength: 5,
       key.bodyoffset: 2675,
-      key.bodylength: 8
+      key.bodylength: 8,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.expr.argument,
+          key.offset: 2675,
+          key.length: 8,
+          key.nameoffset: 0,
+          key.namelength: 0,
+          key.bodyoffset: 2675,
+          key.bodylength: 8
+        }
+      ]
     },
     {
       key.kind: source.lang.swift.decl.protocol,


### PR DESCRIPTION
Previously we would only handle TupleExpr argument list exprs. Update the logic to handle ParenExpr argument lists too. This would also be fixed by https://github.com/apple/swift/pull/37435, but split this change out to keep that patch as NFC as possible.

rdar://81154978