### PR TITLE
MemoryLifetimeVerifier: treat enum cases with empty payloads (e.g. an empty tuple) like cases with no payloads.

### DIFF
--- a/include/swift/SIL/MemoryLocations.h
+++ b/include/swift/SIL/MemoryLocations.h
@@ -43,9 +43,9 @@ void dumpBits(const SmallBitVector &bits);
 ///
 /// Memory locations are limited to addresses which are guaranteed to
 /// be not aliased, like @in/inout parameters and alloc_stack.
-/// Currently only a certain set of address instructions are supported:
-/// Specifically those instructions which are going to be included when SIL
-/// supports opaque values.
+/// Currently only a certain set of address instructions are supported, for
+/// details see `MemoryLocations::analyzeLocationUsesRecursively` and
+/// `MemoryLocations::analyzeAddrProjection`.
 class MemoryLocations {
 public:
 
@@ -288,7 +288,7 @@ public:
   /// not covered by sub-fields.
   const Bits &getNonTrivialLocations();
 
-  /// Debug dump the MemoryLifetime internals.
+  /// Debug dump the MemoryLocations internals.
   void dump() const;
 
 private:

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -294,6 +294,10 @@ public:
   /// even though they are technically trivial.
   bool isTrivial(const SILFunction &F) const;
 
+  /// True if the type is an empty tuple or an empty struct or a tuple or
+  /// struct containing only empty types.
+  bool isEmpty(const SILFunction &F) const;
+
   /// True if the type, or the referenced type of an address type, is known to
   /// be a scalar reference-counted type such as a class, box, or thick function
   /// type. Returns false for non-trivial aggregates.

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -31,11 +31,8 @@ namespace {
 /// A utility for verifying memory lifetime.
 ///
 /// The MemoryLifetime utility checks the lifetime of memory locations.
-/// This is limited to memory locations which are guaranteed to be not aliased,
-/// like @in or @inout parameters. Also, alloc_stack locations are handled.
-///
-/// In addition to verification, the MemoryLifetime class can be used as utility
-/// (e.g. base class) for optimizations, which need to compute memory lifetime.
+/// This is limited to memory locations which can be handled by
+/// `MemoryLocations`.
 class MemoryLifetimeVerifier {
 
   using Bits = MemoryLocations::Bits;

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -650,3 +650,35 @@ bb0(%0 : $Int, %1 : @guaranteed $@callee_guaranteed (@in_guaranteed (Int, ((), (
   dealloc_stack %2 : $*(Int, ((), ()))
   return %5 : $Int
 }
+
+enum Result<T1, T2>{
+  case success(T1)
+  case failure(T2)
+}
+
+sil @try_get_error : $@convention(thin) () -> @error Error
+
+sil [ossa] @test_init_enum_empty_case : $@convention(thin) () -> @error Error {
+bb0:
+  %0 = alloc_stack $Result<(), Error>
+  %1 = function_ref @try_get_error : $@convention(thin) () -> @error Error
+  try_apply %1() : $@convention(thin) () -> @error Error, normal bb1, error bb2
+
+bb1(%3 : $()):
+  inject_enum_addr %0 : $*Result<(), Error>, #Result.success!enumelt
+  br bb3
+
+bb2(%6 : @owned $Error):
+  %7 = init_enum_data_addr %0 : $*Result<(), Error>, #Result.failure!enumelt
+  store %6 to [init] %7 : $*Error
+  inject_enum_addr %0 : $*Result<(), Error>, #Result.failure!enumelt
+  br bb3
+
+bb3:
+  %11 = load [take] %0 : $*Result<(), Error>
+  destroy_value %11 : $Result<(), Error>
+  dealloc_stack %0 : $*Result<(), Error>
+  %14 = tuple ()
+  return %14 : $()
+}
+

--- a/test/SIL/memory_lifetime_failures.sil
+++ b/test/SIL/memory_lifetime_failures.sil
@@ -567,3 +567,36 @@ bb1:
   %r = tuple ()
   return %r : $()
 }
+
+enum Result<T1, T2>{
+  case success(T1)
+  case failure(T2)
+}
+
+sil @try_get_error : $@convention(thin) () -> @error Error
+
+// CHECK: SIL memory lifetime failure in @test_init_enum_trivial_case: memory is not initialized, but should
+sil [ossa] @test_init_enum_trivial_case : $@convention(thin) () -> @error Error {
+bb0:
+  %0 = alloc_stack $Result<Int, Error>
+  %1 = function_ref @try_get_error : $@convention(thin) () -> @error Error
+  try_apply %1() : $@convention(thin) () -> @error Error, normal bb1, error bb2
+
+bb1(%3 : $()):
+  inject_enum_addr %0 : $*Result<Int, Error>, #Result.success!enumelt
+  br bb3
+
+
+bb2(%7 : @owned $Error):
+  %8 = init_enum_data_addr %0 : $*Result<Int, Error>, #Result.failure!enumelt
+  store %7 to [init] %8 : $*Error
+  inject_enum_addr %0 : $*Result<Int, Error>, #Result.failure!enumelt
+  br bb3
+
+bb3:
+  %12 = load [take] %0 : $*Result<Int, Error>
+  destroy_value %12 : $Result<Int, Error>
+  dealloc_stack %0 : $*Result<Int, Error>
+  %15 = tuple ()
+  return %15 : $()
+}


### PR DESCRIPTION
This PR is intended to replace https://github.com/apple/swift/pull/39173.
