### PR TITLE
Fix an incorrect assertion involving existential formation.

### DIFF
--- a/test/IRGen/marker_protocol.swift
+++ b/test/IRGen/marker_protocol.swift
@@ -32,3 +32,15 @@ public func testGeneric(i: Int, array: [Int]) {
   generic(i)
   generic(array)
 }
+
+// Forming an existential involving a marker protocol would crash the compiler
+protocol SelfConstrainedProtocol {
+  static var shared: Self { get }
+}
+
+struct Foo: SelfConstrainedProtocol {
+  let x: P
+  static var shared: Self {
+    Foo(x: 123)
+  }
+}


### PR DESCRIPTION
This assertion was tripping when the existential involved a marker
protocol, because it was checking for the number of protocols rather
than the number of protocols that require witness tables. Correct the
assertion and add a test.

Fixes rdar://83020734.
