### PR TITLE
[Index] Apply RelationContainedBy role to references contained by VarDecl.

### DIFF
--- a/include/swift/IDE/SourceEntityWalker.h
+++ b/include/swift/IDE/SourceEntityWalker.h
@@ -88,6 +88,14 @@ public:
   /// false, the remaining traversal is terminated and returns failure.
   virtual bool walkToDeclPost(Decl *D) { return true; }
 
+  /// This method is called in AST order, unlike \c walkToDecl* which are called
+  /// in source order. It is guaranteed to be called in balance with its
+  /// counterpart \c endBalancedASTOrderDeclVisit.
+  virtual void beginBalancedASTOrderDeclVisit(Decl *D){};
+
+  /// This method is called after declaration visitation in AST order.
+  virtual void endBalancedASTOrderDeclVisit(Decl *D){};
+
   /// This method is called when first visiting a statement, before walking into
   /// its children.  If it returns false, the subtree is skipped.
   virtual bool walkToStmtPre(Stmt *S) { return true; }
@@ -111,6 +119,15 @@ public:
   /// This method is called after visiting the children of a pattern. If it
   /// returns false, the remaining traversal is terminated and returns failure.
   virtual bool walkToPatternPost(Pattern *P) { return true; }
+
+  /// This method is called when first visiting a type representation, before
+  /// walking into its children. If it returns false, the subtree is skipped.
+  virtual bool walkToTypeReprPre(TypeRepr *T) { return true; }
+
+  /// This method is called after visiting the children of a type
+  /// representation. If it returns false, the remaining traversal is terminated
+  /// and returns failure.
+  virtual bool walkToTypeReprPost(TypeRepr *T) { return true; }
 
   /// This method is called when a ValueDecl is referenced in source. If it
   /// returns false, the remaining traversal is terminated and returns failure.

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/GenericParamList.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/Pattern.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/TypeRepr.h"
@@ -145,6 +146,275 @@ struct IndexedWitness {
   ValueDecl *Requirement;
 };
 
+/// Identifies containers along with the types and expressions to which they
+/// correspond.
+///
+/// The simplest form of a container is an function, it becomes the active
+/// container immediately when it's visited. Pattern bindings however are more
+/// complex, as their lexical structure does not translate directly into
+/// container semantics.
+///
+/// Given the tuple binding 'let (a, b): (Int, String) = (intValue,
+/// stringValue)' we can see that 'a' corresponds to 'Int' and 'intValue',
+/// while 'b' corresponds to 'String' and 'stringValue'. By identifying these
+/// relationships, we can pinpoint locations within the PatternBindingDecl
+/// that the corresponding VarDecl should be marked as the current active
+/// container. For example, when we walk to the TypeRepr for 'Int', we can
+/// make 'a' the current active container, and likewise for 'String', 'b'. And
+/// thus, when the walk reaches the point of creating the reference for 'Int'
+/// it will be contained by 'a'.
+///
+/// These locations are also identified for single named pattern bindings; in
+/// which case, the VarDecl is activated for all types and expressions with
+/// the pattern.
+///
+/// Pattern bindings containing an AnyPattern (i.e let _) are a special case,
+/// as they have no VarDecl. Their types and expressions are associated with
+/// the current active container, if any. Therefore, given such a pattern
+/// declared within a function, the type and expression references will be
+/// contained by the function. If there is no active container, the references
+/// are not contained.
+class ContainerTracker {
+  typedef llvm::PointerUnion<const VarDecl *, const TuplePattern *>
+      PatternElement;
+  typedef llvm::PointerUnion<const Decl *, const Pattern *> Container;
+  typedef const void *ActivationKey;
+
+  struct StackEntry {
+    const Decl *TrackedDecl = nullptr;
+    ActivationKey ActiveKey = nullptr;
+    llvm::DenseMap<ActivationKey, Container> Containers{};
+  };
+
+  SmallVector<StackEntry, 4> Stack;
+
+public:
+  void beginTracking(Decl *D) {
+    if (auto PBD = dyn_cast<PatternBindingDecl>(D)) {
+      StackEntry Entry = identifyContainers(PBD);
+      Stack.push_back(std::move(Entry));
+    } else if (isa<AbstractFunctionDecl>(D)) {
+      StackEntry Entry;
+      Entry.TrackedDecl = D;
+      Entry.ActiveKey = D;
+      Entry.Containers[D] = D;
+      Stack.push_back(std::move(Entry));
+    }
+  }
+
+  void endTracking(Decl *D) {
+    if (Stack.empty())
+      return;
+    if (Stack.back().TrackedDecl == D)
+      Stack.pop_back();
+  }
+
+  bool empty() const { return Stack.empty(); }
+
+  void forEachActiveContainer(llvm::function_ref<void(const Decl *)> f) const {
+    if (Stack.empty())
+      return;
+
+    const StackEntry &Entry = Stack.back();
+
+    if (!Entry.ActiveKey)
+      return;
+
+    auto MapEntry = Entry.Containers.find(Entry.ActiveKey);
+
+    if (MapEntry == Entry.Containers.end())
+      return;
+
+    Container C = MapEntry->second;
+
+    if (auto *D = C.dyn_cast<const Decl *>()) {
+      f(D);
+    } else if (auto *P = C.dyn_cast<const Pattern *>()) {
+      P->forEachVariable([&](VarDecl *VD) { f(VD); });
+    }
+  }
+
+  void activateContainersFor(ActivationKey K) {
+    if (Stack.empty())
+      return;
+
+    StackEntry &Entry = Stack.back();
+
+    // Only activate the ActivationKey if there's an entry in the Containers.
+    if (Entry.Containers.count(K))
+      Entry.ActiveKey = K;
+  }
+
+private:
+  StackEntry identifyContainers(const PatternBindingDecl *PBD) const {
+    StackEntry Entry;
+    Entry.TrackedDecl = PBD;
+
+    if (auto *VD = PBD->getSingleVar()) {
+      // This is a single var binding; therefore, it may also have custom
+      // attributes. Immediately activate the VarDecl so that it can be the
+      // container for the attribute references.
+      Entry.ActiveKey = PBD;
+      Entry.Containers[PBD] = VD;
+    }
+
+    for (auto Index : range(PBD->getNumPatternEntries())) {
+      Pattern *P = PBD->getPattern(Index);
+      if (!P)
+        continue;
+
+      TypeRepr *PatternTypeRepr = nullptr;
+      Expr *PatternInitExpr = nullptr;
+
+      if (auto *TP = dyn_cast<TypedPattern>(P)) {
+        if (auto *TR = TP->getTypeRepr()) {
+          if (auto *TTR = dyn_cast<TupleTypeRepr>(TR)) {
+            PatternTypeRepr = TTR;
+          } else {
+            // Non-tuple type, associate all elements in this pattern with the
+            // type.
+            associateAllPatternElements(P, TR, Entry);
+          }
+        }
+      }
+
+      if (auto *InitExpr = PBD->getInit(Index)) {
+        if (auto *TE = dyn_cast<TupleExpr>(InitExpr)) {
+          PatternInitExpr = TE;
+        } else {
+          // Non-tuple initializer, associate all elements in this pattern with
+          // the initializer.
+          associateAllPatternElements(P, InitExpr, Entry);
+        }
+      }
+
+      if (PatternTypeRepr || PatternInitExpr) {
+        forEachPatternElementPreservingIndex(
+            P, [&](PatternElement Element, size_t Index) {
+              associatePatternElement(Element, Index, PatternTypeRepr,
+                                      PatternInitExpr, Entry);
+            });
+      }
+    }
+
+    return Entry;
+  }
+
+  void associatePatternElement(PatternElement Element, size_t Index,
+                               TypeRepr *TR, Expr *E, StackEntry &Entry) const {
+    if (auto *TTR = dyn_cast_or_null<TupleTypeRepr>(TR)) {
+      TR = TTR->getElementType(Index);
+    }
+
+    if (auto *TE = dyn_cast_or_null<TupleExpr>(E)) {
+      E = TE->getElement(Index);
+    }
+
+    if (!Element) {
+      // This element is represents an AnyPattern (i.e let _).
+      if (TR)
+        associateAnyPattern(TR, Entry);
+
+      if (E)
+        associateAnyPattern(E, Entry);
+
+      return;
+    }
+
+    if (auto *VD = Element.dyn_cast<const VarDecl *>()) {
+      if (TR)
+        Entry.Containers[TR] = VD;
+
+      if (E)
+        Entry.Containers[E] = VD;
+    } else if (auto *TP = Element.dyn_cast<const TuplePattern *>()) {
+      forEachPatternElementPreservingIndex(
+          TP, [&](PatternElement Element, size_t Index) {
+            associatePatternElement(Element, Index, TR, E, Entry);
+          });
+    }
+  }
+
+  // AnyPatterns behave differently to other patterns as they've no associated
+  // VarDecl. The given ActivationKey is therefore associated with the current
+  // active container, if any.
+  void associateAnyPattern(ActivationKey K, StackEntry &Entry) const {
+    Entry.Containers[K] = activeContainer();
+  }
+
+  Container activeContainer() const {
+    if (Stack.empty())
+      return nullptr;
+
+    const StackEntry &Entry = Stack.back();
+
+    if (Entry.ActiveKey) {
+      auto ActiveContainer = Entry.Containers.find(Entry.ActiveKey);
+
+      if (ActiveContainer != Entry.Containers.end())
+        return ActiveContainer->second;
+    }
+
+    return nullptr;
+  }
+
+  void associateAllPatternElements(const Pattern *P, ActivationKey K,
+                                   StackEntry &Entry) const {
+    if (isAnyPattern(P)) {
+      // This pattern consists of a single AnyPattern (i.e let _).
+      associateAnyPattern(K, Entry);
+    } else {
+      Entry.Containers[K] = P;
+    }
+  }
+
+  /// Enumerates elements within a Pattern while preserving their source
+  /// location. Given the pattern binding 'let (a, _, (b, c)) = ...' the given
+  /// function is called with the following values:
+  ///
+  /// VarDecl(a), 0
+  /// nullptr, 1
+  /// TuplePattern(b, c), 2
+  ///
+  /// Here nullptr represents the location of an AnyPattern, for which there
+  /// is no associated VarDecl.
+  void forEachPatternElementPreservingIndex(
+      const Pattern *P,
+      llvm::function_ref<void(PatternElement, size_t)> f) const {
+    auto *SP = P->getSemanticsProvidingPattern();
+
+    if (auto *TP = dyn_cast<TuplePattern>(SP)) {
+      for (size_t Index = 0; Index < TP->getNumElements(); ++Index) {
+        f(getPatternElement(TP->getElement(Index).getPattern()), Index);
+      }
+    } else {
+      f(getPatternElement(SP), 0);
+    }
+  }
+
+  PatternElement getPatternElement(const Pattern *P) const {
+    auto *SP = P->getSemanticsProvidingPattern();
+
+    if (auto *NP = dyn_cast<NamedPattern>(SP)) {
+      return NP->getDecl();
+    } else if (auto *TP = dyn_cast<TuplePattern>(SP)) {
+      return TP;
+    }
+
+    return nullptr;
+  }
+
+  bool isAnyPattern(const Pattern *P) const {
+    auto *SP = P->getSemanticsProvidingPattern();
+
+    if (isa<NamedPattern>(SP) || isa<TuplePattern>(SP)) {
+      return false;
+    }
+
+    return true;
+  }
+};
+
 class IndexSwiftASTWalker : public SourceEntityWalker {
   IndexDataConsumer &IdxConsumer;
   SourceManager &SrcMgr;
@@ -153,6 +423,7 @@ class IndexSwiftASTWalker : public SourceEntityWalker {
 
   bool IsModuleFile = false;
   bool isSystemModule = false;
+
   struct Entity {
     Decl *D;
     SymbolInfo SymInfo;
@@ -173,6 +444,7 @@ class IndexSwiftASTWalker : public SourceEntityWalker {
   llvm::DenseMap<void *, NameAndUSR> nameAndUSRCache;
   llvm::DenseMap<DeclAccessorPair, NameAndUSR> accessorNameAndUSRCache;
   StringScratchSpace stringStorage;
+  ContainerTracker Containers;
 
   bool getNameAndUSR(ValueDecl *D, ExtensionDecl *ExtD,
                      StringRef &name, StringRef &USR) {
@@ -291,6 +563,7 @@ public:
   ~IndexSwiftASTWalker() override {
     assert(Cancelled || EntitiesStack.empty());
     assert(Cancelled || ManuallyVisitedAccessorStack.empty());
+    assert(Cancelled || Containers.empty());
   }
 
   void visitModule(ModuleDecl &Mod);
@@ -334,10 +607,11 @@ private:
     return true;
   }
 
-  /// Report calls to the initializers of property wrapper types on wrapped properties.
+  /// Report calls to the initializers of property wrapper types on wrapped
+  /// properties.
   ///
   /// These may be either explicit:
-  ///     `\@Wrapper(initialialValue: 42) var x: Int`
+  ///     `\@Wrapper(initialValue: 42) var x: Int`
   /// or implicit:
   ///     `\@Wrapper var x = 10`
   bool handleCustomAttrInitRefs(Decl * D) {
@@ -426,7 +700,7 @@ private:
     if (Cancelled)
       return false;
     ExprStack.push_back(E);
-
+    Containers.activateContainersFor(E);
     handleMemberwiseInitRefs(E);
     return true;
   }
@@ -437,6 +711,28 @@ private:
     assert(ExprStack.back() == E);
     ExprStack.pop_back();
     return true;
+  }
+
+  bool walkToTypeReprPre(TypeRepr *T) override {
+    if (Cancelled)
+      return false;
+    Containers.activateContainersFor(T);
+    return true;
+  }
+
+  bool walkToPatternPre(Pattern *P) override {
+    if (Cancelled)
+      return false;
+    Containers.activateContainersFor(P);
+    return true;
+  }
+
+  void beginBalancedASTOrderDeclVisit(Decl *D) override {
+    Containers.beginTracking(D);
+  }
+
+  void endBalancedASTOrderDeclVisit(Decl *D) override {
+    Containers.endTracking(D);
   }
 
   /// Extensions redeclare all generic parameters of their extended type to add
@@ -540,9 +836,7 @@ private:
     Info.roles |= (unsigned)SymbolRole::Reference;
     Info.symInfo = getSymbolInfoForModule(Mod);
     getModuleNameAndUSR(Mod, Info.name, Info.USR);
-
-    if (auto Container = getContainingDecl())
-      addRelation(Info, (unsigned)SymbolRole::RelationContainedBy, Container);
+    addContainedByRelationIfContained(Info);
 
     if (!IdxConsumer.startSourceEntity(Info)) {
       Cancelled = true;
@@ -565,14 +859,11 @@ private:
     return nullptr;
   }
 
-  Decl *getContainingDecl() const {
-    for (const auto &Entity: EntitiesStack) {
-      if (isa<AbstractFunctionDecl>(Entity.D) &&
-          (Entity.Roles & (SymbolRoleSet)SymbolRole::Definition)) {
-        return Entity.D;
-      }
-    }
-    return nullptr;
+  void addContainedByRelationIfContained(IndexSymbol &Info) {
+    Containers.forEachActiveContainer([&](const Decl *D) {
+      addRelation(Info, (unsigned)SymbolRole::RelationContainedBy,
+                  const_cast<Decl *>(D));
+    });
   }
 
   void repressRefAtLoc(SourceLoc Loc) {
@@ -586,7 +877,6 @@ private:
       return false;
     auto &Suppressed = EntitiesStack.back().RefsToSuppress;
     return std::find(Suppressed.begin(), Suppressed.end(), Loc) != Suppressed.end();
-
   }
 
   Expr *getContainingExpr(size_t index) const {
@@ -1321,8 +1611,7 @@ bool IndexSwiftASTWalker::initIndexSymbol(ValueDecl *D, SourceLoc Loc,
 
   if (IsRef) {
     Info.roles |= (unsigned)SymbolRole::Reference;
-    if (auto Container = getContainingDecl())
-      addRelation(Info, (unsigned)SymbolRole::RelationContainedBy, Container);
+    addContainedByRelationIfContained(Info);
   } else {
     Info.roles |= (unsigned)SymbolRole::Definition;
     if (D->isImplicit())
@@ -1428,7 +1717,6 @@ bool IndexSwiftASTWalker::initFuncRefIndexSymbol(ValueDecl *D, SourceLoc Loc,
 bool IndexSwiftASTWalker::initVarRefIndexSymbols(Expr *CurrentE, ValueDecl *D,
                                                  SourceLoc Loc, IndexSymbol &Info,
                                                  Optional<AccessKind> AccKind) {
-
   if (initIndexSymbol(D, Loc, /*IsRef=*/true, Info))
     return true;
 

--- a/test/Index/Store/record-sourcefile.swift
+++ b/test/Index/Store/record-sourcefile.swift
@@ -7,12 +7,12 @@
 // CHECK: record-sourcefile.swift
 // CHECK: ------------
 // CHECK: struct/Swift | S1 | s:4file2S1V | <no-cgname> | Def,Ref,RelCont -
-// CHECK: instance-method/acc-get/Swift | getter:property | s:4file2S1V8propertySivg | <no-cgname> | Def,Ref,Call,Impl,RelChild,RelRec,RelCall,RelAcc,RelCont - 
+// CHECK: instance-method/acc-get/Swift | getter:property | s:4file2S1V8propertySivg | <no-cgname> | Def,Ref,Call,Impl,RelChild,RelRec,RelCall,RelAcc,RelCont -
 // CHECK: instance-property/Swift | property | [[property_USR:s:4file2S1V8propertySivp]] | <no-cgname> | Def,Ref,Read,RelChild,RelCont -
 // CHECK: static-method/acc-get/Swift | getter:staticProperty | s:4file2S1V14staticPropertySivgZ | <no-cgname> | Def,Ref,Call,Impl,RelChild,RelRec,RelCall,RelAcc,RelCont -
 // CHECK: static-property/Swift | staticProperty | s:{{.*}} | <no-cgname> | Def,Ref,Read,RelChild,RelCont -
 // CHECK: instance-property/Swift | computedPropertyGetSet | s:{{.*}} | <no-cgname> | Def,RelChild -
-// CHECK: struct/Swift | Int | s:Si | <no-cgname> | Ref -
+// CHECK: struct/Swift | Int | s:Si | <no-cgname> | Ref,RelCont -
 // CHECK: instance-method/acc-get/Swift | getter:computedPropertyGetSet | s:4file2S1V22computedPropertyGetSetSivg | <no-cgname> | Def,RelChild,RelAcc -
 // CHECK: instance-method/acc-set/Swift | setter:computedPropertyGetSet | s:4file2S1V22computedPropertyGetSetSivs | <no-cgname> | Def,RelChild,RelAcc -
 // CHECK: instance-property/Swift | computedPropertyWillDid | s:{{.*}} | <no-cgname> | Def,RelChild -
@@ -47,7 +47,7 @@ struct S1 {
 
 // CHECK: [[@LINE+3]]:7 | instance-property/Swift | [[computedPropertyGetSet_USR:s:.*]] | Def,RelChild | rel: 1
 // CHECK-NEXT: RelChild | [[S1_USR]]
-// CHECK: [[@LINE+1]]:31 | struct/Swift | s:Si | Ref | rel: 0
+// CHECK: [[@LINE+1]]:31 | struct/Swift | s:Si | Ref,RelCont | rel: 1
   var computedPropertyGetSet: Int {
 // CHECK: [[@LINE+2]]:5 | instance-method/acc-get/Swift | s:{{.*}} | Def,RelChild,RelAcc | rel: 1
 // CHECK-NEXT: RelChild,RelAcc | [[computedPropertyGetSet_USR]]

--- a/test/Index/expressions.swift
+++ b/test/Index/expressions.swift
@@ -17,36 +17,6 @@ func test(_ o: P1?) {
   }
 }
 
-func foo() {} // CHECK: [[@LINE]]:6 | function/Swift | foo() | [[foo_USR:.*]] | Def
-
-func test1() { // CHECK: [[@LINE]]:6 | function/Swift | test1() | [[test1_USR:.*]] | Def
-  func local_func() {
-    // FIXME: Saying that 'test1' is the caller of 'foo' is inaccurate, but we'd need
-    // to switch to recording local symbols in order to model this properly.
-    foo() // CHECK: [[@LINE]]:5 | function/Swift | foo() | [[foo_USR]] | Ref,Call,RelCall,RelCont | rel: 1
-      // CHECK-NEXT: RelCall,RelCont | function/Swift | test1() | [[test1_USR]]
-  }
-
-  var local_prop: Int {
-    get {
-      foo() // CHECK: [[@LINE]]:7 | function/Swift | foo() | [[foo_USR]] | Ref,Call,RelCall,RelCont | rel: 1
-        // CHECK-NEXT: RelCall,RelCont | function/Swift | test1() | [[test1_USR]]
-      return 0
-    }
-    set {
-      foo() // CHECK: [[@LINE]]:7 | function/Swift | foo() | [[foo_USR]] | Ref,Call,RelCall,RelCont | rel: 1
-        // CHECK-NEXT: RelCall,RelCont | function/Swift | test1() | [[test1_USR]]
-    }
-  }
-
-  struct LocalS {
-    func meth() {
-      foo() // CHECK: [[@LINE]]:7 | function/Swift | foo() | [[foo_USR]] | Ref,Call,RelCall,RelCont | rel: 1
-        // CHECK-NEXT: RelCall,RelCont | function/Swift | test1() | [[test1_USR]]
-    }
-  }
-}
-
 protocol AP {
   // CHECK: [[@LINE+1]]:18 | type-alias/associated-type/Swift | A | [[AP_P_USR:.*]] | Def,RelChild | rel: 1
   associatedtype A

--- a/test/Index/property_wrappers.swift
+++ b/test/Index/property_wrappers.swift
@@ -30,34 +30,34 @@ var globalInt: Int { return 17 }
 
 public struct HasWrappers {
   @Wrapper
-  // CHECK: [[@LINE-1]]:4 | struct/Swift | Wrapper | [[Wrapper_USR]] | Ref | rel: 0
+  // CHECK: [[@LINE-1]]:4 | struct/Swift | Wrapper | [[Wrapper_USR]] | Ref,RelCont | rel: 1
   public var x: Int = globalInt
   // CHECK-NOT: [[@LINE-1]]:23 | variable/Swift | globalInt
-  // CHECK: [[@LINE-4]]:4 | constructor/Swift | init(initialValue:) | [[WrapperInit_USR]] | Ref,Call,Impl | rel: 0
+  // CHECK: [[@LINE-4]]:4 | constructor/Swift | init(initialValue:) | [[WrapperInit_USR]] | Ref,Call,Impl,RelCont | rel: 1
   // CHECK: [[@LINE-3]]:14 | instance-property/Swift | x | [[x_USR:.*]] | Def,RelChild | rel: 1
-  // CHECK: [[@LINE-4]]:23 | variable/Swift | globalInt | [[globalInt_USR]] | Ref,Read | rel: 0
+  // CHECK: [[@LINE-4]]:23 | variable/Swift | globalInt | [[globalInt_USR]] | Ref,Read,RelCont | rel: 1
 
   @Wrapper(body: { globalInt })
-  // CHECK: [[@LINE-1]]:4 | struct/Swift | Wrapper | [[Wrapper_USR]] | Ref | rel: 0
-  // CHECK: [[@LINE-2]]:20 | variable/Swift | globalInt | [[globalInt_USR]] | Ref,Read | rel: 0
-  // CHECK: [[@LINE-3]]:4 | constructor/Swift | init(body:) | [[WrapperBodyInit_USR]] | Ref,Call | rel: 0
+  // CHECK: [[@LINE-1]]:4 | struct/Swift | Wrapper | [[Wrapper_USR]] | Ref,RelCont | rel: 1
+  // CHECK: [[@LINE-2]]:20 | variable/Swift | globalInt | [[globalInt_USR]] | Ref,Read,RelCont | rel: 1
+  // CHECK: [[@LINE-3]]:4 | constructor/Swift | init(body:) | [[WrapperBodyInit_USR]] | Ref,Call,RelCont | rel: 1
   public var y: Int
   // CHECK: [[@LINE-1]]:14 | instance-property/Swift | y | [[y_USR:.*]] | Def,RelChild | rel: 1
   // CHECK-NOT: [[@LINE-6]]:20 | variable/Swift | globalInt
 
   @Wrapper(body: {
-  // CHECK: [[@LINE-1]]:4 | struct/Swift | Wrapper | [[Wrapper_USR]] | Ref | rel: 0
+  // CHECK: [[@LINE-1]]:4 | struct/Swift | Wrapper | [[Wrapper_USR]] | Ref,RelCont | rel: 1
     struct Inner {
       @Wrapper
-      // CHECK: [[@LINE-1]]:8 | struct/Swift | Wrapper | [[Wrapper_USR]] | Ref | rel: 0
-      // CHECK: [[@LINE-2]]:8 | constructor/Swift | init(initialValue:) | [[WrapperInit_USR]] | Ref,Call,Impl | rel: 0
+      // CHECK: [[@LINE-1]]:8 | struct/Swift | Wrapper | [[Wrapper_USR]] | Ref,RelCont | rel: 1
+      // CHECK: [[@LINE-2]]:8 | constructor/Swift | init(initialValue:) | [[WrapperInit_USR]] | Ref,Call,Impl,RelCont | rel: 1
       var x: Int = globalInt
-      // CHECK: [[@LINE-1]]:20 | variable/Swift | globalInt | [[globalInt_USR]] | Ref,Read | rel: 0
+      // CHECK: [[@LINE-1]]:20 | variable/Swift | globalInt | [[globalInt_USR]] | Ref,Read,RelCont | rel: 1
     }
     return Inner().x + globalInt
-    // CHECK: [[@LINE-1]]:24 | variable/Swift | globalInt | [[globalInt_USR]] | Ref,Read | rel: 0
+    // CHECK: [[@LINE-1]]:24 | variable/Swift | globalInt | [[globalInt_USR]] | Ref,Read,RelCont | rel: 1
   })
-  // CHECK: [[@LINE-12]]:4 | constructor/Swift | init(body:) | [[WrapperBodyInit_USR]] | Ref,Call | rel: 0
+  // CHECK: [[@LINE-12]]:4 | constructor/Swift | init(body:) | [[WrapperBodyInit_USR]] | Ref,Call,RelCont | rel: 1
   public var z: Int
   // CHECK: [[@LINE-1]]:14 | instance-property/Swift | z | [[z_USR:.*]] | Def,RelChild | rel: 1
 

--- a/test/Index/result_builders.swift
+++ b/test/Index/result_builders.swift
@@ -44,8 +44,8 @@ func acceptColorTagged<Result>(@TaggedBuilder<Color> body: () -> Result) {
 
 struct Context {
     @TaggedBuilder<Color>
-    // CHECK: [[@LINE-1]]:6 | struct/Swift | TaggedBuilder | s:14swift_ide_test13TaggedBuilderV | Ref | rel: 0
-    // CHECK: [[@LINE-2]]:20 | enum/Swift | Color | s:14swift_ide_test5ColorO | Ref | rel: 0
+    // CHECK: [[@LINE-1]]:6 | struct/Swift | TaggedBuilder | s:14swift_ide_test13TaggedBuilderV | Ref,RelCont | rel: 1
+    // CHECK: [[@LINE-2]]:20 | enum/Swift | Color | s:14swift_ide_test5ColorO | Ref,RelCont | rel: 1
     func foo() -> () {}
     // CHECK: [[@LINE-1]]:10 | instance-method/Swift | foo() | s:14swift_ide_test7ContextV3fooyyF | Def,RelChild | rel: 1
 }

--- a/test/Index/roles-contained.swift
+++ b/test/Index/roles-contained.swift
@@ -1,0 +1,297 @@
+// RUN: %target-swift-ide-test -print-indexed-symbols -include-locals -source-filename %s | %FileCheck %s
+
+// Helpers
+let intValue = 1
+let stringValue = ""
+let floatValue: Float = 1.0
+let doubleValue: Double = 1.0
+func calledFunc(value: Int) {}
+func tupleReturnType() -> (Int, String) { (1, "") }
+typealias TupleTypeAlias = (Int, String)
+
+@propertyWrapper
+struct Wrapped<T> {
+    let wrappedValue: T
+    init(wrappedValue: T) {}
+}
+
+// Begin tests
+
+let _: Int = intValue
+// CHECK: [[@LINE-1]]:8 | struct/Swift | Int | {{.*}} | Ref | rel: 0
+// CHECK: [[@LINE-2]]:14 | variable/Swift | intValue | {{.*}} | Ref,Read | rel: 0
+
+let typedProperty: Int = 1
+// CHECK: [[@LINE-1]]:20 | struct/Swift | Int | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | typedProperty | {{.*}}
+
+let propertyWithExpressionReference = typedProperty
+// CHECK: [[@LINE-1]]:39 | variable/Swift | typedProperty | {{.*}} | Ref,Read,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | propertyWithExpressionReference | {{.*}}
+// CHECK: [[@LINE-3]]:39 | function/acc-get/Swift | getter:typedProperty | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | propertyWithExpressionReference | {{.*}}
+
+var propertyWithExplicitAccessors: Int {
+    get {
+        calledFunc(value: 0)
+        // CHECK: [[@LINE-1]]:9 | function/Swift | calledFunc(value:) | {{.*}} | Ref,Call,RelCall,RelCont | rel: 1
+        // CHECK-NEXT: RelCall,RelCont | function/acc-get/Swift | getter:propertyWithExplicitAccessors | {{.*}}
+        return 0
+    }
+    set {
+        calledFunc(value: 0)
+        // CHECK: [[@LINE-1]]:9 | function/Swift | calledFunc(value:) | {{.*}} | Ref,Call,RelCall,RelCont | rel: 1
+        // CHECK-NEXT: RelCall,RelCont | function/acc-set/Swift | setter:propertyWithExplicitAccessors | {{.*}}
+    }
+}
+
+let closureTypedProperty: ((Int) -> Void) = { _ in }
+// CHECK: [[@LINE-1]]:29 | struct/Swift | Int | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | closureTypedProperty | {{.*}}
+// CHECK: [[@LINE-3]]:37 | type-alias/Swift | Void | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | closureTypedProperty | {{.*}}
+
+let ((((((parenProperty)))))): ((((((Int)))))) = ((((((intValue))))))
+// CHECK: [[@LINE-1]]:38 | struct/Swift | Int | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | parenProperty | {{.*}}
+// CHECK: [[@LINE-3]]:56 | variable/Swift | intValue | {{.*}} | Ref,Read,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | parenProperty | {{.*}}
+// CHECK: [[@LINE-5]]:56 | function/acc-get/Swift | getter:intValue | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | parenProperty | {{.*}}
+
+let tupleTypedProperty: (Int, String) = (1, "")
+// CHECK: [[@LINE-1]]:26 | struct/Swift | Int | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleTypedProperty | {{.*}}
+// CHECK: [[@LINE-3]]:31 | struct/Swift | String | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleTypedProperty | {{.*}}
+
+let (tupleDestructuredInitElementA, tupleDestructuredInitElementB) = (intValue, stringValue)
+// CHECK: [[@LINE-1]]:71 | variable/Swift | intValue | {{.*}} | Ref,Read,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleDestructuredInitElementA | {{.*}}
+// CHECK: [[@LINE-3]]:71 | function/acc-get/Swift | getter:intValue | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleDestructuredInitElementA | {{.*}}
+// CHECK: [[@LINE-5]]:81 | variable/Swift | stringValue | {{.*}} | Ref,Read,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleDestructuredInitElementB | {{.*}}
+// CHECK: [[@LINE-7]]:81 | function/acc-get/Swift | getter:stringValue | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleDestructuredInitElementB | {{.*}}
+
+let (tupleTypedDestructuredInitElementA, tupleTypedDestructuredInitElementB): (Int, String) = (intValue, stringValue)
+// CHECK: [[@LINE-1]]:80 | struct/Swift | Int | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleTypedDestructuredInitElementA | {{.*}}
+// CHECK: [[@LINE-3]]:85 | struct/Swift | String | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleTypedDestructuredInitElementB | {{.*}}
+// CHECK: [[@LINE-5]]:96 | variable/Swift | intValue | {{.*}} | Ref,Read,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleTypedDestructuredInitElementA | {{.*}}
+// CHECK: [[@LINE-7]]:96 | function/acc-get/Swift | getter:intValue | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleTypedDestructuredInitElementA | {{.*}}
+// CHECK: [[@LINE-9]]:106 | variable/Swift | stringValue | {{.*}} | Ref,Read,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleTypedDestructuredInitElementB | {{.*}}
+// CHECK: [[@LINE-11]]:106 | function/acc-get/Swift | getter:stringValue | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleTypedDestructuredInitElementB | {{.*}}
+
+let (tupleNonDestructuredInitElementA, tupleNonDestructuredInitElementB) = tupleReturnType()
+// CHECK: [[@LINE-1]]:76 | function/Swift | tupleReturnType() | {{.*}} | Ref,Call,RelCont | rel: 2
+// CHECK-NEXT: RelCont | variable/Swift | tupleNonDestructuredInitElementA | {{.*}}
+// CHECK-NEXT: RelCont | variable/Swift | tupleNonDestructuredInitElementB | {{.*}}
+
+let (tupleTypedNonDestructuredInitElementA, tupleTypedNonDestructuredInitElementB): (Int, String) = tupleReturnType()
+// CHECK: [[@LINE-1]]:86 | struct/Swift | Int | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleTypedNonDestructuredInitElementA | {{.*}}
+// CHECK: [[@LINE-3]]:91 | struct/Swift | String | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleTypedNonDestructuredInitElementB | {{.*}}
+// CHECK: [[@LINE-5]]:101 | function/Swift | tupleReturnType() | {{.*}} | Ref,Call,RelCont | rel: 2
+// CHECK-NEXT: RelCont | variable/Swift | tupleTypedNonDestructuredInitElementA | {{.*}}
+// CHECK-NEXT: RelCont | variable/Swift | tupleTypedNonDestructuredInitElementB | {{.*}}
+
+let (tupleMultiBindingElementA, tupleMultiBindingElementB): (Int, String) = (1, ""),
+    (tupleMultiBindingElementC, tupleMultiBindingElementD) = tupleReturnType(),
+    nonTupleMultiBindingProperty = intValue
+// CHECK: [[@LINE-3]]:62 | struct/Swift | Int | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleMultiBindingElementA | {{.*}}
+// CHECK: [[@LINE-5]]:67 | struct/Swift | String | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleMultiBindingElementB | {{.*}}
+// CHECK: [[@LINE-6]]:62 | function/Swift | tupleReturnType() | {{.*}} | Ref,Call,RelCont | rel: 2
+// CHECK-NEXT: RelCont | variable/Swift | tupleMultiBindingElementC | {{.*}}
+// CHECK-NEXT: RelCont | variable/Swift | tupleMultiBindingElementD | {{.*}}
+// CHECK: [[@LINE-8]]:36 | variable/Swift | intValue | {{.*}} | Ref,Read,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | nonTupleMultiBindingProperty | {{.*}}
+// CHECK: [[@LINE-10]]:36 | function/acc-get/Swift | getter:intValue | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | nonTupleMultiBindingProperty | {{.*}}
+
+let (tupleSingleTypedDestructuredInitElementA, tupleSingleTypedDestructuredInitElementB): TupleTypeAlias = (1, "")
+// CHECK: [[@LINE-1]]:91 | type-alias/Swift | TupleTypeAlias | {{.*}} | Ref,RelCont | rel: 2
+// CHECK-NEXT: RelCont | variable/Swift | tupleSingleTypedDestructuredInitElementA | {{.*}}
+// CHECK-NEXT:  RelCont | variable/Swift | tupleSingleTypedDestructuredInitElementB | {{.*}}
+
+let (_, tupleIgnoredSiblingElement): (Int, String) = (intValue, stringValue)
+// CHECK: [[@LINE-1]]:39 | struct/Swift | Int | {{.*}} | Ref | rel: 0
+// CHECK: [[@LINE-2]]:44 | struct/Swift | String | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleIgnoredSiblingElement | {{.*}}
+// CHECK: [[@LINE-4]]:55 | variable/Swift | intValue | {{.*}} | Ref,Read | rel: 0
+// CHECK: [[@LINE-5]]:55 | function/acc-get/Swift | getter:intValue | {{.*}} | Ref,Call,Impl | rel: 0
+// CHECK: [[@LINE-6]]:65 | variable/Swift | stringValue | {{.*}} | Ref,Read,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleIgnoredSiblingElement | {{.*}}
+// CHECK: [[@LINE-8]]:65 | function/acc-get/Swift | getter:stringValue | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+// CHECK-NEXT:  RelCont | variable/Swift | tupleIgnoredSiblingElement | {{.*}}
+
+let (tupleNestedElementA, (tupleNestedElementB, (tupleNestedElementC, tupleNestedElementD))): (Int, (String, (Float, Double))) = (intValue, (stringValue, (floatValue, doubleValue)))
+// CHECK: [[@LINE-1]]:96 | struct/Swift | Int | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedElementA | {{.*}}
+// CHECK: [[@LINE-3]]:102 | struct/Swift | String | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedElementB | {{.*}}
+// CHECK: [[@LINE-5]]:111 | struct/Swift | Float | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedElementC | {{.*}}
+// CHECK: [[@LINE-7]]:118 | struct/Swift | Double | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedElementD | {{.*}}
+// CHECK: [[@LINE-9]]:131 | variable/Swift | intValue | {{.*}} | Ref,Read,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedElementA | {{.*}}
+// CHECK: [[@LINE-11]]:131 | function/acc-get/Swift | getter:intValue | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedElementA | {{.*}}
+// CHECK: [[@LINE-13]]:142 | variable/Swift | stringValue | {{.*}} | Ref,Read,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedElementB | {{.*}}
+// CHECK: [[@LINE-15]]:142 | function/acc-get/Swift | getter:stringValue | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedElementB | {{.*}}
+// CHECK: [[@LINE-17]]:156 | variable/Swift | floatValue | {{.*}} | Ref,Read,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedElementC | {{.*}}
+// CHECK: [[@LINE-19]]:156 | function/acc-get/Swift | getter:floatValue | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedElementC | {{.*}}
+// CHECK: [[@LINE-21]]:168 | variable/Swift | doubleValue | {{.*}} | Ref,Read,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedElementD | {{.*}}
+// CHECK: [[@LINE-23]]:168 | function/acc-get/Swift | getter:doubleValue | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedElementD | {{.*}}
+
+let (tupleNonDestructuredSiblingElementA, (tupleNonDestructuredSiblingElementB)): (Int, (String, (Float, Double))) = (intValue, (stringValue, (floatValue, doubleValue)))
+// CHECK: [[@LINE-1]]:84 | struct/Swift | Int | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNonDestructuredSiblingElementA | {{.*}}
+// CHECK: [[@LINE-3]]:90 | struct/Swift | String | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNonDestructuredSiblingElementB | {{.*}}
+// CHECK: [[@LINE-5]]:99 | struct/Swift | Float | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNonDestructuredSiblingElementB | {{.*}}
+// CHECK: [[@LINE-7]]:106 | struct/Swift | Double | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNonDestructuredSiblingElementB | {{.*}}
+// CHECK: [[@LINE-9]]:119 | variable/Swift | intValue | {{.*}} | Ref,Read,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNonDestructuredSiblingElementA | {{.*}}
+// CHECK: [[@LINE-11]]:119 | function/acc-get/Swift | getter:intValue | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNonDestructuredSiblingElementA | {{.*}}
+// CHECK: [[@LINE-13]]:130 | variable/Swift | stringValue | {{.*}} | Ref,Read,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNonDestructuredSiblingElementB | {{.*}}
+// CHECK: [[@LINE-15]]:130 | function/acc-get/Swift | getter:stringValue | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNonDestructuredSiblingElementB | {{.*}}
+// CHECK: [[@LINE-17]]:144 | variable/Swift | floatValue | {{.*}} | Ref,Read,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNonDestructuredSiblingElementB | {{.*}}
+// CHECK: [[@LINE-19]]:144 | function/acc-get/Swift | getter:floatValue | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNonDestructuredSiblingElementB | {{.*}}
+// CHECK: [[@LINE-21]]:156 | variable/Swift | doubleValue | {{.*}} | Ref,Read,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNonDestructuredSiblingElementB | {{.*}}
+// CHECK: [[@LINE-23]]:156 | function/acc-get/Swift | getter:doubleValue | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNonDestructuredSiblingElementB | {{.*}}
+
+let (tupleNestedIgnoredSiblingElementA, (tupleNestedIgnoredSiblingElementB, _)): (Int, (String, Float)) = (intValue, (stringValue, floatValue))
+// CHECK: [[@LINE-1]]:83 | struct/Swift | Int | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedIgnoredSiblingElementA | {{.*}}
+// CHECK: [[@LINE-3]]:89 | struct/Swift | String | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedIgnoredSiblingElementB | {{.*}}
+// CHECK: [[@LINE-5]]:97 | struct/Swift | Float | {{.*}} | Ref | rel: 0
+// CHECK: [[@LINE-6]]:108 | variable/Swift | intValue | {{.*}} | Ref,Read,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedIgnoredSiblingElementA | {{.*}}
+// CHECK: [[@LINE-8]]:108 | function/acc-get/Swift | getter:intValue | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedIgnoredSiblingElementA | {{.*}}
+// CHECK: [[@LINE-10]]:119 | variable/Swift | stringValue | {{.*}} | Ref,Read,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedIgnoredSiblingElementB | {{.*}}
+// CHECK: [[@LINE-12]]:119 | function/acc-get/Swift | getter:stringValue | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedIgnoredSiblingElementB | {{.*}}
+// CHECK: [[@LINE-14]]:132 | variable/Swift | floatValue | {{.*}} | Ref,Read | rel: 0
+// CHECK: [[@LINE-15]]:132 | function/acc-get/Swift | getter:floatValue | {{.*}} | Ref,Call,Impl | rel: 0
+
+let (tupleNestedFuncSiblingElementA, (tupleNestedFuncSiblingElementB, tupleNestedFuncSiblingElementC)): (Double, (Float, (Int, String))) = (doubleValue, (floatValue, tupleReturnType()))
+// CHECK: [[@LINE-1]]:106 | struct/Swift | Double | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedFuncSiblingElementA | {{.*}}
+// CHECK: [[@LINE-3]]:115 | struct/Swift | Float | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedFuncSiblingElementB | {{.*}}
+// CHECK: [[@LINE-5]]:123 | struct/Swift | Int | {{.*}}| Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedFuncSiblingElementC | {{.*}}
+// CHECK: [[@LINE-7]]:128 | struct/Swift | String | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedFuncSiblingElementC | {{.*}}
+// CHECK: [[@LINE-9]]:141 | variable/Swift | doubleValue | {{.*}} | Ref,Read,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedFuncSiblingElementA | {{.*}}
+// CHECK: [[@LINE-11]]:141 | function/acc-get/Swift | getter:doubleValue | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedFuncSiblingElementA | {{.*}}
+// CHECK: [[@LINE-13]]:155 | variable/Swift | floatValue | {{.*}} | Ref,Read,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedFuncSiblingElementB | {{.*}}
+// CHECK: [[@LINE-15]]:155 | function/acc-get/Swift | getter:floatValue | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedFuncSiblingElementB | {{.*}}
+// CHECK: [[@LINE-17]]:167 | function/Swift | tupleReturnType() | {{.*}} | Ref,Call,RelCont | rel: 1
+// CHECK-NEXT: RelCont | variable/Swift | tupleNestedFuncSiblingElementC | {{.*}}
+
+func containingFunc(param: Int) {
+    // CHECK: [[@LINE-1]]:6 | function/Swift | containingFunc(param:) | {{.*}} | Def | rel: 0
+    // CHECK: [[@LINE-2]]:21 | param/Swift | param | {{.*}} | Def,RelChild | rel: 1
+    // CHECK-NEXT: RelChild | function/Swift | containingFunc(param:) | {{.*}}
+
+    let localProperty = param
+    // CHECK: [[@LINE-1]]:25 | param/Swift | param | {{.*}} | Ref,Read,RelCont | rel: 1
+    // CHECK-NEXT: RelCont | variable(local)/Swift | localProperty | {{.*}}
+
+    calledFunc(value: localProperty)
+    // CHECK: [[@LINE-1]]:5 | function/Swift | calledFunc(value:) | {{.*}} | Ref,Call,RelCall,RelCont | rel: 1
+    // CHECK-NEXT: RelCall,RelCont | function/Swift | containingFunc(param:) | {{.*}}
+
+    // Ignored declarations do not act as containers.
+    let _ = intValue
+    // CHECK: [[@LINE-1]]:13 | variable/Swift | intValue | {{.*}} | Ref,Read,RelCont | rel: 1
+    // CHECK-NEXT: RelCont | function/Swift | containingFunc(param:) | {{.*}}
+
+    let (_, tupleIgnoredSiblingElementContained): (Int, String) = (intValue, stringValue)
+    // CHECK: [[@LINE-1]]:52 | struct/Swift | Int | {{.*}} | Ref,RelCont | rel: 1
+    // CHECK-NEXT: RelCont | function/Swift | containingFunc(param:) | {{.*}}
+    // CHECK: [[@LINE-3]]:57 | struct/Swift | String | {{.*}} | Ref,RelCont | rel: 1
+    // CHECK-NEXT: RelCont | variable(local)/Swift | tupleIgnoredSiblingElementContained | {{.*}}
+    // CHECK: [[@LINE-5]]:68 | variable/Swift | intValue | {{.*}} | Ref,Read,RelCont | rel: 1
+    // CHECK-NEXT: RelCont | function/Swift | containingFunc(param:) | {{.*}}
+    // CHECK: [[@LINE-7]]:68 | function/acc-get/Swift | getter:intValue | {{.*}} | Ref,Call,Impl,RelCall,RelCont | rel: 1
+    // CHECK-NEXT: RelCall,RelCont | function/Swift | containingFunc(param:) | {{.*}}
+    // CHECK: [[@LINE-9]]:78 | variable/Swift | stringValue | {{.*}} | Ref,Read,RelCont | rel: 1
+    // CHECK-NEXT: RelCont | variable(local)/Swift | tupleIgnoredSiblingElementContained | {{.*}}
+    // CHECK: [[@LINE-11]]:78 | function/acc-get/Swift | getter:stringValue | {{.*}} | Ref,Call,Impl,RelCall,RelCont | rel: 2
+    // CHECK-NEXT: RelCont | variable(local)/Swift | tupleIgnoredSiblingElementContained | {{.*}}
+}
+
+func functionWithReturnType() -> Int { 0 }
+// CHECK: [[@LINE-1]]:34 | struct/Swift | Int | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | function/Swift | functionWithReturnType() | {{.*}}
+
+func functionWithParameter(a: Int) {}
+// CHECK: [[@LINE-1]]:31 | struct/Swift | Int | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | function/Swift | functionWithParameter(a:) | {{.*}}
+
+func functionWithGenericConstraint<T: Equatable>(type: T) {}
+// CHECK: [[@LINE-1]]:39 | protocol/Swift | Equatable | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | function/Swift | functionWithGenericConstraint(type:) | {{.*}}
+
+func functionWithGenericClause<T>(type: T) where T: Equatable {}
+// CHECK: [[@LINE-1]]:53 | protocol/Swift | Equatable | {{.*}} | Ref,RelCont | rel: 1
+// CHECK-NEXT: RelCont | function/Swift | functionWithGenericClause(type:) | {{.*}}
+
+struct SomeStruct {
+    static let staticProperty: Int = 1
+    // CHECK: [[@LINE-1]]:32 | struct/Swift | Int | {{.*}} | Ref,RelCont | rel: 1
+    // CHECK-NEXT: RelCont | static-property/Swift | staticProperty | {{.*}}
+
+    lazy var lazyProperty: Int = { 1 }()
+    // CHECK: [[@LINE-1]]:28 | struct/Swift | Int | {{.*}} | Ref,RelCont | rel: 1
+    // CHECK-NEXT: RelCont | instance-property/Swift | lazyProperty | {{.*}}
+
+    @Wrapped
+    var wrappedProperty: Int = 1
+    // CHECK: [[@LINE-2]]:6 | struct/Swift | Wrapped | {{.*}} | Ref,RelCont | rel: 1
+    // CHECK-NEXT: RelCont | instance-property/Swift | wrappedProperty | {{.*}}
+    // CHECK: [[@LINE-4]]:6 | constructor/Swift | init(wrappedValue:) | {{.*}} | Ref,Call,Impl,RelCont | rel: 1
+    // CHECK-NEXT: RelCont | instance-property/Swift | wrappedProperty | {{.*}}
+    // CHECK: [[@LINE-5]]:9 | instance-property/Swift | wrappedProperty | {{.*}} | Def,RelChild | rel: 1
+    // CHECK: [[@LINE-6]]:26 | struct/Swift | Int | {{.*}} | Ref,RelCont | rel: 1
+    // CHECK-NEXT: RelCont | instance-property/Swift | wrappedProperty | {{.*}}
+
+    init(a: Int) {}
+    // CHECK: [[@LINE-1]]:13 | struct/Swift | Int | {{.*}} | Ref,RelCont | rel: 1
+    // CHECK-NEXT: RelCont | constructor/Swift | init(a:) | {{.*}}
+}

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -15,8 +15,9 @@ let x = 2
 // Definition + Read of x
 var y = x + 1
 // CHECK: [[@LINE-1]]:5 | variable/Swift | y | s:14swift_ide_test1ySivp | Def | rel: 0
-// CHECK: [[@LINE-2]]:9 | variable/Swift | x | s:14swift_ide_test1xSivp | Ref,Read | rel: 0
-// CHECK: [[@LINE-3]]:11 | static-method/infix-operator/Swift | +(_:_:) | s:Si1poiyS2i_SitFZ | Ref,Call,RelRec | rel: 1
+// CHECK: [[@LINE-2]]:9 | variable/Swift | x | s:14swift_ide_test1xSivp | Ref,Read,RelCont | rel: 1
+// CHECK: [[@LINE-3]]:11 | static-method/infix-operator/Swift | +(_:_:) | s:Si1poiyS2i_SitFZ | Ref,Call,RelRec,RelCont | rel: 2
+// CHECK-NEXT: RelCont | variable/Swift | y | s:14swift_ide_test1ySivp
 // CHECK-NEXT: RelRec | struct/Swift | Int | s:Si
 
 // Read of x + Write of y
@@ -96,7 +97,7 @@ func aCaller() {
 }
 
 let aRef = aCalledFunction
-// CHECK: [[@LINE-1]]:12 | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunction1a1bySi_SiztF | Ref | rel: 0
+// CHECK: [[@LINE-1]]:12 | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunction1a1bySi_SiztF | Ref,RelCont | rel: 1
 
 // RelationChildOf, Implicit
 struct AStruct {
@@ -328,8 +329,8 @@ extension ExtendMe where Self: Whatever {}
 // CHECK: [[@LINE-1]]:32 | protocol/Swift | Whatever | [[Whatever_USR]] | Ref | rel: 0
 
 var anInstance = AClass(x: 1)
-// CHECK: [[@LINE-1]]:18 | class/Swift | AClass | s:14swift_ide_test6AClassC | Ref | rel: 0
-// CHECK: [[@LINE-2]]:18 | constructor/Swift | init(x:) | s:14swift_ide_test6AClassC1xACSi_tcfc | Ref,Call | rel: 0
+// CHECK: [[@LINE-1]]:18 | class/Swift | AClass | s:14swift_ide_test6AClassC | Ref,RelCont | rel: 1
+// CHECK: [[@LINE-2]]:18 | constructor/Swift | init(x:) | s:14swift_ide_test6AClassC1xACSi_tcfc | Ref,Call,RelCont | rel: 1
 
 anInstance.y.x = anInstance.y.x
 // CHECK: [[@LINE-1]]:1 | variable/Swift | anInstance | s:14swift_ide_test10anInstanceAA6AClassCvp | Ref,Read | rel: 0
@@ -352,8 +353,8 @@ anInstance.z[1] = anInstance.z[0]
 // CHECK: [[@LINE-4]]:30 | instance-property/Swift | z | s:14swift_ide_test6AClassC1zSaySiGvp | Ref,Read,Writ | rel: 0
 
 let otherInstance = AStruct(x: 1)
-// CHECK: [[@LINE-1]]:29 | instance-property/Swift | x | [[AStruct_x_USR]] | Ref | rel: 0
-// CHECK: [[@LINE-2]]:21 | struct/Swift | AStruct | [[AStruct_USR]] | Ref | rel: 0
+// CHECK: [[@LINE-1]]:29 | instance-property/Swift | x | [[AStruct_x_USR]] | Ref,RelCont | rel: 1
+// CHECK: [[@LINE-2]]:21 | struct/Swift | AStruct | [[AStruct_USR]] | Ref,RelCont | rel: 1
 
 _ = AStruct.init(x:)
 // CHECK: [[@LINE-1]]:18 | instance-property/Swift | x | [[AStruct_x_USR]] | Ref | rel: 0
@@ -369,7 +370,7 @@ let _ = anInstance[0]
 
 let aSubInstance: AClass = ASubClass(x: 1)
 // CHECK: [[@LINE-1]]:5 | variable/Swift | aSubInstance | s:14swift_ide_test12aSubInstanceAA6AClassCvp | Def | rel: 0
-// CHECK: [[@LINE-2]]:28 | class/Swift | ASubClass | s:14swift_ide_test9ASubClassC | Ref | rel: 0
+// CHECK: [[@LINE-2]]:28 | class/Swift | ASubClass | s:14swift_ide_test9ASubClassC | Ref,RelCont | rel: 1
 
 // Dynamic, RelationReceivedBy
 let _ = aSubInstance.foo()
@@ -380,47 +381,6 @@ let _ = aSubInstance.foo()
 // RelationContainedBy
 let contained = 2
 // CHECK: [[@LINE-1]]:5 | variable/Swift | contained | s:14swift_ide_test9containedSivp | Def | rel: 0
-
-func containing() {
-// CHECK: [[@LINE-1]]:6 | function/Swift | containing() | s:14swift_ide_test10containingyyF | Def | rel: 0
-  let _ = contained
-  // CHECK: [[@LINE-1]]:11 | variable/Swift | contained | s:14swift_ide_test9containedSivp | Ref,Read,RelCont | rel: 1
-  // CHECK-NEXT: RelCont | function/Swift | containing() | s:14swift_ide_test10containingyyF
-
-  var x = contained
-  // CHECK: [[@LINE-1]]:11 | variable/Swift | contained | s:14swift_ide_test9containedSivp | Ref,Read,RelCont | rel: 1
-  // CHECK-NEXT: RelCont | function/Swift | containing() | s:14swift_ide_test10containingyyF
-
-  struct LocalStruct {
-    var i: AClass = AClass(x: contained)
-    // CHECK: [[@LINE-1]]:12 | class/Swift | AClass | s:14swift_ide_test6AClassC | Ref,RelCont | rel: 1
-    // CHECK-NEXT: RelCont | function/Swift | containing() | s:14swift_ide_test10containingyyF
-    // CHECK: [[@LINE-3]]:21 | class/Swift | AClass | s:14swift_ide_test6AClassC | Ref,RelCont | rel: 1
-    // CHECK-NEXT: RelCont | function/Swift | containing() | s:14swift_ide_test10containingyyF
-    // CHECK: [[@LINE-5]]:31 | variable/Swift | contained | s:14swift_ide_test9containedSivp | Ref,Read,RelCont | rel: 1
-    // CHECK-NEXT: RelCont | function/Swift | containing() | s:14swift_ide_test10containingyyF
-
-    init(i _: AClass) {}
-    // CHECK: [[@LINE-1]]:15 | class/Swift | AClass | s:14swift_ide_test6AClassC | Ref,RelCont | rel: 1
-    // CHECK-NEXT: RelCont | function/Swift | containing() | s:14swift_ide_test10containingyyF
-
-    func inner() -> Int {
-      let _: AClass = AClass(x: contained)
-      // CHECK: [[@LINE-1]]:14 | class/Swift | AClass | s:14swift_ide_test6AClassC | Ref,RelCont | rel: 1
-      // CHECK-NEXT: RelCont | function/Swift | containing() | s:14swift_ide_test10containingyyF
-      // CHECK: [[@LINE-3]]:23 | class/Swift | AClass | s:14swift_ide_test6AClassC | Ref,RelCont | rel: 1
-      // CHECK-NEXT: RelCont | function/Swift | containing() | s:14swift_ide_test10containingyyF
-      // CHECK: [[@LINE-5]]:33 | variable/Swift | contained | s:14swift_ide_test9containedSivp | Ref,Read,RelCont | rel: 1
-      // CHECK-NEXT: RelCont | function/Swift | containing() | s:14swift_ide_test10containingyyF
-
-      aCalledFunction(a: 1, b: &z)
-      // CHECK: [[@LINE-1]]:7 | function/Swift | aCalledFunction(a:b:) | s:14swift_ide_test15aCalledFunction1a1bySi_SiztF | Ref,Call,RelCall,RelCont | rel: 1
-      // CHECK-NEXT: RelCall,RelCont | function/Swift | containing() | s:14swift_ide_test10containingyyF
-
-      return contained
-    }
-  }
-}
 
 protocol ProtRoot {
   func fooCommon()
@@ -433,7 +393,7 @@ protocol ProtRoot {
 protocol ProtDerived : ProtRoot {
   func fooCommon()
   // CHECK: [[@LINE-1]]:8 | instance-method/Swift | fooCommon() | s:14swift_ide_test11ProtDerivedP9fooCommonyyF | Def,Dyn,RelChild,RelOver | rel: 2
-  
+
   func bar1()
   func bar2()
   func bar3(_ : Int)


### PR DESCRIPTION
References associated with a `VarDecl` had no `RelationContainedBy` role, resulting in "orphaned" references. From the perspective of identifying unused code (in tools using the index, like [Periphery](https://github.com/peripheryapp/periphery)), this made it impossible to identify that a variable's type, initializer and custom attributes are associated with the variable.

Resolves #56163

---

Notes to reviewers:
* This is my first contribution to Swift, extra scrutiny needed :sweat_smile:
* I've added some inline comments to explain my reasoning