### PR TITLE
Add missing REQUIRES: CPU=x86_64 to Reflection test.

### DIFF
--- a/test/Reflection/typeref_decoding_concurrency.swift
+++ b/test/Reflection/typeref_decoding_concurrency.swift
@@ -3,6 +3,7 @@
 // REQUIRES: concurrency
 // REQUIRES: libdispatch
 
+// REQUIRES: CPU=x86_64
 // REQUIRES: OS=macosx
 
 // rdar://76038845


### PR DESCRIPTION
Forgot to add this in https://github.com/apple/swift/pull/39120