### PR TITLE
[CSSimplify] Fix a bug where the omitted projected value label was missing as an acceptable parameter label for property wrappers

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2839,6 +2839,23 @@ public:
 
     bool hasInternalLabel() const { return !InternalLabel.empty(); }
     Identifier getInternalLabel() const { return InternalLabel; }
+
+    /// Return true if argument name is valid and matches \c paramName.
+    ///
+    /// The three tests to check if argument name is valid are:
+    /// 1. allow argument if it matches \c paramName,
+    /// 2. allow argument if  $_  for omitted projected value label,
+    /// 3. allow argument if it matches \c paramName without its \c $ prefix.
+    bool matchParameterLabel(Identifier const &paramName) const {
+      auto argLabel = getLabel();
+      if (argLabel == paramName)
+        return true;
+      if ((argLabel.str() == "$_") && paramName.empty())
+        return true;
+      if (argLabel.hasDollarPrefix() && argLabel.str().drop_front() == paramName.str())
+        return true;
+      return false;
+    }
     
     ParameterTypeFlags getParameterFlags() const { return Flags; }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -282,19 +282,19 @@ static bool matchCallArgumentsImpl(
   // requiring further checking at the end.
   bool potentiallyOutOfOrder = false;
 
-  // Local function that claims the argument at \c argNumber, returning the
+  // Local function that claims the argument at \c argIdx, returning the
   // index of the claimed argument. This is primarily a helper for
   // \c claimNextNamed.
-  auto claim = [&](Identifier expectedName, unsigned argNumber,
+  auto claim = [&](Identifier expectedName, unsigned argIdx,
                    bool ignoreNameClash = false)  -> unsigned {
     // Make sure we can claim this argument.
-    assert(argNumber != numArgs && "Must have a valid index to claim");
-    assert(!claimedArgs[argNumber] && "Argument already claimed");
+    assert(argIdx != numArgs && "Must have a valid index to claim");
+    assert(!claimedArgs[argIdx] && "Argument already claimed");
 
-    auto argLabel = args[argNumber].getLabel();
+    auto argLabel = args[argIdx].getLabel();
     if (!actualArgNames.empty()) {
       // We're recording argument names; record this one.
-      actualArgNames[argNumber] = expectedName;
+      actualArgNames[argIdx] = expectedName;
     } else if (argLabel != expectedName && !ignoreNameClash &&
                !(argLabel.str().startswith("$") &&
                  argLabel.str().drop_front() == expectedName.str())) {
@@ -313,12 +313,12 @@ static bool matchCallArgumentsImpl(
       }
 
       // Record this argument name.
-      actualArgNames[argNumber] = expectedName;
+      actualArgNames[argIdx] = expectedName;
     }
 
-    claimedArgs[argNumber] = true;
+    claimedArgs[argIdx] = true;
     ++numClaimedArgs;
-    return argNumber;
+    return argIdx;
   };
 
   // Local function that skips over any claimed arguments.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -340,11 +340,8 @@ static bool matchCallArgumentsImpl(
     // Go hunting for an unclaimed argument whose name does match.
     Optional<unsigned> claimedWithSameName;
     for (unsigned i = nextArgIdx; i != numArgs; ++i) {
-      auto argLabel = args[i].getLabel();
 
-      if (argLabel != paramLabel &&
-          !(argLabel.str().startswith("$") &&
-            argLabel.str().drop_front() == paramLabel.str())) {
+      if (!args[i].matchParameterLabel(paramLabel)) {
         // If this is an attempt to claim additional unlabeled arguments
         // for variadic parameter, we have to stop at first labeled argument.
         if (forVariadic)
@@ -376,7 +373,7 @@ static bool matchCallArgumentsImpl(
         // func foo(_ a: Int, _ b: Int = 0, c: Int = 0, _ d: Int) {}
         // foo(1, c: 2, 3) // -> `3` will be claimed as '_ b:'.
         // ```
-        if (argLabel.empty())
+        if (args[i].getLabel().empty())
           continue;
 
         potentiallyOutOfOrder = true;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -291,13 +291,10 @@ static bool matchCallArgumentsImpl(
     assert(argIdx != numArgs && "Must have a valid index to claim");
     assert(!claimedArgs[argIdx] && "Argument already claimed");
 
-    auto argLabel = args[argIdx].getLabel();
     if (!actualArgNames.empty()) {
       // We're recording argument names; record this one.
       actualArgNames[argIdx] = expectedName;
-    } else if (argLabel != expectedName && !ignoreNameClash &&
-               !(argLabel.str().startswith("$") &&
-                 argLabel.str().drop_front() == expectedName.str())) {
+    } else if (!ignoreNameClash && !args[argIdx].matchParameterLabel(expectedName)) {
       // We have an argument name mismatch. Start recording argument names.
       actualArgNames.resize(numArgs);
 

--- a/test/Sema/property_wrapper_parameter.swift
+++ b/test/Sema/property_wrapper_parameter.swift
@@ -88,6 +88,12 @@ func testClosures() {
   }
 }
 
+func projectionPlaceholder<T>(@Wrapper _ value: T) {}
+
+func testOmittedProjectionLabel(value: Int) {
+    projectionPlaceholder($_: Projection(value: value))
+}
+
 @propertyWrapper
 struct ProjectionWrapper<Value> {
   var wrappedValue: Value


### PR DESCRIPTION
<!-- What's in this pull request? -->
To allow for unnamed property wrapper projected values, the omitted label `$_` needs to be included in the list of valid argument labels for property wrappers. This PR adds the missing label in `Param::matchParameterLabel()`,  includes a test for `$_` as a valid argument label and minor code rewrites to use existing member functions.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-15031.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
