### PR TITLE
swift_build_support: Add WASI to StdlibDeploymentTarget

### DIFF
--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -243,6 +243,8 @@ class StdlibDeploymentTarget(object):
 
     Haiku = Platform("haiku", archs=["x86_64"])
 
+    WASI = Platform("wasi", archs=["wasm32"])
+
     # The list of known platforms.
     known_platforms = [
         OSX,
@@ -256,7 +258,8 @@ class StdlibDeploymentTarget(object):
         Cygwin,
         Android,
         Windows,
-        Haiku]
+        Haiku,
+        WASI]
 
     # Cache of targets by name.
     _targets_by_name = dict((target.name, target)
@@ -337,6 +340,10 @@ class StdlibDeploymentTarget(object):
         elif system == 'Haiku':
             if machine == 'x86_64':
                 return StdlibDeploymentTarget.Haiku.x86_64
+
+        elif system == 'WASI':
+            if machine == 'wasm32':
+                return StdlibDeploymentTarget.WASI.wasm32
 
         raise NotImplementedError('System "%s" with architecture "%s" is not '
                                   'supported' % (system, machine))


### PR DESCRIPTION
This change adds support for WASI to `StdlibDeploymentTarget` in `swift_build_support/targets.py`. This will allow us to build stdlib for WASI in the future.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Related to SR-9307.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
