### PR TITLE
[DNM] [lit] Do not delete the cache.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -430,15 +430,17 @@ config.swift_frontend_test_options += os.environ.get('SWIFT_FRONTEND_TEST_OPTION
 config.swift_driver_test_options += os.environ.get('SWIFT_DRIVER_TEST_OPTIONS', '')
 config.sil_test_options = os.environ.get('SIL_TEST_OPTIONS', '')
 
+# WARNING: Do not delete the cache! That will make repeatedly running individual tests
+# much slower for local development.
 config.clang_module_cache_path = make_path(config.swift_test_results_dir, "clang-module-cache")
-shutil.rmtree(config.clang_module_cache_path, ignore_errors=True)
 mcp_opt = "-module-cache-path %s" % shell_quote(config.clang_module_cache_path)
 clang_mcp_opt = "-fmodules-cache-path=%r" % config.clang_module_cache_path
 lit_config.note("Using Clang module cache: " + config.clang_module_cache_path)
 lit_config.note("Using test results dir: " + config.swift_test_results_dir)
 
+# WARNING: Do not delete the cache! That will make repeatedly running individual tests
+# much slower for local development.
 completion_cache_path = make_path(config.swift_test_results_dir, "completion-cache")
-shutil.rmtree(completion_cache_path, ignore_errors=True)
 ccp_opt = "-completion-cache-path %r" % completion_cache_path
 lit_config.note("Using code completion cache: " + completion_cache_path)
 


### PR DESCRIPTION
Otherwise, running some tests locally takes 15+ seconds even though
the test should finish within a few hundred milliseconds.

Fixes SR-15044, rdar://problem/81672238.