### PR TITLE
Lower the async task slab allocation to 1000 bytes.

### DIFF
--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -238,9 +238,7 @@ public:
 };
 
 /// The size of an allocator slab.
-///
-/// TODO: find the optimal value by experiment.
-static constexpr size_t SlabCapacity = 1024;
+static constexpr size_t SlabCapacity = 1000;
 
 using TaskAllocator = StackAllocator<SlabCapacity>;
 


### PR DESCRIPTION
**Explanation**: Due to malloc quanta rounding, 1024-byte async task allocation slabs actually end up allocating 1536 bytes on Darwin. Instead, use 1000-byte slabs to reduce the memory overhead of asynchronous tasks. This change only affects the concurrency runtime to lower its memory footprint.
**Scope**: Runtime-only change affecting new code using Swift's Concurrency model.
**Radar/SR Issue**:  rdar://81181856
**Risk**: Low.
**Reviewed By**: Mike Ash, John McCall
**Testing**: PR testing and CI
**Original PR**: https://github.com/apple/swift/pull/38727

