### PR TITLE
[ConstraintSystem] Prefer overloads choices that are variables over unapplied functions using the solver score.

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -768,8 +768,18 @@ enum ScoreKind {
   SK_ValueToPointerConversion,
   /// A closure/function conversion to an autoclosure parameter.
   SK_FunctionToAutoClosureConversion,
+  /// An unapplied reference to a function. The purpose of this
+  /// score bit is to prune overload choices that are functions
+  /// when a solution has already been found using property.
+  ///
+  /// \Note The solver only prefers variables over functions
+  /// to resolve ambiguities, so please be sure that any score
+  /// kind added after this is truly less impactful. Only other
+  /// ambiguity tie-breakers should go after this; anything else
+  /// should be added above.
+  SK_UnappliedFunction,
 
-  SK_LastScoreKind = SK_FunctionToAutoClosureConversion,
+  SK_LastScoreKind = SK_UnappliedFunction,
 };
 
 /// The number of score kinds.

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -90,6 +90,9 @@ static StringRef getScoreKindName(ScoreKind kind) {
 
   case SK_ImplicitValueConversion:
     return "value-to-value conversion";
+
+  case SK_UnappliedFunction:
+    return "overloaded unapplied function";
   }
 }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2947,6 +2947,12 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
       }
     }
 
+    if (isa<AbstractFunctionDecl>(decl) || isa<TypeDecl>(decl)) {
+      if (choice.getFunctionRefKind() == FunctionRefKind::Unapplied) {
+        increaseScore(SK_UnappliedFunction);
+      }
+    }
+
     if (auto *afd = dyn_cast<AbstractFunctionDecl>(decl)) {
       // Check whether applying this overload would result in invalid
       // partial function application e.g. partial application of

--- a/validation-test/Sema/type_checker_perf/fast/property_vs_unapplied_func.swift
+++ b/validation-test/Sema/type_checker_perf/fast/property_vs_unapplied_func.swift
@@ -1,0 +1,30 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1 -solver-disable-shrink
+// REQUIRES: tools-release,no_asan
+
+struct Date {
+  var description: String
+  func description(with: Int) -> String { "" }
+}
+
+struct DatabaseLog {
+  let string: String
+  let values: [String]
+  let date: Date
+
+  var description: String {
+    return "[" + string + "] [" + date.description + "] " + string + " [" + values.joined(separator: ", ") + "]"
+  }
+}
+
+extension Sequence {
+  public func count(
+    where predicate: (Element) throws -> Bool
+  ) rethrows -> Int { 0 }
+}
+
+
+func rdar47742750(arr1: [Int], arr2: [Int]?) {
+  let _ = {
+    assert(arr1.count == arr1.count + (arr2 == nil ? 0 : 1 + arr2!.count + arr2!.count + arr2!.count))
+  }
+}


### PR DESCRIPTION
This change increases the score when the solver attempts an overload choice that is an unapplied reference to a function declaration. This will allows the solver to prune those overload choices when it has already found a solution with a property (all else equal in the score). This is already done as an ambiguity tie-breaker in solution ranking, but adding this bit to the score will prune a lot of search space within the solver.

This should fix many of the type checker performance issues that were observed with the addition of `count(where:)`, including using `array.count` in operator expressions.

Resolves: rdar://47742750