### PR TITLE
Allow a Swift 5.5 compiler to process the new _Concurrency module.

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -370,6 +370,13 @@ static void SaveModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
     interleave(RenderedArgs,
                [&](const char *Argument) { PrintArg(OS, Argument, StringRef()); },
                [&] { OS << " "; });
+
+    // Backward-compatibility hack: disable availability checking in the
+    // _Concurrency module, so that older (Swift 5.5) compilers that did not
+    // support back deployment of concurrency do not complain about 'async'
+    // with older availability.
+    if (FOpts.ModuleName == "_Concurrency")
+      OS << " -disable-availability-checking";
   }
   {
     llvm::raw_string_ostream OS(Opts.IgnorableFlags);

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -824,7 +824,14 @@ func _getCurrentThreadPriority() -> Int
 @_alwaysEmitIntoClient
 @usableFromInline
 internal func _runTaskForBridgedAsyncMethod(@_inheritActorContext _ body: __owned @Sendable @escaping () async -> Void) {
+#if compiler(>=5.6)
   Task(operation: body)
+#else
+  Task<Int, Error> {
+    await body()
+    return 0
+  }
+#endif
 }
 
 #endif


### PR DESCRIPTION
Introduce two hacks^H^H^H^Hworkarounds that allow a Swift 5.5 compiler to process the new `_Concurrency` module interface file:
* An `#if` check to dodge Swift 5.5's inability to make `Void` conform to `Sendable`
* Disable availability checking in the `.swiftinterface` of `_Concurrency`, to avoid problems with the back-deployed `async` functions and actors

Fixes rdar://82602353