### PR TITLE
Always use the same TLS context as the runtime for back-deployed concurrency

### DIFF
--- a/test/Concurrency/Runtime/exclusivity.swift
+++ b/test/Concurrency/Runtime/exclusivity.swift
@@ -3,8 +3,6 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 
-// rdar://76038845
-// REQUIRES: rdar83064974
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 


### PR DESCRIPTION
The exclusivity checking support for concurrency relies on having access
to the thread-local set of active memory accesses. Teach the
back-deployed concurrency library to use the same TLS context as the
runtime, which fortunately hasn't change. This fixes the
concurrency exclusivity-checking test in back-deployed configurations
that's tracked by rdar://83064974.
