### PR TITLE
Replace inferrable types before binding literals to contextual type

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1732,8 +1732,9 @@ namespace {
 
       // If a contextual type exists for this expression, apply it directly.
       if (contextualType && ConstraintSystem::isArrayType(contextualType)) {
-        contextualType = CS.replaceInferableTypesWithTypeVars(
-            contextualType, CS.getConstraintLocator(expr));
+        // Now that we know we're actually going to use the type, get the
+        // version for use in a constraint.
+        contextualType = CS.getContextualType(expr, /*forConstraint=*/true);
         Optional<Type> arrayElementType =
             ConstraintSystem::isArrayType(contextualType);
         CS.addConstraint(ConstraintKind::LiteralConformsTo, contextualType,
@@ -1838,15 +1839,18 @@ namespace {
       auto locator = CS.getConstraintLocator(expr);
       auto contextualType = CS.getContextualType(expr);
       auto contextualPurpose = CS.getContextualTypePurpose(expr);
-      auto openedType =
-          CS.openOpaqueType(contextualType, contextualPurpose, locator);
 
       // If a contextual type exists for this expression and is a dictionary
       // type, apply it directly.
-      if (openedType && ConstraintSystem::isDictionaryType(openedType)) {
+      if (contextualType && ConstraintSystem::isDictionaryType(contextualType)) {
+        // Now that we know we're actually going to use the type, get the
+        // version for use in a constraint.
+        contextualType = CS.getContextualType(expr, /*forConstraint=*/true);
+        auto openedType =
+            CS.openOpaqueType(contextualType, contextualPurpose, locator);
         openedType = CS.replaceInferableTypesWithTypeVars(
             openedType, CS.getConstraintLocator(expr));
-        Optional<std::pair<Type, Type>> dictionaryKeyValue =
+        auto dictionaryKeyValue =
             ConstraintSystem::isDictionaryType(openedType);
         Type contextualDictionaryKeyType;
         Type contextualDictionaryValueType;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1731,9 +1731,11 @@ namespace {
       };
 
       // If a contextual type exists for this expression, apply it directly.
-      Optional<Type> arrayElementType;
-      if (contextualType &&
-          (arrayElementType = ConstraintSystem::isArrayType(contextualType))) {
+      if (contextualType && ConstraintSystem::isArrayType(contextualType)) {
+        contextualType = CS.replaceInferableTypesWithTypeVars(
+            contextualType, CS.getConstraintLocator(expr));
+        Optional<Type> arrayElementType =
+            ConstraintSystem::isArrayType(contextualType);
         CS.addConstraint(ConstraintKind::LiteralConformsTo, contextualType,
                          arrayProto->getDeclaredInterfaceType(),
                          locator);
@@ -1841,9 +1843,11 @@ namespace {
 
       // If a contextual type exists for this expression and is a dictionary
       // type, apply it directly.
-      Optional<std::pair<Type, Type>> dictionaryKeyValue;
-      if (openedType && (dictionaryKeyValue =
-                             ConstraintSystem::isDictionaryType(openedType))) {
+      if (openedType && ConstraintSystem::isDictionaryType(openedType)) {
+        openedType = CS.replaceInferableTypesWithTypeVars(
+            openedType, CS.getConstraintLocator(expr));
+        Optional<std::pair<Type, Type>> dictionaryKeyValue =
+            ConstraintSystem::isDictionaryType(openedType);
         Type contextualDictionaryKeyType;
         Type contextualDictionaryValueType;
         std::tie(contextualDictionaryKeyType,

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -180,8 +180,9 @@ Solution ConstraintSystem::finalize() {
   }
 
   // Remember contextual types.
-  solution.contextualTypes.assign(
-      contextualTypes.begin(), contextualTypes.end());
+  for (auto &entry : contextualTypes) {
+    solution.contextualTypes.push_back({entry.first, entry.second.first});
+  }
 
   solution.solutionApplicationTargets = solutionApplicationTargets;
   solution.caseLabelItems = caseLabelItems;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1116,9 +1116,10 @@ void ConstraintSystem::print(raw_ostream &out) const {
   
   out << "Score: " << CurrentScore << "\n";
 
-  for (const auto &contextualType : contextualTypes) {
-    out << "Contextual Type: " << contextualType.second.getType().getString(PO);
-    if (TypeRepr *TR = contextualType.second.typeLoc.getTypeRepr()) {
+  for (const auto &contextualTypeEntry : contextualTypes) {
+    auto info = contextualTypeEntry.second.first;
+    out << "Contextual Type: " << info.getType().getString(PO);
+    if (TypeRepr *TR = info.typeLoc.getTypeRepr()) {
       out << " at ";
       TR->getSourceRange().print(out, getASTContext().SourceMgr, /*text*/false);
     }

--- a/unittests/Sema/CMakeLists.txt
+++ b/unittests/Sema/CMakeLists.txt
@@ -3,7 +3,8 @@ add_swift_unittest(swiftSemaTests
   SemaFixture.cpp
   BindingInferenceTests.cpp
   ConstraintSimplificationTests.cpp
-  UnresolvedMemberLookupTests.cpp)
+  UnresolvedMemberLookupTests.cpp
+  PlaceholderTypeInferenceTests.cpp)
 
 target_link_libraries(swiftSemaTests
   PRIVATE

--- a/unittests/Sema/PlaceholderTypeInferenceTests.cpp
+++ b/unittests/Sema/PlaceholderTypeInferenceTests.cpp
@@ -1,0 +1,98 @@
+//===--- PlaceholderTypeInferenceTests.cpp --------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "SemaFixture.h"
+#include "swift/Sema/ConstraintSystem.h"
+
+using namespace swift;
+using namespace swift::unittest;
+using namespace swift::constraints;
+
+TEST_F(SemaTest, TestPlaceholderInferenceForArrayLiteral) {
+  auto *intTypeDecl = getStdlibNominalTypeDecl("Int");
+
+  auto *intLiteral = new (Context) IntegerLiteralExpr("0", SourceLoc(), true);
+  auto *arrayExpr = ArrayExpr::create(Context, SourceLoc(), {intLiteral}, {}, SourceLoc());
+
+  auto *placeholderRepr = new (Context) PlaceholderTypeRepr(SourceLoc());
+  auto *arrayRepr = new (Context) ArrayTypeRepr(placeholderRepr, SourceRange());
+  auto placeholderTy = PlaceholderType::get(Context, placeholderRepr);
+  auto *arrayTy = ArraySliceType::get(placeholderTy);
+
+  auto *varDecl = new (Context) VarDecl(false, VarDecl::Introducer::Let, SourceLoc(), Context.getIdentifier("x"), DC);
+  auto *namedPattern = new (Context) NamedPattern(varDecl);
+  auto *typedPattern = new (Context) TypedPattern(namedPattern, arrayRepr);
+
+  auto target = SolutionApplicationTarget::forInitialization(arrayExpr, DC, arrayTy, typedPattern, /*bindPatternVarsOneWay=*/false);
+
+  ConstraintSystem cs(DC, ConstraintSystemOptions());
+  cs.setContextualType(arrayExpr, {arrayRepr, arrayTy}, CTP_Initialization);
+  cs.generateConstraints(target, FreeTypeVariableBinding::Disallow);
+  SmallVector<Solution, 2> solutions;
+  cs.solve(solutions);
+
+  // We should have a solution.
+  ASSERT_EQ(solutions.size(), 1u);
+
+  auto &solution = solutions[0];
+
+  auto eltTy = ConstraintSystem::isArrayType(solution.simplifyType(solution.getType(arrayExpr)));
+  ASSERT_TRUE(eltTy.hasValue());
+  ASSERT_TRUE((*eltTy)->is<StructType>());
+  ASSERT_EQ((*eltTy)->getAs<StructType>()->getDecl(), intTypeDecl);
+}
+
+TEST_F(SemaTest, TestPlaceholderInferenceForDictionaryLiteral) {
+  auto *intTypeDecl = getStdlibNominalTypeDecl("Int");
+  auto *stringTypeDecl = getStdlibNominalTypeDecl("String");
+
+  auto *intLiteral = new (Context) IntegerLiteralExpr("0", SourceLoc(), true);
+  auto *stringLiteral = new (Context) StringLiteralExpr("test", SourceRange(), true);
+  auto *kvTupleExpr = TupleExpr::create(Context, SourceLoc(), {stringLiteral, intLiteral}, {}, {}, SourceLoc(), true);
+  auto *dictExpr = DictionaryExpr::create(Context, SourceLoc(), {kvTupleExpr}, {}, SourceLoc());
+
+  auto *keyPlaceholderRepr = new (Context) PlaceholderTypeRepr(SourceLoc());
+  auto *valPlaceholderRepr = new (Context) PlaceholderTypeRepr(SourceLoc());
+  auto *dictRepr = new (Context) DictionaryTypeRepr(keyPlaceholderRepr, valPlaceholderRepr, SourceLoc(), SourceRange());
+  auto keyPlaceholderTy = PlaceholderType::get(Context, keyPlaceholderRepr);
+  auto valPlaceholderTy = PlaceholderType::get(Context, valPlaceholderRepr);
+  auto *dictTy = DictionaryType::get(keyPlaceholderTy, valPlaceholderTy);
+
+  auto *varDecl = new (Context) VarDecl(false, VarDecl::Introducer::Let, SourceLoc(), Context.getIdentifier("x"), DC);
+  auto *namedPattern = new (Context) NamedPattern(varDecl);
+  auto *typedPattern = new (Context) TypedPattern(namedPattern, dictRepr);
+
+  auto target = SolutionApplicationTarget::forInitialization(dictExpr, DC, dictTy, typedPattern, /*bindPatternVarsOneWay=*/false);
+
+  ConstraintSystem cs(DC, ConstraintSystemOptions());
+  cs.setContextualType(dictExpr, {dictRepr, dictTy}, CTP_Initialization);
+  cs.generateConstraints(target, FreeTypeVariableBinding::Disallow);
+  SmallVector<Solution, 2> solutions;
+  cs.solve(solutions);
+
+  // We should have a solution.
+  ASSERT_EQ(solutions.size(), 1u);
+
+  auto &solution = solutions[0];
+
+  auto keyValTys = ConstraintSystem::isDictionaryType(solution.simplifyType(solution.getType(dictExpr)));
+  ASSERT_TRUE(keyValTys.hasValue());
+
+  Type keyTy;
+  Type valTy;
+  std::tie(keyTy, valTy) = *keyValTys;
+  ASSERT_TRUE(keyTy->is<StructType>());
+  ASSERT_EQ(keyTy->getAs<StructType>()->getDecl(), stringTypeDecl);
+
+  ASSERT_TRUE(valTy->is<StructType>());
+  ASSERT_EQ(valTy->getAs<StructType>()->getDecl(), intTypeDecl);
+}


### PR DESCRIPTION
Unconverted `PlaceholderType`s were sneaking into the constraint system via the contextual type due to special handling for collection literals. This PR does the same thing we do in `ConstraintGenerator::inferClosureType` by making sure we call `replaceInferableTypesWithTypeVars` before using the contextual type.

Resolves: SR-15192
Resolves: rdar://problem/83153146
