### PR TITLE
[SIL/Parser] Emit diagnostics for more bad attrs.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -500,6 +500,12 @@ ERROR(expected_sil_tuple_index,none,
 ERROR(invalid_index_subset,none,
       "invalid index subset; expected '[SU]+' where 'S' represents set indices "
       "and 'U' represents unset indices", ())
+ERROR(sil_invalid_attribute_for_instruction,none,
+      "The attribute '%0' is invalid for the instruction '%1'.", 
+      (StringRef, StringRef))
+ERROR(sil_invalid_attribute_for_expected,none,
+      "Invalid attribute '%0' (expected '%1').", 
+      (StringRef, StringRef))
 
 // SIL Values
 ERROR(sil_value_redefinition,none,


### PR DESCRIPTION
Ensured diagnostics were emitted for the new lexical flags on begin_borrow and alloc_stack.  Along the way, ensured diagnostics were emitted on behalf of all callers of

```
parseSILOptional(bool, SILParser&, StringRef)
```

of which there are currently around fifteen.
