### PR TITLE
[NFC][Basic] Import llvm::isa_and_nonnull to 'swift' namespace

### DIFF
--- a/include/swift/Basic/LLVM.h
+++ b/include/swift/Basic/LLVM.h
@@ -73,6 +73,7 @@ namespace llvm {
 namespace swift {
   // Casting operators.
   using llvm::isa;
+  using llvm::isa_and_nonnull;
   using llvm::cast;
   using llvm::dyn_cast;
   using llvm::dyn_cast_or_null;

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1253,7 +1253,7 @@ public:
       if (Walker.Parent.getAsDecl() && VD->getParentPatternBinding())
         return true;
       auto walkerParentAsStmt = Walker.Parent.getAsStmt();
-      if (walkerParentAsStmt && isa<BraceStmt>(walkerParentAsStmt))
+      if (isa_and_nonnull<BraceStmt>(walkerParentAsStmt))
         return true;
     }
     return false;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1343,8 +1343,7 @@ synthesizeValueConstructorBody(AbstractFunctionDecl *afd, void *context) {
     for (unsigned i = 0, e = members.size(); i < e; ++i) {
       auto var = members[i];
 
-      if (var->hasClangNode() &&
-          isa<clang::IndirectFieldDecl>(var->getClangDecl()))
+      if (isa_and_nonnull<clang::IndirectFieldDecl>(var->getClangDecl()))
         continue;
 
       if (var->hasStorage() == (pass != 0)) {

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -6366,7 +6366,7 @@ void CodeCompletionCallbacksImpl::addKeywords(CodeCompletionResultSink &Sink,
     if (ParsedDecl && ParsedDecl == CurDeclContext->getAsDecl())
       DC = ParsedDecl->getDeclContext();
     if (!isa<ProtocolDecl>(DC))
-      if (DC->isTypeContext() || (ParsedDecl && isa<FuncDecl>(ParsedDecl)))
+      if (DC->isTypeContext() || isa_and_nonnull<FuncDecl>(ParsedDecl))
         addOpaqueTypeKeyword(Sink);
 
     LLVM_FALLTHROUGH;
@@ -7012,7 +7012,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
   }
   if (auto *DRE = dyn_cast_or_null<DeclRefExpr>(ParsedExpr)) {
     Lookup.setIsSelfRefExpr(DRE->getDecl()->getName() == Context.Id_self);
-  } else if (ParsedExpr && isa<SuperRefExpr>(ParsedExpr)) {
+  } else if (isa_and_nonnull<SuperRefExpr>(ParsedExpr)) {
     Lookup.setIsSuperRefExpr();
   }
 
@@ -7205,7 +7205,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
       Lookup.setHaveLParen(true);
       for (auto &typeAndDecl : ContextInfo.getPossibleCallees()) {
         auto apply = ContextInfo.getAnalyzedExpr();
-        if (apply && isa<SubscriptExpr>(apply)) {
+        if (isa_and_nonnull<SubscriptExpr>(apply)) {
           Lookup.addSubscriptCallPattern(
               typeAndDecl.Type,
               dyn_cast_or_null<SubscriptDecl>(typeAndDecl.Decl),

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -4505,7 +4505,7 @@ struct AsyncHandlerParamDesc : public AsyncHandlerDesc {
   }
 
   bool alternativeIsAccessor() const {
-    return Alternative && isa<AccessorDecl>(Alternative);
+    return isa_and_nonnull<AccessorDecl>(Alternative);
   }
 };
 
@@ -6828,7 +6828,7 @@ private:
       // for the completion handler call, e.g 'return completion(args...)'. In
       // that case, be sure not to add another return.
       auto *parent = getWalker().Parent.getAsStmt();
-      if (parent && isa<ReturnStmt>(parent) &&
+      if (isa_and_nonnull<ReturnStmt>(parent) &&
           !cast<ReturnStmt>(parent)->isImplicit()) {
         // The statement already has a return keyword. Don't add another one.
         AddedReturnOrThrow = false;

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1690,8 +1690,7 @@ private:
   static bool canMangle(TypeBase *Ty) {
     // TODO: C++ types are not yet supported (SR-13223).
     if (Ty->getStructOrBoundGenericStruct() &&
-        Ty->getStructOrBoundGenericStruct()->getClangDecl() &&
-        isa<clang::CXXRecordDecl>(
+        isa_and_nonnull<clang::CXXRecordDecl>(
             Ty->getStructOrBoundGenericStruct()->getClangDecl()))
       return false;
 
@@ -2445,7 +2444,7 @@ void IRGenDebugInfoImpl::emitVariableDeclaration(
     while (isa<llvm::DILexicalBlock>(Scope))
       Scope = cast<llvm::DILexicalBlock>(Scope)->getScope();
   }
-  assert(Scope && isa<llvm::DIScope>(Scope) && "variable has no scope");
+  assert(isa_and_nonnull<llvm::DIScope>(Scope) && "variable has no scope");
   llvm::DIFile *Unit = getFile(Scope);
   llvm::DIType *DITy = getOrCreateType(DbgTy);
   assert(DITy && "could not determine debug type of variable");
@@ -2636,8 +2635,7 @@ void IRGenDebugInfoImpl::emitGlobalVariableDeclaration(
     if (MetatypeType *metaTy = dyn_cast<MetatypeType>(ty))
       ty = metaTy->getInstanceType().getPointer();
     if (ty->getStructOrBoundGenericStruct() &&
-        ty->getStructOrBoundGenericStruct()->getClangDecl() &&
-        isa<clang::CXXRecordDecl>(
+        isa_and_nonnull<clang::CXXRecordDecl>(
             ty->getStructOrBoundGenericStruct()->getClangDecl()))
       return;
   }

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1065,8 +1065,7 @@ public:
       if (MetatypeType *metaTy = dyn_cast<MetatypeType>(ty))
         ty = metaTy->getRootClass().getPointer();
       if (ty->getStructOrBoundGenericStruct() &&
-          ty->getStructOrBoundGenericStruct()->getClangDecl() &&
-          isa<clang::CXXRecordDecl>(
+          isa_and_nonnull<clang::CXXRecordDecl>(
               ty->getStructOrBoundGenericStruct()->getClangDecl()))
         return;
     }
@@ -1709,7 +1708,7 @@ IRGenSILFunction::IRGenSILFunction(IRGenModule &IGM, SILFunction *f)
     CurFn->addFnAttr(llvm::Attribute::SanitizeAddress);
   if (IGM.IRGen.Opts.Sanitizers & SanitizerKind::Thread) {
     auto declContext = f->getDeclContext();
-    if (declContext && isa<DestructorDecl>(declContext)) {
+    if (isa_and_nonnull<DestructorDecl>(declContext)) {
       // Do not report races in deinit and anything called from it
       // because TSan does not observe synchronization between retain
       // count dropping to '0' and the object deinitialization.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6906,7 +6906,7 @@ ParserResult<FuncDecl> Parser::parseDeclFunc(SourceLoc StaticLoc,
                               CurDeclContext);
 
   // Let the source file track the opaque return type mapping, if any.
-  if (FuncRetTy && isa<OpaqueReturnTypeRepr>(FuncRetTy) &&
+  if (isa_and_nonnull<OpaqueReturnTypeRepr>(FuncRetTy) &&
       !InInactiveClauseEnvironment) {
     if (auto sf = CurDeclContext->getParentSourceFile()) {
       sf->addUnvalidatedDeclWithOpaqueResultType(FD);
@@ -7773,7 +7773,7 @@ Parser::parseDeclSubscript(SourceLoc StaticLoc,
   Subscript->getAttrs() = Attributes;
   
   // Let the source file track the opaque return type mapping, if any.
-  if (ElementTy.get() && isa<OpaqueReturnTypeRepr>(ElementTy.get()) &&
+  if (isa_and_nonnull<OpaqueReturnTypeRepr>(ElementTy.get()) &&
       !InInactiveClauseEnvironment) {
     if (auto sf = CurDeclContext->getParentSourceFile()) {
       sf->addUnvalidatedDeclWithOpaqueResultType(Subscript);

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -4309,8 +4309,8 @@ TypeConverter::getLoweredFormalTypes(SILDeclRef constant,
 
   // If this is a C++ constructor, don't add the metatype "self" parameter
   // because we'll never use it and it will cause problems in IRGen.
-  if (constant.getDecl()->getClangDecl() &&
-      isa<clang::CXXConstructorDecl>(constant.getDecl()->getClangDecl())) {
+  if (isa_and_nonnull<clang::CXXConstructorDecl>(
+          constant.getDecl()->getClangDecl())) {
     // But, make sure it is actually a metatype that we're not adding. If
     // changes to the self parameter are made in the future, this logic may
     // need to be updated.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -555,8 +555,8 @@ public:
     };
 
     // Remove the metatype "self" parameter by making this a static member.
-    if (constant->getDecl()->getClangDecl() &&
-        isa<clang::CXXConstructorDecl>(constant->getDecl()->getClangDecl()))
+    if (isa_and_nonnull<clang::CXXConstructorDecl>(
+            constant->getDecl()->getClangDecl()))
       result.foreign.self.setStatic();
 
     return result;

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -594,7 +594,7 @@ public:
   }
 
   bool isInPlaceInitializationOfGlobal() const override {
-    return existential && isa<GlobalAddrInst>(existential);
+    return isa_and_nonnull<GlobalAddrInst>(existential);
   }
 
   void finishInitialization(SILGenFunction &SGF) override {

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3138,8 +3138,7 @@ bool isCallToReplacedInDynamicReplacement(SILGenFunction &SGF,
                                           bool &isObjCReplacementSelfCall);
 
 static bool isCallToSelfOfCurrentFunction(SILGenFunction &SGF, LookupExpr *e) {
-  return SGF.FunctionDC->getAsDecl() &&
-         isa<AbstractFunctionDecl>(SGF.FunctionDC->getAsDecl()) &&
+  return isa_and_nonnull<AbstractFunctionDecl>(SGF.FunctionDC->getAsDecl()) &&
          e->getBase()->isSelfExprOf(
              cast<AbstractFunctionDecl>(SGF.FunctionDC->getAsDecl()), false);
 }

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -616,7 +616,7 @@ emitDerivativeFunctionReference(
       context.emitNondifferentiabilityError(
           original, invoker, diag::autodiff_private_derivative_from_fragile,
           fragileKind,
-          llvm::isa_and_nonnull<AbstractClosureExpr>(
+          isa_and_nonnull<AbstractClosureExpr>(
               originalFRI->getLoc().getAsASTNode<Expr>()));
       return None;
     }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -202,8 +202,7 @@ Solution::resolveConcreteDeclRef(ValueDecl *decl,
 
   // If this is a C++ function template, get it's specialization for the given
   // substitution map and update the decl accordingly.
-  if (decl->getClangDecl() &&
-      isa<clang::FunctionTemplateDecl>(decl->getClangDecl())) {
+  if (isa_and_nonnull<clang::FunctionTemplateDecl>(decl->getClangDecl())) {
     auto *newFn =
         decl->getASTContext()
             .getClangModuleLoader()

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3162,7 +3162,7 @@ void ContextualFailure::tryComputedPropertyFixIts() const {
       auto *initExpr = PBD->getInit(i);
       if (!VD->isStatic() &&
           !VD->getAttrs().getAttribute<DynamicReplacementAttr>() &&
-          initExpr && isa<ClosureExpr>(initExpr)) {
+          isa_and_nonnull<ClosureExpr>(initExpr)) {
         auto diag = emitDiagnostic(diag::extension_stored_property_fixit,
                                    VD->getName());
         diag.fixItRemove(PBD->getEqualLoc(i));
@@ -3956,7 +3956,7 @@ bool AllowTypeOrInstanceMemberFailure::diagnoseAsError() {
         if (!argExpr)
           return false;
         auto possibleApplyExpr = findParentExpr(expr);
-        return possibleApplyExpr && isa<ApplyExpr>(possibleApplyExpr);
+        return isa_and_nonnull<ApplyExpr>(possibleApplyExpr);
       };
 
       auto *initCall = findParentExpr(findParentExpr(ctorRef));
@@ -6924,14 +6924,14 @@ bool MissingContextualBaseInMemberRefFailure::diagnoseAsError() {
   auto *parentExpr = findParentExpr(anchor);
 
   // Look through immediate call of unresolved member (e.g., `.foo(0)`).
-  if (parentExpr && isa<CallExpr>(parentExpr))
+  if (isa_and_nonnull<CallExpr>(parentExpr))
     parentExpr = findParentExpr(parentExpr);
 
   // FIXME: We should probably look through the entire member chain so that
   // something like `let _ = .foo().bar` gets the "no contextual type" error
   // rather than the "Cannot infer contextual base" error.
   UnresolvedMemberChainResultExpr *resultExpr = nullptr;
-  if (parentExpr && isa<UnresolvedMemberChainResultExpr>(parentExpr)) {
+  if (isa_and_nonnull<UnresolvedMemberChainResultExpr>(parentExpr)) {
     resultExpr = cast<UnresolvedMemberChainResultExpr>(parentExpr);
     parentExpr = findParentExpr(parentExpr);
   }
@@ -7469,12 +7469,12 @@ bool MissingContextualTypeForNil::diagnoseAsError() {
   // attempt any types for it.
   auto *parentExpr = findParentExpr(expr);
 
-  while (parentExpr && isa<IdentityExpr>(parentExpr))
+  while (isa_and_nonnull<IdentityExpr>(parentExpr))
     parentExpr = findParentExpr(parentExpr);
 
   // In cases like `_ = nil?` AST would have `nil`
   // wrapped in `BindOptionalExpr`.
-  if (parentExpr && isa<BindOptionalExpr>(parentExpr))
+  if (isa_and_nonnull<BindOptionalExpr>(parentExpr))
     parentExpr = findParentExpr(parentExpr);
 
   if (parentExpr) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2318,7 +2318,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
 
     if (shouldAttemptFixes()) {
       auto *anchor = locator.trySimplifyToExpr();
-      if (anchor && isa<ClosureExpr>(anchor) &&
+      if (isa_and_nonnull<ClosureExpr>(anchor) &&
           isSingleTupleParam(ctx, func2Params) &&
           canImplodeParams(func1Params)) {
         auto *fix = AllowClosureParamDestructuring::create(

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5096,7 +5096,7 @@ ConstraintSystem::isConversionEphemeral(ConversionRestrictionKind conversion,
         // For an instance member, the base must be an @lvalue struct type.
         if (auto *lvt = simplifyType(getType(base))->getAs<LValueType>()) {
           auto *nominal = lvt->getObjectType()->getAnyNominal();
-          if (nominal && isa<StructDecl>(nominal)) {
+          if (isa_and_nonnull<StructDecl>(nominal)) {
             subExpr = base;
             continue;
           }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -248,7 +248,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
         // Void to _ then warn, because that is redundant.
         if (auto DAE = dyn_cast<DiscardAssignmentExpr>(destExpr)) {
           if (auto CE = dyn_cast<CallExpr>(AE->getSrc())) {
-            if (CE->getCalledValue() && isa<FuncDecl>(CE->getCalledValue()) &&
+            if (isa_and_nonnull<FuncDecl>(CE->getCalledValue()) &&
                 CE->getType()->isVoid()) {
               Ctx.Diags
                   .diagnose(DAE->getLoc(),
@@ -1427,7 +1427,7 @@ static void diagRecursivePropertyAccess(const Expr *E, const DeclContext *DC) {
 
             // But silence the warning if the base was explicitly qualified.
             auto parentAsExpr = Parent.getAsExpr();
-            if (parentAsExpr && isa<DotSyntaxBaseIgnoredExpr>(parentAsExpr))
+            if (isa_and_nonnull<DotSyntaxBaseIgnoredExpr>(parentAsExpr))
               shouldDiagnose = false;
 
             if (shouldDiagnose) {
@@ -4078,7 +4078,7 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
 
       if (auto *apply = dyn_cast<ApplyExpr>(E)) {
         auto *decl = apply->getCalledValue();
-        if (decl && isa<AbstractFunctionDecl>(decl))
+        if (isa_and_nonnull<AbstractFunctionDecl>(decl))
           return decl;
       }
       return nullptr;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2973,7 +2973,7 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
     if (isa<ParamDecl>(D)) {
       // Check for unsupported declarations.
       auto *context = D->getDeclContext()->getAsDecl();
-      if (context && isa<SubscriptDecl>(context)) {
+      if (isa_and_nonnull<SubscriptDecl>(context)) {
         diagnose(attr->getLocation(),
                  diag::property_wrapper_param_not_supported,
                  context->getDescriptiveKind());

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1978,8 +1978,7 @@ static void fixItAvailableAttrRename(InFlightDiagnostic &diag,
 
     // Continue on to diagnose any argument label renames.
 
-  } else if (parsed.BaseName == "init" &&
-             call && isa<CallExpr>(call)) {
+  } else if (parsed.BaseName == "init" && isa_and_nonnull<CallExpr>(call)) {
     // For initializers, replace with a "call" of the context type...but only
     // if we know we're doing a call (rather than a first-class reference).
     if (parsed.isMember()) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1591,7 +1591,7 @@ namespace {
           }
         }
 
-      } else if (llvm::isa_and_nonnull<SelfApplyExpr>(context) &&
+      } else if (isa_and_nonnull<SelfApplyExpr>(context) &&
           isa<AbstractFunctionDecl>(decl)) {
         // actor-isolated non-isolated-self calls are implicitly async
         // and thus OK.
@@ -1649,7 +1649,7 @@ namespace {
       ValueDecl *decl = concDeclRef.getDecl();
       ThrowsMarkingResult result = ThrowsMarkingResult::NotFound;
 
-      if (llvm::isa_and_nonnull<SelfApplyExpr>(context)) {
+      if (isa_and_nonnull<SelfApplyExpr>(context)) {
         if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
           if (func->isDistributed() && !func->hasThrows()) {
             // A distributed function is implicitly throwing if called from

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1935,7 +1935,7 @@ bool swift::isMemberOperator(FuncDecl *decl, Type type) {
   auto selfNominal = DC->getSelfNominalTypeDecl();
 
   // Check the parameters for a reference to 'Self'.
-  bool isProtocol = selfNominal && isa<ProtocolDecl>(selfNominal);
+  bool isProtocol = isa_and_nonnull<ProtocolDecl>(selfNominal);
   for (auto param : *decl->getParameters()) {
     // Look through a metatype reference, if there is one.
     auto paramType = param->getInterfaceType()->getMetatypeInstanceType();

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2777,7 +2777,7 @@ public:
     if (FD->getDeclContext()->isTypeContext()) {
       if (FD->isOperator() && !isMemberOperator(FD, nullptr)) {
         auto selfNominal = FD->getDeclContext()->getSelfNominalTypeDecl();
-        auto isProtocol = selfNominal && isa<ProtocolDecl>(selfNominal);
+        auto isProtocol = isa_and_nonnull<ProtocolDecl>(selfNominal);
         // We did not find 'Self'. Complain.
         FD->diagnose(diag::operator_in_unrelated_type,
                      FD->getDeclContext()->getDeclaredInterfaceType(), isProtocol,

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1422,7 +1422,7 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
     // Otherwise, complain.  Start with more specific diagnostics.
 
     // Diagnose unused constructor calls.
-    if (callee && isa<ConstructorDecl>(callee) && !call->isImplicit()) {
+    if (isa_and_nonnull<ConstructorDecl>(callee) && !call->isImplicit()) {
       DE.diagnose(fn->getLoc(), diag::expression_unused_init_result,
                callee->getDeclContext()->getDeclaredInterfaceType())
         .highlight(call->getArg()->getSourceRange());

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3762,7 +3762,7 @@ TypeResolver::resolveCompositionType(CompositionTypeRepr *repr,
     if (ty->hasError()) return ty;
 
     auto nominalDecl = ty->getAnyNominal();
-    if (nominalDecl && isa<ClassDecl>(nominalDecl)) {
+    if (isa_and_nonnull<ClassDecl>(nominalDecl)) {
       if (checkSuperclass(tyR->getStartLoc(), ty))
         continue;
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6495,8 +6495,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
     } else {
       fatal(thirdOrError.takeError());
     }
-    if (third &&
-        isa<TypeAliasDecl>(third) &&
+    if (isa_and_nonnull<TypeAliasDecl>(third) &&
         third->getModuleContext() != getAssociatedModule() &&
         !third->getDeclaredInterfaceType()->isEqual(second)) {
       // Conservatively drop references to typealiases in other modules


### PR DESCRIPTION
Just for convenicence.

* Replace `llvm::isa_and_nonnull` with imported `isa_and_nonnull`
* Repalce some `EXPR && isa<T>(EXPR)` with `isa_and_nonnull<T>(EXPR)`
