### PR TITLE
[DebugInfo] Adding more SIL DIExpression operator and swift::salvageDebugInfo rules

### DIFF
--- a/include/swift/SIL/SILDebugInfoExpression.h
+++ b/include/swift/SIL/SILDebugInfoExpression.h
@@ -259,6 +259,19 @@ public:
 
   /// Create a op_fragment expression
   static SILDebugInfoExpression createFragment(VarDecl *Field);
+
+  /// Return true if this DIExpression starts with op_deref
+  bool startsWithDeref() const {
+    return Elements.size() &&
+           Elements[0].getAsOperator() == SILDIExprOperator::Dereference;
+  }
+
+  /// Return true if this DIExpression has op_fragment (at the end)
+  bool hasFragment() const {
+    return Elements.size() >= 2 &&
+           Elements[Elements.size() - 2].getAsOperator() ==
+            SILDIExprOperator::Fragment;
+  }
 };
 } // end namespace swift
 #endif

--- a/include/swift/SIL/SILDebugInfoExpression.h
+++ b/include/swift/SIL/SILDebugInfoExpression.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_SIL_DEBUGINFOEXPRESSION_H
 #define SWIFT_SIL_DEBUGINFOEXPRESSION_H
 #include "swift/AST/Decl.h"
+#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/iterator_range.h"
@@ -36,17 +37,30 @@ enum class SILDIExprOperator : unsigned {
   /// VarDecl operand pointing to the field declaration.
   /// Note that this directive can only appear at the end of an
   /// expression.
-  Fragment
+  Fragment,
+  /// Perform arithmetic addition on the top two elements of the
+  /// expression stack and push the result back to the stack.
+  Plus,
+  /// Subtract the top element in expression stack by the second
+  /// element. Then push the result back to the stack.
+  Minus,
+  /// Push an unsigned integer constant onto the stack.
+  ConstUInt,
+  /// Push a signed integer constant onto the stack.
+  ConstSInt
 };
 
 /// Represents a single component in a debug info expression.
 /// Including operator and operand.
 struct SILDIExprElement {
   enum Kind {
-    /// A di-expression operator
+    /// A di-expression operator.
     OperatorKind,
-    /// An operand that has declaration type
-    DeclKind
+    /// An operand that has declaration type.
+    DeclKind,
+    /// An integer constant value. Note that
+    /// we don't specify its signedness here.
+    ConstIntKind
   };
 
 private:
@@ -55,6 +69,7 @@ private:
   union {
     SILDIExprOperator Operator;
     Decl *Declaration;
+    uint64_t ConstantInt;
   };
 
   explicit SILDIExprElement(Kind OpK) : OpKind(OpK) {}
@@ -68,6 +83,13 @@ public:
 
   Decl *getAsDecl() const { return OpKind == DeclKind ? Declaration : nullptr; }
 
+  Optional<uint64_t> getAsConstInt() const {
+    if (OpKind == ConstIntKind)
+      return ConstantInt;
+    else
+      return {};
+  }
+
   static SILDIExprElement createOperator(SILDIExprOperator Op) {
     SILDIExprElement DIOp(OperatorKind);
     DIOp.Operator = Op;
@@ -77,6 +99,12 @@ public:
   static SILDIExprElement createDecl(Decl *D) {
     SILDIExprElement DIOp(DeclKind);
     DIOp.Declaration = D;
+    return DIOp;
+  }
+
+  static SILDIExprElement createConstInt(uint64_t V) {
+    SILDIExprElement DIOp(ConstIntKind);
+    DIOp.ConstantInt = V;
     return DIOp;
   }
 };

--- a/include/swift/SIL/SILInstructionWorklist.h
+++ b/include/swift/SIL/SILInstructionWorklist.h
@@ -37,6 +37,7 @@
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/SILValue.h"
+#include "swift/SILOptimizer/Utils/DebugOptUtils.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
@@ -309,7 +310,9 @@ public:
   void eraseInstFromFunction(SILInstruction &instruction,
                              SILBasicBlock::iterator &iterator,
                              bool addOperandsToWorklist = true) {
-    // Delete any debug users first.
+    // Try to salvage debug info first.
+    swift::salvageDebugInfo(&instruction);
+    // Then delete old debug users.
     for (auto result : instruction.getResults()) {
       while (!result->use_empty()) {
         auto *user = result->use_begin()->getUser();

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2416,6 +2416,24 @@ bool IRGenDebugInfoImpl::buildDebugInfoExpression(
     case SILDIExprOperator::Dereference:
       Operands.push_back(llvm::dwarf::DW_OP_deref);
       break;
+    case SILDIExprOperator::ConstUInt:
+    case SILDIExprOperator::ConstSInt: {
+      auto Args = ExprOperand.args();
+      assert(Args.size() == 1 &&
+             "Incorrect number of argument for op_constu/op_consts");
+      if (ExprOperand.getOperator() == SILDIExprOperator::ConstUInt)
+        Operands.push_back(llvm::dwarf::DW_OP_constu);
+      else
+        Operands.push_back(llvm::dwarf::DW_OP_consts);
+      Operands.push_back(*Args[0].getAsConstInt());
+      break;
+    }
+    case SILDIExprOperator::Plus:
+      Operands.push_back(llvm::dwarf::DW_OP_plus);
+      break;
+    case SILDIExprOperator::Minus:
+      Operands.push_back(llvm::dwarf::DW_OP_minus);
+      break;
     default:
       llvm_unreachable("Unrecognized operator");
     }

--- a/lib/SIL/IR/SILDebugInfoExpression.cpp
+++ b/lib/SIL/IR/SILDebugInfoExpression.cpp
@@ -37,7 +37,13 @@ const SILDIExprInfo *SILDIExprInfo::get(SILDIExprOperator Op) {
   static const std::unordered_map<SILDIExprOperator, SILDIExprInfo> Infos = {
       {SILDIExprOperator::Fragment,
        {"op_fragment", {SILDIExprElement::DeclKind}}},
-      {SILDIExprOperator::Dereference, {"op_deref", {}}}};
+      {SILDIExprOperator::Dereference, {"op_deref", {}}},
+      {SILDIExprOperator::Plus, {"op_plus", {}}},
+      {SILDIExprOperator::Minus, {"op_minus", {}}},
+      {SILDIExprOperator::ConstUInt,
+       {"op_constu", {SILDIExprElement::ConstIntKind}}},
+      {SILDIExprOperator::ConstSInt,
+       {"op_consts", {SILDIExprElement::ConstIntKind}}}};
 
   return Infos.count(Op) ? &Infos.at(Op) : nullptr;
 }

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1656,7 +1656,11 @@ bool SILParser::parseSILDebugInfoExpression(SILDebugInfoExpression &DIExpr) {
   // All operators that we currently support
   static const SILDIExprOperator AllOps[] = {
     SILDIExprOperator::Dereference,
-    SILDIExprOperator::Fragment
+    SILDIExprOperator::Fragment,
+    SILDIExprOperator::Plus,
+    SILDIExprOperator::Minus,
+    SILDIExprOperator::ConstUInt,
+    SILDIExprOperator::ConstSInt
   };
 
   do {
@@ -1687,6 +1691,23 @@ bool SILParser::parseSILDebugInfoExpression(SILDebugInfoExpression &DIExpr) {
             return true;
           }
           auto NewOperand = SILDIExprElement::createDecl(Result.getDecl());
+          DIExpr.push_back(NewOperand);
+          break;
+        }
+        case SILDIExprElement::ConstIntKind: {
+          bool IsNegative = false;
+          if (P.Tok.is(tok::oper_prefix) && P.Tok.getRawText() == "-") {
+            P.consumeToken();
+            IsNegative = true;
+          }
+          int64_t Val;
+          // FIXME: Use the correct diagnostic
+          if (parseInteger(Val, diag::sil_invalid_scope_slot))
+            return true;
+          if (IsNegative)
+            Val = -Val;
+          auto NewOperand =
+            SILDIExprElement::createConstInt(static_cast<uint64_t>(Val));
           DIExpr.push_back(NewOperand);
           break;
         }

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -666,7 +666,7 @@ class SILVerifier : public SILVerifierBase<SILVerifier> {
   const SILFunction &F;
   SILFunctionConventions fnConv;
   Lowering::TypeConverter &TC;
-  SmallVector<StringRef, 16> DebugVars;
+  SmallVector<std::pair<StringRef, SILType>, 16> DebugVars;
   const SILInstruction *CurInstruction = nullptr;
   const SILArgument *CurArgument = nullptr;
   std::unique_ptr<DominanceInfo> Dominance;
@@ -1265,6 +1265,25 @@ public:
     if (!varInfo)
       return;
 
+    // Retrive debug variable type
+    SILType DebugVarTy;
+    if (varInfo->Type)
+      DebugVarTy = *varInfo->Type;
+    else {
+      // Fetch from related SSA value
+      switch (inst->getKind()) {
+      case SILInstructionKind::AllocStackInst:
+      case SILInstructionKind::AllocBoxInst:
+        DebugVarTy = inst->getResult(0)->getType();
+        break;
+      case SILInstructionKind::DebugValueInst:
+        DebugVarTy = inst->getOperand(0)->getType();
+        break;
+      default:
+        llvm_unreachable("");
+      }
+    }
+
     auto *debugScope = inst->getDebugScope();
     if (varInfo->ArgNo)
       require(!varInfo->Name.empty(), "function argument without a name");
@@ -1278,17 +1297,20 @@ public:
     if (debugScope && !debugScope->InlinedCallSite)
       if (unsigned argNum = varInfo->ArgNo) {
         // It is a function argument.
-        if (argNum < DebugVars.size() && !DebugVars[argNum].empty()) {
-          require(DebugVars[argNum] == varInfo->Name,
+        if (argNum < DebugVars.size() && !DebugVars[argNum].first.empty()) {
+          require(DebugVars[argNum].first == varInfo->Name,
                   "Scope contains conflicting debug variables for one function "
                   "argument");
+          // Check for type
+          require(DebugVars[argNum].second == DebugVarTy,
+                  "conflicting debug variable type!");
         } else {
           // Reserve enough space.
           while (DebugVars.size() <= argNum) {
-            DebugVars.push_back(StringRef());
+            DebugVars.push_back({StringRef(), SILType()});
           }
         }
-        DebugVars[argNum] = varInfo->Name;
+        DebugVars[argNum] = {varInfo->Name, DebugVarTy};
       }
 
     // Check the (auxiliary) debug variable scope

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -22,6 +22,7 @@
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBuilder.h"
+#include "swift/SIL/SILDebugInfoExpression.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILUndef.h"
 #include "swift/SIL/TypeLowering.h"
@@ -2126,5 +2127,46 @@ void swift::salvageDebugInfo(SILInstruction *I) {
           SILBuilder(SI, ASI->getDebugScope())
               .createDebugValue(SI->getLoc(), SI->getSrc(), *VarInfo);
       }
+  }
+
+  // If a `struct` SIL instruction is "unwrapped" and removed,
+  // for instance, in favor of using its enclosed value directly,
+  // we need to make sure any of its related `debug_value` instruction
+  // is preserved.
+  if (auto *STI = dyn_cast<StructInst>(I)) {
+    auto STVal = STI->getResult(0);
+    llvm::ArrayRef<VarDecl *> FieldDecls =
+      STI->getStructDecl()->getStoredProperties();
+    for (Operand *U : getDebugUses(STVal)) {
+      auto *DbgInst = cast<DebugValueInst>(U->getUser());
+      auto VarInfo = DbgInst->getVarInfo();
+      if (!VarInfo)
+        continue;
+      if (VarInfo->DIExpr.hasFragment())
+        // Since we can't merge two different op_fragment
+        // now, we're simply bailing out if there is an
+        // existing op_fragment in DIExpresison.
+        // TODO: Try to merge two op_fragment expressions here.
+        continue;
+      for (VarDecl *FD : FieldDecls) {
+        SILDebugVariable NewVarInfo = *VarInfo;
+        auto FieldVal = STI->getFieldValue(FD);
+        // Build the corresponding fragment DIExpression
+        auto FragDIExpr = SILDebugInfoExpression::createFragment(FD);
+        NewVarInfo.DIExpr.append(FragDIExpr);
+
+        // Coalesce auxiliary debug variable info
+        if (!NewVarInfo.Type)
+          NewVarInfo.Type = STI->getType();
+        if (!NewVarInfo.Loc)
+          NewVarInfo.Loc = DbgInst->getLoc();
+        if (!NewVarInfo.Scope)
+          NewVarInfo.Scope = DbgInst->getDebugScope();
+
+        // Create a new debug_value
+        SILBuilder(DbgInst, DbgInst->getDebugScope())
+          .createDebugValue(DbgInst->getLoc(), FieldVal, NewVarInfo);
+      }
+    }
   }
 }

--- a/test/DebugInfo/constant_propagation.sil
+++ b/test/DebugInfo/constant_propagation.sil
@@ -1,0 +1,40 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -sil-print-debuginfo -diagnostic-constant-propagation %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+func foo(x: Int, y: Int) -> Int
+
+sil_scope 1 { loc "file.swift":1:6 parent @foo : $@convention(thin) (Int, Int) -> Int }
+
+// Test if debug_value got preserved when %16 is removed in favor of directly using %13
+// CHECK-LABEL: sil {{.*}} @foo
+sil hidden @foo : $@convention(thin) (Int, Int) -> Int {
+bb0(%0 : $Int, %1 : $Int):
+  %4 = integer_literal $Builtin.Int64, 87, loc "file.swift":2:17, scope 1
+  %9 = struct_extract %0 : $Int, #Int._value, loc "file.swift":2:15, scope 1
+  %11 = integer_literal $Builtin.Int1, -1, loc "file.swift":2:15, scope 1
+  // CHECK: %[[ADD:.+]] = builtin "sadd_with_overflow
+  %12 = builtin "sadd_with_overflow_Int64"(%9 : $Builtin.Int64, %4 : $Builtin.Int64, %11 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1), loc "file.swift":2:15, scope 1
+  // CHECK: (%[[RESULT:.+]], %{{.*}}) = destructure_tuple %[[ADD]]
+  (%13, %14) = destructure_tuple %12 : $(Builtin.Int64, Builtin.Int1), loc "file.swift":2:15, scope 1
+  %16 = struct $Int (%13 : $Builtin.Int64), loc "file.swift":2:15, scope 1
+  // In addition to checking if `op_fragment` is generated, we're also checking if "z"'s declared
+  // source location, as well as `debug_value`'s instruction source location are preserved.
+  // CHECK: debug_value %[[RESULT]] : $Builtin.Int{{[0-9]+}}, let, (name "z", loc "file.swift":2:9, scope 1)
+  // CHECK-SAME: type $Int
+  // CHECK-SAME: expr op_fragment:#Int._value
+  // CHECK-SAME: loc "file.swift":2:9, scope 1
+  debug_value %16 : $Int, let, name "z", loc "file.swift":2:9, scope 1
+  %19 = struct_extract %16 : $Int, #Int._value, loc "file.swift":3:14, scope 1
+  %20 = struct_extract %1 : $Int, #Int._value, loc "file.swift":3:14, scope 1
+  %21 = integer_literal $Builtin.Int1, -1, loc "file.swift":3:14, scope 1
+  %22 = builtin "sadd_with_overflow_Int64"(%19 : $Builtin.Int64, %20 : $Builtin.Int64, %21 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1), loc "file.swift":3:14, scope 1
+  (%23, %24) = destructure_tuple %22 : $(Builtin.Int64, Builtin.Int1), loc "file.swift":3:14, scope 1
+  %26 = struct $Int (%23 : $Builtin.Int64), loc "file.swift":3:14, scope 1
+  return %26 : $Int, loc "file.swift":3:5, scope 1
+} // end sil function 'foo'
+

--- a/test/DebugInfo/constant_propagation.sil
+++ b/test/DebugInfo/constant_propagation.sil
@@ -24,7 +24,7 @@ bb0(%0 : $Int, %1 : $Int):
   %16 = struct $Int (%13 : $Builtin.Int64), loc "file.swift":2:15, scope 1
   // In addition to checking if `op_fragment` is generated, we're also checking if "z"'s declared
   // source location, as well as `debug_value`'s instruction source location are preserved.
-  // CHECK: debug_value %[[RESULT]] : $Builtin.Int{{[0-9]+}}, let, (name "z", loc "file.swift":2:9, scope 1)
+  // CHECK: debug_value %[[RESULT]] : $Builtin.Int{{[0-9]+}}, let, name "z"
   // CHECK-SAME: type $Int
   // CHECK-SAME: expr op_fragment:#Int._value
   // CHECK-SAME: loc "file.swift":2:9, scope 1

--- a/test/DebugInfo/debug_info_expression.sil
+++ b/test/DebugInfo/debug_info_expression.sil
@@ -14,7 +14,7 @@ struct SmallStruct {
 
 sil_scope 1 { loc "file.swift":7:6 parent @test_fragment : $@convention(thin) () -> () }
 
-// Testing op_fragment w/ debug_value_addr
+// Testing op_fragment w/ debug_value
 sil hidden @test_fragment : $@convention(thin) () -> () {
 bb0:
   %2 = alloc_stack $MyStruct, var, name "my_struct", loc "file.swift":8:9, scope 1
@@ -67,3 +67,26 @@ bb0:
   %r = tuple()
   return %r : $()
 }
+
+sil_scope 3 { loc "file.swift":16:7 parent @test_op_const : $@convention(thin) (Int64, Int64) -> () }
+
+// Testing op_constu and op_consts
+sil hidden @test_op_const : $@convention(thin) (Int64, Int64) -> () {
+bb0(%arg : $Int64, %arg2 : $Int64):
+  debug_value %arg : $Int64, let, name "the_arg", argno 1, expr op_constu:77, loc "file.swift":17:2, scope 3
+  debug_value %arg2 : $Int64, let, name "the_2nd_arg", argno 2, expr op_consts:-87, loc "file.swift":17:4, scope 3
+  %r = tuple()
+  return %r : $()
+}
+
+sil_scope 4 { loc "file.swift":18:8 parent @test_arithmetic : $@convention(thin) (Int64, Int64) -> () }
+
+// Testing basic arithmetic operators like op_plus and op_minus
+sil hidden @test_arithmetic : $@convention(thin) (Int64, Int64) -> () {
+bb0(%arg : $Int64, %arg2 : $Int64):
+  debug_value %arg : $Int64, let, name "the_arg", argno 1, expr op_constu:3:op_plus, loc "file.swift":19:2, scope 4
+  debug_value %arg2 : $Int64, let, name "the_2nd_arg", argno 2, expr op_constu:5:op_minus, loc "file.swift":19:4, scope 4
+  %r = tuple()
+  return %r : $()
+}
+

--- a/test/DebugInfo/sil_combine.sil
+++ b/test/DebugInfo/sil_combine.sil
@@ -1,0 +1,28 @@
+// RUN: %target-sil-opt -sil-verify-all -sil-combine %s | %FileCheck %s
+// RUN: %target-swift-frontend -g -O -emit-ir -primary-file %s | %FileCheck --check-prefix=CHECK-IR %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+// CHECK-LABEL: sil {{.*}} @test_nested_index_addr
+// CHECK-IR-LABEL: define {{.*}} @test_nested_index_addr
+sil hidden @test_nested_index_addr : $@convention(thin) (Builtin.RawPointer) -> Builtin.RawPointer {
+bb0(%0 : $Builtin.RawPointer):
+  %offset1 = integer_literal $Builtin.Word, 3
+  %offset2 = integer_literal $Builtin.Word, 7
+  // CHECK: %[[ADDR:.+]] = pointer_to_address %0
+  %addr = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*UInt8
+  %addr1 = index_addr %addr : $*UInt8, %offset1 : $Builtin.Word
+  // CHECK: debug_value %[[ADDR]] : $*UInt8, let, name "hello"
+  // CHECK-SAME: expr op_constu:3:op_plus:op_deref
+  // CHECK-IR: call void @llvm.dbg.value(metadata i8* %0, metadata ![[DBG_VAR:[0-9]+]],
+  // CHECK-IR-SAME: !DIExpression(DW_OP_constu, 3, DW_OP_plus, DW_OP_deref)
+  debug_value %addr1 : $*UInt8, let, name "hello", expr op_deref
+  %addr2 = index_addr %addr1 : $*UInt8, %offset2 : $Builtin.Word
+  %ptr = address_to_pointer %addr2 : $*UInt8 to $Builtin.RawPointer
+  return %ptr : $Builtin.RawPointer
+}
+
+// CHECK-IR: ![[DBG_VAR]] = !DILocalVariable(name: "hello"

--- a/test/SILOptimizer/no_size_specialization.swift
+++ b/test/SILOptimizer/no_size_specialization.swift
@@ -7,9 +7,9 @@ func foo<T>(_ t: T) -> T {
 }
 
 // CHECK-O-LABEL: sil @{{.*}}test
-// CHECK-O: %0 = integer_literal
-// CHECK-O: %1 = struct $Int
-// CHECK-O: return %1
+// CHECK-O: %[[LITERAL:.+]] = integer_literal $Builtin.Int{{[0-9]+}}, 27
+// CHECK-O: %[[STRUCT:.+]] = struct $Int (%[[LITERAL]] : $Builtin.Int{{[0-9]+}})
+// CHECK-O: return %[[STRUCT]]
 
 // CHECK-OSIZE-LABEL: sil {{.*}} @{{.*}}foo
 

--- a/test/SILOptimizer/specialize_opaque_type_archetypes.swift
+++ b/test/SILOptimizer/specialize_opaque_type_archetypes.swift
@@ -435,10 +435,10 @@ func createTrivial<T>(_ t: T) -> Trivial<T> {
 }
 
 // CHECK: sil @$s1A11testTrivialyyF : $@convention(thin) () -> ()
-// CHECK:   %0 = integer_literal $Builtin.Int64, 1
-// CHECK:   %1 = struct $Int64 (%0 : $Builtin.Int64)
-// CHECK:   %2 = function_ref @$s1A4usePyyxAA1PRzlFs5Int64V_Tg5 : $@convention(thin) (Int64) -> ()
-// CHECK:   %3 = apply %2(%1)
+// CHECK:   %[[LITERAL:.+]] = integer_literal $Builtin.Int64, 1
+// CHECK:   %[[STRUCT:.+]] = struct $Int64 (%[[LITERAL]] : $Builtin.Int64)
+// CHECK:   %[[FUNC:.+]] = function_ref @$s1A4usePyyxAA1PRzlFs5Int64V_Tg5 : $@convention(thin) (Int64) -> ()
+// CHECK:   apply %[[FUNC]](%[[STRUCT]])
 public func testTrivial() {
    let s = bar(10)
    let t = createTrivial(s)


### PR DESCRIPTION
This PR adds the following features:
1. Add new SIL DIExpression operator: `op_plus`, `op_minus`, `op_constu`, and `op_consts`.
2. Salvaging debug info whenever a `struct` instruction was removed (and there are `debug_value` associated with it)
3. Salvaging `index_addr` whenever it is removed using `op_plus` and `op_constu`/ `op_consts` operators.
4. Call `swift::salvageDebugInfo` in `eraseInstFromFunction`.
5. Add a new SILVerifier rule to prevent two DIVariables -- with different types -- conflicting with each other on the same argument number.If this rule fails, it's highly possible that we forgot to add 'inlinedAt' somewhere.
6. In the case of IRGen-ing explosion value w/ the need to attach DW_OP_LLVM_fragment, drop the fragment if it's covering the entire debug variable.

Currently it's failing to build (RelWithDebInfo version) stdlib caused by flaws that are caught by the new SILVerifier rule.

Previously, after #38736 was landed, we had at most 19% of improvement on the number of debug variables visible in debugger when measuring with swift-benchmark. This PR can bring another 7% improvement on the number of debug variables visible in debugger, and 11% improvement on the total number of debug variables.
