### PR TITLE
Only run executable tests (--only-executable-test) with standalone stdlib builds

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2342,6 +2342,7 @@ native-clang-tools-path=%(toolchain_path)s
 
 build-ninja
 lit-args=--filter=stdlib/
+only-executable-test
 
 [preset: stdlib_RD_standalone,build]
 mixin-preset=stdlib_base_standalone


### PR DESCRIPTION
Since we're not building the compiler in this mode.