### PR TITLE
AccessBase API for OSSA utilities

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -546,6 +546,17 @@ private:
 /// require traversing phis.
 class AccessBase : public AccessRepresentation {
 public:
+  /// Return an AccessBase for the formally accessed variable pointed to by \p
+  /// sourceAddress.
+  ///
+  /// \p sourceAddress may be an address type or Builtin.RawPointer.
+  ///
+  /// If \p sourceAddress is within a formal access scope, which does not have
+  /// "Unsafe" enforcement, then this always returns the valid base.
+  ///
+  /// If \p sourceAddress is not within a formal access scope, or within an
+  /// "Unsafe" scope, then this finds the formal base if possible,
+  /// otherwise returning an invalid base.
   static AccessBase compute(SILValue sourceAddress);
 
   // Do not add any members to this class. AccessBase can be copied as

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -576,6 +576,20 @@ public:
   /// Precondition: isReference() is true.
   SILValue getReference() const;
 
+  /// Return the OSSA root of the reference being accessed.
+  ///
+  /// Precondition: isReference() is true.
+  SILValue getOwnershipReferenceRoot() const {
+    return findOwnershipReferenceRoot(getReference());
+  }
+
+  /// Return the storage root of the reference being accessed.
+  ///
+  /// Precondition: isReference() is true.
+  SILValue getStorageReferenceRoot() const {
+    return findReferenceRoot(getReference());
+  }
+
   /// Return the global variable being accessed.
   ///
   /// Precondition: getKind() == Global

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -610,6 +610,16 @@ public:
   /// determined. Otherwise returns null.
   const ValueDecl *getDecl() const;
 
+  /// Return true if this base address may be derived from a reference that is
+  /// only valid within a locally scoped OSSA lifetime. This is not true for
+  /// scoped storage such as alloc_stack and @in argument. It can be
+  /// independently assumed that addresses are only used within the scope of the
+  /// storage object.
+  ///
+  /// Useful to determine whether addresses with the same AccessStorage are in
+  /// fact substitutable without fixing OSSA lifetime.
+  bool hasLocalOwnershipLifetime() const;
+
   void print(raw_ostream &os) const;
   void dump() const;
 };
@@ -744,10 +754,6 @@ public:
   bool hasIdenticalStorage(const AccessStorage &other) const {
     return hasIdenticalAccessInfo(other);
   }
-
-  /// Return true if this storage is valid for all uses in a function without
-  /// checking its lifetime.
-  bool isGuaranteedForFunction() const;
 
   /// Returns the ValueDecl for the underlying storage, if it can be
   /// determined. Otherwise returns null.

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -204,6 +204,11 @@ SILValue findReferenceRoot(SILValue ref);
 /// Find the first owned root of the reference.
 SILValue findOwnershipReferenceRoot(SILValue ref);
 
+/// Find the aggregate containing the first owned root of the
+/// reference. Identical to findOwnershipReferenceRoot, but looks through
+/// struct_extract, tuple_extract, etc.
+SILValue findOwnershipReferenceAggregate(SILValue ref);
+
 /// Return true if \p address points to a let-variable.
 ///
 /// let-variables are only written during let-variable initialization, which is

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4937,6 +4937,8 @@ public:
 
 /// A conversion inst that produces a static OwnershipKind set upon the
 /// instruction's construction.
+///
+/// The first operand is the ownership equivalent source.
 class OwnershipForwardingConversionInst : public ConversionInst,
                                           public OwnershipForwardingMixin {
 protected:
@@ -7877,6 +7879,8 @@ public:
   TermKind getTermKind() const { return TermKind(getKind()); }
 
   /// Returns true if this is a transformation terminator.
+  ///
+  /// The first operand is the transformed source.
   bool isTransformationTerminator() const {
     switch (getTermKind()) {
     case TermKind::UnwindInst:
@@ -9396,6 +9400,7 @@ SILFunction *ApplyInstBase<Impl, Base, false>::getCalleeFunction() const {
   }
 }
 
+/// The first operand is the ownership equivalent source.
 class OwnershipForwardingMultipleValueInstruction
     : public MultipleValueInstruction,
       public OwnershipForwardingMixin {


### PR DESCRIPTION
Add basic convenience APIs to the AccessBase abstraction. OSSA utilities typically need to query the access base to know what sort of operation generates the address, then find the reference's lifetime or borrow scope.