### PR TITLE
[release/5.5] Revert "Default to SwiftAsyncFramePointerKind::Always for now"

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -399,7 +399,7 @@ public:
         EmitStackPromotionChecks(false), FunctionSections(false),
         PrintInlineTree(false), EmbedMode(IRGenEmbedMode::None),
         LLVMLTOKind(IRGenLLVMLTOKind::None),
-        SwiftAsyncFramePointer(SwiftAsyncFramePointerKind::Always),
+        SwiftAsyncFramePointer(SwiftAsyncFramePointerKind::Auto),
         HasValueNamesSetting(false),
         ValueNames(false), EnableReflectionMetadata(true),
         EnableReflectionNames(true), EnableAnonymousContextMangledNames(false),

--- a/test/IRGen/swift_async_extended_frame_info.swift
+++ b/test/IRGen/swift_async_extended_frame_info.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-availability-checking -target x86_64-apple-macosx11 %s -S | %FileCheck  -check-prefix=ALWAYS %s
+// RUN: %target-swift-frontend -disable-availability-checking -target x86_64-apple-macosx11 %s -S | %FileCheck  -check-prefix=AUTO %s
 // RUN: %target-swift-frontend -disable-availability-checking -target x86_64-apple-macosx12 %s -S | %FileCheck  -check-prefix=ALWAYS %s
 // RUN: %target-swift-frontend -disable-availability-checking -swift-async-frame-pointer=auto -target x86_64-apple-macosx11 %s -S | %FileCheck  -check-prefix=AUTO %s
 // RUN: %target-swift-frontend -disable-availability-checking -swift-async-frame-pointer=auto -target x86_64-apple-macosx12 %s -S | %FileCheck  -check-prefix=ALWAYS %s


### PR DESCRIPTION
This reverts commit 87883b87db7cb43e83618915f67ac96eefeef37a.

Revert back to SwiftAsyncFramePointerKind::Auto as the default.