### PR TITLE
Fix URL detection for "sip" and "service" schemes

### DIFF
--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -305,7 +305,7 @@ static const std::vector<std::string> URLProtocols = {
   // Use RegexStrURL:
   "acap", "afp", "afs", "cid", "data", "fax", "feed", "file", "ftp", "go",
   "gopher", "http", "https", "imap", "ldap", "mailserver", "mid", "modem",
-  "news", "nntp", "opaquelocktoken", "pop", "prospero", "rdar", "rtsp", "service"
+  "news", "nntp", "opaquelocktoken", "pop", "prospero", "rdar", "rtsp", "service",
   "sip", "soap.beep", "soap.beeps", "tel", "telnet", "tip", "tn3270", "urn",
   "vemmi", "wais", "xcdoc", "z39.50r","z39.50s",
 

--- a/test/IDE/coloring_comments.swift
+++ b/test/IDE/coloring_comments.swift
@@ -76,6 +76,11 @@ func test5() -> Int {
 // CHECK: <comment-line>// <comment-url>http://whatever.com/what-ever</comment-url></comment-line>
 // http://whatever.com/what-ever
 
+// service://example.com
+// sip://example.com
+// CHECK: <comment-line>// <comment-url>service://example.com</comment-url></comment-line>
+// CHECK: <comment-line>// <comment-url>sip://example.com</comment-url></comment-line>
+
 /// Brief.
 ///
 /// Simple case.


### PR DESCRIPTION
We were concatenating these strings due to the missing comma. Found by
clang-tidy.
