### PR TITLE
Rebranch: Fix SingleCommandCompilationDatabase references

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -306,17 +306,13 @@ Optional<ModuleDependencies> ClangImporter::getModuleDependencies(
   }
 
   // Determine the command-line arguments for dependency scanning.
-
   std::vector<std::string> commandLineArgs =
     getClangDepScanningInvocationArguments(ctx, *importHackFile);
-
   std::string workingDir =
       ctx.SourceMgr.getFileSystem()->getCurrentWorkingDirectory().get();
-  CompileCommand command(workingDir, *importHackFile, commandLineArgs, "-");
-  SingleCommandCompilationDatabase database(command);
 
   auto clangDependencies = clangImpl->tool.getFullDependencies(
-      database, workingDir, clangImpl->alreadySeen);
+      commandLineArgs, workingDir, clangImpl->alreadySeen);
   if (!clangDependencies) {
     // FIXME: Route this to a normal diagnostic.
     llvm::logAllUnhandledErrors(clangDependencies.takeError(), llvm::errs());
@@ -354,14 +350,11 @@ bool ClangImporter::addBridgingHeaderDependencies(
   // Determine the command-line arguments for dependency scanning.
   std::vector<std::string> commandLineArgs =
     getClangDepScanningInvocationArguments(ctx, bridgingHeader);
-
   std::string workingDir =
       ctx.SourceMgr.getFileSystem()->getCurrentWorkingDirectory().get();
-  CompileCommand command(workingDir, bridgingHeader, commandLineArgs, "-");
-  SingleCommandCompilationDatabase database(command);
 
   auto clangDependencies = clangImpl->tool.getFullDependencies(
-      database, workingDir, clangImpl->alreadySeen);
+      commandLineArgs, workingDir, clangImpl->alreadySeen);
 
   if (!clangDependencies) {
     // FIXME: Route this to a normal diagnostic.


### PR DESCRIPTION
The SingleCommandCompilationDatabase type was removed from LLVM and the
API's that took it were changed to just take the vector of arguments
instead. This patch updates the calls to `getFullDependencies` to pass
in the argument vector to reflect that change and get things building
again.

It looks like apple/llvm-project commit d64d0fdea2303816700e5b2c40dc7446578ae088 broke this.

Resolves: rdar://83173673