### PR TITLE
Mark legacy overloads of &+ and &- unavailable.

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -3511,7 +3511,10 @@ public protocol SignedInteger: BinaryInteger, SignedNumeric {
   //
   // generated a call to `static Swift.SignedInteger._maskingAdd(A, A) -> A`
   // when compiled with Swift 5.5 and earlier.
+  @available(*, deprecated, message: "Use &+ instead.")
   static func _maskingAdd(_ lhs: Self, _ rhs: Self) -> Self
+  
+  @available(*, deprecated, message: "Use &- instead.")
   static func _maskingSubtract(_ lhs: Self, _ rhs: Self) -> Self
 }
 
@@ -3640,10 +3643,12 @@ public func numericCast<T: BinaryInteger, U: BinaryInteger>(_ x: T) -> U {
 // Needed to support user-defined types conformance to SignedInteger.
 // We need these defaults to exist, but they are not called.
 extension SignedInteger {
+  @available(*, deprecated, message: "Use &+ instead.")
   public static func _maskingAdd(_ lhs: Self, _ rhs: Self) -> Self {
     fatalError("Should be overridden in a more specific type")
   }
   
+  @available(*, deprecated, message: "Use &- instead.")
   public static func _maskingSubtract(_ lhs: Self, _ rhs: Self) -> Self {
     fatalError("Should be overridden in a more specific type")
   }
@@ -3654,7 +3659,7 @@ extension SignedInteger {
 extension SignedInteger where Self: FixedWidthInteger {
   @available(*, unavailable)
   public static func &+(lhs: Self, rhs: Self) -> Self {
-    return lhs.addingReportingOverflow(rhs).partialValue
+    lhs.addingReportingOverflow(rhs).partialValue
   }
   
   // This may be called in rare situations by binaries compiled with
@@ -3663,12 +3668,12 @@ extension SignedInteger where Self: FixedWidthInteger {
   // types in the standard library would not satisfy the protocol requirements.
   @available(*, deprecated, message: "Use &+ instead.")
   public static func _maskingAdd(_ lhs: Self, _ rhs: Self) -> Self {
-    return lhs.addingReportingOverflow(rhs).partialValue
+    lhs.addingReportingOverflow(rhs).partialValue
   }
 
   @available(*, unavailable)
   public static func &-(lhs: Self, rhs: Self) -> Self {
-    return lhs.subtractingReportingOverflow(rhs).partialValue
+    lhs.subtractingReportingOverflow(rhs).partialValue
   }
   
   // This may be called in rare situations by binaries compiled with
@@ -3677,6 +3682,6 @@ extension SignedInteger where Self: FixedWidthInteger {
   // types in the standard library would not satisfy the protocol requirements.
   @available(*, deprecated, message: "Use &- instead.")
   public static func _maskingSubtract(_ lhs: Self, _ rhs: Self) -> Self {
-    return lhs.subtractingReportingOverflow(rhs).partialValue
+    lhs.subtractingReportingOverflow(rhs).partialValue
   }
 }

--- a/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
@@ -2,3 +2,8 @@ Protocol CodingKey has added inherited protocol Sendable
 Protocol CodingKey has generic signature change from <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomStringConvertible> to <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomStringConvertible, Self : Swift.Sendable>
 Protocol Error has added inherited protocol Sendable
 Protocol Error has generic signature change from to <Self : Swift.Sendable>
+
+// Not actually a source break; the typechecker will find these operations on
+// FixedWidthInteger instead.
+Func SignedInteger.&+(_:_:) has been removed
+Func SignedInteger.&-(_:_:) has been removed

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -72,4 +72,11 @@ Protocol Error has added inherited protocol Sendable
 Protocol Error has generic signature change from to <Self : Swift.Sendable>
 Enum Never has added a conformance to an existing protocol Identifiable
 
+// These haven't actually been removed; they are simply marked unavailable.
+// This seems to be a false positive in the ABI checker. This is not an ABI
+// break because the symbols are still present, and is not a source break
+// because FixedWidthInteger still has these operations.
+Func SignedInteger.&+(_:_:) has been removed
+Func SignedInteger.&-(_:_:) has been removed
+
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)


### PR DESCRIPTION
These were defined for both FixedWidthInteger and FixedWidthInteger & SignedInteger for source compatibility with Swift 3; the latter set probably should have been removed when we stabilized the ABI, but were not. We can't easily remove them entirely (because we need them for ABI stability now), but we can mark them unavailable so that the typechecker doesn't have to consider them.

https://forums.swift.org/t/very-long-compilation-times-with-custom-and-but-not-with-and/50789/3