### PR TITLE
[Serialization] Ignore conformance failures when allowing errors

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4510,10 +4510,12 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
 
         Expected<Type> deserialized = MF.getTypeChecked(typeID);
         if (!deserialized) {
-          if (deserialized.errorIsA<XRefNonLoadedModuleError>()) {
+          if (deserialized.errorIsA<XRefNonLoadedModuleError>() ||
+              MF.allowCompilerErrors()) {
             // A custom attribute defined behind an implementation-only import
             // is safe to drop when it can't be deserialized.
-            // rdar://problem/56599179
+            // rdar://problem/56599179. When allowing errors we're doing a best
+            // effort to create a module, so ignore in that case as well.
             consumeError(deserialized.takeError());
             skipAttr = true;
           } else
@@ -6258,9 +6260,15 @@ ModuleFile::loadAllConformances(const Decl *D, uint64_t contextData,
     if (!conformance) {
       auto unconsumedError =
         consumeErrorIfXRefNonLoadedModule(conformance.takeError());
-      if (unconsumedError)
-        fatal(std::move(unconsumedError));
-      return;
+      if (unconsumedError) {
+        // Ignore if allowing errors, it's just doing a best effort to produce
+        // *some* module anyway.
+        if (allowCompilerErrors())
+          consumeError(std::move(unconsumedError));
+        else
+          fatal(std::move(unconsumedError));
+      }
+      continue;
     }
 
     if (conformance.get().isConcrete())
@@ -6381,8 +6389,17 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
           "serialized conformances do not match requirement signature",
           llvm::inconvertibleErrorCode()));
     }
-    while (conformanceCount--)
-      reqConformances.push_back(readConformance(DeclTypeCursor));
+    while (conformanceCount--) {
+      auto conformance = readConformanceChecked(DeclTypeCursor);
+      if (conformance) {
+        reqConformances.push_back(conformance.get());
+      } else if (allowCompilerErrors()) {
+        consumeError(conformance.takeError());
+        reqConformances.push_back(ProtocolConformanceRef::forInvalid());
+      } else {
+        fatal(conformance.takeError());
+      }
+    }
   }
   conformance->setSignatureConformances(reqConformances);
 
@@ -6495,8 +6512,11 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
     if (!witnessSubstitutions) {
       // Missing module errors are most likely caused by an
       // implementation-only import hiding types and decls.
-      // rdar://problem/52837313
-      if (witnessSubstitutions.errorIsA<XRefNonLoadedModuleError>()) {
+      // rdar://problem/52837313. Ignore completely if allowing
+      // errors - we're just doing a best effort to create the
+      // module in that case.
+      if (witnessSubstitutions.errorIsA<XRefNonLoadedModuleError>() ||
+          allowCompilerErrors()) {
         consumeError(witnessSubstitutions.takeError());
         isOpaque = true;
       }

--- a/test/Serialization/AllowErrors/removed-decls.swift
+++ b/test/Serialization/AllowErrors/removed-decls.swift
@@ -1,0 +1,102 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/swiftmods %t/objcmods %t/objc
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// Create a module A, then B that depends on A, replace A with an empty module,
+// and then try make a C that depends on B
+
+// RUN: %target-swift-frontend -module-name A -emit-module -o %t/swiftmods/A.swiftmodule %t/a.swift
+// RUN: %target-swift-frontend -module-name B -emit-module -o %t/swiftmods/B.swiftmodule -I %t/swiftmods %t/b.swift
+// RUN: %target-swift-frontend -module-name A -emit-module -o %t/swiftmods/A.swiftmodule %t/bada.swift
+// RUN: %target-swift-frontend -wmo -module-name C -emit-module -o %t/swiftmods/C.swiftmodule -I %t/swiftmods -experimental-allow-module-with-compiler-errors -index-store-path %t/idx %t/c.swift
+// RUN: not --crash %target-swift-frontend -module-name C -emit-module -o %t/swiftmods/C.swiftmodule -I %t/swiftmods %t/c.swift
+
+// Now do a similar thing but just use different headers instead (ie. to test
+// loading from a PCM rather than swiftmodule)
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name B -emit-module -o %t/objcmods/B.swiftmodule -I %t/objc -module-cache-path %t/mcp %t/b.swift
+// RUN: mv %t/objc/bada.h %t/objc/a.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name C -emit-module -o %t/objcmods/C.swiftmodule -I %t/objcmods -I %t/objc -module-cache-path %t/mcp -experimental-allow-module-with-compiler-errors -index-store-path %t/idx %t/c.swift
+// RUN: not --crash %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name C -emit-module -o %t/objcmods/C.swiftmodule -I %t/objcmods -I %t/objc -module-cache-path %t/mcp %t/c.swift
+
+// BEGIN a.swift
+public protocol ProtoA {}
+public protocol MissingProto {}
+open class MissingClass: ProtoA {}
+
+// BEGIN bada.swift
+public protocol ProtoA {}
+
+// BEGIN objc/a.h
+@import Foundation;
+@protocol ProtoA
+@end
+@protocol MissingProto
+@end
+@interface MissingClass <ProtoA>
+@end
+
+// BEGIN objc/bada.h
+@import Foundation;
+@protocol ProtoA
+@end
+
+// BEGIN objc/module.modulemap
+module A {
+  header "a.h"
+}
+
+// BEGIN b.swift
+import A
+
+public protocol ProtoB: MissingProto {}
+open class ClassB: MissingProto {}
+open class InheritingClassB: MissingClass {}
+
+public protocol ATProto {
+  associatedtype Value
+}
+public protocol ReqProto: ATProto {
+  static func thing(_ value: Value)
+}
+extension ReqProto where Value: ProtoA {
+  public static func thing(_ value: Value) {}
+}
+public enum EnumB: ReqProto  {
+  public typealias Value = MissingClass
+  case a
+}
+
+// BEGIN c.swift
+import B
+
+func useB(p: ProtoB, c: ClassB, i: InheritingClassB, e: EnumB) {
+  print("p:\(p) c:\(c) i:\(i) e:\(e)")
+  EnumB.thing(i)
+}
+
+public protocol ProtoC: ProtoB {}
+public class ClassC: ClassB {}
+public class ClassC2: InheritingClassB {}
+
+public struct AllAsMembers {
+  let p: ProtoB
+  let c: ClassB
+  let i: InheritingClassB
+  let e: EnumB
+}
+
+extension ProtoB {
+  func newProtoBMethod() {}
+}
+extension ClassB {
+  func newClassBMethod() {}
+}
+extension InheritingClassB {
+  func newInheritingClassBMethod() {}
+}
+extension EnumB {
+  func newEnumBMethod() {}
+}


### PR DESCRIPTION
Allowing errors is attempting to create a module regardless of any
potential failures, so do our best to continue rather than crash (even
if a corresponding build would then crash).