### PR TITLE
Fix debug scope for SIL instructions created in LowerHopToActor

### DIFF
--- a/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
+++ b/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
@@ -100,6 +100,7 @@ bool LowerHopToActor::processHop(HopToExecutorInst *hop) {
     return false;
 
   B.setInsertionPoint(hop);
+  B.setCurrentDebugScope(hop->getDebugScope());
 
   // Get the dominating executor value for this actor, if available,
   // or else emit code to derive it.
@@ -117,6 +118,7 @@ bool LowerHopToActor::processExtract(ExtractExecutorInst *extract) {
   auto executor = extract->getExpectedExecutor();
   if (!isOptionalBuiltinExecutor(executor->getType())) {
     B.setInsertionPoint(extract);
+    B.setCurrentDebugScope(extract->getDebugScope());
     executor = emitGetExecutor(extract->getLoc(), executor, /*optional*/false);
   }
 

--- a/test/Concurrency/Runtime/actor_counters.swift
+++ b/test/Concurrency/Runtime/actor_counters.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking %import-libdispatch -parse-as-library)
+// RUN: %target-run-simple-swift( -Xfrontend -sil-verify-all -Xfrontend -disable-availability-checking %import-libdispatch -parse-as-library)
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency


### PR DESCRIPTION
The pass uses SILBuilder instant to create instructions and does not
set SILDebugScope.
Due to this, SILVerifier correctly asserts that basic blocks contain non-contiguous
lexical scopes at -Onone.
The long term fix would be to replace SILBuilder instance in the pass with
SILBuilderContext and use SILBuilderWithScope so that such bugs do not come up.