### PR TITLE
[5.5][concurrency] Fix infinite recursion in determining the mangling kind for a backdeployed feature.

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -173,7 +173,7 @@ public:
 };
 
 Optional<llvm::VersionTuple>
-swift::irgen::getRuntimeVersionThatSupportsDemanglingType(CanType type) {
+getRuntimeVersionThatSupportsDemanglingType(CanType type) {
   // Associated types of opaque types weren't mangled in a usable form by the
   // Swift 5.1 runtime, so we needed to add a new mangling in 5.2.
   if (type->hasOpaqueArchetype()) {
@@ -281,6 +281,20 @@ getTypeRefByFunction(IRGenModule &IGM,
   return {constant, 6};
 }
 
+bool swift::irgen::mangledNameIsUnknownToDeployTarget(IRGenModule &IGM,
+                                                      CanType type) {
+  if (auto runtimeCompatVersion = getSwiftRuntimeCompatibilityVersionForTarget(
+          IGM.Context.LangOpts.Target)) {
+    if (auto minimumSupportedRuntimeVersion =
+            getRuntimeVersionThatSupportsDemanglingType(type)) {
+      if (*runtimeCompatVersion < *minimumSupportedRuntimeVersion) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 static std::pair<llvm::Constant *, unsigned>
 getTypeRefImpl(IRGenModule &IGM,
                CanType type,
@@ -297,16 +311,10 @@ getTypeRefImpl(IRGenModule &IGM,
     // If the minimum deployment target's runtime demangler wouldn't understand
     // this mangled name, then fall back to generating a "mangled name" with a
     // symbolic reference with a callback function.
-    if (auto runtimeCompatVersion = getSwiftRuntimeCompatibilityVersionForTarget
-                                      (IGM.Context.LangOpts.Target)) {
-      if (auto minimumSupportedRuntimeVersion =
-              getRuntimeVersionThatSupportsDemanglingType(type)) {
-        if (*runtimeCompatVersion < *minimumSupportedRuntimeVersion) {
-          return getTypeRefByFunction(IGM, sig, type);
-        }
-      }
+    if (mangledNameIsUnknownToDeployTarget(IGM, type)) {
+      return getTypeRefByFunction(IGM, sig, type);
     }
-      
+
     break;
 
   case MangledTypeRefRole::Reflection:

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -641,10 +641,10 @@ protected:
   }
 };
 
-/// Does this type require a special minimum Swift runtime version which
-/// supports demangling it?
-Optional<llvm::VersionTuple>
-getRuntimeVersionThatSupportsDemanglingType(CanType type);
+/// Determines if the minimum deployment target's runtime demangler will not
+/// understand the mangled name for the given type.
+/// \returns true iff the target's runtime does not understand the mangled name.
+bool mangledNameIsUnknownToDeployTarget(IRGenModule &IGM, CanType type);
 
 } // end namespace irgen
 } // end namespace swift

--- a/test/Interpreter/opaque_return_type_protocol_ext.swift
+++ b/test/Interpreter/opaque_return_type_protocol_ext.swift
@@ -4,9 +4,6 @@
 
 // REQUIRES: executable_test
 
-// FIXME: Disabled because compilation is crashing in arm64e
-// REQUIRES: rdar60734429
-
 @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
 protocol P {
   associatedtype AT


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/39497

Resolves rdar://83104637