### PR TITLE
[stdlib] Allow RawRepresentable types to customize their hashing without implementing hashValue

### DIFF
--- a/stdlib/public/core/CompilerProtocols.swift
+++ b/stdlib/public/core/CompilerProtocols.swift
@@ -185,7 +185,11 @@ public func != <T: Equatable>(lhs: T, rhs: T) -> Bool
 extension RawRepresentable where RawValue: Hashable, Self: Hashable {
   @inlinable // trivial
   public var hashValue: Int {
-    return rawValue.hashValue
+    // Note: in Swift 5.5 and below, this used to return `rawValue.hashValue`.
+    // The current definition matches the default `hashValue` implementation,
+    // so that RawRepresentable types don't need to implement both `hashValue`
+    // and `hash(into:)` to customize their hashing.
+    _hashValue(for: self)
   }
 
   @inlinable // trivial


### PR DESCRIPTION
Before this change, `RawRepresentable`'s custom `hashValue` implementation used to forward to `rawValue.hashValue`. (See https://github.com/apple/swift/pull/20705.) This sort of made sense at the time (`hash(into:)` was very new and `hashValue` was still in heavy use): it allowed raw representable values to return the exact same hash value as their `rawValue`, which some code used to (mistakenly) rely on. The big drawback of this is that to customize the Hashable implementation of a RawRepresentable type, people need to implement both `hashValue` and `hash(into:)` -- the former does not otherwise pick up customizations to the latter.

This change makes the default `RawRepresentable.hashValue` implementation call `self.hash(into:)`, just like it would on non-RawRepresentable types.

rdar://82651116
