### PR TITLE
[Sema] Check for extra optionals injected on checked cast subexprs when recording extraneous cast warnings

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6636,8 +6636,12 @@ static ConstraintFix *maybeWarnAboutExtraneousCast(
   }
 
   // Except for forced cast expressions, if optionals are more than a single
-  // level difference, we don't need to record any fix.
-  if (!isExpr<ForcedCheckedCastExpr>(anchor) && extraOptionals > 1)
+  // level difference or there is a single level between the types but an extra
+  // level of optional is added to subexpr via OptionalEvaluationExpr, we don't
+  // need to record any fix.
+  if (!isExpr<ForcedCheckedCastExpr>(anchor) &&
+      (extraOptionals > 1 ||
+       isExpr<OptionalEvaluationExpr>(castExpr->getSubExpr())))
     return nullptr;
 
   // Always succeed

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -535,3 +535,17 @@ protocol PP2: PP1 { }
 extension Optional: PP1 where Wrapped == PP2 { }
 
 nil is PP1 // expected-error {{'nil' requires a contextual type}}
+
+// SR-15039
+enum ChangeType<T> {
+  case initial(T)
+  case delta(previous: T, next: T)
+  case unset
+
+  var delta: (previous: T?, next: T)? { nil }
+}
+
+extension ChangeType where T == String? {
+  var foo: String? { return self.delta?.previous as? String } // OK
+  var bar: String? { self.delta?.next }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Additional check for extra optionally injected in conditional checked cast sub-expressions when recording extraneous cast warnings. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-15039.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
