### PR TITLE
IRGen & Runtime: Add a flag to disable relative pointer for some object formats

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -128,16 +128,57 @@ struct InProcess {
 
   template <typename T>
   using SignedPointer = T;
-  
+
+#if SWIFT_USE_RELATIVE_POINTER
   template <typename T, bool Nullable = false>
   using FarRelativeDirectPointer = FarRelativeDirectPointer<T, Nullable>;
 
-  template <typename T, bool Nullable = false>
+  template <typename T, bool Nullable = false, typename Offset = int32_t,
+            typename IndirectType = const T *>
   using RelativeIndirectablePointer =
-    RelativeIndirectablePointer<T, Nullable>;
-  
+      RelativeIndirectablePointer<T, Nullable, Offset, IndirectType>;
+
   template <typename T, bool Nullable = true>
   using RelativeDirectPointer = RelativeDirectPointer<T, Nullable>;
+
+  template <typename T, typename IntTy, bool Nullable = false>
+  using RelativeDirectPointerIntPair =
+      RelativeDirectPointerIntPair<T, IntTy, Nullable>;
+
+  template <typename T, typename IntTy, bool Nullable = false,
+            typename Offset = int32_t, typename IndirectType = const T *>
+  using RelativeIndirectablePointerIntPair =
+      RelativeIndirectablePointerIntPair<T, IntTy, Nullable, Offset,
+                                         IndirectType>;
+#else
+  static_assert(sizeof(void *) <= 4,
+                "pointer size must be less than or equal 4 bytes");
+
+  template <typename T, bool Nullable = false>
+  using FarRelativeDirectPointer =
+      FarRelativeDirectPointer<T, Nullable, detail::Absolute>;
+
+  template <typename T, bool Nullable = false, typename Offset = int32_t,
+            typename IndirectType = const T *>
+  using RelativeIndirectablePointer =
+      RelativeIndirectablePointer<T, Nullable, Offset, IndirectType,
+                                  detail::Absolute>;
+
+  template <typename T, bool Nullable = true>
+  using RelativeDirectPointer =
+      RelativeDirectPointer<T, Nullable, int32_t, detail::Absolute>;
+
+  template <typename T, typename IntTy, bool Nullable = false>
+  using RelativeDirectPointerIntPair =
+      RelativeDirectPointerIntPair<T, IntTy, Nullable, int32_t,
+                                   detail::Absolute>;
+
+  template <typename T, typename IntTy, bool Nullable = false,
+            typename Offset = int32_t, typename IndirectType = const T *>
+  using RelativeIndirectablePointerIntPair =
+      RelativeIndirectablePointerIntPair<T, IntTy, Nullable, Offset,
+                                         IndirectType, detail::Absolute>;
+#endif
 };
 
 /// Represents a pointer in another address space.
@@ -238,6 +279,12 @@ using TargetRelativeDirectPointer
 template <typename Runtime, typename Pointee, bool Nullable = true>
 using TargetRelativeIndirectablePointer
   = typename Runtime::template RelativeIndirectablePointer<Pointee,Nullable>;
+
+template <typename Runtime, typename Pointee, typename IntTy,
+          bool Nullable = false>
+using TargetRelativeDirectPointerIntPair =
+    typename Runtime::template RelativeDirectPointerIntPair<Pointee, IntTy,
+                                                            Nullable>;
 
 struct HeapObject;
 class WeakReference;
@@ -932,38 +979,40 @@ template<typename Runtime,
 using TargetSignedContextPointer = TargetSignedPointer<Runtime,
                           Context<Runtime> * __ptrauth_swift_type_descriptor>;
 
-template<typename Runtime,
-         template<typename _Runtime> class Context = TargetContextDescriptor>
-using TargetRelativeContextPointer =
-  RelativeIndirectablePointer<const Context<Runtime>,
-                              /*nullable*/ true, int32_t,
-                              TargetSignedContextPointer<Runtime, Context>>;
+template <typename Runtime,
+          template <typename _Runtime> class Context = TargetContextDescriptor>
+using TargetRelativeContextPointer = InProcess::RelativeIndirectablePointer<
+    const Context<Runtime>,
+    /*nullable*/ true, int32_t, TargetSignedContextPointer<Runtime, Context>>;
 
 using RelativeContextPointer = TargetRelativeContextPointer<InProcess>;
 
-template<typename Runtime, typename IntTy,
-         template<typename _Runtime> class Context = TargetContextDescriptor>
+template <typename Runtime, typename IntTy,
+          template <typename _Runtime> class Context = TargetContextDescriptor>
 using RelativeContextPointerIntPair =
-  RelativeIndirectablePointerIntPair<const Context<Runtime>, IntTy,
-                              /*nullable*/ true, int32_t,
-                              TargetSignedContextPointer<Runtime, Context>>;
+    InProcess::RelativeIndirectablePointerIntPair<
+        const Context<Runtime>, IntTy,
+        /*nullable*/ true, int32_t,
+        TargetSignedContextPointer<Runtime, Context>>;
 
 template<typename Runtime> struct TargetMethodDescriptor;
 
-template<typename Runtime>
+template <typename Runtime>
 using TargetRelativeMethodDescriptorPointer =
-  RelativeIndirectablePointer<const TargetMethodDescriptor<Runtime>,
-                              /*nullable*/ true>;
+    InProcess::RelativeIndirectablePointer<
+        const TargetMethodDescriptor<Runtime>,
+        /*nullable*/ true>;
 
 using RelativeMethodDescriptorPointer =
   TargetRelativeMethodDescriptorPointer<InProcess>;
 
 template<typename Runtime> struct TargetProtocolRequirement;
 
-template<typename Runtime>
+template <typename Runtime>
 using TargetRelativeProtocolRequirementPointer =
-  RelativeIndirectablePointer<const TargetProtocolRequirement<Runtime>,
-                              /*nullable*/ true>;
+    InProcess::RelativeIndirectablePointer<
+        const TargetProtocolRequirement<Runtime>,
+        /*nullable*/ true>;
 
 using RelativeProtocolRequirementPointer =
   TargetRelativeProtocolRequirementPointer<InProcess>;
@@ -2099,7 +2148,8 @@ struct TargetProtocolRequirement {
   // TODO: name, type
 
   /// The optional default implementation of the protocol.
-  RelativeDirectPointer<void, /*nullable*/ true> DefaultImplementation;
+  TargetRelativeDirectPointer<Runtime, void, /*nullable*/ true>
+      DefaultImplementation;
 };
 
 using ProtocolRequirement = TargetProtocolRequirement<InProcess>;
@@ -2385,7 +2435,7 @@ using GenericBoxHeapMetadata = TargetGenericBoxHeapMetadata<InProcess>;
 template <typename Runtime>
 struct TargetResilientWitness {
   TargetRelativeProtocolRequirementPointer<Runtime> Requirement;
-  RelativeDirectPointer<void> Witness;
+  TargetRelativeDirectPointer<Runtime, void> Witness;
 };
 using ResilientWitness = TargetResilientWitness<InProcess>;
 
@@ -2448,16 +2498,19 @@ struct TargetGenericWitnessTable {
   uint16_t WitnessTablePrivateSizeInWordsAndRequiresInstantiation;
 
   /// The instantiation function, which is called after the template is copied.
-  RelativeDirectPointer<void(TargetWitnessTable<Runtime> *instantiatedTable,
-                             const TargetMetadata<Runtime> *type,
-                             const void * const *instantiationArgs),
-                        /*nullable*/ true> Instantiator;
+  TargetRelativeDirectPointer<
+      Runtime,
+      void(TargetWitnessTable<Runtime> *instantiatedTable,
+           const TargetMetadata<Runtime> *type,
+           const void *const *instantiationArgs),
+      /*nullable*/ true>
+      Instantiator;
 
   using PrivateDataType = void *[swift::NumGenericMetadataPrivateDataWords];
 
   /// Private data for the instantiator.  Out-of-line so that the rest
   /// of this structure can be constant.
-  RelativeDirectPointer<PrivateDataType> PrivateData;
+  TargetRelativeDirectPointer<Runtime, PrivateDataType> PrivateData;
 
   uint16_t getWitnessTablePrivateSizeInWords() const {
     return WitnessTablePrivateSizeInWordsAndRequiresInstantiation >> 1;
@@ -2480,14 +2533,16 @@ struct TargetTypeMetadataRecord {
 private:
   union {
     /// A direct reference to a nominal type descriptor.
-    RelativeDirectPointerIntPair<TargetContextDescriptor<Runtime>,
-                                 TypeReferenceKind>
-      DirectNominalTypeDescriptor;
+    InProcess::RelativeDirectPointerIntPair<TargetContextDescriptor<Runtime>,
+                                            TypeReferenceKind>
+        DirectNominalTypeDescriptor;
 
     /// An indirect reference to a nominal type descriptor.
-    RelativeDirectPointerIntPair<TargetSignedPointer<Runtime, TargetContextDescriptor<Runtime> * __ptrauth_swift_type_descriptor>,
-                                 TypeReferenceKind>
-      IndirectNominalTypeDescriptor;
+    InProcess::RelativeDirectPointerIntPair<
+        TargetSignedPointer<Runtime, TargetContextDescriptor<Runtime> *
+                                         __ptrauth_swift_type_descriptor>,
+        TypeReferenceKind>
+        IndirectNominalTypeDescriptor;
 
     // We only allow a subset of the TypeReferenceKinds here.
     // Should we just acknowledge that this is a different enum?
@@ -2550,7 +2605,7 @@ class RelativeTargetProtocolDescriptorPointer {
     /// The \c bool value will be false to indicate that the protocol
     /// is a Swift protocol, or true to indicate that this references
     /// an Objective-C protocol.
-    RelativeIndirectablePointerIntPair<Protocol, bool> objcPointer;
+    InProcess::RelativeIndirectablePointerIntPair<Protocol, bool> objcPointer;
 #endif
   };
 
@@ -2591,22 +2646,23 @@ struct TargetTypeReference {
 
   union {
     /// A direct reference to a TypeContextDescriptor or ProtocolDescriptor.
-    RelativeDirectPointer<TargetContextDescriptor<Runtime>>
-      DirectTypeDescriptor;
+    TargetRelativeDirectPointer<Runtime, TargetContextDescriptor<Runtime>>
+        DirectTypeDescriptor;
 
     /// An indirect reference to a TypeContextDescriptor or ProtocolDescriptor.
-    RelativeDirectPointer<
-        TargetSignedPointer<Runtime, TargetContextDescriptor<Runtime> * __ptrauth_swift_type_descriptor>>
-      IndirectTypeDescriptor;
+    TargetRelativeDirectPointer<
+        Runtime,
+        TargetSignedPointer<Runtime, TargetContextDescriptor<Runtime> *
+                                         __ptrauth_swift_type_descriptor>>
+        IndirectTypeDescriptor;
 
     /// An indirect reference to an Objective-C class.
-    RelativeDirectPointer<
-        ConstTargetMetadataPointer<Runtime, TargetClassMetadata>>
+    TargetRelativeDirectPointer<
+        Runtime, ConstTargetMetadataPointer<Runtime, TargetClassMetadata>>
         IndirectObjCClass;
 
     /// A direct reference to an Objective-C class name.
-    RelativeDirectPointer<const char>
-      DirectObjCClassName;
+    TargetRelativeDirectPointer<Runtime, const char> DirectObjCClassName;
   };
 
   const TargetContextDescriptor<Runtime> *
@@ -2694,7 +2750,8 @@ private:
   TargetTypeReference<Runtime> TypeRef;
 
   /// The witness table pattern, which may also serve as the witness table.
-  RelativeDirectPointer<const TargetWitnessTable<Runtime>> WitnessTablePattern;
+  TargetRelativeDirectPointer<Runtime, const TargetWitnessTable<Runtime>>
+      WitnessTablePattern;
 
   /// Various flags, including the kind of conformance.
   ConformanceFlags Flags;
@@ -2833,10 +2890,11 @@ private:
 using ProtocolConformanceDescriptor
   = TargetProtocolConformanceDescriptor<InProcess>;
 
-template<typename Runtime>
+template <typename Runtime>
 using TargetProtocolConformanceRecord =
-  RelativeDirectPointer<TargetProtocolConformanceDescriptor<Runtime>,
-                        /*Nullable=*/false>;
+    TargetRelativeDirectPointer<Runtime,
+                                TargetProtocolConformanceDescriptor<Runtime>,
+                                /*Nullable=*/false>;
 
 using ProtocolConformanceRecord = TargetProtocolConformanceRecord<InProcess>;
 
@@ -2901,7 +2959,7 @@ inline bool isCImportedModuleName(llvm::StringRef name) {
 template<typename Runtime>
 struct TargetModuleContextDescriptor final : TargetContextDescriptor<Runtime> {
   /// The module name.
-  RelativeDirectPointer<const char, /*nullable*/ false> Name;
+  TargetRelativeDirectPointer<Runtime, const char, /*nullable*/ false> Name;
 
   /// Is this module a special C-imported module?
   bool isCImportedContext() const {
@@ -2951,15 +3009,15 @@ public:
   GenericRequirementFlags Flags;
 
   /// The type that's constrained, described as a mangled name.
-  RelativeDirectPointer<const char, /*nullable*/ false> Param;
+  TargetRelativeDirectPointer<Runtime, const char, /*nullable*/ false> Param;
 
   union {
     /// A mangled representation of the same-type or base class the param is
     /// constrained to.
     ///
     /// Only valid if the requirement has SameType or BaseClass kind.
-    RelativeDirectPointer<const char, /*nullable*/ false> Type;
-    
+    TargetRelativeDirectPointer<Runtime, const char, /*nullable*/ false> Type;
+
     /// The protocol the param is constrained to.
     ///
     /// Only valid if the requirement has Protocol kind.
@@ -2968,9 +3026,11 @@ public:
     /// The conformance the param is constrained to use.
     ///
     /// Only valid if the requirement has SameConformance kind.
-    RelativeIndirectablePointer<TargetProtocolConformanceDescriptor<Runtime>,
-                                /*nullable*/ false> Conformance;
-    
+    TargetRelativeIndirectablePointer<
+        InProcess, TargetProtocolConformanceDescriptor<Runtime>,
+        /*nullable*/ false>
+        Conformance;
+
     /// The kind of layout constraint.
     ///
     /// Only valid if the requirement has Layout kind.
@@ -3244,7 +3304,7 @@ public:
   ///
   /// Note that the Parent of the extension will be the module context the
   /// extension is declared inside.
-  RelativeDirectPointer<const char> ExtendedContext;
+  TargetRelativeDirectPointer<Runtime, const char> ExtendedContext;
 
   using TrailingGenericContextObjects::getGenericContext;
 
@@ -3390,7 +3450,8 @@ public:
 
   /// Associated type names, as a space-separated list in the same order
   /// as the requirements.
-  RelativeDirectPointer<const char, /*Nullable=*/true> AssociatedTypeNames;
+  TargetRelativeDirectPointer<Runtime, const char, /*Nullable=*/true>
+      AssociatedTypeNames;
 
   ProtocolContextDescriptorFlags getProtocolContextDescriptorFlags() const {
     return ProtocolContextDescriptorFlags(this->Flags.getKindSpecificFlags());
@@ -3432,16 +3493,15 @@ public:
 /// The descriptor for an opaque type.
 template <typename Runtime>
 struct TargetOpaqueTypeDescriptor final
-  : TargetContextDescriptor<Runtime>,
-    TrailingGenericContextObjects<TargetOpaqueTypeDescriptor<Runtime>,
-                                  TargetGenericContextDescriptorHeader,
-                                  RelativeDirectPointer<const char>>
-{
+    : TargetContextDescriptor<Runtime>,
+      TrailingGenericContextObjects<
+          TargetOpaqueTypeDescriptor<Runtime>,
+          TargetGenericContextDescriptorHeader,
+          TargetRelativeDirectPointer<Runtime, const char>> {
 private:
-  using TrailingGenericContextObjects =
-      swift::TrailingGenericContextObjects<TargetOpaqueTypeDescriptor<Runtime>,
-                                           TargetGenericContextDescriptorHeader,
-                                           RelativeDirectPointer<const char>>;
+  using TrailingGenericContextObjects = swift::TrailingGenericContextObjects<
+      TargetOpaqueTypeDescriptor<Runtime>, TargetGenericContextDescriptorHeader,
+      TargetRelativeDirectPointer<Runtime, const char>>;
   using TrailingObjects =
     typename TrailingGenericContextObjects::TrailingObjects;
   friend TrailingObjects;
@@ -3462,15 +3522,16 @@ public:
   }
   
   using TrailingGenericContextObjects::numTrailingObjects;
-  size_t numTrailingObjects(OverloadToken<RelativeDirectPointer<const char>>) const {
+  size_t numTrailingObjects(
+      OverloadToken<TargetRelativeDirectPointer<Runtime, const char>>) const {
     return getNumUnderlyingTypeArguments();
   }
-  
-  const RelativeDirectPointer<const char> &
+
+  const TargetRelativeDirectPointer<Runtime, const char> &
   getUnderlyingTypeArgumentMangledName(unsigned i) const {
     assert(i < getNumUnderlyingTypeArguments());
-    return (this
-         ->template getTrailingObjects<RelativeDirectPointer<const char>>())[i];
+    return (this->template getTrailingObjects<
+            TargetRelativeDirectPointer<Runtime, const char>>())[i];
   }
 
   llvm::StringRef getUnderlyingTypeArgument(unsigned i) const {
@@ -3483,7 +3544,7 @@ public:
     return cd->getKind() == ContextDescriptorKind::OpaqueType;
   }
 };
-  
+
 using OpaqueTypeDescriptor = TargetOpaqueTypeDescriptor<InProcess>;
 
 /// The instantiation cache for generic metadata.  This must be guaranteed
@@ -5056,7 +5117,8 @@ struct DynamicReplacementChainEntry {
 
 /// A record describing the root of dynamic replacements for a function.
 struct DynamicReplacementKey {
-  RelativeDirectPointer<DynamicReplacementChainEntry, false> root;
+  TargetRelativeDirectPointer<InProcess, DynamicReplacementChainEntry, false>
+      root;
   uint32_t flags;
 
   uint16_t getExtraDiscriminator() const {
@@ -5069,14 +5131,15 @@ struct DynamicReplacementKey {
 
 /// A record describing a dynamic function replacement.
 class DynamicReplacementDescriptor {
-  RelativeIndirectablePointer<
+  InProcess::RelativeIndirectablePointer<
       const DynamicReplacementKey, false, int32_t,
       TargetSignedPointer<InProcess,
                           DynamicReplacementKey *
                               __ptrauth_swift_dynamic_replacement_key>>
       replacedFunctionKey;
-  RelativeDirectPointer<void, false> replacementFunction;
-  RelativeDirectPointer<DynamicReplacementChainEntry, false> chainEntry;
+  TargetRelativeDirectPointer<InProcess, void, false> replacementFunction;
+  TargetRelativeDirectPointer<InProcess, DynamicReplacementChainEntry, false>
+      chainEntry;
   uint32_t flags;
 
   enum : uint32_t { EnableChainingMask = 0x1 };

--- a/include/swift/Reflection/Records.h
+++ b/include/swift/Reflection/Records.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_REFLECTION_RECORDS_H
 #define SWIFT_REFLECTION_RECORDS_H
 
+#include "swift/ABI/Metadata.h"
 #include "swift/Basic/RelativePointer.h"
 #include "swift/Demangling/Demangle.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -86,8 +87,8 @@ class FieldRecord {
   const FieldRecordFlags Flags;
 
 public:
-  const RelativeDirectPointer<const char> MangledTypeName;
-  const RelativeDirectPointer<const char> FieldName;
+  const InProcess::RelativeDirectPointer<const char> MangledTypeName;
+  const InProcess::RelativeDirectPointer<const char> FieldName;
 
   FieldRecord() = delete;
 
@@ -179,8 +180,8 @@ class FieldDescriptor {
   }
 
 public:
-  const RelativeDirectPointer<const char> MangledTypeName;
-  const RelativeDirectPointer<const char> Superclass;
+  const InProcess::RelativeDirectPointer<const char> MangledTypeName;
+  const InProcess::RelativeDirectPointer<const char> Superclass;
 
   FieldDescriptor() = delete;
 
@@ -247,8 +248,8 @@ public:
 // type to the type witness of a conformance.
 class AssociatedTypeRecord {
 public:
-  const RelativeDirectPointer<const char> Name;
-  const RelativeDirectPointer<const char> SubstitutedTypeName;
+  const InProcess::RelativeDirectPointer<const char> Name;
+  const InProcess::RelativeDirectPointer<const char> SubstitutedTypeName;
 
   StringRef getName() const {
     return Name.get();
@@ -308,8 +309,8 @@ struct AssociatedTypeRecordIterator {
 // type records for a conformance.
 struct AssociatedTypeDescriptor {
 public:
-  const RelativeDirectPointer<const char> ConformingTypeName;
-  const RelativeDirectPointer<const char> ProtocolTypeName;
+  const InProcess::RelativeDirectPointer<const char> ConformingTypeName;
+  const InProcess::RelativeDirectPointer<const char> ProtocolTypeName;
 
   uint32_t NumAssociatedTypes;
   uint32_t AssociatedTypeRecordSize;
@@ -345,7 +346,7 @@ public:
 // any builtin types referenced from the other sections.
 class BuiltinTypeDescriptor {
 public:
-  const RelativeDirectPointer<const char> TypeName;
+  const InProcess::RelativeDirectPointer<const char> TypeName;
 
   uint32_t Size;
 
@@ -376,7 +377,7 @@ public:
 
 class CaptureTypeRecord {
 public:
-  const RelativeDirectPointer<const char> MangledTypeName;
+  const InProcess::RelativeDirectPointer<const char> MangledTypeName;
 
   CaptureTypeRecord() = delete;
 
@@ -421,8 +422,8 @@ struct CaptureTypeRecordIterator {
 
 class MetadataSourceRecord {
 public:
-  const RelativeDirectPointer<const char> MangledTypeName;
-  const RelativeDirectPointer<const char> MangledMetadataSource;
+  const InProcess::RelativeDirectPointer<const char> MangledTypeName;
+  const InProcess::RelativeDirectPointer<const char> MangledMetadataSource;
 
   MetadataSourceRecord() = delete;
 

--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -326,6 +326,14 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 #define swift_ptrauth_sign_opaque_modify_resume_function(__fn, __buffer) (__fn)
 #endif
 
+#ifndef SWIFT_USE_RELATIVE_POINTER
+#ifdef __wasm__
+#define SWIFT_USE_RELATIVE_POINTER 0
+#else
+#define SWIFT_USE_RELATIVE_POINTER 1
+#endif
+#endif
+
 #ifdef __cplusplus
 
 /// Copy an address-discriminated signed pointer from the source to the dest.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3726,6 +3726,10 @@ IRGenModule::emitDirectRelativeReference(llvm::Constant *target,
   // Convert the target to an integer.
   auto targetAddr = llvm::ConstantExpr::getPtrToInt(target, SizeTy);
 
+  if (!TargetInfo.UsableRelativePointer) {
+    return targetAddr;
+  }
+
   SmallVector<llvm::Constant*, 4> indices;
   indices.push_back(llvm::ConstantInt::get(Int32Ty, 0));
   for (unsigned baseIndex : baseIndices) {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5477,10 +5477,8 @@ GenericRequirementsMetadata irgen::addGenericRequirements(
           unsigned tag = unsigned(descriptorRef.isIndirect());
           if (protocol->isObjC())
             tag |= 0x02;
-          
-          B.addTaggedRelativeOffset(IGM.RelativeAddressTy,
-                                    descriptorRef.getValue(),
-                                    tag);
+
+          B.addTaggedCompactAddress(descriptorRef.getValue(), tag);
         });
       break;
     }

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -2763,14 +2763,21 @@ emitMetadataAccessByMangledName(IRGenFunction &IGF, CanType type,
                                                        IGM.Int32Ty);
     stringAddrOffset = subIGF.Builder.CreateSExtOrBitCast(stringAddrOffset,
                                                           IGM.SizeTy);
-    auto stringAddrBase = subIGF.Builder.CreatePtrToInt(cache, IGM.SizeTy);
-    if (IGM.getModule()->getDataLayout().isBigEndian()) {
-      stringAddrBase = subIGF.Builder.CreateAdd(stringAddrBase,
-                                      llvm::ConstantInt::get(IGM.SizeTy, 4));
+
+    llvm::Value *stringAddr;
+    if (IGM.TargetInfo.UsableRelativePointer) {
+      auto stringAddrBase = subIGF.Builder.CreatePtrToInt(cache, IGM.SizeTy);
+      if (IGM.getModule()->getDataLayout().isBigEndian()) {
+        stringAddrBase = subIGF.Builder.CreateAdd(stringAddrBase,
+                                        llvm::ConstantInt::get(IGM.SizeTy, 4));
+      }
+      stringAddr = subIGF.Builder.CreateAdd(stringAddrBase,
+                                                stringAddrOffset);
+      stringAddr = subIGF.Builder.CreateIntToPtr(stringAddr, IGM.Int8PtrTy);
+    } else {
+      stringAddr =
+          subIGF.Builder.CreateIntToPtr(stringAddrOffset, IGM.Int8PtrTy);
     }
-    auto stringAddr = subIGF.Builder.CreateAdd(stringAddrBase,
-                                               stringAddrOffset);
-    stringAddr = subIGF.Builder.CreateIntToPtr(stringAddr, IGM.Int8PtrTy);
 
     llvm::CallInst *call;
     if (request.isStaticallyAbstract()) {

--- a/lib/IRGen/SwiftTargetInfo.h
+++ b/lib/IRGen/SwiftTargetInfo.h
@@ -115,6 +115,8 @@ public:
   bool SwiftRetainIgnoresNegativeValues = false;
 
   bool UsableSwiftAsyncContextAddrIntrinsic = false;
+
+  bool UsableRelativePointer = true;
 };
 
 }

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -5285,7 +5285,13 @@ static const WitnessTable *swift_getAssociatedConformanceWitnessSlowImpl(
     // Resolve the relative reference to the witness function.
     int32_t offset;
     memcpy(&offset, mangledName.data() + 1, 4);
-    auto ptr = detail::applyRelativeOffset(mangledName.data() + 1, offset);
+#if SWIFT_USE_RELATIVE_POINTER
+    auto ptr =
+        detail::Relative::applyRelativeOffset(mangledName.data() + 1, offset);
+#else
+    auto ptr =
+        detail::Absolute::applyRelativeOffset(mangledName.data() + 1, offset);
+#endif
 
     // Call the witness function.
     auto witnessFn = (AssociatedWitnessTableAccessFunction *)ptr;

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -76,7 +76,11 @@ static uintptr_t resolveSymbolicReferenceOffset(SymbolicReferenceKind kind,
                                                 Directness isIndirect,
                                                 int32_t offset,
                                                 const void *base) {
-  auto ptr = detail::applyRelativeOffset(base, offset);
+#if SWIFT_USE_RELATIVE_POINTER
+  auto ptr = detail::Relative::applyRelativeOffset(base, offset);
+#else
+  auto ptr = detail::Absolute::applyRelativeOffset(base, offset);
+#endif
 
   // Indirect references may be authenticated in a way appropriate for the
   // referent.
@@ -2612,7 +2616,7 @@ public:
 
 /// A map from original to replaced opaque type descriptor of a some type.
 class DynamicReplacementSomeDescriptor {
-  RelativeIndirectablePointer<
+  InProcess::RelativeIndirectablePointer<
       const OpaqueTypeDescriptor, false, int32_t,
       TargetSignedPointer<InProcess, OpaqueTypeDescriptor *
                                          __ptrauth_swift_type_descriptor>>

--- a/test/IRGen/metadata-wasm.swift
+++ b/test/IRGen/metadata-wasm.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %swift -emit-object -target wasm32-unknown-wasi -parse-as-library -parse-stdlib %s -o %t/main.o
+// REQUIRES: CODEGENERATOR=WebAssembly
+
+public enum E {
+  case a
+  case b
+}
+
+public class C {}
+public struct S {}


### PR DESCRIPTION
This unlocks support of object format which doesn't have subtraction relocation type. (e.g. WebAssembly)
In that case, the compiler emits absolute address instead of relative address because relative address requires link-time subtraction relocation like R_X86_64_PC32 or X86_64_RELOC_SUBTRACTOR.

No relative pointer mode is only supported under 32bit architectures so that it doesn't break metadata structures by extra padding of alignments.

The subtraction relocation will be supported in WebAssembly after [my patch](https://reviews.llvm.org/D96659) will reach the swift branch of llvm, however, this mode still would give Swift more portability.

@MaxDesiatov @jckarter 