### PR TITLE
[stdlib] Set a more correct deployment target for stdlib binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,37 @@ set(SWIFT_DARWIN_XCRUN_TOOLCHAIN "XcodeDefault" CACHE STRING
 set(SWIFT_DARWIN_STDLIB_INSTALL_NAME_DIR "/usr/lib/swift" CACHE STRING
     "The directory of the install_name for standard library dylibs")
 
+# Minimum deployment targets for runtime/stdlib libraries on Apple platforms.
+#
+# Parts of the standard library are tightly coupled to specific versions of
+# libobjc/Foundation, so the stdlib binaries built from this repository will not
+# work on any arbitrary OS version -- in practice, the only OS versions we
+# expect them to work on are the exact ones that we use on our CI system. (And
+# only to the extent covered by our tests.)
+#
+# At any given time, the settings below should match the configuration used by
+# ci.swift.org.
+#
+# Note that while we don't set a maximum deployment target, generated stdlib
+# binaries aren't expected to be forward compatible with future OS releases,
+# either. (Not even minor releases.) This is because OS frameworks are very
+# likely to depend on new APIs introduced in their corresponding Swift stdlib
+# release that would be missing from binaries built from an older codebase.
+set(SWIFT_DARWIN_STDLIB_DEPLOYMENT_VERSION_OSX "11.4" CACHE STRING
+    "Minimum deployment target version for stdlib libraries on OS X")
+
+set(SWIFT_DARWIN_STDLIB_DEPLOYMENT_VERSION_IOS "14.3" CACHE STRING
+    "Minimum deployment target version for stdlib libraries on iOS")
+
+set(SWIFT_DARWIN_STDLIB_DEPLOYMENT_VERSION_TVOS "14.3" CACHE STRING
+    "Minimum deployment target version for stdlib libraries on tvOS")
+
+set(SWIFT_DARWIN_STDLIB_DEPLOYMENT_VERSION_WATCHOS "7.2" CACHE STRING
+    "Minimum deployment target version for stdlib libraries on watchOS")
+
+set(SWIFT_DARWIN_STDLIB_DEPLOYMENT_VERSION_MACCATALYST "14.3" CACHE STRING
+    "Minimum deployment target version for stdlib libraries on Mac Catalyst")
+
 # We don't want to use the same install_name_dir as the standard library which
 # will be installed in /usr/lib/swift. These private libraries should continue
 # to use @rpath for now.
@@ -351,6 +382,9 @@ set(SWIFT_DARWIN_DEPLOYMENT_VERSION_TVOS "9.0" CACHE STRING
 
 set(SWIFT_DARWIN_DEPLOYMENT_VERSION_WATCHOS "2.0" CACHE STRING
     "Minimum deployment target version for watchOS")
+
+set(SWIFT_DARWIN_DEPLOYMENT_VERSION_MACCATALYST "13.0" CACHE STRING
+    "Minimum deployment target version for Mac Catalyst")
 
 #
 # User-configurable debugging options.

--- a/cmake/modules/StandaloneOverlay.cmake
+++ b/cmake/modules/StandaloneOverlay.cmake
@@ -36,14 +36,16 @@ set(SWIFT_SOURCE_DIR "${SWIFT_SOURCE_ROOT}/swift" CACHE PATH
 set(SWIFT_DARWIN_XCRUN_TOOLCHAIN "XcodeDefault" CACHE STRING
   "The name of the toolchain to pass to 'xcrun'.")
 
-set(SWIFT_DARWIN_DEPLOYMENT_VERSION_OSX "10.9" CACHE STRING
+set(SWIFT_DARWIN_DEPLOYMENT_VERSION_OSX "11.4" CACHE STRING
     "Minimum deployment target version for macOS.")
-set(SWIFT_DARWIN_DEPLOYMENT_VERSION_IOS "7.0" CACHE STRING
+set(SWIFT_DARWIN_DEPLOYMENT_VERSION_IOS "14.3" CACHE STRING
     "Minimum deployment target version for iOS.")
-set(SWIFT_DARWIN_DEPLOYMENT_VERSION_TVOS "9.0" CACHE STRING
+set(SWIFT_DARWIN_DEPLOYMENT_VERSION_TVOS "14.3" CACHE STRING
     "Minimum deployment target version for tvOS.")
-set(SWIFT_DARWIN_DEPLOYMENT_VERSION_WATCHOS "2.0" CACHE STRING
+set(SWIFT_DARWIN_DEPLOYMENT_VERSION_WATCHOS "7.2" CACHE STRING
     "Minimum deployment target version for watchOS.")
+set(SWIFT_DARWIN_DEPLOYMENT_VERSION_MACCATALYST "13.0" CACHE STRING
+  "Minimum deployment target version for macCatalyst")
 
 set(SWIFT_INSTALL_COMPONENTS "sdk-overlay" CACHE STRING
   "A semicolon-separated list of install components.")
@@ -104,9 +106,6 @@ set(SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES "SHARED")
 option(SWIFT_ENABLE_MACCATALYST
   "Build the overlays with macCatalyst support"
   FALSE)
-
-set(SWIFT_DARWIN_DEPLOYMENT_VERSION_MACCATALYST "13.0" CACHE STRING
-  "Minimum deployment target version for macCatalyst")
 
 # -----------------------------------------------------------------------------
 

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1826,6 +1826,26 @@ function(add_swift_target_library name)
       list(APPEND swiftlib_link_flags_all "-dynamiclib -Wl,-headerpad_max_install_names")
     endif()
 
+    # Configure deployment target for runtime/stdlib libraries.
+    if((SWIFTLIB_IS_STDLIB OR SWIFTLIB_IS_SDK_OVERLAY) AND
+        sdk IN_LIST SWIFT_APPLE_PLATFORMS)
+      if("${SWIFTLIB_DEPLOYMENT_VERSION_OSX}" STREQUAL "")
+        set(SWIFTLIB_DEPLOYMENT_VERSION_OSX "${SWIFT_DARWIN_STDLIB_DEPLOYMENT_VERSION_OSX}")
+      endif()
+      if("${SWIFTLIB_DEPLOYMENT_VERSION_IOS}" STREQUAL "")
+        set(SWIFTLIB_DEPLOYMENT_VERSION_IOS "${SWIFT_DARWIN_STDLIB_DEPLOYMENT_VERSION_IOS}")
+      endif()
+      if("${SWIFTLIB_DEPLOYMENT_VERSION_TVOS}" STREQUAL "")
+        set(SWIFTLIB_DEPLOYMENT_VERSION_TVOS "${SWIFT_DARWIN_STDLIB_DEPLOYMENT_VERSION_TVOS}")
+      endif()
+      if("${SWIFTLIB_DEPLOYMENT_VERSION_WATCHOS}" STREQUAL "")
+        set(SWIFTLIB_DEPLOYMENT_VERSION_WATCHOS "${SWIFT_DARWIN_STDLIB_DEPLOYMENT_VERSION_WATCHOS}")
+      endif()
+      if("${SWIFTLIB_DEPLOYMENT_VERSION_MACCATALYST}" STREQUAL "")
+        set(SWIFTLIB_DEPLOYMENT_VERSION_MACCATALYST "${SWIFT_DARWIN_STDLIB_DEPLOYMENT_VERSION_MACCATALYST}")
+      endif()
+    endif()
+
     set(sdk_supported_archs
       ${SWIFT_SDK_${sdk}_ARCHITECTURES}
       ${SWIFT_SDK_${sdk}_MODULE_ARCHITECTURES})


### PR DESCRIPTION
On Apple platforms, parts of the standard library are tightly coupled to specific versions of libobjc/Foundation, so the stdlib binaries built from this repository will not work on any arbitrary OS version -- in practice, the only OS versions we expect them to work on are the exact ones that we use on our CI system. (And only to the extent covered by our tests.)

Set the minimum deployment target of stdlib binaries to match whatever OS versions we use on ci.swift.org. (This will need to be updated whenever we upgrade the CI machines.)

Note that while we don't check for a maximum deployment target, generated stdlib binaries aren't expected to be forward compatible with future OS releases, either. (Not even minor releases.) This is because OS frameworks are very likely to depend on new APIs introduced in their corresponding Swift stdlib release that would be missing from binaries built from an older codebase.

Also note that this deployment target does not affect our ability to build apps that need to deploy on earlier OSes -- it just affects the binary stdlib dylibs that are built alongside the compiler. (The swiftinterface file isn't affected by the deployment target setting.)

rdar://81237610