### PR TITLE
[Index] Walk implicit DeclRefExpr with an explicit ValueDecl.

### DIFF
--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -309,7 +309,14 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
   if (auto *CtorRefE = dyn_cast<ConstructorRefCallExpr>(E))
     CtorRefs.push_back(CtorRefE);
 
+  bool IsImplicitDeclRefToExplicitDecl = false;
+
   if (auto *DRE = dyn_cast<DeclRefExpr>(E)) {
+    auto ED = DRE->getDecl();
+    if (E->isImplicit() && ED && !ED->isImplicit()) {
+      IsImplicitDeclRefToExplicitDecl = true;
+    }
+
     auto *FD = dyn_cast<FuncDecl>(DRE->getDecl());
     // Handle implicit callAsFunction reference. An explicit reference will be
     // handled by the usual DeclRefExpr case below.
@@ -321,7 +328,8 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
     }
   }
 
-  if (!isa<InOutExpr>(E) &&
+  if (!IsImplicitDeclRefToExplicitDecl &&
+      !isa<InOutExpr>(E) &&
       !isa<LoadExpr>(E) &&
       !isa<OpenExistentialExpr>(E) &&
       !isa<MakeTemporarilyEscapableExpr>(E) &&

--- a/test/Index/index_appendinterpolation.swift
+++ b/test/Index/index_appendinterpolation.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-ide-test -print-indexed-symbols -swift-version 5 -source-filename %s | %FileCheck %s
+
+extension DefaultStringInterpolation {
+    mutating func appendInterpolation(test value: Int) {
+        appendInterpolation(value)
+    }
+}
+
+"\(test: 1)"
+// CHECK: [[@LINE-1]]:3 | instance-method/Swift | appendInterpolation(test:) | {{.*}} | Ref,Call | rel: 0


### PR DESCRIPTION
All references to explicit declarations should be included in the index store, even when those references are themselves implicit. For example, a custom `appendInterpolation(custom:)` method in `DefaultStringInterpolation` is referenced implicitly via string interpolation: `"\(custom: 1)"`.

Resolves: #56189

@benlangmuir 