### PR TITLE
[Serialization] Remove an assertion that fires spuriously.

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1490,9 +1490,6 @@ void Serializer::writeASTBlockEntity(
       ++numValueWitnesses;
       data.push_back(addDeclRef(req));
       data.push_back(addDeclRef(witness.getDecl()));
-      assert(witness.getDecl() || req->getAttrs().hasAttribute<OptionalAttr>()
-             || req->getAttrs().isUnavailable(req->getASTContext())
-             || allowCompilerErrors());
 
       // If there is no witness, we're done.
       if (!witness.getDecl()) return;


### PR DESCRIPTION
This assertion does not account for the fact that a particular
requirement can be imported both as async and with a completion
handler, and therefore one of those two views won't have a witness.
The assertion is no longer catching anything useful, so remove it.

Addresses rdar://77684000.
