### PR TITLE
test: mark a few tests as unsupported on Wasm/WASI

### DIFF
--- a/test/ClangImporter/availability_returns_twice.swift
+++ b/test/ClangImporter/availability_returns_twice.swift
@@ -1,5 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 // UNSUPPORTED: OS=windows-msvc
+// `setjmp` is not available on WebAssembly/WASI
+// UNSUPPORTED: OS=wasi
 // In Android jmp_buf is int[16], which doesn't convert to &Int (SR-9136)
 // XFAIL: OS=linux-androideabi
 // XFAIL: OS=linux-android

--- a/test/Concurrency/Runtime/exclusivity_custom_executors.swift
+++ b/test/Concurrency/Runtime/exclusivity_custom_executors.swift
@@ -7,6 +7,9 @@
 // UNSUPPORTED: back_deployment_runtime
 // REQUIRES: concurrency_runtime
 
+// Crash expectations can't be implemented on WASI/WebAssembly.
+// UNSUPPORTED: OS=wasi
+
 // Disabled until test hang can be looked at.
 // UNSUPPORTED: OS=windows-msvc
 

--- a/test/IRGen/sanitize_coverage.swift
+++ b/test/IRGen/sanitize_coverage.swift
@@ -8,6 +8,8 @@
 // RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=edge,indirect-calls %s | %FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_INDIRECT_CALLS
 // RUN: %target-swift-frontend -emit-ir -sanitize=address -sanitize-coverage=edge,8bit-counters %s | %FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_8BIT_COUNTERS
 // RUN: %target-swift-frontend -emit-ir -sanitize=fuzzer %s | %FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_TRACE_CMP
+// These sanitizers aren't supported when targeting Wasm.
+// UNSUPPORTED: wasm
 
 #if canImport(Darwin)
   import Darwin

--- a/test/Interpreter/dynamicReplacement_property_observer.swift
+++ b/test/Interpreter/dynamicReplacement_property_observer.swift
@@ -8,6 +8,8 @@
 // REQUIRES: executable_test
 
 // UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
+// Dynamic replacement is not supported when targeting Wasm.
+// UNSUPPORTED: wasm
 
 @_private(sourceFile: "dynamic_replacement_property_observer_orig.swift") import TestDidWillSet
 

--- a/test/Interpreter/dynamic_replacement.swift
+++ b/test/Interpreter/dynamic_replacement.swift
@@ -100,6 +100,7 @@
 
 
 // REQUIRES: executable_test
+// UNSUPPORTED: wasm
 
 import Module1
 

--- a/test/Interpreter/dynamic_replacement_chaining.swift
+++ b/test/Interpreter/dynamic_replacement_chaining.swift
@@ -20,6 +20,7 @@
 
 // This test flips the chaining flag.
 // UNSUPPORTED: swift_test_mode_optimize_none_with_implicit_dynamic
+// UNSUPPORTED: wasm
 
 import A
 

--- a/test/Interpreter/dynamic_replacement_without_previous_calls.swift
+++ b/test/Interpreter/dynamic_replacement_without_previous_calls.swift
@@ -6,6 +6,7 @@
 // RUN: %target-run %t/main %t/%target-library-name(Module1) %t/%target-library-name(Module2)
 
 // REQUIRES: executable_test
+// UNSUPPORTED: wasm
 
 import Module1
 

--- a/test/stdlib/CharacterTraps.swift
+++ b/test/stdlib/CharacterTraps.swift
@@ -7,6 +7,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
+// UNSUPPORTED: OS=wasi
 
 import StdlibUnittest
 

--- a/test/stdlib/DictionaryTraps.swift
+++ b/test/stdlib/DictionaryTraps.swift
@@ -7,6 +7,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
+// UNSUPPORTED: OS=wasi
 
 import StdlibUnittest
 

--- a/test/stdlib/InputStream.swift.gyb
+++ b/test/stdlib/InputStream.swift.gyb
@@ -13,6 +13,7 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 // UNSUPPORTED: freestanding
+// UNSUPPORTED: OS=wasi
 
 import StdlibUnittest
 

--- a/test/stdlib/IntervalTraps.swift
+++ b/test/stdlib/IntervalTraps.swift
@@ -18,6 +18,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
+// UNSUPPORTED: OS=wasi
 
 import StdlibUnittest
 

--- a/test/stdlib/OptionalTraps.swift
+++ b/test/stdlib/OptionalTraps.swift
@@ -10,6 +10,7 @@
 // RUN: %target-run %t/Assert_Release
 // RUN: %target-run %t/Assert_Unchecked
 // REQUIRES: executable_test
+// UNSUPPORTED: OS=wasi
 
 import StdlibUnittest
 
@@ -48,7 +49,7 @@ OptionalTraps.test("UnwrapNone/location")
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .crashOutputMatches(shouldCheckErrorLocation()
-                        ? "OptionalTraps.swift:57:"
+                        ? "OptionalTraps.swift:58:"
                         : "")
   .code {
   expectCrashLater()

--- a/test/stdlib/POSIX.swift
+++ b/test/stdlib/POSIX.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift %t
 // REQUIRES: executable_test
 // UNSUPPORTED: OS=windows-msvc
+// UNSUPPORTED: OS=wasi
 
 import StdlibUnittest
 #if canImport(Darwin)

--- a/test/stdlib/RangeTraps.swift
+++ b/test/stdlib/RangeTraps.swift
@@ -18,6 +18,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
+// UNSUPPORTED: OS=wasi
 
 
 import StdlibUnittest

--- a/test/stdlib/SetTraps.swift
+++ b/test/stdlib/SetTraps.swift
@@ -7,6 +7,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
+// UNSUPPORTED: OS=wasi
 
 import StdlibUnittest
 

--- a/test/stdlib/StringTraps.swift
+++ b/test/stdlib/StringTraps.swift
@@ -7,6 +7,7 @@
 // RUN: %target-run %t/a.out_Debug
 // RUN: %target-run %t/a.out_Release
 // REQUIRES: executable_test
+// UNSUPPORTED: OS=wasi
 
 import StdlibUnittest
 

--- a/test/stdlib/mmap.swift
+++ b/test/stdlib/mmap.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift %t
 // REQUIRES: executable_test
 // UNSUPPORTED: OS=windows-msvc
+// UNSUPPORTED: OS=wasi
 
 import StdlibUnittest
 #if canImport(Darwin)

--- a/test/stdlib/simd_diagnostics.swift
+++ b/test/stdlib/simd_diagnostics.swift
@@ -2,6 +2,7 @@
 
 // FIXME: No simd module on linux rdar://problem/20795411
 // XFAIL: linux, windows, openbsd
+// XFAIL: OS=wasi
 
 import simd
 


### PR DESCRIPTION
Certain traps can't be supported on WASI, such as expectations for crashes, `setjmp` use, dynamic linking, multi-threading etc. These tests are marked as `UNSUPPORTED` when targeting Wasm/WASI.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Related to SR-9307.