### PR TITLE
RequirementMachine: Fixes some bugs with superclass requirements

### DIFF
--- a/include/swift/AST/TypeMatcher.h
+++ b/include/swift/AST/TypeMatcher.h
@@ -195,13 +195,25 @@ class TypeMatcher {
     TRIVIAL_CASE(ModuleType)
     TRIVIAL_CASE(DynamicSelfType)
     TRIVIAL_CASE(ArchetypeType)
-    TRIVIAL_CASE(DependentMemberType)
+
+    bool visitDependentMemberType(CanDependentMemberType firstType,
+                                   Type secondType,
+                                   Type sugaredFirstType) {
+      /* If the types match, continue. */
+      if (!Matcher.asDerived().alwaysMismatchTypeParameters() &&
+          firstType->isEqual(secondType))
+        return true;
+
+      /* Otherwise, let the derived class deal with the mismatch. */
+      return mismatch(firstType.getPointer(), secondType,
+                      sugaredFirstType);
+    }
 
     bool visitGenericTypeParamType(CanGenericTypeParamType firstType,
                                    Type secondType,
                                    Type sugaredFirstType) {
       /* If the types match, continue. */
-      if (!Matcher.asDerived().alwaysMismatchGenericParams() &&
+      if (!Matcher.asDerived().alwaysMismatchTypeParameters() &&
           firstType->isEqual(secondType))
         return true;
 
@@ -312,7 +324,7 @@ class TypeMatcher {
 #undef TRIVIAL_CASE
   };
 
-  bool alwaysMismatchGenericParams() const { return false; }
+  bool alwaysMismatchTypeParameters() const { return false; }
 
   ImplClass &asDerived() { return static_cast<ImplClass &>(*this); }
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4494,7 +4494,7 @@ bool GenericSignatureBuilder::updateSuperclass(
 
     auto layout =
       LayoutConstraint::getLayoutConstraint(
-        superclass->getClassOrBoundGenericClass()->isObjC()
+        superclass->getClassOrBoundGenericClass()->usesObjCObjectModel()
           ? LayoutConstraintKind::Class
           : LayoutConstraintKind::NativeClass,
         getASTContext());

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -47,12 +47,12 @@ RequirementMachine::getLocalRequirements(
     return result;
 
   if (props->isConcreteType()) {
-    result.concreteType = props->getConcreteType({}, protos, Context);
+    result.concreteType = props->getConcreteType({}, term, protos, Context);
     return result;
   }
 
   if (props->hasSuperclassBound()) {
-    result.superclass = props->getSuperclassBound({}, protos, Context);
+    result.superclass = props->getSuperclassBound({}, term, protos, Context);
   }
 
   for (const auto *proto : props->getConformsToExcludingSuperclassConformances())
@@ -153,7 +153,7 @@ Type RequirementMachine::getSuperclassBound(Type depType) const {
     return Type();
 
   auto &protos = System.getProtocols();
-  return props->getSuperclassBound({ }, protos, Context);
+  return props->getSuperclassBound({ }, term, protos, Context);
 }
 
 bool RequirementMachine::isConcreteType(Type depType) const {
@@ -183,7 +183,7 @@ Type RequirementMachine::getConcreteType(Type depType) const {
     return Type();
 
   auto &protos = System.getProtocols();
-  return props->getConcreteType({ }, protos, Context);
+  return props->getConcreteType({ }, term, protos, Context);
 }
 
 bool RequirementMachine::areSameTypeParameterInContext(Type depType1,
@@ -349,7 +349,8 @@ Type RequirementMachine::getCanonicalTypeInContext(
       if (props) {
         if (props->isConcreteType()) {
           auto concreteType = props->getConcreteType(genericParams,
-                                                     protos, Context);
+                                                     prefix, protos,
+                                                     Context);
           if (!concreteType->hasTypeParameter())
             return concreteType;
 
@@ -364,7 +365,8 @@ Type RequirementMachine::getCanonicalTypeInContext(
         if (props->hasSuperclassBound() &&
             prefix.size() != term.size()) {
           auto superclass = props->getSuperclassBound(genericParams,
-                                                      protos, Context);
+                                                      prefix, protos,
+                                                      Context);
           if (!superclass->hasTypeParameter())
             return superclass;
 

--- a/lib/AST/RequirementMachine/PropertyMap.cpp
+++ b/lib/AST/RequirementMachine/PropertyMap.cpp
@@ -493,17 +493,6 @@ void PropertyBag::addProperty(
     return;
 
   case Symbol::Kind::Superclass: {
-    auto superclass = property.getSuperclass();
-
-    // A superclass requirement implies a layout requirement.
-    auto layout =
-      LayoutConstraint::getLayoutConstraint(
-        superclass->getClassOrBoundGenericClass()->isObjC()
-          ? LayoutConstraintKind::Class
-          : LayoutConstraintKind::NativeClass,
-        ctx.getASTContext());
-    addProperty(Symbol::forLayout(layout, ctx), ctx, inducedRules, debug);
-
     // FIXME: This needs to find the most derived subclass and also call
     // unifyConcreteTypes()
     Superclass = property;

--- a/lib/AST/RequirementMachine/PropertyMap.cpp
+++ b/lib/AST/RequirementMachine/PropertyMap.cpp
@@ -144,6 +144,7 @@ static unsigned getGenericParamIndex(Type type) {
 static Type getTypeFromSubstitutionSchema(Type schema,
                                           ArrayRef<Term> substitutions,
                               TypeArrayView<GenericTypeParamType> genericParams,
+                                          const MutableTerm &prefix,
                                           const ProtocolGraph &protos,
                                           RewriteContext &ctx) {
   assert(!schema->isTypeParameter() && "Must have a concrete type here");
@@ -155,8 +156,15 @@ static Type getTypeFromSubstitutionSchema(Type schema,
     if (t->is<GenericTypeParamType>()) {
       auto index = getGenericParamIndex(t);
 
-      return ctx.getTypeForTerm(substitutions[index],
-                                genericParams, protos);
+      // Prepend the prefix of the lookup key to the substitution, skipping
+      // creation of a new MutableTerm in the case where the prefix is empty.
+      if (prefix.empty()) {
+        return ctx.getTypeForTerm(substitutions[index], genericParams, protos);
+      } else {
+        MutableTerm substitution(prefix);
+        substitution.append(substitutions[index]);
+        return ctx.getTypeForTerm(substitution, genericParams, protos);
+      }
     }
 
     assert(!t->isTypeParameter());
@@ -164,32 +172,60 @@ static Type getTypeFromSubstitutionSchema(Type schema,
   });
 }
 
-/// Get the superclass bound for the term represented by this property bag.
+/// Given a term \p lookupTerm whose suffix must equal this property bag's
+/// key, return a new term with that suffix stripped off. Will be empty if
+/// \p lookupTerm exactly equals the key.
+MutableTerm
+PropertyBag::getPrefixAfterStrippingKey(const MutableTerm &lookupTerm) const {
+  assert(lookupTerm.size() >= Key.size());
+  auto prefixBegin = lookupTerm.begin();
+  auto prefixEnd = lookupTerm.end() - Key.size();
+  assert(std::equal(prefixEnd, lookupTerm.end(), Key.begin()) &&
+         "This is not the bag you're looking for");
+  return MutableTerm(prefixBegin, prefixEnd);
+}
+
+/// Get the superclass bound for \p lookupTerm, whose suffix must be the term
+/// represented by this property bag.
+///
+/// The original \p lookupTerm is important in case the concrete type has
+/// substitutions. For example, if \p lookupTerm is [P:A].[U:B], and this
+/// property bag records that the suffix [U:B] has a superclass symbol
+/// [superclass: Cache<τ_0_0> with <[U:C]>], then we actually need to
+/// apply the substitution τ_0_0 := [P:A].[U:C] to the type 'Cache<τ_0_0>'.
 ///
 /// Asserts if this property bag does not have a superclass bound.
 Type PropertyBag::getSuperclassBound(
     TypeArrayView<GenericTypeParamType> genericParams,
+    const MutableTerm &lookupTerm,
     const ProtocolGraph &protos,
     RewriteContext &ctx) const {
+  MutableTerm prefix = getPrefixAfterStrippingKey(lookupTerm);
   return getTypeFromSubstitutionSchema(Superclass->getSuperclass(),
                                        Superclass->getSubstitutions(),
-                                       genericParams,
-                                       protos,
-                                       ctx);
+                                       genericParams, prefix,
+                                       protos, ctx);
 }
 
 /// Get the concrete type of the term represented by this property bag.
 ///
+/// The original \p lookupTerm is important in case the concrete type has
+/// substitutions. For example, if \p lookupTerm is [P:A].[U:B], and this
+/// property bag records that the suffix [U:B] has a concrete type symbol
+/// [concrete: Array<τ_0_0> with <[U:C]>], then we actually need to
+/// apply the substitution τ_0_0 := [P:A].[U:C] to the type 'Array<τ_0_0>'.
+///
 /// Asserts if this property bag is not concrete.
 Type PropertyBag::getConcreteType(
     TypeArrayView<GenericTypeParamType> genericParams,
+    const MutableTerm &lookupTerm,
     const ProtocolGraph &protos,
     RewriteContext &ctx) const {
+  MutableTerm prefix = getPrefixAfterStrippingKey(lookupTerm);
   return getTypeFromSubstitutionSchema(ConcreteType->getConcreteType(),
                                        ConcreteType->getSubstitutions(),
-                                       genericParams,
-                                       protos,
-                                       ctx);
+                                       genericParams, prefix,
+                                       protos, ctx);
 }
 
 /// Computes the term corresponding to a member type access on a substitution.

--- a/lib/AST/RequirementMachine/PropertyMap.cpp
+++ b/lib/AST/RequirementMachine/PropertyMap.cpp
@@ -387,7 +387,7 @@ static bool unifyConcreteTypes(
           rhsSubstitutions(rhsSubstitutions),
           ctx(ctx), inducedRules(inducedRules), debug(debug) {}
 
-    bool alwaysMismatchGenericParams() const { return true; }
+    bool alwaysMismatchTypeParameters() const { return true; }
 
     bool mismatch(TypeBase *firstType, TypeBase *secondType,
                   Type sugaredFirstType) {

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -101,6 +101,7 @@ public:
 
   Type getSuperclassBound(
       TypeArrayView<GenericTypeParamType> genericParams,
+      const MutableTerm &lookupTerm,
       const ProtocolGraph &protos,
       RewriteContext &ctx) const;
 
@@ -114,6 +115,7 @@ public:
 
   Type getConcreteType(
       TypeArrayView<GenericTypeParamType> genericParams,
+      const MutableTerm &lookupTerm,
       const ProtocolGraph &protos,
       RewriteContext &ctx) const;
 
@@ -127,6 +129,8 @@ public:
 
   llvm::TinyPtrVector<const ProtocolDecl *>
   getConformsToExcludingSuperclassConformances() const;
+
+  MutableTerm getPrefixAfterStrippingKey(const MutableTerm &lookupTerm) const;
 };
 
 /// Stores all rewrite rules of the form T.[p] => T, where [p] is a property

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -171,6 +171,13 @@ void RewriteSystemBuilder::addRequirement(const Requirement &req,
     // A superclass requirement T : C<X, Y> becomes a rewrite rule
     //
     //   T.[superclass: C<X, Y>] => T
+    //
+    // Together with a rewrite rule
+    //
+    //   T.[layout: L] => T
+    //
+    // Where 'L' is either AnyObject or _NativeObject, depending on the
+    // ancestry of C.
     auto otherType = CanType(req.getSecondType());
 
     SmallVector<Term, 1> substitutions;
@@ -180,6 +187,16 @@ void RewriteSystemBuilder::addRequirement(const Requirement &req,
     constraintTerm = subjectTerm;
     constraintTerm.add(Symbol::forSuperclass(otherType, substitutions,
                                              Context));
+    Rules.emplace_back(subjectTerm, constraintTerm);
+
+    constraintTerm = subjectTerm;
+    auto layout =
+      LayoutConstraint::getLayoutConstraint(
+        otherType->getClassOrBoundGenericClass()->usesObjCObjectModel()
+          ? LayoutConstraintKind::Class
+          : LayoutConstraintKind::NativeClass,
+        Context.getASTContext());
+    constraintTerm.add(Symbol::forLayout(layout, Context));
     break;
   }
 

--- a/test/Generics/concrete_type_property_of_suffix.swift
+++ b/test/Generics/concrete_type_property_of_suffix.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift -requirement-machine=verify
+
+protocol P {
+  associatedtype T where T == U?
+  associatedtype U
+}
+
+func sameType<T>(_: T.Type, _: T.Type) {}
+
+func foo<X : P, Y : P>(_: X, _: Y) {
+  // X.T is Optional<X.U>.
+  sameType(X.T.self, X.U?.self)
+
+  // Y.T is Optional<Y.U>.
+  sameType(Y.T.self, Y.U?.self)
+}

--- a/test/Generics/generic_objc_superclass.swift
+++ b/test/Generics/generic_objc_superclass.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift %clang-importer-sdk -requirement-machine=verify -debug-requirement-machine 2>&1 | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+class Generic<T> : NSObject {}
+
+func foo<T : Generic<U>, U>(_: T, _: U) {
+  _ = T.self
+  _ = U.self
+}
+
+// CHECK-LABEL: Requirement machine for <τ_0_0, τ_0_1 where τ_0_0 : Generic<τ_0_1>>
+// CHECK-NEXT: Rewrite system: {
+// CHECK-NEXT: - τ_0_0.[superclass: Generic<τ_0_0> with <τ_0_1>] => τ_0_0
+// CHECK-NEXT: - τ_0_0.[layout: AnyObject] => τ_0_0
+// CHECK-NEXT: }
+// CHECK-NEXT: Property map: {
+// CHECK-NEXT:   τ_0_0 => { layout: AnyObject superclass: [superclass: Generic<τ_0_0> with <τ_0_1>] }
+// CHECK-NEXT: }

--- a/test/Generics/member_type_of_superclass_bound.swift
+++ b/test/Generics/member_type_of_superclass_bound.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-emit-silgen %s -requirement-machine=verify
+
+// The substituted type of SS.x.x is computed by taking the type of S.x,
+// which is T.T in the generic signature <T where T : P>, and then
+// canonicalizing it in the generic signature <T : C<U>, U>.
+//
+// The latter generic signature does not have a conformance requirement T : P,
+// but the superclass bound C<U> of T conforms to P concretely; make sure that
+// the requirement machine's getCanonicalTypeInContext() can handle this.
+public protocol P {
+  associatedtype T
+}
+
+public class C<T> : P {}
+
+public struct S<T : P> {
+  public var x: T.T
+}
+
+public struct SS<T : C<U>, U> {
+  public var x: S<T>
+}
+
+

--- a/test/Generics/unify_superclass_types_1.swift
+++ b/test/Generics/unify_superclass_types_1.swift
@@ -1,0 +1,28 @@
+// RUN: %target-typecheck-verify-swift -requirement-machine=verify -debug-requirement-machine 2>&1 | %FileCheck %s
+
+class Base {}
+class Derived : Base {
+  func derivedMethod() {}
+}
+
+protocol P : Base {}
+
+func takesDerived(_: Derived) {}
+
+extension P where Self : Derived {
+  func passesDerived() { derivedMethod() }
+}
+
+// CHECK-LABEL: Requirement machine for <τ_0_0 where τ_0_0 : Derived, τ_0_0 : P>
+// CHECK-NEXT: Rewrite system: {
+// CHECK-NEXT: - [P].[superclass: Base] => [P]
+// CHECK-NEXT: - [P].[layout: _NativeClass] => [P]
+// CHECK-NEXT: - τ_0_0.[superclass: Derived] => τ_0_0
+// CHECK-NEXT: - τ_0_0.[layout: _NativeClass] => τ_0_0
+// CHECK-NEXT: - τ_0_0.[P] => τ_0_0
+// CHECK-NEXT: - τ_0_0.[superclass: Base] => τ_0_0
+// CHECK-NEXT: }
+// CHECK-NEXT: Property map: {
+// CHECK-NEXT:   [P] => { layout: _NativeClass superclass: [superclass: Base] }
+// CHECK-NEXT:   τ_0_0 => { conforms_to: [P] layout: _NativeClass superclass: [superclass: Derived] }
+// CHECK-NEXT: }

--- a/test/Generics/unify_superclass_types_2.swift
+++ b/test/Generics/unify_superclass_types_2.swift
@@ -1,0 +1,47 @@
+// RUN: %target-typecheck-verify-swift -requirement-machine=on -debug-requirement-machine 2>&1 | %FileCheck %s
+
+// Note: The GSB fails this test, because it doesn't implement unification of
+// superclass type constructor arguments.
+
+class Generic<T, U, V> {}
+
+protocol P1 {
+  associatedtype X : Generic<Int, A1, B1>
+  associatedtype A1
+  associatedtype B1
+}
+
+protocol P2 {
+  associatedtype X : Generic<A2, String, B2>
+  associatedtype A2
+  associatedtype B2
+}
+
+func sameType<T>(_: T.Type, _: T.Type) {}
+
+func takesGenericIntString<U>(_: Generic<Int, String, U>.Type) {}
+
+func unifySuperclassTest<T : P1 & P2>(_: T) {
+  sameType(T.A1.self, String.self)
+  sameType(T.A2.self, Int.self)
+  sameType(T.B1.self, T.B2.self)
+  takesGenericIntString(T.X.self)
+}
+
+// CHECK-LABEL: Requirement machine for <τ_0_0 where τ_0_0 : P1, τ_0_0 : P2>
+// CHECK-NEXT: Rewrite system: {
+// CHECK:      - τ_0_0.[P1&P2:X].[superclass: Generic<τ_0_0, String, τ_0_1> with <τ_0_0.[P2:A2], τ_0_0.[P2:B2]>] => τ_0_0.[P1&P2:X]
+// CHECK-NEXT: - τ_0_0.[P1&P2:X].[superclass: Generic<Int, τ_0_0, τ_0_1> with <τ_0_0.[P1:A1], τ_0_0.[P1:B1]>] => τ_0_0.[P1&P2:X]
+// CHECK-NEXT: - τ_0_0.[P1&P2:X].[layout: _NativeClass] => τ_0_0.[P1&P2:X]
+// CHECK-NEXT: - τ_0_0.[P2:A2].[concrete: Int] => τ_0_0.[P2:A2]
+// CHECK-NEXT: - τ_0_0.[P1:A1].[concrete: String] => τ_0_0.[P1:A1]
+// CHECK-NEXT: - τ_0_0.[P2:B2] => τ_0_0.[P1:B1]
+// CHECK:      }
+// CHECK-NEXT: Property map: {
+// CHECK-NEXT:   [P1:X] => { layout: _NativeClass superclass: [superclass: Generic<Int, τ_0_0, τ_0_1> with <[P1:A1], [P1:B1]>] }
+// CHECK-NEXT:   [P2:X] => { layout: _NativeClass superclass: [superclass: Generic<τ_0_0, String, τ_0_1> with <[P2:A2], [P2:B2]>] }
+// CHECK-NEXT:   τ_0_0 => { conforms_to: [P1 P2] }
+// CHECK-NEXT:   τ_0_0.[P1&P2:X] => { layout: _NativeClass superclass: [superclass: Generic<Int, τ_0_0, τ_0_1> with <τ_0_0.[P1:A1], τ_0_0.[P1:B1]>] }
+// CHECK-NEXT:   τ_0_0.[P1:A1] => { concrete_type: [concrete: String] }
+// CHECK-NEXT:   τ_0_0.[P2:A2] => { concrete_type: [concrete: Int] }
+// CHECK-NEXT: }

--- a/test/Generics/unify_superclass_types_3.swift
+++ b/test/Generics/unify_superclass_types_3.swift
@@ -1,0 +1,49 @@
+// RUN: %target-typecheck-verify-swift -requirement-machine=on -debug-requirement-machine 2>&1 | %FileCheck %s
+
+// Note: The GSB fails this test, because it doesn't implement unification of
+// superclass type constructor arguments.
+
+class Generic<T, U, V> {}
+
+class Derived<TT, UU> : Generic<Int, TT, UU> {}
+
+protocol P1 {
+  associatedtype X : Derived<A1, B1>
+  associatedtype A1
+  associatedtype B1
+}
+
+protocol P2 {
+  associatedtype X : Generic<A2, String, B2>
+  associatedtype A2
+  associatedtype B2
+}
+
+func sameType<T>(_: T.Type, _: T.Type) {}
+
+func takesDerivedString<U>(_: Derived<String, U>.Type) {}
+
+func unifySuperclassTest<T : P1 & P2>(_: T) {
+  sameType(T.A1.self, String.self)
+  sameType(T.A2.self, Int.self)
+  sameType(T.B1.self, T.B2.self)
+  takesDerivedString(T.X.self)
+}
+
+// CHECK-LABEL: Requirement machine for <τ_0_0 where τ_0_0 : P1, τ_0_0 : P2>
+// CHECK-NEXT: Rewrite system: {
+// CHECK:      - τ_0_0.[P1&P2:X].[superclass: Generic<τ_0_0, String, τ_0_1> with <τ_0_0.[P2:A2], τ_0_0.[P2:B2]>] => τ_0_0.[P1&P2:X]
+// CHECK-NEXT: - τ_0_0.[P1&P2:X].[superclass: Derived<τ_0_0, τ_0_1> with <τ_0_0.[P1:A1], τ_0_0.[P1:B1]>] => τ_0_0.[P1&P2:X]
+// CHECK-NEXT: - τ_0_0.[P1&P2:X].[layout: _NativeClass] => τ_0_0.[P1&P2:X]
+// CHECK-NEXT: - τ_0_0.[P2:A2].[concrete: Int] => τ_0_0.[P2:A2]
+// CHECK-NEXT: - τ_0_0.[P1:A1].[concrete: String] => τ_0_0.[P1:A1]
+// CHECK-NEXT: - τ_0_0.[P2:B2] => τ_0_0.[P1:B1]
+// CHECK-NEXT: }
+// CHECK-NEXT: Property map: {
+// CHECK-NEXT:   [P1:X] => { layout: _NativeClass superclass: [superclass: Derived<τ_0_0, τ_0_1> with <[P1:A1], [P1:B1]>] }
+// CHECK-NEXT:   [P2:X] => { layout: _NativeClass superclass: [superclass: Generic<τ_0_0, String, τ_0_1> with <[P2:A2], [P2:B2]>] }
+// CHECK-NEXT:   τ_0_0 => { conforms_to: [P1 P2] }
+// CHECK-NEXT:   τ_0_0.[P1&P2:X] => { layout: _NativeClass superclass: [superclass: Derived<τ_0_0, τ_0_1> with <τ_0_0.[P1:A1], τ_0_0.[P1:B1]>] }
+// CHECK-NEXT:   τ_0_0.[P1:A1] => { concrete_type: [concrete: String] }
+// CHECK-NEXT:   τ_0_0.[P2:A2] => { concrete_type: [concrete: Int] }
+// CHECK-NEXT: }

--- a/test/Generics/unify_superclass_types_4.swift
+++ b/test/Generics/unify_superclass_types_4.swift
@@ -1,0 +1,49 @@
+// RUN: %target-typecheck-verify-swift -requirement-machine=on -debug-requirement-machine 2>&1 | %FileCheck %s
+
+// Note: The GSB fails this test, because it doesn't implement unification of
+// superclass type constructor arguments.
+
+class Base<T> {}
+
+protocol Q {
+  associatedtype T
+}
+
+class Derived<TT : Q> : Base<TT.T> {}
+
+protocol P1 {
+  associatedtype X : Base<A1>
+  associatedtype A1
+}
+
+protocol P2 {
+  associatedtype X : Derived<A2>
+  associatedtype A2 : Q
+}
+
+func sameType<T>(_: T.Type, _: T.Type) {}
+
+func takesBase<U>(_: Base<U>.Type, _: U.Type) {}
+
+func takesDerived<U : Q>(_: Derived<U>.Type, _: U.Type) {}
+
+func unifySuperclassTest<T : P1 & P2>(_: T) {
+  sameType(T.A1.self, T.A2.T.self)
+  takesBase(T.X.self, T.A1.self)
+  takesDerived(T.X.self, T.A2.self)
+}
+
+// CHECK-LABEL: Requirement machine for <τ_0_0 where τ_0_0 : P1, τ_0_0 : P2>
+// CHECK-NEXT: Rewrite system: {
+// CHECK:      - τ_0_0.[P1&P2:X].[superclass: Derived<τ_0_0> with <τ_0_0.[P2:A2]>] => τ_0_0.[P1&P2:X]
+// CHECK-NEXT: - τ_0_0.[P1&P2:X].[superclass: Base<τ_0_0> with <τ_0_0.[P1:A1]>] => τ_0_0.[P1&P2:X]
+// CHECK-NEXT: - τ_0_0.[P1&P2:X].[layout: _NativeClass] => τ_0_0.[P1&P2:X]
+// CHECK-NEXT: - τ_0_0.[P2:A2].[Q:T] => τ_0_0.[P1:A1]
+// CHECK-NEXT: }
+// CHECK-NEXT: Property map: {
+// CHECK-NEXT:   [P1:X] => { layout: _NativeClass superclass: [superclass: Base<τ_0_0> with <[P1:A1]>] }
+// CHECK-NEXT:   [P2:A2] => { conforms_to: [Q] }
+// CHECK-NEXT:   [P2:X] => { layout: _NativeClass superclass: [superclass: Derived<τ_0_0> with <[P2:A2]>] }
+// CHECK-NEXT:   τ_0_0 => { conforms_to: [P1 P2] }
+// CHECK-NEXT:   τ_0_0.[P1&P2:X] => { layout: _NativeClass superclass: [superclass: Derived<τ_0_0> with <τ_0_0.[P2:A2]>] }
+// CHECK-NEXT: }


### PR DESCRIPTION
While testing the RequirementMachine on the source compatibility suite and some other projects, I finally found an example where we need to unify superclass requirements and pick the most derived class out of the two. This was on my todo list for a while, and it turned out to be pretty straightforward to implement by refactoring the existing code for doing this with concrete type requirements.

The new implementation is more advanced than what the GSB did, because it also unifies type constructor arguments in the case where the superclasses are generic as well. For example,

    class Base<T> {}
    class Derived : Base<Int> {}

    protocol P1 {
      associatedtype X : Base<Y>
      associatedtype Y
    }

    protocol P2 {
      associatedtype X : Derived
    }

    func foo<T : P1 & P2>(_: T) {}

The RequirementMachine will derive that `T.X : Derived` now just like the GSB, but furthermore, `T.Y == Int`, which the GSB was unable to prove.

This PR has a couple of more minor fixes for other issues found via testing as well.