### PR TITLE
RequirementMachine: Reduction order on symbols should compare associated type name before protocols

### DIFF
--- a/lib/AST/RequirementMachine/Symbol.cpp
+++ b/lib/AST/RequirementMachine/Symbol.cpp
@@ -506,6 +506,9 @@ int Symbol::compare(Symbol other, const ProtocolGraph &graph) const {
     auto protos = getProtocols();
     auto otherProtos = other.getProtocols();
 
+    if (getName() != other.getName())
+      return getName().compare(other.getName());
+
     // Symbols with more protocols are 'smaller' than those with fewer.
     if (protos.size() != otherProtos.size())
       return protos.size() > otherProtos.size() ? -1 : 1;
@@ -516,7 +519,6 @@ int Symbol::compare(Symbol other, const ProtocolGraph &graph) const {
         return result;
     }
 
-    result = getName().compare(other.getName());
     break;
   }
 

--- a/test/Generics/associated_type_order.swift
+++ b/test/Generics/associated_type_order.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-emit-silgen %s -requirement-machine=on | %FileCheck %s
+
+protocol P1 {
+  associatedtype B
+}
+
+protocol P2 {
+  associatedtype A
+}
+
+// Make sure that T.[P1:A] < T.[P2:B].
+
+struct G<T : P1 & P2> where T.A == T.B {
+  // CHECK-LABEL: sil hidden [ossa] @$s21associated_type_order1GV3fooyy1AAA2P2PQzF : $@convention(method) <T where T : P1, T : P2, T.A == T.B> (@in_guaranteed T.A, G<T>) -> () {
+  func foo(_: T.A) {}
+}
+


### PR DESCRIPTION
The canonical order on associated types compares the name before the
protocol, so for example T.[P2:A] < T.[P1:B]. Make sure the reduction
order does the same so that we correctly compute canonical types in
this case.