### PR TITLE
Use cherry-picked commits to disable tests on arm64 macOS

### DIFF
--- a/test/Concurrency/Backdeploy/linking.swift
+++ b/test/Concurrency/Backdeploy/linking.swift
@@ -8,6 +8,7 @@
 // RUN: otool -L %t/linking_rpath_old | %FileCheck -check-prefix CHECK-RPATH %s
 
 // REQUIRES: OS=macosx
+// REQUIRES: CPU=x86_64
 
 // CHECK-DIRECT: /usr/lib/swift/libswift_Concurrency.dylib
 // CHECK-RPATH: @rpath/libswift_Concurrency.dylib

--- a/test/Concurrency/Backdeploy/linking.swift
+++ b/test/Concurrency/Backdeploy/linking.swift
@@ -9,9 +9,6 @@
 
 // REQUIRES: OS=macosx
 
-// rdar://83576231 - link failures on arm64
-// UNSUPPORTED: CPU=arm64
-
 // CHECK-DIRECT: /usr/lib/swift/libswift_Concurrency.dylib
 // CHECK-RPATH: @rpath/libswift_Concurrency.dylib
 

--- a/test/Concurrency/Backdeploy/mangling.swift
+++ b/test/Concurrency/Backdeploy/mangling.swift
@@ -12,6 +12,7 @@
 // RUN: %target-build-swift -target x86_64-apple-macosx10.15 %s -o %t/test_mangling -Xfrontend -disable-availability-checking
 // RUN: %target-run %t/test_mangling
 
+// REQUIRES: CPU=x86_64
 // REQUIRES: OS=macosx
 // REQUIRES: executable_test
 

--- a/test/Concurrency/Backdeploy/mangling.swift
+++ b/test/Concurrency/Backdeploy/mangling.swift
@@ -15,9 +15,6 @@
 // REQUIRES: OS=macosx
 // REQUIRES: executable_test
 
-// rdar://83576231 - link failures on arm64
-// UNSUPPORTED: CPU=arm64
-
 protocol MyProtocol {
   associatedtype AssocSendable
   associatedtype AssocAsync

--- a/test/IRGen/autolink-runtime-compatibility-arm64-macos.swift
+++ b/test/IRGen/autolink-runtime-compatibility-arm64-macos.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar81115750
 // REQUIRES: CPU=arm64,OS=macosx
 
 // Doesn't autolink compatibility library because target OS doesn't need it

--- a/test/IRGen/autolink-runtime-compatibility-arm64-macos.swift
+++ b/test/IRGen/autolink-runtime-compatibility-arm64-macos.swift
@@ -1,8 +1,5 @@
 // REQUIRES: CPU=arm64,OS=macosx
 
-// rdar://83576231 - link failures on arm64
-// REQUIRES: rdar83576231
-
 // Doesn't autolink compatibility library because target OS doesn't need it
 // RUN: %target-swift-frontend -target arm64-apple-macosx10.14  -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=NO-FORCE-LOAD %s
 

--- a/test/Reflection/typeref_decoding_concurrency.swift
+++ b/test/Reflection/typeref_decoding_concurrency.swift
@@ -3,6 +3,7 @@
 // REQUIRES: concurrency
 // REQUIRES: libdispatch
 
+// REQUIRES: CPU=x86_64
 // REQUIRES: OS=macosx
 
 // rdar://76038845

--- a/test/Reflection/typeref_decoding_concurrency.swift
+++ b/test/Reflection/typeref_decoding_concurrency.swift
@@ -9,9 +9,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// rdar://83576231 - link failures on arm64
-// UNSUPPORTED: CPU=arm64
-
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/ConcurrencyTypes.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect) -target x86_64-apple-macosx12.0


### PR DESCRIPTION
https://github.com/apple/swift/pull/39464 disabled a number of tests for arm64 macOS. Revert that, but cherry-pick the individual changes to restrict/disable this test.