### PR TITLE
[Refactorings] Add cursor refactorings for the start of the range

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -3788,43 +3788,18 @@ bool RefactoringActionTrailingClosure::performChange() {
   return false;
 }
 
-static bool rangeStartMayNeedRename(const ResolvedRangeInfo &Info) {
-  switch(Info.Kind) {
-    case RangeKind::SingleExpression: {
-      Expr *E = Info.ContainedNodes[0].get<Expr*>();
-      // We should show rename for the selection of "foo()"
-      if (auto *CE = dyn_cast<CallExpr>(E)) {
-        if (CE->getFn()->getKind() == ExprKind::DeclRef)
-          return true;
-
-        // When callling an instance method inside another instance method,
-        // we have a dot syntax call whose dot and base are both implicit. We
-        // need to explicitly allow the specific case here.
-        if (auto *DSC = dyn_cast<DotSyntaxCallExpr>(CE->getFn())) {
-          if (DSC->getBase()->isImplicit() &&
-              DSC->getFn()->getStartLoc() == Info.TokensInRange.front().getLoc())
-            return true;
-        }
-      }
-      return false;
-    }
-    case RangeKind::PartOfExpression: {
-      if (auto *CE = dyn_cast<CallExpr>(Info.CommonExprParent)) {
-        if (auto *DSC = dyn_cast<DotSyntaxCallExpr>(CE->getFn())) {
-          if (DSC->getFn()->getStartLoc() == Info.TokensInRange.front().getLoc())
-            return true;
-        }
-      }
-      return false;
-    }
-    case RangeKind::SingleDecl:
-    case RangeKind::MultiTypeMemberDecl:
-    case RangeKind::SingleStatement:
-    case RangeKind::MultiStatement:
-    case RangeKind::Invalid:
-      return false;
+static bool collectRangeStartRefactorings(const ResolvedRangeInfo &Info) {
+  switch (Info.Kind) {
+  case RangeKind::SingleExpression:
+  case RangeKind::SingleStatement:
+  case RangeKind::SingleDecl:
+  case RangeKind::PartOfExpression:
+    return true;
+  case RangeKind::MultiStatement:
+  case RangeKind::MultiTypeMemberDecl:
+  case RangeKind::Invalid:
+    return false;
   }
-  llvm_unreachable("unhandled kind");
 }
     
 bool RefactoringActionConvertToComputedProperty::
@@ -8292,7 +8267,7 @@ void swift::ide::collectAvailableRefactorings(
 }
 
 void swift::ide::collectAvailableRefactorings(
-    SourceFile *SF, RangeConfig Range, bool &RangeStartMayNeedRename,
+    SourceFile *SF, RangeConfig Range, bool &CollectRangeStartRefactorings,
     SmallVectorImpl<RefactoringKind> &Kinds,
     ArrayRef<DiagnosticConsumer *> DiagConsumers) {
   if (Range.Length == 0) {
@@ -8321,7 +8296,7 @@ void swift::ide::collectAvailableRefactorings(
     RANGE_REFACTORING(KIND, NAME, ID)
 #include "swift/IDE/RefactoringKinds.def"
 
-  RangeStartMayNeedRename = rangeStartMayNeedRename(Result);
+  CollectRangeStartRefactorings = collectRangeStartRefactorings(Result);
 }
 
 bool swift::ide::

--- a/test/SourceKit/Refactoring/basic.swift
+++ b/test/SourceKit/Refactoring/basic.swift
@@ -116,9 +116,12 @@ HasInitWithDefaultArgs(y: 45, z: 89)
 func `hasBackticks`(`x`: Int) {}
 `hasBackticks`(`x`:2)
 
-func hasAsyncAlternative(completion: @escaping (String?, Error?) -> Void) { }
-func hasCallToAsyncAlternative() {
-  hasAsyncAlternative { str, err in print(str!) }
+struct ConvertAsync {
+  func hasAsyncAlternative(completion: @escaping (String?, Error?) -> Void) { }
+}
+func hasCallToAsyncAlternative(c: ConvertAsync) {
+  ((((c)).hasAsyncAlternative)) { str, err in print(str!) }
+  c.hasAsyncAlternative() { str, err in print(str!) }
 }
 
 // RUN: %sourcekitd-test -req=cursor -pos=3:1 -end-pos=5:13 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK1
@@ -167,12 +170,9 @@ func hasCallToAsyncAlternative() {
 // RUN: %sourcekitd-test -req=cursor -pos=117:16  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
 // RUN: %sourcekitd-test -req=cursor -pos=117:17  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
 
-// RUN: %sourcekitd-test -req=cursor -pos=119:6  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-ASYNC
-// RUN: %sourcekitd-test -req=cursor -pos=121:3  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-CALLASYNC
-
-// RUN: %sourcekitd-test -req=cursor -pos=35:10 -end-pos=35:16 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-RENAME-EXTRACT
 // RUN: %sourcekitd-test -req=cursor -pos=35:10 -end-pos=35:16 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-RENAME-EXTRACT
 
+// RUN: %sourcekitd-test -req=cursor -pos=54:10 -end-pos=54:22 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-LOCAL
 // RUN: %sourcekitd-test -req=cursor -pos=54:12 -end-pos=54:22 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-SELF-RENAME1
 // RUN: %sourcekitd-test -req=cursor -pos=54:23 -end-pos=54:33 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-SELF-RENAME2
 // RUN: %sourcekitd-test -req=cursor -pos=54:34 -end-pos=54:44 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-SELF-RENAME3
@@ -183,6 +183,17 @@ func hasCallToAsyncAlternative() {
 
 // RUN: %sourcekitd-test -req=cursor -pos=72:5 -end-pos=72:11 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-RENAME-EXTRACT
 // RUN: %sourcekitd-test -req=cursor -pos=78:3 -end-pos=78:9 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-RENAME-EXTRACT
+
+// RUN: %sourcekitd-test -req=cursor -pos=120:8 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-ASYNC
+// RUN: %sourcekitd-test -req=cursor -pos=123:11 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-CALLASYNC
+// RUN: %sourcekitd-test -req=cursor -pos=123:11 -end-pos=123:30 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-CALLASYNC
+// RUN: %sourcekitd-test -req=cursor -pos=123:3 -end-pos=123:30 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-CALLASYNC
+// RUN: %sourcekitd-test -req=cursor -pos=123:3 -end-pos=123:60 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-CALLASYNC
+// RUN: %sourcekitd-test -req=cursor -pos=123:3 -end-pos=123:46 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-CALLASYNC
+// RUN: %sourcekitd-test -req=cursor -pos=123:3 -end-pos=123:58 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-CALLASYNC
+// RUN: %sourcekitd-test -req=cursor -pos=124:3 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-CALLASYNC
+// RUN: %sourcekitd-test -req=cursor -pos=124:3 -end-pos=124:26 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-CALLASYNC
+// RUN: %sourcekitd-test -req=cursor -pos=124:3 -end-pos=124:54  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-CALLASYNC
 
 // CHECK-NORENAME-NOT: Global Rename
 // CHECK-NORENAME-NOT: Local Rename

--- a/test/SourceKit/Refactoring/rename-objc.swift
+++ b/test/SourceKit/Refactoring/rename-objc.swift
@@ -8,14 +8,11 @@ func foo1() {
 // RUN: %sourcekitd-test -req=cursor -pos=4:30 -cursor-action %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck %s -check-prefix=CHECK1
 // RUN: %sourcekitd-test -req=cursor -pos=4:30 -length=3 -cursor-action %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck %s -check-prefix=CHECK1
 // RUN: %sourcekitd-test -req=cursor -pos=4:20 -length=15 -cursor-action %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck %s -check-prefix=CHECK1
-// RUN: %sourcekitd-test -req=cursor -pos=4:20 -length=16 -cursor-action %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck %s -check-prefix=CHECK2
+// RUN: %sourcekitd-test -req=cursor -pos=4:20 -length=16 -cursor-action %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck %s -check-prefix=CHECK1
 
 // CHECK1: ACTIONS BEGIN
 // CHECK1-NEXT: source.refactoring.kind.rename.global
 // CHECK1-NEXT: Global Rename
 // CHECK1-NEXT: cannot rename a Clang symbol from its Swift reference
-
-// CHECK2: ACTIONS BEGIN
-// CHECK2-NEXT: ACTIONS END
 
 // REQUIRES: OS=macosx || OS=linux-gnu

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -399,9 +399,9 @@ int main(int argc, char *argv[]) {
 
   if (options::Action == RefactoringKind::None) {
     llvm::SmallVector<RefactoringKind, 32> Kinds;
-    bool RangeStartMayNeedRename = false;
-    collectAvailableRefactorings(SF, Range, RangeStartMayNeedRename, Kinds,
-                                 {&PrintDiags});
+    bool CollectRangeStartRefactorings = false;
+    collectAvailableRefactorings(SF, Range, CollectRangeStartRefactorings,
+                                 Kinds, {&PrintDiags});
     llvm::outs() << "Action begins\n";
     for (auto Kind : Kinds) {
       llvm::outs() << getDescriptiveRefactoringKindName(Kind) << "\n";


### PR DESCRIPTION
When a range is a single expression/statement/decl or part of
expression, also return cursor based refactorings for the start of the
range.

This is a stop gap until the available refactorings are properly fixed
to be more lenient in general - the current fix is a little odd as eg.
if all of `foo.bar()` is selected, rename will be returned as an
available refactoring for `foo`. Still an improvement over completely
missing cursor based refactorings, however.

Resolves rdar://82060063