### PR TITLE
[build] Restore previous semantics of stdlib-deployment-targets test

### DIFF
--- a/utils/swift_build_support/swift_build_support/host_specific_configuration.py
+++ b/utils/swift_build_support/swift_build_support/host_specific_configuration.py
@@ -55,7 +55,7 @@ class HostSpecificConfiguration(object):
             else:
                 stdlib_targets_to_build = set(stdlib_targets_to_configure)
 
-        if stage_dependent_args.stdlib_deployment_targets and \
+        if hasattr(stage_dependent_args, 'stdlib_deployment_targets') and \
            stage_dependent_args.stdlib_deployment_targets == []:
             stdlib_targets_to_configure = []
             stdlib_targets_to_build = []

--- a/utils/swift_build_support/tests/test_host_specific_configuration.py
+++ b/utils/swift_build_support/tests/test_host_specific_configuration.py
@@ -101,6 +101,17 @@ class ToolchainTestCase(unittest.TestCase):
 
         self.assertEqual(len(hsc.swift_stdlib_build_targets), 0)
 
+    def test_should_not_build_stdlib_when_targets_are_empty(self):
+        args = self.default_args()
+        args.host_target = 'macosx-x86_64'
+        args.stdlib_deployment_targets = []
+
+        hsc = HostSpecificConfiguration('macosx-arm64', args)
+
+        self.assertEqual(len(hsc.sdks_to_configure), 0)
+
+        self.assertEqual(len(hsc.swift_stdlib_build_targets), 0)
+
     def generate_should_skip_building_platform(
             host_target, sdk_name, build_target, build_arg_name):
         def test(self):


### PR DESCRIPTION
For historical reasons, we configure and build standard library targets
differently depending on whether `stdlib-deployment-targets` is no set or set to
`[]`.

Add a test to make this need more explicit.

Addresses rdar://81651877