### PR TITLE
[SILOptimizer] Remove auxiliary debug scope in SILDebugInfoGenerator

### DIFF
--- a/lib/SILOptimizer/UtilityPasses/SILDebugInfoGenerator.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SILDebugInfoGenerator.cpp
@@ -150,6 +150,12 @@ class SILDebugInfoGenerator : public SILModuleTransform {
               I->eraseFromParent();
               continue;
             }
+            if (auto *ASI = dyn_cast<AllocStackInst>(I))
+              // Remove the debug variable scope enclosed
+              // within the SILDebugVariable such that we won't
+              // trigger a verification error.
+              ASI->setDebugVarScope(nullptr);
+
             SILLocation Loc = I->getLoc();
             auto *filePos = SILLocation::FilenameAndLocation::alloc(
                 Ctx.LineNums[I], 1, FileNameBuf, *M);


### PR DESCRIPTION
Previously inside SILDebugInfoGenerator (i.e. `-sil-based-debuginfo`
flag) we're removing all `debug_value` and `debug_value_addr` to avoid
mixing Swift and SIL source location. But we forgot to handle the source
location inside the auxiliary debug variable info in a `alloc_stack`
instruction. Which triggered a verification error regarding debug scope
mismatch.

This patch teaches SILDebugInfoGenerator to remove any auxiliary debug
variable scope, if there is any. Which might degrade the debug info
quality but we're mostly care about line number in this mode.

rdar://81709398