### PR TITLE
[silgen] When initializing tuples in SILGen, first evaluate all tuple elts and then perform sub-initialization.

### DIFF
--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -869,6 +869,16 @@ void SILGenBuilder::emitDestructureValueOperation(
   }
 }
 
+void SILGenBuilder::emitDestructureValueOperation(
+    SILLocation loc, ManagedValue value,
+    SmallVectorImpl<ManagedValue> &destructuredValues) {
+  CleanupCloner cloner(*this, value);
+  emitDestructureValueOperation(
+      loc, value.forward(SGF), [&](unsigned index, SILValue subValue) {
+        destructuredValues.push_back(cloner.clone(subValue));
+      });
+}
+
 ManagedValue SILGenBuilder::createProjectBox(SILLocation loc, ManagedValue mv,
                                              unsigned index) {
   auto *pbi = createProjectBox(loc, mv.getValue(), index);

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -389,6 +389,9 @@ public:
   void emitDestructureValueOperation(
       SILLocation loc, ManagedValue value,
       function_ref<void(unsigned, ManagedValue)> func);
+  void emitDestructureValueOperation(
+      SILLocation loc, ManagedValue value,
+      SmallVectorImpl<ManagedValue> &destructuredValues);
 
   using SILBuilder::createProjectBox;
   ManagedValue createProjectBox(SILLocation loc, ManagedValue mv,

--- a/test/SILGen/enum.swift
+++ b/test/SILGen/enum.swift
@@ -219,3 +219,23 @@ func sr7799_1(bar: SR7799??) {
   default: print("default")
   }
 }
+
+// Make sure that we handle enum, tuple initialization composed
+// correctly. Previously, we leaked down a failure path due to us misusing
+// scopes.
+enum rdar81817725 {
+    case localAddress
+    case setOption(Int, Any)
+
+    static func takeAny(_:Any) -> Bool { return true }
+
+    static func testSwitchCleanup(syscall: rdar81817725, expectedLevel: Int,
+                                  valueMatcher: (Any) -> Bool)
+      throws -> Bool {
+        if case .setOption(expectedLevel, let value) = syscall {
+            return rdar81817725.takeAny(value)
+        } else {
+            return false
+        }
+    }
+}

--- a/test/SILGen/indirect_enum.swift
+++ b/test/SILGen/indirect_enum.swift
@@ -448,8 +448,8 @@ func guardTreeB<T>(_ tree: TreeB<T>) {
     // CHECK:   [[TUPLE_ADDR:%.*]] = project_box [[BOX]]
     // CHECK:   copy_addr [[TUPLE_ADDR]] to [initialization] [[TUPLE_COPY:%.*]] :
     // CHECK:   [[L_COPY:%.*]] = tuple_element_addr [[TUPLE_COPY]]
-    // CHECK:   copy_addr [take] [[L_COPY]] to [initialization] [[L]]
     // CHECK:   [[R_COPY:%.*]] = tuple_element_addr [[TUPLE_COPY]]
+    // CHECK:   copy_addr [take] [[L_COPY]] to [initialization] [[L]]
     // CHECK:   copy_addr [take] [[R_COPY]] to [initialization] [[R]]
     // CHECK:   destroy_value [[BOX]]
     guard case .Branch(left: let l, right: let r) = tree else { return }
@@ -492,8 +492,8 @@ func guardTreeB<T>(_ tree: TreeB<T>) {
     // CHECK:   [[TUPLE_ADDR:%.*]] = project_box [[BOX]]
     // CHECK:   copy_addr [[TUPLE_ADDR]] to [initialization] [[TUPLE_COPY:%.*]] :
     // CHECK:   [[L_COPY:%.*]] = tuple_element_addr [[TUPLE_COPY]]
-    // CHECK:   copy_addr [take] [[L_COPY]] to [initialization] [[L]]
     // CHECK:   [[R_COPY:%.*]] = tuple_element_addr [[TUPLE_COPY]]
+    // CHECK:   copy_addr [take] [[L_COPY]] to [initialization] [[L]]
     // CHECK:   copy_addr [take] [[R_COPY]] to [initialization] [[R]]
     // CHECK:   destroy_value [[BOX]]
     // CHECK:   destroy_addr [[R]]


### PR DESCRIPTION
Previsouly we were evaluating a tuple elt and then performing the relevant
sub-initialization. The problem is that a sub-initialization can invoke code
that could perform an early exit cleanup. So any later tuple-elements that may
need to be cleaned up along such path will not have had their cleanups
initialized, resulting in a leak along such paths.

With this commit, we instead evaluate all of the tuple elements and only them
perform the sub-initialization ensuring that any early exits clean up all of the
tuple elements.

rdar://83770295
