### PR TITLE
[cmark] Start always cross compiling cmark on Linux.

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/cmark.py
+++ b/utils/swift_build_support/swift_build_support/products/cmark.py
@@ -54,16 +54,18 @@ class CMark(cmake_product.CMakeProduct):
 
         (platform, arch) = host_target.split('-')
 
+        common_c_flags = ' '.join(self.common_cross_c_flags(platform, arch))
+        self.cmake_options.define('CMAKE_C_FLAGS', common_c_flags)
+        self.cmake_options.define('CMAKE_CXX_FLAGS', common_c_flags)
+
         if host_target.startswith("macosx") or \
            host_target.startswith("iphone") or \
            host_target.startswith("appletv") or \
            host_target.startswith("watch"):
-
-            common_c_flags = ' '.join(self.common_cross_c_flags(platform, arch))
-
-            self.cmake_options.define('CMAKE_C_FLAGS', common_c_flags)
-            self.cmake_options.define('CMAKE_CXX_FLAGS', common_c_flags)
             toolchain_file = self.generate_darwin_toolchain_file(platform, arch)
+            self.cmake_options.define('CMAKE_TOOLCHAIN_FILE:PATH', toolchain_file)
+        elif platform == "linux":
+            toolchain_file = self.generate_linux_toolchain_file(platform, arch)
             self.cmake_options.define('CMAKE_TOOLCHAIN_FILE:PATH', toolchain_file)
 
         self.build_with_cmake(["all"], self.args.cmark_build_variant, [])


### PR DESCRIPTION
To be clear, this means that even when compiling for the host, we are going to be cross compiling, albeit cross compiling on the host for the host.

This change will just test out that this works in that case since I discovered that clang has a bug in it that prevents us for using it for actual cross compilation on Linux (it works if I shim in gcc instead of clang). I think we are going to be able to fix the clang issue and then we can start using this to cross compile with clang on the regular.