### PR TITLE
[stdlib] Stop swapping self in Array.withUnsafeMutableBufferPointer

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1604,31 +1604,16 @@ extension Array {
     _makeMutableAndUnique()
     let count = _buffer.mutableCount
 
-    // Ensure that body can't invalidate the storage or its bounds by
-    // moving self into a temporary working array.
-    // NOTE: The stack promotion optimization that keys of the
-    // "array.withUnsafeMutableBufferPointer" semantics annotation relies on the
-    // array buffer not being able to escape in the closure. It can do this
-    // because we swap the array buffer in self with an empty buffer here. Any
-    // escape via the address of self in the closure will therefore escape the
-    // empty array.
-
-    var work = Array()
-    (work, self) = (self, work)
-
     // Create an UnsafeBufferPointer over work that we can pass to body
-    let pointer = work._buffer.mutableFirstElementAddress
+    let pointer = _buffer.mutableFirstElementAddress
     var inoutBufferPointer = UnsafeMutableBufferPointer(
       start: pointer, count: count)
 
-    // Put the working array back before returning.
     defer {
       _precondition(
         inoutBufferPointer.baseAddress == pointer &&
         inoutBufferPointer.count == count,
         "Array withUnsafeMutableBufferPointer: replacing the buffer is not allowed")
-
-      (work, self) = (self, work)
       _endMutation()
     }
 


### PR DESCRIPTION
`Array.withUnsafeMutableBufferPointer` swaps out `self`'s buffer for an empty array for the duration of its closure call, to prevent the buffer getting released by the closure. 

This code predates the introduction of the law of exclusivity, and I *think* we don't need it anymore.

Removing the swap gets rid of the need to create an empty array, which eliminates a pair of swift_retain/release calls for the dummy value. This can make a measurable difference in performance sensitive code.