### PR TITLE
[ResultBuilders] Improve diagnostics of unsupported variable declarations

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5886,7 +5886,7 @@ ERROR(result_builder_requires_explicit_var_initialization,none,
       "local variable%select{| '%1'}0 requires explicit initializer to be used with "
       "result builder %2", (bool, StringRef, DeclName))
 ERROR(cannot_declare_computed_var_in_result_builder,none,
-      "cannot declare local %select{lazy|wrapped|computed}0 variable "
+      "cannot declare local %select{lazy|wrapped|computed|observed}0 variable "
       "in result builder", (unsigned))
 
 //------------------------------------------------------------------------------

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5885,6 +5885,9 @@ NOTE(result_builder_missing_build_limited_availability, none,
 ERROR(result_builder_requires_explicit_var_initialization,none,
       "local variable%select{| '%1'}0 requires explicit initializer to be used with "
       "result builder %2", (bool, StringRef, DeclName))
+ERROR(cannot_declare_computed_var_in_result_builder,none,
+      "cannot declare local %select{lazy|wrapped|computed}0 variable "
+      "in result builder", (unsigned))
 
 //------------------------------------------------------------------------------
 // MARK: Tuple Shuffle Diagnostics

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5882,6 +5882,9 @@ NOTE(result_builder_missing_build_array, none,
 NOTE(result_builder_missing_build_limited_availability, none,
      "add 'buildLimitedAvailability(_:)' to the result "
      "builder %0 to erase type information for less-available types", (Type))
+ERROR(result_builder_requires_explicit_var_initialization,none,
+      "local variable%select{| '%1'}0 requires explicit initializer to be used with "
+      "result builder %2", (bool, StringRef, DeclName))
 
 //------------------------------------------------------------------------------
 // MARK: Tuple Shuffle Diagnostics

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5877,7 +5877,8 @@ bool SkipUnhandledConstructInResultBuilderFailure::diagnosePatternBinding(
   for (unsigned i : range(PB->getNumPatternEntries())) {
     auto *pattern = PB->getPattern(i);
 
-    // Each variable bound by the pattern must be stored.
+    // Each variable bound by the pattern must be stored and cannot have
+    // observers.
     {
       SmallVector<VarDecl *, 8> variables;
       pattern->collectVariables(variables);
@@ -5917,7 +5918,7 @@ bool SkipUnhandledConstructInResultBuilderFailure::diagnosePatternBinding(
 
 bool SkipUnhandledConstructInResultBuilderFailure::diagnoseStorage(
     VarDecl *var) const {
-  enum class PropertyKind : unsigned { lazy, wrapped, computed };
+  enum class PropertyKind : unsigned { lazy, wrapped, computed, observed };
 
   if (var->getImplInfo().isSimpleStored())
     return false;
@@ -5927,6 +5928,8 @@ bool SkipUnhandledConstructInResultBuilderFailure::diagnoseStorage(
     kind = PropertyKind::lazy;
   } else if (var->hasAttachedPropertyWrapper()) {
     kind = PropertyKind::wrapped;
+  } else if (var->hasObservers()) {
+    kind = PropertyKind::observed;
   } else {
     kind = PropertyKind::computed;
   }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1862,6 +1862,13 @@ public:
 
   bool diagnoseAsError() override;
   bool diagnoseAsNote() override;
+
+private:
+  /// Tailored diagnostics for an unsupported variable declaration.
+  bool diagnosePatternBinding(PatternBindingDecl *PB) const;
+
+  /// Tailored diagnostics for lazy/wrapped/computed variable declarations.
+  bool diagnoseStorage(VarDecl *var) const;
 };
 
 /// Diagnose situation when a single "tuple" parameter is given N arguments e.g.

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -6,7 +6,7 @@ enum Either<T,U> {
 }
 
 @resultBuilder
-struct TupleBuilder { // expected-note 2 {{struct 'TupleBuilder' declared here}}
+struct TupleBuilder { // expected-note 3 {{struct 'TupleBuilder' declared here}}
   static func buildBlock() -> () { }
   
   static func buildBlock<T1>(_ t1: T1) -> T1 {
@@ -99,8 +99,16 @@ func testDiags() {
   tuplify(true) { _ in
     17
     let x = 17
-    let y: Int // expected-error{{closure containing a declaration cannot be used with result builder 'TupleBuilder'}}
+    let y: Int // expected-error{{local variable 'y' requires explicit initializer to be used with result builder 'TupleBuilder'}} {{15-15= = <#value#>}}
     x + 25
+  }
+
+  tuplify(true) { _ in
+    17
+    let y: Int, z: String
+    // expected-error@-1 {{local variable 'y' requires explicit initializer to be used with result builder 'TupleBuilder'}} {{15-15= = <#value#>}}
+    // expected-error@-2 {{local variable 'z' requires explicit initializer to be used with result builder 'TupleBuilder'}} {{26-26= = <#value#>}}
+    y + 25
   }
 
   // Statements unsupported by the particular builder.

--- a/test/Constraints/result_builder_invalid_vars.swift
+++ b/test/Constraints/result_builder_invalid_vars.swift
@@ -20,7 +20,7 @@ dummy {
 }
 
 dummy {
-  var observedVar: Int = 123 { // expected-error {{closure containing a declaration cannot be used with result builder 'DummyBuilder'}}
+  var observedVar: Int = 123 { // expected-error {{cannot declare local observed variable in result builder}}
     didSet {}
   }
 
@@ -28,7 +28,7 @@ dummy {
 }
 
 dummy {
-  var observedVar: Int = 123 { // expected-error {{closure containing a declaration cannot be used with result builder 'DummyBuilder'}}
+  var observedVar: Int = 123 { // expected-error {{cannot declare local observed variable in result builder}}
     willSet {}
   }
 

--- a/test/Constraints/result_builder_invalid_vars.swift
+++ b/test/Constraints/result_builder_invalid_vars.swift
@@ -10,12 +10,12 @@ struct DummyBuilder { // expected-note 5 {{struct 'DummyBuilder' declared here}}
 func dummy<T>(@DummyBuilder _: () -> T) {}
 
 dummy {
-  var computedVar: Int { return 123 } // expected-error {{closure containing a declaration cannot be used with result builder 'DummyBuilder'}}
+  var computedVar: Int { return 123 } // expected-error {{cannot declare local computed variable in result builder}}
   ()
 }
 
 dummy {
-  lazy var lazyVar: Int = 123 // expected-error {{closure containing a declaration cannot be used with result builder 'DummyBuilder'}}
+  lazy var lazyVar: Int = 123 // expected-error {{cannot declare local lazy variable in result builder}}
   ()
 }
 
@@ -40,7 +40,7 @@ dummy {
 }
 
 dummy {
-  @Wrapper var wrappedVar: Int = 123 // expected-error {{closure containing a declaration cannot be used with result builder 'DummyBuilder'}}
+  @Wrapper var wrappedVar: Int = 123 // expected-error {{cannot declare local wrapped variable in result builder}}
   ()
 }
 


### PR DESCRIPTION
Tailored diagnostics for:

- Declarations without explicit initializer
- `lazy`, wrapped (e.g. `@Wrapper var x: Int`), and computed variable declarations
- variables with observers

Resolves: rdar://81532339

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
