### PR TITLE
[CSGen] Don't increase optionality of `weak var` patterns

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2209,12 +2209,17 @@ namespace {
 
         switch (optionality) {
         case ReferenceOwnershipOptionality::Required:
-          varType = TypeChecker::getOptionalType(var->getLoc(), varType);
-          assert(!varType->hasError());
+          // If the externally-imposed type is already optional,
+          // let's not add optionality to the pattern.
+          if (!externalPatternType ||
+              !externalPatternType->getOptionalObjectType()) {
+            varType = TypeChecker::getOptionalType(var->getLoc(), varType);
+            assert(!varType->hasError());
 
-          if (oneWayVarType) {
-            oneWayVarType =
-                TypeChecker::getOptionalType(var->getLoc(), oneWayVarType);
+            if (oneWayVarType) {
+              oneWayVarType =
+                  TypeChecker::getOptionalType(var->getLoc(), oneWayVarType);
+            }
           }
           break;
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2189,9 +2189,16 @@ namespace {
           }
         }
 
-        if (!varType)
+        if (!varType) {
           varType = CS.createTypeVariable(CS.getConstraintLocator(locator),
                                           TVO_CanBindToNoEscape);
+
+          // If this is either a `weak` declaration or capture e.g.
+          // `weak var ...` or `[weak self]`. Let's wrap type variable
+          // into an optional.
+          if (optionality == ReferenceOwnershipOptionality::Required)
+            varType = TypeChecker::getOptionalType(var->getLoc(), varType);
+        }
 
         // When we are supposed to bind pattern variables, create a fresh
         // type variable and a one-way constraint to assign it to either the
@@ -2200,32 +2207,36 @@ namespace {
         if (bindPatternVarsOneWay) {
           oneWayVarType = CS.createTypeVariable(
               CS.getConstraintLocator(locator), TVO_CanBindToNoEscape);
-          CS.addConstraint(
-              ConstraintKind::OneWayEqual, oneWayVarType,
-              externalPatternType ? externalPatternType : varType, locator);
-        }
 
-        // If there is an externally-imposed type.
+          // If there is an externally-imposed pattern type and the
+          // binding/capture is marked as `weak`, let's make sure
+          // that the imposed type is optional.
+          //
+          // Note that there is no need to check `varType` since
+          // it's only "externally" bound if this pattern isn't marked
+          // as `weak`.
+          if (externalPatternType &&
+              optionality == ReferenceOwnershipOptionality::Required) {
+            // If the type is not yet known, let's add a constraint
+            // to make sure that it can only be bound to an optional type.
+            if (externalPatternType->isTypeVariableOrMember()) {
+              auto objectTy = CS.createTypeVariable(
+                  CS.getConstraintLocator(locator.withPathElement(
+                      ConstraintLocator::OptionalPayload)),
+                  TVO_CanBindToLValue | TVO_CanBindToNoEscape);
 
-        switch (optionality) {
-        case ReferenceOwnershipOptionality::Required:
-          // If the externally-imposed type is already optional,
-          // let's not add optionality to the pattern.
-          if (!externalPatternType ||
-              !externalPatternType->getOptionalObjectType()) {
-            varType = TypeChecker::getOptionalType(var->getLoc(), varType);
-            assert(!varType->hasError());
-
-            if (oneWayVarType) {
-              oneWayVarType =
-                  TypeChecker::getOptionalType(var->getLoc(), oneWayVarType);
+              CS.addConstraint(ConstraintKind::OptionalObject,
+                               externalPatternType, objectTy, locator);
+            } else if (!externalPatternType->getOptionalObjectType()) {
+              // TODO(diagnostics): A tailored fix to indiciate that `weak`
+              // should have an optional type.
+              return Type();
             }
           }
-          break;
 
-        case ReferenceOwnershipOptionality::Allowed:
-        case ReferenceOwnershipOptionality::Disallowed:
-          break;
+          CS.addConstraint(ConstraintKind::OneWayEqual, oneWayVarType,
+                           externalPatternType ? externalPatternType : varType,
+                           locator);
         }
 
         // If we have a type to ascribe to the variable, do so now.

--- a/test/Constraints/result_builder.swift
+++ b/test/Constraints/result_builder.swift
@@ -788,3 +788,19 @@ let ts1 = MyTupleStruct {
 
 // CHECK: MyTupleStruct<(Int, String, Optional<String>), (Double, String)>(first: (Function), second: (3.14159, "blah"))
 print(ts1)
+
+// Make sure that `weakV` is `Test?` and not `Test??`
+func test_weak_optionality_stays_the_same() {
+  class Test {
+    func fn() -> Int { 42 }
+  }
+
+  tuplify(true) { c in
+    weak var weakV: Test? = Test()
+
+    0
+    if let v = weakV {
+      v.fn()
+    }
+  }
+}


### PR DESCRIPTION
If the externally-imposed type is already optional,
let's not add optionality to the pattern.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
