### PR TITLE
[SILGen] Fixed handler formal arg type indexing.

### DIFF
--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -408,6 +408,15 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
             continue;
           paramIndices.push_back(index);
         }
+        auto blockParamIndex = [paramIndices](unsigned long i) {
+          // The non-error, non-flag block parameter (formal types of the
+          // completion handler's arguments) indices are the same as the the
+          // parameter (lowered types of the completion handler's arguments)
+          // indices but shifted by 1 corresponding to the fact that the lowered
+          // completion handler has a block_storage argument but the formal type
+          // does not.
+          return paramIndices[i] - 1;
+        };
         if (auto resumeTuple = dyn_cast<TupleType>(resumeType)) {
           assert(paramIndices.size() == resumeTuple->getNumElements());
           assert(params.size() == resumeTuple->getNumElements()
@@ -421,7 +430,8 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
                 F->mapTypeIntoContext(resumeTuple.getElementTypes()[i])
                     ->getCanonicalType(),
                 /*arg*/ params[paramIndices[i]],
-                /*argFormalType*/ blockParams[i].getParameterType());
+                /*argFormalType*/
+                blockParams[blockParamIndex(i)].getParameterType());
           }
         } else {
           assert(paramIndices.size() == 1);
@@ -430,7 +440,8 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
                           /*destFormalType*/
                           F->mapTypeIntoContext(resumeType)->getCanonicalType(),
                           /*arg*/ params[paramIndices[0]],
-                          /*argFormalType*/ blockParams[0].getParameterType());
+                          /*argFormalType*/
+                          blockParams[blockParamIndex(0)].getParameterType());
         }
         
         // Resume the continuation with the composed bridged result.

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -84,6 +84,10 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
 -(void)asyncImportSame:(NSString *)operation replyTo:(void (^)(NSInteger))handler __attribute__((swift_async(none)));
 
 -(void)overridableButRunsOnMainThreadWithCompletionHandler:(MAIN_ACTOR_UNSAFE void (^ _Nullable)(NSString *))completion;
+- (void)obtainClosureWithCompletionHandler:(void (^)(void (^_Nullable)(void),
+                                                     NSError *_Nullable,
+                                                     BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
 @end
 
 @protocol RefrigeratorDelegate<NSObject>

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -85,6 +85,8 @@ func testSlowServer(slowServer: SlowServer) async throws {
   let _: ((Any) -> Void, (Any) -> Void) = await slowServer.performId2VoidId2Void()
 
   let _: String = try await slowServer.findAnswerFailingly()
+
+  let _: () -> Void = try await slowServer.obtainClosure()
 }
 
 func testGeneric<T: AnyObject>(x: GenericObject<T>) async throws {

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807.h
@@ -1,0 +1,29 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+@interface PFXObject : NSObject {
+}
+- (void)continuePassSyncWithCompletionHandler:(void (^)(void (^_Nullable)(void),
+                                                        NSError *_Nullable,
+                                                        BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)continuePassAsyncWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)continueFailSyncWithCompletionHandler:(void (^)(void (^_Nullable)(void),
+                                                        NSError *_Nullable,
+                                                        BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)continueFailAsyncWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)continueIncorrectWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807.m
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807.m
@@ -1,0 +1,54 @@
+#include "rdar81590807.h"
+
+#pragma clang assume_nonnull begin
+
+@implementation PFXObject
+- (void)continuePassSyncWithCompletionHandler:(void (^)(void (^_Nullable)(void),
+                                                        NSError *_Nullable,
+                                                        BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  completionHandler(
+      ^{
+        NSLog(@"passSync");
+      },
+      NULL, YES);
+}
+- (void)continuePassAsyncWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    completionHandler(
+        ^{
+          NSLog(@"passAsync");
+        },
+        NULL, YES);
+  });
+}
+- (void)continueFailSyncWithCompletionHandler:(void (^)(void (^_Nullable)(void),
+                                                        NSError *_Nullable,
+                                                        BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  completionHandler(
+      NULL, [NSError errorWithDomain:@"failSync" code:1 userInfo:nil], NO);
+}
+- (void)continueFailAsyncWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    completionHandler(
+        NULL, [NSError errorWithDomain:@"failAsync" code:2 userInfo:nil], NO);
+  });
+}
+- (void)continueIncorrectWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    completionHandler(NULL, NULL, NO);
+  });
+}
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807_2.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807_2.h
@@ -1,0 +1,24 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+@interface PFXObject : NSObject {
+}
+- (void)findAnswerSyncSuccessAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerSyncSuccess(completionHandler:)")));
+- (void)findAnswerAsyncSuccessAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerAsyncSuccess(completionHandler:)")));
+- (void)findAnswerSyncFailAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerSyncFail(completionHandler:)")));
+- (void)findAnswerAsyncFailAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerAsyncFail(completionHandler:)")));
+- (void)findAnswerIncorrectAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerIncorrect(completionHandler:)")));
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807_2.m
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807_2.m
@@ -1,0 +1,37 @@
+#include "rdar81590807_2.h"
+
+#pragma clang assume_nonnull begin
+
+@implementation PFXObject
+- (void)findAnswerSyncSuccessAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerSyncSuccess(completionHandler:)"))) {
+  handler(@"syncSuccess", NULL);
+}
+- (void)findAnswerAsyncSuccessAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerAsyncSuccess(completionHandler:)"))) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    handler(@"asyncSuccess", NULL);
+  });
+}
+- (void)findAnswerSyncFailAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerSyncFail(completionHandler:)"))) {
+  handler(NULL, [NSError errorWithDomain:@"syncFail" code:1 userInfo:nil]);
+}
+- (void)findAnswerAsyncFailAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerAsyncFail(completionHandler:)"))) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    handler(NULL, [NSError errorWithDomain:@"asyncFail" code:2 userInfo:nil]);
+  });
+}
+- (void)findAnswerIncorrectAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerIncorrect(completionHandler:)"))) {
+  handler(NULL, NULL);
+}
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar81617749.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar81617749.h
@@ -1,0 +1,123 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+typedef void (^CompletionHandler)(void);
+
+@interface PFXObject : NSObject
+- (void)performSingleFlaggy1WithCompletionHandler:
+    (void (^)(BOOL, CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1)));
+- (void)performSingleFlaggy2WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2)));
+
+- (void)performSingleErrory1WithCompletionHandler:
+    (void (^)(NSError *_Nullable,
+              CompletionHandler _Nullable))completionHandler;
+- (void)performSingleErrory2WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable,
+              NSError *_Nullable))completionHandler;
+
+- (void)performSingleBothy12WithCompletionHandler:
+    (void (^)(NSError *_Nullable, BOOL,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2)));
+- (void)performSingleBothy13WithCompletionHandler:
+    (void (^)(NSError *_Nullable, CompletionHandler _Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)performSingleBothy21WithCompletionHandler:
+    (void (^)(BOOL, NSError *_Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1)));
+- (void)performSingleBothy23WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)performSingleBothy31WithCompletionHandler:
+    (void (^)(BOOL, CompletionHandler _Nullable,
+              NSError *_Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1)));
+- (void)performSingleBothy32WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, BOOL,
+              NSError *_Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2)));
+
+- (void)performDoubleFlaggy1WithCompletionHandler:
+    (void (^)(BOOL, CompletionHandler _Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1)));
+- (void)performDoubleFlaggy2WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, BOOL,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2)));
+- (void)performDoubleFlaggy3WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, CompletionHandler _Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+
+- (void)performDoubleErrory1WithCompletionHandler:
+    (void (^)(NSError *_Nullable, CompletionHandler _Nullable,
+              CompletionHandler _Nullable))completionHandler;
+- (void)performDoubleErrory2WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, NSError *_Nullable,
+              CompletionHandler _Nullable))completionHandler;
+- (void)performDoubleErrory3WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, CompletionHandler _Nullable,
+              NSError *_Nullable))completionHandler;
+
+- (void)performDoubleBothy12WithCompletionHandler:
+    (void (^)(NSError *_Nullable, BOOL, CompletionHandler _Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2)));
+- (void)performDoubleBothy13WithCompletionHandler:
+    (void (^)(NSError *_Nullable, CompletionHandler _Nullable, BOOL,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)performDoubleBothy14WithCompletionHandler:
+    (void (^)(NSError *_Nullable, CompletionHandler _Nullable,
+              CompletionHandler _Nullable, BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 4)));
+
+- (void)performDoubleBothy21WithCompletionHandler:
+    (void (^)(BOOL, NSError *_Nullable, CompletionHandler _Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1)));
+- (void)performDoubleBothy23WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, NSError *_Nullable, BOOL,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)performDoubleBothy24WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, NSError *_Nullable,
+              CompletionHandler _Nullable, BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 4)));
+
+- (void)performDoubleBothy31WithCompletionHandler:
+    (void (^)(BOOL, CompletionHandler _Nullable, NSError *_Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1)));
+- (void)performDoubleBothy32WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, BOOL, NSError *_Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2)));
+- (void)performDoubleBothy34WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, CompletionHandler _Nullable,
+              NSError *_Nullable, BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 4)));
+
+- (void)performDoubleBothy41WithCompletionHandler:
+    (void (^)(BOOL, CompletionHandler _Nullable, CompletionHandler _Nullable,
+              NSError *_Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1)));
+- (void)performDoubleBothy42WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, BOOL, CompletionHandler _Nullable,
+              NSError *_Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2)));
+- (void)performDoubleBothy43WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, CompletionHandler _Nullable, BOOL,
+              NSError *_Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar81617749.m
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar81617749.m
@@ -1,0 +1,343 @@
+#include "rdar81617749.h"
+
+#pragma clang assume_nonnull begin
+
+@implementation PFXObject
+- (void)performSingleFlaggy1WithCompletionHandler:
+    (void (^)(BOOL, CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1))) {
+  completionHandler(YES, ^{
+    fprintf(stdout, "%s\n", "performSingleFlaggy1");
+  });
+}
+- (void)performSingleFlaggy2WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performSingleFlaggy2");
+      },
+      YES);
+}
+
+- (void)performSingleErrory1WithCompletionHandler:
+    (void (^)(NSError *_Nullable,
+              CompletionHandler _Nullable))completionHandler {
+  completionHandler(NULL, ^{
+    fprintf(stdout, "%s\n", "performSingleErrory1");
+  });
+}
+- (void)performSingleErrory2WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable,
+              NSError *_Nullable))completionHandler {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performSingleErrory2");
+      },
+      NULL);
+}
+
+- (void)performSingleBothy12WithCompletionHandler:
+    (void (^)(NSError *_Nullable, BOOL,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2))) {
+  completionHandler(NULL, YES, ^{
+    fprintf(stdout, "%s\n", "performSingleBothy12");
+  });
+}
+- (void)performSingleBothy13WithCompletionHandler:
+    (void (^)(NSError *_Nullable, CompletionHandler _Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  completionHandler(
+      NULL,
+      ^{
+        fprintf(stdout, "%s\n", "performSingleBothy13");
+      },
+      YES);
+}
+- (void)performSingleBothy21WithCompletionHandler:
+    (void (^)(BOOL, NSError *_Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1))) {
+  completionHandler(YES, NULL, ^{
+    fprintf(stdout, "%s\n", "performSingleBothy21");
+  });
+}
+- (void)performSingleBothy23WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performSingleBothy23");
+      },
+      NULL, YES);
+}
+- (void)performSingleBothy31WithCompletionHandler:
+    (void (^)(BOOL, CompletionHandler _Nullable,
+              NSError *_Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1))) {
+  completionHandler(
+      YES,
+      ^{
+        fprintf(stdout, "%s\n", "performSingleBothy31");
+      },
+      NULL);
+}
+- (void)performSingleBothy32WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, BOOL,
+              NSError *_Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performSingleBothy32");
+      },
+      YES, NULL);
+}
+
+- (void)performDoubleFlaggy1WithCompletionHandler:
+    (void (^)(BOOL, CompletionHandler _Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1))) {
+  completionHandler(
+      YES,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleFlaggy1, part 1");
+      },
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleFlaggy1, part 2");
+      });
+}
+- (void)performDoubleFlaggy2WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, BOOL,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleFlaggy2, part 1");
+      },
+      YES,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleFlaggy2, part 2");
+      });
+}
+- (void)performDoubleFlaggy3WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, CompletionHandler _Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleFlaggy3, part 1");
+      },
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleFlaggy3, part 2");
+      },
+      YES);
+}
+
+- (void)performDoubleErrory1WithCompletionHandler:
+    (void (^)(NSError *_Nullable, CompletionHandler _Nullable,
+              CompletionHandler _Nullable))completionHandler {
+  completionHandler(
+      NULL,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleErrory1, part 1");
+      },
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleErrory1, part 2");
+      });
+}
+- (void)performDoubleErrory2WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, NSError *_Nullable,
+              CompletionHandler _Nullable))completionHandler {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleErrory2, part 1");
+      },
+      NULL,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleErrory2, part 2");
+      });
+}
+- (void)performDoubleErrory3WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, CompletionHandler _Nullable,
+              NSError *_Nullable))completionHandler {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleErrory3, part 1");
+      },
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleErrory3, part 2");
+      },
+      NULL);
+}
+
+- (void)performDoubleBothy12WithCompletionHandler:
+    (void (^)(NSError *_Nullable, BOOL, CompletionHandler _Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2))) {
+  completionHandler(
+      NULL, YES,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy12, part 1");
+      },
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy12, part 2");
+      });
+}
+- (void)performDoubleBothy13WithCompletionHandler:
+    (void (^)(NSError *_Nullable, CompletionHandler _Nullable, BOOL,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  completionHandler(
+      NULL,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy13, part 1");
+      },
+      YES,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy13, part 2");
+      });
+}
+- (void)performDoubleBothy14WithCompletionHandler:
+    (void (^)(NSError *_Nullable, CompletionHandler _Nullable,
+              CompletionHandler _Nullable, BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 4))) {
+  completionHandler(
+      NULL,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy14, part 1");
+      },
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy14, part 2");
+      },
+      YES);
+}
+
+- (void)performDoubleBothy21WithCompletionHandler:
+    (void (^)(BOOL, NSError *_Nullable, CompletionHandler _Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1))) {
+  completionHandler(
+      YES, NULL,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy21, part 1");
+      },
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy21, part 2");
+      });
+}
+- (void)performDoubleBothy23WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, NSError *_Nullable, BOOL,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy23, part 1");
+      },
+      NULL, YES,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy23, part 2");
+      });
+}
+- (void)performDoubleBothy24WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, NSError *_Nullable,
+              CompletionHandler _Nullable, BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 4))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy24, part 1");
+      },
+      NULL,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy24, part 2");
+      },
+      YES);
+}
+
+- (void)performDoubleBothy31WithCompletionHandler:
+    (void (^)(BOOL, CompletionHandler _Nullable, NSError *_Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1))) {
+  completionHandler(
+      YES,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy31, part 1");
+      },
+      NULL,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy31, part 2");
+      });
+}
+- (void)performDoubleBothy32WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, BOOL, NSError *_Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy32, part 1");
+      },
+      YES, NULL,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy32, part 2");
+      });
+}
+- (void)performDoubleBothy34WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, CompletionHandler _Nullable,
+              NSError *_Nullable, BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 4))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy34, part 1");
+      },
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy34, part 2");
+      },
+      NULL, YES);
+}
+
+- (void)performDoubleBothy41WithCompletionHandler:
+    (void (^)(BOOL, CompletionHandler _Nullable, CompletionHandler _Nullable,
+              NSError *_Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1))) {
+  completionHandler(
+      YES,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy41, part 1");
+      },
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy41, part 2");
+      },
+      NULL);
+}
+- (void)performDoubleBothy42WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, BOOL, CompletionHandler _Nullable,
+              NSError *_Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy42, part 1");
+      },
+      YES,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy42, part 2");
+      },
+      NULL);
+}
+- (void)performDoubleBothy43WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, CompletionHandler _Nullable, BOOL,
+              NSError *_Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy43, part 1");
+      },
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy43, part 2");
+      },
+      YES, NULL);
+}
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/rdar81590807.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar81590807.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar81590807.m -I %S/Inputs -c -o %t/rdar81590807.o
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar81590807.h -Xlinker %t/rdar81590807.o -parse-as-library %s -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main > %t/log 2>&1 || true
+// RUN: %FileCheck %s < %t/log
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=ios
+
+func run(on object: PFXObject) async throws {
+  // CHECK: passSync
+  let cl1 = try await object.continuePassSync()
+  cl1()
+  // CHECK: passAsync
+  let cl2 = try await object.continuePassAsync()
+  cl2()
+  do {
+    let cl = try await object.continueFailSync()
+    // CHECK-NOT: oh no failSync
+    fputs("oh no failSync\n", stderr)
+  }
+  catch let error {
+    // CHECK: Error Domain=failSync Code=1 "(null)"
+    fputs("\(error)\n", stderr)
+  }
+  do {
+    let cl = try await object.continueFailAsync()
+    // CHECK-NOT: oh no failAsync
+    fputs("oh no failAsync\n", stderr)
+  }
+  catch let error {
+    // CHECK: Error Domain=failAsync Code=2 "(null)"
+    fputs("\(error)\n", stderr)
+  }
+  // CHECK: Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value
+  print(try await object.continueIncorrect())
+}
+
+@main struct Main {
+  static func main() async throws {
+    let object = PFXObject()
+    try await run(on: object)
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar81590807_2.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar81590807_2.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar81590807_2.m -I %S/Inputs -c -o %t/rdar81590807_2.o
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar81590807_2.h -Xlinker %t/rdar81590807_2.o -parse-as-library %s -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=ios
+
+func run(on object: PFXObject) async throws {
+  // CHECK: syncSuccess
+  print("\(try await object.findAnswerSyncSuccess())\n")
+  // CHECK: asyncSuccess
+  print("\(try await object.findAnswerAsyncSuccess())\n")
+  do {
+    try await object.findAnswerSyncFail()
+    // CHECK-NOT: oh no syncFail
+    print("\("oh no syncFail")\n")
+  }
+  catch let error {
+    // CHECK: Error Domain=syncFail Code=1 "(null)"
+    print("\(error)\n")
+  }
+  do {
+    try await object.findAnswerAsyncFail()
+    // CHECK-NOT: oh no asyncFail
+    print("\("oh no asyncFail")\n")
+  }
+  catch let error {
+    // CHECK: Error Domain=asyncFail Code=2 "(null)"
+    print("\(error)\n")
+  }
+  // CHECK: <<>>
+  print("<<\(try await object.findAnswerIncorrect())>>\n")
+}
+
+@main struct Main {
+  static func main() async throws {
+    let object = PFXObject()
+    try await run(on: object)
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar81617749.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar81617749.swift
@@ -1,0 +1,141 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar81617749.m -I %S/Inputs -c -o %t/rdar81617749.o
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar81617749.h -Xlinker %t/rdar81617749.o -parse-as-library %s -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// Enable with rdar://81617749
+// UNSUPPORTED: CPU=i386 && OS=watchos
+
+func run(on object: PFXObject) async throws {
+  // CHECK: performSingleFlaggy1
+  print(try await object.performSingleFlaggy1()?())
+  // CHECK: performSingleFlaggy2
+  print(try await object.performSingleFlaggy2()?())
+  // CHECK: performSingleErrory1
+  print(try await object.performSingleErrory1()())
+  // CHECK: performSingleErrory2
+  print(try await object.performSingleErrory2()())
+
+  // CHECK: performSingleBothy12
+  print(try await object.performSingleBothy12()())
+  // CHECK: performSingleBothy13
+  print(try await object.performSingleBothy13()())
+
+  // Reenable with rdar://81625544
+  // CHECK  performSingleBothy21
+  //  print(try await object.performSingleBothy21()())
+  
+  // CHECK: performSingleBothy23
+  print(try await object.performSingleBothy23()())
+  // CHECK: performSingleBothy31
+  print(try await object.performSingleBothy31()())
+  // CHECK: performSingleBothy32
+  print(try await object.performSingleBothy32()())
+
+  // CHECK: performDoubleFlaggy1, part 1
+  // CHECK: performDoubleFlaggy1, part 2
+  let rFlaggy1 = try await object.performDoubleFlaggy1()
+  rFlaggy1.0?()
+  rFlaggy1.1?()
+  // CHECK: performDoubleFlaggy2, part 1
+  // CHECK: performDoubleFlaggy2, part 2
+  let rFlaggy2 = try await object.performDoubleFlaggy2()
+  rFlaggy2.0?()
+  rFlaggy2.1?()
+  // CHECK: performDoubleFlaggy3, part 1
+  // CHECK: performDoubleFlaggy3, part 2
+  let rFlaggy3 = try await object.performDoubleFlaggy3()
+  rFlaggy3.0?()
+  rFlaggy3.1?()
+
+  // CHECK: performDoubleErrory1, part 1
+  // CHECK: performDoubleErrory1, part 2
+  let rErrory1 = try await object.performDoubleErrory1()
+  rErrory1.0()
+  rErrory1.1()
+  // CHECK: performDoubleErrory2, part 1
+  // CHECK: performDoubleErrory2, part 2
+  let rErrory2 = try await object.performDoubleErrory2()
+  rErrory2.0()
+  rErrory2.1()
+  // CHECK: performDoubleErrory3, part 1
+  // CHECK: performDoubleErrory3, part 2
+  let rErrory3 = try await object.performDoubleErrory3()
+  rErrory3.0()
+  rErrory3.1()
+
+  // CHECK: performDoubleBothy12, part 1
+  // CHECK: performDoubleBothy12, part 2
+  let rBothy12 = try await object.performDoubleBothy12()
+  rBothy12.0()
+  rBothy12.1()
+  // CHECK: performDoubleBothy13, part 1
+  // CHECK: performDoubleBothy13, part 2
+  let rBothy13 = try await object.performDoubleBothy13()
+  rBothy13.0()
+  rBothy13.1()
+  // CHECK: performDoubleBothy14, part 1
+  // CHECK: performDoubleBothy14, part 2
+  let rBothy14 = try await object.performDoubleBothy14()
+  rBothy14.0()
+  rBothy14.1()
+
+  // CHECK: performDoubleBothy21, part 1
+  // CHECK: performDoubleBothy21, part 2
+  let rBothy21 = try await object.performDoubleBothy21()
+  rBothy21.0()
+  rBothy21.1()
+  // CHECK: performDoubleBothy23, part 1
+  // CHECK: performDoubleBothy23, part 2
+  let rBothy23 = try await object.performDoubleBothy23()
+  rBothy23.0()
+  rBothy23.1()
+  // CHECK: performDoubleBothy24, part 1
+  // CHECK: performDoubleBothy24, part 2
+  let rBothy24 = try await object.performDoubleBothy24()
+  rBothy24.0()
+  rBothy24.1()
+
+  // CHECK: performDoubleBothy31, part 1
+  // CHECK: performDoubleBothy31, part 2
+  let rBothy31 = try await object.performDoubleBothy31()
+  rBothy31.0()
+  rBothy31.1()
+  // CHECK: performDoubleBothy32, part 1
+  // CHECK: performDoubleBothy32, part 2
+  let rBothy32 = try await object.performDoubleBothy32()
+  rBothy32.0()
+  rBothy32.1()
+  // CHECK: performDoubleBothy34, part 1
+  // CHECK: performDoubleBothy34, part 2
+  let rBothy34 = try await object.performDoubleBothy34()
+  rBothy34.0()
+  rBothy34.1()
+
+  // CHECK: performDoubleBothy41, part 1
+  // CHECK: performDoubleBothy41, part 2
+  let rBothy41 = try await object.performDoubleBothy41()
+  rBothy41.0()
+  rBothy41.1()
+  // CHECK: performDoubleBothy42, part 1
+  // CHECK: performDoubleBothy42, part 2
+  let rBothy42 = try await object.performDoubleBothy42()
+  rBothy42.0()
+  rBothy42.1()
+  // CHECK: performDoubleBothy43, part 1
+  // CHECK: performDoubleBothy43, part 2
+  let rBothy43 = try await object.performDoubleBothy43()
+  rBothy43.0()
+  rBothy43.1()
+}
+
+@main struct Main {
+  static func main() async throws {
+    let object = PFXObject()
+    try await run(on: object)
+  }
+}


### PR DESCRIPTION
In the synthesized completion handler that is passed to ObjC methods that are called as async, the formal type of each argument is the corresponding parameter of the formal type of the block.  The non-error, non-index arguments need to be prepared so that they can be used to fulfill the continuation; the lambda which does that preparation for each such argument takes the formal type of that argument.  As such, the call to that lambda needs to pass the type of the corresponding parameter of the formal type of the block to that lambda.  Doing so entails skipping over the error and flag parameters if they appear before some of the non-error, non-index arguments.

Previously, no parameters were skipped over.  Consequently, when an error or flag argument preceded one of the non-error, non-index arguments, the wrong formal type was passed to the preparation lambda.

Here, that is fixed by passing the correct index.  The to-be-used indices for the formal block parameters are the same as the to-be-used indices for the lowered block parameters minus one reflecting the fact that the lowered block always has an initial block_storage parameter as the first argument which the formal type never has.

Based on https://github.com/apple/swift/pull/38773 .

rdar://81617749
