### PR TITLE
[5.5] Fix `'linker' input unused` warnings in Explicit Module Builds

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -242,6 +242,13 @@ void ClangImporter::recordModuleDependencies(
       // from the depending Swift modules.
       if (arg == "-target") {
         It += 2;
+      } else if (arg == "clang" ||
+                 arg.endswith(llvm::sys::path::get_separator().str() + "clang")) {
+        // Remove the initial path to clang executable argument, to avoid
+        // treating it as an executable input to compilation. It is not needed
+        // because the consumer of this command-line will invoke the emit-PCM
+        // action via swift-frontend.
+        It += 1;
       } else if (arg.startswith("-fapinotes-swift-version=")) {
         // Remove the apinotes version because we should use the language version
         // specified in the interface file.

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -126,8 +126,7 @@ import SubE
 // CHECK: "commandLine": [
 // CHECK-NEXT: "-frontend"
 // CHECK-NEXT: "-only-use-extra-clang-opts"
-// CHECK-NEXT: "-Xcc"
-// CHECK-NEXT: "clang"
+// CHECK-NOT: "clang"
 // CHECK:      "-fsystem-module",
 // CHECK-NEXT: "-emit-pcm",
 // CHECK-NEXT: "-module-name",

--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -110,8 +110,7 @@ import SubE
 // CHECK: "commandLine": [
 // CHECK-NEXT: "-frontend"
 // CHECK-NEXT: "-only-use-extra-clang-opts"
-// CHECK-NEXT: "-Xcc"
-// CHECK-NEXT: "clang"
+// CHECK-NOT: "clang"
 // CHECK:      "-fsystem-module",
 // CHECK-NEXT: "-emit-pcm",
 // CHECK-NEXT: "-module-name",


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/39509
------------------------------------------------------
- **Explanation**: Omit path to clang from PCM build command-line
It gets interpreted as just an executable we feed to the linker, since we launch emit-pcm actions via swift-frontend invocations, not clang.

Resolves rdar://83104047
