### PR TITLE
[5.5] ModuleInterface: avoid omitting platform names when printing @available

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -425,7 +425,9 @@ static void printShortFormAvailable(ArrayRef<const DeclAttribute *> Attrs,
     for (auto *DA : Attrs) {
       auto *AvailAttr = cast<AvailableAttr>(DA);
       assert(AvailAttr->Introduced.hasValue());
-      if (isShortFormAvailabilityImpliedByOther(AvailAttr, Attrs))
+      // Avoid omitting available attribute when we are printing module interface.
+      if (!Options.IsForSwiftInterface &&
+          isShortFormAvailabilityImpliedByOther(AvailAttr, Attrs))
         continue;
       Printer << platformString(AvailAttr->Platform) << " "
               << AvailAttr->Introduced.getValue().getAsString() << ", ";

--- a/test/ModuleInterface/available-attr-no-collapse.swift
+++ b/test/ModuleInterface/available-attr-no-collapse.swift
@@ -1,0 +1,8 @@
+// RUN: %empty-directory(%t)
+// RUN: echo '@available(macOS 12.0, iOS 15.0, macCatalyst 15.0, *)' > %t/Foo.swift
+// RUN: echo 'public struct Foo {}' >> %t/Foo.swift
+
+// RUN: %target-swift-frontend -emit-module -emit-module-interface-path %t/Foo.swiftinterface -enable-library-evolution %t/Foo.swift
+// RUN: %FileCheck %s < %t/Foo.swiftinterface
+
+// CHECK: macCatalyst


### PR DESCRIPTION
When printing module interfaces, the Swift compiler used to omit explicit @available attribute for macCatalyst if the introducing OS version number is identical to that of the iOS @available attribute. This is problematic when adding @_originallyDefinedIn attribute for macCatalyst to an interface because the compiler will then complain about missing availability information for macCatalyst. This PR teaches the compiler to always print explicit @available attributes for all platforms in module interfaces.

rdar://81903124
