### PR TITLE
[SILGen] Gave arguments lexical lifetimes.

### DIFF
--- a/lib/SILGen/Cleanup.h
+++ b/lib/SILGen/Cleanup.h
@@ -133,6 +133,14 @@ protected:
   }
 };
 
+struct EndBorrowCleanup final : Cleanup {
+  SILValue borrowedValue;
+  EndBorrowCleanup(SILValue borrowedValue);
+  void emit(SILGenFunction &SGF, CleanupLocation l,
+            ForUnwind_t forUnwind) override;
+  void dump(SILGenFunction &) const override;
+};
+
 /// A cleanup depth is generally used to denote the set of cleanups
 /// between the given cleanup (and not including it) and the top of
 /// the stack.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -158,34 +158,30 @@ SILGenFunction::emitManagedBeginBorrow(SILLocation loc, SILValue v,
   return emitManagedBorrowedRValueWithCleanup(v, bbi, lowering);
 }
 
-namespace {
-
-struct EndBorrowCleanup : Cleanup {
-  SILValue borrowedValue;
-
-  EndBorrowCleanup(SILValue borrowedValue) : borrowedValue(borrowedValue) {
-    if (auto *arg = dyn_cast<SILPhiArgument>(borrowedValue)) {
-      if (auto *ti = arg->getSingleTerminator()) {
-        assert(!ti->isTransformationTerminator() &&
-               "Transforming terminators do not have end_borrow");
-      }
+EndBorrowCleanup::EndBorrowCleanup(SILValue borrowedValue)
+    : borrowedValue(borrowedValue) {
+  if (auto *arg = dyn_cast<SILPhiArgument>(borrowedValue)) {
+    if (auto *ti = arg->getSingleTerminator()) {
+      assert(!ti->isTransformationTerminator() &&
+             "Transforming terminators do not have end_borrow");
     }
   }
+}
 
-  void emit(SILGenFunction &SGF, CleanupLocation l,
-            ForUnwind_t forUnwind) override {
-    SGF.B.createEndBorrow(l, borrowedValue);
-  }
+void EndBorrowCleanup::emit(SILGenFunction &SGF, CleanupLocation l,
+                            ForUnwind_t forUnwind) {
+  SGF.B.createEndBorrow(l, borrowedValue);
+}
 
-  void dump(SILGenFunction &) const override {
+void EndBorrowCleanup::dump(SILGenFunction &) const {
 #ifndef NDEBUG
-    llvm::errs() << "EndBorrowCleanup "
-                 << "State:" << getState() << "\n"
-                 << "borrowed:" << borrowedValue
-                 << "\n";
+  llvm::errs() << "EndBorrowCleanup "
+               << "State:" << getState() << "\n"
+               << "borrowed:" << borrowedValue << "\n";
 #endif
-  }
-};
+}
+
+namespace {
 
 struct FormalEvaluationEndBorrowCleanup : Cleanup {
   FormalEvaluationContext::stable_iterator Depth;

--- a/test/SILGen/borrow.swift
+++ b/test/SILGen/borrow.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -enable-experimental-lexical-lifetimes -module-name borrow -parse-stdlib %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name borrow -parse-stdlib %s | %FileCheck %s
 
 import Swift
 
@@ -13,7 +13,6 @@ final class C {
   var d: D = D()
 }
 
-func use<T>(_ t: T) {}
 func useD(_ d: D) {}
 
 // CHECK-LABEL: sil hidden [ossa] @$s6borrow44lvalueBorrowShouldBeAtEndOfFormalAccessScope{{.*}} : $@convention(thin) () -> () {
@@ -35,59 +34,4 @@ func useD(_ d: D) {}
 func lvalueBorrowShouldBeAtEndOfFormalAccessScope() {
   var c = C()
   useD(c.d)
-}
-
-// CHECK-LABEL: sil hidden [ossa] @lexical_borrow_let_class
-// CHECK:   [[INIT_C:%[^,]+]] = function_ref @$s6borrow1CCACycfC
-// CHECK:   [[INSTANCE:%[^,]+]] = apply [[INIT_C]]({{%[0-9]+}})
-// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] : $C
-// CHECK:   end_borrow [[BORROW:%[^,]+]]
-// CHECK-LABEL: } // end sil function 'lexical_borrow_let_class'
-@_silgen_name("lexical_borrow_let_class")
-func lexical_borrow_let_class() {
-  let c = C()
-}
-
-// CHECK-LABEL: sil hidden [ossa] @lexical_borrow_if_let_class
-// CHECK:   [[INIT_C:%[^,]+]] = function_ref @$s6borrow1CC8failablyACSgyt_tcfC
-// CHECK:   [[INSTANCE:%[^,]+]] = apply [[INIT_C]]({{%[^,]+}})
-// CHECK:   switch_enum [[INSTANCE]] : $Optional<C>, case #Optional.some!enumelt: [[BASIC_BLOCK2:bb[^,]+]], case #Optional.none!enumelt: {{bb[^,]+}}
-// CHECK: [[BASIC_BLOCK2]]([[INSTANCE:%[^,]+]] : @owned $C):
-// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] : $C
-// CHECK:   end_borrow [[BORROW]] : $C
-// CHECK-LABEL: // end sil function 'lexical_borrow_if_let_class'
-@_silgen_name("lexical_borrow_if_let_class")
-func lexical_borrow_if_let_class() {
-  if let c = C(failably: ()) {
-    use(())
-  }
-}
-
-struct S {
-  let c: C
-}
-
-// CHECK-LABEL: sil hidden [ossa] @lexical_borrow_let_class_in_struct
-// CHECK:   [[INIT_S:%[^,]+]] = function_ref @$s6borrow1SV1cAcA1CC_tcfC
-// CHECK:   [[INSTANCE:%[^,]+]] = apply [[INIT_S]]({{%[0-9]+}}, {{%[0-9]+}})
-// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] : $S
-// CHECK:   end_borrow [[BORROW:%[^,]+]]
-// CHECK-LABEL: } // end sil function 'lexical_borrow_let_class_in_struct'
-@_silgen_name("lexical_borrow_let_class_in_struct")
-func lexical_borrow_let_class_in_struct() {
-  let s = S(c: C())
-}
-
-enum E {
-  case e(C)
-}
-
-// CHECK-LABEL: sil hidden [ossa] @lexical_borrow_let_class_in_enum
-// CHECK:   [[INSTANCE:%[^,]+]] = enum $E, #E.e!enumelt, {{%[0-9]+}} : $C
-// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] : $E
-// CHECK:   end_borrow [[BORROW:%[^,]+]]
-// CHECK-LABEL: } // end sil function 'lexical_borrow_let_class_in_enum'
-@_silgen_name("lexical_borrow_let_class_in_enum")
-func lexical_borrow_let_class_in_enum() {
-  let s = E.e(C())
 }

--- a/test/SILGen/lexical_lifetime.swift
+++ b/test/SILGen/lexical_lifetime.swift
@@ -1,0 +1,85 @@
+// RUN: %target-swift-emit-silgen -enable-experimental-lexical-lifetimes -module-name borrow -parse-stdlib %s | %FileCheck %s
+
+import Swift
+
+////////////////////////////////////////////////////////////////////////////////
+// Declarations                                                               {{
+////////////////////////////////////////////////////////////////////////////////
+
+final class C {
+  init() {}
+  init?(failably: ()) {}
+}
+
+struct S {
+  let c: C
+}
+
+enum E {
+  case e(C)
+}
+
+func use<T>(_ t: T) {}
+
+////////////////////////////////////////////////////////////////////////////////
+// Declarations                                                               }}
+////////////////////////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Tests                                                                      {{
+////////////////////////////////////////////////////////////////////////////////
+
+// let bindings:
+
+// CHECK-LABEL: sil hidden [ossa] @lexical_borrow_let_class
+// CHECK:   [[INIT_C:%[^,]+]] = function_ref @$s6borrow1CCACycfC
+// CHECK:   [[INSTANCE:%[^,]+]] = apply [[INIT_C]]({{%[0-9]+}})
+// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] : $C
+// CHECK:   end_borrow [[BORROW:%[^,]+]]
+// CHECK-LABEL: } // end sil function 'lexical_borrow_let_class'
+@_silgen_name("lexical_borrow_let_class")
+func lexical_borrow_let_class() {
+  let c = C()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @lexical_borrow_if_let_class
+// CHECK:   [[INIT_C:%[^,]+]] = function_ref @$s6borrow1CC8failablyACSgyt_tcfC
+// CHECK:   [[INSTANCE:%[^,]+]] = apply [[INIT_C]]({{%[^,]+}})
+// CHECK:   switch_enum [[INSTANCE]] : $Optional<C>, case #Optional.some!enumelt: [[BASIC_BLOCK2:bb[^,]+]], case #Optional.none!enumelt: {{bb[^,]+}}
+// CHECK: [[BASIC_BLOCK2]]([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] : $C
+// CHECK:   end_borrow [[BORROW]] : $C
+// CHECK-LABEL: // end sil function 'lexical_borrow_if_let_class'
+@_silgen_name("lexical_borrow_if_let_class")
+func lexical_borrow_if_let_class() {
+  if let c = C(failably: ()) {
+    use(())
+  }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @lexical_borrow_let_class_in_struct
+// CHECK:   [[INIT_S:%[^,]+]] = function_ref @$s6borrow1SV1cAcA1CC_tcfC
+// CHECK:   [[INSTANCE:%[^,]+]] = apply [[INIT_S]]({{%[0-9]+}}, {{%[0-9]+}})
+// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] : $S
+// CHECK:   end_borrow [[BORROW:%[^,]+]]
+// CHECK-LABEL: } // end sil function 'lexical_borrow_let_class_in_struct'
+@_silgen_name("lexical_borrow_let_class_in_struct")
+func lexical_borrow_let_class_in_struct() {
+  let s = S(c: C())
+}
+
+// CHECK-LABEL: sil hidden [ossa] @lexical_borrow_let_class_in_enum
+// CHECK:   [[INSTANCE:%[^,]+]] = enum $E, #E.e!enumelt, {{%[0-9]+}} : $C
+// CHECK:   [[BORROW:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] : $E
+// CHECK:   end_borrow [[BORROW:%[^,]+]]
+// CHECK-LABEL: } // end sil function 'lexical_borrow_let_class_in_enum'
+@_silgen_name("lexical_borrow_let_class_in_enum")
+func lexical_borrow_let_class_in_enum() {
+  let s = E.e(C())
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Test                                                                       }}
+////////////////////////////////////////////////////////////////////////////////
+


### PR DESCRIPTION
When the frontend flag -enable-experimental-lexical-lifetimes is passed, arguments of non-trivial, non-address types get lexical borrow scopes.  The borrow scope begins in the function prolog.  Usages of the arguments are actually usages of the borrowed value.  The borrow scope is ended when the function's scope ends.
