### PR TITLE
[SwiftSyntaxBuilder] Add protocol conformance map

### DIFF
--- a/utils/gyb_syntax_support/protocolsMap.py
+++ b/utils/gyb_syntax_support/protocolsMap.py
@@ -1,0 +1,18 @@
+SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES = {
+    'ExpressibleAsConditionElement': [
+        'ExpressibleAsConditionElementList'
+    ],
+    'ExpressibleAsDeclBuildable': [
+        'ExpressibleAsCodeBlockItem',
+        'ExpressibleAsMemberDeclListItem',
+        'ExpressibleAsSyntaxBuildable'
+    ],
+    'ExpressibleAsStmtBuildable': [
+        'ExpressibleAsCodeBlockItem',
+        'ExpressibleAsSyntaxBuildable'
+    ],
+    'ExpressibleAsExprList': [
+        'ExpressibleAsConditionElement',
+        'ExpressibleAsSyntaxBuildable'
+    ]
+}


### PR DESCRIPTION
Added a map to help add protocols to SwiftSyntax Buildables

https://github.com/apple/swift-syntax/pull/320