### PR TITLE
[SILInliner] Fixed some arg lexical lifetimes.

### DIFF
--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -437,7 +437,8 @@ SILInlineCloner::cloneInline(ArrayRef<SILValue> AppliedArgs) {
     unsigned idx = p.index();
     if (idx >= calleeConv.getSILArgIndexOfFirstParam()) {
       if (Apply.getFunction()->hasOwnership() && enableLexicalLifetimes) {
-        if (!callArg->getType().isTrivial(*Apply.getFunction())) {
+        if (!callArg->getType().isTrivial(*Apply.getFunction()) &&
+            !callArg->getType().isAddress()) {
           SILBuilderWithScope builder(Apply.getInstruction(), getBuilder());
           if (calleeConv.getParamInfoForSILArg(idx).isGuaranteed()) {
             callArg = builder.createBeginBorrow(Apply.getLoc(), callArg,

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -448,8 +448,8 @@ SILInlineCloner::cloneInline(ArrayRef<SILValue> AppliedArgs) {
             callArg = builder.createCopyValue(Apply.getLoc(), bbi);
             copiedArgs[idx] = true;
           }
+          borrowedArgs[idx] = true;
         }
-        borrowedArgs[idx] = true;
       } else {
         // Insert begin/end borrow for guaranteed arguments.
         if (calleeConv.getParamInfoForSILArg(idx).isGuaranteed()) {

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -436,8 +436,9 @@ SILInlineCloner::cloneInline(ArrayRef<SILValue> AppliedArgs) {
     SILValue callArg = p.value();
     unsigned idx = p.index();
     if (idx >= calleeConv.getSILArgIndexOfFirstParam()) {
-      if (Apply.getFunction()->hasOwnership() && enableLexicalLifetimes) {
-        if (!callArg->getType().isTrivial(*Apply.getFunction()) &&
+      if (enableLexicalLifetimes) {
+        if (Apply.getFunction()->hasOwnership() &&
+            !callArg->getType().isTrivial(*Apply.getFunction()) &&
             !callArg->getType().isAddress()) {
           SILBuilderWithScope builder(Apply.getInstruction(), getBuilder());
           if (calleeConv.getParamInfoForSILArg(idx).isGuaranteed()) {

--- a/test/SILOptimizer/inline_lifetime.sil
+++ b/test/SILOptimizer/inline_lifetime.sil
@@ -4,6 +4,8 @@ import Swift
 
 class C {}
 
+struct S {}
+
 ////////////////////////////////////////////////////////////////////////////////
 // apply
 ////////////////////////////////////////////////////////////////////////////////
@@ -19,6 +21,12 @@ entry(%instance : @owned $C):
 
 sil [ossa] [always_inline] @callee_guaranteed : $@convention(thin) (@guaranteed C) -> () {
 entry(%instance : @guaranteed $C):
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_trivial : $@convention(thin) (S) -> () {
+entry(%instance : $S):
     %retval = tuple ()
     return %retval : $()
 }
@@ -91,6 +99,18 @@ entry(%instance : @guaranteed $C):
     return %result : $()
 }
 
+// CHECK-LABEL: sil [ossa] @caller_trivial_callee_trivial : $@convention(thin) (S) -> () {
+// CHECK:       {{bb[^,]+}}({{%[^,]+}} : $S):
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'caller_trivial_callee_trivial'
+sil [ossa] @caller_trivial_callee_trivial : $@convention(thin) (S) -> () {
+entry(%instance : $S):
+  %callee_trivial = function_ref @callee_trivial : $@convention(thin) (S) -> ()
+  %result = apply %callee_trivial(%instance) : $@convention(thin) (S) -> ()
+  return %result : $()
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // begin_apply
 ////////////////////////////////////////////////////////////////////////////////
@@ -127,6 +147,20 @@ bb1:
 bb2:
   destroy_addr %addr : $*C
   dealloc_stack %addr : $*C
+  unwind
+}
+
+sil hidden [ossa] [always_inline] @callee_coro_trivial : $@yield_once @convention(method) (S) -> @yields @inout S {
+bb0(%instance : $S):
+  %addr = alloc_stack $S
+  store %instance to [trivial] %addr : $*S
+  yield %addr : $*S, resume bb1, unwind bb2
+bb1:
+  dealloc_stack %addr : $*S
+  %result = tuple ()
+  return %result : $()
+bb2:
+  dealloc_stack %addr : $*S
   unwind
 }
 
@@ -242,6 +276,27 @@ bb0(%instance : @guaranteed $C):
   return %retval : $()
 }
 
+// CHECK-LABEL: sil hidden [ossa] @caller_trivial_callee_coro_trivial : $@convention(method) (S) -> () {
+// CHECK:       {{bb[0-9]+}}([[REGISTER_0:%[^,]+]] : $S):
+// CHECK:         [[REGISTER_1:%[^,]+]] = alloc_stack $S
+// CHECK:         store [[REGISTER_0]] to [trivial] [[REGISTER_1]] : $*S
+// CHECK:         dealloc_stack [[REGISTER_1]] : $*S
+// CHECK:         [[REGISTER_4:%[^,]+]] = tuple ()
+// CHECK:         [[REGISTER_5:%[^,]+]] = tuple ()
+// CHECK:         return [[REGISTER_5]] : $()
+// CHECK:       {{bb[0-9]+}}:
+// CHECK:         dealloc_stack [[REGISTER_1]] : $*S
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'caller_trivial_callee_coro_trivial'
+sil hidden [ossa] @caller_trivial_callee_coro_trivial : $@convention(method) (S) -> () {
+bb0(%instance : $S):
+  %callee_coro_trivial = function_ref @callee_coro_trivial : $@yield_once @convention(method) (S) -> @yields @inout S
+  (%addr, %continuation) = begin_apply %callee_coro_trivial(%instance) : $@yield_once @convention(method) (S) -> @yields @inout S
+  end_apply %continuation
+  %retval = tuple ()
+  return %retval : $()
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // try_apply
 ////////////////////////////////////////////////////////////////////////////////
@@ -262,6 +317,16 @@ bb2:
 
 sil [ossa] [always_inline] @callee_error_guaranteed : $@convention(thin) (@guaranteed C) -> @error Error {
 bb0(%0 : @guaranteed $C):
+  cond_br undef, bb1, bb2
+bb1:
+  throw undef : $Error
+bb2:
+  %18 = tuple ()
+  return %18 : $()
+}
+
+sil [ossa] @callee_error_trivial : $@convention(thin) (S) -> @error Error {
+bb0(%0 : $S):
   cond_br undef, bb1, bb2
 bb1:
   throw undef : $Error
@@ -378,6 +443,27 @@ sil [ossa] @callee_guaranteed_callee_error_guaranteed : $@convention(thin) (@gua
 bb0(%instance : @guaranteed $C):
   %callee_error_guaranteed = function_ref @callee_error_guaranteed : $@convention(thin) (@guaranteed C) -> @error Error
   try_apply %callee_error_guaranteed(%instance) : $@convention(thin) (@guaranteed C) -> @error Error, normal bb1, error bb2
+bb1(%9 : $()):
+  %10 = tuple ()
+  return %10 : $()
+bb2(%12 : @owned $Error):
+  throw %12 : $Error
+}
+
+// CHECK-LABEL: sil hidden [ossa] @callee_trivial_callee_error_trivial : $@convention(thin) (S) -> @error Error {
+// CHECK:       {{bb[^,]+}}({{%[^,]+}} : $S):
+// CHECK:         cond_br undef, [[THROW_BLOCK:bb[^,]+]], [[REGULAR_BLOCK:bb[0-9]+]]
+// CHECK:       [[THROW_BLOCK]]:
+// CHECK:         throw undef
+// CHECK:       [[REGULAR_BLOCK]]:
+// CHECK:         [[ORIGINAL_RETVAL:%[^,]+]] = tuple ()
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'callee_trivial_callee_error_trivial'
+sil hidden [ossa] @callee_trivial_callee_error_trivial : $@convention(thin) (S) -> @error Error {
+bb0(%instance : $S):
+  %callee_error_trivial = function_ref @callee_error_trivial : $@convention(thin) (S) -> @error Error
+  try_apply %callee_error_trivial(%instance) : $@convention(thin) (S) -> @error Error, normal bb1, error bb2
 bb1(%9 : $()):
   %10 = tuple ()
   return %10 : $()

--- a/test/SILOptimizer/inline_lifetime.sil
+++ b/test/SILOptimizer/inline_lifetime.sil
@@ -429,11 +429,11 @@ bb2(%12 : @owned $Error):
 // CHECK-LABEL: sil [ossa] @callee_guaranteed_callee_error_guaranteed : $@convention(thin) (@guaranteed C) -> @error Error {
 // CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @guaranteed $C):
 // CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
-// CHECK:         cond_br undef, [[BASIC_BLOCK1:bb[^,]+]], [[BASIC_BLOCK2:bb[0-9]+]]
-// CHECK:       [[BASIC_BLOCK1]]:
+// CHECK:         cond_br undef, [[THROW_BLOCK:bb[^,]+]], [[REGULAR_BLOCK:bb[0-9]+]]
+// CHECK:       [[THROW_BLOCK]]:
 // CHECK:         end_borrow [[LIFETIME]]
 // CHECK:         throw undef
-// CHECK:       [[BASIC_BLOCK2]]:
+// CHECK:       [[REGULAR_BLOCK]]:
 // CHECK:         [[ORIGINAL_RETVAL:%[^,]+]] = tuple ()
 // CHECK:         end_borrow [[LIFETIME]]
 // CHECK:         [[RETVAL:%[^,]+]] = tuple ()

--- a/test/SILOptimizer/inline_lifetime.sil
+++ b/test/SILOptimizer/inline_lifetime.sil
@@ -31,6 +31,12 @@ entry(%instance : $S):
     return %retval : $()
 }
 
+sil [ossa] [always_inline] @callee_address : $@convention(thin) (@in S) -> () {
+entry(%instance : $*S):
+    %retval = tuple ()
+    return %retval : $()
+}
+
 // tests
 
 // CHECK-LABEL: sil [ossa] @caller_owned_callee_owned : $@convention(thin) (@owned C) -> () {
@@ -111,6 +117,18 @@ entry(%instance : $S):
   return %result : $()
 }
 
+// CHECK-LABEL: sil [ossa] @caller_address_callee_address : $@convention(thin) (@in S) -> () {
+// CHECK:       {{bb[^,]+}}({{%[^,]+}} : $*S):
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'caller_address_callee_address'
+sil [ossa] @caller_address_callee_address : $@convention(thin) (@in S) -> () {
+entry(%instance : $*S):
+    %callee_address = function_ref @callee_address : $@convention(thin) (@in S) -> ()
+    %result = apply %callee_address(%instance) : $@convention(thin) (@in S) -> ()
+    return %result : $()
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // begin_apply
 ////////////////////////////////////////////////////////////////////////////////
@@ -161,6 +179,16 @@ bb1:
   return %result : $()
 bb2:
   dealloc_stack %addr : $*S
+  unwind
+}
+
+sil hidden [ossa] [always_inline] @callee_coro_address : $@yield_once @convention(method) (@in S) -> @yields @inout S {
+bb0(%instance : $*S):
+  yield %instance : $*S, resume bb1, unwind bb2
+bb1:
+  %result = tuple ()
+  return %result : $()
+bb2:
   unwind
 }
 
@@ -297,6 +325,23 @@ bb0(%instance : $S):
   return %retval : $()
 }
 
+// CHECK-LABEL: sil hidden [ossa] @caller_address_callee_coro_address : $@convention(method) (@in S) -> () {
+// CHECK:       {{bb[^,]+}}({{%[^,]+}} : $*S):
+// CHECK:         {{%[^,]+}} = tuple ()
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK:       {{bb[^,]+}}:
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'caller_address_callee_coro_address'
+sil hidden [ossa] @caller_address_callee_coro_address : $@convention(method) (@in S) -> () {
+bb0(%instance : $*S):
+  %callee_coro_address = function_ref @callee_coro_address : $@yield_once @convention(method) (@in S) -> @yields @inout S
+  (%addr, %continuation) = begin_apply %callee_coro_address(%instance) : $@yield_once @convention(method) (@in S) -> @yields @inout S
+  end_apply %continuation
+  %retval = tuple ()
+  return %retval : $()
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // try_apply
 ////////////////////////////////////////////////////////////////////////////////
@@ -327,6 +372,16 @@ bb2:
 
 sil [ossa] @callee_error_trivial : $@convention(thin) (S) -> @error Error {
 bb0(%0 : $S):
+  cond_br undef, bb1, bb2
+bb1:
+  throw undef : $Error
+bb2:
+  %18 = tuple ()
+  return %18 : $()
+}
+
+sil [ossa] @callee_error_address : $@convention(thin) (@in S) -> @error Error {
+bb0(%0 : $*S):
   cond_br undef, bb1, bb2
 bb1:
   throw undef : $Error
@@ -464,6 +519,27 @@ sil hidden [ossa] @callee_trivial_callee_error_trivial : $@convention(thin) (S) 
 bb0(%instance : $S):
   %callee_error_trivial = function_ref @callee_error_trivial : $@convention(thin) (S) -> @error Error
   try_apply %callee_error_trivial(%instance) : $@convention(thin) (S) -> @error Error, normal bb1, error bb2
+bb1(%9 : $()):
+  %10 = tuple ()
+  return %10 : $()
+bb2(%12 : @owned $Error):
+  throw %12 : $Error
+}
+
+// CHECK-LABEL: sil hidden [ossa] @callee_address_callee_error_address : $@convention(thin) (@in S) -> @error Error {
+// CHECK:       {{bb[^,]+}}({{%[^,]+}} : $*S):
+// CHECK:         cond_br undef, [[THROW_BLOCK:bb[0-9]+]], [[REGULAR_BLOCK:bb[0-9]+]]
+// CHECK:       [[THROW_BLOCK]]:
+// CHECK:         throw undef
+// CHECK:       [[REGULAR_BLOCK]]:
+// CHECK:         {{%[^,]+}} = tuple ()
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'callee_address_callee_error_address'
+sil hidden [ossa] @callee_address_callee_error_address : $@convention(thin) (@in S) -> @error Error {
+bb0(%instance : $*S):
+  %callee_error_address = function_ref @callee_error_address : $@convention(thin) (@in S) -> @error Error
+  try_apply %callee_error_address(%instance) : $@convention(thin) (@in S) -> @error Error, normal bb1, error bb2
 bb1(%9 : $()):
   %10 = tuple ()
   return %10 : $()


### PR DESCRIPTION
Running the source compat suite with -Xfrontend -enable-experimental-lexical-lifetimes revealed a couple of issues with the change to the SILInliner.  They are fixed here.
