### PR TITLE
Runtime: correct the location of windows header inclusion

### DIFF
--- a/include/swift/Runtime/Atomic.h
+++ b/include/swift/Runtime/Atomic.h
@@ -20,6 +20,9 @@
 #include "swift/Runtime/Config.h"
 #include <assert.h>
 #include <atomic>
+#if defined(_WIN64)
+#include <intrin.h>
+#endif
 
 // FIXME: Workaround for rdar://problem/18889711. 'Consume' does not require
 // a barrier on ARM64, but LLVM doesn't know that. Although 'relaxed'
@@ -72,7 +75,6 @@ public:
 };
 
 #if defined(_WIN64)
-#include <intrin.h>
 
 /// MSVC's std::atomic uses an inline spin lock for 16-byte atomics,
 /// which is not only unnecessarily inefficient but also doubles the size


### PR DESCRIPTION
We would previously include a header inside the `swift::impl` namespace,
which would prevent the proper declaration of the functions and
enumerators.  This corrects the location of the header inclusion to fix
this issue.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
