### PR TITLE
Re-enable TSan versions of `async_let_fibonacci.swift` test

### DIFF
--- a/test/Sanitizers/symbolication.swift
+++ b/test/Sanitizers/symbolication.swift
@@ -5,10 +5,6 @@
 // REQUIRES: asan_runtime
 // REQUIRES: VENDOR=apple
 
-// rdar://80274830 ([Swift CI] Sanitizer report symbolication fails because we fail to start atos, sanbox issue?)
-// REQUIRES: 80274830
-// Might be related/same issue as below
-
 // rdar://75365575 (Failing to start atos external symbolizer)
 // UNSUPPORTED: OS=watchos
 

--- a/test/Sanitizers/tsan/async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/async_let_fibonacci.swift
@@ -1,20 +1,14 @@
-// RUN: %target-run-simple-swift( %import-libdispatch -parse-as-library -sanitize=thread)
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking %import-libdispatch -parse-as-library -sanitize=thread)
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: libdispatch
 // REQUIRES: tsan_runtime
-// UNSUPPORTED: use_os_stdlib
 
-// REQUIRES: radar76446550
+// rdar://76038845
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
 
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-import Glibc
-#endif
-
-@available(SwiftStdlib 5.5, *)
 func fib(_ n: Int) -> Int {
   var first = 0
   var second = 1
@@ -36,12 +30,12 @@ func asyncFib(_ n: Int) async -> Int {
   async let second = await asyncFib(n-1)
 
   // Sleep a random amount of time waiting on the result producing a result.
-  await Task.sleep(UInt64.random(in: 0..<100) * 1000)
+  await Task.sleep(UInt64.random(in: 0..<100) * 1_000_000)
 
   let result = await first + second
 
   // Sleep a random amount of time before producing a result.
-  await Task.sleep(UInt64.random(in: 0..<100) * 1000)
+  await Task.sleep(UInt64.random(in: 0..<100) * 1_000_000)
 
   return result
 }

--- a/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftc_driver %s  -parse-as-library %import-libdispatch -target %sanitizers-target-triple -g -sanitize=thread -o %t
+// RUN: %target-swiftc_driver %s -Xfrontend -disable-availability-checking -parse-as-library %import-libdispatch -target %sanitizers-target-triple -g -sanitize=thread -o %t
 // RUN: %target-codesign %t
 // RUN: env %env-TSAN_OPTIONS="abort_on_error=0" not %target-run %t 2>&1 | %swift-demangle --simplified | %FileCheck %s
 
@@ -8,20 +8,11 @@
 // REQUIRES: tsan_runtime
 
 // rdar://76038845
-// UNSUPPORTED: use_os_stdlib
-
-// rdar://80274830 ([Swift CI] Sanitizer report symbolication fails because we fail to start atos, sanbox issue?)
-// REQUIRES: 80274830
-// Might be related/same issue as below
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
 
 // rdar://75365575 (Failing to start atos external symbolizer)
 // UNSUPPORTED: OS=watchos
-
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-import Glibc
-#endif
 
 func fib(_ n: Int) -> Int {
   var first = 0
@@ -36,6 +27,7 @@ func fib(_ n: Int) -> Int {
 
 var racyCounter = 0
 
+@available(SwiftStdlib 5.5, *)
 func asyncFib(_ n: Int) async -> Int {
   racyCounter += 1
   if n == 0 || n == 1 {
@@ -46,25 +38,26 @@ func asyncFib(_ n: Int) async -> Int {
   async let second = await asyncFib(n-1)
 
   // Sleep a random amount of time waiting on the result producing a result.
-  usleep(UInt32.random(in: 0..<100) * 1000)
+  await Task.sleep(UInt64.random(in: 0..<100) * 1_000_000)
 
   let result = await first + second
 
   // Sleep a random amount of time before producing a result.
-  usleep(UInt32.random(in: 0..<100) * 1000)
+  await Task.sleep(UInt64.random(in: 0..<100) * 1_000_000)
 
   return result
 }
 
+@available(SwiftStdlib 5.5, *)
 func runFibonacci(_ n: Int) async {
   let result = await asyncFib(n)
 
   print()
   print("Async fib = \(result), sequential fib = \(fib(n))")
   assert(result == fib(n))
-  print("asyncFib() called around \(racyCounter) times")
 }
 
+@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
     await runFibonacci(10)


### PR DESCRIPTION
The two TSan versions of the
`test/Concurrency/Runtime/async_let_fibonacci.swift` were disabled for
different reasons:
[1] Swift Concurrency work broke the test and it was never re-enabled.
[2] Regression in atos required test to be disabled.  Re-enablement was
    blocked on Swift CI upgrading to an Xcode that contains the fixed
    version of atos.

While the TSan versions of the test was not running they fell out of
sync with the original test and then started failing for different
(trivial) reasons once re-enabled.

Please help us keep these tests running by:
* Not landing work that makes them fail (and deferring the fix to a
  later point), if at all possible.  Breaking sanitizers should be a
  "blocker".
* Keeping them in sync with the original tests.

Radar-Id: rdar://83162880

[1] rdar://76446550 (Re-enable test: Sanitizers/tsan/async_let_fibonacci.swift)
[2] rdar://80274830 ([Swift CI] Sanitizer report symbolication fails due to regression in atos)
