### PR TITLE
[Test] Disable IRGen/autolink-runtime-compatibility-arm64-macos.swift

### DIFF
--- a/test/IRGen/autolink-runtime-compatibility-arm64-macos.swift
+++ b/test/IRGen/autolink-runtime-compatibility-arm64-macos.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar81115750
 // REQUIRES: CPU=arm64,OS=macosx
 
 // Doesn't autolink compatibility library because target OS doesn't need it


### PR DESCRIPTION
rdar://81115750
