### PR TITLE
runtime, WebAssembly: add ImageInspectionWasm.cpp

### DIFF
--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -53,6 +53,7 @@ set(swift_runtime_sources
     ImageInspectionELF.cpp
     ImageInspectionCOFF.cpp
     ImageInspectionStatic.cpp
+    ImageInspectionWasm.cpp
     KeyPaths.cpp
     KnownMetadata.cpp
     Metadata.cpp

--- a/stdlib/public/runtime/ImageInspectionWasm.cpp
+++ b/stdlib/public/runtime/ImageInspectionWasm.cpp
@@ -1,4 +1,4 @@
-//===--- ImageInspectionStatic.cpp - image inspection for static stdlib ---===//
+//===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -24,6 +24,11 @@
 using namespace swift;
 
 int swift::lookupSymbol(const void *address, SymbolInfo *info) {
+  // Currently, Wasm doesn't have a standard stable ABI for exporting address <->
+  // symbol table, it's work in progress. Also, there is no API to access such
+  // information from Wasm binary side. It's accessible only from host VM. 
+  // See https://github.com/WebAssembly/tool-conventions/blob/main/DynamicLinking.md
+  // Seems reasonable to use a stub for now.
   return 0;
 }
 

--- a/stdlib/public/runtime/ImageInspectionWasm.cpp
+++ b/stdlib/public/runtime/ImageInspectionWasm.cpp
@@ -1,0 +1,30 @@
+//===--- ImageInspectionStatic.cpp - image inspection for static stdlib ---===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// Implementation of ImageInspection for WebAssembly.
+///
+//===----------------------------------------------------------------------===//
+
+#if defined(__wasm__)
+
+#include "../SwiftShims/MetadataSections.h"
+#include "ImageInspection.h"
+
+using namespace swift;
+
+int swift::lookupSymbol(const void *address, SymbolInfo *info) {
+  return 0;
+}
+
+#endif // defined(__wasm__)


### PR DESCRIPTION
This change adds a stub for `swift::lookupSymbol` for the WebAssembly platform.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Related to SR-9307.
