### PR TITLE
NFC: fix range loop analysis warning.

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -3538,7 +3538,7 @@ llvm::Constant *IRGenModule::getAddrOfGenericEnvironment(
         llvm::SmallVector<uint16_t, 4> genericParamCounts;
         unsigned curDepth = 0;
         unsigned genericParamCount = 0;
-        for (const auto gp : signature.getGenericParams()) {
+        for (const auto &gp : signature.getGenericParams()) {
           if (curDepth != gp->getDepth()) {
             genericParamCounts.push_back(genericParamCount);
             curDepth = gp->getDepth();


### PR DESCRIPTION
```
[399/977] Building CXX object lib/IRGen/CMakeFiles/swiftIRGen.dir/GenProto.cpp.o
/Users/danielzheng/swift-bart/swift/lib/IRGen/GenProto.cpp:3541:25: warning: loop variable 'gp' of type 'const swift::CanTypeWrapper<swift::GenericTypeParamType>' creates a copy from type 'const swift::CanTypeWrapper<swift::GenericTypeParamType>' [-Wrange-loop-analysis]
        for (const auto gp : signature.getGenericParams()) {
                        ^
/Users/danielzheng/swift-bart/swift/lib/IRGen/GenProto.cpp:3541:14: note: use reference type 'const swift::CanTypeWrapper<swift::GenericTypeParamType> &' to prevent copying
        for (const auto gp : signature.getGenericParams()) {
             ^~~~~~~~~~~~~~~
                        &
1 warning generated.
```

Silence warning by using reference type (`&`) to avoid creating a copy.