### PR TITLE
[ResultBuilders] Properly diagnose `weak` declarations with non-optional type

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -331,7 +331,10 @@ enum class FixKind : uint8_t {
 
   /// Specify a type for an explicitly written placeholder that could not be
   /// resolved.
-  SpecifyTypeForPlaceholder
+  SpecifyTypeForPlaceholder,
+
+  /// Allow `weak` declarations to be bound to a non-optional type.
+  AllowNonOptionalWeak,
 };
 
 class ConstraintFix {
@@ -2422,6 +2425,21 @@ class AllowInvalidStaticMemberRefOnProtocolMetatype final
 
   static AllowInvalidStaticMemberRefOnProtocolMetatype *
   create(ConstraintSystem &cs, ConstraintLocator *locator);
+};
+
+class AllowNonOptionalWeak final : public ConstraintFix {
+  AllowNonOptionalWeak(ConstraintSystem &cs, ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AllowNonOptionalWeak, locator) {}
+
+public:
+  std::string getName() const override {
+    return "allow `weak` with non-optional type";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static AllowNonOptionalWeak *create(ConstraintSystem &cs,
+                                      ConstraintLocator *locator);
 };
 
 } // end namespace constraints

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7776,3 +7776,27 @@ bool UnsupportedRuntimeCheckedCastFailure::diagnoseAsError() {
       .fixItReplace(getCastRange(), "as");
   return true;
 }
+
+bool InvalidWeakAttributeUse::diagnoseAsError() {
+  auto *pattern =
+      dyn_cast_or_null<NamedPattern>(getAnchor().dyn_cast<Pattern *>());
+  if (!pattern)
+    return false;
+
+  auto *var = pattern->getDecl();
+  auto varType = getType(var);
+
+  auto diagnostic =
+      emitDiagnosticAt(var, diag::invalid_ownership_not_optional,
+                       ReferenceOwnership::Weak, varType);
+
+  auto typeRange = var->getTypeSourceRangeForDiagnostics();
+  if (varType->hasSimpleTypeRepr()) {
+    diagnostic.fixItInsertAfter(typeRange.End, "?");
+  } else {
+    diagnostic.fixItInsert(typeRange.Start, "(")
+        .fixItInsertAfter(typeRange.End, ")?");
+  }
+
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7784,7 +7784,7 @@ bool InvalidWeakAttributeUse::diagnoseAsError() {
     return false;
 
   auto *var = pattern->getDecl();
-  auto varType = getType(var);
+  auto varType = OptionalType::get(getType(var));
 
   auto diagnostic =
       emitDiagnosticAt(var, diag::invalid_ownership_not_optional,

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2589,6 +2589,25 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose situations where `weak` attribute is used with a non-optional type
+/// in declaration e.g. `weak var x: <Type>`:
+///
+/// \code
+/// class X {
+/// }
+///
+/// weak var x: X = ...
+/// \endcode
+///
+/// `weak` declaration is required to use an optional type e.g. `X?`.
+class InvalidWeakAttributeUse final : public FailureDiagnostic {
+public:
+  InvalidWeakAttributeUse(const Solution &solution, ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1992,7 +1992,8 @@ AllowInvalidStaticMemberRefOnProtocolMetatype::create(
 
 bool AllowNonOptionalWeak::diagnose(const Solution &solution,
                                     bool asNote) const {
-  return false;
+  InvalidWeakAttributeUse failure(solution, getLocator());
+  return failure.diagnose(asNote);
 }
 
 AllowNonOptionalWeak *AllowNonOptionalWeak::create(ConstraintSystem &cs,

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1989,3 +1989,13 @@ AllowInvalidStaticMemberRefOnProtocolMetatype::create(
   return new (cs.getAllocator())
       AllowInvalidStaticMemberRefOnProtocolMetatype(cs, locator);
 }
+
+bool AllowNonOptionalWeak::diagnose(const Solution &solution,
+                                    bool asNote) const {
+  return false;
+}
+
+AllowNonOptionalWeak *AllowNonOptionalWeak::create(ConstraintSystem &cs,
+                                                   ConstraintLocator *locator) {
+  return new (cs.getAllocator()) AllowNonOptionalWeak(cs, locator);
+}

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4956,6 +4956,25 @@ bool ConstraintSystem::repairFailures(
           *this, lhs, rhs, getConstraintLocator(locator)));
     }
 
+    // `weak` declaration with an explicit non-optional type e.g.
+    // `weak x: X = ...` where `X` is a class.
+    if (auto *TP = dyn_cast<TypedPattern>(pattern)) {
+      if (auto *NP = dyn_cast<NamedPattern>(TP->getSubPattern())) {
+        auto *var = NP->getDecl();
+
+        auto ROK = ReferenceOwnership::Strong;
+        if (auto *OA = var->getAttrs().getAttribute<ReferenceOwnershipAttr>())
+          ROK = OA->get();
+
+        if (!rhs->getOptionalObjectType() &&
+            optionalityOf(ROK) == ReferenceOwnershipOptionality::Required) {
+          conversionsOrFixes.push_back(
+              AllowNonOptionalWeak::create(*this, getConstraintLocator(NP)));
+          break;
+        }
+      }
+    }
+
     break;
   }
 
@@ -11544,8 +11563,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowInvalidStaticMemberRefOnProtocolMetatype:
   case FixKind::AllowWrappedValueMismatch:
   case FixKind::RemoveExtraneousArguments:
-  case FixKind::SpecifyTypeForPlaceholder:
-  case FixKind::AllowNonOptionalWeak: {
+  case FixKind::SpecifyTypeForPlaceholder: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }
 
@@ -11706,6 +11724,17 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
           increaseScore(SK_Fix);
       }
     }
+
+    return SolutionKind::Solved;
+  }
+
+  case FixKind::AllowNonOptionalWeak: {
+    if (recordFix(fix))
+      return SolutionKind::Error;
+
+    (void)matchTypes(type1, OptionalType::get(type2),
+                     ConstraintKind::Conversion,
+                     TypeMatchFlags::TMF_ApplyingFix, locator);
 
     return SolutionKind::Solved;
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11544,7 +11544,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowInvalidStaticMemberRefOnProtocolMetatype:
   case FixKind::AllowWrappedValueMismatch:
   case FixKind::RemoveExtraneousArguments:
-  case FixKind::SpecifyTypeForPlaceholder: {
+  case FixKind::SpecifyTypeForPlaceholder:
+  case FixKind::AllowNonOptionalWeak: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }
 

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -781,3 +781,19 @@ func test_rdar65667992() {
     }
   }
 }
+
+func test_weak_with_nonoptional_type() {
+  class X {
+    func test() -> Int { 0 }
+  }
+
+  tuplify(true) { c in
+    weak var x: X = X() // expected-error {{'weak' variable should have optional type 'X?'}}
+
+    if let x = x {
+      x.test()
+    }
+
+    42
+  }
+}


### PR DESCRIPTION
Diagnose situations where `weak` attribute is used with a non-optional type
in declaration used in the body of a result builder e.g. `weak var x: <Type>`:

```swift
class X {
}

// some result builder context
weak var x: X = ...
```

`weak` declaration is required to use an optional type e.g. `X?`.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
