### PR TITLE
[NFC] remove test use of `cmp` to compare swiftmodules

### DIFF
--- a/test/Serialization/async_initializers.swift
+++ b/test/Serialization/async_initializers.swift
@@ -1,8 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend  -disable-availability-checking -emit-module-path %t/a.swiftmodule -module-name a %s
+// RUN: llvm-bcanalyzer -dump %t/a.swiftmodule | %FileCheck --implicit-check-not UnknownCode %s
 // RUN: %target-swift-ide-test -print-module -module-to-print a -source-filename x -I %t | %FileCheck -check-prefix MODULE-CHECK %s
-// RUN: %target-swift-frontend  -disable-availability-checking -emit-module-path %t/b.swiftmodule -module-name a %t/a.swiftmodule
-// RUN: cmp -s %t/a.swiftmodule %t/b.swiftmodule
 
 // REQUIRES: concurrency
 
@@ -14,7 +13,6 @@
 
 // MODULE-CHECK:       actor A {
 // MODULE-CHECK-NEXT:    init() async
-
 actor A {
   init() async {}
 }
@@ -25,20 +23,18 @@ class C {
   init() async {}
 }
 
+// MODULE-CHECK:       enum E {
+// MODULE-CHECK-NEXT:    case nothing
+// MODULE-CHECK-NEXT:    init() async
+enum E {
+  case nothing
+  init() async {
+    self = .nothing
+  }
+}
+
 // MODULE-CHECK:       struct S {
 // MODULE-CHECK-NEXT:    init() async
 struct S {
   init() async {}
 }
-
-// ignore-----MODULE-CHECK:       enum E {
-// ignore-----MODULE-CHECK-NEXT:    case nothing
-// ignore-----MODULE-CHECK-NEXT:    init() async
-
-// FIXME: until rdar://76678907 is fixed, this won't work.
-// enum E {
-//   case nothing
-//   init() async {
-//     self = .nothing
-//   }
-// }

--- a/test/Serialization/attr-nonisolated.swift
+++ b/test/Serialization/attr-nonisolated.swift
@@ -1,9 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend  -disable-availability-checking -emit-module-path %t/a.swiftmodule -module-name a %s
-// RUN: llvm-bcanalyzer -dump %t/a.swiftmodule | %FileCheck -check-prefix BC-CHECK %s
-// RUN: %target-swift-ide-test -print-module -module-to-print a -source-filename x -I %t | %FileCheck -check-prefix MODULE-CHECK %s
-// RUN: %target-swift-frontend  -disable-availability-checking -emit-module-path %t/b.swiftmodule -module-name a  %t/a.swiftmodule
-// RUN: cmp -s %t/a.swiftmodule %t/b.swiftmodule
+// RUN: llvm-bcanalyzer -dump %t/a.swiftmodule | %FileCheck --check-prefix BC-CHECK --implicit-check-not UnknownCode %s
+// RUN: %target-swift-ide-test -print-module -module-to-print a -source-filename x -I %t | %FileCheck --check-prefix MODULE-CHECK %s
 
 // REQUIRES: concurrency
 
@@ -21,7 +19,6 @@
 
 // and look for nonisolated
 
-// BC-CHECK-NOT: UnknownCode
 // BC-CHECK: <Nonisolated_DECL_ATTR abbrevid={{[0-9]+}} op0=0/>
 
 

--- a/test/Serialization/effectful_properties.swift
+++ b/test/Serialization/effectful_properties.swift
@@ -1,8 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/a.swiftmodule -module-name a %s -disable-availability-checking
+// RUN: llvm-bcanalyzer -dump %t/a.swiftmodule | %FileCheck --implicit-check-not UnknownCode %s
 // RUN: %target-swift-ide-test -print-module -module-to-print a -source-filename x -I %t | %FileCheck -check-prefix MODULE-CHECK %s
-// RUN: %target-swift-frontend -emit-module-path %t/b.swiftmodule -module-name a  %t/a.swiftmodule -disable-availability-checking
-// RUN: cmp -s %t/a.swiftmodule %t/b.swiftmodule
 
 ///////////
 // This test checks for correct serialization & deserialization of


### PR DESCRIPTION
In the test infrastructure, I was using the binary
comparison tool `cmp` to check if the serialization
of a module can be deserialized and reserialized to
the exact same swiftmodule file. It turns out that
bitwise equality on the emitted files is not
guaranteed between those two methods of creating
a swiftmodule file is not always guaranteed.

Thus, this commit removes the uses of cmp to check
for this fragile guarantee.

Resolves rdar://78786620
