### PR TITLE
[Concurrency] repair cooperative global executor

### DIFF
--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -93,6 +93,7 @@ func _checkExpectedExecutor(_filenameStart: Builtin.RawPointer,
     _filenameStart, _filenameLength, _filenameIsASCII, _line, _executor)
 }
 
+#if !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
 // This must take a DispatchQueueShim, not something like AnyObject,
 // or else SILGen will emit a retain/release in unoptimized builds,
 // which won't work because DispatchQueues aren't actually
@@ -119,3 +120,4 @@ internal final class DispatchQueueShim: UnsafeSendable, SerialExecutor {
     return UnownedSerialExecutor(ordinary: self)
   }
 }
+#endif

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -34,7 +34,9 @@
 #include "queue" // TODO: remove and replace with usage of our mpsc queue
 #include <atomic>
 #include <assert.h>
+#if !SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
 #include <dispatch/dispatch.h>
+#endif
 
 #if !defined(_WIN32)
 #include <dlfcn.h>

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -112,12 +112,14 @@ void _swift_tsan_release(void *addr);
 /// executors.
 #define DISPATCH_QUEUE_GLOBAL_EXECUTOR (void *)1
 
+#if !defined(SWIFT_STDLIB_SINGLE_THREADED_RUNTIME)
 inline SerialExecutorWitnessTable *
 _swift_task_getDispatchQueueSerialExecutorWitnessTable() {
   extern SerialExecutorWitnessTable wtable
     SWIFT_ASM_LABEL_WITH_PREFIX("$ss17DispatchQueueShimCScfsWP");
   return &wtable;
 }
+#endif
 
 // ==== ------------------------------------------------------------------------
 


### PR DESCRIPTION
`SWIFT_STDLIB_SINGLE_THREADED_RUNTIME` mode has been broken for a long time.

This patch guards some includes and use of libdispatch headers so that platforms
that doesn't support libdispatch can build cooperative executor runtime.
And fixed missing implementations for cooperative mode.

CC: @MaxDesiatov 

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
