### PR TITLE
[swift-inspect] Make sure to initialize backtrace flags.

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/main.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/main.swift
@@ -159,10 +159,10 @@ struct UniversalOptions: ParsableArguments {
 
 struct BacktraceOptions: ParsableArguments {
   @Flag(help: "Show the backtrace for each allocation")
-  var backtrace: Bool
+  var backtrace: Bool = false
 
   @Flag(help: "Show a long-form backtrace for each allocation")
-  var backtraceLong: Bool
+  var backtraceLong: Bool = false
 
   var style: Backtrace.Style? {
     backtrace ? .oneLine :


### PR DESCRIPTION
This eliminates a compilation error with Swift 5.5 and the latest
argument parser library.
