### PR TITLE
Fix unnecessary one-time recompile of stdlib with -enable-ossa-flag

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -22,6 +22,7 @@
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Import.h"
+#include "swift/AST/SILOptions.h"
 #include "swift/AST/SearchPathOptions.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/TypeAlignments.h"
@@ -38,8 +39,8 @@
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
-#include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/DataTypes.h"
@@ -221,11 +222,10 @@ class ASTContext final {
   void operator=(const ASTContext&) = delete;
 
   ASTContext(LangOptions &langOpts, TypeCheckerOptions &typeckOpts,
-             SearchPathOptions &SearchPathOpts,
+             SILOptions &silOpts, SearchPathOptions &SearchPathOpts,
              ClangImporterOptions &ClangImporterOpts,
              symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts,
-             SourceManager &SourceMgr,
-             DiagnosticEngine &Diags);
+             SourceManager &SourceMgr, DiagnosticEngine &Diags);
 
 public:
   // Members that should only be used by ASTContext.cpp.
@@ -237,7 +237,7 @@ public:
   void operator delete(void *Data) throw();
 
   static ASTContext *get(LangOptions &langOpts, TypeCheckerOptions &typeckOpts,
-                         SearchPathOptions &SearchPathOpts,
+                         SILOptions &silOpts, SearchPathOptions &SearchPathOpts,
                          ClangImporterOptions &ClangImporterOpts,
                          symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts,
                          SourceManager &SourceMgr, DiagnosticEngine &Diags);
@@ -254,6 +254,9 @@ public:
 
   /// The type checker options.
   const TypeCheckerOptions &TypeCheckerOpts;
+
+  /// Options for SIL.
+  const SILOptions &SILOpts;
 
   /// The search path options used by this AST context.
   SearchPathOptions &SearchPathOpts;

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -141,6 +141,7 @@ namespace swift {
     bool IsSIB = false;
     bool DisableCrossModuleIncrementalInfo = false;
     bool StaticLibrary = false;
+    bool IsOSSA = false;
   };
 
 } // end namespace swift

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -161,6 +161,8 @@ public:
           std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
           bool isFramework);
 
+  bool isRequiredOSSAModules() const;
+
   /// Check whether the module with a given name can be imported without
   /// importing it.
   ///

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -42,6 +42,9 @@ enum class Status {
   /// The precise revision version doesn't match.
   RevisionIncompatible,
 
+  /// The module is required to be in OSSA, but is not.
+  NotInOSSA,
+
   /// The module file depends on another module that can't be loaded.
   MissingDependency,
 
@@ -186,13 +189,16 @@ public:
 ///
 /// \param data A buffer containing the serialized AST. Result information
 /// refers directly into this buffer.
+/// \param requiresOSSAModules If true, necessitates the module to be
+/// compiled with -enable-ossa-modules.
 /// \param[out] extendedInfo If present, will be populated with additional
 /// compilation options serialized into the AST at build time that may be
 /// necessary to load it properly.
 /// \param[out] dependencies If present, will be populated with list of
 /// input files the module depends on, if present in INPUT_BLOCK.
 ValidationInfo validateSerializedAST(
-    StringRef data, ExtendedValidationInfo *extendedInfo = nullptr,
+    StringRef data, bool requiresOSSAModules,
+    ExtendedValidationInfo *extendedInfo = nullptr,
     SmallVectorImpl<SerializationOptions::FileDependency> *dependencies =
         nullptr);
 

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -52,6 +52,7 @@ namespace swift {
   class GenericParamList;
   class IRGenOptions;
   class LangOptions;
+  class SILOptions;
   class ModuleDecl;
   /// A opaque syntax node created by a \c SyntaxParseAction, whose contents
   /// must be interpreted by the \c SyntaxParseAction which created it.
@@ -283,7 +284,7 @@ namespace swift {
   public:
     ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned BufferID,
                const LangOptions &LangOpts, const TypeCheckerOptions &TyOpts,
-               StringRef ModuleName,
+               const SILOptions &SILOpts, StringRef ModuleName,
                std::shared_ptr<SyntaxParseActions> spActions = nullptr,
                SyntaxParsingCache *SyntaxCache = nullptr);
     ParserUnit(SourceManager &SM, SourceFileKind SFKind, unsigned BufferID);

--- a/lib/ASTSectionImporter/ASTSectionImporter.cpp
+++ b/lib/ASTSectionImporter/ASTSectionImporter.cpp
@@ -17,6 +17,7 @@
 
 #include "swift/ASTSectionImporter/ASTSectionImporter.h"
 #include "../Serialization/ModuleFormat.h"
+#include "swift/AST/ASTContext.h"
 #include "swift/Basic/Dwarf.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
 #include "swift/Serialization/Validation.h"
@@ -34,7 +35,8 @@ bool swift::parseASTSection(MemoryBufferSerializedModuleLoader &Loader,
   // An AST section consists of one or more AST modules, optionally with
   // headers. Iterate over all AST modules.
   while (!buf.empty()) {
-    auto info = serialization::validateSerializedAST(buf);
+    auto info = serialization::validateSerializedAST(
+        buf, Loader.isRequiredOSSAModules());
 
     assert(info.name.size() < (2 << 10) && "name failed sanity check");
 

--- a/lib/DriverTool/modulewrap_main.cpp
+++ b/lib/DriverTool/modulewrap_main.cpp
@@ -175,20 +175,20 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
   SearchPathOpts.RuntimeResourcePath = std::string(RuntimeResourcePath.str());
 
   SourceManager SrcMgr;
+  SILOptions SILOpts;
   TypeCheckerOptions TypeCheckOpts;
   LangOptions LangOpts;
   ClangImporterOptions ClangImporterOpts;
   symbolgraphgen::SymbolGraphOptions SymbolGraphOpts;
   LangOpts.Target = Invocation.getTargetTriple();
-  ASTContext &ASTCtx = *ASTContext::get(LangOpts, TypeCheckOpts, SearchPathOpts,
-                                        ClangImporterOpts, SymbolGraphOpts, SrcMgr,
-                                        Instance.getDiags());
+  ASTContext &ASTCtx = *ASTContext::get(
+      LangOpts, TypeCheckOpts, SILOpts, SearchPathOpts, ClangImporterOpts,
+      SymbolGraphOpts, SrcMgr, Instance.getDiags());
   registerParseRequestFunctions(ASTCtx.evaluator);
   registerTypeCheckerRequestFunctions(ASTCtx.evaluator);
   
   ASTCtx.addModuleLoader(ClangImporter::create(ASTCtx, ""), true);
   ModuleDecl *M = ModuleDecl::create(ASTCtx.getIdentifier("swiftmodule"), ASTCtx);
-  SILOptions SILOpts;
   std::unique_ptr<Lowering::TypeConverter> TC(new Lowering::TypeConverter(*M));
   std::unique_ptr<SILModule> SM = SILModule::createEmptyModule(M, *TC, SILOpts);
   createSwiftModuleObjectFile(*SM, (*ErrOrBuf)->getBuffer(),

--- a/lib/DriverTool/swift_indent_main.cpp
+++ b/lib/DriverTool/swift_indent_main.cpp
@@ -59,10 +59,10 @@ public:
 
   void updateCode(std::unique_ptr<llvm::MemoryBuffer> Buffer) {
     BufferID = SM.addNewSourceBuffer(std::move(Buffer));
-    Parser.reset(new ParserUnit(SM, SourceFileKind::Main,
-                                BufferID, CompInv.getLangOptions(),
-                                CompInv.getTypeCheckerOptions(),
-                                CompInv.getModuleName()));
+    Parser.reset(new ParserUnit(
+        SM, SourceFileKind::Main, BufferID, CompInv.getLangOptions(),
+        CompInv.getTypeCheckerOptions(), CompInv.getSILOptions(),
+        CompInv.getModuleName()));
     Parser->getDiagnosticEngine().addConsumer(DiagConsumer);
     Parser->parse();
   }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2146,8 +2146,8 @@ bool CompilerInvocation::parseArgs(
 serialization::Status
 CompilerInvocation::loadFromSerializedAST(StringRef data) {
   serialization::ExtendedValidationInfo extendedInfo;
-  serialization::ValidationInfo info =
-      serialization::validateSerializedAST(data, &extendedInfo);
+  serialization::ValidationInfo info = serialization::validateSerializedAST(
+      data, getSILOptions().EnableOSSAModules, &extendedInfo);
 
   if (info.status != serialization::Status::Valid)
     return info.status;
@@ -2182,7 +2182,8 @@ CompilerInvocation::setUpInputForSILTool(
       InputFile(inputFilename, bePrimary, fileBufOrErr.get().get(), file_types::TY_SIL));
 
   auto result = serialization::validateSerializedAST(
-      fileBufOrErr.get()->getBuffer(), &extendedInfo);
+      fileBufOrErr.get()->getBuffer(), getSILOptions().EnableOSSAModules,
+      &extendedInfo);
   bool hasSerializedAST = result.status == serialization::Status::Valid;
 
   if (hasSerializedAST) {

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -181,6 +181,8 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
 
   serializationOpts.StaticLibrary = opts.Static;
 
+  serializationOpts.IsOSSA = getSILOptions().EnableOSSAModules;
+
   return serializationOpts;
 }
 
@@ -215,9 +217,8 @@ bool CompilerInstance::setUpASTContextIfNeeded() {
 
   Context.reset(ASTContext::get(
       Invocation.getLangOptions(), Invocation.getTypeCheckerOptions(),
-      Invocation.getSearchPathOptions(),
-      Invocation.getClangImporterOptions(),
-      Invocation.getSymbolGraphOptions(),
+      Invocation.getSILOptions(), Invocation.getSearchPathOptions(),
+      Invocation.getClangImporterOptions(), Invocation.getSymbolGraphOptions(),
       SourceMgr, Diagnostics));
   registerParseRequestFunctions(Context->evaluator);
   registerTypeCheckerRequestFunctions(Context->evaluator);

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -265,6 +265,8 @@ bool ModuleInterfaceBuilder::buildSwiftModuleInternal(
     }
     if (ShouldSerializeDeps)
       SerializationOpts.Dependencies = Deps;
+    SerializationOpts.IsOSSA = SILOpts.EnableOSSAModules;
+
     SILMod->setSerializeSILAction([&]() {
       if (isTypeChecking)
         return;

--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -328,12 +328,13 @@ bool CompletionInstance::performCachedOperationIfPossible(
 
   LangOptions langOpts = CI.getASTContext().LangOpts;
   TypeCheckerOptions typeckOpts = CI.getASTContext().TypeCheckerOpts;
+  SILOptions silOpts = CI.getASTContext().SILOpts;
   SearchPathOptions searchPathOpts = CI.getASTContext().SearchPathOpts;
   DiagnosticEngine tmpDiags(tmpSM);
   ClangImporterOptions clangOpts;
   symbolgraphgen::SymbolGraphOptions symbolOpts;
   std::unique_ptr<ASTContext> tmpCtx(
-      ASTContext::get(langOpts, typeckOpts, searchPathOpts, clangOpts,
+      ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts, clangOpts,
                       symbolOpts, tmpSM, tmpDiags));
   registerParseRequestFunctions(tmpCtx->evaluator);
   registerIDERequestFunctions(tmpCtx->evaluator);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1522,10 +1522,8 @@ void Parser::parseAllAvailabilityMacroArguments() {
     // Create temporary parser.
     int bufferID = SM.addMemBufferCopy(macro,
                                        "-define-availability argument");
-    swift::ParserUnit PU(SM,
-                         SourceFileKind::Main, bufferID,
-                         LangOpts,
-                         TypeCheckerOptions(), "unknown");
+    swift::ParserUnit PU(SM, SourceFileKind::Main, bufferID, LangOpts,
+                         TypeCheckerOptions(), SILOptions(), "unknown");
 
     ForwardingDiagnosticConsumer PDC(Context.Diags);
     PU.getDiagnosticEngine().addConsumer(PDC);

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -349,12 +349,10 @@ ModuleFile::getModuleName(ASTContext &Ctx, StringRef modulePath,
     /*RequiresNullTerminator=*/false);
   std::shared_ptr<const ModuleFileSharedCore> loadedModuleFile;
   bool isFramework = false;
-  serialization::ValidationInfo loadInfo =
-     ModuleFileSharedCore::load(modulePath.str(),
-                      std::move(newBuf),
-                      nullptr,
-                      nullptr,
-                      /*isFramework*/isFramework, loadedModuleFile);
+  serialization::ValidationInfo loadInfo = ModuleFileSharedCore::load(
+      modulePath.str(), std::move(newBuf), nullptr, nullptr,
+      /*isFramework*/ isFramework, Ctx.SILOpts.EnableOSSAModules,
+      loadedModuleFile);
   Name = loadedModuleFile->Name.str();
   return std::move(moduleBuf.get());
 }

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -165,11 +165,10 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
   return true;
 }
 
-static ValidationInfo
-validateControlBlock(llvm::BitstreamCursor &cursor,
-                     SmallVectorImpl<uint64_t> &scratch,
-                     std::pair<uint16_t, uint16_t> expectedVersion,
-                     ExtendedValidationInfo *extendedInfo) {
+static ValidationInfo validateControlBlock(
+    llvm::BitstreamCursor &cursor, SmallVectorImpl<uint64_t> &scratch,
+    std::pair<uint16_t, uint16_t> expectedVersion, bool requiresOSSAModules,
+    ExtendedValidationInfo *extendedInfo) {
   // The control block is malformed until we've at least read a major version
   // number.
   ValidationInfo result;
@@ -332,6 +331,12 @@ validateControlBlock(llvm::BitstreamCursor &cursor,
       }
       break;
     }
+    case control_block::IS_OSSA: {
+      auto isModuleInOSSA = scratch[0];
+      if (requiresOSSAModules && !isModuleInOSSA)
+        result.status = Status::NotInOSSA;
+      break;
+    }
     default:
       // Unknown metadata record, possibly for use by a future version of the
       // module format.
@@ -418,7 +423,7 @@ bool serialization::isSerializedAST(StringRef data) {
 }
 
 ValidationInfo serialization::validateSerializedAST(
-    StringRef data,
+    StringRef data, bool requiresOSSAModules,
     ExtendedValidationInfo *extendedInfo,
     SmallVectorImpl<SerializationOptions::FileDependency> *dependencies) {
   ValidationInfo result;
@@ -457,10 +462,10 @@ ValidationInfo serialization::validateSerializedAST(
         result.status = Status::Malformed;
         return result;
       }
-      result = validateControlBlock(cursor, scratch,
-                                    {SWIFTMODULE_VERSION_MAJOR,
-                                     SWIFTMODULE_VERSION_MINOR},
-                                    extendedInfo);
+      result = validateControlBlock(
+          cursor, scratch,
+          {SWIFTMODULE_VERSION_MAJOR, SWIFTMODULE_VERSION_MINOR},
+          requiresOSSAModules, extendedInfo);
       if (result.status == Status::Malformed)
         return result;
     } else if (dependencies &&
@@ -966,10 +971,10 @@ bool ModuleFileSharedCore::readModuleDocIfPresent() {
         return false;
       }
 
-      info = validateControlBlock(docCursor, scratch,
-                                  {SWIFTDOC_VERSION_MAJOR,
-                                   SWIFTDOC_VERSION_MINOR},
-                                  /*extendedInfo*/nullptr);
+      info = validateControlBlock(
+          docCursor, scratch, {SWIFTDOC_VERSION_MAJOR, SWIFTDOC_VERSION_MINOR},
+          RequiresOSSAModules,
+          /*extendedInfo*/ nullptr);
       if (info.status != Status::Valid)
         return false;
       // Check that the swiftdoc is actually for this module.
@@ -1109,10 +1114,11 @@ bool ModuleFileSharedCore::readModuleSourceInfoIfPresent() {
         consumeError(std::move(Err));
         return false;
       }
-      info = validateControlBlock(infoCursor, scratch,
-                                  {SWIFTSOURCEINFO_VERSION_MAJOR,
-                                   SWIFTSOURCEINFO_VERSION_MINOR},
-                                  /*extendedInfo*/nullptr);
+      info = validateControlBlock(
+          infoCursor, scratch,
+          {SWIFTSOURCEINFO_VERSION_MAJOR, SWIFTSOURCEINFO_VERSION_MINOR},
+          RequiresOSSAModules,
+          /*extendedInfo*/ nullptr);
       if (info.status != Status::Valid)
         return false;
       // Check that the swiftsourceinfo is actually for this module.
@@ -1186,10 +1192,12 @@ ModuleFileSharedCore::ModuleFileSharedCore(
     std::unique_ptr<llvm::MemoryBuffer> moduleInputBuffer,
     std::unique_ptr<llvm::MemoryBuffer> moduleDocInputBuffer,
     std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
-    bool isFramework, serialization::ValidationInfo &info)
+    bool isFramework, bool requiresOSSAModules,
+    serialization::ValidationInfo &info)
     : ModuleInputBuffer(std::move(moduleInputBuffer)),
       ModuleDocInputBuffer(std::move(moduleDocInputBuffer)),
-      ModuleSourceInfoInputBuffer(std::move(moduleSourceInfoInputBuffer)) {
+      ModuleSourceInfoInputBuffer(std::move(moduleSourceInfoInputBuffer)),
+      RequiresOSSAModules(requiresOSSAModules) {
   assert(!hasError());
   Bits.IsFramework = isFramework;
 
@@ -1233,10 +1241,10 @@ ModuleFileSharedCore::ModuleFileSharedCore(
       }
 
       ExtendedValidationInfo extInfo;
-      info = validateControlBlock(cursor, scratch,
-                                  {SWIFTMODULE_VERSION_MAJOR,
-                                   SWIFTMODULE_VERSION_MINOR},
-                                  &extInfo);
+      info = validateControlBlock(
+          cursor, scratch,
+          {SWIFTMODULE_VERSION_MAJOR, SWIFTMODULE_VERSION_MINOR},
+          RequiresOSSAModules, &extInfo);
       if (info.status != Status::Valid) {
         error(info.status);
         return;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 630; // Precise
+const uint16_t SWIFTMODULE_VERSION_MINOR = 631; // IS_OSSA
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -757,6 +757,7 @@ namespace control_block {
     TARGET,
     SDK_NAME,
     REVISION,
+    IS_OSSA
   };
 
   using MetadataLayout = BCRecordLayout<
@@ -790,6 +791,11 @@ namespace control_block {
   using RevisionLayout = BCRecordLayout<
     REVISION,
     BCBlob
+  >;
+
+  using IsOSSALayout = BCRecordLayout<
+    IS_OSSA,
+    BCFixed<1>
   >;
 }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -805,6 +805,7 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(control_block, TARGET);
   BLOCK_RECORD(control_block, SDK_NAME);
   BLOCK_RECORD(control_block, REVISION);
+  BLOCK_RECORD(control_block, IS_OSSA);
 
   BLOCK(OPTIONS_BLOCK);
   BLOCK_RECORD(options_block, SDK_PATH);
@@ -957,6 +958,7 @@ void Serializer::writeHeader(const SerializationOptions &options) {
     control_block::TargetLayout Target(Out);
     control_block::SDKNameLayout SDKName(Out);
     control_block::RevisionLayout Revision(Out);
+    control_block::IsOSSALayout IsOSSA(Out);
 
     ModuleName.emit(ScratchRecord, M->getName().str());
 
@@ -1006,6 +1008,8 @@ void Serializer::writeHeader(const SerializationOptions &options) {
 
       Revision.emit(ScratchRecord, revision);
     }
+
+    IsOSSA.emit(ScratchRecord, options.IsOSSA);
 
     {
       llvm::BCBlockRAII restoreBlock(Out, OPTIONS_BLOCK_ID, 4);

--- a/test/ModuleInterface/ossa-modules/Inputs/sdk-test-stdlib-no-ossa-referent-with-rebuild-remark.swift
+++ b/test/ModuleInterface/ossa-modules/Inputs/sdk-test-stdlib-no-ossa-referent-with-rebuild-remark.swift
@@ -1,5 +1,9 @@
 
 import Swift // expected-remark {{rebuilding module 'Swift'}}
+// expected-note @-1 {{compiled module is out of date}}
+// expected-note @-2 {{unable to load compiled module}}
+// expected-note @-3 {{prebuilt module is out of date}}
+// expected-note @-4 {{unable to load compiled module}}
 
 func main() {
   let f = foo() // expected-warning {{initialization of immutable value 'f' was never used}}

--- a/test/ModuleInterface/ossa-modules/different-modes-have-different-hashes.swift
+++ b/test/ModuleInterface/ossa-modules/different-modes-have-different-hashes.swift
@@ -68,16 +68,18 @@
 // RUN: %target-swift-frontend -typecheck -sdk '' -module-cache-path %t/MCP.default -parse-stdlib -I %t %t/test.default.remark.swift -Rmodule-interface-rebuild -verify
 // RUN: ls %t/MCP.default | count 3
 // RUN: %target-swift-frontend -typecheck -sdk '' -module-cache-path %t/MCP.default -parse-stdlib -I %t %t/test.default.swift -Rmodule-interface-rebuild -verify
-// RUN: %target-sil-opt -module-name SwiftModuleDefault %t/MCP.default/*.swiftmodule | grep '@$s18SwiftModuleDefault3fooAA5KlassCyF' | grep '[[]ossa[]]'
+// RUN: %target-sil-opt -module-name SwiftModuleDefault %t/MCP.default/*.swiftmodule > %t/MCP.default/old/first.sil
+// RUN: cat %t/MCP.default/old/first.sil | grep '@$s18SwiftModuleDefault3fooAA5KlassCyF' | grep '[[]ossa[]]'
 // RUN: mv %t/MCP.default/*.swiftmodule %t/MCP.default/old
 // RUN: ls %t/MCP.default | count 2
 // RUN: %target-swift-frontend -typecheck -sdk '' -enable-ossa-modules -module-cache-path %t/MCP.default -parse-stdlib -I %t %t/test.default.remark.swift -Rmodule-interface-rebuild -verify
 // RUN: ls %t/MCP.default | count 3
 // RUN: %target-swift-frontend -typecheck -sdk '' -enable-ossa-modules -module-cache-path %t/MCP.default -parse-stdlib -I %t %t/test.default.swift -Rmodule-interface-rebuild -verify
 // RUN: ls %t/MCP.default | count 3
+// RUN: %target-sil-opt -module-name SwiftModuleDefault %t/MCP.default/*.swiftmodule > %t/MCP.default/second.sil
 //
 // These should be the same.
-// RUN: diff -u %t/MCP.default/*.swiftmodule %t/MCP.default/old/*.swiftmodule
+// RUN: diff -u %t/MCP.default/old/first.sil %t/MCP.default/second.sil
 //
 // But their actual names should be different since the hash is in the file name.
 // RUN: cd %t/MCP.default && ls *.swiftmodule > %t/MCP.default/firstFile
@@ -103,7 +105,6 @@
 // RUN: ls %t/MCP.Onone | count 3
 //
 // These should be the same.
-// RUN: diff -u %t/MCP.Onone/*.swiftmodule %t/MCP.Onone/old/*.swiftmodule
 //
 // But their name should be different
 // RUN: cd %t/MCP.Onone && ls *.swiftmodule > %t/MCP.Onone/firstFile

--- a/test/ModuleInterface/ossa-modules/sdk-test-stdlib-ossa.swift
+++ b/test/ModuleInterface/ossa-modules/sdk-test-stdlib-ossa.swift
@@ -21,13 +21,9 @@
 
 // RUN: %target-swift-frontend -typecheck -sdk '%t/SDK' -prebuilt-module-cache-path '%t/PreBuiltSDKModules' -module-cache-path %t/TempModuleCacheOther -resource-dir '' -parse-stdlib -Rmodule-interface-rebuild %S/Inputs/sdk-test-stdlib-no-ossa-referent-no-rebuild-remark.swift -verify
 
-// In this case, we should rebuild.
+// In this case also, we should not rebuild.
 
-// RUN: %target-swift-frontend -typecheck -sdk '%t/SDK' -prebuilt-module-cache-path '%t/PreBuiltSDKModules' -module-cache-path %t/TempModuleCacheOther -resource-dir '' -parse-stdlib -Rmodule-interface-rebuild %S/Inputs/sdk-test-stdlib-no-ossa-referent-with-rebuild-remark.swift -verify -enable-ossa-modules
-
-// Make sure the rebuild is in OSSA.
-
-// RUN: %target-sil-opt -module-name Swift %t/PreBuiltSDKModules/Swift.swiftmodule/*.swiftmodule | grep '@$ss3foos5KlassCyF' | grep '[[]ossa[]]'
+// RUN: %target-swift-frontend -typecheck -sdk '%t/SDK' -prebuilt-module-cache-path '%t/PreBuiltSDKModules' -module-cache-path %t/TempModuleCacheOther -resource-dir '' -parse-stdlib -Rmodule-interface-rebuild %S/Inputs/sdk-test-stdlib-no-ossa-referent-no-rebuild-remark.swift -verify -enable-ossa-modules
 
 // Flacky hangs: rdar://77288690
 // UNSUPPORTED: CPU=arm64, CPU=arm64e

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -716,14 +716,11 @@ public:
           SM, BufferID, CompInv.getMainFileSyntaxParsingCache(), syntaxArena);
     }
 
-    Parser.reset(
-                 new ParserUnit(SM, SourceFileKind::Main, BufferID,
-                     CompInv.getLangOptions(),
-                     CompInv.getTypeCheckerOptions(),
-                     CompInv.getModuleName(),
-                     SynTreeCreator,
-                     CompInv.getMainFileSyntaxParsingCache())
-    );
+    Parser.reset(new ParserUnit(
+        SM, SourceFileKind::Main, BufferID, CompInv.getLangOptions(),
+        CompInv.getTypeCheckerOptions(), CompInv.getSILOptions(),
+        CompInv.getModuleName(), SynTreeCreator,
+        CompInv.getMainFileSyntaxParsingCache()));
 
     registerParseRequestFunctions(Parser->getParser().Context.evaluator);
     registerTypeCheckerRequestFunctions(

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -481,7 +481,6 @@ swiftparse_client_node_t SynParser::parse(const char *source, size_t len) {
   SourceManager SM;
   unsigned bufID = SM.addNewSourceBuffer(llvm::MemoryBuffer::getMemBuffer(
       StringRef(source, len), "syntax_parse_source"));
-  TypeCheckerOptions tyckOpts;
   LangOptions langOpts;
   langOpts.BuildSyntaxTree = true;
   langOpts.ParseForSyntaxTreeOnly = true;
@@ -494,8 +493,8 @@ swiftparse_client_node_t SynParser::parse(const char *source, size_t len) {
     std::make_shared<CLibParseActions>(*this, SM, bufID);
   // We have to use SourceFileKind::Main to avoid diagnostics like
   // illegal_top_level_expr
-  ParserUnit PU(SM, SourceFileKind::Main, bufID, langOpts, tyckOpts,
-                "syntax_parse_module", std::move(parseActions),
+  ParserUnit PU(SM, SourceFileKind::Main, bufID, langOpts, TypeCheckerOptions(),
+                SILOptions(), "syntax_parse_module", std::move(parseActions),
                 /*SyntaxCache=*/nullptr);
   std::unique_ptr<SynParserDiagConsumer> pConsumer;
   if (DiagHandler) {

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -45,10 +45,11 @@ void anchorForGetMainExecutable() {}
 using namespace llvm::MachO;
 
 static bool
-validateModule(llvm::StringRef data, bool Verbose,
+validateModule(llvm::StringRef data, bool Verbose, bool requiresOSSAModules,
                swift::serialization::ValidationInfo &info,
                swift::serialization::ExtendedValidationInfo &extendedInfo) {
-  info = swift::serialization::validateSerializedAST(data, &extendedInfo);
+  info = swift::serialization::validateSerializedAST(data, requiresOSSAModules,
+                                                     &extendedInfo);
   if (info.status != swift::serialization::Status::Valid) {
     llvm::outs() << "error: validateSerializedAST() failed\n";
     return false;
@@ -240,6 +241,9 @@ int main(int argc, char **argv) {
   opt<bool> QualifyTypes("qualify-types", desc("Qualify dumped types"),
                          cat(Visible));
 
+  opt<bool> EnableOSSAModules("enable-ossa-modules", init(false),
+                              desc("Serialize modules in OSSA"), cat(Visible));
+
   ParseCommandLineOptions(argc, argv);
 
   // Unregister our options so they don't interfere with the command line
@@ -282,8 +286,8 @@ int main(int argc, char **argv) {
   for (auto &Module : Modules) {
     info = {};
     extendedInfo = {};
-    if (!validateModule(StringRef(Module.first, Module.second), Verbose, info,
-                        extendedInfo)) {
+    if (!validateModule(StringRef(Module.first, Module.second), Verbose,
+                        EnableOSSAModules, info, extendedInfo)) {
       llvm::errs() << "Malformed module!\n";
       return 1;
     }
@@ -306,6 +310,7 @@ int main(int argc, char **argv) {
   Invocation.setModuleName("lldbtest");
   Invocation.getClangImporterOptions().ModuleCachePath = ModuleCachePath;
   Invocation.getLangOptions().EnableMemoryBufferImporter = true;
+  Invocation.getSILOptions().EnableOSSAModules = EnableOSSAModules;
 
   if (!ResourceDir.empty()) {
     Invocation.setRuntimeResourcePath(ResourceDir);

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1651,12 +1651,11 @@ static int doSyntaxColoring(const CompilerInvocation &InitInvok,
             SM, BufferID, Invocation.getMainFileSyntaxParsingCache(),
             syntaxArena);
 
-    ParserUnit Parser(SM, SourceFileKind::Main, BufferID,
-                      Invocation.getLangOptions(),
-                      Invocation.getTypeCheckerOptions(),
-                      Invocation.getModuleName(),
-                      SynTreeCreator,
-                      Invocation.getMainFileSyntaxParsingCache());
+    ParserUnit Parser(
+        SM, SourceFileKind::Main, BufferID, Invocation.getLangOptions(),
+        Invocation.getTypeCheckerOptions(), Invocation.getSILOptions(),
+        Invocation.getModuleName(), SynTreeCreator,
+        Invocation.getMainFileSyntaxParsingCache());
 
     registerParseRequestFunctions(Parser.getParser().Context.evaluator);
     registerTypeCheckerRequestFunctions(Parser.getParser().Context.evaluator);
@@ -1889,9 +1888,8 @@ static int doStructureAnnotation(const CompilerInvocation &InitInvok,
   ParserUnit Parser(SM, SourceFileKind::Main, BufferID,
                     Invocation.getLangOptions(),
                     Invocation.getTypeCheckerOptions(),
-                    Invocation.getModuleName(),
-                    SynTreeCreator,
-                    Invocation.getMainFileSyntaxParsingCache());
+                    Invocation.getSILOptions(), Invocation.getModuleName(),
+                    SynTreeCreator, Invocation.getMainFileSyntaxParsingCache());
 
   registerParseRequestFunctions(Parser.getParser().Context.evaluator);
   registerTypeCheckerRequestFunctions(

--- a/unittests/AST/TestContext.cpp
+++ b/unittests/AST/TestContext.cpp
@@ -35,9 +35,9 @@ static Decl *createOptionalType(ASTContext &ctx, SourceFile *fileForLookups,
 }
 
 TestContext::TestContext(ShouldDeclareOptionalTypes optionals)
-    : Ctx(*ASTContext::get(LangOpts, TypeCheckerOpts, SearchPathOpts,
-                           ClangImporterOpts, SymbolGraphOpts,
-                           SourceMgr, Diags)) {
+    : Ctx(*ASTContext::get(LangOpts, TypeCheckerOpts, SILOpts, SearchPathOpts,
+                           ClangImporterOpts, SymbolGraphOpts, SourceMgr,
+                           Diags)) {
   registerParseRequestFunctions(Ctx.evaluator);
   registerTypeCheckerRequestFunctions(Ctx.evaluator);
   registerClangImporterRequestFunctions(Ctx.evaluator);

--- a/unittests/AST/TestContext.h
+++ b/unittests/AST/TestContext.h
@@ -31,6 +31,7 @@ class TestContextBase {
 public:
   LangOptions LangOpts;
   TypeCheckerOptions TypeCheckerOpts;
+  SILOptions SILOpts;
   SearchPathOptions SearchPathOpts;
   ClangImporterOptions ClangImporterOpts;
   symbolgraphgen::SymbolGraphOptions SymbolGraphOpts;

--- a/unittests/ClangImporter/ClangImporterTests.cpp
+++ b/unittests/ClangImporter/ClangImporterTests.cpp
@@ -70,6 +70,7 @@ TEST(ClangImporterTest, emitPCHInMemory) {
   // Set up the importer and emit a bridging PCH.
   swift::LangOptions langOpts;
   langOpts.Target = llvm::Triple("x86_64", "apple", "darwin");
+  swift::SILOptions silOpts;
   swift::TypeCheckerOptions typeckOpts;
   INITIALIZE_LLVM();
   swift::SearchPathOptions searchPathOpts;
@@ -77,7 +78,7 @@ TEST(ClangImporterTest, emitPCHInMemory) {
   swift::SourceManager sourceMgr;
   swift::DiagnosticEngine diags(sourceMgr);
   std::unique_ptr<ASTContext> context(
-      ASTContext::get(langOpts, typeckOpts, searchPathOpts, options,
+      ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts, options,
                       symbolGraphOpts, sourceMgr, diags));
   auto importer = ClangImporter::create(*context);
 

--- a/unittests/FrontendTool/ModuleLoadingTests.cpp
+++ b/unittests/FrontendTool/ModuleLoadingTests.cpp
@@ -103,9 +103,8 @@ protected:
     ClangImporterOptions clangImpOpts;
     symbolgraphgen::SymbolGraphOptions symbolGraphOpts;
     SILOptions silOpts;
-    auto ctx =
-        ASTContext::get(langOpts, typeckOpts, searchPathOpts, clangImpOpts,
-                        symbolGraphOpts, sourceMgr, diags);
+    auto ctx = ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts,
+                               clangImpOpts, symbolGraphOpts, sourceMgr, diags);
 
     ctx->addModuleInterfaceChecker(
       std::make_unique<ModuleInterfaceCheckerImpl>(*ctx, cacheDir,
@@ -149,7 +148,8 @@ protected:
     ASSERT_TRUE(bufOrErr);
 
     auto bufData = (*bufOrErr)->getBuffer();
-    auto validationInfo = serialization::validateSerializedAST(bufData);
+    auto validationInfo = serialization::validateSerializedAST(
+        bufData, silOpts.EnableOSSAModules);
     ASSERT_EQ(serialization::Status::Valid, validationInfo.status);
     ASSERT_EQ(bufData, moduleBuffer->getBuffer());
   }

--- a/unittests/Parse/TokenizerTests.cpp
+++ b/unittests/Parse/TokenizerTests.cpp
@@ -82,8 +82,8 @@ public:
   }
   
   std::vector<Token> parseAndGetSplitTokens(unsigned BufID) {
-    swift::ParserUnit PU(SM, SourceFileKind::Main, BufID,
-                         LangOpts, TypeCheckerOptions(), "unknown");
+    swift::ParserUnit PU(SM, SourceFileKind::Main, BufID, LangOpts,
+                         TypeCheckerOptions(), SILOptions(), "unknown");
     SmallVector<Decl *, 8> decls;
     PU.getParser().parseTopLevel(decls);
     return PU.getParser().getSplitTokens();

--- a/unittests/Sema/SemaFixture.cpp
+++ b/unittests/Sema/SemaFixture.cpp
@@ -29,9 +29,9 @@ using namespace swift::unittest;
 using namespace swift::constraints::inference;
 
 SemaTest::SemaTest()
-    : Context(*ASTContext::get(LangOpts, TypeCheckerOpts, SearchPathOpts,
-                               ClangImporterOpts, SymbolGraphOpts,
-                               SourceMgr, Diags)) {
+    : Context(*ASTContext::get(LangOpts, TypeCheckerOpts, SILOpts,
+                               SearchPathOpts, ClangImporterOpts,
+                               SymbolGraphOpts, SourceMgr, Diags)) {
   INITIALIZE_LLVM();
 
   registerParseRequestFunctions(Context.evaluator);

--- a/unittests/Sema/SemaFixture.h
+++ b/unittests/Sema/SemaFixture.h
@@ -38,6 +38,7 @@ class SemaTestBase : public ::testing::Test {
 public:
   LangOptions LangOpts;
   TypeCheckerOptions TypeCheckerOpts;
+  SILOptions SILOpts;
   SearchPathOptions SearchPathOpts;
   ClangImporterOptions ClangImporterOpts;
   symbolgraphgen::SymbolGraphOptions SymbolGraphOpts;


### PR DESCRIPTION
This includes a bit in the module format to represent if the module was compiled with -enable-ossa-modules flag. When compiling a client module with -enable-ossa-modules flag, all dependent modules are checked for this bit, if not on, recompilation is triggered with -enable-ossa-modules.