### PR TITLE
[Sema] Have isValidTypeExprParent consider its child

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -558,8 +558,8 @@ public:
   /// the parent map.
   llvm::DenseMap<Expr *, Expr *> getParentMap();
 
-  /// Whether this expression is a valid parent for a TypeExpr.
-  bool isValidTypeExprParent() const;
+  /// Whether this expression is a valid parent for a given TypeExpr.
+  bool isValidParentOfTypeExpr(Expr *typeExpr) const;
 
   SWIFT_DEBUG_DUMP;
   void dump(raw_ostream &OS, unsigned Indent = 0) const;

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -621,7 +621,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       DiagnosticBehavior behavior = DiagnosticBehavior::Error;
 
       if (auto *ParentExpr = Parent.getAsExpr()) {
-        if (ParentExpr->isValidTypeExprParent())
+        if (ParentExpr->isValidParentOfTypeExpr(E))
           return;
 
         if (!Ctx.LangOpts.isSwiftVersionAtLeast(6)) {


### PR DESCRIPTION
With the introduction of the ArgumentList type in https://github.com/apple/swift/pull/38836, argument expressions will be direct decedents of call expressions, without an intermediate TupleExpr. As such, we need to tweak `isValidTypeExprParent` to consider the child expression such that `T(x)` is permissible, but `x(T)` is not.

Change `isValidTypeExprParent` to take a child expr parameter, and update its use in MiscDiagnostics and PreCheckExpr. For PreCheckExpr, switch from a stack to walking the parent directly, as a stack-based approach would be a bit more fiddly in this case, and walking the parents shouldn't be expensive.

This should be NFC, I'm splitting it off from the ArgumentList refactoring to make the rebasing there a little more straightforward.
