### PR TITLE
Force the mangled name of MainActor.run to not include the Sendable constraint

### DIFF
--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -45,6 +45,7 @@ import Swift
 @available(SwiftStdlib 5.5, *)
 extension MainActor {
   /// Execute the given body closure on the main actor.
+  @_silgen_name("$sScM3run10resultType4bodyxxm_xyYbKScMYcXEtYaKlFZ")
   public static func run<T: Sendable>(
     resultType: T.Type = T.self,
     body: @MainActor @Sendable () throws -> T


### PR DESCRIPTION
This API already shipped without the `Sendable` constraint, and adding the
constraint (while it's fine with the compiler) changed the mangled name of
this API. Use `@_silgen_name` to restore the old existing mangled name so
we don't break the ABI.

Fixes rdar://83644760.
