### PR TITLE
[moveOnly] Add a Builtin.move operator that is overloaded over Builtin types.

### DIFF
--- a/include/swift/AST/ASTSynthesis.h
+++ b/include/swift/AST/ASTSynthesis.h
@@ -130,6 +130,22 @@ Type synthesizeType(SynthesisContext &SC,
   return ExistentialMetatypeType::get(synthesizeType(SC, M.Sub));
 }
 
+/// A synthesizer that generates a MoveOnly wrapper of a type.
+template <class S>
+struct MoveOnlyTypeSynthesizer {
+  S Sub;
+};
+template <class S>
+constexpr MoveOnlyTypeSynthesizer<S> _moveOnly(S sub) {
+  return {sub};
+}
+template <class S>
+Type synthesizeType(SynthesisContext &SC, const MoveOnlyTypeSynthesizer<S> &M) {
+  // Until we get the actual move only type, we just return the synthesized
+  // type.
+  return synthesizeType(SC, M.Sub);
+}
+
 /// Helper types for variadic synthesis.
 template <class... Ss>
 struct VariadicSynthesizerStorage;

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -515,6 +515,9 @@ BUILTIN_SIL_OPERATION(WithUnsafeThrowingContinuation, "withUnsafeThrowingContinu
 /// Force the current task to be rescheduled on the specified actor.
 BUILTIN_SIL_OPERATION(HopToActor, "hopToActor", None)
 
+/// Generate a move_value instruction to convert a T to a @_moveOnly T.
+BUILTIN_SIL_OPERATION(Move, "move", Special)
+
 #undef BUILTIN_SIL_OPERATION
 
 // BUILTIN_RUNTIME_CALL - A call into a runtime function.

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -854,6 +854,12 @@ static ValueDecl *getDestroyArrayOperation(ASTContext &ctx, Identifier id) {
                             _void);
 }
 
+static ValueDecl *getMoveOperation(ASTContext &ctx, Identifier id) {
+  return getBuiltinFunction(ctx, id, _thin, _generics(_unrestricted),
+                            _parameters(_owned(_typeparam(0))),
+                            _moveOnly(_typeparam(0)));
+}
+
 static ValueDecl *getTransferArrayOperation(ASTContext &ctx, Identifier id) {
   return getBuiltinFunction(ctx, id, _thin,
                             _generics(_unrestricted),
@@ -2499,6 +2505,11 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
   case BuiltinValueKind::EndUnpairedAccess:
     if (!Types.empty()) return nullptr;
     return getEndUnpairedAccessOperation(Context, Id);
+
+  case BuiltinValueKind::Move:
+    if (!Types.empty())
+      return nullptr;
+    return getMoveOperation(Context, Id);
 
 #define BUILTIN(id, name, Attrs)
 #define BUILTIN_BINARY_OPERATION(id, name, attrs)

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1577,6 +1577,15 @@ static ManagedValue emitBuiltinHopToActor(SILGenFunction &SGF, SILLocation loc,
   return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));
 }
 
+static ManagedValue emitBuiltinMove(SILGenFunction &SGF, SILLocation loc,
+                                    SubstitutionMap subs,
+                                    ArrayRef<ManagedValue> args, SGFContext C) {
+  assert(args.size() == 1 && "Move has a single argument");
+  auto firstArg = args[0].ensurePlusOne(SGF, loc);
+  CleanupCloner cloner(SGF, firstArg);
+  return cloner.clone(SGF.B.createMoveValue(loc, firstArg.forward(SGF)));
+}
+
 static ManagedValue emitBuiltinAutoDiffCreateLinearMapContext(
     SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
     ArrayRef<ManagedValue> args, SGFContext C) {

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-emit-silgen -parse-stdlib %s -disable-access-control -disable-objc-attr-requires-foundation-module | %FileCheck %s
+
+import Swift
+
+class Klass {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly7useMoveyAA5KlassCADF : $@convention(thin) (@guaranteed Klass) -> @owned Klass {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK-NEXT: debug_value
+// CHECK-NEXT: copy_value
+// CHECK-NEXT: move_value
+// CHECK-NEXT: return
+// CHECK: } // end sil function '$s8moveonly7useMoveyAA5KlassCADF'
+func useMove(_ k: Klass) -> Klass {
+    Builtin.move(k)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly7useMoveyxxRlzClF : $@convention(thin) <T where T : AnyObject> (@guaranteed T) -> @owned T {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK-NEXT: debug_value
+// CHECK-NEXT: copy_value
+// CHECK-NEXT: move_value
+// CHECK-NEXT: return
+// CHECK: } // end sil function '$s8moveonly7useMoveyxxRlzClF'
+func useMove<T : AnyObject>(_ k: T) -> T {
+    Builtin.move(k)
+}

--- a/test/SILGen/moveonly_generic_failure.swift
+++ b/test/SILGen/moveonly_generic_failure.swift
@@ -1,0 +1,10 @@
+// RUN: not --crash %target-swift-emit-silgen -parse-stdlib %s -disable-access-control -disable-objc-attr-requires-foundation-module
+
+// REQUIRES: asserts
+
+// This test makes sure that we do not accept using Builtin.move on address only
+// types.
+
+func addressOnlyMove<T>(t: T) -> T {
+    Builtin.move(t)
+}


### PR DESCRIPTION
Right now this does not actually do anything beyond causing a move_value
instruction to be emitted. With time, I am going to use this to map T ->
@_moveOnly T in the fullness of time... but I am going to stage in that part in
a different commit once I add the MoveOnly type itself. I am trying to split up
that larger commit as much as possible to make it easy to review.
