### PR TITLE
stdlib: add support for WebAssembly in VarArgs

### DIFF
--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -601,7 +601,7 @@ final internal class __VaListBuilder {
     // supported vararg type is greater than the alignment of Int, such
     // as non-iOS ARM. Note that we can't use alignof because it
     // differs from ABI alignment on some architectures.
-#if (arch(arm) && !os(iOS)) || arch(arm64_32)
+#if (arch(arm) && !os(iOS)) || arch(arm64_32) || arch(wasm32)
     if let arg = arg as? _CVarArgAligned {
       let alignmentInWords = arg._cVarArgAlignment / MemoryLayout<Int>.size
       let misalignmentInWords = count % alignmentInWords


### PR DESCRIPTION
When targeting `wasm32` we're relying on the alignment padding branch that's used for 32-bit ARM.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves a part of SR-9307.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
