### PR TITLE
Docs: fix a few examples in the C++ interop manifesto

### DIFF
--- a/docs/CppInteroperabilityManifesto.md
+++ b/docs/CppInteroperabilityManifesto.md
@@ -407,13 +407,13 @@ void printInt(const int &value);
 ```swift
 // C++ header imported in Swift.
 
-void printInt(_ value: UnsafePointer<Int>)
+func printInt(_ value: UnsafePointer<Int>)
 ```
 
 ```swift
 // Usage example.
 
-void caller() {
+func caller() {
   var x = 42
   printInt(&x) // OK
 
@@ -450,13 +450,13 @@ void printInt(const int &value);
 ```swift
 // C++ header imported in Swift.
 
-void printInt(_ value: Int)
+func printInt(_ value: Int)
 ```
 
 ```swift
 // Usage example.
 
-void caller() {
+func caller() {
   let x = 42
   printInt(y) // OK
 }


### PR DESCRIPTION
This change fixes a few typos in the code snippets to make them valid in Swift.