### PR TITLE
[Driver] Make -library-level a driver argument and pass it to the frontend

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -485,11 +485,6 @@ def disable_swift3_objc_inference :
   Flags<[FrontendOption, HelpHidden]>,
   HelpText<"Disable Swift 3's @objc inference rules for NSObject-derived classes and 'dynamic' members (emulates Swift 4 behavior)">;
 
-def library_level : Separate<["-"], "library-level">,
-  MetaVarName<"<level>">,
-  Flags<[FrontendOption, ModuleInterfaceOption]>,
-  HelpText<"Library distribution level 'api', 'spi' or 'other' (the default)">;
-
 def enable_implicit_dynamic : Flag<["-"], "enable-implicit-dynamic">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
   HelpText<"Add 'dynamic' to all declarations">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -418,6 +418,11 @@ def define_availability : Separate<["-"], "define-availability">,
   HelpText<"Define an availability macro in the format 'macroName : iOS 13.0, macOS 10.15'">,
   MetaVarName<"<macro>">;
 
+def library_level : Separate<["-"], "library-level">,
+  MetaVarName<"<level>">,
+  Flags<[HelpHidden, FrontendOption, ModuleInterfaceOption]>,
+  HelpText<"Library distribution level 'api', 'spi' or 'other' (the default)">;
+
 def module_name : Separate<["-"], "module-name">,
   Flags<[FrontendOption, ModuleInterfaceOption, SwiftAPIExtractOption,
          SwiftSymbolGraphExtractOption]>,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -285,6 +285,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments,
                        options::OPT_verify_incremental_dependencies);
   inputArgs.AddLastArg(arguments, options::OPT_access_notes_path);
+  inputArgs.AddLastArg(arguments, options::OPT_library_level);
 
   // Pass on any build config options
   inputArgs.AddAllArgs(arguments, options::OPT_D);

--- a/test/Sema/implementation-only-import-suggestion.swift
+++ b/test/Sema/implementation-only-import-suggestion.swift
@@ -20,6 +20,11 @@
 // RUN:   -F %t/sdk/System/Library/PrivateFrameworks/ \
 // RUN:   -library-level spi -D PUBLIC_IMPORTS
 
+/// The driver should also accept the flag and pass it along.
+// RUN: %swiftc_driver -typecheck -sdk %t/sdk -module-cache-path %t %s \
+// RUN:   -F %t/sdk/System/Library/PrivateFrameworks/ \
+// RUN:   -library-level spi -D PUBLIC_IMPORTS
+
 /// Expect no warnings when building a client with some other library level.
 // RUN: %target-swift-frontend -typecheck -sdk %t/sdk -module-cache-path %t %s \
 // RUN:   -F %t/sdk/System/Library/PrivateFrameworks/ \


### PR DESCRIPTION
C++ driver change to align it with the new driver.

Corresponding new driver change: https://github.com/apple/swift-driver/pull/813

rdar://82458987