### PR TITLE
[Demangler] Fix incorrect assertions in OldRemangler and NodePrinter.

### DIFF
--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -775,7 +775,7 @@ private:
 
   void printFunctionType(NodePointer LabelList, NodePointer node,
                          unsigned depth) {
-    if (node->getNumChildren() < 2 || node->getNumChildren() > 6) {
+    if (node->getNumChildren() < 2) {
       setInvalid();
       return;
     }
@@ -814,9 +814,14 @@ private:
       assert(false && "Unhandled function type in printFunctionType!");
     }
 
+    unsigned argIndex = node->getNumChildren() - 2;
     unsigned startIndex = 0;
     bool isSendable = false, isAsync = false, isThrows = false;
     auto diffKind = MangledDifferentiabilityKind::NonDifferentiable;
+    if (node->getChild(startIndex)->getKind() == Node::Kind::ClangType) {
+      // handled earlier
+      ++startIndex;
+    }
     if (node->getChild(startIndex)->getKind() ==
           Node::Kind::GlobalActorFunctionType) {
       print(node->getChild(startIndex), depth + 1);
@@ -826,10 +831,6 @@ private:
         Node::Kind::DifferentiableFunctionType) {
       diffKind =
           (MangledDifferentiabilityKind)node->getChild(startIndex)->getIndex();
-      ++startIndex;
-    }
-    if (node->getChild(startIndex)->getKind() == Node::Kind::ClangType) {
-      // handled earlier
       ++startIndex;
     }
     if (node->getChild(startIndex)->getKind() == Node::Kind::ThrowsAnnotation) {
@@ -866,7 +867,7 @@ private:
     if (isSendable)
       Printer << "@Sendable ";
 
-    printFunctionParameters(LabelList, node->getChild(startIndex), depth,
+    printFunctionParameters(LabelList, node->getChild(argIndex), depth,
                             Options.ShowFunctionArgumentTypes);
 
     if (!Options.ShowFunctionArgumentTypes)
@@ -878,7 +879,7 @@ private:
     if (isThrows)
       Printer << " throws";
 
-    print(node->getChild(startIndex + 1), depth + 1);
+    print(node->getChild(argIndex + 1), depth + 1);
   }
 
   void printImplFunctionType(NodePointer fn, unsigned depth) {

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -1206,8 +1206,8 @@ void Remangler::mangleEntityType(Node *node, EntityContext &ctx,
              node->getKind() == Node::Kind::NoEscapeFunctionType)
                 ? 'F'
                 : 'f');
+    assert(node->getNumChildren() >= 2);
     unsigned inputIndex = node->getNumChildren() - 2;
-    assert(inputIndex <= 1);
     for (unsigned i = 0; i <= inputIndex; ++i)
       mangle(node->begin()[i], depth + 1);
     auto returnType = node->begin()[inputIndex+1];

--- a/test/Demangle/rdar-82252704.swift
+++ b/test/Demangle/rdar-82252704.swift
@@ -1,0 +1,10 @@
+// rdar://82252704 - [SR-15070]: Declaring a class inside a async throws
+//                   function crashes compiler
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -c %s -o %t/test.o
+
+@available(SwiftStdlib 5.5, *)
+func MyFunction() async throws {
+    class MyClass {}
+}


### PR DESCRIPTION
There can be, currently, up to eight child nodes for a FunctionType. OldRemangler seemed to think there could only be three, while NodePrinter plumped for six.

rdar://82252704
