### PR TITLE
[Sema][SR-15161] Be more conservative when emit warning for bridge downcast

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6663,6 +6663,13 @@ static ConstraintFix *maybeWarnAboutExtraneousCast(
     return fix;
   }
   if (extraOptionals > 0) {
+    // Conditional cast in this case can be an attempt to just unwrap a nil
+    // value.
+    if (isExpr<ConditionalCheckedCastExpr>(anchor) &&
+        castKind == CheckedCastKind::BridgingCoercion) {
+      return nullptr;
+    }
+
     return AllowCheckedCastCoercibleOptionalType::create(
         cs, origFromType, origToType, castKind,
         cs.getConstraintLocator(locator));

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -394,3 +394,16 @@ func rdar60501780() {
     foo(["": "", "": v as NSString])
   }
 }
+
+// SR-15161
+func SR15161_as(e: Error?) {
+  let _ = e as? NSError // Ok
+}
+
+func SR15161_is(e: Error?) {
+  _ = e is NSError // expected-warning{{checking a value with optional type 'Error?' against dynamic type 'NSError' succeeds whenever the value is non-nil; did you mean to use '!= nil'?}}
+}
+
+func SR15161_as_1(e: Error?) {
+  let _ = e as! NSError // expected-warning{{forced cast from 'Error?' to 'NSError' only unwraps and bridges; did you mean to use '!' with 'as'?}}
+}

--- a/test/Constraints/casts_objc.swift
+++ b/test/Constraints/casts_objc.swift
@@ -55,7 +55,7 @@ func alwaysSucceedingConditionalCasts(f: CGFloat, n: NSNumber) {
 }
 
 func optionalityReducingCasts(f: CGFloat?, n: NSNumber?) {
-  let _ = f as? NSNumber // expected-warning{{conditional downcast from 'CGFloat?' to 'NSNumber' is a bridging conversion; did you mean to use 'as'?}}
+  let _ = f as? NSNumber 
   let _ = f as! NSNumber // expected-warning{{forced cast from 'CGFloat?' to 'NSNumber' only unwraps and bridges; did you mean to use '!' with 'as'?}}
   let _ = n as? CGFloat
   let _ = n as! CGFloat
@@ -71,7 +71,7 @@ func optionalityMatchingCasts(f: CGFloat?, n: NSNumber?) {
 
 func optionalityMatchingCastsIUO(f: CGFloat?!, n: NSNumber?!) {
   let _ = f as NSNumber?
-  let _ = f as? NSNumber? // expected-warning{{conditional downcast from 'CGFloat??' to 'NSNumber?' is a bridging conversion; did you mean to use 'as'?}}
+  let _ = f as? NSNumber?
   let _ = f as! NSNumber? // expected-warning{{forced cast from 'CGFloat??' to 'NSNumber?' only unwraps and bridges; did you mean to use '!' with 'as'?}}
   let _ = n as? CGFloat?
   let _ = n as! CGFloat?

--- a/test/expr/cast/bridged.swift
+++ b/test/expr/cast/bridged.swift
@@ -77,8 +77,8 @@ func testBridgeDowncastSuperclass(_ obj: NSObject, objOpt: NSObject?,
 func testBridgeDowncastExact(_ obj: BridgedClass, objOpt: BridgedClass?,
                              objImplicitOpt: BridgedClass!) -> BridgedStruct? {
   _ = obj as? BridgedStruct // expected-warning{{conditional cast from 'BridgedClass' to 'BridgedStruct' always succeeds}}
-  _ = objOpt as? BridgedStruct // expected-warning{{conditional downcast from 'BridgedClass?' to 'BridgedStruct' is a bridging conversion; did you mean to use 'as'?}}{{14-17=as}}{{31-31=?}}
-  _ = objImplicitOpt as? BridgedStruct // expected-warning{{conditional downcast from 'BridgedClass?' to 'BridgedStruct' is a bridging conversion; did you mean to use 'as'?}}{{22-25=as}}{{39-39=?}}
+  _ = objOpt as? BridgedStruct
+  _ = objImplicitOpt as? BridgedStruct
 
   _ = obj as! BridgedStruct // expected-warning{{forced cast from 'BridgedClass' to 'BridgedStruct' always succeeds; did you mean to use 'as'?}}{{11-14=as}}
   _ = objOpt as! BridgedStruct // expected-warning{{forced cast from 'BridgedClass?' to 'BridgedStruct' only unwraps and bridges; did you mean to use '!' with 'as'?}}{{13-13=!}}{{14-17=as}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Just not emit such warning for conditional downcast when bridging from an optional type. As seen in the example 
```swift
func f(e: Error?) {
  if let _ = e as? NSError { // warning: conditional downcast from 'Error?' to 'NSError' is a bridging conversion; did you mean to use 'as'?
    print("non-nil")
  } else {
    print("nil")
  }
}
enum MyError: Error {
  case fail
}

let nserror = NSError(domain: "domain.com", code: -1, userInfo: nil)

f(e: MyError.fail) // non-nil conditional down cast and bridge
f(e: nserror) // non-nil just conditional down cast 
f(e: nil) // nil
```
this should be valid and a warning is not correct in this case.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-15161.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
