### PR TITLE
SE-0333: Expand usability of `withMemoryRebound`

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -749,19 +749,7 @@ extension Unsafe${Mutable}BufferPointer {
     to type: T.Type,
     _ body: (${Self}<T>) throws -> Result
   ) rethrows -> Result {
-    if let base = _position {
-      _debugPrecondition(MemoryLayout<Element>.stride == MemoryLayout<T>.stride)
-      Builtin.bindMemory(base._rawValue, count._builtinWordValue, T.self)
-      defer {
-        Builtin.bindMemory(base._rawValue, count._builtinWordValue, Element.self)
-      }
-
-      return try body(${Self}<T>(
-        start: Unsafe${Mutable}Pointer<T>(base._rawValue), count: count))
-    }
-    else {
-      return try body(${Self}<T>(start: nil, count: 0))
-    }
+    return try withMemoryRebound(to: T.self, body)
   }
 
   /// A pointer to the first element of the buffer.

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -654,8 +654,16 @@ extension Unsafe${Mutable}BufferPointer {
   /// the same memory as an unrelated type without first rebinding the memory
   /// is undefined.
   ///
-  /// The entire region of memory referenced by this buffer must be initialized.
+  /// The number of instances of `T` referenced by the rebound buffer may be
+  /// different than the number of instances of `Element` referenced by the
+  /// original buffer. The number of instances of `T` will be calculated
+  /// at runtime.
   /// 
+  /// Any instance of `T` within the re-bound region may be initialized or
+  /// uninitialized. If a given instance of `T` overlaps with memory previously
+  /// bound to an uninitialized `Pointee`, it shall be considered uninitialized
+  /// when executing `body`.
+  ///
   /// Because this buffer's memory is no longer bound to its `Element` type
   /// while the `body` closure executes, do not access memory using the
   /// original buffer from within `body`. Instead, use the `body` closure's
@@ -666,39 +674,57 @@ extension Unsafe${Mutable}BufferPointer {
   /// `Element` type.
   ///
   /// - Note: Only use this method to rebind the buffer's memory to a type
-  ///   with the same size and stride as the currently bound `Element` type.
-  ///   To bind a region of memory to a type that is a different size, convert
-  ///   the buffer to a raw buffer and use the `bindMemory(to:)` method.
+  ///   that is layout compatible with the currently bound `Element` type.
+  ///   The stride of the temporary type (`T`) may be an integer multiple
+  ///   or a whole fraction of `Element`'s stride.
+  ///   To bind a region of memory to a type that does not match these
+  ///   requirements, convert the buffer to a raw buffer and use the
+  ///   `bindMemory(to:)` method.
+  ///   If `T` and `Element` have different alignments, this buffer's
+  ///   `baseAddress` must be aligned with the larger of the two alignments.
   ///
   /// - Parameters:
   ///   - type: The type to temporarily bind the memory referenced by this
-  ///     buffer. The type `T` must have the same size and be layout compatible
+  ///     buffer. The type `T` must be layout compatible
   ///     with the pointer's `Element` type.
   ///   - body: A closure that takes a ${Mutable.lower()} typed buffer to the
-  ///     same memory as this buffer, only bound to type `T`. The buffer argument 
-  ///     contains the same number of complete instances of `T` as the original  
-  ///     buffer’s `count`. The closure's buffer argument is valid only for the 
-  ///     duration of the closure's execution. If `body` has a return value, that 
-  ///     value is also used as the return value for the `withMemoryRebound(to:_:)` 
+  ///     same memory as this buffer, only bound to type `T`. The buffer
+  ///     parameter contains a number of complete instances of `T` based
+  ///     on the capacity of the original buffer and the stride of `Element`.
+  ///     The closure's buffer argument is valid only for the duration of the
+  ///     closure's execution. If `body` has a return value, that value
+  ///     is also used as the return value for the `withMemoryRebound(to:_:)`
   ///     method.
+  ///   - buffer: The buffer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable // unsafe-performance
+  @_alwaysEmitIntoClient
   public func withMemoryRebound<T, Result>(
-    to type: T.Type, _ body: (${Self}<T>) throws -> Result
+    to type: T.Type,
+    _ body: (_ buffer: ${Self}<T>) throws -> Result
   ) rethrows -> Result {
-    if let base = _position {
-      _debugPrecondition(MemoryLayout<Element>.stride == MemoryLayout<T>.stride)
-      Builtin.bindMemory(base._rawValue, count._builtinWordValue, T.self)
-      defer {
-        Builtin.bindMemory(base._rawValue, count._builtinWordValue, Element.self)
-      }
+    guard let base = _position?._rawValue else {
+      return try body(.init(start: nil, count: 0))
+    }
 
-      return try body(${Self}<T>(
-        start: Unsafe${Mutable}Pointer<T>(base._rawValue), count: count))
+    let newCount: Int
+    if MemoryLayout<T>.stride == MemoryLayout<Element>.stride {
+      newCount = count
+      _debugPrecondition(
+        MemoryLayout<T>.alignment == MemoryLayout<Element>.alignment
+      )
+    } else {
+      newCount = count * MemoryLayout<Element>.stride / MemoryLayout<T>.stride
+      _debugPrecondition(
+        Int(bitPattern: .init(base)) & (MemoryLayout<T>.alignment-1) == 0 &&
+        MemoryLayout<T>.stride > MemoryLayout<Element>.stride
+        ? MemoryLayout<T>.stride % MemoryLayout<Element>.stride == 0
+        : MemoryLayout<Element>.stride % MemoryLayout<T>.stride == 0
+      )
     }
-    else {
-      return try body(${Self}<T>(start: nil, count: 0))
-    }
+    let binding = Builtin.bindMemory(base, newCount._builtinWordValue, T.self)
+    defer { Builtin.rebindMemory(base, binding) }
+    return try body(.init(start: .init(base), count: newCount))
   }
 
   /// A pointer to the first element of the buffer.

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -744,8 +744,10 @@ extension Unsafe${Mutable}BufferPointer {
 % else:
   @_silgen_name("$sSR17withMemoryRebound2to_qd_0_qd__m_qd_0_SRyqd__GKXEtKr0_lF")
 % end
-  public func _legacy_se0333_withMemoryRebound<T, Result>(
-    to type: T.Type, _ body: (${Self}<T>) throws -> Result
+  @usableFromInline
+  internal func _legacy_se0333_withMemoryRebound<T, Result>(
+    to type: T.Type,
+    _ body: (${Self}<T>) throws -> Result
   ) rethrows -> Result {
     if let base = _position {
       _debugPrecondition(MemoryLayout<Element>.stride == MemoryLayout<T>.stride)

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -660,9 +660,11 @@ extension Unsafe${Mutable}BufferPointer {
   /// at runtime.
   /// 
   /// Any instance of `T` within the re-bound region may be initialized or
-  /// uninitialized. If a given instance of `T` overlaps with memory previously
-  /// bound to an uninitialized `Pointee`, it shall be considered uninitialized
-  /// when executing `body`.
+  /// uninitialized. Every instance of `Pointee` overlapping with a given
+  /// instance of `T` should have the same initialization state (i.e.
+  /// initialized or uninitialized.) Accessing a `T` whose underlying
+  /// `Pointee` storage is in a mixed initialization state shall be
+  /// undefined behaviour.
   ///
   /// Because this buffer's memory is no longer bound to its `Element` type
   /// while the `body` closure executes, do not access memory using the

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -699,6 +699,12 @@ extension Unsafe${Mutable}BufferPointer {
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable // unsafe-performance
   @_alwaysEmitIntoClient
+  // This custom silgen name is chosen to not interfere with the old ABI
+% if Mutable:
+  @_silgen_name("$_swift_se0333_UnsafeMutableBufferPointer_withMemoryRebound")
+% else:
+  @_silgen_name("$_swift_se0333_UnsafeBufferPointer_withMemoryRebound")
+% end
   public func withMemoryRebound<T, Result>(
     to type: T.Type,
     _ body: (_ buffer: ${Self}<T>) throws -> Result
@@ -725,6 +731,33 @@ extension Unsafe${Mutable}BufferPointer {
     let binding = Builtin.bindMemory(base, newCount._builtinWordValue, T.self)
     defer { Builtin.rebindMemory(base, binding) }
     return try body(.init(start: .init(base), count: newCount))
+  }
+
+  // This unavailable implementation uses the expected mangled name
+  // of `withMemoryRebound`, and provides an entry point for any
+  // binary compiled against the stlib binary for Swift 5.6 and older.
+  @available(*, unavailable)
+% if Mutable:
+  @_silgen_name("$sSr17withMemoryRebound2to_qd_0_qd__m_qd_0_Sryqd__GKXEtKr0_lF")
+% else:
+  @_silgen_name("$sSR17withMemoryRebound2to_qd_0_qd__m_qd_0_SRyqd__GKXEtKr0_lF")
+% end
+  public func _legacy_se0333_withMemoryRebound<T, Result>(
+    to type: T.Type, _ body: (${Self}<T>) throws -> Result
+  ) rethrows -> Result {
+    if let base = _position {
+      _debugPrecondition(MemoryLayout<Element>.stride == MemoryLayout<T>.stride)
+      Builtin.bindMemory(base._rawValue, count._builtinWordValue, T.self)
+      defer {
+        Builtin.bindMemory(base._rawValue, count._builtinWordValue, Element.self)
+      }
+
+      return try body(${Self}<T>(
+        start: Unsafe${Mutable}Pointer<T>(base._rawValue), count: count))
+    }
+    else {
+      return try body(${Self}<T>(start: nil, count: 0))
+    }
   }
 
   /// A pointer to the first element of the buffer.

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -266,8 +266,9 @@ public struct UnsafePointer<Pointee>: _Pointer {
   /// pointer to `Int64`, then accesses a property on the signed integer.
   ///
   ///     let uint64Pointer: UnsafePointer<UInt64> = fetchValue()
-  ///     let isNegative = uint64Pointer.withMemoryRebound(to: Int64.self,
-  ///                                                      capacity: 1) {
+  ///     let isNegative = uint64Pointer.withMemoryRebound(
+  ///         to: Int64.self, capacity: 1
+  ///     ) {
   ///         return $0.pointee < 0
   ///     }
   ///
@@ -308,7 +309,8 @@ public struct UnsafePointer<Pointee>: _Pointer {
   // This custom silgen name is chosen to not interfere with the old ABI
   @_silgen_name("_swift_se0333_UnsafePointer_withMemoryRebound")
   public func withMemoryRebound<T, Result>(
-    to type: T.Type, capacity count: Int,
+    to type: T.Type,
+    capacity count: Int,
     _ body: (_ pointer: UnsafePointer<T>) throws -> Result
   ) rethrows -> Result {
     _debugPrecondition(
@@ -952,8 +954,8 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
   /// pointer to `Int64`, then modifies the signed integer.
   ///
   ///     let uint64Pointer: UnsafeMutablePointer<UInt64> = fetchValue()
-  ///     uint64Pointer.withMemoryRebound(to: Int64.self, capacity: 1) { ptr in
-  ///         ptr.pointee.negate()
+  ///     uint64Pointer.withMemoryRebound(to: Int64.self, capacity: 1) {
+  ///         $0.pointee.negate()
   ///     }
   ///
   /// Because this pointer's memory is no longer bound to its `Pointee` type
@@ -993,7 +995,8 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
   // This custom silgen name is chosen to not interfere with the old ABI
   @_silgen_name("$_swift_se0333_UnsafeMutablePointer_withMemoryRebound")
   public func withMemoryRebound<T, Result>(
-    to type: T.Type, capacity count: Int,
+    to type: T.Type,
+    capacity count: Int,
     _ body: (_ pointer: UnsafeMutablePointer<T>) throws -> Result
   ) rethrows -> Result {
     _debugPrecondition(

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -303,6 +303,8 @@ public struct UnsafePointer<Pointee>: _Pointer {
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable
   @_alwaysEmitIntoClient
+  // This custom silgen name is chosen to not interfere with the old ABI
+  @_silgen_name("_swift_se0333_UnsafePointer_withMemoryRebound")
   public func withMemoryRebound<T, Result>(
     to type: T.Type, capacity count: Int,
     _ body: (_ pointer: UnsafePointer<T>) throws -> Result
@@ -315,6 +317,21 @@ public struct UnsafePointer<Pointee>: _Pointer {
     )
     let binding = Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
     defer { Builtin.rebindMemory(_rawValue, binding) }
+    return try body(.init(_rawValue))
+  }
+
+  // This unavailable implementation uses the expected mangled name
+  // of `withMemoryRebound`, and provides an entry point for any
+  // binary compiled against the stlib binary for Swift 5.6 and older.
+  @available(*, unavailable)
+  @_silgen_name("$sSP17withMemoryRebound2to8capacity_qd_0_qd__m_Siqd_0_SPyqd__GKXEtKr0_lF")
+  public func _legacy_se0333_withMemoryRebound<T, Result>(to type: T.Type, capacity count: Int,
+    _ body: (UnsafePointer<T>) throws -> Result
+  ) rethrows -> Result {
+    Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
+    defer {
+      Builtin.bindMemory(_rawValue, count._builtinWordValue, Pointee.self)
+    }
     return try body(.init(_rawValue))
   }
 
@@ -970,6 +987,8 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable
   @_alwaysEmitIntoClient
+  // This custom silgen name is chosen to not interfere with the old ABI
+  @_silgen_name("$_swift_se0333_UnsafeMutablePointer_withMemoryRebound")
   public func withMemoryRebound<T, Result>(
     to type: T.Type, capacity count: Int,
     _ body: (_ pointer: UnsafeMutablePointer<T>) throws -> Result
@@ -982,6 +1001,21 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
     )
     let binding = Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
     defer { Builtin.rebindMemory(_rawValue, binding) }
+    return try body(.init(_rawValue))
+  }
+
+  // This unavailable implementation uses the expected mangled name
+  // of `withMemoryRebound`, and provides an entry point for any
+  // binary compiled against the stlib binary for Swift 5.6 and older.
+  @available(*, unavailable)
+  @_silgen_name("$sSp17withMemoryRebound2to8capacity_qd_0_qd__m_Siqd_0_Spyqd__GKXEtKr0_lF")
+  public func _legacy_se0333_withMemoryRebound<T, Result>(to type: T.Type, capacity count: Int,
+    _ body: (UnsafeMutablePointer<T>) throws -> Result
+  ) rethrows -> Result {
+    Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
+    defer {
+      Builtin.bindMemory(_rawValue, count._builtinWordValue, Pointee.self)
+    }
     return try body(.init(_rawValue))
   }
 

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -243,8 +243,8 @@ public struct UnsafePointer<Pointee>: _Pointer {
     }
   }
 
-  /// Executes the given closure while temporarily binding the specified number
-  /// of instances to the given type.
+  /// Executes the given closure while temporarily binding memory to
+  /// the specified number of instances of type `T`.
   ///
   /// Use this method when you have a pointer to memory bound to one type and
   /// you need to access that memory as instances of another type. Accessing
@@ -253,15 +253,20 @@ public struct UnsafePointer<Pointee>: _Pointer {
   /// the same memory as an unrelated type without first rebinding the memory
   /// is undefined.
   ///
-  /// The region of memory starting at this pointer and covering `count`
-  /// instances of the pointer's `Pointee` type must be initialized.
+  /// The region of memory that starts at this pointer and covers `count`
+  /// strides of `T` instances must be bound to `Pointee`.
+  /// Any instance of `T` within the re-bound region may be initialized or
+  /// uninitialized. If a given instance of `T` overlaps with memory previously
+  /// bound to an uninitialized `Pointee`, it shall be considered uninitialized
+  /// when executing `body`.
   ///
   /// The following example temporarily rebinds the memory of a `UInt64`
   /// pointer to `Int64`, then accesses a property on the signed integer.
   ///
   ///     let uint64Pointer: UnsafePointer<UInt64> = fetchValue()
-  ///     let isNegative = uint64Pointer.withMemoryRebound(to: Int64.self, capacity: 1) { ptr in
-  ///         return ptr.pointee < 0
+  ///     let isNegative = uint64Pointer.withMemoryRebound(to: Int64.self,
+  ///                                                      capacity: 1) {
+  ///         return $0.pointee < 0
   ///     }
   ///
   /// Because this pointer's memory is no longer bound to its `Pointee` type
@@ -274,31 +279,43 @@ public struct UnsafePointer<Pointee>: _Pointer {
   /// `Pointee` type.
   ///
   /// - Note: Only use this method to rebind the pointer's memory to a type
-  ///   with the same size and stride as the currently bound `Pointee` type.
-  ///   To bind a region of memory to a type that is a different size, convert
-  ///   the pointer to a raw pointer and use the `bindMemory(to:capacity:)`
-  ///   method.
+  ///   that is layout compatible with the `Pointee` type. The stride of the
+  ///   temporary type (`T`) may be an integer multiple or a whole fraction
+  ///   of `Pointee`'s stride, for example to point to one element of
+  ///   an aggregate.
+  ///   To bind a region of memory to a type that does not match these
+  ///   requirements, convert the pointer to a raw pointer and use the
+  ///   `bindMemory(to:)` method.
+  ///   If `T` and `Pointee` have different alignments, this pointer
+  ///   must be aligned with the larger of the two alignments.
   ///
   /// - Parameters:
   ///   - type: The type to temporarily bind the memory referenced by this
-  ///     pointer. The type `T` must be the same size and be layout compatible
+  ///     pointer. The type `T` must be layout compatible
   ///     with the pointer's `Pointee` type.
-  ///   - count: The number of instances of `Pointee` to bind to `type`.
-  ///   - body: A closure that takes a  typed pointer to the
+  ///   - count: The number of instances of `T` in the re-bound region.
+  ///   - body: A closure that takes a typed pointer to the
   ///     same memory as this pointer, only bound to type `T`. The closure's
   ///     pointer argument is valid only for the duration of the closure's
   ///     execution. If `body` has a return value, that value is also used as
   ///     the return value for the `withMemoryRebound(to:capacity:_:)` method.
+  ///   - pointer: The pointer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable
-  public func withMemoryRebound<T, Result>(to type: T.Type, capacity count: Int,
-    _ body: (UnsafePointer<T>) throws -> Result
+  @_alwaysEmitIntoClient
+  public func withMemoryRebound<T, Result>(
+    to type: T.Type, capacity count: Int,
+    _ body: (_ pointer: UnsafePointer<T>) throws -> Result
   ) rethrows -> Result {
-    Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
-    defer {
-      Builtin.bindMemory(_rawValue, count._builtinWordValue, Pointee.self)
-    }
-    return try body(UnsafePointer<T>(_rawValue))
+    _debugPrecondition(
+      Int(bitPattern: .init(_rawValue)) & (MemoryLayout<T>.alignment-1) == 0 &&
+      MemoryLayout<Pointee>.stride > MemoryLayout<T>.stride
+      ? MemoryLayout<Pointee>.stride % MemoryLayout<T>.stride == 0
+      : MemoryLayout<T>.stride % MemoryLayout<Pointee>.stride == 0
+    )
+    let binding = Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
+    defer { Builtin.rebindMemory(_rawValue, binding) }
+    return try body(.init(_rawValue))
   }
 
   /// Accesses the pointee at the specified offset from this pointer.
@@ -894,8 +911,8 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
     return UnsafeMutableRawPointer(self)
   }
 
-  /// Executes the given closure while temporarily binding the specified number
-  /// of instances to the given type.
+  /// Executes the given closure while temporarily binding memory to
+  /// the specified number of instances of the given type.
   ///
   /// Use this method when you have a pointer to memory bound to one type and
   /// you need to access that memory as instances of another type. Accessing
@@ -904,15 +921,19 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
   /// the same memory as an unrelated type without first rebinding the memory
   /// is undefined.
   ///
-  /// The region of memory starting at this pointer and covering `count`
-  /// instances of the pointer's `Pointee` type must be initialized.
+  /// The region of memory that starts at this pointer and covers `count`
+  /// strides of `T` instances must be bound to `Pointee`.
+  /// Any instance of `T` within the re-bound region may be initialized or
+  /// uninitialized. If a given instance of `T` overlaps with memory previously
+  /// bound to an uninitialized `Pointee`, it shall be considered uninitialized
+  /// when executing `body`.
   ///
   /// The following example temporarily rebinds the memory of a `UInt64`
-  /// pointer to `Int64`, then accesses a property on the signed integer.
+  /// pointer to `Int64`, then modifies the signed integer.
   ///
   ///     let uint64Pointer: UnsafeMutablePointer<UInt64> = fetchValue()
-  ///     let isNegative = uint64Pointer.withMemoryRebound(to: Int64.self, capacity: 1) { ptr in
-  ///         return ptr.pointee < 0
+  ///     uint64Pointer.withMemoryRebound(to: Int64.self, capacity: 1) { ptr in
+  ///         ptr.pointee.negate()
   ///     }
   ///
   /// Because this pointer's memory is no longer bound to its `Pointee` type
@@ -925,31 +946,43 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
   /// `Pointee` type.
   ///
   /// - Note: Only use this method to rebind the pointer's memory to a type
-  ///   with the same size and stride as the currently bound `Pointee` type.
-  ///   To bind a region of memory to a type that is a different size, convert
-  ///   the pointer to a raw pointer and use the `bindMemory(to:capacity:)`
-  ///   method.
+  ///   that is layout compatible with the `Pointee` type. The stride of the
+  ///   temporary type (`T`) may be an integer multiple or a whole fraction
+  ///   of `Pointee`'s stride, for example to point to one element of
+  ///   an aggregate.
+  ///   To bind a region of memory to a type that does not match these
+  ///   requirements, convert the pointer to a raw pointer and use the
+  ///   `bindMemory(to:)` method.
+  ///   If `T` and `Pointee` have different alignments, this pointer
+  ///   must be aligned with the larger of the two alignments.
   ///
   /// - Parameters:
   ///   - type: The type to temporarily bind the memory referenced by this
-  ///     pointer. The type `T` must be the same size and be layout compatible
+  ///     pointer. The type `T` must be layout compatible
   ///     with the pointer's `Pointee` type.
-  ///   - count: The number of instances of `Pointee` to bind to `type`.
+  ///   - count: The number of instances of `T` in the re-bound region.
   ///   - body: A closure that takes a mutable typed pointer to the
   ///     same memory as this pointer, only bound to type `T`. The closure's
   ///     pointer argument is valid only for the duration of the closure's
   ///     execution. If `body` has a return value, that value is also used as
   ///     the return value for the `withMemoryRebound(to:capacity:_:)` method.
+  ///   - pointer: The pointer temporarily bound to `T`.
   /// - Returns: The return value, if any, of the `body` closure parameter.
   @inlinable
-  public func withMemoryRebound<T, Result>(to type: T.Type, capacity count: Int,
-    _ body: (UnsafeMutablePointer<T>) throws -> Result
+  @_alwaysEmitIntoClient
+  public func withMemoryRebound<T, Result>(
+    to type: T.Type, capacity count: Int,
+    _ body: (_ pointer: UnsafeMutablePointer<T>) throws -> Result
   ) rethrows -> Result {
-    Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
-    defer {
-      Builtin.bindMemory(_rawValue, count._builtinWordValue, Pointee.self)
-    }
-    return try body(UnsafeMutablePointer<T>(_rawValue))
+    _debugPrecondition(
+      Int(bitPattern: .init(_rawValue)) & (MemoryLayout<T>.alignment-1) == 0 &&
+      MemoryLayout<Pointee>.stride > MemoryLayout<T>.stride
+      ? MemoryLayout<Pointee>.stride % MemoryLayout<T>.stride == 0
+      : MemoryLayout<T>.stride % MemoryLayout<Pointee>.stride == 0
+    )
+    let binding = Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
+    defer { Builtin.rebindMemory(_rawValue, binding) }
+    return try body(.init(_rawValue))
   }
 
   /// Accesses the pointee at the specified offset from this pointer.

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -256,9 +256,11 @@ public struct UnsafePointer<Pointee>: _Pointer {
   /// The region of memory that starts at this pointer and covers `count`
   /// strides of `T` instances must be bound to `Pointee`.
   /// Any instance of `T` within the re-bound region may be initialized or
-  /// uninitialized. If a given instance of `T` overlaps with memory previously
-  /// bound to an uninitialized `Pointee`, it shall be considered uninitialized
-  /// when executing `body`.
+  /// uninitialized. Every instance of `Pointee` overlapping with a given
+  /// instance of `T` should have the same initialization state (i.e.
+  /// initialized or uninitialized.) Accessing a `T` whose underlying
+  /// `Pointee` storage is in a mixed initialization state shall be
+  /// undefined behaviour.
   ///
   /// The following example temporarily rebinds the memory of a `UInt64`
   /// pointer to `Int64`, then accesses a property on the signed integer.
@@ -941,9 +943,11 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
   /// The region of memory that starts at this pointer and covers `count`
   /// strides of `T` instances must be bound to `Pointee`.
   /// Any instance of `T` within the re-bound region may be initialized or
-  /// uninitialized. If a given instance of `T` overlaps with memory previously
-  /// bound to an uninitialized `Pointee`, it shall be considered uninitialized
-  /// when executing `body`.
+  /// uninitialized. Every instance of `Pointee` overlapping with a given
+  /// instance of `T` should have the same initialization state (i.e.
+  /// initialized or uninitialized.) Accessing a `T` whose underlying
+  /// `Pointee` storage is in a mixed initialization state shall be
+  /// undefined behaviour.
   ///
   /// The following example temporarily rebinds the memory of a `UInt64`
   /// pointer to `Int64`, then modifies the signed integer.

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -333,11 +333,7 @@ public struct UnsafePointer<Pointee>: _Pointer {
     capacity count: Int,
     _ body: (UnsafePointer<T>) throws -> Result
   ) rethrows -> Result {
-    Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
-    defer {
-      Builtin.bindMemory(_rawValue, count._builtinWordValue, Pointee.self)
-    }
-    return try body(.init(_rawValue))
+    return try withMemoryRebound(to: T.self, capacity: count, body)
   }
 
   /// Accesses the pointee at the specified offset from this pointer.
@@ -1022,11 +1018,7 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
     capacity count: Int,
     _ body: (UnsafeMutablePointer<T>) throws -> Result
   ) rethrows -> Result {
-    Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
-    defer {
-      Builtin.bindMemory(_rawValue, count._builtinWordValue, Pointee.self)
-    }
-    return try body(.init(_rawValue))
+    return try withMemoryRebound(to: T.self, capacity: count, body)
   }
 
   /// Accesses the pointee at the specified offset from this pointer.

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -327,7 +327,10 @@ public struct UnsafePointer<Pointee>: _Pointer {
   // binary compiled against the stlib binary for Swift 5.6 and older.
   @available(*, unavailable)
   @_silgen_name("$sSP17withMemoryRebound2to8capacity_qd_0_qd__m_Siqd_0_SPyqd__GKXEtKr0_lF")
-  public func _legacy_se0333_withMemoryRebound<T, Result>(to type: T.Type, capacity count: Int,
+  @usableFromInline
+  internal func _legacy_se0333_withMemoryRebound<T, Result>(
+    to type: T.Type,
+    capacity count: Int,
     _ body: (UnsafePointer<T>) throws -> Result
   ) rethrows -> Result {
     Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
@@ -1013,7 +1016,10 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
   // binary compiled against the stlib binary for Swift 5.6 and older.
   @available(*, unavailable)
   @_silgen_name("$sSp17withMemoryRebound2to8capacity_qd_0_qd__m_Siqd_0_Spyqd__GKXEtKr0_lF")
-  public func _legacy_se0333_withMemoryRebound<T, Result>(to type: T.Type, capacity count: Int,
+  @usableFromInline
+  internal func _legacy_se0333_withMemoryRebound<T, Result>(
+    to type: T.Type,
+    capacity count: Int,
     _ body: (UnsafeMutablePointer<T>) throws -> Result
   ) rethrows -> Result {
     Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -729,6 +729,61 @@ extension Unsafe${Mutable}RawBufferPointer {
     return Unsafe${Mutable}BufferPointer<T>(
       start: Unsafe${Mutable}Pointer<T>(base._rawValue), count: capacity)
   }
+
+  /// Executes the given closure while temporarily binding the buffer to
+  /// instances of type `T`.
+  ///
+  /// Use this method when you have a buffer to raw memory and you need
+  /// to access that memory as instances of a given type `T`. Accessing
+  /// memory as a type `T` requires that the memory be bound to that type.
+  /// A memory location may only be bound to one type at a time, so accessing
+  /// the same memory as an unrelated type without first rebinding the memory
+  /// is undefined.
+  ///
+  /// Any instance of `T` within the re-bound region may be initialized or
+  /// uninitialized. If a given instance of `T` within the re-bound region
+  /// overlaps with previously uninitialized memory, it shall be considered
+  /// uninitialized when executing `body`.
+  ///
+  /// After executing `body`, this method rebinds memory back to its original
+  /// binding state. This can be unbound memory, or bound to a different type.
+  ///
+  /// - Note: The buffer's base address must match the
+  ///   alignment of `T` (as reported by `MemoryLayout<T>.alignment`).
+  ///   That is, `Int(bitPattern: self.baseAddress) % MemoryLayout<T>.alignment`
+  ///   must equal zero.
+  ///
+  /// - Parameters:
+  ///   - type: The type to temporarily bind the memory referenced by this
+  ///     pointer. This pointer must be a multiple of this type's alignment.
+  ///   - count: The number of instances of `T` to bind to `type`.
+  ///   - body: A closure that takes a typed pointer to the
+  ///     same memory as this pointer, only bound to type `T`. The closure's
+  ///     pointer argument is valid only for the duration of the closure's
+  ///     execution. If `body` has a return value, that value is also used as
+  ///     the return value for the `withMemoryRebound(to:capacity:_:)` method.
+  ///   - buffer: The buffer temporarily bound to instances of `T`.
+  /// - Returns: The return value, if any, of the `body` closure parameter.
+  @inlinable
+  @_alwaysEmitIntoClient
+  public func withMemoryRebound<T, Result>(
+    to type: T.Type,
+    _ body: (_ buffer: Unsafe${Mutable}BufferPointer<T>) throws -> Result
+  ) rethrows -> Result {
+    guard let s = _position else {
+      return try body(.init(start: nil, count: 0))
+    }
+    _debugPrecondition(
+      Int(bitPattern: s) & (MemoryLayout<T>.alignment-1) == 0
+    )
+    // initializer ensures _end is nil only when _position is nil.
+    _internalInvariant(_end != nil)
+    let c = _assumeNonNegative(s.distance(to: _end._unsafelyUnwrappedUnchecked))
+    let n = c / MemoryLayout<T>.stride
+    let binding = Builtin.bindMemory(s._rawValue, n._builtinWordValue, T.self)
+    defer { Builtin.rebindMemory(s._rawValue, binding) }
+    return try body(.init(start: .init(s._rawValue), count: n))
+  }
 }
 
 extension Unsafe${Mutable}RawBufferPointer: CustomDebugStringConvertible {

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -784,6 +784,37 @@ extension Unsafe${Mutable}RawBufferPointer {
     defer { Builtin.rebindMemory(s._rawValue, binding) }
     return try body(.init(start: .init(s._rawValue), count: n))
   }
+
+  /// Returns a typed buffer to the memory referenced by this buffer,
+  /// assuming that the memory is already bound to the specified type.
+  ///
+  /// Use this method when you have a raw buffer to memory that has *already*
+  /// been bound to the specified type. The memory starting at this pointer
+  /// must be bound to the type `T`. Accessing memory through the returned
+  /// pointer is undefined if the memory has not been bound to `T`. To bind
+  /// memory to `T`, use `bindMemory(to:capacity:)` instead of this method.
+  ///
+  /// - Note: The buffer's base address must match the
+  ///   alignment of `T` (as reported by `MemoryLayout<T>.alignment`).
+  ///   That is, `Int(bitPattern: self.baseAddress) % MemoryLayout<T>.alignment`
+  ///   must equal zero.
+  ///
+  /// - Parameter to: The type `T` that the memory has already been bound to.
+  /// - Returns: A typed pointer to the same memory as this raw pointer.
+  @inlinable
+  @_alwaysEmitIntoClient
+  public func assumingMemoryBound<T>(
+    to: T.Type
+  ) -> Unsafe${Mutable}BufferPointer<T> {
+    guard let s = _position else {
+      return .init(start: nil, count: 0)
+    }
+    // initializer ensures _end is nil only when _position is nil.
+    _internalInvariant(_end != nil)
+    let c = _assumeNonNegative(s.distance(to: _end._unsafelyUnwrappedUnchecked))
+    let n = c / MemoryLayout<T>.stride
+    return .init(start: .init(s._rawValue), count: n)
+  }
 }
 
 extension Unsafe${Mutable}RawBufferPointer: CustomDebugStringConvertible {

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -741,9 +741,14 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// is undefined.
   ///
   /// Any instance of `T` within the re-bound region may be initialized or
-  /// uninitialized. If a given instance of `T` within the re-bound region
-  /// overlaps with previously uninitialized memory, it shall be considered
-  /// uninitialized when executing `body`.
+  /// uninitialized. The memory underlying any individual instance of `T`
+  /// must have the same initialization state (i.e.  initialized or
+  /// uninitialized.) Accessing a `T` whose underlying memory
+  /// is in a mixed initialization state shall be undefined behaviour.
+  ///
+  /// If the byte count of the original buffer is not a multiple of
+  /// the stride of `T`, then the re-bound buffer is shorter
+  /// than the original buffer.
   ///
   /// After executing `body`, this method rebinds memory back to its original
   /// binding state. This can be unbound memory, or bound to a different type.
@@ -753,10 +758,15 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///   That is, `Int(bitPattern: self.baseAddress) % MemoryLayout<T>.alignment`
   ///   must equal zero.
   ///
+  /// - Note: A raw buffer may represent memory that has been bound to a type.
+  ///   If that is the case, then `T` must be layout compatible with the
+  ///   type to which the memory has been bound. This requirement does not
+  ///   apply if the raw buffer represents memory that has not been bound
+  ///   to any type.
+  ///
   /// - Parameters:
   ///   - type: The type to temporarily bind the memory referenced by this
   ///     pointer. This pointer must be a multiple of this type's alignment.
-  ///   - count: The number of instances of `T` to bind to `type`.
   ///   - body: A closure that takes a typed pointer to the
   ///     same memory as this pointer, only bound to type `T`. The closure's
   ///     pointer argument is valid only for the duration of the closure's
@@ -788,7 +798,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// Returns a typed buffer to the memory referenced by this buffer,
   /// assuming that the memory is already bound to the specified type.
   ///
-  /// Use this method when you have a raw buffer to memory that has *already*
+  /// Use this method when you have a raw buffer to memory that has already
   /// been bound to the specified type. The memory starting at this pointer
   /// must be bound to the type `T`. Accessing memory through the returned
   /// pointer is undefined if the memory has not been bound to `T`. To bind

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -319,6 +319,64 @@ public struct UnsafeRawPointer: _Pointer {
     return UnsafePointer<T>(_rawValue)
   }
 
+  /// Executes the given closure while temporarily binding memory to
+  /// the specified number of instances of type `T`.
+  ///
+  /// Use this method when you have a pointer to raw memory and you need
+  /// to access that memory as instances of a given type `T`. Accessing
+  /// memory as a type `T` requires that the memory be bound to that type. A
+  /// memory location may only be bound to one type at a time, so accessing
+  /// the same memory as an unrelated type without first rebinding the memory
+  /// is undefined.
+  ///
+  /// Any instance of `T` within the re-bound region may be initialized or
+  /// uninitialized. If a given instance of `T` within the re-bound region
+  /// overlaps with previously uninitialized memory, it shall be considered
+  /// uninitialized when executing `body`.
+  ///
+  /// The following example temporarily rebinds a raw memory pointer
+  /// to `Int64`, then accesses a property on the signed integer.
+  ///
+  ///     let pointer: UnsafeRawPointer = fetchValue()
+  ///     let isNegative = pointer.withMemoryRebound(to: Int64.self,
+  ///                                                capacity: 1) {
+  ///         return $0.pointee < 0
+  ///     }
+  ///
+  /// After executing `body`, this method rebinds memory back to its original
+  /// binding state. This can be unbound memory, or bound to a different type.
+  ///
+  /// - Note: The region of memory starting at this pointer must match the
+  ///   alignment of `T` (as reported by `MemoryLayout<T>.alignment`).
+  ///   That is, `Int(bitPattern: self) % MemoryLayout<T>.alignment`
+  ///   must equal zero.
+  ///
+  /// - Parameters:
+  ///   - type: The type to temporarily bind the memory referenced by this
+  ///     pointer. This pointer must be a multiple of this type's alignment.
+  ///   - count: The number of instances of `T` in the re-bound region.
+  ///   - body: A closure that takes a typed pointer to the
+  ///     same memory as this pointer, only bound to type `T`. The closure's
+  ///     pointer argument is valid only for the duration of the closure's
+  ///     execution. If `body` has a return value, that value is also used as
+  ///     the return value for the `withMemoryRebound(to:capacity:_:)` method.
+  ///   - pointer: The pointer temporarily bound to `T`.
+  /// - Returns: The return value, if any, of the `body` closure parameter.
+  @inlinable
+  @_alwaysEmitIntoClient
+  public func withMemoryRebound<T, Result>(
+    to type: T.Type,
+    capacity count: Int,
+    _ body: (_ pointer: UnsafePointer<T>) throws -> Result
+  ) rethrows -> Result {
+    _debugPrecondition(
+      Int(bitPattern: self) & (MemoryLayout<T>.alignment-1) == 0
+    )
+    let binding = Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
+    defer { Builtin.rebindMemory(_rawValue, binding) }
+    return try body(.init(_rawValue))
+  }
+
   /// Returns a typed pointer to the memory referenced by this pointer,
   /// assuming that the memory is already bound to the specified type.
   ///
@@ -692,6 +750,63 @@ public struct UnsafeMutableRawPointer: _Pointer {
   ) -> UnsafeMutablePointer<T> {
     Builtin.bindMemory(_rawValue, count._builtinWordValue, type)
     return UnsafeMutablePointer<T>(_rawValue)
+  }
+
+  /// Executes the given closure while temporarily binding memory to
+  /// the specified number of instances of type `T`.
+  ///
+  /// Use this method when you have a pointer to raw memory and you need
+  /// to access that memory as instances of a given type `T`. Accessing
+  /// memory as a type `T` requires that the memory be bound to that type. A
+  /// memory location may only be bound to one type at a time, so accessing
+  /// the same memory as an unrelated type without first rebinding the memory
+  /// is undefined.
+  ///
+  /// Any instance of `T` within the re-bound region may be initialized or
+  /// uninitialized. If a given instance of `T` within the re-bound region
+  /// overlaps with previously uninitialized memory, it shall be considered
+  /// uninitialized when executing `body`.
+  ///
+  /// The following example temporarily rebinds a raw memory pointer
+  /// to `Int64`, then modifies the signed integer.
+  ///
+  ///     let pointer: UnsafeMutableRawPointer = fetchValue()
+  ///     pointer.withMemoryRebound(to: Int64.self, capacity: 1) {
+  ///         ptr.pointee.negate()
+  ///     }
+  ///
+  /// After executing `body`, this method rebinds memory back to its original
+  /// binding state. This can be unbound memory, or bound to a different type.
+  ///
+  /// - Note: The region of memory starting at this pointer must match the
+  ///   alignment of `T` (as reported by `MemoryLayout<T>.alignment`).
+  ///   That is, `Int(bitPattern: self) % MemoryLayout<T>.alignment`
+  ///   must equal zero.
+  ///
+  /// - Parameters:
+  ///   - type: The type to temporarily bind the memory referenced by this
+  ///     pointer. This pointer must be a multiple of this type's alignment.
+  ///   - count: The number of instances of `T` in the re-bound region.
+  ///   - body: A closure that takes a typed pointer to the
+  ///     same memory as this pointer, only bound to type `T`. The closure's
+  ///     pointer argument is valid only for the duration of the closure's
+  ///     execution. If `body` has a return value, that value is also used as
+  ///     the return value for the `withMemoryRebound(to:capacity:_:)` method.
+  ///   - pointer: The pointer temporarily bound to `T`.
+  /// - Returns: The return value, if any, of the `body` closure parameter.
+  @inlinable
+  @_alwaysEmitIntoClient
+  public func withMemoryRebound<T, Result>(
+    to type: T.Type,
+    capacity count: Int,
+    _ body: (_ pointer: UnsafeMutablePointer<T>) throws -> Result
+  ) rethrows -> Result {
+    _debugPrecondition(
+      Int(bitPattern: self) & (MemoryLayout<T>.alignment-1) == 0
+    )
+    let binding = Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
+    defer { Builtin.rebindMemory(_rawValue, binding) }
+    return try body(.init(_rawValue))
   }
 
   /// Returns a typed pointer to the memory referenced by this pointer,

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -330,9 +330,10 @@ public struct UnsafeRawPointer: _Pointer {
   /// is undefined.
   ///
   /// Any instance of `T` within the re-bound region may be initialized or
-  /// uninitialized. If a given instance of `T` within the re-bound region
-  /// overlaps with previously uninitialized memory, it shall be considered
-  /// uninitialized when executing `body`.
+  /// uninitialized. The memory underlying any individual instance of `T`
+  /// must have the same initialization state (i.e.  initialized or
+  /// uninitialized.) Accessing a `T` whose underlying memory
+  /// is in a mixed initialization state shall be undefined behaviour.
   ///
   /// The following example temporarily rebinds a raw memory pointer
   /// to `Int64`, then accesses a property on the signed integer.
@@ -350,6 +351,12 @@ public struct UnsafeRawPointer: _Pointer {
   ///   alignment of `T` (as reported by `MemoryLayout<T>.alignment`).
   ///   That is, `Int(bitPattern: self) % MemoryLayout<T>.alignment`
   ///   must equal zero.
+  ///
+  /// - Note: The region of memory starting at this pointer may have been
+  ///   bound to a type. If that is the case, then `T` must be
+  ///   layout compatible with the type to which the memory has been bound.
+  ///   This requirement does not apply if the region of memory
+  ///   has not been bound to any type.
   ///
   /// - Parameters:
   ///   - type: The type to temporarily bind the memory referenced by this
@@ -763,9 +770,10 @@ public struct UnsafeMutableRawPointer: _Pointer {
   /// is undefined.
   ///
   /// Any instance of `T` within the re-bound region may be initialized or
-  /// uninitialized. If a given instance of `T` within the re-bound region
-  /// overlaps with previously uninitialized memory, it shall be considered
-  /// uninitialized when executing `body`.
+  /// uninitialized. The memory underlying any individual instance of `T`
+  /// must have the same initialization state (i.e.  initialized or
+  /// uninitialized.) Accessing a `T` whose underlying memory
+  /// is in a mixed initialization state shall be undefined behaviour.
   ///
   /// The following example temporarily rebinds a raw memory pointer
   /// to `Int64`, then modifies the signed integer.
@@ -782,6 +790,12 @@ public struct UnsafeMutableRawPointer: _Pointer {
   ///   alignment of `T` (as reported by `MemoryLayout<T>.alignment`).
   ///   That is, `Int(bitPattern: self) % MemoryLayout<T>.alignment`
   ///   must equal zero.
+  ///
+  /// - Note: The region of memory starting at this pointer may have been
+  ///   bound to a type. If that is the case, then `T` must be
+  ///   layout compatible with the type to which the memory has been bound.
+  ///   This requirement does not apply if the region of memory
+  ///   has not been bound to any type.
   ///
   /// - Parameters:
   ///   - type: The type to temporarily bind the memory referenced by this

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -339,8 +339,9 @@ public struct UnsafeRawPointer: _Pointer {
   /// to `Int64`, then accesses a property on the signed integer.
   ///
   ///     let pointer: UnsafeRawPointer = fetchValue()
-  ///     let isNegative = pointer.withMemoryRebound(to: Int64.self,
-  ///                                                capacity: 1) {
+  ///     let isNegative = pointer.withMemoryRebound(
+  ///         to: Int64.self, capacity: 1
+  ///     ) {
   ///         return $0.pointee < 0
   ///     }
   ///
@@ -780,7 +781,7 @@ public struct UnsafeMutableRawPointer: _Pointer {
   ///
   ///     let pointer: UnsafeMutableRawPointer = fetchValue()
   ///     pointer.withMemoryRebound(to: Int64.self, capacity: 1) {
-  ///         ptr.pointee.negate()
+  ///         $0.pointee.negate()
   ///     }
   ///
   /// After executing `body`, this method rebinds memory back to its original

--- a/test/api-digester/stability-stdlib-abi-with-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-with-asserts.test
@@ -64,4 +64,14 @@ Func _COWChecksEnabled() is a new API without @available attribute
 Func _swift_isImmutableCOWBuffer(_:) is a new API without @available attribute
 Func _swift_setImmutableCOWBuffer(_:_:) is a new API without @available attribute
 
+// These haven't actually been removed; they were replaced with @_alwaysEmitIntoClient
+// alternatives. The old silgen-name entry point was preserved under an alternative
+// source-level name. This causes a false positive with the ABI checker.
+// The symbols are still present at the ABI level. The symbols are also still present
+// at the source level. The association between them is simply no longer straightforward.
+Func UnsafeBufferPointer.withMemoryRebound(to:_:) has been removed
+Func UnsafeMutableBufferPointer.withMemoryRebound(to:_:) has been removed
+Func UnsafeMutablePointer.withMemoryRebound(to:capacity:_:) has been removed
+Func UnsafePointer.withMemoryRebound(to:capacity:_:) has been removed
+
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)

--- a/test/stdlib/UnsafePointer.swift.gyb
+++ b/test/stdlib/UnsafePointer.swift.gyb
@@ -470,6 +470,28 @@ ${SelfName}TestSuite.test("withMemoryRebound") {
   }
 }
 
+${SelfName}TestSuite.test("withMemoryReboundSE0333") {
+  let mutablePtrI = UnsafeMutablePointer<Int>.allocate(capacity: 4)
+  defer { mutablePtrI.deallocate() }
+  let ptrI = ${SelfName}<Int>(mutablePtrI)
+  // test rebinding to a wider type with the same alignment
+  ptrI.withMemoryRebound(to: (Int, Int).self, capacity: 2) {
+    // Make sure the closure argument isa $SelfName
+    let ptrT: ${SelfName}<(Int, Int)> = $0
+    // and that the element type is (Int, Int).
+    let mutablePtrT = UnsafeMutablePointer(mutating: ptrT)
+    expectType((Int, Int).self, &mutablePtrT.pointee)
+    // test rebinding to a narrower type
+    ptrT.withMemoryRebound(to: UInt.self, capacity: 4) {
+      // Make sure the closure argument isa $SelfName
+      let ptrU: ${SelfName}<UInt> = $0
+      // and that the element type is UInt.
+      let mutablePtrU = UnsafeMutablePointer(mutating: ptrU)
+      expectType(UInt.self, &mutablePtrU.pointee)
+    }
+  }
+}
+
 % end
 
 runAllTests()

--- a/test/stdlib/UnsafePointer.swift.gyb
+++ b/test/stdlib/UnsafePointer.swift.gyb
@@ -29,7 +29,7 @@ extension UnsafeMutablePointer where Pointee : TestProtocol1 {
 }
 
 // Check that the generic parameter is called 'Element'.
-extension UnsafeBufferPointerIterator where Element : TestProtocol1 {
+extension UnsafeBufferPointer.Iterator where Element : TestProtocol1 {
   var _elementIsTestProtocol1: Bool {
     fatalError("not implemented")
   }
@@ -358,7 +358,7 @@ UnsafeMutablePointerTestSuite.test("initialize:from:.Right") {
 }
 
 UnsafeMutablePointerTestSuite.test("initialize:from:/immutable") {
-  var ptr = UnsafeMutablePointer<Missile>.allocate(capacity: 3)
+  let ptr = UnsafeMutablePointer<Missile>.allocate(capacity: 3)
   defer {
     ptr.deinitialize(count: 3)
     ptr.deallocate()
@@ -373,7 +373,7 @@ UnsafeMutablePointerTestSuite.test("initialize:from:/immutable") {
 }
 
 UnsafeMutablePointerTestSuite.test("assign/immutable") {
-  var ptr = UnsafeMutablePointer<Missile>.allocate(capacity: 2)
+  let ptr = UnsafeMutablePointer<Missile>.allocate(capacity: 2)
   defer {
     ptr.deinitialize(count: 2)
     ptr.deallocate()
@@ -463,9 +463,9 @@ ${SelfName}TestSuite.test("withMemoryRebound") {
   let ptrI = ${SelfName}<Int>(mutablePtrI)
   ptrI.withMemoryRebound(to: UInt.self, capacity: 4) {
     // Make sure the closure argument isa $SelfName
-    var ptrU: ${SelfName}<UInt> = $0
+    let ptrU: ${SelfName}<UInt> = $0
     // and that the element type is UInt.
-    var mutablePtrU = UnsafeMutablePointer(mutating: ptrU)
+    let mutablePtrU = UnsafeMutablePointer(mutating: ptrU)
     expectType(UInt.self, &mutablePtrU.pointee)
   }
 }

--- a/test/stdlib/UnsafeRawPointer.swift
+++ b/test/stdlib/UnsafeRawPointer.swift
@@ -17,7 +17,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory") {
   Missile.missilesLaunched = 0
   do {
     let sizeInBytes = 3 * MemoryLayout<Missile>.stride
-    var p1 = UnsafeMutableRawPointer.allocate(
+    let p1 = UnsafeMutableRawPointer.allocate(
       byteCount: sizeInBytes, alignment: MemoryLayout<Missile>.alignment)
     defer {
       p1.deallocate()
@@ -28,7 +28,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory") {
     expectEqual(2, ptrM[1].number)
     expectEqual(2, ptrM[2].number)
 
-    var p2 = UnsafeMutableRawPointer.allocate(
+    let p2 = UnsafeMutableRawPointer.allocate(
       byteCount: sizeInBytes, alignment: MemoryLayout<Missile>.alignment)
     defer {
       p2.deallocate()
@@ -56,25 +56,25 @@ UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory") {
 
 UnsafeMutableRawPointerExtraTestSuite.test("bindMemory") {
   let sizeInBytes = 3 * MemoryLayout<Int>.stride
-  var p1 = UnsafeMutableRawPointer.allocate(
+  let p1 = UnsafeMutableRawPointer.allocate(
     byteCount: sizeInBytes, alignment: MemoryLayout<Int>.alignment)
   defer {
     p1.deallocate()
   }
   let ptrI = p1.bindMemory(to: Int.self, capacity: 3)
   let bufI = UnsafeMutableBufferPointer(start: ptrI, count: 3)
-  bufI.initialize(from: 1...3)
+  _ = bufI.initialize(from: 1...3)
   let ptrU = p1.bindMemory(to: UInt.self, capacity: 3)
   expectEqual(1, ptrU[0])
   expectEqual(2, ptrU[1])
   expectEqual(3, ptrU[2])
   let ptrU2 = p1.assumingMemoryBound(to: UInt.self)
-  expectEqual(1, ptrU[0])
+  expectEqual(1, ptrU2[0])
 }
 
 UnsafeMutableRawPointerExtraTestSuite.test("load/store") {
   let sizeInBytes = 3 * MemoryLayout<Int>.stride
-  var p1 = UnsafeMutableRawPointer.allocate(
+  let p1 = UnsafeMutableRawPointer.allocate(
     byteCount: sizeInBytes, alignment: MemoryLayout<Int>.alignment)
   defer {
     p1.deallocate()
@@ -96,7 +96,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("load/store") {
 
 UnsafeMutableRawPointerExtraTestSuite.test("copyMemory") {
   let sizeInBytes = 4 * MemoryLayout<Int>.stride
-  var rawPtr = UnsafeMutableRawPointer.allocate(
+  let rawPtr = UnsafeMutableRawPointer.allocate(
     byteCount: sizeInBytes, alignment: MemoryLayout<Int>.alignment)
   defer {
     rawPtr.deallocate()

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -1054,4 +1054,33 @@ UnsafeMutableBufferPointerTestSuite.test("nonmutating-swapAt-withARC") {
 
 % end # SelfName
 
+% for mutable in [True, False]:
+% TypedName = 'UnsafeMutableBufferPointer' if mutable else 'UnsafeBufferPointer'
+Unsafe${'Mutable' if mutable else ''}BufferPointerTestSuite.test("withMemoryRebound") {
+  // test withMemoryRebound behaviour, post SE-0333.
+  let mutableBufferI = UnsafeMutableBufferPointer<Int>.allocate(capacity: 4)
+  defer { mutableBufferI.deallocate() }
+  let ptrI = ${'mutableBufferI' if mutable else TypedName + '(mutableBufferI)'}
+  // test rebinding to a wider type with the same alignment
+  ptrI.withMemoryRebound(to: (Int, Int).self) {
+    // Make sure the closure argument is a ${TypedName}
+    let ptrT: ${TypedName}<(Int, Int)> = $0
+    expectEqual(ptrT.count, 2)
+    // and that the element type is (Int, Int).
+    let mutablePtrT = ${'ptrT' if mutable else 'UnsafeMutableBufferPointer(mutating: ptrT)'}
+    expectType((Int, Int).self, &mutablePtrT[0])
+    // test rebinding to a narrower type
+    ptrT.withMemoryRebound(to: UInt.self) {
+      // Make sure the closure argument is a ${TypedName}
+      let ptrU: ${TypedName}<UInt> = $0
+      expectEqual(ptrU.count, 4)
+      // and that the element type is UInt.
+      let mutablePtrU = ${'ptrU' if mutable else 'UnsafeMutableBufferPointer(mutating: ptrU)'}
+      expectType(UInt.self, &mutablePtrU[0])
+    }
+  }
+}
+
+% end # mutable
+
 runAllTests()

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -1081,6 +1081,22 @@ Unsafe${'Mutable' if mutable else ''}BufferPointerTestSuite.test("withMemoryRebo
   }
 }
 
+% RawName = 'UnsafeMutableRawBufferPointer' if mutable else 'UnsafeRawBufferPointer'
+Unsafe${'Mutable' if mutable else ''}RawBufferPointerTestSuite.test("withMemoryRebound") {
+  // test withMemoryRebound behaviour, post SE-0333.
+  let allocated = UnsafeMutableRawBufferPointer.allocate(byteCount: 32,  alignment: 8)
+  defer { allocated.deallocate() }
+  let ptrR = ${'allocated' if mutable else RawName + '(allocated)'}
+  ptrR.withMemoryRebound(to: Int.self) {
+    // Make sure the closure argument is a ${TypedName}
+    let ptrT: ${TypedName}<Int> = $0
+    expectEqual(ptrT.count, 32/MemoryLayout<Int>.stride)
+    // and that the element type is `Int`.
+    let mutablePtrT = ${'ptrT' if mutable else 'UnsafeMutableBufferPointer(mutating: ptrT)'}
+    expectType(Int.self, &mutablePtrT[0])
+  }
+}
+
 % end # mutable
 
 runAllTests()

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -1099,4 +1099,20 @@ Unsafe${'Mutable' if mutable else ''}RawBufferPointerTestSuite.test("withMemoryR
 
 % end # mutable
 
+UnsafeRawBufferPointerTestSuite.test("assumingMemoryBound") {
+  let array = (0..<4).map({ $0 })
+  array.withUnsafeBytes({
+    let b: UnsafeBufferPointer = $0.assumingMemoryBound(to: Int.self)
+    expectEqual(b.count, array.count)
+    expectEqual(b[3], array[3])
+  })
+  var mutableArray = array
+  mutableArray.withUnsafeMutableBytes({
+    let b: UnsafeMutableBufferPointer = $0.assumingMemoryBound(to: Int.self)
+    expectEqual(b.count, array.count)
+    for i in b.indices { b[i] += 1 }
+  })
+  expectEqual(mutableArray[3], array[3]+1)
+}
+
 runAllTests()


### PR DESCRIPTION
Implementation of SE-0333, "Expand usability of `withMemoryRebound`. See proposal [here](https://github.com/apple/swift-evolution/blob/main/proposals/0333-with-memory-rebound.md).

Addresses bugs [SR-11082](https://bugs.swift.org/browse/SR-11082), [SR-11087](https://bugs.swift.org/browse/SR-11087), rdar://88087816