### PR TITLE
[Docs] Note that partition(by:) is unstable

### DIFF
--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -221,8 +221,9 @@ extension MutableCollection {
   /// After partitioning a collection, there is a pivot index `p` where
   /// no element before `p` satisfies the `belongsInSecondPartition`
   /// predicate and every element at or after `p` satisfies
-  /// `belongsInSecondPartition`. This operation is not stable, so the
-  /// relative ordering of elements within the partitions is not preserved.
+  /// `belongsInSecondPartition`. This operation isn't guaranteed to be
+  /// stable, so the relative ordering of elements within the partitions might
+  /// change.
   ///
   /// In the following example, an array of numbers is partitioned by a
   /// predicate that matches elements greater than 30.
@@ -242,10 +243,9 @@ extension MutableCollection {
   ///     let second = numbers[p...]
   ///     // second == [60, 40]
   ///
-  /// Note that elements in both partitions have changed their
-  /// relative order compared to before partitioning. That is, `40`
-  /// appears before `60` in the original collection, but afterward
-  /// after calling `partition(by:)`.
+  /// Note that the order of elements in both partitions changed.
+  /// That is, `40` appears before `60` in the original collection,
+  /// but, after calling `partition(by:)`, `60` appears before `40`.
   ///
   /// - Parameter belongsInSecondPartition: A predicate used to partition
   ///   the collection. All elements satisfying this predicate are ordered
@@ -291,8 +291,9 @@ extension MutableCollection where Self: BidirectionalCollection {
   /// After partitioning a collection, there is a pivot index `p` where
   /// no element before `p` satisfies the `belongsInSecondPartition`
   /// predicate and every element at or after `p` satisfies
-  /// `belongsInSecondPartition`. This operation is not stable, so the
-  /// relative ordering of elements within the partitions is not preserved.
+  /// `belongsInSecondPartition`. This operation isn't guaranteed to be
+  /// stable, so the relative ordering of elements within the partitions might
+  /// change.
   ///
   /// In the following example, an array of numbers is partitioned by a
   /// predicate that matches elements greater than 30.
@@ -312,10 +313,9 @@ extension MutableCollection where Self: BidirectionalCollection {
   ///     let second = numbers[p...]
   ///     // second == [60, 40]
   ///
-  /// Note that elements in both partitions have changed their
-  /// relative order compared to before partitioning. That is, `40`
-  /// appears before `60` in the original collection, but afterward
-  /// after calling `partition(by:)`.
+  /// Note that the order of elements in both partitions changed.
+  /// That is, `40` appears before `60` in the original collection,
+  /// but, after calling `partition(by:)`, `60` appears before `40`.
   ///
   /// - Parameter belongsInSecondPartition: A predicate used to partition
   ///   the collection. All elements satisfying this predicate are ordered

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -221,7 +221,8 @@ extension MutableCollection {
   /// After partitioning a collection, there is a pivot index `p` where
   /// no element before `p` satisfies the `belongsInSecondPartition`
   /// predicate and every element at or after `p` satisfies
-  /// `belongsInSecondPartition`.
+  /// `belongsInSecondPartition`. This operation is not stable, so the
+  /// relative ordering of elements within the partitions is not preserved.
   ///
   /// In the following example, an array of numbers is partitioned by a
   /// predicate that matches elements greater than 30.
@@ -240,6 +241,11 @@ extension MutableCollection {
   ///     // first == [30, 10, 20, 30, 30]
   ///     let second = numbers[p...]
   ///     // second == [60, 40]
+  ///
+  /// Note that elements in both partitions have changed their
+  /// relative order compared to before partitioning. That is, `40`
+  /// appears before `60` in the original collection, but afterward
+  /// after calling `partition(by:)`.
   ///
   /// - Parameter belongsInSecondPartition: A predicate used to partition
   ///   the collection. All elements satisfying this predicate are ordered
@@ -285,7 +291,8 @@ extension MutableCollection where Self: BidirectionalCollection {
   /// After partitioning a collection, there is a pivot index `p` where
   /// no element before `p` satisfies the `belongsInSecondPartition`
   /// predicate and every element at or after `p` satisfies
-  /// `belongsInSecondPartition`.
+  /// `belongsInSecondPartition`. This operation is not stable, so the
+  /// relative ordering of elements within the partitions is not preserved.
   ///
   /// In the following example, an array of numbers is partitioned by a
   /// predicate that matches elements greater than 30.
@@ -304,6 +311,11 @@ extension MutableCollection where Self: BidirectionalCollection {
   ///     // first == [30, 10, 20, 30, 30]
   ///     let second = numbers[p...]
   ///     // second == [60, 40]
+  ///
+  /// Note that elements in both partitions have changed their
+  /// relative order compared to before partitioning. That is, `40`
+  /// appears before `60` in the original collection, but afterward
+  /// after calling `partition(by:)`.
   ///
   /// - Parameter belongsInSecondPartition: A predicate used to partition
   ///   the collection. All elements satisfying this predicate are ordered

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -121,8 +121,9 @@ where SubSequence: MutableCollection
   /// After partitioning a collection, there is a pivot index `p` where
   /// no element before `p` satisfies the `belongsInSecondPartition`
   /// predicate and every element at or after `p` satisfies
-  /// `belongsInSecondPartition`. This operation is not stable, so the
-  /// relative ordering of elements within the partitions is not preserved.
+  /// `belongsInSecondPartition`. This operation isn't guaranteed to be
+  /// stable, so the relative ordering of elements within the partitions might
+  /// change.
   ///
   /// In the following example, an array of numbers is partitioned by a
   /// predicate that matches elements greater than 30.
@@ -142,10 +143,9 @@ where SubSequence: MutableCollection
   ///     let second = numbers[p...]
   ///     // second == [60, 40]
   ///
-  /// Note that elements in both partitions have changed their
-  /// relative order compared to before partitioning. That is, `40`
-  /// appears before `60` in the original collection, but afterward
-  /// after calling `partition(by:)`.
+  /// Note that the order of elements in both partitions changed.
+  /// That is, `40` appears before `60` in the original collection,
+  /// but, after calling `partition(by:)`, `60` appears before `40`.
   ///
   /// - Parameter belongsInSecondPartition: A predicate used to partition
   ///   the collection. All elements satisfying this predicate are ordered

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -121,7 +121,8 @@ where SubSequence: MutableCollection
   /// After partitioning a collection, there is a pivot index `p` where
   /// no element before `p` satisfies the `belongsInSecondPartition`
   /// predicate and every element at or after `p` satisfies
-  /// `belongsInSecondPartition`.
+  /// `belongsInSecondPartition`. This operation is not stable, so the
+  /// relative ordering of elements within the partitions is not preserved.
   ///
   /// In the following example, an array of numbers is partitioned by a
   /// predicate that matches elements greater than 30.
@@ -140,6 +141,11 @@ where SubSequence: MutableCollection
   ///     // first == [30, 10, 20, 30, 30]
   ///     let second = numbers[p...]
   ///     // second == [60, 40]
+  ///
+  /// Note that elements in both partitions have changed their
+  /// relative order compared to before partitioning. That is, `40`
+  /// appears before `60` in the original collection, but afterward
+  /// after calling `partition(by:)`.
   ///
   /// - Parameter belongsInSecondPartition: A predicate used to partition
   ///   the collection. All elements satisfying this predicate are ordered


### PR DESCRIPTION
The standard library's `partition(by:)` method is unstable, but this isn't noted in the docs. This adds some detail describing that fact.