### PR TITLE
[build] Add copy_shim_headers to all target

### DIFF
--- a/stdlib/public/SwiftShims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/CMakeLists.txt
@@ -69,7 +69,7 @@ endforeach()
 # Put the output dir itself last so that it isn't considered the primary output.
 list(APPEND outputs "${output_dir}")
 
-add_custom_target("copy_shim_headers"
+add_custom_target("copy_shim_headers" ALL
     DEPENDS "${outputs}"
     COMMENT "Copying SwiftShims module to ${output_dir}")
 


### PR DESCRIPTION
Currently `copy_shim_headers` is only invoked as a dependency to `swiftCore`. It isn't invoked at all when you are not building the stdlib, resulting in a broken compiler in the build directory because there is no `clang` resource directory where it expects it (via `symlink_clang_headers`).

Adding it to the `all` target fixes the issue, so it can be run without compiling `swiftCore`.