### PR TITLE
C++ Interop: import caret operators

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1721,6 +1721,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     case clang::OverloadedOperatorKind::OO_Star:
     case clang::OverloadedOperatorKind::OO_Slash:
     case clang::OverloadedOperatorKind::OO_Percent:
+    case clang::OverloadedOperatorKind::OO_Caret:
     case clang::OverloadedOperatorKind::OO_Amp:
     case clang::OverloadedOperatorKind::OO_Pipe:
     case clang::OverloadedOperatorKind::OO_Less:

--- a/test/Interop/Cxx/operators/Inputs/non-member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/non-member-inline.h
@@ -25,6 +25,10 @@ inline LoadableIntWrapper operator%(LoadableIntWrapper lhs, LoadableIntWrapper r
   return LoadableIntWrapper{.value = lhs.value % rhs.value};
 }
 
+inline LoadableIntWrapper operator^(LoadableIntWrapper lhs, LoadableIntWrapper rhs) {
+  return LoadableIntWrapper{.value = lhs.value ^ rhs.value};
+}
+
 inline LoadableIntWrapper operator&(LoadableIntWrapper lhs, LoadableIntWrapper rhs) {
   return LoadableIntWrapper{.value = lhs.value & rhs.value};
 }

--- a/test/Interop/Cxx/operators/non-member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-module-interface.swift
@@ -5,6 +5,7 @@
 // CHECK-NEXT: func * (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
 // CHECK-NEXT: func / (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
 // CHECK-NEXT: func % (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
+// CHECK-NEXT: func ^ (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
 // CHECK-NEXT: func & (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
 // CHECK-NEXT: func | (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
 // CHECK-NEXT: func << (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper

--- a/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
@@ -10,6 +10,7 @@ let resultMinus = lhs - rhs
 let resultStar = lhs * rhs
 let resultSlash = lhs / rhs
 let resultPercent = lhs % rhs
+let resultCaret = lhs ^ rhs
 let resultAmp = lhs & rhs
 let resultPipe = lhs | rhs
 let resultLessLess = lhs << rhs

--- a/test/Interop/Cxx/operators/non-member-inline.swift
+++ b/test/Interop/Cxx/operators/non-member-inline.swift
@@ -43,6 +43,15 @@ OperatorsTestSuite.test("slash (/)") {
   expectEqual(1, result.value)
 }
 
+OperatorsTestSuite.test("caret (^)") {
+  let lhs = LoadableIntWrapper(value: 42)
+  let rhs = LoadableIntWrapper(value: 23)
+
+  let result = lhs ^ rhs
+
+  expectEqual(61, result.value)
+}
+
 OperatorsTestSuite.test("percent (%)") {
   let lhs = LoadableIntWrapper(value: 11)
   let rhs = LoadableIntWrapper(value: 2)


### PR DESCRIPTION
This change makes it possible to call `operator^` from Swift.
It works exactly the same way as for all the other arithmetic operators.