### PR TITLE
[Distributed] Fix swift-api-dump missing option

### DIFF
--- a/utils/swift-api-dump.py
+++ b/utils/swift-api-dump.py
@@ -104,6 +104,8 @@ def create_parser():
                         'member.')
     parser.add_argument('--enable-experimental-concurrency', action='store_true',
                         help='Enable experimental concurrency model.')
+    parser.add_argument('--enable-experimental-distributed', action='store_true',
+                        help='Enable experimental distributed actors.')
     parser.add_argument('-swift-version', metavar='N',
                         help='the Swift version to use')
     parser.add_argument('-show-overlay', action='store_true',


### PR DESCRIPTION
Resolves rdar://83727543

Without the fix we fail silly:

```
-> % ./utils/swift-api-dump.py ... 
Traceback (most recent call last):
  File "./utils/swift-api-dump.py", line 358, in <module>
    main()
  File "./utils/swift-api-dump.py", line 333, in main
    if args.enable_experimental_distributed:
AttributeError: 'Namespace' object has no attribute 'enable_experimental_distributed'
```

