### PR TITLE
[sourcekitd-test] Add option to count number of instructions taken to execute request

### DIFF
--- a/tools/SourceKit/tools/sourcekitd-test/Options.td
+++ b/tools/SourceKit/tools/sourcekitd-test/Options.td
@@ -134,6 +134,9 @@ def cancel_on_subsequent_request_EQ : Joined<["-"], "cancel-on-subsequent-reques
 def time_request : Flag<["-"], "time-request">,
   HelpText<"Print the time taken to process the request">;
 
+def measure_instructions : Flag<["-"], "measure-instructions">,
+  HelpText<"Measure how many instructions the execution of this request took in the SourceKit process.">;
+
 def repeat_request : Separate<["-"], "repeat-request">,
   HelpText<"Repeat the request n times">, MetaVarName<"<n>">;
 def repeat_request_EQ : Joined<["-"], "repeat-request=">, Alias<repeat_request>;

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -382,6 +382,10 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
       timeRequest = true;
       break;
 
+    case OPT_measure_instructions:
+      measureInstructions = true;
+      break;
+
     case OPT_repeat_request:
       if (StringRef(InputArg->getValue()).getAsInteger(10, repeatRequest)) {
         llvm::errs() << "error: expected integer for 'cancel-on-subsequent-request'\n";

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -114,6 +114,7 @@ struct TestOptions {
   bool CollectActionables = false;
   bool isAsyncRequest = false;
   bool timeRequest = false;
+  bool measureInstructions = false;
   bool DisableImplicitConcurrencyModuleImport = false;
   llvm::Optional<unsigned> CompletionCheckDependencyInterval;
   unsigned repeatRequest = 1;


### PR DESCRIPTION
This adds a `-measure-instructions` option to `sourcekitd-test` which measures the number of instructions the SourceKit process took to execute the request.