### PR TITLE
[Property Wrappers] Improve Error Message to include var wrappedValue:<#Value#>" fix when declaring a new property wrapper

### DIFF
--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -54,9 +54,13 @@ static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
   switch (vars.size()) {
   case 0:
     if (!allowMissing) {
+      std::string fixIt = "var wrappedValue: <#Value#>";
+      auto fixitLocation = nominal->getBraces().Start;
       nominal->diagnose(diag::property_wrapper_no_value_property,
-                        nominal->getDeclaredType(), name);
+                        nominal->getDeclaredType(), name)
+        .fixItInsertAfter(fixitLocation, fixIt);
     }
+
     return nullptr;
 
   case 1:

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -58,13 +58,13 @@ struct WrapperAcceptingAutoclosure<T> {
 
 @propertyWrapper
 struct MissingValue<T> { }
-// expected-error@-1{{property wrapper type 'MissingValue' does not contain a non-static property named 'wrappedValue'}} {{educational-notes=property-wrapper-requirements}}
+// expected-error@-1{{property wrapper type 'MissingValue' does not contain a non-static property named 'wrappedValue'}} {{educational-notes=property-wrapper-requirements}}{{25-25=var wrappedValue: <#Value#>}}
 
 @propertyWrapper
 struct StaticValue {
   static var wrappedValue: Int = 17
 }
-// expected-error@-3{{property wrapper type 'StaticValue' does not contain a non-static property named 'wrappedValue'}}
+// expected-error@-3{{property wrapper type 'StaticValue' does not contain a non-static property named 'wrappedValue'}}{{20-20=var wrappedValue: <#Value#>}}
 
 
 // expected-error@+1{{'@propertyWrapper' attribute cannot be applied to this declaration}}

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -64,7 +64,7 @@ struct MissingValue<T> { }
 struct StaticValue {
   static var wrappedValue: Int = 17
 }
-// expected-error@-3{{property wrapper type 'StaticValue' does not contain a non-static property named 'wrappedValue'}}{{20-20=var wrappedValue: <#Value#>}}
+// expected-error@-3{{property wrapper type 'StaticValue' does not contain a non-static property named 'wrappedValue'}}{{21-21=var wrappedValue: <#Value#>}}
 
 
 // expected-error@+1{{'@propertyWrapper' attribute cannot be applied to this declaration}}


### PR DESCRIPTION
[Property Wrappers] Improve Error Message to include var wrappedValue:<#Value#>" fix when declaring a new property wrapper

Resolves: rdar://65045235
