### PR TITLE
[ConstraintSystem] Fix a misleading argument mismatch error when using wrapped parameters.

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4329,6 +4329,19 @@ public:
       llvm::function_ref<ConstraintFix *(unsigned, const OverloadChoice &)>
           getFix = [](unsigned, const OverloadChoice &) { return nullptr; });
 
+  /// Generate constraints for the given property that has an
+  /// attached property wrapper.
+  ///
+  /// \param wrappedVar The property that has a property wrapper.
+  /// \param initializerType The type of the initializer for the
+  ///        backing storage variable.
+  /// \param propertyType The type of the wrapped property.
+  ///
+  /// \returns true if there is an error.
+  bool generateWrappedPropertyTypeConstraints(VarDecl *wrappedVar,
+                                              Type initializerType,
+                                              Type propertyType);
+
   /// Propagate constraints in an effort to enforce local
   /// consistency to reduce the time to solve the system.
   ///

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4150,7 +4150,8 @@ ConstraintSystem::applyPropertyWrapperToParameter(
 
     initKind = PropertyWrapperInitKind::ProjectedValue;
   } else {
-    generateWrappedPropertyTypeConstraints(param, wrapperType, paramType);
+    Type wrappedValueType = computeWrappedValueType(param, wrapperType);
+    addConstraint(matchKind, paramType, wrappedValueType, locator);
     initKind = PropertyWrapperInitKind::WrappedValue;
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8897,6 +8897,11 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
         setType(projection, computeProjectedValueType(paramDecl, backingType));
       }
 
+      if (!paramDecl->getName().hasDollarPrefix()) {
+        generateWrappedPropertyTypeConstraints(paramDecl, backingType,
+                                               param.getParameterType());
+      }
+
       auto result = applyPropertyWrapperToParameter(backingType, param.getParameterType(),
                                                     paramDecl, paramDecl->getName(),
                                                     ConstraintKind::Equal,

--- a/test/Sema/property_wrapper_parameter_invalid.swift
+++ b/test/Sema/property_wrapper_parameter_invalid.swift
@@ -86,7 +86,7 @@ struct S {
   subscript(@Wrapper position: Int) -> Int { 0 }
 }
 
-func testInvalidArgLabel() {
+func testInvalidArgLabel(projection: Projection<Int>) {
   // expected-note@+1 2 {{parameter 'argLabel' does not have an attached property wrapper}}
   func noWrappers(argLabel: Int) {}
 
@@ -95,6 +95,11 @@ func testInvalidArgLabel() {
 
   // expected-error@+1 {{cannot use property wrapper projection argument}}
   noWrappers($argLabel: 10)
+
+  func takesWrapper(@Wrapper argLabel: Int) {}
+
+  // expected-error@+1 {{cannot convert value of type 'Projection<Int>' to expected argument type 'Int'}}
+  takesWrapper(argLabel: projection)
 }
 
 protocol P {


### PR DESCRIPTION
When calling a function with a wrapped parameter, the solver will produce a misleading error message if the argument type isn't convertible to the parameter type:

```swift
import SwiftUI

func messageView(@Binding message: String) -> some View { // error: Property type 'Binding<String>' does not match 'wrappedValue' type 'String'
  EmptyView()
}

struct S {
  @Binding var message: String

  func test() {
    messageView(message: $message) // the actual error is that Binding<String> was passed here
  }
}
```

This happens because when type checking the function call, the solver will generate constraints for the property wrapper attribute chain, which will equate each wrapped-value type of a wrapper attribute with the next property wrapper attribute type (or the property type itself, if it's the innermost wrapper attribute).

For regular function parameters, these constraints were already generated and solved for when type checking the parameter declaration anyway, and they don't need to be repeated for function calls. This only needs to be done for closure parameters, so the fix is to only call `generateWrappedPropertyTypeConstraints` when resolving closures.

Resolves: [SR-15030](https://bugs.swift.org/browse/SR-15030)