### PR TITLE
[CSGen] A couple of improvements to pattern binding handling

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3918,8 +3918,15 @@ bool ConstraintSystem::generateConstraints(
 
     /// Generate constraints for each pattern binding entry
     for (unsigned index : range(patternBinding->getNumPatternEntries())) {
-      // Type check the pattern.
-      auto pattern = patternBinding->getPattern(index);
+      auto *pattern = TypeChecker::resolvePattern(
+          patternBinding->getPattern(index), dc, /*isStmtCondition=*/true);
+
+      if (!pattern)
+        return true;
+
+      // Type check the pattern. Note use of `forRawPattern` here instead
+      // of `forPatternBindingDecl` because resolved `pattern` is not
+      // associated with `patternBinding`.
       auto contextualPattern = ContextualPattern::forRawPattern(pattern, dc);
       Type patternType = TypeChecker::typeCheckPattern(contextualPattern);
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3930,6 +3930,10 @@ bool ConstraintSystem::generateConstraints(
       auto contextualPattern = ContextualPattern::forRawPattern(pattern, dc);
       Type patternType = TypeChecker::typeCheckPattern(contextualPattern);
 
+      // Fail early if pattern couldn't be type-checked.
+      if (!patternType || patternType->hasError())
+        return true;
+
       auto init = patternBinding->getInit(index);
       if (!init) {
         llvm_unreachable("Unsupported pattern binding entry");


### PR DESCRIPTION
-  Resolve binding pattern before using it
- Fail early if pattern binding is incorrect

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
