### PR TITLE
[5.5][Driver] Support for emit-module-separately

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -581,8 +581,8 @@ def experimental_cxx_stdlib :
 
 def experimental_emit_module_separately:
   Flag<["-"], "experimental-emit-module-separately">,
-  Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
-  HelpText<"Schedule a swift module emission job instead of a merge-modules job (new Driver only)">;
+  Flags<[NoInteractiveOption, HelpHidden]>,
+  HelpText<"Emit module files as a distinct job (new Driver only)">;
 
 // Diagnostic control options
 def suppress_warnings : Flag<["-"], "suppress-warnings">,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -584,6 +584,11 @@ def experimental_emit_module_separately:
   Flags<[NoInteractiveOption, HelpHidden]>,
   HelpText<"Emit module files as a distinct job (new Driver only)">;
 
+def no_emit_module_separately:
+  Flag<["-"], "no-emit-module-separately">,
+  Flags<[NoInteractiveOption, HelpHidden]>,
+  HelpText<"Force using merge-module as the incremental build mode (new Driver only)">;
+
 // Diagnostic control options
 def suppress_warnings : Flag<["-"], "suppress-warnings">,
   Flags<[FrontendOption]>,

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -276,8 +276,11 @@ void SourceLookupCache::populateMemberCache(const ModuleDecl &Mod) {
                              "populate-module-class-member-cache");
 
   for (const FileUnit *file : Mod.getFiles()) {
-    auto &SF = *cast<SourceFile>(file);
-    addToMemberCache(SF.getTopLevelDecls());
+    assert(isa<SourceFile>(file) ||
+           isa<SynthesizedFileUnit>(file));
+    SmallVector<Decl *, 8> decls;
+    file->getTopLevelDecls(decls);
+    addToMemberCache(decls);
   }
 
   MemberCachePopulated = true;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1144,10 +1144,10 @@ CompilerInstance::getSourceFileParsingOptions(bool forPrimary) const {
       opts |= SourceFile::ParsingFlags::DisableDelayedBodies;
   }
 
+  auto typeOpts = getASTContext().TypeCheckerOpts;
   if (forPrimary || isWholeModuleCompilation()) {
     // Disable delayed body parsing for primaries and in WMO, unless
     // forcefully skipping function bodies
-    auto typeOpts = getASTContext().TypeCheckerOpts;
     if (typeOpts.SkipFunctionBodies == FunctionBodySkipping::None)
       opts |= SourceFile::ParsingFlags::DisableDelayedBodies;
   } else {
@@ -1156,9 +1156,10 @@ CompilerInstance::getSourceFileParsingOptions(bool forPrimary) const {
     opts |= SourceFile::ParsingFlags::SuppressWarnings;
   }
 
-  // Enable interface hash computation for primaries, but not in WMO, as it's
-  // only currently needed for incremental mode.
-  if (forPrimary) {
+  // Enable interface hash computation for primaries or emit-module-separately,
+  // but not in WMO, as it's only currently needed for incremental mode.
+  if (forPrimary ||
+      typeOpts.SkipFunctionBodies == FunctionBodySkipping::NonInlinableWithoutTypes) {
     opts |= SourceFile::ParsingFlags::EnableInterfaceHash;
   }
   return opts;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1549,9 +1549,19 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
     SerializationOptions serializationOpts =
         Invocation.computeSerializationOptions(outs, Instance.getMainModule());
 
+    // Infer if this is an emit-module job part of an incremental build,
+    // vs a partial emit-module job (with primary files) or other kinds.
+    // We may want to rely on a flag instead to differentiate them.
+    const bool isEmitModuleSeparately =
+        Action == FrontendOptions::ActionType::EmitModuleOnly &&
+        MSF.is<ModuleDecl *>() &&
+        Instance.getInvocation()
+            .getTypeCheckerOptions()
+            .SkipFunctionBodies == FunctionBodySkipping::NonInlinableWithoutTypes;
     const bool canEmitIncrementalInfoIntoModule =
         !serializationOpts.DisableCrossModuleIncrementalInfo &&
-        (Action == FrontendOptions::ActionType::MergeModules);
+        (Action == FrontendOptions::ActionType::MergeModules ||
+         isEmitModuleSeparately);
     if (canEmitIncrementalInfoIntoModule) {
       const auto alsoEmitDotFile =
           Instance.getInvocation()

--- a/test/Driver/Dependencies/one-way-merge-module-fine.swift
+++ b/test/Driver/Dependencies/one-way-merge-module-fine.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/one-way-fine/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v -no-emit-module-separately 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 // CHECK-FIRST-NOT: warning
 // CHECK-FIRST: Handled main.swift
@@ -14,7 +14,7 @@
 // swift-driver checks existence of all outputs
 // RUN: touch -t 201401240006 %t/{main,other,master}.swift{module,doc,sourceinfo}
 
-// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
+// RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v -no-emit-module-separately 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 // CHECK-SECOND-NOT: warning
 // CHECK-SECOND-NOT: Handled

--- a/test/InterfaceHash/added_function.swift
+++ b/test/InterfaceHash/added_function.swift
@@ -4,6 +4,11 @@
 // RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
 // RUN: not cmp %t/a.hash %t/b.hash
 
+/// We should generate an interface hash for emit-module-separately jobs even
+/// with no primaries.
+// RUN: %target-swift-frontend -dump-interface-hash %t/b.swift -experimental-skip-non-inlinable-function-bodies-without-types 2> %t/b-emit-module.hash
+// RUN: cmp %t/b.hash %t/b-emit-module.hash
+
 // BEGIN a.swift
 func f() {}
 


### PR DESCRIPTION
The new incremental build mode in the Swift driver, emit-module-separately, offers a more reliable alternative to merge-module. However, it needs some compiler-side improvements and fixes to work reliably with the existing incremental building logic.

- Scope of issue: These issues affect incremental compilation in emit-module-separately mode. This mode is still op-in but should be supported in future 5.5 releases.
- Origination: Introduction of the emit-module-separately compilation mode.
- Risk: Low as the feature is opt-in.
- Resolves: rdar://83956908
- Cherry-pick of #38211, #38939 and #38966.