### PR TITLE
[Async Refactoring] Better handle bool flag parameter bindings

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -4982,6 +4982,10 @@ public:
   bool hasBinding(const ParamDecl *Param) const {
     if (!hasParam(Param))
       return false;
+    if (auto BoolFlag = getKnownBoolFlagParam()) {
+      if (Param == BoolFlag->Param)
+        return false;
+    }
     return true;
   }
 

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -7184,10 +7184,9 @@ private:
       AllBindings.append(SuccessBindings.begin(), SuccessBindings.end());
       AllBindings.push_back(ErrParam);
 
-      // Don't do any unwrapping or placeholder replacement since all params
-      // are still valid in the fallback case
       prepareNames(ClassifiedBlock(), AllBindings, InlinePatterns);
-
+      preparePlaceholdersAndUnwraps(HandlerDesc, CallbackParams,
+                                    PlaceholderMode::FALLBACK);
       addFallbackVars(AllBindings, Blocks);
       addDo();
       addAwaitCall(CE, Blocks.SuccessBlock, SuccessBindings, InlinePatterns,
@@ -7243,7 +7242,7 @@ private:
 
     prepareNames(Blocks.SuccessBlock, SuccessBindings, InlinePatterns);
     preparePlaceholdersAndUnwraps(HandlerDesc, CallbackParams,
-                                  /*Success=*/true);
+                                  PlaceholderMode::SUCCESS_BLOCK);
 
     addAwaitCall(CE, Blocks.SuccessBlock, SuccessBindings, InlinePatterns,
                  HandlerDesc, /*AddDeclarations=*/true);
@@ -7260,7 +7259,7 @@ private:
                    ErrInlinePatterns,
                    /*AddIfMissing=*/HandlerDesc.Type != HandlerType::RESULT);
       preparePlaceholdersAndUnwraps(HandlerDesc, CallbackParams,
-                                    /*Success=*/false);
+                                    PlaceholderMode::ERROR_BLOCK);
 
       addCatch(ErrOrResultParam);
       convertNodes(Blocks.ErrorBlock.nodesToPrint());
@@ -7547,14 +7546,31 @@ private:
     OS << tok::l_brace;
   }
 
+  enum class PlaceholderMode {
+    SUCCESS_BLOCK, ERROR_BLOCK, FALLBACK
+  };
+
   void preparePlaceholdersAndUnwraps(AsyncHandlerDesc HandlerDesc,
                                      const ClosureCallbackParams &Params,
-                                     bool Success) {
+                                     PlaceholderMode Mode) {
+    // Params that have been dropped always need placeholdering.
+    for (auto *Param : Params.getAllParams()) {
+      if (!Params.hasBinding(Param))
+        Placeholders.insert(Param);
+    }
+    // For the fallback case, no other params need placeholdering, as they are
+    // all freely accessible in the fallback case.
+    if (Mode == PlaceholderMode::FALLBACK)
+      return;
+
     switch (HandlerDesc.Type) {
     case HandlerType::PARAMS: {
       auto *ErrParam = Params.getErrParam();
       auto SuccessParams = Params.getSuccessParams();
-      if (!Success) {
+      switch (Mode) {
+      case PlaceholderMode::FALLBACK:
+        llvm_unreachable("Already handled");
+      case PlaceholderMode::ERROR_BLOCK:
         if (ErrParam) {
           if (HandlerDesc.shouldUnwrap(ErrParam->getType())) {
             Placeholders.insert(ErrParam);
@@ -7563,7 +7579,8 @@ private:
           // Can't use success params in the error body
           Placeholders.insert(SuccessParams.begin(), SuccessParams.end());
         }
-      } else {
+        break;
+      case PlaceholderMode::SUCCESS_BLOCK:
         for (auto *SuccessParam : SuccessParams) {
           auto Ty = SuccessParam->getType();
           if (HandlerDesc.shouldUnwrap(Ty)) {
@@ -7573,10 +7590,6 @@ private:
             Placeholders.insert(SuccessParam);
           }
 
-          // If the parameter doesn't have a binding, it needs placeholdering.
-          if (!Params.hasBinding(SuccessParam))
-            Placeholders.insert(SuccessParam);
-
           // Void parameters get omitted where possible, so turn any reference
           // into a placeholder, as its usage is unlikely what the user wants.
           if (HandlerDesc.getSuccessParamAsyncReturnType(Ty)->isVoid())
@@ -7585,6 +7598,7 @@ private:
         // Can't use the error param in the success body
         if (ErrParam)
           Placeholders.insert(ErrParam);
+        break;
       }
       break;
     }

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -4916,6 +4916,113 @@ public:
   }
 };
 
+/// A completion handler function parameter that is known to be a Bool flag
+/// indicating success or failure.
+struct KnownBoolFlagParam {
+  const ParamDecl *Param;
+  bool IsSuccessFlag;
+};
+
+/// A set of parameters for a completion callback closure.
+class ClosureCallbackParams final {
+  const AsyncHandlerParamDesc &HandlerDesc;
+  ArrayRef<const ParamDecl *> AllParams;
+  llvm::SetVector<const ParamDecl *> SuccessParams;
+  const ParamDecl *ErrParam = nullptr;
+  Optional<KnownBoolFlagParam> BoolFlagParam;
+
+public:
+  ClosureCallbackParams(const AsyncHandlerParamDesc &HandlerDesc,
+                        const ClosureExpr *Closure)
+      : HandlerDesc(HandlerDesc),
+        AllParams(Closure->getParameters()->getArray()) {
+    assert(AllParams.size() == HandlerDesc.params().size());
+    assert(!(HandlerDesc.Type == HandlerType::RESULT && AllParams.size() != 1));
+
+    SuccessParams.insert(AllParams.begin(), AllParams.end());
+    if (HandlerDesc.HasError && HandlerDesc.Type == HandlerType::PARAMS)
+      ErrParam = SuccessParams.pop_back_val();
+
+    // Check to see if we have a known bool flag parameter.
+    if (auto *AsyncAlt = HandlerDesc.Func->getAsyncAlternative()) {
+      if (auto Conv = AsyncAlt->getForeignAsyncConvention()) {
+        auto FlagIdx = Conv->completionHandlerFlagParamIndex();
+        if (FlagIdx && *FlagIdx >= 0 && *FlagIdx < AllParams.size()) {
+          auto IsSuccessFlag = Conv->completionHandlerFlagIsErrorOnZero();
+          BoolFlagParam = {AllParams[*FlagIdx], IsSuccessFlag};
+        }
+      }
+    }
+  }
+
+  /// Whether the closure has a particular parameter.
+  bool hasParam(const ParamDecl *Param) const {
+    return Param == ErrParam || SuccessParams.contains(Param);
+  }
+
+  /// Whether \p Param is a success param.
+  bool isSuccessParam(const ParamDecl *Param) const {
+    return SuccessParams.contains(Param);
+  }
+
+  /// Whether \p Param is a closure parameter that may be unwrapped. This
+  /// includes optional parameters as well as \c Result parameters that may be
+  /// unwrapped through e.g 'try? res.get()'.
+  bool isUnwrappableParam(const ParamDecl *Param) const {
+    if (!hasParam(Param))
+      return false;
+    if (getResultParam() == Param)
+      return true;
+    return HandlerDesc.shouldUnwrap(Param->getType());
+  }
+
+  /// Whether \p Param is a closure parameter that has a binding available in
+  /// the async variant of the call, either as a thrown error, or a success
+  /// return value.
+  bool hasBinding(const ParamDecl *Param) const {
+    if (!hasParam(Param))
+      return false;
+    return true;
+  }
+
+  /// Retrieve the success parameters that have a binding in a call to the
+  /// async variant.
+  ArrayRef<const ParamDecl *>
+  getSuccessParamsToBind(SmallVectorImpl<const ParamDecl *> &Scratch) {
+    assert(Scratch.empty());
+    for (auto *Param : SuccessParams) {
+      if (hasBinding(Param))
+        Scratch.push_back(Param);
+    }
+    return Scratch;
+  }
+
+  /// If there is a known Bool flag parameter indicating success or failure,
+  /// returns it, \c None otherwise.
+  Optional<KnownBoolFlagParam> getKnownBoolFlagParam() const {
+    return BoolFlagParam;
+  }
+
+  /// All the parameters of the closure passed as the completion handler.
+  ArrayRef<const ParamDecl *> getAllParams() const { return AllParams; }
+
+  /// The success parameters of the closure passed as the completion handler.
+  /// Note this includes a \c Result parameter.
+  ArrayRef<const ParamDecl *> getSuccessParams() const {
+    return SuccessParams.getArrayRef();
+  }
+
+  /// The error parameter of the closure passed as the completion handler, or
+  /// \c nullptr if there is no error parameter.
+  const ParamDecl *getErrParam() const { return ErrParam; }
+
+  /// If the closure has a single \c Result parameter, returns it, \c nullptr
+  /// otherwise.
+  const ParamDecl *getResultParam() const {
+    return HandlerDesc.Type == HandlerType::RESULT ? SuccessParams[0] : nullptr;
+  }
+};
+
 /// Whether or not the given statement starts a new scope. Note that most
 /// statements are handled by the \c BraceStmt check. The others listed are
 /// a somewhat special case since they can also declare variables in their
@@ -4953,30 +5060,21 @@ struct CallbackClassifier {
   /// Updates the success and error block of `Blocks` with nodes and bound
   /// names from `Body`. Errors are added through `DiagEngine`, possibly
   /// resulting in partially filled out blocks.
-  static void classifyInto(ClassifiedBlocks &Blocks, const FuncDecl *Callee,
-                           ArrayRef<const ParamDecl *> SuccessParams,
+  static void classifyInto(ClassifiedBlocks &Blocks,
+                           const ClosureCallbackParams &Params,
                            llvm::DenseSet<SwitchStmt *> &HandledSwitches,
-                           DiagnosticEngine &DiagEngine,
-                           llvm::DenseSet<const Decl *> UnwrapParams,
-                           const ParamDecl *ErrParam, HandlerType ResultType,
-                           BraceStmt *Body) {
+                           DiagnosticEngine &DiagEngine, BraceStmt *Body) {
     assert(!Body->getElements().empty() && "Cannot classify empty body");
-    CallbackClassifier Classifier(Blocks, Callee, SuccessParams,
-                                  HandledSwitches, DiagEngine, UnwrapParams,
-                                  ErrParam, ResultType == HandlerType::RESULT);
+    CallbackClassifier Classifier(Blocks, Params, HandledSwitches, DiagEngine);
     Classifier.classifyNodes(Body->getElements(), Body->getRBraceLoc());
   }
 
 private:
   ClassifiedBlocks &Blocks;
-  const FuncDecl *Callee;
-  ArrayRef<const ParamDecl *> SuccessParams;
+  const ClosureCallbackParams &Params;
   llvm::DenseSet<SwitchStmt *> &HandledSwitches;
   DiagnosticEngine &DiagEngine;
   ClassifiedBlock *CurrentBlock;
-  llvm::DenseSet<const Decl *> UnwrapParams;
-  const ParamDecl *ErrParam;
-  bool IsResultParam;
 
   /// This is set to \c true if we're currently classifying on a known condition
   /// path, where \c CurrentBlock is set to the appropriate block. This lets us
@@ -4984,16 +5082,12 @@ private:
   /// we're supposed to be in.
   bool IsKnownConditionPath = false;
 
-  CallbackClassifier(ClassifiedBlocks &Blocks, const FuncDecl *Callee,
-                     ArrayRef<const ParamDecl *> SuccessParams,
+  CallbackClassifier(ClassifiedBlocks &Blocks,
+                     const ClosureCallbackParams &Params,
                      llvm::DenseSet<SwitchStmt *> &HandledSwitches,
-                     DiagnosticEngine &DiagEngine,
-                     llvm::DenseSet<const Decl *> UnwrapParams,
-                     const ParamDecl *ErrParam, bool IsResultParam)
-      : Blocks(Blocks), Callee(Callee), SuccessParams(SuccessParams),
-        HandledSwitches(HandledSwitches), DiagEngine(DiagEngine),
-        CurrentBlock(&Blocks.SuccessBlock), UnwrapParams(UnwrapParams),
-        ErrParam(ErrParam), IsResultParam(IsResultParam) {}
+                     DiagnosticEngine &DiagEngine)
+      : Blocks(Blocks), Params(Params), HandledSwitches(HandledSwitches),
+        DiagEngine(DiagEngine), CurrentBlock(&Blocks.SuccessBlock) {}
 
   void classifyNodes(ArrayRef<ASTNode> Nodes, SourceLoc endCommentLoc) {
     for (auto I = Nodes.begin(), E = Nodes.end(); I < E; ++I) {
@@ -5026,7 +5120,8 @@ private:
   /// Whether any of the provided ASTNodes have a child expression that force
   /// unwraps the error parameter. Note that this doesn't walk into new scopes.
   bool hasForceUnwrappedErrorParam(ArrayRef<ASTNode> Nodes) {
-    if (IsResultParam || !ErrParam)
+    auto *ErrParam = Params.getErrParam();
+    if (!ErrParam)
       return false;
 
     class ErrUnwrapFinder : public ASTWalker {
@@ -5095,22 +5190,26 @@ private:
     if (Cond.BindPattern && Cond.BindPattern->isRefutablePattern())
       return None;
 
-    // For certain types of condition, they need to appear in certain lists.
+    auto *SubjectParam = dyn_cast<ParamDecl>(Cond.Subject);
+    if (!SubjectParam)
+      return None;
+
+    // For certain types of condition, they need to be certain kinds of params.
     auto CondType = *Cond.Type;
     switch (CondType) {
     case ConditionType::NOT_NIL:
     case ConditionType::NIL:
-      if (!UnwrapParams.count(Cond.Subject))
+      if (!Params.isUnwrappableParam(SubjectParam))
         return None;
       break;
     case ConditionType::IS_TRUE:
     case ConditionType::IS_FALSE:
-      if (!llvm::is_contained(SuccessParams, Cond.Subject))
+      if (!Params.isSuccessParam(SubjectParam))
         return None;
       break;
     case ConditionType::SUCCESS_PATTERN:
     case ConditionType::FAILURE_PATTEN:
-      if (!IsResultParam || Cond.Subject != ErrParam)
+      if (SubjectParam != Params.getResultParam())
         return None;
       break;
     }
@@ -5119,7 +5218,7 @@ private:
     auto Path = ConditionPath::SUCCESS;
 
     // If it's an error param, that's a flip.
-    if (Cond.Subject == ErrParam && !IsResultParam)
+    if (SubjectParam == Params.getErrParam())
       Path = flippedConditionPath(Path);
 
     // If we have a nil, false, or failure condition, that's a flip.
@@ -5142,29 +5241,15 @@ private:
       return ClassifiedCondition(Cond, Path, /*ObjCFlagCheck*/ false);
     }
 
-    // Check to see if the async alternative function has a convention that
-    // specifies where the flag is and what it indicates.
-    Optional<std::pair</*Idx*/ unsigned, /*SuccessFlag*/ bool>> CustomFlag;
-    if (auto *AsyncAlt = Callee->getAsyncAlternative()) {
-      if (auto Conv = AsyncAlt->getForeignAsyncConvention()) {
-        if (auto Idx = Conv->completionHandlerFlagParamIndex()) {
-          auto IsSuccessFlag = Conv->completionHandlerFlagIsErrorOnZero();
-          CustomFlag = std::make_pair(*Idx, IsSuccessFlag);
-        }
-      }
-    }
-    if (CustomFlag) {
-      auto Idx = CustomFlag->first;
-      if (Idx < 0 || Idx >= SuccessParams.size())
-        return None;
-
-      if (SuccessParams[Idx] != Cond.Subject)
+    // Check to see if we have a known bool flag parameter that indicates
+    // success or failure.
+    if (auto KnownBoolFlag = Params.getKnownBoolFlagParam()) {
+      if (KnownBoolFlag->Param != Cond.Subject)
         return None;
 
       // The path may need to be flipped depending on whether the flag indicates
       // success.
-      auto IsSuccessFlag = CustomFlag->second;
-      if (!IsSuccessFlag)
+      if (!KnownBoolFlag->IsSuccessFlag)
         Path = flippedConditionPath(Path);
 
       return ClassifiedCondition(Cond, Path, /*ObjCStyleFlagCheck*/ true);
@@ -5290,7 +5375,7 @@ private:
     ClassifiedCallbackConditions CallbackConditions;
     bool UnhandledConditions = classifyConditionsOf(
         Condition, ThenNodesToPrint, ElseStmt, CallbackConditions);
-    auto ErrCondition = CallbackConditions.lookup(ErrParam);
+    auto ErrCondition = CallbackConditions.lookup(Params.getErrParam());
 
     if (UnhandledConditions) {
       // Some unknown conditions. If there's an else, assume we can't handle
@@ -5413,7 +5498,8 @@ private:
   }
 
   void classifySwitch(SwitchStmt *SS) {
-    if (!IsResultParam || singleSwitchSubject(SS) != ErrParam) {
+    auto *ResultParam = Params.getResultParam();
+    if (singleSwitchSubject(SS) != ResultParam) {
       CurrentBlock->addNode(SS);
       return;
     }
@@ -5455,7 +5541,7 @@ private:
 
       // Classify the case pattern.
       auto CC = classifyCallbackCondition(
-          CallbackCondition(ErrParam, &Items[0]), SuccessNodes,
+          CallbackCondition(ResultParam, &Items[0]), SuccessNodes,
           /*elseStmt*/ nullptr);
       if (!CC) {
         DiagEngine.diagnose(CS->getLoc(), diag::unknown_callback_case_item);
@@ -7061,42 +7147,23 @@ private:
   void addHoistedClosureCallback(const CallExpr *CE,
                                  const AsyncHandlerParamDesc &HandlerDesc,
                                  const ClosureExpr *Callback) {
-    ArrayRef<const ParamDecl *> CallbackParams =
-        Callback->getParameters()->getArray();
-    auto CallbackBody = Callback->getBody();
-    if (HandlerDesc.params().size() != CallbackParams.size()) {
+    if (HandlerDesc.params().size() != Callback->getParameters()->size()) {
       DiagEngine.diagnose(CE->getStartLoc(), diag::mismatched_callback_args);
       return;
     }
-
-    // Note that the `ErrParam` may be a Result (in which case it's also the
-    // only element in `SuccessParams`)
-    ArrayRef<const ParamDecl *> SuccessParams = CallbackParams;
-    const ParamDecl *ErrParam = nullptr;
-    if (HandlerDesc.Type == HandlerType::RESULT) {
-      ErrParam = SuccessParams.back();
-    } else if (HandlerDesc.HasError) {
-      assert(HandlerDesc.Type == HandlerType::PARAMS);
-      ErrParam = SuccessParams.back();
-      SuccessParams = SuccessParams.drop_back();
-    }
-
+    ClosureCallbackParams CallbackParams(HandlerDesc, Callback);
     ClassifiedBlocks Blocks;
+    auto *CallbackBody = Callback->getBody();
     if (!HandlerDesc.HasError) {
       Blocks.SuccessBlock.addNodesInBraceStmt(CallbackBody);
     } else if (!CallbackBody->getElements().empty()) {
-      llvm::DenseSet<const Decl *> UnwrapParams;
-      for (auto *Param : SuccessParams) {
-        if (HandlerDesc.shouldUnwrap(Param->getType()))
-          UnwrapParams.insert(Param);
-      }
-      if (ErrParam)
-        UnwrapParams.insert(ErrParam);
-      CallbackClassifier::classifyInto(
-          Blocks, HandlerDesc.Func, SuccessParams, HandledSwitches, DiagEngine,
-          UnwrapParams, ErrParam, HandlerDesc.Type, CallbackBody);
+      CallbackClassifier::classifyInto(Blocks, CallbackParams, HandledSwitches,
+                                       DiagEngine, CallbackBody);
     }
 
+    SmallVector<const ParamDecl *, 4> Scratch;
+    auto SuccessBindings = CallbackParams.getSuccessParamsToBind(Scratch);
+    auto *ErrParam = CallbackParams.getErrParam();
     if (DiagEngine.hadAnyError()) {
       // For now, only fallback when the results are params with an error param,
       // in which case only the names are used (defaulted to the names of the
@@ -7109,21 +7176,29 @@ private:
       // assignments to the names in the outer scope.
       InlinePatternsToPrint InlinePatterns;
 
+      SmallVector<const ParamDecl *, 4> AllBindings;
+      AllBindings.append(SuccessBindings.begin(), SuccessBindings.end());
+      AllBindings.push_back(ErrParam);
+
       // Don't do any unwrapping or placeholder replacement since all params
       // are still valid in the fallback case
-      prepareNames(ClassifiedBlock(), CallbackParams, InlinePatterns);
+      prepareNames(ClassifiedBlock(), AllBindings, InlinePatterns);
 
-      addFallbackVars(CallbackParams, Blocks);
+      addFallbackVars(AllBindings, Blocks);
       addDo();
-      addAwaitCall(CE, Blocks.SuccessBlock, SuccessParams, InlinePatterns,
+      addAwaitCall(CE, Blocks.SuccessBlock, SuccessBindings, InlinePatterns,
                    HandlerDesc, /*AddDeclarations*/ false);
       addFallbackCatch(ErrParam);
       OS << "\n";
       convertNodes(NodesToPrint::inBraceStmt(CallbackBody));
 
-      clearNames(CallbackParams);
+      clearNames(AllBindings);
       return;
     }
+
+    auto *ErrOrResultParam = ErrParam;
+    if (auto *ResultParam = CallbackParams.getResultParam())
+      ErrOrResultParam = ResultParam;
 
     auto ErrorNodes = Blocks.ErrorBlock.nodesToPrint().getNodes();
     bool RequireDo = !ErrorNodes.empty();
@@ -7137,8 +7212,8 @@ private:
           // Skip if we have the param itself or the name it's bound to
           auto *ArgExpr = Res.args()[0].getExpr();
           auto *SingleDecl = ArgExpr->getReferencedDecl().getDecl();
-          auto ErrName = Blocks.ErrorBlock.boundName(ErrParam);
-          RequireDo = SingleDecl != ErrParam &&
+          auto ErrName = Blocks.ErrorBlock.boundName(ErrOrResultParam);
+          RequireDo = SingleDecl != ErrOrResultParam &&
                       !(Res.isError() && SingleDecl &&
                         SingleDecl->getName().isSimpleName(ErrName));
         }
@@ -7159,34 +7234,34 @@ private:
       addDo();
     }
 
-    auto InlinePatterns =
-        getInlinePatternsToPrint(Blocks.SuccessBlock, SuccessParams, Callback);
+    auto InlinePatterns = getInlinePatternsToPrint(Blocks.SuccessBlock,
+                                                   SuccessBindings, Callback);
 
-    prepareNames(Blocks.SuccessBlock, SuccessParams, InlinePatterns);
-    preparePlaceholdersAndUnwraps(HandlerDesc, SuccessParams, ErrParam,
+    prepareNames(Blocks.SuccessBlock, SuccessBindings, InlinePatterns);
+    preparePlaceholdersAndUnwraps(HandlerDesc, CallbackParams,
                                   /*Success=*/true);
 
-    addAwaitCall(CE, Blocks.SuccessBlock, SuccessParams, InlinePatterns,
+    addAwaitCall(CE, Blocks.SuccessBlock, SuccessBindings, InlinePatterns,
                  HandlerDesc, /*AddDeclarations=*/true);
     printOutOfLineBindingPatterns(Blocks.SuccessBlock, InlinePatterns);
     convertNodes(Blocks.SuccessBlock.nodesToPrint());
-    clearNames(SuccessParams);
+    clearNames(SuccessBindings);
 
     if (RequireDo) {
       // We don't use inline patterns for the error path.
       InlinePatternsToPrint ErrInlinePatterns;
 
       // Always use the ErrParam name if none is bound.
-      prepareNames(Blocks.ErrorBlock, llvm::makeArrayRef(ErrParam),
+      prepareNames(Blocks.ErrorBlock, llvm::makeArrayRef(ErrOrResultParam),
                    ErrInlinePatterns,
                    /*AddIfMissing=*/HandlerDesc.Type != HandlerType::RESULT);
-      preparePlaceholdersAndUnwraps(HandlerDesc, SuccessParams, ErrParam,
+      preparePlaceholdersAndUnwraps(HandlerDesc, CallbackParams,
                                     /*Success=*/false);
 
-      addCatch(ErrParam);
+      addCatch(ErrOrResultParam);
       convertNodes(Blocks.ErrorBlock.nodesToPrint());
       OS << "\n" << tok::r_brace;
-      clearNames(llvm::makeArrayRef(ErrParam));
+      clearNames(llvm::makeArrayRef(ErrOrResultParam));
     }
   }
 
@@ -7469,10 +7544,12 @@ private:
   }
 
   void preparePlaceholdersAndUnwraps(AsyncHandlerDesc HandlerDesc,
-                                     ArrayRef<const ParamDecl *> SuccessParams,
-                                     const ParamDecl *ErrParam, bool Success) {
+                                     const ClosureCallbackParams &Params,
+                                     bool Success) {
     switch (HandlerDesc.Type) {
-    case HandlerType::PARAMS:
+    case HandlerType::PARAMS: {
+      auto *ErrParam = Params.getErrParam();
+      auto SuccessParams = Params.getSuccessParams();
       if (!Success) {
         if (ErrParam) {
           if (HandlerDesc.shouldUnwrap(ErrParam->getType())) {
@@ -7492,6 +7569,10 @@ private:
             Placeholders.insert(SuccessParam);
           }
 
+          // If the parameter doesn't have a binding, it needs placeholdering.
+          if (!Params.hasBinding(SuccessParam))
+            Placeholders.insert(SuccessParam);
+
           // Void parameters get omitted where possible, so turn any reference
           // into a placeholder, as its usage is unlikely what the user wants.
           if (HandlerDesc.getSuccessParamAsyncReturnType(Ty)->isVoid())
@@ -7502,12 +7583,15 @@ private:
           Placeholders.insert(ErrParam);
       }
       break;
-    case HandlerType::RESULT:
+    }
+    case HandlerType::RESULT: {
       // Any uses of the result parameter in the current body (that aren't
       // replaced) are invalid, so replace them with a placeholder.
-      assert(SuccessParams.size() == 1 && SuccessParams[0] == ErrParam);
-      Placeholders.insert(ErrParam);
+      auto *ResultParam = Params.getResultParam();
+      assert(ResultParam);
+      Placeholders.insert(ResultParam);
       break;
+    }
     default:
       llvm_unreachable("Unhandled handler type");
     }

--- a/test/refactoring/ConvertAsync/convert_bool.swift
+++ b/test/refactoring/ConvertAsync/convert_bool.swift
@@ -459,4 +459,21 @@ func testConvertBool() async throws {
   // OBJC-BOOL-WITH-ERR2-NEXT:   print("neat")
   // OBJC-BOOL-WITH-ERR2-NEXT:   print("neato")
   // OBJC-BOOL-WITH-ERR2-NEXT: }
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 -I %S/Inputs -I %t -target %target-triple %clang-importer-sdk-nosource | %FileCheck -check-prefix=OBJC-BOOL-WITH-ERR-FALLBACK %s
+  ClassWithHandlerMethods.firstBoolFlagSuccess("") { str, success, unrelated, err in
+    guard success && success == .random() else { fatalError() }
+    print("much success", unrelated, str)
+  }
+  // OBJC-BOOL-WITH-ERR-FALLBACK:      var str: String? = nil
+  // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT: var unrelated: Bool? = nil
+  // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT: var err: Error? = nil
+  // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT: do {
+  // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT:   (str, unrelated) = try await ClassWithHandlerMethods.firstBoolFlagSuccess("")
+  // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT: } catch {
+  // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT:   err = error
+  // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT: }
+  // OBJC-BOOL-WITH-ERR-FALLBACK-EMPTY:
+  // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT: guard <#success#> && <#success#> == .random() else { fatalError() }
+  // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT: print("much success", unrelated, str)
 }

--- a/test/refactoring/ConvertAsync/convert_bool.swift
+++ b/test/refactoring/ConvertAsync/convert_bool.swift
@@ -384,8 +384,7 @@ func testConvertBool() async throws {
   // OPT-BOOL-WITH-ERR-NEXT:   print("g \(err)")
   // OPT-BOOL-WITH-ERR-NEXT: }
 
-  // We cannot use refactor-check-compiles, as a placeholder cannot be force unwrapped.
-  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 -I %S/Inputs -I %t -target %target-triple %clang-importer-sdk-nosource | %FileCheck -check-prefix=OBJC-BOOL-WITH-ERR %s
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 -I %S/Inputs -I %t -target %target-triple %clang-importer-sdk-nosource | %FileCheck -check-prefix=OBJC-BOOL-WITH-ERR %s
   ClassWithHandlerMethods.firstBoolFlagSuccess("") { str, success, unrelated, err in
     if !unrelated {
       print(err!)
@@ -405,7 +404,7 @@ func testConvertBool() async throws {
   }
 
   // OBJC-BOOL-WITH-ERR:      do {
-  // OBJC-BOOL-WITH-ERR-NEXT:   let (str, success, unrelated) = try await ClassWithHandlerMethods.firstBoolFlagSuccess("")
+  // OBJC-BOOL-WITH-ERR-NEXT:   let (str, unrelated) = try await ClassWithHandlerMethods.firstBoolFlagSuccess("")
   // OBJC-BOOL-WITH-ERR-NEXT:   if !unrelated {
   // OBJC-BOOL-WITH-ERR-NEXT:     print(<#err#>!)
   // OBJC-BOOL-WITH-ERR-NEXT:   }
@@ -416,8 +415,7 @@ func testConvertBool() async throws {
   // OBJC-BOOL-WITH-ERR-NEXT:   print(err)
   // OBJC-BOOL-WITH-ERR-NEXT: }
 
-  // We cannot use refactor-check-compiles, as a placeholder cannot be force unwrapped.
-  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 -I %S/Inputs -I %t -target %target-triple %clang-importer-sdk-nosource | %FileCheck -check-prefix=OBJC-BOOL-WITH-ERR2 %s
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 -I %S/Inputs -I %t -target %target-triple %clang-importer-sdk-nosource | %FileCheck -check-prefix=OBJC-BOOL-WITH-ERR2 %s
   ClassWithHandlerMethods.secondBoolFlagFailure("") { str, unrelated, failure, err in
     if unrelated {
       print(err!)
@@ -446,13 +444,13 @@ func testConvertBool() async throws {
   }
 
   // OBJC-BOOL-WITH-ERR2:      do {
-  // OBJC-BOOL-WITH-ERR2-NEXT:   let (str, unrelated, failure) = try await ClassWithHandlerMethods.secondBoolFlagFailure("")
+  // OBJC-BOOL-WITH-ERR2-NEXT:   let (str, unrelated) = try await ClassWithHandlerMethods.secondBoolFlagFailure("")
   // OBJC-BOOL-WITH-ERR2-NEXT:   if unrelated {
   // OBJC-BOOL-WITH-ERR2-NEXT:     print(<#err#>!)
   // OBJC-BOOL-WITH-ERR2-NEXT:   }
   // OBJC-BOOL-WITH-ERR2-NEXT:   print("woo")
   // OBJC-BOOL-WITH-ERR2-NEXT:   print("also woo")
-  // OBJC-BOOL-WITH-ERR2-NEXT:   if failure && <#err#> == nil {
+  // OBJC-BOOL-WITH-ERR2-NEXT:   if <#failure#> && <#err#> == nil {
   // OBJC-BOOL-WITH-ERR2-NEXT:     print("wat")
   // OBJC-BOOL-WITH-ERR2-NEXT:   }
   // OBJC-BOOL-WITH-ERR2-NEXT: } catch let err {

--- a/test/refactoring/ConvertAsync/convert_bool.swift
+++ b/test/refactoring/ConvertAsync/convert_bool.swift
@@ -466,14 +466,37 @@ func testConvertBool() async throws {
     print("much success", unrelated, str)
   }
   // OBJC-BOOL-WITH-ERR-FALLBACK:      var str: String? = nil
+  // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT: let success: Bool
   // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT: var unrelated: Bool? = nil
   // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT: var err: Error? = nil
   // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT: do {
   // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT:   (str, unrelated) = try await ClassWithHandlerMethods.firstBoolFlagSuccess("")
+  // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT:   success = true
   // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT: } catch {
   // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT:   err = error
+  // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT:   success = false
   // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT: }
   // OBJC-BOOL-WITH-ERR-FALLBACK-EMPTY:
-  // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT: guard <#success#> && <#success#> == .random() else { fatalError() }
+  // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT: guard success && success == .random() else { fatalError() }
   // OBJC-BOOL-WITH-ERR-FALLBACK-NEXT: print("much success", unrelated, str)
+
+  // RUN: %refactor-check-compiles -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 -I %S/Inputs -I %t -target %target-triple %clang-importer-sdk-nosource | %FileCheck -check-prefix=OBJC-BOOL-WITH-ERR-FALLBACK2 %s
+  ClassWithHandlerMethods.secondBoolFlagFailure("") { str, unrelated, failure, err in
+    guard !failure && failure == .random() else { fatalError() }
+    print("much fails", unrelated, str)
+  }
+  // OBJC-BOOL-WITH-ERR-FALLBACK2:      var str: String? = nil
+  // OBJC-BOOL-WITH-ERR-FALLBACK2-NEXT: var unrelated: Bool? = nil
+  // OBJC-BOOL-WITH-ERR-FALLBACK2-NEXT: let failure: Bool
+  // OBJC-BOOL-WITH-ERR-FALLBACK2-NEXT: var err: Error? = nil
+  // OBJC-BOOL-WITH-ERR-FALLBACK2-NEXT: do {
+  // OBJC-BOOL-WITH-ERR-FALLBACK2-NEXT:   (str, unrelated) = try await ClassWithHandlerMethods.secondBoolFlagFailure("")
+  // OBJC-BOOL-WITH-ERR-FALLBACK2-NEXT:   failure = false
+  // OBJC-BOOL-WITH-ERR-FALLBACK2-NEXT: } catch {
+  // OBJC-BOOL-WITH-ERR-FALLBACK2-NEXT:   err = error
+  // OBJC-BOOL-WITH-ERR-FALLBACK2-NEXT:   failure = true
+  // OBJC-BOOL-WITH-ERR-FALLBACK2-NEXT: }
+  // OBJC-BOOL-WITH-ERR-FALLBACK2-EMPTY:
+  // OBJC-BOOL-WITH-ERR-FALLBACK2-NEXT: guard !failure && failure == .random() else { fatalError() }
+  // OBJC-BOOL-WITH-ERR-FALLBACK2-NEXT: print("much fails", unrelated, str)
 }


### PR DESCRIPTION
If we have a known bool flag parameter, drop it from the success parameters being bound in a refactored await call, as the async variant drops it. And in the fallback case, add a binding for it in the success and error block.

rdar://81896460