### PR TITLE
[5.5] ABIChecker: don't fail when hitting EnumCaseDecl

### DIFF
--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -1797,12 +1797,17 @@ SwiftDeclCollector::addMembersToRoot(SDKNode *Root, IterableDeclContext *Context
       Root->addChild(constructSubscriptDeclNode(SD));
     } else if (isa<PatternBindingDecl>(Member)) {
       // All containing variables should have been handled.
+    } else if (isa<EnumCaseDecl>(Member)) {
+      // All containing variables should have been handled.
+    } else if (isa<IfConfigDecl>(Member)) {
+      // All containing members should have been handled.
     } else if (isa<DestructorDecl>(Member)) {
       // deinit has no impact.
     } else if (isa<MissingMemberDecl>(Member)) {
       // avoid adding MissingMemberDecl
     } else {
-      llvm_unreachable("unhandled member decl kind.");
+      llvm::errs() << "Unhandled decl:\n";
+      Member->dump(llvm::errs());
     }
   }
 }

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -2165,7 +2165,9 @@ static parseJsonEmit(SDKContext &Ctx, StringRef FileName) {
 
   // Load the input file.
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
-    vfs::getFileOrSTDIN(*Ctx.getSourceMgr().getFileSystem(), FileName);
+    vfs::getFileOrSTDIN(*Ctx.getSourceMgr().getFileSystem(), FileName,
+                        /*FileSize*/-1, /*RequiresNullTerminator*/true,
+                        /*IsVolatile*/false, /*RetryCount*/30);
   if (!FileBufOrErr) {
     llvm_unreachable("Failed to read JSON file");
   }

--- a/test/ModuleInterface/emit-abi-descriptor.swift
+++ b/test/ModuleInterface/emit-abi-descriptor.swift
@@ -2,6 +2,7 @@
 // RUN: %empty-directory(%t/Foo.swiftmodule)
 // RUN: %empty-directory(%t/ResourceDir/%target-sdk-name/prebuilt-modules/Foo.swiftmodule)
 // RUN: echo "public func foo() {}" > %t/Foo.swift
+// RUN: echo "public enum DisplayStyle { case tuple, optional, collection }" > %t/Foo.swift
 
 // RUN: %target-swift-frontend -emit-module %t/Foo.swift -module-name Foo -emit-module-interface-path %t/Foo.swiftinterface
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Foo.swiftinterface -o %t/Foo.swiftmodule -module-name Foo -emit-abi-descriptor-path %t/Foo.json


### PR DESCRIPTION
All enum elements should have been handled separately so we don't need to anything special
for EnumCaseDecl except consuming them.
