### PR TITLE
[Distributed] Ensure _remote funcs synthesized before dynamic replacement

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -502,7 +502,7 @@ protected:
     IsDebuggerAlias : 1
   );
 
-  SWIFT_INLINE_BITFIELD(NominalTypeDecl, GenericTypeDecl, 1+1+1+1,
+  SWIFT_INLINE_BITFIELD(NominalTypeDecl, GenericTypeDecl, 1+1+1,
     /// Whether we have already added implicitly-defined initializers
     /// to this declaration.
     AddedImplicitInitializers : 1,
@@ -511,10 +511,7 @@ protected:
     HasLazyConformances : 1,
 
     /// Whether this nominal type is having its semantic members resolved.
-    IsComputingSemanticMembers : 1,
-
-    /// Whether we have already added implicitly-defined distributed actor members.
-    AddedImplicitDistributedActorMembers: 1
+    IsComputingSemanticMembers : 1
   );
 
   SWIFT_INLINE_BITFIELD_FULL(ProtocolDecl, NominalTypeDecl, 1+1+1+1+1+1+1+1+1+1+1+8+16,
@@ -3163,7 +3160,6 @@ protected:
     ExtensionGeneration = 0;
     Bits.NominalTypeDecl.HasLazyConformances = false;
     Bits.NominalTypeDecl.IsComputingSemanticMembers = false;
-    Bits.NominalTypeDecl.AddedImplicitDistributedActorMembers = false;
   }
 
   friend class ProtocolType;
@@ -3198,17 +3194,6 @@ public:
 
   /// Note that we have attempted to add implicit initializers.
   void setAddedImplicitInitializers() {
-    Bits.NominalTypeDecl.AddedImplicitInitializers = true;
-  }
-
-  /// Determine whether we have already attempted to add any
-  /// implicitly-defined distributed actor members to this declaration.
-  bool addedImplicitDistributedActorMembers() const {
-    return Bits.NominalTypeDecl.AddedImplicitInitializers;
-  }
-
-  /// Note that we have attempted to add implicit initializers.
-  void setAddedImplicitDistributedActorMembers() {
     Bits.NominalTypeDecl.AddedImplicitInitializers = true;
   }
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -502,7 +502,7 @@ protected:
     IsDebuggerAlias : 1
   );
 
-  SWIFT_INLINE_BITFIELD(NominalTypeDecl, GenericTypeDecl, 1+1+1,
+  SWIFT_INLINE_BITFIELD(NominalTypeDecl, GenericTypeDecl, 1+1+1+1,
     /// Whether we have already added implicitly-defined initializers
     /// to this declaration.
     AddedImplicitInitializers : 1,
@@ -511,7 +511,10 @@ protected:
     HasLazyConformances : 1,
 
     /// Whether this nominal type is having its semantic members resolved.
-    IsComputingSemanticMembers : 1
+    IsComputingSemanticMembers : 1,
+
+    /// Whether we have already added implicitly-defined distributed actor members.
+    AddedImplicitDistributedActorMembers: 1
   );
 
   SWIFT_INLINE_BITFIELD_FULL(ProtocolDecl, NominalTypeDecl, 1+1+1+1+1+1+1+1+1+1+1+8+16,
@@ -3160,6 +3163,7 @@ protected:
     ExtensionGeneration = 0;
     Bits.NominalTypeDecl.HasLazyConformances = false;
     Bits.NominalTypeDecl.IsComputingSemanticMembers = false;
+    Bits.NominalTypeDecl.AddedImplicitDistributedActorMembers = false;
   }
 
   friend class ProtocolType;
@@ -3194,6 +3198,17 @@ public:
 
   /// Note that we have attempted to add implicit initializers.
   void setAddedImplicitInitializers() {
+    Bits.NominalTypeDecl.AddedImplicitInitializers = true;
+  }
+
+  /// Determine whether we have already attempted to add any
+  /// implicitly-defined distributed actor members to this declaration.
+  bool addedImplicitDistributedActorMembers() const {
+    return Bits.NominalTypeDecl.AddedImplicitInitializers;
+  }
+
+  /// Note that we have attempted to add implicit initializers.
+  void setAddedImplicitDistributedActorMembers() {
     Bits.NominalTypeDecl.AddedImplicitInitializers = true;
   }
 
@@ -5994,6 +6009,10 @@ public:
 
   /// Returns 'true' if the function is distributed.
   bool isDistributed() const;
+
+  /// Get (or synthesize)  the associated remote function for this one.
+  /// For example, for `distributed func hi()` get `func _remote_hi()`.
+  AbstractFunctionDecl *getDistributedActorRemoteFuncDecl() const;
 
   PolymorphicEffectKind getPolymorphicEffectKind(EffectKind kind) const;
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -951,6 +951,24 @@ public:
     bool isCached() const { return true; }
 };
 
+/// Obtain the 'remote' counterpart of a 'distributed func'.
+class GetDistributedRemoteFuncRequest :
+    public SimpleRequest<GetDistributedRemoteFuncRequest,
+        AbstractFunctionDecl *(AbstractFunctionDecl *),
+        RequestFlags::Cached> {
+public:
+    using SimpleRequest::SimpleRequest;
+
+private:
+    friend SimpleRequest;
+
+    AbstractFunctionDecl *evaluate(Evaluator &evaluator, AbstractFunctionDecl *func) const;
+
+public:
+    // Caching
+    bool isCached() const { return true; }
+};
+
 /// Retrieve the static "shared" property within a global actor that provides
 /// the actor instance representing the global actor.
 ///
@@ -2046,8 +2064,6 @@ enum class ImplicitMemberAction : uint8_t {
   ResolveEncodable,
   ResolveDecodable,
   ResolveDistributedActor,
-  ResolveDistributedActorIdentity,
-  ResolveDistributedActorTransport,
 };
 
 class ResolveImplicitMemberRequest

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -933,24 +933,6 @@ public:
     bool isCached() const { return true; }
 };
 
-/// Determine whether the given func is distributed.
-class IsDistributedFuncRequest :
-    public SimpleRequest<IsDistributedFuncRequest,
-        bool(FuncDecl *),
-        RequestFlags::Cached> {
-public:
-    using SimpleRequest::SimpleRequest;
-
-private:
-    friend SimpleRequest;
-
-    bool evaluate(Evaluator &evaluator, FuncDecl *func) const;
-
-public:
-    // Caching
-    bool isCached() const { return true; }
-};
-
 /// Obtain the 'remote' counterpart of a 'distributed func'.
 class GetDistributedRemoteFuncRequest :
     public SimpleRequest<GetDistributedRemoteFuncRequest,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -102,6 +102,8 @@ SWIFT_REQUEST(TypeChecker, IsDistributedActorRequest, bool(NominalTypeDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsDistributedFuncRequest, bool(FuncDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, GetDistributedRemoteFuncRequest, AbstractFunctionDecl *(AbstractFunctionDecl *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GlobalActorInstanceRequest,
               VarDecl *(NominalTypeDecl *),
               Cached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -100,8 +100,6 @@ SWIFT_REQUEST(TypeChecker, IsDefaultActorRequest,
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsDistributedActorRequest, bool(NominalTypeDecl *),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, IsDistributedFuncRequest, bool(FuncDecl *),
-              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GetDistributedRemoteFuncRequest, AbstractFunctionDecl *(AbstractFunctionDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GlobalActorInstanceRequest,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7221,11 +7221,6 @@ bool AbstractFunctionDecl::isSendable() const {
 
 bool AbstractFunctionDecl::isDistributed() const {
   return this->getAttrs().hasAttribute<DistributedActorAttr>();
-
-//  auto mutableFunc = const_cast<FuncDecl *>(func);
-//  return evaluateOrDefault(getASTContext().evaluator,
-//                           IsDistributedFuncRequest{mutableFunc},
-//                           false);
 }
 
 AbstractFunctionDecl*

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1036,12 +1036,6 @@ void swift::simple_display(llvm::raw_ostream &out,
   case ImplicitMemberAction::ResolveDistributedActor:
     out << "resolve DistributedActor";
     break;
-  case ImplicitMemberAction::ResolveDistributedActorIdentity:
-    out << "resolve DistributedActor.id";
-    break;
-  case ImplicitMemberAction::ResolveDistributedActorTransport:
-    out << "resolve DistributedActor.actorTransport";
-    break;
   }
 }
 

--- a/lib/SILGen/SILGenDistributed.cpp
+++ b/lib/SILGen/SILGenDistributed.cpp
@@ -638,7 +638,6 @@ void SILGenFunction::emitDistributedActor_resignAddress(
 void SILGenFunction::emitDistributedActorClassMemberDestruction(
     SILLocation cleanupLoc, ManagedValue selfValue, ClassDecl *cd,
     SILBasicBlock *normalMemberDestroyBB, SILBasicBlock *finishBB) {
-  ASTContext &ctx = getASTContext();
   auto selfTy = cd->getDeclaredInterfaceType();
 
   Scope scope(Cleanups, CleanupLocation(cleanupLoc));

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1255,9 +1255,10 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
 
   auto &Context = target->getASTContext();
   switch (action) {
-  case ImplicitMemberAction::ResolveImplicitInit:
+  case ImplicitMemberAction::ResolveImplicitInit: {
     TypeChecker::addImplicitConstructors(target);
     break;
+  }
   case ImplicitMemberAction::ResolveCodingKeys: {
     // CodingKeys is a special type which may be synthesized as part of
     // Encodable/Decodable conformance. If the target conforms to either
@@ -1274,8 +1275,8 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
     if (!evaluateTargetConformanceTo(decodableProto)) {
       (void)evaluateTargetConformanceTo(encodableProto);
     }
-  }
     break;
+  }
   case ImplicitMemberAction::ResolveEncodable: {
     // encode(to:) may be synthesized as part of derived conformance to the
     // Encodable protocol.
@@ -1283,8 +1284,8 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
     // conformance here to attempt synthesis.
     auto *encodableProto = Context.getProtocol(KnownProtocolKind::Encodable);
     (void)evaluateTargetConformanceTo(encodableProto);
-  }
     break;
+  }
   case ImplicitMemberAction::ResolveDecodable: {
     // init(from:) may be synthesized as part of derived conformance to the
     // Decodable protocol.
@@ -1293,17 +1294,11 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
     TypeChecker::addImplicitConstructors(target);
     auto *decodableProto = Context.getProtocol(KnownProtocolKind::Decodable);
     (void)evaluateTargetConformanceTo(decodableProto);
-  }
     break;
-  case ImplicitMemberAction::ResolveDistributedActor:
-  case ImplicitMemberAction::ResolveDistributedActorTransport:
-  case ImplicitMemberAction::ResolveDistributedActorIdentity: {
-    // init(transport:) and init(resolve:using:) may be synthesized as part of
-    // derived conformance to the DistributedActor protocol.
-    // If the target should conform to the DistributedActor protocol, check the
-    // conformance here to attempt synthesis.
-    // FIXME(distributed): invoke the requirement adding explicitly here
-     TypeChecker::addImplicitConstructors(target);
+  }
+case ImplicitMemberAction::ResolveDistributedActor: {
+    if (auto classDecl = dyn_cast<ClassDecl>(target))
+      swift::addImplicitDistributedActorMembers(classDecl);
     auto *distributedActorProto =
         Context.getProtocol(KnownProtocolKind::DistributedActor);
     (void)evaluateTargetConformanceTo(distributedActorProto);

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -205,7 +205,8 @@ synthesizeRemoteFuncStubBody(AbstractFunctionDecl *func, void *context) {
   auto uintInit = ctx.getIntBuiltinInitDecl(uintDecl);
 
   auto missingTransportDecl = ctx.getMissingDistributedActorTransport();
-  assert(missingTransportDecl && "Could not locate '_missingDistributedActorTransport' function");
+  assert(missingTransportDecl &&
+         "Could not locate '_missingDistributedActorTransport' function");
 
   // Create a call to _Distributed._missingDistributedActorTransport
   auto loc = func->getLoc();
@@ -243,16 +244,10 @@ synthesizeRemoteFuncStubBody(AbstractFunctionDecl *func, void *context) {
   file->setBuiltinInitializer(staticStringInit);
 
   auto startLineAndCol = SM.getPresumedLineAndColumnForLoc(distributedFunc->getStartLoc());
-//  auto *line = new (ctx) MagicIdentifierLiteralExpr(
-//      MagicIdentifierLiteralExpr::Line, loc, /*Implicit=*/true);
-//  auto *line = new (ctx) IntegerLiteralExpr(startLineAndCol.first, loc,
-//                                            /*implicit*/ true);
   auto *line = IntegerLiteralExpr::createFromUnsigned(ctx, startLineAndCol.first);
   line->setType(uintType);
   line->setBuiltinInitializer(uintInit);
 
-//  auto *column = new (ctx) MagicIdentifierLiteralExpr(
-//      MagicIdentifierLiteralExpr::Column, loc, /*Implicit=*/true);
   auto *column = IntegerLiteralExpr::createFromUnsigned(ctx, startLineAndCol.second);
   column->setType(uintType);
   column->setBuiltinInitializer(uintInit);
@@ -264,7 +259,6 @@ synthesizeRemoteFuncStubBody(AbstractFunctionDecl *func, void *context) {
 
   SmallVector<ASTNode, 2> stmts;
   stmts.push_back(call); // something() -> Never
-  // stmts.push_back(new (ctx) ReturnStmt(SourceLoc(), /*Result=*/nullptr)); // FIXME: this causes 'different types for return type: String vs. ()'
   auto body = BraceStmt::create(ctx, SourceLoc(), stmts, SourceLoc(),
                                 /*implicit=*/true);
   return { body, /*isTypeChecked=*/true };
@@ -290,7 +284,8 @@ static Identifier makeRemoteFuncIdentifier(FuncDecl* func) {
 ///
 /// and is intended to be replaced by a transport library by providing an
 /// appropriate @_dynamicReplacement function.
-static void addImplicitRemoteActorFunction(ClassDecl *decl, FuncDecl *func) {
+static FuncDecl*
+addImplicitRemoteFunction(ClassDecl *decl, FuncDecl *func) {
   auto &C = decl->getASTContext();
   auto parentDC = decl;
 
@@ -315,6 +310,10 @@ static void addImplicitRemoteActorFunction(ClassDecl *decl, FuncDecl *func) {
   remoteFuncDecl->getAttrs().add(
       new (C) DistributedActorIndependentAttr(/*IsImplicit=*/true));
 
+  // nonisolated
+  remoteFuncDecl->getAttrs().add(
+      new (C) NonisolatedAttr(/*IsImplicit=*/true));
+
   // users should never have to access this function directly;
   // it is only invoked from our distributed function thunk if the actor is remote.
   remoteFuncDecl->setUserAccessible(false);
@@ -326,16 +325,16 @@ static void addImplicitRemoteActorFunction(ClassDecl *decl, FuncDecl *func) {
   remoteFuncDecl->copyFormalAccessFrom(func, /*sourceIsParentContext=*/false);
 
   decl->addMember(remoteFuncDecl);
+  return remoteFuncDecl;
 }
 
 /// Synthesize dynamic _remote stub functions for each encountered distributed function.
-static void addImplicitRemoteActorFunctions(ClassDecl *decl) {
+static void addImplicitRemoteFunctions(ClassDecl *decl) {
   assert(decl->isDistributedActor());
-
   for (auto member : decl->getMembers()) {
-    auto func = dyn_cast<FuncDecl>(member);
+    auto func = dyn_cast<AbstractFunctionDecl>(member);
     if (func && func->isDistributed()) {
-      addImplicitRemoteActorFunction(decl, func);
+      (void) func->getDistributedActorRemoteFuncDecl();
     }
   }
 }
@@ -344,8 +343,33 @@ static void addImplicitRemoteActorFunctions(ClassDecl *decl) {
 /************************ SYNTHESIS ENTRY POINT *******************************/
 /******************************************************************************/
 
+AbstractFunctionDecl *TypeChecker::addImplicitDistributedActorRemoteFunction(
+    ClassDecl *decl, AbstractFunctionDecl *AFD) {
+  if (!decl->isDistributedActor())
+    return nullptr;
+
+  if (auto func = dyn_cast<FuncDecl>(AFD))
+    return addImplicitRemoteFunction(decl, func);
+
+  return nullptr;
+}
+
+void TypeChecker::addImplicitDistributedActorRemoteFunctions(NominalTypeDecl *decl) {
+  // Bail out if not a distributed actor definition.
+  if (!decl->isDistributedActor())
+    return;
+
+  // If the _Distributed module is missing we cannot synthesize anything.
+  if (!swift::ensureDistributedModuleLoaded(decl))
+    return;
+
+  if (auto clazz = dyn_cast<ClassDecl>(decl))
+    addImplicitRemoteFunctions(clazz);
+}
+
 /// Entry point for adding all computed members to a distributed actor decl.
-void swift::addImplicitDistributedActorMembersToClass(ClassDecl *decl) {
+// TODO(distributed): move the synthesis of protocol requirements to DerivedConformance style
+void swift::addImplicitDistributedActorMembers(ClassDecl *decl) {
   // Bail out if not a distributed actor definition.
   if (!decl->isDistributedActor())
     return;
@@ -356,5 +380,4 @@ void swift::addImplicitDistributedActorMembersToClass(ClassDecl *decl) {
 
   addFactoryResolveFunction(decl);
   addImplicitDistributedActorStoredProperties(decl);
-  addImplicitRemoteActorFunctions(decl);
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2576,12 +2576,6 @@ static ArrayRef<Decl *> evaluateMembersRequest(
     // We need to add implicit initializers because they
     // affect vtable layout.
     TypeChecker::addImplicitConstructors(nominal);
-
-    auto classDecl = dyn_cast<ClassDecl>(idc);
-    if (classDecl  && classDecl->isDistributedActor()) {
-      // We need to synthesize _remote methods for every distributed method.
-      TypeChecker::addImplicitDistributedActorRemoteFunctions(nominal);
-    }
   }
 
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2673,7 +2673,7 @@ public:
 
   /// FIXME: This is an egregious hack to turn off availability checking
   /// for specific functions that were missing availability in older versions
-  /// of existing libraries that we must nonethess still support.
+  /// of existing libraries that we must nonetheless still support.
   static bool hasHistoricallyWrongAvailability(FuncDecl *func) {
     return func->getName().isCompoundName("swift_deletedAsyncMethodError", { });
   }

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -74,11 +74,36 @@ bool IsDistributedActorRequest::evaluate(
 bool IsDistributedFuncRequest::evaluate(
     Evaluator &evaluator, FuncDecl *func) const {
   // Check whether the attribute was explicitly specified.
-  if (auto attr = func->getAttrs().getAttribute<DistributedActorAttr>()) {
-    return true;
-  } else {
-    return false;
+  return func->getAttrs().hasAttribute<DistributedActorAttr>();
+}
+
+AbstractFunctionDecl *GetDistributedRemoteFuncRequest::evaluate(
+    Evaluator &evaluator, AbstractFunctionDecl *func) const {
+  if (!func->isDistributed())
+    return nullptr;
+
+  auto &C = func->getASTContext();
+  DeclContext *DC = func->getDeclContext();
+
+  // not via `ensureDistributedModuleLoaded` to avoid generating a warning,
+  // we won't be emitting the offending decl after all.
+  if (!C.getLoadedModule(C.Id_Distributed))
+    return nullptr;
+
+  // Locate the actor decl that the member must be synthesized to.
+  // TODO(distributed): should this just be added to the extension instead when we're in one?
+  ClassDecl *decl = dyn_cast<ClassDecl>(DC);
+  if (!decl) {
+    if (auto ED = dyn_cast<ExtensionDecl>(DC)) {
+      decl = dyn_cast<ClassDecl>(ED->getExtendedNominal());
+    }
   }
+
+  /// A distributed func cannot be added to a non-distributed actor;
+  /// If the 'decl' was not a distributed actor we must have declared and
+  /// requested it from a illegal context, let's just ignore the synthesis.
+  assert(decl && "Can't find actor detect to add implicit _remote function to");
+  return TypeChecker::addImplicitDistributedActorRemoteFunction(decl, func);
 }
 
 // ==== ------------------------------------------------------------------------
@@ -131,6 +156,9 @@ bool swift::checkDistributedFunction(FuncDecl *func, bool diagnose) {
 
   // === Check _remote functions
   ClassDecl *actorDecl = dyn_cast<ClassDecl>(func->getParent());
+  if (actorDecl == nullptr)
+    if (auto ED = dyn_cast<ExtensionDecl>(func->getParent()))
+      actorDecl = dyn_cast<ClassDecl>(ED->getExtendedNominal());
   assert(actorDecl && actorDecl->isDistributedActor());
 
   // _remote function for a distributed function must not be implemented by end-users,
@@ -234,7 +262,7 @@ void TypeChecker::checkDistributedActor(ClassDecl *decl) {
 
   // --- Synthesize properties
   // TODO: those could technically move to DerivedConformance style
-  swift::addImplicitDistributedActorMembersToClass(decl);
+  swift::addImplicitDistributedActorMembers(decl);
 
   // ==== Functions
 }

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -71,12 +71,6 @@ bool IsDistributedActorRequest::evaluate(
   return classDecl->isExplicitDistributedActor();
 }
 
-bool IsDistributedFuncRequest::evaluate(
-    Evaluator &evaluator, FuncDecl *func) const {
-  // Check whether the attribute was explicitly specified.
-  return func->getAttrs().hasAttribute<DistributedActorAttr>();
-}
-
 AbstractFunctionDecl *GetDistributedRemoteFuncRequest::evaluate(
     Evaluator &evaluator, AbstractFunctionDecl *func) const {
   if (!func->isDistributed())

--- a/lib/Sema/TypeCheckDistributed.h
+++ b/lib/Sema/TypeCheckDistributed.h
@@ -45,7 +45,7 @@ bool checkDistributedFunction(FuncDecl *decl, bool diagnose);
 
 /// Synthesis of members which are not directly driven filling in protocol requirements,
 /// such as the default local and resolve constructors, and `_remote_` function stubs.
-void addImplicitDistributedActorMembersToClass(ClassDecl *decl);
+void addImplicitDistributedActorMembers(ClassDecl *decl);
 
 }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -516,6 +516,17 @@ bool checkContextualRequirements(GenericTypeDecl *decl,
 /// struct, class or actor.
 void addImplicitConstructors(NominalTypeDecl *typeDecl);
 
+/// Synthesize and add a '_remote' counterpart of the passed in `func` to `decl`.
+///
+/// \param decl the actor type to add the '_remote' definition to
+/// \param func the 'distributed func' that the '_remote' func should mirror
+/// \return the synthesized function
+AbstractFunctionDecl *addImplicitDistributedActorRemoteFunction(
+    ClassDecl* decl, AbstractFunctionDecl *func);
+
+// TODO(distributed): remove this?
+void addImplicitDistributedActorRemoteFunctions(NominalTypeDecl *decl);
+
 /// Fold the given sequence expression into an (unchecked) expression
 /// tree.
 Expr *foldSequence(SequenceExpr *expr, DeclContext *dc);

--- a/test/Distributed/Inputs/dynamic_replacement_da_decl.swift
+++ b/test/Distributed/Inputs/dynamic_replacement_da_decl.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import _Distributed
+
+distributed actor DA {
+  distributed func hello(other: DA) {}
+}
+

--- a/test/Distributed/Inputs/dynamic_replacement_da_extension.swift
+++ b/test/Distributed/Inputs/dynamic_replacement_da_extension.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import _Distributed
+
+extension DA {
+  @_dynamicReplacement(for:_remote_hello(other:))
+  nonisolated func _impl_hello(other: DA) async throws {}
+}

--- a/test/Distributed/distributed_actor_dynamic_replacement.swift
+++ b/test/Distributed/distributed_actor_dynamic_replacement.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -disable-availability-checking -enable-experimental-distributed -c -enable-batch-mode -module-name foo -primary-file %S/Inputs/dynamic_replacement_da_extension.swift -primary-file %S/Inputs/dynamic_replacement_da_decl.swift
+
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import _Distributed
+
+func runtimeReceive(da: DA) async throws {
+  try await da.hello(other:da)
+}

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-distributed -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -enable-experimental-distributed -disable-availability-checking -verify-ignore-unknown
+// TODO(distributed): remove the -verify-ignore-unknown, we're causing Sendable warnings in <unknown> locs right now
 // REQUIRES: concurrency
 // REQUIRES: distributed
 
@@ -67,24 +68,26 @@ distributed actor DistributedActor_1 {
     fatalError()
   }
 
-  distributed func distReturnGeneric<T: Codable>(item: T) async throws -> T { // ok
+  distributed func distReturnGeneric<T: Sendable & Codable>(item: T) async throws -> T { // ok
     item
   }
-  distributed func distReturnGenericWhere<T>(item: Int) async throws -> T where T: Codable { // ok
+  distributed func distReturnGenericWhere<T>(item: Int) async throws -> T
+      where T: Sendable, T: Codable { // ok
     fatalError()
   }
-  distributed func distBadReturnGeneric<T>(int: Int) async throws -> T {
+  distributed func distBadReturnGeneric<T: Sendable>(int: Int) async throws -> T {
     // expected-error@-1 {{distributed function result type 'T' does not conform to 'Codable'}}
     fatalError()
   }
 
-  distributed func distGenericParam<T: Codable>(value: T) async throws { // ok
+  distributed func distGenericParam<T: Sendable & Codable>(value: T) async throws { // ok
     fatalError()
   }
-  distributed func distGenericParamWhere<T>(value: T) async throws -> T where T: Codable { // ok
+  distributed func distGenericParamWhere<T>(value: T) async throws -> T
+      where T: Sendable, T: Codable { // ok
     value
   }
-  distributed func distBadGenericParam<T>(int: T) async throws {
+  distributed func distBadGenericParam<T>(int: T) async throws where T: Sendable {
     // expected-error@-1 {{distributed function parameter 'int' of type 'T' does not conform to 'Codable'}}
     fatalError()
   }


### PR DESCRIPTION
This enables a _remote function to be looked up even if we FIRST visit an extension, say in a different file, and notice a dynamic member replacement there. This will be the case basically always since member replacements are in generated sources, in other files.

This cleans up also some cached requests which don't need to be cached since they just check for the presence of an attribute which is pretty cheap.

More cleanups to follow because now we can move all protocol witness required synthesis to the DerivedMember style -- something we could not do before since we needed to synthesize initializers etc.