### PR TITLE
Tiny RequirementMachine fixes

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1181,6 +1181,11 @@ public:
   rewriting::RequirementMachine *getOrCreateRequirementMachine(
       CanGenericSignature sig);
 
+  /// This is a hack to break cycles. Don't introduce new callers of this
+  /// method.
+  bool isRecursivelyConstructingRequirementMachine(
+      CanGenericSignature sig);
+
   /// Retrieve a generic signature with a single unconstrained type parameter,
   /// like `<T>`.
   CanGenericSignature getSingleGenericParameterSignature() const;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1997,6 +1997,22 @@ ASTContext::getOrCreateRequirementMachine(CanGenericSignature sig) {
   return machine;
 }
 
+bool ASTContext::isRecursivelyConstructingRequirementMachine(
+      CanGenericSignature sig) {
+  auto &rewriteCtx = getImpl().TheRewriteContext;
+  if (!rewriteCtx)
+    return false;
+
+  auto arena = getArena(sig);
+  auto &machines = getImpl().getArena(arena).RequirementMachines;
+
+  auto found = machines.find(sig);
+  if (found == machines.end())
+    return false;
+
+  return !found->second->isComplete();
+}
+
 Optional<llvm::TinyPtrVector<ValueDecl *>>
 OverriddenDeclsRequest::getCachedResult() const {
   auto decl = std::get<0>(getStorage());

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -819,9 +819,14 @@ Type AssociatedTypeInference::computeFixedTypeWitness(
         !conformedProto->inheritsFrom(assocType->getProtocol()))
       continue;
 
-    const auto ty =
-        conformedProto->getGenericSignature()->getCanonicalTypeInContext(
-            structuralTy);
+    auto sig = conformedProto->getGenericSignature();
+
+    // FIXME: The RequirementMachine will assert on re-entrant construction.
+    // We should find a more principled way of breaking this cycle.
+    if (ctx.isRecursivelyConstructingRequirementMachine(sig.getCanonicalSignature()))
+      continue;
+
+    const auto ty = sig->getCanonicalTypeInContext(structuralTy);
 
     // A dependent member type with an identical base and name indicates that
     // the protocol does not same-type constrain it in any way; move on to


### PR DESCRIPTION
This fixes a few `compiler_crasher` failures when the requirement machine is enabled (it's still disabled by default).