### PR TITLE
Temporarily disable long test parse_stdlib.sil

### DIFF
--- a/validation-test/SIL/parse_stdlib.sil
+++ b/validation-test/SIL/parse_stdlib.sil
@@ -3,3 +3,4 @@
 // RUN: %target-sil-opt -enable-sil-verify-all=true %t.sil > /dev/null
 // REQUIRES: long_test
 // REQUIRES: nonexecutable_test
+// REQUIRES: rdar81658645


### PR DESCRIPTION
rdar://81658645 (Swift CI: 1. OSS - Swift (Tools Opt+Assert, Stdlib
Opt+DebInfo+Assert, Long Test) - macOS (main);
parse_stdlib.sil.tmp.sil: error: expected '>' in SIL instruction)

This may have to do with variadics.
```
error: expected '>' in SIL instruction

   %6 = apply %5<Self, Self.Scalar...>(%0, %3, %2) : $@convention(method) <τ_0_0 where τ_0_0 : SIMD><τ_1_0 where τ_1_0 : Sequence, τ_0_0.Scalar == τ_1_0.Element> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
```