### PR TITLE
[Diagnostics] Ignore warnings while diagnosing ambiguities

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3989,8 +3989,14 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
 
   llvm::SmallSetVector<FixInContext, 4> fixes;
   for (auto &solution : solutions) {
-    for (auto *fix : solution.Fixes)
+    for (auto *fix : solution.Fixes) {
+      // Ignore warnings in favor of actual error fixes,
+      // because they are not the source of ambiguity/failures.
+      if (fix->isWarning())
+        continue;
+
       fixes.insert({&solution, fix});
+    }
   }
 
   llvm::MapVector<ConstraintLocator *, SmallVector<FixInContext, 4>>

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1163,3 +1163,13 @@ func rdar78917861() {
     }()
   }
 }
+
+// rdar://81228501 - type-checker crash due to applied invalid solution
+func test(arr: [[Int]]) {
+  struct A {
+    init(arg: [Int]) {}
+  }
+
+  arr.map { ($0 as? [Int]).map { A($0) } } // expected-error {{missing argument label 'arg:' in call}} {{36-36=arg: }}
+  // expected-warning@-1 {{conditional cast from '[Int]' to '[Int]' always succeeds}}
+}


### PR DESCRIPTION
Warnings cannot lead to failures or ambiguity so let's remove
them from consideration when attempting to diagnose ambiguity
potentially caused by the same fix appearing in different
solutions.

Resolves: rdar://81228501

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
