### PR TITLE
Make `ThrowingTaskGroup.nextResult()` non-throwing.

### DIFF
--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -577,8 +577,9 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
     return try await _taskGroupWaitNext(group: _group)
   }
 
-  /// - SeeAlso: `next()`
-  public mutating func nextResult() async throws -> Result<ChildTaskResult, Failure>? {
+  @_silgen_name("$sScg10nextResults0B0Oyxq_GSgyYaKF")
+  @usableFromInline
+  mutating func nextResultForABI() async throws -> Result<ChildTaskResult, Failure>? {
     do {
       guard let success: ChildTaskResult = try await _taskGroupWaitNext(group: _group) else {
         return nil
@@ -588,6 +589,12 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
     } catch {
       return .failure(error as! Failure) // as!-safe, because we are only allowed to throw Failure (Error)
     }
+  }
+
+  /// - SeeAlso: `next()`
+  @_alwaysEmitIntoClient
+  public mutating func nextResult() async -> Result<ChildTaskResult, Failure>? {
+    return try! await nextResultForABI()
   }
 
   /// Query whether the group has any remaining tasks.


### PR DESCRIPTION
We erroneously marked this API as `throws`, even though it returns its
error via a `Result` instead. Remove the `throws` in a strange-looking
manner so that we maintain the existing ABI.

Fixes rdar://81585954.
