### PR TITLE
AST: repair the build after #39010

### DIFF
--- a/include/swift/AST/USRGeneration.h
+++ b/include/swift/AST/USRGeneration.h
@@ -21,6 +21,8 @@
 
 #include "swift/Basic/LLVM.h"
 
+#include <string>
+
 namespace swift {
 class Decl;
 class AbstractStorageDecl;


### PR DESCRIPTION
There is a reference to `std::string` being introduced without the necessary header being included.  Add the missing include.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
