### PR TITLE
[Concurrency] Propagate Darwin vouchers across async tasks.

### DIFF
--- a/include/swift/Runtime/VoucherShims.h
+++ b/include/swift/Runtime/VoucherShims.h
@@ -1,0 +1,87 @@
+//===--- VoucherShims.h - Shims for OS vouchers --------------------*- C++ -*-//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Shims for interfacing with OS voucher calls.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_CONCURRENCY_VOUCHERSHIMS_H
+#define SWIFT_CONCURRENCY_VOUCHERSHIMS_H
+
+#include "Config.h"
+
+// swift-corelibs-libdispatch has os/voucher_private.h but it doesn't work for
+// us yet, so only look for it on Apple platforms.
+#if __APPLE__ && __has_include(<os/voucher_private.h>)
+#define SWIFT_HAS_VOUCHER_HEADER 1
+#include <os/voucher_private.h>
+#endif
+
+// A "dead" voucher pointer, indicating that a voucher has been removed from
+// a Job, distinct from a NULL voucher that could just mean no voucher was
+// present. This allows us to catch problems like adopting a voucher from the
+// same Job twice without restoring it.
+#define SWIFT_DEAD_VOUCHER ((voucher_t)-1)
+
+// The OS has voucher support if it has the header or if it has ObjC interop.
+#if SWIFT_HAS_VOUCHER_HEADER || SWIFT_OBJC_INTEROP
+#define SWIFT_HAS_VOUCHERS 1
+#endif
+
+#if SWIFT_HAS_VOUCHERS
+
+// If the header isn't available, declare the necessary calls here.
+#if !SWIFT_HAS_VOUCHER_HEADER
+
+#include <os/object.h>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+OS_OBJECT_DECL_CLASS(voucher);
+#pragma clang diagnostic pop
+
+extern "C" voucher_t _Nullable voucher_copy(void);
+
+// Consumes argument, returns retained value.
+extern "C" voucher_t _Nullable voucher_adopt(voucher_t _Nullable voucher);
+
+static inline bool voucher_needs_adopt(voucher_t _Nullable voucher) {
+  return true;
+}
+
+#endif // __has_include(<os/voucher_private.h>)
+
+static inline void swift_voucher_release(voucher_t _Nullable voucher) {
+  // This NULL check isn't necessary, but NULL vouchers will be common, so
+  // optimize for that.
+  if (!voucher)
+    return;
+  if (voucher == SWIFT_DEAD_VOUCHER)
+    return;
+  os_release(voucher);
+}
+
+#else  // __APPLE__
+
+// Declare some do-nothing stubs for OSes without voucher support.
+typedef void *voucher_t;
+static inline voucher_t _Nullable voucher_copy(void) { return nullptr; }
+static inline voucher_t _Nullable voucher_adopt(voucher_t _Nullable voucher) {
+  return nullptr;
+}
+static inline bool voucher_needs_adopt(voucher_t _Nullable voucher) {
+  return true;
+}
+static inline void swift_voucher_release(voucher_t _Nullable voucher) {}
+#endif // __APPLE__
+
+#endif

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -586,15 +586,18 @@ static AsyncTaskAndContext swift_task_create_commonImpl(
   // Initialize the task so that resuming it will run the given
   // function on the initial context.
   AsyncTask *task = nullptr;
+  bool captureCurrentVoucher = taskCreateFlags.copyTaskLocals() || jobFlags.task_isChildTask();
   if (asyncLet) {
     // Initialize the refcount bits to "immortal", so that
     // ARC operations don't have any effect on the task.
     task = new(allocation) AsyncTask(&taskHeapMetadata,
                              InlineRefCounts::Immortal, jobFlags,
-                             function, initialContext);
+                             function, initialContext,
+                             captureCurrentVoucher);
   } else {
     task = new(allocation) AsyncTask(&taskHeapMetadata, jobFlags,
-                                    function, initialContext);
+                                    function, initialContext,
+                                    captureCurrentVoucher);
   }
 
   // Initialize the child fragment if applicable.

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -82,6 +82,14 @@ void _swift_task_dealloc_specific(AsyncTask *task, void *ptr);
 /// related to the active task.
 void runJobInEstablishedExecutorContext(Job *job);
 
+/// Adopt the voucher stored in `task`. This removes the voucher from the task
+/// and adopts it on the current thread.
+void adoptTaskVoucher(AsyncTask *task);
+
+/// Restore the voucher for `task`. This un-adopts the current thread's voucher
+/// and stores it back into the task again.
+void restoreTaskVoucher(AsyncTask *task);
+
 /// Initialize the async let storage for the given async-let child task.
 void asyncLet_addImpl(AsyncTask *task, AsyncLet *asyncLet,
                       bool didAllocateInParentTask);
@@ -354,11 +362,13 @@ inline bool AsyncTask::isCancelled() const {
 }
 
 inline void AsyncTask::flagAsRunning() {
+  SWIFT_TASK_DEBUG_LOG("%p->flagAsRunning()", this);
   auto oldStatus = _private().Status.load(std::memory_order_relaxed);
   while (true) {
     assert(!oldStatus.isRunning());
     if (oldStatus.isLocked()) {
       flagAsRunning_slow();
+      adoptTaskVoucher(this);
       swift_task_enterThreadLocalContext(
           (char *)&_private().ExclusivityAccessSet[0]);
       return;
@@ -373,6 +383,7 @@ inline void AsyncTask::flagAsRunning() {
     if (_private().Status.compare_exchange_weak(oldStatus, newStatus,
                                                 std::memory_order_relaxed,
                                                 std::memory_order_relaxed)) {
+      adoptTaskVoucher(this);
       swift_task_enterThreadLocalContext(
           (char *)&_private().ExclusivityAccessSet[0]);
       return;
@@ -381,6 +392,7 @@ inline void AsyncTask::flagAsRunning() {
 }
 
 inline void AsyncTask::flagAsSuspended() {
+  SWIFT_TASK_DEBUG_LOG("%p->flagAsSuspended()", this);
   auto oldStatus = _private().Status.load(std::memory_order_relaxed);
   while (true) {
     assert(oldStatus.isRunning());
@@ -388,6 +400,7 @@ inline void AsyncTask::flagAsSuspended() {
       flagAsSuspended_slow();
       swift_task_exitThreadLocalContext(
           (char *)&_private().ExclusivityAccessSet[0]);
+      restoreTaskVoucher(this);
       return;
     }
 
@@ -402,6 +415,7 @@ inline void AsyncTask::flagAsSuspended() {
                                                 std::memory_order_relaxed)) {
       swift_task_exitThreadLocalContext(
           (char *)&_private().ExclusivityAccessSet[0]);
+      restoreTaskVoucher(this);
       return;
     }
   }

--- a/stdlib/public/Concurrency/VoucherSupport.h
+++ b/stdlib/public/Concurrency/VoucherSupport.h
@@ -1,0 +1,124 @@
+//===--- VoucherSupport.h - Support code for OS vouchers -----------*- C++ -*-//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Support code for interfacing with OS voucher calls.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_CONCURRENCY_VOUCHERSUPPORT_H
+#define SWIFT_CONCURRENCY_VOUCHERSUPPORT_H
+
+#include "llvm/ADT/Optional.h"
+#include "swift/ABI/Task.h"
+#include "swift/Runtime/VoucherShims.h"
+#include "TaskPrivate.h"
+
+namespace swift {
+
+/// A class which manages voucher adoption for Job and Task objects.
+class VoucherManager {
+  /// The original voucher that was set on the thread before Swift started
+  /// doing async work. This must be restored on the thread after we finish
+  /// async work.
+  llvm::Optional<voucher_t> OriginalVoucher;
+
+public:
+  VoucherManager() {
+    SWIFT_TASK_DEBUG_LOG("[%p] Constructing VoucherManager", this);
+  }
+
+  /// Clean up after completing async work, restoring the original voucher on
+  /// the current thread if necessary. This MUST be called before the
+  /// VoucherManager object is destroyed. It may also be called in other
+  /// places to restore the original voucher and reset the VoucherManager.
+  void leave() {
+    if (OriginalVoucher) {
+      SWIFT_TASK_DEBUG_LOG("[%p] Restoring original voucher %p", this,
+                           *OriginalVoucher);
+      if (voucher_needs_adopt(*OriginalVoucher)) {
+        auto previous = voucher_adopt(*OriginalVoucher);
+        swift_voucher_release(previous);
+      } else {
+        swift_voucher_release(*OriginalVoucher);
+      }
+      OriginalVoucher = llvm::None;
+    } else
+      SWIFT_TASK_DEBUG_LOG("[%p] Leaving empty VoucherManager", this);
+  }
+
+  ~VoucherManager() { assert(!OriginalVoucher); }
+
+  /// Set up for a new Job by adopting its voucher on the current thread. This
+  /// takes over ownership of the voucher from the Job object. For plain Jobs,
+  /// this is permanent. For Tasks, the voucher must be restored using
+  /// restoreVoucher if the task suspends.
+  void swapToJob(Job *job) {
+    SWIFT_TASK_DEBUG_LOG("[%p] Swapping jobs to %p", this, job);
+    assert(job);
+    assert(job->Voucher != SWIFT_DEAD_VOUCHER);
+
+    voucher_t previous;
+    if (voucher_needs_adopt(job->Voucher)) {
+      // If we need to adopt the voucher, do so, and grab the old one.
+      SWIFT_TASK_DEBUG_LOG("[%p] Swapping jobs to %p, adopting voucher %p",
+                           this, job, job->Voucher);
+      previous = voucher_adopt(job->Voucher);
+    } else {
+      // If we don't need to adopt the voucher, take the voucher out of Job
+      // directly.
+      SWIFT_TASK_DEBUG_LOG(
+          "[%p] Swapping jobs to to %p, voucher %p does not need adoption",
+          this, job, job->Voucher);
+      previous = job->Voucher;
+    }
+
+    // Either way, we've taken ownership of the job's voucher, so mark the job
+    // as having a dead voucher.
+    job->Voucher = SWIFT_DEAD_VOUCHER;
+    if (!OriginalVoucher) {
+      // If we don't yet have an original voucher, then save the one we grabbed
+      // above to restore later.
+      OriginalVoucher = previous;
+      SWIFT_TASK_DEBUG_LOG("[%p] Saved original voucher %p", this, previous);
+    } else {
+      // We already have an original voucher. The one we grabbed above is not
+      // needed. We own it, so destroy it here.
+      swift_voucher_release(previous);
+    }
+  }
+
+  // Take the current thread's adopted voucher and place it back into the task
+  // that previously owned it, re-adopting the thread's original voucher.
+  void restoreVoucher(AsyncTask *task) {
+    SWIFT_TASK_DEBUG_LOG("[%p] Restoring %svoucher on task %p", this,
+                         OriginalVoucher ? "" : "missing ", task);
+    assert(OriginalVoucher);
+    assert(task->Voucher == SWIFT_DEAD_VOUCHER);
+
+    if (voucher_needs_adopt(*OriginalVoucher)) {
+      // Adopt the execution thread's original voucher. The task's voucher is
+      // the one currently adopted, and is returned by voucher_adopt.
+      task->Voucher = voucher_adopt(*OriginalVoucher);
+    } else {
+      // No need to adopt the voucher, so we can take the one out of
+      // OriginalVoucher and return it to the task.
+      task->Voucher = *OriginalVoucher;
+    }
+
+    // We've given up ownership of OriginalVoucher, clear it out.
+    OriginalVoucher = llvm::None;
+  }
+};
+
+} // end namespace swift
+
+#endif

--- a/test/Concurrency/voucher_propagation.swift
+++ b/test/Concurrency/voucher_propagation.swift
@@ -1,0 +1,363 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -Xfrontend -disable-availability-checking -o %t/voucher_propagation
+// RUN: %target-codesign %t/voucher_propagation
+// RUN: MallocStackLogging=1 %target-run %t/voucher_propagation
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+// Use objc_interop as a proxy for voucher support in the OS.
+// REQUIRES: objc_interop
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import Darwin
+import Dispatch
+import StdlibUnittest
+
+// These are an attempt to simulate some kind of async work, and the
+// computations being performed are not intended to actually make any kind of
+// sense.
+actor Accumulator {
+  let label: String
+  var x = 0
+
+  init(label: String) {
+    self.label = label
+  }
+
+  func add(_ n: Int, _ voucher: voucher_t?) async {
+    let currentVoucher = voucher_copy()
+    expectEqual(voucher, currentVoucher)
+    print("\(n) \(label)", voucher: currentVoucher)
+    os_release(currentVoucher)
+    x += n
+    usleep(1000)
+  }
+
+  func add<T: Sequence>(sequence: T, _ voucher: voucher_t?) async -> Int where T.Element == Int {
+    for n in sequence {
+      await add(n, voucher)
+    }
+    return x
+  }
+
+  func get() -> Int { x }
+}
+
+actor Combiner {
+  var accumulators: [Accumulator] = []
+
+  func add(accumulator: Accumulator) {
+    accumulators.append(accumulator)
+  }
+
+  func sum() async -> Int {
+    var sum = 0
+    for a in accumulators {
+      fputs("Accumulating from \(ptrstr(a))\n", stderr)
+      sum += await a.get()
+    }
+    return sum
+  }
+}
+
+actor Counter {
+  var n = 0
+
+  func increment() {
+    n += 1
+  }
+
+  func get() -> Int { n }
+}
+
+// Make a nice string for a pointer, like what %p would produce in printf.
+func ptrstr<T>(_ ptr: T) -> String {
+  "0x" + String(unsafeBitCast(ptr, to: UInt.self), radix: 16)
+}
+
+// Print a voucher to stderr with an optional label.
+func print(_ s: String = "", voucher: voucher_t?) {
+  fputs("\(s) - \(ptrstr(voucher))\n", stderr)
+}
+
+// Look up a symbol using dlsym and cast the result to an arbitrary type.
+func lookup<T>(_ name: String) -> T {
+  let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: -2)
+  let result = dlsym(RTLD_DEFAULT, name)
+  return unsafeBitCast(result, to: T.self)
+}
+
+// We'll use os_activity calls to make our test vouchers. The calls aren't in
+// the headers so we need to look them up dynamically.
+let _os_activity_create = lookup("_os_activity_create")
+    as @convention(c) (UnsafeRawPointer, UnsafePointer<CChar>, UnsafeRawPointer,
+                       UInt32) -> voucher_t?
+let OS_ACTIVITY_NONE = lookup("_os_activity_none") as UnsafeRawPointer
+let OS_ACTIVITY_FLAG_DETACHED = 1 as UInt32
+
+// Look up the voucher calls we'll be using. Vouchers are ObjC objects, but we
+// want total control over their memory management, so we'll treat them as raw
+// pointers instead, and manually manage their memory.
+typealias voucher_t = UnsafeMutableRawPointer
+let voucher_copy = lookup("voucher_copy") as @convention(c) () -> voucher_t?
+let voucher_adopt = lookup("voucher_adopt") as @convention(c) (voucher_t?)
+    -> voucher_t?
+let os_retain = lookup("os_retain") as @convention(c) (voucher_t?) -> voucher_t?
+let os_release = lookup("os_release") as @convention(c) (voucher_t?) -> Void
+
+// Run some async code with test vouchers. Wait for the async code to complete,
+// then verify that the vouchers aren't leaked.
+func withVouchers(call: @Sendable @escaping (voucher_t?, voucher_t?, voucher_t?)
+    async -> Void) {
+  // We'll store weak pointers to the vouchers to verify that they don't leak.
+  // If the voucher was deallocated after we're done, then the weak references
+  // will be nil. We can't use Swift `weak` references since we're treating
+  // vouchers as raw pointers. We'll use the ObjC runtime APIs directly. Those
+  // require a stable address for the storage, so we'll allocate that manually.
+  let weakPtrsAllocation = UnsafeMutablePointer<AnyObject?>.allocate(capacity: 3)
+  weakPtrsAllocation.initialize(repeating: nil, count: 3)
+  let weakPtrs = AutoreleasingUnsafeMutablePointer<AnyObject?>(weakPtrsAllocation)
+
+  // Helper function to store three vouchers into the weak storage.
+  func storeWeak(vouchers: [voucher_t?]) {
+    for (i, voucher) in vouchers.enumerated() {
+      objc_storeWeak(weakPtrs + i, unsafeBitCast(voucher, to: AnyObject?.self))
+    }
+  }
+
+  // Make convenient pointers to the individual weak variables.
+  let weak1 = AutoreleasingUnsafeMutablePointer<AnyObject?>(weakPtrs + 0)
+  let weak2 = AutoreleasingUnsafeMutablePointer<AnyObject?>(weakPtrs + 1)
+  let weak3 = AutoreleasingUnsafeMutablePointer<AnyObject?>(weakPtrs + 2)
+  do {
+    let v1 = _os_activity_create(#dsohandle, "Swift Test Voucher 1", OS_ACTIVITY_NONE, OS_ACTIVITY_FLAG_DETACHED)
+    let v2 = _os_activity_create(#dsohandle, "Swift Test Voucher 2", OS_ACTIVITY_NONE, OS_ACTIVITY_FLAG_DETACHED)
+    let v3 = _os_activity_create(#dsohandle, "Swift Test Voucher 3", OS_ACTIVITY_NONE, OS_ACTIVITY_FLAG_DETACHED)
+
+    print("Created v1", voucher: v1)
+    print("Created v2", voucher: v2)
+    print("Created v3", voucher: v3)
+
+    // Place the vouchers in the weak variables and verify that it worked.
+    storeWeak(vouchers: [v1, v2, v3])
+    autoreleasepool {
+      expectNotNil(objc_loadWeak(weak1))
+      expectNotNil(objc_loadWeak(weak2))
+      expectNotNil(objc_loadWeak(weak3))
+    }
+
+    // Start the async call in the background, waiting for it to complete.
+    let group = DispatchGroup()
+    group.enter()
+    Task {
+      await call(v1, v2, v3)
+
+      // Clear any voucher that the call adopted.
+      adopt(voucher: nil)
+      group.leave()
+    }
+    group.wait()
+
+    // Release what should be the last reference to the vouchers.
+    os_release(v1)
+    os_release(v2)
+    os_release(v3)
+  }
+  func now() -> UInt64 {
+    return clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+  }
+  // The vouchers may take a moment to be destroyed, as background threads
+  // finish what they're doing. Wait for the voucher weak references to become
+  // nil. We'll give them ten seconds, and otherwise assume they've leaked.
+  let start = now();
+  var allNil = false;
+  while !allNil && now() - start < 10_000_000_000 {
+    autoreleasepool {
+      allNil = objc_loadWeak(weak1) == nil
+            && objc_loadWeak(weak2) == nil
+            && objc_loadWeak(weak3) == nil
+    }
+  }
+
+  // If any weak reference contains non-nil at this point, a voucher has leaked.
+  expectNil(objc_loadWeak(weak1))
+  expectNil(objc_loadWeak(weak2))
+  expectNil(objc_loadWeak(weak3))
+
+  // Clean up the weak references.
+  storeWeak(vouchers: [nil, nil, nil])
+  weakPtrsAllocation.deallocate()
+}
+
+// Adopt the given voucher on the current thread. This takes the voucher at +0
+// and handles the memory management around voucher_adopt.
+func adopt(voucher: voucher_t?) {
+  os_release(voucher_adopt(os_retain(voucher)))
+}
+
+let tests = TestSuite("Voucher Propagation")
+
+if #available(SwiftStdlib 5.5, *) {
+  tests.test("simple voucher propagation") {
+    withVouchers { v1, v2, v3 in
+      let a = Accumulator(label: "a: ")
+      adopt(voucher: v1)
+      await a.add(42, v1)
+    }
+  }
+
+  tests.test("voucher propagation with a simple async let") {
+    withVouchers { v1, v2, v3 in
+      let a1 = Accumulator(label: "a1: ")
+      let a2 = Accumulator(label: "a2: ")
+
+      adopt(voucher: v1)
+      async let r1: () = a1.add(42, v1)
+      adopt(voucher: v2)
+      async let r2: () = a2.add(42, v2)
+      _ = await (r1, r2)
+    }
+  }
+
+  tests.test("Task {} voucher propagation") {
+    withVouchers { v1, v2, v3 in
+      let a = Accumulator(label: "a: ")
+      adopt(voucher: v1)
+
+      let group = DispatchGroup()
+      group.enter()
+      Task {
+        await a.add(42, v1)
+        group.leave()
+      }
+      group.wait()
+    }
+  }
+
+  tests.test("Task.detached {} voucher propagation") {
+    withVouchers { v1, v2, v3 in
+      let a = Accumulator(label: "a: ")
+      adopt(voucher: v1)
+
+      let group = DispatchGroup()
+      group.enter()
+      Task.detached {
+        // Task.detached should NOT propagate vouchers, so tell add to look for
+        // nil.
+        await a.add(42, nil)
+        group.leave()
+      }
+      group.wait()
+    }
+  }
+
+  tests.test("complex voucher propagation") {
+    withVouchers { v1, v2, v3 in
+      fputs("Hello, whirled.\n", stderr)
+
+      let a1 = Accumulator(label: "a1: ")
+      let a2 = Accumulator(label: "a2: ")
+
+      adopt(voucher: v1)
+
+      @Sendable
+      func go(_ log: String, _ v: voucher_t?, _ a: Accumulator, _ n: Int) async -> Int {
+        print("Starting \(log): ", voucher: v)
+        return await a.add(sequence: (n*10)..<(n*10+10), v)
+      }
+
+      adopt(voucher: v1)
+      async let r1 = go("1 a1", v1, a1, 1)
+      adopt(voucher: v2)
+      async let r2 = go("2 a2", v2, a2, 2)
+
+      async let r3 = go("3 a1", v2, a1, 3)
+      adopt(voucher: v1)
+      async let r4 = go("4 a2", v1, a2, 4)
+
+      adopt(voucher: v1)
+      async let r5 = go("5 a1", v1, a1, 5)
+      async let r6 = go("6 a2", v1, a2, 6)
+
+      adopt(voucher: v2)
+      async let r7 = go("7 a1", v2, a1, 7)
+      async let r8 = go("8 a2", v2, a2, 8)
+
+      adopt(voucher: v3)
+      async let r9 = go("9 a1", v3, a1, 9)
+      async let r10 = go("10 a2", v3, a2, 10)
+      fputs("async let results: \((await r1, await r2, await r3, await r4, await r5, await r6, await r7, await r8, await r9, await r10))\n", stderr)
+
+      fputs("\(await a2.get())\n", stderr)
+
+      let combiner = Combiner()
+      async let add1: () = await combiner.add(accumulator: a1)
+      async let add2: () = await combiner.add(accumulator: a2)
+      _ = await (add1, add2)
+      fputs("combiner 1 - \(await combiner.sum())\n", stderr)
+      async let add3: () = await combiner.add(accumulator: a1)
+      async let add4: () = await combiner.add(accumulator: a2)
+      _ = await (add3, add4)
+      fputs("combiner 2 - \(await combiner.sum())\n", stderr)
+      for n in 0..<10 {
+        async let a = combiner.sum()
+        async let b = combiner.sum()
+        fputs("combiner loop \(n) - \(await a + b)\n", stderr)
+      }
+    }
+  }
+
+  tests.test("voucher propagation with mixed concurrency/dispatch code") {
+    withVouchers {v1, v2, v3 in
+     let a = Accumulator(label: "a: ")
+     let group = DispatchGroup()
+     let n = Counter()
+     let limit = 100
+     group.enter()
+     @Sendable func detachedTask() async {
+       let voucher = [v1, v2, v3][await n.get() % 3]
+       adopt(voucher: voucher)
+       let currentVoucher = voucher_copy()
+       expectEqual(voucher, currentVoucher)
+       os_release(currentVoucher)
+       DispatchQueue.global().async {
+         let currentVoucher = voucher_copy()
+         expectEqual(voucher, currentVoucher)
+         os_release(currentVoucher)
+
+         Task {
+           let currentVoucher = voucher_copy()
+           expectEqual(voucher, currentVoucher)
+           os_release(currentVoucher)
+
+           async let g: () = withTaskGroup(of: Void.self, body: { group in
+             for _ in 0..<10 {
+               group.async {
+                 let currentVoucher = voucher_copy()
+                 expectEqual(voucher, currentVoucher)
+                 os_release(currentVoucher)
+               }
+             }
+           })
+           async let add: () = a.add(42, voucher)
+           _ = await (g, add)
+
+           if await n.get() >= limit {
+             group.leave()
+           } else {
+             await n.increment()
+             await detachedTask()
+           }
+         }
+       }
+     }
+     await detachedTask()
+     group.wait()
+   }
+  }
+}
+
+runAllTests()


### PR DESCRIPTION
Darwin OSes support vouchers, which are key/value sets that can be adopted on a thread to influence its execution, or sent to another process. APIs like Dispatch propagate vouchers to worker threads when running async code. This change makes Swift Concurrency do the same.

The change consists of a few different parts:

1. A set of shims (in VoucherShims.h) which provides declarations for the necessary calls when they're not available from the SDK, and stub implementations for non-Darwin platforms.
2. One of Job's reserved fields is now used to store the voucher associated with a job.
3. Jobs grab the current thread's voucher when they're created.
4. A VoucherManager class manages adoption of vouchers when running a Job, and replacing vouchers in suspended tasks.
5. A VoucherManager instance is maintained in ExecutionTrackingInfo, and is updated as necessary throughout a Job/Task's lifecycle.

rdar://76080222