### PR TITLE
[sil-opt] Add AssumeSingleThreaded libswift libswift implementation

### DIFF
--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -219,6 +219,7 @@ SwiftInt TryApplyInst_numArguments(BridgedInstruction ai);
 BridgedBasicBlock BranchInst_getTargetBlock(BridgedInstruction bi);
 SwiftInt SwitchEnumInst_getNumCases(BridgedInstruction se);
 SwiftInt SwitchEnumInst_getCaseIndex(BridgedInstruction se, SwiftInt idx);
+void RefCountingInst_setNonAtomic(BridgedInstruction inst);
 
 BridgedInstruction SILBuilder_createBuiltinBinaryFunction(
           BridgedInstruction insertionPoint,

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -62,6 +62,9 @@ BridgedMemoryBehavior AliasAnalysis_getMemBehavior(BridgedAliasAnalysis aa,
 
 BridgedCalleeAnalysis PassContext_getCalleeAnalysis(BridgedPassContext context);
 
+void PassContext_invalidateAnalysis(BridgedPassContext context, BridgedFunction function, enum ChangeNotificationKind changeKind);
+SwiftInt PassContext_isAssumeSingleThreadedEnabled(BridgedPassContext context);
+
 BridgedCalleeList CalleeAnalysis_getCallees(BridgedCalleeAnalysis calleeAnalysis,
                                             BridgedValue callee);
 SwiftInt BridgedFunctionArray_size(BridgedCalleeList callees);

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -132,7 +132,7 @@ PASS(ArrayCountPropagation, "array-count-propagation",
      "Array Count Propagation")
 PASS(ArrayElementPropagation, "array-element-propagation",
      "Array Element Propagation")
-PASS(AssumeSingleThreaded, "sil-assume-single-threaded",
+SWIFT_FUNCTION_PASS_WITH_LEGACY(AssumeSingleThreaded, "sil-assume-single-threaded",
      "Assume Single-Threaded Environment")
 PASS(BasicInstructionPropertyDumper, "basic-instruction-property-dump",
      "Print SIL Instruction MemBehavior and ReleaseBehavior Information")

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -456,6 +456,10 @@ SwiftInt SwitchEnumInst_getCaseIndex(BridgedInstruction se, SwiftInt idx) {
   return getCaseIndex(castToInst<SwitchEnumInst>(se)->getCase(idx).first);
 }
 
+void RefCountingInst_setNonAtomic(BridgedInstruction inst) {
+  castToInst<RefCountingInst>(inst)->setNonAtomic();
+}
+
 //===----------------------------------------------------------------------===//
 //                                SILBuilder
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -1191,3 +1191,25 @@ BridgedCalleeAnalysis PassContext_getCalleeAnalysis(BridgedPassContext context) 
   SILPassManager *pm = castToPassInvocation(context)->getPassManager();
   return {pm->getAnalysis<BasicCalleeAnalysis>()};
 }
+
+void PassContext_invalidateAnalysis(BridgedPassContext context,
+                         BridgedFunction function,
+                         enum ChangeNotificationKind changeKind) {
+  SILPassManager *pm = castToPassInvocation(context)->getPassManager();
+  switch (changeKind) {
+  case instructionsChanged:
+    pm->invalidateAnalysis(castToFunction(function), SILAnalysis::InvalidationKind::Instructions);
+    break;
+  case callsChanged:
+    pm->invalidateAnalysis(castToFunction(function), SILAnalysis::InvalidationKind::CallsAndInstructions);
+    break;
+  case branchesChanged:
+    pm->invalidateAnalysis(castToFunction(function), SILAnalysis::InvalidationKind::BranchesAndInstructions);
+    break;
+  }
+}
+
+SwiftInt PassContext_isAssumeSingleThreadedEnabled(BridgedPassContext context) {
+  SILPassManager *pm = castToPassInvocation(context)->getPassManager();
+  return pm->getOptions().AssumeSingleThreaded;
+}

--- a/libswift/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/libswift/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -9,4 +9,5 @@
 libswift_sources(Optimizer
   SILPrinter.swift
   MergeCondFails.swift
+  AssumeSingleThreaded.swift
 )

--- a/libswift/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/libswift/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -41,4 +41,5 @@ private func registerSwiftPasses() {
   registerPass(simplifyGlobalValuePass, { simplifyGlobalValuePass.run($0) })
   registerPass(simplifyStrongRetainPass, { simplifyStrongRetainPass.run($0) })
   registerPass(simplifyStrongReleasePass, { simplifyStrongReleasePass.run($0) })
+  registerPass(assumeSingleThreaded, { assumeSingleThreaded.run($0) })
 }

--- a/libswift/Sources/Optimizer/PassManager/PassUtils.swift
+++ b/libswift/Sources/Optimizer/PassManager/PassUtils.swift
@@ -25,7 +25,7 @@ struct PassContext {
   var isSwift51RuntimeAvailable: Bool {
     PassContext_isSwift51RuntimeAvailable(passContext) != 0
   }
-  
+
   var aliasAnalysis: AliasAnalysis {
     let bridgedAA = PassContext_getAliasAnalysis(passContext)
     return AliasAnalysis(bridged: bridgedAA)
@@ -34,6 +34,10 @@ struct PassContext {
   var calleeAnalysis: CalleeAnalysis {
     let bridgeCA = PassContext_getCalleeAnalysis(passContext)
     return CalleeAnalysis(bridged: bridgeCA)
+  }
+
+  var isAssumeSingleThreadedEnabled: Bool {
+    return !(PassContext_isAssumeSingleThreadedEnabled(passContext) == 0)
   }
 
   func erase(instruction: Instruction) {
@@ -55,6 +59,10 @@ struct PassContext {
     PassContext_notifyChanges(passContext, instructionsChanged)
 
     SILInstruction_setOperand(instruction.bridged, index, value.bridged)
+  }
+
+  func invalidateAnalysis(_ kind: ChangeNotificationKind, at function: Function) {
+    PassContext_invalidateAnalysis(passContext, function.bridged, kind)
   }
 }
 

--- a/libswift/Sources/SIL/Instruction.swift
+++ b/libswift/Sources/SIL/Instruction.swift
@@ -225,7 +225,11 @@ final public class SetDeallocatingInst : Instruction, UnaryInstruction {}
 
 final public class DeallocRefInst : Instruction, UnaryInstruction {}
 
-public class RefCountingInst : Instruction, UnaryInstruction {}
+public class RefCountingInst : Instruction, UnaryInstruction {
+  public func setNonAtomic() {
+    RefCountingInst_setNonAtomic(bridged)
+  }
+}
 
 final public class StrongRetainInst : RefCountingInst {
 }


### PR DESCRIPTION
# Summary
- Added AsumeSingleThreaded implementation in libswift with some bridge implementation 

# Motivation
I researched libswift several month ago and talked about libswift and how to implement pass in swift compiler with this implementation in swift compiler meetup in Japan. 
As an easy example for beginners, I re-implemented AssumeSingleThreaded which is the smallest Pass in SILOptimizer.

it looks there is no AsumeSingleThreaded libswift implementation in main branch so I made this Pull Request.

I hope this Pull Request becomes a good reference for beginners who want to learn SIL Optimiser and libswift.