### PR TITLE
Rip designated types out of the AST

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -435,11 +435,12 @@ ERROR(deprecated_operator_body_use_group,PointsToFirstBadToken,
       "use a precedence group instead", ())
 ERROR(operator_decl_no_fixity,none,
       "operator must be declared as 'prefix', 'postfix', or 'infix'", ())
+ERROR(operator_decl_expected_precedencegroup, none,
+      "expected precedence group name after ':' in operator declaration", ())
 
-ERROR(operator_decl_expected_type,none,
-      "expected designated type in operator declaration", ())
-ERROR(operator_decl_trailing_comma,none,
-      "trailing comma in operator declaration", ())
+WARNING(operator_decl_remove_designated_types,none,
+        "designated types are no longer used by the compiler; please remove "
+        "the designated type list from this operator declaration", ())
 
 // PrecedenceGroup
 ERROR(precedencegroup_not_infix,none,

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1145,43 +1145,23 @@ namespace {
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
 
-    void printOperatorIdentifiers(OperatorDecl *OD) {
-      auto identifiers = OD->getIdentifiers();
-      for (auto index : indices(identifiers)) {
-        OS.indent(Indent + 2);
-        OS << "identifier #" << index << " " << identifiers[index].Item;
-        if (index != identifiers.size() - 1)
-          OS << "\n";
-      }
-    }
-
     void visitInfixOperatorDecl(InfixOperatorDecl *IOD) {
       printCommon(IOD, "infix_operator_decl");
       OS << " " << IOD->getName();
-      if (!IOD->getIdentifiers().empty()) {
-        OS << "\n";
-        printOperatorIdentifiers(IOD);
-      }
+      if (!IOD->getPrecedenceGroupName().empty())
+        OS << " precedence_group_name=" << IOD->getPrecedenceGroupName();
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
 
     void visitPrefixOperatorDecl(PrefixOperatorDecl *POD) {
       printCommon(POD, "prefix_operator_decl");
       OS << " " << POD->getName();
-      if (!POD->getIdentifiers().empty()) {
-        OS << "\n";
-        printOperatorIdentifiers(POD);
-      }
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
 
     void visitPostfixOperatorDecl(PostfixOperatorDecl *POD) {
       printCommon(POD, "postfix_operator_decl");
       OS << " " << POD->getName();
-      if (!POD->getIdentifiers().empty()) {
-        OS << "\n";
-        printOperatorIdentifiers(POD);
-      }
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3776,15 +3776,6 @@ void PrintAST::visitInfixOperatorDecl(InfixOperatorDecl *decl) {
     });
   if (auto *group = decl->getPrecedenceGroup())
     Printer << " : " << group->getName();
-  auto designatedNominalTypes = decl->getDesignatedNominalTypes();
-  auto first = true;
-  for (auto typeDecl : designatedNominalTypes) {
-    if (first && !decl->getPrecedenceGroup())
-      Printer << " : " << typeDecl->getName();
-    else
-      Printer << ", " << typeDecl->getName();
-    first = false;
-  }
 }
 
 void PrintAST::visitPrecedenceGroupDecl(PrecedenceGroupDecl *decl) {
@@ -3853,15 +3844,6 @@ void PrintAST::visitPrefixOperatorDecl(PrefixOperatorDecl *decl) {
     [&]{
       Printer.printName(decl->getName());
     });
-  auto designatedNominalTypes = decl->getDesignatedNominalTypes();
-  auto first = true;
-  for (auto typeDecl : designatedNominalTypes) {
-    if (first)
-      Printer << " : " << typeDecl->getName();
-    else
-      Printer << ", " << typeDecl->getName();
-    first = false;
-  }
 }
 
 void PrintAST::visitPostfixOperatorDecl(PostfixOperatorDecl *decl) {
@@ -3871,15 +3853,6 @@ void PrintAST::visitPostfixOperatorDecl(PostfixOperatorDecl *decl) {
     [&]{
       Printer.printName(decl->getName());
     });
-  auto designatedNominalTypes = decl->getDesignatedNominalTypes();
-  auto first = true;
-  for (auto typeDecl : designatedNominalTypes) {
-    if (first)
-      Printer << " : " << typeDecl->getName();
-    else
-      Printer << ", " << typeDecl->getName();
-    first = false;
-  }
 }
 
 void PrintAST::visitModuleDecl(ModuleDecl *decl) { }

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1874,12 +1874,10 @@ public:
   }
 
   void visitInfixOperatorDecl(InfixOperatorDecl *IOD) {
-    // FIXME: Handle operator designated types (which also applies to prefix
-    // and postfix operators).
     if (auto *precedenceGroup = IOD->getPrecedenceGroup()) {
-      if (!IOD->getIdentifiers().empty()) {
+      if (!IOD->getPrecedenceGroupName().empty()) {
         checkPrecedenceGroup(precedenceGroup, IOD, IOD->getLoc(),
-                             IOD->getIdentifiers().front().Loc);
+                             IOD->getPrecedenceGroupLoc());
       }
     }
   }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1524,44 +1524,19 @@ TypeChecker::lookupPrecedenceGroup(DeclContext *dc, Identifier name,
   return PrecedenceGroupLookupResult(dc, name, std::move(groups));
 }
 
-static NominalTypeDecl *resolveSingleNominalTypeDecl(
-    DeclContext *DC, SourceLoc loc, Identifier ident, ASTContext &Ctx,
-    TypeResolutionFlags flags = TypeResolutionFlags(0)) {
+static bool canResolveSingleNominalTypeDecl(
+    DeclContext *DC, SourceLoc loc, Identifier ident, ASTContext &Ctx) {
   auto *TyR = new (Ctx) SimpleIdentTypeRepr(DeclNameLoc(loc),
                                             DeclNameRef(ident));
 
-  const auto options =
-      TypeResolutionOptions(TypeResolverContext::TypeAliasDecl) | flags;
-
+  TypeResolutionOptions options{TypeResolverContext::TypeAliasDecl};
+  options |= TypeResolutionFlags::SilenceErrors;
   const auto result =
-      TypeResolution::forInterface(DC, options,
-                                   // FIXME: Should unbound generics be allowed
-                                   // to appear amongst designated types?
-                                   /*unboundTyOpener*/ nullptr,
+      TypeResolution::forInterface(DC, options, /*unboundTyOpener*/ nullptr,
                                    /*placeholderHandler*/ nullptr)
           .resolveType(TyR);
 
-  if (result->hasError())
-    return nullptr;
-  return result->getAnyNominal();
-}
-
-bool swift::checkDesignatedTypes(OperatorDecl *OD,
-                                 ArrayRef<Located<Identifier>> identifiers) {
-  auto &ctx = OD->getASTContext();
-  auto *DC = OD->getDeclContext();
-
-  SmallVector<NominalTypeDecl *, 1> designatedNominalTypes;
-  for (auto ident : identifiers) {
-    auto *decl = resolveSingleNominalTypeDecl(DC, ident.Loc, ident.Item, ctx);
-    if (!decl)
-      return true;
-
-    designatedNominalTypes.push_back(decl);
-  }
-
-  OD->setDesignatedNominalTypes(ctx.AllocateCopy(designatedNominalTypes));
-  return false;
+  return !result->hasError();
 }
 
 /// Validate the given operator declaration.
@@ -1575,49 +1550,28 @@ OperatorPrecedenceGroupRequest::evaluate(Evaluator &evaluator,
   auto &ctx = IOD->getASTContext();
   auto *dc = IOD->getDeclContext();
 
-  auto enableOperatorDesignatedTypes =
-      ctx.TypeCheckerOpts.EnableOperatorDesignatedTypes;
-
-  PrecedenceGroupDecl *group = nullptr;
-
-  auto identifiers = IOD->getIdentifiers();
-  if (!identifiers.empty()) {
-    auto name = identifiers[0].Item;
-    auto loc = identifiers[0].Loc;
-
-    auto canResolveType = [&]() -> bool {
-      return enableOperatorDesignatedTypes &&
-             resolveSingleNominalTypeDecl(dc, loc, name, ctx,
-                                          TypeResolutionFlags::SilenceErrors);
-    };
-
-    // Make sure not to diagnose in the case where we failed to find a
-    // precedencegroup, but we could resolve a type instead.
+  auto name = IOD->getPrecedenceGroupName();
+  if (!name.empty()) {
+    auto loc = IOD->getPrecedenceGroupLoc();
     auto groups = TypeChecker::lookupPrecedenceGroup(dc, name, loc);
-    if (groups.hasResults() || !canResolveType()) {
-      group = groups.getSingleOrDiagnose(loc);
-      identifiers = identifiers.slice(1);
-    }
+
+    bool wasActuallyADesignatedType = !groups.hasResults() &&
+        ctx.TypeCheckerOpts.EnableOperatorDesignatedTypes &&
+        canResolveSingleNominalTypeDecl(dc, loc, name, ctx);
+
+    if (!wasActuallyADesignatedType)
+      return groups.getSingleOrDiagnose(loc);
+
+    // Warn about the designated type, then fall through to look up
+    // DefaultPrecedence as though `PrecedenceGroupName` had never been set.
+    ctx.Diags.diagnose(IOD->getColonLoc(),
+                       diag::operator_decl_remove_designated_types)
+        .fixItRemove({IOD->getColonLoc(), loc});
   }
 
-  // Unless operator designed types are enabled, the parser will ensure that
-  // only one identifier is allowed in the clause, which we should have just
-  // handled.
-  assert(identifiers.empty() || enableOperatorDesignatedTypes);
-
-  if (!group) {
-    auto groups = TypeChecker::lookupPrecedenceGroup(
-        dc, ctx.Id_DefaultPrecedence, SourceLoc());
-    group = groups.getSingleOrDiagnose(IOD->getLoc(), /*forBuiltin*/ true);
-  }
-
-  auto nominalTypes = IOD->getDesignatedNominalTypes();
-  if (nominalTypes.empty() && enableOperatorDesignatedTypes) {
-    if (checkDesignatedTypes(IOD, identifiers)) {
-      IOD->setInvalid();
-    }
-  }
-  return group;
+  auto groups = TypeChecker::lookupPrecedenceGroup(
+      dc, ctx.Id_DefaultPrecedence, SourceLoc());
+  return groups.getSingleOrDiagnose(IOD->getLoc(), /*forBuiltin*/ true);
 }
 
 SelfAccessKind

--- a/lib/Sema/TypeCheckDecl.h
+++ b/lib/Sema/TypeCheckDecl.h
@@ -56,9 +56,6 @@ Optional<AutomaticEnumValueKind> computeAutomaticEnumValueKind(EnumDecl *ED);
 
 void validatePrecedenceGroup(PrecedenceGroupDecl *PGD);
 
-bool checkDesignatedTypes(OperatorDecl *OD,
-                          ArrayRef<Located<Identifier>> identifiers);
-
 void diagnoseAttrsAddedByAccessNote(SourceFile &SF);
 
 }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1746,20 +1746,8 @@ public:
   void visitOperatorDecl(OperatorDecl *OD) {
     TypeChecker::checkDeclAttributes(OD);
     checkRedeclaration(OD);
-    auto &Ctx = OD->getASTContext();
-    if (auto *IOD = dyn_cast<InfixOperatorDecl>(OD)) {
+    if (auto *IOD = dyn_cast<InfixOperatorDecl>(OD))
       (void)IOD->getPrecedenceGroup();
-    } else {
-      auto nominalTypes = OD->getDesignatedNominalTypes();
-      const auto wantsDesignatedTypes =
-          Ctx.TypeCheckerOpts.EnableOperatorDesignatedTypes;
-      if (nominalTypes.empty() && wantsDesignatedTypes) {
-        auto identifiers = OD->getIdentifiers();
-        if (checkDesignatedTypes(OD, identifiers))
-          OD->setInvalid();
-      }
-      return;
-    }
     checkAccessControl(OD);
   }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3632,27 +3632,16 @@ public:
                                             StringRef blobData) {
     IdentifierID nameID;
     DeclContextID contextID;
-    ArrayRef<uint64_t> designatedNominalTypeDeclIDs;
 
-    OperatorLayout::readRecord(scratch, nameID, contextID,
-                               designatedNominalTypeDeclIDs);
+    OperatorLayout::readRecord(scratch, nameID, contextID);
 
     Identifier name = MF.getIdentifier(nameID);
     PrettySupplementalDeclNameTrace trace(name);
 
     auto DC = MF.getDeclContext(contextID);
 
-    SmallVector<NominalTypeDecl *, 1> designatedNominalTypes;
-    for (auto id : designatedNominalTypeDeclIDs) {
-      Expected<Decl *> nominal = MF.getDeclChecked(id);
-      if (!nominal)
-        return nominal.takeError();
-      designatedNominalTypes.push_back(cast<NominalTypeDecl>(nominal.get()));
-    }
-
     auto result = MF.createDecl<OperatorDecl>(
-        DC, SourceLoc(), name, SourceLoc(),
-        ctx.AllocateCopy(designatedNominalTypes));
+        DC, SourceLoc(), name, SourceLoc());
 
     declOrOffset = result;
     return result;
@@ -3675,11 +3664,9 @@ public:
     IdentifierID nameID;
     DeclContextID contextID;
     DeclID precedenceGroupID;
-    ArrayRef<uint64_t> designatedNominalTypeDeclIDs;
 
     decls_block::InfixOperatorLayout::readRecord(scratch, nameID, contextID,
-                                                 precedenceGroupID,
-                                                 designatedNominalTypeDeclIDs);
+                                                 precedenceGroupID);
     Identifier name = MF.getIdentifier(nameID);
     PrettySupplementalDeclNameTrace trace(name);
 
@@ -3689,18 +3676,9 @@ public:
 
     auto DC = MF.getDeclContext(contextID);
 
-    SmallVector<NominalTypeDecl *, 1> designatedNominalTypes;
-    for (auto id : designatedNominalTypeDeclIDs) {
-      Expected<Decl *> nominal = MF.getDeclChecked(id);
-      if (!nominal)
-        return nominal.takeError();
-      designatedNominalTypes.push_back(cast<NominalTypeDecl>(nominal.get()));
-    }
-
     auto result = MF.createDecl<InfixOperatorDecl>(
-        DC, SourceLoc(), name, SourceLoc(), SourceLoc(),
-        ArrayRef<Located<Identifier>>{});
-    result->setDesignatedNominalTypes(ctx.AllocateCopy(designatedNominalTypes));
+        DC, SourceLoc(), name, SourceLoc(), SourceLoc(), Identifier(),
+        SourceLoc());
     ctx.evaluator.cacheOutput(
         OperatorPrecedenceGroupRequest{result},
         std::move(cast_or_null<PrecedenceGroupDecl>(precedenceGroup.get())));

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 622; // builtin conformance kind
+const uint16_t SWIFTMODULE_VERSION_MINOR = 623; // remove designated types
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1427,8 +1427,7 @@ namespace decls_block {
   using UnaryOperatorLayout = BCRecordLayout<
     Code, // ID field
     IdentifierIDField,  // name
-    DeclContextIDField, // context decl
-    BCArray<DeclIDField> // designated types
+    DeclContextIDField  // context decl
   >;
 
   using PrefixOperatorLayout = UnaryOperatorLayout<PREFIX_OPERATOR_DECL>;
@@ -1438,8 +1437,7 @@ namespace decls_block {
     INFIX_OPERATOR_DECL,
     IdentifierIDField, // name
     DeclContextIDField,// context decl
-    DeclIDField,       // precedence group
-    BCArray<DeclIDField> // designated types
+    DeclIDField        // precedence group
   >;
 
   using PrecedenceGroupLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3238,29 +3238,21 @@ public:
     auto contextID = S.addDeclContextRef(op->getDeclContext());
     auto nameID = S.addDeclBaseNameRef(op->getName());
     auto groupID = S.addDeclRef(op->getPrecedenceGroup());
-    SmallVector<DeclID, 1> designatedNominalTypeDeclIDs;
-    for (auto *decl : op->getDesignatedNominalTypes())
-      designatedNominalTypeDeclIDs.push_back(S.addDeclRef(decl));
 
     unsigned abbrCode = S.DeclTypeAbbrCodes[InfixOperatorLayout::Code];
     InfixOperatorLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode, nameID,
-                                    contextID.getOpaqueValue(), groupID,
-                                    designatedNominalTypeDeclIDs);
+                                    contextID.getOpaqueValue(), groupID);
 
   }
 
   template <typename Layout>
   void visitUnaryOperatorDecl(const OperatorDecl *op) {
     auto contextID = S.addDeclContextRef(op->getDeclContext());
-    SmallVector<DeclID, 1> designatedNominalTypeDeclIDs;
-    for (auto *decl : op->getDesignatedNominalTypes())
-      designatedNominalTypeDeclIDs.push_back(S.addDeclRef(decl));
 
     unsigned abbrCode = S.DeclTypeAbbrCodes[Layout::Code];
     Layout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
                        S.addDeclBaseNameRef(op->getName()),
-                       contextID.getOpaqueValue(),
-                       designatedNominalTypeDeclIDs);
+                       contextID.getOpaqueValue());
   }
 
   void visitPrefixOperatorDecl(const PrefixOperatorDecl *op) {

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -384,7 +384,7 @@ precedencegroup BitwiseShiftPrecedence {
 // Standard postfix operators.
 postfix operator ++
 postfix operator --
-postfix operator ...: Comparable
+postfix operator ...
 
 // Optional<T> unwrapping operator is built into the compiler as a part of
 // postfix expression grammar.
@@ -394,42 +394,42 @@ postfix operator ...: Comparable
 // Standard prefix operators.
 prefix operator ++
 prefix operator --
-prefix operator !: Bool
-prefix operator ~: BinaryInteger
-prefix operator +: AdditiveArithmetic
-prefix operator -: SignedNumeric
-prefix operator ...: Comparable
-prefix operator ..<: Comparable
+prefix operator !
+prefix operator ~
+prefix operator +
+prefix operator -
+prefix operator ...
+prefix operator ..<
 
 // Standard infix operators.
 
 // "Exponentiative"
 
-infix operator  <<: BitwiseShiftPrecedence, BinaryInteger
-infix operator &<<: BitwiseShiftPrecedence, FixedWidthInteger
-infix operator  >>: BitwiseShiftPrecedence, BinaryInteger
-infix operator &>>: BitwiseShiftPrecedence, FixedWidthInteger
+infix operator  <<: BitwiseShiftPrecedence
+infix operator &<<: BitwiseShiftPrecedence
+infix operator  >>: BitwiseShiftPrecedence
+infix operator &>>: BitwiseShiftPrecedence
 
 // "Multiplicative"
 
-infix operator   *: MultiplicationPrecedence, Numeric
-infix operator  &*: MultiplicationPrecedence, FixedWidthInteger
-infix operator   /: MultiplicationPrecedence, BinaryInteger, FloatingPoint
-infix operator   %: MultiplicationPrecedence, BinaryInteger
-infix operator   &: MultiplicationPrecedence, BinaryInteger
+infix operator   *: MultiplicationPrecedence
+infix operator  &*: MultiplicationPrecedence
+infix operator   /: MultiplicationPrecedence
+infix operator   %: MultiplicationPrecedence
+infix operator   &: MultiplicationPrecedence
 
 // "Additive"
 
-infix operator   +: AdditionPrecedence, AdditiveArithmetic, String, Array, Strideable
-infix operator  &+: AdditionPrecedence, FixedWidthInteger
-infix operator   -: AdditionPrecedence, AdditiveArithmetic, Strideable
-infix operator  &-: AdditionPrecedence, FixedWidthInteger
-infix operator   |: AdditionPrecedence, BinaryInteger
-infix operator   ^: AdditionPrecedence, BinaryInteger
+infix operator   +: AdditionPrecedence
+infix operator  &+: AdditionPrecedence
+infix operator   -: AdditionPrecedence
+infix operator  &-: AdditionPrecedence
+infix operator   |: AdditionPrecedence
+infix operator   ^: AdditionPrecedence
 
 // FIXME: is this the right precedence level for "..." ?
-infix operator  ...: RangeFormationPrecedence, Comparable
-infix operator  ..<: RangeFormationPrecedence, Comparable
+infix operator  ...: RangeFormationPrecedence
+infix operator  ..<: RangeFormationPrecedence
 
 // The cast operators 'as' and 'is' are hardcoded as if they had the
 // following attributes:
@@ -441,12 +441,12 @@ infix operator ??: NilCoalescingPrecedence
 
 // "Comparative"
 
-infix operator  <: ComparisonPrecedence, Comparable
-infix operator  <=: ComparisonPrecedence, Comparable
-infix operator  >: ComparisonPrecedence, Comparable
-infix operator  >=: ComparisonPrecedence, Comparable
-infix operator  ==: ComparisonPrecedence, Equatable
-infix operator  !=: ComparisonPrecedence, Equatable
+infix operator  <: ComparisonPrecedence
+infix operator  <=: ComparisonPrecedence
+infix operator  >: ComparisonPrecedence
+infix operator  >=: ComparisonPrecedence
+infix operator  ==: ComparisonPrecedence
+infix operator  !=: ComparisonPrecedence
 infix operator ===: ComparisonPrecedence
 infix operator !==: ComparisonPrecedence
 // FIXME: ~= will be built into the compiler.
@@ -454,11 +454,11 @@ infix operator  ~=: ComparisonPrecedence
 
 // "Conjunctive"
 
-infix operator &&: LogicalConjunctionPrecedence, Bool
+infix operator &&: LogicalConjunctionPrecedence
 
 // "Disjunctive"
 
-infix operator ||: LogicalDisjunctionPrecedence, Bool
+infix operator ||: LogicalDisjunctionPrecedence
 
 // User-defined ternary operators are not supported. The ? : operator is
 // hardcoded as if it had the following attributes:
@@ -470,21 +470,21 @@ infix operator ||: LogicalDisjunctionPrecedence, Bool
 
 // Compound
 
-infix operator   *=: AssignmentPrecedence, Numeric
-infix operator  &*=: AssignmentPrecedence, FixedWidthInteger
-infix operator   /=: AssignmentPrecedence, BinaryInteger
-infix operator   %=: AssignmentPrecedence, BinaryInteger
-infix operator   +=: AssignmentPrecedence, AdditiveArithmetic, String, Array, Strideable
-infix operator  &+=: AssignmentPrecedence, FixedWidthInteger
-infix operator   -=: AssignmentPrecedence, AdditiveArithmetic, Strideable
-infix operator  &-=: AssignmentPrecedence, FixedWidthInteger
-infix operator  <<=: AssignmentPrecedence, BinaryInteger
-infix operator &<<=: AssignmentPrecedence, FixedWidthInteger
-infix operator  >>=: AssignmentPrecedence, BinaryInteger
-infix operator &>>=: AssignmentPrecedence, FixedWidthInteger
-infix operator   &=: AssignmentPrecedence, BinaryInteger
-infix operator   ^=: AssignmentPrecedence, BinaryInteger
-infix operator   |=: AssignmentPrecedence, BinaryInteger
+infix operator   *=: AssignmentPrecedence
+infix operator  &*=: AssignmentPrecedence
+infix operator   /=: AssignmentPrecedence
+infix operator   %=: AssignmentPrecedence
+infix operator   +=: AssignmentPrecedence
+infix operator  &+=: AssignmentPrecedence
+infix operator   -=: AssignmentPrecedence
+infix operator  &-=: AssignmentPrecedence
+infix operator  <<=: AssignmentPrecedence
+infix operator &<<=: AssignmentPrecedence
+infix operator  >>=: AssignmentPrecedence
+infix operator &>>=: AssignmentPrecedence
+infix operator   &=: AssignmentPrecedence
+infix operator   ^=: AssignmentPrecedence
+infix operator   |=: AssignmentPrecedence
 
 // Workaround for <rdar://problem/14011860> SubTLF: Default
 // implementations in protocols.  Library authors should ensure

--- a/test/Parse/operator_decl.swift
+++ b/test/Parse/operator_decl.swift
@@ -63,7 +63,7 @@ infix operator =#=
 
 infix operator +++=
 infix operator *** : A
-infix operator --- : ;
+infix operator --- : ; // expected-error {{expected precedence group name after ':' in operator declaration}}
 
 precedencegroup { // expected-error {{expected identifier after 'precedencegroup'}}
   associativity: right

--- a/test/Parse/operator_decl_designated_types.swift
+++ b/test/Parse/operator_decl_designated_types.swift
@@ -19,8 +19,11 @@ protocol InfixMagicOperatorProtocol {
 }
 
 prefix operator ^^ : PrefixMagicOperatorProtocol
+// expected-warning@-1 {{designated types are no longer used by the compiler; please remove the designated type list from this operator declaration}} {{20-49=}}
 infix operator  <*< : MediumPrecedence, InfixMagicOperatorProtocol
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{39-67=}}
 postfix operator ^^ : PostfixMagicOperatorProtocol
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{21-51=}}
 
 infix operator ^*^
 prefix operator *^^
@@ -30,44 +33,56 @@ infix operator **>> : UndeclaredPrecedence
 // expected-error@-1 {{unknown precedence group 'UndeclaredPrecedence'}}
 
 infix operator **+> : MediumPrecedence, UndeclaredProtocol
-// expected-error@-1 {{cannot find type 'UndeclaredProtocol' in scope}}
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{39-59=}}
 
 prefix operator *+*> : MediumPrecedence
-// expected-error@-1 {{cannot find type 'MediumPrecedence' in scope}}
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{22-40=}}
 
 postfix operator ++*> : MediumPrecedence
-// expected-error@-1 {{cannot find type 'MediumPrecedence' in scope}}
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{23-41=}}
 
 prefix operator *++> : UndeclaredProtocol
-// expected-error@-1 {{cannot find type 'UndeclaredProtocol' in scope}}
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{22-42=}}
 postfix operator +*+> : UndeclaredProtocol
-// expected-error@-1 {{cannot find type 'UndeclaredProtocol' in scope}}
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{23-43=}}
 
 struct Struct {}
 class Class {}
 infix operator *>*> : Struct
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{21-29=}}
 infix operator >**> : Class
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{21-28=}}
 
 prefix operator **>> : Struct
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{22-30=}}
 prefix operator *>*> : Class
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{22-29=}}
 
 postfix operator >*>* : Struct
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{23-31=}}
 postfix operator >>** : Class
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{23-30=}}
 
 infix operator  <*<<< : MediumPrecedence, &
-// expected-error@-1 {{expected designated type in operator declaration}}
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{41-44=}}
 
 infix operator **^^ : MediumPrecedence // expected-note {{previous operator declaration here}}
 infix operator **^^ : InfixMagicOperatorProtocol // expected-error {{operator redeclared}}
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{21-50=}}
 
 infix operator ^%*%^ : MediumPrecedence, Struct, Class
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{40-55=}}
 infix operator ^%*%% : Struct, Class
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{30-37=}}
+// expected-warning@-2 {{designated types are no longer used by the compiler}} {{22-30=}}
 prefix operator %^*^^ : Struct, Class
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{23-38=}}
 postfix operator ^^*^% : Struct, Class
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{24-39=}}
 prefix operator %%*^^ : LowPrecedence, Class
-// expected-error@-1{{cannot find type 'LowPrecedence' in scope}}
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{23-45=}}
 postfix operator ^^*%% : MediumPrecedence, Class
-// expected-error@-1{{cannot find type 'MediumPrecedence' in scope}}
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{24-49=}}
 
-// expected-error@+1 {{trailing comma in operator declaration}}
 infix operator <*<>*> : AdditionPrecedence,
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{43-44=}}

--- a/test/Parse/operator_decl_designated_types.swift
+++ b/test/Parse/operator_decl_designated_types.swift
@@ -30,7 +30,7 @@ prefix operator *^^
 postfix operator ^^*
 
 infix operator **>> : UndeclaredPrecedence
-// expected-error@-1 {{unknown precedence group 'UndeclaredPrecedence'}}
+// expected-warning@-1 {{designated types are no longer used by the compiler}} {{21-43=}}
 
 infix operator **+> : MediumPrecedence, UndeclaredProtocol
 // expected-warning@-1 {{designated types are no longer used by the compiler}} {{39-59=}}


### PR DESCRIPTION
Designated types were removed from the constraint solver in #34315, but they are currently still represented in the AST and fully checked. This change removes them as completely as possible without breaking source compatibility (mainly with old swiftinterfaces) or changing the SwiftSyntax tree. Designated types are still parsed when the feature is enabled, but they are dropped immediately and a warning is diagnosed. During decl checking we also ~~still check if the precedence group is really a designated type, but only so that we can~~ diagnose a warning and fall back to DefaultPrecedence if a precedence group fails to resolve and designated types were enabled.

This change also fixes an apparent bug in the parser where we did not diagnose operator declarations that contained a `:` followed by a non-identifier token.

Part of work on #34556.