### PR TITLE
RequirementMachine: Clean up merged associated type processing

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -465,6 +465,9 @@ namespace swift {
     /// Enables statistics output from the requirement machine.
     bool AnalyzeRequirementMachine = false;
 
+    /// Enables fine-grained debug output from the requirement machine.
+    std::string DebugRequirementMachine;
+
     /// Maximum iteration count for requirement machine confluent completion
     /// algorithm.
     unsigned RequirementMachineStepLimit = 2000;

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -459,8 +459,8 @@ namespace swift {
     RequirementMachineMode EnableRequirementMachine =
         RequirementMachineMode::Disabled;
 
-    /// Enables debugging output from the requirement machine.
-    bool DebugRequirementMachine = false;
+    /// Enables dumping rewrite systems from the requirement machine.
+    bool DumpRequirementMachine = false;
 
     /// Enables statistics output from the requirement machine.
     bool AnalyzeRequirementMachine = false;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -273,8 +273,8 @@ def debug_constraints_on_line_EQ : Joined<["-"], "debug-constraints-on-line=">,
 def disable_named_lazy_member_loading : Flag<["-"], "disable-named-lazy-member-loading">,
   HelpText<"Disable per-name lazy member loading">;
 
-def debug_requirement_machine : Flag<["-"], "debug-requirement-machine">,
-  HelpText<"Enables debugging output from the generics implementation">;
+def dump_requirement_machine : Flag<["-"], "dump-requirement-machine">,
+  HelpText<"Enables dumping rewrite systems from the generics implementation">;
 
 def analyze_requirement_machine : Flag<["-"], "analyze-requirement-machine">,
   Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -276,6 +276,9 @@ def disable_named_lazy_member_loading : Flag<["-"], "disable-named-lazy-member-l
 def dump_requirement_machine : Flag<["-"], "dump-requirement-machine">,
   HelpText<"Enables dumping rewrite systems from the generics implementation">;
 
+def debug_requirement_machine : Joined<["-"], "debug-requirement-machine=">,
+  HelpText<"Fine-grained debug output from the generics implementation">;
+
 def analyze_requirement_machine : Flag<["-"], "analyze-requirement-machine">,
   Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,
   HelpText<"Print out requirement machine statistics at the end of the compilation job">;

--- a/lib/AST/RequirementMachine/Debug.h
+++ b/lib/AST/RequirementMachine/Debug.h
@@ -1,0 +1,46 @@
+//===--- Debug.h - Requirement machine debugging flags ----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RQM_DEBUG_H
+#define SWIFT_RQM_DEBUG_H
+
+namespace swift {
+
+namespace rewriting {
+
+enum class DebugFlags : unsigned {
+  /// Print debug output when simplifying terms.
+  Simplify = (1<<0),
+
+  /// Print debug output when adding rules.
+  Add = (1<<1),
+
+  /// Print debug output when merging associated types.
+  Merge = (1<<2),
+
+  /// Print debug output from the Knuth-Bendix algorithm.
+  Completion = (1<<3),
+
+  /// Print debug output when unifying concrete types in the property map.
+  ConcreteUnification = (1<<4),
+
+  /// Print debug output when concretizing nested types in the property map.
+  ConcretizeNestedTypes = (1<<5)
+};
+
+using DebugOptions = OptionSet<DebugFlags>;
+
+}
+
+}
+
+#endif

--- a/lib/AST/RequirementMachine/PropertyMap.cpp
+++ b/lib/AST/RequirementMachine/PropertyMap.cpp
@@ -736,7 +736,7 @@ void PropertyMap::addProperty(
   assert(property.isProperty());
   auto *props = getOrCreateProperties(key);
   props->addProperty(property, Context,
-                     inducedRules, DebugConcreteUnification);
+                     inducedRules, Debug.contains(DebugFlags::ConcreteUnification));
 }
 
 /// For each fully-concrete type, find the shortest term having that concrete type.
@@ -772,7 +772,7 @@ void PropertyMap::concretizeNestedTypesFromConcreteParents(
     if (props->getConformsTo().empty())
       continue;
 
-    if (DebugConcretizeNestedTypes) {
+    if (Debug.contains(DebugFlags::ConcretizeNestedTypes)) {
       if (props->isConcreteType() ||
           props->hasSuperclassBound()) {
         llvm::dbgs() << "^ Concretizing nested types of ";
@@ -782,7 +782,7 @@ void PropertyMap::concretizeNestedTypesFromConcreteParents(
     }
 
     if (props->isConcreteType()) {
-      if (DebugConcretizeNestedTypes) {
+      if (Debug.contains(DebugFlags::ConcretizeNestedTypes)) {
         llvm::dbgs() << "- via concrete type requirement\n";
       }
 
@@ -797,7 +797,7 @@ void PropertyMap::concretizeNestedTypesFromConcreteParents(
     }
 
     if (props->hasSuperclassBound()) {
-      if (DebugConcretizeNestedTypes) {
+      if (Debug.contains(DebugFlags::ConcretizeNestedTypes)) {
         llvm::dbgs() << "- via superclass requirement\n";
       }
 
@@ -863,7 +863,7 @@ void PropertyMap::concretizeNestedTypesFromConcreteParent(
                                                  const_cast<ProtocolDecl *>(proto));
     if (conformance.isInvalid()) {
       // FIXME: Diagnose conflict
-      if (DebugConcretizeNestedTypes) {
+      if (Debug.contains(DebugFlags::ConcretizeNestedTypes)) {
         llvm::dbgs() << "^^ " << concreteType << " does not conform to "
                      << proto->getName() << "\n";
       }
@@ -886,7 +886,7 @@ void PropertyMap::concretizeNestedTypesFromConcreteParent(
       continue;
 
     for (auto *assocType : assocTypes) {
-      if (DebugConcretizeNestedTypes) {
+      if (Debug.contains(DebugFlags::ConcretizeNestedTypes)) {
         llvm::dbgs() << "^^ " << "Looking up type witness for "
                      << proto->getName() << ":" << assocType->getName()
                      << " on " << concreteType << "\n";
@@ -894,7 +894,7 @@ void PropertyMap::concretizeNestedTypesFromConcreteParent(
 
       auto t = concrete->getTypeWitness(assocType);
       if (!t) {
-        if (DebugConcretizeNestedTypes) {
+        if (Debug.contains(DebugFlags::ConcretizeNestedTypes)) {
           llvm::dbgs() << "^^ " << "Type witness for " << assocType->getName()
                        << " of " << concreteType << " could not be inferred\n";
         }
@@ -904,7 +904,7 @@ void PropertyMap::concretizeNestedTypesFromConcreteParent(
 
       auto typeWitness = t->getCanonicalType();
 
-      if (DebugConcretizeNestedTypes) {
+      if (Debug.contains(DebugFlags::ConcretizeNestedTypes)) {
         llvm::dbgs() << "^^ " << "Type witness for " << assocType->getName()
                      << " of " << concreteType << " is " << typeWitness << "\n";
       }
@@ -920,7 +920,7 @@ void PropertyMap::concretizeNestedTypesFromConcreteParent(
         // FIXME: ConcreteTypeInDomainMap should support substitutions so
         // that we can remove this.
 
-        if (DebugConcretizeNestedTypes) {
+        if (Debug.contains(DebugFlags::ConcretizeNestedTypes)) {
           llvm::dbgs() << "^^ Type witness is the same as the concrete type\n";
         }
 
@@ -933,7 +933,7 @@ void PropertyMap::concretizeNestedTypesFromConcreteParent(
       }
 
       inducedRules.emplace_back(subjectType, constraintType);
-      if (DebugConcretizeNestedTypes) {
+      if (Debug.contains(DebugFlags::ConcretizeNestedTypes)) {
         llvm::dbgs() << "^^ Induced rule " << constraintType
                      << " => " << subjectType << "\n";
       }
@@ -977,7 +977,7 @@ MutableTerm PropertyMap::computeConstraintTermForTypeWitness(
     if (found != ConcreteTypeInDomainMap.end()) {
       MutableTerm result(found->second);
       if (result != subjectType) {
-        if (DebugConcretizeNestedTypes) {
+        if (Debug.contains(DebugFlags::ConcretizeNestedTypes)) {
           llvm::dbgs() << "^^ Type witness can re-use property bag of "
                        << found->second << "\n";
         }

--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <vector>
 
+#include "Debug.h"
 #include "ProtocolGraph.h"
 #include "RewriteContext.h"
 #include "RewriteSystem.h"
@@ -145,8 +146,7 @@ class PropertyMap {
   llvm::DenseMap<ConcreteTypeInDomain, Term> ConcreteTypeInDomainMap;
 
   const ProtocolGraph &Protos;
-  unsigned DebugConcreteUnification : 1;
-  unsigned DebugConcretizeNestedTypes : 1;
+  DebugOptions Debug;
 
   PropertyBag *getOrCreateProperties(Term key);
 
@@ -159,8 +159,7 @@ public:
   explicit PropertyMap(RewriteContext &ctx,
                        const ProtocolGraph &protos)
       : Context(ctx), Protos(protos) {
-    DebugConcreteUnification = false;
-    DebugConcretizeNestedTypes = false;
+    Debug = ctx.getDebugOptions();
   }
 
   ~PropertyMap();

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -52,7 +52,7 @@ class RequirementMachine final {
   RewriteSystem System;
   PropertyMap Map;
 
-  bool Debug = false;
+  bool Dump = false;
   bool Complete = false;
   unsigned RequirementMachineStepLimit;
   unsigned RequirementMachineDepthLimit;

--- a/lib/AST/RequirementMachine/RewriteContext.h
+++ b/lib/AST/RequirementMachine/RewriteContext.h
@@ -19,6 +19,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/Support/Allocator.h"
+#include "Debug.h"
 #include "Histogram.h"
 #include "Symbol.h"
 #include "Term.h"
@@ -51,12 +52,14 @@ class RewriteContext final {
   /// Cache for merged associated type symbols.
   llvm::DenseMap<std::pair<Symbol, Symbol>, Symbol> MergedAssocTypes;
 
+  ASTContext &Context;
+
+  DebugOptions Debug;
+
   RewriteContext(const RewriteContext &) = delete;
   RewriteContext(RewriteContext &&) = delete;
   RewriteContext &operator=(const RewriteContext &) = delete;
   RewriteContext &operator=(RewriteContext &&) = delete;
-
-  ASTContext &Context;
 
 public:
   /// Statistics.
@@ -71,6 +74,8 @@ public:
   Histogram PropertyTrieRootHistogram;
 
   explicit RewriteContext(ASTContext &ctx);
+
+  DebugOptions getDebugOptions() const { return Debug; }
 
   Term getTermForType(CanType paramType, const ProtocolDecl *proto);
 

--- a/lib/AST/RequirementMachine/RewriteContext.h
+++ b/lib/AST/RequirementMachine/RewriteContext.h
@@ -48,6 +48,9 @@ class RewriteContext final {
   /// Cache for associated type declarations.
   llvm::DenseMap<Symbol, AssociatedTypeDecl *> AssocTypes;
 
+  /// Cache for merged associated type symbols.
+  llvm::DenseMap<std::pair<Symbol, Symbol>, Symbol> MergedAssocTypes;
+
   RewriteContext(const RewriteContext &) = delete;
   RewriteContext(RewriteContext &&) = delete;
   RewriteContext &operator=(const RewriteContext &) = delete;
@@ -90,6 +93,9 @@ public:
 
   AssociatedTypeDecl *getAssociatedTypeForSymbol(Symbol symbol,
                                                  const ProtocolGraph &protos);
+
+  Symbol mergeAssociatedTypes(Symbol lhs, Symbol rhs,
+                              const ProtocolGraph &protos);
 
   ~RewriteContext();
 };

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -123,6 +123,10 @@ bool RewriteSystem::addRule(MutableTerm lhs, MutableTerm rhs) {
       lhs.back().getKind() == Symbol::Kind::AssociatedType &&
       rhs.back().getKind() == Symbol::Kind::AssociatedType &&
       lhs.back().getName() == rhs.back().getName()) {
+    if (Debug.contains(DebugFlags::Merge)) {
+      llvm::dbgs() << "## Associated type merge candidate ";
+      llvm::dbgs() << lhs << " => " << rhs << "\n\n";
+    }
     MergedAssociatedTypes.emplace_back(lhs, rhs);
   }
 

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -62,6 +62,10 @@ bool RewriteSystem::addRule(MutableTerm lhs, MutableTerm rhs) {
   assert(!lhs.empty());
   assert(!rhs.empty());
 
+  if (Debug.contains(DebugFlags::Add)) {
+    llvm::dbgs() << "# Adding rule " << lhs << " == " << rhs << "\n";
+  }
+
   // First, simplify terms appearing inside concrete substitutions before
   // doing anything else.
   if (lhs.back().isSuperclassOrConcreteType())
@@ -89,7 +93,7 @@ bool RewriteSystem::addRule(MutableTerm lhs, MutableTerm rhs) {
   assert(lhs.compare(rhs, Protos) > 0);
 
   if (Debug.contains(DebugFlags::Add)) {
-    llvm::dbgs() << "# Adding rule " << lhs << " => " << rhs << "\n";
+    llvm::dbgs() << "## Simplified and oriented rule " << lhs << " => " << rhs << "\n\n";
   }
 
   unsigned i = Rules.size();

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -15,6 +15,7 @@
 
 #include "llvm/ADT/DenseSet.h"
 
+#include "Debug.h"
 #include "ProtocolGraph.h"
 #include "Symbol.h"
 #include "Term.h"
@@ -111,11 +112,7 @@ class RewriteSystem final {
   /// Pairs of rules which have already been checked for overlap.
   llvm::DenseSet<std::pair<unsigned, unsigned>> CheckedOverlaps;
 
-  /// Set these to true to enable debugging output.
-  unsigned DebugSimplify : 1;
-  unsigned DebugAdd : 1;
-  unsigned DebugMerge : 1;
-  unsigned DebugCompletion : 1;
+  DebugOptions Debug;
 
 public:
   explicit RewriteSystem(RewriteContext &ctx);

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -173,7 +173,6 @@ private:
   computeCriticalPair(ArrayRef<Symbol>::const_iterator from,
                       const Rule &lhs, const Rule &rhs) const;
 
-  Symbol mergeAssociatedTypes(Symbol lhs, Symbol rhs) const;
   void processMergedAssociatedTypes();
 };
 

--- a/lib/AST/RequirementMachine/RewriteSystemCompletion.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystemCompletion.cpp
@@ -219,14 +219,14 @@ void RewriteSystem::processMergedAssociatedTypes() {
     // If we have X.[P2:T] => Y.[P1:T], add a new pair of rules:
     // X.[P1:T] => X.[P1&P2:T]
     // X.[P2:T] => X.[P1&P2:T]
-    if (DebugMerge) {
+    if (Debug.contains(DebugFlags::Merge)) {
       llvm::dbgs() << "## Associated type merge candidate ";
       llvm::dbgs() << lhs << " => " << rhs << "\n";
     }
 
     auto mergedSymbol = Context.mergeAssociatedTypes(lhs.back(), rhs.back(),
                                                      Protos);
-    if (DebugMerge) {
+    if (Debug.contains(DebugFlags::Merge)) {
       llvm::dbgs() << "### Merged symbol " << mergedSymbol << "\n";
     }
 
@@ -259,7 +259,7 @@ void RewriteSystem::processMergedAssociatedTypes() {
           // or
           //
           //   [P2:T].[Q] => [P2:T]
-          if (DebugMerge) {
+          if (Debug.contains(DebugFlags::Merge)) {
             llvm::dbgs() << "### Lifting conformance rule " << otherRule << "\n";
           }
 
@@ -431,7 +431,7 @@ RewriteSystem::computeConfluentCompletion(unsigned maxIterations,
           // Try to repair the confluence violation by adding a new rule.
           resolvedCriticalPairs.push_back(computeCriticalPair(from, lhs, rhs));
 
-          if (DebugCompletion) {
+          if (Debug.contains(DebugFlags::Completion)) {
             const auto &pair = resolvedCriticalPairs.back();
 
             llvm::dbgs() << "$ Overlapping rules: (#" << i << ") ";

--- a/lib/AST/RequirementMachine/Symbol.h
+++ b/lib/AST/RequirementMachine/Symbol.h
@@ -30,6 +30,7 @@ class LayoutConstraint;
 namespace rewriting {
 
 class MutableTerm;
+class ProtocolGraph;
 class RewriteContext;
 class Term;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -829,8 +829,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
                      A->getAsString(Args), A->getValue());
   }
 
-  Opts.DebugRequirementMachine = Args.hasArg(
-      OPT_debug_requirement_machine);
+  Opts.DumpRequirementMachine = Args.hasArg(
+      OPT_dump_requirement_machine);
   Opts.AnalyzeRequirementMachine = Args.hasArg(
       OPT_analyze_requirement_machine);
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -834,6 +834,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.AnalyzeRequirementMachine = Args.hasArg(
       OPT_analyze_requirement_machine);
 
+  if (const Arg *A = Args.getLastArg(OPT_debug_requirement_machine))
+    Opts.DebugRequirementMachine = A->getValue();
+
   if (const Arg *A = Args.getLastArg(OPT_requirement_machine_step_limit)) {
     unsigned limit;
     if (StringRef(A->getValue()).getAsInteger(10, limit)) {

--- a/test/Generics/generic_objc_superclass.swift
+++ b/test/Generics/generic_objc_superclass.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift %clang-importer-sdk -requirement-machine=verify -debug-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift %clang-importer-sdk -requirement-machine=verify -dump-requirement-machine 2>&1 | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/Generics/rdar79564324.swift
+++ b/test/Generics/rdar79564324.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module %S/Inputs/rdar79564324_other.swift -emit-module-path %t/rdar79564324_other.swiftmodule -requirement-machine=on -debug-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module %S/Inputs/rdar79564324_other.swift -emit-module-path %t/rdar79564324_other.swiftmodule -requirement-machine=on -dump-requirement-machine 2>&1 | %FileCheck %s
 // RUN: %target-swift-frontend -emit-silgen %s -I %t -requirement-machine=on
 
 import rdar79564324_other

--- a/test/Generics/unify_associated_types.swift
+++ b/test/Generics/unify_associated_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=verify -debug-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine=verify -dump-requirement-machine 2>&1 | %FileCheck %s
 
 struct Foo<A, B> {}
 

--- a/test/Generics/unify_concrete_types_1.swift
+++ b/test/Generics/unify_concrete_types_1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=verify -debug-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine=verify -dump-requirement-machine 2>&1 | %FileCheck %s
 
 struct Foo<A, B> {}
 

--- a/test/Generics/unify_concrete_types_2.swift
+++ b/test/Generics/unify_concrete_types_2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=verify -debug-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine=verify -dump-requirement-machine 2>&1 | %FileCheck %s
 
 struct Foo<A, B> {}
 

--- a/test/Generics/unify_nested_types_1.swift
+++ b/test/Generics/unify_nested_types_1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=verify -debug-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine=verify -dump-requirement-machine 2>&1 | %FileCheck %s
 
 protocol P1 {
   associatedtype T : P1

--- a/test/Generics/unify_nested_types_2.swift
+++ b/test/Generics/unify_nested_types_2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=verify -debug-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine=verify -dump-requirement-machine 2>&1 | %FileCheck %s
 
 protocol P1 {
   associatedtype T : P1

--- a/test/Generics/unify_nested_types_3.swift
+++ b/test/Generics/unify_nested_types_3.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=verify -debug-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine=verify -dump-requirement-machine 2>&1 | %FileCheck %s
 
 protocol P1 {
   associatedtype T : P1

--- a/test/Generics/unify_nested_types_4.swift
+++ b/test/Generics/unify_nested_types_4.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=verify -debug-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine=verify -dump-requirement-machine 2>&1 | %FileCheck %s
 
 protocol P1 {
   associatedtype A : P1

--- a/test/Generics/unify_superclass_types_1.swift
+++ b/test/Generics/unify_superclass_types_1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=verify -debug-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine=verify -dump-requirement-machine 2>&1 | %FileCheck %s
 
 class Base {}
 class Derived : Base {

--- a/test/Generics/unify_superclass_types_2.swift
+++ b/test/Generics/unify_superclass_types_2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=on -debug-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine=on -dump-requirement-machine 2>&1 | %FileCheck %s
 
 // Note: The GSB fails this test, because it doesn't implement unification of
 // superclass type constructor arguments.

--- a/test/Generics/unify_superclass_types_3.swift
+++ b/test/Generics/unify_superclass_types_3.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=on -debug-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine=on -dump-requirement-machine 2>&1 | %FileCheck %s
 
 // Note: The GSB fails this test, because it doesn't implement unification of
 // superclass type constructor arguments.

--- a/test/Generics/unify_superclass_types_4.swift
+++ b/test/Generics/unify_superclass_types_4.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine=on -debug-requirement-machine 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine=on -dump-requirement-machine 2>&1 | %FileCheck %s
 
 // Note: The GSB fails this test, because it doesn't implement unification of
 // superclass type constructor arguments.


### PR DESCRIPTION
While writing up the design document I realized that this algorithm could be simplified somewhat. This PR also improves the debugging support. `-debug-requirement-machine` is now `-dump-requirement-machine`, and a new `-debug-requirement-machine` flag takes a comma-separated list of tokens: `add`, `simplify`, `merge`, `completion`, `concrete-unification`, `concretize-nested-types`, to enable debug output from each sub-component of the requirement machine.