### PR TITLE
[Driver] Update OS versions for rpath checks.

### DIFF
--- a/include/swift/Basic/Platform.h
+++ b/include/swift/Basic/Platform.h
@@ -55,9 +55,10 @@ namespace swift {
   bool triplesAreValidForZippering(const llvm::Triple &target,
                                    const llvm::Triple &targetVariant);
 
-  /// Returns true if the given triple represents an OS that ships with
-  /// ABI-stable swift libraries (eg. in /usr/lib/swift).
-  bool tripleRequiresRPathForSwiftInOS(const llvm::Triple &triple);
+  /// Returns true if the given triple represents an OS that has all the
+  /// "built-in" ABI-stable libraries (stdlib and _Concurrency)
+  /// (eg. in /usr/lib/swift).
+  bool tripleRequiresRPathForSwiftLibrariesInOS(const llvm::Triple &triple);
 
   /// Returns the platform name for a given target triple.
   ///

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -79,19 +79,25 @@ bool swift::triplesAreValidForZippering(const llvm::Triple &target,
   return false;
 }
 
-bool swift::tripleRequiresRPathForSwiftInOS(const llvm::Triple &triple) {
+bool swift::tripleRequiresRPathForSwiftLibrariesInOS(
+    const llvm::Triple &triple) {
   if (triple.isMacOSX()) {
-    // macOS 10.14.4 contains a copy of Swift, but the linker will still use an
-    // rpath-based install name until 10.15.
-    return triple.isMacOSXVersionLT(10, 15);
+    // macOS versions before 10.14.4 don't have Swift in the OS
+    // (the linker still uses an rpath-based install name until 10.15).
+    // macOS versions before 12.0 don't have _Concurrency in the OS.
+    return triple.isMacOSXVersionLT(12, 0);
   }
 
   if (triple.isiOS()) {
-    return triple.isOSVersionLT(12, 2);
+    // iOS versions before 12.2 don't have Swift in the OS.
+    // iOS versions before 15.0 don't have _Concurrency in the OS.
+    return triple.isOSVersionLT(15, 0);
   }
 
   if (triple.isWatchOS()) {
-    return triple.isOSVersionLT(5, 2);
+    // watchOS versions before 5.2 don't have Swift in the OS.
+    // watchOS versions before 8.0 don't have _Concurrency in the OS.
+    return triple.isOSVersionLT(8, 0);
   }
 
   // Other platforms don't have Swift installed as part of the OS by default.

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -471,7 +471,7 @@ toolchains::Darwin::addArgsToLinkStdlib(ArgStringList &Arguments,
       Arguments.push_back("-rpath");
       Arguments.push_back(context.Args.MakeArgString(path));
     }
-  } else if (!tripleRequiresRPathForSwiftInOS(getTriple()) ||
+  } else if (!tripleRequiresRPathForSwiftLibrariesInOS(getTriple()) ||
              context.Args.hasArg(options::OPT_no_stdlib_rpath)) {
     // If targeting an OS with Swift in /usr/lib/swift, the LC_ID_DYLIB
     // install_name the stdlib will be an absolute path like
@@ -499,9 +499,11 @@ toolchains::Darwin::addArgsToLinkStdlib(ArgStringList &Arguments,
     // package isn't installed.
     Arguments.push_back("-rpath");
     Arguments.push_back(context.Args.MakeArgString("/usr/lib/swift"));
-    // We don't need an rpath for /System/iOSSupport/usr/lib/swift because...
-    assert(!tripleIsMacCatalystEnvironment(getTriple())
-           && "macCatalyst not supported without Swift-in-the-OS");
+    // We don’t need an rpath for /System/iOSSupport/usr/lib/swift because:
+    // 1. The standard library and overlays were part of the OS before
+    //    Catalyst was introduced, so they are always available for Catalyst.
+    // 2. The _Concurrency back-deployment library is zippered, whereas only
+    //    unzippered frameworks need an unzippered twin in /System/iOSSupport.
   }
 }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1841,7 +1841,7 @@ static void printTripleInfo(const llvm::Triple &triple,
   }
 
   out << "    \"librariesRequireRPath\": "
-      << (tripleRequiresRPathForSwiftInOS(triple) ? "true" : "false")
+      << (tripleRequiresRPathForSwiftLibrariesInOS(triple) ? "true" : "false")
       << "\n";
 
   out << "  }";

--- a/test/Driver/linker-rpath.swift
+++ b/test/Driver/linker-rpath.swift
@@ -6,22 +6,30 @@
 // RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.14 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.14.3 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.14.4 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.15 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx10.15 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx11.0 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target x86_64-apple-macosx12.0 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios12 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios12.1 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios12.2 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios13 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios12.2 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios13 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios14 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios15 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos12 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos12.1 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos12.2 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos13 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos12.2 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos13 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos14 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos15 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 
 // RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos5 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos5.1 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos5.2 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos6 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos5.2 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos6 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos7 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target armv7k-apple-watchos8 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 
 // RPATH: bin/ld{{"? }}
 // RPATH-SAME: -rpath {{"?/usr/lib/swift(-.+)?"? }}
@@ -39,7 +47,7 @@
 
 // ### Test with -no-toolchain-stdlib-rpath
 // RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
-// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx10.15 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -no-toolchain-stdlib-rpath -target x86_64-apple-macosx12.0 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 
 // TOOLCHAIN-RPATH: bin/ld{{"? }}
 // TOOLCHAIN-RPATH-SAME: -rpath garbage/[[PLATFORM]]{{ }}

--- a/test/Driver/linker-rpath.swift
+++ b/test/Driver/linker-rpath.swift
@@ -17,6 +17,10 @@
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios14 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios15 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
 
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios13-macabi %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios14-macabi %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
+// RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-ios15-macabi %S/../Inputs/empty.swift | %FileCheck -check-prefix NO-RPATH %s
+
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos12 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos12.1 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s
 // RUN: %swiftc_driver_plain -driver-print-jobs -target arm64-apple-tvos12.2 %S/../Inputs/empty.swift | %FileCheck -check-prefix RPATH %s

--- a/test/Driver/print_target_info.swift
+++ b/test/Driver/print_target_info.swift
@@ -8,8 +8,11 @@
 // RUN: %swift_driver -print-target-info -target x86_64-unknown-linux -static-stdlib | %FileCheck -check-prefix CHECK-LINUX-STATIC %s
 // RUN: %swift_frontend_plain -print-target-info -target x86_64-unknown-linux -use-static-resource-dir | %FileCheck -check-prefix CHECK-LINUX-STATIC %s
 
-// RUN: %swift_driver -print-target-info -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13-macabi | %FileCheck -check-prefix CHECK-ZIPPERED %s
-// RUN: %target-swift-frontend -print-target-info -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13-macabi | %FileCheck -check-prefix CHECK-ZIPPERED %s
+// RUN: %swift_driver -print-target-info -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13-macabi | %FileCheck -check-prefix CHECK-PRE-CONCURRENCY-ZIPPERED %s
+// RUN: %target-swift-frontend -print-target-info -target x86_64-apple-macosx10.15 -target-variant x86_64-apple-ios13-macabi | %FileCheck -check-prefix CHECK-PRE-CONCURRENCY-ZIPPERED %s
+
+// RUN: %swift_driver -print-target-info -target x86_64-apple-macosx12.0 -target-variant x86_64-apple-ios15-macabi | %FileCheck -check-prefix CHECK-ZIPPERED %s
+// RUN: %target-swift-frontend -print-target-info -target x86_64-apple-macosx12.0 -target-variant x86_64-apple-ios15-macabi | %FileCheck -check-prefix CHECK-ZIPPERED %s
 
 // RUN: %swift_driver -print-target-info -target x86_64-apple-ios12.0 | %FileCheck -check-prefix CHECK-IOS-SIM %s
 
@@ -67,20 +70,33 @@
 
 // CHECK-LINUX-STATIC-NOT: "targetVariant":
 
+// CHECK-PRE-CONCURRENCY-ZIPPERED: "target": {
+// CHECK-PRE-CONCURRENCY-ZIPPERED:   "triple": "x86_64-apple-macosx10.15"
+// CHECK-PRE-CONCURRENCY-ZIPPERED:   "unversionedTriple": "x86_64-apple-macosx"
+// CHECK-PRE-CONCURRENCY-ZIPPERED:   "moduleTriple": "x86_64-apple-macos"
+// CHECK-PRE-CONCURRENCY-ZIPPERED:   "swiftRuntimeCompatibilityVersion": "5.1"
+// CHECK-PRE-CONCURRENCY-ZIPPERED:   "librariesRequireRPath": true
+// CHECK-PRE-CONCURRENCY-ZIPPERED: }
+
+// CHECK-PRE-CONCURRENCY-ZIPPERED: "targetVariant": {
+// CHECK-PRE-CONCURRENCY-ZIPPERED:   "triple": "x86_64-apple-ios13-macabi"
+// CHECK-PRE-CONCURRENCY-ZIPPERED:   "unversionedTriple": "x86_64-apple-ios-macabi"
+// CHECK-PRE-CONCURRENCY-ZIPPERED:   "moduleTriple": "x86_64-apple-ios-macabi"
+// CHECK-PRE-CONCURRENCY-ZIPPERED:   "swiftRuntimeCompatibilityVersion": "5.1"
+// CHECK-PRE-CONCURRENCY-ZIPPERED:   "librariesRequireRPath": true
+// CHECK-PRE-CONCURRENCY-ZIPPERED: }
 
 // CHECK-ZIPPERED: "target": {
-// CHECK-ZIPPERED:   "triple": "x86_64-apple-macosx10.15"
+// CHECK-ZIPPERED:   "triple": "x86_64-apple-macosx12.0"
 // CHECK-ZIPPERED:   "unversionedTriple": "x86_64-apple-macosx"
 // CHECK-ZIPPERED:   "moduleTriple": "x86_64-apple-macos"
-// CHECK-ZIPPERED:   "swiftRuntimeCompatibilityVersion": "5.1"
 // CHECK-ZIPPERED:   "librariesRequireRPath": false
 // CHECK-ZIPPERED: }
 
 // CHECK-ZIPPERED: "targetVariant": {
-// CHECK-ZIPPERED:   "triple": "x86_64-apple-ios13-macabi"
+// CHECK-ZIPPERED:   "triple": "x86_64-apple-ios15-macabi"
 // CHECK-ZIPPERED:   "unversionedTriple": "x86_64-apple-ios-macabi"
 // CHECK-ZIPPERED:   "moduleTriple": "x86_64-apple-ios-macabi"
-// CHECK-ZIPPERED:   "swiftRuntimeCompatibilityVersion": "5.1"
 // CHECK-ZIPPERED:   "librariesRequireRPath": false
 // CHECK-ZIPPERED: }
 


### PR DESCRIPTION
Make sure that we add the appropriate rpaths so that the appropriate
_Concurrency back-deployment library can be picked up.

We don't need to update the Swift driver since it uses the C++ driver
as the source of truth to determine if the relevant rpath should be
added or not.