### PR TITLE
Fix MemoryLifetimeVerifier for enums with empty/non-uniform element types

### DIFF
--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -650,3 +650,60 @@ bb0(%0 : $Int, %1 : @guaranteed $@callee_guaranteed (@in_guaranteed (Int, ((), (
   dealloc_stack %2 : $*(Int, ((), ()))
   return %5 : $Int
 }
+
+enum Result<T1, T2>{
+  case success(T1)
+  case failure(T2)
+}
+
+sil @try_get_error : $@convention(thin) () -> @error Error
+
+sil [ossa] @test_init_enum_empty_case : $@convention(thin) () -> @error Error {
+bb0:
+  %0 = alloc_stack $Result<(), Error>
+  %1 = function_ref @try_get_error : $@convention(thin) () -> @error Error
+  try_apply %1() : $@convention(thin) () -> @error Error, normal bb1, error bb2
+
+bb1(%3 : $()):
+  inject_enum_addr %0 : $*Result<(), Error>, #Result.success!enumelt
+  br bb3
+
+bb2(%6 : @owned $Error):
+  %7 = init_enum_data_addr %0 : $*Result<(), Error>, #Result.failure!enumelt
+  store %6 to [init] %7 : $*Error
+  inject_enum_addr %0 : $*Result<(), Error>, #Result.failure!enumelt
+  br bb3
+
+bb3:
+  %11 = load [take] %0 : $*Result<(), Error>
+  destroy_value %11 : $Result<(), Error>
+  dealloc_stack %0 : $*Result<(), Error>
+  %14 = tuple ()
+  return %14 : $()
+}
+
+sil [ossa] @test_init_enum_trivial_case : $@convention(thin) () -> @error Error {
+bb0:
+  %0 = alloc_stack $Result<Int, Error>
+  %1 = function_ref @try_get_error : $@convention(thin) () -> @error Error
+  try_apply %1() : $@convention(thin) () -> @error Error, normal bb1, error bb2
+
+bb1(%3 : $()):
+  inject_enum_addr %0 : $*Result<Int, Error>, #Result.success!enumelt
+  br bb3
+
+
+bb2(%7 : @owned $Error):
+  %8 = init_enum_data_addr %0 : $*Result<Int, Error>, #Result.failure!enumelt
+  store %7 to [init] %8 : $*Error
+  inject_enum_addr %0 : $*Result<Int, Error>, #Result.failure!enumelt
+  br bb3
+
+bb3:
+  %12 = load [take] %0 : $*Result<Int, Error>
+  destroy_value %12 : $Result<Int, Error>
+  dealloc_stack %0 : $*Result<Int, Error>
+  %15 = tuple ()
+  return %15 : $()
+}
+


### PR DESCRIPTION
MemoryLifetimeVerifier currently does not do further analysis when it sees
an empty element type or a non-uniform element type.
But this behaviour is not the same when such element types only have
an inject_enum_addr without an init_enum_data_addr.
This PR makes this behaviour consistent.