### PR TITLE
[Demangler][Tests] Add an explicit test for getObjCClassByMangledName.

### DIFF
--- a/include/swift/Demangling/TypeLookupError.h
+++ b/include/swift/Demangling/TypeLookupError.h
@@ -207,7 +207,10 @@ template <typename... Args>
 static TypeLookupError TypeLookupErrorImpl(const char *fmt, Args... args) {
   return TypeLookupError([=] {
     char *str;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-security"
     swift_asprintf(&str, fmt, args...);
+#pragma clang diagnostic pop
     return str;
   });
 }

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -24,7 +24,6 @@
 #include "swift/Reflection/TypeLowering.h"
 #include "swift/Reflection/TypeRef.h"
 #include "llvm/ADT/Optional.h"
-
 #include <vector>
 #include <unordered_map>
 

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -441,9 +441,11 @@ std::pair<int, Node *> Remangler::mangleConstrainedType(Node *node,
     Chain.push_back(node->getChild(1), Factory);
     node = getChildOfType(node->getFirstChild());
   }
-  
+
   if (node->getKind() != Node::Kind::DependentGenericParamType) {
     mangle(node, depth + 1);
+    if (!Chain.size())
+      return {-1, nullptr};
     node = nullptr;
   }
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3484,22 +3484,23 @@ ExistentialMetatypeValueWitnessTableCacheEntry(unsigned numWitnessTables) {
 SWIFT_RUNTIME_EXPORT
 const ExistentialMetatypeMetadata *
 swift::swift_getExistentialMetatypeMetadata(const Metadata *instanceMetadata) {
-  if (instanceMetadata->getKind() != MetadataKind::Existential
-      && instanceMetadata->getKind() != MetadataKind::ExistentialMetatype)
-    return nullptr;
-
   return &ExistentialMetatypes.getOrInsert(instanceMetadata).first->Data;
 }
 
 ExistentialMetatypeCacheEntry::ExistentialMetatypeCacheEntry(
                                             const Metadata *instanceMetadata) {
   ExistentialTypeFlags flags;
-  if (instanceMetadata->getKind() == MetadataKind::Existential) {
+  switch (instanceMetadata->getKind()) {
+  case MetadataKind::Existential:
     flags = static_cast<const ExistentialTypeMetadata*>(instanceMetadata)
       ->Flags;
-  } else {
+    break;
+  case MetadataKind::ExistentialMetatype:
     flags = static_cast<const ExistentialMetatypeMetadata*>(instanceMetadata)
       ->Flags;
+    break;
+  default:
+    assert(false && "expected existential metadata");
   }
 
   Data.setKind(MetadataKind::ExistentialMetatype);

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3484,6 +3484,10 @@ ExistentialMetatypeValueWitnessTableCacheEntry(unsigned numWitnessTables) {
 SWIFT_RUNTIME_EXPORT
 const ExistentialMetatypeMetadata *
 swift::swift_getExistentialMetatypeMetadata(const Metadata *instanceMetadata) {
+  if (instanceMetadata->getKind() != MetadataKind::Existential
+      && instanceMetadata->getKind() != MetadataKind::ExistentialMetatype)
+    return nullptr;
+
   return &ExistentialMetatypes.getOrInsert(instanceMetadata).first->Data;
 }
 
@@ -3494,7 +3498,6 @@ ExistentialMetatypeCacheEntry::ExistentialMetatypeCacheEntry(
     flags = static_cast<const ExistentialTypeMetadata*>(instanceMetadata)
       ->Flags;
   } else {
-    assert(instanceMetadata->getKind() == MetadataKind::ExistentialMetatype);
     flags = static_cast<const ExistentialMetatypeMetadata*>(instanceMetadata)
       ->Flags;
   }

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1446,7 +1446,13 @@ public:
   TypeLookupErrorOr<BuiltType> createExistentialMetatypeType(
       BuiltType instance,
       llvm::Optional<Demangle::ImplMetatypeRepresentation> repr = None) const {
-    return swift_getExistentialMetatypeMetadata(instance);
+    BuiltType result = swift_getExistentialMetatypeMetadata(instance);
+    if (!result) {
+      return TYPE_LOOKUP_ERROR_FMT("Tried to build an existential metatype from "
+                                   "a type that was neither an existential nor "
+                                   "an existential metatype");
+    }
+    return result;
   }
 
   TypeLookupErrorOr<BuiltType>

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1446,13 +1446,13 @@ public:
   TypeLookupErrorOr<BuiltType> createExistentialMetatypeType(
       BuiltType instance,
       llvm::Optional<Demangle::ImplMetatypeRepresentation> repr = None) const {
-    BuiltType result = swift_getExistentialMetatypeMetadata(instance);
-    if (!result) {
+    if (instance->getKind() != MetadataKind::Existential
+        && instance->getKind() != MetadataKind::ExistentialMetatype) {
       return TYPE_LOOKUP_ERROR_FMT("Tried to build an existential metatype from "
                                    "a type that was neither an existential nor "
                                    "an existential metatype");
     }
-    return result;
+    return swift_getExistentialMetatypeMetadata(instance);
   }
 
   TypeLookupErrorOr<BuiltType>

--- a/test/Demangle/Inputs/objc-getclass.txt
+++ b/test/Demangle/Inputs/objc-getclass.txt
@@ -1,0 +1,28 @@
+# These were found by fuzzing getObjCClassByMangledName
+
+# rdar://63485806
+# This results in an abort(), whereas it should be an error; rdar://79725187
+# covers improving error handling; until that's done, disable this test case
+
+# 3…KySSyGSkySySSGiG3(KˇˇˇˇˇˇˇˇˇˇˇˇˇˇCwKySSiKySS
+# SSmSySyySGGSGyGSyySyySySSGGSGyS78iSLccSGSyySSySSGGccLcV1yVS~^§!zzzzzzzzzzzzhzzzzzSLzSEzzzzzzzzzzzzzzzzzxxxxx8K_S0ttnIx4_
+# ˇyySySyySySyGnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnSgZ1laSgSg
+# SSx3…KySyySGSSG_S2ItLHPˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇMd7KLPlKSSFTc•OSgS
+# 3…KySSiGSeySySSGiGSiySySSGiG3(KˇˇˇˇˇˇˇˇˇˇˇˇˇˇCwKySSiKySS
+# 3…KySSiGSyySySSGiG3(KˇˇˇˇˇˇˇˇˇˇˇˇˇˇCwKySSiKySS
+# SyySyySSySyyGSyySyyGGSGyGSyySySyySySSGGSGGˇˇˇˇˇS4S_SmˇˇAGmmmmmmmmmtLHPL(LHPTVdLHV
+
+# rdar://63488139
+1_SxSt_S4KSgS9OSgRSLAPALÂ
+
+# rdar://63496478
+BwXp
+1TSpXpBOXp
+SJSJSFSrSJSKSKSKSKm_tmcXpXpStmcXpXpSE_tmcXpXpmcXpXpStmcXpXpSE_tmcXpBpXp!E_tXpXpStmcXpZpSE_tmcXpXpSE_tmc3
+x_xSx_SxTd_SySyyS6dyGˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇˇBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBˇˇˇˇˇˇˇˇˇˇXpXpXpf:8–VSBP0
+
+# rdar://63410196
+SlSIxip6/XXS*”PLEPÓd}}}}}}}
+
+# rdar://68449341
+ySfmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmf%mmmmmmmmmmmmmf%w

--- a/test/Demangle/lit.local.cfg
+++ b/test/Demangle/lit.local.cfg
@@ -1,2 +1,3 @@
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes.add('.test')
+config.suffixes.add('.cpp')

--- a/test/Demangle/objc-getclass.cpp
+++ b/test/Demangle/objc-getclass.cpp
@@ -1,0 +1,84 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %s -isysroot %sdk -L%swift_obj_root/lib/swift/%target-os-abi -lswiftCore -o %t/objc-getclass
+// RUN: %target-codesign %t/objc-getclass
+// RUN: %target-run %t/objc-getclass %S/Inputs/objc-getclass.txt
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+#include <objc/runtime.h>
+#include <dlfcn.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <errno.h>
+#include <string.h>
+
+static BOOL dummyHook(const char * _Nonnull name,
+                      Class _Nullable * _Nonnull outClass) {
+  return NO;
+}
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    fprintf(stderr, "usage: objc-getclass <input.txt>\n"
+            "\n"
+            "Test demangling class names to get classes.\n");
+    return 0;
+  }
+
+  // Find the class-by-mangled-name hook
+  objc_hook_getClass getObjCClassByMangledName = NULL;
+
+  if (__builtin_available(macOS 10.14.4, iOS 12.2, tvOS 12.2, watchOS 5.2, *)) {
+    objc_hook_getClass dummy = NULL;
+    objc_setHook_getClass(dummyHook, &getObjCClassByMangledName);
+    objc_setHook_getClass(getObjCClassByMangledName, &dummy);
+  } else {
+    fprintf(stderr, "objc-getclass: macOS version is too old\n");
+    return 1;
+  }
+
+  // Open the input file
+  FILE *fp = fopen(argv[1], "rt");
+  if (!fp) {
+    fprintf(stderr, "objc-getclass: unable to open \"%s\" - %s\n",
+            argv[1], strerror(errno));
+  }
+
+  // Input file is a list of manglings; we don't really care what classes they
+  // resolve to here; this test is about whether or not they actually crash or
+  // assert.
+  char *line = NULL;
+  size_t linecap = 0;
+  ssize_t linelen = 0;
+
+  while ((linelen = getline(&line, &linecap, fp)) > 0) {
+    char *mangling = line;
+
+    // Trim whitespace
+    while (isspace(*mangling))
+      ++mangling;
+
+    char *end = line + linelen;
+    while (end > line && isspace(end[-1]))
+      --end;
+    *end = '\0';
+
+    // Skip comments and blank lines
+    if (*mangling == '#' || !*mangling)
+      continue;
+
+    // Try to get a class
+    Class outClass = nil;
+    BOOL result = getObjCClassByMangledName(mangling, &outClass);
+
+    if (result)
+      printf("%s -> %s\n", mangling, class_getName(outClass));
+    else
+      printf("%s not found\n", mangling);
+  }
+
+  fclose(fp);
+
+  return 0;
+}


### PR DESCRIPTION
Added a special test for `getObjCClassByMangledName`; this needs testing separately as it uses the `DecodedMetadataBuilder`, which doesn't get exercised by the normal demangling tests.

Added all the test cases from rdar://63485806, rdar://63488139, rdar://63496478, rdar://63410196 and rdar://68449341.  The test cases from rdar://63485806 are disabled for now because the problem there is the error handling mechanism (or
lack thereof), rather than us not handling errors.

Fixes the remaining cases from

rdar://63488139
rdar://63496478