### PR TITLE
[Sema][SILGen] refactor the implementation of `try?`

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2020,32 +2020,9 @@ public:
     void verifyChecked(AnyTryExpr *E) {
       PrettyStackTraceExpr debugStack(Ctx, "verifying AnyTryExpr", E);
 
-      if (!isa<OptionalTryExpr>(E)) {
-        checkSameType(E->getType(), E->getSubExpr()->getType(),
-                      "AnyTryExpr and sub-expression");
-      }
+      checkSameType(E->getType(), E->getSubExpr()->getType(),
+                    "AnyTryExpr and sub-expression");
 
-      verifyCheckedBase(E);
-    }
-
-    void verifyChecked(OptionalTryExpr *E) {
-      PrettyStackTraceExpr debugStack(Ctx, "verifying OptionalTryExpr", E);
-
-      if (Ctx.LangOpts.isSwiftVersionAtLeast(5)) {
-        checkSameType(E->getType(), E->getSubExpr()->getType(),
-                      "OptionalTryExpr and sub-expression");
-      }
-      else {
-        Type unwrappedType = E->getType()->getOptionalObjectType();
-        if (!unwrappedType) {
-          Out << "OptionalTryExpr result type is not optional\n";
-          abort();
-        }
-        
-        checkSameType(unwrappedType, E->getSubExpr()->getType(),
-                      "OptionalTryExpr and sub-expression");
-      }
-      
       verifyCheckedBase(E);
     }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1130,7 +1130,7 @@ RValue RValueEmitter::visitOptionalTryExpr(OptionalTryExpr *E, SGFContext C) {
   // FIXME: Much of this was copied from visitOptionalEvaluationExpr.
 
   // Prior to Swift 5, an optional try's subexpression is always wrapped in an additional optional
-  bool shouldWrapInOptional = !(SGF.getASTContext().LangOpts.isSwiftVersionAtLeast(5));
+  bool shouldWrapInOptional = false; // TODO: delete code relying on this, etc.
   
   auto &optTL = SGF.getTypeLowering(E->getType());
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3438,11 +3438,6 @@ namespace {
       //
       // The result is that in Swift 5, 'try?' avoids producing nested optionals.
       
-      if (!cs.getASTContext().LangOpts.isSwiftVersionAtLeast(5)) {
-        // Nothing to do for Swift 4 and earlier!
-        return simplifyExprType(expr);
-      }
-      
       Type exprType = simplifyType(cs.getType(expr));
 
       auto subExpr = coerceToType(expr->getSubExpr(), exprType,

--- a/test/Runtime/optional_try.swift
+++ b/test/Runtime/optional_try.swift
@@ -1,0 +1,61 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+
+enum Bad: Error {
+    case err
+    case custom(String)
+}
+
+func erase<T>(_ val: T) -> Any {
+    return val as Any
+}
+
+class Klass {}
+
+typealias MaybeString = Result<String, Error>
+typealias MaybeKlass = Result<Klass, Error>
+typealias MaybeInt = Result<Int, Error>
+typealias MaybeNumbers = Result<[Int], Error>
+
+////////
+// NOTE: Do _not_ heed the warnings about implicit coercions to Any.
+//       That's an important part of this test's coverage!
+////////
+
+// -- throwing --
+
+// CHECK: nil
+print( try? MaybeString.failure(Bad.err).get() )
+
+// CHECK: nil
+print( try? MaybeKlass.failure(Bad.custom("doggo")).get() )
+
+// CHECK: nil
+print( try? MaybeInt.failure(Bad.err).get() )
+
+// CHECK: nil
+print( try? MaybeNumbers.failure(Bad.err).get() )
+
+// CHECK: nil
+print(erase( try? MaybeNumbers.failure(Bad.err).get() ))
+
+// -- normal --
+
+// CHECK: Optional("catto")
+print( try? MaybeString.success("catto").get() )
+
+// CHECK: Optional(main.Klass)
+print( try? MaybeKlass.success(Klass()).get() )
+
+// CHECK: Optional(3)
+print( try? MaybeInt.success(3).get() )
+
+// CHECK: Optional([4, 8, 15, 16, 23, 42])
+print( try? MaybeNumbers.success([4, 8, 15, 16, 23, 42]).get() )
+
+// CHECK: Optional([0, 1, 1, 2, 3])
+print(erase( try? MaybeNumbers.success([0, 1, 1, 2, 3]).get() ))
+
+
+
+


### PR DESCRIPTION
The SILGen for some optional try expressions, i.e., `try?` trips an assertion that indicates the implementation is not following the standards that SILGen expects. But, the generated code happens to be correct. Here's a simple reproducer that will trip the assertions:

```swift
let _: Any = try? {() throws in 3 }()
```

This PR refactors and simplifies SILGen and Sema treatment of `try?` to eliminate this problem.

Fixes rdar://80277465