### PR TITLE
[Tests] Disable RemoteMirror/interop for remote run tests.

### DIFF
--- a/test/RemoteMirror/interop.swift
+++ b/test/RemoteMirror/interop.swift
@@ -2,6 +2,7 @@
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: remote_run
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %S/Inputs/interop.swift -emit-library -module-name InteropTest -o %t/%target-library-name(InteropTest)


### PR DESCRIPTION
This test isn't compatible with `remote_run`.

rdar://82124292
