### PR TITLE
[SIL] Changed spelling of lifetime flags.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -3671,7 +3671,7 @@ begin_borrow
 
 ::
 
-   sil-instruction ::= 'begin_borrow' '[defined]'? sil-operand
+   sil-instruction ::= 'begin_borrow' '[lexical]'? sil-operand
 
    %1 = begin_borrow %0 : $T
 
@@ -3684,7 +3684,7 @@ region in between this borrow and its lifetime ending use, ``%0`` must be
 live. This makes sense semantically since ``%1`` is modeling a new value with a
 dependent lifetime on ``%0``.
 
-The optional ``defined`` attribute specifies that the operand corresponds to a
+The optional ``lexical`` attribute specifies that the operand corresponds to a
 local variable in the Swift source, so special care must be taken when moving
 the end_borrow.
 

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -302,7 +302,7 @@ namespace swift {
     bool EnableExperimentalConcurrency = false;
 
     /// Enable experimental support for emitting defined borrow scopes.
-    bool EnableExperimentalDefinedLifetimes = false;
+    bool EnableExperimentalLexicalLifetimes = false;
 
     /// Enable experimental support for named opaque result types, e.g.
     /// `func f() -> <T> T`.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -247,9 +247,9 @@ def enable_experimental_concurrency :
   Flag<["-"], "enable-experimental-concurrency">,
   HelpText<"Enable experimental concurrency model">;
 
-def enable_experimental_defined_lifetimes :
-  Flag<["-"], "enable-experimental-defined-lifetimes">,
-  HelpText<"Enable experimental defined lifetimes">;
+def enable_experimental_lexical_lifetimes :
+  Flag<["-"], "enable-experimental-lexical-lifetimes">,
+  HelpText<"Enable experimental lexical lifetimes">;
 
 def enable_experimental_distributed :
   Flag<["-"], "enable-experimental-distributed">,

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -715,10 +715,10 @@ public:
   }
 
   BeginBorrowInst *createBeginBorrow(SILLocation Loc, SILValue LV,
-                                     bool defined = false) {
+                                     bool isLexical = false) {
     assert(!LV->getType().isAddress());
     return insert(new (getModule())
-                      BeginBorrowInst(getSILDebugLocation(Loc), LV, defined));
+                      BeginBorrowInst(getSILDebugLocation(Loc), LV, isLexical));
   }
 
   /// Convenience function for creating a load_borrow on non-trivial values and

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1084,7 +1084,7 @@ void SILCloner<ImplClass>::visitBeginBorrowInst(BeginBorrowInst *Inst) {
   recordClonedInstruction(
       Inst, getBuilder().createBeginBorrow(getOpLocation(Inst->getLoc()),
                                            getOpValue(Inst->getOperand()), 
-                                           Inst->isDefined()));
+                                           Inst->isLexical()));
 }
 
 template <typename ImplClass>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4030,20 +4030,20 @@ class BeginBorrowInst
                                   SingleValueInstruction> {
   friend class SILBuilder;
 
-  bool defined;
+  bool lexical;
 
-  BeginBorrowInst(SILDebugLocation DebugLoc, SILValue LValue, bool defined)
+  BeginBorrowInst(SILDebugLocation DebugLoc, SILValue LValue, bool isLexical)
       : UnaryInstructionBase(DebugLoc, LValue,
                              LValue->getType().getObjectType()),
-        defined(defined) {}
+        lexical(isLexical) {}
 
 public:
   using EndBorrowRange =
       decltype(std::declval<ValueBase>().getUsersOfType<EndBorrowInst>());
 
-  /// Whether the borrow scope defined by this instruction corresponds to a
-  /// source-level VarDecl.
-  bool isDefined() const { return defined; }
+  /// Whether the borrow scope introduced by this instruction corresponds to a
+  /// source-level lexical scope.
+  bool isLexical() const { return lexical; }
 
   /// Return a range over all EndBorrow instructions for this BeginBorrow.
   EndBorrowRange getEndBorrows() const;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -429,8 +429,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalConcurrency |=
     Args.hasArg(OPT_enable_experimental_concurrency);
 
-  Opts.EnableExperimentalDefinedLifetimes |=
-      Args.hasArg(OPT_enable_experimental_defined_lifetimes);
+  Opts.EnableExperimentalLexicalLifetimes |=
+      Args.hasArg(OPT_enable_experimental_lexical_lifetimes);
 
   Opts.EnableExperimentalNamedOpaqueTypes |=
       Args.hasArg(OPT_enable_experimental_named_opaque_types);

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1508,8 +1508,8 @@ public:
   }
 
   void visitBeginBorrowInst(BeginBorrowInst *LBI) {
-    if (LBI->isDefined()) {
-      *this << "[defined] ";
+    if (LBI->isLexical()) {
+      *this << "[lexical] ";
     }
     *this << getIDAndType(LBI->getOperand());
   }

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3278,12 +3278,12 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
   case SILInstructionKind::BeginBorrowInst: {
     SourceLoc AddrLoc;
 
-    bool defined = false;
+    bool isLexical = false;
     StringRef attributeName;
 
     if (parseSILOptional(attributeName, *this)) {
-      if (attributeName.equals("defined"))
-        defined = true;
+      if (attributeName.equals("lexical"))
+        isLexical = true;
       else
         return true;
     }
@@ -3292,7 +3292,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
         parseSILDebugLocation(InstLoc, B))
       return true;
 
-    ResultVal = B.createBeginBorrow(InstLoc, Val, defined);
+    ResultVal = B.createBeginBorrow(InstLoc, Val, isLexical);
     break;
   }
 

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -272,7 +272,7 @@ public:
   void emit(SILGenFunction &SGF, CleanupLocation l,
             ForUnwind_t forUnwind) override {
     SILValue val = SGF.VarLocs[Var].value;
-    if (SGF.getASTContext().LangOpts.EnableExperimentalDefinedLifetimes &&
+    if (SGF.getASTContext().LangOpts.EnableExperimentalLexicalLifetimes &&
         val->getOwnershipKind() != OwnershipKind::None)
       SGF.B.createEndBorrow(l, val);
     SGF.destroyLocalVariable(l, Var);
@@ -543,10 +543,10 @@ public:
       address = value;
     SILLocation PrologueLoc(vd);
 
-    if (SGF.getASTContext().LangOpts.EnableExperimentalDefinedLifetimes &&
+    if (SGF.getASTContext().LangOpts.EnableExperimentalLexicalLifetimes &&
         value->getOwnershipKind() != OwnershipKind::None)
       value = SILValue(
-          SGF.B.createBeginBorrow(PrologueLoc, value, /*defined*/ true));
+          SGF.B.createBeginBorrow(PrologueLoc, value, /*isLexical*/ true));
     SGF.VarLocs[vd] = SILGenFunction::VarLoc::get(value);
 
     // Emit a debug_value[_addr] instruction to record the start of this value's
@@ -1734,7 +1734,7 @@ void SILGenFunction::destroyLocalVariable(SILLocation silLoc, VarDecl *vd) {
   SILValue Val = loc.value;
   if (!Val->getType().isAddress()) {
     SILValue valueToBeDestroyed;
-    if (getASTContext().LangOpts.EnableExperimentalDefinedLifetimes &&
+    if (getASTContext().LangOpts.EnableExperimentalLexicalLifetimes &&
         Val->getOwnershipKind() != OwnershipKind::None) {
       auto *inst = cast<BeginBorrowInst>(Val.getDefiningInstruction());
       valueToBeDestroyed = inst->getOperand();

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1886,12 +1886,12 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
 
   case SILInstructionKind::BeginBorrowInst: {
     assert(RecordKind == SIL_ONE_OPERAND && "Layout should be OneOperand.");
-    unsigned defined = Attr;
+    bool isLexical = Attr & 0x1;
     ResultInst = Builder.createBeginBorrow(
         Loc,
         getLocalValue(ValID, getSILType(MF->getType(TyID),
                                         (SILValueCategory)TyCategory, Fn)),
-        defined == 1);
+        isLexical);
     break;
   }
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1469,7 +1469,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     } else if (auto *ECMI = dyn_cast<EndCOWMutationInst>(&SI)) {
       Attr = ECMI->doKeepUnique();
     } else if (auto *BBI = dyn_cast<BeginBorrowInst>(&SI)) {
-      Attr = BBI->isDefined();
+      Attr = BBI->isLexical();
     }
     writeOneOperandLayout(SI.getKind(), Attr, SI.getOperand(0));
     break;

--- a/test/SIL/Parser/borrow.sil
+++ b/test/SIL/Parser/borrow.sil
@@ -31,11 +31,14 @@ bb0(%0 : $*Builtin.NativeObject, %1 : @guaranteed $Builtin.NativeObject):
 class C {}
 
 // CHECK-LABEL: sil [ossa] @foo
-// CHECK: begin_borrow [defined] {{%[^,]+}}
+// CHECK: begin_borrow {{%[^,]+}}
+// CHECK: begin_borrow [lexical] {{%[^,]+}}
 // CHECK-LABEL: } // end sil function 'foo'
 sil [ossa] @foo : $@convention(thin) () -> () {
   %instance = alloc_ref $C
-  %guaranteed_c = begin_borrow [defined] %instance : $C
+  %guaranteed_c2 = begin_borrow %instance : $C
+  end_borrow %guaranteed_c2 : $C
+  %guaranteed_c = begin_borrow [lexical] %instance : $C
   end_borrow %guaranteed_c : $C
   destroy_value %instance : $C
   %res = tuple ()

--- a/test/SIL/Serialization/borrow.sil
+++ b/test/SIL/Serialization/borrow.sil
@@ -9,12 +9,12 @@ sil_stage canonical
 import Builtin
 
 // CHECK-LABEL: sil [serialized] [ossa] @begin_borrow_test
-// CHECK: begin_borrow [defined] {{%[^,]+}}
+// CHECK: begin_borrow [lexical] {{%[^,]+}}
 // CHECK: begin_borrow {{%[^,]+}}
 // CHECK: } // end sil function 'begin_borrow_test'
 sil [serialized] [ossa] @begin_borrow_test : $@convention(thin) () -> () {
   %instance = alloc_ref $C
-  %guaranteed_c = begin_borrow [defined] %instance : $C
+  %guaranteed_c = begin_borrow [lexical] %instance : $C
   end_borrow %guaranteed_c : $C
   %guaranteed_c2 = begin_borrow %instance : $C
   end_borrow %guaranteed_c2 : $C

--- a/test/SIL/cloning.sil
+++ b/test/SIL/cloning.sil
@@ -28,21 +28,21 @@ bb0:
   return %2 : $()
 }
 
-sil [ossa] [always_inline] @callee_begin_borrow_defined : $@convention(thin) () -> () {
+sil [ossa] [always_inline] @callee_begin_borrow_lexical : $@convention(thin) () -> () {
   %instance = alloc_ref $X
-  %guaranteed_c = begin_borrow [defined] %instance : $X
+  %guaranteed_c = begin_borrow [lexical] %instance : $X
   end_borrow %guaranteed_c : $X
   destroy_value %instance : $X
   %res = tuple ()
   return %res : $()
 }
 
-// CHECK-LABEL: sil [ossa] @caller_begin_borrow_defined
-// CHECK: begin_borrow [defined]
-// CHECK-LABEL: } // end sil function 'caller_begin_borrow_defined'
-sil [ossa] @caller_begin_borrow_defined : $@convention(thin) () -> () {
-  %callee_begin_borrow_defined = function_ref @callee_begin_borrow_defined : $@convention(thin) () -> ()
-  %res = apply %callee_begin_borrow_defined() : $@convention(thin) () -> ()
+// CHECK-LABEL: sil [ossa] @caller_begin_borrow_lexical
+// CHECK: begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_begin_borrow_lexical'
+sil [ossa] @caller_begin_borrow_lexical : $@convention(thin) () -> () {
+  %callee_begin_borrow_lexical = function_ref @callee_begin_borrow_lexical : $@convention(thin) () -> ()
+  %res = apply %callee_begin_borrow_lexical() : $@convention(thin) () -> ()
   return %res : $()
 }
 

--- a/test/SILGen/borrow.swift
+++ b/test/SILGen/borrow.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -enable-experimental-defined-lifetimes -module-name borrow -parse-stdlib %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-experimental-lexical-lifetimes -module-name borrow -parse-stdlib %s | %FileCheck %s
 
 import Swift
 
@@ -37,27 +37,27 @@ func lvalueBorrowShouldBeAtEndOfFormalAccessScope() {
   useD(c.d)
 }
 
-// CHECK-LABEL: sil hidden [ossa] @defined_borrow_let_class
+// CHECK-LABEL: sil hidden [ossa] @lexical_borrow_let_class
 // CHECK:   [[INIT_C:%[^,]+]] = function_ref @$s6borrow1CCACycfC
 // CHECK:   [[INSTANCE:%[^,]+]] = apply [[INIT_C]]({{%[0-9]+}})
-// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [defined] [[INSTANCE]] : $C
+// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] : $C
 // CHECK:   end_borrow [[BORROW:%[^,]+]]
-// CHECK-LABEL: } // end sil function 'defined_borrow_let_class'
-@_silgen_name("defined_borrow_let_class")
-func defined_borrow_let_class() {
+// CHECK-LABEL: } // end sil function 'lexical_borrow_let_class'
+@_silgen_name("lexical_borrow_let_class")
+func lexical_borrow_let_class() {
   let c = C()
 }
 
-// CHECK-LABEL: sil hidden [ossa] @defined_borrow_if_let_class
+// CHECK-LABEL: sil hidden [ossa] @lexical_borrow_if_let_class
 // CHECK:   [[INIT_C:%[^,]+]] = function_ref @$s6borrow1CC8failablyACSgyt_tcfC
 // CHECK:   [[INSTANCE:%[^,]+]] = apply [[INIT_C]]({{%[^,]+}})
 // CHECK:   switch_enum [[INSTANCE]] : $Optional<C>, case #Optional.some!enumelt: [[BASIC_BLOCK2:bb[^,]+]], case #Optional.none!enumelt: {{bb[^,]+}}
 // CHECK: [[BASIC_BLOCK2]]([[INSTANCE:%[^,]+]] : @owned $C):
-// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [defined] [[INSTANCE]] : $C
+// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] : $C
 // CHECK:   end_borrow [[BORROW]] : $C
-// CHECK-LABEL: // end sil function 'defined_borrow_if_let_class'
-@_silgen_name("defined_borrow_if_let_class")
-func defined_borrow_if_let_class() {
+// CHECK-LABEL: // end sil function 'lexical_borrow_if_let_class'
+@_silgen_name("lexical_borrow_if_let_class")
+func lexical_borrow_if_let_class() {
   if let c = C(failably: ()) {
     use(())
   }
@@ -67,14 +67,14 @@ struct S {
   let c: C
 }
 
-// CHECK-LABEL: sil hidden [ossa] @defined_borrow_let_class_in_struct
+// CHECK-LABEL: sil hidden [ossa] @lexical_borrow_let_class_in_struct
 // CHECK:   [[INIT_S:%[^,]+]] = function_ref @$s6borrow1SV1cAcA1CC_tcfC
 // CHECK:   [[INSTANCE:%[^,]+]] = apply [[INIT_S]]({{%[0-9]+}}, {{%[0-9]+}})
-// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [defined] [[INSTANCE]] : $S
+// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] : $S
 // CHECK:   end_borrow [[BORROW:%[^,]+]]
-// CHECK-LABEL: } // end sil function 'defined_borrow_let_class_in_struct'
-@_silgen_name("defined_borrow_let_class_in_struct")
-func defined_borrow_let_class_in_struct() {
+// CHECK-LABEL: } // end sil function 'lexical_borrow_let_class_in_struct'
+@_silgen_name("lexical_borrow_let_class_in_struct")
+func lexical_borrow_let_class_in_struct() {
   let s = S(c: C())
 }
 
@@ -82,12 +82,12 @@ enum E {
   case e(C)
 }
 
-// CHECK-LABEL: sil hidden [ossa] @defined_borrow_let_class_in_enum
+// CHECK-LABEL: sil hidden [ossa] @lexical_borrow_let_class_in_enum
 // CHECK:   [[INSTANCE:%[^,]+]] = enum $E, #E.e!enumelt, {{%[0-9]+}} : $C
-// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [defined] [[INSTANCE]] : $E
+// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] : $E
 // CHECK:   end_borrow [[BORROW:%[^,]+]]
-// CHECK-LABEL: } // end sil function 'defined_borrow_let_class_in_enum'
-@_silgen_name("defined_borrow_let_class_in_enum")
-func defined_borrow_let_class_in_enum() {
+// CHECK-LABEL: } // end sil function 'lexical_borrow_let_class_in_enum'
+@_silgen_name("lexical_borrow_let_class_in_enum")
+func lexical_borrow_let_class_in_enum() {
   let s = E.e(C())
 }


### PR DESCRIPTION
Changed the frontend flag to -enable-experimental-lexical-lifetimes from -enable-experimental-defined-lifetimes.

Changed the attribute on begin_borrow from [defined] to [lexical].
