### PR TITLE
test: fix stdlib tests when targeting WebAssembly/WASI

### DIFF
--- a/stdlib/private/StdlibUnittest/RaceTest.swift
+++ b/stdlib/private/StdlibUnittest/RaceTest.swift
@@ -43,6 +43,8 @@ import SwiftPrivateThreadExtras
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif os(WASI)
+import WASILibc
 #elseif os(Windows)
 import CRT
 import WinSDK
@@ -334,6 +336,36 @@ public func evaluateObservationsAllEqual<T : Equatable>(_ observations: [T])
   }
   return .pass
 }
+
+// WebAssembly/WASI doesn't support multi-threading yet
+#if os(WASI)
+public func runRaceTest<RT : RaceTestWithPerTrialData>(
+  _: RT.Type,
+  trials: Int,
+  timeoutInSeconds: Int? = nil,
+  threads: Int? = nil
+) {}
+public func runRaceTest<RT : RaceTestWithPerTrialData>(
+  _ test: RT.Type,
+  operations: Int,
+  timeoutInSeconds: Int? = nil,
+  threads: Int? = nil
+) {}
+public func consumeCPU(units amountOfWork: Int) {}
+public func runRaceTest(
+  trials: Int,
+  timeoutInSeconds: Int? = nil,
+  threads: Int? = nil,
+  invoking body: @escaping () -> Void
+) {}
+
+public func runRaceTest(
+  operations: Int,
+  timeoutInSeconds: Int? = nil,
+  threads: Int? = nil,
+  invoking body: @escaping () -> Void
+) {}
+#else
 
 struct _RaceTestAggregatedEvaluations : CustomStringConvertible {
   var passCount: Int = 0
@@ -756,3 +788,4 @@ public func runRaceTest(
     timeoutInSeconds: timeoutInSeconds, threads: threads)
 }
 
+#endif // os(WASI)

--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -16,6 +16,8 @@ import SwiftPrivateLibcExtras
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif os(WASI)
+import WASILibc
 #elseif os(Windows)
 import CRT
 #endif

--- a/stdlib/private/StdlibUnittest/SymbolLookup.swift
+++ b/stdlib/private/StdlibUnittest/SymbolLookup.swift
@@ -14,6 +14,8 @@
   import Darwin
 #elseif canImport(Glibc)
   import Glibc
+#elseif os(WASI)
+  import WASILibc
 #elseif os(Windows)
   import CRT
   import WinSDK
@@ -23,7 +25,7 @@
 
 #if canImport(Darwin) || os(OpenBSD)
   let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: -2)
-#elseif os(Linux)
+#elseif os(Linux) || os(WASI)
   let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: 0)
 #elseif os(Android)
   #if arch(arm) || arch(i386)

--- a/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/Subprocess.swift
@@ -15,6 +15,8 @@ import SwiftPrivate
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif os(WASI)
+import WASILibc
 #elseif os(Windows)
 import CRT
 import WinSDK

--- a/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
@@ -15,6 +15,8 @@ import SwiftPrivate
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif os(WASI)
+import WASILibc
 #elseif os(Windows)
 import CRT
 #endif

--- a/stdlib/private/SwiftPrivateThreadExtras/SwiftPrivateThreadExtras.swift
+++ b/stdlib/private/SwiftPrivateThreadExtras/SwiftPrivateThreadExtras.swift
@@ -19,6 +19,8 @@
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif os(WASI)
+import WASILibc
 #elseif os(Windows)
 import CRT
 import WinSDK
@@ -98,6 +100,9 @@ public func _stdlib_thread_create_block<Argument, Result>(
   } else {
     return (0, ThreadHandle(bitPattern: threadID))
   }
+#elseif os(WASI)
+  // WASI environment has a only single thread
+  return (0, nil)
 #else
   var threadID = _make_pthread_t()
   let result = pthread_create(&threadID, nil,
@@ -129,6 +134,9 @@ public func _stdlib_thread_join<Result>(
     }
   }
   return (CInt(result), value)
+#elseif os(WASI)
+   // WASI environment has a only single thread
+   return (0, nil)
 #else
   var threadResultRawPtr: UnsafeMutableRawPointer?
   let result = pthread_join(thread, &threadResultRawPtr)

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -297,6 +297,8 @@ static bool isExecutingOnMainThread() {
   }
 
   return __initialPthread == GetCurrentThread();
+#elif defined(__wasi__)
+  return true;
 #else
   return pthread_main_np() == 1;
 #endif

--- a/stdlib/public/Concurrency/AsyncLet.cpp
+++ b/stdlib/public/Concurrency/AsyncLet.cpp
@@ -26,7 +26,7 @@
 #include "TaskPrivate.h"
 #include "Debug.h"
 
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__wasi__)
 #include <dlfcn.h>
 #endif
 

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -31,7 +31,7 @@
 #include <dispatch/dispatch.h>
 #endif
 
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__wasi__)
 #include <dlfcn.h>
 #endif
 

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -38,7 +38,7 @@
 #include <dispatch/dispatch.h>
 #endif
 
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__wasi__)
 #include <dlfcn.h>
 #endif
 

--- a/stdlib/public/Concurrency/ThreadSanitizer.cpp
+++ b/stdlib/public/Concurrency/ThreadSanitizer.cpp
@@ -16,8 +16,8 @@
 
 #include "TaskPrivate.h"
 
-// Thread Sanitizer is not supported on Windows.
-#if defined(_WIN32)
+// Thread Sanitizer is not supported on Windows or WASI.
+#if defined(_WIN32) || defined(__wasi__)
 void swift::_swift_tsan_acquire(void *addr) {}
 void swift::_swift_tsan_release(void *addr) {}
 #else

--- a/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
+++ b/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
@@ -18,6 +18,8 @@ import Swift
   import Darwin.C.tgmath
 #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(PS4) || os(Android) || os(Cygwin) || os(Haiku)
   import Glibc
+#elseif os(WASI)
+  import WASILibc
 #elseif os(Windows)
   import CRT
 #else

--- a/stdlib/tools/swift-reflection-test/swift-reflection-test.c
+++ b/stdlib/tools/swift-reflection-test/swift-reflection-test.c
@@ -29,7 +29,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__wasi__)
 #include <unistd.h>
 #elif defined(_WIN32)
 #include <io.h>

--- a/test/ClangImporter/clang_builtins.swift
+++ b/test/ClangImporter/clang_builtins.swift
@@ -4,6 +4,8 @@
   import Darwin
 #elseif canImport(Glibc)
   import Glibc
+#elseif os(WASI)
+  import WASILibc
 #elseif os(Windows)
   import CRT
 #else

--- a/test/IRGen/builtin_math.swift
+++ b/test/IRGen/builtin_math.swift
@@ -4,6 +4,8 @@
   import Darwin
 #elseif canImport(Glibc)
   import Glibc
+#elseif os(WASI)
+  import WASILibc
 #elseif os(Windows)
   import CRT
 #else

--- a/test/stdlib/Character.swift
+++ b/test/stdlib/Character.swift
@@ -369,6 +369,8 @@ UnicodeScalarTests.test("UInt8(ascii: UnicodeScalar)") {
   }
 }
 
+#if !os(WASI)
+// Trap tests aren't available on WASI.
 UnicodeScalarTests.test("UInt8(ascii: UnicodeScalar)/non-ASCII should trap")
   .skip(.custom(
     { _isFastAssertConfiguration() },
@@ -378,6 +380,7 @@ UnicodeScalarTests.test("UInt8(ascii: UnicodeScalar)/non-ASCII should trap")
   expectCrashLater()
   _blackHole(UInt8(ascii: us))
 }
+#endif
 
 UnicodeScalarTests.test("UInt32(_: UnicodeScalar),UInt64(_: UnicodeScalar)") {
   for us in baseScalars {

--- a/test/stdlib/Error.swift
+++ b/test/stdlib/Error.swift
@@ -118,6 +118,8 @@ ErrorTests.test("default domain and code") {
 
 enum SillyError: Error { case JazzHands }
 
+#if !os(WASI)
+// Trap tests aren't available on WASI.
 ErrorTests.test("try!")
   .skip(.custom({ _isFastAssertConfiguration() },
                 reason: "trap is not guaranteed to happen in -Ounchecked"))
@@ -140,6 +142,7 @@ ErrorTests.test("try!/location")
     expectCrashLater()
     let _: () = try! { throw SillyError.JazzHands }()
 }
+#endif
 
 ErrorTests.test("try?") {
   var value = try? { () throws -> Int in return 1 }()

--- a/test/stdlib/FloatConstants.swift
+++ b/test/stdlib/FloatConstants.swift
@@ -4,6 +4,8 @@
   import Darwin
 #elseif canImport(Glibc)
   import Glibc
+#elseif os(WASI)
+  import WASILibc
 #elseif os(Windows)
   import CRT
 #else

--- a/test/stdlib/FloatingPoint.swift.gyb
+++ b/test/stdlib/FloatingPoint.swift.gyb
@@ -331,6 +331,8 @@ FloatingPoint.test("Float/Int16") {
   expectEqual(Int16.max, Int16(Float(Int16.max)))
 }
 
+#if !os(WASI)
+// Trap tests aren't available on WASI.
 FloatingPoint.test("Float/UInt32") {
   expectEqual(UInt32.min, UInt32(Float(UInt32.min)))
   expectCrashLater()
@@ -354,6 +356,7 @@ FloatingPoint.test("Float/Int64") {
   expectCrashLater()
   expectEqual(Int64.max, Int64(Float(Int64.max)))
 }
+#endif
 
 FloatingPoint.test("Double/ExpressibleByIntegerLiteral") {
   expectEqual(positiveOne(),  1.0 as Double)
@@ -419,6 +422,8 @@ FloatingPoint.test("Double/Int32") {
   expectEqual(Int32.max, Int32(Double(Int32.max)))
 }
 
+#if !os(WASI)
+// Trap tests aren't available on WASI.
 FloatingPoint.test("Double/UInt64") {
   expectEqual(UInt64.min, UInt64(Double(UInt64.min)))
   expectCrashLater()
@@ -430,6 +435,7 @@ FloatingPoint.test("Double/Int64") {
   expectCrashLater()
   expectEqual(Int64.max, Int64(Double(Int64.max)))
 }
+#endif
 
 FloatingPoint.test("Float/HashValueZero") {
   let zero: Float = getFloat32(0.0)
@@ -1175,11 +1181,14 @@ FloatingPoint.test("Float32/quietNaN") {
     expectTrue(f.isNaN && !f.isSignalingNaN)
     expectEqual(0x7fdf_ffff, f.bitPattern)
   }
+#if !os(WASI)
+// Trap tests aren't available on WASI.
   do {
     // Payload overflow
     expectCrashLater()
     _ = Float32(nan: 0x20_0000, signaling: false)
   }
+#endif
 }
 
 FloatingPoint.test("Float64/quietNaN") {
@@ -1204,11 +1213,14 @@ FloatingPoint.test("Float64/quietNaN") {
     expectTrue(f.isNaN && !f.isSignalingNaN)
     expectEqual(0x7ffb_ffff_ffff_ffff, f.bitPattern)
   }
+#if !os(WASI)
+// Trap tests aren't available on WASI.
   do {
     // Payload overflow
     expectCrashLater()
     _ = Float64(nan: 0x4_0000_0000_0000, signaling: false)
   }
+#endif
 }
 
 #if !os(Windows) && (arch(i386) || arch(x86_64))
@@ -1235,11 +1247,14 @@ FloatingPoint.test("Float80/quietNaN") {
     expectTrue(f.isNaN && !f.isSignalingNaN)
     expectEqual(Float80Bits(0x7fff, 0xdfff_ffff_ffff_ffff), f.bitPattern)
   }
+#if !os(WASI)
+// Trap tests aren't available on WASI.
   do {
     // Payload overflow
     expectCrashLater()
     _ = Float80(nan: 0x2000_0000_0000_0000, signaling: false)
   }
+#endif
 }
 
 #endif
@@ -1268,11 +1283,14 @@ FloatingPoint.test("Float32/signalingNaN") {
     expectTrue(f.isNaN && f.isSignalingNaN)
     expectEqual(0x7fbf_ffff, f.bitPattern)
   }
+#if !os(WASI)
+// Trap tests aren't available on WASI.
   do {
     // payload overflow
     expectCrashLater()
     _ = Float32(nan: 0x20_0000, signaling: true)
   }
+#endif
 }
 
 FloatingPoint.test("Float64/signalingNaN") {
@@ -1297,11 +1315,14 @@ FloatingPoint.test("Float64/signalingNaN") {
     expectTrue(f.isNaN && f.isSignalingNaN)
     expectEqual(0x7ff7_ffff_ffff_ffff, f.bitPattern)
   }
+#if !os(WASI)
+// Trap tests aren't available on WASI.
   do {
     // payload overflow
     expectCrashLater()
     _ = Float64(nan: 0x4_0000_0000_0000, signaling: true)
   }
+#endif
 }
 
 #endif
@@ -1330,11 +1351,14 @@ FloatingPoint.test("Float80/signalingNaN") {
     expectTrue(f.isNaN && f.isSignalingNaN)
     expectEqual(Float80Bits(0x7fff, 0xbfff_ffff_ffff_ffff), f.bitPattern)
   }
+#if !os(WASI)
+// Trap tests aren't available on WASI.
   do {
     // payload overflow
     expectCrashLater()
     _ = Float80(nan: 0x2000_0000_0000_0000, signaling: true)
   }
+#endif
 }
 
 #endif

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -430,6 +430,8 @@ keyPath.test("optional force-unwrapping") {
   expectTrue(value.questionableCanary === newCanary)
 }
 
+#if !os(WASI)
+// Trap tests aren't available on WASI.
 keyPath.test("optional force-unwrapping trap") {
   let origin_x = \TestOptional.origin!.x
   var value = TestOptional(origin: nil)
@@ -437,6 +439,7 @@ keyPath.test("optional force-unwrapping trap") {
   expectCrashLater()
   _ = value[keyPath: origin_x]
 }
+#endif
 
 struct TestOptional2 {
   var optional: TestOptional?

--- a/test/stdlib/MathConstants.swift
+++ b/test/stdlib/MathConstants.swift
@@ -4,6 +4,8 @@
   import Darwin
 #elseif canImport(Glibc)
   import Glibc
+#elseif os(WASI)
+  import WASILibc
 #elseif os(Windows)
   import CRT
 #else

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -958,6 +958,8 @@ mirrors.test("Addressing") {
   expectNil(m.descendant(1, 1, "bork"))
 }
 
+#if !os(WASI)
+// Trap tests aren't available on WASI.
 mirrors.test("Invalid Path Type")
   .skip(.custom(
     { _isFastAssertConfiguration() },
@@ -969,6 +971,7 @@ mirrors.test("Invalid Path Type")
   expectCrashLater()
   _ = m.descendant(X())
 }
+#endif
 
 mirrors.test("PlaygroundQuickLook") {
   // Customization works.

--- a/test/stdlib/NumericParsing.swift.gyb
+++ b/test/stdlib/NumericParsing.swift.gyb
@@ -108,6 +108,8 @@ tests.test("${Self}/success") {
   % end
 }
 
+#if !os(WASI)
+// Trap tests aren't available on WASI.
 tests.test("${Self}/radixTooLow") {
   ${Self}("0", radix: 2)
   expectCrashLater()
@@ -120,6 +122,7 @@ tests.test("${Self}/radixTooHigh") {
   expectCrashLater()
   let y = ${Self}("0", radix: maxRadix + 1)
 }
+#endif
 
 % end
 

--- a/test/stdlib/Optional.swift
+++ b/test/stdlib/Optional.swift
@@ -339,6 +339,8 @@ OptionalTests.test("Casting Optional") {
   expectTrue(anyToAnyIsOptional(Optional<(String, String)>.none, Bool.self))
 }
 
+#if !os(WASI)
+// Trap tests aren't available on WASI.
 OptionalTests.test("Casting Optional Traps") {
   let nx: C? = nil
   expectCrash { _blackHole(anyToAny(nx, Int.self)) }
@@ -347,6 +349,7 @@ OptionalTests.test("Casting Optional Any Traps") {
   let nx: X? = X()
   expectCrash { _blackHole(anyToAny(nx as Any, Optional<Int>.self)) }
 }
+#endif
 
 class TestNoString {}
 class TestString : CustomStringConvertible, CustomDebugStringConvertible {
@@ -408,6 +411,8 @@ OptionalTests.test("unsafelyUnwrapped") {
   expectEqual(3, nonEmpty.unsafelyUnwrapped)
 }
 
+#if !os(WASI)
+// Trap tests aren't available on WASI.
 OptionalTests.test("unsafelyUnwrapped nil")
   .xfail(.custom(
     { !_isDebugAssertConfiguration() },
@@ -417,5 +422,6 @@ OptionalTests.test("unsafelyUnwrapped nil")
   expectCrashLater()
   _blackHole(empty.unsafelyUnwrapped)
 }
+#endif
 
 runAllTests()

--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -14,6 +14,8 @@ import StdlibUnittest
   import Darwin
 #elseif canImport(Glibc)
   import Glibc
+#elseif os(WASI)
+  import WASILibc
 #elseif os(Windows)
   import CRT
 #else

--- a/test/stdlib/Repeat.swift
+++ b/test/stdlib/Repeat.swift
@@ -23,11 +23,13 @@ RepeatTests.test("associated-types") {
       indicesType: CountableRange<Int>.self)
 }
 
+#if !os(WASI)
+// Trap tests aren't available on WASI.
 RepeatTests.test("out-of-bounds") {
   let sequence = repeatElement(0, count: 1)
   expectCrashLater()
   _ = sequence[sequence.count]
 }
+#endif
 
 runAllTests()
-

--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -15,6 +15,8 @@ import SwiftShims
   import Darwin
 #elseif canImport(Glibc)
   import Glibc
+#elseif os(WASI)
+  import WASILibc
 #elseif os(Windows)
   import CRT
   import WinSDK
@@ -684,7 +686,7 @@ Reflection.test("multiprotocolTypes") {
 var BitTwiddlingTestSuite = TestSuite("BitTwiddling")
 
 BitTwiddlingTestSuite.test("_pointerSize") {
-#if arch(i386) || arch(arm) || arch(arm64_32)
+#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
   expectEqual(4, MemoryLayout<Optional<AnyObject>>.size)
 #elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
   expectEqual(8, MemoryLayout<Optional<AnyObject>>.size)
@@ -708,7 +710,7 @@ BitTwiddlingTestSuite.test("_isPowerOf2/Int") {
   expectTrue(_isPowerOf2(asInt(2)))
   expectFalse(_isPowerOf2(asInt(3)))
   expectTrue(_isPowerOf2(asInt(1024)))
-#if arch(i386) || arch(arm) || arch(arm64_32)
+#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
   // Not applicable to 32-bit architectures.
 #elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
   expectTrue(_isPowerOf2(asInt(0x8000_0000)))

--- a/test/stdlib/StaticString.swift
+++ b/test/stdlib/StaticString.swift
@@ -73,6 +73,8 @@ StaticStringTestSuite.test("PointerRepresentation/NonASCII") {
   expectDebugPrinted("\"абв\"", str)
 }
 
+#if !os(WASI)
+// Trap tests aren't available on WASI.
 StaticStringTestSuite.test("PointerRepresentation/unicodeScalar")
   .skip(.custom(
     { _isFastAssertConfiguration() },
@@ -85,6 +87,7 @@ StaticStringTestSuite.test("PointerRepresentation/unicodeScalar")
   expectCrashLater()
   strOpaque.unicodeScalar
 }
+#endif
 
 StaticStringTestSuite.test("UnicodeScalarRepresentation/ASCII") {
   // The type checker does not call the UnicodeScalar initializer even if
@@ -123,6 +126,8 @@ StaticStringTestSuite.test("UnicodeScalarRepresentation/NonASCII") {
   expectDebugPrinted("\"Ы\"", str)
 }
 
+#if !os(WASI)
+// Trap tests aren't available on WASI.
 StaticStringTestSuite.test("UnicodeScalarRepresentation/utf8Start")
   .skip(.custom(
     { _isFastAssertConfiguration() },
@@ -148,6 +153,7 @@ StaticStringTestSuite.test("UnicodeScalarRepresentation/utf8CodeUnitCount")
   expectCrashLater()
   strOpaque.utf8CodeUnitCount
 }
+#endif
 
 runAllTests()
 

--- a/test/stdlib/UnsafePointer.swift.gyb
+++ b/test/stdlib/UnsafePointer.swift.gyb
@@ -305,6 +305,8 @@ func checkPtr(
   }
 }
 
+#if !os(WASI)
+// Trap tests aren't available on WASI.
 UnsafeMutablePointerTestSuite.test("moveAssign:from:") {
   let check = checkPtr(UnsafeMutablePointer.moveAssign, true)
   check(Check.Disjoint)
@@ -323,6 +325,7 @@ UnsafeMutablePointerTestSuite.test("moveAssign:from:.Right") {
     check(Check.RightOverlap)
   }
 }
+#endif
 
 UnsafeMutablePointerTestSuite.test("assign:from:") {
   let check = checkPtr(UnsafeMutablePointer.assign, true)
@@ -338,6 +341,8 @@ UnsafeMutablePointerTestSuite.test("moveInitialize:from:") {
   check(Check.RightOverlap)
 }
 
+#if !os(WASI)
+// Trap tests aren't available on WASI.
 UnsafeMutablePointerTestSuite.test("initialize:from:") {
   let check = checkPtr(UnsafeMutablePointer.initialize(from:count:), false)
   check(Check.Disjoint)
@@ -356,6 +361,7 @@ UnsafeMutablePointerTestSuite.test("initialize:from:.Right") {
     check(Check.RightOverlap)
   }
 }
+#endif
 
 UnsafeMutablePointerTestSuite.test("initialize:from:/immutable") {
   var ptr = UnsafeMutablePointer<Missile>.allocate(capacity: 3)
@@ -401,7 +407,7 @@ ${SelfName}TestSuite.test("customMirror") {
   let ptr = ${SelfType}(bitPattern: reallyBigInt)!
   let mirror = ptr.customMirror
   expectEqual(1, mirror.children.count)
-#if arch(i386) || arch(arm) || arch(arm64_32)
+#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
   expectEqual("18446744071562067968", String(describing: mirror.children.first!.1))
 #elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
   expectEqual("9223372036854775808", String(describing: mirror.children.first!.1))
@@ -416,7 +422,7 @@ ${SelfName}TestSuite.test("customPlaygroundQuickLook") {
   let reallyBigInt: UInt = UInt(Int.max) + 1
   let ptr = ${SelfType}(bitPattern: reallyBigInt)!
   if case let .text(desc) = ptr.customPlaygroundQuickLook {
-#if arch(i386) || arch(arm) || arch(arm64_32)
+#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
     expectEqual("${SelfName}(0xFFFFFFFF80000000)", desc)
 #elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
     expectEqual("${SelfName}(0x8000000000000000)", desc)

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -128,6 +128,8 @@ UnsafeRawBufferPointerTestSuite.test("initFromArray") {
   expectEqual(array2, array1)
 }
 
+#if !os(WASI)
+// Trap tests aren't available on WASI.
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).underflow") {
   let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 30, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
@@ -159,6 +161,7 @@ UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).overflow") {
   expected.withUnsafeBytes { expectEqualSequence($0,buffer[0..<idx]) }
   expectEqualSequence([5, 4, 3],bound)
 }
+#endif
 
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).exact") {
   let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 24, alignment: MemoryLayout<UInt>.alignment)
@@ -172,12 +175,15 @@ UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).exact") {
   expectEqualSequence([5, 4, 3],bound)
 }
 
+#if !os(WASI)
+// Trap tests aren't available on WASI.
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).invalidNilPtr") {
   let buffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
   let source: [Int64] = [5, 4, 3, 2, 1]
   expectCrashLater()
   _ = buffer.initializeMemory(as: Int64.self, from: source)
 }
+#endif
 
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).validNilPtr") {
   let buffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
@@ -280,6 +286,8 @@ UnsafeRawBufferPointerTestSuite.test("inBounds") {
   expectEqualSequence(firstHalf, secondHalf)
 }
 
+#if !os(WASI)
+// Trap tests aren't available on WASI.
 UnsafeRawBufferPointerTestSuite.test("subscript.get.underflow") {
   let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 2, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
@@ -406,6 +414,7 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.wide") {
   // Performs a valid byte-wise copy but triggers a debug bounds check.
   buffer[0..<2] = buffer[0..<3]
 }
+#endif
 
 UnsafeRawBufferPointerTestSuite.test("_copyContents") {
   let a = Array<UInt8>(0..<20)
@@ -419,6 +428,8 @@ UnsafeRawBufferPointerTestSuite.test("_copyContents") {
   expectEqual(written, a.count)
 }
 
+#if !os(WASI)
+// Trap tests aren't available on WASI.
 UnsafeRawBufferPointerTestSuite.test("copyMemory.overflow") {
   var buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
@@ -432,6 +443,7 @@ UnsafeRawBufferPointerTestSuite.test("copyMemory.overflow") {
   UnsafeMutableRawBufferPointer(rebasing: bytes).copyMemory(
       from: UnsafeRawBufferPointer(buffer))
 }
+#endif
 
 // Use copyBytes without contiguous storage
 UnsafeRawBufferPointerTestSuite.test("copyBytes.withoutContiguouseStorage") {
@@ -446,6 +458,8 @@ UnsafeRawBufferPointerTestSuite.test("copyBytes.withoutContiguouseStorage") {
   }
 }
 
+#if !os(WASI)
+// Trap tests aren't available on WASI.
 UnsafeRawBufferPointerTestSuite.test("copyBytes.sequence.overflow") {
   var buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
   defer { buffer.deallocate() }
@@ -537,6 +551,7 @@ UnsafeRawBufferPointerTestSuite.test("copy.sequence.overflow")
     }
   }
 }
+#endif
 
 UnsafeRawBufferPointerTestSuite.test("copy.overlap") {
   let bytes = UnsafeMutableRawBufferPointer.allocate(byteCount: 4, alignment: MemoryLayout<UInt>.alignment)

--- a/test/stdlib/UnsafeRawPointer.swift
+++ b/test/stdlib/UnsafeRawPointer.swift
@@ -200,6 +200,8 @@ func checkPtr(
   }
 }
 
+#if !os(WASI)
+// Trap tests aren't available on WASI.
 UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count:") {
   let check = checkPtr(UnsafeMutableRawPointer.initializeMemory(as:from:count:))
   check(Check.Disjoint)
@@ -220,6 +222,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory:as:from:count:.Righ
     check(Check.RightOverlap)
   }
 }
+#endif
 
 UnsafeMutableRawPointerExtraTestSuite.test("moveInitialize:from:") {
   let check =

--- a/test/stdlib/VarArgs.swift
+++ b/test/stdlib/VarArgs.swift
@@ -24,6 +24,9 @@ runAllTests()
 #elseif canImport(Glibc)
   import Glibc
   typealias CGFloat = Double
+#elseif os(WASI)
+  import WASILibc
+  typealias CGFloat = Double
 #elseif os(Windows)
   import CRT
   #if arch(x86_64) || arch(arm64)

--- a/test/stdlib/tgmath.swift.gyb
+++ b/test/stdlib/tgmath.swift.gyb
@@ -21,6 +21,8 @@
   import Darwin.C.tgmath
 #elseif canImport(Glibc)
   import Glibc
+#elseif os(WASI)
+  import WASILibc
 #elseif os(Windows)
   import CRT
 #else

--- a/test/stdlib/tgmath_optimized.swift
+++ b/test/stdlib/tgmath_optimized.swift
@@ -8,6 +8,8 @@
   import Darwin
 #elseif canImport(Glibc)
   import Glibc
+#elseif os(WASI)
+  import WASILibc
 #elseif os(Windows)
   import CRT
 #else


### PR DESCRIPTION
This change adds support for WASI in stdlib tests. Some tests that expect a crash to happen had to be disabled, since there's currently no way to observe such crash from a WASI host.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Related to SR-9307.