### PR TITLE
AutoDiff: Disable requirement machine when building or testing Differentiation library

### DIFF
--- a/stdlib/private/DifferentiationUnittest/CMakeLists.txt
+++ b/stdlib/private/DifferentiationUnittest/CMakeLists.txt
@@ -3,5 +3,6 @@ add_swift_target_library(swiftDifferentiationUnittest ${SWIFT_STDLIB_LIBRARY_BUI
   GYB_SOURCES DifferentiationUnittest.swift.gyb
 
   SWIFT_MODULE_DEPENDS _Differentiation StdlibUnittest
+  SWIFT_COMPILE_FLAGS -Xfrontend -requirement-machine=off
   INSTALL_IN_COMPONENT stdlib-experimental
   DARWIN_INSTALL_NAME_DIR "${SWIFT_DARWIN_STDLIB_PRIVATE_INSTALL_NAME_DIR}")

--- a/stdlib/public/Differentiation/CMakeLists.txt
+++ b/stdlib/public/Differentiation/CMakeLists.txt
@@ -41,5 +41,6 @@ add_swift_target_library(swift_Differentiation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPE
   SWIFT_COMPILE_FLAGS
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -parse-stdlib
+    -Xfrontend -requirement-machine=off
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   INSTALL_IN_COMPONENT stdlib)

--- a/test/AutoDiff/IRGen/differentiable_function_type.swift
+++ b/test/AutoDiff/IRGen/differentiable_function_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -g %s
+// RUN: %target-swift-frontend -emit-ir -g %s -requirement-machine=off
 
 import _Differentiation
 

--- a/test/AutoDiff/IRGen/loadable_by_address.swift
+++ b/test/AutoDiff/IRGen/loadable_by_address.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -c -Xllvm -sil-verify-after-pass=loadable-address %s
-// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s -check-prefix=CHECK-SIL
-// RUN: %target-swift-frontend -c -Xllvm -sil-print-after=loadable-address %s 2>&1 | %FileCheck %s -check-prefix=CHECK-LBA-SIL
-// RUN: %target-run-simple-swift
+// RUN: %target-swift-frontend -c -Xllvm -sil-verify-after-pass=loadable-address %s -requirement-machine=off
+// RUN: %target-swift-frontend -emit-sil %s -requirement-machine=off | %FileCheck %s -check-prefix=CHECK-SIL
+// RUN: %target-swift-frontend -c -Xllvm -sil-print-after=loadable-address %s -requirement-machine=off 2>&1 | %FileCheck %s -check-prefix=CHECK-LBA-SIL
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 // `isLargeLoadableType` depends on the ABI and differs between architectures.

--- a/test/AutoDiff/IRGen/loadable_by_address_cross_module.swift
+++ b/test/AutoDiff/IRGen/loadable_by_address_cross_module.swift
@@ -1,7 +1,7 @@
 // First, check that LBA actually modifies the function, so that this test is useful.
 
-// RUN: %target-swift-frontend -emit-sil %S/Inputs/loadable_by_address_cross_module.swift | %FileCheck %s -check-prefix=CHECK-MODULE-PRE-LBA
-// RUN: %target-swift-frontend -c -Xllvm -sil-print-after=loadable-address %S/Inputs/loadable_by_address_cross_module.swift 2>&1 | %FileCheck %s -check-prefix=CHECK-MODULE-POST-LBA
+// RUN: %target-swift-frontend -emit-sil %S/Inputs/loadable_by_address_cross_module.swift -requirement-machine=off | %FileCheck %s -check-prefix=CHECK-MODULE-PRE-LBA
+// RUN: %target-swift-frontend -c -Xllvm -sil-print-after=loadable-address %S/Inputs/loadable_by_address_cross_module.swift -requirement-machine=off 2>&1 | %FileCheck %s -check-prefix=CHECK-MODULE-POST-LBA
 
 // CHECK-MODULE-PRE-LBA: sil {{.*}}LBAModifiedFunction{{.*}} $@convention(method) <T> (Float, LargeLoadableType<T>) -> Float
 // CHECK-MODULE-POST-LBA: sil {{.*}}LBAModifiedFunction{{.*}} $@convention(method) <T> (Float, @in_constant LargeLoadableType<T>) -> Float
@@ -9,14 +9,14 @@
 // Compile the module.
 
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%target-library-name(external)) %S/Inputs/loadable_by_address_cross_module.swift -emit-module -emit-module-path %t/external.swiftmodule -module-name external
+// RUN: %target-build-swift-dylib(%t/%target-library-name(external)) %S/Inputs/loadable_by_address_cross_module.swift -emit-module -emit-module-path %t/external.swiftmodule -module-name external -Xfrontend -requirement-machine=off
 
 // Next, check that differentiability_witness_functions in the client get
 // correctly modified by LBA.
 
-// RUN: %target-swift-frontend -emit-sil -I%t %s
-// RUN: %target-swift-frontend -emit-sil -I%t %s | %FileCheck %s -check-prefix=CHECK-CLIENT-PRE-LBA
-// RUN: %target-swift-frontend -c -I%t %s -Xllvm -sil-print-after=loadable-address 2>&1 | %FileCheck %s -check-prefix=CHECK-CLIENT-POST-LBA
+// RUN: %target-swift-frontend -emit-sil -I%t %s -requirement-machine=off
+// RUN: %target-swift-frontend -emit-sil -I%t %s -requirement-machine=off | %FileCheck %s -check-prefix=CHECK-CLIENT-PRE-LBA
+// RUN: %target-swift-frontend -c -I%t %s -Xllvm -sil-print-after=loadable-address -requirement-machine=off 2>&1 | %FileCheck %s -check-prefix=CHECK-CLIENT-POST-LBA
 
 // CHECK-CLIENT-PRE-LBA: differentiability_witness_function [jvp] [reverse] [parameters 0 1] [results 0] <T> @${{.*}}LBAModifiedFunction{{.*}} : $@convention(method) <τ_0_0> (Float, LargeLoadableType<τ_0_0>) -> Float
 // CHECK-CLIENT-PRE-LBA: differentiability_witness_function [vjp] [reverse] [parameters 0 1] [results 0] <T> @${{.*}}LBAModifiedFunction{{.*}} : $@convention(method) <τ_0_0> (Float, LargeLoadableType<τ_0_0>) -> Float
@@ -26,7 +26,7 @@
 
 // Finally, execute the test.
 
-// RUN: %target-build-swift -I%t -L%t %s -o %t/a.out %target-rpath(%t) -L%t -lexternal
+// RUN: %target-build-swift -I%t -L%t %s -o %t/a.out %target-rpath(%t) -L%t -lexternal -Xfrontend -requirement-machine=off
 // RUN: %target-codesign %t/a.out
 // RUN: %target-codesign %t/%target-library-name(external)
 // RUN: %target-run %t/a.out %t/%target-library-name(external)

--- a/test/AutoDiff/SIL/Parse/sildeclref.sil
+++ b/test/AutoDiff/SIL/Parse/sildeclref.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt %s -module-name=sildeclref_parse | %target-sil-opt -module-name=sildeclref_parse | %FileCheck %s
+// RUN: %target-sil-opt %s -module-name=sildeclref_parse -requirement-machine off | %target-sil-opt -module-name=sildeclref_parse -requirement-machine off | %FileCheck %s
 // Parse AutoDiff derivative SILDeclRefs via `witness_method` and `class_method` instructions.
 
 import Swift

--- a/test/AutoDiff/SILGen/autodiff_builtins.swift
+++ b/test/AutoDiff/SILGen/autodiff_builtins.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-stdlib -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse-stdlib -emit-silgen %s -requirement-machine=off | %FileCheck %s
 
 import _Differentiation
 import Swift

--- a/test/AutoDiff/SILGen/reabstraction.swift
+++ b/test/AutoDiff/SILGen/reabstraction.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -requirement-machine=off | %FileCheck %s
 
 import _Differentiation
 

--- a/test/AutoDiff/SILGen/vtable.swift
+++ b/test/AutoDiff/SILGen/vtable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -requirement-machine=off | %FileCheck %s
 
 // Test derivative function vtable entries for `@differentiable` class members:
 // - Methods.

--- a/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -verify %s
+// RUN: %target-swift-frontend -emit-sil -verify -requirement-machine=off %s
 
 // Test differentiation transform diagnostics.
 

--- a/test/AutoDiff/SILOptimizer/generics.swift
+++ b/test/AutoDiff/SILOptimizer/generics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -verify %s | %FileCheck %s -check-prefix=CHECK-SIL
+// RUN: %target-swift-emit-sil -verify %s -requirement-machine=off | %FileCheck %s -check-prefix=CHECK-SIL
 
 import _Differentiation
 

--- a/test/AutoDiff/SILOptimizer/property_wrappers.swift
+++ b/test/AutoDiff/SILOptimizer/property_wrappers.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -verify %s %S/Inputs/nontrivial_loadable_type.swift
+// RUN: %target-swift-frontend -emit-sil -verify %s %S/Inputs/nontrivial_loadable_type.swift -requirement-machine=off
 // REQUIRES: asserts
 
 // Test property wrapper differentiation coverage for a variety of property

--- a/test/AutoDiff/SILOptimizer/semantic_member_accessors_sil.swift
+++ b/test/AutoDiff/SILOptimizer/semantic_member_accessors_sil.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -Xllvm -sil-print-after=differentiation %s -module-name null -o /dev/null 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -Xllvm -sil-print-after=differentiation %s -module-name null -o /dev/null -requirement-machine=off 2>&1 | %FileCheck %s
 
 // Test differentiation of semantic member accessors:
 // - Stored property accessors.

--- a/test/AutoDiff/compiler_crashers_fixed/rdar74087329-debug-scope-trampoline-blocks.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/rdar74087329-debug-scope-trampoline-blocks.swift
@@ -1,5 +1,5 @@
-// RUN: %target-build-swift %s
-// RUN: %target-swift-frontend -c -g -Xllvm -verify-di-holes=true %s
+// RUN: %target-build-swift %s -Xfrontend -requirement-machine=off
+// RUN: %target-swift-frontend -c -g -Xllvm -verify-di-holes=true %s -requirement-machine=off
 
 // rdar://74087329 (DI verification failure with trampoline blocks in VJP)
 

--- a/test/AutoDiff/compiler_crashers_fixed/sr12641-silgen-immutable-address-use-verification-failure.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr12641-silgen-immutable-address-use-verification-failure.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-resilience -emit-sil -verify %s
+// RUN: %target-swift-frontend -enable-resilience -emit-sil -verify %s -requirement-machine=off
 
 // SR-12641: SILGen verification error regarding `ImmutableAddressUseVerifier` and AutoDiff-generated code.
 

--- a/test/AutoDiff/compiler_crashers_fixed/sr12744-unhandled-pullback-indirect-result.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr12744-unhandled-pullback-indirect-result.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -verify %s
+// RUN: %target-swift-frontend -emit-sil -verify %s -requirement-machine=off
 
 // SR-12744: Pullback generation crash for unhandled indirect result.
 // May be due to inconsistent derivative function type calculation logic in

--- a/test/AutoDiff/compiler_crashers_fixed/sr13933-vjpcloner-apply-multiple-consuming-users.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr13933-vjpcloner-apply-multiple-consuming-users.swift
@@ -1,4 +1,4 @@
-// RUN: %target-build-swift %s
+// RUN: %target-build-swift %s -Xfrontend -requirement-machine=off
 
 // SR-13933: Fix "multiple consuming users" ownership error caused by
 // `VJPCloner::visitApply` related to `@differentiable`-function-typed callees.

--- a/test/AutoDiff/compiler_crashers_fixed/tf1202-differentiability-witness-dead-function-elimination.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf1202-differentiability-witness-dead-function-elimination.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-module -module-name tf1202 -emit-module-path %t/tf1202.swiftmodule %S/Inputs/tf1202-differentiability-witness-dead-function-elimination.swift
-// RUN: %target-build-swift -I%t -emit-module -O %s
+// RUN: %target-build-swift -emit-module -module-name tf1202 -emit-module-path %t/tf1202.swiftmodule %S/Inputs/tf1202-differentiability-witness-dead-function-elimination.swift -Xfrontend -requirement-machine=off
+// RUN: %target-build-swift -I%t -emit-module -O %s -Xfrontend -requirement-machine=off
 
 // TF-1202: test bug where DeadFunctionElimination eliminated the
 // SILFunction for `func identity<T>` even though a differentiability witness for it

--- a/test/AutoDiff/mangling.swift
+++ b/test/AutoDiff/mangling.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -enable-experimental-forward-mode-differentiation -module-name=mangling -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -enable-experimental-forward-mode-differentiation -module-name=mangling -verify %s -requirement-machine=off | %FileCheck %s
 
 import _Differentiation
 

--- a/test/AutoDiff/stdlib/anydifferentiable.swift
+++ b/test/AutoDiff/stdlib/anydifferentiable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 import _Differentiation

--- a/test/AutoDiff/stdlib/collection_higher_order_functions.swift
+++ b/test/AutoDiff/stdlib/collection_higher_order_functions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 import _Differentiation

--- a/test/AutoDiff/stdlib/derivative_customization.swift
+++ b/test/AutoDiff/stdlib/derivative_customization.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 import DifferentiationUnittest

--- a/test/AutoDiff/stdlib/differential_operators.swift.gyb
+++ b/test/AutoDiff/stdlib/differential_operators.swift.gyb
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %gyb %s -o %t/differential_operators.swift
-// RUN: %target-build-swift %t/differential_operators.swift -o %t/differential_operators
+// RUN: %target-build-swift %t/differential_operators.swift -o %t/differential_operators -Xfrontend -requirement-machine=off
 // RUN: %target-codesign %t/differential_operators
 // RUN: %target-run %t/differential_operators
 // REQUIRES: executable_test

--- a/test/AutoDiff/stdlib/floating_point.swift.gyb
+++ b/test/AutoDiff/stdlib/floating_point.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swiftgyb(-Xfrontend -enable-experimental-forward-mode-differentiation)
+// RUN: %target-run-simple-swiftgyb(-Xfrontend -enable-experimental-forward-mode-differentiation -Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))

--- a/test/AutoDiff/stdlib/simd.swift
+++ b/test/AutoDiff/stdlib/simd.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 // Would fail due to unavailability of swift_autoDiffCreateLinearMapContext.

--- a/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
+++ b/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swiftgyb(-Xfrontend -enable-experimental-forward-mode-differentiation)
+// RUN: %target-run-simple-swiftgyb(-Xfrontend -enable-experimental-forward-mode-differentiation -Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 #if canImport(Darwin)

--- a/test/AutoDiff/validation-test/address_only_tangentvector.swift
+++ b/test/AutoDiff/validation-test/address_only_tangentvector.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 // Would fail due to unavailability of swift_autoDiffCreateLinearMapContext.

--- a/test/AutoDiff/validation-test/array.swift
+++ b/test/AutoDiff/validation-test/array.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 // Would fail due to unavailability of swift_autoDiffCreateLinearMapContext.

--- a/test/AutoDiff/validation-test/class_differentiation.swift
+++ b/test/AutoDiff/validation-test/class_differentiation.swift
@@ -1,6 +1,6 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // NOTE: Verify whether forward-mode differentiation crashes. It currently does.
-// RUN: not --crash %target-swift-frontend -enable-experimental-forward-mode-differentiation -emit-sil %s
+// RUN: not --crash %target-swift-frontend -enable-experimental-forward-mode-differentiation -emit-sil %s -requirement-machine=off
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/validation-test/control_flow.swift
+++ b/test/AutoDiff/validation-test/control_flow.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 // FIXME(SR-12741): Enable test for all platforms after debugging

--- a/test/AutoDiff/validation-test/cross_module_derivative_attr.swift
+++ b/test/AutoDiff/validation-test/cross_module_derivative_attr.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%target-library-name(module1)) %S/Inputs/cross_module_derivative_attr/module1/module1.swift %S/Inputs/cross_module_derivative_attr/module1/module1_other_file.swift -emit-module -emit-module-path %t/module1.swiftmodule -module-name module1
-// RUN: %target-build-swift -I%t -L%t %S/Inputs/cross_module_derivative_attr/main/main.swift -o %t/a.out -lmodule1 %target-rpath(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(module1)) %S/Inputs/cross_module_derivative_attr/module1/module1.swift %S/Inputs/cross_module_derivative_attr/module1/module1_other_file.swift -emit-module -emit-module-path %t/module1.swiftmodule -module-name module1 -Xfrontend -requirement-machine=off
+// RUN: %target-build-swift -I%t -L%t %S/Inputs/cross_module_derivative_attr/main/main.swift -o %t/a.out -lmodule1 %target-rpath(%t) -Xfrontend -requirement-machine=off
 // RUN: %target-codesign %t/a.out
 // RUN: %target-codesign %t/%target-library-name(module1)
 // RUN: %target-run %t/a.out %t/%target-library-name(module1)

--- a/test/AutoDiff/validation-test/cross_module_differentiation.swift
+++ b/test/AutoDiff/validation-test/cross_module_differentiation.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift-dylib(%t/%target-library-name(cross_module_differentiation_other)) %S/Inputs/cross_module_differentiation_other.swift -emit-module -emit-module-path %t/cross_module_differentiation_other.swiftmodule -module-name cross_module_differentiation_other
-// RUN: %target-build-swift -I%t -L%t %s -o %t/a.out -lcross_module_differentiation_other %target-rpath(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(cross_module_differentiation_other)) %S/Inputs/cross_module_differentiation_other.swift -emit-module -emit-module-path %t/cross_module_differentiation_other.swiftmodule -module-name cross_module_differentiation_other -Xfrontend -requirement-machine=off
+// RUN: %target-build-swift -I%t -L%t %s -o %t/a.out -lcross_module_differentiation_other %target-rpath(%t) -Xfrontend -requirement-machine=off
 // RUN: %target-codesign %t/a.out
 // RUN: %target-codesign %t/%target-library-name(cross_module_differentiation_other)
 // RUN: %target-run %t/a.out %t/%target-library-name(cross_module_differentiation_other)

--- a/test/AutoDiff/validation-test/custom_derivatives.swift
+++ b/test/AutoDiff/validation-test/custom_derivatives.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/validation-test/derivative_registration.swift
+++ b/test/AutoDiff/validation-test/derivative_registration.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/validation-test/differentiable_property.swift
+++ b/test/AutoDiff/validation-test/differentiable_property.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 // An end-to-end test that we can differentiate property accesses, with custom

--- a/test/AutoDiff/validation-test/differentiable_protocol_requirements.swift
+++ b/test/AutoDiff/validation-test/differentiable_protocol_requirements.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 // Disabled due to test failure with `-O`: SR-13250.

--- a/test/AutoDiff/validation-test/existential.swift
+++ b/test/AutoDiff/validation-test/existential.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/validation-test/forward_mode_array.swift
+++ b/test/AutoDiff/validation-test/forward_mode_array.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-forward-mode-differentiation)
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-forward-mode-differentiation -Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/validation-test/forward_mode_inout.swift
+++ b/test/AutoDiff/validation-test/forward_mode_inout.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-forward-mode-differentiation)
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-forward-mode-differentiation -Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/validation-test/forward_mode_simd.swift
+++ b/test/AutoDiff/validation-test/forward_mode_simd.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-forward-mode-differentiation)
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-forward-mode-differentiation -Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/validation-test/forward_mode_simple.swift
+++ b/test/AutoDiff/validation-test/forward_mode_simple.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-forward-mode-differentiation)
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-forward-mode-differentiation -Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/validation-test/inout_control_flow.swift
+++ b/test/AutoDiff/validation-test/inout_control_flow.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/validation-test/inout_parameters.swift
+++ b/test/AutoDiff/validation-test/inout_parameters.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 // Would fail due to unavailability of swift_autoDiffCreateLinearMapContext.

--- a/test/AutoDiff/validation-test/method.swift
+++ b/test/AutoDiff/validation-test/method.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/validation-test/optional.swift
+++ b/test/AutoDiff/validation-test/optional.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 // Test differentiation of `Optional` values and operations.

--- a/test/AutoDiff/validation-test/optional_property.swift
+++ b/test/AutoDiff/validation-test/optional_property.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift
-// RUN: %target-swift-emit-sil -Xllvm -debug-only=differentiation -module-name null -o /dev/null 2>&1 %s | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
+// RUN: %target-swift-emit-sil -Xllvm -debug-only=differentiation -module-name null -o /dev/null -requirement-machine=off 2>&1 %s | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: asserts
 

--- a/test/AutoDiff/validation-test/property_wrappers.swift
+++ b/test/AutoDiff/validation-test/property_wrappers.swift
@@ -1,6 +1,6 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // TODO(TF-1254): Support and test forward-mode differentiation.
-// TODO(TF-1254): %target-run-simple-swift(-Xfrontend -enable-experimental-forward-mode-differentiation)
+// TODO(TF-1254): %target-run-simple-swift(-Xfrontend -enable-experimental-forward-mode-differentiation -Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/validation-test/reabstraction.swift
+++ b/test/AutoDiff/validation-test/reabstraction.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 import _Differentiation

--- a/test/AutoDiff/validation-test/reflection.swift
+++ b/test/AutoDiff/validation-test/reflection.swift
@@ -2,8 +2,8 @@
 // RUN: %empty-directory(%t)
 import _Differentiation
 
-// RUN: %target-build-swift -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/AutoDiffTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect)
-// RUN: %target-build-swift -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/AutoDiffTypes.swift %S/Inputs/main.swift -emit-module -emit-executable -module-name TypesToReflect -o %t/TypesToReflect
+// RUN: %target-build-swift -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/AutoDiffTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect) -Xfrontend -requirement-machine=off
+// RUN: %target-build-swift -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/AutoDiffTypes.swift %S/Inputs/main.swift -emit-module -emit-executable -module-name TypesToReflect -o %t/TypesToReflect -Xfrontend -requirement-machine=off
 
 // RUN: %target-swift-reflection-dump -binary-filename %t/%target-library-name(TypesToReflect) | %FileCheck %s
 // RUN: %target-swift-reflection-dump -binary-filename %t/TypesToReflect | %FileCheck %s

--- a/test/AutoDiff/validation-test/repeated_calls.swift
+++ b/test/AutoDiff/validation-test/repeated_calls.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/validation-test/separate_tangent_type.swift
+++ b/test/AutoDiff/validation-test/separate_tangent_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/validation-test/simple_math.swift
+++ b/test/AutoDiff/validation-test/simple_math.swift
@@ -1,10 +1,10 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 
 // NOTE(TF-813): verify that enabling forward-mode does not affect reverse-mode.
 // Temporarily disabled because forward-mode is not at feature parity with reverse-mode.
-// UN: %target-run-simple-swift(-Xfrontend -enable-experimental-forward-mode-differentiation)
+// UN: %target-run-simple-swift(-Xfrontend -enable-experimental-forward-mode-differentiation -Xfrontend -requirement-machine=off)
 
-// RUN: %target-swift-frontend -Xllvm -sil-print-after=differentiation %s -emit-sil -o /dev/null -module-name null 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-print-after=differentiation %s -emit-sil -o /dev/null -module-name null -requirement-machine=off 2>&1 | %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/AutoDiff/validation-test/simple_model.swift
+++ b/test/AutoDiff/validation-test/simple_model.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/validation-test/subset_parameters_thunk.swift
+++ b/test/AutoDiff/validation-test/subset_parameters_thunk.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/AutoDiff/validation-test/superset_adjoint.swift
+++ b/test/AutoDiff/validation-test/superset_adjoint.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 // REQUIRES: executable_test
 
 import StdlibUnittest


### PR DESCRIPTION
The SIL type lowering logic for AutoDiff gets the substituted generic signature
mixed up with the invocation generic signature, so it tries to ask questions
about DependentMemberTypes in a signature with no requirements. This triggers
assertions when the requirement machine is enabled.

Disable the requirement machine until this is fixed.