### PR TITLE
Improve existential associated type witness note

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2293,7 +2293,13 @@ NOTE(protocol_witness_type,none,
      "possibly intended match", ())
 NOTE(protocol_witness_nonconform_type,none,
      "possibly intended match %0 does not "
-     "%select{inherit from|conform to}2 %1", (Type, Type, bool))
+     "%select{inherit from|conform to}2 %1",
+     (Type, Type, /*isConformanceReq=*/bool))
+NOTE(protocol_witness_nonconform_type_existential,none,
+     "possibly intended match %0 cannot conform to %1: a protocol used as a "
+     "type does not conform to itself%select{ or the protocols it requires "
+     "concrete types to conform to|}2",
+     (Type, Type, /*needsSelfConformancePrecisely=*/bool))
 
 NOTE(protocol_witness_circularity,none,
      "candidate references itself", ())

--- a/include/swift/AST/EducationalNotes.def
+++ b/include/swift/AST/EducationalNotes.def
@@ -76,7 +76,10 @@ EDUCATIONAL_NOTES(append_interpolation_static,
                   "string-interpolation-conformance.md")
 EDUCATIONAL_NOTES(append_interpolation_void_or_discardable,
                   "string-interpolation-conformance.md")
+
 EDUCATIONAL_NOTES(type_cannot_conform, "protocol-type-non-conformance.md")
+EDUCATIONAL_NOTES(protocol_witness_nonconform_type_existential,
+                  "protocol-type-non-conformance.md")
 
 EDUCATIONAL_NOTES(unlabeled_trailing_closure_deprecated,
                   "trailing-closure-matching.md")

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4438,6 +4438,20 @@ ConformanceChecker::resolveWitnessTryingAllStrategies(ValueDecl *requirement) {
   return ResolveWitnessResult::Missing;
 }
 
+static bool containsEveryProtocol(Type attempted, Type required,
+                                  ModuleDecl *visibleFrom) {
+  if (auto protoRequired = required->getAs<ProtocolType>())
+    return !TypeChecker::containsProtocol(attempted, protoRequired->getDecl(),
+                                          visibleFrom).isInvalid();
+
+  if(auto compRequired = required->getAs<ProtocolCompositionType>())
+    for (auto memberRequired : compRequired->getMembers())
+      if (!containsEveryProtocol(attempted, memberRequired, visibleFrom))
+        return false;
+
+  return true;
+}
+
 /// Attempt to resolve a type witness via member name lookup.
 ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
                        AssociatedTypeDecl *assocType) {
@@ -4579,12 +4593,26 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
             candidate.second.isError())
           continue;
 
-        diags.diagnose(
-           candidate.first,
-           diag::protocol_witness_nonconform_type,
-           candidate.first->getDeclaredInterfaceType(),
-           candidate.second.getRequirement(),
-           candidate.second.isConformanceRequirement());
+        auto attempted = candidate.first->getDeclaredInterfaceType();
+        auto required = candidate.second.getRequirement();
+        auto isConformanceReq = candidate.second.isConformanceRequirement();
+
+        // Would this type have satisfied the requirement if existentials
+        // conformed to the protocols they require?
+        if (attempted->isExistentialType() &&
+            containsEveryProtocol(attempted, required,
+                                  candidate.first->getModuleContext())) {
+          assert(isConformanceReq && "existential subclass???");
+          diags.diagnose(
+             candidate.first,
+             diag::protocol_witness_nonconform_type_existential, attempted,
+             required, attempted->isEqual(required));
+        }
+        else {
+          diags.diagnose(
+             candidate.first, diag::protocol_witness_nonconform_type,
+             attempted, required, isConformanceReq);
+        }
       }
     });
 

--- a/test/decl/protocol/conforms/associated_type.swift
+++ b/test/decl/protocol/conforms/associated_type.swift
@@ -3,13 +3,18 @@
 class C { }
 
 protocol P {
-  associatedtype AssocP : C // expected-note{{protocol requires nested type 'AssocP'; do you want to add it?}}
+  associatedtype AssocC : C // expected-note{{protocol requires nested type 'AssocC'; do you want to add it?}}
   associatedtype AssocA : AnyObject // expected-note{{protocol requires nested type 'AssocA'; do you want to add it?}}
+  associatedtype AssocP : P // expected-note{{protocol requires nested type 'AssocP'; do you want to add it?}}
+  associatedtype AssocQ : P // expected-note{{protocol requires nested type 'AssocQ'; do you want to add it?}}
 }
+protocol Q: P {}
 
 struct X : P { // expected-error{{type 'X' does not conform to protocol 'P'}}
-  typealias AssocP = Int // expected-note{{possibly intended match 'X.AssocP' (aka 'Int') does not inherit from 'C'}}
+  typealias AssocC = Int // expected-note{{possibly intended match 'X.AssocC' (aka 'Int') does not inherit from 'C'}}
   typealias AssocA = Int // expected-note{{possibly intended match 'X.AssocA' (aka 'Int') does not conform to 'AnyObject'}}
+  typealias AssocP = P // expected-note{{possibly intended match 'X.AssocP' (aka 'P') cannot conform to 'P': a protocol used as a type does not conform to itself}}
+  typealias AssocQ = Q // expected-note{{possibly intended match 'X.AssocQ' (aka 'Q') cannot conform to 'P': a protocol used as a type does not conform to itself or the protocols it requires concrete types to conform to}}
 }
 
 // SR-5166


### PR DESCRIPTION
Emit a tailored diagnostic when an associated type's witness is invalid, but it is an existential whose concrete types would have satisfied the requirement.