### PR TITLE
Small SIL utilities: checkReachingBlocks and CastBranchBase::SuccesorPath

### DIFF
--- a/include/swift/SIL/BasicBlockUtils.h
+++ b/include/swift/SIL/BasicBlockUtils.h
@@ -148,6 +148,10 @@ void findJointPostDominatingSet(
     function_ref<void(SILBasicBlock *)> foundJointPostDomSetCompletionBlocks,
     function_ref<void(SILBasicBlock *)> inputBlocksInJointPostDomSet = {});
 
+#ifndef NDEBUG
+bool checkDominates(SILBasicBlock *sourceBlock, SILBasicBlock *destBlock);
+#endif
+
 } // namespace swift
 
 #endif

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8767,10 +8767,13 @@ public:
 
   TermInst::SuccessorListTy getSuccessors() { return DestBBs; }
 
-  SILBasicBlock *getSuccessBB() { return DestBBs[0]; }
-  const SILBasicBlock *getSuccessBB() const { return DestBBs[0]; }
-  SILBasicBlock *getFailureBB() { return DestBBs[1]; }
-  const SILBasicBlock *getFailureBB() const { return DestBBs[1]; }
+  // Enumerate the successor indices
+  enum SuccessorPath { SuccessIdx = 0, FailIdx = 1};
+
+  SILBasicBlock *getSuccessBB() { return DestBBs[SuccessIdx]; }
+  const SILBasicBlock *getSuccessBB() const { return DestBBs[SuccessIdx]; }
+  SILBasicBlock *getFailureBB() { return DestBBs[FailIdx]; }
+  const SILBasicBlock *getFailureBB() const { return DestBBs[FailIdx]; }
 
   /// The number of times the True branch was executed
   ProfileCounter getTrueBBCount() const { return DestBBs[0].getCount(); }


### PR DESCRIPTION
Pulling a couple of small SIL functions out of a very large set of OSSA related commits. These are minor/obvious conveniences:

    Add checkReachingBlockDominates utility.

    This is a tiny routine that is useful for writing assertions to be
    used for quick sanity checks without computing Dominance.

    It doesn't always make sense to require a pass to maintain and pass
    around Dominance just for an assert.

   Add CastBranchInstBase::SuccessorPath for easier factoring.

    Code that handles checked_cast_br can not be factored easily without
    coding separate paths for each successor.
