### PR TITLE
[SIL] Enabled printing canonical module.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -308,6 +308,8 @@ PASS(Outliner, "outliner",
      "Function Outlining Optimization")
 PASS(OwnershipModelEliminator, "ownership-model-eliminator",
      "Eliminate Ownership Annotation of SIL")
+PASS(ModulePrinter, "module-printer",
+     "Print the module")
 PASS(NestedSemanticFunctionCheck, "nested-semantic-function-check",
      "Diagnose improperly nested '@_semantics' functions")
 PASS(NonTransparentFunctionOwnershipModelEliminator,

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -47,6 +47,10 @@ static llvm::cl::opt<bool> SILViewCanonicalCFG(
     "sil-view-canonical-cfg", llvm::cl::init(false),
     llvm::cl::desc("Enable the sil cfg viewer pass after diagnostics"));
 
+static llvm::cl::opt<bool> SILPrintCanonicalModule(
+    "sil-print-canonical-module", llvm::cl::init(false),
+    llvm::cl::desc("Print the textual SIL module after diagnostics"));
+
 static llvm::cl::opt<bool> SILViewSILGenCFG(
     "sil-view-silgen-cfg", llvm::cl::init(false),
     llvm::cl::desc("Enable the sil cfg viewer pass before diagnostics"));
@@ -62,6 +66,12 @@ static llvm::cl::opt<bool>
 static void addCFGPrinterPipeline(SILPassPipelinePlan &P, StringRef Name) {
   P.startPipeline(Name);
   P.addCFGPrinter();
+}
+
+static void addModulePrinterPipeline(SILPassPipelinePlan &plan,
+                                     StringRef name) {
+  plan.startPipeline(name);
+  plan.addModulePrinter();
 }
 
 static void addMandatoryDebugSerialization(SILPassPipelinePlan &P) {
@@ -189,6 +199,9 @@ SILPassPipelinePlan::getDiagnosticPassPipeline(const SILOptions &Options) {
 
   if (SILViewCanonicalCFG) {
     addCFGPrinterPipeline(P, "SIL View Canonical CFG");
+  }
+  if (SILPrintCanonicalModule) {
+    addModulePrinterPipeline(P, "SIL Print Canonical Module");
   }
   return P;
 }

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -43,8 +43,8 @@ static llvm::cl::opt<bool>
     SILViewCFG("sil-view-cfg", llvm::cl::init(false),
                llvm::cl::desc("Enable the sil cfg viewer pass"));
 
-static llvm::cl::opt<bool> SILViewGuaranteedCFG(
-    "sil-view-guaranteed-cfg", llvm::cl::init(false),
+static llvm::cl::opt<bool> SILViewCanonicalCFG(
+    "sil-view-canonical-cfg", llvm::cl::init(false),
     llvm::cl::desc("Enable the sil cfg viewer pass after diagnostics"));
 
 static llvm::cl::opt<bool> SILViewSILGenCFG(
@@ -187,8 +187,8 @@ SILPassPipelinePlan::getDiagnosticPassPipeline(const SILOptions &Options) {
   // Otherwise run the rest of diagnostics.
   addMandatoryDiagnosticOptPipeline(P);
 
-  if (SILViewGuaranteedCFG) {
-    addCFGPrinterPipeline(P, "SIL View Guaranteed CFG");
+  if (SILViewCanonicalCFG) {
+    addCFGPrinterPipeline(P, "SIL View Canonical CFG");
   }
   return P;
 }

--- a/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
+++ b/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(swiftSILOptimizer PRIVATE
   LoopInfoPrinter.cpp
   LoopRegionPrinter.cpp
   MemBehaviorDumper.cpp
+  ModulePrinter.cpp
   RCIdentityDumper.cpp
   SerializeSILPass.cpp
   SILDebugInfoGenerator.cpp

--- a/lib/SILOptimizer/UtilityPasses/ModulePrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/ModulePrinter.cpp
@@ -1,0 +1,38 @@
+//===--- ModulePrinter.cpp - Module printer pass --------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// A utility module pass to print the module as textual SIL.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/SILPrintContext.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+
+using namespace swift;
+
+namespace {
+
+class SILModulePrinter : public SILModuleTransform {
+
+  /// The entry point.
+  void run() override {
+    auto *module = getModule();
+    SILPrintContext context(llvm::outs(), /*Verbose*/ true, /*SortedSIL*/ true,
+                            /*PrintFullConvention*/ true);
+    module->print(context);
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createModulePrinter() { return new SILModulePrinter(); }


### PR DESCRIPTION
To print the module, use the new llvm flag -sil-print-guaranteed-module which parallels the existing flag -sil-view-guaranteed-cfg.  When that flag is passed, the new pass ModulePrinter is added to the diagnostic pass pipeline after mandatory diagnostics have run.  The new pass just prints the module to stdout.
