### PR TITLE
[5.5-08092021] [silgen] Ensure that the outer cleanup is emitted along failure paths…

### DIFF
--- a/test/SILGen/enum.swift
+++ b/test/SILGen/enum.swift
@@ -219,3 +219,23 @@ func sr7799_1(bar: SR7799??) {
   default: print("default")
   }
 }
+
+// Make sure that we handle enum, tuple initialization composed
+// correctly. Previously, we leaked down a failure path due to us misusing
+// scopes.
+enum rdar81817725 {
+    case localAddress
+    case setOption(Int, Any)
+
+    static func takeAny(_:Any) -> Bool { return true }
+
+    static func testSwitchCleanup(syscall: rdar81817725, expectedLevel: Int,
+                                  valueMatcher: (Any) -> Bool)
+      throws -> Bool {
+        if case .setOption(expectedLevel, let value) = syscall {
+            return rdar81817725.takeAny(value)
+        } else {
+            return false
+        }
+    }
+}


### PR DESCRIPTION
Cherry-picks #39037 to release/5.5-08092021. (See also #39252.) This crash occurs while compiling the NIO test suite on Linux, so it seems worth backporting.

> Previously, we would leak in this case along the inner failure path since we had
> already forwarded the outer cleanup. Instead in this patch, I change the outer
> cleanup to be persistently active (ensuring that failure paths along the
> sub-pattern are cleaned up appropriately) and forward it manually afterwards
> ensuring that we do not /actually/ emit the cleanup along the success path.
> 
> rdar://81817725