### PR TITLE
Include SwiftNativeNSObject in the back-deployed concurrency library. 

### DIFF
--- a/stdlib/public/BackDeployConcurrency/CMakeLists.txt
+++ b/stdlib/public/BackDeployConcurrency/CMakeLists.txt
@@ -49,7 +49,8 @@ set(swift_concurrency_options
   DARWIN_INSTALL_NAME_DIR "@rpath")
 set(swift_concurrency_extra_sources
   "../BackDeployConcurrency/Exclusivity.cpp"
-  "../BackDeployConcurrency/Metadata.cpp")
+  "../BackDeployConcurrency/Metadata.cpp"
+  "../stubs/SwiftNativeNSObject.mm")
 set(swift_concurrency_async_fp_mode "never")
 
 add_subdirectory(../Concurrency stdlib/public/BackDeployConcurrency)

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -79,6 +79,13 @@ if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)
     INSTALL_IN_COMPONENT never_install)
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  list(APPEND SWIFT_RUNTIME_CONCURRENCY_SWIFT_LINK_FLAGS
+    "-Wl,-reexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/Concurrency/ReexportedSymbols")
+endif()
+
+list(APPEND SWIFT_RUNTIME_CONCURRENCY_SWIFT_LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}")
+
 if(SWIFT_BUILD_STDLIB)
   # These must be kept in dependency order so that any referenced targets
   # exist at the time we look for them in add_swift_*.
@@ -117,10 +124,3 @@ if(SWIFT_BUILD_SDK_OVERLAY)
     add_subdirectory(Windows)
   endif()
 endif()
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  list(APPEND SWIFT_RUNTIME_CONCURRENCY_SWIFT_LINK_FLAGS
-    "-Wl,-reexported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/Concurrency/ReexportedSymbols")
-endif()
-
-list(APPEND SWIFT_RUNTIME_CONCURRENCY_SWIFT_LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}")

--- a/test/Concurrency/Backdeploy/mangling.swift
+++ b/test/Concurrency/Backdeploy/mangling.swift
@@ -15,6 +15,7 @@
 // REQUIRES: CPU=x86_64
 // REQUIRES: OS=macosx
 // REQUIRES: executable_test
+// REQUIRES: concurrency_runtime
 actor MyActor { }
 
 protocol MyProtocol {

--- a/test/Concurrency/Backdeploy/objc_actor.swift
+++ b/test/Concurrency/Backdeploy/objc_actor.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -target x86_64-apple-macosx10.15 %s -o %t/test_mangling -Xfrontend -disable-availability-checking -parse-as-library
+// RUN: %target-run %t/test_mangling
+
+// REQUIRES: CPU=x86_64
+// REQUIRES: OS=macosx
+// REQUIRES: executable_test
+// REQUIRES: concurrency_runtime
+
+import Foundation
+
+@objc actor MyActor {
+  func f() -> String { "hello" }
+}
+
+@main
+enum Main {
+  static func main() async {
+    let ma = MyActor()
+    let greeting = await ma.f()
+    assert(greeting == "hello")
+  }
+}


### PR DESCRIPTION
`SwiftNativeNSObject` is part of the core runtime on OS versions that also have the concurrency library, so we need to include a copy of it with the back-deployed concurrency library.

To ensure this works make the `_Concurrency` library re-export `SwiftNativeNSObject` properly.