### PR TITLE
[WIP] Fix DeadObjectElimination to correctly insert compensating releases

### DIFF
--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -361,11 +361,10 @@ static bool onlyStoresToTailObjects(BuiltinInst *destroyArray,
 }
 
 /// Inserts releases of all stores in \p users.
-static void insertCompensatingReleases(SILInstruction *before,
-                                       const UserList &users) {
+static void insertCompensatingReleases(const UserList &users) {
   for (SILInstruction *user : users) {
     if (auto *store = dyn_cast<StoreInst>(user)) {
-      createDecrementBefore(store->getSrc(), before);
+      createDecrementBefore(store->getSrc(), store);
     }
   }
 }
@@ -834,7 +833,7 @@ bool DeadObjectElimination::processAllocRef(AllocRefInst *ARI) {
     }
   }
   if (releaseOfTailElems)
-    insertCompensatingReleases(releaseOfTailElems, UsersToRemove);
+    insertCompensatingReleases(UsersToRemove);
 
   // Remove the AllocRef and all of its users.
   removeInstructions(

--- a/test/SILOptimizer/silcombine_runtime_crash.swift
+++ b/test/SILOptimizer/silcombine_runtime_crash.swift
@@ -2,6 +2,7 @@
 // RUN: %target-build-swift -O %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
+// RUN: %target-build-swift -Xllvm -sil-enable-late-ome -sil-verify-all -O %s -o %t/a.out
 
 // REQUIRES: executable_test
 


### PR DESCRIPTION
Instruction that may release an object's tail elem may not post dominate
stores that need to be removed and compensated with a release.
While inserting a compensating release for the store, use the store as the insert point.

