### PR TITLE
Add -internalize-at-link flag to allow dead stripping and VFE across modules at link time

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -357,6 +357,8 @@ public:
 
   unsigned WitnessMethodElimination : 1;
 
+  unsigned InternalizeAtLink : 1;
+
   /// The number of threads for multi-threaded code generation.
   unsigned NumThreads = 0;
 
@@ -416,7 +418,7 @@ public:
         DisableRoundTripDebugTypes(false), DisableDebuggerShadowCopies(false),
         DisableConcreteTypeMetadataMangledNameAccessors(false),
         EnableGlobalISel(false), VirtualFunctionElimination(false),
-        WitnessMethodElimination(false),
+        WitnessMethodElimination(false), InternalizeAtLink(false),
         CmdArgs(),
         SanitizeCoverage(llvm::SanitizerCoverageOptions()),
         TypeInfoFilter(TypeInfoDumpFilter::All) {}

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -501,6 +501,12 @@ def enable_llvm_wme : Flag<["-"], "enable-llvm-wme">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
   HelpText<"Use LLVM IR Witness Method Elimination on Swift protocol witness tables">;
 
+def internalize_at_link : Flag<["-"], "internalize-at-link">,
+  Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
+  HelpText<"Allow internalizing public symbols and vtables at link time (assume"
+  " all client code of public types is part of the same link unit, or that"
+  " external symbols are explicitly requested via -exported_symbols_list)">;
+
 def disable_previous_implementation_calls_in_dynamic_replacements :
   Flag<["-"], "disable-previous-implementation-calls-in-dynamic-replacements">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,

--- a/include/swift/TBDGen/TBDGen.h
+++ b/include/swift/TBDGen/TBDGen.h
@@ -41,6 +41,9 @@ struct TBDGenOptions {
   /// Whether to include only symbols with public linkage.
   bool PublicSymbolsOnly = true;
 
+  /// Whether LLVM IR Virtual Function Elimination is enabled.
+  bool VirtualFunctionElimination = false;
+
   /// The install_name to use in the TBD file.
   std::string InstallName;
 
@@ -70,6 +73,7 @@ struct TBDGenOptions {
            lhs.IsInstallAPI == rhs.IsInstallAPI &&
            lhs.LinkerDirectivesOnly == rhs.LinkerDirectivesOnly &&
            lhs.PublicSymbolsOnly == rhs.PublicSymbolsOnly &&
+           lhs.VirtualFunctionElimination == rhs.VirtualFunctionElimination &&
            lhs.InstallName == rhs.InstallName &&
            lhs.ModuleLinkName == rhs.ModuleLinkName &&
            lhs.CurrentVersion == rhs.CurrentVersion &&
@@ -86,7 +90,8 @@ struct TBDGenOptions {
     using namespace llvm;
     return hash_combine(
         opts.HasMultipleIGMs, opts.IsInstallAPI, opts.LinkerDirectivesOnly,
-        opts.PublicSymbolsOnly, opts.InstallName, opts.ModuleLinkName,
+        opts.PublicSymbolsOnly, opts.VirtualFunctionElimination,
+        opts.InstallName, opts.ModuleLinkName,
         opts.CurrentVersion, opts.CompatibilityVersion,
         opts.ModuleInstallNameMapPath,
         hash_combine_range(opts.embedSymbolsFromModules.begin(),

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1528,6 +1528,8 @@ static bool ParseTBDGenArgs(TBDGenOptions &Opts, ArgList &Args,
 
   Opts.IsInstallAPI = Args.hasArg(OPT_tbd_is_installapi);
 
+  Opts.VirtualFunctionElimination = Args.hasArg(OPT_enable_llvm_vfe);
+
   if (const Arg *A = Args.getLastArg(OPT_tbd_compatibility_version)) {
     Opts.CompatibilityVersion = A->getValue();
   }
@@ -1910,6 +1912,10 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
 
   if (Args.hasArg(OPT_enable_llvm_wme)) {
     Opts.WitnessMethodElimination = true;
+  }
+
+  if (Args.hasArg(OPT_internalize_at_link)) {
+    Opts.InternalizeAtLink = true;
   }
 
   // Default to disabling swift async extended frame info on anything but

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -934,7 +934,7 @@ void TBDGenVisitor::visitClassDecl(ClassDecl *CD) {
     void addMethod(SILDeclRef method) {
       assert(method.getDecl()->getDeclContext() == CD);
 
-      if (CD->hasResilientMetadata()) {
+      if (TBD.Opts.VirtualFunctionElimination || CD->hasResilientMetadata()) {
         if (FirstTime) {
           FirstTime = false;
 

--- a/test/IRGen/virtual-function-elimination-two-modules.swift
+++ b/test/IRGen/virtual-function-elimination-two-modules.swift
@@ -1,0 +1,71 @@
+// Tests that under -enable-llvm-vfe + -internalize-at-link, cross-module
+// virtual calls are done via thunks and LLVM GlobalDCE is able to remove unused
+// virtual methods from a library based on a list of used symbols by a client.
+
+// RUN: %empty-directory(%t)
+
+// (1) Build library swiftmodule
+// RUN: %target-build-swift -parse-as-library -Xfrontend -enable-llvm-vfe \
+// RUN:     %s -DLIBRARY -module-name Library \
+// RUN:     -emit-module -o %t/Library.swiftmodule \
+// RUN:     -emit-tbd -emit-tbd-path %t/libLibrary.tbd -Xfrontend -tbd-install_name=%t/libLibrary.dylib
+
+// (2) Build client
+// RUN: %target-build-swift -parse-as-library -Xfrontend -enable-llvm-vfe \
+// RUN:     %s -DCLIENT -module-name Main -I%t -L%t -lLibrary -o %t/main
+
+// (3) Extract a list of used symbols by client from library
+// RUN: %llvm-nm --undefined-only -m %t/main | grep 'from libLibrary' | awk '{print $3}' > %t/used-symbols
+
+// (4) Now produce the .dylib with just the symbols needed by the client
+// RUN: %target-build-swift -parse-as-library -Xfrontend -enable-llvm-vfe -Xfrontend -internalize-at-link \
+// RUN:     %s -DLIBRARY -lto=llvm-full %lto_flags -module-name Library \
+// RUN:     -emit-library -o %t/libLibrary.dylib \
+// RUN:     -Xlinker -exported_symbols_list -Xlinker %t/used-symbols -Xlinker -dead_strip
+
+// (5) Check list of symbols in library
+// RUN: %llvm-nm --defined-only %t/libLibrary.dylib | %FileCheck %s --check-prefix=NM
+
+// (6) Execution test
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// Test disabled until LLVM GlobalDCE supports Swift vtables.
+// REQUIRES: rdar81868930
+
+#if LIBRARY
+
+public class MyClass {
+  public init() {}
+  public func foo() { print("MyClass.foo") }
+  public func bar() { print("MyClass.bar") }
+}
+
+public class MyDerivedClass: MyClass {
+  override public func foo() { print("MyDerivedClass.foo") }
+  override public func bar() { print("MyDerivedClass.bar") }
+}
+
+// NM-NOT: $s7Library14MyDerivedClassC3baryyF
+// NM:     $s7Library14MyDerivedClassC3fooyyF
+// NM-NOT: $s7Library7MyClassC3baryyF
+// NM:     $s7Library7MyClassC3fooyyF
+
+#endif
+
+#if CLIENT
+
+import Library
+
+@_cdecl("main")
+func main() -> Int32 {
+   let o: MyClass = MyDerivedClass()
+   o.foo()
+   print("Done")
+   // CHECK: MyDerivedClass.foo
+   // CHECK-NEXT: Done
+   return 0
+}
+
+#endif


### PR DESCRIPTION
The first commit in the PR is being reviewed at <https://github.com/apple/swift/pull/39128>. Suggestion for reviewers is to only look at the second commit here.

- Under -internalize-at-link, stop unconditionally marking all globals as used.
- Under -internalize-at-link, restrict visibility of vtables to linkage unit.
- Emit virtual method thunks for cross-module vcalls when VFE is enabled.
- Use thunks for vcalls across modules when VFE is enabled.
- Adjust TBDGen to account for virtual method thunks when VFE is enabled.
- Add an end-to-end test case for cross-module VFE.
