### PR TITLE
[cxx-interop] ClangDeclFinder to handle problematic codegen cases

### DIFF
--- a/test/Interop/Cxx/class/Inputs/initializer-from-inline.h
+++ b/test/Interop/Cxx/class/Inputs/initializer-from-inline.h
@@ -1,0 +1,14 @@
+inline int get42() { return 42; }
+struct Hold42 { int m = get42(); };
+
+template <typename T> T passThroughArgT(T t) { return t; }
+struct Hold23 { int m = passThroughArgT<int>(23); };
+
+struct HoldMemberThatHolds42 { Hold42 m; };
+struct HoldMemberThatHoldsMemberThatHolds42 { HoldMemberThatHolds42 m; };
+
+inline int get42Level4() { return get42(); }
+inline int get42Level3() { return get42Level4(); }
+inline int get42Level2() { return get42Level3(); }
+inline int get42Level1() { return get42Level2(); }
+struct Hold42WithLongInitCallGraph { int m = get42Level1(); };

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -87,3 +87,8 @@ module InvalidNestedStruct {
   header "invalid-nested-struct.h"
   requires cplusplus
 }
+
+module InitializerFromInline {
+  header "initializer-from-inline.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/initializer-from-inline.swift
+++ b/test/Interop/Cxx/class/initializer-from-inline.swift
@@ -1,0 +1,20 @@
+// RUN: %swift -I %S/Inputs -enable-cxx-interop -emit-ir %s | %FileCheck %s
+
+import InitializerFromInline
+
+// CHECK: define linkonce_odr i32 @{{_Z5get42v|\?get42@@YAHXZ}}
+// CHECK: define linkonce_odr i32 @{{_Z15passThroughArgTIiET_S0_|\?\?$passThroughArgT@H@@YAHH@Z}}
+// CHECK: define linkonce_odr i32 @{{_Z11get42Level1v|\?get42Level1@@YAHXZ}}
+// CHECK: define linkonce_odr i32 @{{_Z11get42Level2v|\?get42Level2@@YAHXZ}}
+// CHECK: define linkonce_odr i32 @{{_Z11get42Level3v|\?get42Level3@@YAHXZ}}
+// CHECK: define linkonce_odr i32 @{{_Z11get42Level4v|\?get42Level4@@YAHXZ}}
+
+var a = Hold42()
+var b = Hold23()
+var c = HoldMemberThatHolds42()
+var d = HoldMemberThatHoldsMemberThatHolds42()
+var e = Hold42WithLongInitCallGraph()
+
+let sum = a.m + b.m + c.m.m + d.m.m.m + e.m
+
+print("Sum: \(sum)")


### PR DESCRIPTION
At the moment, header defined functions do necessarily get codegened by
C++-Interop if they are invoked purely on the call path from a
constructor. What this means is that when you have inline or template
functions that are header defined and are only invoked on a call graph
path that only originates from a C++ constructor that is invoked from
Swift, that you get LLVM IR Function declares instead of Function
defines with linkonceodr. This results in link errors unless those
functions happen to be invoked or template instantiated from another TU
that gets linked in.

This patch teaches the ClangDeclFinder to look for these cases and add
them to the list of decls that get handled by HandleTopLevelDecl.

Partly addresses SR-15272
