### PR TITLE
[Parse] Properly reject labeled yield

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1030,6 +1030,8 @@ ERROR(expected_await_not_async,none,
 // Yield Statment
 ERROR(expected_expr_yield,PointsToFirstBadToken,
       "expected expression in 'yield' statement", ())
+ERROR(unexpected_label_yield,none,
+      "unexpected label in 'yield' statement", ())
 
 // Defer Statement
 ERROR(expected_lbrace_after_defer,PointsToFirstBadToken,

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3132,8 +3132,7 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
                    Kind, [&] () -> ParserStatus {
     Identifier FieldName;
     SourceLoc FieldNameLoc;
-    if (Kind != SyntaxKind::YieldStmt)
-      parseOptionalArgumentLabel(FieldName, FieldNameLoc);
+    parseOptionalArgumentLabel(FieldName, FieldNameLoc);
 
     // See if we have an operator decl ref '(<op>)'. The operator token in
     // this case lexes as a binary operator because it neither leads nor

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -844,8 +844,11 @@ ParserResult<Stmt> Parser::parseStmtYield(SourceLoc tryLoc) {
     status = parseExprList(tok::l_paren, tok::r_paren, /*isArgumentList*/ false,
                            lpLoc, yieldElts, rpLoc, SyntaxKind::ExprList);
     for (auto &elt : yieldElts) {
-      assert(elt.Label.empty());
-      assert(elt.LabelLoc.isInvalid());
+      // We don't accept labels in a list of yields.
+      if (elt.LabelLoc.isValid()) {
+        diagnose(elt.LabelLoc, diag::unexpected_label_yield)
+          .fixItRemoveChars(elt.LabelLoc, elt.E->getStartLoc());
+      }
       yields.push_back(elt.E);
     }
   } else {

--- a/test/stmt/yield.swift
+++ b/test/stmt/yield.swift
@@ -92,3 +92,16 @@ struct YieldInDefer {
     }
   }
 }
+
+// SR-15066
+struct InvalidYieldParsing {
+  var property: String {
+    _read {
+      yield(x: "test") // expected-error {{unexpected label in 'yield' statement}} {{13-16=}}
+      yield(x: "test", y:   {0}) // expected-error {{expected 1 yield value(s)}}
+      // expected-error@-1 {{unexpected label in 'yield' statement}} {{13-16=}}
+      // expected-error@-2 {{unexpected label in 'yield' statement}} {{24-29=}}
+      yield(_: "test") // expected-error {{unexpected label in 'yield' statement}} {{13-16=}}
+    }
+  }
+}


### PR DESCRIPTION
Instead of asserting, emit a diagnostic with a fix-it to remove the label.

SR-15066
rdar://82132821