### PR TITLE
ClangImporter: import SPIs from underlying clang modules by default

### DIFF
--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -513,8 +513,8 @@ ModuleImplicitImportsRequest::evaluate(Evaluator &evaluator,
     unloadedImports.emplace_back(UnloadedImportedModule(importPath.copyTo(ctx),
                                                         /*isScoped=*/false),
                                  ImportFlags::Exported);
-    imports.back().options |= ImportFlags::SPIAccessControl;
-    imports.back().spiGroups = ctx.AllocateCopy(clangSpiGroups);
+    unloadedImports.back().options |= ImportFlags::SPIAccessControl;
+    unloadedImports.back().spiGroups = ctx.AllocateCopy(clangSpiGroups);
   }
 
   return { ctx.AllocateCopy(imports), ctx.AllocateCopy(unloadedImports) };

--- a/test/ClangImporter/availability_spi_as_unavailable.swift
+++ b/test/ClangImporter/availability_spi_as_unavailable.swift
@@ -1,7 +1,10 @@
 // REQUIRES: OS=macosx
-// RUN: %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks -verify
+// RUN: %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks -verify -DNOT_UNDERLYING
+// RUN: %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks -module-name SPIContainer -import-underlying-module -verify
 
+#if NOT_UNDERLYING
 import SPIContainer
+#endif
 
 @_spi(a) public let a: SPIInterface1
 @_spi(a) public let b: SPIInterface2


### PR DESCRIPTION
rdar://82822440
