### PR TITLE
Sema: Improved recovery from circular generic signature construction

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2430,6 +2430,10 @@ ERROR(requires_generic_param_made_equal_to_concrete,none,
       (Type))
 ERROR(recursive_decl_reference,none,
       "%0 %1 references itself", (DescriptiveDeclKind, DeclBaseName))
+ERROR(recursive_generic_signature,none,
+      "%0 %1 has self-referential generic requirements", (DescriptiveDeclKind, DeclBaseName))
+ERROR(recursive_generic_signature_extension,none,
+      "extension of %0 %1 has self-referential generic requirements", (DescriptiveDeclKind, DeclBaseName))
 ERROR(recursive_same_type_constraint,none,
       "same-type constraint %0 == %1 is recursive", (Type, Type))
 ERROR(recursive_superclass_constraint,none,

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1491,6 +1491,8 @@ public:
   bool isCached() const { return true; }
   Optional<GenericSignature> getCachedResult() const;
   void cacheResult(GenericSignature value) const;
+
+  void diagnoseCycle(DiagnosticEngine &diags) const;
 };
 
 /// Compute the underlying interface type of a typealias.

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -139,7 +139,7 @@ void DeclContext::forEachGenericContext(
         if (auto *gpList = genericCtx->getGenericParams())
           fn(gpList);
     }
-  } while ((dc = dc->getParent()));
+  } while ((dc = dc->getParentForLookup()));
 }
 
 unsigned DeclContext::getGenericContextDepth() const {

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3906,11 +3906,18 @@ bool GenericSignatureBuilder::addGenericParameterRequirements(
 void GenericSignatureBuilder::addGenericParameter(GenericTypeParamType *GenericParam) {
   auto params = getGenericParams();
   (void)params;
-  assert(params.empty() ||
-         ((GenericParam->getDepth() == params.back()->getDepth() &&
-           GenericParam->getIndex() == params.back()->getIndex() + 1) ||
-          (GenericParam->getDepth() > params.back()->getDepth() &&
-           GenericParam->getIndex() == 0)));
+
+#ifndef NDEBUG
+  if (params.empty()) {
+    assert(GenericParam->getDepth() == 0);
+    assert(GenericParam->getIndex() == 0);
+  } else {
+    assert((GenericParam->getDepth() == params.back()->getDepth() &&
+            GenericParam->getIndex() == params.back()->getIndex() + 1) ||
+           (GenericParam->getDepth() > params.back()->getDepth() &&
+            GenericParam->getIndex() == 0));
+  }
+#endif
 
   // Create a potential archetype for this type parameter.
   auto PA = new (Impl->Allocator) PotentialArchetype(GenericParam);

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -738,6 +738,22 @@ void GenericSignatureRequest::cacheResult(GenericSignature value) const {
   GC->GenericSigAndBit.setPointerAndInt(value, true);
 }
 
+void GenericSignatureRequest::diagnoseCycle(DiagnosticEngine &diags) const {
+  auto *GC = std::get<0>(getStorage());
+  auto *D = GC->getAsDecl();
+
+  if (auto *VD = dyn_cast<ValueDecl>(D)) {
+    VD->diagnose(diag::recursive_generic_signature,
+                 VD->getDescriptiveKind(), VD->getBaseName());
+  } else {
+    auto *ED = cast<ExtensionDecl>(D);
+    auto *NTD = ED->getExtendedNominal();
+
+    ED->diagnose(diag::recursive_generic_signature_extension,
+                 NTD->getDescriptiveKind(), NTD->getName());
+  }
+}
+
 //----------------------------------------------------------------------------//
 // InferredGenericSignatureRequest computation.
 //----------------------------------------------------------------------------//

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -597,7 +597,7 @@ static Type formExtensionInterfaceType(
   if (!nominal->isGeneric() || isa<ProtocolDecl>(nominal)) {
     resultType = NominalType::get(nominal, parentType,
                                   nominal->getASTContext());
-  } else {
+  } else if (genericParams) {
     auto currentBoundType = type->getAs<BoundGenericType>();
 
     // Form the bound generic type with the type parameters provided.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -590,8 +590,6 @@ bool TypeChecker::checkContextualRequirements(GenericTypeDecl *decl,
     return true;
   }
 
-  auto &ctx = dc->getASTContext();
-
   SourceLoc noteLoc;
   {
     // We are interested in either a contextual where clause or
@@ -610,14 +608,6 @@ bool TypeChecker::checkContextualRequirements(GenericTypeDecl *decl,
 
   const auto subMap = parentTy->getContextSubstitutions(decl->getDeclContext());
   const auto genericSig = decl->getGenericSignature();
-  if (!genericSig) {
-    if (loc.isValid()) {
-      ctx.Diags.diagnose(loc, diag::recursive_decl_reference,
-                         decl->getDescriptiveKind(), decl->getName());
-      decl->diagnose(diag::kind_declared_here, DescriptiveDeclKind::Type);
-    }
-    return false;
-  }
 
   const auto result =
     TypeChecker::checkGenericArguments(
@@ -763,14 +753,6 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
         return BoundGenericType::get(nominal, /*parent*/ Type(), objectType);
       }
     }  
-  }
-
-  // FIXME: More principled handling of circularity.
-  if (!decl->getGenericSignature()) {
-    diags.diagnose(loc, diag::recursive_decl_reference,
-                   decl->getDescriptiveKind(), decl->getName());
-    decl->diagnose(diag::kind_declared_here, DescriptiveDeclKind::Type);
-    return ErrorType::get(ctx);
   }
 
   // Resolve the types of the generic arguments.

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -228,9 +228,9 @@ var y: X5<X4, Int> // expected-error{{'X5' requires the types 'X4.AssocP' (aka '
 // Recursive generic signature validation.
 class Top {}
 class Bottom<T : Bottom<Top>> {}
-// expected-error@-1 {{generic class 'Bottom' references itself}}
-// expected-note@-2 {{type declared here}}
-// expected-error@-3 {{circular reference}}
+// expected-error@-1 {{'Bottom' requires that 'Top' inherit from 'Bottom<Top>'}}
+// expected-note@-2 {{requirement specified as 'T' : 'Bottom<Top>' [with T = Top]}}
+// expected-error@-3 {{generic class 'Bottom' has self-referential generic requirements}}
 // expected-note@-4 {{while resolving type 'Bottom<Top>'}}
 // expected-note@-5 {{through reference here}}
 

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -43,19 +43,16 @@ public protocol P {
   associatedtype T
 }
 
-public struct S<A: P> where A.T == S<A> { // expected-error {{circular reference}}
-// expected-note@-1 {{type declared here}}
-// expected-error@-2 {{generic struct 'S' references itself}}
-// expected-note@-3 {{while resolving type 'S<A>'}}
+public struct S<A: P> where A.T == S<A> {
+// expected-error@-1 {{generic struct 'S' has self-referential generic requirements}}
+// expected-note@-2 {{while resolving type 'S<A>'}}
   func f(a: A.T) {
     g(a: id(t: a)) // `a` has error type which is diagnosed as circular reference
-    // expected-error@-1 {{conflicting arguments to generic parameter 'T' ('A.T' (associated type of protocol 'P') vs. 'S<A>')}}
     _ = A.T.self
   }
 
   func g(a: S<A>) {
     f(a: id(t: a))
-    // expected-error@-1 {{conflicting arguments to generic parameter 'T' ('S<A>' vs. 'A.T' (associated type of protocol 'P'))}}
     _ = S<A>.self
   }
 
@@ -72,10 +69,9 @@ protocol PI {
   associatedtype T : I
 }
 
-struct SI<A: PI> : I where A : I, A.T == SI<A> { // expected-error {{circular reference}}
-// expected-note@-1 {{type declared here}}
-// expected-error@-2 {{generic struct 'SI' references itself}}
-// expected-note@-3 {{while resolving type 'SI<A>'}}
+struct SI<A: PI> : I where A : I, A.T == SI<A> {
+// expected-error@-1 {{generic struct 'SI' has self-referential generic requirements}}
+// expected-note@-2 {{while resolving type 'SI<A>'}}
   func ggg<T : I>(t: T.Type) -> T {
     return T()
   }

--- a/validation-test/compiler_crashers_2_fixed/0161-sr6569.swift
+++ b/validation-test/compiler_crashers_2_fixed/0161-sr6569.swift
@@ -6,14 +6,10 @@ protocol P {
 
 struct Type<Param> {}
 extension Type: P where Param: P, Param.A == Type<Param> {
-  // expected-error@-1 {{circular reference}}
-  // expected-note@-2 {{through reference here}}
-  // expected-error@-3 {{circular reference}}
-  // expected-note@-4 {{through reference here}}
-  // expected-error@-5 {{circular reference}}
-  // expected-note@-6 {{through reference here}}
-  // expected-error@-7 {{type 'Type<Param>' does not conform to protocol 'P'}}
+  // expected-error@-1 5{{extension of generic struct 'Type' has self-referential generic requirements}}
+  // expected-note@-2 5{{through reference here}}
+  // expected-error@-3 {{type 'Type<Param>' does not conform to protocol 'P'}}
   typealias A = Param
-  // expected-note@-1 {{through reference here}}
-  // expected-note@-2 {{through reference here}}
+  // expected-note@-1 2{{through reference here}}
+  // expected-note@-2 {{possibly intended match 'Type<Param>.A' (aka 'Param') does not conform to 'P'}}
 }

--- a/validation-test/compiler_crashers_2_fixed/0163-sr8033.swift
+++ b/validation-test/compiler_crashers_2_fixed/0163-sr8033.swift
@@ -5,7 +5,8 @@ struct Foo<T> {}
 protocol P1 {
     associatedtype A // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
 }
-extension Foo: P1 where A : P1 {} // expected-error {{circular reference}}
-// expected-note@-1 {{while resolving type 'A'}}
-// expected-note@-2 {{through reference here}}
-// expected-error@-3 {{type 'Foo<T>' does not conform to protocol 'P1'}}
+extension Foo: P1 where A : P1 {}
+// expected-error@-1 {{extension of generic struct 'Foo' has self-referential generic requirements}}
+// expected-note@-2 {{while resolving type 'A'}}
+// expected-note@-3 {{through reference here}}
+// expected-error@-4 {{type 'Foo<T>' does not conform to protocol 'P1'}}


### PR DESCRIPTION
Returning a null GenericSignature is not the right way to break a cycle,
because then callers have to be careful to handle the case of a null
GenericSignature together with a non-null GenericParamList, for example
in applyGenericArguments().

An even worse problem can occur when a GenericSignatureRequest for a
nested generic declaration requests the signature of the parent context,
which hits a cycle. In this case, we would build a signature where
the first generic parameter did not have depth 0.

This makes the requirement machine upset, so this patch implements a new
strategy to break such cycles. Instead of returning a null
GenericSignature, we build a signature with the correct generic
parameters, but no requirements. The generic parameters can be computed
just by traversing GenericParamLists, which does not trigger more
GenericSignatureRequests, so this should be safe.