### PR TITLE
[Next Branch] Get it compiling again

### DIFF
--- a/include/swift/AST/Ownership.h
+++ b/include/swift/AST/Ownership.h
@@ -24,8 +24,9 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
-#include <stdint.h>
 #include <assert.h>
+#include <limits.h>
+#include <stdint.h>
 
 namespace swift {
 

--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -15,8 +15,8 @@
 
 #include "swift/Basic/LLVM.h"
 #include "swift/Config.h"
+#include "clang/Basic/DarwinSDKInfo.h"
 #include "llvm/ADT/StringRef.h"
-#include "clang/Driver/DarwinSDKInfo.h"
 
 namespace llvm {
   class Triple;
@@ -104,7 +104,7 @@ namespace swift {
   getSwiftRuntimeCompatibilityVersionForTarget(const llvm::Triple &Triple);
 
   /// Retrieve the target SDK version for the given SDKInfo and target triple.
-  llvm::VersionTuple getTargetSDKVersion(clang::driver::DarwinSDKInfo &SDKInfo,
+  llvm::VersionTuple getTargetSDKVersion(clang::DarwinSDKInfo &SDKInfo,
                                          const llvm::Triple &triple);
 
   /// Get SDK build version.

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -420,46 +420,12 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(
   return None;
 }
 
-
-/// Remap the given version number via the version map, or produce \c None if
-/// there is no mapping for this version.
-static Optional<llvm::VersionTuple> remapVersion(
-    const llvm::StringMap<llvm::VersionTuple> &versionMap,
-    llvm::VersionTuple version) {
-  // The build number is never used in the lookup.
-  version = version.withoutBuild();
-
-  // Look for this specific version.
-  auto known = versionMap.find(version.getAsString());
-  if (known != versionMap.end())
-    return known->second;
-
-  // If an extra ".0" was specified (in the subminor version), drop that
-  // and look again.
-  if (!version.getSubminor() || *version.getSubminor() != 0)
-    return None;
-
-  version = llvm::VersionTuple(version.getMajor(), *version.getMinor());
-  known = versionMap.find(version.getAsString());
-  if (known != versionMap.end())
-    return known->second;
-
-  // If another extra ".0" wa specified (in the minor version), drop that
-  // and look again.
-  if (!version.getMinor() || *version.getMinor() != 0)
-    return None;
-
-  version = llvm::VersionTuple(version.getMajor());
-  known = versionMap.find(version.getAsString());
-  if (known != versionMap.end())
-    return known->second;
-
-  return None;
+static const llvm::VersionTuple minimumMacCatalystDeploymentTarget() {
+  return llvm::VersionTuple(13, 1);
 }
 
-llvm::VersionTuple
-swift::getTargetSDKVersion(clang::driver::DarwinSDKInfo &SDKInfo,
-                           const llvm::Triple &triple) {
+llvm::VersionTuple swift::getTargetSDKVersion(clang::DarwinSDKInfo &SDKInfo,
+                                              const llvm::Triple &triple) {
   // Retrieve the SDK version.
   auto SDKVersion = SDKInfo.getVersion();
 
@@ -467,9 +433,13 @@ swift::getTargetSDKVersion(clang::driver::DarwinSDKInfo &SDKInfo,
   // SDK version. Map that to the corresponding iOS version number to pass
   // down to the linker.
   if (tripleIsMacCatalystEnvironment(triple)) {
-    return remapVersion(
-        SDKInfo.getVersionMap().MacOS2iOSMacMapping, SDKVersion)
+    if (const auto *MacOStoMacCatalystMapping = SDKInfo.getVersionMapping(
+            clang::DarwinSDKInfo::OSEnvPair::macOStoMacCatalystPair())) {
+      return MacOStoMacCatalystMapping
+          ->map(SDKVersion, minimumMacCatalystDeploymentTarget(), None)
           .getValueOr(llvm::VersionTuple(0, 0, 0));
+    }
+    return llvm::VersionTuple(0, 0, 0);
   }
 
   return SDKVersion;

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -22,10 +22,10 @@
 #include "swift/Basic/TaskQueue.h"
 #include "swift/Config.h"
 #include "swift/Driver/Compilation.h"
-#include "clang/Driver/DarwinSDKInfo.h"
 #include "swift/Driver/Driver.h"
 #include "swift/Driver/Job.h"
 #include "swift/Option/Options.h"
+#include "clang/Basic/DarwinSDKInfo.h"
 #include "clang/Basic/Version.h"
 #include "clang/Driver/Util.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -954,7 +954,7 @@ toolchains::Darwin::validateOutputInfo(DiagnosticEngine &diags,
                                        const OutputInfo &outputInfo) const {
   // If we have been provided with an SDK, go read the SDK information.
   if (!outputInfo.SDKPath.empty()) {
-    auto SDKInfoOrErr = clang::driver::parseDarwinSDKInfo(
+    auto SDKInfoOrErr = clang::parseDarwinSDKInfo(
         *llvm::vfs::getRealFileSystem(), outputInfo.SDKPath);
     if (SDKInfoOrErr) {
       SDKInfo = *SDKInfoOrErr;

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -15,7 +15,7 @@
 
 #include "swift/Basic/LLVM.h"
 #include "swift/Driver/ToolChain.h"
-#include "clang/Driver/DarwinSDKInfo.h"
+#include "clang/Basic/DarwinSDKInfo.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Support/Compiler.h"
 
@@ -81,7 +81,7 @@ protected:
   /// Information about the SDK that the application is being built against.
   /// This information is only used by the linker, so it is only populated
   /// when there will be a linker job.
-  mutable Optional<clang::driver::DarwinSDKInfo> SDKInfo;
+  mutable Optional<clang::DarwinSDKInfo> SDKInfo;
 
   const Optional<llvm::Triple> TargetVariant;
 

--- a/lib/DriverTool/swift_symbolgraph_extract_main.cpp
+++ b/lib/DriverTool/swift_symbolgraph_extract_main.cpp
@@ -23,6 +23,7 @@
 #include "swift/Option/Options.h"
 #include "swift/SymbolGraphGen/SymbolGraphGen.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace swift;
@@ -235,7 +236,7 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
   // don't need to print these errors.
   CI.removeDiagnosticConsumer(&DiagPrinter);
   
-  SmallVector<ModuleDecl *> Overlays;
+  SmallVector<ModuleDecl *, 8> Overlays;
   M->findDeclaredCrossImportOverlaysTransitive(Overlays);
   for (const auto *OM : Overlays) {
     auto CIM = CI.getASTContext().getModuleByName(OM->getNameStr());

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -688,13 +688,17 @@ void IRGenModule::emitRuntimeRegistration() {
       llvm::ConstantInt::get(Int32Ty, 0),
     };
     auto begin = llvm::ConstantExpr::getGetElementPtr(
-        /*Ty=*/nullptr, protocols, beginIndices);
+        cast<llvm::PointerType>(protocols->getType()->getScalarType())
+            ->getElementType(),
+        protocols, beginIndices);
     llvm::Constant *endIndices[] = {
       llvm::ConstantInt::get(Int32Ty, 0),
       llvm::ConstantInt::get(Int32Ty, SwiftProtocols.size()),
     };
     auto end = llvm::ConstantExpr::getGetElementPtr(
-        /*Ty=*/nullptr, protocols, endIndices);
+        cast<llvm::PointerType>(protocols->getType()->getScalarType())
+            ->getElementType(),
+        protocols, endIndices);
 
     RegIGF.Builder.CreateCall(getRegisterProtocolsFn(), {begin, end});
   }
@@ -706,14 +710,18 @@ void IRGenModule::emitRuntimeRegistration() {
       llvm::ConstantInt::get(Int32Ty, 0),
     };
     auto begin = llvm::ConstantExpr::getGetElementPtr(
-        /*Ty=*/nullptr, conformances, beginIndices);
+        cast<llvm::PointerType>(conformances->getType()->getScalarType())
+            ->getElementType(),
+        conformances, beginIndices);
     llvm::Constant *endIndices[] = {
       llvm::ConstantInt::get(Int32Ty, 0),
       llvm::ConstantInt::get(Int32Ty, ProtocolConformances.size()),
     };
     auto end = llvm::ConstantExpr::getGetElementPtr(
-        /*Ty=*/nullptr, conformances, endIndices);
-    
+        cast<llvm::PointerType>(conformances->getType()->getScalarType())
+            ->getElementType(),
+        conformances, endIndices);
+
     RegIGF.Builder.CreateCall(getRegisterProtocolConformancesFn(), {begin, end});
   }
 
@@ -725,13 +733,17 @@ void IRGenModule::emitRuntimeRegistration() {
       llvm::ConstantInt::get(Int32Ty, 0),
     };
     auto begin = llvm::ConstantExpr::getGetElementPtr(
-        /*Ty=*/nullptr, records, beginIndices);
+        cast<llvm::PointerType>(records->getType()->getScalarType())
+            ->getElementType(),
+        records, beginIndices);
     llvm::Constant *endIndices[] = {
       llvm::ConstantInt::get(Int32Ty, 0),
       llvm::ConstantInt::get(Int32Ty, RuntimeResolvableTypes.size()),
     };
     auto end = llvm::ConstantExpr::getGetElementPtr(
-        /*Ty=*/nullptr, records, endIndices);
+        cast<llvm::PointerType>(records->getType()->getScalarType())
+            ->getElementType(),
+        records, endIndices);
 
     RegIGF.Builder.CreateCall(getRegisterTypeMetadataRecordsFn(), {begin, end});
   }
@@ -2468,7 +2480,10 @@ Address IRGenModule::getAddrOfSILGlobalVariable(SILGlobalVariable *var,
     };
     // Return the address of the initialized object itself (and not the address
     // to a reference to it).
-    addr = llvm::ConstantExpr::getGetElementPtr(nullptr, gvar, Indices);
+    addr = llvm::ConstantExpr::getGetElementPtr(
+        cast<llvm::PointerType>(gvar->getType()->getScalarType())
+            ->getElementType(),
+        gvar, Indices);
   }
   addr = llvm::ConstantExpr::getBitCast(
       addr,

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -517,7 +517,9 @@ static llvm::Constant *buildPrivateMetadata(IRGenModule &IGM,
     llvm::ConstantInt::get(IGM.Int32Ty, 2)
   };
   return llvm::ConstantExpr::getInBoundsGetElementPtr(
-      /*Ty=*/nullptr, var, indices);
+      cast<llvm::PointerType>(var->getType()->getScalarType())
+          ->getElementType(),
+      var, indices);
 }
 
 llvm::Constant *

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -678,7 +678,10 @@ emitMetadataTypeRefForKeyPath(IRGenModule &IGM, CanType type,
   // Mask the bottom bit to tell the key path runtime this is a mangled name
   // rather than a direct reference.
   auto bitConstant = llvm::ConstantInt::get(IGM.IntPtrTy, 1);
-  return llvm::ConstantExpr::getGetElementPtr(nullptr, constant, bitConstant);
+  return llvm::ConstantExpr::getGetElementPtr(
+      cast<llvm::PointerType>(constant->getType()->getScalarType())
+          ->getElementType(),
+      constant, bitConstant);
 }
 
 static unsigned getClassFieldIndex(ClassDecl *classDecl, VarDecl *property) {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -847,8 +847,10 @@ namespace {
           B.getAddrOfCurrentPosition(IGM.ProtocolRequirementStructTy);
         int offset = WitnessTableFirstRequirementOffset;
         auto firstReqAdjustment = llvm::ConstantInt::get(IGM.Int32Ty, -offset);
-        address = llvm::ConstantExpr::getGetElementPtr(nullptr, address,
-                                                       firstReqAdjustment);
+        address = llvm::ConstantExpr::getGetElementPtr(
+            cast<llvm::PointerType>(address->getType()->getScalarType())
+                ->getElementType(),
+            address, firstReqAdjustment);
 
         IGM.defineProtocolRequirementsBaseDescriptor(Proto, address);
       }

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1498,8 +1498,10 @@ llvm::Constant *IRGenModule::getAssociatedTypeWitness(Type type,
   auto witness = llvm::ConstantExpr::getBitCast(typeRef, Int8PtrTy);
   unsigned bit = ProtocolRequirementFlags::AssociatedTypeMangledNameBit;
   auto bitConstant = llvm::ConstantInt::get(IntPtrTy, bit);
-  return llvm::ConstantExpr::getInBoundsGetElementPtr(nullptr, witness,
-                                                      bitConstant);
+  return llvm::ConstantExpr::getInBoundsGetElementPtr(
+      cast<llvm::PointerType>(witness->getType()->getScalarType())
+          ->getElementType(),
+      witness, bitConstant);
 }
 
 static void buildAssociatedTypeValueName(CanType depAssociatedType,

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -476,7 +476,10 @@ llvm::Constant *IRGenModule::getMangledAssociatedConformance(
   // Set the low bit.
   unsigned bit = ProtocolRequirementFlags::AssociatedTypeMangledNameBit;
   auto bitConstant = llvm::ConstantInt::get(IntPtrTy, bit);
-  addr = llvm::ConstantExpr::getGetElementPtr(nullptr, addr, bitConstant);
+  addr = llvm::ConstantExpr::getGetElementPtr(
+      cast<llvm::PointerType>(addr->getType()->getScalarType())
+          ->getElementType(),
+      addr, bitConstant);
 
   // Update the entry.
   entry = {var, addr};

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -694,7 +694,7 @@ void IRGenFunction::emitAwaitAsyncContinuation(
         contAwaitSyncAddr->getType()->getPointerElementType(),
         unsigned(ContinuationStatus::Awaited));
     auto results = Builder.CreateAtomicCmpXchg(
-        contAwaitSyncAddr, pendingV, awaitedV,
+        contAwaitSyncAddr, pendingV, awaitedV, {} /*align*/,
         llvm::AtomicOrdering::Release /*success ordering*/,
         llvm::AtomicOrdering::Acquire /* failure ordering */,
         llvm::SyncScope::System);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -852,8 +852,7 @@ public:
   llvm::PointerType *getEnumValueWitnessTablePtrTy();
 
   void unimplemented(SourceLoc, StringRef Message);
-  LLVM_ATTRIBUTE_NORETURN
-  void fatal_unimplemented(SourceLoc, StringRef Message);
+  [[noreturn]] void fatal_unimplemented(SourceLoc, StringRef Message);
   void error(SourceLoc loc, const Twine &message);
 
   bool useDllStorage();

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -269,7 +269,10 @@ llvm::Constant *IRGenModule::getAddrOfStringForMetadataRef(
       return addr;
 
     auto bitConstant = llvm::ConstantInt::get(IntPtrTy, 1);
-    return llvm::ConstantExpr::getGetElementPtr(nullptr, addr, bitConstant);
+    return llvm::ConstantExpr::getGetElementPtr(
+        cast<llvm::PointerType>(addr->getType()->getScalarType())
+            ->getElementType(),
+        addr, bitConstant);
   };
 
   // Check whether we already have an entry with this name.

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1114,7 +1114,9 @@ static llvm::Constant *emitEmptyTupleTypeMetadataRef(IRGenModule &IGM) {
     llvm::ConstantInt::get(IGM.Int32Ty, 1)
   };
   return llvm::ConstantExpr::getInBoundsGetElementPtr(
-        /*Ty=*/nullptr, fullMetadata, indices);
+      cast<llvm::PointerType>(fullMetadata->getType()->getScalarType())
+          ->getElementType(),
+      fullMetadata, indices);
 }
 
 using GetElementMetadataFn =
@@ -1660,8 +1662,11 @@ namespace {
           llvm::ConstantInt::get(IGF.IGM.Int32Ty, 1)
         };
         return MetadataResponse::forComplete(
-          llvm::ConstantExpr::getInBoundsGetElementPtr(
-            /*Ty=*/nullptr, singletonMetadata, indices));
+            llvm::ConstantExpr::getInBoundsGetElementPtr(
+                cast<llvm::PointerType>(
+                    singletonMetadata->getType()->getScalarType())
+                    ->getElementType(),
+                singletonMetadata, indices));
       }
 
       auto layout = type.getExistentialLayout();

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -574,7 +574,7 @@ void StackAllocationPromoter::propagateLiveness(
   // If liveness has not been propagated, go over the incoming operands and mark
   // any operand values that are proactivePhis as live
   livePhis.insert(proactivePhi);
-  SmallVector<SILValue> incomingPhiVals;
+  SmallVector<SILValue, 4> incomingPhiVals;
   proactivePhi->getIncomingPhiValues(incomingPhiVals);
   for (auto &inVal : incomingPhiVals) {
     auto *inPhi = dyn_cast<SILPhiArgument>(inVal);

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -333,7 +333,7 @@ public:
 
   /// Emits one last diagnostic, adds the current module details and errors to
   /// the pretty stack trace, and then aborts.
-  LLVM_ATTRIBUTE_NORETURN void fatal(llvm::Error error) const;
+  [[noreturn]] void fatal(llvm::Error error) const;
   void fatalIfNotSuccess(llvm::Error error) const {
     if (error)
       fatal(std::move(error));
@@ -344,7 +344,7 @@ public:
     fatal(expected.takeError());
   }
 
-  LLVM_ATTRIBUTE_NORETURN void fatal() const {
+  [[noreturn]] void fatal() const {
     fatal(llvm::make_error<llvm::StringError>(
         "(see \"While...\" info below)", llvm::inconvertibleErrorCode()));
   }

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -371,7 +371,7 @@ private:
 
   /// Emits one last diagnostic, logs the error, and then aborts for the stack
   /// trace.
-  LLVM_ATTRIBUTE_NORETURN void fatal(llvm::Error error) const;
+  [[noreturn]] void fatal(llvm::Error error) const;
   void fatalIfNotSuccess(llvm::Error error) const {
     if (error)
       fatal(std::move(error));


### PR DESCRIPTION
This fixes a handful of issues on the `next` branch that prevented it from building.

I pulled one of Arnold's patches to the rebranch branch for fixing issues with the DarwinSDKInfo.
Fixed instances of the `LLVM_ATTRIBUTE_NORETURN`. LLVM removed it.
Fixed call to `CreateAtomicAsyncContinuation`.
Both `getInboundsGetElementPtr` and `getGetElementPtr` now require the type be fully specified and will assert if a `nullptr` is passed in. I fixed each call site with the old default behavior.