### PR TITLE
[swift-stage2] Point the API migrator at the correct directory when building/testing against a host toolchain.

### DIFF
--- a/test/Migrator/always_remove_old_remap_file.swift
+++ b/test/Migrator/always_remove_old_remap_file.swift
@@ -1,13 +1,13 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/input.swift
-// RUN: %target-swift-frontend -c -update-code -primary-file %t/input.swift -emit-migrated-file-path %t/always_remove_old_remap_file.result -emit-remap-file-path %t/always_remove_old_remap_file.remap -o /dev/null
+// RUN: %target-swift-frontend -c -update-code -primary-file %t/input.swift -emit-migrated-file-path %t/always_remove_old_remap_file.result -emit-remap-file-path %t/always_remove_old_remap_file.remap %api_diff_data_dir -o /dev/null %api_diff_data_dir
 // RUN: ls %t/always_remove_old_remap_file.remap
 
 // Simulate leaving behind code that can't build in Swift 4:
 // RUN: echo asdfads >> %t/input.swift
 
 // Migrate again. This should delete the old remap file.
-// RUN: not %target-swift-frontend -c -update-code -primary-file %t/input.swift -emit-migrated-file-path %t/always_remove_old_remap_file.result -emit-remap-file-path %t/always_remove_old_remap_file.remap -o /dev/null
+// RUN: not %target-swift-frontend -c -update-code -primary-file %t/input.swift -emit-migrated-file-path %t/always_remove_old_remap_file.result -emit-remap-file-path %t/always_remove_old_remap_file.remap %api_diff_data_dir -o /dev/null %api_diff_data_dir
 
 // RUN: not ls %t/always_remove_old_remap_file.remap
 

--- a/test/Migrator/fixit_flatMap.swift
+++ b/test/Migrator/fixit_flatMap.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -typecheck %s -swift-version 4
-// RUN: %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t.result -swift-version 4
+// RUN: %target-swift-frontend -typecheck %s -swift-version 4 %api_diff_data_dir
+// RUN: %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t.result -swift-version 4 %api_diff_data_dir
 // RUN: diff -u %s.expected %t.result
 
 // REQUIRES: VENDOR=apple

--- a/test/Migrator/fixit_flatMap.swift.expected
+++ b/test/Migrator/fixit_flatMap.swift.expected
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -typecheck %s -swift-version 4
-// RUN: %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t.result -swift-version 4
+// RUN: %target-swift-frontend -typecheck %s -swift-version 4 %api_diff_data_dir
+// RUN: %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t.result -swift-version 4 %api_diff_data_dir
 // RUN: diff -u %s.expected %t.result
 
 // REQUIRES: VENDOR=apple

--- a/test/Migrator/insert_replace_fixit.swift
+++ b/test/Migrator/insert_replace_fixit.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/result.swift -swift-version 4
+// RUN: %target-swift-frontend -typecheck -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/result.swift -swift-version 4 %api_diff_data_dir
 // RUN: %diff -u %s.expected %t/result.swift
 
 import TestMyTime

--- a/test/Migrator/insert_replace_fixit.swift.expected
+++ b/test/Migrator/insert_replace_fixit.swift.expected
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/result.swift -swift-version 4
+// RUN: %target-swift-frontend -typecheck -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/result.swift -swift-version 4 %api_diff_data_dir
 // RUN: %diff -u %s.expected %t/result.swift
 
 import TestMyTime

--- a/test/Migrator/no_ast_passes_after_swift4.swift
+++ b/test/Migrator/no_ast_passes_after_swift4.swift
@@ -1,7 +1,7 @@
 // REQUIRES: objc_interop
-// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/no_ast_passes_after_swift4.swift.result -emit-remap-file-path %t/no_ast_passes_after_swift4.swift.remap -o /dev/null -swift-version 4.2
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/no_ast_passes_after_swift4.swift.result -emit-remap-file-path %t/no_ast_passes_after_swift4.swift.remap -o /dev/null -swift-version 4.2 %api_diff_data_dir
 // RUN: diff -u %S/no_ast_passes_after_swift4.swift.expected %t/no_ast_passes_after_swift4.swift.result
-// RUN: %target-swift-frontend -typecheck -F %S/mock-sdk -swift-version 4 %t/no_ast_passes_after_swift4.swift.result
+// RUN: %target-swift-frontend -typecheck -F %S/mock-sdk -swift-version 4 %t/no_ast_passes_after_swift4.swift.result %api_diff_data_dir
 
 import Bar
 func foo() -> FooComparisonResult {

--- a/test/Migrator/no_ast_passes_after_swift4.swift.expected
+++ b/test/Migrator/no_ast_passes_after_swift4.swift.expected
@@ -1,7 +1,7 @@
 // REQUIRES: objc_interop
-// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/no_ast_passes_after_swift4.swift.result -emit-remap-file-path %t/no_ast_passes_after_swift4.swift.remap -o /dev/null -swift-version 4.2
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/no_ast_passes_after_swift4.swift.result -emit-remap-file-path %t/no_ast_passes_after_swift4.swift.remap -o /dev/null -swift-version 4.2 %api_diff_data_dir
 // RUN: diff -u %S/no_ast_passes_after_swift4.swift.expected %t/no_ast_passes_after_swift4.swift.result
-// RUN: %target-swift-frontend -typecheck -F %S/mock-sdk -swift-version 4 %t/no_ast_passes_after_swift4.swift.result
+// RUN: %target-swift-frontend -typecheck -F %S/mock-sdk -swift-version 4 %t/no_ast_passes_after_swift4.swift.result %api_diff_data_dir
 
 import Bar
 func foo() -> FooComparisonResult {

--- a/test/Migrator/no_extraneous_argument_labels.swift
+++ b/test/Migrator/no_extraneous_argument_labels.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -typecheck %s -swift-version 4
-// RUN: %empty-directory(%t) && %target-swift-frontend -c -primary-file %s -emit-migrated-file-path %t/no_extraneous_argument_labels.result -swift-version 4 -o /dev/null
+// RUN: %target-swift-frontend -typecheck %s -swift-version 4 %api_diff_data_dir
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -primary-file %s -emit-migrated-file-path %t/no_extraneous_argument_labels.result -swift-version 4 -o /dev/null %api_diff_data_dir
 // RUN: %diff -u %s.expected %t/no_extraneous_argument_labels.result
-// RUN: %target-swift-frontend -typecheck %s.expected -swift-version 5
+// RUN: %target-swift-frontend -typecheck %s.expected -swift-version 5 %api_diff_data_dir
 
 func foo(_ oc: [String]) {
   var args: [String] = []

--- a/test/Migrator/no_extraneous_argument_labels.swift.expected
+++ b/test/Migrator/no_extraneous_argument_labels.swift.expected
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -typecheck %s -swift-version 4
-// RUN: %empty-directory(%t) && %target-swift-frontend -c -primary-file %s -emit-migrated-file-path %t/no_extraneous_argument_labels.result -swift-version 4 -o /dev/null
+// RUN: %target-swift-frontend -typecheck %s -swift-version 4 %api_diff_data_dir
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -primary-file %s -emit-migrated-file-path %t/no_extraneous_argument_labels.result -swift-version 4 -o /dev/null %api_diff_data_dir
 // RUN: %diff -u %s.expected %t/no_extraneous_argument_labels.result
-// RUN: %target-swift-frontend -typecheck %s.expected -swift-version 5
+// RUN: %target-swift-frontend -typecheck %s.expected -swift-version 5 %api_diff_data_dir
 
 func foo(_ oc: [String]) {
   var args: [String] = []

--- a/test/Migrator/no_var_to_let.swift
+++ b/test/Migrator/no_var_to_let.swift
@@ -1,8 +1,8 @@
-// RUN: %target-swift-frontend -typecheck %s -swift-version 4
-// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/no_var_to_let.swift.result -swift-version 4 -o /dev/null
-// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/no_var_to_let.swift.result -swift-version 4 -o /dev/null
+// RUN: %target-swift-frontend -typecheck %s -swift-version 4 %api_diff_data_dir
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/no_var_to_let.swift.result -swift-version 4 -o /dev/null %api_diff_data_dir
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/no_var_to_let.swift.result -swift-version 4 -o /dev/null %api_diff_data_dir
 // RUN: %diff -u %s %t/no_var_to_let.swift.result
-// RUN: %target-swift-frontend -typecheck %s -swift-version 5
+// RUN: %target-swift-frontend -typecheck %s -swift-version 5 %api_diff_data_dir
 
 // Note that the diff run line indicates that there should be no change.
 

--- a/test/Migrator/null_migration.swift
+++ b/test/Migrator/null_migration.swift
@@ -1,4 +1,4 @@
-// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/migrated_null_migration.swift -emit-remap-file-path %t/null_migration.remap -o /dev/null
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/migrated_null_migration.swift -emit-remap-file-path %t/null_migration.remap -o /dev/null %api_diff_data_dir
 // RUN: %diff -u %s %t/migrated_null_migration.swift
 
 // This file tests that, if all migration passes are no-op,

--- a/test/Migrator/optional_try_migration.swift
+++ b/test/Migrator/optional_try_migration.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -c -swift-version 4 -primary-file %s -emit-migrated-file-path %t/optional_try_migration.result.swift
+// RUN: %target-swift-frontend -c -swift-version 4 -primary-file %s -emit-migrated-file-path %t/optional_try_migration.result.swift %api_diff_data_dir
 // RUN: %diff -u %S/optional_try_migration.swift.expected %t/optional_try_migration.result.swift
 
 func fetchOptInt() throws -> Int? {

--- a/test/Migrator/optional_try_migration.swift.expected
+++ b/test/Migrator/optional_try_migration.swift.expected
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -c -swift-version 4 -primary-file %s -emit-migrated-file-path %t/optional_try_migration.result.swift
+// RUN: %target-swift-frontend -c -swift-version 4 -primary-file %s -emit-migrated-file-path %t/optional_try_migration.result.swift %api_diff_data_dir
 // RUN: %diff -u %S/optional_try_migration.swift.expected %t/optional_try_migration.result.swift
 
 func fetchOptInt() throws -> Int? {

--- a/test/Migrator/post_fixit_pass.swift
+++ b/test/Migrator/post_fixit_pass.swift
@@ -1,4 +1,4 @@
-// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/post_fixit_pass.swift.result -o /dev/null -F %S/mock-sdk -swift-version 4
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/post_fixit_pass.swift.result -o /dev/null -F %S/mock-sdk -swift-version 4 %api_diff_data_dir
 // RUN: %diff -u %S/post_fixit_pass.swift.expected %t/post_fixit_pass.swift.result
 
 #if swift(>=4.2)

--- a/test/Migrator/post_fixit_pass.swift.expected
+++ b/test/Migrator/post_fixit_pass.swift.expected
@@ -1,4 +1,4 @@
-// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/post_fixit_pass.swift.result -o /dev/null -F %S/mock-sdk -swift-version 4
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/post_fixit_pass.swift.result -o /dev/null -F %S/mock-sdk -swift-version 4 %api_diff_data_dir
 // RUN: %diff -u %S/post_fixit_pass.swift.expected %t/post_fixit_pass.swift.result
 
 #if swift(>=4.2)

--- a/test/Migrator/rdar31892850.swift
+++ b/test/Migrator/rdar31892850.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -primary-file %s -module-cache-path %t/mcp -emit-remap-file-path %t/edits.remap -swift-version 4
+// RUN: %target-swift-frontend -typecheck -primary-file %s -module-cache-path %t/mcp -emit-remap-file-path %t/edits.remap -swift-version 4 %api_diff_data_dir
 // RUN: %FileCheck %s -input-file=%t/edits.remap
 
 enum SomeStringEnum : String {
@@ -15,12 +15,12 @@ func foo() {
 // CHECK:[
 // CHECK:  {
 // CHECK:    "file": "{{.*}}rdar31892850.swift",
-// CHECK:    "offset": 325,
-// CHECK:    "text": "SomeStringEnum(rawValue: "
+// CHECK-NEXT:    "offset": 344,
+// CHECK-NEXT:    "text": "SomeStringEnum(rawValue: "
 // CHECK:  },
 // CHECK:  {
 // CHECK:    "file": "{{.*}}rdar31892850.swift",
-// CHECK:    "offset": 329,
-// CHECK:    "text": ") ?? <#default value#>"
+// CHECK-NEXT:    "offset": 348,
+// CHECK-NEXT:    "text": ") ?? <#default value#>"
 // CHECK:  }
 // CHECK:]

--- a/test/Migrator/remove_override.swift
+++ b/test/Migrator/remove_override.swift
@@ -1,6 +1,6 @@
 // REQUIRES: OS=macosx
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -c -update-code -swift-version 4 -disable-migrator-fixits -primary-file %s -emit-migrated-file-path %t/remove_override.result.swift -o %t/rename-func-decl.swift.remap
+// RUN: %target-swift-frontend -c -update-code -swift-version 4 -disable-migrator-fixits -primary-file %s -emit-migrated-file-path %t/remove_override.result.swift -o %t/rename-func-decl.swift.remap %api_diff_data_dir
 // RUN: diff -u %S/remove_override.swift.expected %t/remove_override.result.swift
 
 import AppKit

--- a/test/Migrator/remove_override.swift.expected
+++ b/test/Migrator/remove_override.swift.expected
@@ -1,6 +1,6 @@
 // REQUIRES: OS=macosx
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -c -update-code -swift-version 4 -disable-migrator-fixits -primary-file %s -emit-migrated-file-path %t/remove_override.result.swift -o %t/rename-func-decl.swift.remap
+// RUN: %target-swift-frontend -c -update-code -swift-version 4 -disable-migrator-fixits -primary-file %s -emit-migrated-file-path %t/remove_override.result.swift -o %t/rename-func-decl.swift.remap %api_diff_data_dir
 // RUN: diff -u %S/remove_override.swift.expected %t/remove_override.result.swift
 
 import AppKit

--- a/test/Migrator/stdlib_rename.swift
+++ b/test/Migrator/stdlib_rename.swift
@@ -1,7 +1,7 @@
 // REQUIRES: objc_interop
-// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/stdlib_rename.swift.result -emit-remap-file-path %t/stdlib_rename.swift.remap -o /dev/null
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/stdlib_rename.swift.result -emit-remap-file-path %t/stdlib_rename.swift.remap -o /dev/null %api_diff_data_dir
 // RUN: diff -u %S/stdlib_rename.swift.expected %t/stdlib_rename.swift.result
-// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/stdlib_rename.swift.result -emit-remap-file-path %t/stdlib_rename.swift.remap -o /dev/null -swift-version 4.2
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/stdlib_rename.swift.result -emit-remap-file-path %t/stdlib_rename.swift.remap -o /dev/null -swift-version 4.2 %api_diff_data_dir
 // RUN: diff -u %S/stdlib_rename.swift.expected %t/stdlib_rename.swift.result
 
 func test1(_ a: [String], s: String) {

--- a/test/Migrator/stdlib_rename.swift.expected
+++ b/test/Migrator/stdlib_rename.swift.expected
@@ -1,7 +1,7 @@
 // REQUIRES: objc_interop
-// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/stdlib_rename.swift.result -emit-remap-file-path %t/stdlib_rename.swift.remap -o /dev/null
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/stdlib_rename.swift.result -emit-remap-file-path %t/stdlib_rename.swift.remap -o /dev/null %api_diff_data_dir
 // RUN: diff -u %S/stdlib_rename.swift.expected %t/stdlib_rename.swift.result
-// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/stdlib_rename.swift.result -emit-remap-file-path %t/stdlib_rename.swift.remap -o /dev/null -swift-version 4.2
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/stdlib_rename.swift.result -emit-remap-file-path %t/stdlib_rename.swift.remap -o /dev/null -swift-version 4.2 %api_diff_data_dir
 // RUN: diff -u %S/stdlib_rename.swift.expected %t/stdlib_rename.swift.result
 
 func test1(_ a: [String], s: String) {

--- a/test/Migrator/swift_version_change.swift
+++ b/test/Migrator/swift_version_change.swift
@@ -1,5 +1,5 @@
 // REQUIRES: OS=macosx
-// RUN: %empty-directory(%t) && %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t/dummpy.result -swift-version 4
-// RUN: %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t/dummpy.result -swift-version 5
+// RUN: %empty-directory(%t) && %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t/dummpy.result -swift-version 4 %api_diff_data_dir
+// RUN: %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t/dummpy.result -swift-version 5 %api_diff_data_dir
 
 func foo() {}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2205,6 +2205,20 @@ config.environment['SWIFT_DEBUG_ENABLE_COW_CHECKS'] = 'false'
 # Add this to the command which runs an executable to enable COW checks in the swift runtime.
 config.substitutions.append(('%enable-cow-checking', TARGET_ENV_PREFIX + 'SWIFT_DEBUG_ENABLE_COW_CHECKS=true;'))
 
+# We add an expansion to ensure that migrator tests can search for the api diff
+# data dir from the host compiler toolchain instead of the resource dir of the
+# stdlib. Since we are using the host compiler, we would not have built any
+# tools meaning that we would not have generated the -api-diff-data-dir.
+#
+# In the case where we are not building against the host compiler, this just
+# expands to the empty string.
+api_diff_data_dir_flag = ''
+if hasattr(config, 'testing_against_host_compiler'):
+   migrator_dir = os.path.join(os.path.dirname(config.swiftc),
+                               os.pardir, 'lib', 'swift', 'migrator')
+   api_diff_data_dir_flag = ' -api-diff-data-dir {} '.format(migrator_dir)
+config.substitutions.append(('%api_diff_data_dir', api_diff_data_dir_flag))
+
 if config.lldb_build_root != "":
     lldb_python_path = get_lldb_python_path(config.lldb_build_root)
     lldb_python_interpreter = get_lldb_python_interpreter(config.lldb_build_root)

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -60,6 +60,12 @@ config.darwin_enable_maccatalyst = "@SWIFT_ENABLE_MACCATALYST@" == "TRUE"
 config.darwin_maccatalyst_build_flavor = "@BUILD_FLAVOR@"
 config.darwin_osx_variant_suffix = "@DEFAULT_OSX_VARIANT_SUFFIX@"
 
+# If we are not testing against the host compiler, we are testing against the
+# just built compiler. Add that as a feature so we can conditionally mark tests
+# as requiring a just_built_compiler.
+config.testing_against_host_compiler = \
+    "@SWIFT_RUN_TESTS_WITH_HOST_COMPILER@" == "TRUE"
+
 # Please remember to handle empty strings and/or unset variables correctly.
 
 if "@SWIFT_ASAN_BUILD@" == "TRUE":


### PR DESCRIPTION
This involved adding a new substitution called %api_diff_data_dir that when
building against a host toolchain, looks in the host toolchain (next to swiftc)
rather than in the resource dir. The reason why I need to do this is this allows
me to perform a stdlib stage2 build without needing to build swift itself.

The only interesting changes here are that I had to add %api_diff_data_dir to
a bunch of normal/expected tests and also add %api_diff_data_dir's length to the
offsets in rdar31892850.swift.
