### PR TITLE
Clean up doc comments for task APIs.

### DIFF
--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -12,13 +12,13 @@
 
 import Swift
 
-/// A service which can execute jobs.
+/// A service that can execute jobs.
 @available(SwiftStdlib 5.5, *)
 public protocol Executor: AnyObject, Sendable {
   func enqueue(_ job: UnownedJob)
 }
 
-/// A service which can execute jobs.
+/// A service that executes jobs.
 @available(SwiftStdlib 5.5, *)
 public protocol SerialExecutor: Executor {
   // This requirement is repeated here as a non-override so that we

--- a/stdlib/public/Concurrency/GlobalActor.swift
+++ b/stdlib/public/Concurrency/GlobalActor.swift
@@ -20,7 +20,7 @@ import Swift
 /// are called global actor types, and can be applied to any declaration to
 /// specify that such types are isolated to that global actor type. When using
 /// such a declaration from another actor (or from nonisolated code),
-/// synchronization is performed through the \c shared actor instance to ensure
+/// synchronization is performed through the shared actor instance to ensure
 /// mutually-exclusive access to the declaration.
 @available(SwiftStdlib 5.5, *)
 public protocol GlobalActor {

--- a/stdlib/public/Concurrency/GlobalActor.swift
+++ b/stdlib/public/Concurrency/GlobalActor.swift
@@ -15,7 +15,7 @@ import Swift
 /// A type that represents a globally-unique actor that can be used to isolate
 /// various declarations anywhere in the program.
 ///
-/// A type that conforms to the `GlobalActor` protocol and is marked with the
+/// A type that conforms to the `GlobalActor` protocol and is marked with
 /// the `@globalActor` attribute can be used as a custom attribute. Such types
 /// are called global actor types, and can be applied to any declaration to
 /// specify that such types are isolated to that global actor type. When using

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -26,13 +26,14 @@ import Swift
 /// It's not a programming error to discard a reference to a task
 /// without waiting for that task to finish or canceling it.
 /// A task runs whether or not you keep a reference to it.
-/// However, if you discard a task's handle, you give up the ability
+/// However, if you discard the reference to a task,
+/// you give up the ability
 /// to wait for that task's result or cancel the task.
 ///
 /// To support operations on the current task,
 /// which can be either a detached task or a child task,
-/// `Task` also exposes class methods like `yield()` and `currentPriority`.
-/// Because all such functions are asynchronous,
+/// `Task` also exposes class methods like `yield()`.
+/// Because these methods are asynchronous,
 /// they're always invoked as part of an existing task.
 ///
 /// Only code that's running as part of the task can interact with that task,
@@ -92,13 +93,13 @@ public struct Task<Success, Failure: Error>: Sendable {
 extension Task {
   /// Wait for the task to complete, returning its result or throwing an error.
   ///
-  /// If the task hasn't completed,
+  /// If the task hasn't completed yet,
   /// its priority increases to that of the current task.
   /// Note that this might not be as effective as
   /// creating the task with the correct priority,
   /// depending on the executor's scheduling details.
   ///
-  /// If the task throws an error, this method propogates that error.
+  /// If the task throws an error, this property propogates that error.
   /// Tasks that respond to cancellation by throwing `Task.CancellationError`
   /// have that error propogated here upon cancellation.
   ///
@@ -111,7 +112,7 @@ extension Task {
 
   /// Wait for the task to complete, returning its result or its error.
   ///
-  /// If the task hasn't completed, its priority increases to the
+  /// If the task hasn't completed yet, its priority increases to the
   /// priority of the current task. Note that this isn't as effective as
   /// creating the task with the correct priority.
   ///
@@ -150,15 +151,14 @@ extension Task {
 extension Task where Failure == Never {
   /// Wait for the task to complete, returning its result.
   ///
-  /// If the task hasn't completed,
+  /// If the task hasn't completed yet,
   /// its priority increases to that of the current task.
   /// Note that this might not be as effective as
   /// creating the task with the correct priority,
   /// depending on the executor's scheduling details.
   ///
-  /// Because this method is nonthrowing,
-  /// if the task checks for cancellation,
-  /// it needs to handle cancellation using an approach like returning `nil`
+  /// Tasks that never throw an error can still check for cancellation,
+  /// but they need to use an approach like returning `nil`
   /// instead of throwing an error.
   public var value: Success {
     get async {
@@ -458,7 +458,7 @@ extension Task where Failure == Never {
   /// so the operation is treated more like an asynchronous extension
   /// to the synchronous operation.
   ///
-  /// You need to keep a reference to the detached task
+  /// You need to keep a reference to the task
   /// if you want to cancel it by calling the `Task.cancel()` method.
   /// Discarding your reference to a detached task
   /// doesn't implicitly cancel that task,
@@ -506,7 +506,7 @@ extension Task where Failure == Error {
   /// so the operation is treated more like an asynchronous extension
   /// to the synchronous operation.
   ///
-  /// You need to keep a reference to the detached task
+  /// You need to keep a reference to the task
   /// if you want to cancel it by calling the `Task.cancel()` method.
   /// Discarding your reference to a detached task
   /// doesn't implicitly cancel that task,
@@ -747,7 +747,7 @@ public struct UnsafeCurrentTask {
   /// A Boolean value that indicates whether the current task was canceled.
   ///
   /// After the value of this property is `true`, it remains `true` indefinitely.
-  /// There is no way to uncancel the operation.
+  /// There is no way to uncancel a task.
   ///
   /// - SeeAlso: `checkCancellation()`
   public var isCancelled: Bool {

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -22,34 +22,34 @@ import Swift
 /// Tasks can start running immediately after creation;
 /// you don't explicitly start or schedule them.
 /// After creating a task, you use the instance to interact with it ---
-/// for example, to wait for it to complete or to cancel in.
+/// for example, to wait for it to complete or to cancel.
 /// It's not a programming error to discard a reference to a task
 /// without waiting for that task to finish or canceling it.
-/// A task runs whether or not you keep a reference to it.
+/// A task runs regardless of whether<!-- EDIT: Don't use "whether or not". --> you keep a reference to it.
 /// However, if you discard the reference to a task,
 /// you give up the ability
-/// to wait for that task's result or cancel the task.
+/// to wait for that task's result or if it's canceled.
 ///
 /// To support operations on the current task,
-/// which can be either a detached task or a child task,
+/// which can be either a detached task or child task,
 /// `Task` also exposes class methods like `yield()`.
 /// Because these methods are asynchronous,
 /// they're always invoked as part of an existing task.
 ///
-/// Only code that's running as part of the task can interact with that task,
+/// Only code that's running as part of the task can interact with that task
 /// by invoking the appropriate context-sensitive static functions which operate
-/// on the current task.
+/// on the current task.<!-- FIXME: Long sentence that could probably be split in two. -->
 ///
 /// A task's execution can be seen as a series of periods where the task ran.
 /// Each such period ends at a suspension point or the
 /// completion of the task.
 ///
-/// These partial periods towards the task's completion are `PartialAsyncTask`.
+/// These partial periods towards<!-- FIXME: The preceding wording is a little awkward; please rewrite. --> the task's completion are `PartialAsyncTask`.
 /// Unless you're implementing a scheduler,
-/// you don't generally interact with partial tasks directly.
+/// you don't directly interact with partial tasks.
 ///
 /// For information about the language-level concurrency model that `Task` is part of,
-/// see [Concurrency][concurrency] in *[The Swift Programming Language][tspl]*.
+/// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
 ///
 /// [concurrency]: https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html
 /// [tspl]: https://docs.swift.org/swift-book/
@@ -91,9 +91,9 @@ public struct Task<Success, Failure: Error>: Sendable {
 
 @available(SwiftStdlib 5.5, *)
 extension Task {
-  /// Wait for the task to complete, returning its result or throwing an error.
+  /// Wait for the task to complete, then return its result or throw an error.
   ///
-  /// If the task hasn't completed yet,
+  /// If the task hasn't completed,
   /// its priority increases to that of the current task.
   /// Note that this might not be as effective as
   /// creating the task with the correct priority,
@@ -110,9 +110,9 @@ extension Task {
     }
   }
 
-  /// Wait for the task to complete, returning its result or its error.
+  /// Wait for the task to complete, then return its result or error.
   ///
-  /// If the task hasn't completed yet, its priority increases to the
+  /// If the task hasn't completed, its priority increases to the
   /// priority of the current task. Note that this isn't as effective as
   /// creating the task with the correct priority.
   ///
@@ -129,7 +129,7 @@ extension Task {
     }
   }
 
-  /// Indicate that the task should stop.
+  /// Indicate for the task to stop.
   ///
   /// Task cancellation is cooperative:
   /// a task that supports cancellation
@@ -149,7 +149,7 @@ extension Task {
 
 @available(SwiftStdlib 5.5, *)
 extension Task where Failure == Never {
-  /// Wait for the task to complete, returning its result.
+  /// Wait for the task to complete and return its result.
   ///
   /// If the task hasn't completed yet,
   /// its priority increases to that of the current task.
@@ -191,7 +191,7 @@ extension Task: Equatable {
 /// Typically, executors attempt to run tasks with a higher priority
 /// before tasks with a lower priority.
 /// However, the semantics of how priority is treated are left up to each
-/// platform and `Executor` implementation.
+/// platform and `Executor` implementation.<!-- QUERY: Should there be an article before Executor? -->
 ///
 /// Child tasks automatically inherit their parent task's priority.
 /// Detached tasks created by `detach(priority:operation:)` don't inherit task priority
@@ -206,12 +206,12 @@ extension Task: Equatable {
 ///   then the actor's current task is temporarily elevated
 ///   to the priority of the enqueued task.
 ///   This priority elevation allows the new task
-///   to be processed at (effectively) the priority it was enqueued with.
+///   to be processed at the priority it was enqueued with.
 /// - If a a higher-priority task calls the `get()` method,
 ///   then the priority of this task increases until the task completes.
 ///
 /// In both cases, priority elevation helps you prevent a low-priority task
-/// blocking the execution of a high priority task,
+/// that blocks the execution of a high priority task,
 /// which is also known as *priority inversion*.
 @available(SwiftStdlib 5.5, *)
 public struct TaskPriority: RawRepresentable, Sendable {
@@ -284,7 +284,7 @@ extension Task where Success == Never, Failure == Never {
   /// this property's value is `Priority.default`.
   public static var currentPriority: TaskPriority {
     withUnsafeCurrentTask { task in
-      // If we are running on behalf of a task, use that task's priority.
+      // If running on behalf of a task, use that task's priority.
       if let task = task {
         return task.priority
       }
@@ -307,7 +307,7 @@ extension TaskPriority {
 
 /// Flags for schedulable jobs.
 ///
-/// This is a port of the C++ FlagSet.
+/// This is a port of the C++ FlagSet<!-- FIXME: Rewrite so you're not using FlagSet in the abstract. -->.
 @available(SwiftStdlib 5.5, *)
 struct JobFlags {
   /// Kinds of schedulable jobs.
@@ -329,7 +329,7 @@ struct JobFlags {
     }
   }
 
-  /// Whether this is an asynchronous task.
+  /// Whether this is an asynchronous task.<!-- FIXME: All of these "Whether" statements need to be rewritten to be clearer. What does "Whether" tie into? That part of these one-line descriptions doesn't work. Fix here and throughout the remainder of these for this section. Also, should the lines terminate with a colon instead of a period? -->
   var isAsyncTask: Bool { kind == .task }
 
   /// The priority given to the job.
@@ -414,7 +414,7 @@ struct JobFlags {
 
 // ==== Task Creation Flags --------------------------------------------------
 
-/// Form task creation flags for use with the createAsyncTask builtins.
+/// Form task creation flags for use with the `createAsyncTask`<!-- FIXME: If this is an abstract, you'll need to rewrite so you're not including createAsyncTask here. --> built-ins<!-- FIXME: Hyphenate. -->.
 @available(SwiftStdlib 5.5, *)
 @_alwaysEmitIntoClient
 func taskCreateFlags(
@@ -546,7 +546,7 @@ extension Task where Failure == Never {
   /// Runs the given nonthrowing operation asynchronously
   /// as part of a new top-level task.
   ///
-  /// Avoid using a detached task unless it isn't possible
+  /// Don't use a detached task unless it isn't possible
   /// to model the operation using structured concurrency features like child tasks.
   /// Child tasks inherit the parent task's priority and task-local storage,
   /// and canceling a parent task automatically cancels all of its child tasks.
@@ -593,7 +593,7 @@ extension Task where Failure == Error {
   ///
   /// If the operation throws an error, this method propogates that error.
   ///
-  /// Avoid using a detached task unless it isn't possible
+  /// Don't use a detached task unless it isn't possible
   /// to model the operation using structured concurrency features like child tasks.
   /// Child tasks inherit the parent task's priority and task-local storage,
   /// and canceling a parent task automatically cancels all of its child tasks.
@@ -656,7 +656,7 @@ extension Task where Success == Never, Failure == Never {
   /// in the middle of a long-running operation
   /// that doesn't contain any suspension points,
   /// to let other tasks run for a while
-  /// before execution returns back to this task.
+  /// before execution returns to this task.
   ///
   /// If this task is the highest-priority task in the system,
   /// the executor immediately resumes execution of the same task.
@@ -677,15 +677,15 @@ extension Task where Success == Never, Failure == Never {
 /// Calls a closure with an unsafe reference to the current task.
 ///
 /// If you call this function from the body of an asynchronous function,
-/// the unsafe task handle passed to the closure is always non-nil
+/// the unsafe task handle passed to the closure is always non-`nil`
 /// because an asynchronous function always runs in the context of a task.
-/// However if you call this function from the body of a synchronous function,
+/// However, if you call this function from the body of a synchronous function,
 /// and that function isn't executing in the context of any task,
 /// the unsafe task handle is `nil`.
 ///
 /// Don't store an unsafe task reference
 /// for use outside this method's closure.
-/// Storing an unsafe reference doesn't impact the task's actual life cycle,
+/// Storing an unsafe reference doesn't affect the task's actual life cycle,
 /// and the behavior of accessing an unsafe task reference
 /// outside of the `withUnsafeCurrentTask(body:)` method's closure isn't defined.
 /// Instead, use the `task` property of `UnsafeCurrentTask`
@@ -719,7 +719,7 @@ public func withUnsafeCurrentTask<T>(body: (UnsafeCurrentTask?) throws -> T) ret
 /// call the `withUnsafeCurrentTask(body:)` method.
 /// Don't store an unsafe task reference
 /// for use outside that method's closure.
-/// Storing an unsafe reference doesn't impact the task's actual life cycle,
+/// Storing an unsafe reference doesn't affect the task's actual life cycle,
 /// and the behavior of accessing an unsafe task reference
 /// outside of the `withUnsafeCurrentTask(body:)` method's closure isn't defined.
 ///
@@ -731,7 +731,7 @@ public func withUnsafeCurrentTask<T>(body: (UnsafeCurrentTask?) throws -> T) ret
 /// and may lead to crashes or data loss.
 ///
 /// For information about the language-level concurrency model that `UnsafeCurrentTask` is part of,
-/// see [Concurrency][concurrency] in *[The Swift Programming Language][tspl]*.
+/// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
 ///
 /// [concurrency]: https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html
 /// [tspl]: https://docs.swift.org/swift-book/
@@ -878,8 +878,8 @@ func _getCurrentThreadPriority() -> Int
 
 #if _runtime(_ObjC)
 
-/// Intrinsic used by SILGen to launch a task for bridging a Swift async method
-/// which was called through its ObjC-exported completion-handler-based API.
+/// Intrinsic used by SILGen<!-- FIXME: Should this be in code font? --> to launch a task for bridging a Swift async method
+/// which was called through its ObjC<!-- FIXME: Should this be in code font? -->-exported completion-handler–based API.
 @available(SwiftStdlib 5.5, *)
 @_alwaysEmitIntoClient
 @usableFromInline

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -284,7 +284,7 @@ extension Task where Success == Never, Failure == Never {
   /// this property's value is `Priority.default`.
   public static var currentPriority: TaskPriority {
     withUnsafeCurrentTask { task in
-      // If running on behalf of a task, use that task's priority.
+      // If we are running on behalf of a task, use that task's priority.
       if let task = task {
         return task.priority
       }
@@ -307,7 +307,7 @@ extension TaskPriority {
 
 /// Flags for schedulable jobs.
 ///
-/// This is a port of the C++ FlagSet<!-- FIXME: Rewrite so you're not using FlagSet in the abstract. -->.
+/// This is a port of the C++ FlagSet.
 @available(SwiftStdlib 5.5, *)
 struct JobFlags {
   /// Kinds of schedulable jobs.
@@ -329,7 +329,7 @@ struct JobFlags {
     }
   }
 
-  /// Whether this is an asynchronous task.<!-- FIXME: All of these "Whether" statements need to be rewritten to be clearer. What does "Whether" tie into? That part of these one-line descriptions doesn't work. Fix here and throughout the remainder of these for this section. Also, should the lines terminate with a colon instead of a period? -->
+  /// Whether this is an asynchronous task.
   var isAsyncTask: Bool { kind == .task }
 
   /// The priority given to the job.
@@ -414,7 +414,7 @@ struct JobFlags {
 
 // ==== Task Creation Flags --------------------------------------------------
 
-/// Form task creation flags for use with the `createAsyncTask`<!-- FIXME: If this is an abstract, you'll need to rewrite so you're not including createAsyncTask here. --> built-ins<!-- FIXME: Hyphenate. -->.
+/// Form task creation flags for use with the createAsyncTask builtins.
 @available(SwiftStdlib 5.5, *)
 @_alwaysEmitIntoClient
 func taskCreateFlags(
@@ -878,8 +878,8 @@ func _getCurrentThreadPriority() -> Int
 
 #if _runtime(_ObjC)
 
-/// Intrinsic used by SILGen<!-- FIXME: Should this be in code font? --> to launch a task for bridging a Swift async method
-/// which was called through its ObjC<!-- FIXME: Should this be in code font? -->-exported completion-handler–based API.
+/// Intrinsic used by SILGen to launch a task for bridging a Swift async method
+/// which was called through its ObjC-exported completion-handler-based API.
 @available(SwiftStdlib 5.5, *)
 @_alwaysEmitIntoClient
 @usableFromInline

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -17,15 +17,23 @@ import Swift
 
 /// A unit of asynchronous work.
 ///
-/// An instance of `Task` always represents a top-level task. The instance
-/// can be used to await its completion, cancel the task, etc., The task will
-/// run to completion even if there are no other instances of the `Task`.
+/// When you create an instance of `Task`,
+/// you provide a closure that contains the work for that task to perform.
+/// Tasks can start running immediately after creation;
+/// you don't explicitly start or schedule them.
+/// After creating a task, you use the instance to interact with it ---
+/// for example, to wait for it to complete or to cancel in.
+/// It's not a programming error to discard a reference to a task
+/// without waiting for that task to finish or canceling it.
+/// A task runs whether or not you keep a reference to it.
+/// However, if you discard a task's handle, you give up the ability
+/// to wait for that task's result or cancel the task.
 ///
-/// `Task` also provides appropriate context-sensitive static functions which
-/// operate on the "current" task, which might either be a detached task or
-/// a child task. Because all such functions are `async` they can only
-/// be invoked as part of an existing task, and therefore are guaranteed to be
-/// effective.
+/// To support operations on the current task,
+/// which can be either a detached task or a child task,
+/// `Task` also exposes class methods like `yield()` and `currentPriority`.
+/// Because all such functions are asynchronous,
+/// they're always invoked as part of an existing task.
 ///
 /// Only code that's running as part of the task can interact with that task,
 /// by invoking the appropriate context-sensitive static functions which operate
@@ -38,6 +46,12 @@ import Swift
 /// These partial periods towards the task's completion are `PartialAsyncTask`.
 /// Unless you're implementing a scheduler,
 /// you don't generally interact with partial tasks directly.
+///
+/// For information about the language-level concurrency model that `Task` is part of,
+/// see [Concurrency][concurrency] in *[The Swift Programming Language][tspl]*.
+///
+/// [concurrency]: https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html
+/// [tspl]: https://docs.swift.org/swift-book/
 ///
 /// Task Cancellation
 /// =================
@@ -76,42 +90,34 @@ public struct Task<Success, Failure: Error>: Sendable {
 
 @available(SwiftStdlib 5.5, *)
 extension Task {
-  /// Wait for the task to complete, returning (or throwing) its result.
+  /// Wait for the task to complete, returning its result or throwing an error.
   ///
-  /// ### Priority
-  /// If the task has not completed yet, its priority will be elevated to the
-  /// priority of the current task. Note that this may not be as effective as
-  /// creating the task with the "right" priority to in the first place.
+  /// If the task hasn't completed,
+  /// its priority increases to that of the current task.
+  /// Note that this might not be as effective as
+  /// creating the task with the correct priority,
+  /// depending on the executor's scheduling details.
   ///
-  /// ### Cancellation
-  /// If the awaited on task gets cancelled externally the `get()` will throw
-  /// a cancellation error.
+  /// If the task throws an error, this method propogates that error.
+  /// Tasks that respond to cancellation by throwing `Task.CancellationError`
+  /// have that error propogated here upon cancellation.
   ///
-  /// If the task gets cancelled internally --
-  /// for example, by checking for cancellation
-  /// and throwing a specific error, or by calling `checkCancellation()`,
-  /// then the error thrown by the task is rethrown here.
+  /// - Returns: The task's result.
   public var value: Success {
     get async throws {
       return try await _taskFutureGetThrowing(_task)
     }
   }
 
-  /// Wait for the task to complete, returning its result.
+  /// Wait for the task to complete, returning its result or its error.
   ///
-  /// ### Priority
-  /// If the task has not completed yet, its priority will be elevated to the
-  /// priority of the current task. Note that this may not be as effective as
-  /// creating the task with the "right" priority to in the first place.
+  /// If the task hasn't completed, its priority increases to the
+  /// priority of the current task. Note that this isn't as effective as
+  /// creating the task with the correct priority.
   ///
-  /// ### Cancellation
-  /// If the awaited on task gets cancelled externally the `get()` will throw
-  /// a cancellation error.
-  ///
-  /// If the task gets cancelled internally --
-  /// for example, by checking for cancellation
-  /// and throwing a specific error, or by calling `checkCancellation()`,
-  /// then the error thrown by the task is returned here.
+  /// - Returns: If the task succeeded,
+  ///   `.success` with the task's result as the associated value;
+  ///   otherwise, `.failure` with the error as the associated value.
   public var result: Result<Success, Failure> {
     get async {
       do {
@@ -122,14 +128,19 @@ extension Task {
     }
   }
 
-  /// Attempt to cancel the task.
+  /// Indicate that the task should stop.
   ///
-  /// Whether this function has any effect is task-dependent.
+  /// Task cancellation is cooperative:
+  /// a task that supports cancellation
+  /// checks whether it has been canceled at various points during its work.
   ///
-  /// For a task to respect cancellation it must cooperatively check for it
-  /// while running. Many tasks will check for cancellation before beginning
-  /// their "actual work", however this is not a requirement nor is it guaranteed
-  /// how and when tasks check for cancellation in general.
+  /// Calling this method on a task that doesn't support cancellation
+  /// has no effect.
+  /// Likewise, if the task has already run
+  /// past the last point where it would stop early,
+  /// calling this method has no effect.
+  ///
+  /// - SeeAlso: `Task.checkCancellation()`
   public func cancel() {
     Builtin.cancelAsyncTask(_task)
   }
@@ -145,12 +156,10 @@ extension Task where Failure == Never {
   /// creating the task with the correct priority,
   /// depending on the executor's scheduling details.
   ///
-  /// ### Cancellation
-  /// The task this refers to may check for cancellation, however
-  /// since it is not-throwing it would have to handle it using some other
-  /// way than throwing a `CancellationError`, e.g. it could provide a neutral
-  /// value of the `Success` type, or encode that cancellation has occurred in
-  /// that type itself.
+  /// Because this method is nonthrowing,
+  /// if the task checks for cancellation,
+  /// it needs to handle cancellation using an approach like returning `nil`
+  /// instead of throwing an error.
   public var value: Success {
     get async {
       return await _taskFutureGet(_task)
@@ -175,38 +184,35 @@ extension Task: Equatable {
 
 // ==== Task Priority ----------------------------------------------------------
 
-/// Task priority may inform decisions an `Executor` makes about how and when
-/// to schedule tasks submitted to it.
+/// The priority of a task.
 ///
-/// ### Priority scheduling
-/// An executor MAY utilize priority information to attempt running higher
-/// priority tasks first, and then continuing to serve lower priority tasks.
-///
-/// The exact semantics of how priority is treated are left up to each
+/// The executor determines how priority information affects the way tasks are scheduled.
+/// The behavior varies depending on the executor currently being used.
+/// Typically, executors attempt to run tasks with a higher priority
+/// before tasks with a lower priority.
+/// However, the semantics of how priority is treated are left up to each
 /// platform and `Executor` implementation.
 ///
-/// ### Priority inheritance
 /// Child tasks automatically inherit their parent task's priority.
+/// Detached tasks created by `detach(priority:operation:)` don't inherit task priority
+/// because they aren't attached to the current task.
 ///
-/// Detached tasks (created by `Task.detached`) DO NOT inherit task priority,
-/// as they are "detached" from their parent tasks after all.
+/// In some situations the priority of a task is elevated ---
+/// that is, the task is treated as it if had a higher priority,
+/// without actually changing the priority of the task:
 ///
-/// ### Priority elevation
-/// In some situations the priority of a task must be elevated (or "escalated", "raised"):
+/// - If a task runs on behalf of an actor,
+///   and a new higher-priority task is enqueued to the actor,
+///   then the actor's current task is temporarily elevated
+///   to the priority of the enqueued task.
+///   This priority elevation allows the new task
+///   to be processed at (effectively) the priority it was enqueued with.
+/// - If a a higher-priority task calls the `get()` method,
+///   then the priority of this task increases until the task completes.
 ///
-/// - if a `Task` running on behalf of an actor, and a new higher-priority
-///   task is enqueued to the actor, its current task must be temporarily
-///   elevated to the priority of the enqueued task, in order to allow the new
-///   task to be processed at--effectively-- the priority it was enqueued with.
-///   - this DOES NOT affect `Task.currentPriority()`.
-/// - if a task is created with a `Task.Handle`, and a higher-priority task
-///   calls the `await handle.get()` function the priority of this task must be
-///   permanently increased until the task completes.
-///   - this DOES affect `Task.currentPriority()`.
-///
-/// TODO: Define the details of task priority; It is likely to be a concept
-///       similar to Darwin Dispatch's QoS; bearing in mind that priority is not as
-///       much of a thing on other platforms (i.e. server side Linux systems).
+/// In both cases, priority elevation helps you prevent a low-priority task
+/// blocking the execution of a high priority task,
+/// which is also known as *priority inversion*.
 @available(SwiftStdlib 5.5, *)
 public struct TaskPriority: RawRepresentable, Sendable {
   public typealias RawValue = UInt8
@@ -269,13 +275,13 @@ extension TaskPriority: Codable { }
 @available(SwiftStdlib 5.5, *)
 extension Task where Success == Never, Failure == Never {
 
-  /// Returns the `current` task's priority.
+  /// The current task's priority.
   ///
-  /// If no current `Task` is available, queries the system to determine the
-  /// priority at which the current function is running. If the system cannot
-  /// provide an appropriate priority, returns `Priority.default`.
-  ///
-  /// - SeeAlso: `TaskPriority`
+  /// If you access this property outside of any task,
+  /// this queries the system to determine the
+  /// priority at which the current function is running.
+  /// If the system can't provide a priority,
+  /// this property's value is `Priority.default`.
   public static var currentPriority: TaskPriority {
     withUnsafeCurrentTask { task in
       // If we are running on behalf of a task, use that task's priority.
@@ -439,22 +445,29 @@ func taskCreateFlags(
 // ==== Task Creation ----------------------------------------------------------
 @available(SwiftStdlib 5.5, *)
 extension Task where Failure == Never {
-  /// Run given `operation` as asynchronously in its own top-level task.
+  /// Runs the given nonthrowing operation asynchronously
+  /// as part of a new top-level task on behalf of the current actor.
   ///
-  /// The `async` function should be used when creating asynchronous work
+  /// Use this function when creating asynchronous work
   /// that operates on behalf of the synchronous function that calls it.
-  /// Like `Task.detached`, the async function creates a separate, top-level
-  /// task.
+  /// Like `Task.detached(priority:operation:)`,
+  /// this function creates a separate, top-level task.
+  /// Unlike `Task.detached(priority:operation:)`,
+  /// the task created by `Task.init(priority:operation:)`
+  /// inherits the priority and actor context of the caller,
+  /// so the operation is treated more like an asynchronous extension
+  /// to the synchronous operation.
   ///
-  /// Unlike `Task.detached`, the task creating by the `Task` initializer
-  /// inherits the priority and actor context of the caller, so the `operation`
-  /// is treated more like an asynchronous extension to the synchronous
-  /// operation.
+  /// You need to keep a reference to the detached task
+  /// if you want to cancel it by calling the `Task.cancel()` method.
+  /// Discarding your reference to a detached task
+  /// doesn't implicitly cancel that task,
+  /// it only makes it impossible for you to explicitly cancel the task.
   ///
   /// - Parameters:
-  ///   - priority: priority of the task. If nil, the priority will come from
-  ///     Task.currentPriority.
-  ///   - operation: the operation to execute
+  ///   - priority: The priority of the task.
+  ///     Pass `nil` to use the priority from `Task.currentPriority`.
+  ///   - operation: The operation to perform.
   @discardableResult
   @_alwaysEmitIntoClient
   public init(
@@ -480,18 +493,29 @@ extension Task where Failure == Never {
 
 @available(SwiftStdlib 5.5, *)
 extension Task where Failure == Error {
-  /// Run given `operation` as asynchronously in its own top-level task.
+  /// Runs the given throwing operation asynchronously
+  /// as part of a new top-level task on behalf of the current actor.
   ///
-  /// This initializer creates asynchronous work on behalf of the synchronous function that calls it.
-  /// Like `Task.detached`, this initializer creates a separate, top-level task.
-  /// Unlike `Task.detached`, the task created inherits the priority and
-  /// actor context of the caller, so the `operation` is treated more like an
-  /// asynchronous extension to the synchronous operation.
+  /// Use this function when creating asynchronous work
+  /// that operates on behalf of the synchronous function that calls it.
+  /// Like `Task.detached(priority:operation:)`,
+  /// this function creates a separate, top-level task.
+  /// Unlike `detach(priority:operation:)`,
+  /// the task created by `Task.init(priority:operation:)`
+  /// inherits the priority and actor context of the caller,
+  /// so the operation is treated more like an asynchronous extension
+  /// to the synchronous operation.
+  ///
+  /// You need to keep a reference to the detached task
+  /// if you want to cancel it by calling the `Task.cancel()` method.
+  /// Discarding your reference to a detached task
+  /// doesn't implicitly cancel that task,
+  /// it only makes it impossible for you to explicitly cancel the task.
   ///
   /// - Parameters:
-  ///   - priority: priority of the task. If nil, the priority will come from
-  ///     Task.currentPriority.
-  ///   - operation: the operation to execute
+  ///   - priority: The priority of the task.
+  ///     Pass `nil` to use the priority from `Task.currentPriority`.
+  ///   - operation: The operation to perform.
   @discardableResult
   @_alwaysEmitIntoClient
   public init(
@@ -519,36 +543,26 @@ extension Task where Failure == Error {
 // ==== Detached Tasks ---------------------------------------------------------
 @available(SwiftStdlib 5.5, *)
 extension Task where Failure == Never {
-  /// Run given throwing `operation` as part of a new top-level task.
+  /// Runs the given nonthrowing operation asynchronously
+  /// as part of a new top-level task.
   ///
-  /// Creating detached tasks should, generally, be avoided in favor of using
-  /// `async` functions, `async let` declarations and `await` expressions - as
-  /// those benefit from structured, bounded concurrency which is easier to reason
-  /// about, as well as automatically inheriting the parent tasks priority,
-  /// task-local storage, deadlines, as well as being cancelled automatically
-  /// when their parent task is cancelled. Detached tasks do not get any of those
-  /// benefits, and thus should only be used when an operation is impossible to
-  /// be modelled with child tasks.
+  /// Avoid using a detached task unless it isn't possible
+  /// to model the operation using structured concurrency features like child tasks.
+  /// Child tasks inherit the parent task's priority and task-local storage,
+  /// and canceling a parent task automatically cancels all of its child tasks.
+  /// You need to handle these considerations manually with a detached task.
   ///
-  /// ### Cancellation
-  /// A detached task always runs to completion unless it is explicitly cancelled.
-  /// Specifically, dropping a detached tasks `Task` does _not_ automatically
-  /// cancel given task.
-  ///
-  /// Cancelling a task must be performed explicitly via `cancel()`.
-  ///
-  /// - Note: it is generally preferable to use child tasks rather than detached
-  ///   tasks. Child tasks automatically carry priorities, task-local state,
-  ///   deadlines and have other benefits resulting from the structured
-  ///   concurrency concepts that they model. Consider using detached tasks only
-  ///   when strictly necessary and impossible to model operations otherwise.
+  /// You need to keep a reference to the detached task
+  /// if you want to cancel it by calling the `Task.cancel()` method.
+  /// Discarding your reference to a detached task
+  /// doesn't implicitly cancel that task,
+  /// it only makes it impossible for you to explicitly cancel the task.
   ///
   /// - Parameters:
-  ///   - priority: priority of the task
-  ///   - operation: the operation to execute
-  /// - Returns: handle to the task, allowing to `await get()` on the
-  ///     tasks result or `cancel` it. If the operation fails the handle will
-  ///     throw the error the operation has thrown when awaited on.
+  ///   - priority: The priority of the task.
+  ///   - operation: The operation to perform.
+  ///
+  /// - Returns: A reference to the task.
   @discardableResult
   @_alwaysEmitIntoClient
   public static func detached(
@@ -574,38 +588,28 @@ extension Task where Failure == Never {
 
 @available(SwiftStdlib 5.5, *)
 extension Task where Failure == Error {
-  /// Run given throwing `operation` as part of a new top-level task.
+  /// Runs the given throwing operation asynchronously
+  /// as part of a new top-level task.
   ///
-  /// Creating detached tasks should, generally, be avoided in favor of using
-  /// `async` functions, `async let` declarations and `await` expressions - as
-  /// those benefit from structured, bounded concurrency which is easier to reason
-  /// about, as well as automatically inheriting the parent tasks priority,
-  /// task-local storage, deadlines, as well as being cancelled automatically
-  /// when their parent task is cancelled. Detached tasks do not get any of those
-  /// benefits, and thus should only be used when an operation is impossible to
-  /// be modelled with child tasks.
+  /// If the operation throws an error, this method propogates that error.
   ///
-  /// ### Cancellation
-  /// A detached task always runs to completion unless it is explicitly cancelled.
-  /// Specifically, dropping a detached tasks `Task.Handle` does _not_ automatically
-  /// cancel given task.
+  /// Avoid using a detached task unless it isn't possible
+  /// to model the operation using structured concurrency features like child tasks.
+  /// Child tasks inherit the parent task's priority and task-local storage,
+  /// and canceling a parent task automatically cancels all of its child tasks.
+  /// You need to handle these considerations manually with a detached task.
   ///
-  /// Cancelling a task must be performed explicitly via `handle.cancel()`.
-  ///
-  /// - Note: it is generally preferable to use child tasks rather than detached
-  ///   tasks. Child tasks automatically carry priorities, task-local state,
-  ///   deadlines and have other benefits resulting from the structured
-  ///   concurrency concepts that they model. Consider using detached tasks only
-  ///   when strictly necessary and impossible to model operations otherwise.
+  /// You need to keep a reference to the detached task
+  /// if you want to cancel it by calling the `Task.cancel()` method.
+  /// Discarding your reference to a detached task
+  /// doesn't implicitly cancel that task,
+  /// it only makes it impossible for you to explicitly cancel the task.
   ///
   /// - Parameters:
-  ///   - priority: priority of the task
-  ///   - executor: the executor on which the detached closure should start
-  ///               executing on.
-  ///   - operation: the operation to execute
-  /// - Returns: handle to the task, allowing to `await handle.get()` on the
-  ///     tasks result or `cancel` it. If the operation fails the handle will
-  ///     throw the error the operation has thrown when awaited on.
+  ///   - priority: The priority of the task.
+  ///   - operation: The operation to perform.
+  ///
+  /// - Returns: A reference to the task.
   @discardableResult
   @_alwaysEmitIntoClient
   public static func detached(
@@ -670,8 +674,7 @@ extension Task where Success == Never, Failure == Never {
 
 // ==== UnsafeCurrentTask ------------------------------------------------------
 
-/// Calls the given closure with the with the "current" task in which this
-/// function was invoked.
+/// Calls a closure with an unsafe reference to the current task.
 ///
 /// If you call this function from the body of an asynchronous function,
 /// the unsafe task handle passed to the closure is always non-nil
@@ -680,10 +683,10 @@ extension Task where Success == Never, Failure == Never {
 /// and that function isn't executing in the context of any task,
 /// the unsafe task handle is `nil`.
 ///
-/// Don't store an unsafe task handle
+/// Don't store an unsafe task reference
 /// for use outside this method's closure.
-/// Storing an unsafe task handle doesn't have an impact on the task's actual life cycle,
-/// and the behavior of accessing an unsafe task handle
+/// Storing an unsafe reference doesn't impact the task's actual life cycle,
+/// and the behavior of accessing an unsafe task reference
 /// outside of the `withUnsafeCurrentTask(body:)` method's closure isn't defined.
 /// Instead, use the `task` property of `UnsafeCurrentTask`
 /// to access an instance of `Task` that you can store long-term
@@ -710,25 +713,28 @@ public func withUnsafeCurrentTask<T>(body: (UnsafeCurrentTask?) throws -> T) ret
   return try body(UnsafeCurrentTask(_task))
 }
 
-/// An unsafe task handle for the current task.
+/// An unsafe reference to the current task.
 ///
 /// To get an instance of `UnsafeCurrentTask` for the current task,
 /// call the `withUnsafeCurrentTask(body:)` method.
-/// Don't try to store an unsafe task handle
+/// Don't store an unsafe task reference
 /// for use outside that method's closure.
-/// Storing an unsafe task handle doesn't have an impact on the task's actual life cycle,
-/// and the behavior of accessing an unsafe task handle
+/// Storing an unsafe reference doesn't impact the task's actual life cycle,
+/// and the behavior of accessing an unsafe task reference
 /// outside of the `withUnsafeCurrentTask(body:)` method's closure isn't defined.
-/// Instead, use the `task` property of `UnsafeCurrentTask`
-/// to access an instance of `Task` that you can store long-term
-/// and interact with outside of the closure body.
 ///
 /// Only APIs on `UnsafeCurrentTask` that are also part of `Task`
-/// are safe to invoke from another task
-/// besides the one that this task handle represents.
+/// are safe to invoke from a task other than
+/// the task that this `UnsafeCurrentTask` instance refers to.
 /// Calling other APIs from another task is undefined behavior,
 /// breaks invariants in other parts of the program running on this task,
 /// and may lead to crashes or data loss.
+///
+/// For information about the language-level concurrency model that `UnsafeCurrentTask` is part of,
+/// see [Concurrency][concurrency] in *[The Swift Programming Language][tspl]*.
+///
+/// [concurrency]: https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html
+/// [tspl]: https://docs.swift.org/swift-book/
 @available(SwiftStdlib 5.5, *)
 public struct UnsafeCurrentTask {
   internal let _task: Builtin.NativeObject
@@ -738,7 +744,10 @@ public struct UnsafeCurrentTask {
     self._task = task
   }
 
-  /// Returns `true` if the task is cancelled, and should stop executing.
+  /// A Boolean value that indicates whether the current task was canceled.
+  ///
+  /// After the value of this property is `true`, it remains `true` indefinitely.
+  /// There is no way to uncancel the operation.
   ///
   /// - SeeAlso: `checkCancellation()`
   public var isCancelled: Bool {
@@ -747,7 +756,6 @@ public struct UnsafeCurrentTask {
 
   /// The current task's priority.
   ///
-  /// - SeeAlso: `TaskPriority`
   /// - SeeAlso: `Task.currentPriority`
   public var priority: TaskPriority {
     getJobFlags(_task).priority ?? TaskPriority(

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -99,9 +99,9 @@ extension Task {
   /// creating the task with the correct priority,
   /// depending on the executor's scheduling details.
   ///
-  /// If the task throws an error, this property propogates that error.
+  /// If the task throws an error, this property propagates that error.
   /// Tasks that respond to cancellation by throwing `Task.CancellationError`
-  /// have that error propogated here upon cancellation.
+  /// have that error propagated here upon cancellation.
   ///
   /// - Returns: The task's result.
   public var value: Success {
@@ -595,7 +595,7 @@ extension Task where Failure == Error {
   /// Runs the given throwing operation asynchronously
   /// as part of a new top-level task.
   ///
-  /// If the operation throws an error, this method propogates that error.
+  /// If the operation throws an error, this method propagates that error.
   ///
   /// Don't use a detached task if it's possible
   /// to model the operation using structured concurrency features like child tasks.

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -16,11 +16,11 @@ import Swift
 // ==== Task Cancellation ------------------------------------------------------
 
 /// Execute an operation with a cancellation handler that's immediately
-/// invoked if the current task is canceled.
+/// invoked if the current task is canceled<!-- FIXME: Passive; rewrite. -->.
 ///
 /// This differs from the operation cooperatively checking for cancellation
 /// and reacting to it in that the cancellation handler is _always_ and
-/// _immediately_ invoked when the task is canceled. For example, even if the
+/// _immediately_ invoked when the task is canceled<!-- FIXME: Passive; rewrite. -->. For example, even if the
 /// operation is running code that never checks for cancellation, a cancellation
 /// handler still runs and provides a chance to run some cleanup code.
 ///
@@ -34,8 +34,8 @@ public func withTaskCancellationHandler<T>(
 ) async rethrows -> T {
   let task = Builtin.getCurrentAsyncTask()
 
-  // unconditionally add the cancellation record to the task.
-  // if the task was already cancelled, it will be executed right away.
+  // Unconditionally add the cancellation record to the task.
+  // If the task was already canceled, it executes immediately.
   let record = _taskAddCancellationHandler(handler: handler)
   defer { _taskRemoveCancellationHandler(record: record) }
 
@@ -44,7 +44,7 @@ public func withTaskCancellationHandler<T>(
 
 @available(SwiftStdlib 5.5, *)
 extension Task {
-  /// Returns `true` if the task is canceled, and should stop executing.
+  /// Returns `true`<!-- FIXME: If this is an abstract, don't include code font or links. --> if the task is canceled<!-- FIXME: Passive; rewrite. -->, and should stop executing.
   ///
   /// - SeeAlso: `checkCancellation()`
   public var isCancelled: Bool {
@@ -60,10 +60,10 @@ extension Task {
 
 @available(SwiftStdlib 5.5, *)
 extension Task where Success == Never, Failure == Never {
-  /// Returns `true` if the task is canceled, and should stop executing.
+  /// Returns `true` if the task is canceled, and should stop executing.<!-- FIXME: Abstracts need to be unique; this is copy/pasted from what's on line 47, which means it carries the same problems. Rewrite the abstract so that this is different from the one on line 47. What sets it apart? Why would someone use this over the previous? -->
   ///
   /// If no current `Task` is available, returns `false`, as outside of a task
-  /// context no task cancellation may be observed.
+  /// context no task cancellation may be observed<!-- FIXME: Passive; rewrite. -->.
   ///
   /// - SeeAlso: `checkCancellation()`
   public static var isCancelled: Bool {
@@ -75,7 +75,7 @@ extension Task where Success == Never, Failure == Never {
 
 @available(SwiftStdlib 5.5, *)
 extension Task where Success == Never, Failure == Never {
-  /// Check if the task is canceled and throw an `CancellationError` if it was.
+  /// Check if the task is canceled<!-- FIXME: Passive; rewrite. --> and throw an `CancellationError`<!-- FIXME: Don't include symbols in abstracts. --> if it was.
   ///
   /// The error is always an instance of `Task.CancellationError`.
   ///
@@ -87,13 +87,13 @@ extension Task where Success == Never, Failure == Never {
   }
 }
 
-/// The default cancellation thrown when a task is canceled.
+/// The default cancellation thrown when a task is canceled<!-- FIXME: Passive; rewrite. -->.
 ///
 /// This error is also thrown automatically by `Task.checkCancellation()`,
-/// if the current task has been canceled.
+/// if the current task has been canceled<!-- FIXME: Passive; rewrite. -->.
 @available(SwiftStdlib 5.5, *)
 public struct CancellationError: Error {
-  // no extra information, cancellation is intended to be light-weight
+  // No extra information; cancellation is intended to be light-weight.
   public init() {}
 }
 

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -34,8 +34,8 @@ public func withTaskCancellationHandler<T>(
 ) async rethrows -> T {
   let task = Builtin.getCurrentAsyncTask()
 
-  // Unconditionally add the cancellation record to the task.
-  // If the task was already canceled, it executes immediately.
+  // unconditionally add the cancellation record to the task.
+  // if the task was already cancelled, it will be executed right away.
   let record = _taskAddCancellationHandler(handler: handler)
   defer { _taskRemoveCancellationHandler(record: record) }
 

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -44,7 +44,7 @@ public func withTaskCancellationHandler<T>(
 
 @available(SwiftStdlib 5.5, *)
 extension Task {
-  /// Returns `true` if the task is cancelled, and should stop executing.
+  /// Returns `true` if the task is canceled, and should stop executing.
   ///
   /// - SeeAlso: `checkCancellation()`
   public var isCancelled: Bool {
@@ -60,7 +60,7 @@ extension Task {
 
 @available(SwiftStdlib 5.5, *)
 extension Task where Success == Never, Failure == Never {
-  /// Returns `true` if the task is cancelled, and should stop executing.
+  /// Returns `true` if the task is canceled, and should stop executing.
   ///
   /// If no current `Task` is available, returns `false`, as outside of a task
   /// context no task cancellation may be observed.
@@ -75,7 +75,7 @@ extension Task where Success == Never, Failure == Never {
 
 @available(SwiftStdlib 5.5, *)
 extension Task where Success == Never, Failure == Never {
-  /// Check if the task is cancelled and throw an `CancellationError` if it was.
+  /// Check if the task is canceled and throw an `CancellationError` if it was.
   ///
   /// The error is always an instance of `Task.CancellationError`.
   ///
@@ -87,10 +87,10 @@ extension Task where Success == Never, Failure == Never {
   }
 }
 
-/// The default cancellation thrown when a task is cancelled.
+/// The default cancellation thrown when a task is canceled.
 ///
 /// This error is also thrown automatically by `Task.checkCancellation()`,
-/// if the current task has been cancelled.
+/// if the current task has been canceled.
 @available(SwiftStdlib 5.5, *)
 public struct CancellationError: Error {
   // no extra information, cancellation is intended to be light-weight

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -93,7 +93,7 @@ extension Task where Success == Never, Failure == Never {
 /// if the current task has been canceled<!-- FIXME: Passive; rewrite. -->.
 @available(SwiftStdlib 5.5, *)
 public struct CancellationError: Error {
-  // No extra information; cancellation is intended to be light-weight.
+  // no extra information, cancellation is intended to be light-weight
   public init() {}
 }
 

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -16,11 +16,11 @@ import Swift
 // ==== Task Cancellation ------------------------------------------------------
 
 /// Execute an operation with a cancellation handler that's immediately
-/// invoked if the current task is canceled<!-- FIXME: Passive; rewrite. -->.
+/// invoked if the current task is canceled.
 ///
 /// This differs from the operation cooperatively checking for cancellation
 /// and reacting to it in that the cancellation handler is _always_ and
-/// _immediately_ invoked when the task is canceled<!-- FIXME: Passive; rewrite. -->. For example, even if the
+/// _immediately_ invoked when the task is canceled. For example, even if the
 /// operation is running code that never checks for cancellation, a cancellation
 /// handler still runs and provides a chance to run some cleanup code.
 ///
@@ -44,7 +44,10 @@ public func withTaskCancellationHandler<T>(
 
 @available(SwiftStdlib 5.5, *)
 extension Task {
-  /// Returns `true`<!-- FIXME: If this is an abstract, don't include code font or links. --> if the task is canceled<!-- FIXME: Passive; rewrite. -->, and should stop executing.
+  /// A Boolean value that indicates whether the task should stop executing.
+  ///
+  /// After the value of this property becomes `true`, it remains `true` indefinitely.
+  /// There is no way to uncancel a task.
   ///
   /// - SeeAlso: `checkCancellation()`
   public var isCancelled: Bool {
@@ -60,10 +63,10 @@ extension Task {
 
 @available(SwiftStdlib 5.5, *)
 extension Task where Success == Never, Failure == Never {
-  /// Returns `true` if the task is canceled, and should stop executing.<!-- FIXME: Abstracts need to be unique; this is copy/pasted from what's on line 47, which means it carries the same problems. Rewrite the abstract so that this is different from the one on line 47. What sets it apart? Why would someone use this over the previous? -->
+  /// A Boolean value that indicates whether the task should stop executing.
   ///
-  /// If no current `Task` is available, returns `false`, as outside of a task
-  /// context no task cancellation may be observed<!-- FIXME: Passive; rewrite. -->.
+  /// After the value of this property becomes `true`, it remains `true` indefinitely.
+  /// There is no way to uncancel a task.
   ///
   /// - SeeAlso: `checkCancellation()`
   public static var isCancelled: Bool {
@@ -75,7 +78,7 @@ extension Task where Success == Never, Failure == Never {
 
 @available(SwiftStdlib 5.5, *)
 extension Task where Success == Never, Failure == Never {
-  /// Check if the task is canceled<!-- FIXME: Passive; rewrite. --> and throw an `CancellationError`<!-- FIXME: Don't include symbols in abstracts. --> if it was.
+  /// Throws an error if the task was canceled.
   ///
   /// The error is always an instance of `Task.CancellationError`.
   ///
@@ -87,10 +90,10 @@ extension Task where Success == Never, Failure == Never {
   }
 }
 
-/// The default cancellation thrown when a task is canceled<!-- FIXME: Passive; rewrite. -->.
+/// An error that indicates a task was canceled.
 ///
 /// This error is also thrown automatically by `Task.checkCancellation()`,
-/// if the current task has been canceled<!-- FIXME: Passive; rewrite. -->.
+/// if the current task has been canceled.
 @available(SwiftStdlib 5.5, *)
 public struct CancellationError: Error {
   // no extra information, cancellation is intended to be light-weight

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -270,7 +270,7 @@ public struct TaskGroup<ChildTaskResult> {
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
 
     guard canAdd else {
-      // The group is canceled and isn't accepting any new work.
+      // the group is cancelled and is not accepting any new work
       return false
     }
 
@@ -439,8 +439,8 @@ public struct TaskGroup<ChildTaskResult> {
 @frozen
 public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
 
-  /// The group task into which child tasks offer their results,
-  /// and the `next()`<!-- FIXME: If this is an abstract, don't include anything styled in code font. --> function polls those results from.
+  /// Group task into which child tasks offer their results,
+  /// and the `next()` function polls those results from.
   @usableFromInline
   internal let _group: Builtin.RawPointer
 
@@ -450,7 +450,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
     self._group = group
   }
 
-  /// Await all of the remaining tasks on this group.
+  /// Await all the remaining tasks on this group.
   @usableFromInline
   internal mutating func awaitAllRemainingTasks() async {
     while true {
@@ -522,7 +522,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
 
     guard canAdd else {
-      // The group is canceled and isn't accepting any new work.
+      // the group is cancelled and is not accepting any new work
       return false
     }
 
@@ -645,7 +645,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
 
       return .success(success)
     } catch {
-      return .failure(error as! Failure) // as!-safe, because we<!-- FIXME: Correct the use of first-person voice here and throughout. --> are only allowed to throw Failure (Error).
+      return .failure(error as! Failure) // as!-safe, because we are only allowed to throw Failure (Error)
     }
   }
 
@@ -734,7 +734,7 @@ extension TaskGroup: AsyncSequence {
     @usableFromInline
     var finished: Bool = false
 
-    // No public constructors.
+    // no public constructors
     init(group: TaskGroup<ChildTaskResult>) {
       self.group = group
     }
@@ -821,7 +821,7 @@ extension ThrowingTaskGroup: AsyncSequence {
     @usableFromInline
     var finished: Bool = false
 
-    // No public constructors.
+    // no public constructors
     init(group: ThrowingTaskGroup<ChildTaskResult, Failure>) {
       self.group = group
     }
@@ -880,8 +880,8 @@ func _taskGroupAddPendingTask(
 @_silgen_name("swift_taskGroup_cancelAll")
 func _taskGroupCancelAll(group: Builtin.RawPointer)
 
-/// Checks only if the group was specifically canceled<!-- FIXME: Passive; rewrite. -->.
-/// The task itself being canceled<!-- FIXME: Passive; rewrite. --> must be checked<!-- FIXME: Passive; rewrite. --> separately.
+/// Checks ONLY if the group was specifically canceled.
+/// The task itself being canceled must be checked separately.
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_taskGroup_isCancelled")
 func _taskGroupIsCancelled(group: Builtin.RawPointer) -> Bool

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -373,7 +373,6 @@ public struct TaskGroup<ChildTaskResult> {
   ///
   /// There are no restrictions on where you can call this method.
   /// Code inside a child task or even another task can cancel a group.
-  /// ◊TR: Is this rewrite too strong?
   ///
   /// - SeeAlso: `Task.isCancelled`
   /// - SeeAlso: `TaskGroup.isCancelled`
@@ -388,8 +387,6 @@ public struct TaskGroup<ChildTaskResult> {
   /// If the task that's currently running this group is canceled,
   /// the group is also implicitly canceled,
   /// which is also reflected in this property's value.
-  /// ◊TR: Why do we have two implementations of this method?
-  /// ◊TR: What's the difference between them?
   public var isCancelled: Bool {
     return _taskGroupIsCancelled(group: _group)
   }
@@ -669,7 +666,6 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   ///
   /// There are no restrictions on where you can call this method.
   /// Code inside a child task or even another task can cancel a group.
-  /// ◊TR: Is this rewrite too strong?
   ///
   /// - SeeAlso: `Task.isCancelled`
   /// - SeeAlso: `ThrowingTaskGroup.isCancelled`
@@ -684,8 +680,6 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   /// If the task that's currently running this group is canceled,
   /// the group is also implicitly canceled,
   /// which is also reflected in this property's value.
-  /// ◊TR: Why do we have two implementations of this method?
-  /// ◊TR: What's the difference between them?
   public var isCancelled: Bool {
     return _taskGroupIsCancelled(group: _group)
   }

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -133,7 +133,7 @@ public func withTaskGroup<ChildTaskResult, GroupResult>(
 /// Throwing an error in one of the tasks of a task group
 /// doesn't immediately cancel the other tasks in that group.
 /// However,
-/// if you call `next()` in the task group and propogate its error,
+/// if you call `next()` in the task group and propagate its error,
 /// all other tasks are canceled.
 /// For example, in the code below,
 /// nothing is canceled and the group doesn't throw an error:
@@ -744,7 +744,7 @@ extension TaskGroup: AsyncSequence {
     /// appear in the order that the tasks *completed*,
     /// not in the order that those tasks were added to the task group.
     /// After this method returns `nil`,
-    /// this iterater is guaranteed to never produce more values.
+    /// this iterator is guaranteed to never produce more values.
     ///
     /// For more information about the iteration order and semantics,
     /// see `TaskGroup.next()`.
@@ -831,7 +831,7 @@ extension ThrowingTaskGroup: AsyncSequence {
     /// appear in the order that the tasks *completed*,
     /// not in the order that those tasks were added to the task group.
     /// After this method returns `nil`,
-    /// this iterater is guaranteed to never produce more values.
+    /// this iterator is guaranteed to never produce more values.
     ///
     /// For more information about the iteration order and semantics,
     /// see `ThrowingTaskGroup.next()` 

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -15,16 +15,16 @@ import Swift
 
 // ==== TaskGroup --------------------------------------------------------------
 
-/// Starts a new scope in which a dynamic number of tasks can be created.
+/// Starts a new scope in which a dynamic number of tasks can be created<!-- FIXME: Passive; rewrite. -->.
 ///
 /// When the group returns,
 /// it implicitly waits for all child tasks to complete.
-/// The tasks are canceled only if `cancelAll()` was invoked before returning,
-/// if the group's task was canceled.
+/// The tasks are canceled<!-- FIXME: Passive; rewrite. --> only if `cancelAll()` was invoked<!-- FIXME: Passive; rewrite. --> before returning,
+/// if the group's task was canceled<!-- FIXME: Passive; rewrite. -->.
 ///
-/// After this method returns, the task group is guaranteed to be empty.
+/// After this method returns, the task group is guaranteed<!-- FIXME: Passive; rewrite. --> to be empty.
 ///
-/// To collect the results of tasks that were added to the group,
+/// To collect the results of tasks that were added<!-- FIXME: Passive; rewrite. --> to the group,
 /// you can use the following pattern:
 ///
 ///     var sum = 0
@@ -52,11 +52,11 @@ import Swift
 /// If you call `async(priority:operation:)` to create a new task in a canceled group,
 /// that task is immediately canceled after creation.
 /// Alternatively, you can call `asyncUnlessCancelled(priority:operation:)`,
-/// which doesn't create the task if the group has already been canceled
+/// which doesn't create the task if the group has already been canceled<!-- FIXME: Passive; rewrite. -->
 /// Choosing between these two functions
 /// lets you control how to react to cancellation within a group:
 /// some child tasks need to run regardless of cancellation
-/// and others are better not even being created
+/// and others are better not even being created<!-- FIXME: Passive; rewrite. Also, "are better not even being created knowing" doesn't make any sense. How can they "know"? You're anthropomorphizing the code. Don't do that. -->
 /// knowing they can't produce useful results.
 ///
 /// Because the tasks you add to a group with this method are nonthrowing,
@@ -90,18 +90,18 @@ public func withTaskGroup<ChildTaskResult, GroupResult>(
   #endif
 }
 
-/// Starts a new scope in which a dynamic number of throwing tasks can be created.
+/// Starts a new scope in which a dynamic number of throwing tasks can be created<!-- FIXME: Passive; rewrite. -->.
 ///
 /// When the group returns,
 /// it implicitly waits for all child tasks to complete.
-/// The tasks are canceled only if `cancelAll()` was invoked before returning,
-/// if the group's task was canceled,
+/// The tasks are canceled<!-- FIXME: Passive; rewrite. --> only if `cancelAll()` was invoked<!-- FIXME: Passive; rewrite. --> before returning,
+/// if the group's task was canceled<!-- FIXME: Passive; rewrite. -->,
 /// or if the group's body throws an error.
 ///
-/// After this method returns, the task group is guaranteed to be empty.
+/// After this method returns, the task group is guaranteed<!-- FIXME: Passive; rewrite. --> to be empty.
 ///
-/// To collect the results of tasks that were added to the group,
-/// you can use the following pattern:
+/// To collect the results of tasks that were added<!-- FIXME: Passive; rewrite. --> to the group,
+/// use the following pattern:
 ///
 ///     var sum = 0
 ///     for await result in group {
@@ -109,7 +109,7 @@ public func withTaskGroup<ChildTaskResult, GroupResult>(
 ///     }
 ///
 /// If you need more control or only a few results,
-/// you can use a pattern like the following:
+/// you can use the following pattern:
 ///
 ///     guard let first = await group.next() {
 ///         group.cancelAll()
@@ -122,26 +122,26 @@ public func withTaskGroup<ChildTaskResult, GroupResult>(
 /// Task Group Cancellation
 /// =======================
 ///
-/// Canceling the task in which the group is running
+/// Canceling the task that the group is running in
 /// also cancels the group and all of its child tasks.
 ///
 /// If you call `async(priority:operation:)` to create a new task in a canceled group,
-/// that task is is immediately canceled after being created.
+/// that task is immediately canceled after being created<!-- FIXME: Passive; rewrite. -->.
 /// Alternatively, you can call `asyncUnlessCancelled(priority:operation:)`,
-/// which doesn't create the task if the group has already been canceled
+/// which doesn't create the task if the group has already been canceled<!-- FIXME: Passive; rewrite. -->
 /// Choosing between these two functions
 /// lets you control how to react to cancellation within a group:
 /// some child tasks need to run regardless of cancellation
 /// and others are better not even being created
-/// knowing they can't produce useful results.
+/// knowing<!-- FIXME: Rewrite for clarity, fix the passive voice, and don't anthropomorphize the code; how can it "know"? --> they can't produce useful results.
 ///
 /// Throwing an error in one of the tasks of a task group
 /// doesn't immediately cancel the other tasks in that group.
 /// However,
 /// if you call `next()` in the task group and propogate its error,
-/// all other tasks are canceled.
+/// all other tasks are canceled<!-- FIXME: Passive; rewrite. -->.
 /// For example, in the code below,
-/// nothing is canceled and the group doesn't throw an error:
+/// nothing is canceled<!-- FIXME: Passive; rewrite. --> and the group doesn't throw an error:
 ///
 ///     withThrowingTaskGroup { group in
 ///         group.addTask { throw SomeError() }
@@ -158,7 +158,7 @@ public func withTaskGroup<ChildTaskResult, GroupResult>(
 /// An individual task throws its error
 /// in the corresponding call to `Group.next()`,
 /// which gives you a chance to handle individual error
-/// or to let the error be rethrown by the group.
+/// or to let the error be rethrown<!-- FIXME: Passive; rewrite. --> by the group.
 @available(SwiftStdlib 5.5, *)
 @inlinable
 public func withThrowingTaskGroup<ChildTaskResult, GroupResult>(
@@ -198,15 +198,15 @@ public func withThrowingTaskGroup<ChildTaskResult, GroupResult>(
 /// To create a task group,
 /// call the `withTaskGroup(of:returning:body:)` method.
 ///
-/// A task group must be used only within the task where it was created.
+/// A task group must be used only within the task where it was created<!-- FIXME: Passive; rewrite. -->.
 /// In most cases,
 /// the Swift type system prevents a task group from escaping like that
 /// because adding a child task is a mutating operation,
-/// and mutation operations can't be performed
-/// from concurrent execution contexts likes child tasks.
+/// and mutation operations can't be performed<!-- FIXME: Passive; rewrite. -->
+/// from concurrent execution contexts like child tasks.
 ///
 /// For information about the language-level concurrency model that `TaskGroup` is part of,
-/// see [Concurrency][concurrency] in *[The Swift Programming Language][tspl]*.
+/// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
 ///
 /// [concurrency]: https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html
 /// [tspl]: https://docs.swift.org/swift-book/
@@ -252,7 +252,7 @@ public struct TaskGroup<ChildTaskResult> {
 #endif
   }
 
-  /// Adds a child task to the group, unless the group has been canceled.
+  /// Adds a child task to the group, unless the group has been canceled<!-- FIXME: Passive; rewrite. -->.
   ///
   /// - Parameters:
   ///   - overridingPriority: The priority of the operation task.
@@ -270,7 +270,7 @@ public struct TaskGroup<ChildTaskResult> {
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
 
     guard canAdd else {
-      // the group is cancelled and is not accepting any new work
+      // The group is canceled and isn't accepting any new work.
       return false
     }
 
@@ -294,7 +294,7 @@ public struct TaskGroup<ChildTaskResult> {
   ///
   /// The values returned by successive calls to this method
   /// appear in the order that the tasks *completed*,
-  /// not in the order that those tasks were added to the task group.
+  /// not in the order that those tasks were added<!-- FIXME: Passive; rewrite. --> to the task group.
   /// For example:
   ///
   ///     group.addTask { 1 }
@@ -324,17 +324,17 @@ public struct TaskGroup<ChildTaskResult> {
   /// Awaiting on an empty group
   /// immediate returns `nil` without suspending.
   ///
-  /// You can also use `for await` to collect results of a task groups:
+  /// You can also use `for await` to collect results of a task group:
   ///
   ///     for await try value in group {
   ///         collected += value
   ///     }
   ///
   /// Don't call this method from outside the task
-  /// where this task group was created.
-  /// In most cases, the Swift type system prevents this mistake;
-  /// for example, because the `add(priority:operation:)` method is mutating,
-  /// that method can't be called from a concurrent execution context like a child task.
+  /// where this task group was created<!-- FIXME: Passive; rewrite. -->.
+  /// In most cases, the Swift type system prevents this mistake.
+  /// For example, because the `add(priority:operation:)` method is mutating,
+  /// that method can't be called<!-- FIXME: Passive; rewrite. --> from a concurrent execution context like a child task.
   ///
   /// - Returns: The value returned by the next child task that completes.
   public mutating func next() async -> ChildTaskResult? {
@@ -374,7 +374,7 @@ public struct TaskGroup<ChildTaskResult> {
   /// are silently discarded.
   ///
   /// If you add a task to a group after canceling the group,
-  /// that task is canceled immediately after being added to the group.
+  /// that task is canceled<!-- FIXME: Passive; rewrite. --> immediately after being added<!-- FIXME: Passive; rewrite. --> to the group.
   ///
   /// There are no restrictions on where you can call this method.
   /// Code inside a child task or even another task can cancel a group.
@@ -386,11 +386,11 @@ public struct TaskGroup<ChildTaskResult> {
     _taskGroupCancelAll(group: _group)
   }
 
-  /// A Boolean value that indicates whether the group was canceled.
+  /// A Boolean value that indicates whether the group was canceled<!-- FIXME: Passive; rewrite. -->.
   ///
   /// To cancel a group, call the `TaskGroup.cancelAll()` method.
   ///
-  /// If the task that's currently running this group is canceled,
+  /// If the task that's currently running this group is canceled<!-- FIXME: Passive; rewrite. -->,
   /// the group is also implicitly canceled,
   /// which is also reflected in this property's value.
   public var isCancelled: Bool {
@@ -398,7 +398,7 @@ public struct TaskGroup<ChildTaskResult> {
   }
 }
 
-// Implementation note:
+// Implementation note:<!-- FIXME: I know this doesn't go out as part of the docs, but this text should follow Apple Style and not use first-person voice. -->
 // We are unable to just™ abstract over Failure == Error / Never because of the
 // complicated relationship between `group.spawn` which dictates if `group.next`
 // AND the AsyncSequence conformances would be throwing or not.
@@ -422,7 +422,7 @@ public struct TaskGroup<ChildTaskResult> {
 /// To create a throwing task group,
 /// call the `withThrowingTaskGroup(of:returning:body:)` method.
 ///
-/// A throwing task group must be used only within the task where it was created.
+/// Use a throwing task group within the creating task.
 /// In most cases,
 /// the Swift type system prevents a task group from escaping like that
 /// because adding a child task is a mutating operation,
@@ -430,7 +430,7 @@ public struct TaskGroup<ChildTaskResult> {
 /// from concurrent execution contexts likes child tasks.
 ///
 /// For information about the language-level concurrency model that `ThrowingTaskGroup` is part of,
-/// see [Concurrency][concurrency] in *[The Swift Programming Language][tspl]*.
+/// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
 ///
 /// [concurrency]: https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html
 /// [tspl]: https://docs.swift.org/swift-book/
@@ -439,8 +439,8 @@ public struct TaskGroup<ChildTaskResult> {
 @frozen
 public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
 
-  /// Group task into which child tasks offer their results,
-  /// and the `next()` function polls those results from.
+  /// The group task into which child tasks offer their results,
+  /// and the `next()`<!-- FIXME: If this is an abstract, don't include anything styled in code font. --> function polls those results from.
   @usableFromInline
   internal let _group: Builtin.RawPointer
 
@@ -450,7 +450,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
     self._group = group
   }
 
-  /// Await all the remaining tasks on this group.
+  /// Await all of the remaining tasks on this group.
   @usableFromInline
   internal mutating func awaitAllRemainingTasks() async {
     while true {
@@ -501,7 +501,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
 #endif
   }
 
-  /// Adds a child task to the group, unless the group has been canceled.
+  /// Adds a child task to the group, unless the group has been canceled<!-- FIXME: Passive; rewrite. -->.
   ///
   /// This method doesn't throw an error, even if the child task does.
   /// Instead, the corresponding call to `ThrowingTaskGroup.next()` rethrows that error.
@@ -511,7 +511,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   ///     Omit this parameter or pass `.unspecified`
   ///     to set the child task's priority to the priority of the group.
   ///   - operation: The operation to execute as part of the task group.
-  /// - Returns: `true` if the child task was added to the group;
+  /// - Returns: `true` if the child task was added<!-- FIXME: Passive; rewrite. --> to the group;
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
   public mutating func addTaskUnlessCancelled(
@@ -522,7 +522,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
 
     guard canAdd else {
-      // the group is cancelled and is not accepting any new work
+      // The group is canceled and isn't accepting any new work.
       return false
     }
 
@@ -546,7 +546,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   ///
   /// The values returned by successive calls to this method
   /// appear in the order that the tasks *completed*,
-  /// not in the order that those tasks were added to the task group.
+  /// not in the order that those tasks were added<!-- FIXME: Passive; rewrite. --> to the task group.
   /// For example:
   ///
   ///     group.addTask { 1 }
@@ -564,7 +564,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   ///        return first
   ///     }
   ///
-  /// It also lets you write code like the following
+  /// It also lets you write the following code
   /// to wait for all the child tasks to complete,
   /// collecting the values they returned:
   ///
@@ -576,7 +576,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   /// Awaiting on an empty group
   /// immediate returns `nil` without suspending.
   ///
-  /// You can also use `for await` to collect results of a task groups:
+  /// You can also use `for await`<!-- QUERY: Should this be `for`-`await`? --> to collect results of a task groups:
   ///
   ///     for await try value in group {
   ///         collected += value
@@ -586,13 +586,13 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   /// and you propagate that error from this method
   /// out of the body of a call to the
   /// `ThrowingTaskGroup.withThrowingTaskGroup(of:returning:body:)` method,
-  /// then all remaining child tasks in that group are implicitly canceled.
+  /// then all remaining child tasks in that group are implicitly canceled<!-- FIXME: Passive; rewrite. -->.
   ///
   /// Don't call this method from outside the task
   /// where this task group was created.
   /// In most cases, the Swift type system prevents this mistake;
   /// for example, because the `add(priority:operation:)` method is mutating,
-  /// that method can't be called from a concurrent execution context like a child task.
+  /// that method can't be called<!-- FIXME: Passive; rewrite. --> from a concurrent execution context like a child task.
   ///
   /// - Returns: The value returned by the next child task that completes.
   ///
@@ -629,7 +629,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   /// and you propagate that error from this method
   /// out of the body of a call to the
   /// `ThrowingTaskGroup.withThrowingTaskGroup(of:returning:body:)` method,
-  /// then all remaining child tasks in that group are implicitly canceled.
+  /// then all remaining child tasks in that group are implicitly canceled<!-- FIXME: Passive; rewrite. -->.
   ///
   /// - Returns: A `Result.success` value
   ///   containing the value that the child task returned,
@@ -645,7 +645,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
 
       return .success(success)
     } catch {
-      return .failure(error as! Failure) // as!-safe, because we are only allowed to throw Failure (Error)
+      return .failure(error as! Failure) // as!-safe, because we<!-- FIXME: Correct the use of first-person voice here and throughout. --> are only allowed to throw Failure (Error).
     }
   }
 
@@ -665,10 +665,10 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   ///
   /// After cancellation,
   /// any new results or errors from the tasks in this group
-  /// are silently discarded.
+  /// are silently discarded<!-- FIXME: Passive; rewrite. -->.
   ///
   /// If you add a task to a group after canceling the group,
-  /// that task is canceled immediately after being added to the group.
+  /// that task is canceled<!-- FIXME: Passive; rewrite. --> immediately after being added<!-- FIXME: Passive; rewrite. --> to the group.
   ///
   /// There are no restrictions on where you can call this method.
   /// Code inside a child task or even another task can cancel a group.
@@ -680,13 +680,13 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
     _taskGroupCancelAll(group: _group)
   }
 
-  /// A Boolean value that indicates whether the group was canceled.
+  /// A Boolean value that indicates whether the group was canceled<!-- FIXME: Passive; rewrite. -->.
   ///
   /// To cancel a group, call the `ThrowingTaskGroup.cancelAll()` method.
   ///
-  /// If the task that's currently running this group is canceled,
-  /// the group is also implicitly canceled,
-  /// which is also reflected in this property's value.
+  /// If the task that's currently running this group is canceled<!-- FIXME: Passive; rewrite. -->,
+  /// the group is also implicitly canceled<!-- FIXME: Passive; rewrite. -->,
+  /// which is also reflected<!-- FIXME: Passive; rewrite. --> in this property's value.
   public var isCancelled: Bool {
     return _taskGroupIsCancelled(group: _group)
   }
@@ -708,7 +708,7 @@ extension TaskGroup: AsyncSequence {
   ///
   /// The elements returned by this iterator
   /// appear in the order that the tasks *completed*,
-  /// not in the order that those tasks were added to the task group.
+  /// not in the order that those tasks were added<!-- FIXME: Passive; rewrite. --> to the task group.
   ///
   /// This iterator terminates after all tasks have completed.
   /// After iterating over the results of each task,
@@ -734,7 +734,7 @@ extension TaskGroup: AsyncSequence {
     @usableFromInline
     var finished: Bool = false
 
-    // no public constructors
+    // No public constructors.
     init(group: TaskGroup<ChildTaskResult>) {
       self.group = group
     }
@@ -782,12 +782,12 @@ extension ThrowingTaskGroup: AsyncSequence {
   ///
   /// The elements returned by this iterator
   /// appear in the order that the tasks *completed*,
-  /// not in the order that those tasks were added to the task group.
+  /// not in the order that those tasks were added<!-- FIXME: Passive; rewrite. --> to the task group.
   ///
-  /// This iterator terminates after all tasks have completed successfully,
+  /// This iterator terminates after all tasks have completed,
   /// or after any task completes by throwing an error.
   /// If a task completes by throwing an error,
-  /// no further task results are returned.
+  /// no further task results are returned<!-- FIXME: Passive; rewrite. -->.
   /// After iterating over the results of each task,
   /// it's valid to make a new iterator for the task group,
   /// which you can use to iterate over the results of new tasks you add to the group.
@@ -807,7 +807,7 @@ extension ThrowingTaskGroup: AsyncSequence {
   ///         // Resolve the error.
   ///     }
   ///     
-  ///     // Assuming the child tasks complete in order, this prints "2"
+  ///     // Assuming the child tasks complete in order, this prints "2".
   ///     for try await r in group { print(r) }
   ///
   /// - SeeAlso: `ThrowingTaskGroup.next()`
@@ -821,7 +821,7 @@ extension ThrowingTaskGroup: AsyncSequence {
     @usableFromInline
     var finished: Bool = false
 
-    // no public constructors
+    // No public constructors.
     init(group: ThrowingTaskGroup<ChildTaskResult, Failure>) {
       self.group = group
     }
@@ -830,9 +830,9 @@ extension ThrowingTaskGroup: AsyncSequence {
     ///
     /// The elements returned from this method
     /// appear in the order that the tasks *completed*,
-    /// not in the order that those tasks were added to the task group.
+    /// not in the order that those tasks were added<!-- FIXME: Passive; rewrite. --> to the task group.
     /// After this method returns `nil`,
-    /// this iterater is guaranteed to never produce more values.
+    /// this iterater is guaranteed<!-- FIXME: Passive; rewrite. --> to never produce more values.
     ///
     /// For more information about the iteration order and semantics,
     /// see `ThrowingTaskGroup.next()` 
@@ -880,8 +880,8 @@ func _taskGroupAddPendingTask(
 @_silgen_name("swift_taskGroup_cancelAll")
 func _taskGroupCancelAll(group: Builtin.RawPointer)
 
-/// Checks ONLY if the group was specifically canceled.
-/// The task itself being canceled must be checked separately.
+/// Checks only if the group was specifically canceled<!-- FIXME: Passive; rewrite. -->.
+/// The task itself being canceled<!-- FIXME: Passive; rewrite. --> must be checked<!-- FIXME: Passive; rewrite. --> separately.
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_taskGroup_isCancelled")
 func _taskGroupIsCancelled(group: Builtin.RawPointer) -> Bool

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -15,17 +15,14 @@ import Swift
 
 // ==== TaskGroup --------------------------------------------------------------
 
-/// Starts a new scope in which a dynamic number of tasks can be created<!-- FIXME: Passive; rewrite. -->.
+/// Starts a new scope that can contain a dynamic number of child tasks.
 ///
-/// When the group returns,
-/// it implicitly waits for all child tasks to complete.
-/// The tasks are canceled<!-- FIXME: Passive; rewrite. --> only if `cancelAll()` was invoked<!-- FIXME: Passive; rewrite. --> before returning,
-/// if the group's task was canceled<!-- FIXME: Passive; rewrite. -->.
+/// A group waits for all of its child tasks
+/// to complete or be canceled before it returns.
+/// After this function returns, the task group is always empty.
 ///
-/// After this method returns, the task group is guaranteed<!-- FIXME: Passive; rewrite. --> to be empty.
-///
-/// To collect the results of tasks that were added<!-- FIXME: Passive; rewrite. --> to the group,
-/// you can use the following pattern:
+/// To collect the results of the group's child tasks,
+/// you can use a `for`-`await`-`in` loop:
 ///
 ///     var sum = 0
 ///     for await result in group {
@@ -33,7 +30,7 @@ import Swift
 ///     }
 ///
 /// If you need more control or only a few results,
-/// you can use a pattern like the following:
+/// you can call `next()` directly:
 ///
 ///     guard let first = await group.next() {
 ///         group.cancelAll()
@@ -46,18 +43,19 @@ import Swift
 /// Task Group Cancellation
 /// =======================
 ///
-/// Canceling the task in which the group is running
-/// also cancels the group and all of its child tasks.
+/// You can cancel a task group and all of its child tasks
+/// by calling the `cancellAll()` method on the task group,
+/// or by canceling the task in which the group is running.
 ///
 /// If you call `async(priority:operation:)` to create a new task in a canceled group,
 /// that task is immediately canceled after creation.
 /// Alternatively, you can call `asyncUnlessCancelled(priority:operation:)`,
-/// which doesn't create the task if the group has already been canceled<!-- FIXME: Passive; rewrite. -->
+/// which doesn't create the task if the group has already been canceled
 /// Choosing between these two functions
 /// lets you control how to react to cancellation within a group:
-/// some child tasks need to run regardless of cancellation
-/// and others are better not even being created<!-- FIXME: Passive; rewrite. Also, "are better not even being created knowing" doesn't make any sense. How can they "know"? You're anthropomorphizing the code. Don't do that. -->
-/// knowing they can't produce useful results.
+/// some child tasks need to run regardless of cancellation,
+/// but other tasks are better not even being created
+/// when you know they can't produce useful results.
 ///
 /// Because the tasks you add to a group with this method are nonthrowing,
 /// those tasks can't respond to cancellation by throwing `CancellationError`.
@@ -90,18 +88,14 @@ public func withTaskGroup<ChildTaskResult, GroupResult>(
   #endif
 }
 
-/// Starts a new scope in which a dynamic number of throwing tasks can be created<!-- FIXME: Passive; rewrite. -->.
+/// Starts a new scope that can contain a dynamic number of throwing child tasks.
 ///
-/// When the group returns,
-/// it implicitly waits for all child tasks to complete.
-/// The tasks are canceled<!-- FIXME: Passive; rewrite. --> only if `cancelAll()` was invoked<!-- FIXME: Passive; rewrite. --> before returning,
-/// if the group's task was canceled<!-- FIXME: Passive; rewrite. -->,
-/// or if the group's body throws an error.
+/// A group waits for all of its child tasks
+/// to complete, throw an error, or be canceled before it returns.
+/// After this function returns, the task group is always empty.
 ///
-/// After this method returns, the task group is guaranteed<!-- FIXME: Passive; rewrite. --> to be empty.
-///
-/// To collect the results of tasks that were added<!-- FIXME: Passive; rewrite. --> to the group,
-/// use the following pattern:
+/// To collect the results of the group's child tasks,
+/// you can use a `for`-`await`-`in` loop:
 ///
 ///     var sum = 0
 ///     for await result in group {
@@ -109,7 +103,7 @@ public func withTaskGroup<ChildTaskResult, GroupResult>(
 ///     }
 ///
 /// If you need more control or only a few results,
-/// you can use the following pattern:
+/// you can call `next()` directly:
 ///
 ///     guard let first = await group.next() {
 ///         group.cancelAll()
@@ -122,26 +116,27 @@ public func withTaskGroup<ChildTaskResult, GroupResult>(
 /// Task Group Cancellation
 /// =======================
 ///
-/// Canceling the task that the group is running in
-/// also cancels the group and all of its child tasks.
+/// You can cancel a task group and all of its child tasks
+/// by calling the `cancellAll()` method on the task group,
+/// or by canceling the task in which the group is running.
 ///
 /// If you call `async(priority:operation:)` to create a new task in a canceled group,
-/// that task is immediately canceled after being created<!-- FIXME: Passive; rewrite. -->.
+/// that task is immediately canceled after creation.
 /// Alternatively, you can call `asyncUnlessCancelled(priority:operation:)`,
-/// which doesn't create the task if the group has already been canceled<!-- FIXME: Passive; rewrite. -->
+/// which doesn't create the task if the group has already been canceled
 /// Choosing between these two functions
 /// lets you control how to react to cancellation within a group:
-/// some child tasks need to run regardless of cancellation
-/// and others are better not even being created
-/// knowing<!-- FIXME: Rewrite for clarity, fix the passive voice, and don't anthropomorphize the code; how can it "know"? --> they can't produce useful results.
+/// some child tasks need to run regardless of cancellation,
+/// but other tasks are better not even being created
+/// when you know they can't produce useful results.
 ///
 /// Throwing an error in one of the tasks of a task group
 /// doesn't immediately cancel the other tasks in that group.
 /// However,
 /// if you call `next()` in the task group and propogate its error,
-/// all other tasks are canceled<!-- FIXME: Passive; rewrite. -->.
+/// all other tasks are canceled.
 /// For example, in the code below,
-/// nothing is canceled<!-- FIXME: Passive; rewrite. --> and the group doesn't throw an error:
+/// nothing is canceled and the group doesn't throw an error:
 ///
 ///     withThrowingTaskGroup { group in
 ///         group.addTask { throw SomeError() }
@@ -157,8 +152,8 @@ public func withTaskGroup<ChildTaskResult, GroupResult>(
 ///
 /// An individual task throws its error
 /// in the corresponding call to `Group.next()`,
-/// which gives you a chance to handle individual error
-/// or to let the error be rethrown<!-- FIXME: Passive; rewrite. --> by the group.
+/// which gives you a chance to handle the individual error
+/// or to let the group rethrow the error.
 @available(SwiftStdlib 5.5, *)
 @inlinable
 public func withThrowingTaskGroup<ChildTaskResult, GroupResult>(
@@ -198,12 +193,12 @@ public func withThrowingTaskGroup<ChildTaskResult, GroupResult>(
 /// To create a task group,
 /// call the `withTaskGroup(of:returning:body:)` method.
 ///
-/// A task group must be used only within the task where it was created<!-- FIXME: Passive; rewrite. -->.
+/// Don't use a task group from outside the task where you created it.
 /// In most cases,
 /// the Swift type system prevents a task group from escaping like that
-/// because adding a child task is a mutating operation,
-/// and mutation operations can't be performed<!-- FIXME: Passive; rewrite. -->
-/// from concurrent execution contexts like child tasks.
+/// because adding a child task to a task group is a mutating operation,
+/// and mutation operations can't be performed
+/// from a concurrent execution context like a child task.
 ///
 /// For information about the language-level concurrency model that `TaskGroup` is part of,
 /// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
@@ -252,7 +247,7 @@ public struct TaskGroup<ChildTaskResult> {
 #endif
   }
 
-  /// Adds a child task to the group, unless the group has been canceled<!-- FIXME: Passive; rewrite. -->.
+  /// Adds a child task to the group, unless the group has been canceled.
   ///
   /// - Parameters:
   ///   - overridingPriority: The priority of the operation task.
@@ -294,7 +289,7 @@ public struct TaskGroup<ChildTaskResult> {
   ///
   /// The values returned by successive calls to this method
   /// appear in the order that the tasks *completed*,
-  /// not in the order that those tasks were added<!-- FIXME: Passive; rewrite. --> to the task group.
+  /// not in the order that those tasks were added to the task group.
   /// For example:
   ///
   ///     group.addTask { 1 }
@@ -324,17 +319,17 @@ public struct TaskGroup<ChildTaskResult> {
   /// Awaiting on an empty group
   /// immediate returns `nil` without suspending.
   ///
-  /// You can also use `for await` to collect results of a task group:
+  /// You can also use a `for`-`await`-`in` loop to collect results of a task group:
   ///
   ///     for await try value in group {
   ///         collected += value
   ///     }
   ///
   /// Don't call this method from outside the task
-  /// where this task group was created<!-- FIXME: Passive; rewrite. -->.
+  /// where you created this task group.
   /// In most cases, the Swift type system prevents this mistake.
   /// For example, because the `add(priority:operation:)` method is mutating,
-  /// that method can't be called<!-- FIXME: Passive; rewrite. --> from a concurrent execution context like a child task.
+  /// that method can't be called from a concurrent execution context like a child task.
   ///
   /// - Returns: The value returned by the next child task that completes.
   public mutating func next() async -> ChildTaskResult? {
@@ -374,7 +369,7 @@ public struct TaskGroup<ChildTaskResult> {
   /// are silently discarded.
   ///
   /// If you add a task to a group after canceling the group,
-  /// that task is canceled<!-- FIXME: Passive; rewrite. --> immediately after being added<!-- FIXME: Passive; rewrite. --> to the group.
+  /// that task is canceled immediately after being added to the group.
   ///
   /// There are no restrictions on where you can call this method.
   /// Code inside a child task or even another task can cancel a group.
@@ -386,19 +381,21 @@ public struct TaskGroup<ChildTaskResult> {
     _taskGroupCancelAll(group: _group)
   }
 
-  /// A Boolean value that indicates whether the group was canceled<!-- FIXME: Passive; rewrite. -->.
+  /// A Boolean value that indicates whether the group was canceled.
   ///
   /// To cancel a group, call the `TaskGroup.cancelAll()` method.
   ///
-  /// If the task that's currently running this group is canceled<!-- FIXME: Passive; rewrite. -->,
+  /// If the task that's currently running this group is canceled,
   /// the group is also implicitly canceled,
   /// which is also reflected in this property's value.
+  /// ◊TR: Why do we have two implementations of this method?
+  /// ◊TR: What's the difference between them?
   public var isCancelled: Bool {
     return _taskGroupIsCancelled(group: _group)
   }
 }
 
-// Implementation note:<!-- FIXME: I know this doesn't go out as part of the docs, but this text should follow Apple Style and not use first-person voice. -->
+// Implementation note:
 // We are unable to just™ abstract over Failure == Error / Never because of the
 // complicated relationship between `group.spawn` which dictates if `group.next`
 // AND the AsyncSequence conformances would be throwing or not.
@@ -422,12 +419,12 @@ public struct TaskGroup<ChildTaskResult> {
 /// To create a throwing task group,
 /// call the `withThrowingTaskGroup(of:returning:body:)` method.
 ///
-/// Use a throwing task group within the creating task.
+/// Don't use a task group from outside the task where you created it.
 /// In most cases,
 /// the Swift type system prevents a task group from escaping like that
-/// because adding a child task is a mutating operation,
+/// because adding a child task to a task group is a mutating operation,
 /// and mutation operations can't be performed
-/// from concurrent execution contexts likes child tasks.
+/// from concurrent execution contexts like a child task.
 ///
 /// For information about the language-level concurrency model that `ThrowingTaskGroup` is part of,
 /// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
@@ -501,7 +498,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
 #endif
   }
 
-  /// Adds a child task to the group, unless the group has been canceled<!-- FIXME: Passive; rewrite. -->.
+  /// Adds a child task to the group, unless the group has been canceled.
   ///
   /// This method doesn't throw an error, even if the child task does.
   /// Instead, the corresponding call to `ThrowingTaskGroup.next()` rethrows that error.
@@ -511,7 +508,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   ///     Omit this parameter or pass `.unspecified`
   ///     to set the child task's priority to the priority of the group.
   ///   - operation: The operation to execute as part of the task group.
-  /// - Returns: `true` if the child task was added<!-- FIXME: Passive; rewrite. --> to the group;
+  /// - Returns: `true` if the child task was added to the group;
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
   public mutating func addTaskUnlessCancelled(
@@ -546,7 +543,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   ///
   /// The values returned by successive calls to this method
   /// appear in the order that the tasks *completed*,
-  /// not in the order that those tasks were added<!-- FIXME: Passive; rewrite. --> to the task group.
+  /// not in the order that those tasks were added to the task group.
   /// For example:
   ///
   ///     group.addTask { 1 }
@@ -564,7 +561,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   ///        return first
   ///     }
   ///
-  /// It also lets you write the following code
+  /// It also lets you write code like the following
   /// to wait for all the child tasks to complete,
   /// collecting the values they returned:
   ///
@@ -576,7 +573,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   /// Awaiting on an empty group
   /// immediate returns `nil` without suspending.
   ///
-  /// You can also use `for await`<!-- QUERY: Should this be `for`-`await`? --> to collect results of a task groups:
+  /// You can also use a `for`-`await`-`in` loop to collect results of a task group:
   ///
   ///     for await try value in group {
   ///         collected += value
@@ -586,13 +583,13 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   /// and you propagate that error from this method
   /// out of the body of a call to the
   /// `ThrowingTaskGroup.withThrowingTaskGroup(of:returning:body:)` method,
-  /// then all remaining child tasks in that group are implicitly canceled<!-- FIXME: Passive; rewrite. -->.
+  /// then all remaining child tasks in that group are implicitly canceled.
   ///
   /// Don't call this method from outside the task
   /// where this task group was created.
   /// In most cases, the Swift type system prevents this mistake;
   /// for example, because the `add(priority:operation:)` method is mutating,
-  /// that method can't be called<!-- FIXME: Passive; rewrite. --> from a concurrent execution context like a child task.
+  /// that method can't be called from a concurrent execution context like a child task.
   ///
   /// - Returns: The value returned by the next child task that completes.
   ///
@@ -629,7 +626,7 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   /// and you propagate that error from this method
   /// out of the body of a call to the
   /// `ThrowingTaskGroup.withThrowingTaskGroup(of:returning:body:)` method,
-  /// then all remaining child tasks in that group are implicitly canceled<!-- FIXME: Passive; rewrite. -->.
+  /// then all remaining child tasks in that group are implicitly canceled.
   ///
   /// - Returns: A `Result.success` value
   ///   containing the value that the child task returned,
@@ -665,10 +662,10 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   ///
   /// After cancellation,
   /// any new results or errors from the tasks in this group
-  /// are silently discarded<!-- FIXME: Passive; rewrite. -->.
+  /// are silently discarded.
   ///
   /// If you add a task to a group after canceling the group,
-  /// that task is canceled<!-- FIXME: Passive; rewrite. --> immediately after being added<!-- FIXME: Passive; rewrite. --> to the group.
+  /// that task is canceled immediately after being added to the group.
   ///
   /// There are no restrictions on where you can call this method.
   /// Code inside a child task or even another task can cancel a group.
@@ -680,13 +677,15 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
     _taskGroupCancelAll(group: _group)
   }
 
-  /// A Boolean value that indicates whether the group was canceled<!-- FIXME: Passive; rewrite. -->.
+  /// A Boolean value that indicates whether the group was canceled.
   ///
   /// To cancel a group, call the `ThrowingTaskGroup.cancelAll()` method.
   ///
-  /// If the task that's currently running this group is canceled<!-- FIXME: Passive; rewrite. -->,
-  /// the group is also implicitly canceled<!-- FIXME: Passive; rewrite. -->,
-  /// which is also reflected<!-- FIXME: Passive; rewrite. --> in this property's value.
+  /// If the task that's currently running this group is canceled,
+  /// the group is also implicitly canceled,
+  /// which is also reflected in this property's value.
+  /// ◊TR: Why do we have two implementations of this method?
+  /// ◊TR: What's the difference between them?
   public var isCancelled: Bool {
     return _taskGroupIsCancelled(group: _group)
   }
@@ -708,7 +707,7 @@ extension TaskGroup: AsyncSequence {
   ///
   /// The elements returned by this iterator
   /// appear in the order that the tasks *completed*,
-  /// not in the order that those tasks were added<!-- FIXME: Passive; rewrite. --> to the task group.
+  /// not in the order that those tasks were added to the task group.
   ///
   /// This iterator terminates after all tasks have completed.
   /// After iterating over the results of each task,
@@ -782,12 +781,12 @@ extension ThrowingTaskGroup: AsyncSequence {
   ///
   /// The elements returned by this iterator
   /// appear in the order that the tasks *completed*,
-  /// not in the order that those tasks were added<!-- FIXME: Passive; rewrite. --> to the task group.
+  /// not in the order that those tasks were added to the task group.
   ///
-  /// This iterator terminates after all tasks have completed,
+  /// This iterator terminates after all tasks have completed successfully,
   /// or after any task completes by throwing an error.
   /// If a task completes by throwing an error,
-  /// no further task results are returned<!-- FIXME: Passive; rewrite. -->.
+  /// it doesn't return any further task results.
   /// After iterating over the results of each task,
   /// it's valid to make a new iterator for the task group,
   /// which you can use to iterate over the results of new tasks you add to the group.
@@ -830,9 +829,9 @@ extension ThrowingTaskGroup: AsyncSequence {
     ///
     /// The elements returned from this method
     /// appear in the order that the tasks *completed*,
-    /// not in the order that those tasks were added<!-- FIXME: Passive; rewrite. --> to the task group.
+    /// not in the order that those tasks were added to the task group.
     /// After this method returns `nil`,
-    /// this iterater is guaranteed<!-- FIXME: Passive; rewrite. --> to never produce more values.
+    /// this iterater is guaranteed to never produce more values.
     ///
     /// For more information about the iteration order and semantics,
     /// see `ThrowingTaskGroup.next()` 

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -552,12 +552,12 @@ public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
   ///     group.addTask { 1 }
   ///     group.addTask { 2 }
   ///
-  ///     await print(group.next())
+  ///     print(await group.next())
   ///     // Prints either "2" or "1".
   ///
   /// If there aren't any pending tasks in the task group,
   /// this method returns `nil`,
-  /// which lets you write like the following
+  /// which lets you write the following
   /// to wait for a single task to complete:
   ///
   ///     if let first = try await group.next() {

--- a/stdlib/public/Concurrency/TaskSleep.swift
+++ b/stdlib/public/Concurrency/TaskSleep.swift
@@ -42,10 +42,10 @@ extension Task where Success == Never, Failure == Never {
     /// The sleep has finished.
     case finished
 
-    /// The sleep was cancelled.
+    /// The sleep was canceled.
     case cancelled
 
-    /// The sleep was cancelled before it even got started.
+    /// The sleep was canceled before it even got started.
     case cancelledBeforeStarted
 
     /// Decode sleep state from the word of storage.
@@ -103,7 +103,7 @@ extension Task where Success == Never, Failure == Never {
   }
 
   /// Called when the sleep(nanoseconds:) operation woke up without being
-  /// cancelled.
+  /// canceled.
   private static func onSleepWake(
       _ wordPtr: UnsafeMutablePointer<Builtin.Word>
   ) {
@@ -146,7 +146,7 @@ extension Task where Success == Never, Failure == Never {
     }
   }
 
-  /// Called when the sleep(nanoseconds:) operation has been cancelled before
+  /// Called when the sleep(nanoseconds:) operation has been canceled before
   /// the sleep completed.
   private static func onSleepCancel(
       _ wordPtr: UnsafeMutablePointer<Builtin.Word>
@@ -193,7 +193,7 @@ extension Task where Success == Never, Failure == Never {
   }
 
   /// Suspends the current task for _at least_ the given duration
-  /// in nanoseconds, unless the task is cancelled. If the task is cancelled,
+  /// in nanoseconds, unless the task is canceled. If the task is canceled,
   /// throws \c CancellationError without waiting for the duration.
   ///
   /// This function does _not_ block the underlying thread.

--- a/stdlib/public/Concurrency/TaskSleep.swift
+++ b/stdlib/public/Concurrency/TaskSleep.swift
@@ -14,10 +14,10 @@ import Swift
 
 @available(SwiftStdlib 5.5, *)
 extension Task where Success == Never, Failure == Never {
-  /// Suspends the current task for _at least_ the given duration
+  /// Suspends the current task for at least<!-- NOTE: Don't use italics or any other font styling in an abstract. --> the given duration
   /// in nanoseconds.
   ///
-  /// This function does _not_ block the underlying thread.
+  /// This function does not<!-- NOTE: Italics aren't necessary here. --> block the underlying thread.
   public static func sleep(_ duration: UInt64) async {
     return await Builtin.withUnsafeContinuation { (continuation: Builtin.RawUnsafeContinuation) -> Void in
       let job = _taskCreateNullaryContinuationJob(
@@ -33,19 +33,19 @@ extension Task where Success == Never, Failure == Never {
 
   /// Describes the state of a sleep() operation.
   private enum SleepState {
-    /// The sleep continuation has not yet begun.
+    /// The sleep continuation hasn't begun.
     case notStarted
 
-    // The sleep continuation has been created and is available here.
+    // The sleep continuation has been created<!-- FIXME: Passive; rewrite. --> and is available here.
     case activeContinuation(SleepContinuation)
 
-    /// The sleep has finished.
+    /// The sleep has finished<!-- FIXME: Passive; rewrite. -->.
     case finished
 
-    /// The sleep was canceled.
+    /// The sleep was canceled<!-- FIXME: Passive; rewrite. -->.
     case cancelled
 
-    /// The sleep was canceled before it even got started.
+    /// The sleep was canceled<!-- FIXME: Passive; rewrite. --> before it even started<!-- FIXME: Passive; rewrite. -->.
     case cancelledBeforeStarted
 
     /// Decode sleep state from the word of storage.
@@ -75,12 +75,12 @@ extension Task where Success == Never, Failure == Never {
       }
     }
 
-    /// Decode sleep state by loading from the given pointer
+    /// Decode the sleep state by loading from the given pointer.
     init(loading wordPtr: UnsafeMutablePointer<Builtin.Word>) {
       self.init(word: Builtin.atomicload_seqcst_Word(wordPtr._rawValue))
     }
 
-    /// Encode sleep state into a word of storage.
+    /// Encode the sleep state into a word of storage.
     var word: UInt {
       switch self {
       case .notStarted:
@@ -102,8 +102,8 @@ extension Task where Success == Never, Failure == Never {
     }
   }
 
-  /// Called when the sleep(nanoseconds:) operation woke up without being
-  /// canceled.
+  /// Called when the sleep(nanoseconds:)<!-- FIXME: If this is an abstract, remove the symbol and use an English language equivalent. --> operation woke up without being
+  /// canceled<!-- FIXME: Passive; rewrite. -->.
   private static func onSleepWake(
       _ wordPtr: UnsafeMutablePointer<Builtin.Word>
   ) {
@@ -114,39 +114,39 @@ extension Task where Success == Never, Failure == Never {
         fatalError("Cannot wake before we even started")
 
       case .activeContinuation(let continuation):
-        // We have an active continuation, so try to transition to the
+        // We<!-- FIXME: Correct the use of first person voice here and throughout. Comments, even those that don't get published, should follow Apple Style. --> have an active continuation, so try to transition to the
         // "finished" state.
         let (_, won) = Builtin.cmpxchg_seqcst_seqcst_Word(
             wordPtr._rawValue,
             state.word._builtinWordValue,
             SleepState.finished.word._builtinWordValue)
         if Bool(_builtinBooleanLiteral: won) {
-          // The sleep finished, so invoke the continuation: we're done.
+          // The sleep finished, so invoke the continuation: we're<!-- FIXME: Fix voice. --> done.
           continuation.resume()
           return
         }
 
-        // Try again!
+        // Try again.
         continue
 
       case .finished:
-        fatalError("Already finished normally, can't do that again")
+        fatalError("Already finished normally, can't do that again.")
 
       case .cancelled:
-        // The task was cancelled, which means the continuation was
-        // called by the cancellation handler. We need to deallocate the flag
+        // The task was canceled, which means the continuation was
+        // called by the cancellation handler. We<!-- FIXME: Fix voice. --> need to deallocate the flag
         // word, because it was left over for this task to complete.
         wordPtr.deallocate()
         return
 
       case .cancelledBeforeStarted:
-        // Nothing to do;
+        // Nothing to do.
         return
       }
     }
   }
 
-  /// Called when the sleep(nanoseconds:) operation has been canceled before
+  /// Called when the sleep(nanoseconds:)<!-- FIXME: If this is an abstract, remove the symbol and use an English language equivalent. --> operation has been canceled<!-- FIXME: Passive; rewrite. --> before
   /// the sleep completed.
   private static func onSleepCancel(
       _ wordPtr: UnsafeMutablePointer<Builtin.Word>
@@ -155,7 +155,7 @@ extension Task where Success == Never, Failure == Never {
       let state = SleepState(loading: wordPtr)
       switch state {
       case .notStarted:
-        // We haven't started yet, so try to transition to the cancelled-before
+        // We<!-- FIXME: Fix voice. --> haven't started yet, so try to transition to the cancelled-before
         // started state.
         let (_, won) = Builtin.cmpxchg_seqcst_seqcst_Word(
             wordPtr._rawValue,
@@ -165,24 +165,24 @@ extension Task where Success == Never, Failure == Never {
           return
         }
 
-        // Try again!
+        // Try again.
         continue
 
       case .activeContinuation(let continuation):
-        // We have an active continuation, so try to transition to the
+        // We<!-- FIXME: Fix voice. --> have an active continuation, so try to transition to the
         // "cancelled" state.
         let (_, won) = Builtin.cmpxchg_seqcst_seqcst_Word(
             wordPtr._rawValue,
             state.word._builtinWordValue,
             SleepState.cancelled.word._builtinWordValue)
         if Bool(_builtinBooleanLiteral: won) {
-          // We recorded the task cancellation before the sleep finished, so
+          // We<!-- FIXME: Fix voice. --> recorded the task cancellation before the sleep finished, so
           // invoke the continuation with the cancellation error.
           continuation.resume(throwing: _Concurrency.CancellationError())
           return
         }
 
-        // Try again!
+        // Try again.
         continue
 
       case .finished, .cancelled, .cancelledBeforeStarted:
@@ -192,17 +192,17 @@ extension Task where Success == Never, Failure == Never {
     }
   }
 
-  /// Suspends the current task for _at least_ the given duration
-  /// in nanoseconds, unless the task is canceled. If the task is canceled,
-  /// throws \c CancellationError without waiting for the duration.
+  /// Suspends the current task for at least the given duration
+  /// in nanoseconds, unless the task is canceled<!-- FIXME: Passive; rewrite. -->. If the task is canceled<!-- FIXME: Passive; rewrite. -->,
+  /// throws \c CancellationError without waiting for the duration.<!-- FIXME: If this is an abstract, it shouldn't contain any symbols or additional font styling. Also, an abstract is only a single sentence of 150 chars or less. -->
   ///
-  /// This function does _not_ block the underlying thread.
+  /// This function doen't block the underlying thread.
   public static func sleep(nanoseconds duration: UInt64) async throws {
     // Allocate storage for the storage word.
     let wordPtr = UnsafeMutablePointer<Builtin.Word>.allocate(capacity: 1)
 
     // Initialize the flag word to "not started", which means the continuation
-    // has neither been created nor completed.
+    // has neither been created nor completed<!-- FIXME: Passive; rewrite. -->.
     Builtin.atomicstore_seqcst_Word(
         wordPtr._rawValue, SleepState.notStarted.word._builtinWordValue)
 
@@ -225,13 +225,13 @@ extension Task where Success == Never, Failure == Never {
                   state.word._builtinWordValue,
                   continuationWord._builtinWordValue)
               if !Bool(_builtinBooleanLiteral: won) {
-                // Keep trying!
+                // Keep trying.
                 continue
               }
 
               // Create a task that resumes the continuation normally if it
               // finishes first. Enqueue it directly with the delay, so it fires
-              // when we're done sleeping.
+              // when we're<!-- FIXME: Fix voice. --> done sleeping.
               let sleepTaskFlags = taskCreateFlags(
                 priority: nil, isChildTask: false, copyTaskLocals: false,
                 inheritContext: false, enqueueJob: false,
@@ -244,14 +244,14 @@ extension Task where Success == Never, Failure == Never {
               return
 
             case .activeContinuation, .finished:
-              fatalError("Impossible to have multiple active continuations")
+              fatalError("Impossible to have multiple active continuations.")
 
             case .cancelled:
-              fatalError("Impossible to have cancelled before we began")
+              fatalError("Impossible to have canceled before we<!-- FIXME: Fix voice. --> began.")
 
             case .cancelledBeforeStarted:
-              // Finish the continuation normally. We'll throw later, after
-              // we clean up.
+              // Finish the continuation normally. We'll<!-- FIXME: Fix voice. --> throw later, after
+              // we<!-- FIXME: Fix voice. --> clean up.
               continuation.resume()
               return
           }
@@ -261,11 +261,11 @@ extension Task where Success == Never, Failure == Never {
         onSleepCancel(wordPtr)
       }
 
-      // Determine whether we got cancelled before we even started.
+      // Determine whether we<!-- FIXME: Fix voice. --> got canceled before we<!-- FIXME: Fix voice. --> even started.
       let cancelledBeforeStarted: Bool
       switch SleepState(loading: wordPtr) {
       case .notStarted, .activeContinuation, .cancelled:
-        fatalError("Invalid state for non-cancelled sleep task")
+        fatalError("Invalid state for an uncanceled sleep task.")
 
       case .cancelledBeforeStarted:
         cancelledBeforeStarted = true
@@ -274,17 +274,17 @@ extension Task where Success == Never, Failure == Never {
         cancelledBeforeStarted = false
       }
 
-      // We got here without being cancelled, so deallocate the storage for
+      // We<!-- FIXME: Fix voice. --> got here without being canceled<!-- FIXME: Passive; rewrite. -->, so deallocate the storage for
       // the flag word and continuation.
       wordPtr.deallocate()
 
-      // If we got cancelled before we even started, through the cancellation
+      // If we<!-- FIXME: Fix voice. --> got canceled before w<!-- FIXME: Fix voice. -->e even started, through the cancellation
       // error now.
       if cancelledBeforeStarted {
         throw _Concurrency.CancellationError()
       }
     } catch {
-      // The task was cancelled; propagate the error. The "on wake" task is
+      // The task was canceled<!-- FIXME: Passive; rewrite. -->; propagate the error. The "on wake" task is
       // responsible for deallocating the flag word and continuation, if it's
       // still running.
       throw error

--- a/stdlib/public/Concurrency/TaskSleep.swift
+++ b/stdlib/public/Concurrency/TaskSleep.swift
@@ -16,8 +16,6 @@ import Swift
 extension Task where Success == Never, Failure == Never {
   /// Suspends the current task for at least the given duration
   /// in nanoseconds.
-  /// ◊TR: Why do we have both sleep(_:) and sleep(nanoseconds:) -- what's the difference between them?
-  /// ◊TR: It looks like only sleep(nanoseconds:) throws.
   ///
   /// This function doesn't block the underlying thread.
   public static func sleep(_ duration: UInt64) async {

--- a/stdlib/public/Concurrency/TaskSleep.swift
+++ b/stdlib/public/Concurrency/TaskSleep.swift
@@ -14,10 +14,12 @@ import Swift
 
 @available(SwiftStdlib 5.5, *)
 extension Task where Success == Never, Failure == Never {
-  /// Suspends the current task for at least<!-- NOTE: Don't use italics or any other font styling in an abstract. --> the given duration
+  /// Suspends the current task for at least the given duration
   /// in nanoseconds.
+  /// ◊TR: Why do we have both sleep(_:) and sleep(nanoseconds:) -- what's the difference between them?
+  /// ◊TR: It looks like only sleep(nanoseconds:) throws.
   ///
-  /// This function does not<!-- NOTE: Italics aren't necessary here. --> block the underlying thread.
+  /// This function doesn't block the underlying thread.
   public static func sleep(_ duration: UInt64) async {
     return await Builtin.withUnsafeContinuation { (continuation: Builtin.RawUnsafeContinuation) -> Void in
       let job = _taskCreateNullaryContinuationJob(
@@ -193,10 +195,12 @@ extension Task where Success == Never, Failure == Never {
   }
 
   /// Suspends the current task for at least the given duration
-  /// in nanoseconds, unless the task is canceled<!-- FIXME: Passive; rewrite. -->. If the task is canceled<!-- FIXME: Passive; rewrite. -->,
-  /// throws \c CancellationError without waiting for the duration.<!-- FIXME: If this is an abstract, it shouldn't contain any symbols or additional font styling. Also, an abstract is only a single sentence of 150 chars or less. -->
+  /// in nanoseconds.
   ///
-  /// This function doen't block the underlying thread.
+  /// If the task is canceled before the time ends,
+  /// this function throws `CancellationError`.
+  ///
+  /// This function doesn't block the underlying thread.
   public static func sleep(nanoseconds duration: UInt64) async throws {
     // Allocate storage for the storage word.
     let wordPtr = UnsafeMutablePointer<Builtin.Word>.allocate(capacity: 1)

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -225,7 +225,7 @@ def operatorComment(operator, fixedWidth):
   ///     // y == -35 (after overflow)
   ///
   /// For more about arithmetic with overflow operators, see [Overflow
-  /// Operators][overflow] in *[The Swift Programming Language][tspl]*.
+  /// Operators][overflow] in [The Swift Programming Language][tspl].
   ///
   /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
   /// [tspl]: https://docs.swift.org/swift-book/
@@ -250,7 +250,7 @@ def operatorComment(operator, fixedWidth):
   ///     // y == 245 (after overflow)
   ///
   /// For more about arithmetic with overflow operators, see [Overflow
-  /// Operators][overflow] in *[The Swift Programming Language][tspl]*.
+  /// Operators][overflow] in [The Swift Programming Language][tspl].
   ///
   /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
   /// [tspl]: https://docs.swift.org/swift-book/
@@ -275,7 +275,7 @@ def operatorComment(operator, fixedWidth):
   ///     // y == -12 (after overflow)
   ///
   /// For more about arithmetic with overflow operators, see [Overflow
-  /// Operators][overflow] in *[The Swift Programming Language][tspl]*.
+  /// Operators][overflow] in [The Swift Programming Language][tspl].
   ///
   /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
   /// [tspl]: https://docs.swift.org/swift-book/
@@ -617,7 +617,7 @@ def assignmentOperatorComment(operator, fixedWidth):
   ///     // y == -35 (after overflow)
   ///
   /// For more about arithmetic with overflow operators, see [Overflow
-  /// Operators][overflow] in *[The Swift Programming Language][tspl]*.
+  /// Operators][overflow] in [The Swift Programming Language][tspl].
   ///
   /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
   /// [tspl]: https://docs.swift.org/swift-book/
@@ -644,7 +644,7 @@ def assignmentOperatorComment(operator, fixedWidth):
   ///     // y == 245 (after overflow)
   ///
   /// For more about arithmetic with overflow operators, see [Overflow
-  /// Operators][overflow] in *[The Swift Programming Language][tspl]*.
+  /// Operators][overflow] in [The Swift Programming Language][tspl].
   ///
   /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
   /// [tspl]: https://docs.swift.org/swift-book/
@@ -671,7 +671,7 @@ def assignmentOperatorComment(operator, fixedWidth):
   ///     // y == -12 (after overflow)
   ///
   /// For more about arithmetic with overflow operators, see [Overflow
-  /// Operators][overflow] in *[The Swift Programming Language][tspl]*.
+  /// Operators][overflow] in [The Swift Programming Language][tspl].
   ///
   /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
   /// [tspl]: https://docs.swift.org/swift-book/

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -3200,7 +3200,7 @@ extension FixedWidthInteger {
   ///     // y == -35 (after overflow)
   ///
   /// For more about arithmetic with overflow operators, see [Overflow
-  /// Operators][overflow] in *[The Swift Programming Language][tspl]*.
+  /// Operators][overflow] in [The Swift Programming Language][tspl].
   ///
   /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
   /// [tspl]: https://docs.swift.org/swift-book/
@@ -3230,7 +3230,7 @@ extension FixedWidthInteger {
   ///     // y == -35 (after overflow)
   ///
   /// For more about arithmetic with overflow operators, see [Overflow
-  /// Operators][overflow] in *[The Swift Programming Language][tspl]*.
+  /// Operators][overflow] in [The Swift Programming Language][tspl].
   ///
   /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
   /// [tspl]: https://docs.swift.org/swift-book/
@@ -3258,7 +3258,7 @@ extension FixedWidthInteger {
   ///     // y == 245 (after overflow)
   ///
   /// For more about arithmetic with overflow operators, see [Overflow
-  /// Operators][overflow] in *[The Swift Programming Language][tspl]*.
+  /// Operators][overflow] in [The Swift Programming Language][tspl].
   ///
   /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
   /// [tspl]: https://docs.swift.org/swift-book/
@@ -3288,7 +3288,7 @@ extension FixedWidthInteger {
   ///     // y == 245 (after overflow)
   ///
   /// For more about arithmetic with overflow operators, see [Overflow
-  /// Operators][overflow] in *[The Swift Programming Language][tspl]*.
+  /// Operators][overflow] in [The Swift Programming Language][tspl].
   ///
   /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
   /// [tspl]: https://docs.swift.org/swift-book/
@@ -3316,7 +3316,7 @@ extension FixedWidthInteger {
   ///     // y == -12 (after overflow)
   ///
   /// For more about arithmetic with overflow operators, see [Overflow
-  /// Operators][overflow] in *[The Swift Programming Language][tspl]*.
+  /// Operators][overflow] in [The Swift Programming Language][tspl].
   ///
   /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
   /// [tspl]: https://docs.swift.org/swift-book/
@@ -3346,7 +3346,7 @@ extension FixedWidthInteger {
   ///     // y == -12 (after overflow)
   ///
   /// For more about arithmetic with overflow operators, see [Overflow
-  /// Operators][overflow] in *[The Swift Programming Language][tspl]*.
+  /// Operators][overflow] in [The Swift Programming Language][tspl].
   ///
   /// [overflow]: https://docs.swift.org/swift-book/LanguageGuide/AdvancedOperators.html#ID37
   /// [tspl]: https://docs.swift.org/swift-book/


### PR DESCRIPTION
Use only plain English words in abstracts, no symbol names, per
reference writing guidelines.

Use title case for headings.

Use spelling from Apple Style Guide for 'canceled' and 'canceling'.

Track TaskGroup async(...) renaming to addTask(...) in code examples.

Fill in the -Parameters: markup for methods and initializers that take
parameters, starting the sentence with an upper-case letter.

Add links to TSPL for conceptual discussion, re-using the prose from
elsewhere in the standard library reference for the cross reference.

Restore some prose from fe288c267c4c8f537b6b79567f228f8aa42755d4 in
places where cleanup and revision work to doc comments got overwritten
by API revision.

Restore some prose that was in the discussion of Task.Handle that was
deleted in commit 27bf2c97e5f3753ec31fc857f2b04e4a435ab4f9.

Reduce the number of places where we talk about cooperative cancellation
in detail, and let the individual properties and methods lean on the
longer discussion in the overview for Task.

Remove mention of error propagation from getResult(), which doesn't
throw and therefor can't propagate errors thrown by a task.

Remove mention of what the add(...) methods do if the operation throws
an error from the non-throwing TaskGroup type, since the operation there
can't ever be throwing.

Remove -Returns: markup from properties and from methods that don't
return a value.  Stored and computed properties *have* a value, which is
documented by their abstract and discussion sections; functions and
methods *return* a value.

Remove cross references when they refer to type that's part of the
declaration.  The rendered documentation already provides an affordance
to navigate to a type in that context.

Fixes rdar://81184794