### PR TITLE
Revert "[test] Disable a couple of AutoDiff tests"

### DIFF
--- a/test/AutoDiff/compiler_crashers_fixed/sr14240-symbol-in-ir-file-not-tbd-file.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr14240-symbol-in-ir-file-not-tbd-file.swift
@@ -1,9 +1,5 @@
 // RUN: %target-run-simple-swift(-Xfrontend -requirement-machine=off)
 
-// rdar://82240971 – Temporarily disable this test on non-macOS platforms until
-// the CI is fixed to not produce 'Invalid device: iPhone 8'.
-// REQUIRES: OS=macosx
-
 // REQUIRES: executable_test
 
 // SR-14240: Error: symbol 'powTJfSSpSr' (powTJfSSpSr) is in generated IR file,

--- a/test/AutoDiff/stdlib/differentiable_stdlib_conformances.swift
+++ b/test/AutoDiff/stdlib/differentiable_stdlib_conformances.swift
@@ -1,10 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// rdar://82240971 – Temporarily disable this test on non-macOS platforms until
-// the CI is fixed to not produce 'Invalid device: iPhone 8'.
-// REQUIRES: OS=macosx
-
 import _Differentiation
 
 // Test `Differentiable` protocol conformances for stdlib types.


### PR DESCRIPTION
Reverts apple/swift#38996

This should be fixed by https://github.com/apple/swift/pull/39005