### PR TITLE
[SIL] Added defined flag to begin_borrow.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -3652,7 +3652,7 @@ begin_borrow
 
 ::
 
-   sil-instruction ::= 'begin_borrow' sil-operand
+   sil-instruction ::= 'begin_borrow' '[defined]'? sil-operand
 
    %1 = begin_borrow %0 : $T
 
@@ -3664,6 +3664,10 @@ in `Dead End Blocks`_. This `begin_borrow`_ and the lifetime ending uses of
 region in between this borrow and its lifetime ending use, ``%0`` must be
 live. This makes sense semantically since ``%1`` is modeling a new value with a
 dependent lifetime on ``%0``.
+
+The optional ``defined`` attribute specifies that the operand corresponds to a
+local variable in the Swift source, so special care must be taken when moving
+the end_borrow.
 
 This instruction is only valid in functions in Ownership SSA form.
 

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -713,10 +713,11 @@ public:
                       LoadBorrowInst(getSILDebugLocation(Loc), LV));
   }
 
-  BeginBorrowInst *createBeginBorrow(SILLocation Loc, SILValue LV) {
+  BeginBorrowInst *createBeginBorrow(SILLocation Loc, SILValue LV,
+                                     bool defined = false) {
     assert(!LV->getType().isAddress());
     return insert(new (getModule())
-                      BeginBorrowInst(getSILDebugLocation(Loc), LV));
+                      BeginBorrowInst(getSILDebugLocation(Loc), LV, defined));
   }
 
   /// Convenience function for creating a load_borrow on non-trivial values and

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1083,7 +1083,8 @@ void SILCloner<ImplClass>::visitBeginBorrowInst(BeginBorrowInst *Inst) {
 
   recordClonedInstruction(
       Inst, getBuilder().createBeginBorrow(getOpLocation(Inst->getLoc()),
-                                           getOpValue(Inst->getOperand())));
+                                           getOpValue(Inst->getOperand()), 
+                                           Inst->isDefined()));
 }
 
 template <typename ImplClass>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4027,13 +4027,20 @@ class BeginBorrowInst
                                   SingleValueInstruction> {
   friend class SILBuilder;
 
-  BeginBorrowInst(SILDebugLocation DebugLoc, SILValue LValue)
+  bool defined;
+
+  BeginBorrowInst(SILDebugLocation DebugLoc, SILValue LValue, bool defined)
       : UnaryInstructionBase(DebugLoc, LValue,
-                             LValue->getType().getObjectType()) {}
+                             LValue->getType().getObjectType()),
+        defined(defined) {}
 
 public:
   using EndBorrowRange =
       decltype(std::declval<ValueBase>().getUsersOfType<EndBorrowInst>());
+
+  /// Whether the borrow scope defined by this instruction corresponds to a
+  /// source-level VarDecl.
+  bool isDefined() const { return defined; }
 
   /// Return a range over all EndBorrow instructions for this BeginBorrow.
   EndBorrowRange getEndBorrows() const;

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1457,6 +1457,9 @@ public:
   }
 
   void visitBeginBorrowInst(BeginBorrowInst *LBI) {
+    if (LBI->isDefined()) {
+      *this << "[defined] ";
+    }
     *this << getIDAndType(LBI->getOperand());
   }
 

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3278,11 +3278,21 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
   case SILInstructionKind::BeginBorrowInst: {
     SourceLoc AddrLoc;
 
+    bool defined = false;
+    StringRef attributeName;
+
+    if (parseSILOptional(attributeName, *this)) {
+      if (attributeName.equals("defined"))
+        defined = true;
+      else
+        return true;
+    }
+
     if (parseTypedValueRef(Val, AddrLoc, B) ||
         parseSILDebugLocation(InstLoc, B))
       return true;
 
-    ResultVal = B.createBeginBorrow(InstLoc, Val);
+    ResultVal = B.createBeginBorrow(InstLoc, Val, defined);
     break;
   }
 

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1845,7 +1845,6 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   UNARY_INSTRUCTION(EndLifetime)
   UNARY_INSTRUCTION(CopyBlock)
   UNARY_INSTRUCTION(LoadBorrow)
-  UNARY_INSTRUCTION(BeginBorrow)
   REFCOUNTING_INSTRUCTION(StrongRetain)
   REFCOUNTING_INSTRUCTION(StrongRelease)
   UNARY_INSTRUCTION(IsUnique)
@@ -1854,6 +1853,17 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   UNARY_INSTRUCTION(ExtractExecutor)
 #undef UNARY_INSTRUCTION
 #undef REFCOUNTING_INSTRUCTION
+
+  case SILInstructionKind::BeginBorrowInst: {
+    assert(RecordKind == SIL_ONE_OPERAND && "Layout should be OneOperand.");
+    unsigned defined = Attr;
+    ResultInst = Builder.createBeginBorrow(
+        Loc,
+        getLocalValue(ValID, getSILType(MF->getType(TyID),
+                                        (SILValueCategory)TyCategory, Fn)),
+        defined == 1);
+    break;
+  }
 
   case SILInstructionKind::IsEscapingClosureInst: {
     assert(RecordKind == SIL_ONE_OPERAND && "Layout should be OneOperand.");

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1412,6 +1412,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       Attr = BCMI->isNative();
     } else if (auto *ECMI = dyn_cast<EndCOWMutationInst>(&SI)) {
       Attr = ECMI->doKeepUnique();
+    } else if (auto *BBI = dyn_cast<BeginBorrowInst>(&SI)) {
+      Attr = BBI->isDefined();
     }
     writeOneOperandLayout(SI.getKind(), Attr, SI.getOperand(0));
     break;

--- a/test/SIL/Parser/borrow.sil
+++ b/test/SIL/Parser/borrow.sil
@@ -27,3 +27,17 @@ bb0(%0 : $*Builtin.NativeObject, %1 : @guaranteed $Builtin.NativeObject):
   %4 = tuple()
   return %4 : $()
 }
+
+class C {}
+
+// CHECK-LABEL: sil [ossa] @foo
+// CHECK: begin_borrow [defined] {{%[^,]+}}
+// CHECK-LABEL: } // end sil function 'foo'
+sil [ossa] @foo : $@convention(thin) () -> () {
+  %instance = alloc_ref $C
+  %guaranteed_c = begin_borrow [defined] %instance : $C
+  end_borrow %guaranteed_c : $C
+  destroy_value %instance : $C
+  %res = tuple ()
+  return %res : $()
+}

--- a/test/SIL/Serialization/borrow.sil
+++ b/test/SIL/Serialization/borrow.sil
@@ -29,3 +29,17 @@ bb0(%0 : $*Builtin.NativeObject, %1 : @guaranteed $Builtin.NativeObject):
   %4 = tuple()
   return %4 : $()
 }
+
+class C {}
+
+// CHECK-LABEL: sil [ossa] @defined_borrow_test
+// CHECK: begin_borrow [defined] {{%[^,]+}}
+// CHECK-LABEL: } // end sil function 'defined_borrow_test'
+sil [ossa] @defined_borrow_test : $@convention(thin) () -> () {
+  %instance = alloc_ref $C
+  %guaranteed_c = begin_borrow [defined] %instance : $C
+  end_borrow %guaranteed_c : $C
+  destroy_value %instance : $C
+  %res = tuple ()
+  return %res : $()
+}

--- a/test/SIL/cloning.sil
+++ b/test/SIL/cloning.sil
@@ -28,3 +28,20 @@ bb0:
   return %2 : $()
 }
 
+sil [ossa] [always_inline] @callee_begin_borrow_defined : $@convention(thin) () -> () {
+  %instance = alloc_ref $X
+  %guaranteed_c = begin_borrow [defined] %instance : $X
+  end_borrow %guaranteed_c : $X
+  destroy_value %instance : $X
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_begin_borrow_defined
+// CHECK: begin_borrow [defined]
+// CHECK-LABEL: } // end sil function 'caller_begin_borrow_defined'
+sil [ossa] @caller_begin_borrow_defined : $@convention(thin) () -> () {
+  %callee_begin_borrow_defined = function_ref @callee_begin_borrow_defined : $@convention(thin) () -> ()
+  %res = apply %callee_begin_borrow_defined() : $@convention(thin) () -> ()
+  return %res : $()
+}


### PR DESCRIPTION
The new flag will be used to track whether a borrow scope corresponds to a source-level lexical scope.  Here, the flag is just added to the instruction and represented in textual and serialized SIL.
