### PR TITLE
[test] Disable a couple of AutoDiff tests

### DIFF
--- a/test/AutoDiff/compiler_crashers_fixed/sr14240-symbol-in-ir-file-not-tbd-file.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr14240-symbol-in-ir-file-not-tbd-file.swift
@@ -1,5 +1,9 @@
 // RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 
+// rdar://82240971 – Temporarily disable this test on non-macOS platforms until
+// the CI is fixed to not produce 'Invalid device: iPhone 8'.
+// REQUIRES: OS=macosx
+
 // REQUIRES: executable_test
 
 // SR-14240: Error: symbol 'powTJfSSpSr' (powTJfSSpSr) is in generated IR file,

--- a/test/AutoDiff/stdlib/differentiable_stdlib_conformances.swift
+++ b/test/AutoDiff/stdlib/differentiable_stdlib_conformances.swift
@@ -1,6 +1,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// rdar://82240971 – Temporarily disable this test on non-macOS platforms until
+// the CI is fixed to not produce 'Invalid device: iPhone 8'.
+// REQUIRES: OS=macosx
+
 import _Differentiation
 
 // Test `Differentiable` protocol conformances for stdlib types.


### PR DESCRIPTION
Temporarily disable on non-macOS platforms until the CI is fixed.

rdar://82240971