### PR TITLE
[CodeCompletion] Complete typealias from inherited protocol

### DIFF
--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -477,6 +477,12 @@ static void lookupDeclsFromProtocolsBeingConformedTo(
           if (!isDeclVisibleInLookupMode(VD, LS, FromContext))
             continue;
 
+          if (isa<TypeAliasDecl>(VD)) {
+            // Typealias declarations of the protocol are always visible in
+            // types that inherits from it.
+            Consumer.foundDecl(VD, ReasonForThisProtocol);
+            continue;
+          }
           if (!VD->isProtocolRequirement())
             continue;
 

--- a/test/IDE/complete_protocol_typealias.swift
+++ b/test/IDE/complete_protocol_typealias.swift
@@ -56,3 +56,10 @@ func testGenericUnresolvedMember() {
 // GENERIC_UNRESOLVED_MEMBER-DAG: Decl[TypeAlias]/CurrNominal:   Storage[#Array<T>#];
 // GENERIC_UNRESOLVED_MEMBER: End completions
 }
+
+struct ConformingType: MyProto {
+	func foo(content: #^GLOBAL_COMPLETE_IN_CONFORMING_TYPE^#) {}
+// GLOBAL_COMPLETE_IN_CONFORMING_TYPE: Begin completions
+// GLOBAL_COMPLETE_IN_CONFORMING_TYPE: Decl[TypeAlias]/Super:              Content[#Int#];
+// GLOBAL_COMPLETE_IN_CONFORMING_TYPE: End completions
+}

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -439,12 +439,13 @@ struct AnotherTy: MyProtocol {}
 func testSubType() {
   var _: BaseClass = .#^SUBTYPE_1^#
 }
-// SUBTYPE_1: Begin completions, 4 items
-// SUBTYPE_1-NOT: Concrete1(
+// SUBTYPE_1: Begin completions, 6 items
 // SUBTYPE_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init()[#BaseClass#];
 // SUBTYPE_1-DAG: Decl[Class]/CurrNominal/TypeRelation[Convertible]: SubClass[#BaseClass.SubClass#];
 // SUBTYPE_1-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: subInstance[#BaseClass.SubClass#];
 // SUBTYPE_1-DAG: Decl[Constructor]/CurrNominal:      init({#failable: Void#})[#BaseClass?#];
+// SUBTYPE_1-DAG: Decl[TypeAlias]/Super/TypeRelation[Identical]: Concrete1[#BaseClass#];
+// SUBTYPE_1-DAG: Decl[TypeAlias]/Super:              Concrete2[#AnotherTy#];
 // SUBTYPE_1: End completions
 
 func testMemberTypealias() {


### PR DESCRIPTION
Always suggest typealias declarations from inherited protocols.

Fixes rdar://78780638 [SR-14688]
