### PR TITLE
[TypeChecker] Remove remaining `isInvalid` checks from pattern handling

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1124,8 +1124,6 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
   case PatternKind::Named: {
     NamedPattern *NP = cast<NamedPattern>(P);
     VarDecl *var = NP->getDecl();
-    if (var->hasInterfaceType() && var->isInvalid())
-      type = ErrorType::get(Context);
 
     // In SIL mode, VarDecls are written as having reference storage types.
     type = type->getReferenceStorageReferent();
@@ -1692,9 +1690,6 @@ void TypeChecker::coerceParameterListToType(ParameterList *P,
   // Local function to check whether type of given parameter
   // should be coerced to a given contextual type or not.
   auto shouldOverwriteParam = [&](ParamDecl *param) -> bool {
-    if (param->isInvalid())
-      return true;
-
     return !isValidType(param->getType());
   };
 


### PR DESCRIPTION
- `coercePatternToType` - validity is checked before coercions happen;
- `coerceParameterListToType` - isInvalid check already rejects invalid decls.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
