### PR TITLE
libswift: fix a few bugs in StackList

### DIFF
--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -1096,7 +1096,11 @@ FixedSizeSlab *LibswiftPassInvocation::allocSlab(FixedSizeSlab *afterSlab) {
 }
 
 FixedSizeSlab *LibswiftPassInvocation::freeSlab(FixedSizeSlab *slab) {
-  FixedSizeSlab *prev = std::prev(&*slab->getIterator());
+  FixedSizeSlab *prev = nullptr;
+  assert(!allocatedSlabs.empty());
+  if (&allocatedSlabs.front() != slab)
+    prev = &*std::prev(slab->getIterator());
+
   allocatedSlabs.remove(*slab);
   passManager->getModule()->freeSlab(slab);
   return prev;


### PR DESCRIPTION
Use MemoryLayout.stride instead pf MemoryLayout.size. This fixes a buffer overflow bug in case of unaligned elements.
Plus some other bug fixes for stacklists which get larger than a single slab.
Also, add the `append(contentsOf:)` method.

Unfortunately l cannot provide a test case right now. But it will be tested when I land another change, which uncovered these bugs.