### PR TITLE
[5.5][Async Refactoring] Handle multiple trailing closures

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -7005,20 +7005,26 @@ private:
         Scopes.back().Names.insert(ArgName);
         OS << tok::kw_guard << ' ' << tok::kw_let << ' ' << ArgName << ' '
            << tok::equal << ' ';
+
+        // If the argument is a call with a trailing closure, the generated
+        // guard statement will not compile.
+        // e.g. 'guard let result1 = value.map { $0 + 1 } else { ... }'
+        // doesn't compile. Adding parentheses makes the code compile.
+        auto HasTrailingClosure = false;
+        if (auto *CE = dyn_cast<CallExpr>(Arg)) {
+          if (CE->getUnlabeledTrailingClosureIndex().hasValue())
+            HasTrailingClosure = true;
+        }
+
+        if (HasTrailingClosure)
+          OS << tok::l_paren;
+
         convertNode(Arg, /*StartOverride=*/CE->getArgumentLabelLoc(ArgIndex),
                     /*ConvertCalls=*/false);
-        if (auto CE = dyn_cast<CallExpr>(Arg)) {
-          if (CE->hasTrailingClosure()) {
-            // If the argument is a call with trailing closure, the generated
-            // guard statement does not compile.
-            // e.g. 'guard let result1 = value.map { $0 + 1 } else { ... }'
-            // doesn't compile.
-            // Adding a '.self' at the end makes the code compile (although it
-            // will still issue a warning about a trailing closure use inside a
-            // guard condition).
-            OS << tok::period << tok::kw_self;
-          }
-        }
+
+        if (HasTrailingClosure)
+          OS << tok::r_paren;
+
         OS << ' ' << tok::kw_else << ' ' << tok::l_brace << '\n';
         OS << "fatalError" << tok::l_paren;
         OS << "\"Expected non-nil result ";

--- a/test/refactoring/ConvertAsync/convert_to_continuation.swift
+++ b/test/refactoring/ConvertAsync/convert_to_continuation.swift
@@ -12,6 +12,8 @@ func withoutAsyncAlternativeThrowingWithMultipleResults(closure: @escaping (Int?
 func asyncVoidWithoutAlternative(completionHandler2: @escaping () -> Void) {}
 func resultWithoutAlternative(completionHandler2: @escaping (Result<Int, Error>) -> Void) {}
 
+func lottaClosures(x: () -> Void, y: () -> Void) -> Int? { nil }
+
 struct MyError: Error {}
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=CREATE-CONTINUATION %s
@@ -185,7 +187,7 @@ func testThrowingContinuationRelayingErrorAndComplexResultWithTrailingClosure(co
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:       if let error = theError {
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:         continuation.resume(throwing: error)
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:       } else {
-// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:         guard let result = theValue.map { $0 + 1 }.self else {
+// THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:         guard let result = (theValue.map { $0 + 1 }) else {
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:           fatalError("Expected non-nil result in the non-error case")
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:         }
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:         continuation.resume(returning: result)
@@ -193,6 +195,27 @@ func testThrowingContinuationRelayingErrorAndComplexResultWithTrailingClosure(co
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:     }
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT:   }
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE-NEXT: }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MULTIPLE-TRAILING-CLOSURES %s
+func testThrowingContinuationRelayingErrorAndComplexResultWithMultipleTrailingClosures(completionHandler: @escaping (Int?, Error?) -> Void) {
+  withoutAsyncAlternativeThrowing { theValue, theError in
+    completionHandler(lottaClosures {} y: {}, theError)
+  }
+}
+// MULTIPLE-TRAILING-CLOSURES:      func testThrowingContinuationRelayingErrorAndComplexResultWithMultipleTrailingClosures() async throws -> Int {
+// MULTIPLE-TRAILING-CLOSURES-NEXT:   return try await withCheckedThrowingContinuation { continuation in
+// MULTIPLE-TRAILING-CLOSURES-NEXT:     withoutAsyncAlternativeThrowing { theValue, theError in
+// MULTIPLE-TRAILING-CLOSURES-NEXT:       if let error = theError {
+// MULTIPLE-TRAILING-CLOSURES-NEXT:         continuation.resume(throwing: error)
+// MULTIPLE-TRAILING-CLOSURES-NEXT:       } else {
+// MULTIPLE-TRAILING-CLOSURES-NEXT:         guard let result = (lottaClosures {} y: {}) else {
+// MULTIPLE-TRAILING-CLOSURES-NEXT:           fatalError("Expected non-nil result in the non-error case")
+// MULTIPLE-TRAILING-CLOSURES-NEXT:         }
+// MULTIPLE-TRAILING-CLOSURES-NEXT:         continuation.resume(returning: result)
+// MULTIPLE-TRAILING-CLOSURES-NEXT:       }
+// MULTIPLE-TRAILING-CLOSURES-NEXT:     }
+// MULTIPLE-TRAILING-CLOSURES-NEXT:   }
+// MULTIPLE-TRAILING-CLOSURES-NEXT: }
 
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=THROWING-CONTINUATION-ALWAYS-RETURNING-ERROR-AND-RESULT %s
 func testAlwaysReturnBothResultAndCompletionHandler(completionHandler: @escaping (Int?, Error?) -> Void) {

--- a/test/refactoring/ConvertAsync/convert_to_continuation.swift
+++ b/test/refactoring/ConvertAsync/convert_to_continuation.swift
@@ -173,7 +173,7 @@ func testThrowingContinuationRelayingErrorAndTwoComplexResults(completionHandler
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT:   }
 // THROWING-CONTINUATION-RELAYING-ERROR-AND-TWO-COMPLEX-RESULTS-NEXT: }
 
-// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE %s
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=THROWING-CONTINUATION-RELAYING-ERROR-AND-COMPLEX-RESULT-WITH-TRAILING-CLOSURE %s
 func testThrowingContinuationRelayingErrorAndComplexResultWithTrailingClosure(completionHandler: @escaping (Int?, Error?) -> Void) {
   withoutAsyncAlternativeThrowing { (theValue, theError) in
     completionHandler(theValue.map { $0 + 1 }, theError)


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/38674

---

[Async Refactoring] Handle multiple trailing closures

Update the trailing closure handling logic to
handle multiple trailing closures, and adjust the
refactoring output to surround the call in
parentheses rather than adding '.self'. This allows
the parser to deal with the multiple trailing
closures and also silences a warning that would
previously occur.

rdar://81230908