### PR TITLE
[test] Disable 4 tests failing on macOS-arm64

### DIFF
--- a/test/Concurrency/Backdeploy/linking.swift
+++ b/test/Concurrency/Backdeploy/linking.swift
@@ -9,6 +9,9 @@
 
 // REQUIRES: OS=macosx
 
+// rdar://83576231 - link failures on arm64
+// UNSUPPORTED: CPU=arm64
+
 // CHECK-DIRECT: /usr/lib/swift/libswift_Concurrency.dylib
 // CHECK-RPATH: @rpath/libswift_Concurrency.dylib
 

--- a/test/Concurrency/Backdeploy/mangling.swift
+++ b/test/Concurrency/Backdeploy/mangling.swift
@@ -15,6 +15,9 @@
 // REQUIRES: OS=macosx
 // REQUIRES: executable_test
 
+// rdar://83576231 - link failures on arm64
+// UNSUPPORTED: CPU=arm64
+
 protocol MyProtocol {
   associatedtype AssocSendable
   associatedtype AssocAsync

--- a/test/IRGen/autolink-runtime-compatibility-arm64-macos.swift
+++ b/test/IRGen/autolink-runtime-compatibility-arm64-macos.swift
@@ -1,5 +1,8 @@
 // REQUIRES: CPU=arm64,OS=macosx
 
+// rdar://83576231 - link failures on arm64
+// REQUIRES: rdar83576231
+
 // Doesn't autolink compatibility library because target OS doesn't need it
 // RUN: %target-swift-frontend -target arm64-apple-macosx10.14  -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=NO-FORCE-LOAD %s
 

--- a/test/Reflection/typeref_decoding_concurrency.swift
+++ b/test/Reflection/typeref_decoding_concurrency.swift
@@ -9,6 +9,9 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
+// rdar://83576231 - link failures on arm64
+// UNSUPPORTED: CPU=arm64
+
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/ConcurrencyTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect) -target x86_64-apple-macosx12.0


### PR DESCRIPTION
We're hitting a linking failure in these tests on arm64 macOS. Disable
them until we can fix.