### PR TITLE
[test] When using swift-ide-test specify a resource dir.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -476,7 +476,7 @@ config.substitutions.append( ('%lldb-moduleimport-test-with-sdk',
                              '%s -sdk %r' % (config.lldb_moduleimport_test, config.variant_sdk)) )
 config.substitutions.append( ('%swift-dump-pcm', "%r -dump-pcm" % config.swiftc) )
 config.substitutions.append( ('%swift-ide-test_plain', config.swift_ide_test) )
-config.substitutions.append( ('%swift-ide-test', "%r %s %s -swift-version %s" % (config.swift_ide_test, mcp_opt, ccp_opt, swift_version)) )
+config.substitutions.append( ('%swift-ide-test', "%r %s %s -swift-version %s %s" % (config.swift_ide_test, mcp_opt, ccp_opt, swift_version, config.resource_dir_opt)) )
 config.substitutions.append( ('%swift-dependency-tool', config.swift_dependency_tool) )
 config.substitutions.append( ('%swift-syntax-test', config.swift_syntax_test) )
 if 'syntax_parser_lib' in config.available_features:


### PR DESCRIPTION
Otherwise, these tests fail when one runs these tests against a just
built toolchain but have not yet installed a stage2 stdlib.
