### PR TITLE
Re-enable remote_run tests that were disabled

### DIFF
--- a/test/Interpreter/indirect_enum.swift
+++ b/test/Interpreter/indirect_enum.swift
@@ -5,9 +5,6 @@
 // REQUIRES: executable_test
 // REQUIRES: asan_runtime
 
-// rdar://problem/47367694 tracks re-enabling this test for backward deployment.
-// UNSUPPORTED: remote_run
-
 // Make sure that we do not use-after-free here.
 
 class Box<T> {

--- a/test/Sanitizers/asan/asan.swift
+++ b/test/Sanitizers/asan/asan.swift
@@ -12,9 +12,6 @@
 // REQUIRES: executable_test
 // REQUIRES: asan_runtime
 
-// rdar://problem/47367694 tracks re-enabling this test for backward deployment.
-// UNSUPPORTED: remote_run
-
 // Make sure we can handle swifterror. LLVM's address sanitizer pass needs to
 // ignore swifterror addresses.
 

--- a/validation-test/execution/arc_36509461.swift
+++ b/validation-test/execution/arc_36509461.swift
@@ -10,9 +10,6 @@
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
 
-// rdar://problem/47367694 tracks re-enabling this test for backward deployment.
-// UNSUPPORTED: remote_run
-
 import Foundation
 
 struct FakeUUID {


### PR DESCRIPTION
The underlying issue was supposedly fixed a while ago.
