### PR TITLE
IRGen: Emit a weak reference to swift_async_extendedFramePointerFlags when neccessary

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1644,6 +1644,7 @@ bool IRGenModule::finalize() {
   if (!ClangCodeGen->GetModule())
     return false;
 
+  emitSwiftAsyncExtendedFrameInfoWeakRef();
   emitAutolinkInfo();
   emitGlobalLists();
   if (DebugInfo)
@@ -1775,4 +1776,46 @@ TypeExpansionContext IRGenModule::getMaximalTypeExpansionContext() const {
 
 const TypeLayoutEntry &IRGenModule::getTypeLayoutEntry(SILType T) {
   return Types.getTypeLayoutEntry(T);
+}
+
+/// Return whether FrameLowering should always set the "extended frame
+/// present" bit in FP, or set it based on a symbol in the runtime.
+static bool isSwiftAsyncContextIsDynamicallySet(llvm::Triple TT) {
+  // Older OS versions (particularly system unwinders) are confused by the
+  // Swift extended frame, so when building code that might be run on them we
+  // must dynamically query the concurrency library to determine whether
+  // extended frames should be flagged as present.
+  unsigned Major, Minor, Micro;
+  TT.getOSVersion(Major, Minor, Micro);
+  switch(TT.getOS()) {
+  default:
+    return false;
+  case llvm::Triple::IOS:
+  case llvm::Triple::TvOS:
+    return Major < 15;
+  case llvm::Triple::WatchOS:
+    return Major < 8;
+  case llvm::Triple::MacOSX:
+  case llvm::Triple::Darwin:
+    return Major < 12;
+  }
+}
+
+void IRGenModule::emitSwiftAsyncExtendedFrameInfoWeakRef() {
+  if (!hasSwiftAsyncFunctionDef || extendedFramePointerFlagsWeakRef)
+    return;
+  if (IRGen.Opts.SwiftAsyncFramePointer !=
+      SwiftAsyncFramePointerKind::Auto)
+    return;
+  if (!isSwiftAsyncContextIsDynamicallySet(Triple))
+    return;
+
+  // Emit a weak reference to the `swift_async_extendedFramePointerFlags` symbol
+  // needed by Swift async functions.
+  auto symbolName = "swift_async_extendedFramePointerFlags";
+  if ((extendedFramePointerFlagsWeakRef = Module.getGlobalVariable(symbolName)))
+    return;
+  extendedFramePointerFlagsWeakRef = new llvm::GlobalVariable(Module, Int8PtrTy, false,
+                                         llvm::GlobalValue::ExternalWeakLinkage, nullptr,
+                                         symbolName);
 }

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1778,28 +1778,6 @@ const TypeLayoutEntry &IRGenModule::getTypeLayoutEntry(SILType T) {
   return Types.getTypeLayoutEntry(T);
 }
 
-/// Return whether FrameLowering should always set the "extended frame
-/// present" bit in FP, or set it based on a symbol in the runtime.
-static bool isSwiftAsyncContextIsDynamicallySet(llvm::Triple TT) {
-  // Older OS versions (particularly system unwinders) are confused by the
-  // Swift extended frame, so when building code that might be run on them we
-  // must dynamically query the concurrency library to determine whether
-  // extended frames should be flagged as present.
-  unsigned Major, Minor, Micro;
-  TT.getOSVersion(Major, Minor, Micro);
-  switch(TT.getOS()) {
-  default:
-    return false;
-  case llvm::Triple::IOS:
-  case llvm::Triple::TvOS:
-    return Major < 15;
-  case llvm::Triple::WatchOS:
-    return Major < 8;
-  case llvm::Triple::MacOSX:
-  case llvm::Triple::Darwin:
-    return Major < 12;
-  }
-}
 
 void IRGenModule::emitSwiftAsyncExtendedFrameInfoWeakRef() {
   if (!hasSwiftAsyncFunctionDef || extendedFramePointerFlagsWeakRef)
@@ -1807,7 +1785,7 @@ void IRGenModule::emitSwiftAsyncExtendedFrameInfoWeakRef() {
   if (IRGen.Opts.SwiftAsyncFramePointer !=
       SwiftAsyncFramePointerKind::Auto)
     return;
-  if (!isSwiftAsyncContextIsDynamicallySet(Triple))
+  if (isConcurrencyAvailable())
     return;
 
   // Emit a weak reference to the `swift_async_extendedFramePointerFlags` symbol
@@ -1818,4 +1796,11 @@ void IRGenModule::emitSwiftAsyncExtendedFrameInfoWeakRef() {
   extendedFramePointerFlagsWeakRef = new llvm::GlobalVariable(Module, Int8PtrTy, false,
                                          llvm::GlobalValue::ExternalWeakLinkage, nullptr,
                                          symbolName);
+}
+
+bool IRGenModule::isConcurrencyAvailable() {
+  auto &ctx = getSwiftModule()->getASTContext();
+  auto deploymentAvailability =
+    AvailabilityContext::forDeploymentTarget(ctx);
+  return deploymentAvailability.isContainedIn(ctx.getConcurrencyAvailability());
 }

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1698,6 +1698,7 @@ private:
   /// symbol needed by Swift async functions.
   void emitSwiftAsyncExtendedFrameInfoWeakRef();
 public:
+  bool isConcurrencyAvailable();
   void noteSwiftAsyncFunctionDef() {
     hasSwiftAsyncFunctionDef = true;
   }

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1691,7 +1691,16 @@ private:
   void addLazyConformances(const IterableDeclContext *idc);
 
 //--- Global context emission --------------------------------------------------
+  bool hasSwiftAsyncFunctionDef = false;
+  llvm::Value *extendedFramePointerFlagsWeakRef = nullptr;
+
+  /// Emit a weak reference to the `swift_async_extendedFramePointerFlags`
+  /// symbol needed by Swift async functions.
+  void emitSwiftAsyncExtendedFrameInfoWeakRef();
 public:
+  void noteSwiftAsyncFunctionDef() {
+    hasSwiftAsyncFunctionDef = true;
+  }
   void emitRuntimeRegistration();
   void emitVTableStubs();
   void emitTypeVerifier();

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2181,11 +2181,15 @@ void IRGenSILFunction::emitSILFunction() {
     IGM.IRGen.addDynamicReplacement(CurSILFn);
 
   auto funcTy = CurSILFn->getLoweredFunctionType();
-  if (funcTy->isAsync() && funcTy->getLanguage() == SILFunctionLanguage::Swift) {
+  bool isAsyncFn = funcTy->isAsync();
+  if (isAsyncFn && funcTy->getLanguage() == SILFunctionLanguage::Swift) {
     emitAsyncFunctionPointer(IGM,
                              CurFn,
                              LinkEntity::forSILFunction(CurSILFn),
                              getAsyncContextLayout(*this).getSize());
+  }
+  if (isAsyncFn) {
+    IGM.noteSwiftAsyncFunctionDef();
   }
 
   // Configure the dominance resolver.

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1230,13 +1230,6 @@ static MetadataResponse emitTupleTypeMetadataRef(IRGenFunction &IGF,
   }
 }
 
-/// Determine whether concurrency support is available in the runtime.
-static bool isConcurrencyAvailable(ASTContext &ctx) {
-  auto deploymentAvailability =
-    AvailabilityContext::forDeploymentTarget(ctx);
-  return deploymentAvailability.isContainedIn(ctx.getConcurrencyAvailability());
-}
-
 namespace {
   /// A visitor class for emitting a reference to a metatype object.
   /// This implements a "raw" access, useful for implementing cache
@@ -1598,7 +1591,7 @@ namespace {
         }
 
         auto *getMetadataFn = type->getGlobalActor()
-            ? (isConcurrencyAvailable(IGF.getSwiftModule()->getASTContext())
+            ? (IGF.IGM.isConcurrencyAvailable()
                ? IGF.IGM.getGetFunctionMetadataGlobalActorFn()
                : IGF.IGM.getGetFunctionMetadataGlobalActorBackDeployFn())
             : type->isDifferentiable()

--- a/test/IRGen/swift_async_extended_frame_info.swift
+++ b/test/IRGen/swift_async_extended_frame_info.swift
@@ -21,3 +21,7 @@ public func someAsyncFunction() async {
 // NEVER: s31swift_async_extended_frame_info17someAsyncFunctionyyYaF:
 // NEVER-NOT:	_swift_async_extendedFramePointerFlags
 // NEVER-NOT: btsq	$60
+
+// AUTO: .weak_reference _swift_async_extendedFramePointerFlags
+// NEVER-NOT: .weak_reference _swift_async_extendedFramePointerFlags
+// ALWAYS-NOT: .weak_reference _swift_async_extendedFramePointerFlags


### PR DESCRIPTION
When we deploy to a minimum target that is not known to support extended
frame information the function prolog of Swift async functions will
contain a reference to swift_async_extendedFramePointerFlags. This
reference needs to be weak like any async symbols.

rdar://83412550