### PR TITLE
[Dependency Scanning] Have the scanner cache answer queries relevant to current search paths only.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -37,6 +37,7 @@
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/Support/Allocator.h"
@@ -852,6 +853,13 @@ public:
       StringRef moduleName,
       ModuleDependenciesCache &cache,
       InterfaceSubContextDelegate &delegate);
+
+  /// Compute the extra implicit framework search paths on Apple platforms:
+  /// $SDKROOT/System/Library/Frameworks/ and $SDKROOT/Library/Frameworks/.
+  std::vector<std::string> getDarwinImplicitFrameworkSearchPaths() const;
+
+  /// Return a set of all possible filesystem locations where modules can be found.
+  llvm::StringSet<> getAllModuleSearchPathsSet() const;
 
   /// Load extensions to the given nominal type from the external
   /// module loaders.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -41,6 +41,7 @@
 #include "swift/AST/PropertyWrappers.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/RawComment.h"
+#include "swift/AST/SearchPathOptions.h"
 #include "swift/AST/SILLayout.h"
 #include "swift/AST/SemanticAttrs.h"
 #include "swift/AST/SourceFile.h"
@@ -1641,20 +1642,23 @@ Optional<ModuleDependencies> ASTContext::getModuleDependencies(
     bool cacheOnly) {
   // Retrieve the dependencies for this module.
   if (cacheOnly) {
+    auto searchPathSet = getAllModuleSearchPathsSet();
     // Check whether we've cached this result.
     if (!isUnderlyingClangModule) {
-      if (auto found = cache.findDependencies(moduleName,
-                                              ModuleDependenciesKind::SwiftTextual))
+      if (auto found = cache.findDependencies(
+              moduleName,
+              {ModuleDependenciesKind::SwiftTextual, searchPathSet}))
         return found;
-      if (auto found = cache.findDependencies(moduleName,
-                                              ModuleDependenciesKind::SwiftTextual))
+      if (auto found = cache.findDependencies(
+              moduleName, {ModuleDependenciesKind::SwiftBinary, searchPathSet}))
         return found;
-      if (auto found = cache.findDependencies(moduleName,
-                                              ModuleDependenciesKind::SwiftPlaceholder))
+      if (auto found = cache.findDependencies(
+              moduleName,
+              {ModuleDependenciesKind::SwiftPlaceholder, searchPathSet}))
         return found;
     }
-    if (auto found = cache.findDependencies(moduleName,
-                                            ModuleDependenciesKind::Clang))
+    if (auto found = cache.findDependencies(
+            moduleName, {ModuleDependenciesKind::Clang, searchPathSet}))
       return found;
   } else {
     for (auto &loader : getImpl().ModuleLoaders) {
@@ -1662,8 +1666,8 @@ Optional<ModuleDependencies> ASTContext::getModuleDependencies(
           loader.get() != getImpl().TheClangModuleLoader)
         continue;
 
-      if (auto dependencies = loader->getModuleDependencies(moduleName, cache,
-                                                            delegate))
+      if (auto dependencies =
+              loader->getModuleDependencies(moduleName, cache, delegate))
         return dependencies;
     }
   }
@@ -1684,6 +1688,65 @@ ASTContext::getSwiftModuleDependencies(StringRef moduleName,
       return dependencies;
   }
   return None;
+}
+
+namespace {
+  static StringRef
+  pathStringFromFrameworkSearchPath(const SearchPathOptions::FrameworkSearchPath &next) {
+    return next.Path;
+  };
+}
+
+std::vector<std::string> ASTContext::getDarwinImplicitFrameworkSearchPaths()
+const {
+  assert(LangOpts.Target.isOSDarwin());
+  SmallString<128> systemFrameworksScratch;
+  systemFrameworksScratch = SearchPathOpts.SDKPath;
+  llvm::sys::path::append(systemFrameworksScratch, "System", "Library", "Frameworks");
+
+  SmallString<128> frameworksScratch;
+  frameworksScratch = SearchPathOpts.SDKPath;
+  llvm::sys::path::append(frameworksScratch, "Library", "Frameworks");
+  return {systemFrameworksScratch.str().str(), frameworksScratch.str().str()};
+}
+
+llvm::StringSet<> ASTContext::getAllModuleSearchPathsSet()
+const {
+  llvm::StringSet<> result;
+  result.insert(SearchPathOpts.ImportSearchPaths.begin(),
+                SearchPathOpts.ImportSearchPaths.end());
+
+  // Framework paths are "special", they contain more than path strings,
+  // but path strings are all we care about here.
+  using FrameworkPathView = ArrayRefView<SearchPathOptions::FrameworkSearchPath,
+                                         StringRef,
+                                         pathStringFromFrameworkSearchPath>;
+  FrameworkPathView frameworkPathsOnly{SearchPathOpts.FrameworkSearchPaths};
+  result.insert(frameworkPathsOnly.begin(), frameworkPathsOnly.end());
+
+  if (LangOpts.Target.isOSDarwin()) {
+    auto implicitFrameworkSearchPaths = getDarwinImplicitFrameworkSearchPaths();
+    result.insert(implicitFrameworkSearchPaths.begin(),
+                  implicitFrameworkSearchPaths.end());
+  }
+  result.insert(SearchPathOpts.RuntimeLibraryImportPaths.begin(),
+                SearchPathOpts.RuntimeLibraryImportPaths.end());
+
+  // ClangImporter special-cases the path for SwiftShims, so do the same here
+  // If there are no shims in the resource dir, add a search path in the SDK.
+  SmallString<128> shimsPath(SearchPathOpts.RuntimeResourcePath);
+  llvm::sys::path::append(shimsPath, "shims");
+  if (!llvm::sys::fs::exists(shimsPath)) {
+    shimsPath = SearchPathOpts.SDKPath;
+    llvm::sys::path::append(shimsPath, "usr", "lib", "swift", "shims");
+  }
+  result.insert(shimsPath.str());
+
+  // Clang system modules are found in the SDK root
+  SmallString<128> clangSysRootPath(SearchPathOpts.SDKPath);
+  llvm::sys::path::append(clangSysRootPath, "usr", "include");
+  result.insert(clangSysRootPath.str());
+  return result;
 }
 
 void ASTContext::loadExtensions(NominalTypeDecl *nominal,

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -131,7 +131,7 @@ void ModuleDependencies::addBridgingModuleDependency(
     swiftStorage->bridgingModuleDependencies.push_back(module.str());
 }
 
-llvm::StringMap<ModuleDependencies> &
+llvm::StringMap<ModuleDependenciesCache::ModuleDependenciesVector> &
 ModuleDependenciesCache::getDependenciesMap(ModuleDependenciesKind kind) {
   switch (kind) {
   case ModuleDependenciesKind::SwiftTextual:
@@ -146,7 +146,7 @@ ModuleDependenciesCache::getDependenciesMap(ModuleDependenciesKind kind) {
   llvm_unreachable("invalid dependency kind");
 }
 
-const llvm::StringMap<ModuleDependencies> &
+const llvm::StringMap<ModuleDependenciesCache::ModuleDependenciesVector> &
 ModuleDependenciesCache::getDependenciesMap(ModuleDependenciesKind kind) const {
   switch (kind) {
   case ModuleDependenciesKind::SwiftTextual:
@@ -161,43 +161,165 @@ ModuleDependenciesCache::getDependenciesMap(ModuleDependenciesKind kind) const {
   llvm_unreachable("invalid dependency kind");
 }
 
-bool ModuleDependenciesCache::hasDependencies(
-    StringRef moduleName,
-    Optional<ModuleDependenciesKind> kind) const {
-  if (!kind) {
-    return hasDependencies(moduleName, ModuleDependenciesKind::SwiftTextual) ||
-        hasDependencies(moduleName, ModuleDependenciesKind::SwiftBinary) ||
-        hasDependencies(moduleName, ModuleDependenciesKind::SwiftPlaceholder) ||
-        hasDependencies(moduleName, ModuleDependenciesKind::Clang);
+static std::string moduleBasePath(const StringRef modulePath) {
+  auto parent = llvm::sys::path::parent_path(modulePath);
+  // If the modulePath is that of a .swiftinterface contained in a .swiftmodule,
+  // disambiguate further to parent.
+  if (llvm::sys::path::extension(parent) == ".swiftmodule") {
+    parent = llvm::sys::path::parent_path(parent);
   }
 
-  const auto &map = getDependenciesMap(*kind);
-  return map.count(moduleName) > 0;
+  // If the module is a part of a framework, disambiguate to the framework's parent
+  if (llvm::sys::path::filename(parent) == "Modules") {
+    auto grandParent = llvm::sys::path::parent_path(parent);
+    if (llvm::sys::path::extension(grandParent) == ".framework") {
+      parent = llvm::sys::path::parent_path(grandParent);
+    }
+  }
+
+  return parent.str();
+}
+
+static bool moduleContainedInImportPathSet(const StringRef modulePath,
+                                           const llvm::StringSet<> &importPaths)
+{
+  return importPaths.contains(moduleBasePath(modulePath));
+}
+
+static bool moduleContainedInImportPathSet(const ModuleDependencies &module,
+                                           const llvm::StringSet<> &importPaths)
+{
+  std::string modulePath = "";
+  if (auto *swiftDep = module.getAsSwiftTextualModule()) {
+    if (swiftDep->swiftInterfaceFile)
+      modulePath = *(swiftDep->swiftInterfaceFile);
+    else {
+      // If we encountered a Swift textual dependency without an interface
+      // file, we are seeing the main scan module itself. This means that
+      // our search-path disambiguation is not necessary here.
+      return true;
+    }
+  } else if (auto *swiftBinaryDep = module.getAsSwiftBinaryModule()) {
+    modulePath = swiftBinaryDep->compiledModulePath;
+  } else if (auto *placehodlerDep = module.getAsPlaceholderDependencyModule()) {
+    // Placeholders are resolved as `true` because they are not associated with
+    // any specific search path.
+    return true;
+  } else if (auto *clangDep = module.getAsClangModule()) {
+    modulePath = clangDep->moduleMapFile;
+  }
+
+  if (moduleContainedInImportPathSet(modulePath, importPaths)) {
+    return true;
+  }
+  return false;
+}
+
+bool ModuleDependenciesCache::hasDependencies(
+    StringRef moduleName,
+    ModuleLookupSpecifics details) const {
+  if (!details.kind) {
+    return hasDependencies(moduleName,
+                           {ModuleDependenciesKind::SwiftTextual,
+                            details.currentSearchPaths}) ||
+        hasDependencies(moduleName,
+                        {ModuleDependenciesKind::SwiftBinary,
+                         details.currentSearchPaths}) ||
+        hasDependencies(moduleName,
+                        {ModuleDependenciesKind::SwiftPlaceholder,
+                         details.currentSearchPaths}) ||
+        hasDependencies(moduleName,
+                        {ModuleDependenciesKind::Clang,
+                         details.currentSearchPaths});
+  }
+
+  const auto &map = getDependenciesMap(*details.kind);
+  auto known = map.find(moduleName);
+  if (known != map.end()) {
+    assert(!known->second.empty());
+    for (auto &dep : known->second) {
+      if (moduleContainedInImportPathSet(dep, details.currentSearchPaths))
+        return true;
+    }
+    return false;
+  }
+  return false;
 }
 
 Optional<ModuleDependencies> ModuleDependenciesCache::findDependencies(
     StringRef moduleName,
-    Optional<ModuleDependenciesKind> kind) const {
-  if (!kind) {
+    ModuleLookupSpecifics details) const {
+  if (!details.kind) {
     if (auto swiftTextualDep = findDependencies(
-            moduleName, ModuleDependenciesKind::SwiftTextual))
+            moduleName,
+            {ModuleDependenciesKind::SwiftTextual, details.currentSearchPaths}))
       return swiftTextualDep;
     else if (auto swiftBinaryDep = findDependencies(
-            moduleName, ModuleDependenciesKind::SwiftBinary))
+            moduleName,
+            {ModuleDependenciesKind::SwiftBinary, details.currentSearchPaths}))
       return swiftBinaryDep;
     else if (auto swiftPlaceholderDep = findDependencies(
-            moduleName, ModuleDependenciesKind::SwiftPlaceholder))
+            moduleName,
+            {ModuleDependenciesKind::SwiftPlaceholder, details.currentSearchPaths}))
       return swiftPlaceholderDep;
     else
-      return findDependencies(moduleName, ModuleDependenciesKind::Clang);
+      return findDependencies(moduleName,
+                              {ModuleDependenciesKind::Clang, details.currentSearchPaths});
+  }
+
+  const auto &map = getDependenciesMap(*details.kind);
+  auto known = map.find(moduleName);
+  if (known != map.end()) {
+    assert(!known->second.empty());
+    for (auto &dep : known->second) {
+      if (moduleContainedInImportPathSet(dep, details.currentSearchPaths))
+        return dep;
+    }
+    return None;
+  }
+  return None;
+}
+
+Optional<ModuleDependenciesCache::ModuleDependenciesVector>
+ModuleDependenciesCache::findAllDependenciesIrrespectiveOfSearchPaths(
+    StringRef moduleName, Optional<ModuleDependenciesKind> kind) const {
+  if (!kind) {
+    if (auto swiftTextualDeps = findAllDependenciesIrrespectiveOfSearchPaths(
+            moduleName, ModuleDependenciesKind::SwiftTextual))
+      return swiftTextualDeps;
+    else if (auto swiftBinaryDeps =
+                 findAllDependenciesIrrespectiveOfSearchPaths(
+                     moduleName, ModuleDependenciesKind::SwiftBinary))
+      return swiftBinaryDeps;
+    else if (auto swiftPlaceholderDeps =
+                 findAllDependenciesIrrespectiveOfSearchPaths(
+                     moduleName, ModuleDependenciesKind::SwiftPlaceholder))
+      return swiftPlaceholderDeps;
+    else
+      return findAllDependenciesIrrespectiveOfSearchPaths(
+          moduleName, ModuleDependenciesKind::Clang);
   }
 
   const auto &map = getDependenciesMap(*kind);
   auto known = map.find(moduleName);
-  if (known != map.end())
+  if (known != map.end()) {
+    assert(!known->second.empty());
     return known->second;
-
+  }
   return None;
+}
+
+static std::string modulePathForVerification(const ModuleDependencies &module) {
+  std::string existingModulePath = "";
+  if (auto *swiftDep = module.getAsSwiftTextualModule()) {
+    if (swiftDep->swiftInterfaceFile)
+      existingModulePath = *(swiftDep->swiftInterfaceFile);
+  } else if (auto *swiftBinaryDep = module.getAsSwiftBinaryModule()) {
+    existingModulePath = swiftBinaryDep->compiledModulePath;
+  } else if (auto *clangDep = module.getAsClangModule()) {
+    existingModulePath = clangDep->moduleMapFile;
+  }
+  return existingModulePath;
 }
 
 void ModuleDependenciesCache::recordDependencies(
@@ -205,10 +327,22 @@ void ModuleDependenciesCache::recordDependencies(
     ModuleDependencies dependencies) {
   auto kind = dependencies.getKind();
   auto &map = getDependenciesMap(kind);
-  assert(map.count(moduleName) == 0 && "Already added to map");
-  map.insert({moduleName, std::move(dependencies)});
-
-  AllModules.push_back({moduleName.str(), kind});
+  // Cache may already have a dependency for this module
+  if (map.count(moduleName) != 0) {
+    // Ensure that the existing dependencies objects are at a different path.
+    // i.e. do not record duplicate dependencies.
+    auto newModulePath = modulePathForVerification(dependencies);
+    bool newEntry = true;
+    for (auto &existingDeps : map[moduleName]) {
+      if (modulePathForVerification(existingDeps) == newModulePath)
+        newEntry = false;
+    }
+    if (newEntry)
+      map[moduleName].emplace_back(std::move(dependencies));
+  } else {
+    map.insert({moduleName, ModuleDependenciesVector{std::move(dependencies)}});
+    AllModules.push_back({moduleName.str(), kind});
+  }
 }
 
 void ModuleDependenciesCache::updateDependencies(
@@ -216,5 +350,6 @@ void ModuleDependenciesCache::updateDependencies(
   auto &map = getDependenciesMap(moduleID.second);
   auto known = map.find(moduleID.first);
   assert(known != map.end() && "Not yet added to map");
-  known->second = std::move(dependencies);
+  assert(known->second.size() == 1 && "Cannot update dependency with multiple candidates.");
+  known->second[0] = std::move(dependencies);
 }

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -197,11 +197,14 @@ void ClangImporter::recordModuleDependencies(
     std::string PCMPath;
     std::string ModuleMapPath;
   };
+  auto &ctx = Impl.SwiftContext;
+  auto currentSwiftSearchPathSet = ctx.getAllModuleSearchPathsSet();
 
   for (const auto &clangModuleDep : clangDependencies.DiscoveredModules) {
     // If we've already cached this information, we're done.
-    if (cache.hasDependencies(clangModuleDep.ModuleName,
-                              ModuleDependenciesKind::Clang))
+    if (cache.hasDependencies(
+                    clangModuleDep.ModuleName,
+                    {ModuleDependenciesKind::Clang, currentSwiftSearchPathSet}))
       continue;
 
     // File dependencies for this module.
@@ -303,9 +306,12 @@ void ClangImporter::recordModuleDependencies(
 Optional<ModuleDependencies> ClangImporter::getModuleDependencies(
     StringRef moduleName, ModuleDependenciesCache &cache,
     InterfaceSubContextDelegate &delegate) {
+  auto &ctx = Impl.SwiftContext;
+  auto currentSwiftSearchPathSet = ctx.getAllModuleSearchPathsSet();
   // Check whether there is already a cached result.
   if (auto found = cache.findDependencies(
-          moduleName, ModuleDependenciesKind::Clang))
+          moduleName,
+          {ModuleDependenciesKind::Clang, currentSwiftSearchPathSet}))
     return found;
 
   // Retrieve or create the shared state.
@@ -319,7 +325,7 @@ Optional<ModuleDependencies> ClangImporter::getModuleDependencies(
   }
 
   // Determine the command-line arguments for dependency scanning.
-  auto &ctx = Impl.SwiftContext;
+
   std::vector<std::string> commandLineArgs =
     getClangDepScanningInvocationArguments(ctx, *importHackFile);
 
@@ -338,14 +344,19 @@ Optional<ModuleDependencies> ClangImporter::getModuleDependencies(
 
   // Record module dependencies for each module we found.
   recordModuleDependencies(cache, *clangDependencies);
-  return cache.findDependencies(moduleName, ModuleDependenciesKind::Clang);
+            return cache.findDependencies(
+                    moduleName,
+                    {ModuleDependenciesKind::Clang, currentSwiftSearchPathSet});
 }
 
 bool ClangImporter::addBridgingHeaderDependencies(
     StringRef moduleName,
     ModuleDependenciesCache &cache) {
+  auto &ctx = Impl.SwiftContext;
+  auto currentSwiftSearchPathSet = ctx.getAllModuleSearchPathsSet();
   auto targetModule = *cache.findDependencies(
-      moduleName, ModuleDependenciesKind::SwiftTextual);
+              moduleName,
+              {ModuleDependenciesKind::SwiftTextual,currentSwiftSearchPathSet});
 
   // If we've already recorded bridging header dependencies, we're done.
   auto swiftDeps = targetModule.getAsSwiftTextualModule();
@@ -360,7 +371,6 @@ bool ClangImporter::addBridgingHeaderDependencies(
   std::string bridgingHeader = *targetModule.getBridgingHeader();
 
   // Determine the command-line arguments for dependency scanning.
-  auto &ctx = Impl.SwiftContext;
   std::vector<std::string> commandLineArgs =
     getClangDepScanningInvocationArguments(ctx, bridgingHeader);
 

--- a/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
+++ b/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
@@ -682,7 +682,10 @@ void Serializer::writeModuleInfo(ModuleDependencyID moduleID,
       getIdentifier(moduleID.first),
       getArray(moduleID, ModuleIdentifierArrayKind::DirectDependencies));
 
-  if (auto swiftTextDeps = dependencyInfo.getAsSwiftTextualModule()) {
+  switch (dependencyInfo.getKind()) {
+  case swift::ModuleDependenciesKind::SwiftTextual: {
+    auto swiftTextDeps = dependencyInfo.getAsSwiftTextualModule();
+    assert(swiftTextDeps);
     unsigned swiftInterfaceFileId =
         swiftTextDeps->swiftInterfaceFile
             ? getIdentifier(swiftTextDeps->swiftInterfaceFile.getValue())
@@ -703,24 +706,33 @@ void Serializer::writeModuleInfo(ModuleDependencyID moduleID,
         getArray(moduleID, ModuleIdentifierArrayKind::BridgingSourceFiles),
         getArray(moduleID,
                  ModuleIdentifierArrayKind::BridgingModuleDependencies));
-
-  } else if (auto swiftBinDeps = dependencyInfo.getAsSwiftBinaryModule()) {
+    break;
+  }
+  case swift::ModuleDependenciesKind::SwiftBinary: {
+    auto swiftBinDeps = dependencyInfo.getAsSwiftBinaryModule();
+    assert(swiftBinDeps);
     SwiftBinaryModuleDetailsLayout::emitRecord(
         Out, ScratchRecord, AbbrCodes[SwiftBinaryModuleDetailsLayout::Code],
         getIdentifier(swiftBinDeps->compiledModulePath),
         getIdentifier(swiftBinDeps->moduleDocPath),
         getIdentifier(swiftBinDeps->sourceInfoPath), swiftBinDeps->isFramework);
 
-  } else if (auto swiftPHDeps =
-                 dependencyInfo.getAsPlaceholderDependencyModule()) {
+    break;
+  }
+  case swift::ModuleDependenciesKind::SwiftPlaceholder: {
+    auto swiftPHDeps = dependencyInfo.getAsPlaceholderDependencyModule();
+    assert(swiftPHDeps);
     SwiftPlaceholderModuleDetailsLayout::emitRecord(
         Out, ScratchRecord,
         AbbrCodes[SwiftPlaceholderModuleDetailsLayout::Code],
         getIdentifier(swiftPHDeps->compiledModulePath),
         getIdentifier(swiftPHDeps->moduleDocPath),
         getIdentifier(swiftPHDeps->sourceInfoPath));
-
-  } else if (auto clangDeps = dependencyInfo.getAsClangModule()) {
+    break;
+  }
+  case swift::ModuleDependenciesKind::Clang: {
+    auto clangDeps = dependencyInfo.getAsClangModule();
+    assert(clangDeps);
     ClangModuleDetailsLayout::emitRecord(
         Out, ScratchRecord, AbbrCodes[ClangModuleDetailsLayout::Code],
         getIdentifier(clangDeps->moduleMapFile),
@@ -728,8 +740,8 @@ void Serializer::writeModuleInfo(ModuleDependencyID moduleID,
         getArray(moduleID, ModuleIdentifierArrayKind::NonPathCommandLine),
         getArray(moduleID, ModuleIdentifierArrayKind::FileDependencies));
 
-  } else {
-    llvm_unreachable("Unexpected module dependency kind.");
+    break;
+  }
   }
 }
 
@@ -802,52 +814,69 @@ unsigned Serializer::getArray(ModuleDependencyID moduleID,
 
 void Serializer::collectStringsAndArrays(const ModuleDependenciesCache &cache) {
   for (auto &moduleID : cache.getAllModules()) {
-    auto dependencyInfo =
-        cache.findDependencies(moduleID.first, moduleID.second);
-    assert(dependencyInfo.hasValue() && "Expected dependency info.");
-    // Add the module's name
-    addIdentifier(moduleID.first);
-    // Add the module's dependencies
-    addArray(moduleID, ModuleIdentifierArrayKind::DirectDependencies,
-             dependencyInfo->getModuleDependencies());
+    auto dependencyInfos = cache.findAllDependenciesIrrespectiveOfSearchPaths(
+        moduleID.first, moduleID.second);
+    assert(dependencyInfos.hasValue() && "Expected dependency info.");
+    for (auto &dependencyInfo : *dependencyInfos) {
+      // Add the module's name
+      addIdentifier(moduleID.first);
+      // Add the module's dependencies
+      addArray(moduleID, ModuleIdentifierArrayKind::DirectDependencies,
+               dependencyInfo.getModuleDependencies());
 
-    // Add the dependency-kind-specific data
-    if (auto swiftTextDeps = dependencyInfo->getAsSwiftTextualModule()) {
-      if (swiftTextDeps->swiftInterfaceFile)
-        addIdentifier(swiftTextDeps->swiftInterfaceFile.getValue());
-      addArray(moduleID, ModuleIdentifierArrayKind::CompiledModuleCandidates,
-               swiftTextDeps->compiledModuleCandidates);
-      addArray(moduleID, ModuleIdentifierArrayKind::BuildCommandLine,
-               swiftTextDeps->buildCommandLine);
-      addArray(moduleID, ModuleIdentifierArrayKind::ExtraPCMArgs,
-               swiftTextDeps->extraPCMArgs);
-      addIdentifier(swiftTextDeps->contextHash);
-      if (swiftTextDeps->bridgingHeaderFile)
-        addIdentifier(swiftTextDeps->bridgingHeaderFile.getValue());
-      addArray(moduleID, ModuleIdentifierArrayKind::SourceFiles,
-               swiftTextDeps->sourceFiles);
-      addArray(moduleID, ModuleIdentifierArrayKind::BridgingSourceFiles,
-               swiftTextDeps->bridgingSourceFiles);
-      addArray(moduleID, ModuleIdentifierArrayKind::BridgingModuleDependencies,
-               swiftTextDeps->bridgingModuleDependencies);
-    } else if (auto swiftBinDeps = dependencyInfo->getAsSwiftBinaryModule()) {
-      addIdentifier(swiftBinDeps->compiledModulePath);
-      addIdentifier(swiftBinDeps->moduleDocPath);
-      addIdentifier(swiftBinDeps->sourceInfoPath);
-    } else if (auto swiftPHDeps =
-                   dependencyInfo->getAsPlaceholderDependencyModule()) {
-      addIdentifier(swiftPHDeps->compiledModulePath);
-      addIdentifier(swiftPHDeps->moduleDocPath);
-      addIdentifier(swiftPHDeps->sourceInfoPath);
-    } else if (auto clangDeps = dependencyInfo->getAsClangModule()) {
-      addIdentifier(clangDeps->moduleMapFile);
-      addIdentifier(clangDeps->contextHash);
-      addArray(moduleID, ModuleIdentifierArrayKind::NonPathCommandLine,
-               clangDeps->nonPathCommandLine);
-      addArray(moduleID, ModuleIdentifierArrayKind::FileDependencies,
-               clangDeps->fileDependencies);
-    } else {
-      llvm_unreachable("Unexpected module dependency kind.");
+      // Add the dependency-kind-specific data
+      switch (dependencyInfo.getKind()) {
+      case swift::ModuleDependenciesKind::SwiftTextual: {
+        auto swiftTextDeps = dependencyInfo.getAsSwiftTextualModule();
+        assert(swiftTextDeps);
+        if (swiftTextDeps->swiftInterfaceFile)
+          addIdentifier(swiftTextDeps->swiftInterfaceFile.getValue());
+        addArray(moduleID, ModuleIdentifierArrayKind::CompiledModuleCandidates,
+                 swiftTextDeps->compiledModuleCandidates);
+        addArray(moduleID, ModuleIdentifierArrayKind::BuildCommandLine,
+                 swiftTextDeps->buildCommandLine);
+        addArray(moduleID, ModuleIdentifierArrayKind::ExtraPCMArgs,
+                 swiftTextDeps->extraPCMArgs);
+        addIdentifier(swiftTextDeps->contextHash);
+        if (swiftTextDeps->bridgingHeaderFile)
+          addIdentifier(swiftTextDeps->bridgingHeaderFile.getValue());
+        addArray(moduleID, ModuleIdentifierArrayKind::SourceFiles,
+                 swiftTextDeps->sourceFiles);
+        addArray(moduleID, ModuleIdentifierArrayKind::BridgingSourceFiles,
+                 swiftTextDeps->bridgingSourceFiles);
+        addArray(moduleID,
+                 ModuleIdentifierArrayKind::BridgingModuleDependencies,
+                 swiftTextDeps->bridgingModuleDependencies);
+        break;
+      }
+      case swift::ModuleDependenciesKind::SwiftBinary: {
+        auto swiftBinDeps = dependencyInfo.getAsSwiftBinaryModule();
+        assert(swiftBinDeps);
+        addIdentifier(swiftBinDeps->compiledModulePath);
+        addIdentifier(swiftBinDeps->moduleDocPath);
+        addIdentifier(swiftBinDeps->sourceInfoPath);
+        break;
+      }
+      case swift::ModuleDependenciesKind::SwiftPlaceholder: {
+        auto swiftPHDeps = dependencyInfo.getAsPlaceholderDependencyModule();
+        assert(swiftPHDeps);
+        addIdentifier(swiftPHDeps->compiledModulePath);
+        addIdentifier(swiftPHDeps->moduleDocPath);
+        addIdentifier(swiftPHDeps->sourceInfoPath);
+        break;
+      }
+      case swift::ModuleDependenciesKind::Clang: {
+        auto clangDeps = dependencyInfo.getAsClangModule();
+        assert(clangDeps);
+        addIdentifier(clangDeps->moduleMapFile);
+        addIdentifier(clangDeps->contextHash);
+        addArray(moduleID, ModuleIdentifierArrayKind::NonPathCommandLine,
+                 clangDeps->nonPathCommandLine);
+        addArray(moduleID, ModuleIdentifierArrayKind::FileDependencies,
+                 clangDeps->fileDependencies);
+        break;
+      }
+      }
     }
   }
 }
@@ -888,10 +917,12 @@ void Serializer::writeInterModuleDependenciesCache(
 
   // Write the core graph
   for (auto &moduleID : cache.getAllModules()) {
-    auto dependencyInfo =
-        cache.findDependencies(moduleID.first, moduleID.second);
-    assert(dependencyInfo.hasValue() && "Expected dependency info.");
-    writeModuleInfo(moduleID, dependencyInfo.getValue());
+    auto dependencyInfos = cache.findAllDependenciesIrrespectiveOfSearchPaths(
+        moduleID.first, moduleID.second);
+    assert(dependencyInfos.hasValue() && "Expected dependency info.");
+    for (auto &dependencyInfo : *dependencyInfos) {
+      writeModuleInfo(moduleID, dependencyInfo);
+    }
   }
 
   return;

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -165,15 +165,19 @@ ErrorOr<ModuleDependencies> ModuleDependencyScanner::scanInterfaceFile(
 Optional<ModuleDependencies> SerializedModuleLoaderBase::getModuleDependencies(
     StringRef moduleName, ModuleDependenciesCache &cache,
     InterfaceSubContextDelegate &delegate) {
+  auto currentSearchPathSet = Ctx.getAllModuleSearchPathsSet();
   // Check whether we've cached this result.
   if (auto found = cache.findDependencies(
-          moduleName, ModuleDependenciesKind::SwiftTextual))
+           moduleName,
+           {ModuleDependenciesKind::SwiftTextual, currentSearchPathSet}))
     return found;
   if (auto found = cache.findDependencies(
-          moduleName, ModuleDependenciesKind::SwiftBinary))
+            moduleName,
+            {ModuleDependenciesKind::SwiftBinary, currentSearchPathSet}))
     return found;
   if (auto found = cache.findDependencies(
-          moduleName, ModuleDependenciesKind::SwiftPlaceholder))
+            moduleName,
+            {ModuleDependenciesKind::SwiftPlaceholder, currentSearchPathSet}))
     return found;
 
   auto moduleId = Ctx.getIdentifier(moduleName);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -88,18 +88,10 @@ Optional<bool> forEachModuleSearchPath(
   // Apple platforms have extra implicit framework search paths:
   // $SDKROOT/System/Library/Frameworks/ and $SDKROOT/Library/Frameworks/.
   if (Ctx.LangOpts.Target.isOSDarwin()) {
-    SmallString<128> scratch;
-    scratch = Ctx.SearchPathOpts.SDKPath;
-    llvm::sys::path::append(scratch, "System", "Library", "Frameworks");
-    if (auto result =
-            callback(scratch, SearchPathKind::Framework, /*isSystem=*/true))
-      return result;
-
-    scratch = Ctx.SearchPathOpts.SDKPath;
-    llvm::sys::path::append(scratch, "Library", "Frameworks");
-    if (auto result =
-            callback(scratch, SearchPathKind::Framework, /*isSystem=*/true))
-      return result;
+    for (const auto &path : Ctx.getDarwinImplicitFrameworkSearchPaths())
+      if (auto result =
+          callback(path, SearchPathKind::Framework, /*isSystem=*/true))
+        return result;
   }
 
   for (auto importPath : Ctx.SearchPathOpts.RuntimeLibraryImportPaths) {

--- a/test/ScanDependencies/Inputs/SwiftDifferent/A.swiftinterface
+++ b/test/ScanDependencies/Inputs/SwiftDifferent/A.swiftinterface
@@ -1,0 +1,5 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A
+import Swift
+
+public func FuncAA() { }

--- a/test/ScanDependencies/module_deps_different_paths_no_reuse.swift
+++ b/test/ScanDependencies/module_deps_different_paths_no_reuse.swift
@@ -1,0 +1,50 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+
+// This test ensures that subsequent invocations of the dependency scanner that re-use previous cache state do not re-use cache entries that contain modules found outside of the current scanner invocation's search paths.
+
+// Run the scanner once, emitting the serialized scanner cache, with one set of search paths
+// RUN: %target-swift-frontend -scan-dependencies -serialize-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/clang-module-cache %s -o %t/deps_initial.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
+// RUN: %FileCheck -input-file %t/deps_initial.json %s -check-prefix CHECK-INITIAL-SCAN
+
+// Run the scanner again, but now re-using previously-serialized cache and using a different search path for Swift modules
+// RUN: %target-swift-frontend -scan-dependencies -load-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/SwiftDifferent -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
+// RUN: %FileCheck -input-file %t/deps.json %s -check-prefix CHECK-DIFFERENT
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import A
+
+// CHECK-INITIAL-SCAN:           "modulePath": "A.swiftmodule",
+// CHECK-INITIAL-SCAN-NEXT:      "sourceFiles": [
+// CHECK-INITIAL-SCAN-NEXT:      ],
+// CHECK-INITIAL-SCAN-NEXT:      "directDependencies": [
+// CHECK-INITIAL-SCAN-NEXT:        {
+// CHECK-INITIAL-SCAN-NEXT:          "clang": "A"
+// CHECK-INITIAL-SCAN-NEXT:        },
+// CHECK-INITIAL-SCAN-NEXT:        {
+// CHECK-INITIAL-SCAN-NEXT:          "swift": "Swift"
+// CHECK-INITIAL-SCAN-NEXT:        },
+// CHECK-INITIAL-SCAN-NEXT:        {
+// CHECK-INITIAL-SCAN-NEXT:          "swift": "SwiftOnoneSupport"
+// CHECK-INITIAL-SCAN-NEXT:        }
+// CHECK-INITIAL-SCAN-NEXT:      ],
+// CHECK-INITIAL-SCAN-NEXT:      "details": {
+// CHECK-INITIAL-SCAN-NEXT:        "swift": {
+// CHECK-INITIAL-SCAN-NEXT:          "moduleInterfacePath": "{{.*}}/Swift/A.swiftinterface",
+
+// CHECK-DIFFERENT:           "modulePath": "A.swiftmodule",
+// CHECK-DIFFERENT-NEXT:      "sourceFiles": [
+// CHECK-DIFFERENT-NEXT:      ],
+// CHECK-DIFFERENT-NEXT:      "directDependencies": [
+// CHECK-DIFFERENT-NEXT:        {
+// CHECK-DIFFERENT-NEXT:          "swift": "Swift"
+// CHECK-DIFFERENT-NEXT:        },
+// CHECK-DIFFERENT-NEXT:        {
+// CHECK-DIFFERENT-NEXT:          "swift": "SwiftOnoneSupport"
+// CHECK-DIFFERENT-NEXT:        }
+// CHECK-DIFFERENT-NEXT:      ],
+// CHECK-DIFFERENT-NEXT:      "details": {
+// CHECK-DIFFERENT-NEXT:        "swift": {
+// CHECK-DIFFERENT-NEXT:          "moduleInterfacePath": "{{.*}}/SwiftDifferent/A.swiftinterface",


### PR DESCRIPTION
The dependency scanner's cache persists across different queries and answering a subsequent query's module lookup with a module not in the query's search path is not correct.

For example, suppose we are looking for a Swift module `Foo` with a set of search paths `SP`.
And dependency scanner cache already contains a module `Foo`, for which we found an interface file at location `L`. If `L`∉`SP`, then we cannot re-use the cached entry because we’d be resolving the scanning query to a filesystem location that the current scanning context is not aware of.

Resolves rdar://81175942
