### PR TITLE
[Tests] Disable RemoteMirror/interop on use_os_stdlib builds.

### DIFF
--- a/test/RemoteMirror/interop.swift
+++ b/test/RemoteMirror/interop.swift
@@ -1,5 +1,7 @@
 // REQUIRES: OS=macosx
 // REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %S/Inputs/interop.swift -emit-library -module-name InteropTest -o %t/%target-library-name(InteropTest)


### PR DESCRIPTION
Even after the previous fix, this still isn't working on `use_os_stdlib` builds.  Just mark those as unsupported for now.

rdar://82124292
