### PR TITLE
Revert "[Swift CI] Re-enable sanitizer symbolication tests"

### DIFF
--- a/test/Sanitizers/symbolication.swift
+++ b/test/Sanitizers/symbolication.swift
@@ -5,6 +5,10 @@
 // REQUIRES: asan_runtime
 // REQUIRES: VENDOR=apple
 
+// rdar://80274830 ([Swift CI] Sanitizer report symbolication fails because we fail to start atos, sanbox issue?)
+// REQUIRES: 80274830
+// Might be related/same issue as below
+
 // rdar://75365575 (Failing to start atos external symbolizer)
 // UNSUPPORTED: OS=watchos
 

--- a/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
@@ -10,6 +10,10 @@
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib
 
+// rdar://80274830 ([Swift CI] Sanitizer report symbolication fails because we fail to start atos, sanbox issue?)
+// REQUIRES: 80274830
+// Might be related/same issue as below
+
 // rdar://75365575 (Failing to start atos external symbolizer)
 // UNSUPPORTED: OS=watchos
 


### PR DESCRIPTION
Reverts apple/swift#38489 to unblock PR tests