### PR TITLE
[Diagnostics] Modify diagnostics to suggest updating existing available attribute

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5327,6 +5327,8 @@ NOTE(availability_guard_with_version_check, none,
 
 NOTE(availability_add_attribute, none,
      "add @available attribute to enclosing %0", (DescriptiveDeclKind))
+NOTE(availability_update_attribute, none,
+     "update existing @available attribute", ())
 FIXIT(insert_available_attr,
       "@available(%0 %1, *)\n%2",
       (StringRef, StringRef, StringRef))

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1453,8 +1453,10 @@ static void fixAvailabilityForDecl(SourceRange ReferenceRange, const Decl *D,
   if (TypeChecker::diagnosticIfDeclCannotBePotentiallyUnavailable(D).hasValue())
     return;
 
-  if (getActiveAvailableAttribute(D, Context)) {
-    // For QoI, in future should emit a fixit to update the existing attribute.
+  if (auto *attr = getActiveAvailableAttribute(D, Context)) {
+    D->diagnose(diag::availability_update_attribute)
+        .fixItReplace(attr->IntroducedRange,
+                      RequiredRange.getLowerEndpoint().getAsString());
     return;
   }
 

--- a/test/attr/ApplicationMain/attr_main_struct_available_future.swift
+++ b/test/attr/ApplicationMain/attr_main_struct_available_future.swift
@@ -3,8 +3,7 @@
 // REQUIRES: OS=macosx
 
 @main // expected-error {{'main()' is only available in macOS 10.99 or newer}}
-@available(OSX 10.0, *)
-struct EntryPoint {
+@available(OSX 10.0, *) struct EntryPoint { // expected-note {{update existing @available attribute}} {{16-20=10.99}} 
   @available(OSX 10.99, *)
   static func main() {
   }

--- a/test/attr/attr_availability_osx.swift
+++ b/test/attr/attr_availability_osx.swift
@@ -100,17 +100,27 @@ extension TestStruct { // expected-note {{enclosing scope here}}
   @available(swift 1)
   func doFourthThing() {}
 
+  @available(macOS 10.12, iOS 13, tvOS 13, *)
+  func doFifthThing() {}
+
   @available(*, deprecated)
   func doDeprecatedThing() {}
 }
 
-@available(macOS 10.11, *)
-func testMemberAvailability() {
+@available(macOS 10.11, *) func testMemberAvailability() { // expected-note {{update existing @available attribute}} {{18-23=10.12}}
   TestStruct().doTheThing() // expected-error {{'doTheThing()' is unavailable}}
   TestStruct().doAnotherThing() // expected-error {{'doAnotherThing()' is unavailable}}
   TestStruct().doThirdThing() // expected-error {{'doThirdThing()' is unavailable}}
   TestStruct().doFourthThing() // expected-error {{'doFourthThing()' is only available in macOS 10.12 or newer}} expected-note {{'if #available'}}
   TestStruct().doDeprecatedThing() // expected-warning {{'doDeprecatedThing()' is deprecated}}
+}
+
+@available(iOS 11, macOS 10.11, *) func testUpdateAvailabilityAttribute() { // expected-note {{update existing @available attribute}} {{26-31=10.12}}
+  TestStruct().doFifthThing() // expected-error {{'doFifthThing()' is only available in macOS 10.12 or newer}} expected-note {{'if #available'}}
+}
+
+@available(macOS, introduced: 10.11) func testUpdateAvailabilityAttribute2() { // expected-note {{update existing @available attribute}} {{31-36=10.12}}
+  TestStruct().doFifthThing() // expected-error {{'doFifthThing()' is only available in macOS 10.12 or newer}} expected-note {{'if #available'}}
 }
 
 extension TestStruct {


### PR DESCRIPTION
<!-- What's in this pull request? -->
Currently, fixAvailabilityForDecl() in TypeCheckAvailability.cpp exits early if there is already an @available attribute on the declaration, with a comment noting work that should be done in the future:
```
/// Emit a diagnostic note and Fix-It to add an @available attribute
/// on the given declaration for the given version range.
static void fixAvailabilityForDecl(SourceRange ReferenceRange, const Decl *D,
                                   const VersionRange &RequiredRange,
                                   ASTContext &Context) {
  // ...irrelevant code omitted...

  if (getActiveAvailableAttribute(D, Context)) {
    // For QoI, in future should emit a fixit to update the existing attribute.
    return;
  }
```
Indeed, we should make this change. For instance, if you give the compiler this code:
```
@available(macOS 42, *) func foo() {}

@available(macOS 12, *) func bar() {
    foo()
}
```
Swift should emit a note with a fix-it replacing "macOS 12" with "macOS 42".

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-15051](https://bugs.swift.org/browse/SR-15051)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
