### PR TITLE
Clarify the documentation of SignedNumeric.

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -258,7 +258,7 @@ public protocol Numeric: AdditiveArithmetic, ExpressibleByIntegerLiteral {
   static func *=(lhs: inout Self, rhs: Self)
 }
 
-/// A type that can represent both positive and negative values.
+/// A numeric type with a negation operation.
 ///
 /// The `SignedNumeric` protocol extends the operations defined by the
 /// `Numeric` protocol to include a value's additive inverse.


### PR DESCRIPTION
Previously we said that a type conforming to SignedNumeric allows positive and negative values, but that's nonsense. A type conforms to signed numeric if it has a negate() operation; it doesn't even have to have a notion of positive or negative values (for examples, see complex numbers, quaternions, integers mod n, etc).

Resolves SR-12078, rdar://58997153
