### PR TITLE
Allow building a concurrent libSwiftConcurrency without libdispatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -494,7 +494,7 @@ endif()
 # Use dispatch as the system scheduler by default.
 # For convenience, we set this to false when concurrency is disabled.
 set(SWIFT_CONCURRENCY_USES_DISPATCH FALSE)
-if(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY AND NOT SWIFT_STDLIB_SINGLE_THREADED_RUNTIME)
+if(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY AND "${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "dispatch")
   set(SWIFT_CONCURRENCY_USES_DISPATCH TRUE)
 endif()
 

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -25,6 +25,22 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 
+// Does the runtime use a cooperative global executor?
+#if defined(SWIFT_STDLIB_SINGLE_THREADED_RUNTIME)
+#define SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR 1
+#else
+#define SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR 0
+#endif
+
+// Does the runtime integrate with libdispatch?
+#ifndef SWIFT_CONCURRENCY_ENABLE_DISPATCH
+#if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
+#define SWIFT_CONCURRENCY_ENABLE_DISPATCH 0
+#else
+#define SWIFT_CONCURRENCY_ENABLE_DISPATCH 1
+#endif
+#endif
+
 namespace swift {
 class DefaultActor;
 class TaskOptionRecord;
@@ -661,9 +677,13 @@ void swift_task_enqueueGlobalWithDelay(unsigned long long delay, Job *job);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_enqueueMainExecutor(Job *job);
 
+#if SWIFT_CONCURRENCY_ENABLE_DISPATCH
+
 /// Enqueue the given job on the main executor.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_enqueueOnDispatchQueue(Job *job, HeapObject *queue);
+
+#endif
 
 /// A hook to take over global enqueuing.
 typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobal_original)(Job *job);
@@ -805,6 +825,17 @@ void swift_task_reportUnexpectedExecutor(
 
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 JobPriority swift_task_getCurrentThreadPriority(void);
+
+#if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
+
+/// Donate this thread to the global executor until either the
+/// given condition returns true or we've run out of cooperative
+/// tasks to run.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_task_donateThreadToGlobalExecutorUntil(bool (*condition)(void*),
+                                                  void *context);
+
+#endif
 
 #ifdef __APPLE__
 /// A magic symbol whose address is the mask to apply to a frame pointer to

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -114,6 +114,16 @@ option(SWIFT_ENABLE_REFLECTION
   "Build stdlib with support for runtime reflection and mirrors."
   TRUE)
 
+if(SWIFT_STDLIB_SINGLE_THREADED_RUNTIME)
+  set(SWIFT_CONCURRENCY_GLOBAL_EXECUTOR_default "singlethreaded")
+else()
+  set(SWIFT_CONCURRENCY_GLOBAL_EXECUTOR_default "dispatch")
+endif()
+
+set(SWIFT_CONCURRENCY_GLOBAL_EXECUTOR
+    "${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR_default}" CACHE STRING
+    "Build the concurrency library to use the given global executor (options: dispatch, singlethreaded, hooked)")
+
 #
 # End of user-configurable options.
 #
@@ -244,6 +254,11 @@ function(swift_create_stdlib_targets name variant define_all_alias)
     message(WARNING "Primary variant ${SWIFT_PRIMARY_VARIANT_SDK} is not being built, not creating ${name}${variant} alias target for it.")
   endif()
 endfunction()
+
+if("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "singlethreaded"
+   AND NOT SWIFT_STDLIB_SINGLE_THREADED_RUNTIME)
+  message(SEND_ERROR "Cannot enable the single-threaded global executor without enabling SWIFT_STDLIB_SINGLE_THREADED_RUNTIME")
+endif()
 
 swift_create_stdlib_targets("swift-stdlib" "" TRUE)
 if(SWIFT_STDLIB_ENABLE_SIB_TARGETS)

--- a/stdlib/public/BackDeployConcurrency/CMakeLists.txt
+++ b/stdlib/public/BackDeployConcurrency/CMakeLists.txt
@@ -16,6 +16,8 @@ cmake_minimum_required(VERSION 3.19.6)
 include("${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/modules/StandaloneOverlay.cmake")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/modules")
 set(SWIFT_STDLIB_STABLE_ABI TRUE)
+set(SWIFT_STDLIB_SINGLE_THREADED_RUNTIME FALSE)
+set(SWIFT_CONCURRENCY_GLOBAL_EXECUTOR "dispatch")
 include(AddSwiftStdlib)
 
 # Don't build the libraries for 32-bit iOS targets; there is no back-deployment

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -46,7 +46,7 @@
 #include "TaskPrivate.h"
 #include "VoucherSupport.h"
 
-#if !SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
+#if SWIFT_CONCURRENCY_ENABLE_DISPATCH
 #include <dispatch/dispatch.h>
 #endif
 

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -18,7 +18,10 @@ if(NOT swift_concurrency_install_component)
   set(swift_concurrency_install_component stdlib)
 endif()
 
-if(SWIFT_CONCURRENCY_USES_DISPATCH)
+set(SWIFT_RUNTIME_CONCURRENCY_C_FLAGS)
+set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS)
+
+if("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "dispatch")
   if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
     include_directories(AFTER
                           ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE})
@@ -29,11 +32,18 @@ if(SWIFT_CONCURRENCY_USES_DISPATCH)
     list(APPEND swift_concurrency_link_libraries
       dispatch)
   endif()
+elseif("${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "singlethreaded" OR
+       "${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}" STREQUAL "hooked")
+  list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS
+    "-DSWIFT_CONCURRENCY_ENABLE_DISPATCH=0")
+else()
+  message(FATAL_ERROR "Invalid value for SWIFT_CONCURRENCY_GLOBAL_EXECUTOR (\"${SWIFT_CONCURRENCY_GLOBAL_EXECUTOR}\").")
 endif()
 
 
-set(SWIFT_RUNTIME_CONCURRENCY_C_FLAGS)
-set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS)
+if(NOT SWIFT_CONCURRENCY_USES_DISPATCH)
+
+endif()
 
 if(NOT swift_concurrency_async_fp_mode)
   set(swift_concurrency_async_fp_mode "always")

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -34,7 +34,7 @@
 #include "queue" // TODO: remove and replace with usage of our mpsc queue
 #include <atomic>
 #include <assert.h>
-#if !SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
+#if SWIFT_CONCURRENCY_ENABLE_DISPATCH
 #include <dispatch/dispatch.h>
 #endif
 

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -100,20 +100,6 @@ void asyncLet_addImpl(AsyncTask *task, AsyncLet *asyncLet,
 /// Clear the active task reference for the current thread.
 AsyncTask *_swift_task_clearCurrent();
 
-#if defined(SWIFT_STDLIB_SINGLE_THREADED_RUNTIME)
-#define SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR 1
-#else
-#define SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR 0
-#endif
-
-#if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
-/// Donate this thread to the global executor until either the
-/// given condition returns true or we've run out of cooperative
-/// tasks to run.
-void donateThreadToGlobalExecutorUntil(bool (*condition)(void*),
-                                       void *context);
-#endif
-
 /// release() establishes a happens-before relation with a preceding acquire()
 /// on the same address.
 void _swift_tsan_acquire(void *addr);


### PR DESCRIPTION
The goal here is not to eventually implement a concurrent thread pool ourselves.  We're just making it easier for integrators who have their own pool and don't want to use Dispatch to build the Swift concurrency runtime.  Just hook the right functions and you should be fine.

The necessary functions to hook are:
- `swift_task_enqueueGlobal`
- `swift_task_enqueueGlobalAfterDelay`

The following functions *would* be necessary to hook:
- `swift_task_enqueueMainExecutor`
- `swift_task_asyncMainDrainQueue` (only if you have an async main?)
However, this configuration does not currently properly support the main executor, and so `@MainActor` should be avoided for now.

rdar://83513751

This is a revision of #39480, which was reverted, to properly handle the weird back-deployment library build configuration and to add a top-level option.