### PR TITLE
Fix missing template member in SmallVector

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -41,6 +41,7 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Statistic.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 #include <algorithm>
 #include <queue>
@@ -402,11 +403,11 @@ class StackAllocationPromoter {
   DeallocStackInst *dsi;
 
   /// All the dealloc_stack instructions.
-  SmallVector<DeallocStackInst *> dsis;
+  llvm::SmallVector<DeallocStackInst *> dsis;
 
   /// The lexical begin_borrow instructions that were created to track the
   /// lexical lifetimes introduced by the alloc_stack, if it is lexical.
-  SmallVector<SILBasicBlock *> lexicalBBIBlocks;
+  llvm::SmallVector<SILBasicBlock *> lexicalBBIBlocks;
 
   /// Dominator info.
   DominanceInfo *domInfo;
@@ -792,7 +793,7 @@ void StackAllocationPromoter::fixPhiPredBlock(BlockSetVector &phiBlocks,
 
   LLVM_DEBUG(llvm::dbgs() << "*** Found the definition: " << *def.copy);
 
-  SmallVector<SILValue> vals;
+  llvm::SmallVector<SILValue> vals;
   vals.push_back(def.stored);
   if (shouldAddLexicalLifetime(asi)) {
     vals.push_back(def.borrow);


### PR DESCRIPTION
The ubuntu 18.04 Linux builder fails to build when the SmallVector does
not include the number of elements. This is a known issue and is
incorrect, but that is the version of clang on that OS.

The definition of SmallVector is already available transitively since
there are values of that type, I've just made it explicit.

llvm::SmallVector has a default parameter for the number of elements
while swift::SmallVector doesn't. I've gone ahead and made it explicitly
use the llvm::SmallVector to receive that.

The failing build is on the rebranch branch at the moment: https://ci.swift.org/job/swift-PR-Linux/29128/console
