### PR TITLE
[NFC] Strip Unnecessary %s's out of Tests

### DIFF
--- a/test/Concurrency/async_main_no_concurrency.swift
+++ b/test/Concurrency/async_main_no_concurrency.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -parse-as-library -disable-availability-checking -disable-implicit-concurrency-module-import %s
-// RUN: %target-typecheck-verify-swift -parse-as-library  -disable-availability-checking -parse-stdlib %s
+// RUN: %target-typecheck-verify-swift -parse-as-library -disable-availability-checking -disable-implicit-concurrency-module-import
+// RUN: %target-typecheck-verify-swift -parse-as-library -disable-availability-checking -parse-stdlib
 
 @main struct Main {
   // expected-error@+1:22{{'_Concurrency' module not imported, required for async main}}

--- a/test/Interop/Cxx/templates/function-template-typechecker-errors.swift
+++ b/test/Interop/Cxx/templates/function-template-typechecker-errors.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-typecheck-verify-swift %s -I %S/Inputs -enable-cxx-interop 2>&1 | %FileCheck %s
+// RUN: not %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop 2>&1 | %FileCheck %s
 
 // README: If you just added support for protocol composition to the
 // ClangTypeConverter, please update this test to use a different type that we

--- a/test/SILGen/magic_identifier_filepath.swift
+++ b/test/SILGen/magic_identifier_filepath.swift
@@ -3,7 +3,7 @@
 
 // Even if concise #file is not available, we now allow you to write #filePath.
 // Check that we don't diagnose any errors in this file.
-// RUN: %target-typecheck-verify-swift -module-name Foo %s
+// RUN: %target-typecheck-verify-swift -module-name Foo
 
 // #filePath should appear in swiftinterfaces with this change.
 // RUN: %target-swift-frontend-typecheck -module-name Foo -emit-module-interface-path %t.swiftinterface %s

--- a/test/Sema/impl_throw_objc.swift
+++ b/test/Sema/impl_throw_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift %s
+// RUN: %target-typecheck-verify-swift
 // REQUIRES: objc_interop
 
 import Foundation

--- a/validation-test/compiler_crashers_2_fixed/sr13118.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr13118.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift %s
+// RUN: %target-typecheck-verify-swift
 
 public struct S<T : Codable> : Codable {
   var s: [T]!


### PR DESCRIPTION
%target-typecheck-verify-swift already implies the current file being passed to the frontend - these just lead to duplicate input file errors.