### PR TITLE
[nfc][cxx-interop] Add three utilities to the `ClangModuleLoader`.

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -33,6 +33,8 @@ namespace swift {
 
 class Decl;
 class DeclContext;
+class EffectiveClangContext;
+class SwiftLookupTable;
 class VisibleDeclConsumer;
 
 /// Represents the different namespaces for types in C.
@@ -177,6 +179,9 @@ public:
                       StringRef relatedEntityKind,
                       llvm::function_ref<void(TypeDecl *)> receiver) = 0;
 
+  /// Imports a clang decl directly, rather than looking up its name.
+  virtual Decl *importDeclDirectly(const clang::NamedDecl *decl) = 0;
+
   /// Instantiate and import class template using given arguments.
   ///
   /// This method will find the clang::ClassTemplateSpecialization decl if
@@ -241,6 +246,21 @@ public:
 
   virtual Type importFunctionReturnType(const clang::FunctionDecl *clangDecl,
                                         DeclContext *dc) = 0;
+
+  /// Find the lookup table that corresponds to the given Clang module.
+  ///
+  /// \param clangModule The module, or null to indicate that we're talking
+  /// about the directly-parsed headers.
+  virtual SwiftLookupTable *
+  findLookupTable(const clang::Module *clangModule) = 0;
+
+  virtual DeclName
+  importName(const clang::NamedDecl *D,
+             clang::DeclarationName givenName = clang::DeclarationName()) = 0;
+
+  /// Determine the effective Clang context for the given Swift nominal type.
+  EffectiveClangContext virtual getEffectiveClangContext(
+      const NominalTypeDecl *nominal) = 0;
 };
 
 /// Describes a C++ template instantiation error.

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -62,12 +62,14 @@ class ClangModuleUnit;
 class ClangNode;
 class Decl;
 class DeclContext;
+class EffectiveClangContext;
 class EnumDecl;
 class ImportDecl;
 class IRGenOptions;
 class ModuleDecl;
 class NominalTypeDecl;
 class StructDecl;
+class SwiftLookupTable;
 class TypeDecl;
 class VisibleDeclConsumer;
 enum class SelectorSplitKind;
@@ -457,11 +459,12 @@ public:
   /// Given a Clang module, decide whether this module is imported already.
   static bool isModuleImported(const clang::Module *M);
 
-  DeclName importName(const clang::NamedDecl *D,
-                      clang::DeclarationName givenName);
+  DeclName importName(
+      const clang::NamedDecl *D,
+      clang::DeclarationName givenName = clang::DeclarationName()) override;
 
   Type importFunctionReturnType(const clang::FunctionDecl *clangDecl,
-                                DeclContext *dc) override;
+                                 DeclContext *dc) override;
 
   Optional<std::string>
   getOrCreatePCH(const ClangImporterOptions &ImporterOptions,
@@ -493,6 +496,19 @@ public:
                                  SubstitutionMap subst) override;
 
   bool isCXXMethodMutating(const clang::CXXMethodDecl *method) override;
+
+  /// Find the lookup table that corresponds to the given Clang module.
+  ///
+  /// \param clangModule The module, or null to indicate that we're talking
+  /// about the directly-parsed headers.
+  SwiftLookupTable *findLookupTable(const clang::Module *clangModule) override;
+
+  /// Determine the effective Clang context for the given Swift nominal type.
+  EffectiveClangContext
+  getEffectiveClangContext(const NominalTypeDecl *nominal) override;
+
+  /// Imports a clang decl directly, rather than looking up it's name.
+  Decl *importDeclDirectly(const clang::NamedDecl *decl) override;
 };
 
 ImportDecl *createImportDecl(ASTContext &Ctx, DeclContext *DC, ClangNode ClangN,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4340,3 +4340,18 @@ bool ClangImporter::isCXXMethodMutating(const clang::CXXMethodDecl *method) {
   return isa<clang::CXXConstructorDecl>(method) || !method->isConst() ||
          method->getParent()->hasMutableFields();
 }
+
+SwiftLookupTable *
+ClangImporter::findLookupTable(const clang::Module *clangModule) {
+  return Impl.findLookupTable(clangModule);
+}
+
+/// Determine the effective Clang context for the given Swift nominal type.
+EffectiveClangContext
+ClangImporter::getEffectiveClangContext(const NominalTypeDecl *nominal) {
+  return Impl.getEffectiveClangContext(nominal);
+}
+
+Decl *ClangImporter::importDeclDirectly(const clang::NamedDecl *decl) {
+  return Impl.importDecl(decl, Impl.CurrentVersion);
+}


### PR DESCRIPTION
This adds `importDeclDirectly`, `findLookupTable`, `importName`, and `getEffectiveClangContext`. These are all needed for #38675.

This is part one of many in an effort to split #38675 into a few pieces. 