### PR TITLE
Revert "[test] Fix a bug in test/Profiler/coverage_smoke.swift"

### DIFF
--- a/test/Profiler/coverage_smoke.swift
+++ b/test/Profiler/coverage_smoke.swift
@@ -150,7 +150,7 @@ func throwError(_ b: Bool) throws {
 func catchError(_ b: Bool) -> Int {
   do {
     try throwError(b) // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}2
-  } catch {           // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+  } catch {           // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}2
     return 1          // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
   }                   // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
   let _ = 1 + 1       // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1


### PR DESCRIPTION
This reverts commit ebdb4d9ace39107d6912a572aaf4d10bd81871a8, due to
https://reviews.llvm.org/D85036 being reverted upstream.

rdar://81815347
