### PR TITLE
Stop using 'no_dead_strip' Mach-O section attribute on __swift5_protos, __swift5_proto, __swift5_types sections

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3682,7 +3682,7 @@ llvm::Constant *IRGenModule::emitSwiftProtocols() {
     llvm_unreachable("Don't know how to emit protocols for "
                      "the selected object format.");
   case llvm::Triple::MachO:
-    sectionName = "__TEXT, __swift5_protos, regular, no_dead_strip";
+    sectionName = "__TEXT, __swift5_protos, regular";
     break;
   case llvm::Triple::ELF:
   case llvm::Triple::Wasm:
@@ -3743,7 +3743,7 @@ llvm::Constant *IRGenModule::emitProtocolConformances() {
     llvm_unreachable("Don't know how to emit protocol conformances for "
                      "the selected object format.");
   case llvm::Triple::MachO:
-    sectionName = "__TEXT, __swift5_proto, regular, no_dead_strip";
+    sectionName = "__TEXT, __swift5_proto, regular";
     break;
   case llvm::Triple::ELF:
   case llvm::Triple::Wasm:
@@ -3769,7 +3769,7 @@ llvm::Constant *IRGenModule::emitTypeMetadataRecords() {
   std::string sectionName;
   switch (TargetInfo.OutputObjectFormat) {
   case llvm::Triple::MachO:
-    sectionName = "__TEXT, __swift5_types, regular, no_dead_strip";
+    sectionName = "__TEXT, __swift5_types, regular";
     break;
   case llvm::Triple::ELF:
   case llvm::Triple::Wasm:

--- a/test/IRGen/runtime-records-are-used.swift
+++ b/test/IRGen/runtime-records-are-used.swift
@@ -1,0 +1,23 @@
+// RUN: %swift -target arm64-apple-macos11.0 -parse-stdlib %s -module-name Swift -emit-ir -o - | %FileCheck %s
+
+public protocol Simple {}
+
+public struct Other : Simple {}
+
+// CHECK:      @"\01l_protocols" = private constant
+// CHECK-SAME: @"$ss6SimpleMp"
+// CHECK-SAME: , section "__TEXT, __swift5_protos, regular"
+
+// CHECK:      @"\01l_protocol_conformances" = private constant
+// CHECK-SAME: @"$ss5OtherVs6SimplesMc"
+// CHECK-SAME: , section "__TEXT, __swift5_proto, regular"
+
+// CHECK:      @"\01l_type_metadata_table" = private constant
+// CHECK-SAME: @"$ss5OtherVMn"
+// CHECK-SAME: , section "__TEXT, __swift5_types, regular"
+
+// CHECK:      @llvm.used = appending global [{{.*}} x i8*] [
+// CHECK-SAME: @"\01l_protocols"
+// CHECK-SAME: @"\01l_protocol_conformances"
+// CHECK-SAME: @"\01l_type_metadata_table"
+// CHECK-SAME: ], section "llvm.metadata"


### PR DESCRIPTION
This is needed to for a future change, <apple#39313>, which will start to allow
under certain conditions to dead-strip unused types, protocols and conformances.

The globals emitted into these sections are already marked as used via `addUsedGlobal()` so they have desired "no dead stripping" effect already.