### PR TITLE
Start testing Swift 6 mode changes

### DIFF
--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -326,6 +326,17 @@ Optional<Version> Version::getEffectiveLanguageVersion() const {
     static_assert(SWIFT_VERSION_MAJOR == 5,
                   "getCurrentLanguageVersion is no longer correct here");
     return Version::getCurrentLanguageVersion();
+  case 6:
+    // Allow version '6' in asserts compilers *only* so that we can start
+    // testing changes slated for Swift 6. Note that it's still not listed in
+    // `Version::getValidEffectiveVersions()`.
+    // FIXME: When Swift 6 becomes real, remove 'REQUIRES: asserts' from tests
+    //        using '-swift-version 6'.
+#ifdef NDEBUG
+    LLVM_FALLTHROUGH;
+#else
+    return Version{6};
+#endif
   default:
     return None;
   }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -654,7 +654,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   }
 
   Opts.EnableConcisePoundFile =
-      Args.hasArg(OPT_enable_experimental_concise_pound_file);
+      Args.hasArg(OPT_enable_experimental_concise_pound_file) ||
+      Opts.EffectiveLanguageVersion.isVersionAtLeast(6);
   Opts.EnableFuzzyForwardScanTrailingClosureMatching =
       Args.hasFlag(OPT_enable_fuzzy_forward_scan_trailing_closure_matching,
                    OPT_disable_fuzzy_forward_scan_trailing_closure_matching,

--- a/test/Concurrency/actor_definite_init_swift6.swift
+++ b/test/Concurrency/actor_definite_init_swift6.swift
@@ -1,0 +1,402 @@
+// RUN: %target-swift-frontend -parse-as-library -emit-sil -swift-version 6 -verify %s
+
+// Requires 'asserts' for Swift 6 mode.
+// REQUIRES: concurrency && asserts
+
+enum BogusError: Error {
+    case blah
+}
+
+@available(SwiftStdlib 5.5, *)
+actor Convenient {
+    var x: Int
+    var y: Convenient?
+
+    init(val: Int) {
+        self.x = val
+    }
+
+    convenience init(bigVal: Int) {
+        if bigVal < 0 {
+            self.init(val: 0)
+            say(msg: "hello from actor!")
+        }
+        say(msg: "said this too early!") // expected-error {{'self' used before 'self.init' call or assignment to 'self'}}
+        self.init(val: bigVal)
+
+        Task { await self.mutateIsolatedState() }
+    }
+
+    convenience init!(biggerVal1 biggerVal: Int) {
+        guard biggerVal < 1234567 else { return nil }
+        self.init(bigVal: biggerVal)
+        say(msg: "hello?")
+    }
+
+    @MainActor
+    convenience init?(biggerVal2 biggerVal: Int) async {
+        guard biggerVal < 1234567 else { return nil }
+        self.init(bigVal: biggerVal)
+        say(msg: "hello?")
+        await mutateIsolatedState()
+    }
+
+    convenience init() async {
+        self.init(val: 10)
+        await mutateIsolatedState()
+    }
+
+    init(throwyDesignated val: Int) throws {
+        guard val > 0 else { throw BogusError.blah }
+        self.x = 10
+        say(msg: "hello?")  // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        Task { self }       // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+    }
+
+    init(asyncThrowyDesignated val: Int) async throws {
+        guard val > 0 else { throw BogusError.blah }
+        self.x = 10
+        say(msg: "hello?")
+        Task { self }
+    }
+
+    convenience init(throwyConvenient val: Int) throws {
+        try self.init(throwyDesignated: val)
+        say(msg: "hello?")
+        Task { self }
+    }
+
+    func mutateIsolatedState() {
+        self.y = self
+    }
+
+    nonisolated func say(msg: String) {
+        print(msg)
+    }
+}
+
+func randomInt() -> Int { return 4 }
+
+@available(SwiftStdlib 5.5, *)
+func callMethod(_ a: MyActor) {}
+
+@available(SwiftStdlib 5.5, *)
+func passInout<T>(_ a: inout T) {}
+
+@available(SwiftStdlib 5.5, *)
+actor MyActor {
+    var x: Int
+    var y: Int
+    var hax: MyActor?
+
+    var computedProp : Int {
+        get { 0 }
+        set { }
+    }
+
+    func helloWorld() {}
+
+    convenience init(ci1 c: Bool) {
+        self.init(i1: c)
+        Task { self }
+        callMethod(self)
+    }
+
+    init(i1 c:  Bool) {
+        self.x = 0
+        _ = self.x
+        self.y = self.x
+
+        Task { self }     // expected-error{{actor 'self' can only be captured by a closure from an async initializer}}
+                          // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        self.helloWorld() // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                          // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        callMethod(self) // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                         // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        passInout(&self.x) // expected-error{{actor 'self' can only be passed 'inout' from an async initializer}}
+
+        self.x = self.y
+        self.x = randomInt()
+        (_, _) = (self.x, self.y)
+        _ = self.x == 0
+
+        self.hax = self     // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        _ = self.hax
+
+        _ = computedProp    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        computedProp = 1    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        Task { // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+               // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+            _ = await self.hax
+            await self.helloWorld()
+        }
+    }
+
+    init?(i1_nil c:  Bool) {
+        self.x = 0
+        guard c else { return nil }
+        self.y = self.x
+
+        Task { self }     // expected-error{{actor 'self' can only be captured by a closure from an async initializer}}
+                          // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        self.helloWorld() // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                          // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        callMethod(self) // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                         // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        passInout(&self.x) // expected-error{{actor 'self' can only be passed 'inout' from an async initializer}}
+
+        self.x = self.y
+
+        self.hax = self     // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        _ = self.hax
+
+        _ = computedProp    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        computedProp = 1    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        Task { // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+               // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+            _ = await self.hax
+            await self.helloWorld()
+        }
+    }
+
+    init!(i1_boom c:  Bool) {
+        self.x = 0
+        guard c else { return nil }
+        self.y = self.x
+
+        Task { self }     // expected-error{{actor 'self' can only be captured by a closure from an async initializer}}
+                          // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        self.helloWorld() // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                          // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        callMethod(self) // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                         // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        passInout(&self.x) // expected-error{{actor 'self' can only be passed 'inout' from an async initializer}}
+
+        self.x = self.y
+
+        self.hax = self     // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+        _ = self.hax
+
+        _ = computedProp    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        computedProp = 1    // expected-error{{this use of actor 'self' can only appear in an async initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        Task { // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+               // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+            _ = await self.hax
+            await self.helloWorld()
+        }
+    }
+
+    @MainActor
+    init(i2 c:  Bool) {
+        self.x = 0
+        self.y = self.x
+
+        Task { self }     // expected-error{{actor 'self' cannot be captured by a closure from a global-actor isolated initializer}}
+                          // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        self.helloWorld() // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+                          // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        callMethod(self) // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+                         // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        passInout(&self.x) // expected-error{{actor 'self' cannot be passed 'inout' from a global-actor isolated initializer}}
+
+        self.x = self.y
+
+        self.hax = self     // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+        _ = self.hax
+
+        _ = computedProp    // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        computedProp = 1    // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        Task { // expected-error {{actor 'self' cannot be captured by a closure from a global-actor isolated initializer}}
+               // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+            _ = await self.hax
+            await self.helloWorld()
+        }
+    }
+
+    init(i3 c:  Bool) async {
+        self.x = 0
+        self.y = self.x
+
+        Task { self }
+
+        self.helloWorld()
+        callMethod(self)
+        passInout(&self.x)
+
+        self.x = self.y
+
+        self.hax = self
+        _ = Optional.some(self)
+
+        _ = computedProp
+        computedProp = 1
+
+        Task {
+            _ = await self.hax
+            await self.helloWorld()
+        }
+    }
+
+    @MainActor
+    init(i4 c:  Bool) async {
+        self.x = 0
+        self.y = self.x
+
+        Task { self }     // expected-error{{actor 'self' cannot be captured by a closure from a global-actor isolated initializer}}
+                          // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        self.helloWorld() // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+                          // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        callMethod(self) // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+                         // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        passInout(&self.x) // expected-error{{actor 'self' cannot be passed 'inout' from a global-actor isolated initializer}}
+
+        self.x = self.y
+
+        self.hax = self     // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+        _ = self.hax
+
+        _ = computedProp    // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        computedProp = 1    // expected-error{{this use of actor 'self' cannot appear in a global-actor isolated initializer}}
+                            // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        Task { // expected-error {{actor 'self' cannot be captured by a closure from a global-actor isolated initializer}}
+               // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+            _ = await self.hax
+            await self.helloWorld()
+        }
+    }
+
+}
+
+
+@available(SwiftStdlib 5.5, *)
+actor X {
+    var counter: Int
+
+    init(v1 start: Int) {
+        self.counter = start
+        Task { await self.setCounter(start + 1) } // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+                                                  // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        if self.counter != start {
+            fatalError("where's my protection?")
+        }
+    }
+
+    func setCounter(_ x : Int) {
+        self.counter = x
+    }
+}
+
+struct CardboardBox<T> {
+    public let item: T
+}
+
+
+@available(SwiftStdlib 5.5, *)
+var globalVar: EscapeArtist?
+
+@available(SwiftStdlib 5.5, *)
+actor EscapeArtist {
+    var x: Int
+
+    init(attempt1: Bool) {
+        self.x = 0
+
+        globalVar = self    // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+        Task { await globalVar!.isolatedMethod() }
+
+        if self.x == 0 {
+            fatalError("race detected.")
+        }
+    }
+
+    init(attempt2: Bool) {
+        self.x = 0
+
+        let wrapped: EscapeArtist? = .some(self)    // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+        let selfUnchained = wrapped!
+
+        Task { await selfUnchained.isolatedMethod() }
+        if self.x == 0 {
+            fatalError("race detected.")
+        }
+    }
+
+    init(attempt3: Bool) {
+        self.x = 0
+
+        // expected-warning@+2 {{variable 'unchainedSelf' was never mutated; consider changing to 'let' constant}}
+        // expected-error@+1 {{this use of actor 'self' can only appear in an async initializer}}
+        var unchainedSelf = self
+
+        unchainedSelf.nonisolated()
+    }
+
+    init(attempt4: Bool) {
+        self.x = 0
+
+        let unchainedSelf = self
+
+        unchainedSelf.nonisolated() // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+                                    // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+
+        let _ = { unchainedSelf.nonisolated() } // expected-error {{actor 'self' can only be captured by a closure from an async initializer}}
+                                                // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+    }
+
+    init(attempt5: Bool) {
+        self.x = 0
+
+        let box = CardboardBox(item: self) // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+        box.item.nonisolated()
+    }
+
+    init(attempt6: Bool) {
+        self.x = 0
+        func fn() {
+            self.nonisolated()
+        }
+        fn()    // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+                // expected-note@-1 {{convenience initializers allow non-isolated use of 'self' once initialized}}
+    }
+
+    func isolatedMethod() { x += 1 }
+    nonisolated func nonisolated() {}
+}

--- a/test/Concurrency/actor_keypath_isolation_swift6.swift
+++ b/test/Concurrency/actor_keypath_isolation_swift6.swift
@@ -1,0 +1,87 @@
+// RUN: %target-typecheck-verify-swift  -disable-availability-checking -warn-concurrency -swift-version 6
+// REQUIRES: concurrency && asserts
+
+class Box {
+    let size : Int = 0
+}
+
+actor Door {
+    let immutable : Int = 0
+    let letBox : Box? = nil
+    let letDict : [Int : Box] = [:]
+    let immutableNeighbor : Door? = nil
+
+
+    var mutableNeighbor : Door? = nil
+    var varDict : [Int : Box] = [:]
+    var mutable : Int = 0
+    var varBox : Box = Box()
+    var getOnlyInt : Int {
+        get { 0 }
+    }
+
+    @MainActor var globActor_mutable : Int = 0
+    @MainActor let globActor_immutable : Int = 0
+
+    @MainActor(unsafe) var unsafeGlobActor_mutable : Int = 0
+    @MainActor(unsafe) let unsafeGlobActor_immutable : Int = 0
+
+    subscript(byIndex: Int) -> Int { 0 }
+
+    @MainActor subscript(byName: String) -> Int { 0 }
+
+    nonisolated subscript(byIEEE754: Double) -> Int { 0 }
+}
+
+func attemptAccess<T, V>(_ t : T, _ f : (T) -> V) -> V {
+    return f(t)
+}
+
+func tryKeyPathsMisc(d : Door) {
+    // as a func
+    _ = attemptAccess(d, \Door.mutable) // expected-error {{cannot form key path to actor-isolated property 'mutable'}}
+    _ = attemptAccess(d, \Door.immutable)
+    _ = attemptAccess(d, \Door.immutableNeighbor?.immutableNeighbor)
+
+    // in combination with other key paths
+
+    _ = (\Door.letBox).appending(path:  // expected-warning {{cannot form key path that accesses non-sendable type 'Box?'}}
+                                       \Box?.?.size)
+
+    _ = (\Door.varBox).appending(path:  // expected-error {{cannot form key path to actor-isolated property 'varBox'}}
+                                       \Box.size)
+
+}
+
+func tryKeyPathsFromAsync() async {
+    _ = \Door.unsafeGlobActor_immutable
+    _ = \Door.unsafeGlobActor_mutable // expected-error {{cannot form key path to actor-isolated property 'unsafeGlobActor_mutable'}}
+}
+
+func tryNonSendable() {
+    _ = \Door.letDict[0] // expected-warning {{cannot form key path that accesses non-sendable type '[Int : Box]'}}
+    _ = \Door.varDict[0] // expected-error {{cannot form key path to actor-isolated property 'varDict'}}
+    _ = \Door.letBox!.size // expected-warning {{cannot form key path that accesses non-sendable type 'Box?'}}
+}
+
+func tryKeypaths() {
+    _ = \Door.unsafeGlobActor_immutable
+    _ = \Door.unsafeGlobActor_mutable // expected-error {{cannot form key path to actor-isolated property 'unsafeGlobActor_mutable'}}
+
+    _ = \Door.immutable
+    _ = \Door.globActor_immutable
+    _ = \Door.[4.2]
+    _ = \Door.immutableNeighbor?.immutableNeighbor?.immutableNeighbor
+
+    _ = \Door.varBox // expected-error{{cannot form key path to actor-isolated property 'varBox'}}
+    _ = \Door.mutable  // expected-error{{cannot form key path to actor-isolated property 'mutable'}}
+    _ = \Door.getOnlyInt  // expected-error{{cannot form key path to actor-isolated property 'getOnlyInt'}}
+    _ = \Door.mutableNeighbor?.mutableNeighbor?.mutableNeighbor // expected-error 3 {{cannot form key path to actor-isolated property 'mutableNeighbor'}}
+
+    let _ : PartialKeyPath<Door> = \.mutable // expected-error{{cannot form key path to actor-isolated property 'mutable'}}
+    let _ : AnyKeyPath = \Door.mutable  // expected-error{{cannot form key path to actor-isolated property 'mutable'}}
+
+    _ = \Door.globActor_mutable // expected-error{{cannot form key path to actor-isolated property 'globActor_mutable'}}
+    _ = \Door.[0] // expected-error{{cannot form key path to actor-isolated subscript 'subscript(_:)'}}
+    _ = \Door.["hello"] // expected-error {{cannot form key path to actor-isolated subscript 'subscript(_:)'}}
+}

--- a/test/Constraints/dynamic_lookup_swift6.swift
+++ b/test/Constraints/dynamic_lookup_swift6.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %S/Inputs/PrivateObjC.swift -o %t
+// RUN: %target-typecheck-verify-swift -swift-version 6 -I %t -verify-ignore-unknown
+
+// REQUIRES: objc_interop && asserts
+
+import Foundation
+import PrivateObjC
+
+func test_dynamic_subscript_accepts_type_name_argument() {
+  @objc class A {
+    @objc subscript(a: A.Type) -> Int { get { 42 } }
+  }
+
+  func test(a: AnyObject, optA: AnyObject?) {
+    let _ = a[A] // expected-error {{expected member name or constructor call after type name}}
+    // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{16-16=()}}
+    // expected-note@-2 {{use '.self' to reference the type object}} {{16-16=.self}}
+
+    let _ = optA?[A] // expected-error {{expected member name or constructor call after type name}}
+    // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{20-20=()}}
+    // expected-note@-2 {{use '.self' to reference the type object}} {{20-20=.self}}
+  }
+}

--- a/test/Constraints/subscript_swift6.swift
+++ b/test/Constraints/subscript_swift6.swift
@@ -1,0 +1,20 @@
+// RUN: %target-typecheck-verify-swift -swift-version 6
+
+// REQUIRES: asserts
+
+// Note: In Swift >= 6 mode this would become an error.
+func test_subscript_accepts_type_name_argument() {
+  struct A {
+    subscript(a: A.Type) -> Int { get { 42 } }
+  }
+
+  func test(a: A, optA: A?) {
+    let _ = a[A] // expected-error {{expected member name or constructor call after type name}}
+    // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{16-16=()}}
+    // expected-note@-2 {{use '.self' to reference the type object}} {{16-16=.self}}
+
+    let _ = optA?[A] // expected-error {{expected member name or constructor call after type name}}
+    // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{20-20=()}}
+    // expected-note@-2 {{use '.self' to reference the type object}} {{20-20=.self}}
+  }
+}

--- a/test/Driver/swift-version-6-asserts.swift
+++ b/test/Driver/swift-version-6-asserts.swift
@@ -1,0 +1,54 @@
+// Tests temporary -swift-version 6 behavior in compilers with asserts enabled,
+// where we allow -swift-version 6 for testing but don't list it as a permitted
+// version.
+
+// REQUIRES: asserts
+
+// RUN: not %target-swiftc_driver -swift-version 6 -typecheck %s 2>&1 | %FileCheck --check-prefix ERROR_6 %s
+// RUN: not %target-swiftc_driver -swift-version 7 -typecheck %s 2>&1 | %FileCheck --check-prefix ERROR_7 %s
+
+#if swift(>=3)
+asdf
+// ERROR_6: [[@LINE-1]]:1: error: {{cannot find 'asdf' in scope}}
+#else
+jkl
+#endif
+
+#if swift(>=3.1)
+asdf
+// ERROR_6: [[@LINE-1]]:1: error: {{cannot find 'asdf' in scope}}
+#else
+jkl
+#endif
+
+#if swift(>=4)
+asdf 
+// ERROR_6: [[@LINE-1]]:1: error: {{cannot find 'asdf' in scope}}
+#else
+jkl
+#endif
+
+#if swift(>=4.1)
+asdf
+// ERROR_6: [[@LINE-1]]:1: error: {{cannot find 'asdf' in scope}}
+#else
+jkl
+#endif
+
+#if swift(>=6)
+asdf
+// ERROR_6: [[@LINE-1]]:1: error: {{cannot find 'asdf' in scope}}
+#else
+jkl
+#endif
+
+#if swift(>=7)
+asdf
+#else
+jkl
+// ERROR_6: [[@LINE-1]]:1: error: {{cannot find 'jkl' in scope}}
+#endif
+
+// ERROR_7: <unknown>:0: error: invalid value '7' in '-swift-version 7'
+// ERROR_7: <unknown>:0: note: valid arguments to '-swift-version'
+// ERROR_7-NOT: '6'

--- a/test/Driver/swift-version-6-noasserts.swift
+++ b/test/Driver/swift-version-6-noasserts.swift
@@ -1,0 +1,10 @@
+// Tests temporary -swift-version 6 behavior in compilers with asserts disabled,
+// where we don't allow -swift-version 6 to keep it out of release compilers.
+
+// UNSUPPORTED: asserts
+
+// RUN: not %target-swiftc_driver -swift-version 6 -typecheck %s 2>&1 | %FileCheck --check-prefix ERROR_6 %s
+
+// ERROR_6: <unknown>:0: error: invalid value '6' in '-swift-version 6'
+// ERROR_7: <unknown>:0: note: valid arguments to '-swift-version'
+// ERROR_7-NOT: '6'

--- a/test/Sema/diag_mismatched_magic_literals_swift6.swift
+++ b/test/Sema/diag_mismatched_magic_literals_swift6.swift
@@ -1,6 +1,10 @@
 // The future "Swift 6 mode" behavior is staged in behind  `-enable-experimental-concise-pound-file`.
 // RUN: %target-typecheck-verify-swift -enable-experimental-concise-pound-file
 
+// And is also available in Swift 6 mode on asserts compilers.
+// RUN: %target-typecheck-verify-swift -swift-version 6
+// REQUIRES: asserts
+
 func callee(file: String = #file) {} // expected-note {{'file' declared here}}
 func callee(fileID: String = #fileID) {} // expected-note {{'fileID' declared here}}
 func callee(filePath: String = #filePath) {} // expected-note 2 {{'filePath' declared here}}

--- a/test/decl/protocol/special/Sendable_swift6.swift
+++ b/test/decl/protocol/special/Sendable_swift6.swift
@@ -1,0 +1,30 @@
+// RUN: %target-typecheck-verify-swift -warn-concurrency -swift-version 6
+
+// REQUIRES: asserts
+
+func acceptSendable<T: Sendable>(_: T) { }
+
+class NotSendable { }
+
+func testSendableBuiltinConformances(
+  i: Int, ns: NotSendable, sf: @escaping @Sendable () -> Void,
+  nsf: @escaping () -> Void, mt: NotSendable.Type,
+  cf: @escaping @convention(c) () -> Void,
+  funSendable: [(Int, @Sendable () -> Void, NotSendable.Type)?],
+  funNotSendable: [(Int, () -> Void, NotSendable.Type)?]
+) {
+  acceptSendable(())
+  acceptSendable(mt)
+  acceptSendable(sf)
+  acceptSendable(cf)
+  acceptSendable((i, sf, mt))
+  acceptSendable((i, label: sf))
+  acceptSendable(funSendable)
+
+  // Complaints about missing Sendable conformances
+  acceptSendable((i, ns)) // expected-error{{type 'NotSendable' does not conform to the 'Sendable' protocol}}
+  acceptSendable(nsf) // expected-error{{function type '() -> Void' must be marked '@Sendable' to conform to 'Sendable'}}
+  acceptSendable((nsf, i)) // expected-error{{function type '() -> Void' must be marked '@Sendable' to conform to 'Sendable'}}
+  acceptSendable(funNotSendable) // expected-error{{function type '() -> Void' must be marked '@Sendable' to conform to 'Sendable'}}
+  acceptSendable((i, ns)) // expected-error{{type 'NotSendable' does not conform to the 'Sendable' protocol}}
+}


### PR DESCRIPTION
This pull request makes asserts compilers **only** accept `-swift-version 6` so that we can begin to test source-breaking changes intended for the next language version mode, but without shipping that unfinished work to Swift users. It also adds tests for existing Swift 6 mode behaviors (mostly warnings being strengthened into errors) and enables the changes to `#file` approved in SE-0274/SE-0285 for Swift 6 mode.

Tests that wish to use `-swift-version 6` currently **must** be marked with `REQUIRES: asserts` or they will fail in no-asserts bots. The simplest pattern is probably to duplicate part or all of the Swift 5 test to check that will behave as intended in Swift 6.