### PR TITLE
[Compiler] add 'value' label for `NSNumber` to prevent roundabout err…

### DIFF
--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -701,6 +701,29 @@ protected:
 
   static Optional<Diag<Type, Type>>
   getDiagnosticFor(ContextualTypePurpose context, Type contextualType);
+
+protected:
+  bool exprNeedsParensBeforeAddingAs(const Expr *expr, DeclContext *DC) const {
+    auto asPG = TypeChecker::lookupPrecedenceGroup(
+                    DC, DC->getASTContext().Id_CastingPrecedence, SourceLoc())
+                    .getSingle();
+    if (!asPG)
+      return true;
+    return exprNeedsParensInsideFollowingOperator(DC, const_cast<Expr *>(expr),
+                                                  asPG);
+  }
+
+  bool exprNeedsParensAfterAddingAs(const Expr *expr, DeclContext *DC) const {
+    auto asPG = TypeChecker::lookupPrecedenceGroup(
+                    DC, DC->getASTContext().Id_CastingPrecedence, SourceLoc())
+                    .getSingle();
+    if (!asPG)
+      return true;
+
+    return exprNeedsParensOutsideFollowingOperator(
+        DC, const_cast<Expr *>(expr), asPG,
+        [&](auto *E) { return findParentExpr(E); });
+  }
 };
 
 /// Diagnose errors related to using an array literal where a
@@ -891,29 +914,6 @@ public:
   ASTNode getAnchor() const override;
 
   bool diagnoseAsError() override;
-
-private:
-  bool exprNeedsParensBeforeAddingAs(const Expr *expr) {
-    auto *DC = getDC();
-    auto asPG = TypeChecker::lookupPrecedenceGroup(
-        DC, DC->getASTContext().Id_CastingPrecedence, SourceLoc()).getSingle();
-    if (!asPG)
-      return true;
-    return exprNeedsParensInsideFollowingOperator(DC, const_cast<Expr *>(expr),
-                                                  asPG);
-  }
-
-  bool exprNeedsParensAfterAddingAs(const Expr *expr) {
-    auto *DC = getDC();
-    auto asPG = TypeChecker::lookupPrecedenceGroup(
-        DC, DC->getASTContext().Id_CastingPrecedence, SourceLoc()).getSingle();
-    if (!asPG)
-      return true;
-
-    return exprNeedsParensOutsideFollowingOperator(
-        DC, const_cast<Expr *>(expr), asPG,
-        [&](auto *E) { return findParentExpr(E); });
-  }
 };
 
 /// Diagnose failures related to passing value of some type

--- a/test/Constraints/rdar82828226.swift
+++ b/test/Constraints/rdar82828226.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+let int: Int = 0
+func a(_ a: NSNumber) {}
+a(int)// expected-error {{cannot convert value of type 'Int' to expected argument type 'NSNumber'}} {{6-6= as NSNumber}}


### PR DESCRIPTION
Roundabout error message is viewed when `Int` is passed to where `NSNumber` is expected. NSNumber(value: ) should be suggested first.

Resolves SR-15165.


