### PR TITLE
Assign variable names for anonymous function arguments in SILGen.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1785,7 +1785,7 @@ class TailAllocatedDebugVariable {
   } Bits;
 public:
   TailAllocatedDebugVariable(Optional<SILDebugVariable>, char *buf,
-                             SILType *AuxVarType = nullptr,
+                             bool HasDeclName, SILType *AuxVarType = nullptr,
                              SILLocation *DeclLoc = nullptr,
                              const SILDebugScope **DeclScope = nullptr,
                              SILDIExprElement *DIExprOps = nullptr);
@@ -1810,13 +1810,11 @@ public:
     if (!Bits.Data.HasValue)
       return None;
 
-    if (VD)
-      return SILDebugVariable(VD->getName().empty() ? "" : VD->getName().str(),
-                              VD->isLet(), getArgNo(), isImplicit(), AuxVarType,
-                              DeclLoc, DeclScope, DIExprElements);
-    else
-      return SILDebugVariable(getName(buf), isLet(), getArgNo(), isImplicit(),
-                              AuxVarType, DeclLoc, DeclScope, DIExprElements);
+    StringRef name = getName(buf);
+    if (VD && name.empty())
+      name = VD->getName().str();
+    return SILDebugVariable(name, isLet(), getArgNo(), isImplicit(), AuxVarType,
+                            DeclLoc, DeclScope, DIExprElements);
   }
 };
 static_assert(sizeof(TailAllocatedDebugVariable) == 4,

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2487,7 +2487,8 @@ void IRGenDebugInfoImpl::emitVariableDeclaration(
 
   // Get or create the DILocalVariable.
   llvm::DILocalVariable *Var;
-  auto CachedVar = LocalVarCache.find({KeyScope, VarInfo.Name.data(), ArgNo});
+  VarID Key(KeyScope, VarInfo.Name.data(), ArgNo);
+  auto CachedVar = LocalVarCache.find(Key);
   if (CachedVar != LocalVarCache.end()) {
     Var = cast<llvm::DILocalVariable>(CachedVar->second);
   } else {
@@ -2501,8 +2502,7 @@ void IRGenDebugInfoImpl::emitVariableDeclaration(
     else
       Var = DBuilder.createAutoVariable(VarScope, VarInfo.Name, Unit, DVarLine,
                                         DITy, Preserve, Flags);
-    LocalVarCache.insert(
-        {{KeyScope, VarInfo.Name.data(), ArgNo}, llvm::TrackingMDNodeRef(Var)});
+    LocalVarCache.insert({Key, llvm::TrackingMDNodeRef(Var)});
   }
 
   auto appendDIExpression =

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -649,7 +649,7 @@ public:
     if (Name.empty()) {
       {
         llvm::raw_svector_ostream S(Name);
-        S << '_' << NumAnonVars++;
+        S << "$_" << NumAnonVars++;
       }
       AnonymousVariables.insert({Decl, Name});
     }

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1224,6 +1224,8 @@ public:
       return;
 
     auto *debugScope = inst->getDebugScope();
+    if (varInfo->ArgNo)
+      require(!varInfo->Name.empty(), "function argument without a name");
 
     // Check that there is at most one debug variable defined for each argument
     // slot if our debug scope is not an inlined call site.
@@ -1234,8 +1236,7 @@ public:
     if (debugScope && !debugScope->InlinedCallSite)
       if (unsigned argNum = varInfo->ArgNo) {
         // It is a function argument.
-        if (argNum < DebugVars.size() && !DebugVars[argNum].empty() &&
-            !varInfo->Name.empty()) {
+        if (argNum < DebugVars.size() && !DebugVars[argNum].empty()) {
           require(DebugVars[argNum] == varInfo->Name,
                   "Scope contains conflicting debug variables for one function "
                   "argument");

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -363,7 +363,7 @@ static void emitCaptureArguments(SILGenFunction &SGF,
     if (auto *AllocStack = dyn_cast<AllocStackInst>(val))
       AllocStack->setArgNo(ArgNo);
     else {
-      SILDebugVariable DbgVar(/*Constant*/ true, ArgNo);
+      SILDebugVariable DbgVar(VD->isLet(), ArgNo);
       SGF.B.createDebugValue(Loc, val, DbgVar);
     }
 
@@ -388,7 +388,7 @@ static void emitCaptureArguments(SILGenFunction &SGF,
         SILType::getPrimitiveObjectType(boxTy), VD);
     SILValue addr = SGF.B.createProjectBox(VD, box, 0);
     SGF.VarLocs[VD] = SILGenFunction::VarLoc::get(addr, box);
-    SILDebugVariable DbgVar(/*Constant*/ false, ArgNo);
+    SILDebugVariable DbgVar(VD->isLet(), ArgNo);
     SGF.B.createDebugValueAddr(Loc, addr, DbgVar);
     break;
   }
@@ -399,7 +399,7 @@ static void emitCaptureArguments(SILGenFunction &SGF,
     SILType ty = SGF.getLoweredType(type).getAddressType();
     SILValue addr = SGF.F.begin()->createFunctionArgument(ty, VD);
     SGF.VarLocs[VD] = SILGenFunction::VarLoc::get(addr);
-    SILDebugVariable DbgVar(/*Constant*/ true, ArgNo);
+    SILDebugVariable DbgVar(VD->isLet(), ArgNo);
     SGF.B.createDebugValueAddr(Loc, addr, DbgVar);
     break;
   }

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -275,12 +275,11 @@ struct ArgumentInitHelper {
     // Emit debug information for the argument.
     SILLocation loc(PD);
     loc.markAsPrologue();
+    SILDebugVariable DebugVar(PD->isLet(), ArgNo);
     if (argrv.getType().isAddress())
-      SGF.B.createDebugValueAddr(loc, argrv.getValue(),
-                                 SILDebugVariable(PD->isLet(), ArgNo));
+      SGF.B.createDebugValueAddr(loc, argrv.getValue(), DebugVar);
     else
-      SGF.B.createDebugValue(loc, argrv.getValue(),
-                             SILDebugVariable(PD->isLet(), ArgNo));
+      SGF.B.createDebugValue(loc, argrv.getValue(), DebugVar);
   }
 };
 } // end anonymous namespace

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1389,14 +1389,12 @@ static bool keepArgsOfPartialApplyAlive(PartialApplyInst *pai,
 
   for (Operand *argOp : argsToHandle) {
     SILValue arg = argOp->get();
-    int argIdx = argOp->getOperandNumber() - pai->getArgumentOperandNumber();
-    SILDebugVariable dbgVar(/*Constant*/ true, argIdx);
 
     SILValue tmp = arg;
     if (arg->getType().isAddress()) {
       // Move the value to a stack-allocated temporary.
       SILBuilderWithScope builder(pai, builderCtxt);
-      tmp = builder.createAllocStack(pai->getLoc(), arg->getType(), dbgVar);
+      tmp = builder.createAllocStack(pai->getLoc(), arg->getType());
       builder.createCopyAddr(pai->getLoc(), arg, tmp, IsTake_t::IsTake,
                              IsInitialization_t::IsInitialization);
     }

--- a/lib/SILOptimizer/Utils/PartialApplyCombiner.cpp
+++ b/lib/SILOptimizer/Utils/PartialApplyCombiner.cpp
@@ -98,16 +98,13 @@ bool PartialApplyCombiner::copyArgsToTemporaries(
 
   for (Operand *argOp : argsToHandle) {
     SILValue arg = argOp->get();
-    int argIdx = ApplySite(pai).getAppliedArgIndex(*argOp);
-    SILDebugVariable dbgVar(/*Constant*/ true, argIdx);
-
     SILValue tmp = arg;
     SILBuilderWithScope builder(pai, builderCtxt);
     if (arg->getType().isObject()) {
       tmp = builder.emitCopyValueOperation(pai->getLoc(), arg);
     } else {
       // Copy address-arguments into a stack-allocated temporary.
-      tmp = builder.createAllocStack(pai->getLoc(), arg->getType(), dbgVar);
+      tmp = builder.createAllocStack(pai->getLoc(), arg->getType());
       builder.createCopyAddr(pai->getLoc(), arg, tmp, IsTake_t::IsNotTake,
                              IsInitialization_t::IsInitialization);
     }

--- a/test/DebugInfo/ErrorVar.swift
+++ b/test/DebugInfo/ErrorVar.swift
@@ -17,10 +17,8 @@ func simple(_ placeholder: Int64) throws -> () {
   // CHECK-SAME: %swift.error** noalias nocapture dereferenceable(4)
   // CHECK: call void @llvm.dbg.declare
   // CHECK: call void @llvm.dbg.declare({{.*}}, metadata ![[ERROR:[0-9]+]], metadata !DIExpression(DW_OP_deref))
-  // CHECK: ![[ERRTY:.*]] = !DICompositeType({{.*}}identifier: "$ss5Error_pD"
-  // CHECK: ![[ERROR]] = !DILocalVariable(name: "$error", arg: 2,
-  // CHECK-SAME:                          type: ![[ERRTY]],
-  // CHECK-SAME:                          flags: DIFlagArtificial)
+  // CHECK-DAG: ![[ERRTY:.*]] = !DICompositeType({{.*}}identifier: "$ss5Error_pD"
+  // CHECK-DAG: ![[ERROR]] = !DILocalVariable(name: "$error", arg: 2, {{.*}}, type: ![[ERRTY]], flags: DIFlagArtificial)
   throw MyError.Simple
 }
 

--- a/test/DebugInfo/Errors.swift
+++ b/test/DebugInfo/Errors.swift
@@ -4,9 +4,8 @@ public enum E : Error { case Err }
 // Function throws.
 public func throwError() throws { throw E.Err }
 // CHECK: !DISubprogram(name: "throwError", {{.*}}thrownTypes: ![[THROWN:.*]])
-// CHECK: ![[THROWN]] = !{![[ERROR:[0-9]+]]}
-// CHECK: ![[ERROR]] = !DICompositeType(tag: DW_TAG_structure_type,
-// CHECK-SAME:                          name: "Error"
+// CHECK-DAG: ![[THROWN]] = !{![[ERROR:[0-9]+]]}
+// CHECK-DAG: ![[ERROR]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Error"
 
 
 // Function rethrows.

--- a/test/DebugInfo/anonymous.swift
+++ b/test/DebugInfo/anonymous.swift
@@ -1,5 +1,10 @@
+// RUN: %target-swift-frontend %s -emit-sil -g -o - | %FileCheck --check-prefix=SIL %s
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o - | %FileCheck %s
 
+// SIL: debug_value %1 : $*T, let, name "_0", argno 1, expr op_deref
+// SIL: debug_value %2 : $*T, let, name "_1", argno 2, expr op_deref
+// SIL: debug_value %3 : $*T, let, name "_2", argno 3, expr op_deref
+// SIL: debug_value %4 : $*T, let, name "x4", argno 4, expr op_deref
 // CHECK: !DILocalVariable(name: "_0", arg: 1
 // CHECK: !DILocalVariable(name: "_1", arg: 2
 // CHECK: !DILocalVariable(name: "_2", arg: 3

--- a/test/DebugInfo/async-let-await.swift
+++ b/test/DebugInfo/async-let-await.swift
@@ -11,7 +11,7 @@ public func getVegetables() async -> [String] {
 public func chopVegetables() async throws -> [String] {
   let veggies = await getVegetables()
   // CHECK-NOT: {{^define }}
-  // CHECK:  call void @llvm.dbg.declare(metadata i8* %0, metadata ![[V:[0-9]+]], metadata !DIExpression(
+  // CHECK:  call void @llvm.dbg.declare(metadata i8* %0, metadata ![[V:[0-9]+]], metadata !DIExpression(DW_OP_deref, DW_OP_plus_uconst, {{[0-9]+}}, DW_OP_plus_uconst, {{[0-9]+}})
   // CHECK: ![[V]] = !DILocalVariable(name: "veggies"
   return veggies.map { "chopped \($0)" }
 }

--- a/test/DebugInfo/async-local-var.swift
+++ b/test/DebugInfo/async-local-var.swift
@@ -16,7 +16,7 @@ public func makeDinner() async throws -> String {
 // CHECK-LABEL: define {{.*}} void @"$s1a10makeDinnerSSyYaKFTQ0_"
 // CHECK-NEXT: entryresume.0:
 // CHECK-NOT: {{ ret }}
-// CHECK: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[LOCAL:[0-9]+]], {{.*}}!DIExpression(DW_OP_deref, DW_OP_plus_uconst
+// CHECK: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[LOCAL:[0-9]+]], {{.*}}!DIExpression(DW_OP_deref, DW_OP_plus_uconst, {{[0-9]+}})
 // CHECK: ![[LOCAL]] = !DILocalVariable(name: "local"
   return local
 }

--- a/test/DebugInfo/inout.swift
+++ b/test/DebugInfo/inout.swift
@@ -18,9 +18,8 @@ typealias MyFloat = Float
 // PROMO-CHECK: call void @llvm.dbg.declare(metadata %Ts5Int64V** %
 // PROMO-CHECK-SAME:   metadata ![[A1:[0-9]+]], metadata !DIExpression(DW_OP_deref))
 
-// PROMO-CHECK-DAG: ![[INT:.*]] = !DICompositeType({{.*}}identifier: "$ss5Int64VD"
-// PROMO-CHECK: ![[A1]] = !DILocalVariable(name: "a", arg: 1
-// PROMO-CHECK-SAME:                       type: ![[INT]]
+// PROMO-CHECK: ![[INT:.*]] = !DICompositeType({{.*}}identifier: "$ss5Int64VD"
+// PROMO-CHECK: ![[A1]] = !DILocalVariable(name: "a", arg: 1,{{.*}} type: ![[INT]]
 func modifyFooHeap(_ a: inout Int64,
   // CHECK-DAG: ![[A]] = !DILocalVariable(name: "a", arg: 1{{.*}} line: [[@LINE-1]],{{.*}} type: ![[RINT:[0-9]+]]
   // CHECK-DAG: ![[RINT]] = !DICompositeType({{.*}}identifier: "$ss5Int64VD"

--- a/test/Inputs/conditional_conformance_basic_conformances_future.swift
+++ b/test/Inputs/conditional_conformance_basic_conformances_future.swift
@@ -311,7 +311,7 @@ public func double_generic_concrete<X: P2>(_: X.Type) {
 // CHECK-SAME:        @"$s42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlMc" 
 // CHECK-SAME:        to %swift.protocol_conformance_descriptor*
 // CHECK-SAME:      ), 
-// CHECK-SAME:      %swift.type* %2, 
+// CHECK-SAME:      %swift.type* %3,
 // CHECK-SAME:      i8*** [[CONDITIONAL_REQUIREMENTS]]
 // CHECK-SAME:    )
 


### PR DESCRIPTION
Later stages use the name to disambiguate variables and this amgiguity can lead to incorrect debug info that crashes LLVM. This also makes the artificial variable names visible in textual SIL output.
    
rdar://82313550