### PR TITLE
Check if the C++ compiler used to build the Concurrency library has the -fswift-async-fp flag

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -35,19 +35,29 @@ endif()
 set(SWIFT_RUNTIME_CONCURRENCY_C_FLAGS)
 set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS)
 
+check_cxx_compiler_flag(-fswift-async-fp=always CXX_COMPILER_HAS_SWIFT_ASYNC_FP_FLAG)
+
 if(NOT swift_concurrency_async_fp_mode)
   set(swift_concurrency_async_fp_mode "always")
 endif()
 
-# Don't emit extended frame info on platforms other than darwin, system
-# backtracer and system debugger are unlikely to support it.
+# Don't emit extended frame info on platforms other than darwin, if the compiler
+# has that flag, as the system backtracer and system debugger are unlikely to
+# support it.
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS
-    "-fswift-async-fp=${swift_concurrency_async_fp_mode}")
-  list(APPEND SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS
-    "-Xfrontend"
-    "-swift-async-frame-pointer=${swift_concurrency_async_fp_mode}")
-else()
+  if(CXX_COMPILER_HAS_SWIFT_ASYNC_FP_FLAG)
+    list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS
+      "-fswift-async-fp=${swift_concurrency_async_fp_mode}")
+    list(APPEND SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS
+      "-Xfrontend"
+      "-swift-async-frame-pointer=${swift_concurrency_async_fp_mode}")
+  else()
+    message(ERROR
+      "The -fswift-async-fp clang flag is not available. This is most likely "
+      "because you are using the Xcode toolchain, which may not have the "
+      "latest flags yet.")
+  endif()
+elseif(CXX_COMPILER_HAS_SWIFT_ASYNC_FP_FLAG)
   list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS "-fswift-async-fp=never")
 endif()
 


### PR DESCRIPTION
This clang flag is only available in upstream trunk this week, so [it breaks my Android CI that tries to build this library with clang 12 from Android NDK 23](https://github.com/buttaface/swift-android-sdk/runs/3644126454?check_suite_focus=true#step:7:1342)~. Only commenting this out so we remember to re-enable it once clang 14 comes out.~, which this pull fixes.

@aschwaighofer, you added this flag in #39245. @davezarzycki, you've tried to keep this repo building with upstream clang.