### PR TITLE
[Compiler] Fixit for `override func` that should be `override var`

### DIFF
--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -534,6 +534,9 @@ static void diagnoseGeneralOverrideFailure(ValueDecl *decl,
                                            ArrayRef<OverrideMatch> matches,
                                            OverrideCheckingAttempt attempt) {
   auto &diags = decl->getASTContext().Diags;
+  if (cases where you have a property trying to override a no-args function on base class and vice-versa) {
+      fixitOverride(decl,diags)
+  }
 
   switch (attempt) {
   case OverrideCheckingAttempt::PerfectMatch:


### PR DESCRIPTION
add a special case to diagnoseGeneralOverrideFailure that tries to see if it can correct no-args FuncDecls to VarDecls and vice-versa.
Resolves SR-15176.

