### PR TITLE
Concurrency: Don't rely on future wait context in asyncLet_finish.

### DIFF
--- a/test/Concurrency/Runtime/async_let_throw_completion_order.swift
+++ b/test/Concurrency/Runtime/async_let_throw_completion_order.swift
@@ -1,0 +1,28 @@
+// rdar://81481317
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking %import-libdispatch -parse-as-library) | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+struct Bad: Error {}
+
+class Foo { init() async throws {}; deinit { print("Foo down") } }
+class Bar { init() async throws { throw Bad() }; deinit { print("Bar down") } }
+class Baz { init() async throws {}; deinit { print("Baz down") } }
+
+func zim(y: Bar, x: Foo, z: Baz) { print("hooray") }
+
+@main struct Butt {
+
+  static func main() async {
+    do {
+      async let x = Foo()
+      async let y = Bar()
+      async let z = Baz()
+
+      return try await zim(y: y, x: x, z: z)
+    } catch {
+      // CHECK: oopsie woopsie
+      print("oopsie woopsie")
+    }
+  }
+}


### PR DESCRIPTION
If a future task has already completed, then task_future_wait doesn't populate the future context,
but asyncLet_finish was inappropriately relying on it to recover the result buffer pointer to
destroy the value inside. There's room in asyncLet_finish's own context to put this pointer, so
do that instead. Fixes rdar://81481317.