### PR TITLE
Fix formatting in `update-checkout-config.json`

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -2,9 +2,9 @@
     "ssh-clone-pattern": "git@github.com:%s.git",
     "https-clone-pattern": "https://github.com/%s.git",
     "repos" : {
-       "swift": {
+        "swift": {
             "remote": { "id": "apple/swift" } },
-       "cmark": {
+        "cmark": {
             "remote": { "id": "apple/swift-cmark" } },
         "llbuild": {
             "remote": { "id": "apple/swift-llbuild" } },
@@ -53,7 +53,7 @@
             "remote": { "id": "KitWare/CMake" },
             "platforms": [ "Linux" ]
         },
-       "indexstore-db": {
+        "indexstore-db": {
             "remote": { "id": "apple/indexstore-db" } },
         "sourcekit-lsp": {
             "remote": { "id": "apple/sourcekit-lsp" } },
@@ -84,7 +84,7 @@
     },
     "default-branch-scheme": "main",
     "branch-schemes": {
-       "main": {
+        "main": {
             "aliases": ["swift/main", "main", "stable/20211026"],
             "repos": {
                 "llvm-project": "stable/20211026",
@@ -201,7 +201,7 @@
                 "swift-nio-ssl": "2.15.0"
             }
         },
-       "release/5.5": {
+        "release/5.5": {
             "aliases": ["release/5.5", "swift/release/5.5"],
             "repos": {
                 "llvm-project": "swift/release/5.5",


### PR DESCRIPTION
3-spaces formatting is inconsistently used for some keys instead of 4 spaces. This change makes the formatting consistent in `update-checkout-config.json`.

