### PR TITLE
Enable concurrency back deployment in CI configurations

### DIFF
--- a/stdlib/public/BackDeployConcurrency/CMakeLists.txt
+++ b/stdlib/public/BackDeployConcurrency/CMakeLists.txt
@@ -39,6 +39,8 @@ endforeach()
 # Build the concurrency library for back deployment.
 add_compile_definitions(SWIFT_CONCURRENCY_BACK_DEPLOYMENT)
 set(swift_concurrency_install_component back-deployment)
-set(swift_concurrency_options BACK_DEPLOYMENT_LIBRARY 5.5)
+set(swift_concurrency_options
+  BACK_DEPLOYMENT_LIBRARY 5.5
+  DARWIN_INSTALL_NAME_DIR "@rpath")
 
 add_subdirectory(../Concurrency stdlib/public/BackDeployConcurrency)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -408,7 +408,7 @@ config.swift_test_options = '-swift-version ' + swift_version
 
 # Define a macro for the next release OS version.
 # This macro can be used in code as `@available(SwiftStdlib 5.5, *)`.
-if 'back_deploy_concurrency' in lit_config.params:
+if 'back_deploy_concurrency' in config.available_features:
     swift_stdlib_macro = '\'SwiftStdlib 5.5:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0\''
 else:
     swift_stdlib_macro = '\'SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0\''
@@ -1913,12 +1913,17 @@ if not kIsWindows:
 	else:
 		config.available_features.add('use_os_stdlib')
 		os_stdlib_path = ''
+		concurrency_back_deploy_path = ''
 		if run_vendor == 'apple':
 			#If we get swift-in-the-OS for non-Apple platforms, add a condition here
 			os_stdlib_path = "/usr/lib/swift"
 			if run_os == 'maccatalyst':
 			    os_stdlib_path = "/System/iOSSupport/usr/lib/swift:/usr/lib/swift"
-		all_stdlib_path = os.path.pathsep.join((os_stdlib_path, target_stdlib_path))
+			if 'back_deploy_concurrency' in config.available_features:
+			  concurrency_back_deploy_path = os.path.join(os.path.dirname(swift_obj_root), os.path.basename(swift_obj_root).replace("swift-", "backdeployconcurrency-"), 'lib', 'swift-5.5', run_os)
+
+		all_stdlib_path = os.path.pathsep.join((os_stdlib_path, concurrency_back_deploy_path, target_stdlib_path))
+
 		lit_config.note('Testing with the standard libraries coming from the OS ' + all_stdlib_path)
 		config.target_run = (
 			"/usr/bin/env "

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -37,6 +37,7 @@ build-swift-stdlib-unittest-extra
 
 install-llvm
 install-swift
+install-back-deploy-concurrency
 
 skip-test-cmark
 
@@ -1245,6 +1246,7 @@ install-swiftevolve
 install-playgroundsupport
 install-libcxx
 install-sourcekit-lsp
+install-back-deploy-concurrency
 
 install-destdir=%(install_destdir)s
 
@@ -2497,6 +2499,7 @@ ios
 tvos
 watchos
 back-deploy-concurrency
+install-back-deploy-concurrency
 compiler-vendor=apple
 darwin-install-extract-symbols
 darwin-toolchain-alias=swift

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -14,10 +14,10 @@
 # Buildbots for Darwin OSes
 #===------------------------------------------------------------------------===#
 [preset: mixin_buildbot_install_components]
-swift-install-components=compiler;clang-builtin-headers;stdlib;sdk-overlay;parser-lib;editor-integration;tools;toolchain-tools;testsuite-tools;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers;
+swift-install-components=back-deployment;compiler;clang-builtin-headers;stdlib;sdk-overlay;parser-lib;editor-integration;tools;toolchain-tools;testsuite-tools;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers;
 
 [preset: mixin_buildbot_install_components_with_clang]
-swift-install-components=compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;parser-lib;toolchain-tools;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
+swift-install-components=back-deployment;compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;parser-lib;toolchain-tools;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
 llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;dsymutil
 
 [preset: mixin_buildbot_trunk_base]
@@ -39,6 +39,9 @@ install-llvm
 install-swift
 
 skip-test-cmark
+
+# Build concurrency back-deployment binaries
+back-deploy-concurrency
 
 # Path to the root of the installation filesystem.
 install-destdir=%(install_destdir)s
@@ -1197,6 +1200,9 @@ playgroundsupport
 libcxx
 indexstore-db
 sourcekit-lsp
+
+# Build concurrency back-deployment binaries
+back-deploy-concurrency
 
 # Don't generate the SwiftSyntax gyb files. Instead verify that up-to-date ones
 # are checked in.
@@ -2490,6 +2496,7 @@ build-subdir=compat_macos
 ios
 tvos
 watchos
+back-deploy-concurrency
 compiler-vendor=apple
 darwin-install-extract-symbols
 darwin-toolchain-alias=swift
@@ -2499,7 +2506,7 @@ darwin-toolchain-display-name=Swift Development Snapshot
 darwin-toolchain-name=swift-DEVELOPMENT-SNAPSHOT
 darwin-toolchain-version=3.999.999
 llvm-install-components=libclang;libclang-headers;dsymutil
-swift-install-components=compiler;clang-builtin-headers;stdlib;sdk-overlay;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
+swift-install-components=back-deployment;compiler;clang-builtin-headers;stdlib;sdk-overlay;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
 symbols-package=%(symbols_package)s
 install-symroot=%(install_symroot)s
 

--- a/utils/build-toolchain
+++ b/utils/build-toolchain
@@ -56,10 +56,12 @@ case $(uname -s) in
   Darwin)
     SWIFT_PACKAGE=buildbot_osx_package,no_test
     OS_SUFFIX=osx
+    BUILD_SUBDIR=buildbot_osx
   ;;
   Linux)
     SWIFT_PACKAGE=buildbot_linux,no_test
     OS_SUFFIX=linux
+    BUILD_SUBDIR=buildbot_linux
   ;;
   *)
     echo "Unrecognised platform $(uname -s)"
@@ -77,8 +79,10 @@ while [ $# -ne 0 ]; do
     -t|--test)
       if [ "$(uname -s)" == "Linux" ]; then
         SWIFT_PACKAGE=buildbot_linux
+        BUILD_SUBDIR=buildbot_linux
       else
         SWIFT_PACKAGE=buildbot_osx_package
+        BUILD_SUBDIR=buildbot_osx
       fi
   ;;
     --distcc)
@@ -137,7 +141,7 @@ DISPLAY_NAME_SHORT="Local Swift Development Snapshot"
 DISPLAY_NAME="${DISPLAY_NAME_SHORT} ${YEAR}-${MONTH}-${DAY}"
 
 SWIFT_INSTALLABLE_PACKAGE="${RESULT_DIR}/${ARCHIVE}"
-SWIFT_INSTALL_DIR="${RESULT_DIR}/swift-nightly-install"
+SWIFT_INSTALL_DIR="${RESULT_DIR}/${BUILD_SUBDIR}"
 SWIFT_INSTALL_SYMROOT="${RESULT_DIR}/swift-nightly-symroot"
 SWIFT_TOOLCHAIN_DIR="/Library/Developer/Toolchains/${TOOLCHAIN_NAME}.xctoolchain"
 SYMBOLS_PACKAGE="${RESULT_DIR}/${SYM_ARCHIVE}"

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -599,6 +599,9 @@ def create_argument_parser():
     option(['--back-deploy-concurrency'], toggle_true('build_backdeployconcurrency'),
            help='build back-deployment support for concurrency')
 
+    option(['--install-back-deploy-concurrency'], toggle_true('install_backdeployconcurrency'),
+           help='install back-deployment support libraries for concurrency')
+
     option(['--libcxx'], toggle_true('build_libcxx'),
            help='build libcxx')
 

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -599,7 +599,8 @@ def create_argument_parser():
     option(['--back-deploy-concurrency'], toggle_true('build_backdeployconcurrency'),
            help='build back-deployment support for concurrency')
 
-    option(['--install-back-deploy-concurrency'], toggle_true('install_backdeployconcurrency'),
+    option(['--install-back-deploy-concurrency'],
+           toggle_true('install_backdeployconcurrency'),
            help='install back-deployment support libraries for concurrency')
 
     option(['--libcxx'], toggle_true('build_libcxx'),

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -169,6 +169,7 @@ EXPECTED_DEFAULTS = {
     'only_executable_test': False,
     'only_non_executable_test': False,
     'infer_dependencies': False,
+    'install_backdeployconcurrency': False,
     'install_prefix': targets.install_prefix(),
     'install_symroot': None,
     'install_destdir': None,
@@ -476,7 +477,8 @@ EXPECTED_OPTIONS = [
               dest='test_early_swift_driver', value=False),
 
     SetTrueOption('--back-deploy-concurrency', dest='build_backdeployconcurrency'),
-    SetTrueOption('--install-back-deploy-concurrency', dest='install_backdeployconcurrency'),
+    SetTrueOption('--install-back-deploy-concurrency',
+                  dest='install_backdeployconcurrency'),
     SetTrueOption('--benchmark'),
     SetTrueOption('--clean'),
     SetTrueOption('--dry-run'),

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -476,6 +476,7 @@ EXPECTED_OPTIONS = [
               dest='test_early_swift_driver', value=False),
 
     SetTrueOption('--back-deploy-concurrency', dest='build_backdeployconcurrency'),
+    SetTrueOption('--install-back-deploy-concurrency', dest='install_backdeployconcurrency'),
     SetTrueOption('--benchmark'),
     SetTrueOption('--clean'),
     SetTrueOption('--dry-run'),

--- a/utils/swift_build_support/swift_build_support/products/backdeployconcurrency.py
+++ b/utils/swift_build_support/swift_build_support/products/backdeployconcurrency.py
@@ -137,7 +137,7 @@ class BackDeployConcurrency(cmake_product.CMakeProduct):
         raise RuntimeError("Testing not implemented")
 
     def should_install(self, host_target):
-        return False
+        return self.args.install_backdeployconcurrency
 
     def install(self, host_target):
         destdir = self.host_install_destdir(host_target) + self.args.install_prefix


### PR DESCRIPTION
Enable concurrency back deployment in the CI configurations so we can test it more thoroughly and build toolchains