### PR TITLE
Revert "Fixup Coverage Mapping"

### DIFF
--- a/lib/IRGen/GenCoverage.cpp
+++ b/lib/IRGen/GenCoverage.cpp
@@ -68,10 +68,12 @@ void IRGenModule::emitCoverageMapping() {
   auto remapper = getOptions().CoveragePrefixMap;
   // Awkwardly munge absolute filenames into a vector of StringRefs.
   llvm::SmallVector<std::string, 8> FilenameStrs;
+  llvm::SmallVector<StringRef, 8> FilenameRefs;
   for (StringRef Name : Files) {
     llvm::SmallString<256> Path(Name);
     llvm::sys::fs::make_absolute(Path);
     FilenameStrs.push_back(remapper.remapPath(Path));
+    FilenameRefs.push_back(FilenameStrs.back());
   }
 
   // Encode the filenames.
@@ -79,7 +81,7 @@ void IRGenModule::emitCoverageMapping() {
   llvm::LLVMContext &Ctx = getLLVMContext();
   {
     llvm::raw_string_ostream OS(Filenames);
-    llvm::coverage::CoverageFilenamesSectionWriter(FilenameStrs).write(OS);
+    llvm::coverage::CoverageFilenamesSectionWriter(FilenameRefs).write(OS);
   }
   auto *FilenamesVal =
       llvm::ConstantDataArray::getString(Ctx, Filenames, false);


### PR DESCRIPTION
This reverts commit 40e420641041912dfa970ae9d7e5fcc9eee29aa0, due to
rdar://82543962. It should still remain in effect on next.
