### PR TITLE
[Test] Added for call-as-async Optional<NS_EXTENSIBLE_STRING_ENUM>.

### DIFF
--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -6,6 +6,9 @@
 #define MAIN_ACTOR __attribute__((__swift_attr__("@MainActor")))
 #define MAIN_ACTOR_UNSAFE __attribute__((__swift_attr__("@_unsafeMainActor")))
 
+#define NS_EXTENSIBLE_STRING_ENUM __attribute__((swift_wrapper(struct)));
+typedef NSString *Flavor NS_EXTENSIBLE_STRING_ENUM;
+
 @protocol ServiceProvider
 @property(readonly) NSArray<NSString *> *allOperations;
 -(void)allOperationsWithCompletionHandler:(void (^)(NSArray<NSString *> *))completion;
@@ -88,6 +91,8 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
                                                      NSError *_Nullable,
                                                      BOOL))completionHandler
     __attribute__((swift_async_error(zero_argument, 3)));
+- (void)getIceCreamFlavorWithCompletionHandler:
+    (void (^)(Flavor flavor, NSError *__nullable error))completionHandler;
 @end
 
 @protocol RefrigeratorDelegate<NSObject>

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -84,6 +84,10 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
 -(void)asyncImportSame:(NSString *)operation replyTo:(void (^)(NSInteger))handler __attribute__((swift_async(none)));
 
 -(void)overridableButRunsOnMainThreadWithCompletionHandler:(MAIN_ACTOR_UNSAFE void (^ _Nullable)(NSString *))completion;
+- (void)obtainClosureWithCompletionHandler:(void (^)(void (^_Nullable)(void),
+                                                     NSError *_Nullable,
+                                                     BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
 @end
 
 @protocol RefrigeratorDelegate<NSObject>

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -87,6 +87,8 @@ func testSlowServer(slowServer: SlowServer) async throws {
   let _: String = try await slowServer.findAnswerFailingly()
 
   let _: () -> Void = try await slowServer.obtainClosure()
+
+  let _: Flavor = try await slowServer.iceCreamFlavor()
 }
 
 func testGeneric<T: AnyObject>(x: GenericObject<T>) async throws {

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -85,6 +85,8 @@ func testSlowServer(slowServer: SlowServer) async throws {
   let _: ((Any) -> Void, (Any) -> Void) = await slowServer.performId2VoidId2Void()
 
   let _: String = try await slowServer.findAnswerFailingly()
+
+  let _: () -> Void = try await slowServer.obtainClosure()
 }
 
 func testGeneric<T: AnyObject>(x: GenericObject<T>) async throws {

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704382.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704382.h
@@ -1,0 +1,25 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+typedef NSString *FileProviderItemIdentifier NS_EXTENSIBLE_STRING_ENUM;
+FileProviderItemIdentifier const
+    FileProviderRootContainerItemIdentifier NS_SWIFT_NAME(FileProviderItemIdentifier.rootContainer);
+FileProviderItemIdentifier const
+    FileProviderWorkingSetContainerItemIdentifier NS_SWIFT_NAME(FileProviderItemIdentifier.workingSet);
+FileProviderItemIdentifier const
+    FileProviderTrashContainerItemIdentifier NS_SWIFT_NAME(FileProviderItemIdentifier.trashContainer);
+typedef NSString *FileProviderDomainIdentifier NS_EXTENSIBLE_STRING_ENUM;
+
+@interface PFXObject : NSObject
++ (void)getIdentifierForUserVisibleFileAtURL:(NSURL *)url
+                           completionHandler:
+                               (void (^)(FileProviderItemIdentifier __nullable
+                                             itemIdentifier,
+                                         FileProviderDomainIdentifier __nullable
+                                             domainIdentifier,
+                                         NSError *__nullable error))
+                                   completionHandler;
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704382.m
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704382.m
@@ -1,0 +1,23 @@
+#include "rdar80704382.h"
+
+#pragma clang assume_nonnull begin
+
+@implementation PFXObject
+- (instancetype)init {
+  if (self = [super init]) {
+  }
+  return self;
+}
++ (void)getIdentifierForUserVisibleFileAtURL:(NSURL *)url
+                           completionHandler:
+                               (void (^)(FileProviderItemIdentifier __nullable
+                                             itemIdentifier,
+                                         FileProviderDomainIdentifier __nullable
+                                             domainIdentifier,
+                                         NSError *__nullable error))
+                                   completionHandler {
+  completionHandler(@"item_id", @"file_id", NULL);
+}
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807.h
@@ -1,0 +1,29 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+@interface PFXObject : NSObject {
+}
+- (void)continuePassSyncWithCompletionHandler:(void (^)(void (^_Nullable)(void),
+                                                        NSError *_Nullable,
+                                                        BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)continuePassAsyncWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)continueFailSyncWithCompletionHandler:(void (^)(void (^_Nullable)(void),
+                                                        NSError *_Nullable,
+                                                        BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)continueFailAsyncWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)continueIncorrectWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807.m
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807.m
@@ -1,0 +1,54 @@
+#include "rdar81590807.h"
+
+#pragma clang assume_nonnull begin
+
+@implementation PFXObject
+- (void)continuePassSyncWithCompletionHandler:(void (^)(void (^_Nullable)(void),
+                                                        NSError *_Nullable,
+                                                        BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  completionHandler(
+      ^{
+        NSLog(@"passSync");
+      },
+      NULL, YES);
+}
+- (void)continuePassAsyncWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    completionHandler(
+        ^{
+          NSLog(@"passAsync");
+        },
+        NULL, YES);
+  });
+}
+- (void)continueFailSyncWithCompletionHandler:(void (^)(void (^_Nullable)(void),
+                                                        NSError *_Nullable,
+                                                        BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  completionHandler(
+      NULL, [NSError errorWithDomain:@"failSync" code:1 userInfo:nil], NO);
+}
+- (void)continueFailAsyncWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    completionHandler(
+        NULL, [NSError errorWithDomain:@"failAsync" code:2 userInfo:nil], NO);
+  });
+}
+- (void)continueIncorrectWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    completionHandler(NULL, NULL, NO);
+  });
+}
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807_2.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807_2.h
@@ -1,0 +1,24 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+@interface PFXObject : NSObject {
+}
+- (void)findAnswerSyncSuccessAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerSyncSuccess(completionHandler:)")));
+- (void)findAnswerAsyncSuccessAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerAsyncSuccess(completionHandler:)")));
+- (void)findAnswerSyncFailAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerSyncFail(completionHandler:)")));
+- (void)findAnswerAsyncFailAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerAsyncFail(completionHandler:)")));
+- (void)findAnswerIncorrectAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerIncorrect(completionHandler:)")));
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807_2.m
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807_2.m
@@ -1,0 +1,37 @@
+#include "rdar81590807_2.h"
+
+#pragma clang assume_nonnull begin
+
+@implementation PFXObject
+- (void)findAnswerSyncSuccessAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerSyncSuccess(completionHandler:)"))) {
+  handler(@"syncSuccess", NULL);
+}
+- (void)findAnswerAsyncSuccessAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerAsyncSuccess(completionHandler:)"))) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    handler(@"asyncSuccess", NULL);
+  });
+}
+- (void)findAnswerSyncFailAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerSyncFail(completionHandler:)"))) {
+  handler(NULL, [NSError errorWithDomain:@"syncFail" code:1 userInfo:nil]);
+}
+- (void)findAnswerAsyncFailAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerAsyncFail(completionHandler:)"))) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    handler(NULL, [NSError errorWithDomain:@"asyncFail" code:2 userInfo:nil]);
+  });
+}
+- (void)findAnswerIncorrectAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerIncorrect(completionHandler:)"))) {
+  handler(NULL, NULL);
+}
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/rdar80704382.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar80704382.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar80704382.m -I %S/Inputs -c -o %t/rdar80704382.o
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar80704382.h -Xlinker %t/rdar80704382.o -parse-as-library %s -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+func run() async throws {
+  // CHECK: item_id
+  // CHECK: file_id
+  print(try await PFXObject.identifierForUserVisibleFile(at: URL(fileURLWithPath: "/tmp/file")))
+}
+
+@main struct Main {
+  static func main() async throws {
+    try await run()
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar81590807.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar81590807.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar81590807.m -I %S/Inputs -c -o %t/rdar81590807.o
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar81590807.h -Xlinker %t/rdar81590807.o -parse-as-library %s -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main > %t/log 2>&1 || true
+// RUN: %FileCheck %s < %t/log
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=ios
+
+func run(on object: PFXObject) async throws {
+  // CHECK: passSync
+  let cl1 = try await object.continuePassSync()
+  cl1()
+  // CHECK: passAsync
+  let cl2 = try await object.continuePassAsync()
+  cl2()
+  do {
+    let cl = try await object.continueFailSync()
+    // CHECK-NOT: oh no failSync
+    fputs("oh no failSync\n", stderr)
+  }
+  catch let error {
+    // CHECK: Error Domain=failSync Code=1 "(null)"
+    fputs("\(error)\n", stderr)
+  }
+  do {
+    let cl = try await object.continueFailAsync()
+    // CHECK-NOT: oh no failAsync
+    fputs("oh no failAsync\n", stderr)
+  }
+  catch let error {
+    // CHECK: Error Domain=failAsync Code=2 "(null)"
+    fputs("\(error)\n", stderr)
+  }
+  // CHECK: Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value
+  print(try await object.continueIncorrect())
+}
+
+@main struct Main {
+  static func main() async throws {
+    let object = PFXObject()
+    try await run(on: object)
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar81590807_2.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar81590807_2.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar81590807_2.m -I %S/Inputs -c -o %t/rdar81590807_2.o
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar81590807_2.h -Xlinker %t/rdar81590807_2.o -parse-as-library %s -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=ios
+
+func run(on object: PFXObject) async throws {
+  // CHECK: syncSuccess
+  print("\(try await object.findAnswerSyncSuccess())\n")
+  // CHECK: asyncSuccess
+  print("\(try await object.findAnswerAsyncSuccess())\n")
+  do {
+    try await object.findAnswerSyncFail()
+    // CHECK-NOT: oh no syncFail
+    print("\("oh no syncFail")\n")
+  }
+  catch let error {
+    // CHECK: Error Domain=syncFail Code=1 "(null)"
+    print("\(error)\n")
+  }
+  do {
+    try await object.findAnswerAsyncFail()
+    // CHECK-NOT: oh no asyncFail
+    print("\("oh no asyncFail")\n")
+  }
+  catch let error {
+    // CHECK: Error Domain=asyncFail Code=2 "(null)"
+    print("\(error)\n")
+  }
+  // CHECK: <<>>
+  print("<<\(try await object.findAnswerIncorrect())>>\n")
+}
+
+@main struct Main {
+  static func main() async throws {
+    let object = PFXObject()
+    try await run(on: object)
+  }
+}


### PR DESCRIPTION
The underlying problem was fixed by the change for rdar://81590807 .  Add tests
for the specific case that was originally reported.

Requires https://github.com/apple/swift/pull/38773 .

rdar://80704382
