### PR TITLE
XFAIL decl/protocol/protocols_with_self_or_assoc_reqs_executable.swift

### DIFF
--- a/test/decl/protocol/protocols_with_self_or_assoc_reqs_executable.swift
+++ b/test/decl/protocol/protocols_with_self_or_assoc_reqs_executable.swift
@@ -1,6 +1,9 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// Temporarily disabled due to a runtime crash.
+// REQUIRES: rdar83066987
+
 import StdlibUnittest
 
 let Tests = TestSuite(#file)


### PR DESCRIPTION
To work around failure seen in https://ci.swift.org/job/oss-swift_tools-RA_stdlib-RDA_test-simulator/4027.

rdar://83066987