### PR TITLE
[stdlib] fix another accidental infinite-recursion bug

### DIFF
--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -757,6 +757,23 @@ extension RangeReplaceableCollection {
     self.replaceSubrange(subrange.relative(to: self), with: newElements)
   }
 
+  // This unavailable default implementation of
+  // `replaceSubrange<C: Collection>(_: Range<Index>, with: C)` prevents
+  // incomplete RangeReplaceableCollection implementations from satisfying
+  // the protocol through the use of the generic convenience implementation
+  // `replaceSubrange<C: Collection, R: RangeExpression>(_: R, with: C)`,
+  // If that were the case, at runtime the implementation generic over
+  // `RangeExpression` would call itself in an infinite recursion
+  // due to the absence of a better option.
+  @available(*, unavailable)
+  @_alwaysEmitIntoClient
+  public mutating func replaceSubrange<C>(
+    _ subrange: Range<Index>,
+    with newElements: C
+  ) where C: Collection, C.Element == Element {
+    fatalError()
+  }
+
   /// Removes the elements in the specified subrange from the collection.
   ///
   /// All the elements following the specified position are moved to close the

--- a/validation-test/stdlib/CollectionDiagnostics.swift
+++ b/validation-test/stdlib/CollectionDiagnostics.swift
@@ -200,6 +200,18 @@ func subscriptMutableCollectionIgnored() {
   ds[3..<5] = goodSlice
 }
 
+// expected-error@+2 {{type 'IncompleteRangeReplaceableCollection' does not conform to protocol 'RangeReplaceableCollection'}}
+// expected-error@+1 {{unavailable instance method 'replaceSubrange(_:with:)' was used to satisfy a requirement of protocol 'RangeReplaceableCollection'}}
+struct IncompleteRangeReplaceableCollection: RangeReplaceableCollection {
+  var startIndex: Int
+  var endIndex: Int
+
+  func index(after i: Int) -> Int { i+1 }
+  subscript(position: Int) -> Int { position }
+
+  init() { startIndex = 0; endIndex = 0 }
+ }
+
 // FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: possibly intended match
 // <unknown>:0: error: unexpected note produced: possibly intended match


### PR DESCRIPTION
It's been known for years (see SR-6501) that it's easy to forget to implement the critical function `replaceSubrange<C>(_: with: C)` when conforming a type to `RangeReplaceableCollection`, because the compiler doesn't ask for it. At runtime, there is then an infinite-recursion crash on just about any RRC-specific function.

This adds an unavailable implementation to transform this issue into a compile-time error, in line with other recent similar fixes, such as https://github.com/apple/swift/pull/36969.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-6501

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
