### PR TITLE
RequirementMachine: Preserve sugared generic params in getSuperclassBound() and getConcreteType()

### DIFF
--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -539,7 +539,7 @@ Type GenericSignatureImpl::getSuperclassBound(Type type) const {
 
   auto computeViaRQM = [&]() {
     auto *machine = getRequirementMachine();
-    return machine->getSuperclassBound(type);
+    return machine->getSuperclassBound(type, getGenericParams());
   };
 
   auto &ctx = getASTContext();
@@ -772,7 +772,7 @@ Type GenericSignatureImpl::getConcreteType(Type type) const {
 
   auto computeViaRQM = [&]() {
     auto *machine = getRequirementMachine();
-    return machine->getConcreteType(type);
+    return machine->getConcreteType(type, getGenericParams());
   };
 
   auto &ctx = getASTContext();

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -139,7 +139,9 @@ RequirementMachine::getRequiredProtocols(Type depType) const {
   return result;
 }
 
-Type RequirementMachine::getSuperclassBound(Type depType) const {
+Type RequirementMachine::
+getSuperclassBound(Type depType,
+                   TypeArrayView<GenericTypeParamType> genericParams) const {
   auto term = Context.getMutableTermForType(depType->getCanonicalType(),
                                             /*proto=*/nullptr);
   System.simplify(term);
@@ -153,7 +155,7 @@ Type RequirementMachine::getSuperclassBound(Type depType) const {
     return Type();
 
   auto &protos = System.getProtocols();
-  return props->getSuperclassBound({ }, term, protos, Context);
+  return props->getSuperclassBound(genericParams, term, protos, Context);
 }
 
 bool RequirementMachine::isConcreteType(Type depType) const {
@@ -169,7 +171,9 @@ bool RequirementMachine::isConcreteType(Type depType) const {
   return props->isConcreteType();
 }
 
-Type RequirementMachine::getConcreteType(Type depType) const {
+Type RequirementMachine::
+getConcreteType(Type depType,
+                TypeArrayView<GenericTypeParamType> genericParams) const {
   auto term = Context.getMutableTermForType(depType->getCanonicalType(),
                                             /*proto=*/nullptr);
   System.simplify(term);
@@ -183,7 +187,7 @@ Type RequirementMachine::getConcreteType(Type depType) const {
     return Type();
 
   auto &protos = System.getProtocols();
-  return props->getConcreteType({ }, term, protos, Context);
+  return props->getConcreteType(genericParams, term, protos, Context);
 }
 
 bool RequirementMachine::areSameTypeParameterInContext(Type depType1,

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -98,9 +98,11 @@ public:
   LayoutConstraint getLayoutConstraint(Type depType) const;
   bool requiresProtocol(Type depType, const ProtocolDecl *proto) const;
   GenericSignature::RequiredProtocols getRequiredProtocols(Type depType) const;
-  Type getSuperclassBound(Type depType) const;
+  Type getSuperclassBound(Type depType,
+                          TypeArrayView<GenericTypeParamType> genericParams) const;
   bool isConcreteType(Type depType) const;
-  Type getConcreteType(Type depType) const;
+  Type getConcreteType(Type depType,
+                       TypeArrayView<GenericTypeParamType> genericParams) const;
   bool areSameTypeParameterInContext(Type depType1, Type depType2) const;
   bool isCanonicalTypeInContext(Type type) const;
   Type getCanonicalTypeInContext(Type type,

--- a/test/ModuleInterface/protocol-with-self-constraint.swift
+++ b/test/ModuleInterface/protocol-with-self-constraint.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface -module-name Test -enable-library-evolution -swift-version 5 %s
+// RUN: %FileCheck %s < %t/Test.swiftinterface
+
+public protocol P {
+}
+
+public class Foo<T> : P {
+  public struct Nested {}
+}
+
+extension P {
+  public static func blah1<T>(_: Self) where Self == Foo<T> {}
+  public static func blah2<T>(_: Self.Nested) where Self == Foo<T> {}
+
+  public static func blah3<T>(_: Self) where Self : Foo<T> {}
+  public static func blah4<T>(_: Self.Nested) where Self : Foo<T> {}
+}
+
+// CHECK-LABEL: extension Test.P {
+// CHECK-NEXT:    public static func blah1<T>(_: Self) where Self == Test.Foo<T>
+// CHECK-NEXT:    public static func blah2<T>(_: Test.Foo<T>.Nested) where Self == Test.Foo<T>
+// CHECK-NEXT:    public static func blah3<T>(_: Self) where Self : Test.Foo<T>
+// CHECK-NEXT:    public static func blah4<T>(_: Test.Foo<T>.Nested) where Self : Test.Foo<T>
+// CHECK-NEXT:  }


### PR DESCRIPTION
This was manifesting as module interfaces printing generic parameters
as `τ_0_0` in some cases.

Note that the GSB has the same bug, so this test case will fail with
-requirement-machine=off. I don't plan on fixing the bug in the GSB
unless we need to.

Fixes rdar://problem/78977127.