### PR TITLE
[build-script] Split the build-script-impl pipeline into two pipelines so I can put a build-script product pipeline in between.

### DIFF
--- a/validation-test/BuildSystem/core_lipo_and_non_core_epilogue_opts.test
+++ b/validation-test/BuildSystem/core_lipo_and_non_core_epilogue_opts.test
@@ -1,0 +1,16 @@
+# REQUIRES: standalone_build
+# REQUIRES: OS=macosx
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --infer --swiftpm --verbose-build 2>&1 | %FileCheck %s
+
+# Make sure we build swift, llvm, llbuild, then do core lipo, then build
+# swiftpm, and finally finish by running the rest of the epilogue operations.
+
+# CHECK: cmake -G Ninja {{.*}}llvm-project/llvm
+# CHECK: cmake -G Ninja {{.*}}swift
+# CHECK: --only-execute {{.*}}-llbuild-build
+# CHECK: --only-execute merged-hosts-lipo-core
+# CHECK: --- Building swiftpm ---
+# CHECK: --only-execute merged-hosts-lipo

--- a/validation-test/BuildSystem/default_build_still_performs_epilogue_opts_after_split.test
+++ b/validation-test/BuildSystem/default_build_still_performs_epilogue_opts_after_split.test
@@ -1,0 +1,11 @@
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --verbose-build --dry-run --cmake %cmake 2>&1 | %FileCheck %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --verbose-build --dry-run --cmake %cmake --infer 2>&1 | %FileCheck %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --verbose-build --dry-run --cmake %cmake --infer --swiftpm 2>&1 | %FileCheck %s
+
+# Make sure we run the merged hosts lipo step regardless of whether or not we
+# are building anything from the 2nd build-script-impl phase with or without
+# infer.
+
+# CHECK: --only-execute merged-hosts-lipo

--- a/validation-test/BuildSystem/infer_dumps_deps_if_verbose_build.test
+++ b/validation-test/BuildSystem/infer_dumps_deps_if_verbose_build.test
@@ -10,17 +10,20 @@
 # CHECK: Initial Product List:
 # CHECK:     earlyswiftdriver
 # CHECK: -- Build Graph Inference --
-# CHECK: Initial Product List:
+# CHECK-NEXT: Initial Product List:
 # CHECK:     llvm
 # CHECK:     swift
+# CHECK-NOT: llbuild
 # CHECK: -- Build Graph Inference --
-# CHECK: Initial Product List:
+# CHECK-NEXT: Initial Product List:
 # CHECK:     swiftpm
+# CHECK-NOT: llbuild
 # CHECK: Final Build Order:
 # CHECK:     earlyswiftdriver
 # CHECK:     cmark
 # CHECK:     llvm
 # CHECK:     swift
+# CHECK:     llbuild
 # CHECK:     swiftpm
 
 # Ensure early SwiftDriver is built first


### PR DESCRIPTION
This is where I am going to put the stage 2 swift. The reason why I need to do
this is that I need libdispatch, foundation, etc on Linux to use the stage2
compiler.