### PR TITLE
Handle missing Sendable conformances in SILFunctionType substitutions.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1880,7 +1880,8 @@ public:
       
       for (auto proto : upperBound->getConformsTo()) {
         // Find the DeclContext providing the conformance for the type.
-        auto nomConformance = moduleDecl->lookupConformance(substType, proto);
+        auto nomConformance = moduleDecl->lookupConformance(
+            substType, proto, /*allowMissing=*/true);
         if (!nomConformance)
           return CanType();
         if (nomConformance.isAbstract())
@@ -1916,7 +1917,8 @@ public:
             if (substTy->isTypeParameter()) {
               substConformance = ProtocolConformanceRef(proto);
             } else {
-              substConformance = moduleDecl->lookupConformance(substTy, proto);
+              substConformance = moduleDecl->lookupConformance(
+                  substTy, proto, /*allowMissing=*/true);
             }
             
             LLVM_DEBUG(llvm::dbgs() << "\n` adds conformance for subst type\n";
@@ -2040,7 +2042,8 @@ public:
           newConformances.push_back(ProtocolConformanceRef(proto));
         } else {
           auto newConformance
-            = moduleDecl->lookupConformance(newSubstTy, proto);
+            = moduleDecl->lookupConformance(
+                  newSubstTy, proto, /*allowMissing=*/true);
           if (!newConformance)
             return CanType();
           newConformances.push_back(newConformance);

--- a/validation-test/compiler_crashers_2_fixed/sr15248.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr15248.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -emit-ir %s
+// REQUIRES: concurrency
+private struct TransformResult<T> {
+    var index: Int
+    var transformedElement: T
+
+    init(index: Int, transformedElement: T) {
+        self.index = index
+        self.transformedElement = transformedElement
+    }
+}
+
+public extension Collection {
+    @available(macOS 12.0.0, *)
+    private func f<T>(_ transform: @escaping (Element) async throws -> T) async throws -> [T] {
+        return try await withThrowingTaskGroup(of: TransformResult<T>.self) { group in
+          return []
+        }
+    }
+}


### PR DESCRIPTION
Fixes SR-15248 / rdar://83556240.
