### PR TITLE
git: ensure that dosbatch files use CRLF for line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.swift.gyb linguist-language=Swift
 *.cpp.gyb linguist-language=C++
+*.bat text eol=crlf


### PR DESCRIPTION
This ensures that we do not accidentally convert line-endings in Windows
batch files.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
