### PR TITLE
[Concurrent] Warnings/errors should use "sendable" not "concurrent"

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -676,9 +676,9 @@ WARNING(semantic_function_improper_nesting, none, "'@_semantics' function calls 
 
 // Capture promotion diagnostics
 WARNING(capturepromotion_concurrentcapture_mutation, none,
-        "'%0' mutated after capture by concurrent closure", (StringRef))
+        "'%0' mutated after capture by sendable closure", (StringRef))
 NOTE(capturepromotion_concurrentcapture_closure_here, none,
-     "variable captured by concurrent closure", ())
+     "variable captured by sendable closure", ())
 NOTE(capturepromotion_concurrentcapture_capturinguse_here, none,
      "capturing use", ())
 NOTE(capturepromotion_variable_defined_here,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3883,28 +3883,28 @@ NOTE(silence_debug_description_in_interpolation_segment_call,none,
      "use 'String(describing:)' to silence this warning", ())
 
 NOTE(noescape_parameter,none,
-    "parameter %1 is implicitly %select{non-escaping|non-concurrent}0",
+    "parameter %1 is implicitly %select{non-escaping|non-sendable}0",
      (unsigned, Identifier))
 NOTE(generic_parameters_always_escaping,none,
      "generic parameters are always considered '@escaping'", ())
 
 ERROR(passing_noattrfunc_to_attrfunc,none,
-      "passing %select{non-escaping|non-concurrent}0 parameter %1 to function "
+      "passing %select{non-escaping|non-sendable}0 parameter %1 to function "
       "expecting %select{an @escaping|a @Sendable}0 closure",
       (unsigned, Identifier))
 ERROR(converting_noespace_param_to_generic_type,none,
       "converting non-escaping parameter %0 to generic parameter %1 may allow it to escape",
       (Identifier, Type))
 ERROR(assigning_noattrfunc_to_attrfunc,none,
-      "assigning %select{non-escaping|non-concurrent}0 parameter %1 to "
+      "assigning %select{non-escaping|non-sendable}0 parameter %1 to "
       "%select{an @escaping|a @Sendable}0 closure",
       (unsigned, Identifier))
 ERROR(general_noattrfunc_to_attr,none,
-      "using %select{non-escaping|non-concurrent}0 parameter %1 in a context "
+      "using %select{non-escaping|non-sendable}0 parameter %1 in a context "
       "expecting %select{an @escaping|a @Sendable}0 closure",
       (unsigned, Identifier))
 ERROR(converting_noattrfunc_to_type,none,
-      "converting %select{non-escaping|non-concurrent function}0 value to %1 "
+      "converting %select{non-escaping|non-sendable function}0 value to %1 "
       "may %select{allow it to escape|introduce data races}0",
       (unsigned, Type))
 NOTE(escape_expected_at_parameter_position,none,

--- a/include/swift/Runtime/Concurrent.h
+++ b/include/swift/Runtime/Concurrent.h
@@ -63,7 +63,7 @@ template <class ElemTy> struct ConcurrentList {
 
   /// Remove all of the links in the chain. This method leaves
   /// the list at a usable state and new links can be added.
-  /// Notice that this operation is non-concurrent because
+  /// Notice that this operation is non-sendable because
   /// we have no way of ensuring that no one is currently
   /// traversing the list.
   void clear() {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -754,7 +754,7 @@ public:
   bool diagnoseAsError() override;
 
 private:
-  /// Emit tailored diagnostics for no-escape/non-concurrent parameter
+  /// Emit tailored diagnostics for no-escape/non-sendable parameter
   /// conversions e.g. passing such parameter as an @escaping or @Sendable
   /// argument, or trying to assign it to a variable which expects @escaping
   /// or @Sendable function.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1629,7 +1629,7 @@ namespace {
       }
 
       if (result == AsyncMarkingResult::FoundAsync) {
-        // Check for non-concurrent types.
+        // Check for non-sendable types.
         bool problemFound =
             diagnoseNonSendableTypesInReference(
               concDeclRef, getDeclContext()->getParentModule(), declLoc,

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -218,7 +218,7 @@ void checkOverrideActorIsolation(ValueDecl *value);
 /// as async functions or actors.
 bool contextUsesConcurrencyFeatures(const DeclContext *dc);
 
-/// Diagnose the presence of any non-concurrent types when referencing a
+/// Diagnose the presence of any non-sendable types when referencing a
 /// given declaration from a particular declaration context.
 ///
 /// This function should be invoked any time that the given declaration

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2932,7 +2932,7 @@ bool ConformanceChecker::checkActorIsolation(
       witnessGlobalActor->isEqual(requirementGlobalActor))
     return false;
 
-  // For cross-actor references, check for non-concurrent types.
+  // For cross-actor references, check for non-sendable types.
   if (isCrossActor) {
     // If the requirement was imported from Objective-C, it may not have been
     // annotated appropriately. Allow the mismatch.

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -90,9 +90,9 @@ func testSlowServerOldSchool(slowServer: SlowServer) {
   _ = slowServer.allOperations
 }
 
-func testSendable(fn: () -> Void) { // expected-note{{parameter 'fn' is implicitly non-concurrent}}
+func testSendable(fn: () -> Void) { // expected-note{{parameter 'fn' is implicitly non-sendable}}
   doSomethingConcurrently(fn)
-  // expected-error@-1{{passing non-concurrent parameter 'fn' to function expecting a @Sendable closure}}
+  // expected-error@-1{{passing non-sendable parameter 'fn' to function expecting a @Sendable closure}}
   doSomethingConcurrentlyButUnsafe(fn) // okay, @Sendable not part of the type
 
   var x = 17

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -603,7 +603,7 @@ func checkLocalFunctions() async {
   local1()
   local2()
 
-  // Non-concurrent closures don't cause problems.
+  // non-sendable closures don't cause problems.
   acceptClosure {
     local1()
     local2()

--- a/test/Concurrency/concurrentfunction_capturediagnostics.swift
+++ b/test/Concurrency/concurrentfunction_capturediagnostics.swift
@@ -29,9 +29,9 @@ func testCaseTrivialValue() {
   // We only emit a warning here since we use the last write.
   //
   // TODO: Should we emit for all writes?
-  i.addOne() // expected-warning {{'i' mutated after capture by concurrent closure}}
+  i.addOne() // expected-warning {{'i' mutated after capture by sendable closure}}
              // expected-note @-14 {{variable defined here}}
-             // expected-note @-14 {{variable captured by concurrent closure}}
+             // expected-note @-14 {{variable captured by sendable closure}}
              // expected-note @-14 {{capturing use}}
              // expected-note @-14 {{capturing use}}
              // expected-note @-14 {{capturing use}}
@@ -46,9 +46,9 @@ func testCaseTrivialValue2() {
   }
 
   i2 = 20
-  i2 += 21 // expected-warning {{'i2' mutated after capture by concurrent closure}}
+  i2 += 21 // expected-warning {{'i2' mutated after capture by sendable closure}}
              // expected-note @-9 {{variable defined here}}
-             // expected-note @-9 {{variable captured by concurrent closure}}
+             // expected-note @-9 {{variable captured by sendable closure}}
              // expected-note @-9 {{capturing use}}
              // expected-note @-9 {{capturing use}}
              // expected-note @-9 {{capturing use}}
@@ -62,9 +62,9 @@ func testCaseTrivialValue3() {
     print(i3 + 19)
   }
 
-  i3 = 20 // expected-warning {{'i3' mutated after capture by concurrent closure}}
+  i3 = 20 // expected-warning {{'i3' mutated after capture by sendable closure}}
           // expected-note @-8 {{variable defined here}}
-          // expected-note @-8 {{variable captured by concurrent closure}}
+          // expected-note @-8 {{variable captured by sendable closure}}
           // expected-note @-8 {{capturing use}}
           // expected-note @-8 {{capturing use}}
           // expected-note @-8 {{capturing use}}
@@ -78,9 +78,9 @@ func testCaseTrivialValue4() {
     print(i4 + 19)
   }
 
-  inoutUserInt(&i4) // expected-warning {{'i4' mutated after capture by concurrent closure}}
+  inoutUserInt(&i4) // expected-warning {{'i4' mutated after capture by sendable closure}}
                     // expected-note @-8 {{variable defined here}}
-                    // expected-note @-8 {{variable captured by concurrent closure}}
+                    // expected-note @-8 {{variable captured by sendable closure}}
                     // expected-note @-8 {{capturing use}}
                     // expected-note @-8 {{capturing use}}
                     // expected-note @-8 {{capturing use}}
@@ -98,9 +98,9 @@ func testCaseClass() {
     print(i)
   }
 
-  i = Klass() // expected-warning {{'i' mutated after capture by concurrent closure}}
+  i = Klass() // expected-warning {{'i' mutated after capture by sendable closure}}
               // expected-note @-6 {{variable defined here}}
-              // expected-note @-6 {{variable captured by concurrent closure}}
+              // expected-note @-6 {{variable captured by sendable closure}}
               // expected-note @-6 {{capturing use}}
 }
 
@@ -109,9 +109,9 @@ func testCaseClassInout() {
   f {
     print(i2)
   }
-  inoutUserKlass(&i2) // expected-warning {{'i2' mutated after capture by concurrent closure}}
+  inoutUserKlass(&i2) // expected-warning {{'i2' mutated after capture by sendable closure}}
                       // expected-note @-5 {{variable defined here}}
-                      // expected-note @-5 {{variable captured by concurrent closure}}
+                      // expected-note @-5 {{variable captured by sendable closure}}
                       // expected-note @-5 {{capturing use}}
 }
 
@@ -154,9 +154,9 @@ func testCaseNonTrivialValue() {
   // We only emit a warning here since we use the last write.
   //
   // TODO: Should we emit for all writes?
-  i.i.addOne() // expected-warning {{'i' mutated after capture by concurrent closure}}
+  i.i.addOne() // expected-warning {{'i' mutated after capture by sendable closure}}
                // expected-note @-14 {{variable defined here}}
-               // expected-note @-14 {{variable captured by concurrent closure}}
+               // expected-note @-14 {{variable captured by sendable closure}}
                // expected-note @-14 {{capturing use}}
                // expected-note @-14 {{capturing use}}
                // expected-note @-14 {{capturing use}}
@@ -170,9 +170,9 @@ func testCaseNonTrivialValueInout() {
   }
 
   // We only emit a warning here since we use the last write.
-  inoutUserOptKlass(&i.k) // expected-warning {{'i' mutated after capture by concurrent closure}}
+  inoutUserOptKlass(&i.k) // expected-warning {{'i' mutated after capture by sendable closure}}
                           // expected-note @-8 {{variable defined here}}
-                          // expected-note @-8 {{variable captured by concurrent closure}}
+                          // expected-note @-8 {{variable captured by sendable closure}}
                           // expected-note @-8 {{capturing use}}
                           // expected-note @-8 {{capturing use}}
 }
@@ -190,9 +190,9 @@ func testCaseAddressOnlyAllocBoxToStackable<T : MyProt & Sendable>(i : T) {
   }
 
   // TODO: Make sure we emit these once we support address only types!
-  inoutUserOptKlass(&i2.k) // xpected-warning {{'i2' mutated after capture by concurrent closure}}
+  inoutUserOptKlass(&i2.k) // xpected-warning {{'i2' mutated after capture by sendable closure}}
                            // xpected-note @-8 {{variable defined here}}
-                           // xpected-note @-8 {{variable captured by concurrent closure}}
+                           // xpected-note @-8 {{variable captured by sendable closure}}
                            // xpected-note @-8 {{capturing use}}
                            // xpected-note @-8 {{capturing use}}
 }
@@ -208,9 +208,9 @@ func testCaseAddressOnlyNoAllocBoxToStackable<T : MyProt & Sendable>(i : T) {
   }
 
   // TODO: Make sure we emit these once we support address only types!
-  inoutUserOptKlass(&i2.k) // xpected-warning {{'i2' mutated after capture by concurrent closure}}
+  inoutUserOptKlass(&i2.k) // xpected-warning {{'i2' mutated after capture by sendable closure}}
                            // xpected-note @-8 {{variable defined here}}
-                           // xpected-note @-8 {{variable captured by concurrent closure}}
+                           // xpected-note @-8 {{variable captured by sendable closure}}
                            // xpected-note @-8 {{capturing use}}
                            // xpected-note @-8 {{capturing use}}
 }

--- a/test/attr/attr_concurrent.swift
+++ b/test/attr/attr_concurrent.swift
@@ -22,14 +22,14 @@ func acceptsNonConcurrent(_ fn: (Int) -> Int) { }
 
 func passingConcurrentOrNot(
   _ cfn: @Sendable (Int) -> Int,
-  ncfn: (Int) -> Int // expected-note{{parameter 'ncfn' is implicitly non-concurrent}}{{9-9=@Sendable }}
+  ncfn: (Int) -> Int // expected-note{{parameter 'ncfn' is implicitly non-sendable}}{{9-9=@Sendable }}
 ) {
   // Okay due to overloading
   f(cfn)
   f(ncfn)
 
   acceptsConcurrent(cfn) // okay
-  acceptsConcurrent(ncfn) // expected-error{{passing non-concurrent parameter 'ncfn' to function expecting a @Sendable closure}}
+  acceptsConcurrent(ncfn) // expected-error{{passing non-sendable parameter 'ncfn' to function expecting a @Sendable closure}}
   acceptsNonConcurrent(cfn) // okay
   acceptsNonConcurrent(ncfn) // okay
 
@@ -49,8 +49,8 @@ func closures() {
       return i
     })
 
-  let closure1 = { $0 + 1 } // inferred to be non-concurrent
-  acceptsConcurrent(closure1) // expected-error{{converting non-concurrent function value to '@Sendable (Int) -> Int' may introduce data races}}
+  let closure1 = { $0 + 1 } // inferred to be non-sendable
+  acceptsConcurrent(closure1) // expected-error{{converting non-sendable function value to '@Sendable (Int) -> Int' may introduce data races}}
 }
 
 // Mutation of captured locals from within @Sendable functions.


### PR DESCRIPTION
Resolves rdar://83416205

We used to have a notion of "concurrent closures" etc before `Sendable` was a thing. Seems we still use this wording in some of the errors / warnings. This fixes the old wording to use "sendable" instead.