### PR TITLE
IRGen: Mangle DWARF types with the right generic signature

### DIFF
--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1441,9 +1441,6 @@ TypeConverter::~TypeConverter() {
 }
 
 void TypeConverter::setGenericContext(CanGenericSignature signature) {
-  if (!signature)
-    return;
-  
   CurGenericSignature = signature;
 
   // Clear the dependent type info cache since we have a new active signature

--- a/lib/IRGen/GenType.h
+++ b/lib/IRGen/GenType.h
@@ -277,8 +277,6 @@ public:
   {}
   
   ~GenericContextScope() {
-    if (!newSig)
-      return;
     assert(TC.CurGenericSignature == newSig);
     TC.setGenericContext(oldSig);
   }

--- a/test/IRGen/retroactive_conformance_path.swift
+++ b/test/IRGen/retroactive_conformance_path.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t) 
-// RUN: %target-build-swift -module-name=test %s -o %t/a.out
+// RUN: %target-build-swift -module-name=test %s -o %t/a.out -requirement-machine=verify
 // RUN: %target-run %t/a.out | %FileCheck %s
 // REQUIRES: executable_test
 // REQUIRES: CPU=arm64 || CPU=x86_64

--- a/test/IRGen/retroactive_conformance_path_2.swift
+++ b/test/IRGen/retroactive_conformance_path_2.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -emit-ir -g -primary-file %s -requirement-machine=verify
+
+public struct TestType<T: Error> { }
+
+extension Array: Error where Element: Error { }
+
+public struct GenericType<G> {
+    public func test<T>(_ value: TestType<[T]>) { }
+}


### PR DESCRIPTION
The symptom here was a crash in getConformanceAccessPath(), but the root
cause was that the ASTMangler used an incorrect generic signature when
looking up the conformance path for a type parameter.

The mangler requires a generic signature to be set to properly mangle types
containing retroactive conformances. However, DebugInfo just used the
IRGenModule's current signature, which wasn't always the same as the
signature describing the archetypes found inside the SILFunction.

Fixes rdar://problem/81683650 / https://bugs.swift.org/browse/SR-15046.