### PR TITLE
[IRGen] De-duplicate implementations of minimum OS versions supporting mangling.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -784,6 +784,11 @@ public:
   /// compiler for the target platform.
   AvailabilityContext getSwift56Availability();
 
+  // Note: Update this function if you add a new getSwiftXYAvailability above.
+  /// Get the runtime availability for a particular version of Swift (5.0+).
+  AvailabilityContext
+  getSwift5PlusAvailability(llvm::VersionTuple swiftVersion);
+
   /// Get the runtime availability of features that have been introduced in the
   /// Swift compiler for future versions of the target platform.
   AvailabilityContext getSwiftFutureAvailability();

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -457,3 +457,21 @@ AvailabilityContext ASTContext::getSwiftFutureAvailability() {
     return AvailabilityContext::alwaysAvailable();
   }
 }
+
+AvailabilityContext
+ASTContext::getSwift5PlusAvailability(llvm::VersionTuple swiftVersion) {
+  if (swiftVersion.getMajor() == 5) {
+    switch (*swiftVersion.getMinor()) {
+    case 0: return getSwift50Availability();
+    case 1: return getSwift51Availability();
+    case 2: return getSwift52Availability();
+    case 3: return getSwift53Availability();
+    case 4: return getSwift54Availability();
+    case 5: return getSwift55Availability();
+    case 6: return getSwift56Availability();
+    default: break;
+    }
+  }
+  llvm::report_fatal_error("Missing call to getSwiftXYAvailability for Swift " +
+                           swiftVersion.getAsString());
+}

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -650,6 +650,11 @@ protected:
   }
 };
 
+/// Does this type require a special minimum Swift runtime version which
+/// supports demangling it?
+Optional<llvm::VersionTuple>
+getRuntimeVersionThatSupportsDemanglingType(CanType type);
+
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -2487,18 +2487,10 @@ static bool shouldAccessByMangledName(IRGenModule &IGM, CanType type) {
   }
   
   // The Swift 5.1 runtime fails to demangle associated types of opaque types.
-  if (!IGM.getAvailabilityContext().isContainedIn(IGM.Context.getSwift52Availability())) {
-    auto hasNestedOpaqueArchetype = type.findIf([](CanType sub) -> bool {
-      if (auto archetype = dyn_cast<NestedArchetypeType>(sub)) {
-        if (isa<OpaqueTypeArchetypeType>(archetype->getRoot())) {
-          return true;
-        }
-      }
-      return false;
-    });
-    
-    if (hasNestedOpaqueArchetype)
-      return false;
+  if (auto minimumSwiftVersion =
+          getRuntimeVersionThatSupportsDemanglingType(type)) {
+    return IGM.getAvailabilityContext().isContainedIn(
+        IGM.Context.getSwift5PlusAvailability(*minimumSwiftVersion));
   }
   
   return true;


### PR DESCRIPTION
This makes it easier to add handling for new types with special mangling,
as only one place needs to be changed instead of two.