### PR TITLE
[ResultBuilders] A couple pattern matching fixes to make it consistent with `TypeCheckPattern`

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2290,9 +2290,29 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
             increaseScore(SK_FunctionConversion);
           }
         }
-      } else if (last->getKind() == ConstraintLocator::PatternMatch &&
-          isa<EnumElementPattern>(
-            last->castTo<LocatorPathElt::PatternMatch>().getPattern())) {
+      } else if (last->is<LocatorPathElt::PatternMatch>() &&
+                 isa<EnumElementPattern>(
+                     last->castTo<LocatorPathElt::PatternMatch>()
+                         .getPattern())) {
+        // A single paren pattern becomes a labeled tuple pattern
+        // e.g. `case .test(let value):` should be able to match
+        // `case test(result: Int)`. Note that it also means that:
+        // `cast test(result: (String, Int))` would be matched against
+        // e.g. `case .test((let x, let y))` but that fails during
+        // pattern coercion (behavior consistent with what happens in
+        // `TypeCheckPattern`).
+        if (func1Params.size() == 1 && !func1Params.front().hasLabel() &&
+            func2Params.size() == 1 && func2Params.front().hasLabel()) {
+          auto param = func1Params.front();
+          auto label = func2Params.front().getLabel();
+
+          auto labeledParam = FunctionType::Param(param.getPlainType(), label,
+                                                  param.getParameterFlags());
+
+          func1Params.clear();
+          func1Params.push_back(labeledParam);
+        }
+
         // Consider following example:
         //
         // enum E {

--- a/test/Constraints/result_builder.swift
+++ b/test/Constraints/result_builder.swift
@@ -513,6 +513,64 @@ func getE(_ i: Int) -> E {
   }
 }
 
+func test_labeled_splats() {
+  enum E {
+  case multi(a: String, b: String)
+  case tuple((a: Int, b: Int))
+  case single(result: Int)
+  case single_multi(result: (a: Int, q: String))
+  }
+
+  func test_answer(_: String) -> Int { 42 }
+  func test_question(_: Int) -> String { "ultimate question" }
+
+  let e: E = E.single(result: 42)
+
+  tuplify(true) { _ in
+    switch e {
+    case .single(let result):
+      test_question(result)
+    case let .single_multi(result):
+      test_answer(result.q)
+      test_question(result.a)
+    case let .multi(value): // tuple splat preserves labels
+      test_answer(value.a)
+      test_answer(value.b)
+    case let .tuple(a: a, b: b): // un-splat preserves labels too
+      test_question(a)
+      test_question(b)
+    }
+
+    // compound names still work with and without splat
+    switch e {
+    case .single(_): 42
+    case .single_multi(result: (let a, let q)):
+      test_answer(q)
+      test_question(a)
+    case let .multi(a: a, b: b):
+      test_answer(a)
+      test_answer(b)
+    case let .tuple((a: a, b: b)):
+      test_question(a)
+      test_question(b)
+    }
+
+    // no labels, no problem regardless of splatting
+    switch e {
+    case .single(_): 42
+    case let .single_multi(result: (a, q)):
+      test_question(a)
+      test_answer(q)
+    case let .multi(a, b):
+      test_answer(a)
+      test_answer(b)
+    case let .tuple((a, b)):
+      test_question(a)
+      test_question(b)
+    }
+  }
+}
+
 tuplify(true) { c in
   "testIfLetMatching"
   if let theValue = getOptionalInt(c) {


### PR DESCRIPTION
- Preserve labels during splat situations in pattern matching context

Tuple splat/implosion is (still) allowed for patterns (with a warning in Swift 5)
so we need to use `SingleApply` while looking up members to make sure that e.g.
`case test(x: Int, y: Int)` gets the labels preserved when matched with
`case let .test(tuple)` and `Compound` when associated values form a tuple pattern.

-  Make solver behavior consistent with `TypeCheckPattern` for paren patterns

A single paren pattern becomes a labeled tuple pattern e.g. `case .test(let value):` 
should be able to match `case test(result: Int)`. Note that it also means that:
`cast test(result: (String, Int))` would be matched against e.g. `case .test((let x, let y))` 
but that fails during pattern coercion (behavior consistent with what happens in
`TypeCheckPattern`).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
