### PR TITLE
[Sema] Copy key path component types when merging solutions

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -260,6 +260,11 @@ void ConstraintSystem::applySolution(const Solution &solution) {
     setType(nodeType.first, nodeType.second);
   }
 
+  for (auto &nodeType : solution.keyPathComponentTypes) {
+    setType(nodeType.getFirst().first, nodeType.getFirst().second,
+            nodeType.getSecond());
+  }
+
   // Add the contextual types.
   for (const auto &contextualType : solution.contextualTypes) {
     if (!getContextualTypeInfo(contextualType.first)) {
@@ -489,6 +494,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numOpenedExistentialTypes = cs.OpenedExistentialTypes.size();
   numDefaultedConstraints = cs.DefaultedConstraints.size();
   numAddedNodeTypes = cs.addedNodeTypes.size();
+  numAddedKeyPathComponentTypes = cs.addedKeyPathComponentTypes.size();
   numDisabledConstraints = cs.solverState->getNumDisabledConstraints();
   numFavoredConstraints = cs.solverState->getNumFavoredConstraints();
   numResultBuilderTransformed = cs.resultBuilderTransformed.size();
@@ -569,6 +575,19 @@ ConstraintSystem::SolverScope::~SolverScope() {
       cs.NodeTypes.erase(node);
   }
   truncate(cs.addedNodeTypes, numAddedNodeTypes);
+
+  // Remove any node types we registered.
+  for (unsigned i : reverse(range(numAddedKeyPathComponentTypes,
+                                  cs.addedKeyPathComponentTypes.size()))) {
+    auto KeyPath = std::get<0>(cs.addedKeyPathComponentTypes[i]);
+    auto KeyPathIndex = std::get<1>(cs.addedKeyPathComponentTypes[i]);
+    if (Type oldType = std::get<2>(cs.addedKeyPathComponentTypes[i])) {
+      cs.KeyPathComponentTypes[{KeyPath, KeyPathIndex}] = oldType;
+    } else {
+      cs.KeyPathComponentTypes.erase({KeyPath, KeyPathIndex});
+    }
+  }
+  truncate(cs.addedKeyPathComponentTypes, numAddedKeyPathComponentTypes);
 
   /// Remove any builder transformed closures.
   truncate(cs.resultBuilderTransformed, numResultBuilderTransformed);

--- a/validation-test/IDE/crashers_fixed/sr14979.swift
+++ b/validation-test/IDE/crashers_fixed/sr14979.swift
@@ -1,0 +1,30 @@
+// RUN: %swift-ide-test --code-completion --source-filename %s -code-completion-token CC
+
+func foo() {
+    let months: [[String]] = []
+    let abcd: Int
+    let x = ForEach2(months) { group in
+        HStack2(spacing: 3) {
+            useKeyPath(id: \.abcd#^CC^#)
+        }
+    }
+}
+
+
+struct ForEach2<Data> where Data : RandomAccessCollection {
+    init(_ data: Data, content: @escaping (Data.Element) -> Void) {}
+}
+
+struct Bar {
+	let abcd: Int
+}
+
+func useKeyPath(id: KeyPath<Bar, String>) {}
+
+struct HStack2<Content> {
+    init(spacing: Double, @ViewBuilder2 content: () -> Content)
+}
+
+@resultBuilder struct ViewBuilder2 {
+  static func buildBlock<Content>(_ content: Content) -> Content { fatalError() }
+}


### PR DESCRIPTION
In #38389 I forgot to copy key path component types when applying a solution to the constraint system. That caused a crash in key path code completion.

Fixes rdar://81118700 [SR-14979]