### PR TITLE
Preserve -requirement-machine=(off|on|verify) in module interfaces

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -273,9 +273,6 @@ def debug_constraints_on_line_EQ : Joined<["-"], "debug-constraints-on-line=">,
 def disable_named_lazy_member_loading : Flag<["-"], "disable-named-lazy-member-loading">,
   HelpText<"Disable per-name lazy member loading">;
 
-def requirement_machine_EQ : Joined<["-"], "requirement-machine=">,
-  HelpText<"Control usage of experimental generics implementation: 'on', 'off', or 'verify'">;
-
 def debug_requirement_machine : Flag<["-"], "debug-requirement-machine">,
   HelpText<"Enables debugging output from the generics implementation">;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -603,6 +603,10 @@ def experimental_emit_module_separately:
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
   HelpText<"Schedule a swift module emission job instead of a merge-modules job (new Driver only)">;
 
+def requirement_machine_EQ : Joined<["-"], "requirement-machine=">,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
+  HelpText<"Control usage of experimental generics implementation: 'on', 'off', or 'verify'">;
+
 // Diagnostic control options
 def suppress_warnings : Flag<["-"], "suppress-warnings">,
   Flags<[FrontendOption]>,


### PR DESCRIPTION
Hopefully I won't regret this later. This is needed to ensure that clients
of _Differentiation.swiftinterface don't fall over while building a module
from the interface.