### PR TITLE
[Rebranch] Disable storage3 check in NewStringAppending test

### DIFF
--- a/test/stdlib/NewStringAppending.swift
+++ b/test/stdlib/NewStringAppending.swift
@@ -143,7 +143,7 @@ print("\(repr(s1))")
 print("(expect copy to trigger reallocation without growth)")
 
 //  CHECK-NEXT: String(Native(owner: @[[storage4:[x0-9a-f]+]], count: 73, capacity: 87)) = "{{.*}}X"
-// CHECK-NOT: @[[storage3]],
+// xCHECK-NOT: @[[storage3]],
 s1 += "X"
 print("\(repr(s1))")
 


### PR DESCRIPTION
The other instances had been disabled in commit 5236224eb16a.
FileCheck was recently updated so that it complains about undefined
variables, which is why no one noticed until now. storage3 wasn't
defined because the place where it got defined was disabled. Disabling
that instance now.

rdar://82052117