### PR TITLE
[stdlib] add a fast path to UMRBP.initialize(as:from:)

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -639,20 +639,20 @@ extension Unsafe${Mutable}RawBufferPointer {
     var it = source.makeIterator()
     var idx = startIndex
     let elementStride = MemoryLayout<S.Element>.stride
-    
+
     // This has to be a debug precondition due to the cost of walking over some collections.
     _debugPrecondition(source.underestimatedCount <= (count / elementStride),
       "insufficient space to accommodate source.underestimatedCount elements")
     guard let base = baseAddress else {
       // this can be a precondition since only an invalid argument should be costly
-      _precondition(source.underestimatedCount == 0, 
+      _precondition(source.underestimatedCount == 0,
         "no memory available to initialize from source")
       return (it, UnsafeMutableBufferPointer(start: nil, count: 0))
-    }  
+    }
 
-    for p in stride(from: base, 
+    for p in stride(from: base,
       // only advance to as far as the last element that will fit
-      to: base + count - elementStride + 1, 
+      to: base + count - elementStride + 1,
       by: elementStride
     ) {
       // underflow is permitted -- e.g. a sequence into

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -636,35 +636,35 @@ extension Unsafe${Mutable}RawBufferPointer {
   ) -> (unwritten: S.Iterator, initialized: UnsafeMutableBufferPointer<S.Element>) {
     // TODO: Optimize where `C` is a `ContiguousArrayBuffer`.
 
-    var it = source.makeIterator()
-    var idx = startIndex
     let elementStride = MemoryLayout<S.Element>.stride
 
     // This has to be a debug precondition due to the cost of walking over some collections.
     _debugPrecondition(source.underestimatedCount <= (count / elementStride),
       "insufficient space to accommodate source.underestimatedCount elements")
-    guard let base = baseAddress else {
+    guard let base = _position, let end = _end else {
       // this can be a precondition since only an invalid argument should be costly
       _precondition(source.underestimatedCount == 0,
         "no memory available to initialize from source")
-      return (it, UnsafeMutableBufferPointer(start: nil, count: 0))
+      let unwritten = source.makeIterator()
+      return (unwritten, UnsafeMutableBufferPointer(start: nil, count: 0))
     }
 
+    var written = 0
+    var unwritten = source.makeIterator()
     for p in stride(from: base,
       // only advance to as far as the last element that will fit
-      to: base + count - elementStride + 1,
+      to: end - elementStride + 1,
       by: elementStride
     ) {
       // underflow is permitted -- e.g. a sequence into
       // the spare capacity of an Array buffer
-      guard let x = it.next() else { break }
+      guard let x = unwritten.next() else { break }
       p.initializeMemory(as: S.Element.self, repeating: x, count: 1)
-      formIndex(&idx, offsetBy: elementStride)
+      written += 1
     }
 
-    return (it, UnsafeMutableBufferPointer(
-                  start: base.assumingMemoryBound(to: S.Element.self), 
-                  count: idx / elementStride))
+    let start = base.assumingMemoryBound(to: S.Element.self)
+    return (unwritten, UnsafeMutableBufferPointer(start: start, count: written))
   }
   %  end # mutable
 

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -634,7 +634,6 @@ extension Unsafe${Mutable}RawBufferPointer {
   public func initializeMemory<S: Sequence>(
     as type: S.Element.Type, from source: S
   ) -> (unwritten: S.Iterator, initialized: UnsafeMutableBufferPointer<S.Element>) {
-    // TODO: Optimize where `C` is a `ContiguousArrayBuffer`.
 
     let elementStride = MemoryLayout<S.Element>.stride
 
@@ -647,6 +646,14 @@ extension Unsafe${Mutable}RawBufferPointer {
         "no memory available to initialize from source")
       let unwritten = source.makeIterator()
       return (unwritten, UnsafeMutableBufferPointer(start: nil, count: 0))
+    }
+
+    if let count = source.withContiguousStorageIfAvailable({ $0.count }) {
+      let typedBase = base.bindMemory(to: S.Element.self, capacity: count)
+      let buffer = UnsafeMutableBufferPointer(start: typedBase, count: count)
+      let (unwritten, written) = source._copyContents(initializing: buffer)
+      _internalInvariant(written == count)
+      return (unwritten, buffer)
     }
 
     var written = 0

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -310,7 +310,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.set.underflow") {
   let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 2, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
 
-  var bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[1..<2])
+  let bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[1..<2])
 
   if _isDebugAssertConfiguration() {
     expectCrashLater()
@@ -323,7 +323,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.set.overflow") {
   let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 2, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
 
-  var bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[0..<1])
+  let bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[0..<1])
 
   if _isDebugAssertConfiguration() {
     expectCrashLater()
@@ -359,10 +359,10 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.get.overflow") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.set.underflow") {
-  var buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
 
-  var bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[1..<3])
+  let bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[1..<3])
 
   if _isDebugAssertConfiguration() {
     expectCrashLater()
@@ -372,10 +372,10 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.set.underflow") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.set.overflow") {
-  var buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
 
-  var bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[0..<2])
+  let bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[0..<2])
 
   if _isDebugAssertConfiguration() {
     expectCrashLater()
@@ -386,7 +386,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.set.overflow") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.narrow") {
-  var buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
 
   if _isDebugAssertConfiguration() {
@@ -397,7 +397,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.narrow") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.wide") {
-  var buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
 
   if _isDebugAssertConfiguration() {
@@ -408,7 +408,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.wide") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("copyMemory.overflow") {
-  var buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
 
   let bytes = buffer[0..<2]
@@ -422,7 +422,7 @@ UnsafeRawBufferPointerTestSuite.test("copyMemory.overflow") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("copyBytes.sequence.overflow") {
-  var buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
   
   let bytes = buffer[0..<2]


### PR DESCRIPTION
<!-- What's in this pull request? -->
Add fast path via `withContiguousStorageIfAvailable` and `_copyContents` for `UnsafeMutableRawBufferPointer.initialize(as:from:)`.
The current implementation just copies element-by-element, and the performance could be better.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-14982 (rdar://81168547)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
