### PR TITLE
[build-script-impl] don't assume installation folders are created

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3267,10 +3267,12 @@ for host in "${ALL_HOSTS[@]}"; do
 
         # Copy executables and shared libraries from the `host_install_destdir` to
         # INSTALL_SYMROOT and run dsymutil on them.
-        (cd "${CURRENT_INSTALL_DIR}" &&
-         find ./"${CURRENT_PREFIX}" -perm -0111 -type f -print | \
-         filter_paths "${DARWIN_SYMROOT_PATH_FILTERS}" | \
-         cpio --insecure -pdm -v "${host_symroot}")
+        if [ -d "${CURRENT_INSTALL_DIR}" ]; then
+            (cd "${CURRENT_INSTALL_DIR}" &&
+             find ./"${CURRENT_PREFIX}" -perm -0111 -type f -print | \
+             filter_paths "${DARWIN_SYMROOT_PATH_FILTERS}" | \
+             cpio --insecure -pdm -v "${host_symroot}")
+        fi
 
         dsymutil_path=
         if [[ -n "${DARWIN_INSTALL_EXTRACT_SYMBOLS_USE_JUST_BUILT_DSYMUTIL}" ]]; then
@@ -3285,22 +3287,26 @@ for host in "${ALL_HOSTS[@]}"; do
         # Tweak carefully the amount of parallelism -- dsymutil can be memory intensive and
         # as such too many instance can exhaust the memory and slow down/panic the machine
         printJSONStartTimestamp dsymutil
-        (cd "${host_symroot}" &&
-         find ./"${CURRENT_PREFIX}" -perm -0111 -type f -not -name "*.a" -not -name "*.py" -print | \
-           xargs -n 1 -P ${DSYMUTIL_JOBS} ${dsymutil_path})
+        if [ -d "${host_symroot}" ]; then
+            (cd "${host_symroot}" &&
+             find ./"${CURRENT_PREFIX}" -perm -0111 -type f -not -name "*.a" -not -name "*.py" -print | \
+               xargs -n 1 -P ${DSYMUTIL_JOBS} ${dsymutil_path})
+        fi
         printJSONEndTimestamp dsymutil
 
-        # Strip executables, shared libraries and static libraries in
-        # `host_install_destdir`.
-        find "${CURRENT_INSTALL_DIR}${CURRENT_PREFIX}/" \
-          '(' -perm -0111 -or -name "*.a" ')' -type f -print | \
-          xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool strip) -S
+        if [ -d "${CURRENT_INSTALL_DIR}${CURRENT_PREFIX}/" ]; then
+            # Strip executables, shared libraries and static libraries in
+            # `host_install_destdir`.
+            find "${CURRENT_INSTALL_DIR}${CURRENT_PREFIX}/" \
+              '(' -perm -0111 -or -name "*.a" ')' -type f -print | \
+              xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool strip) -S
 
-        # Codesign dylibs after strip tool
-        # rdar://45388785
-        find "${CURRENT_INSTALL_DIR}${CURRENT_PREFIX}/" \
-          '(' -name "*.dylib" ')' -type f -print | \
-          xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool codesign) -f -s -
+            # Codesign dylibs after strip tool
+            # rdar://45388785
+            find "${CURRENT_INSTALL_DIR}${CURRENT_PREFIX}/" \
+              '(' -name "*.dylib" ')' -type f -print | \
+              xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool codesign) -f -s -
+        fi
 
         { set +x; } 2>/dev/null
     fi


### PR DESCRIPTION
This would be needed to both allow to dry-run the toolchain creation and
allow tests for symbol filters to run

Addresses rdar://82577188