### PR TITLE
[ConstraintSystem] Allow IUO types to be unrelated while forming a di…

### DIFF
--- a/validation-test/Sema/type_checker_crashers_fixed/sr14893.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/sr14893.swift
@@ -1,0 +1,29 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5
+
+// REQUIRES: OS=macosx
+
+enum Category {
+case first
+}
+
+protocol View {}
+
+extension View {
+  func test(_ tag: Category) -> some View {
+    Image()
+  }
+}
+
+@resultBuilder struct ViewBuilder {
+  static func buildBlock<Content>(_ content: Content) -> Content where Content : View { fatalError() }
+}
+
+struct Image : View {
+}
+
+struct MyView {
+  @ViewBuilder var body: some View {
+    let icon: Category! = Category.first // expected-error {{using '!' is not allowed here; perhaps '?' was intended?}} {{23-24=?}}
+    Image().test(icon)
+  }
+}


### PR DESCRIPTION
…sjunction

Detect situations when type of a declaration hasn't been resolved yet
(one-way constraints would use a type variable to represent a type of IUO pattern),
and use additional type variable and a constraint to represent an
object type of a future optional type.

Resolves: SR-14893
Resolves: rdar://80271666

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
