### PR TITLE
[Deserialization] Do not assert on a missing witness if allowing errors

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6556,8 +6556,8 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
     } else {
       fatal(deserializedWitness.takeError());
     }
-    
-    assert(!req || isOpaque || witness ||
+
+    assert(allowCompilerErrors() || !req || isOpaque || witness ||
            req->getAttrs().hasAttribute<OptionalAttr>() ||
            req->getAttrs().isUnavailable(getContext()));
     if (!witness && !isOpaque) {

--- a/validation-test/Serialization/AllowErrors/invalid-witness.swift
+++ b/validation-test/Serialization/AllowErrors/invalid-witness.swift
@@ -1,14 +1,15 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -module-name errors -emit-module -o %t/errors.swiftmodule -experimental-allow-module-with-compiler-errors %s
+// RUN: %target-swift-frontend -module-name errors -emit-module -o %t/errors.partial.swiftmodule -experimental-allow-module-with-compiler-errors %s
+// RUN: %target-swift-frontend -merge-modules -module-name errors -emit-module -o %t/errors.swiftmodule -experimental-allow-module-with-compiler-errors %t/errors.partial.swiftmodule
 
 public protocol SomeProto {
   init(from: SomeProto)
 }
 
-struct A {}
-struct B: SomeProto {
+public struct A {}
+public struct B: SomeProto {
   let a: A
 }
 
-let thing = B(a: A())
+public let thing = B(a: A())


### PR DESCRIPTION
When allowing errors we may have serialized a requirement without a
witness, do not assert when deserializing.

Resolves rdar://81884767