### PR TITLE
Differentiation: correct the storage annotation for runtime functions

### DIFF
--- a/stdlib/public/runtime/AutoDiffSupport.h
+++ b/stdlib/public/runtime/AutoDiffSupport.h
@@ -39,16 +39,16 @@ public:
 };
 
 /// Creates a linear map context with a tail-allocated top-level subcontext.
-SWIFT_EXPORT_FROM(swift_Differentiation) SWIFT_CC(swift)
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
 AutoDiffLinearMapContext *swift_autoDiffCreateLinearMapContext(
     size_t topLevelSubcontextSize);
 
 /// Returns the address of the tail-allocated top-level subcontext.
-SWIFT_EXPORT_FROM(swift_Differentiation) SWIFT_CC(swift)
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
 void *swift_autoDiffProjectTopLevelSubcontext(AutoDiffLinearMapContext *);
 
 /// Allocates memory for a new subcontext.
-SWIFT_EXPORT_FROM(swift_Differentiation) SWIFT_CC(swift)
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
 void *swift_autoDiffAllocateSubcontext(AutoDiffLinearMapContext *, size_t size);
 
 }


### PR DESCRIPTION
The runtime support functions are currently vended by
swiftCore.{dll,dylib,so} rather than
swift_Differentiation.{dll,dylib,so}.  This corrects the annotations to
indicate that reality.  This never could have worked as declared in the
first place.  swift_Differentiation never links against swiftRuntime
and swiftCore effectively whole-archives swiftRuntime into itself.  This
change is now reflecting that reality.  If the desire is to move this
(even on Darwin, where this may have already shipped and thus would
break ABI), we could split up the swiftRuntime into swiftRuntime and
swiftDifferentiationRuntime and link that as we do with the runtime into
swiftCore.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
