### PR TITLE
[Concurrency] repair cooperative executor and its tests

### DIFF
--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -49,6 +49,13 @@ function(add_swift_unittest test_dirname)
       _ENABLE_EXTENDED_ALIGNED_STORAGE)
   endif()
 
+  # some headers switch their inline implementations based on
+  # SWIFT_STDLIB_SINGLE_THREADED_RUNTIME definition
+  if(SWIFT_STDLIB_SINGLE_THREADED_RUNTIME)
+    target_compile_definitions("${test_dirname}" PRIVATE
+      SWIFT_STDLIB_SINGLE_THREADED_RUNTIME)
+  endif()
+
   if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
     if(SWIFT_USE_LINKER)
       target_link_options(${test_dirname} PRIVATE

--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -103,7 +103,7 @@ static DelayedJob *DelayedJobQueue = nullptr;
 
 /// Get the next-in-queue storage slot.
 static Job *&nextInQueue(Job *cur) {
-  return reinterpret_cast<Job*&>(&cur->SchedulerPrivate[NextWaitingTaskIndex]);
+  return reinterpret_cast<Job*&>(cur->SchedulerPrivate[Job::NextWaitingTaskIndex]);
 }
 
 /// Insert a job into the cooperative global queue.
@@ -448,13 +448,9 @@ void swift::swift_task_enqueueOnDispatchQueue(Job *job,
 }
 #endif
 
-#if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
-static HeapObject _swift_mainExecutorIdentity;
-#endif
-
 ExecutorRef swift::swift_task_getMainExecutor() {
 #if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
-  return ExecutorRef::forOrdinary(&_swift_mainExecutorIdentity, nullptr);
+  return ExecutorRef::generic();
 #else
   return ExecutorRef::forOrdinary(
            reinterpret_cast<HeapObject*>(&_dispatch_main_q),
@@ -464,7 +460,7 @@ ExecutorRef swift::swift_task_getMainExecutor() {
 
 bool ExecutorRef::isMainExecutor() const {
 #if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
-  return Identity == &_swift_mainExecutorIdentity;
+  return isGeneric();
 #else
   return Identity == reinterpret_cast<HeapObject*>(&_dispatch_main_q);
 #endif

--- a/stdlib/public/Concurrency/Mutex.cpp
+++ b/stdlib/public/Concurrency/Mutex.cpp
@@ -19,3 +19,6 @@
 
 #include "../runtime/MutexPThread.cpp"
 #include "../runtime/MutexWin32.cpp"
+#ifdef SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
+  #include "swift/Runtime/MutexSingleThreaded.h"
+#endif

--- a/test/Concurrency/Runtime/async_task_locals_copy_to_sync.swift
+++ b/test/Concurrency/Runtime/async_task_locals_copy_to_sync.swift
@@ -7,6 +7,8 @@
 // rdar://76038845
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
+// Disable on cooperative executor because it can't dispatch jobs before the end of main function
+// UNSUPPORTED: single_threaded_runtime
 
 import Dispatch
 

--- a/test/Concurrency/Runtime/cancellation_handler.swift
+++ b/test/Concurrency/Runtime/cancellation_handler.swift
@@ -5,6 +5,7 @@
 // rdar://76038845
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: single_threaded_runtime
 
 // for sleep
 #if canImport(Darwin)

--- a/test/Concurrency/Runtime/data_race_detection.swift
+++ b/test/Concurrency/Runtime/data_race_detection.swift
@@ -8,6 +8,7 @@
 // rdar://76038845
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: single_threaded_runtime
 
 import _Concurrency
 import Dispatch
@@ -58,14 +59,14 @@ actor MyActor {
 struct Runner {
   static func main() async {
     print("Launching a main-actor task")
-    // CHECK: warning: data race detected: @MainActor function at main/data_race_detection.swift:22 was not called on the main thread
+    // CHECK: warning: data race detected: @MainActor function at main/data_race_detection.swift:23 was not called on the main thread
     launchFromMainThread()
     sleep(1)
 
     let actor = MyActor()
     let actorFn = await actor.getTaskOnMyActor()
     print("Launching an actor-instance task")
-    // CHECK: warning: data race detected: actor-isolated function at main/data_race_detection.swift:51 was not called on the same actor
+    // CHECK: warning: data race detected: actor-isolated function at main/data_race_detection.swift:52 was not called on the same actor
     launchTask(actorFn)
 
     sleep(1)

--- a/test/Concurrency/Runtime/mainactor.swift
+++ b/test/Concurrency/Runtime/mainactor.swift
@@ -7,6 +7,7 @@
 // rdar://76038845
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: single_threaded_runtime
 
 import Dispatch
 

--- a/test/Interpreter/enforce_exclusive_access.swift
+++ b/test/Interpreter/enforce_exclusive_access.swift
@@ -4,6 +4,7 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
+// UNSUPPORTED: single_threaded_runtime
 
 // Tests for traps at run time when enforcing exclusive access.
 

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -84,6 +84,10 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     endif()
   endif()
 
+  if(NOT SWIFT_STDLIB_SINGLE_THREADED_RUNTIME)
+    list(APPEND PLATFORM_SOURCES Mutex.cpp)
+  endif()
+
   if(SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED)
 #    list(APPEND PLATFORM_SOURCES
 #      DistributedActor.cpp
@@ -98,7 +102,8 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     weak.mm
     Refcounting.mm
     Actor.cpp
-    TaskStatus.cpp)
+    TaskStatus.cpp
+    Mutex.cpp)
 
   add_swift_unittest(SwiftRuntimeTests
     Array.cpp
@@ -106,7 +111,6 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     CompatibilityOverrideConcurrency.cpp
     Concurrent.cpp
     Metadata.cpp
-    Mutex.cpp
     Enum.cpp
     Refcounting.cpp
     Stdlib.cpp

--- a/unittests/runtime/Concurrent.cpp
+++ b/unittests/runtime/Concurrent.cpp
@@ -45,6 +45,8 @@ TEST(ConcurrentReadableArrayTest, SingleThreaded) {
   check();
 }
 
+#ifndef SWIFT_STDLIB_SINGLE_THREADED_RUNTIME
+
 TEST(ConcurrentReadableArrayTest, MultiThreaded) {
   const int insertCount = 100000;
 
@@ -542,3 +544,4 @@ TEST(ConcurrentReadableHashMapTest, MultiThreaded4) {
   runTest(16, 1);
   runTest(16, 8);
 }
+#endif // !SWIFT_STDLIB_SINGLE_THREADED_RUNTIME

--- a/validation-test/Runtime/ConcurrentMetadata.swift
+++ b/validation-test/Runtime/ConcurrentMetadata.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
+// UNSUPPORTED: single_threaded_runtime
 
 // Exercise the metadata cache from multiple threads to shake out any
 // concurrency bugs.


### PR DESCRIPTION
This patch repairs the main executor to avoid assertion failure due to `witnessTable == nullptr` introduced by my previous patch 😓 https://github.com/apple/swift/pull/39092

And fixes and disables some tests that depend on multi-thread based executor implementation detail.

This also fixes CI failure on WebAssembly CI: https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-20.04-webassembly/10/console

