### PR TITLE
[test] Restrict two driver tests to macOS

### DIFF
--- a/test/Driver/sanitize_address_use_odr_indicator.swift
+++ b/test/Driver/sanitize_address_use_odr_indicator.swift
@@ -1,6 +1,9 @@
 // REQUIRES: asan_runtime
 // RUN: %swiftc_driver -driver-print-jobs -sanitize=address -sanitize-address-use-odr-indicator %s 2>&1 | %FileCheck %s
 
+// rdar://83458140
+// REQUIRES: OS=macosx
+
 // CHECK: swift
 // CHECK-DAG: -sanitize=address
 // CHECK-DAG: -sanitize-address-use-odr-indicator

--- a/test/Driver/sanitize_recover.swift
+++ b/test/Driver/sanitize_recover.swift
@@ -5,6 +5,9 @@
 // RUN: %swiftc_driver -driver-print-jobs -sanitize=address %s 2>&1 | %FileCheck -check-prefix=ASAN_WITHOUT_RECOVER --implicit-check-not='-sanitize-recover=address' %s
 // REQUIRES: asan_runtime
 
+// rdar://83458140
+// REQUIRES: OS=macosx
+
 // SAN_RECOVER_INVALID_ARG: unsupported argument 'foo' to option '-sanitize-recover='
 // SAN_RECOVER_UNSUPPORTED_ARG: unsupported argument 'thread' to option '-sanitize-recover='
 


### PR DESCRIPTION
These appear to fail when run for other configurations, so restrict them
for now until we can figure out what is going wrong.
