### PR TITLE
[android] Android seems to support constexpr mutex with NDK 19c (at least)

### DIFF
--- a/include/swift/Runtime/MutexPThread.h
+++ b/include/swift/Runtime/MutexPThread.h
@@ -37,12 +37,11 @@ typedef os_unfair_lock MutexHandle;
 typedef pthread_mutex_t MutexHandle;
 #endif
 
-#if defined(__CYGWIN__) || defined(__ANDROID__) || defined(__HAIKU__) || defined(__wasi__)
+#if defined(__CYGWIN__) || defined(__HAIKU__) || defined(__wasi__)
 // At the moment CYGWIN pthreads implementation doesn't support the use of
 // constexpr for static allocation versions. The way they define things
-// results in a reinterpret_cast which violates constexpr. Similarly, Android's
-// pthread implementation makes use of volatile attributes that prevent it from
-// being marked as constexpr. WASI currently doesn't support threading/locking at all.
+// results in a reinterpret_cast which violates constexpr.
+// WASI currently doesn't support threading/locking at all.
 #define SWIFT_CONDITION_SUPPORTS_CONSTEXPR 0
 #define SWIFT_MUTEX_SUPPORTS_CONSTEXPR 0
 #define SWIFT_READWRITELOCK_SUPPORTS_CONSTEXPR 0


### PR DESCRIPTION
The usage of constexpr was disabled in 2016 in #2345, but using NDK 19c,
it seems that the usage doesn't fail compiling at the moment.

The Android CI started failing after the introduction of #38562. Using constexpr seems to avoid the problem.

@buttaface: do you mind looking at this and maybe checking that the runtime is not completely broken (I tested with the compiler itself, but I have no way of testing the runtime at the moment).