### PR TITLE
Add missing REQUIRES: CPU=x86_64 to Concurrency test.

### DIFF
--- a/test/Concurrency/Backdeploy/mangling.swift
+++ b/test/Concurrency/Backdeploy/mangling.swift
@@ -12,6 +12,7 @@
 // RUN: %target-build-swift -target x86_64-apple-macosx10.15 %s -o %t/test_mangling -Xfrontend -disable-availability-checking
 // RUN: %target-run %t/test_mangling
 
+// REQUIRES: CPU=x86_64
 // REQUIRES: OS=macosx
 // REQUIRES: executable_test
 


### PR DESCRIPTION
This test is failing on `macosx-arm64`, we only need to run it on `x86_64`.