### PR TITLE
[Sema][SR-15053] Ignore ambiguity from conformance in some situations

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -19,14 +19,15 @@
 
 #include "swift/AST/ArgumentList.h"
 #include "swift/AST/Attr.h"
+#include "swift/AST/Availability.h"
 #include "swift/AST/CaptureInfo.h"
 #include "swift/AST/ConcreteDeclRef.h"
+#include "swift/AST/Decl.h"
 #include "swift/AST/DeclContext.h"
 #include "swift/AST/DeclNameLoc.h"
 #include "swift/AST/FunctionRefKind.h"
 #include "swift/AST/ProtocolConformanceRef.h"
 #include "swift/AST/TypeAlignments.h"
-#include "swift/AST/Availability.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/InlineBitfield.h"
 #include "llvm/Support/TrailingObjects.h"
@@ -1452,6 +1453,8 @@ public:
   DeclNameLoc getNameLoc() const { return Loc; }
   SourceLoc getLoc() const { return Loc.getBaseNameLoc(); }
   SourceRange getSourceRange() const { return Loc.getSourceRange(); }
+
+  bool isForOperator() const { return getDecls().front()->isOperator(); }
 
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::OverloadedDeclRef;

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -1106,6 +1106,14 @@ public:
     return false;
   }
 
+  bool isForRequirement(RequirementKind kind) const {
+    if (auto lastElt = last()) {
+      auto requirement = lastElt->getAs<LocatorPathElt::AnyRequirement>();
+      return requirement && kind == requirement->getRequirementKind();
+    }
+    return false;
+  }
+
   /// Checks whether this locator is describing an argument application for a
   /// non-ephemeral parameter.
   bool isNonEphemeralParameterApplication() const {

--- a/test/Constraints/diag_ambiguities.swift
+++ b/test/Constraints/diag_ambiguities.swift
@@ -68,3 +68,13 @@ class MoviesViewController {
     _ = itemType // expected-error {{ambiguous use of 'itemType'}}
   }
 }
+
+// SR-15053
+func SR15053<T : Numeric>(_ a: T, _ b: T) -> T {
+  (a + b) / 2 // expected-error{{cannot convert return expression of type 'Int' to return type 'T'}}
+  // expected-error@-1{{cannot convert value of type 'T' to expected argument type 'Int'}}
+}
+
+func SR15053<T : Numeric>(_ a: T, _ b: T) {
+  (a + b) / 2 // expected-error{{cannot convert value of type 'T' to expected argument type 'Int'}}
+}

--- a/test/Constraints/rdar40002266.swift
+++ b/test/Constraints/rdar40002266.swift
@@ -6,6 +6,6 @@ import Foundation
 struct S {
   init<T: NSNumber>(_ num: T) { // expected-note {{where 'T' = 'Bool'}}
     self.init(num != 0) // expected-error {{initializer 'init(_:)' requires that 'Bool' inherit from 'NSNumber'}}
-    // expected-error@-1 {{referencing operator function '!=' on 'BinaryInteger' requires that 'T' conform to 'BinaryInteger'}}
+    // expected-error@-1 {{cannot convert value of type 'T' to expected argument type 'Int'}}
   }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
The problem here for this additional extra diagnostic
```swift
func fooAAA<T : Numeric>(_ a: T, _ b: T) -> T {
    // this results in two compile errors, first is correct, second should not be:
    // Binary operator '/' cannot be applied to operands of type 'T' and 'Int'    <=== this error is correct
    // Binary operator '+' cannot be applied to two 'T' operands    <=== !!! but this should not be an error!!!
    (a + b) / 2
}
```
Is that for some overloads attempted for `/` operator given the type bound to `T` some additional conformance fixes are recorded on `+` arguments which then latter arrive in diagnose overload ambiguity and end up producing the extra diagnostic. The initial idea was to try not record the conformance fixes in case operator locator is already anchored in a argument mismatch fix, but this didn't work, sometimes at the point conformance constraint is being simplified and fix is being recorded we may or may not have argument mismatch recorded being that because there is no mismatch for the current overload being attempted or because given the ordering of simplification of constraints arg mismatch fix is yet to be recorded. 

So this PR I took the approach of detecting this at the ambiguity diagnostic. But this PR is more to get your thoughts and suggestions on maybe better approaches in this case :)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-15053.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
