### PR TITLE
[AST] Fix comment merging

### DIFF
--- a/include/swift/AST/RawComment.h
+++ b/include/swift/AST/RawComment.h
@@ -55,6 +55,10 @@ struct SingleRawComment {
     return getKind() == CommentKind::OrdinaryLine ||
            getKind() == CommentKind::LineDoc;
   }
+
+  bool isGyb() const {
+    return RawText.startswith("// ###");
+  }
 };
 
 struct RawComment {

--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -68,6 +68,10 @@ SingleRawComment::SingleRawComment(StringRef RawText, unsigned ColumnIndent)
     : RawText(RawText), Kind(static_cast<unsigned>(getCommentKind(RawText))),
       ColumnIndent(ColumnIndent) {}
 
+/// Converts a range of comments (ordinary or doc) to a \c RawComment with
+/// only the last range of doc comments. Gyb comments, ie. "// ###" are skipped
+/// entirely as if they did not exist (so two doc comments would still be
+/// merged if there was a gyb comment inbetween).
 static RawComment toRawComment(ASTContext &Context, CharSourceRange Range) {
   if (Range.isInvalid())
     return RawComment();
@@ -91,25 +95,34 @@ static RawComment toRawComment(ASTContext &Context, CharSourceRange Range) {
     assert(Tok.is(tok::comment));
 
     auto SRC = SingleRawComment(Tok.getRange(), SM);
+    unsigned Start =
+        SM.getLineAndColumnInBuffer(Tok.getRange().getStart()).first;
+    unsigned End = SM.getLineAndColumnInBuffer(Tok.getRange().getEnd()).first;
+    if (SRC.RawText.back() == '\n')
+      End--;
+
     if (SRC.isOrdinary()) {
-      // Skip gyb comments that are line number markers.
-      if (!SRC.RawText.startswith("// ###")) {
+      // If there's a normal comment then reset the current group, unless it's
+      // a gyb comment in which case we should just skip it.
+      if (SRC.isGyb())
+        LastEnd = End;
+      else
         Comments.clear();
-        LastEnd = 0;
-      }
       continue;
     }
 
-    // Merge comments if they are on same or consecutive lines.
-    unsigned Start =
-        SM.getLineAndColumnInBuffer(Tok.getRange().getStart()).first;
-    if (LastEnd > 0 && LastEnd + 1 < Start) {
+    // Merge and keep the *last* group, ie. if there's:
+    //   <comment1>
+    //   <whitespace>
+    //   <comment2>
+    //   <comment3>
+    // Only keep <comment2/3> and group into the one RawComment.
+
+    if (!Comments.empty() && Start > LastEnd + 1)
       Comments.clear();
-      LastEnd = 0;
-    } else {
-      Comments.push_back(SRC);
-      LastEnd = SM.getLineAndColumnInBuffer(Tok.getRange().getEnd()).first;
-    }
+    Comments.push_back(SRC);
+
+    LastEnd = End;
   }
 
   RawComment Result;

--- a/test/IDE/comment_merge.swift
+++ b/test/IDE/comment_merge.swift
@@ -67,30 +67,81 @@ func is_doc14() {}
 /// IS_DOC_END
 func is_doc15() {}
 
-/// is_doc16 IS_DOC_START
-/** Aaa bbb ccc. */
-/// IS_DOC_END
-func is_doc16() {}
+/// IS_DOC_NOT_ATTACHED
+/// Should not return with the comments for the function below it or prevent
+/// its actual comment from being returned.
 
-/** Aaa is_doc17 IS_DOC_START *//** bbb */
-/// IS_DOC_END
-func is_doc17() {}
+/// IS_DOC_START priorCommentOneLineGap Aaa.
+///
+/// Bbb. IS_DOC_END
+func priorCommentOneLineGap() {}
 
 /// IS_DOC_NOT_ATTACHED
-// NOT_DOC
-/// is_doc18 IS_DOC_START IS_DOC_END
-func is_doc18() {}
+/// Same as above but with a two line gap this time.
 
-// Aaa.  NOT_DOC
-/// is_doc19 IS_DOC_START
-/** Aaa
- *
- * Bbb */
-/// Ccc
-/** Ddd
- *  Eee  IS_DOC_END
+
+/// IS_DOC_START priorCommentTwoLineGap Aaa.
+///
+/// Bbb. IS_DOC_END
+func priorCommentTwoLineGap() {}
+
+/// IS_DOC_NOT_ATTACHED
+/// Make sure a gyb comment doesn't cause the previous comment to stay
+/// attached.
+// ###line 9001
+
+/// IS_DOC_START priorCommentGyb Aaa.
+///
+/// Bbb. IS_DOC_END
+func priorCommentGyb() {}
+
+/**
+  IS_DOC_START priorBlockMultiLineComment Aaa.
  */
-func is_doc19() {}
+/**
+  Bbb. IS_DOC_END
+ */
+func priorBlockMultiLineComment() {}
+
+/** IS_DOC_START priorBlockSingleLineComment Aaa. */
+/**
+  Bbb. IS_DOC_END
+ */
+func priorBlockSingleLineComment() {}
+
+/** IS_DOC_START priorBlockMixedComment Aaa. */
+/// Bbb.
+/// Multiline. IS_DOC_END
+func priorBlockMixedComment() {}
+
+/// IS_DOC_START priorLineMixedComment Aaa.
+/// Multiline.
+/**  Bbb. IS_DOC_END */
+func priorLineMixedComment() {}
+
+/// IS_DOC_START priorSingleLineMixedComment Aaa.
+/**
+  Bbb. IS_DOC_END
+ */
+func priorSingleLineMixedComment() {}
+
+/**
+  IS_DOC_START priorBlockMultiLineMixedComment Aaa.
+ */
+/// Bbb. IS_DOC_END
+func priorBlockMultiLineMixedComment() {}
+
+// Aaa. NOT_DOC
+/// allTheThings IS_DOC_NOT_ATTACHED
+/** Bbb IS_DOC_NOT_ATTACHED
+ *
+ * Ccc. */
+// Ddd. NOT_DOC
+/// IS_DOC_START Eee
+/**
+ * Fff. IS_DOC_END
+ */
+func allTheThings() {}
 
 // RUN: %target-swift-ide-test -print-comments -source-filename %s > %t.txt
 // RUN: %FileCheck %s -check-prefix=WRONG < %t.txt
@@ -121,8 +172,13 @@ func is_doc19() {}
 // CHECK-NEXT: comment_merge.swift:59:6: Func/not_doc13 RawComment=none
 // CHECK-NEXT: comment_merge.swift:63:6: Func/is_doc14 RawComment=[/// is_doc14 IS_DOC_START\n/// IS_DOC_END\n]
 // CHECK-NEXT: comment_merge.swift:68:6: Func/is_doc15 RawComment=[/// is_doc15 IS_DOC_START\n/// Aaa bbb ccc.\n/// IS_DOC_END\n]
-// CHECK-NEXT: comment_merge.swift:73:6: Func/is_doc16 RawComment=[/// is_doc16 IS_DOC_START\n/** Aaa bbb ccc. *//// IS_DOC_END\n]
-// CHECK-NEXT: comment_merge.swift:77:6: Func/is_doc17 RawComment=[/** Aaa is_doc17 IS_DOC_START *//** bbb *//// IS_DOC_END\n]
-// CHECK-NEXT: comment_merge.swift:82:6: Func/is_doc18 RawComment=[/// is_doc18 IS_DOC_START IS_DOC_END\n]
-// CHECK-NEXT: comment_merge.swift:93:6: Func/is_doc19 RawComment=[/// is_doc19 IS_DOC_START\n/** Aaa\n *\n * Bbb *//// Ccc\n/** Ddd\n *  Eee  IS_DOC_END\n */]
-
+// CHECK-NEXT: comment_merge.swift:77:6: Func/priorCommentOneLineGap RawComment=[/// IS_DOC_START priorCommentOneLineGap Aaa.\n///\n/// Bbb. IS_DOC_END\n]
+// CHECK-NEXT: comment_merge.swift:86:6: Func/priorCommentTwoLineGap RawComment=[/// IS_DOC_START priorCommentTwoLineGap Aaa.\n///\n/// Bbb. IS_DOC_END\n]
+// CHECK-NEXT: comment_merge.swift:96:6: Func/priorCommentGyb RawComment=[/// IS_DOC_START priorCommentGyb Aaa.\n///\n/// Bbb. IS_DOC_END\n]
+// CHECK-NEXT: comment_merge.swift:104:6: Func/priorBlockMultiLineComment RawComment=[/**\n  IS_DOC_START priorBlockMultiLineComment Aaa.\n *//**\n  Bbb. IS_DOC_END\n */]
+// CHECK-NEXT: comment_merge.swift:110:6: Func/priorBlockSingleLineComment RawComment=[/** IS_DOC_START priorBlockSingleLineComment Aaa. *//**\n  Bbb. IS_DOC_END\n */]
+// CHECK-NEXT: comment_merge.swift:115:6: Func/priorBlockMixedComment RawComment=[/** IS_DOC_START priorBlockMixedComment Aaa. *//// Bbb.\n/// Multiline. IS_DOC_END\n]
+// CHECK-NEXT: comment_merge.swift:120:6: Func/priorLineMixedComment RawComment=[/// IS_DOC_START priorLineMixedComment Aaa.\n/// Multiline.\n/**  Bbb. IS_DOC_END */]
+// CHECK-NEXT: comment_merge.swift:126:6: Func/priorSingleLineMixedComment RawComment=[/// IS_DOC_START priorSingleLineMixedComment Aaa.\n/**\n  Bbb. IS_DOC_END\n */]
+// CHECK-NEXT: comment_merge.swift:132:6: Func/priorBlockMultiLineMixedComment RawComment=[/**\n  IS_DOC_START priorBlockMultiLineMixedComment Aaa.\n *//// Bbb. IS_DOC_END\n]
+// CHECK-NEXT: comment_merge.swift:144:6: Func/allTheThings RawComment=[/// IS_DOC_START Eee\n/**\n * Fff. IS_DOC_END\n */]


### PR DESCRIPTION
`toRawComment` takes a range of line/block ordinary/doc comments and
converts them into a `RawComment` that should represent the doc comment
for the attached decl.

Fix a bunch of unhandled cases:
  - A prior comment with whitespace in between would cause the first
    line of the next comment to be missed
  - A gyb comment would attach the prior comment, regardless of
    whitespace inbetween

Resolves rdar://82414210