### PR TITLE
[Sema] Allow extending specialized types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1886,9 +1886,8 @@ ERROR(extension_access_with_conformances,none,
       "protocol conformances", (DeclAttribute))
 ERROR(extension_metatype,none,
       "cannot extend a metatype %0", (Type))
-ERROR(extension_specialization,none,
-      "constrained extension must be declared on the unspecialized generic "
-      "type %0 with constraints specified by a 'where' clause", (Identifier))
+ERROR(extension_placeholder,none,
+      "cannot extend a type that contains placeholders", ())
 ERROR(extension_stored_property,none,
       "extensions must not contain stored properties", ())
 NOTE(extension_stored_property_fixit,none,

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -587,8 +587,8 @@ static Type formExtensionInterfaceType(
   auto nominal = dyn_cast<NominalTypeDecl>(genericDecl);
   auto typealias = dyn_cast<TypeAliasDecl>(genericDecl);
   if (!nominal) {
-    Type underlyingType = typealias->getUnderlyingType();
-    nominal = underlyingType->getNominalOrBoundGenericNominal();
+    type = typealias->getUnderlyingType();
+    nominal = type->getNominalOrBoundGenericNominal();
   }
 
   // Form the result.
@@ -618,8 +618,7 @@ static Type formExtensionInterfaceType(
   }
 
   // If we have a typealias, try to form type sugar.
-  if (typealias && TypeChecker::isPassThroughTypealias(
-                       typealias, typealias->getUnderlyingType(), nominal)) {
+  if (typealias) {
     auto typealiasSig = typealias->getGenericSignature();
     SubstitutionMap subMap;
     if (typealiasSig) {
@@ -630,7 +629,6 @@ static Type formExtensionInterfaceType(
 
     resultType = TypeAliasType::get(typealias, parentType, subMap, resultType);
   }
-
 
   return resultType;
 }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -254,27 +254,6 @@ Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *Context,
 Type substMemberTypeWithBase(ModuleDecl *module, TypeDecl *member, Type baseTy,
                              bool useArchetypes = true);
 
-/// Determine whether this is a "pass-through" typealias, which has the
-/// same type parameters as the nominal type it references and specializes
-/// the underlying nominal type with exactly those type parameters.
-/// For example, the following typealias \c GX is a pass-through typealias:
-///
-/// \code
-/// struct X<T, U> { }
-/// typealias GX<A, B> = X<A, B>
-/// \endcode
-///
-/// whereas \c GX2 and \c GX3 are not pass-through because \c GX2 has
-/// different type parameters and \c GX3 doesn't pass its type parameters
-/// directly through.
-///
-/// \code
-/// typealias GX2<A> = X<A, A>
-/// typealias GX3<A, B> = X<B, A>
-/// \endcode
-bool isPassThroughTypealias(TypeAliasDecl *typealias, Type underlyingType,
-                            NominalTypeDecl *nominal);
-
 /// Determine whether one type is a subtype of another.
 ///
 /// \param t1 The potential subtype.

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -504,9 +504,24 @@ extension X1WithP2Changed {
 
 extension X1WithP2MoreArgs {
   func bad2() {
-    _ = X5<T>() // expected-error{{type 'T' does not conform to protocol 'P2'}}
+    _ = X5<T>()
   }
 }
+
+protocol ReallyBadProto1 {}
+protocol ReallyBadProto2 {}
+
+struct ReallyBadStruct1<T: ReallyBadProto1> {}
+typealias ReallyBadTypealias1<T: ReallyBadProto1> = ReallyBadStruct1<T> where T: ReallyBadProto2
+
+extension ReallyBadTypealias1 { // expected-note {{where 'T' = 'ReallyBadProto1Conformer'}}
+  func hello() {}
+}
+
+struct ReallyBadProto1Conformer: ReallyBadProto1 {}
+
+let x = ReallyBadStruct1<ReallyBadProto1Conformer>()
+x.hello() // expected-error {{referencing instance method 'hello()' on 'ReallyBadStruct1' requires that 'ReallyBadProto1Conformer' conform to 'ReallyBadProto2'}}
 
 // Inference from protocol inheritance clauses is not allowed.
 typealias ExistentialP4WithP2Assoc<T: P4> = P4 where T.P4Assoc : P2

--- a/test/SILGen/mangling_generic_extensions.swift
+++ b/test/SILGen/mangling_generic_extensions.swift
@@ -67,3 +67,10 @@ extension Bar {
   // CHECK-LABEL: $s27mangling_generic_extensions3BarV4bar1yyqd__AA8RuncibleRd__AaE5SpoonRp_lF
   func bar1<V: Runcible>(_: V) where U.Spoon: Runcible { }
 }
+
+// Extending specialized types should use the same mangling as same type constraints
+
+extension Foo<Int> {
+  // CHECK-LABEL: sil hidden [ossa] @$s27mangling_generic_extensions3FooVAASiRszlE013someIntFuncOnD0yyF
+  func someIntFuncOnFoo() {}
+}

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -339,7 +339,8 @@ extension Tree.LimbContent.Contents {
 }
 
 extension Tree.BoughPayload.Contents {
- // expected-error@-1 {{constrained extension must be declared on the unspecialized generic type 'Nest'}}
+ // expected-error@-1 {{extension of type 'Tree.BoughPayload.Contents' (aka 'Nest<Int>') must be declared as an extension of 'Nest<Int>'}}
+ // expected-note@-2 {{did you mean to extend 'Nest<Int>' instead?}}
 }
 
 // SR-10466 Check 'where' clause when referencing type defined inside extension

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -19,11 +19,10 @@ extension Double : P2 {
 }
 
 extension X<Int, Double, String> {
-// expected-error@-1{{constrained extension must be declared on the unspecialized generic type 'X' with constraints specified by a 'where' clause}}
   let x = 0
   // expected-error@-1 {{extensions must not contain stored properties}}
   static let x = 0
-  // expected-error@-1 {{static stored properties not supported in generic types}}
+
   func f() -> Int {}
   class C<T> {}
 }
@@ -224,3 +223,37 @@ extension NewGeneric {
     return NewGeneric()
   }
 }
+
+// Extending specialized types
+
+extension Array<Int> {
+  func someIntFuncOnArray() {}
+}
+
+let _ = [0, 1, 2].someIntFuncOnArray()
+
+extension [Character] {
+  func makeString() -> String { fatalError() }
+}
+
+let _ = ["a", "b", "c"].makeString()
+
+extension Set<_> {} // expected-error {{cannot extend a type that contains placeholders}}
+
+// https://bugs.swift.org/browse/SR-4875
+
+struct Foo<T, U> {
+    var x: T
+    var y: U
+}
+
+typealias IntFoo<U> = Foo<Int, U>
+
+extension IntFoo where U == Int {
+    func hello() {
+        print("hello")
+    }
+}
+
+Foo(x: "test", y: 1).hello() // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -302,9 +302,9 @@ func takesSugaredType2(m: GenericClass<Int>.TA<Float>) {
 extension A {}
 
 extension A<T> {}  // expected-error {{generic type 'A' specialized with too few type parameters (got 1, but expected 2)}}
-extension A<Float,Int> {}  // expected-error {{constrained extension must be declared on the unspecialized generic type 'MyType' with constraints specified by a 'where' clause}}
+extension A<Float,Int> {} // ok
 extension C<T> {}  // expected-error {{cannot find type 'T' in scope}}
-extension C<Int> {}  // expected-error {{constrained extension must be declared on the unspecialized generic type 'MyType' with constraints specified by a 'where' clause}}
+extension C<Int> {} // ok
 
 
 protocol ErrorQ {


### PR DESCRIPTION
While we patiently wait for parameterized extensions, I figured this feature can be split off and proposed separately so that people can use some much needed sugar for extensions. This allows for the following:

```swift
extension Array<Int> {} // translates to `extension Array where Element == Int {}`
```

This means that users can now finally use type sugar for their extended types like the following:

```swift
extension [Character] {
  func makeString() -> String {
    // ...
  }
}
```

In the process of doing this, I stumbled upon https://bugs.swift.org/browse/SR-4875 , and removing the constrained extension diagnostic means that this bug should probably just be fixed, so it is now.

Resolves: https://bugs.swift.org/browse/SR-4875