### PR TITLE
[Mem2Reg] Tied lexical borrow to initialization.

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -1677,7 +1677,7 @@ bool MemoryToRegisters::promoteSingleAllocation(AllocStackInst *alloc) {
   }
 
   // Remove write-only AllocStacks.
-  if (isWriteOnlyAllocation(alloc)) {
+  if (isWriteOnlyAllocation(alloc) && !shouldAddLexicalLifetime(alloc)) {
     deleter.forceDeleteWithUsers(alloc);
 
     LLVM_DEBUG(llvm::dbgs() << "*** Deleting store-only AllocStack: "<< *alloc);

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -398,7 +398,7 @@ class StackAllocationPromoter {
   /// The AllocStackInst that we are handling.
   AllocStackInst *asi;
 
-  /// The deallocation Instruction. This value could be NULL if there are
+  /// The unique deallocation instruction. This value could be NULL if there are
   /// multiple deallocations.
   DeallocStackInst *dsi;
 

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -40,8 +40,9 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/Statistic.h"
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Debug.h"
 #include <algorithm>
 #include <queue>
@@ -60,9 +61,13 @@ namespace {
 using DomTreeNode = llvm::DomTreeNodeBase<SILBasicBlock>;
 using DomTreeLevelMap = llvm::DenseMap<DomTreeNode *, unsigned>;
 
-/// The values pertaining to an alloc_stack that might be live, whether within
-/// the block, as the block is entered (live-in) or exited
-/// (live-out) relating to an alloc_stack.
+/// A transient structure containing the values that are accessible in some
+/// context: coming into a block, going out of the block, or within a block
+/// (during promoteAllocationInBlock and removeSingleBlockAllocation).
+///
+/// At block boundaries, these are phi arguments or initializationPoints.  As we
+/// iterate over a block, a way to keep track of the current (running) value
+/// within a block.
 struct LiveValues {
   SILValue stored = SILValue();
   SILValue borrow = SILValue();
@@ -81,6 +86,7 @@ struct LiveValues {
       return {SILValue(), SILValue(), replacement};
     return {replacement, SILValue(), SILValue()};
   };
+
   /// The value with which usages of the provided AllocStackInst should be
   /// replaced.
   ///
@@ -92,18 +98,17 @@ struct LiveValues {
   };
 };
 
-/// The instructions that are involved in or introduced in response to a store
-/// into an alloc_stack.
+/// A transient structure used only by promoteAllocationInBlock and
+/// removeSingleBlockAllocation.
 ///
-/// There is always a store.  The begin_borrow and copy_value instructions are
-/// introduced for lexical alloc_stacks.
-struct ValueInstructions {
-  // The value of interest is the operand of the store instruction.
-  StoreInst *store = nullptr;
-  // The value of interest is the result of the begin_borrow instruction.
-  BeginBorrowInst *borrow = nullptr;
-  // The value of interest is the result of the copy_value instruction.
-  CopyValueInst *copy = nullptr;
+/// A pair of a CFG-position-relative value T and a boolean indicating whether
+/// the alloc_stack's storage is valid at the position where that value exists.
+template <typename T>
+struct StorageStateTracking {
+  /// The value which exists at some CFG position.
+  T value;
+  /// Whether the stack storage is initialized at that position.
+  bool isStorageValid;
 };
 
 } // anonymous namespace
@@ -112,9 +117,26 @@ struct ValueInstructions {
 //                                 Utilities
 //===----------------------------------------------------------------------===//
 
-static void replaceDestroy(DestroyAddrInst *dai, SILValue newValue,
-                           SILBuilderContext &ctx,
-                           InstructionDeleter &deleter) {
+/// Make the specified instruction cease to be a user of its operands and add it
+/// to the list of instructions to delete.
+///
+/// This both (1) removes the specified instruction from the list of users of
+/// its operands, avoiding disrupting logic that examines those users and (2)
+/// keeps the specified instruction in place, allowing it to be used for
+/// insertion until instructionsToDelete is culled.
+static void
+prepareForDeletion(SILInstruction *inst,
+                   SmallVectorImpl<SILInstruction *> &instructionsToDelete) {
+  for (auto &operand : inst->getAllOperands()) {
+    operand.set(SILUndef::get(operand.get()->getType(), *inst->getFunction()));
+  }
+  instructionsToDelete.push_back(inst);
+}
+
+static void
+replaceDestroy(DestroyAddrInst *dai, SILValue newValue, SILBuilderContext &ctx,
+               InstructionDeleter &deleter,
+               SmallVectorImpl<SILInstruction *> &instructionsToDelete) {
   SILFunction *f = dai->getFunction();
   auto ty = dai->getOperand()->getType();
 
@@ -134,7 +156,8 @@ static void replaceDestroy(DestroyAddrInst *dai, SILValue newValue,
                               : TypeExpansionKind::None;
   typeLowering.emitLoweredDestroyValue(builder, dai->getLoc(), newValue,
                                        expansionKind);
-  deleter.forceDelete(dai);
+
+  prepareForDeletion(dai, instructionsToDelete);
 }
 
 /// Promote a DebugValue w/ address value to a DebugValue of non-address value.
@@ -204,8 +227,10 @@ static void collectLoads(SILInstruction *i,
   }
 }
 
-static void replaceLoad(LoadInst *li, SILValue newValue, AllocStackInst *asi,
-                        SILBuilderContext &ctx, InstructionDeleter &deleter) {
+static void
+replaceLoad(LoadInst *li, SILValue newValue, AllocStackInst *asi,
+            SILBuilderContext &ctx, InstructionDeleter &deleter,
+            SmallVectorImpl<SILInstruction *> &instructionsToDelete) {
   ProjectionPath projections(newValue->getType());
   SILValue op = li->getOperand();
   SILBuilderWithScope builder(li, ctx);
@@ -257,7 +282,7 @@ static void replaceLoad(LoadInst *li, SILValue newValue, AllocStackInst *asi,
   std::move(scope).popAtEndOfScope(&*builder.getInsertionPoint());
 
   // Delete the load
-  deleter.forceDelete(li);
+  prepareForDeletion(li, instructionsToDelete);
 
   while (op != asi && op->use_empty()) {
     assert(isa<UncheckedAddrCastInst>(op) || isa<StructElementAddrInst>(op) ||
@@ -296,28 +321,31 @@ static bool shouldAddLexicalLifetime(AllocStackInst *asi) {
          !asi->getElementType().isTrivial(*asi->getFunction());
 }
 
-/// Given a store instruction after which it is known that a lexical borrow
-/// scope should be added, add the beginning at the appropriate position.
+/// Begin a lexical borrow scope for the value stored into the provided
+/// StoreInst after that instruction.
 ///
 /// The beginning of the scope looks like
 ///
 ///     %lifetime = begin_borrow %original
 ///     %copy = copy_value %lifetime
-static std::pair<ValueInstructions, LiveValues>
-beginLexicalLifetimeAtStore(AllocStackInst *asi, StoreInst *si,
-                            SILBuilderContext &ctx) {
+static StorageStateTracking<LiveValues>
+beginLexicalLifetimeAfterStore(AllocStackInst *asi, StoreInst *si) {
   assert(shouldAddLexicalLifetime(asi));
-  auto *bbi =
-      SILBuilderWithScope(si, ctx).createBeginBorrow(si->getLoc(), si->getSrc(),
-                                                     /*isLexical*/ true);
-  auto *cvi = SILBuilderWithScope(si, ctx).createCopyValue(si->getLoc(), bbi);
-  ValueInstructions insts = {si, bbi, cvi};
-  LiveValues vals = {si->getSrc(), bbi, cvi};
-  return std::make_pair(insts, vals);
+  BeginBorrowInst *bbi = nullptr;
+  CopyValueInst *cvi = nullptr;
+  SILBuilderWithScope::insertAfter(si, [&](SILBuilder &builder) {
+    SILLocation loc = RegularLocation::getAutoGeneratedLocation(si->getLoc());
+    bbi = builder.createBeginBorrow(loc, si->getSrc(),
+                                    /*isLexical*/ true);
+    cvi = builder.createCopyValue(loc, bbi);
+  });
+  StorageStateTracking<LiveValues> vals = {{si->getSrc(), bbi, cvi},
+                                           /*isStorageValid=*/true};
+  return vals;
 }
 
-/// Given a block to which it is known that the end of a lexical borrow scope
-/// should be added, add the end at the appropriate position.
+/// End the lexical borrow scope described by the provided LiveValues struct
+/// before the specified instruction.
 ///
 /// The end of the scope looks like
 ///
@@ -329,52 +357,18 @@ beginLexicalLifetimeAtStore(AllocStackInst *asi, StoreInst *si,
 ///
 ///     %lifetime = begin_borrow %original
 ///     %copy = copy_value %lifetime
-///
-/// There are a couple options for where the instructions will be added:
-/// (1) If there are uses of the borrow within the block, then they are added
-///     after the last use.
-/// (2) If there are no uses of the borrow within the block, and the copy_value
-///     instruction appears within the block, they are added immediately after
-///     it.
-/// (3) If there are no uses of the borrow within the block and the copy_value
-///     instruction does not appear within the block, then the instructions are
-///     added at the beginning of the block.
-/// They should be added after the value is done being used.  If the value is
-/// ever used, that means after the last use.  Otherwise, it means immediately
-/// after the definition.
-static void endLexicalLifetimeInBlock(AllocStackInst *asi, SILBasicBlock *bb,
-                                      SILBuilderContext &ctx,
-                                      DominanceInfo *domInfo, SILValue copy,
-                                      SILValue borrow, SILValue original) {
+static void endLexicalLifetimeBeforeInst(AllocStackInst *asi,
+                                         SILInstruction *beforeInstruction,
+                                         SILBuilderContext &ctx,
+                                         LiveValues values) {
   assert(shouldAddLexicalLifetime(asi));
-  SILInstruction *lastInst = nullptr;
-  if (auto *cvi = copy->getDefiningInstruction()) {
-    if (cvi->getParent() == bb) {
-      lastInst = cvi;
-    }
-  }
-  for (auto *use : copy->getUses()) {
-    auto *thisInst = use->getUser();
-    if (thisInst->getParent() != bb)
-      continue;
-    if (!lastInst || domInfo->dominates(lastInst, thisInst))
-      lastInst = thisInst;
-  }
-  if (lastInst) {
-    assert(!isa<TermInst>(lastInst) &&
-           "the last use of the value cannot be terminal--Mem2Reg does not run "
-           "on alloc_stacks which are passed to checked_cast_addr_br or "
-           "switch_enum_addr");
-    SILBuilderWithScope::insertAfter(lastInst, [&](SILBuilder &B) {
-      B.createEndBorrow(lastInst->getLoc(), borrow);
-      B.emitDestroyValueOperation(lastInst->getLoc(), original);
-    });
-  } else {
-    auto *firstInst = &*bb->begin();
-    auto builder = SILBuilderWithScope(firstInst, ctx);
-    builder.createEndBorrow(firstInst->getLoc(), borrow);
-    builder.emitDestroyValueOperation(firstInst->getLoc(), original);
-  }
+  assert(beforeInstruction);
+
+  auto builder = SILBuilderWithScope(beforeInstruction, ctx);
+  SILLocation loc =
+      RegularLocation::getAutoGeneratedLocation(beforeInstruction->getLoc());
+  builder.createEndBorrow(loc, values.borrow);
+  builder.emitDestroyValueOperation(loc, values.stored);
 }
 
 //===----------------------------------------------------------------------===//
@@ -386,7 +380,8 @@ namespace {
 /// Promotes a single AllocStackInst into registers..
 class StackAllocationPromoter {
   using BlockSetVector = BasicBlockSetVector;
-  using BlockToInstsMap = llvm::DenseMap<SILBasicBlock *, ValueInstructions>;
+  template <typename Inst = SILInstruction>
+  using BlockToInstMap = llvm::DenseMap<SILBasicBlock *, Inst *>;
 
   // Use a priority queue keyed on dominator tree level so that inserted nodes
   // are handled from the bottom of the dom tree upwards.
@@ -402,13 +397,6 @@ class StackAllocationPromoter {
   /// multiple deallocations.
   DeallocStackInst *dsi;
 
-  /// All the dealloc_stack instructions.
-  llvm::SmallVector<DeallocStackInst *> dsis;
-
-  /// The lexical begin_borrow instructions that were created to track the
-  /// lexical lifetimes introduced by the alloc_stack, if it is lexical.
-  llvm::SmallVector<SILBasicBlock *> lexicalBBIBlocks;
-
   /// Dominator info.
   DominanceInfo *domInfo;
 
@@ -421,26 +409,60 @@ class StackAllocationPromoter {
 
   InstructionDeleter &deleter;
 
-  /// Records the last store instruction in each block for a specific
-  /// AllocStackInst.
-  BlockToInstsMap lastStoreInBlock;
+  /// Instructions that could not be deleted immediately with forceDelete until
+  /// StackAllocationPromoter finishes its run.
+  ///
+  /// There are two reasons why an instruction might not be deleted:
+  /// (1) new instructions are inserted before or after it
+  /// (2) it ensures that an instruction remains used, preventing it from being
+  ///     deleted
+  SmallVectorImpl<SILInstruction *> &instructionsToDelete;
+
+  /// The last instruction in each block that initializes the storage that is
+  /// not succeeded by an instruction that deinitializes it.
+  ///
+  /// The live-out values for every block can be derived from these.
+  ///
+  /// For non-lexical alloc_stacks, that is just a StoreInst.  For lexical
+  /// alloc_stacks, that is the StoreInst, a BeginBorrowInst of the
+  /// value stored into the StoreInst and a CopyValueInst of the result of the
+  /// BeginBorrowInst.
+  BlockToInstMap<StoreInst> initializationPoints;
+
+  /// The first instruction in each block that deinitializes the storage that is
+  /// not preceeded by an instruction that initializes it.
+  ///
+  /// That includes:
+  ///     store
+  ///     destroy_addr
+  ///     load [take]
+  ///
+  /// Ending lexical lifetimes before these instructions is one way that the
+  /// cross-block lexical lifetimes of initializationPoints can be ended in
+  /// StackAllocationPromoter::endLexicalLifetime.
+  BlockToInstMap<> deinitializationPoints;
 
 public:
   /// C'tor.
-  StackAllocationPromoter(AllocStackInst *inputASI, DominanceInfo *inputDomInfo,
-                          DomTreeLevelMap &inputDomTreeLevels,
-                          SILBuilderContext &inputCtx,
-                          InstructionDeleter &deleter)
+  StackAllocationPromoter(
+      AllocStackInst *inputASI, DominanceInfo *inputDomInfo,
+      DomTreeLevelMap &inputDomTreeLevels, SILBuilderContext &inputCtx,
+      InstructionDeleter &deleter,
+      SmallVectorImpl<SILInstruction *> &instructionsToDelete)
       : asi(inputASI), dsi(nullptr), domInfo(inputDomInfo),
-        domTreeLevels(inputDomTreeLevels), ctx(inputCtx), deleter(deleter) {
+        domTreeLevels(inputDomTreeLevels), ctx(inputCtx), deleter(deleter),
+        instructionsToDelete(instructionsToDelete) {
     // Scan the users in search of a deallocation instruction.
-    for (auto *use : asi->getUses())
-      if (auto *foundDealloc = dyn_cast<DeallocStackInst>(use->getUser()))
-        dsis.push_back(foundDealloc);
-    if (dsis.size() == 1) {
-      // Record the deallocation instruction, but don't record multiple dealloc
-      // instructions.
-      dsi = dsis.front();
+    for (auto *use : asi->getUses()) {
+      if (auto *foundDealloc = dyn_cast<DeallocStackInst>(use->getUser())) {
+        // Don't record multiple dealloc instructions.
+        if (dsi) {
+          dsi = nullptr;
+          break;
+        }
+        // Record the deallocation instruction.
+        dsi = foundDealloc;
+      }
     }
   }
 
@@ -509,23 +531,36 @@ private:
   /// Promote all of the AllocStacks in a single basic block in one
   /// linear scan. This function deletes all of the loads and stores except
   /// for the first load and the last store.
-  /// \returns the last ValueInstructions (the store, and, if lexical, the
-  ///          begin_borrow and copy_value) found, if any, or else llvm::None.
-  Optional<ValueInstructions> promoteAllocationInBlock(SILBasicBlock *block);
+  /// \returns the last StoreInst found, whose storage was not subsequently
+  ///          deinitialized
+  StoreInst *promoteAllocationInBlock(SILBasicBlock *block);
 };
 
 } // end of namespace
 
-Optional<ValueInstructions> StackAllocationPromoter::promoteAllocationInBlock(
+StoreInst *StackAllocationPromoter::promoteAllocationInBlock(
     SILBasicBlock *blockPromotingWithin) {
   LLVM_DEBUG(llvm::dbgs() << "*** Promoting ASI in block: " << *asi);
 
   // RunningVal is the current value in the stack location.
   // We don't know the value of the alloca until we find the first store.
-  Optional<LiveValues> runningVals;
+  Optional<StorageStateTracking<LiveValues>> runningVals;
   // Keep track of the last StoreInst that we found and the BeginBorrowInst and
   // CopyValueInst that we created in response if the alloc_stack was lexical.
-  Optional<ValueInstructions> lastValueInstructions = llvm::None;
+  Optional<StorageStateTracking<StoreInst *>> lastStoreInst;
+
+  /// Returns true if we have enough information to end the lifetime during
+  /// promoteAllocationInBlock.
+  ///
+  /// The lifetime cannot be ended during this function's execution if we don't
+  /// yet have enough information to end it.  That occurs when the running
+  /// values are from a load which was not preceeded by a store.  In that case,
+  /// the lifetime end will be added later, when we have enough information,
+  /// namely the live in values, to end it.
+  auto canEndLexicalLifetime =
+      [](StorageStateTracking<LiveValues> values) -> bool {
+    return values.value.borrow;
+  };
 
   // For all instructions in the block.
   for (auto bbi = blockPromotingWithin->begin(),
@@ -535,12 +570,33 @@ Optional<ValueInstructions> StackAllocationPromoter::promoteAllocationInBlock(
     ++bbi;
 
     if (isLoadFromStack(inst, asi)) {
+      assert(!runningVals || runningVals->isStorageValid);
       auto *li = cast<LoadInst>(inst);
+      if (li->getOwnershipQualifier() == LoadOwnershipQualifier::Take) {
+        if (shouldAddLexicalLifetime(asi)) {
+          // End the lexical lifetime at a load [take].  The storage is no
+          // longer keeping the value alive.
+          if (runningVals && canEndLexicalLifetime(*runningVals)) {
+            // End it right now if we have enough information.
+            endLexicalLifetimeBeforeInst(asi, /*beforeInstruction=*/li, ctx,
+                                         runningVals->value);
+          } else {
+            // If we dont't have enough information, end it endLexicalLifetime.
+            assert(!deinitializationPoints[blockPromotingWithin]);
+            deinitializationPoints[blockPromotingWithin] = li;
+          }
+        }
+        if (runningVals)
+          runningVals->isStorageValid = false;
+        if (lastStoreInst)
+          lastStoreInst->isStorageValid = false;
+      }
       if (runningVals) {
         // If we are loading from the AllocStackInst and we already know the
         // content of the Alloca then use it.
         LLVM_DEBUG(llvm::dbgs() << "*** Promoting load: " << *li);
-        replaceLoad(li, runningVals->replacement(asi), asi, ctx, deleter);
+        replaceLoad(li, runningVals->value.replacement(asi), asi, ctx, deleter,
+                    instructionsToDelete);
         ++NumInstRemoved;
       } else if (li->getOperand() == asi &&
                  li->getOwnershipQualifier() != LoadOwnershipQualifier::Copy) {
@@ -550,7 +606,8 @@ Optional<ValueInstructions> StackAllocationPromoter::promoteAllocationInBlock(
         // additional logic for cleanup of consuming instructions of the result.
         // StackAllocationPromoter::fixBranchesAndUses will later handle it.
         LLVM_DEBUG(llvm::dbgs() << "*** First load: " << *li);
-        runningVals = LiveValues::toReplace(asi, /*replacement=*/li);
+        runningVals = {LiveValues::toReplace(asi, /*replacement=*/li),
+                       /*isStorageValid=*/true};
       }
       continue;
     }
@@ -565,42 +622,60 @@ Optional<ValueInstructions> StackAllocationPromoter::promoteAllocationInBlock(
       // simplifies further processing.
       if (si->getOwnershipQualifier() == StoreOwnershipQualifier::Assign) {
         if (runningVals) {
+          assert(runningVals->isStorageValid);
           SILBuilderWithScope(si, ctx).createDestroyValue(
-              si->getLoc(), runningVals->replacement(asi));
+              si->getLoc(), runningVals->value.replacement(asi));
         } else {
           SILBuilderWithScope localBuilder(si, ctx);
           auto *newLoad = localBuilder.createLoad(si->getLoc(), asi,
                                                   LoadOwnershipQualifier::Take);
           localBuilder.createDestroyValue(si->getLoc(), newLoad);
+          if (shouldAddLexicalLifetime(asi)) {
+            assert(!deinitializationPoints[blockPromotingWithin]);
+            deinitializationPoints[blockPromotingWithin] = si;
+          }
         }
         si->setOwnershipQualifier(StoreOwnershipQualifier::Init);
       }
 
       // If we met a store before this one, delete it.
-      if (lastValueInstructions) {
-        assert(lastValueInstructions->store->getOwnershipQualifier() !=
+      if (lastStoreInst) {
+        assert(lastStoreInst->value->getOwnershipQualifier() !=
                    StoreOwnershipQualifier::Assign &&
                "store [assign] to the stack location should have been "
                "transformed to a store [init]");
-        LLVM_DEBUG(llvm::dbgs() << "*** Removing redundant store: "
-                                << lastValueInstructions->store);
+        LLVM_DEBUG(llvm::dbgs()
+                   << "*** Removing redundant store: " << lastStoreInst->value);
         ++NumInstRemoved;
-        deleter.forceDelete(lastValueInstructions->store);
+        prepareForDeletion(lastStoreInst->value, instructionsToDelete);
       }
 
-      // The stored value is the new running value.
       auto oldRunningVals = runningVals;
-      runningVals = LiveValues::toReplace(asi, /*replacement=*/si->getSrc());
-      // The current store is now the LastStore
-      lastValueInstructions = {si, nullptr, nullptr};
+      // The stored value is the new running value.
+      runningVals = {LiveValues::toReplace(asi, /*replacement=*/si->getSrc()),
+                     /*isStorageValid=*/true};
+      // The current store is now the lastStoreInst (until we see
+      // another).
+      lastStoreInst = {si, /*isStorageValid=*/true};
       if (shouldAddLexicalLifetime(asi)) {
-        if (oldRunningVals) {
-          endLexicalLifetimeInBlock(
-              asi, si->getParent(), ctx, domInfo, oldRunningVals->copy,
-              oldRunningVals->borrow, oldRunningVals->stored);
+        if (oldRunningVals && oldRunningVals->isStorageValid &&
+            canEndLexicalLifetime(*oldRunningVals)) {
+          endLexicalLifetimeBeforeInst(asi, /*beforeInstruction=*/si, ctx,
+                                       oldRunningVals->value);
         }
-        std::tie(lastValueInstructions, runningVals) =
-            beginLexicalLifetimeAtStore(asi, si, ctx);
+        runningVals = beginLexicalLifetimeAfterStore(asi, si);
+        // Create a use of the newly created copy in order to keep phi pruning
+        // from deleting our lifetime beginning instructions.
+        SILBuilderWithScope::insertAfter(
+            runningVals->value.copy->getDefiningInstruction(),
+            [&](auto builder) {
+              SILLocation loc = RegularLocation::getAutoGeneratedLocation();
+              auto *useOfCopy =
+                  builder.createCopyValue(loc, runningVals->value.copy);
+              // Note that we don't call prepareToDelete useOfCopy because we
+              // specifically want this instruction to remain a use of copy.
+              instructionsToDelete.push_back(useOfCopy);
+            });
       }
       continue;
     }
@@ -611,32 +686,39 @@ Optional<ValueInstructions> StackAllocationPromoter::promoteAllocationInBlock(
     // promote this when we deal with hooking up phis.
     if (auto *dvi = DebugValueInst::hasAddrVal(inst)) {
       if (dvi->getOperand() == asi && runningVals)
-        promoteDebugValueAddr(dvi, runningVals->replacement(asi), ctx, deleter);
+        promoteDebugValueAddr(dvi, runningVals->value.replacement(asi), ctx,
+                              deleter);
       continue;
     }
 
     // Replace destroys with a release of the value.
     if (auto *dai = dyn_cast<DestroyAddrInst>(inst)) {
-      if (dai->getOperand() == asi && runningVals) {
-        replaceDestroy(dai, runningVals->replacement(asi), ctx, deleter);
+      if (dai->getOperand() == asi) {
+        if (runningVals) {
+          replaceDestroy(dai, runningVals->value.replacement(asi), ctx, deleter,
+                         instructionsToDelete);
+          if (shouldAddLexicalLifetime(asi)) {
+            endLexicalLifetimeBeforeInst(asi, /*beforeInstruction=*/dai, ctx,
+                                         runningVals->value);
+          }
+          runningVals->isStorageValid = false;
+          if (lastStoreInst)
+            lastStoreInst->isStorageValid = false;
+        } else {
+          assert(!deinitializationPoints[blockPromotingWithin]);
+          deinitializationPoints[blockPromotingWithin] = dai;
+        }
       }
       continue;
     }
 
     if (auto *dvi = dyn_cast<DestroyValueInst>(inst)) {
-      if (runningVals && dvi->getOperand() == runningVals->replacement(asi)) {
-        if (runningVals->borrow) {
-          // If we have started a lexical borrow scope in this block for
-          // runningVals->stored (when runningVals->stored's definition comes
-          // from a store and not from a load), end the borrrow scope here.
-          endLexicalLifetimeInBlock(asi, dvi->getParent(), ctx, domInfo,
-                                    runningVals->copy, runningVals->borrow,
-                                    runningVals->stored);
-        }
+      if (runningVals &&
+          dvi->getOperand() == runningVals->value.replacement(asi)) {
         // Reset LastStore.
         // So that we don't end up passing dead values as phi args in
         // StackAllocationPromoter::fixBranchesAndUses
-        lastValueInstructions = llvm::None;
+        lastStoreInst = llvm::None;
       }
     }
 
@@ -647,18 +729,18 @@ Optional<ValueInstructions> StackAllocationPromoter::promoteAllocationInBlock(
     }
   }
 
-  if (lastValueInstructions) {
-    assert(lastValueInstructions->store->getOwnershipQualifier() !=
+  if (lastStoreInst && lastStoreInst->isStorageValid) {
+    assert(lastStoreInst->value->getOwnershipQualifier() !=
                StoreOwnershipQualifier::Assign &&
            "store [assign] to the stack location should have been "
            "transformed to a store [init]");
     LLVM_DEBUG(llvm::dbgs() << "*** Finished promotion. Last store: "
-                            << lastValueInstructions->store);
-  } else {
-    LLVM_DEBUG(llvm::dbgs() << "*** Finished promotion with no stores.\n");
+                            << lastStoreInst->value);
+    return lastStoreInst->value;
   }
 
-  return lastValueInstructions;
+  LLVM_DEBUG(llvm::dbgs() << "*** Finished promotion with no stores.\n");
+  return nullptr;
 }
 
 void StackAllocationPromoter::addBlockArguments(BlockSetVector &phiBlocks) {
@@ -687,14 +769,21 @@ StackAllocationPromoter::getLiveOutValues(BlockSetVector &phiBlocks,
     SILBasicBlock *domBlock = domNode->getBlock();
 
     // If there is a store (that must come after the phi), use its value.
-    BlockToInstsMap::iterator it = lastStoreInBlock.find(domBlock);
-    if (it != lastStoreInBlock.end()) {
-      auto storedValues = it->second;
-      auto *si = storedValues.store;
-      LLVM_DEBUG(llvm::dbgs() << "*** Found Store def " << *si->getSrc());
-      SILValue borrow = storedValues.borrow;
-      SILValue copy = storedValues.copy;
-      LiveValues values = {si->getSrc(), borrow, copy};
+    BlockToInstMap<StoreInst>::iterator it =
+        initializationPoints.find(domBlock);
+    if (it != initializationPoints.end()) {
+      auto *si = it->second;
+      LLVM_DEBUG(llvm::dbgs() << "*** Found Store def " << si->getSrc());
+      SILValue stored = si->getSrc();
+      SILValue borrow = SILValue();
+      SILValue copy = SILValue();
+      if (shouldAddLexicalLifetime(asi)) {
+        auto *bbi = cast<BeginBorrowInst>(&*std::next(si->getIterator()));
+        borrow = bbi;
+        auto *cvi = cast<CopyValueInst>(bbi->getNextInstruction());
+        copy = cvi;
+      }
+      LiveValues values = {stored, borrow, copy};
       return values;
     }
 
@@ -871,11 +960,12 @@ void StackAllocationPromoter::fixBranchesAndUses(BlockSetVector &phiBlocks,
       SILBasicBlock *loadBlock = li->getParent();
       def = getEffectiveLiveInValues(phiBlocks, loadBlock);
 
-      LLVM_DEBUG(llvm::dbgs()
-                 << "*** Replacing " << *li << " with Def " << def.stored);
+      LLVM_DEBUG(llvm::dbgs() << "*** Replacing " << *li << " with Def "
+                              << def.replacement(asi));
 
       // Replace the load with the definition that we found.
-      replaceLoad(li, def.replacement(asi), asi, ctx, deleter);
+      replaceLoad(li, def.replacement(asi), asi, ctx, deleter,
+                  instructionsToDelete);
       removedUser = true;
       ++NumInstRemoved;
     }
@@ -900,7 +990,8 @@ void StackAllocationPromoter::fixBranchesAndUses(BlockSetVector &phiBlocks,
     // Replace destroys with a release of the value.
     if (auto *dai = dyn_cast<DestroyAddrInst>(user)) {
       auto def = getEffectiveLiveInValues(phiBlocks, userBlock);
-      replaceDestroy(dai, def.replacement(asi), ctx, deleter);
+      replaceDestroy(dai, def.replacement(asi), ctx, deleter,
+                     instructionsToDelete);
       continue;
     }
   }
@@ -957,50 +1048,125 @@ void StackAllocationPromoter::fixBranchesAndUses(BlockSetVector &phiBlocks,
   }
 }
 
-/// End the lexical lifetimes that were introduced for the alloc_stack if it was
-/// lexical, if any.
+/// End the lexical lifetimes that were introduced for storage to the
+/// alloc_stack and have not already been ended.
 ///
-/// Identify the blocks which need to end a lexical borrow scope, and then
-/// insert the end into them.  Find those blocks by visiting the successors of
-/// each new lexical begin_borrow's block.  End the borrow scope in the visited
-/// blocks if any of the following conditions are met:
-/// (1) The block is terminal--if we haven't managed to end the borrow scope
-///     before the last block in the function, it must be ended there.
-/// (2) Any of its successors don't have live-in values for the alloc_stack--in
-///     order for a block to propagate the copied value so that it might
-///     eventually be destroyed, the block must pass that value on to all its
-///     successors; if any successor does not take that value, then neither it
-///     nor any of its successors could possibly destroy the value.
-/// (3) The block had a dealloc_stack--if the allocated space was deallocated
-///     in this block, the lifetime of any value stored in it must end there.
+/// Walk forward from the out-edge of each of the blocks which began but did not
+/// end a borrow scope.  The scope must be ended if any of the following three
+/// conditions hold:
+///
+/// Normally, we are relying on the invariant that the storage's
+/// deinitializations must jointly postdominate its initializations.  That fact
+/// allows us to simply end scopes when memory is deinitialized.  There is only
+/// one simple check to do:
+///
+/// (1) A block deinitializes the storage before initializing it.
+///
+///     These blocks and the relevant instruction within them are tracked by the
+///     deinitializationPoints map.
+///
+/// If this were all we needed to do, we could just iterate over that map.
+///
+/// The above invariant does not help us with unreachable terminators, however.
+/// Because it is valid to have the alloc_stack be initialized when exiting a
+/// function via an unreachable, we can't rely on the memory having been
+/// deinitialized.  But we still need to ensure that borrow scopes are ended and
+/// values are destroyed before getting to an unreachable.
+///
+/// (2.a) A block has as its terminator an UnreachableInst.
+///
+/// (2.b) A block's single successor does not have live-in values.
+///
+///       This can only happen if the successor is a CFG merge and all paths
+///       from here lead to unreachable.
 void StackAllocationPromoter::endLexicalLifetime(BlockSetVector &phiBlocks) {
   if (!shouldAddLexicalLifetime(asi))
     return;
 
-  SmallPtrSet<SILBasicBlock *, 4> dsiBlocks;
-  for (auto *dsi : dsis)
-    dsiBlocks.insert(dsi->getParent());
+  // We need to separately consider and visit incoming unopened borrow scopes
+  // and outgoing unclosed borrow scopes.  The reason is that a walk should stop
+  // on any path where it encounters an incoming unopened borrow scope but that
+  // should _NOT_ count as a visit of outgoing unclosed borrow scopes.
+  //
+  // Without this distinction, a case like the following wouldn't be visited
+  // properly:
+  //
+  //     bb1:
+  //       %addr = alloc_stack
+  //       store %value to [init] %addr
+  //       br bb2
+  //     bb2:
+  //       %value_2 = load [take] %addr
+  //       store %value_2 to [init] %addr
+  //       br bb3
+  //     bb3:
+  //       destroy_addr %addr
+  //       dealloc_stack %addr
+  //       %r = tuple ()
+  //       return %r
+  //
+  // Both bb1 and bb2 have cross-block initialization points.  Suppose that we
+  // visited bb1 first.  We would see that it didn't have an incoming unopened
+  // borrow scope (already, we can tell something is amiss that we're
+  // considering this) and then add bb2 to the worklist--except it's already
+  // there.  Next we would visit bb2.  We would see that it had an incoming
+  // unopened borrow scope so we would close it.  And then we'd be done.  In
+  // particular, we'd leave the scope that opens in bb2 unclosed.
+  //
+  // The root cause here is that it's important to stop walking when we hit a
+  // scope close.  Otherwise, we could keep walking down to blocks which don't
+  // have live-in or live-out values.
+  //
+  // Visiting the incoming and outgoing edges works as follows in the above
+  // example:  The worklist is initialiized with {(bb1, ::Out), (bb2, ::Out)}.
+  // When visiting (bb1, ::Out), we see that bb1 is neither unreachable nor
+  // has exactly one successor without live-in values.  So we add (bb2, ::In) to
+  // the worklist.  Next, we visit (bb2, ::Out).  We see that it _also_ doesn't
+  // have an unreachable terminator or a unique successor without live-in
+  // values, so we add (bb3, ::In).  Next, we visit (bb2, ::In).  We see that
+  // it _does_ have an incoming unopened borrow scope, so we close it and stop.
+  // Finally, we visit (bb3, ::Out).  We see that it too has an incoming
+  // unopened borrow scope so we close it and stop.
+  enum class AvailableValuesKind : uint8_t { In, Out };
 
-  DAGNodeWorklist<SILBasicBlock *, 32> worklist;
-  worklist.initializeRange(lexicalBBIBlocks);
-  while (auto *bb = worklist.pop()) {
-    bool isFunctionExit = bb->getSuccessorBlocks().empty();
-    auto successorsHaveLiveInValues = [&]() -> bool {
-      return llvm::all_of(bb->getSuccessorBlocks(), [&](auto *successor) {
-        return getLiveInValues(phiBlocks, successor);
-      });
-    };
-    auto hadDeallocStack = [&]() -> bool { return dsiBlocks.contains(bb); };
-    if (isFunctionExit || !successorsHaveLiveInValues() || hadDeallocStack()) {
-      auto values = getLiveOutValues(phiBlocks, bb);
-      if (!values)
+  using ScopeEndPosition =
+      llvm::PointerIntPair<SILBasicBlock *, 1, AvailableValuesKind>;
+
+  DAGNodeWorklist<ScopeEndPosition, 16> worklist;
+  for (auto pair : initializationPoints) {
+    worklist.insert({pair.getFirst(), AvailableValuesKind::Out});
+  }
+  while (!worklist.empty()) {
+    auto position = worklist.pop();
+    auto *bb = position.getPointer();
+    switch (position.getInt()) {
+    case AvailableValuesKind::In: {
+      if (auto *inst = deinitializationPoints[bb]) {
+        auto values = getLiveInValues(phiBlocks, bb);
+        endLexicalLifetimeBeforeInst(asi, /*beforeInstruction=*/inst, ctx,
+                                     *values);
         continue;
-      endLexicalLifetimeInBlock(asi, bb, ctx, domInfo, values->copy,
-                                values->borrow, values->stored);
-    } else {
-      for (auto *successor : bb->getSuccessorBlocks()) {
-        worklist.insert(successor);
       }
+      worklist.insert({bb, AvailableValuesKind::Out});
+      break;
+    }
+    case AvailableValuesKind::Out: {
+      bool terminatesInUnreachable = isa<UnreachableInst>(bb->getTerminator());
+      auto uniqueSuccessorLacksLiveInValues = [&]() -> bool {
+        return bb->getSingleSuccessorBlock() &&
+               !getLiveInValues(phiBlocks, bb->getSingleSuccessorBlock());
+      };
+      if (terminatesInUnreachable || uniqueSuccessorLacksLiveInValues()) {
+        auto values = getLiveOutValues(phiBlocks, bb);
+        endLexicalLifetimeBeforeInst(
+            asi, /*beforeInstruction=*/bb->getTerminator(), ctx, *values);
+        continue;
+      }
+      for (auto *successor : bb->getSuccessorBlocks()) {
+        worklist.insert({successor, AvailableValuesKind::In});
+      }
+      break;
+    }
     }
   }
 }
@@ -1013,18 +1179,12 @@ void StackAllocationPromoter::pruneAllocStackUsage() {
   for (auto *use : asi->getUses())
     functionBlocks.insert(use->getUser()->getParent());
 
-  // Clear AllocStack state.
-  lastStoreInBlock.clear();
-
   for (auto block : functionBlocks)
-    if (auto lastValueInstructions = promoteAllocationInBlock(block)) {
-      lastStoreInBlock[block] = *lastValueInstructions;
-      if (lastValueInstructions->borrow) {
-        // If begin_borrow instructions were created, record the blocks to which
-        // they were added.  In order to end these scopes, we need to have a
-        // list of the blocks in which they are begun.
-        lexicalBBIBlocks.push_back(lastValueInstructions->borrow->getParent());
-      }
+    if (auto si = promoteAllocationInBlock(block)) {
+      // There was a final storee instruction which was not followed by an
+      // instruction that deinitializes the memory.  Record it as a cross-block
+      // initialization point.
+      initializationPoints[block] = si;
     }
 
   LLVM_DEBUG(llvm::dbgs() << "*** Finished pruning : " << *asi);
@@ -1174,6 +1334,7 @@ class MemoryToRegisters {
   SILBuilderContext ctx;
 
   InstructionDeleter deleter;
+  SmallVector<SILInstruction *, 32> instructionsToDelete;
 
   /// Returns the dom tree levels for the current function. Computes these
   /// lazily.
@@ -1367,7 +1528,7 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
 
   // The default value of the AllocStack is NULL because we don't have
   // uninitialized variables in Swift.
-  Optional<LiveValues> runningVals;
+  Optional<StorageStateTracking<LiveValues>> runningVals;
 
   // For all instructions in the block.
   for (auto bbi = parentBlock->begin(), bbe = parentBlock->end(); bbi != bbe;) {
@@ -1380,12 +1541,25 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
       if (!runningVals) {
         // Loading without a previous store is only acceptable if the type is
         // Void (= empty tuple) or a tuple of Voids.
-        runningVals =
-            LiveValues::toReplace(asi, /*replacement=*/createValueForEmptyTuple(
-                                      asi->getElementType(), inst, ctx));
+        runningVals = {
+            LiveValues::toReplace(asi,
+                                  /*replacement=*/createValueForEmptyTuple(
+                                      asi->getElementType(), inst, ctx)),
+            /*isStorageValid=*/true};
       }
-      replaceLoad(cast<LoadInst>(inst), runningVals->replacement(asi), asi, ctx,
-                  deleter);
+      assert(runningVals && runningVals->isStorageValid);
+      if (cast<LoadInst>(inst)->getOwnershipQualifier() ==
+          LoadOwnershipQualifier::Take) {
+        if (shouldAddLexicalLifetime(asi)) {
+          // End the lexical lifetime at a load [take].  The storage is no
+          // longer keeping the value alive.
+          endLexicalLifetimeBeforeInst(asi, /*beforeInstruction=*/inst, ctx,
+                                       runningVals->value);
+        }
+        runningVals->isStorageValid = false;
+      }
+      replaceLoad(cast<LoadInst>(inst), runningVals->value.replacement(asi),
+                  asi, ctx, deleter, instructionsToDelete);
       ++NumInstRemoved;
       continue;
     }
@@ -1395,19 +1569,19 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
     if (auto *si = dyn_cast<StoreInst>(inst)) {
       if (si->getDest() == asi) {
         if (si->getOwnershipQualifier() == StoreOwnershipQualifier::Assign) {
-          assert(runningVals);
+          assert(runningVals && runningVals->isStorageValid);
           SILBuilderWithScope(si, ctx).createDestroyValue(
-              si->getLoc(), runningVals->replacement(asi));
+              si->getLoc(), runningVals->value.replacement(asi));
         }
         auto oldRunningVals = runningVals;
-        runningVals = LiveValues::toReplace(asi, /*replacement=*/si->getSrc());
+        runningVals = {LiveValues::toReplace(asi, /*replacement=*/si->getSrc()),
+                       /*isStorageValid=*/true};
         if (shouldAddLexicalLifetime(asi)) {
-          if (oldRunningVals) {
-            endLexicalLifetimeInBlock(
-                asi, si->getParent(), ctx, domInfo, oldRunningVals->copy,
-                oldRunningVals->borrow, oldRunningVals->stored);
+          if (oldRunningVals && oldRunningVals->isStorageValid) {
+            endLexicalLifetimeBeforeInst(asi, /*beforeInstruction=*/si, ctx,
+                                         oldRunningVals->value);
           }
-          runningVals = beginLexicalLifetimeAtStore(asi, si, ctx).second;
+          runningVals = beginLexicalLifetimeAfterStore(asi, si);
         }
         deleter.forceDelete(inst);
         ++NumInstRemoved;
@@ -1420,7 +1594,7 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
     if (auto *dvi = DebugValueInst::hasAddrVal(inst)) {
       if (dvi->getOperand() == asi) {
         if (runningVals) {
-          promoteDebugValueAddr(dvi, runningVals->replacement(asi), ctx,
+          promoteDebugValueAddr(dvi, runningVals->value.replacement(asi), ctx,
                                 deleter);
         } else {
           // Drop debug_value of uninitialized void values.
@@ -1435,7 +1609,14 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
     // Replace destroys with a release of the value.
     if (auto *dai = dyn_cast<DestroyAddrInst>(inst)) {
       if (dai->getOperand() == asi) {
-        replaceDestroy(dai, runningVals->replacement(asi), ctx, deleter);
+        assert(runningVals && runningVals->isStorageValid);
+        replaceDestroy(dai, runningVals->value.replacement(asi), ctx, deleter,
+                       instructionsToDelete);
+        if (shouldAddLexicalLifetime(asi)) {
+          endLexicalLifetimeBeforeInst(asi, /*beforeInstruction=*/dai, ctx,
+                                       runningVals->value);
+        }
+        runningVals->isStorageValid = false;
       }
       continue;
     }
@@ -1463,10 +1644,14 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
     }
   }
 
-  if (runningVals && shouldAddLexicalLifetime(asi)) {
-    endLexicalLifetimeInBlock(asi, asi->getParent(), ctx, domInfo,
-                              runningVals->copy, runningVals->borrow,
-                              runningVals->stored);
+  if (runningVals && runningVals->isStorageValid &&
+      shouldAddLexicalLifetime(asi)) {
+    assert(isa<UnreachableInst>(parentBlock->getTerminator()) &&
+           "valid storage after reaching end of single-block allocation not "
+           "terminated by unreachable?!");
+    endLexicalLifetimeBeforeInst(
+        asi, /*beforeInstruction=*/parentBlock->getTerminator(), ctx,
+        runningVals->value);
   }
 }
 
@@ -1525,7 +1710,9 @@ bool MemoryToRegisters::promoteSingleAllocation(AllocStackInst *alloc) {
   // Promote this allocation, lazily computing dom tree levels for this function
   // if we have not done so yet.
   auto &domTreeLevels = getDomTreeLevels();
-  StackAllocationPromoter(alloc, domInfo, domTreeLevels, ctx, deleter).run();
+  StackAllocationPromoter(alloc, domInfo, domTreeLevels, ctx, deleter,
+                          instructionsToDelete)
+      .run();
 
   // Make sure that all of the allocations were promoted into registers.
   assert(isWriteOnlyAllocation(alloc) && "Non-write uses left behind");
@@ -1547,6 +1734,10 @@ bool MemoryToRegisters::run() {
         continue;
 
       if (promoteSingleAllocation(asi)) {
+        for (auto *inst : instructionsToDelete) {
+          deleter.forceDelete(inst);
+        }
+        instructionsToDelete.clear();
         ++NumInstRemoved;
         madeChange = true;
       }

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -342,10 +342,10 @@ beginLexicalLifetimeAtStore(AllocStackInst *asi, StoreInst *si,
 /// They should be added after the value is done being used.  If the value is
 /// ever used, that means after the last use.  Otherwise, it means immediately
 /// after the definition.
-void endLexicalLifetimeInBlock(AllocStackInst *asi, SILBasicBlock *bb,
-                               SILBuilderContext &ctx, DominanceInfo *domInfo,
-                               SILValue copy, SILValue borrow,
-                               SILValue original) {
+static void endLexicalLifetimeInBlock(AllocStackInst *asi, SILBasicBlock *bb,
+                                      SILBuilderContext &ctx,
+                                      DominanceInfo *domInfo, SILValue copy,
+                                      SILValue borrow, SILValue original) {
   assert(shouldAddLexicalLifetime(asi));
   SILInstruction *lastInst = nullptr;
   if (auto *cvi = copy->getDefiningInstruction()) {

--- a/test/SILOptimizer/mem2reg_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_lifetime.sil
@@ -1493,6 +1493,37 @@ work:
   unreachable
 }
 
+// CHECK-LABEL: sil [ossa] @unreachable_2 : $@convention(thin) (@owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'unreachable_2'
+sil [ossa] @unreachable_2 : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance to [init] %addr : $*C
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @unreachable_3 : $@convention(thin) (@owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'unreachable_3'
+sil [ossa] @unreachable_3 : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance to [init] %addr : $*C
+  %instance_loaded = load [take] %addr : $*C
+  unreachable
+}
+
 // CHECK-LABEL: sil [ossa] @unreachable_4 : $@convention(thin) (@owned C) -> () {
 // CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
 // CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] : $C

--- a/test/SILOptimizer/mem2reg_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_lifetime.sil
@@ -407,10 +407,10 @@ bb0(%0 : @owned $LargeCodesizeStruct):
 // CHECK:   [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[ARG0]]
 // CHECK:   [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
 // CHECK:   ([[ELEM1:%[0-9]+]], [[ELEM2:%[0-9]+]]) = destructure_struct [[LIFETIME_OWNED]]
-// CHECK:   end_borrow [[LIFETIME]]
-// CHECK:   destroy_value [[ARG0]]
 // CHECK:   destroy_value [[ELEM1]]
 // CHECK:   destroy_value [[ELEM2]]
+// CHECK:   end_borrow [[LIFETIME]]
+// CHECK:   destroy_value [[ARG0]]
 // CHECK: } // end sil function 'small_struct_test'
 sil [ossa] @small_struct_test : $@convention(thin) (@owned SmallCodesizeStruct) -> () {
 bb0(%0 : @owned $SmallCodesizeStruct):
@@ -430,20 +430,20 @@ bb0(%0 : @owned $SmallCodesizeStruct):
 // CHECK:       bb1:
 // CHECK:         [[COPY:%.*]] = copy_value [[LIFETIME_OWNED]]
 // CHECK-NEXT:    destructure_struct [[LIFETIME_OWNED]]
+// CHECK-NEXT:    destroy_value
+// CHECK-NEXT:    destroy_value
 // CHECK-NEXT:    end_borrow [[LIFETIME]]
 // CHECK-NEXT:    destroy_value [[INSTANCE]]
-// CHECK-NEXT:    destroy_value
-// CHECK-NEXT:    destroy_value
 // CHECK-NEXT:    begin_borrow [[COPY]]
 // CHECK-NEXT:    debug_value
 // CHECK-NEXT:    end_borrow
 // CHECK-NEXT:    destroy_value [[COPY]]
 // CHECK:       bb2:
 // CHECK-NEXT:    destructure_struct [[LIFETIME_OWNED]]
+// CHECK-NEXT:    destroy_value
+// CHECK-NEXT:    destroy_value
 // CHECK-NEXT:    end_borrow [[LIFETIME]]
 // CHECK-NEXT:    destroy_value [[INSTANCE]]
-// CHECK-NEXT:    destroy_value
-// CHECK-NEXT:    destroy_value
 // CHECK-LABEL: } // end sil function 'small_struct_multi_test'
 sil [ossa] @small_struct_multi_test : $@convention(thin) (@owned SmallCodesizeStruct) -> () {
 bb0(%0 : @owned $SmallCodesizeStruct):
@@ -518,9 +518,15 @@ bb0:
 // =============================================================================
 
 class C {}
+class D : C {}
+enum E {
+case one(C)
+}
 
 sil [ossa] @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
 sil [ossa] @callee_owned : $@convention(thin) (@owned C) -> ()
+sil [ossa] @callee_error_owned : $@convention(thin) (@owned C) -> @error Error
+sil [ossa] @callee_void_to_void : $@convention(thin) () -> ()
 
 // basic_N {{ functions consisting of a single block
 
@@ -531,11 +537,11 @@ sil [ossa] @callee_owned : $@convention(thin) (@owned C) -> ()
 // CHECK:       bb0([[INSTANCE:%[^,]+]] : @owned $C):
 // CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
 // CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
 // CHECK:         [[CALLEE:%[^,]+]] = function_ref @callee_guaranteed
 // CHECK:         [[RETVAL:%[^,]+]] = apply [[CALLEE]]([[LIFETIME_OWNED]])
 // CHECK:         destroy_value [[LIFETIME_OWNED]]
-// CHECK:         end_borrow [[LIFETIME]]
-// CHECK:         destroy_value [[INSTANCE]]
 // CHECK:         return [[RETVAL]]
 // CHECK-LABEL: } // end sil function 'basic_1'
 sil [ossa] @basic_1 : $(@owned C) -> () {
@@ -558,11 +564,11 @@ entry(%instance : @owned $C):
 // CHECK:         [[INSTANCE:%[^,]+]] = copy_value [[INSTANCE_GUARANTEED]]
 // CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
 // CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
 // CHECK:         [[CALLEE:%[^,]+]] = function_ref @callee_guaranteed
 // CHECK:         [[RETVAL:%[^,]+]] = apply [[CALLEE]]([[LIFETIME_OWNED]])
 // CHECK:         destroy_value [[LIFETIME_OWNED]]
-// CHECK:         end_borrow [[LIFETIME]]
-// CHECK:         destroy_value [[INSTANCE]]
 // CHECK:         return [[RETVAL]]
 // CHECK-LABEL: } // end sil function 'basic_3'
 sil [ossa] @basic_3 : $(@guaranteed C) -> () {
@@ -585,10 +591,10 @@ entry(%instance_guaranteed : @guaranteed $C):
 // CHECK:       bb0([[INSTANCE:%[^,]+]] : @owned $C):
 // CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
 // CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
-// CHECK:         [[CALLEE:%[^,]+]] = function_ref @callee_owned
-// CHECK:         [[RETVAL:%[^,]+]] = apply [[CALLEE]]([[LIFETIME_OWNED]])
 // CHECK:         end_borrow [[LIFETIME]]
 // CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         [[CALLEE:%[^,]+]] = function_ref @callee_owned
+// CHECK:         [[RETVAL:%[^,]+]] = apply [[CALLEE]]([[LIFETIME_OWNED]])
 // CHECK:         return [[RETVAL]]
 // CHECK-LABEL: } // end sil function 'basic_4'
 sil [ossa] @basic_4 : $(@owned C) -> () {
@@ -602,7 +608,913 @@ entry(%instance : @owned $C):
     return %res : $()
 }
 
+// CHECK-LABEL: sil [ossa] @basic_5 : $@convention(thin) (@owned C, @owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE_1:%[^,]+]] : @owned $C, [[INSTANCE_2:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]]
+// CHECK:         destroy_value [[LIFETIME_OWNED_1]]
+// CHECK:         end_borrow [[LIFETIME_1]]
+// CHECK:         destroy_value [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]]
+// CHECK:         destroy_value [[LIFETIME_OWNED_2]]
+// CHECK:         end_borrow [[LIFETIME_2]]
+// CHECK:         destroy_value [[INSTANCE_2]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'basic_5'
+sil [ossa] @basic_5 : $@convention(thin) (@owned C, @owned C) -> () {
+entry(%instance_1 : @owned $C, %instance_2 : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance_1 to [init] %addr : $*C
+  store %instance_2 to [assign] %addr : $*C
+  destroy_addr %addr : $*C
+  dealloc_stack %addr : $*C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @basic_6 : $@convention(thin) (@owned C, @owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE_1:%[^,]+]] : @owned $C, [[INSTANCE_2:%[^,]+]] : @owned $C):
+// CHECK:         br [[WORK:bb[0-9]+]]
+// CHECK:       [[WORK]]:
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]]
+// CHECK:         destroy_value [[LIFETIME_OWNED_1]]
+// CHECK:         end_borrow [[LIFETIME_1]]
+// CHECK:         destroy_value [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]]
+// CHECK:         destroy_value [[LIFETIME_OWNED_2]]
+// CHECK:         end_borrow [[LIFETIME_2]]
+// CHECK:         destroy_value [[INSTANCE_2]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'basic_6' 
+sil [ossa] @basic_6 : $@convention(thin) (@owned C, @owned C) -> () {
+entry(%instance_1 : @owned $C, %instance_2 : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  br work
+work:
+  store %instance_1 to [init] %addr : $*C
+  store %instance_2 to [assign] %addr : $*C
+  destroy_addr %addr : $*C
+  dealloc_stack %addr : $*C
+  br exit
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @basic_7 : $@convention(thin) (@owned C, @owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE_1:%[^,]+]] : @owned $C, [[INSTANCE_2:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]]
+// CHECK:         br [[WORK:bb[0-9]+]]
+// CHECK:       [[WORK]]:
+// CHECK:         destroy_value [[LIFETIME_OWNED_1]]
+// CHECK:         end_borrow [[LIFETIME_1]]
+// CHECK:         destroy_value [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]]
+// CHECK:         destroy_value [[LIFETIME_OWNED_2]]
+// CHECK:         end_borrow [[LIFETIME_2]]
+// CHECK:         destroy_value [[INSTANCE_2]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'basic_7'
+sil [ossa] @basic_7 : $@convention(thin) (@owned C, @owned C) -> () {
+entry(%instance_1 : @owned $C, %instance_2 : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance_1 to [init] %addr : $*C
+  br work
+work:
+  store %instance_2 to [assign] %addr : $*C
+  destroy_addr %addr : $*C
+  dealloc_stack %addr : $*C
+  br exit
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
 // basic_N }}
+
+// after_N {{ uses of the loaded value after dealloc_stack
+
+// CHECK-LABEL: sil [ossa] @after_1 : $@convention(thin) (@owned C) -> @owned C {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         [[CALLEE_VOID_TO_VOID:%[^,]+]] = function_ref @callee_void_to_void
+// CHECK:         apply [[CALLEE_VOID_TO_VOID]]
+// CHECK:         return [[LIFETIME_OWNED]]
+// CHECK-LABEL: } // end sil function 'after_1'
+sil [ossa] @after_1 : $@convention(thin) (@owned C) -> @owned C {
+bb0(%instance : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance to [init] %addr : $*C
+  %instance_loaded = load [take] %addr : $*C
+  dealloc_stack %addr : $*C
+  %callee_void_to_void = function_ref @callee_void_to_void : $@convention(thin) () -> ()
+  %ok = apply %callee_void_to_void() : $@convention(thin) () -> ()
+  return %instance_loaded : $C
+}
+
+// CHECK-LABEL: sil [ossa] @after_2 : $@convention(thin) (@owned C, @owned C) -> @owned C {
+// CHECK:       {{bb[^,]+}}([[INSTANCE_1:%[^,]+]] : @owned $C, [[INSTANCE_2:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]] 
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]] 
+// CHECK:         end_borrow [[LIFETIME_1]] 
+// CHECK:         destroy_value [[INSTANCE_1]] 
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]] 
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]] 
+// CHECK:         end_borrow [[LIFETIME_2]] 
+// CHECK:         destroy_value [[INSTANCE_2]] 
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         apply [[CALLEE_GUARANTEED]]([[LIFETIME_OWNED_2]]) 
+// CHECK:         destroy_value [[LIFETIME_OWNED_2]] 
+// CHECK:         return [[LIFETIME_OWNED_1]] 
+// CHECK-LABEL: } // end sil function 'after_2' 
+sil [ossa] @after_2 : $@convention(thin) (@owned C, @owned C) -> @owned C {
+bb0(%instance_1 : @owned $C, %instance_2 : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance_1 to [init] %addr : $*C
+  %instance_1_loaded = load [take] %addr : $*C
+  store %instance_2 to [init] %addr : $*C
+  %instance_2_loaded = load [take] %addr : $*C
+  dealloc_stack %addr : $*C
+  %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+  %ok2 = apply %callee_guaranteed(%instance_2_loaded) : $@convention(thin) (@guaranteed C) -> ()
+  destroy_value %instance_2_loaded : $C
+  return %instance_1_loaded : $C
+}
+
+// CHECK-LABEL: sil [ossa] @after_3 : $@convention(thin) (@owned C) -> @owned C {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] 
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]] 
+// CHECK:         end_borrow [[LIFETIME]] 
+// CHECK:         destroy_value [[INSTANCE]] 
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         [[CALLEE_VOID_TO_VOID:%[^,]+]] = function_ref @callee_void_to_void 
+// CHECK:         apply [[CALLEE_VOID_TO_VOID]]() 
+// CHECK:         return [[LIFETIME_OWNED]] 
+// CHECK-LABEL: } // end sil function 'after_3'
+sil [ossa] @after_3 : $@convention(thin) (@owned C) -> @owned C {
+bb0(%instance : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance to [init] %addr : $*C
+  %instance_loaded = load [take] %addr : $*C
+  br exit
+exit:
+  dealloc_stack %addr : $*C
+  %callee_void_to_void = function_ref @callee_void_to_void : $@convention(thin) () -> ()
+  %ok = apply %callee_void_to_void() : $@convention(thin) () -> ()
+  return %instance_loaded : $C
+}
+
+// CHECK-LABEL: sil [ossa] @after_4 : $@convention(thin) (@owned C) -> @owned C {
+// CHECK:       bb0([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] 
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]] 
+// CHECK:         end_borrow [[LIFETIME]] 
+// CHECK:         destroy_value [[INSTANCE]] 
+// CHECK:         br bb1
+// CHECK:       bb1:
+// CHECK:         [[CALLEE_VOID_TO_VOID:%[^,]+]] = function_ref @callee_void_to_void 
+// CHECK:         apply [[CALLEE_VOID_TO_VOID]]() 
+// CHECK:         return [[LIFETIME_OWNED]] 
+// CHECK-LABEL: } // end sil function 'after_4'
+sil [ossa] @after_4 : $@convention(thin) (@owned C) -> @owned C {
+bb0(%instance : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance to [init] %addr : $*C
+  %instance_loaded = load [take] %addr : $*C
+  br exit
+exit:
+  %callee_void_to_void = function_ref @callee_void_to_void : $@convention(thin) () -> ()
+  %ok = apply %callee_void_to_void() : $@convention(thin) () -> ()
+  dealloc_stack %addr : $*C
+  return %instance_loaded : $C
+}
+
+// CHECK-LABEL: sil [ossa] @after_5 : $@convention(thin) (@owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         [[RETVAL:%[^,]+]] = apply [[CALLEE_GUARANTEED]]([[LIFETIME_OWNED]])
+// CHECK:         destroy_value [[LIFETIME_OWNED]]
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'after_5'
+sil [ossa] @after_5 : $@convention(thin) (@owned C) -> () {
+bb0(%instance : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance to [init] %addr : $*C
+  %instance_loaded = load [take] %addr : $*C
+  br exit
+exit:
+  dealloc_stack %addr : $*C
+  %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+  %retval = apply %callee_guaranteed(%instance_loaded) : $@convention(thin) (@guaranteed C) -> ()
+  destroy_value %instance_loaded : $C
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @after_6 : $@convention(thin) (@owned C, @owned C, @owned C) -> @owned C {
+// CHECK:       {{bb[^,]+}}([[INSTANCE_1:%[^,]+]] : @owned $C, [[INSTANCE_2:%[^,]+]] : @owned $C, [[INSTANCE_3:%[^,]+]] : @owned $C):
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]]
+// CHECK:         end_borrow [[LIFETIME_1]]
+// CHECK:         destroy_value [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]]
+// CHECK:         end_borrow [[LIFETIME_2]]
+// CHECK:         destroy_value [[INSTANCE_2]]
+// CHECK:         apply [[CALLEE_GUARANTEED]]([[LIFETIME_OWNED_2]])
+// CHECK:         apply [[CALLEE_GUARANTEED]]([[LIFETIME_OWNED_1]])
+// CHECK:         [[LIFETIME_3:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_3]]
+// CHECK:         [[LIFETIME_OWNED_3:%[^,]+]] = copy_value [[LIFETIME_3]]
+// CHECK:         end_borrow [[LIFETIME_3]]
+// CHECK:         destroy_value [[INSTANCE_3]]
+// CHECK:         destroy_value [[LIFETIME_OWNED_2]]
+// CHECK:         destroy_value [[LIFETIME_OWNED_3]]
+// CHECK:         return [[LIFETIME_OWNED_1]]
+// CHECK-LABEL: } // end sil function 'after_6'
+sil [ossa] @after_6 : $@convention(thin) (@owned C, @owned C, @owned C) -> @owned C {
+bb0(%instance_1 : @owned $C, %instance_2 : @owned $C, %instance_3 : @owned $C):
+  %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+  %addr = alloc_stack [lexical] $C
+  store %instance_1 to [init] %addr : $*C
+  %instance_1_loaded = load [take] %addr : $*C
+  store %instance_2 to [init] %addr : $*C
+  %instance_2_loaded = load [take] %addr : $*C
+  %ok2 = apply %callee_guaranteed(%instance_2_loaded) : $@convention(thin) (@guaranteed C) -> ()
+  %ok1 = apply %callee_guaranteed(%instance_1_loaded) : $@convention(thin) (@guaranteed C) -> ()
+  store %instance_3 to [init] %addr : $*C
+  %instance_3_loaded = load [take] %addr : $*C
+  dealloc_stack %addr : $*C
+  destroy_value %instance_2_loaded : $C
+  destroy_value %instance_3_loaded : $C
+  return %instance_1_loaded : $C
+}
+
+// CHECK-LABEL: sil [ossa] @after_7 : $@convention(thin) (@owned C) -> @owned C {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] 
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]] 
+// CHECK:         end_borrow [[LIFETIME]] 
+// CHECK:         destroy_value [[INSTANCE]] 
+// CHECK:         [[CALLEE_VOID_TO_VOID:%[^,]+]] = function_ref @callee_void_to_void 
+// CHECK:         apply [[CALLEE_VOID_TO_VOID]]() 
+// CHECK:         return [[LIFETIME_OWNED]] 
+// CHECK-LABEL: } // end sil function 'after_7'
+sil [ossa] @after_7 : $@convention(thin) (@owned C) -> @owned C {
+bb0(%instance : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance to [init] %addr : $*C
+  %instance_loaded = load [take] %addr : $*C
+  %callee_void_to_void = function_ref @callee_void_to_void : $@convention(thin) () -> ()
+  %ok = apply %callee_void_to_void() : $@convention(thin) () -> ()
+  dealloc_stack %addr : $*C
+  return %instance_loaded : $C
+}
+
+// CHECK-LABEL: sil [ossa] @after_8 : $@convention(thin) (@owned C) -> @owned C {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] 
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]] 
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[LIFETIME_OWNED]] 
+// CHECK:         destroy_value [[LIFETIME_OWNED]] 
+// CHECK:         end_borrow [[LIFETIME]] 
+// CHECK:         destroy_value [[INSTANCE]] 
+// CHECK:         [[CALLEE_VOID_TO_VOID:%[^,]+]] = function_ref @callee_void_to_void 
+// CHECK:         apply [[CALLEE_VOID_TO_VOID]]() 
+// CHECK:         return [[COPY]] 
+// CHECK-LABEL: } // end sil function 'after_8'
+sil [ossa] @after_8 : $@convention(thin) (@owned C) -> @owned C {
+bb0(%instance : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance to [init] %addr : $*C
+  %instance_loaded = load [copy] %addr : $*C
+  destroy_addr %addr : $*C
+  %callee_void_to_void = function_ref @callee_void_to_void : $@convention(thin) () -> ()
+  %ok = apply %callee_void_to_void() : $@convention(thin) () -> ()
+  dealloc_stack %addr : $*C
+  return %instance_loaded : $C
+}
+
+// CHECK-LABEL: sil [ossa] @after_9 : $@convention(thin) (@owned C, @owned C) -> @owned C {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE_1:%[^,]+]] : @owned $C, [[INSTANCE_2:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]] 
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]] 
+// CHECK:         end_borrow [[LIFETIME_1]] 
+// CHECK:         destroy_value [[INSTANCE_1]] 
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]] 
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]] 
+// CHECK:         end_borrow [[LIFETIME_2]] 
+// CHECK:         destroy_value [[INSTANCE_2]] 
+// CHECK:         destroy_value [[LIFETIME_OWNED_2]] 
+// CHECK:         return [[LIFETIME_OWNED_1]] 
+// CHECK-LABEL: } // end sil function 'after_9'
+sil [ossa] @after_9 : $@convention(thin) (@owned C, @owned C) -> @owned C {
+bb0(%instance_1 : @owned $C, %instance_2 : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance_1 to [init] %addr : $*C
+  %instance_1_loaded = load [take] %addr : $*C
+  br exit
+exit:
+  store %instance_2 to [init] %addr : $*C
+  %instance_2_loaded = load [take] %addr : $*C
+  dealloc_stack %addr : $*C
+  destroy_value %instance_2_loaded : $C
+  return %instance_1_loaded : $C
+}
+
+// CHECK-LABEL: sil [ossa] @after_10 : $@convention(thin) (@owned C, @owned C) -> @owned C {
+// CHECK:       {{bb[^,]+}}([[INSTANCE_1:%[^,]+]] : @owned $C, [[INSTANCE_2:%[^,]+]] : @owned $C):
+// CHECK:         br [[WORK:bb[0-9]+]]
+// CHECK:       [[WORK]]:
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]] 
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]] 
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[LIFETIME_OWNED_1]] 
+// CHECK:         destroy_value [[LIFETIME_OWNED_1]] 
+// CHECK:         end_borrow [[LIFETIME_1]] 
+// CHECK:         destroy_value [[INSTANCE_1]] 
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]] 
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]] 
+// CHECK:         end_borrow [[LIFETIME_2]] 
+// CHECK:         destroy_value [[INSTANCE_2]] 
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         destroy_value [[LIFETIME_OWNED_2]] 
+// CHECK:         return [[COPY]] 
+// CHECK-LABEL: } // end sil function 'after_10'
+sil [ossa] @after_10 : $@convention(thin) (@owned C, @owned C) -> @owned C {
+bb0(%instance_1 : @owned $C, %instance_2 : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  br work
+work:
+  store %instance_1 to [init] %addr : $*C
+  %instance_1_loaded = load [copy] %addr : $*C
+  store %instance_2 to [assign] %addr : $*C
+  %instance_2_loaded = load [take] %addr : $*C
+  br exit
+exit:
+  dealloc_stack %addr : $*C
+  destroy_value %instance_2_loaded : $C
+  return %instance_1_loaded : $C
+}
+
+// CHECK-LABEL: sil [ossa] @after_11 : $@convention(thin) (@owned C, @owned C) -> @owned C {
+// CHECK:       {{bb[^,]+}}([[INSTANCE_1:%[^,]+]] : @owned $C, [[INSTANCE_2:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]]
+// CHECK:         br [[WORK:bb[0-9]+]]
+// CHECK:       [[WORK]]:
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[LIFETIME_OWNED_1]]
+// CHECK:         destroy_value [[LIFETIME_OWNED_1]]
+// CHECK:         end_borrow [[LIFETIME_1]]
+// CHECK:         destroy_value [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]]
+// CHECK:         end_borrow [[LIFETIME_2]]
+// CHECK:         destroy_value [[INSTANCE_2]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         destroy_value [[LIFETIME_OWNED_2]]
+// CHECK:         return [[COPY]]
+// CHECK-LABEL: } // end sil function 'after_11'
+sil [ossa] @after_11 : $@convention(thin) (@owned C, @owned C) -> @owned C {
+bb0(%instance_1 : @owned $C, %instance_2 : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance_1 to [init] %addr : $*C
+  br work
+work:
+  %instance_1_loaded = load [copy] %addr : $*C
+  store %instance_2 to [assign] %addr : $*C
+  %instance_2_loaded = load [take] %addr : $*C
+  br exit
+exit:
+  dealloc_stack %addr : $*C
+  destroy_value %instance_2_loaded : $C
+  return %instance_1_loaded : $C
+}
+
+// after_N }}
+
+// deferred_N {{ // scope closure isn't done immediately because it can't be
+
+// Check that an initial store [assign] becomes a scope end.
+// CHECK-LABEL: sil [ossa] @deferred_1 : $@convention(thin) (@owned C, @owned C) -> @owned C {
+// CHECK:       {{bb[^,]+}}([[INSTANCE_1:%[^,]+]] : @owned $C, [[INSTANCE_2:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]] : $C
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]] : $C
+// CHECK:         br [[WORK:bb[0-9]+]]
+// CHECK:       [[WORK]]:
+// CHECK:         destroy_value [[LIFETIME_OWNED_2]] : $C
+// CHECK:         end_borrow [[LIFETIME_2]] : $C
+// CHECK:         destroy_value [[INSTANCE_2]] : $C
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]] : $C
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]] : $C
+// CHECK:         end_borrow [[LIFETIME_1]] : $C
+// CHECK:         destroy_value [[INSTANCE_1]] : $C
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         return [[LIFETIME_OWNED_1]] : $C
+// CHECK-LABEL: } // end sil function 'deferred_1' 
+sil [ossa] @deferred_1 : $@convention(thin) (@owned C,@owned C) -> @owned C {
+entry(%instance_1 : @owned $C, %instance_2 : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance_2 to [init] %addr : $*C
+  br work
+work:
+  store %instance_1 to [assign] %addr : $*C
+  %instance_1_loaded = load [take] %addr : $*C
+  br exit
+exit:
+  dealloc_stack %addr : $*C
+  return %instance_1_loaded : $C
+}
+
+// Ensure that a store [assign] following an initial load [copy] gets a deferred
+// scope end.
+// CHECK-LABEL: sil [ossa] @deferred_2 : $@convention(thin) (@owned C, @owned C) -> @owned C {
+// CHECK:       {{bb[^,]+}}([[INSTANCE_1:%[^,]+]] : @owned $C, [[INSTANCE_2:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]]
+// CHECK:         br [[WORK:bb[0-9]+]]
+// CHECK:       [[WORK]]:
+// CHECK:         [[COPY_2:%[^,]+]] = copy_value [[LIFETIME_OWNED_2]]
+// CHECK:         destroy_value [[COPY_2]]
+// CHECK:         destroy_value [[LIFETIME_OWNED_2]]
+// CHECK:         end_borrow [[LIFETIME_2]]
+// CHECK:         destroy_value [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]]
+// CHECK:         end_borrow [[LIFETIME_1]]
+// CHECK:         destroy_value [[INSTANCE_1]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         return [[LIFETIME_OWNED_1]]
+// CHECK-LABEL: } // end sil function 'deferred_2'
+sil [ossa] @deferred_2 : $@convention(thin) (@owned C,@owned C) -> @owned C {
+entry(%instance_1 : @owned $C, %instance_2 : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance_2 to [init] %addr : $*C
+  br work
+work:
+  %instance_2_loaded = load [copy] %addr : $*C
+  destroy_value %instance_2_loaded : $C
+  store %instance_1 to [assign] %addr : $*C
+  %instance_1_loaded = load [take] %addr : $*C
+  br exit
+exit:
+  dealloc_stack %addr : $*C
+  return %instance_1_loaded : $C
+}
+
+// Ensure that an initial deferred destroy_addr becomes a scope end.
+// CHECK-LABEL: sil [ossa] @deferred_3 : $@convention(thin) (@owned C, @owned C) -> @owned C {
+// CHECK:       {{bb[^,]+}}([[INSTANCE_1:%[^,]+]] : @owned $C, [[INSTANCE_2:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]]
+// CHECK:         br [[WORK:bb[0-9]+]]
+// CHECK:       [[WORK]]:
+// CHECK:         destroy_value [[LIFETIME_OWNED_2]]
+// CHECK:         end_borrow [[LIFETIME_2]]
+// CHECK:         destroy_value [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]]
+// CHECK:         end_borrow [[LIFETIME_1]]
+// CHECK:         destroy_value [[INSTANCE_1]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         return [[LIFETIME_OWNED_1]]
+// CHECK-LABEL: } // end sil function 'deferred_3'
+sil [ossa] @deferred_3 : $@convention(thin) (@owned C,@owned C) -> @owned C {
+entry(%instance_1 : @owned $C, %instance_2 : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance_2 to [init] %addr : $*C
+  br work
+work:
+  destroy_addr %addr : $*C
+  store %instance_1 to [init] %addr : $*C
+  %instance_1_loaded = load [take] %addr : $*C
+  br exit
+exit:
+  dealloc_stack %addr : $*C
+  return %instance_1_loaded : $C
+}
+
+// Ensure thtat a destroy_addr following an initial load [copy] gets a deferred
+// scope end.
+// CHECK-LABEL: sil [ossa] @deferred_4 : $@convention(thin) (@owned C, @owned C) -> @owned C {
+// CHECK:       {{bb[^,]+}}([[INSTANCE_1:%[^,]+]] : @owned $C, [[INSTANCE_2:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]]
+// CHECK:         br [[WORK:bb[0-9]+]]
+// CHECK:       [[WORK]]:
+// CHECK:         [[COPY_2:%[^,]+]] = copy_value [[LIFETIME_OWNED_2]]
+// CHECK:         destroy_value [[COPY_2]]
+// CHECK:         destroy_value [[LIFETIME_OWNED_2]]
+// CHECK:         end_borrow [[LIFETIME_2]]
+// CHECK:         destroy_value [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]]
+// CHECK:         end_borrow [[LIFETIME_1]]
+// CHECK:         destroy_value [[INSTANCE_1]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         return [[LIFETIME_OWNED_1]]
+// CHECK-LABEL: } // end sil function 'deferred_4'
+sil [ossa] @deferred_4 : $@convention(thin) (@owned C,@owned C) -> @owned C {
+entry(%instance_1 : @owned $C, %instance_2 : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance_2 to [init] %addr : $*C
+  br work
+work:
+  %instance_2_loaded = load [copy] %addr : $*C
+  destroy_value %instance_2_loaded : $C
+  destroy_addr %addr : $*C
+  store %instance_1 to [init] %addr : $*C
+  %instance_1_loaded = load [take] %addr : $*C
+  br exit
+exit:
+  dealloc_stack %addr : $*C
+  return %instance_1_loaded : $C
+}
+
+// Ensure that an initial load [take] gets a deferred scope end.
+// CHECK-LABEL: sil [ossa] @deferred_5 : $@convention(thin) (@owned C, @owned C) -> @owned C {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE_1:%[^,]+]] : @owned $C, [[INSTANCE_2:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]]
+// CHECK:         br [[WORK:bb[0-9]+]]
+// CHECK:       [[WORK]]:
+// CHECK:         end_borrow [[LIFETIME_1]]
+// CHECK:         destroy_value [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]]
+// CHECK:         end_borrow [[LIFETIME_2]]
+// CHECK:         destroy_value [[INSTANCE_2]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         destroy_value [[LIFETIME_OWNED_2]]
+// CHECK:         return [[LIFETIME_OWNED_1]]
+// CHECK-LABEL: } // end sil function 'deferred_5'
+sil [ossa] @deferred_5 : $@convention(thin) (@owned C, @owned C) -> @owned C {
+entry(%instance_1 : @owned $C, %instance_2 : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance_1 to [init] %addr : $*C
+  br work
+work:
+  %instance_1_loaded = load [take] %addr : $*C
+  store %instance_2 to [init] %addr : $*C
+  %instance_2_loaded = load [take] %addr : $*C
+  br exit
+exit:
+  dealloc_stack %addr : $*C
+  destroy_value %instance_2_loaded : $C
+  return %instance_1_loaded : $C
+}
+
+// Ensure that a load [take] following an initial load [copy] gets a deferred
+// scope end.
+// CHECK-LABEL: sil [ossa] @deferred_6 : $@convention(thin) (@owned C) -> @owned C {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         br [[WORK:bb[0-9]+]]
+// CHECK:       [[WORK]]:
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[LIFETIME_OWNED]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         return [[LIFETIME_OWNED]]
+// CHECK-LABEL: } // end sil function 'deferred_6'
+sil [ossa] @deferred_6 : $@convention(thin) (@owned C) -> @owned C {
+entry(%instance_1 : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance_1 to [init] %addr : $*C
+  br work
+work:
+  %temporary = load [copy] %addr : $*C
+  %instance_1_loaded = load [take] %addr : $*C
+  br exit
+exit:
+  dealloc_stack %addr : $*C
+  destroy_value %temporary : $C
+  return %instance_1_loaded : $C
+}
+
+// CHECK-LABEL: sil [ossa] @deferred_7 : $@convention(thin) (@owned C, @owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE_1:%[^,]+]] : @owned $C, [[INSTANCE_2:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]]
+// CHECK:         br [[WORK:bb[0-9]+]]
+// CHECK:       [[WORK]]:
+// CHECK:         [[COPY_1:%[^,]+]] = copy_value [[LIFETIME_OWNED_1]]
+// CHECK:         destroy_value [[COPY_1]]
+// CHECK:         destroy_value [[LIFETIME_OWNED_1]]
+// CHECK:         end_borrow [[LIFETIME_1]]
+// CHECK:         destroy_value [[INSTANCE_2]]
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]]
+// CHECK:         end_borrow [[LIFETIME_2]]
+// CHECK:         destroy_value [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_3:%[^,]+]] = begin_borrow [lexical] [[LIFETIME_OWNED_2]]
+// CHECK:         [[LIFETIME_OWNED_3:%[^,]+]] = copy_value [[LIFETIME_3]]
+// CHECK:         destroy_value [[LIFETIME_OWNED_3]]
+// CHECK:         end_borrow [[LIFETIME_3]]
+// CHECK:         destroy_value [[LIFETIME_OWNED_2]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'deferred_7'
+sil [ossa] @deferred_7 : $@convention(thin) (@owned C,@owned C) -> () {
+entry(%instance_1 : @owned $C, %instance_2 : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance_2 to [init] %addr : $*C
+  br work
+work:
+  %instance_2_loaded = load [copy] %addr : $*C
+  destroy_value %instance_2_loaded : $C
+  store %instance_1 to [assign] %addr : $*C
+  %instance_1_loaded = load [take] %addr : $*C
+  store %instance_1_loaded to [init] %addr : $*C
+  destroy_addr %addr : $*C  
+  br exit
+exit:
+  dealloc_stack %addr : $*C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// deferred_N }}
+
+// term_N {{ the last use of the stored value is a terminator
+
+// CHECK-LABEL: sil [ossa] @term_1 : $@convention(thin) (@owned C) -> @owned C {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[RETVAL:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'term_1'
+sil [ossa] @term_1 : $@convention(thin) (@owned C) -> @owned C {
+entry(%instance : @owned $C):
+    %addr = alloc_stack [lexical] $C
+    store %instance to [init] %addr : $*C
+    %result = load [take] %addr : $*C
+    dealloc_stack %addr : $*C
+    return %result : $C
+}
+
+// CHECK-LABEL: sil [ossa] @term_2 : $@convention(thin) (@owned C) -> @owned C {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         br [[EXIT:bb[^,]+]]([[LIFETIME_OWNED_1]] : $C)
+// CHECK:       [[EXIT]]([[OUTSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         return [[OUTSTANCE]]
+// CHECK-LABEL: } // end sil function 'term_2'
+sil [ossa] @term_2 : $@convention(thin) (@owned C) -> @owned C {
+entry(%instance : @owned $C):
+    %addr = alloc_stack [lexical] $C
+    store %instance to [init] %addr : $*C
+    %result = load [take] %addr : $*C
+    br exit(%result : $C)
+exit(%outstance : @owned $C):
+    dealloc_stack %addr : $*C
+    return %outstance : $C
+}
+
+// CHECK-LABEL: sil [ossa] @term_3 : $@convention(thin) (@owned E) -> @owned C {
+// CHECK:       {{bb[^,]+}}([[EITHER:%[^,]+]] : @owned $E):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[EITHER]] : $E
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]] : $E
+// CHECK:         end_borrow [[LIFETIME]] : $E
+// CHECK:         destroy_value [[EITHER]] : $E
+// CHECK:         switch_enum [[LIFETIME_OWNED]] : $E, case #E.one!enumelt: [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         return [[INSTANCE]] : $C
+// CHECK-LABEL: } // end sil function 'term_3'
+sil [ossa] @term_3 : $@convention(thin) (@owned E) -> @owned C {
+entry(%either : @owned $E):
+    %addr = alloc_stack [lexical] $E
+    store %either to [init] %addr : $*E
+    %either2 = load [take] %addr : $*E
+    switch_enum %either2 : $E, case #E.one!enumelt: one
+one(%instance : @owned $C):
+    dealloc_stack %addr : $*E
+    return %instance : $C
+}
+
+// CHECK-LABEL: sil [ossa] @term_4 : $@convention(thin) (@owned C, @owned D) -> @owned D {
+// CHECK:       {{bb[^,]+}}([[SUPER_IN:%[^,]+]] : @owned $C, [[SUB_IN:%[^,]+]] : @owned $D):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[SUPER_IN]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[SUPER_IN]]
+// CHECK:         checked_cast_br [[LIFETIME_OWNED]] : $C to D, [[SUPER_IS_SUB:bb[^,]+]], [[SUPER_IS_SUPER:bb[0-9]+]]
+// CHECK:       [[SUPER_IS_SUB]]([[SUPER_AS_SUB:%[^,]+]] : @owned $D):
+// CHECK:         destroy_value [[SUB_IN]]
+// CHECK:         br [[EXIT:bb[^,]+]]([[SUPER_AS_SUB]] : $D)
+// CHECK:       [[SUPER_IS_SUPER]]([[SUPER_AS_SUPER:%[^,]+]] : @owned $C):
+// CHECK:         destroy_value [[SUPER_AS_SUPER]]
+// CHECK:         br [[EXIT]]([[SUB_IN]] : $D)
+// CHECK:       [[EXIT]]([[SUB_OUT:%[^,]+]] : @owned $D):
+// CHECK:         return [[SUB_OUT]]
+// CHECK-LABEL: } // end sil function 'term_4'
+sil [ossa] @term_4 : $@convention(thin) (@owned C, @owned D) -> @owned D {
+bb0(%super_in : @owned $C, %sub_in : @owned $D):
+    %addr = alloc_stack [lexical] $C
+    store %super_in to [init] %addr : $*C
+    %super_load = load [take] %addr : $*C
+    checked_cast_br %super_load : $C to D, super_is_sub, super_is_super
+super_is_sub(%super_as_sub : @owned $D):
+    destroy_value %sub_in : $D
+    br exit(%super_as_sub : $D)
+super_is_super(%super_as_super : @owned $C):
+    destroy_value %super_as_super : $C
+    br exit(%sub_in : $D)
+exit(%sub_out : @owned $D):
+    dealloc_stack %addr : $*C
+    return %sub_out : $D
+}
+
+// CHECK-LABEL: sil hidden [ossa] @term_5 : $@convention(thin) (@owned C) -> @error Error {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         [[CALLEE_ERROR_OWNED:%[^,]+]] = function_ref @callee_error_owned
+// CHECK:         try_apply [[CALLEE_ERROR_OWNED]]([[LIFETIME_OWNED]]) : $@convention(thin) (@owned C) -> @error Error, normal [[REGULAR_BLOCK:bb[^,]+]], error [[THROW_BLOCK:bb[0-9]+]]
+// CHECK:       [[REGULAR_BLOCK]]({{%[^,]+}} : $()):
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[THROW_BLOCK]]([[ERROR:%[^,]+]] : @owned $Error):
+// CHECK:         destroy_value [[ERROR]]
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'term_5' 
+sil hidden [ossa] @term_5 : $@convention(thin) (@owned C) -> @error Error {
+bb0(%instance : @owned $C):
+    %addr = alloc_stack [lexical] $C
+    store %instance to [init] %addr : $*C
+    %instance_load = load [take] %addr : $*C
+    %callee_error_owned = function_ref @callee_error_owned : $@convention(thin) (@owned C) -> @error Error
+    try_apply %callee_error_owned(%instance_load) : $@convention(thin) (@owned C) -> @error Error, normal regular_block, error throw_block
+regular_block(%7 : $()):
+    br exit
+throw_block(%error : @owned $Error):
+    destroy_value %error : $Error
+    br exit
+exit:
+    dealloc_stack %addr : $*C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @term_6 : $@yield_once @convention(method) (@owned C) -> @yields C {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] 
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]] 
+// CHECK:         end_borrow [[LIFETIME]] 
+// CHECK:         destroy_value [[INSTANCE]] 
+// CHECK:         yield [[LIFETIME_OWNED]] : $C, resume [[RESUME_BLOCK:bb[^,]+]], unwind [[UNWIND_BLOCK:bb[0-9]+]]
+// CHECK:       [[RESUME_BLOCK]]:
+// CHECK:         destroy_value [[LIFETIME_OWNED]] 
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]] 
+// CHECK:       [[UNWIND_BLOCK]]:
+// CHECK:         destroy_value [[LIFETIME_OWNED]] 
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function 'term_6'
+sil [ossa] @term_6 : $@yield_once @convention(method) (@owned C) -> @yields C {
+entry(%instance : @owned $C):
+    %addr = alloc_stack [lexical] $C
+    store %instance to [init] %addr : $*C
+    %instance_load = load [take] %addr : $*C
+    yield %instance_load : $C, resume resume_block, unwind unwind_block
+resume_block:
+    destroy_value %instance_load : $C
+    dealloc_stack %addr : $*C
+    %result = tuple ()
+    return %result : $()
+unwind_block:
+    destroy_value %instance_load : $C
+    dealloc_stack %addr : $*C
+    unwind
+}
+
+// CHECK-LABEL: sil [ossa] @term_7 : $@convention(thin) (@owned C) -> @error C {
+// CHECK:       bb0([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] 
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]] 
+// CHECK:         end_borrow [[LIFETIME]] 
+// CHECK:         destroy_value [[INSTANCE]] 
+// CHECK:         cond_br undef, [[THROW_BLOCK:bb[^,]+]], [[REGULAR_BLOCK:bb[0-9]+]]
+// CHECK:       [[THROW_BLOCK]]:
+// CHECK:         throw [[LIFETIME_OWNED]] 
+// CHECK:       [[REGULAR_BLOCK]]:
+// CHECK:         destroy_value [[LIFETIME_OWNED]] 
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]] 
+// CHECK-LABEL: } // end sil function 'term_7'
+sil [ossa] @term_7 : $@convention(thin) (@owned C) -> @error C {
+bb0(%instance : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance to [init] %addr : $*C
+  %instance_load = load [take] %addr : $*C
+  cond_br undef, bb1, bb2
+bb1:
+  dealloc_stack %addr : $*C
+  throw %instance_load : $C
+bb2:
+  destroy_value %instance_load : $C
+  dealloc_stack %addr : $*C
+  %18 = tuple ()
+  return %18 : $()
+}
+
+// term_N }}
+
+// unreachable_N {{ ending of scopes in blocks that terminate in unreachable
+
+// CHECK-LABEL: sil [ossa] @unreachable_1 : $@convention(thin) (@owned C, @owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE_1:%[^,]+]] : @owned $C, [[INSTANCE_2:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]]
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]]
+// CHECK:         br [[DIE:bb[0-9]+]]
+// CHECK:       [[DIE]]:
+// CHECK:         end_borrow [[LIFETIME_1]]
+// CHECK:         destroy_value [[INSTANCE_1]]
+// CHECK:         destroy_value [[LIFETIME_OWNED_1]]
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_2]]
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[LIFETIME_2]]
+// CHECK:         end_borrow [[LIFETIME_2]]
+// CHECK:         destroy_value [[INSTANCE_2]]
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'unreachable_1'
+sil [ossa] @unreachable_1 : $@convention(thin) (@owned C, @owned C) -> () {
+entry(%one : @owned $C, %two : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %one to [init] %addr : $*C
+  br work
+work:
+  %one_loaded = load [take] %addr : $*C
+  destroy_value %one_loaded : $C
+  store %two to [init] %addr : $*C
+  unreachable
+}
+
+// CHECK-LABEL: sil [ossa] @unreachable_4 : $@convention(thin) (@owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME_1:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] : $C
+// CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = copy_value [[LIFETIME_1]] : $C
+// CHECK:         end_borrow [[LIFETIME_1]] : $C
+// CHECK:         destroy_value [[INSTANCE]] : $C
+// CHECK:         [[LIFETIME_2:%[^,]+]] = begin_borrow [lexical] [[LIFETIME_OWNED_1]] : $C
+// CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]] : $C
+// CHECK:         end_borrow [[LIFETIME_2]] : $C
+// CHECK:         destroy_value [[LIFETIME_OWNED_1]] : $C
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'unreachable_4'
+sil [ossa] @unreachable_4 : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  store %instance to [init] %addr : $*C
+  %instance_loaded = load [take] %addr : $*C
+  store %instance_loaded to [init] %addr : $*C
+  unreachable
+}
+
+// }} unreachable_N
 
 // diamond_N {{ the usages of the alloc_stack occur over a diamond of blocks
 
@@ -620,11 +1532,11 @@ entry(%instance : @owned $C):
 // CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = copy_value [[LIFETIME_2]]
 // CHECK:         br [[EXIT]]([[INSTANCE_2]] : $C, [[LIFETIME_2]] : $C, [[LIFETIME_OWNED_2]] : $C)
 // CHECK:       [[EXIT]]([[INSTANCE:%[^,]+]] : @owned $C, [[LIFETIME:%[^,]+]] : @guaranteed $C, [[LIFETIME_OWNED:%[^,]+]] : @owned $C):
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
 // CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
 // CHECK:         {{%[^,]+}} = apply [[CALLEE_GUARANTEED]]([[LIFETIME_OWNED]])
 // CHECK:         destroy_value [[LIFETIME_OWNED]]
-// CHECK:         end_borrow [[LIFETIME]]
-// CHECK:         destroy_value [[INSTANCE]]
 // CHECK:         [[RESULT:%[^,]+]] = tuple ()
 // CHECK:         return [[RESULT]] : $()
 // CHECK-LABEL: } // end sil function 'diamond_1'
@@ -663,11 +1575,11 @@ exit:
 // CHECK:         destroy_value [[INSTANCE_0]]
 // CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE_1]]
 // CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE_1]]
 // CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
 // CHECK:         {{%[^,]+}} = apply [[CALLEE_GUARANTEED]]([[LIFETIME_OWNED]])
 // CHECK:         destroy_value [[LIFETIME_OWNED]]
-// CHECK:         end_borrow [[LIFETIME]]
-// CHECK:         destroy_value [[INSTANCE_1]]
 // CHECK:         br [[EXIT]]
 // CHECK:       [[EXIT]]:
 // CHECK:         [[RETVAL:%[^,]+]] = tuple ()
@@ -829,14 +1741,14 @@ exit:
 // CHECK:       {{bb[^,]+}}([[ORIGINAL:%[^,]+]] : @owned $C):
 // CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[ORIGINAL]]
 // CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
-// CHECK:         cond_br undef, [[BASIC_BLOCK1:bb[^,]+]], [[BASIC_BLOCK2:bb[0-9]+]]
-// CHECK:       [[BASIC_BLOCK1]]:
-// CHECK:         br [[BASIC_BLOCK3:bb[0-9]+]]
-// CHECK:       [[BASIC_BLOCK2]]:
+// CHECK:         cond_br undef, [[THROW_BLOCK:bb[^,]+]], [[REGULAR_BLOCK:bb[0-9]+]]
+// CHECK:       [[THROW_BLOCK]]:
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[REGULAR_BLOCK]]:
 // CHECK:         end_borrow [[LIFETIME]]
 // CHECK:         destroy_value [[ORIGINAL]]
 // CHECK:         unreachable
-// CHECK:       [[BASIC_BLOCK3:bb[^,]+]]:
+// CHECK:       [[EXIT:bb[^,]+]]:
 // CHECK:         destroy_value [[LIFETIME_OWNED]]
 // CHECK:         end_borrow [[LIFETIME]]
 // CHECK:         destroy_value [[ORIGINAL]]
@@ -857,6 +1769,119 @@ exit:
     dealloc_stack %addr : $*C
     %result = tuple ()
     return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @diamond_7 : $@convention(thin) (@owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[LIFETIME_OWNED]]
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         apply [[CALLEE_GUARANTEED]]([[COPY]])
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         destroy_value [[LIFETIME_OWNED]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         unreachable
+// CHECK:       [[RIGHT]]:
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'diamond_7' 
+sil [ossa] @diamond_7 : $@convention(thin) (@owned C) -> () {
+entry(%one : @owned $C):
+    %addr = alloc_stack [lexical] $C
+    store %one  to [init] %addr : $*C
+    %value2 = load [copy] %addr : $*C
+    %callee2 = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %_2 = apply %callee2(%value2) : $@convention(thin) (@guaranteed C) -> ()
+    destroy_value %value2 : $C
+    destroy_addr %addr : $*C
+    cond_br undef, left, right
+left:
+    unreachable
+right:
+    dealloc_stack %addr : $*C
+    %result = tuple ()
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @diamond_8 : $@convention(thin) (@owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[LIFETIME_OWNED]]
+// CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
+// CHECK:         apply [[CALLEE_GUARANTEED]]([[COPY]])
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         cond_br undef, [[DIE:bb[0-9]+]], [[EXIT:bb[0-9]+]]
+// CHECK:       [[DIE]]:
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         unreachable
+// CHECK:       [[EXIT]]:
+// CHECK:         destroy_value [[LIFETIME_OWNED]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         [[RETVAL:%[^,]+]] = tuple ()
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'diamond_8'
+sil [ossa] @diamond_8 : $@convention(thin) (@owned C) -> () {
+entry(%one : @owned $C):
+    %addr = alloc_stack [lexical] $C
+    store %one  to [init] %addr : $*C
+    %value2 = load [copy] %addr : $*C
+    %callee2 = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+    %_2 = apply %callee2(%value2) : $@convention(thin) (@guaranteed C) -> ()
+    destroy_value %value2 : $C
+    cond_br undef, left, right
+left:
+    unreachable
+right:
+    destroy_addr %addr : $*C
+    dealloc_stack %addr : $*C
+    %result = tuple ()
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @diamond_9 : $@convention(thin) (@owned C) -> () {
+// CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         cond_br undef, [[BB1:bb[0-9]+]], [[BB4:bb[0-9]+]]
+// CHECK:       [[BB1]]:
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         cond_br undef, [[BB2:bb[0-9]+]], [[BB3:bb[0-9]+]]
+// CHECK:       [[BB2]]:
+// CHECK:         destroy_value [[LIFETIME_OWNED]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         br [[BB5:bb[0-9]+]]
+// CHECK:       [[BB3]]:
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         br [[BB5]]
+// CHECK:       [[BB4]]:
+// CHECK:         br [[BB5]]
+// CHECK:       [[BB5]]:
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'diamond_9'
+sil [ossa] @diamond_9 : $@convention(thin) (@owned C) -> () {
+bb0(%instance : @owned $C):
+  %addr = alloc_stack [lexical] $C
+  cond_br undef, bb1, bb4
+bb1:
+  store %instance to [init] %addr : $*C
+  cond_br undef, bb2, bb3
+bb2:
+  destroy_addr %addr : $*C
+  br bb5
+bb3:
+  br bb5
+bb4:
+  br bb5
+bb5:
+  unreachable
 }
 
 // diamond_N }}

--- a/test/SILOptimizer/mem2reg_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_lifetime.sil
@@ -522,6 +522,7 @@ class C {}
 sil [ossa] @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
 sil [ossa] @callee_owned : $@convention(thin) (@owned C) -> ()
 
+// basic_N {{ functions consisting of a single block
 
 // An owned instance of C is passed in, stored to the stack, used
 // non-consumingly once, and destroyed.
@@ -601,6 +602,9 @@ entry(%instance : @owned $C):
     return %res : $()
 }
 
+// basic_N }}
+
+// diamond_N {{ the usages of the alloc_stack occur over a diamond of blocks
 
 // CHECK-LABEL: sil [ossa] @diamond_1 : $@convention(thin) (@owned C, @owned C) -> () {
 // CHECK:       {{bb[^,]+}}([[INSTANCE_1:%[^,]+]] : @owned $C, [[INSTANCE_2:%[^,]+]] : @owned $C):
@@ -854,6 +858,8 @@ exit:
     %result = tuple ()
     return %result : $()
 }
+
+// diamond_N }}
 
 // =============================================================================
 // lexical scope specific                                                     }}

--- a/test/SILOptimizer/mem2reg_lifetime_nontrivial_casts.sil
+++ b/test/SILOptimizer/mem2reg_lifetime_nontrivial_casts.sil
@@ -1,0 +1,97 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-experimental-lexical-lifetimes %s -mem2reg | %FileCheck %s
+
+import Builtin
+import Swift
+
+// We cannot use unchecked_value_cast for conversions to trivial type.
+// Since it is forwarding, the ownersip of the src forwards, but we cannot destroy the dst because it is trivial
+
+// CHECK-LABEL: sil [ossa] @casttotrivial :
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] %0
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         [[CAST:%.*]]  = unchecked_bitwise_cast [[LIFETIME_OWNED]] : $AnyObject to $UInt8
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value %0
+// CHECK-NEXT:    destroy_value [[LIFETIME_OWNED]]
+// CHECK-NEXT:    return [[CAST]]
+// CHECK-LABEL: } // end sil function 'casttotrivial'
+sil [ossa] @casttotrivial : $@convention(thin) (@owned AnyObject) -> @owned UInt8 {
+bb0(%0 : @owned $AnyObject):
+  %1 = alloc_stack [lexical] $AnyObject
+  store %0 to [init] %1 : $*AnyObject
+  %2 = unchecked_addr_cast %1 : $*AnyObject to $*UInt8
+  %3 = load [trivial] %2 : $*UInt8
+  %4 = load [take] %1 : $*AnyObject
+  destroy_value %4 : $AnyObject
+  dealloc_stack %1 : $*AnyObject
+  return %3 : $UInt8
+}
+
+// We cannot use unchecked_value_cast, because it is forwarding, it forwards the src, and the src can no longer be used as a RunningVal
+// To get rid of this issue we need to use a copy_value of the src, and make sure we don't generate copy_value in case of a load [copy].
+// To avoid all this spl handling, just use bitwise cast
+
+// CHECK-LABEL: sil [ossa] @casttonontrivial :
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] %0
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         [[CAST:%.*]] = unchecked_bitwise_cast [[LIFETIME_OWNED]] : $AnyObject to $String
+// CHECK:         [[COPY:%.*]] = copy_value [[CAST]]
+// CHECK-NEXT:    end_borrow [[LIFETIME]]
+// CHECK-NEXT:    destroy_value %0
+// CHECK-NEXT:    destroy_value [[LIFETIME_OWNED]]
+// CHECK-NEXT:    return [[COPY]]
+// CHECK-LABEL: } // end sil function 'casttonontrivial'
+sil [ossa] @casttonontrivial : $@convention(thin) (@owned AnyObject) -> @owned String {
+bb0(%0 : @owned $AnyObject):
+  %1 = alloc_stack [lexical] $AnyObject
+  store %0 to [init] %1 : $*AnyObject
+  %2 = unchecked_addr_cast %1 : $*AnyObject to $*String
+  %3 = load [copy] %2 : $*String
+  %4 = load [take] %1 : $*AnyObject
+  destroy_value %4 : $AnyObject
+  dealloc_stack %1 : $*AnyObject
+  return %3 : $String
+}
+
+struct Pair { var lhs: AnyObject; var rhs: AnyObject }
+
+// CHECK-LABEL: sil [ossa] @shorteningcast :
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] %0
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         [[CAST:%.*]] = unchecked_bitwise_cast [[LIFETIME_OWNED]] : $Pair to $AnyObject
+// CHECK:         [[COPY:%.*]] = copy_value [[CAST]]
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value %0
+// CHECK-NEXT:    destroy_value [[LIFETIME_OWNED]]
+// CHECK-NEXT:    return [[COPY]]
+// CHECK-LABEL: } // end sil function 'shorteningcast'
+sil [ossa] @shorteningcast : $@convention(thin) (@owned Pair) -> @owned AnyObject {
+bb0(%0 : @owned $Pair):
+  %1 = alloc_stack [lexical] $Pair
+  store %0 to [init] %1 : $*Pair
+  %2 = unchecked_addr_cast %1 : $*Pair to $*AnyObject
+  %3 = load [copy] %2 : $*AnyObject
+  %4 = load [take] %1 : $*Pair
+  destroy_value %4 : $Pair
+  dealloc_stack %1 : $*Pair
+  return %3 : $AnyObject
+}
+
+// CHECK-LABEL: sil [ossa] @deadcast :
+// CHECK-LABEL: bb0
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] %0
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK-NEXT:    destroy_value [[LIFETIME_OWNED]]
+// CHECK-NEXT:    end_borrow [[LIFETIME]]
+// CHECK-NEXT:    destroy_value %0
+// CHECK-LABEL: } // end sil function 'deadcast'
+sil [ossa] @deadcast : $@convention(thin) (@owned AnyObject) -> () {
+bb0(%0 : @owned $AnyObject):
+  %1 = alloc_stack [lexical] $AnyObject
+  store %0 to [init] %1 : $*AnyObject
+  %2 = unchecked_addr_cast %1 : $*AnyObject to $*String
+  destroy_addr %1 : $*AnyObject
+  dealloc_stack %1 : $*AnyObject
+  %4 = tuple()
+  return %4 : $()
+}

--- a/test/SILOptimizer/mem2reg_liveness_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_liveness_lifetime.sil
@@ -1,0 +1,57 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-experimental-lexical-lifetimes %s -mem2reg | %FileCheck %s
+
+import Builtin
+import Swift
+
+class C {}
+
+sil [ossa] @_Ts5printFT3valSi_T_ : $@convention(thin) (@guaranteed C) -> ()
+
+// CHECK-LABEL: sil [ossa] @liveness0 :
+// CHECK-NOT: alloc_stack
+sil [ossa] @liveness0 : $@convention(thin) (@owned C, @owned C, @owned C, @owned C) -> () {
+bb0(%instance_1 : @owned $C, %instance_2 : @owned $C, %instance_3 : @owned $C, %instance_4 : @owned $C):
+  %addr_x = alloc_stack [lexical] $C
+  store %instance_1 to [init] %addr_x : $*C
+  cond_br undef, bb1, bb5
+
+bb1:
+  %addr_y = alloc_stack [lexical] $C
+  store %instance_2 to [init] %addr_y : $*C
+  cond_br undef, bb2, bb3
+
+bb2:
+  destroy_value %instance_4 : $C
+  store %instance_3 to [assign] %addr_y : $*C
+  br bb4
+
+bb3:
+  destroy_value %instance_3 : $C
+  store %instance_4 to [assign] %addr_y : $*C
+  br bb4
+
+bb4:
+  // function_ref
+  %print = function_ref @_Ts5printFT3valSi_T_ : $@convention(thin) (@guaranteed C) -> ()
+  %26 = load [take] %addr_y : $*C
+  %36 = apply %print(%26) : $@convention(thin) (@guaranteed C) -> ()
+  destroy_value %26 : $C
+  dealloc_stack %addr_y : $*C
+  br bb6
+
+bb5:
+  destroy_value %instance_2 : $C
+  destroy_value %instance_3 : $C
+  destroy_value %instance_4 : $C
+  br bb6
+
+// We don't need a PHI node here because the value is dead!
+// CHECK: bb5:
+bb6:
+  destroy_addr %addr_x : $*C
+  dealloc_stack %addr_x : $*C
+  %40 = tuple ()
+  return %40 : $()
+}
+// CHECK-LABEL: } // end sil function 'liveness0'
+

--- a/test/SILOptimizer/mem2reg_resilient_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_resilient_lifetime.sil
@@ -1,0 +1,32 @@
+
+// RUN: %target-sil-opt -enable-sil-verify-all -enable-experimental-lexical-lifetimes %s -mem2reg -enable-library-evolution | %FileCheck %s
+
+import Builtin
+import Swift
+
+public struct ResilientStruct {
+    var x: AnyObject
+}
+
+// CHECK-LABEL: sil [ossa] @mem2reg_debug_value :
+// CHECK:       {{bb[^,]+}}([[REGISTER_0:%[^,]+]] : $*ResilientStruct):
+// CHECK-NEXT:    [[REGISTER_1:%[^,]+]] = load [copy] [[REGISTER_0]]
+// CHECK-NEXT:    [[REGISTER_2:%[^,]+]] = begin_borrow [lexical] [[REGISTER_1]]
+// CHECK-NEXT:    [[REGISTER_3:%[^,]+]] = copy_value [[REGISTER_2]]
+// CHECK-NEXT:    debug_value [[REGISTER_3]]
+// CHECK-NEXT:    end_borrow [[REGISTER_2]]
+// CHECK-NEXT:    destroy_value [[REGISTER_1]]
+// CHECK-NEXT:    destroy_value [[REGISTER_3]]
+// CHECK-LABEL: } // end sil function 'mem2reg_debug_value'
+sil [ossa] @mem2reg_debug_value : $@convention(thin) (@in_guaranteed ResilientStruct) -> () {
+bb0(%0 : $*ResilientStruct):
+  %1 = alloc_stack [lexical] $ResilientStruct
+  %2 = load [copy] %0 : $*ResilientStruct
+  store %2 to [init] %1 : $*ResilientStruct
+  debug_value %1 : $*ResilientStruct, expr op_deref
+  %3 = load [take] %1 : $*ResilientStruct
+  destroy_value %3 : $ResilientStruct
+  dealloc_stack %1 : $*ResilientStruct
+  %4 = tuple ()
+  return %4 : $()
+}


### PR DESCRIPTION
Previously, the lexical borrow scopes that were introduced to replace lexical stack allocations were tied to the uses of the stored value.  That meant that the borrow scope could be both too long and also too short.  It could be too long if there were uses of the value after the dealloc stack and it would be too short if there were not uses of the value while the value was still stored into the stack allocation.

Here, instead, the lexical borrow scopes are tied to the storage of a value into the stack allocation.  A value's lexical borrow scope begins when the storage is initialied with the value; its lexical borrow scope ends when the storage is deinitialized.  That corresponds to the range during which a var in the Swift source has a particular value assigned to it.

Mem2Reg's implementation is split into a few steps:
(1) visiting the instructions in a basic block which contains all uses of an alloc_stack
(2.a) visiting the instructions in each basic block which contains a use of the alloc_stack
(2.b) adding phis
(2.c) using the last stored values as arguments to the new outgoing phi arguments
(2.c) replacing initial uses of the storage with the new incoming phi arguments
And here, (1) amounts to a special case of (2.a).

During (1) and (2.a):
(a) lexical borrow scopes are begun after store instructions for the values that were stored
(b) when possible, lexical borrow scopes are ended before instructions that deinitialize memory
    - destroy_addr
    - store [assign]
    - load [take]
For (1), that is enough to create valid borrow scopes.

For (2), there are two complications:
(a) Borrow scopes that are begun may not be ended (when visiting a single block's instructions).

    For example, when visiting

    ```
    bb1:
      store %instance to [init] %addr
      br bb2
    ```

    a borrow scope is started after the store but cannot be ended.

(b) There may not be enough information available to end borrow scopes when visiting instructions that would typically introduce borrow scopes.

    For example, when visiting

    ```
    bb2:
      %copy = load [copy] %addr
      %instance = load [take] %addr
      br bb3
    ```

    there is not enough information available to end the borrow scope that should be ended before the `load [take]`.

To resolve these issues, both sorts of instructions are tracked.  For (a), in `StackAllocationPromoter::unendedLexicalLifetimes`.  For (b), in `StackAllocationPromoter::unprecedentedDeinitializations`.  Finally, a new step is added:

(2.d) `StackAllocationPromoter::endLexicalLifetimes` does a forward CFG walk starting from the out-edge of each of the blocks which began but did not end lexical lifetimes.  At an out-edge, we do a check regarding unreachables is done, and we may end the borrow scope.  Otherwise, the walk continues to the in-edge of each successor.  At an in-edge, we look for an instruction from (b) (in `unprecedentedDeinitializations`) above.  If one is found, then we end the borrow scope before that instruction.  Otherwise, the walk continues to the out-edge of the block.