### PR TITLE
[Refactoring] Do not try to unique '_'

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -7238,7 +7238,7 @@ private:
                                   /*Success=*/true);
 
     addAwaitCall(CE, ArgList.ref(), Blocks.SuccessBlock, SuccessParams,
-                 InlinePatterns, HandlerDesc, /*AddDeclarations*/ true);
+                 InlinePatterns, HandlerDesc, /*AddDeclarations=*/true);
     printOutOfLineBindingPatterns(Blocks.SuccessBlock, InlinePatterns);
     convertNodes(Blocks.SuccessBlock.nodesToPrint());
     clearNames(SuccessParams);
@@ -7249,7 +7249,8 @@ private:
 
       // Always use the ErrParam name if none is bound.
       prepareNames(Blocks.ErrorBlock, llvm::makeArrayRef(ErrParam),
-                   ErrInlinePatterns, HandlerDesc.Type != HandlerType::RESULT);
+                   ErrInlinePatterns,
+                   /*AddIfMissing=*/HandlerDesc.Type != HandlerType::RESULT);
       preparePlaceholdersAndUnwraps(HandlerDesc, SuccessParams, ErrParam,
                                     /*Success=*/false);
 
@@ -7530,7 +7531,7 @@ private:
   void addCatch(const ParamDecl *ErrParam) {
     OS << "\n" << tok::r_brace << " " << tok::kw_catch << " ";
     auto ErrName = newNameFor(ErrParam, false);
-    if (!ErrName.empty()) {
+    if (!ErrName.empty() && ErrName != "_") {
       OS << tok::kw_let << " " << ErrName << " ";
     }
     OS << tok::l_brace;
@@ -7614,6 +7615,8 @@ private:
   /// other names in the current scope.
   Identifier createUniqueName(StringRef Name) {
     Identifier Ident = getASTContext().getIdentifier(Name);
+    if (Name == "_")
+      return Ident;
 
     auto &CurrentNames = Scopes.back().Names;
     if (CurrentNames.count(Ident)) {

--- a/test/refactoring/ConvertAsync/convert_function.swift
+++ b/test/refactoring/ConvertAsync/convert_function.swift
@@ -622,3 +622,46 @@ func twoCompletionHandlerCalls(completion: @escaping (String?, Error?) -> Void) 
 // TWO-COMPLETION-HANDLER-CALLS-NEXT:   return res
 // TWO-COMPLETION-HANDLER-CALLS-NEXT:   return res
 // TWO-COMPLETION-HANDLER-CALLS-NEXT: }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NESTED-IGNORED %s
+func nestedIgnored() throws {
+  simple { _ in
+    print("done")
+    simple { _ in
+      print("done")
+    }
+  }
+}
+// NESTED-IGNORED:      func nestedIgnored() async throws {
+// NESTED-IGNORED-NEXT:   let _ = await simple()
+// NESTED-IGNORED-NEXT:   print("done")
+// NESTED-IGNORED-NEXT:   let _ = await simple()
+// NESTED-IGNORED-NEXT:   print("done")
+// NESTED-IGNORED-NEXT: }
+
+// RUN: %refactor-check-compiles -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=IGNORED-ERR %s
+func nestedIgnoredErr() throws {
+  simpleErr(arg: "") { str, _ in
+    if str == nil {
+      print("error")
+    }
+
+    simpleErr(arg: "") { str, _ in
+      if str == nil {
+        print("error")
+      }
+    }
+  }
+}
+// IGNORED-ERR:      func nestedIgnoredErr() async throws {
+// IGNORED-ERR-NEXT:   do {
+// IGNORED-ERR-NEXT:     let str = try await simpleErr(arg: "")
+// IGNORED-ERR-NEXT:     do {
+// IGNORED-ERR-NEXT:       let str1 = try await simpleErr(arg: "")
+// IGNORED-ERR-NEXT:     } catch {
+// IGNORED-ERR-NEXT:       print("error")
+// IGNORED-ERR-NEXT:     }
+// IGNORED-ERR-NEXT:   } catch {
+// IGNORED-ERR-NEXT:     print("error")
+// IGNORED-ERR-NEXT:   }
+// IGNORED-ERR-NEXT: }


### PR DESCRIPTION
The async refactorings should not try to unique `_` when it's used as
the parameter name. Also skip adding a let binding to the `catch` if the
error parameter is `_`.

Resolves rdar://82158389
