### PR TITLE
[5.5] Concurrency: Don't rely on future wait context in asyncLet_finish.

### DIFF
--- a/stdlib/public/Concurrency/AsyncLet.cpp
+++ b/stdlib/public/Concurrency/AsyncLet.cpp
@@ -247,8 +247,12 @@ static void swift_asyncLet_getImpl(SWIFT_ASYNC_CONTEXT AsyncContext *callerConte
 }
 
 struct AsyncLetContinuationContext: AsyncContext {
-  AsyncLet *alet;  
+  AsyncLet *alet;
+  OpaqueValue *resultBuffer;
 };
+
+static_assert(sizeof(AsyncLetContinuationContext) <= sizeof(TaskFutureWaitAsyncContext),
+              "compiler provides the same amount of context space to each");
 
 SWIFT_CC(swiftasync)
 static void _asyncLet_get_throwing_continuation(
@@ -370,8 +374,7 @@ static void _asyncLet_finish_continuation(
   auto continuationContext
     = reinterpret_cast<AsyncLetContinuationContext*>(callContext);
   auto alet = continuationContext->alet;
-  auto resultBuffer = asImpl(alet)->getFutureContext()
-                                  ->successResultPointer;
+  auto resultBuffer = continuationContext->resultBuffer;
   
   // Destroy the error, or the result that was stored to the buffer.
   if (error) {
@@ -416,6 +419,7 @@ static void swift_asyncLet_finishImpl(SWIFT_ASYNC_CONTEXT AsyncContext *callerCo
   aletContext->Parent = callerContext;
   aletContext->ResumeParent = resumeFunction;
   aletContext->alet = alet;
+  aletContext->resultBuffer = reinterpret_cast<OpaqueValue*>(resultBuffer);
   auto futureContext = asImpl(alet)->getFutureContext();
   
   // TODO: It would be nice if we could await the future without having to

--- a/test/Concurrency/Runtime/async_let_throw_completion_order.swift
+++ b/test/Concurrency/Runtime/async_let_throw_completion_order.swift
@@ -1,0 +1,28 @@
+// rdar://81481317
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking %import-libdispatch -parse-as-library) | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+struct Bad: Error {}
+
+class Foo { init() async throws {}; deinit { print("Foo down") } }
+class Bar { init() async throws { throw Bad() }; deinit { print("Bar down") } }
+class Baz { init() async throws {}; deinit { print("Baz down") } }
+
+func zim(y: Bar, x: Foo, z: Baz) { print("hooray") }
+
+@main struct Butt {
+
+  static func main() async {
+    do {
+      async let x = Foo()
+      async let y = Bar()
+      async let z = Baz()
+
+      return try await zim(y: y, x: x, z: z)
+    } catch {
+      // CHECK: oopsie woopsie
+      print("oopsie woopsie")
+    }
+  }
+}


### PR DESCRIPTION
Explanation: Fixes a bug where awaiting an `async let` binding after it has completed could cause memory corruption if tasks are scheduled in a particular order.

Scope: Fixes a runtime bug that causes unpredictable behavior, could be a security vulnerability, and doesn't have a clear workaround.

Issue: rdar://81481317

Risk: Low. The fix is small and scoped to `async let` behavior.

Testing: Swift CI, test case from Radar

Reviewed by: @mikeash, @rjmccall, @ktoso

