### PR TITLE
[stdlib] fast path for UMBP.initialize<C>(from: C) when C is a Slice

### DIFF
--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1144,7 +1144,7 @@ extension Sequence {
     return _copySequenceContents(initializing: buffer)
   }
 
-  @inlinable
+  @_alwaysEmitIntoClient
   internal __consuming func _copySequenceContents(
     initializing buffer: UnsafeMutableBufferPointer<Element>
   ) -> (Iterator,UnsafeMutableBufferPointer<Element>.Index) {

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1141,6 +1141,13 @@ extension Sequence {
   public __consuming func _copyContents(
     initializing buffer: UnsafeMutableBufferPointer<Element>
   ) -> (Iterator,UnsafeMutableBufferPointer<Element>.Index) {
+    return _copySequenceContents(initializing: buffer)
+  }
+
+  @inlinable
+  internal __consuming func _copySequenceContents(
+    initializing buffer: UnsafeMutableBufferPointer<Element>
+  ) -> (Iterator,UnsafeMutableBufferPointer<Element>.Index) {
     var it = self.makeIterator()
     guard var ptr = buffer.baseAddress else { return (it,buffer.startIndex) }
     for idx in buffer.startIndex..<buffer.count {

--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -237,9 +237,8 @@ extension Slice {
     if let (_, copied) = self.withContiguousStorageIfAvailable({
       $0._copyContents(initializing: buffer)
     }) {
-      let distance = buffer.distance(from: buffer.startIndex, to: copied)
-      let i = index(startIndex, offsetBy: distance)
-      return (Iterator(_elements: self, _position: i), copied)
+      let position = index(startIndex, offsetBy: copied)
+      return (Iterator(_elements: self, _position: position), copied)
     }
 
     return _copySequenceContents(initializing: buffer)

--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -229,6 +229,23 @@ extension Slice: Collection {
   }
 }
 
+extension Slice {
+  @inlinable
+  public __consuming func _copyContents(
+      initializing buffer: UnsafeMutableBufferPointer<Element>
+  ) -> (Iterator, UnsafeMutableBufferPointer<Element>.Index) {
+    if let (_, copied) = self.withContiguousStorageIfAvailable({
+      $0._copyContents(initializing: buffer)
+    }) {
+      let distance = buffer.distance(from: buffer.startIndex, to: copied)
+      let i = index(startIndex, offsetBy: distance)
+      return (Iterator(_elements: self, _position: i), copied)
+    }
+
+    return _copySequenceContents(initializing: buffer)
+  }
+}
+
 extension Slice: BidirectionalCollection where Base: BidirectionalCollection {
   @inlinable // generic-performance
   public func index(before i: Index) -> Index {

--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -230,7 +230,7 @@ extension Slice: Collection {
 }
 
 extension Slice {
-  @inlinable
+  @_alwaysEmitIntoClient
   public __consuming func _copyContents(
       initializing buffer: UnsafeMutableBufferPointer<Element>
   ) -> (Iterator, UnsafeMutableBufferPointer<Element>.Index) {

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -361,6 +361,22 @@ UnsafeMutableBufferPointerTestSuite.test("withContiguous(Mutable)StorageIfAvaila
   expectEqual(result1, result2)
 }
 
+UnsafeMutableBufferPointerTestSuite.test("initialize(from: Slice)") {
+  let o = 91
+  let c = 1_000
+  let a = Slice(base: Array(0..<c), bounds: o..<c)
+
+  let buffer = UnsafeMutableBufferPointer<Int>.allocate(capacity: c-o)
+  defer { buffer.deallocate() }
+
+  var (iterator, copied) = buffer.initialize(from: a)
+  expectEqual(iterator.next(), nil)
+  expectEqual(copied, c-o)
+
+  let t = buffer.indices.randomElement()!
+  expectEqual(a[t+o], buffer[t])
+}
+
 UnsafeMutableBufferPointerTestSuite.test("Slice.withContiguousStorageIfAvailable") {
   guard #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) else {
     return


### PR DESCRIPTION
`UnsafeMutableBufferPointer.initialize(from:)` initializes a buffer from a `Sequence`. Many standard library collections have a fast path that implements the multi-element copy in a single call, but that fast path is currently stymied when the collection is wrapped in a `Slice`. This PR implements `Slice._copyContents`, which attempts a fast copy via `_withContiguousStorageIfAvailable` before reverting to an element-by-element copy. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-14491 (rdar://76728166)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
