### PR TITLE
Generalize test slightly to work on older Swift runtimes.

### DIFF
--- a/test/Concurrency/Runtime/async_task_priority_current.swift
+++ b/test/Concurrency/Runtime/async_task_priority_current.swift
@@ -10,6 +10,13 @@
 
 import Dispatch
 
+// Work around the inability of older Swift runtimes to print a task priority.
+extension TaskPriority: CustomStringConvertible {
+  public var description: String {
+    "TaskPriority(rawValue: \(rawValue))"
+  }
+}
+
 @available(SwiftStdlib 5.5, *)
 func test_detach() async {
   let a1 = Task.currentPriority


### PR DESCRIPTION
Older Swift runtimes aren't able to print a TaskPriority value well.
Paper over the issue by adding a local CustomStringConvertible
conformance.
