### PR TITLE
build: repair the sub-build for libdispatch on Windows i686

### DIFF
--- a/cmake/modules/Libdispatch.cmake
+++ b/cmake/modules/Libdispatch.cmake
@@ -69,6 +69,11 @@ foreach(sdk ${DISPATCH_SDKS})
   foreach(arch ${ARCHS})
     set(LIBDISPATCH_VARIANT_NAME "libdispatch-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
 
+    if(sdk MATCHES WINDOWS)
+      set(SWIFT_LIBDISPATCH_COMPILER_TRIPLE_CMAKE_ARGS -DCMAKE_C_COMPILER_TARGET=${SWIFT_SDK_WINDOWS_ARCH_${arch}_TRIPLE};-DCMAKE_CXX_COMPILER_TARGET=${SWIFT_SDK_WINDOWS_ARCH_${arch}_TRIPLE})
+    endif()
+
+
     if(NOT sdk STREQUAL ANDROID)
       set(SWIFT_LIBDISPATCH_SYSTEM_PROCESSOR  -DCMAKE_SYSTEM_PROCESSOR=${arch})
     endif()
@@ -80,6 +85,7 @@ foreach(sdk ${DISPATCH_SDKS})
                           -DCMAKE_AR=${CMAKE_AR}
                           -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                           ${SWIFT_LIBDISPATCH_COMPILER_CMAKE_ARGS}
+                          ${SWIFT_LIBDISPATCH_COMPILER_TRIPLE_CMAKE_ARGS}
                           -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                           -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
                           -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}


### PR DESCRIPTION
When building on Windows i686 with a toolchain build for Windows x64, we
would try to build libdispatch for i686 as x86_64.  This obviously would
be incorrect.  Explicitly pass the target triple for the sub-builds.  We
can do this unconditionally since we always use `clang-cl` builds.  This
allows us to build the SDK only components for Windows i686 from a 64bit
build.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
