### PR TITLE
[Serialization] Write protocol compositions as dependencies of protocols

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3511,7 +3511,9 @@ public:
     for (auto element : proto->getInherited()) {
       auto elementType = element.getType();
       assert(!elementType || !elementType->hasArchetype());
-      if (elementType && elementType->is<ProtocolType>())
+      if (elementType &&
+          (elementType->is<ProtocolType>() ||
+           elementType->is<ProtocolCompositionType>()))
         dependencyTypes.insert(elementType);
     }
 

--- a/test/Serialization/Recovery/implementation-only-missing.swift
+++ b/test/Serialization/Recovery/implementation-only-missing.swift
@@ -43,6 +43,8 @@ public protocol HiddenProtocol {
   associatedtype Value
 }
 
+public protocol HiddenProtocol2 {}
+
 public protocol HiddenProtocolWithOverride {
   func hiddenOverride()
 }
@@ -97,6 +99,15 @@ public struct PublicStructConformsToHiddenProtocol: RefinesHiddenProtocol {
 public class SomeClass {
     func funcUsingIoiType(_ a: HiddenClass) {}
 }
+
+// Check that we recover from a reference to an implementation-only
+// imported type in a protocol composition. rdar://78631465
+protocol CompositionMemberInheriting : HiddenProtocol2 {}
+protocol CompositionMemberSimple {}
+protocol InheritingFromComposition : CompositionMemberInheriting & CompositionMemberSimple {}
+struct StructInheritingFromComposition : CompositionMemberInheriting & CompositionMemberSimple {}
+class ClassInheritingFromComposition : CompositionMemberInheriting & CompositionMemberSimple {}
+protocol InheritingFromCompositionDirect : CompositionMemberSimple & HiddenProtocol2 {}
 
 #elseif CLIENT_APP
 


### PR DESCRIPTION
A type dependencies are used at deserialization to drop a protocol early when a dependency is not deserializable. Dependencies on protocols via a protocol composition were not taken into account. This lead to the deserialization process failing later. Fix the serialization process to write protocol dependencies too.

rdar://78631465