### PR TITLE
[Rebranch] Remove BORROWED_FN_COPY from unmanaged_ownership

### DIFF
--- a/test/SILGen/unmanaged_ownership.swift
+++ b/test/SILGen/unmanaged_ownership.swift
@@ -63,5 +63,4 @@ func project(fn fn: () -> Holder) -> C {
 // CHECK-NEXT: [[T0:%.*]] = apply [[FN]]()
 // CHECK-NEXT: [[T1:%.*]] = struct_extract [[T0]] : $Holder, #Holder.value
 // CHECK-NEXT: [[T2:%.*]] = strong_copy_unmanaged_value [[T1]]
-// CHECK-NOT: destroy_value [[BORROWED_FN_COPY]]
 // CHECK-NEXT: return [[T2]]


### PR DESCRIPTION
This test doesn't define a BORROWED_FN_COPY variable, so it is failing.
FileCheck no longer allows undefined variables.

rdar://82050267