### PR TITLE
Override -triple on fallback to arm64e interface

### DIFF
--- a/test/ModuleInterface/arm64e-fallback.swift
+++ b/test/ModuleInterface/arm64e-fallback.swift
@@ -11,9 +11,7 @@
 // When run on arm64e, this tests that we build the same interface with
 // `#if _ptrauth(_arm64e)` on.
 //
-// REQUIRES: CPU=arm64
-// Disabled arm64e for now since it isn't passing tests on apple silicon.
-// XFAIL: CPU=arm64e
+// REQUIRES: CPU=arm64 || CPU=arm64e
 
 import PtrAuthFramework // expected-remark{{rebuilding module 'PtrAuthFramework' from interface}}
 

--- a/test/stdlib/Reflection_objc.swift
+++ b/test/stdlib/Reflection_objc.swift
@@ -12,9 +12,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// Disabled arm64e for now since it is failing
-// XFAIL: CPU=arm64e
-
 //
 // DO NOT add more tests to this file.  Add them to test/1_stdlib/Runtime.swift.
 //


### PR DESCRIPTION
When we fall back to loading an arm64e module interface during an arm64 build, we want to compile it for the arm64 target so that it is fully compatible with the module that will load it, even though the flags in the file specify the arm64e target. Rewrite the sub-invocation's `TargetTriple` property in this specific situation. If the two targets differ by more than just the sub-architecture, we will continue to respect the `-target` flag in the file.

Fixes <rdar://83056545>. Corrects implementation of #39083.