### PR TITLE
[SILInliner] Added lexical lifetimes for arguments.

### DIFF
--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -424,17 +424,40 @@ SILInlineCloner::cloneInline(ArrayRef<SILValue> AppliedArgs) {
   SmallVector<SILValue, 4> entryArgs;
   entryArgs.reserve(AppliedArgs.size());
   SmallBitVector borrowedArgs(AppliedArgs.size());
+  SmallBitVector copiedArgs(AppliedArgs.size());
+  auto enableLexicalLifetimes =
+      Apply.getFunction()
+          ->getModule()
+          .getASTContext()
+          .LangOpts.EnableExperimentalLexicalLifetimes;
 
   auto calleeConv = getCalleeFunction()->getConventions();
   for (auto p : llvm::enumerate(AppliedArgs)) {
     SILValue callArg = p.value();
     unsigned idx = p.index();
-    // Insert begin/end borrow for guaranteed arguments.
-    if (idx >= calleeConv.getSILArgIndexOfFirstParam() &&
-        calleeConv.getParamInfoForSILArg(idx).isGuaranteed()) {
-      if (SILValue newValue = borrowFunctionArgument(callArg, Apply)) {
-        callArg = newValue;
+    if (idx >= calleeConv.getSILArgIndexOfFirstParam()) {
+      if (Apply.getFunction()->hasOwnership() && enableLexicalLifetimes) {
+        if (!callArg->getType().isTrivial(*Apply.getFunction())) {
+          SILBuilderWithScope builder(Apply.getInstruction(), getBuilder());
+          if (calleeConv.getParamInfoForSILArg(idx).isGuaranteed()) {
+            callArg = builder.createBeginBorrow(Apply.getLoc(), callArg,
+                                                /*isLexical*/ true);
+          } else { /*owned*/
+            auto *bbi = builder.createBeginBorrow(Apply.getLoc(), callArg,
+                                                  /*isLexical*/ true);
+            callArg = builder.createCopyValue(Apply.getLoc(), bbi);
+            copiedArgs[idx] = true;
+          }
+        }
         borrowedArgs[idx] = true;
+      } else {
+        // Insert begin/end borrow for guaranteed arguments.
+        if (calleeConv.getParamInfoForSILArg(idx).isGuaranteed()) {
+          if (SILValue newValue = borrowFunctionArgument(callArg, Apply)) {
+            callArg = newValue;
+            borrowedArgs[idx] = true;
+          }
+        }
       }
     }
     entryArgs.push_back(callArg);
@@ -490,7 +513,23 @@ SILInlineCloner::cloneInline(ArrayRef<SILValue> AppliedArgs) {
 
       for (auto *insertPt : endBorrowInsertPts) {
         SILBuilderWithScope returnBuilder(insertPt, getBuilder());
-        returnBuilder.createEndBorrow(Apply.getLoc(), entryArgs[i]);
+        SILValue original;
+        SILValue borrow;
+        if (copiedArgs.test(i)) {
+          auto *cvi =
+              cast<CopyValueInst>(entryArgs[i]->getDefiningInstruction());
+          auto *bbi = cast<BeginBorrowInst>(
+              cvi->getOperand()->getDefiningInstruction());
+          borrow = bbi;
+          original = bbi->getOperand();
+        } else {
+          original = SILValue();
+          borrow = entryArgs[i];
+        }
+        returnBuilder.createEndBorrow(Apply.getLoc(), borrow);
+        if (original) {
+          returnBuilder.createDestroyValue(Apply.getLoc(), original);
+        }
       }
     }
   }

--- a/test/SILOptimizer/inline_lifetime.sil
+++ b/test/SILOptimizer/inline_lifetime.sil
@@ -1,0 +1,386 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -inline -enable-experimental-lexical-lifetimes | %FileCheck %s
+
+import Swift
+
+class C {}
+
+////////////////////////////////////////////////////////////////////////////////
+// apply
+////////////////////////////////////////////////////////////////////////////////
+
+// declarations
+
+sil [ossa] [always_inline] @callee_owned : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+    destroy_value %instance : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_guaranteed : $@convention(thin) (@guaranteed C) -> () {
+entry(%instance : @guaranteed $C):
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// tests
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_owned : $@convention(thin) (@owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_owned'
+sil [ossa] @caller_owned_callee_owned : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+    %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+    %result = apply %callee_owned(%instance) : $@convention(thin) (@owned C) -> ()
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed : $@convention(thin) (@owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_guaranteed'
+sil [ossa] @caller_owned_callee_guaranteed : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+    %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %result = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed C) -> ()
+    destroy_value %instance : $C
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_guaranteed_callee_guaranteed : $@convention(thin) (@guaranteed C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @guaranteed $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'caller_guaranteed_callee_guaranteed'
+sil [ossa] @caller_guaranteed_callee_guaranteed : $@convention(thin) (@guaranteed C) -> () {
+entry(%instance : @guaranteed $C):
+    %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %result = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed C) -> ()
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_guaranteed_callee_owned : $@convention(thin) (@guaranteed C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @guaranteed $C):
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[INSTANCE]]
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[COPY]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         destroy_value [[LIFETIME_OWNED]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'caller_guaranteed_callee_owned'
+sil [ossa] @caller_guaranteed_callee_owned : $@convention(thin) (@guaranteed C) -> () {
+entry(%instance : @guaranteed $C):
+    %copy = copy_value %instance : $C
+    %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+    %result = apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+    return %result : $()
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// begin_apply
+////////////////////////////////////////////////////////////////////////////////
+
+// declarations
+
+sil [ossa] [always_inline] @callee_coro_owned : $@yield_once @convention(method) (@owned C) -> @yields @inout C {
+bb0(%instance : @owned $C):
+  %addr = alloc_stack $C
+  store %instance to [init] %addr : $*C
+  yield %addr : $*C, resume bb1, unwind bb2
+bb1:
+  destroy_addr %addr : $*C
+  dealloc_stack %addr : $*C
+  %result = tuple ()
+  return %result : $()
+bb2:
+  destroy_addr %addr : $*C
+  dealloc_stack %addr : $*C
+  unwind
+}
+
+sil [ossa] [always_inline] @callee_coro_guaranteed : $@yield_once @convention(method) (@guaranteed C) -> @yields @inout C {
+bb0(%instance : @guaranteed $C):
+  %copy = copy_value %instance : $C
+  %addr = alloc_stack $C
+  store %copy to [init] %addr : $*C
+  yield %addr : $*C, resume bb1, unwind bb2
+bb1:
+  destroy_addr %addr : $*C
+  dealloc_stack %addr : $*C
+  %result = tuple ()
+  return %result : $()
+bb2:
+  destroy_addr %addr : $*C
+  dealloc_stack %addr : $*C
+  unwind
+}
+
+// tests
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_coro_owned : $@convention(method) (@owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         [[ADDR:%[^,]+]] = alloc_stack $C
+// CHECK:         store [[LIFETIME_OWNED]] to [init] [[ADDR]]
+// CHECK:         destroy_addr [[ADDR]]
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK:         [[ORIGINAL_RETVAL:%[^,]+]] = tuple ()
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       bb1:
+// CHECK:         destroy_addr [[ADDR]]
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_coro_owned'
+sil [ossa] @caller_owned_callee_coro_owned : $@convention(method) (@owned C) -> () {
+bb0(%instance : @owned $C):
+  %callee_coro_owned = function_ref @callee_coro_owned : $@yield_once @convention(method) (@owned C) -> @yields @inout C
+  (%addr, %continuation) = begin_apply %callee_coro_owned(%instance) : $@yield_once @convention(method) (@owned C) -> @yields @inout C
+  end_apply %continuation
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_coro_guaranteed : $@convention(method) (@owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         [[ADDR:%[^,]+]] = alloc_stack $C
+// CHECK:         store [[LIFETIME_OWNED]] to [init] [[ADDR]]
+// CHECK:         destroy_addr [[ADDR]]
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK:         [[ORIGINAL_RETVAL:%[^,]+]] = tuple ()
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       bb1:
+// CHECK:         destroy_addr [[ADDR]]
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_coro_guaranteed'
+sil [ossa] @caller_owned_callee_coro_guaranteed : $@convention(method) (@owned C) -> () {
+bb0(%instance : @owned $C):
+  %callee_coro_guaranteed = function_ref @callee_coro_guaranteed : $@yield_once @convention(method) (@guaranteed C) -> @yields @inout C
+  (%addr, %continuation) = begin_apply %callee_coro_guaranteed(%instance) : $@yield_once @convention(method) (@guaranteed C) -> @yields @inout C
+  end_apply %continuation
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_guaranteed_callee_coro_owned : $@convention(method) (@guaranteed C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @guaranteed $C):
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[INSTANCE]]
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[COPY]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         [[ADDR:%[^,]+]] = alloc_stack $C
+// CHECK:         store [[LIFETIME_OWNED]] to [init] [[ADDR]]
+// CHECK:         destroy_addr [[ADDR]]
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK:         [[ORIGINAL_RETVAL:%[^,]+]] = tuple ()
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       bb1:
+// CHECK:         destroy_addr [[ADDR]]
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'caller_guaranteed_callee_coro_owned'
+sil [ossa] @caller_guaranteed_callee_coro_owned : $@convention(method) (@guaranteed C) -> () {
+bb0(%instance : @guaranteed $C):
+  %copy = copy_value %instance : $C
+  %callee_coro_owned = function_ref @callee_coro_owned : $@yield_once @convention(method) (@owned C) -> @yields @inout C
+  (%addr, %continuation) = begin_apply %callee_coro_owned(%copy) : $@yield_once @convention(method) (@owned C) -> @yields @inout C
+  end_apply %continuation
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_guaranteed_callee_coro_guaranteed : $@convention(method) (@guaranteed C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @guaranteed $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         [[ADDR:%[^,]+]] = alloc_stack $C
+// CHECK:         store [[LIFETIME_OWNED]] to [init] [[ADDR]]
+// CHECK:         destroy_addr [[ADDR]]
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK:         [[ORIGINAL_RETVAL:%[^,]+]] = tuple ()
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       bb1:
+// CHECK:         destroy_addr [[ADDR]]
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'caller_guaranteed_callee_coro_guaranteed'
+sil [ossa] @caller_guaranteed_callee_coro_guaranteed : $@convention(method) (@guaranteed C) -> () {
+bb0(%instance : @guaranteed $C):
+  %callee_coro_guaranteed = function_ref @callee_coro_guaranteed : $@yield_once @convention(method) (@guaranteed C) -> @yields @inout C
+  (%addr, %continuation) = begin_apply %callee_coro_guaranteed(%instance) : $@yield_once @convention(method) (@guaranteed C) -> @yields @inout C
+  end_apply %continuation
+  %retval = tuple ()
+  return %retval : $()
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// try_apply
+////////////////////////////////////////////////////////////////////////////////
+
+// declarations
+
+sil [ossa] [always_inline] @callee_error_owned : $@convention(thin) (@owned C) -> @error Error {
+bb0(%instance : @owned $C):
+  cond_br undef, bb1, bb2
+bb1:
+  destroy_value %instance : $C
+  throw undef : $Error
+bb2:
+  destroy_value %instance : $C
+  %18 = tuple ()
+  return %18 : $()
+}
+
+sil [ossa] [always_inline] @callee_error_guaranteed : $@convention(thin) (@guaranteed C) -> @error Error {
+bb0(%0 : @guaranteed $C):
+  cond_br undef, bb1, bb2
+bb1:
+  throw undef : $Error
+bb2:
+  %18 = tuple ()
+  return %18 : $()
+}
+
+// tests
+
+// CHECK-LABEL: sil [ossa] @callee_owned_callee_error_owned : $@convention(thin) (@owned C) -> @error Error {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         cond_br undef, [[THROW_BLOCK:bb[^,]+]], [[REGULAR_BLOCK:bb[0-9]+]]
+// CHECK:       [[THROW_BLOCK]]:
+// CHECK:         destroy_value [[LIFETIME_OWNED]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         throw undef
+// CHECK:       [[REGULAR_BLOCK]]:
+// CHECK:         destroy_value [[LIFETIME_OWNED]]
+// CHECK:         [[ORIGINAL_RETVAL:%[^,]+]] = tuple ()
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'callee_owned_callee_error_owned'
+sil [ossa] @callee_owned_callee_error_owned : $@convention(thin) (@owned C) -> @error Error {
+bb0(%instance : @owned $C):
+  %callee_error_owned = function_ref @callee_error_owned : $@convention(thin) (@owned C) -> @error Error
+  try_apply %callee_error_owned(%instance) : $@convention(thin) (@owned C) -> @error Error, normal bb1, error bb2
+
+bb1(%9 : $()):
+  %10 = tuple ()
+  return %10 : $()
+bb2(%12 : @owned $Error):
+  throw %12 : $Error
+}
+
+// CHECK-LABEL: sil [ossa] @callee_owned_callee_error_guaranteed : $@convention(thin) (@owned C) -> @error Error {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         cond_br undef, [[THROW_BLOCK:bb[^,]+]], [[REGULAR_BLOCK:bb[0-9]+]]
+// CHECK:       [[THROW_BLOCK]]:
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         throw undef
+// CHECK:       [[REGULAR_BLOCK]]:
+// CHECK:         [[ORIGINAL_RETVAL:%[^,]+]] = tuple ()
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'callee_owned_callee_error_guaranteed'
+sil [ossa] @callee_owned_callee_error_guaranteed : $@convention(thin) (@owned C) -> @error Error {
+bb0(%instance : @owned $C):
+  %callee_error_guaranteed = function_ref @callee_error_guaranteed : $@convention(thin) (@guaranteed C) -> @error Error
+  try_apply %callee_error_guaranteed(%instance) : $@convention(thin) (@guaranteed C) -> @error Error, normal bb1, error bb2
+bb1(%9 : $()):
+  destroy_value %instance : $C
+  %10 = tuple ()
+  return %10 : $()
+bb2(%12 : @owned $Error):
+  destroy_value %instance : $C
+  throw %12 : $Error
+}
+
+// CHECK-LABEL: sil [ossa] @callee_guaranteed_callee_error_owned : $@convention(thin) (@guaranteed C) -> @error Error {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @guaranteed $C):
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[INSTANCE]]
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[COPY]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         cond_br undef, [[THROW_BLOCK:bb[^,]+]], [[REGULAR_BLOCK:bb[0-9]+]]
+// CHECK:       [[THROW_BLOCK]]:
+// CHECK:         destroy_value [[LIFETIME_OWNED]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         throw undef
+// CHECK:       [[REGULAR_BLOCK]]:
+// CHECK:         destroy_value [[LIFETIME_OWNED]]
+// CHECK:         [[ORIGINAL_RETVAL:%[^,]+]] = tuple ()
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'callee_guaranteed_callee_error_owned'
+sil [ossa] @callee_guaranteed_callee_error_owned : $@convention(thin) (@guaranteed C) -> @error Error {
+bb0(%instance : @guaranteed $C):
+  %copy = copy_value %instance : $C
+  %callee_error_owned = function_ref @callee_error_owned : $@convention(thin) (@owned C) -> @error Error
+  try_apply %callee_error_owned(%copy) : $@convention(thin) (@owned C) -> @error Error, normal bb1, error bb2
+bb1(%9 : $()):
+  %10 = tuple ()
+  return %10 : $()
+bb2(%12 : @owned $Error):
+  throw %12 : $Error
+}
+
+// CHECK-LABEL: sil [ossa] @callee_guaranteed_callee_error_guaranteed : $@convention(thin) (@guaranteed C) -> @error Error {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @guaranteed $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         cond_br undef, [[BASIC_BLOCK1:bb[^,]+]], [[BASIC_BLOCK2:bb[0-9]+]]
+// CHECK:       [[BASIC_BLOCK1]]:
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         throw undef
+// CHECK:       [[BASIC_BLOCK2]]:
+// CHECK:         [[ORIGINAL_RETVAL:%[^,]+]] = tuple ()
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'callee_guaranteed_callee_error_guaranteed'
+sil [ossa] @callee_guaranteed_callee_error_guaranteed : $@convention(thin) (@guaranteed C) -> @error Error {
+bb0(%instance : @guaranteed $C):
+  %callee_error_guaranteed = function_ref @callee_error_guaranteed : $@convention(thin) (@guaranteed C) -> @error Error
+  try_apply %callee_error_guaranteed(%instance) : $@convention(thin) (@guaranteed C) -> @error Error, normal bb1, error bb2
+bb1(%9 : $()):
+  %10 = tuple ()
+  return %10 : $()
+bb2(%12 : @owned $Error):
+  throw %12 : $Error
+}


### PR DESCRIPTION
When the -enable-experimental-lexical-lifetimes flag is passed, added lexical borrow scopes for every non-trivial argument when inlining a function.
