### PR TITLE
Revert "Allow building a concurrent libSwiftConcurrency without libdispatch"

### DIFF
--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -25,22 +25,6 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 
-// Does the runtime use a cooperative global executor?
-#if defined(SWIFT_STDLIB_SINGLE_THREADED_RUNTIME)
-#define SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR 1
-#else
-#define SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR 0
-#endif
-
-// Does the runtime integrate with libdispatch?
-#ifndef SWIFT_CONCURRENCY_ENABLE_DISPATCH
-#if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
-#define SWIFT_CONCURRENCY_ENABLE_DISPATCH 0
-#else
-#define SWIFT_CONCURRENCY_ENABLE_DISPATCH 1
-#endif
-#endif
-
 namespace swift {
 class DefaultActor;
 class TaskOptionRecord;
@@ -677,13 +661,9 @@ void swift_task_enqueueGlobalWithDelay(unsigned long long delay, Job *job);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_enqueueMainExecutor(Job *job);
 
-#if SWIFT_CONCURRENCY_ENABLE_DISPATCH
-
 /// Enqueue the given job on the main executor.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_enqueueOnDispatchQueue(Job *job, HeapObject *queue);
-
-#endif
 
 /// A hook to take over global enqueuing.
 typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobal_original)(Job *job);
@@ -825,17 +805,6 @@ void swift_task_reportUnexpectedExecutor(
 
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 JobPriority swift_task_getCurrentThreadPriority(void);
-
-#if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
-
-/// Donate this thread to the global executor until either the
-/// given condition returns true or we've run out of cooperative
-/// tasks to run.
-SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-void swift_task_donateThreadToGlobalExecutorUntil(bool (*condition)(void*),
-                                                  void *context);
-
-#endif
 
 #ifdef __APPLE__
 /// A magic symbol whose address is the mask to apply to a frame pointer to

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -46,7 +46,7 @@
 #include "TaskPrivate.h"
 #include "VoucherSupport.h"
 
-#if SWIFT_CONCURRENCY_ENABLE_DISPATCH
+#if !SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
 #include <dispatch/dispatch.h>
 #endif
 

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -35,11 +35,6 @@ endif()
 set(SWIFT_RUNTIME_CONCURRENCY_C_FLAGS)
 set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS)
 
-if(NOT SWIFT_CONCURRENCY_USES_DISPATCH)
-  list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS
-    "-DSWIFT_CONCURRENCY_ENABLE_DISPATCH=0")
-endif()
-
 if(NOT swift_concurrency_async_fp_mode)
   set(swift_concurrency_async_fp_mode "always")
 endif()

--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -59,7 +59,7 @@
 #include "TaskPrivate.h"
 #include "Error.h"
 
-#if SWIFT_CONCURRENCY_ENABLE_DISPATCH
+#if !SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
 #include <dispatch/dispatch.h>
 
 #if !defined(_WIN32)
@@ -178,20 +178,14 @@ static Job *claimNextFromJobQueue() {
   }
 }
 
-void swift::
-swift_task_donateThreadToGlobalExecutorUntil(bool (*condition)(void *),
-                                             void *conditionContext) {
+void swift::donateThreadToGlobalExecutorUntil(bool (*condition)(void *),
+                                              void *conditionContext) {
   while (!condition(conditionContext)) {
     auto job = claimNextFromJobQueue();
     if (!job) return;
     swift_job_run(job, ExecutorRef::generic());
   }
 }
-
-#elif !SWIFT_CONCURRENCY_ENABLE_DISPATCH
-
-// No implementation.  The expectation is that integrators in this
-// configuration will hook all the appropriate functions.
 
 #else
 
@@ -336,9 +330,6 @@ static void swift_task_enqueueGlobalImpl(Job *job) {
 
 #if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
   insertIntoJobQueue(job);
-#elif !SWIFT_CONCURRENCY_ENABLE_DISPATCH
-  swift_reportError(0, "operation unsupported without libdispatch: "
-                       "swift_task_enqueueGlobal");
 #else
   // We really want four things from the global execution service:
   //  - Enqueuing work should have minimal runtime and memory overhead.
@@ -394,9 +385,6 @@ static void swift_task_enqueueGlobalWithDelayImpl(unsigned long long delay,
 
 #if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
   insertIntoDelayedJobQueue(delay, job);
-#elif !SWIFT_CONCURRENCY_ENABLE_DISPATCH
-  swift_reportError(0, "operation unsupported without libdispatch: "
-                       "swift_task_enqueueGlobalWithDelay");
 #else
 
   dispatch_function_t dispatchFunction = &__swift_run_job;
@@ -431,9 +419,6 @@ static void swift_task_enqueueMainExecutorImpl(Job *job) {
 
 #if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
   insertIntoJobQueue(job);
-#elif !SWIFT_CONCURRENCY_ENABLE_DISPATCH
-  swift_reportError(0, "operation unsupported without libdispatch: "
-                       "swift_task_enqueueMainExecutor");
 #else
 
   JobPriority priority = job->getPriority();
@@ -454,7 +439,7 @@ void swift::swift_task_enqueueMainExecutor(Job *job) {
     swift_task_enqueueMainExecutorImpl(job);
 }
 
-#if SWIFT_CONCURRENCY_ENABLE_DISPATCH
+#if !SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
 void swift::swift_task_enqueueOnDispatchQueue(Job *job,
                                               HeapObject *_queue) {
   JobPriority priority = job->getPriority();
@@ -464,8 +449,7 @@ void swift::swift_task_enqueueOnDispatchQueue(Job *job,
 #endif
 
 ExecutorRef swift::swift_task_getMainExecutor() {
-#if !SWIFT_CONCURRENCY_ENABLE_DISPATCH
-  // FIXME: this isn't right for the non-cooperative environment
+#if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
   return ExecutorRef::generic();
 #else
   return ExecutorRef::forOrdinary(
@@ -475,8 +459,7 @@ ExecutorRef swift::swift_task_getMainExecutor() {
 }
 
 bool ExecutorRef::isMainExecutor() const {
-#if !SWIFT_CONCURRENCY_ENABLE_DISPATCH
-  // FIXME: this isn't right for the non-cooperative environment
+#if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
   return isGeneric();
 #else
   return Identity == reinterpret_cast<HeapObject*>(&_dispatch_main_q);

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -27,7 +27,7 @@
 #include "Debug.h"
 #include "Error.h"
 
-#if SWIFT_CONCURRENCY_ENABLE_DISPATCH
+#if !SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
 #include <dispatch/dispatch.h>
 #endif
 
@@ -248,7 +248,7 @@ static void destroyTask(SWIFT_CONTEXT HeapObject *obj) {
 }
 
 static ExecutorRef executorForEnqueuedJob(Job *job) {
-#if !SWIFT_CONCURRENCY_ENABLE_DISPATCH
+#if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
   return ExecutorRef::generic();
 #else
   void *jobQueue = job->SchedulerPrivate[Job::DispatchQueueIndex];
@@ -1065,19 +1065,13 @@ void swift::swift_continuation_logFailedCheck(const char *message) {
   swift_reportError(0, message);
 }
 
-SWIFT_RUNTIME_ATTRIBUTE_NORETURN
 SWIFT_CC(swift)
 static void swift_task_asyncMainDrainQueueImpl() {
 #if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
   bool Finished = false;
-  swift_task_donateThreadToGlobalExecutorUntil([](void *context) {
+  donateThreadToGlobalExecutorUntil([](void *context) {
     return *reinterpret_cast<bool*>(context);
   }, &Finished);
-#elif !SWIFT_CONCURRENCY_ENABLE_DISPATCH
-  // FIXME: consider implementing a concurrent global main queue for
-  // these environments?
-  swift_reportError(0, "operation unsupported without libdispatch: "
-                       "swift_task_asyncMainDrainQueue");
 #else
 #if defined(_WIN32)
   static void(FAR *pfndispatch_main)(void) = NULL;

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -34,7 +34,7 @@
 #include "queue" // TODO: remove and replace with usage of our mpsc queue
 #include <atomic>
 #include <assert.h>
-#if SWIFT_CONCURRENCY_ENABLE_DISPATCH
+#if !SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
 #include <dispatch/dispatch.h>
 #endif
 

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -100,6 +100,20 @@ void asyncLet_addImpl(AsyncTask *task, AsyncLet *asyncLet,
 /// Clear the active task reference for the current thread.
 AsyncTask *_swift_task_clearCurrent();
 
+#if defined(SWIFT_STDLIB_SINGLE_THREADED_RUNTIME)
+#define SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR 1
+#else
+#define SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR 0
+#endif
+
+#if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
+/// Donate this thread to the global executor until either the
+/// given condition returns true or we've run out of cooperative
+/// tasks to run.
+void donateThreadToGlobalExecutorUntil(bool (*condition)(void*),
+                                       void *context);
+#endif
+
 /// release() establishes a happens-before relation with a preceding acquire()
 /// on the same address.
 void _swift_tsan_acquire(void *addr);


### PR DESCRIPTION
Reverts apple/swift#39480

This caused a build failure: https://ci.swift.org/job/oss-swift-package-macos/6216/

```
Undefined symbols for architecture arm64:
  "_swift_task_enqueueOnDispatchQueue", referenced from:
      protocol witness for Swift.Executor.enqueue(Swift.UnownedJob) -> () in conformance Swift.DispatchQueueShim : Swift.Executor in Swift in _Concurrency.o
ld: symbol(s) not found for architecture arm64
```

rdar://83627093