### PR TITLE
[Distributed] fix missing _remote func entry in TBD

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -153,6 +153,10 @@ class LinkEntity {
     /// a class.
     DispatchThunkAllocatorAsyncFunctionPointer,
 
+    /// An async function pointer for a distributed thunk.
+    /// The pointer is a FuncDecl* inside an actor (class).
+    DistributedThunkAsyncFunctionPointer,
+
     /// A method descriptor.  The pointer is a FuncDecl* inside a protocol
     /// or a class.
     MethodDescriptor,
@@ -1198,7 +1202,9 @@ public:
 
   static LinkEntity forAsyncFunctionPointer(SILDeclRef declRef) {
     LinkEntity entity;
-    entity.setForDecl(Kind::AsyncFunctionPointerAST,
+    entity.setForDecl(declRef.isDistributedThunk()
+                          ? Kind::DistributedThunkAsyncFunctionPointer
+                          : Kind::AsyncFunctionPointerAST,
                       declRef.getAbstractFunctionDecl());
     entity.SecondaryPointer =
         reinterpret_cast<void *>(static_cast<uintptr_t>(declRef.kind));
@@ -1264,6 +1270,8 @@ public:
   void mangle(llvm::raw_ostream &out) const;
   void mangle(SmallVectorImpl<char> &buffer) const;
   std::string mangleAsString() const;
+
+  SILDeclRef getSILDeclRef() const;
   SILLinkage getLinkage(ForDefinition_t isDefinition) const;
 
   bool hasDecl() const {

--- a/lib/FrontendTool/TBD.cpp
+++ b/lib/FrontendTool/TBD.cpp
@@ -76,6 +76,7 @@ static bool validateSymbols(DiagnosticEngine &diags,
     // symbol table, so make sure to mangle IRGen names before comparing them
     // with what TBDGen created.
     auto unmangledName = nameValue.getKey();
+
     SmallString<128> name;
     llvm::Mangler::getNameWithPrefix(name, unmangledName,
                                      IRModule.getDataLayout());

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -718,6 +718,7 @@ void TBDGenVisitor::visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
 
   if (AFD->isDistributed()) {
     addSymbol(SILDeclRef(AFD).asDistributed());
+    addAsyncFunctionPointerSymbol(SILDeclRef(AFD).asDistributed());
   }
 
   // Add derivative function symbols.

--- a/test/TBD/distributed.swift
+++ b/test/TBD/distributed.swift
@@ -1,0 +1,26 @@
+// REQUIRES: VENDOR=apple
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -enable-testing -enable-experimental-distributed -disable-availability-checking -emit-ir -o %t/test.ll -emit-tbd -emit-tbd-path %t/test.tbd
+// RUN cat %t/test.tbd | %FileCheck %s --dump-input=always
+
+import _Distributed
+
+// CHECK: @"$s4test1AC13_remote_helloyyYaKFTd" = hidden global %swift.async_func_pointer
+// CHECK: @"$s4test1AC13_remote_helloyyYaKFTdTu" = hidden global %swift.async_func_pointer
+distributed actor SomeDistributedActor {
+  distributed func hello(name: String) -> String {
+    "Hello, \(name)!"
+  }
+}
+
+// function:
+// IR unmangledName = $s4test20SomeDistributedActorC5hello4nameS2S_tF
+// function method descriptor
+// IR unmangledName = $s4test20SomeDistributedActorC5hello4nameS2S_tFTq
+// thunk, method reference
+// IR unmangledName = $s4test20SomeDistributedActorC5hello4nameS2S_tFTd
+// thunk, method reference + async function pointer
+// IR unmangledName = $s4test20SomeDistributedActorC5hello4nameS2S_tFTdTu


### PR DESCRIPTION
Resolves rdar://82199717 

This reliably reproduces the issue of:

`<unknown>:0: error: symbol '$s4test20SomeDistributedActorC5hello4nameS2S_tFTd' (super test.SomeDistributedActor.hello(name: Swift.String) -> Swift.String) is in generated IR file, but not in TBD file`
`<unknown>:0: error: symbol '$s4test20SomeDistributedActorC5hello4nameS2S_tFTdTu' (async function pointer to super test.SomeDistributedActor.hello(name: Swift.String) -> Swift.String) is in generated IR file, but not in TBD file`

I can't really figure out how to emit those while I get a `$s4test20SomeDistributedActorC5hello4nameS2S_tF` in the TBDGenVisitor, does it mean the contents it is visiting are missing the `Td` method descriptor...?