### PR TITLE
Fix an edge case in AccessUseDefChainCloner

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -1590,6 +1590,11 @@ public:
     return cloneProjection(cast, sourceOper);
   }
 
+  SILValue visitNestedAccess(BeginAccessInst *access) {
+    // The cloner does not currently know how to handle begin_access
+    return SILValue();
+  }
+
   SILValue visitAccessProjection(SingleValueInstruction *projectedAddr,
                                  Operand *sourceOper) {
     return cloneProjection(projectedAddr, sourceOper);

--- a/test/SILOptimizer/cse_ossa_nontrivial.sil
+++ b/test/SILOptimizer/cse_ossa_nontrivial.sil
@@ -830,3 +830,32 @@ bb0(%0 : @guaranteed $Klass):
   return %6 : $()
 }
 
+class TestKlass {
+  var testStruct: NonTrivialStruct
+}
+
+sil [ossa] @use_klass : $@convention(thin) (@guaranteed Klass) -> ()
+
+// Currently ownership rauw does not handle this case
+// CHECK-LABEL: sil [ossa] @cse_ossa_accesspathclonetest :
+// CHECK: struct_element_addr
+// CHECK: struct_element_addr
+// CHECK-LABEL: } // end sil function 'cse_ossa_accesspathclonetest'
+sil [ossa] @cse_ossa_accesspathclonetest : $@convention(thin) (@guaranteed TestKlass) -> () {
+bb0(%0 : @guaranteed $TestKlass):
+  %1 = ref_element_addr %0 : $TestKlass, #TestKlass.testStruct
+  %2 = begin_access [modify] [dynamic] %1 : $*NonTrivialStruct
+  %3 = struct_element_addr %2 : $*NonTrivialStruct, #NonTrivialStruct.val
+  %4 = load_borrow %3 : $*Klass
+  %f = function_ref @use_klass : $@convention(thin) (@guaranteed Klass) -> ()
+  %c = apply %f(%4) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %4 : $Klass
+  %3a = struct_element_addr %2 : $*NonTrivialStruct, #NonTrivialStruct.val
+  %4a = load_borrow %3a : $*Klass
+  %ca = apply %f(%4a) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %4a : $Klass
+  end_access %2 : $*NonTrivialStruct
+  %139 = tuple ()
+  return %139 : $()
+}
+


### PR DESCRIPTION
The cloner cannot handle begin_access yet. Handle this case so that `canCloneUseDefChain` does not assert.
