### PR TITLE
Rename --enable-experimental-opaque-return-types and gate structural …

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1861,6 +1861,9 @@ WARNING(spi_attribute_on_import_of_public_module,none,
         (DeclName, StringRef))
 
 // Opaque return types
+ERROR(structural_opaque_types_are_experimental,none,
+      "'opaque' types cannot be nested inside other types; "
+      "structural 'opaque' types are an experimental feature", ())
 ERROR(opaque_type_invalid_constraint,none,
       "an 'opaque' type must specify only 'Any', 'AnyObject', protocols, "
       "and/or a base class", ())

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -298,10 +298,13 @@ namespace swift {
     /// Enable experimental concurrency model.
     bool EnableExperimentalConcurrency = false;
 
-    /// Enable experimental support for additional opaque return type features,
-    /// i.e. named opaque return types (with 'where' clause support), and opaque
-    /// types in nested position within the function return type.
-    bool EnableExperimentalOpaqueReturnTypes = false;
+    /// Enable experimental support for named opaque result types, e.g.
+    /// `func f() -> <T> T`.
+    bool EnableExperimentalNamedOpaqueTypes = false;
+
+    /// Enable experimental support for structural opaque result types, e.g.
+    /// `func f() -> (some P)?`.
+    bool EnableExperimentalStructuralOpaqueTypes = false;
 
     /// Enable experimental flow-sensitive concurrent captures.
     bool EnableExperimentalFlowSensitiveConcurrentCaptures = false;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -427,9 +427,13 @@ def enable_experimental_static_assert :
   Flag<["-"], "enable-experimental-static-assert">,
   HelpText<"Enable experimental #assert">;
 
-def enable_experimental_opaque_return_types :
-  Flag<["-"], "enable-experimental-opaque-return-types">,
-  HelpText<"Enable experimental extensions to opaque return type support">;
+def enable_experimental_named_opaque_types :
+  Flag<["-"], "enable-experimental-named-opaque-types">,
+  HelpText<"Enable experimental support for named opaque result types">;
+
+def enable_experimental_structural_opaque_types :
+  Flag<["-"], "enable-experimental-structural-opaque-types">,
+  HelpText<"Enable experimental support for structural opaque result types">;
 
 def enable_deserialization_recovery :
   Flag<["-"], "enable-deserialization-recovery">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -422,8 +422,11 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalConcurrency |=
     Args.hasArg(OPT_enable_experimental_concurrency);
 
-  Opts.EnableExperimentalOpaqueReturnTypes |=
-      Args.hasArg(OPT_enable_experimental_opaque_return_types);
+  Opts.EnableExperimentalNamedOpaqueTypes |=
+      Args.hasArg(OPT_enable_experimental_named_opaque_types);
+
+  Opts.EnableExperimentalStructuralOpaqueTypes |=
+      Args.hasArg(OPT_enable_experimental_structural_opaque_types);
 
   Opts.EnableExperimentalDistributed |=
     Args.hasArg(OPT_enable_experimental_distributed);

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -550,7 +550,7 @@ ParserResult<TypeRepr> Parser::parseType(
 
 ParserResult<TypeRepr> Parser::parseTypeWithOpaqueParams(Diag<> MessageID) {
   GenericParamList *genericParams = nullptr;
-  if (Context.LangOpts.EnableExperimentalOpaqueReturnTypes) {
+  if (Context.LangOpts.EnableExperimentalNamedOpaqueTypes) {
     auto result = maybeParseGenericParams();
     genericParams = result.getPtrOrNull();
     if (result.hasCodeCompletion())

--- a/test/Constraints/result_builder_infer.swift
+++ b/test/Constraints/result_builder_infer.swift
@@ -66,13 +66,6 @@ struct TupleMe: Tupled {
   }
 }
 
-struct TupleMeStructural: Tupled {
-  var tuple: (some Any, Int) {
-    "hello"
-    0
-  }
-}
-
 // Witness is separated from the context declaring conformance, so don't infer
 // the result builder.
 struct DoNotTupleMe {

--- a/test/Constraints/result_builder_opaque_result_structural.swift
+++ b/test/Constraints/result_builder_opaque_result_structural.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-structural-opaque-types -disable-availability-checking
+
+@resultBuilder
+struct TupleBuilder {
+  static func buildBlock<T1, T2>(_ t1: T1, _ t2: T2) -> (T1, T2) {
+    return (t1, t2)
+  }
+}
+
+protocol Tupled {
+  associatedtype TupleType
+  
+  @TupleBuilder var tuple: TupleType { get }
+}
+
+struct TupleMeStructural: Tupled {
+  var tuple: (some Any, Int) {
+    "hello"
+    0
+  }
+}

--- a/test/IDE/print_ast_named_opaque_return.swift
+++ b/test/IDE/print_ast_named_opaque_return.swift
@@ -5,7 +5,7 @@ func f1() -> <T> Int {
 func f2() -> <T: SignedInteger, U: SignedInteger> Int {
 }
 
-// RUN: %target-swift-ide-test -print-ast-typechecked -enable-experimental-opaque-return-types -source-filename %s | %FileCheck %s -check-prefix=CHECK1
+// RUN: %target-swift-ide-test -print-ast-typechecked -enable-experimental-named-opaque-types -source-filename %s | %FileCheck %s -check-prefix=CHECK1
 // CHECK1: {{^}}func f0() {{{$}}
 // CHECK1: {{^}}}{{$}}
 // CHECK1: {{^}}func f1() -> <T> Int {{{$}}

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -75,81 +75,11 @@ struct Test {
 
 let zingle = {() -> some P in 1 } // expected-error{{'some' types are only implemented}}
 
-// Structural positions
 
-struct S1<T> {
-  var x: T
-}
-struct S2<T, U> {
-  var x: T
-  var y: U
-}
-struct R1<T: P> {
-  var x: T
-}
-struct R2<T: P, U: Q> {
-  var x: T
-  var y: U
-}
-
-// TODO: cases that we should support, but don't yet:
-//
-// WARNING: using '!' is not allowed here; treating this as '?' instead
-// func asUnwrappedOptionalBase() -> (some P)! { return 1 }
-//
-// ERROR: generic parameter 'τ_0_0' could not be inferred
-// func asHOFRetRet() -> () -> some P { return { 1 } }
-//
-// ERROR: function declares an opaque return type, but has no return statements in its body from which to infer an underlying type
-// func asHOFRetArg() -> (some P) -> () { return { (x: String) -> () in } }
-//
-// ERROR: 'some' types are only implemented for the declared type of properties and subscripts and the return type of functions
-// let x = { () -> some P in return ConcreteP() }
-
-func twoOpaqueTypes() -> (some P, some P) { return (1, 2) } // expected-error{{only one 'opaque' type is supported}}
-func asTupleElemBad() -> (P, some Q) { return (1, C()) } // expected-note{{opaque return type declared here}} expected-error{{requires that 'C' conform to 'Q'}}
-
-func asTupleElem() -> (P, some Q) { return (1, 2) }
-func asArrayElem() -> [some P] { return [1] }
-func asOptionalBase() -> (some P)? { return 1 }
-
-let asTupleElemLet: (P, some Q) = (1, 2)
-let asArrayElemLet: [some P] = [1]
-let asOptionalBaseLet: (some P)? = 1
-
-func asUnconstrainedGeneric1() -> S1<some P> { return S1(x: 1) }
-func asUnconstrainedGeneric2() -> S2<P, some Q> { return S2(x: 1, y: 2) }
-func asConstrainedGeneric1() -> R1<some P> { return R1(x: 1) }
-func asConstrainedGeneric2() -> R2<Int, some Q> { return R2(x: 1, y: 2) }
-func asNestedGenericDirect() -> S1<S1<some P>> { return S1(x: S1(x: 1)) }
-func asNestedGenericIndirect() -> S1<S1<(Int, some P)>> { return S1(x: S1(x: (1, 2))) }
-
-let asUnconstrainedGeneric2Let: S2<P, some Q> = S2(x: 1, y: 2)
-let asNestedGenericIndirectLet: S1<S1<(Int, some P)>> = S1(x: S1(x: (1, 2)))
-
-// Tests an interesting SILGen case. For the underlying opaque type, we have to
-// use the generic calling convention for closures.
-func funcToAnyOpaqueCoercion() -> S1<some Any> {
-  let f: () -> () = {}
-  return S1(x: f)
-}
-
-// TODO: We should give better error messages here. The opaque types have
-// underlying types 'Int' and 'String', but the return statments have underlying
-// types '(Int, Int)' and '(String, Int)'.
-func structuralMismatchedReturnTypes(_ x: Bool, _ y: Int, _ z: String) -> (some P, Int) { // expected-error{{do not have matching underlying types}}
-  if x {
-    return (y, 1) // expected-note{{return statement has underlying type 'Int'}}
-  } else {
-    return (z, 1) // expected-note{{return statement has underlying type 'String'}}
-  }
-}
-
-func structuralMemberLookupBad() {
-  var tup: (some P, Int) = (1, 1)
-  tup.0.paul();
-  tup.0.d(); // expected-error{{value of type 'some P' has no member 'd'}}
-}
+// Support for structural opaque result types is hidden behind a compiler flag
+// until the proposal gets approved.
+func twoOpaqueTypes() -> (some P, some P) { return (1, 2) } // expected-error{{'opaque' types cannot be nested inside other types}}
+func asArrayElem() -> (some P)! { return [1] } // expected-error{{'opaque' types cannot be nested inside other types}}
 
 // Invalid positions
 

--- a/test/type/opaque_return_named.swift
+++ b/test/type/opaque_return_named.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-opaque-return-types -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -enable-experimental-named-opaque-types -disable-availability-checking
 
 // Tests for experimental extensions to opaque return type support.
 

--- a/test/type/opaque_return_structural.swift
+++ b/test/type/opaque_return_structural.swift
@@ -1,0 +1,87 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-structural-opaque-types -disable-availability-checking
+
+// Tests for experimental extensions to opaque return type support.
+
+protocol P { func paul() }
+protocol Q {}
+
+extension Int: P, Q { func paul() {} }
+extension String: P, Q { func paul() {} }
+
+class C {}
+class D: P, Q { func paul() {}; func d() {} }
+
+
+// TODO: cases that we should support, but don't yet:
+//
+// WARNING: using '!' is not allowed here; treating this as '?' instead
+// func asUnwrappedOptionalBase() -> (some P)! { return 1 }
+//
+// ERROR: generic parameter 'τ_0_0' could not be inferred
+// func asHOFRetRet() -> () -> some P { return { 1 } }
+//
+// ERROR: function declares an opaque return type, but has no return statements in its body from which to infer an underlying type
+// func asHOFRetArg() -> (some P) -> () { return { (x: Int) -> () in } }
+//
+// ERROR: 'some' types are only implemented for the declared type of properties and subscripts and the return type of functions
+// let x = { () -> some P in return 1 }
+
+func twoOpaqueTypes() -> (some P, some P) { return (1, 2) } // expected-error{{only one 'opaque' type is supported}}
+func asTupleElemBad() -> (P, some Q) { return (1, C()) } // expected-note{{opaque return type declared here}} expected-error{{requires that 'C' conform to 'Q'}}
+
+func asTupleElem() -> (P, some Q) { return (1, 2) }
+func asArrayElem() -> [some P] { return [1] }
+func asOptionalBase() -> (some P)? { return 1 }
+
+let asTupleElemLet: (P, some Q) = (1, 2)
+let asArrayElemLet: [some P] = [1]
+let asOptionalBaseLet: (some P)? = 1
+
+struct S1<T> {
+  var x: T
+}
+struct S2<T, U> {
+  var x: T
+  var y: U
+}
+struct R1<T: P> {
+  var x: T
+}
+struct R2<T: P, U: Q> {
+  var x: T
+  var y: U
+}
+
+func asUnconstrainedGeneric1() -> S1<some P> { return S1(x: 1) }
+func asUnconstrainedGeneric2() -> S2<P, some Q> { return S2(x: 1, y: 2) }
+func asConstrainedGeneric1() -> R1<some P> { return R1(x: 1) }
+func asConstrainedGeneric2() -> R2<Int, some Q> { return R2(x: 1, y: 2) }
+func asNestedGenericDirect() -> S1<S1<some P>> { return S1(x: S1(x: 1)) }
+func asNestedGenericIndirect() -> S1<S1<(Int, some P)>> { return S1(x: S1(x: (1, 2))) }
+
+let asUnconstrainedGeneric2Let: S2<P, some Q> = S2(x: 1, y: 2)
+let asNestedGenericIndirectLet: S1<S1<(Int, some P)>> = S1(x: S1(x: (1, 2)))
+
+// Tests an interesting SILGen case. For the underlying opaque type, we have to
+// use the generic calling convention for closures.
+func funcToAnyOpaqueCoercion() -> S1<some Any> {
+  let f: () -> () = {}
+  return S1(x: f)
+}
+
+// TODO: We should give better error messages here. The opaque types have
+// underlying types 'Int' and 'String', but the return statments have underlying
+// types '(Int, Int)' and '(String, Int)'.
+func structuralMismatchedReturnTypes(_ x: Bool, _ y: Int, _ z: String) -> (some P, Int) { // expected-error{{do not have matching underlying types}}
+  if x {
+    return (y, 1) // expected-note{{return statement has underlying type 'Int'}}
+  } else {
+    return (z, 1) // expected-note{{return statement has underlying type 'String'}}
+  }
+}
+
+func structuralMemberLookupBad() {
+  var tup: (some P, Int) = (D(), 1)
+  tup.0.paul();
+  tup.0.d(); // expected-error{{value of type 'some P' has no member 'd'}}
+}

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -767,10 +767,9 @@ DisableImplicitConcurrencyImport("disable-implicit-concurrency-module-import",
                                  llvm::cl::desc("Disable implicit import of _Concurrency module"),
                                  llvm::cl::init(false));
 
-static llvm::cl::opt<bool> EnableExperimentalOpaqueReturnTypes(
-    "enable-experimental-opaque-return-types",
-    llvm::cl::desc(
-        "Enable experimental extensions to opaque return type support"),
+static llvm::cl::opt<bool> EnableExperimentalNamedOpaqueTypes(
+    "enable-experimental-named-opaque-types",
+    llvm::cl::desc("Enable experimental support for named opaque result types"),
     llvm::cl::Hidden, llvm::cl::cat(Category), llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
@@ -3875,8 +3874,8 @@ int main(int argc, char *argv[]) {
   if (options::DisableImplicitConcurrencyImport) {
     InitInvok.getLangOptions().DisableImplicitConcurrencyModuleImport = true;
   }
-  if (options::EnableExperimentalOpaqueReturnTypes) {
-    InitInvok.getLangOptions().EnableExperimentalOpaqueReturnTypes = true;
+  if (options::EnableExperimentalNamedOpaqueTypes) {
+    InitInvok.getLangOptions().EnableExperimentalNamedOpaqueTypes = true;
   }
 
   if (options::EnableExperimentalDistributed) {


### PR DESCRIPTION
Initially, we decided to merge structural opaque result types as a "bug" fix. However, the core team decided that there are enough degrees of freedom in their implementation to warrant a proposal, so they need to be hidden behind a feature flag for the time being.

I decided to make this a separate flag from the flag for named opaque result types because the former is much further from usability.