### PR TITLE
[5.5][Property Wrappers] Fix a bug where wrapped arguments were not properly coerced to the wrapper generator input type.

### DIFF
--- a/include/swift/AST/Initializer.h
+++ b/include/swift/AST/Initializer.h
@@ -209,15 +209,16 @@ public:
   };
 
 private:
-  ParamDecl *param;
+  VarDecl *wrappedVar;
   Kind kind;
 
 public:
-  explicit PropertyWrapperInitializer(DeclContext *parent, ParamDecl *param, Kind kind)
+  explicit PropertyWrapperInitializer(DeclContext *parent, VarDecl *wrappedVar,
+                                      Kind kind)
       : Initializer(InitializerKind::PropertyWrapper, parent),
-        param(param), kind(kind) {}
+        wrappedVar(wrappedVar), kind(kind) {}
 
-  ParamDecl *getParam() const { return param; }
+  VarDecl *getWrappedVar() const { return wrappedVar; }
 
   Kind getKind() const { return kind; }
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2128,10 +2128,10 @@ void ASTMangler::appendContext(const DeclContext *ctx, StringRef useModuleName) 
       auto wrapperInit = cast<PropertyWrapperInitializer>(ctx);
       switch (wrapperInit->getKind()) {
       case PropertyWrapperInitializer::Kind::WrappedValue:
-        appendBackingInitializerEntity(wrapperInit->getParam());
+        appendBackingInitializerEntity(wrapperInit->getWrappedVar());
         break;
       case PropertyWrapperInitializer::Kind::ProjectedValue:
-        appendInitFromProjectedValueEntity(wrapperInit->getParam());
+        appendInitFromProjectedValueEntity(wrapperInit->getWrappedVar());
         break;
       }
       return;

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -679,7 +679,7 @@ unsigned DeclContext::printContext(raw_ostream &OS, const unsigned indent,
     }
     case InitializerKind::PropertyWrapper: {
       auto init = cast<PropertyWrapperInitializer>(this);
-      OS << "PropertyWrapper 0x" << (void*)init->getParam() << ", kind=";
+      OS << "PropertyWrapper 0x" << (void*)init->getWrappedVar() << ", kind=";
       switch (init->getKind()) {
       case PropertyWrapperInitializer::Kind::WrappedValue:
         OS << "wrappedValue";

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -1297,8 +1297,8 @@ class ExprContextAnalyzer {
       auto AFD = dyn_cast<AbstractFunctionDecl>(initDC->getParent());
       if (!AFD)
         return;
-      auto *param = initDC->getParam();
-      recordPossibleType(AFD->mapTypeIntoContext(param->getInterfaceType()));
+      auto *var = initDC->getWrappedVar();
+      recordPossibleType(AFD->mapTypeIntoContext(var->getInterfaceType()));
       break;
     }
     }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8432,13 +8432,18 @@ static Optional<SolutionApplicationTarget> applySolutionToInitialization(
   // been subsumed by the backing property.
   if (wrappedVar) {
     ASTContext &ctx = cs.getASTContext();
-    wrappedVar->getParentPatternBinding()->setInitializerSubsumed(0);
     ctx.setSideCachedPropertyWrapperBackingPropertyType(
         wrappedVar, initType->mapTypeOutOfContext());
 
     // Record the semantic initializer on the outermost property wrapper.
     wrappedVar->getAttachedPropertyWrappers().front()
         ->setSemanticInit(initializer);
+
+    // If this is a wrapped parameter, we're done.
+    if (isa<ParamDecl>(wrappedVar))
+      return resultTarget;
+
+    wrappedVar->getParentPatternBinding()->setInitializerSubsumed(0);
   }
 
   // Coerce the pattern to the type of the initializer.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5102,7 +5102,14 @@ SolutionApplicationTarget::SolutionApplicationTarget(
 void SolutionApplicationTarget::maybeApplyPropertyWrapper() {
   assert(kind == Kind::expression);
   assert(expression.contextualPurpose == CTP_Initialization);
-  auto singleVar = expression.pattern->getSingleVar();
+
+  VarDecl *singleVar;
+  if (auto *pattern = expression.pattern) {
+    singleVar = pattern->getSingleVar();
+  } else {
+    singleVar = expression.propertyWrapper.wrappedVar;
+  }
+
   if (!singleVar)
     return;
 
@@ -5230,6 +5237,23 @@ SolutionApplicationTarget SolutionApplicationTarget::forForEachStmt(
 SolutionApplicationTarget
 SolutionApplicationTarget::forUninitializedWrappedVar(VarDecl *wrappedVar) {
   return SolutionApplicationTarget(wrappedVar);
+}
+
+SolutionApplicationTarget
+SolutionApplicationTarget::forPropertyWrapperInitializer(
+    VarDecl *wrappedVar, DeclContext *dc, Expr *initializer) {
+  SolutionApplicationTarget target(
+      initializer, dc, CTP_Initialization, wrappedVar->getType(),
+      /*isDiscarded=*/false);
+  target.expression.propertyWrapper.wrappedVar = wrappedVar;
+  if (auto *patternBinding = wrappedVar->getParentPatternBinding()) {
+    auto index = patternBinding->getPatternEntryIndexForVarDecl(wrappedVar);
+    target.expression.initialization.patternBinding = patternBinding;
+    target.expression.initialization.patternBindingIndex = index;
+    target.expression.pattern = patternBinding->getPattern(index);
+  }
+  target.maybeApplyPropertyWrapper();
+  return target;
 }
 
 ContextualPattern

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -113,6 +113,8 @@ static void forEachOuterDecl(DeclContext *DC, Fn fn) {
     case DeclContextKind::Initializer:
       if (auto *PBI = dyn_cast<PatternBindingInitializer>(DC))
         fn(PBI->getBinding());
+      else if (auto *I = dyn_cast<PropertyWrapperInitializer>(DC))
+        fn(I->getWrappedVar());
       break;
 
     case DeclContextKind::SubscriptDecl:

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2597,8 +2597,8 @@ void swift::checkEnumElementActorIsolation(
 }
 
 void swift::checkPropertyWrapperActorIsolation(
-   PatternBindingDecl *binding, Expr *expr) {
-  ActorIsolationChecker checker(binding->getDeclContext());
+    VarDecl *wrappedVar, Expr *expr) {
+  ActorIsolationChecker checker(wrappedVar->getDeclContext());
   expr->walk(checker);
 }
 

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -44,6 +44,7 @@ class ProtocolConformance;
 class TopLevelCodeDecl;
 class TypeBase;
 class ValueDecl;
+class VarDecl;
 
 /// Add notes suggesting the addition of 'async' or '@asyncHandler', as
 /// appropriate, to a diagnostic for a function that isn't an async context.
@@ -54,8 +55,7 @@ void checkTopLevelActorIsolation(TopLevelCodeDecl *decl);
 void checkFunctionActorIsolation(AbstractFunctionDecl *decl);
 void checkInitializerActorIsolation(Initializer *init, Expr *expr);
 void checkEnumElementActorIsolation(EnumElementDecl *element, Expr *expr);
-void checkPropertyWrapperActorIsolation(
-    PatternBindingDecl *binding, Expr *expr);
+void checkPropertyWrapperActorIsolation(VarDecl *wrappedVar, Expr *expr);
 
 /// Determine the isolation of a particular closure.
 ///

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2571,31 +2571,24 @@ static VarDecl *synthesizePropertyWrapperProjectionVar(
 
 static void typeCheckSynthesizedWrapperInitializer(VarDecl *wrappedVar,
                                                    Expr *&initializer) {
-  // Figure out the context in which the initializer was written.
-  auto *parentPBD = wrappedVar->getParentPatternBinding();
-  auto i = parentPBD->getPatternEntryIndexForVarDecl(wrappedVar);
-  DeclContext *originalDC = parentPBD->getDeclContext();
-  if (!originalDC->isLocalContext()) {
-    auto initContext =
-        cast_or_null<PatternBindingInitializer>(parentPBD->getInitContext(i));
-    if (initContext)
-      originalDC = initContext;
-  }
+  auto *dc = wrappedVar->getInnermostDeclContext();
+  auto &ctx = wrappedVar->getASTContext();
+  auto *initContext = new (ctx) PropertyWrapperInitializer(
+      dc, wrappedVar, PropertyWrapperInitializer::Kind::WrappedValue);
 
   // Type-check the initialization.
-  auto *pattern = parentPBD->getPattern(i);
-  TypeChecker::typeCheckBinding(pattern, initializer, originalDC,
-                                wrappedVar->getType(), parentPBD, i);
+  using namespace constraints;
+  auto target = SolutionApplicationTarget::forPropertyWrapperInitializer(
+      wrappedVar, initContext, initializer);
+  auto result = TypeChecker::typeCheckExpression(target);
+  if (!result)
+    return;
 
-  if (auto initializerContext =
-          dyn_cast_or_null<Initializer>(parentPBD->getInitContext(i))) {
-    TypeChecker::contextualizeInitializer(initializerContext, initializer);
-  }
+  initializer = result->getAsExpr();
 
-  auto *backingVar = wrappedVar->getPropertyWrapperBackingProperty();
-  auto *backingPBD = backingVar->getParentPatternBinding();
-  checkPropertyWrapperActorIsolation(backingPBD, initializer);
-  TypeChecker::checkPropertyWrapperEffects(backingPBD, initializer);
+  TypeChecker::contextualizeInitializer(initContext, initializer);
+  checkPropertyWrapperActorIsolation(wrappedVar, initializer);
+  TypeChecker::checkInitializerEffects(initContext, initializer);
 }
 
 static PropertyWrapperMutability::Value
@@ -2954,21 +2947,7 @@ PropertyWrapperInitializerInfoRequest::evaluate(Evaluator &evaluator,
              !var->getName().hasDollarPrefix()) {
     wrappedValueInit = PropertyWrapperValuePlaceholderExpr::create(
         ctx, var->getSourceRange(), var->getType(), /*wrappedValue=*/nullptr);
-
-    if (auto *param = dyn_cast<ParamDecl>(var)) {
-      wrappedValueInit = buildPropertyWrapperInitCall(
-          var, storageType, wrappedValueInit, PropertyWrapperInitKind::WrappedValue);
-      TypeChecker::typeCheckExpression(wrappedValueInit, dc);
-
-      // Check initializer effects.
-      auto *initContext = new (ctx) PropertyWrapperInitializer(
-          dc, param, PropertyWrapperInitializer::Kind::WrappedValue);
-      TypeChecker::contextualizeInitializer(initContext, wrappedValueInit);
-      checkInitializerActorIsolation(initContext, wrappedValueInit);
-      TypeChecker::checkInitializerEffects(initContext, wrappedValueInit);
-    } else {
-      typeCheckSynthesizedWrapperInitializer(var, wrappedValueInit);
-    }
+    typeCheckSynthesizedWrapperInitializer(var, wrappedValueInit);
   }
 
   return PropertyWrapperInitializerInfo(wrappedValueInit, projectedValueInit);

--- a/test/SILGen/property_wrapper_parameter.swift
+++ b/test/SILGen/property_wrapper_parameter.swift
@@ -52,6 +52,10 @@ func simpleWrapperParameterCaller(projection: Projection<Int>) {
 
   testSimpleWrapperParameter($value: projection)
   // CHECK: function_ref @$s26property_wrapper_parameter26testSimpleWrapperParameter5valueyAA0F0VySiG_tFACL_SivpfW : $@convention(thin) (Projection<Int>) -> Wrapper<Int>
+
+  var x: Int = 10
+  testSimpleWrapperParameter(value: x)
+  // CHECK: function_ref @$s26property_wrapper_parameter26testSimpleWrapperParameter5valueyAA0F0VySiG_tFACL_SivpfP : $@convention(thin) (Int) -> Wrapper<Int>
 }
 
 // CHECK-LABEL: sil [ossa] @$s26property_wrapper_parameter18testGenericWrapper5valueyAA0F0VyxG_tlF : $@convention(thin) <T> (@in_guaranteed Wrapper<T>) -> ()
@@ -71,6 +75,41 @@ func genericWrapperCaller(projection: Projection<Int>) {
 
   testGenericWrapper($value: projection)
   // CHECK: function_ref @$s26property_wrapper_parameter18testGenericWrapper5valueyAA0F0VyxG_tlFACL_xvpfW : $@convention(thin) <τ_0_0> (@in Projection<τ_0_0>) -> @out Wrapper<τ_0_0>
+
+  var x: Int = 10
+  testGenericWrapper(value: x)
+  // CHECK: function_ref @$s26property_wrapper_parameter18testGenericWrapper5valueyAA0F0VyxG_tlFACL_xvpfP : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out Wrapper<τ_0_0>
+}
+
+@propertyWrapper
+public struct AutoClosureWrapper<T> {
+  public var wrappedValue: T
+
+  // CHECK-LABEL: sil [ossa] @$s26property_wrapper_parameter18AutoClosureWrapperV12wrappedValueACyxGxyXK_tcfC : $@convention(method) <T> (@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <T>, @thin AutoClosureWrapper<T>.Type) -> @out AutoClosureWrapper<T>
+  public init(wrappedValue: @autoclosure () -> T) {
+    self.wrappedValue = wrappedValue()
+  }
+
+  public var projectedValue: Projection<T> {
+    Projection(wrappedValue: wrappedValue)
+  }
+
+  public init(projectedValue: Projection<T>) {
+    self.wrappedValue = projectedValue.wrappedValue
+  }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter22testAutoClosureWrapper5valueyAA0efG0VyxG_tlF : $@convention(thin) <T> (@in_guaranteed AutoClosureWrapper<T>) -> ()
+func testAutoClosureWrapper<T>(@AutoClosureWrapper value: T) {
+  // property wrapper backing initializer of value #1 in testAutoClosureWrapper<A>(value:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter22testAutoClosureWrapper5valueyAA0efG0VyxG_tlFACL_xvpfP : $@convention(thin) <T> (@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <T>) -> @out AutoClosureWrapper<T>
+  // CHECK: function_ref @$s26property_wrapper_parameter18AutoClosureWrapperV12wrappedValueACyxGxyXK_tcfC : $@convention(method) <τ_0_0> (@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_0>, @thin AutoClosureWrapper<τ_0_0>.Type) -> @out AutoClosureWrapper<τ_0_0>
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter24autoClosureWrapperCalleryyF : $@convention(thin) () -> ()
+func autoClosureWrapperCaller() {
+  testAutoClosureWrapper(value: 10)
+  // CHECK: function_ref @$s26property_wrapper_parameter22testAutoClosureWrapper5valueyAA0efG0VyxG_tlFACL_xvpfP : $@convention(thin) <τ_0_0> (@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_0>) -> @out AutoClosureWrapper<τ_0_0>
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter33testSimpleClosureWrapperParameteryyF : $@convention(thin) () -> ()


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/38766

This is important for 5.5 because it fixes a SILGen crash.

---

For wrapped parameters that are initialized at the call-site (i.e. property wrappers with `init(projectedValue:)`), the argument needs to be coerced to the wrapper generator input type in CSApply. Otherwise, this leads to a SILGen crash.

This change also fixes a bug where `@autoclosure` was not properly propagated from `init(wrappedValue:)` to a wrapped argument because the property wrapper initializer was built manually in `PropertyWrapperInitializerInfoRequest` instead of going through `SolutionApplicationTarget::maybeApplyPropertyWrapper()` which handles `@autoclosure` injection around the initial wrapped value for regular wrapped properties.

Resolves: rdar://80820408 / [SR-14927](https://bugs.swift.org/browse/SR-14927)