### PR TITLE
[Tests] Fix RemoteMirror interop test to require executable_test.

### DIFF
--- a/test/RemoteMirror/interop.swift
+++ b/test/RemoteMirror/interop.swift
@@ -1,4 +1,5 @@
 // REQUIRES: OS=macosx
+// REQUIRES: executable_test
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %S/Inputs/interop.swift -emit-library -module-name InteropTest -o %t/%target-library-name(InteropTest)


### PR DESCRIPTION
Missing REQUIRES: executable_test in the test script.

rdar://81274645