### PR TITLE
[DebugInfo] PATCH 2/3: Duplicate logics regarding debug_value_addr

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -927,8 +927,8 @@ public:
   DebugValueInst *createDebugValue(SILLocation Loc, SILValue src,
                                    SILDebugVariable Var,
                                    bool poisonRefs = false);
-  DebugValueAddrInst *createDebugValueAddr(SILLocation Loc, SILValue src,
-                                           SILDebugVariable Var);
+  DebugValueInst *createDebugValueAddr(SILLocation Loc, SILValue src,
+                                       SILDebugVariable Var);
 
   /// Create a debug_value_addr if \p src is an address; a debug_value if not.
   SILInstruction *emitDebugDescription(SILLocation Loc, SILValue src,

--- a/include/swift/SIL/SILDebugInfoExpression.h
+++ b/include/swift/SIL/SILDebugInfoExpression.h
@@ -162,6 +162,15 @@ public:
     appendElements(Tail.Elements);
   }
 
+  void prependElements(llvm::ArrayRef<SILDIExprElement> NewElements) {
+    Elements.insert(Elements.begin(),
+                    NewElements.begin(), NewElements.end());
+  }
+
+  void eraseElement(const_iterator It) {
+    Elements.erase(It);
+  }
+
   /// The iterator for SILDIExprOperand
   class op_iterator {
     friend class SILDebugInfoExpression;

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4672,6 +4672,8 @@ class DebugValueInst final
   static DebugValueInst *create(SILDebugLocation DebugLoc, SILValue Operand,
                                 SILModule &M, SILDebugVariable Var,
                                 bool poisonRefs);
+  static DebugValueInst *createAddr(SILDebugLocation DebugLoc, SILValue Operand,
+                                    SILModule &M, SILDebugVariable Var);
 
   SIL_DEBUG_VAR_SUPPLEMENT_TRAILING_OBJS_IMPL()
 
@@ -4711,6 +4713,17 @@ public:
   bool hasAddrVal() const {
     return getOperand()->getType().isAddress();
   }
+
+  /// An utility to check if \p I is DebugValueInst and
+  /// whether it's associated with address type SSA value.
+  static DebugValueInst *hasAddrVal(SILInstruction *I) {
+    auto *DVI = dyn_cast_or_null<DebugValueInst>(I);
+    return DVI && DVI->hasAddrVal()? DVI : nullptr;
+  }
+
+  /// Whether the attached di-expression (if there is any) starts
+  /// with `op_deref`.
+  bool exprStartsWithDeref() const;
 
   /// True if all references within this debug value will be overwritten with a
   /// poison sentinel at this point in the program. This is used in debug builds

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4706,6 +4706,12 @@ public:
       *getTrailingObjects<const SILDebugScope *>() = NewDS;
   }
 
+  /// Whether the SSA value associated with the current debug_value
+  /// instruction has an address type.
+  bool hasAddrVal() const {
+    return getOperand()->getType().isAddress();
+  }
+
   /// True if all references within this debug value will be overwritten with a
   /// poison sentinel at this point in the program. This is used in debug builds
   /// when shortening non-trivial value lifetimes to ensure the debugger cannot

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2410,6 +2410,9 @@ bool IRGenDebugInfoImpl::buildDebugInfoExpression(
       if (!handleFragmentDIExpr(ExprOperand, Operands))
         return false;
       break;
+    case SILDIExprOperator::Dereference:
+      Operands.push_back(llvm::dwarf::DW_OP_deref);
+      break;
     default:
       llvm_unreachable("Unrecognized operator");
     }

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -4770,14 +4770,11 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
   } else
     return;
 
-  // Calculate the indirection
-  IndirectionKind Indirection = DirectValue;
-  if (IsInCoro)
-    Indirection = IsAddrVal ? CoroIndirectValue : CoroDirectValue;
-  else if (IsAddrVal && !isa<AllocStackInst>(SILVal))
-    Indirection = IndirectValue;
+  // Since debug_value is expressing indirection explicitly via op_deref,
+  // we're not using either IndirectValue or CoroIndirectValue here.
+  IndirectionKind Indirection = IsInCoro? CoroDirectValue : DirectValue;
 
-  // Put the value into a stack slot at -Onone.
+  // Put the value into a shadow-copy stack slot at -Onone.
   llvm::SmallVector<llvm::Value *, 8> Copy;
   if (IsAddrVal)
     Copy.emplace_back(

--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -569,7 +569,6 @@ void SILBuilder::emitDestructureValueOperation(
 DebugValueInst *SILBuilder::createDebugValue(SILLocation Loc, SILValue src,
                                              SILDebugVariable Var,
                                              bool poisonRefs) {
-  assert(isLoadableOrOpaque(src->getType()));
   // Debug location overrides cannot apply to debug value instructions.
   DebugLocOverrideRAII LocOverride{*this, None};
   return insert(
@@ -577,12 +576,12 @@ DebugValueInst *SILBuilder::createDebugValue(SILLocation Loc, SILValue src,
                            poisonRefs));
 }
 
-DebugValueAddrInst *SILBuilder::createDebugValueAddr(SILLocation Loc,
-                                                     SILValue src,
-                                                     SILDebugVariable Var) {
+DebugValueInst *SILBuilder::createDebugValueAddr(SILLocation Loc,
+                                                 SILValue src,
+                                                 SILDebugVariable Var) {
   // Debug location overrides cannot apply to debug addr instructions.
   DebugLocOverrideRAII LocOverride{*this, None};
-  return insert(DebugValueAddrInst::create(getSILDebugLocation(Loc), src,
+  return insert(DebugValueInst::createAddr(getSILDebugLocation(Loc), src,
                                            getModule(), Var));
 }
 

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1179,31 +1179,37 @@ public:
 
   void printDebugVar(Optional<SILDebugVariable> Var,
                      const SourceManager *SM = nullptr) {
-    if (!Var || Var->Name.empty())
+    if (!Var)
       return;
-    if (Var->Constant)
-      *this << ", let";
-    else
-      *this << ", var";
 
-    if ((Var->Loc || Var->Scope) && SM) {
-      *this << ", (name \"" << Var->Name << '"';
-      if (Var->Loc)
-        printDebugLocRef(*Var->Loc, *SM);
-      if (Var->Scope)
-        printDebugScopeRef(Var->Scope, *SM);
-      *this << ")";
-    } else
-      *this << ", name \"" << Var->Name << '"';
+    if (!Var->Name.empty()) {
+      if (Var->Constant)
+        *this << ", let";
+      else
+        *this << ", var";
 
-    if (Var->ArgNo)
-      *this << ", argno " << Var->ArgNo;
-    if (Var->Implicit)
-      *this << ", implicit";
-    if (Var->Type) {
-      *this << ", type ";
-      Var->Type->print(PrintState.OS, PrintState.ASTOptions);
+      if ((Var->Loc || Var->Scope) && SM) {
+        *this << ", (name \"" << Var->Name << '"';
+        if (Var->Loc)
+          printDebugLocRef(*Var->Loc, *SM);
+        if (Var->Scope)
+          printDebugScopeRef(Var->Scope, *SM);
+        *this << ")";
+      } else
+        *this << ", name \"" << Var->Name << '"';
+
+      if (Var->ArgNo)
+        *this << ", argno " << Var->ArgNo;
+      if (Var->Implicit)
+        *this << ", implicit";
+      if (Var->Type) {
+        *this << ", type ";
+        Var->Type->print(PrintState.OS, PrintState.ASTOptions);
+      }
     }
+    // Although it's rare in real-world use cases, but during testing,
+    // sometimes we want to print out di-expression, even the debug
+    // variable name is empty.
     if (Var->DIExpr)
       printDebugInfoExpression(Var->DIExpr);
   }

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1649,7 +1649,10 @@ bool SILParser::parseSILDebugInfoExpression(SILDebugInfoExpression &DIExpr) {
     return true;
 
   // All operators that we currently support
-  static const SILDIExprOperator AllOps[] = {SILDIExprOperator::Fragment};
+  static const SILDIExprOperator AllOps[] = {
+    SILDIExprOperator::Dereference,
+    SILDIExprOperator::Fragment
+  };
 
   do {
     P.consumeToken();

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -1629,6 +1629,10 @@ swift::getSingleInitAllocStackUse(AllocStackInst *asi,
       if (destroyingUses)
         destroyingUses->push_back(use);
       continue;
+    case SILInstructionKind::DebugValueInst:
+      if (cast<DebugValueInst>(user)->hasAddrVal())
+        continue;
+      break;
     case SILInstructionKind::DeallocStackInst:
     case SILInstructionKind::LoadBorrowInst:
     case SILInstructionKind::DebugValueAddrInst:

--- a/lib/SIL/Utils/MemoryLocations.cpp
+++ b/lib/SIL/Utils/MemoryLocations.cpp
@@ -362,6 +362,10 @@ bool MemoryLocations::analyzeLocationUsesRecursively(SILValue V, unsigned locIdx
         if (!cast<LoadBorrowInst>(user)->getUsersOfType<BranchInst>().empty())
           return false;
         break;
+      case SILInstructionKind::DebugValueInst:
+        if (cast<DebugValueInst>(user)->hasAddrVal())
+          break;
+        return false;
       case SILInstructionKind::InjectEnumAddrInst:
       case SILInstructionKind::SelectEnumAddrInst:
       case SILInstructionKind::ExistentialMetatypeInst:

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -613,6 +613,11 @@ void MemoryLifetimeVerifier::checkBlock(SILBasicBlock *block, Bits &bits) {
       case SILInstructionKind::DebugValueAddrInst:
         requireBitsSet(bits, I.getOperand(0), &I);
         break;
+      case SILInstructionKind::DebugValueInst:
+        if (cast<DebugValueInst>(&I)->hasAddrVal() &&
+            cast<DebugValueInst>(&I)->exprStartsWithDeref())
+          requireBitsSet(bits, I.getOperand(0), &I);
+        break;
       case SILInstructionKind::UncheckedTakeEnumDataAddrInst: {
         // Note that despite the name, unchecked_take_enum_data_addr does _not_
         // "take" the payload of the Swift.Optional enum. This is a terrible

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -545,6 +545,13 @@ struct ImmutableAddressUseVerifier {
       case SILInstructionKind::SwitchEnumAddrInst:
       case SILInstructionKind::SelectEnumAddrInst:
         break;
+      case SILInstructionKind::DebugValueInst:
+        if (cast<DebugValueInst>(inst)->hasAddrVal())
+          break;
+        else {
+          llvm::errs() << "Unhandled, unexpected instruction: " << *inst;
+          llvm_unreachable("invoking standard assertion failure");
+        }
       case SILInstructionKind::AddressToPointerInst:
         // We assume that the user is attempting to do something unsafe since we
         // are converting to a raw pointer. So just ignore this use.

--- a/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
@@ -124,6 +124,10 @@ void AccessSummaryAnalysis::processArgument(FunctionInfo *info,
       processPartialApply(info, argumentIndex, cast<PartialApplyInst>(user),
                           operand, order);
       break;
+    case SILInstructionKind::DebugValueInst:
+      if (DebugValueInst::hasAddrVal(user))
+        break;
+      LLVM_FALLTHROUGH;
     default:
       // FIXME: These likely represent scenarios in which we're not generating
       // begin access markers. Ignore these for now. But we really should

--- a/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
+++ b/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
@@ -374,6 +374,10 @@ static bool hasEscapingUses(SILValue address, int &numChecks) {
       case SILInstructionKind::EndAccessInst:
         // Those instructions have no result and cannot escape the address.
         break;
+      case SILInstructionKind::DebugValueInst:
+        if (DebugValueInst::hasAddrVal(user))
+          break;
+        return true;
       case SILInstructionKind::ApplyInst:
       case SILInstructionKind::TryApplyInst:
       case SILInstructionKind::BeginApplyInst:

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -514,6 +514,10 @@ bool SILCombiner::optimizeStackAllocatedEnum(AllocStackInst *AS) {
       case SILInstructionKind::InjectEnumAddrInst:
         // We'll check init_enum_addr below.
         break;
+      case SILInstructionKind::DebugValueInst:
+        if (DebugValueInst::hasAddrVal(user))
+          break;
+        return false;
       case SILInstructionKind::InitEnumDataAddrInst: {
         auto *ieda = cast<InitEnumDataAddrInst>(user);
         auto *el = ieda->getElement();
@@ -599,6 +603,12 @@ bool SILCombiner::optimizeStackAllocatedEnum(AllocStackInst *AS) {
         eraseInstFromFunction(*svi);
         break;
       }
+      case SILInstructionKind::DebugValueInst:
+        if (DebugValueInst::hasAddrVal(user)) {
+          eraseInstFromFunction(*user);
+          break;
+        }
+        LLVM_FALLTHROUGH;
       default:
         llvm_unreachable("unexpected alloc_stack user");
     }

--- a/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
@@ -1045,7 +1045,9 @@ void DSEContext::processStoreInst(SILInstruction *I, DSEKind Kind) {
 
 void DSEContext::processDebugValueAddrInstForGenKillSet(SILInstruction *I) {
   BlockState *S = getBlockState(I);
-  SILValue Mem = cast<DebugValueAddrInst>(I)->getOperand();
+  SILValue Mem = isa<DebugValueAddrInst>(I)?
+    cast<DebugValueAddrInst>(I)->getOperand() :
+    cast<DebugValueInst>(I)->getOperand();
   for (unsigned i = 0; i < S->LocationNum; ++i) {
     if (!S->BBMaxStoreSet.test(i))
       continue;
@@ -1058,7 +1060,9 @@ void DSEContext::processDebugValueAddrInstForGenKillSet(SILInstruction *I) {
 
 void DSEContext::processDebugValueAddrInstForDSE(SILInstruction *I) {
   BlockState *S = getBlockState(I);
-  SILValue Mem = cast<DebugValueAddrInst>(I)->getOperand();
+  SILValue Mem = isa<DebugValueAddrInst>(I)?
+    cast<DebugValueAddrInst>(I)->getOperand() :
+    cast<DebugValueInst>(I)->getOperand();
   for (unsigned i = 0; i < S->LocationNum; ++i) {
     if (!S->isTrackingLocation(S->BBWriteSetMid, i))
       continue;
@@ -1140,7 +1144,7 @@ void DSEContext::processInstruction(SILInstruction *I, DSEKind Kind) {
     processLoadInst(I, Kind);
   } else if (isa<StoreInst>(I)) {
     processStoreInst(I, Kind);
-  } else if (isa<DebugValueAddrInst>(I)) {
+  } else if (isa<DebugValueAddrInst>(I) || DebugValueInst::hasAddrVal(I)) {
     processDebugValueAddrInst(I, Kind);
   } else if (I->mayReadFromMemory()) {
     processUnknownReadInst(I, Kind);

--- a/lib/SILOptimizer/Transforms/StringOptimization.cpp
+++ b/lib/SILOptimizer/Transforms/StringOptimization.cpp
@@ -441,6 +441,10 @@ isStringStoreToIdentifyableObject(SILInstruction *inst) {
       case SILInstructionKind::DeallocStackInst:
       case SILInstructionKind::LoadInst:
         break;
+      case SILInstructionKind::DebugValueInst:
+        if (DebugValueInst::hasAddrVal(user))
+          break;
+        LLVM_FALLTHROUGH;
       default:
         if (!mayWriteToIdentifyableObject(user)) {
           // We don't handle user. It is some instruction which may write to

--- a/lib/SILOptimizer/Transforms/TempLValueOpt.cpp
+++ b/lib/SILOptimizer/Transforms/TempLValueOpt.cpp
@@ -273,7 +273,7 @@ void TempLValueOptPass::combineCopyAndDestroy(CopyAddrInst *copyInst) {
 
   // Check if the destroy_addr is after the copy_addr and if there are no
   // memory accesses between them.
-  SmallVector<DebugValueAddrInst *, 4> debugInsts;
+  SmallVector<SILInstruction *, 4> debugInsts;
   for (auto iter = std::next(copyInst->getIterator());
        iter != block->end(); ++iter) {
     SILInstruction *inst = &*iter;
@@ -288,6 +288,9 @@ void TempLValueOptPass::combineCopyAndDestroy(CopyAddrInst *copyInst) {
       return;
     }
     if (auto *debugInst = dyn_cast<DebugValueAddrInst>(inst)) {
+      if (debugInst->getOperand() == copyInst->getSrc())
+        debugInsts.push_back(debugInst);
+    } else if(auto *debugInst = DebugValueInst::hasAddrVal(inst)) {
       if (debugInst->getOperand() == copyInst->getSrc())
         debugInsts.push_back(debugInst);
     }

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -1422,7 +1422,8 @@ ConstExprFunctionState::initializeAddressFromSingleWriter(SILValue addr) {
     // Ignore markers, loads, and other things that aren't stores to this stack
     // value.
     if (isa<LoadInst>(user) || isa<DeallocStackInst>(user) ||
-        isa<DestroyAddrInst>(user) || isa<DebugValueAddrInst>(user))
+        isa<DestroyAddrInst>(user) || isa<DebugValueAddrInst>(user) ||
+        DebugValueInst::hasAddrVal(user))
       continue;
 
     // TODO: Allow BeginAccess/EndAccess users.

--- a/lib/SILOptimizer/Utils/Existential.cpp
+++ b/lib/SILOptimizer/Utils/Existential.cpp
@@ -87,6 +87,7 @@ static SILInstruction *getStackInitInst(SILValue allocStackAddr,
     // Ignore instructions which don't write to the stack location.
     // Also ignore ASIUser (only kicks in if ASIUser is the original apply).
     if (isa<DeallocStackInst>(User) || isa<DebugValueAddrInst>(User) ||
+        DebugValueInst::hasAddrVal(User) ||
         isa<DestroyAddrInst>(User) || isa<WitnessMethodInst>(User) ||
         isa<DeinitExistentialAddrInst>(User) ||
         isa<OpenExistentialAddrInst>(User) || User == ASIUser) {

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -124,6 +124,18 @@ void GenericCloner::populateCloned() {
                                             *DVAI->getVarInfo());
               getBuilder().setCurrentDebugScope(oldScope);
               break;
+            } else if (auto *DVI = DebugValueInst::hasAddrVal(ArgUse->getUser())) {
+              auto *oldScope = getBuilder().getCurrentDebugScope();
+              getBuilder().setCurrentDebugScope(
+                  remapScope(DVI->getDebugScope()));
+              auto VarInfo = DVI->getVarInfo();
+              assert(VarInfo && VarInfo->DIExpr &&
+                     "No DebugVarInfo or no DIExpr operand?");
+              // Drop the op_deref
+              VarInfo->DIExpr.eraseElement(VarInfo->DIExpr.element_begin());
+              getBuilder().createDebugValue(DVI->getLoc(), NewArg, *VarInfo);
+              getBuilder().setCurrentDebugScope(oldScope);
+              break;
             }
           }
 

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -759,6 +759,12 @@ getConcreteValueOfExistentialBoxAddr(SILValue addr, SILInstruction *ignoreUser) 
     case SILInstructionKind::DebugValueAddrInst:
     case SILInstructionKind::LoadInst:
       break;
+    case SILInstructionKind::DebugValueInst:
+      if (!DebugValueInst::hasAddrVal(stackUser)) {
+        if (stackUser != ignoreUser)
+          return SILValue();
+      }
+      break;
     case SILInstructionKind::StoreInst: {
       auto *store = cast<StoreInst>(stackUser);
       assert(store->getSrc() != stackLoc && "cannot store an address");

--- a/test/DebugInfo/debug_info_expression.sil
+++ b/test/DebugInfo/debug_info_expression.sil
@@ -24,9 +24,9 @@ bb0:
   // CHECK: llvm.dbg.declare(metadata {{.*}}* %[[SMALL_STRUCT]], metadata ![[SMALL_VAR_DECL_MD:[0-9]+]]
   %3 = struct_element_addr %2 : $*MyStruct, #MyStruct.x, loc "file.swift":9:17, scope 1
   // CHECK: %[[FIELD_X:.*]] = getelementptr {{.*}} %[[MY_STRUCT]]
-  // CHECK-SIL: debug_value_addr %{{[0-9]+}} : $*Builtin.Int64
-  // CHECK-SIL-SAME:            (name "my_struct", loc "file.swift":8:9, scope {{[0-9]+}})
-  // CHECK-SIL-SAME             type $MyStruct, expr op_fragment:#MyStruct.x
+  // CHECK-SIL: debug_value %{{[0-9]+}} : $*Builtin.Int64
+  // CHECK-SIL-SAME:        (name "my_struct", loc "file.swift":8:9, scope {{[0-9]+}})
+  // CHECK-SIL-SAME         type $MyStruct, expr op_deref:op_fragment:#MyStruct.x
   debug_value_addr %3 : $*Builtin.Int64, var, (name "my_struct", loc "file.swift":8:9, scope 1), type $MyStruct, expr op_fragment:#MyStruct.x, loc "file.swift":9:17, scope 1
   // CHECK: llvm.dbg.value(metadata {{.*}}* %[[FIELD_X]], metadata ![[VAR_DECL_MD]]
   // CHECK-SAME:           !DIExpression(DW_OP_deref, DW_OP_LLVM_fragment, 0, 64)

--- a/test/DebugInfo/debug_value_addr.swift
+++ b/test/DebugInfo/debug_value_addr.swift
@@ -5,7 +5,7 @@
 // instructions.
 
 // CHECK-SIL: sil hidden @$s16debug_value_addr4testyyxlF
-// CHECK-SIL: debug_value_addr %0 : $*T, let, name "t"
+// CHECK-SIL: debug_value %0 : $*T, let, name "t", {{.*}}, expr op_deref
 
 // CHECK: define {{.*}}$s16debug_value_addr4testyyxlF
 // CHECK: entry:

--- a/test/DebugInfo/inlined-generics-basic.swift
+++ b/test/DebugInfo/inlined-generics-basic.swift
@@ -44,7 +44,7 @@ public class C<R> {
   // IR-LABEL: define {{.*}} @"$s1A1CC1fyyqd__lF"
 #sourceLocation(file: "f.swift", line: 1)
   public func f<S>(_ s: S) {
-    // SIL: debug_value_addr %0 : $*S, let, name "s", argno 1,{{.*}} scope [[F]]
+    // SIL: debug_value %0 : $*S, let, name "s", argno 1, expr op_deref, {{.*}} scope [[F]]
     // SIL: function_ref {{.*}}yes{{.*}} scope [[F1G1]]
     // SIL: function_ref {{.*}}use{{.*}} scope [[F1G3H]]
     // IR: dbg.value(metadata %swift.type* %S, metadata ![[MD_1_0:[0-9]+]]

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -168,7 +168,7 @@ class SuperSub : SuperBase {
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s22big_types_corner_cases10MUseStructV16superclassMirrorAA03BigF0VSgvg"(%T22big_types_corner_cases9BigStructVSg* noalias nocapture sret({{.*}}) %0, %T22big_types_corner_cases10MUseStructV* noalias nocapture swiftself dereferenceable({{.*}}) %1)
 // CHECK: [[ALLOC:%.*]] = alloca %T22big_types_corner_cases9BigStructVSg
 // CHECK: [[LOAD:%.*]] = load %swift.refcounted*, %swift.refcounted** %.callInternalLet.data
-// CHECK: call swiftcc void %7(%T22big_types_corner_cases9BigStructVSg* noalias nocapture sret({{.*}}) [[ALLOC]], %swift.refcounted* swiftself [[LOAD]])
+// CHECK: call swiftcc void %{{[0-9]+}}(%T22big_types_corner_cases9BigStructVSg* noalias nocapture sret({{.*}}) [[ALLOC]], %swift.refcounted* swiftself [[LOAD]])
 // CHECK: ret void
 public struct MUseStruct {
   var x = BigStruct()

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -635,10 +635,10 @@ func acceptsBuiltinNativeObject(_ ref: inout Builtin.NativeObject?) {}
 // native
 // CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_BoSgzF"({{%.*}}* nocapture dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
-// CHECK-NEXT: bitcast [[BUILTIN_NATIVE_OBJECT_TY]]* %0 to %swift.refcounted**
-// CHECK-NEXT: load %swift.refcounted*, %swift.refcounted** %1
-// CHECK-NEXT: call i1 @swift_isUniquelyReferenced_native(%swift.refcounted* %2)
-// CHECK-NEXT: ret i1 %3
+// CHECK:      %[[BITCAST_RC:.+]] = bitcast [[BUILTIN_NATIVE_OBJECT_TY]]* %0 to %swift.refcounted**
+// CHECK:      %[[LD_RC:.+]] = load %swift.refcounted*, %swift.refcounted** %[[BITCAST_RC]]
+// CHECK-NEXT: %[[RET:.+]] = call i1 @swift_isUniquelyReferenced_native(%swift.refcounted* %[[LD_RC]])
+// CHECK-NEXT: ret i1 %[[RET]]
 func isUnique(_ ref: inout Builtin.NativeObject?) -> Bool {
   return Builtin.isUnique(&ref)
 }
@@ -646,9 +646,9 @@ func isUnique(_ ref: inout Builtin.NativeObject?) -> Bool {
 // native nonNull
 // CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_BozF"(%swift.refcounted** nocapture dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
-// CHECK-NEXT: load %swift.refcounted*, %swift.refcounted** %0
-// CHECK-NEXT: call i1 @swift_isUniquelyReferenced_nonNull_native(%swift.refcounted* %1)
-// CHECK-NEXT: ret i1 %2
+// CHECK:      %[[LD_RC:.+]] = load %swift.refcounted*, %swift.refcounted** %0
+// CHECK:      %[[RET:.+]] = call i1 @swift_isUniquelyReferenced_nonNull_native(%swift.refcounted* %[[LD_RC]])
+// CHECK-NEXT: ret i1 %[[RET]]
 func isUnique(_ ref: inout Builtin.NativeObject) -> Bool {
   return Builtin.isUnique(&ref)
 }
@@ -659,7 +659,7 @@ func acceptsAnyObject(_ ref: inout Builtin.AnyObject?) {}
 // ObjC
 // CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_yXlSgzF"({{%.*}}* nocapture dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
-// CHECK-NEXT: [[ADDR:%.+]] = getelementptr inbounds [[OPTIONAL_ANYOBJECT_TY]], [[OPTIONAL_ANYOBJECT_TY]]* %0, i32 0, i32 0
+// CHECK:      [[ADDR:%.+]] = getelementptr inbounds [[OPTIONAL_ANYOBJECT_TY]], [[OPTIONAL_ANYOBJECT_TY]]* %0, i32 0, i32 0
 // CHECK-NEXT: [[CASTED:%.+]] = bitcast {{.+}}* [[ADDR]] to [[UNKNOWN_OBJECT:%objc_object|%swift\.refcounted]]**
 // CHECK-NEXT: [[REF:%.+]] = load [[UNKNOWN_OBJECT]]*, [[UNKNOWN_OBJECT]]** [[CASTED]]
 // CHECK-objc-NEXT: [[RESULT:%.+]] = call i1 @swift_isUniquelyReferenced{{(NonObjC)?}}([[UNKNOWN_OBJECT]]* [[REF]])
@@ -673,8 +673,8 @@ func isUnique(_ ref: inout Builtin.AnyObject?) -> Bool {
 // CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_yXlzF"
 // CHECK-SAME:    (%AnyObject* nocapture dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
-// CHECK-NEXT: [[ADDR:%.+]] = getelementptr inbounds %AnyObject, %AnyObject* %0, i32 0, i32 0
-// CHECK-NEXT: [[REF:%.+]] = load [[UNKNOWN_OBJECT]]*, [[UNKNOWN_OBJECT]]** [[ADDR]]
+// CHECK:      [[ADDR:%.+]] = getelementptr inbounds %AnyObject, %AnyObject* %0, i32 0, i32 0
+// CHECK:      [[REF:%.+]] = load [[UNKNOWN_OBJECT]]*, [[UNKNOWN_OBJECT]]** [[ADDR]]
 // CHECK-objc-NEXT: [[RESULT:%.+]] = call i1 @swift_isUniquelyReferenced{{(NonObjC)?}}_nonNull([[UNKNOWN_OBJECT]]* [[REF]])
 // CHECK-native-NEXT: [[RESULT:%.+]] = call i1 @swift_isUniquelyReferenced_nonNull_native([[UNKNOWN_OBJECT]]* [[REF]])
 // CHECK-NEXT: ret i1 [[RESULT]]
@@ -685,9 +685,9 @@ func isUnique(_ ref: inout Builtin.AnyObject) -> Bool {
 // BridgeObject nonNull
 // CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_BbzF"(%swift.bridge** nocapture dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
-// CHECK-NEXT: load %swift.bridge*, %swift.bridge** %0
-// CHECK-NEXT: call i1 @swift_isUniquelyReferenced{{(NonObjC)?}}_nonNull_bridgeObject(%swift.bridge* %1)
-// CHECK-NEXT: ret i1 %2
+// CHECK:      %[[LD:.+]] = load %swift.bridge*, %swift.bridge** %0
+// CHECK:      %[[RET:.+]] = call i1 @swift_isUniquelyReferenced{{(NonObjC)?}}_nonNull_bridgeObject(%swift.bridge* %[[LD]])
+// CHECK-NEXT: ret i1 %[[RET]]
 func isUnique(_ ref: inout Builtin.BridgeObject) -> Bool {
   return Builtin.isUnique(&ref)
 }
@@ -701,10 +701,10 @@ func assumeTrue(_ x: Builtin.Int1) {
 // BridgeObject nonNull
 // CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins15isUnique_nativeyBi1_BbzF"(%swift.bridge** nocapture dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
-// CHECK-NEXT: bitcast %swift.bridge** %0 to %swift.refcounted**
-// CHECK-NEXT: load %swift.refcounted*, %swift.refcounted** %1
-// CHECK-NEXT: call i1 @swift_isUniquelyReferenced_nonNull_native(%swift.refcounted* %2)
-// CHECK-NEXT: ret i1 %3
+// CHECK:      %[[BC:.+]] = bitcast %swift.bridge** %0 to %swift.refcounted**
+// CHECK:      %[[LD:.+]] = load %swift.refcounted*, %swift.refcounted** %[[BC]]
+// CHECK-NEXT: %[[RET:.+]] = call i1 @swift_isUniquelyReferenced_nonNull_native(%swift.refcounted* %[[LD]])
+// CHECK-NEXT: ret i1 %[[RET]]
 func isUnique_native(_ ref: inout Builtin.BridgeObject) -> Bool {
   return Builtin.isUnique_native(&ref)
 }

--- a/test/IRGen/enum_resilience.swift
+++ b/test/IRGen/enum_resilience.swift
@@ -165,7 +165,7 @@ public func constructResilientEnumPayload(_ s: Size) -> Medium {
 // CHECK-NEXT: call void @llvm.lifetime.start.p0i8({{(i32|i64)}} -1, i8* [[ALLOCA]])
 // CHECK-NEXT: [[ENUM_STORAGE:%.*]] = bitcast i8* [[ALLOCA]] to %swift.opaque*
 
-// CHECK-NEXT: [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 2
+// CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 2
 // CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
 // CHECK-NEXT: [[WITNESS_FN:%initializeWithCopy]] = bitcast i8* [[WITNESS]] to %swift.opaque* (%swift.opaque*, %swift.opaque*, %swift.type*)*
 // CHECK-arm64e-NEXT: ptrtoint i8** [[WITNESS_ADDR]] to i64

--- a/test/IRGen/frozen_protocols.swift
+++ b/test/IRGen/frozen_protocols.swift
@@ -43,7 +43,7 @@ public struct ConformsToFrozenProtocol : FrozenProtocol {
 // CHECK: [[ADDR:%.*]] = getelementptr inbounds i8*, i8** %T.OtherFrozenProtocol, i32 1
 // CHECK: [[FN:%.*]] = load i8*, i8** [[ADDR]]
 // CHECK: [[CAST:%.*]] = bitcast i8* [[FN]] to void (%swift.opaque*, %swift.type*, i8**)*
-// CHECK: call swiftcc void %3(%swift.opaque* noalias nocapture swiftself %0, %swift.type* %T, i8** %T.OtherFrozenProtocol)
+// CHECK: call swiftcc void [[CAST]](%swift.opaque* noalias nocapture swiftself %0, %swift.type* %T, i8** %T.OtherFrozenProtocol)
 // CHECK: ret void
 
 // @_fixed_layout protocols still emit method dispatch thunks though, which

--- a/test/IRGen/generic_tuples.swift
+++ b/test/IRGen/generic_tuples.swift
@@ -25,7 +25,7 @@ func dup<T>(_ x: T) -> (T, T) { var x = x; return (x,x) }
 // CHECK: [[X_TMP:%.*]] = bitcast i8* [[X_ALLOCA]] to %swift.opaque*
 // Debug info shadow copy.
 // CHECK-NEXT: store i8* [[X_ALLOCA]]
-// CHECK-NEXT: [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 2
+// CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 2
 // CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]], align 8
 // CHECK-NEXT: [[INITIALIZE_WITH_COPY:%.*]] = bitcast i8* [[WITNESS]] to [[OPAQUE]]* ([[OPAQUE]]*, [[OPAQUE]]*, [[TYPE]]*)*
 // CHECK-NEXT: [[X:%.*]] = call [[OPAQUE]]* [[INITIALIZE_WITH_COPY]]([[OPAQUE]]* noalias [[X_TMP]], [[OPAQUE]]* noalias {{.*}}, [[TYPE]]* %T)

--- a/test/IRGen/struct_resilience.swift
+++ b/test/IRGen/struct_resilience.swift
@@ -63,7 +63,7 @@ public func functionWithResilientTypesSize(_ s: __owned Size, f: (__owned Size) 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s17struct_resilience35functionWithResilientTypesRectangleyy010resilient_A00G0VF"(%T16resilient_struct9RectangleV* noalias nocapture %0)
 public func functionWithResilientTypesRectangle(_ r: Rectangle) {
 // CHECK: entry:
-// CHECK-NEXT: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$s16resilient_struct9RectangleVMa"([[INT]] 0)
+// CHECK:      [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$s16resilient_struct9RectangleVMa"([[INT]] 0)
 // CHECK-NEXT: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
 // CHECK-NEXT: [[METADATA_ADDR:%.*]] = bitcast %swift.type* [[METADATA]] to i32*
 // CHECK-NEXT: [[FIELD_OFFSET_PTR:%.*]] = getelementptr inbounds i32, i32* [[METADATA_ADDR]], [[INT]] [[IDX:2|4|6]]
@@ -202,7 +202,7 @@ public func resilientAny(s : ResilientWeakRef) {
 // CHECK: entry:
 // CHECK: [[ANY:%.*]] = alloca %Any
 // CHECK: [[META:%.*]] = call swiftcc %swift.metadata_response @"$s16resilient_struct16ResilientWeakRefVMa"([[INT]] 0)
-// CHECK: [[META2:%.*]] = extractvalue %swift.metadata_response %3, 0
+// CHECK: [[META2:%.*]] = extractvalue %swift.metadata_response [[META]], 0
 // CHECK: [[TYADDR:%.*]] = getelementptr inbounds %Any, %Any* [[ANY]], i32 0, i32 1
 // CHECK: store %swift.type* [[META2]], %swift.type** [[TYADDR]]
 // CHECK: [[BITCAST:%.*]] = bitcast %Any* [[ANY]] to %__opaque_existential_type_0*

--- a/test/Interop/Cxx/class/type-classification-non-trivial-irgen.swift
+++ b/test/Interop/Cxx/class/type-classification-non-trivial-irgen.swift
@@ -73,7 +73,7 @@ public func testStructWithCopyConstructorAndSubobjectCopyConstructorAndValue()
 // CHECK: [[VAL:%.*]] = getelementptr inbounds %TSo33StructWithCopyConstructorAndValueV, %TSo33StructWithCopyConstructorAndValueV* %0, i32 0, i32 0
 // CHECK: [[VAL_VAL:%.*]] = getelementptr inbounds %Ts5Int32V, %Ts5Int32V* [[VAL]], i32 0, i32 0
 // CHECK: [[LHS:%.*]] = load i32, i32* [[VAL_VAL]]
-// CHECK: [[OUT:%.*]] = icmp eq i32 %1, 42
+// CHECK: [[OUT:%.*]] = icmp eq i32 [[LHS]], 42
 // CHECK: ret i1 [[OUT]]
 public func test(obj: StructWithCopyConstructorAndValue) -> Bool {
   return obj.value == 42

--- a/test/SIL/Distributed/distributed_actor_default_init_sil.swift
+++ b/test/SIL/Distributed/distributed_actor_default_init_sil.swift
@@ -12,7 +12,7 @@ distributed actor SimpleEmptyDistributedActor {
 // CHECK: // %0 "transport" // users: %15, %7, %6, %2
 // CHECK: // %1 "self" // users: %5, %12, %4, %16, %3
 // CHECK: bb0(%0 : $*ActorTransport, %1 : $SimpleEmptyDistributedActor):
-// CHECK:  debug_value_addr %0 : $*ActorTransport, let, name "transport", argno 1, implicit // id: %2
+// CHECK:  debug_value %0 : $*ActorTransport, let, name "transport", argno 1, implicit, expr op_deref // id: %2
 // CHECK:  debug_value %1 : $SimpleEmptyDistributedActor, let, name "self", argno 2, implicit // id: %3
 // CHECK:  %4 = builtin "initializeDefaultActor"(%1 : $SimpleEmptyDistributedActor) : $()
 

--- a/test/SIL/Distributed/distributed_actor_user_transport_init_sil.swift
+++ b/test/SIL/Distributed/distributed_actor_user_transport_init_sil.swift
@@ -15,7 +15,7 @@ distributed actor SimpleUserDefinedInitDistributedActor {
 // CHECK: // %1 "other" // user: %4
 // CHECK: // %2 "self" // users: %7, %14, %6, %18, %5
 // CHECK: bb0(%0 : $*ActorTransport, %1 : $Int, %2 : $SimpleUserDefinedInitDistributedActor):
-// CHECK:  debug_value_addr %0 : $*ActorTransport, let, name "transport", argno 1 // id: %3
+// CHECK:  debug_value %0 : $*ActorTransport, let, name "transport", argno 1, expr op_deref // id: %3
 // CHECK:  debug_value %1 : $Int, let, name "other", argno 2 // id: %4
 // CHECK:  debug_value %2 : $SimpleUserDefinedInitDistributedActor, let, name "self", argno 3, implicit // id: %5
 // CHECK:  %6 = builtin "initializeDefaultActor"(%2 : $SimpleUserDefinedInitDistributedActor) : $()
@@ -48,7 +48,7 @@ distributed actor SimpleUserDefinedInitDistributedActor {
 // CHECK: // %2 "self" // users: %7, %14, %6, %18, %5
 // CHECK: bb0(%0 : $Int, %1 : $*ActorTransport, %2 : $SimpleUserDefinedInitDistributedActor):
 // CHECK:  debug_value %0 : $Int, let, name "other", argno 1 // id: %3
-// CHECK:  debug_value_addr %1 : $*ActorTransport, let, name "theTransport", argno 2 // id: %4
+// CHECK:  debug_value %1 : $*ActorTransport, let, name "theTransport", argno 2, expr op_deref // id: %4
 // CHECK:  debug_value %2 : $SimpleUserDefinedInitDistributedActor, let, name "self", argno 3, implicit // id: %5
 // CHECK:  %6 = builtin "initializeDefaultActor"(%2 : $SimpleUserDefinedInitDistributedActor) : $()
 

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -1271,7 +1271,7 @@ sil @debug_value : $@convention(thin) (Int, @in P, AnyObject) -> () {
 bb0(%0 : $Int, %1 : $*P, %2 : $AnyObject):
   debug_value %0 : $Int         // CHECK: debug_value %0 : $Int
   debug_value [poison] %2 : $AnyObject // CHECK: debug_value [poison] %2 : $AnyObject
-  debug_value_addr %1 : $*P     // CHECK: debug_value_addr %1 : $*P
+  debug_value_addr %1 : $*P     // CHECK: debug_value %1 : $*P, expr op_deref
   unreachable
 }
 

--- a/test/SIL/Parser/undef.sil
+++ b/test/SIL/Parser/undef.sil
@@ -48,7 +48,7 @@ bb0:
 
   // CHECK: debug_value undef : $()
   debug_value undef : $()
-  // CHECK: debug_value_addr undef : $*()
+  // CHECK: debug_value undef : $*(), expr op_deref
   debug_value_addr undef : $*()
 
   // Accessing memory

--- a/test/SILGen/address_only_types.swift
+++ b/test/SILGen/address_only_types.swift
@@ -16,7 +16,7 @@ protocol Unloadable {
 // CHECK-LABEL: sil hidden [ossa] @$s18address_only_types0a1_B9_argument{{[_0-9a-zA-Z]*}}F
 func address_only_argument(_ x: Unloadable) {
   // CHECK: bb0([[XARG:%[0-9]+]] : $*Unloadable):
-  // CHECK: debug_value_addr [[XARG]]
+  // CHECK: debug_value [[XARG]] {{.*}} expr op_deref
   // CHECK-NEXT: tuple
   // CHECK-NEXT: return
 }
@@ -31,7 +31,7 @@ func address_only_ignored_argument(_: Unloadable) {
 // CHECK-LABEL: sil hidden [ossa] @$s18address_only_types0a1_B7_return{{[_0-9a-zA-Z]*}}F
 func address_only_return(_ x: Unloadable, y: Int) -> Unloadable {
   // CHECK: bb0([[RET:%[0-9]+]] : $*Unloadable, [[XARG:%[0-9]+]] : $*Unloadable, [[YARG:%[0-9]+]] : $Builtin.Int64):
-  // CHECK-NEXT: debug_value_addr [[XARG]] : $*Unloadable, let, name "x"
+  // CHECK-NEXT: debug_value [[XARG]] : $*Unloadable, let, name "x", {{.*}} expr op_deref
   // CHECK-NEXT: debug_value [[YARG]] : $Builtin.Int64, let, name "y"
   // CHECK-NEXT: copy_addr [[XARG]] to [initialization] [[RET]]
   // CHECK-NEXT: [[VOID:%[0-9]+]] = tuple ()
@@ -115,7 +115,7 @@ func address_only_call_1_ignore_return() {
 // CHECK-LABEL: sil hidden [ossa] @$s18address_only_types0a1_B7_call_2{{[_0-9a-zA-Z]*}}F
 func address_only_call_2(_ x: Unloadable) {
   // CHECK: bb0([[XARG:%[0-9]+]] : $*Unloadable):
-  // CHECK: debug_value_addr [[XARG]] : $*Unloadable
+  // CHECK: debug_value [[XARG]] : $*Unloadable, {{.*}} expr op_deref
   some_address_only_function_2(x)
   // CHECK: [[FUNC:%[0-9]+]] = function_ref @$s18address_only_types05some_a1_B11_function_2{{[_0-9a-zA-Z]*}}F
   // CHECK: apply [[FUNC]]([[XARG]])
@@ -197,7 +197,7 @@ func address_only_assignment_from_temp_to_property() {
 // CHECK-LABEL: sil hidden [ossa] @$s18address_only_types0a1_B31_assignment_from_lv_to_property{{[_0-9a-zA-Z]*}}F
 func address_only_assignment_from_lv_to_property(_ v: Unloadable) {
   // CHECK: bb0([[VARG:%[0-9]+]] : $*Unloadable):
-  // CHECK: debug_value_addr [[VARG]] : $*Unloadable
+  // CHECK: debug_value [[VARG]] : $*Unloadable, {{.*}} expr op_deref
   // CHECK: [[TEMP:%[0-9]+]] = alloc_stack $Unloadable
   // CHECK: copy_addr [[VARG]] to [initialization] [[TEMP]]
   // CHECK: [[SETTER:%[0-9]+]] = function_ref @$s18address_only_types11global_propAA10Unloadable_pvs

--- a/test/SILGen/addressors.swift
+++ b/test/SILGen/addressors.swift
@@ -203,7 +203,7 @@ struct D : Subscriptable {
 // SILGEN: bb0([[VALUE:%.*]] : $Int32, [[I:%.*]] : $Int32, [[SELF:%.*]] : $*D):
 // SILGEN:   debug_value [[VALUE]] : $Int32
 // SILGEN:   debug_value [[I]] : $Int32
-// SILGEN:   debug_value_addr [[SELF]]
+// SILGEN:   debug_value [[SELF]]{{.*}} expr op_deref
 // SILGEN:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[SELF]] : $*D
 // SILGEN:   [[T0:%.*]] = function_ref @$s10addressors1DVys5Int32VAEciau{{.*}}
 // SILGEN:   [[PTR:%.*]] = apply [[T0]]([[I]], [[ACCESS]])

--- a/test/SILGen/didset_oldvalue_not_accessed_silgen.swift
+++ b/test/SILGen/didset_oldvalue_not_accessed_silgen.swift
@@ -7,7 +7,7 @@ class Foo<T> {
   var value: T {
     // CHECK-LABEL: sil private [ossa] @$s35didset_oldvalue_not_accessed_silgen3FooC5valuexvW : $@convention(method) <T> (@guaranteed Foo<T>) -> ()
     // CHECK: debug_value %0 : $Foo<T>, let, name "self", argno {{[0-9]+}}
-    // CHECK-NOT: debug_value_addr %0 : $*T, let, name "oldValue", argno {{[0-9]+}}
+    // CHECK-NOT: debug_value %0 : $*T, let, name "oldValue", argno {{[0-9]+}}, {{.*}} expr op_deref
     didSet { print("didSet called!") }
   }
 
@@ -20,7 +20,7 @@ let foo = Foo(value: "Hello")
 // Foo.value.setter //
 
 // CHECK-LABEL: sil hidden [ossa] @$s35didset_oldvalue_not_accessed_silgen3FooC5valuexvs : $@convention(method) <T> (@in T, @guaranteed Foo<T>) -> ()
-// CHECK: debug_value_addr [[VALUE:%.*]] : $*T, let, name "value", argno {{[0-9+]}}
+// CHECK: debug_value [[VALUE:%.*]] : $*T, let, name "value", argno {{[0-9+]}}, {{.*}} expr op_deref
 // CHECK-NEXT: debug_value [[SELF:%.*]] : $Foo<T>, let, name "self", argno {{[0-9+]}}
 // CHECK-NEXT: [[ALLOC_STACK:%.*]] = alloc_stack $T
 // CHECK-NEXT: copy_addr [[VALUE]] to [initialization] [[ALLOC_STACK]] : $*T

--- a/test/SILGen/expressions.swift
+++ b/test/SILGen/expressions.swift
@@ -545,7 +545,7 @@ func dontLoadIgnoredLValueForceUnwrap(_ a: inout NonTrivialStruct?) -> NonTrivia
 }
 // CHECK-LABEL: dontLoadIgnoredLValueForceUnwrap
 // CHECK: bb0(%0 : $*Optional<NonTrivialStruct>):
-// CHECK-NEXT: debug_value_addr %0
+// CHECK-NEXT: debug_value %0{{.*}} expr op_deref
 // CHECK-NEXT: [[READ:%[0-9]+]] = begin_access [read] [unknown] %0
 // CHECK-NEXT: switch_enum_addr [[READ]] : $*Optional<NonTrivialStruct>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb1
 // CHECK: bb1:
@@ -561,7 +561,7 @@ func dontLoadIgnoredLValueDoubleForceUnwrap(_ a: inout NonTrivialStruct??) -> No
 }
 // CHECK-LABEL: dontLoadIgnoredLValueDoubleForceUnwrap
 // CHECK: bb0(%0 : $*Optional<Optional<NonTrivialStruct>>):
-// CHECK-NEXT: debug_value_addr %0
+// CHECK-NEXT: debug_value %0{{.*}} expr op_deref
 // CHECK-NEXT: [[READ:%[0-9]+]] = begin_access [read] [unknown] %0
 // CHECK-NEXT: switch_enum_addr [[READ]] : $*Optional<Optional<NonTrivialStruct>>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb1
 // CHECK: bb1:
@@ -582,7 +582,7 @@ func loadIgnoredLValueForceUnwrap(_ a: inout NonTrivialStruct) -> NonTrivialStru
 }
 // CHECK-LABEL: loadIgnoredLValueForceUnwrap
 // CHECK: bb0(%0 : $*NonTrivialStruct):
-// CHECK-NEXT: debug_value_addr %0
+// CHECK-NEXT: debug_value %0{{.*}} expr op_deref
 // CHECK-NEXT: [[READ:%[0-9]+]] = begin_access [read] [unknown] %0
 // CHECK-NEXT: [[BORROW:%[0-9]+]] = load_borrow [[READ]]
 // CHECK-NEXT: // function_ref NonTrivialStruct.x.getter
@@ -603,7 +603,7 @@ func loadIgnoredLValueThroughForceUnwrap(_ a: inout NonTrivialStruct?) -> NonTri
 }
 // CHECK-LABEL: loadIgnoredLValueThroughForceUnwrap
 // CHECK: bb0(%0 : $*Optional<NonTrivialStruct>):
-// CHECK-NEXT: debug_value_addr %0
+// CHECK-NEXT: debug_value %0{{.*}} expr op_deref
 // CHECK-NEXT: [[READ:%[0-9]+]] = begin_access [read] [unknown] %0
 // CHECK-NEXT: switch_enum_addr [[READ]] : $*Optional<NonTrivialStruct>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb1
 // CHECK: bb1:
@@ -629,7 +629,7 @@ func evaluateIgnoredKeyPathExpr(_ s: inout NonTrivialStruct, _ kp: WritableKeyPa
 }
 // CHECK-LABEL: evaluateIgnoredKeyPathExpr
 // CHECK: bb0(%0 : $*NonTrivialStruct, %1 : @guaranteed $WritableKeyPath<NonTrivialStruct, Int>):
-// CHECK-NEXT: debug_value_addr %0
+// CHECK-NEXT: debug_value %0{{.*}} expr op_deref
 // CHECK-NEXT: debug_value %1
 // CHECK-NEXT: [[KP_TEMP:%[0-9]+]] = copy_value %1
 // CHECK-NEXT: [[S_READ:%[0-9]+]] = begin_access [read] [unknown] %0

--- a/test/SILGen/generic_tuples.swift
+++ b/test/SILGen/generic_tuples.swift
@@ -5,7 +5,7 @@
 func dup<T>(_ x: T) -> (T, T) { return (x,x) }
 // CHECK-LABEL:      sil hidden [ossa] @$s14generic_tuples3dup{{[_0-9a-zA-Z]*}}F
 // CHECK:      ([[RESULT_0:%.*]] : $*T, [[RESULT_1:%.*]] : $*T, [[XVAR:%.*]] : $*T):
-// CHECK-NEXT: debug_value_addr [[XVAR]] : $*T, let, name "x"
+// CHECK-NEXT: debug_value [[XVAR]] : $*T, let, name "x", {{.*}} expr op_deref
 // CHECK-NEXT: copy_addr [[XVAR]] to [initialization] [[RESULT_0]]
 // CHECK-NEXT: copy_addr [[XVAR]] to [initialization] [[RESULT_1]]
 // CHECK-NEXT: [[T0:%.*]] = tuple ()

--- a/test/SILGen/lazy_property_with_observers.swift
+++ b/test/SILGen/lazy_property_with_observers.swift
@@ -140,7 +140,7 @@ foo1.bar = 2
 // CHECK-LABEL: sil hidden [ossa] @$s28lazy_property_with_observers4Foo1V3barSivs : $@convention(method) (Int, @inout Foo1) -> () {
 // CHECK: bb0([[VALUE:%.*]] : $Int, [[FOO1:%.*]] : $*Foo1):
 // CHECK-NEXT:  debug_value [[VALUE]] : $Int, let, name "value", argno 1
-// CHECK-NEXT:  debug_value_addr [[FOO1]] : $*Foo1, var, name "self", argno 2
+// CHECK-NEXT:  debug_value [[FOO1]] : $*Foo1, var, name "self", argno 2, {{.*}} expr op_deref
 // CHECK-NEXT:  [[BEGIN_ACCESS:%.*]] = begin_access [modify] [unknown] %1 : $*Foo1
 // CHECK-NEXT: // function_ref Foo1.bar.getter
 // CHECK-NEXT:  [[GETTER:%.*]] = function_ref @$s28lazy_property_with_observers4Foo1V3barSivg : $@convention(method) (@inout Foo1) -> Int

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -254,7 +254,7 @@ func test_weird_property(_ v : WeirdPropertyTest, i : Int) -> Int {
 
 // CHECK-LABEL: sil hidden [ossa] @{{.*}}generic_identity
 // CHECK: bb0(%0 : $*T, %1 : $*T):
-// CHECK-NEXT: debug_value_addr %1 : $*T
+// CHECK-NEXT: debug_value %1 : $*T, {{.*}} expr op_deref
 // CHECK-NEXT: copy_addr %1 to [initialization] %0 : $*T
 // CHECK-NOT: destroy_addr %1
 // CHECK: } // end sil function '{{.*}}generic_identity{{.*}}'
@@ -286,7 +286,7 @@ protocol SimpleProtocol {
 // CHECK-LABEL: sil hidden [ossa] @{{.*}}testLetProtocolBases
 // CHECK: bb0(%0 : $*SimpleProtocol):
 func testLetProtocolBases(_ p : SimpleProtocol) {
-  // CHECK-NEXT: debug_value_addr
+  // CHECK-NEXT: debug_value {{.*}} expr op_deref
   // CHECK-NEXT: open_existential_addr
   // CHECK-NEXT: witness_method
   // CHECK-NEXT: apply
@@ -305,7 +305,7 @@ func testLetProtocolBases(_ p : SimpleProtocol) {
 // CHECK-LABEL: sil hidden [ossa] @{{.*}}testLetArchetypeBases
 // CHECK: bb0(%0 : $*T):
 func testLetArchetypeBases<T : SimpleProtocol>(_ p : T) {
-  // CHECK-NEXT: debug_value_addr
+  // CHECK-NEXT: debug_value {{.*}} expr op_deref
   // CHECK-NEXT: witness_method $T
   // CHECK-NEXT: apply
   p.doSomethingGreat()
@@ -321,7 +321,7 @@ func testLetArchetypeBases<T : SimpleProtocol>(_ p : T) {
 // CHECK-LABEL: sil hidden [ossa] @{{.*}}testDebugValue
 // CHECK: bb0(%0 : $Int, %1 : $*SimpleProtocol):
 // CHECK-NEXT: debug_value %0 : $Int, let, name "a"
-// CHECK-NEXT: debug_value_addr %1 : $*SimpleProtocol, let, name "b"
+// CHECK-NEXT: debug_value %1 : $*SimpleProtocol, let, name "b", {{.*}} expr op_deref
 func testDebugValue(_ a : Int, b : SimpleProtocol) -> Int {
 
   // CHECK-NEXT: debug_value %0 : $Int, let, name "x"
@@ -439,7 +439,7 @@ struct GenericStruct<T> {
   }
   // CHECK-LABEL: sil hidden [ossa] @{{.*}}GenericStructV4getA{{.*}} : $@convention(method) <T> (@in_guaranteed GenericStruct<T>) -> @out T
   // CHECK: bb0(%0 : $*T, %1 : $*GenericStruct<T>):
-  // CHECK-NEXT: debug_value_addr %1 : $*GenericStruct<T>, let, name "self"
+  // CHECK-NEXT: debug_value %1 : $*GenericStruct<T>, let, name "self", {{.*}} expr op_deref
   // CHECK-NEXT: %3 = struct_element_addr %1 : $*GenericStruct<T>, #GenericStruct.a
   // CHECK-NEXT: copy_addr %3 to [initialization] %0 : $*T
   // CHECK-NEXT: %5 = tuple ()
@@ -451,7 +451,7 @@ struct GenericStruct<T> {
   
   // CHECK-LABEL: sil hidden [ossa] @{{.*}}GenericStructV4getB{{.*}} : $@convention(method) <T> (@in_guaranteed GenericStruct<T>) -> Int
   // CHECK: bb0([[SELF_ADDR:%.*]] : $*GenericStruct<T>):
-  // CHECK-NEXT: debug_value_addr [[SELF_ADDR]] : $*GenericStruct<T>, let, name "self"
+  // CHECK-NEXT: debug_value [[SELF_ADDR]] : $*GenericStruct<T>, let, name "self", {{.*}} expr op_deref
   // CHECK-NEXT: [[PROJ_ADDR:%.*]] = struct_element_addr [[SELF_ADDR]] : $*GenericStruct<T>, #GenericStruct.b
   // CHECK-NEXT: [[PROJ_VAL:%.*]] = load [trivial] [[PROJ_ADDR]] : $*Int
   // CHECK-NOT: destroy_addr [[SELF]] : $*GenericStruct<T>

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -30,14 +30,14 @@ func passingToId<T: CP, U>(receiver: NSIdLover,
   // CHECK:   debug_value [[OBJECT:%.*]] : $AnyObject
   // CHECK:   debug_value [[CLASS_GENERIC:%.*]] : $T
   // CHECK:   debug_value [[CLASS_EXISTENTIAL:%.*]] : $CP
-  // CHECK:   debug_value_addr [[GENERIC:%.*]] : $*U
-  // CHECK:   debug_value_addr [[EXISTENTIAL:%.*]] : $*P
+  // CHECK:   debug_value [[GENERIC:%.*]] : $*U, {{.*}} expr op_deref
+  // CHECK:   debug_value [[EXISTENTIAL:%.*]] : $*P, {{.*}} expr op_deref
   // CHECK:   debug_value [[ERROR:%.*]] : $Error
-  // CHECK:   debug_value_addr [[ANY:%.*]] : $*Any
+  // CHECK:   debug_value [[ANY:%.*]] : $*Any, {{.*}} expr op_deref
   // CHECK:   debug_value [[KNOWN_UNBRIDGED:%.*]] : $KnownUnbridged
   // CHECK:   debug_value [[OPT_STRING:%.*]] : $Optional<String>
   // CHECK:   debug_value [[OPT_NSSTRING:%.*]] : $Optional<NSString>
-  // CHECK:   debug_value_addr [[OPT_ANY:%.*]] : $*Optional<Any>
+  // CHECK:   debug_value [[OPT_ANY:%.*]] : $*Optional<Any>, {{.*}} expr op_deref
 
   // CHECK:   [[STRING_COPY:%.*]] = copy_value [[STRING]]
   // CHECK:   [[BRIDGE_STRING:%.*]] = function_ref @$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF

--- a/test/SILGen/observers.swift
+++ b/test/SILGen/observers.swift
@@ -30,7 +30,7 @@ public struct DidSetWillSetTests {
     willSet(newA) {
       // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
       // CHECK-NEXT: debug_value %0
-      // CHECK-NEXT: debug_value_addr %1 : $*DidSetWillSetTests
+      // CHECK-NEXT: debug_value %1 : $*DidSetWillSetTests, {{.*}} expr op_deref
 
       takeInt(a)
 
@@ -64,7 +64,7 @@ public struct DidSetWillSetTests {
     // CHECK-LABEL: sil private [ossa] @$s9observers010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW
     didSet {
       // CHECK: bb0(%0 : $*DidSetWillSetTests):
-      // CHECK-NEXT: debug_value_addr %0 : $*DidSetWillSetTests
+      // CHECK-NEXT: debug_value %0 : $*DidSetWillSetTests, {{.*}} expr op_deref
 
       takeInt(a)
 
@@ -102,7 +102,7 @@ public struct DidSetWillSetTests {
     // CHECK-LABEL: sil [ossa] @$s9observers010DidSetWillC5TestsV1aSivs : $@convention(method) (Int, @inout DidSetWillSetTests) -> () {
     // CHECK: bb0([[NEWVALUE:%.*]] : $Int, %1 : $*DidSetWillSetTests):
     // CHECK-NEXT: debug_value [[NEWVALUE]] : $Int, let, name "value", argno 1
-    // CHECK-NEXT: debug_value_addr %1
+    // CHECK-NEXT: debug_value %1{{.*}} expr op_deref
 
     // CHECK-NEXT: [[MODIFY_ONE:%.*]] = begin_access [modify] [unknown] %1 : $*DidSetWillSetTests
     // CHECK-NEXT: // function_ref observers.DidSetWillSetTests.a.willset : Swift.Int
@@ -313,7 +313,7 @@ func propertyWithDidSetTakingOldValue() {
 // CHECK: bb0([[ARG1:%.*]] : $Int, [[ARG2:%.*]] : @guaranteed ${ var Int }):
 // CHECK-NEXT:  debug_value [[ARG1]] : $Int, let, name "value", argno 1
 // CHECK-NEXT:  [[ARG2_PB:%.*]] = project_box [[ARG2]]
-// CHECK-NEXT:  debug_value_addr [[ARG2_PB]] : $*Int, var, name "p", argno 2
+// CHECK-NEXT:  debug_value [[ARG2_PB]] : $*Int, var, name "p", argno 2, expr op_deref
 // CHECK-NEXT:  [[READ:%.*]] = begin_access [read] [unknown] [[ARG2_PB]]
 // CHECK-NEXT:  [[ARG2_PB_VAL:%.*]] = load [trivial] [[READ]] : $*Int
 // CHECK-NEXT:  end_access [[READ]]

--- a/test/SILGen/optional-cast.swift
+++ b/test/SILGen/optional-cast.swift
@@ -174,7 +174,7 @@ func opt_to_opt_reference(_ x : C!) -> C? { return x }
 
 // CHECK-LABEL: sil hidden [ossa] @$s4main07opt_to_B12_addressOnly{{[_0-9a-zA-Z]*}}F
 // CHECK:       bb0(%0 : $*Optional<T>, %1 : $*Optional<T>):
-// CHECK-NEXT:  debug_value_addr %1 : $*Optional<T>, let, name "x"
+// CHECK-NEXT:  debug_value %1 : $*Optional<T>, let, name "x", {{.*}} expr op_deref
 // CHECK-NEXT:  copy_addr %1 to [initialization] %0
 // CHECK-NOT:  destroy_addr %1
 func opt_to_opt_addressOnly<T>(_ x : T!) -> T? { return x }

--- a/test/SILGen/property_wrapper_coroutine.swift
+++ b/test/SILGen/property_wrapper_coroutine.swift
@@ -36,7 +36,7 @@ _ = state1.someValues
 
 // CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_coroutine5StateV6valuesSaySSGvM : $@yield_once @convention(method) (@inout State) -> @yields @inout Array<String> {
 // CHECK: bb0([[STATE:%.*]] : $*State):
-// CHECK:  debug_value_addr [[STATE]] : $*State, var, name "self", argno {{.*}}
+// CHECK:  debug_value [[STATE]] : $*State, var, name "self", argno {{.*}}, {{.*}} expr op_deref
 // CHECK:  [[BEGIN_ACCESS:%.*]] = begin_access [modify] [unknown] [[STATE]] : $*State
 // CHECK:  [[BACKING_ADDR:%.*]] = struct_element_addr [[BEGIN_ACCESS]] : $*State, #State._values
 // CHECK:  [[VALUE_ADDR:%.*]] = struct_element_addr [[BACKING_ADDR]] : $*TestWrapper<Array<String>>, #TestWrapper.wrappedValue

--- a/test/SILGen/switch_multiple_entry_address_only.swift
+++ b/test/SILGen/switch_multiple_entry_address_only.swift
@@ -91,7 +91,7 @@ func multipleLabelsVar(e: E) {
   // CHECK-NEXT: br bb3
 
   // CHECK:      bb3:
-  // CHECK-NEXT: debug_value_addr [[X_PHI]] : $*Any, var, name "x"
+  // CHECK-NEXT: debug_value [[X_PHI]] : $*Any, var, name "x"
   // CHECK-NEXT: [[ANY_BOX:%.*]] = alloc_box ${ var Any }, var, name "x"
   // CHECK-NEXT: [[BOX_PAYLOAD:%.*]] = project_box [[ANY_BOX]] : ${ var Any }, 0
   // CHECK-NEXT: copy_addr [take] [[X_PHI]] to [initialization] [[BOX_PAYLOAD]]

--- a/test/SILGen/unmanaged.swift
+++ b/test/SILGen/unmanaged.swift
@@ -35,7 +35,7 @@ func get(holder holder: inout Holder) -> C {
 }
 // CHECK-LABEL:sil hidden @$s9unmanaged3get6holderAA1CCAA6HolderVz_tF : $@convention(thin) (@inout Holder) -> @owned C
 // CHECK: bb0([[ADDR:%.*]] : $*Holder):
-// CHECK-NEXT:   debug_value_addr %0 : $*Holder, var, name "holder", argno 1 
+// CHECK-NEXT:   debug_value %0 : $*Holder, var, name "holder", argno 1, expr op_deref
 // CHECK-NEXT:   [[READ:%.*]] = begin_access [read] [static] [[ADDR]] : $*Holder
 // CHECK-NEXT:   [[T0:%.*]] = struct_element_addr [[READ]] : $*Holder, #Holder.value
 // CHECK-NEXT:   [[T1:%.*]] = load [[T0]] : $*@sil_unmanaged C

--- a/test/SILGen/unmanaged_ownership.swift
+++ b/test/SILGen/unmanaged_ownership.swift
@@ -46,7 +46,7 @@ func get(holder holder: inout Holder) -> C {
 }
 // CHECK-LABEL: sil hidden [ossa] @$ss3get6holders1CCs6HolderVz_tF : $@convention(thin) (@inout Holder) -> @owned C {
 // CHECK: bb0([[ADDR:%.*]] : $*Holder):
-// CHECK-NEXT:   debug_value_addr %0 : $*Holder, var, name "holder", argno 1 
+// CHECK-NEXT:   debug_value %0 : $*Holder, var, name "holder", argno 1, expr op_deref
 // CHECK-NEXT:   [[READ:%.*]] = begin_access [read] [unknown] [[ADDR]] : $*Holder
 // CHECK-NEXT:   [[T0:%.*]] = struct_element_addr [[READ]] : $*Holder, #Holder.value
 // CHECK-NEXT:   [[T1:%.*]] = load [trivial] [[T0]] : $*@sil_unmanaged C

--- a/test/SILGen/weak.swift
+++ b/test/SILGen/weak.swift
@@ -55,7 +55,7 @@ func test0(c c: C) {
 // CHECK-LABEL: sil private [ossa] @$s4weak19testClosureOverWeakyyFSiycfU_ : $@convention(thin) (@guaranteed { var @sil_weak Optional<C> }) -> Int {
 // CHECK: bb0(%0 : @guaranteed ${ var @sil_weak Optional<C> }):
 // CHECK-NEXT:  %1 = project_box %0
-// CHECK-NEXT:  debug_value_addr %1 : $*@sil_weak Optional<C>, var, name "bC", argno 1
+// CHECK-NEXT:  debug_value %1 : $*@sil_weak Optional<C>, var, name "bC", argno 1, expr op_deref
 // CHECK-NEXT:  [[READ:%.*]] = begin_access [read] [unknown] %1
 // CHECK-NEXT:  [[VAL:%.*]] = load_weak [[READ]] : $*@sil_weak Optional<C>
 // CHECK-NEXT:  end_access [[READ]]

--- a/test/SILOptimizer/accesspath_uses_ossa.sil
+++ b/test/SILOptimizer/accesspath_uses_ossa.sil
@@ -416,13 +416,13 @@ enum IntTEnum<T> {
 // CHECK: Storage: Argument %0 = argument of bb0 : $*IntTEnum<T>
 // CHECK: Path: ()
 // CHECK: Exact Uses {
-// CHECK-NEXT:  debug_value_addr %0 : $*IntTEnum<T>, let, name "self", argno 1
+// CHECK-NEXT:  debug_value %0 : $*IntTEnum<T>, let, name "self", argno 1, expr op_deref
 // CHECK-NEXT:  Path: ()
 // CHECK-NEXT:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
 // CHECK-NEXT:  Path: ()
 // CHECK-NEXT: }
 // CHECK: Overlapping Uses {
-// CHECK-NEXT:  debug_value_addr %0 : $*IntTEnum<T>, let, name "self", argno 1
+// CHECK-NEXT:  debug_value %0 : $*IntTEnum<T>, let, name "self", argno 1, expr op_deref
 // CHECK-NEXT:  Path: ()
 // CHECK-NEXT:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
 // CHECK-NEXT:  Path: ()

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -154,9 +154,9 @@ bb0(%0 : $T):
 // CHECK:   %[[PREV1:.*]] = alloc_stack $T
 // CHECK:   %[[ARG2:.*]] = alloc_stack $T
 // CHECK:   %[[PREV2:.*]] = alloc_stack $T
-// CHECK:   debug_value_addr %0 : $*T, var, name "t", argno 1
-// CHECK:   debug_value_addr %1 : $*T, var, name "u", argno 2
-// CHECK:   debug_value_addr %2 : $*T
+// CHECK:   debug_value %0 : $*T, var, name "t", argno 1, expr op_deref
+// CHECK:   debug_value %1 : $*T, var, name "u", argno 2, expr op_deref
+// CHECK:   debug_value %2 : $*T, {{.*}} expr op_deref
 // CHECK:   copy_addr %2 to [initialization] %[[ARG1]] : $*T
 // CHECK:   copy_addr [take] %0 to [initialization] %[[PREV1]] : $*T
 // CHECK:   copy_addr [take] %[[ARG1]] to [initialization] %0 : $*T

--- a/test/SILOptimizer/address_projection.sil
+++ b/test/SILOptimizer/address_projection.sil
@@ -145,9 +145,9 @@ bb0(%0 : $T):
 // CHECK: bb0(%0 : $*T, %1 : $*T, %2 : $*T):
 // CHECK:   %[[PREV1:.*]] = alloc_stack $T
 // CHECK:   %[[PREV2:.*]] = alloc_stack $T
-// CHECK:   debug_value_addr %0 : $*T, var, name "t", argno 1
-// CHECK:   debug_value_addr %1 : $*T, var, name "u", argno 2
-// CHECK:   debug_value_addr %2 : $*T
+// CHECK:   debug_value %0 : $*T, var, name "t", argno 1, expr op_deref
+// CHECK:   debug_value %1 : $*T, var, name "u", argno 2, expr op_deref
+// CHECK:   debug_value %2 : $*T, {{.*}} expr op_deref
 // CHECK:   copy_addr [take] %0 to [initialization] %[[PREV1]] : $*T
 // CHECK:   copy_addr %2 to [initialization] %0 : $*T
 // CHECK:   destroy_addr %[[PREV1]] : $*T

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -502,7 +502,7 @@ bb0(%0 : $@callee_guaranteed () -> @out U):
 sil @callWithAutoclosure : $@convention(thin) <T where T : P> (@in T) -> () {
 // CHECK: bb0
 bb0(%0 : $*T):
-  // CHECK: debug_value_addr
+  // CHECK: debug_value {{.*}} expr op_deref
   debug_value_addr %0 : $*T
   // CHECK: function_ref @mightApply
   %2 = function_ref @mightApply : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned @callee_owned () -> @out τ_0_0) -> ()
@@ -530,7 +530,7 @@ bb0(%0 : $*T):
 sil @callWithAutoclosure_2 : $@convention(thin) <T where T : P> (@in T) -> () {
 // CHECK: bb0
 bb0(%0 : $*T):
-  // CHECK: debug_value_addr
+  // CHECK: debug_value {{.*}} expr op_deref
   debug_value_addr %0 : $*T
   // CHECK: function_ref @mightApply
   %2 = function_ref @mightApply : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned @callee_owned () -> @out τ_0_0) -> ()

--- a/test/SILOptimizer/allocbox_to_stack_ownership.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ownership.sil
@@ -501,7 +501,7 @@ bb0(%0 : @guaranteed $@callee_guaranteed () -> @out U):
 sil [ossa] @callWithAutoclosure : $@convention(thin) <T where T : P> (@in T) -> () {
 // CHECK: bb0
 bb0(%0 : $*T):
-  // CHECK: debug_value_addr
+  // CHECK: debug_value {{.*}} expr op_deref
   debug_value_addr %0 : $*T
   // CHECK: function_ref @mightApply
   %2 = function_ref @mightApply : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned @callee_owned () -> @out τ_0_0) -> ()
@@ -528,7 +528,7 @@ bb0(%0 : $*T):
 sil [ossa] @callWithAutoclosure_2 : $@convention(thin) <T where T : P> (@in T) -> () {
 // CHECK: bb0
 bb0(%0 : $*T):
-  // CHECK: debug_value_addr
+  // CHECK: debug_value {{.*}} expr op_deref
   debug_value_addr %0 : $*T
   // CHECK: function_ref @mightApply
   %2 = function_ref @mightApply : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned @callee_owned () -> @out τ_0_0) -> ()

--- a/test/SILOptimizer/copy_propagation_opaque.sil
+++ b/test/SILOptimizer/copy_propagation_opaque.sil
@@ -139,7 +139,7 @@ bb3(%11 : @owned $T):
 //
 // The non-consuming use now uses the original value.
 // CHECK-DEBUG-NEXT:   debug_value %0 : $T
-// CHECK-NEXT:   debug_value_addr %1 : $*T
+// CHECK-NEXT:   debug_value %1 : $*T, expr op_deref
 //
 // The original destroy is deleted with optimizations enabled.
 // CHECK-DEBUG-NEXT: destroy_value %0 : $T

--- a/test/SILOptimizer/copyforward_ossa.sil
+++ b/test/SILOptimizer/copyforward_ossa.sil
@@ -536,7 +536,7 @@ public struct S<T> {
 // CHECK-LABEL: sil [ossa] @deadtemp :
 // CHECK: %[[G:.*]] = struct_element_addr %0 : $*S<T>, #S.g
 // CHECK-NOT: copy_addr
-// CHECK-NOT: debug_value_addr
+// CHECK-NOT: debug_value {{.*}} expr op_deref
 // CHECK: %[[F:.*]] = struct_element_addr %0 : $*S<T>, #S.f
 // CHECK: copy_addr %[[G]] to %[[F]] : $*T
 // CHECK-LABEL: } // end sil function 'deadtemp'

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -373,7 +373,7 @@ bb2:
 // CHECK-LABEL: blocking_debug_value_addr_on_dead_store
 // CHECK: bb0
 // CHECK: {{ store}}
-// CHECK: debug_value_addr
+// CHECK: debug_value %{{.*}} : $*Int
 sil hidden @blocking_debug_value_addr_on_dead_store : $@convention(thin) () -> () {
 bb0:
   %0 = alloc_stack $Int, var, name "a"

--- a/test/SILOptimizer/existential_transform.swift
+++ b/test/SILOptimizer/existential_transform.swift
@@ -196,7 +196,7 @@ internal class KK : PP {
 
 // CHECK-LABEL: sil hidden [noinline] @$s21existential_transform13wrap_inout_cp1aSiAA2PP_pz_tF : $@convention(thin) (@inout PP) -> Int {
 // CHECK: bb0(%0 : $*PP):
-// CHECK: debug_value_addr
+// CHECK: debug_value {{.*}} expr op_deref
 // CHECK: load
 // CHECK: [[O1:%.*]] = open_existential_ref
 // CHECK:  witness_method $@opened("{{.*}}") PP, #PP.foo : <Self where Self : PP> (Self) -> () -> Int, %3 : $@opened("{{.*}}PP : $@convention(witness_method: PP) <τ_0_0 where τ_0_0 : PP> (@guaranteed τ_0_0) -> Int 
@@ -350,9 +350,9 @@ struct MyStruct : Foo {
 // CHECK:   alloc_stack
 // CHECK:   init_existential_addr
 // CHECK:   copy_addr
-// CHECK:   debug_value_addr 
+// CHECK:   debug_value {{.*}} expr op_deref
 // CHECK:   open_existential_addr
-// CHECK:   witness_method 
+// CHECK:   witness_method
 // CHECK:   apply
 // CHECK:   dealloc_stack
 // CHECK:   return
@@ -382,7 +382,7 @@ class RC: RP {
 // CHECK:   copy_addr
 // CHECK:   debug_value
 // CHECK:   debug_value
-// CHECK:   debug_value_addr
+// CHECK:   debug_value {{.*}} expr op_deref
 // CHECK:   struct_extract
 // CHECK:   struct_extract
 // CHECK:   integer_literal

--- a/test/SILOptimizer/existential_transform_extras.sil
+++ b/test/SILOptimizer/existential_transform_extras.sil
@@ -60,7 +60,7 @@ bb0:
 
 // CHECK-LABEL: sil public_external [serialized] @$s7dealloc20wrap_foo_ncp_another1aSiAA1P_pz_tF : $@convention(thin) (@inout P) -> Int32 {
 // CHECK: bb0(%0 : $*P):
-// CHECK:  debug_value_addr
+// CHECK:  debug_value {{.*}} expr op_deref
 // CHECK:  alloc_stack
 // CHECK:  copy_addr
 // CHECK:  open_existential_addr
@@ -94,7 +94,7 @@ sil_global hidden [let] @$global_var : $P
 
 // CHECK-LABEL: sil hidden [noinline] @$helper : $@convention(thin) (@in P) -> Int32 {
 // CHECK: bb0(%0 : $*P):
-// CHECK:   debug_value_addr
+// CHECK:   debug_value {{.*}} expr op_deref
 // CHECK:   alloc_stack
 // CHECK:   copy_addr
 // CHECK:   destroy_addr

--- a/test/SILOptimizer/existential_transform_extras_ossa.sil
+++ b/test/SILOptimizer/existential_transform_extras_ossa.sil
@@ -80,7 +80,7 @@ bb0:
 
 // CHECK-LABEL: sil public_external [serialized] [ossa] @$s7dealloc20wrap_foo_ncp_another1aSiAA1P_pz_tF : $@convention(thin) (@inout P) -> Int32 {
 // CHECK: bb0(%0 : $*P):
-// CHECK:  debug_value_addr
+// CHECK:  debug_value {{.*}} expr op_deref
 // CHECK:  alloc_stack
 // CHECK:  copy_addr
 // CHECK:  open_existential_addr
@@ -114,7 +114,7 @@ sil_global hidden [let] @$global_var : $P
 
 // CHECK-LABEL: sil hidden [noinline] [ossa] @$helper : $@convention(thin) (@in P) -> Int32 {
 // CHECK: bb0(%0 : $*P):
-// CHECK:   debug_value_addr
+// CHECK:   debug_value {{.*}} expr op_deref
 // CHECK:   alloc_stack
 // CHECK:   copy_addr
 // CHECK:   destroy_addr

--- a/test/SILOptimizer/existential_transform_soletype.swift
+++ b/test/SILOptimizer/existential_transform_soletype.swift
@@ -19,7 +19,7 @@ internal class SCC: SPP {
 
 // CHECK-LABEL: sil hidden [noinline] @$s30existential_transform_soletype4opt11bs5Int32VAA3SPP_p_tF : $@convention(thin) (@in_guaranteed SPP) -> Int32 {
 // CHECK: bb0(%0 : $*SPP):
-// CHECK:   debug_value_addr
+// CHECK:   debug_value {{.*}} expr op_deref
 // CHECK:   function_ref @$s30existential_transform_soletype4opt21bs5Int32VAA3SPP_p_tFTf4e_n : $@convention(thin) <τ_0_0 where τ_0_0 : SPP> (@in_guaranteed τ_0_0) -> Int32 // user: %4
 // CHECK:   open_existential_addr
 // CHECK:   apply
@@ -31,9 +31,9 @@ internal class SCC: SPP {
 // CHECK:   alloc_stack
 // CHECK:   init_existential_addr
 // CHECK:   copy_addr
-// CHECK:   debug_value_addr
+// CHECK:   debug_value {{.*}} expr op_deref
 // CHECK:   open_existential_addr
-// CHECK:   witness_method 
+// CHECK:   witness_method
 // CHECK:   apply
 // CHECK:   dealloc_stack
 // CHECK:   return

--- a/test/SILOptimizer/mem2reg.sil
+++ b/test/SILOptimizer/mem2reg.sil
@@ -180,7 +180,7 @@ bb0(%0 : $*()):
 
 // CHECK-LABEL: sil @mem2reg_debug_value_addr
 // CHECK-NOT: alloc_stack
-// CHECK-NOT: debug_value_addr
+// CHECK-NOT: debug_value {{.*}} expr op_deref
 // CHECK: debug_value %0
 // CHECK: return
 sil @mem2reg_debug_value_addr : $@convention(thin) (Int) -> Int {
@@ -327,7 +327,7 @@ sil @no_real_uses : $@convention(thin) () -> () {
 bb0:
   // CHECK-NOT: alloc_stack
   %0 = alloc_stack $Builtin.Int32
-  // CHECK-NOT: debug_value_addr
+  // CHECK-NOT: debug_value {{.*}} expr op_deref
   debug_value_addr %0 : $*Builtin.Int32, let, name "x", argno 1
   // CHECK-NOT: dealloc_stack
   dealloc_stack %0 : $*Builtin.Int32

--- a/test/SILOptimizer/mem2reg_ossa.sil
+++ b/test/SILOptimizer/mem2reg_ossa.sil
@@ -180,7 +180,7 @@ bb0(%0 : $*()):
 
 // CHECK-LABEL: sil [ossa] @mem2reg_debug_value_addr :
 // CHECK-NOT: alloc_stack
-// CHECK-NOT: debug_value_addr
+// CHECK-NOT: debug_value {{.*}} expr op_deref
 // CHECK: debug_value %0
 // CHECK-LABEL: } // end sil function 'mem2reg_debug_value_addr'
 sil [ossa] @mem2reg_debug_value_addr : $@convention(thin) (Int) -> Int {
@@ -327,7 +327,7 @@ sil [ossa] @no_real_uses : $@convention(thin) () -> () {
 bb0:
   // CHECK-NOT: alloc_stack
   %0 = alloc_stack [dynamic_lifetime] $Builtin.Int32
-  // CHECK-NOT: debug_value_addr
+  // CHECK-NOT: debug_value {{.*}} expr op_deref
   debug_value_addr %0 : $*Builtin.Int32, let, name "x", argno 1
   // CHECK-NOT: dealloc_stack
   dealloc_stack %0 : $*Builtin.Int32

--- a/test/SILOptimizer/mem2reg_ossa_nontrivial.sil
+++ b/test/SILOptimizer/mem2reg_ossa_nontrivial.sil
@@ -564,7 +564,7 @@ bb3:
 
 // CHECK-LABEL: sil [ossa] @mem2reg_debug_value_addr :
 // CHECK-NOT: alloc_stack
-// CHECK-NOT: debug_value_addr
+// CHECK-NOT: debug_value {{.*}} expr op_deref
 // CHECK: debug_value %0
 // CHECK-LABEL: } // end sil function 'mem2reg_debug_value_addr'
 sil [ossa] @mem2reg_debug_value_addr : $@convention(thin) (@owned Klass) -> @owned Klass {
@@ -682,7 +682,7 @@ bb0:
   %0 = alloc_stack $Klass
   %local = alloc_ref $Klass
   store %local to [init] %0 : $*Klass
-  // CHECK-NOT: debug_value_addr
+  // CHECK-NOT: debug_value {{.*}} expr op_deref
   debug_value_addr %0 : $*Klass
   destroy_addr %0 : $*Klass
   // CHECK-NOT: dealloc_stack

--- a/test/SILOptimizer/simplify_cfg_address_phi.sil
+++ b/test/SILOptimizer/simplify_cfg_address_phi.sil
@@ -144,10 +144,10 @@ public class CC<R> {
 sil @useAny : $@convention(thin) <V> (@in_guaranteed V) -> ()
 
 // CHECK-LABEL: sil @testDebugValue : $@convention(method) <R><S> (@in_guaranteed S, @guaranteed CC<R>, Bool) -> () {
-// CHECK: debug_value_addr %0 : $*S, let, name "u"
+// CHECK: debug_value %0 : $*S, let, name "u", expr op_deref
 // CHECK: apply %{{.*}}<S>(%0) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
 // CHECK: [[FIELD:%.*]] = ref_element_addr %1 : $CC<R>, #CC.r
-// CHECK: debug_value_addr [[FIELD]] : $*R, let, name "u"
+// CHECK: debug_value [[FIELD]] : $*R, let, name "u", expr op_deref
 // CHECK: apply %{{.*}}<R>([[FIELD]]) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
 // CHECK-LABEL: } // end sil function 'testDebugValue'
 sil @testDebugValue : $@convention(method) <R><S> (@in_guaranteed S, @guaranteed CC<R>, Bool) -> () {

--- a/test/SILOptimizer/simplify_cfg_simple_jumpthread.sil
+++ b/test/SILOptimizer/simplify_cfg_simple_jumpthread.sil
@@ -89,10 +89,10 @@ bb5:
 }
 
 // CHECK-LABEL: sil @testDebugValue : $@convention(method) <R><S> (@in_guaranteed S, @guaranteed CC<R>, Bool) -> () {
-// CHECK: debug_value_addr %0 : $*S, let, name "u"
+// CHECK: debug_value %0 : $*S, let, name "u", expr op_deref
 // CHECK: apply %{{.*}}<S>(%0) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
 // CHECK: [[FIELD:%.*]] = ref_element_addr %1 : $CC<R>, #CC.r
-// CHECK: debug_value_addr [[FIELD]] : $*R, let, name "u"
+// CHECK: debug_value [[FIELD]] : $*R, let, name "u", expr op_deref
 // CHECK: apply %{{.*}}<R>([[FIELD]]) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
 // CHECK-LABEL: } // end sil function 'testDebugValue'
 sil @testDebugValue : $@convention(method) <R><S> (@in_guaranteed S, @guaranteed CC<R>, Bool) -> () {

--- a/test/SILOptimizer/templvalueopt_ossa.sil
+++ b/test/SILOptimizer/templvalueopt_ossa.sil
@@ -285,7 +285,7 @@ bb0(%0 :@owned  $Child):
 
 // CHECK-LABEL: sil [ossa] @cleanup_debuginsts :
 // CHECK:   copy_addr [take]
-// CHECK-NOT: debug_value_addr
+// CHECK-NOT: debug_value {{.*}} expr op_deref
 // CHECK-LABEL: } // end sil function 'cleanup_debuginsts'
 sil [ossa] @cleanup_debuginsts : $@convention(thin) <T> (@in T) -> () {
 bb0(%0 : $*T):


### PR DESCRIPTION
This patch replace all in-memory objects of DebugValueAddrInst with
DebugValueInst + op_deref, and duplicates logics that handles
DebugValueAddrInst with the latter. All related check in the tests
have been updated as well.

Note that this patch neither remove the DebugValueAddrInst class nor
remove `debug_value_addr` syntax in the test inputs.

This is a PR only for code review. DO NOT MERGE.