### PR TITLE
[stdlib] implement _copyContents for UnsafeRawBufferPointer

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -145,6 +145,26 @@ extension Unsafe${Mutable}RawBufferPointer: Sequence {
   public func makeIterator() -> Iterator {
     return Iterator(_position: _position, _end: _end)
   }
+
+  /// Copies the elements of `self` to the memory at `destination.baseAddress`,
+  /// stopping when either `self` or `destination` is exhausted.
+  ///
+  /// - Returns: an iterator over any remaining elements of `self` and the
+  ///   number of elements copied.
+  @inlinable // unsafe-performance
+  @_alwaysEmitIntoClient
+  public func _copyContents(
+    initializing destination: UnsafeMutableBufferPointer<UInt8>
+  ) -> (Iterator, UnsafeMutableBufferPointer<UInt8>.Index) {
+    guard let s = _position, let e = _end, e > s, !destination.isEmpty else {
+      return (makeIterator(), 0)
+    }
+    let destinationAddress = destination.baseAddress._unsafelyUnwrappedUnchecked
+    let d = UnsafeMutableRawPointer(destinationAddress)
+    let n = Swift.min(destination.count, self.count)
+    d.copyMemory(from: s, byteCount: n)
+    return (Iterator(_position: s.advanced(by: n), _end: e), n)
+  }
 }
 
 extension Unsafe${Mutable}RawBufferPointer: ${Mutable}Collection {

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -407,6 +407,18 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.wide") {
   buffer[0..<2] = buffer[0..<3]
 }
 
+UnsafeRawBufferPointerTestSuite.test("_copyContents") {
+  let a = Array<UInt8>(0..<20)
+  let b = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: 10*a.count)
+  defer { b.deallocate() }
+  var (unwritten, written) = a.withUnsafeBytes {
+    bytes in
+    bytes._copyContents(initializing: b)
+  }
+  expectNil(unwritten.next())
+  expectEqual(written, a.count)
+}
+
 UnsafeRawBufferPointerTestSuite.test("copyMemory.overflow") {
   var buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }


### PR DESCRIPTION
Implements `_copyContents` for `Unsafe[Mutable]RawBufferPointer`, which enables a fast path when filling up `Array` or `UnsafeMutableBufferPointer<UInt8>`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-9604 (rdar://52529574).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
