### PR TITLE
[stdlib] Fix a crash on Scalar init with negative numbers

### DIFF
--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -337,8 +337,8 @@ extension Unicode.Scalar {
   ///     }
   @inlinable
   public init?(_ v: Int) {
-    if let us = Unicode.Scalar(UInt32(v)) {
-      self = us
+    if let exact = UInt32(exactly: v) {
+      self.init(exact)
     } else {
       return nil
     }

--- a/validation-test/stdlib/Unicode.swift.gyb
+++ b/validation-test/stdlib/Unicode.swift.gyb
@@ -210,6 +210,8 @@ UnicodeScalarTests.test("init") {
   expectEqual("h", UnicodeScalar(UInt16(104)))
   expectEqual("i", UnicodeScalar(UInt8(105)))
   expectEqual(nil, UnicodeScalar(UInt32(0xD800)))
+  expectEqual("j", Unicode.Scalar(Int(0x6A)))
+  expectEqual(nil, Unicode.Scalar(-0x6A))
 }
 
 var UTF8Decoder = TestSuite("UTF8Decoder")


### PR DESCRIPTION
Go through `UInt32`'s failable init when we're given an integer who it can't represent (negative/larger).

Resolves: rdar://73747263