### PR TITLE
 ClangImporter: teach clang importer to import Clang SPI symbols and model them similarly as Swift SPIs

### DIFF
--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -58,6 +58,10 @@ constexpr static const StringLiteral DEFAULT_ACTOR_STORAGE_FIELD_NAME =
 /// The name of the Builtin type prefix
 constexpr static const StringLiteral BUILTIN_TYPE_NAME_PREFIX = "Builtin.";
 
+/// The default SPI group name to associate with Clang SPIs.
+constexpr static const StringLiteral CLANG_MODULE_DEFUALT_SPI_GROUP_NAME =
+  "OBJC_DEFAULT_SPI_GROUP";
+
 /// A composition class containing a StringLiteral for the names of
 /// Swift builtins. The reason we use this is to ensure that we when
 /// necessary slice off the "Builtin." prefix from these names in a

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8545,6 +8545,21 @@ Optional<bool> swift::importer::isMainActorAttr(
   return None;
 }
 
+static bool isUsingMacroName(clang::SourceManager &SM,
+                             clang::SourceLocation loc,
+                             StringRef MacroName) {
+  if (!loc.isMacroID())
+    return false;
+  auto Sloc = SM.getExpansionLoc(loc);
+  if (Sloc.isInvalid())
+    return false;
+  auto Eloc = Sloc.getLocWithOffset(MacroName.size());
+  if (Eloc.isInvalid())
+    return false;
+  StringRef content(SM.getCharacterData(Sloc), MacroName.size());
+  return content == MacroName;
+}
+
 /// Import Clang attributes as Swift attributes.
 void ClangImporter::Implementation::importAttributes(
     const clang::NamedDecl *ClangDecl,
@@ -8666,6 +8681,17 @@ void ClangImporter::Implementation::importAttributes(
       if (avail->getUnavailable()) {
         PlatformAgnostic = PlatformAgnosticAvailabilityKind::Unavailable;
         AnyUnavailable = true;
+      }
+
+      if (isUsingMacroName(getClangASTContext().getSourceManager(),
+                            avail->getLoc(), "SPI_AVAILABLE") ||
+           isUsingMacroName(getClangASTContext().getSourceManager(),
+                            avail->getLoc(), "__SPI_AVAILABLE")) {
+        // The decl has been marked as SPI in the header by using the SPI macro,
+        // thus we add the SPI attribute to it with a default group name.
+        MappedDecl->getAttrs().add(SPIAccessControlAttr::create(SwiftContext,
+          SourceLoc(), SourceRange(),
+          SwiftContext.getIdentifier(CLANG_MODULE_DEFUALT_SPI_GROUP_NAME)));
       }
 
       StringRef message = avail->getMessage();

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -642,6 +642,7 @@ private:
   
   /// The DWARF importer delegate, if installed.
   DWARFImporterDelegate *DWARFImporter = nullptr;
+
 public:
   /// Only used for testing.
   void setDWARFImporterDelegate(DWARFImporterDelegate &delegate);

--- a/test/ClangImporter/Inputs/frameworks/SPIContainer.framework/Headers/SPIContainer.h
+++ b/test/ClangImporter/Inputs/frameworks/SPIContainer.framework/Headers/SPIContainer.h
@@ -1,0 +1,23 @@
+#import <Foundation/Foundation.h>
+
+#ifdef SPI_AVAILABLE
+#undef SPI_AVAILABLE
+#define SPI_AVAILABLE API_AVAILABLE
+#endif
+
+#ifdef __SPI_AVAILABLE
+#undef __SPI_AVAILABLE
+#define __SPI_AVAILABLE API_AVAILABLE
+#endif
+
+SPI_AVAILABLE(macos(10.7))
+@interface SPIInterface1
+@end
+
+__SPI_AVAILABLE(macos(10.7))
+@interface SPIInterface2
+@end
+
+@interface SharedInterface
+  + (NSInteger)foo SPI_AVAILABLE(macos(10.7));
+@end

--- a/test/ClangImporter/Inputs/frameworks/SPIContainer.framework/Modules/module.modulemap
+++ b/test/ClangImporter/Inputs/frameworks/SPIContainer.framework/Modules/module.modulemap
@@ -1,0 +1,7 @@
+framework module SPIContainer {
+  umbrella header "SPIContainer.h"
+  export *
+  module * {
+    export *
+  }
+}

--- a/test/ClangImporter/availability_spi_as_unavailable.swift
+++ b/test/ClangImporter/availability_spi_as_unavailable.swift
@@ -1,0 +1,15 @@
+// REQUIRES: OS=macosx
+// RUN: %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks -verify
+
+import SPIContainer
+
+@_spi(a) public let a: SPIInterface1
+@_spi(a) public let b: SPIInterface2
+
+public let c: SPIInterface1 // expected-error{{cannot use class 'SPIInterface1' here; it is an SPI imported from 'SPIContainer'}}
+public let d: SPIInterface2 // expected-error{{cannot use class 'SPIInterface2' here; it is an SPI imported from 'SPIContainer'}}
+
+@inlinable
+public func inlinableUsingSPI() {
+  SharedInterface.foo() // expected-error{{class method 'foo()' cannot be used in an '@inlinable' function because it is an SPI imported from 'SPIContainer'}}
+}

--- a/validation-test/Serialization/bridging-header-first.swift
+++ b/validation-test/Serialization/bridging-header-first.swift
@@ -18,7 +18,7 @@
 // CHECK-DUMP: IMPORTED_MODULE
 // CHECK-DUMP-SAME: 'Module'
 // CHECK-DUMP: IMPORTED_MODULE
-// CHECK-DUMP-SAME: 'Swift'
+// CHECK-DUMP: 'Swift'
 
 
 import Module


### PR DESCRIPTION
For clang symbols marked with SPI_AVAILABLE, we add SPIAccessControlAttr to them so they will be considered as SPIs in the AST. To be able to use all these symbols, we also add an implicit SPI import statement for all clang modules. All clang SPIs belong to the same SPI group named `<objc>` because clang currently doesn't support custom SPI group.

rdar://73902734
