### PR TITLE
build: identify and centralise the build artifacts

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -666,6 +666,16 @@ msbuild %SourceRoot%\swift-installer-scripts\platforms\Windows\installer.wixproj
 :: TODO(compnerd) actually perform the code-signing
 :: signtool sign /f Apple_CodeSign.pfx /p Apple_CodeSign_Password /tr http://timestamp.digicert.com /fd sha256 %PackageRoot%\installer\installer.exe
 
+:: Stage Artifacts
+md %BuildRoot%\artifacts
+:: FIXME(compnerd) should we provide SDKs as standalone artifact?
+move %PackageRoot%\sdk.msi %BuildRoot%\artifacts || (exit /b)
+:: Redistributable libraries for developers
+move %PackageRoot%\runtime.msi %BuildRoot%\artifacts || (exit /b)
+move %PackageRoot%\icu.msi %BuildRoot%\artifacts || (exit /b)
+:: Installer
+move %PackageRoot%\installer\installer.exe %BuildRoot%\artifacts || (exit /b)
+
 :: TODO(compnerd) test LLVM
 
 :: Test Swift


### PR DESCRIPTION
This collects the build artifacts into a central location for easy
handling by the CI system.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
