### PR TITLE
[test] Make %swift and %target-swift-frontend specify a resource dir.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -499,8 +499,9 @@ config.substitutions.append( ('%swift-path', config.swift) )
 # This must come after all substitutions containing "%swift".
 config.substitutions.append(
     ('%swift',
-     "%r %s -disable-objc-attr-requires-foundation-module %s %s"
-       % (config.swift_frontend, mcp_opt, config.swift_test_options, config.swift_frontend_test_options)) )
+     "%r %s -disable-objc-attr-requires-foundation-module %s %s %s"
+       % (config.swift_frontend, mcp_opt, config.swift_test_options, config.swift_frontend_test_options,
+          config.resource_dir_opt)) )
 
 config.clang_include_dir = make_path(config.swift, '..', '..', 'include')
 config.substitutions.append( ('%clang-include-dir', config.clang_include_dir) )
@@ -2061,8 +2062,9 @@ config.substitutions.append(('%target-swift-frontend\(mock-sdk:([^)]+)\)',
                              SubstituteCaptures(r'%s \1 %s' % (
                                  escape_for_substitute_captures(subst_target_swift_frontend_mock_sdk),
                                  escape_for_substitute_captures(subst_target_swift_frontend_mock_sdk_after)))))
-config.substitutions.append(('%target-swift-frontend', config.target_swift_frontend))
-
+config.substitutions.append(('%target-swift-frontend', '{} {}'.format(config.target_swift_frontend,
+                                                       config.resource_dir_opt)))
+config.substitutions.append(('%target-swift-frontend-plain', config.target_swift_frontend))
 
 config.substitutions.append(('%target-run-simple-swiftgyb\(([^)]+)\)',
                             config.target_run_simple_swiftgyb_parameterized))


### PR DESCRIPTION
I added a %target-swift-frontend-plain for situations where we are actually
testing the resource-dir functionality. Additionally any code that actually
specifies the resource-dir already will override the specified value since
resource-dir I think takes on the last value passed to it.

This is needed for the stage 2 swift stdlib.
