### PR TITLE
[cxx-interop] Lazily load function parameter types.

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -33,6 +33,7 @@ namespace swift {
 
 class Decl;
 class DeclContext;
+class ParamDecl;
 class VisibleDeclConsumer;
 
 /// Represents the different namespaces for types in C.
@@ -238,6 +239,9 @@ public:
                                  SubstitutionMap subst) = 0;
 
   virtual bool isCXXMethodMutating(const clang::CXXMethodDecl *method) = 0;
+
+  virtual Type importParamType(const clang::ParmVarDecl *decl,
+                               ParamDecl *swiftParam) = 0;
 };
 
 /// Describes a C++ template instantiation error.

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -458,6 +458,9 @@ public:
   DeclName importName(const clang::NamedDecl *D,
                       clang::DeclarationName givenName);
 
+  Type importParamType(const clang::ParmVarDecl *decl,
+                       ParamDecl *swiftParam) override;
+
   Optional<std::string>
   getOrCreatePCH(const ClangImporterOptions &ImporterOptions,
                  StringRef SwiftPCHHash);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2237,6 +2237,11 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
 
   case DeclKind::Param: {
     auto *PD = cast<ParamDecl>(D);
+
+    if (PD->getClangDecl())
+      return Context.getClangModuleLoader()->importParamType(
+          cast<clang::ParmVarDecl>(PD->getClangDecl()), PD);
+
     if (PD->isSelfParameter()) {
       auto *AFD = cast<AbstractFunctionDecl>(PD->getDeclContext());
       auto selfParam = computeSelfParam(AFD,

--- a/test/Interop/Cxx/class/constructors-copy-irgen.swift
+++ b/test/Interop/Cxx/class/constructors-copy-irgen.swift
@@ -10,6 +10,7 @@ import TypeClassification
 typealias Void = ()
 struct UnsafePointer<T> { }
 struct UnsafeMutablePointer<T> { }
+@frozen public struct CInt { var _value: Builtin.Int32 }
 
 // ITANIUM_X64-LABEL: define swiftcc void @"$ss35copyWithUserProvidedCopyConstructorySo03HascdeF0V_ACtACF"
 // ITANIUM_X64-SAME: (%TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG0:%.*]], %TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG1:%.*]], %TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG2:%.*]])

--- a/test/Interop/Cxx/class/constructors-irgen.swift
+++ b/test/Interop/Cxx/class/constructors-irgen.swift
@@ -10,6 +10,7 @@ import TypeClassification
 typealias Void = ()
 struct UnsafePointer<T> { }
 struct UnsafeMutablePointer<T> { }
+@frozen public struct CInt { var _value: Builtin.Int32 }
 
 public func createHasVirtualBase() -> HasVirtualBase {
   // ITANIUM_X64: define swiftcc void @"$ss20createHasVirtualBaseSo0bcD0VyF"(%TSo14HasVirtualBaseV* noalias nocapture sret({{.*}}) %0)
@@ -61,7 +62,7 @@ public func createStructWithSubobjectCopyConstructorAndValue() {
   // ITANIUM_X64: [[OBJ_MEMBER:%.*]] = getelementptr inbounds %TSo42StructWithSubobjectCopyConstructorAndValueV, %TSo42StructWithSubobjectCopyConstructorAndValueV* [[OBJ]], i32 0, i32 0
   // ITANIUM_X64: call %TSo33StructWithCopyConstructorAndValueV* @"$sSo33StructWithCopyConstructorAndValueVWOb"(%TSo33StructWithCopyConstructorAndValueV* [[TMP]], %TSo33StructWithCopyConstructorAndValueV* [[OBJ_MEMBER]])
   // ITANIUM_X64: ret void
-  
+
   // ITANIUM_ARM-LABEL: define protected swiftcc void @"$ss48createStructWithSubobjectCopyConstructorAndValueyyF"()
   // ITANIUM_ARM: [[MEMBER:%.*]] = alloca %TSo33StructWithCopyConstructorAndValueV
   // ITANIUM_ARM: [[OBJ:%.*]] = alloca %TSo42StructWithSubobjectCopyConstructorAndValueV
@@ -98,16 +99,16 @@ public func createTemplatedConstructor() {
   // ITANIUM_X64: [[OBJ_AS_STRUCT:%.*]] = bitcast %TSo20TemplatedConstructorV* [[OBJ]] to %struct.TemplatedConstructor*
   // ITANIUM_X64: call void @_ZN20TemplatedConstructorC1I7ArgTypeEET_(%struct.TemplatedConstructor* [[OBJ_AS_STRUCT]], i32 [[IVAL]])
   // ITANIUM_X64: ret void
-  
+
   // ITANIUM_X64-LABEL: define linkonce_odr void @_ZN20TemplatedConstructorC1I7ArgTypeEET_(%struct.TemplatedConstructor* nonnull dereferenceable(4) {{.*}}, i32 {{.*}})
-  
+
   // ITANIUM_ARM-LABEL: define protected swiftcc void @"$ss26createTemplatedConstructoryyF"()
   // ITANIUM_ARM: [[OBJ:%.*]] = alloca %TSo20TemplatedConstructorV
   // ITANIUM_ARM: [[IVAL:%.*]] = load [1 x i32], [1 x i32]*
   // ITANIUM_ARM: [[OBJ_AS_STRUCT:%.*]] = bitcast %TSo20TemplatedConstructorV* [[OBJ]] to %struct.TemplatedConstructor*
   // ITANIUM_ARM:  call %struct.TemplatedConstructor* @_ZN20TemplatedConstructorC2I7ArgTypeEET_(%struct.TemplatedConstructor* [[OBJ_AS_STRUCT]], [1 x i32] [[IVAL]])
   // ITANIUM_ARM: ret void
-  
+
   // ITANIUM_ARM-LABEL: define linkonce_odr %struct.TemplatedConstructor* @_ZN20TemplatedConstructorC2I7ArgTypeEET_(%struct.TemplatedConstructor* nonnull returned dereferenceable(4) {{.*}}, [1 x i32] {{.*}})
 
   // MICROSOFT_X64-LABEL: define dllexport swiftcc void @"$ss26createTemplatedConstructoryyF"()
@@ -116,7 +117,7 @@ public func createTemplatedConstructor() {
   // MICROSOFT_X64: [[OBJ_AS_STRUCT:%.*]] = bitcast %TSo20TemplatedConstructorV* [[OBJ]] to %struct.TemplatedConstructor*
   // MICROSOFT_X64: call %struct.TemplatedConstructor* @"??$?0UArgType@@@TemplatedConstructor@@QEAA@UArgType@@@Z"(%struct.TemplatedConstructor* [[OBJ_AS_STRUCT]], i32 [[IVAL]])
   // MICROSOFT_X64: ret void
-  
+
   // MICROSOFT_X64-LABEL: define linkonce_odr dso_local %struct.TemplatedConstructor* @"??$?0UArgType@@@TemplatedConstructor@@QEAA@UArgType@@@Z"(%struct.TemplatedConstructor* nonnull returned dereferenceable(4) {{.*}}, i32 {{.*}})
   let templated = TemplatedConstructor(ArgType())
 }

--- a/test/Interop/Cxx/class/constructors-objc-module-interface.swift
+++ b/test/Interop/Cxx/class/constructors-objc-module-interface.swift
@@ -6,5 +6,5 @@
 // REQUIRES: objc_interop
 
 // CHECK:      struct ConstructorWithNSArrayParam {
-// CHECK-NEXT:   init(_ array: [Any]!)
+// CHECK-NEXT:   init(_ array: [Any]?)
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/linked-records-module-interface.swift
+++ b/test/Interop/Cxx/class/linked-records-module-interface.swift
@@ -16,7 +16,7 @@
 // CHECK:   }
 // CHECK:   struct E {
 // CHECK:     init()
-// CHECK:     static func test(_: UnsafePointer<Space.C>!)
+// CHECK:     static func test(_: UnsafePointer<Space.C>?)
 // CHECK:   }
 // CHECK: }
 

--- a/test/Interop/Cxx/reference/reference-module-interface.swift
+++ b/test/Interop/Cxx/reference/reference-module-interface.swift
@@ -13,4 +13,5 @@
 // CHECK: func getFuncRef() -> @convention(c) () -> Int32
 // CHECK: func getFuncRvalueRef() -> @convention(c) () -> Int32
 
-// CHECK-NOT: dontImportAtomicRef
+// TODO(SR-XXXX): Never will be replaced with a type named something like "FailedImport".
+// CHECK: func dontImportAtomicRef(_: Never)


### PR DESCRIPTION
If we fail to import a type, it's too late to not import the decl (because someone has already started using it) so we use the `Never` type. In the future this will be changed to a `FailImport` type (or something similar). We could potentially create some diagnostics around that as well. 