### PR TITLE
stdlib: add `wasi.modulemap.gyb` for WebAssembly support

### DIFF
--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -63,6 +63,58 @@ add_swift_target_library(swiftGlibc ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_O
     INSTALL_IN_COMPONENT sdk-overlay
     DEPENDS glibc_modulemap)
 
+if(WASI IN_LIST SWIFT_SDKS)
+  set(arch_subdir "${SWIFT_SDK_WASI_LIB_SUBDIR}/wasm32")
+  set(module_dir "${SWIFTLIB_DIR}/${arch_subdir}")
+  set(module_dir_static "${SWIFTSTATICLIB_DIR}/${arch_subdir}")
+  set(wasi_libc_modulemap_out "${module_dir}/wasi.modulemap")
+  set(wasi_libc_modulemap_out_static "${module_dir_static}/wasi.modulemap")
+  handle_gyb_source_single(wasi_libc_modulemap_target
+    SOURCE "wasi.modulemap.gyb"
+    OUTPUT "${wasi_libc_modulemap_out}"
+    FLAGS "-DLIBC_INCLUDE_PATH=${SWIFT_SDK_WASI_ARCH_wasm32_LIBC_INCLUDE_DIRECTORY}"
+          "-DLIBC_ARCH_INCLUDE_PATH=${SWIFT_SDK_WASI_ARCH_wasm32_LIBC_ARCHITECTURE_INCLUDE_DIRECTORY}")
+  add_custom_command_target(
+    copy_wasi_libc_modulemap_static
+    COMMAND
+      "${CMAKE_COMMAND}" "-E" "make_directory" ${module_dir_static}
+    COMMAND
+      "${CMAKE_COMMAND}" "-E" "copy" ${wasi_libc_modulemap_out} ${wasi_libc_modulemap_out_static}
+    OUTPUT ${wasi_libc_modulemap_out_static}
+    DEPENDS
+      "${wasi_libc_modulemap_target}"
+    COMMENT "Copying WASILlibc modulemap to static resources")
+
+  add_swift_target_library(swiftWASILibc ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+      ${swift_platform_sources}
+      POSIXError.swift
+
+      GYB_SOURCES
+        ${swift_platform_gyb_sources}
+        WASI.swift.gyb
+
+      SWIFT_COMPILE_FLAGS
+        ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}
+        ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+      LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
+      TARGET_SDKS WASI
+      INSTALL_IN_COMPONENT sdk-overlay
+      DEPENDS ${wasi_libc_modulemap_target} ${copy_wasi_libc_modulemap_static})
+
+  swift_install_in_component(FILES "${wasi_libc_modulemap_out}"
+                             DESTINATION "lib/swift/${arch_subdir}"
+                             COMPONENT sdk-overlay)
+
+  swift_install_in_component(FILES "${wasi_libc_modulemap_out}"
+                             DESTINATION "lib/swift_static/${arch_subdir}"
+                             COMPONENT sdk-overlay)
+
+  add_custom_target(wasi_libc_modulemap
+      DEPENDS ${wasi_libc_modulemap_target} ${copy_wasi_libc_modulemap_static})
+  set_property(TARGET wasi_libc_modulemap PROPERTY FOLDER "Miscellaneous")
+  add_dependencies(sdk-overlay wasi_libc_modulemap)
+endif()
+
 add_swift_target_library(swiftCRT ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
     ucrt.swift
     ${swift_platform_sources}

--- a/stdlib/public/Platform/WASI.swift.gyb
+++ b/stdlib/public/Platform/WASI.swift.gyb
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import SwiftWASILibc // Clang module
+
+//  Constants defined by <math.h>
+@available(swift, deprecated: 3.0, message: "Please use 'Double.pi' or '.pi' to get the value of correct type and avoid casting.")
+public let M_PI = Double.pi
+
+@available(swift, deprecated: 3.0, message: "Please use 'Double.pi / 2' or '.pi / 2' to get the value of correct type and avoid casting.")
+public let M_PI_2 = Double.pi / 2
+
+@available(swift, deprecated: 3.0, message: "Please use 'Double.pi / 4' or '.pi / 4' to get the value of correct type and avoid casting.")
+public let M_PI_4 = Double.pi / 4
+
+@available(swift, deprecated: 3.0, message: "Please use '2.squareRoot()'.")
+public let M_SQRT2 = 2.squareRoot()
+
+@available(swift, deprecated: 3.0, message: "Please use '0.5.squareRoot()'.")
+public let M_SQRT1_2 = 0.5.squareRoot()
+
+//  Constants defined by <float.h>
+@available(swift, deprecated: 3.0, message: "Please use 'T.radix' to get the radix of a FloatingPoint type 'T'.")
+public let FLT_RADIX = Double.radix
+
+%for type, prefix in [('Float', 'FLT'), ('Double', 'DBL')]:
+//  Where does the 1 come from? C counts the usually-implicit leading
+//  significand bit, but Swift does not. Neither is really right or wrong.
+@available(swift, deprecated: 3.0, message: "Please use '${type}.significandBitCount + 1'.")
+public let ${prefix}_MANT_DIG = ${type}.significandBitCount + 1
+
+//  Where does the 1 come from? C models floating-point numbers as having a
+//  significand in [0.5, 1), but Swift (following IEEE 754) considers the
+//  significand to be in [1, 2). This rationale applies to ${prefix}_MIN_EXP
+//  as well.
+@available(swift, deprecated: 3.0, message: "Please use '${type}.greatestFiniteMagnitude.exponent + 1'.")
+public let ${prefix}_MAX_EXP = ${type}.greatestFiniteMagnitude.exponent + 1
+
+@available(swift, deprecated: 3.0, message: "Please use '${type}.leastNormalMagnitude.exponent + 1'.")
+public let ${prefix}_MIN_EXP = ${type}.leastNormalMagnitude.exponent + 1
+
+@available(swift, deprecated: 3.0, message: "Please use '${type}.greatestFiniteMagnitude' or '.greatestFiniteMagnitude'.")
+public let ${prefix}_MAX = ${type}.greatestFiniteMagnitude
+
+@available(swift, deprecated: 3.0, message: "Please use '${type}.ulpOfOne' or '.ulpOfOne'.")
+public let ${prefix}_EPSILON = ${type}.ulpOfOne
+
+@available(swift, deprecated: 3.0, message: "Please use '${type}.leastNormalMagnitude' or '.leastNormalMagnitude'.")
+public let ${prefix}_MIN = ${type}.leastNormalMagnitude
+
+@available(swift, deprecated: 3.0, message: "Please use '${type}.leastNonzeroMagnitude' or '.leastNonzeroMagnitude'.")
+public let ${prefix}_TRUE_MIN = ${type}.leastNonzeroMagnitude
+
+%end
+
+public let MAP_FAILED: UnsafeMutableRawPointer! = UnsafeMutableRawPointer(bitPattern: -1)
+
+// wasi-libc's error.h uses a macro that Swift can't import.
+@available(*, deprecated, message: "Please use 'POSIXErrorCode.EINTR'.")
+public let EINTR: Int32 = 27
+@available(*, deprecated, message: "Please use 'POSIXErrorCode.EINVAL'.")
+public let EINVAL: Int32 = 28

--- a/stdlib/public/Platform/wasi.modulemap.gyb
+++ b/stdlib/public/Platform/wasi.modulemap.gyb
@@ -1,0 +1,231 @@
+//===--- wasi.modulemap.gyb ----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// This is a semi-complete modulemap that maps WASI headers in a roughly
+/// similar way to the Darwin SDK modulemap. We do not take care to list every
+/// single header which may be included by a particular submodule, so there can
+/// still be issues if imported into the same context as one in which someone
+/// included those headers directly.
+///
+/// It's not named just WASI so that it doesn't conflict in the event of a
+/// future official WASI modulemap.
+module SwiftWASILibc [system] {
+  // C standard library
+  module C {
+    module ctype {
+      header "${LIBC_INCLUDE_PATH}/ctype.h"
+      export *
+    }
+    module errno {
+      header "${LIBC_INCLUDE_PATH}/errno.h"
+      export *
+    }
+
+    module fenv {
+      header "${LIBC_INCLUDE_PATH}/fenv.h"
+      export *
+    }
+
+    // note: supplied by compiler
+    // module float {
+    //   header "${LIBC_INCLUDE_PATH}/float.h"
+    //   export *
+    // }
+
+    module inttypes {
+      header "${LIBC_INCLUDE_PATH}/inttypes.h"
+      export *
+    }
+
+    // note: potentially supplied by compiler
+    // module iso646 {
+    //   header "${LIBC_INCLUDE_PATH}/iso646.h"
+    //   export *
+    // }
+    // module limits {
+    //   header "${LIBC_INCLUDE_PATH}/limits.h"
+    //   export *
+    // }
+
+    module locale {
+      header "${LIBC_INCLUDE_PATH}/locale.h"
+      export *
+    }
+    module math {
+      header "${LIBC_INCLUDE_PATH}/math.h"
+      export *
+    }
+    module signal {
+      header "${LIBC_INCLUDE_PATH}/signal.h"
+      export *
+    }
+
+    // note: supplied by the compiler
+    // module stdarg {
+    //   header "${LIBC_INCLUDE_PATH}/stdarg.h"
+    //   export *
+    // }
+    // module stdbool {
+    //   header "${LIBC_INCLUDE_PATH}/stdbool.h"
+    //   export *
+    // }
+    // module stddef {
+    //   header "${LIBC_INCLUDE_PATH}/stddef.h"
+    //   export *
+    // }
+    // module stdint {
+    //   header "${LIBC_INCLUDE_PATH}/stdint.h"
+    //   export *
+    // }
+
+    module stdio {
+      header "${LIBC_INCLUDE_PATH}/stdio.h"
+      export *
+    }
+    module stdlib {
+      header "${LIBC_INCLUDE_PATH}/stdlib.h"
+      export *
+      export stddef
+    }
+    module string {
+      header "${LIBC_INCLUDE_PATH}/string.h"
+      export *
+    }
+
+    // note: supplied by the compiler
+    // explicit module tgmath {
+    //   header "${LIBC_INCLUDE_PATH}/tgmath.h"
+    //   export *
+    // }
+
+    module time {
+      header "${LIBC_INCLUDE_PATH}/time.h"
+      export *
+    }
+  }
+
+  // POSIX
+  module POSIX {
+    module arpa {
+      module inet {
+        header "${LIBC_INCLUDE_PATH}/arpa/inet.h"
+        export *
+      }
+      export *
+    }
+    module dirent {
+      header "${LIBC_INCLUDE_PATH}/dirent.h"
+      export *
+    }
+    module fcntl {
+      header "${LIBC_INCLUDE_PATH}/fcntl.h"
+      export *
+    }
+    module fnmatch {
+      header "${LIBC_INCLUDE_PATH}/fnmatch.h"
+      export *
+    }
+    module ioctl {
+      header "${LIBC_ARCH_INCLUDE_PATH}/sys/ioctl.h"
+      export *
+    }
+    module libgen {
+      header "${LIBC_INCLUDE_PATH}/libgen.h"
+      export *
+    }
+    module netinet {
+      module in {
+        header "${LIBC_INCLUDE_PATH}/netinet/in.h"
+        export *
+
+        exclude header "${LIBC_INCLUDE_PATH}/netinet6/in6.h"
+      }
+      module tcp {
+        header "${LIBC_INCLUDE_PATH}/netinet/tcp.h"
+        export *
+      }
+    }
+    module poll {
+      header "${LIBC_INCLUDE_PATH}/poll.h"
+      export *
+    }
+    module regex {
+      header "${LIBC_INCLUDE_PATH}/regex.h"
+      export *
+    }
+    module sched {
+      header "${LIBC_INCLUDE_PATH}/sched.h"
+      export *
+    }
+    module semaphore {
+      header "${LIBC_INCLUDE_PATH}/semaphore.h"
+      export *
+    }
+    module strings {
+      header "${LIBC_INCLUDE_PATH}/strings.h"
+      export *
+    }
+
+    module sys {
+      export *
+
+      module mman {
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/mman.h"
+        export *
+      }
+      module resource {
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/resource.h"
+        export *
+      }
+      module select {
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/select.h"
+        export *
+      }
+      module socket {
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/socket.h"
+        export *
+      }
+      module stat {
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/stat.h"
+        export *
+      }
+      module time {
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/time.h"
+        export *
+      }
+      module times {
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/times.h"
+        export *
+      }
+      module types {
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/types.h"
+        export *
+      }
+      module uio {
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/uio.h"
+        export *
+      }
+      module un {
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/un.h"
+        export *
+      }
+      module utsname {
+        header "${LIBC_ARCH_INCLUDE_PATH}/sys/utsname.h"
+        export *
+      }
+    }
+    module unistd {
+      header "${LIBC_INCLUDE_PATH}/unistd.h"
+      export *
+    }
+  }
+}


### PR DESCRIPTION
WASI libc is substantially different from Glibc, thus we need a separate modulemap for it.

Related to SR-9307

cc @kateinoigakukun