### PR TITLE
Implement LLVM IR Virtual Function Elimination for Swift classes.

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -345,6 +345,8 @@ public:
 
   unsigned EnableGlobalISel : 1;
 
+  unsigned VirtualFunctionElimination : 1;
+
   /// The number of threads for multi-threaded code generation.
   unsigned NumThreads = 0;
 
@@ -401,7 +403,8 @@ public:
         GenerateProfile(false), EnableDynamicReplacementChaining(false),
         DisableRoundTripDebugTypes(false), DisableDebuggerShadowCopies(false),
         DisableConcreteTypeMetadataMangledNameAccessors(false),
-        EnableGlobalISel(false), CmdArgs(),
+        EnableGlobalISel(false), VirtualFunctionElimination(false),
+        CmdArgs(),
         SanitizeCoverage(llvm::SanitizerCoverageOptions()),
         TypeInfoFilter(TypeInfoDumpFilter::All) {}
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -489,6 +489,10 @@ def enable_implicit_dynamic : Flag<["-"], "enable-implicit-dynamic">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
   HelpText<"Add 'dynamic' to all declarations">;
 
+def enable_llvm_vfe : Flag<["-"], "enable-llvm-vfe">,
+  Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
+  HelpText<"Use LLVM Virtual Function Elimination on Swift class virtual tables">;
+
 def disable_previous_implementation_calls_in_dynamic_replacements :
   Flag<["-"], "disable-previous-implementation-calls-in-dynamic-replacements">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1896,6 +1896,10 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Opts.EnableGlobalISel = true;
   }
 
+  if (Args.hasArg(OPT_enable_llvm_vfe)) {
+    Opts.VirtualFunctionElimination = true;
+  }
+
   return false;
 }
 

--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -25,6 +25,7 @@ namespace llvm {
   class Constant;
   class Value;
   class Function;
+  class MDString;
 }
 
 namespace swift {
@@ -200,6 +201,9 @@ namespace irgen {
   emitClassResilientInstanceSizeAndAlignMask(IRGenFunction &IGF,
                                              ClassDecl *theClass,
                                              llvm::Value *metadata);
+
+  /// For VFE, returns a type identifier for the given base method on a class.
+  llvm::MDString *typeIdForMethod(IRGenModule &IGM, SILDeclRef method);
 
   /// Given a metadata pointer, emit the callee for the given method.
   FunctionPointer emitVirtualMethodValue(IRGenFunction &IGF,

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -192,6 +192,10 @@ void setModuleFlags(IRGenModule &IGM) {
   // error during LTO if the user tries to combine files across ABIs.
   Module->addModuleFlag(llvm::Module::Error, "Swift Version",
                         IRGenModule::swiftVersion);
+
+  if (IGM.getOptions().VirtualFunctionElimination) {
+    Module->addModuleFlag(llvm::Module::Error, "Virtual Function Elim", 1);
+  }
 }
 
 void swift::performLLVMOptimizations(const IRGenOptions &Opts,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1448,11 +1448,14 @@ public:
                                                      bool isDestroyer,
                                                      bool isForeign,
                                                      ForDefinition_t forDefinition);
-  llvm::GlobalValue *defineTypeMetadata(CanType concreteType,
-                                        bool isPattern,
-                                        bool isConstant,
-                                        ConstantInitFuture init,
-                                        llvm::StringRef section = {});
+  void addVTableTypeMetadata(
+      ClassDecl *decl, llvm::GlobalVariable *var,
+      SmallVector<std::pair<Size, SILDeclRef>, 8> vtableEntries);
+
+  llvm::GlobalValue *defineTypeMetadata(
+      CanType concreteType, bool isPattern, bool isConstant,
+      ConstantInitFuture init, llvm::StringRef section = {},
+      SmallVector<std::pair<Size, SILDeclRef>, 8> vtableEntries = {});
 
   TypeEntityReference getTypeEntityReference(GenericTypeDecl *D);
 

--- a/test/IRGen/virtual-function-elimination-exec.swift
+++ b/test/IRGen/virtual-function-elimination-exec.swift
@@ -1,0 +1,34 @@
+// Tests that under -enable-llvm-vfe, LLVM GlobalDCE is able to remove unused
+// virtual methods, and that used virtual methods are not removed (by running
+// the program).
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -disable-objc-interop -Xfrontend -enable-llvm-vfe %s -emit-ir -o %t/main.ll
+// RUN: %target-clang %t/main.ll -isysroot %sdk -L%swift_obj_root/lib/swift/%target-sdk-name -flto -o %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// RUN: %llvm-nm --defined-only %t/main | %FileCheck %s --check-prefix=NM
+
+// REQUIRES: executable_test
+
+// Test disabled until LLVM GlobalDCE supports Swift vtables.
+// REQUIRES: rdar81868930
+
+class MyClass {
+  func foo() { print("MyClass.foo") }
+  func bar() { print("MyClass.bar") }
+}
+
+class MyDerivedClass: MyClass {
+  override func foo() { print("MyDerivedClass.foo") }
+  override func bar() { print("MyDerivedClass.bar") }
+}
+
+let o: MyClass = MyDerivedClass()
+o.foo()
+// CHECK: MyDerivedClass.foo
+
+// NM-NOT: $s4main14MyDerivedClassC3baryyF
+// NM:     $s4main14MyDerivedClassC3fooyyF
+// NM-NOT: $s4main7MyClassC3baryyF
+// NM:     $s4main7MyClassC3fooyyF

--- a/test/IRGen/virtual-function-elimination-ir.swift
+++ b/test/IRGen/virtual-function-elimination-ir.swift
@@ -1,0 +1,74 @@
+// Tests that under -enable-llvm-vfe, IRGen marks vtables and vcall sites with
+// the right attributes and intrinsics.
+
+// RUN: %target-build-swift -Xfrontend -disable-objc-interop -Xfrontend -enable-llvm-vfe \
+// RUN:    %s -emit-ir -o - | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+
+// UNSUPPORTED: OS=windows-msvc
+
+class MyClass {
+  func foo() { print("MyClass.foo") }
+  func bar() { print("MyClass.bar") }
+}
+
+class MyDerivedClass: MyClass {
+  override func foo() { print("MyDerivedClass.foo") }
+  override func bar() { print("MyDerivedClass.bar") }
+}
+
+// Has vfunc slots at offsets 56, 64, 72 (in swift.method_descriptor structs).
+// CHECK:      @"$s4main7MyClassCMn" =
+// CHECK-SAME:     align 4, !type !0, !type !1, !type !2, !vcall_visibility !3
+
+// Has vfunc slots at offsets 72, 80, 88 (on 64-bit) / 48, 52, 56 (on 32-bit).
+// CHECK:         @"$s4main7MyClassCMf" =
+// CHECK-64-SAME:     align 8, !type !4, !type !5, !type !6, !vcall_visibility !3
+// CHECK-32-SAME:     align 4, !type !4, !type !5, !type !6, !vcall_visibility !3
+
+// Has vfunc slots at offsets 56, 68, 80 (in swift.method_override_descriptor structs).
+// CHECK:      @"$s4main14MyDerivedClassCMn" =
+// CHECK-SAME:     align 4, !type !0, !type !7, !type !8, !vcall_visibility !3
+
+// Has vfunc slots at offsets 72, 80, 88 (on 64-bit) / 48, 52, 56 (on 32-bit)
+// CHECK:         @"$s4main14MyDerivedClassCMf" =
+// CHECK-64-SAME:     align 8, !type !4, !type !5, !type !6, !vcall_visibility !3
+// CHECK-32-SAME:     align 4, !type !4, !type !5, !type !6, !vcall_visibility !3
+
+
+func func1() {
+  // CHECK: define hidden swiftcc void @"$s4main5func1yyF"()
+  let o: MyClass = MyDerivedClass()
+  o.foo()
+  // CHECK:  [[SLOT:%.*]] = getelementptr inbounds void (%T4main7MyClassC*)*, void (%T4main7MyClassC*)** {{.*}}, {{i64|i32}} {{.*}}
+  // CHECK:  [[SLOTASPTR:%.*]] = bitcast void (%T4main7MyClassC*)** [[SLOT]] to i8*
+  // CHECK:  call { i8*, i1 } @llvm.type.checked.load(i8* [[SLOTASPTR]], i32 0, metadata !"$s4main7MyClassC3fooyyFTq")
+}
+
+func func2() {
+  // CHECK: define hidden swiftcc void @"$s4main5func2yyF"()
+  let o: MyDerivedClass = MyDerivedClass()
+  o.foo()
+  // CHECK:  [[SLOT:%.*]] = getelementptr inbounds void (%T4main14MyDerivedClassC*)*, void (%T4main14MyDerivedClassC*)** {{.*}}, {{i64|i32}} {{.*}}
+  // CHECK:  [[SLOTASPTR:%.*]] = bitcast void (%T4main14MyDerivedClassC*)** [[SLOT]] to i8*
+  // CHECK:  call { i8*, i1 } @llvm.type.checked.load(i8* [[SLOTASPTR]], i32 0, metadata !"$s4main7MyClassC3fooyyFTq")
+}
+
+// CHECK-64: !0 = !{i64 56, !"$s4main7MyClassC3fooyyFTq"}
+// CHECK-64: !1 = !{i64 64, !"$s4main7MyClassC3baryyFTq"}
+// CHECK-64: !2 = !{i64 72, !"$s4main7MyClassCACycfCTq"}
+// CHECK-64: !3 = !{i64 1}
+// CHECK-64: !4 = !{i64 72, !"$s4main7MyClassC3fooyyFTq"}
+// CHECK-64: !5 = !{i64 80, !"$s4main7MyClassC3baryyFTq"}
+// CHECK-64: !6 = !{i64 88, !"$s4main7MyClassCACycfCTq"}
+// CHECK-64: !7 = !{i64 68, !"$s4main7MyClassC3baryyFTq"}
+// CHECK-64: !8 = !{i64 80, !"$s4main7MyClassCACycfCTq"}
+
+// CHECK-32: !0 = !{i64 56, !"$s4main7MyClassC3fooyyFTq"}
+// CHECK-32: !1 = !{i64 64, !"$s4main7MyClassC3baryyFTq"}
+// CHECK-32: !2 = !{i64 72, !"$s4main7MyClassCACycfCTq"}
+// CHECK-32: !3 = !{i64 1}
+// CHECK-32: !4 = !{i64 48, !"$s4main7MyClassC3fooyyFTq"}
+// CHECK-32: !5 = !{i64 52, !"$s4main7MyClassC3baryyFTq"}
+// CHECK-32: !6 = !{i64 56, !"$s4main7MyClassCACycfCTq"}
+// CHECK-32: !7 = !{i64 68, !"$s4main7MyClassC3baryyFTq"}
+// CHECK-32: !8 = !{i64 80, !"$s4main7MyClassCACycfCTq"}


### PR DESCRIPTION
- Virtual calls are done via a @llvm.type.checked.load instrinsic call with a type identifier
- Type identifier of a vfunc is the base method's mangling
- Type descriptors and class metadata get !type markers that list offsets and type identifiers of all vfuncs
- The -enable-llvm-vfe frontend flag enables VFE
- Two added tests verify the behavior on IR and by executing a program

Depends on changes in LLVM (some unmerged yet): https://reviews.llvm.org/D107645, https://reviews.llvm.org/D108741, https://reviews.llvm.org/D109114, https://reviews.llvm.org/D109169.