### PR TITLE
IRGen: fix `swifterror` attribute mismatch for WebAssembly

### DIFF
--- a/include/swift/Runtime/RuntimeFnWrappersGen.h
+++ b/include/swift/Runtime/RuntimeFnWrappersGen.h
@@ -25,6 +25,10 @@ namespace swift {
 class AvailabilityContext;
 class ASTContext;
 
+namespace irgen {
+class IRGenModule;
+}
+
 enum class RuntimeAvailability {
   AlwaysAvailable,
   AvailableByCompatibilityLibrary,
@@ -39,7 +43,8 @@ llvm::Constant *getRuntimeFn(llvm::Module &Module, llvm::Constant *&cache,
                              RuntimeAvailability availability,
                              llvm::ArrayRef<llvm::Type *> retTypes,
                              llvm::ArrayRef<llvm::Type *> argTypes,
-                             llvm::ArrayRef<llvm::Attribute::AttrKind> attrs);
+                             llvm::ArrayRef<llvm::Attribute::AttrKind> attrs,
+                             irgen::IRGenModule *IGM = nullptr);
 
 } // namespace swift
 #endif

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -349,7 +349,7 @@ void IRGenModule::addSwiftErrorAttributes(llvm::AttributeList &attrs,
   // We create a shadow stack location of the swifterror parameter for the
   // debugger on such platforms and so we can't mark the parameter with a
   // swifterror attribute.
-  if (IsSwiftErrorInRegister)
+  if (ShouldUseSwiftError)
     b.addAttribute(llvm::Attribute::SwiftError);
   
   // The error result should not be aliased, captured, or pointed at invalid
@@ -4245,7 +4245,7 @@ Address IRGenFunction::createErrorResultSlot(SILType errorType, bool isAsync) {
   // The slot for async callees cannot be annotated swifterror because those
   // errors are never passed in registers but rather are always passed
   // indirectly in the async context.
-  if (IGM.IsSwiftErrorInRegister && !isAsync)
+  if (IGM.ShouldUseSwiftError && !isAsync)
     cast<llvm::AllocaInst>(addr.getAddress())->setSwiftError(true);
 
   // Initialize at the alloca point.

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -577,10 +577,15 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
     AtomicBoolSize = Size(ClangASTContext->getTypeSize(atomicBoolTy));
     AtomicBoolAlign = Alignment(ClangASTContext->getTypeSize(atomicBoolTy));
   }
-
-  IsSwiftErrorInRegister =
+  // On WebAssembly, tail optional arguments are not allowed because Wasm requires
+  // callee and caller signature to be the same. So LLVM adds dummy arguments for
+  // `swiftself` and `swifterror`. If there is `swiftself` but is no `swifterror` in
+  // a swiftcc function or invocation, then LLVM adds dummy `swifterror` parameter or
+  // argument. To count up how many dummy arguments should be added, we need to mark
+  // it as `swifterror` even though it's not in register.
+  ShouldUseSwiftError =
     clang::CodeGen::swiftcall::isSwiftErrorLoweredInRegister(
-      ClangCodeGen->CGM());
+      ClangCodeGen->CGM()) || TargetInfo.OutputObjectFormat == llvm::Triple::Wasm;
 
 #ifndef NDEBUG
   sanityCheckStdlib(*this);
@@ -881,7 +886,8 @@ llvm::Constant *swift::getRuntimeFn(llvm::Module &Module,
                       RuntimeAvailability availability,
                       llvm::ArrayRef<llvm::Type*> retTypes,
                       llvm::ArrayRef<llvm::Type*> argTypes,
-                      ArrayRef<Attribute::AttrKind> attrs) {
+                      ArrayRef<Attribute::AttrKind> attrs,
+                      IRGenModule *IGM) {
 
   if (cache)
     return cache;
@@ -954,6 +960,22 @@ llvm::Constant *swift::getRuntimeFn(llvm::Module &Module,
     fn->addFnAttrs(buildFnAttr);
     fn->addRetAttrs(buildRetAttr);
     fn->addParamAttrs(0, buildFirstParamAttr);
+
+    // Add swiftself and swifterror attributes only when swift_willThrow
+    // swift_willThrow is defined in RuntimeFunctions.def, but due to the
+    // DSL limitation, arguments attributes are not set.
+    // On the other hand, caller of `swift_willThrow` assumes that it's attributed
+    // with `swiftself` and `swifterror`.
+    // This mismatch of attributes would be issue when lowering to WebAssembly.
+    // While lowering, LLVM counts how many dummy params are necessary to match
+    // callee and caller signature. So we need to add them correctly.
+    if (functionName == "swift_willThrow") {
+      assert(IGM && "IGM is required for swift_willThrow.");
+      fn->addParamAttr(0, Attribute::AttrKind::SwiftSelf);
+      if (IGM->ShouldUseSwiftError) {
+        fn->addParamAttr(1, Attribute::AttrKind::SwiftError);
+      }
+    }
   }
 
   return cache;
@@ -997,7 +1019,7 @@ void IRGenModule::registerRuntimeEffect(ArrayRef<RuntimeEffect> effect,
     registerRuntimeEffect(EFFECT, #NAME);                                      \
     return getRuntimeFn(Module, ID##Fn, #NAME, CC,                             \
                         AVAILABILITY(this->Context),                           \
-                        RETURNS, ARGS, ATTRS);                                 \
+                        RETURNS, ARGS, ATTRS, this);                           \
   }
 
 #include "swift/Runtime/RuntimeFunctions.def"

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -628,8 +628,8 @@ public:
   /// Should we add value names to local IR values?
   bool EnableValueNames = false;
 
-  // Is swifterror returned in a register by the target ABI.
-  bool IsSwiftErrorInRegister;
+  // Should `swifterror` attribute be explicitly added for the target ABI.
+  bool ShouldUseSwiftError;
 
   llvm::Type *VoidTy;                  /// void (usually {})
   llvm::IntegerType *Int1Ty;           /// i1

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -4812,7 +4812,7 @@ void IRGenSILFunction::emitErrorResultVar(CanSILFunctionType FnTy,
                                           DebugValueInst *DbgValue) {
   // We don't need a shadow error variable for debugging on ABI's that return
   // swifterror in a register.
-  if (IGM.IsSwiftErrorInRegister)
+  if (IGM.ShouldUseSwiftError)
     return;
   auto ErrorResultSlot = getCalleeErrorResultSlot(IGM.silConv.getSILType(
       ErrorInfo, FnTy, IGM.getMaximalTypeExpansionContext()));


### PR DESCRIPTION
On WebAssembly, tail optional arguments are not allowed because Wasm requires callee and caller signature to be the same. So LLVM adds dummy arguments for `swiftself` and `swifterror`. If there is `swiftself` but is no `swifterror` in a swiftcc function or invocation, then LLVM adds dummy `swifterror` parameter or argument. To count up how many dummy arguments should be added, we need to mark it as `swifterror` even though it's not in register.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Related to SR-9307.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
