### PR TITLE
[WIP, DNM] Don't try to get nonexistent text.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6821,6 +6821,9 @@ ParamDecl::getDefaultValueStringRepresentation(
           return ".init()";
         }
 
+        if (isImplicit())
+          return StringRef();
+        
         auto &sourceMgr = getASTContext().SourceMgr;
         return extractInlinableText(sourceMgr, wrappedValue, scratch);
       }


### PR DESCRIPTION
Try not serializing implicit `ParamDecl`s. 

`@propertyWrapper public struct W { public var wrappedValue: (); public init(wrappedValue: ()) {} }; public struct S { @W var prop: () }`
crashes the compile with `-emit-module` set.