### PR TITLE
Temporarily disable SILCombine keypath optimization in OSSA

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -512,6 +512,10 @@ bool SILCombiner::tryOptimizeKeypath(ApplyInst *AI) {
 ///   %addr = struct_element_addr/ref_element_addr %root_object
 ///   // use %inout_addr
 bool SILCombiner::tryOptimizeInoutKeypath(BeginApplyInst *AI) {
+  // Disable in OSSA because KeyPathProjector is not fully ported
+  if (AI->getFunction()->hasOwnership())
+    return false;
+
   SILFunction *callee = AI->getReferencedFunctionOrNull();
   if (!callee)
     return false;


### PR DESCRIPTION
KeyPathProjector is not fully ported. Disable until OSSA support
in KeyPathProjector is implemented.
