### PR TITLE
[Distributed] Fix when we invoke thunk, base it on typesystem implicit effects

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1206,7 +1206,9 @@ public:
   /// which are cross-actor invoked, because such calls actually go over the
   /// transport/network, and may throw from this, rather than the function
   /// implementation itself..
-  bool isImplicitlyThrows() const { return Bits.DeclRefExpr.IsImplicitlyThrows; }
+  bool isImplicitlyThrows() const {
+    return Bits.DeclRefExpr.IsImplicitlyThrows;
+  }
 
   /// Set whether this reference must account for a `throw` occurring for reasons
   /// other than the function implementation itself throwing, e.g. an
@@ -4391,7 +4393,7 @@ public:
   ///
   /// where the new closure is declared to be async.
   ///
-  /// When the application is implciitly async, the result describes
+  /// When the application is implicitly async, the result describes
   /// the actor to which we need to need to hop.
   Optional<ImplicitActorHopTarget> isImplicitlyAsync() const {
     if (!Bits.ApplyExpr.ImplicitlyAsync)
@@ -4418,6 +4420,10 @@ public:
   void setImplicitlyThrows(bool flag) {
     Bits.ApplyExpr.ImplicitlyThrows = flag;
   }
+
+  /// Informs IRGen to that this expression should be applied as its distributed
+  /// thunk, rather than invoking the function directly.
+  bool shouldApplyDistributedThunk() const;
 
   ValueDecl *getCalledValue() const;
 

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -307,12 +307,13 @@ protected:
     NumCaptures : 32
   );
 
-  SWIFT_INLINE_BITFIELD(ApplyExpr, Expr, 1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ApplyExpr, Expr, 1+1+1+1+1+1,
     ThrowsIsSet : 1,
     Throws : 1,
     ImplicitlyAsync : 1,
     ImplicitlyThrows : 1,
-    NoAsync : 1
+    NoAsync : 1,
+    ShouldApplyDistributedThunk : 1
   );
 
   SWIFT_INLINE_BITFIELD_EMPTY(CallExpr, ApplyExpr);
@@ -4423,7 +4424,12 @@ public:
 
   /// Informs IRGen to that this expression should be applied as its distributed
   /// thunk, rather than invoking the function directly.
-  bool shouldApplyDistributedThunk() const;
+  bool shouldApplyDistributedThunk() const {
+    return Bits.ApplyExpr.ShouldApplyDistributedThunk;
+  }
+  void setShouldApplyDistributedThunk(bool flag) {
+    Bits.ApplyExpr.ShouldApplyDistributedThunk = flag;
+  }
 
   ValueDecl *getCalledValue() const;
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1068,22 +1068,6 @@ Type OverloadSetRefExpr::getBaseType() const {
   llvm_unreachable("Unhandled overloaded set reference expression");
 }
 
-bool ApplyExpr::shouldApplyDistributedThunk() const {
-  // only a distributed decl has a chance of needing to be invoked as a thunk
-  auto func = dyn_cast<AbstractFunctionDecl>(getCalledValue());
-  if (!func || !func->isDistributed())
-    return false;
-
-  if (implicitlyThrows())
-    return true;
-
-  auto isEffectivelyAsync = func->hasAsync() || isImplicitlyAsync();
-  if (func->hasThrows() && isEffectivelyAsync)
-    return true;
-
-  return false;
-}
-
 bool OverloadSetRefExpr::hasBaseObject() const {
   if (Type BaseTy = getBaseType())
     return !BaseTy->is<AnyMetatypeType>();

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1068,6 +1068,22 @@ Type OverloadSetRefExpr::getBaseType() const {
   llvm_unreachable("Unhandled overloaded set reference expression");
 }
 
+bool ApplyExpr::shouldApplyDistributedThunk() const {
+  // only a distributed decl has a chance of needing to be invoked as a thunk
+  auto func = dyn_cast<AbstractFunctionDecl>(getCalledValue());
+  if (!func || !func->isDistributed())
+    return false;
+
+  if (implicitlyThrows())
+    return true;
+
+  auto isEffectivelyAsync = func->hasAsync() || isImplicitlyAsync();
+  if (func->hasThrows() && isEffectivelyAsync)
+    return true;
+
+  return false;
+}
+
 bool OverloadSetRefExpr::hasBaseObject() const {
   if (Type BaseTy = getBaseType())
     return !BaseTy->is<AnyMetatypeType>();

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1117,12 +1117,8 @@ public:
 
     // Otherwise, we have a statically-dispatched call.
     auto constant = SILDeclRef(e->getDecl());
-    if (e->getDecl()->getAttrs().hasAttribute<DistributedActorAttr>()) {
-      // we're calling a distributed function, only in cross-actor situations
-      // does this actually need to call the thunk.
-      if (!selfApply) {
-        constant = constant.asDistributed(true);
-      }
+    if (callSite && callSite->shouldApplyDistributedThunk()) {
+      constant = constant.asDistributed(true);
     } else {
       constant = constant.asForeign(
                    !isConstructorWithGeneratedAllocatorThunk(e->getDecl())

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2277,7 +2277,8 @@ namespace {
             } else if (func->isDistributed()) {
               tryMarkImplicitlyAsync(memberLoc, memberRef, context,
                                      ImplicitActorHopTarget::forInstanceSelf());
-                tryMarkImplicitlyThrows(memberLoc, memberRef, context);
+              tryMarkImplicitlyThrows(memberLoc, memberRef, context);
+
             } else {
               // neither static or distributed, apply full distributed isolation
               ctx.Diags.diagnose(memberLoc, diag::distributed_actor_isolated_method)

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1003,7 +1003,8 @@ namespace {
     ///
     /// and we reach up to mark the CallExpr.
     void markNearestCallAsImplicitly(
-        Optional<ImplicitActorHopTarget> setAsync, bool setThrows = false) {
+        Optional<ImplicitActorHopTarget> setAsync,
+        bool setThrows = false, bool setDistributedThunk = false) {
       assert(applyStack.size() > 0 && "not contained within an Apply?");
 
       const auto End = applyStack.rend();
@@ -1011,6 +1012,7 @@ namespace {
         if (auto call = dyn_cast<CallExpr>(*I)) {
           if (setAsync) call->setImplicitlyAsync(*setAsync);
           if (setThrows) call->setImplicitlyThrows(true);
+          if (setDistributedThunk) call->setShouldApplyDistributedThunk(true);
           return;
         }
       llvm_unreachable("expected a CallExpr in applyStack!");
@@ -1667,7 +1669,6 @@ namespace {
     ThrowsMarkingResult tryMarkImplicitlyThrows(SourceLoc declLoc,
                                                 ConcreteDeclRef concDeclRef,
                                                 Expr* context) {
-
       ValueDecl *decl = concDeclRef.getDecl();
       ThrowsMarkingResult result = ThrowsMarkingResult::NotFound;
 
@@ -1869,8 +1870,11 @@ namespace {
       }
 
       switch (contextIsolation) {
-      case ActorIsolation::ActorInstance:
-      case ActorIsolation::DistributedActorInstance: {
+      case ActorIsolation::DistributedActorInstance:
+        markNearestCallAsImplicitly(/*setAsync*/None, /*setThrows*/false,
+                                    /*setDistributedThunk*/true);
+        LLVM_FALLTHROUGH;
+      case ActorIsolation::ActorInstance: {
         auto result = tryMarkImplicitlyAsync(
           loc, valueRef, context,
           ImplicitActorHopTarget::forGlobalActor(globalActor));
@@ -2278,6 +2282,8 @@ namespace {
               tryMarkImplicitlyAsync(memberLoc, memberRef, context,
                                      ImplicitActorHopTarget::forInstanceSelf());
               tryMarkImplicitlyThrows(memberLoc, memberRef, context);
+              markNearestCallAsImplicitly(/*setAsync*/None, /*setThrows*/false,
+                                          /*setDistributedThunk*/true);
 
             } else {
               // neither static or distributed, apply full distributed isolation
@@ -2363,8 +2369,7 @@ namespace {
           }
 
           // It wasn't a distributed func, so ban the access
-          // TODO(distributed): handle subscripts here too
-          if (auto var = dyn_cast<VarDecl>(member)) {
+          if (isPropOrSubscript(member)) {
             ctx.Diags.diagnose(
                 memberLoc, diag::distributed_actor_isolated_non_self_reference,
                 member->getDescriptiveKind(), member->getName());
@@ -2380,6 +2385,8 @@ namespace {
         if (isolation.getActorType()->isDistributedActor() &&
             !isolatedActor.isPotentiallyIsolated) {
           tryMarkImplicitlyThrows(memberLoc, memberRef, context);
+          markNearestCallAsImplicitly(/*setAsync*/None, /*setThrows*/false,
+                                      /*setDistributedThunk*/true);
         }
 
         if (implicitAsyncResult == AsyncMarkingResult::FoundAsync)

--- a/test/Distributed/Runtime/distributed_actor_dynamic_remote_func.swift
+++ b/test/Distributed/Runtime/distributed_actor_dynamic_remote_func.swift
@@ -54,7 +54,7 @@ struct FakeTransport: ActorTransport {
     fatalError("not implemented:\(#function)")
   }
 
-  func resolve<Act>(_ identity: Act.ID, as actorType: Act.Type)
+  func resolve<Act>(_ identity: AnyActorIdentity, as actorType: Act.Type)
   throws -> Act?
       where Act: DistributedActor {
     return nil
@@ -95,7 +95,7 @@ func test_remote() async throws {
   let address = ActorAddress(parse: "")
   let transport = FakeTransport()
 
-  let worker = try LocalWorker(resolve: .init(address), using: transport)
+  let worker = try LocalWorkerresolve(.init(address), using: transport)
   let x = try await worker.function()
   print("call: \(x)")
   // CHECK: call: _cluster_remote_function():

--- a/test/Distributed/Runtime/distributed_actor_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_local.swift
@@ -49,7 +49,7 @@ struct FakeTransport: ActorTransport {
     fatalError("not implemented \(#function)")
   }
 
-  func resolve<Act>(_ identity: Act.ID, as actorType: Act.Type) throws -> Act?
+  func resolve<Act>(_ identity: AnyActorIdentity, as actorType: Act.Type) throws -> Act?
       where Act: DistributedActor {
     return nil
   }
@@ -75,7 +75,7 @@ func test_initializers() {
   let transport = FakeTransport()
 
   _ = SomeSpecificDistributedActor(transport: transport)
-  _ = try! SomeSpecificDistributedActor(resolve: .init(address), using: transport)
+  _ = try! SomeSpecificDistributedActor.resolve(.init(address), using: transport)
 }
 
 @available(SwiftStdlib 5.5, *)

--- a/test/Distributed/Runtime/distributed_actor_remote_functions.swift
+++ b/test/Distributed/Runtime/distributed_actor_remote_functions.swift
@@ -11,8 +11,6 @@
 // rdar://77798215
 // UNSUPPORTED: OS=windows-msvc
 
-// REQUIRES: rdar78290608
-
 import _Distributed
 import _Concurrency
 
@@ -114,7 +112,7 @@ struct FakeTransport: ActorTransport {
     fatalError("not implemented:\(#function)")
   }
 
-  func resolve<Act>(_ identity: Act.ID, as actorType: Act.Type)
+  func resolve<Act>(_ identity: AnyActorIdentity, as actorType: Act.Type)
   throws -> Act?
       where Act: DistributedActor {
     return nil
@@ -155,21 +153,21 @@ func test_remote_invoke(address: ActorAddress, transport: ActorTransport) async 
     if __isRemoteActor(actor) {
       do {
         _ = try await actor.helloThrowsTransportBoom()
-        preconditionFailure("helloThrowsTransportBoom: should have thrown")
+        print("WRONG: helloThrowsTransportBoom: should have thrown")
       } catch {
         print("\(personality) - helloThrowsTransportBoom: \(error)")
       }
     } else {
       do {
         _ = try await actor.helloThrowsImplBoom()
-        preconditionFailure("helloThrowsImplBoom: Should have thrown")
+        print("WRONG: helloThrowsImplBoom: Should have thrown")
       } catch {
         print("\(personality) - helloThrowsImplBoom: \(error)")
       }
     }
   }
 
-  let remote = try! SomeSpecificDistributedActor(resolve: .init(address), using: transport)
+  let remote = try! SomeSpecificDistributedActor.resolve(.init(address), using: transport)
   assert(__isRemoteActor(remote) == true, "should be remote")
 
   let local = SomeSpecificDistributedActor(transport: transport)

--- a/test/Distributed/Runtime/distributed_no_transport_boom.swift
+++ b/test/Distributed/Runtime/distributed_no_transport_boom.swift
@@ -36,7 +36,7 @@ struct FakeTransport: ActorTransport {
     fatalError("not implemented:\(#function)")
   }
 
-  func resolve<Act>(_ identity: Act.ID, as actorType: Act.Type)
+  func resolve<Act>(_ identity: AnyActorIdentity, as actorType: Act.Type)
   throws -> Act?
       where Act: DistributedActor {
     return nil
@@ -65,7 +65,7 @@ func test_remote() async {
   let address = ActorAddress(parse: "")
   let transport = FakeTransport()
 
-  let remote = try! SomeSpecificDistributedActor(resolve: .init(address), using: transport)
+  let remote = try! SomeSpecificDistributedActor.resolve(.init(address), using: transport)
   _ = try! await remote.hello() // let it crash!
 
   // CHECK: SOURCE_DIR/test/Distributed/Runtime/distributed_no_transport_boom.swift:18: Fatal error: Invoked remote placeholder function '_remote_hello' on remote distributed actor of type 'main.SomeSpecificDistributedActor'. Configure an appropriate 'ActorTransport' for this actor to resolve this error (e.g. by depending on some specific transport library).


### PR DESCRIPTION
This solves: https://github.com/apple/swift/pull/39523/files#r719927958 which actually was not only meh style but actually wrong! It caused us to never call the distributed thunk ⚠️

I also unlocked the https://github.com/apple/swift/compare/main...ktoso:remote-calls-bad?expand=1#diff-72a02f8df5425bc51b955369eac5037b49dc42971a6788d8de9dbc79e296d1f7 which shows the issue... (Long story why it was disabled... there's a PR reviving all those tests)
