### PR TITLE
[Reflection] Fix iterateAsyncTaskAllocations again.

### DIFF
--- a/include/swift/Reflection/RuntimeInternals.h
+++ b/include/swift/Reflection/RuntimeInternals.h
@@ -21,6 +21,8 @@
 #ifndef SWIFT_REFLECTION_RUNTIME_INTERNALS_H
 #define SWIFT_REFLECTION_RUNTIME_INTERNALS_H
 
+#include <stdint.h>
+
 namespace swift {
 
 namespace reflection {
@@ -91,8 +93,14 @@ struct StackAllocator {
 };
 
 template <typename Runtime>
+struct ActiveTaskStatus {
+  typename Runtime::StoredPointer Record;
+  typename Runtime::StoredSize Flags;
+};
+
+template <typename Runtime>
 struct AsyncTaskPrivateStorage {
-  typename Runtime::StoredSize Status;
+  ActiveTaskStatus<Runtime> Status;
   StackAllocator<Runtime> Allocator;
   typename Runtime::StoredPointer Local;
 };

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -40,8 +40,10 @@ extern unsigned long long swift_reflection_classIsSwiftMask;
 /// presence of a bug fix or feature that can't be detected from the outside
 /// otherwise. The currently used version numbers are:
 ///
-/// 0 - Indicates that swift_reflection_iterateAsyncTaskAllocations has been
-///     fixed to use the right AsyncTask layout.
+/// 0 - Indicates that swift_reflection_iterateAsyncTaskAllocations has the
+///     first attempted fix to use the right AsyncTask layout.
+/// 1 - Indicates that swift_reflection_iterateAsyncTaskAllocations has been
+///     actually fixed to use the right AsyncTask layout.
 SWIFT_REMOTE_MIRROR_LINKAGE extern uint32_t swift_reflection_libraryVersion;
 
 /// Get the metadata version supported by the Remote Mirror library.

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -18,7 +18,7 @@ extern "C" {
 SWIFT_REMOTE_MIRROR_LINKAGE
 unsigned long long swift_reflection_classIsSwiftMask = 2;
 
-SWIFT_REMOTE_MIRROR_LINKAGE uint32_t swift_reflection_libraryVersion = 0;
+SWIFT_REMOTE_MIRROR_LINKAGE uint32_t swift_reflection_libraryVersion = 1;
 }
 
 #include "swift/Demangling/Demangler.h"


### PR DESCRIPTION
We were missing a Status field. The reflect_task test didn't catch this becasue it was reading LastAllocation as FirstSlab, which still worked well enough in that context.

rdar://81427584