### PR TITLE
tests: disable Concurrency.throwing

### DIFF
--- a/test/Concurrency/throwing.swift
+++ b/test/Concurrency/throwing.swift
@@ -6,6 +6,9 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
+// SR-15252
+// XFAIL: OS=windows-msvc
+
 import _Concurrency
 import StdlibUnittest
 


### PR DESCRIPTION
The rebranch is exposing a UaF/stack corruption, disable this for the
time being.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
