### PR TITLE
Make `ThrowingTaskGroup.nextResult()` non-throwing.

### DIFF
--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -599,6 +599,20 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
     return try await _taskGroupWaitNext(group: _group)
   }
 
+  @_silgen_name("$sScg10nextResults0B0Oyxq_GSgyYaKF")
+  @usableFromInline
+  mutating func nextResultForABI() async throws -> Result<ChildTaskResult, Failure>? {
+    do {
+      guard let success: ChildTaskResult = try await _taskGroupWaitNext(group: _group) else {
+        return nil
+      }
+
+      return .success(success)
+    } catch {
+      return .failure(error as! Failure) // as!-safe, because we are only allowed to throw Failure (Error)
+    }
+  }
+
   /// Wait for the next child task to complete,
   /// and return a result containing either
   /// the value that the child task returned or the error that it threw.
@@ -632,16 +646,9 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   ///   containing the error that the child task threw.
   ///
   /// - SeeAlso: `next()`
-  public mutating func nextResult() async throws -> Result<ChildTaskResult, Failure>? {
-    do {
-      guard let success: ChildTaskResult = try await _taskGroupWaitNext(group: _group) else {
-        return nil
-      }
-
-      return .success(success)
-    } catch {
-      return .failure(error as! Failure) // as!-safe, because we are only allowed to throw Failure (Error)
-    }
+  @_alwaysEmitIntoClient
+  public mutating func nextResult() async -> Result<ChildTaskResult, Failure>? {
+    return try! await nextResultForABI()
   }
 
   /// A Boolean value that indicates whether the group has any remaining tasks.

--- a/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
@@ -23,7 +23,7 @@ func boom() async throws -> Int {
 @available(SwiftStdlib 5.5, *)
 func test_taskGroup_throws() async {
   let got: Int = try await withThrowingTaskGroup(of: Int.self) { group in
-    group.spawn { try await boom()  }
+    group.addTask { try await boom()  }
 
     do {
       while let r = try await group.next() {
@@ -35,19 +35,24 @@ func test_taskGroup_throws() async {
       let gc = group.isCancelled
       print("group cancelled: \(gc)")
 
-      group.spawn { () async -> Int in
+      group.addTask { () async -> Int in
         let c = Task.isCancelled
         print("task 3 (cancelled: \(c))")
         return 3
       }
 
-      guard let third = try! await group.next() else {
+      switch await group.nextResult() {
+      case .success(let third):
+        print("task group returning normally: \(third)")
+        return third
+
+      case .failure(let error):
+        fatalError("got an erroneous third result")
+
+      case .none:
         print("task group failed to get 3")
         return 0
       }
-
-      print("task group returning normally: \(third)")
-      return third
     }
 
     fatalError("Should have thrown and handled inside the catch block")


### PR DESCRIPTION
**Explanation**: We erroneously marked `ThrowingTaskGroup.nextResult()`  as `throws`, even though it returns its error via a `Result` instead. Remove the `throws` in a strange-looking manner so that we maintain the existing ABI.
**Scope**: Affects new code using Swift's Concurrency model that uses task groups.
**Radar/SR Issue**:  rdar://81585954.
**Risk**: Low.
**Reviewed By**: Konrad Malawski
**Testing**: PR testing and CI on main, including new tests.
**Original PR**: https://github.com/apple/swift/pull/38771
