### PR TITLE
[CSFix] Add support for `classof` for all fixes

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -357,6 +357,10 @@ enum class FixKind : uint8_t {
 
   /// Ignore a type imposed by an assignment destination e.g. `let x: Int = ...`
   IgnoreAssignmentDestinationType,
+
+  /// Allow argument-to-parameter subtyping even when parameter type
+  /// is marked as `inout`.
+  AllowConversionThroughInOut,
 };
 
 class ConstraintFix {
@@ -1993,7 +1997,8 @@ public:
 class AllowInOutConversion final : public ContextualMismatch {
   AllowInOutConversion(ConstraintSystem &cs, Type argType, Type paramType,
                        ConstraintLocator *locator)
-      : ContextualMismatch(cs, argType, paramType, locator) {}
+      : ContextualMismatch(cs, FixKind::AllowConversionThroughInOut, argType,
+                           paramType, locator) {}
 
 public:
   std::string getName() const override {
@@ -2005,6 +2010,10 @@ public:
   static AllowInOutConversion *create(ConstraintSystem &cs, Type argType,
                                       Type paramType,
                                       ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowConversionThroughInOut;
+  }
 };
 
 class AllowArgumentMismatch : public ContextualMismatch {

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -347,6 +347,10 @@ enum class FixKind : uint8_t {
   /// Fix conversion from async to sync function by removing explicit
   /// `async` attribute from the source function.
   DropAsyncAttribute,
+
+  /// Allow invalid pointer conversions for autoclosure result types as if the
+  /// pointer type is a function parameter rather than an autoclosure result.
+  AllowAutoClosurePointerConversion,
 };
 
 class ConstraintFix {
@@ -982,12 +986,12 @@ public:
   }
 };
 
-/// Allow invalid pointer conversions for autoclosure result types as if the
-/// pointer type is a function parameter rather than an autoclosure result.
 class AllowAutoClosurePointerConversion final : public ContextualMismatch {
   AllowAutoClosurePointerConversion(ConstraintSystem &cs, Type pointeeType,
-                                    Type pointerType, ConstraintLocator *locator)
-      : ContextualMismatch(cs, pointeeType, pointerType, locator) {}
+                                    Type pointerType,
+                                    ConstraintLocator *locator)
+      : ContextualMismatch(cs, FixKind::AllowAutoClosurePointerConversion,
+                           pointeeType, pointerType, locator) {}
 
 public:
   std::string getName() const override {
@@ -1000,6 +1004,10 @@ public:
                                                    Type pointeeType,
                                                    Type pointerType,
                                                    ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowAutoClosurePointerConversion;
+  }
 };
 
 class RemoveUnwrap final : public ConstraintFix {

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -335,6 +335,10 @@ enum class FixKind : uint8_t {
 
   /// Allow `weak` declarations to be bound to a non-optional type.
   AllowNonOptionalWeak,
+
+  /// Fix conversion from non-Sendable to Sendable by adding explicit
+  /// @Sendable attribute to the source function.
+  AddSendableAttribute,
 };
 
 class ConstraintFix {
@@ -735,8 +739,9 @@ public:
 /// function types, repair it by adding @Sendable attribute.
 class AddSendableAttribute final : public ContextualMismatch {
   AddSendableAttribute(ConstraintSystem &cs, FunctionType *fromType,
-                     FunctionType *toType, ConstraintLocator *locator)
-      : ContextualMismatch(cs, fromType, toType, locator) {
+                       FunctionType *toType, ConstraintLocator *locator)
+      : ContextualMismatch(cs, FixKind::AddSendableAttribute, fromType, toType,
+                           locator) {
     assert(fromType->isSendable() != toType->isSendable());
   }
 
@@ -746,9 +751,13 @@ public:
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static AddSendableAttribute *create(ConstraintSystem &cs,
-                                    FunctionType *fromType,
-                                    FunctionType *toType,
-                                    ConstraintLocator *locator);
+                                      FunctionType *fromType,
+                                      FunctionType *toType,
+                                      ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AddSendableAttribute;
+  }
 };
 
 /// This is a contextual mismatch between throwing and non-throwing

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -343,6 +343,10 @@ enum class FixKind : uint8_t {
   /// Fix conversion from throwing to non-throwing by removing explicit
   /// `throws` attribute from the source function.
   DropThrowsAttribute,
+
+  /// Fix conversion from async to sync function by removing explicit
+  /// `async` attribute from the source function.
+  DropAsyncAttribute,
 };
 
 class ConstraintFix {
@@ -794,7 +798,8 @@ public:
 class DropAsyncAttribute final : public ContextualMismatch {
   DropAsyncAttribute(ConstraintSystem &cs, FunctionType *fromType,
                      FunctionType *toType, ConstraintLocator *locator)
-      : ContextualMismatch(cs, fromType, toType, locator) {
+      : ContextualMismatch(cs, FixKind::DropAsyncAttribute, fromType, toType,
+                           locator) {
     assert(fromType->isAsync() != toType->isAsync());
   }
 
@@ -807,6 +812,10 @@ public:
                                     FunctionType *fromType,
                                     FunctionType *toType,
                                     ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::DropAsyncAttribute;
+  }
 };
 
 /// Append 'as! T' to force a downcast to the specified type.

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -2320,19 +2320,17 @@ class SpecifyKeyPathRootType final : public ConstraintFix {
     SpecifyKeyPathRootType(ConstraintSystem &cs, ConstraintLocator *locator)
         : ConstraintFix(cs, FixKind::SpecifyKeyPathRootType, locator) {}
 
-  public:
-    std::string getName() const override {
-      return "specify key path root type";
-    }
+public:
+  std::string getName() const override { return "specify key path root type"; }
 
-    bool diagnose(const Solution &solution, bool asNote = false) const override;
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-    static SpecifyKeyPathRootType *create(ConstraintSystem &cs,
-                                          ConstraintLocator *locator);
+  static SpecifyKeyPathRootType *create(ConstraintSystem &cs,
+                                        ConstraintLocator *locator);
 
-    static bool classof(ConstraintFix *fix) {
-      return fix->getKind() == FixKind::SpecifyKeyPathRootType;
-    }
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::SpecifyKeyPathRootType;
+  }
 };
 
 /// Diagnose missing unwrap of optional base type on key path application.
@@ -2649,7 +2647,7 @@ class AllowInvalidStaticMemberRefOnProtocolMetatype final
                       FixKind::AllowInvalidStaticMemberRefOnProtocolMetatype,
                       locator) {}
 
-  public:
+public:
   std::string getName() const override {
     return "allow invalid static member reference on a protocol metatype";
   }

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -351,6 +351,9 @@ enum class FixKind : uint8_t {
   /// Allow invalid pointer conversions for autoclosure result types as if the
   /// pointer type is a function parameter rather than an autoclosure result.
   AllowAutoClosurePointerConversion,
+
+  /// Ignore externally imposed type.
+  IgnoreContextualType,
 };
 
 class ConstraintFix {
@@ -1938,7 +1941,8 @@ public:
 class IgnoreContextualType : public ContextualMismatch {
   IgnoreContextualType(ConstraintSystem &cs, Type resultTy, Type specifiedTy,
                        ConstraintLocator *locator)
-      : ContextualMismatch(cs, resultTy, specifiedTy, locator) {}
+      : ContextualMismatch(cs, FixKind::IgnoreContextualType, resultTy,
+                           specifiedTy, locator) {}
 
 public:
   std::string getName() const override {
@@ -1950,6 +1954,10 @@ public:
   static IgnoreContextualType *create(ConstraintSystem &cs, Type resultTy,
                                       Type specifiedTy,
                                       ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::IgnoreContextualType;
+  }
 };
 
 class IgnoreAssignmentDestinationType final : public ContextualMismatch {

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -361,6 +361,10 @@ enum class FixKind : uint8_t {
   /// Allow argument-to-parameter subtyping even when parameter type
   /// is marked as `inout`.
   AllowConversionThroughInOut,
+
+  /// Ignore either capability (read/write) or type mismatch in conversion
+  /// between two key path types.
+  IgnoreKeyPathContextualMismatch,
 };
 
 class ConstraintFix {
@@ -958,7 +962,8 @@ private:
 class KeyPathContextualMismatch final : public ContextualMismatch {
   KeyPathContextualMismatch(ConstraintSystem &cs, Type lhs, Type rhs,
                             ConstraintLocator *locator)
-      : ContextualMismatch(cs, lhs, rhs, locator) {}
+      : ContextualMismatch(cs, FixKind::IgnoreKeyPathContextualMismatch, lhs,
+                           rhs, locator) {}
 
 public:
   std::string getName() const override {
@@ -967,6 +972,10 @@ public:
 
   static KeyPathContextualMismatch *
   create(ConstraintSystem &cs, Type lhs, Type rhs, ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::IgnoreKeyPathContextualMismatch;
+  }
 };
 
 /// Detect situations when argument of the @autoclosure parameter is itself

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -636,11 +636,12 @@ public:
 class ContextualMismatch : public ConstraintFix {
   Type LHS, RHS;
 
-protected:
   ContextualMismatch(ConstraintSystem &cs, Type lhs, Type rhs,
                      ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::ContextualMismatch, locator), LHS(lhs),
         RHS(rhs) {}
+
+protected:
   ContextualMismatch(ConstraintSystem &cs, FixKind kind, Type lhs, Type rhs,
                      ConstraintLocator *locator, bool warning = false)
       : ConstraintFix(cs, kind, locator, warning), LHS(lhs), RHS(rhs) {}
@@ -657,6 +658,10 @@ public:
 
   static ContextualMismatch *create(ConstraintSystem &cs, Type lhs, Type rhs,
                                     ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::ContextualMismatch;
+  }
 };
 
 class TreatArrayLiteralAsDictionary final : public ContextualMismatch {

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -444,6 +444,10 @@ public:
 
   static TreatRValueAsLValue *create(ConstraintSystem &cs,
                                      ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::TreatRValueAsLValue;
+  }
 };
 
 /// Arguments have labeling failures - missing/extraneous or incorrect
@@ -476,6 +480,10 @@ public:
   static RelabelArguments *create(ConstraintSystem &cs,
                                   llvm::ArrayRef<Identifier> correctLabels,
                                   ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::RelabelArguments;
+  }
 
 private:
   MutableArrayRef<Identifier> getLabelsBuffer() {
@@ -549,6 +557,10 @@ public:
 
   static SkipSameTypeRequirement *create(ConstraintSystem &cs, Type lhs,
                                          Type rhs, ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::SkipSameTypeRequirement;
+  }
 };
 
 /// Skip 'superclass' generic requirement constraint,
@@ -573,6 +585,10 @@ public:
 
   static SkipSuperclassRequirement *
   create(ConstraintSystem &cs, Type lhs, Type rhs, ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::SkipSuperclassRequirement;
+  }
 };
 
 /// For example: Sometimes type returned from the body of the
@@ -626,6 +642,10 @@ public:
   static TreatArrayLiteralAsDictionary *create(ConstraintSystem &cs,
                                                Type dictionaryTy, Type arrayTy,
                                                ConstraintLocator *loc);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::TreatArrayLiteralAsDictionary;
+  }
 };
 
 class AllowWrappedValueMismatch : public ContextualMismatch {
@@ -640,6 +660,10 @@ public:
 
   static AllowWrappedValueMismatch *create(ConstraintSystem &cs, Type lhs, Type rhs,
                                            ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowWrappedValueMismatch;
+  }
 };
 
 /// Mark function type as explicitly '@escaping'.
@@ -656,6 +680,10 @@ public:
 
   static MarkExplicitlyEscaping *create(ConstraintSystem &cs, Type lhs,
                                         Type rhs, ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::ExplicitlyEscaping;
+  }
 };
 
 /// Mark function type as being part of a global actor.
@@ -673,6 +701,10 @@ public:
 
   static MarkGlobalActorFunction *create(ConstraintSystem &cs, Type lhs,
                                          Type rhs, ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::MarkGlobalActorFunction;
+  }
 };
 
 /// Introduce a '!' to force an optional unwrap.
@@ -693,6 +725,10 @@ public:
 
   static ForceOptional *create(ConstraintSystem &cs, Type fromType, Type toType,
                                ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::ForceOptional;
+  }
 };
 
 /// This is a contextual mismatch between @Sendable and non-@Sendable
@@ -769,6 +805,10 @@ public:
 
   static ForceDowncast *create(ConstraintSystem &cs, Type fromType, Type toType,
                                ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::ForceDowncast;
+  }
 };
 
 /// Introduce a '&' to take the address of an lvalue.
@@ -784,6 +824,10 @@ public:
 
   static AddAddressOf *create(ConstraintSystem &cs, Type argTy, Type paramTy,
                               ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AddressOf;
+  }
 };
 
 class RemoveAddressOf final : public ContextualMismatch {
@@ -800,6 +844,10 @@ public:
 
   static RemoveAddressOf *create(ConstraintSystem &cs, Type lhs, Type rhs,
                                  ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::RemoveAddressOf;
+  }
 };
 
 /// Detect situations where two type's generic arguments must
@@ -844,6 +892,10 @@ public:
                                           Type required,
                                           llvm::ArrayRef<unsigned> mismatches,
                                           ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::GenericArgumentsMismatch;
+  }
 
 private:
   MutableArrayRef<unsigned> getMismatchesBuf() {
@@ -897,6 +949,10 @@ public:
 
   static AutoClosureForwarding *create(ConstraintSystem &cs,
                                        ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AutoClosureForwarding;
+  }
 };
 
 /// Allow invalid pointer conversions for autoclosure result types as if the
@@ -934,6 +990,10 @@ public:
 
   static RemoveUnwrap *create(ConstraintSystem &cs, Type baseType,
                               ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::RemoveUnwrap;
+  }
 };
 
 class InsertExplicitCall final : public ConstraintFix {
@@ -949,6 +1009,10 @@ public:
 
   static InsertExplicitCall *create(ConstraintSystem &cs,
                                     ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::InsertCall;
+  }
 };
 
 class UsePropertyWrapper final : public ConstraintFix {
@@ -978,6 +1042,10 @@ public:
   static UsePropertyWrapper *create(ConstraintSystem &cs, VarDecl *wrapped,
                                     bool usingProjection, Type base,
                                     Type wrapper, ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::UsePropertyWrapper;
+  }
 };
 
 class UseWrappedValue final : public ConstraintFix {
@@ -1009,6 +1077,10 @@ public:
   static UseWrappedValue *create(ConstraintSystem &cs, VarDecl *propertyWrapper,
                                  Type base, Type wrapper,
                                  ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::UseWrappedValue;
+  }
 };
 
 class AllowInvalidPropertyWrapperType final : public ConstraintFix {
@@ -1028,6 +1100,10 @@ public:
   }
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowInvalidPropertyWrapperType;
+  }
 };
 
 class RemoveProjectedValueArgument final : public ConstraintFix {
@@ -1048,6 +1124,10 @@ public:
   }
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::RemoveProjectedValueArgument;
+  }
 };
 
 class UseSubscriptOperator final : public ConstraintFix {
@@ -1063,6 +1143,10 @@ public:
 
   static UseSubscriptOperator *create(ConstraintSystem &cs,
                                       ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::UseSubscriptOperator;
+  }
 };
 
 class DefineMemberBasedOnUse final : public ConstraintFix {
@@ -1172,6 +1256,10 @@ public:
                                              Type baseType, ValueDecl *member,
                                              DeclNameRef memberName,
                                              ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowMemberRefOnExistential;
+  }
 };
 
 class AllowTypeOrInstanceMember final : public AllowInvalidMemberRef {
@@ -1193,6 +1281,10 @@ public:
   static AllowTypeOrInstanceMember *create(ConstraintSystem &cs, Type baseType,
                                            ValueDecl *member, DeclNameRef usedName,
                                            ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowTypeOrInstanceMember;
+  }
 };
 
 class AllowInvalidPartialApplication final : public ConstraintFix {
@@ -1211,6 +1303,10 @@ public:
   static AllowInvalidPartialApplication *create(bool isWarning,
                                                 ConstraintSystem &cs,
                                                 ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowInvalidPartialApplication;
+  }
 };
 
 class AllowInvalidInitRef final : public ConstraintFix {
@@ -1252,6 +1348,10 @@ public:
                                                  Type baseTy,
                                                  ConstructorDecl *init,
                                                  ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowInvalidInitRef;
+  }
 
 private:
   static AllowInvalidInitRef *create(RefKind kind, ConstraintSystem &cs,
@@ -1345,6 +1445,10 @@ public:
   static AllowMutatingMemberOnRValueBase *
   create(ConstraintSystem &cs, Type baseType, ValueDecl *member,
          DeclNameRef name, ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowMutatingMemberOnRValueBase;
+  }
 };
 
 class AllowClosureParamDestructuring final : public ConstraintFix {
@@ -1366,6 +1470,10 @@ public:
   static AllowClosureParamDestructuring *create(ConstraintSystem &cs,
                                                 FunctionType *contextualType,
                                                 ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowClosureParameterDestructuring;
+  }
 };
 
 struct SynthesizedArg {
@@ -1464,6 +1572,10 @@ public:
   create(ConstraintSystem &cs, FunctionType *contextualType,
          llvm::ArrayRef<IndexedParam> extraArgs, ConstraintLocator *locator);
 
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::RemoveExtraneousArguments;
+  }
+
 private:
   MutableArrayRef<IndexedParam> getExtraArgumentsBuf() {
     return {getTrailingObjects<IndexedParam>(), NumExtraneous};
@@ -1524,6 +1636,10 @@ public:
   static AllowInaccessibleMember *create(ConstraintSystem &cs, Type baseType,
                                          ValueDecl *member, DeclNameRef name,
                                          ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowInaccessibleMember;
+  }
 };
 
 class AllowAnyObjectKeyPathRoot final : public ConstraintFix {
@@ -1540,6 +1656,10 @@ public:
 
   static AllowAnyObjectKeyPathRoot *create(ConstraintSystem &cs,
                                            ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowAnyObjectKeyPathRoot;
+  }
 };
 
 class AllowMultiArgFuncKeyPathMismatch final : public ConstraintFix {
@@ -1560,6 +1680,10 @@ public:
   static AllowMultiArgFuncKeyPathMismatch *create(ConstraintSystem &cs,
                                                   Type fnType,
                                                   ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowMultiArgFuncKeyPathMismatch;
+  }
 };
 
 class TreatKeyPathSubscriptIndexAsHashable final : public ConstraintFix {
@@ -1580,6 +1704,10 @@ public:
 
   static TreatKeyPathSubscriptIndexAsHashable *
   create(ConstraintSystem &cs, Type type, ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::TreatKeyPathSubscriptIndexAsHashable;
+  }
 };
 
 class AllowInvalidRefInKeyPath final : public ConstraintFix {
@@ -1654,6 +1782,10 @@ public:
 
   static RemoveReturn *create(ConstraintSystem &cs, Type resultTy,
                               ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::RemoveReturn;
+  }
 };
 
 class CollectionElementContextualMismatch final : public ContextualMismatch {
@@ -1732,6 +1864,10 @@ public:
   static SkipUnhandledConstructInResultBuilder *
   create(ConstraintSystem &cs, UnhandledNode unhandledNode,
          NominalTypeDecl *builder, ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::SkipUnhandledConstructInResultBuilder;
+  }
 };
 
 class AllowTupleSplatForSingleParameter final : public ConstraintFix {
@@ -1758,6 +1894,10 @@ public:
                       ArrayRef<Param> params,
                       SmallVectorImpl<SmallVector<unsigned, 1>> &bindings,
                       ConstraintLocatorBuilder locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowTupleSplatForSingleParameter;
+  }
 };
 
 class IgnoreContextualType : public ContextualMismatch {
@@ -1863,6 +2003,10 @@ public:
   static ExpandArrayIntoVarargs *attempt(ConstraintSystem &cs, Type argType,
                                          Type paramType,
                                          ConstraintLocatorBuilder locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::ExpandArrayIntoVarargs;
+  }
 };
 
 class ExplicitlyConstructRawRepresentable final : public ConstraintFix {
@@ -1886,6 +2030,10 @@ public:
   static ExplicitlyConstructRawRepresentable *
   create(ConstraintSystem &cs, Type rawTypeRepr, Type expectedType,
          ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::ExplicitlyConstructRawRepresentable;
+  }
 };
 
 class UseRawValue final : public ConstraintFix {
@@ -1906,6 +2054,10 @@ public:
 
   static UseRawValue *create(ConstraintSystem &cs, Type rawReprType,
                              Type expectedType, ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::UseRawValue;
+  }
 };
 
 /// Replace a coercion ('as') with runtime checked cast ('as!' or 'as?').
@@ -1927,6 +2079,10 @@ public:
   static CoerceToCheckedCast *attempt(ConstraintSystem &cs, Type fromType,
                                       Type toType, bool useConditionalCast,
                                       ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::CoerceToCheckedCast;
+  }
 };
 
 class RemoveInvalidCall final : public ConstraintFix {
@@ -1942,6 +2098,10 @@ public:
 
   static RemoveInvalidCall *create(ConstraintSystem &cs,
                                    ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::RemoveCall;
+  }
 };
 
 class TreatEphemeralAsNonEphemeral final : public AllowArgumentMismatch {
@@ -1965,6 +2125,10 @@ public:
   create(ConstraintSystem &cs, ConstraintLocator *locator, Type srcType,
          Type dstType, ConversionRestrictionKind conversionKind,
          bool downgradeToWarning);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::TreatEphemeralAsNonEphemeral;
+  }
 };
 
 class SpecifyBaseTypeForContextualMember final : public ConstraintFix {
@@ -1990,6 +2154,10 @@ public:
 
   static SpecifyBaseTypeForContextualMember *
   create(ConstraintSystem &cs, DeclNameRef member, ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::SpecifyBaseTypeForContextualMember;
+  }
 };
 
 class SpecifyClosureParameterType final : public ConstraintFix {
@@ -2003,6 +2171,10 @@ public:
 
   static SpecifyClosureParameterType *create(ConstraintSystem &cs,
                                              ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::SpecifyClosureParameterType;
+  }
 };
 
 class SpecifyClosureReturnType final : public ConstraintFix {
@@ -2018,6 +2190,10 @@ public:
 
   static SpecifyClosureReturnType *create(ConstraintSystem &cs,
                                           ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::SpecifyClosureReturnType;
+  }
 };
 
 class SpecifyObjectLiteralTypeImport final : public ConstraintFix {
@@ -2033,6 +2209,10 @@ public:
 
   static SpecifyObjectLiteralTypeImport *create(ConstraintSystem &cs,
                                                 ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::SpecifyObjectLiteralTypeImport;
+  }
 };
 
 class AddQualifierToAccessTopLevelName final : public ConstraintFix {
@@ -2049,6 +2229,10 @@ public:
 
   static AddQualifierToAccessTopLevelName *create(ConstraintSystem &cs,
                                                   ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AddQualifierToAccessTopLevelName;
+  }
 };
 
 class AllowNonClassTypeToConvertToAnyObject final : public ContextualMismatch {
@@ -2064,6 +2248,10 @@ public:
 
   static AllowNonClassTypeToConvertToAnyObject *
   create(ConstraintSystem &cs, Type type, ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowNonClassTypeToConvertToAnyObject;
+  }
 };
 
 /// A warning fix to maintain compatibility with the following:
@@ -2092,6 +2280,10 @@ public:
   static AllowCoercionToForceCast *create(ConstraintSystem &cs, Type fromType,
                                           Type toType,
                                           ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowCoercionToForceCast;
+  }
 };
 
 /// Attempt to fix a key path application where the key path type cannot be
@@ -2118,6 +2310,10 @@ public:
 
   static AllowKeyPathRootTypeMismatch *
   create(ConstraintSystem &cs, Type lhs, Type rhs, ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowKeyPathRootTypeMismatch;
+  }
 };
 
 class SpecifyKeyPathRootType final : public ConstraintFix {
@@ -2133,6 +2329,10 @@ class SpecifyKeyPathRootType final : public ConstraintFix {
 
     static SpecifyKeyPathRootType *create(ConstraintSystem &cs,
                                           ConstraintLocator *locator);
+
+    static bool classof(ConstraintFix *fix) {
+      return fix->getKind() == FixKind::SpecifyKeyPathRootType;
+    }
 };
 
 /// Diagnose missing unwrap of optional base type on key path application.
@@ -2159,6 +2359,10 @@ public:
   static UnwrapOptionalBaseKeyPathApplication *
   attempt(ConstraintSystem &cs, Type baseTy, Type rootTy,
           ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::UnwrapOptionalBaseKeyPathApplication;
+  }
 };
 
 /// Diagnose situations when solver used old (backward scan) rule
@@ -2187,6 +2391,10 @@ public:
 
   static SpecifyLabelToAssociateTrailingClosure *
   create(ConstraintSystem &cs, ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::SpecifyLabelToAssociateTrailingClosure;
+  }
 };
 
 /// Diagnose situations where we have a key path with no components.
@@ -2206,6 +2414,10 @@ public:
 
   static AllowKeyPathWithoutComponents *create(ConstraintSystem &cs,
                                                ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowKeyPathWithoutComponents;
+  }
 };
 
 class IgnoreInvalidResultBuilderBody : public ConstraintFix {
@@ -2227,6 +2439,10 @@ public:
 
   static IgnoreInvalidResultBuilderBody *create(ConstraintSystem &cs,
                                                 ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::IgnoreInvalidResultBuilderBody;
+  }
 };
 
 class IgnoreResultBuilderWithReturnStmts final
@@ -2262,6 +2478,10 @@ public:
 
   static SpecifyContextualTypeForNil *create(ConstraintSystem & cs,
                                              ConstraintLocator * locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::SpecifyContextualTypeForNil;
+  }
 };
 
 class SpecifyTypeForPlaceholder final : public ConstraintFix {
@@ -2281,6 +2501,10 @@ public:
 
   static SpecifyTypeForPlaceholder *create(ConstraintSystem &cs,
                                            ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::SpecifyTypeForPlaceholder;
+  }
 };
 
 class AllowRefToInvalidDecl final : public ConstraintFix {
@@ -2300,6 +2524,10 @@ public:
 
   static AllowRefToInvalidDecl *create(ConstraintSystem &cs,
                                        ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowRefToInvalidDecl;
+  }
 };
 
 /// Diagnose if the base type is optional, we're referring to a nominal
@@ -2328,6 +2556,11 @@ public:
   attempt(ConstraintSystem &cs, ConstraintKind kind, Type baseTy,
           DeclNameRef memberName, FunctionRefKind functionRefKind,
           MemberLookupResult result, ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() ==
+           FixKind::SpecifyBaseTypeForOptionalUnresolvedMember;
+  }
 };
 
 class CheckedCastContextualMismatchWarning : public ContextualMismatch {
@@ -2360,6 +2593,10 @@ public:
   static AllowCheckedCastCoercibleOptionalType *
   create(ConstraintSystem &cs, Type fromType, Type toType, CheckedCastKind kind,
          ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowCheckedCastCoercibleOptionalType;
+  }
 };
 
 class AllowAlwaysSucceedCheckedCast final
@@ -2425,6 +2662,11 @@ class AllowInvalidStaticMemberRefOnProtocolMetatype final
 
   static AllowInvalidStaticMemberRefOnProtocolMetatype *
   create(ConstraintSystem &cs, ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() ==
+           FixKind::AllowInvalidStaticMemberRefOnProtocolMetatype;
+  }
 };
 
 class AllowNonOptionalWeak final : public ConstraintFix {
@@ -2440,6 +2682,10 @@ public:
 
   static AllowNonOptionalWeak *create(ConstraintSystem &cs,
                                       ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowNonOptionalWeak;
+  }
 };
 
 } // end namespace constraints

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -365,6 +365,10 @@ enum class FixKind : uint8_t {
   /// Ignore either capability (read/write) or type mismatch in conversion
   /// between two key path types.
   IgnoreKeyPathContextualMismatch,
+
+  /// Ignore a type mismatch between deduced element type and externally
+  /// imposed one.
+  IgnoreCollectionElementContextualMismatch,
 };
 
 class ConstraintFix {
@@ -1845,7 +1849,9 @@ public:
 class CollectionElementContextualMismatch final : public ContextualMismatch {
   CollectionElementContextualMismatch(ConstraintSystem &cs, Type srcType,
                                       Type dstType, ConstraintLocator *locator)
-      : ContextualMismatch(cs, srcType, dstType, locator) {}
+      : ContextualMismatch(cs,
+                           FixKind::IgnoreCollectionElementContextualMismatch,
+                           srcType, dstType, locator) {}
 
 public:
   std::string getName() const override {
@@ -1857,6 +1863,10 @@ public:
   static CollectionElementContextualMismatch *
   create(ConstraintSystem &cs, Type srcType, Type dstType,
          ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::IgnoreCollectionElementContextualMismatch;
+  }
 };
 
 class DefaultGenericArgument final : public ConstraintFix {

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -290,6 +290,9 @@ enum class FixKind : uint8_t {
   /// Ignore result builder body which fails `pre-check` call.
   IgnoreInvalidResultBuilderBody,
 
+  /// Ignore result builder body if it has `return` statements.
+  IgnoreResultBuilderWithReturnStmts,
+
   /// Resolve type of `nil` by providing a contextual type.
   SpecifyContextualTypeForNil,
 
@@ -2503,10 +2506,15 @@ public:
 };
 
 class IgnoreInvalidResultBuilderBody : public ConstraintFix {
-protected:
   IgnoreInvalidResultBuilderBody(ConstraintSystem &cs,
                                  ConstraintLocator *locator)
-      : ConstraintFix(cs, FixKind::IgnoreInvalidResultBuilderBody, locator) {}
+      : IgnoreInvalidResultBuilderBody(
+            cs, FixKind::IgnoreInvalidResultBuilderBody, locator) {}
+
+protected:
+  IgnoreInvalidResultBuilderBody(ConstraintSystem &cs, FixKind kind,
+                                 ConstraintLocator *locator)
+      : ConstraintFix(cs, kind, locator) {}
 
 public:
   std::string getName() const override {
@@ -2533,13 +2541,19 @@ class IgnoreResultBuilderWithReturnStmts final
 
   IgnoreResultBuilderWithReturnStmts(ConstraintSystem &cs, Type builderTy,
                                      ConstraintLocator *locator)
-      : IgnoreInvalidResultBuilderBody(cs, locator), BuilderType(builderTy) {}
+      : IgnoreInvalidResultBuilderBody(
+            cs, FixKind::IgnoreResultBuilderWithReturnStmts, locator),
+        BuilderType(builderTy) {}
 
 public:
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
   static IgnoreResultBuilderWithReturnStmts *
   create(ConstraintSystem &cs, Type builderTy, ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::IgnoreResultBuilderWithReturnStmts;
+  }
 };
 
 class SpecifyContextualTypeForNil final : public ConstraintFix {

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -354,6 +354,9 @@ enum class FixKind : uint8_t {
 
   /// Ignore externally imposed type.
   IgnoreContextualType,
+
+  /// Ignore a type imposed by an assignment destination e.g. `let x: Int = ...`
+  IgnoreAssignmentDestinationType,
 };
 
 class ConstraintFix {
@@ -1963,7 +1966,8 @@ public:
 class IgnoreAssignmentDestinationType final : public ContextualMismatch {
   IgnoreAssignmentDestinationType(ConstraintSystem &cs, Type sourceTy,
                                   Type destTy, ConstraintLocator *locator)
-      : ContextualMismatch(cs, sourceTy, destTy, locator) {}
+      : ContextualMismatch(cs, FixKind::IgnoreAssignmentDestinationType,
+                           sourceTy, destTy, locator) {}
 
 public:
   std::string getName() const override {
@@ -1977,6 +1981,10 @@ public:
   static IgnoreAssignmentDestinationType *create(ConstraintSystem &cs,
                                                  Type sourceTy, Type destTy,
                                                  ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::IgnoreAssignmentDestinationType;
+  }
 };
 
 /// If this is an argument-to-parameter conversion which is associated with

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -339,6 +339,10 @@ enum class FixKind : uint8_t {
   /// Fix conversion from non-Sendable to Sendable by adding explicit
   /// @Sendable attribute to the source function.
   AddSendableAttribute,
+
+  /// Fix conversion from throwing to non-throwing by removing explicit
+  /// `throws` attribute from the source function.
+  DropThrowsAttribute,
 };
 
 class ConstraintFix {
@@ -765,7 +769,8 @@ public:
 class DropThrowsAttribute final : public ContextualMismatch {
   DropThrowsAttribute(ConstraintSystem &cs, FunctionType *fromType,
                       FunctionType *toType, ConstraintLocator *locator)
-      : ContextualMismatch(cs, fromType, toType, locator) {
+      : ContextualMismatch(cs, FixKind::DropThrowsAttribute, fromType, toType,
+                           locator) {
     assert(fromType->isThrowing() != toType->isThrowing());
   }
 
@@ -778,6 +783,10 @@ public:
                                      FunctionType *fromType,
                                      FunctionType *toType,
                                      ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::DropThrowsAttribute;
+  }
 };
 
 /// This is a contextual mismatch between async and non-async

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1871,8 +1871,9 @@ TypeVariableBinding::fixForHole(ConstraintSystem &cs) const {
     // If the whole body is being ignored due to a pre-check failure,
     // let's not record a fix about result type since there is
     // just not enough context to infer it without a body.
-    if (cs.hasFixFor(cs.getConstraintLocator(closure),
-                     FixKind::IgnoreInvalidResultBuilderBody))
+    auto *closureLoc = cs.getConstraintLocator(closure);
+    if (cs.hasFixFor(closureLoc, FixKind::IgnoreInvalidResultBuilderBody) ||
+        cs.hasFixFor(closureLoc, FixKind::IgnoreResultBuilderWithReturnStmts))
       return None;
 
     ConstraintFix *fix = SpecifyClosureReturnType::create(cs, dstLocator);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7698,7 +7698,7 @@ bool CoercibleOptionalCheckedCastFailure::diagnoseConditionalCastExpr() const {
   return true;
 }
 
-bool AlwaysSucceedCheckedCastFailure::diagnoseIfExpr() const {
+bool NoopCheckedCast::diagnoseIfExpr() const {
   auto *expr = getAsExpr<IsExpr>(CastExpr);
   if (!expr)
     return false;
@@ -7707,7 +7707,7 @@ bool AlwaysSucceedCheckedCastFailure::diagnoseIfExpr() const {
   return true;
 }
 
-bool AlwaysSucceedCheckedCastFailure::diagnoseConditionalCastExpr() const {
+bool NoopCheckedCast::diagnoseConditionalCastExpr() const {
   auto *expr = getAsExpr<ConditionalCheckedCastExpr>(CastExpr);
   if (!expr)
     return false;
@@ -7717,7 +7717,7 @@ bool AlwaysSucceedCheckedCastFailure::diagnoseConditionalCastExpr() const {
   return true;
 }
 
-bool AlwaysSucceedCheckedCastFailure::diagnoseForcedCastExpr() const {
+bool NoopCheckedCast::diagnoseForcedCastExpr() const {
   auto *expr = getAsExpr<ForcedCheckedCastExpr>(CastExpr);
   if (!expr)
     return false;
@@ -7742,7 +7742,7 @@ bool AlwaysSucceedCheckedCastFailure::diagnoseForcedCastExpr() const {
   return true;
 }
 
-bool AlwaysSucceedCheckedCastFailure::diagnoseAsError() {
+bool NoopCheckedCast::diagnoseAsError() {
   if (diagnoseIfExpr())
     return true;
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2537,11 +2537,10 @@ private:
 
 /// Warn situations where the compiler can statically know a runtime
 /// checked cast always succeed.
-class AlwaysSucceedCheckedCastFailure final : public CheckedCastBaseFailure {
+class NoopCheckedCast final : public CheckedCastBaseFailure {
 public:
-  AlwaysSucceedCheckedCastFailure(const Solution &solution, Type fromType,
-                                  Type toType, CheckedCastKind kind,
-                                  ConstraintLocator *locator)
+  NoopCheckedCast(const Solution &solution, Type fromType, Type toType,
+                  CheckedCastKind kind, ConstraintLocator *locator)
       : CheckedCastBaseFailure(solution, fromType, toType, kind, locator) {}
 
   bool diagnoseAsError() override;

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1920,19 +1920,19 @@ bool AllowCheckedCastCoercibleOptionalType::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
-AllowAlwaysSucceedCheckedCast *
-AllowAlwaysSucceedCheckedCast::create(ConstraintSystem &cs, Type fromType,
-                                      Type toType, CheckedCastKind kind,
-                                      ConstraintLocator *locator) {
+AllowNoopCheckedCast *AllowNoopCheckedCast::create(ConstraintSystem &cs,
+                                                   Type fromType, Type toType,
+                                                   CheckedCastKind kind,
+                                                   ConstraintLocator *locator) {
   return new (cs.getAllocator())
-      AllowAlwaysSucceedCheckedCast(cs, fromType, toType, kind, locator);
+      AllowNoopCheckedCast(cs, fromType, toType, kind, locator);
 }
 
-bool AllowAlwaysSucceedCheckedCast::diagnose(const Solution &solution,
-                                             bool asNote) const {
-  AlwaysSucceedCheckedCastFailure failure(solution, getFromType(), getToType(),
-                                          CastKind, getLocator());
-  return failure.diagnose(asNote);
+bool AllowNoopCheckedCast::diagnose(const Solution &solution,
+                                    bool asNote) const {
+  NoopCheckedCast warning(solution, getFromType(), getToType(), CastKind,
+                          getLocator());
+  return warning.diagnose(asNote);
 }
 
 // Although function types maybe compile-time convertible because

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11686,7 +11686,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   }
 
   case FixKind::ContextualMismatch:
-  case FixKind::IgnoreContextualType: {
+  case FixKind::IgnoreContextualType:
+  case FixKind::IgnoreAssignmentDestinationType: {
     auto impact = 1;
 
     auto locator = fix->getLocator();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4565,12 +4565,12 @@ bool ConstraintSystem::repairFailures(
       return true;
 
     // If we could record a generic arguments mismatch instead of this fix,
-    // don't record a ContextualMismatch here.
+    // don't record a contextual type mismatch here.
     if (hasConversionOrRestriction(ConversionRestrictionKind::DeepEquality))
       break;
 
-    auto *fix = ContextualMismatch::create(*this, lhs, rhs,
-                                           getConstraintLocator(locator));
+    auto *fix = IgnoreContextualType::create(*this, lhs, rhs,
+                                             getConstraintLocator(locator));
     conversionsOrFixes.push_back(fix);
     break;
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11564,7 +11564,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowWrappedValueMismatch:
   case FixKind::RemoveExtraneousArguments:
   case FixKind::SpecifyTypeForPlaceholder:
-  case FixKind::AllowAutoClosurePointerConversion: {
+  case FixKind::AllowAutoClosurePointerConversion:
+  case FixKind::IgnoreKeyPathContextualMismatch: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11685,7 +11685,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
     return matchTypes(*elemTy, dictionaryKeyTy, kind, subflags, elemLoc);
   }
 
-  case FixKind::ContextualMismatch: {
+  case FixKind::ContextualMismatch:
+  case FixKind::IgnoreContextualType: {
     auto impact = 1;
 
     auto locator = fix->getLocator();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11764,6 +11764,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::SpecifyClosureParameterType:
   case FixKind::SpecifyClosureReturnType:
   case FixKind::AddQualifierToAccessTopLevelName:
+  case FixKind::AddSendableAttribute:
     llvm_unreachable("handled elsewhere");
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4909,7 +4909,7 @@ bool ConstraintSystem::repairFailures(
       if (contextualType->isEqual(rhs)) {
         auto *loc = getConstraintLocator(
             anchor, LocatorPathElt::ContextualType(purpose));
-        if (hasFixFor(loc, FixKind::ContextualMismatch))
+        if (hasFixFor(loc, FixKind::IgnoreContextualType))
           return true;
 
         if (contextualType->isVoid() && purpose == CTP_ReturnStmt) {
@@ -4918,7 +4918,7 @@ bool ConstraintSystem::repairFailures(
         }
 
         conversionsOrFixes.push_back(
-            ContextualMismatch::create(*this, lhs, rhs, loc));
+            IgnoreContextualType::create(*this, lhs, rhs, loc));
         break;
       }
     }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11563,7 +11563,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowInvalidStaticMemberRefOnProtocolMetatype:
   case FixKind::AllowWrappedValueMismatch:
   case FixKind::RemoveExtraneousArguments:
-  case FixKind::SpecifyTypeForPlaceholder: {
+  case FixKind::SpecifyTypeForPlaceholder:
+  case FixKind::AllowAutoClosurePointerConversion: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11689,7 +11689,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::ContextualMismatch:
   case FixKind::IgnoreContextualType:
   case FixKind::IgnoreAssignmentDestinationType:
-  case FixKind::AllowConversionThroughInOut: {
+  case FixKind::AllowConversionThroughInOut:
+  case FixKind::IgnoreCollectionElementContextualMismatch: {
     auto impact = 1;
 
     auto locator = fix->getLocator();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11553,6 +11553,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::SpecifyLabelToAssociateTrailingClosure:
   case FixKind::AllowKeyPathWithoutComponents:
   case FixKind::IgnoreInvalidResultBuilderBody:
+  case FixKind::IgnoreResultBuilderWithReturnStmts:
   case FixKind::SpecifyContextualTypeForNil:
   case FixKind::AllowRefToInvalidDecl:
   case FixKind::SpecifyBaseTypeForOptionalUnresolvedMember:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11765,6 +11765,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::SpecifyClosureReturnType:
   case FixKind::AddQualifierToAccessTopLevelName:
   case FixKind::AddSendableAttribute:
+  case FixKind::DropThrowsAttribute:
     llvm_unreachable("handled elsewhere");
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6678,9 +6678,9 @@ static ConstraintFix *maybeWarnAboutExtraneousCast(
 
   // Always succeed
   if (isCastToExpressibleByNilLiteral(cs, origFromType, toType)) {
-    return AllowAlwaysSucceedCheckedCast::create(
-        cs, fromType, toType, CheckedCastKind::Coercion,
-        cs.getConstraintLocator(locator));
+    return AllowNoopCheckedCast::create(cs, fromType, toType,
+                                        CheckedCastKind::Coercion,
+                                        cs.getConstraintLocator(locator));
   }
 
   // If both original are metatypes we have to use them because most of the
@@ -6715,10 +6715,9 @@ static ConstraintFix *maybeWarnAboutExtraneousCast(
         cs, origFromType, origToType, castKind,
         cs.getConstraintLocator(locator));
   } else {
-    // No optionals, just a trivial cast that always succeed.
-    return AllowAlwaysSucceedCheckedCast::create(
-        cs, origFromType, origToType, castKind,
-        cs.getConstraintLocator(locator));
+    // No optionals, just a trivial cast that always succeeds.
+    return AllowNoopCheckedCast::create(cs, origFromType, origToType, castKind,
+                                        cs.getConstraintLocator(locator));
   }
 }
 
@@ -11558,8 +11557,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowRefToInvalidDecl:
   case FixKind::SpecifyBaseTypeForOptionalUnresolvedMember:
   case FixKind::AllowCheckedCastCoercibleOptionalType:
+  case FixKind::AllowNoopCheckedCast:
   case FixKind::AllowUnsupportedRuntimeCheckedCast:
-  case FixKind::AllowAlwaysSucceedCheckedCast:
   case FixKind::AllowInvalidStaticMemberRefOnProtocolMetatype:
   case FixKind::AllowWrappedValueMismatch:
   case FixKind::RemoveExtraneousArguments:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11766,6 +11766,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AddQualifierToAccessTopLevelName:
   case FixKind::AddSendableAttribute:
   case FixKind::DropThrowsAttribute:
+  case FixKind::DropAsyncAttribute:
     llvm_unreachable("handled elsewhere");
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11687,7 +11687,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
 
   case FixKind::ContextualMismatch:
   case FixKind::IgnoreContextualType:
-  case FixKind::IgnoreAssignmentDestinationType: {
+  case FixKind::IgnoreAssignmentDestinationType:
+  case FixKind::AllowConversionThroughInOut: {
     auto impact = 1;
 
     auto locator = fix->getLocator();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3885,7 +3885,7 @@ static bool diagnoseContextualFunctionCallGenericAmbiguity(
         if (fixLocator->isForContextualType())
           return true;
 
-        if (!(fix.second->getKind() == FixKind::ContextualMismatch ||
+        if (!(fix.second->getKind() == FixKind::IgnoreContextualType ||
               fix.second->getKind() == FixKind::AllowTupleTypeMismatch))
           return false;
 

--- a/test/Constraints/without_actually_escaping.swift
+++ b/test/Constraints/without_actually_escaping.swift
@@ -60,8 +60,10 @@ func rethrowThroughWAE(_ zz: (Int, Int, Int) throws -> Int, _ value: Int) throws
   }
 }
 
-let _: ((Int) -> Int, (@escaping (Int) -> Int) -> ()) -> ()
-  = withoutActuallyEscaping(_:do:) // expected-error{{}}
+// There should be two errors - here one for async -> sync, and another throws -> non-throws
+let _: ((Int) -> Int, (@escaping (Int) -> Int) -> ()) -> () = withoutActuallyEscaping(_:do:)
+// expected-error@-1 {{invalid conversion from throwing function of type '((Int) -> Int, (@escaping (Int) -> Int) async throws -> ()) async throws -> ()' to non-throwing function type '((Int) -> Int, (@escaping (Int) -> Int) -> ()) -> ()'}}
+// expected-error@-2 {{invalid conversion from 'async' function of type '((Int) -> Int, (@escaping (Int) -> Int) async throws -> ()) async throws -> ()' to synchronous function type '((Int) -> Int, (@escaping (Int) -> Int) -> ()) -> ()'}}
 
 
 // Failing to propagate @noescape into non-single-expression


### PR DESCRIPTION
- Require that all sub-classes of `ContextualMismatch` provide a specific fix kind;
- Add `static bool classof(ConstraintFix *)` to all fixes that don't currently have it;
- Rename fix/diagnostic for checked casts that always succeed;
- Fix use of `ContextualMismatch` in a couple of places where `IgnoreContextualType` is more appropriate.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
