### PR TITLE
[cxx-interop] Rudimentary support for importing base classes.

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -268,7 +268,7 @@ public:
              clang::DeclarationName givenName = clang::DeclarationName()) = 0;
 
   /// Determine the effective Clang context for the given Swift nominal type.
-  EffectiveClangContext virtual getEffectiveClangContext(
+  virtual EffectiveClangContext getEffectiveClangContext(
       const NominalTypeDecl *nominal) = 0;
 };
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1460,7 +1460,8 @@ private:
   void
   loadAllMembersOfObjcContainer(Decl *D,
                                 const clang::ObjCContainerDecl *objcContainer);
-  void loadAllMembersOfRecordDecl(NominalTypeDecl *recordDecl);
+  void loadAllMembersOfRecordDecl(NominalTypeDecl *swiftDecl,
+                                  const clang::RecordDecl *clangRecord);
 
   void collectMembersToAdd(const clang::ObjCContainerDecl *objcContainer,
                            Decl *D, DeclContext *DC,

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -469,10 +469,14 @@ void IRGenModule::emitSourceFile(SourceFile &SF) {
   if (ObjCInterop)
     this->addLinkLibrary(LinkLibrary("objc", LibraryKind::Library));
 
-  // Automatically with libc++ when possible.
-  if (Context.LangOpts.EnableCXXInterop && Context.LangOpts.Target.isOSDarwin())
-    this->addLinkLibrary(LinkLibrary("c++", LibraryKind::Library));
-  
+  // If C++ interop is enabled, add -lc++ on Darwin and -lstdc++ on linux.
+  if (Context.LangOpts.EnableCXXInterop) {
+    if (Context.LangOpts.Target.isOSDarwin())
+      this->addLinkLibrary(LinkLibrary("c++", LibraryKind::Library));
+    else if (Context.LangOpts.Target.isOSLinux())
+      this->addLinkLibrary(LinkLibrary("stdc++", LibraryKind::Library));
+  }
+
   // FIXME: It'd be better to have the driver invocation or build system that
   // executes the linker introduce these compatibility libraries, since at
   // that point we know whether we're building an executable, which is the only

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -96,7 +96,7 @@ namespace {
     StringRef getFieldName() const {
       return Field->getName().str();
     }
-    
+
     SILType getType(IRGenModule &IGM, SILType T) const {
       return T.getFieldType(Field, IGM.getSILModule(),
                             IGM.getMaximalTypeExpansionContext());
@@ -117,7 +117,7 @@ namespace {
       : RecordField(layout, explosionBegin, explosionEnd),
         Field(swiftField) {}
 
-    VarDecl * const Field;
+    VarDecl *Field;
 
     StringRef getFieldName() const {
       if (Field) return Field->getName().str();
@@ -160,36 +160,31 @@ namespace {
     }
 
     /// Given a full struct explosion, project out a single field.
-    void projectFieldFromExplosion(IRGenFunction &IGF,
-                                   Explosion &in,
-                                   VarDecl *field,
-                                   Explosion &out) const {
+    virtual void projectFieldFromExplosion(IRGenFunction &IGF, Explosion &in,
+                                           VarDecl *field,
+                                           Explosion &out) const {
       auto &fieldInfo = getFieldInfo(field);
 
       // If the field requires no storage, there's nothing to do.
       if (fieldInfo.isEmpty())
         return;
-  
+
       // Otherwise, project from the base.
       auto fieldRange = fieldInfo.getProjectionRange();
       auto elements = in.getRange(fieldRange.first, fieldRange.second);
       out.add(elements);
     }
-       
+
     /// Given the address of a struct value, project out the address of a
     /// single field.
-    Address projectFieldAddress(IRGenFunction &IGF,
-                                Address addr,
-                                SILType T,
+    Address projectFieldAddress(IRGenFunction &IGF, Address addr, SILType T,
                                 const FieldInfoType &field) const {
       return asImpl().projectFieldAddress(IGF, addr, T, field.Field);
     }
 
     /// Given the address of a struct value, project out the address of a
     /// single field.
-    Address projectFieldAddress(IRGenFunction &IGF,
-                                Address addr,
-                                SILType T,
+    Address projectFieldAddress(IRGenFunction &IGF, Address addr, SILType T,
                                 VarDecl *field) const {
       auto &fieldInfo = getFieldInfo(field);
       if (fieldInfo.isEmpty())
@@ -255,7 +250,7 @@ namespace {
         return false;
       return fields[0].getTypeInfo().isSingleRetainablePointer(expansion, rc);
     }
-       
+
     void verify(IRGenTypeVerifierFunction &IGF,
                 llvm::Value *metadata,
                 SILType structType) const override {
@@ -289,14 +284,14 @@ namespace {
                   FindOffsetOfFieldOffsetVector>::addFieldOffset(Field);
             }
           };
-          
+
           FindOffsetOfFieldOffsetVector scanner(IGF.IGM, field.Field);
           scanner.layout();
-          
+
           if (scanner.FieldOffset == Size::invalid()
               || scanner.AddressPoint == Size::invalid())
             continue;
-          
+
           // Load the offset from the field offset vector and ensure it matches
           // the compiler's idea of the offset.
           auto metadataBytes =
@@ -314,7 +309,7 @@ namespace {
             IGF.Builder.CreateLoad(fieldOffsetPtr, Alignment(4));
           fieldOffset = IGF.Builder.CreateZExtOrBitCast(fieldOffset,
                                                         IGF.IGM.SizeTy);
-          
+
           IGF.verifyValues(metadata, fieldOffset,
                        IGF.IGM.getSize(field.getFixedByteOffset()),
                        Twine("offset of struct field ") + field.getFieldName());
@@ -334,21 +329,70 @@ namespace {
   class LoadableClangRecordTypeInfo final :
     public StructTypeInfoBase<LoadableClangRecordTypeInfo, LoadableTypeInfo,
                               ClangFieldInfo> {
+    IRGenModule &IGM;
     const clang::RecordDecl *ClangDecl;
+
+    template <class Fn>
+    void forEachNonEmptyBase(Fn fn) const {
+      auto &layout = ClangDecl->getASTContext().getASTRecordLayout(ClangDecl);
+
+      if (auto cxxRecord = dyn_cast<clang::CXXRecordDecl>(ClangDecl)) {
+        for (auto base : cxxRecord->bases()) {
+          auto baseRecord = cast<clang::RecordType>(base.getType())->getDecl();
+          auto baseCxxRecord = cast<clang::CXXRecordDecl>(baseRecord);
+
+          if (baseCxxRecord->isEmpty())
+            continue;
+
+          auto offset = layout.getBaseClassOffset(baseCxxRecord);
+          auto size =
+              ClangDecl->getASTContext().getTypeSizeInChars(base.getType());
+          fn(base.getType(), offset, size);
+        }
+      }
+    }
+
+    template <class Fn>
+    void forEachNonEmptyBaseTypeInfo(Fn fn) const {
+      forEachNonEmptyBase([&](clang::QualType, clang::CharUnits,
+                              clang::CharUnits size) {
+        auto &typeInfo = IGM.getOpaqueStorageTypeInfo(Size(size.getQuantity()),
+                                                      Alignment(1));
+        fn(typeInfo);
+      });
+    }
+
+    template <class Fn>
+    void forEachNonEmptyBaseTypeInfoAndBaseAddress(IRGenFunction &IGF,
+                                                   Address addr, Fn fn) const {
+      forEachNonEmptyBase([&](clang::QualType,
+                              clang::CharUnits offset, clang::CharUnits size) {
+        auto &typeInfo = IGM.getOpaqueStorageTypeInfo(Size(size.getQuantity()),
+                                                      Alignment(1));
+
+        Address baseAddr = addr;
+        if (offset.getQuantity() != 0) {
+          auto baseAddrVal =
+              IGF.Builder.CreateBitCast(addr.getAddress(), IGF.IGM.Int8PtrTy);
+          baseAddrVal =
+              IGF.Builder.CreateConstGEP1_64(baseAddrVal, offset.getQuantity());
+          baseAddr = Address(baseAddrVal, Alignment(1));
+        }
+
+        fn(typeInfo, baseAddr);
+      });
+    }
 
   public:
     LoadableClangRecordTypeInfo(ArrayRef<ClangFieldInfo> fields,
-                        unsigned explosionSize,
-                        llvm::Type *storageType, Size size,
-                        SpareBitVector &&spareBits, Alignment align,
-                        const clang::RecordDecl *clangDecl)
-      : StructTypeInfoBase(StructTypeInfoKind::LoadableClangRecordTypeInfo,
-                           fields, explosionSize,
-                           storageType, size, std::move(spareBits),
-                           align, IsPOD, IsFixedSize),
-        ClangDecl(clangDecl)
-    {
-    }
+                                unsigned explosionSize, IRGenModule &IGM,
+                                llvm::Type *storageType, Size size,
+                                SpareBitVector &&spareBits, Alignment align,
+                                const clang::RecordDecl *clangDecl)
+        : StructTypeInfoBase(StructTypeInfoKind::LoadableClangRecordTypeInfo,
+                             fields, explosionSize, storageType, size,
+                             std::move(spareBits), align, IsPOD, IsFixedSize),
+          IGM(IGM), ClangDecl(clangDecl) {}
 
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
@@ -383,7 +427,108 @@ namespace {
 
     void addToAggLowering(IRGenModule &IGM, SwiftAggLowering &lowering,
                           Size offset) const override {
+      auto &layout = ClangDecl->getASTContext().getASTRecordLayout(ClangDecl);
+
+      forEachNonEmptyBase([&](clang::QualType type, clang::CharUnits offset,
+                              clang::CharUnits) {
+        lowering.addTypedData(type, offset);
+      });
+
       lowering.addTypedData(ClangDecl, offset.asCharUnits());
+    }
+
+    void getSchema(ExplosionSchema &schema) const override {
+      forEachNonEmptyBaseTypeInfo([&](const LoadableTypeInfo &typeInfo) {
+        typeInfo.getSchema(schema);
+      });
+
+      for (auto &field : getFields()) {
+        field.getTypeInfo().getSchema(schema);
+      }
+    }
+
+    void projectFieldFromExplosion(IRGenFunction &IGF, Explosion &in,
+                                   VarDecl *field,
+                                   Explosion &out) const override {
+      auto &fieldInfo = getFieldInfo(field);
+
+      // If the field requires no storage, there's nothing to do.
+      if (fieldInfo.isEmpty())
+        return;
+
+      unsigned baseOffset = 0;
+      if (auto cxxRecord = dyn_cast<clang::CXXRecordDecl>(ClangDecl)) {
+        baseOffset =
+            std::distance(cxxRecord->bases().begin(), cxxRecord->bases().end());
+      }
+
+      // Otherwise, project from the base.
+      auto fieldRange = fieldInfo.getProjectionRange();
+      auto elements = in.getRange(fieldRange.first + baseOffset,
+                                  fieldRange.second + baseOffset);
+      out.add(elements);
+    }
+
+    void reexplode(IRGenFunction &IGF, Explosion &src,
+                   Explosion &dest) const override {
+      forEachNonEmptyBaseTypeInfo([&](const LoadableTypeInfo &typeInfo) {
+        typeInfo.reexplode(IGF, src, dest);
+      });
+
+      for (auto &field : getFields()) {
+        cast<LoadableTypeInfo>(field.getTypeInfo()).reexplode(IGF, src, dest);
+      }
+    }
+
+    void initialize(IRGenFunction &IGF, Explosion &e, Address addr,
+                    bool isOutlined) const override {
+      forEachNonEmptyBaseTypeInfoAndBaseAddress(
+          IGF, addr, [&](const LoadableTypeInfo &typeInfo, Address baseAddr) {
+            typeInfo.initialize(IGF, e, baseAddr, isOutlined);
+          });
+
+      for (auto &field : getFields()) {
+        if (field.isEmpty())
+          continue;
+
+        Address fieldAddr = field.projectAddress(IGF, addr, None);
+        cast<LoadableTypeInfo>(field.getTypeInfo())
+            .initialize(IGF, e, fieldAddr, isOutlined);
+      }
+    }
+
+    void loadAsTake(IRGenFunction &IGF, Address addr,
+                    Explosion &e) const override {
+      forEachNonEmptyBaseTypeInfoAndBaseAddress(
+          IGF, addr, [&](const LoadableTypeInfo &typeInfo, Address baseAddr) {
+            typeInfo.loadAsTake(IGF, baseAddr, e);
+          });
+
+      for (auto &field : getFields()) {
+        if (field.isEmpty())
+          continue;
+
+        Address fieldAddr = field.projectAddress(IGF, addr, None);
+        cast<LoadableTypeInfo>(field.getTypeInfo())
+            .loadAsTake(IGF, fieldAddr, e);
+      }
+    }
+
+    void loadAsCopy(IRGenFunction &IGF, Address addr,
+                    Explosion &e) const override {
+      forEachNonEmptyBaseTypeInfoAndBaseAddress(
+          IGF, addr, [&](const LoadableTypeInfo &typeInfo, Address baseAddr) {
+            typeInfo.loadAsCopy(IGF, baseAddr, e);
+          });
+
+      for (auto &field : getFields()) {
+        if (field.isEmpty())
+          continue;
+
+        Address fieldAddr = field.projectAddress(IGF, addr, None);
+        cast<LoadableTypeInfo>(field.getTypeInfo())
+            .loadAsCopy(IGF, fieldAddr, e);
+      }
     }
 
     llvm::NoneType getNonFixedOffsets(IRGenFunction &IGF) const {
@@ -717,7 +862,7 @@ namespace {
       llvm_unreachable("non-fixed field in fixed struct?");
     }
   };
-  
+
   /// Accessor for the non-fixed offsets of a struct type.
   class StructNonFixedOffsets : public NonFixedOffsetsImpl {
     SILType TheStruct;
@@ -725,7 +870,7 @@ namespace {
     StructNonFixedOffsets(SILType type) : TheStruct(type) {
       assert(TheStruct.getStructOrBoundGenericStruct());
     }
-    
+
     llvm::Value *getOffsetForIndex(IRGenFunction &IGF, unsigned index) override {
       auto &layout =
           IGF.IGM.getMetadataLayout(TheStruct.getStructOrBoundGenericStruct());
@@ -981,10 +1126,9 @@ public:
       return AddressOnlyClangRecordTypeInfo::create(
           FieldInfos, llvmType, TotalStride, TotalAlignment, ClangDecl);
     }
-    return LoadableClangRecordTypeInfo::create(FieldInfos, NextExplosionIndex,
-                                       llvmType, TotalStride,
-                                       std::move(SpareBits), TotalAlignment,
-                                       ClangDecl);
+    return LoadableClangRecordTypeInfo::create(
+        FieldInfos, NextExplosionIndex, IGM, llvmType, TotalStride,
+        std::move(SpareBits), TotalAlignment, ClangDecl);
   }
 
 private:

--- a/test/Interop/Cxx/class/inheritance/Inputs/fields.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/fields.h
@@ -1,0 +1,48 @@
+template <class From, class To>
+To __swift_interopStaticCast(From from) { return from; }
+
+struct HasThreeFields {
+  int a = 1;
+  int b = 2;
+  int c = 3;
+};
+
+struct DerivedWithOneField : HasThreeFields {
+  int d = 4;
+};
+
+struct HasOneField {
+  int e = 5;
+};
+
+struct DerivedFromAll : HasOneField, DerivedWithOneField {
+  int f = 6;
+};
+
+// Non trivial types:
+
+struct NonTrivial {
+  NonTrivial() {}
+  ~NonTrivial() {}
+};
+
+struct NonTrivialHasThreeFields : NonTrivial {
+  int a = 1;
+  int b = 2;
+  int c = 3;
+};
+
+struct NonTrivialDerivedWithOneField : NonTrivialHasThreeFields {
+  int d = 4;
+};
+
+struct NonTrivialHasOneField {
+  NonTrivialHasOneField() {}
+  ~NonTrivialHasOneField() {}
+
+  int e = 5;
+};
+
+struct NonTrivialDerivedFromAll : NonTrivialHasOneField, NonTrivialDerivedWithOneField {
+  int f = 6;
+};

--- a/test/Interop/Cxx/class/inheritance/Inputs/functions.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/functions.h
@@ -1,0 +1,51 @@
+template <class From, class To>
+To __swift_interopStaticCast(From from) {
+  return static_cast<To>(from);
+}
+
+struct NonTrivial {
+  NonTrivial() {}
+  ~NonTrivial() {}
+
+  inline const char *inNonTrivial() const { return "NonTrivial::inNonTrivial"; }
+  inline const char *inNonTrivialWithArgs(int a, int b) const {
+    return "NonTrivial::inNonTrivialWithArgs";
+  }
+};
+
+struct Base {
+  inline const char *mutatingInBase() { return "Base::mutatingInBase"; }
+  inline const char *constInBase() const { return "Base::constInBase"; }
+  // TODO: if these are unnamed we hit an (unrelated) SILGen bug. Same for
+  // subscripts.
+  inline const char *takesArgsInBase(int a, int b, int c) const {
+    return "Base::takesArgsInBase";
+  }
+
+  inline const char *takesNonTrivialInBase(NonTrivial a) const {
+    return "Base::takesNonTrivialInBase";
+  }
+  inline NonTrivial returnsNonTrivialInBase() const { return NonTrivial{}; }
+
+  template <class T>
+  inline const char *templateInBase(T t) const {
+    return "Base::templateInBase";
+  }
+
+  static const char *staticInBase() { return "Base::staticInBase"; }
+};
+
+struct OtherBase {
+  inline const char *inOtherBase() const { return "OtherBase::inOtherBase"; }
+  // TODO: test private access
+};
+
+struct Derived : Base, OtherBase {
+  inline const char *inDerived() const { return "Derived::inDerived"; }
+};
+
+struct DerivedFromDerived : Derived {
+  inline const char *topLevel() const { return "DerivedFromDerived::topLevel"; }
+};
+
+struct DerivedFromNonTrivial : NonTrivial {};

--- a/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
@@ -1,0 +1,15 @@
+module Functions {
+  header "functions.h"
+}
+
+module Fields {
+  header "fields.h"
+}
+
+module SubTypes {
+  header "sub-types.h"
+}
+
+module TypeAliases {
+  header "type-aliases.h"
+}

--- a/test/Interop/Cxx/class/inheritance/Inputs/sub-types.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/sub-types.h
@@ -1,0 +1,27 @@
+template <class From, class To>
+To __swift_interopStaticCast(From from) {
+  return static_cast<To>(from);
+}
+
+struct Base {
+  enum class EnumClass : char { eca = 2, ecb = 3, ecc = 4 };
+  enum Enum { ea, eb, ec };
+
+  struct Struct {
+    int sa;
+    int sb;
+  };
+
+  struct Parent {
+    struct Child {
+      int pca;
+    };
+  };
+
+  union Union {
+    int ua;
+    Struct ub;
+  };
+};
+
+struct Derived : Base {};

--- a/test/Interop/Cxx/class/inheritance/Inputs/type-aliases.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/type-aliases.h
@@ -1,0 +1,13 @@
+template <class From, class To>
+To __swift_interopStaticCast(From from) {
+  return static_cast<To>(from);
+}
+
+struct Base {
+  struct Struct {};
+
+  using T = int;
+  using U = Struct;
+};
+
+struct Derived : Base {};

--- a/test/Interop/Cxx/class/inheritance/fields-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/fields-module-interface.swift
@@ -1,0 +1,67 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=Fields -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK:      struct HasThreeFields {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   init(a: Int32, b: Int32, c: Int32)
+// CHECK-NEXT:   var a: Int32
+// CHECK-NEXT:   var b: Int32
+// CHECK-NEXT:   var c: Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: struct DerivedWithOneField {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   var d: Int32
+// CHECK-NEXT:   var a: Int32
+// CHECK-NEXT:   var b: Int32
+// CHECK-NEXT:   var c: Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: struct HasOneField {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   init(e: Int32)
+// CHECK-NEXT:   var e: Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: struct DerivedFromAll {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   var f: Int32
+// CHECK-NEXT:   var e: Int32
+// CHECK-NEXT:   var d: Int32
+// CHECK-NEXT:   var a: Int32
+// CHECK-NEXT:   var b: Int32
+// CHECK-NEXT:   var c: Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: struct NonTrivial {
+// CHECK-NEXT:   init()
+// CHECK-NEXT: }
+
+// CHECK-NEXT: struct NonTrivialHasThreeFields {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   var a: Int32
+// CHECK-NEXT:   var b: Int32
+// CHECK-NEXT:   var c: Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: struct NonTrivialDerivedWithOneField {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   var d: Int32
+// CHECK-NEXT:   var a: Int32
+// CHECK-NEXT:   var b: Int32
+// CHECK-NEXT:   var c: Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: struct NonTrivialHasOneField {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   var e: Int32
+// CHECK-NEXT: }
+
+// CHECK-NEXT: struct NonTrivialDerivedFromAll {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   var f: Int32
+// CHECK-NEXT:   var e: Int32
+// CHECK-NEXT:   var d: Int32
+// CHECK-NEXT:   var a: Int32
+// CHECK-NEXT:   var b: Int32
+// CHECK-NEXT:   var c: Int32
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/class/inheritance/fields.swift
+++ b/test/Interop/Cxx/class/inheritance/fields.swift
@@ -1,0 +1,55 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop)
+//
+// REQUIRES: executable_test
+//
+// Windows doesn't support -lc++ or -lstdc++.
+// UNSUPPORTED: OS=windows-msvc
+
+import StdlibUnittest
+import Fields
+
+var FieldsTestSuite = TestSuite("Getting and setting fields in base classes")
+
+FieldsTestSuite.test("Fields from derived from all") {
+  let derived = DerivedFromAll()
+  expectEqual(derived.a, 1)
+  expectEqual(derived.b, 2)
+  expectEqual(derived.c, 3)
+  expectEqual(derived.d, 4)
+  expectEqual(derived.e, 5)
+  expectEqual(derived.f, 6)
+
+  var mutable = DerivedFromAll()
+  mutable.a = 42
+  mutable.d = 44
+  mutable.e = 46
+  mutable.f = 48
+
+  expectEqual(mutable.a, 42)
+  expectEqual(mutable.d, 44)
+  expectEqual(mutable.e, 46)
+  expectEqual(mutable.f, 48)
+}
+
+FieldsTestSuite.test("Fields from derived from non trivial") {
+  let derived = NonTrivialDerivedFromAll()
+  expectEqual(derived.a, 1)
+  expectEqual(derived.b, 2)
+  expectEqual(derived.c, 3)
+  expectEqual(derived.d, 4)
+  expectEqual(derived.e, 5)
+  expectEqual(derived.f, 6)
+
+  var mutable = NonTrivialDerivedFromAll()
+  mutable.a = 42
+  mutable.d = 44
+  mutable.e = 46
+  mutable.f = 48
+
+  expectEqual(mutable.a, 42)
+  expectEqual(mutable.d, 44)
+  expectEqual(mutable.e, 46)
+  expectEqual(mutable.f, 48)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
@@ -1,0 +1,52 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=Functions -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK:      struct NonTrivial {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   func inNonTrivial() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   func inNonTrivialWithArgs(_ a: Int32, _ b: Int32) -> UnsafePointer<CChar>!
+// CHECK-NEXT: }
+
+// CHECK-NEXT: struct Base {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   mutating func mutatingInBase() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   func constInBase() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>!
+// CHECK-NEXT:   func takesNonTrivialInBase(_ a: NonTrivial) -> UnsafePointer<CChar>!
+// CHECK-NEXT:   func returnsNonTrivialInBase() -> NonTrivial
+// CHECK-NEXT:   func templateInBase<T>(_ t: T) -> UnsafePointer<CChar>!
+// CHECK-NEXT:   static func staticInBase() -> UnsafePointer<CChar>!
+// CHECK-NEXT: }
+
+// CHECK-NEXT: struct OtherBase {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   func inOtherBase() -> UnsafePointer<CChar>!
+// CHECK-NEXT: }
+
+// CHECK-NEXT: struct Derived {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   func inDerived() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   mutating func mutatingInBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   func constInBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>?
+// CHECK-NEXT:   func takesNonTrivialInBase(_ a: NonTrivial) -> UnsafePointer<CChar>?
+// CHECK-NEXT:   func returnsNonTrivialInBase() -> NonTrivial
+// CHECK-NEXT:   func inOtherBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT: }
+
+// CHECK-NEXT: struct DerivedFromDerived {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   func topLevel() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   func inDerived() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   mutating func mutatingInBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   func constInBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>?
+// CHECK-NEXT:   func takesNonTrivialInBase(_ a: NonTrivial) -> UnsafePointer<CChar>?
+// CHECK-NEXT:   func returnsNonTrivialInBase() -> NonTrivial
+// CHECK-NEXT:   func inOtherBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT: }
+
+// CHECK-NEXT: struct DerivedFromNonTrivial {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   func inNonTrivial() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   func inNonTrivialWithArgs(_ a: Int32, _ b: Int32) -> UnsafePointer<CChar>?
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/class/inheritance/functions.swift
+++ b/test/Interop/Cxx/class/inheritance/functions.swift
@@ -1,0 +1,72 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop)
+//
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import Functions
+
+var FunctionsTestSuite = TestSuite("Calling functions in base classes")
+
+FunctionsTestSuite.test("Basic methods from derived") {
+  let derived = Derived()
+  expectEqual(String(cString: derived.constInBase()!), "Base::constInBase")
+  expectEqual(String(cString: derived.takesArgsInBase(0, 1, 2)!), "Base::takesArgsInBase")
+
+  var mutableDerived = derived
+  expectEqual(String(cString: mutableDerived.mutatingInBase()!), "Base::mutatingInBase")
+}
+
+FunctionsTestSuite.test("NonTrivial methods from derived") {
+  let derived = Derived()
+  expectEqual(String(cString: derived.takesNonTrivialInBase(NonTrivial())!), "Base::takesNonTrivialInBase")
+  _ = derived.returnsNonTrivialInBase()
+}
+
+// TODO: eventually support templates.
+//FunctionsTestSuite.test("Template from derived") {
+//  let derived = Derived()
+// expectEqual(String(cString: derived.templateInBase(0)!), "Base::templateInBase")
+//}
+
+// TODO: eventually support static functions.
+//FunctionsTestSuite.test("Static from derived") {
+// expectEqual(String(cString: Derived.staticInBase()!), "Base::staticInBase")
+//}
+
+FunctionsTestSuite.test("Other base member from derived") {
+  let derived = Derived()
+  expectEqual(String(cString: derived.inOtherBase()!), "OtherBase::inOtherBase")
+}
+
+FunctionsTestSuite.test("Basic methods from derived * 2") {
+  let dd = DerivedFromDerived()
+  expectEqual(String(cString: dd.constInBase()!), "Base::constInBase")
+  expectEqual(String(cString: dd.takesArgsInBase(0, 1, 2)!), "Base::takesArgsInBase")
+
+  var mutableDerived = dd
+  expectEqual(String(cString: mutableDerived.mutatingInBase()!), "Base::mutatingInBase")
+}
+
+FunctionsTestSuite.test("NonTrivial methods from derived * 2") {
+  let dd = DerivedFromDerived()
+  expectEqual(String(cString: dd.takesNonTrivialInBase(NonTrivial())!), "Base::takesNonTrivialInBase")
+  _ = dd.returnsNonTrivialInBase()
+}
+
+// TODO: eventually support static functions.
+//FunctionsTestSuite.test("Static from derived * 2") {
+// expectEqual(String(cString: DerivedFromDerived.staticInBase()!), "Base::staticInBase")
+//}
+
+FunctionsTestSuite.test("Other base member from derived * 2") {
+  let dd = DerivedFromDerived()
+  expectEqual(String(cString: dd.inOtherBase()!), "OtherBase::inOtherBase")
+}
+
+FunctionsTestSuite.test("base member from derived from non trivial") {
+  let dnt = DerivedFromNonTrivial()
+  expectEqual(String(cString: dnt.inNonTrivial()!), "NonTrivial::inNonTrivial")
+  expectEqual(String(cString: dnt.inNonTrivialWithArgs(0, 1)!), "NonTrivial::inNonTrivialWithArgs")
+}
+
+runAllTests()

--- a/test/Interop/Cxx/class/inheritance/sub-types-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/sub-types-module-interface.swift
@@ -11,10 +11,10 @@
 // CHECK-NEXT:     case ecc
 // CHECK-NEXT:   }
 // CHECK-NEXT:   struct Enum : Equatable, RawRepresentable {
-// CHECK-NEXT:     init(_ rawValue: UInt32)
-// CHECK-NEXT:     init(rawValue: UInt32)
-// CHECK-NEXT:     var rawValue: UInt32
-// CHECK-NEXT:     typealias RawValue = UInt32
+// CHECK-NEXT:     init(_ rawValue: {{UInt32|Int32}})
+// CHECK-NEXT:     init(rawValue: {{UInt32|Int32}})
+// CHECK-NEXT:     var rawValue: {{UInt32|Int32}}
+// CHECK-NEXT:     typealias RawValue = {{UInt32|Int32}}
 // CHECK-NEXT:   }
 // CHECK-NEXT:   struct Struct {
 // CHECK-NEXT:     init()

--- a/test/Interop/Cxx/class/inheritance/sub-types-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/sub-types-module-interface.swift
@@ -1,0 +1,49 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=SubTypes -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK:      struct Base {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   enum EnumClass : CChar {
+// CHECK-NEXT:     init?(rawValue: CChar)
+// CHECK-NEXT:     var rawValue: CChar { get }
+// CHECK-NEXT:     typealias RawValue = CChar
+// CHECK-NEXT:     case eca
+// CHECK-NEXT:     case ecb
+// CHECK-NEXT:     case ecc
+// CHECK-NEXT:   }
+// CHECK-NEXT:   struct Enum : Equatable, RawRepresentable {
+// CHECK-NEXT:     init(_ rawValue: UInt32)
+// CHECK-NEXT:     init(rawValue: UInt32)
+// CHECK-NEXT:     var rawValue: UInt32
+// CHECK-NEXT:     typealias RawValue = UInt32
+// CHECK-NEXT:   }
+// CHECK-NEXT:   struct Struct {
+// CHECK-NEXT:     init()
+// CHECK-NEXT:     init(sa: Int32, sb: Int32)
+// CHECK-NEXT:     var sa: Int32
+// CHECK-NEXT:     var sb: Int32
+// CHECK-NEXT:   }
+// CHECK-NEXT:   struct Parent {
+// CHECK-NEXT:     init()
+// CHECK-NEXT:     struct Child {
+// CHECK-NEXT:       init()
+// CHECK-NEXT:       init(pca: Int32)
+// CHECK-NEXT:       var pca: Int32
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT:   struct Union {
+// CHECK-NEXT:     init()
+// CHECK-NEXT:     init(ua: Int32)
+// CHECK-NEXT:     init(ub: Base.Struct)
+// CHECK-NEXT:     var ua: Int32
+// CHECK-NEXT:     var ub: Base.Struct
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+// CHECK-NEXT: struct Derived {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   typealias EnumClass = Base.EnumClass.Type
+// CHECK-NEXT:   typealias Enum = Base.Enum.Type
+// CHECK-NEXT:   typealias Struct = Base.Struct.Type
+// CHECK-NEXT:   typealias Parent = Base.Parent.Type
+// CHECK-NEXT:   typealias Union = Base.Union.Type
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/class/inheritance/type-aliases-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/type-aliases-module-interface.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=TypeAliases -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK:      struct Base {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   struct Struct {
+// CHECK-NEXT:     init()
+// CHECK-NEXT:   }
+// CHECK-NEXT:   typealias T = Int32
+// CHECK-NEXT:   typealias U = Base.Struct
+// CHECK-NEXT: }
+
+// CHECK-NEXT: struct Derived {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   typealias Struct = Base.Struct.Type
+// CHECK-NEXT:   typealias T = Int32
+// CHECK-NEXT:   typealias U = Base.Struct
+// CHECK-NEXT: }


### PR DESCRIPTION
This PR adds very basic support for importing and calling base class methods, getting and setting base class fields, and using types inside of base classes. The approach is outlined in [this forum post.](https://forums.swift.org/t/base-classes-an-intermediate-solution/52056)

This PR is based on #38675 so please just click on the last commit and review that. 

Edit: I should note that, code wise, this change almost entirely consists of adding synthesized members and some changes to how we lower loadable clang types in IRGen. Loadable clang types now account for the fact that base classes exist and emit them as opaque buffers (which is OK because all the casting/accesses happen inside of clang functions). 