### PR TITLE
[android] Disable fake-toolchain-module-interface test

### DIFF
--- a/test/Interop/Cxx/stdlib/fake-toolchain-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/fake-toolchain-module-interface.swift
@@ -2,6 +2,9 @@
 
 // Clang driver on Windows doesn't support -stdlib=libc++
 // XFAIL: OS=windows-msvc
+// Android NDK layout might need more flags to find libc++
+// XFAIL: OS=linux-androideabi
+// XFAIL: OS=linux-android
 
 // CHECK: extension FakeNamespace {
 // CHECK:   static func foo(_ x: Int32)


### PR DESCRIPTION
Android NDK layout might not be the same as the system layout for
finding libc++ so the test seems to fail. Disabling for the time being
to avoid having the CI broken.

/cc @egorzhdan @zoecarver 