### PR TITLE
AST: Remove bogus check from IsBindableVisitor::handleGenericNominalType()

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2025,12 +2025,6 @@ public:
         auto substConf = substSubMap.lookupConformance(canTy, proto);
 
         if (origConf.isConcrete()) {
-          // A generic argument may inherit a concrete conformance from a class
-          // constraint, which could still be bound to a type parameter we don't
-          // know more about.
-          if (origConf.getConcrete()->getType()->is<ArchetypeType>())
-            continue;
-          
           if (!substConf.isConcrete())
             return CanType();
           if (origConf.getConcrete()->getRootConformance()

--- a/test/SILGen/type_lowering_subst_function_type_superclass_archetype.swift
+++ b/test/SILGen/type_lowering_subst_function_type_superclass_archetype.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-emit-silgen %s
+
+public protocol Q {}
+
+public protocol P {}
+public class C : P {}
+
+public class G<T : P> {}
+
+extension Q where Self : C {
+  public func foo(_: (G<Self>) -> ()) {}
+}


### PR DESCRIPTION
The number of conformances in a substitution map must exactly equal the
number of conformance requirements in the generic signature, but in one
case we would skip a conformance requirement.