### PR TITLE
[Gardening] Correcting var usage in stdlib

### DIFF
--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2448,7 +2448,6 @@ public func _swift_getKeyPath(pattern: UnsafeMutableRawPointer,
   // These are resolved dynamically, so that they always reflect the dynamic
   // capability of the properties involved.
 
-  let oncePtrPtr = pattern
   let patternPtr = pattern.advanced(by: 4)
 
   let bufferHeader = patternPtr.load(fromByteOffset: keyPathPatternHeaderSize,
@@ -2457,10 +2456,10 @@ public func _swift_getKeyPath(pattern: UnsafeMutableRawPointer,
 
   // If the first word is nonzero, it relative-references a cache variable
   // we can use to reference a single shared instantiation of this key path.
-  let oncePtrOffset = oncePtrPtr.load(as: Int32.self)
+  let oncePtrOffset = pattern.load(as: Int32.self)
   let oncePtr: UnsafeRawPointer?
   if oncePtrOffset != 0 {
-    let theOncePtr = _resolveRelativeAddress(oncePtrPtr, oncePtrOffset)
+    let theOncePtr = _resolveRelativeAddress(pattern, oncePtrOffset)
     oncePtr = theOncePtr
 
     // See whether we already instantiated this key path.
@@ -3631,7 +3630,7 @@ internal func _instantiateKeyPathBuffer(
   _ arguments: UnsafeRawPointer
 ) {
   let destHeaderPtr = origDestData.baseAddress.unsafelyUnwrapped
-  var destData = UnsafeMutableRawBufferPointer(
+  let destData = UnsafeMutableRawBufferPointer(
     start: destHeaderPtr.advanced(by: MemoryLayout<Int>.size),
     count: origDestData.count - MemoryLayout<Int>.size)
 

--- a/stdlib/public/core/StringNormalization.swift
+++ b/stdlib/public/core/StringNormalization.swift
@@ -217,10 +217,9 @@ private func fastFill(
   // TODO: Additional fast-path: All CCC-ascending NFC_QC segments are NFC
   // TODO: Just freakin do normalization and don't bother with ICU
   var outputCount = 0
-  let outputEnd = outputBufferThreshold
   var inputCount = 0
   let inputEnd = sourceBuffer.count
-  while inputCount < inputEnd && outputCount < outputEnd {
+  while inputCount < inputEnd && outputCount < outputBufferThreshold {
     // TODO: Slightly faster code-unit scan for latiny (<0xCC)
 
     // Check scalar-based fast-paths
@@ -318,10 +317,9 @@ internal func _allocateBuffers(
   icuOutputBuffer: inout UnsafeMutableBufferPointer<UInt16>
 ) {
   let output = count * _Normalization._maxNFCExpansionFactor * _Normalization._maxUTF16toUTF8ExpansionFactor
-  let icuInput = count
   let icuOutput = count * _Normalization._maxNFCExpansionFactor
   let newOutputBuffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: output)
-  let newICUInputBuffer = UnsafeMutableBufferPointer<UInt16>.allocate(capacity: icuInput)
+  let newICUInputBuffer = UnsafeMutableBufferPointer<UInt16>.allocate(capacity: count)
   let newICUOutputBuffer = UnsafeMutableBufferPointer<UInt16>.allocate(capacity: icuOutput)
   
   switch bufferToCopy {

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -572,7 +572,6 @@ extension String.UTF16View {
       _internalInvariant(readIdx < readEnd)
 
       var utf16I = 0
-      let utf16End: Int = remaining
 
       // Adjust for sub-scalar initial transcoding: If we're starting the scan
       // at a trailing surrogate, then we set our starting count to be -1 so as
@@ -586,9 +585,9 @@ extension String.UTF16View {
         let utf16Len = len == 4 ? 2 : 1
         utf16I &+= utf16Len
 
-        if utf16I >= utf16End {
+        if utf16I >= remaining {
           // Uncommon: final sub-scalar transcoded offset
-          if _slowPath(utf16I > utf16End) {
+          if _slowPath(utf16I > remaining) {
             _internalInvariant(utf16Len == 2)
             return Index(encodedOffset: readIdx, transcodedOffset: 1)
           }

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -499,7 +499,7 @@ final internal class __VaListBuilder {
     }
 #endif
 
-    var encoded = arg._cVarArgEncoding
+    let encoded = arg._cVarArgEncoding
 
 #if arch(x86_64) || arch(arm64)
     let isDouble = arg is _CVarArgPassedAsDouble


### PR DESCRIPTION
With [this PR](https://github.com/apple/swift/pull/36134) replacing the current `VarDeclUsageChecker`, it catches some var usages in the standard library that can be more strict. Splitting these out into a separate PR because it can be cleaned up without merging #36134.
