### PR TITLE
Remove metadata section functions from the stdlib

### DIFF
--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -118,17 +118,3 @@ public func _getTypeByMangledNameInContext(
   genericContext: UnsafeRawPointer?,
   genericArguments: UnsafeRawPointer?)
   -> Any.Type?
-
-@_silgen_name("swift_getMetadataSection")
-public func _getMetadataSection(
-  _ index: UInt)
-  -> UnsafeRawPointer?
-
-@_silgen_name("swift_getMetadataSectionCount")
-public func _getMetadataSectionCount()
-  -> UInt
-
-@_silgen_name("swift_getMetadataSectionName")
-public func _getMetadataSectionName(
-  _ metadata_section: UnsafeRawPointer)
-  -> UnsafePointer<CChar>

--- a/stdlib/public/runtime/ImageInspectionCommon.cpp
+++ b/stdlib/public/runtime/ImageInspectionCommon.cpp
@@ -131,9 +131,10 @@ void swift::initializeTypeMetadataRecordLookup() {
 void swift::initializeDynamicReplacementLookup() {
 }
 
+#ifndef NDEBUG
+
 SWIFT_RUNTIME_EXPORT
 const swift::MetadataSections *swift_getMetadataSection(size_t index) {
-  #ifndef NDEBUG
   if (swift::registered == nullptr) {
     return nullptr;
   }
@@ -147,27 +148,21 @@ const swift::MetadataSections *swift_getMetadataSection(size_t index) {
     --index;
   }
   return selected;
-  #else // NDEBUG
-  return nullptr;
-  #endif // else NDEBUG
 }
 
 SWIFT_RUNTIME_EXPORT
 const char *swift_getMetadataSectionName(void *metadata_section) {
-  #ifndef NDEBUG
   swift::SymbolInfo info;
   if (lookupSymbol(metadata_section, &info)) {
     if (info.fileName) {
       return info.fileName;
     }
   }
-  #endif // NDEBUG
   return "";
 }
 
 SWIFT_RUNTIME_EXPORT
 size_t swift_getMetadataSectionCount() {
-  #ifndef NDEBUG
   if (swift::registered == nullptr)
     return 0;
 
@@ -176,10 +171,10 @@ size_t swift_getMetadataSectionCount() {
        current != swift::registered; current = current->next, ++count);
 
   return count;
-  #else // NDEBUG
-  return 0;
-  #endif // else NDEBUG
 }
+
+#endif // NDEBUG
+
 #endif // !defined(__MACH__)
 
 #endif // SWIFT_RUNTIME_IMAGEINSPECTIONCOMMON_H

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -50,11 +50,6 @@
 Func _prespecialize() is a new API without @available attribute
 Func _stdlib_isOSVersionAtLeastOrVariantVersionAtLeast(_:_:_:_:_:_:) is a new API without @available attribute
 
-// These reflection APIs are exposed to facilitate building SwiftReflectionTest.swift when testing Release builds.
-Func _getMetadataSection(_:) is a new API without @available attribute
-Func _getMetadataSectionCount() is a new API without @available attribute
-Func _getMetadataSectionName(_:) is a new API without @available attribute
-
 Func Collection.removingSubranges(_:) has been removed
 Func Collection.subranges(of:) has been removed
 Func Collection.subranges(where:) has been removed


### PR DESCRIPTION
Remove the `@_silgen_name` aliases from the stdlib, and instead add them conditionally in the test suite.