### PR TITLE
[5.5] DiagnoseInfiniteRecursion: fix a false warning caused by dead-end blocks

### DIFF
--- a/test/SILOptimizer/infinite_recursion.swift
+++ b/test/SILOptimizer/infinite_recursion.swift
@@ -103,6 +103,18 @@ func multipleArgsNoWarning(_ x : Int, _ y : Int) {
   }
 }
 
+struct A {}
+struct B {}
+
+func deadEndBlockInElseBranch(_ x : Int) {
+  if x != 0 {
+    deadEndBlockInElseBranch(x - 1) // no warning
+  } else {
+    _ = unsafeBitCast(A(), to: B.self)
+  }
+}
+
+
 struct Str {
   var x = 27
 


### PR DESCRIPTION
The algorithm needs to take care of dead-end blocks.
This is done by propagating two flags instead of one: `reachesRecursiveCall` and `reachesFunctionExit`.
Dead-end blocks have none of both flags set.

This fixes a regression in 5.5

rdar://80645083

This is a cherry-pick of https://github.com/apple/swift/pull/38906