### PR TITLE
Re-enable IRGen test opaque_result_type.swift on arm64e

### DIFF
--- a/test/IRGen/opaque_result_type.swift
+++ b/test/IRGen/opaque_result_type.swift
@@ -5,9 +5,6 @@
 // rdar://76863553
 // UNSUPPORTED: OS=watchos && CPU=x86_64
 
-// https://bugs.swift.org/browse/SR-15237
-// UNSUPPORTED: CPU=arm64e
-
 public protocol O {
   func bar()
 }


### PR DESCRIPTION
This was fixed by #39497