### PR TITLE
[Parse] Fix empty platform condition crash

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1751,6 +1751,9 @@ ERROR(unsupported_platform_condition_expression,none,
       "unexpected platform condition "
       "(expected 'os', 'arch', or 'swift')",
       ())
+ERROR(platform_condition_expected_argument,none,
+      "expected argument to platform condition",
+      ())
 ERROR(platform_condition_expected_one_argument,none,
       "expected only one argument to platform condition",
       ())

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -263,7 +263,11 @@ public:
 
     Expr *Arg = getSingleSubExp(E->getArgs(), *KindName, &D);
     if (!Arg) {
-      D.diagnose(E->getLoc(), diag::platform_condition_expected_one_argument);
+      if (E->getArgs()->empty()) {
+        D.diagnose(E->getLoc(), diag::platform_condition_expected_argument);
+      } else {
+        D.diagnose(E->getLoc(), diag::platform_condition_expected_one_argument);
+      }
       return nullptr;
     }
     // '_compiler_version' '(' string-literal ')'

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -116,6 +116,9 @@ static llvm::VersionTuple getCanImportVersion(ArgumentList *args,
 
 static Expr *getSingleSubExp(ArgumentList *args, StringRef kindName,
                              DiagnosticEngine *D) {
+  if (args->empty())
+    return nullptr;
+
   if (auto *unary = args->getUnlabeledUnaryExpr())
     return unary;
 

--- a/test/Parse/ConditionalCompilation/basicParseErrors.swift
+++ b/test/Parse/ConditionalCompilation/basicParseErrors.swift
@@ -168,3 +168,8 @@ undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}}
 #else
 if true {}
 #endif // OK
+
+// rdar://83017601 Make sure we don't crash
+#if canImport()
+// expected-error@-1 {{expected only one argument to platform condition}}
+#endif

--- a/test/Parse/ConditionalCompilation/basicParseErrors.swift
+++ b/test/Parse/ConditionalCompilation/basicParseErrors.swift
@@ -98,7 +98,7 @@ func fn_j() {}
 #endif
 fn_j() // OK
 
-#if foo || bar || nonExistent() // expected-error {{expected only one argument to platform condition}}
+#if foo || bar || nonExistent() // expected-error {{expected argument to platform condition}}
 #endif
 
 #if FOO = false
@@ -171,5 +171,5 @@ if true {}
 
 // rdar://83017601 Make sure we don't crash
 #if canImport()
-// expected-error@-1 {{expected only one argument to platform condition}}
+// expected-error@-1 {{expected argument to platform condition}}
 #endif


### PR DESCRIPTION
Handle the empty argument case in `getSingleSubExp`, otherwise we'd crash with an index out of bounds.

rdar://83017601