### PR TITLE
Improve usability of -l flag

### DIFF
--- a/include/swift/Driver/ToolChain.h
+++ b/include/swift/Driver/ToolChain.h
@@ -249,6 +249,14 @@ public:
   const Driver &getDriver() const { return D; }
   const llvm::Triple &getTriple() const { return Triple; }
 
+  static void addLinkedLibArgs(const llvm::opt::ArgList &Args,
+                               llvm::opt::ArgStringList &FrontendArgs);
+
+  static void addArgsFromGroupExcept(const llvm::opt::ArgList &Args,
+                                     llvm::opt::ArgStringList &FrontendArgs,
+                                     llvm::opt::OptSpecifier groupID,
+                                     llvm::opt::OptSpecifier exceptID);
+
   /// Construct a Job for the action \p JA, taking the given information into
   /// account.
   ///

--- a/include/swift/Driver/ToolChain.h
+++ b/include/swift/Driver/ToolChain.h
@@ -249,13 +249,13 @@ public:
   const Driver &getDriver() const { return D; }
   const llvm::Triple &getTriple() const { return Triple; }
 
+  /// Special handling for passing down '-l' arguments.
+  ///
+  /// Not all downstream tools (lldb, ld etc.) consistently accept
+  /// a space between the '-l' flag and its argument, so we remove
+  /// the extra space if it was present in \c Args.
   static void addLinkedLibArgs(const llvm::opt::ArgList &Args,
                                llvm::opt::ArgStringList &FrontendArgs);
-
-  static void addArgsFromGroupExcept(const llvm::opt::ArgList &Args,
-                                     llvm::opt::ArgStringList &FrontendArgs,
-                                     llvm::opt::OptSpecifier groupID,
-                                     llvm::opt::OptSpecifier exceptID);
 
   /// Construct a Job for the action \p JA, taking the given information into
   /// account.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -701,7 +701,7 @@ def libc : Separate<["-"], "libc">, HelpText<"libc runtime library to use">;
 
 def linker_option_Group : OptionGroup<"<linker-specific options>">;
 
-def l : Joined<["-"], "l">, Group<linker_option_Group>,
+def l : JoinedOrSeparate<["-"], "l">, Group<linker_option_Group>,
     Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
     HelpText<"Specifies a library which should be linked against">;
 def framework : Separate<["-"], "framework">, Group<linker_option_Group>,

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -796,7 +796,10 @@ toolchains::Darwin::constructInvocation(const DynamicLinkJobAction &job,
   Arguments.push_back("-no_objc_category_merging");
 
   // These custom arguments should be right before the object file at the end.
-  context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
+  ToolChain::addArgsFromGroupExcept(context.Args, Arguments,
+                                    options::OPT_linker_option_Group,
+                                    options::OPT_l);
+  ToolChain::addLinkedLibArgs(context.Args, Arguments);
   context.Args.AddAllArgValues(Arguments, options::OPT_Xlinker);
 
   // This should be the last option, for convenience in checking output.

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -796,9 +796,8 @@ toolchains::Darwin::constructInvocation(const DynamicLinkJobAction &job,
   Arguments.push_back("-no_objc_category_merging");
 
   // These custom arguments should be right before the object file at the end.
-  ToolChain::addArgsFromGroupExcept(context.Args, Arguments,
-                                    options::OPT_linker_option_Group,
-                                    options::OPT_l);
+  context.Args.AddAllArgsExcept(Arguments, {options::OPT_linker_option_Group},
+                                {options::OPT_l});
   ToolChain::addLinkedLibArgs(context.Args, Arguments);
   context.Args.AddAllArgValues(Arguments, options::OPT_Xlinker);
 

--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -287,28 +287,12 @@ mergeBatchInputs(ArrayRef<const Job *> jobs,
   return false;
 }
 
-/// Remove space for -l arg values from \c Args and add to \c FrontendArgs
 void ToolChain::addLinkedLibArgs(const llvm::opt::ArgList &Args,
                                  llvm::opt::ArgStringList &FrontendArgs) {
   Args.getLastArg(options::OPT_l);
   for (auto Arg : Args.getAllArgValues(options::OPT_l)) {
     const std::string lArg("-l" + Arg);
     FrontendArgs.push_back(Args.MakeArgString(Twine(lArg)));
-  }
-}
-
-/// Add all values of a \c groupID from \c Args to \c FrontendArgs .
-/// except for \c exceptID .
-void ToolChain::addArgsFromGroupExcept(const llvm::opt::ArgList &Args,
-                                       llvm::opt::ArgStringList &FrontendArgs,
-                                       llvm::opt::OptSpecifier groupID,
-                                       llvm::opt::OptSpecifier exceptID) {
-  for (auto *Arg : Args) {
-    if (Arg->getOption().matches(groupID) &&
-        !Arg->getOption().matches(exceptID)) {
-      Arg->claim();
-      Arg->render(Args, FrontendArgs);
-    }
   }
 }
 

--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -287,6 +287,31 @@ mergeBatchInputs(ArrayRef<const Job *> jobs,
   return false;
 }
 
+/// Remove space for -l arg values from \c Args and add to \c FrontendArgs
+void ToolChain::addLinkedLibArgs(const llvm::opt::ArgList &Args,
+                                 llvm::opt::ArgStringList &FrontendArgs) {
+  Args.getLastArg(options::OPT_l);
+  for (auto Arg : Args.getAllArgValues(options::OPT_l)) {
+    const std::string lArg("-l" + Arg);
+    FrontendArgs.push_back(Args.MakeArgString(Twine(lArg)));
+  }
+}
+
+/// Add all values of a \c groupID from \c Args to \c FrontendArgs .
+/// except for \c exceptID .
+void ToolChain::addArgsFromGroupExcept(const llvm::opt::ArgList &Args,
+                                       llvm::opt::ArgStringList &FrontendArgs,
+                                       llvm::opt::OptSpecifier groupID,
+                                       llvm::opt::OptSpecifier exceptID) {
+  for (auto *Arg : Args) {
+    if (Arg->getOption().matches(groupID) &&
+        !Arg->getOption().matches(exceptID)) {
+      Arg->claim();
+      Arg->render(Args, FrontendArgs);
+    }
+  }
+}
+
 /// Construct a \c BatchJob by merging the constituent \p jobs' CommandOutput,
 /// input \c Job and \c Action members. Call through to \c constructInvocation
 /// on \p BatchJob, to build the \c InvocationInfo.

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -142,6 +142,14 @@ static void addLTOArgs(const OutputInfo &OI, ArgStringList &arguments) {
   }
 }
 
+static void addLinkedLibArgs(const ArgList &Args, ArgStringList &FrontendArgs) {
+  for(auto Arg:Args.getAllArgValues(options::OPT_l))
+  {
+    std::string* lArg = new std::string("-l" + Arg);
+    FrontendArgs.push_back(lArg->c_str());
+  }
+}
+
 void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
                                       const CommandOutput &output,
                                       const ArgList &inputArgs,
@@ -842,7 +850,8 @@ ToolChain::constructInvocation(const InterpretJobAction &job,
   Arguments.push_back("-module-name");
   Arguments.push_back(context.Args.MakeArgString(context.OI.ModuleName));
 
-  context.Args.AddAllArgs(Arguments, options::OPT_l, options::OPT_framework);
+  context.Args.AddAllArgs(Arguments, options::OPT_framework);
+  addLinkedLibArgs(context.Args, Arguments);
 
   // The immediate arguments must be last.
   context.Args.AddLastArg(Arguments, options::OPT__DASH_DASH);
@@ -1190,8 +1199,8 @@ ToolChain::constructInvocation(const REPLJobAction &job,
   addRuntimeLibraryFlags(context.OI, FrontendArgs);
 
   context.Args.AddLastArg(FrontendArgs, options::OPT_import_objc_header);
-  context.Args.AddAllArgs(FrontendArgs, options::OPT_l, options::OPT_framework,
-                          options::OPT_L);
+  context.Args.AddAllArgs(FrontendArgs, options::OPT_framework, options::OPT_L);
+  addLinkedLibArgs(context.Args, FrontendArgs);
 
   if (!useLLDB) {
     FrontendArgs.insert(FrontendArgs.begin(), {"-frontend", "-repl"});

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -143,10 +143,10 @@ static void addLTOArgs(const OutputInfo &OI, ArgStringList &arguments) {
 }
 
 static void addLinkedLibArgs(const ArgList &Args, ArgStringList &FrontendArgs) {
-  for(auto Arg:Args.getAllArgValues(options::OPT_l))
-  {
-    std::string* lArg = new std::string("-l" + Arg);
-    FrontendArgs.push_back(lArg->c_str());
+  Args.getLastArg(options::OPT_l);
+  for (auto Arg : Args.getAllArgValues(options::OPT_l)) {
+    const std::string lArg("-l" + Arg);
+    FrontendArgs.push_back(Args.MakeArgString(Twine(lArg)));
   }
 }
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -142,13 +142,6 @@ static void addLTOArgs(const OutputInfo &OI, ArgStringList &arguments) {
   }
 }
 
-static void addLinkedLibArgs(const ArgList &Args, ArgStringList &FrontendArgs) {
-  Args.getLastArg(options::OPT_l);
-  for (auto Arg : Args.getAllArgValues(options::OPT_l)) {
-    const std::string lArg("-l" + Arg);
-    FrontendArgs.push_back(Args.MakeArgString(Twine(lArg)));
-  }
-}
 
 void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
                                       const CommandOutput &output,
@@ -851,7 +844,7 @@ ToolChain::constructInvocation(const InterpretJobAction &job,
   Arguments.push_back(context.Args.MakeArgString(context.OI.ModuleName));
 
   context.Args.AddAllArgs(Arguments, options::OPT_framework);
-  addLinkedLibArgs(context.Args, Arguments);
+  ToolChain::addLinkedLibArgs(context.Args, Arguments);
 
   // The immediate arguments must be last.
   context.Args.AddLastArg(Arguments, options::OPT__DASH_DASH);
@@ -1200,7 +1193,7 @@ ToolChain::constructInvocation(const REPLJobAction &job,
 
   context.Args.AddLastArg(FrontendArgs, options::OPT_import_objc_header);
   context.Args.AddAllArgs(FrontendArgs, options::OPT_framework, options::OPT_L);
-  addLinkedLibArgs(context.Args, FrontendArgs);
+  ToolChain::addLinkedLibArgs(context.Args, FrontendArgs);
 
   if (!useLLDB) {
     FrontendArgs.insert(FrontendArgs.begin(), {"-frontend", "-repl"});

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -358,7 +358,10 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
   }
 
   // These custom arguments should be right before the object file at the end.
-  context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
+  ToolChain::addArgsFromGroupExcept(context.Args, Arguments,
+                                    options::OPT_linker_option_Group,
+                                    options::OPT_l);
+  ToolChain::addLinkedLibArgs(context.Args, Arguments);
   context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);
   context.Args.AddAllArgValues(Arguments, options::OPT_Xclang_linker);
 

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -358,9 +358,8 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
   }
 
   // These custom arguments should be right before the object file at the end.
-  ToolChain::addArgsFromGroupExcept(context.Args, Arguments,
-                                    options::OPT_linker_option_Group,
-                                    options::OPT_l);
+  context.Args.AddAllArgsExcept(Arguments, {options::OPT_linker_option_Group},
+                                {options::OPT_l});
   ToolChain::addLinkedLibArgs(context.Args, Arguments);
   context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);
   context.Args.AddAllArgValues(Arguments, options::OPT_Xclang_linker);

--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -179,9 +179,8 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
   }
 
   context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);
-  ToolChain::addArgsFromGroupExcept(context.Args, Arguments,
-                                    options::OPT_linker_option_Group,
-                                    options::OPT_l);
+  context.Args.AddAllArgsExcept(Arguments, {options::OPT_linker_option_Group},
+                                {options::OPT_l});
   ToolChain::addLinkedLibArgs(context.Args, Arguments);
   context.Args.AddAllArgValues(Arguments, options::OPT_Xclang_linker);
 

--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -179,7 +179,10 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
   }
 
   context.Args.AddAllArgs(Arguments, options::OPT_Xlinker);
-  context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);
+  ToolChain::addArgsFromGroupExcept(context.Args, Arguments,
+                                    options::OPT_linker_option_Group,
+                                    options::OPT_l);
+  ToolChain::addLinkedLibArgs(context.Args, Arguments);
   context.Args.AddAllArgValues(Arguments, options::OPT_Xclang_linker);
 
   // Run clang in verbose mode if "-v" is set

--- a/test/Driver/linker-library-with-space.swift
+++ b/test/Driver/linker-library-with-space.swift
@@ -15,4 +15,4 @@
 // LINUX-lib-flag-space-DAG: -L baz
 // LINUX-lib-flag-space-DAG: -lboo
 // LINUX-lib-flag-space-DAG: -Xlinker -undefined
-// LINUX-lib-flag-space: -o linker
+// LINUX-lib-flag-space: -o main

--- a/test/Driver/linker-library-with-space.swift
+++ b/test/Driver/linker-library-with-space.swift
@@ -1,0 +1,18 @@
+// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-unknown-linux-gnu -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.linux.txt
+// RUN: %FileCheck -check-prefix LINUX-lib-flag-space %s < %t.linux.txt
+
+// LINUX-lib-flag-space: swift
+// LINUX-lib-flag-space: -o [[OBJECTFILE:.*]]
+
+// LINUX-lib-flag-space: clang{{(\.exe)?"? }}
+// LINUX-lib-flag-space-DAG: -pie
+// LINUX-lib-flag-space-DAG: [[OBJECTFILE]]
+// LINUX-lib-flag-space-DAG: -lswiftCore
+// LINUX-lib-flag-space-DAG: -L [[STDLIB_PATH:[^ ]+(/|\\\\)lib(/|\\\\)swift(/|\\\\)]]
+// LINUX-lib-flag-space-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH]]
+// LINUX-lib-flag-space-DAG: -F foo -iframework car -F cdr
+// LINUX-lib-flag-space-DAG: -framework bar
+// LINUX-lib-flag-space-DAG: -L baz
+// LINUX-lib-flag-space-DAG: -lboo
+// LINUX-lib-flag-space-DAG: -Xlinker -undefined
+// LINUX-lib-flag-space: -o linker

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -1,6 +1,8 @@
 // Must be able to run xcrun-return-self.sh
 // REQUIRES: shell
 // REQUIRES: rdar65281056
+// FIXME: When this is turned on, please move the test from linker-library-with-space.swift
+// to this file and remove that file.
 // RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-apple-macosx10.9 %s 2>&1 > %t.simple.txt
 // RUN: %FileCheck %s < %t.simple.txt
 // RUN: %FileCheck -check-prefix SIMPLE %s < %t.simple.txt
@@ -18,9 +20,6 @@
 
 // RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-unknown-linux-gnu -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.linux.txt
 // RUN: %FileCheck -check-prefix LINUX-x86_64 %s < %t.linux.txt
-
-// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-unknown-linux-gnu -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -l boo -Xlinker -undefined %s 2>&1 > %t.linux.txt
-// RUN: %FileCheck -check-prefix LINUX-lib-flag-space %s < %t.linux.txt
 
 // RUN: %swiftc_driver -sdk "" -driver-print-jobs -target armv6-unknown-linux-gnueabihf -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.linux.txt
 // RUN: %FileCheck -check-prefix LINUX-armv6 %s < %t.linux.txt
@@ -219,22 +218,6 @@
 // LINUX-x86_64-DAG: -lboo
 // LINUX-x86_64-DAG: -Xlinker -undefined
 // LINUX-x86_64: -o linker
-
-// LINUX-lib-flag-space: swift
-// LINUX-lib-flag-space: -o [[OBJECTFILE:.*]]
-
-// LINUX-lib-flag-space: clang{{(\.exe)?"? }}
-// LINUX-lib-flag-space-DAG: -pie
-// LINUX-lib-flag-space-DAG: [[OBJECTFILE]]
-// LINUX-lib-flag-space-DAG: -lswiftCore
-// LINUX-lib-flag-space-DAG: -L [[STDLIB_PATH:[^ ]+(/|\\\\)lib(/|\\\\)swift(/|\\\\)]]
-// LINUX-lib-flag-space-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH]]
-// LINUX-lib-flag-space-DAG: -F foo -iframework car -F cdr
-// LINUX-lib-flag-space-DAG: -framework bar
-// LINUX-lib-flag-space-DAG: -L baz
-// LINUX-lib-flag-space-DAG: -lboo
-// LINUX-lib-flag-space-DAG: -Xlinker -undefined
-// LINUX-lib-flag-space: -o linker
 
 // LINUX-armv6: swift
 // LINUX-armv6: -o [[OBJECTFILE:.*]]

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -19,6 +19,9 @@
 // RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-unknown-linux-gnu -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.linux.txt
 // RUN: %FileCheck -check-prefix LINUX-x86_64 %s < %t.linux.txt
 
+// RUN: %swiftc_driver -sdk "" -driver-print-jobs -target x86_64-unknown-linux-gnu -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -l boo -Xlinker -undefined %s 2>&1 > %t.linux.txt
+// RUN: %FileCheck -check-prefix LINUX-lib-flag-space %s < %t.linux.txt
+
 // RUN: %swiftc_driver -sdk "" -driver-print-jobs -target armv6-unknown-linux-gnueabihf -Ffoo -Fsystem car -F cdr -framework bar -Lbaz -lboo -Xlinker -undefined %s 2>&1 > %t.linux.txt
 // RUN: %FileCheck -check-prefix LINUX-armv6 %s < %t.linux.txt
 
@@ -216,6 +219,22 @@
 // LINUX-x86_64-DAG: -lboo
 // LINUX-x86_64-DAG: -Xlinker -undefined
 // LINUX-x86_64: -o linker
+
+// LINUX-lib-flag-space: swift
+// LINUX-lib-flag-space: -o [[OBJECTFILE:.*]]
+
+// LINUX-lib-flag-space: clang{{(\.exe)?"? }}
+// LINUX-lib-flag-space-DAG: -pie
+// LINUX-lib-flag-space-DAG: [[OBJECTFILE]]
+// LINUX-lib-flag-space-DAG: -lswiftCore
+// LINUX-lib-flag-space-DAG: -L [[STDLIB_PATH:[^ ]+(/|\\\\)lib(/|\\\\)swift(/|\\\\)]]
+// LINUX-lib-flag-space-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH]]
+// LINUX-lib-flag-space-DAG: -F foo -iframework car -F cdr
+// LINUX-lib-flag-space-DAG: -framework bar
+// LINUX-lib-flag-space-DAG: -L baz
+// LINUX-lib-flag-space-DAG: -lboo
+// LINUX-lib-flag-space-DAG: -Xlinker -undefined
+// LINUX-lib-flag-space: -o linker
 
 // LINUX-armv6: swift
 // LINUX-armv6: -o [[OBJECTFILE:.*]]

--- a/test/Driver/options-repl.swift
+++ b/test/Driver/options-repl.swift
@@ -16,7 +16,7 @@
 
 
 // RUN: %swift_driver -sdk "" -lldb-repl -### | %FileCheck -check-prefix=LLDB %s
-// RUN: %swift_driver -sdk "" -lldb-repl -D A -DB -D C -DD -L /path/to/libraries -L /path/to/more/libraries -F /path/to/frameworks -lsomelib -framework SomeFramework -sdk / -I "this folder" -module-name Test -target %target-triple -### | %FileCheck -check-prefix=LLDB-OPTS %s
+// RUN: %swift_driver -sdk "" -lldb-repl -D A -DB -D C -DD -L /path/to/libraries -L /path/to/more/libraries -F /path/to/frameworks -lsomelib -l otherlib -framework SomeFramework -sdk / -I "this folder" -module-name Test -target %target-triple -### | %FileCheck -check-prefix=LLDB-OPTS %s
 
 // LLDB: lldb{{(\.exe)?"?}} {{"?}}--repl=
 // LLDB-NOT: -module-name
@@ -30,6 +30,7 @@
 // LLDB-OPTS-DAG: -L /path/to/more/libraries
 // LLDB-OPTS-DAG: -F /path/to/frameworks
 // LLDB-OPTS-DAG: -lsomelib
+// LLDB-OPTS-DAG: -lotherlib
 // LLDB-OPTS-DAG: -framework SomeFramework
 // LLDB-OPTS-DAG: -I \"this folder\"
 // LLDB-OPTS: "


### PR DESCRIPTION
<!-- What's in this pull request? -->
Adding space to -l flag causes swiftc  to produce abstract error. This PR aims at improving usability to -l flag by allowing it to take a space.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-14122](https://bugs.swift.org/browse/SR-14122).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
