### PR TITLE
[WIP] Have IsBindableVisitor consider conditional conformances.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1798,12 +1798,13 @@ public:
   }
   
   CanType visitDynamicSelfType(DynamicSelfType *orig, CanType subst,
-                               ArchetypeType *, ArrayRef<ProtocolConformanceRef>) {
+                           ArchetypeType *upperBound,
+                           ArrayRef<ProtocolConformanceRef> substConformances) {
     // A "dynamic self" type can be bound to another dynamic self type, or the
     // non-dynamic base class type.
     if (auto dynSubst = dyn_cast<DynamicSelfType>(subst)) {
       if (auto newBase = visit(orig->getSelfType(), dynSubst.getSelfType(),
-                               nullptr, {})) {
+                               upperBound, substConformances)) {
         return CanDynamicSelfType::get(newBase, orig->getASTContext())
                                  ->getCanonicalType();
       }
@@ -1811,31 +1812,146 @@ public:
     }
     
     if (auto newNonDynBase = visit(orig->getSelfType(), subst,
-                                   nullptr, {})) {
+                                   upperBound, substConformances)) {
       return newNonDynBase;
     }
     return CanType();
   }
   
+  /// Handle a nominal type with generic parameters anywhere in its context.
+  /// \c origType and \c substType must already have been established to be
+  /// instantiations of the same \c NominalTypeDecl.
+  CanType handleGenericNominalType(NominalTypeDecl *decl,
+                           CanType origType,
+                           CanType substType,
+                           ArchetypeType *upperBound,
+                           ArrayRef<ProtocolConformanceRef> substConformances) {
+    assert(origType->getAnyNominal() == decl
+           && substType->getAnyNominal() == decl);
+    
+    auto *moduleDecl = decl->getParentModule();
+    auto origSubMap = origType->getContextSubstitutionMap(
+        moduleDecl, decl, decl->getGenericEnvironment());
+    auto substSubMap = substType->getContextSubstitutionMap(
+        moduleDecl, decl, decl->getGenericEnvironment());
+
+    auto genericSig = decl->getGenericSignature();
+    
+    SmallVector<Type, 4> newParams;
+    llvm::DenseMap<Type, Type> newParamsMap;
+    bool didChange = false;
+    
+    for (auto gpTy : genericSig.getGenericParams()) {
+      auto gp = gpTy->getCanonicalType();
+      
+      auto orig = gp.subst(origSubMap)->getCanonicalType();
+      auto subst = gp.subst(substSubMap)->getCanonicalType();
+      
+      // The new type is upper-bounded by the constraints the nominal type
+      // requires. The substitution operation may be interested in transforming
+      // the substituted type's conformances to these protocols.
+      //
+      // FIXME: The upperBound on the nominal type itself may impose additional
+      // requirements on the type parameters due to conditional conformances.
+      // These are currently not considered, leading to invalid generic signatures
+      // built during SILGen.
+      auto paramUpperBound = decl->mapTypeIntoContext(gp)
+                                 ->getAs<ArchetypeType>();
+      SmallVector<ProtocolConformanceRef, 4> paramSubstConformances;
+      if (paramUpperBound) {
+        for (auto proto : paramUpperBound->getConformsTo()) {
+          auto conformance = substSubMap.lookupConformance(gp->getCanonicalType(),
+                                                           proto);
+          if (!conformance)
+            return CanType();
+          paramSubstConformances.push_back(conformance);
+        }
+      }
+      
+      auto newParam = visit(orig, subst, paramUpperBound,
+                            paramSubstConformances);
+      if (!newParam)
+        return CanType();
+      
+      newParams.push_back(newParam);
+      newParamsMap.insert({gpTy, newParam});
+      didChange |= (newParam != subst);
+    }
+    
+    SmallVector<ProtocolConformanceRef, 4> newConformances;
+
+    // Collect conformances for the new substitutions, and verify that they don't
+    // invalidate the binding to the original type.
+    for (const auto &req : genericSig.getRequirements()) {
+      if (req.getKind() != RequirementKind::Conformance) continue;
+
+      auto canTy = req.getFirstType()->getCanonicalType();
+      
+      // Verify the generic requirements, if the subst type is bound to
+      // concrete type.
+      auto *proto = req.getProtocolDecl();
+      if (!canTy.subst(substSubMap)->isTypeParameter()) {
+        auto origConf = origSubMap.lookupConformance(canTy, proto);
+        auto substConf = substSubMap.lookupConformance(canTy, proto);
+
+        if (origConf.isConcrete()) {
+          // A generic argument may inherit a concrete conformance from a class
+          // constraint, which could still be bound to a type parameter we don't
+          // know more about.
+          if (origConf.getConcrete()->getType()->is<ArchetypeType>())
+            continue;
+          
+          if (!substConf.isConcrete())
+            return CanType();
+          if (origConf.getConcrete()->getRootConformance()
+                != substConf.getConcrete()->getRootConformance())
+            return CanType();
+        }
+      }
+      
+      // Gather the conformances for the new binding type, if the type changed.
+      if (didChange) {
+        auto newSubstTy = newParamsMap.find(req.getFirstType());
+        assert(newSubstTy != newParamsMap.end());
+        
+        if (newSubstTy->second->isTypeParameter()) {
+          newConformances.push_back(ProtocolConformanceRef(proto));
+        } else {
+          auto newConformance
+            = moduleDecl->lookupConformance(newSubstTy->second, proto);
+          if (!newConformance)
+            return CanType();
+          newConformances.push_back(newConformance);
+        }
+      }
+    }
+
+    if (!didChange)
+      return substType;
+    
+    // Build the new substituted generic type.
+    auto newSubMap = SubstitutionMap::get(genericSig,
+                                          newParams,
+                                          newConformances);
+    return decl->getDeclaredInterfaceType().subst(newSubMap)
+               ->getCanonicalType();
+  }
+  
   CanType visitNominalType(NominalType *nom, CanType subst,
-                           ArchetypeType*, ArrayRef<ProtocolConformanceRef>) {
+                           ArchetypeType* upperBound,
+                           ArrayRef<ProtocolConformanceRef> substConformances) {
     if (auto substNom = dyn_cast<NominalType>(subst)) {
+      auto nomDecl = nom->getDecl();
       if (nom->getDecl() != substNom->getDecl())
         return CanType();
       
-      // Same decl should always either have or not have a parent.
-      assert((bool)nom->getParent() == (bool)substNom->getParent());
-      
-      if (nom->getParent()) {
-        auto substParent = visit(nom->getParent()->getCanonicalType(),
-                                 substNom->getParent()->getCanonicalType(),
-                                 nullptr, {});
-        if (substParent == substNom.getParent())
-          return subst;
-        return NominalType::get(nom->getDecl(), substParent,
-                                nom->getASTContext())
-          ->getCanonicalType();
+      // If the type is generic (because it's a nested type in a generic context),
+      // process the generic type bindings.
+      if (!isa<ProtocolDecl>(nomDecl) && nomDecl->isGenericContext()) {
+        return handleGenericNominalType(nomDecl, CanType(nom), subst,
+                                        upperBound, substConformances);
       }
+      // Otherwise, the nongeneric nominal types trivially match.
       return subst;
     }
     return CanType();
@@ -2055,7 +2171,8 @@ public:
   }
   
   CanType visitBoundGenericType(BoundGenericType *bgt, CanType subst,
-                            ArchetypeType *, ArrayRef<ProtocolConformanceRef>) {
+                          ArchetypeType *upperBound,
+                          ArrayRef<ProtocolConformanceRef> substConformances) {
     auto substBGT = dyn_cast<BoundGenericType>(subst);
     if (!substBGT)
       return CanType();
@@ -2065,95 +2182,8 @@ public:
 
     auto *decl = bgt->getDecl();
 
-    auto *moduleDecl = decl->getParentModule();
-    auto origSubMap = bgt->getContextSubstitutionMap(
-        moduleDecl, decl, decl->getGenericEnvironment());
-    auto substSubMap = substBGT->getContextSubstitutionMap(
-        moduleDecl, decl, decl->getGenericEnvironment());
-
-    auto genericSig = decl->getGenericSignature();
-    
-    // Same decl should always either have or not have a parent.
-    assert((bool)bgt->getParent() == (bool)substBGT->getParent());
-    CanType newParent;
-    if (bgt->getParent()) {
-      newParent = visit(bgt->getParent()->getCanonicalType(),
-                        substBGT.getParent(),
-                        nullptr, {});
-      if (!newParent)
-        return CanType();
-    }
-    
-    SmallVector<Type, 4> newParams;
-    bool didChange = newParent != substBGT.getParent();
-    
-    auto depthStart =
-      genericSig.getGenericParams().size() - bgt->getGenericArgs().size();
-    for (auto i : indices(bgt->getGenericArgs())) {
-      auto orig = bgt->getGenericArgs()[i]->getCanonicalType();
-      auto subst = substBGT.getGenericArgs()[i];
-      auto gp = genericSig.getGenericParams()[depthStart + i];
-      
-      // The new type is upper-bounded by the constraints the nominal type
-      // requires. The substitution operation may be interested in transforming
-      // the substituted type's conformances to these protocols.
-      auto upperBoundArchetype = decl->mapTypeIntoContext(gp)
-                                     ->getAs<ArchetypeType>();
-      SmallVector<ProtocolConformanceRef, 4> substConformances;
-      if (upperBoundArchetype) {
-        for (auto proto : upperBoundArchetype->getConformsTo()) {
-          auto conformance = substSubMap.lookupConformance(gp->getCanonicalType(),
-                                                           proto);
-          if (!conformance)
-            return CanType();
-          substConformances.push_back(conformance);
-        }
-      }
-      
-      auto newParam = visit(orig, subst, upperBoundArchetype,
-                            substConformances);
-      if (!newParam)
-        return CanType();
-      
-      newParams.push_back(newParam);
-      didChange |= (newParam != subst);
-    }
-
-    for (const auto &req : genericSig.getRequirements()) {
-      if (req.getKind() != RequirementKind::Conformance) continue;
-
-      auto canTy = req.getFirstType()->getCanonicalType();
-
-      // If the substituted type is an interface type, we can't verify the
-      // generic requirements.
-      if (canTy.subst(substSubMap)->isTypeParameter())
-        continue;
-
-      auto *proto = req.getProtocolDecl();
-      auto origConf = origSubMap.lookupConformance(canTy, proto);
-      auto substConf = substSubMap.lookupConformance(canTy, proto);
-
-      if (origConf.isConcrete()) {
-        // A generic argument may inherit a concrete conformance from a class
-        // constraint, which could still be bound to a type parameter we don't
-        // know more about.
-        if (origConf.getConcrete()->getType()->is<ArchetypeType>())
-          continue;
-        
-        if (!substConf.isConcrete())
-          return CanType();
-        if (origConf.getConcrete()->getRootConformance()
-              != substConf.getConcrete()->getRootConformance())
-          return CanType();
-      }
-    }
-
-    if (!didChange)
-      return subst;
-    
-    return BoundGenericType::get(substBGT->getDecl(),
-                                 newParent, newParams)
-      ->getCanonicalType();
+    return handleGenericNominalType(decl, CanType(bgt), subst,
+                                    upperBound, substConformances);
   }
 };
 }

--- a/test/SILGen/type_lowering_subst_function_type_conditional_conformance.swift
+++ b/test/SILGen/type_lowering_subst_function_type_conditional_conformance.swift
@@ -1,0 +1,53 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+enum E<T : P> {
+  case a(T.X)
+}
+
+struct S<T> {}
+
+protocol P {
+  associatedtype X
+}
+
+extension S : P where T : P {
+  typealias X = T.X
+}
+
+func foo<T : P>(_ x: E<S<T>>) {
+// Ensure that the lowered substituted SIL function type for `() -> E<S<T>>`
+// preserves the T: P constraint necessary to allow for `S<T>` to substitute
+// into `E<T: P>`
+  bar({ return x })
+}
+
+// CHECK-LABEL: {{^}}sil {{.*}} @${{.*}}3bar
+// CHECK-SAME: @substituted <τ_0_0 where τ_0_0 : P> () -> @out E<S<τ_0_0>> for <T>
+func bar<T: P>(_: () -> E<S<T>>) {}
+
+// ---
+
+protocol Q: P {
+  associatedtype Y
+}
+
+enum E2<T: Q> {
+  case a(T.Y)
+}
+
+struct S2<T: P>: P {
+  typealias X = T.X
+}
+
+extension S2: Q where T: Q {
+  typealias Y = T.Y
+}
+
+func foo2<T : Q>(_ x: E2<S2<T>>) {
+  bar2({ return x })
+}
+
+// CHECK-LABEL: {{^}}sil {{.*}} @${{.*}}4bar2
+// CHECK-SAME: @substituted <τ_0_0 where τ_0_0 : Q> () -> @out E2<S2<τ_0_0>> for <T>
+func bar2<T: Q>(_: () -> E2<S2<T>>) {}
+


### PR DESCRIPTION
The upper bound on a nominal type's generic argument can have more requirements imposed on it than those written in the original nominal type's generic signature, depending on the requirements imposed on the nominal type itself, thanks to conditional conformances. `IsBindableVisitor` failed to take this into account when visiting the bindings of generic type arguments. This could cause `Type::isBindableTo` to provide a false positive for a substituted type that doesn't satisfy conditional conformances, but more importantly, SIL type lowering uses the same visitor to extract an upper bound generic signature for substituted SIL function types, and if it doesn't preserve requirements from conditional conformances on nominal types in that signature, it can end up building an incorrect substitution map. Fix this by passing down the upper bound from generic arguments even when visiting nominal types, and using those upper bounds to check for conditional conformances that add requirements to generic arguments while visiting them.