### PR TITLE
IRGen: convert an argument to deal with API changes

### DIFF
--- a/lib/IRGen/GenCoverage.cpp
+++ b/lib/IRGen/GenCoverage.cpp
@@ -79,7 +79,11 @@ void IRGenModule::emitCoverageMapping() {
   llvm::LLVMContext &Ctx = getLLVMContext();
   {
     llvm::raw_string_ostream OS(Filenames);
-    llvm::coverage::CoverageFilenamesSectionWriter(FilenameStrs).write(OS);
+    std::vector<StringRef> Strings;
+    std::transform(std::begin(FilenameStrs), std::end(FilenameStrs),
+                   std::begin(Strings),
+                   [](const std::string &S) -> StringRef { return S; });
+    llvm::coverage::CoverageFilenamesSectionWriter(Strings).write(OS);
   }
   auto *FilenamesVal =
       llvm::ConstantDataArray::getString(Ctx, Filenames, false);


### PR DESCRIPTION
The current API in the associated branch point in LLVM has the following
signature for the `CoverageFiklenamesSectionWriter` ctor:

```c++
CoverageFilenamesSectionWriter(llvm::ArrayRef<llvm::StringRef>);
```

We currently had a `llvm::SmallVector<std::string, 8>` which could be
implicitly converted to `llvm::ArrayRef<std::string>`.  However, that is
not implicitly converted to `llvm::ArrayRef<llvm::StringRef>`.
Unfortunately, we currently have to convert `std::vector<StringRef>` to
`llvm::SmallVector<std::string, 8>` due to the file remapping, which
needs storage.  This storage then needs another conversion layer to get
the correct type setup.

The desired API would be available with
5fbd1a333aa1a0b70903d036b98ea56c51ae5224 (D95753), however that does not
cleanly apply and is a large refactoring.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
