### PR TITLE
[AST] Treat actors inheriting from NSObject as SwiftNativeNSObjects.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8491,8 +8491,13 @@ bool ClassDecl::isRootDefaultActor(ModuleDecl *M,
 
 bool ClassDecl::isNativeNSObjectSubclass() const {
   // @objc actors implicitly inherit from NSObject.
-  if (isActor() && getAttrs().hasAttribute<ObjCAttr>())
-    return true;
+  if (isActor()) {
+    if (getAttrs().hasAttribute<ObjCAttr>()) {
+      return true;
+    }
+    ClassDecl *superclass = getSuperclassDecl();
+    return superclass && superclass->isNSObject();
+  }
 
   // For now, non-actor classes cannot use the native NSObject subclass.
   // Eventually we should roll this out to more classes that directly

--- a/test/SILGen/objc_actor.swift
+++ b/test/SILGen/objc_actor.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -emit-silgen %s -swift-version 5  -disable-availability-checking | %FileCheck %s
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+
+// rdar://80863853 - For an actor inheriting from NSObject and using '@objc'
+// should have the same effect: the effective superclass is SwiftNativeNSObject
+// (see 945011d39f8b271b8906bd509aac3aa954f4fc57) not NSObject.
+// Check that we don't treat any case as an ObjC class.
+
+import Foundation
+
+public actor MyClass1: NSObject {
+  public var x: Int
+  public init(_ x: Int) { self.x = x }
+}
+
+// CHECK: alloc_ref $MyClass1
+// CHECK-NOT: alloc_ref [objc] $MyClass1
+
+@objc public actor MyClass2 {
+  public var x: Int
+  public init(_ x: Int) { self.x = x }
+}
+
+// CHECK: alloc_ref $MyClass2
+// CHECK-NOT: alloc_ref [objc] $MyClass2
+
+@objc public actor MyClass3: NSObject {
+  public var x: Int
+  public init(_ x: Int) { self.x = x }
+}
+
+// CHECK: alloc_ref $MyClass3
+// CHECK-NOT: alloc_ref [objc] $MyClass3


### PR DESCRIPTION
Previously, omitting `@objc` meant that ObjC-refcounting was used (even if `: NSObject`
was present), meaning that the multi-step deinitialization of different zombie states was
bypassed, leading to eager deallocation on the last release and user-after-free.

Fixes rdar://80863853.