### PR TITLE
Allow a global-actor-isolated class to inherit from a nonisolated one.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3028,14 +3028,7 @@ static bool checkClassGlobalActorIsolation(
   switch (superIsolation) {
   case ActorIsolation::Unspecified:
   case ActorIsolation::Independent:
-    // Allow ObjC superclasses with unspecified global actors, because we do
-    // not expect for Objective-C classes to have been universally annotated.
-    // FIXME: We might choose to tighten this up in Swift 6.
-    if (superclassDecl->getClangNode())
-      return false;
-
-    // Break out to diagnose the error below.
-    break;
+    return false;
 
   case ActorIsolation::ActorInstance:
     // This is an error that will be diagnosed later. Ignore it here.

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -956,7 +956,7 @@ actor Counter {
 class C2 { }
 
 @SomeGlobalActor
-class C3: C2 { } // expected-error{{global actor 'SomeGlobalActor'-isolated class 'C3' has different actor isolation from nonisolated superclass 'C2'}}
+class C3: C2 { } // it's okay to add a global actor to a nonisolated class.
 
 @GenericGlobalActor<U>
 class GenericSuper<U> { }

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -219,7 +219,7 @@ class SuperclassWithGlobalActors {
   func j() { }
 }
 
-@GenericGlobalActor<String> // expected-error@+1{{global actor 'GenericGlobalActor<String>'-isolated class 'SubclassWithGlobalActors' has different actor isolation from nonisolated superclass 'SuperclassWithGlobalActors'}}
+@GenericGlobalActor<String> // it's okay to add a global actor to nonisolated
 class SubclassWithGlobalActors : SuperclassWithGlobalActors {
   override func f() { } // okay: inferred to @GenericGlobalActor<Int>
 


### PR DESCRIPTION
**Explanation**: In tightening up the semantic rules around data races for class inheritance (https://github.com/apple/swift/pull/38213), the Swift compiler started rejecting a common pattern that is actually safe: a main-actor-isolated subclass of a non-isolated class, causing a number of apps to be incorrectly rejected. Allow this inheritance pattern.
**Scope**: Affects Swift code using the new concurrency features.
**Radar/SR Issue**: rdar://80902604
**Risk**: Very low. This loosens up a recently-added restriction, accepting more Swift code that was accepted before.
**Testing**: PR testing and CI on main.
**Original PR**: https://github.com/apple/swift/pull/38707
