### PR TITLE
[build-script] Begin putting in infrastructure for the multi-compiler stage swift build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,10 @@ option(SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER
        "Use the host compiler and not the internal clang to build the swift runtime"
        FALSE)
 
+option(SWIFT_RUN_TESTS_WITH_HOST_COMPILER
+       "Run tests against the host compiler and not the just built swift"
+       FALSE)
+
 set(SWIFT_SDKS "" CACHE STRING
     "If non-empty, limits building target binaries only to specified SDKs (despite other SDKs being available)")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -134,10 +134,20 @@ set(SWIFT_LIT_ARGS "" CACHE STRING "Arguments to pass to lit")
 set(SWIFT_LIT_ENVIRONMENT "" CACHE STRING "Environment to use for lit invocations")
 
 if(NOT SWIFT_INCLUDE_TOOLS)
-  list(APPEND SWIFT_LIT_ARGS
-       "--path=${SWIFT_NATIVE_LLVM_TOOLS_PATH}"
-       "--path=${SWIFT_NATIVE_CLANG_TOOLS_PATH}"
-       "--path=${SWIFT_NATIVE_SWIFT_TOOLS_PATH}")
+  if(SWIFT_RUN_TESTS_WITH_HOST_COMPILER)
+    precondition(CMAKE_Swift_COMPILER MESSAGE "Can only run tests if a Swift compiler is specified")
+    get_filename_component(SWIFT_COMPILER_DIR "${CMAKE_Swift_COMPILER}" DIRECTORY)
+    precondition(SWIFT_COMPILER_DIR)
+    # We assume that we are building against a toolchain where all tools are
+    # next to swiftc.
+    list(APPEND SWIFT_LIT_ARGS
+      "--path=${SWIFT_COMPILER_DIR}")
+  else()
+    list(APPEND SWIFT_LIT_ARGS
+      "--path=${SWIFT_NATIVE_LLVM_TOOLS_PATH}"
+      "--path=${SWIFT_NATIVE_CLANG_TOOLS_PATH}"
+      "--path=${SWIFT_NATIVE_SWIFT_TOOLS_PATH}")
+  endif()
   if(SWIFT_BUILD_STDLIB)
     list(APPEND SWIFT_LIT_ARGS
          "--param" "test_resource_dir=${SWIFTLIB_DIR}")

--- a/utils/swift_build_support/swift_build_support/compiler_stage.py
+++ b/utils/swift_build_support/swift_build_support/compiler_stage.py
@@ -1,0 +1,32 @@
+# ===--- compiler_stage.py -----------------------------------------------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https:#swift.org/LICENSE.txt for license information
+# See https:#swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ===---------------------------------------------------------------------===#
+
+class StageArgs(object):
+    def __init__(self, stage, args):
+        self.stage = stage
+        self.args = args
+
+    def __getattr__(self, key):
+        real_key = '{}{}'.format(key, self.stage.postfix)
+        if not hasattr(self.args, real_key):
+            return None
+        return getattr(self.args, real_key)
+
+
+class Stage(object):
+    def __init__(self, identifier, postfix=""):
+        self.identifier = identifier
+        self.postfix = postfix
+
+
+STAGE_1 = Stage(1, "")
+STAGE_2 = Stage(2, "_stage2")

--- a/utils/swift_build_support/swift_build_support/host_specific_configuration.py
+++ b/utils/swift_build_support/swift_build_support/host_specific_configuration.py
@@ -14,43 +14,49 @@ import re
 import sys
 from argparse import ArgumentError
 
+from . import compiler_stage
 from .targets import StdlibDeploymentTarget
 
 
 class HostSpecificConfiguration(object):
-
     """Configuration information for an individual host."""
 
-    def __init__(self, host_target, args):
+    def __init__(self, host_target, args, stage_dependent_args=None):
         """Initialize for the given `host_target`."""
+        # If we were not passed a stage_dependent_args object, then we do not need
+        # to make a distinction in between them and can just use args.
+        if not isinstance(args, compiler_stage.StageArgs):
+            args = compiler_stage.StageArgs(compiler_stage.STAGE_1, args)
+        if stage_dependent_args is None:
+            stage_dependent_args = args
 
         # Compute the set of deployment targets to configure/build.
-        if host_target == args.host_target:
+        if host_target == stage_dependent_args.host_target:
             # This host is the user's desired product, so honor the requested
             # set of targets to configure/build.
-            stdlib_targets_to_configure = args.stdlib_deployment_targets
-            if "all" in args.build_stdlib_deployment_targets:
+            stdlib_targets_to_configure = stage_dependent_args.stdlib_deployment_targets
+            if "all" in stage_dependent_args.build_stdlib_deployment_targets:
                 stdlib_targets_to_build = set(stdlib_targets_to_configure)
             else:
                 stdlib_targets_to_build = set(
-                    args.build_stdlib_deployment_targets).intersection(
-                    set(args.stdlib_deployment_targets))
+                    stage_dependent_args.build_stdlib_deployment_targets).intersection(
+                    set(stage_dependent_args.stdlib_deployment_targets))
         else:
             # Otherwise, this is a host we are building as part of
             # cross-compiling, so we only need the target itself.
             stdlib_targets_to_configure = [host_target]
-            if (hasattr(args, 'stdlib_deployment_targets')):
+            if stage_dependent_args.stdlib_deployment_targets:
                 # there are some build configs that expect
                 # not to be building the stdlib for the target
                 # since it will be provided by different means
                 stdlib_targets_to_build = set(
                     stdlib_targets_to_configure).intersection(
-                    set(args.stdlib_deployment_targets))
+                    set(stage_dependent_args.stdlib_deployment_targets))
             else:
                 stdlib_targets_to_build = set(stdlib_targets_to_configure)
 
-        if (hasattr(args, 'stdlib_deployment_targets') and
-                args.stdlib_deployment_targets == []):
+        if stage_dependent_args.stdlib_deployment_targets and \
+           stage_dependent_args.stdlib_deployment_targets == []:
             stdlib_targets_to_configure = []
             stdlib_targets_to_build = []
 
@@ -59,11 +65,15 @@ class HostSpecificConfiguration(object):
         # FIXME: We should move the platform-derived arguments to be entirely
         # data driven, so that we can eliminate this code duplication and just
         # iterate over all supported platforms.
-        platforms_to_skip_build = self.__platforms_to_skip_build(args)
-        platforms_to_skip_test = self.__platforms_to_skip_test(args)
+        platforms_to_skip_build = \
+            self.__platforms_to_skip_build(args, stage_dependent_args)
+        platforms_to_skip_test = \
+            self.__platforms_to_skip_test(args, stage_dependent_args)
         platforms_archs_to_skip_test = \
-            self.__platforms_archs_to_skip_test(args, host_target)
-        platforms_to_skip_test_host = self.__platforms_to_skip_test_host(args)
+            self.__platforms_archs_to_skip_test(args, stage_dependent_args,
+                                                host_target)
+        platforms_to_skip_test_host = \
+            self.__platforms_to_skip_test_host(args, stage_dependent_args)
 
         # Compute the lists of **CMake** targets for each use case (configure
         # vs. build vs. run) and the SDKs to configure with.
@@ -125,7 +135,10 @@ class HostSpecificConfiguration(object):
                 # Validation, long, and stress tests require building the full
                 # standard library, whereas the other targets can build a
                 # slightly smaller subset which is faster to build.
-                if args.build_swift_stdlib_unittest_extra or \
+                #
+                # NOTE: We currently do not seperate testing options for
+                # stage1/stage2 compiler. This can change with time.
+                if stage_dependent_args.build_swift_stdlib_unittest_extra or \
                         args.validation_test or args.long_test or \
                         args.stress_test:
                     self.swift_stdlib_build_targets.append(
@@ -172,7 +185,7 @@ class HostSpecificConfiguration(object):
                 # If the compiler is being tested after being built to use the
                 # standalone swift-driver, we build a test-target to
                 # run a reduced set of lit-tests that verify the early swift-driver.
-                if getattr(args, 'test_early_swift_driver', False) and\
+                if args.test_early_swift_driver and\
                    not test_host_only:
                     self.swift_test_run_targets.append(
                         "check-swift-only_early_swiftdriver-{}".format(name))
@@ -215,80 +228,82 @@ class HostSpecificConfiguration(object):
         self.swift_flags = deployment_target.platform.swift_flags(args)
         self.cmake_options = deployment_target.platform.cmake_options(args)
 
-    def __platforms_to_skip_build(self, args):
+    def __platforms_to_skip_build(self, args, stage_dependent_args):
         platforms_to_skip_build = set()
-        if not args.build_linux:
+        if not stage_dependent_args.build_linux:
             platforms_to_skip_build.add(StdlibDeploymentTarget.Linux)
-        if not args.build_freebsd:
+        if not stage_dependent_args.build_freebsd:
             platforms_to_skip_build.add(StdlibDeploymentTarget.FreeBSD)
-        if not args.build_cygwin:
+        if not stage_dependent_args.build_cygwin:
             platforms_to_skip_build.add(StdlibDeploymentTarget.Cygwin)
-        if not args.build_osx:
+        if not stage_dependent_args.build_osx:
             platforms_to_skip_build.add(StdlibDeploymentTarget.OSX)
-        if not args.build_ios_device:
+        if not stage_dependent_args.build_ios_device:
             platforms_to_skip_build.add(StdlibDeploymentTarget.iOS)
-        if not args.build_ios_simulator:
+        if not stage_dependent_args.build_ios_simulator:
             platforms_to_skip_build.add(StdlibDeploymentTarget.iOSSimulator)
-        if not args.build_tvos_device:
+        if not stage_dependent_args.build_tvos_device:
             platforms_to_skip_build.add(StdlibDeploymentTarget.AppleTV)
-        if not args.build_tvos_simulator:
+        if not stage_dependent_args.build_tvos_simulator:
             platforms_to_skip_build.add(
                 StdlibDeploymentTarget.AppleTVSimulator)
-        if not args.build_watchos_device:
+        if not stage_dependent_args.build_watchos_device:
             platforms_to_skip_build.add(StdlibDeploymentTarget.AppleWatch)
-        if not args.build_watchos_simulator:
+        if not stage_dependent_args.build_watchos_simulator:
             platforms_to_skip_build.add(
                 StdlibDeploymentTarget.AppleWatchSimulator)
-        if not args.build_android:
+        if not stage_dependent_args.build_android:
             platforms_to_skip_build.add(StdlibDeploymentTarget.Android)
         return platforms_to_skip_build
 
-    def __platforms_to_skip_test(self, args):
+    def __platforms_to_skip_test(self, args, stage_dependent_args):
         platforms_to_skip_test = set()
-        if not args.test_linux:
+        if not stage_dependent_args.test_linux:
             platforms_to_skip_test.add(StdlibDeploymentTarget.Linux)
-        if not args.test_freebsd:
+        if not stage_dependent_args.test_freebsd:
             platforms_to_skip_test.add(StdlibDeploymentTarget.FreeBSD)
-        if not args.test_cygwin:
+        if not stage_dependent_args.test_cygwin:
             platforms_to_skip_test.add(StdlibDeploymentTarget.Cygwin)
-        if not args.test_osx:
+        if not stage_dependent_args.test_osx:
             platforms_to_skip_test.add(StdlibDeploymentTarget.OSX)
-        if not args.test_ios_host and not args.only_non_executable_test:
+        if not stage_dependent_args.test_ios_host and not args.only_non_executable_test:
             platforms_to_skip_test.add(StdlibDeploymentTarget.iOS)
         elif not args.only_non_executable_test:
             raise ArgumentError(None,
                                 "error: iOS device tests are not " +
                                 "supported in open-source Swift.")
-        if not args.test_ios_simulator:
+        if not stage_dependent_args.test_ios_simulator:
             platforms_to_skip_test.add(StdlibDeploymentTarget.iOSSimulator)
-        if not args.test_tvos_host and not args.only_non_executable_test:
+        if not stage_dependent_args.test_tvos_host and \
+           not args.only_non_executable_test:
             platforms_to_skip_test.add(StdlibDeploymentTarget.AppleTV)
         elif not args.only_non_executable_test:
             raise ArgumentError(None,
                                 "error: tvOS device tests are not " +
                                 "supported in open-source Swift.")
-        if not args.test_tvos_simulator:
+        if not stage_dependent_args.test_tvos_simulator:
             platforms_to_skip_test.add(StdlibDeploymentTarget.AppleTVSimulator)
-        if not args.test_watchos_host and not args.only_non_executable_test:
+        if not stage_dependent_args.test_watchos_host and \
+           not args.only_non_executable_test:
             platforms_to_skip_test.add(StdlibDeploymentTarget.AppleWatch)
         elif not args.only_non_executable_test:
             raise ArgumentError(None,
                                 "error: watchOS device tests are not " +
                                 "supported in open-source Swift.")
-        if not args.test_watchos_simulator:
+        if not stage_dependent_args.test_watchos_simulator:
             platforms_to_skip_test.add(
                 StdlibDeploymentTarget.AppleWatchSimulator)
-        if not args.test_android:
+        if not stage_dependent_args.test_android:
             platforms_to_skip_test.add(StdlibDeploymentTarget.Android)
 
         return platforms_to_skip_test
 
-    def __platforms_archs_to_skip_test(self, args, host_target):
+    def __platforms_archs_to_skip_test(self, args, stage_dependent_args, host_target):
         platforms_archs_to_skip_test = set()
-        if not args.test_ios_32bit_simulator:
+        if not stage_dependent_args.test_ios_32bit_simulator:
             platforms_archs_to_skip_test.add(
                 StdlibDeploymentTarget.iOSSimulator.i386)
-        if not args.test_watchos_32bit_simulator:
+        if not stage_dependent_args.test_watchos_32bit_simulator:
             platforms_archs_to_skip_test.add(
                 StdlibDeploymentTarget.AppleWatchSimulator.i386)
         if host_target == StdlibDeploymentTarget.OSX.x86_64.name:
@@ -312,14 +327,17 @@ class HostSpecificConfiguration(object):
 
         return platforms_archs_to_skip_test
 
-    def __platforms_to_skip_test_host(self, args):
+    def __platforms_to_skip_test_host(self, args, stage_dependent_args):
         platforms_to_skip_test_host = set()
-        if not args.test_android_host:
+        if not stage_dependent_args.test_android_host:
             platforms_to_skip_test_host.add(StdlibDeploymentTarget.Android)
-        if not args.test_ios_host and not args.only_non_executable_test:
+        if not stage_dependent_args.test_ios_host and \
+           not args.only_non_executable_test:
             platforms_to_skip_test_host.add(StdlibDeploymentTarget.iOS)
-        if not args.test_tvos_host and not args.only_non_executable_test:
+        if not stage_dependent_args.test_tvos_host and \
+           not args.only_non_executable_test:
             platforms_to_skip_test_host.add(StdlibDeploymentTarget.AppleTV)
-        if not args.test_watchos_host and not args.only_non_executable_test:
+        if not stage_dependent_args.test_watchos_host and \
+           not args.only_non_executable_test:
             platforms_to_skip_test_host.add(StdlibDeploymentTarget.AppleWatch)
         return platforms_to_skip_test_host

--- a/utils/swift_build_support/swift_build_support/products/cmake_product.py
+++ b/utils/swift_build_support/swift_build_support/products/cmake_product.py
@@ -18,6 +18,9 @@ from .. import shell
 
 
 class CMakeProduct(product.Product):
+    def is_verbose(self):
+        return self.args.verbose_build
+
     def build_with_cmake(self, build_targets, build_type, build_args,
                          prefer_just_built_toolchain=False):
         assert self.toolchain.cmake is not None
@@ -28,6 +31,12 @@ class CMakeProduct(product.Product):
         if self.toolchain.distcc_pump:
             cmake_build.append(self.toolchain.distcc_pump)
         cmake_build.extend([self.toolchain.cmake, "--build"])
+
+        # If we are verbose...
+        if self.is_verbose():
+            # And ninja, add a -v.
+            if self.args.cmake_generator == "Ninja":
+                build_args.append('-v')
 
         generator_output_path = ""
         if self.args.cmake_generator == "Ninja":
@@ -82,6 +91,13 @@ class CMakeProduct(product.Product):
 
         if self.toolchain.distcc_pump:
             cmake_build.append(self.toolchain.distcc_pump)
+
+        # If we are verbose...
+        if self.is_verbose():
+            # And ninja, add a -v.
+            if self.args.cmake_generator == "Ninja":
+                build_args.append('-v')
+
         cmake_args = [self.toolchain.cmake, "--build", self.build_dir,
                       "--config", build_type, "--"]
         cmake_build.extend(cmake_args + build_args)

--- a/utils/swift_build_support/swift_build_support/products/cmake_product.py
+++ b/utils/swift_build_support/swift_build_support/products/cmake_product.py
@@ -18,10 +18,12 @@ from .. import shell
 
 
 class CMakeProduct(product.Product):
-    def build_with_cmake(self, build_targets, build_type, build_args):
+    def build_with_cmake(self, build_targets, build_type, build_args,
+                         prefer_just_built_toolchain=False):
         assert self.toolchain.cmake is not None
         cmake_build = []
-        _cmake = cmake.CMake(self.args, self.toolchain)
+        _cmake = cmake.CMake(self.args, self.toolchain,
+                             prefer_just_built_toolchain)
 
         if self.toolchain.distcc_pump:
             cmake_build.append(self.toolchain.distcc_pump)
@@ -52,7 +54,7 @@ class CMakeProduct(product.Product):
 
             with shell.pushd(self.build_dir):
                 shell.call([self.toolchain.cmake] + list(self.cmake_options) +
-                           list(_cmake.common_options()) +
+                           list(_cmake.common_options(self)) +
                            self.args.extra_cmake_options + [self.source_dir],
                            env=env)
 

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -47,6 +47,7 @@ class CMakeTestCase(unittest.TestCase):
         """
         return Namespace(host_cc="/path/to/clang",
                          host_cxx="/path/to/clang++",
+                         host_swiftc="/path/to/swiftc",
                          host_libtool="/path/to/libtool",
                          host_ar="/path/to/ar",
                          enable_asan=False,
@@ -81,6 +82,7 @@ class CMakeTestCase(unittest.TestCase):
         toolchain = host_toolchain()
         toolchain.cc = args.host_cc
         toolchain.cxx = args.host_cxx
+        toolchain.swiftc = args.host_swiftc
         toolchain.libtool = args.host_libtool
         toolchain.ar = args.host_ar
         if args.distcc:
@@ -98,6 +100,7 @@ class CMakeTestCase(unittest.TestCase):
             ["-G", "Ninja",
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_Swift_COMPILER:PATH=/path/to/swiftc",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
              "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
@@ -112,6 +115,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DLLVM_USE_SANITIZER=Address",
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_Swift_COMPILER:PATH=/path/to/swiftc",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
              "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
@@ -126,6 +130,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DLLVM_USE_SANITIZER=Undefined",
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_Swift_COMPILER:PATH=/path/to/swiftc",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
              "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
@@ -140,6 +145,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DLLVM_USE_SANITIZER=Thread",
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_Swift_COMPILER:PATH=/path/to/swiftc",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
              "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
@@ -155,6 +161,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DLLVM_USE_SANITIZER=Address;Undefined",
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_Swift_COMPILER:PATH=/path/to/swiftc",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
              "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
@@ -170,6 +177,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DLLVM_USE_SANITIZER=Undefined;Thread",
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_Swift_COMPILER:PATH=/path/to/swiftc",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
              "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
@@ -186,6 +194,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DLLVM_USE_SANITIZER=Address;Undefined;Thread",
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_Swift_COMPILER:PATH=/path/to/swiftc",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
              "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
@@ -200,6 +209,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DLLVM_USE_SANITIZER=Leaks",
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_Swift_COMPILER:PATH=/path/to/swiftc",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
              "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
@@ -214,6 +224,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DLLVM_USE_SANITIZE_COVERAGE=ON",
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_Swift_COMPILER:PATH=/path/to/swiftc",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
              "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
@@ -228,6 +239,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_Swift_COMPILER:PATH=/path/to/swiftc",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
              "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
@@ -243,6 +255,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_CXX_COMPILER_LAUNCHER:PATH=" + self.mock_distcc_path(),
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_Swift_COMPILER:PATH=/path/to/swiftc",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
              "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
@@ -258,6 +271,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_CXX_COMPILER_LAUNCHER:PATH=" + self.mock_sccache_path(),
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_Swift_COMPILER:PATH=/path/to/swiftc",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
              "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
@@ -276,6 +290,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_CXX_COMPILER_LAUNCHER:PATH=" + cmake_cxx_launcher,
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_Swift_COMPILER:PATH=/path/to/swiftc",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
              "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
@@ -289,6 +304,7 @@ class CMakeTestCase(unittest.TestCase):
             ["-G", "Xcode",
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_Swift_COMPILER:PATH=/path/to/swiftc",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
              "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_CONFIGURATION_TYPES=" +
@@ -303,6 +319,7 @@ class CMakeTestCase(unittest.TestCase):
             ["-G", "Ninja",
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_Swift_COMPILER:PATH=/path/to/swiftc",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
              "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
@@ -316,6 +333,7 @@ class CMakeTestCase(unittest.TestCase):
             ["-G", "Ninja",
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_Swift_COMPILER:PATH=/path/to/swiftc",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
              "-DCMAKE_AR:PATH=/path/to/ar",
              "-DLLVM_VERSION_MAJOR:STRING=9",
@@ -335,6 +353,7 @@ class CMakeTestCase(unittest.TestCase):
             ["-G", "Ninja",
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_Swift_COMPILER:PATH=/path/to/swiftc",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
              "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_MAKE_PROGRAM=" + self.which_ninja(args)])
@@ -359,6 +378,7 @@ class CMakeTestCase(unittest.TestCase):
              "-DCMAKE_CXX_COMPILER_LAUNCHER:PATH=" + self.mock_distcc_path(),
              "-DCMAKE_C_COMPILER:PATH=/path/to/clang",
              "-DCMAKE_CXX_COMPILER:PATH=/path/to/clang++",
+             "-DCMAKE_Swift_COMPILER:PATH=/path/to/swiftc",
              "-DCMAKE_LIBTOOL:PATH=/path/to/libtool",
              "-DCMAKE_AR:PATH=/path/to/ar",
              "-DCMAKE_CONFIGURATION_TYPES=" +


### PR DESCRIPTION
In this PR, I am introducing some new infrastructure to enable me to begin staging in the multi-compilerstage swift build-script product build. This will let us eventually have a stage1 build-script based on this and in the shorter-term be able to bootstrap libswift on platforms where we do not have a toolchain (important for Linux/windows where we do not have a toolchain on the bots).

The key thing here is that I have:

1. Added support for CMakeProduct subclasses to be able to opt into building against the just built toolchain. No one specifies this today but I will need it for the stage2 compiler.
2. I added support in HostSpecificConfiguration for dynamically depending on the stage accepting certain stage specific args. The key thing is that it is the same set of options, we just post-fix with _stage2 in the case of a stage2 compiler. This will ensure we can have a single implementation of this code for both compiler stages.

One last thing to note: even though this is adding support for a full stage 2 compiler, we will not actually typically use a full stage2 compilation. Instead most of the time we will do a stage2 compilation where we tell the compiler to just use the just built compiler to build a new stdlib/build libswift/relink swiftc.