### PR TITLE
test in optimized mode in linux smoke PR testing

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -994,6 +994,7 @@ install-foundation
 install-libdispatch
 reconfigure
 skip-test-lldb
+test-optimized
 
 
 [preset: buildbot_linux_1404_no_lldb]


### PR DESCRIPTION
the regular linux PR testing already did run in optimized mode, but not the linux smoke test
