### PR TITLE
[Rebranch] Disable ELF-remove-autolink-section test

### DIFF
--- a/test/IRGen/ELF-remove-autolink-section.swift
+++ b/test/IRGen/ELF-remove-autolink-section.swift
@@ -1,5 +1,7 @@
 // RUN: %swiftc_driver -emit-ir %s -o - -Xfrontend -disable-implicit-concurrency-module-import | %FileCheck %s -check-prefix ELF
 
+// REQUIRES: SR-15184
+
 // Check that the swift auto link section is available in the object file.
 // RUN: %swiftc_driver -c %s -o %t -Xfrontend -disable-implicit-concurrency-module-import
 // RUN: llvm-readelf %t -S | %FileCheck %s -check-prefix SECTION


### PR DESCRIPTION
This test is failing on the rebranch branch and I don't know why.
It looks like a codesize savings, and so it should be safe to disable,
though less efficient.

Gating on https://bugs.swift.org/browse/SR-15184