### PR TITLE
[Diagnostics] Improve diagnostics on invalid open extensions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1499,7 +1499,7 @@ ERROR(access_control_extension_more,none,
       "be declared %select{%error|fileprivate|internal|public|%error}2",
       (AccessLevel, DescriptiveDeclKind, AccessLevel))
 ERROR(access_control_extension_open,none,
-      "extensions cannot use 'open' as their default access; use 'public'",
+      "extensions cannot be declared 'open'; declare individual members as 'open' instead",
       ())
 ERROR(access_control_open_bad_decl,none,
       "only classes and overridable class members can be declared 'open';"

--- a/test/attr/open.swift
+++ b/test/attr/open.swift
@@ -134,3 +134,12 @@ open class OpenSubClass : OpenSuperClass {
   open override subscript(index: MarkerForNonOpenSubscripts) -> Int { return 0 }
   
 }
+
+class InvalidOpenExtensionClass { }
+
+open extension InvalidOpenExtensionClass {  // expected-error {{extensions cannot be declared 'open'; declare individual members as 'open' instead}} {{1-6=}} {{3-3=public }} {{3-3=public }}
+  func C() { } // Insert public
+  private func A() { } // OK
+  var F: Int { 3 } // Insert public
+  private var G: Int { 3 } // Okay
+}

--- a/test/attr/open_objc.swift
+++ b/test/attr/open_objc.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -I %t
+// REQUIRES: objc_interop
+
+import Foundation
+
+class InvalidOpenExtensionClass { }
+
+open extension InvalidOpenExtensionClass {  // expected-error {{extensions cannot be declared 'open'; declare individual members as 'open' instead}} {{1-6=}} {{3-3=public }} {{9-9=open }} {{9-9=open }} {{3-3=public }}
+  private func A() { } // OK
+  @objc func B() { } // Insert open 
+  func C() { } // Insert public
+  @objc private var D: Int { 3 } // Okay
+  @objc var E: Int { 3 } // Insert open
+  var F: Int { 3 } // Insert public
+  private var G: Int { 3 } // Okay
+}
+
+@objc
+@objcMembers
+class InvalidOpenExtensionObjcClass: NSObject { }
+
+open extension InvalidOpenExtensionObjcClass {  // expected-error {{extensions cannot be declared 'open'; declare individual members as 'open' instead}} {{1-6=}} {{3-3=open }} {{9-9=open }} {{9-9=open }} {{3-3=open }}
+  private func A() { } // OK
+  @objc func B() { } // Insert open 
+  func C() { } // Insert open
+  @objc private var D: Int { 3 } // Okay
+  @objc var E: Int { 3 } // Insert open
+  var F: Int { 3 } // Insert open
+  private var G: Int { 3 } // Okay
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Using 'open' as default access for an extension results in the following error: 
```
open extension AClass { // Extensions cannot use 'open' as their default access; use 'public'
// Replace 'open' with 'public'
    @objc func functionA()
``` 

Applying the autocorrect and making the function as open instead, the code is changed to this and warning is emitted:
```
public extension AClass {
    @objc open func functionA() // 'open' modifier conflicts with extension's default access of 'public'
```
where the warning holds no purpose because the 'open' modifier still works. (It seems like this is the case for other types of this conflict, i.e. public function in a private extension, and the function is still publicly visible. Similar thing can be observed in classes, i.e. a private class with a public variable, and no warning is shown there)

To remove the warning, you have to now remove the 'public' modifier like this: 

```
extension PublicClass {
    @objc open func functionC()
 ```

I think we can improve these diagnostics to something like this to make this more convenient:
```
open extension AClass { // Extensions cannot use 'open' as their default access; remove the default access and mark methods as 'open' instead // remove 'open'
    @objc func functionA() // add 'open' ← maybe?
```
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-15071](https://bugs.swift.org/browse/SR-15071)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
