### PR TITLE
Sema: Fix generics invariant violations in override checking

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2708,10 +2708,6 @@ WARNING(override_swift3_objc_inference,Deprecation,
         "override of %0 %1 from extension of %2 depends on deprecated "
         "inference of '@objc'",
         (DescriptiveDeclKind, DeclName, Identifier))
-ERROR(override_method_different_generic_sig,none,
-      "overridden method %0 has generic signature %1 which is incompatible with "
-      "base method's generic signature %2; expected generic signature to be %3",
-      (DeclBaseName, StringRef, StringRef, StringRef))
 
 // Inheritance
 ERROR(duplicate_inheritance,none,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5150,11 +5150,22 @@ ASTContext::getOverrideGenericSignature(const ValueDecl *base,
 bool ASTContext::overrideGenericSignatureReqsSatisfied(
     const ValueDecl *base, const ValueDecl *derived,
     const OverrideGenericSignatureReqCheck direction) {
+  auto *baseCtx = base->getAsGenericContext();
+  auto *derivedCtx = derived->getAsGenericContext();
+
+  if (baseCtx->isGeneric() != derivedCtx->isGeneric())
+    return false;
+
+  if (baseCtx->isGeneric() &&
+      (baseCtx->getGenericParams()->size() !=
+       derivedCtx->getGenericParams()->size()))
+    return false;
+
   auto sig = getOverrideGenericSignature(base, derived);
   if (!sig)
     return true;
 
-  auto derivedSig = derived->getAsGenericContext()->getGenericSignature();
+  auto derivedSig = derivedCtx->getGenericSignature();
 
   switch (direction) {
   case OverrideGenericSignatureReqCheck::BaseReqSatisfiedByDerived:

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -541,8 +541,9 @@ computeDesignatedInitOverrideSignature(ASTContext &ctx,
       auto lookupConformanceFn =
           [&](CanType depTy, Type substTy,
               ProtocolDecl *proto) -> ProtocolConformanceRef {
-        if (auto conf = subMap.lookupConformance(depTy, proto))
-          return conf;
+        if (depTy->getRootGenericParam()->getDepth() < superclassDepth)
+          if (auto conf = subMap.lookupConformance(depTy, proto))
+            return conf;
 
         return ProtocolConformanceRef(proto);
       };
@@ -1125,9 +1126,7 @@ static void addImplicitInheritedConstructorsToClass(ClassDecl *decl) {
           continue;
 
         auto type = swift::getMemberTypeForComparison(ctor, nullptr);
-        auto parentType = swift::getMemberTypeForComparison(superclassCtor, ctor);
-
-        if (isOverrideBasedOnType(ctor, type, superclassCtor, parentType)) {
+        if (isOverrideBasedOnType(ctor, type, superclassCtor)) {
           alreadyDeclared = true;
           break;
         }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1261,7 +1261,7 @@ Type getMemberTypeForComparison(const ValueDecl *member,
 /// Determine whether the given declaration is an override by comparing type
 /// information.
 bool isOverrideBasedOnType(const ValueDecl *decl, Type declTy,
-                           const ValueDecl *parentDecl, Type parentDeclTy);
+                           const ValueDecl *parentDecl);
 
 /// Determine whether the given declaration is an operator defined in a
 /// protocol. If \p type is not null, check specifically whether \p decl

--- a/test/attr/attr_override.swift
+++ b/test/attr/attr_override.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 5 -requirement-machine=verify
 
 @override // expected-error {{'override' can only be specified on class members}} {{1-11=}} expected-error {{'override' is a declaration modifier, not an attribute}} {{1-2=}}
 func virtualAttributeCanNotBeUsedInSource() {}
@@ -545,21 +545,21 @@ class SR_4206_DerivedConcrete_2<T>: SR_4206_BaseGeneric_2<T> {
 // Base class generic w/ method generic, derived class generic w/ method generic but different requirement
 
 class SR_4206_BaseGeneric_3<T> {
-  func foo<T>(arg: T) {} // expected-note {{overridden declaration is here}}
+  func foo<T>(arg: T) {}
 }
 
 class SR_4206_DerivedGeneric_3<T>: SR_4206_BaseGeneric_3<T> {
-  override func foo<T: SR_4206_Protocol_1>(arg: T) {} // expected-error {{overridden method 'foo' has generic signature <T, T where T : SR_4206_Protocol_1> which is incompatible with base method's generic signature <T, T>; expected generic signature to be <T, T>}}
+  override func foo<T: SR_4206_Protocol_1>(arg: T) {} // expected-error {{method does not override any method from its superclass}}
 }
 
 // Base class not generic w/ method generic, derived class not generic w/ method generic but different requirement
 
 class SR_4206_BaseConcrete_4 {
-  func foo<T>(arg: T) {} // expected-note {{overridden declaration is here}}
+  func foo<T>(arg: T) {}
 }
 
 class SR_4206_DerivedConcrete_4: SR_4206_BaseConcrete_4 {
-  override func foo<T: SR_4206_Protocol_1>(arg: T) {} // expected-error {{overridden method 'foo' has generic signature <T where T : SR_4206_Protocol_1> which is incompatible with base method's generic signature <T>; expected generic signature to be <T>}}
+  override func foo<T: SR_4206_Protocol_1>(arg: T) {} // expected-error {{method does not override any method from its superclass}}
 }
 
 // Base class not generic w/ method generic, derived class not generic w/ method generic but removed requirement
@@ -575,22 +575,22 @@ class SR_4206_DerivedConcrete_5: SR_4206_BaseConcrete_5 {
 // Base class not generic w/ method generic, derived class generic w/ method generic but different requirement
 
 class SR_4206_BaseConcrete_6 {
-  func foo<T: SR_4206_Protocol_2>(arg: T) {} // expected-note {{overridden declaration is here}}
+  func foo<T: SR_4206_Protocol_2>(arg: T) {}
 }
 
 class SR_4206_DerivedGeneric_6<T>: SR_4206_BaseConcrete_6 {
-  override func foo<T: SR_4206_Protocol_1>(arg: T) {} // expected-error {{overridden method 'foo' has generic signature <T, T where T : SR_4206_Protocol_1> which is incompatible with base method's generic signature <T where T : SR_4206_Protocol_2>; expected generic signature to be <T, T where T : SR_4206_Protocol_2>}}
+  override func foo<T: SR_4206_Protocol_1>(arg: T) {} // expected-error {{method does not override any method from its superclass}}
 }
 
 // Contextual where clauses on non-generic members
 
 class SR_4206_Base_7<T> {
-  func foo1() where T: SR_4206_Protocol_1 {} // expected-note {{overridden declaration is here}}
+  func foo1() where T: SR_4206_Protocol_1 {}
   func foo2() where T: SR_4206_Protocol_1 {}
 }
 
 class SR_4206_Derived_7<T>: SR_4206_Base_7<T> {
-  override func foo1() where T: SR_4206_Protocol_2 {} // expected-error {{overridden method 'foo1' has generic signature <T where T : SR_4206_Protocol_2> which is incompatible with base method's generic signature <T where T : SR_4206_Protocol_1>; expected generic signature to be <T where T : SR_4206_Protocol_1>}}
+  override func foo1() where T: SR_4206_Protocol_2 {} // expected-error {{method does not override any method from its superclass}}
 
   override func foo2() {} // OK
 }
@@ -624,10 +624,10 @@ class SR_4206_Derived_9<T>: SR_4206_Base_9<T> {
 // Override with constraint on a non-inherited generic param
 
 class SR_4206_Base_10<T> {
-  func foo() where T: SR_4206_Protocol_1 {} // expected-note {{overridden declaration is here}}
+  func foo() where T: SR_4206_Protocol_1 {}
 }
 class SR_4206_Derived_10<T, U>: SR_4206_Base_10<T> {
-  override func foo() where U: SR_4206_Protocol_1 {} // expected-error {{overridden method 'foo' has generic signature <T, U where U : SR_4206_Protocol_1> which is incompatible with base method's generic signature <T where T : SR_4206_Protocol_1>; expected generic signature to be <T, U where T : SR_4206_Protocol_1>}}
+  override func foo() where U: SR_4206_Protocol_1 {} // expected-error {{method does not override any method from its superclass}}
 }
 
 // Override with return type specialization
@@ -709,4 +709,20 @@ public extension SR_11740_Base where F: SR_11740_Q {
 
 extension SR_11740_Derived where F: SR_11740_P {
     public static func foo(_: A) {}
+}
+
+// Make sure we don't crash on generic requirement mismatch
+protocol P3 {}
+
+protocol P4 {
+  associatedtype T
+}
+
+class Base {
+  func method<T: P3>(_: T) {}
+  func method<T: P4>(_: T) where T.T : P3 {}
+}
+
+class Derived: Base {
+  override func method<T: P3>(_: T) {}
 }

--- a/test/decl/circularity.swift
+++ b/test/decl/circularity.swift
@@ -84,8 +84,12 @@ open class G1<A> {
 class C3: G1<A>, P {
     // expected-error@-1 {{type 'C3' does not conform to protocol 'P'}}
     // expected-error@-2 {{cannot find type 'A' in scope}}
+    // expected-note@-3 {{through reference here}}
     override func run(a: A) {}
     // expected-error@-1 {{method does not override any method from its superclass}}
+    // expected-error@-2 {{circular reference}}
+    // expected-note@-3 2 {{through reference here}}
+    // expected-note@-4 {{while resolving type 'A'}}
 }
 
 // Another case that triggers circular override checking.


### PR DESCRIPTION
Override checking checks if the derived declaration's generic
signature is compatible with the base, but it does this after
doing a bunch of other checks which feed potentially invalid
type parameters to generic signature queries.

Now that the requirement machine is stricter about this kind
of thing, re-organize some code to get around this.

Unfortunately this regresses a diagnostic, because we reject
candidates with mismatched generic requirements earlier in
the process.