### PR TITLE
[Tests] Mark TypeRoundTrip as unsupported on use_os_stdlib.

### DIFF
--- a/test/TypeRoundTrip/round-trip.swift
+++ b/test/TypeRoundTrip/round-trip.swift
@@ -12,6 +12,8 @@
 
 // REQUIRES: executable_test
 // REQUIRES: shell
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 
 // CHECK-NOT: FAIL
 


### PR DESCRIPTION
When `use_os_stdlib` is set, we use the system Swift libraries, rather than the ones we've just built.  Older Swift libraries don't have some of the required functions to run this test, and since the test is supposed to be testing the library rather than the compiler, it makes sense to just mark it as unsupported in that configuration.

rdar://82171600
