### PR TITLE
[build-script] Add a SKIP_XCODE_VERSION_CHECK to all dry-run build-script

### DIFF
--- a/validation-test/BuildSystem/android_cross_compile.test
+++ b/validation-test/BuildSystem/android_cross_compile.test
@@ -5,7 +5,7 @@
 # UNSUPPORTED: OS=watchos
 
 # RUN: %empty-directory(%t)
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --libdispatch --cross-compile-hosts=android-aarch64 --skip-local-build --android --android-ndk %t/ndk/ --android-arch aarch64 --android-icu-uc %t/lib/libicuuc.so --android-icu-uc-include %t/include/ --android-icu-i18n %t/lib/libicui18n.so --android-icu-i18n-include %t/include/ --android-icu-data %t/lib/libicudata.so 2>&1 | %FileCheck %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --libdispatch --cross-compile-hosts=android-aarch64 --skip-local-build --android --android-ndk %t/ndk/ --android-arch aarch64 --android-icu-uc %t/lib/libicuuc.so --android-icu-uc-include %t/include/ --android-icu-i18n %t/lib/libicui18n.so --android-icu-i18n-include %t/include/ --android-icu-data %t/lib/libicudata.so 2>&1 | %FileCheck %s
 
 # CHECK: -DCMAKE_Swift_FLAGS{{.*}}-target {{.*}}unknown-linux-android{{.*}} -sdk
 # CHECK: -DCMAKE_SYSTEM_NAME=Android {{.*}} -DCMAKE_ANDROID_NDK

--- a/validation-test/BuildSystem/extractsymbols-darwin-symroot-path-filters.test
+++ b/validation-test/BuildSystem/extractsymbols-darwin-symroot-path-filters.test
@@ -22,7 +22,7 @@
 # RUN: mkdir -p %t/symroot/macosx-%target-cpu
 
 # test build-script-impl on its own
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script-impl --dry-run --build-dir=%t/build --workspace=%swift_src_root/.. --cmake %cmake --only-execute macosx-%target-cpu-extractsymbols --host-cc /usr/bin/true --darwin-install-extract-symbols=1 --host-target=macosx-%target-cpu --install-symroot=%t/symroot --install-destdir=%t/destdir --build-jobs=1 --darwin-symroot-path-filters="/lib/ /swift-demangle"  2>&1 | tee %t/build-script-impl-output.txt
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script-impl --dry-run --build-dir=%t/build --workspace=%swift_src_root/.. --cmake %cmake --only-execute macosx-%target-cpu-extractsymbols --host-cc /usr/bin/true --darwin-install-extract-symbols=1 --host-target=macosx-%target-cpu --install-symroot=%t/symroot --install-destdir=%t/destdir --build-jobs=1 --darwin-symroot-path-filters="/lib/ /swift-demangle"  2>&1 | tee %t/build-script-impl-output.txt
 # RUN: %FileCheck --input-file=%t/build-script-impl-output.txt %s
 # RUN: %FileCheck --input-file=%t/build-script-impl-output.txt --check-prefixes CHECK-SKIPPED %s
 

--- a/validation-test/BuildSystem/extractsymbols-default-behaviour.test
+++ b/validation-test/BuildSystem/extractsymbols-default-behaviour.test
@@ -21,7 +21,7 @@
 # RUN: chmod a+x %t/destdir/libswiftCompatibility51.a
 # RUN: mkdir -p %t/symroot/macosx-%target-cpu
 
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script-impl --dry-run --build-dir=%t/build --workspace=%swift_src_root/.. --cmake %cmake --only-execute macosx-%target-cpu-extractsymbols --host-cc /usr/bin/true --darwin-install-extract-symbols=1 --host-target=macosx-%target-cpu --install-symroot=%t/symroot --install-destdir=%t/destdir --build-jobs=1 > %t/build-script-impl-output.txt 2>&1
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script-impl --dry-run --build-dir=%t/build --workspace=%swift_src_root/.. --cmake %cmake --only-execute macosx-%target-cpu-extractsymbols --host-cc /usr/bin/true --darwin-install-extract-symbols=1 --host-target=macosx-%target-cpu --install-symroot=%t/symroot --install-destdir=%t/destdir --build-jobs=1 > %t/build-script-impl-output.txt 2>&1
 # RUN: %FileCheck --input-file=%t/build-script-impl-output.txt %s
 # RUN: %FileCheck --input-file=%t/build-script-impl-output.txt --check-prefixes CHECK-SKIPPED %s
 

--- a/validation-test/BuildSystem/extractsymbols-dry-run-does-not-fail.test
+++ b/validation-test/BuildSystem/extractsymbols-dry-run-does-not-fail.test
@@ -13,7 +13,7 @@
 # RUN: mkdir -p %t
 # RUN: mkdir -p %t/destdir
 # RUN: mkdir -p %t/symroot/macosx-%target-cpu
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script-impl --dry-run --build-dir=%t/build --workspace=%swift_src_root/.. --cmake %cmake --only-execute macosx-%target-cpu-extractsymbols --host-cc /usr/bin/true --darwin-install-extract-symbols=1 --host-target=macosx-%target-cpu --install-symroot=%t/symroot --install-destdir=%t/destdir --build-jobs=1 2>&1 | %FileCheck %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script-impl --dry-run --build-dir=%t/build --workspace=%swift_src_root/.. --cmake %cmake --only-execute macosx-%target-cpu-extractsymbols --host-cc /usr/bin/true --darwin-install-extract-symbols=1 --host-target=macosx-%target-cpu --install-symroot=%t/symroot --install-destdir=%t/destdir --build-jobs=1 2>&1 | %FileCheck %s
 
 # CHECK: --- Extracting symbols ---
 

--- a/validation-test/BuildSystem/install_all.test
+++ b/validation-test/BuildSystem/install_all.test
@@ -1,6 +1,6 @@
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --cmake %cmake 2>&1 | %FileCheck %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --cmake %cmake 2>&1 | %FileCheck %s
 
 # REQUIRES: standalone_build
 

--- a/validation-test/BuildSystem/install_all_linux.test
+++ b/validation-test/BuildSystem/install_all_linux.test
@@ -1,6 +1,6 @@
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --llbuild --swiftpm --foundation --libdispatch --cmake %cmake 2>&1 | %FileCheck %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --llbuild --swiftpm --foundation --libdispatch --cmake %cmake 2>&1 | %FileCheck %s
 
 # REQUIRES: standalone_build
 # REQUIRES: OS=linux-gnu

--- a/validation-test/BuildSystem/llvm-targets-options-for-cross-compile-hosts.test
+++ b/validation-test/BuildSystem/llvm-targets-options-for-cross-compile-hosts.test
@@ -3,7 +3,7 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets="lib/all clangDependencyScanning" --cross-compile-hosts=iphoneos-arm64e --cmake %cmake  2>&1 | %FileCheck --check-prefix=LLVM-NINJA-TARGETS-APPLY-TO-CROSS-COMPILE-HOSTS-TOO-CHECK %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets="lib/all clangDependencyScanning" --cross-compile-hosts=iphoneos-arm64e --cmake %cmake  2>&1 | %FileCheck --check-prefix=LLVM-NINJA-TARGETS-APPLY-TO-CROSS-COMPILE-HOSTS-TOO-CHECK %s
 
 # LLVM-NINJA-TARGETS-APPLY-TO-CROSS-COMPILE-HOSTS-TOO-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} lib/all clangDependencyScanning
 # LLVM-NINJA-TARGETS-APPLY-TO-CROSS-COMPILE-HOSTS-TOO-CHECK: cmake --build {{.*}}/llvm-iphoneos-arm64e {{.*}} lib/all clangDependencyScanning
@@ -11,7 +11,7 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets="lib/all clangDependencyScanning" --llvm-ninja-targets-for-cross-compile-hosts="bin/clang" --cross-compile-hosts=iphoneos-arm64e --cmake %cmake 2>&1 | %FileCheck --check-prefix=LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets="lib/all clangDependencyScanning" --llvm-ninja-targets-for-cross-compile-hosts="bin/clang" --cross-compile-hosts=iphoneos-arm64e --cmake %cmake 2>&1 | %FileCheck --check-prefix=LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK %s
 
 # LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} lib/all clangDependencyScanning
 # LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK: cmake --build {{.*}}/llvm-iphoneos-arm64e {{.*}} bin/clang
@@ -19,7 +19,7 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets-for-cross-compile-hosts="bin/clang" --cross-compile-hosts=iphoneos-arm64e --cmake %cmake 2>&1 | %FileCheck --check-prefix=ONLY-LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets-for-cross-compile-hosts="bin/clang" --cross-compile-hosts=iphoneos-arm64e --cmake %cmake 2>&1 | %FileCheck --check-prefix=ONLY-LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK %s
 
 # ONLY-LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} all
 # ONLY-LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK: cmake --build {{.*}}/llvm-iphoneos-arm64e {{.*}} bin/clang

--- a/validation-test/BuildSystem/llvm-targets-options.test
+++ b/validation-test/BuildSystem/llvm-targets-options.test
@@ -2,30 +2,30 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --build-llvm=0 --cmake %cmake  2>&1 | %FileCheck --check-prefix=BUILD-LLVM-0-CHECK %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --build-llvm=0 --cmake %cmake  2>&1 | %FileCheck --check-prefix=BUILD-LLVM-0-CHECK %s
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --build-llvm=0 --llvm-ninja-targets="lib/all clangDependencyScanning" --cmake %cmake  2>&1 | %FileCheck --check-prefix=BUILD-LLVM-0-CHECK %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --build-llvm=0 --llvm-ninja-targets="lib/all clangDependencyScanning" --cmake %cmake  2>&1 | %FileCheck --check-prefix=BUILD-LLVM-0-CHECK %s
 
 # BUILD-LLVM-0-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} clean
 
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build --llvm-ninja-targets="lib/all bin/clang" --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build --llvm-ninja-targets="lib/all bin/clang" --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build-llvm --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build-llvm --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build-llvm --llvm-ninja-targets="bin/clang clangDependencyScanning" --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build-llvm --llvm-ninja-targets="bin/clang clangDependencyScanning" --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
 
 # SKIP-BUILD-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} llvm-tblgen clang-resource-headers intrinsics_gen clang-tablegen-targets
 # SKIP-BUILD-CHECK-SAME: FileCheck not llvm-nm
@@ -33,7 +33,7 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build-llvm --build-toolchain-only=1 --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-LLVM-BUILD-TOOLCHAIN-ONLY-CHECK %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build-llvm --build-toolchain-only=1 --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-LLVM-BUILD-TOOLCHAIN-ONLY-CHECK %s
 
 # SKIP-BUILD-LLVM-BUILD-TOOLCHAIN-ONLY-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} llvm-tblgen clang-resource-headers intrinsics_gen clang-tablegen-targets
 # SKIP-BUILD-LLVM-BUILD-TOOLCHAIN-ONLY-CHECK-NOT: FileCheck not llvm-nm
@@ -41,7 +41,7 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets="lib/all clangDependencyScanning" --cmake %cmake  2>&1 | %FileCheck --check-prefix=LLVM-NINJA-TARGETS-CHECK %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets="lib/all clangDependencyScanning" --cmake %cmake  2>&1 | %FileCheck --check-prefix=LLVM-NINJA-TARGETS-CHECK %s
 
 # LLVM-NINJA-TARGETS-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} lib/all clangDependencyScanning
 

--- a/validation-test/BuildSystem/relocate_xdg_cache_home_under_build_subdir.test
+++ b/validation-test/BuildSystem/relocate_xdg_cache_home_under_build_subdir.test
@@ -1,6 +1,6 @@
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --llbuild --swiftpm --foundation --libdispatch --relocate-xdg-cache-home-under-build-subdir --verbose-build --cmake %cmake 2>&1 | %FileCheck %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --install-all --llbuild --swiftpm --foundation --libdispatch --relocate-xdg-cache-home-under-build-subdir --verbose-build --cmake %cmake 2>&1 | %FileCheck %s
 
 # REQUIRES: standalone_build
 # REQUIRES: OS=linux-gnu

--- a/validation-test/BuildSystem/skip-local-build.test-sh
+++ b/validation-test/BuildSystem/skip-local-build.test-sh
@@ -1,10 +1,10 @@
 # REQUIRES: standalone_build
 
 # RUN: %empty-directory(%t)
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --cmake %cmake --dump-config --skip-local-build 2>&1 | %FileCheck %s -check-prefix=CONFIG
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --cmake %cmake --dump-config --skip-local-build 2>&1 | %FileCheck %s -check-prefix=CONFIG
 # CONFIG: "skip_local_build": true
 
 # RUN: %empty-directory(%t)
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --cmake %cmake --dry-run --verbose-build --skip-local-build 2>&1 | %FileCheck %s -check-prefix=DRY
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --cmake %cmake --dry-run --verbose-build --skip-local-build 2>&1 | %FileCheck %s -check-prefix=DRY
 # DRY: build-script-impl
 # DRY-SAME: --skip-local-build

--- a/validation-test/BuildSystem/skip_clean_corelibs.test
+++ b/validation-test/BuildSystem/skip_clean_corelibs.test
@@ -6,11 +6,11 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --xctest --cmake %cmake  2>&1 | %FileCheck --check-prefix=CLEAN-CORELIBS-CHECK %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --xctest --cmake %cmake  2>&1 | %FileCheck --check-prefix=CLEAN-CORELIBS-CHECK %s
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --xctest --skip-clean-libdispatch --skip-clean-foundation --skip-clean-xctest --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-CLEAN-CORELIBS-CHECK %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --xctest --skip-clean-libdispatch --skip-clean-foundation --skip-clean-xctest --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-CLEAN-CORELIBS-CHECK %s
 
 # CLEAN-CORELIBS-CHECK: Cleaning the libdispatch build directory
 # CLEAN-CORELIBS-CHECK-NEXT: rm -rf

--- a/validation-test/BuildSystem/skip_clean_llbuild.test
+++ b/validation-test/BuildSystem/skip_clean_llbuild.test
@@ -2,11 +2,11 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llbuild --cmake %cmake  2>&1 | %FileCheck --check-prefix=CLEAN-LLBUILD-CHECK %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llbuild --cmake %cmake  2>&1 | %FileCheck --check-prefix=CLEAN-LLBUILD-CHECK %s
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llbuild --skip-clean-llbuild --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-CLEAN-LLBUILD-CHECK %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llbuild --skip-clean-llbuild --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-CLEAN-LLBUILD-CHECK %s
 
 # CLEAN-LLBUILD-CHECK: Cleaning the llbuild build directory
 # CLEAN-LLBUILD-CHECK-NEXT: rm -rf


### PR DESCRIPTION
It makes sense to just set this here since we aren't testing that functionality
and enables us to test this if we aren't using one of the specified Xcodes
(which can be useful).
