### PR TITLE
Make it clear that arr[n] panics rather than throws

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -697,7 +697,8 @@ extension Array: RandomAccessCollection, MutableCollection {
     // NOTE: This method is a no-op for performance reasons.
   }
 
-  /// Accesses the element at the specified position.
+  /// Accesses the element at the specified position and panics with a
+  /// fatal error if the index is out of range.
   ///
   /// The following example uses indexed subscripting to update an array's
   /// second element. After assigning the new value (`"Butler"`) at a specific

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -507,7 +507,8 @@ extension ArraySlice: RandomAccessCollection, MutableCollection {
     // NOTE: This method is a no-op for performance reasons.
   }
 
-  /// Accesses the element at the specified position.
+  /// Accesses the element at the specified position and panics with a
+  /// fatal error if the index is out of range.
   ///
   /// The following example uses indexed subscripting to update an array's
   /// second element. After assigning the new value (`"Butler"`) at a specific

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -382,7 +382,8 @@ extension ContiguousArray: RandomAccessCollection, MutableCollection {
     // NOTE: This method is a no-op for performance reasons.
   }
 
-  /// Accesses the element at the specified position.
+  /// Accesses the element at the specified position and panics with a
+  /// fatal error if the index is out of range.
   ///
   /// The following example uses indexed subscripting to update an array's
   /// second element. After assigning the new value (`"Butler"`) at a specific

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -65,7 +65,8 @@ where SubSequence: MutableCollection
   override associatedtype Index
   override associatedtype SubSequence
 
-  /// Accesses the element at the specified position.
+  /// Accesses the element at the specified position and panics with a
+  /// fatal error if the index is out of range.
   ///
   /// For example, you can replace an element of an array by using its
   /// subscript.


### PR DESCRIPTION
<!-- What's in this pull request? -->
I've always thought that the documentation for subscripts of arr where an index is received should mention that the code panics if the index is out of bounds.

This PR is inspired by the Rust documentation on `Vec` where in the [indexing section](https://doc.rust-lang.org/std/vec/struct.Vec.html#indexing) it is clearly stated that the code panics if index is out of bounds.

I am not a native English speaker so the wording here could need some polishing!

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Does not resolve a bug, purely a documentation update.