### PR TITLE
OSSA support for Box types. AccessedStorage Box handling. isBorrowedAddress utility.

### DIFF
--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -27,10 +27,6 @@ SILValue getUnderlyingObject(SILValue V);
 
 SILValue getUnderlyingObjectStopAtMarkDependence(SILValue V);
 
-/// Given an address look through address to address projections and indexing
-/// insts.
-SILValue getUnderlyingObjectStoppingAtObjectToAddrProjections(SILValue v);
-
 SILValue stripSinglePredecessorArgs(SILValue V);
 
 /// Return the underlying SILValue after stripping off all casts from the

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -485,7 +485,7 @@ public:
   /// This compares only the AccessedStorage base class bits, ignoring the
   /// subclass bits. It is used for hash lookup equality, so it should not
   /// perform any additional lookups or dereference memory outside itself.
-  bool hasIdenticalBase(const AccessedStorage &other) const {
+  bool hasIdenticalStorage(const AccessedStorage &other) const {
     if (getKind() != other.getKind())
       return false;
 
@@ -609,7 +609,7 @@ private:
   template <bool (AccessedStorage::*IsUniqueFn)() const>
   bool isDistinctFrom(const AccessedStorage &other) const {
     if ((this->*IsUniqueFn)()) {
-      if ((other.*IsUniqueFn)() && !hasIdenticalBase(other))
+      if ((other.*IsUniqueFn)() && !hasIdenticalStorage(other))
         return true;
 
       if (other.isObjectAccess())
@@ -706,7 +706,7 @@ template <> struct DenseMapInfo<swift::AccessedStorage> {
   }
 
   static bool isEqual(swift::AccessedStorage LHS, swift::AccessedStorage RHS) {
-    return LHS.hasIdenticalBase(RHS);
+    return LHS.hasIdenticalStorage(RHS);
   }
 };
 
@@ -944,8 +944,9 @@ public:
 
   bool operator==(AccessPath other) const {
     return
-      storage.hasIdenticalBase(other.storage) && pathNode == other.pathNode &&
-      offset == other.offset;
+      storage.hasIdenticalStorage(other.storage)
+      && pathNode == other.pathNode
+      && offset == other.offset;
   }
   bool operator!=(AccessPath other) const { return !(*this == other); }
 
@@ -1220,8 +1221,8 @@ void checkSwitchEnumBlockArg(SILPhiArgument *arg);
 /// This is not a member of AccessedStorage because it only makes sense to use
 /// in SILGen before access markers are emitted, or when verifying access
 /// markers.
-bool isPossibleFormalAccessBase(const AccessedStorage &storage,
-                                SILFunction *F);
+bool isPossibleFormalAccessStorage(const AccessedStorage &storage,
+                                   SILFunction *F);
 
 /// Perform a RAUW operation on begin_access with it's own source operand.
 /// Then erase the begin_access and all associated end_access instructions.

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -44,7 +44,7 @@
 /// 3. getAccessBase(): Find the ultimate base of any address corresponding to
 /// the accessed object, regardless of whether the address is nested within
 /// access scopes, and regardless of any storage casts. This returns either an
-/// address type, pointer type, or box type, but never a reference type.
+/// address or pointer type, but never a reference or box type.
 /// Each object's property or its tail storage is separately accessed.
 ///
 /// For better identification an access base, use
@@ -166,6 +166,11 @@ SILValue getAccessScope(SILValue address);
 /// return the same base address, then they must also have the same storage.
 SILValue getAccessBase(SILValue address);
 
+/// Find the root of a reference, which may be a non-trivial type, box type, or
+/// BridgeObject. This is guaranteed to be consistent with
+/// AccessedStorage::getRoot() and AccessPath::getRoot().
+SILValue findReferenceRoot(SILValue ref);
+
 /// Return true if \p address points to a let-variable.
 ///
 /// let-variables are only written during let-variable initialization, which is
@@ -237,7 +242,8 @@ enum class AccessUseType { Exact, Inner, Overlapping };
 /// represent any arbitrary base address--it must at least been proven not to
 /// correspond to any class or global variable access, unless it's nested within
 /// another access to the same object. So, Unidentified can overlap with
-/// Class/Global access, but it cannot be the only formal access to that memory.
+/// Class/Global access because it was derived from another Class/Global access,
+/// but Unidentified can never be the only formal access to that memory.
 ///
 /// An *invalid* AccessedStorage object is Unidentified and associated with an
 /// invalid SILValue. This signals that analysis has failed to recognize an
@@ -268,7 +274,7 @@ public:
     Global,
     Class,
     Tail,
-    Argument,
+    Argument, // Address or RawPointer argument
     Yield,
     Nested,
     Unidentified,
@@ -280,22 +286,11 @@ public:
   // Give object tail storage a fake large property index for convenience.
   static constexpr unsigned TailIndex = std::numeric_limits<int>::max();
 
-  /// Directly create an AccessedStorage for class or tail property access.
-  static AccessedStorage forClass(SILValue object, unsigned propertyIndex) {
-    AccessedStorage storage;
-    if (propertyIndex == TailIndex)
-      storage.initKind(Tail);
-    else
-      storage.initKind(Class, propertyIndex);
-    storage.value = object;
-    return storage;
-  }
-
   /// Return an AccessedStorage value that best identifies a formally accessed
   /// variable pointed to by \p sourceAddress, looking through any nested
   /// formal accesses to find the underlying storage.
   ///
-  /// \p sourceAddress may be an address, pointer, or box type.
+  /// \p sourceAddress may be an address type or Builtin.RawPointer.
   ///
   /// If \p sourceAddress is within a formal access scope, which does not have
   /// "Unsafe" enforcement, then this always returns valid storage.
@@ -308,7 +303,7 @@ public:
   /// Return an AccessedStorage object that identifies formal access scope that
   /// immediately encloses \p sourceAddress.
   ///
-  /// \p sourceAddress may be an address, pointer, or box type.
+  /// \p sourceAddress may be an address type or Builtin.RawPointer.
   ///
   /// If \p sourceAddress is within a formal access scope, this always returns a
   /// valid "Nested" storage value.
@@ -316,6 +311,14 @@ public:
   /// If \p sourceAddress is not within a formal access scope, then this finds
   /// the formal storage if possible, otherwise returning invalid storage.
   static AccessedStorage computeInScope(SILValue sourceAddress);
+
+  /// Create storage for the tail elements of \p object.
+  static AccessedStorage forObjectTail(SILValue object) {
+    AccessedStorage storage;
+    storage.initKind(Tail, TailIndex);
+    storage.value = findReferenceRoot(object);
+    return storage;
+  }
 
 protected:
   // Checking the storage kind is far more common than other fields. Make sure
@@ -389,7 +392,7 @@ private:
     SILGlobalVariable *global;
   };
 
-  void initKind(Kind k, unsigned elementIndex = InvalidElementIndex) {
+  void initKind(Kind k, unsigned elementIndex) {
     Bits.opaqueBits = 0;
     Bits.AccessedStorage.kind = k;
     Bits.AccessedStorage.elementIndex = elementIndex;
@@ -401,7 +404,7 @@ private:
   }
 
 public:
-  AccessedStorage() : value() { initKind(Unidentified); }
+  AccessedStorage() : value() { initKind(Unidentified, InvalidElementIndex); }
 
   AccessedStorage(SILValue base, Kind kind);
 
@@ -418,6 +421,7 @@ public:
 
   SILValue getValue() const {
     assert(getKind() != Global && getKind() != Class && getKind() != Tail);
+    assert(value && "Invalid storage has an invalid value");
     return value;
   }
 
@@ -436,7 +440,9 @@ public:
     return global;
   }
 
-  bool isReference() const { return getKind() == Class || getKind() == Tail; }
+  bool isReference() const {
+    return getKind() == Box || getKind() == Class || getKind() == Tail;
+  }
 
   SILValue getObject() const {
     assert(isReference());
@@ -445,6 +451,15 @@ public:
   unsigned getPropertyIndex() const {
     assert(getKind() == Class);
     return getElementIndex();
+  }
+
+  /// Return a new AccessedStorage for Class/Tail/Box access based on
+  /// existing storage and a new object.
+  AccessedStorage transformReference(SILValue object) const {
+    AccessedStorage storage;
+    storage.initKind(getKind(), getElementIndex());
+    storage.value = findReferenceRoot(object);
+    return storage;
   }
 
   /// Return the address or reference root that the storage was based
@@ -457,7 +472,7 @@ public:
     case AccessedStorage::Argument:
     case AccessedStorage::Yield:
     case AccessedStorage::Unidentified:
-      return getValue(); // Can be invalid for Unidentified storage.
+      return getValue();
     case AccessedStorage::Global:
       return SILValue();
     case AccessedStorage::Class:
@@ -511,6 +526,7 @@ public:
   bool isLocal() const {
     switch (getKind()) {
     case Box:
+      return isa<AllocBoxInst>(value);
     case Stack:
       return true;
     case Global:
@@ -538,6 +554,7 @@ public:
   bool isUniquelyIdentified() const {
     switch (getKind()) {
     case Box:
+      return isa<AllocBoxInst>(value);
     case Stack:
     case Global:
       return true;
@@ -686,11 +703,14 @@ template <> struct DenseMapInfo<swift::AccessedStorage> {
 
   static unsigned getHashValue(swift::AccessedStorage storage) {
     switch (storage.getKind()) {
+    case swift::AccessedStorage::Unidentified:
+      if (!storage)
+        return DenseMapInfo<swift::SILValue>::getHashValue(swift::SILValue());
+      LLVM_FALLTHROUGH;
     case swift::AccessedStorage::Box:
     case swift::AccessedStorage::Stack:
     case swift::AccessedStorage::Nested:
     case swift::AccessedStorage::Yield:
-    case swift::AccessedStorage::Unidentified:
       return DenseMapInfo<swift::SILValue>::getHashValue(storage.getValue());
     case swift::AccessedStorage::Argument:
       return storage.getParamIndex();
@@ -1008,15 +1028,19 @@ public:
 // recover the def-use chain for a specific global_addr or ref_element_addr.
 struct AccessPathWithBase {
   AccessPath accessPath;
-  // The address-type value that is the base of the formal access. For
-  // class storage, it is the ref_element_addr. For global storage it is the
-  // global_addr or initializer apply. For other storage, it is the same as
-  // accessPath.getRoot().
+  // The address-type value that is the base of the formal access. For class
+  // storage, it is the ref_element_addr; for box storage, the project_box; for
+  // global storage the global_addr or initializer apply. For other
+  // storage, it is the same as accessPath.getRoot().
   //
-  // Note: base may be invalid for global_addr -> address_to_pointer -> phi
-  // patterns, while the accessPath is still valid.
+  // Note: base may be invalid for phi patterns, even though the accessPath is
+  // valid because we don't currently keep track of multiple bases. Multiple
+  // bases for the same storage can happen with global_addr, ref_element_addr,
+  // ref_tail_addr, and project_box.
   //
-  // FIXME: add a structural requirement to SIL so base is always valid in OSSA.
+  // FIXME: add a structural requirement to SIL/OSSA so valid storage has
+  // a single base. For most cases, it is as simple by sinking the
+  // projection. For index_addr, it may require hoisting ref_tail_addr.
   SILValue base;
 
   /// Compute the access path at \p address, and record the access base. This
@@ -1309,14 +1333,7 @@ inline bool isAccessedStorageCast(SingleValueInstruction *svi) {
   case SILInstructionKind::MarkUninitializedInst:
   case SILInstructionKind::UncheckedAddrCastInst:
   case SILInstructionKind::MarkDependenceInst:
-  // Look through a project_box to identify the underlying alloc_box as the
-  // accesed object. It must be possible to reach either the alloc_box or the
-  // containing enum in this loop, only looking through simple value
-  // propagation such as copy_value and begin_borrow.
-  case SILInstructionKind::ProjectBoxInst:
-  case SILInstructionKind::ProjectBlockStorageInst:
   case SILInstructionKind::CopyValueInst:
-  case SILInstructionKind::BeginBorrowInst:
   // Casting to RawPointer does not affect the AccessPath. When converting
   // between address types, they must be layout compatible (with truncation).
   case SILInstructionKind::AddressToPointerInst:
@@ -1366,7 +1383,7 @@ public:
   Result visitArgumentAccess(SILFunctionArgument *arg) {
     return asImpl().visitBase(arg, AccessedStorage::Argument);
   }
-  Result visitBoxAccess(AllocBoxInst *box) {
+  Result visitBoxAccess(ProjectBoxInst *box) {
     return asImpl().visitBase(box, AccessedStorage::Box);
   }
   /// \p global may be either a GlobalAddrInst or the ApplyInst for a global
@@ -1414,9 +1431,8 @@ Result AccessUseDefChainVisitor<Impl, Result>::visit(SILValue sourceAddr) {
 
   // MARK: Handle immediately-identifiable instructions.
 
-  // An AllocBox is a fully identified memory location.
-  case ValueKind::AllocBoxInst:
-    return asImpl().visitBoxAccess(cast<AllocBoxInst>(sourceAddr));
+  case ValueKind::ProjectBoxInst:
+    return asImpl().visitBoxAccess(cast<ProjectBoxInst>(sourceAddr));
 
   // An AllocStack is a fully identified memory location, which may occur
   // after inlining code already subjected to stack promotion.

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -649,6 +649,7 @@ public:
     RefElementAddr,
     RefTailAddr,
     OpenExistentialBox,
+    ProjectBox,
     StoreBorrow,
   };
 
@@ -676,6 +677,8 @@ public:
       return Kind::RefTailAddr;
     case SILInstructionKind::OpenExistentialBoxInst:
       return Kind::OpenExistentialBox;
+    case SILInstructionKind::ProjectBoxInst:
+      return Kind::ProjectBox;
     case SILInstructionKind::StoreBorrowInst:
       return Kind::StoreBorrow;
     }
@@ -694,6 +697,8 @@ public:
       return Kind::RefTailAddr;
     case ValueKind::OpenExistentialBoxInst:
       return Kind::OpenExistentialBox;
+    case ValueKind::ProjectBoxInst:
+      return Kind::ProjectBox;
     case ValueKind::StoreBorrowInst:
       return Kind::StoreBorrow;
     }
@@ -747,6 +752,7 @@ struct InteriorPointerOperand {
     case InteriorPointerOperandKind::RefElementAddr:
     case InteriorPointerOperandKind::RefTailAddr:
     case InteriorPointerOperandKind::OpenExistentialBox:
+    case InteriorPointerOperandKind::ProjectBox:
     case InteriorPointerOperandKind::StoreBorrow: {
       // Ok, we have a valid instruction. Return the relevant operand.
       auto *op =
@@ -788,6 +794,8 @@ struct InteriorPointerOperand {
       return cast<RefTailAddrInst>(operand->getUser());
     case InteriorPointerOperandKind::OpenExistentialBox:
       return cast<OpenExistentialBoxInst>(operand->getUser());
+    case InteriorPointerOperandKind::ProjectBox:
+      return cast<ProjectBoxInst>(operand->getUser());
     case InteriorPointerOperandKind::StoreBorrow:
       return cast<StoreBorrowInst>(operand->getUser());
     }

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -727,6 +727,8 @@ struct InteriorPointerOperand {
     return kind != InteriorPointerOperandKind::Invalid && operand;
   }
 
+  SILInstruction *getUser() const { return operand->getUser(); }
+
   /// If \p op has a user that is an interior pointer, return a valid
   /// value. Otherwise, return None.
   static InteriorPointerOperand get(Operand *op) {
@@ -833,6 +835,25 @@ private:
   /// its usage since it assumes the code passed in is well formed.
   InteriorPointerOperand(Operand *op, InteriorPointerOperandKind kind)
       : operand(op), kind(kind) {}
+};
+
+/// Utility to check if an address may originate from a borrowed value. If so,
+/// then uses of the address cannot be replaced without ensuring that they are
+/// also within the same scope.
+///
+/// If mayBeBorrowed is false, then there is no enclosing borrow scope and
+/// interiorPointerOp is irrelevant.
+///
+/// If mayBeBorrowed is true, then interiorPointerOp refers to the operand that
+/// converts a non-address value into the address from which the contructor's
+/// address is derived. If the best-effort to find an InteriorPointerOperand
+/// fails, then interiorPointerOp remains invalid, and clients must be
+/// conservative.
+struct BorrowedAddress {
+  bool mayBeBorrowed = true;
+  InteriorPointerOperand interiorPointerOp;
+
+  BorrowedAddress(SILValue address);
 };
 
 class OwnedValueIntroducerKind {

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -135,6 +135,9 @@ SILValue swift::stripSinglePredecessorArgs(SILValue V) {
 SILValue swift::stripCastsWithoutMarkDependence(SILValue v) {
   while (true) {
     v = stripSinglePredecessorArgs(v);
+    if (isa<MarkDependenceInst>(v))
+      return v;
+
     if (auto *svi = dyn_cast<SingleValueInstruction>(v)) {
       if (isRCIdentityPreservingCast(svi)
           || isa<UncheckedTrivialBitCastInst>(v)

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -62,20 +62,6 @@ SILValue swift::getUnderlyingObject(SILValue v) {
   }
 }
 
-SILValue
-swift::getUnderlyingObjectStoppingAtObjectToAddrProjections(SILValue v) {
-  if (!v->getType().isAddress())
-    return SILValue();
-
-  while (true) {
-    auto v2 = lookThroughAddressToAddressProjections(v);
-    v2 = stripIndexingInsts(v2);
-    if (v2 == v)
-      return v2;
-    v = v2;
-  }
-}
-
 SILValue swift::getUnderlyingObjectStopAtMarkDependence(SILValue v) {
   while (true) {
     SILValue v2 = stripCastsWithoutMarkDependence(v);

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -689,7 +689,7 @@ private:
       // `storage` may still be invalid. If both `storage` and `foundStorage`
       // are invalid, this check passes, but we return an invalid storage
       // below.
-      if (!result.storage->hasIdenticalBase(foundStorage))
+      if (!result.storage->hasIdenticalStorage(foundStorage))
         result.storage = AccessedStorage();
       if (result.base != foundBase)
         result.base = SILValue();
@@ -777,7 +777,7 @@ bool AccessPath::contains(AccessPath subPath) const {
   if (!isValid() || !subPath.isValid()) {
     return false;
   }
-  if (!storage.hasIdenticalBase(subPath.storage)) {
+  if (!storage.hasIdenticalStorage(subPath.storage)) {
     return false;
   }
   // Does the offset index match?
@@ -1228,7 +1228,7 @@ bool AccessPathDefUseTraversal::pushPhiUses(const SILPhiArgument *phi,
   // looking through it. If the phi input differ the its storage is invalid.
   auto phiPath = AccessPath::compute(phi);
   if (phiPath.isValid()) {
-    assert(phiPath.getStorage().hasIdenticalBase(storage)
+    assert(phiPath.getStorage().hasIdenticalStorage(storage)
            && "inconsistent phi storage");
     // If the phi paths have different offsets, its path has unknown offset.
     if (phiPath.getOffset() == AccessPath::UnknownOffset) {
@@ -1699,8 +1699,8 @@ void swift::checkSwitchEnumBlockArg(SILPhiArgument *arg) {
   }
 }
 
-bool swift::isPossibleFormalAccessBase(const AccessedStorage &storage,
-                                       SILFunction *F) {
+bool swift::isPossibleFormalAccessStorage(const AccessedStorage &storage,
+                                          SILFunction *F) {
   switch (storage.getKind()) {
   case AccessedStorage::Nested:
     assert(false && "don't pass nested storage to this helper");

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -390,6 +390,10 @@ bool swift::isRCIdentityPreservingCast(SingleValueInstruction *svi) {
   case SILInstructionKind::UnconditionalCheckedCastInst:
   case SILInstructionKind::UnconditionalCheckedCastValueInst:
     return SILDynamicCastInst(svi).isRCIdentityPreserving();
+  // Ignore markers
+  case SILInstructionKind::MarkUninitializedInst:
+  case SILInstructionKind::MarkDependenceInst:
+    return true;
   }
 }
 
@@ -446,7 +450,7 @@ protected:
 
 } // end anonymous namespace
 
-static SILValue findReferenceRoot(SILValue ref) {
+SILValue swift::findReferenceRoot(SILValue ref) {
   return FindReferenceRoot().findRoot(ref);
 }
 
@@ -471,12 +475,13 @@ constexpr unsigned AccessedStorage::TailIndex;
 AccessedStorage::AccessedStorage(SILValue base, Kind kind) {
   // For kind==Unidentified, base may be an invalid empty or tombstone value.
   assert(base && "invalid storage base");
-  initKind(kind);
+  initKind(kind, InvalidElementIndex);
   switch (kind) {
-  case Box:
-    assert(isa<AllocBoxInst>(base));
-    value = base;
+  case Box: {
+    auto *projectBox = cast<ProjectBoxInst>(base);
+    value = findReferenceRoot(projectBox->getOperand());
     break;
+  }
   case Stack:
     assert(isa<AllocStackInst>(base));
     value = base;
@@ -533,9 +538,6 @@ void AccessedStorage::visitRoots(
     visitor(root);
     return;
   }
-  if (getKind() == Unidentified) {
-    return;
-  }
   assert(getKind() == Global && function);
   SILGlobalVariable *global = getGlobal();
   for (auto &block : *function) {
@@ -567,7 +569,10 @@ void AccessedStorage::setLetAccess(SILValue base) {
 const ValueDecl *AccessedStorage::getDecl(SILValue base) const {
   switch (getKind()) {
   case Box:
-    return cast<AllocBoxInst>(value)->getLoc().getAsASTNode<VarDecl>();
+    if (auto *allocBox = dyn_cast<AllocBoxInst>(value))
+      return allocBox->getLoc().getAsASTNode<VarDecl>();
+
+    return nullptr;
 
   case Stack:
     return cast<AllocStackInst>(value)->getDecl();
@@ -768,7 +773,7 @@ AccessedStorage AccessedStorage::computeInScope(SILValue sourceAddress) {
 
 AccessPath AccessPath::forTailStorage(SILValue rootReference) {
   return AccessPath(
-    AccessedStorage::forClass(rootReference, AccessedStorage::TailIndex),
+    AccessedStorage::forObjectTail(rootReference),
     PathNode(rootReference->getModule()->getIndexTrieRoot()),
     /*offset*/ 0);
 }
@@ -937,6 +942,8 @@ public:
       assert(isa<OpenExistentialAddrInst>(projectedAddr)
              || isa<InitEnumDataAddrInst>(projectedAddr)
              || isa<UncheckedTakeEnumDataAddrInst>(projectedAddr)
+             // project_box is not normally an access projection but we treat it
+             // as such when it operates on unchecked_take_enum_data_addr.
              || isa<ProjectBoxInst>(projectedAddr));
     }
     return sourceAddr->get();
@@ -1354,8 +1361,8 @@ AccessPathDefUseTraversal::visitSingleValueUser(SingleValueInstruction *svi,
     pushUsers(svi, dfs);
     return IgnoredUse;
 
-  // Handle ref_element_addr since we start at the object root instead of
-  // the access base.
+  // Handle ref_element_addr, ref_tail_addr, and project_box since we start at
+  // the object root instead of the access base.
   case SILInstructionKind::RefElementAddrInst:
     assert(dfs.isRef());
     assert(dfs.pathCursor > 0 && "ref_element_addr cannot occur within access");
@@ -1373,6 +1380,13 @@ AccessPathDefUseTraversal::visitSingleValueUser(SingleValueInstruction *svi,
     if (pathIndex.getSubObjectIndex() == AccessedStorage::TailIndex)
       pushUsers(svi, dfs);
 
+    return IgnoredUse;
+  }
+
+  case SILInstructionKind::ProjectBoxInst: {
+    assert(dfs.isRef());
+    dfs.useAndIsRef.setInt(false);
+    pushUsers(svi, dfs);
     return IgnoredUse;
   }
 
@@ -1434,8 +1448,10 @@ AccessPathDefUseTraversal::visitSingleValueUser(SingleValueInstruction *svi,
       assert(isa<UncheckedTakeEnumDataAddrInst>(addrOper->get()));
       // Push the project_box uses
       for (auto *use : svi->getUses()) {
-        if (isa<ProjectBoxInst>(use->getUser()))
-          pushUser(DFSEntry(use, dfs.isRef(), dfs.pathCursor, dfs.offset));
+        if (auto *projectBox = dyn_cast<ProjectBoxInst>(use->getUser())) {
+          assert(!dfs.isRef() && "originates from an enum address");
+          pushUsers(projectBox, dfs);
+        }
       }
     }
     return LeafUse;

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -729,7 +729,8 @@ bool InteriorPointerOperand::findTransitiveUsesForAddress(
         isa<BeginAccessInst>(user) || isa<TailAddrInst>(user) ||
         isa<IndexAddrInst>(user) || isa<StoreBorrowInst>(user) ||
         isa<UnconditionalCheckedCastAddrInst>(user) ||
-        isa<UncheckedAddrCastInst>(user)) {
+        isa<UncheckedAddrCastInst>(user)
+        || isa<MarkFunctionEscapeInst>(user)) {
       for (SILValue r : user->getResults()) {
         llvm::copy(r->getUses(), std::back_inserter(worklist));
       }

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -16,6 +16,7 @@
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/LinearLifetimeChecker.h"
 #include "swift/SIL/Projection.h"
+#include "swift/SIL/MemAccessUtils.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILInstruction.h"
 
@@ -785,6 +786,46 @@ bool InteriorPointerOperand::findTransitiveUsesForAddress(
   // We were able to recognize all of the uses of the address, so return false
   // that we did not find any errors.
   return foundError;
+}
+
+// Determine whether \p address may be in a borrow scope and if so record the
+// InteriorPointerOperand that produces the address from a guaranteed value.
+BorrowedAddress::BorrowedAddress(SILValue address) {
+  assert(address->getType().isAddress());
+
+  auto storageWithBase = AccessedStorageWithBase::compute(address);
+  switch (storageWithBase.storage.getKind()) {
+  case AccessedStorage::Argument:
+  case AccessedStorage::Stack:
+  case AccessedStorage::Global:
+  // Unidentified storage is from an "escaped pointer", so it need not be
+  // restricted to a borrow scope.
+  case AccessedStorage::Unidentified:
+    this->mayBeBorrowed = false;
+    return;
+  case AccessedStorage::Box:
+  case AccessedStorage::Yield:
+  case AccessedStorage::Class:
+  case AccessedStorage::Tail:
+    // The base object might be within a borrow scope.
+    break;
+  case AccessedStorage::Nested:
+    llvm_unreachable("unexpected storage");
+  };
+  auto base = storageWithBase.base;
+  if (!base)
+    return; // bail on unexpected patterns
+
+  auto intPtrOp = InteriorPointerOperand::inferFromResult(base);
+  if (!intPtrOp)
+    return;
+
+  SILValue nonAddressValue = intPtrOp.operand->get();
+  if (nonAddressValue->getOwnershipKind() != OwnershipKind::Guaranteed) {
+    this->mayBeBorrowed = false;
+    return;
+  }
+  this->interiorPointerOp = intPtrOp;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -619,7 +619,7 @@ SILValue UnenforcedAccess::beginAccess(SILGenFunction &SGF, SILLocation loc,
 
   auto storage = AccessedStorage::compute(address);
   // Unsafe access may have invalid storage (e.g. a RawPointer).
-  if (storage && !isPossibleFormalAccessBase(storage, &SGF.F))
+  if (storage && !isPossibleFormalAccessStorage(storage, &SGF.F))
     return address;
 
   auto BAI =

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -1034,7 +1034,7 @@ static void checkAccessedAddress(Operand *memOper, StorageMap &Accesses) {
 
   // Some identifiable addresses can also be recognized as local initialization
   // or other patterns that don't qualify as formal access.
-  if (!isPossibleFormalAccessBase(storage, memInst->getFunction()))
+  if (!isPossibleFormalAccessStorage(storage, memInst->getFunction()))
     return;
 
   // A box or stack variable may represent lvalues, but they can only conflict

--- a/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
@@ -185,6 +185,7 @@ SILCombiner::optimizeBuiltinCOWBufferForReadingOSSA(BuiltinInst *bi) {
             cast<RefTailAddrInst>(intPtrOperand->getUser())->setImmutable();
             return;
           case InteriorPointerOperandKind::OpenExistentialBox:
+          case InteriorPointerOperandKind::ProjectBox:
           case InteriorPointerOperandKind::StoreBorrow:
             // Can not mark this immutable.
             return;

--- a/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
@@ -428,7 +428,7 @@ BeginAccessInst *AccessConflictAndMergeAnalysis::findMergeableOutOfScopeAccess(
   auto identicalStorageIter = llvm::find_if(
       state.outOfScopeConflictFreeAccesses, [&](BeginAccessInst *bai) {
         auto storageInfo = result.getAccessInfo(bai);
-        return storageInfo.hasIdenticalBase(currStorageInfo);
+        return storageInfo.hasIdenticalStorage(currStorageInfo);
       });
   if (identicalStorageIter == state.outOfScopeConflictFreeAccesses.end())
     return nullptr;
@@ -484,7 +484,7 @@ void AccessConflictAndMergeAnalysis::insertOutOfScopeAccess(
   auto identicalStorageIter = llvm::find_if(
       state.outOfScopeConflictFreeAccesses, [&](BeginAccessInst *bai) {
         auto storageInfo = result.getAccessInfo(bai);
-        return storageInfo.hasIdenticalBase(currStorageInfo);
+        return storageInfo.hasIdenticalStorage(currStorageInfo);
       });
   if (identicalStorageIter == state.outOfScopeConflictFreeAccesses.end())
     state.outOfScopeConflictFreeAccesses.insert(beginAccess);

--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -442,8 +442,8 @@ func testEnumPattern(ie: IndirectEnum) -> Bool {
 // CHECK:   switch_enum %{{.*}} : $IndirectEnum, case #IndirectEnum.V!enumelt: [[BBV:bb.*]], default bb
 // CHECK: [[BBV]](%{{.*}} : @owned ${ var Int }):
 // CHECK:   [[PROJ:%.*]] = project_box
-// CHECK-NOT: begin_access
-// CHECK:   load [trivial] [[PROJ]] : $*Int
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unsafe] [[PROJ]]
+// CHECK:   load [trivial] [[ACCESS]] : $*Int
 // CHECK-LABEL: } // end sil function '$s20access_marker_verify15testEnumPattern2ieSbAA08IndirectE0O_tF'
 
 // --- enum LValue.

--- a/test/SILOptimizer/accessed_storage_analysis.sil
+++ b/test/SILOptimizer/accessed_storage_analysis.sil
@@ -67,7 +67,7 @@ bb0(%0 : $Int):
 }
 
 // CHECK-LABEL: @readIdentifiedBoxArg
-// CHECK: [read] Argument %0 = argument of bb0 : ${ var Int }
+// CHECK: [read] Box %0 = argument of bb0 : ${ var Int }
 sil @readIdentifiedBoxArg : $@convention(thin) (@guaranteed { var Int }) -> Int {
 bb0(%0 : ${ var Int }):
   %1 = project_box %0 : ${ var Int }, 0
@@ -78,7 +78,7 @@ bb0(%0 : ${ var Int }):
 }
 
 // CHECK-LABEL: @writeIdentifiedBoxArg
-// CHECK: [modify] Argument %0 = argument of bb0 : ${ var Int }
+// CHECK: [modify] Box %0 = argument of bb0 : ${ var Int }
 sil @writeIdentifiedBoxArg : $@convention(thin) (@guaranteed { var Int }, Int) -> () {
 bb0(%0 : ${ var Int }, %1 : $Int):
   %2 = project_box %0 : ${ var Int }, 0
@@ -90,7 +90,7 @@ bb0(%0 : ${ var Int }, %1 : $Int):
 }
 
 // CHECK-LABEL: @readWriteIdentifiedBoxArg
-// CHECK: [modify] Argument %0 = argument of bb0 : ${ var Int }
+// CHECK: [modify] Box %0 = argument of bb0 : ${ var Int }
 sil @readWriteIdentifiedBoxArg : $@convention(thin) (@guaranteed { var Int }, Int) -> Int {
 bb0(%0 : ${ var Int }, %1 : $Int):
   %2 = function_ref @writeIdentifiedBoxArg : $@convention(thin) (@guaranteed { var Int }, Int) -> ()
@@ -634,7 +634,7 @@ enum IndirectEnum {
 }
 
 // CHECK-LABEL: @readUnidentifiedArgCaller
-// CHECK:   unidentified accesses: read
+// CHECK: Box %{{.*}} = argument of bb2 : ${ var Int }
 sil @readUnidentifiedArgCaller : $@convention(thin) (@guaranteed IndirectEnum, Int) -> Int {
 bb0(%0 : $IndirectEnum, %1 : $Int):
   switch_enum %0 : $IndirectEnum, case #IndirectEnum.V!enumelt: bb2, default bb1

--- a/test/SILOptimizer/accessed_storage_analysis_ossa.sil
+++ b/test/SILOptimizer/accessed_storage_analysis_ossa.sil
@@ -67,7 +67,7 @@ bb0(%0 : $Int):
 }
 
 // CHECK-LABEL: @readIdentifiedBoxArg
-// CHECK: [read] Argument %0 = argument of bb0 : ${ var Int }
+// CHECK: [read] Box %0 = argument of bb0 : ${ var Int }
 sil [ossa] @readIdentifiedBoxArg : $@convention(thin) (@guaranteed { var Int }) -> Int {
 bb0(%0 : @guaranteed ${ var Int }):
   %1 = project_box %0 : ${ var Int }, 0
@@ -78,7 +78,7 @@ bb0(%0 : @guaranteed ${ var Int }):
 }
 
 // CHECK-LABEL: @writeIdentifiedBoxArg
-// CHECK: [modify] Argument %0 = argument of bb0 : ${ var Int }
+// CHECK: [modify] Box %0 = argument of bb0 : ${ var Int }
 sil [ossa] @writeIdentifiedBoxArg : $@convention(thin) (@guaranteed { var Int }, Int) -> () {
 bb0(%0 : @guaranteed ${ var Int }, %1 : $Int):
   %2 = project_box %0 : ${ var Int }, 0
@@ -90,7 +90,7 @@ bb0(%0 : @guaranteed ${ var Int }, %1 : $Int):
 }
 
 // CHECK-LABEL: @readWriteIdentifiedBoxArg
-// CHECK: [modify] Argument %0 = argument of bb0 : ${ var Int }
+// CHECK: [modify] Box %0 = argument of bb0 : ${ var Int }
 sil [ossa] @readWriteIdentifiedBoxArg : $@convention(thin) (@guaranteed { var Int }, Int) -> Int {
 bb0(%0 : @guaranteed ${ var Int }, %1 : $Int):
   %2 = function_ref @writeIdentifiedBoxArg : $@convention(thin) (@guaranteed { var Int }, Int) -> ()
@@ -639,7 +639,7 @@ enum IndirectEnum {
 }
 
 // CHECK-LABEL: @readUnidentifiedArgCaller
-// CHECK:   unidentified accesses: read
+// CHECK: [read] Box %{{.*}} = argument of bb2 : ${ var Int }
 sil [ossa] @readUnidentifiedArgCaller : $@convention(thin) (@guaranteed IndirectEnum, Int) -> Int {
 bb0(%0 : @guaranteed $IndirectEnum, %1 : $Int):
   switch_enum %0 : $IndirectEnum, case #IndirectEnum.V!enumelt: bb2, default bb1


### PR DESCRIPTION
These 4 commits are interdependent as far as avoiding test regressions. The two main features are
- Unify Box/Class/Tail handling in AccessedStorage/MemAccessUtils.
- Add `isBorrowedAddress`, which is required for OSSA-based transformations. 

 Add a tiny BorrowedAddress utility.

    Determines whether an address might be inside a borrowed scope. If so,
    then any address substitution needs to find that scope boundary to
    avoid violating its basic guarantee that all uses are within scope.

 MemAccessUtils: unify Box/Class/Tail storage for consistency and usability

    It was originally convenient for exclusivity optimization to treat
    boxes specially. We wanted to know that the 'Box' kind was always
    uniquely identified. But that's not really important. And now that
    AccessedStorage is being used more generally, the inconsistency is
    problematic.

    A consistent model is also must easier to understand and explain.

    This also make the implementation of the utility simpler and more powerful.

    Functional changes:

    isRCIdentical will look through mark_dependence and mark_uninitialized.

    findReferenceRoot is used consistently everywhere increasing analysis precision.