### PR TITLE
Do not build Swift interface files into binary modules when performing a `canImport` query.

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -139,7 +139,8 @@ class ExplicitSwiftModuleLoader: public SerializedModuleLoaderBase {
                   std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
                   std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
                   std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
-                  bool &isFramework, bool &isSystemModule) override;
+                  bool skipBuildingInterface, bool &isFramework,
+                  bool &isSystemModule) override;
 
   std::error_code findModuleFilesInDirectory(
                   ImportPath::Element ModuleID,
@@ -148,7 +149,7 @@ class ExplicitSwiftModuleLoader: public SerializedModuleLoaderBase {
                   std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
                   std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
                   std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-                  bool IsFramework) override;
+                  bool skipBuildingInterface, bool IsFramework) override;
 
   bool canImportModule(ImportPath::Element mID, llvm::VersionTuple version,
                        bool underlyingVersion) override;
@@ -400,7 +401,7 @@ class ModuleInterfaceLoader : public SerializedModuleLoaderBase {
      std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
      std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
      std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-     bool IsFramework) override;
+     bool skipBuildingInterface, bool IsFramework) override;
 
   bool isCached(StringRef DepPath) override;
 public:

--- a/include/swift/Serialization/ModuleDependencyScanner.h
+++ b/include/swift/Serialization/ModuleDependencyScanner.h
@@ -55,7 +55,7 @@ namespace swift {
           std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
           std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
           std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-          bool IsFramework) override;
+          bool skipBuildingInterface, bool IsFramework) override;
 
       virtual void collectVisibleTopLevelModuleNames(
           SmallVectorImpl<Identifier> &names) const override {
@@ -117,7 +117,7 @@ namespace swift {
           std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
           std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
           std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-                                                 bool IsFramework) override;
+          bool skipBuildingInterface, bool IsFramework) override;
 
       static bool classof(const ModuleDependencyScanner *MDS) {
         return MDS->getKind() == MDS_placeholder;

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -77,7 +77,7 @@ protected:
                           std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
                           std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
                           std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
-                          bool &isFramework, bool &isSystemModule);
+                          bool skipBuildingInterface, bool &isFramework, bool &isSystemModule);
 
   /// Attempts to search the provided directory for a loadable serialized
   /// .swiftmodule with the provided `ModuleFilename`. Subclasses must
@@ -98,7 +98,7 @@ protected:
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-      bool IsFramework) = 0;
+      bool skipBuildingInterface, bool IsFramework) = 0;
 
   std::error_code
   openModuleFile(
@@ -220,7 +220,7 @@ class ImplicitSerializedModuleLoader : public SerializedModuleLoaderBase {
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-      bool IsFramework) override;
+      bool skipBuildingInterface, bool IsFramework) override;
 
   bool maybeDiagnoseTargetMismatch(
       SourceLoc sourceLocation,
@@ -272,7 +272,7 @@ class MemoryBufferSerializedModuleLoader : public SerializedModuleLoaderBase {
       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
       std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-      bool IsFramework) override;
+      bool skipBuildingInterface, bool IsFramework) override;
 
   bool maybeDiagnoseTargetMismatch(
       SourceLoc sourceLocation,

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -32,7 +32,7 @@ std::error_code ModuleDependencyScanner::findModuleFilesInDirectory(
                                       std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
                                       std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
                                       std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-                                      bool IsFramework) {
+                                      bool skipBuildingInterface, bool IsFramework) {
   using namespace llvm::sys;
 
   auto &fs = *Ctx.SourceMgr.getFileSystem();
@@ -77,7 +77,7 @@ std::error_code PlaceholderSwiftModuleScanner::findModuleFilesInDirectory(
     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-    bool IsFramework) {
+    bool skipBuildingInterface, bool IsFramework) {
   StringRef moduleName = ModuleID.Item.str();
   auto it = PlaceholderDependencyModuleMap.find(moduleName);
   // If no placeholder module stub path is given matches the name, return with an

--- a/test/ScanDependencies/Inputs/Swift/Foo.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/Foo.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Foo
+import Swift
+

--- a/test/ScanDependencies/can_import_no_build.swift
+++ b/test/ScanDependencies/can_import_no_build.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -c -primary-file %s -Rmodule-interface-rebuild -I %S/Inputs/Swift/
+
+#if canImport(Foo)
+print("Can indeed import Foo!")
+#else
+print("Cannot import Foo!")
+#endif
+
+// CHECK-NOT: rebuilding module 'Foo' from interface

--- a/unittests/FrontendTool/ModuleLoadingTests.cpp
+++ b/unittests/FrontendTool/ModuleLoadingTests.cpp
@@ -128,7 +128,8 @@ protected:
       loader->findModuleFilesInDirectory({moduleName, SourceLoc()},
         SerializedModuleBaseName(tempDir, SerializedModuleBaseName("Library")),
         /*ModuleInterfacePath*/nullptr,
-        &moduleBuffer, &moduleDocBuffer, &moduleSourceInfoBuffer, /*IsFramework*/false);
+        &moduleBuffer, &moduleDocBuffer, &moduleSourceInfoBuffer,
+        /*skipBuildingInterface*/ false, /*IsFramework*/false);
     ASSERT_FALSE(error);
     ASSERT_FALSE(diags.hadAnyError());
 


### PR DESCRIPTION
We should hold off actually building the binary module file until it is imported.
`canImport` queries can happen, for example, during dependency scanning, when we do not wish to have the scanner tool execute any module builds.

Resolves rdar://82603098