### PR TITLE
Disable flaky `Driver/lock_interface.swift` test to keep CI reliable.

### DIFF
--- a/test/Driver/lock_interface.swift
+++ b/test/Driver/lock_interface.swift
@@ -1,3 +1,4 @@
+// REQUIRES: radar82261445
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/sdk)
 // RUN: %empty-directory(%t/module-cache-lock)


### PR DESCRIPTION
This `Driver/lock_interface.swift test` has been spontaneously failing for the past few days. I've decided to disable it until an investigation and fix can happen. This test failed at least once a few days earlier.

Here is an example failure from a [recent build](https://ci.swift.org/job/oss-swift_tools-RA_stdlib-RD_test-simulator/4499/):

```
******************** TEST 'Swift(macosx-x86_64) :: Driver/lock_interface.swift' FAILED ********************
Script:
--
: 'RUN: at line 1';   rm -rf "/Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp" && mkdir -p "/Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp"
: 'RUN: at line 2';   rm -rf "/Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/sdk" && mkdir -p "/Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/sdk"
: 'RUN: at line 3';   rm -rf "/Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/module-cache-lock" && mkdir -p "/Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/module-cache-lock"
: 'RUN: at line 4';   rm -rf "/Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/module-cache-no-lock" && mkdir -p "/Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/module-cache-no-lock"
: 'RUN: at line 5';   echo 'public func foo() {}' > /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/sdk/Foo.swift
: 'RUN: at line 6';   /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/bin/swift-frontend -target x86_64-apple-macosx10.9  -module-cache-path /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/swift-test-results/x86_64-apple-macosx10.9/clang-module-cache -sdk '/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.0.sdk'  -swift-version 4  -define-availability 'SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0' -typo-correction-limit 10 -typecheck -emit-module-interface-path /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/sdk/Foo.swiftinterface /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/sdk/Foo.swift -enable-library-evolution
: 'RUN: at line 7';   chmod a-w /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/sdk
: 'RUN: at line 9';   touch /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/main.swift /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/file-01.swift /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/file-02.swift /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/file-03.swift
: 'RUN: at line 10';   echo 'import Foo' > /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/file-01.swift
: 'RUN: at line 11';   echo 'import Foo' > /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/file-02.swift
: 'RUN: at line 12';   echo 'import Foo' > /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/file-03.swift
: 'RUN: at line 13';   xcrun --toolchain default --sdk '/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.0.sdk' /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/bin/swiftc -toolchain-stdlib-rpath -target x86_64-apple-macosx10.9  -module-cache-path /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/swift-test-results/x86_64-apple-macosx10.9/clang-module-cache -Xlinker -headerpad_max_install_names -Xlinker -rpath -Xlinker /usr/lib/swift  -Xfrontend -define-availability -Xfrontend 'SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0'  -j20 /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/main.swift /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/file-01.swift /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/file-02.swift /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/file-03.swift -I /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/sdk -Xfrontend -Rmodule-interface-rebuild -module-cache-path /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/module-cache &> /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/result-with-lock.txt
: 'RUN: at line 18';   xcrun --toolchain default --sdk '/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.0.sdk' /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/bin/swiftc -toolchain-stdlib-rpath -target x86_64-apple-macosx10.9  -module-cache-path /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/swift-test-results/x86_64-apple-macosx10.9/clang-module-cache -Xlinker -headerpad_max_install_names -Xlinker -rpath -Xlinker /usr/lib/swift  -Xfrontend -define-availability -Xfrontend 'SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0'  -j20 /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/main.swift /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/file-01.swift /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/file-02.swift /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/file-03.swift -I /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/sdk -Xfrontend -Rmodule-interface-rebuild -Xfrontend -disable-interface-lock -module-cache-path /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/module-cache-no-lock &> /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/result-no-lock.txt
: 'RUN: at line 21';   chmod a+w /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/sdk
: 'RUN: at line 24';   /Applications/Xcode-beta.app/Contents/Developer/usr/bin/python3 /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/swift/utils/PathSanitizingFileCheck --sanitize BUILD_DIR=/Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64 --sanitize SOURCE_DIR=/Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/swift --use-filecheck /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/llvm-macosx-x86_64/bin/FileCheck  /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/swift/test/Driver/lock_interface.swift  -check-prefix=CHECK-REBUILD < /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/result-with-lock.txt
: 'RUN: at line 29';   /Applications/Xcode-beta.app/Contents/Developer/usr/bin/python3 /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/swift/utils/PathSanitizingFileCheck --sanitize BUILD_DIR=/Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64 --sanitize SOURCE_DIR=/Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/swift --use-filecheck /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/llvm-macosx-x86_64/bin/FileCheck  /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/swift/test/Driver/lock_interface.swift  -check-prefix=CHECK-REBUILD-NO-LOCK < /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/result-no-lock.txt
--
Exit Code: 1

Command Output (stderr):
--
rm: /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/sdk/Foo.swift: Permission denied
rm: /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/sdk/Foo.swiftinterface: Permission denied
rm: /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp/sdk: Directory not empty
rm: /Volumes/swift-ci/jenkins/workspace/oss-swift_tools-RA_stdlib-RD_test-simulator/Ninja-ReleaseAssert/swift-macosx-x86_64/test-macosx-x86_64/Driver/Output/lock_interface.swift.tmp: Directory not empty

--

********************
```
