### PR TITLE
[ConstraintSystem] Improve the "transitive conformance" heuristic and remove early conformance checking from `DisjunctionStep::shouldSkip`

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6479,6 +6479,12 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyTransitivelyConformsTo(
   // If the type doesn't conform, let's check whether
   // an Optional or Unsafe{Mutable}Pointer from it would.
 
+  // If the current score is equal to the best score, fail without checking
+  // implicit conversions, because an implicit conversion would lead to a
+  // worse score anyway.
+  if (solverState && solverState->BestScore && CurrentScore == *solverState->BestScore)
+    return SolutionKind::Error;
+
   SmallVector<Type, 4> typesToCheck;
 
   // T -> Optional<T>


### PR DESCRIPTION
The "transitive conformance" constraint is a generalization of the early conformance checking in `DisjunctionStep::shouldSkip`. The code in `DisjunctionStep` ignored the potential for implicit conversions if the best score is equal to the current score, because if the current path needs an implicit conversion to satisfy a conformance requirement, that score would be worse anyway. We can use this assumption when simplifying a transitive conformance constraint, and remove the conformance checking from `DisjunctionStep`.