### PR TITLE
Sema: Don't derive witnesses in swiftinterface files

### DIFF
--- a/test/ModuleInterface/DerivedWitnesses.swiftinterface
+++ b/test/ModuleInterface/DerivedWitnesses.swiftinterface
@@ -1,0 +1,44 @@
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Apple Swift version 5.5 (swiftlang-1300.0.29.102 clang-1300.0.28.1)
+// swift-module-flags: -target x86_64-apple-macosx11.0 -enable-objc-interop -enable-library-evolution -module-name DerivedWitnesses
+import Swift
+
+public enum HasSynthesizedEquals : Int {
+  case x
+  case y
+
+  public static func == (a: HasSynthesizedEquals, b: HasSynthesizedEquals) -> Bool
+  public func hash(into hasher: inout Hasher)
+  public var hashValue: Int {
+    get
+  }
+
+  public init?(rawValue: Int)
+  public typealias RawValue = Int
+  public var rawValue: Int {
+    get
+  }
+}
+
+public enum UsesDefaultEquals : Int {
+  case x
+  case y
+
+  public init?(rawValue: Int)
+  public typealias RawValue = Int
+  public var rawValue: Int {
+    get
+  }
+}
+
+// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] [ossa] @$s16DerivedWitnesses20HasSynthesizedEqualsOSQAASQ2eeoiySbx_xtFZTW : $@convention(witness_method: Equatable) (@in_guaranteed HasSynthesizedEquals, @in_guaranteed HasSynthesizedEquals, @thick HasSynthesizedEquals.Type) -> Bool {
+// CHECK: bb0(%0 : $*HasSynthesizedEquals, %1 : $*HasSynthesizedEquals, %2 : $@thick HasSynthesizedEquals.Type):
+// CHECK: function_ref @$s16DerivedWitnesses20HasSynthesizedEqualsO2eeoiySbAC_ACtFZ : $@convention(method) (HasSynthesizedEquals, HasSynthesizedEquals, @thin HasSynthesizedEquals.Type) -> Bool
+// CHECK: return
+
+// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] [ossa] @$s16DerivedWitnesses17UsesDefaultEqualsOSQAASQ2eeoiySbx_xtFZTW : $@convention(witness_method: Equatable) (@in_guaranteed UsesDefaultEquals, @in_guaranteed UsesDefaultEquals, @thick UsesDefaultEquals.Type) -> Bool {
+// CHECK: bb0(%0 : $*UsesDefaultEquals, %1 : $*UsesDefaultEquals, %2 : $@thick UsesDefaultEquals.Type):
+// CHECK: function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF : $@convention(thin) <τ_0_0 where τ_0_0 : RawRepresentable, τ_0_0.RawValue : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> Bool
+// CHECK: return


### PR DESCRIPTION
This fixes a regression from https://github.com/apple/swift/pull/36752.

Previously, a RawRepresentable enum would use the default implementation
of == from a protocol extension in the standard library. After the above
PR, we began synthesizing the == operator, just like we do for ordinary
enums.

However, when type checking an older swiftinterface file, we would
still synthesize the declaration and try to use it, even though it would
not have existed in the older dylib built with the older compiler.

Fix this by not deriving witnesses in swiftinterface files at all.
The interface should already explicitly list out all derived witnesses;
if one is not listed, it should not be derived, because it does not
exist in the dylib.

Fixes rdar://problem/80466745.