### PR TITLE
[Tests] Fix a couple of type round trip test problems.

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -70,14 +70,8 @@ if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)
     "${SWIFT_SOURCE_DIR}/lib/Demangling/OldDemangler.cpp"
     "${SWIFT_SOURCE_DIR}/lib/Demangling/OldRemangler.cpp"
     "${SWIFT_SOURCE_DIR}/lib/Demangling/Punycode.cpp"
-    "${SWIFT_SOURCE_DIR}/lib/Demangling/Remangler.cpp")
-
-  # When we're building with assertions, include the demangle node dumper to aid
-  # in debugging.
-  if(LLVM_ENABLE_ASSERTIONS)
-    list(APPEND swiftDemanglingSources
-      "${SWIFT_SOURCE_DIR}/lib/Demangling/NodeDumper.cpp")
-  endif()
+    "${SWIFT_SOURCE_DIR}/lib/Demangling/Remangler.cpp"
+    "${SWIFT_SOURCE_DIR}/lib/Demangling/NodeDumper.cpp")
 
   add_swift_target_library(swiftDemangling OBJECT_LIBRARY
     ${swiftDemanglingSources}

--- a/test/TypeRoundTrip/Inputs/testcases/structural_types.swift
+++ b/test/TypeRoundTrip/Inputs/testcases/structural_types.swift
@@ -22,7 +22,11 @@ public func test() {
   roundTripType((x: Int, Float, y: Int.Type).self)
   roundTripType(((@escaping () -> ()) -> ()).self)
   roundTripType(Array<@convention(c) () -> ()>.self)
+
+  // @convention(block) requires Objective-C support
+  #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
   roundTripType(Array<(@escaping @convention(block) () -> (), @convention(block) () -> ()) -> ()>.self)
+  #endif
 
   roundTripType(Int.Type.self)
   roundTripType(((inout String) -> ()).Type.self)
@@ -39,7 +43,11 @@ public func test() {
   roundTripType((x: Int, Float, y: Int.Type).Type.self)
   roundTripType(((@escaping () -> ()) -> ()).Type.self)
   roundTripType(Array<@convention(c) () -> ()>.Type.self)
+
+  // @convention(block) requires Objective-C support
+  #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
   roundTripType(Array<(@escaping @convention(block) () -> (), @convention(block) () -> ()) -> ()>.Type.self)
+  #endif
 
   // rdar://81587763: [SR-15025]: Function type syntax doesn't accept variadics
   // or __owned


### PR DESCRIPTION
The stdlib version of libswiftDemangle doesn't include the node dumper when not building with assertions, but the type round trip test needs it.

Also, on Linux, it appears it's possible to write a type with `@convention(block)`, but passing that to the runtime causes an assertion failure if assertions are enabled. That's either a compiler bug (`@convention(block)` should only be allowed if we have ObjC interop), or a runtime bug (it shouldn't fail, but should do something reasonable instead), or both. It still breaks the build, however, so I've added a workaround for now.
