### PR TITLE
ABI checker: require explicit @available attributes for new APIs

### DIFF
--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -1251,7 +1251,7 @@ StringRef SDKContext::getPlatformIntroVersion(Decl *D, PlatformKind Kind) {
       }
     }
   }
-  return getPlatformIntroVersion(D->getDeclContext()->getAsDecl(), Kind);
+  return StringRef();
 }
 
 StringRef SDKContext::getLanguageIntroVersion(Decl *D) {

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -36,6 +36,7 @@ extension Never: Equatable, Comparable, Hashable {}
 
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 extension Never: Identifiable {
+  @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
   public var id: Never {
     switch self {}
   }

--- a/test/api-digester/Outputs/Cake-abi.txt
+++ b/test/api-digester/Outputs/Cake-abi.txt
@@ -53,15 +53,19 @@ cake: Accessor fixedLayoutStruct2.BecomeFixedBinaryOrder.Modify() is a new API w
 cake: Accessor fixedLayoutStruct2.BecomeFixedBinaryOrder.Set() is a new API without @available attribute
 cake: Class C0 is a new API without @available attribute
 cake: Class C8 is a new API without @available attribute
+cake: Constructor AddingNewDesignatedInit.init(_:) is a new API without @available attribute
 cake: Constructor C1.init(_:) is a new API without @available attribute
 cake: Constructor ClassWithMissingDesignatedInits.init() is a new API without @available attribute
 cake: Constructor SubclassWithMissingDesignatedInits.init() is a new API without @available attribute
 cake: Enum IceKind is now without @frozen
 cake: EnumElement FrozenKind.AddedCase is a new API without @available attribute
+cake: EnumElement FutureKind.FineToAdd is a new API without @available attribute
 cake: Func C1.foo1() is now not static
 cake: Func FinalFuncContainer.NewFinalFunc() is now with final
 cake: Func FinalFuncContainer.NoLongerFinalFunc() is now without final
 cake: Func Float.floatHigher() is a new API without @available attribute
+cake: Func FutureKind.==(_:_:) is a new API without @available attribute
+cake: Func FutureKind.hash(into:) is a new API without @available attribute
 cake: Func HasMutatingMethodClone.foo() has self access kind changing from Mutating to NonMutating
 cake: Func RequiementChanges.addedFunc() is a new API without @available attribute
 cake: Func S1.foo1() has self access kind changing from NonMutating to Mutating
@@ -72,6 +76,7 @@ cake: Protocol P4 is a new API without @available attribute
 cake: Struct C6 is now with @frozen
 cake: Var C1.CIIns1 changes from weak to strong
 cake: Var C1.CIIns2 changes from strong to weak
+cake: Var FutureKind.hashValue is a new API without @available attribute
 cake: Var RequiementChanges.addedVar is a new API without @available attribute
 cake: Var fixedLayoutStruct.$__lazy_storage_$_lazy_d is a new API without @available attribute
 cake: Var fixedLayoutStruct.c is a new API without @available attribute

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -1248,10 +1248,6 @@
           "moduleName": "cake",
           "genericSig": "<τ_0_0 where τ_0_0 : cake.PSuper>",
           "sugared_genericSig": "<Self where Self : cake.PSuper>",
-          "intro_Macosx": "10.15",
-          "intro_iOS": "13",
-          "intro_tvOS": "13",
-          "intro_watchOS": "6",
           "funcSelfKind": "NonMutating"
         }
       ],

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -1135,10 +1135,6 @@
           "usr": "s:4cake6PSuperPAAE9futureFooyyF",
           "moduleName": "cake",
           "genericSig": "<Self where Self : cake.PSuper>",
-          "intro_Macosx": "10.15",
-          "intro_iOS": "13",
-          "intro_tvOS": "13",
-          "intro_watchOS": "6",
           "funcSelfKind": "NonMutating"
         }
       ],


### PR DESCRIPTION
Before this change, the ABI checker didn't complain about missing @available
attributes on new APIs if the enclosing scopes of new APIs have
availablity information. Instead, we should require explicit @available attributes
for new APIs to prevent them inheriting wrong availability information from a
preexisting scope.

rdar://81719628
