### PR TITLE
[Serialization] Restrict resilient swiftmodules to the compiler that built them

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -766,6 +766,10 @@ ERROR(serialization_module_too_old,Fatal,
       "compiled module was created by an older version of the compiler; "
       "rebuild %0 and try again: %1",
       (Identifier, StringRef))
+ERROR(serialization_module_incompatible_revision,Fatal,
+      "compiled module was created by a different version of the compiler; "
+      "rebuild %0 and try again: %1",
+      (Identifier, StringRef))
 ERROR(serialization_missing_single_dependency,Fatal,
       "missing required module '%0'", (StringRef))
 ERROR(serialization_missing_dependencies,Fatal,

--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -181,7 +181,7 @@ std::string getSwiftFullVersion(Version effectiveLanguageVersion =
 
 /// Retrieves the repository revision number (or identifier) from which
 /// this Swift was built.
-std::string getSwiftRevision();
+StringRef getSwiftRevision();
 
 } // end namespace version
 } // end namespace swift

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -39,6 +39,9 @@ enum class Status {
   /// compiler.
   FormatTooNew,
 
+  /// The precise revision version doesn't match.
+  RevisionIncompatible,
+
   /// The module file depends on another module that can't be loaded.
   MissingDependency,
 

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -438,7 +438,7 @@ std::string getSwiftFullVersion(Version effectiveVersion) {
   return OS.str();
 }
 
-std::string getSwiftRevision() {
+StringRef getSwiftRevision() {
 #ifdef SWIFT_REVISION
   return SWIFT_REVISION;
 #else

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -149,8 +149,8 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc,
       return error(status);
   }
 
-  auto clientSDK = ctx.LangOpts.SDKName;
   StringRef moduleSDK = Core->SDKName;
+  StringRef clientSDK = ctx.LangOpts.SDKName;
   if (ctx.SearchPathOpts.EnableSameSDKCheck &&
       !moduleSDK.empty() && !clientSDK.empty() &&
       moduleSDK != clientSDK) {

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -303,6 +303,35 @@ validateControlBlock(llvm::BitstreamCursor &cursor,
       result.sdkName = blobData;
       break;
     }
+    case control_block::REVISION: {
+      // Tagged compilers should load only resilient modules if they were
+      // produced by the exact same version.
+
+      // Disable this restriction for compiler testing by setting this
+      // env var to any value.
+      static const char* ignoreRevision =
+        ::getenv("SWIFT_DEBUG_IGNORE_SWIFTMODULE_REVISION");
+      if (ignoreRevision)
+        break;
+
+      // Override this env var for testing, forcing the behavior of a tagged
+      // compiler and using the env var value to override this compiler's
+      // revision.
+      static const char* forcedDebugRevision =
+        ::getenv("SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION");
+
+      bool isCompilerTagged = forcedDebugRevision ||
+-        !version::Version::getCurrentCompilerVersion().empty();
+
+      StringRef moduleRevision = blobData;
+      if (isCompilerTagged && !moduleRevision.empty()) {
+        std::string compilerRevision = forcedDebugRevision ?
+          forcedDebugRevision : version::getSwiftRevision();
+        if (moduleRevision != compilerRevision)
+          result.status = Status::RevisionIncompatible;
+      }
+      break;
+    }
     default:
       // Unknown metadata record, possibly for use by a future version of the
       // module format.

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -325,7 +325,7 @@ validateControlBlock(llvm::BitstreamCursor &cursor,
 
       StringRef moduleRevision = blobData;
       if (isCompilerTagged && !moduleRevision.empty()) {
-        std::string compilerRevision = forcedDebugRevision ?
+        StringRef compilerRevision = forcedDebugRevision ?
           forcedDebugRevision : version::getSwiftRevision();
         if (moduleRevision != compilerRevision)
           result.status = Status::RevisionIncompatible;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 629; // BuilderSDK
+const uint16_t SWIFTMODULE_VERSION_MINOR = 630; // Precise
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -755,7 +755,8 @@ namespace control_block {
     METADATA = 1,
     MODULE_NAME,
     TARGET,
-    SDK_NAME
+    SDK_NAME,
+    REVISION,
   };
 
   using MetadataLayout = BCRecordLayout<
@@ -783,6 +784,11 @@ namespace control_block {
 
   using SDKNameLayout = BCRecordLayout<
     SDK_NAME,
+    BCBlob
+  >;
+
+  using RevisionLayout = BCRecordLayout<
+    REVISION,
     BCBlob
   >;
 }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -803,6 +803,7 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(control_block, MODULE_NAME);
   BLOCK_RECORD(control_block, TARGET);
   BLOCK_RECORD(control_block, SDK_NAME);
+  BLOCK_RECORD(control_block, REVISION);
 
   BLOCK(OPTIONS_BLOCK);
   BLOCK_RECORD(options_block, SDK_PATH);
@@ -949,11 +950,12 @@ void Serializer::writeBlockInfoBlock() {
 
 void Serializer::writeHeader(const SerializationOptions &options) {
   {
-    BCBlockRAII restoreBlock(Out, CONTROL_BLOCK_ID, 3);
+    BCBlockRAII restoreBlock(Out, CONTROL_BLOCK_ID, 4);
     control_block::ModuleNameLayout ModuleName(Out);
     control_block::MetadataLayout Metadata(Out);
     control_block::TargetLayout Target(Out);
     control_block::SDKNameLayout SDKName(Out);
+    control_block::RevisionLayout Revision(Out);
 
     ModuleName.emit(ScratchRecord, M->getName().str());
 
@@ -991,6 +993,18 @@ void Serializer::writeHeader(const SerializationOptions &options) {
       SDKName.emit(ScratchRecord, options.SDKName);
 
     Target.emit(ScratchRecord, M->getASTContext().LangOpts.Target.str());
+
+    // Write the producer's Swift revision only for resilient modules.
+    if (M->getResilienceStrategy() != ResilienceStrategy::Default) {
+      auto revision = version::getSwiftRevision();
+
+      static const char* forcedDebugRevision =
+        ::getenv("SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION");
+      if (forcedDebugRevision)
+        revision = forcedDebugRevision;
+
+      Revision.emit(ScratchRecord, revision);
+    }
 
     {
       llvm::BCBlockRAII restoreBlock(Out, OPTIONS_BLOCK_ID, 4);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -839,6 +839,10 @@ void swift::serialization::diagnoseSerializedASTLoadFailure(
     Ctx.Diags.diagnose(diagLoc, diag::serialization_module_too_old, ModuleName,
                        moduleBufferID);
     break;
+  case serialization::Status::RevisionIncompatible:
+    Ctx.Diags.diagnose(diagLoc, diag::serialization_module_incompatible_revision,
+                       ModuleName, moduleBufferID);
+    break;
   case serialization::Status::Malformed:
     Ctx.Diags.diagnose(diagLoc, diag::serialization_malformed_module,
                        moduleBufferID);

--- a/test/Serialization/restrict-swiftmodule-to-revision.swift
+++ b/test/Serialization/restrict-swiftmodule-to-revision.swift
@@ -1,0 +1,58 @@
+// RUN: %empty-directory(%t/cache)
+// RUN: %empty-directory(%t/build)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+/// 1. Compile Lib.swift as non-resilient untagged, resilient untagged, and resilient tagged
+// BEGIN Lib.swift
+public func foo() {}
+
+/// Build Lib as a resilient and non-resilient swiftmodule
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -swift-version 5 -o %t/build -parse-stdlib -module-cache-path %t/cache -module-name ResilientLib -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -swift-version 5 -o %t/build -parse-stdlib -module-cache-path %t/cache -module-name NonresilientLib
+// RUN: SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=my-revision \
+// RUN:   %target-swift-frontend -emit-module %t/Lib.swift -swift-version 5 -o %t/build -parse-stdlib -module-cache-path %t/cache -module-name TaggedLib -enable-library-evolution
+
+
+/// 2. Test importing the non-resilient untagged library
+// BEGIN NonresilientClient.swift
+import NonresilientLib
+foo()
+
+/// Building a NonresilientLib client should always succeed
+// RUN: %target-swift-frontend -typecheck %t/NonresilientClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache
+// RUN: SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=my-revision \
+// RUN:   %target-swift-frontend -typecheck %t/NonresilientClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache
+
+
+/// 3. Test importing the resilient untagged library
+// BEGIN ResilientClient.swift
+import ResilientLib
+foo()
+
+/// Building a ResilientLib client should succeed in non-revision/dev mode
+// RUN: %target-swift-frontend -typecheck %t/ResilientClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache
+
+/// Building a ResilientLib client should reject the import for a tagged compiler
+// RUN: SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=not-a-revision \
+// RUN:   not %target-swift-frontend -typecheck %t/ResilientClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache 2>&1 | %FileCheck %s
+// CHECK: compiled module was created by a different version of the compiler; rebuild 'ResilientLib' and try again: {{.*}}ResilientLib.swiftmodule
+
+/// Building a ResilientLib client should succeed for a tagged compiler with SWIFT_DEBUG_IGNORE_SWIFTMODULE_REVISION
+// RUN: SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=not-a-revision SWIFT_DEBUG_IGNORE_SWIFTMODULE_REVISION=true \
+// RUN:   %target-swift-frontend -typecheck %t/ResilientClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache
+
+
+/// 4. Test importing the resilient tagged library
+// BEGIN TaggedClient.swift
+import TaggedLib
+foo()
+
+/// Importing TaggedLib should success with the same tag or a dev compiler
+// RUN: SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=my-revision \
+// RUN:   %target-swift-frontend -typecheck %t/TaggedClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache
+// RUN: %target-swift-frontend -typecheck %t/TaggedClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache
+
+/// Building a TaggedLib client should reject the import for a different tagged compiler
+// RUN: SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=not-a-revision \
+// RUN:   not %target-swift-frontend -typecheck %t/TaggedClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache 2>&1 | %FileCheck %s --check-prefix=CHECK-TAGGED
+// CHECK-TAGGED: compiled module was created by a different version of the compiler; rebuild 'TaggedLib' and try again: {{.*}}TaggedLib.swiftmodule


### PR DESCRIPTION
Introduce a new loading restriction that is more strict than the serialization version check on swiftmodules. Tagged compilers will only load library-evolution enabled swiftmodules that are produced by a compiler with the exact same revision id. This will be more reliable in production environments than using the serialization version which we forgot to update from time to time. This shouldn't affect development compilers that will still load any module with a compatible serialization version.

rdar://83105234