### PR TITLE
Additional architecture support for the `ScanDependencies/clang-target.swift` test.

### DIFF
--- a/test/ScanDependencies/Inputs/Swift/XWithTarget.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/XWithTarget.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name XWithTarget -target arm64-apple-macosx10.9
+// swift-module-flags: -module-name XWithTarget -target arm64e-apple-macosx10.9
 import Swift
 @_exported import X
 public func overlayFuncX() { }


### PR DESCRIPTION

Resolves rdar://81128522
