### PR TITLE
[DNM] Proof-of-concept: property destructuring

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4131,6 +4131,9 @@ WARNING(converting_tuple_into_several_associated_values,none,
 WARNING(converting_several_associated_values_into_tuple,none,
         "enum case '%0' has one associated value that is a tuple of %1 "
         "elements",(StringRef, unsigned))
+NOTE(property_destructure_requires_names,none,
+     "label elements with property names to destructure by property",
+     ())
 ERROR(closure_argument_list_tuple,none,
       "contextual closure type %0 expects %1 argument%s1, "
       "but %2 %select{were|was}3 used in closure body", (Type, unsigned, unsigned, bool))

--- a/include/swift/AST/PatternNodes.def
+++ b/include/swift/AST/PatternNodes.def
@@ -35,6 +35,7 @@
 // Metavars: x (variable binding), pat (pattern), e (expression)
 PATTERN(Paren, Pattern)   // (pat)
 PATTERN(Tuple, Pattern)   // (pat1, ..., patN), N >= 1
+PATTERN(Mapping, Pattern) // Wraps a TuplePattern on a non-tuple
 PATTERN(Named, Pattern)   // let pat, var pat
 PATTERN(Any, Pattern)     // _
 PATTERN(Typed, Pattern)   // pat : type

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -365,6 +365,13 @@ namespace {
       }
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
+    void visitMappingPattern(MappingPattern *P) {
+      printCommon(P, "pattern_mapping");
+      printRec(P->getSourceValue());
+      printRec(P->getMappingExpr());
+      printRec(P->getSubPattern());
+      PrintWithColorRAII(OS, ParenthesisColor) << ')';
+    }
     void visitNamedPattern(NamedPattern *P) {
       printCommon(P, "pattern_named");
       PrintWithColorRAII(OS, IdentifierColor) << " '" << P->getNameStr() << "'";

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1993,6 +1993,9 @@ namespace {
     VarDecl *visitParenPattern(ParenPattern *P) {
       return visit(P->getSubPattern());
     }
+    VarDecl *visitMappingPattern(MappingPattern *P) {
+      return visit(P->getSubPattern());
+    }
     VarDecl *visitBindingPattern(BindingPattern *P) {
       return visit(P->getSubPattern());
     }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1259,6 +1259,10 @@ void PrintAST::printPattern(const Pattern *pattern) {
     break;
   }
 
+  case PatternKind::Mapping:
+    printPattern(cast<MappingPattern>(pattern)->getSubPattern());
+    break;
+
   case PatternKind::Typed:
     printTypedPattern(cast<TypedPattern>(pattern));
     break;

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1675,6 +1675,14 @@ Pattern *Traversal::visitTuplePattern(TuplePattern *P) {
   }
   return P;
 }
+Pattern *Traversal::visitMappingPattern(MappingPattern *P) {
+  if (Pattern *newSub = doIt(P->getSubPattern()))
+    P->setSubPattern(newSub);
+  else
+    return nullptr;
+  return P;
+}
+
 
 Pattern *Traversal::visitNamedPattern(NamedPattern *P) {
   if (doIt(P->getDecl()))

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2720,6 +2720,8 @@ void FindLocalVal::checkPattern(const Pattern *Pat, DeclVisibilityKind Reason) {
     for (auto &field : cast<TuplePattern>(Pat)->getElements())
       checkPattern(field.getPattern(), Reason);
     return;
+  case PatternKind::Mapping:
+    return checkPattern(cast<MappingPattern>(Pat)->getSubPattern(), Reason);
   case PatternKind::Paren:
   case PatternKind::Typed:
   case PatternKind::Binding:

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5945,6 +5945,9 @@ ManagedValue SILGenFunction::emitReadAsyncLetBinding(SILLocation loc,
     void visitParenPattern(ParenPattern *P) {
       return visit(P->getSubPattern());
     }
+    void visitMappingPattern(MappingPattern *P) {
+      return visit(P->getSubPattern());
+    }
     void visitTypedPattern(TypedPattern *P) {
       return visit(P->getSubPattern());
     }

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -982,6 +982,10 @@ emitMemberInit(SILGenFunction &SGF, VarDecl *selfDecl, Pattern *pattern) {
     return InitializationPtr(init);
   }
 
+  case PatternKind::Mapping:
+    return emitMemberInit(SGF, selfDecl,
+                          cast<MappingPattern>(pattern)->getSubPattern());
+
   case PatternKind::Named: {
     auto named = cast<NamedPattern>(pattern);
 

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1020,6 +1020,9 @@ struct InitializationForPattern
   InitializationPtr visitBindingPattern(BindingPattern *P) {
     return visit(P->getSubPattern());
   }
+  InitializationPtr visitMappingPattern(MappingPattern *P) {
+    return visit(P->getSubPattern());
+  }
 
   // AnyPatterns (i.e, _) don't require any storage. Any value bound here will
   // just be dropped.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4593,6 +4593,10 @@ namespace {
     }
 #include "swift/AST/PatternNodes.def"
 
+    Type visitMappingPattern(MappingPattern *pattern) {
+      llvm::report_fatal_error("unimplemented");
+    }
+
     Type visitTuplePattern(TuplePattern *pattern) {
       SmallVector<TupleTypeElt, 4> tupleElts;
       for (auto &element : pattern->getElements()) {

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -148,6 +148,9 @@ struct GenGlobalAccessors : public PatternVisitor<GenGlobalAccessors>
     for (auto &elt : P->getElements())
       visit(elt.getPattern());
   }
+  void visitMappingPattern(MappingPattern *P) {
+    return visit(P->getSubPattern());
+  }
   void visitAnyPattern(AnyPattern *P) {}
 
   // When we see a variable binding, emit its global accessor.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2320,6 +2320,9 @@ namespace {
         return setType(TupleType::get(tupleTypeElts, CS.getASTContext()));
       }
 
+      case PatternKind::Mapping:
+        llvm_unreachable("MappingPattern should only be added after typechecking");
+
       case PatternKind::OptionalSome: {
         // Remove an optional from the object type.
         if (externalPatternType) {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1171,6 +1171,10 @@ static Optional<std::string> buildDefaultInitializerString(DeclContext *dc,
     return result;
   }
 
+  case PatternKind::Mapping:
+    return buildDefaultInitializerString(
+        dc, cast<MappingPattern>(pattern)->getSubPattern());
+
   case PatternKind::Typed:
     return buildDefaultInitializerString(
         dc, cast<TypedPattern>(pattern)->getSubPattern());

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -287,6 +287,10 @@ public:
   ALWAYS_RESOLVED_PATTERN(Bool)
 #undef ALWAYS_RESOLVED_PATTERN
 
+  Pattern *visitMappingPattern(MappingPattern *P) {
+    llvm_unreachable("MappingPattern only added after type checking");
+  }
+
   Pattern *visitBindingPattern(BindingPattern *P) {
     // Keep track of the fact that we're inside of a var/let pattern.  This
     // affects how unqualified identifiers are processed.
@@ -862,6 +866,10 @@ Type PatternTypeRequest::evaluate(Evaluator &evaluator,
 
     return TupleType::get(typeElts, Context);
   }
+
+  // A MappingPattern has the type of its source, not its subpattern.
+  case PatternKind::Mapping:
+    return cast<MappingPattern>(P)->getSourceValue()->getType();
       
   //--- Refutable patterns.
   //
@@ -1182,11 +1190,11 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
     // Sometimes a paren is just a paren. If the tuple pattern has a single
     // element, we can reduce it to a paren pattern.
     bool canDecayToParen = TP->getNumElements() == 1;
-    auto decayToParen = [&]() -> Pattern * {
+    auto decayToParen = [&](Type subtype) -> Pattern * {
       assert(canDecayToParen);
       Pattern *sub = TP->getElement(0).getPattern();
       sub = TypeChecker::coercePatternToType(
-          pattern.forSubPattern(sub, /*retainTopLevel=*/false), type,
+          pattern.forSubPattern(sub, /*retainTopLevel=*/false), subtype,
           subOptions);
       if (!sub)
         return nullptr;
@@ -1200,29 +1208,111 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
       }
       return P;
     };
+    auto canMapToTuple =
+        [&](SmallVectorImpl<SourceLoc> &unlabeledElemSourceLocs) -> bool {
+      if (TP->getNumElements() == 0 || !type->mayHaveMembers())
+        return false;
 
-    // The context type must be a tuple.
+      for (auto &elt : TP->getElements())
+        if (elt.getLabel().empty())
+          unlabeledElemSourceLocs.push_back(elt.getLoc());
+
+      return unlabeledElemSourceLocs.empty();
+    };
+
+    // The context is a tuple in the simple case.
     TupleType *tupleTy = type->getAs<TupleType>();
+
+    // No? Try making this a ParenPattern or, if it has members, wrapping it in
+    // a MappingPattern that will map it to a tuple.
     if (!tupleTy && !hadError) {
-      if (canDecayToParen)
-        return decayToParen();
-      diags.diagnose(TP->getStartLoc(),
-                     diag::tuple_pattern_in_non_tuple_context, type);
-      hadError = true;
+      if (canDecayToParen && TP->getElement(0).getLabel().empty())
+        return decayToParen(type);
+
+      SmallVector<SourceLoc, 4> unlabeledElemSourceLocs;
+      if (!canMapToTuple(unlabeledElemSourceLocs)) {
+        // Diagnose this impossible destructuring.
+        diags.diagnose(TP->getStartLoc(),
+                       diag::tuple_pattern_in_non_tuple_context, type);
+
+        if (!unlabeledElemSourceLocs.empty()) {
+          auto note = diags.diagnose(TP->getStartLoc(),
+                                     diag::property_destructure_requires_names);
+          for (auto loc : unlabeledElemSourceLocs)
+            note.fixItInsert(loc, "<#property name#>: ");
+        }
+        hadError = true;
+      } else { // canMapToTuple()
+        // Reverse-engineer from `TP` an expression that will look up each
+        // element as a property in `sourceExpr` and construct a tuple from
+        // them.
+        OpaqueValueExpr *sourceExpr =
+            new (Context) OpaqueValueExpr(TP->getSourceRange(), type,
+                                          /*isPlaceholder=*/true);
+
+        SmallVector<Expr *, 16> elemExprs;
+        SmallVector<Identifier, 16> elemNames;
+        SmallVector<SourceLoc, 16> elemNameLocs;
+
+        for (auto &elt : TP->getElements()) {
+          assert(!elt.getLabel().empty());
+
+          elemNames.push_back(elt.getLabel());
+          elemNameLocs.push_back(elt.getLabelLoc());
+          elemExprs.push_back(new (Context) UnresolvedDotExpr(
+                                  sourceExpr, SourceLoc(),
+                                  DeclNameRef(elt.getLabel()),
+                                  DeclNameLoc(elt.getLabelLoc()),
+                                  /*Implicit=*/true));
+        }
+
+        // If we would form a single-element tuple by doing this, use the single
+        // element as the `mappingExpr`. We will later decay `TP` to a
+        // `ParenPattern`.
+        Expr *mappingExpr;
+        if (canDecayToParen) {
+          assert(elemExprs.size() == 1);
+          mappingExpr = elemExprs.front();
+        } else {
+          assert(elemExprs.size() != 1);
+          mappingExpr = TupleExpr::create(
+              Context, TP->getLParenLoc(), elemExprs, elemNames, elemNameLocs,
+              TP->getRParenLoc(), /*TrailingClosure=*/false, /*Implicit=*/true);
+        }
+
+        // Type-check this whole mess.
+        Type mappingTy = TypeChecker::typeCheckExpression(mappingExpr, dc);
+        if (mappingTy.isNull() || mappingTy->hasError())
+          hadError = true;
+        else
+          tupleTy = mappingTy->getAs<TupleType>();
+
+        assert(tupleTy || canDecayToParen);
+
+        // The rest of this code will examine/mutate `TP` and `tupleTy`, but
+        // return `P`.
+        P = new (Context) MappingPattern(
+                              canDecayToParen ? decayToParen(mappingTy) : TP,
+                              sourceExpr, mappingExpr);
+        P->setType(type);
+
+        if (canDecayToParen)
+          return hadError ? nullptr : P;
+      }
     }
 
     // The number of elements must match exactly.
     if (!hadError && tupleTy->getNumElements() != TP->getNumElements()) {
       if (canDecayToParen)
-        return decayToParen();
+        return decayToParen(type);
       
       diags.diagnose(TP->getStartLoc(), diag::tuple_pattern_length_mismatch,
-                     type);
+                     tupleTy);
       hadError = true;
     }
 
     // Coerce each tuple element to the respective type.
-    P->setType(type);
+    TP->setType(tupleTy);
 
     for (unsigned i = 0, e = TP->getNumElements(); i != e; ++i) {
       TuplePatternElt &elt = TP->getElement(i);
@@ -1232,7 +1322,7 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
         CoercionType = ErrorType::get(Context);
       else
         CoercionType = tupleTy->getElement(i).getType();
-      
+
       // If the tuple pattern had a label for the tuple element, it must match
       // the label for the tuple type being matched.
       if (!hadError && !elt.getLabel().empty() &&
@@ -1257,6 +1347,9 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
 
     return P;
   }
+
+  case PatternKind::Mapping:
+    llvm_unreachable("Cannot exist before coercePatternToType()");
 
   // Coerce expressions by finding a '~=' operator that can compare the
   // expression to a value of the coerced type.

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1567,6 +1567,8 @@ namespace {
         return Space::forConstructor(item->getType(), Identifier(),
                                      conArgSpace);
       }
+      case PatternKind::Mapping:
+        return projectPattern(cast<MappingPattern>(item)->getSubPattern());
       }
       llvm_unreachable("unhandled kind");
     }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2923,6 +2923,8 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       }
       break;
     }
+    case PatternKind::Mapping:
+      llvm::report_fatal_error("unimplemented");
     case PatternKind::Named: {
       auto named = cast<NamedPattern>(pattern);
 

--- a/test/Interpreter/switch.swift
+++ b/test/Interpreter/switch.swift
@@ -282,4 +282,56 @@ SwitchTestSuite.test("Enum Initialization Leaks") {
   }
 }
 
+SwitchTestSuite.test("Property Destructuring") {
+  struct Alignment {
+    enum Lawfulness { case lawful, neutral, chaotic }
+    enum Goodness { case good, neutral, evil }
+    var lawfulness: Lawfulness
+    var goodness: Goodness
+
+    var descriptionPrefix: String {
+      switch self {
+      case (lawfulness: .lawful):
+        return "lawful"
+      case (lawfulness: .neutral):
+        return "neutral"
+      case (lawfulness: .chaotic):
+        return "chaotic"
+      default: // FIXME: should not be necessary
+        fatalError()
+      }
+    }
+
+    var descriptionSuffix: String {
+      switch self {
+      case (goodness: .good):
+        return "good"
+      case (goodness: .neutral):
+        return "neutral"
+      case (goodness: .evil):
+        return "evil"
+      default: // FIXME: should not be necessary
+        fatalError()
+      }
+    }
+
+    var description: String {
+      switch self {
+      case (lawfulness: .neutral, goodness: .neutral):
+        return "true netural"
+      default:
+        return "\(descriptionPrefix) \(descriptionSuffix)"
+      }
+    }
+  }
+
+  func desc(_ lawfulness: Alignment.Lawfulness, _ goodness: Alignment.Goodness) -> String {
+    return Alignment(lawfulness: lawfulness, goodness: goodness).description
+  }
+
+  expectEqual(desc(.lawful, .good), "lawful good")
+  expectEqual(desc(.neutral, .evil), "neutral evil")
+  expectEqual(desc(.neutral, .neutral), "true neutral")
+}
+
 runAllTests()

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -93,7 +93,7 @@ enum Voluntary<T> : Equatable {
     case .Mere,
          .Mere(), // expected-error{{tuple pattern cannot match values of the non-tuple type 'T'}}
          .Mere(_),
-         .Mere(_, _): // expected-error{{tuple pattern cannot match values of the non-tuple type 'T'}}
+         .Mere(_, _): // expected-error{{tuple pattern cannot match values of the non-tuple type 'T'}} expected-note {{label elements with property names to destructure by property}} {{16-16=<#property name#>: }} {{19-19=<#property name#>: }}
       ()
 
     case .Twain(), // expected-error{{tuple pattern has the wrong length for tuple type '(T, T)'}}
@@ -134,7 +134,7 @@ case Voluntary<Int>.Naught,
   ()
 case Voluntary<Int>.Mere,
      Voluntary<Int>.Mere(_),
-     Voluntary<Int>.Mere(_, _), // expected-error{{tuple pattern cannot match values of the non-tuple type 'Int'}}
+     Voluntary<Int>.Mere(_, _), // expected-error{{tuple pattern cannot match values of the non-tuple type 'Int'}} expected-note {{label elements with property names to destructure by property}} {{26-26=<#property name#>: }} {{29-29=<#property name#>: }}
      Voluntary.Mere,
      Voluntary.Mere(_),
      .Mere,
@@ -304,6 +304,59 @@ case is [Derived]: // expected-error{{collection downcast in cast pattern is not
 default:
   ()
 }
+
+
+
+// Property destructuring.
+struct Alignment {
+  enum Lawfulness { case lawful, neutral, chaotic }
+  enum Goodness { case good, neutral, evil }
+  var lawfulness: Lawfulness
+  var goodness: Goodness    // expected-note {{'goodness' declared here}}
+}
+
+var alignment = Alignment(lawfulness: .chaotic, goodness: .good)
+
+switch alignment {
+case ():    // expected-error {{tuple pattern cannot match values of the non-tuple type 'Alignment'}}
+  break
+}
+
+switch alignment {
+case (_):    // no-error; degrades to ParenPattern
+  break
+}
+
+switch alignment {
+case (lawfulness: _):    // no-error
+  break
+}
+
+switch alignment {
+case (lawfulness: _, goodness: _):    // no-error
+  break
+default: // FIXME: Shouldn't be needed
+  break
+}
+
+switch alignment {
+case (goodness: _, lawfulness: _):    // no-error
+  break
+default: // FIXME: Shouldn't be needed
+  break
+}
+
+switch alignment {
+case (hotness: _):    // expected-error {{value of type 'Alignment' has no member 'hotness'}}
+  break
+}
+
+switch alignment {
+case (goodness: _, _):    // expected-error {{tuple pattern cannot match values of the non-tuple type 'Alignment'}} expected-note {{label elements with property names to destructure by property}}
+  break
+}
+
+// TODO: Exhuastiveness checker tests.
 
 
 // Optional patterns.


### PR DESCRIPTION
This patch makes it so that, if you use a `TuplePattern` to match a non-tuple type, and all of the elements in the pattern are labeled, Swift matches against the properties named by the labels instead of emitting a type error. In other words, you can do things like:

```swift
  struct Alignment {
    enum Lawfulness { case lawful, neutral, chaotic }
    enum Goodness { case good, neutral, evil }
    var lawfulness: Lawfulness
    var goodness: Goodness

    var descriptionPrefix: String {
      switch self {
      case (lawfulness: .lawful):
        return "lawful"
      case (lawfulness: .neutral):
        return "neutral"
      case (lawfulness: .chaotic):
        return "chaotic"
      }
    }

    var descriptionSuffix: String {
      switch self {
      case (goodness: .good):
        return "good"
      case (goodness: .neutral):
        return "neutral"
      case (goodness: .evil):
        return "evil"
      }
    }

    var description: String {
      switch self {
      case (lawfulness: .neutral, goodness: .neutral):
        return "true netural"
      default:
        return "\(descriptionPrefix) \(descriptionSuffix)"
      }
    }
  }
```

(Except that I haven't gotten this modeled correctly in the space engine yet, so the first two switch statements currently need `default:` cases.)

Current status: very janky. This is much, much, *much* more expedient than correct at every level of the design, from the syntax to the typechecking to the AST modeling to the SILGen lowering. I'm posting this to facilitate discussion, not to seriously suggest merging it in anything like its current state.

Based on discussion here: https://twitter.com/UINT_MIN/status/1429554495940292608