### PR TITLE
[IRGen] Emit keypath thunk helpers with swiftcc to match with the caller cc

### DIFF
--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -281,6 +281,7 @@ getLayoutFunctionForComputedComponent(IRGenModule &IGM,
   auto layoutFn = llvm::Function::Create(fnTy,
     llvm::GlobalValue::PrivateLinkage, "keypath_get_arg_layout", IGM.getModule());
   layoutFn->setAttributes(IGM.constructInitialAttributes());
+  layoutFn->setCallingConv(IGM.SwiftCC);
     
   {
     IRGenFunction IGF(IGM, layoutFn);
@@ -383,6 +384,7 @@ getWitnessTableForComputedComponent(IRGenModule &IGM,
         llvm::GlobalValue::PrivateLinkage, "keypath_destroy", IGM.getModule());
       destroy = destroyFn;
       destroyFn->setAttributes(IGM.constructInitialAttributes());
+      destroyFn->setCallingConv(IGM.SwiftCC);
       
       IRGenFunction IGF(IGM, destroyFn);
       if (IGM.DebugInfo)
@@ -432,6 +434,7 @@ getWitnessTableForComputedComponent(IRGenModule &IGM,
         llvm::GlobalValue::PrivateLinkage, "keypath_copy", IGM.getModule());
       copy = copyFn;
       copyFn->setAttributes(IGM.constructInitialAttributes());
+      copyFn->setCallingConv(IGM.SwiftCC);
       
       IRGenFunction IGF(IGM, copyFn);
       if (IGM.DebugInfo)
@@ -545,6 +548,7 @@ getInitializerForComputedComponent(IRGenModule &IGM,
   auto initFn = llvm::Function::Create(fnTy,
     llvm::GlobalValue::PrivateLinkage, "keypath_arg_init", IGM.getModule());
   initFn->setAttributes(IGM.constructInitialAttributes());
+  initFn->setCallingConv(IGM.SwiftCC);
     
   {
     IRGenFunction IGF(IGM, initFn);

--- a/test/IRGen/default_function_ir_attributes.swift
+++ b/test/IRGen/default_function_ir_attributes.swift
@@ -119,35 +119,35 @@ func test_computed_key_path_sil_thunks() -> KeyPath<S, Int> {
 }
 
 //   helper function: IR-generated key path getter
-// CHECK-LABEL: define {{.*}} @keypath_get(
+// CHECK-LABEL: define {{.*}} swiftcc {{.*}} @keypath_get(
 // CHECK-SAME: [[ATTRS_SIMPLE]]
 
 //   helper function: IR-generated key path setter
-// CHECK-LABEL: define {{.*}} @keypath_set(
+// CHECK-LABEL: define {{.*}} swiftcc {{.*}} @keypath_set(
 // CHECK-SAME: [[ATTRS_SIMPLE]]
 
 //   helper function: IR-generated key path arg layout accessor
-// CHECK-LABEL: define {{.*}} @keypath_get_arg_layout(
+// CHECK-LABEL: define {{.*}} swiftcc {{.*}} @keypath_get_arg_layout(
 // CHECK-SAME: [[ATTRS_SIMPLE]]
 
 //   helper function: IR-generated key path destroy function
-// CHECK-LABEL: define {{.*}} @keypath_destroy(
+// CHECK-LABEL: define {{.*}} swiftcc {{.*}} @keypath_destroy(
 // CHECK-SAME: [[ATTRS_SIMPLE]]
 
 //   helper function: IR-generated key path copy function
-// CHECK-LABEL: define {{.*}} @keypath_copy(
+// CHECK-LABEL: define {{.*}} swiftcc {{.*}} @keypath_copy(
 // CHECK-SAME: [[ATTRS_SIMPLE]]
 
 //   helper function: IR-generated key path equals function
-// CHECK-LABEL: define {{.*}} @keypath_equals(
+// CHECK-LABEL: define {{.*}} swiftcc {{.*}} @keypath_equals(
 // CHECK-SAME: [[ATTRS_SIMPLE]]
 
 //   helper function: IR-generated key path hash function
-// CHECK-LABEL: define {{.*}} @keypath_hash(
+// CHECK-LABEL: define {{.*}} swiftcc {{.*}} @keypath_hash(
 // CHECK-SAME: [[ATTRS_SIMPLE]]
 
 //   helper function: IR-generated key path argument initializer
-// CHECK-LABEL: define {{.*}} @keypath_arg_init(
+// CHECK-LABEL: define {{.*}} swiftcc {{.*}} @keypath_arg_init(
 // CHECK-SAME: [[ATTRS_SIMPLE]]
 
 func test_computed_key_path_generic_thunks<T: P0 & Hashable>(value: T) -> KeyPath<S, Int> {


### PR DESCRIPTION
KeyPath thunk helpers are called from stdlib indirectly through
descriptor and its calling-convention in the caller side are SwiftCC.
However, the definition side expects C calling-convention, so they
can be broken on some architectures, that SwiftCC is not compatible
with C-CC on it.

This patch changes to use SwiftCC consistently on caller side and
definition side.
This doesn't have any effect on the ABI stable platforms because
SwiftCC is compatible with C-CC on them.

The caller-side signatures are defined here without `@convention(c)` 
https://github.com/apple/swift/blob/ef4a2eeb6b8347752897f43351da946cbf1323d7/stdlib/public/core/KeyPath.swift#L481-L486
https://github.com/apple/swift/blob/ef4a2eeb6b8347752897f43351da946cbf1323d7/stdlib/public/core/KeyPath.swift#L568-L581

This fixes case 2 of https://bugs.swift.org/browse/SR-15188

CC: @MaxDesiatov 
