### PR TITLE
[NFC] Add module alias map and lookup func to ASTContext

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -347,6 +347,9 @@ private:
   /// Cache of module names that fail the 'canImport' test in this context.
   mutable llvm::SmallPtrSet<Identifier, 8> FailedModuleImportNames;
   
+  /// Mapping between aliases and underlying names of modules imported or referenced modules.
+  mutable llvm::DenseMap<Identifier, Identifier> ModuleAliasMap;
+
   /// Retrieve the allocator for the given arena.
   llvm::BumpPtrAllocator &
   getAllocator(AllocationArena arena = AllocationArena::Permanent) const;
@@ -470,6 +473,12 @@ public:
   /// getIdentifier - Return the uniqued and AST-Context-owned version of the
   /// specified string.
   Identifier getIdentifier(StringRef Str) const;
+
+  /// Convert a given alias map to a map of Identifiers between module aliases and underlying names.
+  void setModuleAliases(const llvm::StringMap<StringRef> &aliasMap);
+
+  /// Retrieve the underlying name given an alias name key.
+  Identifier lookupModuleAlias(Identifier key) const;
 
   /// Decide how to interpret two precedence groups.
   Associativity associateInfixOperators(PrecedenceGroupDecl *left,

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -347,7 +347,7 @@ private:
   /// Cache of module names that fail the 'canImport' test in this context.
   mutable llvm::SmallPtrSet<Identifier, 8> FailedModuleImportNames;
   
-  /// Mapping between aliases and underlying names of modules imported or referenced modules.
+  /// Mapping between aliases and real (physical) names of imported or referenced modules.
   mutable llvm::DenseMap<Identifier, Identifier> ModuleAliasMap;
 
   /// Retrieve the allocator for the given arena.
@@ -474,13 +474,13 @@ public:
   /// specified string.
   Identifier getIdentifier(StringRef Str) const;
 
-  /// Convert a given alias map to a map of Identifiers between module aliases and underlying names.
+  /// Convert a given alias map to a map of Identifiers between module aliases and their actual names.
   /// For example, if '-module-alias A=X -module-alias B=Y' input is passed in, the aliases A and B are
   /// the names of the imported or referenced modules in source files in the main module, and X and Y
-  /// are the underlying (physical) module names on disk.
+  /// are the real (physical) module names on disk.
   void setModuleAliases(const llvm::StringMap<StringRef> &aliasMap);
 
-  /// Retrieve the underlying name given an alias name key.
+  /// Retrieve the actual module name given a module alias name key.
   Identifier lookupModuleAlias(Identifier key) const;
 
   /// Decide how to interpret two precedence groups.

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -475,6 +475,9 @@ public:
   Identifier getIdentifier(StringRef Str) const;
 
   /// Convert a given alias map to a map of Identifiers between module aliases and underlying names.
+  /// For example, if '-module-alias A=X -module-alias B=Y' input is passed in, the aliases A and B are
+  /// the names of the imported or referenced modules in source files in the main module, and X and Y
+  /// are the underlying (physical) module names on disk.
   void setModuleAliases(const llvm::StringMap<StringRef> &aliasMap);
 
   /// Retrieve the underlying name given an alias name key.

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -475,13 +475,14 @@ public:
   Identifier getIdentifier(StringRef Str) const;
 
   /// Convert a given alias map to a map of Identifiers between module aliases and their actual names.
-  /// For example, if '-module-alias A=X -module-alias B=Y' input is passed in, the aliases A and B are
+  /// For example, if '-module-alias Foo=X -module-alias Bar=Y' input is passed in, the aliases Foo and Bar are
   /// the names of the imported or referenced modules in source files in the main module, and X and Y
   /// are the real (physical) module names on disk.
   void setModuleAliases(const llvm::StringMap<StringRef> &aliasMap);
 
-  /// Retrieve the actual module name given a module alias name key.
-  Identifier lookupModuleAlias(Identifier key) const;
+  /// Retrieve the actual module name if a module alias is used via '-module-alias Foo=X', where Foo is
+  /// a module alias and X is the real (physical) name. Returns \p key if no aliasing is used.
+  Identifier getRealModuleName(Identifier key) const;
 
   /// Decide how to interpret two precedence groups.
   Associativity associateInfixOperators(PrecedenceGroupDecl *left,

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -171,6 +171,9 @@ class ModuleDecl
   /// The ABI name of the module, if it differs from the module name.
   mutable Identifier ModuleABIName;
 
+  /// The underlying name for an alias used for this module (if any).
+  mutable Identifier ModuleUnderlyingName;
+
 public:
   /// Produces the components of a given module's full name in reverse order.
   ///
@@ -357,6 +360,10 @@ public:
     ModuleABIName = name;
   }
 
+  /// Retrieve the underlying name of the alias (if any) used for this module.
+  /// If no module alias is set, it returns getName().
+  Identifier getUnderlyingName() const;
+
   /// User-defined module version number.
   llvm::VersionTuple UserModuleVersion;
   void setUserModuleVersion(llvm::VersionTuple UserVer) {
@@ -365,6 +372,7 @@ public:
   llvm::VersionTuple getUserModuleVersion() const {
     return UserModuleVersion;
   }
+
 private:
   /// A cache of this module's underlying module and required bystander if it's
   /// an underscored cross-import overlay.
@@ -379,6 +387,12 @@ private:
   ///  If this is a traditional (non-cross-import) overlay, get its underlying
   ///  module if one exists.
   ModuleDecl *getUnderlyingModuleIfOverlay() const;
+
+  /// If a module alias is used, set the corresponding underlying name,
+  /// which will be used for contents including metadata and mangling.
+  void setUnderlyingName(Identifier name) {
+    ModuleUnderlyingName = name;
+  }
 
 public:
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -171,9 +171,6 @@ class ModuleDecl
   /// The ABI name of the module, if it differs from the module name.
   mutable Identifier ModuleABIName;
 
-  /// The actual module name for an alias used for this module (if any).
-  mutable Identifier ModuleRealName;
-
 public:
   /// Produces the components of a given module's full name in reverse order.
   ///
@@ -392,12 +389,6 @@ private:
   ///  If this is a traditional (non-cross-import) overlay, get its underlying
   ///  module if one exists.
   ModuleDecl *getUnderlyingModuleIfOverlay() const;
-
-  /// If a module alias is used, set the corresponding real name on disk,
-  /// which will be used for contents including metadata and mangling.
-  void setRealName(Identifier name) {
-    ModuleRealName = name;
-  }
 
 public:
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -172,7 +172,7 @@ class ModuleDecl
   mutable Identifier ModuleABIName;
 
   /// The underlying name for an alias used for this module (if any).
-  mutable Identifier ModuleUnderlyingName;
+  mutable Identifier ModuleRealName;
 
 public:
   /// Produces the components of a given module's full name in reverse order.
@@ -360,9 +360,14 @@ public:
     ModuleABIName = name;
   }
 
-  /// Retrieve the underlying name of the alias (if any) used for this module.
-  /// If no module alias is set, it returns getName().
-  Identifier getUnderlyingName() const;
+  /// Retrieve the actual module name of an alias used for this module (if any).
+  ///
+  /// For example, if '-module-alias Foo=Bar' is passed in when building the main module,
+  /// and this module is (a) not the main module and (b) is named Foo, then it returns
+  /// the real (physically on-disk) module name Bar.
+  ///
+  /// If no module aliasing is set, it will return getName(), i.e. Foo.
+  Identifier getRealName() const;
 
   /// User-defined module version number.
   llvm::VersionTuple UserModuleVersion;
@@ -388,10 +393,10 @@ private:
   ///  module if one exists.
   ModuleDecl *getUnderlyingModuleIfOverlay() const;
 
-  /// If a module alias is used, set the corresponding underlying name,
+  /// If a module alias is used, set the corresponding real name on disk,
   /// which will be used for contents including metadata and mangling.
-  void setUnderlyingName(Identifier name) {
-    ModuleUnderlyingName = name;
+  void setRealName(Identifier name) {
+    ModuleRealName = name;
   }
 
 public:

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -171,7 +171,7 @@ class ModuleDecl
   /// The ABI name of the module, if it differs from the module name.
   mutable Identifier ModuleABIName;
 
-  /// The underlying name for an alias used for this module (if any).
+  /// The actual module name for an alias used for this module (if any).
   mutable Identifier ModuleRealName;
 
 public:

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1651,7 +1651,7 @@ void ASTContext::setModuleAliases(const llvm::StringMap<StringRef> &aliasMap) {
   }
 }
 
-Identifier ASTContext::lookupModuleAlias(Identifier key) const {
+Identifier ASTContext::getRealModuleName(Identifier key) const {
   auto found = ModuleAliasMap.find(key);
   if (found != ModuleAliasMap.end()) {
     return found->second;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1642,6 +1642,21 @@ void ASTContext::addModuleInterfaceChecker(
   getImpl().InterfaceChecker = std::move(checker);
 }
 
+void ASTContext::setModuleAliases(const llvm::StringMap<StringRef> &aliasMap) {
+  for (auto k: aliasMap.keys()) {
+    auto val = aliasMap.lookup(k);
+    ModuleAliasMap[getIdentifier(k)] = getIdentifier(val);
+  }
+}
+
+Identifier ASTContext::lookupModuleAlias(Identifier key) const {
+  auto found = ModuleAliasMap.find(key);
+  if (found != ModuleAliasMap.end()) {
+    return found->second;
+  }
+  return Identifier();
+}
+
 Optional<ModuleDependencies> ASTContext::getModuleDependencies(
     StringRef moduleName, bool isUnderlyingClangModule,
     ModuleDependenciesCache &cache, InterfaceSubContextDelegate &delegate,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1645,7 +1645,9 @@ void ASTContext::addModuleInterfaceChecker(
 void ASTContext::setModuleAliases(const llvm::StringMap<StringRef> &aliasMap) {
   for (auto k: aliasMap.keys()) {
     auto val = aliasMap.lookup(k);
-    ModuleAliasMap[getIdentifier(k)] = getIdentifier(val);
+    if (!val.empty()) {
+      ModuleAliasMap[getIdentifier(k)] = getIdentifier(val);
+    }
   }
 }
 
@@ -1654,7 +1656,7 @@ Identifier ASTContext::lookupModuleAlias(Identifier key) const {
   if (found != ModuleAliasMap.end()) {
     return found->second;
   }
-  return Identifier();
+  return key;
 }
 
 Optional<ModuleDependencies> ASTContext::getModuleDependencies(

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -476,7 +476,6 @@ ModuleDecl::ModuleDecl(Identifier name, ASTContext &ctx,
   setImplicit();
   setInterfaceType(ModuleType::get(this));
   setAccess(AccessLevel::Public);
-  setRealName(ctx.lookupModuleAlias(name));
 
   Bits.ModuleDecl.StaticLibrary = 0;
   Bits.ModuleDecl.TestingEnabled = 0;
@@ -1565,9 +1564,8 @@ ImportedModule::removeDuplicates(SmallVectorImpl<ImportedModule> &imports) {
 }
 
 Identifier ModuleDecl::getRealName() const {
-    if (!ModuleRealName.empty())
-      return ModuleRealName;
-    return getName();
+  // This will return the real name for an alias (if used) or getName()
+  return getASTContext().lookupModuleAlias(getName());
 }
 
 Identifier ModuleDecl::getABIName() const {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -476,7 +476,7 @@ ModuleDecl::ModuleDecl(Identifier name, ASTContext &ctx,
   setImplicit();
   setInterfaceType(ModuleType::get(this));
   setAccess(AccessLevel::Public);
-  setUnderlyingName(ctx.lookupModuleAlias(name));
+  setRealName(ctx.lookupModuleAlias(name));
 
   Bits.ModuleDecl.StaticLibrary = 0;
   Bits.ModuleDecl.TestingEnabled = 0;
@@ -1564,9 +1564,9 @@ ImportedModule::removeDuplicates(SmallVectorImpl<ImportedModule> &imports) {
   imports.erase(last, imports.end());
 }
 
-Identifier ModuleDecl::getUnderlyingName() const {
-    if (!ModuleUnderlyingName.empty())
-        return ModuleUnderlyingName;
+Identifier ModuleDecl::getRealName() const {
+    if (!ModuleRealName.empty())
+      return ModuleRealName;
     return getName();
 }
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1565,7 +1565,7 @@ ImportedModule::removeDuplicates(SmallVectorImpl<ImportedModule> &imports) {
 
 Identifier ModuleDecl::getRealName() const {
   // This will return the real name for an alias (if used) or getName()
-  return getASTContext().lookupModuleAlias(getName());
+  return getASTContext().getRealModuleName(getName());
 }
 
 Identifier ModuleDecl::getABIName() const {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -475,8 +475,8 @@ ModuleDecl::ModuleDecl(Identifier name, ASTContext &ctx,
   ctx.addDestructorCleanup(*this);
   setImplicit();
   setInterfaceType(ModuleType::get(this));
-
   setAccess(AccessLevel::Public);
+  setUnderlyingName(ctx.lookupModuleAlias(name));
 
   Bits.ModuleDecl.StaticLibrary = 0;
   Bits.ModuleDecl.TestingEnabled = 0;
@@ -1562,6 +1562,12 @@ ImportedModule::removeDuplicates(SmallVectorImpl<ImportedModule> &imports) {
         return lhs.accessPath.isSameAs(rhs.accessPath);
       });
   imports.erase(last, imports.end());
+}
+
+Identifier ModuleDecl::getUnderlyingName() const {
+    if (!ModuleUnderlyingName.empty())
+        return ModuleUnderlyingName;
+    return getName();
 }
 
 Identifier ModuleDecl::getABIName() const {

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -219,6 +219,9 @@ bool CompilerInstance::setUpASTContextIfNeeded() {
       Invocation.getClangImporterOptions(),
       Invocation.getSymbolGraphOptions(),
       SourceMgr, Diagnostics));
+  if (!Invocation.getFrontendOptions().ModuleAliasMap.empty())
+    Context->setModuleAliases(Invocation.getFrontendOptions().ModuleAliasMap);
+
   registerParseRequestFunctions(Context->evaluator);
   registerTypeCheckerRequestFunctions(Context->evaluator);
   registerSILGenRequestFunctions(Context->evaluator);


### PR DESCRIPTION
[NFC] Add a module alias map and a lookup func to ASTContext.
Add a getter for the actual module name in ModuleDecl if a module alias is used.
rdar://83682112