### PR TITLE
[Sema][SR-15179] Ignore FunctionArgument inout mismatch if there is already a fix for locator

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4497,8 +4497,21 @@ bool ConstraintSystem::repairFailures(
       break;
     }
 
+    auto *parentLoc = getConstraintLocator(anchor, path);
+
     if ((lhs->is<InOutType>() && !rhs->is<InOutType>()) ||
         (!lhs->is<InOutType>() && rhs->is<InOutType>())) {
+      // Since `FunctionArgument` as a last locator element represents
+      // a single parameter of the function type involved in a conversion
+      // to another function type, see `matchFunctionTypes`. If there is already
+      // a fix for the this convertion, we can just ignore individual function
+      // argument in-out mismatch failure by considered this fixed increasing
+      // the score.
+      if (hasFixFor(parentLoc)) {
+        increaseScore(SK_Fix);
+        return true;
+      }
+
       // We want to call matchTypes with the default decomposition options
       // in case there are type variables that we couldn't bind due to the
       // inout attribute mismatch.
@@ -4514,7 +4527,6 @@ bool ConstraintSystem::repairFailures(
       }
     }
 
-    auto *parentLoc = getConstraintLocator(anchor, path);
     // In cases like this `FunctionArgument` as a last locator element
     // represents a single parameter of the function type involved in
     // a conversion to another function type, see `matchFunctionTypes`.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4410,6 +4410,11 @@ bool ConstraintSystem::repairFailures(
                                                   loc))
       return true;
 
+    // There is already a remove extraneous arguments fix recorded for this
+    // apply arg to param locator, so let's skip the default argument mismatch.
+    if (hasFixFor(loc, FixKind::RemoveExtraneousArguments))
+      return true;
+
     conversionsOrFixes.push_back(
         AllowArgumentMismatch::create(*this, lhs, rhs, loc));
     break;
@@ -4505,12 +4510,9 @@ bool ConstraintSystem::repairFailures(
       // a single parameter of the function type involved in a conversion
       // to another function type, see `matchFunctionTypes`. If there is already
       // a fix for the this convertion, we can just ignore individual function
-      // argument in-out mismatch failure by considered this fixed increasing
-      // the score.
-      if (hasFixFor(parentLoc)) {
-        increaseScore(SK_Fix);
+      // argument in-out mismatch failure by considered this fixed.
+      if (hasFixFor(parentLoc))
         return true;
-      }
 
       // We want to call matchTypes with the default decomposition options
       // in case there are type variables that we couldn't bind due to the

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -107,8 +107,7 @@ func tuplify<Ts>(_ fn: (Ts) -> Void) {} // expected-note {{in call to function '
 
 @available(SwiftStdlib 5.5, *)
 func testTuplingIsolated(_ a: isolated A, _ b: isolated A) {
-  // FIXME: We shouldn't duplicate the "cannot convert value of type" diagnostic (SR-15179)
   tuplify(testTuplingIsolated)
   // expected-error@-1 {{generic parameter 'Ts' could not be inferred}}
-  // expected-error@-2 2{{cannot convert value of type '(isolated A, isolated A) -> ()' to expected argument type '(Ts) -> Void'}}
+  // expected-error@-2 {{cannot convert value of type '(isolated A, isolated A) -> ()' to expected argument type '(Ts) -> Void'}}
 }

--- a/test/Constraints/function.swift
+++ b/test/Constraints/function.swift
@@ -265,6 +265,10 @@ func testInvalidTupleImplosions() {
 }
 
 // SR-15179 
-func SR15179<Ts>(_ fn: @escaping (Ts) -> Void) {}
+func SR15179<Ts>(_ fn: @escaping (Ts) -> Void) {} // expected-note {{in call to function 'SR15179'}}
+func fn1(x: Int..., y: Int...) {}
+SR15179(fn1) // expected-error {{cannot convert value of type '(Int..., Int...) -> ()' to expected argument type '(Ts) -> Void'}}
+// expected-error@-1{{generic parameter 'Ts' could not be inferred}}
+
 func fn(_ x: inout Int, _ y: inout Int) {}
-SR15179(fn) // expected-error{{cannot convert value of type '(inout Int, inout Int) -> ()' to expected argument type '(Int) -> Void'}}
+SR15179(fn) // expected-error {{cannot convert value of type '(inout Int, inout Int) -> ()' to expected argument type '(Int) -> Void'}}

--- a/test/Constraints/function.swift
+++ b/test/Constraints/function.swift
@@ -263,3 +263,8 @@ func testInvalidTupleImplosions() {
   func takesInout(_ x: Int, _ y: inout String) {}
   tuplify(takesInout) // expected-error {{cannot convert value of type '(Int, inout String) -> ()' to expected argument type '(Int) -> Void'}}
 }
+
+// SR-15179 
+func SR15179<Ts>(_ fn: @escaping (Ts) -> Void) {}
+func fn(_ x: inout Int, _ y: inout Int) {}
+SR15179(fn) // expected-error{{cannot convert value of type '(inout Int, inout Int) -> ()' to expected argument type '(Int) -> Void'}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Just ignore the inout fix for individual FunctionArgument if there is a fix already in place.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves: SR-15179
Resolves: rdar://problem/82924296

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
