### PR TITLE
[Async Refactoring] Handle parenthesis around params that no longer need to be unwrapped after refactoring

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -6802,7 +6802,8 @@ private:
         // Synthesize the force unwrap so that we get the expected results.
         if (TopHandler.getHandlerType() == HandlerType::PARAMS &&
             TopHandler.HasError) {
-          if (auto DRE = dyn_cast<DeclRefExpr>(Elt)) {
+          if (auto DRE =
+                  dyn_cast<DeclRefExpr>(Elt->getSemanticsProvidingExpr())) {
             auto D = DRE->getDecl();
             if (Unwraps.count(D)) {
               Elt = new (getASTContext()) ForceValueExpr(Elt, SourceLoc());

--- a/test/refactoring/ConvertAsync/convert_function.swift
+++ b/test/refactoring/ConvertAsync/convert_function.swift
@@ -587,6 +587,17 @@ func wrapCompletionCallInParenthesis(completion: @escaping (String?, Error?) -> 
 // WRAP-COMPLETION-CALL-IN-PARENS-NEXT:   return res
 // WRAP-COMPLETION-CALL-IN-PARENS-NEXT: }
 
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=WRAP-RESULT-IN-PARENS %s
+func wrapResultInParenthesis(completion: @escaping (String?, Error?) -> Void) {
+  simpleErr(arg: "test") { (res, err) in
+    completion((res).self, err)
+  }
+}
+// WRAP-RESULT-IN-PARENS:      func wrapResultInParenthesis() async throws -> String {
+// WRAP-RESULT-IN-PARENS-NEXT:   let res = try await simpleErr(arg: "test")
+// WRAP-RESULT-IN-PARENS-NEXT:   return res
+// WRAP-RESULT-IN-PARENS-NEXT: }
+
 // RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=TWO-COMPLETION-HANDLER-CALLS %s
 func twoCompletionHandlerCalls(completion: @escaping (String?, Error?) -> Void) {
   simpleErr(arg: "test") { (res, err) in


### PR DESCRIPTION
Throw another `getSemanticsProvidingExpr` in the async refactoring code for better results.