### PR TITLE
[5.5] [SILGen] Handle foreign funcs with error and async conventions.

### DIFF
--- a/lib/SILGen/ResultPlan.h
+++ b/lib/SILGen/ResultPlan.h
@@ -38,7 +38,8 @@ class CalleeTypeInfo;
 class ResultPlan {
 public:
   virtual RValue finish(SILGenFunction &SGF, SILLocation loc, CanType substType,
-                        ArrayRef<ManagedValue> &directResults) = 0;
+                        ArrayRef<ManagedValue> &directResults,
+                        SILValue bridgedForeignError) = 0;
   virtual ~ResultPlan() = default;
 
   virtual void

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -187,7 +187,8 @@ public:
   SILFunction *getOrCreateForeignAsyncCompletionHandlerImplFunction(
       CanSILFunctionType blockType, CanType continuationTy,
       AbstractionPattern origFormalType, CanGenericSignature sig,
-      ForeignAsyncConvention convention);
+      ForeignAsyncConvention convention,
+      Optional<ForeignErrorConvention> foreignError);
 
   /// Determine whether the given class has any instance variables that
   /// need to be destroyed.

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1871,14 +1871,16 @@ public:
                                        SILValue foreignErrorSlot,
                                  const ForeignErrorConvention &foreignError);
 
-  void emitForeignErrorBlock(SILLocation loc, SILBasicBlock *errorBB,
-                             Optional<ManagedValue> errorSlot);
+  SILValue emitForeignErrorBlock(SILLocation loc, SILBasicBlock *errorBB,
+                                 Optional<ManagedValue> errorSlot,
+                                 Optional<ForeignAsyncConvention> foreignAsync);
 
-  void emitForeignErrorCheck(SILLocation loc,
-                             SmallVectorImpl<ManagedValue> &directResults,
-                             ManagedValue errorSlot,
-                             bool suppressErrorCheck,
-                             const ForeignErrorConvention &foreignError);
+  SILValue emitForeignErrorCheck(SILLocation loc,
+                                 SmallVectorImpl<ManagedValue> &directResults,
+                                 ManagedValue errorSlot,
+                                 bool suppressErrorCheck,
+                                 const ForeignErrorConvention &foreignError,
+                                 Optional<ForeignAsyncConvention> foreignAsync);
 
   //===--------------------------------------------------------------------===//
   // Re-abstraction thunks

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -28,8 +28,9 @@
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/FileUnit.h"
 #include "swift/AST/ForeignAsyncConvention.h"
-#include "swift/SIL/FormalLinkage.h"
+#include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/SIL/FormalLinkage.h"
 #include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/TypeLowering.h"
@@ -185,7 +186,8 @@ static const clang::Type *prependParameterType(
 SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
     CanSILFunctionType blockType, CanType continuationTy,
     AbstractionPattern origFormalType, CanGenericSignature sig,
-    ForeignAsyncConvention convention) {
+    ForeignAsyncConvention convention,
+    Optional<ForeignErrorConvention> foreignError) {
   // Extract the result and error types from the continuation type.
   auto resumeType = cast<BoundGenericType>(continuationTy).getGenericArgs()[0];
 
@@ -355,10 +357,12 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
         errorScope.pop();
         SGF.B.createBranch(loc, returnBB);
         SGF.B.emitBlock(noneErrorBB);
+      } else if (foreignError) {
+        resumeIntrinsic = getResumeUnsafeThrowingContinuation();
       } else {
         resumeIntrinsic = getResumeUnsafeContinuation();
       }
-            
+
       auto loweredResumeTy = SGF.getLoweredType(AbstractionPattern::getOpaque(),
                                             F->mapTypeIntoContext(resumeType));
       

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -83,6 +83,8 @@ func testSlowServer(slowServer: SlowServer) async throws {
 
   let _: ((String) -> String, String) = await slowServer.performNSString2NSStringNSString()
   let _: ((Any) -> Void, (Any) -> Void) = await slowServer.performId2VoidId2Void()
+
+  let _: String = try await slowServer.findAnswerFailingly()
 }
 
 func testGeneric<T: AnyObject>(x: GenericObject<T>) async throws {

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704984.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704984.h
@@ -1,0 +1,21 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+typedef void (^CompletionHandler)(int status, NSUInteger bytesTransferred);
+
+@interface PFXObject : NSObject {
+}
+- (BOOL)enqueueErroryRequestWithError:(NSError *_Nullable *)error
+                    completionHandler:
+                        (nullable CompletionHandler)completionHandler;
+- (BOOL)enqueueSyncSuccessfulErroryRequestWithError:(NSError *_Nullable *)error
+                                  completionHandler:(nullable CompletionHandler)
+                                                        completionHandler;
+- (BOOL)enqueueAsyncSuccessfulErroryRequestWithError:(NSError *_Nullable *)error
+                                   completionHandler:
+                                       (nullable CompletionHandler)
+                                           completionHandler;
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704984.m
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704984.m
@@ -1,0 +1,35 @@
+#include "rdar80704984.h"
+
+#pragma clang assume_nonnull begin
+
+@implementation PFXObject
+- (instancetype)init {
+  if (self = [super init]) {
+  }
+  return self;
+}
+- (BOOL)enqueueErroryRequestWithError:(NSError *_Nullable *)error
+                    completionHandler:
+                        (nullable CompletionHandler)completionHandler {
+  *error = [[NSError alloc] initWithDomain:@"d" code:1 userInfo:nil];
+  return NO;
+}
+- (BOOL)enqueueSyncSuccessfulErroryRequestWithError:(NSError *_Nullable *)error
+                                  completionHandler:(nullable CompletionHandler)
+                                                        completionHandler {
+  completionHandler(0, 1);
+  return YES;
+}
+- (BOOL)enqueueAsyncSuccessfulErroryRequestWithError:(NSError *_Nullable *)error
+                                   completionHandler:
+                                       (nullable CompletionHandler)
+                                           completionHandler;
+{
+  dispatch_async(dispatch_get_main_queue(), ^{
+    completionHandler(0, 2);
+  });
+  return YES;
+}
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704984_2.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704984_2.h
@@ -1,0 +1,24 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+@interface PFXObject : NSObject {
+}
+- (BOOL)failReturnWithError:(NSError *_Nullable *)error
+          completionHandler:
+              (void (^_Nonnull)(NSError *_Nullable error))completionHandler;
+- (BOOL)failInvokeSyncWithError:(NSError *_Nullable *)error
+              completionHandler:
+                  (void (^_Nonnull)(NSError *_Nullable error))completionHandler;
+- (BOOL)failInvokeAsyncWithError:(NSError *_Nullable *)error
+               completionHandler:(void (^_Nonnull)(NSError *_Nullable error))
+                                     completionHandler;
+- (BOOL)succeedSyncWithError:(NSError *_Nullable *)error
+           completionHandler:
+               (void (^_Nonnull)(NSError *_Nullable error))completionHandler;
+- (BOOL)succeedAsyncWithError:(NSError *_Nullable *)error
+            completionHandler:
+                (void (^_Nonnull)(NSError *_Nullable error))completionHandler;
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704984_2.m
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704984_2.m
@@ -1,0 +1,51 @@
+#include "rdar80704984_2.h"
+
+#pragma clang assume_nonnull begin
+
+@implementation PFXObject
+- (instancetype)init {
+  if (self = [super init]) {
+  }
+  return self;
+}
+- (BOOL)failReturnWithError:(NSError *_Nullable *)error
+          completionHandler:
+              (void (^_Nonnull)(NSError *_Nullable error))completionHandler {
+  *error = [NSError errorWithDomain:@"failReturn" code:1 userInfo:nil];
+  return NO;
+}
+- (BOOL)failInvokeSyncWithError:(NSError *_Nullable *)error
+              completionHandler:(void (^_Nonnull)(NSError *_Nullable error))
+                                    completionHandler {
+  completionHandler([NSError errorWithDomain:@"failInvokeSync"
+                                        code:2
+                                    userInfo:nil]);
+  return YES;
+}
+- (BOOL)failInvokeAsyncWithError:(NSError *_Nullable *)error
+               completionHandler:(void (^_Nonnull)(NSError *_Nullable error))
+                                     completionHandler {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    completionHandler([NSError errorWithDomain:@"failInvokeAsync"
+                                          code:2
+                                      userInfo:nil]);
+  });
+  return YES;
+}
+- (BOOL)succeedSyncWithError:(NSError *_Nullable *)error
+           completionHandler:
+               (void (^_Nonnull)(NSError *_Nullable error))completionHandler {
+  completionHandler(nil);
+  return YES;
+}
+- (BOOL)succeedAsyncWithError:(NSError *_Nullable *)error
+            completionHandler:
+                (void (^_Nonnull)(NSError *_Nullable error))completionHandler {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    completionHandler(nil);
+  });
+  return YES;
+}
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/rdar80704984.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar80704984.swift
@@ -1,0 +1,51 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar80704984.m -I %S/Inputs -c -o %t/rdar80704984.o
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar80704984.h -Xlinker %t/rdar80704984.o -parse-as-library %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+func run1(on object: PFXObject) async throws {
+  do {
+    try await object.enqueueErroryRequest()
+    fatalError();
+  } catch let error {
+    // CHECK: Domain=d Code=1
+    print(error)
+  }
+}
+func run2(on object: PFXObject) async throws {
+  // CHECK: (0, 1)
+  print(try await object.enqueueSyncSuccessfulErroryRequest())
+}
+
+func run3(on object: PFXObject) async throws {
+  // CHECK: (0, 2)
+  print(try await object.enqueueAsyncSuccessfulErroryRequest())
+}
+
+func runAll(on object: PFXObject) async throws {
+  do {
+    try await object.enqueueErroryRequest()
+    fatalError();
+  } catch let error {
+    // CHECK: Domain=d Code=1
+    print(error)
+  }
+  // CHECK: (0, 1)
+  print(try await object.enqueueSyncSuccessfulErroryRequest())
+  // CHECK: (0, 2)
+  print(try await object.enqueueAsyncSuccessfulErroryRequest())
+}
+
+@main struct Main {
+  static func main() async throws {
+    let object = PFXObject()
+    try await run1(on: object)
+    try await run2(on: object)
+    try await run3(on: object)
+    try await runAll(on: object)
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar80704984_2.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar80704984_2.swift
@@ -1,0 +1,94 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar80704984_2.m -I %S/Inputs -c -o %t/rdar80704984_2.o
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar80704984_2.h -Xlinker %t/rdar80704984_2.o -parse-as-library %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+func run1(on object: PFXObject) async throws {
+  do {
+    try await object.failReturn()
+    fatalError()
+  }
+  catch let error {
+    // CHECK: Error Domain=failReturn Code=1 "(null)"
+    print(error)
+  }
+}
+
+func run2(on object: PFXObject) async throws {
+  do {
+    try await object.failInvokeSync()
+    fatalError()
+  }
+  catch let error {
+    // CHECK: Error Domain=failInvokeSync Code=2 "(null)"
+    print(error)
+  }
+}
+
+func run3(on object: PFXObject) async throws {
+  do {
+    try await object.failInvokeAsync()
+    fatalError()
+  }
+  catch let error {
+    // CHECK: Error Domain=failInvokeAsync Code=2 "(null)"
+    print(error)
+  }
+}
+
+func run4(on object: PFXObject) async throws {
+  // CHECK: ()
+  print(try await object.succeedSync())
+}
+
+func run5(on object: PFXObject) async throws {
+  // CHECK: ()
+  print(try await object.succeedAsync())
+}
+
+func runAll(on object: PFXObject) async throws {
+  do {
+    try await object.failReturn()
+    fatalError()
+  }
+  catch let error {
+    // CHECK: Error Domain=failReturn Code=1 "(null)"
+    print(error)
+  }
+  do {
+    try await object.failInvokeSync()
+    fatalError()
+  }
+  catch let error {
+    // CHECK: Error Domain=failInvokeSync Code=2 "(null)"
+    print(error)
+  }
+  do {
+    try await object.failInvokeAsync()
+    fatalError()
+  }
+  catch let error {
+    // CHECK: Error Domain=failInvokeAsync Code=2 "(null)"
+    print(error)
+  }
+  // CHECK: ()
+  print(try await object.succeedSync())
+  // CHECK: ()
+  print(try await object.succeedAsync())
+}
+
+@main struct Main {
+  static func main() async throws {
+    let object = PFXObject()
+    try await run1(on: object)
+    try await run2(on: object)
+    try await run3(on: object)
+    try await run4(on: object)
+    try await run5(on: object)
+    try await runAll(on: object)
+  }
+}


### PR DESCRIPTION
5.5 Summary: Fix compiler crashes during emission of calls-as-async to ObjC functions that take error out parameters.

---

Explanation: When an ObjC method is called-as-async from Swift, SILGen generates code to handle ObjC's conventions around error handling.  For example, ObjC often communicates errors via an NSError or flag argument passed to the completion handler.  ObjC may, however, also communicate an error via a NSError out parameter at the top level such as

```
- (BOOL)minimalWithError:(NSError* _Nullable*)error
         completionHandler:(void (^ _Nonnull)(void))completionHandler;
```

Previously, SILGen assumed that a foreign function could either have a foreign async convention or a foreign error convention, but not both.  Consequently, SILGen failed when attempting to call-as-async that method.

Here, SILGen gains the ability to emit calls-as-async to such functions.  To enable that, the ResultPlan for such calls is now a ForeignErrorResultPlan nesting a ForeignAsyncResultPlan.  The ForeignAsyncResultPlan-created continuation used for the call is now always of the form `UnsafeContinuation<_, Error>` regardless of whether the ObjC method's completion has an error or flag argument.  That in turn enables the foreign error block--which is branched to if the error out parameter/return value indicates an error--to fill that continuation with the error and then to branch to the block which awaits the fulfillment of the continuation.

Issue: rdar://80704984

Original PR: https://github.com/apple/swift/pull/38740

Testing: New regression tests, Swift CI

Reviewed by: Joe Groff

Risk: Low.

Scope: Limited to Swift import of ObjC methods as async functions.
