### PR TITLE
[Refactoring] Do not add "async" if function is already async

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -6655,7 +6655,8 @@ private:
     addRange(MidStartLoc, MidEndLoc);
 
     // Third chunk: add in async and throws if necessary
-    OS << " async";
+    if (!FD->hasAsync())
+      OS << " async";
     if (FD->hasThrows() || TopHandler.HasError)
       // TODO: Add throws if converting a function and it has a converted call
       //       without a do/catch

--- a/test/refactoring/ConvertAsync/convert_function.swift
+++ b/test/refactoring/ConvertAsync/convert_function.swift
@@ -21,6 +21,17 @@ func simpleErr(arg: String) async throws -> String { }
 func simpleRes(arg: String, _ completion: @escaping (Result<String, Error>) -> Void) { }
 func simpleRes(arg: String) async throws -> String { }
 
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ALREADY-ASYNC %s
+func alreadyAsync() async {
+  simple {
+    print($0)
+  }
+}
+// ALREADY-ASYNC: func alreadyAsync() async {
+// ALREADY-ASYNC-NEXT: let val0 = await simple()
+// ALREADY-ASYNC-NEXT: print(val0)
+// ALREADY-ASYNC-NEXT: }
+
 // RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NESTED %s
 func nested() {
   simple {


### PR DESCRIPTION
Convert Function to Async is available on an async function. It could be
useful to run this refactoring still, as it would attempt to convert any
completion-handler functions to their async alternatives. Keep allowing
this, but make sure not to re-add "async" to the function declaration.

Resolves rdar://82156720