### PR TITLE
test: disable `Concurrency/Runtime/exclusivity.swift` on WASI

### DIFF
--- a/test/Concurrency/Runtime/exclusivity.swift
+++ b/test/Concurrency/Runtime/exclusivity.swift
@@ -5,6 +5,7 @@
 
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: OS=wasi
 
 // This test makes sure that:
 //


### PR DESCRIPTION

Tests for crashes aren't available on WebAssembly/WASI since there's no way to intercept traps or crashes on this platform. Trapping causes the whole Wasm VM to shut down with no way to recover from within the test code.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Related to SR-9307.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
