### PR TITLE
[Test] Used test header rather than SDK.

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar79383990.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar79383990.h
@@ -1,0 +1,12 @@
+@import Foundation;
+
+typedef NS_ENUM(NSInteger, BackgroundActivityResult) {
+    BackgroundActivityResultFinished = 1,
+    BackgroundActivityResultDeferred = 2,
+};
+
+typedef void (^BackgroundActivityCompletionHandler)(BackgroundActivityResult result);
+
+@interface BackgroundActivityScheduler : NSObject
+- (void)scheduleWithBlock:(void (^)(BackgroundActivityCompletionHandler completionHandler))block;
+@end

--- a/validation-test/compiler_crashers_2_fixed/rdar79383990.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar79383990.swift
@@ -1,9 +1,9 @@
-// RUN: %target-swift-frontend %s -emit-silgen -disable-availability-checking
+// RUN: %target-swift-frontend %s -emit-silgen -disable-availability-checking -import-objc-header %S/Inputs/rdar79383990.h
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
 
 import Foundation
 
-func test(s: NSBackgroundActivityScheduler) async {
+func test(s: BackgroundActivityScheduler) async {
     _ = await s.schedule()
 }


### PR DESCRIPTION
Stopped validation-test/compiler_crashers_2_fixed/rdar79383990.swift from trying to call -[NSBackgroundActivityScheduler scheduleWithBlock:] async--that method is now annotated NS_SWIFT_DISABLE_ASYNC.
