### PR TITLE
[Distributed] always emit the distributed thunk

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1299,8 +1299,7 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
 
   if (AFD->isDistributed()) {
     auto thunk = SILDeclRef(AFD).asDistributed();
-    if (!hasFunction(thunk))
-      emitDistributedThunk(thunk);
+    emitDistributedThunk(thunk);
   }
 }
 


### PR DESCRIPTION
I don't really know why the `!hasFunction` was needed but I think it was copied from other code which was doing it this way.

With this guard though we would not emit the thunk in situations where it is necessary and cause missing symbols (missing SIL), like this:

```
 1465 // super Chatter.chatterJoined(room:chatter:)
 1466 sil @$s15FishyActorsDemo7ChatterC13chatterJoined4room0E0yAA8ChatRoomC_ACtFTd : $@convention(method) @async (@guaranteed ChatRoom, @guaranteed Chatter, @guaranteed Chatter) -> @error Error
 1467
```

where we'd want the full function:

```
// super Chatter.chatterJoined(room:chatter:)
sil [thunk] [ossa] @$s15FishyActorsDemo7ChatterC13chatterJoined4room0E0yAA8ChatRoomC_ACtFTd : $@convention(method) @async (@guaranteed ChatRoom, @guaranteed Chatter, @guaranteed Chatter) -> @error Error {
// %0 "room"                                      // users: %21, %24
// %1 "chatter"                                   // users: %21, %24
// %2 "self"                                      // users: %21, %20, %24, %3
bb0(%0 : @guaranteed $ChatRoom, %1 : @guaranteed $Chatter, %2 : @guaranteed $Chatter):
  %3 = init_existential_ref %2 : $Chatter : $Chatter, $AnyObject // user: %5
  // function_ref swift_distributed_actor_is_remote
```

removing the if solves the issue. I could not reproduce the issue in small files but only in a swiftpm project though, so not super sure how to add a test for it 🤔 

(functions from some silly example app)