### PR TITLE
Fixing flag truncations in llvm-readobj tests

### DIFF
--- a/test/Incremental/autolinking-overlay.swift
+++ b/test/Incremental/autolinking-overlay.swift
@@ -9,9 +9,9 @@
 // RUN: %target-build-swift-dylib(%t/%target-library-name(AutolinkingTest)) -autolink-force-load -module-link-name swiftAutolinkingTest -incremental -driver-show-incremental -module-name AutolinkingTest -output-file-map ofm.json -F %t -import-underlying-module autolinking-overlay.swift autolinking-other.swift
 
 // Make sure `swift_FORCE_LOAD_$_swiftAutolinkingTest` appears in all objects
-// RUN: llvm-readobj -symbols -coff-exports %t/autolinking-overlay.o | %FileCheck %s
-// RUN: llvm-readobj -symbols -coff-exports %t/autolinking-other.o | %FileCheck %s
-// RUN: llvm-readobj -symbols -coff-exports %t/%target-library-name(AutolinkingTest) | %FileCheck %s
+// RUN: llvm-readobj --symbols --coff-exports %t/autolinking-overlay.o | %FileCheck %s
+// RUN: llvm-readobj --symbols --coff-exports %t/autolinking-other.o | %FileCheck %s
+// RUN: llvm-readobj --symbols --coff-exports %t/%target-library-name(AutolinkingTest) | %FileCheck %s
 
 // Emulate an overlay build by importing content from the underlying module.
 extension Test { }

--- a/test/Incremental/autolinking.swift
+++ b/test/Incremental/autolinking.swift
@@ -9,8 +9,8 @@
 // RUN: %target-build-swift-dylib(%t/%target-library-name(AutolinkingTest)) -autolink-force-load -module-link-name swiftAutolinkingTest -incremental -driver-show-incremental -module-name AutolinkingTest -output-file-map ofm.json autolinking.swift autolinking-other.swift
 
 // Make sure `swift_FORCE_LOAD_$_swiftAutolinkingTest` appears in all objects
-// RUN: llvm-readobj -symbols -coff-exports %t/autolinking.o | %FileCheck %s
-// RUN: llvm-readobj -symbols -coff-exports %t/autolinking-other.o | %FileCheck %s
-// RUN: llvm-readobj -symbols -coff-exports %t/%target-library-name(AutolinkingTest) | %FileCheck %s
+// RUN: llvm-readobj --symbols --coff-exports %t/autolinking.o | %FileCheck %s
+// RUN: llvm-readobj --symbols --coff-exports %t/autolinking-other.o | %FileCheck %s
+// RUN: llvm-readobj --symbols --coff-exports %t/%target-library-name(AutolinkingTest) | %FileCheck %s
 
 // CHECK: _swift_FORCE_LOAD_$_swiftAutolinkingTest

--- a/test/multifile/protocol-conformance-member.swift
+++ b/test/multifile/protocol-conformance-member.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -emit-library %s %S/Inputs/protocol-conformance-member-helper.swift -o %t/%target-library-name(Test) -module-name Test
-// RUN: llvm-readobj -symbols -coff-exports %t/%target-library-name(Test) | %FileCheck %s
+// RUN: llvm-readobj --symbols --coff-exports %t/%target-library-name(Test) | %FileCheck %s
 
 // CHECK: Name: {{_?}}$s4Test10CoolStructV10coolFactorSdvg
 


### PR DESCRIPTION
It looks like llvm commit 46580d43fc70d migrated the flags from llvm::cl to
OptTable. As a result, the flag behaviour changed. LLVM Commit
e29e30b1397f3e50f3487491f8a77ae08e4e3471 from 2019 went through and
changed the llvm tests to consistently use the double-dash for long
options so it was undetected.

With this info, I'm just going to go ahead and fix these tests cases to
get them going again.

rdar://81804962