### PR TITLE
[5.5][SILGen] Fix a couple bugs with wrapped parameters in initializers.

### DIFF
--- a/lib/AST/Parameter.cpp
+++ b/lib/AST/Parameter.cpp
@@ -60,8 +60,7 @@ ParameterList *ParameterList::clone(const ASTContext &C,
 
   // Remap the ParamDecls inside of the ParameterList.
   for (auto &decl : params) {
-    bool hadDefaultArgument =
-        decl->getDefaultArgumentKind() == DefaultArgumentKind::Normal;
+    auto defaultArgKind = decl->getDefaultArgumentKind();
 
     decl = ParamDecl::cloneWithoutType(C, decl);
     if (options & Implicit)
@@ -74,11 +73,18 @@ ParameterList *ParameterList::clone(const ASTContext &C,
     
     // If we're inheriting a default argument, mark it as such.
     // FIXME: Figure out how to clone default arguments as well.
-    if (hadDefaultArgument) {
-      if (options & Inherited)
+    if (options & Inherited) {
+      switch (defaultArgKind) {
+      case DefaultArgumentKind::Normal:
+      case DefaultArgumentKind::StoredProperty:
         decl->setDefaultArgumentKind(DefaultArgumentKind::Inherited);
-      else
-        decl->setDefaultArgumentKind(DefaultArgumentKind::None);
+        break;
+
+      default:
+        break;
+      }
+    } else {
+      decl->setDefaultArgumentKind(DefaultArgumentKind::None);
     }
   }
   

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1299,8 +1299,8 @@ emitMarkFunctionEscapeForTopLevelCodeGlobals(SILLocation loc,
 }
 
 void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
-  // Emit any default argument generators.
-  emitDefaultArgGenerators(AFD, AFD->getParameters());
+  // Emit default arguments and property wrapper initializers.
+  emitArgumentGenerators(AFD, AFD->getParameters());
 
   // If this is a function at global scope, it may close over a global variable.
   // If we're emitting top-level code, then emit a "mark_function_escape" that
@@ -1388,6 +1388,9 @@ SILFunction *SILGenModule::emitClosure(AbstractClosureExpr *ce) {
   // initializer of the containing type.
   if (!f->isExternalDeclaration())
     return f;
+
+  // Emit property wrapper argument generators.
+  emitArgumentGenerators(ce, ce->getParameters());
 
   emitFunctionDefinition(constant, f);
   return f;
@@ -1575,13 +1578,17 @@ void SILGenModule::emitGlobalAccessor(VarDecl *global,
   emitOrDelayFunction(*this, accessor);
 }
 
-void SILGenModule::emitDefaultArgGenerators(SILDeclRef::Loc decl,
-                                            ParameterList *paramList) {
+void SILGenModule::emitArgumentGenerators(SILDeclRef::Loc decl,
+                                          ParameterList *paramList) {
   unsigned index = 0;
   for (auto param : *paramList) {
     if (param->isDefaultArgument())
       emitDefaultArgGenerator(SILDeclRef::getDefaultArgGenerator(decl, index),
                               param);
+
+    if (param->hasExternalPropertyWrapper())
+      emitPropertyWrapperBackingInitializer(param);
+
     ++index;
   }
 }

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -321,9 +321,9 @@ public:
   /// Emits the backing initializer for a property with an attached wrapper.
   void emitPropertyWrapperBackingInitializer(VarDecl *var);
 
-  /// Emits default argument generators for the given parameter list.
-  void emitDefaultArgGenerators(SILDeclRef::Loc decl,
-                                ParameterList *paramList);
+  /// Emits argument generators, including default argument generators and
+  /// property wrapper argument generators, for the given parameter list.
+  void emitArgumentGenerators(SILDeclRef::Loc decl, ParameterList *paramList);
   
   /// Emits a thunk from a foreign function to the native Swift convention.
   void emitForeignToNativeThunk(SILDeclRef thunk);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -376,6 +376,10 @@ public:
   /// a local variable.
   llvm::DenseMap<ValueDecl*, VarLoc> VarLocs;
 
+  /// The local auxiliary declarations for the parameters of this function that
+  /// need to be emitted inside the next brace statement.
+  llvm::SmallVector<VarDecl *, 2> LocalAuxiliaryDecls;
+
   // Context information for tracking an `async let` child task.
   struct AsyncLetChildTask {
     SILValue asyncLet; // RawPointer to the async let state

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -244,6 +244,10 @@ struct ArgumentInitHelper {
   }
 
   void emitParam(ParamDecl *PD) {
+    PD->visitAuxiliaryDecls([&](VarDecl *localVar) {
+      SGF.LocalAuxiliaryDecls.push_back(localVar);
+    });
+
     if (PD->hasExternalPropertyWrapper()) {
       PD = cast<ParamDecl>(PD->getPropertyWrapperBackingProperty());
     }

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -306,6 +306,10 @@ static void makeArgument(Type ty, ParamDecl *decl,
 
 void SILGenFunction::bindParameterForForwarding(ParamDecl *param,
                                      SmallVectorImpl<SILValue> &parameters) {
+  if (param->hasExternalPropertyWrapper()) {
+    param = cast<ParamDecl>(param->getPropertyWrapperBackingProperty());
+  }
+
   makeArgument(param->getType(), param, parameters, *this);
 }
 

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -245,11 +245,6 @@ struct ArgumentInitHelper {
 
   void emitParam(ParamDecl *PD) {
     if (PD->hasExternalPropertyWrapper()) {
-      auto initInfo = PD->getPropertyWrapperInitializerInfo();
-      if (initInfo.hasSynthesizedInitializers()) {
-        SGF.SGM.emitPropertyWrapperBackingInitializer(PD);
-      }
-
       PD = cast<ParamDecl>(PD->getPropertyWrapperBackingProperty());
     }
 

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -282,7 +282,19 @@ void StmtEmitter::visitBraceStmt(BraceStmt *S) {
   const unsigned ThrowStmtType    = 3;
   const unsigned UnknownStmtType  = 4;
   unsigned StmtType = UnknownStmtType;
-  
+
+  // Emit local auxiliary declarations.
+  if (!SGF.LocalAuxiliaryDecls.empty()) {
+    for (auto *var : SGF.LocalAuxiliaryDecls) {
+      if (auto *patternBinding = var->getParentPatternBinding())
+        SGF.visit(patternBinding);
+
+      SGF.visit(var);
+    }
+
+    SGF.LocalAuxiliaryDecls.clear();
+  }
+
   for (auto &ESD : S->getElements()) {
     
     if (auto D = ESD.dyn_cast<Decl*>())

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1106,7 +1106,7 @@ public:
       return;
 
     // Emit any default argument generators.
-    SGM.emitDefaultArgGenerators(EED, EED->getParameterList());
+    SGM.emitArgumentGenerators(EED, EED->getParameterList());
   }
 
   void visitPatternBindingDecl(PatternBindingDecl *pd) {
@@ -1141,7 +1141,7 @@ public:
   }
 
   void visitSubscriptDecl(SubscriptDecl *sd) {
-    SGM.emitDefaultArgGenerators(sd, sd->getIndices());
+    SGM.emitArgumentGenerators(sd, sd->getIndices());
     visitAbstractStorageDecl(sd);
   }
 
@@ -1268,7 +1268,7 @@ public:
   }
 
   void visitSubscriptDecl(SubscriptDecl *sd) {
-    SGM.emitDefaultArgGenerators(sd, sd->getIndices());
+    SGM.emitArgumentGenerators(sd, sd->getIndices());
     visitAbstractStorageDecl(sd);
   }
 

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -434,6 +434,23 @@ func testCallableWithDefault(_ x: CallableWithDefault) {
   x(y: 5)
 }
 
+enum E {
+  // CHECK-LABEL: sil hidden [ossa] @$s17default_arguments1EO6ResultV4name9platformsAESS_SaySiGtcfcfA0_ : $@convention(thin) () -> @owned Array<Int>
+  struct Result {
+    var name: String
+    var platforms: [Int] = []
+  }
+
+  // CHECK-LABEL: sil hidden [ossa] @$s17default_arguments1EO4testyyFZ : $@convention(method) (@thin E.Type) -> ()
+  static func test() {
+    // CHECK: function_ref @$s17default_arguments1EO6ResultV4name9platformsAESS_SaySiGtcfcfA0_ : $@convention(thin) () -> @owned Array<Int>
+    // CHECK: function_ref @$s17default_arguments1EO4testyyFZAC6ResultVSS_SaySiGtcfu_ : $@convention(thin) (@guaranteed String, @guaranteed Array<Int>) -> @owned E.Result
+
+    // CHECK-LABEL: sil private [ossa] @$s17default_arguments1EO4testyyFZAC6ResultVSS_SaySiGtcfu_ : $@convention(thin) (@guaranteed String, @guaranteed Array<Int>) -> @owned E.Result
+    var result = Self.Result(name: "")
+  }
+}
+
 // FIXME: Arguably we shouldn't allow calling a constructor like this, as
 // we usually require the user write an explicit '.init'.
 struct WeirdUMEInitCase {

--- a/test/SILGen/property_wrapper_parameter.swift
+++ b/test/SILGen/property_wrapper_parameter.swift
@@ -26,17 +26,17 @@ public struct Wrapper<T> {
   }
 }
 
+// property wrapper backing initializer of value #1 in testSimpleWrapperParameter(value:)
+// CHECK: sil non_abi [serialized] [ossa] @$s26property_wrapper_parameter26testSimpleWrapperParameter5valueyAA0F0VySiG_tFACL_SivpfP : $@convention(thin) (Int) -> Wrapper<Int>
+
+// property wrapper init from projected value of value #1 in testSimpleWrapperParameter(value:)
+// CHECK: sil non_abi [serialized] [ossa] @$s26property_wrapper_parameter26testSimpleWrapperParameter5valueyAA0F0VySiG_tFACL_SivpfW : $@convention(thin) (Projection<Int>) -> Wrapper<Int>
+
 // CHECK-LABEL: sil [ossa] @$s26property_wrapper_parameter26testSimpleWrapperParameter5valueyAA0F0VySiG_tF : $@convention(thin) (Wrapper<Int>) -> ()
 public func testSimpleWrapperParameter(@Wrapper value: Int) {
   _ = value
   _ = _value
   _ = $value
-
-  // property wrapper backing initializer of value #1 in testSimpleWrapperParameter(value:)
-  // CHECK: sil non_abi [serialized] [ossa] @$s26property_wrapper_parameter26testSimpleWrapperParameter5valueyAA0F0VySiG_tFACL_SivpfP : $@convention(thin) (Int) -> Wrapper<Int>
-
-  // property wrapper init from projected value of value #1 in testSimpleWrapperParameter(value:)
-  // CHECK: sil non_abi [serialized] [ossa] @$s26property_wrapper_parameter26testSimpleWrapperParameter5valueyAA0F0VySiG_tFACL_SivpfW : $@convention(thin) (Projection<Int>) -> Wrapper<Int>
 
   // getter of $value #1 in testSimpleWrapperParameter(value:)
   // CHECK: sil private [ossa] @$s26property_wrapper_parameter26testSimpleWrapperParameter5valueyAA0F0VySiG_tF6$valueL_AA10ProjectionVySiGvg : $@convention(thin) (Wrapper<Int>) -> Projection<Int>
@@ -58,14 +58,14 @@ func simpleWrapperParameterCaller(projection: Projection<Int>) {
   // CHECK: function_ref @$s26property_wrapper_parameter26testSimpleWrapperParameter5valueyAA0F0VySiG_tFACL_SivpfP : $@convention(thin) (Int) -> Wrapper<Int>
 }
 
+// property wrapper backing initializer of value #1 in testGenericWrapper<A>(value:)
+// CHECK: sil non_abi [serialized] [ossa] @$s26property_wrapper_parameter18testGenericWrapper5valueyAA0F0VyxG_tlFACL_xvpfP : $@convention(thin) <T> (@in T) -> @out Wrapper<T>
+
+// property wrapper init from projected value of value #1 in testGenericWrapper<A>(value:)
+// CHECK: sil non_abi [serialized] [ossa] @$s26property_wrapper_parameter18testGenericWrapper5valueyAA0F0VyxG_tlFACL_xvpfW : $@convention(thin) <T> (@in Projection<T>) -> @out Wrapper<T>
+
 // CHECK-LABEL: sil [ossa] @$s26property_wrapper_parameter18testGenericWrapper5valueyAA0F0VyxG_tlF : $@convention(thin) <T> (@in_guaranteed Wrapper<T>) -> ()
 public func testGenericWrapper<T>(@Wrapper value: T) {
-
-  // property wrapper backing initializer of value #1 in testGenericWrapper<A>(value:)
-  // CHECK: sil non_abi [serialized] [ossa] @$s26property_wrapper_parameter18testGenericWrapper5valueyAA0F0VyxG_tlFACL_xvpfP : $@convention(thin) <T> (@in T) -> @out Wrapper<T>
-
-  // property wrapper init from projected value of value #1 in testGenericWrapper<A>(value:)
-  // CHECK: sil non_abi [serialized] [ossa] @$s26property_wrapper_parameter18testGenericWrapper5valueyAA0F0VyxG_tlFACL_xvpfW : $@convention(thin) <T> (@in Projection<T>) -> @out Wrapper<T>
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter20genericWrapperCaller10projectionyAA10ProjectionVySiG_tF : $@convention(thin) (Projection<Int>) -> ()
@@ -99,11 +99,12 @@ public struct AutoClosureWrapper<T> {
   }
 }
 
+// property wrapper backing initializer of value #1 in testAutoClosureWrapper<A>(value:)
+// CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter22testAutoClosureWrapper5valueyAA0efG0VyxG_tlFACL_xvpfP : $@convention(thin) <T> (@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <T>) -> @out AutoClosureWrapper<T>
+// CHECK: function_ref @$s26property_wrapper_parameter18AutoClosureWrapperV12wrappedValueACyxGxyXK_tcfC : $@convention(method) <τ_0_0> (@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_0>, @thin AutoClosureWrapper<τ_0_0>.Type) -> @out AutoClosureWrapper<τ_0_0>
+
 // CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter22testAutoClosureWrapper5valueyAA0efG0VyxG_tlF : $@convention(thin) <T> (@in_guaranteed AutoClosureWrapper<T>) -> ()
 func testAutoClosureWrapper<T>(@AutoClosureWrapper value: T) {
-  // property wrapper backing initializer of value #1 in testAutoClosureWrapper<A>(value:)
-  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter22testAutoClosureWrapper5valueyAA0efG0VyxG_tlFACL_xvpfP : $@convention(thin) <T> (@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <T>) -> @out AutoClosureWrapper<T>
-  // CHECK: function_ref @$s26property_wrapper_parameter18AutoClosureWrapperV12wrappedValueACyxGxyXK_tcfC : $@convention(method) <τ_0_0> (@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_0>, @thin AutoClosureWrapper<τ_0_0>.Type) -> @out AutoClosureWrapper<τ_0_0>
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter24autoClosureWrapperCalleryyF : $@convention(thin) () -> ()
@@ -275,24 +276,24 @@ func genericContext<T>(_: T) where T: P {
   // property wrapper init from projected value of $value #1 in closure #2 in implicit closure #2 in genericContext<A>(_:)
   // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14genericContextyyxAA1PRzlFxAA17ProjectionWrapperVySiGcfu0_xAFcfU0_6$valueL_AFvpfW : $@convention(thin) <T where T : P> (ProjectionWrapper<Int>) -> ProjectionWrapper<Int>
 
-  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14genericContextyyxAA1PRzlF5innerL_1ayAA7WrapperVySiG_tAaCRzlF : $@convention(thin) (Wrapper<Int>) -> ()
-  func inner(@Wrapper a: Int) {}
-
   // property wrapper backing initializer of a #1 in inner #1 <A>(a:) in genericContext<A>(_:)
   // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14genericContextyyxAA1PRzlF5innerL_1ayAA7WrapperVySiG_tAaCRzlFAEL_SivpfP : $@convention(thin) (Int) -> Wrapper<Int>
+
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14genericContextyyxAA1PRzlF5innerL_1ayAA7WrapperVySiG_tAaCRzlF : $@convention(thin) (Wrapper<Int>) -> ()
+  func inner(@Wrapper a: Int) {}
 
   inner(a: 1)
 
   // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14genericContextyyxAA1PRzlF5innerL0_yyAaCRzlF : $@convention(thin) <T where T : P> () -> ()
   func inner() { _ = T.self }
 
+  // property wrapper backing initializer of b #1 in inner #3 <A>(b:) in genericContext<A>(_:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14genericContextyyxAA1PRzlF5innerL1_1byAA7WrapperVySiG_tAaCRzlFAEL_SivpfP : $@convention(thin) <T where T : P> (Int) -> Wrapper<Int>
+
   // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14genericContextyyxAA1PRzlF5innerL1_1byAA7WrapperVySiG_tAaCRzlF : $@convention(thin) <T where T : P> (Wrapper<Int>) -> ()
   func inner(@Wrapper b: Int) {
     inner()
   }
-
-  // property wrapper backing initializer of b #1 in inner #3 <A>(b:) in genericContext<A>(_:)
-  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14genericContextyyxAA1PRzlF5innerL1_1byAA7WrapperVySiG_tAaCRzlFAEL_SivpfP : $@convention(thin) <T where T : P> (Int) -> Wrapper<Int>
 
   inner(b: 1)
 }
@@ -314,24 +315,24 @@ public struct PublicWrapper<T> {
   }
 }
 
+// property wrapper backing initializer of value #1 in publicFunc(value:)
+// CHECK: sil non_abi [serialized] [ossa] @$s26property_wrapper_parameter10publicFunc5valueyAA13PublicWrapperVySSG_tFACL_SSvpfP : $@convention(thin) (@owned String) -> @owned PublicWrapper<String>
+
+// property wrapper init from projected value of value #1 in publicFunc(value:)
+// CHECK: sil non_abi [serialized] [ossa] @$s26property_wrapper_parameter10publicFunc5valueyAA13PublicWrapperVySSG_tFACL_SSvpfW : $@convention(thin) (@owned PublicWrapper<String>) -> @owned PublicWrapper<String>
+
 // CHECK-LABEL: sil [ossa] @$s26property_wrapper_parameter10publicFunc5valueyAA13PublicWrapperVySSG_tF : $@convention(thin) (@guaranteed PublicWrapper<String>) -> ()
 public func publicFunc(@PublicWrapper value: String) {
-  // property wrapper backing initializer of value #1 in publicFunc(value:)
-  // CHECK: sil non_abi [serialized] [ossa] @$s26property_wrapper_parameter10publicFunc5valueyAA13PublicWrapperVySSG_tFACL_SSvpfP : $@convention(thin) (@owned String) -> @owned PublicWrapper<String>
-
-  // property wrapper init from projected value of value #1 in publicFunc(value:)
-  // CHECK: sil non_abi [serialized] [ossa] @$s26property_wrapper_parameter10publicFunc5valueyAA13PublicWrapperVySSG_tFACL_SSvpfW : $@convention(thin) (@owned PublicWrapper<String>) -> @owned PublicWrapper<String>
 }
+
+// property wrapper backing initializer of value #1 in inlinableFunc(value:)
+// CHECK: sil non_abi [serialized] [ossa] @$s26property_wrapper_parameter13inlinableFunc5valueyAA13PublicWrapperVySSG_tFACL_SSvpfP : $@convention(thin) (@owned String) -> @owned PublicWrapper<String>
+
+// property wrapper init from projected value of value #1 in inlinableFunc(value:)
+// CHECK: sil non_abi [serialized] [ossa] @$s26property_wrapper_parameter13inlinableFunc5valueyAA13PublicWrapperVySSG_tFACL_SSvpfW : $@convention(thin) (@owned PublicWrapper<String>) -> @owned PublicWrapper<String>
 
 // CHECK-LABEL: sil [serialized] [ossa] @$s26property_wrapper_parameter13inlinableFunc5valueyAA13PublicWrapperVySSG_tF : $@convention(thin) (@guaranteed PublicWrapper<String>) -> ()
 @inlinable func inlinableFunc(@PublicWrapper value: String) {
-  // property wrapper backing initializer of value #1 in inlinableFunc(value:)
-  // CHECK: sil non_abi [serialized] [ossa] @$s26property_wrapper_parameter13inlinableFunc5valueyAA13PublicWrapperVySSG_tFACL_SSvpfP : $@convention(thin) (@owned String) -> @owned PublicWrapper<String>
-
-  // property wrapper init from projected value of value #1 in inlinableFunc(value:)
-  // CHECK: sil non_abi [serialized] [ossa] @$s26property_wrapper_parameter13inlinableFunc5valueyAA13PublicWrapperVySSG_tFACL_SSvpfW : $@convention(thin) (@owned PublicWrapper<String>) -> @owned PublicWrapper<String>
-
-
   _ = publicFunc(value:)
 
   // implicit closure #1 in inlinableFunc(value:)

--- a/test/SILGen/property_wrapper_parameter.swift
+++ b/test/SILGen/property_wrapper_parameter.swift
@@ -82,6 +82,76 @@ func genericWrapperCaller(projection: Projection<Int>) {
 }
 
 @propertyWrapper
+struct ImplementationDetail<T> {
+  var wrappedValue: T
+
+  // CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter20ImplementationDetailV12wrappedValueACyxGx_tcfC : $@convention(method) <T> (@in T, @thin ImplementationDetail<T>.Type) -> @out ImplementationDetail<T>
+  init(wrappedValue: T) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+
+struct TestStructInit {
+  // property wrapper backing initializer of number #1 in TestStructInit.init(number:message:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14TestStructInitV6number7messageAcA7WrapperVySiG_SStcfcADL_SivpfP : $@convention(thin) (Int) -> Wrapper<Int>
+
+  // property wrapper init from projected value of number #1 in TestStructInit.init(number:message:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14TestStructInitV6number7messageAcA7WrapperVySiG_SStcfcADL_SivpfW : $@convention(thin) (Projection<Int>) -> Wrapper<Int>
+
+  // CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter14TestStructInitV6number7messageAcA7WrapperVySiG_SStcfC : $@convention(method) (Wrapper<Int>, @owned String, @thin TestStructInit.Type) -> TestStructInit
+  init(@Wrapper number: Int, @ImplementationDetail message: String) {
+    // CHECK: debug_value %0 : $Wrapper<Int>, let, name "_number"
+    // CHECK: debug_value %1 : $String, let, name "message"
+    // CHECK: alloc_stack $ImplementationDetail<String>
+    // CHECK" function_ref @$s26property_wrapper_parameter20ImplementationDetailV12wrappedValueACyxGx_tcfC : $@convention(method) <τ_0_0> (@in τ_0_0, @thin ImplementationDetail<τ_0_0>.Type) -> @out ImplementationDetail<τ_0_0>
+
+    _ = number
+    _ = _number
+
+    _ = message
+    _ = _message
+
+    // getter of number #1 in TestStructInit.init(number:message:)
+    // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14TestStructInitV6number7messageAcA7WrapperVySiG_SStcfcADL_Sivg : $@convention(thin) (Wrapper<Int>) -> Int
+
+    // getter of message #1 in TestStructInit.init(number:message:)
+    // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14TestStructInitV6number7messageAcA7WrapperVySiG_SStcfcAEL_SSvg : $@convention(thin) (@guaranteed ImplementationDetail<String>) -> @owned String
+  }
+}
+
+class TestClassInit {
+  // property wrapper backing initializer of number #1 in TestClassInit.init(number:message:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter13TestClassInitC6number7messageAcA7WrapperVySiG_SStcfcADL_SivpfP : $@convention(thin) (Int) -> Wrapper<Int>
+
+  // property wrapper init from projected value of number #1 in TestClassInit.init(number:message:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter13TestClassInitC6number7messageAcA7WrapperVySiG_SStcfcADL_SivpfW : $@convention(thin) (Projection<Int>) -> Wrapper<Int>
+
+  // TestClassInit.__allocating_init(number:message:)
+  // CHECK-LABEL: sil hidden [exact_self_class] [ossa] @$s26property_wrapper_parameter13TestClassInitC6number7messageAcA7WrapperVySiG_SStcfC : $@convention(method) (Wrapper<Int>, @owned String, @thick TestClassInit.Type) -> @owned TestClassInit
+  // CHECK-NOT: alloc_stack $ImplementationDetail<String>
+
+  // CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter13TestClassInitC6number7messageAcA7WrapperVySiG_SStcfc : $@convention(method) (Wrapper<Int>, @owned String, @owned TestClassInit) -> @owned TestClassInit
+  init(@Wrapper number: Int, @ImplementationDetail message: String) {
+    // CHECK: debug_value %0 : $Wrapper<Int>, let, name "_number"
+    // CHECK: debug_value %1 : $String, let, name "message"
+    // CHECK: alloc_stack $ImplementationDetail<String>
+
+    _ = number
+    _ = _number
+
+    _ = message
+    _ = _message
+
+    // getter of number #1 in TestClassInit.init(number:message:)
+    // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter13TestClassInitC6number7messageAcA7WrapperVySiG_SStcfcADL_Sivg : $@convention(thin) (Wrapper<Int>) -> Int
+
+    // getter of message #1 in TestClassInit.init(number:message:)
+    // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter13TestClassInitC6number7messageAcA7WrapperVySiG_SStcfcAEL_SSvg : $@convention(thin) (@guaranteed ImplementationDetail<String>) -> @owned String
+  }
+}
+
+@propertyWrapper
 public struct AutoClosureWrapper<T> {
   public var wrappedValue: T
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/38854

This is important to take for 5.5 because it fixes a SILGen crash and bogus error messages.

---

Attempting to use wrapped parameters in initializers would lead to a SILGen crash or a bogus error message because the local auxiliary decls for wrapped parameters were never emitted. Fix this by recording local auxiliary decls when the parameter is emitted, and emit those auxiliary decls before the body statements in `StmtEmitter::visitBraceStmt`.

Resolves: rdar://81560448, [SR-15033](https://bugs.swift.org/browse/SR-15033)