### PR TITLE
[ClangImporter] Pass -mcx16 to Clang invocation for all x86_64 targets

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -781,8 +781,9 @@ importer::addCommonInvocationArguments(
     invocationArgStrs.push_back("-march=z13");
   }
 
-  if (triple.isOSLinux() && triple.getArch() == llvm::Triple::x86_64) {
-    // Enable double wide atomic intrinsics for x86_64 archs on Linux.
+  if (triple.getArch() == llvm::Triple::x86_64) {
+    // Enable double wide atomic intrinsics on every x86_64 target.
+    // (This is the default on Darwin, but not so on other platforms.)
     invocationArgStrs.push_back("-mcx16");
   }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -781,6 +781,11 @@ importer::addCommonInvocationArguments(
     invocationArgStrs.push_back("-march=z13");
   }
 
+  if (triple.isOSLinux() && triple.getArch() == llvm::Triple::x86_64) {
+    // Enable double wide atomic intrinsics for x86_64 archs on Linux.
+    invocationArgStrs.push_back("-mcx16");
+  }
+
   if (!importerOpts.Optimization.empty()) {
     invocationArgStrs.push_back(importerOpts.Optimization);
   }

--- a/test/IRGen/cx16.swift
+++ b/test/IRGen/cx16.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -target x86_64-unknown-linux-gnu -parse-stdlib -disable-objc-interop %s -module-name main -emit-ir -o - | %FileCheck %s
-// RUN: %target-swift-frontend -target x86_64-unknown-windows-msvc -parse-stdlib -disable-objc-interop %s -module-name main -emit-ir -o - | %FileCheck %s
-// RUN: %target-swift-frontend -target x86_64-unknown-freebsd -parse-stdlib -disable-objc-interop %s -module-name main -emit-ir -o - | %FileCheck %s
-// RUN: %target-swift-frontend -target x86_64-apple-macosx10.9 -parse-stdlib -module-name main %s -emit-ir -o - | %FileCheck %s
+// RUN: %target-swift-frontend -target x86_64-unknown-linux-gnu -disable-legacy-type-info -parse-stdlib -disable-objc-interop %s -module-name main -emit-ir -o - | %FileCheck %s
+// RUN: %target-swift-frontend -target x86_64-unknown-windows-msvc -disable-legacy-type-info -parse-stdlib -disable-objc-interop %s -module-name main -emit-ir -o - | %FileCheck %s
+// RUN: %target-swift-frontend -target x86_64-unknown-freebsd -disable-legacy-type-info -parse-stdlib -disable-objc-interop %s -module-name main -emit-ir -o - | %FileCheck %s
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.9 -disable-legacy-type-info -parse-stdlib -module-name main %s -emit-ir -o - | %FileCheck %s
 
 // REQUIRES: CODEGENERATOR=X86
 

--- a/test/IRGen/cx16.swift
+++ b/test/IRGen/cx16.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -target x86_64-unknown-linux-gnu -parse-stdlib -disable-objc-interop %s -module-name main -emit-ir -o - | %FileCheck %s
+// RUN: %target-swift-frontend -target x86_64-unknown-windows-msvc -parse-stdlib -disable-objc-interop %s -module-name main -emit-ir -o - | %FileCheck %s
+// RUN: %target-swift-frontend -target x86_64-unknown-freebsd -parse-stdlib -disable-objc-interop %s -module-name main -emit-ir -o - | %FileCheck %s
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.9 -parse-stdlib -module-name main %s -emit-ir -o - | %FileCheck %s
+
+// REQUIRES: CODEGENERATOR=X86
+
+public func test() {
+}
+
+// We expect double-wide atomic intrinsics to always be available on x86_64.
+// CHECK: "target-features"="{{.*}}+cx16,


### PR DESCRIPTION
The Swift runtime and the concurrency module both use -mcx16, so there seems to be little point in not enabling it for Swift code in general.

This allows packages like [swift-atomics](https://github.com/apple/swift-atomics) to rely on double wide atomics always being available. 

(They can't enable this on their own, as `-mcx16` is considered an "unsafe" compiler option; worse, AFAIK there isn't even a way to detect whether cx16 is available from Swift code.  So swift-atomics clients on Linux/x86_64 must manually enable this feature by specifying `-Xcc -mcx16 -Xswiftc -DENABLE_DOUBLEWIDE_ATOMICS` while building their code. This is terrible.)

https://bugs.swift.org/browse/SR-13781
