### PR TITLE
[Sema] Improve diagnostic handling of multiple trailing closures

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1267,7 +1267,8 @@ ERROR(extra_argument_named,none,
 ERROR(extra_argument_positional,none,
       "extra argument in call", ())
 ERROR(extra_arguments_in_call,none,
-      "extra arguments at positions %0 in call", (StringRef))
+      "extra %select{arguments|trailing closures}0 at positions %1 in call",
+       (bool, StringRef))
 ERROR(extra_argument_to_nullary_call,none,
       "argument passed to call that takes no arguments", ())
 ERROR(extra_trailing_closure_in_call,none,

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -243,7 +243,32 @@ namespace swift {
     SmallVector<SourceLoc, 4> labelLocs;
     SourceLoc lParenLoc;
     SourceLoc rParenLoc;
-    bool hasTrailingClosure = false;
+    Optional<unsigned> unlabeledTrailingClosureIdx;
+
+    /// The number of trailing closures in the argument list.
+    unsigned getNumTrailingClosures() const {
+      if (!unlabeledTrailingClosureIdx)
+        return 0;
+      return args.size() - *unlabeledTrailingClosureIdx;
+    }
+
+    /// Whether any unlabeled or labeled trailing closures are present.
+    bool hasAnyTrailingClosures() const {
+      return unlabeledTrailingClosureIdx.hasValue();
+    }
+
+    /// Whether the given index is for an unlabeled trailing closure.
+    bool isUnlabeledTrailingClosureIdx(unsigned i) const {
+      return unlabeledTrailingClosureIdx && *unlabeledTrailingClosureIdx == i;
+    }
+
+    /// Whether the given index is for a labeled trailing closure in an
+    /// argument list with multiple trailing closures.
+    bool isLabeledTrailingClosureIdx(unsigned i) const {
+      if (!unlabeledTrailingClosureIdx)
+        return false;
+      return i > *unlabeledTrailingClosureIdx && i < args.size();
+    }
   };
 
   /// When applying a solution to a constraint system, the type checker rewrites

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5837,8 +5837,9 @@ Expr *ExprRewriter::coerceCallArguments(
   // Apply labels to arguments.
   AnyFunctionType::relabelParams(args, argLabels);
 
-  auto unlabeledTrailingClosureIndex =
+  auto oldTrailingClosureIndex =
       arg->getUnlabeledTrailingClosureIndexOfPackedArgument();
+  Optional<unsigned> newTrailingClosureIndex;
 
   // Determine the parameter bindings that were applied.
   auto *locatorPtr = cs.getConstraintLocator(locator);
@@ -5912,6 +5913,12 @@ Expr *ExprRewriter::coerceCallArguments(
         auto arg = getArg(argIdx);
         auto argType = cs.getType(arg);
 
+        // Update the trailing closure index if needed.
+        if (oldTrailingClosureIndex && *oldTrailingClosureIndex == argIdx) {
+          assert(!newTrailingClosureIndex);
+          newTrailingClosureIndex = newArgs.size();
+        }
+
         // If the argument type exactly matches, this just works.
         if (argType->isEqual(param.getPlainType())) {
           variadicArgs.push_back(arg);
@@ -5973,6 +5980,12 @@ Expr *ExprRewriter::coerceCallArguments(
     unsigned argIdx = parameterBindings[paramIdx].front();
     auto arg = getArg(argIdx);
     auto argType = cs.getType(arg);
+
+    // Update the trailing closure index if needed.
+    if (oldTrailingClosureIndex && *oldTrailingClosureIndex == argIdx) {
+      assert(!newTrailingClosureIndex);
+      newTrailingClosureIndex = newArgs.size();
+    }
 
     // Save the original label location.
     newLabelLocs.push_back(getLabelLoc(argIdx));
@@ -6089,6 +6102,9 @@ Expr *ExprRewriter::coerceCallArguments(
   assert(newArgs.size() == newParams.size());
   assert(newArgs.size() == newLabels.size());
   assert(newArgs.size() == newLabelLocs.size());
+  assert(oldTrailingClosureIndex.hasValue() ==
+         newTrailingClosureIndex.hasValue());
+  assert(!newTrailingClosureIndex || *newTrailingClosureIndex < newArgs.size());
 
   // This is silly. SILGen gets confused if a 'self' parameter is wrapped
   // in a ParenExpr sometimes.
@@ -6096,7 +6112,7 @@ Expr *ExprRewriter::coerceCallArguments(
       (params[0].getValueOwnership() == ValueOwnership::Default ||
        params[0].getValueOwnership() == ValueOwnership::InOut)) {
     assert(newArgs.size() == 1);
-    assert(!unlabeledTrailingClosureIndex);
+    assert(!newTrailingClosureIndex);
     return newArgs[0];
   }
 
@@ -6111,7 +6127,7 @@ Expr *ExprRewriter::coerceCallArguments(
       bool isImplicit = arg->isImplicit();
       arg = new (ctx) ParenExpr(
           lParenLoc, newArgs[0], rParenLoc,
-          static_cast<bool>(unlabeledTrailingClosureIndex));
+          static_cast<bool>(newTrailingClosureIndex));
       arg->setImplicit(isImplicit);
     }
   } else {
@@ -6126,7 +6142,7 @@ Expr *ExprRewriter::coerceCallArguments(
     } else {
       // Build a new TupleExpr, re-using source location information.
       arg = TupleExpr::create(ctx, lParenLoc, rParenLoc, newArgs, newLabels,
-                              newLabelLocs, unlabeledTrailingClosureIndex,
+                              newLabelLocs, newTrailingClosureIndex,
                               /*implicit=*/arg->isImplicit());
     }
   }

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -288,18 +288,18 @@ public:
         new (C) ParenExpr(argList.lParenLoc,
                           argList.args[0],
                           argList.rParenLoc,
-                          argList.hasTrailingClosure);
+                          argList.hasAnyTrailingClosures());
       result->setImplicit();
       return result;
     }
 
     return TupleExpr::create(C,
                              argList.lParenLoc,
+                             argList.rParenLoc,
                              argList.args,
                              argList.labels,
                              argList.labelLocs,
-                             argList.rParenLoc,
-                             argList.hasTrailingClosure,
+                             argList.unlabeledTrailingClosureIdx,
                              /*implicit=*/true);
   }
 

--- a/test/Constraints/argument_matching.swift
+++ b/test/Constraints/argument_matching.swift
@@ -1762,3 +1762,23 @@ func rdar70764991() {
     bar(str, S.foo) // expected-error {{unnamed argument #1 must precede unnamed argument #2}}  {{9-12=}} {{14-14=str}}
   }
 }
+
+func testExtraTrailingClosure() {
+  func foo() {}
+  foo() {} // expected-error@:9 {{extra trailing closure passed in call}}
+  foo {} // expected-error@:7 {{extra trailing closure passed in call}}
+  foo {} x: {} // expected-error@:7 {{argument passed to call that takes no arguments}}
+
+  func bar(_ x: Int) {} // expected-note 2{{'bar' declared here}}
+  bar(5) {} // expected-error@:10 {{extra trailing closure passed in call}}
+  bar(0) {} x: {} // expected-error@:6 {{extra trailing closures at positions #2, #3 in call}}
+  bar(5, "") {} // expected-error@:6 {{extra arguments at positions #2, #3 in call}}
+
+  func baz(_ fn: () -> Void) {} // expected-note {{'baz' declared here}}
+  baz {} x: {} // expected-error@:13 {{extra trailing closure passed in call}}
+  baz({}) {} // expected-error@:11 {{extra trailing closure passed in call}}
+  baz({}) {} y: {} // expected-error@:6 {{extra trailing closures at positions #2, #3 in call}}
+
+  func qux(x: () -> Void, y: () -> Void, z: () -> Void) {} // expected-note {{'qux(x:y:z:)' declared here}}
+  qux() {} m: {} y: {} n: {} z: {} o: {} // expected-error@:6 {{extra trailing closures at positions #2, #4, #6 in call}}
+}

--- a/test/Parse/trailing_closures.swift
+++ b/test/Parse/trailing_closures.swift
@@ -93,28 +93,16 @@ func test_multiple_trailing_syntax_without_labels() {
   func mixed_args_1(a: () -> Void, _: () -> Void) {}
   func mixed_args_2(_: () -> Void, a: () -> Void, _: () -> Void) {} // expected-note {{'mixed_args_2(_:a:_:)' declared here}}
 
-  mixed_args_1
-    {}
-    _: {}
+  mixed_args_1 {} _: {}
 
-  mixed_args_1
-    {}  // expected-error {{incorrect argument labels in call (have '_:a:', expected 'a:_:')}}
-    a: {}
+  mixed_args_1 {} a: {}  // expected-error@:16 {{incorrect argument labels in call (have '_:a:', expected 'a:_:')}}
 
-  mixed_args_2
-    {}
-    a: {}
-    _: {}
+  mixed_args_2 {} a: {} _: {}
 
-  mixed_args_2
-    {} // expected-error {{missing argument for parameter 'a' in call}}
-    _: {}
+  mixed_args_2 {} _: {} // expected-error@:18 {{missing argument for parameter 'a' in call}}
 
   // FIXME: not a good diagnostic
-  mixed_args_2
-    {}  // expected-error {{missing argument label 'a:' in call}}
-    _: {}
-    _: {}
+  mixed_args_2 {} _: {} _: {} // expected-error@:16 {{missing argument label 'a:' in call}}
 }
 
 func produce(fn: () -> Int?, default d: () -> Int) -> Int { // expected-note {{declared here}}

--- a/test/Parse/trailing_closures.swift
+++ b/test/Parse/trailing_closures.swift
@@ -82,7 +82,7 @@ func test_multiple_trailing_syntax_without_labels() {
 
   fn {} g: {} // Ok
 
-  fn {} _: {} // expected-error {{missing argument labels 'f:g:' in call}}
+  fn {} _: {} // expected-error {{missing argument label 'g:' in call}} {{9-10=g}} {{none}}
 
   fn {} g: <#T##() -> Void#> // expected-error {{editor placeholder in source file}}
 
@@ -95,14 +95,13 @@ func test_multiple_trailing_syntax_without_labels() {
 
   mixed_args_1 {} _: {}
 
-  mixed_args_1 {} a: {}  // expected-error@:16 {{incorrect argument labels in call (have '_:a:', expected 'a:_:')}}
+  mixed_args_1 {} a: {}  // expected-error@:16 {{extraneous argument label 'a:' in call}} {{19-20=_}} {{none}}
 
   mixed_args_2 {} a: {} _: {}
 
-  mixed_args_2 {} _: {} // expected-error@:18 {{missing argument for parameter 'a' in call}}
+  mixed_args_2 {} _: {} // expected-error@:18 {{missing argument for parameter 'a' in call}} {{18-18= a: <#() -> Void#>}} {{none}}
 
-  // FIXME: not a good diagnostic
-  mixed_args_2 {} _: {} _: {} // expected-error@:16 {{missing argument label 'a:' in call}}
+  mixed_args_2 {} _: {} _: {} // expected-error@:16 {{missing argument label 'a:' in call}} {{19-20=a}} {{none}}
 }
 
 func produce(fn: () -> Int?, default d: () -> Int) -> Int { // expected-note {{declared here}}

--- a/test/Parse/trailing_closures.swift
+++ b/test/Parse/trailing_closures.swift
@@ -116,7 +116,7 @@ func f() -> Int { 42 }
 // This should be interpreted as a trailing closure, instead of being 
 // interpreted as a computed property with undesired initial value.
 struct TrickyTest {
-    var x : Int = f () { // expected-error {{argument passed to call that takes no arguments}}
+    var x : Int = f () { // expected-error {{extra trailing closure passed in call}}
         3
     }
 }

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -1128,3 +1128,54 @@ class UnavailableNoArgsSubclassInit: UnavailableNoArgsSuperclassInit {
   // expected-error@-1 {{'init()' is unavailable}}
   // expected-note@-2 {{call to unavailable initializer 'init()' from superclass 'UnavailableNoArgsSuperclassInit' occurs implicitly at the end of this initializer}}
 }
+
+struct TypeWithTrailingClosures {
+  func twoTrailingClosures(a: () -> Void, b: () -> Void) {}
+  func threeTrailingClosures(a: () -> Void, b: () -> Void, c: () -> Void) {}
+  func threeUnlabeledTrailingClosures(_ a: () -> Void, _ b: () -> Void, _ c: () -> Void) {}
+  func variadicTrailingClosures(a: (() -> Void)..., b: Int = 0, c: Int = 0) {}
+}
+
+@available(*, deprecated, renamed: "TypeWithTrailingClosures.twoTrailingClosures(self:a:b:)")
+func twoTrailingClosures(_ x: TypeWithTrailingClosures, a: () -> Void, b: () -> Void) {}
+
+@available(*, deprecated, renamed: "TypeWithTrailingClosures.twoTrailingClosures(self:a:b:)")
+func twoTrailingClosuresWithDefaults(x: TypeWithTrailingClosures, y: Int = 0, z: Int = 0, a: () -> Void, b: () -> Void) {}
+
+@available(*, deprecated, renamed: "TypeWithTrailingClosures.threeTrailingClosures(self:a:b:c:)")
+func threeTrailingClosures(_ x: TypeWithTrailingClosures, a: () -> Void, b: () -> Void, c: () -> Void) {}
+
+@available(*, deprecated, renamed: "TypeWithTrailingClosures.threeTrailingClosures(self:a:b:c:)")
+func threeTrailingClosuresDiffLabels(_: TypeWithTrailingClosures, x: () -> Void, y: () -> Void, z: () -> Void) {}
+
+@available(*, deprecated, renamed: "TypeWithTrailingClosures.threeUnlabeledTrailingClosures(self:_:_:_:)")
+func threeTrailingClosuresRemoveLabels(_ x: TypeWithTrailingClosures, a: () -> Void, b: () -> Void, c: () -> Void) {}
+
+@available(*, deprecated, renamed: "TypeWithTrailingClosures.variadicTrailingClosures(self:a:b:c:)")
+func variadicTrailingClosures(_ x: TypeWithTrailingClosures, a: (() -> Void)...) {}
+
+func testMultipleTrailingClosures(_ x: TypeWithTrailingClosures) {
+  twoTrailingClosures(x) {} b: {} // expected-warning {{'twoTrailingClosures(_:a:b:)' is deprecated: replaced by instance method 'TypeWithTrailingClosures.twoTrailingClosures(a:b:)'}}
+  // expected-note@-1 {{use 'TypeWithTrailingClosures.twoTrailingClosures(a:b:)' instead}} {{3-22=x.twoTrailingClosures}} {{23-24=}} {{none}}
+  x.twoTrailingClosures() {} b: {}
+
+  twoTrailingClosuresWithDefaults(x: x) {} b: {} // expected-warning {{'twoTrailingClosuresWithDefaults(x:y:z:a:b:)' is deprecated: replaced by instance method 'TypeWithTrailingClosures.twoTrailingClosures(a:b:)'}}
+  // expected-note@-1 {{use 'TypeWithTrailingClosures.twoTrailingClosures(a:b:)' instead}} {{3-34=x.twoTrailingClosures}} {{35-39=}} {{none}}
+  x.twoTrailingClosures() {} b: {}
+
+  threeTrailingClosures(x, a: {}) {} c: {} // expected-warning {{'threeTrailingClosures(_:a:b:c:)' is deprecated: replaced by instance method 'TypeWithTrailingClosures.threeTrailingClosures(a:b:c:)'}}
+  // expected-note@-1 {{use 'TypeWithTrailingClosures.threeTrailingClosures(a:b:c:)' instead}} {{3-24=x.threeTrailingClosures}} {{25-28=}} {{none}}
+  x.threeTrailingClosures(a: {}) {} c: {}
+
+  threeTrailingClosuresDiffLabels(x, x: {}) {} z: {} // expected-warning {{'threeTrailingClosuresDiffLabels(_:x:y:z:)' is deprecated: replaced by instance method 'TypeWithTrailingClosures.threeTrailingClosures(a:b:c:)'}}
+  // expected-note@-1 {{use 'TypeWithTrailingClosures.threeTrailingClosures(a:b:c:)' instead}} {{3-34=x.threeTrailingClosures}} {{35-38=}} {{38-39=a}} {{48-49=c}} {{none}}
+  x.threeTrailingClosures(a: {}) {} c: {}
+
+  threeTrailingClosuresRemoveLabels(x, a: {}) {} c: {} // expected-warning {{'threeTrailingClosuresRemoveLabels(_:a:b:c:)' is deprecated: replaced by instance method 'TypeWithTrailingClosures.threeUnlabeledTrailingClosures(_:_:_:)'}}
+  // expected-note@-1 {{use 'TypeWithTrailingClosures.threeUnlabeledTrailingClosures(_:_:_:)' instead}} {{3-36=x.threeUnlabeledTrailingClosures}} {{37-40=}} {{40-43=}} {{50-51=_}} {{none}}
+  x.threeUnlabeledTrailingClosures({}) {} _: {}
+
+  variadicTrailingClosures(x) {} _: {} _: {} // expected-warning {{'variadicTrailingClosures(_:a:)' is deprecated: replaced by instance method 'TypeWithTrailingClosures.variadicTrailingClosures(a:b:c:)'}}
+  // expected-note@-1 {{use 'TypeWithTrailingClosures.variadicTrailingClosures(a:b:c:)' instead}} {{3-27=x.variadicTrailingClosures}} {{28-29=}} {{none}}
+  x.variadicTrailingClosures() {} _: {} _: {}
+}


### PR DESCRIPTION
Correct some fix-it logic to account for multiple trailing closures, and improve the extraneous argument diagnostic for trailing closures.

rdar://81278194
rdar://81289222