### PR TITLE
Fix python3 compatibility in validation-test/SIL/verify_all_overlays.py.

### DIFF
--- a/validation-test/SIL/verify_all_overlays.py
+++ b/validation-test/SIL/verify_all_overlays.py
@@ -40,7 +40,7 @@ for module_file in os.listdir(sdk_overlay_dir):
     # llvm-bcanalyzer | not grep Unknown
     bcanalyzer_output = subprocess.check_output(["llvm-bcanalyzer",
                                                  module_path])
-    if "Unknown" in bcanalyzer_output:
+    if b"Unknown" in bcanalyzer_output:
         print(bcanalyzer_output)
         sys.exit(1)
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This validation test script relies on a `#!/usr/bin/python` shebang which defaults to Python 3 in many modern Linuxes. While certainly written with the intent of being Python 3 compatible, it does not take into account `subprocess.check_output()` returns byte-encoded output in Python3, so checking for a string literal instead of a byte literal in the modified line raises a type error on these modern Linux systems . The byte literal in Python 2.6 and 2.7 is an alias for a Latin encoded string literal, so it will not affect MacOS (which I think is still on Python 2.7) or older Linuxes. 

Out of curiosity, I checked which other scripts use this absolute path shebang and may result in other subtle errors as more Unix systems move towards a Python 3 `/usr/bin/python` in accordance with [PEP 394](https://www.python.org/dev/peps/pep-0394/). They include:

- `utils/rusage.py`
- `utils/process-stats-dir.py`
- `utils/jobstats/__init__.py`
- `utils/jobstats/jobstats.py`
- `validation-test/ParseableInterface/verify_all_overlays.py`
- `validation-test/SIL/verify_all_overlays.py`
- `benchmark/scripts/test_Benchmark_Driver.py`
- `benchmark/scripts/test_compare_perf_tests.py`
- `benchmark/scripts/test_utils.py`
- `benchmark/scripts/compare_perf_tests.py`
- `test/ScanDependencies/Inputs/CommandRunner.py`

It may be worth switching these over to `/usr/bin/env python` and standardizing tree-wide to avoid subtle Python 2/3 compatibility bugs cropping up moving forward.

Full disclosure: I caught this bug while updating the Swift package for NixOS, but was able to repro it on Fedora 34, suggesting it will be an issue going forward for your officially supported RHEL-family targets.