### PR TITLE
IRGen: Fix subtle issue with "circular" conformance access paths

### DIFF
--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -61,14 +61,14 @@ class RequirementMachine final {
   UnifiedStatsReporter *Stats;
 
   /// All conformance access paths computed so far.
-  llvm::DenseMap<std::pair<CanType, ProtocolDecl *>,
+  llvm::DenseMap<std::pair<Term, ProtocolDecl *>,
                  ConformanceAccessPath> ConformanceAccessPaths;
 
   /// Conformance access paths computed during the last round. All elements
   /// have the same length. If a conformance access path of greater length
   /// is requested, we refill CurrentConformanceAccessPaths with all paths of
   /// length N+1, and add them to the ConformanceAccessPaths map.
-  std::vector<std::pair<CanType, ConformanceAccessPath>>
+  std::vector<std::pair<Term, ConformanceAccessPath>>
       CurrentConformanceAccessPaths;
 
   explicit RequirementMachine(RewriteContext &rewriteCtx);

--- a/lib/AST/RequirementMachine/Term.h
+++ b/lib/AST/RequirementMachine/Term.h
@@ -65,6 +65,10 @@ public:
     return Ptr;
   }
 
+  static Term fromOpaquePointer(void *ptr) {
+    return Term((Storage *) ptr);
+  }
+
   static Term get(const MutableTerm &term, RewriteContext &ctx);
 
   ArrayRef<const ProtocolDecl *> getRootProtocols() const {
@@ -202,5 +206,25 @@ public:
 } // end namespace rewriting
 
 } // end namespace swift
+
+namespace llvm {
+  template<> struct DenseMapInfo<swift::rewriting::Term> {
+    static swift::rewriting::Term getEmptyKey() {
+      return swift::rewriting::Term::fromOpaquePointer(
+        llvm::DenseMapInfo<void *>::getEmptyKey());
+    }
+    static swift::rewriting::Term getTombstoneKey() {
+      return swift::rewriting::Term::fromOpaquePointer(
+        llvm::DenseMapInfo<void *>::getTombstoneKey());
+    }
+    static unsigned getHashValue(swift::rewriting::Term Val) {
+      return DenseMapInfo<void *>::getHashValue(Val.getOpaquePointer());
+    }
+    static bool isEqual(swift::rewriting::Term LHS,
+                        swift::rewriting::Term RHS) {
+      return LHS == RHS;
+    }
+  };
+} // end namespace llvm
 
 #endif

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2599,7 +2599,7 @@ MetadataResponse MetadataPath::followComponent(IRGenFunction &IGF,
 
     CanType associatedType =
       sourceConformance.getAssociatedType(sourceType, association)
-      ->getCanonicalType();
+        ->getCanonicalType();
     sourceKey.Type = associatedType;
 
     auto associatedConformance =
@@ -2614,10 +2614,77 @@ MetadataResponse MetadataPath::followComponent(IRGenFunction &IGF,
 
     if (!source) return MetadataResponse();
 
-    auto sourceMetadata =
-      IGF.emitAbstractTypeMetadataRef(sourceType);
-    auto associatedMetadata =
-      IGF.emitAbstractTypeMetadataRef(sourceKey.Type);
+    auto *sourceMetadata =
+        IGF.emitAbstractTypeMetadataRef(sourceType);
+
+    // Try to avoid circularity when realizing the associated metadata.
+    //
+    // Suppose we are asked to produce the witness table for some
+    // conformance access path (T : P)(Self.X : Q)(Self.Y : R).
+    //
+    // The associated conformance accessor for (Self.Y : R) takes the
+    // metadata for T.X and T.X : Q as arguments. If T.X is concrete,
+    // there are two ways of building it:
+    //
+    // a) Using the knowledge of the concrete type to build it directly,
+    // by first constructing the type metadata for its generic arguments.
+    //
+    // b) Obtaining T.X from the witness table for T : P. This will also
+    // construct the generic type, but from the generic environment
+    // of the concrete type of T, and not the abstract environment of
+    // our conformance access path.
+    //
+    // Now, say that T.X == Foo<T.X.Y>, with "Foo<A> where A : R".
+    //
+    // If approach a) is taken, then constructing Foo<T.X.Y> requires
+    // recovering the conformance T.X.Y : R, which recursively evaluates
+    // the same conformance access path, eventually causing a stack
+    // overflow.
+    //
+    // With approach b) on the other hand, the type metadata for
+    // Foo<T.X.Y> is constructed from the concrete type metadata for T,
+    // which must provide some other conformance access path for the
+    // conformance to R.
+    //
+    // This is not very principled, and a remaining issue is with conformance
+    // requirements where the subject type consists of multiple terms.
+    //
+    // A better approach would be for conformance access paths to directly
+    // record how type metadata at each intermediate step is constructed.
+    llvm::Value *associatedMetadata = nullptr;
+
+    if (auto response = IGF.tryGetLocalTypeMetadata(associatedType,
+                                                    MetadataState::Abstract)) {
+      // The associated type metadata was already cached, so we're fine.
+      associatedMetadata = response.getMetadata();
+    } else {
+      // If the associated type is concrete and the parent type is an archetype,
+      // it is better to realize the associated type metadata from the witness
+      // table of the parent's conformance, instead of realizing the concrete
+      // type directly.
+      auto depMemType = cast<DependentMemberType>(association);
+      CanType baseSubstType =
+        sourceConformance.getAssociatedType(sourceType, depMemType.getBase())
+          ->getCanonicalType();
+      if (auto archetypeType = cast<ArchetypeType>(baseSubstType)) {
+        AssociatedType baseAssocType(depMemType->getAssocType());
+
+        MetadataResponse response =
+          emitAssociatedTypeMetadataRef(IGF, archetypeType, baseAssocType,
+                                        MetadataState::Abstract);
+
+        // Cache this response in case we have to realize the associated type
+        // again later.
+        IGF.setScopedLocalTypeMetadata(associatedType, response);
+
+        associatedMetadata = response.getMetadata();
+      } else {
+        // Ok, fall back to realizing the (possibly concrete) type.
+        associatedMetadata =
+          IGF.emitAbstractTypeMetadataRef(sourceKey.Type);
+      }
+    }
+
     auto sourceWTable = source.getMetadata();
 
     AssociatedConformance associatedConformanceRef(sourceProtocol,

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2600,13 +2600,6 @@ MetadataResponse MetadataPath::followComponent(IRGenFunction &IGF,
     CanType associatedType =
       sourceConformance.getAssociatedType(sourceType, association)
       ->getCanonicalType();
-    if (sourceConformance.isConcrete() &&
-        isa<NormalProtocolConformance>(sourceConformance.getConcrete())) {
-      associatedType =
-        sourceConformance.getConcrete()->getDeclContext()
-          ->mapTypeIntoContext(associatedType)
-          ->getCanonicalType();
-    }
     sourceKey.Type = associatedType;
 
     auto associatedConformance =

--- a/test/Generics/rdar83687967.swift
+++ b/test/Generics/rdar83687967.swift
@@ -1,0 +1,66 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s
+
+public protocol P1 {}
+
+public protocol P2 {
+  associatedtype A: P1
+}
+
+public protocol P3 {
+  associatedtype B: P2
+  associatedtype A where B.A == A
+}
+
+public struct G<A: P1>: P2 {}
+
+public func callee<T: P1>(_: T.Type) {}
+
+// CHECK: rdar83687967.(file).caller11@
+// CHECK: Generic signature: <Child where Child : P3, Child.B == G<Child.A>>
+public func caller11<Child: P3>(_: Child)
+    where Child.B == G<Child.A> {
+  callee(Child.A.self)
+}
+
+// CHECK: rdar83687967.(file).caller12@
+// CHECK: Generic signature: <Child where Child : P3, Child.B == G<Child.A>>
+public func caller12<Child: P3>(_: Child)
+    // expected-note@-1 {{conformance constraint 'Child.A' : 'P1' implied here}}
+    where Child.B == G<Child.A>, Child.A : P1 {
+    // expected-warning@-1 {{redundant conformance constraint 'Child.A' : 'P1'}}
+
+  // Make sure IRGen can evaluate the conformance access path
+  // (Child : P3)(Self.B : P2)(Self.A : P1).
+  callee(Child.A.self)
+}
+
+// CHECK: rdar83687967.(file).X1@
+// CHECK: Requirement signature: <Self where Self.Child : P3, Self.Child.B == G<Self.Child.A>>
+public protocol X1 {
+  associatedtype Child: P3
+    where Child.B == G<Child.A>
+}
+
+// CHECK: rdar83687967.(file).X2@
+// CHECK: Requirement signature: <Self where Self.Child : P3, Self.Child.B == G<Self.Child.A>>
+
+public protocol X2 {
+  associatedtype Child: P3
+    // expected-note@-1 {{conformance constraint 'Self.Child.A' : 'P1' implied here}}
+    where Child.B == G<Child.A>, Child.A : P1
+    // expected-warning@-1 {{redundant conformance constraint 'Self.Child.A' : 'P1'}}
+}
+
+public func caller21<T : X1>(_: T) {
+  // Make sure IRGen can evaluate the conformance access path
+  // (T : X1)(Child : P3)(Self.B : P2)(Self.A : P1).
+  callee(T.Child.A.self)
+}
+
+public func caller22<T : X2>(_: T) {
+  // Make sure IRGen can evaluate the conformance access path
+  // (T : X2)(Child : P3)(Self.B : P2)(Self.A : P1).
+  callee(T.Child.A.self)
+}

--- a/test/IRGen/associated_types.swift
+++ b/test/IRGen/associated_types.swift
@@ -75,17 +75,17 @@ func testFastRuncible<T: Runcible, U: FastRuncible>(_ t: T, u: U)
 //   1. Get the type metadata for U.RuncerType.Runcee.
 //     1a. Get the type metadata for U.RuncerType.
 //         Note that we actually look things up in T, which is going to prove unfortunate.
-// CHECK: [[T2:%.*]] = call swiftcc %swift.metadata_response @swift_getAssociatedTypeWitness([[INT]] 255, i8** %T.Runcible, %swift.type* %T, %swift.protocol_requirement* getelementptr{{.*}}i32 12), i32 -1), %swift.protocol_requirement* getelementptr inbounds (<{{.*}}>, <{{.*}}>* @"$s16associated_types8RuncibleMp", i32 0, i32 14)) [[NOUNWIND_READNONE:#.*]]
-// CHECK-NEXT: %T.RuncerType = extractvalue %swift.metadata_response [[T2]], 0
+// CHECK: [[T2:%.*]] = call swiftcc %swift.metadata_response @swift_getAssociatedTypeWitness([[INT]] 255, i8** %U.FastRuncible, %swift.type* %U, %swift.protocol_requirement* getelementptr{{.*}}i32 9), i32 -1), %swift.protocol_requirement* getelementptr inbounds (<{{.*}}>, <{{.*}}>* @"$s16associated_types12FastRuncibleMp", i32 0, i32 10)) [[NOUNWIND_READNONE:#.*]]
+// CHECK-NEXT: [[T3:%.*]] = extractvalue %swift.metadata_response [[T2]], 0
 // CHECK-NEXT: extractvalue %swift.metadata_response [[T2]], 1
 //   2. Get the witness table for U.RuncerType.Runcee : Speedy
 //     2a. Get the protocol witness table for U.RuncerType : FastRuncer.
-// CHECK-NEXT: %T.RuncerType.FastRuncer = call swiftcc i8** @swift_getAssociatedConformanceWitness(i8** %U.FastRuncible, %swift.type* %U, %swift.type* %T.RuncerType
+// CHECK-NEXT: %T.RuncerType.FastRuncer = call swiftcc i8** @swift_getAssociatedConformanceWitness(i8** %U.FastRuncible, %swift.type* %U, %swift.type* [[T3]]
 //     1c. Get the type metadata for U.RuncerType.Runcee.
-// CHECK-NEXT: [[T2:%.*]] = call swiftcc %swift.metadata_response @swift_getAssociatedTypeWitness([[INT]] 0, i8** %T.RuncerType.FastRuncer, %swift.type* %T.RuncerType, {{.*}}, %swift.protocol_requirement* getelementptr inbounds (<{{.*}}>, <{{.*}}>* @"$s16associated_types10FastRuncerMp", i32 0, i32 10))
+// CHECK-NEXT: [[T2:%.*]] = call swiftcc %swift.metadata_response @swift_getAssociatedTypeWitness([[INT]] 0, i8** %T.RuncerType.FastRuncer, %swift.type* [[T3]], {{.*}}, %swift.protocol_requirement* getelementptr inbounds (<{{.*}}>, <{{.*}}>* @"$s16associated_types10FastRuncerMp", i32 0, i32 10))
 // CHECK-NEXT: %T.RuncerType.Runcee = extractvalue %swift.metadata_response [[T2]], 0
 //     2b. Get the witness table for U.RuncerType.Runcee : Speedy.
-// CHECK-NEXT: %T.RuncerType.Runcee.Speedy = call swiftcc i8** @swift_getAssociatedConformanceWitness(i8** %T.RuncerType.FastRuncer, %swift.type* %T.RuncerType, %swift.type* %T.RuncerType.Runcee
+// CHECK-NEXT: %T.RuncerType.Runcee.Speedy = call swiftcc i8** @swift_getAssociatedConformanceWitness(i8** %T.RuncerType.FastRuncer, %swift.type* [[T3]], %swift.type* %T.RuncerType.Runcee
 //   3. Perform the actual call.
 // CHECK-NEXT: [[T0_GEP:%.*]] = getelementptr inbounds i8*, i8** %T.RuncerType.Runcee.Speedy, i32 1
 // CHECK-NEXT: [[T0:%.*]] = load i8*, i8** [[T0_GEP]]


### PR DESCRIPTION
There are three things going on in rdar://83687967:

- An accidental ABI break between Swift 5.4 and 5.5
- A bug in `getConformanceAccessPath()`
- A bug in IRGen's conformance access path evaluation

# The ABI break

This part is actually not the root cause of the problem, but it is the reason why the test case used to work in Swift 5.4. Since we already shipped Swift 5.5, I think changing the ABI back to match the old behavior in this particular case would risk further regressions. The new ABI seems to make more sense, and I'm not changing it in this PR. But it could be changed back if we need to.

Here is the code:

```
public protocol P1 {}

public protocol P2 {
  associatedtype A: P1
}

public protocol P3 {
  associatedtype B: P2
  associatedtype A where B.A == A
}

public struct G<A: P1>: P2 {}

public func callee<T: P1>(_: T.Type) {}

public func caller11<Child: P3>(_: Child)
    where Child.B == G<Child.A> {
  callee(Child.A.self)
}
```

Requirement inference on the concrete type `G<Child.A>` in the `where` clause introduces the explicit conformance requirement `Child.A: P1` from the requirement `A: P1` in the signature of `G`.

In 5.4 and 5.5, we discover the alternate conformance access path `(Child: P3)(Self.B: P2)(Self.A: P1)` for `Child.A`. Note that the canonical type of `Child.B.A` is `Child.A`.

In 5.4, the "derived via concrete" check evaluates to true for this path, because the prefix Child.B is fixed to a concrete type. This excludes this conformance path from consideration.

In 5.5, the code was rewritten in an attempt to preserve existing behavior while fixing additional cases involving concrete types that the "derived via concrete" check didn't handle. This is where the "signature rebuilding after dropping conformances" stage of the GSB came from.

Clearly, I failed at preserving existing behavior in all cases, because in this case, it turns out that the "derived via concrete" check was too conservative. It was supposed to only consider a path "derived via concrete" if the root conformance was also redundant. This would happen if `Child : P3` was made redundant by a requirement like `Child == SomeConcreteType<...>`. In this example though, `(Child: P3)` is not redundant, so the original conformance access path is actually valid for `Child.A: P1`. This means that the inferred requirement `Child.A : P1` is actually redundant, according to the actual semantics of conformance access paths.

Indeed, 5.4 had a further inconsistency which highlights why the old behavior was wrong. In protocols, we don't perform requirement inference, since the idea is that the user should explicitly state all conformance requirements on associated types in a protocol, for readability.

You could write these two protocols in 5.4:

```
public protocol X1 {
  associatedtype Child: P3
    where Child.B == G<Child.A>
}

public protocol X2 {
  associatedtype Child: P3
    where Child.B == G<Child.A>, Child.A : P1
}
```

In the first example, there's no explicit `Child.A : P1` requirement. In the second, there was. Reformulating the original test case into the protocol requirement signature equivalent would still trigger the same IRGen crash with protocol X1, but not X2 in Swift 5.4:

```
public func caller21<T : X1>(_: T) {
  callee(T.Child.A.self)
}
```

# The conformance access path bug

There was a new implementation of conformance access paths in 5.5. It would skip recursing into the children of a conformance access path if its subject type was fixed to a concrete type. This is actually wrong because of exactly this case that we never tested: the witness table for `Child.A: P1` is recovered from `Child.B: P2`, and `Child.B` is a concrete type.

Concrete types were skipped here because the use of `getCanonicalTypeInContext()` would replace the type with its concrete type, but really what we want is the "canonical anchor", which is the most canonical type parameter of a type parameter (even if it happens to be concrete). After making that change a couple of redundant term/type round-trips become apparent, so simplifying the algorithm by using `Term` throughout fixes this problem.

# The IRGen bug

The final problem is revealed when IRGen attempts to recover the witness table from the conformance path `(Child: P3)(Self.B: P2)(Self.A: P1)`. The associated conformance access function for the final step `(Self.A : P1)` takes the metadata for `Child.B` together with the witness table for `Child.B : P2` as input. Since `Child.B` is concrete, IRGen would prefer to construct it directly, as the known concrete type `G<Child.A>`. The metadata for `G` is instantiated with the type metadata `Child.B` and the conformance `Child.A: P1`. Unfortunately, recovering `Child.A: P1` from the generic environment of `caller11()` requires recursively evaluating the same conformance access path that is being evaluated now.

However, IRGen can also recover `Child.B` from the conformance `Child: P3`, which is immediately available, and the metadata for `Child`, by calling the associated type metadata access function. This function also constructs `G<Child.A>`, however it does it from the concrete nominal type metadata for the `Child: P3` conformance, which must store `Child.A: P1`. By using abstract metadata access here, we avoid the circularity.

This last part is a bit of a hack because a more principled implementation would amend the conformance access path representation to encode access paths for each metadata component as well. I'll clean this up later.

# Next steps

If we do need to change back to the 5.4 ABI, we can bring back the "derived via concrete" check in the GSB, and try to simulate it in the requirement machine's in-progress minimization algorithm.

The added test case covers several variations of this pattern to ensure the minimized set of conformance requirements does not change again.

The "generating conformances" algorithm that I'm working on to replace the GSB's signature minimization builds a set of simultaneous equations relating conformance access paths algebraically, and uses this to find a minimal set. These equations also encode the information describing how to recover the type metadata for the subject type of a conformance requirement. By serializing this information in type metadata, we will in the future be able to recover witness tables using conformance access paths encoded in the mangling format, avoiding `swift_conformsToProtocol()` calls at runtime on newer deployment targets. This will build on @al45tair's work in https://github.com/apple/swift/pull/39246.

Fixes rdar://83687967.