### PR TITLE
Emit `hop_to_executor` instructors for foreign `async` calls.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4414,7 +4414,7 @@ RValue SILGenFunction::emitApply(
   }
 
   ExecutorBreadcrumb breadcrumb;
-  
+
   // The presence of `implicitActorHopTarget` indicates that the callee is a
   // synchronous function isolated to an actor other than our own.
   // Such functions require the caller to hop to the callee's executor
@@ -4440,7 +4440,8 @@ RValue SILGenFunction::emitApply(
     }
 
     breadcrumb = emitHopToTargetExecutor(loc, executor);
-  } else if (ExpectedExecutor && substFnType->isAsync()) {
+  } else if (ExpectedExecutor &&
+             (substFnType->isAsync() || calleeTypeInfo.foreign.async)) {
     // Otherwise, if we're in an actor method ourselves, and we're calling into
     // any sort of async function, we'll want to make sure to hop back to our
     // own executor afterward, since the callee could have made arbitrary hops
@@ -4457,8 +4458,10 @@ RValue SILGenFunction::emitApply(
     rawDirectResult = rawDirectResults[0];
   }
 
-  // hop back to the current executor
-  breadcrumb.emit(*this, loc);
+  if (!calleeTypeInfo.foreign.async) {
+    // hop back to the current executor
+    breadcrumb.emit(*this, loc);
+  }
 
   // For objc async calls, lifetime extend the args until the result plan which
   // generates `await_async_continuation`.
@@ -4570,6 +4573,9 @@ RValue SILGenFunction::emitApply(
       B.emitFixLifetime(loc, value);
       B.emitDestroyOperation(loc, value);
     }
+
+    // hop back to the current executor
+    breadcrumb.emit(*this, loc);
   }
 
   return result;

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -161,3 +161,30 @@ func testGeneric2<T: AnyObject, U>(x: GenericObject<T>, y: U) async throws {
 // CHECK:   [[RESULT_1_BUF:%.*]] = tuple_element_addr [[RESULT_BUF]] {{.*}}, 1
 // CHECK:   store %2 to [trivial] [[RESULT_1_BUF]]
 
+// CHECK-LABEL: sil {{.*}}@${{.*}}22testSlowServerFromMain
+@MainActor
+func testSlowServerFromMain(slowServer: SlowServer) async throws {
+  // CHECK: hop_to_executor %6 : $MainActor
+  // CHECK: [[RESUME_BUF:%.*]] = alloc_stack $Int
+  // CHECK: [[STRINGINIT:%.*]] = function_ref @$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF :
+  // CHECK: [[ARG:%.*]] = apply [[STRINGINIT]]
+  // CHECK: [[METHOD:%.*]] = objc_method {{.*}} $@convention(objc_method) (NSString, @convention(block) (Int) -> (), SlowServer) -> ()
+  // CHECK: [[CONT:%.*]] = get_async_continuation_addr Int, [[RESUME_BUF]]
+  // CHECK: [[WRAPPED:%.*]] = struct $UnsafeContinuation<Int, Never> ([[CONT]] : $Builtin.RawUnsafeContinuation)
+  // CHECK: [[BLOCK_STORAGE:%.*]] = alloc_stack $@block_storage UnsafeContinuation<Int, Never>
+  // CHECK: [[CONT_SLOT:%.*]] = project_block_storage [[BLOCK_STORAGE]]
+  // CHECK: store [[WRAPPED]] to [trivial] [[CONT_SLOT]]
+  // CHECK: [[BLOCK_IMPL:%.*]] = function_ref @[[INT_COMPLETION_BLOCK:.*]] : $@convention(c) (@inout_aliasable @block_storage UnsafeContinuation<Int, Never>, Int) -> ()
+  // CHECK: [[BLOCK:%.*]] = init_block_storage_header [[BLOCK_STORAGE]] {{.*}}, invoke [[BLOCK_IMPL]]
+  // CHECK: apply [[METHOD]]([[ARG]], [[BLOCK]], %0)
+  // CHECK: [[COPY:%.*]] = copy_value [[ARG]]
+  // CHECK: destroy_value [[ARG]]
+  // CHECK: await_async_continuation [[CONT]] {{.*}}, resume [[RESUME:bb[0-9]+]]
+  // CHECK: [[RESUME]]:
+  // CHECK: [[RESULT:%.*]] = load [trivial] [[RESUME_BUF]]
+  // CHECK: fix_lifetime [[COPY]]
+  // CHECK: destroy_value [[COPY]]
+  // CHECK: hop_to_executor %6 : $MainActor
+  // CHECK: dealloc_stack [[RESUME_BUF]]
+  let _: Int = await slowServer.doSomethingSlow("mail")
+}


### PR DESCRIPTION
**Explanation**: Fix a miscompile where a call to an Objective-C completion-handler method as `async` would fail to emit an
appropriate `hop_to_executor` instruction to hop back to the current executor afterward, meaning that subsequent code would not execute on the correct actor. This could cause data races and crashes.
**Scope**: Affects new code using Swift's Concurrency model.
**Radar/SR Issue**:  rdar://81468980
**Risk**: Low.
**Reviewed By**: Joe Groff
**Testing**: PR testing and CI on main, including new tests.
**Original PR**: https://github.com/apple/swift/pull/38767
