### PR TITLE
[benchmark] Fix spurious benchmark regressions

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -199,7 +199,30 @@ benchmarks will be compiled with -Onone!**
 * `$ ./Benchmark_O --tags=Dictionary`
 * `$ ./Benchmark_O --skip-tags=unstable,skip,validation`
 
-### Note
+### Deterministic Hashing Requirement
+
+To run benchmarks, you'll need to disable randomized hash seeding by setting the
+`SWIFT_DETERMINISTIC_HASHING` environment variable to `1`. (You only need to do
+this when running the benchmark executables directly -- the driver script does
+this for you automatically.)
+
+* `$ env SWIFT_DETERMINISTIC_HASHING=1 ./Benchmark_O --num-iters=1 --num-samples=1`
+
+This makes for more stable results, by preventing random hash collision changes
+from affecting benchmark measurements. Benchmark measurements start by checking
+that deterministic hashing is enabled and they fail with a runtime trap when it
+isn't.
+
+If for some reason you want to run the benchmarks using standard randomized
+hashing, you can disable this check by passing the
+`--allow-nondeterministic-hashing` option to the executable.
+
+* `$ ./Benchmark_O --num-iters=1 --num-samples=1 --allow-nondeterministic-hashing`
+
+This will affect the reliability of measurements, so this is not recommended.
+
+### Benchmarking by Numbers
+
 As a shortcut, you can also refer to benchmarks by their ordinal numbers.
 These are printed out together with benchmark names and tags using the
 `--list` parameter. For a complete list of all available performance tests run

--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -683,7 +683,7 @@ function (swift_benchmark_compile_archopts)
           ${objcfile}
           "-o" "${OUTPUT_EXEC}"
         COMMAND
-        "codesign" "-f" "-s" "-" "${OUTPUT_EXEC}")
+        "${srcdir}/../utils/swift-darwin-postprocess.py" "${OUTPUT_EXEC}")
   else()
     # TODO: rpath.
     add_custom_command(

--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -56,6 +56,11 @@ class BenchmarkDriver(object):
         """
         self.args = args
         self.run_env = os.environ.copy()
+
+        # Set a constant hash seed. Some tests are highly sensitive to
+        # fluctuations in the number of hash collisions.
+        self.run_env["SWIFT_DETERMINISTIC_HASHING"] = "1"
+
         if hasattr(args, 'libdir') and args.libdir:
             # The benchmark binaries should pick up the built swift libraries
             # automatically, because their RPATH should point to ../lib/swift
@@ -65,15 +70,13 @@ class BenchmarkDriver(object):
                 self.run_env["DYLD_LIBRARY_PATH"] = args.libdir
             elif platform.system() == "Linux":
                 self.run_env["LD_LIBRARY_PATH"] = args.libdir
+
         self._subprocess = _subprocess or subprocess
         self.all_tests = []
         self.test_number = {}
         self.tests = tests or self._get_tests()
         self.parser = parser or LogParser()
         self.results = {}
-        # Set a constant hash seed. Some tests are currently sensitive to
-        # fluctuations in the number of hash collisions.
-        os.environ["SWIFT_DETERMINISTIC_HASHING"] = "1"
 
     def _invoke(self, cmd):
         return self._subprocess.check_output(

--- a/utils/swift_build_support/swift_build_support/products/benchmarks.py
+++ b/utils/swift_build_support/swift_build_support/products/benchmarks.py
@@ -52,14 +52,16 @@ class Benchmarks(product.Product):
         return self.args.test_toolchainbenchmarks
 
     def _get_test_environment(self, host_target):
+        env = {
+            "SWIFT_DETERMINISTIC_HASHING": "1"
+        }
         if platform.system() == 'Darwin':
             # the resulting binaries would search first in /usr/lib/swift,
             # we need to prefer the libraries we just built
-            return {'DYLD_LIBRARY_PATH': os.path.join(
+            env['DYLD_LIBRARY_PATH'] = os.path.join(
                 _get_toolchain_path(host_target, self, self.args),
-                'usr', 'lib', 'swift', 'macosx')}
-
-        return None
+                'usr', 'lib', 'swift', 'macosx')
+        return env
 
     def test(self, host_target):
         """Just run a single instance of the command for both .debug and


### PR DESCRIPTION
The benchmark driver accidentally fails to set the `SWIFT_DETERMINISTIC_HASHING` environment variable for its subprocesses, which means that hashed collections have far more performance variance than expected.

I think the recent plague of flaky benchmark results (especially `DictionaryOfAnyHashableStrings_insert`) has been due to this issue.

Additionally, update CMake to postprocess the benchmark executables with [`swift-darwin-postprocess.py`](https://github.com/apple/swift/blob/main/utils/swift-darwin-postprocess.py) to work around a dyld issue on macOS Monterey that makes the benchmark executable fail with spurious unknown selector exceptions.
