### PR TITLE
[frontend] Support passing the optimization record file via the supplemental outputs map

### DIFF
--- a/include/swift/Basic/SupplementaryOutputPaths.h
+++ b/include/swift/Basic/SupplementaryOutputPaths.h
@@ -146,6 +146,12 @@ struct SupplementaryOutputPaths {
   /// The output path to generate ABI baseline.
   std::string ABIDescriptorOutputPath;
 
+  /// The output path for YAML optimization record file.
+  std::string YAMLOptRecordPath;
+
+  /// The output path for bitstream optimization record file.
+  std::string BitstreamOptRecordPath;
+
   SupplementaryOutputPaths() = default;
   SupplementaryOutputPaths(const SupplementaryOutputPaths &) = default;
 
@@ -179,6 +185,10 @@ struct SupplementaryOutputPaths {
       fn(ModuleSummaryOutputPath);
     if (!ABIDescriptorOutputPath.empty())
       fn(ABIDescriptorOutputPath);
+    if (!YAMLOptRecordPath.empty())
+      fn(YAMLOptRecordPath);
+    if (!BitstreamOptRecordPath.empty())
+      fn(BitstreamOptRecordPath);
   }
 
   bool empty() const {
@@ -187,7 +197,8 @@ struct SupplementaryOutputPaths {
            ReferenceDependenciesFilePath.empty() &&
            SerializedDiagnosticsPath.empty() && LoadedModuleTracePath.empty() &&
            TBDPath.empty() && ModuleInterfaceOutputPath.empty() &&
-           ModuleSourceInfoOutputPath.empty() && ABIDescriptorOutputPath.empty();
+           ModuleSourceInfoOutputPath.empty() && ABIDescriptorOutputPath.empty() &&
+           YAMLOptRecordPath.empty() && BitstreamOptRecordPath.empty();
   }
 };
 } // namespace swift

--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -259,6 +259,8 @@ public:
   bool hasABIDescriptorOutputPath() const;
   bool hasModuleSummaryOutputPath() const;
   bool hasTBDPath() const;
+  bool hasYAMLOptRecordPath() const;
+  bool hasBitstreamOptRecordPath() const;
 
   bool hasDependencyTrackerPath() const;
 };

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -341,11 +341,14 @@ SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
       options::OPT_emit_module_summary_path);
   auto abiDescriptorOutput = getSupplementaryFilenamesFromArguments(
       options::OPT_emit_abi_descriptor_path);
+  auto optRecordOutput = getSupplementaryFilenamesFromArguments(
+      options::OPT_save_optimization_record_path);
   if (!objCHeaderOutput || !moduleOutput || !moduleDocOutput ||
       !dependenciesFile || !referenceDependenciesFile ||
       !serializedDiagnostics || !fixItsOutput || !loadedModuleTrace || !TBD ||
       !moduleInterfaceOutput || !privateModuleInterfaceOutput ||
-      !moduleSourceInfoOutput || !moduleSummaryOutput || !abiDescriptorOutput) {
+      !moduleSourceInfoOutput || !moduleSummaryOutput || !abiDescriptorOutput ||
+      !optRecordOutput) {
     return None;
   }
   std::vector<SupplementaryOutputPaths> result;
@@ -368,6 +371,8 @@ SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
     sop.ModuleSourceInfoOutputPath = (*moduleSourceInfoOutput)[i];
     sop.ModuleSummaryOutputPath = (*moduleSummaryOutput)[i];
     sop.ABIDescriptorOutputPath = (*abiDescriptorOutput)[i];
+    sop.YAMLOptRecordPath = (*optRecordOutput)[i];
+    sop.BitstreamOptRecordPath = (*optRecordOutput)[i];
     result.push_back(sop);
   }
   return result;
@@ -479,6 +484,15 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
       file_types::TY_SwiftModuleFile, mainOutputIfUsableForModule,
       defaultSupplementaryOutputPathExcludingExtension);
 
+  auto YAMLOptRecordPath = determineSupplementaryOutputFilename(
+      OPT_save_optimization_record_path, pathsFromArguments.YAMLOptRecordPath,
+      file_types::TY_YAMLOptRecord, "",
+      defaultSupplementaryOutputPathExcludingExtension);
+  auto bitstreamOptRecordPath = determineSupplementaryOutputFilename(
+      OPT_save_optimization_record_path, pathsFromArguments.BitstreamOptRecordPath,
+      file_types::TY_BitstreamOptRecord, "",
+      defaultSupplementaryOutputPathExcludingExtension);
+
   SupplementaryOutputPaths sop;
   sop.ObjCHeaderOutputPath = objcHeaderOutputPath;
   sop.ModuleOutputPath = moduleOutputPath;
@@ -494,6 +508,8 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
   sop.ModuleSourceInfoOutputPath = moduleSourceInfoOutputPath;
   sop.ModuleSummaryOutputPath = moduleSummaryOutputPath;
   sop.ABIDescriptorOutputPath = ABIDescriptorOutputPath;
+  sop.YAMLOptRecordPath = YAMLOptRecordPath;
+  sop.BitstreamOptRecordPath = bitstreamOptRecordPath;
   return sop;
 }
 
@@ -576,6 +592,8 @@ createFromTypeToPathMap(const TypeToPathMap *map) {
       {file_types::TY_SwiftModuleSummaryFile, paths.ModuleSummaryOutputPath},
       {file_types::TY_PrivateSwiftModuleInterfaceFile,
        paths.PrivateModuleInterfaceOutputPath},
+      {file_types::TY_YAMLOptRecord, paths.YAMLOptRecordPath},
+      {file_types::TY_BitstreamOptRecord, paths.BitstreamOptRecordPath},
   };
   for (const std::pair<file_types::ID, std::string &> &typeAndString :
        typesAndStrings) {

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -521,6 +521,18 @@ bool FrontendInputsAndOutputs::hasTBDPath() const {
         return outs.TBDPath;
       });
 }
+bool FrontendInputsAndOutputs::hasYAMLOptRecordPath() const {
+  return hasSupplementaryOutputPath(
+      [](const SupplementaryOutputPaths &outs) -> const std::string & {
+        return outs.YAMLOptRecordPath;
+      });
+}
+bool FrontendInputsAndOutputs::hasBitstreamOptRecordPath() const {
+  return hasSupplementaryOutputPath(
+      [](const SupplementaryOutputPaths &outs) -> const std::string & {
+        return outs.BitstreamOptRecordPath;
+      });
+}
 
 bool FrontendInputsAndOutputs::hasDependencyTrackerPath() const {
   return hasDependenciesPath() || hasReferenceDependenciesPath() ||

--- a/test/Frontend/opt-record-supplemental.swift
+++ b/test/Frontend/opt-record-supplemental.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: echo '"%s": { yaml-opt-record: "%t/foo.opt.yaml" }' > %t/filemap.yaml.yaml
+// RUN: echo '"%s": { bitstream-opt-record: "%t/foo.opt.bitstream" }' > %t/filemap.bitstream.yaml
+
+// RUN: %target-swift-frontend -c -O -wmo -save-optimization-record=bitstream %s -module-name foo -o %t/foo.o -supplementary-output-file-map %t/filemap.bitstream.yaml
+// RUN: llvm-bcanalyzer -dump "%t/foo.opt.bitstream" | %FileCheck -check-prefix=BITSTREAM %s
+
+// RUN: %target-swift-frontend -c -O -wmo -save-optimization-record=yaml %s -module-name foo -o %t/foo.o -supplementary-output-file-map %t/filemap.yaml.yaml
+// RUN: %FileCheck %s -check-prefix=YAML --input-file=%t/foo.opt.yaml
+
+// REQUIRES: VENDOR=apple
+
+var a: Int = 1
+
+#sourceLocation(file: "custom.swift", line: 2000)
+func foo() {
+  a = 2
+}
+#sourceLocation() // reset
+
+public func bar() {
+  foo()
+  // BITSTREAM: <Remark NumWords=13 BlockCodeSize=4>
+  // BITSTREAM: </Remark>
+
+  // YAML: sil-assembly-vision-remark-gen
+}


### PR DESCRIPTION
The Swift driver is passing the optimization record file path via the supplementals output, instead of the flag, on certain circumstances.
Enhance the frontend to check supplemental outputs otherwise the record file will not get emitted when using the new swift driver.