### PR TITLE
[ConstraintSystem] Relax the left-over information check in `ComponentStep`

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2141,6 +2141,11 @@ private:
   /// explored.
   size_t MaxMemory = 0;
 
+  /// Flag to indicate to the solver that the system is in invalid
+  /// state and it shouldn't proceed but instead produce a fallback
+  /// diagnostic.
+  bool InvalidState = false;
+
   /// Cached member lookups.
   llvm::DenseMap<std::pair<Type, DeclNameRef>, Optional<LookupResult>>
     MemberLookups;
@@ -2639,6 +2644,11 @@ public:
 
     Phase = newPhase;
   }
+
+  /// Check whether constraint system is in valid state e.g.
+  /// has left-over active/inactive constraints which should
+  /// have been simplified.
+  bool inInvalidState() const { return InvalidState; }
 
   /// Cache the types of the given expression and all subexpressions.
   void cacheExprTypes(Expr *expr) {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -422,6 +422,11 @@ ConstraintSystem::SolverState::~SolverState() {
          "Expected constraint system to have this solver state!");
   CS.solverState = nullptr;
 
+  // If constraint system ended up being in an invalid state
+  // let's just drop the state without attempting to rollback.
+  if (CS.inInvalidState())
+    return;
+
   // Make sure that all of the retired constraints have been returned
   // to constraint system.
   assert(!hasRetiredConstraints());
@@ -513,6 +518,10 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
 }
 
 ConstraintSystem::SolverScope::~SolverScope() {
+  // Don't attempt to rollback from an incorrect state.
+  if (cs.inInvalidState())
+    return;
+
   // Erase the end of various lists.
   while (cs.TypeVariables.size() > numTypeVariables)
     cs.TypeVariables.pop_back();

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -362,22 +362,16 @@ StepResult ComponentStep::take(bool prevFailed) {
     return finalize(/*isSuccess=*/false);
   }
 
-#ifdef NDEBUG
   auto printConstraints = [&](const ConstraintList &constraints) {
     for (auto &constraint : constraints)
       constraint.print(getDebugLogger(), &CS.getASTContext().SourceMgr);
   };
-#endif
 
   // If we don't have any disjunction or type variable choices left, we're done
   // solving. Make sure we don't have any unsolved constraints left over, using
   // report_fatal_error to make sure we trap in debug builds and fail the step
   // in release builds.
   if (!CS.ActiveConstraints.empty()) {
-#ifndef NDEBUG
-    CS.print(llvm::errs());
-    llvm::report_fatal_error("Active constraints left over?");
-#else
     if (CS.isDebugMode()) {
       getDebugLogger() << "(failed due to remaining active constraints:\n";
       printConstraints(CS.ActiveConstraints);
@@ -386,15 +380,10 @@ StepResult ComponentStep::take(bool prevFailed) {
 
     CS.InvalidState = true;
     return finalize(/*isSuccess=*/false);
-#endif
   }
 
   if (!CS.solverState->allowsFreeTypeVariables()) {
     if (!CS.InactiveConstraints.empty()) {
-#ifndef NDEBUG
-      CS.print(llvm::errs());
-      llvm::report_fatal_error("Inactive constraints left over?");
-#else
       if (CS.isDebugMode()) {
         getDebugLogger() << "(failed due to remaining inactive constraints:\n";
         printConstraints(CS.InactiveConstraints);
@@ -403,7 +392,6 @@ StepResult ComponentStep::take(bool prevFailed) {
 
       CS.InvalidState = true;
       return finalize(/*isSuccess=*/false);
-#endif
     }
   }
 

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -384,6 +384,7 @@ StepResult ComponentStep::take(bool prevFailed) {
       getDebugLogger() << ")\n";
     }
 
+    CS.InvalidState = true;
     return finalize(/*isSuccess=*/false);
 #endif
   }
@@ -400,6 +401,7 @@ StepResult ComponentStep::take(bool prevFailed) {
         getDebugLogger() << ")\n";
       }
 
+      CS.InvalidState = true;
       return finalize(/*isSuccess=*/false);
 #endif
     }

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -403,20 +403,6 @@ StepResult ComponentStep::take(bool prevFailed) {
       return finalize(/*isSuccess=*/false);
 #endif
     }
-
-    if (CS.hasFreeTypeVariables()) {
-#ifndef NDEBUG
-      CS.print(llvm::errs());
-      llvm::report_fatal_error("Free type variables left over?");
-#else
-      if (CS.isDebugMode()) {
-        getDebugLogger() << "(failed due to remaining free type variables)\n";
-        CS.print(getDebugLogger(/*indent=*/false));
-      }
-
-      return finalize(/*isSuccess=*/false);
-#endif
-    }
   }
 
   // If this solution is worse than the best solution we've seen so far,

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5472,6 +5472,14 @@ void ConstraintSystem::diagnoseFailureFor(SolutionApplicationTarget target) {
   SWIFT_DEFER { setPhase(ConstraintSystemPhase::Finalization); };
 
   auto &DE = getASTContext().Diags;
+
+  // If constraint system is in invalid state always produce
+  // a fallback diagnostic that asks to file a bug.
+  if (inInvalidState()) {
+    DE.diagnose(target.getLoc(), diag::failed_to_produce_diagnostic);
+    return;
+  }
+
   if (auto expr = target.getAsExpr()) {
     if (auto *assignment = dyn_cast<AssignExpr>(expr)) {
       if (isa<DiscardAssignmentExpr>(assignment->getDest()))


### PR DESCRIPTION
Instead of crashing in release builds, let's simply fail the
step and let type-checker produce a fallback diagnostic.

Resolves: rdar://56167233

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
