### PR TITLE
[test] closures_swift6.swift requires asserts

### DIFF
--- a/test/expr/closure/closures_swift6.swift
+++ b/test/expr/closure/closures_swift6.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift -swift-version 6
+// REQUIRES: asserts
 
 func doStuff(_ fn : @escaping () -> Int) {}
 func doVoidStuff(_ fn : @escaping () -> ()) {}


### PR DESCRIPTION
`-swift-version 6` is currently only permitted for asserts builds.

https://ci.swift.org/job/oss-swift_tools-R_stdlib-RD_test-simulator/6321

rdar://82126678