### PR TITLE
[stdlib] Add `take` to Optional

### DIFF
--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -262,6 +262,33 @@ public enum Optional<Wrapped>: ExpressibleByNilLiteral {
       _internalInvariantFailure("_unsafelyUnwrappedUnchecked of nil optional")
     }
   }
+
+  /// Takes the wrapped value being stored in this instance and returns it while
+  /// also setting the instance to `nil`. If there is no value being stored in
+  /// this instance, this returns `nil` instead.
+  ///
+  ///     var numberOfShoes: Int? = 34
+  ///
+  ///     if let numberOfShoes = numberOfShoes.take() {
+  ///       print(numberOfShoes)
+  ///       // Prints "34"
+  ///     }
+  ///
+  ///     print(numberOfShoes)
+  ///     // Prints "nil"
+  ///
+  /// - Returns: The wrapped value being stored in this instance. If this
+  ///   instance is `nil`, returns `nil`.
+  @_alwaysEmitIntoClient
+  public mutating func take() -> Wrapped? {
+    switch self {
+    case .some(let wrapped):
+      self = nil
+      return wrapped
+    case .none:
+      return nil
+    }
+  }
 }
 
 extension Optional: CustomDebugStringConvertible {

--- a/test/stdlib/Optional.swift
+++ b/test/stdlib/Optional.swift
@@ -417,4 +417,16 @@ OptionalTests.test("unsafelyUnwrapped nil")
   _blackHole(empty.unsafelyUnwrapped)
 }
 
+OptionalTests.test("take") {
+  var x: Int? = 128
+
+  expectEqual(x.take(), 128)
+  expectEqual(x, nil)
+
+  var y: Int? = nil
+
+  expectEqual(y.take(), nil)
+  expectEqual(y, nil)
+}
+
 runAllTests()


### PR DESCRIPTION
Adds a simple take operation on Optional.

```swift
var x: Int? = 128

if let x = x.take() {
  print(x) // 128
}

print(x) // nil
```