### PR TITLE
[Driver] Define the feature flag library-level

### DIFF
--- a/lib/Option/features.json
+++ b/lib/Option/features.json
@@ -8,6 +8,9 @@
     },
     {
       "name": "index-unit-output-path"
+    },
+    {
+      "name": "library-level"
     }
   ]
 }


### PR DESCRIPTION
Set the feature flag `library-level` to indicate the availability of the `-library-level` flag in the compiler and driver. As the driver isn't in perfect sync with the compiler let's integrating this flag late to be safe.

rdar://82742547