### PR TITLE
Refactor canonical type ordering

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -475,6 +475,8 @@ inline bool CanGenericSignature::isActuallyCanonicalOrNull() const {
 int compareAssociatedTypes(AssociatedTypeDecl *assocType1,
                            AssociatedTypeDecl *assocType2);
 
+int compareDependentTypes(Type type1, Type type2);
+
 } // end namespace swift
 
 namespace llvm {

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -472,6 +472,9 @@ inline bool CanGenericSignature::isActuallyCanonicalOrNull() const {
          getPointer()->isCanonical();
 }
 
+int compareAssociatedTypes(AssociatedTypeDecl *assocType1,
+                           AssociatedTypeDecl *assocType2);
+
 } // end namespace swift
 
 namespace llvm {

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1677,9 +1677,6 @@ inline bool isErrorResult(GenericSignatureBuilder::ConstraintResult result) {
   llvm_unreachable("unhandled result");
 }
 
-/// Canonical ordering for dependent types.
-int compareDependentTypes(Type type1, Type type2);
-
 template<typename T>
 Type GenericSignatureBuilder::Constraint<T>::getSubjectDependentType(
                       TypeArrayView<GenericTypeParamType> genericParams) const {

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -92,6 +92,9 @@ public:
   /// superclass requirement, 'T : C' cannot be satisfied.
   bool canBeSatisfied() const;
 
+  /// Linear order on requirements in a generic signature.
+  int compare(const Requirement &other) const;
+
   SWIFT_DEBUG_DUMP;
   void dump(raw_ostream &out) const;
   void print(raw_ostream &os, const PrintOptions &opts) const;

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -1459,3 +1459,41 @@ int swift::compareAssociatedTypes(AssociatedTypeDecl *assocType1,
 
   return 0;
 }
+
+/// Canonical ordering for type parameters.
+int swift::compareDependentTypes(Type type1, Type type2) {
+  // Fast-path check for equality.
+  if (type1->isEqual(type2)) return 0;
+
+  // Ordering is as follows:
+  // - Generic params
+  auto gp1 = type1->getAs<GenericTypeParamType>();
+  auto gp2 = type2->getAs<GenericTypeParamType>();
+  if (gp1 && gp2)
+    return GenericParamKey(gp1) < GenericParamKey(gp2) ? -1 : +1;
+
+  // A generic parameter is always ordered before a nested type.
+  if (static_cast<bool>(gp1) != static_cast<bool>(gp2))
+    return gp1 ? -1 : +1;
+
+  // - Dependent members
+  auto depMemTy1 = type1->castTo<DependentMemberType>();
+  auto depMemTy2 = type2->castTo<DependentMemberType>();
+
+  // - by base, so t_0_n.`P.T` < t_1_m.`P.T`
+  if (int compareBases =
+        compareDependentTypes(depMemTy1->getBase(), depMemTy2->getBase()))
+    return compareBases;
+
+  // - by name, so t_n_m.`P.T` < t_n_m.`P.U`
+  if (int compareNames = depMemTy1->getName().str().compare(
+                                                  depMemTy2->getName().str()))
+    return compareNames;
+
+  auto *assocType1 = depMemTy1->getAssocType();
+  auto *assocType2 = depMemTy2->getAssocType();
+  if (int result = compareAssociatedTypes(assocType1, assocType2))
+    return result;
+
+  return 0;
+}

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -1430,3 +1430,32 @@ bool Requirement::canBeSatisfied() const {
 
   llvm_unreachable("Bad requirement kind");
 }
+
+/// Compare two associated types.
+int swift::compareAssociatedTypes(AssociatedTypeDecl *assocType1,
+                                  AssociatedTypeDecl *assocType2) {
+  // - by name.
+  if (int result = assocType1->getName().str().compare(
+                                              assocType2->getName().str()))
+    return result;
+
+  // Prefer an associated type with no overrides (i.e., an anchor) to one
+  // that has overrides.
+  bool hasOverridden1 = !assocType1->getOverriddenDecls().empty();
+  bool hasOverridden2 = !assocType2->getOverriddenDecls().empty();
+  if (hasOverridden1 != hasOverridden2)
+    return hasOverridden1 ? +1 : -1;
+
+  // - by protocol, so t_n_m.`P.T` < t_n_m.`Q.T` (given P < Q)
+  auto proto1 = assocType1->getProtocol();
+  auto proto2 = assocType2->getProtocol();
+  if (int compareProtocols = TypeDecl::compare(proto1, proto2))
+    return compareProtocols;
+
+  // Error case: if we have two associated types with the same name in the
+  // same protocol, just tie-break based on address.
+  if (assocType1 != assocType2)
+    return assocType1 < assocType2 ? -1 : +1;
+
+  return 0;
+}

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1979,35 +1979,6 @@ bool EquivalenceClass::isConformanceSatisfiedBySuperclass(
   return false;
 }
 
-/// Compare two associated types.
-static int compareAssociatedTypes(AssociatedTypeDecl *assocType1,
-                                  AssociatedTypeDecl *assocType2) {
-  // - by name.
-  if (int result = assocType1->getName().str().compare(
-                                              assocType2->getName().str()))
-    return result;
-
-  // Prefer an associated type with no overrides (i.e., an anchor) to one
-  // that has overrides.
-  bool hasOverridden1 = !assocType1->getOverriddenDecls().empty();
-  bool hasOverridden2 = !assocType2->getOverriddenDecls().empty();
-  if (hasOverridden1 != hasOverridden2)
-    return hasOverridden1 ? +1 : -1;
-
-  // - by protocol, so t_n_m.`P.T` < t_n_m.`Q.T` (given P < Q)
-  auto proto1 = assocType1->getProtocol();
-  auto proto2 = assocType2->getProtocol();
-  if (int compareProtocols = TypeDecl::compare(proto1, proto2))
-    return compareProtocols;
-
-  // Error case: if we have two associated types with the same name in the
-  // same protocol, just tie-break based on address.
-  if (assocType1 != assocType2)
-    return assocType1 < assocType2 ? -1 : +1;
-
-  return 0;
-}
-
 static void lookupConcreteNestedType(NominalTypeDecl *decl,
                                      Identifier name,
                                      SmallVectorImpl<TypeDecl *> &concreteDecls) {

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -575,35 +575,6 @@ RequirementMachine::getConformanceAccessPath(Type type,
   }
 }
 
-/// Compare two associated types.
-static int compareAssociatedTypes(AssociatedTypeDecl *assocType1,
-                                  AssociatedTypeDecl *assocType2) {
-  // - by name.
-  if (int result = assocType1->getName().str().compare(
-                                              assocType2->getName().str()))
-    return result;
-
-  // Prefer an associated type with no overrides (i.e., an anchor) to one
-  // that has overrides.
-  bool hasOverridden1 = !assocType1->getOverriddenDecls().empty();
-  bool hasOverridden2 = !assocType2->getOverriddenDecls().empty();
-  if (hasOverridden1 != hasOverridden2)
-    return hasOverridden1 ? +1 : -1;
-
-  // - by protocol, so t_n_m.`P.T` < t_n_m.`Q.T` (given P < Q)
-  auto proto1 = assocType1->getProtocol();
-  auto proto2 = assocType2->getProtocol();
-  if (int compareProtocols = TypeDecl::compare(proto1, proto2))
-    return compareProtocols;
-
-  // Error case: if we have two associated types with the same name in the
-  // same protocol, just tie-break based on address.
-  if (assocType1 != assocType2)
-    return assocType1 < assocType2 ? -1 : +1;
-
-  return 0;
-}
-
 static void lookupConcreteNestedType(NominalTypeDecl *decl,
                                      Identifier name,
                                      SmallVectorImpl<TypeDecl *> &concreteDecls) {


### PR DESCRIPTION
This PR moves some support code for comparing associated types from GenericSignatureBuilder.cpp to GenericSignature.cpp, killing off a duplicated definition in the process.