### PR TITLE
[Concurrency] Disable applying the -fswift-async-fp flag for Xcode builds until someone figures out the root cause

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -49,16 +49,21 @@ if(NOT swift_concurrency_async_fp_mode)
   set(swift_concurrency_async_fp_mode "always")
 endif()
 
-# Don't emit extended frame info on platforms other than darwin, system
-# backtracer and system debugger are unlikely to support it.
-if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS
-    "-fswift-async-fp=${swift_concurrency_async_fp_mode}")
-  list(APPEND SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS
-    "-Xfrontend"
-    "-swift-async-frame-pointer=${swift_concurrency_async_fp_mode}")
+if(XCODE)
+  message(WARNING "The -fswift-async-fp flag is being disabled because of an "
+                  "issue with the Xcode build, see SR-15216 for info.")
 else()
-  list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS "-fswift-async-fp=never")
+  # Don't emit extended frame info on platforms other than darwin, system
+  # backtracer and system debugger are unlikely to support it.
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS
+      "-fswift-async-fp=${swift_concurrency_async_fp_mode}")
+    list(APPEND SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS
+      "-Xfrontend"
+      "-swift-async-frame-pointer=${swift_concurrency_async_fp_mode}")
+  else()
+    list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS "-fswift-async-fp=never")
+  endif()
 endif()
 
 add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB


### PR DESCRIPTION
Since people are still complaining about this on the forum, disable it for the Xcode builds for now.

@davezarzycki, let me know what you think.