### PR TITLE
[swift-api-extract] Handle @_spi interfaces with correct APIAccess

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -1266,6 +1266,10 @@ public:
   std::string mangleAsString() const;
   SILLinkage getLinkage(ForDefinition_t isDefinition) const;
 
+  bool hasDecl() const {
+    return isDeclKind(getKind());
+  }
+
   const ValueDecl *getDecl() const {
     assert(isDeclKind(getKind()));
     return reinterpret_cast<ValueDecl*>(Pointer);

--- a/test/APIJSON/spi.swift
+++ b/test/APIJSON/spi.swift
@@ -3,15 +3,18 @@
 // RUN: %target-swift-frontend %s -typecheck -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5
 // RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule -module-cache-path %t | %FileCheck %s
 
+// RUN: %target-swift-frontend %s -emit-module -emit-module-path %t/MyModule.swiftmodule -enable-library-evolution -module-name MyModule -swift-version 5
+// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftmodule -module-name MyModule -module-cache-path %t | %FileCheck %s --check-prefix=CHECK-SPI
+
 import Foundation
 
 @_spi(Experimental) public func newUnprovenFunc() {}
 @_spi(Experimental) public class MyClass : NSObject {
-  public func spiMethod() {}
+  @objc public func spiMethod() {}
 }
 
 public class MyClass2 : NSObject {
-  @_spi(Experimental) public func spiMethod() {}
+  @_spi(Experimental) @objc public func spiMethod() {}
 }
 
 // CHECK:      {
@@ -91,3 +94,208 @@ public class MyClass2 : NSObject {
 // CHECK-NEXT:   ],
 // CHECK-NEXT:   "version": "1.0"
 // CHECK-NEXT: }
+
+// CHECK-SPI:      {
+// CHECK-SPI-NEXT:   "target":
+// CHECK-SPI-NEXT:   "globals": [
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A5ClassC9spiMethodyyFTj",
+// CHECK-SPI-NEXT:       "access": "private",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A5ClassC9spiMethodyyFTq",
+// CHECK-SPI-NEXT:       "access": "private",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A5ClassCACycfC",
+// CHECK-SPI-NEXT:       "access": "private",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A5ClassCACycfc",
+// CHECK-SPI-NEXT:       "access": "private",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A5ClassCMa",
+// CHECK-SPI-NEXT:       "access": "public",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A5ClassCMn",
+// CHECK-SPI-NEXT:       "access": "private",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A5ClassCMo",
+// CHECK-SPI-NEXT:       "access": "private",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A5ClassCMu",
+// CHECK-SPI-NEXT:       "access": "private",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A5ClassCN",
+// CHECK-SPI-NEXT:       "access": "public",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A5ClassCfD",
+// CHECK-SPI-NEXT:       "access": "private",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A6Class2C9spiMethodyyFTj",
+// CHECK-SPI-NEXT:       "access": "private",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A6Class2C9spiMethodyyFTq",
+// CHECK-SPI-NEXT:       "access": "private",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A6Class2CACycfC",
+// CHECK-SPI-NEXT:       "access": "public",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A6Class2CACycfc",
+// CHECK-SPI-NEXT:       "access": "public",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A6Class2CMa",
+// CHECK-SPI-NEXT:       "access": "public",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A6Class2CMn",
+// CHECK-SPI-NEXT:       "access": "public",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A6Class2CMo",
+// CHECK-SPI-NEXT:       "access": "public",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A6Class2CMu",
+// CHECK-SPI-NEXT:       "access": "public",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A6Class2CN",
+// CHECK-SPI-NEXT:       "access": "public",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule0A6Class2CfD",
+// CHECK-SPI-NEXT:       "access": "public",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule15newUnprovenFuncyyF",
+// CHECK-SPI-NEXT:       "access": "private",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_OBJC_CLASS_$__TtC8MyModule7MyClass",
+// CHECK-SPI-NEXT:       "access": "private",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_OBJC_CLASS_$__TtC8MyModule8MyClass2",
+// CHECK-SPI-NEXT:       "access": "public",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_OBJC_METACLASS_$__TtC8MyModule7MyClass",
+// CHECK-SPI-NEXT:       "access": "private",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_OBJC_METACLASS_$__TtC8MyModule8MyClass2",
+// CHECK-SPI-NEXT:       "access": "public",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_main",
+// CHECK-SPI-NEXT:       "access": "public",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     }
+// CHECK-SPI-NEXT:   ],
+// CHECK-SPI-NEXT:   "interfaces": [
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_TtC8MyModule7MyClass",
+// CHECK-SPI-NEXT:       "access": "private",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported",
+// CHECK-SPI-NEXT:       "super": "NSObject",
+// CHECK-SPI-NEXT:       "instanceMethods": [
+// CHECK-SPI-NEXT:         {
+// CHECK-SPI-NEXT:           "name": "init",
+// CHECK-SPI-NEXT:           "access": "private",
+// CHECK-SPI-NEXT:           "file": "/@input/MyModule.swiftmodule"
+// CHECK-SPI-NEXT:         },
+// CHECK-SPI-NEXT:         {
+// CHECK-SPI-NEXT:           "name": "spiMethod",
+// CHECK-SPI-NEXT:           "access": "private",
+// CHECK-SPI-NEXT:           "file": "/@input/MyModule.swiftmodule"
+// CHECK-SPI-NEXT:         }
+// CHECK-SPI-NEXT:       ],
+// CHECK-SPI-NEXT:       "classMethods": []
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:     {
+// CHECK-SPI-NEXT:       "name": "_TtC8MyModule8MyClass2",
+// CHECK-SPI-NEXT:       "access": "public",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported",
+// CHECK-SPI-NEXT:       "super": "NSObject",
+// CHECK-SPI-NEXT:       "instanceMethods": [
+// CHECK-SPI-NEXT:         {
+// CHECK-SPI-NEXT:           "name": "init",
+// CHECK-SPI-NEXT:           "access": "public",
+// CHECK-SPI-NEXT:           "file": "/@input/MyModule.swiftmodule"
+// CHECK-SPI-NEXT:         },
+// CHECK-SPI-NEXT:         {
+// CHECK-SPI-NEXT:           "name": "spiMethod",
+// CHECK-SPI-NEXT:           "access": "private",
+// CHECK-SPI-NEXT:           "file": "/@input/MyModule.swiftmodule"
+// CHECK-SPI-NEXT:         }
+// CHECK-SPI-NEXT:       ],
+// CHECK-SPI-NEXT:       "classMethods": []
+// CHECK-SPI-NEXT:     }
+// CHECK-SPI-NEXT:   ],
+// CHECK-SPI-NEXT:   "version": "1.0"
+// CHECK-SPI-NEXT: }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Handle @_spi correctly. The previous iteration/tests were written to extract from `.swiftinterface` files which doesn't include SPIs. Now correctly extract @_spi when a binary `.swiftmodule` is provided and marked as correct `APIAccess`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
rdar://83506338

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
