### PR TITLE
[cxx-interop] Allow importing templated functions when template args do not appear in function signature

### DIFF
--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1223,7 +1223,7 @@ public:
       DeclContext *dc, const clang::FunctionDecl *clangDecl,
       ArrayRef<const clang::ParmVarDecl *> params, bool isVariadic,
       bool allowNSUIntegerAsInt, ArrayRef<Identifier> argNames,
-      ArrayRef<GenericTypeParamDecl *> genericParams);
+      ArrayRef<GenericTypeParamDecl *> genericParams, Type resultType);
 
   ImportedType importPropertyType(const clang::ObjCPropertyDecl *clangDecl,
                                   bool isFromSystemModule);
@@ -1559,6 +1559,12 @@ bool isSpecialUIKitStructZeroProperty(const clang::NamedDecl *decl);
 /// \returns true if this operator should be made a static function
 /// even if imported as a non-static member function.
 bool isImportedAsStatic(clang::OverloadedOperatorKind op);
+
+/// \returns true if \p a has the same underlying type as \p b after removing
+/// any pointer/reference specifiers. Note that this does not currently look through
+/// nested types other than pointers or references.
+bool hasSameUnderlyingType(const clang::Type *a,
+                           const clang::TemplateTypeParmDecl *b);
 
 /// Add command-line arguments for a normal import of Clang code.
 void getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -109,16 +109,18 @@ Solution::computeSubstitutions(GenericSignature sig,
                               lookupConformanceFn);
 }
 
-static ConcreteDeclRef generateDeclRefForSpecializedCXXFunctionTemplate(
-    ASTContext &ctx, AbstractFunctionDecl *oldDecl, SubstitutionMap subst,
-    clang::FunctionDecl *specialized) {
+// Derive a concrete function type for fdecl by substituting the generic args
+// and use that to derive the corresponding function type and parameter list.
+static std::pair<FunctionType *, ParameterList *>
+substituteFunctionTypeAndParamList(ASTContext &ctx, AbstractFunctionDecl *fdecl,
+                                   SubstitutionMap subst) {
   FunctionType *newFnType = nullptr;
   // Create a new ParameterList with the substituted type.
   if (auto oldFnType = dyn_cast<GenericFunctionType>(
-          oldDecl->getInterfaceType().getPointer())) {
+          fdecl->getInterfaceType().getPointer())) {
     newFnType = oldFnType->substGenericArgs(subst);
   } else {
-    newFnType = cast<FunctionType>(oldDecl->getInterfaceType().getPointer());
+    newFnType = cast<FunctionType>(fdecl->getInterfaceType().getPointer());
   }
   // The constructor type is a function type as follows:
   //   (CType.Type) -> (Generic) -> CType
@@ -127,21 +129,48 @@ static ConcreteDeclRef generateDeclRefForSpecializedCXXFunctionTemplate(
   // In either case, we only want the result of that function type because that
   // is the function type with the generic params that need to be substituted:
   //   (Generic) -> CType
-  if (isa<ConstructorDecl>(oldDecl) || oldDecl->isInstanceMember() ||
-      oldDecl->isStatic())
+  if (isa<ConstructorDecl>(fdecl) || fdecl->isInstanceMember() ||
+      fdecl->isStatic())
     newFnType = cast<FunctionType>(newFnType->getResult().getPointer());
   SmallVector<ParamDecl *, 4> newParams;
   unsigned i = 0;
+
   for (auto paramTy : newFnType->getParams()) {
-    auto *oldParamDecl = oldDecl->getParameters()->get(i);
+    auto *oldParamDecl = fdecl->getParameters()->get(i);
     auto *newParamDecl =
-        ParamDecl::cloneWithoutType(oldDecl->getASTContext(), oldParamDecl);
+        ParamDecl::cloneWithoutType(fdecl->getASTContext(), oldParamDecl);
     newParamDecl->setInterfaceType(paramTy.getParameterType());
     newParams.push_back(newParamDecl);
     (void)++i;
   }
   auto *newParamList =
       ParameterList::create(ctx, SourceLoc(), newParams, SourceLoc());
+
+  return {newFnType, newParamList};
+}
+
+static ValueDecl *generateSpecializedCXXFunctionTemplate(
+    ASTContext &ctx, AbstractFunctionDecl *oldDecl, SubstitutionMap subst,
+    clang::FunctionDecl *specialized) {
+  auto newFnTypeAndParams = substituteFunctionTypeAndParamList(ctx, oldDecl, subst);
+  auto newFnType = newFnTypeAndParams.first;
+  auto paramList = newFnTypeAndParams.second;
+
+  SmallVector<ParamDecl *, 4> newParamsWithoutMetatypes;
+  for (auto param : *paramList ) {
+    if (isa<FuncDecl>(oldDecl) &&
+        isa<MetatypeType>(param->getType().getPointer())) {
+      // Metatype parameters are added synthetically to account for template
+      // params that don't make it to the function signature. These shouldn't
+      // exist in the resulting specialized FuncDecl. Note that this doesn't
+      // affect constructors because all template params for a constructor
+      // must be in the function signature by design.
+      continue;
+    }
+    newParamsWithoutMetatypes.push_back(param);
+  }
+  auto *newParamList =
+      ParameterList::create(ctx, SourceLoc(), newParamsWithoutMetatypes, SourceLoc());
 
   if (isa<ConstructorDecl>(oldDecl)) {
     DeclName ctorName(ctx, DeclBaseName::createConstructor(), newParamList);
@@ -152,7 +181,7 @@ static ConcreteDeclRef generateDeclRefForSpecializedCXXFunctionTemplate(
         /*throws=*/false, /*throwsLoc=*/SourceLoc(), 
         newParamList, /*genericParams=*/nullptr,
         oldDecl->getDeclContext());
-    return ConcreteDeclRef(newCtorDecl);
+    return newCtorDecl;
   }
 
   // Generate a name for the specialized function.
@@ -176,7 +205,48 @@ static ConcreteDeclRef generateDeclRefForSpecializedCXXFunctionTemplate(
     newFnDecl->setImportAsStaticMember();
   }
   newFnDecl->setSelfAccessKind(cast<FuncDecl>(oldDecl)->getSelfAccessKind());
-  return ConcreteDeclRef(newFnDecl);
+  return newFnDecl;
+}
+
+// Synthesizes the body of a thunk that takes extra metatype arguments and
+// skips over them to forward them along to the FuncDecl contained by context.
+// This is used when importing a C++ templated function where the template params
+// are not used in the function signature. We supply the type params as explicit
+// metatype arguments to aid in typechecking, but they shouldn't be forwarded to
+// the corresponding C++ function.
+static std::pair<BraceStmt *, bool>
+synthesizeForwardingThunkBody(AbstractFunctionDecl *afd, void *context) {
+  ASTContext &ctx = afd->getASTContext();
+
+  auto thunkDecl = cast<FuncDecl>(afd);
+  auto specializedFuncDecl = static_cast<FuncDecl *>(context);
+
+  SmallVector<Argument, 8> forwardingParams;
+  for (auto param : *thunkDecl->getParameters()) {
+    if (isa<MetatypeType>(param->getType().getPointer())) {
+      continue;
+    }
+    auto paramRefExpr = new (ctx) DeclRefExpr(param, DeclNameLoc(),
+                                             /*Implicit=*/true);
+    paramRefExpr->setType(param->getType());
+    forwardingParams.push_back(Argument(SourceLoc(), Identifier(), paramRefExpr));
+  }
+
+  auto *specializedFuncDeclRef = new (ctx) DeclRefExpr(ConcreteDeclRef(specializedFuncDecl),
+                                                DeclNameLoc(), true);
+  specializedFuncDeclRef->setType(specializedFuncDecl->getInterfaceType());
+
+  auto argList = ArgumentList::createImplicit(ctx, forwardingParams);
+  auto *specializedFuncCallExpr = CallExpr::createImplicit(ctx, specializedFuncDeclRef, argList);
+  specializedFuncCallExpr->setType(thunkDecl->getResultInterfaceType());
+  specializedFuncCallExpr->setThrows(false);
+
+  auto returnStmt = new (ctx) ReturnStmt(SourceLoc(), specializedFuncCallExpr,
+                                        /*implicit=*/true);
+
+  auto body = BraceStmt::create(ctx, SourceLoc(), {returnStmt}, SourceLoc(),
+                               /*implicit=*/true);
+  return {body, /*isTypeChecked=*/true};
 }
 
 ConcreteDeclRef
@@ -215,12 +285,34 @@ Solution::resolveConcreteDeclRef(ValueDecl *decl,
                 const_cast<clang::FunctionTemplateDecl *>(
                     cast<clang::FunctionTemplateDecl>(decl->getClangDecl())),
                 subst);
-    return generateDeclRefForSpecializedCXXFunctionTemplate(
+    auto newDecl = generateSpecializedCXXFunctionTemplate(
         decl->getASTContext(), cast<AbstractFunctionDecl>(decl), subst, newFn);
+    if (auto fn = dyn_cast<FuncDecl>(decl)) {
+      if (newFn->getNumParams() != fn->getParameters()->size()) {
+        // We added additional metatype parameters to aid template
+        // specialization, which are no longer now that we've specialized
+        // this function. Create a thunk that only forwards the original
+        // parameters along to the clang function.
+        auto thunkTypeAndParamList = substituteFunctionTypeAndParamList(decl->getASTContext(),
+                                                                        fn, subst);
+        auto thunk = FuncDecl::createImplicit(
+                 fn->getASTContext(), fn->getStaticSpelling(), fn->getName(),
+                 fn->getNameLoc(), fn->hasAsync(), fn->hasThrows(),
+                 /*genericParams=*/nullptr, thunkTypeAndParamList.second,
+                 thunkTypeAndParamList.first->getResult(), fn->getDeclContext());
+        thunk->copyFormalAccessFrom(fn);
+        thunk->setBodySynthesizer(synthesizeForwardingThunkBody, cast<FuncDecl>(newDecl));
+        thunk->setSelfAccessKind(fn->getSelfAccessKind());
+
+        return ConcreteDeclRef(thunk);
+      }
+    }
+    return ConcreteDeclRef(newDecl);
   }
 
   return ConcreteDeclRef(decl, subst);
 }
+
 
 ConstraintLocator *Solution::getCalleeLocator(ConstraintLocator *locator,
                                               bool lookThroughApply) const {

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -122,3 +122,8 @@ module DefaultedTemplateTypeParameter {
   header "defaulted-template-type-parameter.h"
   requires cplusplus
 }
+
+module TemplateTypeParameterNotInSignature {
+  header "template-type-parameter-not-in-signature.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/templates/Inputs/template-type-parameter-not-in-signature.h
+++ b/test/Interop/Cxx/templates/Inputs/template-type-parameter-not-in-signature.h
@@ -1,0 +1,31 @@
+#ifndef TEST_INTEROP_CXX_TEMPLATES_INPUTS_TEMPLATE_TYPE_PARAMETER_NOT_IN_SIGNATURE_H
+#define TEST_INTEROP_CXX_TEMPLATES_INPUTS_TEMPLATE_TYPE_PARAMETER_NOT_IN_SIGNATURE_H
+
+template <typename T>
+void templateTypeParamNotUsedInSignature() {}
+
+template <typename T, typename U>
+void multiTemplateTypeParamNotUsedInSignature() {}
+
+template <typename T, typename U>
+U multiTemplateTypeParamOneUsedInSignature(U u) { return u; }
+
+template <typename T, typename U>
+void multiTemplateTypeParamNotUsedInSignatureWithUnrelatedParams(int x, long y) {}
+
+template <typename T>
+T templateTypeParamUsedInReturnType(int x) { return x; }
+
+template <typename T>
+T templateTypeParamUsedInReferenceParam(T &t) { return t; }
+
+template <typename T, typename U>
+void templateTypeParamNotUsedInSignatureWithVarargs(...) {}
+
+template <typename T, typename U, typename V>
+void templateTypeParamNotUsedInSignatureWithVarargsAndUnrelatedParam(int x, ...) {}
+
+template <typename T, int N>
+void templateTypeParamNotUsedInSignatureWithNonTypeParam() {}
+
+#endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_TEMPLATE_TYPE_PARAMETER_NOT_IN_SIGNATURE_H

--- a/test/Interop/Cxx/templates/function-template-module-interface.swift
+++ b/test/Interop/Cxx/templates/function-template-module-interface.swift
@@ -5,7 +5,7 @@
 // CHECK: func passThrough<T>(_ value: T) -> T
 // CHECK: func passThroughConst<T>(_ value: T) -> T
 // CHECK: func templateParameterReturnType<R, T, U>(_ a: T, _ b: U) -> R
-// CHECK: func cannotInferTemplate<T>()
+// CHECK: func cannotInferTemplate<T>(T: T.Type)
 
 // CHECK: struct HasVariadicMemeber {
 // CHECK:   @available(*, unavailable, message: "Variadic function is unavailable")

--- a/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-module-interface.swift
+++ b/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-module-interface.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=TemplateTypeParameterNotInSignature -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK: func templateTypeParamNotUsedInSignature<T>(T: T.Type)
+// CHECK: func multiTemplateTypeParamNotUsedInSignature<T, U>(T: T.Type, U: U.Type)
+// CHECK: func multiTemplateTypeParamOneUsedInSignature<T, U>(_ u: U, T: T.Type) -> U
+// CHECK: func multiTemplateTypeParamNotUsedInSignatureWithUnrelatedParams<T, U>(_ x: Int32, _ y: Int, T: T.Type, U: U.Type)
+// CHECK: func templateTypeParamUsedInReturnType<T>(_ x: Int32) -> T
+// CHECK: func templateTypeParamUsedInReferenceParam<T>(_ t: UnsafeMutablePointer<T>) -> T
+// CHECK: @available(*, unavailable, message: "Variadic function is unavailable")
+// CHECK: func templateTypeParamNotUsedInSignatureWithVarargs<T, U>(T: T.Type, U: U.Type, _ varargs: Any...)
+// CHECK: @available(*, unavailable, message: "Variadic function is unavailable")
+// CHECK: func templateTypeParamNotUsedInSignatureWithVarargsAndUnrelatedParam<T, U, V>(_ x: Int32, T: T.Type, U: U.Type, V: V.Type, _ varargs: Any...)

--- a/test/Interop/Cxx/templates/template-type-parameter-not-in-signature.swift
+++ b/test/Interop/Cxx/templates/template-type-parameter-not-in-signature.swift
@@ -1,0 +1,26 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop -Xfrontend -validate-tbd-against-ir=none)
+//
+// REQUIRES: executable_test
+
+import TemplateTypeParameterNotInSignature
+import StdlibUnittest
+
+var TemplateNotInSignatureTestSuite = TestSuite("Template Type Parameters Not in Function Signature")
+
+TemplateNotInSignatureTestSuite.test("Function with defaulted template type parameters") {
+  templateTypeParamNotUsedInSignature(T: Int.self)
+  multiTemplateTypeParamNotUsedInSignature(T: Float.self, U: Int.self)
+  let x: Int = multiTemplateTypeParamOneUsedInSignature(1, T: Int.self)
+  expectEqual(x, 1)
+  multiTemplateTypeParamNotUsedInSignatureWithUnrelatedParams(1, 1, T: Int32.self, U: Int.self)
+  let y: Int = templateTypeParamUsedInReturnType(10)
+  expectEqual(y, 10)
+}
+
+TemplateNotInSignatureTestSuite.test("Pointer types") {
+  var x = 1
+  x = templateTypeParamUsedInReferenceParam(&x)
+  expectEqual(x, 1)
+}
+
+runAllTests()


### PR DESCRIPTION
Currently if we try to import a templated function when the template parameters do not appear in the function signature, the corresponding Swift function will have extra unused generic parameters, which means we can't call those functions. This patch fixes the problem by making those template params into explicit metatype function parameters to the corresponding Swift function. E.g.
```
template <typename T>
void foo()
```
becomes:
```
func foo<T>(T: T.Type) 
```
instead of:
```
func foo<T>() // can't be called
```
This extra argument is only used to deduce the generic type needed to specialize the C++ function. The corresponding function call made under the hood will cut out the extra argument and forward along the proper parameters to the C++ function. 
