### PR TITLE
Added build preset for Fedora Linux

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -933,6 +933,71 @@ mixin-preset=buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build
 
 android-arch=aarch64
 
+# Preset for Fedora Linux
+[preset: buildbot_linux_fedora,no_test]
+mixin-preset=
+    mixin_lightweight_assertions,no-stdlib-asserts
+    mixin_linux_install_components_with_clang
+    mixin_buildbot_linux,no_test
+build-subdir=buildbot_linux
+
+lldb
+release
+test
+validation-test
+long-test
+stress-test
+test-optimized
+foundation
+libdispatch
+indexstore-db
+sourcekit-lsp
+lit-args=-v --time-tests
+
+# rdar://problem/31454823
+lldb-test-swift-only
+
+llbuild
+swiftpm
+swift-driver
+xctest
+libicu
+libcxx
+
+install-foundation
+install-libdispatch
+reconfigure
+
+install-llvm
+install-swift
+install-lldb
+install-llbuild
+install-swiftpm
+install-swift-driver
+install-xctest
+install-libicu
+install-prefix=/usr
+install-libcxx
+install-sourcekit-lsp
+build-swift-static-stdlib
+build-swift-static-sdk-overlay
+build-swift-stdlib-unittest-extra
+
+# Build the benchmarks against the toolchain.
+toolchain-benchmarks
+
+# Path to the root of the installation filesystem.
+install-destdir=%(install_destdir)s
+
+# Path to the .tar.gz package we would create.
+installable-package=%(installable_package)s
+
+# This ensures the default module cache
+# location is local to this run, allowing
+# to schedule multiple builds safely
+# in Linux CI bots
+relocate-xdg-cache-home-under-build-subdir
+
 # Ubuntu 18.04 preset for backwards compat and future customizations.
 [preset: buildbot_linux_1804]
 mixin-preset=buildbot_linux


### PR DESCRIPTION
This PR adds a specific build preset for Fedora Linux. It eliminates needing to patch the `build-presets.ini` file when building Swift for Fedora to remove building Ninja as well testing the installable package.