### PR TITLE
Frontend: remove -swift-module-file. NFC

### DIFF
--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -82,9 +82,6 @@ public:
   /// would for a non-system header.
   bool DisableModulesValidateSystemDependencies = false;
 
-  /// The paths to a set of explicitly built modules from interfaces.
-  std::vector<std::string> ExplicitSwiftModules;
-
   /// A set of compiled modules that may be ready to use.
   std::vector<std::string> CandidateCompiledModules;
 

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -161,7 +161,6 @@ public:
   static std::unique_ptr<ExplicitSwiftModuleLoader>
   create(ASTContext &ctx,
          DependencyTracker *tracker, ModuleLoadingMode loadMode,
-         ArrayRef<std::string> ExplicitModulePaths,
          StringRef ExplicitSwiftModuleMap,
          bool IgnoreSwiftSourceInfoFile);
 
@@ -180,8 +179,6 @@ struct ExplicitModuleInfo {
   std::string moduleDocPath;
   // Path of the .swiftsourceinfo file.
   std::string moduleSourceInfoPath;
-  // Opened buffer for the .swiftmodule file.
-  std::unique_ptr<llvm::MemoryBuffer> moduleBuffer;
   // A flag that indicates whether this module is a framework
   bool isFramework;
 };

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -169,10 +169,6 @@ def disable_typo_correction : Flag<["-"], "disable-typo-correction">,
 def disable_implicit_swift_modules: Flag<["-"], "disable-implicit-swift-modules">,
   HelpText<"Disable building Swift modules implicitly by the compiler">;
 
-def swift_module_file
-  : Separate<["-"], "swift-module-file">, MetaVarName<"<path>">,
-    HelpText<"Specify Swift module explicitly built from textual interface">;
-
 def explict_swift_module_map
   : Separate<["-"], "explicit-swift-module-map-file">, MetaVarName<"<path>">,
     HelpText<"Specify a JSON file containing information of explict Swift modules">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1098,9 +1098,6 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts,
   Opts.DisableModulesValidateSystemDependencies |=
       Args.hasArg(OPT_disable_modules_validate_system_headers);
 
-  for (auto A: Args.filtered(OPT_swift_module_file)) {
-    Opts.ExplicitSwiftModules.push_back(resolveSearchPath(A->getValue()));
-  }
   if (const Arg *A = Args.getLastArg(OPT_explict_swift_module_map))
     Opts.ExplicitSwiftModuleMap = A->getValue();
   for (auto A: Args.filtered(OPT_candidate_module_file)) {

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -546,7 +546,6 @@ bool CompilerInstance::setUpModuleLoaders() {
     auto ESML = ExplicitSwiftModuleLoader::create(
         *Context,
         getDependencyTracker(), MLM,
-        Invocation.getSearchPathOptions().ExplicitSwiftModules,
         Invocation.getSearchPathOptions().ExplicitSwiftModuleMap,
         IgnoreSourceInfoFile);
     this->DefaultSerializedLoader = ESML.get();

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -86,9 +86,6 @@ std::error_code PlaceholderSwiftModuleScanner::findModuleFilesInDirectory(
     return std::make_error_code(std::errc::not_supported);
   }
   auto &moduleInfo = it->getValue();
-  assert(!moduleInfo.moduleBuffer &&
-         "Placeholder dependency module stubs cannot have an associated buffer");
-
   auto dependencies = ModuleDependencies::forPlaceholderSwiftModuleStub(
       moduleInfo.modulePath, moduleInfo.moduleDocPath,
       moduleInfo.moduleSourceInfoPath);


### PR DESCRIPTION
We are now using a JSON file for explicit module inputs, so this argument can be removed.
