### PR TITLE
AST: Add request to compute protocol structural requirements and dependencies

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4151,6 +4151,8 @@ class ProtocolDecl final : public NominalTypeDecl {
 
   friend class SuperclassDeclRequest;
   friend class SuperclassTypeRequest;
+  friend class StructuralRequirementsRequest;
+  friend class ProtocolDependenciesRequest;
   friend class RequirementSignatureRequest;
   friend class ProtocolRequiresClassRequest;
   friend class ExistentialConformsToSelfRequest;
@@ -4337,6 +4339,17 @@ public:
   /// Retrieve the name to use for this protocol when interoperating
   /// with the Objective-C runtime.
   StringRef getObjCRuntimeName(llvm::SmallVectorImpl<char> &buffer) const;
+
+  /// Retrieve the original requirements written in source, as structural types.
+  ///
+  /// The requirement machine builds the requirement signature from structural
+  /// requirements. Almost everywhere else should use getRequirementSignature()
+  /// instead.
+  ArrayRef<StructuralRequirement> getStructuralRequirements() const;
+
+  /// Get the list of protocols appearing on the right hand side of conformance
+  /// requirements. Computed from the structural requirements, above.
+  ArrayRef<ProtocolDecl *> getProtocolDependencies() const;
 
   /// Retrieve the requirements that describe this protocol.
   ///

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -105,6 +105,25 @@ inline void simple_display(llvm::raw_ostream &out, const Requirement &req) {
   req.print(out, PrintOptions());
 }
 
+/// A requirement as written in source, together with a source location. See
+/// ProtocolDecl::getStructuralRequirements().
+struct StructuralRequirement {
+  /// The actual requirement, where the types were resolved with the
+  /// 'Structural' type resolution stage.
+  Requirement req;
+
+  /// The source location where the requirement is written, used for redundancy
+  /// and conflict diagnostics.
+  SourceLoc loc;
+
+  /// A flag indicating whether the requirement was inferred from the
+  /// application of a type constructor. Also used for diagnostics, because
+  /// an inferred requirement made redundant by an explicit requirement is not
+  /// diagnosed as redundant, since we want to give users the option of
+  /// spelling out these requirements explicitly.
+  bool inferred = false;
+};
+
 } // end namespace swift
 
 #endif

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -368,6 +368,44 @@ public:
   void cacheResult(bool value) const;
 };
 
+class StructuralRequirementsRequest :
+    public SimpleRequest<StructuralRequirementsRequest,
+                         ArrayRef<StructuralRequirement>(ProtocolDecl *),
+                         RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  ArrayRef<StructuralRequirement>
+  evaluate(Evaluator &evaluator, ProtocolDecl *proto) const;
+
+public:
+  // Caching.
+  bool isCached() const { return true; }
+};
+
+class ProtocolDependenciesRequest :
+    public SimpleRequest<ProtocolDependenciesRequest,
+                         ArrayRef<ProtocolDecl *>(ProtocolDecl *),
+                         RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  ArrayRef<ProtocolDecl *>
+  evaluate(Evaluator &evaluator, ProtocolDecl *proto) const;
+
+public:
+  // Caching.
+  bool isCached() const { return true; }
+};
+
 /// Compute the requirements that describe a protocol.
 class RequirementSignatureRequest :
     public SimpleRequest<RequirementSignatureRequest,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -217,6 +217,12 @@ SWIFT_REQUEST(TypeChecker, ProtocolRequiresClassRequest, bool(ProtocolDecl *),
 SWIFT_REQUEST(TypeChecker, RequirementRequest,
               Requirement(WhereClauseOwner, unsigned, TypeResolutionStage),
               Cached, HasNearestLocation)
+SWIFT_REQUEST(TypeChecker, StructuralRequirementsRequest,
+              ArrayRef<StructuralRequirement>(ProtocolDecl *), Cached,
+              HasNearestLocation)
+SWIFT_REQUEST(TypeChecker, ProtocolDependenciesRequest,
+              ArrayRef<ProtocolDecl *>(ProtocolDecl *), Cached,
+              HasNearestLocation)
 SWIFT_REQUEST(TypeChecker, RequirementSignatureRequest,
               ArrayRef<Requirement>(ProtocolDecl *), SeparatelyCached,
               NoLocationInfo)

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5202,6 +5202,20 @@ StringRef ProtocolDecl::getObjCRuntimeName(
   return mangleObjCRuntimeName(this, buffer);
 }
 
+ArrayRef<StructuralRequirement>
+ProtocolDecl::getStructuralRequirements() const {
+  return evaluateOrDefault(getASTContext().evaluator,
+               StructuralRequirementsRequest { const_cast<ProtocolDecl *>(this) },
+               None);
+}
+
+ArrayRef<ProtocolDecl *>
+ProtocolDecl::getProtocolDependencies() const {
+  return evaluateOrDefault(getASTContext().evaluator,
+               ProtocolDependenciesRequest { const_cast<ProtocolDecl *>(this) },
+               None);
+}
+
 ArrayRef<Requirement> ProtocolDecl::getRequirementSignature() const {
   return evaluateOrDefault(getASTContext().evaluator,
                RequirementSignatureRequest { const_cast<ProtocolDecl *>(this) },


### PR DESCRIPTION
These will be used by the RequirementMachine to compute requirement
signatures. For now, they're not hooked up.

ProtocolDecl::getStructuralRequirements() produces a list of Requirements
with SourceLocs from the structural types written in the protocol's
inheritance clause and 'where' clauses.

ProtocolDecl::getProtocolDependencies() produces a list of protocols which
appear on the right hand side of the protocol's conformance requirements.