### PR TITLE
[NFC] Factor out ASTContext `operator new`s

### DIFF
--- a/include/swift/AST/ASTAllocated.h
+++ b/include/swift/AST/ASTAllocated.h
@@ -1,0 +1,73 @@
+//===--- ASTAllocated.h - Allocation in the AST Context ---------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_ASTALLOCATED_H
+#define SWIFT_AST_ASTALLOCATED_H
+
+#include <cassert>
+#include <cstddef>
+
+namespace swift {
+class ASTContext;
+
+/// The arena in which a particular ASTContext allocation will go.
+enum class AllocationArena {
+  /// The permanent arena, which is tied to the lifetime of
+  /// the ASTContext.
+  ///
+  /// All global declarations and types need to be allocated into this arena.
+  /// At present, everything that is not a type involving a type variable is
+  /// allocated in this arena.
+  Permanent,
+  /// The constraint solver's temporary arena, which is tied to the
+  /// lifetime of a particular instance of the constraint solver.
+  ///
+  /// Any type involving a type variable is allocated in this arena.
+  ConstraintSolver
+};
+
+namespace detail {
+void *allocateInASTContext(size_t bytes, const ASTContext &ctx,
+                           AllocationArena arena, unsigned alignment);
+}
+
+/// Types inheriting from this class are intended to be allocated in an
+/// \c ASTContext allocator; you cannot allocate them by using a normal \c new,
+/// and instead you must either provide an \c ASTContext or use a placement
+/// \c new.
+///
+/// The template parameter is a type with the desired alignment. It is usually,
+/// but not always, the type that is inheriting \c ASTAllocated.
+template <typename AlignTy>
+class ASTAllocated {
+public:
+  // Make vanilla new/delete illegal.
+  void *operator new(size_t Bytes) throw() = delete;
+  void operator delete(void *Data) throw() = delete;
+
+  // Only allow allocation using the allocator in ASTContext
+  // or by doing a placement new.
+  void *operator new(size_t bytes, const ASTContext &ctx,
+                     AllocationArena arena = AllocationArena::Permanent,
+                     unsigned alignment = alignof(AlignTy)) {
+    return detail::allocateInASTContext(bytes, ctx, arena, alignment);
+  }
+
+  void *operator new(size_t Bytes, void *Mem) throw() {
+    assert(Mem && "placement new into failed allocation");
+    return Mem;
+  }
+};
+
+}
+
+#endif

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_AST_ASTCONTEXT_H
 #define SWIFT_AST_ASTCONTEXT_H
 
+#include "swift/AST/ASTAllocated.h"
 #include "swift/AST/Evaluator.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/Identifier.h"
@@ -144,22 +145,6 @@ namespace rewriting {
 namespace syntax {
   class SyntaxArena;
 }
-
-/// The arena in which a particular ASTContext allocation will go.
-enum class AllocationArena {
-  /// The permanent arena, which is tied to the lifetime of
-  /// the ASTContext.
-  ///
-  /// All global declarations and types need to be allocated into this arena.
-  /// At present, everything that is not a type involving a type variable is
-  /// allocated in this arena.
-  Permanent,
-  /// The constraint solver's temporary arena, which is tied to the
-  /// lifetime of a particular instance of the constraint solver.
-  ///
-  /// Any type involving a type variable is allocated in this arena.
-  ConstraintSolver
-};
 
 /// Lists the set of "known" Foundation entities that are used in the
 /// compiler.

--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -119,7 +119,7 @@ SourceLoc extractNearestSourceLoc(std::tuple<ASTScopeImpl *, ScopeCreator *>);
 /// \code
 /// -dump-scope-maps expanded
 /// \endcode
-class ASTScopeImpl {
+class ASTScopeImpl : public ASTAllocated<ASTScopeImpl> {
   friend class NodeAdder;
   friend class Portion;
   friend class GenericTypeOrExtensionWholePortion;
@@ -159,19 +159,8 @@ public:
   ASTScopeImpl(const ASTScopeImpl &) = delete;
   ASTScopeImpl &operator=(const ASTScopeImpl &) = delete;
 
-  // Make vanilla new illegal for ASTScopes.
-  void *operator new(size_t bytes) = delete;
   // Need this because have virtual destructors
   void operator delete(void *data) {}
-
-  // Only allow allocation of scopes using the allocator of a particular source
-  // file.
-  void *operator new(size_t bytes, const ASTContext &ctx,
-                     unsigned alignment = alignof(ASTScopeImpl));
-  void *operator new(size_t Bytes, void *Mem) {
-    ASTScopeAssert(Mem, "Allocation failed");
-    return Mem;
-  }
 
 #pragma mark - tree declarations
 protected:
@@ -425,25 +414,14 @@ private:
   expandAScopeThatCreatesANewInsertionPoint(ScopeCreator &);
 };
 
-class Portion {
+class Portion : public ASTAllocated<ASTScopeImpl> {
 public:
   const char *portionName;
   Portion(const char *n) : portionName(n) {}
   virtual ~Portion() {}
 
-  // Make vanilla new illegal for ASTScopes.
-  void *operator new(size_t bytes) = delete;
   // Need this because have virtual destructors
   void operator delete(void *data) {}
-
-  // Only allow allocation of scopes using the allocator of a particular source
-  // file.
-  void *operator new(size_t bytes, const ASTContext &ctx,
-                     unsigned alignment = alignof(ASTScopeImpl));
-  void *operator new(size_t Bytes, void *Mem) {
-    ASTScopeAssert(Mem, "Allocation failed");
-    return Mem;
-  }
 
   /// Return the new insertion point
   virtual ASTScopeImpl *expandScope(GenericTypeOrExtensionScope *,

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -26,6 +26,7 @@
 #include "swift/Basic/OptimizationMode.h"
 #include "swift/Basic/Version.h"
 #include "swift/Basic/Located.h"
+#include "swift/AST/ASTAllocated.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/AttrKind.h"
 #include "swift/AST/AutoDiff.h"
@@ -60,7 +61,8 @@ class PatternBindingInitializer;
 class TrailingWhereClause;
 class TypeExpr;
 
-class alignas(1 << AttrAlignInBits) AttributeBase {
+class alignas(1 << AttrAlignInBits) AttributeBase
+    : public ASTAllocated<AttributeBase> {
 public:
   /// The location of the '@'.
   const SourceLoc AtLoc;
@@ -79,17 +81,6 @@ public:
       return {AtLoc, Range.End};
     return Range;
   }
-
-  // Only allow allocation of attributes using the allocator in ASTContext
-  // or by doing a placement new.
-  void *operator new(size_t Bytes, ASTContext &C,
-                     unsigned Alignment = alignof(AttributeBase));
-
-  void operator delete(void *Data) throw() { }
-  void *operator new(size_t Bytes, void *Mem) throw() { return Mem; }
-
-  // Make vanilla new/delete illegal for attributes.
-  void *operator new(size_t Bytes) throw() = delete;
 
   AttributeBase(const AttributeBase &) = delete;
 

--- a/include/swift/AST/AvailabilitySpec.h
+++ b/include/swift/AST/AvailabilitySpec.h
@@ -44,7 +44,7 @@ enum class AvailabilitySpecKind {
 
 /// The root class for specifications of API availability in availability
 /// queries.
-class AvailabilitySpec {
+class AvailabilitySpec : public ASTAllocated<AvailabilitySpec> {
   AvailabilitySpecKind Kind;
 
 public:
@@ -53,12 +53,6 @@ public:
   AvailabilitySpecKind getKind() const { return Kind; }
 
   SourceRange getSourceRange() const;
-
-  void *
-  operator new(size_t Bytes, ASTContext &C,
-               unsigned Alignment = alignof(AvailabilitySpec));
-  void *operator new(size_t Bytes) throw() = delete;
-  void operator delete(void *Data) throw() = delete;
 };
 
 /// An availability specification that guards execution based on the
@@ -133,7 +127,8 @@ public:
   void *
   operator new(size_t Bytes, ASTContext &C,
                unsigned Alignment = alignof(PlatformVersionConstraintAvailabilitySpec)){
-    return AvailabilitySpec::operator new(Bytes, C, Alignment);
+    return AvailabilitySpec::operator new(Bytes, C, AllocationArena::Permanent,
+                                          Alignment);
   }
 };
 
@@ -180,7 +175,8 @@ public:
   void *
   operator new(size_t Bytes, ASTContext &C,
                unsigned Alignment = alignof(PlatformAgnosticVersionConstraintAvailabilitySpec)){
-    return AvailabilitySpec::operator new(Bytes, C, Alignment);
+    return AvailabilitySpec::operator new(Bytes, C, AllocationArena::Permanent,
+                                          Alignment);
   }
 };
 
@@ -214,7 +210,8 @@ public:
   void *
   operator new(size_t Bytes, ASTContext &C,
                unsigned Alignment = alignof(OtherPlatformAvailabilitySpec)) {
-    return AvailabilitySpec::operator new(Bytes, C, Alignment);
+    return AvailabilitySpec::operator new(Bytes, C, AllocationArena::Permanent,
+                                          Alignment);
   }
 };
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -292,7 +292,7 @@ enum class ArtificialMainKind : uint8_t {
 };
 
 /// Decl - Base class for all declarations in Swift.
-class alignas(1 << DeclAlignInBits) Decl {
+class alignas(1 << DeclAlignInBits) Decl : public ASTAllocated<Decl> {
 protected:
   union { uint64_t OpaqueBits;
 
@@ -1015,19 +1015,6 @@ public:
   /// Retrieve the diagnostic engine for diagnostics emission.
   LLVM_READONLY
   DiagnosticEngine &getDiags() const;
-
-  // Make vanilla new/delete illegal for Decls.
-  void *operator new(size_t Bytes) = delete;
-  void operator delete(void *Data) = delete;
-
-  // Only allow allocation of Decls using the allocator in ASTContext
-  // or by doing a placement new.
-  void *operator new(size_t Bytes, const ASTContext &C,
-                     unsigned Alignment = alignof(Decl));
-  void *operator new(size_t Bytes, void *Mem) { 
-    assert(Mem); 
-    return Mem; 
-  }
 };
 
 /// Allocates memory for a Decl with the given \p baseSize. If necessary,
@@ -1410,6 +1397,7 @@ public:
   }
 
   using DeclContext::operator new;
+  using DeclContext::operator delete;
 };
 
 /// Iterator that walks the extensions of a particular type.
@@ -1964,6 +1952,7 @@ public:
   }
   
   using DeclContext::operator new;
+  using DeclContext::operator delete;
 };
 
 /// SerializedTopLevelCodeDeclContext - This represents what was originally a
@@ -2614,6 +2603,7 @@ public:
   // Resolve ambiguity due to multiple base classes.
   using TypeDecl::getASTContext;
   using DeclContext::operator new;
+  using DeclContext::operator delete;
   using TypeDecl::getDeclaredInterfaceType;
 
   static bool classof(const DeclContext *C) {
@@ -5732,6 +5722,7 @@ public:
   }
 
   using DeclContext::operator new;
+  using DeclContext::operator delete;
   using Decl::getASTContext;
 };
 
@@ -6244,6 +6235,7 @@ public:
   bool hasKnownUnsafeSendableFunctionParams() const;
 
   using DeclContext::operator new;
+  using DeclContext::operator delete;
   using Decl::getASTContext;
 };
 
@@ -6775,6 +6767,7 @@ public:
   }
 
   using DeclContext::operator new;
+  using DeclContext::operator delete;
   using Decl::getASTContext;
 };
   

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -19,6 +19,7 @@
 #ifndef SWIFT_DECLCONTEXT_H
 #define SWIFT_DECLCONTEXT_H
 
+#include "swift/AST/ASTAllocated.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/LookupKinds.h"
 #include "swift/AST/ResilienceExpansion.h"
@@ -221,7 +222,8 @@ struct FragileFunctionKind {
 /// and therefore can safely access trailing memory. If you need to create a
 /// macro context, please see GenericContext for how to minimize new entries in
 /// the ASTHierarchy enum below.
-class alignas(1 << DeclContextAlignInBits) DeclContext {
+class alignas(1 << DeclContextAlignInBits) DeclContext
+    : public ASTAllocated<DeclContext> {
   enum class ASTHierarchy : unsigned {
     Decl,
     Expr,
@@ -628,10 +630,6 @@ public:
   SWIFT_DEBUG_DUMPER(dumpContext());
   unsigned printContext(llvm::raw_ostream &OS, unsigned indent = 0,
                         bool onlyAPartialLine = false) const;
-
-  // Only allow allocation of DeclContext using the allocator in ASTContext.
-  void *operator new(size_t Bytes, ASTContext &C,
-                     unsigned Alignment = alignof(DeclContext));
   
   // Some Decls are DeclContexts, but not all. See swift/AST/Decl.h
   static bool classof(const Decl *D);

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -138,7 +138,7 @@ enum class AccessSemantics : uint8_t {
 };
 
 /// Expr - Base class for all expressions in swift.
-class alignas(8) Expr {
+class alignas(8) Expr : public ASTAllocated<Expr> {
   Expr(const Expr&) = delete;
   void operator=(const Expr&) = delete;
 
@@ -567,20 +567,6 @@ public:
             unsigned Indent = 0) const;
 
   void print(ASTPrinter &Printer, const PrintOptions &Opts) const;
-
-  // Only allow allocation of Exprs using the allocator in ASTContext
-  // or by doing a placement new.
-  void *operator new(size_t Bytes, ASTContext &C,
-                     unsigned Alignment = alignof(Expr));
-
-  // Make placement new and vanilla new/delete illegal for Exprs.
-  void *operator new(size_t Bytes) throw() = delete;
-  void operator delete(void *Data) throw() = delete;
-
-  void *operator new(size_t Bytes, void *Mem) { 
-    assert(Mem); 
-    return Mem; 
-  }
 };
 
 /// ErrorExpr - Represents a semantically erroneous subexpression in the AST,
@@ -3864,6 +3850,7 @@ public:
   }
 
   using DeclContext::operator new;
+  using DeclContext::operator delete;
   using Expr::dump;
 };
 

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -18,8 +18,6 @@
 #include "swift/Basic/BasicSourceInfo.h"
 
 namespace swift {
-static inline unsigned alignOfFileUnit();
-
 /// A container for module-scope declarations that itself provides a scope; the
 /// smallest unit of code organization.
 ///
@@ -28,7 +26,7 @@ static inline unsigned alignOfFileUnit();
 /// file. A module can contain several file-units.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnon-virtual-dtor"
-class FileUnit : public DeclContext {
+class FileUnit : public DeclContext, public ASTAllocated<FileUnit> {
 #pragma clang diagnostic pop
   virtual void anchor();
 
@@ -313,22 +311,9 @@ public:
     return DC->getContextKind() == DeclContextKind::FileUnit;
   }
 
-private:
-  // Make placement new and vanilla new/delete illegal for FileUnits.
-  void *operator new(size_t Bytes) throw() = delete;
-  void *operator new(size_t Bytes, void *Mem) throw() = delete;
-  void operator delete(void *Data) throw() = delete;
-
-public:
-  // Only allow allocation of FileUnits using the allocator in ASTContext
-  // or by doing a placement new.
-  void *operator new(size_t Bytes, ASTContext &C,
-                     unsigned Alignment = alignOfFileUnit());
+  using ASTAllocated<FileUnit>::operator new;
+  using ASTAllocated<FileUnit>::operator delete;
 };
-
-static inline unsigned alignOfFileUnit() {
-  return alignof(FileUnit&);
-}
 
 /// This represents the compiler's implicitly generated declarations in the
 /// Builtin module.

--- a/include/swift/AST/LayoutConstraint.h
+++ b/include/swift/AST/LayoutConstraint.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_LAYOUT_CONSTRAINT_H
 #define SWIFT_LAYOUT_CONSTRAINT_H
 
+#include "swift/AST/ASTAllocated.h"
 #include "swift/AST/LayoutConstraintKind.h"
 #include "swift/AST/PrintOptions.h"
 #include "swift/AST/TypeAlignments.h"
@@ -29,12 +30,12 @@
 
 namespace swift {
 
-enum class AllocationArena;
-class ASTContext;
 class ASTPrinter;
 
 /// This is a class representing the layout constraint.
-class LayoutConstraintInfo : public llvm::FoldingSetNode {
+class LayoutConstraintInfo
+    : public llvm::FoldingSetNode,
+      public ASTAllocated<std::aligned_storage<8, 8>::type> {
   friend class LayoutConstraint;
   // Alignment of the layout in bytes.
   const unsigned Alignment : 16;
@@ -208,16 +209,6 @@ class LayoutConstraintInfo : public llvm::FoldingSetNode {
                       LayoutConstraintKind Kind,
                       unsigned SizeInBits,
                       unsigned Alignment);
-  private:
-  // Make vanilla new/delete illegal for LayoutConstraintInfo.
-  void *operator new(size_t Bytes) throw() = delete;
-  void operator delete(void *Data) throw() = delete;
-  public:
-  // Only allow allocation of LayoutConstraintInfo using the allocator in
-  // ASTContext or by doing a placement new.
-  void *operator new(size_t bytes, const ASTContext &ctx,
-                     AllocationArena arena, unsigned alignment = 8);
-  void *operator new(size_t Bytes, void *Mem) throw() { return Mem; }
 
   // Representation of the non-parameterized layouts.
   static LayoutConstraintInfo UnknownLayoutConstraintInfo;

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -163,7 +163,8 @@ class OverlayFile;
 /// output binary and logical module (such as a single library or executable).
 ///
 /// \sa FileUnit
-class ModuleDecl : public DeclContext, public TypeDecl {
+class ModuleDecl
+    : public DeclContext, public TypeDecl, public ASTAllocated<ModuleDecl> {
   friend class DirectOperatorLookupRequest;
   friend class DirectPrecedenceGroupLookupRequest;
 
@@ -812,16 +813,8 @@ public:
     return D->getKind() == DeclKind::Module;
   }
 
-private:
-  // Make placement new and vanilla new/delete illegal for Modules.
-  void *operator new(size_t Bytes) throw() = delete;
-  void operator delete(void *Data) throw() = delete;
-  void *operator new(size_t Bytes, void *Mem) throw() = delete;
-public:
-  // Only allow allocation of Modules using the allocator in ASTContext
-  // or by doing a placement new.
-  void *operator new(size_t Bytes, const ASTContext &C,
-                     unsigned Alignment = alignof(ModuleDecl));
+  using ASTAllocated<ModuleDecl>::operator new;
+  using ASTAllocated<ModuleDecl>::operator delete;
 };
 
 /// Wraps either a swift module or a clang one.

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -696,7 +696,7 @@ public:
 } // end namespace namelookup
 
 /// The interface into the ASTScope subsystem
-class ASTScope {
+class ASTScope : public ASTAllocated<ASTScope> {
   friend class ast_scope::ASTScopeImpl;
   ast_scope::ASTSourceFileScope *const impl;
 
@@ -754,20 +754,6 @@ public:
   SWIFT_DEBUG_DUMP;
   void print(llvm::raw_ostream &) const;
   void dumpOneScopeMapLocation(std::pair<unsigned, unsigned>);
-
-  // Make vanilla new illegal for ASTScopes.
-  void *operator new(size_t bytes) = delete;
-  // Need this because have virtual destructors
-  void operator delete(void *data) {}
-
-  // Only allow allocation of scopes using the allocator of a particular source
-  // file.
-  void *operator new(size_t bytes, const ASTContext &ctx,
-                     unsigned alignment = alignof(ASTScope));
-  void *operator new(size_t Bytes, void *Mem) {
-    assert(Mem);
-    return Mem;
-  }
 
 private:
   static ast_scope::ASTSourceFileScope *createScopeTree(SourceFile *);

--- a/include/swift/AST/ParameterList.h
+++ b/include/swift/AST/ParameterList.h
@@ -27,14 +27,10 @@ namespace swift {
 /// This describes a list of parameters.  Each parameter descriptor is tail
 /// allocated onto this list.
 class alignas(ParamDecl *) ParameterList final :
+    // FIXME: Do we really just want to allocate these pointer-aligned?
+    public ASTAllocated<std::aligned_storage<8, 8>::type>,
     private llvm::TrailingObjects<ParameterList, ParamDecl *> {
   friend TrailingObjects;
-
-  void *operator new(size_t Bytes) throw() = delete;
-  void operator delete(void *Data) throw() = delete;
-  void *operator new(size_t Bytes, void *Mem) throw() = delete;
-  void *operator new(size_t Bytes, ASTContext &C,
-                     unsigned Alignment = 8);
 
   SourceLoc LParenLoc, RParenLoc;
   size_t numParameters;

--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -20,6 +20,7 @@
 #include "swift/Basic/AnyValue.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Basic/type_traits.h"
+#include "swift/AST/ASTAllocated.h"
 #include "swift/AST/Decl.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
@@ -50,7 +51,7 @@ enum : unsigned { NumPatternKindBits =
 llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, PatternKind kind);
 
 /// Pattern - Base class for all patterns in Swift.
-class alignas(8) Pattern {
+class alignas(8) Pattern : public ASTAllocated<Pattern> {
 protected:
   union { uint64_t OpaqueBits;
 
@@ -208,13 +209,6 @@ public:
   static bool classof(const Pattern *P) { return true; }
 
   //*** Allocation Routines ************************************************/
-
-  void *operator new(size_t bytes, const ASTContext &C);
-
-  // Make placement new and vanilla new/delete illegal for Patterns.
-  void *operator new(size_t bytes) = delete;
-  void operator delete(void *data) = delete;
-  void *operator new(size_t bytes, void *data) = delete;
 
   void print(llvm::raw_ostream &OS,
              const PrintOptions &Options = PrintOptions()) const;

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -91,7 +91,8 @@ enum class ProtocolConformanceState {
 ///
 /// ProtocolConformance is an abstract base class, implemented by subclasses
 /// for the various kinds of conformance (normal, specialized, inherited).
-class alignas(1 << DeclAlignInBits) ProtocolConformance {
+class alignas(1 << DeclAlignInBits) ProtocolConformance
+    : public ASTAllocated<ProtocolConformance> {
   /// The kind of protocol conformance.
   ProtocolConformanceKind Kind;
 
@@ -283,20 +284,6 @@ public:
   /// Determine whether the witness for the given requirement
   /// is either the default definition or was otherwise deduced.
   bool usesDefaultDefinition(AssociatedTypeDecl *requirement) const;
-
-  // Make vanilla new/delete illegal for protocol conformances.
-  void *operator new(size_t bytes) = delete;
-  void operator delete(void *data) = delete;
-
-  // Only allow allocation of protocol conformances using the allocator in
-  // ASTContext or by doing a placement new.
-  void *operator new(size_t bytes, ASTContext &context,
-                     AllocationArena arena,
-                     unsigned alignment = alignof(ProtocolConformance));
-  void *operator new(size_t bytes, void *mem) {
-    assert(mem);
-    return mem;
-  }
 
   /// Print a parseable and human-readable description of the identifying
   /// information of the protocol conformance.

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_AST_STMT_H
 #define SWIFT_AST_STMT_H
 
+#include "swift/AST/ASTAllocated.h"
 #include "swift/AST/ASTNode.h"
 #include "swift/AST/Availability.h"
 #include "swift/AST/AvailabilitySpec.h"
@@ -53,7 +54,7 @@ enum : unsigned { NumStmtKindBits =
   countBitsUsed(static_cast<unsigned>(StmtKind::Last_Stmt)) };
 
 /// Stmt - Base class for all statements in swift.
-class alignas(8) Stmt {
+class alignas(8) Stmt : public ASTAllocated<Stmt> {
   Stmt(const Stmt&) = delete;
   Stmt& operator=(const Stmt&) = delete;
 
@@ -138,16 +139,6 @@ public:
 
   SWIFT_DEBUG_DUMP;
   void dump(raw_ostream &OS, const ASTContext *Ctx = nullptr, unsigned Indent = 0) const;
-
-  // Only allow allocation of Exprs using the allocator in ASTContext
-  // or by doing a placement new.
-  void *operator new(size_t Bytes, ASTContext &C,
-                     unsigned Alignment = alignof(Stmt));
-  
-  // Make vanilla new/delete illegal for Stmts.
-  void *operator new(size_t Bytes) throw() = delete;
-  void operator delete(void *Data) throw() = delete;
-  void *operator new(size_t Bytes, void *Mem) throw() = delete;
 };
 
 /// BraceStmt - A brace enclosed sequence of expressions, stmts, or decls, like

--- a/include/swift/AST/TypeRefinementContext.h
+++ b/include/swift/AST/TypeRefinementContext.h
@@ -46,7 +46,7 @@ namespace swift {
 /// These refinement contexts form a lexical tree parallel to the AST but much
 /// more sparse: we only introduce refinement contexts when there is something
 /// to refine.
-class TypeRefinementContext {
+class TypeRefinementContext : public ASTAllocated<TypeRefinementContext> {
 
 public:
   /// Describes the reason a type refinement context was introduced.
@@ -276,11 +276,6 @@ public:
   void print(raw_ostream &OS, SourceManager &SrcMgr, unsigned Indent = 0) const;
   
   static StringRef getReasonName(Reason R);
-  
-  // Only allow allocation of TypeRefinementContext using the allocator in
-  // ASTContext.
-  void *operator new(size_t Bytes, ASTContext &C,
-                     unsigned Alignment = alignof(TypeRefinementContext));
 };
 
 } // end namespace swift

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -48,7 +48,8 @@ enum : unsigned { NumTypeReprKindBits =
   countBitsUsed(static_cast<unsigned>(TypeReprKind::Last_TypeRepr)) };
 
 /// Representation of a type as written in source.
-class alignas(1 << TypeReprAlignInBits) TypeRepr {
+class alignas(1 << TypeReprAlignInBits) TypeRepr
+    : public ASTAllocated<TypeRepr> {
   TypeRepr(const TypeRepr&) = delete;
   void operator=(const TypeRepr&) = delete;
 
@@ -165,18 +166,6 @@ public:
   bool hasOpaque();
 
   //*** Allocation Routines ************************************************/
-
-  void *operator new(size_t bytes, const ASTContext &C,
-                     unsigned Alignment = alignof(TypeRepr));
-
-  void *operator new(size_t bytes, void *data) {
-    assert(data);
-    return data;
-  }
-
-  // Make placement new and vanilla new/delete illegal for TypeReprs.
-  void *operator new(size_t bytes) = delete;
-  void operator delete(void *data) = delete;
 
   void print(raw_ostream &OS, const PrintOptions &Opts = PrintOptions()) const;
   void print(ASTPrinter &Printer, const PrintOptions &Opts) const;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_TYPES_H
 #define SWIFT_TYPES_H
 
+#include "swift/AST/ASTAllocated.h"
 #include "swift/AST/AutoDiff.h"
 #include "swift/AST/DeclContext.h"
 #include "swift/AST/ExtInfo.h"
@@ -293,7 +294,8 @@ using TypeMatchOptions = OptionSet<TypeMatchFlags>;
 /// Base class for all types which describe the Swift and SIL ASTs.
 ///
 /// See TypeNodes.def for a succinct description of the full class hierarchy.
-class alignas(1 << TypeAlignInBits) TypeBase {
+class alignas(1 << TypeAlignInBits) TypeBase
+    : public ASTAllocated<std::aligned_storage<8, 8>::type> {
   
   friend class ASTContext;
   TypeBase(const TypeBase&) = delete;
@@ -1232,17 +1234,6 @@ public:
   /// return `None`.
   Optional<TangentSpace>
   getAutoDiffTangentSpace(LookupConformanceFn lookupConformance);
-
-private:
-  // Make vanilla new/delete illegal for Types.
-  void *operator new(size_t Bytes) throw() = delete;
-  void operator delete(void *Data) throw() = delete;
-public:
-  // Only allow allocation of Types using the allocator in ASTContext
-  // or by doing a placement new.
-  void *operator new(size_t bytes, const ASTContext &ctx,
-                     AllocationArena arena, unsigned alignment = 8);
-  void *operator new(size_t Bytes, void *Mem) throw() { return Mem; }
 };
 
 /// AnyGenericType - This abstract class helps types ensure that fields

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -683,6 +683,11 @@ llvm::BumpPtrAllocator &ASTContext::getAllocator(AllocationArena arena) const {
   llvm_unreachable("bad AllocationArena");
 }
 
+void *detail::allocateInASTContext(size_t bytes, const ASTContext &ctx,
+                                   AllocationArena arena, unsigned alignment) {
+  return ctx.Allocate(bytes, alignment, arena);
+}
+
 ImportPath::Raw
 swift::detail::ImportPathBuilder_copyToImpl(ASTContext &ctx,
                                             ImportPath::Raw raw) {

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -44,7 +44,7 @@ namespace ast_scope {
 
 #pragma mark ScopeCreator
 
-class ScopeCreator final {
+class ScopeCreator final : public ASTAllocated<ScopeCreator> {
   friend class ASTSourceFileScope;
   /// For allocating scopes.
   ASTContext &ctx;
@@ -180,18 +180,6 @@ public:
 
   void print(raw_ostream &out) const {
     out << "(swift::ASTSourceFileScope*) " << sourceFileScope << "\n";
-  }
-
-  // Make vanilla new illegal.
-  void *operator new(size_t bytes) = delete;
-
-  // Only allow allocation of scopes using the allocator of a particular source
-  // file.
-  void *operator new(size_t bytes, const ASTContext &ctx,
-                     unsigned alignment = alignof(ScopeCreator));
-  void *operator new(size_t Bytes, void *Mem) {
-    ASTScopeAssert(Mem, "Allocation failed");
-    return Mem;
   }
 };
 } // ast_scope
@@ -1163,25 +1151,6 @@ AbstractPatternEntryScope::AbstractPatternEntryScope(
     : decl(declBeingScoped), patternEntryIndex(entryIndex) {
   ASTScopeAssert(entryIndex < declBeingScoped->getPatternList().size(),
                  "out of bounds");
-}
-
-#pragma mark new operators
-void *ASTScopeImpl::operator new(size_t bytes, const ASTContext &ctx,
-                                 unsigned alignment) {
-  return ctx.Allocate(bytes, alignment);
-}
-
-void *Portion::operator new(size_t bytes, const ASTContext &ctx,
-                             unsigned alignment) {
-  return ctx.Allocate(bytes, alignment);
-}
-void *ASTScope::operator new(size_t bytes, const ASTContext &ctx,
-                             unsigned alignment) {
-  return ctx.Allocate(bytes, alignment);
-}
-void *ScopeCreator::operator new(size_t bytes, const ASTContext &ctx,
-                                 unsigned alignment) {
-  return ctx.Allocate(bytes, alignment);
 }
 
 #pragma mark - expandBody

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -68,12 +68,6 @@ static_assert(DeclAttribute::isOptionSetFor##Id(DeclAttribute::DeclAttrOptions::
               #Name " needs to specify either APIBreakingToRemove or APIStableToRemove");
 #include "swift/AST/Attr.def"
 
-// Only allow allocation of attributes using the allocator in ASTContext.
-void *AttributeBase::operator new(size_t Bytes, ASTContext &C,
-                                  unsigned Alignment) {
-  return C.Allocate(Bytes, Alignment);
-}
-
 StringRef swift::getAccessLevelSpelling(AccessLevel value) {
   switch (value) {
   case AccessLevel::Private: return "private";

--- a/lib/AST/AvailabilitySpec.cpp
+++ b/lib/AST/AvailabilitySpec.cpp
@@ -35,14 +35,6 @@ SourceRange AvailabilitySpec::getSourceRange() const {
   llvm_unreachable("bad AvailabilitySpecKind");
 }
 
-// Only allow allocation of AvailabilitySpecs using the
-// allocator in ASTContext.
-void *AvailabilitySpec::operator new(size_t Bytes, ASTContext &C,
-                                     unsigned Alignment) {
-  return C.Allocate(Bytes, Alignment);
-}
-
-
 SourceRange PlatformVersionConstraintAvailabilitySpec::getSourceRange() const {
   return SourceRange(PlatformLoc, VersionSrcRange.End);
 }

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -54,13 +54,6 @@ ProtocolDecl *ConformanceLookupTable::ConformanceEntry::getProtocol() const {
   return Conformance.get<ProtocolConformance *>()->getProtocol();
 }
 
-void *ConformanceLookupTable::ConformanceEntry::operator new(
-        size_t Bytes,
-        ASTContext &C,
-        unsigned Alignment) {
-  return C.Allocate(Bytes, Alignment);
-}
-
 void ConformanceLookupTable::ConformanceEntry::markSupersededBy(
        ConformanceLookupTable &table,
        ConformanceEntry *entry,
@@ -120,12 +113,6 @@ void ConformanceLookupTable::ConformanceEntry::dump(raw_ostream &os,
     os << " superseded_by=@" << static_cast<const void *>(SupersededBy);
 
   os << ")\n";
-}
-
-void *ConformanceLookupTable::operator new(size_t Bytes,
-                                           ASTContext &C,
-                                           unsigned Alignment) {
-  return C.Allocate(Bytes, Alignment);
 }
 
 ConformanceLookupTable::ConformanceLookupTable(ASTContext &ctx) {

--- a/lib/AST/ConformanceLookupTable.h
+++ b/lib/AST/ConformanceLookupTable.h
@@ -39,7 +39,7 @@ class ModuleDecl;
 /// This table is a lower-level detail that clients should generally not
 /// access directly. Rather, one should use the protocol- and
 /// conformance-centric entry points in \c NominalTypeDecl and \c DeclContext.
-class ConformanceLookupTable {
+class ConformanceLookupTable : public ASTAllocated<ConformanceLookupTable> {
   /// Describes the stage at which a particular nominal type or
   /// extension's conformances has been processed.
   enum class ConformanceStage : uint8_t {
@@ -199,7 +199,7 @@ class ConformanceLookupTable {
   };
 
   /// An entry in the conformance table.
-  struct ConformanceEntry {
+  struct ConformanceEntry : public ASTAllocated<ConformanceEntry> {
     /// The source location within the current context where the
     /// protocol conformance was specified.
     SourceLoc Loc;
@@ -299,11 +299,6 @@ class ConformanceLookupTable {
 
       return Loc;
     }
-
-    // Only allow allocation of conformance entries using the
-    // allocator in ASTContext.
-    void *operator new(size_t Bytes, ASTContext &C,
-                       unsigned Alignment = alignof(ConformanceEntry));
 
     SWIFT_DEBUG_DUMP;
     void dump(raw_ostream &os, unsigned indent = 0) const;
@@ -479,16 +474,6 @@ public:
   getSatisfiedProtocolRequirementsForMember(const ValueDecl *member,
                                             NominalTypeDecl *nominal,
                                             bool sorted);
-
-  // Only allow allocation of conformance lookup tables using the
-  // allocator in ASTContext or by doing a placement new.
-  void *operator new(size_t Bytes, ASTContext &C,
-                     unsigned Alignment = alignof(ConformanceLookupTable));
-
-  void *operator new(size_t Bytes, void *Mem) {
-    assert(Mem);
-    return Mem;
-  }
 
   SWIFT_DEBUG_DUMP;
   void dump(raw_ostream &os) const;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -134,18 +134,6 @@ void ClangNode::dump() const {
     llvm::errs() << "ClangNode contains nullptr\n";
 }
 
-// Only allow allocation of Decls using the allocator in ASTContext.
-void *Decl::operator new(size_t Bytes, const ASTContext &C,
-                         unsigned Alignment) {
-  return C.Allocate(Bytes, Alignment);
-}
-
-// Only allow allocation of Modules using the allocator in ASTContext.
-void *ModuleDecl::operator new(size_t Bytes, const ASTContext &C,
-                           unsigned Alignment) {
-  return C.Allocate(Bytes, Alignment);
-}
-
 StringRef Decl::getKindName(DeclKind K) {
   switch (K) {
 #define DECL(Id, Parent) case DeclKind::Id: return #Id;
@@ -7640,14 +7628,8 @@ StringRef AbstractFunctionDecl::getInlinableBodyText(
 
 /// A uniqued list of derivative function configurations.
 struct AbstractFunctionDecl::DerivativeFunctionConfigurationList
-    : public llvm::SetVector<AutoDiffConfig> {
-  // Necessary for `ASTContext` allocation.
-  void *operator new(
-      size_t bytes, ASTContext &ctx,
-      unsigned alignment = alignof(DerivativeFunctionConfigurationList)) {
-    return ctx.Allocate(bytes, alignment);
-  }
-};
+    : public ASTAllocated<DerivativeFunctionConfigurationList>,
+      public llvm::SetVector<AutoDiffConfig> {};
 
 void AbstractFunctionDecl::prepareDerivativeFunctionConfigurations() {
   if (DerivativeFunctionConfigs)

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -39,12 +39,6 @@ STATISTIC(NumLazyIterableDeclContexts,
 STATISTIC(NumUnloadedLazyIterableDeclContexts,
           "# of serialized iterable declaration contexts never loaded");
 
-// Only allow allocation of DeclContext using the allocator in ASTContext.
-void *DeclContext::operator new(size_t Bytes, ASTContext &C,
-                                unsigned Alignment) {
-  return C.Allocate(Bytes, Alignment);
-}
-
 ASTContext &DeclContext::getASTContext() const {
   return getParentModule()->getASTContext();
 }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -57,12 +57,6 @@ StringRef swift::getFunctionRefKindStr(FunctionRefKind refKind) {
 // Expr methods.
 //===----------------------------------------------------------------------===//
 
-// Only allow allocation of Stmts using the allocator in ASTContext.
-void *Expr::operator new(size_t Bytes, ASTContext &C,
-                         unsigned Alignment) {
-  return C.Allocate(Bytes, Alignment);
-}
-
 StringRef Expr::getKindName(ExprKind K) {
   switch (K) {
 #define EXPR(Id, Parent) case ExprKind::Id: return #Id;

--- a/lib/AST/LayoutConstraint.cpp
+++ b/lib/AST/LayoutConstraint.cpp
@@ -140,12 +140,6 @@ bool LayoutConstraintInfo::isNativeRefCounted(LayoutConstraintKind Kind) {
          Kind == LayoutConstraintKind::NativeClass;
 }
 
-void *LayoutConstraintInfo::operator new(size_t bytes, const ASTContext &ctx,
-                                         AllocationArena arena,
-                                         unsigned alignment) {
-  return ctx.Allocate(bytes, alignment, arena);
-}
-
 SourceRange LayoutConstraintLoc::getSourceRange() const { return getLoc(); }
 
 #define MERGE_LOOKUP(lhs, rhs)                                                 \

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1851,7 +1851,7 @@ bool ModuleDecl::isExternallyConsumed() const {
 
 namespace swift {
 /// Represents a file containing information about cross-module overlays.
-class OverlayFile {
+class OverlayFile : public ASTAllocated<OverlayFile> {
   friend class ModuleDecl;
   /// The file that data should be loaded from.
   StringRef filePath;
@@ -1874,13 +1874,6 @@ class OverlayFile {
                               StringRef bystandingModule,
                               SourceLoc diagLoc);
 public:
-  // Only allocate in ASTContexts.
-  void *operator new(size_t bytes) = delete;
-  void *operator new(size_t bytes, const ASTContext &ctx,
-                     unsigned alignment = alignof(OverlayFile)) {
-    return ctx.Allocate(bytes, alignment);
-  }
-
   OverlayFile(StringRef filePath)
       : filePath(filePath) {
     assert(!filePath.empty());
@@ -3012,10 +3005,6 @@ void SynthesizedFileUnit::getTopLevelDecls(
 //===----------------------------------------------------------------------===//
 
 void FileUnit::anchor() {}
-void *FileUnit::operator new(size_t Bytes, ASTContext &C, unsigned Alignment) {
-  return C.Allocate(Bytes, Alignment);
-}
-
 void FileUnit::getTopLevelDeclsWhereAttributesMatch(
             SmallVectorImpl<Decl*> &Results,
             llvm::function_ref<bool(DeclAttributes)> matchAttributes) const {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1023,7 +1023,7 @@ void LazyConformanceLoader::anchor() {}
 
 /// Lookup table used to store members of a nominal type (and its extensions)
 /// for fast retrieval.
-class swift::MemberLookupTable {
+class swift::MemberLookupTable : public ASTAllocated<swift::MemberLookupTable> {
   /// The last extension that was included within the member lookup table's
   /// results.
   ExtensionDecl *LastExtensionIncluded = nullptr;
@@ -1107,17 +1107,6 @@ public:
   SWIFT_DEBUG_DUMP {
     dump(llvm::errs());
   }
-
-  // Only allow allocation of member lookup tables using the allocator in
-  // ASTContext or by doing a placement new.
-  void *operator new(size_t Bytes, ASTContext &C,
-                     unsigned Alignment = alignof(MemberLookupTable)) {
-    return C.Allocate(Bytes, Alignment);
-  }
-  void *operator new(size_t Bytes, void *Mem) {
-    assert(Mem);
-    return Mem;
-  }
 };
 
 namespace {
@@ -1136,20 +1125,9 @@ namespace {
 /// table for lookup based on Objective-C selector.
 class ClassDecl::ObjCMethodLookupTable
         : public llvm::DenseMap<std::pair<ObjCSelector, char>,
-                                StoredObjCMethods>
-{
-public:
-  // Only allow allocation of member lookup tables using the allocator in
-  // ASTContext or by doing a placement new.
-  void *operator new(size_t Bytes, ASTContext &C,
-                     unsigned Alignment = alignof(MemberLookupTable)) {
-    return C.Allocate(Bytes, Alignment);
-  }
-  void *operator new(size_t Bytes, void *Mem) {
-    assert(Mem);
-    return Mem;
-  }
-};
+                                StoredObjCMethods>,
+          public ASTAllocated<ClassDecl::ObjCMethodLookupTable>
+{};
 
 MemberLookupTable::MemberLookupTable(ASTContext &ctx) {
   // Register a cleanup with the ASTContext to call the lookup table

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -354,11 +354,6 @@ case PatternKind::ID: foundRefutablePattern = true; break;
   return foundRefutablePattern;
 }
 
-/// Standard allocator for Patterns.
-void *Pattern::operator new(size_t numBytes, const ASTContext &C) {
-  return C.Allocate(numBytes, alignof(Pattern));
-}
-
 /// Find the name directly bound by this pattern.  When used as a
 /// tuple element in a function signature, such names become part of
 /// the type.

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -186,13 +186,6 @@ ProtocolConformanceRef::getWitnessByName(Type type, DeclName name) const {
   return getConcrete()->getWitnessDeclRef(requirement);
 }
 
-void *ProtocolConformance::operator new(size_t bytes, ASTContext &context,
-                                        AllocationArena arena,
-                                        unsigned alignment) {
-  return context.Allocate(bytes, alignment, arena);
-
-}
-
 #define CONFORMANCE_SUBCLASS_DISPATCH(Method, Args)                          \
 switch (getKind()) {                                                         \
   case ProtocolConformanceKind::Normal:                                      \

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -33,12 +33,6 @@ using namespace swift;
 // Stmt methods.
 //===----------------------------------------------------------------------===//
 
-// Only allow allocation of Stmts using the allocator in ASTContext.
-void *Stmt::operator new(size_t Bytes, ASTContext &C,
-                         unsigned Alignment) {
-  return C.Allocate(Bytes, Alignment);
-}
-
 StringRef Stmt::getKindName(StmtKind K) {
   switch (K) {
 #define STMT(Id, Parent) case StmtKind::Id: return #Id;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -96,12 +96,6 @@ SourceLoc TypeLoc::getLoc() const {
   return SourceLoc();
 }
 
-// Only allow allocation of Types using the allocator in ASTContext.
-void *TypeBase::operator new(size_t bytes, const ASTContext &ctx,
-                             AllocationArena arena, unsigned alignment) {
-  return ctx.Allocate(bytes, alignment, arena);
-}
-
 NominalTypeDecl *CanType::getAnyNominal() const {
   return dyn_cast_or_null<NominalTypeDecl>(getAnyGeneric());
 }

--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -137,13 +137,6 @@ TypeRefinementContext::createForWhileStmtBody(ASTContext &Ctx, WhileStmt *S,
       Ctx, S, Parent, S->getBody()->getSourceRange(), Info, /* ExplicitInfo */Info);
 }
 
-// Only allow allocation of TypeRefinementContext using the allocator in
-// ASTContext.
-void *TypeRefinementContext::operator new(size_t Bytes, ASTContext &C,
-                                          unsigned Alignment) {
-  return C.Allocate(Bytes, Alignment);
-}
-
 TypeRefinementContext *
 TypeRefinementContext::findMostRefinedSubContext(SourceLoc Loc,
                                                  SourceManager &SM) {

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -103,12 +103,6 @@ bool TypeRepr::hasOpaque() {
   return findIf([](TypeRepr *ty) { return isa<OpaqueReturnTypeRepr>(ty); });
 }
 
-/// Standard allocator for TypeReprs.
-void *TypeRepr::operator new(size_t Bytes, const ASTContext &C,
-                             unsigned Alignment) {
-  return C.Allocate(Bytes, Alignment);
-}
-
 SourceLoc TypeRepr::findUncheckedAttrLoc() const {
   auto typeRepr = this;
   while (auto attrTypeRepr = dyn_cast<AttributedTypeRepr>(typeRepr)) {


### PR DESCRIPTION
Many, many, many types in the Swift compiler are intended to only be allocated in the ASTContext. We have previously implemented this by writing several `operator new` and `operator delete` implementations into these types. Factor those out into a new base class instead.