### PR TITLE
[concurrency] Fix infinite recursion in determining the mangling kind for a backdeployed feature.

### DIFF
--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -634,10 +634,10 @@ protected:
   }
 };
 
-/// Does this type require a special minimum Swift runtime version which
-/// supports demangling it?
-Optional<llvm::VersionTuple>
-getRuntimeVersionThatSupportsDemanglingType(CanType type);
+/// Determines if the minimum deployment target's runtime demangler will not
+/// understand the mangled name for the given type.
+/// \returns true iff the target's runtime does not understand the mangled name.
+bool mangledNameIsUnknownToDeployTarget(IRGenModule &IGM, CanType type);
 
 } // end namespace irgen
 } // end namespace swift

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -2484,7 +2484,11 @@ static bool shouldAccessByMangledName(IRGenModule &IGM, CanType type) {
   // Never access by mangled name if we've been asked not to.
   if (IGM.getOptions().DisableConcreteTypeMetadataMangledNameAccessors)
     return false;
-  
+
+  // Do not access by mangled name if the runtime won't understand it.
+  if (mangledNameIsUnknownToDeployTarget(IGM, type))
+    return false;
+
   // A nongeneric nominal type with nontrivial metadata has an accessor
   // already we can just call.
   if (auto nom = dyn_cast<NominalType>(type)) {
@@ -2494,14 +2498,7 @@ static bool shouldAccessByMangledName(IRGenModule &IGM, CanType type) {
       return false;
     }
   }
-  
-  // The Swift 5.1 runtime fails to demangle associated types of opaque types.
-  if (auto minimumSwiftVersion =
-          getRuntimeVersionThatSupportsDemanglingType(type)) {
-    return IGM.getAvailabilityContext().isContainedIn(
-        IGM.Context.getSwift5PlusAvailability(*minimumSwiftVersion));
-  }
-  
+
   return true;
 
 // The visitor below can be used to fine-tune a heuristic to decide whether

--- a/test/Interpreter/opaque_return_type_protocol_ext.swift
+++ b/test/Interpreter/opaque_return_type_protocol_ext.swift
@@ -4,9 +4,6 @@
 
 // REQUIRES: executable_test
 
-// FIXME: Disabled because compilation is crashing in arm64e
-// REQUIRES: rdar60734429
-
 @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
 protocol P {
   associatedtype AT


### PR DESCRIPTION
One of the places where we ask whether a type's metadata should be obtained via its mangled name was missing the newer, more robust checking for minimum deployment target.

This PR also re-enables a test that was suppose to be enabled after a fix, but was missed.

Resolves rdar://83104637