### PR TITLE
Cannot back-deploy mangled names including isolated parameters.

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -178,7 +178,15 @@ getRuntimeVersionThatSupportsDemanglingType(CanType type) {
   // related to concurrency.
   bool needsConcurrency = type.findIf([](CanType t) -> bool {
     if (auto fn = dyn_cast<AnyFunctionType>(t)) {
-      return fn->isAsync() || fn->isSendable() || fn->hasGlobalActor();
+      if (fn->isAsync() || fn->isSendable() || fn->hasGlobalActor())
+        return true;
+
+      for (const auto param: fn->getParams()) {
+        if (param.isIsolated())
+          return true;
+      }
+
+      return false;
     }
     return false;
   });

--- a/test/Concurrency/Backdeploy/mangling.swift
+++ b/test/Concurrency/Backdeploy/mangling.swift
@@ -15,33 +15,36 @@
 // REQUIRES: CPU=x86_64
 // REQUIRES: OS=macosx
 // REQUIRES: executable_test
-
-// rdar://83465277 - failing when using OS stdlib on 10.15 and earlier.
-// UNSUPPORTED: use_os_stdlib
+actor MyActor { }
 
 protocol MyProtocol {
   associatedtype AssocSendable
   associatedtype AssocAsync
   associatedtype AssocGlobalActor
+  associatedtype AssocIsolated
 }
 
 typealias SendableFn = @Sendable () -> Void
 typealias AsyncFn = () async -> Void
 typealias GlobalActorFn = @MainActor () -> Void
+typealias ActorIsolatedFn = (isolated MyActor) -> String
 
 struct MyStruct: MyProtocol {
   typealias AssocSendable = SendableFn
   typealias AssocAsync = AsyncFn
   typealias AssocGlobalActor = GlobalActorFn
+  typealias AssocIsolated = ActorIsolatedFn
 }
 
 func assocSendable<T: MyProtocol>(_: T.Type) -> Any.Type { return T.AssocSendable.self }
 func assocAsync<T: MyProtocol>(_: T.Type) -> Any.Type { return T.AssocAsync.self }
 func assocGlobalActor<T: MyProtocol>(_: T.Type) -> Any.Type { return T.AssocGlobalActor.self }
+func assocIsolated<T: MyProtocol>(_: T.Type) -> Any.Type { return T.AssocIsolated.self }
 
 assert(assocSendable(MyStruct.self) == SendableFn.self)
 assert(assocAsync(MyStruct.self) == AsyncFn.self)
 assert(assocGlobalActor(MyStruct.self) == GlobalActorFn.self)
+assert(assocIsolated(MyStruct.self) == ActorIsolatedFn.self)
 
 // type metadata accessor for @Sendable () -> ()
 // OLD: define linkonce_odr hidden swiftcc %swift.metadata_response @"$syyYbcMa"
@@ -72,3 +75,9 @@ assert(assocGlobalActor(MyStruct.self) == GlobalActorFn.self)
 
 // NEW-NOT: call swiftcc %swift.metadata_response @"$syyScMYccMa"
 // NEW: call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$syyScMYccMD")
+
+// OLD: call swiftcc %swift.metadata_response @"$sSS4main7MyActorCYicMa"(i64 0) #3
+// OLD-NOT: call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$sSS4main7MyActorCYicMD")
+
+// NEW-NOT: call swiftcc %swift.metadata_response @"$sSS4main7MyActorCYicMa"(i64 0) #3
+// NEW: call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$sSS4main7MyActorCYicMD")


### PR DESCRIPTION
Isolated parameters were introduced with concurrency, so don't mangle
names including them in back-deployed code.
