### PR TITLE
Don't crash on invalid dependent values

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4404,6 +4404,9 @@ namespace {
     AccessorDecl *tryCreateConstexprAccessor(const clang::VarDecl *clangVar,
                                              VarDecl *swiftVar) {
       assert(clangVar->isConstexpr());
+      auto *Eval = clangVar->ensureEvaluatedStmt();
+      if (cast<clang::Expr>(Eval->Value)->isValueDependent())
+        return nullptr;
       clangVar->evaluateValue();
       auto evaluated = clangVar->getEvaluatedValue();
       if (!evaluated)

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4404,9 +4404,9 @@ namespace {
     AccessorDecl *tryCreateConstexprAccessor(const clang::VarDecl *clangVar,
                                              VarDecl *swiftVar) {
       assert(clangVar->isConstexpr());
-      // Ensure that the value of const expression doesn't rely on template 
-      // parameter. This prevents compiler crash due to assertion failure on the 
-      //clang side.
+      // Ensure that the value of const expression doesn't rely on template
+      // parameter. This prevents compiler crash due to assertion failure on the
+      // clang side.
       auto *eval = clangVar->ensureEvaluatedStmt();
       if (cast<clang::Expr>(eval->Value)->isValueDependent())
         return nullptr;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4404,8 +4404,11 @@ namespace {
     AccessorDecl *tryCreateConstexprAccessor(const clang::VarDecl *clangVar,
                                              VarDecl *swiftVar) {
       assert(clangVar->isConstexpr());
-      auto *Eval = clangVar->ensureEvaluatedStmt();
-      if (cast<clang::Expr>(Eval->Value)->isValueDependent())
+      // Ensure that the value of const expression doesn't rely on template 
+      // parameter. This prevents compiler crash due to assertion failure on the 
+      //clang side.
+      auto *eval = clangVar->ensureEvaluatedStmt();
+      if (cast<clang::Expr>(eval->Value)->isValueDependent())
         return nullptr;
       clangVar->evaluateValue();
       auto evaluated = clangVar->getEvaluatedValue();

--- a/test/Interop/Cxx/static/Inputs/constexpr-static-member-var-errors.h
+++ b/test/Interop/Cxx/static/Inputs/constexpr-static-member-var-errors.h
@@ -11,3 +11,11 @@ struct GetTypeValueInline {
 };
 
 using Invalid2 = GetTypeValueInline<int>;
+
+struct S {};
+template <class T>
+struct IsSubtypeSame {
+   static constexpr const S value = T();
+};
+
+using Invalid3 = IsSubtypeSame<int>;

--- a/test/Interop/Cxx/static/Inputs/constexpr-static-member-var-errors.h
+++ b/test/Interop/Cxx/static/Inputs/constexpr-static-member-var-errors.h
@@ -15,7 +15,7 @@ using Invalid2 = GetTypeValueInline<int>;
 struct S {};
 template <class T>
 struct IsSubtypeSame {
-   static constexpr const S value = T();
+  static constexpr const S value = T();
 };
 
 using Invalid3 = IsSubtypeSame<int>;

--- a/test/Interop/Cxx/static/constexpr-static-member-var-errors.swift
+++ b/test/Interop/Cxx/static/constexpr-static-member-var-errors.swift
@@ -8,3 +8,6 @@
 
 // CHECK: error: type 'int' cannot be used prior to '::' because it has no members
 // CHECK: note: in instantiation of static data member 'GetTypeValueInline<int>::value' requested here
+
+// CHECK: error: no viable conversion from 'int' to 'const S'
+// CHECK: note: in instantiation of template class 'IsSubtypeSame<int>' requested here


### PR DESCRIPTION
<!-- What's in this pull request? -->
Swift compiler crashes when the expression is value dependant. This PR fixes it.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-14443](https://bugs.swift.org/browse/SR-14443)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
