### PR TITLE
[5.5] Fix serialization crashes found from stress tester

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3929,9 +3929,6 @@ public:
     using namespace decls_block;
     verifyAttrSerializable(dtor);
 
-    if (S.allowCompilerErrors() && dtor->isInvalid())
-      return;
-
     auto contextID = S.addDeclContextRef(dtor->getDeclContext());
 
     unsigned abbrCode = S.DeclTypeAbbrCodes[DestructorLayout::Code];
@@ -3973,11 +3970,33 @@ public:
   }
 };
 
+/// When allowing modules with errors there may be cases where there's little
+/// point in serializing a declaration and doing so would create a maintenance
+/// burden on the deserialization side. Returns \c true if the given declaration
+/// should be skipped and \c false otherwise.
+static bool canSkipWhenInvalid(const Decl *D) {
+  // There's no point writing out the deinit when its context is not a class
+  // as nothing would be able to reference it
+  if (auto *deinit = dyn_cast<DestructorDecl>(D)) {
+    if (!isa<ClassDecl>(D->getDeclContext()))
+      return true;
+  }
+  return false;
+}
+
 void Serializer::writeASTBlockEntity(const Decl *D) {
   using namespace decls_block;
 
   PrettyStackTraceDecl trace("serializing", D);
   assert(DeclsToSerialize.hasRef(D));
+
+  if (D->isInvalid()) {
+    assert(allowCompilerErrors() &&
+           "cannot create a module with an invalid decl");
+
+    if (canSkipWhenInvalid(D))
+      return;
+  }
 
   BitOffset initialOffset = Out.GetCurrentBitNo();
   SWIFT_DEFER {
@@ -3988,8 +4007,6 @@ void Serializer::writeASTBlockEntity(const Decl *D) {
     }
   };
 
-  assert((allowCompilerErrors() || !D->isInvalid()) &&
-         "cannot create a module with an invalid decl");
   if (isDeclXRef(D)) {
     writeCrossReference(D);
     return;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2029,8 +2029,10 @@ void Serializer::writePatternBindingInitializer(PatternBindingDecl *binding,
   StringRef initStr;
   SmallString<128> scratch;
   auto varDecl = binding->getAnchoringVarDecl(bindingIndex);
+  assert((varDecl || allowCompilerErrors()) &&
+         "Serializing PDB without anchoring VarDecl");
   if (binding->hasInitStringRepresentation(bindingIndex) &&
-      varDecl->isInitExposedToClients()) {
+      varDecl && varDecl->isInitExposedToClients()) {
     initStr = binding->getInitStringRepresentation(bindingIndex, scratch);
   }
 

--- a/test/Serialization/AllowErrors/invalid-deinit.swift
+++ b/test/Serialization/AllowErrors/invalid-deinit.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+
+// Serialize and deserialize a deinit with SourceFile context to make sure we
+// don't crash
+// RUN: %target-swift-frontend -verify -module-name errors -emit-module -o %t/errors.swiftmodule -experimental-allow-module-with-compiler-errors %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=errors -source-filename=x -I %t -allow-compiler-errors
+
+// Also check it wasn't serialized
+// RUN: llvm-bcanalyzer -dump %t/errors.swiftmodule | %FileCheck %s
+// CHECK-NOT: DESTRUCTOR_DECL
+
+struct Foo {}
+
+@discardableResult // expected-error{{'@discardableResult' attribute cannot be applied to this declaration}}
+deinit {} // expected-error{{deinitializers may only be declared within a class}}
+
+func foo() -> Foo { return Foo() }
+
+// Make sure @discardableResult isn't added to `foo`, which could be possible
+// if the deinit is partially serialized
+foo() // expected-warning{{result of call to 'foo()' is unused}}

--- a/validation-test/Serialization/AllowErrors/invalid-deinit.swift
+++ b/validation-test/Serialization/AllowErrors/invalid-deinit.swift
@@ -1,8 +1,0 @@
-// RUN: %empty-directory(%t)
-
-// RUN: %target-swift-frontend -module-name errors -emit-module -o %t/errors.swiftmodule -experimental-allow-module-with-compiler-errors %s
-
-// deinit is only valid on a class, make sure we don't crash when allowing
-// errors
-
-deinit {}

--- a/validation-test/Serialization/AllowErrors/invalid-pattern.swift
+++ b/validation-test/Serialization/AllowErrors/invalid-pattern.swift
@@ -1,0 +1,7 @@
+// RUN: %empty-directory(%t)
+
+// -parse-as-library added so that the PDB isn't added to a TopLevelCodeDecl,
+// which isn't serialized at all
+// RUN: %target-swift-frontend -emit-module -o %t/errors.swiftmodule -module-name errors -experimental-allow-module-with-compiler-errors -parse-as-library %s
+
+let self = 1


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/38779

-----

I ran another stress tester in preparation for merging the TestModule request, which found a couple new issues:
  - A previous fix to not serialize invalid destructors wasn't skipping the common serialization section
  - A segfault when a PDB has no anchoring VarDecl