### PR TITLE
[Refactoring] Use known alternative in async refactoring if one exists

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6599,6 +6599,10 @@ public:
     Bits.AccessorDecl.IsTransparentComputed = 1;
   }
 
+  /// A representation of the name to be displayed to users. \c getNameStr
+  /// for anything other than a getter or setter.
+  void printUserFacingName(llvm::raw_ostream &out) const;
+
   static bool classof(const Decl *D) {
     return D->getKind() == DeclKind::Accessor;
   }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6220,7 +6220,7 @@ public:
   /// handler if \p asyncAlternative is not set (with the same conditions on
   /// its type as above).
   Optional<unsigned> findPotentialCompletionHandlerParam(
-      AbstractFunctionDecl *asyncAlternative = nullptr) const;
+      const AbstractFunctionDecl *asyncAlternative = nullptr) const;
 
   /// Determine whether this function is implicitly known to have its
   /// parameters of function type be @_unsafeSendable.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -30,6 +30,8 @@ NOTE(decl_declared_here,none,
      "%0 declared here", (DeclName))
 NOTE(kind_declared_here,none,
      "%0 declared here", (DescriptiveDeclKind))
+NOTE(descriptive_decl_declared_here,none,
+     "'%0' declared here", (StringRef))
 NOTE(implicit_member_declared_here,none,
      "%1 '%0' is implicitly declared", (StringRef, StringRef))
 NOTE(extended_type_declared_here,none,

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -886,17 +886,10 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     } else if (Attr->RenameDecl) {
       Printer << ", renamed: \"";
       if (auto *Accessor = dyn_cast<AccessorDecl>(Attr->RenameDecl)) {
-        switch (Accessor->getAccessorKind()) {
-        case AccessorKind::Get:
-          Printer << "getter:";
-          break;
-        case AccessorKind::Set:
-          Printer << "setter:";
-          break;
-        default:
-          break;
-        }
-        Printer << Accessor->getStorage()->getName() << "()";
+        SmallString<32> Name;
+        llvm::raw_svector_ostream OS(Name);
+        Accessor->printUserFacingName(OS);
+        Printer << Name.str();
       } else {
         Printer << Attr->RenameDecl->getName();
       }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7120,7 +7120,7 @@ static bool isPotentialCompletionHandler(const ParamDecl *param) {
 }
 
 Optional<unsigned> AbstractFunctionDecl::findPotentialCompletionHandlerParam(
-    AbstractFunctionDecl *asyncAlternative) const {
+    const AbstractFunctionDecl *asyncAlternative) const {
   const ParameterList *params = getParameters();
   if (params->size() == 0)
     return None;
@@ -7203,7 +7203,7 @@ Optional<unsigned> AbstractFunctionDecl::findPotentialCompletionHandlerParam(
 
     // The next original param should match the current async, so don't
     // increment the async index
-    potentialParam = asyncParamIndex;
+    potentialParam = paramIndex;
     paramIndex++;
   }
   return potentialParam;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7910,6 +7910,28 @@ bool AccessorDecl::isSimpleDidSet() const {
                            SimpleDidSetRequest{mutableThis}, false);
 }
 
+void AccessorDecl::printUserFacingName(raw_ostream &out) const {
+  switch (getAccessorKind()) {
+  case AccessorKind::Get:
+    out << "getter:";
+    break;
+  case AccessorKind::Set:
+    out << "setter:";
+    break;
+  default:
+    out << getName();
+    return;
+  }
+
+  out << getStorage()->getName() << "(";
+  if (this->isSetter()) {
+    for (const auto *param : *getParameters()) {
+      out << param->getName() << ":";
+    }
+  }
+  out << ")";
+}
+
 StaticSpellingKind FuncDecl::getCorrectStaticSpelling() const {
   assert(getDeclContext()->isTypeContext());
   if (!isStatic())

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -4424,6 +4424,8 @@ struct AsyncHandlerDesc {
     });
   }
 
+  // TODO: If we have an async alternative we should check its result types
+  //       for whether to unwrap or not
   bool shouldUnwrap(swift::Type Ty) const {
     return HasError && Ty->isOptional();
   }
@@ -4433,60 +4435,71 @@ struct AsyncHandlerDesc {
 /// information about that completion handler and its index within the function
 /// declaration.
 struct AsyncHandlerParamDesc : public AsyncHandlerDesc {
+  /// Enum to represent the position of the completion handler param within
+  /// the parameter list. Given `(A, B, C, D)`:
+  ///   - A is `First`
+  ///   - B and C are `Middle`
+  ///   - D is `Last`
+  /// The position is `Only` if there's a single parameter that is the
+  /// completion handler and `None` if there is no handler.
+  enum class Position {
+    First, Middle, Last, Only, None
+  };
+
   /// The function the completion handler is a parameter of.
   const FuncDecl *Func = nullptr;
   /// The index of the completion handler in the function that declares it.
-  int Index = -1;
+  unsigned Index = 0;
+  /// The async alternative, if one is found.
+  const AbstractFunctionDecl *Alternative = nullptr;
 
   AsyncHandlerParamDesc() : AsyncHandlerDesc() {}
   AsyncHandlerParamDesc(const AsyncHandlerDesc &Handler, const FuncDecl *Func,
-                        int Index)
-      : AsyncHandlerDesc(Handler), Func(Func), Index(Index) {}
+                        unsigned Index,
+                        const AbstractFunctionDecl *Alternative)
+      : AsyncHandlerDesc(Handler), Func(Func), Index(Index),
+        Alternative(Alternative) {}
 
   static AsyncHandlerParamDesc find(const FuncDecl *FD,
                                     bool RequireAttributeOrName) {
-    if (!FD || FD->hasAsync() || FD->hasThrows())
+    if (!FD || FD->hasAsync() || FD->hasThrows() ||
+        !FD->getResultInterfaceType()->isVoid())
       return AsyncHandlerParamDesc();
 
-    bool RequireName = RequireAttributeOrName;
-    if (RequireAttributeOrName && FD->getAsyncAlternative())
-      RequireName = false;
-
-    // Require at least one parameter and void return type
-    auto *Params = FD->getParameters();
-    if (Params->size() == 0 || !FD->getResultInterfaceType()->isVoid())
+    const auto *Alternative = FD->getAsyncAlternative();
+    Optional<unsigned> Index =
+        FD->findPotentialCompletionHandlerParam(Alternative);
+    if (!Index)
       return AsyncHandlerParamDesc();
 
-    // Assume the handler is the last parameter for now
-    int Index = Params->size() - 1;
-    const ParamDecl *Param = Params->get(Index);
-
-    // Callback must not be attributed with @autoclosure
-    if (Param->isAutoClosure())
-      return AsyncHandlerParamDesc();
-
-    return AsyncHandlerParamDesc(AsyncHandlerDesc::get(Param, RequireName), FD,
-                                 Index);
+    bool RequireName = RequireAttributeOrName && !Alternative;
+    return AsyncHandlerParamDesc(
+        AsyncHandlerDesc::get(FD->getParameters()->get(*Index), RequireName),
+        FD, *Index, Alternative);
   }
 
-  /// Print the name of the function with the completion handler, without
-  /// the completion handler parameter, to \p OS. That is, the name of the
-  /// async alternative function.
-  void printAsyncFunctionName(llvm::raw_ostream &OS) const {
-    if (!Func || Index < 0)
-      return;
+  /// Build an @available attribute with the name of the async alternative as
+  /// the \c renamed argument, followed by a newline.
+  SmallString<128> buildRenamedAttribute() const {
+    SmallString<128> AvailabilityAttr;
+    llvm::raw_svector_ostream OS(AvailabilityAttr);
+
+    // If there's an alternative then there must already be an attribute,
+    // don't add another.
+    if (!isValid() || Alternative)
+      return AvailabilityAttr;
 
     DeclName Name = Func->getName();
-    OS << Name.getBaseName();
-
-    OS << tok::l_paren;
+    OS << "@available(*, renamed: \"" << Name.getBaseName() << "(";
     ArrayRef<Identifier> ArgNames = Name.getArgumentNames();
     for (size_t I = 0; I < ArgNames.size(); ++I) {
-      if (I != (size_t)Index) {
+      if (I != Index) {
         OS << ArgNames[I] << tok::colon;
       }
     }
-    OS << tok::r_paren;
+    OS << ")\")\n";
+
+    return AvailabilityAttr;
   }
 
   /// Retrieves the parameter decl for the completion handler parameter, or
@@ -4494,12 +4507,30 @@ struct AsyncHandlerParamDesc : public AsyncHandlerDesc {
   const ParamDecl *getHandlerParam() const {
     if (!isValid())
       return nullptr;
-    return Func->getParameters()->get(Index);
+    return cast<ParamDecl>(getHandler());
+  }
+
+  /// See \c Position
+  Position handlerParamPosition() const {
+    if (!isValid())
+      return Position::None;
+    const auto *Params = Func->getParameters();
+    if (Params->size() == 1)
+      return Position::Only;
+    if (Index == 0)
+      return Position::First;
+    if (Index == Params->size() - 1)
+      return Position::Last;
+    return Position::Middle;
   }
 
   bool operator==(const AsyncHandlerParamDesc &Other) const {
     return Handler == Other.Handler && Type == Other.Type &&
            HasError == Other.HasError && Index == Other.Index;
+  }
+
+  bool alternativeIsAccessor() const {
+    return Alternative && isa<AccessorDecl>(Alternative);
   }
 };
 
@@ -5626,10 +5657,18 @@ private:
     if (AfterTarget && !E->isImplicit()) {
       if (auto *DRE = dyn_cast<DeclRefExpr>(E)) {
         if (auto *D = DRE->getDecl()) {
-          // Only care about references that aren't declared as seen decls will
+          // Only care about references that aren't declared, as seen decls will
           // be renamed (if necessary) during the refactoring.
-          if (!D->isImplicit() && !DeclaredDecls.count(D))
+          if (!D->isImplicit() && !DeclaredDecls.count(D)) {
             ReferencedDecls.insert(D);
+
+            // Also add the async alternative of a function to prevent
+            // collisions if a call is replaced with the alternative.
+            if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
+              if (auto *Alternative = AFD->getAsyncAlternative())
+                ReferencedDecls.insert(Alternative);
+            }
+          }
         }
       }
     } else if (E == Target.dyn_cast<Expr *>()) {
@@ -5713,8 +5752,16 @@ private:
         if (auto *D = DRE->getDecl()) {
           // If we have a reference that isn't declared in the same scope,
           // increment the number of references to that decl.
-          if (!D->isImplicit() && !ScopeStack.back().DeclaredDecls.count(D))
+          if (!D->isImplicit() && !ScopeStack.back().DeclaredDecls.count(D)) {
             (*ScopeStack.back().ReferencedDecls)[D] += 1;
+
+            // Also add the async alternative of a function to prevent
+            // collisions if a call is replaced with the alternative.
+            if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
+              if (auto *Alternative = AFD->getAsyncAlternative())
+                (*ScopeStack.back().ReferencedDecls)[Alternative] += 1;
+            }
+          }
         }
       }
     }
@@ -5921,7 +5968,8 @@ public:
         convertNode(FD->getBody());
       }
     } else {
-      convertNode(StartNode);
+      convertNode(StartNode, /*StartOverride=*/{}, /*ConvertCalls=*/true,
+                  /*IncludeComments=*/false);
     }
     return !DiagEngine.hadAnyError();
   }
@@ -5936,11 +5984,11 @@ public:
   bool createLegacyBody() {
     assert(Buffer.empty() &&
            "AsyncConverter can only be used once");
-    if (!canCreateLegacyBody()) {
-      return false;
-    }
-    FuncDecl *FD = cast<FuncDecl>(StartNode.get<Decl *>());
 
+    if (!canCreateLegacyBody())
+      return false;
+
+    FuncDecl *FD = cast<FuncDecl>(StartNode.get<Decl *>());
     OS << tok::l_brace << "\n"; // start function body
     OS << "Task " << tok::l_brace << "\n";
     addHoistedNamedCallback(FD, TopHandler, TopHandler.getNameStr(), [&]() {
@@ -5948,7 +5996,12 @@ public:
         OS << tok::kw_try << " ";
       }
       OS << "await ";
-      addCallToAsyncMethod(FD, TopHandler);
+
+      // Since we're *creating* the async alternative here, there shouldn't
+      // already be one. Thus, just assume that the call to the alternative is
+      // the same as the call to the old completion handler function, minus the
+      // completion handler arg.
+      addForwardingCallTo(FD, /*HandlerReplacement=*/"");
     });
     OS << "\n";
     OS << tok::r_brace << "\n"; // end 'Task'
@@ -5985,8 +6038,9 @@ public:
     // fnWithHandler(args...) { ... }
     auto ClosureStr =
         getAsyncWrapperCompletionClosure("continuation", TopHandler);
-    addForwardingCallTo(FD, TopHandler, /*HandlerReplacement=*/ClosureStr);
+    addForwardingCallTo(FD, /*HandlerReplacement=*/ClosureStr);
 
+    OS << "\n";
     OS << tok::r_brace << "\n"; // end continuation closure
     OS << tok::r_brace << "\n"; // end function body
     return true;
@@ -6151,18 +6205,18 @@ private:
       llvm_unreachable("Should not have an invalid handler here");
     }
 
-    OS << tok::r_brace << "\n"; // end closure
+    OS << tok::r_brace; // end closure
     return OutputStr;
   }
 
   /// Retrieves the location for the start of a comment attached to the token
   /// at the provided location, or the location itself if there is no comment.
-  SourceLoc getLocIncludingPrecedingComment(SourceLoc loc) {
-    auto tokens = SF->getAllTokens();
-    auto tokenIter = token_lower_bound(tokens, loc);
-    if (tokenIter != tokens.end() && tokenIter->hasComment())
-      return tokenIter->getCommentStart();
-    return loc;
+  SourceLoc getLocIncludingPrecedingComment(SourceLoc Loc) {
+    auto Tokens = SF->getAllTokens();
+    auto TokenIter = token_lower_bound(Tokens, Loc);
+    if (TokenIter != Tokens.end() && TokenIter->hasComment())
+      return TokenIter->getCommentStart();
+    return Loc;
   }
 
   /// If the provided SourceLoc has a preceding comment, print it out. Returns
@@ -6218,14 +6272,13 @@ private:
   }
 
   void convertNode(ASTNode Node, SourceLoc StartOverride = {},
-                   bool ConvertCalls = true) {
+                   bool ConvertCalls = true,
+                   bool IncludePrecedingComment = true) {
     if (!StartOverride.isValid())
       StartOverride = Node.getStartLoc();
 
-    // Unless this is the start node, make sure to include any preceding
-    // comments attached to the loc. If it's the start node, the attached
-    // comment is outside the range of the transform.
-    if (Node != StartNode)
+    // Make sure to include any preceding comments attached to the loc
+    if (IncludePrecedingComment)
       StartOverride = getLocIncludingPrecedingComment(StartOverride);
 
     llvm::SaveAndRestore<SourceLoc> RestoreLoc(LastAddedLoc, StartOverride);
@@ -6412,14 +6465,14 @@ private:
       //    calls in the continuation block)
       if (NestedExprCount == 0 && !Scopes.back().isWrappedInContination()) {
         // If the refactoring is on the call itself, do not require the callee
-        // to have the @completionHandlerAsync attribute or a completion-like
-        // name.
+        // to have the @available attribute or a completion-like name.
         auto HandlerDesc = AsyncHandlerParamDesc::find(
             getUnderlyingFunc(CE->getFn()),
             /*RequireAttributeOrName=*/StartNode.dyn_cast<Expr *>() != CE);
-        if (HandlerDesc.isValid())
+        if (HandlerDesc.isValid()) {
           return addCustom(CE->getSourceRange(),
                            [&]() { addHoistedCallback(CE, HandlerDesc); });
+        }
       }
     }
 
@@ -6538,6 +6591,7 @@ private:
   void addFuncDecl(const FuncDecl *FD) {
     auto *Params = FD->getParameters();
     auto *HandlerParam = TopHandler.getHandlerParam();
+    auto ParamPos = TopHandler.handlerParamPosition();
 
     // If the completion handler parameter has a default argument, the async
     // version is effectively @discardableResult, as not all the callers care
@@ -6546,22 +6600,57 @@ private:
       OS << tok::at_sign << "discardableResult" << "\n";
 
     // First chunk: start -> the parameter to remove (if any)
-    SourceLoc LeftEndLoc = Params->getLParenLoc().getAdvancedLoc(1);
-    if (TopHandler.Index - 1 >= 0) {
+    SourceLoc LeftEndLoc;
+    switch (ParamPos) {
+    case AsyncHandlerParamDesc::Position::None:
+    case AsyncHandlerParamDesc::Position::Only:
+    case AsyncHandlerParamDesc::Position::First:
+      // Handler is the first param (or there is none), so only include the (
+      LeftEndLoc = Params->getLParenLoc().getAdvancedLoc(1);
+      break;
+    case AsyncHandlerParamDesc::Position::Middle:
+      // Handler is somewhere in the middle of the params, so we need to
+      // include any comments and comma up until the handler
+      LeftEndLoc = Params->get(TopHandler.Index)->getStartLoc();
+      LeftEndLoc = getLocIncludingPrecedingComment(LeftEndLoc);
+      break;
+    case AsyncHandlerParamDesc::Position::Last:
+      // Handler is the last param, which means we don't want the comma. This
+      // is a little annoying since we *do* want the comments past for the
+      // last parameter
       LeftEndLoc = Lexer::getLocForEndOfToken(
           SM, Params->get(TopHandler.Index - 1)->getEndLoc());
+      // Skip to the end of any comments
+      Token Next = Lexer::getTokenAtLocation(SM, LeftEndLoc,
+                                             CommentRetentionMode::None);
+      if (Next.getKind() != tok::NUM_TOKENS)
+        LeftEndLoc = Next.getLoc();
+      break;
     }
     addRange(FD->getSourceRangeIncludingAttrs().Start, LeftEndLoc);
 
     // Second chunk: end of the parameter to remove -> right parenthesis
-    SourceLoc MidStartLoc = LeftEndLoc;
+    SourceLoc MidStartLoc;
     SourceLoc MidEndLoc = Params->getRParenLoc().getAdvancedLoc(1);
-    if (TopHandler.isValid()) {
-      if ((size_t)(TopHandler.Index + 1) < Params->size()) {
-        MidStartLoc = Params->get(TopHandler.Index + 1)->getStartLoc();
-      } else {
-        MidStartLoc = Params->getRParenLoc();
-      }
+    switch (ParamPos) {
+    case AsyncHandlerParamDesc::Position::None:
+      // No handler param, so make sure to include them all
+      MidStartLoc = LeftEndLoc;
+      break;
+    case AsyncHandlerParamDesc::Position::First:
+    case AsyncHandlerParamDesc::Position::Middle:
+      // Handler param is either the first or one of the middle params. Skip
+      // past it but make sure to include comments preceding the param after
+      // the handler
+      MidStartLoc = Params->get(TopHandler.Index + 1)->getStartLoc();
+      MidStartLoc = getLocIncludingPrecedingComment(MidStartLoc);
+      break;
+    case AsyncHandlerParamDesc::Position::Only:
+    case AsyncHandlerParamDesc::Position::Last:
+      // Handler param is last, this is easy since there's no other params
+      // to copy over
+      MidStartLoc = Params->getRParenLoc();
+      break;
     }
     addRange(MidStartLoc, MidEndLoc);
 
@@ -6984,7 +7073,7 @@ private:
     llvm::SaveAndRestore<bool> RestoreHoisting(Hoisting, true);
 
     auto ArgList = callArgs(CE);
-    if ((size_t)HandlerDesc.Index >= ArgList.ref().size()) {
+    if (HandlerDesc.Index >= ArgList.ref().size()) {
       DiagEngine.diagnose(CE->getStartLoc(), diag::missing_callback_arg);
       return;
     }
@@ -7021,8 +7110,7 @@ private:
       if (CompletionHandler.isValid()) {
         if (auto CalledFunc = getUnderlyingFunc(CE->getFn())) {
           StringRef HandlerName = Lexer::getCharSourceRangeFromSourceRange(
-                                      SM, CallbackArg->getSourceRange())
-                                      .str();
+              SM, CallbackArg->getSourceRange()).str();
           addHoistedNamedCallback(
               CalledFunc, CompletionHandler, HandlerName, [&] {
                 InlinePatternsToPrint InlinePatterns;
@@ -7042,12 +7130,9 @@ private:
   /// completion handler in the function that's called by \p CE and \p ArgList
   /// are the arguments being passed in \p CE.
   void addHoistedClosureCallback(const CallExpr *CE,
-                                 const AsyncHandlerDesc &HandlerDesc,
+                                 const AsyncHandlerParamDesc &HandlerDesc,
                                  const ClosureExpr *Callback,
                                  PtrArrayRef<Expr *> ArgList) {
-    auto *Callee = getUnderlyingFunc(CE->getFn());
-    assert(Callee);
-
     ArrayRef<const ParamDecl *> CallbackParams =
         Callback->getParameters()->getArray();
     auto CallbackBody = Callback->getBody();
@@ -7080,7 +7165,7 @@ private:
       if (ErrParam)
         UnwrapParams.insert(ErrParam);
       CallbackClassifier::classifyInto(
-          Blocks, Callee, SuccessParams, HandledSwitches, DiagEngine,
+          Blocks, HandlerDesc.Func, SuccessParams, HandledSwitches, DiagEngine,
           UnwrapParams, ErrParam, HandlerDesc.Type, CallbackBody);
     }
 
@@ -7319,7 +7404,8 @@ private:
                     const ClassifiedBlock &SuccessBlock,
                     ArrayRef<const ParamDecl *> SuccessParams,
                     const InlinePatternsToPrint &InlinePatterns,
-                    const AsyncHandlerDesc &HandlerDesc, bool AddDeclarations) {
+                    const AsyncHandlerParamDesc &HandlerDesc,
+                    bool AddDeclarations) {
     // Print the bindings to match the completion handler success parameters,
     // making sure to omit in the case of a Void return.
     if (!SuccessParams.empty() && !HandlerDesc.willAsyncReturnVoid()) {
@@ -7363,23 +7449,74 @@ private:
       OS << tok::kw_try << " ";
     }
     OS << "await ";
-    addRange(CE->getStartLoc(), CE->getFn()->getEndLoc(),
-             /*ToEndOfToken=*/true);
 
-    OS << tok::l_paren;
-    size_t realArgCount = 0;
-    for (size_t I = 0, E = Args.size() - 1; I < E; ++I) {
-      if (isa<DefaultArgumentExpr>(Args[I]))
+    // Try to replace the name with that of the alternative. Use the existing
+    // name if for some reason that's not possible.
+    bool NameAdded = false;
+    if (HandlerDesc.Alternative) {
+      const ValueDecl *Named = HandlerDesc.Alternative;
+      if (auto *Accessor = dyn_cast<AccessorDecl>(HandlerDesc.Alternative))
+        Named = Accessor->getStorage();
+      if (!Named->getBaseName().isSpecial()) {
+        Names.try_emplace(HandlerDesc.Func,
+                          Named->getBaseName().getIdentifier());
+        convertNode(CE->getFn(), /*StartOverride=*/{}, /*ConvertCalls=*/false,
+                    /*IncludeComments=*/false);
+        NameAdded = true;
+      }
+    }
+    if (!NameAdded) {
+      addRange(CE->getStartLoc(), CE->getFn()->getEndLoc(),
+               /*ToEndOfToken=*/true);
+    }
+
+    if (!HandlerDesc.alternativeIsAccessor())
+      OS << tok::l_paren;
+
+    size_t ConvertedArgIndex = 0;
+    ArrayRef<ParamDecl *> AlternativeParams;
+    if (HandlerDesc.Alternative)
+      AlternativeParams = HandlerDesc.Alternative->getParameters()->getArray();
+    ArrayRef<Identifier> ArgLabels = CE->getArgumentLabels();
+    for (size_t I = 0, E = Args.size(); I < E; ++I) {
+      if (I == HandlerDesc.Index || isa<DefaultArgumentExpr>(Args[I]))
         continue;
 
-      if (realArgCount > 0)
+      if (ConvertedArgIndex > 0)
         OS << tok::comma << " ";
-      // Can't just add the range as we need to perform replacements
+
+      if (HandlerDesc.Alternative) {
+        // Skip argument if it's defaulted and has a different name
+        while (ConvertedArgIndex < AlternativeParams.size() &&
+               AlternativeParams[ConvertedArgIndex]->isDefaultArgument() &&
+               AlternativeParams[ConvertedArgIndex]->getArgumentName() !=
+               ArgLabels[I]) {
+          ConvertedArgIndex++;
+        }
+
+        if (ConvertedArgIndex < AlternativeParams.size()) {
+          // Could have a different argument label (or none), so add it instead
+          auto Name = AlternativeParams[ConvertedArgIndex]->getArgumentName();
+          if (!Name.empty())
+            OS << Name << ": ";
+          convertNode(Args[I], /*StartOverride=*/{}, /*ConvertCalls=*/false);
+
+          ConvertedArgIndex++;
+          continue;
+        }
+
+        // Fallthrough if arguments don't match up for some reason
+      }
+
+      // Can't just add the range as we need to perform replacements. Also
+      // make sure to include the argument label (if any)
       convertNode(Args[I], /*StartOverride=*/CE->getArgumentLabelLoc(I),
                   /*ConvertCalls=*/false);
-      realArgCount++;
+      ConvertedArgIndex++;
     }
-    OS << tok::r_paren;
+
+    if (!HandlerDesc.alternativeIsAccessor())
+      OS << tok::r_paren;
   }
 
   void addFallbackCatch(const ParamDecl *ErrParam) {
@@ -7553,51 +7690,44 @@ private:
     }
   }
 
-  /// Adds the call to an 'async' version of \p FD, where \p HanderDesc
-  /// describes the async completion handler of \p FD. This does not add an
-  /// 'await' keyword.
-  void addCallToAsyncMethod(const FuncDecl *FD,
-                            const AsyncHandlerDesc &HandlerDesc) {
-    // The call to the async function is the same as the call to the old
-    // completion handler function, minus the completion handler arg.
-    addForwardingCallTo(FD, HandlerDesc, /*HandlerReplacement*/ "");
-  }
-
   /// Adds a forwarding call to the old completion handler function, with
   /// \p HandlerReplacement that allows for a custom replacement or, if empty,
   /// removal of the completion handler closure.
-  void addForwardingCallTo(
-      const FuncDecl *FD, const AsyncHandlerDesc &HandlerDesc,
-      StringRef HandlerReplacement, bool CanUseTrailingClosure = true) {
+  void addForwardingCallTo(const FuncDecl *FD, StringRef HandlerReplacement) {
     OS << FD->getBaseName() << tok::l_paren;
 
     auto *Params = FD->getParameters();
-    for (auto Param : *Params) {
-      if (Param == HandlerDesc.getHandler()) {
+    size_t ConvertedArgsIndex = 0;
+    for (size_t I = 0, E = Params->size(); I < E; ++I) {
+      if (I == TopHandler.Index) {
         /// If we're not replacing the handler with anything, drop it.
         if (HandlerReplacement.empty())
           continue;
 
-        // If this is the last param, and we can use a trailing closure, do so.
-        if (CanUseTrailingClosure && Param == Params->back()) {
+        // Use a trailing closure if the handler is the last param
+        if (I == E - 1) {
           OS << tok::r_paren << " ";
           OS << HandlerReplacement;
           return;
         }
+
         // Otherwise fall through to do the replacement.
       }
 
-      if (Param != Params->front())
+      if (ConvertedArgsIndex > 0)
         OS << tok::comma << " ";
 
+      const auto *Param = Params->get(I);
       if (!Param->getArgumentName().empty())
         OS << Param->getArgumentName() << tok::colon << " ";
 
-      if (Param == HandlerDesc.getHandler()) {
+      if (I == TopHandler.Index) {
         OS << HandlerReplacement;
       } else {
         OS << Param->getParameterName();
       }
+
+      ConvertedArgsIndex++;
     }
     OS << tok::r_paren;
   }
@@ -7782,21 +7912,6 @@ private:
   }
 };
 
-/// Adds an attribute to describe a completion handler function's async
-/// alternative if necessary.
-void addCompletionHandlerAsyncAttrIfNeccessary(
-    ASTContext &Ctx, const FuncDecl *FD,
-    const AsyncHandlerParamDesc &HandlerDesc,
-    SourceEditConsumer &EditConsumer) {
-  llvm::SmallString<0> HandlerAttribute;
-  llvm::raw_svector_ostream OS(HandlerAttribute);
-  OS << "@available(*, renamed: \"";
-  HandlerDesc.printAsyncFunctionName(OS);
-  OS << "\")\n";
-  EditConsumer.accept(Ctx.SourceMgr, FD->getAttributeInsertionLoc(false),
-                      HandlerAttribute);
-}
-
 } // namespace asyncrefactorings
 
 bool RefactoringActionConvertCallToAsyncAlternative::isApplicable(
@@ -7913,7 +8028,11 @@ bool RefactoringActionAddAsyncAlternative::performChange() {
   if (!Converter.convert())
     return true;
 
-  addCompletionHandlerAsyncAttrIfNeccessary(Ctx, FD, HandlerDesc, EditConsumer);
+  // Add a reference to the async function so that warnings appear when the
+  // synchronous function is used in an async context
+  SmallString<128> AvailabilityAttr = HandlerDesc.buildRenamedAttribute();
+  EditConsumer.accept(SM, FD->getAttributeInsertionLoc(false),
+                      AvailabilityAttr);
 
   AsyncConverter LegacyBodyCreator(TheFile, SM, DiagEngine, FD, HandlerDesc);
   if (LegacyBodyCreator.createLegacyBody()) {
@@ -7955,10 +8074,15 @@ bool RefactoringActionAddAsyncWrapper::performChange() {
   if (!Converter.createAsyncWrapper())
     return true;
 
-  addCompletionHandlerAsyncAttrIfNeccessary(Ctx, FD, HandlerDesc, EditConsumer);
+  // Add a reference to the async function so that warnings appear when the
+  // synchronous function is used in an async context
+  SmallString<128> AvailabilityAttr = HandlerDesc.buildRenamedAttribute();
+  EditConsumer.accept(SM, FD->getAttributeInsertionLoc(false),
+                      AvailabilityAttr);
 
   // Add the async wrapper.
   Converter.insertAfter(FD, EditConsumer);
+
   return false;
 }
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4702,8 +4702,17 @@ public:
           if (!asyncFunc)
             return {false, call};
           ctx.Diags.diagnose(call->getLoc(), diag::warn_use_async_alternative);
-          ctx.Diags.diagnose(asyncFunc->getLoc(), diag::decl_declared_here,
-                             asyncFunc->getName());
+
+          if (auto *accessor = dyn_cast<AccessorDecl>(asyncFunc)) {
+            SmallString<32> name;
+            llvm::raw_svector_ostream os(name);
+            accessor->printUserFacingName(os);
+            ctx.Diags.diagnose(asyncFunc->getLoc(),
+                               diag::descriptive_decl_declared_here, name);
+          } else {
+            ctx.Diags.diagnose(asyncFunc->getLoc(), diag::decl_declared_here,
+                               asyncFunc->getName());
+          }
         }
       }
     }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5686,8 +5686,10 @@ static bool renameCouldMatch(const ValueDecl *original,
   if (original == candidate)
     return false;
 
-  // Kinds have to match
-  if (candidate->getKind() != original->getKind())
+  // Kinds have to match, but we want to allow eg. an accessor to match
+  // a function
+  if (candidate->getKind() != original->getKind() &&
+      !(isa<FuncDecl>(candidate) && isa<FuncDecl>(original)))
     return false;
 
   // Instance can't match static/class function
@@ -5761,12 +5763,24 @@ ValueDecl *RenamedDeclRequest::evaluate(Evaluator &evaluator,
       objc_translation::isVisibleToObjC(attached, minAccess);
 
   SmallVector<ValueDecl *, 4> lookupResults;
+  SmallVector<AbstractFunctionDecl *, 4> asyncResults;
   lookupReplacedDecl(nameRef, attr, attached, lookupResults);
 
   ValueDecl *renamedDecl = nullptr;
   auto attachedFunc = dyn_cast<AbstractFunctionDecl>(attached);
-  bool candidateHasAsync = false;
   for (auto candidate : lookupResults) {
+    // If the name is a getter or setter, grab the underlying accessor (if any)
+    if (parsedName.IsGetter || parsedName.IsSetter) {
+      auto *VD = dyn_cast<VarDecl>(candidate);
+      if (!VD)
+        continue;
+
+      candidate = VD->getAccessor(parsedName.IsGetter ? AccessorKind::Get :
+                                                        AccessorKind::Set);
+      if (!candidate)
+        continue;
+    }
+
     if (!renameCouldMatch(attached, candidate, attachedIsObjcVisible,
                           minAccess))
       continue;
@@ -5775,7 +5789,8 @@ ValueDecl *RenamedDeclRequest::evaluate(Evaluator &evaluator,
       // Require both functions to be async/not. Async alternatives are handled
       // below if there's no other matches
       if (attachedFunc->hasAsync() != candidateFunc->hasAsync()) {
-        candidateHasAsync |= candidateFunc->hasAsync();
+        if (candidateFunc->hasAsync())
+          asyncResults.push_back(candidateFunc);
         continue;
       }
 
@@ -5796,18 +5811,10 @@ ValueDecl *RenamedDeclRequest::evaluate(Evaluator &evaluator,
 
   // Try to match up an async alternative instead (ie. one where the
   // completion handler has been removed).
-  if (!renamedDecl && candidateHasAsync) {
-    for (ValueDecl *candidate : lookupResults) {
-      auto *candidateFunc = dyn_cast<AbstractFunctionDecl>(candidate);
-      if (!candidateFunc || !candidateFunc->hasAsync())
-        continue;
-
-      if (!renameCouldMatch(attached, candidate, attachedIsObjcVisible,
-                            minAccess))
-        continue;
-
+  if (!renamedDecl && !asyncResults.empty()) {
+    for (AbstractFunctionDecl *candidate : asyncResults) {
       Optional<unsigned> completionHandler =
-          attachedFunc->findPotentialCompletionHandlerParam(candidateFunc);
+          attachedFunc->findPotentialCompletionHandlerParam(candidate);
       if (!completionHandler)
         continue;
 

--- a/test/attr/attr_availability_async_rename.swift
+++ b/test/attr/attr_availability_async_rename.swift
@@ -85,6 +85,10 @@ func platformOnly(completionHandler: @escaping () -> Void) { }
 // expected-note@+1 {{'platformOnlyNew()' declared here}}
 func platformOnlyNew() async { }
 
+struct AnotherStruct {
+  var otherInstanceProp: Int { get async { 1 } }
+}
+
 struct SomeStruct {
   @available(*, renamed: "structFunc")
   func structFunc(continuation: @escaping () -> Void) { }
@@ -97,6 +101,31 @@ struct SomeStruct {
 
   // expected-note@+1 2 {{'staticStructFunc()' declared here}}
   static func staticStructFunc() async { }
+
+  // expected-note@+1 3 {{'getter:instanceProp()' declared here}}
+  var instanceProp: Int { get async { 1 } }
+  var regInstanceProp: Int { get { 1 } set { } }
+  // expected-note@+1 {{'getter:classProp()' declared here}}
+  static var classProp: Int { get async { 1 } }
+
+  @available(*, renamed: "getter:instanceProp()")
+  func instanceGetter(completion: @escaping (Int) -> Void) { }
+  @available(*, renamed: "getter:classProp()")
+  static func classGetter(completion: @escaping (Int) -> Void) { }
+  @available(*, renamed: "getter:instanceProp(a:b:)")
+  func argsIgnored(completion: @escaping (Int) -> Void) { }
+  @available(*, renamed: "getter:DoesNotExist.instanceProp()")
+  func baseIgnored(completion: @escaping (Int) -> Void) { }
+
+  @available(*, renamed: "instanceProp()")
+  func noPrefix(completion: @escaping (Int) -> Void) { }
+  @available(*, renamed: "getter:instanceProp()")
+  func argMismatch(arg: Int, completion: @escaping (Int) -> Void) { }
+  @available(*, renamed: "setter:regInstanceProp(newValue:)")
+  func instanceSetter(arg: Int, completion: @escaping (Int) -> Void) { }
+
+  @available(*, renamed: "getter:AnotherStruct.otherInstanceProp()")
+  func otherInstance(completion: @escaping (Int) -> Void) { }
 }
 
 
@@ -328,6 +357,20 @@ class ClassCallingAsyncStuff {
 
     // expected-warning@+1{{consider using asynchronous alternative function}}
     type(of: other).staticStructFunc { }
+
+    // expected-warning@+1{{consider using asynchronous alternative function}}
+    other.instanceGetter { _ in }
+    // expected-warning@+1{{consider using asynchronous alternative function}}
+    other.argsIgnored { _ in }
+    // expected-warning@+1{{consider using asynchronous alternative function}}
+    other.baseIgnored { _ in }
+    // expected-warning@+1{{consider using asynchronous alternative function}}
+    SomeStruct.classGetter { _ in }
+
+    other.noPrefix { _ in }
+    other.argMismatch(arg: 1) { _ in }
+    other.instanceSetter(arg: 1) { _ in }
+    other.otherInstance { _ in }
   }
 
   // no warning

--- a/test/refactoring/ConvertAsync/async_attribute_added.swift
+++ b/test/refactoring/ConvertAsync/async_attribute_added.swift
@@ -2,7 +2,7 @@
 
 // RUN: %empty-directory(%t)
 
-// RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 -enable-experimental-concurrency | %FileCheck -check-prefix=SIMPLE %s
+// RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=SIMPLE %s
 func simple(completion: @escaping (String) -> Void) { }
 // SIMPLE: async_attribute_added.swift [[# @LINE-1]]:1 -> [[# @LINE-1]]:1
 // SIMPLE-NEXT: @available(*, renamed: "simple()")
@@ -22,26 +22,10 @@ func simple(completion: @escaping (String) -> Void) { }
 // SIMPLE-NEXT: async_attribute_added.swift [[# @LINE-16]]:56 -> [[# @LINE-16]]:56
 // SIMPLE-NEXT: func simple() async -> String { }
 
-// RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):5 -enable-experimental-concurrency | %FileCheck -check-prefix=OTHER-ARGS %s
+// RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):5 | %FileCheck -check-prefix=OTHER-ARGS %s
 func otherArgs(first: Int, second: String, completion: @escaping (String) -> Void) { }
 // OTHER-ARGS: @available(*, renamed: "otherArgs(first:second:)")
 
-// RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):5 -enable-experimental-concurrency | %FileCheck -check-prefix=EMPTY-NAMES %s
+// RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):5 | %FileCheck -check-prefix=EMPTY-NAMES %s
 func emptyNames(first: Int, _ second: String, completion: @escaping (String) -> Void) { }
 // EMPTY-NAMES: @available(*, renamed: "emptyNames(first:_:)")
-
-// Not a completion handler named parameter, but should still be converted
-// during function conversion since it has been attributed
-@available(*, renamed: "otherName()")
-func otherName(notHandlerName: @escaping (String) -> (Void)) {}
-func otherName() async -> String {}
-
-// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):5 -enable-experimental-concurrency | %FileCheck -check-prefix=OTHER-CONVERTED %s
-func otherStillConverted() {
-  otherName { str in
-    print(str)
-  }
-}
-// OTHER-CONVERTED: func otherStillConverted() async {
-// OTHER-CONVERTED-NEXT: let str = await otherName()
-// OTHER-CONVERTED-NEXT: print(str)

--- a/test/refactoring/ConvertAsync/convert_async_attributed_renames.swift
+++ b/test/refactoring/ConvertAsync/convert_async_attributed_renames.swift
@@ -1,0 +1,243 @@
+// REQUIRES: concurrency
+
+// RUN: %empty-directory(%t)
+
+@available(*, renamed: "simple2")
+func simple(_ completion: @escaping (String) -> Void) { }
+@available(*, renamed: "simple2")
+func nonCompletionName(_ random: @escaping (String) -> Void) { }
+func simple2() async -> String { return "" }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):6 | %FileCheck -check-prefix=SIMPLERENAMED %s
+func simpleRenamed() {
+  // preserve me
+  simple { str in
+    print(str)
+  }
+  // and me
+  nonCompletionName { str in
+    print(str)
+  }
+}
+// SIMPLERENAMED: func simpleRenamed() async {
+// SIMPLERENAMED-NEXT: // preserve me
+// SIMPLERENAMED-NEXT: let str = await simple2()
+// SIMPLERENAMED-NEXT: print(str)
+// SIMPLERENAMED-NEXT: // and me
+// SIMPLERENAMED-NEXT: let str1 = await simple2()
+// SIMPLERENAMED-NEXT: print(str1)
+// SIMPLERENAMED-NEXT: }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):6 | %FileCheck -check-prefix=RENAMEDCOLLISION %s
+func renamedCollision() {
+  simple { simple2 in
+    print(simple2)
+  }
+}
+// RENAMEDCOLLISION: func renamedCollision() async {
+// RENAMEDCOLLISION-NEXT: let simple21 = await simple2()
+// RENAMEDCOLLISION-NEXT: print(simple21)
+// RENAMEDCOLLISION-NEXT: }
+
+@available(*, renamed: "simpleArg2")
+func simpleArgRenamed(arg: String, _ random: @escaping (String) -> Void) { }
+@available(*, renamed: "simpleArg2")
+func completionFirstArg(random: @escaping (String) -> Void, arg: String) { }
+func simpleArg2(newArg: String) async -> String { return "" }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):6 | %FileCheck -check-prefix=ARGRENAMED %s
+func argRenamed() {
+  (simpleArgRenamed)(arg: "foo") { str in
+    print(str)
+  }
+  (completionFirstArg)(random: { str in
+    print(str)
+  }, arg: "foo")
+}
+// ARGRENAMED: func argRenamed() async {
+// ARGRENAMED-NEXT: let str = await (simpleArg2)(newArg: "foo")
+// ARGRENAMED-NEXT: print(str)
+// ARGRENAMED-NEXT: let str1 = await (simpleArg2)(newArg: "foo")
+// ARGRENAMED-NEXT: print(str1)
+// ARGRENAMED-NEXT: }
+
+@available(*, renamed: "multiHandlers2")
+func multiHandlers(arg: String, handler1: @escaping (String) -> Void, handler2: @escaping (String) -> Void) { }
+func multiHandlers2(newArg: String, newHandler: @escaping (String) -> Void) async -> String { return "" }
+
+@available(*, renamed: "multiHandlersWithTrailing2")
+func multiHandlersWithTrailing(arg: String, handler1: @escaping (String) -> Void, handler2: @escaping (String) -> Void, other: String) { }
+func multiHandlersWithTrailing2(newArg: String, newHandler: @escaping (String) -> Void, other: String) async -> String { return "" }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):6 | %FileCheck -check-prefix=MULTIPLEHANDLERS %s
+func multipleHandlers() {
+  multiHandlers(arg: "foo", handler1: { str1 in
+    print(str1)
+  }, handler2: { str2 in
+    print(str2)
+  })
+  multiHandlers(arg: "foo", handler1: { str3 in
+    print(str3)
+  }) { str4 in
+    print(str4)
+  }
+  multiHandlers(arg: "foo") { str5 in
+    print(str5)
+  } handler2: { str6 in
+    print(str6)
+  }
+  multiHandlersWithTrailing(arg: "foo", handler1: { str7 in
+    print(str7)
+  }, handler2: { str8 in
+    print(str8)
+  }, other: "bar")
+}
+// MULTIPLEHANDLERS: func multipleHandlers() async {
+// MULTIPLEHANDLERS-NEXT: let str2 = await multiHandlers2(newArg: "foo", newHandler: { str1 in
+// MULTIPLEHANDLERS-NEXT: print(str1)
+// MULTIPLEHANDLERS-NEXT: })
+// MULTIPLEHANDLERS-NEXT: print(str2)
+// MULTIPLEHANDLERS-NEXT: let str4 = await multiHandlers2(newArg: "foo", newHandler: { str3 in
+// MULTIPLEHANDLERS-NEXT: print(str3)
+// MULTIPLEHANDLERS-NEXT: })
+// MULTIPLEHANDLERS-NEXT: print(str4)
+// MULTIPLEHANDLERS-NEXT: let str6 = await multiHandlers2(newArg: "foo", newHandler: { str5 in
+// MULTIPLEHANDLERS-NEXT: print(str5)
+// MULTIPLEHANDLERS-NEXT: })
+// MULTIPLEHANDLERS-NEXT: print(str6)
+// MULTIPLEHANDLERS-NEXT: let str8 = await multiHandlersWithTrailing2(newArg: "foo", newHandler: { str7 in
+// MULTIPLEHANDLERS-NEXT: print(str7)
+// MULTIPLEHANDLERS-NEXT: }, other: "bar")
+// MULTIPLEHANDLERS-NEXT: print(str8)
+// MULTIPLEHANDLERS-NEXT: }
+
+@available(*, renamed: "defaultedParamsStartNew(newArg:newArg1:)")
+func defaultedParamsStart(arg1: Int, completionHandler: @escaping (String) -> Void) { }
+func defaultedParamsStartNew(newArg: Int = 0, newArg1: Int) async -> String { return "" }
+
+@available(*, renamed: "defaultedParamsMiddleNew(newArg1:newArg:newArg2:)")
+func defaultedParamsMiddle(arg1: Int, arg2: Int, completionHandler: @escaping (String) -> Void) { }
+func defaultedParamsMiddleNew(newArg1: Int, newArg: Int = 0, newArg2: Int) async -> String { return "" }
+
+@available(*, renamed: "defaultedParamsEndNew(newArg1:newArg:)")
+func defaultedParamsEnd(arg1: Int, completionHandler: @escaping (String) -> Void) { }
+func defaultedParamsEndNew(newArg1: Int, newArg: Int = 0) async -> String { return "" }
+
+@available(*, renamed: "defaultedSameLabelNew(newArg1:arg1:newArg2:)")
+func defaultedSameLabel(arg1: Int, completionHandler: @escaping (String) -> Void) { }
+func defaultedSameLabelNew(newArg1: Int = 0, arg1: Int = 0, newArg2: Int = 0) async -> String { return "" }
+
+@available(*, renamed: "unlabelledArgNew(newArg1:_:newArg2:)")
+func unlabelledArg(_ arg1: Int, completionHandler: @escaping (String) -> Void) { }
+func unlabelledArgNew(newArg1: Int = 0, _ arg1: Int = 0, newArg2: Int = 0) async -> String { return "" }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):6 | %FileCheck -check-prefix=DEFAULTEDPARAMS %s
+func defaultedParams() {
+  defaultedParamsStart(arg1: 1) { str in
+    print(str)
+  }
+  defaultedParamsMiddle(arg1: 1, arg2: 2) { str in
+    print(str)
+  }
+  defaultedParamsEnd(arg1: 1) { str in
+    print(str)
+  }
+  defaultedSameLabel(arg1: 1) { str in
+    print(str)
+  }
+  unlabelledArg(1) { str in
+    print(str)
+  }
+}
+// DEFAULTEDPARAMS: func defaultedParams() async {
+// DEFAULTEDPARAMS-NEXT: let str = await defaultedParamsStartNew(newArg1: 1)
+// DEFAULTEDPARAMS-NEXT: print(str)
+// DEFAULTEDPARAMS-NEXT: let str1 = await defaultedParamsMiddleNew(newArg1: 1, newArg2: 2)
+// DEFAULTEDPARAMS-NEXT: print(str1)
+// DEFAULTEDPARAMS-NEXT: let str2 = await defaultedParamsEndNew(newArg1: 1)
+// DEFAULTEDPARAMS-NEXT: print(str2)
+// DEFAULTEDPARAMS-NEXT: let str3 = await defaultedSameLabelNew(arg1: 1)
+// DEFAULTEDPARAMS-NEXT: print(str3)
+// DEFAULTEDPARAMS-NEXT: let str4 = await unlabelledArgNew(1)
+// DEFAULTEDPARAMS-NEXT: print(str4)
+// DEFAULTEDPARAMS-NEXT: }
+
+struct SomeStruct {
+  var instanceProp: String { get async { "" } }
+  static var classProp: String { get async { "" } }
+
+  @available(*, renamed: "simple2")
+  func simple(_ completion: @escaping (String) -> Void) { }
+  func simple2() async -> String { return "" }
+
+  @available(*, renamed: "getter:instanceProp()")
+  func instanceGetter(_ completion: @escaping (String) -> Void) { }
+  @available(*, renamed: "getter:classProp()")
+  static func classGetter(_ completion: @escaping (String) -> Void) { }
+}
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):6 | %FileCheck -check-prefix=MEMBERS %s
+func members(s: SomeStruct) {
+  s.simple { str in
+    print(str)
+  }
+  (((s).simple)) { str in
+    print(str)
+  }
+  s.instanceGetter { str in
+    print(str)
+  }
+  (((s).instanceGetter)) { str in
+    print(str)
+  }
+  SomeStruct.classGetter { str in
+    print(str)
+  }
+  (((SomeStruct).classGetter)) { str in
+    print(str)
+  }
+}
+// MEMBERS: func members(s: SomeStruct) async {
+// MEMBERS-NEXT: let str = await s.simple2()
+// MEMBERS-NEXT: print(str)
+// MEMBERS-NEXT: let str1 = await (((s).simple2))()
+// MEMBERS-NEXT: print(str1)
+// MEMBERS-NEXT: let str2 = await s.instanceProp
+// MEMBERS-NEXT: print(str2)
+// MEMBERS-NEXT: let str3 = await (((s).instanceProp))
+// MEMBERS-NEXT: print(str3)
+// MEMBERS-NEXT: let str4 = await SomeStruct.classProp
+// MEMBERS-NEXT: print(str4)
+// MEMBERS-NEXT: let str5 = await (((SomeStruct).classProp))
+// MEMBERS-NEXT: print(str5)
+// MEMBERS-NEXT: }
+
+@available(*, renamed: "nomatch")
+func badRename(_ completion: @escaping (String) -> Void) { }
+@available(*, renamed: "nomatch")
+func badRenameUnlabelled(_ arg: Int, _ completion: @escaping (String) -> Void) { }
+@available(*, renamed: "badRename2Async(arg:newArg:)")
+func badRename2(arg: Int, completionHandler: @escaping (String) -> Void) { }
+func badRename2Async(arg: Int = 0, newArg: Int) async -> String { return "" }
+
+// Won't compile since there are no corresponding async functions
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):6 | %FileCheck -check-prefix=FALLBACK %s
+func fallback() {
+  badRename { str in
+    print(str)
+  }
+  badRenameUnlabelled(1) { str in
+    print(str)
+  }
+  badRename2(arg: 1) { str in
+    print(str)
+  }
+}
+// FALLBACK: func fallback() async {
+// FALLBACK-NEXT: let str = await badRename()
+// FALLBACK-NEXT: print(str)
+// FALLBACK-NEXT: let str1 = await badRenameUnlabelled(1)
+// FALLBACK-NEXT: print(str1)
+// FALLBACK-NEXT: let str2 = await badRename2(arg: 1)
+// FALLBACK-NEXT: print(str2)
+// FALLBACK-NEXT: }

--- a/test/refactoring/ConvertAsync/handler_position.swift
+++ b/test/refactoring/ConvertAsync/handler_position.swift
@@ -1,0 +1,43 @@
+// REQUIRES: concurrency
+
+// RUN: %empty-directory(%t)
+
+// RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix=FIRST-ARG %s
+// RUN: %refactor-check-compiles -add-async-wrapper -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=FIRST-ARG-WRAPPER %s
+func completionFirst(/*c1s*/ completion: @escaping (String) -> Void /*c1e*/, /*c2s*/ arg: Int /*c2e*/) { }
+
+// FIRST-ARG:      @available(*, renamed: "completionFirst(arg:)")
+// FIRST-ARG:      Task {
+// FIRST-ARG-NEXT:   let result = await completionFirst(arg: arg)
+// FIRST-ARG-NEXT:   completion(result)
+// FIRST-ARG-NEXT: }
+// FIRST-ARG:      func completionFirst(/*c2s*/ arg: Int /*c2e*/) async -> String { }
+
+// FIRST-ARG-WRAPPER:      @available(*, renamed: "completionFirst(arg:)")
+// FIRST-ARG-WRAPPER:      func completionFirst(/*c2s*/ arg: Int /*c2e*/) async -> String {
+// FIRST-ARG-WRAPPER-NEXT:   return await withCheckedContinuation { continuation in
+// FIRST-ARG-WRAPPER-NEXT:     completionFirst(completion: { result in
+// FIRST-ARG-WRAPPER-NEXT:       continuation.resume(returning: result)
+// FIRST-ARG-WRAPPER-NEXT:     }, arg: arg)
+// FIRST-ARG-WRAPPER-NEXT:   }
+// FIRST-ARG-WRAPPER-NEXT: }
+
+// RUN: %refactor-check-compiles -add-async-alternative -dump-text -source-filename %s -pos=%(line+2):1 | %FileCheck -check-prefix MIDDLE-ARG %s
+// RUN: %refactor-check-compiles -add-async-wrapper -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MIDDLE-ARG-WRAPPER %s
+func completionMiddle(/*c1s*/ arg1: Int /*c1e*/, /*c2s*/ _ arg2: Int /*c2e*/, /*c3s*/ completion: @escaping (String) -> Void /*c3e*/, /*c4s*/ arg3: Int /*c4e*/) { }
+
+// MIDDLE-ARG:      @available(*, renamed: "completionMiddle(arg1:_:arg3:)")
+// MIDDLE-ARG:      Task {
+// MIDDLE-ARG-NEXT:   let result = await completionMiddle(arg1: arg1, arg2, arg3: arg3)
+// MIDDLE-ARG-NEXT:   completion(result)
+// MIDDLE-ARG-NEXT: }
+// MIDDLE-ARG:      func completionMiddle(/*c1s*/ arg1: Int /*c1e*/, /*c2s*/ _ arg2: Int /*c2e*/, /*c4s*/ arg3: Int /*c4e*/) async -> String { }
+
+// MIDDLE-ARG-WRAPPER:      @available(*, renamed: "completionMiddle(arg1:_:arg3:)")
+// MIDDLE-ARG-WRAPPER:      func completionMiddle(/*c1s*/ arg1: Int /*c1e*/, /*c2s*/ _ arg2: Int /*c2e*/, /*c4s*/ arg3: Int /*c4e*/) async -> String {
+// MIDDLE-ARG-WRAPPER-NEXT:   return await withCheckedContinuation { continuation in
+// MIDDLE-ARG-WRAPPER-NEXT:     completionMiddle(arg1: arg1, arg2, completion: { result in
+// MIDDLE-ARG-WRAPPER-NEXT:       continuation.resume(returning: result)
+// MIDDLE-ARG-WRAPPER-NEXT:     }, arg3: arg3)
+// MIDDLE-ARG-WRAPPER-NEXT:   }
+// MIDDLE-ARG-WRAPPER-NEXT: }


### PR DESCRIPTION
Update the async refactorings to use the name from the async alternative
if one is known, rather than always assuming the name matches the
synchronous function.

Note that this could also be used to determine whether results remain
optional or not, but that has been left for a future patch.

Resolves rdar://80612521