### PR TITLE
[5.5] Keep the buffer in the invalid UTF8 handling path of String(unsafeUninitializedCapacity:initializingWith:) alive while we're using it

### DIFF
--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -120,6 +120,7 @@ extension String {
       )
       return result.asString
     case .error(let initialRange):
+      defer { _fixLifetime(result) }
       //This could be optimized to use excess tail capacity
       return repairUTF8(result.codeUnits, firstKnownBrokenRange: initialRange)
     }


### PR DESCRIPTION
5.5 backport of https://github.com/apple/swift/pull/39105