### PR TITLE
[CodeCompletion] Remove two completion options from LangOptions

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -230,14 +230,6 @@ namespace swift {
     /// Keep comments during lexing and attach them to declarations.
     bool AttachCommentsToDecls = false;
 
-    /// Whether to include initializers when code-completing a postfix
-    /// expression.
-    bool CodeCompleteInitsInPostfixExpr = false;
-
-    /// Whether to use heuristics to decide whether to show call-pattern
-    /// completions.
-    bool CodeCompleteCallPatternHeuristics = false;
-
     ///
     /// Flags for use by tests
     ///

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -947,6 +947,13 @@ struct CodeCompletionResultSink {
   /// Whether to emit object literals if desired.
   bool includeObjectLiterals = true;
 
+  /// Whether to emit type initializers in addition to type names in expression
+  /// position.
+  bool addInitsToTopLevel = false;
+
+  /// Whether to perform "call pettern heuristics".
+  bool enableCallPatternHeuristics = false;
+
   std::vector<CodeCompletionResult *> Results;
 
   /// A single-element cache for module names stored in Allocator, keyed by a
@@ -1021,7 +1028,23 @@ public:
   void setIncludeObjectLiterals(bool flag) {
     CurrentResults.includeObjectLiterals = flag;
   }
-  bool includeObjectLiterals() { return CurrentResults.includeObjectLiterals; }
+  bool includeObjectLiterals() const {
+    return CurrentResults.includeObjectLiterals;
+  }
+
+  void setAddInitsToTopLevel(bool flag) {
+    CurrentResults.addInitsToTopLevel = flag;
+  }
+  bool getAddInitsToTopLevel() const {
+    return CurrentResults.addInitsToTopLevel;
+  }
+
+  void setCallPatternHeuristics(bool flag) {
+    CurrentResults.enableCallPatternHeuristics = flag;
+  }
+  bool getCallPatternHeuristics() const {
+    return CurrentResults.enableCallPatternHeuristics;
+  }
 
   /// Allocate a string owned by the code completion context.
   StringRef copyString(StringRef Str);

--- a/include/swift/IDE/CodeCompletionCache.h
+++ b/include/swift/IDE/CodeCompletionCache.h
@@ -42,7 +42,7 @@ public:
     bool ResultsHaveLeadingDot;
     bool ForTestableLookup;
     bool ForPrivateImportLookup;
-    bool CodeCompleteInitsInPostfixExpr;
+    bool AddInitsInToplevel;
     bool Annotated;
 
     friend bool operator==(const Key &LHS, const Key &RHS) {
@@ -52,7 +52,8 @@ public:
         LHS.ResultsHaveLeadingDot == RHS.ResultsHaveLeadingDot &&
         LHS.ForTestableLookup == RHS.ForTestableLookup &&
         LHS.ForPrivateImportLookup == RHS.ForPrivateImportLookup &&
-        LHS.CodeCompleteInitsInPostfixExpr == RHS.CodeCompleteInitsInPostfixExpr;
+        LHS.AddInitsInToplevel == RHS.AddInitsInToplevel &&
+        LHS.Annotated == RHS.Annotated;
     }
   };
 
@@ -123,6 +124,7 @@ struct DenseMapInfo<swift::ide::CodeCompletionCache::Key> {
     H ^= std::hash<bool>()(Val.ResultsHaveLeadingDot);
     H ^= std::hash<bool>()(Val.ForTestableLookup);
     H ^= std::hash<bool>()(Val.ForPrivateImportLookup);
+    H ^= std::hash<bool>()(Val.AddInitsInToplevel);
     H ^= std::hash<bool>()(Val.Annotated);
     return static_cast<unsigned>(H);
   }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -501,12 +501,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
-  Opts.CodeCompleteInitsInPostfixExpr |=
-      Args.hasArg(OPT_code_complete_inits_in_postfix_expr);
-
-  Opts.CodeCompleteCallPatternHeuristics |=
-      Args.hasArg(OPT_code_complete_call_pattern_heuristics);
-
   if (auto A = Args.getLastArg(OPT_enable_target_os_checking,
                                OPT_disable_target_os_checking)) {
     Opts.EnableTargetOSChecking

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -293,7 +293,7 @@ static void writeCachedModule(llvm::raw_ostream &out,
     OSSLE.write(K.ResultsHaveLeadingDot);
     OSSLE.write(K.ForTestableLookup);
     OSSLE.write(K.ForPrivateImportLookup);
-    OSSLE.write(K.CodeCompleteInitsInPostfixExpr);
+    OSSLE.write(K.AddInitsInToplevel);
     OSSLE.write(K.Annotated);
     LE.write(static_cast<uint32_t>(OSS.tell()));   // Size of debug info
     out.write(OSS.str().data(), OSS.str().size()); // Debug info blob
@@ -404,7 +404,7 @@ static std::string getName(StringRef cacheDirectory,
   OSS << (K.ResultsHaveLeadingDot ? "-dot" : "")
       << (K.ForTestableLookup ? "-testable" : "")
       << (K.ForPrivateImportLookup ? "-private" : "")
-      << (K.CodeCompleteInitsInPostfixExpr ? "-inits" : "")
+      << (K.AddInitsInToplevel ? "-inits" : "")
       << (K.Annotated ? "-annotated" : "");
 
   // name[-access-path-components]

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.h
@@ -36,7 +36,7 @@ struct Options {
   bool addInnerResults = false;
   bool addInnerOperators = true;
   bool addInitsToTopLevel = false;
-  bool callPatternHeuristics = true;
+  bool callPatternHeuristics = false;
   bool hideUnderscores = true;
   bool reallyHideAllUnderscores = false;
   bool hideLowPriority = true;

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -466,7 +466,7 @@ CodeCompletionSourceText("code-completion-sourcetext",
                          llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
-CodeCOmpletionAnnotateResults("code-completion-annotate-results",
+CodeCompletionAnnotateResults("code-completion-annotate-results",
                               llvm::cl::desc("annotate completion results with XML"),
                               llvm::cl::cat(Category),
                               llvm::cl::init(false));
@@ -920,6 +920,8 @@ static int doCodeCompletion(const CompilerInvocation &InitInvok,
                             bool CodeCompletionKeywords,
                             bool CodeCompletionComments,
                             bool CodeCompletionAnnotateResults,
+                            bool CodeCompletionAddInitsToTopLevel,
+                            bool CodeCompletionCallPatternHeuristics,
                             bool CodeCompletionSourceText) {
   std::unique_ptr<ide::OnDiskCodeCompletionCache> OnDiskCache;
   if (!options::CompletionCachePath.empty()) {
@@ -929,6 +931,8 @@ static int doCodeCompletion(const CompilerInvocation &InitInvok,
   ide::CodeCompletionCache CompletionCache(OnDiskCache.get());
   ide::CodeCompletionContext CompletionContext(CompletionCache);
   CompletionContext.setAnnotateResult(CodeCompletionAnnotateResults);
+  CompletionContext.setAddInitsToTopLevel(CodeCompletionAddInitsToTopLevel);
+  CompletionContext.setCallPatternHeuristics(CodeCompletionCallPatternHeuristics);
 
   // Create a CodeCompletionConsumer.
   std::unique_ptr<ide::CodeCompletionConsumer> Consumer(
@@ -1125,6 +1129,8 @@ static int doBatchCodeCompletion(const CompilerInvocation &InitInvok,
                                  bool CodeCompletionKeywords,
                                  bool CodeCompletionComments,
                                  bool CodeCompletionAnnotateResults,
+                                 bool CodeCompletionAddInitsToTopLevel,
+                                 bool CodeCompletionCallPatternHeuristics,
                                  bool CodeCompletionSourceText) {
   auto FileBufOrErr = llvm::MemoryBuffer::getFile(SourceFilename);
   if (!FileBufOrErr) {
@@ -1267,6 +1273,8 @@ static int doBatchCodeCompletion(const CompilerInvocation &InitInvok,
           // Consumer.
           ide::CodeCompletionContext CompletionContext(CompletionCache);
           CompletionContext.setAnnotateResult(CodeCompletionAnnotateResults);
+          CompletionContext.setAddInitsToTopLevel(CodeCompletionAddInitsToTopLevel);
+          CompletionContext.setCallPatternHeuristics(CodeCompletionCallPatternHeuristics);
           std::unique_ptr<CodeCompletionCallbacksFactory> callbacksFactory(
               ide::makeCodeCompletionCallbacksFactory(CompletionContext,
                                                       *Consumer));
@@ -3822,7 +3830,7 @@ int main(int argc, char *argv[]) {
         llvm::outs(), options::CodeCompletionKeywords,
         options::CodeCompletionComments,
         options::CodeCompletionSourceText,
-        options::CodeCOmpletionAnnotateResults);
+        options::CodeCompletionAnnotateResults);
     for (StringRef filename : options::InputFilenames) {
       auto resultsOpt = ide::OnDiskCodeCompletionCache::getFromFile(filename);
       if (!resultsOpt) {
@@ -3946,10 +3954,6 @@ int main(int argc, char *argv[]) {
     options::ImportObjCHeader;
   InitInvok.getLangOptions().EnableAccessControl =
     !options::DisableAccessControl;
-  InitInvok.getLangOptions().CodeCompleteInitsInPostfixExpr |=
-      options::CodeCompleteInitsInPostfixExpr;
-  InitInvok.getLangOptions().CodeCompleteCallPatternHeuristics |=
-      options::CodeCompleteCallPatternHeuristics;
   InitInvok.getLangOptions().EnableSwift3ObjCInference =
     options::EnableSwift3ObjCInference;
   InitInvok.getClangImporterOptions().ImportForwardDeclarations |=
@@ -4057,7 +4061,9 @@ int main(int argc, char *argv[]) {
                                      options::CodeCompletionDiagnostics,
                                      options::CodeCompletionKeywords,
                                      options::CodeCompletionComments,
-                                     options::CodeCOmpletionAnnotateResults,
+                                     options::CodeCompletionAnnotateResults,
+                                     options::CodeCompleteInitsInPostfixExpr,
+                                     options::CodeCompleteCallPatternHeuristics,
                                      options::CodeCompletionSourceText);
     break;
 
@@ -4073,7 +4079,9 @@ int main(int argc, char *argv[]) {
                                 options::CodeCompletionDiagnostics,
                                 options::CodeCompletionKeywords,
                                 options::CodeCompletionComments,
-                                options::CodeCOmpletionAnnotateResults,
+                                options::CodeCompletionAnnotateResults,
+                                options::CodeCompleteInitsInPostfixExpr,
+                                options::CodeCompleteCallPatternHeuristics,
                                 options::CodeCompletionSourceText);
     break;
 


### PR DESCRIPTION
Move "add inits to toplevel" and "call pattern heuristics" from `LangOptions` to `CodeCompletionContext`. They are only used in code completion.