### PR TITLE
[Wasm] Specify the least valid pointer for wasm32

### DIFF
--- a/lib/Driver/WebAssemblyToolChains.cpp
+++ b/lib/Driver/WebAssemblyToolChains.cpp
@@ -1,5 +1,4 @@
-//===---- WebAssemblyToolChains.cpp - Job invocations (WebAssembly-specific)
-//------===//
+//===---- WebAssemblyToolChains.cpp - Job invocations (WebAssembly-specific) ------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -189,6 +188,9 @@ toolchains::WebAssembly::constructInvocation(const DynamicLinkJobAction &job,
   // worse. So assume that compiler driver uses wasm-ld and --global-base=1024
   // to reserve low 1KB.
   Arguments.push_back("-Xlinker");
+  Arguments.push_back(context.Args.MakeArgString(
+      Twine("--global-base=") +
+      std::to_string(SWIFT_ABI_WASM32_LEAST_VALID_POINTER)));
 
   // These custom arguments should be right before the object file at the end.
   context.Args.AddAllArgs(Arguments, options::OPT_linker_option_Group);

--- a/lib/IRGen/SwiftTargetInfo.cpp
+++ b/lib/IRGen/SwiftTargetInfo.cpp
@@ -169,6 +169,13 @@ static void configureSystemZ(IRGenModule &IGM, const llvm::Triple &triple,
   target.SwiftRetainIgnoresNegativeValues = true;
 }
 
+/// Configures target-specific information for wasm32 platforms.
+static void configureWasm32(IRGenModule &IGM, const llvm::Triple &triple,
+                            SwiftTargetInfo &target) {
+  target.LeastValidPointerValue =
+    SWIFT_ABI_WASM32_LEAST_VALID_POINTER;
+}
+
 /// Configure a default target.
 SwiftTargetInfo::SwiftTargetInfo(
   llvm::Triple::ObjectFormatType outputObjectFormat,
@@ -239,6 +246,9 @@ SwiftTargetInfo SwiftTargetInfo::get(IRGenModule &IGM) {
 
   case llvm::Triple::systemz:
     configureSystemZ(IGM, triple, target);
+    break;
+  case llvm::Triple::wasm32:
+    configureWasm32(IGM, triple, target);
     break;
 
   default:

--- a/stdlib/public/SwiftShims/HeapObject.h
+++ b/stdlib/public/SwiftShims/HeapObject.h
@@ -190,6 +190,22 @@ static_assert(alignof(HeapObject) == alignof(void*),
 #define _swift_BridgeObject_TaggedPointerBits                                  \
   (__swift_uintptr_t) SWIFT_ABI_DEFAULT_BRIDGEOBJECT_TAG_64
 
+#elif defined(__wasm32__)
+
+#define _swift_abi_LeastValidPointerValue                                      \
+  (__swift_uintptr_t) SWIFT_ABI_WASM32_LEAST_VALID_POINTER
+
+#define _swift_abi_SwiftSpareBitsMask                                          \
+  (__swift_uintptr_t) SWIFT_ABI_DEFAULT_SWIFT_SPARE_BITS_MASK
+
+#define _swift_abi_ObjCReservedBitsMask                                        \
+  (__swift_uintptr_t) SWIFT_ABI_DEFAULT_OBJC_RESERVED_BITS_MASK
+#define _swift_abi_ObjCReservedLowBits                                         \
+  (unsigned) SWIFT_ABI_DEFAULT_OBJC_NUM_RESERVED_LOW_BITS
+
+#define _swift_BridgeObject_TaggedPointerBits                                  \
+  (__swift_uintptr_t) SWIFT_ABI_DEFAULT_BRIDGEOBJECT_TAG_32
+
 #else
 
 #define _swift_abi_LeastValidPointerValue                                      \

--- a/stdlib/public/SwiftShims/System.h
+++ b/stdlib/public/SwiftShims/System.h
@@ -213,6 +213,6 @@
 // the pointer representation, runtime performance and memory footprint are
 // worse. So assume that compiler driver uses wasm-ld and --global-base=1024 to
 // reserve low 1KB.
-#define SWIFT_ABI_WASM32_LEAST_VALID_POINTER 1024
+#define SWIFT_ABI_WASM32_LEAST_VALID_POINTER 4096
 
 #endif // SWIFT_STDLIB_SHIMS_ABI_SYSTEM_H

--- a/stdlib/public/SwiftShims/System.h
+++ b/stdlib/public/SwiftShims/System.h
@@ -207,4 +207,12 @@
 #define SWIFT_ABI_S390X_OBJC_WEAK_REFERENCE_MARKER_VALUE \
   (1<<SWIFT_ABI_S390X_OBJC_NUM_RESERVED_LOW_BITS)
 
+/*********************************** wasm32 ************************************/
+
+// WebAssembly doesn't reserve low addresses. But without "extra inhabitants" of
+// the pointer representation, runtime performance and memory footprint are
+// worse. So assume that compiler driver uses wasm-ld and --global-base=1024 to
+// reserve low 1KB.
+#define SWIFT_ABI_WASM32_LEAST_VALID_POINTER 1024
+
 #endif // SWIFT_STDLIB_SHIMS_ABI_SYSTEM_H


### PR DESCRIPTION
WebAssembly doesn't reserve low addresses but without "extra inhabitants" of
the pointer representation, runtime performance and memory footprint are
worse. So assume that compiler driver uses wasm-ld and --global-base=1024 to
reserve low 1KB.