### PR TITLE
[NFC] Tweaked doc for alloc_stack's lexical attr.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -3105,7 +3105,7 @@ The ``dynamic_lifetime`` attribute specifies that the initialization and
 destruction of the stored value cannot be verified at compile time.
 This is the case, e.g. for conditionally initialized objects.
 
-The optional ``lexical`` attribute specifies that the operand corresponds to a
+The optional ``lexical`` attribute specifies that the storage corresponds to a
 local variable in the Swift source.
 
 The memory is not retainable. To allocate a retainable box for a value


### PR DESCRIPTION
Thanks to Erik for catching this. The instruction doesn't have an operand.  It creates storage.  The lexical attribute indicates that the storage corresponds to a source-level variable.
