### PR TITLE
[stdlib] Fix cc mismatch violation on swift_isClassType

### DIFF
--- a/stdlib/public/SwiftShims/RuntimeShims.h
+++ b/stdlib/public/SwiftShims/RuntimeShims.h
@@ -20,6 +20,7 @@
 
 #include "SwiftStddef.h"
 #include "SwiftStdint.h"
+#include "SwiftStdbool.h"
 #include "Visibility.h"
 
 #ifdef __cplusplus
@@ -60,6 +61,12 @@ int _swift_stdlib_putc_stderr(int C);
 
 SWIFT_RUNTIME_STDLIB_API
 __swift_size_t _swift_stdlib_getHardwareConcurrency(void);
+
+#ifdef __swift__
+/// Called by ReflectionMirror in stdlib through C-calling-convention
+SWIFT_RUNTIME_STDLIB_API
+__swift_bool swift_isClassType(const void *type);
+#endif
 
 /// Manually allocated memory is at least 16-byte aligned in Swift.
 ///

--- a/stdlib/public/core/ReflectionMirror.swift
+++ b/stdlib/public/core/ReflectionMirror.swift
@@ -12,8 +12,11 @@
 
 import SwiftShims
 
-@_silgen_name("swift_isClassType")
-internal func _isClassType(_: Any.Type) -> Bool
+internal func _isClassType(_ type: Any.Type) -> Bool {
+  // a thick metatype is represented with a pointer metadata structure,
+  // so this unsafeBitCast is a safe operation here.
+  return swift_isClassType(unsafeBitCast(type, to: UnsafeRawPointer.self))
+}
 
 @_silgen_name("swift_getMetadataKind")
 internal func _metadataKind(_: Any.Type) -> UInt


### PR DESCRIPTION
_isClassType is mainly called by compiler-generated code, but it's also called by stdlib.
The call-site of stdlib used @_silgen_name to link the function, so it's called through swiftcc.
However its cc is defined as C-cc, so caller and callee used different cc. The definition is here: https://github.com/apple/swift/blob/6e3548797503b4a2bbabcebf7ffd156bc1cac245/stdlib/public/runtime/Casting.cpp#L1420-L1423

This patch adds C-compatible decl of swift_isClassType in shims so that it can be called by stdlib with C-cc.
This change doesn't break ABI because `_isClassType` in stdlib was defined as internal API.


I sent a similar patch https://github.com/apple/swift/pull/30938 before, but it breaks ABI. So I re-started it from a safe point.

CC: @MaxDesiatov @jckarter 
