### PR TITLE
[5.5] IRGen: Private opaque result types from another TU are not ABI accessible

### DIFF
--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -95,12 +95,13 @@ namespace {
 class OpaqueArchetypeTypeInfo
   : public ResilientTypeInfo<OpaqueArchetypeTypeInfo>
 {
-  OpaqueArchetypeTypeInfo(llvm::Type *type)
-    : ResilientTypeInfo(type, IsABIAccessible) {}
+  OpaqueArchetypeTypeInfo(llvm::Type *type, IsABIAccessible_t abiAccessible)
+      : ResilientTypeInfo(type, abiAccessible) {}
 
 public:
-  static const OpaqueArchetypeTypeInfo *create(llvm::Type *type) {
-    return new OpaqueArchetypeTypeInfo(type);
+  static const OpaqueArchetypeTypeInfo *
+  create(llvm::Type *type, IsABIAccessible_t abiAccessible) {
+    return new OpaqueArchetypeTypeInfo(type, abiAccessible);
   }
 
   void collectMetadataForOutlining(OutliningMetadataCollector &collector,
@@ -342,7 +343,18 @@ const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {
 
   // Otherwise, for now, always use an opaque indirect type.
   llvm::Type *storageType = IGM.OpaquePtrTy->getElementType();
-  return OpaqueArchetypeTypeInfo::create(storageType);
+
+  // Opaque result types can be private and from a different module. In this
+  // case we can't access their type metadata from another module.
+  IsABIAccessible_t abiAccessible = IsABIAccessible;
+  if (auto opaqueArchetype = dyn_cast<OpaqueTypeArchetypeType>(archetype)) {
+    auto &currentSILModule = IGM.getSILModule();
+    abiAccessible =
+        currentSILModule.isTypeMetadataAccessible(archetype->getCanonicalType())
+            ? IsABIAccessible
+            : IsNotABIAccessible;
+  }
+  return OpaqueArchetypeTypeInfo::create(storageType, abiAccessible);
 }
 
 static void setMetadataRef(IRGenFunction &IGF,

--- a/lib/SIL/IR/SIL.cpp
+++ b/lib/SIL/IR/SIL.cpp
@@ -107,8 +107,14 @@ bool SILModule::isTypeMetadataAccessible(CanType type) {
   return !type.findIf([&](CanType type) {
     // Note that this function returns true if the type is *illegal* to use.
 
-    // Ignore non-nominal types.
-    auto decl = type.getNominalOrBoundGenericNominal();
+    // Ignore non-nominal types -- except for opaque result types which can be
+    // private and in a different translation unit in which case they can't be
+    // accessed.
+    ValueDecl *decl = type.getNominalOrBoundGenericNominal();
+    if (!decl)
+      decl = isa<OpaqueTypeArchetypeType>(type)
+                 ? cast<OpaqueTypeArchetypeType>(type)->getDecl()
+                 : nullptr;
     if (!decl)
       return false;
 

--- a/test/IRGen/Inputs/opaque_result_type_private_typemetadata2.swift
+++ b/test/IRGen/Inputs/opaque_result_type_private_typemetadata2.swift
@@ -1,0 +1,10 @@
+public protocol P { }
+
+extension Int : P {}
+
+struct Container {
+  // This opaque result type is private to this file and its type metadata is
+  // not accessible from another TU. Therefore, Container's fields are not ABI
+  // accessible from another TU.
+  private let mem : some P = 5
+}

--- a/test/IRGen/opaque_result_type_private_typemetadata.swift
+++ b/test/IRGen/opaque_result_type_private_typemetadata.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -primary-file %s %S/Inputs/opaque_result_type_private_typemetadata2.swift | %FileCheck %s
+
+// Container's fields are not ABI accessible so copying Container must use its
+// metadata instead of exploding its fields.
+
+// CHECK: define{{.*}} swiftcc void @"$s39opaque_result_type_private_typemetadata4doItyyF"()
+// CHECK-NOT:  ret void
+// CHECK: call {{.*}} @"$s39opaque_result_type_private_typemetadata9ContainerVMa"(
+// CHECK:  ret void
+
+public func doIt() {
+  var x = Container()
+  var y = x
+}


### PR DESCRIPTION
Fix a compiler error when using a struct with a private field that has
an opaque result type in another file.

```
% cat A.swift
public protocol P { }
extension Int : P {}
struct Container {
  private let mem : some P = 5
}

% cat B.swift
public func doIt() {
  var x = Container()
  var y = x
}
```

Risk: Low. If the condition matches we will access containing struct's
metadata instead of the fields metadata.

Testing: Swift test added
Reviewed-by: Slava Pestov

Original PR #38873

rdar://76416817
