### PR TITLE
Redo The Notes For "Uninhabited" Parameter Types 

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -290,7 +290,9 @@ ERROR(guard_body_must_not_fallthrough,none,
       " to exit the scope", ())
 WARNING(unreachable_code,none, "will never be executed", ())
 NOTE(unreachable_code_uninhabited_param_note,none,
-	"'%0' is uninhabited, so this function body can never be executed", (StringRef))
+     "'%0' is of type %1 which cannot be constructed because %select{it "
+     "contains %3 which is an enum with no cases|it is an enum with no cases}2",
+     (StringRef, Type, bool, Type))
 NOTE(unreachable_code_branch,none,
      "condition always evaluates to %select{false|true}0", (bool))
 NOTE(call_to_noreturn_note,none,

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -358,10 +358,19 @@ void StmtEmitter::visitBraceStmt(BraceStmt *S) {
                  diag::unreachable_code);
         if (!S->getElements().empty()) {
           for (auto *arg : SGF.getFunction().getArguments()) {
-            if (arg->getType().getASTType()->isStructurallyUninhabited()) {
+            auto argTy = arg->getType().getASTType();
+            if (argTy->isStructurallyUninhabited()) {
+              // Use the interface type in this diagnostic because the SIL type
+              // unpacks tuples. But, the SIL type being exploded means it
+              // points directly at the offending tuple element type and we can
+              // use that to point the user at problematic component(s).
+              auto argIFaceTy = arg->getDecl()->getInterfaceType();
               diagnose(getASTContext(), S->getStartLoc(),
                        diag::unreachable_code_uninhabited_param_note,
-                       arg->getDecl()->getBaseName().userFacingName());
+                       arg->getDecl()->getBaseName().userFacingName(),
+                       argIFaceTy,
+                       argIFaceTy->is<EnumType>(),
+                       argTy);
               break;
             }
           }

--- a/test/SILGen/functions_uninhabited_param.swift
+++ b/test/SILGen/functions_uninhabited_param.swift
@@ -2,7 +2,7 @@
 
 //===--- Function declaration with uninhabited parameter type
                                    
-func foo(baz: Never) -> Int { // expected-note {{'baz' is uninhabited, so this function body can never be executed}}
+func foo(baz: Never) -> Int { // expected-note {{'baz' is of type 'Never' which cannot be constructed because it is an enum with no cases}}
   print("I can't be called!") // expected-warning{{will never be executed}}
   return 0
 }
@@ -11,11 +11,11 @@ func bar(baz: Never) -> Int {} // ok
 
 // SR-13432
 func map<T>(_ block: (Never) -> T) {}
-map { arg in // expected-note {{'arg' is uninhabited, so this function body can never be executed}}
+map { arg in // expected-note {{'arg' is of type 'Never' which cannot be constructed because it is an enum with no cases}}
   5 // expected-warning {{will never be executed}}
 }
 
-map { arg in // expected-note {{'arg' is uninhabited, so this function body can never be executed}}
+map { arg in // expected-note {{'arg' is of type 'Never' which cannot be constructed because it is an enum with no cases}}
   return 5 // expected-warning {{will never be executed}}
 }
 
@@ -26,4 +26,4 @@ enum E {
 
 let _: (E.Type) -> (E) -> () = { s in { e in s.f(e) } }
 // expected-warning@-1 {{will never be executed}}
-// expected-note@-2 {{'e' is uninhabited, so this function body can never be executed}}
+// expected-note@-2 {{'e' is of type 'E' which cannot be constructed because it is an enum with no cases}}

--- a/test/SILGen/functions_uninhabited_param.swift
+++ b/test/SILGen/functions_uninhabited_param.swift
@@ -27,3 +27,11 @@ enum E {
 let _: (E.Type) -> (E) -> () = { s in { e in s.f(e) } }
 // expected-warning@-1 {{will never be executed}}
 // expected-note@-2 {{'e' is of type 'E' which cannot be constructed because it is an enum with no cases}}
+
+func empty_product(_ xs: (Int, String, Never)) { // expected-note {{'xs' is of type '(Int, String, Never)' which cannot be constructed because it contains 'Never' which is an enum with no cases}}
+  print() // expected-warning{{will never be executed}}
+}
+func empty_custom_product(_ xs: (E, Int)) { // expected-note {{'xs' is of type '(E, Int)' which cannot be constructed because it contains 'E' which is an enum with no cases}}
+  print() // expected-warning{{will never be executed}}
+}
+


### PR DESCRIPTION
The use of the term 'uninhabited' does not make sense outside of formal type theoretic contexts. In Swift, we also do not use this term in a standard way - hence the term "structurally uninhabited" since we only consider products and sums eligible for the check. (Aside: We do not do exponentials because... well, Swift's type system implements Harper's "typerec" operator and as a consequence parametricity is just _not a thing_). I digress...

So, improve upon the old diagnostic in two ways:
1) Do away with 'uninhabited' - instead, mention that it's either an enum or a tuple with an enum in it that 'has no cases'
2) Since the SIL parameter convention flattens all tuples, point directly at the offending uninhabited element type

rdar://83600669