### PR TITLE
build: add a workaround for CMake 3.20

### DIFF
--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -79,9 +79,10 @@ call :build_swift %exitOnError%
 
 call :build_lldb %exitOnError%
 
+path %PATH%;C:\Program Files\Git\usr\bin
 call :build_libdispatch %exitOnError%
 
-path %source_root%\icu-%icu_version%\bin64;%install_directory%\bin;%build_root%\swift\bin;%build_root%\swift\libdispatch-prefix\bin;%PATH%;C:\Program Files\Git\usr\bin
+path %source_root%\icu-%icu_version%\bin64;%install_directory%\bin;%build_root%\swift\bin;%build_root%\swift\libdispatch-prefix\bin;%PATH%
 call :test_swift %exitOnError%
 call :test_libdispatch %exitOnError%
 
@@ -333,6 +334,8 @@ endlocal
 :: Configures, builds, and installs Dispatch
 setlocal enableextensions enabledelayedexpansion
 
+for /f "delims=" %%O in ('cygpath -m %install_directory%\lib\swift') do set RESOURCE_DIR=%%O
+
 cmake^
     -B "%build_root%\swift-corelibs-libdispatch"^
     -G Ninja^
@@ -352,8 +355,8 @@ cmake^
     -DCMAKE_EXE_LINKER_FLAGS:STRING="/INCREMENTAL:NO"^
     -DCMAKE_SHARED_LINKER_FLAGS:STRING="/INCREMENTAL:NO"^
     -DCMAKE_Swift_COMPILER_TARGET:STRING=x86_64-unknown-windows-msvc^
-    -DCMAKE_Swift_FLAGS:STRING="-resource-dir \"%install_directory%\lib\swift\""^
-    -DCMAKE_Swift_LINK_FLAGS:STRING="-resource-dir \"%install_directory%\lib\swift\""^
+    -DCMAKE_Swift_FLAGS:STRING="-resource-dir \"%RESOURCE_DIR%\""^
+    -DCMAKE_Swift_LINK_FLAGS:STRING="-resource-dir \"%RESOURCE_DIR%\""^
     -S "%source_root%\swift-corelibs-libdispatch" %exitOnError%
 
 cmake --build "%build_root%\swift-corelibs-libdispatch" %exitOnError%

--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -2,7 +2,7 @@
 ::
 :: This source file is part of the Swift.org open source project
 ::
-:: Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+:: Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 :: Licensed under Apache License v2.0 with Runtime Library Exception
 ::
 :: See https://swift.org/LICENSE.txt for license information


### PR DESCRIPTION
CMake 3.20 had a bug on the release where the user supplied paths would
be processed without conversion.  This adds a workaround by using
`cygpath` to convert the path to a mixed model style which should avoid
the problem.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
