### PR TITLE
Revert "Read machO sections section by section"

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -205,7 +205,36 @@ public:
       return false;
 
     auto Slide = ImageStart.getAddressData() - Command->vmaddr;
+    std::string Prefix = "__swift5";
+    uint64_t RangeStart = UINT64_MAX;
+    uint64_t RangeEnd = UINT64_MAX;
     auto SectionsBuf = reinterpret_cast<const char *>(Sections.get());
+    for (unsigned I = 0; I < NumSect; ++I) {
+      auto S = reinterpret_cast<typename T::Section *>(
+          SectionsBuf + (I * sizeof(typename T::Section)));
+      if (strncmp(S->sectname, Prefix.c_str(), strlen(Prefix.c_str())) != 0)
+        continue;
+      if (RangeStart == UINT64_MAX && RangeEnd == UINT64_MAX) {
+        RangeStart = S->addr + Slide;
+        RangeEnd = S->addr + S->size + Slide;
+        continue;
+      }
+      RangeStart = std::min(RangeStart, (uint64_t)S->addr + Slide);
+      RangeEnd = std::max(RangeEnd, (uint64_t)(S->addr + S->size + Slide));
+      // Keep the range rounded to 8 byte alignment on both ends so we don't
+      // introduce misaligned pointers mapping between local and remote
+      // address space.
+      RangeStart = RangeStart & ~7;
+      RangeEnd = RangeEnd + 7 & ~7;      
+    }
+ 
+    if (RangeStart == UINT64_MAX && RangeEnd == UINT64_MAX)
+      return false;
+
+    auto SectBuf = this->getReader().readBytes(RemoteAddress(RangeStart),
+                                               RangeEnd - RangeStart);
+    if (!SectBuf)
+      return false;
 
     auto findMachOSectionByName = [&](llvm::StringRef Name)
         -> std::pair<RemoteRef<void>, uint64_t> {
@@ -215,13 +244,11 @@ public:
         if (strncmp(S->sectname, Name.data(), strlen(Name.data())) != 0)
           continue;
         auto RemoteSecStart = S->addr + Slide;
-        auto LocalSectBuf =
-            this->getReader().readBytes(RemoteAddress(RemoteSecStart), S->size);
-        if (!LocalSectBuf)
-          return {nullptr, 0};
-
-        auto StartRef = RemoteRef<void>(RemoteSecStart, LocalSectBuf.get());
-        savedBuffers.push_back(std::move(LocalSectBuf));
+        auto SectBufData = reinterpret_cast<const char *>(SectBuf.get());
+        auto LocalSectStart =
+            reinterpret_cast<const char *>(SectBufData + RemoteSecStart - RangeStart);
+        
+        auto StartRef = RemoteRef<void>(RemoteSecStart, LocalSectStart);
         return {StartRef, S->size};
       }
       return {nullptr, 0};
@@ -280,6 +307,7 @@ public:
     }
 
     savedBuffers.push_back(std::move(Buf));
+    savedBuffers.push_back(std::move(SectBuf));
     savedBuffers.push_back(std::move(Sections));
     return true;
   }


### PR DESCRIPTION
This reverts commit b54d42653e7b07a9eb5d9213bb405857242bcb35.

Explanation: LLDB has a bug where a bad interaction between reading from a  local file and the shared cache causes some memory reads to return incorrect data. As a temporary measure, we've disabled reading metadata information to be read from the local file. This patch speeds up memory reads from the running process, by reading all the metadata sections in one go. 
Scope: Speed up LLDB (especially when remote debugging).
Risk: Low. This PR just undoes https://github.com/apple/swift/pull/37043, and the previous implementation was working correctly with live memory.
Testing: most, if not all tests in lldb/test/api/lang/swift rely on this functionality to work.
Reviewer: @adrian-prantl 

