### PR TITLE
Remove _swift_stdlib_putchar_unlocked

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -35,8 +35,6 @@ extern "C" {
 
 // Input/output <stdio.h>
 SWIFT_RUNTIME_STDLIB_INTERNAL
-int _swift_stdlib_putchar_unlocked(int c);
-SWIFT_RUNTIME_STDLIB_INTERNAL
 __swift_size_t _swift_stdlib_fwrite_stdout(const void *ptr, __swift_size_t size,
                                            __swift_size_t nitems);
 

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -32,15 +32,6 @@
 #include "../SwiftShims/LibcShims.h"
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
-int _swift_stdlib_putchar_unlocked(int c) {
-#if defined(_WIN32)
-  return _putc_nolock(c, stdout);
-#else
-  return putchar_unlocked(c);
-#endif
-}
-
-SWIFT_RUNTIME_STDLIB_INTERNAL
 __swift_size_t _swift_stdlib_fwrite_stdout(const void *ptr,
                                                   __swift_size_t size,
                                                   __swift_size_t nitems) {


### PR DESCRIPTION
As far as I can tell, it's completely unused. The last and only use of it was dropped in 2018, in <https://github.com/apple/swift/commit/4ab45dfe205ae79500773bea139ff809ccd295e6>.