### PR TITLE
[cxx-interop] Lazily load the result of imported functions.

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -238,6 +238,9 @@ public:
                                  SubstitutionMap subst) = 0;
 
   virtual bool isCXXMethodMutating(const clang::CXXMethodDecl *method) = 0;
+
+  virtual Type importFunctionReturnType(const clang::FunctionDecl *clangDecl,
+                                        DeclContext *dc) = 0;
 };
 
 /// Describes a C++ template instantiation error.

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -458,6 +458,9 @@ public:
   DeclName importName(const clang::NamedDecl *D,
                       clang::DeclarationName givenName);
 
+  Type importFunctionReturnType(const clang::FunctionDecl *clangDecl,
+                                DeclContext *dc) override;
+
   Optional<std::string>
   getOrCreatePCH(const ClangImporterOptions &ImporterOptions,
                  StringRef SwiftPCHHash);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7773,7 +7773,7 @@ FuncDecl *FuncDecl::createImported(ASTContext &Context, SourceLoc FuncLoc,
                                    Type FnRetType,
                                    GenericParamList *GenericParams,
                                    DeclContext *Parent, ClangNode ClangN) {
-  assert(ClangN && FnRetType);
+  assert(ClangN);
   auto *const FD = FuncDecl::createImpl(
       Context, SourceLoc(), StaticSpellingKind::None, FuncLoc, Name, NameLoc,
       Async, SourceLoc(), Throws, SourceLoc(), GenericParams, Parent, ClangN);

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4234,6 +4234,19 @@ importName(const clang::NamedDecl *D,
     getDeclName();
 }
 
+Type ClangImporter::importFunctionReturnType(
+    const clang::FunctionDecl *clangDecl, DeclContext *dc) {
+  bool isInSystemModule =
+      cast<ClangModuleUnit>(dc->getModuleScopeContext())->isSystemModule();
+  bool allowNSUIntegerAsInt =
+      Impl.shouldAllowNSUIntegerAsInt(isInSystemModule, clangDecl);
+  if (auto imported =
+          Impl.importFunctionReturnType(dc, clangDecl, allowNSUIntegerAsInt)
+              .getType())
+    return imported;
+  return dc->getASTContext().getNeverType();
+}
+
 bool ClangImporter::isInOverlayModuleForImportedModule(
                                                const DeclContext *overlayDC,
                                                const DeclContext *importedDC) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4162,8 +4162,9 @@ namespace {
         if (!bodyParams)
           return nullptr;
 
-        importedType =
-            Impl.importFunctionReturnType(dc, decl, allowNSUIntegerAsInt);
+        if (decl->getReturnType()->isScalarType())
+          importedType =
+              Impl.importFunctionReturnType(dc, decl, allowNSUIntegerAsInt);
       } else {
         // Import the function type. If we have parameters, make sure their
         // names get into the resulting function type.
@@ -4199,7 +4200,7 @@ namespace {
         name = DeclName(Impl.SwiftContext, name.getBaseName(), bodyParams);
       }
 
-      if (!importedType)
+      if (!bodyParams)
         return nullptr;
 
       auto loc = Impl.importSourceLoc(decl->getLocation());

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2015,6 +2015,13 @@ ResultTypeRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
     resultTyRepr = cast<SubscriptDecl>(decl)->getElementTypeRepr();
   }
 
+  if (!resultTyRepr && decl->getClangDecl() &&
+      isa<clang::FunctionDecl>(decl->getClangDecl())) {
+    auto clangFn = cast<clang::FunctionDecl>(decl->getClangDecl());
+    return ctx.getClangModuleLoader()->importFunctionReturnType(
+        clangFn, decl->getDeclContext());
+  }
+
   // Nothing to do if there's no result type.
   if (resultTyRepr == nullptr)
     return TupleType::getEmpty(ctx);


### PR DESCRIPTION
Note: we only lazily load the result if it's a record, because otherwise it's trivial to load when importing the function. Also, we still eagerly import operator's results types.

Same as the other two patches wrt using `Never` if the type fails to import. 