### PR TITLE
Shims: remove last remnant of Windows ARM64 workaround

### DIFF
--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -1610,19 +1610,6 @@ static_assert(sizeof(InlineRefCounts) == sizeof(__swift_uintptr_t),
 static_assert(__alignof(InlineRefCounts) == __alignof(__swift_uintptr_t),
               "InlineRefCounts must be pointer-aligned");
 
-#if defined(_WIN32) && defined(_M_ARM64)
-#if defined(__cplusplus)
-namespace std {
-template <>
-inline void _Atomic_storage<swift::SideTableRefCountBits, 16>::_Unlock() const noexcept {
-  __dmb(0x8);
-  __iso_volatile_store32(&reinterpret_cast<volatile int &>(_Spinlock), 0);
-  __dmb(0x8);
-}
-}
-#endif
-#endif
-
 #endif // !defined(__swift__)
 
 #endif


### PR DESCRIPTION
The Windows ARM64 builds can require a newer build of VS2019 (update 3
or newer).  This removes the workaround from the shims.  This was needed
for older installations of Visual Studio and no longer works with Visual
Studio 2022.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
