### PR TITLE
ModuleInterface: avoid omitting platform names when printing @available

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -457,7 +457,9 @@ static void printShortFormAvailable(ArrayRef<const DeclAttribute *> Attrs,
     for (auto *DA : Attrs) {
       auto *AvailAttr = cast<AvailableAttr>(DA);
       assert(AvailAttr->Introduced.hasValue());
-      if (isShortFormAvailabilityImpliedByOther(AvailAttr, Attrs))
+      // Avoid omitting available attribute when we are printing module interface.
+      if (!Options.IsForSwiftInterface &&
+          isShortFormAvailabilityImpliedByOther(AvailAttr, Attrs))
         continue;
       Printer << platformString(AvailAttr->Platform) << " "
               << AvailAttr->Introduced.getValue().getAsString() << ", ";

--- a/test/ModuleInterface/available-attr-no-collapse.swift
+++ b/test/ModuleInterface/available-attr-no-collapse.swift
@@ -1,0 +1,8 @@
+// RUN: %empty-directory(%t)
+// RUN: echo '@available(macOS 12.0, iOS 15.0, macCatalyst 15.0, *)' > %t/Foo.swift
+// RUN: echo 'public struct Foo {}' >> %t/Foo.swift
+
+// RUN: %target-swift-frontend -emit-module -emit-module-interface-path %t/Foo.swiftinterface -enable-library-evolution %t/Foo.swift
+// RUN: %FileCheck %s < %t/Foo.swiftinterface
+
+// CHECK: macCatalyst


### PR DESCRIPTION
rdar://81903124