### PR TITLE
When the stdlib is built with LTO and a custom toolchain, point -lto_library to the toolchain's lib directory when running lit tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -145,8 +145,12 @@ if(NOT SWIFT_INCLUDE_TOOLS)
   else()
     list(APPEND SWIFT_LIT_ARGS
       "--path=${SWIFT_NATIVE_LLVM_TOOLS_PATH}"
+      "--param" "swift_native_llvm_tools_path=${SWIFT_NATIVE_LLVM_TOOLS_PATH}"
       "--path=${SWIFT_NATIVE_CLANG_TOOLS_PATH}"
-      "--path=${SWIFT_NATIVE_SWIFT_TOOLS_PATH}")
+      "--param" "swift_native_clang_tools_path=${SWIFT_NATIVE_CLANG_TOOLS_PATH}"
+      "--path=${SWIFT_NATIVE_SWIFT_TOOLS_PATH}"
+      "--param" "swift_native_swift_tools_path=${SWIFT_NATIVE_SWIFT_TOOLS_PATH}"
+      )
   endif()
   if(SWIFT_BUILD_STDLIB)
     list(APPEND SWIFT_LIT_ARGS

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -976,6 +976,10 @@ if run_vendor == 'apple':
                         "swiftSwiftOnoneSupport"]:
             swift_execution_tests_extra_flags += ' -Xlinker -l%s'% library
 
+        swift_native_clang_tools_path = lit_config.params.get('swift_native_clang_tools_path', None)
+        if swift_native_clang_tools_path:
+            swift_execution_tests_extra_flags += ' -Xlinker -lto_library -Xlinker %s/../lib/libLTO.dylib' % swift_native_clang_tools_path
+
     xcrun_prefix = (
         "xcrun --toolchain %s --sdk %r" %
         (config.darwin_xcrun_toolchain, config.variant_sdk))


### PR DESCRIPTION
Let's see how much you hate this, @compnerd :)

The problem I'm trying to solve is this: I am building the 'freestanding' stdlib with a pre-built toolchain (that has ./usr/bin/clang, ./usr/bin/clang++, ./usr/bin/swiftc, ./usr/lib/libLTO.dylib) like this:

```
./swift/utils/build-script --preset stdlib_S_standalone_minimal_macho_x86_64,build,test toolchain_path=<PATH>
```

But since we're now enabling LTO on the 'freestanding' stdlib, linking must use the same toolchain. So I need a way of propagating `-lto_library <PATH>/lib/libLTO.dylib` into lit execution tests.