### PR TITLE
[5.5] disable some assertions to quickly workaround 'try?' bug

### DIFF
--- a/lib/SILGen/Cleanup.cpp
+++ b/lib/SILGen/Cleanup.cpp
@@ -265,7 +265,7 @@ void CleanupManager::setCleanupState(Cleanup &cleanup, CleanupState state) {
   (void)oldState;
   cleanup.setState(SGF, state);
 
-  assert(state != oldState && "trivial cleanup state change");
+//  assert(state != oldState && "trivial cleanup state change");
   assert(oldState != CleanupState::Dead && "changing state of dead cleanup");
 
   // Our current cleanup emission logic, where we don't try to re-use

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -555,7 +555,7 @@ public:
     // Create the buffer when needed, because in some cases the type may
     // be the opened type from another existential that hasn't been opened
     // at the point the existential destination was formed.
-    assert(!concreteBuffer && "concrete buffer already formed?!");
+//    assert(!concreteBuffer && "concrete buffer already formed?!");
     
     auto concreteLoweredType =
         SGF.getLoweredType(AbstractionPattern::getOpaque(), concreteFormalType);

--- a/test/Runtime/optional_try.swift
+++ b/test/Runtime/optional_try.swift
@@ -1,0 +1,61 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+
+enum Bad: Error {
+    case err
+    case custom(String)
+}
+
+func erase<T>(_ val: T) -> Any {
+    return val as Any
+}
+
+class Klass {}
+
+typealias MaybeString = Result<String, Error>
+typealias MaybeKlass = Result<Klass, Error>
+typealias MaybeInt = Result<Int, Error>
+typealias MaybeNumbers = Result<[Int], Error>
+
+////////
+// NOTE: Do _not_ heed the warnings about implicit coercions to Any.
+//       That's an important part of this test's coverage!
+////////
+
+// -- throwing --
+
+// CHECK: nil
+print( try? MaybeString.failure(Bad.err).get() )
+
+// CHECK: nil
+print( try? MaybeKlass.failure(Bad.custom("doggo")).get() )
+
+// CHECK: nil
+print( try? MaybeInt.failure(Bad.err).get() )
+
+// CHECK: nil
+print( try? MaybeNumbers.failure(Bad.err).get() )
+
+// CHECK: nil
+print(erase( try? MaybeNumbers.failure(Bad.err).get() ))
+
+// -- normal --
+
+// CHECK: Optional("catto")
+print( try? MaybeString.success("catto").get() )
+
+// CHECK: Optional(main.Klass)
+print( try? MaybeKlass.success(Klass()).get() )
+
+// CHECK: Optional(3)
+print( try? MaybeInt.success(3).get() )
+
+// CHECK: Optional([4, 8, 15, 16, 23, 42])
+print( try? MaybeNumbers.success([4, 8, 15, 16, 23, 42]).get() )
+
+// CHECK: Optional([0, 1, 1, 2, 3])
+print(erase( try? MaybeNumbers.success([0, 1, 1, 2, 3]).get() ))
+
+
+
+


### PR DESCRIPTION
If a 'try?' expression is implicitly coerced to 'Any',
assertions are tripped during SILGen, but we end up with
functionally-correct code emission. This is a
long-standing bug (since at least 5.0.3) in the compiler.
The best fix appears to be a minor overhaul of the SILGen
emission for all 'try?' expressions.

For now, this patch simply turns off the two assertions
that stand in the way of compiling such 'try?'
expressions for people using an asserts-enabled build
of the compiler.

A simple reproducer for this bug in an asserts build is:

```swift
    let _: Any = try? {() throws in 3 }()
```
