### PR TITLE
[AST] Enforce that TupleExprs and ParenExprs dont have param flags

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3005,12 +3005,7 @@ protected:
 
 public:
   /// Take an array of parameters and turn it into a tuple or paren type.
-  static Type composeTuple(ASTContext &ctx, ArrayRef<Param> params,
-                           bool canonicalVararg);
-  static Type composeTuple(ASTContext &ctx, CanParamArrayRef params,
-                           bool canonicalVararg) {
-    return composeTuple(ctx, params.getOriginalArray(), canonicalVararg);
-  }
+  static Type composeTuple(ASTContext &ctx, ArrayRef<Param> params);
 
   /// Given two arrays of parameters determine if they are equal in their
   /// canonicalized form. Internal labels and type sugar is *not* taken into

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3005,7 +3005,11 @@ protected:
 
 public:
   /// Take an array of parameters and turn it into a tuple or paren type.
-  static Type composeTuple(ASTContext &ctx, ArrayRef<Param> params);
+  ///
+  /// \param wantParamFlags Whether to preserve the parameter flags from the
+  /// given set of parameters.
+  static Type composeTuple(ASTContext &ctx, ArrayRef<Param> params,
+                           bool wantParamFlags = true);
 
   /// Given two arrays of parameters determine if they are equal in their
   /// canonicalized form. Internal labels and type sugar is *not* taken into

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -1519,8 +1519,7 @@ SwiftDeclCollector::constructTypeNode(Type T, TypeInitInfo Info) {
     Root->addChild(constructTypeNode(Fun->getResult()));
 
     auto Input = AnyFunctionType::composeTuple(Fun->getASTContext(),
-                                               Fun->getParams(),
-                                               /*canonicalVararg=*/false);
+                                               Fun->getParams());
     Root->addChild(constructTypeNode(Input));
     return Root;
   }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3456,12 +3456,10 @@ Type AnyFunctionType::Param::getParameterType(bool forCanonical,
   return type;
 }
 
-Type AnyFunctionType::composeTuple(ASTContext &ctx, ArrayRef<Param> params,
-                                   bool canonicalVararg) {
+Type AnyFunctionType::composeTuple(ASTContext &ctx, ArrayRef<Param> params) {
   SmallVector<TupleTypeElt, 4> elements;
   for (const auto &param : params) {
-    Type eltType = param.getParameterType(canonicalVararg, &ctx);
-    elements.emplace_back(eltType, param.getLabel(),
+    elements.emplace_back(param.getParameterType(), param.getLabel(),
                           param.getParameterFlags());
   }
   return TupleType::get(elements, ctx);

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3456,11 +3456,13 @@ Type AnyFunctionType::Param::getParameterType(bool forCanonical,
   return type;
 }
 
-Type AnyFunctionType::composeTuple(ASTContext &ctx, ArrayRef<Param> params) {
+Type AnyFunctionType::composeTuple(ASTContext &ctx, ArrayRef<Param> params,
+                                   bool wantParamFlags) {
   SmallVector<TupleTypeElt, 4> elements;
   for (const auto &param : params) {
-    elements.emplace_back(param.getParameterType(), param.getLabel(),
-                          param.getParameterFlags());
+    auto flags = wantParamFlags ? param.getParameterFlags()
+                                : ParameterTypeFlags();
+    elements.emplace_back(param.getParameterType(), param.getLabel(), flags);
   }
   return TupleType::get(elements, ctx);
 }

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1136,6 +1136,7 @@ public:
     }
 
     void verifyChecked(TupleExpr *E) {
+      PrettyStackTraceExpr debugStack(Ctx, "verifying TupleExpr", E);
       const TupleType *exprTy = E->getType()->castTo<TupleType>();
       for_each(exprTy->getElements().begin(), exprTy->getElements().end(),
                E->getElements().begin(),
@@ -1148,8 +1149,14 @@ public:
           Out << elt->getType() << "\n";
           abort();
         }
+        if (!field.getParameterFlags().isNone()) {
+          Out << "TupleExpr has non-empty parameter flags?\n";
+          Out << "sub expr: \n";
+          elt->dump(Out);
+          Out << "\n";
+          abort();
+        }
       });
-      // FIXME: Check all the variadic elements.
       verifyCheckedBase(E);
     }
 
@@ -1970,8 +1977,13 @@ public:
 
     void verifyChecked(ParenExpr *E) {
       PrettyStackTraceExpr debugStack(Ctx, "verifying ParenExpr", E);
-      if (!isa<ParenType>(E->getType().getPointer())) {
+      auto ty = dyn_cast<ParenType>(E->getType().getPointer());
+      if (!ty) {
         Out << "ParenExpr not of ParenType\n";
+        abort();
+      }
+      if (!ty->getParameterFlags().isNone()) {
+        Out << "ParenExpr has non-empty parameter flags?\n";
         abort();
       }
       verifyCheckedBase(E);

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4023,8 +4023,7 @@ RValue CallEmission::applyEnumElementConstructor(SGFContext C) {
                                 std::move(*callSite).forward());
 
     auto payloadTy = AnyFunctionType::composeTuple(SGF.getASTContext(),
-                                                  resultFnType.getParams(),
-                                                  /*canonicalVararg*/ true);
+                                                   resultFnType->getParams());
     auto arg = RValue(SGF, argVals, payloadTy->getCanonicalType());
     payload = ArgumentSource(uncurriedLoc, std::move(arg));
     formalResultType = cast<FunctionType>(formalResultType).getResult();

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2659,8 +2659,7 @@ loadIndexValuesForKeyPathComponent(SILGenFunction &SGF, SILLocation loc,
 
   auto indexLoweredTy =
     SGF.getLoweredType(
-      AnyFunctionType::composeTuple(SGF.getASTContext(), indexParams,
-                                    /*canonicalVararg=*/false));
+      AnyFunctionType::composeTuple(SGF.getASTContext(), indexParams));
 
   auto addr = SGF.B.createPointerToAddress(loc, pointer,
                                            indexLoweredTy.getAddressType(),

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2002,8 +2002,7 @@ static bool fixMissingArguments(ConstraintSystem &cs, ASTNode anchor,
   // synthesized arguments to it.
   if (argumentTuple) {
     cs.addConstraint(ConstraintKind::Bind, *argumentTuple,
-                     FunctionType::composeTuple(ctx, args,
-                                                /*canonicalVararg=*/false),
+                     FunctionType::composeTuple(ctx, args),
                      cs.getConstraintLocator(anchor));
   }
 
@@ -2218,8 +2217,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   };
 
   auto implodeParams = [&](SmallVectorImpl<AnyFunctionType::Param> &params) {
-    auto input = AnyFunctionType::composeTuple(getASTContext(), params,
-                                               /*canonicalVararg=*/false);
+    auto input = AnyFunctionType::composeTuple(getASTContext(), params);
 
     params.clear();
     // If fixes are disabled let's do an easy thing and implode
@@ -6073,8 +6071,7 @@ ConstraintSystem::simplifyConstructionConstraint(
 
     // Tuple construction is simply tuple conversion.
     Type argType = AnyFunctionType::composeTuple(getASTContext(),
-                                                 fnType->getParams(),
-                                                 /*canonicalVararg=*/false);
+                                                 fnType->getParams());
     Type resultType = fnType->getResult();
 
     ConstraintLocatorBuilder builder(locator);
@@ -7006,8 +7003,7 @@ ConstraintSystem::simplifyFunctionComponentConstraint(
 
     if (kind == ConstraintKind::FunctionInput) {
       type = AnyFunctionType::composeTuple(getASTContext(),
-                                           funcTy->getParams(),
-                                           /*canonicalVararg=*/false);
+                                           funcTy->getParams());
       locKind = ConstraintLocator::FunctionArgument;
     } else if (kind == ConstraintKind::FunctionResult) {
       type = funcTy->getResult();

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -482,7 +482,7 @@ static bool noteFixableMismatchedTypes(ValueDecl *decl, const ValueDecl *base) {
     auto *fnType = baseTy->getAs<AnyFunctionType>();
     baseTy = fnType->getResult();
     Type argTy = FunctionType::composeTuple(
-        ctx, baseTy->getAs<AnyFunctionType>()->getParams(), false);
+        ctx, baseTy->getAs<AnyFunctionType>()->getParams());
     auto diagKind = diag::override_type_mismatch_with_fixits_init;
     unsigned numArgs = baseInit->getParameters()->size();
     return computeFixitsForOverridenDeclaration(

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2164,8 +2164,7 @@ static Type getTypeForDisplay(ModuleDecl *module, ValueDecl *decl) {
     return AnyFunctionType::composeTuple(module->getASTContext(),
                                          ctor->getMethodInterfaceType()
                                              ->castTo<FunctionType>()
-                                             ->getParams(),
-                                         /*canonicalVararg=*/false);
+                                             ->getParams());
   }
 
   Type type = decl->getInterfaceType();

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -102,3 +102,13 @@ actor TestActor {
 
 func redecl(_: TestActor) { } // expected-note{{'redecl' previously declared here}}
 func redecl(_: isolated TestActor) { } // expected-error{{invalid redeclaration of 'redecl'}}
+
+func tuplify<Ts>(_ fn: (Ts) -> Void) {} // expected-note {{in call to function 'tuplify'}}
+
+@available(SwiftStdlib 5.5, *)
+func testTuplingIsolated(_ a: isolated A, _ b: isolated A) {
+  // FIXME: We shouldn't duplicate the "cannot convert value of type" diagnostic (SR-15179)
+  tuplify(testTuplingIsolated)
+  // expected-error@-1 {{generic parameter 'Ts' could not be inferred}}
+  // expected-error@-2 2{{cannot convert value of type '(isolated A, isolated A) -> ()' to expected argument type '(Ts) -> Void'}}
+}

--- a/test/Constraints/function.swift
+++ b/test/Constraints/function.swift
@@ -250,3 +250,16 @@ func test_passing_noescape_function_ref_to_generic_parameter() {
 func SR14784<T>(_ fs: () -> T..., a _ : Int) -> T {
   fs.first! // expected-error{{function produces expected type 'T'; did you mean to call it with '()'?}} {{11-11=()}}
 }
+
+func tuplify<Ts>(_ fn: (Ts) -> Void) {}
+
+func testInvalidTupleImplosions() {
+  func takesVargs(_ x: Int, _ y: String...) {}
+  tuplify(takesVargs) // expected-error {{cannot convert value of type '(Int, String...) -> ()' to expected argument type '(Int) -> Void'}}
+
+  func takesAutoclosure(_ x: @autoclosure () -> Int, y: String) {}
+  tuplify(takesAutoclosure) // expected-error {{cannot convert value of type '(@autoclosure () -> Int, String) -> ()' to expected argument type '(@escaping () -> Int) -> Void'}}
+
+  func takesInout(_ x: Int, _ y: inout String) {}
+  tuplify(takesInout) // expected-error {{cannot convert value of type '(Int, inout String) -> ()' to expected argument type '(Int) -> Void'}}
+}


### PR DESCRIPTION
Tuple and paren types may still have parameter type flags in certain cases, but they should never make it into expressions.

This requires formalizing the rules around whether we can convert a function with N parameters into a function with a single N-element tuple parameter. Previously, only functions with variadic, autoclosure, or inout parameter flags were rejected. Other parameter flags were preserved on the resulting tuple, which could cause issues in downstream code, as tuples shouldn't have parameter flags. This patch ensures we either reject the parameter flags, or strip them from the tuple type.

By default, a parameter with non-empty parameter flags will now be rejected, with an exception for ownership flags, `@_nonEphemeral`, and `@noDerivative`. 

This means that tupling `isolated` parameters is now forbidden. An additional rule has also been added that forbids tupling into a `@differentiable` function.