### PR TITLE
Require MainActor isolation on main() function

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4339,6 +4339,10 @@ NOTE(note_add_globalactor_to_function,none,
      "add '@%0' to make %1 %2 part of global actor %3", 
      (StringRef, DescriptiveDeclKind, DeclName, Type))
 FIXIT(insert_globalactor_attr, "@%0 ", (Type))
+
+ERROR(main_function_must_be_mainActor,none,
+      "main() must be '@MainActor'", ())
+
 ERROR(not_objc_function_async,none,
       "'async' %0 cannot be represented in Objective-C", (DescriptiveDeclKind))
 NOTE(not_objc_function_type_async,none,

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2853,6 +2853,41 @@ static ActorIsolation getActorIsolationFromWrappedProperty(VarDecl *var) {
   return ActorIsolation::forUnspecified();
 }
 
+static Optional<ActorIsolation>
+getActorIsolationForMainFuncDecl(FuncDecl *fnDecl) {
+  // Ensure that the base type that this function is declared in has @main
+  // attribute
+  NominalTypeDecl *declContext =
+      dyn_cast<NominalTypeDecl>(fnDecl->getDeclContext());
+  if (ExtensionDecl *exDecl =
+          dyn_cast<ExtensionDecl>(fnDecl->getDeclContext())) {
+    declContext = exDecl->getExtendedNominal();
+  }
+
+  // We're not even in a nominal decl type, this can't be the main function decl
+  if (!declContext)
+    return {};
+  const bool isMainDeclContext =
+      declContext->getAttrs().hasAttribute<MainTypeAttr>();
+
+  ASTContext &ctx = fnDecl->getASTContext();
+
+  const bool isMainMain = fnDecl->isMainTypeMainMethod();
+  const bool isMain$Main =
+      fnDecl->getBaseIdentifier() == ctx.getIdentifier("$main") &&
+      !fnDecl->isInstanceMember() &&
+      fnDecl->getResultInterfaceType()->isVoid() &&
+      fnDecl->getParameters()->size() == 0;
+  const bool isMainFunction = isMainDeclContext && (isMainMain || isMain$Main);
+  const bool hasMainActor = !ctx.getMainActorType().isNull();
+
+  return isMainFunction && hasMainActor
+             ? ActorIsolation::forGlobalActor(
+                   ctx.getMainActorType()->mapTypeOutOfContext(),
+                   /*isUnsafe*/ false)
+             : Optional<ActorIsolation>();
+}
+
 /// Check rules related to global actor attributes on a class declaration.
 ///
 /// \returns true if an error occurred.
@@ -2922,9 +2957,26 @@ ActorIsolation ActorIsolationRequest::evaluate(
         : ActorIsolation::forActorInstance(actor);
   }
 
+  auto isolationFromAttr = getIsolationFromAttributes(value);
+  if (FuncDecl *fd = dyn_cast<FuncDecl>(value)) {
+    // Main.main() and Main.$main are implicitly MainActor-protected.
+    // Any other isolation is an error.
+    Optional<ActorIsolation> mainIsolation =
+        getActorIsolationForMainFuncDecl(fd);
+    if (mainIsolation) {
+      if (isolationFromAttr && isolationFromAttr->isGlobalActor()) {
+        if (!areTypesEqual(isolationFromAttr->getGlobalActor(),
+                           mainIsolation->getGlobalActor())) {
+          fd->getASTContext().Diags.diagnose(
+              fd->getLoc(), diag::main_function_must_be_mainActor);
+        }
+      }
+      return *mainIsolation;
+    }
+  }
   // If this declaration has one of the actor isolation attributes, report
   // that.
-  if (auto isolationFromAttr = getIsolationFromAttributes(value)) {
+  if (isolationFromAttr) {
     // Nonisolated declarations must involve Sendable types.
     if (*isolationFromAttr == ActorIsolation::Independent) {
       SubstitutionMap subs;

--- a/test/Concurrency/Runtime/class_resilience.swift
+++ b/test/Concurrency/Runtime/class_resilience.swift
@@ -55,23 +55,24 @@ func virtualWait<T>(orThrow: Bool, _ c: BaseClass<T>) async throws {
   return try await c.wait(orThrow: orThrow)
 }
 
-
-
-
 @main struct Main {
   static func main() async {
-    var AsyncVTableMethodSuite = TestSuite("ResilientClass")
-    AsyncVTableMethodSuite.test("AsyncVTableMethod") {
-      let x = MyDerived(value: 321)
+    let task = Task.detached {
+      var AsyncVTableMethodSuite = TestSuite("ResilientClass")
+      AsyncVTableMethodSuite.test("AsyncVTableMethod") {
+        let x = MyDerived(value: 321)
 
-      await virtualWaitForNothing(x)
+        await virtualWaitForNothing(x)
 
-      expectEqual(642, await virtualWait(x))
-      expectEqual(246, await virtualWaitForInt(x))
+        expectEqual(642, await virtualWait(x))
+        expectEqual(246, await virtualWaitForInt(x))
 
-      expectNil(try? await virtualWait(orThrow: true, x))
-      try! await virtualWait(orThrow: false, x)
+        expectNil(try? await virtualWait(orThrow: true, x))
+        try! await virtualWait(orThrow: false, x)
+      }
+      await runAllTestsAsync()
     }
-    await runAllTestsAsync()
+
+    await task.value
   }
 }

--- a/test/Concurrency/Runtime/protocol_resilience.swift
+++ b/test/Concurrency/Runtime/protocol_resilience.swift
@@ -62,19 +62,23 @@ func genericWait<T : Awaitable>(orThrow: Bool, _ t: T) async throws {
 
 @main struct Main {
   static func main() async {
-    var AsyncProtocolRequirementSuite = TestSuite("ResilientProtocol")
+    let task = Task.detached {
+      var AsyncProtocolRequirementSuite = TestSuite("ResilientProtocol")
 
-    AsyncProtocolRequirementSuite.test("AsyncProtocolRequirement") {
-      let x = IntAwaitable()
+      AsyncProtocolRequirementSuite.test("AsyncProtocolRequirement") {
+        let x = IntAwaitable()
 
-      await genericWaitForNothing(x)
+        await genericWaitForNothing(x)
 
-      expectEqual(123, await genericWait(x))
-      expectEqual(321, await genericWaitForInt(x))
+        expectEqual(123, await genericWait(x))
+        expectEqual(321, await genericWaitForInt(x))
 
-      expectNil(try? await genericWait(orThrow: true, x))
-      try! await genericWait(orThrow: false, x)
+        expectNil(try? await genericWait(orThrow: true, x))
+        try! await genericWait(orThrow: false, x)
+      }
+      await runAllTestsAsync()
     }
-    await runAllTestsAsync()
+
+    await task.value
   }
 }

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -10,17 +10,25 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
+@MainActor
+var foo: Int = 42
+
 func asyncFunc() async {
   print("Hello World!")
 }
 
 @main struct MyProgram {
   static func main() async throws {
+    print(foo)
+    foo += 1
     await asyncFunc()
+    print(foo)
   }
 }
 
-// CHECK-EXEC: Hello World!
+// CHECK-EXEC: 42
+// CHECK-EXEC-NEXT: Hello World!
+// CHECK-EXEC-NEXT: 43
 
 // static MyProgram.main()
 // CHECK-SIL-LABEL: sil hidden @$s10async_main9MyProgramV0B0yyYaKFZ : $@convention(method) @async (@thin MyProgram.Type) -> @error Error

--- a/test/Concurrency/async_main_invalid_global_actor.swift
+++ b/test/Concurrency/async_main_invalid_global_actor.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -parse-as-library
+
+@globalActor
+actor Kat {
+  static let shared = Kat()
+}
+
+@Kat
+var poof: Int = 1337 // expected-note{{var declared here}}
+
+@main struct Doggo {
+  @Kat
+  static func main() { // expected-error{{main() must be '@MainActor'}}
+    // expected-error@+1{{var 'poof' isolated to global actor 'Kat' can not be referenced from different global actor 'MainActor' in a synchronous context}}
+    print("Kat value: \(poof)")
+  }
+}
+
+struct Bunny {
+  // Bunnies are not @main, so they can have a "main" function that is on
+  // another actor. It's not actually the main function, so it's fine.
+  @Kat
+  static func main() {
+  }
+}

--- a/test/Concurrency/async_main_mainactor_isolation.swift
+++ b/test/Concurrency/async_main_mainactor_isolation.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -parse-as-library
+// This should pass without any warnings or errors
+
+@MainActor
+var floofer: Int = 42
+
+@main struct Doggo { }
+
+extension Doggo {
+  static func main() {
+    print("Doggo value: \(floofer)")
+  }
+}


### PR DESCRIPTION
This patch forces the main function to be protected behind MainActor
isolation.

This implements the other part of SE-0323.