### PR TITLE
Adopt Sendable in the Task APIs

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -598,7 +598,7 @@ protected:
     HasAnyUnavailableValues : 1
   );
 
-  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1,
     /// If the module is compiled as static library.
     StaticLibrary : 1,
 
@@ -633,7 +633,11 @@ protected:
     IsMainModule : 1,
 
     /// Whether this module has incremental dependency information available.
-    HasIncrementalInfo : 1
+    HasIncrementalInfo : 1,
+
+    /// Whether this module has been compiled with comprehensive checking for
+    /// concurrency, e.g., Sendable checking.
+    IsConcurrencyChecked : 1
   );
 
   SWIFT_INLINE_BITFIELD(PrecedenceGroupDecl, Decl, 1+2,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -445,7 +445,7 @@ NOTE(constexpr_witness_call_with_no_conformance, none,
     "%select{for this call|for a witness-method invoked during this call}0",
     (bool))
 
-NOTE(constexpr_unknown_control_flow_due_to_skip,none, "branch depends on "
+REMARK(constexpr_unknown_control_flow_due_to_skip,none, "branch depends on "
      "non-constant value produced by an unevaluated instructions", ())
 NOTE(constexpr_returned_by_unevaluated_instruction,none,
      "result of an unevaluated instruction is not a constant", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1940,7 +1940,7 @@ NOTE(nonsendable_tuple_type,none,
      "a tuple type must be composed of 'Sendable' elements to conform to "
      "'Sendable'", ())
 NOTE(add_nominal_sendable_conformance,none,
-     "add conformance of %0 %1 to the 'Sendable' protocol",
+     "consider making %0 %1 conform to the 'Sendable' protocol",
      (DescriptiveDeclKind, DeclName))
 
 NOTE(required_by_opaque_return,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1939,6 +1939,9 @@ NOTE(nonsendable_function_type,none,
 NOTE(nonsendable_tuple_type,none,
      "a tuple type must be composed of 'Sendable' elements to conform to "
      "'Sendable'", ())
+NOTE(non_sendable_nominal,none,
+     "%0 %1 does not conform to the `Sendable` protocol",
+      (DescriptiveDeclKind, DeclName))
 NOTE(add_nominal_sendable_conformance,none,
      "consider making %0 %1 conform to the 'Sendable' protocol",
      (DescriptiveDeclKind, DeclName))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1939,6 +1939,9 @@ NOTE(nonsendable_function_type,none,
 NOTE(nonsendable_tuple_type,none,
      "a tuple type must be composed of 'Sendable' elements to conform to "
      "'Sendable'", ())
+NOTE(add_nominal_sendable_conformance,none,
+     "add conformance of %0 %1 to the 'Sendable' protocol",
+     (DescriptiveDeclKind, DeclName))
 
 NOTE(required_by_opaque_return,none,
     "required by opaque return type of %0 %1", (DescriptiveDeclKind, DeclName))
@@ -4492,20 +4495,20 @@ NOTE(protocol_isolated_to_global_actor_here,none,
 ERROR(isolated_parameter_not_actor,none,
       "'isolated' parameter has non-actor type %0", (Type))
       
-WARNING(non_concurrent_param_type,none,
+WARNING(non_sendable_param_type,none,
         "cannot pass argument of non-sendable type %0 across actors",
         (Type))
-WARNING(non_concurrent_result_type,none,
+WARNING(non_sendable_result_type,none,
         "cannot call function returning non-sendable type %0 across "
         "actors", (Type))
-WARNING(non_concurrent_property_type,none,
-        "cannot use %0 %1 with a non-sendable type %2 "
+WARNING(non_sendable_property_type,none,
+        "cannot use %1 %2 with a non-sendable type %0 "
         "%select{across actors|from concurrently-executed code}3",
-        (DescriptiveDeclKind, DeclName, Type, bool))
-WARNING(non_concurrent_keypath_capture,none,
+        (Type, DescriptiveDeclKind, DeclName, bool))
+WARNING(non_sendable_keypath_capture,none,
         "cannot form key path that captures non-sendable type %0",
         (Type))
-WARNING(non_concurrent_keypath_access,none,
+WARNING(non_sendable_keypath_access,none,
         "cannot form key path that accesses non-sendable type %0",
         (Type))
 ERROR(non_concurrent_type_member,none,
@@ -4528,9 +4531,6 @@ ERROR(concurrent_value_inherit,none,
       (bool, DeclName))
 ERROR(non_sendable_type,none,
       "type %0 does not conform to the 'Sendable' protocol", (Type))
-ERROR(non_sendable_function_type,none,
-     "function type %0 must be marked '@Sendable' to conform to 'Sendable'",
-      (Type))
 
 WARNING(unchecked_conformance_not_special,none,
       "@unchecked conformance to %0 has no meaning", (Type))

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -513,6 +513,16 @@ public:
     return Bits.ModuleDecl.IsMainModule;
   }
 
+  /// Whether this module has been compiled with comprehensive checking for
+  /// concurrency, e.g., Sendable checking.
+  bool isConcurrencyChecked() const {
+    return Bits.ModuleDecl.IsConcurrencyChecked;
+  }
+
+  void setIsConcurrencyChecked(bool value = true) {
+    Bits.ModuleDecl.IsConcurrencyChecked = value;
+  }
+
   /// For the main module, retrieves the list of primary source files being
   /// compiled, that is, the files we're generating code for.
   ArrayRef<SourceFile *> getPrimarySourceFiles() const;

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -19,6 +19,8 @@
 #include "swift/Basic/Debug.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/PointerUnion.h"
+#include "llvm/ADT/STLExtras.h"
+#include "swift/AST/ProtocolConformanceRef.h"
 #include "swift/AST/Requirement.h"
 #include "swift/AST/TypeAlignments.h"
 #include "swift/AST/Type.h"
@@ -29,6 +31,7 @@ namespace llvm {
 
 namespace swift {
 
+class BuiltinProtocolConformance;
 class ConcreteDeclRef;
 class ProtocolConformance;
 enum class EffectKind : uint8_t;
@@ -72,6 +75,11 @@ public:
     return ProtocolConformanceRef();
   }
 
+  /// Retrieve an invalid or missing conformance, as appropriate, when a
+  /// legitimate conformance doesn't exist.
+  static ProtocolConformanceRef forMissingOrInvalid(
+      Type type, ProtocolDecl *proto);
+
   bool isInvalid() const {
     return !Union;
   }
@@ -102,6 +110,19 @@ public:
   /// involves a "missing" conformance anywhere. Such conformances
   /// cannot be depended on to always exist.
   bool hasMissingConformance(ModuleDecl *module) const;
+
+  /// Enumerate the missing conformances in this conformance.
+  ///
+  /// Calls \c fn with each missing conformance found within this conformance,
+  /// including this conformance or any conditional conformances it depends on.
+  /// If the invocation of \c fn returns \c true, the traversal exits early
+  /// and the overall function returns \c true.
+  ///
+  /// \returns \c true if any invocation of \c fn returned true,
+  /// \c false otherwise.
+  bool forEachMissingConformance(
+      ModuleDecl *module,
+      llvm::function_ref<bool(BuiltinProtocolConformance *missing)> fn) const;
 
   using OpaqueValue = void*;
   OpaqueValue getOpaqueValue() const { return Union.getOpaqueValue(); }

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -659,7 +659,7 @@ def warn_swift3_objc_inference : Flag<["-"], "warn-swift3-objc-inference">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, HelpHidden]>;
 
 def warn_concurrency : Flag<["-"], "warn-concurrency">,
-  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ModuleInterfaceOptionIgnorable]>,
   HelpText<"Warn about code that is unsafe according to the Swift Concurrency "
            "model and will become ill-formed in a future language version">;
 

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -103,6 +103,7 @@ class ExtendedValidationInfo {
     unsigned ResilienceStrategy : 2;
     unsigned IsImplicitDynamicEnabled : 1;
     unsigned IsAllowModuleWithCompilerErrorsEnabled : 1;
+    unsigned IsConcurrencyChecked : 1;
   } Bits;
 public:
   ExtendedValidationInfo() : Bits() {}
@@ -155,6 +156,13 @@ public:
 
   StringRef getModuleABIName() const { return ModuleABIName; }
   void setModuleABIName(StringRef name) { ModuleABIName = name; }
+
+  bool isConcurrencyChecked() const {
+    return Bits.IsConcurrencyChecked;
+  }
+  void setIsConcurrencyChecked(bool val = true) {
+    Bits.IsConcurrencyChecked = val;
+  }
 };
 
 /// Returns info about the serialized AST in the given data.

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -458,7 +458,7 @@ GenericSignatureImpl::lookupConformance(CanType type,
   if (type->isTypeParameter())
     return ProtocolConformanceRef(proto);
 
-  return M->lookupConformance(type, proto);
+  return M->lookupConformance(type, proto, /*allowMissing=*/true);
 }
 
 bool GenericSignatureImpl::requiresClass(Type type) const {

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -365,8 +365,10 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
 
   // If the type doesn't conform to this protocol, the result isn't formed
   // from these requirements.
-  if (!genericSig->requiresProtocol(type, proto))
-    return ProtocolConformanceRef::forInvalid();
+  if (!genericSig->requiresProtocol(type, proto)) {
+    Type substType = type.subst(*this);
+    return ProtocolConformanceRef::forMissingOrInvalid(substType, proto);
+  }
 
   auto accessPath =
     genericSig->getConformanceAccessPath(type, proto);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -975,6 +975,9 @@ ModuleDecl *CompilerInstance::getMainModule() const {
     }
     if (Invocation.getFrontendOptions().EnableLibraryEvolution)
       MainModule->setResilienceStrategy(ResilienceStrategy::Resilient);
+    if (Invocation.getLangOptions().WarnConcurrency ||
+        Invocation.getLangOptions().isSwiftVersionAtLeast(6))
+      MainModule->setIsConcurrencyChecked(true);
 
     // Register the main module with the AST context.
     Context->addLoadedModule(MainModule);

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -236,8 +236,21 @@ static EnumDecl *addImplicitCodingKeys(NominalTypeDecl *target) {
   return addImplicitCodingKeys(target, caseIdentifiers, C.Id_CodingKeys);
 }
 
+namespace {
+  /// Container for a set of functions that produces notes used when a
+  /// synthesized conformance fails.
+  struct DelayedNotes : public std::vector<std::function<void()>> {
+    ~DelayedNotes() {
+      for (const auto &fn : *this) {
+        fn();
+      }
+    }
+  };
+}
+
 static EnumDecl *validateCodingKeysType(const DerivedConformance &derived,
-                                        TypeDecl *_codingKeysTypeDecl) {
+                                        TypeDecl *_codingKeysTypeDecl,
+                                        DelayedNotes &delayedNotes) {
   auto &C = derived.Context;
   // CodingKeys may be a typealias. If so, follow the alias to its canonical
   // type. We are creating a copy here, so we can hold on to the original
@@ -258,17 +271,22 @@ static EnumDecl *validateCodingKeysType(const DerivedConformance &derived,
     SourceLoc loc = codingKeysTypeDecl ? codingKeysTypeDecl->getLoc()
                                        : cast<TypeDecl>(_codingKeysTypeDecl)->getLoc();
 
-    C.Diags.diagnose(loc, diag::codable_codingkeys_type_does_not_conform_here,
-                     derived.getProtocolType());
+    delayedNotes.push_back([=] {
+      ASTContext &C = derived.getProtocolType()->getASTContext();
+      C.Diags.diagnose(loc, diag::codable_codingkeys_type_does_not_conform_here,
+                       derived.getProtocolType());
+    });
     return nullptr;
   }
 
   auto *codingKeysDecl =
       dyn_cast_or_null<EnumDecl>(codingKeysType->getAnyNominal());
   if (!codingKeysDecl) {
-    codingKeysTypeDecl->diagnose(
-        diag::codable_codingkeys_type_is_not_an_enum_here,
-        derived.getProtocolType());
+    delayedNotes.push_back([=] {
+      codingKeysTypeDecl->diagnose(
+          diag::codable_codingkeys_type_is_not_an_enum_here,
+          derived.getProtocolType());
+    });
     return nullptr;
   }
 
@@ -282,8 +300,10 @@ static EnumDecl *validateCodingKeysType(const DerivedConformance &derived,
 /// \param codingKeysTypeDecl The \c CodingKeys enum decl to validate.
 static bool validateCodingKeysEnum(const DerivedConformance &derived,
                                llvm::SmallMapVector<Identifier, VarDecl *, 8> varDecls,
-                               TypeDecl *codingKeysTypeDecl) {
-  auto *codingKeysDecl = validateCodingKeysType(derived, codingKeysTypeDecl);
+                               TypeDecl *codingKeysTypeDecl,
+                               DelayedNotes &delayedNotes) {
+  auto *codingKeysDecl = validateCodingKeysType(
+      derived, codingKeysTypeDecl, delayedNotes);
   if (!codingKeysDecl)
     return false;
 
@@ -297,8 +317,10 @@ static bool validateCodingKeysEnum(const DerivedConformance &derived,
   for (auto elt : codingKeysDecl->getAllElements()) {
     auto it = varDecls.find(elt->getBaseIdentifier());
     if (it == varDecls.end()) {
-      elt->diagnose(diag::codable_extraneous_codingkey_case_here,
-                    elt->getBaseIdentifier());
+      delayedNotes.push_back([=] {
+        elt->diagnose(diag::codable_extraneous_codingkey_case_here,
+                      elt->getBaseIdentifier());
+      });
       // TODO: Investigate typo-correction here; perhaps the case name was
       //       misspelled and we can provide a fix-it.
       varDeclsAreValid = false;
@@ -315,8 +337,13 @@ static bool validateCodingKeysEnum(const DerivedConformance &derived,
           it->second->getTypeReprOrParentPatternTypeRepr(),
           it->second->getType(),
       };
-      it->second->diagnose(diag::codable_non_conforming_property_here,
-                           derived.getProtocolType(), typeLoc);
+
+      auto var = it->second;
+      auto proto = derived.getProtocolType();
+      delayedNotes.push_back([=] {
+        var->diagnose(diag::codable_non_conforming_property_here,
+                      proto, typeLoc);
+      });
       varDeclsAreValid = false;
     } else {
       // The property was valid. Remove it from the list.
@@ -350,8 +377,10 @@ static bool validateCodingKeysEnum(const DerivedConformance &derived,
       // The var was not default initializable, and did not have an explicit
       // initial value.
       varDeclsAreValid = false;
-      entry.second->diagnose(diag::codable_non_decoded_property_here,
-                             derived.getProtocolType(), entry.first);
+      delayedNotes.push_back([=] {
+        entry.second->diagnose(diag::codable_non_decoded_property_here,
+                               derived.getProtocolType(), entry.first);
+      });
     }
   }
 
@@ -359,7 +388,8 @@ static bool validateCodingKeysEnum(const DerivedConformance &derived,
 }
 
 static bool validateCodingKeysEnum_enum(const DerivedConformance &derived,
-                                        TypeDecl *codingKeysTypeDecl) {
+                                        TypeDecl *codingKeysTypeDecl,
+                                        DelayedNotes &delayedNotes) {
   auto *enumDecl = dyn_cast<EnumDecl>(derived.Nominal);
   if (!enumDecl) {
     return false;
@@ -369,16 +399,18 @@ static bool validateCodingKeysEnum_enum(const DerivedConformance &derived,
     caseNames.insert(elt->getBaseIdentifier());
   }
 
-  auto *codingKeysDecl = validateCodingKeysType(derived,
-                                                codingKeysTypeDecl);
+  auto *codingKeysDecl = validateCodingKeysType(
+      derived, codingKeysTypeDecl, delayedNotes);
   if (!codingKeysDecl)
     return false;
 
   bool casesAreValid = true;
   for (auto *elt : codingKeysDecl->getAllElements()) {
     if (!caseNames.contains(elt->getBaseIdentifier())) {
-      elt->diagnose(diag::codable_extraneous_codingkey_case_here,
-                    elt->getBaseIdentifier());
+      delayedNotes.push_back([=] {
+        elt->diagnose(diag::codable_extraneous_codingkey_case_here,
+                      elt->getBaseIdentifier());
+      });
       casesAreValid = false;
     }
   }
@@ -388,7 +420,8 @@ static bool validateCodingKeysEnum_enum(const DerivedConformance &derived,
 
 /// Looks up and validates a CodingKeys enum for the given DerivedConformance.
 /// If a CodingKeys enum does not exist, one will be derived.
-static bool validateCodingKeysEnum(const DerivedConformance &derived) {
+static bool validateCodingKeysEnum(const DerivedConformance &derived,
+                                   DelayedNotes &delayedNotes) {
   auto &C = derived.Context;
 
   auto codingKeysDecls =
@@ -403,13 +436,16 @@ static bool validateCodingKeysEnum(const DerivedConformance &derived) {
                           : codingKeysDecls.front();
   auto *codingKeysTypeDecl = dyn_cast<TypeDecl>(result);
   if (!codingKeysTypeDecl) {
-    result->diagnose(diag::codable_codingkeys_type_is_not_an_enum_here,
-                     derived.getProtocolType());
+    delayedNotes.push_back([=] {
+      result->diagnose(diag::codable_codingkeys_type_is_not_an_enum_here,
+                       derived.getProtocolType());
+    });
     return false;
   }
 
   if (dyn_cast<EnumDecl>(derived.Nominal)) {
-    return validateCodingKeysEnum_enum(derived, codingKeysTypeDecl);
+    return validateCodingKeysEnum_enum(
+        derived, codingKeysTypeDecl, delayedNotes);
   } else {
 
     // Look through all var decls in the given type.
@@ -426,7 +462,8 @@ static bool validateCodingKeysEnum(const DerivedConformance &derived) {
       properties[getVarNameForCoding(varDecl)] = varDecl;
     }
 
-    return validateCodingKeysEnum(derived, properties, codingKeysTypeDecl);
+    return validateCodingKeysEnum(
+        derived, properties, codingKeysTypeDecl, delayedNotes);
   }
 }
 
@@ -435,7 +472,8 @@ static bool validateCodingKeysEnum(const DerivedConformance &derived) {
 ///
 /// \param elementDecl The \c EnumElementDecl to validate against.
 static bool validateCaseCodingKeysEnum(const DerivedConformance &derived,
-                                       EnumElementDecl *elementDecl) {
+                                       EnumElementDecl *elementDecl,
+                                       DelayedNotes &delayedNotes) {
   auto &C = derived.Context;
   auto *enumDecl = dyn_cast<EnumDecl>(derived.Nominal);
   if (!enumDecl) {
@@ -471,8 +509,10 @@ static bool validateCaseCodingKeysEnum(const DerivedConformance &derived,
 
   auto *codingKeysTypeDecl = dyn_cast<TypeDecl>(result);
   if (!codingKeysTypeDecl) {
-    result->diagnose(diag::codable_codingkeys_type_is_not_an_enum_here,
-                     derived.getProtocolType());
+    delayedNotes.push_back([=] {
+      result->diagnose(diag::codable_codingkeys_type_is_not_an_enum_here,
+                       derived.getProtocolType());
+    });
     return false;
   }
 
@@ -490,7 +530,8 @@ static bool validateCaseCodingKeysEnum(const DerivedConformance &derived,
     }
   }
 
-  return validateCodingKeysEnum(derived, properties, codingKeysTypeDecl);
+  return validateCodingKeysEnum(
+      derived, properties, codingKeysTypeDecl, delayedNotes);
 }
 
 /// Creates a new var decl representing
@@ -1815,7 +1856,8 @@ static ValueDecl *deriveDecodable_init(DerivedConformance &derived) {
 /// not, attempts to synthesize one for it.
 ///
 /// \param requirement The requirement we want to synthesize.
-static bool canSynthesize(DerivedConformance &derived, ValueDecl *requirement) {
+static bool canSynthesize(DerivedConformance &derived, ValueDecl *requirement,
+                          DelayedNotes &delayedNotes) {
   // Before we attempt to look up (or more importantly, synthesize) a CodingKeys
   // entity on target, we need to make sure the type is otherwise valid.
   //
@@ -1851,8 +1893,11 @@ static bool canSynthesize(DerivedConformance &derived, ValueDecl *requirement) {
 
       if (result.empty()) {
         // No super initializer for us to call.
-        superclassDecl->diagnose(diag::decodable_no_super_init_here,
-                                 requirement->getName(), memberName);
+        delayedNotes.push_back([=] {
+          superclassDecl->diagnose(diag::decodable_no_super_init_here,
+                                   requirement->getName(), memberName);
+        });
+
         return false;
       } else if (result.size() > 1) {
         // There are multiple results for this lookup. We'll end up producing a
@@ -1865,28 +1910,35 @@ static bool canSynthesize(DerivedConformance &derived, ValueDecl *requirement) {
         auto conformanceDC = derived.getConformanceContext();
         if (!initializer->isDesignatedInit()) {
           // We must call a superclass's designated initializer.
-          initializer->diagnose(diag::decodable_super_init_not_designated_here,
-                                requirement->getName(), memberName);
+          delayedNotes.push_back([=] {
+            initializer->diagnose(
+                diag::decodable_super_init_not_designated_here,
+                requirement->getName(), memberName);
+          });
           return false;
         } else if (!initializer->isAccessibleFrom(conformanceDC)) {
           // Cannot call an inaccessible method.
-          auto accessScope = initializer->getFormalAccessScope(conformanceDC);
-          initializer->diagnose(diag::decodable_inaccessible_super_init_here,
-                                requirement->getName(), memberName,
-                                accessScope.accessLevelForDiagnostics());
+          delayedNotes.push_back([=] {
+            auto accessScope = initializer->getFormalAccessScope(conformanceDC);
+            initializer->diagnose(diag::decodable_inaccessible_super_init_here,
+                                  requirement->getName(), memberName,
+                                  accessScope.accessLevelForDiagnostics());
+          });
           return false;
         } else if (initializer->isFailable()) {
           // We can't call super.init() if it's failable, since init(from:)
           // isn't failable.
-          initializer->diagnose(diag::decodable_super_init_is_failable_here,
-                                requirement->getName(), memberName);
+          delayedNotes.push_back([=] {
+            initializer->diagnose(diag::decodable_super_init_is_failable_here,
+                                  requirement->getName(), memberName);
+          });
           return false;
         }
       }
     }
   }
 
-  if (!validateCodingKeysEnum(derived)) {
+  if (!validateCodingKeysEnum(derived, delayedNotes)) {
     return false;
   }
 
@@ -1896,10 +1948,12 @@ static bool canSynthesize(DerivedConformance &derived, ValueDecl *requirement) {
     for (auto *elementDecl : enumDecl->getAllElements()) {
       bool duplicate = false;
       if (!caseNames.insert(elementDecl->getBaseIdentifier())) {
-        elementDecl->diagnose(diag::codable_enum_duplicate_case_name_here,
-                             derived.getProtocolType(),
-                             derived.Nominal->getDeclaredType(),
-                             elementDecl->getBaseIdentifier());
+        delayedNotes.push_back([=] {
+          elementDecl->diagnose(diag::codable_enum_duplicate_case_name_here,
+                               derived.getProtocolType(),
+                               derived.Nominal->getDeclaredType(),
+                               elementDecl->getBaseIdentifier());
+        });
         allValid = false;
         duplicate = true;
       }
@@ -1925,17 +1979,20 @@ static bool canSynthesize(DerivedConformance &derived, ValueDecl *requirement) {
               userDefinedParam = inserted.first->second;
             }
 
-            userDefinedParam->diagnose(diag::codable_enum_duplicate_parameter_name_here,
-                                  derived.getProtocolType(),
-                                  derived.Nominal->getDeclaredType(),
-                                  paramIdentifier,
-                                  elementDecl->getBaseIdentifier());
+            delayedNotes.push_back([=] {
+              userDefinedParam->diagnose(diag::codable_enum_duplicate_parameter_name_here,
+                                    derived.getProtocolType(),
+                                    derived.Nominal->getDeclaredType(),
+                                    paramIdentifier,
+                                    elementDecl->getBaseIdentifier());
+            });
             allValid = false;
           }
         }
       }
 
-      if (!duplicate && !validateCaseCodingKeysEnum(derived, elementDecl)) {
+      if (!duplicate &&
+          !validateCaseCodingKeysEnum(derived, elementDecl, delayedNotes)) {
         allValid = false;
       }
     }
@@ -1989,7 +2046,8 @@ ValueDecl *DerivedConformance::deriveEncodable(ValueDecl *requirement) {
 
   // Check other preconditions for synthesized conformance.
   // This synthesizes a CodingKeys enum if possible.
-  if (!canSynthesize(*this, requirement)) {
+  DelayedNotes delayedNotes;
+  if (!canSynthesize(*this, requirement, delayedNotes)) {
     ConformanceDecl->diagnose(diag::type_does_not_conform,
                               Nominal->getDeclaredType(), getProtocolType());
     requirement->diagnose(diag::no_witnesses, diag::RequirementKind::Func,
@@ -1998,6 +2056,7 @@ ValueDecl *DerivedConformance::deriveEncodable(ValueDecl *requirement) {
 
     return nullptr;
   }
+  assert(delayedNotes.empty());
 
   return deriveEncodable_encode(*this);
 }
@@ -2019,7 +2078,8 @@ ValueDecl *DerivedConformance::deriveDecodable(ValueDecl *requirement) {
 
   // Check other preconditions for synthesized conformance.
   // This synthesizes a CodingKeys enum if possible.
-  if (!canSynthesize(*this, requirement)) {
+  DelayedNotes delayedNotes;
+  if (!canSynthesize(*this, requirement, delayedNotes)) {
     ConformanceDecl->diagnose(diag::type_does_not_conform,
                               Nominal->getDeclaredType(), getProtocolType());
     requirement->diagnose(diag::no_witnesses, diag::RequirementKind::Constructor,
@@ -2028,6 +2088,7 @@ ValueDecl *DerivedConformance::deriveDecodable(ValueDecl *requirement) {
 
     return nullptr;
   }
+  assert(delayedNotes.empty());
 
   return deriveDecodable_init(*this);
 }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3461,9 +3461,9 @@ void swift::diagnoseTypeAvailability(const TypeRepr *TR, Type T, SourceLoc loc,
 }
 
 static void diagnoseMissingConformance(
-    SourceLoc loc, Type type, ProtocolDecl *proto) {
+    SourceLoc loc, Type type, ProtocolDecl *proto, ModuleDecl *module) {
   assert(proto->isSpecificProtocol(KnownProtocolKind::Sendable));
-  diagnoseMissingSendableConformance(loc, type);
+  diagnoseMissingSendableConformance(loc, type, module);
 }
 
 bool
@@ -3484,7 +3484,8 @@ swift::diagnoseConformanceAvailability(SourceLoc loc,
   if (auto builtinConformance = dyn_cast<BuiltinProtocolConformance>(rootConf)){
     if (builtinConformance->isMissing()) {
       diagnoseMissingConformance(loc, builtinConformance->getType(),
-                                 builtinConformance->getProtocol());
+                                 builtinConformance->getProtocol(),
+                                 where.getDeclContext()->getParentModule());
     }
   }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -557,70 +557,127 @@ bool swift::isSendableType(ModuleDecl *module, Type type) {
     return false;
 
   // Look for missing Sendable conformances.
-  return !conformance.hasMissingConformance(module);
+  return !conformance.forEachMissingConformance(module,
+      [](BuiltinProtocolConformance *missing) {
+        return missing->getProtocol()->isSpecificProtocol(
+            KnownProtocolKind::Sendable);
+      });
 }
 
-static bool diagnoseNonConcurrentParameter(
-    SourceLoc loc, ConcurrentReferenceKind refKind, ConcreteDeclRef declRef,
-    ParamDecl *param, Type paramType, DiagnosticBehavior behavior) {
-  ASTContext &ctx = declRef.getDecl()->getASTContext();
-  ctx.Diags.diagnose(loc, diag::non_concurrent_param_type, paramType)
-      .limitBehavior(behavior);
-  return false;
+/// Produce a diagnostic for a single instance of a non-Sendable type where
+/// a Sendable type is required.
+static bool diagnoseSingleNonSendableType(
+    Type type, ModuleDecl *module, SourceLoc loc,
+    llvm::function_ref<bool(Type, DiagnosticBehavior)> diagnose) {
+
+  auto behavior = DiagnosticBehavior::Unspecified;
+
+  ASTContext &ctx = module->getASTContext();
+  auto nominal = type->getAnyNominal();
+  const LangOptions &langOpts = ctx.LangOpts;
+  if (nominal) {
+    // A nominal type that has not provided conformance to Sendable will be
+    // diagnosed based on whether its defining module was consistently
+    // checked for concurrency.
+    auto nominalModule = nominal->getParentModule();
+
+    if (langOpts.isSwiftVersionAtLeast(6)) {
+      // In Swift 6, error when the nominal type comes from a module that
+      // had the concurrency checks consistently applied. Otherwise,
+      // warn only when requested (via -warn-concurrency) and leave a safety
+      // hole otherwise.
+      if (nominalModule->isConcurrencyChecked())
+        behavior = DiagnosticBehavior::Unspecified;
+      else if (langOpts.WarnConcurrency)
+        behavior = DiagnosticBehavior::Warning;
+      else
+        behavior = DiagnosticBehavior::Ignore;
+    } else {
+      // In Swift 5, warn if either the imported or importing model is
+      // checking for concurrency. Otherwise, leave a safety hole.
+      if (nominalModule->isConcurrencyChecked() || langOpts.WarnConcurrency)
+        behavior = DiagnosticBehavior::Warning;
+      else
+        behavior = DiagnosticBehavior::Ignore;
+    }
+  } else if (!langOpts.isSwiftVersionAtLeast(6)) {
+    // In Swift 5, warn if the current module requested warnings. Otherwise,
+    // leave a safety hole.
+    if (langOpts.WarnConcurrency)
+      behavior = DiagnosticBehavior::Warning;
+    else
+      behavior = DiagnosticBehavior::Ignore;
+  }
+
+  bool wasError = diagnose(type, behavior);
+
+  if (type->is<FunctionType>()) {
+    ctx.Diags.diagnose(loc, diag::nonsendable_function_type);
+  } else if (nominal && nominal->getParentModule() == module &&
+             (isa<StructDecl>(nominal) || isa<EnumDecl>(nominal))) {
+    auto note = nominal->diagnose(
+        diag::add_nominal_sendable_conformance,
+        nominal->getDescriptiveKind(), nominal->getName());
+    if (nominal->getInherited().empty()) {
+      SourceLoc fixItLoc = nominal->getBraces().Start;
+      note.fixItInsert(fixItLoc, ": Sendable ");
+    } else {
+      SourceLoc fixItLoc = nominal->getInherited().back().getSourceRange().End;
+      fixItLoc = Lexer::getLocForEndOfToken(ctx.SourceMgr, fixItLoc);
+      note.fixItInsert(fixItLoc, ", Sendable");
+    }
+  }
+
+  return wasError;
 }
 
-static bool diagnoseNonConcurrentResult(
-    SourceLoc loc, ConcurrentReferenceKind refKind, ConcreteDeclRef declRef,
-    Type resultType, DiagnosticBehavior behavior) {
-  ASTContext &ctx = declRef.getDecl()->getASTContext();
-  ctx.Diags.diagnose(loc, diag::non_concurrent_result_type, resultType)
-      .limitBehavior(behavior);
-  return false;
-}
-
-static bool diagnoseNonConcurrentProperty(
-    SourceLoc loc, ConcurrentReferenceKind refKind, VarDecl *var,
-    Type propertyType, DiagnosticBehavior behavior) {
-  ASTContext &ctx = var->getASTContext();
-  ctx.Diags.diagnose(loc, diag::non_concurrent_property_type,
-                     var->getDescriptiveKind(), var->getName(),
-                     propertyType, var->isLocalCapture())
-      .limitBehavior(behavior);
-  return false;
-}
-
-/// Whether we should diagnose cases where Sendable conformances are
-/// missing.
-static bool shouldDiagnoseNonSendableViolations(
-    const LangOptions &langOpts) {
-  return langOpts.WarnConcurrency;
-}
-
-bool swift::diagnoseNonConcurrentTypesInReference(
-    ConcreteDeclRef declRef, ModuleDecl *module, SourceLoc loc,
-    ConcurrentReferenceKind refKind, DiagnosticBehavior behavior) {
-  // Bail out immediately if we aren't supposed to do this checking.
-  if (!shouldDiagnoseNonSendableViolations(module->getASTContext().LangOpts))
+bool swift::diagnoseNonSendableTypes(
+    Type type, ModuleDecl *module, SourceLoc loc,
+    llvm::function_ref<bool(Type, DiagnosticBehavior)> diagnose) {
+  // If the Sendable protocol is missing, do nothing.
+  auto proto = module->getASTContext().getProtocol(KnownProtocolKind::Sendable);
+  if (!proto)
     return false;
 
+  auto conformance = TypeChecker::conformsToProtocol(type, proto, module);
+  if (conformance.isInvalid()) {
+    return diagnoseSingleNonSendableType(type, module, loc, diagnose);
+  }
+
+  // Walk the conformance, diagnosing any missing Sendable conformances.
+  bool anyMissing = false;
+  conformance.forEachMissingConformance(module,
+      [&](BuiltinProtocolConformance *missing) {
+        if (diagnoseSingleNonSendableType(
+                missing->getType(), module, loc, diagnose)) {
+          anyMissing = true;
+        }
+
+        return false;
+      });
+
+  return anyMissing;
+}
+
+bool swift::diagnoseNonSendableTypesInReference(
+    ConcreteDeclRef declRef, ModuleDecl *module, SourceLoc loc,
+    ConcurrentReferenceKind refKind) {
   // For functions, check the parameter and result types.
   SubstitutionMap subs = declRef.getSubstitutions();
   if (auto function = dyn_cast<AbstractFunctionDecl>(declRef.getDecl())) {
     for (auto param : *function->getParameters()) {
       Type paramType = param->getInterfaceType().subst(subs);
-      if (!isSendableType(module, paramType)) {
-        return diagnoseNonConcurrentParameter(
-            loc, refKind, declRef, param, paramType, behavior);
-      }
+      if (diagnoseNonSendableTypes(
+              paramType, module, loc, diag::non_sendable_param_type))
+        return true;
     }
 
     // Check the result type of a function.
     if (auto func = dyn_cast<FuncDecl>(function)) {
       Type resultType = func->getResultInterfaceType().subst(subs);
-      if (!isSendableType(module, resultType)) {
-        return diagnoseNonConcurrentResult(loc, refKind, declRef, resultType,
-                                           behavior);
-      }
+      if (diagnoseNonSendableTypes(
+              resultType, module, loc, diag::non_sendable_result_type))
+        return true;
     }
 
     return false;
@@ -630,27 +687,27 @@ bool swift::diagnoseNonConcurrentTypesInReference(
     Type propertyType = var->isLocalCapture()
         ? var->getType()
         : var->getValueInterfaceType().subst(subs);
-    if (!isSendableType(module, propertyType)) {
-      return diagnoseNonConcurrentProperty(loc, refKind, var, propertyType,
-                                           behavior);
-    }
+    if (diagnoseNonSendableTypes(
+            propertyType, module, loc,
+            diag::non_sendable_property_type,
+            var->getDescriptiveKind(), var->getName(),
+            var->isLocalCapture()))
+      return true;
   }
 
   if (auto subscript = dyn_cast<SubscriptDecl>(declRef.getDecl())) {
     for (auto param : *subscript->getIndices()) {
       Type paramType = param->getInterfaceType().subst(subs);
-      if (!isSendableType(module, paramType)) {
-        return diagnoseNonConcurrentParameter(
-            loc, refKind, declRef, param, paramType, behavior);
-      }
+      if (diagnoseNonSendableTypes(
+              paramType, module, loc, diag::non_sendable_param_type))
+        return true;
     }
 
     // Check the element type of a subscript.
     Type resultType = subscript->getElementInterfaceType().subst(subs);
-    if (!isSendableType(module, resultType)) {
-      return diagnoseNonConcurrentResult(loc, refKind, declRef, resultType,
-                                         behavior);
-    }
+    if (diagnoseNonSendableTypes(
+            resultType, module, loc, diag::non_sendable_result_type))
+      return true;
 
     return false;
   }
@@ -658,15 +715,10 @@ bool swift::diagnoseNonConcurrentTypesInReference(
   return false;
 }
 
-void swift::diagnoseMissingSendableConformance(SourceLoc loc, Type type) {
-  ASTContext &ctx = type->getASTContext();
-  if (type->is<FunctionType>()) {
-    ctx.Diags.diagnose(loc, diag::non_sendable_function_type, type)
-      .warnUntilSwiftVersion(6);
-  } else {
-    ctx.Diags.diagnose(loc, diag::non_sendable_type, type)
-      .warnUntilSwiftVersion(6);
-  }
+void swift::diagnoseMissingSendableConformance(
+    SourceLoc loc, Type type, ModuleDecl *module) {
+  diagnoseNonSendableTypes(
+      type, module, loc, diag::non_sendable_type);
 }
 
 /// Determine whether this is the main actor type.
@@ -1368,7 +1420,7 @@ namespace {
     ///
     /// \returns true if we diagnosed the entity, \c false otherwise.
     bool diagnoseReferenceToUnsafeGlobal(ValueDecl *value, SourceLoc loc) {
-      if (!ctx.LangOpts.WarnConcurrency)
+      if (!getDeclContext()->getParentModule()->isConcurrencyChecked())
         return false;
 
       // Only diagnose direct references to mutable global state.
@@ -1575,7 +1627,7 @@ namespace {
       if (result == AsyncMarkingResult::FoundAsync) {
         // Check for non-concurrent types.
         bool problemFound =
-            diagnoseNonConcurrentTypesInReference(
+            diagnoseNonSendableTypesInReference(
               concDeclRef, getDeclContext()->getParentModule(), declLoc,
               ConcurrentReferenceKind::SynchronousAsAsyncCall);
         if (problemFound)
@@ -1773,28 +1825,20 @@ namespace {
         }
       }
 
-      // If we don't need to check for sendability, we're done.
-      if (!shouldDiagnoseNonSendableViolations(ctx.LangOpts))
-        return false;
-
       // Check for sendability of the parameter types.
       for (const auto &param : fnType->getParams()) {
         // FIXME: Dig out the locations of the corresponding arguments.
-        if (!isSendableType(getParentModule(), param.getParameterType())) {
-          ctx.Diags.diagnose(
-              apply->getLoc(), diag::non_concurrent_param_type,
-              param.getParameterType());
+        if (diagnoseNonSendableTypes(
+                param.getParameterType(), getParentModule(), apply->getLoc(),
+                diag::non_sendable_param_type))
           return true;
-        }
       }
 
       // Check for sendability of the result type.
-      if (!isSendableType(getParentModule(), fnType->getResult())) {
-        ctx.Diags.diagnose(
-            apply->getLoc(), diag::non_concurrent_result_type,
-            fnType->getResult());
+      if (diagnoseNonSendableTypes(
+             fnType->getResult(), getParentModule(), apply->getLoc(),
+             diag::non_sendable_result_type))
         return true;
-      }
 
       return false;
     }
@@ -1817,7 +1861,7 @@ namespace {
 
       // A cross-actor access requires types to be concurrent-safe.
       if (isCrossActor) {
-        return diagnoseNonConcurrentTypesInReference(
+        return diagnoseNonSendableTypesInReference(
             valueRef, getParentModule(), loc,
             ConcurrentReferenceKind::CrossActor);
       }
@@ -1952,7 +1996,7 @@ namespace {
         if (!var->supportsMutation() ||
             (ctx.LangOpts.EnableExperimentalFlowSensitiveConcurrentCaptures &&
              parent.dyn_cast<LoadExpr *>())) {
-          return diagnoseNonConcurrentTypesInReference(
+          return diagnoseNonSendableTypesInReference(
               valueRef, getParentModule(), loc,
               ConcurrentReferenceKind::LocalCapture);
         }
@@ -2003,13 +2047,11 @@ namespace {
         if (auto varDecl = dyn_cast<VarDecl>(decl)) {
           if (varDecl->isLet()) {
             auto type = component.getComponentType();
-            if (shouldDiagnoseNonSendableViolations(ctx.LangOpts)
-                && !isSendableType(getParentModule(), type)) {
-              ctx.Diags.diagnose(
-                  component.getLoc(), diag::non_concurrent_keypath_access,
-                  type);
+            if (diagnoseNonSendableTypes(
+                    type, getParentModule(), component.getLoc(),
+                    diag::non_sendable_keypath_access))
               return true;
-            }
+
             return false;
           }
         }
@@ -2070,13 +2112,11 @@ namespace {
         // such as \Type.dict[k] where k is a captured dictionary key.
         if (auto indexExpr = component.getIndexExpr()) {
           auto type = indexExpr->getType();
-          if (type && shouldDiagnoseNonSendableViolations(ctx.LangOpts)
-              && !isSendableType(getParentModule(), type)) {
-            ctx.Diags.diagnose(
-                component.getLoc(), diag::non_concurrent_keypath_capture,
-                indexExpr->getType());
+          if (type &&
+              diagnoseNonSendableTypes(
+                  type, getParentModule(), component.getLoc(),
+                  diag::non_sendable_keypath_capture))
             diagnosed = true;
-          }
         }
       }
 
@@ -2211,7 +2251,7 @@ namespace {
         if (getIsolatedActor(base))
           return false;
 
-        return diagnoseNonConcurrentTypesInReference(
+        return diagnoseNonSendableTypesInReference(
             memberRef, getDeclContext()->getParentModule(), memberLoc,
             ConcurrentReferenceKind::CrossActor);
       }
@@ -2983,7 +3023,7 @@ ActorIsolation ActorIsolationRequest::evaluate(
               ->getGenericEnvironmentOfContext()) {
         subs = genericEnv->getForwardingSubstitutionMap();
       }
-      diagnoseNonConcurrentTypesInReference(
+      diagnoseNonSendableTypesInReference(
           ConcreteDeclRef(value, subs),
           value->getDeclContext()->getParentModule(), value->getLoc(),
           ConcurrentReferenceKind::Nonisolated);
@@ -3403,27 +3443,47 @@ bool swift::contextUsesConcurrencyFeatures(const DeclContext *dc) {
 }
 
 static bool shouldDiagnoseExistingDataRaces(const DeclContext *dc) {
-  if (dc->getASTContext().LangOpts.WarnConcurrency)
+  if (dc->getParentModule()->isConcurrencyChecked())
     return true;
 
   return contextUsesConcurrencyFeatures(dc);
 }
 
-static DiagnosticBehavior toDiagnosticBehavior(const LangOptions &langOpts,
-                                               SendableCheck check,
-                                               bool diagnoseImplicit = false) {
+/// Limit the diagnostic behavior used when performing checks for the Sendable
+/// instance storage of Sendable types.
+///
+/// \returns a pair containing the diagnostic behavior that should be used
+/// for this diagnostic, as well as a Boolean value indicating whether to
+/// treat this as an error.
+static std::pair<DiagnosticBehavior, bool> limitSendableInstanceBehavior(
+    const LangOptions &langOpts, SendableCheck check,
+    DiagnosticBehavior suggestedBehavior) {
+  // Is an error suggested?
+  bool suggestedError = suggestedBehavior == DiagnosticBehavior::Unspecified ||
+      suggestedBehavior == DiagnosticBehavior::Error;
   switch (check) {
-  case SendableCheck::ImpliedByStandardProtocol:
-    return shouldDiagnoseNonSendableViolations(langOpts)
-        ? DiagnosticBehavior::Warning
-        : DiagnosticBehavior::Ignore;
-  case SendableCheck::Explicit:
-    return DiagnosticBehavior::Unspecified;
   case SendableCheck::Implicit:
-    return (diagnoseImplicit &&
-            shouldDiagnoseNonSendableViolations(langOpts))
-      ? DiagnosticBehavior::Unspecified
-      : DiagnosticBehavior::Ignore;
+    // For implicit checks, we always ignore the diagnostic and fail.
+    return std::make_pair(DiagnosticBehavior::Ignore, true);
+
+  case SendableCheck::Explicit:
+    // Bump warnings up to errors due to explicit Sendable conformance.
+    if (suggestedBehavior == DiagnosticBehavior::Warning)
+      return std::make_pair(DiagnosticBehavior::Unspecified, true);
+
+    return std::make_pair(suggestedBehavior, suggestedError);
+
+  case SendableCheck::ImpliedByStandardProtocol:
+    // If we aren't in Swift 6, downgrade diagnostics.
+    if (!langOpts.isSwiftVersionAtLeast(6)) {
+      if (langOpts.WarnConcurrency &&
+          suggestedBehavior != DiagnosticBehavior::Ignore)
+        return std::make_pair(DiagnosticBehavior::Warning, false);
+
+      return std::make_pair(DiagnosticBehavior::Ignore, false);
+    }
+
+    return std::make_pair(suggestedBehavior, suggestedError);
   }
 }
 
@@ -3433,35 +3493,49 @@ static bool checkSendableInstanceStorage(
     NominalTypeDecl *nominal, DeclContext *dc, SendableCheck check) {
   // Stored properties of structs and classes must have
   // Sendable-conforming types.
-  const auto &langOpts = dc->getASTContext().LangOpts;
-  auto behavior = toDiagnosticBehavior(langOpts, check);
+  const LangOptions &langOpts = dc->getASTContext().LangOpts;
   bool invalid = false;
   if (isa<StructDecl>(nominal) || isa<ClassDecl>(nominal)) {
     auto classDecl = dyn_cast<ClassDecl>(nominal);
     for (auto property : nominal->getStoredProperties()) {
       if (classDecl && property->supportsMutation()) {
-        if (behavior == DiagnosticBehavior::Ignore)
+        if (check == SendableCheck::Implicit)
           return true;
+
+        auto action = limitSendableInstanceBehavior(
+            langOpts, check, DiagnosticBehavior::Unspecified);
+
         property->diagnose(diag::concurrent_value_class_mutable_property,
                            property->getName(), nominal->getDescriptiveKind(),
                            nominal->getName())
-            .limitBehavior(behavior);
-        invalid = true;
+            .limitBehavior(action.first);
+        invalid = invalid || action.second;
         continue;
       }
 
+      // Check that the property is Sendable.
       auto propertyType = dc->mapTypeIntoContext(property->getInterfaceType())
           ->getRValueType()->getReferenceStorageReferent();
-      if (!isSendableType(dc->getParentModule(), propertyType)) {
-        if (behavior == DiagnosticBehavior::Ignore)
-          return true;
-        property->diagnose(diag::non_concurrent_type_member,
-                           false, property->getName(),
-                           nominal->getDescriptiveKind(), nominal->getName(),
-                           propertyType)
-            .limitBehavior(behavior);
+      bool diagnosedProperty = diagnoseNonSendableTypes(
+              propertyType, dc->getParentModule(), property->getLoc(),
+              [&](Type type, DiagnosticBehavior suggestedBehavior) {
+                auto action = limitSendableInstanceBehavior(
+                    langOpts, check, suggestedBehavior);
+                property->diagnose(diag::non_concurrent_type_member,
+                                   false, property->getName(),
+                                   nominal->getDescriptiveKind(),
+                                   nominal->getName(),
+                                   propertyType)
+                    .limitBehavior(action.first);
+                return action.second;
+              });
+
+      if (diagnosedProperty) {
         invalid = true;
-        continue;
+
+        // For implicit checks, bail out early if anything failed.
+        if (check == SendableCheck::Implicit)
+          return true;
       }
     }
 
@@ -3476,18 +3550,29 @@ static bool checkSendableInstanceStorage(
         if (!element->hasAssociatedValues())
           continue;
 
+        // Check that the associated value type is Sendable.
         auto elementType = dc->mapTypeIntoContext(
             element->getArgumentInterfaceType());
-        if (!isSendableType(dc->getParentModule(), elementType)) {
-          if (behavior == DiagnosticBehavior::Ignore)
-            return true;
-          element->diagnose(diag::non_concurrent_type_member,
-                            true, element->getName(),
-                            nominal->getDescriptiveKind(), nominal->getName(),
-                            elementType)
-              .limitBehavior(behavior);
+        bool diagnosedElement = diagnoseNonSendableTypes(
+              elementType, dc->getParentModule(), element->getLoc(),
+              [&](Type type, DiagnosticBehavior suggestedBehavior) {
+                auto action = limitSendableInstanceBehavior(
+                    langOpts, check, suggestedBehavior);
+                element->diagnose(diag::non_concurrent_type_member,
+                                  true, element->getName(),
+                                  nominal->getDescriptiveKind(),
+                                  nominal->getName(),
+                                  type)
+                    .limitBehavior(action.first);
+                return action.second;
+              });
+
+        if (diagnosedElement) {
           invalid = true;
-          continue;
+
+          // For implicit checks, bail out early if anything failed.
+          if (check == SendableCheck::Implicit)
+            return true;
         }
       }
     }
@@ -3526,8 +3611,11 @@ bool swift::checkSendableConformance(
 
   // Sendable can only be used in the same source file.
   auto conformanceDecl = conformanceDC->getAsDecl();
-  auto behavior = toDiagnosticBehavior(
-      nominal->getASTContext().LangOpts, check, /*diagnoseImplicit=*/true);
+  const LangOptions &langOpts = conformanceDC->getASTContext().LangOpts;
+  DiagnosticBehavior behavior;
+  bool diagnosticCausesFailure;
+  std::tie(behavior, diagnosticCausesFailure) = limitSendableInstanceBehavior(
+      langOpts, check, DiagnosticBehavior::Unspecified);
   if (!conformanceDC->getParentSourceFile() ||
       conformanceDC->getParentSourceFile() != nominal->getParentSourceFile()) {
     conformanceDecl->diagnose(diag::concurrent_value_outside_source_file,
@@ -3535,7 +3623,7 @@ bool swift::checkSendableConformance(
                               nominal->getName())
         .limitBehavior(behavior);
 
-    if (behavior != DiagnosticBehavior::Warning)
+    if (diagnosticCausesFailure)
       return true;
   }
 
@@ -3546,7 +3634,7 @@ bool swift::checkSendableConformance(
                           classDecl->getName())
           .limitBehavior(behavior);
 
-      if (behavior != DiagnosticBehavior::Warning)
+      if (diagnosticCausesFailure)
         return true;
     }
 
@@ -3561,7 +3649,7 @@ bool swift::checkSendableConformance(
               classDecl->getName())
               .limitBehavior(behavior);
 
-          if (behavior != DiagnosticBehavior::Warning)
+          if (diagnosticCausesFailure)
             return true;
         }
       }

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -432,22 +432,19 @@ static bool checkObjCInForeignClassContext(const ValueDecl *VD,
 static bool checkObjCActorIsolation(const ValueDecl *VD,
                                     ObjCReason Reason) {
   // Check actor isolation.
-  auto behavior = behaviorLimitForObjCReason(Reason, VD->getASTContext());
-
   switch (auto restriction = ActorIsolationRestriction::forDeclaration(
               const_cast<ValueDecl *>(VD), VD->getDeclContext(),
               /*fromExpression=*/false)) {
   case ActorIsolationRestriction::CrossActorSelf:
     // FIXME: Substitution map?
-    diagnoseNonConcurrentTypesInReference(
+    diagnoseNonSendableTypesInReference(
         const_cast<ValueDecl *>(VD), VD->getDeclContext()->getParentModule(),
-        VD->getLoc(), ConcurrentReferenceKind::CrossActor, behavior);
+        VD->getLoc(), ConcurrentReferenceKind::CrossActor);
     return false;
   case ActorIsolationRestriction::ActorSelf:
     // Actor-isolated functions cannot be @objc.
     VD->diagnose(diag::actor_isolated_objc, VD->getDescriptiveKind(),
-                 VD->getName())
-        .limitBehavior(behavior);
+                 VD->getName());
     Reason.describe(VD);
     if (auto FD = dyn_cast<FuncDecl>(VD)) {
       addAsyncNotes(const_cast<FuncDecl *>(FD));

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2869,7 +2869,7 @@ bool ConformanceChecker::checkActorIsolation(
   }
 
   case ActorIsolationRestriction::CrossActorSelf:
-    return diagnoseNonConcurrentTypesInReference(
+    return diagnoseNonSendableTypesInReference(
         witness, DC->getParentModule(), witness->getLoc(),
         ConcurrentReferenceKind::CrossActor);
 
@@ -2940,7 +2940,7 @@ bool ConformanceChecker::checkActorIsolation(
     if (requirement->hasClangNode())
       return false;
 
-    return diagnoseNonConcurrentTypesInReference(
+    return diagnoseNonSendableTypesInReference(
       witness, DC->getParentModule(), witness->getLoc(),
       ConcurrentReferenceKind::CrossActor);
   }
@@ -2975,7 +2975,7 @@ bool ConformanceChecker::checkActorIsolation(
       return false;
 
     if (isCrossActor) {
-      return diagnoseNonConcurrentTypesInReference(
+      return diagnoseNonSendableTypesInReference(
         witness, DC->getParentModule(), witness->getLoc(),
         ConcurrentReferenceKind::CrossActor);
     }
@@ -5927,6 +5927,9 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
     SendableCheck check = SendableCheck::Explicit;
     if (errorConformance || codingKeyConformance)
       check = SendableCheck::ImpliedByStandardProtocol;
+    else if (SendableConformance->getSourceKind() ==
+                 ConformanceEntryKind::Synthesized)
+      check = SendableCheck::Implicit;
     checkSendableConformance(SendableConformance, check);
   }
 

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -501,6 +501,9 @@ public:
   /// .swiftsourceinfo file (ie. the file exists and has been read).
   bool hasSourceInfo() const { return Core->hasSourceInfo(); }
 
+  /// \c true if this module was built with complete checking for concurrency.
+  bool isConcurrencyChecked() const { return Core->isConcurrencyChecked(); }
+
   /// Associates this module file with the AST node representing it.
   ///
   /// Checks that the file is compatible with the AST module it's being loaded

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -152,6 +152,9 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
     case options_block::MODULE_ABI_NAME:
       extendedInfo.setModuleABIName(blobData);
       break;
+    case options_block::IS_CONCURRENCY_CHECKED:
+      extendedInfo.setIsConcurrencyChecked(true);
+      break;
     default:
       // Unknown options record, possibly for use by a future version of the
       // module format.
@@ -1217,6 +1220,7 @@ ModuleFileSharedCore::ModuleFileSharedCore(
       Bits.IsImplicitDynamicEnabled = extInfo.isImplicitDynamicEnabled();
       Bits.IsAllowModuleWithCompilerErrorsEnabled =
           extInfo.isAllowModuleWithCompilerErrorsEnabled();
+      Bits.IsConcurrencyChecked = extInfo.isConcurrencyChecked();
       MiscVersion = info.miscVersion;
       ModuleABIName = extInfo.getModuleABIName();
 

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -341,8 +341,11 @@ private:
     /// Whether this module is compiled while allowing errors.
     unsigned IsAllowModuleWithCompilerErrorsEnabled: 1;
 
+    /// \c true if this module was built with complete checking for concurrency.
+    unsigned IsConcurrencyChecked: 1;
+
     // Explicitly pad out to the next word boundary.
-    unsigned : 3;
+    unsigned : 5;
   } Bits = {};
   static_assert(sizeof(ModuleBits) <= 8, "The bit set should be small");
 
@@ -534,6 +537,8 @@ public:
   /// Returns \c true if a corresponding .swiftsourceinfo has been found *and
   /// read*.
   bool hasSourceInfo() const;
+
+  bool isConcurrencyChecked() const { return Bits.IsConcurrencyChecked; }
 };
 
 template <typename T, typename RawData>

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 624; // new BodyKind for AbstractFunctionDecl
+const uint16_t SWIFTMODULE_VERSION_MINOR = 625; // is concurrency checked?
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -797,6 +797,7 @@ namespace options_block {
     IS_IMPLICIT_DYNAMIC_ENABLED,
     IS_ALLOW_MODULE_WITH_COMPILER_ERRORS_ENABLED,
     MODULE_ABI_NAME,
+    IS_CONCURRENCY_CHECKED,
   };
 
   using SDKPathLayout = BCRecordLayout<
@@ -842,6 +843,10 @@ namespace options_block {
   using ModuleABINameLayout = BCRecordLayout<
     MODULE_ABI_NAME,
     BCBlob
+  >;
+
+  using IsConcurrencyCheckedLayout = BCRecordLayout<
+    IS_CONCURRENCY_CHECKED
   >;
 }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -812,6 +812,7 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(options_block, RESILIENCE_STRATEGY);
   BLOCK_RECORD(options_block, IS_ALLOW_MODULE_WITH_COMPILER_ERRORS_ENABLED);
   BLOCK_RECORD(options_block, MODULE_ABI_NAME);
+  BLOCK_RECORD(options_block, IS_CONCURRENCY_CHECKED);
 
   BLOCK(INPUT_BLOCK);
   BLOCK_RECORD(input_block, IMPORTED_MODULE);
@@ -1024,6 +1025,11 @@ void Serializer::writeHeader(const SerializationOptions &options) {
       if (M->getABIName() != M->getName()) {
         options_block::ModuleABINameLayout ABIName(Out);
         ABIName.emit(ScratchRecord, M->getABIName().str());
+      }
+
+      if (M->isConcurrencyChecked()) {
+        options_block::IsConcurrencyCheckedLayout IsConcurrencyChecked(Out);
+        IsConcurrencyChecked.emit(ScratchRecord);
       }
 
       if (options.SerializeOptionsForDebugging) {

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -728,6 +728,8 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
       M.setHasIncrementalInfo();
     if (!loadedModuleFile->getModuleABIName().empty())
       M.setABIName(Ctx.getIdentifier(loadedModuleFile->getModuleABIName()));
+    if (loadedModuleFile->isConcurrencyChecked())
+      M.setIsConcurrencyChecked();
     M.setUserModuleVersion(loadedModuleFile->getUserModuleVersion());
     auto diagLocOrInvalid = diagLoc.getValueOr(SourceLoc());
     loadInfo.status = loadedModuleFile->associateWithFileContext(

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -37,7 +37,7 @@ import Swift
 /// with by end-users directly, unless implementing a scheduler.
 @available(SwiftStdlib 5.5, *)
 @frozen
-public struct Task<Success, Failure: Error>: Sendable {
+public struct Task<Success: Sendable, Failure: Error>: Sendable {
   @usableFromInline
   internal let _task: Builtin.NativeObject
 

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -179,7 +179,7 @@ public func withThrowingTaskGroup<ChildTaskResult, GroupResult>(
 /// It is created by the `withTaskGroup` function.
 @available(SwiftStdlib 5.5, *)
 @frozen
-public struct TaskGroup<ChildTaskResult> {
+public struct TaskGroup<ChildTaskResult: Sendable> {
 
   /// Group task into which child tasks offer their results,
   /// and the `next()` function polls those results from.
@@ -406,7 +406,7 @@ public struct TaskGroup<ChildTaskResult> {
 /// It is created by the `withTaskGroup` function.
 @available(SwiftStdlib 5.5, *)
 @frozen
-public struct ThrowingTaskGroup<ChildTaskResult, Failure: Error> {
+public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
 
   /// Group task into which child tasks offer their results,
   /// and the `next()` function polls those results from.

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -95,8 +95,7 @@ import Swift
 /// value for lookups in the task local storage.
 @propertyWrapper
 @available(SwiftStdlib 5.5, *)
-// TODO: add Sendable enforcement when we're ready to do so rdar://77441933
-public final class TaskLocal<Value>: UnsafeSendable, CustomStringConvertible {
+public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible {
   let defaultValue: Value
 
   public init(wrappedValue defaultValue: Value) {

--- a/test/Concurrency/Inputs/NonStrictModule.swift
+++ b/test/Concurrency/Inputs/NonStrictModule.swift
@@ -1,0 +1,1 @@
+public class NonStrictClass { }

--- a/test/Concurrency/Inputs/StrictModule.swift
+++ b/test/Concurrency/Inputs/StrictModule.swift
@@ -1,0 +1,1 @@
+public struct StrictStruct: Hashable { }

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -359,18 +359,23 @@ actor Calculator {
 @OrangeActor func doSomething() async {
   let _ = (await bananaAdd(1))(2)
   // expected-warning@-1{{cannot call function returning non-sendable type}}
+  // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   let _ = await (await bananaAdd(1))(2) // expected-warning{{no 'async' operations occur within 'await' expression}}
   // expected-warning@-1{{cannot call function returning non-sendable type}}
+  // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
   let calc = Calculator()
   
   let _ = (await calc.addCurried(1))(2)
   // expected-warning@-1{{cannot call function returning non-sendable type}}
+  // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   let _ = await (await calc.addCurried(1))(2) // expected-warning{{no 'async' operations occur within 'await' expression}}
   // expected-warning@-1{{cannot call function returning non-sendable type}}
+  // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
   let plusOne = await calc.addCurried(await calc.add(0, 1))
   // expected-warning@-1{{cannot call function returning non-sendable type}}
+  // expected-note@-2{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   let _ = plusOne(2)
 }
 

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -13,7 +13,7 @@ func rethrower(_ f : @autoclosure () throws -> Any) rethrows -> Any {
 func asAutoclosure(_ f : @autoclosure () -> Any) -> Any { return f() }
 
 // not a concurrency-safe type
-class Box {
+class Box { // expected-note 4{{class 'Box' does not conform to the `Sendable` protocol}}
   var counter : Int = 0
 }
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -46,7 +46,7 @@ actor MySuperActor {
   }
 }
 
-class Point {
+class Point { // expected-note{{class 'Point' does not conform to the `Sendable` protocol}}
   var x : Int = 0
   var y : Int = 0
 }

--- a/test/Concurrency/actor_isolation_unsafe.swift
+++ b/test/Concurrency/actor_isolation_unsafe.swift
@@ -34,7 +34,7 @@ struct S4_P1: P1 {
 }
 
 @MainActor(unsafe)
-protocol P2 {
+protocol P2 { // expected-note{{protocol 'P2' does not conform to the `Sendable` protocol}}
   func f() // expected-note{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
   nonisolated func g()
 }
@@ -44,6 +44,7 @@ struct S5_P2: P2 {
   func g() { }
 }
 
+// expected-warning@+1{{cannot pass argument of non-sendable type 'P2' across actors}}
 nonisolated func testP2(x: S5_P2, p2: P2) {
   p2.f() // expected-error{{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
   p2.g() // OKAY

--- a/test/Concurrency/actor_keypath_isolation.swift
+++ b/test/Concurrency/actor_keypath_isolation.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift  -disable-availability-checking -warn-concurrency
 // REQUIRES: concurrency
 
-class Box {
+class Box { // expected-note 3{{class 'Box' does not conform to the `Sendable` protocol}}
     let size : Int = 0
 }
 

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -92,6 +92,7 @@ func globalTestMain(nc: NotConcurrent) async {
   await globalAsync(a) // expected-warning{{cannot pass argument of non-sendable type 'NotConcurrent?' across actors}}
   await globalSync(a)  // expected-warning{{cannot pass argument of non-sendable type 'NotConcurrent?' across actors}}
   _ = await ClassWithGlobalActorInits(nc) // expected-warning{{cannot pass argument of non-sendable type 'NotConcurrent' across actors}}
+  // expected-warning@-1{{cannot call function returning non-sendable type 'ClassWithGlobalActorInits' across actors}}
   _ = await ClassWithGlobalActorInits() // expected-warning{{cannot call function returning non-sendable type 'ClassWithGlobalActorInits' across actors}}
 }
 

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift  -disable-availability-checking -warn-concurrency
 // REQUIRES: concurrency
 
-class NotConcurrent { }
+class NotConcurrent { } // expected-note 17{{class 'NotConcurrent' does not conform to the `Sendable` protocol}}
 
 // ----------------------------------------------------------------------
 // Sendable restriction on actor operations
@@ -77,7 +77,7 @@ struct HasSubscript {
   subscript (i: Int) -> NotConcurrent? { nil }
 }
 
-class ClassWithGlobalActorInits {
+class ClassWithGlobalActorInits { // expected-note 2{{class 'ClassWithGlobalActorInits' does not conform to the `Sendable` protocol}}
   @SomeGlobalActor
   init(_: NotConcurrent) { }
 
@@ -144,7 +144,7 @@ func testUnsafeSendableInAsync() async {
 // ----------------------------------------------------------------------
 // Sendable restriction on key paths.
 // ----------------------------------------------------------------------
-class NC: Hashable {
+class NC: Hashable { // expected-note 3{{class 'NC' does not conform to the `Sendable` protocol}}
   func hash(into: inout Hasher) { }
   static func==(_: NC, _: NC) -> Bool { true }
 }

--- a/test/Concurrency/concurrent_value_checking_objc.swift
+++ b/test/Concurrency/concurrent_value_checking_objc.swift
@@ -13,7 +13,7 @@ final class B: NSObject, Sendable {
   var x: Int = 5 // expected-error{{stored property 'x' of 'Sendable'-conforming class 'B' is mutable}}
 }
 
-class C { }
+class C { } // expected-note{{class 'C' does not conform to the `Sendable` protocol}}
 
 final class D: NSObject, Sendable {
   let c: C = C() // expected-error{{stored property 'c' of 'Sendable'-conforming class 'D' has non-sendable type 'C'}}

--- a/test/Concurrency/concurrent_value_checking_objc.swift
+++ b/test/Concurrency/concurrent_value_checking_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift  -disable-availability-checking
+// RUN: %target-typecheck-verify-swift  -disable-availability-checking -warn-concurrency
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop

--- a/test/Concurrency/concurrent_value_inference.swift
+++ b/test/Concurrency/concurrent_value_inference.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-library-evolution
+// RUN: %target-typecheck-verify-swift -enable-library-evolution -warn-concurrency
 // REQUIRES: concurrency
 
 class C1 { }
@@ -10,7 +10,7 @@ struct S1 {
   var c: C2
 }
 
-enum E1 {
+enum E1 { // expected-note{{add conformance of enum 'E1' to the 'Sendable' protocol}}
   case base
   indirect case nested(E1)
 }
@@ -22,7 +22,7 @@ enum E2 {
 
 struct GS1<T> { }
 
-struct GS2<T> {
+struct GS2<T> {  // expected-note{{add conformance of generic struct 'GS2' to the 'Sendable' protocol}}
   var storage: T
 }
 
@@ -33,7 +33,7 @@ struct Signature { }
 struct Data { }
 struct BlockInfo { }
 
-struct Bitcode {
+struct Bitcode { // expected-note{{add conformance of struct 'Bitcode' to the 'Sendable' protocol}}
   let signature: Signature
   let elements: [BitcodeElement]
   let blockInfo: [UInt64: BlockInfo]
@@ -64,11 +64,11 @@ enum BitcodeElement {
 
 // Public structs and enums do not get implicit Sendable unless they
 // are frozen.
-public struct PublicStruct {
+public struct PublicStruct { // expected-note{{add conformance of struct 'PublicStruct' to the 'Sendable' protocol}}
   var i: Int
 }
 
-public enum PublicEnum {
+public enum PublicEnum { // expected-note{{add conformance of enum 'PublicEnum' to the 'Sendable' protocol}}
   case some
 }
 

--- a/test/Concurrency/concurrent_value_inference.swift
+++ b/test/Concurrency/concurrent_value_inference.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -enable-library-evolution -warn-concurrency
 // REQUIRES: concurrency
 
-class C1 { }
+class C1 { } // expected-note{{class 'C1' does not conform to the `Sendable` protocol}}
 final class C2: Sendable { }
 
 struct S1 {

--- a/test/Concurrency/concurrent_value_inference.swift
+++ b/test/Concurrency/concurrent_value_inference.swift
@@ -10,7 +10,7 @@ struct S1 {
   var c: C2
 }
 
-enum E1 { // expected-note{{add conformance of enum 'E1' to the 'Sendable' protocol}}
+enum E1 { // expected-note{{consider making enum 'E1' conform to the 'Sendable' protocol}}{{9-9=: Sendable }}
   case base
   indirect case nested(E1)
 }
@@ -22,7 +22,7 @@ enum E2 {
 
 struct GS1<T> { }
 
-struct GS2<T> {  // expected-note{{add conformance of generic struct 'GS2' to the 'Sendable' protocol}}
+struct GS2<T> {  // expected-note{{consider making generic struct 'GS2' conform to the 'Sendable' protocol}}
   var storage: T
 }
 
@@ -33,7 +33,7 @@ struct Signature { }
 struct Data { }
 struct BlockInfo { }
 
-struct Bitcode { // expected-note{{add conformance of struct 'Bitcode' to the 'Sendable' protocol}}
+struct Bitcode { // expected-note{{consider making struct 'Bitcode' conform to the 'Sendable' protocol}}
   let signature: Signature
   let elements: [BitcodeElement]
   let blockInfo: [UInt64: BlockInfo]
@@ -64,11 +64,11 @@ enum BitcodeElement {
 
 // Public structs and enums do not get implicit Sendable unless they
 // are frozen.
-public struct PublicStruct { // expected-note{{add conformance of struct 'PublicStruct' to the 'Sendable' protocol}}
+public struct PublicStruct { // expected-note{{consider making struct 'PublicStruct' conform to the 'Sendable' protocol}}
   var i: Int
 }
 
-public enum PublicEnum { // expected-note{{add conformance of enum 'PublicEnum' to the 'Sendable' protocol}}
+public enum PublicEnum { // expected-note{{consider making enum 'PublicEnum' conform to the 'Sendable' protocol}}
   case some
 }
 

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -256,7 +256,7 @@ func barSync() {
 
 @propertyWrapper
 @OtherGlobalActor
-struct WrapperOnActor<Wrapped> {
+struct WrapperOnActor<Wrapped: Sendable> {
   private var stored: Wrapped
 
   nonisolated init(wrappedValue: Wrapped) {
@@ -286,7 +286,7 @@ public struct WrapperOnMainActor<Wrapped> {
 }
 
 @propertyWrapper
-actor WrapperActor<Wrapped> {
+actor WrapperActor<Wrapped: Sendable> {
   var storage: Wrapped
 
   init(wrappedValue: Wrapped) {
@@ -345,7 +345,7 @@ actor WrapperActorBad1<Wrapped> {
 }
 
 @propertyWrapper
-actor WrapperActorBad2<Wrapped> {
+actor WrapperActorBad2<Wrapped: Sendable> {
   var storage: Wrapped
 
   init(wrappedValue: Wrapped) {
@@ -383,7 +383,7 @@ actor ActorWithWrapper {
 }
 
 @propertyWrapper
-struct WrapperOnSomeGlobalActor<Wrapped> {
+struct WrapperOnSomeGlobalActor<Wrapped: Sendable> {
   private var stored: Wrapped
 
   nonisolated init(wrappedValue: Wrapped) {

--- a/test/Concurrency/sendable_module_checking.swift
+++ b/test/Concurrency/sendable_module_checking.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -warn-concurrency %S/Inputs/StrictModule.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
+// RUN: %target-swift-frontend -typecheck -disable-availability-checking -I %t 2>&1 %s | %FileCheck %s
+
+// REQUIRES: concurrency
+
+import StrictModule
+import NonStrictModule
+
+actor A {
+  func f() -> [StrictStruct: NonStrictClass] { [:] }
+}
+
+func testA(a: A) async {
+  _ = await a.f() // CHECK: warning: cannot call function returning non-sendable type '[StrictStruct : NonStrictClass]' across actors}}
+  // CHECK-NOT: NonStrictClass
+  // CHECK: note: struct 'StrictStruct' does not conform to the `Sendable` protocol
+  // CHECK-NOT: NonStrictClass
+}

--- a/test/SILOptimizer/constant_evaluator_skip_test.sil
+++ b/test/SILOptimizer/constant_evaluator_skip_test.sil
@@ -92,7 +92,7 @@ bb0:
   %9 = integer_literal $Builtin.Int32, 0
   %10 = builtin "cmp_slt_Int32"(%8 : $Builtin.Int32, %9 : $Builtin.Int32) : $Builtin.Int1
   cond_br %10, bb2, bb3
-    // CHECK: {{.*}}:[[@LINE-1]]:{{.*}}: note: branch depends on non-constant value produced by an unevaluated instructions
+    // CHECK-LABEL: {{.*}}:94:{{.*}}: remark: branch depends on non-constant value produced by an unevaluated instructions
     // CHECK: {{.*}}: note: result of an unevaluated instruction is not a constant
 bb2:
   br bb4

--- a/test/decl/protocol/special/Sendable.swift
+++ b/test/decl/protocol/special/Sendable.swift
@@ -2,7 +2,7 @@
 
 func acceptSendable<T: Sendable>(_: T) { }
 
-class NotSendable { }
+class NotSendable { } // expected-note 2{{class 'NotSendable' does not conform to the `Sendable` protocol}}
 
 func testSendableBuiltinConformances(
   i: Int, ns: NotSendable, sf: @escaping @Sendable () -> Void,

--- a/test/decl/protocol/special/Sendable.swift
+++ b/test/decl/protocol/special/Sendable.swift
@@ -21,8 +21,11 @@ func testSendableBuiltinConformances(
 
   // Complaints about missing Sendable conformances
   acceptSendable((i, ns)) // expected-warning{{type 'NotSendable' does not conform to the 'Sendable' protocol}}
-  acceptSendable(nsf) // expected-warning{{function type '() -> Void' must be marked '@Sendable' to conform to 'Sendable'}}
-  acceptSendable((nsf, i)) // expected-warning{{function type '() -> Void' must be marked '@Sendable' to conform to 'Sendable'}}
-  acceptSendable(funNotSendable) // expected-warning{{function type '() -> Void' must be marked '@Sendable' to conform to 'Sendable'}}
+  acceptSendable(nsf) // expected-warning{{type '() -> Void' does not conform to the 'Sendable' protocol}}
+  // expected-note@-1{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  acceptSendable((nsf, i)) // expected-warning{{type '() -> Void' does not conform to the 'Sendable' protocol}}
+  // expected-note@-1{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  acceptSendable(funNotSendable) // expected-warning{{type '() -> Void' does not conform to the 'Sendable' protocol}}
+  // expected-note@-1{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   acceptSendable((i, ns)) // expected-warning{{type 'NotSendable' does not conform to the 'Sendable' protocol}}
 }


### PR DESCRIPTION
Rework `Sendable` checking to be completely based on "missing"
conformances, so that we can individually diagnose missing `Sendable`
conformances based on both the module in which the conformance check
happened as well as where the type was declared. The basic rules here
are to only diagnose if the non-`Sendable` type either comes from the
current model or from a module that was compiled in a mode that
consistently diagnoses `Sendable`. The latter is true for modules
compiled in Swift 6 mode or that provide `-warn-concurrency` on
the command line. This is tracked by rdar://78269348.

The diagnostics will be an error in Swift 6 or a warning in Swift 5.x.

Use this to adopt `Sendable` in the Task APIs without breaking code, 
tracked by rdar://77441933. 