### PR TITLE
Add pointer_to_address [align=] option.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -6194,7 +6194,8 @@ pointer_to_address
 ``````````````````
 ::
 
-  sil-instruction ::= 'pointer_to_address' sil-operand 'to' ('[' 'strict' ']')? sil-type
+  sil-instruction ::= 'pointer_to_address' sil-operand 'to' ('[' 'strict' ']')? ('[' 'invariant' ']')? ('[' 'alignment' '=' alignment ']')? sil-type
+  alignment ::= [0-9]+
 
   %1 = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*T
   // %1 will be of type $*T
@@ -6214,6 +6215,12 @@ type. A memory access from an address that is not strict cannot have
 its address substituted with a strict address, even if other nearby
 memory accesses at the same location are strict.
 
+The ``invariant`` flag is set if loading from the returned address
+always produces the same value.
+
+The ``alignment`` integer value specifies the byte alignment of the
+address. ``alignment=0`` is the default, indicating the natural
+alignment of ``T``.
 
 unchecked_ref_cast
 ``````````````````

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1064,12 +1064,12 @@ public:
         getSILDebugLocation(Loc), Op, Ty));
   }
 
-  PointerToAddressInst *createPointerToAddress(SILLocation Loc, SILValue Op,
-                                               SILType Ty,
-                                               bool isStrict,
-                                               bool isInvariant = false){
+  PointerToAddressInst *
+  createPointerToAddress(SILLocation Loc, SILValue Op, SILType Ty,
+                         bool isStrict, bool isInvariant = false,
+                         llvm::MaybeAlign alignment = llvm::MaybeAlign()) {
     return insert(new (getModule()) PointerToAddressInst(
-                    getSILDebugLocation(Loc), Op, Ty, isStrict, isInvariant));
+        getSILDebugLocation(Loc), Op, Ty, isStrict, isInvariant, alignment));
   }
 
   UncheckedRefCastInst *createUncheckedRefCast(SILLocation Loc, SILValue Op,

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5127,10 +5127,15 @@ class PointerToAddressInst
   friend SILBuilder;
 
   PointerToAddressInst(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
-                       bool IsStrict, bool IsInvariant)
-    : UnaryInstructionBase(DebugLoc, Operand, Ty) {
+                       bool IsStrict, bool IsInvariant,
+                       llvm::MaybeAlign Alignment)
+      : UnaryInstructionBase(DebugLoc, Operand, Ty) {
     SILNode::Bits.PointerToAddressInst.IsStrict = IsStrict;
     SILNode::Bits.PointerToAddressInst.IsInvariant = IsInvariant;
+    unsigned encodedAlignment = llvm::encode(Alignment);
+    SILNode::Bits.PointerToAddressInst.Alignment = encodedAlignment;
+    assert(SILNode::Bits.PointerToAddressInst.Alignment == encodedAlignment
+           && "pointer_to_address alignment overflow");
   }
 
 public:
@@ -5145,6 +5150,13 @@ public:
   /// produces the same value.
   bool isInvariant() const {
     return SILNode::Bits.PointerToAddressInst.IsInvariant;
+  }
+
+  /// The byte alignment of the address. Since the alignment of types isn't
+  /// known until IRGen (TypeInfo::getBestKnownAlignment), in SIL an unknown
+  /// alignment indicates the natural in-memory alignment of the element type.
+  llvm::MaybeAlign alignment() const {
+    return llvm::decodeMaybeAlign(SILNode::Bits.PointerToAddressInst.Alignment);
   }
 };
 

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -368,10 +368,8 @@ protected:
   UIWTDOB_BITFIELD_EMPTY(ObjCMethodInst, MethodInst);
 
   SWIFT_INLINE_BITFIELD_EMPTY(ConversionInst, SingleValueInstruction);
-  SWIFT_INLINE_BITFIELD(PointerToAddressInst, ConversionInst, 1+1,
-    IsStrict : 1,
-    IsInvariant : 1
-  );
+  SWIFT_INLINE_BITFIELD(PointerToAddressInst, ConversionInst, 8 + 1 + 1,
+                        Alignment : 8, IsStrict : 1, IsInvariant : 1);
 
   UIWTDOB_BITFIELD(ConvertFunctionInst, ConversionInst, 1,
                    WithoutActuallyEscaping : 1);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -5632,9 +5632,11 @@ void IRGenSILFunction::visitPointerToAddressInst(swift::PointerToAddressInst *i)
   
   llvm::Type *destType = ti.getStorageType()->getPointerTo();
   ptrValue = Builder.CreateBitCast(ptrValue, destType);
-  
-  setLoweredAddress(i,
-                    ti.getAddressForPointer(ptrValue));
+
+  if (i->alignment())
+    setLoweredAddress(i, Address(ptrValue, Alignment(i->alignment()->value())));
+  else
+    setLoweredAddress(i, ti.getAddressForPointer(ptrValue));
 }
 
 static void emitPointerCastInst(IRGenSILFunction &IGF,

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1751,6 +1751,8 @@ public:
       *this << "[strict] ";
     if (CI->isInvariant())
       *this << "[invariant] ";
+    if (CI->alignment())
+      *this << "[align=" << CI->alignment()->value() << "] ";
     *this << CI->getType();
   }
   void visitUncheckedRefCastInst(UncheckedRefCastInst *CI) {

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -802,15 +802,35 @@ static SILLinkage resolveSILLinkage(Optional<SILLinkage> linkage,
   }
 }
 
-static bool parseSILOptional(StringRef &Result, SourceLoc &Loc, SILParser &SP) {
-  if (SP.P.consumeIf(tok::l_square)) {
-    Identifier Id;
-    SP.parseSILIdentifier(Id, Loc, diag::expected_in_attribute_list);
-    SP.P.parseToken(tok::r_square, diag::expected_in_attribute_list);
-    Result = Id.str();
+// Returns false if no optional exists. Returns true on both success and
+// failure. On success, the Result string is nonempty. If the optional is
+// assigned to an integer value, \p value contains the parsed value. Otherwise,
+// value is set to the maximum uint64_t.
+static bool parseSILOptional(StringRef &Result, uint64_t &value, SourceLoc &Loc,
+                             SILParser &SP) {
+  if (!SP.P.consumeIf(tok::l_square))
+    return false;
+
+  value = ~uint64_t(0);
+
+  Identifier Id;
+  if (SP.parseSILIdentifier(Id, Loc, diag::expected_in_attribute_list))
     return true;
+
+  if (SP.P.consumeIf(tok::equal)) {
+    if (SP.parseInteger(value, diag::expected_in_attribute_list))
+      return true;
   }
-  return false;
+  if (SP.P.parseToken(tok::r_square, diag::expected_in_attribute_list))
+    return true;
+
+  Result = Id.str();
+  return true;
+}
+
+static bool parseSILOptional(StringRef &Result, SourceLoc &Loc, SILParser &SP) {
+  uint64_t value;
+  return parseSILOptional(Result, value, Loc, SP);
 }
 
 static bool parseSILOptional(StringRef &Result, SILParser &SP) {
@@ -3603,21 +3623,35 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
         parseSILIdentifier(ToToken, ToLoc, diag::expected_tok_in_sil_instr,
                            "to"))
       return true;
-    if (parseSILOptional(attr, *this) && attr.empty())
-      return true;
+
+    bool isStrict = false;
+    bool isInvariant = false;
+    llvm::MaybeAlign alignment;
+    uint64_t parsedValue = 0;
+    while (parseSILOptional(attr, parsedValue, ToLoc, *this)) {
+      if (attr.empty())
+        return true;
+
+      if (attr.equals("strict"))
+        isStrict = true;
+
+      if (attr.equals("invariant"))
+        isInvariant = true;
+
+      if (attr.equals("align"))
+        alignment = llvm::Align(parsedValue);
+    }
+
     if (parseSILType(Ty) || parseSILDebugLocation(InstLoc, B))
       return true;
-
-    bool isStrict = attr.equals("strict");
-    bool isInvariant = attr.equals("invariant");
 
     if (ToToken.str() != "to") {
       P.diagnose(ToLoc, diag::expected_tok_in_sil_instr, "to");
       return true;
     }
 
-    ResultVal =
-        B.createPointerToAddress(InstLoc, Val, Ty, isStrict, isInvariant);
+    ResultVal = B.createPointerToAddress(InstLoc, Val, Ty, isStrict,
+                                         isInvariant, alignment);
     break;
   }
   case SILInstructionKind::RefToBridgeObjectInst: {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 627; // move_value inst
+const uint16_t SWIFTMODULE_VERSION_MINOR = 628; // unaligned pointer
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -149,6 +149,7 @@ namespace sil_block {
     SIL_SPECIALIZE_ATTR,
     SIL_PROPERTY,
     SIL_ONE_OPERAND_EXTRA_ATTR,
+    SIL_ONE_TYPE_ONE_OPERAND_EXTRA_ATTR,
     SIL_TWO_OPERANDS_EXTRA_ATTR,
     SIL_INST_DIFFERENTIABLE_FUNCTION,
     SIL_INST_LINEAR_FUNCTION,
@@ -333,7 +334,7 @@ namespace sil_block {
   using SILOneTypeOneOperandLayout = BCRecordLayout<
     SIL_ONE_TYPE_ONE_OPERAND,
     SILInstOpCodeField,
-    BCFixed<2>,          // Optional attributes
+    BCFixed<1>,          // Optional attribute
     TypeIDField,
     SILTypeCategoryField,
     TypeIDField,
@@ -418,6 +419,13 @@ namespace sil_block {
     BCFixed<6>, // Optional attributes
     TypeIDField, SILTypeCategoryField, ValueIDField
   >;
+
+  // SIL instructions with one type, one typed valueref, and extra bits.
+  using SILOneTypeOneOperandExtraAttributeLayout =
+      BCRecordLayout<SIL_ONE_TYPE_ONE_OPERAND_EXTRA_ATTR, SILInstOpCodeField,
+                     BCFixed<10>, // Optional attributes
+                     TypeIDField, SILTypeCategoryField, TypeIDField,
+                     SILTypeCategoryField, ValueIDField>;
 
   // SIL instructions with two typed values.
   using SILTwoOperandsLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -890,6 +890,7 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(sil_block, SIL_INST_WITNESS_METHOD);
   BLOCK_RECORD(sil_block, SIL_SPECIALIZE_ATTR);
   BLOCK_RECORD(sil_block, SIL_ONE_OPERAND_EXTRA_ATTR);
+  BLOCK_RECORD(sil_block, SIL_ONE_TYPE_ONE_OPERAND_EXTRA_ATTR);
   BLOCK_RECORD(sil_block, SIL_TWO_OPERANDS_EXTRA_ATTR);
 
   // These layouts can exist in both decl blocks and sil blocks.

--- a/test/IRGen/alignment.sil
+++ b/test/IRGen/alignment.sil
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
 
 import Swift
+import Builtin
 
 @_alignment(16) struct Foo { var x, y, z, w: Float }
 @_alignment(16) enum Empty {}
@@ -9,6 +10,7 @@ import Swift
 @_alignment(16) enum SinglePayload { case A(Float), B, C }
 @_alignment(16) enum MultiPayload { case A(Float), B(Float), C }
 
+// CHECK-LABEL: define {{.*}} @test_alignment
 sil @test_alignment : $@convention(thin) () -> () {
 entry:
   // CHECK: alloca %T9alignment3FooV, align 16
@@ -74,5 +76,31 @@ entry:
   dealloc_stack %c : $*Empty
   dealloc_stack %b : $*Singleton
   dealloc_stack %a : $*Foo
+  return undef : $()
+}
+
+// CHECK-LABEL: define {{.*}} @test_unaligned
+// CHECK:   store i64 %{{.*}}, i64* %{{.*}}, align 8
+// CHECK:   %{{.*}} = load i64, i64* %{{.*}}, align 8
+// CHECK:   store i64 %{{.*}}, i64* %{{.*}}, align 1
+// CHECK:   %{{.*}} = load i64, i64* %{{.*}}, align 1
+// CHECK:   store i64 %{{.*}}, i64* %{{.*}}, align 8
+// CHECK:   %{{.*}} = load i64, i64* %{{.*}}, align 8
+// CHECK:   store i64 %{{.*}}, i64* %{{.*}}, align 536870912
+// CHECK:   %{{.*}} = load i64, i64* %{{.*}}, align 536870912
+sil @test_unaligned : $@convention(thin) (Builtin.RawPointer, Builtin.Int64) -> () {
+entry(%0 : $Builtin.RawPointer, %1 : $Builtin.Int64):
+  %2 = pointer_to_address %0 : $Builtin.RawPointer to $*Builtin.Int64
+  store %1 to %2 : $*Builtin.Int64
+  %4 = load %2 : $*Builtin.Int64
+  %5 = pointer_to_address %0 : $Builtin.RawPointer to [align=1] $*Builtin.Int64
+  store %1 to %5 : $*Builtin.Int64
+  %7 = load %5 : $*Builtin.Int64
+  %8 = pointer_to_address %0 : $Builtin.RawPointer to [align=8] $*Builtin.Int64
+  store %1 to %8 : $*Builtin.Int64
+  %10 = load %8 : $*Builtin.Int64
+  %11 = pointer_to_address %0 : $Builtin.RawPointer to [align=536870912] $*Builtin.Int64
+  store %1 to %11 : $*Builtin.Int64
+  %12 = load %11 : $*Builtin.Int64
   return undef : $()
 }

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -310,7 +310,7 @@ bb0(%0 : $*Runcible, %1 : $*Bendable & Runcible):
   return %7 : $()
 }
 
-protocol ClassBound : class {
+protocol ClassBound : AnyObject {
   func classBoundMethod()
 }
 
@@ -837,7 +837,7 @@ bb0(%t : $T):
   return %1 : $()
 }
 
-protocol ClassP : class {}
+protocol ClassP : AnyObject {}
 
 enum MaybePair {
   case Neither
@@ -1571,6 +1571,18 @@ bb0(%0 : $Builtin.RawPointer, %1 : $X):
   store %1 to %3 : $*X
   // CHECK: [[T3:%.*]] = pointer_to_address {{%.*}} : $Builtin.RawPointer to [strict] $*X
   // CHECK-NEXT: store %1 to [[T3]] : $*X
+  %5 = pointer_to_address %0 : $Builtin.RawPointer to [align=1] $*X
+  store %1 to %5 : $*X
+  // CHECK: [[T4:%.*]] = pointer_to_address {{%.*}} : $Builtin.RawPointer to [align=1] $*X
+  // CHECK-NEXT: store %1 to [[T4]] : $*X
+  %7 = pointer_to_address %0 : $Builtin.RawPointer to [align=8] $*X
+  store %1 to %7 : $*X
+  // CHECK: [[T5:%.*]] = pointer_to_address {{%.*}} : $Builtin.RawPointer to [align=8] $*X
+  // CHECK-NEXT: store %1 to [[T5]] : $*X
+  %9 = pointer_to_address %0 : $Builtin.RawPointer to [align=4294967296] $*X
+  store %1 to %9 : $*X
+  // CHECK: [[T6:%.*]] = pointer_to_address {{%.*}} : $Builtin.RawPointer to [align=4294967296] $*X
+  // CHECK-NEXT: store %1 to [[T6]] : $*X
   %28 = tuple ()
   return %28 : $()
 }

--- a/test/SIL/Serialization/basic.sil
+++ b/test/SIL/Serialization/basic.sil
@@ -2,44 +2,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name borrow
 // RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name borrow
-// RUN: %target-sil-opt %t/tmp.2.sib -module-name borrow | %FileCheck %s
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name borrow -emit-sorted-sil | %FileCheck %s
 
 import Builtin
-
-// CHECK-LABEL: sil [serialized] [ossa] @test_unchecked_ownership_conversion : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
-// CHECK: unchecked_ownership_conversion {{%.*}} : $Builtin.NativeObject, @guaranteed to @owned
-sil [serialized] [ossa] @test_unchecked_ownership_conversion : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
-bb0(%0 : @guaranteed $Builtin.NativeObject):
-  %1 = unchecked_ownership_conversion %0 : $Builtin.NativeObject, @guaranteed to @owned
-  destroy_value %1 : $Builtin.NativeObject
-  return undef : $()
-}
-
-// CHECK-LABEL: sil @async_test : $@convention(thin) @async
-sil @async_test : $@async () -> () {
-bb0:
-  %0 = tuple ()
-  return %0 : $()
-}
-
-// CHECK-LABEL: sil [serialized] [ossa] @test_end_lifetime : $@convention(thin) (@owned Builtin.NativeObject) -> () {
-// CHECK: end_lifetime {{%.*}} : $Builtin.NativeObject
-sil [serialized] [ossa] @test_end_lifetime : $@convention(thin) (@owned Builtin.NativeObject) -> () {
-bb0(%0 : @owned $Builtin.NativeObject):
-  end_lifetime %0 : $Builtin.NativeObject
-  return undef : $()
-}
-
-// CHECK-LABEL: sil @test_movevalue_parsing_non_ossa : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
-// CHECK: bb0(%0 :
-// CHECK-NEXT: %1 = move_value %0 : $Builtin.NativeObject
-// CHECK-NEXT: return
-// CHECK-NEXT: } // end sil function 'test_movevalue_parsing_non_ossa'
-sil @test_movevalue_parsing_non_ossa : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
-bb0(%0 : $Builtin.NativeObject):
-  %1 = move_value %0 : $Builtin.NativeObject
-  return %1 : $Builtin.NativeObject
-}
 
 class TestArrayStorage {
   @_hasStorage var count: Int32
@@ -56,10 +21,19 @@ struct Int32 {
   var x: Builtin.Int32
 }
 
-// CHECK-LABEL: sil [serialized] [ossa] @test_subst_function_type : $@convention(thin) (@guaranteed @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in τ_0_0, @in τ_0_1) -> () for <Builtin.Int32, Builtin.Int64>) -> ()
-sil [serialized] [ossa] @test_subst_function_type : $@convention(thin) (@guaranteed @callee_guaranteed @substituted <A, B> (@in A, @in B) -> () for <Builtin.Int32, Builtin.Int64>) -> () {
-entry(%0 : @guaranteed $@callee_guaranteed @substituted <C, D> (@in C, @in D) -> () for <Builtin.Int32, Builtin.Int64>):
-  return undef : $()
+struct EmptyStruct {}
+
+// CHECK-LABEL: sil @async_test : $@convention(thin) @async
+sil @async_test : $@async () -> () {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+}
+
+sil [ossa] @strong_copy_unmanaged_value_test : $@convention(thin) (@sil_unmanaged Builtin.NativeObject) -> @owned Builtin.NativeObject {
+bb0(%0 : $@sil_unmanaged Builtin.NativeObject):
+  %1 = strong_copy_unmanaged_value %0 : $@sil_unmanaged Builtin.NativeObject
+  return %1 : $Builtin.NativeObject
 }
 
 sil [ossa] @test_destructure_struct_tuple : $@convention(thin) (@owned (Builtin.NativeObject, Builtin.Int32), @owned TestArray2) -> @owned (Builtin.NativeObject, Builtin.Int32, TestArrayStorage, Int32, TestArrayStorage) {
@@ -68,6 +42,30 @@ bb0(%0 : @owned $(Builtin.NativeObject, Builtin.Int32), %1 : @owned $TestArray2)
   (%4, %5, %6) = destructure_struct %1 : $TestArray2
   %7 = tuple(%2 : $Builtin.NativeObject, %3 : $Builtin.Int32, %4 : $TestArrayStorage, %5 : $Int32, %6 : $TestArrayStorage)
   return %7 : $(Builtin.NativeObject, Builtin.Int32, TestArrayStorage, Int32, TestArrayStorage)
+}
+
+sil @test_empty_destructure : $@convention(thin) () -> () {
+bb0:
+  %0 = struct $EmptyStruct()
+  () = destructure_struct %0 : $EmptyStruct
+  %1 = tuple()
+  () = destructure_tuple %1 : $()
+  return %1 : $()
+}
+
+// CHECK-LABEL: sil [serialized] [ossa] @test_end_lifetime : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+// CHECK: end_lifetime {{%.*}} : $Builtin.NativeObject
+sil [serialized] [ossa] @test_end_lifetime : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  end_lifetime %0 : $Builtin.NativeObject
+  return undef : $()
+}
+
+// CHECK-LABEL: sil [lazy_getter] @test_lazy_getter
+sil [lazy_getter] @test_lazy_getter : $@convention(thin) () -> () {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
 }
 
 // CHECK-LABEL: sil [ossa] @test_movevalue_parsing : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
@@ -81,33 +79,58 @@ bb0(%0 : @owned $Builtin.NativeObject):
   return %1 : $Builtin.NativeObject
 }
 
+// CHECK-LABEL: sil @test_movevalue_parsing_non_ossa : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
+// CHECK: bb0(%0 :
+// CHECK-NEXT: %1 = move_value %0 : $Builtin.NativeObject
+// CHECK-NEXT: return
+// CHECK-NEXT: } // end sil function 'test_movevalue_parsing_non_ossa'
+sil @test_movevalue_parsing_non_ossa : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
+bb0(%0 : $Builtin.NativeObject):
+  %1 = move_value %0 : $Builtin.NativeObject
+  return %1 : $Builtin.NativeObject
+}
+
+// CHECK-LABEL: sil [ossa] @test_pointer_to_address : $@convention(thin) (Builtin.RawPointer, Builtin.Int64) -> () {
+// CHECK:   pointer_to_address %0 : $Builtin.RawPointer to [strict] $*Builtin.Int64
+// CHECK:   pointer_to_address %0 : $Builtin.RawPointer to [invariant] $*Builtin.Int64
+// CHECK:   pointer_to_address %0 : $Builtin.RawPointer to [align=1] $*Builtin.Int64
+// CHECK:   pointer_to_address %0 : $Builtin.RawPointer to [strict] [align=8] $*Builtin.Int64
+// CHECK:   pointer_to_address %0 : $Builtin.RawPointer to [align=4294967296] $*Builtin.Int64
+sil [ossa] @test_pointer_to_address : $@convention(thin) (Builtin.RawPointer, Builtin.Int64) -> () {
+bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Int64):
+  %3 = pointer_to_address %0 : $Builtin.RawPointer to $*Builtin.Int64
+  store %1 to [trivial] %3 : $*Builtin.Int64
+  %5 = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*Builtin.Int64
+  store %1 to [trivial] %5 : $*Builtin.Int64
+  %7 = pointer_to_address %0 : $Builtin.RawPointer to [invariant] $*Builtin.Int64
+  store %1 to [trivial] %7 : $*Builtin.Int64
+  %9 = pointer_to_address %0 : $Builtin.RawPointer to [align=1] $*Builtin.Int64
+  store %1 to [trivial] %9 : $*Builtin.Int64
+  %11 = pointer_to_address %0 : $Builtin.RawPointer to [strict] [align=8] $*Builtin.Int64
+  store %1 to [trivial] %11 : $*Builtin.Int64
+  %13 = pointer_to_address %0 : $Builtin.RawPointer to [align=4294967296] $*Builtin.Int64
+  store %1 to [trivial] %13 : $*Builtin.Int64
+  %28 = tuple ()
+  return %28 : $()
+}
+
+// CHECK-LABEL: sil [serialized] [ossa] @test_subst_function_type : $@convention(thin) (@guaranteed @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in τ_0_0, @in τ_0_1) -> () for <Builtin.Int32, Builtin.Int64>) -> ()
+sil [serialized] [ossa] @test_subst_function_type : $@convention(thin) (@guaranteed @callee_guaranteed @substituted <A, B> (@in A, @in B) -> () for <Builtin.Int32, Builtin.Int64>) -> () {
+entry(%0 : @guaranteed $@callee_guaranteed @substituted <C, D> (@in C, @in D) -> () for <Builtin.Int32, Builtin.Int64>):
+  return undef : $()
+}
+
 // CHECK-LABEL: sil [serialized] [ossa] @test_subst_function_type_generic_context : $@convention(thin) <X, Y> (@guaranteed @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in τ_0_0, @in τ_0_1) -> () for <X, Y>) -> ()
 sil [serialized] [ossa] @test_subst_function_type_generic_context : $@convention(thin) <X, Y> (@guaranteed @callee_guaranteed @substituted <A, B> (@in A, @in B) -> () for <X, Y>) -> () {
 entry(%0 : @guaranteed $@callee_guaranteed @substituted <C, D> (@in C, @in D) -> () for <X, Y>):
   return undef : $()
 }
 
-// CHECK-LABEL: sil [lazy_getter] @test_lazy_getter
-sil [lazy_getter] @test_lazy_getter : $@convention(thin) () -> () {
-bb0:
-  %0 = tuple ()
-  return %0 : $()
-}
-
-
-struct EmptyStruct {}
-
-sil @test_empty_destructure : $@convention(thin) () -> () {
-bb0:
-  %0 = struct $EmptyStruct()
-  () = destructure_struct %0 : $EmptyStruct
-  %1 = tuple()
-  () = destructure_tuple %1 : $()
-  return %1 : $()
-}
-
-sil [ossa] @strong_copy_unmanaged_value_test : $@convention(thin) (@sil_unmanaged Builtin.NativeObject) -> @owned Builtin.NativeObject {
-bb0(%0 : $@sil_unmanaged Builtin.NativeObject):
-  %1 = strong_copy_unmanaged_value %0 : $@sil_unmanaged Builtin.NativeObject
-  return %1 : $Builtin.NativeObject
+// CHECK-LABEL: sil [serialized] [ossa] @test_unchecked_ownership_conversion : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+// CHECK: unchecked_ownership_conversion {{%.*}} : $Builtin.NativeObject, @guaranteed to @owned
+sil [serialized] [ossa] @test_unchecked_ownership_conversion : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  %1 = unchecked_ownership_conversion %0 : $Builtin.NativeObject, @guaranteed to @owned
+  destroy_value %1 : $Builtin.NativeObject
+  return undef : $()
 }


### PR DESCRIPTION
Support for addresses with arbitrary alignment as opposed to their
element type's natural in-memory alignment.

Required for bytestream encoding/decoding without resorting to memcpy.

SIL instruction flag, documentation, printing, parsing, serialization,
and IRGen.
