### PR TITLE
Disabling ClangImporter/overlay.swift

### DIFF
--- a/test/ClangImporter/overlay.swift
+++ b/test/ClangImporter/overlay.swift
@@ -3,6 +3,8 @@
 
 // REQUIRES: objc_interop
 
+// REQUIRES: rdar83592270
+
 // Do not import Foundation! This tests indirect visibility.
 #if REVERSED
 import Redeclaration


### PR DESCRIPTION
The last good merge commit was: bc61e6adeea
The first bad merge commit was: 0d6ac8f2cbf

The commit where it broke was 7e77bc4d877. This commit only changes a
test and shouldn’t have affected the failing test.

I'm disabling this test for now since we need to rebranch.