### PR TITLE
[docs] Describe how _alwaysEmitIntoClient relates to library evolution.

### DIFF
--- a/docs/LibraryEvolution.rst
+++ b/docs/LibraryEvolution.rst
@@ -269,15 +269,16 @@ Always Emit Into Client
 A function, computed property or subscript annotated as ``@_alwaysEmitIntoClient``
 is similar to an ``@inlinable`` declaration, except the declaration is
 not part of the module's ABI, meaning that the client must always emit
-their own copy.
+their own copy. As a result:
 
-As a result, removing a declaration annotated as ``@_alwaysEmitIntoClient``
-is a binary-compatible source-breaking change.
-
-.. admonition:: TODO
-
-    The implementation of ``@_alwaysEmitIntoClient`` is incomplete and
-    should probably graduate to having its own evolution proposal.
+- Removing a declaration annotated as ``@_alwaysEmitIntoClient`` is a
+  `binary-compatible source-breaking change`.
+- Adding ``@_alwaysEmitIntoClient`` to a declaration breaks ABI but is a
+  source-compatible change.
+- Removing ``@_alwaysEmitIntoClient`` from a declaration is a
+  binary-compatible change. It also requires updating the availability
+  to at least the OS version where the attribute was removed. As a result,
+  it may be a source-breaking change.
 
 Default Argument Expressions
 ----------------------------


### PR DESCRIPTION
I also removed an admonition for stabilizing AEIC; I don't think these docs are the right place for that.

I will file separate tickets for tracking stabilization and desired changes to AEIC.