### PR TITLE
[Frontend] Generate an interface hash for emit-module-separately jobs

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1156,10 +1156,10 @@ CompilerInstance::getSourceFileParsingOptions(bool forPrimary) const {
       opts |= SourceFile::ParsingFlags::DisableDelayedBodies;
   }
 
+  auto typeOpts = getASTContext().TypeCheckerOpts;
   if (forPrimary || isWholeModuleCompilation()) {
     // Disable delayed body parsing for primaries and in WMO, unless
     // forcefully skipping function bodies
-    auto typeOpts = getASTContext().TypeCheckerOpts;
     if (typeOpts.SkipFunctionBodies == FunctionBodySkipping::None)
       opts |= SourceFile::ParsingFlags::DisableDelayedBodies;
   } else {
@@ -1168,9 +1168,10 @@ CompilerInstance::getSourceFileParsingOptions(bool forPrimary) const {
     opts |= SourceFile::ParsingFlags::SuppressWarnings;
   }
 
-  // Enable interface hash computation for primaries, but not in WMO, as it's
-  // only currently needed for incremental mode.
-  if (forPrimary) {
+  // Enable interface hash computation for primaries or emit-module-separately,
+  // but not in WMO, as it's only currently needed for incremental mode.
+  if (forPrimary ||
+      typeOpts.SkipFunctionBodies == FunctionBodySkipping::NonInlinableWithoutTypes) {
     opts |= SourceFile::ParsingFlags::EnableInterfaceHash;
   }
   return opts;

--- a/test/InterfaceHash/added_function.swift
+++ b/test/InterfaceHash/added_function.swift
@@ -4,6 +4,11 @@
 // RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash
 
+/// We should generate an interface hash for emit-module-separately jobs even
+/// with no primaries.
+// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift -experimental-skip-non-inlinable-function-bodies-without-types 2> %t/b-emit-module.hash
+// RUN: cmp %t/b.hash %t/b-emit-module.hash
+
 // BEGIN a.swift
 func f() {}
 


### PR DESCRIPTION
We need emit-module jobs created for an emit-module-separately incremental build to generate the interface has for this build mode to support fine-grained incremental builds.

I used `typeOpts.SkipFunctionBodies == FunctionBodySkipping::NonInlinableWithoutTypes` as an heuristic to differentiate this emit-module-separately job from other kind of emit-module jobs. This flag should be passed to the compiler only in this build mode. In the future, we may want to have a flag dedicated to identifying jobs used in an incremental build from those from WMO as we move away from merge-module.