### PR TITLE
[swift-stage2] Install CMakeConfig.h as a testsuite-tool into the just built toolchain.

### DIFF
--- a/include/swift/Runtime/CMakeLists.txt
+++ b/include/swift/Runtime/CMakeLists.txt
@@ -11,3 +11,6 @@ endif()
 
 configure_file(CMakeConfig.h.in ${CMAKE_CURRENT_BINARY_DIR}/CMakeConfig.h
                ESCAPE_QUOTES @ONLY)
+swift_install_in_component(FILES ${CMAKE_CURRENT_BINARY_DIR}/CMakeConfig.h
+                           DESTINATION "include/swift/Runtime"
+                           COMPONENT testsuite-tools)


### PR DESCRIPTION
 Needed to run tests against the just built toolchain.

I made this as conservative as I could. Instead of installing it always, we only do it when we are trying to install testsuite-tools which seems like a reasonable carve-out since we are never going to ship test suite related stuff.