### PR TITLE
[IDE] Skip synthesized curry thunks and walk their unwrapped expression

### DIFF
--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -588,8 +588,10 @@ ClangNode extensionGetClangNode(const ExtensionDecl *ext);
 
 /// Utility for finding the referenced declaration from a call, which might
 /// include a second level of function application for a 'self.' expression,
-/// or a curry thunk, etc.
-std::pair<Type, ConcreteDeclRef> getReferencedDecl(Expr *expr);
+/// or a curry thunk, etc. If \p semantic is true then the underlying semantic
+/// expression of \p expr is used.
+std::pair<Type, ConcreteDeclRef> getReferencedDecl(Expr *expr,
+                                                   bool semantic = true);
 
 /// Whether the last expression in \p ExprStack is being called.
 bool isBeingCalled(ArrayRef<Expr*> ExprStack);

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -572,7 +572,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
       }
       return false;
     };
-    if (auto *VD = getReferencedDecl(Call).second.getDecl())
+    if (auto *VD = getReferencedDecl(Call, /*semantic=*/false).second.getDecl())
       if (handleDecl(VD, Call->getSourceRange()))
         return true;
 

--- a/test/Index/index_curry_thunk.swift
+++ b/test/Index/index_curry_thunk.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
+
+struct SomeStruct {
+  func simple(_ someClosure: () -> Void) { }
+}
+
+func test(s: SomeStruct) {
+  s.simple { }
+  // CHECK: [[@LINE-1]]:5 | instance-method/Swift | simple(_:) | s:14swift_ide_test10SomeStructV6simpleyyyyXEF | Ref,Call,RelRec,RelCall,RelCont | rel: 2
+  (((s).simple)) { }
+  // CHECK: [[@LINE-1]]:9 | instance-method/Swift | simple(_:) | s:14swift_ide_test10SomeStructV6simpleyyyyXEF | Ref,Call,RelRec,RelCall,RelCont | rel: 2
+}


### PR DESCRIPTION
SemaAnnotator was walking into an autoclosure and then manually running
`passReference` on the unwrapped expression without walking it. Since
its synthesized anyway, skip walking the autoclosure entirely and walk
the unwrapped expression instead.

Fix `swift::ide::isBeingCalled` to look through `IdentityExpr`s and
`swift::ide::getBase` also not unwrapping curry thunks.

Resolves rdar://81312849