### PR TITLE
Add a BorrowedLifetimeExtender utility.

### DIFF
--- a/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
@@ -58,6 +58,9 @@ struct OwnershipFixupContext {
   InstModCallbacks &callbacks;
   DeadEndBlocks &deBlocks;
 
+
+  // FIXME: remove these two vectors once BorrowedLifetimeExtender is used
+  // everywhere.
   SmallVector<Operand *, 8> transitiveBorrowedUses;
   SmallVector<PhiOperand, 8> recursiveReborrows;
 

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -512,6 +512,9 @@ void BorrowedValue::getLocalScopeEndingInstructions(
   llvm_unreachable("Covered switch isn't covered?!");
 }
 
+// Note: BorrowedLifetimeExtender assumes no intermediate values between a
+// borrow introducer and its reborrow. The borrowed value must be an operand of
+// the reborrow.
 bool BorrowedValue::visitLocalScopeEndingUses(
     function_ref<bool(Operand *)> visitor) const {
   assert(isLocalScope() && "Should only call this given a local scope");


### PR DESCRIPTION
Handle SSA update (phi creation) when extending an owned lifetime over
a borrowed lifetime.

This is a layer of logic above BorrowedValue but below
OwnershipLifetimeExtender and other higher-level utilities.

Required for OSSA-SimplifyCFG and general guaranteed phi handling.
Unit tests are being developed in a branch that already makes use of this utility, but that depends on rewriting other utilities, which is too much for one PR.

This is a stand-alone utility that can be used independently. It will also replace a large chunk of RAUW helper logic. In general, we need to break up the OSSA utilities into small self-contained pieces that can be used to build other utilities.
