### PR TITLE
[SILGen] Change Builtin.convertUnownedUnsafeToGuaranteed access to ReadWrite

### DIFF
--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1332,7 +1332,7 @@ static ManagedValue emitBuiltinConvertUnownedUnsafeToGuaranteed(
 
   // Then grab our LValue operand, drop the last ownership component.
   auto srcLV = SGF.emitLValue(args[1]->getSemanticsProvidingExpr(),
-                              SGFAccessKind::BorrowedAddressRead);
+                              SGFAccessKind::ReadWrite);
   srcLV.unsafelyDropLastComponent(PathComponent::OwnershipKind);
   if (!srcLV.isPhysical() || !srcLV.isLoadingPure()) {
     llvm::report_fatal_error("Builtin.convertUnownedUnsafeToGuaranteed passed "

--- a/test/SILGen/unsafevalue.swift
+++ b/test/SILGen/unsafevalue.swift
@@ -72,7 +72,7 @@ public struct UnsafeValue<Element: AnyObject> {
   // CHECK:  [[COPY_BOX:%.*]] = alloc_box
   // CHECK:  [[COPY_PROJ:%.*]] = project_box [[COPY_BOX]]
   // CHECK:  store [[UNSAFE_VALUE]] to [trivial] [[COPY_PROJ]]
-  // CHECK:  [[VALUE_ADDR:%.*]] = begin_access [read] [unknown] [[COPY_PROJ]]
+  // CHECK:  [[VALUE_ADDR:%.*]] = begin_access [modify] [unknown] [[COPY_PROJ]]
   // CHECK:  [[STR_VALUE_ADDR:%.*]] = struct_element_addr [[VALUE_ADDR]]
   // CHECK:  [[UNMANAGED_VALUE:%.*]] = load [trivial] [[STR_VALUE_ADDR]]
   // CHECK:  [[UNOWNED_REF:%.*]] = unmanaged_to_ref [[UNMANAGED_VALUE]]


### PR DESCRIPTION
`Builtin.convertUnownedUnsafeToGuaranteed` [takes the second parameter as an inout argument](https://github.com/apple/swift/blob/main/stdlib/public/core/Unmanaged.swift#L218). However, when lowered to SIL, the function uses a `SGFAccessKind::BorrowedAddressRead` to access the value (as seen [here](https://github.com/apple/swift/blob/main/lib/SILGen/SILGenBuiltin.cpp#L1335)).

Because this uses a mutating inout parameter, streamlining this access kind to use `SGFAccessKind::ReadWrite` will completely remove [this costly check](https://github.com/apple/swift/blob/87f31add5d5126cfdbee74e4d0da303b2c2e8e69/lib/SILOptimizer/Mandatory/DiagnoseVarUsage.cpp#L306-L341) in #39179. @varungandhi-apple 

I know that the construction of `Builtin.convertUnownedUnsafeToGuaranteed` is a bit of a hack, so I'm not technically sure the change in this PR works. The tests are passing for my machine, but I want to check in with @gottesmm to see if this still works as intended.