### PR TITLE
ModuleInterface: sanitize long version numbers when collecting user versions from textual interface files

### DIFF
--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1067,6 +1067,10 @@ swift::extractUserModuleVersionFromInterface(StringRef moduleInterfacePath) {
       // Check the version number specified via -user-module-version.
       StringRef current(args[I]), next(args[I + 1]);
       if (current == "-user-module-version") {
+        // Sanitize versions that are too long
+        while(next.count('.') > 3) {
+          next = next.rsplit('.').first;
+        }
         result.tryParse(next);
         break;
       }

--- a/test/Parse/versioned_canimport.swift
+++ b/test/Parse/versioned_canimport.swift
@@ -4,7 +4,7 @@
 // RUN: %empty-directory(%t/module-cache)
 
 // RUN: echo "public func foo() {}" > %t/Foo.swift
-// RUN: %target-swift-frontend -emit-module %t/Foo.swift -module-name Foo -swift-version 5 -disable-implicit-concurrency-module-import -user-module-version 113.330 -emit-module-interface-path %t/textual/Foo.swiftinterface -enable-library-evolution -emit-module-path %t/binary/Foo.swiftmodule
+// RUN: %target-swift-frontend -emit-module %t/Foo.swift -module-name Foo -swift-version 5 -disable-implicit-concurrency-module-import -user-module-version 113.330.1.2.3 -emit-module-interface-path %t/textual/Foo.swiftinterface -enable-library-evolution -emit-module-path %t/binary/Foo.swiftmodule
 // RUN: %target-swift-frontend -emit-module %t/Foo.swift -module-name Bar -swift-version 5 -disable-implicit-concurrency-module-import -emit-module-interface-path %t/textual/Bar.swiftinterface -enable-library-evolution -emit-module-path %t/binary/Bar.swiftmodule
 
 // RUN: %target-typecheck-verify-swift -disable-implicit-concurrency-module-import -I %t/textual


### PR DESCRIPTION
Some Swift module versions are beyond the scope of `llvm::VersionTuple()`, therefore we need to sanitize the most
trivial bits so that we can handle most cases in versioned `canImport` queries.

