### PR TITLE
[SourceKit] Suppress oslog_invalid_log_message diagnostic in live issues

### DIFF
--- a/test/SourceKit/Sema/oslog.swift
+++ b/test/SourceKit/Sema/oslog.swift
@@ -1,0 +1,36 @@
+// REQUIRES: VENDOR=apple
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-build-swift -emit-module -module-name Lib -o %t -Xfrontend -experimental-allow-module-with-compiler-errors -Xfrontend -experimental-skip-all-function-bodies %t/lib.swift
+// RUN: %sourcekitd-test -req=sema %t/main.swift -- %t/main.swift -I%t -sdk %sdk -Xfrontend -experimental-allow-module-with-compiler-errors | %FileCheck %s
+// CHECK-NOT: oslog_invalid_log_message
+
+// BEGIN lib.swift
+import os
+
+public struct Foo {
+  public let prop: String
+  public init() { self.prop = "boop" }
+}
+
+@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+extension OSLogInterpolation {
+  @_optimize(none)
+  @_transparent
+  @_semantics("oslog.requires_constant_arguments")
+  public mutating func appendInterpolation(_ value: @autoclosure @escaping () -> Foo) {
+    let v = value()
+    appendInterpolation(v.prop)
+  }
+}
+
+// BEGIN main.swift
+import os
+import Lib
+
+if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+  let logger = Logger()
+  logger.log("Log a foo: \(Foo())")
+}

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -27,6 +27,7 @@
 #include "swift/AST/DiagnosticsClangImporter.h"
 #include "swift/AST/DiagnosticsParse.h"
 #include "swift/AST/DiagnosticsFrontend.h"
+#include "swift/AST/DiagnosticsSIL.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Demangling/ManglingUtils.h"
 #include "swift/Frontend/Frontend.h"
@@ -83,7 +84,13 @@ void EditorDiagConsumer::handleDiagnostic(SourceManager &SM,
   }
 
   // Filter out benign diagnostics for editing.
-  if (Info.ID == diag::lex_editor_placeholder.ID)
+  // oslog_invalid_log_message is spuriously output for live issues as modules
+  // in the index build are built without function bodies (including inline
+  // functions). OSLogOptimization expects SIL for bodies and hence errors
+  // when there isn't any. Ignore in live issues for now and re-evaluate if
+  // this (not having SIL for inline functions) becomes a more widespread issue.
+  if (Info.ID == diag::lex_editor_placeholder.ID ||
+      Info.ID == diag::oslog_invalid_log_message.ID)
     return;
 
   bool IsNote = (Info.Kind == DiagnosticKind::Note);


### PR DESCRIPTION
The index build skips *all* function bodies, including inlinable. The
`OSLogOptimization` pass expects SIL for inlinable bodies and thus
outputs a spurious diagnostic for live issues when the
`OSLogInterpolation` extension is in a separate module to the log
statement.

Ignore this for now, but we may need to re-evaluate if this becomes a
more widespread problem.

Resolves rdar://79100763