### PR TITLE
[Dependency Scanning] Split the ModuleDependencyCache into two: current scan cache & global.

### DIFF
--- a/include/swift/DependencyScan/DependencyScanningTool.h
+++ b/include/swift/DependencyScan/DependencyScanningTool.h
@@ -59,7 +59,7 @@ public:
 
   /// Writes the current `SharedCache` instance to a specified FileSystem path.
   void serializeCache(llvm::StringRef path);
-  /// Loads an instance of a `ModuleDependenciesCache` to serve as the `SharedCache`
+  /// Loads an instance of a `GlobalModuleDependenciesCache` to serve as the `SharedCache`
   /// from a specified FileSystem path.
   bool loadCache(llvm::StringRef path);
   /// Discard the tool's current `SharedCache` and start anew.
@@ -73,7 +73,7 @@ private:
 
   /// Shared cache of module dependencies, re-used by individual full-scan queries
   /// during the lifetime of this Tool.
-  std::unique_ptr<ModuleDependenciesCache> SharedCache;
+  std::unique_ptr<GlobalModuleDependenciesCache> SharedCache;
 
   /// Shared cache of compiler instances created during batch scanning, corresponding to
   /// command-line options specified in the batch scan input entry.

--- a/include/swift/DependencyScan/ScanDependencies.h
+++ b/include/swift/DependencyScan/ScanDependencies.h
@@ -27,12 +27,18 @@ namespace swift {
 class CompilerInvocation;
 class CompilerInstance;
 class ModuleDependenciesCache;
+class GlobalModuleDependenciesCache;
 
 namespace dependencies {
 
+//using CompilerArgInstanceCacheMap =
+//    llvm::StringMap<std::pair<std::unique_ptr<CompilerInstance>,
+//                              std::unique_ptr<ModuleDependenciesCache>>>;
+
 using CompilerArgInstanceCacheMap =
-    llvm::StringMap<std::pair<std::unique_ptr<CompilerInstance>,
-                              std::unique_ptr<ModuleDependenciesCache>>>;
+    llvm::StringMap<std::tuple<std::unique_ptr<CompilerInstance>,
+                               std::unique_ptr<GlobalModuleDependenciesCache>,
+                               std::unique_ptr<ModuleDependenciesCache>>>;
 
 struct BatchScanInput {
   llvm::StringRef moduleName;

--- a/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
+++ b/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
@@ -23,7 +23,7 @@ class MemoryBuffer;
 namespace swift {
 
 class DiagnosticEngine;
-class ModuleDependenciesCache;
+class GlobalModuleDependenciesCache;
 
 namespace dependencies {
 namespace module_dependency_cache_serialization {
@@ -160,23 +160,23 @@ using ClangModuleDetailsLayout =
 /// Tries to read the dependency graph from the given buffer.
 /// Returns \c true if there was an error.
 bool readInterModuleDependenciesCache(llvm::MemoryBuffer &buffer,
-                                      ModuleDependenciesCache &cache);
+                                      GlobalModuleDependenciesCache &cache);
 
 /// Tries to read the dependency graph from the given path name.
 /// Returns true if there was an error.
 bool readInterModuleDependenciesCache(llvm::StringRef path,
-                                      ModuleDependenciesCache &cache);
+                                      GlobalModuleDependenciesCache &cache);
 
 /// Tries to write the dependency graph to the given path name.
 /// Returns true if there was an error.
 bool writeInterModuleDependenciesCache(DiagnosticEngine &diags,
                                        llvm::StringRef path,
-                                       const ModuleDependenciesCache &cache);
+                                       const GlobalModuleDependenciesCache &cache);
 
 /// Tries to write out the given dependency cache with the given
 /// bitstream writer.
 void writeInterModuleDependenciesCache(llvm::BitstreamWriter &Out,
-                                       const ModuleDependenciesCache &cache);
+                                       const GlobalModuleDependenciesCache &cache);
 
 } // end namespace module_dependency_cache_serialization
 } // end namespace dependencies

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -310,10 +310,6 @@ public:
   /// Emit remarks indicating use of the serialized module dependency scanning cache
   bool EmitDependencyScannerCacheRemarks = false;
 
-  /// After performing a dependency scanning action, serialize and deserialize the
-  /// dependency cache before producing the result.
-  bool TestDependencyScannerCacheSerialization = false;
-
   /// When performing an incremental build, ensure that cross-module incremental
   /// build metadata is available in any swift modules emitted by this frontend
   /// job.

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -178,8 +178,6 @@ static void validateDependencyScanningArgs(DiagnosticEngine &diags,
       args.getLastArg(options::OPT_reuse_dependency_scan_cache);
   const Arg *CacheSerializationPath =
       args.getLastArg(options::OPT_dependency_scan_cache_path);
-  const Arg *TestSerialization = args.getLastArg(
-      options::OPT_debug_test_dependency_scan_cache_serialization);
 
   if (ExternalDependencyMap && !ScanDependencies) {
     diags.diagnose(SourceLoc(), diag::error_requirement_not_met,
@@ -201,11 +199,6 @@ static void validateDependencyScanningArgs(DiagnosticEngine &diags,
   if (ReuseCache && !ScanDependencies) {
     diags.diagnose(SourceLoc(), diag::error_requirement_not_met,
                    "-load-dependency-scan-cache", "-scan-dependencies");
-  }
-  if (TestSerialization && !ScanDependencies) {
-    diags.diagnose(SourceLoc(), diag::error_requirement_not_met,
-                   "-test-dependency-scan-cache-serialization",
-                   "-scan-dependencies");
   }
   if (SerializeCache && !CacheSerializationPath) {
     diags.diagnose(SourceLoc(), diag::error_requirement_not_met,

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -120,7 +120,6 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.SerializeDependencyScannerCache |= Args.hasArg(OPT_serialize_dependency_scan_cache);
   Opts.ReuseDependencyScannerCache |= Args.hasArg(OPT_reuse_dependency_scan_cache);
   Opts.EmitDependencyScannerCacheRemarks |= Args.hasArg(OPT_dependency_scan_cache_remarks);
-  Opts.TestDependencyScannerCacheSerialization |= Args.hasArg(OPT_debug_test_dependency_scan_cache_serialization);
   if (const Arg *A = Args.getLastArg(OPT_dependency_scan_cache_path)) {
     Opts.SerializedDependencyScannerCachePath = A->getValue();
   }

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1069,7 +1069,6 @@ withSemanticAnalysis(CompilerInstance &Instance, FrontendObserver *observer,
 static bool performScanDependencies(CompilerInstance &Instance) {
   auto batchScanInput =
       Instance.getASTContext().SearchPathOpts.BatchScanInputFilePath;
-  ModuleDependenciesCache SingleUseCache;
   if (batchScanInput.empty()) {
     if (Instance.getInvocation().getFrontendOptions().ImportPrescan)
       return dependencies::prescanDependencies(Instance);

--- a/test/ScanDependencies/local_cache_consistency.swift
+++ b/test/ScanDependencies/local_cache_consistency.swift
@@ -1,0 +1,26 @@
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+
+// Run the scanner once, ensuring CoreFoundation dependencies are as expected
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -swift-version 4
+// RUN: %FileCheck %s < %t/deps.json
+
+import CoreFoundation
+
+// CHECK: "clang": "CoreFoundation"
+
+// CHECK:       "directDependencies": [
+// CHECK:         {
+// CHECK:           "clang": "Darwin"
+// CHECK:         },
+// CHECK:         {
+// CHECK:           "clang": "Dispatch"
+// CHECK:         }
+// CHECK:       ],
+
+// Make sure the transitive dependency on os_object is present
+// CHECK:       "clang": "os_object"


### PR DESCRIPTION
This change causes the cache to be layered with a local "cache" that wraps the global cache, which will serve as the source of truth. The local cache persists only for the duration of a given scanning action, and has a store of references to dependencies resolved as a part of the current scanning action only, while the global cache is the one that persists across scanning actions (e.g. in `DependencyScanningTool`) and stores actual module dependency info values.

Only the local cache can answer dependency lookup queries, checking current scanning action results first, before falling back to querying the global cache, with queries disambiguated by the current scannning action's search paths, ensuring we never resolve a dependency lookup query with a module info that could not be found in the current action's search paths.

This change is required because search-path disambiguation can lead to false-negatives: for example, the Clang dependency scanner may find modules relative to the compiler's path that are not on the compiler's direct search paths. While such false-negative query responses should be functionally safe, we rely on the current scanning action's results being always-present-in-the-cache for the scanner's functionality. This layering ensures that the cache use-sites remain unchanged and that we get both: preserved global state which can be queried disambiguated with the search path details, and an always-consistent local (current action) cache state.