### PR TITLE
[CSClosure] Use rewritten expression when applying solution to a brac…

### DIFF
--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -181,7 +181,7 @@ private:
       if (auto expr = node.dyn_cast<Expr *>()) {
         // Rewrite the expression.
         if (auto rewrittenExpr = rewriteExpr(expr))
-          node = expr;
+          node = rewrittenExpr;
         else
           hadError = true;
       } else if (auto stmt = node.dyn_cast<Stmt *>()) {


### PR DESCRIPTION
…e statement

It went un-noticed because currently only single-statement closures
using this logic and their bodies are modeled as a single return statement.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
