### PR TITLE
[stdlib] ContiguousArray & ArraySlice: Stop swapping self in wUMBP

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1604,7 +1604,7 @@ extension Array {
     _makeMutableAndUnique()
     let count = _buffer.mutableCount
 
-    // Create an UnsafeBufferPointer over work that we can pass to body
+    // Create an UnsafeBufferPointer that we can pass to body
     let pointer = _buffer.mutableFirstElementAddress
     var inoutBufferPointer = UnsafeMutableBufferPointer(
       start: pointer, count: count)
@@ -1615,6 +1615,7 @@ extension Array {
         inoutBufferPointer.count == count,
         "Array withUnsafeMutableBufferPointer: replacing the buffer is not allowed")
       _endMutation()
+      _fixLifetime(self)
     }
 
     // Invoke the body.

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1176,32 +1176,18 @@ extension ContiguousArray {
     _makeMutableAndUnique()
     let count = _buffer.mutableCount
 
-    // Ensure that body can't invalidate the storage or its bounds by
-    // moving self into a temporary working array.
-    // NOTE: The stack promotion optimization that keys of the
-    // "array.withUnsafeMutableBufferPointer" semantics annotation relies on the
-    // array buffer not being able to escape in the closure. It can do this
-    // because we swap the array buffer in self with an empty buffer here. Any
-    // escape via the address of self in the closure will therefore escape the
-    // empty array.
-
-    var work = ContiguousArray()
-    (work, self) = (self, work)
-
-    // Create an UnsafeBufferPointer over work that we can pass to body
-    let pointer = work._buffer.mutableFirstElementAddress
+    // Create an UnsafeBufferPointer that we can pass to body
+    let pointer = _buffer.mutableFirstElementAddress
     var inoutBufferPointer = UnsafeMutableBufferPointer(
       start: pointer, count: count)
 
-    // Put the working array back before returning.
     defer {
       _precondition(
         inoutBufferPointer.baseAddress == pointer &&
         inoutBufferPointer.count == count,
         "ContiguousArray withUnsafeMutableBufferPointer: replacing the buffer is not allowed")
-
-      (work, self) = (self, work)
       _endMutation()
+      _fixLifetime(self)
     }
 
     // Invoke the body.


### PR DESCRIPTION
Implements https://github.com/apple/swift/pull/38867 for ContiguousArray and ArraySlice -- these have the same unnecessary swapping logic.
