### PR TITLE
[ConstraintSystem] Propagate holes up to result of optional chaining

### DIFF
--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -797,3 +797,21 @@ func test_weak_with_nonoptional_type() {
     42
   }
 }
+
+// rdar://80941497 - compiler fails to produce diagnostic when referencing missing member in optional context
+func test_missing_member_in_optional_context() {
+  struct Test {
+  }
+
+  var test: Test? = nil
+
+  tuplify(true) { c in
+    if let prop = test?.prop { // expected-error {{value of type 'Test' has no member 'prop'}}
+      0
+    }
+
+    if let method = test?.method() { // expected-error {{value of type 'Test' has no member 'method'}}
+      1
+    }
+  }
+}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -1089,8 +1089,7 @@ func rdar74711236() {
     var s = S()
 
     s.arr = {
-      // FIXME: Missing member reference is pattern needs a better diagnostic
-      if let type = context?.store { // expected-error {{type of expression is ambiguous without more context}}
+        if let type = context?.store { // expected-error {{value of type 'Context' has no member 'store'}}
         // `isSupported` should be an invalid declaration to trigger a crash in `map(\.option)`
         let isSupported = context!.supported().contains(type)
         return (isSupported ? [type] : []).map(\.option)


### PR DESCRIPTION
If underlying type of an optional chain has been marked as a hole,
e.g. due to a reference to an invalid or missing member, let's
propagate that information to object type of an optional that
represents a result of an optional chain.

Resolves: rdar://80941497

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
