### PR TITLE
[5.5] [test] Add missing postprocessing phase to executable stress tests

### DIFF
--- a/test/Prototypes/BigInt.swift
+++ b/test/Prototypes/BigInt.swift
@@ -12,6 +12,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -swift-version 4 -o %t/a.out %s
+// RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
 // REQUIRES: CPU=x86_64

--- a/validation-test/Runtime/weak-reference-racetests-dispatch.swift
+++ b/validation-test/Runtime/weak-reference-racetests-dispatch.swift
@@ -1,4 +1,5 @@
 // RUN: %target-build-swift %s %import-libdispatch -o %t_binary
+// RUN: %target-codesign %t_binary
 // RUN: %target-run %t_binary
 // REQUIRES: executable_test
 // REQUIRES: stress_test

--- a/validation-test/SILOptimizer/string_switch.swift
+++ b/validation-test/SILOptimizer/string_switch.swift
@@ -1,5 +1,6 @@
 // RUN: %target-build-swift -O %s -module-name=test -Xllvm -sil-disable-pass=FunctionSignatureOpts -o %t.out
 // RUN: %target-build-swift -O %s -module-name=test -Xllvm -sil-disable-pass=FunctionSignatureOpts -emit-sil | %FileCheck %s
+// RUN: %target-codesign %t.out
 // RUN: %target-run %t.out
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: stress_test

--- a/validation-test/StdlibUnittest/AtomicInt.swift
+++ b/validation-test/StdlibUnittest/AtomicInt.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 //
 // RUN: %target-build-swift -module-name a %s -o %t.out -O
+// RUN: %target-codesign %t.out
 // RUN: %target-run %t.out
 // REQUIRES: executable_test
 // REQUIRES: stress_test

--- a/validation-test/stdlib/ArrayBridging.swift
+++ b/validation-test/stdlib/ArrayBridging.swift
@@ -3,6 +3,7 @@
 // RUN: %target-clang -fobjc-arc %S/Inputs/SlurpFastEnumeration/SlurpFastEnumeration.m -c -o %t/SlurpFastEnumeration.o
 // RUN: echo '#sourceLocation(file: "%s", line: 1)' > "%t/main.swift" && cat "%s" >> "%t/main.swift" && chmod -w "%t/main.swift"
 // RUN: %target-build-swift -Xfrontend -disable-access-control -I %S/Inputs/SlurpFastEnumeration/ %t/main.swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift -Xlinker %t/SlurpFastEnumeration.o -o %t.out -O -swift-version 4
+// RUN: %target-codesign %t.out
 // RUN: %target-run %t.out
 // REQUIRES: executable_test
 

--- a/validation-test/stdlib/DictionaryBridging.swift
+++ b/validation-test/stdlib/DictionaryBridging.swift
@@ -3,6 +3,7 @@
 // RUN: %target-clang -fobjc-arc %S/Inputs/SlurpFastEnumeration/SlurpFastEnumeration.m -c -o %t/SlurpFastEnumeration.o
 // RUN: echo '#sourceLocation(file: "%s", line: 1)' > "%t/main.swift" && cat "%s" >> "%t/main.swift" && chmod -w "%t/main.swift"
 // RUN: %target-build-swift -Xfrontend -disable-access-control -I %S/Inputs/SlurpFastEnumeration/ %t/main.swift %S/Inputs/DictionaryKeyValueTypes.swift %S/Inputs/DictionaryKeyValueTypesObjC.swift -Xlinker %t/SlurpFastEnumeration.o -o %t.out -O -swift-version 4.2
+// RUN: %target-codesign %t.out
 // RUN: %target-run %t.out
 // REQUIRES: executable_test
 // REQUIRES: stress_test

--- a/validation-test/stdlib/ParameterPassing.swift.gyb
+++ b/validation-test/stdlib/ParameterPassing.swift.gyb
@@ -12,6 +12,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %gyb %s -o %t/ParameterPassing.swift
 // RUN: %line-directive %t/ParameterPassing.swift -- %target-build-swift %t/ParameterPassing.swift -o %t/a.out_Release -O
+// RUN: %target-codesign %t/a.out_Release
 // RUN: %target-run %t/a.out_Release
 // UNSUPPORTED: CPU=armv7k || CPU=arm64_32
 // REQUIRES: executable_test

--- a/validation-test/stdlib/SIMDParameterPassing.swift.gyb
+++ b/validation-test/stdlib/SIMDParameterPassing.swift.gyb
@@ -12,6 +12,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %gyb %s -o %t/SIMDParameterPassing.swift
 // RUN: %line-directive %t/SIMDParameterPassing.swift -- %target-build-swift %t/SIMDParameterPassing.swift -o %t/a.out_Release -O
+// RUN: %target-codesign %t/a.out_Release
 // RUN: %target-run %t/a.out_Release
 
 // UNSUPPORTED: CPU=armv7k || CPU=arm64_32


### PR DESCRIPTION
5.5 cherry-pick of https://github.com/apple/swift/pull/37978 & https://github.com/apple/swift/pull/39040 to work around a dyld issue. Add `%target-codesign` to tests that are missing it to make sure we run `utils/swift-darwin-postprocess.py` on them.

rdar://82335489