### PR TITLE
[Sema] Consider Objective-C SPIs as always imported in `isImportedAsSPI`

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -642,11 +642,11 @@ public:
                          const ModuleDecl *importedModule,
                          llvm::SmallSetVector<Identifier, 4> &spiGroups) const;
 
-  // Is \p attr accessible as an explictly imported SPI from this module?
+  // Is \p attr accessible as an explicitly imported SPI from this module?
   bool isImportedAsSPI(const SpecializeAttr *attr,
                        const ValueDecl *targetDecl) const;
 
-  // Is \p spiGroup accessible as an explictly imported SPI from this module?
+  // Is \p spiGroup accessible as an explicitly imported SPI from this module?
   bool isImportedAsSPI(Identifier spiGroup, const ModuleDecl *fromModule) const;
 
   /// \sa getImportedModules

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2389,11 +2389,16 @@ void SourceFile::lookupImportedSPIGroups(
 bool SourceFile::isImportedAsSPI(const ValueDecl *targetDecl) const {
   auto targetModule = targetDecl->getModuleContext();
   llvm::SmallSetVector<Identifier, 4> importedSPIGroups;
+
+  // Objective-C SPIs are always imported implicitly.
+  if (targetDecl->hasClangNode())
+    return !targetDecl->getSPIGroups().empty();
+
   lookupImportedSPIGroups(targetModule, importedSPIGroups);
-  if (importedSPIGroups.empty()) return false;
+  if (importedSPIGroups.empty())
+    return false;
 
   auto declSPIGroups = targetDecl->getSPIGroups();
-
   for (auto declSPI : declSPIGroups)
     if (importedSPIGroups.count(declSPI))
       return true;

--- a/test/ClangImporter/Inputs/frameworks/SPIContainerImporter.framework/Headers/SPIContainerImporter.h
+++ b/test/ClangImporter/Inputs/frameworks/SPIContainerImporter.framework/Headers/SPIContainerImporter.h
@@ -1,0 +1,1 @@
+#import <SPIContainer/SPIContainer.h>

--- a/test/ClangImporter/Inputs/frameworks/SPIContainerImporter.framework/Modules/module.modulemap
+++ b/test/ClangImporter/Inputs/frameworks/SPIContainerImporter.framework/Modules/module.modulemap
@@ -1,0 +1,7 @@
+framework module SPIContainerImporter {
+  umbrella header "SPIContainerImporter.h"
+  export *
+  module * {
+    export *
+  }
+}

--- a/test/ClangImporter/availability_spi_transitive.swift
+++ b/test/ClangImporter/availability_spi_transitive.swift
@@ -1,0 +1,8 @@
+// REQUIRES: OS=macosx
+// RUN: %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks -enable-clang-spi -verify
+
+import SPIContainerImporter
+
+@_spi(a) public let a: SPIInterface1
+
+public let c: SPIInterface1 // expected-error{{cannot use class 'SPIInterface1' here; it is an SPI imported from 'SPIContainer'}}


### PR DESCRIPTION
Objective-C SPIs are always imported implicitly. Let's make this a fast path in `isImportedAsSPI`.

This addresses the limitation with transitively imported clang modules as the SPI attribute on an import doesn't apply to transitive imports. This takes a different approach then the existing logic so @nkcsgexi please feel free to go for an alternative solution.

rdar://83186214