### PR TITLE
Implement `guard` capture specifier for closure capture lists

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -222,6 +222,7 @@ public:
   virtual NullablePtr<DeclAttribute> getDeclAttributeIfAny() const {
     return nullptr;
   }
+  virtual NullablePtr<Stmt> getParentStmtIfAny() const;
 
 #pragma mark - debugging and printing
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1598,6 +1598,12 @@ ERROR(attr_unowned_invalid_specifier,none,
 ERROR(attr_unowned_expected_rparen,none,
       "expected ')' after specifier for 'unowned'", ())
 
+// weak
+ERROR(attr_weak_invalid_specifier,none,
+      "expected 'weak' or 'weak(guard)'", ())
+ERROR(attr_weak_expected_rparen,none,
+      "expected ')' after specifier for 'weak'", ())
+
 // warn_unused_result
 WARNING(attr_warn_unused_result_removed,none,
         "'warn_unused_result' attribute behavior is now the default", ())

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1669,9 +1669,12 @@ public:
           SourceLoc &throwsLoc,
           SourceLoc &arrowLoc,
           TypeExpr *&explicitResultType,
-          SourceLoc &inLoc);
+          SourceLoc &inLocm,
+          SmallVectorImpl<Identifier> &varsForSynthesizedGuard);
 
   Expr *parseExprAnonClosureArg();
+  GuardStmt *synthesizedGuardStmt(SmallVectorImpl<Identifier> &varsForSynthesizedGuard,
+                                  SourceLoc guardLoc);
   ParserResult<Expr> parseExprList(tok LeftTok, tok RightTok,
                                    syntax::SyntaxKind Kind);
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1670,11 +1670,12 @@ public:
           SourceLoc &arrowLoc,
           TypeExpr *&explicitResultType,
           SourceLoc &inLocm,
-          SmallVectorImpl<Identifier> &varsForSynthesizedGuard);
+          SmallVectorImpl<Identifier> &weakGuardVars);
 
   Expr *parseExprAnonClosureArg();
-  GuardStmt *synthesizedGuardStmt(SmallVectorImpl<Identifier> &varsForSynthesizedGuard,
-                                  SourceLoc guardLoc);
+  void synthesizeGuardStmts(SmallVectorImpl<ASTNode> &closureBodyElements,
+                            SmallVectorImpl<Identifier> &weakGuardVars,
+                            SourceLoc guardLoc);
   ParserResult<Expr> parseExprList(tok LeftTok, tok RightTok,
                                    syntax::SyntaxKind Kind);
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2936,6 +2936,20 @@ ParserResult<Expr> Parser::parseExprClosure() {
   auto guardStmt = synthesizedGuardStmt(varsForSynthesizedGuard, inLoc);
   if (guardStmt) {
     bodyElements.push_back(guardStmt);
+    
+    // If the capture list has `[guard self]` then we can
+    // allow implicit self in the closure body.
+    bool guardsSelf = false;
+    
+    for (auto identifier : varsForSynthesizedGuard) {
+      if (identifier.str() == "self") {
+        guardsSelf = true;
+        break;
+      }
+    }
+    
+    if (guardsSelf)
+      closure->setAllowsImplicitSelfCapture();
   }
   
   Status |= parseBraceItems(bodyElements, BraceItemListKind::Brace);

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1711,6 +1711,11 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
       if (auto *VD = closureExpr->getCapturedSelfDecl()) {
         // Either this is a weak capture of self...
         if (VD->getType()->is<WeakStorageType>()) {
+          // `[guard self]` captures have runtime semantics of `[weak self]`
+          // but allows implicit `self.` references.
+          if (closureExpr->allowsImplicitSelfCapture())
+            return false;
+          
           Diags.diagnose(VD->getLoc(), diag::note_self_captured_weakly);
         // ...or something completely different.
         } else {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1711,8 +1711,7 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
       if (auto *VD = closureExpr->getCapturedSelfDecl()) {
         // Either this is a weak capture of self...
         if (VD->getType()->is<WeakStorageType>()) {
-          // `[guard self]` captures have runtime semantics of `[weak self]`
-          // but allows implicit `self.` references.
+          // `[weak(guard) self]` captures allow implicit `self.` references.
           if (closureExpr->allowsImplicitSelfCapture())
             return false;
           

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -164,6 +164,7 @@ class ExplicitSelfRequiredTest {
     doVoidStuff({ [unowned self] in x += 1 })
     doVoidStuff({ [unowned(unsafe) self] in x += 1 })
     doVoidStuff({ [unowned self = self] in x += 1 })
+    doVoidStuff({ [guard self] in x += 1 })
 
     doStuff({ [self] in x+1 })
     doStuff({ [self = self] in x+1 })
@@ -199,6 +200,7 @@ class ExplicitSelfRequiredTest {
     doVoidStuff({ [unowned self] in _ = method() })
     doVoidStuff({ [unowned(unsafe) self] in _ = method() })
     doVoidStuff({ [unowned self = self] in _ = method() })
+    doVoidStuff({ [guard self] in _ = method() })
 
     doStuff { self.method() }
     doStuff { [self] in method() }
@@ -322,6 +324,7 @@ func testCaptureBehavior(_ ptr : SomeClass) {
   let v2 : SomeClass = ptr
 
   doStuff { [weak v1] in v1!.foo() }
+  // doStuff { [guard v1] in v1.foo() } // This should fail, todo: write expected error
   // expected-warning @+2 {{variable 'v1' was written to, but never read}}
   doStuff { [weak v1,                 // expected-note {{previous}}
              weak v1] in v1!.foo() }  // expected-error {{invalid redeclaration of 'v1'}}

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -164,7 +164,7 @@ class ExplicitSelfRequiredTest {
     doVoidStuff({ [unowned self] in x += 1 })
     doVoidStuff({ [unowned(unsafe) self] in x += 1 })
     doVoidStuff({ [unowned self = self] in x += 1 })
-    doVoidStuff({ [guard self] in x += 1 })
+    doVoidStuff({ [weak(guard) self] in x += 1 })
 
     doStuff({ [self] in x+1 })
     doStuff({ [self = self] in x+1 })
@@ -200,7 +200,7 @@ class ExplicitSelfRequiredTest {
     doVoidStuff({ [unowned self] in _ = method() })
     doVoidStuff({ [unowned(unsafe) self] in _ = method() })
     doVoidStuff({ [unowned self = self] in _ = method() })
-    doVoidStuff({ [guard self] in _ = method() })
+    doVoidStuff({ [weak(guard) self] in _ = method() })
 
     doStuff { self.method() }
     doStuff { [self] in method() }
@@ -324,7 +324,7 @@ func testCaptureBehavior(_ ptr : SomeClass) {
   let v2 : SomeClass = ptr
 
   doStuff { [weak v1] in v1!.foo() }
-  // doStuff { [guard v1] in v1.foo() } // This should fail, todo: write expected error
+  // doStuff { [weak(guard) v1] in v1.foo() } // This should fail, todo: write expected error
   // expected-warning @+2 {{variable 'v1' was written to, but never read}}
   doStuff { [weak v1,                 // expected-note {{previous}}
              weak v1] in v1!.foo() }  // expected-error {{invalid redeclaration of 'v1'}}


### PR DESCRIPTION
This PR implements a `weak(guard)` capture specifier for closure capture lists. ([Swift Evolution discussion thread](https://forums.swift.org/t/guard-capture-specifier-for-closure-capture-lists/50805))

`weak(guard)` captures objects as a `weak` reference, but the closure body is only executed if the referenced object still exists. Within the closure body, objects captured with `weak(guard)` are available as non-optional values. When using `weak(guard) self`, implicit `self` is permitted within the closure body.

```swift
class ViewController {
    let button: Button

    func setup() {
        button.tapHandler = { [weak(guard) self, weak(guard) button] in
            if canBeDismissed(by: button) {
                dismiss()
            }
        }
    }
}
```