### PR TITLE
ASTPrinter: print public inherited protocols of the skipped private protocols

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -5742,10 +5742,9 @@ swift::getInheritedForPrinting(
 
   // Collect synthesized conformances.
   auto &ctx = decl->getASTContext();
+  llvm::SetVector<ProtocolDecl *> protocols;
   for (auto attr : decl->getAttrs().getAttributes<SynthesizedProtocolAttr>()) {
     if (auto *proto = ctx.getProtocol(attr->getProtocolKind())) {
-      if (!options.shouldPrint(proto))
-        continue;
       // The SerialExecutor conformance is only synthesized on the root
       // actor class, so we can just test resilience immediately.
       if (proto->isSpecificProtocol(KnownProtocolKind::SerialExecutor) &&
@@ -5755,9 +5754,28 @@ swift::getInheritedForPrinting(
           isa<EnumDecl>(decl) &&
           cast<EnumDecl>(decl)->hasRawType())
         continue;
-      Results.push_back({TypeLoc::withoutLoc(proto->getDeclaredInterfaceType()),
-                      /*isUnchecked=*/false});
+      protocols.insert(proto);
     }
+  }
+
+  for (size_t i = 0; i < protocols.size(); i++) {
+    auto proto = protocols[i];
+
+    if (!options.shouldPrint(proto)) {
+      // If private stdlib protocols are skipped and this is a private stdlib
+      // protocol, see if any of its inherited protocols are public. Those
+      // protocols can affect the user-visible behavior of the declaration, and
+      // should be printed.
+      if (options.SkipPrivateStdlibDecls &&
+          proto->isPrivateStdlibDecl(!options.SkipUnderscoredStdlibProtocols)) {
+        auto inheritedProtocols = proto->getInheritedProtocols();
+        protocols.insert(inheritedProtocols.begin(), inheritedProtocols.end());
+      }
+      continue;
+    }
+
+    Results.push_back({TypeLoc::withoutLoc(proto->getDeclaredInterfaceType()),
+                       /*isUnchecked=*/false});
   }
 }
 

--- a/test/ClangImporter/enum-error.swift
+++ b/test/ClangImporter/enum-error.swift
@@ -14,6 +14,8 @@
 // RUN: echo '#include "enum-error.h"' > %t.m
 // RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/enum-error.h -import-objc-header %S/Inputs/enum-error.h -print-regular-comments --cc-args %target-cc-options -fsyntax-only %t.m -I %S/Inputs > %t.txt
 // RUN: %FileCheck -check-prefix=HEADER %s < %t.txt
+// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/enum-error.h -import-objc-header %S/Inputs/enum-error.h -print-regular-comments --skip-private-stdlib-decls -skip-underscored-stdlib-protocols --cc-args %target-cc-options -fsyntax-only %t.m -I %S/Inputs > %t2.txt
+// RUN: %FileCheck -check-prefix=HEADER-NO-PRIVATE %s < %t2.txt
 
 import Foundation
 
@@ -121,12 +123,25 @@ class ObjCTest {
 }
 #endif
 
-// HEADER: enum Code : Int32, _ErrorCodeProtocol {
-// HEADER:   init?(rawValue: Int32)
-// HEADER:   var rawValue: Int32 { get }
-// HEADER:   typealias _ErrorType = TestError
-// HEADER:   case TENone
-// HEADER:   case TEOne
-// HEADER:   case TETwo
+// HEADER: struct TestError : _BridgedStoredNSError {
+// HEADER:   enum Code : Int32, _ErrorCodeProtocol {
+// HEADER:     init?(rawValue: Int32)
+// HEADER:     var rawValue: Int32 { get }
+// HEADER:     typealias _ErrorType = TestError
+// HEADER:     case TENone
+// HEADER:     case TEOne
+// HEADER:     case TETwo
+// HEADER:   }
 // HEADER: }
 // HEADER: func getErr() -> TestError.Code
+
+// HEADER-NO-PRIVATE: struct TestError : CustomNSError, Hashable, Error {
+// HEADER-NO-PRIVATE:   enum Code : Int32, Equatable {
+// HEADER-NO-PRIVATE:     init?(rawValue: Int32)
+// HEADER-NO-PRIVATE:     var rawValue: Int32 { get }
+// HEADER-NO-PRIVATE:     typealias _ErrorType = TestError
+// HEADER-NO-PRIVATE:     case TENone
+// HEADER-NO-PRIVATE:     case TEOne
+// HEADER-NO-PRIVATE:     case TETwo
+// HEADER-NO-PRIVATE:   }
+// HEADER-NO-PRIVATE: }

--- a/test/SourceKit/DocSupport/doc_error_domain.swift
+++ b/test/SourceKit/DocSupport/doc_error_domain.swift
@@ -3,8 +3,8 @@
 // RUN:         -sdk %sdk | %sed_clean > %t.response
 // RUN: %FileCheck -input-file=%t.response %s
 
-// CHECK: struct MyError {
-// CHECK:     enum Code : Int32 {
+// CHECK: struct MyError : CustomNSError, Hashable, Error {
+// CHECK:     enum Code : Int32, Equatable {
 // CHECK:         case errFirst
 // CHECK:         case errSecond
 // CHECK:     }


### PR DESCRIPTION
When printing the list of inherited protocols in the module interface, if private stdlib protocols are requested to be hidden (`PrintOptions::SkipUnderscoredStdlibProtocols`), make sure to print public inherited protocols of the hidden protocols.

This is especially noticeable for `NSError` types imported into Swift. For example, `CocoaError` is imported with a synthesized conformance to `_BridgedStoredNSError`, however, in the module interface generated by SourceKit, `_BridgedStoredNSError` is currently hidden from the inheritance list:
```swift
/// Describes errors within the Cocoa error domain.
public struct CocoaError {
    // ...
}
```
There is no indication in the module interface that `CocoaError` is an `Error` and can be thrown. This might cause confusion for someone reading the module interface, and for static analysis tools relying on it.

This change improves the module interface generation for synthesized conformances, so that the inheritance list contains all the public conformances that can be observed by the user. For `CocoaError`, we would now see this:
```swift
/// Describes errors within the Cocoa error domain.
public struct CocoaError : CustomNSError, Hashable, Error {
    // ...
}
```

