### PR TITLE
[AST] Enforce that ParenExpr is typed as ParenType

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2008,6 +2008,15 @@ public:
       verifyCheckedBase(E);
     }
 
+    void verifyChecked(ParenExpr *E) {
+      PrettyStackTraceExpr debugStack(Ctx, "verifying ParenExpr", E);
+      if (!isa<ParenType>(E->getType().getPointer())) {
+        Out << "ParenExpr not of ParenType\n";
+        abort();
+      }
+      verifyCheckedBase(E);
+    }
+
     void verifyChecked(AnyTryExpr *E) {
       PrettyStackTraceExpr debugStack(Ctx, "verifying AnyTryExpr", E);
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6178,8 +6178,15 @@ static bool applyTypeToClosureExpr(ConstraintSystem &cs,
                                    Expr *expr, Type toType) {
   // Look through identity expressions, like parens.
   if (auto IE = dyn_cast<IdentityExpr>(expr)) {
-    if (!applyTypeToClosureExpr(cs, IE->getSubExpr(), toType)) return false;
-    cs.setType(IE, toType);
+    if (!applyTypeToClosureExpr(cs, IE->getSubExpr(), toType))
+      return false;
+
+    auto subExprTy = cs.getType(IE->getSubExpr());
+    if (isa<ParenExpr>(IE)) {
+      cs.setType(IE, ParenType::get(cs.getASTContext(), subExprTy));
+    } else {
+      cs.setType(IE, subExprTy);
+    }
     return true;
   }
 

--- a/test/expr/closure/nested_inner_closures.swift
+++ b/test/expr/closure/nested_inner_closures.swift
@@ -5,3 +5,4 @@ assert({ () -> Bool in
 }(), "")
 
 var x = ({ () -> String in return "s" })()
+var y = ((({ () -> String in return "s" })))()


### PR DESCRIPTION
Make sure we don't accidentally drop the sugar of the type.