### PR TITLE
Fix group child tasks not being released 

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -141,7 +141,7 @@ void NullaryContinuationJob::process(Job *_job) {
 void AsyncTask::completeFuture(AsyncContext *context) {
   using Status = FutureFragment::Status;
   using WaitQueueItem = FutureFragment::WaitQueueItem;
-
+  SWIFT_TASK_DEBUG_LOG("complete future = %p", this);
   assert(isFuture());
   auto fragment = futureFragment();
 
@@ -227,7 +227,6 @@ AsyncTask::~AsyncTask() {
 SWIFT_CC(swift)
 static void destroyTask(SWIFT_CONTEXT HeapObject *obj) {
   auto task = static_cast<AsyncTask*>(obj);
-
   task->~AsyncTask();
 
   // The task execution itself should always hold a reference to it, so

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -32,7 +32,9 @@ namespace swift {
 // Set to 1 to enable helpful debug spew to stderr
 #if 0
 #define SWIFT_TASK_DEBUG_LOG(fmt, ...)                                         \
-  fprintf(stderr, "[%lu] " fmt "\n", (unsigned long)_swift_get_thread_id(),    \
+  fprintf(stderr, "[%lu] [%s:%d](%s) " fmt "\n",                               \
+          (unsigned long)_swift_get_thread_id(),                               \
+          __FILE__, __LINE__, __FUNCTION__,                                    \
           __VA_ARGS__)
 #else
 #define SWIFT_TASK_DEBUG_LOG(fmt, ...) (void)0

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -30,6 +30,7 @@
 namespace swift {
 
 // Set to 1 to enable helpful debug spew to stderr
+// If this is enabled, tests with `swift_task_debug_log` requirement can run.
 #if 0
 #define SWIFT_TASK_DEBUG_LOG(fmt, ...)                                         \
   fprintf(stderr, "[%lu] [%s:%d](%s) " fmt "\n",                               \

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -354,6 +354,8 @@ static bool swift_task_tryAddStatusRecordImpl(TaskStatusRecord *newRecord) {
 SWIFT_CC(swift)
 static bool swift_task_removeStatusRecordImpl(TaskStatusRecord *record) {
   auto task = swift_task_getCurrent();
+  SWIFT_TASK_DEBUG_LOG("remove status record = %p, from current task = %p",
+                       record, task);
 
   // Load the current state.
   auto &status = task->_private().Status;
@@ -454,6 +456,8 @@ static ChildTaskStatusRecord*
 swift_task_attachChildImpl(AsyncTask *child) {
   void *allocation = malloc(sizeof(swift::ChildTaskStatusRecord));
   auto record = new (allocation) swift::ChildTaskStatusRecord(child);
+  SWIFT_TASK_DEBUG_LOG("attach child task = %p, record = %p, to current task = %p",
+                       child, record, swift_task_getCurrent());
   swift_task_addStatusRecord(record);
   return record;
 }
@@ -548,6 +552,7 @@ static void performGroupCancellationAction(TaskStatusRecord *record) {
 
 SWIFT_CC(swift)
 static void swift_task_cancelImpl(AsyncTask *task) {
+  SWIFT_TASK_DEBUG_LOG("cancel task = %p", task);
   Optional<StatusRecordLockRecord> recordLockRecord;
 
   // Acquire the status record lock.

--- a/test/Concurrency/Runtime/async_task_withUnsafeCurrentTask.swift
+++ b/test/Concurrency/Runtime/async_task_withUnsafeCurrentTask.swift
@@ -1,0 +1,39 @@
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library) 2>&1 | %FileCheck %s --dump-input=always
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: swift_task_debug_log
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+#if os(Linux)
+import Glibc
+#elseif os(Windows)
+import MSVCRT
+#else
+import Darwin
+#endif
+
+func test_withUnsafeCurrentTask() async {
+  // The task we're running in ("main")
+  // CHECK: creating task [[MAIN_TASK:0x.*]] with parent 0x0
+
+  // CHECK: creating task [[TASK:0x.*]] with parent 0x0
+  let t = Task.detached {
+    withUnsafeCurrentTask { task in
+      fputs("OK: \(task!)", stderr)
+    }
+    fputs("DONE", stderr)
+  }
+
+  // CHECK: OK: UnsafeCurrentTask(_task: (Opaque Value))
+  // CHECK: DONE
+  // CHECK: destroy task [[TASK]]
+  await t.value
+}
+
+@main struct Main {
+  static func main() async {
+    await test_withUnsafeCurrentTask()
+  }
+}

--- a/test/Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift
@@ -27,9 +27,11 @@ func test_taskGroup_next() async {
       do {
         while let r = try await group.next() {
           sum += r
+          print("add \(r) -> sum: \(sum)")
         }
       } catch {
         catches += 1
+        print("catch: \(catches)")
       }
     }
 

--- a/test/Concurrency/Runtime/async_taskgroup_dontLeakTasks.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_dontLeakTasks.swift
@@ -1,0 +1,43 @@
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library) | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: linux
+
+#if os(Linux)
+import Glibc
+#elseif os(Windows)
+import MSVCRT
+#else
+import Darwin
+#endif
+
+@available(SwiftStdlib 5.5, *)
+func test_taskGroup_next() async {
+  _ = await withTaskGroup(of: Int.self, returning: Int.self) { group in
+    for n in 0..<100 {
+      group.spawn {
+        return n
+      }
+    }
+    await Task.sleep(2_000_000)
+
+    var sum = 0
+    for await value in group {
+      sum += 1
+    }
+
+    return sum
+  }
+
+  // CHECK: result with group.next(): 100
+  print("result with group.next(): \(100)")
+}
+
+@available(SwiftStdlib 5.5, *)
+@main struct Main {
+  static func main() async {
+    await test_taskGroup_next()
+  }
+}

--- a/test/Concurrency/Runtime/async_taskgroup_next_on_completed.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_on_completed.swift
@@ -15,11 +15,9 @@ func test_sum_nextOnCompleted() async {
   let numbers = [1, 2, 3, 4, 5]
   let expected = 15 // FIXME: numbers.reduce(0, +) this hangs?
 
-  let sum = try! await withTaskGroup(of: Int.self) {
-    (group) async -> Int in
+  let sum = try! await withTaskGroup(of: Int.self) { group async -> Int in
     for n in numbers {
       group.spawn {
-        () async -> Int in
         print("  complete group.spawn { \(n) }")
         return n
       }
@@ -27,17 +25,13 @@ func test_sum_nextOnCompleted() async {
 
     // We specifically want to await on completed child tasks in this test,
     // so give them some time to complete before we hit group.next()
-    await Task.sleep(2_000_000_000)
+    try! await Task.sleep(nanoseconds: 2_000_000_000)
 
     var sum = 0
-    do {
-      while let r = try await group.next() {
-        print("next: \(r)")
-        sum += r
-        print("sum: \(sum)")
-      }
-    } catch {
-      print("ERROR: \(error)")
+    while let r = await group.next() {
+      print("next: \(r)")
+      sum += r
+      print("sum: \(sum)")
     }
 
     assert(group.isEmpty, "Group must be empty after we consumed all tasks")

--- a/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
@@ -47,7 +47,7 @@ func test_taskGroup_throws() async {
         return third
 
       case .failure(let error):
-        fatalError("got an erroneous third result")
+        fatalError("got an erroneous third result: \(error)")
 
       case .none:
         print("task group failed to get 3")

--- a/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
@@ -21,9 +21,9 @@ func boom() async throws -> Int { throw Boom() }
 func test_taskGroup_throws_rethrows() async {
   do {
     let got = try await withThrowingTaskGroup(of: Int.self, returning: Int.self) { group in
-      group.spawn { await echo(1) }
-      group.spawn { await echo(2) }
-      group.spawn { try await boom() }
+      group.addTask { await echo(1) }
+      group.addTask { await echo(2) }
+      group.addTask { try await boom() }
 
       do {
         while let r = try await group.next() {


### PR DESCRIPTION
**Explanation**: Task groups were failing to remove release their child tasks, which led to memory leaks.
**Scope**: Affects new code using Swift's Concurrency model that uses task groups.
**Radar/SR Issue**: [https://bugs.swift.org/browse/SR-14973](SR-14973) / rdar://81130259
**Risk**: Low.
**Reviewed By**: Doug Gregor / nominated on behalf of Konrad Malawski
**Testing**: PR testing and CI on main, including new tests.
**Original PR**: https://github.com/apple/swift/pull/39158
