### PR TITLE
[test] Add REQUIRES: CPU=x86_64 to test that is failing in CI

### DIFF
--- a/test/Concurrency/Backdeploy/linking.swift
+++ b/test/Concurrency/Backdeploy/linking.swift
@@ -8,6 +8,7 @@
 // RUN: otool -L %t/linking_rpath_old | %FileCheck -check-prefix CHECK-RPATH %s
 
 // REQUIRES: OS=macosx
+// REQUIRES: CPU=x86_64
 
 // CHECK-DIRECT: /usr/lib/swift/libswift_Concurrency.dylib
 // CHECK-RPATH: @rpath/libswift_Concurrency.dylib


### PR DESCRIPTION
Failing on macOS-arm64 job.