### PR TITLE
Skip standard substitutions for _Concurrency types when back-deploying.

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -56,6 +56,10 @@ protected:
   /// to fill these in.
   bool AllowSymbolicReferences = false;
 
+  /// If enabled, allows the use of standard substitutions for types in the
+  /// concurrency library.
+  bool AllowConcurrencyStandardSubstitutions = true;
+
 public:
   using SymbolicReferent = llvm::PointerUnion<const NominalTypeDecl *,
                                               const OpaqueTypeDecl *>;

--- a/include/swift/Demangling/ManglingUtils.h
+++ b/include/swift/Demangling/ManglingUtils.h
@@ -99,7 +99,12 @@ char translateOperatorChar(char op);
 std::string translateOperator(StringRef Op);
 
 /// Returns the standard type kind for an 'S' substitution, e.g. 'i' for "Int".
-llvm::Optional<StringRef> getStandardTypeSubst(StringRef TypeName);
+///
+/// \param allowConcurrencyManglings When true, allows the standard
+/// substitutions for types in the _Concurrency module that were introduced in
+/// Swift 5.5.
+llvm::Optional<StringRef> getStandardTypeSubst(
+    StringRef TypeName, bool allowConcurrencyManglings);
 
 /// Mangles an identifier using a generic Mangler class.
 ///

--- a/include/swift/Demangling/StandardTypesMangling.def
+++ b/include/swift/Demangling/StandardTypesMangling.def
@@ -13,10 +13,10 @@
 /// STANDARD_TYPE(KIND, MANGLING, TYPENAME)
 ///   The 1-character MANGLING for a known TYPENAME of KIND.
 ///
-/// STANDARD_TYPE_2(KIND, MANGLING, TYPENAME)
+/// STANDARD_TYPE_CONCURRENCY(KIND, MANGLING, TYPENAME)
 ///   The 1-character MANGLING for a known TYPENAME of KIND that is in the
-///   second level of standard types, all of which are mangled with the form
-///   Sc<MANGLING>.
+///   second level of standard types in the Concurrency model, all of which are
+///   mangled with the form Sc<MANGLING>.
 ///
 /// OBJC_INTEROP_STANDARD_TYPE(KIND, MANGLING, TYPENAME)
 ///   The 1-character MANGLING for a known TYPENAME of KIND, for a type that's
@@ -79,25 +79,25 @@ STANDARD_TYPE(Protocol, y, StringProtocol)
 STANDARD_TYPE(Protocol, Z, SignedInteger)
 STANDARD_TYPE(Protocol, z, BinaryInteger)
 
-STANDARD_TYPE_2(Protocol, A, Actor)
-STANDARD_TYPE_2(Structure, C, CheckedContinuation)
-STANDARD_TYPE_2(Structure, c, UnsafeContinuation)
-STANDARD_TYPE_2(Structure, E, CancellationError)
-STANDARD_TYPE_2(Structure, e, UnownedSerialExecutor)
-STANDARD_TYPE_2(Protocol, F, Executor)
-STANDARD_TYPE_2(Protocol, f, SerialExecutor)
-STANDARD_TYPE_2(Structure, G, TaskGroup)
-STANDARD_TYPE_2(Structure, g, ThrowingTaskGroup)
-STANDARD_TYPE_2(Protocol, I, AsyncIteratorProtocol)
-STANDARD_TYPE_2(Protocol, i, AsyncSequence)
-STANDARD_TYPE_2(Structure, J, UnownedJob)
-STANDARD_TYPE_2(Class, M, MainActor)
-STANDARD_TYPE_2(Structure, P, TaskPriority)
-STANDARD_TYPE_2(Structure, S, AsyncStream)
-STANDARD_TYPE_2(Structure, s, AsyncThrowingStream)
-STANDARD_TYPE_2(Structure, T, Task)
-STANDARD_TYPE_2(Structure, t, UnsafeCurrentTask)
+STANDARD_TYPE_CONCURRENCY(Protocol, A, Actor)
+STANDARD_TYPE_CONCURRENCY(Structure, C, CheckedContinuation)
+STANDARD_TYPE_CONCURRENCY(Structure, c, UnsafeContinuation)
+STANDARD_TYPE_CONCURRENCY(Structure, E, CancellationError)
+STANDARD_TYPE_CONCURRENCY(Structure, e, UnownedSerialExecutor)
+STANDARD_TYPE_CONCURRENCY(Protocol, F, Executor)
+STANDARD_TYPE_CONCURRENCY(Protocol, f, SerialExecutor)
+STANDARD_TYPE_CONCURRENCY(Structure, G, TaskGroup)
+STANDARD_TYPE_CONCURRENCY(Structure, g, ThrowingTaskGroup)
+STANDARD_TYPE_CONCURRENCY(Protocol, I, AsyncIteratorProtocol)
+STANDARD_TYPE_CONCURRENCY(Protocol, i, AsyncSequence)
+STANDARD_TYPE_CONCURRENCY(Structure, J, UnownedJob)
+STANDARD_TYPE_CONCURRENCY(Class, M, MainActor)
+STANDARD_TYPE_CONCURRENCY(Structure, P, TaskPriority)
+STANDARD_TYPE_CONCURRENCY(Structure, S, AsyncStream)
+STANDARD_TYPE_CONCURRENCY(Structure, s, AsyncThrowingStream)
+STANDARD_TYPE_CONCURRENCY(Structure, T, Task)
+STANDARD_TYPE_CONCURRENCY(Structure, t, UnsafeCurrentTask)
 
 #undef STANDARD_TYPE
 #undef OBJC_INTEROP_STANDARD_TYPE
-#undef STANDARD_TYPE_2
+#undef STANDARD_TYPE_CONCURRENCY

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2973,7 +2973,8 @@ bool ASTMangler::tryAppendStandardSubstitution(const GenericTypeDecl *decl) {
     return false;
 
   if (isa<NominalTypeDecl>(decl)) {
-    if (auto Subst = getStandardTypeSubst(decl->getName().str())) {
+    if (auto Subst = getStandardTypeSubst(
+            decl->getName().str(), AllowConcurrencyStandardSubstitutions)) {
       if (!SubstMerging.tryMergeSubst(*this, *Subst, /*isStandardSubst*/ true)){
         appendOperator("S", *Subst);
       }

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -975,7 +975,7 @@ NodePointer Demangler::createStandardSubstitution(
     return createSwiftType(Node::Kind::KIND, #TYPENAME);          \
   }
 
-#define STANDARD_TYPE_2(KIND, MANGLING, TYPENAME)                   \
+#define STANDARD_TYPE_CONCURRENCY(KIND, MANGLING, TYPENAME)                   \
   if (SecondLevel && Subst == #MANGLING[0]) {                    \
     return createSwiftType(Node::Kind::KIND, #TYPENAME);          \
   }

--- a/lib/Demangling/ManglingUtils.cpp
+++ b/lib/Demangling/ManglingUtils.cpp
@@ -66,15 +66,16 @@ std::string Mangle::translateOperator(StringRef Op) {
   return Encoded;
 }
 
-llvm::Optional<StringRef> Mangle::getStandardTypeSubst(StringRef TypeName) {
+llvm::Optional<StringRef> Mangle::getStandardTypeSubst(
+    StringRef TypeName, bool allowConcurrencyManglings) {
 #define STANDARD_TYPE(KIND, MANGLING, TYPENAME)      \
   if (TypeName == #TYPENAME) {                       \
     return StringRef(#MANGLING);                     \
   }
 
-#define STANDARD_TYPE_2(KIND, MANGLING, TYPENAME)    \
-  if (TypeName == #TYPENAME) {                       \
-    return StringRef("c" #MANGLING);                 \
+#define STANDARD_TYPE_CONCURRENCY(KIND, MANGLING, TYPENAME)    \
+  if (allowConcurrencyManglings && TypeName == #TYPENAME) {    \
+    return StringRef("c" #MANGLING);                           \
   }
 
 #include "swift/Demangling/StandardTypesMangling.def"

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -397,7 +397,8 @@ bool Remangler::mangleStandardSubstitution(Node *node) {
   if (node->getChild(1)->getKind() != Node::Kind::Identifier)
     return false;
 
-  if (auto Subst = getStandardTypeSubst(node->getChild(1)->getText())) {
+  if (auto Subst = getStandardTypeSubst(
+          node->getChild(1)->getText(), /*allowConcurrencyManglings=*/true)) {
     if (!SubstMerging.tryMergeSubst(*this, *Subst, /*isStandardSubst*/ true)) {
       Buffer << 'S' << *Subst;
     }

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -16,6 +16,7 @@
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/ProtocolAssociations.h"
 #include "swift/AST/ProtocolConformance.h"
+#include "swift/Basic/Platform.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/ABI/MetadataValues.h"
@@ -98,7 +99,8 @@ IRGenMangler::withSymbolicReferences(IRGenModule &IGM,
       // manglings already, and the runtime ought to have a lookup table for
       // them. Symbolic referencing would be wasteful.
       if (type->getModuleContext()->hasStandardSubstitutions()
-          && Mangle::getStandardTypeSubst(type->getName().str())) {
+          && Mangle::getStandardTypeSubst(
+               type->getName().str(), AllowConcurrencyStandardSubstitutions)) {
         return false;
       }
       
@@ -146,6 +148,17 @@ SymbolicMangling
 IRGenMangler::mangleTypeForReflection(IRGenModule &IGM,
                                       CanGenericSignature Sig,
                                       CanType Ty) {
+  // If our target predates Swift 5.5, we cannot apply the standard
+  // substitutions for types defined in the Concurrency module.
+  ASTContext &ctx = Ty->getASTContext();
+  llvm::SaveAndRestore<bool> savedConcurrencyStandardSubstitutions(
+      AllowConcurrencyStandardSubstitutions);
+  if (auto runtimeCompatVersion = getSwiftRuntimeCompatibilityVersionForTarget(
+          ctx.LangOpts.Target)) {
+    if (*runtimeCompatVersion < llvm::VersionTuple(5, 5))
+      AllowConcurrencyStandardSubstitutions = false;
+  }
+
   return withSymbolicReferences(IGM, [&]{
     appendType(Ty, Sig);
   });

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -675,7 +675,7 @@ _searchTypeMetadataRecords(TypeMetadataPrivateState &T,
 
 // FIXME: When the _Concurrency library gets merged into the Standard Library,
 // we will be able to reference those symbols directly as well.
-#define STANDARD_TYPE_2(KIND, MANGLING, TYPENAME)
+#define STANDARD_TYPE_CONCURRENCY(KIND, MANGLING, TYPENAME)
 
 #if !SWIFT_OBJC_INTEROP
 # define OBJC_INTEROP_STANDARD_TYPE(KIND, MANGLING, TYPENAME)
@@ -709,7 +709,7 @@ _findContextDescriptor(Demangle::NodePointer node,
     }
   // FIXME: When the _Concurrency library gets merged into the Standard Library,
   // we will be able to reference those symbols directly as well.
-#define STANDARD_TYPE_2(KIND, MANGLING, TYPENAME)
+#define STANDARD_TYPE_CONCURRENCY(KIND, MANGLING, TYPENAME)
 #if !SWIFT_OBJC_INTEROP
 # define OBJC_INTEROP_STANDARD_TYPE(KIND, MANGLING, TYPENAME)
 #endif


### PR DESCRIPTION
When back-deploying concurrency support, do not use the standard
substitutions for _Concurrency-defined types (such as `Task`) in type
metadata because older Swift runtimes will not be able to demangle
them. Instead, use the full mangled names so the runtime can still
demangle them appropriately.

Addresses rdar://82931890.
