### PR TITLE
[test] Add %target-codesign to BigInt.swift

### DIFF
--- a/test/Prototypes/BigInt.swift
+++ b/test/Prototypes/BigInt.swift
@@ -12,6 +12,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -swift-version 4 -o %t/a.out %s
+// RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 // REQUIRES: CPU=x86_64


### PR DESCRIPTION
Make sure to run `utils/swift-darwin-postprocess.py` on this test to work around a dyld issue.

rdar://82335489