### PR TITLE
Replace /usr/bin/python with /usr/bin/env python

### DIFF
--- a/benchmark/scripts/compare_perf_tests.py
+++ b/benchmark/scripts/compare_perf_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # ===--- compare_perf_tests.py -------------------------------------------===//

--- a/benchmark/scripts/test_Benchmark_Driver.py
+++ b/benchmark/scripts/test_Benchmark_Driver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # ===--- test_Benchmark_Driver.py ----------------------------------------===//

--- a/benchmark/scripts/test_compare_perf_tests.py
+++ b/benchmark/scripts/test_compare_perf_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # ===--- test_compare_perf_tests.py --------------------------------------===//

--- a/benchmark/scripts/test_utils.py
+++ b/benchmark/scripts/test_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # ===--- test_utils.py ---------------------------------------------------===//

--- a/test/ScanDependencies/Inputs/CommandRunner.py
+++ b/test/ScanDependencies/Inputs/CommandRunner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import subprocess
 import sys

--- a/utils/jobstats/__init__.py
+++ b/utils/jobstats/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # ==-- jobstats - support for reading the contents of stats dirs --==#
 #

--- a/utils/jobstats/jobstats.py
+++ b/utils/jobstats/jobstats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # ==-- jobstats - support for reading the contents of stats dirs --==#
 #

--- a/utils/process-stats-dir.py
+++ b/utils/process-stats-dir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # ==-- process-stats-dir - summarize one or more Swift -stats-output-dirs --==#
 #

--- a/utils/rusage.py
+++ b/utils/rusage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # utils/rusage.py - Utility to measure resource usage -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Note that this test should still "pass" when no swiftinterfaces have been
 # generated.

--- a/validation-test/SIL/verify_all_overlays.py
+++ b/validation-test/SIL/verify_all_overlays.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # RUN: ${python} %s %target-swiftmodule-name %platform-sdk-overlay-dir \
 # RUN:     %target-sil-opt -sdk %sdk -enable-sil-verify-all \
 # RUN:       -F %sdk/System/Library/PrivateFrameworks \
@@ -39,7 +39,7 @@ for module_file in os.listdir(sdk_overlay_dir):
 
     # llvm-bcanalyzer | not grep Unknown
     bcanalyzer_output = subprocess.check_output(["llvm-bcanalyzer",
-                                                 module_path])
+                                                 module_path]).decode("utf-8")
     if "Unknown" in bcanalyzer_output:
         print(bcanalyzer_output)
         sys.exit(1)


### PR DESCRIPTION
/usr/bin/python doesn't exist on ubuntu 20.04 causing tests to fail.
I've updated the shebangs everywhere to use `/usr/bin/env python`
instead.

I've forced `SIL/verify_all_overlays.py` on to python3 because subprocess emits bytes that need decoding on python3, while it's just a string in python2. I'm not sure what the python-version-agnostic representation of that is.