### PR TITLE
Frontend: remove -emit-ldadd-cfile-path. NFC

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -251,11 +251,6 @@ ERROR(tbd_not_supported_with_cmo,none,
         "Test-Based InstallAPI (TBD) is not support with cross-module-optimization",
         ())
 
-WARNING(linker_directives_choice_confusion,none,
-        "only one of -emit-ldadd-cfile-path and -module-installname-map-file can be specified;"
-        "the c file won't be generated",
-        ())
-
 ERROR(previous_installname_map_missing,none,
       "cannot open previous install name map from %0",
       (StringRef))

--- a/include/swift/Basic/SupplementaryOutputPaths.h
+++ b/include/swift/Basic/SupplementaryOutputPaths.h
@@ -140,16 +140,6 @@ struct SupplementaryOutputPaths {
   /// \sa ModuleInterfaceOutputPath
   std::string PrivateModuleInterfaceOutputPath;
 
-  /// The path to a .c file where we should declare $ld$add symbols for those
-  /// symbols moved to the current module.
-  /// When symbols are moved to this module, this module declares them as HIDE
-  /// for the OS versions prior to when the move happened. On the other hand, the
-  /// original module should ADD them for these OS versions. An executable
-  /// can choose the right library to link against depending on the deployment target.
-  /// This is a walk-around that linker directives cannot specify other install
-  /// name per symbol, we should eventually remove this.
-  std::string LdAddCFilePath;
-
   /// The path to which we should emit module summary file.
   std::string ModuleSummaryOutputPath;
 
@@ -182,8 +172,6 @@ struct SupplementaryOutputPaths {
       fn(ModuleInterfaceOutputPath); 
     if (!PrivateModuleInterfaceOutputPath.empty())
       fn(PrivateModuleInterfaceOutputPath); 
-    if (!LdAddCFilePath.empty())
-      fn(LdAddCFilePath); 
     if (!ModuleSummaryOutputPath.empty())
       fn(ModuleSummaryOutputPath);
   }
@@ -194,7 +182,7 @@ struct SupplementaryOutputPaths {
            ReferenceDependenciesFilePath.empty() &&
            SerializedDiagnosticsPath.empty() && LoadedModuleTracePath.empty() &&
            TBDPath.empty() && ModuleInterfaceOutputPath.empty() &&
-           ModuleSourceInfoOutputPath.empty() && LdAddCFilePath.empty();
+           ModuleSourceInfoOutputPath.empty();
   }
 };
 } // namespace swift

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -391,8 +391,6 @@ public:
   std::string getModuleInterfaceOutputPathForWholeModule() const;
   std::string getPrivateModuleInterfaceOutputPathForWholeModule() const;
 
-  std::string getLdAddCFileOutputPathForWholeModule() const;
-
 public:
   /// Given the current configuration of this frontend invocation, a set of
   /// supplementary output paths, and a module, compute the appropriate set of

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -787,10 +787,6 @@ def type_info_dump_filter_EQ : Joined<["-"], "type-info-dump-filter=">,
   Flags<[FrontendOption]>,
   HelpText<"One of 'all', 'resilient' or 'fragile'">;
 
-def emit_ldadd_cfile_path
-  : Separate<["-"], "emit-ldadd-cfile-path">, MetaVarName<"<path>">,
-    HelpText<"Generate .c file defining symbols to add back">;
-
 def previous_module_installname_map_file
   : Separate<["-"], "previous-module-installname-map-file">, MetaVarName<"<path>">,
     HelpText<"Path to a Json file indicating module name to installname map for @_originallyDefinedIn">;

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -337,15 +337,13 @@ SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
       options::OPT_emit_private_module_interface_path);
   auto moduleSourceInfoOutput = getSupplementaryFilenamesFromArguments(
       options::OPT_emit_module_source_info_path);
-  auto ldAddCFileOutput  = getSupplementaryFilenamesFromArguments(
-      options::OPT_emit_ldadd_cfile_path);
   auto moduleSummaryOutput = getSupplementaryFilenamesFromArguments(
       options::OPT_emit_module_summary_path);
   if (!objCHeaderOutput || !moduleOutput || !moduleDocOutput ||
       !dependenciesFile || !referenceDependenciesFile ||
       !serializedDiagnostics || !fixItsOutput || !loadedModuleTrace || !TBD ||
       !moduleInterfaceOutput || !privateModuleInterfaceOutput ||
-      !moduleSourceInfoOutput || !ldAddCFileOutput || !moduleSummaryOutput) {
+      !moduleSourceInfoOutput || !moduleSummaryOutput) {
     return None;
   }
   std::vector<SupplementaryOutputPaths> result;
@@ -366,7 +364,6 @@ SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
     sop.ModuleInterfaceOutputPath = (*moduleInterfaceOutput)[i];
     sop.PrivateModuleInterfaceOutputPath = (*privateModuleInterfaceOutput)[i];
     sop.ModuleSourceInfoOutputPath = (*moduleSourceInfoOutput)[i];
-    sop.LdAddCFilePath = (*ldAddCFileOutput)[i];
     sop.ModuleSummaryOutputPath = (*moduleSummaryOutput)[i];
     result.push_back(sop);
   }
@@ -490,7 +487,6 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
   sop.ModuleInterfaceOutputPath = ModuleInterfaceOutputPath;
   sop.PrivateModuleInterfaceOutputPath = PrivateModuleInterfaceOutputPath;
   sop.ModuleSourceInfoOutputPath = moduleSourceInfoOutputPath;
-  sop.LdAddCFilePath = pathsFromArguments.LdAddCFilePath;
   sop.ModuleSummaryOutputPath = moduleSummaryOutputPath;
   return sop;
 }
@@ -596,8 +592,7 @@ SupplementaryOutputPathsComputer::readSupplementaryOutputFileMap() const {
         options::OPT_emit_module_interface_path,
         options::OPT_emit_private_module_interface_path,
         options::OPT_emit_module_source_info_path,
-        options::OPT_emit_tbd_path,
-        options::OPT_emit_ldadd_cfile_path)) {
+        options::OPT_emit_tbd_path)) {
     Diags.diagnose(SourceLoc(),
                    diag::error_cannot_have_supplementary_outputs,
                    A->getSpelling(), "-supplementary-output-file-map");

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -117,14 +117,6 @@ std::string CompilerInvocation::getTBDPathForWholeModule() const {
 }
 
 std::string
-CompilerInvocation::getLdAddCFileOutputPathForWholeModule() const {
-  assert(getFrontendOptions().InputsAndOutputs.isWholeModule() &&
-         "LdAdd cfile only makes sense when the whole module can be seen");
-  return getPrimarySpecificPathsForAtMostOnePrimary()
-    .SupplementaryOutputs.LdAddCFilePath;
-}
-
-std::string
 CompilerInvocation::getModuleInterfaceOutputPathForWholeModule() const {
   assert(getFrontendOptions().InputsAndOutputs.isWholeModule() &&
          "ModuleInterfaceOutputPath only makes sense when the whole module "

--- a/test/TBD/linker-directives.swift
+++ b/test/TBD/linker-directives.swift
@@ -17,9 +17,3 @@ public func toast() {}
 
 // CHECK-HAS-NOT-NOT: $ld$hide$os10.15$_$s10ToasterKit5toastyyF
 // CHECK-HAS-NOT-NOT: $ld$hide$os10.7$_$s10ToasterKit5toastyyF
-
-// RUN: %target-swift-frontend -typecheck %s -emit-tbd -emit-tbd-path %t/linker_directives.tbd -emit-ldadd-cfile-path %t/ldAdd.c -module-name AppKit
-// RUN: %FileCheck %s --check-prefix CHECK-C-SYMBOL < %t/ldAdd.c
-
-// CHECK-C-SYMBOL: $ld$add$os10.8$_$s10ToasterKit5toastyyF
-// CHECK-C-SYMBOL: $ld$add$os10.14$_$s10ToasterKit5toastyyF


### PR DESCRIPTION
ld should now fully support $ld$previous$, so we shouldn't need this workaround
to generate a C source file to include $ld$add$ definitions.
