### PR TITLE
Use existing CMake in some build-script tests

### DIFF
--- a/validation-test/BuildSystem/reconfigure-passed-to-build-script-impl.test
+++ b/validation-test/BuildSystem/reconfigure-passed-to-build-script-impl.test
@@ -1,6 +1,6 @@
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --reconfigure --verbose 2>&1| %FileCheck %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --reconfigure --verbose --cmake %cmake 2>&1| %FileCheck %s
 
 # REQUIRES: standalone_build
 

--- a/validation-test/BuildSystem/test_early_swift_driver_and_infer.swift
+++ b/validation-test/BuildSystem/test_early_swift_driver_and_infer.swift
@@ -2,6 +2,6 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --swiftpm --infer 2>&1 | %FileCheck %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --swiftpm --infer --cmake %cmake 2>&1 | %FileCheck %s
 
 # CHECK: --- Building earlyswiftdriver ---


### PR DESCRIPTION
This will prevent the tests to rebuild CMake (especially under Linux)
and cause transient issues.

This is similar to what was done for #37611