### PR TITLE
[SourceKit] Support cancellation of requests while an AST is being built

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -595,6 +595,12 @@ namespace swift {
     /// than this many seconds.
     unsigned ExpressionTimeoutThreshold = 600;
 
+    /// If the shared pointer is not a \c nullptr and the pointee is \c true,
+    /// typechecking should be aborted at the next possible opportunity.
+    /// This is used by SourceKit to cancel requests for which the result is no
+    /// longer of interest.
+    std::shared_ptr<bool> CancellationFlag = nullptr;
+
     /// If non-zero, abort the switch statement exhaustiveness checker if
     /// the Space::minus function is called more than this many times.
     ///

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -599,7 +599,7 @@ namespace swift {
     /// typechecking should be aborted at the next possible opportunity.
     /// This is used by SourceKit to cancel requests for which the result is no
     /// longer of interest.
-    std::shared_ptr<bool> CancellationFlag = nullptr;
+    std::shared_ptr<std::atomic<bool>> CancellationFlag = nullptr;
 
     /// If non-zero, abort the switch statement exhaustiveness checker if
     /// the Space::minus function is called more than this many times.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5155,6 +5155,10 @@ public:
     if (isExpressionAlreadyTooComplex)
       return true;
 
+    auto CancellationFlag = getASTContext().TypeCheckerOpts.CancellationFlag;
+    if (CancellationFlag && *CancellationFlag)
+      return true;
+
     auto used = getASTContext().getSolverMemory() + solutionMemory;
     MaxMemory = std::max(used, MaxMemory);
     auto threshold = getASTContext().TypeCheckerOpts.SolverMemoryThreshold;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5156,7 +5156,7 @@ public:
       return true;
 
     auto CancellationFlag = getASTContext().TypeCheckerOpts.CancellationFlag;
-    if (CancellationFlag && *CancellationFlag)
+    if (CancellationFlag && CancellationFlag->load(std::memory_order_relaxed))
       return true;
 
     auto used = getASTContext().getSolverMemory() + solutionMemory;

--- a/test/SourceKit/Misc/stats.swift
+++ b/test/SourceKit/Misc/stats.swift
@@ -46,8 +46,8 @@ func foo() {}
 // SEMA_3: 1 {{.*}} source.statistic.num-ast-builds
 // SEMA_3: 1 {{.*}} source.statistic.num-asts-in-memory
 // SEMA_3: 1 {{.*}} source.statistic.max-asts-in-memory
-// SEMA_3: 0 {{.*}} source.statistic.num-ast-cache-hits
-// SEMA_3: 1 {{.*}} source.statistic.num-ast-snaphost-uses
+// SEMA_3: 1 {{.*}} source.statistic.num-ast-cache-hits
+// SEMA_3: 0 {{.*}} source.statistic.num-ast-snaphost-uses
 
 // RUN: %sourcekitd-test -req=sema %s -- -Xfrontend -disable-implicit-concurrency-module-import  %s == -req=related-idents -pos=1:6 %s -- -Xfrontend -disable-implicit-concurrency-module-import  %s == -req=stats | %FileCheck %s -check-prefix=SEMA_4
 
@@ -58,3 +58,14 @@ func foo() {}
 // SEMA_4: 1 {{.*}} source.statistic.max-asts-in-memory
 // SEMA_4: 1 {{.*}} source.statistic.num-ast-cache-hits
 // SEMA_4: 0 {{.*}} source.statistic.num-ast-snaphost-uses
+
+// Test that we can have two files open and don't need to rebuild an AST when doing the cursor info request on '%s' after opening '10bytes.swift'
+// RUN: %sourcekitd-test \
+// RUN: -req=sema %s -- -Xfrontend -disable-implicit-concurrency-module-import  %s == \
+// RUN: -req=sema %S/Inputs/10bytes.swift -- -Xfrontend -disable-implicit-concurrency-module-import %S/Inputs/10bytes.swift == \
+// RUN: -req=cursor -pos=1:6 %s -- -Xfrontend -disable-implicit-concurrency-module-import  %s == \
+// RUN: -req=stats | %FileCheck %s -check-prefix=OPEN_TWO_FILES
+
+// OPEN_TWO_FILES: 2 {{.*}} source.statistic.num-ast-builds
+// OPEN_TWO_FILES: 2 {{.*}} source.statistic.num-asts-in-memory
+// OPEN_TWO_FILES: 2 {{.*}} source.statistic.max-asts-in-memory

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
@@ -9,15 +9,77 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+//
+// The SwiftASTManager stack consists of four essential classes:
+//  - SwiftASTManager: Global object that is the entry point into AST building
+//  - ASTProducer: Produces ASTs for a single compiler invocation. Keeps track
+//      of old ASTs and determines if the olds ASTs are suitable to serve a
+//      SwiftASTConsumer (through SwiftASTConsumer::canUseASTWithSnapshots).
+//  - ASTBuildOperation: If ASTProducer decides that an AST needs to be built,
+//      it creates an ASTBuildOperation. It keeps track of all consumers that
+//      depend on it and supports AST build cancellation if all interested
+//      consumers disappear.
+//  - SwiftASTConsumer: Correlates to a SourceKit request. It just wants an AST
+//      and doesn't care if/how the AST is built or whether it's served from a
+//      cache.
+//
+// There is a strict memory ownership hierarchy. Classes higher up hold strong
+// references to once further down. Callbacks that call upwards only hold weak
+// references.
+// Exception: Everything can hold a strong reference to the SwiftASTManager,
+// because it's expected to stay alive anyway. The SwiftASTManager is
+// responsible to occasionally clean up all strong references to classes lower
+// down.
+//
+// Adding a new consumer:
+// ----------------------
+// To add a new consumer, SwiftASTManager::processASTAsync is called. It finds
+// a suitable ASTProducer, which in turn looks up an ASTBuildOperation that
+// either contains the same snapshot state that the consumer requested or one
+// that is close enough to the consumer's expectation that it can serve it.
+// If there already exists one, the consumer is added to it. Should the build
+// operation already be finished, the consumer is directly called with the
+// result. Otherwise, a new ASTBuildOperation is created, the consumer is added
+// to it and the ASTBuildOperation is scheduled on
+// SwiftASTManager::Implemenation::ASTBuildQueue. This ensures that only one
+// AST is built at a time.
+// The SwiftASTManager keeps a weak reference to the consumer, so that the
+// consumer can be cancelled if new requests come in (see implementation of
+// processASTAsync).
+//
+// Building an AST:
+// ----------------
+// If it's a ASTBuildOperation's turn to build an AST (guarded by
+// ASTBuildQueue), it checks whether any consumers are attached to it. If none
+// are, there is no work to do and it finishes.
+// Otherwise, it builds the AST, informs the consumers about the result and
+// saves the result in a member variable so that it can serve future
+// SwiftASTConsumers from it.
+//
+// Cancellation:
+// -------------
+// Only SwiftASTConsumers can be cancelled. The cancellation of the AST build
+// only happens if no more consumers are interested in it.
+// If requestCancellation is called on a SwiftASTConsumer, it informs the
+// ASTBuildOperation, it is scheduled on, that it's no longer interested in the
+// result. In theory, the ASTBuildOperation might or might not honour that
+// request. In practice, it will always call SwiftASTConsumer::cancelled and
+// remove the consumer from the list of consumers interested in its result. If
+// no more consumers are interested in the ASTBuildOperation's result, it
+// cancels the AST build by setting a flag that causes the type checker to fail
+// with a "expression is too complex" error at the next suitable opportunity.
+//
+//===----------------------------------------------------------------------===//
 
 #ifndef LLVM_SOURCEKIT_LIB_SWIFTLANG_SWIFTASTMANAGER_H
 #define LLVM_SOURCEKIT_LIB_SWIFTLANG_SWIFTASTMANAGER_H
 
-#include "SwiftInvocation.h"
 #include "SourceKit/Core/LLVM.h"
+#include "SwiftInvocation.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Mutex.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include <functional>
 #include <string>
@@ -68,24 +130,92 @@ public:
 
 typedef IntrusiveRefCntPtr<ASTUnit> ASTUnitRef;
 
-class SwiftASTConsumer {
+class SwiftASTConsumer : public std::enable_shared_from_this<SwiftASTConsumer> {
+  /// Mutex guarding all accesses to CancellationRequestCallback
+  llvm::sys::Mutex CancellationRequestCallbackMtx;
+
+  /// A callback that informs the \c ASTBuildOperation, which is producing the
+  /// AST for this consumer, that the consumer is no longer of interest. Calling
+  /// this callback will eventually call \c cancelled on this consumer.
+  /// If the consumer isn't associated with any \c ASTBuildOperation at the
+  /// moment (e.g. if it hasn't been scheduled on one yet or if the build
+  /// operation has already informed the ASTConsumer), the callback is \c None.
+  Optional<std::function<void(std::shared_ptr<SwiftASTConsumer>)>>
+      CancellationRequestCallback;
+
 public:
   virtual ~SwiftASTConsumer() { }
+
+  // MARK: Cancellation
+
+  /// The result of this consumer is no longer of interest to the SourceKit
+  /// client.
+  /// This will cause \c cancelled to be called on this \c SwiftASTConsumer and
+  /// cause the \c ASTBuildOperation to be cancelled if no other consumer is
+  /// depending on it.
+  void requestCancellation() {
+    llvm::sys::ScopedLock L(CancellationRequestCallbackMtx);
+    if (CancellationRequestCallback.hasValue()) {
+      (*CancellationRequestCallback)(shared_from_this());
+      CancellationRequestCallback = None;
+    }
+  }
+
+  /// Set a cancellation request callback that informs a \c ASTBuildOperation
+  /// when this \c SwiftASTConsumer is cancelled. Asserts that there is
+  /// currently no callback set.
+  /// The cancellation request callback will automatically be removed when the
+  /// SwiftASTManager is cancelled.
+  void setCancellationRequestCallback(
+      std::function<void(std::shared_ptr<SwiftASTConsumer>)> NewCallback) {
+    llvm::sys::ScopedLock L(CancellationRequestCallbackMtx);
+    assert(!CancellationRequestCallback.hasValue() &&
+           "Can't set two cancellation callbacks on a SwiftASTConsumer");
+    CancellationRequestCallback = NewCallback;
+  }
+
+  /// Removes the cancellation request callback previously set by \c
+  /// setCancellationRequestCallback.
+  void removeCancellationRequestCallback() {
+    llvm::sys::ScopedLock L(CancellationRequestCallbackMtx);
+    CancellationRequestCallback = None;
+  }
+
+  // MARK: Result methods
+  // Exactly one of these will be called for every consumer.
+
+  /// An AST was produced that the consumer should handle.
+  virtual void handlePrimaryAST(ASTUnitRef AstUnit) = 0;
+
+  /// Creation of the AST failed due to \p Error. The request corresonding to
+  /// this consumer should fail.
+  virtual void failed(StringRef Error);
+
+  /// The consumer was cancelled by the \c requestCancellation method and the \c
+  /// ASTBuildOperation creating the AST for this consumer honored the request.
   virtual void cancelled() {}
-  /// If there is an existing AST, this is called before trying to update it.
-  /// Consumers may choose to still accept it even though it may have stale parts.
+
+  // MARK: Use ASTs from older snapshots
+
+  /// Typically a \c SwiftASTConsumer expects an AST for a specific source
+  /// state, namely the one on disk when the request was created.
+  /// If an AST for a similar source state has already been built, it might be
+  /// sufficient to serve this consumer.
   ///
-  /// \param Snapshots that were used to create the AST.
-  /// \returns true if the existing AST is acceptable to be used.
+  /// An \c ASTProducer might ask a consumer if it can also handle an AST
+  /// constructed from the source state described by \p Snapshots.
+  /// If the consumer returns \c true from this method, it should expect to
+  /// receive an AST constructed from the source state described by \p
+  /// Snapshots. It might need to adjust its internal state (e.g. requested
+  /// offset for this new source state).
   virtual bool canUseASTWithSnapshots(
       ArrayRef<ImmutableTextSnapshotRef> Snapshots) {
     return false;
   }
-  virtual void failed(StringRef Error);
-  virtual void handlePrimaryAST(ASTUnitRef AstUnit) = 0;
 };
 
 typedef std::shared_ptr<SwiftASTConsumer> SwiftASTConsumerRef;
+typedef std::weak_ptr<SwiftASTConsumer> SwiftASTConsumerWeakRef;
 
 class SwiftASTManager : public std::enable_shared_from_this<SwiftASTManager> {
 public:
@@ -153,6 +283,8 @@ public:
   struct Implementation;
   Implementation &Impl;
 };
+
+typedef std::shared_ptr<SwiftASTManager> SwiftASTManagerRef;
 
 } // namespace SourceKit
 

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -93,6 +93,7 @@ public:
 struct TestCursorInfo {
   // Empty if no error.
   std::string Error;
+  std::string InternalDiagnostic;
   std::string Name;
   std::string Typename;
   std::string Filename;
@@ -145,30 +146,34 @@ public:
   }
 
   TestCursorInfo getCursor(const char *DocName, unsigned Offset,
-                           ArrayRef<const char *> CArgs) {
+                           ArrayRef<const char *> CArgs,
+                           bool CancelOnSubsequentRequest = false) {
     auto Args = makeArgs(DocName, CArgs);
     Semaphore sema(0);
 
     TestCursorInfo TestInfo;
-    getLang().getCursorInfo(DocName, Offset, 0, false, false, false, Args, None,
-      [&](const RequestResult<CursorInfoData> &Result) {
-        assert(!Result.isCancelled());
-        if (Result.isError()) {
-          TestInfo.Error = Result.getError().str();
+    getLang().getCursorInfo(
+        DocName, Offset, /*Length=*/0, /*Actionables=*/false,
+        /*SymbolGraph=*/false, CancelOnSubsequentRequest, Args,
+        /*vfsOptions=*/None, [&](const RequestResult<CursorInfoData> &Result) {
+          assert(!Result.isCancelled());
+          if (Result.isError()) {
+            TestInfo.Error = Result.getError().str();
+            sema.signal();
+            return;
+          }
+          const CursorInfoData &Info = Result.value();
+          TestInfo.InternalDiagnostic = Info.InternalDiagnostic.str();
+          if (!Info.Symbols.empty()) {
+            const CursorSymbolInfo &MainSymbol = Info.Symbols[0];
+            TestInfo.Name = std::string(MainSymbol.Name.str());
+            TestInfo.Typename = MainSymbol.TypeName.str();
+            TestInfo.Filename = MainSymbol.Location.Filename.str();
+            TestInfo.Offset = MainSymbol.Location.Offset;
+            TestInfo.Length = MainSymbol.Location.Length;
+          }
           sema.signal();
-          return;
-        }
-        const CursorInfoData &Info = Result.value();
-        if (!Info.Symbols.empty()) {
-          const CursorSymbolInfo &MainSymbol = Info.Symbols[0];
-          TestInfo.Name = std::string(MainSymbol.Name.str());
-          TestInfo.Typename = MainSymbol.TypeName.str();
-          TestInfo.Filename = MainSymbol.Location.Filename.str();
-          TestInfo.Offset = MainSymbol.Location.Offset;
-          TestInfo.Length = MainSymbol.Location.Length;
-        }
-        sema.signal();
-      });
+        });
 
     bool expired = sema.wait(60 * 1000);
     if (expired)
@@ -255,6 +260,8 @@ TEST_F(CursorInfoTest, EditBefore) {
   auto FooRefOffs = findOffset("foo;", Contents);
   auto FooOffs = findOffset("foo =", Contents);
   auto Info = getCursor(DocName, FooRefOffs, Args);
+  EXPECT_STREQ("", Info.Error.c_str());
+  EXPECT_STREQ("", Info.InternalDiagnostic.c_str());
   EXPECT_STREQ("foo", Info.Name.c_str());
   EXPECT_STREQ("Int", Info.Typename.c_str());
   EXPECT_STREQ(DocName, Info.Filename.c_str());
@@ -272,6 +279,8 @@ TEST_F(CursorInfoTest, EditBefore) {
 
   // Should not wait for the new AST, it should give the previous answer.
   Info = getCursor(DocName, FooRefOffs, Args);
+  EXPECT_STREQ("", Info.Error.c_str());
+  EXPECT_STREQ("", Info.InternalDiagnostic.c_str());
   EXPECT_STREQ("foo", Info.Name.c_str());
   EXPECT_STREQ("Int", Info.Typename.c_str());
   EXPECT_STREQ(DocName, Info.Filename.c_str());
@@ -290,6 +299,8 @@ TEST_F(CursorInfoTest, CursorInfoMustWaitDueDeclLoc) {
   auto FooRefOffs = findOffset("foo", Contents);
   auto FooOffs = findOffset("foo =", Contents);
   auto Info = getCursor(DocName, FooRefOffs, Args);
+  EXPECT_STREQ("", Info.Error.c_str());
+  EXPECT_STREQ("", Info.InternalDiagnostic.c_str());
   EXPECT_STREQ("foo", Info.Name.c_str());
   EXPECT_STREQ("Int", Info.Typename.c_str());
 
@@ -302,6 +313,8 @@ TEST_F(CursorInfoTest, CursorInfoMustWaitDueDeclLoc) {
   // Should wait for the new AST, because the declaration location for the 'foo'
   // reference has been edited out.
   Info = getCursor(DocName, FooRefOffs, Args);
+  EXPECT_STREQ("", Info.Error.c_str());
+  EXPECT_STREQ("", Info.InternalDiagnostic.c_str());
   EXPECT_STREQ("foo", Info.Name.c_str());
   EXPECT_STREQ("[Int : Int]", Info.Typename.c_str());
   EXPECT_EQ(FooOffs, Info.Offset);
@@ -367,8 +380,7 @@ TEST_F(CursorInfoTest, CursorInfoMustWaitDueToken) {
   EXPECT_EQ(strlen("fog"), Info.Length);
 }
 
-// This test is failing occassionally in CI: rdar://55314062
-TEST_F(CursorInfoTest, DISABLED_CursorInfoMustWaitDueTokenRace) {
+TEST_F(CursorInfoTest, CursorInfoMustWaitDueTokenRace) {
   const char *DocName = "test.swift";
   const char *Contents = "let value = foo\n"
                          "let foo = 0\n";
@@ -394,4 +406,52 @@ TEST_F(CursorInfoTest, DISABLED_CursorInfoMustWaitDueTokenRace) {
   EXPECT_STREQ("Int", Info.Typename.c_str());
   EXPECT_EQ(FooOffs, Info.Offset);
   EXPECT_EQ(strlen("fog"), Info.Length);
+}
+
+TEST_F(CursorInfoTest, CursorInfoCancelsPreviousRequest) {
+  // TODO: This test case relies on the following snippet being slow to type 
+  // check so that the first cursor info request takes longer to execute than it 
+  // takes time to schedule the second request. If that is fixed, we need to 
+  // find a new way to cause slow type checking. rdar://80582770
+  const char *SlowDocName = "slow.swift";
+  const char *SlowContents = "func foo(x: Invalid1, y: Invalid2) {\n"
+                             "    x / y / x / y / x / y / x / y\n"
+                             "}\n";
+  auto SlowOffset = findOffset("x", SlowContents);
+  const char *Args[] = {"-parse-as-library"};
+  std::vector<const char *> ArgsForSlow = llvm::makeArrayRef(Args).vec();
+  ArgsForSlow.push_back(SlowDocName);
+
+  const char *FastDocName = "fast.swift";
+  const char *FastContents = "func bar() {\n"
+                             "    let foo = 123\n"
+                             "}\n";
+  auto FastOffset = findOffset("foo", FastContents);
+  std::vector<const char *> ArgsForFast = llvm::makeArrayRef(Args).vec();
+  ArgsForFast.push_back(FastDocName);
+
+  open(SlowDocName, SlowContents, llvm::makeArrayRef(Args));
+  open(FastDocName, FastContents, llvm::makeArrayRef(Args));
+
+  // Schedule a cursor info request that takes long to execute. This should be
+  // cancelled as the next cursor info (which is faster) gets requested.
+  Semaphore FirstCursorInfoSema(0);
+  getLang().getCursorInfo(
+      SlowDocName, SlowOffset, /*Length=*/0, /*Actionables=*/false,
+      /*SymbolGraph=*/false, /*CancelOnSubsequentRequest=*/true, ArgsForSlow,
+      /*vfsOptions=*/None, [&](const RequestResult<CursorInfoData> &Result) {
+        EXPECT_TRUE(Result.isCancelled());
+        FirstCursorInfoSema.signal();
+      });
+
+  auto Info = getCursor(FastDocName, FastOffset, Args,
+                        /*CancelOnSubsequentRequest=*/true);
+  EXPECT_STREQ("foo", Info.Name.c_str());
+  EXPECT_STREQ("Int", Info.Typename.c_str());
+  EXPECT_EQ(FastOffset, Info.Offset);
+  EXPECT_EQ(strlen("foo"), Info.Length);
+
+  bool expired = FirstCursorInfoSema.wait(30 * 1000);
+  if (expired)
+    llvm::report_fatal_error("Did not receive a resonse for the first request");
 }


### PR DESCRIPTION
This commit refactors the way ASTs are being built in SourceKit and how `SwiftASTConsumer`s are served by the built ASTs. `SwiftASTManager.h` should give an overview of the new design.

This commit does not change the cancellation paradigm in SourceKit (yet). That is, subsequent requests with the same `OncePerASTToken` still cancel previous requests with the same token. But while previously, we were only able to cancel requests that haven’t started an AST build yet, we can now also cancel the AST build of the to-be-cancelled requests.

With this change in place, we can start looking into explicit cancellation of requests or other cancellation paradigms.

rdar://83391478