### PR TITLE
Reduce duplication in toolchain argument parsing

### DIFF
--- a/utils/build-toolchain
+++ b/utils/build-toolchain
@@ -50,16 +50,17 @@ DRY_RUN=
 BUNDLE_PREFIX=
 PRESET_FILE_FLAGS=
 PRESET_PREFIX=
-PRESET_SUFFIX=
+NO_TEST=",no_test"
+USE_OS_RUNTIME=
 
 case $(uname -s) in
   Darwin)
-    SWIFT_PACKAGE=buildbot_osx_package,no_test
+    SWIFT_PACKAGE=buildbot_osx_package
     OS_SUFFIX=osx
     BUILD_SUBDIR=buildbot_osx
   ;;
   Linux)
-    SWIFT_PACKAGE=buildbot_linux,no_test
+    SWIFT_PACKAGE=buildbot_linux
     OS_SUFFIX=linux
     BUILD_SUBDIR=buildbot_linux
   ;;
@@ -77,13 +78,7 @@ while [ $# -ne 0 ]; do
       DRY_RUN="-n"
   ;;
     -t|--test)
-      if [ "$(uname -s)" == "Linux" ]; then
-        SWIFT_PACKAGE=buildbot_linux
-        BUILD_SUBDIR=buildbot_linux
-      else
-        SWIFT_PACKAGE=buildbot_osx_package
-        BUILD_SUBDIR=buildbot_osx
-      fi
+      NO_TEST=
   ;;
     --distcc)
       DISTCC_FLAG="--distcc"
@@ -100,7 +95,7 @@ while [ $# -ne 0 ]; do
       PRESET_PREFIX="$1"
   ;;
     --use-os-runtime)
-      PRESET_SUFFIX=",use_os_runtime"
+      USE_OS_RUNTIME=",use_os_runtime"
   ;;
   -h|--help)
     usage
@@ -152,7 +147,7 @@ SCCACHE_FLAG="${SCCACHE_FLAG}"
 
 ./utils/build-script ${DRY_RUN} ${DISTCC_FLAG} ${PRESET_FILE_FLAGS} \
         ${SCCACHE_FLAG} \
-        --preset="${PRESET_PREFIX}${SWIFT_PACKAGE}${PRESET_SUFFIX}" \
+        --preset="${PRESET_PREFIX}${SWIFT_PACKAGE}${NO_TEST}${USE_OS_RUNTIME}" \
         install_destdir="${SWIFT_INSTALL_DIR}" \
         installable_package="${SWIFT_INSTALLABLE_PACKAGE}" \
         install_toolchain_dir="${SWIFT_TOOLCHAIN_DIR}" \


### PR DESCRIPTION
<!-- What's in this pull request? -->
This changes how the build-toolchain script parses its arguments and constucts the preset name to remove the duplication of the "buildbot_osx_package" and "buildbot_linux" names.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link:
Resolves SR-NNNN. -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
