### PR TITLE
[ConstraintSystem] Fix a silly crash in `repairFailures`.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4761,7 +4761,7 @@ bool ConstraintSystem::repairFailures(
     path.pop_back();
 
     // Drop the tuple type path elements too, but extract each tuple type first.
-    if (path.back().is<LocatorPathElt::TupleType>()) {
+    if (!path.empty() && path.back().is<LocatorPathElt::TupleType>()) {
       rhs = path.back().getAs<LocatorPathElt::TupleType>()->getType();
       path.pop_back();
       lhs = path.back().getAs<LocatorPathElt::TupleType>()->getType();

--- a/validation-test/compiler_crashers_2_fixed/sr14894.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr14894.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+struct S {
+  private let data: [[String]]
+  private func f() {}
+
+  func test() {
+    // expected-error@+1 {{static method 'buildBlock' requires that 'ForEach<[String], ()>' conform to 'View'}}
+    ForEach(data) { group in
+      ForEach(group) { month in
+        self.f()
+      }
+    }
+  }
+}
+
+struct Wrapper<T> {}
+
+protocol View {}
+
+@resultBuilder struct Builder {
+  // expected-note@+1 {{where 'Content' = 'ForEach<[String], ()>'}}
+  static func buildBlock<Content: View>(_ content: Content) -> Content { fatalError() }
+}
+
+struct ForEach<Data, Content> where Data : RandomAccessCollection {
+  init<C>(_ data: Wrapper<C>, @Builder content: (Wrapper<C.Element>) -> Content) where C : MutableCollection {}
+  init(_ data: Data, @Builder content: @escaping (Data.Element) -> Content) {}
+}


### PR DESCRIPTION
The code checked if the last element of locator path vector is a certain kind of element without first ensuring that the vector isn't empty.

Resolves: rdar://80271707 / [SR-14894](https://bugs.swift.org/browse/SR-14894)