### PR TITLE
[Sema][CSSimplify] Account for synthesized args when diagnosing labelling issues in matchCallArgumentsImpl

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -786,7 +786,9 @@ static bool matchCallArgumentsImpl(
       unsigned argIdx = 0;
       for (const auto &binding : parameterBindings) {
         paramToArgMap.push_back(argIdx);
-        argIdx += binding.size();
+        // Ignore argument bindings that were synthesized due to missing args.
+         argIdx += llvm::count_if(
+             binding, [numArgs](unsigned argIdx) { return argIdx < numArgs; });
       }
     }
 
@@ -802,6 +804,10 @@ static bool matchCallArgumentsImpl(
         // needs to move (fromArgIdx) and the argument location
         // it should move to (toArgIdx).
         const auto fromArgIdx = binding[paramBindIdx];
+
+        // Ignore argument bindings that were synthesized due to missing args.
+        if (fromArgIdx >= numArgs)
+          continue;
 
         // Does nothing for variadic tail.
         if (params[paramIdx].isVariadic() && paramBindIdx > 0) {

--- a/test/Constraints/argument_matching.swift
+++ b/test/Constraints/argument_matching.swift
@@ -1153,7 +1153,7 @@ func testUnlabeledParameterBindingPosition() {
     // expected-error@-2:22 {{missing argument for parameter 'dd' in call}}
 
     f(1, xx: 2, dd: 3)
-    // expected-error@-1 {{incorrect argument labels in call (have '_:xx:dd:', expected '_:_:cc:dd:')}}
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
     // expected-error@-2:15 {{missing argument for parameter 'cc' in call}}
 
     f(xx: 1, 2, cc: 3)
@@ -1161,7 +1161,7 @@ func testUnlabeledParameterBindingPosition() {
     // expected-error@-2:22 {{missing argument for parameter 'dd' in call}}
 
     f(xx: 1, 2, dd: 3)
-    // expected-error@-1 {{incorrect argument labels in call (have 'xx:_:dd:', expected '_:_:cc:dd:')}}
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
     // expected-error@-2:15 {{missing argument for parameter 'cc' in call}}
 
     f(1, xx: 2, cc: 3, dd: 4)
@@ -1207,23 +1207,26 @@ func testUnlabeledParameterBindingPosition() {
 
     f(1, xx: 2)
     // expected-error@-1:6 {{missing arguments for parameters 'aa', 'bb' in call}}
-    // expected-error@-2 {{incorrect argument labels in call (have '_:xx:', expected 'aa:bb:_:_:')}}
+    // expected-error@-2 {{extraneous argument label 'xx:' in call}}
 
     f(xx: 1, 2)
-    // expected-error@-1 {{incorrect argument labels in call (have 'xx:_:', expected 'aa:bb:_:_:')}}
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
     // expected-error@-2:6 {{missing arguments for parameters 'aa', 'bb' in call}}
 
     f(bb: 1, 2, xx: 3)
     // expected-error@-1:7 {{missing argument for parameter 'aa' in call}}
+    // expected-error@-2:6 {{extraneous argument label 'xx:' in call}}
 
     f(bb: 1, xx: 2, 3)
     // expected-error@-1:7 {{missing argument for parameter 'aa' in call}}
+    // expected-error@-2:6 {{extraneous argument label 'xx:' in call}}
 
     f(aa: 1, 2, xx: 3)
     // expected-error@-1:12 {{missing argument for parameter 'bb' in call}}
+    // expected-error@-2:6 {{extraneous argument label 'xx:' in call}}
 
     f(aa: 1, xx: 2, 3)
-    // expected-error@-1 {{incorrect argument labels in call (have 'aa:xx:_:', expected 'aa:bb:_:_:')}}
+    // expected-error@-1 {{extraneous argument label 'xx:' in call}}
     // expected-error@-2:12 {{missing argument for parameter 'bb' in call}}
 
     f(aa: 1, bb: 2, 3, xx: 4)
@@ -1639,7 +1642,7 @@ _ = CurriedClass.method3(1, 2)           // expected-error {{instance member 'me
 // expected-error@-1 {{missing argument label 'b:' in call}}
 CurriedClass.method3(c)(1.0, b: 1)       // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 CurriedClass.method3(c)(1)               // expected-error {{missing argument for parameter 'b' in call}}
-CurriedClass.method3(c)(c: 1.0)          // expected-error {{incorrect argument labels in call (have 'c:', expected '_:b:')}}
+CurriedClass.method3(c)(c: 1.0)          // expected-error {{incorrect argument label in call (have 'c:', expected 'b:')}}
 // expected-error@-1 {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 // expected-error@-2 {{missing argument for parameter #1 in call}}
 


### PR DESCRIPTION
Unfulfilled params get arguments synthesized for them which are added to the end of the argument list. Later logic to detect out-of-order arguments and produce relabelling fixes treated them as real arguments appearing at the end of the argument list though.

This improves several diagnostics for call sites with both missing and mislabelled call arguments in the existing tests.