### PR TITLE
RequirementMachine: Some more performance improvements

### DIFF
--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -389,10 +389,6 @@ void RequirementMachine::computeCompletion() {
 
     checkCompletionResult();
 
-    // Simplify right hand sides in preparation for building the
-    // property map.
-    System.simplifyRewriteSystem();
-
     // Check invariants.
     System.verify();
 

--- a/lib/AST/RequirementMachine/RewriteContext.h
+++ b/lib/AST/RequirementMachine/RewriteContext.h
@@ -16,6 +16,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Statistic.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/Support/Allocator.h"
 #include "Histogram.h"
@@ -44,6 +45,9 @@ class RewriteContext final {
   /// Folding set for uniquing terms.
   llvm::FoldingSet<Term::Storage> Terms;
 
+  /// Cache for associated type declarations.
+  llvm::DenseMap<Symbol, AssociatedTypeDecl *> AssocTypes;
+
   RewriteContext(const RewriteContext &) = delete;
   RewriteContext(RewriteContext &&) = delete;
   RewriteContext &operator=(const RewriteContext &) = delete;
@@ -70,7 +74,7 @@ public:
   MutableTerm getMutableTermForType(CanType paramType,
                                     const ProtocolDecl *proto);
 
-  ASTContext &getASTContext() { return Context; }
+  ASTContext &getASTContext() const { return Context; }
 
   Type getTypeForTerm(Term term,
                       TypeArrayView<GenericTypeParamType> genericParams,
@@ -83,6 +87,9 @@ public:
   Type getRelativeTypeForTerm(
                       const MutableTerm &term, const MutableTerm &prefix,
                       const ProtocolGraph &protos) const;
+
+  AssociatedTypeDecl *getAssociatedTypeForSymbol(Symbol symbol,
+                                                 const ProtocolGraph &protos);
 
   ~RewriteContext();
 };

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -127,28 +127,6 @@ bool RewriteSystem::addRule(MutableTerm lhs, MutableTerm rhs) {
     MergedAssociatedTypes.emplace_back(lhs, rhs);
   }
 
-  // Since we added a new rule, we have to check for overlaps between the
-  // new rule and all existing rules.
-  for (unsigned j : indices(Rules)) {
-    // A rule does not overlap with itself.
-    if (i == j)
-      continue;
-
-    // We don't have to check for overlap with deleted rules.
-    if (Rules[j].isDeleted())
-      continue;
-
-    // The overlap check is not commutative so we have to check both
-    // directions.
-    Worklist.emplace_back(i, j);
-    Worklist.emplace_back(j, i);
-
-    if (DebugCompletion) {
-      llvm::dbgs() << "$ Queued up (" << i << ", " << j << ") and ";
-      llvm::dbgs() << "(" << j << ", " << i << ")\n";
-    }
-  }
-
   // Tell the caller that we added a new rule.
   return true;
 }

--- a/lib/AST/RequirementMachine/RewriteSystemCompletion.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystemCompletion.cpp
@@ -431,6 +431,8 @@ RewriteSystem::computeConfluentCompletion(unsigned maxIterations,
       }
     }
 
+    simplifyRewriteSystem();
+
     again = false;
     for (const auto &pair : resolvedCriticalPairs) {
       // Check if we've already done too much work.

--- a/lib/AST/RequirementMachine/RewriteSystemCompletion.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystemCompletion.cpp
@@ -67,95 +67,6 @@ Symbol Symbol::prependPrefixToConcreteSubstitutions(
     }, ctx);
 }
 
-/// Check if this term overlaps with \p other for the purposes
-/// of the Knuth-Bendix completion algorithm.
-///
-/// An overlap occurs if one of the following two cases holds:
-///
-/// 1) If this == TUV and other == U.
-/// 2) If this == TU and other == UV.
-///
-/// In both cases, we return the subterms T and V, together with
-/// an 'overlap kind' identifying the first or second case.
-///
-/// If both rules have identical left hand sides, either case could
-/// apply, but we arbitrarily pick case 1.
-///
-/// Note that this relation is not commutative; we need to check
-/// for overlap between both (X and Y) and (Y and X).
-OverlapKind
-Term::checkForOverlap(Term other,
-                      MutableTerm &t,
-                      MutableTerm &v) const {
-  if (*this == other) {
-    // If this term is equal to the other term, we have an overlap.
-    t = MutableTerm();
-    v = MutableTerm();
-    return OverlapKind::First;
-  }
-
-  if (size() > other.size()) {
-    // If this term is longer than the other term, check if it contains
-    // the other term.
-    auto first1 = begin();
-    while (first1 <= end() - other.size()) {
-      if (std::equal(other.begin(), other.end(), first1)) {
-        // We have an overlap.
-        t = MutableTerm(begin(), first1);
-        v = MutableTerm(first1 + other.size(), end());
-
-        // If both T and V are empty, we have two equal terms, which
-        // should have been handled above.
-        assert(!t.empty() || !v.empty());
-        assert(t.size() + other.size() + v.size() == size());
-
-        return OverlapKind::First;
-      }
-
-      ++first1;
-    }
-  }
-
-  // Finally, check if a suffix of this term is equal to a prefix of
-  // the other term.
-  unsigned count = std::min(size(), other.size());
-  auto first1 = end() - count;
-  auto last2 = other.begin() + count;
-
-  // Initial state, depending on size() <=> other.size():
-  //
-  // ABC   -- count = 3, first1 = this[0], last2 = other[3]
-  // XYZ
-  //
-  // ABC   -- count = 2, first1 = this[1], last2 = other[2]
-  //  XY
-  //
-  // ABC   -- count = 3, first1 = this[0], last2 = other[3]
-  // XYZW
-
-  // Advance by 1, since we don't need to check for full containment
-  ++first1;
-  --last2;
-
-  while (last2 != other.begin()) {
-    if (std::equal(other.begin(), last2, first1)) {
-      t = MutableTerm(begin(), first1);
-      v = MutableTerm(last2, other.end());
-
-      assert(!t.empty());
-      assert(!v.empty());
-      assert(t.size() + other.size() - v.size() == size());
-
-      return OverlapKind::Second;
-    }
-
-    ++first1;
-    --last2;
-  }
-
-  return OverlapKind::None;
-}
-
 /// If we have two symbols [P:T] and [Q:T], produce a merged symbol:
 ///
 /// - If P inherits from Q, this is just [P:T].
@@ -359,7 +270,9 @@ void RewriteSystem::processMergedAssociatedTypes() {
   MergedAssociatedTypes.clear();
 }
 
-/// Compute a critical pair from two rewrite rules.
+/// Compute a critical pair from the left hand sides of two rewrite rules,
+/// where \p rhs begins at \p from, which must be an iterator pointing
+/// into \p lhs.
 ///
 /// There are two cases:
 ///
@@ -388,15 +301,11 @@ void RewriteSystem::processMergedAssociatedTypes() {
 /// concrete substitution 'X' to get 'A.X'; the new concrete term
 /// is now rooted at the same level as A.B in the rewrite system,
 /// not just B.
-Optional<std::pair<MutableTerm, MutableTerm>>
-RewriteSystem::computeCriticalPair(const Rule &lhs, const Rule &rhs) const {
-  MutableTerm t, v;
-
-  switch (lhs.checkForOverlap(rhs, t, v)) {
-  case OverlapKind::None:
-    return None;
-
-  case OverlapKind::First: {
+std::pair<MutableTerm, MutableTerm>
+RewriteSystem::computeCriticalPair(ArrayRef<Symbol>::const_iterator from,
+                                   const Rule &lhs, const Rule &rhs) const {
+  auto end = lhs.getLHS().end();
+  if (from + rhs.getLHS().size() < end) {
     // lhs == TUV -> X, rhs == U -> Y.
 
     // Note: This includes the case where the two rules have exactly
@@ -405,31 +314,31 @@ RewriteSystem::computeCriticalPair(const Rule &lhs, const Rule &rhs) const {
     // In this case, T and V are both empty.
 
     // Compute the term TYV.
+    MutableTerm t(lhs.getLHS().begin(), from);
     t.append(rhs.getRHS());
-    t.append(v);
+    t.append(from + rhs.getLHS().size(), lhs.getLHS().end());
     return std::make_pair(MutableTerm(lhs.getRHS()), t);
-  }
-
-  case OverlapKind::Second: {
+  } else {
     // lhs == TU -> X, rhs == UV -> Y.
 
-    if (v.back().isSuperclassOrConcreteType()) {
-      v.back() = v.back().prependPrefixToConcreteSubstitutions(
+    // Compute the term T.
+    MutableTerm t(lhs.getLHS().begin(), from);
+
+    // Compute the term XV.
+    MutableTerm xv(lhs.getRHS());
+    xv.append(rhs.getLHS().begin() + (lhs.getLHS().end() - from),
+              rhs.getLHS().end());
+
+    if (xv.back().isSuperclassOrConcreteType()) {
+      xv.back() = xv.back().prependPrefixToConcreteSubstitutions(
           t, Context);
     }
 
-    // Compute the term XV.
-    MutableTerm xv;
-    xv.append(lhs.getRHS());
-    xv.append(v);
-
     // Compute the term TY.
     t.append(rhs.getRHS());
+
     return std::make_pair(xv, t);
   }
-  }
-
-  llvm_unreachable("Bad overlap kind");
 }
 
 /// Computes the confluent completion using the Knuth-Bendix algorithm.
@@ -448,64 +357,97 @@ RewriteSystem::computeConfluentCompletion(unsigned maxIterations,
                                           unsigned maxDepth) {
   unsigned steps = 0;
 
-  // The worklist must be processed in first-in-first-out order, to ensure
-  // that we resolve all overlaps among the initial set of rules before
-  // moving on to overlaps between rules introduced by completion.
-  while (!Worklist.empty()) {
-    // Check if we've already done too much work.
-    if (Rules.size() > maxIterations)
-      return std::make_pair(CompletionResult::MaxIterations, steps);
+  bool again = false;
 
-    auto next = Worklist.front();
-    Worklist.pop_front();
+  do {
+    std::vector<std::pair<MutableTerm, MutableTerm>> resolvedCriticalPairs;
 
-    const auto &lhs = Rules[next.first];
-    const auto &rhs = Rules[next.second];
+    // For every rule, looking for other rules that overlap with this rule.
+    for (unsigned i = 0, e = Rules.size(); i < e; ++i) {
+      const auto &lhs = Rules[i];
+      if (lhs.isDeleted())
+        continue;
 
-    if (DebugCompletion) {
-      llvm::dbgs() << "$ Check for overlap: (#" << next.first << ") ";
-      llvm::dbgs() << lhs << "\n";
-      llvm::dbgs() << "                -vs- (#" << next.second << ") ";
-      llvm::dbgs() << rhs << ":\n";
-    }
+      // Look up every suffix of this rule in the trie using findAll(). This
+      // will find both kinds of overlap:
+      //
+      // 1) rules whose left hand side is fully contained in [from,to)
+      // 2) rules whose left hand side has a prefix equal to [from,to)
+      auto from = lhs.getLHS().begin();
+      auto to = lhs.getLHS().end();
+      while (from < to) {
+        Trie.findAll(from, to, [&](unsigned j) {
+          // We don't have to consider the same pair of rules more than once,
+          // since those critical pairs were already resolved.
+          if (!CheckedOverlaps.insert(std::make_pair(i, j)).second)
+            return;
 
-    auto pair = computeCriticalPair(lhs, rhs);
-    if (!pair) {
-      if (DebugCompletion) {
-        llvm::dbgs() << " no overlap\n\n";
+          const auto &rhs = Rules[j];
+          if (rhs.isDeleted())
+            return;
+
+          if (from == lhs.getLHS().begin()) {
+            // While every rule will have an overlap of the first kind
+            // with itself, it's not useful to consider since the
+            // resulting trivial pair is always trivial.
+            if (i == j)
+              return;
+
+            // If the first rule's left hand side is a proper prefix
+            // of the second rule's left hand side, don't do anything.
+            //
+            // We will find the 'opposite' overlap later, where the two
+            // rules are swapped around. Then it becomes an overlap of
+            // the first kind, and will be handled as such.
+            if (rhs.getLHS().size() > lhs.getLHS().size())
+              return;
+          }
+
+          // Try to repair the confluence violation by adding a new rule.
+          resolvedCriticalPairs.push_back(computeCriticalPair(from, lhs, rhs));
+
+          if (DebugCompletion) {
+            const auto &pair = resolvedCriticalPairs.back();
+
+            llvm::dbgs() << "$ Overlapping rules: (#" << i << ") ";
+            llvm::dbgs() << lhs << "\n";
+            llvm::dbgs() << "                -vs- (#" << j << ") ";
+            llvm::dbgs() << rhs << ":\n";
+            llvm::dbgs() << "$$ First term of critical pair is "
+                         << pair.first << "\n";
+            llvm::dbgs() << "$$ Second term of critical pair is "
+                         << pair.second << "\n\n";
+          }
+        });
+
+        ++from;
       }
-      continue;
     }
 
-    MutableTerm first, second;
+    again = false;
+    for (const auto &pair : resolvedCriticalPairs) {
+      // Check if we've already done too much work.
+      if (Rules.size() > maxIterations)
+        return std::make_pair(CompletionResult::MaxIterations, steps);
 
-    // We have a critical pair (X, Y).
-    std::tie(first, second) = *pair;
+      if (!addRule(pair.first, pair.second))
+        continue;
 
-    if (DebugCompletion) {
-      llvm::dbgs() << "$$ First term of critical pair is " << first << "\n";
-      llvm::dbgs() << "$$ Second term of critical pair is " << second << "\n\n";
+      // Check if the new rule is too long.
+      if (Rules.back().getDepth() > maxDepth)
+        return std::make_pair(CompletionResult::MaxDepth, steps);
+
+      // Only count a 'step' once we add a new rule.
+      ++steps;
+      again = true;
     }
-    unsigned i = Rules.size();
 
-    // Try to repair the confluence violation by adding a new rule
-    // X == Y.
-    if (!addRule(first, second))
-      continue;
-
-    // Only count a 'step' once we add a new rule.
-    ++steps;
-
-    const auto &newRule = Rules[i];
-    if (newRule.getDepth() > maxDepth)
-      return std::make_pair(CompletionResult::MaxDepth, steps);
-
-    // If this new rule merges any associated types, process the merge now
+    // If the added rules merged any associated types, process the merges now
     // before we continue with the completion procedure. This is important
     // to perform incrementally since merging is required to repair confluence
     // violations.
     processMergedAssociatedTypes();
-  }
+  } while (again);
 
   return std::make_pair(CompletionResult::Success, steps);
 }

--- a/lib/AST/RequirementMachine/Term.h
+++ b/lib/AST/RequirementMachine/Term.h
@@ -25,16 +25,6 @@ namespace swift {
 
 namespace rewriting {
 
-/// See the implementation of MutableTerm::checkForOverlap() for a discussion.
-enum class OverlapKind {
-  /// Terms do not overlap.
-  None,
-  /// First kind of overlap (TUV vs U).
-  First,
-  /// Second kind of overlap (TU vs UV).
-  Second
-};
-
 /// A term is a sequence of one or more symbols.
 ///
 /// The Term type is a uniqued, permanently-allocated representation,
@@ -76,10 +66,6 @@ public:
   }
 
   static Term get(const MutableTerm &term, RewriteContext &ctx);
-
-  OverlapKind checkForOverlap(Term other,
-                              MutableTerm &t,
-                              MutableTerm &v) const;
 
   ArrayRef<const ProtocolDecl *> getRootProtocols() const {
     return begin()->getRootProtocols();
@@ -144,6 +130,11 @@ public:
 
   void append(const MutableTerm &other) {
     Symbols.append(other.begin(), other.end());
+  }
+
+  void append(decltype(Symbols)::const_iterator from,
+              decltype(Symbols)::const_iterator to) {
+    Symbols.append(from, to);
   }
 
   int compare(const MutableTerm &other, const ProtocolGraph &protos) const;

--- a/lib/AST/RequirementMachine/Trie.h
+++ b/lib/AST/RequirementMachine/Trie.h
@@ -13,7 +13,7 @@
 #ifndef SWIFT_RQM_TRIE_H
 #define SWIFT_RQM_TRIE_H
 
-#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/MapVector.h"
 #include "Histogram.h"
 
 namespace swift {
@@ -36,7 +36,7 @@ public:
   };
 
   struct Node {
-    llvm::SmallDenseMap<Symbol, Entry, 1> Entries;
+    llvm::SmallMapVector<Symbol, Entry, 1> Entries;
   };
 
 private:
@@ -133,6 +133,53 @@ public:
         return bestMatch;
 
       node = entry.Children;
+    }
+  }
+
+  /// Find all keys that either match a prefix of [begin,end), or where
+  /// [begin,end) matches a prefix of the key. Fn must take a single
+  /// argument of type ValueType.
+  template<typename Iter, typename Fn>
+  void findAll(Iter begin, Iter end, Fn fn) {
+    assert(begin != end);
+    auto *node = &Root;
+
+    while (true) {
+      auto found = node->Entries.find(*begin);
+      ++begin;
+
+      if (found == node->Entries.end())
+        return;
+
+      const auto &entry = found->second;
+
+      if (entry.Value)
+        fn(*entry.Value);
+
+      if (entry.Children == nullptr)
+        return;
+
+      node = entry.Children;
+
+      if (begin == end) {
+        visitChildren(node, fn);
+        return;
+      }
+    }
+  }
+
+private:
+  /// Depth-first traversal of all children of the given node, including
+  /// the node itself. Fn must take a single argument of type ValueType.
+  template<typename Fn>
+  void visitChildren(Node *node, Fn fn) {
+    for (const auto &pair : node->Entries) {
+      const auto &entry = pair.second;
+      if (entry.Value)
+        fn(*entry.Value);
+
+      if (entry.Children)
+        visitChildren(entry.Children, fn);
     }
   }
 };

--- a/lib/AST/RequirementMachine/Trie.h
+++ b/lib/AST/RequirementMachine/Trie.h
@@ -136,6 +136,25 @@ public:
     }
   }
 
+  /// Find all keys that begin with the given symbol. Fn must take a single
+  /// argument of type ValueType.
+  template<typename Fn>
+  void findAll(Symbol symbol, Fn fn) {
+    auto found = Root.Entries.find(symbol);
+    if (found == Root.Entries.end())
+      return;
+
+    const auto &entry = found->second;
+
+    if (entry.Value)
+      fn(*entry.Value);
+
+    if (entry.Children == nullptr)
+      return;
+
+    visitChildren(entry.Children, fn);
+  }
+
   /// Find all keys that either match a prefix of [begin,end), or where
   /// [begin,end) matches a prefix of the key. Fn must take a single
   /// argument of type ValueType.

--- a/test/Generics/unify_associated_types.swift
+++ b/test/Generics/unify_associated_types.swift
@@ -24,8 +24,8 @@ struct MergeTest<G : P1a & P2a> {}
 // CHECK-LABEL: Rewrite system: {
 // CHECK: - τ_0_0.[P2a:T] => τ_0_0.[P1a&P2a:T]
 // CHECK: - τ_0_0.[P1a:T] => τ_0_0.[P1a&P2a:T]
-// CHECK: - τ_0_0.[P1a&P2a:T].[P1:X] => τ_0_0.[P1a&P2a:T].[P1&P2:X]
 // CHECK: - [P1a&P2a:T].[P2:X] => [P1a&P2a:T].[P1&P2:X]
+// CHECK: - τ_0_0.[P1a&P2a:T].[P1:X] => τ_0_0.[P1a&P2a:T].[P1&P2:X]
 // CHECK: - [P1a&P2a:T].[P1:X] => [P1a&P2a:T].[P1&P2:X]
 // CHECK: }
 // CHECK: Property map: {


### PR DESCRIPTION
- Use the prefix trie to speed up the completion procedure's check for overlapping rules, and the processing of merged associated types
- Cache the mapping from symbols to AssociatedTypeDecls when forming a canonical type from a reduced term