### PR TITLE
Fix availability inference for unownedExecutor.

### DIFF
--- a/test/Concurrency/concurrency_availability.swift
+++ b/test/Concurrency/concurrency_availability.swift
@@ -11,3 +11,11 @@ actor A { }  // expected-error{{concurrency is only available in}}
 // Allow this without any availability for Historical Reasons.
 public func swift_deletedAsyncMethodError() async {
 }
+
+// Ensure that our synthesis of the actor's unownedExecutor does not cause
+// availability errors.
+@available(macOS 12.0, *)
+struct S {
+  actor A {
+  }
+}


### PR DESCRIPTION
Rather that copying availability directly from `UnownedExecutorRef`, we need
to properly infer availability from both it and the enclosing context.
Otherwise, the synthesized `unownedExecutor` will have an availability that
could conflict with our enclosing declaration.

Fixes rdar://83246377.
