### PR TITLE
[ClangImporter] Add @available(*, renamed:) to imported async getters

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -884,7 +884,23 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     if (!Attr->Rename.empty()) {
       Printer << ", renamed: \"" << Attr->Rename << "\"";
     } else if (Attr->RenameDecl) {
-      Printer << ", renamed: \"" << Attr->RenameDecl->getName() << "\"";
+      Printer << ", renamed: \"";
+      if (auto *Accessor = dyn_cast<AccessorDecl>(Attr->RenameDecl)) {
+        switch (Accessor->getAccessorKind()) {
+        case AccessorKind::Get:
+          Printer << "getter:";
+          break;
+        case AccessorKind::Set:
+          Printer << "setter:";
+          break;
+        default:
+          break;
+        }
+        Printer << Accessor->getStorage()->getName() << "()";
+      } else {
+        Printer << Attr->RenameDecl->getName();
+      }
+      Printer << "\"";
     }
 
     // If there's no message, but this is specifically an imported

--- a/test/IDE/print_clang_objc_effectful_properties.swift
+++ b/test/IDE/print_clang_objc_effectful_properties.swift
@@ -7,26 +7,32 @@
 // REQUIRES: objc_interop
 
 // CHECK-LABEL: class EffProps : NSObject {
-// CHECK:  func getDogWithCompletion(_ completionHandler: @escaping (NSObject) -> Void)
-// CHECK:  var doggo: NSObject { get async }
+// CHECK:       @available(*, renamed: "getter:doggo()")
+// CHECK-NEXT:  func getDogWithCompletion(_ completionHandler: @escaping (NSObject) -> Void)
+// CHECK:       var doggo: NSObject { get async }
 
-// CHECK:       func obtainCat(_ completionHandler: @escaping (NSObject?, Error?) -> Void)
+// CHECK:       @available(*, renamed: "getter:catto()")
+// CHECK-NEXT:  func obtainCat(_ completionHandler: @escaping (NSObject?, Error?) -> Void)
 // CHECK-NEXT:  var catto: NSObject? { get async throws }
 
-// CHECK:       func checkAvailability(completionHandler: @escaping (Bool) -> Void)
+// CHECK:       @available(*, renamed: "getter:available()")
+// CHECK-NEXT:  func checkAvailability(completionHandler: @escaping (Bool) -> Void)
 // CHECK-NEXT:  var available: Bool { get async }
 // CHECK-NEXT:  @available(swift, obsoleted: 3, renamed: "checkAvailability(completionHandler:)")
 // CHECK-NEXT:  func checkAvailabilityWithCompletionHandler(_ completionHandler: @escaping (Bool) -> Void)
 
-// CHECK:       func returnNothing(completion completionHandler: @escaping () -> Void)
+// CHECK:       @available(*, renamed: "getter:touch()")
+// CHECK-NEXT:  func returnNothing(completion completionHandler: @escaping () -> Void)
 // CHECK-NEXT:  var touch: Void { get async }
 // CHECK-NEXT:  @available(swift, obsoleted: 3, renamed: "returnNothing(completion:)")
 // CHECK-NEXT:  func returnNothingWithCompletion(_ completionHandler: @escaping () -> Void)
 
-// CHECK:       func nullableHandler(_ completion: ((String) -> Void)? = nil)
+// CHECK:       @available(*, renamed: "getter:fromNullableHandler()")
+// CHECK-NEXT:  func nullableHandler(_ completion: ((String) -> Void)? = nil)
 // CHECK-NEXT:  var fromNullableHandler: String { get async }
 
-// CHECK:  func getMainDog(_ completion: @escaping (String) -> Void)
+// CHECK:       @available(*, renamed: "getter:mainDogProp()")
+// CHECK-NEXT:  func getMainDog(_ completion: @escaping (String) -> Void)
 // CHECK-NEXT:  var mainDogProp: String { get async }
 
 // CHECK:       @available(*, renamed: "regularMainDog()")


### PR DESCRIPTION
The attribute was missing from functions with getters as their async
alternative. Only getters are imported like this, so no need to check
for the other accessors.

Resolves rdar://80612566