### PR TITLE
Fix LoadBorrowImmutabilityAnalysis in cases it raises false errors on destroy_value

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -171,6 +171,9 @@ SILValue getAccessBase(SILValue address);
 /// AccessedStorage::getRoot() and AccessPath::getRoot().
 SILValue findReferenceRoot(SILValue ref);
 
+/// Find the first owned root of the reference.
+SILValue findOwnershipReferenceRoot(SILValue ref);
+
 /// Return true if \p address points to a let-variable.
 ///
 /// let-variables are only written during let-variable initialization, which is
@@ -1264,9 +1267,13 @@ SILBasicBlock::iterator removeBeginAccess(BeginAccessInst *beginAccess);
 
 namespace swift {
 
-/// Return true if \p svi is a cast that preserves the identity and
+/// Return true if \p svi is a cast that preserves the identity equivalence of
+/// the reference at operand zero.
+bool isIdentityPreservingRefCast(SingleValueInstruction *svi);
+
+/// Return true if \p svi is a cast that preserves the identity equivalence and
 /// reference-counting equivalence of the reference at operand zero.
-bool isRCIdentityPreservingCast(SingleValueInstruction *svi);
+bool isIdentityAndOwnershipPreservingRefCast(SingleValueInstruction *svi);
 
 /// If \p svi is an access projection, return an address-type operand for the
 /// incoming address.

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -125,10 +125,9 @@ SILValue swift::stripCastsWithoutMarkDependence(SILValue v) {
       return v;
 
     if (auto *svi = dyn_cast<SingleValueInstruction>(v)) {
-      if (isRCIdentityPreservingCast(svi)
-          || isa<UncheckedTrivialBitCastInst>(v)
-          || isa<BeginAccessInst>(v)
-          || isa<EndCOWMutationInst>(v)) {
+      if (isIdentityPreservingRefCast(svi) ||
+          isa<UncheckedTrivialBitCastInst>(v) || isa<BeginAccessInst>(v) ||
+          isa<EndCOWMutationInst>(v)) {
         v = svi->getOperand(0);
         continue;
       }
@@ -141,10 +140,9 @@ SILValue swift::stripCasts(SILValue v) {
   while (true) {
     v = stripSinglePredecessorArgs(v);
     if (auto *svi = dyn_cast<SingleValueInstruction>(v)) {
-      if (isRCIdentityPreservingCast(svi)
-          || isa<UncheckedTrivialBitCastInst>(v)
-          || isa<MarkDependenceInst>(v)
-          || isa<BeginAccessInst>(v)) {
+      if (isIdentityPreservingRefCast(svi) ||
+          isa<UncheckedTrivialBitCastInst>(v) || isa<MarkDependenceInst>(v) ||
+          isa<BeginAccessInst>(v)) {
         v = cast<SingleValueInstruction>(v)->getOperand(0);
         continue;
       }

--- a/lib/SIL/Verifier/LoadBorrowImmutabilityChecker.cpp
+++ b/lib/SIL/Verifier/LoadBorrowImmutabilityChecker.cpp
@@ -292,8 +292,8 @@ LoadBorrowImmutabilityAnalysis::LoadBorrowImmutabilityAnalysis(
 // \p address may be an address, pointer, or box type.
 bool LoadBorrowImmutabilityAnalysis::isImmutableInScope(
     LoadBorrowInst *lbi, ArrayRef<Operand *> endBorrowUses,
-    AccessPath accessPath) {
-
+    AccessPathWithBase accessPathWithBase) {
+  auto accessPath = accessPathWithBase.accessPath;
   LinearLifetimeChecker checker(deadEndBlocks);
   auto writes = cache.get(accessPath);
 
@@ -303,11 +303,20 @@ bool LoadBorrowImmutabilityAnalysis::isImmutableInScope(
     accessPath.getStorage().print(llvm::errs());
     return false;
   }
+  auto ownershipRoot = accessPath.getStorage().isReference()
+                           ? findOwnershipReferenceRoot(accessPathWithBase.base)
+                           : SILValue();
   // Then for each write...
   for (auto *op : *writes) {
     // First see if the write is a dead end block. In such a case, just skip it.
     if (deadEndBlocks.isDeadEnd(op->getUser()->getParent())) {
       continue;
+    }
+    // A destroy_value will be a definite write only when the destroy is on the
+    // ownershipRoot
+    if (isa<DestroyValueInst>(op->getUser())) {
+      if (op->get() != ownershipRoot)
+        continue;
     }
     // See if the write is within the load borrow's lifetime. If it isn't, we
     // don't have to worry about it.
@@ -326,7 +335,9 @@ bool LoadBorrowImmutabilityAnalysis::isImmutableInScope(
 //===----------------------------------------------------------------------===//
 
 bool LoadBorrowImmutabilityAnalysis::isImmutable(LoadBorrowInst *lbi) {
-  AccessPath accessPath = AccessPath::computeInScope(lbi->getOperand());
+  auto accessPathWithBase = AccessPathWithBase::compute(lbi->getOperand());
+  auto accessPath = accessPathWithBase.accessPath;
+
   // Bail on an invalid AccessPath. AccessPath completeness is verified
   // independently--it may be invalid in extraordinary situations. When
   // AccessPath is valid, we know all its uses are recognizable.
@@ -358,7 +369,7 @@ bool LoadBorrowImmutabilityAnalysis::isImmutable(LoadBorrowInst *lbi) {
     //
     // TODO: As a separate analysis, verify that the load_borrow scope is always
     // nested within the begin_access scope (to ensure no aliasing access).
-    return isImmutableInScope(lbi, endBorrowUses, accessPath);
+    return isImmutableInScope(lbi, endBorrowUses, accessPathWithBase);
   }
   case AccessedStorage::Argument: {
     auto *arg =
@@ -366,7 +377,7 @@ bool LoadBorrowImmutabilityAnalysis::isImmutable(LoadBorrowInst *lbi) {
     if (arg->hasConvention(SILArgumentConvention::Indirect_In_Guaranteed)) {
       return true;
     }
-    return isImmutableInScope(lbi, endBorrowUses, accessPath);
+    return isImmutableInScope(lbi, endBorrowUses, accessPathWithBase);
   }
   // FIXME: A yielded address could overlap with another in this function.
   case AccessedStorage::Yield:
@@ -376,7 +387,7 @@ bool LoadBorrowImmutabilityAnalysis::isImmutable(LoadBorrowInst *lbi) {
   case AccessedStorage::Tail:
   case AccessedStorage::Global:
   case AccessedStorage::Unidentified:
-    return isImmutableInScope(lbi, endBorrowUses, accessPath);
+    return isImmutableInScope(lbi, endBorrowUses, accessPathWithBase);
   }
   llvm_unreachable("Covered switch isn't covered?!");
 }

--- a/lib/SIL/Verifier/VerifierPrivate.h
+++ b/lib/SIL/Verifier/VerifierPrivate.h
@@ -41,7 +41,7 @@ public:
 private:
   bool isImmutableInScope(LoadBorrowInst *lbi,
                           ArrayRef<Operand *> endBorrowUses,
-                          AccessPath accessPath);
+                          AccessPathWithBase accessPathWithBase);
 };
 
 } // namespace silverifier

--- a/test/SIL/ownership-verifier/load_borrow_invalidation_test.sil
+++ b/test/SIL/ownership-verifier/load_borrow_invalidation_test.sil
@@ -428,3 +428,29 @@ bb0(%0 : @owned $Builtin.NativeObject):
   %9999 = tuple()
   return %9999 : $()
 }
+
+class ComplexStruct {
+  var val : NonTrivialStruct
+}
+
+class Klass {
+}
+
+struct NonTrivialStruct {
+  var val : Klass
+}
+
+sil [ossa] @test_borrow : $@convention(thin) (@owned ComplexStruct) -> () {
+bb0(%0 : @owned $ComplexStruct):
+  %2 = copy_value %0 : $ComplexStruct
+  %4 = begin_borrow %2 : $ComplexStruct
+  %5 = ref_element_addr %4 : $ComplexStruct, #ComplexStruct.val
+  %6 = load_borrow %5 : $*NonTrivialStruct
+  destroy_value %0 : $ComplexStruct
+  end_borrow %6 : $NonTrivialStruct
+  end_borrow %4 : $ComplexStruct
+  destroy_value %2 : $ComplexStruct
+  %ret = tuple ()
+  return %ret : $()
+}
+


### PR DESCRIPTION
We should only flag an error if there is a destroy_value on the first owned root of the access path.

