### PR TITLE
[stdlib] Improve set isDisjoint by iterating on smaller set

### DIFF
--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1123,7 +1123,15 @@ extension Set {
   ///   otherwise, `false`.
   @inlinable
   public func isDisjoint(with other: Set<Element>) -> Bool {
-    return _isDisjoint(with: other)
+    guard !isEmpty && !other.isEmpty else { return true }
+    let (smaller, larger) =
+      count < other.count ? (self, other) : (other, self)
+    for member in smaller {
+      if larger.contains(member) {
+        return false
+      }
+    }
+    return true
   }
     
   @inlinable


### PR DESCRIPTION
<!-- What's in this pull request? -->
Just a small improvement in `Set.isDisjoint` by iterating on smaller set.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
