### PR TITLE
[test] stability-stdlib-abi*: Mask out unstable parts of private names

### DIFF
--- a/test/api-digester/stability-stdlib-abi-with-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-with-asserts.test
@@ -4,7 +4,7 @@
 // RUN: %clang -E -P -x c %S/stability-stdlib-abi-without-asserts.test -o - > %t.tmp/stability-stdlib-abi.swift.expected
 // RUN: %clang -E -P -x c %S/stability-stdlib-abi-with-asserts.test -o - >> %t.tmp/stability-stdlib-abi.swift.expected
 // RUN: %clang -E -P -x c %t.tmp/stability-stdlib-abi.swift.expected -o - | sed '/^\s*$/d' | sort > %t.tmp/stability-stdlib-abi.swift.expected.sorted
-// RUN: %clang -E -P -x c %t.tmp/changes.txt -o - | sed '/^\s*$/d' | sort > %t.tmp/changes.txt.tmp
+// RUN: %clang -E -P -x c %t.tmp/changes.txt -o - | sed -E -e '/^\s*$/d' -e 's/ in _[0-9A-F]{32}/ in #UNSTABLE ID#/g' | sort > %t.tmp/changes.txt.tmp
 // RUN: diff -u %t.tmp/stability-stdlib-abi.swift.expected.sorted %t.tmp/changes.txt.tmp
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment below.)

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -2,7 +2,7 @@
 // mkdir %t.tmp/module-cache && mkdir %t.tmp/dummy.sdk
 // RUN: %api-digester -diagnose-sdk -module Swift -o %t.tmp/changes.txt -module-cache-path %t.tmp/module-cache -sdk %t.tmp/dummy.sdk -abi -avoid-location -v
 // RUN: %clang -E -P -x c %S/stability-stdlib-abi-without-asserts.test -o - | sed '/^\s*$/d' | sort > %t.tmp/stability-stdlib-abi.swift.expected
-// RUN: %clang -E -P -x c %t.tmp/changes.txt -o - | sed '/^\s*$/d' | sort > %t.tmp/changes.txt.tmp
+// RUN: %clang -E -P -x c %t.tmp/changes.txt -o - | sed -E -e '/^\s*$/d' -e 's/ in _[0-9A-F]{32}/ in #UNSTABLE ID#/g' | sort > %t.tmp/changes.txt.tmp
 // RUN: diff -u %t.tmp/stability-stdlib-abi.swift.expected %t.tmp/changes.txt.tmp
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment below.)


### PR DESCRIPTION
The type `Hasher._Core` is `@frozen` but its stored properties are `private`, which currently makes them show up in api-digester ABI reports, leading to failures like this one:

```
+Var Hasher._Core._buffer has mangled name changing from 'Swift.Hasher._Core.(_buffer in _A19879A32F7D08A6DD54BABBA00BBA0C) : Swift.Hasher._TailBuffer' to 'Swift.Hasher._Core.(_buffer in _16630011A164FCBB1F12E5E0A3A7C863) : Swift.Hasher._TailBuffer'
```

These names aren't ABI impacting, so this checker probably should ignore their name changes. (The property names do appear in the .swiftinterface files, but IIUC the only their type and ordering matters.)

These ever-changing unstable ids make it impossible to add an entry to the expectation list that would allow these tests to pass. Work around this issue by postprocessing the reports to replace the unstable parts with the constant string `#UNSTABLE ID#`.

rdar://82552099
