### PR TITLE
Revert "[silgen] Ensure that the outer cleanup is emitted along failure paths when initializing sub-tuple patterns"

### DIFF
--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -69,16 +69,9 @@ void TupleInitialization::copyOrInitValueInto(SILGenFunction &SGF,
   // In the address case, we forward the underlying value and store it
   // into memory and then create a +1 cleanup. since we assume here
   // that we have a +1 value since we are forwarding into memory.
-  //
-  // In order to ensure that we properly clean up along any failure paths, we
-  // need to mark value as being persistently active. We then unforward it once
-  // we are done.
   assert(value.isPlusOne(SGF) && "Can not store a +0 value into memory?!");
-  CleanupStateRestorationScope valueScope(SGF.Cleanups);
-  if (value.hasCleanup())
-    valueScope.pushCleanupState(value.getCleanup(),
-                                CleanupState::PersistentlyActive);
-  copyOrInitValueIntoHelper(
+  value = ManagedValue::forUnmanaged(value.forward(SGF));
+  return copyOrInitValueIntoHelper(
       SGF, loc, value, isInit, SubInitializations,
       [&](ManagedValue aggregate, unsigned i,
           SILType fieldType) -> ManagedValue {
@@ -90,8 +83,6 @@ void TupleInitialization::copyOrInitValueInto(SILGenFunction &SGF,
 
         return SGF.emitManagedRValueWithCleanup(elt.getValue());
       });
-  std::move(valueScope).pop();
-  value.forward(SGF);
 }
 
 void TupleInitialization::finishUninitialized(SILGenFunction &SGF) {

--- a/test/SILGen/enum.swift
+++ b/test/SILGen/enum.swift
@@ -219,23 +219,3 @@ func sr7799_1(bar: SR7799??) {
   default: print("default")
   }
 }
-
-// Make sure that we handle enum, tuple initialization composed
-// correctly. Previously, we leaked down a failure path due to us misusing
-// scopes.
-enum rdar81817725 {
-    case localAddress
-    case setOption(Int, Any)
-
-    static func takeAny(_:Any) -> Bool { return true }
-
-    static func testSwitchCleanup(syscall: rdar81817725, expectedLevel: Int,
-                                  valueMatcher: (Any) -> Bool)
-      throws -> Bool {
-        if case .setOption(expectedLevel, let value) = syscall {
-            return rdar81817725.takeAny(value)
-        } else {
-            return false
-        }
-    }
-}


### PR DESCRIPTION
This reverts commit be922b999038eae35b8aa120e1df7b11892fcf5f.

By adding some extra scopes here we are triggering some broken behavior in a
bunch of projects. I am going to see if I can do another fix for this. That
being said in the short term, we are reverting to unblock those projects.

rdar://83770295 is tracking a new fix

This resolves rdar://83622269