### PR TITLE
[DO NOT MERGE][benchmark] Modernize benchmark definitions

### DIFF
--- a/benchmark/single-source/Ackermann.swift
+++ b/benchmark/single-source/Ackermann.swift
@@ -14,38 +14,44 @@
 // for performance measuring.
 import TestsUtils
 
-public let Ackermann = BenchmarkInfo(
-  name: "Ackermann",
-  runFunction: run_Ackermann,
-  tags: [.algorithm])
+public let benchmarks: [Benchmark] = [
+  Ackermann()
+]
 
-func ackermann(_ M: Int, _ N : Int) -> Int {
-  if (M == 0) { return N + 1 }
-  if (N == 0) { return ackermann(M - 1, 1) }
-  return ackermann(M - 1, ackermann(M, N - 1))
-}
+struct Ackermann: Benchmark {
+  var name: String { "Ackermann" }
+  var tags: Tags { [.algorithm] }
 
-@inline(never)
-func Ackermann(_ M: Int, _ N : Int) -> Int {
-  // This if prevents optimizer from computing return value of Ackermann(3,9)
-  // at compile time.
-  if False() { return 0 }
-  if (M == 0) { return N + 1 }
-  if (N == 0) { return ackermann(M - 1, 1) }
-  return ackermann(M - 1, ackermann(M, N - 1))
-}
+  let ref_result = [
+    5, 13, 29, 61, 125, 253, 509, 1021, 2045,
+    4093, 8189, 16381, 32765, 65533, 131069
+  ]
 
-let ref_result = [5, 13, 29, 61, 125, 253, 509, 1021, 2045, 4093, 8189, 16381, 32765, 65533, 131069]
-
-@inline(never)
-public func run_Ackermann(_ N: Int) {
-  let (m, n) = (3, 6)
-  var result = 0
-  for _ in 1...N {
-    result = Ackermann(m, n)
-    if result != ref_result[n] {
-      break
+  func run(iterations: Int) {
+    let (m, n) = (3, 6)
+    var result = 0
+    for _ in 1 ... iterations {
+      result = ackermann(m, n)
+      if result != ref_result[n] {
+        break
+      }
     }
+    check(result == ref_result[n])
   }
-  CheckResults(result == ref_result[n])
+
+  @inline(never)
+  func ackermann(_ m: Int, _ n : Int) -> Int {
+    // This if prevents optimizer from computing the return value at compile
+    // time.
+    if getFalse() { return 0 }
+    if m == 0 { return n + 1 }
+    if n == 0 { return ackermann(m - 1, 1) }
+    return ackermann(m - 1, ackermann(m, n - 1))
+  }
+
+  func _ackermann(_ m: Int, _ n : Int) -> Int {
+    if m == 0 { return n + 1 }
+    if n == 0 { return ackermann(m - 1, 1) }
+    return ackermann(m - 1, ackermann(m, n - 1))
+  }
 }

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -59,7 +59,23 @@ struct BenchResults {
   var median: T { return self[0.5] }
 }
 
-public var registeredBenchmarks: [BenchmarkInfo] = []
+public var registeredBenchmarks: [Benchmark] = []
+
+public func register(_ benchmark: Benchmark) {
+  registeredBenchmarks.append(benchmark)
+}
+
+public func register<S: Sequence>(_ benchmarks: S) where S.Element == Benchmark {
+  registeredBenchmarks.append(contentsOf: benchmarks)
+}
+
+extension Benchmark {
+  /// Returns true if this benchmark should be run on the current platform.
+  var shouldRun: Bool {
+    return !unsupportedPlatforms.contains(.currentPlatform)
+  }
+}
+
 
 enum TestAction {
   case run
@@ -109,11 +125,11 @@ struct TestConfig {
   let afterRunSleep: UInt32?
 
   /// The list of tests to run.
-  let tests: [(index: String, info: BenchmarkInfo)]
+  let tests: [(index: String, benchmark: Benchmark)]
 
   let action: TestAction
 
-  init(_ registeredBenchmarks: [BenchmarkInfo]) {
+  init(_ registeredBenchmarks: [Benchmark]) {
 
     struct PartialTestConfig {
       var delim: String?
@@ -256,27 +272,27 @@ struct TestConfig {
   /// - Returns: An array of test number and benchmark info tuples satisfying
   ///     specified filtering conditions.
   static func filterTests(
-    _ registeredBenchmarks: [BenchmarkInfo],
+    _ registeredBenchmarks: [Benchmark],
     tests: [String],
     tags: Set<BenchmarkCategory>,
     skipTags: Set<BenchmarkCategory>
-  ) -> [(index: String, info: BenchmarkInfo)] {
+  ) -> [(index: String, benchmark: Benchmark)] {
     var t = tests
     let filtersIndex = t.partition { $0.hasPrefix("+") || $0.hasPrefix("-") }
     let excludesIndex = t[filtersIndex...].partition { $0.hasPrefix("-") }
     let specifiedTests = Set(t[..<filtersIndex])
     let includes = t[filtersIndex..<excludesIndex].map { $0.dropFirst() }
     let excludes = t[excludesIndex...].map { $0.dropFirst() }
-    let allTests = registeredBenchmarks.sorted()
+    let allTests = registeredBenchmarks.sorted(by: { $0.name < $1.name })
     let indices = Dictionary(uniqueKeysWithValues:
       zip(allTests.map { $0.name },
           (1...).lazy.map { String($0) } ))
 
-    func byTags(b: BenchmarkInfo) -> Bool {
+    func byTags(_ b: Benchmark) -> Bool {
       return b.tags.isSuperset(of: tags) &&
         b.tags.isDisjoint(with: skipTags)
     }
-    func byNamesOrIndices(b: BenchmarkInfo) -> Bool {
+    func byNamesOrIndices(_ b: Benchmark) -> Bool {
       return specifiedTests.contains(b.name) ||
         // !! "`allTests` have been assigned an index"
         specifiedTests.contains(indices[b.name]!) ||
@@ -511,20 +527,20 @@ final class TestRunner {
   }
 
   /// Measure the `fn` and return the average sample time per iteration (μs).
-  func measure(_ name: String, fn: (Int) -> Void, numIters: Int) -> Int {
+  func measure(_ benchmark: Benchmark, iterations: Int) -> Int {
 #if SWIFT_RUNTIME_ENABLE_LEAK_CHECKER
-    name.withCString { p in startTrackingObjects(p) }
+    benchmark.name.withCString { p in startTrackingObjects(p) }
 #endif
 
     startMeasurement()
-    fn(numIters)
+    benchmark.run(iterations: iterations)
     stopMeasurement()
 
 #if SWIFT_RUNTIME_ENABLE_LEAK_CHECKER
     name.withCString { p in stopTrackingObjects(p) }
 #endif
 
-    return lastSampleTime.microseconds / numIters
+    return lastSampleTime.microseconds / iterations
   }
 
   func logVerbose(_ msg: @autoclosure () -> String) {
@@ -532,11 +548,11 @@ final class TestRunner {
   }
 
   /// Run the benchmark and return the measured results.
-  func run(_ test: BenchmarkInfo) -> BenchResults? {
+  func run(_ test: Benchmark) -> BenchResults? {
     // Before we do anything, check that we actually have a function to
     // run. If we don't it is because the benchmark is not supported on
     // the platform and we should skip it.
-    guard let testFn = test.runFunction else {
+    guard test.shouldRun else {
       logVerbose("Skipping unsupported benchmark \(test.name)!")
       return nil
     }
@@ -550,16 +566,14 @@ final class TestRunner {
     }
 
     resetMeasurements()
-    if let setUp = test.setUpFunction {
-      setUp()
-      stopMeasurement()
-      logVerbose("    SetUp \(lastSampleTime.microseconds)")
-      resetMeasurements()
-    }
+    test.setUp()
+    stopMeasurement()
+    logVerbose("    SetUp \(lastSampleTime.microseconds)")
+    resetMeasurements()
 
     // Determine number of iterations for testFn to run for desired time.
     func iterationsPerSampleTime() -> (numIters: Int, oneIter: Int) {
-      let oneIter = measure(test.name, fn: testFn, numIters: 1)
+      let oneIter = measure(test, iterations: 1)
       if oneIter > 0 {
         let timePerSample = Int(c.sampleTime * 1_000_000.0) // microseconds (μs)
         return (max(timePerSample / oneIter, 1), oneIter)
@@ -591,10 +605,10 @@ final class TestRunner {
     logVerbose("    Collecting \(numSamples) samples.")
     logVerbose("    Measuring with scale \(numIters).")
     for _ in samples.count..<numSamples {
-      addSample(measure(test.name, fn: testFn, numIters: numIters))
+      addSample(measure(test, iterations: numIters))
     }
 
-    test.tearDownFunction?()
+    test.tearDown()
     if let lf = test.legacyFactor {
       logVerbose("    Applying legacy factor: \(lf)")
       samples = samples.map { $0 * lf }
@@ -631,7 +645,7 @@ final class TestRunner {
   func runBenchmarks() {
     var testCount = 0
 
-    func report(_ index: String, _ t: BenchmarkInfo, results: BenchResults?) {
+    func report(_ index: String, _ t: Benchmark, results: BenchResults?) {
       func values(r: BenchResults) -> [String] {
         func quantiles(q: Int) -> [Int] {
           let qs = (0...q).map { i in r[Double(i) / Double(q)] }

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -287,7 +287,22 @@ public struct SplitMix64: RandomNumberGenerator {
     }
 }
 
-@inlinable // FIXME(inline-always)
+@inlinable
+@inline(__always)
+public func check(
+  _ result: Bool,
+  file: StaticString = #file,
+  function: StaticString = #function,
+  line: Int = #line
+) {
+  guard _fastPath(result) else {
+    print("Incorrect result in \(function), \(file):\(line)")
+    abort()
+  }
+}
+
+@available(*, deprecated)
+@inlinable
 @inline(__always)
 public func CheckResults(
     _ resultsMatch: Bool,
@@ -305,7 +320,7 @@ public func CheckResults(
 // If we do not have an objc-runtime, then we do not have a definition for
 // autoreleasepool. Add in our own fake autoclosure for it that is inline
 // always. That should be able to be eaten through by the optimizer no problem.
-@inlinable // FIXME(inline-always)
+@inlinable
 @inline(__always)
 public func autoreleasepool<Result>(
   invoking body: () throws -> Result
@@ -314,6 +329,9 @@ public func autoreleasepool<Result>(
 }
 #endif
 
+public func getFalse() -> Bool { return false }
+
+@available(*, deprecated, renamed: "getFalse")
 public func False() -> Bool { return false }
 
 /// This is a dummy protocol to test the speed of our protocol dispatch.
@@ -332,6 +350,8 @@ public func blackHole<T>(_ x: T) {
 }
 
 // Return the passed argument without letting the optimizer know that.
+// It's important that this function is in another module than the tests
+// which are using it.
 @inline(never)
 public func identity<T>(_ x: T) -> T {
   return x

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -108,6 +108,56 @@ public struct BenchmarkPlatformSet : OptionSet {
   }
 }
 
+public protocol Benchmark {
+  typealias Tags = Set<BenchmarkCategory>
+
+  /// The name of the benchmark that should be displayed by the harness.
+  var name: String { get }
+
+  /// A set of category tags that describe this benchmark. This is used by the
+  /// harness to allow for easy slicing of the set of benchmarks along tag
+  /// boundaries, e.x.: run all string benchmarks or ref count benchmarks, etc.
+  var tags: Tags { get }
+
+  /// The platforms that this benchmark does not support. This is an OptionSet.
+  var unsupportedPlatforms: BenchmarkPlatformSet { get }
+
+  /// DON'T USE ON NEW BENCHMARKS!
+  /// Optional `legacyFactor` is a multiplication constant applied to runtime
+  /// statistics reported in the benchmark summary (it doesn’t affect the
+  /// individual sample times reported in `--verbose` mode).
+  ///
+  /// It enables the migration of benchmark suite to smaller workloads (< 1 ms),
+  /// which are more robust to measurement errors from system under load,
+  /// while maintaining the continuity of longterm benchmark tracking.
+  ///
+  /// Most legacy benchmarks had workloads artificially inflated in their main
+  /// `for` loops with a constant integer factor and the migration consisted of
+  /// dividing it so that the optimized runtime (-O) was less than 1000 μs and
+  /// storing the divisor in `legacyFactor`. This effectively only increases the
+  /// frequency of measurement, gathering more samples that are much less likely
+  /// to be interrupted by a context switch.
+  var legacyFactor: Int? { get }
+
+  /// This method is run before benchmark samples are timed.
+  func setUp()
+
+  /// A function that invokes the specific benchmark routine.
+  func run(iterations: Int)
+
+  /// This method is run after samples are taken.
+  func tearDown()
+}
+
+// Default implementations.
+extension Benchmark {
+  public var unsupportedPlatforms: BenchmarkPlatformSet { [] }
+  public var legacyFactor: Int? { nil }
+  public func setUp() {}
+  public func tearDown() {}
+}
+
+@available(*, deprecated)
 public struct BenchmarkInfo {
   /// The name of the benchmark that should be displayed by the harness.
   public var name: String
@@ -115,44 +165,19 @@ public struct BenchmarkInfo {
   /// Shadow static variable for runFunction.
   private var _runFunction: (Int) -> ()
 
-  /// A function that invokes the specific benchmark routine.
-  public var runFunction: ((Int) -> ())? {
-    if !shouldRun {
-      return nil
-    }
-    return _runFunction
-  }
-
   /// A set of category tags that describe this benchmark. This is used by the
   /// harness to allow for easy slicing of the set of benchmarks along tag
   /// boundaries, e.x.: run all string benchmarks or ref count benchmarks, etc.
   public var tags: Set<BenchmarkCategory>
 
   /// The platforms that this benchmark supports. This is an OptionSet.
-  private var unsupportedPlatforms: BenchmarkPlatformSet
+  public var unsupportedPlatforms: BenchmarkPlatformSet
 
   /// Shadow variable for setUpFunction.
   private var _setUpFunction: (() -> ())?
 
-  /// An optional function that if non-null is run before benchmark samples
-  /// are timed.
-  public var setUpFunction : (() -> ())? {
-    if !shouldRun {
-      return nil
-    }
-    return _setUpFunction
-  }
-
   /// Shadow static variable for computed property tearDownFunction.
   private var _tearDownFunction: (() -> ())?
-
-  /// An optional function that if non-null is run after samples are taken.
-  public var tearDownFunction: (() -> ())? {
-    if !shouldRun {
-      return nil
-    }
-    return _tearDownFunction
-  }
 
   /// DON'T USE ON NEW BENCHMARKS!
   /// Optional `legacyFactor` is a multiplication constant applied to runtime
@@ -171,38 +196,38 @@ public struct BenchmarkInfo {
   /// to be interrupted by a context switch.
   public var legacyFactor: Int?
 
-  public init(name: String, runFunction: @escaping (Int) -> (), tags: [BenchmarkCategory],
-              setUpFunction: (() -> ())? = nil,
-              tearDownFunction: (() -> ())? = nil,
-              unsupportedPlatforms: BenchmarkPlatformSet = [],
-              legacyFactor: Int? = nil) {
+  public init(
+    name: String,
+    runFunction: @escaping (Int) -> (),
+    tags: [BenchmarkCategory],
+    setUpFunction: (() -> ())? = nil,
+    tearDownFunction: (() -> ())? = nil,
+    unsupportedPlatforms: BenchmarkPlatformSet = [],
+    legacyFactor: Int? = nil
+  ) {
     self.name = name
-    self._runFunction = runFunction
     self.tags = Set(tags)
+    self.unsupportedPlatforms = unsupportedPlatforms
+    self._runFunction = runFunction
     self._setUpFunction = setUpFunction
     self._tearDownFunction = tearDownFunction
-    self.unsupportedPlatforms = unsupportedPlatforms
     self.legacyFactor = legacyFactor
   }
-
-  /// Returns true if this benchmark should be run on the current platform.
-  var shouldRun: Bool {
-    return !unsupportedPlatforms.contains(.currentPlatform)
-  }
 }
 
-extension BenchmarkInfo : Comparable {
-  public static func < (lhs: BenchmarkInfo, rhs: BenchmarkInfo) -> Bool {
-    return lhs.name < rhs.name
+@available(*, deprecated)
+extension BenchmarkInfo: Benchmark {
+  public func setUp() {
+    _setUpFunction?()
   }
-  public static func == (lhs: BenchmarkInfo, rhs: BenchmarkInfo) -> Bool {
-    return lhs.name == rhs.name
-  }
-}
 
-extension BenchmarkInfo : Hashable {
-  public func hash(into hasher: inout Hasher) {
-    hasher.combine(name)
+  /// An optional function that if non-null is run after samples are taken.
+  public func tearDown() {
+    _tearDownFunction?()
+  }
+
+  public func run(iterations: Int) {
+    _runFunction(iterations)
   }
 }
 

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -194,6 +194,9 @@ import Walsh
 import WordCount
 import XorLoop
 
+register(Ackermann.benchmarks)
+register(AngryPhonebook.benchmarks)
+
 private func registerBenchmark(_ bench: BenchmarkInfo) {
   registeredBenchmarks.append(bench)
 }
@@ -206,8 +209,6 @@ private func registerBenchmark<
   }
 }
 
-registerBenchmark(Ackermann)
-registerBenchmark(AngryPhonebook)
 registerBenchmark(AnyHashableWithAClass)
 registerBenchmark(Array2D)
 registerBenchmark(ArrayAppend)

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -194,16 +194,16 @@ import Walsh
 import WordCount
 import XorLoop
 
-@inline(__always)
 private func registerBenchmark(_ bench: BenchmarkInfo) {
   registeredBenchmarks.append(bench)
 }
 
-@inline(__always)
 private func registerBenchmark<
   S : Sequence
 >(_ infos: S) where S.Element == BenchmarkInfo {
-  registeredBenchmarks.append(contentsOf: infos)
+  for info in infos {
+    registeredBenchmarks.append(info)
+  }
 }
 
 registerBenchmark(Ackermann)


### PR DESCRIPTION
This is an experiment in writing benchmark definitions in a way that's friendlier to actual Swift programmers.

- Replace `struct BenchmarkInfo` with a more helpful `protocol Benchmark`
- Stop Capitalizing Function And Parameter Names, That's Not How Swift Code Looks

The potential benefit is that it becomes easier for contributors to develop new benchmarks -- no more weird language dialect. 

The risk as I see it is either 
- perturbing existing benchmarks (if they get adapted to use `protocol Benchmark`), or
- diverging benchmarking definitions into an old and a new syntax, adding to confusion (if existing benchmarks are kept as is).


The basic idea with `protocol Benchmark` is that instead of creating a bunch of top-level functions and static lets / vars, then registering things using:

```swift
  BenchmarkInfo(
    name: "AngryPhonebook.ASCII2.Small",
    runFunction: { angryPhonebook($0*10, ascii) },
    tags: t,
    setUpFunction: { blackHole(ascii) }),
  BenchmarkInfo(
    name: "AngryPhonebook.Strasse.Small",
    runFunction: { angryPhonebook($0, strasse) },
    tags: t,
    setUpFunction: { blackHole(strasse) }),
```

we'd define a custom struct:

```swift
struct AngryPhonebook: Benchmark {
  let name: String
  let input: [String]
  let factor: Int

  init(name: String, input: [String], factor: Int = 1) {
    self.name = name
    self.input = input
    self.factor = factor
  }

  var tags: Tags { [.validation, .api, .String] }

  func run(iterations: Int) {
    ...
  }
}
```

and simply register instances of it as individual benchmarks:

```swift
  AngryPhonebook(
    name: "AngryPhonebook.ASCII2.Small",
    input: ascii,
    factor: 10),
  AngryPhonebook(
    name: "AngryPhonebook.Strasse.Small",
    input: strasse),
  AngryPhonebook(
    name: "AngryPhonebook.Armenian.Small",
    input: armenian),
  AngryPhonebook(
    name: "AngryPhonebook.Cyrillic.Small",
    input: cyrillic),
```

This gets rid of the closure stuff, and encourages encapsulating the preprocessed input data in the struct itself, preventing the preprocessing from leaking into the measurement. Currently we need to remember to do this by manually triggering swift_onces in the `setUpFunction` -- this is much too tricky.