### PR TITLE
Prefix @_cdecl functions with `extern "C"` in -Swift.h headers

### DIFF
--- a/lib/PrintAsObjC/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.cpp
@@ -728,6 +728,8 @@ private:
     auto resultTy = getForeignResultType(
         FD, funcTy, asyncConvention, errorConvention);
 
+    os << "SWIFT_EXTERN ";
+
     // The result type may be a partial function type we need to close
     // up later.
     PrintMultiPartType multiPart(*this);

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -243,6 +243,13 @@ static void writePrologue(raw_ostream &out, ASTContext &ctx,
          "#if !defined(IBSegueAction)\n"
          "# define IBSegueAction\n"
          "#endif\n"
+         "#if !defined(SWIFT_EXTERN)\n"
+         "# if defined(__cplusplus)\n"
+         "#  define SWIFT_EXTERN extern \"C\"\n"
+         "# else\n"
+         "#  define SWIFT_EXTERN extern\n"
+         "# endif\n"
+         "#endif\n"
          ;
   static_assert(SWIFT_MAX_IMPORTED_SIMD_ELEMENTS == 4,
               "need to add SIMD typedefs here if max elements is increased");

--- a/test/PrintAsObjC/cdecl.swift
+++ b/test/PrintAsObjC/cdecl.swift
@@ -8,51 +8,51 @@
 // REQUIRES: objc_interop
 
 // CHECK: /// What a nightmare!
-// CHECK-LABEL: double (^ _Nonnull block_nightmare(SWIFT_NOESCAPE float (^ _Nonnull x)(NSInteger)))(char) SWIFT_WARN_UNUSED_RESULT;
+// CHECK-LABEL: SWIFT_EXTERN double (^ _Nonnull block_nightmare(SWIFT_NOESCAPE float (^ _Nonnull x)(NSInteger)))(char) SWIFT_WARN_UNUSED_RESULT;
 
 /// What a nightmare!
 @_cdecl("block_nightmare")
 public func block_nightmare(x: @convention(block) (Int) -> Float)
   -> @convention(block) (CChar) -> Double { return { _ in 0 } }
 
-// CHECK-LABEL: double (^ _Nonnull block_recurring_nightmare(float (^ _Nonnull x)(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(double))))(SWIFT_NOESCAPE char (^ _Nonnull)(unsigned char)) SWIFT_WARN_UNUSED_RESULT;
+// CHECK-LABEL: SWIFT_EXTERN double (^ _Nonnull block_recurring_nightmare(float (^ _Nonnull x)(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(double))))(SWIFT_NOESCAPE char (^ _Nonnull)(unsigned char)) SWIFT_WARN_UNUSED_RESULT;
 @_cdecl("block_recurring_nightmare")
 public func block_recurring_nightmare(x: @escaping @convention(block) (@convention(block) (Double) -> Int) -> Float)
   -> @convention(block) (_ asdfasdf: @convention(block) (CUnsignedChar) -> CChar) -> Double {
   fatalError()
 }
 
-// CHECK-LABEL: void foo_bar(NSInteger x, NSInteger y);
+// CHECK-LABEL: SWIFT_EXTERN void foo_bar(NSInteger x, NSInteger y);
 @_cdecl("foo_bar")
 func foo(x: Int, bar y: Int) {}
 
-// CHECK-LABEL: double (* _Nonnull function_pointer_nightmare(SWIFT_NOESCAPE float (* _Nonnull x)(NSInteger)))(char) SWIFT_WARN_UNUSED_RESULT;
+// CHECK-LABEL: SWIFT_EXTERN double (* _Nonnull function_pointer_nightmare(SWIFT_NOESCAPE float (* _Nonnull x)(NSInteger)))(char) SWIFT_WARN_UNUSED_RESULT;
 @_cdecl("function_pointer_nightmare")
 func function_pointer_nightmare(x: @convention(c) (Int) -> Float)
   -> @convention(c) (CChar) -> Double { return { _ in 0 } }
 
-// CHECK-LABEL: double (* _Nonnull function_pointer_recurring_nightmare(float (* _Nonnull x)(SWIFT_NOESCAPE NSInteger (* _Nonnull)(double))))(SWIFT_NOESCAPE char (* _Nonnull)(unsigned char)) SWIFT_WARN_UNUSED_RESULT;
+// CHECK-LABEL: SWIFT_EXTERN double (* _Nonnull function_pointer_recurring_nightmare(float (* _Nonnull x)(SWIFT_NOESCAPE NSInteger (* _Nonnull)(double))))(SWIFT_NOESCAPE char (* _Nonnull)(unsigned char)) SWIFT_WARN_UNUSED_RESULT;
 @_cdecl("function_pointer_recurring_nightmare")
 public func function_pointer_recurring_nightmare(x: @escaping @convention(c) (@convention(c) (Double) -> Int) -> Float)
   -> @convention(c) (@convention(c) (CUnsignedChar) -> CChar) -> Double {
   fatalError()
 }
   
-// CHECK-LABEL: void has_keyword_arg_names(NSInteger auto_, NSInteger union_);
+// CHECK-LABEL: SWIFT_EXTERN void has_keyword_arg_names(NSInteger auto_, NSInteger union_);
 @_cdecl("has_keyword_arg_names")
 func keywordArgNames(auto: Int, union: Int) {}
 
 @objc
 class C {}
 
-// CHECK-LABEL: C * _Null_unspecified return_iuo(void) SWIFT_WARN_UNUSED_RESULT;
+// CHECK-LABEL: SWIFT_EXTERN C * _Null_unspecified return_iuo(void) SWIFT_WARN_UNUSED_RESULT;
 @_cdecl("return_iuo")
 func returnIUO() -> C! { return C() }
 
-// CHECK-LABEL: void return_never(void) SWIFT_NORETURN;
+// CHECK-LABEL: SWIFT_EXTERN void return_never(void) SWIFT_NORETURN;
 @_cdecl("return_never")
 func returnNever() -> Never { fatalError() }
 
-// CHECK-LABEL: void takes_iuo(C * _Null_unspecified c);
+// CHECK-LABEL: SWIFT_EXTERN void takes_iuo(C * _Null_unspecified c);
 @_cdecl("takes_iuo")
 func takesIUO(c: C!) {}


### PR DESCRIPTION
This ensures that the functions use the appropriate mangling if the header is imported and the functions are used from Objective-C++ code. Without this, users must place an `extern "C" { … }` block around the import of the generated header.