### PR TITLE
[NFC] Adjust `driver-time-compilation.swift` to the new format of `llvm::Timer`

### DIFF
--- a/test/Driver/driver-time-compilation.swift
+++ b/test/Driver/driver-time-compilation.swift
@@ -3,8 +3,11 @@
 
 // CHECK: Driver Compilation Time
 // CHECK: Total Execution Time: {{[0-9]+}}.{{[0-9]+}} seconds ({{[0-9]+}}.{{[0-9]+}} wall clock)
-// CHECK: ---Wall Time---
-// CHECK: --- Name ---
-// CHECK: {compile: {{.*}}driver-time-compilation.swift}
+// CHECK: ---User Time---
+// CHECK-SAME: --System Time--
+// CHECK-SAME: --User+System--
+// CHECK-SAME: ---Wall Time---
+// CHECK-SAME: ---Instr---
+// CHECK-SAME: --- Name ---
 // CHECK-MULTIPLE: {compile: {{.*}}empty.swift}
-// CHECK: {{[0-9]+}}.{{[0-9]+}} (100.0%)  Total
+// CHECK: {{[0-9]+}}.{{[0-9]+}} (100.0%) {{[0-9]+}}.{{[0-9]+}} (100.0%) {{[0-9]+}}.{{[0-9]+}} (100.0%) {{[0-9]+}}.{{[0-9]+}} (100.0%) {{.*}} {compile: {{.*}}driver-time-compilation.swift}


### PR DESCRIPTION
Resolves rdar://81809942

