### PR TITLE
Deserializer: call the deserialization callback when a new function declaration is created

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -406,7 +406,14 @@ SILFunction *SILDeserializer::getFuncForReference(StringRef name,
   // SIL.
   SourceLoc sourceLoc;
   SILSerializationFunctionBuilder builder(SILMod);
-  return builder.createDeclaration(name, type, RegularLocation(sourceLoc));
+  fn = builder.createDeclaration(name, type,
+                                 RegularLocation(sourceLoc));
+  // The function is not really de-serialized, but it's important to call
+  // `didDeserialize` on every new function. Otherwise some Analysis might miss
+  // `notifyAddedOrModifiedFunction` notifications.
+  if (Callback)
+    Callback->didDeserialize(MF->getAssociatedModule(), fn);
+  return fn;
 }
 
 /// Helper function to find a SILFunction, given its name and type.


### PR DESCRIPTION
This makes sure that all analysis will get the `notifyAddedOrModifiedFunction` notifications.
It fixes a crash in CallerAnalysis, which relies that it's notified for all newly created functions.

This is related to following bug reports for cross-module-optimization:

https://bugs.swift.org/browse/SR-15048
rdar://81701218

Although I believe that there are more bugs involved which need to be fixed.

Unfortunately I don't have a test case for this fix.
