### PR TITLE
[AST] Preserve source location in packIntoImplicitTupleOrParen

### DIFF
--- a/lib/AST/ArgumentList.cpp
+++ b/lib/AST/ArgumentList.cpp
@@ -220,28 +220,35 @@ Optional<unsigned> ArgumentList::findArgumentExpr(Expr *expr,
 Expr *ArgumentList::packIntoImplicitTupleOrParen(
     ASTContext &ctx, llvm::function_ref<Type(Expr *)> getType) const {
   assert(!hasAnyInOutArgs() && "Cannot construct bare tuple/paren with inout");
+
+  // Make sure to preserve the source location info here and below as it may be
+  // needed for e.g serialization of its textual representation.
   if (auto *unary = getUnlabeledUnaryExpr()) {
-    auto *paren = new (ctx) ParenExpr(SourceLoc(), unary, SourceLoc());
+    auto *paren = new (ctx) ParenExpr(getLParenLoc(), unary, getRParenLoc());
     if (auto ty = getType(unary))
       paren->setType(ParenType::get(ctx, ty));
     paren->setImplicit();
     return paren;
   }
 
-  SmallVector<Expr *, 8> argExprs;
-  SmallVector<Identifier, 8> argLabels;
-  SmallVector<TupleTypeElt, 8> tupleEltTypes;
+  SmallVector<Expr *, 2> argExprs;
+  SmallVector<Identifier, 2> argLabels;
+  SmallVector<SourceLoc, 2> argLabelLocs;
+  SmallVector<TupleTypeElt, 2> tupleEltTypes;
 
   for (auto arg : *this) {
     auto *argExpr = arg.getExpr();
     argExprs.push_back(argExpr);
     argLabels.push_back(arg.getLabel());
+    argLabelLocs.push_back(arg.getLabelLoc());
     if (auto ty = getType(argExpr))
       tupleEltTypes.emplace_back(ty, arg.getLabel());
   }
   assert(tupleEltTypes.empty() || tupleEltTypes.size() == argExprs.size());
 
-  auto *tuple = TupleExpr::createImplicit(ctx, argExprs, argLabels);
+  auto *tuple =
+      TupleExpr::create(ctx, getLParenLoc(), argExprs, argLabels, argLabelLocs,
+                        getRParenLoc(), /*implicit*/ true);
   if (empty() || !tupleEltTypes.empty())
     tuple->setType(TupleType::get(tupleEltTypes, ctx));
 

--- a/test/ModuleInterface/default-args.swift
+++ b/test/ModuleInterface/default-args.swift
@@ -54,3 +54,7 @@ public func hasMagicDefaultArgs(_ f: String = #file, _ fu: String = #function, _
 // CHECK: func hasSimpleDefaultArgs(_ x: Swift.Int = 0, b: Swift.Int = 1)
 public func hasSimpleDefaultArgs(_ x: Int = 0, b: Int = 1) {
 }
+
+// rdar://83202870 (SR-15181): Make sure we can extract the textual representation here.
+// CHECK: func hasTupleConstructionDefaultArgs(_ x: Any = (), y: (Swift.String, Swift.Int) = ("", 0))
+public func hasTupleConstructionDefaultArgs(_ x: Any = Void(), y: (String, Int) = (String, Int)("", 0)) {}


### PR DESCRIPTION
Fix a crash introduced by the ArgumentList refactoring. When type-checking a tuple construction such as `Void()`, make sure to preserve the source info from the argument list in the resulting type-checked TupleExpr `()`. This is needed for serialization to be able to grab the textual representation.

Note that we still need to do more here to fully preserve the entire tuple construction expression in case the destination tuple type has important contextual information such as `(Substring, Substring)("", "")`. I've filed SR-15264 to track that, as I'm not entirely sure whether or not it has compatibility implications. This patch should at least get us back to the behavior prior to the ArgumentList refactoring though.

SR-15181
rdar://83202870