### PR TITLE
Overhaul availability checking to diagnose errors in inlinable code

### DIFF
--- a/include/swift/AST/Availability.h
+++ b/include/swift/AST/Availability.h
@@ -217,6 +217,10 @@ public:
   /// deployment target.
   static AvailabilityContext forDeploymentTarget(ASTContext &Ctx);
 
+  /// Creates a context that imposes the constraints of the ASTContext's
+  /// inlining target (i.e. minimum inlining version).
+  static AvailabilityContext forInliningTarget(ASTContext &Ctx);
+
   /// Creates a context that imposes no constraints.
   ///
   /// \see isAlwaysAvailable

--- a/include/swift/AST/TypeRefinementContext.h
+++ b/include/swift/AST/TypeRefinementContext.h
@@ -58,6 +58,12 @@ public:
     /// function declaration or the contents of a class declaration).
     Decl,
 
+    /// The context was introduced by a resilience boundary; that is, we are in
+    /// a module with library evolution enabled and the parent context's
+    /// contents can be visible to the module's clients, but this context's
+    /// contents are not.
+    ResilienceBoundary,
+
     /// The context was introduced for the Then branch of an IfStmt.
     IfStmtThenBranch,
 
@@ -102,7 +108,10 @@ private:
 
   public:
     IntroNode(SourceFile *SF) : IntroReason(Reason::Root), SF(SF) {}
-    IntroNode(Decl *D) : IntroReason(Reason::Decl), D(D) {}
+    IntroNode(Decl *D, Reason introReason = Reason::Decl)
+        : IntroReason(introReason), D(D) {
+      (void)getAsDecl();    // check that assertion succeeds
+    }
     IntroNode(IfStmt *IS, bool IsThen) :
     IntroReason(IsThen ? Reason::IfStmtThenBranch : Reason::IfStmtElseBranch),
                 IS(IS) {}
@@ -122,7 +131,8 @@ private:
     }
 
     Decl *getAsDecl() const {
-      assert(IntroReason == Reason::Decl);
+      assert(IntroReason == Reason::Decl ||
+             IntroReason == Reason::ResilienceBoundary);
       return D;
     }
 
@@ -182,7 +192,14 @@ public:
                                               const AvailabilityContext &Info,
                                               const AvailabilityContext &ExplicitInfo,
                                               SourceRange SrcRange);
-  
+
+  /// Create a refinement context for the given declaration.
+  static TypeRefinementContext *
+  createForResilienceBoundary(ASTContext &Ctx, Decl *D,
+                              TypeRefinementContext *Parent,
+                              const AvailabilityContext &Info,
+                              SourceRange SrcRange);
+
   /// Create a refinement context for the Then branch of the given IfStmt.
   static TypeRefinementContext *
   createForIfStmtThen(ASTContext &Ctx, IfStmt *S, TypeRefinementContext *Parent,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -127,6 +127,13 @@ namespace swift {
     /// The target variant SDK version, if known.
     Optional<llvm::VersionTuple> VariantSDKVersion;
 
+    /// The lowest target OS version that code in this module may be inlined
+    /// into. In resilient modules, this should match the minimum
+    /// deployment target of the *first* resilient version of the module, since
+    /// clients may need to interoperate with versions as far back as that
+    /// deployment target.
+    llvm::VersionTuple MinimumInliningTargetVersion;
+
     /// The alternate name to use for the entry point instead of main.
     std::string entryPointFunctionName = "main";
 

--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -55,6 +55,9 @@ namespace swift {
   bool triplesAreValidForZippering(const llvm::Triple &target,
                                    const llvm::Triple &targetVariant);
 
+  const Optional<llvm::VersionTuple>
+  minimumABIStableOSVersionForTriple(const llvm::Triple &triple);
+
   /// Returns true if the given triple represents an OS that ships with
   /// ABI-stable swift libraries (eg. in /usr/lib/swift).
   bool tripleRequiresRPathForSwiftInOS(const llvm::Triple &triple);

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -100,7 +100,7 @@ private:
   /// unexpected ones.
   Result verifyFile(unsigned BufferID);
 
-  bool checkForFixIt(const ExpectedFixIt &Expected,
+  bool checkForFixIt(const std::vector<ExpectedFixIt> &ExpectedAlts,
                      const CapturedDiagnosticInfo &D, StringRef buffer);
 
   // Render the verifier syntax for a given set of fix-its.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1092,6 +1092,11 @@ def disable_clang_target : Flag<["-"], "disable-clang-target">,
   Flags<[NewDriverOnlyOption]>,
   HelpText<"Disable a separately specified target triple for Clang instance to use">;
 
+def min_inlining_target_version : Separate<["-"], "target-min-inlining-version">,
+  Flags<[FrontendOption, ModuleInterfaceOptionIgnorable]>,
+  HelpText<"Require inlinable code with no '@available' attribute to back-deploy "
+           "to this version of the '-target' OS">;
+
 def profile_generate : Flag<["-"], "profile-generate">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Generate instrumented code to collect execution counts">;

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -30,6 +30,11 @@ AvailabilityContext AvailabilityContext::forDeploymentTarget(ASTContext &Ctx) {
       VersionRange::allGTE(Ctx.LangOpts.getMinPlatformVersion()));
 }
 
+AvailabilityContext AvailabilityContext::forInliningTarget(ASTContext &Ctx) {
+  return AvailabilityContext(
+      VersionRange::allGTE(Ctx.LangOpts.MinimumInliningTargetVersion));
+}
+
 namespace {
 
 /// The inferred availability required to access a group of declarations

--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -312,6 +312,10 @@ void TypeRefinementContext::print(raw_ostream &OS, SourceManager &SrcMgr,
     R.print(OS, SrcMgr, /*PrintText=*/false);
   }
 
+  if (!ExplicitAvailabilityInfo.isAlwaysAvailable())
+    OS << " explicit_versions="
+       << ExplicitAvailabilityInfo.getOSVersion().getAsString();
+
   for (TypeRefinementContext *Child : Children) {
     OS << '\n';
     Child->print(OS, SrcMgr, Indent + 2);

--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -65,6 +65,20 @@ TypeRefinementContext::createForDecl(ASTContext &Ctx, Decl *D,
 }
 
 TypeRefinementContext *
+TypeRefinementContext::createForResilienceBoundary(ASTContext &Ctx, Decl *D,
+                                TypeRefinementContext *Parent,
+                                const AvailabilityContext &Info,
+                                SourceRange SrcRange) {
+  assert(D);
+  assert(Parent);
+  return new (Ctx)
+      TypeRefinementContext(Ctx, IntroNode(D, Reason::ResilienceBoundary),
+                            Parent, SrcRange, Info,
+                            AvailabilityContext::alwaysAvailable());
+
+}
+
+TypeRefinementContext *
 TypeRefinementContext::createForIfStmtThen(ASTContext &Ctx, IfStmt *S,
                                            TypeRefinementContext *Parent,
                                            const AvailabilityContext &Info) {
@@ -170,6 +184,7 @@ void TypeRefinementContext::dump(raw_ostream &OS, SourceManager &SrcMgr) const {
 SourceLoc TypeRefinementContext::getIntroductionLoc() const {
   switch (getReason()) {
   case Reason::Decl:
+  case Reason::ResilienceBoundary:
     return Node.getAsDecl()->getLoc();
 
   case Reason::IfStmtThenBranch:
@@ -283,6 +298,7 @@ TypeRefinementContext::getAvailabilityConditionVersionSourceRange(
       Node.getAsWhileStmt()->getCond(), Platform, Version);
 
   case Reason::Root:
+  case Reason::ResilienceBoundary:
     return SourceRange();
   }
 
@@ -296,13 +312,16 @@ void TypeRefinementContext::print(raw_ostream &OS, SourceManager &SrcMgr,
 
   OS << " versions=" << AvailabilityInfo.getOSVersion().getAsString();
 
-  if (getReason() == Reason::Decl) {
+  if (getReason() == Reason::Decl
+      || getReason() == Reason::ResilienceBoundary) {
     Decl *D = Node.getAsDecl();
     OS << " decl=";
     if (auto VD = dyn_cast<ValueDecl>(D)) {
       OS << VD->getName();
     } else if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
       OS << "extension." << ED->getExtendedType().getString();
+    } else if (isa<TopLevelCodeDecl>(D)) {
+      OS << "<top-level-code>";
     }
   }
 
@@ -335,6 +354,9 @@ StringRef TypeRefinementContext::getReasonName(Reason R) {
 
   case Reason::Decl:
     return "decl";
+
+  case Reason::ResilienceBoundary:
+    return "resilience_boundary";
 
   case Reason::IfStmtThenBranch:
     return "if_then";

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -79,6 +79,20 @@ bool swift::triplesAreValidForZippering(const llvm::Triple &target,
   return false;
 }
 
+const Optional<llvm::VersionTuple>
+swift::minimumABIStableOSVersionForTriple(const llvm::Triple &triple) {
+  if (triple.isMacOSX())
+    return llvm::VersionTuple(10, 14, 4);
+
+  if (triple.isiOS() /* including tvOS */)
+    return llvm::VersionTuple(12, 2);
+
+  if (triple.isWatchOS())
+    return llvm::VersionTuple(5, 2);
+
+  return None;
+}
+
 bool swift::tripleRequiresRPathForSwiftInOS(const llvm::Triple &triple) {
   if (triple.isMacOSX()) {
     // macOS 10.14.4 contains a copy of Swift, but the linker will still use an
@@ -86,13 +100,10 @@ bool swift::tripleRequiresRPathForSwiftInOS(const llvm::Triple &triple) {
     return triple.isMacOSXVersionLT(10, 15);
   }
 
-  if (triple.isiOS()) {
-    return triple.isOSVersionLT(12, 2);
-  }
-
-  if (triple.isWatchOS()) {
-    return triple.isOSVersionLT(5, 2);
-  }
+  if (auto abiStability = minimumABIStableOSVersionForTriple(triple))
+    return triple.isOSVersionLT(abiStability->getMajor(),
+                                abiStability->getMinor().getValueOr(0),
+                                abiStability->getSubminor().getValueOr(0));
 
   // Other platforms don't have Swift installed as part of the OS by default.
   return false;

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -994,6 +994,9 @@ public:
                             bool isStatic,
                             ClangNode ClangN);
 
+  static std::pair<BraceStmt *, bool>
+  synthesizeConstantGetterBody(AbstractFunctionDecl *afd, void *voidContext);
+
   /// Determine whether the given declaration is considered
   /// 'unavailable' in Swift.
   bool isUnavailableInSwift(const clang::Decl *decl) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -743,29 +743,63 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Diags.diagnose(SourceLoc(), diag::error_unsupported_target_os, TargetArgOS);
   }
 
-  // Parse the SDK version.
-  if (Arg *A = Args.getLastArg(options::OPT_target_sdk_version)) {
-    auto vers = version::Version::parseVersionString(
-      A->getValue(), SourceLoc(), &Diags);
-    if (vers.hasValue()) {
-      Opts.SDKVersion = *vers;
-    } else {
-      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
-                     A->getAsString(Args), A->getValue());
-    }
-  }
+  // First, set up default minimum inlining target versions.
+  auto getDefaultMinimumInliningTargetVersion =
+      [&](const llvm::Triple &triple) -> llvm::VersionTuple {
+#if SWIFT_DEFAULT_TARGET_MIN_INLINING_VERSION_TO_ABI
+        // In ABI-stable modules, default to the version where the target's ABI
+        // was first frozen; older versions will use that one's backwards
+        // compatibility libraries.
+        if (FrontendOpts.EnableLibraryEvolution)
+          if (auto abiStability = minimumABIStableOSVersionForTriple(triple))
+            // FIXME: Should we raise it to the minimum supported OS version for
+            //        architectures which were born ABI-stable?
+            return *abiStability;
+#endif
 
-  // Parse the target variant SDK version.
-  if (Arg *A = Args.getLastArg(options::OPT_target_variant_sdk_version)) {
-    auto vers = version::Version::parseVersionString(
-      A->getValue(), SourceLoc(), &Diags);
-    if (vers.hasValue()) {
-      Opts.VariantSDKVersion = *vers;
-    } else {
-      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
-                     A->getAsString(Args), A->getValue());
-    }
-  }
+        // In ABI-unstable modules, we will never have to interoperate with
+        // older versions of the module, so we should default to the minimum
+        // deployment target.
+        unsigned major, minor, patch;
+        if (triple.isMacOSX())
+          triple.getMacOSXVersion(major, minor, patch);
+        else
+          triple.getOSVersion(major, minor, patch);
+        return llvm::VersionTuple(major, minor, patch);
+      };
+
+  Opts.MinimumInliningTargetVersion =
+      getDefaultMinimumInliningTargetVersion(Opts.Target);
+
+  // Parse OS version number arguments.
+  auto parseVersionArg = [&](OptSpecifier opt) -> Optional<llvm::VersionTuple> {
+    Arg *A = Args.getLastArg(opt);
+    if (!A)
+      return None;
+
+    if (StringRef(A->getValue()) == "target")
+      return Opts.getMinPlatformVersion();
+    if (StringRef(A->getValue()) == "abi")
+      return minimumABIStableOSVersionForTriple(Opts.Target);
+
+    if (auto vers = version::Version::parseVersionString(
+                        A->getValue(), SourceLoc(), &Diags))
+      return (llvm::VersionTuple)*vers;
+
+    Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                   A->getAsString(Args), A->getValue());
+    return None;
+  };
+
+  if (auto vers = parseVersionArg(OPT_min_inlining_target_version))
+    // FIXME: Should we diagnose if it's below the default?
+    Opts.MinimumInliningTargetVersion = *vers;
+
+  if (auto vers = parseVersionArg(OPT_target_sdk_version))
+    Opts.SDKVersion = *vers;
+
+  if (auto vers = parseVersionArg(OPT_target_variant_sdk_version))
+    Opts.VariantSDKVersion = *vers;
 
   if (const Arg *A = Args.getLastArg(OPT_entry_point_function_name)) {
     Opts.entryPointFunctionName = A->getValue();

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1627,6 +1627,13 @@ InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleName,
     .setMainAndSupplementaryOutputs(outputFiles, ModuleOutputPaths);
 
   SmallVector<const char *, 64> SubArgs;
+  
+  // If the interface was emitted by a compiler that didn't print
+  // `-target-min-inlining-version` into it, default to using the version from
+  // the target triple, emulating previous behavior.
+  SubArgs.push_back("-target-min-inlining-version");
+  SubArgs.push_back("target");
+
   std::string CompilerVersion;
   // Extract compiler arguments from the interface file and use them to configure
   // the compiler invocation.

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1036,7 +1036,8 @@ static bool printSwiftFeature(CompilerInstance &instance) {
 
 static bool
 withSemanticAnalysis(CompilerInstance &Instance, FrontendObserver *observer,
-                     llvm::function_ref<bool(CompilerInstance &)> cont) {
+                     llvm::function_ref<bool(CompilerInstance &)> cont,
+                     bool runDespiteErrors = false) {
   const auto &Invocation = Instance.getInvocation();
   const auto &opts = Invocation.getFrontendOptions();
   assert(!FrontendOptions::shouldActionOnlyParse(opts.RequestedAction) &&
@@ -1059,11 +1060,12 @@ withSemanticAnalysis(CompilerInstance &Instance, FrontendObserver *observer,
 
   (void)migrator::updateCodeAndEmitRemapIfNeeded(&Instance);
 
-  if (Instance.getASTContext().hadError() &&
-      !opts.AllowModuleWithCompilerErrors)
+  bool hadError = Instance.getASTContext().hadError()
+                      && !opts.AllowModuleWithCompilerErrors;
+  if (hadError && !runDespiteErrors)
     return true;
 
-  return cont(Instance);
+  return cont(Instance) || hadError;
 }
 
 static bool performScanDependencies(CompilerInstance &Instance) {
@@ -1125,14 +1127,11 @@ static bool performAction(CompilerInstance &Instance,
   // MARK: Actions that Dump
   case FrontendOptions::ActionType::DumpParse:
     return dumpAST(Instance);
-  case FrontendOptions::ActionType::DumpAST: {
-    // FIXME: -dump-ast expects to be able to write output even if type checking
-    // fails which does not cleanly fit the model \c withSemanticAnalysis is
-    // trying to impose. Once there is a request for the "semantic AST", this
-    // point is moot.
-    Instance.performSema();
-    return dumpAST(Instance);
-  }
+  case FrontendOptions::ActionType::DumpAST:
+    return withSemanticAnalysis(
+        Instance, observer, [](CompilerInstance &Instance) {
+          return dumpAST(Instance);
+        }, /*runDespiteErrors=*/true);
   case FrontendOptions::ActionType::PrintAST:
     return withSemanticAnalysis(
         Instance, observer, [](CompilerInstance &Instance) {
@@ -1145,14 +1144,14 @@ static bool performAction(CompilerInstance &Instance,
         Instance, observer, [](CompilerInstance &Instance) {
           return dumpAndPrintScopeMap(Instance,
                                       getPrimaryOrMainSourceFile(Instance));
-        });
+        }, /*runDespiteErrors=*/true);
   case FrontendOptions::ActionType::DumpTypeRefinementContexts:
     return withSemanticAnalysis(
         Instance, observer, [](CompilerInstance &Instance) {
           getPrimaryOrMainSourceFile(Instance).getTypeRefinementContext()->dump(
               llvm::errs(), Instance.getASTContext().SourceMgr);
           return Instance.getASTContext().hadError();
-        });
+        }, /*runDespiteErrors=*/true);
   case FrontendOptions::ActionType::DumpInterfaceHash:
     getPrimaryOrMainSourceFile(Instance).dumpInterfaceHash(llvm::errs());
     return Context.hadError();

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -569,12 +569,19 @@ private:
     if (auto afd = dyn_cast<AbstractFunctionDecl>(D))
       return bodyIsResilienceBoundary(afd);
 
-    return false;
+    // The only other case we care about is top-level code.
+    return isa<TopLevelCodeDecl>(D);
   }
 
   TypeRefinementContext *buildBodyRefinementContext(Decl *D) {
-    auto afd = cast<AbstractFunctionDecl>(D);
-    SourceRange range = afd->getBodySourceRange();
+    SourceRange range;
+    if (auto tlcd = dyn_cast<TopLevelCodeDecl>(D)) {
+      range = tlcd->getSourceRange();
+    } else if (auto afd = dyn_cast<AbstractFunctionDecl>(D)) {
+      range = afd->getBodySourceRange();
+    } else {
+      llvm_unreachable("unknown decl");
+    }
 
     AvailabilityContext DeploymentTargetInfo =
         AvailabilityContext::forDeploymentTarget(Context);

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -181,7 +181,7 @@ ExportContext ExportContext::forDeclSignature(Decl *D) {
   auto runningOSVersion =
       (Ctx.LangOpts.DisableAvailabilityChecking
        ? AvailabilityContext::alwaysAvailable()
-       : TypeChecker::overApproximateAvailabilityAtLocation(D->getEndLoc(), DC));
+       : TypeChecker::overApproximateAvailabilityAtLocation(D->getLoc(), DC));
   bool spi = Ctx.LangOpts.LibraryLevel == LibraryLevel::SPI;
   bool implicit = false;
   bool deprecated = false;
@@ -288,6 +288,27 @@ static bool hasActiveAvailableAttribute(Decl *D,
   return getActiveAvailableAttribute(D, AC);
 }
 
+static bool bodyIsResilienceBoundary(Decl *D) {
+  // The declaration contains code...
+  if (auto afd = dyn_cast<AbstractFunctionDecl>(D)) {
+    // And it has a location so we can check it...
+    if (!afd->isImplicit() && afd->getBodySourceRange().isValid()) {
+      // And the code is within our resilience domain, so it should be
+      // compiled with the minimum deployment target, not the minimum inlining
+      // target.
+      return afd->getResilienceExpansion() != ResilienceExpansion::Minimal;
+    }
+  }
+
+  return false;
+}
+
+static bool computeContainedByDeploymentTarget(TypeRefinementContext *TRC,
+                                               ASTContext &ctx) {
+  return TRC->getAvailabilityInfo()
+                  .isContainedIn(AvailabilityContext::forDeploymentTarget(ctx));
+}
+
 namespace {
 
 /// A class to walk the AST to build the type refinement context hierarchy.
@@ -302,6 +323,8 @@ class TypeRefinementContextBuilder : private ASTWalker {
     /// indicating that custom logic elsewhere will handle removing
     /// the context when needed.
     ParentTy ScopeNode;
+
+    bool ContainedByDeploymentTarget;
   };
 
   std::vector<ContextInfo> ContextStack;
@@ -318,10 +341,24 @@ class TypeRefinementContextBuilder : private ASTWalker {
     return ContextStack.back().TRC;
   }
 
+  bool isCurrentTRCContainedByDeploymentTarget() {
+    return ContextStack.back().ContainedByDeploymentTarget;
+  }
+
   void pushContext(TypeRefinementContext *TRC, ParentTy PopAfterNode) {
     ContextInfo Info;
     Info.TRC = TRC;
     Info.ScopeNode = PopAfterNode;
+
+    if (!ContextStack.empty() && isCurrentTRCContainedByDeploymentTarget()) {
+      assert(computeContainedByDeploymentTarget(TRC, Context) &&
+             "incorrectly skipping computeContainedByDeploymentTarget()");
+      Info.ContainedByDeploymentTarget = true;
+    } else {
+      Info.ContainedByDeploymentTarget =
+          computeContainedByDeploymentTarget(TRC, Context);
+    }
+
     ContextStack.push_back(Info);
   }
 
@@ -367,11 +404,16 @@ private:
       pushContext(DeclTRC, D);
     }
 
+    // Adds in a TRC that covers only the body of the declaration.
+    if (auto BodyTRC = getNewContextForBodyOfDecl(D)) {
+      pushContext(BodyTRC, D);
+    }
+
     return true;
   }
 
   bool walkToDeclPost(Decl *D) override {
-    // As seen above, we could have up to two TRCs in the stack for a single
+    // As seen above, we could have up to three TRCs in the stack for a single
     // declaration.
     while (ContextStack.back().ScopeNode.getAsDecl() == D) {
       ContextStack.pop_back();
@@ -508,6 +550,39 @@ private:
     }
     
     return D->getSourceRange();
+  }
+
+  TypeRefinementContext *getNewContextForBodyOfDecl(Decl *D) {
+    if (bodyIntroducesNewContext(D))
+      return buildBodyRefinementContext(D);
+
+    return nullptr;
+  }
+
+  bool bodyIntroducesNewContext(Decl *D) {
+    // Are we already effectively in a resilience boundary? If not, adding one
+    // wouldn't change availability.
+    if (isCurrentTRCContainedByDeploymentTarget())
+      return false;
+
+    // If we're in a function, is its body a resilience boundary?
+    if (auto afd = dyn_cast<AbstractFunctionDecl>(D))
+      return bodyIsResilienceBoundary(afd);
+
+    return false;
+  }
+
+  TypeRefinementContext *buildBodyRefinementContext(Decl *D) {
+    auto afd = cast<AbstractFunctionDecl>(D);
+    SourceRange range = afd->getBodySourceRange();
+
+    AvailabilityContext DeploymentTargetInfo =
+        AvailabilityContext::forDeploymentTarget(Context);
+    DeploymentTargetInfo.intersectWith(getCurrentTRC()->getAvailabilityInfo());
+
+    return TypeRefinementContext::createForResilienceBoundary(
+                                           Context, D, getCurrentTRC(),
+                                           DeploymentTargetInfo, range);
   }
 
   std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
@@ -927,8 +1002,8 @@ void TypeChecker::buildTypeRefinementContextHierarchy(SourceFile &SF) {
   if (!RootTRC) {
     // The root type refinement context reflects the fact that all parts of
     // the source file are guaranteed to be executing on at least the minimum
-    // platform version.
-    auto MinPlatformReq = AvailabilityContext::forDeploymentTarget(Context);
+    // platform version for inlining.
+    auto MinPlatformReq = AvailabilityContext::forInliningTarget(Context);
     RootTRC = TypeRefinementContext::createRoot(&SF, MinPlatformReq);
     SF.setTypeRefinementContext(RootTRC);
   }
@@ -973,9 +1048,8 @@ TypeChecker::overApproximateAvailabilityAtLocation(SourceLoc loc,
   // refined. For now, this is fine -- but if we ever synthesize #available(),
   // this will be a real problem.
 
-  // We can assume we are running on at least the minimum deployment target.
-  auto OverApproximateContext =
-    AvailabilityContext::forDeploymentTarget(Context);
+  // We can assume we are running on at least the minimum inlining target.
+  auto OverApproximateContext = AvailabilityContext::forInliningTarget(Context);
   auto isInvalidLoc = [SF](SourceLoc loc) {
     return SF ? loc.isInvalid() : true;
   };

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1640,14 +1640,16 @@ static bool fixAvailabilityByNarrowingNearbyVersionCheck(
     ASTContext &Context,
     InFlightDiagnostic &Err) {
   const TypeRefinementContext *TRC = nullptr;
-  AvailabilityContext RunningOSOverApprox =
-    TypeChecker::overApproximateAvailabilityAtLocation(ReferenceRange.Start,
-                                                       ReferenceDC, &TRC);
-  VersionRange RunningRange = RunningOSOverApprox.getOSVersion();
+  (void)TypeChecker::overApproximateAvailabilityAtLocation(ReferenceRange.Start,
+                                                           ReferenceDC, &TRC);
+  if (!TRC)
+    return false;
+  VersionRange RunningRange = TRC->getExplicitAvailabilityInfo().getOSVersion();
   if (RunningRange.hasLowerEndpoint() &&
       RequiredRange.hasLowerEndpoint() &&
-      AvailabilityContext(RequiredRange).isContainedIn(RunningOSOverApprox) &&
-      TRC && TRC->getReason() != TypeRefinementContext::Reason::Root) {
+      TRC->getReason() != TypeRefinementContext::Reason::Root &&
+      AvailabilityContext(RequiredRange).isContainedIn(
+                                 AvailabilityContext(RunningRange))) {
 
     // Only fix situations that are "nearby" versions, meaning
     // disagreement on a minor-or-less version for non-macOS,

--- a/test/Frontend/verify.swift
+++ b/test/Frontend/verify.swift
@@ -11,6 +11,21 @@ undefinedFunc()
 // CHECK: [[@LINE+1]]:20: error: expected {{{{}} in {{expected}}-{{warning}}
 // expected-warning
 
+func fn() {}
+fn(())    // expected-error {{argument passed to call that takes no arguments}}
+fn(())    // expected-error {{argument passed to call that takes no arguments}} {{4-6=}}
+fn(())    // expected-error {{argument passed to call that takes no arguments}} {{4-6=}}||{{3-4=fnord}}
+fn(())    // expected-error {{argument passed to call that takes no arguments}} {{3-4=fnord}} || {{4-6=}}
+fn(())    // expected-error {{argument passed to call that takes no arguments}} {{4-6=}} {{none}}
+fn(())    // expected-error {{argument passed to call that takes no arguments}} {{4-6=}}||{{3-4=fnord}} {{none}}
+fn(())    // expected-error {{argument passed to call that takes no arguments}} {{3-4=fnord}}||{{4-6=}} {{none}}
+
+// CHECK: [[@LINE+1]]:81: error: expected fix-it not seen; actual fix-it seen: {{[{][{]4-6=[}][}]}}
+fn(())    // expected-error {{argument passed to call that takes no arguments}} {{3-4=fnord}} {{4-6=}}
+
+// CHECK: [[@LINE+1]]:81: error: expected no fix-its; actual fix-it seen: {{[{][{]4-6=[}][}]}}
+fn(())    // expected-error {{argument passed to call that takes no arguments}} {{none}}
+
 // CHECK: [[@LINE+2]]:8: error: unexpected error produced: generic type 'Array' specialized with too many type parameters
 // CHECK: note: diagnostic produced elsewhere: generic type 'Array' declared here
 let x: Array<Int, Int>

--- a/test/ModuleInterface/option-preservation.swift
+++ b/test/ModuleInterface/option-preservation.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -enable-library-evolution -emit-module-interface-path %t.swiftinterface -module-name t %s -emit-module -o /dev/null -Onone -enforce-exclusivity=unchecked -autolink-force-load
+// RUN: %target-swift-frontend -enable-library-evolution -emit-module-interface-path %t.swiftinterface -module-name t %s -target-min-inlining-version 42 -emit-module -o /dev/null -Onone -enforce-exclusivity=unchecked -autolink-force-load
 // RUN: %FileCheck %s < %t.swiftinterface -check-prefix=CHECK-SWIFTINTERFACE
 //
 // CHECK-SWIFTINTERFACE: swift-module-flags:
@@ -8,6 +8,8 @@
 // CHECK-SWIFTINTERFACE-SAME: -Onone
 // CHECK-SWIFTINTERFACE-SAME: -enforce-exclusivity=unchecked
 // CHECK-SWIFTINTERFACE-SAME: -autolink-force-load
+// CHECK-SWIFTINTERFACE: swift-module-flags-ignorable:
+// CHECK-SWIFTINTERFACE-SAME: -target-min-inlining-version 42
 
 // Make sure flags show up when filelists are enabled
 

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -1,0 +1,467 @@
+// A module with library evolution enabled has two different "minimum versions".
+// One, the minimum deployment target, is the lowest version that non-ABI
+// declarations and bodies of non-inlinable functions will ever see. The other,
+// the minimum inlining target, is the lowest version that ABI declarations and
+// inlinable bodies will ever see.
+//
+// Test that we use the right version floor in the right places.
+//
+// To keep this test multi-platform, we only check fragments of diagnostics that
+// don't include platform names or versions.
+
+// REQUIRES: swift_stable_abi
+
+
+// Primary execution of this test. Uses the default minimum inlining version,
+// which is the version when the ABI became stable.
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -target %target-next-stable-abi-triple -target-min-inlining-version abi
+
+
+// Check that these rules are only applied when requested and that at least some
+// diagnostics are not present without it.
+// RUN: not %target-typecheck-verify-swift -swift-version 5 -target %target-next-stable-abi-triple 2>&1 | %FileCheck --check-prefix NON_ABI %s
+// NON_ABI: error: expected error not produced
+// NON_ABI: {'BetweenTargets' is only available in}
+
+
+// Check that we respect -target-min-inlining-version by cranking it up high
+// enough to suppress any possible errors.
+// RUN: %target-swift-frontend -typecheck -disable-objc-attr-requires-foundation-module %s -swift-version 5 -enable-library-evolution -target %target-next-stable-abi-triple -target-min-inlining-version 42.0
+
+/// Declaration with no availability annotation. Should be inferred as minimum
+/// inlining target.
+public struct NoAvailable {
+  @usableFromInline internal init() {}
+}
+
+@available(macOS 10.14.3, iOS 12.1, tvOS 12.1, watchOS 5.1, *)
+public struct BeforeInliningTarget {
+  @usableFromInline internal init() {}
+}
+
+@available(macOS 10.14.4, iOS 12.2, tvOS 12.2, watchOS 5.2, *)
+public struct AtInliningTarget {
+  @usableFromInline internal init() {}
+}
+
+@available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *)
+public struct BetweenTargets {
+  @usableFromInline internal init() {}
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public struct AtDeploymentTarget {
+  @usableFromInline internal init() {}
+}
+
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
+public struct AfterDeploymentTarget {
+  @usableFromInline internal init() {}
+}
+
+
+
+//
+// Uses in resilient functions are based on the minimum deployment target
+// (i.e. the -target).
+//
+
+public func deployedUseNoAvailable( // expected-note 5 {{add @available attribute}}
+  _: NoAvailable,
+  _: BeforeInliningTarget,
+  _: AtInliningTarget,
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+) {
+  defer {
+    _ = AtDeploymentTarget()
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  }
+  _ = NoAvailable()
+  _ = BeforeInliningTarget()
+  _ = AtInliningTarget()
+  _ = BetweenTargets()
+  _ = AtDeploymentTarget()
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+
+  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+    _ = AfterDeploymentTarget()
+  }
+}
+
+@available(macOS 10.14.3, iOS 12.1, tvOS 12.1, watchOS 5.1, *)
+public func deployedUseBeforeInliningTarget(
+  _: NoAvailable,
+  _: BeforeInliningTarget,
+  _: AtInliningTarget,
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+) {
+  defer {
+    _ = AtDeploymentTarget()
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  }
+  _ = NoAvailable()
+  _ = BeforeInliningTarget()
+  _ = AtInliningTarget()
+  _ = BetweenTargets()
+  _ = AtDeploymentTarget()
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+
+  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+    _ = AfterDeploymentTarget()
+  }
+}
+
+@available(macOS 10.14.4, iOS 12.2, tvOS 12.2, watchOS 5.2, *)
+public func deployedUseAtInliningTarget(
+  _: NoAvailable,
+  _: BeforeInliningTarget,
+  _: AtInliningTarget,
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+) {
+  defer {
+    _ = AtDeploymentTarget()
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  }
+  _ = NoAvailable()
+  _ = BeforeInliningTarget()
+  _ = AtInliningTarget()
+  _ = BetweenTargets()
+  _ = AtDeploymentTarget()
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+
+  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+    _ = AfterDeploymentTarget()
+  }
+}
+
+@available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *)
+public func deployedUseBetweenTargets(
+  _: NoAvailable,
+  _: BeforeInliningTarget,
+  _: AtInliningTarget,
+  _: BetweenTargets,
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+) {
+  defer {
+    _ = AtDeploymentTarget()
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  }
+  _ = NoAvailable()
+  _ = BeforeInliningTarget()
+  _ = AtInliningTarget()
+  _ = BetweenTargets()
+  _ = AtDeploymentTarget()
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+
+  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+    _ = AfterDeploymentTarget()
+  }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public func deployedUseAtDeploymentTarget(
+  _: NoAvailable,
+  _: BeforeInliningTarget,
+  _: AtInliningTarget,
+  _: BetweenTargets,
+  _: AtDeploymentTarget,
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+) {
+  defer {
+    _ = AtDeploymentTarget()
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  }
+  _ = NoAvailable()
+  _ = BeforeInliningTarget()
+  _ = AtInliningTarget()
+  _ = BetweenTargets()
+  _ = AtDeploymentTarget()
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+
+  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+    _ = AfterDeploymentTarget()
+  }
+}
+
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
+public func deployedUseAfterDeploymentTarget(
+  _: NoAvailable,
+  _: BeforeInliningTarget,
+  _: AtInliningTarget,
+  _: BetweenTargets,
+  _: AtDeploymentTarget,
+  _: AfterDeploymentTarget
+) {
+  defer {
+    _ = AtDeploymentTarget()
+    _ = AfterDeploymentTarget()
+  }
+  _ = NoAvailable()
+  _ = BeforeInliningTarget()
+  _ = AtInliningTarget()
+  _ = BetweenTargets()
+  _ = AtDeploymentTarget()
+  _ = AfterDeploymentTarget()
+}
+
+
+
+//
+// Uses in inlinable functions are based on the minimum inlining target
+// (i.e. the first ABI-stable version, in this case)
+//
+
+@inlinable public func inlinedUseNoAvailable( // expected-note 8 {{add @available attribute}}
+  _: NoAvailable,
+  _: BeforeInliningTarget,
+  _: AtInliningTarget,
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+) {
+  defer {
+    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  }
+  _ = NoAvailable()
+  _ = BeforeInliningTarget()
+  _ = AtInliningTarget()
+  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in}} expected-note {{add 'if #available'}}
+  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+
+  if #available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *) {
+    _ = BetweenTargets()
+  }
+  if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+    _ = AtDeploymentTarget()
+  }
+  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+    _ = AfterDeploymentTarget()
+  }
+}
+
+@available(macOS 10.14.3, iOS 12.1, tvOS 12.1, watchOS 5.1, *)
+@inlinable public func inlinedUseBeforeInliningTarget(
+  _: NoAvailable,
+  _: BeforeInliningTarget,
+  _: AtInliningTarget,
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+) {
+  defer {
+    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  }
+  _ = NoAvailable()
+  _ = BeforeInliningTarget()
+  _ = AtInliningTarget()
+  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in}} FIXME: should have {{18-25=10.14.5}} || {{31-35=12.3}} || {{42-46=12.3}} || {{56-59=149}}; instead, expected-note {{add 'if #available'}}
+  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+
+  if #available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *) {
+    _ = BetweenTargets()
+  }
+  if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+    _ = AtDeploymentTarget()
+  }
+  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+    _ = AfterDeploymentTarget()
+  }
+}
+
+@available(macOS 10.14.4, iOS 12.2, tvOS 12.2, watchOS 5.2, *)
+@inlinable public func inlinedUseAtInliningTarget(
+  _: NoAvailable,
+  _: BeforeInliningTarget,
+  _: AtInliningTarget,
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+) {
+  defer {
+    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  }
+  _ = NoAvailable()
+  _ = BeforeInliningTarget()
+  _ = AtInliningTarget()
+  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in}} {{18-25=10.14.5}} || {{31-35=12.3}} || {{42-46=12.3}} || {{56-59=149}}
+  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+
+  if #available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *) {
+    _ = BetweenTargets()
+  }
+  if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+    _ = AtDeploymentTarget()
+  }
+  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+    _ = AfterDeploymentTarget()
+  }
+}
+
+@available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *)
+@inlinable public func inlinedUseBetweenTargets(
+  _: NoAvailable,
+  _: BeforeInliningTarget,
+  _: AtInliningTarget,
+  _: BetweenTargets,
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+) {
+  defer {
+    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  }
+  _ = NoAvailable()
+  _ = BeforeInliningTarget()
+  _ = AtInliningTarget()
+  _ = BetweenTargets()
+  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+
+  if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+    _ = AtDeploymentTarget()
+  }
+  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+    _ = AfterDeploymentTarget()
+  }
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@inlinable public func inlinedUseAtDeploymentTarget(
+  _: NoAvailable,
+  _: BeforeInliningTarget,
+  _: AtInliningTarget,
+  _: BetweenTargets,
+  _: AtDeploymentTarget,
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+) {
+  defer {
+    _ = AtDeploymentTarget()
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  }
+  _ = NoAvailable()
+  _ = BeforeInliningTarget()
+  _ = AtInliningTarget()
+  _ = BetweenTargets()
+  _ = AtDeploymentTarget()
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+
+  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+    _ = AfterDeploymentTarget()
+  }
+}
+
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
+@inlinable public func inlinedUseAfterDeploymentTarget(
+  _: NoAvailable,
+  _: BeforeInliningTarget,
+  _: AtInliningTarget,
+  _: BetweenTargets,
+  _: AtDeploymentTarget,
+  _: AfterDeploymentTarget
+) {
+  defer {
+    _ = AtDeploymentTarget()
+    _ = AfterDeploymentTarget()
+  }
+  _ = NoAvailable()
+  _ = BeforeInliningTarget()
+  _ = AtInliningTarget()
+  _ = BetweenTargets()
+  _ = AtDeploymentTarget()
+  _ = AfterDeploymentTarget()
+}
+
+//
+// Edge cases.
+//
+
+// Internal functions should use the minimum deployment target.
+
+internal func fn() {
+  _ = AtDeploymentTarget()
+}
+
+// @_alwaysEmitIntoClient acts like @inlinable.
+
+@_alwaysEmitIntoClient public func aEICUseNoAvailable( // expected-note 8 {{add @available attribute}}
+  _: NoAvailable,
+  _: BeforeInliningTarget,
+  _: AtInliningTarget,
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+) {
+  defer {
+    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  }
+  _ = NoAvailable()
+  _ = BeforeInliningTarget()
+  _ = AtInliningTarget()
+  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in}} expected-note {{add 'if #available'}}
+  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+
+  if #available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *) {
+    _ = BetweenTargets()
+  }
+  if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+    _ = AtDeploymentTarget()
+  }
+  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+    _ = AfterDeploymentTarget()
+  }
+}
+
+// Default arguments act like @inlinable.
+
+public func defaultArgsUseNoAvailable( // expected-note 3 {{add @available attribute}}
+  _: Any = NoAvailable.self,
+  _: Any = BeforeInliningTarget.self,
+  _: Any = AtInliningTarget.self,
+  _: Any = BetweenTargets.self, // expected-error {{'BetweenTargets' is only available in}}
+  _: Any = AtDeploymentTarget.self, // expected-error {{'AtDeploymentTarget' is only available in}}
+  _: Any = AfterDeploymentTarget.self // expected-error {{'AfterDeploymentTarget' is only available in}}
+) {}
+
+public struct PublicStruct { // expected-note 6 {{add @available attribute}}
+  // Public declarations act like @inlinable.
+  public var aPublic: NoAvailable
+  public var bPublic: BeforeInliningTarget
+  public var cPublic: AtInliningTarget
+  public var dPublic: BetweenTargets // expected-error {{'BetweenTargets' is only available in}}
+  public var ePublic: AtDeploymentTarget // expected-error {{'AtDeploymentTarget' is only available in}}
+  public var fPublic: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+
+  // Internal declarations act like non-inlinable.
+  var aInternal: NoAvailable
+  var bInternal: BeforeInliningTarget
+  var cInternal: AtInliningTarget
+  var dInternal: BetweenTargets // FIXME: expected-error {{'BetweenTargets' is only available in}}
+  var eInternal: AtDeploymentTarget // FIXME: expected-error {{'AtDeploymentTarget' is only available in}}
+  var fInternal: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+}
+
+internal struct InternalStruct { // expected-note 3 {{add @available attribute}}
+  // Internal declarations act like non-inlinable.
+  var aInternal: NoAvailable
+  var bInternal: BeforeInliningTarget
+  var cInternal: AtInliningTarget
+  var dInternal: BetweenTargets // FIXME: expected-error {{'BetweenTargets' is only available in}}
+  var eInternal: AtDeploymentTarget // FIXME: expected-error {{'AtDeploymentTarget' is only available in}}
+  var fInternal: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+}
+

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -295,7 +295,7 @@ public func deployedUseAfterDeploymentTarget(
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
-  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in}} {{18-25=10.14.5}} || {{31-35=12.3}} || {{42-46=12.3}} || {{56-59=149}}
+  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in}} FIXME: should have {{18-25=10.14.5}} || {{31-35=12.3}} || {{42-46=12.3}} || {{56-59=149}}
   _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
   _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
 
@@ -437,7 +437,7 @@ public func defaultArgsUseNoAvailable( // expected-note 3 {{add @available attri
   _: Any = AfterDeploymentTarget.self // expected-error {{'AfterDeploymentTarget' is only available in}}
 ) {}
 
-public struct PublicStruct { // expected-note 6 {{add @available attribute}}
+public struct PublicStruct { // expected-note 7 {{add @available attribute}}
   // Public declarations act like @inlinable.
   public var aPublic: NoAvailable
   public var bPublic: BeforeInliningTarget
@@ -450,18 +450,59 @@ public struct PublicStruct { // expected-note 6 {{add @available attribute}}
   var aInternal: NoAvailable
   var bInternal: BeforeInliningTarget
   var cInternal: AtInliningTarget
-  var dInternal: BetweenTargets // FIXME: expected-error {{'BetweenTargets' is only available in}}
-  var eInternal: AtDeploymentTarget // FIXME: expected-error {{'AtDeploymentTarget' is only available in}}
+  var dInternal: BetweenTargets
+  var eInternal: AtDeploymentTarget
+  var fInternal: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+
+  @available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *)
+  public internal(set) var internalSetter: Void {
+    @inlinable get {
+      // Public inlinable getter acts like @inlinable
+      _ = NoAvailable()
+      _ = BeforeInliningTarget()
+      _ = AtInliningTarget()
+      _ = BetweenTargets()
+      _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+      _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+
+    }
+    set {
+      // Private setter acts like non-inlinable
+      _ = NoAvailable()
+      _ = BeforeInliningTarget()
+      _ = AtInliningTarget()
+      _ = BetweenTargets()
+      _ = AtDeploymentTarget()
+      _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    }
+  }
+}
+
+@frozen public struct FrozenPublicStruct { // expected-note 6 {{add @available attribute}}
+  // Public declarations act like @inlinable.
+  public var aPublic: NoAvailable
+  public var bPublic: BeforeInliningTarget
+  public var cPublic: AtInliningTarget
+  public var dPublic: BetweenTargets // expected-error {{'BetweenTargets' is only available in}}
+  public var ePublic: AtDeploymentTarget // expected-error {{'AtDeploymentTarget' is only available in}}
+  public var fPublic: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+
+  // Internal declarations act like @inlinable in a frozen struct.
+  var aInternal: NoAvailable
+  var bInternal: BeforeInliningTarget
+  var cInternal: AtInliningTarget
+  var dInternal: BetweenTargets // expected-error {{'BetweenTargets' is only available in}}
+  var eInternal: AtDeploymentTarget // expected-error {{'AtDeploymentTarget' is only available in}}
   var fInternal: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
 }
 
-internal struct InternalStruct { // expected-note 3 {{add @available attribute}}
+internal struct InternalStruct { // expected-note {{add @available attribute}}
   // Internal declarations act like non-inlinable.
   var aInternal: NoAvailable
   var bInternal: BeforeInliningTarget
   var cInternal: AtInliningTarget
-  var dInternal: BetweenTargets // FIXME: expected-error {{'BetweenTargets' is only available in}}
-  var eInternal: AtDeploymentTarget // FIXME: expected-error {{'AtDeploymentTarget' is only available in}}
+  var dInternal: BetweenTargets
+  var eInternal: AtDeploymentTarget
   var fInternal: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
 }
 

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -264,7 +264,7 @@ public func deployedUseAfterDeploymentTarget(
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
-  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in}} FIXME: should have {{18-25=10.14.5}} || {{31-35=12.3}} || {{42-46=12.3}} || {{56-59=149}}; instead, expected-note {{add 'if #available'}}
+  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in}} {{18-25=10.14.5}} || {{31-35=12.3}} || {{42-46=12.3}} || {{56-59=149}}
   _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
   _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
 
@@ -295,7 +295,7 @@ public func deployedUseAfterDeploymentTarget(
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
-  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in}} FIXME: should have {{18-25=10.14.5}} || {{31-35=12.3}} || {{42-46=12.3}} || {{56-59=149}}
+  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in}} {{18-25=10.14.5}} || {{31-35=12.3}} || {{42-46=12.3}} || {{56-59=149}}
   _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
   _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
 

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -465,3 +465,20 @@ internal struct InternalStruct { // expected-note 3 {{add @available attribute}}
   var fInternal: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
 }
 
+// Top-level code, if somehow present in a resilient module, is treated like
+// a non-inlinable function.
+defer {
+  _ = AtDeploymentTarget()
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+}
+_ = NoAvailable()
+_ = BeforeInliningTarget()
+_ = AtInliningTarget()
+_ = BetweenTargets()
+_ = AtDeploymentTarget()
+_ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+
+if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+  _ = AfterDeploymentTarget()
+}
+


### PR DESCRIPTION
Currently, the compiler assumes that *all* code in a module will only run when the minimum deployment target is satisfied. However, in modules using library evolution, this is only true for code that stays entirely inside the module's resilience domain. Anything that goes into the module interface, such as ABI-visible declarations and inlinable code, could affect the code generated in a module with a lower minimum deployment target, and could end up interoperating with older versions of the library built when it had a lower minimum deployment target.

This would be fine if the minimum deployment target never changed, but it's common practice to raise minimum deployment targets to reflect the minimum OS requirement of the *current* implementation, even if older versions of the module supported older OSes. The minimum deployment target essentially acts as a floor during availability checking, so all of the detail about old OS versions gets squashed away and ignored, even when checking code that will be inlined into other modules that can execute on those OSes. The result is that we do not reason correctly about which APIs will be available in the bodies of functions using features like `@inlinable` or `@_alwaysEmitIntoClient`. Uses that should be diagnosed as errors are instead allowed, causing us to compile code that won't work correctly when back-deployed.

This PR begins to address this by allowing you to base availability checking on a second, lower OS version number, except in parts of the code that are not externally visible. The idea is that, unlike the minimum deployment target, you would set this OS version when you first published the module and never raise it. At this point, the default behavior has not changed, but it probably ought to somewhere down the line.