### PR TITLE
[test] ArrayBridge: Add missing availability checks

### DIFF
--- a/test/stdlib/ArrayBridge.swift.gyb
+++ b/test/stdlib/ArrayBridge.swift.gyb
@@ -485,6 +485,10 @@ tests.test("rdar://problem/27905230") {
 }
 
 tests.test("verbatimBridged/Base/withUnsafeBufferPointer") {
+  // https://bugs.swift.org/browse/SR-14663
+  // This tests a bad precondition that was fixed in
+  // https://github.com/apple/swift/pull/37960
+  guard #available(macOS 12, iOS 15, watchOS 8, tvOS 15, *) else { return }
   let a = NSArray(array: [Base(0), Base(1), Base(2), Base(3)])
   let b = a as! [Base]
   let success: Bool = b.withUnsafeBufferPointer { buffer in
@@ -499,8 +503,11 @@ tests.test("verbatimBridged/Base/withUnsafeBufferPointer") {
   expectTrue(success)
 }
 
-// https://bugs.swift.org/browse/SR-14663
 tests.test("verbatimBridged/AnyObject/withUnsafeBufferPointer") {
+  // https://bugs.swift.org/browse/SR-14663
+  // This tests a bad precondition that was fixed in
+  // https://github.com/apple/swift/pull/37960
+  guard #available(macOS 12, iOS 15, watchOS 8, tvOS 15, *) else { return }
   let a = NSArray(array: [Base(0), Base(1), Base(2), Base(3)])
   let b = a as [AnyObject]
   let success: Bool = b.withUnsafeBufferPointer { buffer in


### PR DESCRIPTION
Welp, the bogus precondition that was fixed in https://github.com/apple/swift/pull/37960 indeed doesn't entirely deploy back to previous OSes.

This makes sense -- bridging is generally not specialized.

rdar://82125353
