### PR TITLE
Implicitly build "missing" conformances to Sendable.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -106,6 +106,7 @@ namespace swift {
   class InheritedProtocolConformance;
   class SelfProtocolConformance;
   class SpecializedProtocolConformance;
+  enum class BuiltinConformanceKind;
   class BuiltinProtocolConformance;
   enum class ProtocolConformanceState;
   class Pattern;
@@ -1046,7 +1047,8 @@ public:
   BuiltinProtocolConformance *
   getBuiltinConformance(Type type, ProtocolDecl *protocol,
                         GenericSignature genericSig,
-                        ArrayRef<Requirement> conditionalRequirements);
+                        ArrayRef<Requirement> conditionalRequirements,
+                        BuiltinConformanceKind kind);
 
   /// A callback used to produce a diagnostic for an ill-formed protocol
   /// conformance that was type-checked before we're actually walking the

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3251,7 +3251,8 @@ public:
   ///
   /// This is used by deserialization of module files to report
   /// conformances.
-  void registerProtocolConformance(ProtocolConformance *conformance);
+  void registerProtocolConformance(ProtocolConformance *conformance,
+                                   bool synthesized = false);
 
   void setConformanceLoader(LazyMemberLoader *resolver, uint64_t contextData);
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4516,6 +4516,11 @@ ERROR(concurrent_value_inherit,none,
       "`Sendable` class %1 cannot inherit from another class"
       "%select{| other than 'NSObject'}0",
       (bool, DeclName))
+ERROR(non_sendable_type,none,
+      "type %0 does not conform to the 'Sendable' protocol", (Type))
+ERROR(non_sendable_function_type,none,
+     "function type %0 must be marked '@Sendable' to conform to 'Sendable'",
+      (Type))
 
 WARNING(unchecked_conformance_not_special,none,
       "@unchecked conformance to %0 has no meaning", (Type))

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -373,7 +373,8 @@ public:
   /// T: Foo or T == U (etc.) with the information it knows. This includes
   /// checking against global state, if any/all of the types in the requirement
   /// are concrete, not type parameters.
-  bool isRequirementSatisfied(Requirement requirement) const;
+  bool isRequirementSatisfied(
+      Requirement requirement, bool allowMissing = false) const;
 
   /// Return the requirements of this generic signature that are not also
   /// satisfied by \c otherSig.

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -578,10 +578,15 @@ public:
   ///
   /// \param protocol The protocol to which we are computing conformance.
   ///
+  /// \param allowMissing When \c true, the resulting conformance reference
+  /// might include "missing" conformances, which are synthesized for some
+  /// protocols as an error recovery mechanism.
+  ///
   /// \returns The result of the conformance search, which will be
   /// None if the type does not conform to the protocol or contain a
   /// ProtocolConformanceRef if it does conform.
-  ProtocolConformanceRef lookupConformance(Type type, ProtocolDecl *protocol);
+  ProtocolConformanceRef lookupConformance(Type type, ProtocolDecl *protocol,
+                                           bool allowMissing = false);
 
   /// Look for the conformance of the given existential type to the given
   /// protocol.

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -993,6 +993,15 @@ public:
   }
 };
 
+/// Describes the kind of a builtin conformance.
+enum class BuiltinConformanceKind {
+  // A builtin conformance that has been synthesized by the implementation.
+  Synthesized = 0,
+  // A missing conformance that we have nonetheless synthesized so that
+  // we can diagnose it later.
+  Missing,
+};
+
 /// A builtin conformance appears when a non-nominal type has a
 /// conformance that is synthesized by the implementation.
 class BuiltinProtocolConformance final : public RootProtocolConformance,
@@ -1002,7 +1011,8 @@ class BuiltinProtocolConformance final : public RootProtocolConformance,
 
   ProtocolDecl *protocol;
   GenericSignature genericSig;
-  size_t numConditionalRequirements;
+  size_t numConditionalRequirements : 31;
+  unsigned builtinConformanceKind : 1;
 
   size_t numTrailingObjects(OverloadToken<Requirement>) const {
     return numConditionalRequirements;
@@ -1010,7 +1020,8 @@ class BuiltinProtocolConformance final : public RootProtocolConformance,
 
   BuiltinProtocolConformance(Type conformingType, ProtocolDecl *protocol,
                              GenericSignature genericSig,
-                             ArrayRef<Requirement> conditionalRequirements);
+                             ArrayRef<Requirement> conditionalRequirements,
+                             BuiltinConformanceKind kind);
 
 public:
   /// Get the protocol being conformed to.
@@ -1022,6 +1033,16 @@ public:
   /// within the conforming type.
   GenericSignature getGenericSignature() const {
     return genericSig;
+  }
+
+  BuiltinConformanceKind getBuiltinConformanceKind() const {
+    return static_cast<BuiltinConformanceKind>(builtinConformanceKind);
+  }
+
+  /// Whether this represents a "missing" conformance that should be diagnosed
+  /// later.
+  bool isMissing() const {
+    return getBuiltinConformanceKind() == BuiltinConformanceKind::Missing;
   }
 
   /// Get any requirements that must be satisfied for this conformance to apply.

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -98,6 +98,11 @@ public:
     return Union.get<ProtocolDecl*>();
   }
 
+  /// Determine whether this conformance (or a conformance it depends on)
+  /// involves a "missing" conformance anywhere. Such conformances
+  /// cannot be depended on to always exist.
+  bool hasMissingConformance(ModuleDecl *module) const;
+
   using OpaqueValue = void*;
   OpaqueValue getOpaqueValue() const { return Union.getOpaqueValue(); }
   static ProtocolConformanceRef getFromOpaqueValue(OpaqueValue value) {

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -81,7 +81,8 @@ public:
   /// \param conditionalRequirements An out parameter initialized to an
   /// array of requirements that the caller must check to ensure this
   /// requirement is completely satisfied.
-  bool isSatisfied(ArrayRef<Requirement> &conditionalRequirements) const;
+  bool isSatisfied(ArrayRef<Requirement> &conditionalRequirements,
+                   bool allowMissing = false) const;
 
   /// Determines if this substituted requirement can ever be satisfied,
   /// possibly with additional substitutions.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2331,7 +2331,8 @@ BuiltinProtocolConformance *
 ASTContext::getBuiltinConformance(
     Type type, ProtocolDecl *protocol,
     GenericSignature genericSig,
-    ArrayRef<Requirement> conditionalRequirements
+    ArrayRef<Requirement> conditionalRequirements,
+    BuiltinConformanceKind kind
 ) {
   auto key = std::make_pair(type, protocol);
   AllocationArena arena = getArena(type->getRecursiveProperties());
@@ -2343,7 +2344,7 @@ ASTContext::getBuiltinConformance(
         totalSizeToAlloc<Requirement>(conditionalRequirements.size());
     auto mem = this->Allocate(size, alignof(BuiltinProtocolConformance), arena);
     entry = new (mem) BuiltinProtocolConformance(
-        type, protocol, genericSig, conditionalRequirements);
+        type, protocol, genericSig, conditionalRequirements, kind);
   }
   return entry;
 }

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -937,7 +937,7 @@ bool GenericSignatureImpl::areSameTypeParameterInContext(Type type1,
 }
 
 bool GenericSignatureImpl::isRequirementSatisfied(
-    Requirement requirement) const {
+    Requirement requirement, bool allowMissing) const {
   if (requirement.getFirstType()->hasTypeParameter()) {
     auto *genericEnv = getGenericEnvironment();
 
@@ -959,7 +959,7 @@ bool GenericSignatureImpl::isRequirementSatisfied(
   // FIXME: Need to check conditional requirements here.
   ArrayRef<Requirement> conditionalRequirements;
 
-  return requirement.isSatisfied(conditionalRequirements);
+  return requirement.isSatisfied(conditionalRequirements, allowMissing);
 }
 
 SmallVector<Requirement, 4> GenericSignatureImpl::requirementsNotSatisfiedBy(
@@ -1391,12 +1391,14 @@ ProtocolDecl *Requirement::getProtocolDecl() const {
 }
 
 bool
-Requirement::isSatisfied(ArrayRef<Requirement> &conditionalRequirements) const {
+Requirement::isSatisfied(ArrayRef<Requirement> &conditionalRequirements,
+                         bool allowMissing) const {
   switch (getKind()) {
   case RequirementKind::Conformance: {
     auto *proto = getProtocolDecl();
     auto *module = proto->getParentModule();
-    auto conformance = module->lookupConformance(getFirstType(), proto);
+    auto conformance = module->lookupConformance(
+        getFirstType(), proto, allowMissing);
     if (!conformance)
       return false;
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -989,10 +989,29 @@ ProtocolConformanceRef ModuleDecl::lookupConformance(Type type,
       getASTContext().evaluator, request, ProtocolConformanceRef::forInvalid());
 }
 
+/// Retrieve an invalid or missing conformance, as appropriate, when a
+/// legitimate conformance doesn't exist.
+static ProtocolConformanceRef getInvalidOrMissingConformance(
+    Type type, ProtocolDecl *proto) {
+  // Introduce "missing" conformances to Sendable, so that type checking
+  // (and even code generation) can continue.
+  ASTContext &ctx = proto->getASTContext();
+  if (proto->isSpecificProtocol(KnownProtocolKind::Sendable) &&
+      ctx.LangOpts.WarnConcurrency) {
+    return ProtocolConformanceRef(
+        ctx.getBuiltinConformance(
+          type, proto, GenericSignature(), { },
+          BuiltinConformanceKind::Missing));
+  }
+
+  return ProtocolConformanceRef::forInvalid();
+}
+
 /// Synthesize a builtin tuple type conformance to the given protocol, if
 /// appropriate.
 static ProtocolConformanceRef getBuiltinTupleTypeConformance(
-    Type type, const TupleType *tupleType, ProtocolDecl *protocol) {
+    Type type, const TupleType *tupleType, ProtocolDecl *protocol,
+    ModuleDecl *module) {
   // Tuple type are Sendable when all of their element types are Sendable.
   if (protocol->isSpecificProtocol(KnownProtocolKind::Sendable)) {
     ASTContext &ctx = protocol->getASTContext();
@@ -1016,26 +1035,38 @@ static ProtocolConformanceRef getBuiltinTupleTypeConformance(
     // If there were no generic parameters, just form the builtin conformance.
     if (genericParams.empty()) {
       return ProtocolConformanceRef(
-          ctx.getBuiltinConformance(type, protocol, GenericSignature(), { }));
+          ctx.getBuiltinConformance(type, protocol, GenericSignature(), { },
+                                    BuiltinConformanceKind::Synthesized));
     }
 
     // Form a generic conformance of (T1, T2, ..., TN): Sendable with signature
     // <T1, T2, ..., TN> and conditional requirements T1: Sendable,
     // T2: Sendable, ..., TN: Sendable.
     auto genericTupleType = TupleType::get(genericElements, ctx);
-    auto genericSig = GenericSignature::get(genericParams, { });
+    auto genericSig = GenericSignature::get(
+        genericParams, conditionalRequirements);
     auto genericConformance = ctx.getBuiltinConformance(
-        genericTupleType, protocol, genericSig, conditionalRequirements);
+        genericTupleType, protocol, genericSig, conditionalRequirements,
+        BuiltinConformanceKind::Synthesized);
 
     // Compute the substitution map from the generic parameters of the
     // generic conformance to actual types that were in the tuple type.
     // Form a specialized conformance from that.
-    auto subMap = SubstitutionMap::get(genericSig, typeSubstitutions, { });
+    auto subMap = SubstitutionMap::get(
+        genericSig, [&](SubstitutableType *type) {
+          if (auto gp = dyn_cast<GenericTypeParamType>(type)) {
+            if (gp->getDepth() == 0)
+              return typeSubstitutions[gp->getIndex()];
+          }
+
+          return Type(type);
+        },
+        LookUpConformanceInModule(module));
     return ProtocolConformanceRef(
         ctx.getSpecializedConformance(type, genericConformance, subMap));
   }
 
-  return ProtocolConformanceRef::forInvalid();
+  return getInvalidOrMissingConformance(type, protocol);
 }
 
 /// Whether the given function type conforms to Sendable.
@@ -1064,10 +1095,11 @@ static ProtocolConformanceRef getBuiltinFunctionTypeConformance(
       isSendableFunctionType(functionType)) {
     ASTContext &ctx = protocol->getASTContext();
     return ProtocolConformanceRef(
-        ctx.getBuiltinConformance(type, protocol, GenericSignature(), { }));
+        ctx.getBuiltinConformance(type, protocol, GenericSignature(), { },
+                                  BuiltinConformanceKind::Synthesized));
   }
 
-  return ProtocolConformanceRef::forInvalid();
+  return getInvalidOrMissingConformance(type, protocol);
 }
 
 /// Synthesize a builtin metatype type conformance to the given protocol, if
@@ -1078,10 +1110,11 @@ static ProtocolConformanceRef getBuiltinMetaTypeTypeConformance(
   if (protocol->isSpecificProtocol(KnownProtocolKind::Sendable)) {
     ASTContext &ctx = protocol->getASTContext();
     return ProtocolConformanceRef(
-        ctx.getBuiltinConformance(type, protocol, GenericSignature(), { }));
+        ctx.getBuiltinConformance(type, protocol, GenericSignature(), { },
+                                  BuiltinConformanceKind::Synthesized));
   }
 
-  return ProtocolConformanceRef::forInvalid();
+  return getInvalidOrMissingConformance(type, protocol);
 }
 
 /// Synthesize a builtin type conformance to the given protocol, if
@@ -1092,10 +1125,11 @@ static ProtocolConformanceRef getBuiltinBuiltinTypeConformance(
   if (protocol->isSpecificProtocol(KnownProtocolKind::Sendable)) {
     ASTContext &ctx = protocol->getASTContext();
     return ProtocolConformanceRef(
-        ctx.getBuiltinConformance(type, protocol, GenericSignature(), { }));
+        ctx.getBuiltinConformance(type, protocol, GenericSignature(), { },
+                                  BuiltinConformanceKind::Synthesized));
   }
 
-  return ProtocolConformanceRef::forInvalid();
+  return getInvalidOrMissingConformance(type, protocol);
 }
 
 ProtocolConformanceRef
@@ -1133,14 +1167,18 @@ LookupConformanceInModuleRequest::evaluate(
         return ProtocolConformanceRef(protocol);
     }
 
-    return ProtocolConformanceRef::forInvalid();
+    return getInvalidOrMissingConformance(type, protocol);
   }
 
   // An existential conforms to a protocol if the protocol is listed in the
   // existential's list of conformances and the existential conforms to
   // itself.
-  if (type->isExistentialType())
-    return mod->lookupExistentialConformance(type, protocol);
+  if (type->isExistentialType()) {
+    auto result = mod->lookupExistentialConformance(type, protocol);
+    if (result.isInvalid())
+      return getInvalidOrMissingConformance(type, protocol);
+    return result;
+  }
 
   // Type variables have trivial conformances.
   if (type->isTypeVariableOrMember())
@@ -1154,7 +1192,7 @@ LookupConformanceInModuleRequest::evaluate(
 
   // Tuple types can conform to protocols.
   if (auto tupleType = type->getAs<TupleType>()) {
-    return getBuiltinTupleTypeConformance(type, tupleType, protocol);
+    return getBuiltinTupleTypeConformance(type, tupleType, protocol, mod);
   }
 
   // Function types can conform to protocols.
@@ -1176,13 +1214,13 @@ LookupConformanceInModuleRequest::evaluate(
 
   // If we don't have a nominal type, there are no conformances.
   if (!nominal || isa<ProtocolDecl>(nominal))
-    return ProtocolConformanceRef::forInvalid();
+    return getInvalidOrMissingConformance(type, protocol);
 
   // Find the (unspecialized) conformance.
   SmallVector<ProtocolConformance *, 2> conformances;
   if (!nominal->lookupConformance(mod, protocol, conformances)) {
     if (!protocol->isSpecificProtocol(KnownProtocolKind::Sendable))
-      return ProtocolConformanceRef::forInvalid();
+      return getInvalidOrMissingConformance(type, protocol);
 
     // Try to infer Sendable conformance.
     GetImplicitSendableRequest cvRequest{nominal};
@@ -1191,7 +1229,7 @@ LookupConformanceInModuleRequest::evaluate(
       conformances.clear();
       conformances.push_back(conformance);
     } else {
-      return ProtocolConformanceRef::forInvalid();
+      return getInvalidOrMissingConformance(type, protocol);
     }
   }
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -996,8 +996,7 @@ static ProtocolConformanceRef getInvalidOrMissingConformance(
   // Introduce "missing" conformances to Sendable, so that type checking
   // (and even code generation) can continue.
   ASTContext &ctx = proto->getASTContext();
-  if (proto->isSpecificProtocol(KnownProtocolKind::Sendable) &&
-      ctx.LangOpts.WarnConcurrency) {
+  if (proto->isSpecificProtocol(KnownProtocolKind::Sendable)) {
     return ProtocolConformanceRef(
         ctx.getBuiltinConformance(
           type, proto, GenericSignature(), { },

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1320,9 +1320,9 @@ void NominalTypeDecl::getImplicitProtocols(
 }
 
 void NominalTypeDecl::registerProtocolConformance(
-       ProtocolConformance *conformance) {
+       ProtocolConformance *conformance, bool synthesized) {
   prepareConformanceTable();
-  ConformanceTable->registerProtocolConformance(conformance);
+  ConformanceTable->registerProtocolConformance(conformance, synthesized);
 }
 
 ArrayRef<ValueDecl *>

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1591,10 +1591,13 @@ ProtocolConformanceRef::getCanonicalConformanceRef() const {
 BuiltinProtocolConformance::BuiltinProtocolConformance(
     Type conformingType, ProtocolDecl *protocol,
     GenericSignature genericSig,
-    ArrayRef<Requirement> conditionalRequirements
+    ArrayRef<Requirement> conditionalRequirements,
+    BuiltinConformanceKind kind
 ) : RootProtocolConformance(ProtocolConformanceKind::Builtin, conformingType),
     protocol(protocol), genericSig(genericSig),
-    numConditionalRequirements(conditionalRequirements.size()) {
+    numConditionalRequirements(conditionalRequirements.size()),
+    builtinConformanceKind(static_cast<unsigned>(kind))
+{
   std::uninitialized_copy(conditionalRequirements.begin(),
                           conditionalRequirements.end(),
                           getTrailingObjects<Requirement>());

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3772,7 +3772,8 @@ operator()(CanType dependentType, Type conformingReplacementType,
     return ProtocolConformanceRef(conformedProtocol);
 
   return M->lookupConformance(conformingReplacementType,
-                              conformedProtocol);
+                              conformedProtocol,
+                              /*allowMissing=*/true);
 }
 
 ProtocolConformanceRef LookUpConformanceInSubstitutionMap::

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6225,7 +6225,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
   case ConstraintKind::LiteralConformsTo: {
     // Check whether this type conforms to the protocol.
     auto conformance = DC->getParentModule()->lookupConformance(
-        type, protocol);
+        type, protocol, /*allowMissing=*/true);
     if (conformance) {
       return recordConformance(conformance);
     }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3741,6 +3741,7 @@ NormalProtocolConformance *GetImplicitSendableRequest::evaluate(
     conformance->setSourceKindAndImplyingConformance(
         ConformanceEntryKind::Synthesized, nullptr);
 
+    nominal->registerProtocolConformance(conformance, /*synthesized=*/true);
     return conformance;
   };
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -546,32 +546,6 @@ static bool isSendableClosure(
   return false;
 }
 
-/// Look for missing Sendable conformances
-static bool hasMissingSendableConformance(
-    ModuleDecl *module, ProtocolConformanceRef conformance) {
-  if (!conformance.isConcrete())
-    return false;
-
-  // Is this a missing Sendable conformance?
-  const ProtocolConformance *concreteConf = conformance.getConcrete();
-  const RootProtocolConformance *rootConf = concreteConf->getRootConformance();
-  if (auto builtinConformance = dyn_cast<BuiltinProtocolConformance>(rootConf)){
-    if (builtinConformance->isMissing() && builtinConformance->getProtocol()->isSpecificProtocol(
-            KnownProtocolKind::Sendable)) {
-      return true;
-    }
-  }
-
-  // Check conformances that are part of this conformance.
-  auto subMap = concreteConf->getSubstitutions(module);
-  for (auto conformance : subMap.getConformances()) {
-    if (hasMissingSendableConformance(module, conformance))
-      return true;
-  }
-
-  return false;
-}
-
 /// Determine whether the given type is suitable as a concurrent value type.
 bool swift::isSendableType(ModuleDecl *module, Type type) {
   auto proto = module->getASTContext().getProtocol(KnownProtocolKind::Sendable);
@@ -583,7 +557,7 @@ bool swift::isSendableType(ModuleDecl *module, Type type) {
     return false;
 
   // Look for missing Sendable conformances.
-  return !hasMissingSendableConformance(module, conformance);
+  return !conformance.hasMissingConformance(module);
 }
 
 static bool diagnoseNonConcurrentParameter(

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -245,6 +245,9 @@ bool diagnoseNonConcurrentTypesInReference(
     ConcurrentReferenceKind refKind,
     DiagnosticBehavior behavior = DiagnosticBehavior::Unspecified);
 
+/// Produce a diagnostic for a missing conformance to Sendable.
+void diagnoseMissingSendableConformance(SourceLoc loc, Type type);
+
 /// How the concurrent value check should be performed.
 enum class SendableCheck {
   /// Sendable conformance was explicitly stated and should be

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -800,7 +800,7 @@ RequirementCheckResult TypeChecker::checkGenericArguments(
       }
 
       ArrayRef<Requirement> conditionalRequirements;
-      if (req.isSatisfied(conditionalRequirements)) {
+      if (req.isSatisfied(conditionalRequirements, /*allowMissing=*/true)) {
         if (!conditionalRequirements.empty()) {
           assert(req.getKind() == RequirementKind::Conformance);
 
@@ -897,7 +897,7 @@ TypeChecker::checkGenericArguments(ModuleDecl *module,
   while (!worklist.empty()) {
     auto req = worklist.pop_back_val();
     ArrayRef<Requirement> conditionalRequirements;
-    if (!req.isSatisfied(conditionalRequirements))
+    if (!req.isSatisfied(conditionalRequirements, /*allowMissing=*/true))
       return RequirementCheckResult::Failure;
 
     worklist.append(conditionalRequirements.begin(),

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3248,7 +3248,8 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
     // Find the conformance for this overridden protocol.
     auto overriddenConformance =
       DC->getParentModule()->lookupConformance(Adoptee,
-                                               overridden->getProtocol());
+                                               overridden->getProtocol(),
+                                               /*allowMissing=*/true);
     if (overriddenConformance.isInvalid() ||
         !overriddenConformance.isConcrete())
       continue;
@@ -5180,7 +5181,7 @@ TypeChecker::containsProtocol(Type T, ProtocolDecl *Proto, ModuleDecl *M,
 ProtocolConformanceRef
 TypeChecker::conformsToProtocol(Type T, ProtocolDecl *Proto, ModuleDecl *M) {
   // Look up conformance in the module.
-  auto lookupResult = M->lookupConformance(T, Proto);
+  auto lookupResult = M->lookupConformance(T, Proto, /*alllowMissing=*/true);
   if (lookupResult.isInvalid()) {
     return ProtocolConformanceRef::forInvalid();
   }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -547,8 +547,10 @@ ModuleFile::readConformanceChecked(llvm::BitstreamCursor &Cursor,
     TypeID conformingTypeID;
     DeclID protoID;
     GenericSignatureID genericSigID;
+    unsigned builtinConformanceKind;
     BuiltinProtocolConformanceLayout::readRecord(scratch, conformingTypeID,
-                                                 protoID, genericSigID);
+                                                 protoID, genericSigID,
+                                                 builtinConformanceKind);
 
     Type conformingType = getType(conformingTypeID);
 
@@ -569,7 +571,8 @@ ModuleFile::readConformanceChecked(llvm::BitstreamCursor &Cursor,
       return std::move(error);
 
     auto conformance = getContext().getBuiltinConformance(
-        conformingType, proto, *genericSig, conditionalRequirements);
+        conformingType, proto, *genericSig, conditionalRequirements,
+        static_cast<BuiltinConformanceKind>(builtinConformanceKind));
     return ProtocolConformanceRef(conformance);
   }
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 621; // protocol associated type list
+const uint16_t SWIFTMODULE_VERSION_MINOR = 622; // builtin conformance kind
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1680,7 +1680,8 @@ namespace decls_block {
     BUILTIN_PROTOCOL_CONFORMANCE,
     TypeIDField, // the conforming type
     DeclIDField, // the protocol
-    GenericSignatureIDField // the generic signature
+    GenericSignatureIDField, // the generic signature
+    BCFixed<2> // the builtin conformance kind
     // the (optional) conditional requirements follow
   >;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1625,7 +1625,8 @@ Serializer::writeConformance(ProtocolConformanceRef conformanceRef,
     auto protocolID = addDeclRef(builtin->getProtocol());
     auto genericSigID = addGenericSignatureRef(builtin->getGenericSignature());
     BuiltinProtocolConformanceLayout::emitRecord(
-        Out, ScratchRecord, abbrCode, typeID, protocolID, genericSigID);
+        Out, ScratchRecord, abbrCode, typeID, protocolID, genericSigID,
+        static_cast<unsigned>(builtin->getBuiltinConformanceKind()));
     writeGenericRequirements(builtin->getConditionalRequirements(), abbrCodes);
     break;
   }

--- a/test/Concurrency/concurrent_value_inference.swift
+++ b/test/Concurrency/concurrent_value_inference.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-library-evolution -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -enable-library-evolution
 // REQUIRES: concurrency
 
 class C1 { }
@@ -27,7 +27,6 @@ struct GS2<T> {
 }
 
 func acceptCV<T: Sendable>(_: T) { }
-// expected-note@-1 6{{where 'T' =}}
 
 // Example that was triggering circular dependencies.
 struct Signature { }
@@ -86,6 +85,7 @@ struct HasFunctions {
   var cfp: @convention(c) () -> Void
 }
 
+@available(SwiftStdlib 5.5, *)
 @globalActor
 actor MyGlobalActor {
   static let shared = MyGlobalActor()
@@ -103,22 +103,22 @@ func testCV(
   fps: FrozenPublicStruct, fpe: FrozenPublicEnum,
   hf: HasFunctions
 ) {
-  acceptCV(c1) // expected-error{{'C1' conform to 'Sendable'}}
+  acceptCV(c1) // expected-warning{{type 'C1' does not conform to the 'Sendable' protocol}}
   acceptCV(c2)
   acceptCV(c3)
   acceptCV(c4)
   acceptCV(s1)
-  acceptCV(e1) // expected-error{{'E1' conform to 'Sendable'}}
+  acceptCV(e1) // expected-warning{{type 'E1' does not conform to the 'Sendable'}}
   acceptCV(e2)
   acceptCV(gs1)
-  acceptCV(gs2) // expected-error{{'GS2<Int>' conform to 'Sendable'}}
+  acceptCV(gs2) // expected-warning{{type 'GS2<Int>' does not conform to the 'Sendable' protocol}}
 
   // Not available due to recursive conformance dependencies.
-  acceptCV(bc) // expected-error{{global function 'acceptCV' requires that 'Bitcode' conform to 'Sendable'}}
+  acceptCV(bc) // expected-warning{{type 'Bitcode' does not conform to the 'Sendable' protocol}}
 
   // Not available due to "public".
-  acceptCV(ps) // expected-error{{global function 'acceptCV' requires that 'PublicStruct' conform to 'Sendable'}}
-  acceptCV(pe) // expected-error{{global function 'acceptCV' requires that 'PublicEnum' conform to 'Sendable'}}
+  acceptCV(ps) // expected-warning{{type 'PublicStruct' does not conform to the 'Sendable' protocol}}
+  acceptCV(pe) // expected-warning{{type 'PublicEnum' does not conform to the 'Sendable' protocol}}
 
   // Public is okay when also @frozen.
   acceptCV(fps)

--- a/test/SourceKit/CursorInfo/cursor_symbol_graph.swift
+++ b/test/SourceKit/CursorInfo/cursor_symbol_graph.swift
@@ -323,7 +323,8 @@ enum MyEnum {
 // CHECKFOO:       "vendor":
 // CHECKFOO:     }
 // CHECKFOO:   },
-// CHECKFOO:   "relationships": [],
+// CHECKFOO:   "relationships": [
+// CHECKFOO:       "target": "s:s8SendableP",
 // CHECKFOO:   "symbols": [
 // CHECKFOO:     {
 // CHECKFOO:       "accessLevel": "internal",

--- a/test/decl/protocol/special/Sendable.swift
+++ b/test/decl/protocol/special/Sendable.swift
@@ -1,6 +1,6 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -warn-concurrency
 
-func acceptSendable<T: Sendable>(_: T) { } // expected-note{{required by global function 'acceptSendable' where 'T' = '() -> Void'}}
+func acceptSendable<T: Sendable>(_: T) { }
 
 class NotSendable { }
 
@@ -19,15 +19,10 @@ func testSendableBuiltinConformances(
   acceptSendable((i, label: sf))
   acceptSendable(funSendable)
 
-  // Errors
-  acceptSendable((i, ns)) // expected-error{{global function 'acceptSendable' requires that 'NotSendable' conform to 'Sendable'}}
-  acceptSendable(nsf) // expected-error{{type '() -> Void' cannot conform to 'Sendable'}}
-  // expected-note@-1{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-  acceptSendable((nsf, i)) // expected-error{{type '() -> Void' cannot conform to 'Sendable'}}
-  // expected-note@-1{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-  // expected-note@-2{{requirement from conditional conformance of '(() -> Void, Int)' to 'Sendable'}}
-  acceptSendable(funNotSendable) // expected-error{{type '() -> Void' cannot conform to 'Sendable'}}
-  // expected-note@-1{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-  // expected-note@-2{{requirement from conditional conformance of '(Int, () -> Void, NotSendable.Type)' to 'Sendable'}}
-  acceptSendable((i, ns)) // expected-error{{global function 'acceptSendable' requires that 'NotSendable' conform to 'Sendable'}}
+  // Complaints about missing Sendable conformances
+  acceptSendable((i, ns)) // expected-warning{{type 'NotSendable' does not conform to the 'Sendable' protocol}}
+  acceptSendable(nsf) // expected-warning{{function type '() -> Void' must be marked '@Sendable' to conform to 'Sendable'}}
+  acceptSendable((nsf, i)) // expected-warning{{function type '() -> Void' must be marked '@Sendable' to conform to 'Sendable'}}
+  acceptSendable(funNotSendable) // expected-warning{{function type '() -> Void' must be marked '@Sendable' to conform to 'Sendable'}}
+  acceptSendable((i, ns)) // expected-warning{{type 'NotSendable' does not conform to the 'Sendable' protocol}}
 }


### PR DESCRIPTION
When looking up a conformance to Sendable fails, implicitly create a
"missing" builtin conformance. Such conformances allow type checking
to continue even in the presence of Sendable-related problems.

Diagnose these missing conformances when they are used in an actual
program, as part of availability checking for conformances and when we
are determining Sendability. This allows us to decide between an
error, a warning, and suppressing the diagnostic entirely without
affecting how the program is compiled. This is a step toward enabling
selective enforcement of Sendable.

Part of rdar://78269348.