### PR TITLE
Fix the host-specific installation destdir for build-script products.

### DIFF
--- a/utils/build-toolchain
+++ b/utils/build-toolchain
@@ -57,12 +57,10 @@ case $(uname -s) in
   Darwin)
     SWIFT_PACKAGE=buildbot_osx_package
     OS_SUFFIX=osx
-    BUILD_SUBDIR=buildbot_osx
   ;;
   Linux)
     SWIFT_PACKAGE=buildbot_linux
     OS_SUFFIX=linux
-    BUILD_SUBDIR=buildbot_linux
   ;;
   *)
     echo "Unrecognised platform $(uname -s)"
@@ -136,7 +134,7 @@ DISPLAY_NAME_SHORT="Local Swift Development Snapshot"
 DISPLAY_NAME="${DISPLAY_NAME_SHORT} ${YEAR}-${MONTH}-${DAY}"
 
 SWIFT_INSTALLABLE_PACKAGE="${RESULT_DIR}/${ARCHIVE}"
-SWIFT_INSTALL_DIR="${RESULT_DIR}/${BUILD_SUBDIR}"
+SWIFT_INSTALL_DIR="${RESULT_DIR}/swift-nightly-install"
 SWIFT_INSTALL_SYMROOT="${RESULT_DIR}/swift-nightly-symroot"
 SWIFT_TOOLCHAIN_DIR="/Library/Developer/Toolchains/${TOOLCHAIN_NAME}.xctoolchain"
 SYMBOLS_PACKAGE="${RESULT_DIR}/${SYM_ARCHIVE}"

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -224,7 +224,7 @@ class Product(object):
                 # If this is one of the hosts we should lipo,
                 # install in to a temporary subdirectory.
                 return '%s/intermediate-install/%s' % \
-                    (self.args.install_destdir, host_target)
+                    (os.path.dirname(self.build_dir), host_target)
             elif host_target == "merged-hosts":
                 # This assumes that all hosts are merged to the lipo.
                 return self.args.install_destdir


### PR DESCRIPTION
Prior to this, build-script products that build in the host-specific
directories for cross-compilation would get the wrong path, and
therefore wouldn't get picked up in toolchain builds.