### PR TITLE
LLVMPasses: adapt to ba664d9

### DIFF
--- a/include/swift/LLVMPasses/Passes.h
+++ b/include/swift/LLVMPasses/Passes.h
@@ -34,7 +34,7 @@ namespace swift {
     using AAResultBase::getModRefInfo;
     llvm::ModRefInfo getModRefInfo(const llvm::CallBase *Call,
                                    const llvm::MemoryLocation &Loc) {
-      llvm::AAQueryInfo AAQI;
+      llvm::SimpleAAQueryInfo AAQI;
       return getModRefInfo(Call, Loc, AAQI);
     }
     llvm::ModRefInfo getModRefInfo(const llvm::CallBase *Call,


### PR DESCRIPTION
Adapt to API changes in ba664d9, where `AAQueryInfo` now requires the
capturing information.  Switch to the new `SimpleAAQueryInfo` which
maintains the status quo for alias analysis.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
