### PR TITLE
[benchmark] UnsafeRawBufferPointer._copyContents

### DIFF
--- a/benchmark/single-source/BufferFill.swift
+++ b/benchmark/single-source/BufferFill.swift
@@ -131,7 +131,9 @@ var b8: UnsafeMutableBufferPointer<UInt8> = .init(start: nil, count: 0)
 public func rawBufferCopyContentsSetup() {
   assert(r8.baseAddress == nil)
   let count = a.count * MemoryLayout<Int>.stride
-  let rb = UnsafeMutableRawBufferPointer.allocate(byteCount: count, alignment: 8)
+  let rb = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: count, 
+    alignment: MemoryLayout<Int>.alignment)
   a.withUnsafeBytes {
     rb.copyMemory(from: $0)
   }

--- a/benchmark/single-source/BufferFill.swift
+++ b/benchmark/single-source/BufferFill.swift
@@ -28,6 +28,11 @@ public let BufferFill = [
                 tags: [.validation, .api],
                 setUpFunction: rawBufferInitializeMemorySetup,
                 tearDownFunction: rawBufferInitializeMemoryTeardown),
+  BenchmarkInfo(name: "RawBuffer.copyContents",
+                runFunction: rawBufferCopyContentsExecute,
+                tags: [.validation, .api],
+                setUpFunction: rawBufferCopyContentsSetup,
+                tearDownFunction: rawBufferCopyContentsTeardown),
 ]
 
 let c = 100_000
@@ -118,4 +123,42 @@ public func rawBufferInitializeMemoryExecute(n: Int) {
   let offset = rb.baseAddress!.advanced(by: r*MemoryLayout<Int>.stride)
   let value = offset.load(as: Int.self)
   CheckResults(value == a[r])
+}
+
+var r8: UnsafeRawBufferPointer = .init(start: nil, count: 0)
+var b8: UnsafeMutableBufferPointer<UInt8> = .init(start: nil, count: 0)
+
+public func rawBufferCopyContentsSetup() {
+  assert(r8.baseAddress == nil)
+  let count = a.count * MemoryLayout<Int>.stride
+  let rb = UnsafeMutableRawBufferPointer.allocate(byteCount: count, alignment: 8)
+  a.withUnsafeBytes {
+    rb.copyMemory(from: $0)
+  }
+  r8 = UnsafeRawBufferPointer(rb)
+  assert(b8.baseAddress == nil)
+  b8 = .allocate(capacity: rb.count)
+  r = rb.indices.randomElement()!
+}
+
+public func rawBufferCopyContentsTeardown() {
+  r8.deallocate()
+  r8 = .init(start: nil, count: 0)
+  b8.deallocate()
+  b8 = .init(start: nil, count: 0)
+}
+
+@inline(never)
+public func rawBufferCopyContentsExecute(n: Int) {
+  // Measure performance of copying bytes from an
+  // `UnsafeRawBufferPointer` to an `UnsafeMutableBufferPointer<UInt8>`.
+  // See: https://bugs.swift.org/browse/SR-9604
+
+  for _ in 0..<n {
+    var (iterator, initialized) = b8.initialize(from: r8)
+    blackHole(b8)
+    CheckResults(initialized == r8.count && iterator.next() == nil)
+  }
+
+  CheckResults(b8[r] == r8[r])
 }


### PR DESCRIPTION
Add a benchmark to measure `UnsafeRawBufferPointer._copyContents`. Prompted by the observation that creating an `[UInt8]` from an `UnsafeRawBufferPointer` is slow, while creating a `[UInt8]` from an `UnsafeBufferPointer<UInt8>` is much faster. This slowness was reported in https://bugs.swift.org/browse/SR-9604.
The fast path to initialize `Array` from a `Collection` ultimately relies on said collection's implementation of `_copyContents`, therefore we benchmark `URBP`'s implementation.
