### PR TITLE
[5.5] [SILGen] Handled transforming Bridged? -> Swift.

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1019,16 +1019,11 @@ SILGenFunction::emitBlockToFunc(SILLocation loc,
       loc, thunkedFn, SILType::getPrimitiveObjectType(loweredFuncTy));
 }
 
-static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
-                                              SILLocation loc,
-                                              ManagedValue v,
-                                              CanType bridgedType,
-                                              CanType nativeType,
-                                              SILType loweredNativeTy,
-                                              bool isCallResult,
-                                              SGFContext C) {
+static ManagedValue emitCBridgedToNativeValue(
+    SILGenFunction &SGF, SILLocation loc, ManagedValue v, CanType bridgedType,
+    SILType loweredBridgedTy, CanType nativeType, SILType loweredNativeTy,
+    int bridgedOptionalsToUnwrap, bool isCallResult, SGFContext C) {
   assert(loweredNativeTy.isObject());
-  SILType loweredBridgedTy = v.getType();
   if (loweredNativeTy == loweredBridgedTy.getObjectType())
     return v;
 
@@ -1039,37 +1034,50 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
     if (!bridgedObjectType) {
       auto helper = [&](SILGenFunction &SGF, SILLocation loc, SGFContext C) {
         auto loweredNativeObjectTy = loweredNativeTy.getOptionalObjectType();
-        return emitCBridgedToNativeValue(SGF, loc, v, bridgedType,
-                                         nativeObjectType,
-                                         loweredNativeObjectTy,
-                                         isCallResult, C);
+        return emitCBridgedToNativeValue(
+            SGF, loc, v, bridgedType, loweredBridgedTy, nativeObjectType,
+            loweredNativeObjectTy, bridgedOptionalsToUnwrap, isCallResult, C);
       };
       return SGF.emitOptionalSome(loc, loweredNativeTy, helper, C);
     }
 
     // Optional-to-optional.
-    auto helper =
-        [=](SILGenFunction &SGF, SILLocation loc, ManagedValue v,
-            SILType loweredNativeObjectTy, SGFContext C) {
-      return emitCBridgedToNativeValue(SGF, loc, v, bridgedObjectType,
-                                       nativeObjectType, loweredNativeObjectTy,
-                                       isCallResult, C);
+    auto helper = [=](SILGenFunction &SGF, SILLocation loc, ManagedValue v,
+                      SILType loweredNativeObjectTy, SGFContext C) {
+      return emitCBridgedToNativeValue(
+          SGF, loc, v, bridgedObjectType,
+          loweredBridgedTy.getOptionalObjectType(), nativeObjectType,
+          loweredNativeObjectTy, bridgedOptionalsToUnwrap, isCallResult, C);
     };
     return SGF.emitOptionalToOptional(loc, v, loweredNativeTy, helper, C);
   }
+  if (auto bridgedObjectType = bridgedType.getOptionalObjectType()) {
+    return emitCBridgedToNativeValue(
+        SGF, loc, v, bridgedObjectType,
+        loweredBridgedTy.getOptionalObjectType(), nativeType, loweredNativeTy,
+        bridgedOptionalsToUnwrap + 1, isCallResult, C);
+  }
+
+  auto unwrapBridgedOptionals = [&](ManagedValue v) {
+    for (int i = 0; i < bridgedOptionalsToUnwrap; ++i) {
+      v = SGF.emitPreconditionOptionalHasValue(loc, v,
+                                               /*implicit*/ true);
+    };
+    return v;
+  };
 
   // Bridge ObjCBool, DarwinBoolean, WindowsBool to Bool when requested.
   if (nativeType == SGF.SGM.Types.getBoolType()) {
     if (bridgedType == SGF.SGM.Types.getObjCBoolType()) {
-      return emitBridgeForeignBoolToBool(SGF, loc, v,
+      return emitBridgeForeignBoolToBool(SGF, loc, unwrapBridgedOptionals(v),
                                          SGF.SGM.getObjCBoolToBoolFn());
     }
     if (bridgedType == SGF.SGM.Types.getDarwinBooleanType()) {
-      return emitBridgeForeignBoolToBool(SGF, loc, v,
+      return emitBridgeForeignBoolToBool(SGF, loc, unwrapBridgedOptionals(v),
                                          SGF.SGM.getDarwinBooleanToBoolFn());
     }
     if (bridgedType == SGF.SGM.Types.getWindowsBoolType()) {
-      return emitBridgeForeignBoolToBool(SGF, loc, v,
+      return emitBridgeForeignBoolToBool(SGF, loc, unwrapBridgedOptionals(v),
                                          SGF.SGM.getWindowsBoolToBoolFn());
     }
   }
@@ -1079,8 +1087,8 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
     auto bridgedMetaTy = cast<AnyMetatypeType>(bridgedType);
     if (bridgedMetaTy->hasRepresentation() &&
         bridgedMetaTy->getRepresentation() == MetatypeRepresentation::ObjC) {
-      SILValue native =
-        SGF.B.emitObjCToThickMetatype(loc, v.getValue(), loweredNativeTy);
+      SILValue native = SGF.B.emitObjCToThickMetatype(
+          loc, unwrapBridgedOptionals(v).getValue(), loweredNativeTy);
       // *NOTE*: ObjCMetatypes are trivial types. They only gain ARC semantics
       // when they are converted to an object via objc_metatype_to_object.
       assert(!v.hasCleanup() && "Metatypes are trivial and should not have "
@@ -1096,7 +1104,8 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
           == AnyFunctionType::Representation::Block
         && nativeFTy->getRepresentation()
           != AnyFunctionType::Representation::Block) {
-      return SGF.emitBlockToFunc(loc, v, bridgedFTy, nativeFTy,
+      return SGF.emitBlockToFunc(loc, unwrapBridgedOptionals(v), bridgedFTy,
+                                 nativeFTy,
                                  loweredNativeTy.castTo<SILFunctionType>());
     }
   }
@@ -1105,8 +1114,10 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
   if (auto conformance =
         SGF.SGM.getConformanceToObjectiveCBridgeable(loc, nativeType)) {
     if (auto result = emitBridgeObjectiveCToNative(SGF, loc, v, bridgedType,
-                                                   conformance))
-      return *result;
+                                                   conformance)) {
+      --bridgedOptionalsToUnwrap;
+      return unwrapBridgedOptionals(*result);
+    }
 
     assert(SGF.SGM.getASTContext().Diags.hadAnyError() &&
            "Bridging code should have complained");
@@ -1117,7 +1128,8 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
   if (nativeType->isAny()) {
     // If this is not a call result, use the normal erasure logic.
     if (!isCallResult) {
-      return SGF.emitTransformedValue(loc, v, bridgedType, nativeType, C);
+      return SGF.emitTransformedValue(loc, unwrapBridgedOptionals(v),
+                                      bridgedType, nativeType, C);
     }
 
     // Otherwise, we use more complicated logic that handles results that
@@ -1129,7 +1141,8 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
     CanType anyObjectTy =
       SGF.getASTContext().getAnyObjectType()->getCanonicalType();
     if (bridgedType != anyObjectTy) {
-      v = SGF.emitTransformedValue(loc, v, bridgedType, anyObjectTy);
+      v = SGF.emitTransformedValue(loc, unwrapBridgedOptionals(v), bridgedType,
+                                   anyObjectTy);
     }
 
     // TODO: Ever need to handle +0 values here?
@@ -1142,8 +1155,8 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
     // Bitcast to Optional. This provides a barrier to the optimizer to prevent
     // it from attempting to eliminate null checks.
     auto optionalBridgedTy = SILType::getOptionalType(loweredBridgedTy);
-    auto optionalMV =
-      SGF.B.createUncheckedBitCast(loc, v, optionalBridgedTy);
+    auto optionalMV = SGF.B.createUncheckedBitCast(
+        loc, unwrapBridgedOptionals(v), optionalBridgedTy);
     return SGF.emitApplyOfLibraryIntrinsic(loc,
                            SGF.getASTContext().getBridgeAnyObjectToAny(),
                            SubstitutionMap(), optionalMV, C)
@@ -1152,9 +1165,9 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
 
   // Bridge NSError to Error.
   if (bridgedType == SGF.SGM.Types.getNSErrorType())
-    return SGF.emitBridgedToNativeError(loc, v);
+    return SGF.emitBridgedToNativeError(loc, unwrapBridgedOptionals(v));
 
-  return v;
+  return unwrapBridgedOptionals(v);
 }
 
 ManagedValue SILGenFunction::emitBridgedToNativeValue(SILLocation loc,
@@ -1165,8 +1178,10 @@ ManagedValue SILGenFunction::emitBridgedToNativeValue(SILLocation loc,
                                                       SGFContext C,
                                                       bool isCallResult) {
   loweredNativeTy = loweredNativeTy.getObjectType();
-  return emitCBridgedToNativeValue(*this, loc, v, bridgedType, nativeType,
-                                   loweredNativeTy, isCallResult, C);
+  SILType loweredBridgedTy = v.getType();
+  return emitCBridgedToNativeValue(
+      *this, loc, v, bridgedType, loweredBridgedTy, nativeType, loweredNativeTy,
+      /*bridgedOptionalsToUnwrap=*/0, isCallResult, C);
 }
 
 /// Bridge a possibly-optional foreign error type to Error.

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -6,6 +6,9 @@
 #define MAIN_ACTOR __attribute__((__swift_attr__("@MainActor")))
 #define MAIN_ACTOR_UNSAFE __attribute__((__swift_attr__("@_unsafeMainActor")))
 
+#define NS_EXTENSIBLE_STRING_ENUM __attribute__((swift_wrapper(struct)));
+typedef NSString *Flavor NS_EXTENSIBLE_STRING_ENUM;
+
 @protocol ServiceProvider
 @property(readonly) NSArray<NSString *> *allOperations;
 -(void)allOperationsWithCompletionHandler:(void (^)(NSArray<NSString *> *))completion;
@@ -88,6 +91,8 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
                                                      NSError *_Nullable,
                                                      BOOL))completionHandler
     __attribute__((swift_async_error(zero_argument, 3)));
+- (void)getIceCreamFlavorWithCompletionHandler:
+    (void (^)(Flavor flavor, NSError *__nullable error))completionHandler;
 @end
 
 @protocol RefrigeratorDelegate<NSObject>

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -84,6 +84,10 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
 -(void)asyncImportSame:(NSString *)operation replyTo:(void (^)(NSInteger))handler __attribute__((swift_async(none)));
 
 -(void)overridableButRunsOnMainThreadWithCompletionHandler:(MAIN_ACTOR_UNSAFE void (^ _Nullable)(NSString *))completion;
+- (void)obtainClosureWithCompletionHandler:(void (^)(void (^_Nullable)(void),
+                                                     NSError *_Nullable,
+                                                     BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
 @end
 
 @protocol RefrigeratorDelegate<NSObject>

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -87,6 +87,8 @@ func testSlowServer(slowServer: SlowServer) async throws {
   let _: String = try await slowServer.findAnswerFailingly()
 
   let _: () -> Void = try await slowServer.obtainClosure()
+
+  let _: Flavor = try await slowServer.iceCreamFlavor()
 }
 
 func testGeneric<T: AnyObject>(x: GenericObject<T>) async throws {

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -85,6 +85,8 @@ func testSlowServer(slowServer: SlowServer) async throws {
   let _: ((Any) -> Void, (Any) -> Void) = await slowServer.performId2VoidId2Void()
 
   let _: String = try await slowServer.findAnswerFailingly()
+
+  let _: () -> Void = try await slowServer.obtainClosure()
 }
 
 func testGeneric<T: AnyObject>(x: GenericObject<T>) async throws {

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704382.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704382.h
@@ -1,0 +1,25 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+typedef NSString *FileProviderItemIdentifier NS_EXTENSIBLE_STRING_ENUM;
+FileProviderItemIdentifier const
+    FileProviderRootContainerItemIdentifier NS_SWIFT_NAME(FileProviderItemIdentifier.rootContainer);
+FileProviderItemIdentifier const
+    FileProviderWorkingSetContainerItemIdentifier NS_SWIFT_NAME(FileProviderItemIdentifier.workingSet);
+FileProviderItemIdentifier const
+    FileProviderTrashContainerItemIdentifier NS_SWIFT_NAME(FileProviderItemIdentifier.trashContainer);
+typedef NSString *FileProviderDomainIdentifier NS_EXTENSIBLE_STRING_ENUM;
+
+@interface PFXObject : NSObject
++ (void)getIdentifierForUserVisibleFileAtURL:(NSURL *)url
+                           completionHandler:
+                               (void (^)(FileProviderItemIdentifier __nullable
+                                             itemIdentifier,
+                                         FileProviderDomainIdentifier __nullable
+                                             domainIdentifier,
+                                         NSError *__nullable error))
+                                   completionHandler;
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704382.m
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704382.m
@@ -1,0 +1,23 @@
+#include "rdar80704382.h"
+
+#pragma clang assume_nonnull begin
+
+@implementation PFXObject
+- (instancetype)init {
+  if (self = [super init]) {
+  }
+  return self;
+}
++ (void)getIdentifierForUserVisibleFileAtURL:(NSURL *)url
+                           completionHandler:
+                               (void (^)(FileProviderItemIdentifier __nullable
+                                             itemIdentifier,
+                                         FileProviderDomainIdentifier __nullable
+                                             domainIdentifier,
+                                         NSError *__nullable error))
+                                   completionHandler {
+  completionHandler(@"item_id", @"file_id", NULL);
+}
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807.h
@@ -1,0 +1,29 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+@interface PFXObject : NSObject {
+}
+- (void)continuePassSyncWithCompletionHandler:(void (^)(void (^_Nullable)(void),
+                                                        NSError *_Nullable,
+                                                        BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)continuePassAsyncWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)continueFailSyncWithCompletionHandler:(void (^)(void (^_Nullable)(void),
+                                                        NSError *_Nullable,
+                                                        BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)continueFailAsyncWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)continueIncorrectWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807.m
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807.m
@@ -1,0 +1,54 @@
+#include "rdar81590807.h"
+
+#pragma clang assume_nonnull begin
+
+@implementation PFXObject
+- (void)continuePassSyncWithCompletionHandler:(void (^)(void (^_Nullable)(void),
+                                                        NSError *_Nullable,
+                                                        BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  completionHandler(
+      ^{
+        NSLog(@"passSync");
+      },
+      NULL, YES);
+}
+- (void)continuePassAsyncWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    completionHandler(
+        ^{
+          NSLog(@"passAsync");
+        },
+        NULL, YES);
+  });
+}
+- (void)continueFailSyncWithCompletionHandler:(void (^)(void (^_Nullable)(void),
+                                                        NSError *_Nullable,
+                                                        BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  completionHandler(
+      NULL, [NSError errorWithDomain:@"failSync" code:1 userInfo:nil], NO);
+}
+- (void)continueFailAsyncWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    completionHandler(
+        NULL, [NSError errorWithDomain:@"failAsync" code:2 userInfo:nil], NO);
+  });
+}
+- (void)continueIncorrectWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    completionHandler(NULL, NULL, NO);
+  });
+}
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807_2.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807_2.h
@@ -1,0 +1,24 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+@interface PFXObject : NSObject {
+}
+- (void)findAnswerSyncSuccessAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerSyncSuccess(completionHandler:)")));
+- (void)findAnswerAsyncSuccessAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerAsyncSuccess(completionHandler:)")));
+- (void)findAnswerSyncFailAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerSyncFail(completionHandler:)")));
+- (void)findAnswerAsyncFailAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerAsyncFail(completionHandler:)")));
+- (void)findAnswerIncorrectAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerIncorrect(completionHandler:)")));
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807_2.m
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807_2.m
@@ -1,0 +1,37 @@
+#include "rdar81590807_2.h"
+
+#pragma clang assume_nonnull begin
+
+@implementation PFXObject
+- (void)findAnswerSyncSuccessAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerSyncSuccess(completionHandler:)"))) {
+  handler(@"syncSuccess", NULL);
+}
+- (void)findAnswerAsyncSuccessAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerAsyncSuccess(completionHandler:)"))) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    handler(@"asyncSuccess", NULL);
+  });
+}
+- (void)findAnswerSyncFailAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerSyncFail(completionHandler:)"))) {
+  handler(NULL, [NSError errorWithDomain:@"syncFail" code:1 userInfo:nil]);
+}
+- (void)findAnswerAsyncFailAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerAsyncFail(completionHandler:)"))) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    handler(NULL, [NSError errorWithDomain:@"asyncFail" code:2 userInfo:nil]);
+  });
+}
+- (void)findAnswerIncorrectAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerIncorrect(completionHandler:)"))) {
+  handler(NULL, NULL);
+}
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/rdar80704382.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar80704382.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar80704382.m -I %S/Inputs -c -o %t/rdar80704382.o
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar80704382.h -Xlinker %t/rdar80704382.o -parse-as-library %s -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+func run() async throws {
+  // CHECK: item_id
+  // CHECK: file_id
+  print(try await PFXObject.identifierForUserVisibleFile(at: URL(fileURLWithPath: "/tmp/file")))
+}
+
+@main struct Main {
+  static func main() async throws {
+    try await run()
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar81590807.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar81590807.swift
@@ -1,0 +1,50 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar81590807.m -I %S/Inputs -c -o %t/rdar81590807.o
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar81590807.h -Xlinker %t/rdar81590807.o -parse-as-library %s -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main > %t/log 2>&1 || true
+// RUN: %FileCheck %s < %t/log
+
+// Unsupported because the crash on continueIncorrect is just an illegal 
+// instruction rather than a nice fatal error.
+// UNSUPPORTED: swift_test_mode_optimize
+// UNSUPPORTED: swift_test_mode_optimize_size
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=ios
+
+func run(on object: PFXObject) async throws {
+  // CHECK: passSync
+  let cl1 = try await object.continuePassSync()
+  cl1()
+  // CHECK: passAsync
+  let cl2 = try await object.continuePassAsync()
+  cl2()
+  do {
+    let cl = try await object.continueFailSync()
+    // CHECK-NOT: oh no failSync
+    fputs("oh no failSync\n", stderr)
+  }
+  catch let error {
+    // CHECK: Error Domain=failSync Code=1 "(null)"
+    fputs("\(error)\n", stderr)
+  }
+  do {
+    let cl = try await object.continueFailAsync()
+    // CHECK-NOT: oh no failAsync
+    fputs("oh no failAsync\n", stderr)
+  }
+  catch let error {
+    // CHECK: Error Domain=failAsync Code=2 "(null)"
+    fputs("\(error)\n", stderr)
+  }
+  // CHECK: Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value
+  print(try await object.continueIncorrect())
+}
+
+@main struct Main {
+  static func main() async throws {
+    let object = PFXObject()
+    try await run(on: object)
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar81590807_2.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar81590807_2.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar81590807_2.m -I %S/Inputs -c -o %t/rdar81590807_2.o
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar81590807_2.h -Xlinker %t/rdar81590807_2.o -parse-as-library %s -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=ios
+
+func run(on object: PFXObject) async throws {
+  // CHECK: syncSuccess
+  print("\(try await object.findAnswerSyncSuccess())\n")
+  // CHECK: asyncSuccess
+  print("\(try await object.findAnswerAsyncSuccess())\n")
+  do {
+    try await object.findAnswerSyncFail()
+    // CHECK-NOT: oh no syncFail
+    print("\("oh no syncFail")\n")
+  }
+  catch let error {
+    // CHECK: Error Domain=syncFail Code=1 "(null)"
+    print("\(error)\n")
+  }
+  do {
+    try await object.findAnswerAsyncFail()
+    // CHECK-NOT: oh no asyncFail
+    print("\("oh no asyncFail")\n")
+  }
+  catch let error {
+    // CHECK: Error Domain=asyncFail Code=2 "(null)"
+    print("\(error)\n")
+  }
+  // CHECK: <<>>
+  print("<<\(try await object.findAnswerIncorrect())>>\n")
+}
+
+@main struct Main {
+  static func main() async throws {
+    let object = PFXObject()
+    try await run(on: object)
+  }
+}


### PR DESCRIPTION
5.5 Summary: Fix compiler crash for called-as-async ObjC methods whose completions take complex optional types that get unwrapped by Swift.

---

Explanation: When an ObjC method is called-as-async from Swift, SILGen creates a completion handler to pass to the ObjC method.  That completion handler is sometimes responsible for unwrapping Optionals that ObjC passes in.  To do that unwrapping, a common utility is used.  That common utility needs to know how to deal with various cases of Optional-ness of the source/bridged/ObjC type and the target/native/Swift type.

Previously, that utility knew how to deal with three of the four cases of Optional-ness: (1) `Optional<Bridged> -> Optional<Native>`, (2) `Bridged -> Optional<Native>`, (3) `Bridged -> Native`.  It didn't, however, handle the other case: (4) `Optional<Bridged> -> Native`.  Consequently, SILGen failed to generate code for calling-as-async methods like the following:

```
typedef NSString *Flavor NS_EXTENSIBLE_STRING_ENUM;
- (void)getIceCreamFlavorWithCompletionHandler:(void (^)(NSError * __nullable error, Flavor __nullable flavor))completionHandler;
- (void)badWithCompletionHandler:(void (^)(void (^ _Nullable)(void), NSError * _Nullable, BOOL))completionHandler  __attribute__((swift_async_error(zero_argument, 3)));
```

Here, handling for that fourth case is added.  The number of Optional wrappings that the bridged type has that the native type does not is passed in to the utility.  When the utility recurs, it increments the number as appropriate.  Then, in the portions of the function where transformations are done, the values are unwrapped an appropriate number of times.  Mostly that means force unwrapping N times before doing the transformation.  In the case of types that conform to `_ObjectiveCBridgeable`, however, it means force unwrapping the value N-1 times after doing the transformation because `_ObjectiveCBridgeable._unconditionallyBridgeFromObjectiveC` performs one layer of unwrapping itself.  As a side note, the reason why this hadn't been more of a problem is because many handlers use types which conform to `ObjectiveCBridgeable` and as such were already unwrapped.

Issue: rdar://80704382

Original PR: https://github.com/apple/swift/pull/38773

Testing: New regression tests, Swift CI

Reviewed by: Joe Groff

Risk: Low.

Scope: Limited to Swift import of ObjC methods as async functions.
