### PR TITLE
[TypeChecker] Prevent pattern resolution from triggering type-checking for unresolved references

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1661,6 +1661,14 @@ Optional<BraceStmt *> TypeChecker::applyResultBuilderBodyTransform(
   // Build a constraint system in which we can check the body of the function.
   ConstraintSystem cs(func, options);
 
+  if (cs.isDebugMode()) {
+    auto &log = llvm::errs();
+
+    log << "--- Applying result builder to function ---\n";
+    func->dump(log);
+    log << '\n';
+  }
+
   if (auto result = cs.matchResultBuilder(
           func, builderType, resultContextType, resultConstraintKind,
           cs.getConstraintLocator(func->getBody()))) {

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -85,20 +85,6 @@ filterForEnumElement(DeclContext *DC, SourceLoc UseLoc,
     ValueDecl *e = result.getValueDecl();
     assert(e);
 
-    // Check `isInvalid` only if the declaration has been
-    // verified, otherwise this would cause a problem if
-    // this declaration is found in the body of a result
-    // builder because it wouldn't have a type set until
-    // whole body is type-checked, and `isInvalid` would
-    // trigger a separate type-check that interfers with
-    // result builder transformation and causes crashes.
-    //
-    // Note: This check cannot simply be removed because
-    // enums with re-declarationed members would trigger
-    // an ambiguity assertion below.
-    if (e->hasInterfaceType() && e->isInvalid())
-      continue;
-
     // Skip if the enum element was referenced as an instance member
     if (unqualifiedLookup) {
       if (!result.getBaseDecl() ||
@@ -108,8 +94,10 @@ filterForEnumElement(DeclContext *DC, SourceLoc UseLoc,
     }
 
     if (auto *oe = dyn_cast<EnumElementDecl>(e)) {
-      // Ambiguities should be ruled out by parsing.
-      assert(!foundElement && "ambiguity in enum case name lookup?!");
+      // Note that there could be multiple elements with the same
+      // name, such results in a re-declaration error, so let's
+      // just always pick the last element, just like in `foundConstant`
+      // case.
       foundElement = oe;
       continue;
     }

--- a/test/Constraints/result_builder.swift
+++ b/test/Constraints/result_builder.swift
@@ -582,6 +582,26 @@ func testSwitch(_ e: E) {
   }
 }
 
+func testExistingPatternsInCaseStatements() {
+  tuplify(true) { c in
+    switch false {
+    case (c): 1 // Ok
+    default:  0
+    }
+  }
+
+  var arr: [Int] = []
+
+  tuplify(true) { c in
+    let n = arr.endIndex
+
+    switch arr.startIndex {
+    case (n): 1 // Ok
+    default:  0
+    }
+  }
+}
+
 // CHECK: testSwitch
 // CHECK-SAME: first(main.Either<Swift.String, (Swift.Int, Swift.String)>.first("a"))
 testSwitch(getE(0))


### PR DESCRIPTION
Workaround for Clang enum typaliases called `isInvalid()` and `getInterfaceType()`
on discovered declarations. That doesn't play well with result builders because
declarations/patterns used in the body of a result builder don't get a type until
a solution is applied. Calling `isInvalid()` or `getInterfaceType` on declarations
located in the body of a result builder trigger a separate type-check for the
declaration that interferes with builder transformation and leads to crashes.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
