### PR TITLE
[SymbolGraph] Determine optional requirement by presence of OptionalAttr

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -431,16 +431,11 @@ SymbolGraph::recordRequirementRelationships(Symbol S) {
 void SymbolGraph::recordOptionalRequirementRelationships(Symbol S) {
   const auto VD = S.getSymbolDecl();
   if (const auto *Protocol = dyn_cast<ProtocolDecl>(VD->getDeclContext())) {
-    if (VD->isProtocolRequirement()) {
-      if (const auto *ClangDecl = VD->getClangDecl()) {
-        if (const auto *Method = dyn_cast<clang::ObjCMethodDecl>(ClangDecl)) {
-          if (Method->isOptional()) {
-            recordEdge(Symbol(this, VD, nullptr),
-                       Symbol(this, Protocol, nullptr),
-                       RelationshipKind::OptionalRequirementOf());
-          }
-        }
-      }
+    if (VD->isProtocolRequirement() &&
+        VD->getAttrs().hasAttribute<OptionalAttr>()) {
+      recordEdge(Symbol(this, VD, nullptr),
+                 Symbol(this, Protocol, nullptr),
+                 RelationshipKind::OptionalRequirementOf());
     }
   }
 }

--- a/test/SymbolGraph/Relationships/OptionalRequirementOf.swift
+++ b/test/SymbolGraph/Relationships/OptionalRequirementOf.swift
@@ -1,0 +1,35 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/frameworks/OptionalRequirementOf.framework/Modules/OptionalRequirementOf.swiftmodule
+// RUN: split-file %s %t
+
+// RUN: %target-build-swift %t/reqs.swift -module-name OptionalRequirementOf -emit-module-path %t/frameworks/OptionalRequirementOf.framework/Modules/OptionalRequirementOf.swiftmodule/%target-swiftmodule-name -import-underlying-module -F %t/frameworks -Xfrontend -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-symbolgraph-extract -module-name OptionalRequirementOf -F %t/frameworks -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/OptionalRequirementOf.symbols.json
+
+// ObjCProto.objcReq -> ObjCProto
+// CHECK-DAG: "kind": "requirementOf",{{[[:space:]]*}}"source": "c:@M@OptionalRequirementOf@objc(pl)SwiftProto(im)swiftReq",{{[[:space:]]*}}"target": "c:@M@OptionalRequirementOf@objc(pl)SwiftProto"
+// CHECK-DAG: "kind": "optionalRequirementOf",{{[[:space:]]*}}"source": "c:@M@OptionalRequirementOf@objc(pl)SwiftProto(im)swiftReq",{{[[:space:]]*}}"target": "c:@M@OptionalRequirementOf@objc(pl)SwiftProto"
+
+// SwiftProto.swiftReq -> SwiftProto
+// CHECK-DAG: "kind": "requirementOf",{{[[:space:]]*}}"source": "c:objc(pl)ObjCProto(im)objcReq",{{[[:space:]]*}}"target": "c:objc(pl)ObjCProto"
+// CHECK-DAG: "kind": "optionalRequirementOf",{{[[:space:]]*}}"source": "c:objc(pl)ObjCProto(im)objcReq",{{[[:space:]]*}}"target": "c:objc(pl)ObjCProto"
+
+//--- reqs.swift
+@objc
+public protocol SwiftProto {
+  @objc optional func swiftReq()
+}
+
+//--- frameworks/OptionalRequirementOf.framework/module.map
+framework module OptionalRequirementOf {
+  header "req.h"
+  export *
+}
+
+//--- frameworks/OptionalRequirementOf.framework/Headers/req.h
+@protocol ObjCProto
+@optional
+- (void)objcReq;
+@end

--- a/test/SymbolGraph/Relationships/RequirementOf.swift
+++ b/test/SymbolGraph/Relationships/RequirementOf.swift
@@ -1,13 +1,13 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -module-name ConformsTo -emit-module -emit-module-path %t/
-// RUN: %target-swift-symbolgraph-extract -module-name ConformsTo -I %t -pretty-print -output-dir %t
-// RUN: %FileCheck %s --input-file %t/ConformsTo.symbols.json
+// RUN: %target-build-swift %s -module-name RequirementOf -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name RequirementOf -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/RequirementOf.symbols.json
 
 public protocol P {
   var x: Int { get }
 }
 
 // CHECK: "kind": "requirementOf"
-// CHECK-NEXT: "source": "s:10ConformsTo1PP1xSivp"
-// CHECK-NEXT: "target": "s:10ConformsTo1PP"
+// CHECK-NEXT: "source": "s:13RequirementOf1PP1xSivp"
+// CHECK-NEXT: "target": "s:13RequirementOf1PP"
 // CHECK-NOT: defaultImplementationOf


### PR DESCRIPTION
Rather than checking the underlying ObjectiveC decl, use the presence of
`OptionalAttr` to determine if a requirement is optional instead. This
is already added by the importer when necessary. An added benefit here
is that this also works for optional requirements defined in Swift (ie.
`@objc optional ...`).
