### PR TITLE
Add swift-package-editor to update-checkout

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -24,6 +24,8 @@
             "remote": { "id": "apple/swift-tools-support-core" } },
         "swiftpm": {
             "remote": { "id": "apple/swift-package-manager" } },
+        "swift-package-editor": {
+            "remote": { "id": "owenv/swift-package-editor" } },
         "swift-syntax": {
             "remote": { "id": "apple/swift-syntax" } },
         "swift-system": {
@@ -75,6 +77,7 @@
                 "llbuild": "main",
                 "swift-tools-support-core": "main",
                 "swiftpm": "main",
+                "swift-package-editor": "main",
                 "swift-argument-parser": "0.4.4",
                 "swift-atomics": "0.0.3",
                 "swift-collections": "0.0.4",
@@ -195,6 +198,7 @@
                 "llbuild": "main",
                 "swift-tools-support-core": "main",
                 "swiftpm": "main",
+                "swift-package-editor": "main",
                 "swift-argument-parser": "0.4.4",
                 "swift-atomics": "0.0.3",
                 "swift-collections": "0.0.4",
@@ -230,6 +234,7 @@
                 "llbuild": "main",
                 "swift-tools-support-core": "main",
                 "swiftpm": "main",
+                "swift-package-editor": "main",
                 "swift-argument-parser": "0.4.4",
                 "swift-atomics": "0.0.3",
                 "swift-collections": "0.0.4",                


### PR DESCRIPTION
https://github.com/owenv/swift-package-editor contains the new canonical implementation of SE-301 derived from https://github.com/apple/swift-package-manager/pull/3034. If it makes sense, I'd be happy to transfer the ownership on the repository before this is accepted. I was planning on adding the build-script integration as a follow-up PR but can combine them if that's easier.
