### PR TITLE
[NFC] Remove unused diagnostic from DiagnosticsParse.def

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1347,10 +1347,6 @@ ERROR(expr_selector_expected_property_expr,PointsToFirstBadToken,
 ERROR(expr_selector_expected_rparen,PointsToFirstBadToken,
       "expected ')' to complete '#selector' expression", ())
 
-// Type-of expressions.
-ERROR(expr_dynamictype_deprecated,PointsToFirstBadToken,
-      "'.dynamicType' is deprecated. Use 'type(of: ...)' instead", ())
-
 // '#assert'
 ERROR(pound_assert_disabled,PointsToFirstBadToken,
       "#assert is an experimental feature that is currently disabled", ())


### PR DESCRIPTION
<!-- What's in this pull request? -->
#39443 Removed the emission of diagnostic, but we forgot to remove the diagnostic itself

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
