### PR TITLE
Lower the async task slab allocation to 1000 bytes.

### DIFF
--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -264,9 +264,7 @@ public:
 };
 
 /// The size of an allocator slab.
-///
-/// TODO: find the optimal value by experiment.
-static constexpr size_t SlabCapacity = 1024;
+static constexpr size_t SlabCapacity = 1000;
 
 using TaskAllocator = StackAllocator<SlabCapacity>;
 


### PR DESCRIPTION
Due to malloc quanta rounding, 1024-byte async task allocation slabs
actually end up allocating 1536 bytes on Darwin. Instead, use 1000-byte
slabs.

Fixes rdar://81181856.
