### PR TITLE
Unsafe*Pointer types should not be Sendable.

### DIFF
--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -589,7 +589,7 @@ extension UnsafeRawPointer {
   }
 }
 
-extension AutoreleasingUnsafeMutablePointer: Sendable { }
+extension AutoreleasingUnsafeMutablePointer { }
 
 internal struct _CocoaFastEnumerationStackBuf {
   // Clang uses 16 pointers.  So do we.

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -124,7 +124,7 @@ public typealias CBool = Bool
 /// Opaque pointers are used to represent C pointers to types that
 /// cannot be represented in Swift, such as incomplete struct types.
 @frozen
-public struct OpaquePointer: Sendable {
+public struct OpaquePointer {
   @usableFromInline
   internal var _rawValue: Builtin.RawPointer
 
@@ -235,7 +235,7 @@ extension UInt {
 /// A wrapper around a C `va_list` pointer.
 #if arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Windows))
 @frozen
-public struct CVaListPointer: Sendable {
+public struct CVaListPointer {
   @usableFromInline // unsafe-performance
   internal var _value: (__stack: UnsafeMutablePointer<Int>?,
                         __gr_top: UnsafeMutablePointer<Int>?,

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -749,10 +749,6 @@ extension UnsafeMutableBufferPointer {
   }
 }
 
-extension UnsafeBufferPointer: Sendable { }
-extension UnsafeBufferPointer.Iterator: Sendable { }
-extension UnsafeMutableBufferPointer: Sendable { }
-
 // ${'Local Variables'}:
 // eval: (read-only-mode 1)
 // End:

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -205,7 +205,7 @@
 ///       let numberPointer = UnsafePointer<Int>(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
 @frozen // unsafe-performance
-public struct UnsafePointer<Pointee>: _Pointer, Sendable {
+public struct UnsafePointer<Pointee>: _Pointer {
 
   /// A type that represents the distance between two pointers.
   public typealias Distance = Int
@@ -511,7 +511,7 @@ public struct UnsafePointer<Pointee>: _Pointer, Sendable {
 ///       let numberPointer = UnsafeMutablePointer<Int>(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
 @frozen // unsafe-performance
-public struct UnsafeMutablePointer<Pointee>: _Pointer, Sendable {
+public struct UnsafeMutablePointer<Pointee>: _Pointer {
 
   /// A type that represents the distance between two pointers.
   public typealias Distance = Int

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -856,11 +856,6 @@ public func withUnsafeBytes<T, Result>(
   return try body(buffer)
 }
 
-extension UnsafeRawBufferPointer: Sendable { }
-extension UnsafeRawBufferPointer.Iterator: Sendable { }
-extension UnsafeMutableRawBufferPointer: Sendable { }
-
-
 // ${'Local Variables'}:
 // eval: (read-only-mode 1)
 // End:

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -169,7 +169,7 @@
 ///       let numberPointer = UnsafeRawPointer(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
 @frozen
-public struct UnsafeRawPointer: _Pointer, Sendable {
+public struct UnsafeRawPointer: _Pointer {
   
   public typealias Pointee = UInt8
   
@@ -527,7 +527,7 @@ extension UnsafeRawPointer: Strideable {
 ///       let numberPointer = UnsafeMutableRawPointer(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
 @frozen
-public struct UnsafeMutableRawPointer: _Pointer, Sendable {
+public struct UnsafeMutableRawPointer: _Pointer {
   
   public typealias Pointee = UInt8
   

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -5591,11 +5591,6 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.ref.protocol,
         key.name: "_Pointer",
         key.usr: "s:s8_PointerP"
-      },
-      {
-        key.kind: source.lang.swift.ref.protocol,
-        key.name: "Sendable",
-        key.usr: "s:s8SendableP"
       }
     ]
   },


### PR DESCRIPTION
To send them across actors, they need to be wrapped in an '@unchecked
Sendable' type. Typically such a wrapper type would be be responsible
for ensuring its uniqueness or immutability.

Inferring Sendability for arbitrary types that contain Unsafe*Pointers
would introduce race conditions without warning or any explicit
acknoledgement from the programmer that the pointer is in fact unique.
