### PR TITLE
[CodeComplete] Don't crash if solution doesn't contain a type for the parsed expression

### DIFF
--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -1057,6 +1057,11 @@ fallbackTypeCheck(DeclContext *DC) {
 }
 
 static Type getTypeForCompletion(const constraints::Solution &S, Expr *E) {
+  if (!S.hasType(E)) {
+    assert(false && "Expression wasn't type checked?");
+    return nullptr;
+  }
+
   auto &CS = S.getConstraintSystem();
 
   // To aid code completion, we need to attempt to convert type placeholders


### PR DESCRIPTION
In rdar://82027315 we are trying to retrieve the type of an `ASTNode` that doesn’t have a type associated with it in the solution from `getTypeForCompletion`.

This shouldn’t happen but we shouldn’t crash because of it, either. Since we already have handling logic for null types returned by `getTypeForCompletion` in place, I’m adding a check if the solution contains a type for the given node. If not, we’re causing an assertion failure and are returning a null type in non-assert builds.

rdar://82027315