### PR TITLE
[build-script] Make `--infer` to be `True` by default

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -587,6 +587,9 @@ def create_argument_parser():
     # -------------------------------------------------------------------------
     in_group('Options to select projects')
 
+    option('--no-infer', toggle_false('infer_dependencies'),
+           help='Do not infer any downstream dependencies from enabled projects')
+
     option('--infer', toggle_true('infer_dependencies'),
            help='Infer any downstream dependencies from enabled projects')
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR sets the `--infer` option to [`build-script`](https://github.com/apple/swift/blob/main/utils/build-script) to be `True` by default and adds a `--no-infer` tag to set it to `False`.

When the `--infer` tag is `True` it invokes [`build-script`'s dependency solver](https://github.com/apple/swift/blob/main/utils/swift_build_support/swift_build_support/build_graph.py). Currently this is set to false by default. 

I realized this when adding two new dependencies to the build system. I think it could make sense to always run the dependency solver despite the fact that it is not necessary given the current build configuration. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

@CodaFi could you review this?

P.S. - This is my first PR to the Swift project! Please let me know if there is anything I should change about my PR and if it even makes sense for the Swift project :)