### PR TITLE
Fix IRGenFunction.cpp's Builder.CreateAtomicCmpXchg call

### DIFF
--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -694,7 +694,7 @@ void IRGenFunction::emitAwaitAsyncContinuation(
         contAwaitSyncAddr->getType()->getPointerElementType(),
         unsigned(ContinuationStatus::Awaited));
     auto results = Builder.CreateAtomicCmpXchg(
-        contAwaitSyncAddr, pendingV, awaitedV,
+        contAwaitSyncAddr, pendingV, awaitedV, llvm::MaybeAlign(),
         llvm::AtomicOrdering::Release /*success ordering*/,
         llvm::AtomicOrdering::Acquire /* failure ordering */,
         llvm::SyncScope::System);


### PR DESCRIPTION
LLVM changed and requires an alignment argument.

rdar://81060394