### PR TITLE
[SourceKit] Add a dedicated request to retrieve the diagnostics of a file

### DIFF
--- a/test/SourceKit/CompileNotifications/cursor-info.swift
+++ b/test/SourceKit/CompileNotifications/cursor-info.swift
@@ -1,4 +1,5 @@
 // RUN: %sourcekitd-test -req=track-compiles == -req=cursor %s -offset=0 -- %s | %FileCheck %s -check-prefix=COMPILE_1 --enable-yaml-compatibility
+// COMPILE_1: <empty cursor info; internal diagnostic: "Unable to resolve cursor info.">
 // COMPILE_1: {
 // COMPILE_1:  key.notification: source.notification.compile-will-start,
 // COMPILE_1:  key.filepath: "SOURCE_DIR{{.*}}cursor-info.swift",
@@ -8,6 +9,5 @@
 // COMPILE_1:   key.notification: source.notification.compile-did-finish,
 // COMPILE_1:   key.compileid: [[CID1]]
 // COMPILE_1: }
-// COMPILE_1: <empty cursor info; internal diagnostic: "Unable to resolve cursor info.">
 // COMPILE_1-NOT: compile-will-start
 // COMPILE_1-NOT: compile-did-finish

--- a/test/SourceKit/Diagnostics/diags.swift
+++ b/test/SourceKit/Diagnostics/diags.swift
@@ -1,0 +1,49 @@
+// Use -print-raw-response on the first request so we don't wait for semantic info which will never come.
+// RUN: %sourcekitd-test -req=open %s -req-opts=syntactic_only=1 -print-raw-response -- %s == \
+// RUN: -req=stats == \
+// RUN: -req=diags %s -print-raw-response -- %s == \
+// RUN: -req=stats == \
+// RUN: -req=diags %s -print-raw-response -- %s == \
+// RUN: -req=stats | %FileCheck %s
+
+func foo(y: String) {
+  foo(y: 1)
+}
+
+// We shouldn't build an AST for the syntactic open
+// CHECK: 0 {{.*}} source.statistic.num-ast-builds
+
+// Retrieving diagnostics should workd
+// CHECK: {
+// CHECK:   key.diagnostics: [
+// CHECK:     {
+// CHECK:       key.line: 10,
+// CHECK:       key.column: 10,
+// CHECK:       key.filepath: "{{.*}}",
+// CHECK:       key.severity: source.diagnostic.severity.error,
+// CHECK:       key.id: "cannot_convert_argument_value",
+// CHECK:       key.description: "cannot convert value of type 'Int' to expected argument type 'String'"
+// CHECK:     }
+// CHECK:   ]
+// CHECK: }
+
+// ... and we should have built an AST for it
+// CHECK: 1 {{.*}} source.statistic.num-ast-builds
+
+// Retrieving diagnostics again should workd
+// CHECK: {
+// CHECK:   key.diagnostics: [
+// CHECK:     {
+// CHECK:       key.line: 10,
+// CHECK:       key.column: 10,
+// CHECK:       key.filepath: "{{.*}}",
+// CHECK:       key.severity: source.diagnostic.severity.error,
+// CHECK:       key.id: "cannot_convert_argument_value",
+// CHECK:       key.description: "cannot convert value of type 'Int' to expected argument type 'String'"
+// CHECK:     }
+// CHECK:   ]
+// CHECK: }
+
+// ... but we shouldn't rebuild an AST
+// CHECK: 1 {{.*}} source.statistic.num-ast-builds
+// CHECK: 1 {{.*}} source.statistic.num-ast-cache-hits

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -500,6 +500,9 @@ struct CursorInfoData {
   llvm::ArrayRef<RefactoringInfo> AvailableActions;
 };
 
+/// The result type of `LangSupport::getDiagnostics`
+typedef ArrayRef<DiagnosticEntryInfo> DiagnosticsResult;
+
 struct RangeInfo {
   UIdent RangeKind;
   StringRef ExprType;
@@ -831,6 +834,13 @@ public:
       ArrayRef<const char *> Args, Optional<VFSOptions> vfsOptions,
       SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<CursorInfoData> &)> Receiver) = 0;
+
+  virtual void
+  getDiagnostics(StringRef InputFile, ArrayRef<const char *> Args,
+                 Optional<VFSOptions> VfsOptions,
+                 SourceKitCancellationToken CancellationToken,
+                 std::function<void(const RequestResult<DiagnosticsResult> &)>
+                     Receiver) = 0;
 
   virtual void
   getNameInfo(StringRef Filename, unsigned Offset, NameTranslatingInfo &Input,

--- a/tools/SourceKit/include/SourceKit/Support/FileSystemProvider.h
+++ b/tools/SourceKit/include/SourceKit/Support/FileSystemProvider.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SOURCEKIT_SUPPORT_FILESYSTEMPROVIDER_H
 #define LLVM_SOURCEKIT_SUPPORT_FILESYSTEMPROVIDER_H
 
+#include "SourceKit/Core/LangSupport.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -569,6 +569,13 @@ public:
                      std::function<void(const RequestResult<CursorInfoData> &)>
                          Receiver) override;
 
+  void
+  getDiagnostics(StringRef InputFile, ArrayRef<const char *> Args,
+                 Optional<VFSOptions> VfsOptions,
+                 SourceKitCancellationToken CancellationToken,
+                 std::function<void(const RequestResult<DiagnosticsResult> &)>
+                     Receiver) override;
+
   void getNameInfo(
       StringRef Filename, unsigned Offset, NameTranslatingInfo &Input,
       ArrayRef<const char *> Args, SourceKitCancellationToken CancellationToken,

--- a/tools/SourceKit/tools/complete-test/complete-test.cpp
+++ b/tools/SourceKit/tools/complete-test/complete-test.cpp
@@ -568,6 +568,7 @@ public:
 static void printResponse(sourcekitd_response_t resp, bool raw, bool structure,
                           unsigned indentation) {
   if (raw) {
+    llvm::outs().flush();
     sourcekitd_response_description_dump_filedesc(resp, STDOUT_FILENO);
     return;
   }

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -150,6 +150,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
         .Case("collect-var-type", SourceKitRequest::CollectVariableType)
         .Case("global-config", SourceKitRequest::GlobalConfiguration)
         .Case("dependency-updated", SourceKitRequest::DependencyUpdated)
+        .Case("diags", SourceKitRequest::Diagnostics)
 #define SEMANTIC_REFACTORING(KIND, NAME, ID) .Case("refactoring." #ID, SourceKitRequest::KIND)
 #include "swift/IDE/RefactoringKinds.def"
         .Default(SourceKitRequest::None);

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -67,6 +67,7 @@ enum class SourceKitRequest {
   CollectVariableType,
   GlobalConfiguration,
   DependencyUpdated,
+  Diagnostics,
 #define SEMANTIC_REFACTORING(KIND, NAME, ID) KIND,
 #include "swift/IDE/RefactoringKinds.def"
 };

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -1075,6 +1075,9 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
     sourcekitd_request_dictionary_set_uid(Req, KeyRequest,
                                           RequestDependencyUpdated);
     break;
+  case SourceKitRequest::Diagnostics:
+    sourcekitd_request_dictionary_set_uid(Req, KeyRequest, RequestDiagnostics);
+    break;
   }
 
   if (!SourceFile.empty()) {
@@ -1305,6 +1308,7 @@ static bool handleResponse(sourcekitd_response_t Resp, const TestOptions &Opts,
     case SourceKitRequest::TypeContextInfo:
     case SourceKitRequest::ConformingMethodList:
     case SourceKitRequest::DependencyUpdated:
+    case SourceKitRequest::Diagnostics:
       sourcekitd_response_description_dump_filedesc(Resp, STDOUT_FILENO);
       break;
 
@@ -1465,6 +1469,7 @@ static bool handleResponse(sourcekitd_response_t Resp, const TestOptions &Opts,
         break;
       case SourceKitRequest::Statistics:
         printStatistics(Info, llvm::outs());
+        break;
     }
   }
 

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -170,6 +170,16 @@ struct NotificationBuffer {
 };
 static NotificationBuffer notificationBuffer;
 
+static void printRawResponse(sourcekitd_response_t resp) {
+  llvm::outs().flush();
+  sourcekitd_response_description_dump_filedesc(resp, STDOUT_FILENO);
+}
+
+static void printRawVariant(sourcekitd_variant_t obj) {
+  llvm::outs().flush();
+  sourcekitd_variant_description_dump_filedesc(obj, STDOUT_FILENO);
+}
+
 static void syncNotificationsWithService() {
   // Send TestNotification request, then wait for the notification. This ensures
   // that all notifications previously posted on the service side have been
@@ -192,9 +202,8 @@ static void printBufferedNotifications(bool syncWithService = true) {
   if (syncWithService) {
     syncNotificationsWithService();
   }
-  notificationBuffer.handleNotifications([](sourcekitd_response_t note) {
-    sourcekitd_response_description_dump_filedesc(note, STDOUT_FILENO);
-  });
+  notificationBuffer.handleNotifications(
+      [](sourcekitd_response_t note) { printRawResponse(note); });
 }
 
 struct skt_args {
@@ -443,7 +452,7 @@ static int handleJsonRequestPath(StringRef QueryPath, const TestOptions &Opts) {
   sourcekitd_response_t Resp = sendRequestSync(Req, Opts);
   auto Error = sourcekitd_response_is_error(Resp);
   if (Opts.PrintResponse) {
-    sourcekitd_response_description_dump_filedesc(Resp, STDOUT_FILENO);
+    printRawResponse(Resp);
   }
   return Error ? 1 : 0;
 }
@@ -1256,7 +1265,7 @@ static bool handleResponse(sourcekitd_response_t Resp, const TestOptions &Opts,
     free(json);
 
   } else if (Opts.PrintRawResponse) {
-    sourcekitd_response_description_dump_filedesc(Resp, STDOUT_FILENO);
+    printRawResponse(Resp);
 
   } else {
     sourcekitd_variant_t Info = sourcekitd_response_get_value(Resp);
@@ -1279,7 +1288,7 @@ static bool handleResponse(sourcekitd_response_t Resp, const TestOptions &Opts,
     case SourceKitRequest::Edit:
       if (Opts.Length == 0 && Opts.ReplaceText->empty()) {
         // Length=0, replace="" is a nop and will not trigger sema.
-        sourcekitd_response_description_dump_filedesc(Resp, STDOUT_FILENO);
+        printRawResponse(Resp);
       } else {
         getSemanticInfo(Info, SourceFile);
         KeepResponseAlive = true;
@@ -1309,7 +1318,7 @@ static bool handleResponse(sourcekitd_response_t Resp, const TestOptions &Opts,
     case SourceKitRequest::ConformingMethodList:
     case SourceKitRequest::DependencyUpdated:
     case SourceKitRequest::Diagnostics:
-      sourcekitd_response_description_dump_filedesc(Resp, STDOUT_FILENO);
+      printRawResponse(Resp);
       break;
 
     case SourceKitRequest::RelatedIdents:
@@ -1380,7 +1389,7 @@ static bool handleResponse(sourcekitd_response_t Resp, const TestOptions &Opts,
     }
     case SourceKitRequest::SyntaxMap:
     case SourceKitRequest::Structure:
-      sourcekitd_response_description_dump_filedesc(Resp, STDOUT_FILENO);
+      printRawResponse(Resp);
       if (Opts.ReplaceText.hasValue()) {
         unsigned Offset =
             resolveFromLineCol(Opts.Line, Opts.Col, SourceFile, Opts.VFSFiles);
@@ -1405,7 +1414,7 @@ static bool handleResponse(sourcekitd_response_t Resp, const TestOptions &Opts,
                                                 !Opts.UsedSema);
 
         sourcekitd_response_t EdResp = sendRequestSync(EdReq, Opts);
-        sourcekitd_response_description_dump_filedesc(EdResp, STDOUT_FILENO);
+        printRawResponse(EdResp);
         sourcekitd_response_dispose(EdResp);
         sourcekitd_request_release(EdReq);
       }
@@ -1440,7 +1449,7 @@ static bool handleResponse(sourcekitd_response_t Resp, const TestOptions &Opts,
         }
 
         sourcekitd_response_t FmtResp = sendRequestSync(Fmt, Opts);
-        sourcekitd_response_description_dump_filedesc(FmtResp, STDOUT_FILENO);
+        printRawResponse(FmtResp);
         sourcekitd_response_dispose(FmtResp);
         sourcekitd_request_release(Fmt);
       }
@@ -1449,7 +1458,7 @@ static bool handleResponse(sourcekitd_response_t Resp, const TestOptions &Opts,
       case SourceKitRequest::ExpandPlaceholder:
         if (Opts.Length) {
           // Single placeholder by location.
-          sourcekitd_response_description_dump_filedesc(Resp, STDOUT_FILENO);
+          printRawResponse(Resp);
         } else {
           // Expand all placeholders.
           expandPlaceholders(SourceBuf.get(), llvm::outs());
@@ -1523,13 +1532,12 @@ static void getSemanticInfo(sourcekitd_variant_t Info, StringRef Filename) {
 }
 
 static int printAnnotations() {
-  sourcekitd_variant_description_dump_filedesc(LatestSemaAnnotations,
-                                               STDOUT_FILENO);
+  printRawVariant(LatestSemaAnnotations);
   return 0;
 }
 
 static int printDiags() {
-  sourcekitd_variant_description_dump_filedesc(LatestSemaDiags, STDOUT_FILENO);
+  printRawVariant(LatestSemaDiags);
   return 0;
 }
 
@@ -2106,16 +2114,14 @@ static void printFoundUSR(sourcekitd_variant_t Info,
 static void printNormalizedDocComment(sourcekitd_variant_t Info) {
   sourcekitd_variant_t Source =
     sourcekitd_variant_dictionary_get_value(Info, KeySourceText);
-  sourcekitd_variant_description_dump_filedesc(Source, STDOUT_FILENO);
+  printRawVariant(Source);
 }
 
 static void printDocInfo(sourcekitd_variant_t Info, StringRef Filename) {
   const char *text =
       sourcekitd_variant_dictionary_get_string(Info, KeySourceText);
-  llvm::raw_fd_ostream OS(STDOUT_FILENO, /*shouldClose=*/false);
   if (text) {
-    OS << text << '\n';
-    OS.flush();
+    llvm::outs() << text << '\n';
   }
 
   sourcekitd_variant_t annotations =
@@ -2126,11 +2132,11 @@ static void printDocInfo(sourcekitd_variant_t Info, StringRef Filename) {
   sourcekitd_variant_t diags =
       sourcekitd_variant_dictionary_get_value(Info, KeyDiagnostics);
 
-  sourcekitd_variant_description_dump_filedesc(annotations, STDOUT_FILENO);
-  sourcekitd_variant_description_dump_filedesc(entities, STDOUT_FILENO);
+  printRawVariant(annotations);
+  printRawVariant(entities);
 
   if (sourcekitd_variant_get_type(diags) != SOURCEKITD_VARIANT_TYPE_NULL)
-    sourcekitd_variant_description_dump_filedesc(diags, STDOUT_FILENO);
+    printRawVariant(diags);
 }
 
 static void checkTextIsASCII(const char *Text) {
@@ -2278,8 +2284,7 @@ static void printInterfaceGen(sourcekitd_variant_t Info, bool CheckASCII) {
       sourcekitd_variant_dictionary_get_string(Info, KeySourceText);
 
   if (text) {
-    llvm::raw_fd_ostream OS(STDOUT_FILENO, /*shouldClose=*/false);
-    OS << text << '\n';
+    llvm::outs() << text << '\n';
   }
 
   if (CheckASCII) {
@@ -2288,13 +2293,13 @@ static void printInterfaceGen(sourcekitd_variant_t Info, bool CheckASCII) {
 
   sourcekitd_variant_t syntaxmap =
       sourcekitd_variant_dictionary_get_value(Info, KeySyntaxMap);
-  sourcekitd_variant_description_dump_filedesc(syntaxmap, STDOUT_FILENO);
+  printRawVariant(syntaxmap);
   sourcekitd_variant_t annotations =
       sourcekitd_variant_dictionary_get_value(Info, KeyAnnotations);
-  sourcekitd_variant_description_dump_filedesc(annotations, STDOUT_FILENO);
+  printRawVariant(annotations);
   sourcekitd_variant_t structure =
       sourcekitd_variant_dictionary_get_value(Info, KeySubStructure);
-  sourcekitd_variant_description_dump_filedesc(structure, STDOUT_FILENO);
+  printRawVariant(structure);
 }
 
 static void printRelatedIdents(sourcekitd_variant_t Info, StringRef Filename,

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -193,6 +193,9 @@ static sourcekitd_response_t reportDocInfo(llvm::MemoryBuffer *InputBuf,
 
 static void reportCursorInfo(const RequestResult<CursorInfoData> &Result, ResponseReceiver Rec);
 
+static void reportDiagnostics(const RequestResult<DiagnosticsResult> &Result,
+                              ResponseReceiver Rec);
+
 static void reportExpressionTypeInfo(const RequestResult<ExpressionTypesInFile> &Result,
                                      ResponseReceiver Rec);
 
@@ -1277,6 +1280,16 @@ static void handleSemanticRequest(
                              Args, CancellationToken, Rec);
   }
 
+  if (ReqUID == RequestDiagnostics) {
+    LangSupport &Lang = getGlobalContext().getSwiftLangSupport();
+    Lang.getDiagnostics(*SourceFile, Args, std::move(vfsOptions),
+                        CancellationToken,
+                        [Rec](const RequestResult<DiagnosticsResult> &Result) {
+                          reportDiagnostics(Result, Rec);
+                        });
+    return;
+  }
+
   {
     llvm::raw_svector_ostream OSErr(ErrBuf);
     OSErr << "unknown request: " << UIdentFromSKDUID(ReqUID).getName();
@@ -1946,6 +1959,27 @@ static void reportCursorInfo(const RequestResult<CursorInfoData> &Result,
   }
 
   return Rec(RespBuilder.createResponse());
+}
+
+//===----------------------------------------------------------------------===//
+// ReportDiagnostics
+//===----------------------------------------------------------------------===//
+
+static void reportDiagnostics(const RequestResult<DiagnosticsResult> &Result,
+                              ResponseReceiver Rec) {
+  if (Result.isCancelled())
+    return Rec(createErrorRequestCancelled());
+  if (Result.isError())
+    return Rec(createErrorRequestFailed(Result.getError()));
+
+  auto &DiagResults = Result.value();
+
+  ResponseBuilder RespBuilder;
+  auto Dict = RespBuilder.getDictionary();
+  auto DiagArray = Dict.setArray(KeyDiagnostics);
+  for (const auto &DiagInfo : DiagResults)
+    fillDictionaryForDiagnosticInfo(DiagArray.appendDictionary(), DiagInfo);
+  Rec(RespBuilder.createResponse());
 }
 
 //===----------------------------------------------------------------------===//

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -262,6 +262,7 @@ UID_REQUESTS = [
     REQUEST('CollectVariableType', 'source.request.variable.type'),
     REQUEST('GlobalConfiguration', 'source.request.configuration.global'),
     REQUEST('DependencyUpdated', 'source.request.dependency_updated'),
+    REQUEST('Diagnostics', 'source.request.diagnostics'),
 ]
 
 


### PR DESCRIPTION
Currently, SourceKit always implicitly sends diagnostics to the client after every edit. This doesn’t match our new cancellation story because diagnostics retrieval is no request and thus can’t be cancelled.

Instead, diagnostics retrieval should be a standalone request, which returns a cancellation token like every other request and which can thus also be cancelled as such.

The indented transition path here is to change all open and edit requests to be syntactic only. When diagnostics are needed, the new diagnostics request should be used.

rdar://83391522