### PR TITLE
Revert "Disable test while MikeA fixes it to unblock the builds."

### DIFF
--- a/test/Concurrency/Runtime/exclusivity_custom_executors.swift
+++ b/test/Concurrency/Runtime/exclusivity_custom_executors.swift
@@ -3,8 +3,6 @@
 // REQUIRES: concurrency
 // REQUIRES: executable_test
 
-// REQUIRES: rdar82734785
-
 // rdar://76038845
 // UNSUPPORTED: back_deployment_runtime
 // REQUIRES: concurrency_runtime


### PR DESCRIPTION
This reverts commit 433215f8fe4a34c1b02f6edf54b5ae978a48fde0.

This should be fixed now by disabling emission of extend async frame
info on linux.