### PR TITLE
Speculative PrintAsObjC crasher fix

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -96,5 +96,20 @@ WARNING(import_multiple_mainactor_attr,none,
 
 ERROR(module_map_not_found, none, "module map file '%0' not found", (StringRef))
 
+//------------------------------------------------------------------------------
+// MARK: PrintAsObjC
+//------------------------------------------------------------------------------
+// Included here only because the diagnostic below is hopefully temporary. If
+// PrintAsObjC ever grows its own diagnostics for real, we should put them in
+// their own file.
+
+WARNING(objc_printing_unexpected_sort_tie,none,
+        "generated header file declaration order may change on recompile "
+        "because '@objc' %0 %1 unexpectedly cannot be sorted with respect to "
+        "other %0 %1; non-extensions should always be sortable, so please file "
+        "a bug report (" SWIFT_BUG_REPORT_URL ") containing the build log and, "
+        "if possible, the source code of your project",
+        (DescriptiveDeclKind, DeclName, DescriptiveDeclKind, DeclName))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"


### PR DESCRIPTION
Before printing the top-level decls in the generated header, PrintAsObjC sorts them to ensure they will be printed in a stable order. This sort starts by evaluating several criteria which ought to distinguish any ValueDecls, then includes extra criteria to sort ExtensionDecls on the same type.

Apple has received a number of automated crash reports on this extension-only part of the sort comparison. Unfortunately, nobody has filed a bug report about this crash and we have not been able to devise a reproducer, but the crash reports are consistent with the comparison misinterpreting other declaration kinds as ExtensionDecls. In theory, the code above this point ought to always return when it isn't processing two ExtensionDecls, but in practice it seems like it doesn't.

Without a reproducer for this bug, we cannot fully fix it, but we can at least make the code more defensive by adding an explicit check that it is only handling `ExtensionDecl`s. This will cause declarations to be printed in the header in a nondeterministic order, so we will emit a warning soliciting a bug report to gather more information about this problem.

Hopefully fixes rdar://81811616, at least to the point of no longer crashing. No new tests because we don't know how to cause this crash.