### PR TITLE
[ConstraintSystem] Store pattern binding associated with uninitialize…

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1632,6 +1632,7 @@ private:
     } caseLabelItem;
 
     struct {
+      PatternBindingDecl *binding;
       /// Index into pattern binding declaration (if any).
       unsigned index;
       PointerUnion<VarDecl *, Pattern *> declaration;
@@ -1688,10 +1689,11 @@ public:
   SolutionApplicationTarget(VarDecl *uninitializedWrappedVar)
       : kind(Kind::uninitializedVar) {
     if (auto *PDB = uninitializedWrappedVar->getParentPatternBinding()) {
-      patternBinding = PDB;
+      uninitializedVar.binding = PDB;
       uninitializedVar.index =
           PDB->getPatternEntryIndexForVarDecl(uninitializedWrappedVar);
     } else {
+      uninitializedVar.binding = nullptr;
       uninitializedVar.index = 0;
     }
 
@@ -1702,9 +1704,7 @@ public:
   SolutionApplicationTarget(PatternBindingDecl *binding, unsigned index,
                             Pattern *var, Type patternTy)
       : kind(Kind::uninitializedVar) {
-    assert(patternBinding);
-
-    patternBinding = binding;
+    uninitializedVar.binding = binding;
     uninitializedVar.index = index;
     uninitializedVar.declaration = var;
     uninitializedVar.type = patternTy;
@@ -1781,7 +1781,7 @@ public:
               uninitializedVar.declaration.dyn_cast<VarDecl *>())
         return wrappedVar->getDeclContext();
 
-      return patternBinding->getInitContext(uninitializedVar.index);
+      return uninitializedVar.binding->getInitContext(uninitializedVar.index);
     }
     }
     llvm_unreachable("invalid decl context type");
@@ -2072,7 +2072,7 @@ public:
       return nullptr;
 
     case Kind::uninitializedVar:
-      return patternBinding;
+      return uninitializedVar.binding;
     }
     llvm_unreachable("invalid case label type");
   }


### PR DESCRIPTION
…d variable

This is a follow-up to the uninitialized variable generalization.
Pattern binding declaration has to be stored together with the
variable because all of the entries in `SolutionApplicationTarget`
form a union.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
