### PR TITLE
test: repair IRGen.objc_protocol_vars on Windows

### DIFF
--- a/test/IRGen/objc_protocol_vars.sil
+++ b/test/IRGen/objc_protocol_vars.sil
@@ -27,4 +27,5 @@ import Foundation
 
 // CHECK-macho: @llvm.used = appending global [{{.*}}] [{{.*}}, i8* bitcast (i8** @"\01l_OBJC_LABEL_PROTOCOL_$__TtP18objc_protocol_vars1T_" to i8*), i8* bitcast (i8** @"\01l_OBJC_PROTOCOL_REFERENCE_$__TtP18objc_protocol_vars1T_" to i8*), {{.*}}], {{.*}}
 // CHECK-elf: @llvm.compiler.used = appending global [{{.*}}] [{{.*}}, i8* bitcast (i8** @"\01l_OBJC_LABEL_PROTOCOL_$__TtP18objc_protocol_vars1T_" to i8*), i8* bitcast (i8** @"\01l_OBJC_PROTOCOL_REFERENCE_$__TtP18objc_protocol_vars1T_" to i8*), {{.*}}], {{.*}}
+// CHECK-coff: @llvm.used = appending global [{{.*}}] [{{.*}}, i8* bitcast (i8** @"\01l_OBJC_LABEL_PROTOCOL_$__TtP18objc_protocol_vars1T_" to i8*), i8* bitcast (i8** @"\01l_OBJC_PROTOCOL_REFERENCE_$__TtP18objc_protocol_vars1T_" to i8*), {{.*}}], {{.*}}
 


### PR DESCRIPTION
This has regressed on the rebranch.  Add a check for the COFF case.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
