### PR TITLE
[SILGen] Handle foreign funcs with error and async conventions.

### DIFF
--- a/include/swift/AST/ForeignInfo.h
+++ b/include/swift/AST/ForeignInfo.h
@@ -26,9 +26,9 @@
 namespace swift {
 
 struct ForeignInfo {
-  ImportAsMemberStatus Self;
-  Optional<ForeignErrorConvention> Error;
-  Optional<ForeignAsyncConvention> Async;
+  ImportAsMemberStatus self;
+  Optional<ForeignErrorConvention> error;
+  Optional<ForeignAsyncConvention> async;
 };
 
 } // end namespace swift

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1557,11 +1557,11 @@ private:
     unsigned numEltTypes = params.size();
 
     bool hasSelf =
-        (extInfoBuilder.hasSelfParam() || Foreign.Self.isImportAsMember());
+        (extInfoBuilder.hasSelfParam() || Foreign.self.isImportAsMember());
     unsigned numNonSelfParams = (hasSelf ? numEltTypes - 1 : numEltTypes);
     TopLevelOrigType = origType;
     // If we have a foreign-self, install handleSelf as the handler.
-    if (Foreign.Self.isInstance()) {
+    if (Foreign.self.isInstance()) {
       assert(hasSelf && numEltTypes > 0);
       ForeignSelf = ForeignSelfInfo{origType.getFunctionParamType(numNonSelfParams),
                                     params[numNonSelfParams]};
@@ -1582,7 +1582,7 @@ private:
 
     // Process the self parameter.  Note that we implicitly drop self
     // if this is a static foreign-self import.
-    if (hasSelf && !Foreign.Self.isImportAsMember()) {
+    if (hasSelf && !Foreign.self.isImportAsMember()) {
       auto selfParam = params[numNonSelfParams];
       auto ty = selfParam.getParameterType();
       auto eltPattern = origType.getFunctionParamType(numNonSelfParams);
@@ -1670,12 +1670,13 @@ private:
   }
   
   bool maybeAddForeignAsyncParameter() {
-    if (!Foreign.Async
-        || NextOrigParamIndex != Foreign.Async->completionHandlerParamIndex())
+    if (!Foreign.async ||
+        NextOrigParamIndex != Foreign.async->completionHandlerParamIndex())
       return false;
-    
-    CanType foreignCHTy = TopLevelOrigType
-      .getObjCMethodAsyncCompletionHandlerForeignType(Foreign.Async.getValue(), TC);
+
+    CanType foreignCHTy =
+        TopLevelOrigType.getObjCMethodAsyncCompletionHandlerForeignType(
+            Foreign.async.getValue(), TC);
     auto completionHandlerOrigTy = TopLevelOrigType.getObjCMethodAsyncCompletionHandlerType(foreignCHTy);
     auto completionHandlerTy = TC.getLoweredType(completionHandlerOrigTy,
                                                  foreignCHTy, expansion)
@@ -1689,15 +1690,15 @@ private:
   bool maybeAddForeignErrorParameter() {
     // A foreign async convention absorbs any error parameter, making it into
     // an argument to the callback.
-    if (Foreign.Async)
+    if (Foreign.async)
       return false;
-    
-    if (!Foreign.Error ||
-        NextOrigParamIndex != Foreign.Error->getErrorParameterIndex())
+
+    if (!Foreign.error ||
+        NextOrigParamIndex != Foreign.error->getErrorParameterIndex())
       return false;
 
     auto foreignErrorTy = TC.getLoweredRValueType(
-        expansion, Foreign.Error->getErrorParameterType());
+        expansion, Foreign.error->getErrorParameterType());
 
     // Assume the error parameter doesn't have interesting lowering.
     Inputs.push_back(SILParameterInfo(foreignErrorTy,
@@ -1707,8 +1708,8 @@ private:
   }
 
   bool maybeAddForeignSelfParameter() {
-    if (!Foreign.Self.isInstance() ||
-        NextOrigParamIndex != Foreign.Self.getSelfIndex())
+    if (!Foreign.self.isInstance() ||
+        NextOrigParamIndex != Foreign.self.getSelfIndex())
       return false;
 
     if (ForeignSelf) {
@@ -1759,22 +1760,22 @@ void updateResultTypeForForeignInfo(
     const ForeignInfo &foreignInfo, CanGenericSignature genericSig,
     AbstractionPattern &origResultType, CanType &substFormalResultType) {
   // If there's no error or async convention, the return type is unchanged.
-  if (!foreignInfo.Async && !foreignInfo.Error) {
+  if (!foreignInfo.async && !foreignInfo.error) {
     return;
   }
-  
+
   // A foreign async convention means our lowered return type is Void, since
   // the imported semantic return and/or error type map to the completion
   // callback's argument(s).
   auto &C = substFormalResultType->getASTContext();
-  if (auto async = foreignInfo.Async) {
+  if (auto async = foreignInfo.async) {
     substFormalResultType = TupleType::getEmpty(C);
     origResultType = AbstractionPattern(genericSig, substFormalResultType);
     return;
   }
-  
+
   // Otherwise, adjust the return type to match the foreign error convention.
-  auto convention = *foreignInfo.Error;
+  auto convention = *foreignInfo.error;
   switch (convention.getKind()) {
   // These conventions replace the result type.
   case ForeignErrorConvention::ZeroResult:
@@ -2086,27 +2087,25 @@ static CanSILFunctionType getSILFunctionType(
 
   Optional<SILResultInfo> errorResult;
   assert(
-      (!foreignInfo.Error || substFnInterfaceType->getExtInfo().isThrowing())
-      && "foreignError was set but function type does not throw?");
-  assert(
-      (!foreignInfo.Async || substFnInterfaceType->getExtInfo().isAsync())
-      && "foreignAsync was set but function type is not async?");
+      (!foreignInfo.error || substFnInterfaceType->getExtInfo().isThrowing()) &&
+      "foreignError was set but function type does not throw?");
+  assert((!foreignInfo.async || substFnInterfaceType->getExtInfo().isAsync()) &&
+         "foreignAsync was set but function type is not async?");
 
   // Map '@Sendable' to the appropriate `@Sendable` modifier.
   bool isSendable = substFnInterfaceType->getExtInfo().isSendable();
 
   // Map 'async' to the appropriate `@async` modifier.
   bool isAsync = false;
-  if (substFnInterfaceType->getExtInfo().isAsync() && !foreignInfo.Async) {
+  if (substFnInterfaceType->getExtInfo().isAsync() && !foreignInfo.async) {
     assert(!origType.isForeign()
            && "using native Swift async for foreign type!");
     isAsync = true;
   }
-  
+
   // Map 'throws' to the appropriate error convention.
-  if (substFnInterfaceType->getExtInfo().isThrowing()
-      && !foreignInfo.Error
-      && !foreignInfo.Async) {
+  if (substFnInterfaceType->getExtInfo().isThrowing() && !foreignInfo.error &&
+      !foreignInfo.async) {
     assert(!origType.isForeign()
            && "using native Swift error convention for foreign type!");
     SILType exnType = SILType::getExceptionType(TC.Context);
@@ -2892,10 +2891,8 @@ static CanSILFunctionType getSILFunctionTypeForClangDecl(
     SILExtInfoBuilder extInfoBuilder, const ForeignInfo &foreignInfo,
     Optional<SILDeclRef> constant) {
   if (auto method = dyn_cast<clang::ObjCMethodDecl>(clangDecl)) {
-    auto origPattern =
-      AbstractionPattern::getObjCMethod(origType, method,
-                                        foreignInfo.Error,
-                                        foreignInfo.Async);
+    auto origPattern = AbstractionPattern::getObjCMethod(
+        origType, method, foreignInfo.error, foreignInfo.async);
     return getSILFunctionType(
         TC, TypeExpansionContext::minimal(), origPattern, substInterfaceType,
         extInfoBuilder, ObjCMethodConventions(method), foreignInfo, constant,
@@ -2903,9 +2900,12 @@ static CanSILFunctionType getSILFunctionTypeForClangDecl(
   }
 
   if (auto method = dyn_cast<clang::CXXMethodDecl>(clangDecl)) {
-    AbstractionPattern origPattern = method->isOverloadedOperator() ?
-        AbstractionPattern::getCXXOperatorMethod(origType, method, foreignInfo.Self):
-        AbstractionPattern::getCXXMethod(origType, method, foreignInfo.Self);
+    AbstractionPattern origPattern =
+        method->isOverloadedOperator()
+            ? AbstractionPattern::getCXXOperatorMethod(origType, method,
+                                                       foreignInfo.self)
+            : AbstractionPattern::getCXXMethod(origType, method,
+                                               foreignInfo.self);
     bool isMutating =
         TC.Context.getClangModuleLoader()->isCXXMethodMutating(method);
     auto conventions = CXXMethodConventions(method, isMutating);
@@ -2918,10 +2918,10 @@ static CanSILFunctionType getSILFunctionTypeForClangDecl(
   if (auto func = dyn_cast<clang::FunctionDecl>(clangDecl)) {
     auto clangType = func->getType().getTypePtr();
     AbstractionPattern origPattern =
-      foreignInfo.Self.isImportAsMember()
-        ? AbstractionPattern::getCFunctionAsMethod(origType, clangType,
-                                                   foreignInfo.Self)
-        : AbstractionPattern(origType, clangType);
+        foreignInfo.self.isImportAsMember()
+            ? AbstractionPattern::getCFunctionAsMethod(origType, clangType,
+                                                       foreignInfo.self)
+            : AbstractionPattern(origType, clangType);
     return getSILFunctionType(TC, TypeExpansionContext::minimal(), origPattern,
                               substInterfaceType, extInfoBuilder,
                               CFunctionConventions(func), foreignInfo, constant,
@@ -3214,10 +3214,10 @@ static CanSILFunctionType getUncachedSILFunctionTypeForConstant(
       // import-as-member but do involve the same gymnastics with the
       // formal type.  That's all that SILFunctionType cares about, so
       // pretend that it's import-as-member.
-      if (!foreignInfo.Self.isImportAsMember() &&
+      if (!foreignInfo.self.isImportAsMember() &&
           isImporterGeneratedAccessor(clangDecl, constant)) {
         unsigned selfIndex = cast<AccessorDecl>(decl)->isSetter() ? 1 : 0;
-        foreignInfo.Self.setSelfIndex(selfIndex);
+        foreignInfo.self.setSelfIndex(selfIndex);
       }
 
       return getSILFunctionTypeForClangDecl(

--- a/lib/SILGen/Callee.h
+++ b/lib/SILGen/Callee.h
@@ -15,6 +15,7 @@
 
 #include "swift/AST/ForeignAsyncConvention.h"
 #include "swift/AST/ForeignErrorConvention.h"
+#include "swift/AST/ForeignInfo.h"
 #include "swift/AST/Types.h"
 #include "swift/SIL/AbstractionPattern.h"
 
@@ -27,11 +28,6 @@ public:
   CanSILFunctionType substFnType;
   Optional<AbstractionPattern> origResultType;
   CanType substResultType;
-  struct ForeignInfo {
-    Optional<ForeignErrorConvention> error;
-    Optional<ForeignAsyncConvention> async;
-    ImportAsMemberStatus self;
-  };
   ForeignInfo foreign;
 
 private:
@@ -48,8 +44,8 @@ public:
                  Optional<SILFunctionTypeRepresentation> overrideRep = None)
       : origFormalType(llvm::None), substFnType(substFnType),
         origResultType(origResultType),
-        substResultType(substResultType), foreign{foreignError, foreignAsync,
-                                                  foreignSelf},
+        substResultType(substResultType), foreign{foreignSelf, foreignError,
+                                                  foreignAsync},
         overrideRep(overrideRep) {}
 
   CalleeTypeInfo(CanSILFunctionType substFnType,

--- a/lib/SILGen/ResultPlan.h
+++ b/lib/SILGen/ResultPlan.h
@@ -38,7 +38,8 @@ class CalleeTypeInfo;
 class ResultPlan {
 public:
   virtual RValue finish(SILGenFunction &SGF, SILLocation loc, CanType substType,
-                        ArrayRef<ManagedValue> &directResults) = 0;
+                        ArrayRef<ManagedValue> &directResults,
+                        SILValue bridgedForeignError) = 0;
   virtual ~ResultPlan() = default;
 
   virtual void

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -184,7 +184,8 @@ public:
   SILFunction *getOrCreateForeignAsyncCompletionHandlerImplFunction(
       CanSILFunctionType blockType, CanType continuationTy,
       AbstractionPattern origFormalType, CanGenericSignature sig,
-      ForeignAsyncConvention convention);
+      ForeignAsyncConvention convention,
+      Optional<ForeignErrorConvention> foreignError);
 
   /// Determine whether the given class has any instance variables that
   /// need to be destroyed.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4415,7 +4415,7 @@ RValue SILGenFunction::emitApply(
   if (auto foreignAsync = calleeTypeInfo.foreign.async) {
     unsigned completionIndex = foreignAsync->completionHandlerParamIndex();
 
-    // Ram the emitted error into the argument list, over the placeholder
+    // Ram the emitted completion into the argument list, over the placeholder
     // we left during the first pass.
     auto &completionArgSlot = const_cast<ManagedValue &>(args[completionIndex]);
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4152,7 +4152,7 @@ CallEmission::applySpecializedEmitter(SpecializedEmitter &specializedEmitter,
   // Then finish our value.
   if (resultPlan.hasValue()) {
     return std::move(*resultPlan)
-            ->finish(SGF, loc, formalResultType, directResultsFinal);
+        ->finish(SGF, loc, formalResultType, directResultsFinal, SILValue());
   } else {
     return RValue(
         SGF, *uncurriedLoc, formalResultType, directResultsFinal[0]);
@@ -4206,12 +4206,18 @@ ApplyOptions CallEmission::emitArgumentsForNormalApply(
 
     args.push_back({});
 
-    // Claim the foreign error and/or async argument(s) with the method
-    // formal params.
-    auto siteForeign = ForeignInfo{{}, foreign.error, foreign.async};
-    std::move(*callSite).emit(SGF, origFormalType, substFnType, paramLowering,
-                              args.back(), delayedArgs,
-                              siteForeign);
+    if (!foreign.async || (foreign.async && foreign.error)) {
+      // Claim the foreign error argument(s) with the method formal params.
+      auto siteForeignError = ForeignInfo{{}, foreign.error, {}};
+      std::move(*callSite).emit(SGF, origFormalType, substFnType, paramLowering,
+                                args.back(), delayedArgs, siteForeignError);
+    }
+    if (foreign.async) {
+      // Claim the foreign async argument(s) with the method formal params.
+      auto siteForeignAsync = ForeignInfo{{}, {}, foreign.async};
+      std::move(*callSite).emit(SGF, origFormalType, substFnType, paramLowering,
+                                args.back(), delayedArgs, siteForeignAsync);
+    }
   }
 
   uncurriedLoc = callSite->Loc;
@@ -4422,8 +4428,8 @@ RValue SILGenFunction::emitApply(
     auto origFormalType = *calleeTypeInfo.origFormalType;
     completionArgSlot = resultPlan->emitForeignAsyncCompletionHandler(
         *this, origFormalType, loc);
-
-  } else if (auto foreignError = calleeTypeInfo.foreign.error) {
+  }
+  if (auto foreignError = calleeTypeInfo.foreign.error) {
     unsigned errorParamIndex =
         foreignError->getErrorParameterIndex();
 
@@ -4579,13 +4585,15 @@ RValue SILGenFunction::emitApply(
         });
   }
 
+  SILValue bridgedForeignError;
   // If there was a foreign error convention, consider it.
   // TODO: maybe this should happen after managing the result if it's
   // not a result-checking convention?
   if (auto foreignError = calleeTypeInfo.foreign.error) {
     bool doesNotThrow = options.contains(ApplyFlags::DoesNotThrow);
-    emitForeignErrorCheck(loc, directResults, errorTemp, doesNotThrow,
-                          *foreignError);
+    bridgedForeignError =
+        emitForeignErrorCheck(loc, directResults, errorTemp, doesNotThrow,
+                              *foreignError, calleeTypeInfo.foreign.async);
   }
 
   // For objc async calls, push cleanup to be used on throw paths in the result
@@ -4597,8 +4605,8 @@ RValue SILGenFunction::emitApply(
   }
 
   auto directResultsArray = makeArrayRef(directResults);
-  RValue result =
-    resultPlan->finish(*this, loc, substResultType, directResultsArray);
+  RValue result = resultPlan->finish(*this, loc, substResultType,
+                                     directResultsArray, bridgedForeignError);
   assert(directResultsArray.empty() && "didn't claim all direct results");
 
   // For objc async calls, generate cleanup on the resume path here and forward

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -548,10 +548,10 @@ public:
       return result;
 
     auto func = cast<AbstractFunctionDecl>(constant->getDecl());
-    result.foreign = CalleeTypeInfo::ForeignInfo{
-      func->getForeignErrorConvention(),
-      func->getForeignAsyncConvention(),
-      func->getImportAsMemberStatus(),
+    result.foreign = ForeignInfo{
+        func->getImportAsMemberStatus(),
+        func->getForeignErrorConvention(),
+        func->getForeignAsyncConvention(),
     };
 
     // Remove the metatype "self" parameter by making this a static member.
@@ -2764,7 +2764,7 @@ class ArgEmitter {
   SILFunctionTypeRepresentation Rep;
   bool IsYield;
   bool IsForCoroutine;
-  CalleeTypeInfo::ForeignInfo Foreign;
+  ForeignInfo Foreign;
   ClaimedParamsRef ParamInfos;
   SmallVectorImpl<ManagedValue> &Args;
 
@@ -2777,10 +2777,10 @@ public:
              bool isYield, bool isForCoroutine, ClaimedParamsRef paramInfos,
              SmallVectorImpl<ManagedValue> &args,
              SmallVectorImpl<DelayedArgument> &delayedArgs,
-             const CalleeTypeInfo::ForeignInfo &foreign)
+             const ForeignInfo &foreign)
       : SGF(SGF), Rep(Rep), IsYield(isYield), IsForCoroutine(isForCoroutine),
-        Foreign(foreign),
-        ParamInfos(paramInfos), Args(args), DelayedArguments(delayedArgs) {}
+        Foreign(foreign), ParamInfos(paramInfos), Args(args),
+        DelayedArguments(delayedArgs) {}
 
   // origParamType is a parameter type.
   void emitSingleArg(ArgumentSource &&arg, AbstractionPattern origParamType) {
@@ -3362,11 +3362,9 @@ void DelayedArgument::emitDefaultArgument(SILGenFunction &SGF,
 
   SmallVector<ManagedValue, 4> loweredArgs;
   SmallVector<DelayedArgument, 4> delayedArgs;
-  auto emitter =
-      ArgEmitter(SGF, info.functionRepresentation, /*yield*/ false,
-                 /*coroutine*/ false, info.paramsToEmit, loweredArgs,
-                 delayedArgs,
-                 CalleeTypeInfo::ForeignInfo{});
+  auto emitter = ArgEmitter(SGF, info.functionRepresentation, /*yield*/ false,
+                            /*coroutine*/ false, info.paramsToEmit, loweredArgs,
+                            delayedArgs, ForeignInfo{});
 
   emitter.emitSingleArg(ArgumentSource(info.loc, std::move(value)),
                         info.origResultType);
@@ -3528,10 +3526,9 @@ struct ParamLowering {
         Rep(fnType->getRepresentation()), fnConv(fnType, SGF.SGM.M),
         typeExpansionContext(SGF.getTypeExpansionContext()) {}
 
-  ClaimedParamsRef
-  claimParams(AbstractionPattern origFormalType,
-              ArrayRef<AnyFunctionType::Param> substParams,
-              const CalleeTypeInfo::ForeignInfo &foreign) {
+  ClaimedParamsRef claimParams(AbstractionPattern origFormalType,
+                               ArrayRef<AnyFunctionType::Param> substParams,
+                               const ForeignInfo &foreign) {
     unsigned count = 0;
     if (!foreign.self.isStatic()) {
       for (auto i : indices(substParams)) {
@@ -3640,7 +3637,7 @@ public:
             CanSILFunctionType substFnType, ParamLowering &lowering,
             SmallVectorImpl<ManagedValue> &args,
             SmallVectorImpl<DelayedArgument> &delayedArgs,
-            const CalleeTypeInfo::ForeignInfo &foreign) && {
+            const ForeignInfo &foreign) && {
     auto params = lowering.claimParams(origFormalType, getParams(), foreign);
 
     ArgEmitter emitter(SGF, lowering.Rep, /*yield*/ false,
@@ -3781,8 +3778,7 @@ private:
   /// ApplyOptions.
   ApplyOptions emitArgumentsForNormalApply(
       AbstractionPattern origFormalType, CanSILFunctionType substFnType,
-      const CalleeTypeInfo::ForeignInfo &foreign,
-      SmallVectorImpl<ManagedValue> &uncurriedArgs,
+      const ForeignInfo &foreign, SmallVectorImpl<ManagedValue> &uncurriedArgs,
       Optional<SILLocation> &uncurriedLoc);
 
   RValue
@@ -4101,8 +4097,7 @@ CallEmission::applySpecializedEmitter(SpecializedEmitter &specializedEmitter,
   SmallVector<ManagedValue, 4> uncurriedArgs;
   Optional<SILLocation> uncurriedLoc;
   CanFunctionType formalApplyType;
-  emitArgumentsForNormalApply(origFormalType, substFnType,
-                              CalleeTypeInfo::ForeignInfo{},
+  emitArgumentsForNormalApply(origFormalType, substFnType, ForeignInfo{},
                               uncurriedArgs, uncurriedLoc);
 
   // If we have a late emitter, now that we have emitted our arguments, call the
@@ -4166,8 +4161,7 @@ CallEmission::applySpecializedEmitter(SpecializedEmitter &specializedEmitter,
 
 ApplyOptions CallEmission::emitArgumentsForNormalApply(
     AbstractionPattern origFormalType, CanSILFunctionType substFnType,
-    const CalleeTypeInfo::ForeignInfo &foreign,
-    SmallVectorImpl<ManagedValue> &uncurriedArgs,
+    const ForeignInfo &foreign, SmallVectorImpl<ManagedValue> &uncurriedArgs,
     Optional<SILLocation> &uncurriedLoc) {
   ApplyOptions options;
 
@@ -4202,7 +4196,7 @@ ApplyOptions CallEmission::emitArgumentsForNormalApply(
       args.push_back({});
       
       // Claim the foreign "self" with the self param.
-      auto siteForeign = CalleeTypeInfo::ForeignInfo{{}, {}, foreign.self};
+      auto siteForeign = ForeignInfo{foreign.self, {}, {}};
       std::move(*selfArg).emit(SGF, origFormalType, substFnType, paramLowering,
                                args.back(), delayedArgs,
                                siteForeign);
@@ -4214,8 +4208,7 @@ ApplyOptions CallEmission::emitArgumentsForNormalApply(
 
     // Claim the foreign error and/or async argument(s) with the method
     // formal params.
-    auto siteForeign =
-        CalleeTypeInfo::ForeignInfo{foreign.error, foreign.async, {}};
+    auto siteForeign = ForeignInfo{{}, foreign.error, foreign.async};
     std::move(*callSite).emit(SGF, origFormalType, substFnType, paramLowering,
                               args.back(), delayedArgs,
                               siteForeign);
@@ -4629,10 +4622,8 @@ RValue SILGenFunction::emitMonomorphicApply(
     SGFContext evalContext) {
   auto fnType = fn.getType().castTo<SILFunctionType>();
   assert(!fnType->isPolymorphic());
-  CalleeTypeInfo::ForeignInfo foreign{
-    foreignError,
-    {}, // TODO: take a foreign async convention?
-    {},
+  ForeignInfo foreign{
+      {}, foreignError, {}, // TODO: take a foreign async convention?
   };
   CalleeTypeInfo calleeTypeInfo(fnType, AbstractionPattern(foreignResultType),
                                 nativeResultType,
@@ -4733,10 +4724,8 @@ void SILGenFunction::emitYield(SILLocation loc,
   }
 
   ArgEmitter emitter(*this, fnType->getRepresentation(), /*yield*/ true,
-                     /*isForCoroutine*/ false,
-                     ClaimedParamsRef(substYieldTys),
-                     yieldArgs, delayedArgs,
-                     CalleeTypeInfo::ForeignInfo{});
+                     /*isForCoroutine*/ false, ClaimedParamsRef(substYieldTys),
+                     yieldArgs, delayedArgs, ForeignInfo{});
 
   for (auto i : indices(valueSources)) {
     emitter.emitSingleArg(std::move(valueSources[i]), origTypes[i]);
@@ -5609,11 +5598,9 @@ static void emitPseudoFunctionArguments(SILGenFunction &SGF,
   SmallVector<DelayedArgument, 2> delayedArgs;
 
   ArgEmitter emitter(SGF, SILFunctionTypeRepresentation::Thin,
-     /*yield*/ false,
-     /*isForCoroutine*/ false,
-     ClaimedParamsRef(substParamTys),
-     argValues, delayedArgs,
-     CalleeTypeInfo::ForeignInfo{});
+                     /*yield*/ false,
+                     /*isForCoroutine*/ false, ClaimedParamsRef(substParamTys),
+                     argValues, delayedArgs, ForeignInfo{});
 
   emitter.emitPreparedArgs(std::move(args), origFnType);
 
@@ -6284,9 +6271,8 @@ SmallVector<ManagedValue, 4> SILGenFunction::emitKeyPathSubscriptOperands(
   ArgEmitter emitter(*this, fnType->getRepresentation(),
                      /*yield*/ false,
                      /*isForCoroutine*/ false,
-                     ClaimedParamsRef(fnType->getParameters()),
-                     argValues, delayedArgs,
-                     CalleeTypeInfo::ForeignInfo{});
+                     ClaimedParamsRef(fnType->getParameters()), argValues,
+                     delayedArgs, ForeignInfo{});
 
   auto prepared =
       prepareSubscriptIndices(subscript, subs,

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1876,14 +1876,16 @@ public:
                                        SILValue foreignErrorSlot,
                                  const ForeignErrorConvention &foreignError);
 
-  void emitForeignErrorBlock(SILLocation loc, SILBasicBlock *errorBB,
-                             Optional<ManagedValue> errorSlot);
+  SILValue emitForeignErrorBlock(SILLocation loc, SILBasicBlock *errorBB,
+                                 Optional<ManagedValue> errorSlot,
+                                 Optional<ForeignAsyncConvention> foreignAsync);
 
-  void emitForeignErrorCheck(SILLocation loc,
-                             SmallVectorImpl<ManagedValue> &directResults,
-                             ManagedValue errorSlot,
-                             bool suppressErrorCheck,
-                             const ForeignErrorConvention &foreignError);
+  SILValue emitForeignErrorCheck(SILLocation loc,
+                                 SmallVectorImpl<ManagedValue> &directResults,
+                                 ManagedValue errorSlot,
+                                 bool suppressErrorCheck,
+                                 const ForeignErrorConvention &foreignError,
+                                 Optional<ForeignAsyncConvention> foreignAsync);
 
   //===--------------------------------------------------------------------===//
   // Re-abstraction thunks

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -28,8 +28,9 @@
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/FileUnit.h"
 #include "swift/AST/ForeignAsyncConvention.h"
-#include "swift/SIL/FormalLinkage.h"
+#include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/SIL/FormalLinkage.h"
 #include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/TypeLowering.h"
@@ -191,7 +192,8 @@ static const clang::Type *prependParameterType(
 SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
     CanSILFunctionType blockType, CanType continuationTy,
     AbstractionPattern origFormalType, CanGenericSignature sig,
-    ForeignAsyncConvention convention) {
+    ForeignAsyncConvention convention,
+    Optional<ForeignErrorConvention> foreignError) {
   // Extract the result and error types from the continuation type.
   auto resumeType = cast<BoundGenericType>(continuationTy).getGenericArgs()[0];
 
@@ -360,10 +362,12 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
         errorScope.pop();
         SGF.B.createBranch(loc, returnBB);
         SGF.B.emitBlock(noneErrorBB);
+      } else if (foreignError) {
+        resumeIntrinsic = getResumeUnsafeThrowingContinuation();
       } else {
         resumeIntrinsic = getResumeUnsafeContinuation();
       }
-            
+
       auto loweredResumeTy = SGF.getLoweredType(AbstractionPattern::getOpaque(),
                                             F->mapTypeIntoContext(resumeType));
       

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -83,6 +83,8 @@ func testSlowServer(slowServer: SlowServer) async throws {
 
   let _: ((String) -> String, String) = await slowServer.performNSString2NSStringNSString()
   let _: ((Any) -> Void, (Any) -> Void) = await slowServer.performId2VoidId2Void()
+
+  let _: String = try await slowServer.findAnswerFailingly()
 }
 
 func testGeneric<T: AnyObject>(x: GenericObject<T>) async throws {

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704984.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704984.h
@@ -1,0 +1,21 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+typedef void (^CompletionHandler)(int status, NSUInteger bytesTransferred);
+
+@interface PFXObject : NSObject {
+}
+- (BOOL)enqueueErroryRequestWithError:(NSError *_Nullable *)error
+                    completionHandler:
+                        (nullable CompletionHandler)completionHandler;
+- (BOOL)enqueueSyncSuccessfulErroryRequestWithError:(NSError *_Nullable *)error
+                                  completionHandler:(nullable CompletionHandler)
+                                                        completionHandler;
+- (BOOL)enqueueAsyncSuccessfulErroryRequestWithError:(NSError *_Nullable *)error
+                                   completionHandler:
+                                       (nullable CompletionHandler)
+                                           completionHandler;
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704984.m
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704984.m
@@ -1,0 +1,35 @@
+#include "rdar80704984.h"
+
+#pragma clang assume_nonnull begin
+
+@implementation PFXObject
+- (instancetype)init {
+  if (self = [super init]) {
+  }
+  return self;
+}
+- (BOOL)enqueueErroryRequestWithError:(NSError *_Nullable *)error
+                    completionHandler:
+                        (nullable CompletionHandler)completionHandler {
+  *error = [[NSError alloc] initWithDomain:@"d" code:1 userInfo:nil];
+  return NO;
+}
+- (BOOL)enqueueSyncSuccessfulErroryRequestWithError:(NSError *_Nullable *)error
+                                  completionHandler:(nullable CompletionHandler)
+                                                        completionHandler {
+  completionHandler(0, 1);
+  return YES;
+}
+- (BOOL)enqueueAsyncSuccessfulErroryRequestWithError:(NSError *_Nullable *)error
+                                   completionHandler:
+                                       (nullable CompletionHandler)
+                                           completionHandler;
+{
+  dispatch_async(dispatch_get_main_queue(), ^{
+    completionHandler(0, 2);
+  });
+  return YES;
+}
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704984_2.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704984_2.h
@@ -1,0 +1,24 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+@interface PFXObject : NSObject {
+}
+- (BOOL)failReturnWithError:(NSError *_Nullable *)error
+          completionHandler:
+              (void (^_Nonnull)(NSError *_Nullable error))completionHandler;
+- (BOOL)failInvokeSyncWithError:(NSError *_Nullable *)error
+              completionHandler:
+                  (void (^_Nonnull)(NSError *_Nullable error))completionHandler;
+- (BOOL)failInvokeAsyncWithError:(NSError *_Nullable *)error
+               completionHandler:(void (^_Nonnull)(NSError *_Nullable error))
+                                     completionHandler;
+- (BOOL)succeedSyncWithError:(NSError *_Nullable *)error
+           completionHandler:
+               (void (^_Nonnull)(NSError *_Nullable error))completionHandler;
+- (BOOL)succeedAsyncWithError:(NSError *_Nullable *)error
+            completionHandler:
+                (void (^_Nonnull)(NSError *_Nullable error))completionHandler;
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704984_2.m
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704984_2.m
@@ -1,0 +1,51 @@
+#include "rdar80704984_2.h"
+
+#pragma clang assume_nonnull begin
+
+@implementation PFXObject
+- (instancetype)init {
+  if (self = [super init]) {
+  }
+  return self;
+}
+- (BOOL)failReturnWithError:(NSError *_Nullable *)error
+          completionHandler:
+              (void (^_Nonnull)(NSError *_Nullable error))completionHandler {
+  *error = [NSError errorWithDomain:@"failReturn" code:1 userInfo:nil];
+  return NO;
+}
+- (BOOL)failInvokeSyncWithError:(NSError *_Nullable *)error
+              completionHandler:(void (^_Nonnull)(NSError *_Nullable error))
+                                    completionHandler {
+  completionHandler([NSError errorWithDomain:@"failInvokeSync"
+                                        code:2
+                                    userInfo:nil]);
+  return YES;
+}
+- (BOOL)failInvokeAsyncWithError:(NSError *_Nullable *)error
+               completionHandler:(void (^_Nonnull)(NSError *_Nullable error))
+                                     completionHandler {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    completionHandler([NSError errorWithDomain:@"failInvokeAsync"
+                                          code:2
+                                      userInfo:nil]);
+  });
+  return YES;
+}
+- (BOOL)succeedSyncWithError:(NSError *_Nullable *)error
+           completionHandler:
+               (void (^_Nonnull)(NSError *_Nullable error))completionHandler {
+  completionHandler(nil);
+  return YES;
+}
+- (BOOL)succeedAsyncWithError:(NSError *_Nullable *)error
+            completionHandler:
+                (void (^_Nonnull)(NSError *_Nullable error))completionHandler {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    completionHandler(nil);
+  });
+  return YES;
+}
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/rdar80704984.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar80704984.swift
@@ -1,0 +1,51 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar80704984.m -I %S/Inputs -c -o %t/rdar80704984.o
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar80704984.h -Xlinker %t/rdar80704984.o -parse-as-library %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+func run1(on object: PFXObject) async throws {
+  do {
+    try await object.enqueueErroryRequest()
+    fatalError();
+  } catch let error {
+    // CHECK: Domain=d Code=1
+    print(error)
+  }
+}
+func run2(on object: PFXObject) async throws {
+  // CHECK: (0, 1)
+  print(try await object.enqueueSyncSuccessfulErroryRequest())
+}
+
+func run3(on object: PFXObject) async throws {
+  // CHECK: (0, 2)
+  print(try await object.enqueueAsyncSuccessfulErroryRequest())
+}
+
+func runAll(on object: PFXObject) async throws {
+  do {
+    try await object.enqueueErroryRequest()
+    fatalError();
+  } catch let error {
+    // CHECK: Domain=d Code=1
+    print(error)
+  }
+  // CHECK: (0, 1)
+  print(try await object.enqueueSyncSuccessfulErroryRequest())
+  // CHECK: (0, 2)
+  print(try await object.enqueueAsyncSuccessfulErroryRequest())
+}
+
+@main struct Main {
+  static func main() async throws {
+    let object = PFXObject()
+    try await run1(on: object)
+    try await run2(on: object)
+    try await run3(on: object)
+    try await runAll(on: object)
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar80704984_2.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar80704984_2.swift
@@ -1,0 +1,94 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar80704984_2.m -I %S/Inputs -c -o %t/rdar80704984_2.o
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar80704984_2.h -Xlinker %t/rdar80704984_2.o -parse-as-library %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+func run1(on object: PFXObject) async throws {
+  do {
+    try await object.failReturn()
+    fatalError()
+  }
+  catch let error {
+    // CHECK: Error Domain=failReturn Code=1 "(null)"
+    print(error)
+  }
+}
+
+func run2(on object: PFXObject) async throws {
+  do {
+    try await object.failInvokeSync()
+    fatalError()
+  }
+  catch let error {
+    // CHECK: Error Domain=failInvokeSync Code=2 "(null)"
+    print(error)
+  }
+}
+
+func run3(on object: PFXObject) async throws {
+  do {
+    try await object.failInvokeAsync()
+    fatalError()
+  }
+  catch let error {
+    // CHECK: Error Domain=failInvokeAsync Code=2 "(null)"
+    print(error)
+  }
+}
+
+func run4(on object: PFXObject) async throws {
+  // CHECK: ()
+  print(try await object.succeedSync())
+}
+
+func run5(on object: PFXObject) async throws {
+  // CHECK: ()
+  print(try await object.succeedAsync())
+}
+
+func runAll(on object: PFXObject) async throws {
+  do {
+    try await object.failReturn()
+    fatalError()
+  }
+  catch let error {
+    // CHECK: Error Domain=failReturn Code=1 "(null)"
+    print(error)
+  }
+  do {
+    try await object.failInvokeSync()
+    fatalError()
+  }
+  catch let error {
+    // CHECK: Error Domain=failInvokeSync Code=2 "(null)"
+    print(error)
+  }
+  do {
+    try await object.failInvokeAsync()
+    fatalError()
+  }
+  catch let error {
+    // CHECK: Error Domain=failInvokeAsync Code=2 "(null)"
+    print(error)
+  }
+  // CHECK: ()
+  print(try await object.succeedSync())
+  // CHECK: ()
+  print(try await object.succeedAsync())
+}
+
+@main struct Main {
+  static func main() async throws {
+    let object = PFXObject()
+    try await run1(on: object)
+    try await run2(on: object)
+    try await run3(on: object)
+    try await run4(on: object)
+    try await run5(on: object)
+    try await runAll(on: object)
+  }
+}


### PR DESCRIPTION
Previously, SILGen assumed that a foreign function could either have a foreign async convention or a foreign error convention, but if it had both, the error would be subsumed into the completion.  That resulted in failures to emit code for async calls of functions like

```
- (BOOL)minimalWithError:(NSError* _Nullable*)error
         completionHandler:(void (^ _Nonnull)(void))completionHandler;
```

Here, SILGen gains the ability to emit such functions.  To enable that, a few changes were required when both conventions are present:
- a separate argument for each convention is used
- the ResultPlan is a ForeignErrorResultPlan nesting a
  ForeignAsyncResultPlan
- the continuation is always of the form UnsafeContinuation<_, Error>
  regardless of whether the completion handler takes an error
- the foreign error block fills the continuation with the error that was
  passed by reference out of the ObjC method call
- the foreign error block branches to the block containing the await
  instruction

rdar://80704984
