### PR TITLE
[Refactoring] Disable availability checking to reduce errors

### DIFF
--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -294,6 +294,7 @@ int main(int argc, char *argv[]) {
   Invocation.getLangOptions().AttachCommentsToDecls = true;
   Invocation.getLangOptions().CollectParsedToken = true;
   Invocation.getLangOptions().BuildSyntaxTree = true;
+  Invocation.getLangOptions().DisableAvailabilityChecking = true;
 
   if (options::EnableExperimentalConcurrency)
     Invocation.getLangOptions().EnableExperimentalConcurrency = true;


### PR DESCRIPTION
https://github.com/apple/swift/pull/38510 introduces a new error for concurrency not being available, so every async function will cause an `error: concurrency is only available in macOS 12.0.0 or newer` if on an older platform.

We don't care about availability in swift-refactor, so just disable it to reduce the error spam when a test fails.