### PR TITLE
Remove end_lifetime being considered as an end of scope marker

### DIFF
--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -70,8 +70,8 @@ NullablePtr<SILInstruction> createDecrementBefore(SILValue ptr,
 Optional<SILBasicBlock::iterator> getInsertAfterPoint(SILValue val);
 
 /// True if this instruction's only uses are debug_value (in -O mode),
-/// destroy_value, or end-of-scope instruction such as end_borrow.
-bool hasOnlyEndOfScopeOrDestroyUses(SILInstruction *inst);
+/// destroy_value, end_lifetime or end-of-scope instruction such as end_borrow.
+bool hasOnlyEndOfScopeOrEndOfLifetimeUses(SILInstruction *inst);
 
 /// Return the number of @inout arguments passed to the given apply site.
 unsigned getNumInOutArguments(FullApplySite applySite);

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -280,14 +280,13 @@ bool swift::isEndOfScopeMarker(SILInstruction *user) {
     return false;
   case SILInstructionKind::EndAccessInst:
   case SILInstructionKind::EndBorrowInst:
-  case SILInstructionKind::EndLifetimeInst:
     return true;
   }
 }
 
 bool swift::isIncidentalUse(SILInstruction *user) {
   return isEndOfScopeMarker(user) || user->isDebugInstruction() ||
-         isa<FixLifetimeInst>(user);
+         isa<FixLifetimeInst>(user) || isa<EndLifetimeInst>(user);
 }
 
 bool swift::onlyAffectsRefCount(SILInstruction *user) {

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -488,7 +488,7 @@ void CopyPropagation::run() {
       // Dead borrow scopes must be removed as uses before canonicalizing the
       // outer copy.
       if (auto *beginBorrow = dyn_cast<BeginBorrowInst>(borrow.value)) {
-        if (hasOnlyEndOfScopeOrDestroyUses(beginBorrow)) {
+        if (hasOnlyEndOfScopeOrEndOfLifetimeUses(beginBorrow)) {
           deleter.recursivelyDeleteUsersIfDead(beginBorrow);
         }
       }

--- a/test/SILOptimizer/cse_ossa.sil
+++ b/test/SILOptimizer/cse_ossa.sil
@@ -4,7 +4,9 @@ sil_stage canonical
 import Builtin
 import Swift
 
-class B { }
+class B { 
+  func foo()
+}
 class E : B { }
 
 class C {}
@@ -1298,3 +1300,20 @@ bb0(%0 : $LazyKlass):
   return %4 : $(Int64, Int64)
 }
 
+// CHECK-LABEL: sil [ossa] @test_end_lifetime :
+// CHECK:       upcast
+// CHECK-NOT:   upcast
+// CHECK: } // end sil function 'test_end_lifetime'
+sil [ossa] @test_end_lifetime : $@convention(method) (@owned E) -> () {
+bb0(%0 : @owned $E):
+  %copy = copy_value %0 : $E
+  %u1 = upcast %0 : $E to $B
+  %f = objc_method %u1 : $B, #B.foo!foreign : (B) -> () -> (), $@convention(objc_method) (B) -> ()
+  %c1 = apply %f(%u1) : $@convention(objc_method) (B) -> ()
+  end_lifetime %u1 : $B
+  %u2 = upcast %copy : $E to $B
+  %c2 = apply %f(%u2) : $@convention(objc_method) (B) -> ()
+  end_lifetime %u2 : $B
+  %r = tuple ()
+  return %r : $()
+}

--- a/test/SILOptimizer/load_borrow_verify.sil
+++ b/test/SILOptimizer/load_borrow_verify.sil
@@ -134,3 +134,22 @@ bb0(%0 : @owned $K):
   %r = tuple ()
   return %r : $()
 }
+
+sil [ossa] @test_end_lifetime : $@convention(thin) (@owned K) -> () {
+bb0(%0 : @owned $K):
+  %1 = begin_borrow %0 : $K
+  %2 = ref_element_addr %1 : $K, #K.x
+  %3 = begin_access [read] [dynamic] %2 : $*B
+  %4 = load_borrow %3 : $*B
+  end_borrow %4 : $B
+  end_access %3 : $*B
+  %cast = unchecked_ref_cast %1 : $K to $Builtin.NativeObject
+  %conv1 = unchecked_ownership_conversion %cast : $Builtin.NativeObject, @guaranteed to @owned
+  end_borrow %1 : $K
+  end_lifetime %0 : $K
+  %conv2 = unchecked_ref_cast %conv1 : $Builtin.NativeObject to $K
+  dealloc_ref %conv2 : $K
+  %r = tuple ()
+  return %r : $()
+}
+


### PR DESCRIPTION
OSSA rauw cleans up end of scope markers before rauw'ing.
This can lead to inadvertant deleting of end_lifetime, later
resulting in an ownership verifier error indicating a leak.

This PR stops treating end_lifetime scope ending like end_borrow/end_access.
