### PR TITLE
IRGen: remove ELF autolink discard gadget

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1465,13 +1465,6 @@ void AutolinkKind::writeEntries(llvm::SetVector<llvm::MDNode *, Vector, Set> Ent
     }
     auto EntriesConstant = llvm::ConstantDataArray::getString(
         IGM.getLLVMContext(), EntriesString, /*AddNull=*/false);
-    // Mark the swift1_autolink_entries section with the SHF_EXCLUDE attribute
-    // to get the linker to drop it in the final linked binary.
-    // LLVM doesn't provide an interface to specify section attributs in the
-    // IR so we pass the attribute with inline assembly.
-    if (IGM.TargetInfo.OutputObjectFormat == llvm::Triple::ELF)
-      IGM.Module.appendModuleInlineAsm(".section .swift1_autolink_entries,"
-                                       "\"0x80000000\"");
     auto var =
         new llvm::GlobalVariable(*IGM.getModule(), EntriesConstant->getType(),
                                  true, llvm::GlobalValue::PrivateLinkage,

--- a/test/IRGen/ELF-remove-autolink-section.swift
+++ b/test/IRGen/ELF-remove-autolink-section.swift
@@ -12,8 +12,6 @@
 
 print("Hi from Swift!")
 
-// ELF: module asm ".section .swift1_autolink_entries,\220x80000000\22"
-
 // Find the metadata entry for the denylisting of the metadata symbol
 // Ensure that it is in the ASAN metadata
 

--- a/test/IRGen/ELF-remove-autolink-section.swift
+++ b/test/IRGen/ELF-remove-autolink-section.swift
@@ -15,7 +15,7 @@ print("Hi from Swift!")
 // Find the metadata entry for the denylisting of the metadata symbol
 // Ensure that it is in the ASAN metadata
 
-// ELF-DAG: !llvm.asan.globals = !{
+// ELF: !llvm.asan.globals = !{
 // ELF-SAME: [[MD:![0-9]+]]
 // ELF-SAME: }
 


### PR DESCRIPTION
The ELF autolink section was previously relying on the SHF_EXCLUDE flag
being applied through module-level assembly.  Remove this gadget and
sink the handling down into LLVM.  The latest improvements to LLVM now
cause this workaround to be insufficient as the section is explicitly
marked as SHF_ALLOC, which will implicitly negate the SHF_EXCLUDE.  As a
result, we no longer discard the metadata.  Once this is sunk into LLVM
the attribute is unnecessary.  Furthermore, due to uniquing, will
actually cause a problem as there is no uniform handling for metadata
section prefixes.

rdar://82640394

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
