### PR TITLE
Removing undefined variables from mem2reg_lifetime.sil

### DIFF
--- a/test/SILOptimizer/mem2reg_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_lifetime.sil
@@ -310,7 +310,6 @@ bb2:
 
 // CHECK: bb3([[ARG:%.*]] : @owned $@callee_owned () -> Int):
 bb3:
-// CHECK-NOT: load [[STACK]]
   %13 = load [copy] %1 : $*@callee_owned () -> Int
 // CHECK: [[COPY:%.*]] = copy_value [[ARG]]
 // CHECK: [[RESULT:%.*]] = apply [[COPY]]
@@ -322,10 +321,8 @@ bb3:
   //       block.
 // CHECK: bb4
 bb4:
-// CHECK-NOT: destroy_addr [[STACK]]
 // CHECK: destroy_value [[ARG]]
   destroy_addr %1 : $*@callee_owned () -> Int
-// CHECK-NOT: dealloc_stack [[STACK]]
   dealloc_stack %1 : $*@callee_owned () -> Int
   return %15 : $Int
 }


### PR DESCRIPTION
FileCheck on the rebranch doesn't allow undefined variables. If the
variable is defined in a CHECK-NOT and the CHECK-NOT doesn't get hit,
the variable isn't actually defined.

https://ci.swift.org/job/swift-pr-ubuntu-2004/47/console