### PR TITLE
[ConstraintSystem] Improvements to pattern binding checking

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8811,6 +8811,7 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
 
       if (patternBinding->getInit(index)) {
         patternBinding->setInit(index, resultTarget->getAsExpr());
+        patternBinding->setInitializerChecked(index);
       }
     }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8831,11 +8831,9 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
     auto contextualPattern = target.getContextualPattern();
     auto patternType = target.getTypeOfUninitializedVar();
 
-    TypeResolutionOptions options = TypeResolverContext::PatternBindingDecl;
-    options |= TypeResolutionFlags::OverrideType;
-
     if (auto coercedPattern = TypeChecker::coercePatternToType(
-            contextualPattern, patternType, options)) {
+            contextualPattern, patternType,
+            TypeResolverContext::PatternBindingDecl)) {
       auto resultTarget = target;
       resultTarget.setPattern(coercedPattern);
       return resultTarget;

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2873,16 +2873,17 @@ PropertyWrapperInitializerInfoRequest::evaluate(Evaluator &evaluator,
         && parentPBD->isDefaultInitializable(patternNumber)
         && !wrapperInfo.defaultInit) {
       auto ty = parentPBD->getPattern(patternNumber)->getType();
-      if (auto defaultInit = TypeChecker::buildDefaultInitializer(ty))
-        parentPBD->setInit(patternNumber, defaultInit);
-    }
-
-    if (parentPBD->isInitialized(patternNumber) &&
-        !parentPBD->isInitializerChecked(patternNumber)) {
-      TypeChecker::typeCheckPatternBinding(parentPBD, patternNumber);
+      if (auto defaultInit = TypeChecker::buildDefaultInitializer(ty)) {
+        typeCheckSynthesizedWrapperInitializer(var, defaultInit);
+        parentPBD->setInit(0, defaultInit);
+        parentPBD->setInitializerChecked(0);
+      }
     }
 
     if ((initializer = parentPBD->getInit(patternNumber))) {
+      assert(parentPBD->isInitializerChecked(0) &&
+             "Initializer should to be type-checked");
+
       pbd->setInit(0, initializer);
       pbd->setInitializerChecked(0);
       wrappedValue = findWrappedValuePlaceholder(initializer);


### PR DESCRIPTION
I couple of issues I have found while working on multi-statement closure type-checking.

- When a coerced pattern is set for the binding that needs to be signaled via using `setInitializerChecked`
- Pattern coercion used an extraneous flag
- Property wrapper initializer request attempted could attempt to re-typecheck initializer which left it in an incorrect state.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
