### PR TITLE
runtime: remove workaround for Windows ARM64

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -6123,17 +6123,6 @@ const HeapObject *swift_getKeyPathImpl(const void *pattern,
 #define OVERRIDE_WITNESSTABLE COMPATIBILITY_OVERRIDE
 #include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
 
-#if defined(_WIN32) && defined(_M_ARM64)
-namespace std {
-template <>
-inline void _Atomic_storage<::PoolRange, 16>::_Unlock() const noexcept {
-  __dmb(0x8);
-  __iso_volatile_store32(&reinterpret_cast<volatile int &>(_Spinlock), 0);
-  __dmb(0x8);
-}
-}
-#endif
-
 // Autolink with libc++, for cases where libswiftCore is linked statically.
 #if defined(__MACH__)
 asm(".linker_option \"-lc++\"\n");


### PR DESCRIPTION
If anyone else is building Windows ARM64 they should be using a new
enough Visual Studio.  This workaround is more difficult to keep working
properly and the CI hosts should have a new enough Visual Studio
installation hopefully in order to enable the ARM64 builds of the
runtime.  If they do not, we can re-evaluate whether to re-instate the
workaround.  This allows building part of the runtime with Visual Studio
2022 and reduces the maintenance overheads for the runtime.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
