### PR TITLE
Use the just-built Darwin libLTO.dylib in lit tests

### DIFF
--- a/test/Interpreter/llvm_link_time_opt.swift
+++ b/test/Interpreter/llvm_link_time_opt.swift
@@ -4,8 +4,8 @@
 // REQUIRES: lld_lto
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swiftc_driver -emit-library -static -lto=llvm-full -emit-module %S/Inputs/lto/module1.swift -working-directory %t
-// RUN: %target-swiftc_driver -lto=llvm-full %s -I%t -L%t -lmodule1 -module-name main -o %t/main
+// RUN: %target-swiftc_driver -emit-library -static -lto=llvm-full %lto_flags -emit-module %S/Inputs/lto/module1.swift -working-directory %t
+// RUN: %target-swiftc_driver -lto=llvm-full %lto_flags %s -I%t -L%t -lmodule1 -module-name main -o %t/main
 // RUN: %llvm-nm --defined-only %t/main | %FileCheck %s
 
 // CHECK-NOT: _$s7module120unusedPublicFunctionyyF

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -219,11 +219,21 @@ lit_config.note('Using cmake: ' + config.cmake)
 config.llvm_src_root = getattr(config, 'llvm_src_root', None)
 config.llvm_obj_root = getattr(config, 'llvm_obj_root', None)
 
+lto_flags = ""
+
 if platform.system() == 'OpenBSD':
     llvm_libs_dir = getattr(config, 'llvm_libs_dir', None)
     if not llvm_libs_dir:
         lit_config.fatal('No LLVM libs dir set.')
     config.environment['LD_LIBRARY_PATH'] = llvm_libs_dir
+
+elif platform.system() == 'Darwin':
+    llvm_libs_dir = getattr(config, 'llvm_libs_dir', None)
+    if not llvm_libs_dir:
+        lit_config.fatal('No LLVM libs dir set.')
+    lto_flags = "-Xlinker -lto_library -Xlinker %s/libLTO.dylib" % llvm_libs_dir
+
+config.substitutions.append( ('%lto_flags', lto_flags) )
 
 def append_to_env_path(directory):
     config.environment['PATH'] = \


### PR DESCRIPTION
Turns out that today, Darwin linker invocations from tests using -lto end up using the system compiler's LTO library. We need to be using the just-built one instead.