### PR TITLE
[SE-0286] Disable backward scanning for trailing closures in Swift 6 mode

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -333,14 +333,6 @@ namespace swift {
     /// behavior. This is a staging flag, and will be removed in the future.
     bool EnableNewOperatorLookup = false;
 
-    /// Whether to enable the "fuzzy" forward-scanning behavior for trailing
-    /// closure matching, which skips over defaulted closure parameters
-    /// to match later (non-defaulted) closure parameters
-    ///
-    /// This is a backward-compatibility hack for unlabeled trailing closures,
-    /// to be disabled in Swift 6+.
-    bool EnableFuzzyForwardScanTrailingClosureMatching = true;
-
     /// Use Clang function types for computing canonical types.
     /// If this option is false, the clang function types will still be computed
     /// but will not be used for checking type equality.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -580,16 +580,6 @@ def enable_experimental_concise_pound_file : Flag<["-"],
   Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Enable experimental concise '#file' identifier">;
 
-def disable_fuzzy_forward_scan_trailing_closure_matching : Flag<["-"],
-    "disable-fuzzy-forward-scan-trailing-closure-matching">,
-  Flags<[FrontendOption]>,
-  HelpText<"Disable fuzzy forward-scan trailing closure matching">;
-
-def enable_fuzzy_forward_scan_trailing_closure_matching : Flag<["-"],
-    "enable-fuzzy-forward-scan-trailing-closure-matching">,
-  Flags<[FrontendOption]>,
-  HelpText<"Enable fuzzy forward-scan trailing closure matching">;
-
 def enable_experimental_cxx_interop :
   Flag<["-"], "enable-experimental-cxx-interop">,
   HelpText<"Allow importing C++ modules into Swift (experimental feature)">;

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -282,10 +282,6 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_diagnostic_style);
   inputArgs.AddLastArg(arguments,
                        options::OPT_enable_experimental_concise_pound_file);
-  inputArgs.AddLastArg(
-      arguments,
-      options::OPT_enable_fuzzy_forward_scan_trailing_closure_matching,
-      options::OPT_disable_fuzzy_forward_scan_trailing_closure_matching);
   inputArgs.AddLastArg(arguments,
                        options::OPT_verify_incremental_dependencies);
   inputArgs.AddLastArg(arguments, options::OPT_access_notes_path);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -659,10 +659,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableConcisePoundFile =
       Args.hasArg(OPT_enable_experimental_concise_pound_file) ||
       Opts.EffectiveLanguageVersion.isVersionAtLeast(6);
-  Opts.EnableFuzzyForwardScanTrailingClosureMatching =
-      Args.hasFlag(OPT_enable_fuzzy_forward_scan_trailing_closure_matching,
-                   OPT_disable_fuzzy_forward_scan_trailing_closure_matching,
-                   true);
 
   Opts.EnableCrossImportOverlays =
       Args.hasFlag(OPT_enable_cross_import_overlays,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -446,11 +446,11 @@ static bool matchCallArgumentsImpl(
       }
 
       // If this parameter does not require an argument, consider applying a
-      // "fuzzy" match rule that skips this parameter if doing so is the only
+      // backward-match rule that skips this parameter if doing so is the only
       // way to successfully match arguments to parameters.
       if (!parameterRequiresArgument(params, paramInfo, paramIdx) &&
-          param.getPlainType()->getASTContext().LangOpts
-              .EnableFuzzyForwardScanTrailingClosureMatching &&
+          !param.getPlainType()->getASTContext().LangOpts
+              .isSwiftVersionAtLeast(6) &&
           anyParameterRequiresArgument(
               params, paramInfo, paramIdx + 1,
               nextArgIdx + 1 < numArgs
@@ -900,9 +900,9 @@ static bool requiresBothTrailingClosureDirections(
   if (params.empty())
     return false;
 
-  // If "fuzzy" matching is disabled, only scan forward.
+  // If backward matching is disabled, only scan forward.
   ASTContext &ctx = params.front().getPlainType()->getASTContext();
-  if (!ctx.LangOpts.EnableFuzzyForwardScanTrailingClosureMatching)
+  if (ctx.LangOpts.isSwiftVersionAtLeast(6))
     return false;
 
   // If there are at least two parameters that meet the backward scan's

--- a/test/Concurrency/actor_definite_init_swift6.swift
+++ b/test/Concurrency/actor_definite_init_swift6.swift
@@ -330,7 +330,7 @@ struct CardboardBox<T> {
 
 
 @available(SwiftStdlib 5.5, *)
-var globalVar: EscapeArtist?
+var globalVar: EscapeArtist? // expected-note 2 {{var declared here}}
 
 @available(SwiftStdlib 5.5, *)
 actor EscapeArtist {
@@ -340,7 +340,9 @@ actor EscapeArtist {
         self.x = 0
 
         globalVar = self    // expected-error {{this use of actor 'self' can only appear in an async initializer}}
+        // expected-warning@-1{{reference to var 'globalVar' is not concurrency-safe because it involves shared mutable state}}
         Task { await globalVar!.isolatedMethod() }
+        // expected-warning@-1{{reference to var 'globalVar' is not concurrency-safe because it involves shared mutable state}}
 
         if self.x == 0 {
             fatalError("race detected.")

--- a/test/Concurrency/actor_keypath_isolation_swift6.swift
+++ b/test/Concurrency/actor_keypath_isolation_swift6.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift  -disable-availability-checking -warn-concurrency -swift-version 6
 // REQUIRES: concurrency && asserts
 
-class Box {
+class Box { // expected-note 3{{class 'Box' does not conform to the `Sendable` protocol}}
     let size : Int = 0
 }
 

--- a/test/decl/protocol/special/Sendable_swift6.swift
+++ b/test/decl/protocol/special/Sendable_swift6.swift
@@ -4,7 +4,7 @@
 
 func acceptSendable<T: Sendable>(_: T) { }
 
-class NotSendable { }
+class NotSendable { } // expected-note 2{{class 'NotSendable' does not conform to the `Sendable` protocol}}
 
 func testSendableBuiltinConformances(
   i: Int, ns: NotSendable, sf: @escaping @Sendable () -> Void,
@@ -23,8 +23,11 @@ func testSendableBuiltinConformances(
 
   // Complaints about missing Sendable conformances
   acceptSendable((i, ns)) // expected-error{{type 'NotSendable' does not conform to the 'Sendable' protocol}}
-  acceptSendable(nsf) // expected-error{{function type '() -> Void' must be marked '@Sendable' to conform to 'Sendable'}}
-  acceptSendable((nsf, i)) // expected-error{{function type '() -> Void' must be marked '@Sendable' to conform to 'Sendable'}}
-  acceptSendable(funNotSendable) // expected-error{{function type '() -> Void' must be marked '@Sendable' to conform to 'Sendable'}}
+  acceptSendable(nsf) // expected-error{{type '() -> Void' does not conform to the 'Sendable' protocol}}
+  // expected-note@-1{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  acceptSendable((nsf, i)) // expected-error{{type '() -> Void' does not conform to the 'Sendable' protocol}}
+  // expected-note@-1{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  acceptSendable(funNotSendable) // expected-error{{type '() -> Void' does not conform to the 'Sendable' protocol}}
+  // expected-note@-1{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   acceptSendable((i, ns)) // expected-error{{type 'NotSendable' does not conform to the 'Sendable' protocol}}
 }

--- a/test/expr/postfix/call/forward_trailing_closure.swift
+++ b/test/expr/postfix/call/forward_trailing_closure.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift -disable-fuzzy-forward-scan-trailing-closure-matching
+// RUN: %target-typecheck-verify-swift -swift-version 6
+// REQUIRES: asserts
 
 func forwardMatch1(
   a: Int = 0, b: Int = 17, closure1: (Int) -> Int = { $0 }, c: Int = 42,

--- a/test/expr/postfix/call/forward_trailing_closure_errors.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_errors.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift -disable-fuzzy-forward-scan-trailing-closure-matching
+// RUN: %target-typecheck-verify-swift -swift-version 6
+// REQUIRES: asserts
 
 func forwardMatchWithGeneric<T>( // expected-note{{'forwardMatchWithGeneric(closure1:closure2:)' declared here}}
   closure1: T,


### PR DESCRIPTION
Remove the experimental staging flag used to disable the backward scan for trailing closure matching. Instead, implement this semantics as part of the Swift 6 language mode.