### PR TITLE
Concurrency: add Windows support to `SWIFT_TASK_PRINTF_DEBUG`

### DIFF
--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -27,6 +27,16 @@
 
 #include "../runtime/StackAllocator.h"
 
+#if HAVE_PTHREAD_H
+#include <pthread.h>
+#endif
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#define VC_EXTRA_LEAN
+#define NOMINMAX
+#include <Windows.h>
+#endif
+
 namespace swift {
 
 // Set to 1 to enable helpful debug spew to stderr
@@ -40,6 +50,20 @@ namespace swift {
 #else
 #define SWIFT_TASK_DEBUG_LOG(fmt, ...) (void)0
 #endif
+
+#if defined(_WIN32)
+using ThreadID = decltype(GetCurrentThreadId());
+#else
+using ThreadID = decltype(pthread_self());
+#endif
+
+inline ThreadID _swift_get_thread_id() {
+#if defined(_WIN32)
+  return GetCurrentThreadId();
+#else
+  return pthread_self();
+#endif
+}
 
 class AsyncTask;
 class TaskGroup;


### PR DESCRIPTION
`pthread_self` is not portable to all platforms.  Introduce a
`_swift_get_current_thread_id` to abstract over accessing the current
thread ID.  On Windows, the thread ID and thread handle are two separate
entities, unlike POSIX threads which treats them the same.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
