### PR TITLE
[5.5] Serialization: include global variables in the worklist-processing

### DIFF
--- a/test/SIL/Serialization/function-global-function.sil
+++ b/test/SIL/Serialization/function-global-function.sil
@@ -1,0 +1,26 @@
+// RUN: %target-sil-opt %s -serialize -o /dev/null
+
+sil_stage canonical
+
+import Builtin
+
+// Check that we don't crash if a serialiable function is referenced from the
+// initializer of a global variable.
+
+sil_global [serialized] @globalFuncPtr : $@callee_guaranteed () -> () = {
+  %0 = function_ref @calledFromFuncPtr : $@convention(thin) () -> ()
+  %initval = thin_to_thick_function %0 : $@convention(thin) () -> () to $@callee_guaranteed () -> ()
+}
+
+sil @caller : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @globalFuncPtr : $*@callee_guaranteed () -> ()
+  %7 = tuple ()
+  return %7 : $()
+}
+
+sil shared [serializable] @calledFromFuncPtr : $@convention(thin) () -> () {
+bb0:
+  %6 = tuple ()
+  return %6 : $()
+}

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -228,6 +228,9 @@ EmitVerboseSIL("emit-verbose-sil",
 static llvm::cl::opt<bool>
 EmitSIB("emit-sib", llvm::cl::desc("Emit serialized AST + SIL file(s)"));
 
+static llvm::cl::opt<bool>
+Serialize("serialize", llvm::cl::desc("Emit serialized AST + SIL file(s)"));
+
 static llvm::cl::opt<std::string>
 ModuleCachePath("module-cache-path", llvm::cl::desc("Clang module cache path"));
 
@@ -564,7 +567,7 @@ int main(int argc, char **argv) {
   }
   }
 
-  if (EmitSIB) {
+  if (EmitSIB || Serialize) {
     llvm::SmallString<128> OutputFile;
     if (OutputFilename.size()) {
       OutputFile = OutputFilename;
@@ -580,8 +583,8 @@ int main(int argc, char **argv) {
 
     SerializationOptions serializationOpts;
     serializationOpts.OutputPath = OutputFile.c_str();
-    serializationOpts.SerializeAllSIL = true;
-    serializationOpts.IsSIB = true;
+    serializationOpts.SerializeAllSIL = EmitSIB;
+    serializationOpts.IsSIB = EmitSIB;
 
     serialize(CI.getMainModule(), serializationOpts, SILMod.get());
   } else {


### PR DESCRIPTION
It's not sufficient to first serialize all functions and then serialize all globals, because a function can be referenced from the initializer expression of a global.
Therefore the worklist processing must include both, functions and globals.

This fixes a crash in the serializer, which is exposed through cross-module-optimization.

https://bugs.swift.org/browse/SR-15162
rdar://82827256

This is a cherry-pick of https://github.com/apple/swift/pull/39203
