### PR TITLE
DependenciesScanner: include -sdk in Swift module building command

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1290,6 +1290,13 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
   genericSubInvocation.setImportSearchPaths(SearchPathOpts.ImportSearchPaths);
   genericSubInvocation.setFrameworkSearchPaths(SearchPathOpts.FrameworkSearchPaths);
   if (!SearchPathOpts.SDKPath.empty()) {
+    // Add -sdk arguments to the module building commands.
+    // Module building commands need this because dependencies sometimes use
+    // sdk-relative paths (prebuilt modules for example). Without -sdk, the command
+    // will not be able to local these dependencies, leading to unnecessary
+    // building from textual interfaces.
+    GenericArgs.push_back("-sdk");
+    GenericArgs.push_back(ArgSaver.save(SearchPathOpts.SDKPath));
     genericSubInvocation.setSDKPath(SearchPathOpts.SDKPath);
   }
 

--- a/test/ScanDependencies/include-sdk-in-command.swift
+++ b/test/ScanDependencies/include-sdk-in-command.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -sdk %t/mysecretsdk.sdk
+
+// Check the contents of the JSON output
+// RUN: %FileCheck %s < %t/deps.json
+
+func foo() { print(1) }
+
+// CHECK: "-sdk",
+// CHECK-NEXT: mysecretsdk.sdk

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -213,7 +213,6 @@ import SubE
 /// --------Clang module SwiftShims
 // CHECK-LABEL: "modulePath": "SwiftShims.pcm",
 
-// CHECK-NO-SEARCH-PATHS-NOT: "-sdk"
 // CHECK-NO-SEARCH-PATHS-NOT: "-prebuilt-module-cache-path"
 
 // Check make-style dependencies


### PR DESCRIPTION
Swift module building commands need -sdk because dependencies sometimes use
sdk-relative paths (prebuilt modules for example). Without -sdk, the command
will not be able to local these dependencies, leading to unnecessary
rebuilding from textual interfaces.

rdar://81177968