### PR TITLE
RequirementMachine: Fix another bug in getTypeFromSubstitutionSchema()

### DIFF
--- a/test/Generics/concrete_type_property_of_suffix.swift
+++ b/test/Generics/concrete_type_property_of_suffix.swift
@@ -14,3 +14,15 @@ func foo<X : P, Y : P>(_: X, _: Y) {
   // Y.T is Optional<Y.U>.
   sameType(Y.T.self, Y.U?.self)
 }
+
+protocol Q {
+  associatedtype T where T == Self?
+}
+
+func foo<X : Q, Y : Q>(_: X, _: Y) {
+  // X.T is Optional<X>.
+  sameType(X.T.self, X?.self)
+
+  // Y.T is Optional<Y>.
+  sameType(Y.T.self, Y?.self)
+}


### PR DESCRIPTION
    protocol Q {
      associatedtype T where T == Self?
    }

    func foo<X, Y : Q>(_: X, _: Y) {}

This generates the rewrite system

    [Q:T].[concrete: Optional<τ_0_0> with <[Q]>]
    τ_0_1.[Q] => τ_0_1

With this property map:

    [Q:T] => { [concrete: Optional<τ_0_0> with <[Q]>] }
    τ_0_1 => { [Q] }

Suppose we're resolving the concrete type `τ_0_1.[Q:T]`. The property map
entry is keyed by `[Q:T]`, so the prefix `τ_0_1` must be prepended to the
concrete substitutions of `[concrete: Optional<τ_0_0> with <[Q]>]`.

However, `[Q]` is just the protocol Self type, and `τ_0_0.[Q]` is not a
valid type-like term. We could simplify the term before building the
Swift type which would apply the second rewrite rule, but it's easier
to just drop the protocol symbol in this case.