### PR TITLE
[Test] Mark sr14240-symbol-in-ir-file-not-tbd-file.swift to require an executable test.

### DIFF
--- a/test/AutoDiff/compiler_crashers_fixed/sr14240-symbol-in-ir-file-not-tbd-file.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr14240-symbol-in-ir-file-not-tbd-file.swift
@@ -1,5 +1,7 @@
 // RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 
+// REQUIRES: executable_test
+
 // SR-14240: Error: symbol 'powTJfSSpSr' (powTJfSSpSr) is in generated IR file,
 // but not in TBD file.
 


### PR DESCRIPTION
Resolves: rdar://81902208