### PR TITLE
[swift-refactor] When testing always specify a resource-dir

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -348,12 +348,12 @@ config.link = lit.util.which('link', config.environment.get('PATH', '')) or     
 
 # Find the resource directory.  Assume it's near the swift compiler if not set.
 test_resource_dir = lit_config.params.get('test_resource_dir')
+config.resource_dir_opt = ""
 if test_resource_dir:
-    resource_dir_opt = ("-resource-dir %s" % test_resource_dir)
+   config.resource_dir_opt = ("-resource-dir %s" % test_resource_dir)
 else:
     test_resource_dir = make_path(config.swift_lib_dir, 'swift')
-    resource_dir_opt = ""
-stdlib_resource_dir_opt = resource_dir_opt
+stdlib_resource_dir_opt = config.resource_dir_opt
 sourcekitd_framework_dir = config.swift_lib_dir
 config.substitutions.append( ('%test-resource-dir', test_resource_dir) )
 lit_config.note('Using resource dir: ' + test_resource_dir)
@@ -396,7 +396,7 @@ if test_sdk_overlay_dir is not None:
         "-L %s -Xlinker -rpath -Xlinker %s" %
         (sdk_overlay_link_path_dir, sdk_overlay_link_path_dir))
     lit_config.note('Using SDK overlay dir: ' + test_sdk_overlay_dir)
-    resource_dir_opt += (" %s" % sdk_overlay_dir_opt)
+    config.resource_dir_opt += (" %s" % sdk_overlay_dir_opt)
 
 # Default to Swift 4 for now.
 # Note that this accepts both `--param swift-version` (like the compiler flag)
@@ -931,7 +931,7 @@ if run_vendor == 'apple':
         symlink_if_not_exists("clang", "clang")
         symlink_if_not_exists("shims", "shims")
         symlink_if_not_exists("freestanding", "macosx")
-        resource_dir_opt = "-resource-dir %s" % new_resource_dir
+        config.resource_dir_opt = "-resource-dir %s" % new_resource_dir
         lit_config.note('Using freestanding resource dir: ' + new_resource_dir)
 
     xcrun_prefix = (
@@ -941,7 +941,7 @@ if run_vendor == 'apple':
                                      "Developer", "Library", "Frameworks")
     target_options = (
         "-target %s %s %s" %
-        (config.variant_triple, resource_dir_opt, mcp_opt))
+        (config.variant_triple, config.resource_dir_opt, mcp_opt))
     target_options_for_mock_sdk = (
         "-target %s %s %s" %
         (config.variant_triple, stdlib_resource_dir_opt, mcp_opt))
@@ -1217,7 +1217,7 @@ elif run_os in ['windows-msvc']:
 
     config.target_build_swift =                                                  \
             ('%r -target %s %s %s %s %s -libc %s' %                              \
-                    (config.swiftc, config.variant_triple, resource_dir_opt,     \
+                    (config.swiftc, config.variant_triple, config.resource_dir_opt,     \
                      config.swift_test_options, config.swift_driver_test_options,\
                      swift_execution_tests_extra_flags,                          \
                      config.swift_stdlib_msvc_runtime))
@@ -1227,7 +1227,7 @@ elif run_os in ['windows-msvc']:
     config.target_swift_frontend =                                               \
             ('%r -target %s %s %s %s %s' % (config.swift_frontend,             \
                                                       config.variant_triple,     \
-                                                      resource_dir_opt, mcp_opt, \
+                                                      config.resource_dir_opt, mcp_opt, \
                                                       config.swift_test_options, \
                                                       config.swift_frontend_test_options))
 
@@ -1249,7 +1249,7 @@ elif run_os in ['windows-msvc']:
                                                            config.target_sdk_name)))
     config.target_sil_opt =                                                      \
             ('%r -target %s %s %s %s' % (config.sil_opt, config.variant_triple,  \
-                                         resource_dir_opt, mcp_opt,              \
+                                         config.resource_dir_opt, mcp_opt,              \
                                          config.sil_test_options))
     subst_target_sil_opt_mock_sdk = config.target_sil_opt
     subst_target_sil_opt_mock_sdk_after = ''
@@ -1264,14 +1264,14 @@ elif run_os in ['windows-msvc']:
     config.target_swift_ide_test =                                               \
             ('%r -target %s %s %s %s' % (config.swift_ide_test,                  \
                                          config.variant_triple,                  \
-                                         resource_dir_opt, mcp_opt, ccp_opt))
+                                         config.resource_dir_opt, mcp_opt, ccp_opt))
 
     subst_target_swift_ide_test_mock_sdk = config.target_swift_ide_test
     subst_target_swift_ide_test_mock_sdk_after = ''
 
     config.target_swiftc_driver =                                                \
             ('%r -target %s %s %s %s' % (config.swiftc, config.variant_triple,   \
-                                      resource_dir_opt, mcp_opt,                 \
+                                      config.resource_dir_opt, mcp_opt,                 \
                                       config.swift_driver_test_options))
     config.target_swift_modulewrap =                                             \
             ('%r -modulewrap -target %s' % (config.swiftc, config.variant_triple))
@@ -1365,7 +1365,7 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
 
     config.target_build_swift = (
         '%s -target %s -toolchain-stdlib-rpath %s %s %s %s %s'
-        % (config.swiftc, config.variant_triple, resource_dir_opt, mcp_opt,
+        % (config.swiftc, config.variant_triple, config.resource_dir_opt, mcp_opt,
            config.swift_test_options, config.swift_driver_test_options,
            swift_execution_tests_extra_flags))
     config.target_codesign = "echo"
@@ -1375,7 +1375,7 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
     config.target_add_rpath = r'-Xlinker -rpath -Xlinker \1'
     config.target_swift_frontend = (
         '%s -target %s %s %s %s %s '
-        % (config.swift_frontend, config.variant_triple, resource_dir_opt, mcp_opt,
+        % (config.swift_frontend, config.variant_triple, config.resource_dir_opt, mcp_opt,
         config.swift_test_options, config.swift_frontend_test_options))
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
@@ -1384,7 +1384,7 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
         use_interpreter_for_simple_runs()
     config.target_sil_opt = (
         '%s -target %s %s %s %s' %
-        (config.sil_opt, config.variant_triple, resource_dir_opt, mcp_opt, config.sil_test_options))
+        (config.sil_opt, config.variant_triple, config.resource_dir_opt, mcp_opt, config.sil_test_options))
     subst_target_sil_opt_mock_sdk = config.target_sil_opt
     subst_target_sil_opt_mock_sdk_after = ""
     config.target_swift_symbolgraph_extract = (
@@ -1395,13 +1395,13 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
         (config.swift_api_extract, config.variant_triple, config.variant_sdk))
     config.target_swift_ide_test = (
         '%s -target %s %s %s %s' %
-        (config.swift_ide_test, config.variant_triple, resource_dir_opt,
+        (config.swift_ide_test, config.variant_triple, config.resource_dir_opt,
          mcp_opt, ccp_opt))
     subst_target_swift_ide_test_mock_sdk = config.target_swift_ide_test
     subst_target_swift_ide_test_mock_sdk_after = ""
     config.target_swiftc_driver = (
         "%s -target %s -toolchain-stdlib-rpath %s %s %s" %
-        (config.swiftc, config.variant_triple, resource_dir_opt, mcp_opt, config.swift_driver_test_options))
+        (config.swiftc, config.variant_triple, config.resource_dir_opt, mcp_opt, config.swift_driver_test_options))
     config.target_swift_modulewrap = (
         '%s -modulewrap -target %s' %
         (config.swiftc, config.variant_triple))
@@ -1463,7 +1463,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         shell_quote(make_path(
             toolchain_directory, "lib", "gcc", ndk_platform_triple,
             "{}.x".format(config.android_ndk_gcc_version))))
-    resource_dir_opt = ("-resource-dir %s" % test_resource_dir)
+    config.resource_dir_opt = ("-resource-dir %s" % test_resource_dir)
     # Since NDK r19, the headers and libraries are available in a unified
     # sysroot at $NDK_PATH/toolchains/llvm/prebuilt/$prebuilt_directory/sysroot,
     # so the -sdk switch can now be used.
@@ -1474,7 +1474,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         '--target={}{}'.format(config.variant_triple, config.android_api_level),
         '-tools-directory', tools_directory,
         android_link_paths_opt, '-use-ld=%s' % config.android_linker_name,
-        resource_dir_opt, mcp_opt, config.swift_test_options,
+        config.resource_dir_opt, mcp_opt, config.swift_test_options,
         config.swift_driver_test_options, swift_execution_tests_extra_flags])
     config.target_codesign = "echo"
     config.target_build_swift_dylib = ' '.join([
@@ -1485,7 +1485,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
     config.target_swift_frontend = ' '.join([
         config.swift_frontend,
         '-target', config.variant_triple,
-        '-sdk', config.variant_sdk, android_link_paths_opt, resource_dir_opt,
+        '-sdk', config.variant_sdk, android_link_paths_opt, config.resource_dir_opt,
         mcp_opt, config.swift_test_options, config.swift_frontend_test_options])
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
@@ -1496,7 +1496,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         'env', 'SDKROOT={}'.format(shell_quote(config.variant_sdk)),
         config.sil_opt,
         '-target', config.variant_triple,
-        resource_dir_opt, mcp_opt, config.sil_test_options])
+        config.resource_dir_opt, mcp_opt, config.sil_test_options])
     subst_target_sil_opt_mock_sdk = config.target_sil_opt
     subst_target_sil_opt_mock_sdk_after = ""
     config.target_swift_symbolgraph_extract = ' '.join([
@@ -1510,7 +1510,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
     config.target_swift_ide_test = ' '.join([
         config.swift_ide_test,
         '-target', config.variant_triple,
-        resource_dir_opt, mcp_opt, ccp_opt])
+        config.resource_dir_opt, mcp_opt, ccp_opt])
     subst_target_swift_ide_test_mock_sdk = config.target_swift_ide_test
     subst_target_swift_ide_test_mock_sdk_after = ""
     config.target_swiftc_driver = ' '.join([
@@ -1520,7 +1520,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         '-sdk', config.variant_sdk, '-Xclang-linker',
         '--target={}{}'.format(config.variant_triple, config.android_api_level),
         '-tools-directory', tools_directory,
-        android_link_paths_opt, resource_dir_opt, mcp_opt,
+        android_link_paths_opt, config.resource_dir_opt, mcp_opt,
         '-use-ld=%s' % config.android_linker_name,
         config.swift_driver_test_options])
     config.target_swift_modulewrap = ' '.join([
@@ -1555,7 +1555,7 @@ elif run_os == 'wasi':
         '-target', config.variant_triple,
         '-Xcc', '--sysroot=%s' % config.variant_sdk,
         '-Xclang-linker', '--sysroot=%s' % config.variant_sdk,
-        '-toolchain-stdlib-rpath', resource_dir_opt,
+        '-toolchain-stdlib-rpath', config.resource_dir_opt,
         mcp_opt, config.swift_test_options,
         config.swift_driver_test_options, swift_execution_tests_extra_flags])
     config.target_codesign = "echo"
@@ -1567,7 +1567,7 @@ elif run_os == 'wasi':
         config.swift_frontend,
         '-target', config.variant_triple,
         '-Xcc', '--sysroot=%s' % config.variant_sdk,
-        resource_dir_opt, mcp_opt,
+        config.resource_dir_opt, mcp_opt,
         config.swift_test_options, config.swift_frontend_test_options])
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
@@ -1576,20 +1576,20 @@ elif run_os == 'wasi':
         use_interpreter_for_simple_runs()
     config.target_sil_opt = (
         '%s -target %s %s %s %s' %
-        (config.sil_opt, config.variant_triple, resource_dir_opt, mcp_opt, config.sil_test_options))
+        (config.sil_opt, config.variant_triple, config.resource_dir_opt, mcp_opt, config.sil_test_options))
     config.target_swift_symbolgraph_extract = ' '.join([
         config.swift_symbolgraph_extract,
         '-target', config.variant_triple,
         mcp_opt])
     config.target_swift_ide_test = (
         '%s -target %s %s %s %s' %
-        (config.swift_ide_test, config.variant_triple, resource_dir_opt,
+        (config.swift_ide_test, config.variant_triple, config.resource_dir_opt,
          mcp_opt, ccp_opt))
     subst_target_swift_ide_test_mock_sdk = config.target_swift_ide_test
     subst_target_swift_ide_test_mock_sdk_after = ""
     config.target_swiftc_driver = (
         "%s -target %s -toolchain-stdlib-rpath %s %s" %
-        (config.swiftc, config.variant_triple, resource_dir_opt, mcp_opt))
+        (config.swiftc, config.variant_triple, config.resource_dir_opt, mcp_opt))
     config.target_swift_modulewrap = (
         '%s -modulewrap -target %s' %
         (config.swiftc, config.variant_triple))

--- a/test/refactoring/lit.local.cfg
+++ b/test/refactoring/lit.local.cfg
@@ -2,5 +2,6 @@ if 'OS=macosx' not in config.available_features:
     config.unsupported = True
 
 else:
-    config.substitutions.append(('%refactor-check-compiles', '{} -swift-refactor {} -swift-frontend {} -temp-dir %t'.format(config.refactor_check_compiles, config.swift_refactor, config.swift_frontend)))
-    config.substitutions.append(('%refactor', config.swift_refactor))
+    config.substitutions.append(('%refactor-check-compiles', '{} -swift-refactor {} -swift-frontend {} -temp-dir %t {}'.format(config.refactor_check_compiles, config.swift_refactor, config.swift_frontend, config.resource_dir_opt)))
+    config.substitutions.append(('%refactor', '{} {}'.format(config.swift_refactor,
+        config.resource_dir_opt)))

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -138,6 +138,10 @@ static llvm::cl::list<std::string>
 static llvm::cl::opt<std::string>
 Triple("target", llvm::cl::desc("target triple"));
 
+static llvm::cl::opt<std::string> ResourceDir(
+    "resource-dir",
+    llvm::cl::desc("The directory that holds the compiler resource files"));
+
 enum class DumpType {
   REWRITTEN,
   JSON,
@@ -293,6 +297,9 @@ int main(int argc, char *argv[]) {
   Invocation.setImportSearchPaths(options::ImportPaths);
   if (!options::Triple.empty())
     Invocation.setTargetTriple(options::Triple);
+
+  if (!options::ResourceDir.empty())
+    Invocation.setRuntimeResourcePath(options::ResourceDir);
 
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(
       options::SourceFilename);

--- a/utils/refactor-check-compiles.py
+++ b/utils/refactor-check-compiles.py
@@ -87,6 +87,9 @@ def parse_args():
         '-target',
         help='The target triple to build for'
     )
+    parser.add_argument(
+        '-resource-dir',
+        help='The resource dir where the stdlib is stored')
 
     return parser.parse_known_args()
 
@@ -107,6 +110,8 @@ def main():
         extra_both_args += ['-sdk', args.sdk]
     if args.target:
         extra_both_args += ['-target', args.target]
+    if args.resource_dir:
+        extra_both_args += ['-resource-dir', args.resource_dir]
 
     dump_text_output = run_cmd([
         args.swift_refactor,


### PR DESCRIPTION
Otherwise, swift-refactor always assumes the stdlib is shipped with it. This is not true when doing a stage 2 stdlib build.