### PR TITLE
[test] Disable two IRGen tests failing on arm64e

### DIFF
--- a/test/IRGen/opaque_result_type.swift
+++ b/test/IRGen/opaque_result_type.swift
@@ -5,6 +5,9 @@
 // rdar://76863553
 // UNSUPPORTED: OS=watchos && CPU=x86_64
 
+// https://bugs.swift.org/browse/SR-15237
+// UNSUPPORTED: CPU=arm64e
+
 public protocol O {
   func bar()
 }

--- a/test/IRGen/typelayout_based_value_witness.swift
+++ b/test/IRGen/typelayout_based_value_witness.swift
@@ -3,6 +3,9 @@
 // RUN: %target-swift-frontend -enable-type-layout -force-struct-type-layouts -primary-file %s -O -emit-ir | %FileCheck %s --check-prefix=FORCE-OPT --check-prefix=FORCE-OPT-%target-ptrsize
 // RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s --check-prefix=NOTL
 
+// https://bugs.swift.org/browse/SR-15237
+// UNSUPPORTED: CPU=arm64e
+
 public struct B<T> {
   var x: T
   var y: T


### PR DESCRIPTION
Disable these until we fix them.

  Swift(iphoneos-arm64e) :: IRGen/opaque_result_type.swift
  Swift(iphoneos-arm64e) :: IRGen/typelayout_based_value_witness.swift

https://bugs.swift.org/browse/SR-15237