### PR TITLE
[5.5] Frontend: teach -emit-module and -merge-modules to emit ABI descriptor files

### DIFF
--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -31,6 +31,7 @@ namespace swift {
     const char *DocOutputPath = nullptr;
     const char *SourceInfoOutputPath = nullptr;
     std::string SymbolGraphOutputDir;
+    std::string ABIDescriptorPath;
     bool SkipSymbolGraphInheritedDocs = true;
     bool IncludeSPISymbolsInSymbolGraph = false;
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -155,7 +155,8 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
     serializationOpts.ImportedHeader = opts.ImplicitObjCHeaderPath;
   serializationOpts.ModuleLinkName = opts.ModuleLinkName;
   serializationOpts.ExtraClangOptions = getClangImporterOptions().ExtraArgs;
-  
+  serializationOpts.ABIDescriptorPath = outs.ABIDescriptorOutputPath.c_str();
+
   if (opts.EmitSymbolGraph) {
     if (!opts.SymbolGraphOutputDir.empty()) {
       serializationOpts.SymbolGraphOutputDir = opts.SymbolGraphOutputDir;

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -526,6 +526,8 @@ bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
 }
 bool FrontendOptions::canActionEmitABIDescriptor(ActionType action) {
   switch (action) {
+  case ActionType::MergeModules:
+  case ActionType::EmitModuleOnly:
   case ActionType::CompileModuleFromInterface:
     return true;
   case ActionType::NoneAction:
@@ -550,8 +552,6 @@ bool FrontendOptions::canActionEmitABIDescriptor(ActionType action) {
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
   case ActionType::PrintFeature:
-  case ActionType::MergeModules:
-  case ActionType::EmitModuleOnly:
   case ActionType::EmitSIL:
   case ActionType::EmitSIBGen:
   case ActionType::EmitSIB:

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -24,7 +24,6 @@
 #include "swift/Frontend/ModuleInterfaceSupport.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/Serialization/SerializationOptions.h"
-#include "swift/APIDigester/ModuleAnalyzerNodes.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Lex/PreprocessorOptions.h"
 #include "llvm/ADT/Hashing.h"
@@ -252,6 +251,7 @@ bool ModuleInterfaceBuilder::buildSwiftModuleInternal(
     if (!getRelativeDepPath(InPath, SDKPath))
       SerializationOpts.ModuleInterface = InPath;
 
+    SerializationOpts.ABIDescriptorPath = ABIDescriptorPath.str();
     SmallVector<FileDependency, 16> Deps;
     bool serializeHashes = FEOpts.SerializeModuleInterfaceDependencyHashes;
     if (collectDepsForSerialization(SubInstance, Deps, serializeHashes)) {
@@ -278,9 +278,6 @@ bool ModuleInterfaceBuilder::buildSwiftModuleInternal(
     }
     if (SubInstance.getDiags().hadAnyError()) {
       return std::make_error_code(std::errc::not_supported);
-    }
-    if (!ABIDescriptorPath.empty()) {
-      swift::ide::api::dumpModuleContent(Mod, ABIDescriptorPath, true);
     }
     return std::error_code();
     });

--- a/lib/Option/features.json
+++ b/lib/Option/features.json
@@ -8,6 +8,9 @@
     },
     {
       "name": "index-unit-output-path"
+    },
+    {
+      "name": "emit-abi-descriptor"
     }
   ]
 }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -36,6 +36,7 @@
 #include "swift/AST/SynthesizedFileUnit.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeVisitor.h"
+#include "swift/APIDigester/ModuleAnalyzerNodes.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Dwarf.h"
 #include "swift/Basic/FileSystem.h"
@@ -5550,6 +5551,17 @@ bool Serializer::allowCompilerErrors() const {
   return getASTContext().LangOpts.AllowModuleWithCompilerErrors;
 }
 
+
+static void emitABIDescriptor(ModuleOrSourceFile DC,
+                              const SerializationOptions &options) {
+  if (!options.ABIDescriptorPath.empty()) {
+    if (DC.is<ModuleDecl*>()) {
+      swift::ide::api::dumpModuleContent(DC.get<ModuleDecl*>(),
+                                         options.ABIDescriptorPath, true);
+    }
+  }
+}
+
 void swift::serializeToBuffers(
   ModuleOrSourceFile DC, const SerializationOptions &options,
   std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
@@ -5573,6 +5585,7 @@ void swift::serializeToBuffers(
     });
     if (hadError)
       return;
+    emitABIDescriptor(DC, options);
     if (moduleBuffer)
       *moduleBuffer = std::make_unique<llvm::SmallVectorMemoryBuffer>(
                         std::move(buf), options.OutputPath);
@@ -5677,4 +5690,5 @@ void swift::serialize(ModuleOrSourceFile DC,
       symbolgraphgen::emitSymbolGraphForModule(M, SGOpts);
     }
   }
+  emitABIDescriptor(DC, options);
 }

--- a/test/ModuleInterface/emit-abi-descriptor.swift
+++ b/test/ModuleInterface/emit-abi-descriptor.swift
@@ -2,12 +2,24 @@
 // RUN: %empty-directory(%t/Foo.swiftmodule)
 // RUN: %empty-directory(%t/ResourceDir/%target-sdk-name/prebuilt-modules/Foo.swiftmodule)
 // RUN: echo "public func foo() {}" > %t/Foo.swift
-// RUN: echo "public enum DisplayStyle { case tuple, optional, collection }" > %t/Foo.swift
+// RUN: echo "public enum DisplayStyle { case tuple, optional, collection }" >> %t/Foo.swift
+
+// RUN: echo "public func bar() {}" > %t/Bar.swift
 
 // RUN: %target-swift-frontend -emit-module %t/Foo.swift -module-name Foo -emit-module-interface-path %t/Foo.swiftinterface
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Foo.swiftinterface -o %t/Foo.swiftmodule -module-name Foo -emit-abi-descriptor-path %t/Foo.json
 
 // RUN: %FileCheck %s < %t/Foo.json
+
+// RUN: %target-swift-frontend -emit-module -module-name Bar -emit-module-path %t/Bar.swiftmodule -emit-abi-descriptor-path %t/Bar.json %t/Bar.swift
+
+// RUN: %FileCheck %s < %t/Bar.json
+
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Foo~partial1.swiftmodule %t/Foo.swift -module-name FooBar
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Foo~partial2.swiftmodule %t/Bar.swift -module-name FooBar
+// RUN: %target-swift-frontend -merge-modules -emit-module -emit-module-path %t/FooBar.swiftmodule %t/Foo~partial1.swiftmodule %t/Foo~partial2.swiftmodule -module-name FooBar -emit-abi-descriptor-path %t/FooBar.json
+
+// RUN: %FileCheck %s < %t/FooBar.json
 
 // CHECK: "kind": "Root"
 // CHECK-NEXT: "name": "TopLevel"

--- a/tools/libSwiftScan/libSwiftScan.cpp
+++ b/tools/libSwiftScan/libSwiftScan.cpp
@@ -508,6 +508,8 @@ swiftscan_compiler_supported_arguments_query() {
 
 swiftscan_string_set_t *
 swiftscan_compiler_supported_features_query() {
-  // TODO: We are yet to figure out how "Features" will be organized.
-  return nullptr;
+  std::vector<std::string> allFeatures;
+  allFeatures.emplace_back("library-level");
+  allFeatures.emplace_back("emit-abi-descriptor");
+  return create_set(allFeatures);
 }


### PR DESCRIPTION
Explanation: This change teaches the compiler to emit ABI descriptors as byproducts of emitting final modules. We could use these ABI descriptors to diagnose breakages between two revisions of the codebase. 
Risk: Low
Reviewed by: @xymus 
Testing: Automated tests added