### PR TITLE
Enter a new debug scope for every let binding.

### DIFF
--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -305,7 +305,7 @@ public:
   std::vector<PatternMatchContext*> SwitchStack;
   /// Keep track of our current nested scope.
   ///
-  /// The boolean tracks whether this is a 'guard' scope, which should be
+  /// The boolean tracks whether this is a binding scope, which should be
   /// popped automatically when we leave the innermost BraceStmt scope.
   std::vector<llvm::PointerIntPair<const SILDebugScope *, 1>> DebugScopeStack;
 
@@ -576,11 +576,12 @@ public:
 
   /// Enter the debug scope for \p Loc, creating it if necessary.
   ///
-  /// \param isGuardScope If true, this is a scope for the bindings introduced by
-  /// a 'guard' statement. This scope ends when the next innermost BraceStmt ends.
-  void enterDebugScope(SILLocation Loc, bool isGuardScope=false) {
-    auto *Parent =
-        DebugScopeStack.size() ? DebugScopeStack.back().getPointer() : F.getDebugScope();
+  /// \param isBindingScope If true, this is a scope for the bindings introduced
+  /// by a let expression. This scope ends when the next innermost BraceStmt
+  /// ends.
+  void enterDebugScope(SILLocation Loc, bool isBindingScope = false) {
+    auto *Parent = DebugScopeStack.size() ? DebugScopeStack.back().getPointer()
+                                          : F.getDebugScope();
     auto *DS = Parent;
     // Don't create a pointless scope for the function body's BraceStmt.
     if (!DebugScopeStack.empty())
@@ -588,7 +589,7 @@ public:
       if (RegularLocation(DS->getLoc()) != RegularLocation(Loc))
         DS = new (SGM.M)
           SILDebugScope(RegularLocation(Loc), &getFunction(), DS);
-    DebugScopeStack.emplace_back(DS, isGuardScope);
+    DebugScopeStack.emplace_back(DS, isBindingScope);
     B.setCurrentDebugScope(DS);
   }
 

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -730,9 +730,6 @@ void StmtEmitter::visitGuardStmt(GuardStmt *S) {
   // Emit the condition bindings, branching to the bodyBB if they fail.
   auto NumFalseTaken = SGF.loadProfilerCount(S->getBody());
   auto NumNonTaken = SGF.loadProfilerCount(S);
-  // Begin a new 'guard' scope, which is popped when the next innermost debug
-  // scope ends.
-  SGF.enterDebugScope(S, /*isGuardScope=*/true);
   SGF.emitStmtCondition(S->getCond(), bodyBB, S, NumNonTaken, NumFalseTaken);
 }
 

--- a/lib/SILGen/SwitchEnumBuilder.cpp
+++ b/lib/SILGen/SwitchEnumBuilder.cpp
@@ -137,6 +137,11 @@ void SwitchEnumBuilder::emit() && {
     // Don't allow cleanups to escape the conditional block.
     SwitchCaseFullExpr presentScope(builder.getSILGenFunction(),
                                     CleanupLocation(loc), branchDest);
+    // Begin a new binding scope, which is popped when the next innermost debug
+    // scope ends. The cleanup location loc isn't the perfect source location
+    // but it's close enough.
+    builder.getSILGenFunction().enterDebugScope(loc,
+                                                /*isBindingScope=*/true);
 
     builder.emitBlock(caseBlock);
 

--- a/test/DebugInfo/guard-let-scope.swift
+++ b/test/DebugInfo/guard-let-scope.swift
@@ -3,7 +3,7 @@
 func f(c: AnyObject?) {
   let x = c
   // CHECK: sil_scope [[S1:[0-9]+]] { {{.*}} parent @{{.*}}1f
-  // CHECK: sil_scope [[S2:[0-9]+]] { loc "{{.*}}":[[@LINE+3]]:3 parent [[S1]] }
+  // CHECK: sil_scope [[S2:[0-9]+]] { loc "{{.*}}":[[@LINE+3]]:17 parent [[S1]] }
   // CHECK: debug_value %{{.*}} : $Optional<AnyObject>, let, name "x"{{.*}} scope [[S1]]
   // CHECK: debug_value %{{.*}} : $AnyObject, let, name "x", {{.*}} scope [[S2]]
   guard let x = x else {

--- a/test/SILOptimizer/constantprop-wrongscope.swift
+++ b/test/SILOptimizer/constantprop-wrongscope.swift
@@ -12,10 +12,10 @@
 // Make sure that the destroy_addr instruction has the same scope of the
 // instructions surrounding it.
 
-// CHECK:   destroy_addr %7 : $*Any, loc {{.*}}:22:19, scope 1
-// CHECK:   dealloc_stack %12 : $*Optional<Any>, loc {{.*}}:22:23, scope 1
-// CHECK:   dealloc_stack %7 : $*Any, loc {{.*}}:22:23, scope 1
-// CHECK:   dealloc_stack %6 : $*A, loc {{.*}}:22:7, scope 1
+// CHECK:   destroy_addr %7 : $*Any, loc {{.*}}:22:19, scope 2
+// CHECK:   dealloc_stack %12 : $*Optional<Any>, loc {{.*}}:22:23, scope 2
+// CHECK:   dealloc_stack %7 : $*Any, loc {{.*}}:22:23, scope 2
+// CHECK:   dealloc_stack %6 : $*A, loc {{.*}}:22:7, scope 2
 
 import Foundation
 func indexedSubscripting(b b: B, idx: Int, a: A) {

--- a/test/SILOptimizer/definite-init-wrongscope.swift
+++ b/test/SILOptimizer/definite-init-wrongscope.swift
@@ -33,14 +33,14 @@ public class M {
 
 // CHECK-LABEL: sil [ossa] @$s3del1MC4fromAcA12WithDelegate_p_tKcfc : $@convention(method) (@in WithDelegate, @owned M) -> (@owned M, @error Error)
 
-// CHECK:   [[I:%.*]] = integer_literal $Builtin.Int2, 1, loc {{.*}}:23:12, scope 2
-// CHECK:   [[V:%.*]] = load [trivial] %2 : $*Builtin.Int2, loc {{.*}}:23:12, scope 2
-// CHECK:   [[OR:%.*]] = builtin "or_Int2"([[V]] : $Builtin.Int2, [[I]] : $Builtin.Int2) : $Builtin.Int2, loc {{.*}}:23:12, scope 2
-// CHECK:   store [[OR]] to [trivial] %2 : $*Builtin.Int2, loc {{.*}}:23:12, scope 2
-// CHECK:   store %{{.*}} to [init] %{{.*}} : $*C, loc {{.*}}:26:20, scope 2
+// CHECK:   [[I:%.*]] = integer_literal $Builtin.Int2, 1, loc {{.*}}:23:12, scope 4
+// CHECK:   [[V:%.*]] = load [trivial] %2 : $*Builtin.Int2, loc {{.*}}:23:12, scope 4
+// CHECK:   [[OR:%.*]] = builtin "or_Int2"([[V]] : $Builtin.Int2, [[I]] : $Builtin.Int2) : $Builtin.Int2, loc {{.*}}:23:12, scope 4
+// CHECK:   store [[OR]] to [trivial] %2 : $*Builtin.Int2, loc {{.*}}:23:12, scope 4
+// CHECK:   store %{{.*}} to [init] %{{.*}} : $*C, loc {{.*}}:26:20, scope 4
 
 // Make sure the dealloc_stack gets the same scope of the instructions surrounding it.
 
-// CHECK:   destroy_addr %0 : $*WithDelegate, loc {{.*}}:29:5, scope 2
-// CHECK:   dealloc_stack %2 : $*Builtin.Int2, loc {{.*}}:23:12, scope 2
+// CHECK:   destroy_addr %0 : $*WithDelegate, loc {{.*}}:29:5, scope 4
+// CHECK:   dealloc_stack %2 : $*Builtin.Int2, loc {{.*}}:23:12, scope 4
 // CHECK:   throw %{{.*}} : $Error, loc {{.*}}:23:12, scope 1


### PR DESCRIPTION
This fixes an ambiguity (that leads to a crash further down the pipeline) when
compiling optional unwrap bindings that bind the same variable name.

rdar://73490741

