### PR TITLE
[Property Wrappers] Fix a bug where wrapped arguments were not properly coerced to the wrapper generator input type.

### DIFF
--- a/include/swift/AST/Initializer.h
+++ b/include/swift/AST/Initializer.h
@@ -209,15 +209,16 @@ public:
   };
 
 private:
-  ParamDecl *param;
+  VarDecl *wrappedVar;
   Kind kind;
 
 public:
-  explicit PropertyWrapperInitializer(DeclContext *parent, ParamDecl *param, Kind kind)
+  explicit PropertyWrapperInitializer(DeclContext *parent, VarDecl *wrappedVar,
+                                      Kind kind)
       : Initializer(InitializerKind::PropertyWrapper, parent),
-        param(param), kind(kind) {}
+        wrappedVar(wrappedVar), kind(kind) {}
 
-  ParamDecl *getParam() const { return param; }
+  VarDecl *getWrappedVar() const { return wrappedVar; }
 
   Kind getKind() const { return kind; }
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1706,6 +1706,10 @@ public:
   static SolutionApplicationTarget forUninitializedWrappedVar(
       VarDecl *wrappedVar);
 
+  /// Form a target for a synthesized property wrapper initializer.
+  static SolutionApplicationTarget forPropertyWrapperInitializer(
+      VarDecl *wrappedVar, DeclContext *dc, Expr *initializer);
+
   Expr *getAsExpr() const {
     switch (kind) {
     case Kind::expression:
@@ -1813,7 +1817,7 @@ public:
   bool isOptionalSomePatternInit() const {
     return kind == Kind::expression &&
         expression.contextualPurpose == CTP_Initialization &&
-        isa<OptionalSomePattern>(expression.pattern) &&
+        dyn_cast_or_null<OptionalSomePattern>(expression.pattern) &&
         !expression.pattern->isImplicit();
   }
 
@@ -1837,7 +1841,9 @@ public:
 
     // Don't create property wrapper generator functions for static variables and
     // local variables with initializers.
-    if (wrappedVar->isStatic() || wrappedVar->getDeclContext()->isLocalContext())
+    bool hasInit = expression.propertyWrapper.hasInitialWrappedValue;
+    if (wrappedVar->isStatic() ||
+        (hasInit && wrappedVar->getDeclContext()->isLocalContext()))
       return false;
 
     return expression.propertyWrapper.innermostWrappedValueInit == apply;

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2138,10 +2138,10 @@ void ASTMangler::appendContext(const DeclContext *ctx, StringRef useModuleName) 
       auto wrapperInit = cast<PropertyWrapperInitializer>(ctx);
       switch (wrapperInit->getKind()) {
       case PropertyWrapperInitializer::Kind::WrappedValue:
-        appendBackingInitializerEntity(wrapperInit->getParam());
+        appendBackingInitializerEntity(wrapperInit->getWrappedVar());
         break;
       case PropertyWrapperInitializer::Kind::ProjectedValue:
-        appendInitFromProjectedValueEntity(wrapperInit->getParam());
+        appendInitFromProjectedValueEntity(wrapperInit->getWrappedVar());
         break;
       }
       return;

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -679,7 +679,7 @@ unsigned DeclContext::printContext(raw_ostream &OS, const unsigned indent,
     }
     case InitializerKind::PropertyWrapper: {
       auto init = cast<PropertyWrapperInitializer>(this);
-      OS << "PropertyWrapper 0x" << (void*)init->getParam() << ", kind=";
+      OS << "PropertyWrapper 0x" << (void*)init->getWrappedVar() << ", kind=";
       switch (init->getKind()) {
       case PropertyWrapperInitializer::Kind::WrappedValue:
         OS << "wrappedValue";

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -1296,8 +1296,8 @@ class ExprContextAnalyzer {
       auto AFD = dyn_cast<AbstractFunctionDecl>(initDC->getParent());
       if (!AFD)
         return;
-      auto *param = initDC->getParam();
-      recordPossibleType(AFD->mapTypeIntoContext(param->getInterfaceType()));
+      auto *var = initDC->getWrappedVar();
+      recordPossibleType(AFD->mapTypeIntoContext(var->getInterfaceType()));
       break;
     }
     }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8420,13 +8420,18 @@ static Optional<SolutionApplicationTarget> applySolutionToInitialization(
   // been subsumed by the backing property.
   if (wrappedVar) {
     ASTContext &ctx = cs.getASTContext();
-    wrappedVar->getParentPatternBinding()->setInitializerSubsumed(0);
     ctx.setSideCachedPropertyWrapperBackingPropertyType(
         wrappedVar, initType->mapTypeOutOfContext());
 
     // Record the semantic initializer on the outermost property wrapper.
     wrappedVar->getAttachedPropertyWrappers().front()
         ->setSemanticInit(initializer);
+
+    // If this is a wrapped parameter, we're done.
+    if (isa<ParamDecl>(wrappedVar))
+      return resultTarget;
+
+    wrappedVar->getParentPatternBinding()->setInitializerSubsumed(0);
   }
 
   // Coerce the pattern to the type of the initializer.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6017,16 +6017,44 @@ Expr *ExprRewriter::coerceCallArguments(
     };
 
     if (paramInfo.hasExternalPropertyWrapper(paramIdx)) {
-      auto *param = getParameterAt(callee.getDecl(), paramIdx);
+      auto *paramDecl = getParameterAt(callee.getDecl(), paramIdx);
       auto appliedWrapper = appliedPropertyWrappers[appliedWrapperIndex++];
       auto wrapperType = solution.simplifyType(appliedWrapper.wrapperType);
       auto initKind = appliedWrapper.initKind;
 
-      using ValueKind = AppliedPropertyWrapperExpr::ValueKind;
-      ValueKind valueKind = (initKind == PropertyWrapperInitKind::ProjectedValue ?
-                             ValueKind::ProjectedValue : ValueKind::WrappedValue);
+      AppliedPropertyWrapperExpr::ValueKind valueKind;
+      PropertyWrapperValuePlaceholderExpr *generatorArg;
+      auto initInfo = paramDecl->getPropertyWrapperInitializerInfo();
+      if (initKind == PropertyWrapperInitKind::ProjectedValue) {
+        valueKind = AppliedPropertyWrapperExpr::ValueKind::ProjectedValue;
+        generatorArg = initInfo.getProjectedValuePlaceholder();
+      } else {
+        valueKind = AppliedPropertyWrapperExpr::ValueKind::WrappedValue;
+        generatorArg = initInfo.getWrappedValuePlaceholder();
+      }
 
-      arg = AppliedPropertyWrapperExpr::create(ctx, callee, param, arg->getStartLoc(),
+      // Coerce the property wrapper argument type to the input type of
+      // the property wrapper generator function. The wrapper generator
+      // has the same generic signature as the enclosing function, so we
+      // can use substitutions from the callee.
+      Type generatorInputType =
+          generatorArg->getType().subst(callee.getSubstitutions());
+      auto argLoc = getArgLocator(argIdx, paramIdx, param.getParameterFlags());
+
+      if (generatorArg->isAutoClosure()) {
+        auto *closureType = generatorInputType->castTo<FunctionType>();
+        arg = coerceToType(
+            arg, closureType->getResult(),
+            argLoc.withPathElement(ConstraintLocator::AutoclosureResult));
+        arg = cs.buildAutoClosureExpr(arg, closureType, dc);
+      }
+
+      arg = coerceToType(arg, generatorInputType, argLoc);
+
+      // Wrap the argument in an applied property wrapper expr, which will
+      // later turn into a call to the property wrapper generator function.
+      arg = AppliedPropertyWrapperExpr::create(ctx, callee, paramDecl,
+                                               arg->getStartLoc(),
                                                wrapperType, arg, valueKind);
       cs.cacheExprTypes(arg);
     }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -113,6 +113,8 @@ static void forEachOuterDecl(DeclContext *DC, Fn fn) {
     case DeclContextKind::Initializer:
       if (auto *PBI = dyn_cast<PatternBindingInitializer>(DC))
         fn(PBI->getBinding());
+      else if (auto *I = dyn_cast<PropertyWrapperInitializer>(DC))
+        fn(I->getWrappedVar());
       break;
 
     case DeclContextKind::SubscriptDecl:

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2596,8 +2596,8 @@ void swift::checkEnumElementActorIsolation(
 }
 
 void swift::checkPropertyWrapperActorIsolation(
-   PatternBindingDecl *binding, Expr *expr) {
-  ActorIsolationChecker checker(binding->getDeclContext());
+    VarDecl *wrappedVar, Expr *expr) {
+  ActorIsolationChecker checker(wrappedVar->getDeclContext());
   expr->walk(checker);
 }
 

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -45,6 +45,7 @@ class ProtocolConformance;
 class TopLevelCodeDecl;
 class TypeBase;
 class ValueDecl;
+class VarDecl;
 
 /// Add notes suggesting the addition of 'async', as appropriate,
 /// to a diagnostic for a function that isn't an async context.
@@ -57,8 +58,7 @@ void checkActorConstructor(ClassDecl *decl, ConstructorDecl *ctor);
 void checkActorConstructorBody(ClassDecl *decl, ConstructorDecl *ctor, BraceStmt *body);
 void checkInitializerActorIsolation(Initializer *init, Expr *expr);
 void checkEnumElementActorIsolation(EnumElementDecl *element, Expr *expr);
-void checkPropertyWrapperActorIsolation(
-    PatternBindingDecl *binding, Expr *expr);
+void checkPropertyWrapperActorIsolation(VarDecl *wrappedVar, Expr *expr);
 
 /// Determine the isolation of a particular closure.
 ///

--- a/test/SILGen/property_wrapper_parameter.swift
+++ b/test/SILGen/property_wrapper_parameter.swift
@@ -52,6 +52,10 @@ func simpleWrapperParameterCaller(projection: Projection<Int>) {
 
   testSimpleWrapperParameter($value: projection)
   // CHECK: function_ref @$s26property_wrapper_parameter26testSimpleWrapperParameter5valueyAA0F0VySiG_tFACL_SivpfW : $@convention(thin) (Projection<Int>) -> Wrapper<Int>
+
+  var x: Int = 10
+  testSimpleWrapperParameter(value: x)
+  // CHECK: function_ref @$s26property_wrapper_parameter26testSimpleWrapperParameter5valueyAA0F0VySiG_tFACL_SivpfP : $@convention(thin) (Int) -> Wrapper<Int>
 }
 
 // CHECK-LABEL: sil [ossa] @$s26property_wrapper_parameter18testGenericWrapper5valueyAA0F0VyxG_tlF : $@convention(thin) <T> (@in_guaranteed Wrapper<T>) -> ()
@@ -71,6 +75,41 @@ func genericWrapperCaller(projection: Projection<Int>) {
 
   testGenericWrapper($value: projection)
   // CHECK: function_ref @$s26property_wrapper_parameter18testGenericWrapper5valueyAA0F0VyxG_tlFACL_xvpfW : $@convention(thin) <τ_0_0> (@in Projection<τ_0_0>) -> @out Wrapper<τ_0_0>
+
+  var x: Int = 10
+  testGenericWrapper(value: x)
+  // CHECK: function_ref @$s26property_wrapper_parameter18testGenericWrapper5valueyAA0F0VyxG_tlFACL_xvpfP : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out Wrapper<τ_0_0>
+}
+
+@propertyWrapper
+public struct AutoClosureWrapper<T> {
+  public var wrappedValue: T
+
+  // CHECK-LABEL: sil [ossa] @$s26property_wrapper_parameter18AutoClosureWrapperV12wrappedValueACyxGxyXK_tcfC : $@convention(method) <T> (@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <T>, @thin AutoClosureWrapper<T>.Type) -> @out AutoClosureWrapper<T>
+  public init(wrappedValue: @autoclosure () -> T) {
+    self.wrappedValue = wrappedValue()
+  }
+
+  public var projectedValue: Projection<T> {
+    Projection(wrappedValue: wrappedValue)
+  }
+
+  public init(projectedValue: Projection<T>) {
+    self.wrappedValue = projectedValue.wrappedValue
+  }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter22testAutoClosureWrapper5valueyAA0efG0VyxG_tlF : $@convention(thin) <T> (@in_guaranteed AutoClosureWrapper<T>) -> ()
+func testAutoClosureWrapper<T>(@AutoClosureWrapper value: T) {
+  // property wrapper backing initializer of value #1 in testAutoClosureWrapper<A>(value:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter22testAutoClosureWrapper5valueyAA0efG0VyxG_tlFACL_xvpfP : $@convention(thin) <T> (@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <T>) -> @out AutoClosureWrapper<T>
+  // CHECK: function_ref @$s26property_wrapper_parameter18AutoClosureWrapperV12wrappedValueACyxGxyXK_tcfC : $@convention(method) <τ_0_0> (@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_0>, @thin AutoClosureWrapper<τ_0_0>.Type) -> @out AutoClosureWrapper<τ_0_0>
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter24autoClosureWrapperCalleryyF : $@convention(thin) () -> ()
+func autoClosureWrapperCaller() {
+  testAutoClosureWrapper(value: 10)
+  // CHECK: function_ref @$s26property_wrapper_parameter22testAutoClosureWrapper5valueyAA0efG0VyxG_tlFACL_xvpfP : $@convention(thin) <τ_0_0> (@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_0>) -> @out AutoClosureWrapper<τ_0_0>
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter33testSimpleClosureWrapperParameteryyF : $@convention(thin) () -> ()


### PR DESCRIPTION
For wrapped parameters that are initialized at the call-site (i.e. property wrappers with `init(projectedValue:)`), the argument needs to be coerced to the wrapper generator input type in CSApply. Otherwise, this leads to a SILGen crash.

This change also fixes a bug where `@autoclosure` was not properly propagated from `init(wrappedValue:)` to a wrapped argument because the property wrapper initializer was built manually in `PropertyWrapperInitializerInfoRequest` instead of going through `SolutionApplicationTarget::maybeApplyPropertyWrapper()` which handles `@autoclosure` injection around the initial wrapped value for regular wrapped properties.

Resolves: rdar://80820408 / [SR-14927](https://bugs.swift.org/browse/SR-14927)