### PR TITLE
ASTMangler: Pass around generic signature explicitly and remove CurGenericSignature

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -32,7 +32,6 @@ namespace Mangle {
 /// The mangler for AST declarations.
 class ASTMangler : public Mangler {
 protected:
-  CanGenericSignature CurGenericSignature;
   ModuleDecl *Mod = nullptr;
 
   /// Optimize out protocol names if a type only conforms to one protocol.
@@ -94,12 +93,12 @@ public:
   ASTMangler(bool DWARFMangling = false)
     : DWARFMangling(DWARFMangling) {}
 
-  void addTypeSubstitution(Type type) {
-    type = dropProtocolsFromAssociatedTypes(type);
+  void addTypeSubstitution(Type type, GenericSignature sig) {
+    type = dropProtocolsFromAssociatedTypes(type, sig);
     addSubstitution(type.getPointer());
   }
-  bool tryMangleTypeSubstitution(Type type) {
-    type = dropProtocolsFromAssociatedTypes(type);
+  bool tryMangleTypeSubstitution(Type type, GenericSignature sig) {
+    type = dropProtocolsFromAssociatedTypes(type, sig);
     return tryMangleSubstitution(type.getPointer());
   }
 
@@ -255,7 +254,7 @@ public:
   std::string mangleObjCRuntimeName(const NominalTypeDecl *Nominal);
 
   std::string mangleTypeWithoutPrefix(Type type) {
-    appendType(type);
+    appendType(type, nullptr);
     return finalize();
   }
 
@@ -293,17 +292,17 @@ protected:
 
   void appendSymbolKind(SymbolKind SKind);
 
-  void appendType(Type type, const ValueDecl *forDecl = nullptr);
+  void appendType(Type type, GenericSignature sig,
+                  const ValueDecl *forDecl = nullptr);
   
   void appendDeclName(const ValueDecl *decl);
 
   GenericTypeParamType *appendAssocType(DependentMemberType *DepTy,
+                                        GenericSignature sig,
                                         bool &isAssocTypeAtDepth);
 
   void appendOpWithGenericParamIndex(StringRef,
                                      const GenericTypeParamType *paramTy);
-
-  void bindGenericParameters(GenericSignature sig);
 
   /// Mangles a sugared type iff we are mangling for the debugger.
   template <class T> void appendSugaredType(Type type,
@@ -314,7 +313,8 @@ protected:
     appendType(BlandTy, forDecl);
   }
 
-  void appendBoundGenericArgs(Type type, bool &isFirstArgList);
+  void appendBoundGenericArgs(Type type, GenericSignature sig,
+                              bool &isFirstArgList);
 
   /// Append the bound generics arguments for the given declaration context
   /// based on a complete substitution map.
@@ -322,17 +322,20 @@ protected:
   /// \returns the number of generic parameters that were emitted
   /// thus far.
   unsigned appendBoundGenericArgs(DeclContext *dc,
+                                  GenericSignature sig,
                                   SubstitutionMap subs,
                                   bool &isFirstArgList);
   
   /// Append the bound generic arguments as a flat list, disregarding depth.
-  void appendFlatGenericArgs(SubstitutionMap subs);
+  void appendFlatGenericArgs(SubstitutionMap subs,
+                             GenericSignature sig);
 
   /// Append any retroactive conformances.
-  void appendRetroactiveConformances(Type type);
+  void appendRetroactiveConformances(Type type, GenericSignature sig);
   void appendRetroactiveConformances(SubstitutionMap subMap,
+                                     GenericSignature sig,
                                      ModuleDecl *fromModule);
-  void appendImplFunctionType(SILFunctionType *fn);
+  void appendImplFunctionType(SILFunctionType *fn, GenericSignature sig);
 
   void appendContextOf(const ValueDecl *decl);
 
@@ -350,27 +353,33 @@ protected:
     FunctionMangling,
   };
 
-  void appendFunction(AnyFunctionType *fn,
+  void appendFunction(AnyFunctionType *fn, GenericSignature sig,
                     FunctionManglingKind functionMangling = NoFunctionMangling,
                     const ValueDecl *forDecl = nullptr);
-  void appendFunctionType(AnyFunctionType *fn, bool isAutoClosure = false,
+  void appendFunctionType(AnyFunctionType *fn, GenericSignature sig,
+                          bool isAutoClosure = false,
                           const ValueDecl *forDecl = nullptr);
   void appendClangType(AnyFunctionType *fn);
   template <typename FnType>
   void appendClangType(FnType *fn, llvm::raw_svector_ostream &os);
 
   void appendFunctionSignature(AnyFunctionType *fn,
+                               GenericSignature sig,
                                const ValueDecl *forDecl,
                                FunctionManglingKind functionMangling);
 
   void appendFunctionInputType(ArrayRef<AnyFunctionType::Param> params,
+                               GenericSignature sig,
                                const ValueDecl *forDecl = nullptr);
   void appendFunctionResultType(Type resultType,
+                                GenericSignature sig,
                                 const ValueDecl *forDecl = nullptr);
 
-  void appendTypeList(Type listTy, const ValueDecl *forDecl = nullptr);
+  void appendTypeList(Type listTy, GenericSignature sig,
+                      const ValueDecl *forDecl = nullptr);
   void appendTypeListElement(Identifier name, Type elementType,
                              ParameterTypeFlags flags,
+                             GenericSignature sig,
                              const ValueDecl *forDecl = nullptr);
 
   /// Append a generic signature to the mangling.
@@ -385,16 +394,21 @@ protected:
   bool appendGenericSignature(GenericSignature sig,
                               GenericSignature contextSig = nullptr);
 
-  void appendRequirement(const Requirement &reqt);
+  void appendRequirement(const Requirement &reqt,
+                         GenericSignature sig);
 
-  void appendGenericSignatureParts(ArrayRef<CanTypeWrapper<GenericTypeParamType>> params,
+  void appendGenericSignatureParts(GenericSignature sig,
+                                   ArrayRef<CanTypeWrapper<GenericTypeParamType>> params,
                                    unsigned initialParamDepth,
                                    ArrayRef<Requirement> requirements);
 
-  DependentMemberType *dropProtocolFromAssociatedType(DependentMemberType *dmt);
-  Type dropProtocolsFromAssociatedTypes(Type type);
+  DependentMemberType *dropProtocolFromAssociatedType(DependentMemberType *dmt,
+                                                      GenericSignature sig);
+  Type dropProtocolsFromAssociatedTypes(Type type,
+                                        GenericSignature sig);
 
-  void appendAssociatedTypeName(DependentMemberType *dmt);
+  void appendAssociatedTypeName(DependentMemberType *dmt,
+                                GenericSignature sig);
 
   void appendClosureEntity(const SerializedAbstractClosureExpr *closure);
   
@@ -437,12 +451,14 @@ protected:
 
   void appendProtocolConformance(const ProtocolConformance *conformance);
   void appendProtocolConformanceRef(const RootProtocolConformance *conformance);
-  void appendAnyProtocolConformance(CanGenericSignature genericSig,
+  void appendAnyProtocolConformance(GenericSignature genericSig,
                                     CanType conformingType,
                                     ProtocolConformanceRef conformance);
   void appendConcreteProtocolConformance(
-                                        const ProtocolConformance *conformance);
-  void appendDependentProtocolConformance(const ConformanceAccessPath &path);
+                                        const ProtocolConformance *conformance,
+                                        GenericSignature sig);
+  void appendDependentProtocolConformance(const ConformanceAccessPath &path,
+                                          GenericSignature sig);
   void appendOpParamForLayoutConstraint(LayoutConstraint Layout);
   
   void appendSymbolicReference(SymbolicReferent referent);

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3153,6 +3153,7 @@ void ASTMangler::appendDependentProtocolConformance(
     // are.
     SWIFT_DEFER {
       currentProtocol = entry.second;
+      sig = currentProtocol->getGenericSignature();
     };
 
     // The first entry is the "root". Find this requirement in the generic

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -288,12 +288,12 @@ std::string ASTMangler::mangleKeyPathGetterThunkHelper(
   appendEntity(property);
   if (signature)
     appendGenericSignature(signature);
-  appendType(baseType);
+  appendType(baseType, signature);
   if (isa<SubscriptDecl>(property)) {
     // Subscripts can be generic, and different key paths could capture the same
     // subscript at different generic arguments.
     for (auto sub : subs.getReplacementTypes()) {
-      appendType(sub->mapTypeOutOfContext()->getCanonicalType());
+      appendType(sub->mapTypeOutOfContext()->getCanonicalType(), signature);
     }
   }
   appendOperator("TK");
@@ -312,12 +312,12 @@ std::string ASTMangler::mangleKeyPathSetterThunkHelper(
   appendEntity(property);
   if (signature)
     appendGenericSignature(signature);
-  appendType(baseType);
+  appendType(baseType, signature);
   if (isa<SubscriptDecl>(property)) {
     // Subscripts can be generic, and different key paths could capture the same
     // subscript at different generic arguments.
     for (auto sub : subs.getReplacementTypes()) {
-      appendType(sub->mapTypeOutOfContext()->getCanonicalType());
+      appendType(sub->mapTypeOutOfContext()->getCanonicalType(), signature);
     }
   }
   appendOperator("Tk");
@@ -331,7 +331,7 @@ std::string ASTMangler::mangleKeyPathEqualsHelper(ArrayRef<CanType> indices,
                                                   ResilienceExpansion expansion) {
   beginMangling();
   for (auto &index : indices)
-    appendType(index);
+    appendType(index, nullptr);
   if (signature)
     appendGenericSignature(signature);
   appendOperator("TH");
@@ -345,7 +345,7 @@ std::string ASTMangler::mangleKeyPathHashHelper(ArrayRef<CanType> indices,
                                                 ResilienceExpansion expansion) {
   beginMangling();
   for (auto &index : indices)
-    appendType(index);
+    appendType(index, nullptr);
   if (signature)
     appendGenericSignature(signature);
   appendOperator("Th");
@@ -390,14 +390,12 @@ std::string ASTMangler::mangleReabstractionThunkHelper(
   Mod = Module;
   assert(ThunkType->getPatternSubstitutions().empty() && "not implemented");
   GenericSignature GenSig = ThunkType->getInvocationGenericSignature();
-  if (GenSig)
-    CurGenericSignature = GenSig.getCanonicalSignature();
 
   beginMangling();
-  appendType(FromType);
-  appendType(ToType);
+  appendType(FromType, GenSig);
+  appendType(ToType, GenSig);
   if (SelfType)
-    appendType(SelfType);
+    appendType(SelfType, GenSig);
 
   if (GenSig)
     appendGenericSignature(GenSig);
@@ -408,7 +406,7 @@ std::string ASTMangler::mangleReabstractionThunkHelper(
     appendOperator("TR");
   
   if (GlobalActorBound) {
-    appendType(GlobalActorBound);
+    appendType(GlobalActorBound, GenSig);
     appendOperator("TU");
   }
 
@@ -422,8 +420,8 @@ std::string ASTMangler::mangleObjCAsyncCompletionHandlerImpl(
                                                    Optional<bool> ErrorOnZero,
                                                    bool predefined) {
   beginMangling();
-  appendType(BlockType);
-  appendType(ResultType);
+  appendType(BlockType, Sig);
+  appendType(ResultType, Sig);
   if (Sig)
     appendGenericSignature(Sig);
   if (ErrorOnZero)
@@ -491,8 +489,8 @@ std::string ASTMangler::mangleAutoDiffSelfReorderingReabstractionThunk(
     CanType fromType, CanType toType, GenericSignature signature,
     AutoDiffLinearMapKind linearMapKind) {
   beginMangling();
-  appendType(fromType);
-  appendType(toType);
+  appendType(fromType, signature);
+  appendType(toType, signature);
   if (signature)
     appendGenericSignature(signature);
   auto kindCode = (char)getAutoDiffFunctionKind(linearMapKind);
@@ -636,15 +634,14 @@ std::string ASTMangler::mangleTypeForDebugger(Type Ty, GenericSignature sig) {
 
   Ty = getTypeForDWARFMangling(Ty);
 
-  bindGenericParameters(sig);
-  appendType(Ty);
+  appendType(Ty, sig);
   appendOperator("D");
   return finalize();
 }
 
 std::string ASTMangler::mangleTypeForTypeName(Type type) {
   beginManglingWithoutPrefix();
-  appendType(type);
+  appendType(type, nullptr);
   return finalize();
 }
 
@@ -743,9 +740,9 @@ std::string ASTMangler::mangleTypeAsUSR(Type Ty) {
   Ty = getTypeForDWARFMangling(Ty);
 
   if (auto *fnType = Ty->getAs<AnyFunctionType>()) {
-    appendFunction(fnType);
+    appendFunction(fnType, nullptr);
   } else {
-    appendType(Ty);
+    appendType(Ty, nullptr);
   }
 
   appendOperator("D");
@@ -762,9 +759,6 @@ std::string ASTMangler::mangleDeclAsUSR(const ValueDecl *Decl,
   beginManglingWithoutPrefix();
   llvm::SaveAndRestore<bool> allowUnnamedRAII(AllowNamelessEntities, true);
   Buffer << USRPrefix;
-
-  auto Sig = Decl->getInnermostDeclContext()->getGenericSignatureOfContext();
-  bindGenericParameters(Sig);
 
   if (auto Ctor = dyn_cast<ConstructorDecl>(Decl)) {
     appendConstructorEntity(Ctor, /*isAllocating=*/false);
@@ -1015,8 +1009,6 @@ void ASTMangler::appendOpaqueDeclName(const OpaqueTypeDecl *opaqueDecl) {
   if (canSymbolicReference(opaqueDecl)) {
     appendSymbolicReference(opaqueDecl);
   } else if (auto namingDecl = opaqueDecl->getNamingDecl()) {
-    llvm::SaveAndRestore<CanGenericSignature> savedSignature(
-        CurGenericSignature);
     appendEntity(namingDecl);
     appendOperator("QO");
   } else {
@@ -1026,7 +1018,8 @@ void ASTMangler::appendOpaqueDeclName(const OpaqueTypeDecl *opaqueDecl) {
 
 /// Mangle a type into the buffer.
 ///
-void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
+void ASTMangler::appendType(Type type, GenericSignature sig,
+                            const ValueDecl *forDecl) {
   assert((DWARFMangling || type->isCanonical()) &&
          "expecting canonical types when not mangling for the debugger");
   TypeBase *tybase = type.getPointer();
@@ -1086,7 +1079,7 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
     case TypeKind::SILToken:
       return appendOperator("Bt");
     case TypeKind::BuiltinVector:
-      appendType(cast<BuiltinVectorType>(tybase)->getElementType(),
+      appendType(cast<BuiltinVectorType>(tybase)->getElementType(), sig,
                  forDecl);
       // The mangling calls for using the actual element count, which we have
       // to adjust by 1 in order to mangle it as an index.
@@ -1102,28 +1095,26 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
       auto underlyingType = aliasTy->getSinglyDesugaredType();
       TypeAliasDecl *decl = aliasTy->getDecl();
       if (decl->getModuleContext() == decl->getASTContext().TheBuiltinModule) {
-        return appendType(underlyingType, forDecl);
+        return appendType(underlyingType, sig, forDecl);
       }
 
       if (decl->getDeclaredInterfaceType()
             .subst(aliasTy->getSubstitutionMap()).getPointer()
             != aliasTy) {
-        return appendType(underlyingType, forDecl);
+        return appendType(underlyingType, sig, forDecl);
       }
 
       if (aliasTy->getSubstitutionMap()) {
         // Try to mangle the entire name as a substitution.
-        if (tryMangleTypeSubstitution(tybase))
+        if (tryMangleTypeSubstitution(tybase, sig))
           return;
 
-        auto outerGenericSig = CurGenericSignature;
         appendAnyGenericType(decl);
-        CurGenericSignature = outerGenericSig;
         bool isFirstArgList = true;
-        appendBoundGenericArgs(type, isFirstArgList);
-        appendRetroactiveConformances(type);
+        appendBoundGenericArgs(type, sig, isFirstArgList);
+        appendRetroactiveConformances(type, sig);
         appendOperator("G");
-        addTypeSubstitution(type);
+        addTypeSubstitution(type, sig);
         return;
       }
 
@@ -1132,38 +1123,38 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
 
     case TypeKind::Paren:
       assert(DWARFMangling && "sugared types are only legal for the debugger");
-      appendType(cast<ParenType>(tybase)->getUnderlyingType());
+      appendType(cast<ParenType>(tybase)->getUnderlyingType(), sig, forDecl);
       appendOperator("XSp");
       return;
 
     case TypeKind::ArraySlice:
       assert(DWARFMangling && "sugared types are only legal for the debugger");
-      appendType(cast<ArraySliceType>(tybase)->getBaseType());
+      appendType(cast<ArraySliceType>(tybase)->getBaseType(), sig, forDecl);
       appendOperator("XSa");
       return;
 
     case TypeKind::VariadicSequence:
       assert(DWARFMangling && "sugared types are only legal for the debugger");
-      appendType(cast<VariadicSequenceType>(tybase)->getBaseType());
+      appendType(cast<VariadicSequenceType>(tybase)->getBaseType(), sig, forDecl);
       appendOperator("XSa");
       return;
 
     case TypeKind::Optional:
       assert(DWARFMangling && "sugared types are only legal for the debugger");
-      appendType(cast<OptionalType>(tybase)->getBaseType());
+      appendType(cast<OptionalType>(tybase)->getBaseType(), sig, forDecl);
       appendOperator("XSq");
       return;
 
     case TypeKind::Dictionary:
       assert(DWARFMangling && "sugared types are only legal for the debugger");
-      appendType(cast<DictionaryType>(tybase)->getKeyType());
-      appendType(cast<DictionaryType>(tybase)->getValueType());
+      appendType(cast<DictionaryType>(tybase)->getKeyType(), sig, forDecl);
+      appendType(cast<DictionaryType>(tybase)->getValueType(), sig, forDecl);
       appendOperator("XSD");
       return;
 
     case TypeKind::ExistentialMetatype: {
       ExistentialMetatypeType *EMT = cast<ExistentialMetatypeType>(tybase);
-      appendType(EMT->getInstanceType(), forDecl);
+      appendType(EMT->getInstanceType(), sig, forDecl);
       if (EMT->hasRepresentation()) {
         appendOperator("Xm",
                        getMetatypeRepresentationOp(EMT->getRepresentation()));
@@ -1174,7 +1165,7 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
     }
     case TypeKind::Metatype: {
       MetatypeType *MT = cast<MetatypeType>(tybase);
-      appendType(MT->getInstanceType(), forDecl);
+      appendType(MT->getInstanceType(), sig, forDecl);
       if (MT->hasRepresentation()) {
         appendOperator("XM",
                        getMetatypeRepresentationOp(MT->getRepresentation()));
@@ -1187,17 +1178,17 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
       llvm_unreachable("@lvalue types should not occur in function interfaces");
 
     case TypeKind::InOut:
-      appendType(cast<InOutType>(tybase)->getObjectType(), forDecl);
+      appendType(cast<InOutType>(tybase)->getObjectType(), sig, forDecl);
       return appendOperator("z");
 
 #define REF_STORAGE(Name, ...) \
     case TypeKind::Name##Storage: \
-      appendType(cast<Name##StorageType>(tybase)->getReferentType(), forDecl); \
+      appendType(cast<Name##StorageType>(tybase)->getReferentType(), sig, forDecl); \
       return appendOperator(manglingOf(ReferenceOwnership::Name));
 #include "swift/AST/ReferenceStorage.def"
 
     case TypeKind::Tuple:
-      appendTypeList(type, forDecl);
+      appendTypeList(type, sig, forDecl);
       return appendOperator("t");
 
     case TypeKind::Protocol: {
@@ -1220,7 +1211,7 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
         appendOperator("y");
 
       if (auto superclass = layout.explicitSuperclass) {
-        appendType(superclass, forDecl);
+        appendType(superclass, sig, forDecl);
         return appendOperator("Xc");
       } else if (layout.hasExplicitAnyObject) {
         return appendOperator("Xl");
@@ -1242,24 +1233,22 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
         Decl = type->getAnyGeneric();
       if (shouldMangleAsGeneric(type)) {
         // Try to mangle the entire name as a substitution.
-        if (tryMangleTypeSubstitution(tybase))
+        if (tryMangleTypeSubstitution(tybase, sig))
           return;
 
         if (Decl->isStdlibDecl() && Decl->getName().str() == "Optional") {
           auto GenArgs = type->castTo<BoundGenericType>()->getGenericArgs();
           assert(GenArgs.size() == 1);
-          appendType(GenArgs[0], forDecl);
+          appendType(GenArgs[0], sig, forDecl);
           appendOperator("Sg");
         } else {
-          auto outerGenericSig = CurGenericSignature;
           appendAnyGenericType(Decl);
-          CurGenericSignature = outerGenericSig;
           bool isFirstArgList = true;
-          appendBoundGenericArgs(type, isFirstArgList);
-          appendRetroactiveConformances(type);
+          appendBoundGenericArgs(type, sig, isFirstArgList);
+          appendRetroactiveConformances(type, sig);
           appendOperator("G");
         }
-        addTypeSubstitution(type);
+        addTypeSubstitution(type, sig);
         return;
       }
       appendAnyGenericType(type->getAnyGeneric());
@@ -1267,7 +1256,7 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
     }
 
     case TypeKind::SILFunction:
-      return appendImplFunctionType(cast<SILFunctionType>(tybase));
+      return appendImplFunctionType(cast<SILFunctionType>(tybase), sig);
 
       // type ::= archetype
     case TypeKind::PrimaryArchetype:
@@ -1285,23 +1274,23 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
       }
       
       // Otherwise, try to substitute it.
-      if (tryMangleTypeSubstitution(type))
+      if (tryMangleTypeSubstitution(type, sig))
         return;
       
       // Use the fully elaborated explicit mangling.
       appendOpaqueDeclName(opaqueDecl);
       bool isFirstArgList = true;
-      appendBoundGenericArgs(opaqueDecl,
+      appendBoundGenericArgs(opaqueDecl, sig,
                              opaqueType->getSubstitutions(),
                              isFirstArgList);
-      appendRetroactiveConformances(opaqueType->getSubstitutions(),
+      appendRetroactiveConformances(opaqueType->getSubstitutions(), sig,
                                     opaqueDecl->getParentModule());
       
       // TODO: If we support multiple opaque types in a return, put the
       // ordinal for this archetype here.
       appendOperator("Qo", Index(0));
 
-      addTypeSubstitution(type);
+      addTypeSubstitution(type, sig);
       return;
     }
       
@@ -1312,18 +1301,19 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
       // types, so that they can be accurately demangled at runtime.
       if (auto opaque =
             dyn_cast<OpaqueTypeArchetypeType>(nestedType->getRoot())) {
-        if (tryMangleTypeSubstitution(nestedType))
+        if (tryMangleTypeSubstitution(nestedType, sig))
           return;
         
-        appendType(opaque);
+        appendType(opaque, sig);
         bool isAssocTypeAtDepth = false;
-        appendAssocType(nestedType->getInterfaceType(), isAssocTypeAtDepth);
+        appendAssocType(nestedType->getInterfaceType(),
+                        sig, isAssocTypeAtDepth);
         appendOperator(isAssocTypeAtDepth ? "QX" : "Qx");
-        addTypeSubstitution(nestedType);
+        addTypeSubstitution(nestedType, sig);
         return;
       }
       
-      appendType(nestedType->getParent());
+      appendType(nestedType->getParent(), sig);
       appendIdentifier(nestedType->getName().str());
       appendOperator("Qa");
       return;
@@ -1332,15 +1322,16 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
     case TypeKind::DynamicSelf: {
       auto dynamicSelf = cast<DynamicSelfType>(tybase);
       if (dynamicSelf->getSelfType()->getAnyNominal()) {
-        appendType(dynamicSelf->getSelfType(), forDecl);
+        appendType(dynamicSelf->getSelfType(), sig, forDecl);
         return appendOperator("XD");
       }
-      return appendType(dynamicSelf->getSelfType(), forDecl);
+      return appendType(dynamicSelf->getSelfType(), sig, forDecl);
     }
 
     case TypeKind::GenericFunction: {
       auto genFunc = cast<GenericFunctionType>(tybase);
-      appendFunctionType(genFunc, /*autoclosure*/ false, forDecl);
+      appendFunctionType(genFunc, genFunc->getGenericSignature(),
+                         /*autoclosure*/ false, forDecl);
       appendGenericSignature(genFunc->getGenericSignature());
       appendOperator("u");
       return;
@@ -1363,11 +1354,11 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
 
     case TypeKind::DependentMember: {
       auto *DepTy = cast<DependentMemberType>(tybase);
-      if (tryMangleTypeSubstitution(DepTy))
+      if (tryMangleTypeSubstitution(DepTy, sig))
         return;
 
       bool isAssocTypeAtDepth = false;
-      if (GenericTypeParamType *gpBase = appendAssocType(DepTy,
+      if (GenericTypeParamType *gpBase = appendAssocType(DepTy, sig,
                                                          isAssocTypeAtDepth)) {
         if (gpBase->getDepth() == 0 && gpBase->getIndex() == 0) {
           appendOperator(isAssocTypeAtDepth ? "QZ" : "Qz");
@@ -1378,16 +1369,17 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
       } else {
         // Dependent members of non-generic-param types are not canonical, but
         // we may still want to mangle them for debugging or indexing purposes.
-        appendType(DepTy->getBase(), forDecl);
+        appendType(DepTy->getBase(), sig, forDecl);
         appendIdentifier(DepTy->getName().str());
         appendOperator("Qa");
       }
-      addTypeSubstitution(DepTy);
+      addTypeSubstitution(DepTy, sig);
       return;
     }
       
     case TypeKind::Function:
-      appendFunctionType(cast<FunctionType>(tybase), /*autoclosure*/ false,
+      appendFunctionType(cast<FunctionType>(tybase), sig,
+                         /*autoclosure*/ false,
                          forDecl);
       return;
       
@@ -1396,7 +1388,7 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
       auto layout = box->getLayout();
       bool firstField = true;
       for (auto &field : layout->getFields()) {
-        appendType(field.getLoweredType(), forDecl);
+        appendType(field.getLoweredType(), sig, forDecl);
         if (field.isMutable()) {
           // Use the `inout` mangling to represent a mutable field.
           appendOperator("z");
@@ -1409,7 +1401,7 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
       if (auto sig = layout->getGenericSignature()) {
         bool firstType = true;
         for (Type type : box->getSubstitutions().getReplacementTypes()) {
-          appendType(type, forDecl);
+          appendType(type, sig, forDecl);
           appendListSeparator(firstType);
         }
         if (firstType)
@@ -1431,11 +1423,12 @@ void ASTMangler::appendType(Type type, const ValueDecl *forDecl) {
 }
 
 GenericTypeParamType *ASTMangler::appendAssocType(DependentMemberType *DepTy,
+                                                  GenericSignature sig,
                                                   bool &isAssocTypeAtDepth) {
   auto base = DepTy->getBase()->getCanonicalType();
   // 't_0_0.Member'
   if (auto gpBase = dyn_cast<GenericTypeParamType>(base)) {
-    appendAssociatedTypeName(DepTy);
+    appendAssociatedTypeName(DepTy, sig);
     isAssocTypeAtDepth = false;
     return gpBase;
   }
@@ -1450,7 +1443,7 @@ GenericTypeParamType *ASTMangler::appendAssocType(DependentMemberType *DepTy,
   if (auto gpRoot = dyn_cast<GenericTypeParamType>(base)) {
     bool first = true;
     for (auto *member : llvm::reverse(path)) {
-      appendAssociatedTypeName(member);
+      appendAssociatedTypeName(member, sig);
       appendListSeparator(first);
     }
     isAssocTypeAtDepth = true;
@@ -1475,24 +1468,19 @@ void ASTMangler::appendOpWithGenericParamIndex(StringRef Op,
   appendOperator(Op, Index(paramTy->getIndex() - 1));
 }
 
-
-/// Bind the generic parameters from the given signature.
-void ASTMangler::bindGenericParameters(GenericSignature sig) {
-  if (sig)
-    CurGenericSignature = sig.getCanonicalSignature();
-}
-
-void ASTMangler::appendFlatGenericArgs(SubstitutionMap subs) {
+void ASTMangler::appendFlatGenericArgs(SubstitutionMap subs,
+                                       GenericSignature sig) {
   appendOperator("y");
 
   for (auto replacement : subs.getReplacementTypes()) {
     if (replacement->hasArchetype())
       replacement = replacement->mapTypeOutOfContext();
-    appendType(replacement);
+    appendType(replacement, sig);
   }
 }
 
 unsigned ASTMangler::appendBoundGenericArgs(DeclContext *dc,
+                                            GenericSignature sig,
                                             SubstitutionMap subs,
                                             bool &isFirstArgList) {
   auto decl = dc->getInnermostDeclarationDeclContext();
@@ -1508,7 +1496,7 @@ unsigned ASTMangler::appendBoundGenericArgs(DeclContext *dc,
 
   // Handle the generic arguments of the parent.
   unsigned currentGenericParamIdx =
-    appendBoundGenericArgs(decl->getDeclContext(), subs, isFirstArgList);
+    appendBoundGenericArgs(decl->getDeclContext(), sig, subs, isFirstArgList);
 
   // If this is potentially a generic context, emit a generic argument list.
   if (auto genericContext = decl->getAsGenericContext()) {
@@ -1533,7 +1521,7 @@ unsigned ASTMangler::appendBoundGenericArgs(DeclContext *dc,
         if (replacementType->hasArchetype())
           replacementType = replacementType->mapTypeOutOfContext();
 
-        appendType(replacementType);
+        appendType(replacementType, sig);
       }
     }
   }
@@ -1541,11 +1529,12 @@ unsigned ASTMangler::appendBoundGenericArgs(DeclContext *dc,
   return currentGenericParamIdx;
 }
 
-void ASTMangler::appendBoundGenericArgs(Type type, bool &isFirstArgList) {
+void ASTMangler::appendBoundGenericArgs(Type type, GenericSignature sig,
+                                        bool &isFirstArgList) {
   TypeBase *typePtr = type.getPointer();
   ArrayRef<Type> genericArgs;
   if (auto *typeAlias = dyn_cast<TypeAliasType>(typePtr)) {
-    appendBoundGenericArgs(typeAlias->getDecl(),
+    appendBoundGenericArgs(typeAlias->getDecl(), sig,
                            typeAlias->getSubstitutionMap(),
                            isFirstArgList);
     return;
@@ -1553,17 +1542,17 @@ void ASTMangler::appendBoundGenericArgs(Type type, bool &isFirstArgList) {
 
   if (auto *unboundType = dyn_cast<UnboundGenericType>(typePtr)) {
     if (Type parent = unboundType->getParent())
-      appendBoundGenericArgs(parent->getDesugaredType(), isFirstArgList);
+      appendBoundGenericArgs(parent->getDesugaredType(), sig, isFirstArgList);
   } else if (auto *nominalType = dyn_cast<NominalType>(typePtr)) {
     if (Type parent = nominalType->getParent())
-      appendBoundGenericArgs(parent->getDesugaredType(), isFirstArgList);
+      appendBoundGenericArgs(parent->getDesugaredType(), sig, isFirstArgList);
   } else {
     auto boundType = cast<BoundGenericType>(typePtr);
     genericArgs = boundType->getGenericArgs();
     if (Type parent = boundType->getParent()) {
       GenericTypeDecl *decl = boundType->getAnyGeneric();
       if (!getSpecialManglingContext(decl, UseObjCRuntimeNames))
-        appendBoundGenericArgs(parent->getDesugaredType(), isFirstArgList);
+        appendBoundGenericArgs(parent->getDesugaredType(), sig, isFirstArgList);
     }
   }
   if (isFirstArgList) {
@@ -1573,7 +1562,7 @@ void ASTMangler::appendBoundGenericArgs(Type type, bool &isFirstArgList) {
     appendOperator("_");
   }
   for (Type arg : genericArgs) {
-    appendType(arg);
+    appendType(arg, sig);
   }
 }
 
@@ -1646,6 +1635,7 @@ static bool containsRetroactiveConformance(
 }
 
 void ASTMangler::appendRetroactiveConformances(SubstitutionMap subMap,
+                                               GenericSignature sig,
                                                ModuleDecl *fromModule) {
   if (subMap.empty()) return;
 
@@ -1663,12 +1653,12 @@ void ASTMangler::appendRetroactiveConformances(SubstitutionMap subMap,
     if (!containsRetroactiveConformance(conformance.getConcrete(), fromModule))
       continue;
 
-    appendConcreteProtocolConformance(conformance.getConcrete());
+    appendConcreteProtocolConformance(conformance.getConcrete(), sig);
     appendOperator("g", Index(numProtocolRequirements));
   }
 }
 
-void ASTMangler::appendRetroactiveConformances(Type type) {
+void ASTMangler::appendRetroactiveConformances(Type type, GenericSignature sig) {
   // Dig out the substitution map to use.
   SubstitutionMap subMap;
   ModuleDecl *module;
@@ -1686,7 +1676,7 @@ void ASTMangler::appendRetroactiveConformances(Type type) {
     subMap = type->getContextSubstitutionMap(module, nominal);
   }
 
-  appendRetroactiveConformances(subMap, module);
+  appendRetroactiveConformances(subMap, sig, module);
 }
 
 static char getParamConvention(ParameterConvention conv) {
@@ -1739,7 +1729,8 @@ getResultDifferentiability(SILResultDifferentiability diffKind) {
   llvm_unreachable("bad result differentiability");
 };
 
-void ASTMangler::appendImplFunctionType(SILFunctionType *fn) {
+void ASTMangler::appendImplFunctionType(SILFunctionType *fn,
+                                        GenericSignature outerGenericSig) {
 
   llvm::SmallVector<char, 32> OpArgs;
 
@@ -1835,15 +1826,14 @@ void ASTMangler::appendImplFunctionType(SILFunctionType *fn) {
     OpArgs.push_back('H');
   }
 
-  auto outerGenericSig = CurGenericSignature;
-  CurGenericSignature = fn->getSubstGenericSignature();
+  GenericSignature sig = fn->getSubstGenericSignature();
   
   // Mangle the parameters.
   for (auto param : fn->getParameters()) {
     OpArgs.push_back(getParamConvention(param.getConvention()));
     if (auto diffKind = getParamDifferentiability(param.getDifferentiability()))
       OpArgs.push_back(*diffKind);
-    appendType(param.getInterfaceType());
+    appendType(param.getInterfaceType(), sig);
   }
 
   // Mangle the results.
@@ -1852,14 +1842,14 @@ void ASTMangler::appendImplFunctionType(SILFunctionType *fn) {
     if (auto diffKind =
             getResultDifferentiability(result.getDifferentiability()))
       OpArgs.push_back(*diffKind);
-    appendType(result.getInterfaceType());
+    appendType(result.getInterfaceType(), sig);
   }
 
   // Mangle the yields.
   for (auto yield : fn->getYields()) {
     OpArgs.push_back('Y');
     OpArgs.push_back(getParamConvention(yield.getConvention()));
-    appendType(yield.getInterfaceType());
+    appendType(yield.getInterfaceType(), sig);
   }
 
   // Mangle the error result if present.
@@ -1867,26 +1857,25 @@ void ASTMangler::appendImplFunctionType(SILFunctionType *fn) {
     auto error = fn->getErrorResult();
     OpArgs.push_back('z');
     OpArgs.push_back(getResultConvention(error.getConvention()));
-    appendType(error.getInterfaceType());
+    appendType(error.getInterfaceType(), sig);
   }
 
-  if (auto sig = fn->getInvocationGenericSignature()) {
-    appendGenericSignature(sig);
-    CurGenericSignature = outerGenericSig;
+  if (auto invocationSig = fn->getInvocationGenericSignature()) {
+    appendGenericSignature(invocationSig);
+    sig = outerGenericSig;
   }
   if (auto subs = fn->getInvocationSubstitutions()) {
-    appendFlatGenericArgs(subs);
-    appendRetroactiveConformances(subs, Mod);
+    appendFlatGenericArgs(subs, sig);
+    appendRetroactiveConformances(subs, sig, Mod);
   }
   if (auto subs = fn->getPatternSubstitutions()) {
     appendGenericSignature(subs.getGenericSignature());
-    CurGenericSignature =
+    sig =
       fn->getInvocationGenericSignature()
         ? fn->getInvocationGenericSignature()
         : outerGenericSig;
-    appendFlatGenericArgs(subs);
-    appendRetroactiveConformances(subs, Mod);
-    CurGenericSignature = outerGenericSig;
+    appendFlatGenericArgs(subs, sig);
+    appendRetroactiveConformances(subs, sig, Mod);
   }
 
   OpArgs.push_back('_');
@@ -2277,7 +2266,7 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl) {
 
   // For generic types, this uses the unbound type.
   if (nominal) {
-    if (tryMangleTypeSubstitution(nominal->getDeclaredType()))
+    if (tryMangleTypeSubstitution(nominal->getDeclaredType(), nullptr))
       return;
   } else {
     if (tryMangleSubstitution(cast<TypeAliasDecl>(decl)))
@@ -2288,7 +2277,7 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl) {
   if (nominal && canSymbolicReference(nominal)) {
     appendSymbolicReference(nominal);
     // Substitutions can refer back to the symbolic reference.
-    addTypeSubstitution(nominal->getDeclaredType());
+    addTypeSubstitution(nominal->getDeclaredType(), nullptr);
     return;
   }
 
@@ -2373,12 +2362,12 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl) {
   }
 
   if (nominal)
-    addTypeSubstitution(nominal->getDeclaredType());
+    addTypeSubstitution(nominal->getDeclaredType(), nullptr);
   else
     addSubstitution(cast<TypeAliasDecl>(decl));
 }
 
-void ASTMangler::appendFunction(AnyFunctionType *fn,
+void ASTMangler::appendFunction(AnyFunctionType *fn, GenericSignature sig,
                                 FunctionManglingKind functionMangling,
                                 const ValueDecl *forDecl) {
   // Append parameter labels right before the signature/type.
@@ -2400,18 +2389,19 @@ void ASTMangler::appendFunction(AnyFunctionType *fn,
   }
 
   if (functionMangling != NoFunctionMangling) {
-    appendFunctionSignature(fn, forDecl, functionMangling);
+    appendFunctionSignature(fn, sig, forDecl, functionMangling);
   } else {
-    appendFunctionType(fn, /*autoclosure*/ false, forDecl);
+    appendFunctionType(fn, sig, /*autoclosure*/ false, forDecl);
   }
 }
 
-void ASTMangler::appendFunctionType(AnyFunctionType *fn, bool isAutoClosure,
+void ASTMangler::appendFunctionType(AnyFunctionType *fn, GenericSignature sig,
+                                    bool isAutoClosure,
                                     const ValueDecl *forDecl) {
   assert((DWARFMangling || fn->isCanonical()) &&
          "expecting canonical types when not mangling for the debugger");
 
-  appendFunctionSignature(fn, forDecl, NoFunctionMangling);
+  appendFunctionSignature(fn, sig, forDecl, NoFunctionMangling);
 
   bool mangleClangType = fn->getASTContext().LangOpts.UseClangFunctionTypes &&
                          fn->hasNonDerivableClangType();
@@ -2477,10 +2467,11 @@ void ASTMangler::appendClangType(AnyFunctionType *fn) {
 }
 
 void ASTMangler::appendFunctionSignature(AnyFunctionType *fn,
-                                        const ValueDecl *forDecl,
-                                        FunctionManglingKind functionMangling) {
-  appendFunctionResultType(fn->getResult(), forDecl);
-  appendFunctionInputType(fn->getParams(), forDecl);
+                                         GenericSignature sig,
+                                         const ValueDecl *forDecl,
+                                         FunctionManglingKind functionMangling) {
+  appendFunctionResultType(fn->getResult(), sig, forDecl);
+  appendFunctionInputType(fn->getParams(), sig, forDecl);
   if (fn->isAsync())
     appendOperator("Ya");
   if (fn->isSendable())
@@ -2505,13 +2496,14 @@ void ASTMangler::appendFunctionSignature(AnyFunctionType *fn,
   }
 
   if (Type globalActor = fn->getGlobalActor()) {
-    appendType(globalActor);
+    appendType(globalActor, sig);
     appendOperator("Yc");
   }
 }
 
 void ASTMangler::appendFunctionInputType(
     ArrayRef<AnyFunctionType::Param> params,
+    GenericSignature sig,
     const ValueDecl *forDecl) {
   switch (params.size()) {
   case 0:
@@ -2527,7 +2519,7 @@ void ASTMangler::appendFunctionInputType(
     if (!param.hasLabel() && !param.isVariadic() &&
         !isa<TupleType>(type.getPointer())) {
       appendTypeListElement(Identifier(), type, param.getParameterFlags(),
-                            forDecl);
+                            sig, forDecl);
       break;
     }
 
@@ -2540,7 +2532,7 @@ void ASTMangler::appendFunctionInputType(
     bool isFirstParam = true;
     for (auto &param : params) {
       appendTypeListElement(Identifier(), param.getPlainType(),
-                            param.getParameterFlags(), forDecl);
+                            param.getParameterFlags(), sig, forDecl);
       appendListSeparator(isFirstParam);
     }
     appendOperator("t");
@@ -2548,13 +2540,14 @@ void ASTMangler::appendFunctionInputType(
   }
 }
 
-void ASTMangler::appendFunctionResultType(Type resultType,
+void ASTMangler::appendFunctionResultType(Type resultType, GenericSignature sig,
                                           const ValueDecl *forDecl) {
   return resultType->isVoid() ? appendOperator("y")
-                              : appendType(resultType, forDecl);
+                              : appendType(resultType, sig, forDecl);
 }
 
-void ASTMangler::appendTypeList(Type listTy, const ValueDecl *forDecl) {
+void ASTMangler::appendTypeList(Type listTy, GenericSignature sig,
+                                const ValueDecl *forDecl) {
   if (TupleType *tuple = listTy->getAs<TupleType>()) {
     if (tuple->getNumElements() == 0)
       return appendOperator("y");
@@ -2563,22 +2556,23 @@ void ASTMangler::appendTypeList(Type listTy, const ValueDecl *forDecl) {
       assert(field.getParameterFlags().isNone());
       appendTypeListElement(field.getName(), field.getRawType(),
                             ParameterTypeFlags(),
-                            forDecl);
+                            sig, forDecl);
       appendListSeparator(firstField);
     }
   } else {
-    appendType(listTy, forDecl);
+    appendType(listTy, sig, forDecl);
     appendListSeparator();
   }
 }
 
 void ASTMangler::appendTypeListElement(Identifier name, Type elementType,
                                        ParameterTypeFlags flags,
+                                       GenericSignature sig,
                                        const ValueDecl *forDecl) {
   if (auto *fnType = elementType->getAs<FunctionType>())
-    appendFunctionType(fnType, flags.isAutoClosure(), forDecl);
+    appendFunctionType(fnType, sig, flags.isAutoClosure(), forDecl);
   else
-    appendType(elementType, forDecl);
+    appendType(elementType, sig, forDecl);
 
   if (flags.isNoDerivative()) {
     appendOperator("Yk");
@@ -2609,7 +2603,6 @@ void ASTMangler::appendTypeListElement(Identifier name, Type elementType,
 bool ASTMangler::appendGenericSignature(GenericSignature sig,
                                         GenericSignature contextSig) {
   auto canSig = sig.getCanonicalSignature();
-  CurGenericSignature = canSig;
 
   unsigned initialParamDepth;
   ArrayRef<CanTypeWrapper<GenericTypeParamType>> genericParams;
@@ -2659,11 +2652,13 @@ bool ASTMangler::appendGenericSignature(GenericSignature sig,
   if (genericParams.empty() && requirements.empty())
     return false;
 
-  appendGenericSignatureParts(genericParams, initialParamDepth, requirements);
+  appendGenericSignatureParts(sig, genericParams,
+                              initialParamDepth, requirements);
   return true;
 }
 
-void ASTMangler::appendRequirement(const Requirement &reqt) {
+void ASTMangler::appendRequirement(const Requirement &reqt,
+                                   GenericSignature sig) {
 
   Type FirstTy = reqt.getFirstType()->getCanonicalType();
 
@@ -2676,13 +2671,13 @@ void ASTMangler::appendRequirement(const Requirement &reqt) {
   case RequirementKind::Superclass:
   case RequirementKind::SameType: {
     Type SecondTy = reqt.getSecondType();
-    appendType(SecondTy->getCanonicalType());
+    appendType(SecondTy->getCanonicalType(), sig);
   } break;
   }
 
   if (auto *DT = FirstTy->getAs<DependentMemberType>()) {
     bool isAssocTypeAtDepth = false;
-    if (tryMangleTypeSubstitution(DT)) {
+    if (tryMangleTypeSubstitution(DT, sig)) {
       switch (reqt.getKind()) {
         case RequirementKind::Conformance:
           return appendOperator("RQ");
@@ -2697,8 +2692,9 @@ void ASTMangler::appendRequirement(const Requirement &reqt) {
       }
       llvm_unreachable("bad requirement type");
     }
-    GenericTypeParamType *gpBase = appendAssocType(DT, isAssocTypeAtDepth);
-    addTypeSubstitution(DT);
+    GenericTypeParamType *gpBase = appendAssocType(DT, sig,
+                                                   isAssocTypeAtDepth);
+    addTypeSubstitution(DT, sig);
     assert(gpBase);
     switch (reqt.getKind()) {
       case RequirementKind::Conformance:
@@ -2734,12 +2730,13 @@ void ASTMangler::appendRequirement(const Requirement &reqt) {
 }
 
 void ASTMangler::appendGenericSignatureParts(
+                                     GenericSignature sig,
                                      ArrayRef<CanTypeWrapper<GenericTypeParamType>> params,
                                      unsigned initialParamDepth,
                                      ArrayRef<Requirement> requirements) {
   // Mangle the requirements.
   for (const Requirement &reqt : requirements) {
-    appendRequirement(reqt);
+    appendRequirement(reqt, sig);
   }
 
   if (params.size() == 1 && params[0]->getDepth() == initialParamDepth)
@@ -2788,14 +2785,15 @@ void ASTMangler::appendGenericSignatureParts(
 // in the current generic context, then we don't need to disambiguate the
 // associated type name by protocol.
 DependentMemberType *
-ASTMangler::dropProtocolFromAssociatedType(DependentMemberType *dmt) {
+ASTMangler::dropProtocolFromAssociatedType(DependentMemberType *dmt,
+                                           GenericSignature sig) {
   auto baseTy = dmt->getBase();
   bool unambiguous =
       (!dmt->getAssocType() ||
-       CurGenericSignature->getRequiredProtocols(baseTy).size() <= 1);
+       sig->getRequiredProtocols(baseTy).size() <= 1);
 
   if (auto *baseDMT = baseTy->getAs<DependentMemberType>())
-    baseTy = dropProtocolFromAssociatedType(baseDMT);
+    baseTy = dropProtocolFromAssociatedType(baseDMT, sig);
 
   if (unambiguous)
     return DependentMemberType::get(baseTy, dmt->getName());
@@ -2804,8 +2802,9 @@ ASTMangler::dropProtocolFromAssociatedType(DependentMemberType *dmt) {
 }
 
 Type
-ASTMangler::dropProtocolsFromAssociatedTypes(Type type) {
-  if (!OptimizeProtocolNames || !CurGenericSignature)
+ASTMangler::dropProtocolsFromAssociatedTypes(Type type,
+                                             GenericSignature sig) {
+  if (!OptimizeProtocolNames || !sig)
     return type;
 
   if (!type->hasDependentMember())
@@ -2813,20 +2812,21 @@ ASTMangler::dropProtocolsFromAssociatedTypes(Type type) {
 
   return type.transform([&](Type t) -> Type {
     if (auto *dmt = dyn_cast<DependentMemberType>(t.getPointer()))
-      return dropProtocolFromAssociatedType(dmt);
+      return dropProtocolFromAssociatedType(dmt, sig);
     return t;
   });
 }
 
-void ASTMangler::appendAssociatedTypeName(DependentMemberType *dmt) {
+void ASTMangler::appendAssociatedTypeName(DependentMemberType *dmt,
+                                          GenericSignature sig) {
   if (auto assocTy = dmt->getAssocType()) {
     appendIdentifier(assocTy->getName().str());
 
     // If the base type is known to have a single protocol conformance
     // in the current generic context, then we don't need to disambiguate the
     // associated type name by protocol.
-    if (!OptimizeProtocolNames || !CurGenericSignature ||
-        CurGenericSignature->getRequiredProtocols(dmt->getBase()).size() > 1) {
+    if (!OptimizeProtocolNames || !sig ||
+        sig->getRequiredProtocols(dmt->getBase()).size() > 1) {
       appendAnyGenericType(assocTy->getProtocol());
     }
     return;
@@ -2857,8 +2857,9 @@ void ASTMangler::appendClosureComponents(Type Ty, unsigned discriminator,
   if (!Ty)
     Ty = ErrorType::get(parentContext->getASTContext());
 
+  auto Sig = parentContext->getGenericSignatureOfContext();
   Ty = Ty->mapTypeOutOfContext();
-  appendType(Ty->getCanonicalType());
+  appendType(Ty->getCanonicalType(), Sig);
   appendOperator(isImplicit ? "fu" : "fU", Index(discriminator));
 }
 
@@ -2914,7 +2915,6 @@ CanType ASTMangler::getDeclTypeForMangling(
 
   if (auto gft = dyn_cast<GenericFunctionType>(canTy)) {
     genericSig = gft.getGenericSignature();
-    CurGenericSignature = gft.getGenericSignature();
 
     canTy = CanFunctionType::get(gft.getParams(), gft.getResult(),
                                  gft->getExtInfo());
@@ -2941,10 +2941,14 @@ void ASTMangler::appendDeclType(const ValueDecl *decl,
   GenericSignature parentGenericSig;
   auto type = getDeclTypeForMangling(decl, genericSig, parentGenericSig);
 
+  auto sig = (genericSig
+              ? genericSig
+              : decl->getDeclContext()->getGenericSignatureOfContext());
+
   if (AnyFunctionType *FuncTy = type->getAs<AnyFunctionType>()) {
-    appendFunction(FuncTy, functionMangling, decl);
+    appendFunction(FuncTy, sig, functionMangling, decl);
   } else {
-    appendType(type, decl);
+    appendType(type, sig, decl);
   }
 
   // Mangle the generic signature, if any.
@@ -2996,12 +3000,10 @@ void ASTMangler::appendAccessorEntity(StringRef accessorKindCode,
                                       bool isStatic) {
   appendContextOf(decl);
   if (auto *varDecl = dyn_cast<VarDecl>(decl)) {
-    bindGenericParameters(varDecl->getDeclContext()->getGenericSignatureOfContext());
     appendDeclName(decl);
     appendDeclType(decl);
     appendOperator("v", accessorKindCode);
   } else if (auto *subscriptDecl = dyn_cast<SubscriptDecl>(decl)) {
-    bindGenericParameters(subscriptDecl->getGenericSignature());
     appendDeclType(decl);
 
     StringRef privateDiscriminator = getPrivateDiscriminatorIfNecessary(decl);
@@ -3057,13 +3059,12 @@ void ASTMangler::appendEntity(const ValueDecl *decl) {
 
 void
 ASTMangler::appendProtocolConformance(const ProtocolConformance *conformance) {
-  GenericSignature contextSig;
   auto topLevelSubcontext =
       conformance->getDeclContext()->getModuleScopeContext();
   Mod = topLevelSubcontext->getParentModule();
 
   auto conformingType = conformance->getType();
-  appendType(conformingType->getCanonicalType());
+  appendType(conformingType->getCanonicalType(), nullptr);
 
   appendProtocolName(conformance->getProtocol());
 
@@ -3088,7 +3089,7 @@ ASTMangler::appendProtocolConformance(const ProtocolConformance *conformance) {
   if (!conformingType->getAnyNominal())
     return;
 
-  contextSig =
+  auto contextSig =
     conformingType->getAnyNominal()->getGenericSignatureOfContext();
 
   if (GenericSignature Sig = conformance->getGenericSignature()) {
@@ -3144,7 +3145,8 @@ static unsigned conformanceRequirementIndex(
 }
 
 void ASTMangler::appendDependentProtocolConformance(
-                                            const ConformanceAccessPath &path) {
+                                            const ConformanceAccessPath &path,
+                                            GenericSignature sig) {
   ProtocolDecl *currentProtocol = nullptr;
   for (const auto &entry : path) {
     // After each step, update the current protocol to refer to where we
@@ -3156,11 +3158,11 @@ void ASTMangler::appendDependentProtocolConformance(
     // The first entry is the "root". Find this requirement in the generic
     // signature.
     if (!currentProtocol) {
-      appendType(entry.first);
+      appendType(entry.first, sig);
       appendProtocolName(entry.second);
       auto index =
         conformanceRequirementIndex(entry,
-                                    CurGenericSignature.getRequirements());
+                                    sig.getRequirements());
       // This is never an unknown index and so must be adjusted by 2 per ABI.
       appendOperator("HD", Index(index + 2));
       continue;
@@ -3184,7 +3186,7 @@ void ASTMangler::appendDependentProtocolConformance(
 
     // Associated conformance.
     // FIXME: Symbolic reference.
-    appendType(entry.first);
+    appendType(entry.first, sig);
     appendProtocolName(entry.second);
 
     // For resilient protocols, the index is unknown, so we use the special
@@ -3196,14 +3198,14 @@ void ASTMangler::appendDependentProtocolConformance(
 }
 
 void ASTMangler::appendAnyProtocolConformance(
-                                           CanGenericSignature genericSig,
+                                           GenericSignature genericSig,
                                            CanType conformingType,
                                            ProtocolConformanceRef conformance) {
   if (conformingType->isTypeParameter()) {
     assert(genericSig && "Need a generic signature to resolve conformance");
     auto path = genericSig->getConformanceAccessPath(conformingType,
                                                      conformance.getAbstract());
-    appendDependentProtocolConformance(path);
+    appendDependentProtocolConformance(path, genericSig);
   } else if (auto opaqueType = conformingType->getAs<OpaqueTypeArchetypeType>()) {
     GenericSignature opaqueSignature = opaqueType->getBoundSignature();
     GenericTypeParamType *opaqueTypeParam = opaqueSignature.getGenericParams().back();
@@ -3212,27 +3214,24 @@ void ASTMangler::appendAnyProtocolConformance(
                                                   conformance.getAbstract());
 
     // Append the conformance access path with the signature of the opaque type.
-    {
-      llvm::SaveAndRestore<CanGenericSignature> savedSignature(
-          CurGenericSignature, opaqueSignature.getCanonicalSignature());
-      appendDependentProtocolConformance(conformanceAccessPath);
-    }
-    appendType(conformingType);
+    appendDependentProtocolConformance(conformanceAccessPath, opaqueSignature);
+    appendType(conformingType, genericSig);
     appendOperator("HO");
   } else {
-    appendConcreteProtocolConformance(conformance.getConcrete());
+    appendConcreteProtocolConformance(conformance.getConcrete(), genericSig);
   }
 }
 
 void ASTMangler::appendConcreteProtocolConformance(
-                                      const ProtocolConformance *conformance) {
+                                      const ProtocolConformance *conformance,
+                                      GenericSignature sig) {
   auto module = conformance->getDeclContext()->getParentModule();
 
   // Conforming type.
   Type conformingType = conformance->getType();
   if (conformingType->hasArchetype())
     conformingType = conformingType->mapTypeOutOfContext();
-  appendType(conformingType->getCanonicalType());
+  appendType(conformingType->getCanonicalType(), sig);
 
   // Protocol conformance reference.
   appendProtocolConformanceRef(conformance->getRootConformance());
@@ -3250,7 +3249,7 @@ void ASTMangler::appendConcreteProtocolConformance(
       auto type = conditionalReq.getFirstType();
       if (type->hasArchetype())
         type = type->mapTypeOutOfContext();
-      CanType canType = type->getCanonicalType(CurGenericSignature);
+      CanType canType = type->getCanonicalType(sig);
       auto proto = conditionalReq.getProtocolDecl();
       
       ProtocolConformanceRef conformance;
@@ -3260,7 +3259,7 @@ void ASTMangler::appendConcreteProtocolConformance(
       } else {
         conformance = module->lookupConformance(canType, proto);
       }
-      appendAnyProtocolConformance(CurGenericSignature, canType, conformance);
+      appendAnyProtocolConformance(sig, canType, conformance);
       appendListSeparator(firstRequirement);
       break;
     }

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -36,7 +36,7 @@ const char *getManglingForWitness(swift::Demangle::ValueWitnessKind kind) {
 
 std::string IRGenMangler::mangleValueWitness(Type type, ValueWitness witness) {
   beginMangling();
-  appendType(type);
+  appendType(type, nullptr);
 
   const char *Code = nullptr;
   switch (witness) {
@@ -147,8 +147,7 @@ IRGenMangler::mangleTypeForReflection(IRGenModule &IGM,
                                       CanGenericSignature Sig,
                                       CanType Ty) {
   return withSymbolicReferences(IGM, [&]{
-    bindGenericParameters(Sig);
-    appendType(Ty);
+    appendType(Ty, Sig);
   });
 }
 
@@ -191,7 +190,7 @@ std::string IRGenMangler::mangleTypeForLLVMTypeName(CanType Ty) {
     appendProtocolName(P->getDecl(), /*allowStandardSubstitution=*/false);
     appendOperator("P");
   } else {
-    appendType(Ty);
+    appendType(Ty, nullptr);
   }
   return finalize();
 }
@@ -224,7 +223,7 @@ mangleProtocolForLLVMTypeName(ProtocolCompositionType *type) {
           ->getDeclaredType();
       }
 
-      appendType(CanType(superclass));
+      appendType(CanType(superclass), nullptr);
       appendOperator("Xc");
     } else if (layout.getLayoutConstraint()) {
       appendOperator("Xl");
@@ -288,10 +287,6 @@ std::string IRGenMangler::mangleSymbolNameForAssociatedConformanceWitness(
     Buffer << "default associated conformance";
   }
 
-  // appendProtocolConformance() sets CurGenericSignature; clear it out
-  // before calling appendAssociatedTypePath().
-  CurGenericSignature = nullptr;
-
   bool isFirstAssociatedTypeIdentifier = true;
   appendAssociatedTypePath(associatedType, isFirstAssociatedTypeIdentifier);
   appendProtocolName(proto);
@@ -309,7 +304,7 @@ std::string IRGenMangler::mangleSymbolNameForMangledMetadataAccessorString(
     appendGenericSignature(genericSig);
 
   if (type)
-    appendType(type);
+    appendType(type, genericSig);
   return finalize();
 }
 

--- a/lib/SIL/Utils/GenericSpecializationMangler.cpp
+++ b/lib/SIL/Utils/GenericSpecializationMangler.cpp
@@ -79,7 +79,7 @@ appendSubstitutions(GenericSignature sig, SubstitutionMap subs) {
   bool First = true;
   sig->forEachParam([&](GenericTypeParamType *ParamType, bool Canonical) {
     if (Canonical) {
-      appendType(Type(ParamType).subst(subs)->getCanonicalType());
+      appendType(Type(ParamType).subst(subs)->getCanonicalType(), nullptr);
       appendListSeparator(First);
     }
   });

--- a/lib/SILOptimizer/Utils/DifferentiationMangler.cpp
+++ b/lib/SILOptimizer/Utils/DifferentiationMangler.cpp
@@ -168,7 +168,7 @@ DifferentiationMangler::mangleDerivativeFunctionSubsetParametersThunk(
   // mangle the other parts.
   beginManglingWithoutPrefix();
   appendOperator(originalName);
-  appendType(toType);
+  appendType(toType, nullptr);
   auto kindCode = (char)kind;
   appendOperator("TJS", StringRef(&kindCode, 1));
   appendIndexSubset(fromParamIndices);
@@ -185,7 +185,7 @@ std::string DifferentiationMangler::mangleLinearMapSubsetParametersThunk(
     IndexSubset *fromParamIndices, IndexSubset *fromResultIndices,
     IndexSubset *toParamIndices) {
   beginMangling();
-  appendType(fromType);
+  appendType(fromType, nullptr);
   auto functionKindCode = (char)getAutoDiffFunctionKind(linearMapKind);
   appendOperator("TJS", StringRef(&functionKindCode, 1));
   appendIndexSubset(fromParamIndices);

--- a/lib/SILOptimizer/Utils/SpecializationMangler.cpp
+++ b/lib/SILOptimizer/Utils/SpecializationMangler.cpp
@@ -26,7 +26,7 @@ using namespace Mangle;
 
 std::string PartialSpecializationMangler::mangle() {
   beginMangling();
-  appendType(SpecializedFnTy);
+  appendType(SpecializedFnTy, nullptr);
   appendSpecializationOperator(isReAbstracted ? "Tp" : "TP");
   return finalize();
 }
@@ -193,7 +193,7 @@ FunctionSignatureSpecializationMangler::mangleClosureProp(SILInstruction *Inst) 
   // specializing.
   for (auto &Op : PAI->getArgumentOperands()) {
     SILType Ty = Op.get()->getType();
-    appendType(Ty.getASTType());
+    appendType(Ty.getASTType(), nullptr);
   }
 }
 

--- a/test/SILGen/Inputs/mangle_conformance_access_path_helper.swift
+++ b/test/SILGen/Inputs/mangle_conformance_access_path_helper.swift
@@ -1,0 +1,13 @@
+public protocol P {
+  associatedtype T
+}
+
+public protocol Q {
+  associatedtype U
+}
+
+public protocol R {
+  associatedtype U : Q where U.U : P
+}
+
+public struct G<T> {}

--- a/test/SILGen/mangle_conformance_access_path.swift
+++ b/test/SILGen/mangle_conformance_access_path.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %S/Inputs/mangle_conformance_access_path_helper.swift -emit-module-path %t/mangle_conformance_access_path_helper.swiftmodule
+// RUN: %target-swift-frontend -emit-silgen %s -I %t -requirement-machine=verify | %FileCheck %s
+
+import mangle_conformance_access_path_helper
+
+struct GG<T : P> {}
+
+// This is a retroactive conformance.
+extension G : P where T : P {}
+
+// The mangling of GG<G<_>> will contain a conformance access path
+// for (Y.U.U : P). This path is (Y : R)(Self.U.U : P). The 'Self.U.U'
+// uses the short mangling if 'Self.U' only conforms to a single
+// protocol. However, this check was being performed in the original
+// generic signature <X, Y where Y : R>, and not the generic signature
+// for the protocol R, which is <Self where Self : R>.
+
+// CHECK-LABEL: sil hidden [ossa] @$s30mangle_conformance_access_path3fooyyAA2GGVy0a1_b1_c1_D7_helper1GVy1U_AHQY_GAjE1PAAq_AE1RHD1_AH_AHQZAeKHA2__HCg_G_xq_tAeLR_r0_lF : $@convention(thin) <X, Y where Y : R> (GG<G<Y.U.U>>, @in_guaranteed X, @in_guaranteed Y) -> ()
+func foo<X, Y : R>(_: GG<G<Y.U.U>>, _: X, _: Y) {}


### PR DESCRIPTION
This pattern was really error-prone. I've fixed multiple bugs related
to CurGenericSignature not being set correctly at the right time, and
found another latent bug by inspection while doing this cleanup.