### PR TITLE
[Sema][SR-14408] Improvements on enum equality diagnostics 

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8251,6 +8251,13 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
       if (instanceTy->isAny() || instanceTy->isAnyObject())
         impact += 5;
 
+      // Increasing the impact for missing member in any argument position so it
+      // doesn't affect situations where there are another fixes involved.
+      auto *anchorExpr = getAsExpr(locator->getAnchor());
+      if (anchorExpr && isArgumentExpr(anchorExpr)) {
+        impact += 5;
+      }
+
       if (recordFix(fix, impact))
         return SolutionKind::Error;
 
@@ -8301,7 +8308,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
                               functionRefKind, locator,
                               /*includeInaccessibleMembers*/ true);
 
-      // If uwrapped type still couldn't find anything for a given name,
+      // If unwrapped type still couldn't find anything for a given name,
       // let's fallback to a "not such member" fix.
       if (result.ViableCandidates.empty() && result.UnviableCandidates.empty())
         return fixMissingMember(origBaseTy, memberTy, locator);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4934,6 +4934,15 @@ ConstraintSystem::isArgumentExpr(Expr *expr) {
     return None;
   }
 
+  // Specifically for unresolved member expr getParentExpr returns a chain
+  // result expr as its immediate parent, so let's look one level up on AST.
+  if (auto *URMCR = getAsExpr<UnresolvedMemberChainResultExpr>(argList)) {
+    argList = getParentExpr(URMCR);
+    if (!argList) {
+      return None;
+    }
+  }
+
   if (isa<ParenExpr>(argList)) {
     for (;;) {
       auto *parent = getParentExpr(argList);

--- a/test/Constraints/enum_cases.swift
+++ b/test/Constraints/enum_cases.swift
@@ -171,3 +171,28 @@ struct EnumElementPatternFromContextualType<T> {
     }
   }
 }
+
+// SR-14408
+enum CompassPoint {
+    case North(Int)
+    case South
+    case East
+    case West
+}
+
+func isNorth(c : CompassPoint) -> Bool {
+  // expected-error@+1{{member 'North' expects argument of type 'Int'}}
+  return c == .North // expected-error {{binary operator '==' cannot be applied to two 'CompassPoint' operands}}
+  // expected-note@-1 {{binary operator '==' cannot be synthesized for enums with associated values}}
+}
+
+func isNorth2(c : CompassPoint) -> Bool {
+  // expected-error@+1{{member 'North' expects argument of type 'Int'}}
+  return .North == c // expected-error {{binary operator '==' cannot be applied to two 'CompassPoint' operands}}
+  // expected-note@-1 {{binary operator '==' cannot be synthesized for enums with associated values}}
+}
+
+func isSouth(c : CompassPoint) -> Bool {
+  return c == .South // expected-error {{binary operator '==' cannot be applied to two 'CompassPoint' operands}}
+  // expected-note@-1 {{binary operator '==' cannot be synthesized for enums with associated values}}
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
For some cases when attempting an == overload choice for enum and a dot member argument, for some choices solver ends trying to record a missing member for the argument. This causes the end result to be a set of solutions where although the score is better, given the context are not exactly. This causes diagnose ambiguity with fixes to work with a set of "best score" solutions that would not give the best diagnostics. 
So the idea here is to look at the context in which this fix is being recorded and increase the impact if in this context a missing member fix less likely to be an useful diagnostic on this case.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-14408.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
