### PR TITLE
Concurrency: add missing Sendable requirements, conformances, and address other warnings

### DIFF
--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -175,15 +175,15 @@ public struct AsyncStream<Element> {
     let storage: _AsyncStreamCriticalStorage<Optional<() async -> Element?>>
       = .create(produce)
     self.produce = {
-      return await Task.withCancellationHandler {
-        storage.value = nil
-        onCancel?()
-      } operation: {
+      return await withTaskCancellationHandler {
         guard let result = await storage.value?() else {
           storage.value = nil
           return nil
         }
         return result
+      } onCancel: {
+        storage.value = nil
+        onCancel?()
       }
     }
   }

--- a/stdlib/public/Concurrency/AsyncStreamBuffer.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBuffer.swift
@@ -543,7 +543,7 @@ extension AsyncThrowingStream {
 }
 
 // this is used to store closures; which are two words
-final class _AsyncStreamCriticalStorage<Contents> {
+final class _AsyncStreamCriticalStorage<Contents>: UnsafeSendable {
   var _value: Contents
   private init(_doNotCallMe: ()) {
     fatalError("_AsyncStreamCriticalStorage must be initialized by create")

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -45,7 +45,7 @@ import Swift
 @available(SwiftStdlib 5.5, *)
 extension MainActor {
   /// Execute the given body closure on the main actor.
-  public static func run<T>(
+  public static func run<T: Sendable>(
     resultType: T.Type = T.self,
     body: @MainActor @Sendable () throws -> T
   ) async rethrows -> T {

--- a/stdlib/public/Concurrency/SourceCompatibilityShims.swift
+++ b/stdlib/public/Concurrency/SourceCompatibilityShims.swift
@@ -155,11 +155,11 @@ public func async<T>(
 @available(SwiftStdlib 5.5, *)
 extension Task where Success == Never, Failure == Never {
   @available(*, deprecated, message: "`Task.Group` was replaced by `ThrowingTaskGroup` and `TaskGroup` and will be removed shortly.")
-  public typealias Group<TaskResult> = ThrowingTaskGroup<TaskResult, Error>
+  public typealias Group<TaskResult: Sendable> = ThrowingTaskGroup<TaskResult, Error>
 
   @available(*, deprecated, message: "`Task.withGroup` was replaced by `withThrowingTaskGroup` and `withTaskGroup` and will be removed shortly.")
   @_alwaysEmitIntoClient
-  public static func withGroup<TaskResult, BodyResult>(
+  public static func withGroup<TaskResult: Sendable, BodyResult>(
       resultType: TaskResult.Type,
       returning returnType: BodyResult.Type = BodyResult.self,
       body: (inout Task.Group<TaskResult>) async throws -> BodyResult

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -756,7 +756,7 @@ func _enqueueJobGlobalWithDelay(_ delay: UInt64, _ task: Builtin.Job)
 public func _asyncMainDrainQueue() -> Never
 
 @available(SwiftStdlib 5.5, *)
-public func _runAsyncMain(_ asyncFun: @escaping () async throws -> ()) {
+public func _runAsyncMain(@_unsafeSendable _ asyncFun: @escaping () async throws -> ()) {
   Task.detached {
     do {
 #if !os(Windows)

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -32,8 +32,6 @@ public func withTaskCancellationHandler<T>(
   operation: () async throws -> T,
   onCancel handler: @Sendable () -> Void
 ) async rethrows -> T {
-  let task = Builtin.getCurrentAsyncTask()
-
   // unconditionally add the cancellation record to the task.
   // if the task was already cancelled, it will be executed right away.
   let record = _taskAddCancellationHandler(handler: handler)

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -188,6 +188,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   // the type-checker that this property-wrapper never wants to have an enclosing
   // instance (it is impossible to declare a property wrapper inside the `Never`
   // type).
+  @available(*, unavailable, message: "property wrappers cannot be instance members")
   public static subscript(
     _enclosingInstance object: Never,
     wrapped wrappedKeyPath: ReferenceWritableKeyPath<Never, Value>,


### PR DESCRIPTION
A few fixes to the concurrency library that address warnings:
* Add `Sendable` constraint to `MainActor.run` and a few of the back-deployment shims.
* Make `_AsyncStreamCriticalStorage` conform to `Sendable` (this is `@unchecked` because it's a class that handles its own locking).
* Make `_runAsyncMain` take an `@_unsafeSendable` parameter. There's a compiler bug here still, which results in a spurious warning.
* Switch the `AsyncStream` implementation over to `withTaskCancellationHandler`.
* Make the unusable property wrapper subscript for task locals unavailable.