### PR TITLE
[5.5] Don't include tests for back deploy concurrency product

### DIFF
--- a/test/attr/Inputs/access-note-gen.py
+++ b/test/attr/Inputs/access-note-gen.py
@@ -25,8 +25,8 @@ def main():
         sys.exit(1)
 
     with io.open(sys.argv[1], mode='r', encoding='utf8') as input_file, \
-         io.open(sys.argv[2], mode='w', encoding='utf8') as output_file, \
-         io.open(sys.argv[3], mode='w', encoding='utf8') as access_notes_file:
+            io.open(sys.argv[2], mode='w', encoding='utf8') as output_file, \
+            io.open(sys.argv[3], mode='w', encoding='utf8') as access_notes_file:
 
         # Add header to access notes file
         access_notes_file.write(u"""\

--- a/utils/swift_build_support/swift_build_support/products/backdeployconcurrency.py
+++ b/utils/swift_build_support/swift_build_support/products/backdeployconcurrency.py
@@ -79,6 +79,7 @@ class BackDeployConcurrency(cmake_product.CMakeProduct):
         self.cmake_options.define('SWIFT_BUILD_SDK_OVERLAY:BOOL', False)
         self.cmake_options.define('SWIFT_BUILD_DYNAMIC_SDK_OVERLAY:BOOL', False)
         self.cmake_options.define('SWIFT_BUILD_STATIC_SDK_OVERLAY:BOOL', False)
+        self.cmake_options.define('SWIFT_INCLUDE_TESTS:BOOL', False)
 
         self.cmake_options.define('SWIFT_HOST_VARIANT_ARCH:STRING', arch)
         self.cmake_options.define('BUILD_STANDALONE:BOOL', True)


### PR DESCRIPTION
Addresses rdar://83777172

(cherry picked from commit 6fbc9623fb18a641ac8f9b95ec7a0b6e00ca322a)