### PR TITLE
[DNM][SR-14665] add default `==` implementation for `Comparable`

### DIFF
--- a/stdlib/public/core/Comparable.swift
+++ b/stdlib/public/core/Comparable.swift
@@ -171,6 +171,16 @@ public protocol Comparable: Equatable {
   ///   - lhs: A value to compare.
   ///   - rhs: Another value to compare.
   static func > (lhs: Self, rhs: Self) -> Bool
+
+  /// Returns a Boolean value indicating whether two values are equal.
+  ///
+  /// Equality is the inverse of inequality. For any values `a` and `b`,
+  /// `a == b` implies that `a != b` is `false`.
+  ///
+  /// - Parameters:
+  ///   - lhs: A value to compare.
+  ///   - rhs: Another value to compare.
+  static func == (lhs: Self, rhs: Self) -> Bool
 }
 
 extension Comparable {
@@ -216,5 +226,20 @@ extension Comparable {
   @inlinable
   public static func >= (lhs: Self, rhs: Self) -> Bool {
     return !(lhs < rhs)
+  }
+
+  /// Returns a Boolean value indicating whether two values are equal.
+  ///
+  /// Equality is the inverse of inequality. For any values `a` and `b`,
+  /// `a == b` implies that `a != b` is `false`.
+  ///
+  /// This is the default implementation of the equal-to operator (`!=`) for
+  /// any type that conforms to `Comparable`.
+  ///
+  /// - Parameters:
+  ///   - lhs: A value to compare.
+  ///   - rhs: Another value to compare.
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    return !(lhs < rhs || lhs > rhs)
   }
 }


### PR DESCRIPTION
Do not merge.

An alternative to #39047.

As discussed in [the forums thread](https://forums.swift.org/t/add-default-implementation-of-to-comparable/48832), this might be source-breaking, so this PR is just doing a compatibility suite test.