### PR TITLE
Verifier: Support line numbers in fix-it verification

### DIFF
--- a/include/swift/AST/DiagnosticConsumer.h
+++ b/include/swift/AST/DiagnosticConsumer.h
@@ -69,7 +69,9 @@ struct DiagnosticInfo {
   public:
     FixIt(CharSourceRange R, StringRef Str, ArrayRef<DiagnosticArgument> Args);
 
-    CharSourceRange getRange() const { return Range; }
+    CharSourceRange &getRange() { return Range; }
+    const CharSourceRange &getRange() const { return Range; }
+
     StringRef getText() const { return Text; }
   };
 

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -247,6 +247,9 @@ public:
     return LLVMSourceMgr.getLineAndColumn(Loc.Value, BufferID);
   }
 
+  /// Returns the column for the given source location in the given buffer.
+  unsigned getColumnInBuffer(SourceLoc Loc, unsigned BufferID) const;
+
   StringRef getEntireTextForBuffer(unsigned BufferID) const;
 
   StringRef extractText(CharSourceRange Range,

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -101,11 +101,11 @@ private:
   Result verifyFile(unsigned BufferID);
 
   bool checkForFixIt(const ExpectedFixIt &Expected,
-                     const CapturedDiagnosticInfo &D, StringRef buffer);
+                     const CapturedDiagnosticInfo &D, unsigned BufferID) const;
 
   // Render the verifier syntax for a given set of fix-its.
   std::string renderFixits(ArrayRef<DiagnosticInfo::FixIt> fixits,
-                           StringRef InputFile);
+                           unsigned BufferID) const;
 
   void printRemainingDiagnostics() const;
 };

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -36,6 +36,15 @@ bool verifyDependencies(SourceManager &SM, ArrayRef<SourceFile *> SFs);
 // MARK: - DiagnosticVerifier
 struct ExpectedFixIt;
 
+/// A range expressed in terms of line-and-column pairs.
+struct LineColumnRange {
+  static constexpr unsigned NoValue = ~0u;
+
+  unsigned StartCol, EndCol;
+
+  LineColumnRange() : StartCol(NoValue), EndCol(NoValue) {}
+};
+
 struct CapturedDiagnosticInfo {
   llvm::SmallString<128> Message;
   llvm::SmallString<32> FileName;

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -40,9 +40,12 @@ struct ExpectedFixIt;
 struct LineColumnRange {
   static constexpr unsigned NoValue = ~0u;
 
-  unsigned StartCol, EndCol;
+  unsigned StartLine, StartCol;
+  unsigned EndLine, EndCol;
 
-  LineColumnRange() : StartCol(NoValue), EndCol(NoValue) {}
+  LineColumnRange()
+      : StartLine(NoValue), StartCol(NoValue), EndLine(NoValue),
+        EndCol(NoValue) {}
 };
 
 class CapturedFixItInfo final {
@@ -60,7 +63,9 @@ public:
   /// Obtain the line-column range corresponding to the fix-it's
   /// replacement range.
   const LineColumnRange &getLineColumnRange(const SourceManager &SM,
-                                            unsigned BufferID) const;
+                                            unsigned BufferID,
+                                            bool ComputeStartLocLine,
+                                            bool ComputeEndLocLine) const;
 };
 
 struct CapturedDiagnosticInfo {
@@ -132,7 +137,7 @@ private:
 
   // Render the verifier syntax for a given set of fix-its.
   std::string renderFixits(ArrayRef<CapturedFixItInfo> ActualFixIts,
-                           unsigned BufferID) const;
+                           unsigned BufferID, unsigned DiagnosticLineNo) const;
 
   void printRemainingDiagnostics() const;
 };

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -220,6 +220,23 @@ unsigned SourceManager::getByteDistance(SourceLoc Start, SourceLoc End) const {
   return End.Value.getPointer() - Start.Value.getPointer();
 }
 
+unsigned SourceManager::getColumnInBuffer(SourceLoc Loc,
+                                          unsigned BufferID) const {
+  assert(Loc.isValid());
+
+  const StringRef Buffer = getEntireTextForBuffer(BufferID);
+  const char *Ptr = static_cast<const char *>(Loc.getOpaquePointerValue());
+
+  StringRef UpToLoc = Buffer.slice(0, Ptr - Buffer.data());
+
+  size_t ColumnNo = UpToLoc.size();
+  size_t NewlinePos = UpToLoc.find_last_of("\r\n");
+  if (NewlinePos != StringRef::npos)
+    ColumnNo -= NewlinePos;
+
+  return static_cast<unsigned>(ColumnNo);
+}
+
 StringRef SourceManager::getEntireTextForBuffer(unsigned BufferID) const {
   return LLVMSourceMgr.getMemoryBuffer(BufferID)->getBuffer();
 }

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -970,8 +970,9 @@ void DiagnosticVerifier::handleDiagnostic(SourceManager &SM,
     for (auto &fixIt : capturedDiag.FixIts) {
       auto newStart = correctSM.getLocForForeignLoc(fixIt.getRange().getStart(),
                                                     SM);
-      fixIt.getRange() = CharSourceRange(newStart,
-                                         fixIt.getRange().getByteLength());
+      auto &mutableRange = fixIt.getRange();
+      mutableRange =
+          CharSourceRange(newStart, fixIt.getRange().getByteLength());
     }
   }
 }

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -346,8 +346,7 @@ DiagnosticVerifier::Result DiagnosticVerifier::verifyFile(unsigned BufferID) {
   using llvm::SMLoc;
   
   const SourceLoc BufferStartLoc = SM.getLocForBufferStart(BufferID);
-  CharSourceRange EntireRange = SM.getRangeForBuffer(BufferID);
-  StringRef InputFile = SM.extractText(EntireRange);
+  StringRef InputFile = SM.getEntireTextForBuffer(BufferID);
   StringRef BufferName = SM.getIdentifierForBuffer(BufferID);
 
   // Queue up all of the diagnostics, allowing us to sort them and emit them in

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -29,8 +29,8 @@ using namespace swift;
 namespace swift {
 struct ExpectedFixIt {
   const char *StartLoc, *EndLoc; // The loc of the {{ and }}'s.
-  unsigned StartCol;
-  unsigned EndCol;
+  LineColumnRange Range;
+
   std::string Text;
 };
 } // end namespace swift
@@ -247,9 +247,10 @@ bool DiagnosticVerifier::checkForFixIt(const ExpectedFixIt &Expected,
       continue;
 
     CharSourceRange Range = ActualFixIt.getRange();
-    if (SM.getColumnInBuffer(Range.getStart(), BufferID) != Expected.StartCol)
+    if (SM.getColumnInBuffer(Range.getStart(), BufferID) !=
+        Expected.Range.StartCol)
       continue;
-    if (SM.getColumnInBuffer(Range.getEnd(), BufferID) != Expected.EndCol)
+    if (SM.getColumnInBuffer(Range.getEnd(), BufferID) != Expected.Range.EndCol)
       continue;
 
     return true;
@@ -544,12 +545,12 @@ DiagnosticVerifier::Result DiagnosticVerifier::verifyFile(unsigned BufferID) {
       ExpectedFixIt FixIt;
       FixIt.StartLoc = OpenLoc;
       FixIt.EndLoc = CloseLoc;
-      if (StartColStr.getAsInteger(10, FixIt.StartCol)) {
+      if (StartColStr.getAsInteger(10, FixIt.Range.StartCol)) {
         addError(StartColStr.data(),
                  "invalid column number in fix-it verification");
         continue;
       }
-      if (EndColStr.getAsInteger(10, FixIt.EndCol)) {
+      if (EndColStr.getAsInteger(10, FixIt.Range.EndCol)) {
         addError(EndColStr.data(),
                  "invalid column number in fix-it verification");
         continue;

--- a/test/Frontend/verify-fixits.swift
+++ b/test/Frontend/verify-fixits.swift
@@ -18,6 +18,42 @@ func test0Fixits() {
   // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-1=a}}
 
+  // CHECK: [[@LINE+1]]:80: error: invalid column number in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{x-1=a}}
+
+  // CHECK: [[@LINE+1]]:82: error: invalid column number in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-x=a}}
+
+  // CHECK: [[@LINE+1]]:82: error: invalid column number in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1:x-1=a}}
+
+  // CHECK: [[@LINE+1]]:80: error: invalid line number in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{x:1-1=a}}
+
+  // CHECK: [[@LINE+1]]:84: error: invalid column number in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-1:x=a}}
+
+  // CHECK: [[@LINE+1]]:82: error: invalid line number in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-x:1=a}}
+
+  // CHECK: [[@LINE+1]]:82: error: invalid column number in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1:x-1:x=a}}
+
+  // CHECK: [[@LINE+1]]:80: error: invalid line number in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{x:1-1:x=a}}
+
+  // CHECK: [[@LINE+1]]:82: error: invalid column number in fix-it verification
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1:x-x:1=a}}
+
+  // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1:1-1:1=a}}
+
+  // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-1:1=a}}
+
+  // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
+  undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1:1-1=a}}
+
   // CHECK: [[@LINE+1]]:78: error: expected fix-it not seen
   undefinedFunc() // expected-error {{cannot find 'undefinedFunc' in scope}} {{1-1=a}} {{2-2=b}}
 
@@ -57,6 +93,15 @@ func test1Fixits() {
 
   // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-18=xx}} {{15-18=aa}} {{none}}
+
+  // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{98:15-98:18=aa}}
+  // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{100:15-18=aa}}
+  // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{15-102:18=aa}}
+  // CHECK: [[@LINE+1]]:121: error: expected fix-it not seen; actual fix-it seen: {{{{}}15-18=aa}}
+  labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{61:15-18=aa}}
 }
 
 func test2Fixits() {

--- a/test/Generics/associated_type_where_clause_hints.swift
+++ b/test/Generics/associated_type_where_clause_hints.swift
@@ -23,14 +23,14 @@ protocol P2 : P1 {
 // A redeclaration of an associated type that adds type/layout requirements
 // should be written via a where clause.
 protocol P3a : P1 {
-  associatedtype A: P0, P0b // expected-warning{{redeclaration of associated type 'A' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{18-18= where A: P0, A: P0b}}{{3-29=}}
+  associatedtype A: P0, P0b // expected-warning{{redeclaration of associated type 'A' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{25:18-25:18= where A: P0, A: P0b}}{{26:3-26:29=}}
   associatedtype A2: P0, P0b where A2.A == Never, A2: P1 // expected-warning{{redeclaration of associated type 'A2' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{18-18= where A2: P0, A2: P0b, A2.A == Never, A2 : P1}}{{3-58=}}
   associatedtype A3 where A3: P0 // expected-warning{{redeclaration of associated type 'A3' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{18-18= where A3 : P0}}{{3-34=}}
 
-  // expected-warning@+1 {{redeclaration of associated type 'A4' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{18-18= where A4: P0, A4 : Collection, A4.Element == A4.Index, A4.SubSequence == A4}}{{3-52=}}
+  // expected-warning@+1 {{redeclaration of associated type 'A4' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{25:18-25:18= where A4: P0, A4 : Collection, A4.Element == A4.Index, A4.SubSequence == A4}}{{31:3-33:51=}}
   associatedtype A4: P0 where A4: Collection,
                               A4.Element == A4.Index,
-                              A4.SubSequence == A4 // {{3-52=}} is this line, so it is correct.
+                              A4.SubSequence == A4
 }
 
 // ... unless it has adds a default type witness


### PR DESCRIPTION
This will come in handy for fix-its that target a different line or span multiple lines. In particular, this applies to upcoming diagnostics described in [SE-0309](https://github.com/apple/swift-evolution/blob/main/proposals/0309-unlock-existential-types-for-all-protocols.md#diagnostics).
