### PR TITLE
Add a temporary flag to stage in back-deployment of concurrency.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -738,6 +738,9 @@ public:
   /// Get the runtime availability of support for concurrency.
   AvailabilityContext getConcurrencyAvailability();
 
+  /// Get the back-deployed availability for concurrency.
+  AvailabilityContext getBackDeployedConcurrencyAvailability();
+
   /// Get the runtime availability of support for differentiation.
   AvailabilityContext getDifferentiationAvailability();
 

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -301,6 +301,9 @@ namespace swift {
     /// Enable experimental concurrency model.
     bool EnableExperimentalConcurrency = false;
 
+    /// Enable experimental back-deployment of the concurrency model.
+    bool EnableExperimentalBackDeployConcurrency = false;
+
     /// Enable experimental support for named opaque result types, e.g.
     /// `func f() -> <T> T`.
     bool EnableExperimentalNamedOpaqueTypes = false;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -247,6 +247,10 @@ def enable_experimental_concurrency :
   Flag<["-"], "enable-experimental-concurrency">,
   HelpText<"Enable experimental concurrency model">;
 
+def enable_experimental_back_deploy_concurrency :
+  Flag<["-"], "enable-experimental-back-deploy-concurrency">,
+  HelpText<"Enable experimental back-deployment of the concurrency model">;
+
 def enable_experimental_distributed :
   Flag<["-"], "enable-experimental-distributed">,
   HelpText<"Enable experimental 'distributed' actors and functions">;

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -330,6 +330,10 @@ AvailabilityContext ASTContext::getConcurrencyAvailability() {
   return getSwift55Availability();
 }
 
+AvailabilityContext ASTContext::getBackDeployedConcurrencyAvailability() {
+  return getSwift51Availability();
+}
+
 AvailabilityContext ASTContext::getDifferentiationAvailability() {
   return getSwiftFutureAvailability();
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -422,6 +422,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalConcurrency |=
     Args.hasArg(OPT_enable_experimental_concurrency);
 
+  Opts.EnableExperimentalBackDeployConcurrency |=
+    Args.hasArg(OPT_enable_experimental_back_deploy_concurrency);
+
   Opts.EnableExperimentalNamedOpaqueTypes |=
       Args.hasArg(OPT_enable_experimental_named_opaque_types);
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1694,7 +1694,9 @@ void TypeChecker::checkConcurrencyAvailability(SourceRange ReferenceRange,
   auto runningOS =
     TypeChecker::overApproximateAvailabilityAtLocation(
       ReferenceRange.Start, ReferenceDC);
-  auto availability = ctx.getConcurrencyAvailability();
+  auto availability = ctx.LangOpts.EnableExperimentalBackDeployConcurrency
+      ? ctx.getBackDeployedConcurrencyAvailability()
+      : ctx.getConcurrencyAvailability();
   if (!runningOS.isContainedIn(availability)) {
     diagnosePotentialConcurrencyUnavailability(
       ReferenceRange, ReferenceDC,

--- a/test/Concurrency/concurrency_availability_back_deploy.swift
+++ b/test/Concurrency/concurrency_availability_back_deploy.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -parse-stdlib -target x86_64-apple-macosx10.13 -typecheck -verify -enable-experimental-back-deploy-concurrency %s
+// RUN: %target-swift-frontend -parse-stdlib -target x86_64-apple-macosx10.15 -typecheck -enable-experimental-back-deploy-concurrency %s
+// REQUIRES: OS=macosx
+
+func f() async { } // expected-error{{concurrency is only available in}}
+// expected-note@-1{{add @available}}
+
+actor A { }  // expected-error{{concurrency is only available in}}
+// expected-note@-1{{add @available}}
+
+// Allow this without any availability for Historical Reasons.
+public func swift_deletedAsyncMethodError() async {
+}


### PR DESCRIPTION
Add a frontend-only flag `-enable-experimental-back-deploy-concurrency`
to be used to stage in the back deployment of concurrency. At present,
all it does is lower the availability minimums for use of concurrency
features.
