### PR TITLE
[Rebranch] Disabling driver-time-compilation test

### DIFF
--- a/test/Driver/driver-time-compilation.swift
+++ b/test/Driver/driver-time-compilation.swift
@@ -1,6 +1,8 @@
 // RUN: %target-build-swift -typecheck -driver-time-compilation %s 2>&1 | %FileCheck %s
 // RUN: %target-build-swift -typecheck -driver-time-compilation %s %S/../Inputs/empty.swift 2>&1 | %FileCheck -check-prefix CHECK-MULTIPLE %s
 
+// REQUIRES: rdar82895550
+
 // CHECK: Driver Compilation Time
 // CHECK: Total Execution Time: {{[0-9]+}}.{{[0-9]+}} seconds ({{[0-9]+}}.{{[0-9]+}} wall clock)
 // CHECK: ---User Time---


### PR DESCRIPTION
This test is pretty brittle on such a short file. If a member of the
timer output is zero, that member is omitted from the output. With how
short the file is, various fields come back zero occasionally.

On the Linux CI bot, there was a run with no "System Time", while I was
seeing it failing locally due to other missing time fields.