### PR TITLE
[Mem2Reg] Lexical allocs create lexical borrows.

### DIFF
--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1083,7 +1083,7 @@ void SILCloner<ImplClass>::visitBeginBorrowInst(BeginBorrowInst *Inst) {
 
   recordClonedInstruction(
       Inst, getBuilder().createBeginBorrow(getOpLocation(Inst->getLoc()),
-                                           getOpValue(Inst->getOperand()), 
+                                           getOpValue(Inst->getOperand()),
                                            Inst->isLexical()));
 }
 

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -190,11 +190,11 @@ bool isAddressOfArrayElement(SILValue addr);
 /// Move an ApplyInst's FuncRef so that it dominates the call site.
 void placeFuncRef(ApplyInst *ai, DominanceInfo *dt);
 
-/// Add an argument, \p val, to the branch-edge that is pointing into
+/// Add arguments, \p vals, to the branch-edge that is pointing into
 /// block \p Dest. Return a new instruction and do not erase the old
 /// instruction.
-TermInst *addArgumentToBranch(SILValue val, SILBasicBlock *dest,
-                              TermInst *branch);
+TermInst *addArgumentsToBranch(ArrayRef<SILValue> vals, SILBasicBlock *dest,
+                               TermInst *branch);
 
 /// Get the linkage to be used for specializations of a function with
 /// the given linkage.

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -533,11 +533,15 @@ static bool rewriteAllocBoxAsAllocStack(AllocBoxInst *ABI) {
   SILBuilderWithScope Builder(ABI);
   assert(ABI->getBoxType()->getLayout()->getFields().size() == 1
          && "rewriting multi-field box not implemented");
+  bool isLexical = ABI->getFunction()
+                       ->getModule()
+                       .getASTContext()
+                       .LangOpts.EnableExperimentalLexicalLifetimes;
   auto *ASI = Builder.createAllocStack(
       ABI->getLoc(),
       getSILBoxFieldType(TypeExpansionContext(*ABI->getFunction()),
                          ABI->getBoxType(), ABI->getModule().Types, 0),
-      ABI->getVarInfo(), ABI->hasDynamicLifetime());
+      ABI->getVarInfo(), ABI->hasDynamicLifetime(), isLexical);
 
   // Transfer a mark_uninitialized if we have one.
   SILValue StackBox = ASI;

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -21,6 +21,7 @@
 #define DEBUG_TYPE "sil-mem2reg"
 
 #include "swift/AST/DiagnosticsSIL.h"
+#include "swift/Basic/DAGNodeWorklist.h"
 #include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/Projection.h"
@@ -51,10 +52,58 @@ STATISTIC(NumAllocStackFound,    "Number of AllocStack found");
 STATISTIC(NumAllocStackCaptured, "Number of AllocStack captured");
 STATISTIC(NumInstRemoved,        "Number of Instructions removed");
 
+static bool shouldAddLexicalLifetime(AllocStackInst *asi);
+
 namespace {
 
 using DomTreeNode = llvm::DomTreeNodeBase<SILBasicBlock>;
 using DomTreeLevelMap = llvm::DenseMap<DomTreeNode *, unsigned>;
+
+/// The values pertaining to an alloc_stack that might be live, whether within
+/// the block, as the block is entered (live-in) or exited
+/// (live-out) relating to an alloc_stack.
+struct LiveValues {
+  SILValue stored = SILValue();
+  SILValue borrow = SILValue();
+  SILValue copy = SILValue();
+
+  /// Create an instance of the minimum values required to replace a usage of an
+  /// AllocStackInst.  It consists of only one value.
+  ///
+  /// Whether the one value occupies the stored or the copy field depends on
+  /// whether the alloc_stack is lexical.  If it is lexical, then usages of the
+  /// asi will be replaced with usages of the copy field; otherwise, those
+  /// usages will be replaced with usages of the stored field.  The
+  /// implementation constructs an instance to match those requirements.
+  static LiveValues toReplace(AllocStackInst *asi, SILValue replacement) {
+    if (shouldAddLexicalLifetime(asi))
+      return {SILValue(), SILValue(), replacement};
+    return {replacement, SILValue(), SILValue()};
+  };
+  /// The value with which usages of the provided AllocStackInst should be
+  /// replaced.
+  ///
+  /// For lexical AllocStackInsts, that is the copy made of the borrowed value.
+  /// For those that are non-lexical, that is the value that was stored into the
+  /// storage.
+  SILValue replacement(AllocStackInst *asi) {
+    return shouldAddLexicalLifetime(asi) ? copy : stored;
+  };
+};
+
+/// The instructions that are involved in or introduced in response to a store
+/// into an alloc_stack.
+///
+/// There is always a store.  The begin_borrow and copy_value instructions are
+/// introduced for lexical alloc_stacks.
+struct ValueInstructions {
+  // The value of interest is the operand of the store instruction.
+  StoreInst *store = nullptr;
+  // The value of interest is the result of the begin_borrow instruction.
+  BeginBorrowInst *borrow = nullptr;
+  // The value of interest is the result of the copy_value instruction.
+  CopyValueInst *copy = nullptr;
+};
 
 } // anonymous namespace
 
@@ -234,6 +283,99 @@ static SILValue createValueForEmptyTuple(SILType ty,
   return builder.createTuple(insertionPoint->getLoc(), ty, elements);
 }
 
+/// Whether lexical lifetimes should be added for the values stored into the
+/// alloc_stack.
+static bool shouldAddLexicalLifetime(AllocStackInst *asi) {
+  return asi->getFunction()->hasOwnership() &&
+         asi->getFunction()
+             ->getModule()
+             .getASTContext()
+             .LangOpts.EnableExperimentalLexicalLifetimes &&
+         asi->isLexical() &&
+         !asi->getElementType().isTrivial(*asi->getFunction());
+}
+
+/// Given a store instruction after which it is known that a lexical borrow
+/// scope should be added, add the beginning at the appropriate position.
+///
+/// The beginning of the scope looks like
+///
+///     %lifetime = begin_borrow %original
+///     %copy = copy_value %lifetime
+static std::pair<ValueInstructions, LiveValues>
+beginLexicalLifetimeAtStore(AllocStackInst *asi, StoreInst *si,
+                            SILBuilderContext &ctx) {
+  assert(shouldAddLexicalLifetime(asi));
+  auto *bbi =
+      SILBuilderWithScope(si, ctx).createBeginBorrow(si->getLoc(), si->getSrc(),
+                                                     /*isLexical*/ true);
+  auto *cvi = SILBuilderWithScope(si, ctx).createCopyValue(si->getLoc(), bbi);
+  ValueInstructions insts = {si, bbi, cvi};
+  LiveValues vals = {si->getSrc(), bbi, cvi};
+  return std::make_pair(insts, vals);
+}
+
+/// Given a block to which it is known that the end of a lexical borrow scope
+/// should be added, add the end at the appropriate position.
+///
+/// The end of the scope looks like
+///
+///     end_borrow %lifetime
+///     destroy_value %original
+///
+/// These two instructions correspond to the following instructions that begin
+/// a lexical borrow scope:
+///
+///     %lifetime = begin_borrow %original
+///     %copy = copy_value %lifetime
+///
+/// There are a couple options for where the instructions will be added:
+/// (1) If there are uses of the borrow within the block, then they are added
+///     after the last use.
+/// (2) If there are no uses of the borrow within the block, and the copy_value
+///     instruction appears within the block, they are added immediately after
+///     it.
+/// (3) If there are no uses of the borrow within the block and the copy_value
+///     instruction does not appear within the block, then the instructions are
+///     added at the beginning of the block.
+/// They should be added after the value is done being used.  If the value is
+/// ever used, that means after the last use.  Otherwise, it means immediately
+/// after the definition.
+void endLexicalLifetimeInBlock(AllocStackInst *asi, SILBasicBlock *bb,
+                               SILBuilderContext &ctx, DominanceInfo *domInfo,
+                               SILValue copy, SILValue borrow,
+                               SILValue original) {
+  assert(shouldAddLexicalLifetime(asi));
+  SILInstruction *lastInst = nullptr;
+  if (auto *cvi = copy->getDefiningInstruction()) {
+    if (cvi->getParent() == bb) {
+      lastInst = cvi;
+    }
+  }
+  for (auto *use : copy->getUses()) {
+    auto *thisInst = use->getUser();
+    if (thisInst->getParent() != bb)
+      continue;
+    if (!lastInst || domInfo->dominates(lastInst, thisInst))
+      lastInst = thisInst;
+  }
+  if (lastInst) {
+    assert(!isa<TermInst>(lastInst) &&
+           "the last use of the value cannot be terminal--Mem2Reg does not run "
+           "on alloc_stacks which are passed to checked_cast_addr_br or "
+           "switch_enum_addr");
+    SILBuilderWithScope::insertAfter(lastInst, [&](SILBuilder &B) {
+      B.createEndBorrow(lastInst->getLoc(), borrow);
+      B.emitDestroyValueOperation(lastInst->getLoc(), original);
+    });
+  } else {
+    auto *firstInst = &*bb->begin();
+    auto builder = SILBuilderWithScope(firstInst, ctx);
+    builder.createEndBorrow(firstInst->getLoc(), borrow);
+    builder.emitDestroyValueOperation(firstInst->getLoc(), original);
+  }
+}
+
 //===----------------------------------------------------------------------===//
 //                     Single Stack Allocation Promotion
 //===----------------------------------------------------------------------===//
@@ -243,7 +385,7 @@ namespace {
 /// Promotes a single AllocStackInst into registers..
 class StackAllocationPromoter {
   using BlockSetVector = BasicBlockSetVector;
-  using BlockToInstMap = llvm::DenseMap<SILBasicBlock *, SILInstruction *>;
+  using BlockToInstsMap = llvm::DenseMap<SILBasicBlock *, ValueInstructions>;
 
   // Use a priority queue keyed on dominator tree level so that inserted nodes
   // are handled from the bottom of the dom tree upwards.
@@ -259,6 +401,13 @@ class StackAllocationPromoter {
   /// multiple deallocations.
   DeallocStackInst *dsi;
 
+  /// All the dealloc_stack instructions.
+  SmallVector<DeallocStackInst *> dsis;
+
+  /// The lexical begin_borrow instructions that were created to track the
+  /// lexical lifetimes introduced by the alloc_stack, if it is lexical.
+  SmallVector<SILBasicBlock *> lexicalBBIBlocks;
+
   /// Dominator info.
   DominanceInfo *domInfo;
 
@@ -273,7 +422,7 @@ class StackAllocationPromoter {
 
   /// Records the last store instruction in each block for a specific
   /// AllocStackInst.
-  BlockToInstMap lastStoreInBlock;
+  BlockToInstsMap lastStoreInBlock;
 
 public:
   /// C'tor.
@@ -284,16 +433,13 @@ public:
       : asi(inputASI), dsi(nullptr), domInfo(inputDomInfo),
         domTreeLevels(inputDomTreeLevels), ctx(inputCtx), deleter(deleter) {
     // Scan the users in search of a deallocation instruction.
-    for (auto *use : asi->getUses()) {
-      if (auto *foundDealloc = dyn_cast<DeallocStackInst>(use->getUser())) {
-        // Don't record multiple dealloc instructions.
-        if (dsi) {
-          dsi = nullptr;
-          break;
-        }
-        // Record the deallocation instruction.
-        dsi = foundDealloc;
-      }
+    for (auto *use : asi->getUses())
+      if (auto *foundDealloc = dyn_cast<DeallocStackInst>(use->getUser()))
+        dsis.push_back(foundDealloc);
+    if (dsis.size() == 1) {
+      // Record the deallocation instruction, but don't record multiple dealloc
+      // instructions.
+      dsi = dsis.front();
     }
   }
 
@@ -320,9 +466,13 @@ private:
                          const BlockSetVector &phiBlocks,
                          SmallPtrSetImpl<SILPhiArgument *> &livePhis);
 
+  /// End the lexical borrow scope that is introduced for lexical alloc_stack
+  /// instructions.
+  void endLexicalLifetime(BlockSetVector &phiBlocks);
+
   /// Fix all of the branch instructions and the uses to use
   /// the AllocStack definitions (which include stores and Phis).
-  void fixBranchesAndUses(BlockSetVector &blocks);
+  void fixBranchesAndUses(BlockSetVector &blocks, BlockSetVector &liveBlocks);
 
   /// update the branch instructions with the new Phi argument.
   /// The blocks in \p PhiBlocks are blocks that define a value, \p Dest is
@@ -331,14 +481,24 @@ private:
   void fixPhiPredBlock(BlockSetVector &phiBlocks, SILBasicBlock *dest,
                        SILBasicBlock *pred);
 
-  /// Get the value for this AllocStack variable that is
-  /// flowing out of StartBB.
-  SILValue getLiveOutValue(BlockSetVector &phiBlocks,
-                           SILBasicBlock *startBlock);
+  /// Get the values for this AllocStack variable that are flowing out of
+  /// StartBB.
+  Optional<LiveValues> getLiveOutValues(BlockSetVector &phiBlocks,
+                                        SILBasicBlock *startBlock);
 
-  /// Get the value for this AllocStack variable that is
-  /// flowing into BB.
-  SILValue getLiveInValue(BlockSetVector &phiBlocks, SILBasicBlock *block);
+  /// Get the values for this AllocStack variable that are flowing out of
+  /// StartBB or undef if there are none.
+  LiveValues getEffectiveLiveOutValues(BlockSetVector &phiBlocks,
+                                       SILBasicBlock *startBlock);
+
+  /// Get the values for this AllocStack variable that are flowing into block.
+  Optional<LiveValues> getLiveInValues(BlockSetVector &phiBlocks,
+                                       SILBasicBlock *block);
+
+  /// Get the values for this AllocStack variable that are flowing into block or
+  /// undef if there are none.
+  LiveValues getEffectiveLiveInValues(BlockSetVector &phiBlocks,
+                                      SILBasicBlock *block);
 
   /// Prune AllocStacks usage in the function. Scan the function
   /// and remove in-block usage of the AllocStack. Leave only the first
@@ -348,21 +508,23 @@ private:
   /// Promote all of the AllocStacks in a single basic block in one
   /// linear scan. This function deletes all of the loads and stores except
   /// for the first load and the last store.
-  /// \returns the last StoreInst found or zero if none found.
-  StoreInst *promoteAllocationInBlock(SILBasicBlock *block);
+  /// \returns the last ValueInstructions (the store, and, if lexical, the
+  ///          begin_borrow and copy_value) found, if any, or else llvm::None.
+  Optional<ValueInstructions> promoteAllocationInBlock(SILBasicBlock *block);
 };
 
 } // end of namespace
 
-StoreInst *StackAllocationPromoter::promoteAllocationInBlock(
+Optional<ValueInstructions> StackAllocationPromoter::promoteAllocationInBlock(
     SILBasicBlock *blockPromotingWithin) {
   LLVM_DEBUG(llvm::dbgs() << "*** Promoting ASI in block: " << *asi);
 
   // RunningVal is the current value in the stack location.
   // We don't know the value of the alloca until we find the first store.
-  SILValue runningVal = SILValue();
-  // Keep track of the last StoreInst that we found.
-  StoreInst *lastStore = nullptr;
+  Optional<LiveValues> runningVals;
+  // Keep track of the last StoreInst that we found and the BeginBorrowInst and
+  // CopyValueInst that we created in response if the alloc_stack was lexical.
+  Optional<ValueInstructions> lastValueInstructions = llvm::None;
 
   // For all instructions in the block.
   for (auto bbi = blockPromotingWithin->begin(),
@@ -373,11 +535,11 @@ StoreInst *StackAllocationPromoter::promoteAllocationInBlock(
 
     if (isLoadFromStack(inst, asi)) {
       auto *li = cast<LoadInst>(inst);
-      if (runningVal) {
+      if (runningVals) {
         // If we are loading from the AllocStackInst and we already know the
         // content of the Alloca then use it.
         LLVM_DEBUG(llvm::dbgs() << "*** Promoting load: " << *li);
-        replaceLoad(li, runningVal, asi, ctx, deleter);
+        replaceLoad(li, runningVals->replacement(asi), asi, ctx, deleter);
         ++NumInstRemoved;
       } else if (li->getOperand() == asi &&
                  li->getOwnershipQualifier() != LoadOwnershipQualifier::Copy) {
@@ -387,7 +549,7 @@ StoreInst *StackAllocationPromoter::promoteAllocationInBlock(
         // additional logic for cleanup of consuming instructions of the result.
         // StackAllocationPromoter::fixBranchesAndUses will later handle it.
         LLVM_DEBUG(llvm::dbgs() << "*** First load: " << *li);
-        runningVal = li;
+        runningVals = LiveValues::toReplace(asi, /*replacement=*/li);
       }
       continue;
     }
@@ -401,9 +563,9 @@ StoreInst *StackAllocationPromoter::promoteAllocationInBlock(
       // If we see a store [assign], always convert it to a store [init]. This
       // simplifies further processing.
       if (si->getOwnershipQualifier() == StoreOwnershipQualifier::Assign) {
-        if (runningVal) {
-          SILBuilderWithScope(si, ctx).createDestroyValue(si->getLoc(),
-                                                          runningVal);
+        if (runningVals) {
+          SILBuilderWithScope(si, ctx).createDestroyValue(
+              si->getLoc(), runningVals->replacement(asi));
         } else {
           SILBuilderWithScope localBuilder(si, ctx);
           auto *newLoad = localBuilder.createLoad(si->getLoc(), asi,
@@ -414,21 +576,31 @@ StoreInst *StackAllocationPromoter::promoteAllocationInBlock(
       }
 
       // If we met a store before this one, delete it.
-      if (lastStore) {
-        assert(lastStore->getOwnershipQualifier() !=
+      if (lastValueInstructions) {
+        assert(lastValueInstructions->store->getOwnershipQualifier() !=
                    StoreOwnershipQualifier::Assign &&
                "store [assign] to the stack location should have been "
                "transformed to a store [init]");
-        LLVM_DEBUG(llvm::dbgs()
-                   << "*** Removing redundant store: " << *lastStore);
+        LLVM_DEBUG(llvm::dbgs() << "*** Removing redundant store: "
+                                << lastValueInstructions->store);
         ++NumInstRemoved;
-        deleter.forceDelete(lastStore);
+        deleter.forceDelete(lastValueInstructions->store);
       }
 
       // The stored value is the new running value.
-      runningVal = si->getSrc();
+      auto oldRunningVals = runningVals;
+      runningVals = LiveValues::toReplace(asi, /*replacement=*/si->getSrc());
       // The current store is now the LastStore
-      lastStore = si;
+      lastValueInstructions = {si, nullptr, nullptr};
+      if (shouldAddLexicalLifetime(asi)) {
+        if (oldRunningVals) {
+          endLexicalLifetimeInBlock(
+              asi, si->getParent(), ctx, domInfo, oldRunningVals->copy,
+              oldRunningVals->borrow, oldRunningVals->stored);
+        }
+        std::tie(lastValueInstructions, runningVals) =
+            beginLexicalLifetimeAtStore(asi, si, ctx);
+      }
       continue;
     }
 
@@ -437,25 +609,33 @@ StoreInst *StackAllocationPromoter::promoteAllocationInBlock(
     // if we have a valid value to use at this point. Otherwise we'll
     // promote this when we deal with hooking up phis.
     if (auto *dvi = DebugValueInst::hasAddrVal(inst)) {
-      if (dvi->getOperand() == asi && runningVal)
-        promoteDebugValueAddr(dvi, runningVal, ctx, deleter);
+      if (dvi->getOperand() == asi && runningVals)
+        promoteDebugValueAddr(dvi, runningVals->replacement(asi), ctx, deleter);
       continue;
     }
 
     // Replace destroys with a release of the value.
     if (auto *dai = dyn_cast<DestroyAddrInst>(inst)) {
-      if (dai->getOperand() == asi && runningVal) {
-        replaceDestroy(dai, runningVal, ctx, deleter);
+      if (dai->getOperand() == asi && runningVals) {
+        replaceDestroy(dai, runningVals->replacement(asi), ctx, deleter);
       }
       continue;
     }
 
     if (auto *dvi = dyn_cast<DestroyValueInst>(inst)) {
-      if (dvi->getOperand() == runningVal) {
+      if (runningVals && dvi->getOperand() == runningVals->replacement(asi)) {
+        if (runningVals->borrow) {
+          // If we have started a lexical borrow scope in this block for
+          // runningVals->stored (when runningVals->stored's definition comes
+          // from a store and not from a load), end the borrrow scope here.
+          endLexicalLifetimeInBlock(asi, dvi->getParent(), ctx, domInfo,
+                                    runningVals->copy, runningVals->borrow,
+                                    runningVals->stored);
+        }
         // Reset LastStore.
         // So that we don't end up passing dead values as phi args in
         // StackAllocationPromoter::fixBranchesAndUses
-        lastStore = nullptr;
+        lastValueInstructions = llvm::None;
       }
     }
 
@@ -466,28 +646,39 @@ StoreInst *StackAllocationPromoter::promoteAllocationInBlock(
     }
   }
 
-  if (lastStore) {
-    assert(lastStore->getOwnershipQualifier() !=
+  if (lastValueInstructions) {
+    assert(lastValueInstructions->store->getOwnershipQualifier() !=
                StoreOwnershipQualifier::Assign &&
            "store [assign] to the stack location should have been "
            "transformed to a store [init]");
-    LLVM_DEBUG(llvm::dbgs()
-               << "*** Finished promotion. Last store: " << *lastStore);
+    LLVM_DEBUG(llvm::dbgs() << "*** Finished promotion. Last store: "
+                            << lastValueInstructions->store);
   } else {
     LLVM_DEBUG(llvm::dbgs() << "*** Finished promotion with no stores.\n");
   }
-  return lastStore;
+
+  return lastValueInstructions;
 }
 
 void StackAllocationPromoter::addBlockArguments(BlockSetVector &phiBlocks) {
   LLVM_DEBUG(llvm::dbgs() << "*** Adding new block arguments.\n");
 
-  for (auto *block : phiBlocks)
+  for (auto *block : phiBlocks) {
+    // The stored value.
     block->createPhiArgument(asi->getElementType(), OwnershipKind::Owned);
+    if (shouldAddLexicalLifetime(asi)) {
+      // The borrow scope.
+      block->createPhiArgument(asi->getElementType(),
+                               OwnershipKind::Guaranteed);
+      // The copy of the borrowed value.
+      block->createPhiArgument(asi->getElementType(), OwnershipKind::Owned);
+    }
+  }
 }
 
-SILValue StackAllocationPromoter::getLiveOutValue(BlockSetVector &phiBlocks,
-                                                  SILBasicBlock *startBlock) {
+Optional<LiveValues>
+StackAllocationPromoter::getLiveOutValues(BlockSetVector &phiBlocks,
+                                          SILBasicBlock *startBlock) {
   LLVM_DEBUG(llvm::dbgs() << "*** Searching for a value definition.\n");
   // Walk the Dom tree in search of a defining value:
   for (DomTreeNode *domNode = domInfo->getNode(startBlock); domNode;
@@ -495,42 +686,82 @@ SILValue StackAllocationPromoter::getLiveOutValue(BlockSetVector &phiBlocks,
     SILBasicBlock *domBlock = domNode->getBlock();
 
     // If there is a store (that must come after the phi), use its value.
-    BlockToInstMap::iterator it = lastStoreInBlock.find(domBlock);
-    if (it != lastStoreInBlock.end())
-      if (auto *si = dyn_cast_or_null<StoreInst>(it->second)) {
-        LLVM_DEBUG(llvm::dbgs() << "*** Found Store def " << *si->getSrc());
-        return si->getSrc();
-      }
+    BlockToInstsMap::iterator it = lastStoreInBlock.find(domBlock);
+    if (it != lastStoreInBlock.end()) {
+      auto storedValues = it->second;
+      auto *si = storedValues.store;
+      LLVM_DEBUG(llvm::dbgs() << "*** Found Store def " << *si->getSrc());
+      SILValue borrow = storedValues.borrow;
+      SILValue copy = storedValues.copy;
+      LiveValues values = {si->getSrc(), borrow, copy};
+      return values;
+    }
 
     // If there is a Phi definition in this block:
     if (phiBlocks.contains(domBlock)) {
       // Return the dummy instruction that represents the new value that we will
       // add to the basic block.
-      SILValue phi = domBlock->getArgument(domBlock->getNumArguments() - 1);
-      LLVM_DEBUG(llvm::dbgs() << "*** Found a dummy Phi def " << *phi);
-      return phi;
+      SILValue original;
+      SILValue borrow;
+      SILValue copy;
+      if (shouldAddLexicalLifetime(asi)) {
+        original = domBlock->getArgument(domBlock->getNumArguments() - 3);
+        borrow = domBlock->getArgument(domBlock->getNumArguments() - 2);
+        copy = domBlock->getArgument(domBlock->getNumArguments() - 1);
+      } else {
+        original = domBlock->getArgument(domBlock->getNumArguments() - 1);
+        borrow = SILValue();
+        copy = SILValue();
+      }
+      LLVM_DEBUG(llvm::dbgs() << "*** Found a dummy Phi def " << *original);
+      LiveValues values = {original, borrow, copy};
+      return values;
     }
 
     // Move to the next dominating block.
     LLVM_DEBUG(llvm::dbgs() << "*** Walking up the iDOM.\n");
   }
   LLVM_DEBUG(llvm::dbgs() << "*** Could not find a Def. Using Undef.\n");
-  return SILUndef::get(asi->getElementType(), *asi->getFunction());
+  return llvm::None;
 }
 
-SILValue StackAllocationPromoter::getLiveInValue(BlockSetVector &phiBlocks,
-                                                 SILBasicBlock *block) {
+LiveValues
+StackAllocationPromoter::getEffectiveLiveOutValues(BlockSetVector &phiBlocks,
+                                                   SILBasicBlock *startBlock) {
+  if (auto values = getLiveOutValues(phiBlocks, startBlock)) {
+    return *values;
+  }
+  auto *undef = SILUndef::get(asi->getElementType(), *asi->getFunction());
+  return {undef, undef, undef};
+}
+
+Optional<LiveValues>
+StackAllocationPromoter::getLiveInValues(BlockSetVector &phiBlocks,
+                                         SILBasicBlock *block) {
   // First, check if there is a Phi value in the current block. We know that
   // our loads happen before stores, so we need to first check for Phi nodes
   // in the first block, but stores first in all other stores in the idom
   // chain.
   if (phiBlocks.contains(block)) {
     LLVM_DEBUG(llvm::dbgs() << "*** Found a local Phi definition.\n");
-    return block->getArgument(block->getNumArguments() - 1);
+    SILValue original;
+    SILValue borrow;
+    SILValue copy;
+    if (shouldAddLexicalLifetime(asi)) {
+      original = block->getArgument(block->getNumArguments() - 3);
+      borrow = block->getArgument(block->getNumArguments() - 2);
+      copy = block->getArgument(block->getNumArguments() - 1);
+    } else {
+      original = block->getArgument(block->getNumArguments() - 1);
+      borrow = SILValue();
+      copy = SILValue();
+    }
+    LiveValues values = {original, borrow, copy};
+    return values;
   }
 
   if (block->pred_empty() || !domInfo->getNode(block))
-    return SILUndef::get(asi->getElementType(), *asi->getFunction());
+    return llvm::None;
 
   // No phi for this value in this block means that the value flowing
   // out of the immediate dominator reaches here.
@@ -538,7 +769,17 @@ SILValue StackAllocationPromoter::getLiveInValue(BlockSetVector &phiBlocks,
   assert(iDom &&
          "Attempt to get live-in value for alloc_stack in entry block!");
 
-  return getLiveOutValue(phiBlocks, iDom->getBlock());
+  return getLiveOutValues(phiBlocks, iDom->getBlock());
+}
+
+LiveValues
+StackAllocationPromoter::getEffectiveLiveInValues(BlockSetVector &phiBlocks,
+                                                  SILBasicBlock *block) {
+  if (auto values = getLiveInValues(phiBlocks, block)) {
+    return *values;
+  }
+  auto *undef = SILUndef::get(asi->getElementType(), *asi->getFunction());
+  return {undef, undef, undef};
 }
 
 void StackAllocationPromoter::fixPhiPredBlock(BlockSetVector &phiBlocks,
@@ -547,11 +788,18 @@ void StackAllocationPromoter::fixPhiPredBlock(BlockSetVector &phiBlocks,
   TermInst *ti = predBlock->getTerminator();
   LLVM_DEBUG(llvm::dbgs() << "*** Fixing the terminator " << ti << ".\n");
 
-  SILValue def = getLiveOutValue(phiBlocks, predBlock);
+  LiveValues def = getEffectiveLiveOutValues(phiBlocks, predBlock);
 
-  LLVM_DEBUG(llvm::dbgs() << "*** Found the definition: " << *def);
+  LLVM_DEBUG(llvm::dbgs() << "*** Found the definition: " << *def.copy);
 
-  addArgumentToBranch(def, destBlock, ti);
+  SmallVector<SILValue> vals;
+  vals.push_back(def.stored);
+  if (shouldAddLexicalLifetime(asi)) {
+    vals.push_back(def.borrow);
+    vals.push_back(def.copy);
+  }
+
+  addArgumentsToBranch(vals, destBlock, ti);
   deleter.forceDelete(ti);
 }
 
@@ -601,7 +849,8 @@ void StackAllocationPromoter::propagateLiveness(
   }
 }
 
-void StackAllocationPromoter::fixBranchesAndUses(BlockSetVector &phiBlocks) {
+void StackAllocationPromoter::fixBranchesAndUses(BlockSetVector &phiBlocks,
+                                                 BlockSetVector &phiBlocksOut) {
   // First update uses of the value.
   SmallVector<LoadInst *, 4> collectedLoads;
 
@@ -613,19 +862,19 @@ void StackAllocationPromoter::fixBranchesAndUses(BlockSetVector &phiBlocks) {
     collectedLoads.clear();
     collectLoads(user, collectedLoads);
     for (auto *li : collectedLoads) {
-      SILValue def;
+      LiveValues def;
       // If this block has no predecessors then nothing dominates it and
       // the instruction is unreachable. If the instruction we're
       // examining is a value, replace it with undef. Either way, delete
       // the instruction and move on.
       SILBasicBlock *loadBlock = li->getParent();
-      def = getLiveInValue(phiBlocks, loadBlock);
+      def = getEffectiveLiveInValues(phiBlocks, loadBlock);
 
       LLVM_DEBUG(llvm::dbgs()
-                 << "*** Replacing " << *li << " with Def " << *def);
+                 << "*** Replacing " << *li << " with Def " << def.stored);
 
       // Replace the load with the definition that we found.
-      replaceLoad(li, def, asi, ctx, deleter);
+      replaceLoad(li, def.replacement(asi), asi, ctx, deleter);
       removedUser = true;
       ++NumInstRemoved;
     }
@@ -641,16 +890,16 @@ void StackAllocationPromoter::fixBranchesAndUses(BlockSetVector &phiBlocks) {
     if (auto *dvi = DebugValueInst::hasAddrVal(user)) {
       // Replace debug_value w/ address-type value with
       // a new debug_value w/ promoted value.
-      SILValue def = getLiveInValue(phiBlocks, userBlock);
-      promoteDebugValueAddr(dvi, def, ctx, deleter);
+      auto def = getEffectiveLiveInValues(phiBlocks, userBlock);
+      promoteDebugValueAddr(dvi, def.replacement(asi), ctx, deleter);
       ++NumInstRemoved;
       continue;
     }
 
     // Replace destroys with a release of the value.
     if (auto *dai = dyn_cast<DestroyAddrInst>(user)) {
-      SILValue def = getLiveInValue(phiBlocks, userBlock);
-      replaceDestroy(dai, def, ctx, deleter);
+      auto def = getEffectiveLiveInValues(phiBlocks, userBlock);
+      replaceDestroy(dai, def.replacement(asi), ctx, deleter);
       continue;
     }
   }
@@ -693,6 +942,63 @@ void StackAllocationPromoter::fixBranchesAndUses(BlockSetVector &phiBlocks) {
       if (!livePhis.contains(proactivePhi)) {
         proactivePhi->replaceAllUsesWithUndef();
         erasePhiArgument(block, block->getNumArguments() - 1);
+        if (shouldAddLexicalLifetime(asi)) {
+          erasePhiArgument(block, block->getNumArguments() - 1);
+          erasePhiArgument(block, block->getNumArguments() - 1);
+        }
+      } else {
+        phiBlocksOut.insert(block);
+      }
+    }
+  } else {
+    for (auto *block : phiBlocks)
+      phiBlocksOut.insert(block);
+  }
+}
+
+/// End the lexical lifetimes that were introduced for the alloc_stack if it was
+/// lexical, if any.
+///
+/// Identify the blocks which need to end a lexical borrow scope, and then
+/// insert the end into them.  Find those blocks by visiting the successors of
+/// each new lexical begin_borrow's block.  End the borrow scope in the visited
+/// blocks if any of the following conditions are met:
+/// (1) The block is terminal--if we haven't managed to end the borrow scope
+///     before the last block in the function, it must be ended there.
+/// (2) Any of its successors don't have live-in values for the alloc_stack--in
+///     order for a block to propagate the copied value so that it might
+///     eventually be destroyed, the block must pass that value on to all its
+///     successors; if any successor does not take that value, then neither it
+///     nor any of its successors could possibly destroy the value.
+/// (3) The block had a dealloc_stack--if the allocated space was deallocated
+///     in this block, the lifetime of any value stored in it must end there.
+void StackAllocationPromoter::endLexicalLifetime(BlockSetVector &phiBlocks) {
+  if (!shouldAddLexicalLifetime(asi))
+    return;
+
+  SmallPtrSet<SILBasicBlock *, 4> dsiBlocks;
+  for (auto *dsi : dsis)
+    dsiBlocks.insert(dsi->getParent());
+
+  DAGNodeWorklist<SILBasicBlock *, 32> worklist;
+  worklist.initializeRange(lexicalBBIBlocks);
+  while (auto *bb = worklist.pop()) {
+    bool isFunctionExit = bb->getSuccessorBlocks().empty();
+    auto successorsHaveLiveInValues = [&]() -> bool {
+      return llvm::all_of(bb->getSuccessorBlocks(), [&](auto *successor) {
+        return getLiveInValues(phiBlocks, successor);
+      });
+    };
+    auto hadDeallocStack = [&]() -> bool { return dsiBlocks.contains(bb); };
+    if (isFunctionExit || !successorsHaveLiveInValues() || hadDeallocStack()) {
+      auto values = getLiveOutValues(phiBlocks, bb);
+      if (!values)
+        continue;
+      endLexicalLifetimeInBlock(asi, bb, ctx, domInfo, values->copy,
+                                values->borrow, values->stored);
+    } else {
+      for (auto *successor : bb->getSuccessorBlocks()) {
+        worklist.insert(successor);
       }
     }
   }
@@ -709,10 +1015,16 @@ void StackAllocationPromoter::pruneAllocStackUsage() {
   // Clear AllocStack state.
   lastStoreInBlock.clear();
 
-  for (auto block : functionBlocks) {
-    StoreInst *si = promoteAllocationInBlock(block);
-    lastStoreInBlock[block] = si;
-  }
+  for (auto block : functionBlocks)
+    if (auto lastValueInstructions = promoteAllocationInBlock(block)) {
+      lastStoreInBlock[block] = *lastValueInstructions;
+      if (lastValueInstructions->borrow) {
+        // If begin_borrow instructions were created, record the blocks to which
+        // they were added.  In order to end these scopes, we need to have a
+        // list of the blocks in which they are begun.
+        lexicalBBIBlocks.push_back(lastValueInstructions->borrow->getParent());
+      }
+    }
 
   LLVM_DEBUG(llvm::dbgs() << "*** Finished pruning : " << *asi);
 }
@@ -813,8 +1125,14 @@ void StackAllocationPromoter::promoteAllocationToPhi() {
   // Replace the dummy values with new block arguments.
   addBlockArguments(phiBlocks);
 
+  // The blocks which still have new phis after fixBranchesAndUses runs.  These
+  // are not necessarily the same as phiBlocks because fixBranchesAndUses
+  // removes superfluous proactive phis.
+  BlockSetVector livePhiBlocks(asi->getFunction());
   // Hook up the Phi nodes, loads, and debug_value_addr with incoming values.
-  fixBranchesAndUses(phiBlocks);
+  fixBranchesAndUses(phiBlocks, livePhiBlocks);
+
+  endLexicalLifetime(livePhiBlocks);
 
   LLVM_DEBUG(llvm::dbgs() << "*** Finished placing Phis ***\n");
 }
@@ -1048,7 +1366,7 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
 
   // The default value of the AllocStack is NULL because we don't have
   // uninitialized variables in Swift.
-  SILValue runningVal = SILValue();
+  Optional<LiveValues> runningVals;
 
   // For all instructions in the block.
   for (auto bbi = parentBlock->begin(), bbe = parentBlock->end(); bbi != bbe;) {
@@ -1058,12 +1376,15 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
     // Remove instructions that we are loading from. Replace the loaded value
     // with our running value.
     if (isLoadFromStack(inst, asi)) {
-      if (!runningVal) {
+      if (!runningVals) {
         // Loading without a previous store is only acceptable if the type is
         // Void (= empty tuple) or a tuple of Voids.
-        runningVal = createValueForEmptyTuple(asi->getElementType(), inst, ctx);
+        runningVals =
+            LiveValues::toReplace(asi, /*replacement=*/createValueForEmptyTuple(
+                                      asi->getElementType(), inst, ctx));
       }
-      replaceLoad(cast<LoadInst>(inst), runningVal, asi, ctx, deleter);
+      replaceLoad(cast<LoadInst>(inst), runningVals->replacement(asi), asi, ctx,
+                  deleter);
       ++NumInstRemoved;
       continue;
     }
@@ -1073,11 +1394,20 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
     if (auto *si = dyn_cast<StoreInst>(inst)) {
       if (si->getDest() == asi) {
         if (si->getOwnershipQualifier() == StoreOwnershipQualifier::Assign) {
-          assert(runningVal);
-          SILBuilderWithScope(si, ctx).createDestroyValue(si->getLoc(),
-                                                          runningVal);
+          assert(runningVals);
+          SILBuilderWithScope(si, ctx).createDestroyValue(
+              si->getLoc(), runningVals->replacement(asi));
         }
-        runningVal = si->getSrc();
+        auto oldRunningVals = runningVals;
+        runningVals = LiveValues::toReplace(asi, /*replacement=*/si->getSrc());
+        if (shouldAddLexicalLifetime(asi)) {
+          if (oldRunningVals) {
+            endLexicalLifetimeInBlock(
+                asi, si->getParent(), ctx, domInfo, oldRunningVals->copy,
+                oldRunningVals->borrow, oldRunningVals->stored);
+          }
+          runningVals = beginLexicalLifetimeAtStore(asi, si, ctx).second;
+        }
         deleter.forceDelete(inst);
         ++NumInstRemoved;
         continue;
@@ -1088,8 +1418,9 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
     // the promoted value.
     if (auto *dvi = DebugValueInst::hasAddrVal(inst)) {
       if (dvi->getOperand() == asi) {
-        if (runningVal) {
-          promoteDebugValueAddr(dvi, runningVal, ctx, deleter);
+        if (runningVals) {
+          promoteDebugValueAddr(dvi, runningVals->replacement(asi), ctx,
+                                deleter);
         } else {
           // Drop debug_value of uninitialized void values.
           assert(asi->getElementType().isVoid() &&
@@ -1103,7 +1434,7 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
     // Replace destroys with a release of the value.
     if (auto *dai = dyn_cast<DestroyAddrInst>(inst)) {
       if (dai->getOperand() == asi) {
-        replaceDestroy(dai, runningVal, ctx, deleter);
+        replaceDestroy(dai, runningVals->replacement(asi), ctx, deleter);
       }
       continue;
     }
@@ -1129,6 +1460,12 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
       ++NumInstRemoved;
       addrInst = dyn_cast<SingleValueInstruction>(op);
     }
+  }
+
+  if (runningVals && shouldAddLexicalLifetime(asi)) {
+    endLexicalLifetimeInBlock(asi, asi->getParent(), ctx, domInfo,
+                              runningVals->copy, runningVals->borrow,
+                              runningVals->stored);
   }
 }
 

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -163,7 +163,9 @@ static void replaceLoad(LoadInst *li, SILValue newValue, AllocStackInst *asi,
 
   while (op != asi) {
     assert(isa<UncheckedAddrCastInst>(op) || isa<StructElementAddrInst>(op) ||
-           isa<TupleElementAddrInst>(op));
+           isa<TupleElementAddrInst>(op) &&
+               "found instruction that should have been skipped in "
+               "isLoadFromStack");
     auto *inst = cast<SingleValueInstruction>(op);
     projections.push_back(Projection(inst));
     op = inst->getOperand(0);

--- a/lib/SILOptimizer/Transforms/SILSROA.cpp
+++ b/lib/SILOptimizer/Transforms/SILSROA.cpp
@@ -202,8 +202,8 @@ createAllocas(llvm::SmallVector<AllocStackInst *, 4> &NewAllocations) {
     // TODO: Add op_fragment support for tuple type
     for (unsigned EltNo : indices(TT->getElementTypes())) {
       SILType EltTy = Type.getTupleElementType(EltNo);
-      NewAllocations.push_back(
-          B.createAllocStack(Loc, EltTy, {}, AI->hasDynamicLifetime()));
+      NewAllocations.push_back(B.createAllocStack(
+          Loc, EltTy, {}, AI->hasDynamicLifetime(), AI->isLexical()));
     }
   } else {
     assert(SD && "SD should not be null since either it or TT must be set at "
@@ -218,7 +218,7 @@ createAllocas(llvm::SmallVector<AllocStackInst *, 4> &NewAllocations) {
 
       NewAllocations.push_back(B.createAllocStack(
           Loc, Type.getFieldType(VD, M, TypeExpansionContext(B.getFunction())),
-          NewDebugVarInfo, AI->hasDynamicLifetime()));
+          NewDebugVarInfo, AI->hasDynamicLifetime(), AI->isLexical()));
     }
   }
 }

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -864,8 +864,8 @@ void swift::placeFuncRef(ApplyInst *ai, DominanceInfo *domInfo) {
 /// Add an argument, \p val, to the branch-edge that is pointing into
 /// block \p Dest. Return a new instruction and do not erase the old
 /// instruction.
-TermInst *swift::addArgumentToBranch(SILValue val, SILBasicBlock *dest,
-                                     TermInst *branch) {
+TermInst *swift::addArgumentsToBranch(ArrayRef<SILValue> vals,
+                                      SILBasicBlock *dest, TermInst *branch) {
   SILBuilderWithScope builder(branch);
 
   if (auto *cbi = dyn_cast<CondBranchInst>(branch)) {
@@ -879,10 +879,12 @@ TermInst *swift::addArgumentToBranch(SILValue val, SILBasicBlock *dest,
       falseArgs.push_back(arg);
 
     if (dest == cbi->getTrueBB()) {
-      trueArgs.push_back(val);
+      for (auto val : vals)
+        trueArgs.push_back(val);
       assert(trueArgs.size() == dest->getNumArguments());
     } else {
-      falseArgs.push_back(val);
+      for (auto val : vals)
+        falseArgs.push_back(val);
       assert(falseArgs.size() == dest->getNumArguments());
     }
 
@@ -898,7 +900,8 @@ TermInst *swift::addArgumentToBranch(SILValue val, SILBasicBlock *dest,
     for (auto arg : bi->getArgs())
       args.push_back(arg);
 
-    args.push_back(val);
+    for (auto val : vals)
+      args.push_back(val);
     assert(args.size() == dest->getNumArguments());
     return builder.createBranch(bi->getLoc(), bi->getDestBB(), args);
   }

--- a/test/SILOptimizer/allocbox_to_stack_lifetime.sil
+++ b/test/SILOptimizer/allocbox_to_stack_lifetime.sil
@@ -1,0 +1,30 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -allocbox-to-stack -enable-experimental-lexical-lifetimes | %FileCheck %s
+
+import Builtin
+
+struct Int {
+  var _value: Builtin.Int64
+}
+
+struct Bool {
+  var _value: Builtin.Int1
+}
+
+protocol Error {}
+
+// CHECK-LABEL: sil [ossa] @simple_promotion
+sil [ossa] @simple_promotion : $@convention(thin) (Int) -> Int {
+bb0(%0 : $Int):
+  %1 = alloc_box ${ var Int }
+  %1a = project_box %1 : ${ var Int }, 0
+  store %0 to [trivial] %1a : $*Int
+
+  %3 = load [trivial] %1a : $*Int
+  destroy_value %1 : ${ var Int }
+  return %3 : $Int
+// CHECK: alloc_stack [lexical]
+// CHECK-NOT: alloc_box
+// CHECK-NOT: destroy_value
+// CHECK: return
+}
+

--- a/test/SILOptimizer/mem2reg_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_lifetime.sil
@@ -1,0 +1,863 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-experimental-lexical-lifetimes %s -mem2reg | %FileCheck %s
+
+// =============================================================================
+// Copied from mem2reg_ossa.sil                                               {{
+// =============================================================================
+
+
+import Builtin
+import Swift
+
+//////////////////
+// Declarations //
+//////////////////
+
+class Klass {}
+
+struct SmallCodesizeStruct {
+  var cls1 : Klass
+  var cls2 : Klass
+}
+
+struct LargeCodesizeStruct {
+  var s1: SmallCodesizeStruct
+  var s2: SmallCodesizeStruct
+  var s3: SmallCodesizeStruct
+  var s4: SmallCodesizeStruct
+  var s5: SmallCodesizeStruct
+}
+
+///////////
+// Tests //
+///////////
+
+// CHECK-LABEL: sil [ossa] @store_only_allocas :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'store_only_allocas'
+// simple.foo0 (c : Swift.Int64) -> ()
+sil [ossa] @store_only_allocas : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  %1 = alloc_stack [lexical] $Int64, var, name "c"
+  store %0 to [trivial] %1 : $*Int64
+  // function_ref Swift.print (val : Swift.Int64) -> ()
+  %3 = function_ref @_Ts5printFT3valSi_T_ : $@convention(thin) (Int64) -> ()
+  %4 = apply %3(%0) : $@convention(thin) (Int64) -> ()
+  dealloc_stack %1 : $*Int64
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// Swift.print (val : Swift.Int64) -> ()
+sil [ossa] @_Ts5printFT3valSi_T_ : $@convention(thin) (Int64) -> ()
+
+// CHECK-LABEL: sil [ossa] @multiple_store_vals :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'multiple_store_vals'
+// simple.foo1 (c : Swift.Int64) -> Swift.Int64
+sil [ossa] @multiple_store_vals : $@convention(thin) (Int64) -> Int64 {
+bb0(%0 : $Int64):
+  %1 = alloc_stack [lexical] $Int64, var, name "c"
+  store %0 to [trivial] %1 : $*Int64
+  %3 = alloc_stack [lexical] $Int64, var, name "x"
+  %4 = integer_literal $Builtin.Int64, 2
+  %5 = struct $Int64 (%4 : $Builtin.Int64)
+  store %5 to [trivial] %3 : $*Int64
+  %7 = integer_literal $Builtin.Int64, 5
+  %8 = integer_literal $Builtin.Int1, 0
+  %9 = struct $Int64 (%7 : $Builtin.Int64)
+  cond_fail %8 : $Builtin.Int1
+  store %9 to [trivial] %3 : $*Int64
+  store %9 to [trivial] %3 : $*Int64
+  dealloc_stack %3 : $*Int64
+  dealloc_stack %1 : $*Int64
+  return %9 : $Int64
+}
+
+// CHECK-LABEL: sil [ossa] @multiple_store_vals2 :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'multiple_store_vals2'
+// simple.foo2 (c : Swift.Int64) -> Swift.Int64
+sil [ossa] @multiple_store_vals2 : $@convention(thin) (Int64) -> Int64 {
+bb0(%0 : $Int64):
+  %1 = alloc_stack [lexical] $Int64, var, name "c"
+  store %0 to [trivial] %1 : $*Int64
+  %3 = alloc_box $<τ_0_0> { var τ_0_0 } <Int64>, var, name "x"
+  %3a = project_box %3 : $<τ_0_0> { var τ_0_0 } <Int64>, 0
+  %4 = integer_literal $Builtin.Int64, 2
+  %5 = struct $Int64 (%4 : $Builtin.Int64)
+  store %5 to [trivial] %3a : $*Int64
+  %8 = struct_extract %0 : $Int64, #Int64._value
+  %9 = builtin "cmp_sgt_Int64"(%8 : $Builtin.Int64, %4 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %9, bb1, bb2
+
+bb1:
+  destroy_value %3 : $<τ_0_0> { var τ_0_0 } <Int64>
+  br bb3(%5 : $Int64)
+
+bb2:
+  %13 = integer_literal $Builtin.Int64, 5
+  %14 = struct $Int64 (%13 : $Builtin.Int64)
+  cond_fail %9 : $Builtin.Int1
+  destroy_value %3 : $<τ_0_0> { var τ_0_0 } <Int64>
+  br bb3(%14 : $Int64)
+
+bb3(%18 : $Int64):
+  dealloc_stack %1 : $*Int64
+  return %18 : $Int64
+}
+
+// CHECK-LABEL: sil [ossa] @with_loads :
+// CHECK: bb3([[RET:%[0-9]+]] : $Int64):
+// CHECK-LABEL: } // end sil function 'with_loads'
+// simple.foo2 (c : Swift.Int64) -> Swift.Int64
+sil [ossa] @with_loads : $@convention(thin) (Int64) -> Int64 {
+bb0(%0 : $Int64):
+  %1 = alloc_stack [lexical] $Int64, var, name "c"
+  store %0 to [trivial] %1 : $*Int64
+  %3 = alloc_box $<τ_0_0> { var τ_0_0 } <Int64>, var, name "x"
+  %3a = project_box %3 : $<τ_0_0> { var τ_0_0 } <Int64>, 0
+  %4 = integer_literal $Builtin.Int64, 2
+  %5 = struct $Int64 (%4 : $Builtin.Int64)
+  store %5 to [trivial] %3a : $*Int64
+  %8 = struct_extract %0 : $Int64, #Int64._value
+  %9 = builtin "cmp_sgt_Int64"(%8 : $Builtin.Int64, %4 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %9, bb1, bb2
+
+bb1:
+  destroy_value %3 : $<τ_0_0> { var τ_0_0 } <Int64>
+  br bb3(%5 : $Int64)
+
+bb2:
+  %13 = integer_literal $Builtin.Int64, 5
+  %14 = struct $Int64 (%13 : $Builtin.Int64)
+  cond_fail %9 : $Builtin.Int1
+  destroy_value %3 : $<τ_0_0> { var τ_0_0 } <Int64>
+  br bb3(%14 : $Int64)
+
+bb3(%18 : $Int64):
+  %20 = load [trivial] %1 : $*Int64
+  dealloc_stack %1 : $*Int64
+  return %18 : $Int64
+}
+
+// CHECK-LABEL: sil [ossa] @basic_block_with_loads_and_stores :
+// CHECK-NOT: alloc_stack
+// CHECK-NOT: begin_borrow
+// CHECK-LABEL: } // end sil function 'basic_block_with_loads_and_stores'
+// test.foo3 (c : Swift.Int64) -> ()
+sil [ossa] @basic_block_with_loads_and_stores : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  %1 = alloc_stack [lexical] $Int64, var, name "c"
+  store %0 to [trivial] %1 : $*Int64
+  %3 = alloc_stack [lexical] $Int64, var, name "x"
+  %4 = integer_literal $Builtin.Int64, 3
+  %5 = struct $Int64 (%4 : $Builtin.Int64)
+  store %5 to [trivial] %3 : $*Int64
+  %7 = integer_literal $Builtin.Int64, 3
+  %9 = struct_extract %0 : $Int64, #Int64._value
+  %10 = builtin "cmp_sgt_Int64"(%9 : $Builtin.Int64, %7 : $Builtin.Int64) : $Builtin.Int1
+
+  %12 = integer_literal $Builtin.Int64, 2
+  %13 = struct $Int64 (%12 : $Builtin.Int64)
+  store %13 to [trivial] %3 : $*Int64
+
+  // function_ref Swift.print (val : Swift.Int64) -> ()
+  %16 = function_ref @_Ts5printFT3valSi_T_ : $@convention(thin) (Int64) -> ()
+  %17 = load [trivial] %3 : $*Int64
+  %18 = apply %16(%17) : $@convention(thin) (Int64) -> ()
+  dealloc_stack %3 : $*Int64
+  dealloc_stack %1 : $*Int64
+  %21 = tuple ()
+  return %21 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @load_uninitialized_empty :
+// CHECK-NOT: load
+// CHECK-NOT: begin_borrow
+// CHECK-LABEL: } // end sil function 'load_uninitialized_empty'
+sil [ossa] @load_uninitialized_empty : $@convention(thin) (@inout ()) -> () {
+bb0(%0 : $*()):
+  %1 = alloc_stack [lexical] $()
+  %2 = load [trivial] %1 : $*()
+  store %2 to [trivial] %0 : $*()
+  dealloc_stack %1 : $*()
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @mem2reg_debug_value :
+// CHECK-NOT: alloc_stack
+// CHECK-NOT: begin_borrow
+// CHECK-NOT: debug_value {{.*}} expr op_deref
+// CHECK: debug_value %0
+// CHECK-LABEL: } // end sil function 'mem2reg_debug_value'
+sil [ossa] @mem2reg_debug_value : $@convention(thin) (Int) -> Int {
+bb0(%0 : $Int):
+  %1 = alloc_stack [lexical] $Int
+  store %0 to [trivial] %1 : $*Int
+  debug_value %1 : $*Int, expr op_deref
+  %2 = load [trivial] %1 : $*Int
+  dealloc_stack %1 : $*Int
+  return %2 : $Int
+}
+
+// CHECK-LABEL: sil [ossa] @mem2reg_struct_addr :
+// CHECK-NOT: alloc_stack
+// CHECK-NOT: begin_borrow
+// CHECK: struct_extract
+// CHECK-LABEL: } // end sil function 'mem2reg_struct_addr'
+sil [ossa] @mem2reg_struct_addr : $@convention(thin) (Int64) -> Builtin.Int64 {
+bb0(%0 : $Int64):
+  %1 = alloc_stack [lexical] $Int64
+  store %0 to [trivial] %1 : $*Int64
+  %2 = struct_element_addr %1 : $*Int64, #Int64._value
+  %3 = load [trivial] %2 : $*Builtin.Int64
+  dealloc_stack %1 : $*Int64
+  return %3 : $Builtin.Int64
+}
+
+// CHECK-LABEL: sil [ossa] @mem2reg_tuple_addr :
+// CHECK-NOT: alloc_stack
+// CHECK-NOT: begin_borrow
+// CHECK: tuple_extract {{.*}}, 0
+// CHECK-LABEL: } // end sil function 'mem2reg_tuple_addr'
+sil [ossa] @mem2reg_tuple_addr : $@convention(thin) (Int64) -> Int64 {
+bb0(%0 : $Int64):
+  %1 = alloc_stack [lexical] $(Int64, Int64)
+  %2 = tuple (%0 : $Int64, %0 : $Int64)
+  store %2 to [trivial] %1 : $*(Int64, Int64)
+  %4 = tuple_element_addr %1 : $*(Int64, Int64), 0
+  %5 = load [trivial] %4 : $*Int64
+  dealloc_stack %1 : $*(Int64, Int64)
+  return %5 : $Int64
+}
+
+// CHECK-LABEL: sil [ossa] @struct_extract_if_then_else :
+// CHECK-NOT: alloc_stack
+// CHECK-NOT: begin_borrow
+sil [ossa] @struct_extract_if_then_else : $@convention(thin) (Int64) -> Int64 {
+bb0(%0 : $Int64):
+  %1 = alloc_stack [lexical] $Int64
+  store %0 to [trivial] %1 : $*Int64
+  %3 = integer_literal $Builtin.Int64, 2
+  %4 = struct_extract %0 : $Int64, #Int64._value
+  %5 = builtin "cmp_sgt_Int64"(%4 : $Builtin.Int64, %3 : $Builtin.Int64) : $Builtin.Int1
+  %6 = struct_element_addr %1 : $*Int64, #Int64._value
+  cond_br %5, bb1, bb2
+
+// CHECK: bb1:
+// CHECK: struct_extract %0
+bb1:
+  %8 = load [trivial] %6 : $*Builtin.Int64
+  %9 = integer_literal $Builtin.Int64, 1
+  %10 = integer_literal $Builtin.Int1, 0
+  %11 = builtin "sadd_with_overflow_Int64"(%8 : $Builtin.Int64, %9 : $Builtin.Int64, %10 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %12 = tuple_extract %11 : $(Builtin.Int64, Builtin.Int1), 0
+  br bb3(%12 : $Builtin.Int64)
+
+// CHECK: bb2:
+// CHECK: struct_extract %0
+bb2:
+  %14 = load [trivial] %6 : $*Builtin.Int64
+  %15 = integer_literal $Builtin.Int64, 2
+  %16 = integer_literal $Builtin.Int1, 0
+  %17 = builtin "sadd_with_overflow_Int64"(%14 : $Builtin.Int64, %15 : $Builtin.Int64, %16 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %18 = tuple_extract %17 : $(Builtin.Int64, Builtin.Int1), 0
+  br bb3(%18 : $Builtin.Int64)
+
+// CHECK-NOT: dealloc_stack
+bb3(%20 : $Builtin.Int64):
+  dealloc_stack %1 : $*Int64
+  %22 = struct $Int64 (%20 : $Builtin.Int64)
+  return %22 : $Int64
+}
+// CHECK-LABEL: } // end sil function 'struct_extract_if_then_else'
+
+sil [ossa] @first : $@convention(thin) () -> Int
+sil [ossa] @second : $@convention(thin) () -> Int
+
+// CHECK: sil [ossa] @promote_function_refs :
+sil [ossa] @promote_function_refs : $@convention(thin) (Bool) -> Int {
+// CHECK: bb0
+bb0(%0 : $Bool):
+// CHECK-NOT: [[STACK:%.*]] = alloc_stack
+  %1 = alloc_stack $@callee_owned () -> Int
+  debug_value %0 : $Bool
+  %3 = struct_extract %0 : $Bool, #Bool._value
+  cond_br %3, bb1, bb2
+
+// CHECK: bb1
+bb1:
+// CHECK: [[FIRSTREF:%.*]] = function_ref @first
+  %5 = function_ref @first : $@convention(thin) () -> Int
+// CHECK: [[FIRSTTHICK:%.*]] =  thin_to_thick_function [[FIRSTREF]]
+  %6 = thin_to_thick_function %5 : $@convention(thin) () -> Int to $@callee_owned () -> Int
+// CHECK-NOT: store
+  store %6 to [init] %1 : $*@callee_owned () -> Int
+// CHECK: br bb3([[FIRSTTHICK]] : $@callee_owned () -> Int
+  br bb3
+
+// CHECK: bb2
+bb2:
+// CHECK: [[SECONDREF:%.*]] = function_ref @second
+  %9 = function_ref @second : $@convention(thin) () -> Int
+// CHECK: [[SECONDTHICK:%.*]] =  thin_to_thick_function [[SECONDREF]]
+  %10 = thin_to_thick_function %9 : $@convention(thin) () -> Int to $@callee_owned () -> Int
+// CHECK-NOT: store
+  store %10 to [init] %1 : $*@callee_owned () -> Int
+// CHECK: br bb3([[SECONDTHICK]] : $@callee_owned () -> Int)
+  br bb3
+
+// CHECK: bb3([[ARG:%.*]] : @owned $@callee_owned () -> Int):
+bb3:
+// CHECK-NOT: load [[STACK]]
+  %13 = load [copy] %1 : $*@callee_owned () -> Int
+// CHECK: [[COPY:%.*]] = copy_value [[ARG]]
+// CHECK: [[RESULT:%.*]] = apply [[COPY]]
+  %15 = apply %13() : $@callee_owned () -> Int
+  br bb4
+
+  // NOTE: This block and the branch above exist to ensure that we
+  //       test what happens when %1 hasn't already been loaded in this
+  //       block.
+// CHECK: bb4
+bb4:
+// CHECK-NOT: destroy_addr [[STACK]]
+// CHECK: destroy_value [[ARG]]
+  destroy_addr %1 : $*@callee_owned () -> Int
+// CHECK-NOT: dealloc_stack [[STACK]]
+  dealloc_stack %1 : $*@callee_owned () -> Int
+  return %15 : $Int
+}
+// CHECK-LABEL: } // end sil function 'promote_function_refs'
+
+// Test cases where the only use is a debug_value_addr
+// CHECK-LABEL: sil [ossa] @no_real_uses :
+sil [ossa] @no_real_uses : $@convention(thin) () -> () {
+// CHECK: bb0
+bb0:
+  // CHECK-NOT: alloc_stack
+  %0 = alloc_stack [lexical] [dynamic_lifetime] $Builtin.Int32
+  // CHECK-NOT: debug_value {{.*}} expr op_deref
+  debug_value %0 : $*Builtin.Int32, let, name "x", argno 1, expr op_deref
+  // CHECK-NOT: dealloc_stack
+  dealloc_stack %0 : $*Builtin.Int32
+  %1 = tuple ()
+  return %1 : $()
+}
+// CHECK-LABEL: } // end sil function 'no_real_uses'
+
+// CHECK-LABEL: sil [ossa] @keep_release :
+// CHECK: destroy_value %0
+// CHECK-LABEL: } // end sil function 'keep_release'
+sil [ossa] @keep_release : $@convention(thin) (@owned AnyObject) -> () {
+bb0(%0 : @owned $AnyObject):
+  %1 = alloc_stack [lexical] $AnyObject
+  store %0 to [init] %1 : $*AnyObject
+  destroy_addr %1 : $*AnyObject
+  dealloc_stack %1 : $*AnyObject
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// Test cases where there are dead address instructions.
+// CHECK-LABEL: sil [ossa] @dead_use :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'dead_use'
+sil [ossa] @dead_use : $@convention(thin) () -> () {
+  %0 = alloc_stack [lexical] $Int64
+  %1 = struct_element_addr %0 : $*Int64, #Int64._value
+  dealloc_stack %0 : $*Int64
+  %2 = alloc_stack [lexical] $(Int64, Int64)
+  %3 = tuple_element_addr %2 : $*(Int64, Int64), 0
+  dealloc_stack %2 : $*(Int64, Int64)
+  %4 = tuple ()
+  return %4 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dont_crash_on_dead_arg_use :
+// CHECK: bb0{{.*}}:
+// CHECK:      tuple ()
+// CHECK-LABEL: } // end sil function 'dont_crash_on_dead_arg_use'
+sil [ossa] @dont_crash_on_dead_arg_use : $@convention(thin) (@inout Int64) -> () {
+bb0(%0 : $*Int64):
+  %2 = alloc_stack [lexical] $Int64
+  %1 = struct_element_addr %0 : $*Int64, #Int64._value
+  %3 = struct_element_addr %2 : $*Int64, #Int64._value
+  dealloc_stack %2 : $*Int64
+  %4 = tuple ()
+  return %4 : $()
+}
+
+// Make sure that we do expand destroy_addr appropriately for code-size
+// trade-offs.
+// CHECK-LABEL: sil [ossa] @large_struct_test :
+// CHECK: bb0([[ARG0:%.*]] : @owned $LargeCodesizeStruct):
+// CHECK:   destroy_value [[ARG0]]
+// CHECK: } // end sil function 'large_struct_test'
+sil [ossa] @large_struct_test : $@convention(thin) (@owned LargeCodesizeStruct) -> () {
+bb0(%0 : @owned $LargeCodesizeStruct):
+  %1 = alloc_stack [lexical] $LargeCodesizeStruct
+  store %0 to [init] %1 : $*LargeCodesizeStruct
+  destroy_addr %1 : $*LargeCodesizeStruct
+  dealloc_stack %1 : $*LargeCodesizeStruct
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @small_struct_test :
+// CHECK: bb0([[ARG0:%.*]] : @owned $SmallCodesizeStruct):
+// CHECK:   [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[ARG0]]
+// CHECK:   [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:   ([[ELEM1:%[0-9]+]], [[ELEM2:%[0-9]+]]) = destructure_struct [[LIFETIME_OWNED]]
+// CHECK:   end_borrow [[LIFETIME]]
+// CHECK:   destroy_value [[ARG0]]
+// CHECK:   destroy_value [[ELEM1]]
+// CHECK:   destroy_value [[ELEM2]]
+// CHECK: } // end sil function 'small_struct_test'
+sil [ossa] @small_struct_test : $@convention(thin) (@owned SmallCodesizeStruct) -> () {
+bb0(%0 : @owned $SmallCodesizeStruct):
+  %1 = alloc_stack [lexical] $SmallCodesizeStruct
+  store %0 to [init] %1 : $*SmallCodesizeStruct
+  destroy_addr %1 : $*SmallCodesizeStruct
+  dealloc_stack %1 : $*SmallCodesizeStruct
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @small_struct_multi_test :
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $SmallCodesizeStruct):
+// CHECK-NOT:     alloc_stack
+// CHECK:       [[LIFETIME:%[^,]+]] = begin_borrow [lexical] %0
+// CHECK:       [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:       bb1:
+// CHECK:         [[COPY:%.*]] = copy_value [[LIFETIME_OWNED]]
+// CHECK-NEXT:    destructure_struct [[LIFETIME_OWNED]]
+// CHECK-NEXT:    end_borrow [[LIFETIME]]
+// CHECK-NEXT:    destroy_value [[INSTANCE]]
+// CHECK-NEXT:    destroy_value
+// CHECK-NEXT:    destroy_value
+// CHECK-NEXT:    begin_borrow [[COPY]]
+// CHECK-NEXT:    debug_value
+// CHECK-NEXT:    end_borrow
+// CHECK-NEXT:    destroy_value [[COPY]]
+// CHECK:       bb2:
+// CHECK-NEXT:    destructure_struct [[LIFETIME_OWNED]]
+// CHECK-NEXT:    end_borrow [[LIFETIME]]
+// CHECK-NEXT:    destroy_value [[INSTANCE]]
+// CHECK-NEXT:    destroy_value
+// CHECK-NEXT:    destroy_value
+// CHECK-LABEL: } // end sil function 'small_struct_multi_test'
+sil [ossa] @small_struct_multi_test : $@convention(thin) (@owned SmallCodesizeStruct) -> () {
+bb0(%0 : @owned $SmallCodesizeStruct):
+  %1 = alloc_stack [lexical] $SmallCodesizeStruct
+  store %0 to [init] %1 : $*SmallCodesizeStruct
+  cond_br undef, bb1, bb2
+  
+bb1:
+  %3 = load [copy] %1 : $*SmallCodesizeStruct
+  destroy_addr %1 : $*SmallCodesizeStruct
+  dealloc_stack %1 : $*SmallCodesizeStruct
+  %4 = begin_borrow %3 : $SmallCodesizeStruct
+  debug_value %4 : $SmallCodesizeStruct
+  end_borrow %4 : $SmallCodesizeStruct
+  destroy_value %3 : $SmallCodesizeStruct
+  br bb3
+
+bb2:
+  destroy_addr %1 : $*SmallCodesizeStruct
+  dealloc_stack %1 : $*SmallCodesizeStruct
+  br bb3
+  
+bb3:
+  %7 = tuple ()
+  return %7 : $()
+}
+
+
+// CHECK-LABEL: sil [ossa] @dead_address_projections :
+// CHECK-NOT: alloc_stack
+// CHECK: } // end sil function 'dead_address_projections'
+sil [ossa] @dead_address_projections : $@convention(thin) (((), ())) -> ((), ()) {
+bb0(%0 : $((), ())):
+  %1 = alloc_stack [lexical] $((), ())
+  %200 = tuple_element_addr %1 : $*((), ()), 0
+  %300 = tuple_element_addr %1 : $*((), ()), 1
+  cond_br undef, bb1, bb2
+
+bb1:
+  store %0 to [trivial] %1 : $*((), ())
+  %16 = load [trivial] %1 : $*((), ())
+  dealloc_stack %1 : $*((), ())
+  br bb3(%16 : $((), ()))
+
+bb2:
+  dealloc_stack %1 : $*((), ())
+  br bb3(%0 : $((), ()))
+
+bb3(%20 : $((), ())):
+  return %20 : $((), ())
+}
+
+// CHECK-LABEL: sil [ossa] @load_tuple_of_void :
+// CHECK-NOT: alloc_stack
+// CHECK:   [[T:%[0-9]+]] = tuple (%{{[0-9]+}} : $(), %{{[0-9]+}} : $())
+// CHECK:   return [[T]] : $((), ())
+// CHECK: } // end sil function 'load_tuple_of_void'
+sil [ossa] @load_tuple_of_void : $@convention(thin) () -> ((), ()) {
+bb0:
+  %1 = alloc_stack [lexical] $((), ())
+  %16 = load [trivial] %1 : $*((), ())
+  dealloc_stack %1 : $*((), ())
+  return %16 : $((), ())
+}
+
+// =============================================================================
+// Copied from mem2reg_ossa.sil                                               }}
+// =============================================================================
+
+// =============================================================================
+// lexical scope specific                                                     {{
+// =============================================================================
+
+class C {}
+
+sil [ossa] @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+sil [ossa] @callee_owned : $@convention(thin) (@owned C) -> ()
+
+
+// An owned instance of C is passed in, stored to the stack, used
+// non-consumingly once, and destroyed.
+//
+// CHECK-LABEL: sil [ossa] @basic_1 : $@convention(thin) (@owned C) -> () {
+// CHECK:       bb0([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         [[CALLEE:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         [[RETVAL:%[^,]+]] = apply [[CALLEE]]([[LIFETIME_OWNED]])
+// CHECK:         destroy_value [[LIFETIME_OWNED]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'basic_1'
+sil [ossa] @basic_1 : $(@owned C) -> () {
+entry(%instance : @owned $C):
+    %scope = alloc_stack [lexical] $C
+    store %instance to [init] %scope : $*C
+    %thing = load [take] %scope : $*C
+    %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %res = apply %callee_guaranteed(%thing) : $@convention(thin) (@guaranteed C) -> ()
+    destroy_value %thing : $C
+    dealloc_stack %scope : $*C
+    return %res : $()
+}
+
+// A guaranteed instance of C is passed in, copied, stored to the stack, used
+// non-consumingly once, and deallocated.
+//
+// CHECK-LABEL: sil [ossa] @basic_3 : $@convention(thin) (@guaranteed C) -> () {
+// CHECK:       bb0([[INSTANCE_GUARANTEED:%[^,]+]] : @guaranteed $C):
+// CHECK:         [[INSTANCE:%[^,]+]] = copy_value [[INSTANCE_GUARANTEED]]
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         [[CALLEE:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         [[RETVAL:%[^,]+]] = apply [[CALLEE]]([[LIFETIME_OWNED]])
+// CHECK:         destroy_value [[LIFETIME_OWNED]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'basic_3'
+sil [ossa] @basic_3 : $(@guaranteed C) -> () {
+entry(%instance_guaranteed : @guaranteed $C):
+    %scope = alloc_stack [lexical] $C
+    %instance = copy_value %instance_guaranteed : $C
+    store %instance to [init] %scope : $*C
+    %thing = load [take] %scope : $*C
+    %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %res = apply %callee_guaranteed(%thing) : $@convention(thin) (@guaranteed C) -> ()
+    destroy_value %thing : $C
+    dealloc_stack %scope : $*C
+    return %res : $()
+}
+
+// An owned instance of C is passed in, stored to the stack, and used
+// consumingly.
+//
+// CHECK-LABEL: sil [ossa] @basic_4 : $@convention(thin) (@owned C) -> () {
+// CHECK:       bb0([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         [[CALLEE:%[^,]+]] = function_ref @callee_owned
+// CHECK:         [[RETVAL:%[^,]+]] = apply [[CALLEE]]([[LIFETIME_OWNED]])
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'basic_4'
+sil [ossa] @basic_4 : $(@owned C) -> () {
+entry(%instance : @owned $C):
+    %scope = alloc_stack [lexical] $C
+    store %instance to [init] %scope : $*C
+    %thing = load [take] %scope : $*C
+    %callee = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+    %res = apply %callee(%thing) : $@convention(thin) (@owned C) -> ()
+    dealloc_stack %scope : $*C
+    return %res : $()
+}
+
+
+// CHECK-LABEL: sil [ossa] @diamond_1 : $@convention(thin) (@owned C, @owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE_1:%[^,]+]] : @owned $C, [[INSTANCE_2:%[^,]+]] : @owned $C):
+// CHECK:         cond_br undef, [[LEFT:bb[^,]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         destroy_value [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]]
+// CHECK:         br [[EXIT:bb[^,]+]]([[INSTANCE_1]] : $C, [[LIFETIME_1]] : $C, [[LIFETIME_OWNED_1]] : $C)
+// CHECK:       [[RIGHT]]:
+// CHECK:         destroy_value [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]]
+// CHECK:         br [[EXIT]]([[INSTANCE_2]] : $C, [[LIFETIME_2]] : $C, [[LIFETIME_OWNED_2]] : $C)
+// CHECK:       [[EXIT]]([[INSTANCE:%[^,]+]] : @owned $C, [[LIFETIME:%[^,]+]] : @guaranteed $C, [[LIFETIME_OWNED:%[^,]+]] : @owned $C):
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         {{%[^,]+}} = apply [[CALLEE_GUARANTEED]]([[LIFETIME_OWNED]])
+// CHECK:         destroy_value [[LIFETIME_OWNED]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         [[RESULT:%[^,]+]] = tuple ()
+// CHECK:         return [[RESULT]] : $()
+// CHECK-LABEL: } // end sil function 'diamond_1'
+sil [ossa] @diamond_1 : $@convention(thin) (@owned C, @owned C) -> () {
+entry(%one : @owned $C, %two : @owned $C):
+    %addr = alloc_stack [lexical] $C
+    cond_br undef, left, right
+left:
+    destroy_value %two : $C
+    store %one to [init] %addr : $*C
+    br exit
+right:
+    destroy_value %one : $C
+    store %two to [init] %addr : $*C
+    br exit
+exit:
+    %value = load [take] %addr : $*C
+    %callee = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %_ = apply %callee(%value) : $@convention(thin) (@guaranteed C) -> ()
+    destroy_value %value : $C
+    dealloc_stack %addr : $*C
+    %result = tuple ()
+    return %result : $()
+}
+
+// Store and load the value to the alloc stack only on one branch.
+//
+// CHECK-LABEL: sil [ossa] @diamond_2 : $@convention(thin) (@owned C, @owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE_0:%[^,]+]] : @owned $C, [[INSTANCE_1:%[^,]+]] : @owned $C):
+// CHECK:         cond_br undef, [[LEFT:bb[^,]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         destroy_value [[INSTANCE_0]]
+// CHECK:         destroy_value [[INSTANCE_1]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         destroy_value [[INSTANCE_0]]
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         {{%[^,]+}} = apply [[CALLEE_GUARANTEED]]([[LIFETIME_OWNED]])
+// CHECK:         destroy_value [[LIFETIME_OWNED]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE_1]]
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'diamond_2'
+sil [ossa] @diamond_2 : $@convention(thin) (@owned C, @owned C) -> () {
+entry(%one : @owned $C, %two : @owned $C):
+    %addr = alloc_stack [lexical] $C
+    cond_br undef, left, right
+left:
+    destroy_value %one : $C
+    destroy_value %two : $C
+    br exit
+right:
+    destroy_value %one : $C
+    store %two to [init] %addr : $*C
+    %value = load [take] %addr : $*C
+    %callee = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %_ = apply %callee(%value) : $@convention(thin) (@guaranteed C) -> ()
+    destroy_value %value : $C
+    br exit
+
+exit:
+    dealloc_stack %addr : $*C
+    %result = tuple ()
+    return %result : $()
+}
+
+// Ensure that the lifetime is extended to the final destroy_addr even when
+// there are no uses after the middle blocks.
+//
+// CHECK-LABEL: sil [ossa] @diamond_3 : $@convention(thin) (@owned C, @owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[ONE:%[^,]+]] : @owned $C, [[TWO:%[^,]+]] : @owned $C):
+// CHECK:         cond_br undef, [[LEFT:bb[^,]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         destroy_value [[TWO]]
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[ONE]]
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]]
+// CHECK:         br [[EXIT:bb[^,]+]]([[ONE]] : $C, [[LIFETIME_1]] : $C, [[LIFETIME_OWNED_1]] : $C)
+// CHECK:       [[RIGHT]]:
+// CHECK:         destroy_value [[ONE]]
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[TWO]]
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]]
+// CHECK:         br [[EXIT]]([[TWO]] : $C, [[LIFETIME_2]] : $C, [[LIFETIME_OWNED_2]] : $C)
+// CHECK:       [[EXIT]]([[INSTANCE:%[^,]+]] : @owned $C, [[LIFETIME:%[^,]+]] : @guaranteed $C, [[LIFETIME_OWNED:%[^,]+]] : @owned $C):
+// CHECK:         destroy_value [[LIFETIME_OWNED]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]] : $()
+// CHECK-LABEL: } // end sil function 'diamond_3'
+sil [ossa] @diamond_3 : $@convention(thin) (@owned C, @owned C) -> () {
+entry(%one : @owned $C, %two : @owned $C):
+    %addr = alloc_stack [lexical] $C
+    cond_br undef, left, right
+left:
+    destroy_value %two : $C
+    store %one to [init] %addr : $*C
+    br exit
+right:
+    destroy_value %one : $C
+    store %two to [init] %addr : $*C
+    br exit
+exit:
+    destroy_addr %addr : $*C
+    dealloc_stack %addr : $*C
+    %result = tuple ()
+    return %result : $()
+}
+
+// Ensure that the value stored to the alloc_stack is kept alive until the
+// destroy_addr in a subsequent block even when there are no uses.
+//
+// CHECK-LABEL: sil [ossa] @diamond_4 : $@convention(thin) (@owned C, @owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[ONE:%[^,]+]] : @owned $C, [[TWO:%[^,]+]] : @owned $C):
+// CHECK:         cond_br undef, [[LEFT:bb[^,]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         destroy_value [[TWO]]
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[ONE]]
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         destroy_value [[ONE]]
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[TWO]]
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]]
+// CHECK:         end_borrow [[LIFETIME_2]]
+// CHECK:         destroy_value [[TWO]]
+// CHECK:         unreachable
+// CHECK:       [[EXIT]]:
+// CHECK:         destroy_value [[LIFETIME_OWNED_1]]
+// CHECK:         end_borrow [[LIFETIME_1]]
+// CHECK:         destroy_value [[ONE]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]] : $()
+// CHECK-LABEL: } // end sil function 'diamond_4' 
+sil [ossa] @diamond_4 : $@convention(thin) (@owned C, @owned C) -> () {
+entry(%one : @owned $C, %two : @owned $C):
+    %addr = alloc_stack [lexical] $C
+    cond_br undef, left, right
+left:
+    destroy_value %two : $C
+    store %one to [init] %addr : $*C
+    br exit
+right:
+    destroy_value %one : $C
+    store %two to [init] %addr : $*C
+    unreachable
+exit:
+    destroy_addr %addr : $*C
+    dealloc_stack %addr : $*C
+    %result = tuple ()
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @diamond_5 : $@convention(thin) (@owned C, @owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[ONE:%[^,]+]] : @owned $C, [[TWO:%[^,]+]] : @owned $C):
+// CHECK:         cond_br undef, [[LEFT:bb[^,]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         destroy_value [[TWO]]
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[ONE]]
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         destroy_value [[ONE]]
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[TWO]]
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]]
+// CHECK:         end_borrow [[LIFETIME_2]]
+// CHECK:         destroy_value [[TWO]]
+// CHECK:         unreachable
+// CHECK:       [[EXIT]]:
+// CHECK:         destroy_value [[LIFETIME_OWNED_1]]
+// CHECK:         end_borrow [[LIFETIME_1]]
+// CHECK:         destroy_value [[ONE]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]] : $()
+// CHECK-LABEL: } // end sil function 'diamond_5' 
+sil [ossa] @diamond_5 : $@convention(thin) (@owned C, @owned C) -> () {
+entry(%one : @owned $C, %two : @owned $C):
+    %addr = alloc_stack [lexical] $C
+    cond_br undef, left, right
+left:
+    destroy_value %two : $C
+    store %one to [init] %addr : $*C
+    br exit
+right:
+    destroy_value %one : $C
+    store %two to [init] %addr : $*C
+    unreachable
+exit:
+    destroy_addr %addr : $*C
+    dealloc_stack %addr : $*C
+    %result = tuple ()
+    return %result : $()
+}
+
+// Verify that a dead-end which succeeds the introduction of a borrow_scope ends
+// the borrow scope before the unreachable.
+// CHECK-LABEL: sil [ossa] @diamond_6 : $@convention(thin) (@owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[ORIGINAL:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[ORIGINAL]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         cond_br undef, [[BASIC_BLOCK1:bb[^,]+]], [[BASIC_BLOCK2:bb[0-9]+]]
+// CHECK:       [[BASIC_BLOCK1]]:
+// CHECK:         br [[BASIC_BLOCK3:bb[0-9]+]]
+// CHECK:       [[BASIC_BLOCK2]]:
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[ORIGINAL]]
+// CHECK:         unreachable
+// CHECK:       [[BASIC_BLOCK3:bb[^,]+]]:
+// CHECK:         destroy_value [[LIFETIME_OWNED]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[ORIGINAL]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]] : $()
+// CHECK-LABEL: } // end sil function 'diamond_6' 
+sil [ossa] @diamond_6 : $@convention(thin) (@owned C) -> () {
+entry(%original : @owned $C):
+    %addr = alloc_stack [lexical] $C
+    store %original to [init] %addr : $*C
+    cond_br undef, left, right
+left:
+    br exit
+right:
+    unreachable
+exit:
+    destroy_addr %addr : $*C
+    dealloc_stack %addr : $*C
+    %result = tuple ()
+    return %result : $()
+}
+
+// =============================================================================
+// lexical scope specific                                                     }}
+// =============================================================================

--- a/test/SILOptimizer/sroa_lifetime.sil
+++ b/test/SILOptimizer/sroa_lifetime.sil
@@ -1,0 +1,61 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -sroa %s -enable-experimental-lexical-lifetimes | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+///////////////////////////////
+// Struct with Scalar Fields //
+///////////////////////////////
+
+struct S1 {
+  var x : Builtin.Int1
+  var y : Builtin.Int32
+  var z : Builtin.Int64
+}
+
+sil [ossa] @use_int32 : $@convention(thin) (Builtin.Int32) -> ()
+
+// CHECK-LABEL: sil [ossa] @struct_with_scalar_fields : $@convention(thin) (S1) -> ()
+// CHECK: bb0([[VAR_0:%[0-9]+]] : $S1):
+
+// CHECK-NEXT:   [[VAR_1:%[0-9]+]] = alloc_stack [lexical] $Builtin.Int1
+// CHECK-NEXT:   [[VAR_2:%[0-9]+]] = alloc_stack [lexical] $Builtin.Int32
+// CHECK-NEXT:   [[VAR_3:%[0-9]+]] = alloc_stack [lexical] $Builtin.Int64
+// CHECK-NEXT:   ([[VAR_4:%[0-9]+]], [[VAR_6:%[0-9]+]], [[VAR_8:%[0-9]+]]) = destructure_struct [[VAR_0]]
+// CHECK-NEXT:   store [[VAR_4]] to [trivial] [[VAR_1]] : $*Builtin.Int1
+// CHECK-NEXT:   store [[VAR_6]] to [trivial] [[VAR_2]] : $*Builtin.Int32
+// CHECK-NEXT:   store [[VAR_8]] to [trivial] [[VAR_3]] : $*Builtin.Int64
+
+// CHECK-NEXT:   function_ref
+// CHECK-NEXT:   [[VAR_10:%[0-9]+]] = function_ref @use_int32 : $@convention(thin) (Builtin.Int32) -> ()
+// CHECK-NEXT:   [[VAR_11:%[0-9]+]] = load [trivial] [[VAR_2]] : $*Builtin.Int32
+// CHECK-NEXT:   [[VAR_12:%[0-9]+]] = apply [[VAR_10]]([[VAR_11]]) : $@convention(thin) (Builtin.Int32) -> ()
+// CHECK-NEXT:   [[VAR_13:%[0-9]+]] = load [trivial] [[VAR_1]] : $*Builtin.Int1
+// CHECK-NEXT:   [[VAR_14:%[0-9]+]] = load [trivial] [[VAR_2]] : $*Builtin.Int32
+// CHECK-NEXT:   [[VAR_15:%[0-9]+]] = load [trivial] [[VAR_3]] : $*Builtin.Int64
+// CHECK-NEXT:   [[VAR_16:%[0-9]+]] = struct $S1 ([[VAR_13]] : $Builtin.Int1, [[VAR_14]] : $Builtin.Int32, [[VAR_15]] : $Builtin.Int64)
+
+// CHECK:   dealloc_stack [[VAR_3]] : $*Builtin.Int64
+// CHECK:   dealloc_stack [[VAR_2]] : $*Builtin.Int32
+// CHECK:   dealloc_stack [[VAR_1]] : $*Builtin.Int1
+
+// CHECK:   [[VAR_20:%[0-9]+]] = tuple ()
+// CHECK:   return [[VAR_20]] : $()
+sil [ossa] @struct_with_scalar_fields : $@convention(thin) (S1) -> () {
+bb0(%0 : $S1):
+  %1 = alloc_stack [lexical] $S1
+  debug_value %1 : $*S1 // should not prevent the optimization
+  debug_value %1 : $*S1                // should not prevent the optimization
+  store %0 to [trivial] %1 : $*S1
+  %2 = function_ref @use_int32 : $@convention(thin) (Builtin.Int32) -> ()
+  %3 = struct_element_addr %1 : $*S1, #S1.y
+  %4 = load [trivial] %3 : $*Builtin.Int32
+  apply %2(%4) : $@convention(thin) (Builtin.Int32) -> ()
+  %5 = load [trivial] %1 : $*S1
+  dealloc_stack %1 : $*S1
+  %6 = tuple ()
+  return %6 : $()
+}
+

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -104,6 +104,10 @@ static llvm::cl::opt<bool>
 EnableExperimentalConcurrency("enable-experimental-concurrency",
                    llvm::cl::desc("Enable experimental concurrency model."));
 
+static llvm::cl::opt<bool> EnableExperimentalLexicalLifetimes(
+    "enable-experimental-lexical-lifetimes",
+    llvm::cl::desc("Enable experimental lexical lifetimes."));
+
 static llvm::cl::opt<bool>
 EnableExperimentalDistributed("enable-experimental-distributed",
                    llvm::cl::desc("Enable experimental distributed actors."));
@@ -420,6 +424,8 @@ int main(int argc, char **argv) {
     EnableExperimentalConcurrency;
   Invocation.getLangOptions().EnableExperimentalDistributed =
     EnableExperimentalDistributed;
+  Invocation.getLangOptions().EnableExperimentalLexicalLifetimes =
+      EnableExperimentalLexicalLifetimes;
 
   Invocation.getLangOptions().EnableObjCInterop =
     EnableObjCInterop ? true :


### PR DESCRIPTION
SILGen turns vars into `alloc_box`es.  When possible, `AllocBoxToStack` turns those into `alloc_stack`s.  In order to preserve the lexical lifetime of those vars, the `alloc_stack`s are annotated with the `[lexical]` attribute.  When `Mem2Reg` runs, it promotes the `load`s from and `store`s into those `alloc_stack`s to uses of registers.  In order to preserve the lexical lifetime during that transformation, lexical borrow scopes must be introduced to encode the same lifetime as the `alloc_stack`s did.  Here, that is done.

