### PR TITLE
[Preset] Add linux crosscompile wasm preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1179,6 +1179,15 @@ mixin-preset=buildbot_incremental_linux,long_test
 indexstore-db=0
 sourcekit-lsp=0
 
+# TODO: This does not build stdlib for wasm32 for now.
+# Enable stdlib cross-compile after build-script will support it.
+[preset: buildbot_incremental_linux_crosscompile_wasm]
+mixin-preset=buildbot_incremental_linux_base
+llvm-targets-to-build=X86;ARM;AArch64;WebAssembly
+# Ensure single-thread-mode is not broken because it's used
+# by stdlib for wasm32 in SwiftWasm fork.
+swift-stdlib-single-threaded-runtime=1
+
 #===------------------------------------------------------------------------===#
 # OS X Package Builders
 #===------------------------------------------------------------------------===#


### PR DESCRIPTION
This preset will be used by community CI for WebAssembly to ensure [single-threaded-runtime mode won't be broken again](https://github.com/apple/swift/pull/39092#issuecomment-908992354) and enable us testing IRGen for WebAssembly in upstream.

Note that the current preset doesn't build stdlib for Wasm for now because some essential patches haven't been ported yet and build-script doesn't support it. But that should be enabled after their supports.

CC: @MaxDesiatov, @shahmishal 

This change is a part of SR-15168.