### PR TITLE
[PrintAsObjC] Do not output invalid decls when allowing errors

### DIFF
--- a/lib/PrintAsObjC/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.cpp
@@ -2017,7 +2017,7 @@ auto DeclAndTypePrinter::getImpl() -> Implementation {
 }
 
 bool DeclAndTypePrinter::shouldInclude(const ValueDecl *VD) {
-  return isVisibleToObjC(VD, minRequiredAccess) &&
+  return !VD->isInvalid() && isVisibleToObjC(VD, minRequiredAccess) &&
          !VD->getAttrs().hasAttribute<ImplementationOnlyAttr>();
 }
 


### PR DESCRIPTION
We still want the ObjectiveC header when allowing errors, but make sure
to skip printing out any invalid declarations that may be caused because
of those errors.

In particular, duplicate declarations were causing a crash when sorting
declarations where various assumptions would end up casting a
non-ExtensionDecl to an ExtensionDecl.

Resolves rdar://78023656