### PR TITLE
Disable GlobalISelAbort

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -175,8 +175,10 @@ swift::getIRTargetOptions(const IRGenOptions &Opts, ASTContext &Ctx) {
   if (Clang->getTargetInfo().getTriple().isOSBinFormatWasm())
     TargetOpts.ThreadModel = llvm::ThreadModel::Single;
 
-  if (Opts.EnableGlobalISel)
+  if (Opts.EnableGlobalISel) {
     TargetOpts.EnableGlobalISel = true;
+    TargetOpts.GlobalISelAbort = GlobalISelAbortMode::DisableWithDiag;
+  }
 
   clang::TargetOptions &ClangOpts = Clang->getTargetInfo().getTargetOpts();
   return std::make_tuple(TargetOpts, ClangOpts.CPU, ClangOpts.Features, ClangOpts.Triple);


### PR DESCRIPTION
When using GlobalISel instead of SelectionDAG lowering allow for
fall-back to SelectionDAG instead of aborting.