### PR TITLE
[Concurrency] Replace SWIFT_TASK_PRINTF_DEBUG with a SWIFT_TASK_DEBUG_LOG macro.

### DIFF
--- a/stdlib/public/Concurrency/AsyncLet.cpp
+++ b/stdlib/public/Concurrency/AsyncLet.cpp
@@ -176,13 +176,10 @@ void swift::swift_asyncLet_begin(AsyncLet *alet,
                                  void *closureEntryPoint,
                                  HeapObject *closureContext,
                                  void *resultBuffer) {
-#if SWIFT_TASK_PRINTF_DEBUG
-  fprintf(stderr, "[%lu] creating async let buffer of type %s at %p\n",
-          _swift_get_thread_id(),
-          swift_getTypeName(futureResultType, true).data,
-          resultBuffer);
-#endif
-  
+  SWIFT_TASK_DEBUG_LOG("creating async let buffer of type %s at %p",
+                       swift_getTypeName(futureResultType, true).data,
+                       resultBuffer);
+
   auto flags = TaskCreateFlags();
   flags.setEnqueueJob(true);
 
@@ -321,10 +318,7 @@ static void swift_asyncLet_endImpl(AsyncLet *alet) {
   AsyncTask *parent = swift_task_getCurrent();
   assert(parent && "async-let must have a parent task");
 
-#if SWIFT_TASK_PRINTF_DEBUG
-  fprintf(stderr, "[%lu] async let end of task %p, parent: %p\n",
-          _swift_get_thread_id(), task, parent);
-#endif
+  SWIFT_TASK_DEBUG_LOG("async let end of task %p, parent: %p", task, parent);
   _swift_task_dealloc_specific(parent, task);
 }
 
@@ -349,10 +343,8 @@ static void asyncLet_finish_after_task_completion(SWIFT_ASYNC_CONTEXT AsyncConte
   // and finally, release the task and destroy the async-let
   assert(swift_task_getCurrent() && "async-let must have a parent task");
 
-#if SWIFT_TASK_PRINTF_DEBUG
-  fprintf(stderr, "[%lu] async let end of task %p, parent: %p\n",
-          _swift_get_thread_id(), task, swift_task_getCurrent());
-#endif
+  SWIFT_TASK_DEBUG_LOG("async let end of task %p, parent: %p", task,
+                       swift_task_getCurrent());
   // Destruct the task.
   task->~AsyncTask();
   // Deallocate it out of the parent, if it was allocated there.

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -41,8 +41,14 @@
 
 namespace swift {
 
-// Uncomment to enable helpful debug spew to stderr
-//#define SWIFT_TASK_PRINTF_DEBUG 1
+// Set to 1 to enable helpful debug spew to stderr
+#if 0
+#define SWIFT_TASK_DEBUG_LOG(fmt, ...)                                         \
+  fprintf(stderr, "[%lu] " fmt "\n", (unsigned long)_swift_get_thread_id(),    \
+          __VA_ARGS__)
+#else
+#define SWIFT_TASK_DEBUG_LOG(fmt, ...) (void)0
+#endif
 
 #if defined(_WIN32)
 using ThreadID = decltype(GetCurrentThreadId());
@@ -405,10 +411,7 @@ inline void AsyncTask::flagAsSuspended() {
 // that can be used when debugging locally to instrument when a task actually is
 // dealloced.
 inline void AsyncTask::flagAsCompleted() {
-#if SWIFT_TASK_PRINTF_DEBUG
-  fprintf(stderr, "[%lu] task completed %p\n",
-          _swift_get_thread_id(), this);
-#endif
+  SWIFT_TASK_DEBUG_LOG("task completed %p", this);
 }
 
 inline void AsyncTask::localValuePush(const HeapObject *key,

--- a/stdlib/public/Concurrency/ThreadSanitizer.cpp
+++ b/stdlib/public/Concurrency/ThreadSanitizer.cpp
@@ -31,18 +31,14 @@ TSanFunc *tsan_acquire, *tsan_release;
 void swift::_swift_tsan_acquire(void *addr) {
   if (tsan_acquire) {
     tsan_acquire(addr);
-#if SWIFT_TASK_PRINTF_DEBUG
-    fprintf(stderr, "[%lu] tsan_acquire on %p\n", _swift_get_thread_id(), addr);
-#endif
+    SWIFT_TASK_DEBUG_LOG("tsan_acquire on %p", addr);
   }
 }
 
 void swift::_swift_tsan_release(void *addr) {
   if (tsan_release) {
     tsan_release(addr);
-#if SWIFT_TASK_PRINTF_DEBUG
-    fprintf(stderr, "[%lu] tsan_release on %p\n", _swift_get_thread_id(), addr);
-#endif
+    SWIFT_TASK_DEBUG_LOG("tsan_release on %p", addr);
   }
 }
 


### PR DESCRIPTION
This macro takes the string and parameters directly, and is conditionally defined to either call fprintf or ignore its arguments. This makes the call sites a little more pleasant (no #if scattered about) and ensures every log includes the thread ID and a newline automatically.