### PR TITLE
COWOpts: handle debug_value instructions

### DIFF
--- a/lib/SILOptimizer/Transforms/COWOpts.cpp
+++ b/lib/SILOptimizer/Transforms/COWOpts.cpp
@@ -247,6 +247,7 @@ void COWOptsPass::collectEscapePoints(SILValue v,
       case SILInstructionKind::BeginCOWMutationInst:
       case SILInstructionKind::RefElementAddrInst:
       case SILInstructionKind::RefTailAddrInst:
+      case SILInstructionKind::DebugValueInst:
         break;
       case SILInstructionKind::BranchInst:
         collectEscapePoints(cast<BranchInst>(user)->getArgForOperand(use),

--- a/test/SILOptimizer/cow_opts.sil
+++ b/test/SILOptimizer/cow_opts.sil
@@ -36,6 +36,7 @@ sil @test_simple : $@convention(thin) (@owned Buffer) -> (Int, Builtin.Int1, @ow
 bb0(%0 : $Buffer):
   %e = end_cow_mutation %0 : $Buffer
   %addr = ref_element_addr [immutable] %e : $Buffer, #Buffer.i
+  debug_value %e : $Buffer, var, name "x"
   %i = load %addr : $*Int
   (%u, %b) = begin_cow_mutation %e : $Buffer
   %t = tuple (%i : $Int, %u : $Builtin.Int1, %b : $Buffer)


### PR DESCRIPTION
Don't let debug_value instructions bail the optimization.

This fixes a couple of performance regressions, which were introduced by adding more debug_value instructions (https://github.com/apple/swift/pull/38736).

rdar://82327743
