### PR TITLE
[test] Restrict test/stdlib/ArrayBuffer_CopyContents.swift to newer runtimes

### DIFF
--- a/test/stdlib/ArrayBuffer_CopyContents.swift
+++ b/test/stdlib/ArrayBuffer_CopyContents.swift
@@ -15,6 +15,10 @@
 // REQUIRES: swift_stdlib_asserts
 // REQUIRES: foundation
 
+// Test is crashing with older runtimes. rdar://82125328
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 import Foundation
 import StdlibUnittest
 


### PR DESCRIPTION
This test is crashing on older runtimes, so disable it until someone can
investigate and decide what if anything should be done about it.
