### PR TITLE
[SIL][DebugInfo] Bring advanced debug info to alloc_stack

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2493,13 +2493,13 @@ void IRGenDebugInfoImpl::emitVariableDeclaration(
       Operands.push_back(SizeInBits);
     }
     llvm::DIExpression *DIExpr = DBuilder.createExpression(Operands);
-    emitDbgIntrinsic(
-        Builder, Piece, Var,
-        // DW_OP_LLVM_fragment must be the last part of an DIExpr
-        // so we can't append more if IsPiece is true.
-        Operands.empty() || IsPiece ? DIExpr : appendDIExpression(DIExpr),
-        DInstLine, DInstLoc.column, Scope, DS,
-        Indirection == CoroDirectValue || Indirection == CoroIndirectValue);
+    emitDbgIntrinsic(Builder, Piece, Var,
+                     // DW_OP_LLVM_fragment must be the last part of an DIExpr
+                     // so we can't append more if IsPiece is true.
+                     IsPiece ? DIExpr : appendDIExpression(DIExpr), DInstLine,
+                     DInstLoc.column, Scope, DS,
+                     Indirection == CoroDirectValue ||
+                         Indirection == CoroIndirectValue);
   }
 
   // Emit locationless intrinsic for variables that were optimized away.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -5160,7 +5160,12 @@ void IRGenSILFunction::emitDebugInfoForAllocStack(AllocStackInst *i,
     }
   }
 
-  SILType SILTy = i->getType();
+  SILType SILTy;
+  if (auto MaybeSILTy = VarInfo->Type)
+    // If there is auxiliary type info, use it
+    SILTy = *MaybeSILTy;
+  else
+    SILTy = i->getType();
   auto RealType = SILTy.getASTType();
   DebugTypeInfo DbgTy;
   if (Decl) {

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1210,7 +1210,8 @@ public:
     if (AVI->hasDynamicLifetime())
       *this << "[dynamic_lifetime] ";
     *this << AVI->getElementType();
-    printDebugVar(AVI->getVarInfo());
+    printDebugVar(AVI->getVarInfo(),
+                  &AVI->getModule().getASTContext().SourceMgr);
   }
 
   void printAllocRefInstBase(AllocRefInstBase *ARI) {
@@ -1245,7 +1246,8 @@ public:
     if (ABI->hasDynamicLifetime())
       *this << "[dynamic_lifetime] ";
     *this << ABI->getType();
-    printDebugVar(ABI->getVarInfo());
+    printDebugVar(ABI->getVarInfo(),
+                  &ABI->getModule().getASTContext().SourceMgr);
   }
 
   void printSubstitutions(SubstitutionMap Subs,

--- a/test/DebugInfo/debug_info_expression.sil
+++ b/test/DebugInfo/debug_info_expression.sil
@@ -10,6 +10,7 @@ struct MyStruct {
 
 sil_scope 1 { loc "file.swift":7:6 parent @test_fragment : $@convention(thin) () -> () }
 
+// Testing op_fragment w/ debug_value_addr
 sil hidden @test_fragment : $@convention(thin) () -> () {
 bb0:
   %2 = alloc_stack $MyStruct, var, name "my_struct", loc "file.swift":8:9, scope 1
@@ -25,6 +26,27 @@ bb0:
   // CHECK-SAME:           !DIExpression(DW_OP_deref, DW_OP_LLVM_fragment, 0, 64)
   // CHECK-NOT:           ), !dbg ![[VAR_DECL_MD]]
   dealloc_stack %2 : $*MyStruct
+  %r = tuple()
+  return %r : $()
+}
+
+sil_scope 2 { loc "file.swift":14:6 parent @test_alloc_stack : $@convention(thin) () -> () }
+
+// Testing di-expression w/ alloc_stack
+sil hidden @test_alloc_stack : $@convention(thin) () -> () {
+bb0:
+  %my_struct = alloc_stack $MyStruct, var, name "my_struct", loc "file.swift":15:9, scope 2
+  // CHECK: %[[MY_STRUCT:.+]] = alloca %{{.*}}MyStruct
+  // CHECK: llvm.dbg.declare(metadata {{.*}}* %[[MY_STRUCT]], metadata ![[VAR_DECL_MD:[0-9]+]]
+  // CHECK-SIL: alloc_stack $Int, var
+  // CHECK-SIL-SAME:        (name "my_struct", loc "file.swift":15:9, scope {{[0-9]+}})
+  // CHECK-SIL-SAME:        type $MyStruct, expr op_fragment:#MyStruct.x
+  %field_x = alloc_stack $Int, var, (name "my_struct", loc "file.swift":15:9, scope 2), type $MyStruct, expr op_fragment:#MyStruct.x, loc "file.swift":16:17, scope 2
+  // CHECK: %[[FIELD_X:.+]] = alloca %TSi
+  // CHECK: llvm.dbg.declare(metadata %TSi* %[[FIELD_X]], metadata ![[VAR_DECL_MD]]
+  // CHECK-SAME:             !DIExpression(DW_OP_LLVM_fragment, 0, 64)
+  dealloc_stack %field_x : $*Int
+  dealloc_stack %my_struct: $*MyStruct
   %r = tuple()
   return %r : $()
 }


### PR DESCRIPTION
The `alloc_stack` instruction now can carry advanced debug info like
source-variable-specific SIL location, type, and SIL DIExpression.

**NOTE**: This PR is only for code review. DO NOT MERGE. Please merge #38736 instead when everything is done.