### PR TITLE
[Sema] Make public imports of private modules an error

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2907,7 +2907,7 @@ WARNING(warn_implementation_only_conflict,none,
         (Identifier))
 NOTE(implementation_only_conflict_here,none,
      "imported as implementation-only here", ())
-WARNING(warn_public_import_of_private_module,none,
+ERROR(error_public_import_of_private_module,none,
         "private module %0 is imported publicly from the public module %1",
         (Identifier, Identifier))
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1715,6 +1715,10 @@ public:
            inFlight.fixItInsert(ID->getStartLoc(),
                               "@_implementationOnly ");
         }
+
+        static bool treatAsError = getenv("ENABLE_PUBLIC_IMPORT_OF_PRIVATE_AS_ERROR");
+        if (!treatAsError)
+          inFlight.limitBehavior(DiagnosticBehavior::Warning);
       }
     }
   }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1709,7 +1709,7 @@ public:
 
         auto &diags = ID->getASTContext().Diags;
         InFlightDiagnostic inFlight =
-            diags.diagnose(ID, diag::warn_public_import_of_private_module,
+            diags.diagnose(ID, diag::error_public_import_of_private_module,
                            target->getName(), importer->getName());
         if (ID->getAttrs().isEmpty()) {
            inFlight.fixItInsert(ID->getStartLoc(),

--- a/test/Sema/implementation-only-import-suggestion-as-error.swift
+++ b/test/Sema/implementation-only-import-suggestion-as-error.swift
@@ -1,0 +1,28 @@
+/// Same test as implementation-only-import-suggestion upgrading warnings to
+/// errors. We can remove this test when this becomes the default behavior.
+
+// RUN: %empty-directory(%t)
+// REQUIRES: VENDOR=apple
+
+/// Prepare the SDK.
+// RUN: cp -r %S/Inputs/public-private-sdk %t/sdk
+// RUN: %target-swift-frontend -emit-module -module-name PublicSwift \
+// RUN:   %t/sdk/System/Library/Frameworks/PublicSwift.framework/Modules/PublicSwift.swiftmodule/source.swift \
+// RUN:   -o %t/sdk/System/Library/Frameworks/PublicSwift.framework/Modules/PublicSwift.swiftmodule/%target-swiftmodule-name
+// RUN: %target-swift-frontend -emit-module -module-name PrivateSwift \
+// RUN:   %t/sdk/System/Library/PrivateFrameworks/PrivateSwift.framework/Modules/PrivateSwift.swiftmodule/source.swift \
+// RUN:   -o %t/sdk/System/Library/PrivateFrameworks/PrivateSwift.framework/Modules/PrivateSwift.swiftmodule/%target-swiftmodule-name
+
+/// Expect errors when building a public client.
+// RUN: env ENABLE_PUBLIC_IMPORT_OF_PRIVATE_AS_ERROR=1 \
+// RUN:    %target-swift-frontend -typecheck -sdk %t/sdk -module-cache-path %t %s \
+// RUN:   -F %t/sdk/System/Library/PrivateFrameworks/ \
+// RUN:   -library-level api -verify
+
+import PublicSwift
+import PrivateSwift // expected-error{{private module 'PrivateSwift' is imported publicly from the public module 'main'}}
+
+import PublicClang
+import PublicClang_Private // expected-error{{private module 'PublicClang_Private' is imported publicly from the public module 'main'}}
+import FullyPrivateClang // expected-error{{private module 'FullyPrivateClang' is imported publicly from the public module 'main'}}
+import main // expected-warning{{'implementation-only-import-suggestion-as-error.swift' is part of module 'main'; ignoring import}}

--- a/test/Sema/implementation-only-import-suggestion.swift
+++ b/test/Sema/implementation-only-import-suggestion.swift
@@ -34,11 +34,11 @@
 // RUN:   -library-level other -D PUBLIC_IMPORTS
 #if PUBLIC_IMPORTS
 import PublicSwift
-import PrivateSwift // expected-error{{private module 'PrivateSwift' is imported publicly from the public module 'main'}}
+import PrivateSwift // expected-warning{{private module 'PrivateSwift' is imported publicly from the public module 'main'}}
 
 import PublicClang
-import PublicClang_Private // expected-error{{private module 'PublicClang_Private' is imported publicly from the public module 'main'}}
-import FullyPrivateClang // expected-error{{private module 'FullyPrivateClang' is imported publicly from the public module 'main'}}
+import PublicClang_Private // expected-warning{{private module 'PublicClang_Private' is imported publicly from the public module 'main'}}
+import FullyPrivateClang // expected-warning{{private module 'FullyPrivateClang' is imported publicly from the public module 'main'}}
 import main // expected-warning{{'implementation-only-import-suggestion.swift' is part of module 'main'; ignoring import}}
 
 /// Expect no warnings with implementation-only imports.

--- a/test/Sema/implementation-only-import-suggestion.swift
+++ b/test/Sema/implementation-only-import-suggestion.swift
@@ -34,11 +34,11 @@
 // RUN:   -library-level other -D PUBLIC_IMPORTS
 #if PUBLIC_IMPORTS
 import PublicSwift
-import PrivateSwift // expected-warning{{private module 'PrivateSwift' is imported publicly from the public module 'main'}}
+import PrivateSwift // expected-error{{private module 'PrivateSwift' is imported publicly from the public module 'main'}}
 
 import PublicClang
-import PublicClang_Private // expected-warning{{private module 'PublicClang_Private' is imported publicly from the public module 'main'}}
-import FullyPrivateClang // expected-warning{{private module 'FullyPrivateClang' is imported publicly from the public module 'main'}}
+import PublicClang_Private // expected-error{{private module 'PublicClang_Private' is imported publicly from the public module 'main'}}
+import FullyPrivateClang // expected-error{{private module 'FullyPrivateClang' is imported publicly from the public module 'main'}}
 import main // expected-warning{{'implementation-only-import-suggestion.swift' is part of module 'main'; ignoring import}}
 
 /// Expect no warnings with implementation-only imports.


### PR DESCRIPTION
Now that library-level and its inference should be more widely available, one of the next steps is to turn the warning about public imports of private modules into an error.

rdar://83731983