### PR TITLE
[ConstraintSystem] Fix a bogus missing function call error message.

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2641,6 +2641,12 @@ void ContextualFailure::tryFixIts(InFlightDiagnostic &diagnostic) const {
 }
 
 bool ContextualFailure::diagnoseMissingFunctionCall() const {
+  // Don't suggest inserting a function call if the function expression
+  // isn't written explicitly in the source code.
+  auto *anchor = getAsExpr(simplifyLocatorToAnchor(getLocator()));
+  if (!anchor || anchor->isImplicit())
+    return false;
+
   if (getLocator()
       ->isLastElement<LocatorPathElt::UnresolvedMemberChainResult>())
     return false;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -633,10 +633,6 @@ public:
   /// Diagnose failed conversion in a `CoerceExpr`.
   bool diagnoseCoercionToUnrelatedType() const;
 
-  /// If we're trying to convert something of type "() -> T" to T,
-  /// then we probably meant to call the value.
-  bool diagnoseMissingFunctionCall() const;
-
   /// Diagnose cases where a pattern tried to match associated values but
   /// the enum case had none.
   bool diagnoseExtraneousAssociatedValues() const;
@@ -686,10 +682,6 @@ private:
   Type resolve(Type rawType) const {
     return resolveType(rawType)->getWithoutSpecifierType();
   }
-
-  /// Try to add a fix-it to convert a stored property into a computed
-  /// property
-  void tryComputedPropertyFixIts() const;
 
   bool isIntegerType(Type type) const {
     return conformsToKnownProtocol(
@@ -1050,6 +1042,10 @@ public:
 };
 
 class MissingCallFailure final : public FailureDiagnostic {
+  /// Try to add a fix-it to convert a stored property into a computed
+  /// property
+  void tryComputedPropertyFixIts() const;
+
 public:
   MissingCallFailure(const Solution &solution, ConstraintLocator *locator)
       : FailureDiagnostic(solution, locator) {}
@@ -1958,6 +1954,15 @@ public:
   /// result value.
   bool diagnoseKeyPathAsFunctionResultMismatch() const;
 
+  /// Situations like this:
+  ///
+  /// func foo(_: Int, _: String) {}
+  /// foo("")
+  ///
+  /// Are currently impossible to fix correctly,
+  /// so we have to attend to that in diagnostics.
+  bool diagnoseMisplacedMissingArgument() const;
+
 protected:
   /// \returns The position of the argument being diagnosed, starting at 1.
   unsigned getArgPosition() const { return Info.getArgPosition(); }
@@ -2042,15 +2047,6 @@ protected:
   ParameterTypeFlags getParameterFlagsAtIndex(unsigned idx) const {
     return Info.getParameterFlagsAtIndex(idx);
   }
-
-  /// Situations like this:
-  ///
-  /// func foo(_: Int, _: String) {}
-  /// foo("")
-  ///
-  /// Are currently impossible to fix correctly,
-  /// so we have to attend to that in diagnostics.
-  bool diagnoseMisplacedMissingArgument() const;
 };
 
 /// Replace a coercion ('as') with a runtime checked cast ('as!' or 'as?').

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -637,6 +637,10 @@ public:
   /// then we probably meant to call the value.
   bool diagnoseMissingFunctionCall() const;
 
+  /// Diagnose cases where a pattern tried to match associated values but
+  /// the enum case had none.
+  bool diagnoseExtraneousAssociatedValues() const;
+
   /// Produce a specialized diagnostic if this is an invalid conversion to Bool.
   bool diagnoseConversionToBool() const;
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3657,15 +3657,17 @@ bool ConstraintSystem::repairFailures(
     if (!fnType)
       return false;
 
+    // If the locator isn't anchored at an expression, or the expression is
+    // implicit, don't try to insert an explicit call into the source code.
+    auto *loc = getConstraintLocator(locator);
+    auto *anchor = getAsExpr(simplifyLocatorToAnchor(loc));
+    if (!anchor || anchor->isImplicit())
+      return false;
+
     // If argument is a function type and all of its parameters have
     // default values, let's see whether error is related to missing
     // explicit call.
     if (fnType->getNumParams() > 0) {
-      auto *loc = getConstraintLocator(locator);
-      auto *anchor = getAsExpr(simplifyLocatorToAnchor(loc));
-      if (!anchor)
-        return false;
-
       auto overload = findSelectedOverloadFor(anchor);
       if (!(overload && overload->choice.isDecl()))
         return false;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4327,6 +4327,12 @@ void constraints::simplifyLocator(ASTNode &anchor,
         continue;
       }
 
+      // If the anchor is an unapplied decl ref, there's nothing to extract.
+      if (isExpr<DeclRefExpr>(anchor) || isExpr<OverloadedDeclRefExpr>(anchor)) {
+        path = path.slice(1);
+        continue;
+      }
+
       break;
 
     case ConstraintLocator::AutoclosureResult:

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1011,6 +1011,17 @@ struct SR_10899_Usage {
   @SR_10899_Wrapper var thing: Bool // expected-error{{property type 'Bool' does not match 'wrappedValue' type 'String'}}
 }
 
+// https://bugs.swift.org/browse/SR-14730
+@propertyWrapper
+struct StringWrappedValue {
+  var wrappedValue: String
+}
+
+struct SR_14730 {
+  // expected-error@+1 {{property type '() -> String' does not match 'wrappedValue' type 'String'}}
+  @StringWrappedValue var value: () -> String
+}
+
 // SR-11061 / rdar://problem/52593304 assertion with DeclContext mismatches
 class SomeValue {
 	@SomeA(closure: { $0 }) var some: Int = 100

--- a/test/type/types.swift
+++ b/test/type/types.swift
@@ -16,7 +16,7 @@ var d2 : () -> Int = { 4 }
 
 var d3 : () -> Float = { 4 }
 
-var d4 : () -> Int = { d2 }  // expected-error{{function produces expected type 'Int'; did you mean to call it with '()'?}} {{26-26=()}}
+var d4 : () -> Int = { d2 }  // expected-error{{function 'd2' was used as a property; add () to call it}} {{26-26=()}}
 
 if #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) {
   var e0 : [Int]


### PR DESCRIPTION
If there is no function expression written in the source code, telling the user to insert an explicit function call is really misleading. This can happen when attempting to match the type of a property with attached property wrapper against the `wrappedValue` type:

```swift
@propertyWrapper
struct StringWrappedValue {
  var wrappedValue: String
}

struct SR_14730 {
  @StringWrappedValue var value: () -> String
}
```

Previously, the constraint system attempted to diagnose a missing function call because the result of the function type `() -> String` matches the wrapped-value type `String`, but this isn't the right fix because there's no expression written in the code to actually call (not to mention the diagnostics code not knowing how to handle this case and crashing!).

Resolves: rdar://79051798 / [SR-14730](https://bugs.swift.org/browse/SR-14730)