### PR TITLE
Rename duplicated swift::fatalError in swiftRuntime and swift_Concurrency

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -47,6 +47,7 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   CheckedContinuation.swift
   GlobalExecutor.cpp
   Errors.swift
+  Error.cpp
   Executor.swift
   AsyncCompactMapSequence.swift
   AsyncDropFirstSequence.swift

--- a/stdlib/public/Concurrency/Error.cpp
+++ b/stdlib/public/Concurrency/Error.cpp
@@ -1,4 +1,4 @@
-//===--- Mutex.cpp - Mutex support code -----------------------------------===//
+//===--- Error.cpp - Error handling support code --------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -12,10 +12,8 @@
 
 #include "Error.h"
 
-#define SWIFT_FATAL_ERROR swift_Concurrency_fatalError
-
-// Include the runtime's mutex support code.
-// FIXME: figure out some reasonable way to share this stuff
-
-#include "../runtime/MutexPThread.cpp"
-#include "../runtime/MutexWin32.cpp"
+// swift::fatalError is not exported from libswiftCore and not shared, so define another
+// internal function instead.
+SWIFT_NORETURN void swift::swift_Concurrency_fatalError(uint32_t flags, const char *format, ...) {
+  abort();
+}

--- a/stdlib/public/Concurrency/Error.h
+++ b/stdlib/public/Concurrency/Error.h
@@ -1,0 +1,30 @@
+//===--- Error.h - Swift Concurrency error helpers --------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Error handling support.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_CONCURRENCY_ERRORS_H
+#define SWIFT_CONCURRENCY_ERRORS_H
+
+#include "../SwiftShims/Visibility.h"
+#include <cstdint>
+#include <stdlib.h>
+
+namespace swift {
+
+SWIFT_NORETURN void swift_Concurrency_fatalError(uint32_t flags, const char *format, ...);
+
+} // namespace swift
+
+#endif

--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -57,6 +57,7 @@
 #include "swift/Runtime/Concurrency.h"
 #include "swift/Runtime/EnvironmentVariables.h"
 #include "TaskPrivate.h"
+#include "Error.h"
 
 #include <dispatch/dispatch.h>
 
@@ -267,7 +268,7 @@ static std::atomic<dispatch_queue_t> globalQueueCache[globalQueueCacheCount];
 static dispatch_queue_t getGlobalQueue(JobPriority priority) {
   size_t numericPriority = static_cast<size_t>(priority);
   if (numericPriority >= globalQueueCacheCount)
-    fatalError(0, "invalid job priority %#zx");
+    swift_Concurrency_fatalError(0, "invalid job priority %#zx");
 
   auto *ptr = &globalQueueCache[numericPriority];
   auto queue = ptr->load(std::memory_order_relaxed);

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -26,6 +26,7 @@
 #include "TaskPrivate.h"
 #include "AsyncCall.h"
 #include "Debug.h"
+#include "Error.h"
 
 #include <dispatch/dispatch.h>
 
@@ -786,7 +787,7 @@ static void swift_task_future_waitImpl(
   }
 
   case FutureFragment::Status::Error:
-    fatalError(0, "future reported an error, but wait cannot throw");
+    swift_Concurrency_fatalError(0, "future reported an error, but wait cannot throw");
   }
 }
 

--- a/stdlib/public/Concurrency/TaskAlloc.cpp
+++ b/stdlib/public/Concurrency/TaskAlloc.cpp
@@ -20,7 +20,6 @@
 #include "swift/Runtime/Concurrency.h"
 #include "swift/ABI/Task.h"
 #include "TaskPrivate.h"
-
 #include <stdlib.h>
 
 using namespace swift;

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -25,6 +25,9 @@
 #include "swift/Runtime/Exclusivity.h"
 #include "swift/Runtime/HeapObject.h"
 
+#include "Error.h"
+
+#define SWIFT_FATAL_ERROR swift_Concurrency_fatalError
 #include "../runtime/StackAllocator.h"
 
 #if HAVE_PTHREAD_H

--- a/stdlib/public/runtime/MutexPThread.cpp
+++ b/stdlib/public/runtime/MutexPThread.cpp
@@ -20,6 +20,13 @@
 #endif
 
 #if defined(_POSIX_THREADS) && !defined(SWIFT_STDLIB_SINGLE_THREADED_RUNTIME)
+
+// Notes: swift::fatalError is not shared between libswiftCore and libswift_Concurrency
+// and libswift_Concurrency uses swift_Concurrency_fatalError instead.
+#ifndef SWIFT_FATAL_ERROR
+#define SWIFT_FATAL_ERROR swift::fatalError
+#endif
+
 #include "swift/Runtime/Mutex.h"
 
 #include "swift/Runtime/Debug.h"
@@ -32,8 +39,8 @@ using namespace swift;
   do {                                                                         \
     int errorcode = PThreadFunction;                                           \
     if (errorcode != 0) {                                                      \
-      fatalError(/* flags = */ 0, "'%s' failed with error '%s'(%d)\n",         \
-                 #PThreadFunction, errorName(errorcode), errorcode);           \
+      SWIFT_FATAL_ERROR(/* flags = */ 0, "'%s' failed with error '%s'(%d)\n",  \
+                        #PThreadFunction, errorName(errorcode), errorcode);    \
     }                                                                          \
   } while (false)
 
@@ -44,8 +51,8 @@ using namespace swift;
       return true;                                                             \
     if (returnFalseOnEBUSY && errorcode == EBUSY)                              \
       return false;                                                            \
-    fatalError(/* flags = */ 0, "'%s' failed with error '%s'(%d)\n",           \
-               #PThreadFunction, errorName(errorcode), errorcode);             \
+    SWIFT_FATAL_ERROR(/* flags = */ 0, "'%s' failed with error '%s'(%d)\n",    \
+                      #PThreadFunction, errorName(errorcode), errorcode);      \
   } while (false)
 
 static const char *errorName(int errorcode) {

--- a/stdlib/public/runtime/MutexWin32.cpp
+++ b/stdlib/public/runtime/MutexWin32.cpp
@@ -16,6 +16,13 @@
 //===----------------------------------------------------------------------===//
 
 #if defined(_WIN32)
+
+// Notes: swift::fatalError is not shared between libswiftCore and libswift_Concurrency
+// and libswift_Concurrency uses swift_Concurrency_fatalError instead.
+#ifndef SWIFT_FATAL_ERROR
+#define SWIFT_FATAL_ERROR swift::fatalError
+#endif
+
 #include "swift/Runtime/Mutex.h"
 #include "swift/Runtime/Debug.h"
 
@@ -26,9 +33,9 @@ void ConditionPlatformHelper::wait(CONDITION_VARIABLE &condition,
   BOOL result = SleepConditionVariableSRW(&condition, &mutex, INFINITE, 0);
   if (!result) {
     DWORD errorcode = GetLastError();
-    fatalError(/* flags = */ 0,
-               "'SleepConditionVariableSRW()' failed with error code %d\n",
-               errorcode);
+    SWIFT_FATAL_ERROR(/* flags = */ 0,
+                      "'SleepConditionVariableSRW()' failed with error code %d\n",
+                      errorcode);
   }
 }
 #endif

--- a/test/Driver/static-stdlib-autolink-linux.swift
+++ b/test/Driver/static-stdlib-autolink-linux.swift
@@ -1,5 +1,4 @@
 // Statically link a program with concurrency module
-// REQUIRES: OS=linux-gnu
 // REQUIRES: static_stdlib
 // REQUIRES: concurrency
 // REQUIRES: libdispatch_static
@@ -13,7 +12,12 @@
 
 // RUN: %t/main | %FileCheck %s
 // CHECK: Hello
-// RUN: ldd %t/main | %FileCheck %s --check-prefix=LDD
+
+// RUN: if [ %target-os == "linux-gnu" ]; \
+// RUN: then \
+// RUN:   ldd %t/main | %FileCheck %s --check-prefix=LDD; \
+// RUN: fi
+
 // LDD-NOT: libswiftCore.so 
 // LDD-NOT: libswift_Concurrency.so 
 

--- a/test/Driver/static-stdlib-autolink-linux.swift
+++ b/test/Driver/static-stdlib-autolink-linux.swift
@@ -1,0 +1,27 @@
+// Statically link a program with concurrency module
+// REQUIRES: OS=linux-gnu
+// REQUIRES: static_stdlib
+// REQUIRES: concurrency
+// REQUIRES: libdispatch_static
+
+// RUN: %empty-directory(%t)
+// RUN: echo 'public func asyncFunc() async { print("Hello") }' > %t/asyncModule.swift
+
+// RUN: %target-swiftc_driver -emit-library -emit-module -module-name asyncModule -module-link-name asyncModule %t/asyncModule.swift -static -static-stdlib -o %t/libasyncModule.a
+// TODO: "-ldispatch -lBlocksRuntime" should be told by asyncModule.swiftmodule transitively
+// RUN: %target-swiftc_driver -parse-as-library -static -static-stdlib -module-name main %s %import-static-libdispatch -I%t -L%t -ldispatch -lBlocksRuntime -o %t/main
+
+// RUN: %t/main | %FileCheck %s
+// CHECK: Hello
+// RUN: ldd %t/main | %FileCheck %s --check-prefix=LDD
+// LDD-NOT: libswiftCore.so 
+// LDD-NOT: libswift_Concurrency.so 
+
+import asyncModule
+
+@main
+struct Main {
+  static func main() async {
+    await asyncFunc()
+  }
+}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1298,6 +1298,7 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
 
     libdispatch_artifact_dir = config.libdispatch_build_path
     libdispatch_swift_module_dir = make_path(libdispatch_artifact_dir, 'src', 'swift', 'swift')
+    libdispatch_source_dir = make_path(config.swift_src_root, os.pardir, 'swift-corelibs-libdispatch')
     libdispatch_artifacts = [
         make_path(libdispatch_artifact_dir, 'libdispatch.so'),
         make_path(libdispatch_artifact_dir, 'libswiftDispatch.so'),
@@ -1305,9 +1306,22 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
     if (all(os.path.exists(p) for p in libdispatch_artifacts)):
         config.available_features.add('libdispatch')
         config.libdispatch_artifact_dir = libdispatch_artifact_dir
-        libdispatch_source_dir = make_path(config.swift_src_root, os.pardir, 'swift-corelibs-libdispatch')
         config.import_libdispatch = ('-I %s -I %s -L %s'
             % (libdispatch_source_dir, libdispatch_swift_module_dir, libdispatch_artifact_dir))
+
+    libdispatch_static_artifact_dir = config.libdispatch_static_build_path
+    libdispatch_swift_static_module_dir = make_path(libdispatch_static_artifact_dir, 'src', 'swift', 'swift')
+    libdispatch_static_artifacts = [
+        make_path(libdispatch_static_artifact_dir, 'src', 'libdispatch.a'),
+        make_path(libdispatch_static_artifact_dir, 'src', 'swift', 'libswiftDispatch.a'),
+        make_path(libdispatch_swift_static_module_dir, 'Dispatch.swiftmodule')]
+    if (all(os.path.exists(p) for p in libdispatch_static_artifacts)):
+        config.available_features.add('libdispatch_static')
+        config.import_libdispatch_static = ('-I %s -I %s -L %s -L %s -L %s'
+            % (libdispatch_source_dir, libdispatch_swift_static_module_dir,
+            make_path(libdispatch_static_artifact_dir, 'src'),
+            make_path(libdispatch_static_artifact_dir, 'src', 'BlocksRuntime'),
+            make_path(libdispatch_static_artifact_dir, 'src', 'swift')))
 
     config.target_build_swift = (
         '%s -target %s -toolchain-stdlib-rpath %s %s %s %s %s'
@@ -2127,6 +2141,7 @@ run_filecheck = '%s %s --sanitize BUILD_DIR=%s --sanitize SOURCE_DIR=%s --use-fi
 config.substitutions.append(('%FileCheck', run_filecheck))
 config.substitutions.append(('%raw-FileCheck', shell_quote(config.filecheck)))
 config.substitutions.append(('%import-libdispatch', getattr(config, 'import_libdispatch', '')))
+config.substitutions.append(('%import-static-libdispatch', getattr(config, 'import_libdispatch_static', '')))
 
 # Disabe COW sanity checks in the swift runtime by default.
 # (But it's required to set this environment variable to something)

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -34,6 +34,7 @@ config.swift_test_results_dir = \
 config.coverage_mode = "@SWIFT_ANALYZE_CODE_COVERAGE@"
 config.lldb_build_root = "@LLDB_BUILD_DIR@"
 config.libdispatch_build_path = "@SWIFT_PATH_TO_LIBDISPATCH_BUILD@"
+config.libdispatch_static_build_path = "@SWIFT_PATH_TO_LIBDISPATCH_STATIC_BUILD@"
 config.swift_driver_test_options = "@SWIFT_DRIVER_TEST_OPTIONS@"
 config.swift_frontend_test_options = "@SWIFT_FRONTEND_TEST_OPTIONS@"
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2002,6 +2002,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DSWIFT_PATH_TO_CMARK_BUILD:PATH="$(build_directory ${host} cmark)"
                     -DSWIFT_PATH_TO_LIBDISPATCH_SOURCE:PATH="${LIBDISPATCH_SOURCE_DIR}"
                     -DSWIFT_PATH_TO_LIBDISPATCH_BUILD:PATH="$(build_directory ${host} libdispatch)"
+                    -DSWIFT_PATH_TO_LIBDISPATCH_STATIC_BUILD:PATH="$(build_directory ${host} libdispatch_static)"
                 )
 
                 if [[ ! "${SKIP_BUILD_LIBICU}" ]] ; then

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -56,6 +56,7 @@ else:
 config.coverage_mode = "@SWIFT_ANALYZE_CODE_COVERAGE@"
 config.lldb_build_root = "@LLDB_BUILD_DIR@"
 config.libdispatch_build_path = "@SWIFT_PATH_TO_LIBDISPATCH_BUILD@"
+config.libdispatch_static_build_path = "@SWIFT_PATH_TO_LIBDISPATCH_STATIC_BUILD@"
 
 if "@SWIFT_ASAN_BUILD@" == "TRUE":
     config.available_features.add("asan")


### PR DESCRIPTION
Cherry-pick #37084 to fix static builds that use the `_Concurrency` library.