### PR TITLE
[5.5] LoadableByAddress: fix handling of yield instructions which can result in invalid SIL

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -2069,6 +2069,11 @@ static void rewriteFunction(StructLoweringState &pass,
     pass.applies.append(currentModApplies.begin(), currentModApplies.end());
   } while (repeat);
 
+  while (!pass.modYieldInsts.empty()) {
+    YieldInst *inst = pass.modYieldInsts.pop_back_val();
+    allocateAndSetAll(pass, allocator, inst, inst->getAllOperands());
+  }
+
   for (SILInstruction *instr : pass.instsToMod) {
     for (Operand &operand : instr->getAllOperands()) {
       auto currOperand = operand.get();
@@ -2323,11 +2328,6 @@ static void rewriteFunction(StructLoweringState &pass,
     auto newRetTuple = retBuilder.createTuple(regLoc, emptyTy, {});
     retBuilder.createReturn(newRetTuple->getLoc(), newRetTuple);
     instr->eraseFromParent();
-  }
-
-  while (!pass.modYieldInsts.empty()) {
-    YieldInst *inst = pass.modYieldInsts.pop_back_val();
-    allocateAndSetAll(pass, allocator, inst, inst->getAllOperands());
   }
 }
 

--- a/test/IRGen/big_types_coroutine.sil
+++ b/test/IRGen/big_types_coroutine.sil
@@ -97,3 +97,24 @@ bb2:
   abort_apply %4
   unwind
 }
+
+// CHECK-LABEL: sil @test_yield_and_retain
+// CHECK:   [[S:%[0-9]+]] = alloc_stack $BigStruct
+// CHECK:   copy_addr [take] %0 to [initialization] [[S]]
+// CHECK:   retain_value_addr [[S]]
+// CHECK:   yield [[S]] : $*BigStruct
+// CHECK: // end sil function 'test_yield_and_retain'
+sil @test_yield_and_retain : $@convention(thin) @yield_once (@in_guaranteed BigStruct) -> @yields BigStruct {
+entry(%0 : $*BigStruct):
+  %big = load %0 : $*BigStruct
+  retain_value %big : $BigStruct
+  yield %big : $BigStruct, resume resume, unwind unwind
+
+resume:
+  %ret = tuple ()
+  return %ret : $()
+
+unwind:
+  unwind
+}
+


### PR DESCRIPTION
The code to handle yield instructions must be done earlier in `rewriteFunction` because it can add more instructions to the data structures, which also needs to be processed in  `rewriteFunction`.

https://bugs.swift.org/browse/SR-14994
rdar://77526343

This is a cherry-pick of https://github.com/apple/swift/pull/38924