### PR TITLE
Revert "[test] Fix a bug in test/Profiler/coverage_smoke.swift"

### DIFF
--- a/test/Profiler/coverage_smoke.swift
+++ b/test/Profiler/coverage_smoke.swift
@@ -134,8 +134,8 @@ var g2: Int = 0
 
 class Class3 {
   var m1 = g2 == 0     // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}2
-             ? "false" // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
-             : "true"; // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+             ? "false" // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}2
+             : "true"; // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}2
 }
 
 // rdar://34244637: Wrong coverage for do/catch sequence


### PR DESCRIPTION
This reverts commit 956558f23fed93d10e6754dbf6448a4d7b3ffbe9, due to
https://reviews.llvm.org/D85036 being reverted upstream.

rdar://81815347
