### PR TITLE
[ResultBuilders] Fix handling of multiple pattern bindings

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -996,7 +996,7 @@ public:
 
   SolutionApplicationTargetsKey(
       const PatternBindingDecl *patternBinding, unsigned index) {
-    kind = Kind::stmt;
+    kind = Kind::patternBindingEntry;
     storage.patternBindingEntry.patternBinding = patternBinding;
     storage.patternBindingEntry.index = index;
   }

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -111,6 +111,13 @@ func testDiags() {
     y + 25
   }
 
+  tuplify(true) { _ in
+    0
+    let x: Int = 0, y: String = "" // Multiple initialized pattern bindings are okay
+    x + 1
+    y
+  }
+
   // Statements unsupported by the particular builder.
   tuplifyWithoutIf(true) {
     if $0 {    // expected-error{{closure containing control flow statement cannot be used with result builder 'TupleBuilderWithoutIf'}}


### PR DESCRIPTION
`SolutionApplicationTargetsKey` was constructing pattern binding
entries with incorrect `kind`, which led to crashes for pattern
bindings with multiple initialized entries.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
