### PR TITLE
libswift: fix a static assert when compiling on architectures with 32-bit pointer sizes

### DIFF
--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -32,7 +32,7 @@ typedef struct {
 
 enum {
   BridgedOperandSize = 4 * sizeof(uintptr_t),
-  BridgedSuccessorSize = 5 * sizeof(uintptr_t)
+  BridgedSuccessorSize = 4 * sizeof(uintptr_t) + sizeof(uint64_t)
 };
 
 typedef struct {


### PR DESCRIPTION
rdar://82008922
