### PR TITLE
Remove dynamic type diagnostic suggesting using type(of: instead

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1154,18 +1154,6 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
         continue;
       }
 
-      // Handle the deprecated 'x.dynamicType' and migrate it to `type(of: x)`
-      if (Tok.getText() == "dynamicType") {
-        auto range = Result.get()->getSourceRange();
-        auto dynamicTypeExprRange = SourceRange(TokLoc, Tok.getLoc());
-        diagnose(TokLoc, diag::expr_dynamictype_deprecated)
-            .highlight(dynamicTypeExprRange)
-            .fixItReplace(dynamicTypeExprRange, ")")
-            .fixItInsert(range.Start, "type(of: ");
-
-        // fallthrough to an UnresolvedDotExpr.
-      }
-
       // Handle "x.<tab>" for code completion.
       if (Tok.is(tok::code_complete)) {
         assert(!InSwiftKeyPath);

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -55,7 +55,6 @@ func unqualifiedType() {
 
   _ = Foo // expected-error{{expected member name or constructor call after type name}} expected-note{{add arguments}} {{10-10=()}} expected-note{{use '.self'}} {{10-10=.self}}
   _ = Foo.dynamicType // expected-error {{type 'Foo' has no member 'dynamicType'}}
-                      // expected-error@-1 {{'.dynamicType' is deprecated. Use 'type(of: ...)' instead}} {{7-7=type(of: }} {{10-22=)}}
 
   _ = Bad // expected-error{{expected member name or constructor call after type name}}
   // expected-note@-1{{use '.self' to reference the type object}}{{10-10=.self}}
@@ -73,7 +72,6 @@ func qualifiedType() {
 
   _ = Foo.Bar // expected-error{{expected member name or constructor call after type name}} expected-note{{add arguments}} {{14-14=()}} expected-note{{use '.self'}} {{14-14=.self}}
   _ = Foo.Bar.dynamicType // expected-error {{type 'Foo.Bar' has no member 'dynamicType'}}
-                          // expected-error@-1 {{'.dynamicType' is deprecated. Use 'type(of: ...)' instead}} {{7-7=type(of: }} {{14-26=)}}
 }
 
 // We allow '.Type' in expr context
@@ -112,7 +110,6 @@ func genQualifiedType() {
                    // expected-note@-1{{add arguments after the type to construct a value of the type}}
                    // expected-note@-2{{use '.self' to reference the type object}}
   _ = Gen<Foo>.Bar.dynamicType // expected-error {{type 'Gen<Foo>.Bar' has no member 'dynamicType'}}
-                               // expected-error@-1 {{'.dynamicType' is deprecated. Use 'type(of: ...)' instead}} {{7-7=type(of: }} {{19-31=)}}
 }
 
 func typeOfShadowing() {


### PR DESCRIPTION
<!-- What's in this pull request? -->
It was suggested in SR-14667 to remove the potentially confusing `.dynamicType` diagnostic suggesting users to use `type(of: ` instead. This PR removes that diagnostic and leaves the other diagnostic: "Foo has no value .dynamicType" 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-14667.
Link: https://bugs.swift.org/browse/SR-14667

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
