### PR TITLE
[stdlib] Improve creating a String from a non-contiguous collection

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -405,15 +405,31 @@ extension String {
   // This force type-casts element to UInt8, since we cannot currently
   // communicate to the type checker that we proved this with our dynamic
   // check in String(decoding:as:).
+  // **Important:** The 'repairsMade' part of the result is not reliable.
   @_alwaysEmitIntoClient
   @inline(never) // slow-path
   private static func _fromNonContiguousUnsafeBitcastUTF8Repairing<
     C: Collection
   >(_ input: C) -> (result: String, repairsMade: Bool) {
     _internalInvariant(C.Element.self == UInt8.self)
-    return Array(input).withUnsafeBufferPointer {
-      let raw = UnsafeRawBufferPointer($0)
-      return String._fromUTF8Repairing(raw.bindMemory(to: UInt8.self))
+    if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+      let count = input.count
+      let string = String(unsafeUninitializedCapacity: count) { buffer in
+        var iterAndCount = unsafeBitCast(
+          buffer, to: UnsafeMutableBufferPointer<C.Element>.self
+        ).initialize(from: input)
+        precondition(
+          iterAndCount.0.next() == nil,
+          "Collection contains more than 'count' elements"
+        )
+        return iterAndCount.1
+      }
+      return (result: string, repairsMade: false)
+    } else {
+      return Array(input).withUnsafeBufferPointer {
+        let raw = UnsafeRawBufferPointer($0)
+        return String._fromUTF8Repairing(raw.bindMemory(to: UInt8.self))
+      }
     }
   }
 

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -418,7 +418,7 @@ extension String {
         var iterAndCount = unsafeBitCast(
           buffer, to: UnsafeMutableBufferPointer<C.Element>.self
         ).initialize(from: input)
-        precondition(
+        _precondition(
           iterAndCount.0.next() == nil,
           "Collection contains more than 'count' elements"
         )


### PR DESCRIPTION
<!-- What's in this pull request? -->
Currently, when creating a String from a non-contiguous Collection, we copy in to an Array and use the Array's contiguous storage to create the String. There really isn't any need to do that - we can just copy in to String's own storage.

I've tested this in `WebURL`, which creates Strings from lazily percent-encoded/decoded input, and I see a consistent 60-75% performance improvements across the various places we create percent-encoded/decoded strings.

I couldn't find a version of `String.init(unsafeUninitializedCapacity:)` which returns whether repairs are made. Luckily, this function appears to be used exactly once in the standard library, in `String.init(decoding:as:)`, which discards that information anyway.

Because the function is `@_alwaysEmitIntoClient`, I assume the availability check is required, but I'm not entirely sure.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-13111](https://github.com/apple/swift/issues/55557) (rdar://64947782).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
