### PR TITLE
Add `-require-explicit-sendable` to warn about non-Sendable public types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1949,6 +1949,15 @@ NOTE(non_sendable_nominal,none,
 NOTE(add_nominal_sendable_conformance,none,
      "consider making %0 %1 conform to the 'Sendable' protocol",
      (DescriptiveDeclKind, DeclName))
+WARNING(public_decl_needs_sendable,none,
+        "public %0 %1 does not specify whether it is 'Sendable' or not",
+        (DescriptiveDeclKind, DeclName))
+NOTE(explicit_unchecked_sendable,none,
+     "add '@unchecked Sendable' conformance to %0 %1 if this type manually implements concurrency safety",
+     (DescriptiveDeclKind, DeclName))
+NOTE(explicit_disable_sendable,none,
+     "make %0 %1 explicitly non-Sendable to suppress this warning",
+     (DescriptiveDeclKind, DeclName))
 
 NOTE(required_by_opaque_return,none,
     "required by opaque return type of %0 %1", (DescriptiveDeclKind, DeclName))

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -176,6 +176,9 @@ namespace swift {
     // Availability macros definitions to be expanded at parsing.
     SmallVector<std::string, 4> AvailabilityMacros;
 
+    /// Require public declarations to declare that they are Sendable (or not).
+    bool RequireExplicitSendable = false;
+
     /// If false, '#file' evaluates to the full path rather than a
     /// human-readable string.
     bool EnableConcisePoundFile = false;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -413,6 +413,10 @@ def require_explicit_availability_target : Separate<["-"], "require-explicit-ava
   HelpText<"Suggest fix-its adding @available(<target>, *) to public declarations without availability">,
   MetaVarName<"<target>">;
 
+def require_explicit_sendable : Flag<["-"], "require-explicit-sendable">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  HelpText<"Require explicit Sendable annotations on public declarations">;
+
 def define_availability : Separate<["-"], "define-availability">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Define an availability macro in the format 'macroName : iOS 13.0, macOS 10.15'">,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -233,6 +233,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_enable_library_evolution);
   inputArgs.AddLastArg(arguments, options::OPT_require_explicit_availability);
   inputArgs.AddLastArg(arguments, options::OPT_require_explicit_availability_target);
+  inputArgs.AddLastArg(arguments, options::OPT_require_explicit_sendable);
   inputArgs.AddLastArg(arguments, options::OPT_enable_testing);
   inputArgs.AddLastArg(arguments, options::OPT_enable_private_imports);
   inputArgs.AddLastArg(arguments, options::OPT_g_Group);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -573,6 +573,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
+  Opts.RequireExplicitSendable |= Args.hasArg(OPT_require_explicit_sendable);
   for (const Arg *A : Args.filtered(OPT_define_availability)) {
     Opts.AvailabilityMacros.push_back(A->getValue());
   }

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -245,6 +245,10 @@ bool diagnoseNonSendableTypesInReference(
 void diagnoseMissingSendableConformance(
     SourceLoc loc, Type type, ModuleDecl *module);
 
+/// If the given nominal type is public and does not explicitly
+/// state whether it conforms to Sendable, provide a diagnostic.
+void diagnoseMissingExplicitSendable(NominalTypeDecl *nominal);
+
 /// Diagnose any non-Sendable types that occur within the given type, using
 /// the given diagnostic.
 ///
@@ -255,7 +259,8 @@ void diagnoseMissingSendableConformance(
 /// \returns \c true if any diagnostics were produced, \c false otherwise.
 bool diagnoseNonSendableTypes(
     Type type, ModuleDecl *module, SourceLoc loc,
-    llvm::function_ref<bool(Type, DiagnosticBehavior)> diagnose);
+    llvm::function_ref<
+      std::pair<DiagnosticBehavior, bool>(Type, DiagnosticBehavior)> diagnose);
 
 namespace detail {
   template<typename T>
@@ -276,7 +281,8 @@ bool diagnoseNonSendableTypes(
       type, module, loc, [&](Type specificType, DiagnosticBehavior behavior) {
     ctx.Diags.diagnose(loc, diag, type, diagArgs...)
       .limitBehavior(behavior);
-    return behavior == DiagnosticBehavior::Unspecified;
+    return std::pair<DiagnosticBehavior, bool>(
+        behavior, behavior == DiagnosticBehavior::Unspecified);
   });
 }
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2207,7 +2207,7 @@ public:
       visit(member);
 
     checkInheritanceClause(ED);
-
+    diagnoseMissingExplicitSendable(ED);
     checkAccessControl(ED);
 
     TypeChecker::checkPatternBindingCaptures(ED);
@@ -2257,6 +2257,7 @@ public:
     TypeChecker::checkPatternBindingCaptures(SD);
 
     checkInheritanceClause(SD);
+    diagnoseMissingExplicitSendable(SD);
 
     checkAccessControl(SD);
 
@@ -2508,6 +2509,7 @@ public:
     }
 
     checkInheritanceClause(CD);
+    diagnoseMissingExplicitSendable(CD);
 
     checkAccessControl(CD);
 

--- a/test/Concurrency/concurrent_value_inference.swift
+++ b/test/Concurrency/concurrent_value_inference.swift
@@ -10,7 +10,7 @@ struct S1 {
   var c: C2
 }
 
-enum E1 { // expected-note{{consider making enum 'E1' conform to the 'Sendable' protocol}}{{9-9=: Sendable }}
+enum E1 { // expected-note {{consider making enum 'E1' conform to the 'Sendable' protocol}}{{9-9=: Sendable}}
   case base
   indirect case nested(E1)
 }

--- a/test/Concurrency/concurrent_value_inference.swift
+++ b/test/Concurrency/concurrent_value_inference.swift
@@ -96,6 +96,14 @@ class C3 { }
 
 class C4: C3 { }
 
+// Make Sendable unavailable, but be sure not to diagnose it.
+struct S2 {
+  var c1: C1
+}
+
+@available(*, unavailable)
+extension S2: Sendable { }
+
 func testCV(
   c1: C1, c2: C2, c3: C3, c4: C4, s1: S1, e1: E1, e2: E2,
   gs1: GS1<Int>, gs2: GS2<Int>,

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -58,7 +58,7 @@ extension S6: Sendable where T: Sendable, U: Sendable { }
 func acceptSendable<T: Sendable>(_: T) {
 }
 
-struct S7 {
+struct S7 { // FIXME: expected-note{{consider making struct 'S7' conform to the 'Sendable' protocol}}
 }
 
 @available(*, unavailable)
@@ -92,4 +92,8 @@ public struct S10 { // expected-warning{{public struct 'S10' does not specify wh
   // expected-note@-1{{add '@unchecked Sendable' conformance to struct 'S10' if this type manually implements concurrency safety}}
   // expected-note@-2{{make struct 'S10' explicitly non-Sendable to suppress this warning}}
   var s7: S7
+}
+
+struct S11: Sendable {
+  var s7: S7 // expected-error{{stored property 's7' of 'Sendable'-conforming struct 'S11' has non-sendable type 'S7'}}
 }

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -87,3 +87,9 @@ public struct S9<T: P2 & Hashable> {
   // expected-note@-3{{make generic struct 'S9' explicitly non-Sendable to suppress this warning}}
   var dict: [T : T.A] = [:]
 }
+
+public struct S10 { // expected-warning{{public struct 'S10' does not specify whether it is 'Sendable' or not}}
+  // expected-note@-1{{add '@unchecked Sendable' conformance to struct 'S10' if this type manually implements concurrency safety}}
+  // expected-note@-2{{make struct 'S10' explicitly non-Sendable to suppress this warning}}
+  var s7: S7
+}

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -1,0 +1,56 @@
+// RUN: %target-typecheck-verify-swift -require-explicit-sendable
+
+public protocol P { }
+
+public struct S1 { // expected-warning{{public struct 'S1' does not specify whether it is 'Sendable' or not}}
+  // expected-note@-1{{consider making struct 'S1' conform to the 'Sendable' protocol}}{{18-18=: Sendable}}
+  // expected-note@-2{{make struct 'S1' explicitly non-Sendable to suppress this warning}}{{2-2=\n\n@available(*, unavailable)\nextension S1: Sendable { \}\n}}
+  var str: String
+}
+
+class C { }
+
+public struct S2 { // expected-warning{{public struct 'S2' does not specify whether it is 'Sendable' or not}}
+  // expected-note@-1{{add '@unchecked Sendable' conformance to struct 'S2' if this type manually implements concurrency safety}}{{18-18=: @unchecked Sendable}}
+  // expected-note@-2{{make struct 'S2' explicitly non-Sendable to suppress this warning}}{{2-2=\n\n@available(*, unavailable)\nextension S2: Sendable { \}\n}}
+  var c: C
+}
+
+final public class C1: P { // expected-warning{{public class 'C1' does not specify whether it is 'Sendable' or not}}
+  // expected-note@-1{{consider making class 'C1' conform to the 'Sendable' protocol}}{{25-25=, Sendable}}
+  // expected-note@-2{{make class 'C1' explicitly non-Sendable to suppress this warning}}{{2-2=\n\n@available(*, unavailable)\nextension C1: Sendable { \}\n}}
+  let str: String = ""
+}
+
+public class C2 { // expected-warning{{public class 'C2' does not specify whether it is 'Sendable' or not}}
+  // expected-note@-1{{add '@unchecked Sendable' conformance to class 'C2' if this type manually implements concurrency safety}}{{17-17=: @unchecked Sendable}}
+  // expected-note@-2{{make class 'C2' explicitly non-Sendable to suppress this warning}}{{2-2=\n\n@available(*, unavailable)\nextension C2: Sendable { \}\n}}
+  var str: String = ""
+}
+
+public struct S3<T> { // expected-warning{{public generic struct 'S3' does not specify whether it is 'Sendable' or not}}
+  // expected-note@-1{{add '@unchecked Sendable' conformance to generic struct 'S3' if this type manually implements concurrency safety}}{{21-21=: @unchecked Sendable}}
+  // expected-note@-2{{make generic struct 'S3' explicitly non-Sendable to suppress this warning}}{{2-2=\n\n@available(*, unavailable)\nextension S3: Sendable { \}\n}}
+  var t: T
+}
+
+public struct S4<T> { // expected-warning{{public generic struct 'S4' does not specify whether it is 'Sendable' or not}}
+  // expected-note@-1{{add '@unchecked Sendable' conformance to generic struct 'S4' if this type manually implements concurrency safety}}{{21-21=: @unchecked Sendable}}
+  // expected-note@-2{{make generic struct 'S4' explicitly non-Sendable to suppress this warning}}{{2-2=\n\n@available(*, unavailable)\nextension S4: Sendable { \}\n}}
+  var t: T
+  var c: C
+}
+
+public struct S5 { } // no diagnostic: S5 is not Sendable
+
+@available(*, unavailable)
+extension S5: Sendable { }
+
+// Public type with a conditional conformance, so don't complain
+public struct S6<T, U> {
+  var t: T
+  var u: U
+}
+
+extension S6: Sendable where T: Sendable, U: Sendable { }
+

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -29,13 +29,13 @@ public class C2 { // expected-warning{{public class 'C2' does not specify whethe
 }
 
 public struct S3<T> { // expected-warning{{public generic struct 'S3' does not specify whether it is 'Sendable' or not}}
-  // expected-note@-1{{add '@unchecked Sendable' conformance to generic struct 'S3' if this type manually implements concurrency safety}}{{21-21=: @unchecked Sendable}}
+  // expected-note@-1{{consider making generic struct 'S3' conform to the 'Sendable' protocol}}{{2-2=\n\nextension S3: Sendable where T: Sendable { \}\n}}
   // expected-note@-2{{make generic struct 'S3' explicitly non-Sendable to suppress this warning}}{{2-2=\n\n@available(*, unavailable)\nextension S3: Sendable { \}\n}}
   var t: T
 }
 
 public struct S4<T> { // expected-warning{{public generic struct 'S4' does not specify whether it is 'Sendable' or not}}
-  // expected-note@-1{{add '@unchecked Sendable' conformance to generic struct 'S4' if this type manually implements concurrency safety}}{{21-21=: @unchecked Sendable}}
+  // expected-note@-1{{add '@unchecked Sendable' conformance to generic struct 'S4' if this type manually implements concurrency safety}}{{2-2=\n\nextension S4: @unchecked Sendable where T: Sendable { \}\n}}
   // expected-note@-2{{make generic struct 'S4' explicitly non-Sendable to suppress this warning}}{{2-2=\n\n@available(*, unavailable)\nextension S4: Sendable { \}\n}}
   var t: T
   var c: C
@@ -69,4 +69,21 @@ extension S7: Sendable { }
 func testMe(s5: S5, s7: S7) {
   acceptSendable(s5) // expected-warning{{conformance of 'S5' to 'Sendable' is unavailable}}
   acceptSendable(s7) // expected-warning{{conformance of 'S7' to 'Sendable' is unavailable}}
+}
+
+public struct S8<T: Hashable, U, V> { // expected-warning{{public generic struct 'S8' does not specify whether it is 'Sendable' or not}}
+  // expected-note@-1{{consider making generic struct 'S8' conform to the 'Sendable' protocol}}{{2-2=\n\nextension S8: Sendable where T: Sendable, U: Sendable, V: Sendable { \}\n}}
+  // expected-note@-2{{make generic struct 'S8' explicitly non-Sendable to suppress this warning}}
+  var member: [T: (U, V?)]
+}
+
+public protocol P2 {
+  associatedtype A
+}
+
+public struct S9<T: P2 & Hashable> {
+  // expected-warning@-1{{public generic struct 'S9' does not specify whether it is 'Sendable' or not}}
+  // expected-note@-2{{consider making generic struct 'S9' conform to the 'Sendable' protocol}}{{2-2=\n\nextension S9: Sendable where T: Sendable, T.A: Sendable { \}\n}}
+  // expected-note@-3{{make generic struct 'S9' explicitly non-Sendable to suppress this warning}}
+  var dict: [T : T.A] = [:]
 }

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -45,6 +45,7 @@ public struct S5 { } // no diagnostic: S5 is not Sendable
 
 @available(*, unavailable)
 extension S5: Sendable { }
+// expected-note@-1{{conformance of 'S5' to 'Sendable' has been explicitly marked unavailable here}}
 
 // Public type with a conditional conformance, so don't complain
 public struct S6<T, U> {
@@ -54,3 +55,18 @@ public struct S6<T, U> {
 
 extension S6: Sendable where T: Sendable, U: Sendable { }
 
+func acceptSendable<T: Sendable>(_: T) {
+}
+
+struct S7 {
+}
+
+@available(*, unavailable)
+extension S7: Sendable { }
+// expected-note@-1{{conformance of 'S7' to 'Sendable' has been explicitly marked unavailable here}}
+
+
+func testMe(s5: S5, s7: S7) {
+  acceptSendable(s5) // expected-warning{{conformance of 'S5' to 'Sendable' is unavailable}}
+  acceptSendable(s7) // expected-warning{{conformance of 'S7' to 'Sendable' is unavailable}}
+}


### PR DESCRIPTION
Introduce a compiler flag that warnings about any public types defined in
a module that are neither explicitly `Sendable` nor explicitly
non-`Sendable` (the latter of which has no spelling currently), which
is intended to help with auditing a module for Sendable conformances.

Try to make the Fix-Its smart enough to provide a good workflow. For example,
given this type:

```swift
public struct DictionaryHolder<T: Hashable, U, V> {
  var member: [T: (U, V?)]
}
```

we'll provide a warning like this:

```
warning: Public generic struct 'DictionaryHolder' does not specify whether it is 'Sendable' or not
```

along with two notes. The first note makes the type `Sendable` via a conditional conformance introduced with a Fix-It:

```
note: Consider making generic struct 'DictionaryHolder' conform to the 'Sendable' protocol

extension DictionaryHolder: Sendable where T: Sendable, U: Sendable, V: Sendable { }
```

and the second note silences the warning using an unavailable extension with the `Sendable` conformance:

```
note: Make generic struct 'DictionaryHolder' explicitly non-Sendable to suppress this warning

@available(*, unavailable)
extension DictionaryHolder: Sendable { }
```