### PR TITLE
fix: typo spelling grammar

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -441,7 +441,7 @@ Here are the necessary changes:
    This ensures when an app is built for deployment targets prior to the symbols' move,
    the app will look for these symbols in ToasterKit instead of ToasterKitCore.
 
-More generally, mutliple availabilities can be specified, like so:
+More generally, mutiple availabilities can be specified, like so:
 
 ```swift
 @available(toasterOS 42, bowlOS 54, mugOS 54, *)

--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -441,7 +441,7 @@ Here are the necessary changes:
    This ensures when an app is built for deployment targets prior to the symbols' move,
    the app will look for these symbols in ToasterKit instead of ToasterKitCore.
 
-More generally, mutiple availabilities can be specified, like so:
+More generally, multiple availabilities can be specified, like so:
 
 ```swift
 @available(toasterOS 42, bowlOS 54, mugOS 54, *)

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -2029,7 +2029,7 @@ called a "forwarding instruction" and any use with such a user instruction a
 "forwarding use". This inference generally occurs upon instruction construction
 and as a result:
 
-* When manipulating forwarding instructions programatically, one must manually
+* When manipulating forwarding instructions programmatically, one must manually
   update their forwarded ownership since most of the time the ownership is
   stored in the instruction itself. Don't worry though because the SIL verifier
   will catch this error for you if you forget to do so!
@@ -2039,7 +2039,7 @@ and as a result:
   parsed operand.
   In some cases the forwarding ownership kind is different from the ownership kind
   of its operand. In such cases, textual SIL represents the forwarding ownership kind
-  explicity.
+  explicitly.
   Eg: ::
 
     %cast = unchecked_ref_cast %val : $Klass to $Optional<Klass>, forwarding: @unowned

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -621,11 +621,11 @@ public:
                          const ModuleDecl *importedModule,
                          llvm::SmallSetVector<Identifier, 4> &spiGroups) const;
 
-  // Is \p attr accessible as an explictly imported SPI from this module?
+  // Is \p attr accessible as an explicitly imported SPI from this module?
   bool isImportedAsSPI(const SpecializeAttr *attr,
                        const ValueDecl *targetDecl) const;
 
-  // Is \p spiGroup accessible as an explictly imported SPI from this module?
+  // Is \p spiGroup accessible as an explicitly imported SPI from this module?
   bool isImportedAsSPI(Identifier spiGroup, const ModuleDecl *fromModule) const;
 
   /// \sa getImportedModules

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -272,7 +272,7 @@ public:
   /// Verify all modules loaded by this loader.
   virtual void verifyAllModules() { }
 
-  /// Discover overlays declared alongside this file and add infomation about
+  /// Discover overlays declared alongside this file and add information about
   /// them to it.
   void findOverlayFiles(SourceLoc diagLoc, ModuleDecl *module, FileUnit *file);
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2642,7 +2642,7 @@ void simple_display(llvm::raw_ostream &out, ConformanceLookupKind kind);
 
 /// Lookup and expand all conformances in the given context.
 ///
-/// This request specifically accomodates algorithms for retrieving all
+/// This request specifically accommodates algorithms for retrieving all
 /// conformances in the primary, even those that are unstated in source but
 /// are implied by other conformances, inherited from other types, or synthesized
 /// by the compiler. A simple case of this is the following:

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -282,7 +282,7 @@ enum class TypeMatchFlags {
   AllowABICompatible = 1 << 3,
   /// Allow escaping function parameters to override optional non-escaping ones.
   ///
-  /// This is necessary because Objective-C allows optional function paramaters
+  /// This is necessary because Objective-C allows optional function parameters
   /// to be non-escaping, but Swift currently does not.
   IgnoreNonEscapingForOptionalFunctionParam = 1 << 4,
   /// Allow compatible opaque archetypes.

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -652,7 +652,7 @@ public:
         isBridged);
   }
 
-  /// Given a known-opaque existential, attemp to discover the pointer to its
+  /// Given a known-opaque existential, attempt to discover the pointer to its
   /// metadata address and its value.
   llvm::Optional<RemoteExistential>
   readMetadataAndValueOpaqueExistential(RemoteAddress ExistentialAddress) {

--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -318,7 +318,7 @@ public:
     case ApplySiteKind::PartialApplyInst:
       // The arguments to partial_apply are a suffix of the partial_apply's
       // callee. Note that getSubstCalleeConv is function type of the callee
-      // argument passed to this apply, not necessarilly the function type of
+      // argument passed to this apply, not necessarily the function type of
       // the underlying callee function (i.e. it is based on the `getCallee`
       // type, not the `getCalleeOrigin` type).
       //

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -248,7 +248,7 @@ enum class AccessUseType { Exact, Inner, Overlapping };
 ///     begin_access.
 ///
 /// Note that the SILValue that represents a storage object is not
-/// necessarilly an address type. It may instead be a SILBoxType. So, even
+/// necessarily an address type. It may instead be a SILBoxType. So, even
 /// though address phis are not allowed, finding the base of an access may
 /// require traversing phis.
 ///
@@ -362,7 +362,7 @@ protected:
     // Define bits for use in the AccessEnforcementOpts pass. Each begin_access
     // in the function is mapped to one instance of this subclass.  Reserve a
     // bit for a seenNestedConflict flag, which is the per-begin-access result
-    // of pass-specific analysis. The remaning bits are sufficient to index all
+    // of pass-specific analysis. The remaining bits are sufficient to index all
     // begin_[unpaired_]access instructions.
     //
     // `AccessedStorage` refers to the AccessedStorageBitfield defined above,
@@ -786,7 +786,7 @@ namespace swift {
 /// The index of ref_element_addr is part of the storage identity and does
 /// not contribute to the access path indices.
 ///
-/// A well-formed path has at most one offset component at the begining of the
+/// A well-formed path has at most one offset component at the beginning of the
 /// path (chained index_addrs are merged into one offset). In other words,
 /// taking an offset from a subobject projection is not well-formed access
 /// path. However, it is possible (however undesirable) for programmers to
@@ -1003,7 +1003,7 @@ public:
 
 // Encapsulate the result of computing an AccessPath. AccessPath does not store
 // the base address of the formal access because it does not always uniquely
-// indentify the access, but AccessPath users may use the base address to to
+// identify the access, but AccessPath users may use the base address to to
 // recover the def-use chain for a specific global_addr or ref_element_addr.
 struct AccessPathWithBase {
   AccessPath accessPath;

--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -695,7 +695,7 @@ private:
   // known.
   bool hasNonConstantCaptures = true;
 
-  // A substitution map that partially maps the generic paramters of the
+  // A substitution map that partially maps the generic parameters of the
   // applied function to the generic arguments of passed to the call.
   SubstitutionMap substitutionMap;
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5778,7 +5778,7 @@ class SetDeallocatingInst
 
 /// ObjectInst - Represents a object value type.
 ///
-/// This instruction can only appear at the end of a gobal variable's
+/// This instruction can only appear at the end of a global variable's
 /// static initializer list.
 class ObjectInst final : public InstructionBaseWithTrailingOperands<
                              SILInstructionKind::ObjectInst, ObjectInst,
@@ -9164,7 +9164,7 @@ public:
   }
 };
 
-/// LinearFunctionInst - given a function, its derivative and traspose functions,
+/// LinearFunctionInst - given a function, its derivative and transpose functions,
 /// create an `@differentiable(_linear)` function that represents a bundle of these.
 class LinearFunctionInst final
     : public InstructionBaseWithTrailingOperands<

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -290,7 +290,7 @@ public:
   bool isAddressOnly(const SILFunction &F) const;
 
   /// True if the underlying AST type is trivial, meaning it is loadable and can
-  /// be trivially copied, moved or detroyed. Returns false for address types
+  /// be trivially copied, moved or destroyed. Returns false for address types
   /// even though they are technically trivial.
   bool isTrivial(const SILFunction &F) const;
 

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -306,9 +306,9 @@ struct ValueOwnershipKind {
   OperandOwnership getForwardingOperandOwnership(bool allowUnowned) const;
 
   /// Returns true if \p Other can be merged successfully with this, implying
-  /// that the two ownership kinds are "compatibile".
+  /// that the two ownership kinds are "compatible".
   ///
-  /// The reason why we do not compare directy is to allow for
+  /// The reason why we do not compare directly is to allow for
   /// OwnershipKind::None to merge into other forms of ValueOwnershipKind.
   bool isCompatibleWith(ValueOwnershipKind other) const {
     return bool(merge(other));

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -441,7 +441,7 @@ protected:
     else {
       // Create a new function with this mangled name with an empty
       // body. There won't be any IR generated for it (hence the linkage),
-      // but the symbol will be refered to by the debug info metadata.
+      // but the symbol will be referred to by the debug info metadata.
       ParentFunction = FuncBuilder.getOrCreateFunction(
           ParentFunction->getLocation(), MangledName, SILLinkage::Shared,
           ParentFunction->getLoweredFunctionType(), ParentFunction->isBare(),

--- a/include/swift/SILOptimizer/Analysis/CallerAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/CallerAnalysis.h
@@ -182,7 +182,7 @@ private:
   void verify(SILFunction *caller, const FunctionInfo &callerInfo) const;
 };
 
-/// Auxillary information that we store about a specific caller.
+/// Auxiliary information that we store about a specific caller.
 struct CallerAnalysis::CallerInfo {
   /// Given a SILFunction F that contains at least one partial apply of the
   /// given function, map F to the minimum number of partial applied

--- a/include/swift/SILOptimizer/Utils/CanonicalOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalOSSALifetime.h
@@ -267,7 +267,7 @@ private:
 
   /// Record all interesting debug_value instructions here rather then treating
   /// them like a normal use. An interesting debug_value is one that may lie
-  /// outisde the pruned liveness at the time it is discovered.
+  /// outside the pruned liveness at the time it is discovered.
   llvm::SmallPtrSet<DebugValueInst *, 8> debugValues;
 
   /// Visited set for general def-use traversal that prevents revisiting values.

--- a/include/swift/SILOptimizer/Utils/InstModCallbacks.h
+++ b/include/swift/SILOptimizer/Utils/InstModCallbacks.h
@@ -1,4 +1,4 @@
-//===--- InstModCallbacks.h - intruction modification callbacks -*- C++ -*-===//
+//===--- InstModCallbacks.h - instruction modification callbacks -*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -98,7 +98,7 @@ struct InstModCallbacks {
   ///
   ///   instToDelete->eraseFromParent();
   ///
-  /// The reason this callback is reponsible for deleting the instruction is to
+  /// The reason this callback is responsible for deleting the instruction is to
   /// interoperate more easily with
   /// CanonicalizeInstruction::killInstruction(). This allows updates to choose
   /// whether to happen before or after deleting the instruction and possibly

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -314,7 +314,7 @@ public:
   /// lifetimes of the operands of \c inst once it is deleted. This function
   /// will not clean up dead code resulting from the instruction's removal. To
   /// do so, invoke the method \c cleanupDeadCode of this instance, once the SIL
-  /// of the contaning function is made consistent.
+  /// of the containing function is made consistent.
   ///
   /// \pre the instruction to be deleted must not have any use other than
   /// incidental uses.
@@ -335,7 +335,7 @@ public:
   /// Clean up dead instructions that are tracked by this instance and all
   /// instructions that transitively become dead.
   ///
-  /// \pre the function contaning dead instructions must be consistent (i.e., no
+  /// \pre the function containing dead instructions must be consistent (i.e., no
   /// under or over releases). Note that if \c forceDelete call leaves the
   /// function body in an inconsistent state, it needs to be made consistent
   /// before this method is invoked.

--- a/include/swift/SILOptimizer/Utils/KeyPathProjector.h
+++ b/include/swift/SILOptimizer/Utils/KeyPathProjector.h
@@ -64,7 +64,7 @@ public:
   /// \param accessType The access type of the projected address.
   /// \param callback A callback to invoke with the projected adddress.
   ///     The projected address is only valid from within \p callback.
-  ///     If accessType is Get or Modify, the projected addres is an
+  ///     If accessType is Get or Modify, the projected address is an
   ///     initialized address type. If accessType is set, the projected
   ///     address points to uninitialized memory.
   virtual void project(AccessType accessType,

--- a/include/swift/SILOptimizer/Utils/PrunedLiveness.h
+++ b/include/swift/SILOptimizer/Utils/PrunedLiveness.h
@@ -24,7 +24,7 @@
 /// Dead, LiveWithin, LiveOut.
 ///
 /// A LiveWithin block has a liveness boundary within the block. The client can
-/// determine the boundary's intruction position by searching for the last use.
+/// determine the boundary's instruction position by searching for the last use.
 ///
 /// LiveOut indicates that liveness extends into a successor edges, therefore,
 /// no uses within that block can be on the liveness boundary, unless that use
@@ -172,7 +172,7 @@ protected:
 /// interesting uses that are "lifetime-ending" are flagged. These uses must be
 /// on the liveness boundary by their nature, regardless of any other uses. It
 /// is up to the client to determine which uses are lifetime-ending. In OSSA,
-/// the lifetime-ending property might be detemined by
+/// the lifetime-ending property might be determined by
 /// OwnershipConstraint::isLifetimeEnding(). In non-OSSA, it might be determined
 /// by deallocation.
 ///

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file defines the \c PotentialBindings class and its auxilary types
-// such as \c PotentialBinding, that are used to descibe bindings which
+// This file defines the \c PotentialBindings class and its auxiliary types
+// such as \c PotentialBinding, that are used to describe bindings which
 // a particular type variable could be bound to.
 //
 //===----------------------------------------------------------------------===//

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -274,7 +274,7 @@ enum class FixKind : uint8_t {
   /// Allow key path to be bound to a function type with more than 1 argument
   AllowMultiArgFuncKeyPathMismatch,
 
-  /// Specify key path root type when it cannot be infered from context.
+  /// Specify key path root type when it cannot be inferred from context.
   SpecifyKeyPathRootType,
 
   /// Unwrap optional base on key path application.

--- a/include/swift/Sema/CodeCompletionTypeChecking.h
+++ b/include/swift/Sema/CodeCompletionTypeChecking.h
@@ -69,7 +69,7 @@ namespace swift {
                                        CodeCompletionExpr *CompletionExpr)
       : DC(DC), CompletionExpr(CompletionExpr) {}
 
-    /// Get the results collected from any sawSolutions() callbacks recevied so
+    /// Get the results collected from any sawSolutions() callbacks received so
     /// far.
     ArrayRef<Result> getResults() const { return Results; }
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5555,7 +5555,7 @@ private:
   /// be supertypes extracted from one of the current bindings
   /// or default literal types etc.
   ///
-  /// \returns true if some new bindings were sucessfully computed,
+  /// \returns true if some new bindings were successfully computed,
   /// false otherwise.
   bool computeNext();
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2865,7 +2865,7 @@ private:
   ///
   /// \param solutions The set of solutions to filter.
   ///
-  /// \param minimize The flag which idicates if the
+  /// \param minimize The flag which indicates if the
   /// set of solutions should be filtered even if there is
   /// no single best solution, see `findBestSolution` for
   /// more details.
@@ -3125,7 +3125,7 @@ public:
                        ArrayRef<ConstraintLocator::PathElement> path,
                        unsigned summaryFlags);
 
-  /// Retrive the constraint locator for the given anchor and
+  /// Retreive the constraint locator for the given anchor and
   /// path, uniqued and automatically infer the summary flags
   ConstraintLocator *
   getConstraintLocator(ASTNode anchor,

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3233,10 +3233,10 @@ for host in "${ALL_HOSTS[@]}"; do
         # The usage for this script says that lipo happens before
         # dsym extraction but that's not really what happens.  At this point,
         # we're processing an individual host (eg macosx-x86_64) but targeting
-        # the (shared) SYMROOT which can cause mutliple hosts to stomp on each
+        # the (shared) SYMROOT which can cause mutiple hosts to stomp on each
         # other.  As a hack, I'm segregating the hosts in the symroot but it
         # would probably be better to make the script behave as the usage
-        # descibes
+        # describes
         host_symroot="${INSTALL_SYMROOT}/${host}"
 
         set -x

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3233,7 +3233,7 @@ for host in "${ALL_HOSTS[@]}"; do
         # The usage for this script says that lipo happens before
         # dsym extraction but that's not really what happens.  At this point,
         # we're processing an individual host (eg macosx-x86_64) but targeting
-        # the (shared) SYMROOT which can cause mutiple hosts to stomp on each
+        # the (shared) SYMROOT which can cause multiple hosts to stomp on each
         # other.  As a hack, I'm segregating the hosts in the symroot but it
         # would probably be better to make the script behave as the usage
         # describes

--- a/utils/build_swift/build_swift/argparse/actions.py
+++ b/utils/build_swift/build_swift/argparse/actions.py
@@ -324,7 +324,7 @@ class ToggleFalseAction(_ToggleAction):
 # -----------------------------------------------------------------------------
 
 class UnsupportedAction(Action):
-    """Action that denotes an unsupported argument or opiton and subsequently
+    """Action that denotes an unsupported argument or option and subsequently
     raises an ArgumentError.
     """
 

--- a/utils/build_swift/build_swift/defaults.py
+++ b/utils/build_swift/build_swift/defaults.py
@@ -87,7 +87,7 @@ def _default_llvm_lto_link_jobs():
     """Use the formula (GB Memory - 3)/6.0GB to get the number of parallel
     link threads we can support. This gives the OS 3 GB of room to work with.
 
-    This is a bit conservative, but I have found that this hueristic prevents
+    This is a bit conservative, but I have found that this heuristic prevents
     me from swapping on my test machine.
     """
 
@@ -102,7 +102,7 @@ def _default_swift_lto_link_jobs():
     """Use the formula (GB Memory - 3)/8.0GB to get the number of parallel
     link threads we can support. This gives the OS 3 GB of room to work with.
 
-    This is a bit conservative, but I have found that this hueristic prevents
+    This is a bit conservative, but I have found that this heuristic prevents
     me from swapping on my test machine.
     """
 

--- a/utils/build_swift/build_swift/migration.py
+++ b/utils/build_swift/build_swift/migration.py
@@ -8,7 +8,7 @@
 
 
 """
-Temporary module with functionaly used to migrate away from build-script-impl.
+Temporary module with functionally used to migrate away from build-script-impl.
 """
 
 

--- a/utils/build_swift/build_swift/presets.py
+++ b/utils/build_swift/build_swift/presets.py
@@ -120,7 +120,7 @@ class PresetError(Exception):
 
 
 class DuplicatePresetError(PresetError):
-    """Raised when an existing preset would be overriden.
+    """Raised when an existing preset would be overridden.
     """
 
     def __init__(self, preset_name):

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -347,7 +347,7 @@ class DisableOption(_BaseOption):
 
 
 class ChoicesOption(_BaseOption):
-    """Option that accepts an argument from a predifined list of choices."""
+    """Option that accepts an argument from a predefined list of choices."""
 
     def __init__(self, *args, **kwargs):
         self.choices = kwargs.pop('choices', None)

--- a/utils/gyb_syntax_support/AvailabilityNodes.py
+++ b/utils/gyb_syntax_support/AvailabilityNodes.py
@@ -79,7 +79,7 @@ AVAILABILITY_NODES = [
     Node('VersionTuple', kind='Syntax',
          description='''
          A version number of the form major.minor.patch in which the minor
-         and patch part may be ommited.
+         and patch part may be omitted.
          ''',
          children=[
              Child('MajorMinor', kind='Syntax',

--- a/utils/gyb_syntax_support/Classification.py
+++ b/utils/gyb_syntax_support/Classification.py
@@ -39,7 +39,7 @@ SYNTAX_CLASSIFICATIONS = [
     A string literal including multiline string literals.
     '''),
     SyntaxClassification('StringInterpolationAnchor', description='''
-    The opening and closing paranthesis of string interpolation.
+    The opening and closing parenthesis of string interpolation.
     '''),
     SyntaxClassification('PoundDirectiveKeyword', description='''
     A `#` keyword like `#warning`.

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -594,7 +594,7 @@ EXPR_NODES = [
              Child('RightParen', kind='RightParenToken'),
          ]),
 
-    # postfix '#if' expession
+    # postfix '#if' expression
     Node('PostfixIfConfigExpr', kind='Expr',
          children=[
              Child('Base', kind='Expr', is_optional=True),

--- a/utils/incrparse/incr_transfer_round_trip.py
+++ b/utils/incrparse/incr_transfer_round_trip.py
@@ -69,7 +69,7 @@ def main():
     # markup for testing incremental parsing
     # =========================================================================
 
-    # Gather command line arguments for swift-syntax-test specifiying the
+    # Gather command line arguments for swift-syntax-test specifying the
     # performed edits in this list
     incremental_edit_args = []
     reparse_args = []

--- a/utils/incrparse/test_util.py
+++ b/utils/incrparse/test_util.py
@@ -163,7 +163,7 @@ def serializeIncrParseMarkupFile(test_file, test_case, mode,
     # markup for testing incremental parsing
     # =========================================================================
 
-    # Gather command line arguments for swift-syntax-test specifiying the
+    # Gather command line arguments for swift-syntax-test specifying the
     # performed edits in this list
     incremental_edit_args = []
     reparse_args = []

--- a/utils/python_format.py
+++ b/utils/python_format.py
@@ -113,7 +113,7 @@ def parse_args():
     parser.add_argument(
         "--check",
         action="store_true",
-        help="Don't format the file, just retun the status.",
+        help="Don't format the file, just return the status.",
     )
 
     parser.add_argument(

--- a/utils/swift_build_support/swift_build_support/host_specific_configuration.py
+++ b/utils/swift_build_support/swift_build_support/host_specific_configuration.py
@@ -136,7 +136,7 @@ class HostSpecificConfiguration(object):
                 # standard library, whereas the other targets can build a
                 # slightly smaller subset which is faster to build.
                 #
-                # NOTE: We currently do not seperate testing options for
+                # NOTE: We currently do not separate testing options for
                 # stage1/stage2 compiler. This can change with time.
                 if stage_dependent_args.build_swift_stdlib_unittest_extra or \
                         args.validation_test or args.long_test or \

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -77,7 +77,7 @@ class Product(object):
         """is_ignore_install_all_product -> bool
 
         Whether this product is to ignore the install-all directive
-        and insted always respect its own should_install.
+        and instead always respect its own should_install.
         This is useful when we run -install-all but have products
         which should never be installed into the toolchain
         (e.g. earlyswiftdriver)

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -436,7 +436,7 @@ def full_target_name(repository, target):
 
 def skip_list_for_platform(config):
     # If there is a platforms key only include the repo if the
-    # plaform is in the list
+    # platform is in the list
     skip_list = []
     platform_name = platform.system()
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
## description
fix separate files which contains typo spelling grammar, and replace to correct with reference from [merriam webster](merriam-webster.com) and [wikitionary](wikitionary.org)

## testing
not include local testing because just replace the typo words to correct one

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
