### PR TITLE
[5.5] [test] Disable IRGen/opaque_result_type.swift on arm64e

### DIFF
--- a/test/IRGen/opaque_result_type.swift
+++ b/test/IRGen/opaque_result_type.swift
@@ -5,6 +5,9 @@
 // rdar://76863553
 // UNSUPPORTED: OS=watchos && CPU=x86_64
 
+// https://bugs.swift.org/browse/SR-15237
+// UNSUPPORTED: CPU=arm64e
+
 public protocol O {
   func bar()
 }


### PR DESCRIPTION
Disable this test until we can fix it. This is also impacting main
branch.

https://bugs.swift.org/browse/SR-15237