### PR TITLE
CMake: disable libdispatch when targeting Wasm/WASI

### DIFF
--- a/cmake/modules/Libdispatch.cmake
+++ b/cmake/modules/Libdispatch.cmake
@@ -47,7 +47,8 @@ endif()
 # Build any target libdispatch if needed.
 foreach(sdk ${SWIFT_SDKS})
   # Darwin targets have libdispatch available, do not build it.
-  if(NOT "${sdk}" IN_LIST SWIFT_DARWIN_PLATFORMS)
+  # Wasm/WASI doesn't support libdispatch yet. See https://bugs.swift.org/browse/SR-12097 for more details.
+  if(NOT "${sdk}" IN_LIST SWIFT_DARWIN_PLATFORMS AND NOT "${sdk}" STREQUAL WASI)
     list(APPEND DISPATCH_SDKS "${sdk}")
   endif()
 endforeach()


### PR DESCRIPTION
Wasm/WASI doesn't currently support multi-threading, and libdispatch should be disabled when building for this target.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Related to SR-12097.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
