### PR TITLE
[Rebranch] Remove undefined variables from let_decls

### DIFF
--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -398,7 +398,6 @@ struct StructMemberTest {
   // CHECK:  debug_value [[ARG]] : $StructMemberTest, let, name "self"
   // CHECK:  [[TRIVIAL_VALUE:%.*]] = struct_extract [[ARG]] : $StructMemberTest, #StructMemberTest.i
   // CHECK-NOT:  destroy_value [[ARG]] : $StructMemberTest
-  // CHECK-NOT:  destroy_value [[BORROWED_ARG]] : $StructMemberTest
   // CHECK:  return [[TRIVIAL_VALUE]] : $Int
 
   // Accessing the int member in s should not copy_value the whole struct.
@@ -454,7 +453,6 @@ struct GenericStruct<T> {
   // CHECK-NEXT: debug_value_addr [[SELF_ADDR]] : $*GenericStruct<T>, let, name "self"
   // CHECK-NEXT: [[PROJ_ADDR:%.*]] = struct_element_addr [[SELF_ADDR]] : $*GenericStruct<T>, #GenericStruct.b
   // CHECK-NEXT: [[PROJ_VAL:%.*]] = load [trivial] [[PROJ_ADDR]] : $*Int
-  // CHECK-NOT: destroy_addr [[SELF]] : $*GenericStruct<T>
   // CHECK-NEXT: return [[PROJ_VAL]] : $Int
 }
 


### PR DESCRIPTION
FileCheck no longer accepts undefined variables. Removing the ones in let_decls.swift

rdar://82050123