### PR TITLE
arm64 macOS was introduced with a Swift 5.3 runtime

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -375,27 +375,27 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(
   if (Triple.isMacOSX()) {
     Triple.getMacOSXVersion(Major, Minor, Micro);
 
-    auto floorFor64e = [&Triple](llvm::VersionTuple v) {
-      if (Triple.getArchName() != "arm64e") return v;
-      // macOS got first arm64e support in 11.0, i.e. VersionTuple(5, 3)
+    auto floorFor64 = [&Triple](llvm::VersionTuple v) {
+      if (!Triple.isAArch64()) return v;
+      // macOS got first arm64(e) support in 11.0, i.e. VersionTuple(5, 3)
       return MAX(v, llvm::VersionTuple(5, 3));
     };
 
     if (Major == 10) {
       if (Triple.isAArch64() && Minor <= 16)
-        return floorFor64e(llvm::VersionTuple(5, 3));
+        return floorFor64(llvm::VersionTuple(5, 3));
 
       if (Minor <= 14) {
-        return floorFor64e(llvm::VersionTuple(5, 0));
+        return floorFor64(llvm::VersionTuple(5, 0));
       } else if (Minor <= 15) {
         if (Micro <= 3) {
-          return floorFor64e(llvm::VersionTuple(5, 1));
+          return floorFor64(llvm::VersionTuple(5, 1));
         } else {
-          return floorFor64e(llvm::VersionTuple(5, 2));
+          return floorFor64(llvm::VersionTuple(5, 2));
         }
       }
     } else if (Major == 11) {
-      return floorFor64e(llvm::VersionTuple(5, 3));
+      return floorFor64(llvm::VersionTuple(5, 3));
     }
   } else if (Triple.isiOS()) { // includes tvOS
     Triple.getiOSVersion(Major, Minor, Micro);


### PR DESCRIPTION
Generalize the check from arm64e to also include arm64. Fixes
rdar://83502661.
