### PR TITLE
[windows][vs2017] Add missing <atomic> include.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -31,6 +31,7 @@
 #include "llvm/Support/Regex.h"
 #include "llvm/Support/VersionTuple.h"
 #include "llvm/Support/raw_ostream.h"
+#include <atomic>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Seems that VS2019 and other C++ standard libraries include `<atomic>` as
part of either `<string>` or `<vector>`, but not VS2017. When #38782 landed
a new usage of `std::atomic` started creating compilation problems in the
VS2017 builders (eg. https://ci-external.swift.org/job/oss-swift-windows-x86_64/8736/).

Including the `<atomic>` header solves the problem.

/cc @ahoppen