### PR TITLE
[Tests] Fix RemoteMirror/interop.swift to work with ASAN enabled.

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -350,6 +350,9 @@ code for the target that is not the build machine:
 * ``%target-cc-options``: the clang flags to setup the target with the right
   architecture and platform version.
 
+* ``%target-sanitizer-opt``: if sanitizers are enabled for the build, the
+  corresponding ``-fsanitize=`` option.
+
 * ``%target-triple``: a triple composed of the ``%target-cpu``, the vendor,
   the ``%target-os``, and the operating system version number. Possible values
   include ``i386-apple-ios7.0`` or ``armv7k-apple-watchos2.0``.

--- a/test/RemoteMirror/interop.swift
+++ b/test/RemoteMirror/interop.swift
@@ -2,7 +2,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %S/Inputs/interop.swift -emit-library -module-name InteropTest -o %t/%target-library-name(InteropTest)
-// RUN: %target-clang %S/Inputs/interop.m -framework Foundation -I %S/../../include/swift/SwiftRemoteMirror -I %S/../../include/ -o %t/InteropTest
+// RUN: %target-clang %target-sanitizer-opt %S/Inputs/interop.m -framework Foundation -I %S/../../include/swift/SwiftRemoteMirror -I %S/../../include/ -o %t/InteropTest
 // RUN: %target-codesign %t/%target-library-name(InteropTest)
 // RUN: %target-codesign %t/InteropTest
 // RUN: %target-run %t/InteropTest %t/%target-library-name(InteropTest) %platform-module-dir/%target-library-name(swiftRemoteMirror) | %FileCheck %s

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -688,6 +688,11 @@ if config.benchmark_o != 'Benchmark_O':
 # Add substitutions for the run target triple, CPU, OS, and pointer size.
 config.substitutions.append(('%target-triple', config.variant_triple))
 
+# Keep track of which sanitizers need to be enabled (matters for some tests)
+config.sanitizers = []
+if 'asan' in config.available_features:
+    config.sanitizers.append('address')
+
 if run_vendor == 'apple':
     if run_os == 'maccatalyst':
         config.stable_abi_triple = '%s-%s-ios13.0-macabi' % (run_cpu, run_vendor)
@@ -2051,6 +2056,13 @@ if hasattr(config, 'target_cc_options'):
     config.substitutions.append(('%target-cc-options', config.target_cc_options))
 else:
     config.substitutions.append(('%target-cc-options', ''))
+
+# Build an -fsanitize= argument (used by some tests)
+if config.sanitizers:
+    config.substitutions.append(('%target-sanitizer-opt',
+                                 '-fsanitize=' + ','.join(config.sanitizers)))
+else:
+    config.substitutions.append(('%target-sanitizer-opt', ''))
 
 # WORKAROUND(rdar://53507844): On some macOS versions, we see flaky failures in
 # tests which create a hard link to an executable and immediately invoke it.


### PR DESCRIPTION
In order to work for an ASAN build, parts of this test need themselves to be built with ASAN turned on.

rdar://81274645
