### PR TITLE
Fix `'linker' input unused` warnings in Explicit Module Builds

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -958,13 +958,17 @@ ClangImporter::getOrCreatePCH(const ClangImporterOptions &ImporterOptions,
 
 std::vector<std::string>
 ClangImporter::getClangArguments(ASTContext &ctx) {
-  if (ctx.ClangImporterOpts.ExtraArgsOnly) {
-    return ctx.ClangImporterOpts.ExtraArgs;
-  }
   std::vector<std::string> invocationArgStrs;
   // Clang expects this to be like an actual command line. So we need to pass in
   // "clang" for argv[0]
   invocationArgStrs.push_back(ctx.ClangImporterOpts.clangPath);
+  if (ctx.ClangImporterOpts.ExtraArgsOnly) {
+    invocationArgStrs.insert(invocationArgStrs.end(),
+                             ctx.ClangImporterOpts.ExtraArgs.begin(),
+                             ctx.ClangImporterOpts.ExtraArgs.end());
+    return invocationArgStrs;
+  }
+
   switch (ctx.ClangImporterOpts.Mode) {
   case ClangImporterOptions::Modes::Normal:
   case ClangImporterOptions::Modes::PrecompiledModule:

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -242,6 +242,13 @@ void ClangImporter::recordModuleDependencies(
       // from the depending Swift modules.
       if (arg == "-target") {
         It += 2;
+      } else if (arg == "clang" ||
+                 arg.endswith(llvm::sys::path::get_separator().str() + "clang")) {
+        // Remove the initial path to clang executable argument, to avoid
+        // treating it as an executable input to compilation. It is not needed
+        // because the consumer of this command-line will invoke the emit-PCM
+        // action via swift-frontend.
+        It += 1;
       } else if (arg.startswith("-fapinotes-swift-version=")) {
         // Remove the apinotes version because we should use the language version
         // specified in the interface file.

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -126,8 +126,7 @@ import SubE
 // CHECK: "commandLine": [
 // CHECK-NEXT: "-frontend"
 // CHECK-NEXT: "-only-use-extra-clang-opts"
-// CHECK-NEXT: "-Xcc"
-// CHECK-NEXT: "BUILD_DIR/bin/clang"
+// CHECK-NOT: "BUILD_DIR/bin/clang"
 // CHECK:      "-fsystem-module",
 // CHECK-NEXT: "-emit-pcm",
 // CHECK-NEXT: "-module-name",

--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -109,9 +109,8 @@ import SubE
 
 // CHECK: "commandLine": [
 // CHECK-NEXT: "-frontend"
-// CHECK-NEXT: "-only-use-extra-clang-opts"
-// CHECK-NEXT: "-Xcc"
-// CHECK-NEXT: "BUILD_DIR/bin/clang"
+// CHECK-NEXT: "-only-use-extra-clang-opts
+// CHECK-NOT: "BUILD_DIR/bin/clang"
 // CHECK-NEXT: "-Xcc"
 // CHECK-NEXT: "-fsyntax-only",
 // CHECK:      "-fsystem-module",


### PR DESCRIPTION
- Use `=` version of `-working-directory` flag when passing it to clang
Under some circumstances this prevents the directory argument from being treated as an arbitrary path input.

- Omit path to `clang` from PCM build command-line
It gets interpreted as just an executable we feed to the linker, since we launch `emit-pcm` actions via `swift-frontend` invocations, not `clang`.

Resolves rdar://83104047
