### PR TITLE
Remove default argument from getContextualType

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3201,7 +3201,7 @@ public:
   /// for use in constraint solving, \c forConstraint should be set to \c true,
   /// which will ensure that unbound generics have been opened and placeholder
   /// types have been converted to type variables, etc.
-  Type getContextualType(ASTNode node, bool forConstraint = false) {
+  Type getContextualType(ASTNode node, bool forConstraint) {
     if (forConstraint) {
       auto known = contextualTypes.find(node);
       if (known == contextualTypes.end())

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6454,7 +6454,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
   // Diagnose conversions to invalid function types that couldn't be performed
   // beforehand because of placeholders.
   if (auto *fnTy = toType->getAs<FunctionType>()) {
-    auto contextTy = cs.getContextualType(expr);
+    auto contextTy = cs.getContextualType(expr, /*forConstraint=*/false);
     if (cs.getConstraintLocator(locator)->isForContextualType() && contextTy &&
         contextTy->hasPlaceholder()) {
       bool hadError = TypeChecker::diagnoseInvalidFunctionType(

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -132,7 +132,7 @@ protected:
 
   Type getContextualType(ASTNode anchor) const {
     auto &cs = getConstraintSystem();
-    return cs.getContextualType(anchor);
+    return cs.getContextualType(anchor, /*forConstraint=*/false);
   }
 
   TypeLoc getContextualTypeLoc(ASTNode anchor) const {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -398,7 +398,7 @@ getStructuralTypeContext(const Solution &solution, ConstraintLocator *locator) {
 
     auto &cs = solution.getConstraintSystem();
     auto anchor = locator->getAnchor();
-    auto contextualType = cs.getContextualType(anchor);
+    auto contextualType = cs.getContextualType(anchor, /*forConstraint=*/false);
     auto exprType = cs.getType(anchor);
     return std::make_tuple(contextualTypeElt->getPurpose(), exprType,
                            contextualType);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -564,8 +564,9 @@ namespace {
         return false;
 
       return isFavoredParamAndArg(CS, paramTy, argTy) &&
-             hasContextuallyFavorableResultType(fnTy,
-                                                CS.getContextualType(expr));
+             hasContextuallyFavorableResultType(
+                 fnTy,
+                 CS.getContextualType(expr, /*forConstraint=*/false));
     };
 
     favorCallOverloads(expr, CS, isFavoredDecl);
@@ -714,7 +715,7 @@ namespace {
       auto firstParamTy = params[0].getOldType();
       auto secondParamTy = params[1].getOldType();
 
-      auto contextualTy = CS.getContextualType(expr);
+      auto contextualTy = CS.getContextualType(expr, /*forConstraint=*/false);
 
       // Avoid favoring overloads that would require narrowing conversion
       // to match the arguments.
@@ -1709,7 +1710,7 @@ namespace {
         return Type();
 
       auto locator = CS.getConstraintLocator(expr);
-      auto contextualType = CS.getContextualType(expr);
+      auto contextualType = CS.getContextualType(expr, /*forConstraint=*/false);
       auto contextualPurpose = CS.getContextualTypePurpose(expr);
 
       auto joinElementTypes = [&](Optional<Type> elementType) {
@@ -1837,7 +1838,7 @@ namespace {
       auto valueAssocTy = dictionaryProto->getAssociatedType(C.Id_Value);
 
       auto locator = CS.getConstraintLocator(expr);
-      auto contextualType = CS.getContextualType(expr);
+      auto contextualType = CS.getContextualType(expr, /*forConstraint=*/false);
       auto contextualPurpose = CS.getContextualTypePurpose(expr);
 
       // If a contextual type exists for this expression and is a dictionary
@@ -1904,7 +1905,7 @@ namespace {
 
       // If no contextual type is present, Merge equivalence classes of key 
       // and value types as necessary.
-      if (!CS.getContextualType(expr)) {
+      if (!CS.getContextualType(expr, /*forConstraint=*/false)) {
         for (auto element1 : expr->getElements()) {
           for (auto element2 : expr->getElements()) {
             if (element1 == element2)
@@ -2068,7 +2069,13 @@ namespace {
             return resolvedTy;
         }
 
-        if (auto contextualType = CS.getContextualType(closure)) {
+        // Because we are only pulling out the result type from the contextual
+        // type, we avoid prematurely converting any inferrable types by setting
+        // forConstraint=false. Later on in inferClosureType we call
+        // replaceInferableTypesWithTypeVars before returning to ensure we don't
+        // introduce any placeholders into the constraint system.
+        if (auto contextualType =
+                CS.getContextualType(closure, /*forConstraint=*/false)) {
           if (auto fnType = contextualType->getAs<FunctionType>())
             return fnType->getResult();
         }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4949,7 +4949,8 @@ bool ConstraintSystem::repairFailures(
     // If `if` expression has a contextual type, let's consider it a source of
     // truth and produce a contextual mismatch instead of  per-branch failure,
     // because it's a better pointer than potential then-to-else type mismatch.
-    if (auto contextualType = getContextualType(anchor)) {
+    if (auto contextualType =
+            getContextualType(anchor, /*forConstraint=*/false)) {
       auto purpose = getContextualTypePurpose(anchor);
       if (contextualType->isEqual(rhs)) {
         auto *loc = getConstraintLocator(
@@ -6336,7 +6337,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     // If this is a `nil` literal, it would be a contextual failure.
     if (auto *Nil = getAsExpr<NilLiteralExpr>(anchor)) {
       auto *fixLocator = getConstraintLocator(
-          getContextualType(Nil)
+          getContextualType(Nil, /*forConstraint=*/false)
               ? locator.withPathElement(LocatorPathElt::ContextualType(
                     getContextualTypePurpose(Nil)))
               : locator);
@@ -9633,7 +9634,7 @@ ConstraintSystem::simplifyKeyPathConstraint(
     return SolutionKind::Error;
 
   // If the expression has contextual type information, try using that too.
-  if (auto contextualTy = getContextualType(keyPath)) {
+  if (auto contextualTy = getContextualType(keyPath, /*forConstraint=*/false)) {
     if (!tryMatchRootAndValueFromType(contextualTy))
       return SolutionKind::Error;
   }

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -877,7 +877,8 @@ void ConstraintSystem::shrink(Expr *expr) {
       // A dictionary expression is just a set of tuples; try to solve ones
       // that have overload sets.
       if (auto collectionExpr = dyn_cast<CollectionExpr>(expr)) {
-        visitCollectionExpr(collectionExpr, CS.getContextualType(expr),
+        visitCollectionExpr(collectionExpr,
+                            CS.getContextualType(expr, /*forConstraint=*/false),
                             CS.getContextualTypePurpose(expr));
         // Don't try to walk into the dictionary.
         return {false, expr};
@@ -950,7 +951,8 @@ void ConstraintSystem::shrink(Expr *expr) {
         if (Candidates.empty())
           return expr;
 
-        auto contextualType = CS.getContextualType(expr);
+        auto contextualType = CS.getContextualType(expr,
+                                                   /*forConstraint=*/false);
         // If there is a contextual type set for this expression.
         if (!contextualType.isNull()) {
           Candidates.push_back(Candidate(CS, PrimaryExpr, contextualType,

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3670,7 +3670,7 @@ static bool diagnoseAmbiguityWithContextualType(
   auto name = result->choices.front().getName();
   DE.diagnose(getLoc(anchor), diag::no_candidates_match_result_type,
               name.getBaseName().userFacingName(),
-              cs.getContextualType(anchor));
+              cs.getContextualType(anchor, /*forConstraint=*/false));
 
   for (const auto &solution : solutions) {
     auto overload = solution.getOverloadChoice(calleeLocator);
@@ -3685,7 +3685,8 @@ static bool diagnoseAmbiguityWithContextualType(
         auto fnType = type->castTo<FunctionType>();
         DE.diagnose(
             loc, diag::cannot_convert_candidate_result_to_contextual_type,
-            decl->getName(), fnType->getResult(), cs.getContextualType(anchor));
+            decl->getName(), fnType->getResult(),
+            cs.getContextualType(anchor, /*forConstraint=*/false));
       } else {
         DE.diagnose(loc, diag::found_candidate_type, type);
       }
@@ -3759,7 +3760,8 @@ static bool diagnoseAmbiguity(
     if (locator->isForContextualType()) {
       auto baseName = name.getBaseName();
       DE.diagnose(getLoc(commonAnchor), diag::no_candidates_match_result_type,
-                  baseName.userFacingName(), cs.getContextualType(anchor));
+                  baseName.userFacingName(),
+                  cs.getContextualType(anchor, /*forConstraint=*/false));
     } else if (name.isOperator()) {
       auto *anchor = castToExpr(commonCalleeLocator->getAnchor());
 

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -1153,7 +1153,7 @@ sawSolution(const constraints::Solution &S) {
   Type ExpectedTy = getTypeForCompletion(S, CompletionExpr);
   Expr *ParentExpr = CS.getParentExpr(CompletionExpr);
   if (!ParentExpr)
-    ExpectedTy = CS.getContextualType(CompletionExpr);
+    ExpectedTy = CS.getContextualType(CompletionExpr, /*forConstraint=*/false);
 
   auto *CalleeLocator = S.getCalleeLocator(Locator);
   ValueDecl *ReferencedDecl = nullptr;


### PR DESCRIPTION
#39412 added a distinction between contextual types as external to the constraint system, and contextual types as they should be used in constraints. We introduced the `forConstraint` argument with a default value to keep the PR focused on the issue at hand—this followup removes the default argument and audits the other locations where we call `getContextualType` to make sure that we are using the correct 'version' of the type.
