### PR TITLE
[DebugInfo][SIL] Introduce the 'implicit' attribute for debug variable

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -3505,6 +3505,7 @@ The operand must have loadable type.
    debug-var-attr ::= 'let'
    debug-var-attr ::= 'name' string-literal
    debug-var-attr ::= 'argno' integer-literal
+   debug-var-attr ::= 'implicit'
 
 ::
 
@@ -3520,12 +3521,13 @@ The operand must have loadable type.
 There are a number of attributes that provide details about the source
 variable that is being described, including the name of the
 variable. For function and closure arguments ``argno`` is the number
-of the function argument starting with 1. The advanced debug variable
-attributes represent source locations and type of the source variable
-when it was originally declared. It is useful when we're indirectly
-associating the SSA value with the source variable (via di-expression,
-for example) in which case SSA value's type is different from that of
-source variable.
+of the function argument starting with 1. A compiler-generated source
+variable will be marked ``implicit`` and optimizers are free to remove
+it even in -Onone. The advanced debug variable attributes represent source
+locations and type of the source variable when it was originally declared.
+It is useful when we're indirectly associating the SSA value with the
+source variable (via di-expression, for example) in which case SSA value's
+type is different from that of source variable.
 
 If the '[poison]' flag is set, then all references within this debug
 value will be overwritten with a sentinel at this point in the

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2493,13 +2493,13 @@ void IRGenDebugInfoImpl::emitVariableDeclaration(
       Operands.push_back(SizeInBits);
     }
     llvm::DIExpression *DIExpr = DBuilder.createExpression(Operands);
-    emitDbgIntrinsic(
-        Builder, Piece, Var,
-        // DW_OP_LLVM_fragment must be the last part of an DIExpr
-        // so we can't append more if IsPiece is true.
-        Operands.empty() || IsPiece ? DIExpr : appendDIExpression(DIExpr),
-        DInstLine, DInstLoc.column, Scope, DS,
-        Indirection == CoroDirectValue || Indirection == CoroIndirectValue);
+    emitDbgIntrinsic(Builder, Piece, Var,
+                     // DW_OP_LLVM_fragment must be the last part of an DIExpr
+                     // so we can't append more if IsPiece is true.
+                     IsPiece ? DIExpr : appendDIExpression(DIExpr), DInstLine,
+                     DInstLoc.column, Scope, DS,
+                     Indirection == CoroDirectValue ||
+                         Indirection == CoroIndirectValue);
   }
 
   // Emit locationless intrinsic for variables that were optimized away.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -5160,7 +5160,12 @@ void IRGenSILFunction::emitDebugInfoForAllocStack(AllocStackInst *i,
     }
   }
 
-  SILType SILTy = i->getType();
+  SILType SILTy;
+  if (auto MaybeSILTy = VarInfo->Type)
+    // If there is auxiliary type info, use it
+    SILTy = *MaybeSILTy;
+  else
+    SILTy = i->getType();
   auto RealType = SILTy.getASTType();
   DebugTypeInfo DbgTy;
   if (Decl) {

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1210,7 +1210,8 @@ public:
     if (AVI->hasDynamicLifetime())
       *this << "[dynamic_lifetime] ";
     *this << AVI->getElementType();
-    printDebugVar(AVI->getVarInfo());
+    printDebugVar(AVI->getVarInfo(),
+                  &AVI->getModule().getASTContext().SourceMgr);
   }
 
   void printAllocRefInstBase(AllocRefInstBase *ARI) {
@@ -1245,7 +1246,8 @@ public:
     if (ABI->hasDynamicLifetime())
       *this << "[dynamic_lifetime] ";
     *this << ABI->getType();
-    printDebugVar(ABI->getVarInfo());
+    printDebugVar(ABI->getVarInfo(),
+                  &ABI->getModule().getASTContext().SourceMgr);
   }
 
   void printSubstitutions(SubstitutionMap Subs,

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1198,6 +1198,8 @@ public:
 
     if (Var->ArgNo)
       *this << ", argno " << Var->ArgNo;
+    if (Var->Implicit)
+      *this << ", implicit";
     if (Var->Type) {
       *this << ", type ";
       Var->Type->print(PrintState.OS, PrintState.ASTOptions);

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1752,6 +1752,8 @@ bool SILParser::parseSILDebugVar(SILDebugVariable &Var) {
       Var.Constant = false;
     } else if (Key == "loc") {
       Var.Constant = false;
+    } else if (Key == "implicit") {
+      Var.Implicit = true;
     } else {
       P.diagnose(P.Tok, diag::sil_dbg_unknown_key, Key);
       return true;

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -222,7 +222,11 @@ bool swift::hasOnlyEndOfScopeOrDestroyUses(SILInstruction *inst) {
       // Include debug uses only in Onone mode.
       if (isDebugUser && inst->getFunction()->getEffectiveOptimizationMode() <=
                              OptimizationMode::NoOptimization)
-        return false;
+        if (auto DbgVarInst = DebugVarCarryingInst(user)) {
+          auto VarInfo = DbgVarInst.getVarInfo();
+          if (VarInfo && !VarInfo->Implicit)
+            return false;
+        }
     }
   }
   return true;

--- a/test/DebugInfo/debug_info_expression.sil
+++ b/test/DebugInfo/debug_info_expression.sil
@@ -10,6 +10,7 @@ struct MyStruct {
 
 sil_scope 1 { loc "file.swift":7:6 parent @test_fragment : $@convention(thin) () -> () }
 
+// Testing op_fragment w/ debug_value_addr
 sil hidden @test_fragment : $@convention(thin) () -> () {
 bb0:
   %2 = alloc_stack $MyStruct, var, name "my_struct", loc "file.swift":8:9, scope 1
@@ -25,6 +26,27 @@ bb0:
   // CHECK-SAME:           !DIExpression(DW_OP_deref, DW_OP_LLVM_fragment, 0, 64)
   // CHECK-NOT:           ), !dbg ![[VAR_DECL_MD]]
   dealloc_stack %2 : $*MyStruct
+  %r = tuple()
+  return %r : $()
+}
+
+sil_scope 2 { loc "file.swift":14:6 parent @test_alloc_stack : $@convention(thin) () -> () }
+
+// Testing di-expression w/ alloc_stack
+sil hidden @test_alloc_stack : $@convention(thin) () -> () {
+bb0:
+  %my_struct = alloc_stack $MyStruct, var, name "my_struct", loc "file.swift":15:9, scope 2
+  // CHECK: %[[MY_STRUCT:.+]] = alloca %{{.*}}MyStruct
+  // CHECK: llvm.dbg.declare(metadata {{.*}}* %[[MY_STRUCT]], metadata ![[VAR_DECL_MD:[0-9]+]]
+  // CHECK-SIL: alloc_stack $Int, var
+  // CHECK-SIL-SAME:        (name "my_struct", loc "file.swift":15:9, scope {{[0-9]+}})
+  // CHECK-SIL-SAME:        type $MyStruct, expr op_fragment:#MyStruct.x
+  %field_x = alloc_stack $Int, var, (name "my_struct", loc "file.swift":15:9, scope 2), type $MyStruct, expr op_fragment:#MyStruct.x, loc "file.swift":16:17, scope 2
+  // CHECK: %[[FIELD_X:.+]] = alloca %TSi
+  // CHECK: llvm.dbg.declare(metadata %TSi* %[[FIELD_X]], metadata ![[VAR_DECL_MD]]
+  // CHECK-SAME:             !DIExpression(DW_OP_LLVM_fragment, 0, 64)
+  dealloc_stack %field_x : $*Int
+  dealloc_stack %my_struct: $*MyStruct
   %r = tuple()
   return %r : $()
 }

--- a/test/DebugInfo/implicit_variable.swift
+++ b/test/DebugInfo/implicit_variable.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-sil -g %s -o %t.sil
+// RUN: %FileCheck %s --input-file=%t.sil
+// Test the SILParser / SILPrinter
+// RUN: %target-swift-frontend -module-name ImplicitVar -emit-sil -g %t.sil | %FileCheck %s
+
+struct MyStruct {
+    // Check if the 'implicit' directive for `self` is properly generated (and parsed)
+    // CHECK: sil {{.*}} @{{.*}}MyStructV5hello
+    // CHECK: debug_value %0 : $MyStruct
+    // CHECK-SAME:        let, name "self", argno 1, implicit, loc
+    func hello() {}
+}


### PR DESCRIPTION
Debug variables that are marked 'implicit' on its `debug_value` instruction mean that they were generated by compiler. Optimizers are free to remove them (if it becomes a dead code, for instance) even in  -Onone. Since they are barely used by users and keeping them might lead to incorrect IRGen results.

**NOTE**: This PR is only for code review. It depends on and _includes_  #38734 . **DO NOT MERGE**. Please merge #38736 instead when everything is done.

