### PR TITLE
[test] Restrict test/Concurrency/voucher_propagation.swift

### DIFF
--- a/test/Concurrency/voucher_propagation.swift
+++ b/test/Concurrency/voucher_propagation.swift
@@ -12,6 +12,9 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
+// rdar://83459813 - assertion failure in TaskGroup.cpp
+// REQUIRES: OS=macosx
+
 import Darwin
 import Dispatch
 import StdlibUnittest


### PR DESCRIPTION
Cherry-pick #39423 to 5.5

---

This is failing (possibly non-deterministically) on some device
platforms, so restrict it to macOS until we fix it.

rdar://83459813
(cherry picked from commit 80d3310d36ed80508544c57fa04586bbacfff2d0)