### PR TITLE
[Tests] Mark some tests as unsupported in back deployment testing.

### DIFF
--- a/test/Concurrency/Runtime/actor_detach.swift
+++ b/test/Concurrency/Runtime/actor_detach.swift
@@ -4,6 +4,9 @@
 // REQUIRES: concurrency
 // REQUIRES: foundation
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 import Foundation
 
 @available(SwiftStdlib 5.5, *)

--- a/test/Concurrency/Runtime/actor_init.swift
+++ b/test/Concurrency/Runtime/actor_init.swift
@@ -4,6 +4,9 @@
 // REQUIRES: concurrency
 // REQUIRES: libdispatch
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 @available(SwiftStdlib 5.5, *)
 actor Number {
     var val: Int

--- a/test/Interpreter/rdar80847020.swift
+++ b/test/Interpreter/rdar80847020.swift
@@ -6,6 +6,10 @@
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
+// REQUIRES: concurrency
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 
 func run(_ s: Clazz) async throws {
     let res: (String, String) = try await s.doSomethingMultiResultFlaggy()

--- a/test/stdlib/Reflection_objc.swift
+++ b/test/stdlib/Reflection_objc.swift
@@ -9,6 +9,9 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 //
 // DO NOT add more tests to this file.  Add them to test/1_stdlib/Runtime.swift.
 //


### PR DESCRIPTION
These tests require a newer runtime and fail on older OSes:

   test/Concurrency/Runtime/actor_detach.swift
   test/Concurrency/Runtime/actor_init.swift
   test/Interpreter/rdar80847020.swift
   test/stdlib/Reflection_objc.swift