### PR TITLE
[ConstraintSystem] Fix incorrect type-check of IUO pattern bindings

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1735,9 +1735,9 @@ public:
   }
 
   static SolutionApplicationTarget
-  forUninitializedVar(PatternBindingDecl *binding, unsigned index, Pattern *var,
+  forUninitializedVar(PatternBindingDecl *binding, unsigned index,
                       Type patternTy) {
-    return {binding, index, var, patternTy};
+    return {binding, index, binding->getPattern(index), patternTy};
   }
 
   /// Form a target for a synthesized property wrapper initializer.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3950,7 +3950,7 @@ bool ConstraintSystem::generateConstraints(
                                init, dc, patternType, patternBinding, index,
                                /*bindPatternVarsOneWay=*/true)
                          : SolutionApplicationTarget::forUninitializedVar(
-                               patternBinding, index, pattern, patternType);
+                               patternBinding, index, patternType);
 
       if (generateConstraints(target, FreeTypeVariableBinding::Disallow)) {
         hadError = true;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3926,10 +3926,13 @@ bool ConstraintSystem::generateConstraints(
       if (!pattern)
         return true;
 
-      // Type check the pattern. Note use of `forRawPattern` here instead
-      // of `forPatternBindingDecl` because resolved `pattern` is not
-      // associated with `patternBinding`.
-      auto contextualPattern = ContextualPattern::forRawPattern(pattern, dc);
+      // Reset binding to point to the resolved pattern. This is required
+      // before calling `forPatternBindingDecl`.
+      patternBinding->setPattern(index, pattern,
+                                 patternBinding->getInitContext(index));
+
+      auto contextualPattern =
+          ContextualPattern::forPatternBindingDecl(patternBinding, index);
       Type patternType = TypeChecker::typeCheckPattern(contextualPattern);
 
       // Fail early if pattern couldn't be type-checked.
@@ -3944,7 +3947,7 @@ bool ConstraintSystem::generateConstraints(
 
       auto init = patternBinding->getInit(index);
       auto target = init ? SolutionApplicationTarget::forInitialization(
-                               init, dc, patternType, pattern,
+                               init, dc, patternType, patternBinding, index,
                                /*bindPatternVarsOneWay=*/true)
                          : SolutionApplicationTarget::forUninitializedVar(
                                patternBinding, index, pattern, patternType);

--- a/validation-test/Sema/type_checker_crashers_fixed/sr14893.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/sr14893.swift
@@ -23,7 +23,7 @@ struct Image : View {
 
 struct MyView {
   @ViewBuilder var body: some View {
-    let icon: Category! = Category.first // expected-error {{using '!' is not allowed here; perhaps '?' was intended?}} {{23-24=?}}
+    let icon: Category! = Category.first // Ok
     Image().test(icon)
   }
 }


### PR DESCRIPTION
Patterns associated with `PatternBindingDecl`s have to be type-checked
in pattern binding context. Not doing so might result in spurious errors.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
