### PR TITLE
[test] move two tests from from stdlib to runtime

### DIFF
--- a/test/Runtime/allocator_sanity.swift
+++ b/test/Runtime/allocator_sanity.swift
@@ -1,0 +1,27 @@
+// RUN: %target-run-simple-swiftgyb
+
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import StdlibUnittest
+
+var AllocationsTestSuite = TestSuite("Allocations")
+
+AllocationsTestSuite.test("absurd.allocation.misaligned") {
+  expectCrashLater()
+  let mustFail = UnsafeMutableRawPointer.allocate(byteCount: 1024,
+                                                  alignment: 19)
+  expectUnreachable()
+  _ = mustFail
+}
+
+AllocationsTestSuite.test("absurd.allocation.gargantuan") {
+  expectCrashLater()
+  let mustFail = UnsafeMutableRawPointer.allocate(byteCount: Int.max,
+                                                  alignment: 0)
+  expectUnreachable()
+  _ = mustFail
+}
+
+runAllTests()

--- a/test/stdlib/UnsafeRawPointer.swift
+++ b/test/stdlib/UnsafeRawPointer.swift
@@ -229,18 +229,4 @@ UnsafeMutableRawPointerExtraTestSuite.test("moveInitialize:from:") {
   check(Check.RightOverlap)
 }
 
-UnsafeMutableRawPointerExtraTestSuite.test("absurd.allocation.misaligned") {
-  expectCrashLater()
-  let mustFail = UnsafeMutableRawPointer.allocate(byteCount: 1024,
-                                                  alignment: 19)
-  expectUnreachable()
-}
-
-UnsafeMutableRawPointerExtraTestSuite.test("absurd.allocation.gargantuan") {
-  expectCrashLater()
-  let mustFail = UnsafeMutableRawPointer.allocate(byteCount: Int.max,
-                                                  alignment: 0)
-  expectUnreachable()
-}
-
 runAllTests()


### PR DESCRIPTION
Simply moves these two tests to a better location.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://81236867.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
