### PR TITLE
[5.5] [SIL] Fixed return index for call-as-async (BOOL, Error, Value) case.

### DIFF
--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -574,12 +574,14 @@ AbstractionPattern AbstractionPattern::getFunctionResultType() const {
         // If there's a single argument, abstract it according to its formal type
         // in the ObjC signature.
         unsigned callbackResultIndex = 0;
-        if (callbackErrorIndex && callbackResultIndex >= *callbackErrorIndex)
-          ++callbackResultIndex;
-        if (callbackErrorFlagIndex
-            && callbackResultIndex >= *callbackErrorFlagIndex)
-          ++callbackResultIndex;
-
+        for (auto index : indices(callbackParamTy->getParamTypes())) {
+          if (callbackErrorIndex && index == *callbackErrorIndex)
+            continue;
+          if (callbackErrorFlagIndex && index == *callbackErrorFlagIndex)
+            continue;
+          callbackResultIndex = index;
+          break;
+        }
         auto clangResultType = callbackParamTy
           ->getParamType(callbackResultIndex)
           .getTypePtr();

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1019,16 +1019,11 @@ SILGenFunction::emitBlockToFunc(SILLocation loc,
       loc, thunkedFn, SILType::getPrimitiveObjectType(loweredFuncTy));
 }
 
-static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
-                                              SILLocation loc,
-                                              ManagedValue v,
-                                              CanType bridgedType,
-                                              CanType nativeType,
-                                              SILType loweredNativeTy,
-                                              bool isCallResult,
-                                              SGFContext C) {
+static ManagedValue emitCBridgedToNativeValue(
+    SILGenFunction &SGF, SILLocation loc, ManagedValue v, CanType bridgedType,
+    SILType loweredBridgedTy, CanType nativeType, SILType loweredNativeTy,
+    int bridgedOptionalsToUnwrap, bool isCallResult, SGFContext C) {
   assert(loweredNativeTy.isObject());
-  SILType loweredBridgedTy = v.getType();
   if (loweredNativeTy == loweredBridgedTy.getObjectType())
     return v;
 
@@ -1039,37 +1034,50 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
     if (!bridgedObjectType) {
       auto helper = [&](SILGenFunction &SGF, SILLocation loc, SGFContext C) {
         auto loweredNativeObjectTy = loweredNativeTy.getOptionalObjectType();
-        return emitCBridgedToNativeValue(SGF, loc, v, bridgedType,
-                                         nativeObjectType,
-                                         loweredNativeObjectTy,
-                                         isCallResult, C);
+        return emitCBridgedToNativeValue(
+            SGF, loc, v, bridgedType, loweredBridgedTy, nativeObjectType,
+            loweredNativeObjectTy, bridgedOptionalsToUnwrap, isCallResult, C);
       };
       return SGF.emitOptionalSome(loc, loweredNativeTy, helper, C);
     }
 
     // Optional-to-optional.
-    auto helper =
-        [=](SILGenFunction &SGF, SILLocation loc, ManagedValue v,
-            SILType loweredNativeObjectTy, SGFContext C) {
-      return emitCBridgedToNativeValue(SGF, loc, v, bridgedObjectType,
-                                       nativeObjectType, loweredNativeObjectTy,
-                                       isCallResult, C);
+    auto helper = [=](SILGenFunction &SGF, SILLocation loc, ManagedValue v,
+                      SILType loweredNativeObjectTy, SGFContext C) {
+      return emitCBridgedToNativeValue(
+          SGF, loc, v, bridgedObjectType,
+          loweredBridgedTy.getOptionalObjectType(), nativeObjectType,
+          loweredNativeObjectTy, bridgedOptionalsToUnwrap, isCallResult, C);
     };
     return SGF.emitOptionalToOptional(loc, v, loweredNativeTy, helper, C);
   }
+  if (auto bridgedObjectType = bridgedType.getOptionalObjectType()) {
+    return emitCBridgedToNativeValue(
+        SGF, loc, v, bridgedObjectType,
+        loweredBridgedTy.getOptionalObjectType(), nativeType, loweredNativeTy,
+        bridgedOptionalsToUnwrap + 1, isCallResult, C);
+  }
+
+  auto unwrapBridgedOptionals = [&](ManagedValue v) {
+    for (int i = 0; i < bridgedOptionalsToUnwrap; ++i) {
+      v = SGF.emitPreconditionOptionalHasValue(loc, v,
+                                               /*implicit*/ true);
+    };
+    return v;
+  };
 
   // Bridge ObjCBool, DarwinBoolean, WindowsBool to Bool when requested.
   if (nativeType == SGF.SGM.Types.getBoolType()) {
     if (bridgedType == SGF.SGM.Types.getObjCBoolType()) {
-      return emitBridgeForeignBoolToBool(SGF, loc, v,
+      return emitBridgeForeignBoolToBool(SGF, loc, unwrapBridgedOptionals(v),
                                          SGF.SGM.getObjCBoolToBoolFn());
     }
     if (bridgedType == SGF.SGM.Types.getDarwinBooleanType()) {
-      return emitBridgeForeignBoolToBool(SGF, loc, v,
+      return emitBridgeForeignBoolToBool(SGF, loc, unwrapBridgedOptionals(v),
                                          SGF.SGM.getDarwinBooleanToBoolFn());
     }
     if (bridgedType == SGF.SGM.Types.getWindowsBoolType()) {
-      return emitBridgeForeignBoolToBool(SGF, loc, v,
+      return emitBridgeForeignBoolToBool(SGF, loc, unwrapBridgedOptionals(v),
                                          SGF.SGM.getWindowsBoolToBoolFn());
     }
   }
@@ -1079,8 +1087,8 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
     auto bridgedMetaTy = cast<AnyMetatypeType>(bridgedType);
     if (bridgedMetaTy->hasRepresentation() &&
         bridgedMetaTy->getRepresentation() == MetatypeRepresentation::ObjC) {
-      SILValue native =
-        SGF.B.emitObjCToThickMetatype(loc, v.getValue(), loweredNativeTy);
+      SILValue native = SGF.B.emitObjCToThickMetatype(
+          loc, unwrapBridgedOptionals(v).getValue(), loweredNativeTy);
       // *NOTE*: ObjCMetatypes are trivial types. They only gain ARC semantics
       // when they are converted to an object via objc_metatype_to_object.
       assert(!v.hasCleanup() && "Metatypes are trivial and should not have "
@@ -1096,7 +1104,8 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
           == AnyFunctionType::Representation::Block
         && nativeFTy->getRepresentation()
           != AnyFunctionType::Representation::Block) {
-      return SGF.emitBlockToFunc(loc, v, bridgedFTy, nativeFTy,
+      return SGF.emitBlockToFunc(loc, unwrapBridgedOptionals(v), bridgedFTy,
+                                 nativeFTy,
                                  loweredNativeTy.castTo<SILFunctionType>());
     }
   }
@@ -1105,8 +1114,10 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
   if (auto conformance =
         SGF.SGM.getConformanceToObjectiveCBridgeable(loc, nativeType)) {
     if (auto result = emitBridgeObjectiveCToNative(SGF, loc, v, bridgedType,
-                                                   conformance))
-      return *result;
+                                                   conformance)) {
+      --bridgedOptionalsToUnwrap;
+      return unwrapBridgedOptionals(*result);
+    }
 
     assert(SGF.SGM.getASTContext().Diags.hadAnyError() &&
            "Bridging code should have complained");
@@ -1117,7 +1128,8 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
   if (nativeType->isAny()) {
     // If this is not a call result, use the normal erasure logic.
     if (!isCallResult) {
-      return SGF.emitTransformedValue(loc, v, bridgedType, nativeType, C);
+      return SGF.emitTransformedValue(loc, unwrapBridgedOptionals(v),
+                                      bridgedType, nativeType, C);
     }
 
     // Otherwise, we use more complicated logic that handles results that
@@ -1129,7 +1141,8 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
     CanType anyObjectTy =
       SGF.getASTContext().getAnyObjectType()->getCanonicalType();
     if (bridgedType != anyObjectTy) {
-      v = SGF.emitTransformedValue(loc, v, bridgedType, anyObjectTy);
+      v = SGF.emitTransformedValue(loc, unwrapBridgedOptionals(v), bridgedType,
+                                   anyObjectTy);
     }
 
     // TODO: Ever need to handle +0 values here?
@@ -1142,8 +1155,8 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
     // Bitcast to Optional. This provides a barrier to the optimizer to prevent
     // it from attempting to eliminate null checks.
     auto optionalBridgedTy = SILType::getOptionalType(loweredBridgedTy);
-    auto optionalMV =
-      SGF.B.createUncheckedBitCast(loc, v, optionalBridgedTy);
+    auto optionalMV = SGF.B.createUncheckedBitCast(
+        loc, unwrapBridgedOptionals(v), optionalBridgedTy);
     return SGF.emitApplyOfLibraryIntrinsic(loc,
                            SGF.getASTContext().getBridgeAnyObjectToAny(),
                            SubstitutionMap(), optionalMV, C)
@@ -1152,9 +1165,9 @@ static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,
 
   // Bridge NSError to Error.
   if (bridgedType == SGF.SGM.Types.getNSErrorType())
-    return SGF.emitBridgedToNativeError(loc, v);
+    return SGF.emitBridgedToNativeError(loc, unwrapBridgedOptionals(v));
 
-  return v;
+  return unwrapBridgedOptionals(v);
 }
 
 ManagedValue SILGenFunction::emitBridgedToNativeValue(SILLocation loc,
@@ -1165,8 +1178,10 @@ ManagedValue SILGenFunction::emitBridgedToNativeValue(SILLocation loc,
                                                       SGFContext C,
                                                       bool isCallResult) {
   loweredNativeTy = loweredNativeTy.getObjectType();
-  return emitCBridgedToNativeValue(*this, loc, v, bridgedType, nativeType,
-                                   loweredNativeTy, isCallResult, C);
+  SILType loweredBridgedTy = v.getType();
+  return emitCBridgedToNativeValue(
+      *this, loc, v, bridgedType, loweredBridgedTy, nativeType, loweredNativeTy,
+      /*bridgedOptionalsToUnwrap=*/0, isCallResult, C);
 }
 
 /// Bridge a possibly-optional foreign error type to Error.

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -6,6 +6,9 @@
 #define MAIN_ACTOR __attribute__((__swift_attr__("@MainActor")))
 #define MAIN_ACTOR_UNSAFE __attribute__((__swift_attr__("@_unsafeMainActor")))
 
+#define NS_EXTENSIBLE_STRING_ENUM __attribute__((swift_wrapper(struct)));
+typedef NSString *Flavor NS_EXTENSIBLE_STRING_ENUM;
+
 @protocol ServiceProvider
 @property(readonly) NSArray<NSString *> *allOperations;
 -(void)allOperationsWithCompletionHandler:(void (^)(NSArray<NSString *> *))completion;
@@ -88,6 +91,8 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
                                                      NSError *_Nullable,
                                                      BOOL))completionHandler
     __attribute__((swift_async_error(zero_argument, 3)));
+- (void)getIceCreamFlavorWithCompletionHandler:
+    (void (^)(Flavor flavor, NSError *__nullable error))completionHandler;
 @end
 
 @protocol RefrigeratorDelegate<NSObject>

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -84,6 +84,10 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
 -(void)asyncImportSame:(NSString *)operation replyTo:(void (^)(NSInteger))handler __attribute__((swift_async(none)));
 
 -(void)overridableButRunsOnMainThreadWithCompletionHandler:(MAIN_ACTOR_UNSAFE void (^ _Nullable)(NSString *))completion;
+- (void)obtainClosureWithCompletionHandler:(void (^)(void (^_Nullable)(void),
+                                                     NSError *_Nullable,
+                                                     BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
 @end
 
 @protocol RefrigeratorDelegate<NSObject>

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -87,6 +87,8 @@ func testSlowServer(slowServer: SlowServer) async throws {
   let _: String = try await slowServer.findAnswerFailingly()
 
   let _: () -> Void = try await slowServer.obtainClosure()
+
+  let _: Flavor = try await slowServer.iceCreamFlavor()
 }
 
 func testGeneric<T: AnyObject>(x: GenericObject<T>) async throws {

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -85,6 +85,8 @@ func testSlowServer(slowServer: SlowServer) async throws {
   let _: ((Any) -> Void, (Any) -> Void) = await slowServer.performId2VoidId2Void()
 
   let _: String = try await slowServer.findAnswerFailingly()
+
+  let _: () -> Void = try await slowServer.obtainClosure()
 }
 
 func testGeneric<T: AnyObject>(x: GenericObject<T>) async throws {

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704382.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704382.h
@@ -1,0 +1,25 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+typedef NSString *FileProviderItemIdentifier NS_EXTENSIBLE_STRING_ENUM;
+FileProviderItemIdentifier const
+    FileProviderRootContainerItemIdentifier NS_SWIFT_NAME(FileProviderItemIdentifier.rootContainer);
+FileProviderItemIdentifier const
+    FileProviderWorkingSetContainerItemIdentifier NS_SWIFT_NAME(FileProviderItemIdentifier.workingSet);
+FileProviderItemIdentifier const
+    FileProviderTrashContainerItemIdentifier NS_SWIFT_NAME(FileProviderItemIdentifier.trashContainer);
+typedef NSString *FileProviderDomainIdentifier NS_EXTENSIBLE_STRING_ENUM;
+
+@interface PFXObject : NSObject
++ (void)getIdentifierForUserVisibleFileAtURL:(NSURL *)url
+                           completionHandler:
+                               (void (^)(FileProviderItemIdentifier __nullable
+                                             itemIdentifier,
+                                         FileProviderDomainIdentifier __nullable
+                                             domainIdentifier,
+                                         NSError *__nullable error))
+                                   completionHandler;
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704382.m
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar80704382.m
@@ -1,0 +1,23 @@
+#include "rdar80704382.h"
+
+#pragma clang assume_nonnull begin
+
+@implementation PFXObject
+- (instancetype)init {
+  if (self = [super init]) {
+  }
+  return self;
+}
++ (void)getIdentifierForUserVisibleFileAtURL:(NSURL *)url
+                           completionHandler:
+                               (void (^)(FileProviderItemIdentifier __nullable
+                                             itemIdentifier,
+                                         FileProviderDomainIdentifier __nullable
+                                             domainIdentifier,
+                                         NSError *__nullable error))
+                                   completionHandler {
+  completionHandler(@"item_id", @"file_id", NULL);
+}
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807.h
@@ -1,0 +1,29 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+@interface PFXObject : NSObject {
+}
+- (void)continuePassSyncWithCompletionHandler:(void (^)(void (^_Nullable)(void),
+                                                        NSError *_Nullable,
+                                                        BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)continuePassAsyncWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)continueFailSyncWithCompletionHandler:(void (^)(void (^_Nullable)(void),
+                                                        NSError *_Nullable,
+                                                        BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)continueFailAsyncWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)continueIncorrectWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807.m
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807.m
@@ -1,0 +1,54 @@
+#include "rdar81590807.h"
+
+#pragma clang assume_nonnull begin
+
+@implementation PFXObject
+- (void)continuePassSyncWithCompletionHandler:(void (^)(void (^_Nullable)(void),
+                                                        NSError *_Nullable,
+                                                        BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  completionHandler(
+      ^{
+        NSLog(@"passSync");
+      },
+      NULL, YES);
+}
+- (void)continuePassAsyncWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    completionHandler(
+        ^{
+          NSLog(@"passAsync");
+        },
+        NULL, YES);
+  });
+}
+- (void)continueFailSyncWithCompletionHandler:(void (^)(void (^_Nullable)(void),
+                                                        NSError *_Nullable,
+                                                        BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  completionHandler(
+      NULL, [NSError errorWithDomain:@"failSync" code:1 userInfo:nil], NO);
+}
+- (void)continueFailAsyncWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    completionHandler(
+        NULL, [NSError errorWithDomain:@"failAsync" code:2 userInfo:nil], NO);
+  });
+}
+- (void)continueIncorrectWithCompletionHandler:
+    (void (^)(void (^_Nullable)(void), NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    completionHandler(NULL, NULL, NO);
+  });
+}
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807_2.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807_2.h
@@ -1,0 +1,24 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+@interface PFXObject : NSObject {
+}
+- (void)findAnswerSyncSuccessAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerSyncSuccess(completionHandler:)")));
+- (void)findAnswerAsyncSuccessAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerAsyncSuccess(completionHandler:)")));
+- (void)findAnswerSyncFailAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerSyncFail(completionHandler:)")));
+- (void)findAnswerAsyncFailAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerAsyncFail(completionHandler:)")));
+- (void)findAnswerIncorrectAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerIncorrect(completionHandler:)")));
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807_2.m
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar81590807_2.m
@@ -1,0 +1,37 @@
+#include "rdar81590807_2.h"
+
+#pragma clang assume_nonnull begin
+
+@implementation PFXObject
+- (void)findAnswerSyncSuccessAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerSyncSuccess(completionHandler:)"))) {
+  handler(@"syncSuccess", NULL);
+}
+- (void)findAnswerAsyncSuccessAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerAsyncSuccess(completionHandler:)"))) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    handler(@"asyncSuccess", NULL);
+  });
+}
+- (void)findAnswerSyncFailAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerSyncFail(completionHandler:)"))) {
+  handler(NULL, [NSError errorWithDomain:@"syncFail" code:1 userInfo:nil]);
+}
+- (void)findAnswerAsyncFailAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerAsyncFail(completionHandler:)"))) {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    handler(NULL, [NSError errorWithDomain:@"asyncFail" code:2 userInfo:nil]);
+  });
+}
+- (void)findAnswerIncorrectAsynchronously:
+    (void (^)(NSString *_Nullable, NSError *_Nullable))handler
+    __attribute__((swift_name("findAnswerIncorrect(completionHandler:)"))) {
+  handler(NULL, NULL);
+}
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar81617749.h
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar81617749.h
@@ -1,0 +1,123 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+typedef void (^CompletionHandler)(void);
+
+@interface PFXObject : NSObject
+- (void)performSingleFlaggy1WithCompletionHandler:
+    (void (^)(BOOL, CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1)));
+- (void)performSingleFlaggy2WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2)));
+
+- (void)performSingleErrory1WithCompletionHandler:
+    (void (^)(NSError *_Nullable,
+              CompletionHandler _Nullable))completionHandler;
+- (void)performSingleErrory2WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable,
+              NSError *_Nullable))completionHandler;
+
+- (void)performSingleBothy12WithCompletionHandler:
+    (void (^)(NSError *_Nullable, BOOL,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2)));
+- (void)performSingleBothy13WithCompletionHandler:
+    (void (^)(NSError *_Nullable, CompletionHandler _Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)performSingleBothy21WithCompletionHandler:
+    (void (^)(BOOL, NSError *_Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1)));
+- (void)performSingleBothy23WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)performSingleBothy31WithCompletionHandler:
+    (void (^)(BOOL, CompletionHandler _Nullable,
+              NSError *_Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1)));
+- (void)performSingleBothy32WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, BOOL,
+              NSError *_Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2)));
+
+- (void)performDoubleFlaggy1WithCompletionHandler:
+    (void (^)(BOOL, CompletionHandler _Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1)));
+- (void)performDoubleFlaggy2WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, BOOL,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2)));
+- (void)performDoubleFlaggy3WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, CompletionHandler _Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+
+- (void)performDoubleErrory1WithCompletionHandler:
+    (void (^)(NSError *_Nullable, CompletionHandler _Nullable,
+              CompletionHandler _Nullable))completionHandler;
+- (void)performDoubleErrory2WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, NSError *_Nullable,
+              CompletionHandler _Nullable))completionHandler;
+- (void)performDoubleErrory3WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, CompletionHandler _Nullable,
+              NSError *_Nullable))completionHandler;
+
+- (void)performDoubleBothy12WithCompletionHandler:
+    (void (^)(NSError *_Nullable, BOOL, CompletionHandler _Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2)));
+- (void)performDoubleBothy13WithCompletionHandler:
+    (void (^)(NSError *_Nullable, CompletionHandler _Nullable, BOOL,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)performDoubleBothy14WithCompletionHandler:
+    (void (^)(NSError *_Nullable, CompletionHandler _Nullable,
+              CompletionHandler _Nullable, BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 4)));
+
+- (void)performDoubleBothy21WithCompletionHandler:
+    (void (^)(BOOL, NSError *_Nullable, CompletionHandler _Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1)));
+- (void)performDoubleBothy23WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, NSError *_Nullable, BOOL,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+- (void)performDoubleBothy24WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, NSError *_Nullable,
+              CompletionHandler _Nullable, BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 4)));
+
+- (void)performDoubleBothy31WithCompletionHandler:
+    (void (^)(BOOL, CompletionHandler _Nullable, NSError *_Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1)));
+- (void)performDoubleBothy32WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, BOOL, NSError *_Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2)));
+- (void)performDoubleBothy34WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, CompletionHandler _Nullable,
+              NSError *_Nullable, BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 4)));
+
+- (void)performDoubleBothy41WithCompletionHandler:
+    (void (^)(BOOL, CompletionHandler _Nullable, CompletionHandler _Nullable,
+              NSError *_Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1)));
+- (void)performDoubleBothy42WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, BOOL, CompletionHandler _Nullable,
+              NSError *_Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2)));
+- (void)performDoubleBothy43WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, CompletionHandler _Nullable, BOOL,
+              NSError *_Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3)));
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/Inputs/rdar81617749.m
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/rdar81617749.m
@@ -1,0 +1,343 @@
+#include "rdar81617749.h"
+
+#pragma clang assume_nonnull begin
+
+@implementation PFXObject
+- (void)performSingleFlaggy1WithCompletionHandler:
+    (void (^)(BOOL, CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1))) {
+  completionHandler(YES, ^{
+    fprintf(stdout, "%s\n", "performSingleFlaggy1");
+  });
+}
+- (void)performSingleFlaggy2WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performSingleFlaggy2");
+      },
+      YES);
+}
+
+- (void)performSingleErrory1WithCompletionHandler:
+    (void (^)(NSError *_Nullable,
+              CompletionHandler _Nullable))completionHandler {
+  completionHandler(NULL, ^{
+    fprintf(stdout, "%s\n", "performSingleErrory1");
+  });
+}
+- (void)performSingleErrory2WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable,
+              NSError *_Nullable))completionHandler {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performSingleErrory2");
+      },
+      NULL);
+}
+
+- (void)performSingleBothy12WithCompletionHandler:
+    (void (^)(NSError *_Nullable, BOOL,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2))) {
+  completionHandler(NULL, YES, ^{
+    fprintf(stdout, "%s\n", "performSingleBothy12");
+  });
+}
+- (void)performSingleBothy13WithCompletionHandler:
+    (void (^)(NSError *_Nullable, CompletionHandler _Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  completionHandler(
+      NULL,
+      ^{
+        fprintf(stdout, "%s\n", "performSingleBothy13");
+      },
+      YES);
+}
+- (void)performSingleBothy21WithCompletionHandler:
+    (void (^)(BOOL, NSError *_Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1))) {
+  completionHandler(YES, NULL, ^{
+    fprintf(stdout, "%s\n", "performSingleBothy21");
+  });
+}
+- (void)performSingleBothy23WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, NSError *_Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performSingleBothy23");
+      },
+      NULL, YES);
+}
+- (void)performSingleBothy31WithCompletionHandler:
+    (void (^)(BOOL, CompletionHandler _Nullable,
+              NSError *_Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1))) {
+  completionHandler(
+      YES,
+      ^{
+        fprintf(stdout, "%s\n", "performSingleBothy31");
+      },
+      NULL);
+}
+- (void)performSingleBothy32WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, BOOL,
+              NSError *_Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performSingleBothy32");
+      },
+      YES, NULL);
+}
+
+- (void)performDoubleFlaggy1WithCompletionHandler:
+    (void (^)(BOOL, CompletionHandler _Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1))) {
+  completionHandler(
+      YES,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleFlaggy1, part 1");
+      },
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleFlaggy1, part 2");
+      });
+}
+- (void)performDoubleFlaggy2WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, BOOL,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleFlaggy2, part 1");
+      },
+      YES,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleFlaggy2, part 2");
+      });
+}
+- (void)performDoubleFlaggy3WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, CompletionHandler _Nullable,
+              BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleFlaggy3, part 1");
+      },
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleFlaggy3, part 2");
+      },
+      YES);
+}
+
+- (void)performDoubleErrory1WithCompletionHandler:
+    (void (^)(NSError *_Nullable, CompletionHandler _Nullable,
+              CompletionHandler _Nullable))completionHandler {
+  completionHandler(
+      NULL,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleErrory1, part 1");
+      },
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleErrory1, part 2");
+      });
+}
+- (void)performDoubleErrory2WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, NSError *_Nullable,
+              CompletionHandler _Nullable))completionHandler {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleErrory2, part 1");
+      },
+      NULL,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleErrory2, part 2");
+      });
+}
+- (void)performDoubleErrory3WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, CompletionHandler _Nullable,
+              NSError *_Nullable))completionHandler {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleErrory3, part 1");
+      },
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleErrory3, part 2");
+      },
+      NULL);
+}
+
+- (void)performDoubleBothy12WithCompletionHandler:
+    (void (^)(NSError *_Nullable, BOOL, CompletionHandler _Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2))) {
+  completionHandler(
+      NULL, YES,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy12, part 1");
+      },
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy12, part 2");
+      });
+}
+- (void)performDoubleBothy13WithCompletionHandler:
+    (void (^)(NSError *_Nullable, CompletionHandler _Nullable, BOOL,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  completionHandler(
+      NULL,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy13, part 1");
+      },
+      YES,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy13, part 2");
+      });
+}
+- (void)performDoubleBothy14WithCompletionHandler:
+    (void (^)(NSError *_Nullable, CompletionHandler _Nullable,
+              CompletionHandler _Nullable, BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 4))) {
+  completionHandler(
+      NULL,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy14, part 1");
+      },
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy14, part 2");
+      },
+      YES);
+}
+
+- (void)performDoubleBothy21WithCompletionHandler:
+    (void (^)(BOOL, NSError *_Nullable, CompletionHandler _Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1))) {
+  completionHandler(
+      YES, NULL,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy21, part 1");
+      },
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy21, part 2");
+      });
+}
+- (void)performDoubleBothy23WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, NSError *_Nullable, BOOL,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy23, part 1");
+      },
+      NULL, YES,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy23, part 2");
+      });
+}
+- (void)performDoubleBothy24WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, NSError *_Nullable,
+              CompletionHandler _Nullable, BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 4))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy24, part 1");
+      },
+      NULL,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy24, part 2");
+      },
+      YES);
+}
+
+- (void)performDoubleBothy31WithCompletionHandler:
+    (void (^)(BOOL, CompletionHandler _Nullable, NSError *_Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1))) {
+  completionHandler(
+      YES,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy31, part 1");
+      },
+      NULL,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy31, part 2");
+      });
+}
+- (void)performDoubleBothy32WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, BOOL, NSError *_Nullable,
+              CompletionHandler _Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy32, part 1");
+      },
+      YES, NULL,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy32, part 2");
+      });
+}
+- (void)performDoubleBothy34WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, CompletionHandler _Nullable,
+              NSError *_Nullable, BOOL))completionHandler
+    __attribute__((swift_async_error(zero_argument, 4))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy34, part 1");
+      },
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy34, part 2");
+      },
+      NULL, YES);
+}
+
+- (void)performDoubleBothy41WithCompletionHandler:
+    (void (^)(BOOL, CompletionHandler _Nullable, CompletionHandler _Nullable,
+              NSError *_Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 1))) {
+  completionHandler(
+      YES,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy41, part 1");
+      },
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy41, part 2");
+      },
+      NULL);
+}
+- (void)performDoubleBothy42WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, BOOL, CompletionHandler _Nullable,
+              NSError *_Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 2))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy42, part 1");
+      },
+      YES,
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy42, part 2");
+      },
+      NULL);
+}
+- (void)performDoubleBothy43WithCompletionHandler:
+    (void (^)(CompletionHandler _Nullable, CompletionHandler _Nullable, BOOL,
+              NSError *_Nullable))completionHandler
+    __attribute__((swift_async_error(zero_argument, 3))) {
+  completionHandler(
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy43, part 1");
+      },
+      ^{
+        fprintf(stdout, "%s\n", "performDoubleBothy43, part 2");
+      },
+      YES, NULL);
+}
+@end
+
+#pragma clang assume_nonnull end

--- a/validation-test/compiler_crashers_2_fixed/rdar80704382.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar80704382.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar80704382.m -I %S/Inputs -c -o %t/rdar80704382.o
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar80704382.h -Xlinker %t/rdar80704382.o -parse-as-library %s -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+func run() async throws {
+  // CHECK: item_id
+  // CHECK: file_id
+  print(try await PFXObject.identifierForUserVisibleFile(at: URL(fileURLWithPath: "/tmp/file")))
+}
+
+@main struct Main {
+  static func main() async throws {
+    try await run()
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar81590807.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar81590807.swift
@@ -1,0 +1,50 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar81590807.m -I %S/Inputs -c -o %t/rdar81590807.o
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar81590807.h -Xlinker %t/rdar81590807.o -parse-as-library %s -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main > %t/log 2>&1 || true
+// RUN: %FileCheck %s < %t/log
+
+// Unsupported because the crash on continueIncorrect is just an illegal 
+// instruction rather than a nice fatal error.
+// UNSUPPORTED: swift_test_mode_optimize
+// UNSUPPORTED: swift_test_mode_optimize_size
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=ios
+
+func run(on object: PFXObject) async throws {
+  // CHECK: passSync
+  let cl1 = try await object.continuePassSync()
+  cl1()
+  // CHECK: passAsync
+  let cl2 = try await object.continuePassAsync()
+  cl2()
+  do {
+    let cl = try await object.continueFailSync()
+    // CHECK-NOT: oh no failSync
+    fputs("oh no failSync\n", stderr)
+  }
+  catch let error {
+    // CHECK: Error Domain=failSync Code=1 "(null)"
+    fputs("\(error)\n", stderr)
+  }
+  do {
+    let cl = try await object.continueFailAsync()
+    // CHECK-NOT: oh no failAsync
+    fputs("oh no failAsync\n", stderr)
+  }
+  catch let error {
+    // CHECK: Error Domain=failAsync Code=2 "(null)"
+    fputs("\(error)\n", stderr)
+  }
+  // CHECK: Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value
+  print(try await object.continueIncorrect())
+}
+
+@main struct Main {
+  static func main() async throws {
+    let object = PFXObject()
+    try await run(on: object)
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar81590807_2.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar81590807_2.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar81590807_2.m -I %S/Inputs -c -o %t/rdar81590807_2.o
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar81590807_2.h -Xlinker %t/rdar81590807_2.o -parse-as-library %s -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=ios
+
+func run(on object: PFXObject) async throws {
+  // CHECK: syncSuccess
+  print("\(try await object.findAnswerSyncSuccess())\n")
+  // CHECK: asyncSuccess
+  print("\(try await object.findAnswerAsyncSuccess())\n")
+  do {
+    try await object.findAnswerSyncFail()
+    // CHECK-NOT: oh no syncFail
+    print("\("oh no syncFail")\n")
+  }
+  catch let error {
+    // CHECK: Error Domain=syncFail Code=1 "(null)"
+    print("\(error)\n")
+  }
+  do {
+    try await object.findAnswerAsyncFail()
+    // CHECK-NOT: oh no asyncFail
+    print("\("oh no asyncFail")\n")
+  }
+  catch let error {
+    // CHECK: Error Domain=asyncFail Code=2 "(null)"
+    print("\(error)\n")
+  }
+  // CHECK: <<>>
+  print("<<\(try await object.findAnswerIncorrect())>>\n")
+}
+
+@main struct Main {
+  static func main() async throws {
+    let object = PFXObject()
+    try await run(on: object)
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar81617749.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar81617749.swift
@@ -1,0 +1,140 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar81617749.m -I %S/Inputs -c -o %t/rdar81617749.o
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar81617749.h -Xlinker %t/rdar81617749.o -parse-as-library %s -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// Enable with rdar://81617749
+// UNSUPPORTED: CPU=i386 && OS=watchos
+
+func run(on object: PFXObject) async throws {
+  // CHECK: performSingleFlaggy1
+  print(try await object.performSingleFlaggy1()?())
+  // CHECK: performSingleFlaggy2
+  print(try await object.performSingleFlaggy2()?())
+  // CHECK: performSingleErrory1
+  print(try await object.performSingleErrory1()())
+  // CHECK: performSingleErrory2
+  print(try await object.performSingleErrory2()())
+
+  // CHECK: performSingleBothy12
+  print(try await object.performSingleBothy12()())
+  // CHECK: performSingleBothy13
+  print(try await object.performSingleBothy13()())
+
+  // CHECK: performSingleBothy21
+  print(try await object.performSingleBothy21()())
+  
+  // CHECK: performSingleBothy23
+  print(try await object.performSingleBothy23()())
+  // CHECK: performSingleBothy31
+  print(try await object.performSingleBothy31()())
+  // CHECK: performSingleBothy32
+  print(try await object.performSingleBothy32()())
+
+  // CHECK: performDoubleFlaggy1, part 1
+  // CHECK: performDoubleFlaggy1, part 2
+  let rFlaggy1 = try await object.performDoubleFlaggy1()
+  rFlaggy1.0?()
+  rFlaggy1.1?()
+  // CHECK: performDoubleFlaggy2, part 1
+  // CHECK: performDoubleFlaggy2, part 2
+  let rFlaggy2 = try await object.performDoubleFlaggy2()
+  rFlaggy2.0?()
+  rFlaggy2.1?()
+  // CHECK: performDoubleFlaggy3, part 1
+  // CHECK: performDoubleFlaggy3, part 2
+  let rFlaggy3 = try await object.performDoubleFlaggy3()
+  rFlaggy3.0?()
+  rFlaggy3.1?()
+
+  // CHECK: performDoubleErrory1, part 1
+  // CHECK: performDoubleErrory1, part 2
+  let rErrory1 = try await object.performDoubleErrory1()
+  rErrory1.0()
+  rErrory1.1()
+  // CHECK: performDoubleErrory2, part 1
+  // CHECK: performDoubleErrory2, part 2
+  let rErrory2 = try await object.performDoubleErrory2()
+  rErrory2.0()
+  rErrory2.1()
+  // CHECK: performDoubleErrory3, part 1
+  // CHECK: performDoubleErrory3, part 2
+  let rErrory3 = try await object.performDoubleErrory3()
+  rErrory3.0()
+  rErrory3.1()
+
+  // CHECK: performDoubleBothy12, part 1
+  // CHECK: performDoubleBothy12, part 2
+  let rBothy12 = try await object.performDoubleBothy12()
+  rBothy12.0()
+  rBothy12.1()
+  // CHECK: performDoubleBothy13, part 1
+  // CHECK: performDoubleBothy13, part 2
+  let rBothy13 = try await object.performDoubleBothy13()
+  rBothy13.0()
+  rBothy13.1()
+  // CHECK: performDoubleBothy14, part 1
+  // CHECK: performDoubleBothy14, part 2
+  let rBothy14 = try await object.performDoubleBothy14()
+  rBothy14.0()
+  rBothy14.1()
+
+  // CHECK: performDoubleBothy21, part 1
+  // CHECK: performDoubleBothy21, part 2
+  let rBothy21 = try await object.performDoubleBothy21()
+  rBothy21.0()
+  rBothy21.1()
+  // CHECK: performDoubleBothy23, part 1
+  // CHECK: performDoubleBothy23, part 2
+  let rBothy23 = try await object.performDoubleBothy23()
+  rBothy23.0()
+  rBothy23.1()
+  // CHECK: performDoubleBothy24, part 1
+  // CHECK: performDoubleBothy24, part 2
+  let rBothy24 = try await object.performDoubleBothy24()
+  rBothy24.0()
+  rBothy24.1()
+
+  // CHECK: performDoubleBothy31, part 1
+  // CHECK: performDoubleBothy31, part 2
+  let rBothy31 = try await object.performDoubleBothy31()
+  rBothy31.0()
+  rBothy31.1()
+  // CHECK: performDoubleBothy32, part 1
+  // CHECK: performDoubleBothy32, part 2
+  let rBothy32 = try await object.performDoubleBothy32()
+  rBothy32.0()
+  rBothy32.1()
+  // CHECK: performDoubleBothy34, part 1
+  // CHECK: performDoubleBothy34, part 2
+  let rBothy34 = try await object.performDoubleBothy34()
+  rBothy34.0()
+  rBothy34.1()
+
+  // CHECK: performDoubleBothy41, part 1
+  // CHECK: performDoubleBothy41, part 2
+  let rBothy41 = try await object.performDoubleBothy41()
+  rBothy41.0()
+  rBothy41.1()
+  // CHECK: performDoubleBothy42, part 1
+  // CHECK: performDoubleBothy42, part 2
+  let rBothy42 = try await object.performDoubleBothy42()
+  rBothy42.0()
+  rBothy42.1()
+  // CHECK: performDoubleBothy43, part 1
+  // CHECK: performDoubleBothy43, part 2
+  let rBothy43 = try await object.performDoubleBothy43()
+  rBothy43.0()
+  rBothy43.1()
+}
+
+@main struct Main {
+  static func main() async throws {
+    let object = PFXObject()
+    try await run(on: object)
+  }
+}


### PR DESCRIPTION
5.5 Summary: Fix compiler crash during call-as-async of ObjC method whose completion handler looks like `(BOOL, NSError *, Value)`.

---

Explanation: When converting an ObjC method type which is being called as async to a Swift function type, some of the values passed to the ObjC method's completion handler are converted to return values of the Swift function.  The flag and error parameters, however, if present, are ignored.

When abstracting the result type for the Swift method, the formal type of the corresponding parameter in the ObjC method's completion handler is used.  Digging out that parameter entails indexing into the parameters of the completion handler.  Previously, the indexing logic relied on the error appearing before the flag if both appeared before the value of interest.  Here, the indexing is tweaked to check both special indices for each possible index until the first that matches neither is found.

Issue: rdar://81625544

Original PR: https://github.com/apple/swift/pull/38825

Testing: New regression tests, Swift CI

Reviewed by: Joe Groff

Risk: Low.

Scope: Limited to Swift import of ObjC methods as async functions.
