### PR TITLE
Disabling arm64e testing in two tests

### DIFF
--- a/test/ModuleInterface/arm64e-fallback.swift
+++ b/test/ModuleInterface/arm64e-fallback.swift
@@ -11,7 +11,9 @@
 // When run on arm64e, this tests that we build the same interface with
 // `#if _ptrauth(_arm64e)` on.
 //
-// REQUIRES: CPU=arm64 || CPU=arm64e
+// REQUIRES: CPU=arm64
+// Disabled arm64e for now since it isn't passing tests on apple silicon.
+// XFAIL: CPU=arm64e
 
 import PtrAuthFramework // expected-remark{{rebuilding module 'PtrAuthFramework' from interface}}
 

--- a/test/stdlib/Reflection_objc.swift
+++ b/test/stdlib/Reflection_objc.swift
@@ -12,6 +12,9 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
+// Disabled arm64e for now since it is failing
+// XFAIL: CPU=arm64e
+
 //
 // DO NOT add more tests to this file.  Add them to test/1_stdlib/Runtime.swift.
 //


### PR DESCRIPTION
I wasn't aware that arm64e was a thing in open-source, but these two
tests are failing on Apple Silicon both on the main branch and on the
rebranch branch, so I'm disabling it for now.

The failing tests are:
 - ModuleInterface/arm64e-fallback.swift
 - stdlib/Reflection_objc.swift

rdar://83059989