### PR TITLE
Add a @_nonSendable attribute

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -376,6 +376,22 @@ override.
 This attribute and the corresponding `-warn-implicit-overrides` flag are
 used when compiling the standard library and overlays.
 
+## `@_nonSendable`
+
+There is no clang attribute to add a Swift conformance to an imported type, but
+there *is* a clang attribute to add a Swift attribute to an imported type. So
+`@Sendable` (which is not normally allowed on types) is used from clang headers
+to indicate that an unconstrained, fully available `Sendable` conformance should
+be added to a given type, while `@_nonSendable` indicates that an unavailable
+`Sendable` conformance should be added to it.
+
+`@_nonSendable` can have no options after it, in which case it "beats"
+`@Sendable` if both are applied to the same declaration, or it can have
+`(_assumed)` after it, in which case `@Sendable` "beats" it.
+`@_nonSendable(_assumed)` is intended to be used when mass-marking whole regions
+of a header as non-`Sendable` so that you can make spot exceptions with
+`@Sendable`.   
+
 ## `@_objc_non_lazy_realization`
 
 Marks a class as being non-lazily (i.e. eagerly) [realized](/docs/Lexicon.md#realization).

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -665,6 +665,13 @@ SIMPLE_DECL_ATTR(_assemblyVision, EmitAssemblyVisionRemarks,
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   120)
 
+DECL_ATTR(_nonSendable, NonSendable,
+  OnNominalType |
+  UserInaccessible | AllowMultipleAttributes |
+  ABIStableToAdd | ABIBreakingToRemove |
+  APIStableToAdd | APIBreakingToRemove,
+  121)
+
 // If you're adding a new underscored attribute here, please document it in
 // docs/ReferenceGuides/UnderscoredAttributes.md.
 

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2030,6 +2030,37 @@ public:
   }
 };
 
+enum class NonSendableKind : uint8_t {
+  /// A plain '@_nonSendable' attribute. Should be applied directly to
+  /// particular declarations; overrides even an explicit 'Sendable'
+  /// conformance.
+  Specific,
+
+  /// A '@_nonSendable(_assumed)' attribute. Should be applied to large swaths
+  /// of declarations; does not override explicit 'Sendable' conformances.
+  Assumed
+};
+
+/// Marks a declaration as explicitly non-Sendable.
+class NonSendableAttr : public DeclAttribute {
+public:
+  NonSendableAttr(SourceLoc AtLoc, SourceRange Range,
+                  NonSendableKind Specificity, bool Implicit = false)
+    : DeclAttribute(DAK_NonSendable, AtLoc, Range, Implicit),
+      Specificity(Specificity)
+  {}
+
+  NonSendableAttr(NonSendableKind Specificity, bool Implicit = false)
+    : NonSendableAttr(SourceLoc(), SourceRange(), Specificity, Implicit) {}
+
+  /// Was this '@_nonSendable(_assumed)'?
+  const NonSendableKind Specificity;
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DAK_NonSendable;
+  }
+};
+
 /// Attributes that may be applied to declarations.
 class DeclAttributes {
   /// Linked list of declaration attributes.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1284,6 +1284,8 @@ public:
   SourceLoc getStartLoc() const { return ExtensionLoc; }
   SourceLoc getLocFromSource() const { return ExtensionLoc; }
   SourceRange getSourceRange() const {
+    if (!Braces.isValid())
+      return SourceRange(ExtensionLoc);
     return { ExtensionLoc, Braces.End };
   }
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1604,10 +1604,6 @@ ERROR(opened_attribute_id_value,none,
 ERROR(opened_attribute_expected_rparen,none,
       "expected ')' after id value for 'opened' attribute", ())
 
-// effects
-ERROR(effects_attribute_expect_option,none,
-      "expected '%0' option (readnone, readonly, readwrite)", (StringRef))
-
 // unowned
 ERROR(attr_unowned_invalid_specifier,none,
       "expected 'safe' or 'unsafe'", ())

--- a/include/swift/AST/SynthesizedFileUnit.h
+++ b/include/swift/AST/SynthesizedFileUnit.h
@@ -28,7 +28,7 @@ class SynthesizedFileUnit final : public FileUnit {
   SourceFile &SF;
 
   /// Synthesized top level declarations.
-  TinyPtrVector<ValueDecl *> TopLevelDecls;
+  TinyPtrVector<Decl *> TopLevelDecls;
 
   /// A unique identifier representing this file; used to mark private decls
   /// within the file to keep them from conflicting with other files in the
@@ -43,7 +43,7 @@ public:
   SourceFile &getSourceFile() const { return SF; }
 
   /// Add a synthesized top-level declaration.
-  void addTopLevelDecl(ValueDecl *D) { TopLevelDecls.push_back(D); }
+  void addTopLevelDecl(Decl *D) { TopLevelDecls.push_back(D); }
 
   virtual void lookupValue(DeclName name, NLKind lookupKind,
                            SmallVectorImpl<ValueDecl *> &result) const override;
@@ -56,7 +56,7 @@ public:
 
   void getTopLevelDecls(SmallVectorImpl<Decl*> &results) const override;
 
-  ArrayRef<ValueDecl *> getTopLevelDecls() const {
+  ArrayRef<Decl *> getTopLevelDecls() const {
     return TopLevelDecls;
   };
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -263,7 +263,8 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
     DAK_SetterAccess,
     DAK_Lazy,
     DAK_StaticInitializeObjCMetadata,
-    DAK_RestatedObjCConformance
+    DAK_RestatedObjCConformance,
+    DAK_NonSendable,
   };
 
   return result;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1226,6 +1226,15 @@ StringRef DeclAttribute::getAttrName() const {
     }
     llvm_unreachable("Invalid inline kind");
   }
+  case DAK_NonSendable: {
+    switch (cast<NonSendableAttr>(this)->Specificity) {
+    case NonSendableKind::Specific:
+      return "_nonSendable";
+    case NonSendableKind::Assumed:
+      return "_nonSendable(_assumed)";
+    }
+    llvm_unreachable("Invalid nonSendable kind");
+  }
   case DAK_Optimize: {
     switch (cast<OptimizeAttr>(this)->getMode()) {
     case OptimizationMode::NoOptimization:

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -874,6 +874,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
   case DAK_ReferenceOwnership:
   case DAK_Effects:
   case DAK_Optimize:
+  case DAK_NonSendable:
     if (DeclAttribute::isDeclModifier(getKind())) {
       Printer.printKeyword(getAttrName(), Options);
     } else if (Options.IsForSwiftInterface && getKind() == DAK_ResultBuilder) {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2996,8 +2996,11 @@ void SynthesizedFileUnit::lookupValue(
     DeclName name, NLKind lookupKind,
     SmallVectorImpl<ValueDecl *> &result) const {
   for (auto *decl : TopLevelDecls) {
-    if (decl->getName().matchesRef(name))
-      result.push_back(decl);
+    if (auto VD = dyn_cast<ValueDecl>(decl)) {
+      if (VD->getName().matchesRef(name)) {
+        result.push_back(VD);
+      }
+    }
   }
 }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1735,6 +1735,133 @@ void Parser::parseAllAvailabilityMacroArguments() {
   AvailabilityMacrosComputed = true;
 }
 
+/// Processes a parsed option name by attempting to match it to a list of
+/// alternative name/value pairs provided by a chain of \c when() calls, ending
+/// in either \c whenOmitted() if omitting the option is allowed, or
+/// \c diagnoseWhenOmitted() if the option is mandatory.
+template<typename T, typename R = T>
+class LLVM_NODISCARD AttrOptionSwitch {
+  // Inputs:
+  Optional<StringRef> parsedName;         // None: parse error, empty: omitted
+  Parser &P;
+  SourceLoc loc;
+  StringRef attrName;                     // empty: error already diagnosed
+  bool isDeclModifier;
+
+  // State:
+  StringRef exampleName;                  // empty: when() was never called
+  Optional<R> result;                     // None: no when() has matched
+
+public:
+  /// \param parsedName The name of the option parsed out of the source code. If
+  ///        \c None, there was some sort of parse error; this will normally be
+  ///        diagnosed as \c diag::attr_expected_option_such_as using the name
+  ///        from the first \c when() call as an example.
+  /// \param P The parser used to diagnose errors concerning this attribute
+  ///        option.
+  /// \param loc The source location to diagnose errors at.
+  /// \param attrName The name of the attribute, used in diagnostics. If empty,
+  ///        an error has already been diagnosed and the AttrOptionSwitch should
+  ///        just fall through.
+  /// \param isDeclModifier Are we parsing an attribute or a modifier?
+  AttrOptionSwitch(Optional<StringRef> parsedName, Parser &P, SourceLoc loc,
+                   StringRef attrName, bool isDeclModifier)
+    :  parsedName(parsedName), P(P), loc(loc), attrName(attrName),
+       isDeclModifier(isDeclModifier) { }
+
+  /// If the option has the identifier \p name, give it value \p value.
+  AttrOptionSwitch<R, T> &when(StringLiteral name, T value) {
+    // Save this to use in a future diagnostic, if needed.
+    if (exampleName.empty() && !name.empty())
+      exampleName = name;
+
+    // Does this string match?
+    if (parsedName && *parsedName == name) {
+      assert(!result && "overlapping AttrOptionSwitch::when()s?");
+      result = std::move(value);
+    }
+
+    return *this;
+  }
+
+  /// Diagnose if the option is missing or was not matched, returning either the
+  /// option's value or \c None if an error was diagnosed.
+  Optional<R> diagnoseWhenOmitted() {
+    assert(!exampleName.empty() && "No AttrOptionSwitch::when() calls");
+
+    if (attrName.empty())
+      // An error has already been diagnosed; nothing to do.
+      return None;
+
+    if (!result) {
+      if (!parsedName)
+        // We parsed a non-identifier; diagnose it with `exampleName`.
+        P.diagnose(loc, diag::attr_expected_option_such_as, attrName,
+                   exampleName);
+      else if (*parsedName == "")
+        // Option list was omitted; apparently this attr doesn't allow that.
+        P.diagnose(loc, diag::attr_expected_lparen, attrName, isDeclModifier);
+      else
+        // The identifier didn't match any of the when() calls.
+        P.diagnose(loc, diag::attr_unknown_option, *parsedName, attrName);
+    }
+
+    return result;
+  }
+
+  /// Diagnose if the option is missing or not matched, returning:
+  ///
+  /// \returns \c None if an error was diagnosed; \p value if the option was
+  /// omitted; the value the option was matched to otherwise.
+  Optional<R> whenOmitted(T value) {
+    return when("", value).diagnoseWhenOmitted();
+  }
+};
+
+/// Parses an attribute argument list that allows a single identifier with a
+/// known set of permitted options:
+///
+/// \verbatim
+///     '(' identifier ')'
+/// \endverbatim
+///
+/// Returns an object of type \c AttrOptionSwitch, a type loosely inspired by
+/// \c llvm::StringSwitch which can be used in a fluent style to map each
+/// permitted identifier to a value. Together, they will automatically
+/// diagnose \c diag::attr_expected_lparen,
+/// \c diag::attr_expected_option_such_as, \c diag::attr_unknown_option, and
+/// \c diag::attr_expected_rparen when needed.
+///
+/// \seealso AttrOptionSwitch
+template<typename R>
+static AttrOptionSwitch<R>
+parseSingleAttrOption(Parser &P, SourceLoc Loc, SourceRange &AttrRange,
+                      StringRef AttrName, DeclAttrKind DK) {
+  bool isModifier = DeclAttribute::isDeclModifier(DK);
+  if (!P.consumeIf(tok::l_paren)) {
+    AttrRange = SourceRange(Loc);
+    // Create an AttrOptionSwitch with an empty value. The calls on it will
+    // decide whether or not that's valid.
+    return AttrOptionSwitch<R>(StringRef(), P, Loc, AttrName, isModifier);
+  }
+
+  StringRef parsedName = P.Tok.getText();
+  if (!P.consumeIf(tok::identifier)) {
+    // Once we have an example of a valid option, diagnose this with
+    // diag::attr_expected_option_such_as.
+    return AttrOptionSwitch<R>(None, P, Loc, AttrName, isModifier);
+  }
+
+  if (!P.consumeIf(tok::r_paren)) {
+    P.diagnose(Loc, diag::attr_expected_rparen, AttrName, isModifier);
+    // Pass through the switch without diagnosing anything.
+    return AttrOptionSwitch<R>(None, P, Loc, "", isModifier);
+  }
+
+  AttrRange = SourceRange(Loc, P.PreviousLoc);
+  return AttrOptionSwitch<R>(parsedName, P, Loc, AttrName, isModifier);
+}
+
 bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
                                    DeclAttrKind DK, bool isFromClangAttribute) {
   // Ok, it is a valid attribute, eat it, and then process it.
@@ -1814,114 +1941,49 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
 #include "swift/AST/Attr.def"
 
   case DAK_Effects: {
-    if (!consumeIf(tok::l_paren)) {
-      diagnose(Loc, diag::attr_expected_lparen, AttrName,
-               DeclAttribute::isDeclModifier(DK));      return false;
-    }
-
-    if (Tok.isNot(tok::identifier)) {
-      diagnose(Loc, diag::effects_attribute_expect_option, AttrName);
+    auto kind = parseSingleAttrOption<EffectsKind>
+                         (*this, Loc, AttrRange, AttrName, DK)
+                    .when("readonly", EffectsKind::ReadOnly)
+                    .when("readnone", EffectsKind::ReadNone)
+                    .when("readwrite", EffectsKind::ReadWrite)
+                    .when("releasenone", EffectsKind::ReleaseNone)
+                    .diagnoseWhenOmitted();
+    if (!kind)
       return false;
-    }
-
-    EffectsKind kind;
-    if (Tok.getText() == "readonly")
-      kind = EffectsKind::ReadOnly;
-    else if (Tok.getText() == "readnone")
-      kind = EffectsKind::ReadNone;
-    else if (Tok.getText() == "readwrite")
-      kind = EffectsKind::ReadWrite;
-    else if (Tok.getText() == "releasenone")
-      kind = EffectsKind::ReleaseNone;
-    else {
-      diagnose(Loc, diag::attr_unknown_option,
-               Tok.getText(), AttrName);
-      return false;
-    }
-    AttrRange = SourceRange(Loc, Tok.getRange().getStart());
-    consumeToken(tok::identifier);
-
-    if (!consumeIf(tok::r_paren)) {
-      diagnose(Loc, diag::attr_expected_rparen, AttrName,
-               DeclAttribute::isDeclModifier(DK));
-      return false;
-    }
 
     if (!DiscardAttribute)
-      Attributes.add(new (Context) EffectsAttr(AtLoc, AttrRange, kind));
+      Attributes.add(new (Context) EffectsAttr(AtLoc, AttrRange, *kind));
+
     break;
   }
 
   case DAK_Inline: {
-    if (!consumeIf(tok::l_paren)) {
-      diagnose(Loc, diag::attr_expected_lparen, AttrName,
-               DeclAttribute::isDeclModifier(DK));
+    auto kind = parseSingleAttrOption<InlineKind>
+                         (*this, Loc, AttrRange, AttrName, DK)
+                    .when("never", InlineKind::Never)
+                    .when("__always", InlineKind::Always)
+                    .diagnoseWhenOmitted();
+    if (!kind)
       return false;
-    }
-
-    if (Tok.isNot(tok::identifier)) {
-      diagnose(Loc, diag::attr_expected_option_such_as, AttrName, "none");
-      return false;
-    }
-
-    InlineKind kind;
-    if (Tok.getText() == "never")
-      kind = InlineKind::Never;
-    else if (Tok.getText() == "__always")
-      kind = InlineKind::Always;
-    else {
-      diagnose(Loc, diag::attr_unknown_option, Tok.getText(), AttrName);
-      return false;
-    }
-    consumeToken(tok::identifier);
-    AttrRange = SourceRange(Loc, Tok.getRange().getStart());
-    
-    if (!consumeIf(tok::r_paren)) {
-      diagnose(Loc, diag::attr_expected_rparen, AttrName,
-               DeclAttribute::isDeclModifier(DK));
-      return false;
-    }
 
     if (!DiscardAttribute)
-      Attributes.add(new (Context) InlineAttr(AtLoc, AttrRange, kind));
+      Attributes.add(new (Context) InlineAttr(AtLoc, AttrRange, *kind));
 
     break;
   }
 
   case DAK_Optimize: {
-    if (!consumeIf(tok::l_paren)) {
-      diagnose(Loc, diag::attr_expected_lparen, AttrName,
-               DeclAttribute::isDeclModifier(DK));
+    auto optMode = parseSingleAttrOption<OptimizationMode>
+                            (*this, Loc, AttrRange, AttrName, DK)
+                       .when("speed", OptimizationMode::ForSpeed)
+                       .when("size", OptimizationMode::ForSize)
+                       .when("none", OptimizationMode::NoOptimization)
+                       .diagnoseWhenOmitted();
+    if (!optMode)
       return false;
-    }
-
-    if (Tok.isNot(tok::identifier)) {
-      diagnose(Loc, diag::attr_expected_option_such_as, AttrName, "speed");
-      return false;
-    }
-
-    OptimizationMode optMode = OptimizationMode::NotSet;
-    if (Tok.getText() == "none")
-      optMode = OptimizationMode::NoOptimization;
-    else if (Tok.getText() == "speed")
-      optMode = OptimizationMode::ForSpeed;
-    else if (Tok.getText() == "size")
-      optMode = OptimizationMode::ForSize;
-    else {
-      diagnose(Loc, diag::attr_unknown_option, Tok.getText(), AttrName);
-      return false;
-    }
-    consumeToken(tok::identifier);
-    AttrRange = SourceRange(Loc, Tok.getRange().getStart());
-
-    if (!consumeIf(tok::r_paren)) {
-      diagnose(Loc, diag::attr_expected_rparen, AttrName,
-               DeclAttribute::isDeclModifier(DK));
-      return false;
-    }
 
     if (!DiscardAttribute)
-      Attributes.add(new (Context) OptimizeAttr(AtLoc, AttrRange, optMode));
+      Attributes.add(new (Context) OptimizeAttr(AtLoc, AttrRange, *optMode));
 
     break;
   }
@@ -1930,30 +1992,25 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     // Handle weak/unowned/unowned(unsafe).
     auto Kind = AttrName == "weak" ? ReferenceOwnership::Weak
                                    : ReferenceOwnership::Unowned;
-    SourceLoc EndLoc = Loc;
 
-    if (Kind == ReferenceOwnership::Unowned && Tok.is(tok::l_paren)) {
+    if (Kind == ReferenceOwnership::Unowned) {
       // Parse an optional specifier after unowned.
-      SourceLoc lp = consumeToken(tok::l_paren);
-      if (Tok.is(tok::identifier) && Tok.getText() == "safe") {
-        consumeToken();
-      } else if (Tok.is(tok::identifier) && Tok.getText() == "unsafe") {
-        consumeToken();
-        Kind = ReferenceOwnership::Unmanaged;
-      } else {
-        diagnose(Tok, diag::attr_unowned_invalid_specifier);
-        consumeIf(tok::identifier);
-      }
-
-      SourceLoc rp;
-      parseMatchingToken(tok::r_paren, rp, diag::attr_unowned_expected_rparen,
-                         lp);
-      EndLoc = rp;
+      Kind = parseSingleAttrOption<ReferenceOwnership>
+                     (*this, Loc, AttrRange, AttrName, DK)
+                .when("unsafe", ReferenceOwnership::Unmanaged)
+                .when("safe", ReferenceOwnership::Unowned)
+                .whenOmitted(ReferenceOwnership::Unowned)
+            // Recover from errors by going back to Unowned.
+            .getValueOr(ReferenceOwnership::Unowned);
+    }
+    else {
+      AttrRange = SourceRange(Loc);
     }
 
     if (!DiscardAttribute)
       Attributes.add(
-          new (Context) ReferenceOwnershipAttr(SourceRange(Loc, EndLoc), Kind));
+          new (Context) ReferenceOwnershipAttr(AttrRange, Kind));
+
     break;
   }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2014,6 +2014,20 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     break;
   }
 
+  case DAK_NonSendable: {
+    auto kind = parseSingleAttrOption<NonSendableKind>
+                         (*this, Loc, AttrRange, AttrName, DK)
+                    .when("_assumed", NonSendableKind::Assumed)
+                    .whenOmitted(NonSendableKind::Specific);
+    if (!kind)
+      return false;
+
+    if (!DiscardAttribute)
+      Attributes.add(new (Context) NonSendableAttr(AtLoc, AttrRange, *kind));
+
+    break;
+  }
+
   case DAK_AccessControl: {
 
     // Diagnose using access control in a local scope, which isn't meaningful.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -107,6 +107,7 @@ public:
   IGNORED_ATTR(NoDerivative)
   IGNORED_ATTR(SpecializeExtension)
   IGNORED_ATTR(Sendable)
+  IGNORED_ATTR(NonSendable)
   IGNORED_ATTR(AtRethrows)
   IGNORED_ATTR(AtReasync)
   IGNORED_ATTR(UnsafeSendable)

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3933,21 +3933,56 @@ NormalProtocolConformance *GetImplicitSendableRequest::evaluate(
   }
 
   // Local function to form the implicit conformance.
-  auto formConformance = [&]() -> NormalProtocolConformance * {
+  auto formConformance = [&](const DeclAttribute *attrMakingUnavailable)
+        -> NormalProtocolConformance * {
     ASTContext &ctx = nominal->getASTContext();
     auto proto = ctx.getProtocol(KnownProtocolKind::Sendable);
     if (!proto)
       return nullptr;
 
+    DeclContext *conformanceDC = nominal;
+    if (attrMakingUnavailable) {
+      llvm::VersionTuple NoVersion;
+      auto attr = new (ctx) AvailableAttr(attrMakingUnavailable->AtLoc,
+                                          attrMakingUnavailable->Range,
+                                          PlatformKind::none, "", "", nullptr,
+                                          NoVersion, SourceRange(),
+                                          NoVersion, SourceRange(),
+                                          NoVersion, SourceRange(),
+                                          PlatformAgnosticAvailabilityKind::Unavailable,
+                                          false);
+
+      // Conformance availability is currently tied to the declaring extension.
+      // FIXME: This is a hack--we should give conformances real availability.
+      auto extension = ExtensionDecl::create(ctx, attrMakingUnavailable->AtLoc,
+                                             nullptr, {},
+                                             nominal->getModuleScopeContext(),
+                                             nullptr);
+      extension->setImplicit();
+      extension->getAttrs().add(attr);
+
+      ctx.evaluator.cacheOutput(ExtendedTypeRequest{extension},
+                                nominal->getDeclaredType());
+      ctx.evaluator.cacheOutput(ExtendedNominalRequest{extension},
+                                std::move(nominal));
+      nominal->addExtension(extension);
+
+      conformanceDC = extension;
+    }
+
     auto conformance = ctx.getConformance(
         nominal->getDeclaredInterfaceType(), proto, nominal->getLoc(),
-        nominal, ProtocolConformanceState::Complete, false);
+        conformanceDC, ProtocolConformanceState::Complete,
+        /*isUnchecked=*/attrMakingUnavailable != nullptr);
     conformance->setSourceKindAndImplyingConformance(
         ConformanceEntryKind::Synthesized, nullptr);
 
     nominal->registerProtocolConformance(conformance, /*synthesized=*/true);
     return conformance;
   };
+
+  if (auto nonSendable = nominal->getAttrs().getAttribute<NonSendableAttr>())
+    return formConformance(nonSendable);
 
   // A non-protocol type with a global actor is implicitly Sendable.
   if (nominal->getGlobalActorAttr()) {
@@ -3966,7 +4001,7 @@ NormalProtocolConformance *GetImplicitSendableRequest::evaluate(
     }
 
     // Form the implicit conformance to Sendable.
-    return formConformance();
+    return formConformance(nullptr);
   }
 
   // Only structs and enums can get implicit Sendable conformances by
@@ -3991,7 +4026,7 @@ NormalProtocolConformance *GetImplicitSendableRequest::evaluate(
           nominal, nominal, SendableCheck::Implicit))
     return nullptr;
 
-  return formConformance();
+  return formConformance(nullptr);
 }
 
 AnyFunctionType *swift::applyGlobalActorType(

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1545,6 +1545,7 @@ namespace  {
     UNINTERESTING_ATTR(GlobalActor)
     UNINTERESTING_ATTR(Async)
     UNINTERESTING_ATTR(Sendable)
+    UNINTERESTING_ATTR(NonSendable)
 
     UNINTERESTING_ATTR(AtRethrows)
     UNINTERESTING_ATTR(Marker)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4404,6 +4404,14 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         break;
       }
 
+      case decls_block::NonSendable_DECL_ATTR: {
+        unsigned kind;
+        serialization::decls_block::NonSendableDeclAttrLayout::readRecord(
+            scratch, kind);
+        Attr = new (ctx) NonSendableAttr((NonSendableKind)kind);
+        break;
+      }
+
       case decls_block::Optimize_DECL_ATTR: {
         unsigned kind;
         serialization::decls_block::OptimizeDeclAttrLayout::readRecord(

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 634; // remove PrivateExternal
+const uint16_t SWIFTMODULE_VERSION_MINOR = 635; // @_nonSendable
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1892,6 +1892,11 @@ namespace decls_block {
   using InlineDeclAttrLayout = BCRecordLayout<
     Inline_DECL_ATTR,
     BCFixed<2>  // inline value
+  >;
+
+  using NonSendableDeclAttrLayout = BCRecordLayout<
+    NonSendable_DECL_ATTR,
+    BCFixed<1>  // assumed flag
   >;
 
   using OptimizeDeclAttrLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2490,6 +2490,14 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
+    case DAK_NonSendable: {
+      auto *theAttr = cast<NonSendableAttr>(DA);
+      auto abbrCode = S.DeclTypeAbbrCodes[NonSendableDeclAttrLayout::Code];
+      NonSendableDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
+                                        (unsigned)theAttr->getKind());
+      return;
+    }
+
     case DAK_Optimize: {
       auto *theAttr = cast<OptimizeAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[OptimizeDeclAttrLayout::Code];

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -require-explicit-sendable
+// RUN: %target-typecheck-verify-swift -require-explicit-sendable -warn-concurrency
 
 public protocol P { }
 

--- a/test/ModuleInterface/conformances.swift
+++ b/test/ModuleInterface/conformances.swift
@@ -237,6 +237,12 @@ public struct NestedAvailabilityOuter {
   public struct Inner: PrivateSubProto {}
 }
 
+@_nonSendable public struct NonSendable {}
+// NEGATIVE-NOT: @_nonSendable
+// CHECK-LABEL: public struct NonSendable {
+// CHECK: @available(*, unavailable)
+// CHECK-NEXT: extension conformances.NonSendable : @unchecked Swift.Sendable {
+
 // CHECK-END: @available(macOS 10.97, iOS 23, *)
 // CHECK-END: @available(tvOS, unavailable)
 // CHECK-END: extension conformances.NestedAvailabilityOuter.Inner : conformances.PublicBaseProto {}

--- a/test/decl/protocol/special/Sendable.swift
+++ b/test/decl/protocol/special/Sendable.swift
@@ -4,9 +4,18 @@ func acceptSendable<T: Sendable>(_: T) { }
 
 class NotSendable { } // expected-note 2{{class 'NotSendable' does not conform to the 'Sendable' protocol}}
 
+@_nonSendable struct ExplicitlyNonSendable { // expected-note {{conformance of 'ExplicitlyNonSendable' to 'Sendable' has been explicitly marked unavailable here}}
+  var int: Int = 0
+}
+
+@_nonSendable struct NonSendableWins: Sendable { }
+@_nonSendable(_assumed) struct NonSendableLoses: Sendable { }
+
 func testSendableBuiltinConformances(
-  i: Int, ns: NotSendable, sf: @escaping @Sendable () -> Void,
-  nsf: @escaping () -> Void, mt: NotSendable.Type,
+  i: Int, ns: NotSendable, xns: ExplicitlyNonSendable,
+  nsw: NonSendableWins, nsl: NonSendableLoses,
+  sf: @escaping @Sendable () -> Void, nsf: @escaping () -> Void,
+  mt: NotSendable.Type,
   cf: @escaping @convention(c) () -> Void,
   funSendable: [(Int, @Sendable () -> Void, NotSendable.Type)?],
   funNotSendable: [(Int, () -> Void, NotSendable.Type)?]
@@ -28,4 +37,9 @@ func testSendableBuiltinConformances(
   acceptSendable(funNotSendable) // expected-warning{{type '() -> Void' does not conform to the 'Sendable' protocol}}
   // expected-note@-1{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   acceptSendable((i, ns)) // expected-warning{{type 'NotSendable' does not conform to the 'Sendable' protocol}}
+
+  // Explicitly @_nonSendable
+  acceptSendable(xns) // expected-warning{{conformance of 'ExplicitlyNonSendable' to 'Sendable' is unavailable}}
+  acceptSendable(nsw) // TODO: @_nonSendable should beat an explicit conformance, or at least conflict with it
+  acceptSendable(nsl)
 }


### PR DESCRIPTION
This PR adds a `@_nonSendable` attribute which synthesizes an unavailable `Sendable` conformance on a type.

Using this attribute from clang is [currently being pitched](https://forums.swift.org/t/pitch-2-staging-in-sendable-checking/52413); some aspects of the attribute's design reflect that pitch, but are not fully implemented yet. In particular, its interaction with explicit `Sendable` conformances hasn't really been developed yet.

As a side effect, using an unavailable `Sendable` conformance in pre-Swift 6-mode code is now either a warning or entirely ignored instead of being an error. This is roughly in line with what would happen if the `Sendable` conformance was not present at all (although the check currently in place is again a rough approximation of the pitch).

`@_nonSendable` is currently *not* printed into module interfaces. Instead, we print the synthesized extension, which is more backwards-compatible.

(I've also slipped in a small cleanup of basic attribute argument parsing.)