### PR TITLE
Don't allow missing conformances from superclasses to block Sendable subclasses

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3720,7 +3720,7 @@ NormalProtocolConformance *GetImplicitSendableRequest::evaluate(
         if (TypeChecker::conformsToKnownProtocol(
                 classDecl->mapTypeIntoContext(superclass),
                 KnownProtocolKind::Sendable,
-                classModule))
+                classModule, /*allowMissing=*/false))
           return nullptr;
       }
     }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5182,9 +5182,10 @@ TypeChecker::containsProtocol(Type T, ProtocolDecl *Proto, ModuleDecl *M,
 }
 
 ProtocolConformanceRef
-TypeChecker::conformsToProtocol(Type T, ProtocolDecl *Proto, ModuleDecl *M) {
+TypeChecker::conformsToProtocol(Type T, ProtocolDecl *Proto, ModuleDecl *M,
+                                bool allowMissing) {
   // Look up conformance in the module.
-  auto lookupResult = M->lookupConformance(T, Proto, /*alllowMissing=*/true);
+  auto lookupResult = M->lookupConformance(T, Proto, allowMissing);
   if (lookupResult.isInvalid()) {
     return ProtocolConformanceRef::forInvalid();
   }
@@ -5212,11 +5213,13 @@ TypeChecker::conformsToProtocol(Type T, ProtocolDecl *Proto, ModuleDecl *M) {
   return lookupResult;
 }
 
-bool TypeChecker::conformsToKnownProtocol(Type type, KnownProtocolKind protocol,
-                                          ModuleDecl *module) {
+bool TypeChecker::conformsToKnownProtocol(
+    Type type, KnownProtocolKind protocol, ModuleDecl *module,
+    bool allowMissing) {
   if (auto *proto =
           TypeChecker::getProtocol(module->getASTContext(), SourceLoc(), protocol))
-    return (bool)TypeChecker::conformsToProtocol(type, proto, module);
+    return (bool)TypeChecker::conformsToProtocol(
+        type, proto, module, allowMissing);
   return false;
 }
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -724,11 +724,12 @@ ProtocolConformanceRef containsProtocol(Type T, ProtocolDecl *Proto,
 /// \returns The protocol conformance, if \c T conforms to the
 /// protocol \c Proto, or \c None.
 ProtocolConformanceRef conformsToProtocol(Type T, ProtocolDecl *Proto,
-                                          ModuleDecl *M);
+                                          ModuleDecl *M,
+                                          bool allowMissing = true);
 
 /// Check whether the type conforms to a given known protocol.
 bool conformsToKnownProtocol(Type type, KnownProtocolKind protocol,
-                             ModuleDecl *module);
+                             ModuleDecl *module, bool allowMissing = true);
 
 /// This is similar to \c conformsToProtocol, but returns \c true for cases where
 /// the type \p T could be dynamically cast to \p Proto protocol, such as a non-final

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -170,3 +170,14 @@ func testMirrored(instance: ClassWithAsync) async {
   await instance.protocolMethod()
   await instance.customAsyncName()
 }
+
+@MainActor class MyToolbarButton : NXButton {
+  var count = 5
+
+  func f() {
+    Task {
+      let c = count
+      print(c)
+    }
+  }
+}


### PR DESCRIPTION
Fixes rdar://83636964.
