### PR TITLE
Distributed actor isolation

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -113,14 +113,6 @@ library), instead of at an arbitrary point in time.
 For more details, see the forum post on
 [dynamic method replacement](https://forums.swift.org/t/dynamic-method-replacement/16619).
 
-## `@_distributedActorIndependent`
-
-Marks a specific property of a distributed actor to be available even if the
-actor is remote.
-
-This only applies to two distributed actor properties `address` and `transport`.
-It cannot be safely declared on any properties defined by ordinary Swift code.
-
 ## `@_effects(effectname)`
 
 Tells the compiler that the implementation of the defined function is limited

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -658,7 +658,7 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(distributed, DistributedActor,
   APIBreakingToAdd | APIBreakingToRemove,
   118)
 
-// 110 is unused
+// 119 is unused
 
 SIMPLE_DECL_ATTR(_assemblyVision, EmitAssemblyVisionRemarks,
   OnFunc | UserInaccessible | NotSerialized | OnNominalType |

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -658,12 +658,7 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(distributed, DistributedActor,
   APIBreakingToAdd | APIBreakingToRemove,
   118)
 
-SIMPLE_DECL_ATTR(_distributedActorIndependent, DistributedActorIndependent,
-  OnFunc | OnVar |
-  DistributedOnly | UserInaccessible |
-  ABIStableToAdd | ABIStableToRemove |
-  APIBreakingToAdd | APIBreakingToRemove,
-  119)
+// 110 is unused
 
 SIMPLE_DECL_ATTR(_assemblyVision, EmitAssemblyVisionRemarks,
   OnFunc | UserInaccessible | NotSerialized | OnNominalType |

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2391,8 +2391,6 @@ public:
   /// Is this declaration marked with 'dynamic'?
   bool isDynamic() const;
 
-  bool isDistributedActorIndependent() const;
-
 private:
   bool isObjCDynamic() const {
     return isObjC() && isDynamic();
@@ -4789,8 +4787,6 @@ public:
   bool hasDidSetOrWillSetDynamicReplacement() const;
 
   bool hasAnyNativeDynamicAccessors() const;
-
-  bool isDistributedActorIndependent() const;
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) {

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4616,9 +4616,6 @@ ERROR(distributed_actor_user_defined_special_property,none,
       "property %0 cannot be defined explicitly, as it conflicts with "
       "distributed actor synthesized stored property",
       (DeclName))
-ERROR(distributed_actor_independent_property_must_be_let,none,
-      "_distributedActorIndependent can be applied to properties, however they must be 'let'",
-      ())
 NOTE(distributed_actor_isolated_property,none,
       "distributed actor state is only available within the actor instance", // TODO: reword in terms of isolation
       ())

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4338,6 +4338,7 @@ protected:
     Bits.ApplyExpr.ImplicitlyAsync = false;
     Bits.ApplyExpr.ImplicitlyThrows = false;
     Bits.ApplyExpr.NoAsync = false;
+    Bits.ApplyExpr.ShouldApplyDistributedThunk = false;
   }
 
 public:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2934,10 +2934,6 @@ bool ValueDecl::isDynamic() const {
     getAttrs().hasAttribute<DynamicAttr>());
 }
 
-bool ValueDecl::isDistributedActorIndependent() const {
-  return getAttrs().hasAttribute<DistributedActorIndependentAttr>();
-}
-
 bool ValueDecl::isObjCDynamicInGenericClass() const {
   if (!isObjCDynamic())
     return false;
@@ -5369,10 +5365,6 @@ bool AbstractStorageDecl::hasAnyNativeDynamicAccessors() const {
       return true;
   }
   return false;
-}
-
-bool AbstractStorageDecl::isDistributedActorIndependent() const {
-  return getAttrs().hasAttribute<DistributedActorIndependentAttr>();
 }
 
 void AbstractStorageDecl::setAccessors(SourceLoc lbraceLoc,

--- a/lib/SILGen/SILGenDistributed.cpp
+++ b/lib/SILGen/SILGenDistributed.cpp
@@ -817,7 +817,7 @@ void SILGenFunction::emitDistributedActorClassMemberDestruction(
     B.emitBlock(remoteMemberDestroyBB);
 
     for (VarDecl *vd : cd->getStoredProperties()) {
-      if (!vd->getAttrs().hasAttribute<DistributedActorIndependentAttr>())
+      if (getActorIsolation(vd) == ActorIsolation::DistributedActorInstance)
         continue;
 
       destroyClassMember(cleanupLoc, selfValue, vd);

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -172,9 +172,8 @@ AbstractFunctionDecl *TypeChecker::addImplicitDistributedActorRemoteFunction(
   remoteFuncDecl->getAttrs().add(
       new (C) DynamicAttr(/*implicit=*/true));
 
-  // @_distributedActorIndependent
-  remoteFuncDecl->getAttrs().add(
-      new (C) DistributedActorIndependentAttr(/*IsImplicit=*/true));
+  // nonisolated
+  remoteFuncDecl->getAttrs().add(new (C) NonisolatedAttr(/*IsImplicit=*/true));
 
   // users should never have to access this function directly;
   // it is only invoked from our distributed function thunk if the actor is remote.

--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -105,7 +105,7 @@ static ValueDecl *deriveDistributedActor_id(DerivedConformance &derived) {
   auto &C = derived.Context;
 
   // ```
-  // @_distributedActorIndependent
+  // nonisolated
   // let id: AnyActorIdentity
   // ```
   auto propertyType = C.getAnyActorIdentityDecl()->getDeclaredInterfaceType();
@@ -133,7 +133,7 @@ static ValueDecl *deriveDistributedActor_actorTransport(
   auto &C = derived.Context;
 
   // ```
-  // @_distributedActorIndependent
+  // nonisolated
   // let actorTransport: ActorTransport
   // ```
   // (no need for @actorIndependent because it is an immutable let)

--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -119,9 +119,9 @@ static ValueDecl *deriveDistributedActor_id(DerivedConformance &derived) {
 
   propDecl->setIntroducer(VarDecl::Introducer::Let);
 
-  // mark as @_distributedActorIndependent, allowing access to it from everywhere
+  // mark as nonisolated, allowing access to it from everywhere
   propDecl->getAttrs().add(
-      new (C) DistributedActorIndependentAttr(/*IsImplicit=*/true));
+      new (C) NonisolatedAttr(/*IsImplicit=*/true));
 
   derived.addMembersToConformanceContext({ propDecl, pbDecl });
   return propDecl;
@@ -148,9 +148,9 @@ static ValueDecl *deriveDistributedActor_actorTransport(
 
   propDecl->setIntroducer(VarDecl::Introducer::Let);
 
-  // mark as @_distributedActorIndependent, allowing access to it from everywhere
+  // mark as nonisolated, allowing access to it from everywhere
   propDecl->getAttrs().add(
-      new (C) DistributedActorIndependentAttr(/*IsImplicit=*/true));
+      new (C) NonisolatedAttr(/*IsImplicit=*/true));
 
   derived.addMembersToConformanceContext({ propDecl, pbDecl });
   return propDecl;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -256,7 +256,6 @@ public:
 
   void visitActorAttr(ActorAttr *attr);
   void visitDistributedActorAttr(DistributedActorAttr *attr);
-  void visitDistributedActorIndependentAttr(DistributedActorIndependentAttr *attr);
   void visitGlobalActorAttr(GlobalActorAttr *attr);
   void visitAsyncAttr(AsyncAttr *attr);
   void visitMarkerAttr(MarkerAttr *attr);
@@ -5507,16 +5506,6 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
 
   if (auto VD = dyn_cast<ValueDecl>(D)) {
     (void)getActorIsolation(VD);
-  }
-}
-
-void AttributeChecker::visitDistributedActorIndependentAttr(DistributedActorIndependentAttr *attr) {
-  /// user-inaccessible _distributedActorIndependent can only be applied to let properties
-  if (auto var = dyn_cast<VarDecl>(D)) {
-    if (!var->isLet()) {
-      diagnoseAndRemoveAttr(attr, diag::distributed_actor_independent_property_must_be_let);
-      return;
-    }
   }
 }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5473,7 +5473,13 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
       // distributed actors. Attempts of nonisolated access would be
       // cross-actor, and that means they might be accessing on a remote actor,
       // in which case the stored property storage does not exist.
-      if (nominal && nominal->isDistributedActor()) {
+      //
+      // The synthesized "id" and "actorTransport" are the only exceptions,
+      // because the implementation mirrors them.
+      if (nominal && nominal->isDistributedActor() &&
+          !(var->isImplicit() &&
+            (var->getName() == Ctx.Id_id ||
+             var->getName() == Ctx.Id_actorTransport))) {
         diagnoseAndRemoveAttr(attr,
                               diag::nonisolated_distributed_actor_storage);
         return;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5400,7 +5400,7 @@ void AttributeChecker::visitActorAttr(ActorAttr *attr) {
 void AttributeChecker::visitDistributedActorAttr(DistributedActorAttr *attr) {
   auto dc = D->getDeclContext();
 
-  // distributed can be applied to actor class definitions and async functions
+  // distributed can be applied to actor definitions and their methods
   if (auto varDecl = dyn_cast<VarDecl>(D)) {
     // distributed can not be applied to stored properties
     diagnoseAndRemoveAttr(attr, diag::distributed_actor_property);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2209,8 +2209,6 @@ namespace {
             if (func->isStatic()) {
               // no additional checks for static functions
             } else if (func->isDistributed()) {
-              tryMarkImplicitlyAsync(memberLoc, memberRef, context,
-                                     ImplicitActorHopTarget::forInstanceSelf());
               tryMarkImplicitlyThrows(memberLoc, memberRef, context);
               markNearestCallAsImplicitly(/*setAsync*/None, /*setThrows*/false,
                                           /*setDistributedThunk*/true);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1847,15 +1847,17 @@ namespace {
             ConcurrentReferenceKind::CrossActor);
       }
 
+      // Call is implicitly asynchronous.
+      auto result = tryMarkImplicitlyAsync(
+        loc, valueRef, context,
+        ImplicitActorHopTarget::forGlobalActor(globalActor));
+      if (result == AsyncMarkingResult::FoundAsync)
+        return false;
+
+      // Diagnose failures.
       switch (contextIsolation) {
       case ActorIsolation::DistributedActorInstance:
       case ActorIsolation::ActorInstance: {
-        auto result = tryMarkImplicitlyAsync(
-          loc, valueRef, context,
-          ImplicitActorHopTarget::forGlobalActor(globalActor));
-        if (result == AsyncMarkingResult::FoundAsync)
-          return false;
-
         auto useKind = static_cast<unsigned>(
             kindOfUsage(value, context).getValueOr(VarRefUseEnv::Read));
 
@@ -1869,14 +1871,6 @@ namespace {
 
       case ActorIsolation::GlobalActor:
       case ActorIsolation::GlobalActorUnsafe: {
-        // Check if this decl reference is the callee of the enclosing Apply,
-        // making it OK as an implicitly async call.
-        auto result = tryMarkImplicitlyAsync(
-            loc, valueRef, context,
-            ImplicitActorHopTarget::forGlobalActor(globalActor));
-        if (result == AsyncMarkingResult::FoundAsync)
-          return false;
-
         auto useKind = static_cast<unsigned>(
             kindOfUsage(value, context).getValueOr(VarRefUseEnv::Read));
 
@@ -1891,12 +1885,6 @@ namespace {
       }
 
       case ActorIsolation::Independent: {
-        auto result = tryMarkImplicitlyAsync(
-            loc, valueRef, context,
-            ImplicitActorHopTarget::forGlobalActor(globalActor));
-        if (result == AsyncMarkingResult::FoundAsync)
-          return false;
-
         auto useKind = static_cast<unsigned>(
             kindOfUsage(value, context).getValueOr(VarRefUseEnv::Read));
 
@@ -1910,12 +1898,6 @@ namespace {
       }
 
       case ActorIsolation::Unspecified: {
-        auto result = tryMarkImplicitlyAsync(
-            loc, valueRef, context,
-            ImplicitActorHopTarget::forGlobalActor(globalActor));
-        if (result == AsyncMarkingResult::FoundAsync)
-          return false;
-
         // Diagnose the reference.
         auto useKind = static_cast<unsigned>(
             kindOfUsage(value, context).getValueOr(VarRefUseEnv::Read));

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1476,8 +1476,7 @@ namespace {
           break;
         }
         case ActorIsolationRestriction::CrossActorSelf:
-        case ActorIsolationRestriction::ActorSelf:
-        case ActorIsolationRestriction::CrossDistributedActorSelf: {
+        case ActorIsolationRestriction::ActorSelf: {
           if (isPartialApply) {
             // The partially applied InoutArg is a property of actor. This
             // can really only happen when the property is a struct with a
@@ -2076,13 +2075,10 @@ namespace {
             }
             LLVM_FALLTHROUGH; // otherwise, it's invalid so diagnose it.
 
-          case ActorIsolationRestriction::ActorSelf:
-          case ActorIsolationRestriction::CrossDistributedActorSelf: {
+          case ActorIsolationRestriction::ActorSelf: {
             auto decl = concDecl.getDecl();
             ctx.Diags.diagnose(component.getLoc(),
                                diag::actor_isolated_keypath_component,
-                               /*isDistributed=*/isolation.getKind() ==
-                                  ActorIsolationRestriction::CrossDistributedActorSelf || // FIXME: remove this
                                isolation.getKind() ==
                                   ActorIsolationRestriction::CrossActorSelf,
                                decl->getDescriptiveKind(), decl->getName());
@@ -2175,7 +2171,6 @@ namespace {
 
       case ActorIsolationRestriction::CrossActorSelf:
       case ActorIsolationRestriction::ActorSelf:
-      case ActorIsolationRestriction::CrossDistributedActorSelf:
         llvm_unreachable("non-member reference into an actor");
 
       case ActorIsolationRestriction::GlobalActorUnsafe:
@@ -2213,7 +2208,6 @@ namespace {
       case ActorIsolationRestriction::Unrestricted:
         return false;
 
-      case ActorIsolationRestriction::CrossDistributedActorSelf:
       case ActorIsolationRestriction::CrossActorSelf: {
         // If a cross-actor reference is to an isolated actor, it's not
         // crossing actors.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -385,18 +385,6 @@ ActorIsolationRestriction ActorIsolationRestriction::forDeclaration(
     if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
       if (func->isAsyncContext())
         isAccessibleAcrossActors = true;
-
-      // FIXME: move diagnosis out of this function entirely (!)
-      if (func->isDistributed()) {
-        if (auto classDecl = dyn_cast<ClassDecl>(decl->getDeclContext())) {
-          if (!classDecl->isDistributedActor()) {
-            // `distributed func` must only be defined in `distributed actor`
-            func->diagnose(
-                diag::distributed_actor_func_defined_outside_of_distributed_actor,
-                func->getName());
-          }
-        } // TODO: need to handle protocol case here too?
-      }
     }
 
     // Similarly, a computed property or subscript that has an 'async' getter

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2588,7 +2588,6 @@ static Optional<ActorIsolation> getIsolationFromAttributes(
             globalActorAttr->second->getName().str())
           .highlight(nonisolatedAttr->getRangeWithAt())
           .highlight(globalActorAttr->first->getRangeWithAt());
-        }
       }
     }
   }

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -115,10 +115,6 @@ public:
     /// are permitted from elsewhere as a cross-actor reference, but
     /// contexts with unspecified isolation won't diagnose anything.
     GlobalActorUnsafe,
-
-    /// References to declarations that are part of a distributed actor are
-    /// only permitted if they are async.
-    CrossDistributedActorSelf, // FIXME(distributed): remove this case entirely rdar://83713366
   };
 
 private:
@@ -149,8 +145,7 @@ public:
   /// Retrieve the actor type that the declaration is within.
   NominalTypeDecl *getActorType() const {
     assert(kind == ActorSelf || 
-           kind == CrossActorSelf || 
-           kind == CrossDistributedActorSelf);
+           kind == CrossActorSelf);
     return data.actorType;
   }
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -455,9 +455,6 @@ static bool checkObjCActorIsolation(const ValueDecl *VD,
   case ActorIsolationRestriction::GlobalActor:
     // FIXME: Consider whether to limit @objc on global-actor-qualified
     // declarations.
-  case ActorIsolationRestriction::CrossDistributedActorSelf:
-    // we do not allow distributed + objc actors.
-    return false;
   case ActorIsolationRestriction::Unrestricted:
   case ActorIsolationRestriction::Unsafe:
     return false;

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1542,7 +1542,6 @@ namespace  {
     UNINTERESTING_ATTR(OriginallyDefinedIn)
     UNINTERESTING_ATTR(Actor)
     UNINTERESTING_ATTR(DistributedActor)
-    UNINTERESTING_ATTR(DistributedActorIndependent)
     UNINTERESTING_ATTR(GlobalActor)
     UNINTERESTING_ATTR(Async)
     UNINTERESTING_ATTR(Sendable)

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2839,13 +2839,6 @@ bool ConformanceChecker::checkActorIsolation(
     /// nonisolated or distributed members.
     auto witnessClass = dyn_cast<ClassDecl>(witness->getDeclContext());
     if (witnessClass && witnessClass->isDistributedActor()) {
-        // we only have two 'distributed-actor-nonisolated' properties,
-        // the address and transport; if we see any such marked property,
-        // we're free to automatically assume those are fine and accessible always.
-      if (witness->isSynthesized() && witness->isDistributedActorIndependent()) {
-        return false;
-      }
-
       // Maybe we're dealing with a 'distributed func' which is witness to
       // a distributed function requirement, this is ok.
       if (requirementFunc && requirementFunc->isDistributed() &&

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2878,7 +2878,6 @@ bool ConformanceChecker::checkActorIsolation(
     return true;
   }
 
-  case ActorIsolationRestriction::CrossDistributedActorSelf:
   case ActorIsolationRestriction::CrossActorSelf:
     return diagnoseNonSendableTypesInReference(
         witness, DC->getParentModule(), witness->getLoc(),

--- a/test/Distributed/distributed_actor_func_implicitly_async_throws.swift
+++ b/test/Distributed/distributed_actor_func_implicitly_async_throws.swift
@@ -48,12 +48,12 @@ func test_outside(distributed: D) async throws {
 
   distributed.distHelloAsync()// expected-error{{expression is 'async' but is not marked with 'await'}}
   // expected-error@-1{{call can throw but is not marked with 'try'}}
-  // expected-note@-2{{calls to instance method 'distHelloAsync()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-2{{call is 'async'}}
   // expected-note@-3{{did you mean to use 'try'?}}
   // expected-note@-4{{did you mean to disable error propagation?}}
   // expected-note@-5{{did you mean to handle error as optional value?}}
   try distributed.distHelloAsync() // expected-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{calls to instance method 'distHelloAsync()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-1{{call is 'async'}}
   await distributed.distHelloAsync() // expected-error{{call can throw but is not marked with 'try'}}
   // expected-note@-1{{did you mean to use 'try'?}}
   // expected-note@-2{{did you mean to disable error propagation?}}
@@ -76,12 +76,12 @@ func test_outside(distributed: D) async throws {
 
   distributed.distHelloAsyncThrows() // expected-error{{expression is 'async' but is not marked with 'await'}}
   // expected-error@-1{{call can throw but is not marked with 'try'}}
-  // expected-note@-2{{calls to instance method 'distHelloAsyncThrows()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-2{{call is 'async'}}
   // expected-note@-3{{did you mean to use 'try'?}}
   // expected-note@-4{{did you mean to disable error propagation?}}
   // expected-note@-5{{did you mean to handle error as optional value?}}
   try distributed.distHelloAsyncThrows() // expected-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{calls to instance method 'distHelloAsyncThrows()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-1{{call is 'async'}}
   await distributed.distHelloAsyncThrows() // expected-error{{call can throw but is not marked with 'try'}}
   // expected-note@-1{{did you mean to use 'try'?}}
   // expected-note@-2{{did you mean to disable error propagation?}}

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -67,24 +67,24 @@ distributed actor DistributedActor_1 {
     fatalError()
   }
 
-  distributed func distReturnGeneric<T: Codable>(item: T) async throws -> T { // ok
+  distributed func distReturnGeneric<T: Codable & Sendable>(item: T) async throws -> T { // ok
     item
   }
-  distributed func distReturnGenericWhere<T>(item: Int) async throws -> T where T: Codable { // ok
+  distributed func distReturnGenericWhere<T: Sendable>(item: Int) async throws -> T where T: Codable { // ok
     fatalError()
   }
-  distributed func distBadReturnGeneric<T>(int: Int) async throws -> T {
+  distributed func distBadReturnGeneric<T: Sendable>(int: Int) async throws -> T {
     // expected-error@-1 {{distributed function result type 'T' does not conform to 'Codable'}}
     fatalError()
   }
 
-  distributed func distGenericParam<T: Codable>(value: T) async throws { // ok
+  distributed func distGenericParam<T: Codable & Sendable>(value: T) async throws { // ok
     fatalError()
   }
-  distributed func distGenericParamWhere<T>(value: T) async throws -> T where T: Codable { // ok
+  distributed func distGenericParamWhere<T: Sendable>(value: T) async throws -> T where T: Codable { // ok
     value
   }
-  distributed func distBadGenericParam<T>(int: T) async throws {
+  distributed func distBadGenericParam<T: Sendable>(int: T) async throws {
     // expected-error@-1 {{distributed function parameter 'int' of type 'T' does not conform to 'Codable'}}
     fatalError()
   }

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -91,9 +91,8 @@ distributed actor DistributedActor_1 {
 
   static func staticFunc() -> String { "" } // ok
 
-// TODO: should be able to handle a static, global actor isolated function as well
-//  @MainActor
-//  static func staticMainActorFunc() -> String { "" } // ok
+  @MainActor
+  static func staticMainActorFunc() -> String { "" } // ok
 
   static distributed func staticDistributedFunc() -> String {
     // expected-error@-1{{'distributed' functions cannot be 'static'}}{10-21=}
@@ -115,6 +114,9 @@ distributed actor DistributedActor_1 {
     await self.distHelloAsync()
     try self.distHelloThrows()
     try await self.distHelloAsyncThrows()
+
+    // Hops over to the global actor.
+    _ = await DistributedActor_1.staticMainActorFunc()
   }
 }
 

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -134,7 +134,7 @@ func test_outside(
   _ = distributed.name // expected-error{{distributed actor-isolated property 'name' can only be referenced inside the distributed actor}}
   _ = distributed.mutable // expected-error{{distributed actor-isolated property 'mutable' can only be referenced inside the distributed actor}}
 
-  // ==== special properties (@_distributedActorIndependent)
+  // ==== special properties (nonisolated, implicitly replicated)
   // the distributed actor's special fields may always be referred to
   _ = distributed.id
   _ = distributed.actorTransport

--- a/test/Distributed/distributed_actor_isolation_and_tasks.swift
+++ b/test/Distributed/distributed_actor_isolation_and_tasks.swift
@@ -14,7 +14,7 @@ distributed actor Philosopher {
   let log: Logger
   // expected-note@-1{{distributed actor state is only available within the actor instance}}
   var variable = 12
-  var variable_fromDetach = 12 // expected-note{{distributed actor state is only available within the actor instance}}
+  var variable_fromDetach = 12
   let INITIALIZED: Int
   let outside: Int = 1
 
@@ -47,7 +47,9 @@ distributed actor Philosopher {
       // because we KNOW this is a local call -- and there is no transport in
       // between that will throw.
       _ = await self.dist() // notice lack of 'try' even though 'distributed func'
-      _ = self.variable_fromDetach // expected-error{{distributed actor-isolated property 'variable_fromDetach' can only be referenced inside the distributed actor}}
+      _ = self.variable_fromDetach // expected-error{{expression is 'async' but is not marked with 'await'}}
+      // expected-note@-1{{property access is 'async'}}
+      _ = await self.variable_fromDetach // okay, we know we're on the local node
     }
   }
 }

--- a/test/Distributed/distributed_actor_nonisolated.swift
+++ b/test/Distributed/distributed_actor_nonisolated.swift
@@ -15,8 +15,6 @@ distributed actor DA {
   // expected-error@-1{{'nonisolated' can not be applied to distributed actor stored properties}}
 
   nonisolated var computedNonisolated: Int {
-    // expected-note@-1{{distributed actor state is only available within the actor instance}}
-
     // nonisolated computed properties are outside of the actor and as such cannot access local
     _ = self.local // expected-error{{distributed actor-isolated property 'local' can only be referenced inside the distributed actor}}
 
@@ -33,7 +31,7 @@ distributed actor DA {
     // self is a distributed actor self is NOT isolated
     _ = self.local // expected-error{{distributed actor-isolated property 'local' can only be referenced inside the distributed actor}}
     _ = try await self.dist() // ok, was made implicitly throwing and async
-    _ = self.computedNonisolated // expected-error{{only 'distributed' functions can be called from outside the distributed actor}}
+    _ = self.computedNonisolated // it's okay, only the body of computedNonisolated is wrong
   }
 
   nonisolated distributed func nonisolatedDistributed() async {

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -27,7 +27,7 @@ protocol DistProtocol: DistributedActor {
 @available(SwiftStdlib 5.5, *)
 distributed actor SpecificDist: DistProtocol {
 
-  nonisolated func local() -> String { "hi" } // expected-note{{only 'distributed' functions can be called from outside the distributed actor}}
+  nonisolated func local() -> String { "hi" }
 
   distributed func dist() -> String { "dist!" }
   distributed func dist(string: String) -> String { string }
@@ -49,7 +49,7 @@ distributed actor SpecificDist: DistProtocol {
 
 @available(SwiftStdlib 5.5, *)
 func outside_good(dp: SpecificDist) async throws {
-  _ = dp.local() // expected-error{{only 'distributed' functions can be called from outside the distributed actor}}
+  _ = dp.local()
 
   _ = try await dp.dist() // implicit async throws
   _ = try await dp.dist(string: "") // implicit async throws


### PR DESCRIPTION
Clean up some aspects of checking distributed actor isolation rules:
* Hopping to a global actor *from* a distributed-actor isolated context does not go through a distributed thunk (global actors can't have one).
* "Unrestricted" declarations are always unrestricted, so we don't need an extra distributed check here (it won't ever occur).
* Actor isolation computation doesn't need a special case for distributed; it marks too much, overriding (e.g.) global actor isolation.
* Model `@_distributedActorIndependent` like `nonisolated`, simplifying away many special cases
* Unify and simplify the checking when performing a cross-actor reference to an entity that is distributed-actor-isolated