### PR TITLE
[stdlib] add a fast path to UMRBP.initialize(as:from:)

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -664,7 +664,6 @@ extension Unsafe${Mutable}RawBufferPointer {
   public func initializeMemory<S: Sequence>(
     as type: S.Element.Type, from source: S
   ) -> (unwritten: S.Iterator, initialized: UnsafeMutableBufferPointer<S.Element>) {
-    // TODO: Optimize where `C` is a `ContiguousArrayBuffer`.
 
     var unwritten = source.makeIterator()
     let elementStride = MemoryLayout<S.Element>.stride
@@ -694,6 +693,43 @@ extension Unsafe${Mutable}RawBufferPointer {
 
     let start = base.assumingMemoryBound(to: S.Element.self)
     let buffer = UnsafeMutableBufferPointer(start: start, count: written)
+    return (unwritten, buffer)
+  }
+
+  /// Initializes the buffer's memory with the given elements, binding the
+  /// initialized memory to the elements' type.
+  ///
+  /// When calling the `initializeMemory(as:from:)` method on a buffer `b`,
+  /// the memory referenced by `b` must be uninitialized or initialized to a
+  /// trivial type, and must be properly aligned for accessing `C.Element`.
+  /// The buffer must contain sufficient memory to accommodate
+  /// `source.count`.
+  ///
+  /// This method initializes the buffer with elements from `source` until
+  /// `source` is exhausted. After calling `initializeMemory(as:from:)`,
+  /// the memory referenced by the returned `UnsafeMutableBufferPointer`
+  /// instance is bound and initialized to type `C.Element`.
+  ///
+  /// - Parameters:
+  ///   - type: The type of the elements to bind the buffer's memory to.
+  ///   - source: A collection of elements with which to initialize the buffer.
+  /// - Returns: An iterator to any elements of `source` that didn't fit in the
+  ///   buffer, and a typed buffer of the written elements. The returned
+  ///   buffer references memory starting at the same base address as this
+  ///   buffer.
+  @_alwaysEmitIntoClient
+  public func initializeMemory<C: Collection>(
+    as type: C.Element.Type, from source: C
+  ) -> (unwritten: C.Iterator, initialized: UnsafeMutableBufferPointer<C.Element>) {
+
+    let offered = source.count
+    _precondition(offered <= count / MemoryLayout<C.Element>.stride,
+      "insufficient space to accommodate source.count elements")
+
+    let start = baseAddress?.bindMemory(to: C.Element.self, capacity: offered)
+    let buffer = UnsafeMutableBufferPointer(start: start, count: offered)
+    let (unwritten, written) = source._copyContents(initializing: buffer)
+    _internalInvariant(written == offered)
     return (unwritten, buffer)
   }
   %  end # mutable

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -669,20 +669,20 @@ extension Unsafe${Mutable}RawBufferPointer {
     var it = source.makeIterator()
     var idx = startIndex
     let elementStride = MemoryLayout<S.Element>.stride
-    
+
     // This has to be a debug precondition due to the cost of walking over some collections.
     _debugPrecondition(source.underestimatedCount <= (count / elementStride),
       "insufficient space to accommodate source.underestimatedCount elements")
     guard let base = baseAddress else {
       // this can be a precondition since only an invalid argument should be costly
-      _precondition(source.underestimatedCount == 0, 
+      _precondition(source.underestimatedCount == 0,
         "no memory available to initialize from source")
       return (it, UnsafeMutableBufferPointer(start: nil, count: 0))
-    }  
+    }
 
-    for p in stride(from: base, 
+    for p in stride(from: base,
       // only advance to as far as the last element that will fit
-      to: base + count - elementStride + 1, 
+      to: base + count - elementStride + 1,
       by: elementStride
     ) {
       // underflow is permitted -- e.g. a sequence into

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -666,35 +666,35 @@ extension Unsafe${Mutable}RawBufferPointer {
   ) -> (unwritten: S.Iterator, initialized: UnsafeMutableBufferPointer<S.Element>) {
     // TODO: Optimize where `C` is a `ContiguousArrayBuffer`.
 
-    var it = source.makeIterator()
-    var idx = startIndex
+    var unwritten = source.makeIterator()
     let elementStride = MemoryLayout<S.Element>.stride
 
     // This has to be a debug precondition due to the cost of walking over some collections.
-    _debugPrecondition(source.underestimatedCount <= (count / elementStride),
+    _debugPrecondition(source.underestimatedCount * elementStride <= count,
       "insufficient space to accommodate source.underestimatedCount elements")
-    guard let base = baseAddress else {
+    guard let base = _position, let end = _end else {
       // this can be a precondition since only an invalid argument should be costly
       _precondition(source.underestimatedCount == 0,
         "no memory available to initialize from source")
-      return (it, UnsafeMutableBufferPointer(start: nil, count: 0))
+      return (unwritten, UnsafeMutableBufferPointer(start: nil, count: 0))
     }
 
+    var written = 0
     for p in stride(from: base,
       // only advance to as far as the last element that will fit
-      to: base + count - elementStride + 1,
+      to: end - elementStride + 1,
       by: elementStride
     ) {
       // underflow is permitted -- e.g. a sequence into
       // the spare capacity of an Array buffer
-      guard let x = it.next() else { break }
+      guard let x = unwritten.next() else { break }
       p.initializeMemory(as: S.Element.self, repeating: x, count: 1)
-      formIndex(&idx, offsetBy: elementStride)
+      written += 1
     }
 
-    return (it, UnsafeMutableBufferPointer(
-                  start: base.assumingMemoryBound(to: S.Element.self), 
-                  count: idx / elementStride))
+    let start = base.assumingMemoryBound(to: S.Element.self)
+    let buffer = UnsafeMutableBufferPointer(start: start, count: written)
+    return (unwritten, buffer)
   }
   %  end # mutable
 

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -310,7 +310,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.set.underflow") {
   let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 2, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
 
-  var bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[1..<2])
+  let bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[1..<2])
 
   if _isDebugAssertConfiguration() {
     expectCrashLater()
@@ -323,7 +323,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.set.overflow") {
   let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 2, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
 
-  var bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[0..<1])
+  let bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[0..<1])
 
   if _isDebugAssertConfiguration() {
     expectCrashLater()
@@ -359,10 +359,10 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.get.overflow") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.set.underflow") {
-  var buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
 
-  var bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[1..<3])
+  let bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[1..<3])
 
   if _isDebugAssertConfiguration() {
     expectCrashLater()
@@ -372,10 +372,10 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.set.underflow") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.set.overflow") {
-  var buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
 
-  var bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[0..<2])
+  let bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[0..<2])
 
   if _isDebugAssertConfiguration() {
     expectCrashLater()
@@ -386,7 +386,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.set.overflow") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.narrow") {
-  var buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
 
   if _isDebugAssertConfiguration() {
@@ -397,7 +397,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.narrow") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.wide") {
-  var buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
 
   if _isDebugAssertConfiguration() {
@@ -420,7 +420,7 @@ UnsafeRawBufferPointerTestSuite.test("_copyContents") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("copyMemory.overflow") {
-  var buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
 
   let bytes = buffer[0..<2]
@@ -447,7 +447,7 @@ UnsafeRawBufferPointerTestSuite.test("copyBytes.withoutContiguouseStorage") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("copyBytes.sequence.overflow") {
-  var buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
   
   let bytes = buffer[0..<2]

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -128,40 +128,88 @@ UnsafeRawBufferPointerTestSuite.test("initFromArray") {
   expectEqual(array2, array1)
 }
 
-UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).underflow") {
-  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 30, alignment: MemoryLayout<UInt>.alignment)
+UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).overflow") {
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: MemoryLayout<Int64>.stride * 3 + 3,
+    alignment: MemoryLayout<Int64>.alignment
+  )
   defer { buffer.deallocate() }
   let source = stride(from: 5 as Int64, to: 0, by: -1)
   if _isDebugAssertConfiguration() {
     expectCrashLater()
   }
-  var (it, bound) = buffer.initializeMemory(as: Int64.self, from: source)
-  let idx = bound.endIndex * MemoryLayout<Int64>.stride
-  expectEqual(it.next()!, 2)
-  expectEqual(idx, 24)
-  let expected: [Int64] = [5,4,3]
-  expected.withUnsafeBytes { expectEqualSequence($0,buffer[0..<idx]) }
-  expectEqualSequence([5, 4, 3],bound)
+  var (unwritten, written) = buffer.initializeMemory(as: Int64.self, from: source)
+  expectEqual(unwritten.next(), Optional(2))
+  let expected = source.dropLast(2)
+  expectEqual(written.count, expected.count)
+  let limit = written.count * MemoryLayout<Int64>.stride
+  expectLT(limit, buffer.count)
+  expected.withUnsafeBytes { expectEqualSequence($0, buffer[0..<limit]) }
+  expectEqualSequence(expected, written)
 }
 
-UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).overflow") {
-  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 30, alignment: MemoryLayout<UInt>.alignment)
+UnsafeRawBufferPointerTestSuite.test(
+  "initializeMemory(as:from:).sequence.partialfill"
+) {
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: MemoryLayout<Int64>.stride * 16,
+    alignment: MemoryLayout<Int64>.alignment
+  )
+  defer { buffer.deallocate() }
+  let source = stride(from: 5 as Int64, to: 0, by: -1)
+  var (unwritten, written) = buffer.initializeMemory(as: Int64.self, from: source)
+  expectNil(unwritten.next())
+  let expected = Array(source)
+  expectEqual(written.count, expected.count)
+  let limit = written.count * MemoryLayout<Int64>.stride
+  expectLT(limit, buffer.count)
+  expected.withUnsafeBytes { expectEqualSequence($0, buffer[0..<limit]) }
+  expectEqualSequence(expected, written)
+}
+
+UnsafeRawBufferPointerTestSuite.test(
+  "initializeMemory(as:from:).collection.partialfill"
+) {
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: MemoryLayout<Int64>.stride * 16,
+    alignment: MemoryLayout<Int64>.alignment
+  )
   defer { buffer.deallocate() }
   let source: [Int64] = [5, 4, 3, 2, 1]
-  if _isDebugAssertConfiguration() {
-    expectCrashLater()
-  }
-  var (it,bound) = buffer.initializeMemory(as: Int64.self, from: source)
-  let idx = bound.endIndex * MemoryLayout<Int64>.stride
-  expectEqual(it.next()!, 2)
-  expectEqual(idx, 24)
-  let expected: [Int64] = [5,4,3]
-  expected.withUnsafeBytes { expectEqualSequence($0,buffer[0..<idx]) }
-  expectEqualSequence([5, 4, 3],bound)
+  var (unwritten, written) = buffer.initializeMemory(as: Int64.self, from: source)
+  expectNil(unwritten.next())
+  expectEqual(written.count, source.count)
+  let limit = written.count * MemoryLayout<Int64>.stride
+  expectLT(limit, buffer.count)
+  source.withUnsafeBytes { expectEqualSequence($0, buffer[0..<limit]) }
+  expectEqualSequence(source, written)
 }
 
-UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).exact") {
-  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 24, alignment: MemoryLayout<UInt>.alignment)
+UnsafeRawBufferPointerTestSuite.test(
+  "initializeMemory(as:from:).sequence.exact"
+) {
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: MemoryLayout<Int64>.stride * 3,
+    alignment: MemoryLayout<Int64>.alignment
+  )
+  defer { buffer.deallocate() }
+  let source = stride(from: 5 as Int64, to: 2, by: -1)
+  var (unwritten, written) = buffer.initializeMemory(as: Int64.self, from: source)
+  expectNil(unwritten.next())
+  expectEqual(written.endIndex, Array(source).count)
+  expectEqual(written.endIndex * MemoryLayout<Int64>.stride, buffer.endIndex)
+  let expected = Array(source)
+  expected.withUnsafeBytes { expectEqualSequence($0, buffer) }
+  expectEqualSequence(expected, written)
+}
+
+UnsafeRawBufferPointerTestSuite.test(
+  "initializeMemory(as:from:).collection.exact"
+) {
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: MemoryLayout<Int64>.stride * 3,
+    alignment: MemoryLayout<Int64>.alignment
+  )
   defer { buffer.deallocate() }
   let source: [Int64] = [5, 4, 3]
   var (it,bound) = buffer.initializeMemory(as: Int64.self, from: source)
@@ -172,20 +220,34 @@ UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).exact") {
   expectEqualSequence([5, 4, 3],bound)
 }
 
-UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).invalidNilPtr") {
+UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).invalidNilPtr.Collection") {
   let buffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
   let source: [Int64] = [5, 4, 3, 2, 1]
   expectCrashLater()
   _ = buffer.initializeMemory(as: Int64.self, from: source)
 }
 
-UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).validNilPtr") {
+UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).invalidNilPtr.Sequence") {
   let buffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
-  let source: [Int64] = []
+  let source = stride(from: Int64.zero, to: 10, by: 2)
+  expectCrashLater()
+  _ = buffer.initializeMemory(as: Int64.self, from: source)
+}
+
+UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).validNilPtr.Collection") {
+  let buffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
+  let source = EmptyCollection<Int64>()
   var (it, bound) = buffer.initializeMemory(as: Int64.self, from: source)
-  let idx = bound.endIndex * MemoryLayout<Int64>.stride
   expectNil(it.next())
-  expectEqual(idx, source.endIndex)
+  expectEqual(bound.startIndex, bound.endIndex)
+}
+
+UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).validNilPtr.Sequence") {
+  let buffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
+  let source = IteratorSequence(EmptyCollection<Int64>().makeIterator())
+  var (it, bound) = buffer.initializeMemory(as: Int64.self, from: source)
+  expectNil(it.next())
+  expectEqual(bound.startIndex, bound.endIndex)
 }
 
 


### PR DESCRIPTION
Add fast path via withContiguousStorageIfAvailable and _copyContents for UnsafeMutableRawBufferPointer.initialize(as:from:).
The current implementation just copies element-by-element, and the performance could be better.
This adds an (`alwaysEmitIntoClient`) overload for `Collection`, which enables using `_copyContents` directly.

Resolves SR-14982 (rdar://81168547)
