### PR TITLE
Avoid including "llvm/Config/config.h" in the concurrency back-deploy library

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -34,7 +34,9 @@
 #include "swift/Runtime/ThreadLocalStorage.h"
 #include "swift/ABI/Task.h"
 #include "swift/ABI/Actor.h"
+#ifndef SWIFT_CONCURRENCY_BACK_DEPLOYMENT
 #include "llvm/Config/config.h"
+#endif
 #include "llvm/ADT/PointerIntPair.h"
 #include "TaskPrivate.h"
 #include "VoucherSupport.h"

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -36,6 +36,11 @@
 #include "swift/ABI/Actor.h"
 #ifndef SWIFT_CONCURRENCY_BACK_DEPLOYMENT
 #include "llvm/Config/config.h"
+#else
+// All platforms where we care about back deployment have a known
+// configurations.
+#define HAVE_PTHREAD_H 1
+#define SWIFT_OBJC_INTEROP 1
 #endif
 #include "llvm/ADT/PointerIntPair.h"
 #include "TaskPrivate.h"


### PR DESCRIPTION
We only build for one flavor of platforms anyway, and have generally avoided
these macros.
