### PR TITLE
Add support for `availability` to `@_specialize`

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1302,7 +1302,8 @@ public:
 /// type list.
 class SpecializeAttr final
     : public DeclAttribute,
-      private llvm::TrailingObjects<SpecializeAttr, Identifier> {
+      private llvm::TrailingObjects<SpecializeAttr, Identifier,
+                                    AvailableAttr *> {
   friend class SpecializeAttrTargetDeclRequest;
   friend TrailingObjects;
 
@@ -1321,35 +1322,44 @@ private:
   LazyMemberLoader *resolver = nullptr;
   uint64_t resolverContextData;
   size_t numSPIGroups;
+  size_t numAvailableAttrs;
 
   SpecializeAttr(SourceLoc atLoc, SourceRange Range,
                  TrailingWhereClause *clause, bool exported,
                  SpecializationKind kind, GenericSignature specializedSignature,
-                 DeclNameRef targetFunctionName,
-                 ArrayRef<Identifier> spiGroups);
+                 DeclNameRef targetFunctionName, ArrayRef<Identifier> spiGroups,
+                 ArrayRef<AvailableAttr *> availabilityAttrs);
 
 public:
-  static SpecializeAttr *create(ASTContext &Ctx, SourceLoc atLoc,
-                                SourceRange Range, TrailingWhereClause *clause,
-                                bool exported, SpecializationKind kind,
-                                DeclNameRef targetFunctionName,
-                                ArrayRef<Identifier> spiGroups,
-                                GenericSignature specializedSignature
-                                    = nullptr);
+  static SpecializeAttr *
+  create(ASTContext &Ctx, SourceLoc atLoc, SourceRange Range,
+         TrailingWhereClause *clause, bool exported, SpecializationKind kind,
+         DeclNameRef targetFunctionName, ArrayRef<Identifier> spiGroups,
+         ArrayRef<AvailableAttr *> availabilityAttrs,
+         GenericSignature specializedSignature = nullptr);
 
   static SpecializeAttr *create(ASTContext &ctx, bool exported,
                                 SpecializationKind kind,
                                 ArrayRef<Identifier> spiGroups,
+                                ArrayRef<AvailableAttr *> availabilityAttrs,
                                 GenericSignature specializedSignature,
                                 DeclNameRef replacedFunction);
 
   static SpecializeAttr *create(ASTContext &ctx, bool exported,
                                 SpecializationKind kind,
                                 ArrayRef<Identifier> spiGroups,
+                                ArrayRef<AvailableAttr *> availabilityAttrs,
                                 GenericSignature specializedSignature,
                                 DeclNameRef replacedFunction,
                                 LazyMemberLoader *resolver, uint64_t data);
 
+  size_t numTrailingObjects(OverloadToken<Identifier>) const {
+    return numSPIGroups;
+  }
+
+  size_t numTrailingObjects(OverloadToken<AvailableAttr *>) const {
+    return numAvailableAttrs;
+  }
   /// Name of SPIs declared by the attribute.
   ///
   /// Note: A single SPI name per attribute is currently supported but this
@@ -1357,6 +1367,11 @@ public:
   ArrayRef<Identifier> getSPIGroups() const {
     return { this->template getTrailingObjects<Identifier>(),
              numSPIGroups };
+  }
+
+  ArrayRef<AvailableAttr *> getAvailabeAttrs() const {
+    return {this->template getTrailingObjects<AvailableAttr *>(),
+            numAvailableAttrs};
   }
 
   TrailingWhereClause *getTrailingWhereClause() const;

--- a/include/swift/AST/Availability.h
+++ b/include/swift/AST/Availability.h
@@ -316,6 +316,9 @@ public:
   static Optional<AvailabilityContext> annotatedAvailableRange(const Decl *D,
                                                                ASTContext &C);
 
+  static AvailabilityContext
+    annotatedAvailableRangeForAttr(const SpecializeAttr* attr, ASTContext &ctx);
+
 };
 
 } // end namespace swift

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1399,6 +1399,9 @@ ERROR(attr_expected_lparen,none,
 ERROR(attr_expected_rparen,none,
 "expected ')' in '%0' %select{attribute|modifier}1", (StringRef, bool))
 
+ERROR(attr_expected_semi,none,
+"expected ';' in '%0' %select{attribute|modifier}1", (StringRef, bool))
+
 ERROR(attr_expected_comma,none,
 "expected ',' in '%0' %select{attribute|modifier}1", (StringRef, bool))
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1049,7 +1049,7 @@ public:
   /// \p Attr is where to store the parsed attribute
   bool parseSpecializeAttribute(
       swift::tok ClosingBrace, SourceLoc AtLoc, SourceLoc Loc,
-      SpecializeAttr *&Attr,
+      SpecializeAttr *&Attr, AvailabilityContext *SILAvailability,
       llvm::function_ref<bool(Parser &)> parseSILTargetName =
           [](Parser &) { return false; },
       llvm::function_ref<bool(Parser &)> parseSILSIPModule =
@@ -1060,6 +1060,7 @@ public:
       swift::tok ClosingBrace, bool &DiscardAttribute, Optional<bool> &Exported,
       Optional<SpecializeAttr::SpecializationKind> &Kind,
       TrailingWhereClause *&TrailingWhereClause, DeclNameRef &targetFunction,
+      AvailabilityContext *SILAvailability,
       SmallVectorImpl<Identifier> &spiGroups,
       SmallVectorImpl<AvailableAttr *> &availableAttrs,
       llvm::function_ref<bool(Parser &)> parseSILTargetName,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1061,6 +1061,7 @@ public:
       Optional<SpecializeAttr::SpecializationKind> &Kind,
       TrailingWhereClause *&TrailingWhereClause, DeclNameRef &targetFunction,
       SmallVectorImpl<Identifier> &spiGroups,
+      SmallVectorImpl<AvailableAttr *> &availableAttrs,
       llvm::function_ref<bool(Parser &)> parseSILTargetName,
       llvm::function_ref<bool(Parser &)> parseSILSIPModule);
 
@@ -1850,7 +1851,11 @@ public:
   parsePlatformVersionConstraintSpec();
   ParserResult<PlatformAgnosticVersionConstraintAvailabilitySpec>
   parsePlatformAgnosticVersionConstraintSpec();
-
+  bool
+  parseAvailability(bool parseAsPartOfSpecializeAttr, StringRef AttrName,
+                    bool &DiscardAttribute, SourceRange &attrRange,
+                    SourceLoc AtLoc, SourceLoc Loc,
+                    llvm::function_ref<void(AvailableAttr *)> addAttribute);
   //===--------------------------------------------------------------------===//
   // Code completion second pass.
 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -72,7 +72,8 @@ public:
                                    GenericSignature specializedSignature,
                                    bool exported, SpecializationKind kind,
                                    SILFunction *target, Identifier spiGroup,
-                                   const ModuleDecl *spiModule);
+                                   const ModuleDecl *spiModule,
+                                   AvailabilityContext availability);
 
   bool isExported() const {
     return exported;
@@ -110,6 +111,10 @@ public:
     return spiModule;
   }
 
+  AvailabilityContext getAvailability() const {
+    return availability;
+  }
+
   void print(llvm::raw_ostream &OS) const;
 
 private:
@@ -117,13 +122,15 @@ private:
   bool exported;
   GenericSignature specializedSignature;
   Identifier spiGroup;
+  AvailabilityContext availability;
   const ModuleDecl *spiModule = nullptr;
   SILFunction *F = nullptr;
   SILFunction *targetFunction = nullptr;
 
   SILSpecializeAttr(bool exported, SpecializationKind kind,
                     GenericSignature specializedSignature, SILFunction *target,
-                    Identifier spiGroup, const ModuleDecl *spiModule);
+                    Identifier spiGroup, const ModuleDecl *spiModule,
+                    AvailabilityContext availability);
 };
 
 /// SILFunction - A function body that has been lowered to SIL. This consists of

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -595,8 +595,10 @@ bool Parser::parseSpecializeAttributeArguments(
       auto ParamLabel = Tok.getText();
       SyntaxParsingContext ArgumentContext(
           SyntaxContext, ParamLabel == "target"
-                             ? SyntaxKind::TargetFunctionEntry
-                             : SyntaxKind::LabeledSpecializeEntry);
+                             ? SyntaxKind::TargetFunctionEntry :
+                             (ParamLabel == "availability" ?
+                              SyntaxKind::AvailabilityEntry
+                              : SyntaxKind::LabeledSpecializeEntry));
       if (ParamLabel != "exported" && ParamLabel != "kind" &&
           ParamLabel != "target" && ParamLabel != "spi" &&
           ParamLabel != "spiModule" && ParamLabel != "availability") {

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -40,9 +40,10 @@ STATISTIC(MaxBitfieldID, "Max value of SILFunction::currentBitfieldID");
 SILSpecializeAttr::SILSpecializeAttr(bool exported, SpecializationKind kind,
                                      GenericSignature specializedSig,
                                      SILFunction *target, Identifier spiGroup,
-                                     const ModuleDecl *spiModule)
+                                     const ModuleDecl *spiModule,
+                                     AvailabilityContext availability)
     : kind(kind), exported(exported), specializedSignature(specializedSig),
-      spiGroup(spiGroup), spiModule(spiModule), targetFunction(target) {
+      spiGroup(spiGroup), availability(availability), spiModule(spiModule), targetFunction(target) {
   if (targetFunction)
     targetFunction->incrementRefCount();
 }
@@ -51,10 +52,11 @@ SILSpecializeAttr *
 SILSpecializeAttr::create(SILModule &M, GenericSignature specializedSig,
                           bool exported, SpecializationKind kind,
                           SILFunction *target, Identifier spiGroup,
-                          const ModuleDecl *spiModule) {
+                          const ModuleDecl *spiModule,
+                          AvailabilityContext availability) {
   void *buf = M.allocate(sizeof(SILSpecializeAttr), alignof(SILSpecializeAttr));
   return ::new (buf) SILSpecializeAttr(exported, kind, specializedSig, target,
-                                       spiGroup, spiModule);
+                                       spiGroup, spiModule, availability);
 }
 
 void SILFunction::addSpecializeAttr(SILSpecializeAttr *Attr) {

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -80,17 +80,20 @@ void SILFunctionBuilder::addFunctionAttributes(
     if (hasSPI) {
       spiGroupIdent = spiGroups[0];
     }
+    auto availability =
+      AvailabilityInference::annotatedAvailableRangeForAttr(SA,
+         M.getSwiftModule()->getASTContext());
     if (targetFunctionDecl) {
       SILDeclRef declRef(targetFunctionDecl, constant.kind, false);
       targetFunction = getOrCreateDeclaration(targetFunctionDecl, declRef);
       F->addSpecializeAttr(SILSpecializeAttr::create(
           M, SA->getSpecializedSignature(), SA->isExported(), kind,
           targetFunction, spiGroupIdent,
-          attributedFuncDecl->getModuleContext()));
+          attributedFuncDecl->getModuleContext(), availability));
     } else {
       F->addSpecializeAttr(SILSpecializeAttr::create(
           M, SA->getSpecializedSignature(), SA->isExported(), kind, nullptr,
-          spiGroupIdent, attributedFuncDecl->getModuleContext()));
+          spiGroupIdent, attributedFuncDecl->getModuleContext(), availability));
     }
   }
 

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3711,6 +3711,10 @@ void SILSpecializeAttr::print(llvm::raw_ostream &OS) const {
   if (targetFunction) {
     OS << "target: \"" << targetFunction->getName() << "\", ";
   }
+ if (!availability.isAlwaysAvailable()) {
+    auto version = availability.getOSVersion().getLowerEndpoint();
+    OS << "available: " << version.getAsString() << ", ";
+  }
   if (!requirements.empty()) {
     OS << "where ";
     SILFunction *F = getFunction();

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -2209,9 +2209,12 @@ static void transferSpecializeAttributeTargets(SILGenModule &SGM, SILModule &M,
       if (hasSPIGroup) {
         spiGroupIdent = spiGroups[0];
       }
+      auto availability =
+        AvailabilityInference::annotatedAvailableRangeForAttr(SA,
+                                                              M.getSwiftModule()->getASTContext());
       targetSILFunction->addSpecializeAttr(SILSpecializeAttr::create(
           M, SA->getSpecializedSignature(), SA->isExported(), kind, nullptr,
-          spiGroupIdent, vd->getModuleContext()));
+          spiGroupIdent, vd->getModuleContext(), availability));
     }
   }
 }

--- a/lib/SILOptimizer/Transforms/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/EagerSpecializer.cpp
@@ -794,6 +794,7 @@ static SILFunction *eagerSpecialize(SILOptFunctionBuilder &FuncBuilder,
   } else if (SA.isExported()) {
     NewFunc->setLinkage(NewFunc->isDefinition() ? SILLinkage::Public
                                                 : SILLinkage::PublicExternal);
+    NewFunc->setAvailabilityForLinkage(SA.getAvailability());
   }
 
   return NewFunc;

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -2485,6 +2485,19 @@ usePrespecialized(SILOptFunctionBuilder &funcBuilder, ApplySite apply,
           !currentModule->isImportedAsSPI(spiGroup, funcModule))
         continue;
     }
+    // Check whether the availability of the specialization allows for using
+    // it. We check the  deployment target or the current functions availability
+    // target depending which one is more recent.
+    auto specializationAvail = SA->getAvailability();
+    auto &ctxt = funcBuilder.getModule().getSwiftModule()->getASTContext();
+    auto deploymentAvail = AvailabilityContext::forDeploymentTarget(ctxt);
+    auto currentFnAvailability = apply.getFunction()->getAvailabilityForLinkage();
+    if (!currentFnAvailability.isAlwaysAvailable() &&
+        !deploymentAvail.isContainedIn(currentFnAvailability))
+      deploymentAvail = currentFnAvailability;
+    if (!deploymentAvail.isContainedIn(specializationAvail))
+      continue;
+
     ReabstractionInfo reInfo(funcBuilder.getModule().getSwiftModule(),
                              funcBuilder.getModule().isWholeModule(), refF,
                              SA->getSpecializedSignature(),
@@ -2499,7 +2512,10 @@ usePrespecialized(SILOptFunctionBuilder &funcBuilder, ApplySite apply,
         mangler.mangleReabstracted(subs, reInfo.needAlternativeMangling());
 
     prespecializedReInfo = reInfo;
-    return lookupOrCreatePrespecialization(funcBuilder, refF, name, reInfo);
+    auto fn = lookupOrCreatePrespecialization(funcBuilder, refF, name, reInfo);
+    if (!specializationAvail.isAlwaysAvailable())
+      fn->setAvailabilityForLinkage(specializationAvail);
+    return fn;
   }
   return nullptr;
 }

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -725,9 +725,11 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     IdentifierID targetFunctionID;
     IdentifierID spiGroupID;
     ModuleID spiModuleID;
+    unsigned LIST_VER_TUPLE_PIECES(available);
     SILSpecializeAttrLayout::readRecord(
         scratch, exported, specializationKindVal, specializedSigID,
-        targetFunctionID, spiGroupID, spiModuleID);
+        targetFunctionID, spiGroupID, spiModuleID,
+        LIST_VER_TUPLE_PIECES(available));
 
     SILFunction *target = nullptr;
     if (targetFunctionID) {
@@ -745,13 +747,19 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
         specializationKindVal ? SILSpecializeAttr::SpecializationKind::Partial
                               : SILSpecializeAttr::SpecializationKind::Full;
 
+    llvm::VersionTuple available;
+    DECODE_VER_TUPLE(available);
+    auto availability = available.empty()
+      ? AvailabilityContext::alwaysAvailable()
+      : AvailabilityContext(VersionRange::allGTE(available));
+
     auto specializedSig = MF->getGenericSignature(specializedSigID);
     // Only add the specialize attributes once.
     if (shouldAddAtttributes) {
       // Read the substitution list and construct a SILSpecializeAttr.
       fn->addSpecializeAttr(SILSpecializeAttr::create(
           SILMod, specializedSig, exported != 0, specializationKind, target,
-          spiGroup, spiModule));
+          spiGroup, spiModule, availability));
     }
   }
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 631; // IS_OSSA
+const uint16_t SWIFTMODULE_VERSION_MINOR = 632; // _specialize availability
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1933,15 +1933,16 @@ namespace decls_block {
   >;
 
   using SpecializeDeclAttrLayout = BCRecordLayout<
-    Specialize_DECL_ATTR,
-    BCFixed<1>, // exported flag
-    BCFixed<1>, // specialization kind
-    GenericSignatureIDField, // specialized signature
-    DeclIDField, // target function
-    BCVBR<4>,   // # of arguments (+1) or 1 if simple decl name, 0 if no target
-    BCVBR<4>,   // # of SPI groups
-    BCArray<IdentifierIDField> // target function pieces, spi groups
-  >;
+      Specialize_DECL_ATTR,
+      BCFixed<1>,              // exported flag
+      BCFixed<1>,              // specialization kind
+      GenericSignatureIDField, // specialized signature
+      DeclIDField,             // target function
+      BCVBR<4>, // # of arguments (+1) or 1 if simple decl name, 0 if no target
+      BCVBR<4>, // # of SPI groups
+      BCVBR<4>, // # of availability attributes
+      BCArray<IdentifierIDField> // target function pieces, spi groups
+      >;
 
   using DifferentiableDeclAttrLayout = BCRecordLayout<
     Differentiable_DECL_ATTR,

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -309,7 +309,8 @@ namespace sil_block {
                      GenericSignatureIDField, // specialized signature
                      DeclIDField, // Target SILFunction name or 0.
                      DeclIDField,  // SPIGroup or 0.
-                     DeclIDField // SPIGroup Module name id.
+                     DeclIDField, // SPIGroup Module name id.
+                     BC_AVAIL_TUPLE // Availability
                      >;
 
   // Has an optional argument list where each argument is a typed valueref.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3114,12 +3114,15 @@ public:
   }
 
   void noteUseOfExportedPrespecialization(const AbstractFunctionDecl *afd) {
+    bool hasNoted = false;
     for (auto *A : afd->getAttrs().getAttributes<SpecializeAttr>()) {
       auto *SA = cast<SpecializeAttr>(A);
       if (!SA->isExported())
         continue;
       if (auto *targetFunctionDecl = SA->getTargetFunctionDecl(afd)) {
-        exportedPrespecializationDecls.push_back(S.addDeclRef(afd));
+        if (!hasNoted)
+          exportedPrespecializationDecls.push_back(S.addDeclRef(afd));
+        hasNoted = true;
       }
     }
   }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2593,12 +2593,16 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       auto numSPIGroups = attr->getSPIGroups().size();
       assert(pieces.size() == numArgs + numSPIGroups ||
              pieces.size() == (numArgs - 1 + numSPIGroups));
-
+      auto numAvailabilityAttrs = attr->getAvailabeAttrs().size();
       SpecializeDeclAttrLayout::emitRecord(
           S.Out, S.ScratchRecord, abbrCode, (unsigned)attr->isExported(),
           (unsigned)attr->getSpecializationKind(),
           S.addGenericSignatureRef(attr->getSpecializedSignature()),
-          S.addDeclRef(targetFunDecl), numArgs, numSPIGroups, pieces);
+          S.addDeclRef(targetFunDecl), numArgs, numSPIGroups,
+          numAvailabilityAttrs, pieces);
+      for (auto availAttr : attr->getAvailabeAttrs()) {
+        writeDeclAttribute(D, availAttr);
+      }
       return;
     }
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -509,11 +509,18 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
       spiGroupID = S.addUniquedStringRef(ident.str());
       spiModuleDeclID = S.addModuleRef(SA->getSPIModule());
     }
+    auto availability = SA->getAvailability();
+    if (!availability.isAlwaysAvailable()) {
+      available = availability.getOSVersion().getLowerEndpoint();
+    }
+    ENCODE_VER_TUPLE(available, available)
+
     SILSpecializeAttrLayout::emitRecord(
         Out, ScratchRecord, specAttrAbbrCode, (unsigned)SA->isExported(),
         (unsigned)SA->getSpecializationKind(),
         S.addGenericSignatureRef(SA->getSpecializedSignature()),
-        targetFunctionNameID, spiGroupID, spiModuleDeclID);
+        targetFunctionNameID, spiGroupID, spiModuleDeclID,
+        LIST_VER_TUPLE_PIECES(available));
   }
 
   // Assign a unique ID to each basic block of the SILFunction.

--- a/test/ModuleInterface/availability-expansion.swift
+++ b/test/ModuleInterface/availability-expansion.swift
@@ -27,3 +27,8 @@ public func onMyProjectV1() {}
 public func onMyProjectV2_5() {}
 // CHECK: @available(macOS 10.12, *)
 // CHECK-NEXT: public func onMyProjectV2_5
+
+@_specialize(exported: true, availability: SwiftStdlib 5.5, *; where T == Int)
+public func testSemanticsAvailability<T>(_ t: T) {}
+// CHECK: @_specialize(exported: true, kind: full, availability: macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *; where T == Swift.Int)
+// CHECK-NEXT: public func testSemanticsAvailability

--- a/test/SIL/Parser/available.sil
+++ b/test/SIL/Parser/available.sil
@@ -25,3 +25,11 @@ sil [available 123.321.444] @version_subminor : $@convention(thin) () -> ()
 
 // CHECK-LABEL: sil [weak_imported] @weak_func : $@convention(thin) () -> ()
 sil [weak_imported] @weak_func : $@convention(thin) () -> ()
+
+public struct SomeData {}
+
+// CHECK-LABEL: sil [_specialize exported: true, kind: full, available: 10.50, where T == SomeData] @specialize_availability : $@convention(thin) <T> (@in_guaranteed T) -> ()
+sil [_specialize exported: true, kind: full, available: 10.50, where T == SomeData] @specialize_availability : $@convention(thin) <T> (@in_guaranteed T) -> () {
+entry(%0 : $*T):
+  return undef: $()
+}

--- a/test/SIL/Serialization/available.sil
+++ b/test/SIL/Serialization/available.sil
@@ -7,6 +7,14 @@
 
 import Builtin
 
+public struct SomeData {}
+
+// CHECK-LABEL: sil [serialized] [_specialize exported: true, kind: full, available: 10.50, where T == SomeData] @specialize_availability : $@convention(thin) <T> (@in_guaranteed T) -> ()
+sil [serialized] [_specialize exported: true, kind: full, available: 10.50, where T == SomeData] @specialize_availability : $@convention(thin) <T> (@in_guaranteed T) -> () {
+bb0(%0 : $*T):
+  return undef : $()
+}
+
 // CHECK-LABEL: sil [serialized] [weak_imported] @weak_func : $@convention(thin) () -> ()
 sil [serialized] [weak_imported] @weak_func : $@convention(thin) () -> () {
 bb0:

--- a/test/SILGen/Inputs/specialize_attr_module2.swift
+++ b/test/SILGen/Inputs/specialize_attr_module2.swift
@@ -2,6 +2,7 @@ import A
 
 extension PublicThing {
   @_specialize(exported: true, kind: full, target: doStuffWith(_:), where T == Int)
+  @_specialize(exported: true, kind: full, target: doStuffWith(_:), availability: macOS 10.50, *; where T == Int16)
   public func specializedoStuff2(_ t: T) {}
 }
 

--- a/test/SILGen/availability_attribute.swift
+++ b/test/SILGen/availability_attribute.swift
@@ -34,3 +34,7 @@ public struct AvailableStruct {
         public func availableNestedMethod() {}
     }
 }
+
+@_specialize(exported: true, availability: macOS 11, iOS 13, *; where T == Int)
+//@_specialize(exported: true, where T == Int)
+public func testAvailability<T>(_ t: T) {}

--- a/test/SILGen/availability_attribute.swift
+++ b/test/SILGen/availability_attribute.swift
@@ -35,6 +35,6 @@ public struct AvailableStruct {
     }
 }
 
-@_specialize(exported: true, availability: macOS 11, iOS 13, *; where T == Int)
-//@_specialize(exported: true, where T == Int)
+@_specialize(exported: true, availability: macOS 10.50, iOS 13, *; where T == Int)
+// CHECK-LABEL: sil [_specialize exported: true, kind: full, available: 10.50, where T == Int] [ossa] @$s22availability_attribute16testAvailabilityyyxlF
 public func testAvailability<T>(_ t: T) {}

--- a/test/SILGen/specialize_attr.swift
+++ b/test/SILGen/specialize_attr.swift
@@ -2,21 +2,21 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -module-name A -emit-module-path %t/A.swiftmodule -enable-library-evolution -swift-version 5 %S/Inputs/specialize_attr_module.swift
 // RUN: %target-swift-frontend -I %t -module-name B -emit-module-path %t/B.swiftmodule -enable-library-evolution -swift-version 5 %S/Inputs/specialize_attr_module2.swift
-// RUN: %target-swift-emit-silgen -I %t -module-name specialize_attr -emit-verbose-sil %s -swift-version 5 | %FileCheck %s
+// RUN: %target-swift-emit-silgen -I %t -module-name specialize_attr -emit-verbose-sil %s -swift-version 5 | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-%target-os
 // RUN: %target-swift-emit-sil -I %t -sil-verify-all -O -module-name specialize_attr -emit-verbose-sil %s | %FileCheck -check-prefix=CHECK-OPT -check-prefix=CHECK-OPT-EVO %s
 
 // Test .swiftinterface
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o /dev/null -module-name A -emit-module-interface-path %t/A.swiftinterface -enable-library-evolution -swift-version 5 %S/Inputs/specialize_attr_module.swift
 // RUN: %target-swift-frontend -emit-module -o /dev/null -I %t -module-name B -emit-module-interface-path %t/B.swiftinterface -enable-library-evolution -swift-version 5 %S/Inputs/specialize_attr_module2.swift
-// RUN: %target-swift-emit-silgen -I %t -module-name specialize_attr -emit-verbose-sil %s -swift-version 5 | %FileCheck %s
+// RUN: %target-swift-emit-silgen -I %t -module-name specialize_attr -emit-verbose-sil %s -swift-version 5 | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-%target-os
 // RUN: %target-swift-emit-sil -I %t -sil-verify-all -O -module-name specialize_attr -emit-verbose-sil %s | %FileCheck -check-prefix=CHECK-OPT -check-prefix=CHECK-OPT-EVO %s
 
 // Test .swiftmodule without library-evolution
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -module-name A -emit-module-path %t/A.swiftmodule -swift-version 5 %S/Inputs/specialize_attr_module.swift
 // RUN: %target-swift-frontend -I %t -module-name B -emit-module-path %t/B.swiftmodule -swift-version 5 %S/Inputs/specialize_attr_module2.swift
-// RUN: %target-swift-emit-silgen -I %t -module-name specialize_attr -emit-verbose-sil %s -swift-version 5 | %FileCheck %s
+// RUN: %target-swift-emit-silgen -I %t -module-name specialize_attr -emit-verbose-sil %s -swift-version 5 | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-%target-os
 // RUN: %target-swift-emit-sil -I %t -sil-verify-all -O -module-name specialize_attr -emit-verbose-sil %s | %FileCheck -check-prefix=CHECK-OPT -check-prefix=CHECK-OPT-NOEVO %s
 
 import A
@@ -124,7 +124,8 @@ public struct CC2<T : PP> {
 }
 
 // Import from module A and B.
-// CHECK-LABEL: sil [serialized] [_specialize exported: true, kind: full, where T == Double] [_specialize exported: true, kind: full, where T == Int] @$s1A11PublicThingV11doStuffWithyyxF : $@convention(method) <τ_0_0> (@in_guaranteed τ_0_0, PublicThing<τ_0_0>) -> ()
+// CHECK-macosx-LABEL: sil [serialized] [_specialize exported: true, kind: full, where T == Double] [_specialize exported: true, kind: full, available: 10.50, where T == Int16] [_specialize exported: true, kind: full, where T == Int] @$s1A11PublicThingV11doStuffWithyyxF : $@convention(method) <τ_0_0> (@in_guaranteed τ_0_0, PublicThing<τ_0_0>) -> ()
+// CHECK-linux-gnu-LABEL: sil [serialized] [_specialize exported: true, kind: full, where T == Double] [_specialize exported: true, kind: full, where T == Int16] [_specialize exported: true, kind: full, where T == Int] @$s1A11PublicThingV11doStuffWithyyxF : $@convention(method) <τ_0_0> (@in_guaranteed τ_0_0, PublicThing<τ_0_0>) -> ()
 // CHECK-LABEL: sil [serialized] [_specialize exported: true, kind: full, where T == Double] [_specialize exported: true, kind: full, where T == Int] @$s1A13InternalThingV11doStuffWith5boxedyAA05BoxedB0VyxG_tF : $@convention(method) <τ_0_0> (BoxedThing<τ_0_0>, InternalThing<τ_0_0>) -> ()
 
 // CHECK-DAG: sil [serialized] [_specialize exported: true, kind: full, where T == Int] @$s1A14InternalThing2V9computedZxvM : $@yield_once @convention(method) <τ_0_0> (@inout InternalThing2<τ_0_0>) -> @yields @inout τ_0_0

--- a/test/SILOptimizer/Inputs/pre_specialized_module.swift
+++ b/test/SILOptimizer/Inputs/pre_specialized_module.swift
@@ -1,7 +1,19 @@
+@frozen
+public struct SomeData {
+  public init() {}
+}
+
 @_specialize(exported: true, where T == Int)
 @_specialize(exported: true, where T == Double)
+@_specialize(exported: true, availability: macOS 10.50, *; where T == SomeData)
 public func publicPrespecialized<T>(_ t: T) {
 }
+
+@_specialize(exported: true, where T == Int)
+@_specialize(exported: true, availability: macOS 10.50, *; where T == SomeData)
+@inlinable
+@inline(never)
+public func publicPrespecialized2<T>(_ t: T) { }
 
 @_specialize(exported: true, where T == Int)
 @_specialize(exported: true, where T == Double)

--- a/test/SILOptimizer/Inputs/pre_specialized_module2.swift
+++ b/test/SILOptimizer/Inputs/pre_specialized_module2.swift
@@ -1,0 +1,10 @@
+import pre_specialized_module
+
+@frozen
+public struct SomeOtherData {
+  public init() {}
+}
+
+@_specialize(exported: true, target: publicPrespecialized2(_:), availability: macOS 10.50, *; where T == SomeOtherData)
+public func pre_specialize_publicPrespecialized<T>(_ t: T) {
+}

--- a/test/SILOptimizer/pre_specialize-macos.swift
+++ b/test/SILOptimizer/pre_specialize-macos.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -O -swift-version 5 -enable-library-evolution -emit-module -o /dev/null -emit-module-interface-path %t/pre_specialized_module.swiftinterface %S/Inputs/pre_specialized_module.swift -module-name pre_specialized_module
+// RUN: %target-swift-frontend -I %t -O -swift-version 5 -enable-library-evolution -emit-module -o /dev/null -emit-module-interface-path %t/pre_specialized_module2.swiftinterface %S/Inputs/pre_specialized_module2.swift -module-name pre_specialized_module2
+// RUN: %target-swift-frontend -I %t -O -emit-sil -target x86_64-apple-macos11 %s | %FileCheck %s --check-prefix=OPT --check-prefix=CHECK
+// RUN: %target-swift-frontend -I %t -O -emit-sil -target x86_64-apple-macosx10.9 %s | %FileCheck %s --check-prefix=NOOPT --check-prefix=CHECK
+
+// REQUIRES: OS=macosx
+
+import pre_specialized_module
+import pre_specialized_module2
+
+// OPT: sil [available 10.50] [noinline] @$s22pre_specialized_module21publicPrespecialized2yyxlFAA8SomeDataV_Ts5 : $@convention(thin) (SomeData) -> ()
+// OPT: sil [available 10.50] [noinline] @$s22pre_specialized_module21publicPrespecialized2yyxlF0a1_B8_module213SomeOtherDataV_Ts5 : $@convention(thin) (SomeOtherData) -> ()
+
+// CHECK: sil @$s4main28usePrespecializedEntryPointsyyF : $@convention(thin) () -> () {
+// OPT:  [[F1:%.*]] = function_ref @$s22pre_specialized_module21publicPrespecialized2yyxlFAA8SomeDataV_Ts5 : $@convention(thin) (SomeData) -> ()
+// OPT:  apply [[F1]](
+// OPT:  [[F2:%.*]] = function_ref @$s22pre_specialized_module21publicPrespecialized2yyxlF0a1_B8_module213SomeOtherDataV_Ts5 : $@convention(thin) (SomeOtherData) -> ()
+// OPT:  apply [[F2]](
+// In the no prespecialization case we get regular generic specialization
+// because the function is inlinable.
+// NOOPT:  [[F1:%.*]] = function_ref @$s22pre_specialized_module21publicPrespecialized2yyxlFAA8SomeDataV_Tg5Tf4d_n : $@convention(thin) () -> ()
+// NOOPT:  apply [[F1]]()
+// NOOPT:  [[F2:%.*]] = function_ref @$s22pre_specialized_module21publicPrespecialized2yyxlF0a1_B8_module213SomeOtherDataV_Tg5Tf4d_n : $@convention(thin) () -> ()
+// NOOPT:  apply [[F2]]()
+// CHECK: } // end sil function '$s4main28usePrespecializedEntryPointsyyF'
+public func usePrespecializedEntryPoints() {
+  publicPrespecialized2(SomeData())
+  publicPrespecialized2(SomeOtherData())
+}

--- a/test/SILOptimizer/pre_specialize.swift
+++ b/test/SILOptimizer/pre_specialize.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/pre_specialized_module.swiftmodule %S/Inputs/pre_specialized_module.swift
-// RUN: %target-swift-frontend -I %t -O -emit-sil %s | %FileCheck %s --check-prefix=OPT
-// RUN: %target-swift-frontend -I %t -Onone -emit-sil %s | %FileCheck %s --check-prefix=NONE
+// RUN: %target-swift-frontend -I %t -O -emit-sil %s | %FileCheck %s --check-prefix=OPT -check-prefix=OPT-%target-os
+// RUN: %target-swift-frontend -I %t -Onone -emit-sil %s | %FileCheck %s --check-prefix=NONE -check-prefix=NONE-%target-os
 
 
 // RUN: %empty-directory(%t)
@@ -13,33 +13,41 @@
 // RUN: %target-swift-frontend -I %t -O -emit-sil %s | %FileCheck %s --check-prefix=OPT
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -O -swift-version 5 -enable-library-evolution -emit-module -o /dev/null -emit-module-interface-path %t/pre_specialized_module.swiftinterface %S/Inputs/pre_specialized_module.swift
+// RUN: %target-swift-frontend -O -swift-version 5 -enable-library-evolution -emit-module -o /dev/null -emit-module-interface-path %t/pre_specialized_module.swiftinterface %S/Inputs/pre_specialized_module.swift -module-name pre_specialized_module
 // RUN: %target-swift-frontend -I %t -O -emit-sil %s | %FileCheck %s --check-prefix=OPT
 
 import pre_specialized_module
 
 // Make sure we generate the public pre-specialized entry points.
 
-// OPT: sil @$s14pre_specialize10testPublic1tyx_tlFSf_Ts5 : $@convention(thin) (Float) -> () {
-// OPT: sil @$s14pre_specialize10testPublic1tyx_tlFSi_Ts5 : $@convention(thin) (Int) -> () {
+// OPT-DAG: sil @$s14pre_specialize10testPublic1tyx_tlFSf_Ts5 : $@convention(thin) (Float) -> () {
+// OPT-DAG: sil @$s14pre_specialize10testPublic1tyx_tlFSi_Ts5 : $@convention(thin) (Int) -> () {
+// OPT-macosx-DAG: sil [available 10.5] @$s14pre_specialize10testPublic1tyx_tlFSd_Ts5 : $@convention(thin) (Double) -> () {
+// OPT-linux-gnu-DAG: sil @$s14pre_specialize10testPublic1tyx_tlFSd_Ts5 : $@convention(thin) (Double) -> () {
 
-// NONE: sil @$s14pre_specialize10testPublic1tyx_tlFSf_Ts5 : $@convention(thin) (Float) -> () {
-// NONE: sil @$s14pre_specialize10testPublic1tyx_tlFSi_Ts5 : $@convention(thin) (Int) -> () {
+// NONE-DAG: sil @$s14pre_specialize10testPublic1tyx_tlFSf_Ts5 : $@convention(thin) (Float) -> () {
+// NONE-DAG: sil @$s14pre_specialize10testPublic1tyx_tlFSi_Ts5 : $@convention(thin) (Int) -> () {
+// NONE-macosx-DAG: sil [available 10.5] @$s14pre_specialize10testPublic1tyx_tlFSd_Ts5 : $@convention(thin) (Double) -> () {
+// NONE-linux-gnu-DAG: sil @$s14pre_specialize10testPublic1tyx_tlFSd_Ts5 : $@convention(thin) (Double) -> () {
 
 @_specialize(exported: true, where T == Int)
 @_specialize(exported: true, where T == Float)
+@_specialize(exported: true, availability: macOS 10.5, *; where T == Double)
 public func testPublic<T>(t: T) {
   print(t)
 }
 
-// OPT: sil @$s14pre_specialize18testEmitIntoClient1tyx_tlFSf_Ts5 : $@convention(thin) (Float) -> () {
-// OPT: sil @$s14pre_specialize18testEmitIntoClient1tyx_tlFSi_Ts5 : $@convention(thin) (Int) -> () {
+// OPT-macosx-DAG: sil [available 10.5] @$s14pre_specialize18testEmitIntoClient1tyx_tlFSd_Ts5 : $@convention(thin) (Double) -> () {
+// OPT-linux-gnu-DAG: sil @$s14pre_specialize18testEmitIntoClient1tyx_tlFSd_Ts5 : $@convention(thin) (Double) -> () {
+// OPT-DAG: sil @$s14pre_specialize18testEmitIntoClient1tyx_tlFSf_Ts5 : $@convention(thin) (Float) -> () {
+// OPT-DAG: sil @$s14pre_specialize18testEmitIntoClient1tyx_tlFSi_Ts5 : $@convention(thin) (Int) -> () {
 
 // NONE: sil @$s14pre_specialize18testEmitIntoClient1tyx_tlFSf_Ts5 : $@convention(thin) (Float) -> () {
 // NONE: sil @$s14pre_specialize18testEmitIntoClient1tyx_tlFSi_Ts5 : $@convention(thin) (Int) -> () {
 
 @_specialize(exported: true, where T == Int)
 @_specialize(exported: true, where T == Float)
+@_specialize(exported: true, availability: macOS 10.5, *; where T == Double)
 @_alwaysEmitIntoClient
 internal func testEmitIntoClient<T>(t: T) {
   print(t)
@@ -50,6 +58,8 @@ internal func testEmitIntoClient<T>(t: T) {
 // OPT:   apply [[F1]]
 // OPT:   [[F2:%.*]] = function_ref @$s22pre_specialized_module20publicPrespecializedyyxlFSd_Ts5 : $@convention(thin) (Double) -> ()
 // OPT:   apply [[F2]]
+// OPT-macosx:   [[F6:%.*]] = function_ref @$s22pre_specialized_module20publicPrespecializedyyxlF : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+// OPT-macosx:    apply [[F6]]<SomeData>
 // OPT:   [[F3:%.*]] = function_ref @$s22pre_specialized_module36internalEmitIntoClientPrespecializedyyxlFSi_Ts5 : $@convention(thin) (Int) -> ()
 // OPT:   apply [[F3]]
 // OPT:   [[F4:%.*]] = function_ref @$s22pre_specialized_module36internalEmitIntoClientPrespecializedyyxlFSd_Ts5 : $@convention(thin) (Double) -> ()
@@ -80,9 +90,18 @@ internal func testEmitIntoClient<T>(t: T) {
 public func usePrespecializedEntryPoints() {
   publicPrespecialized(1)
   publicPrespecialized(1.0)
+  publicPrespecialized(SomeData())
   useInternalEmitIntoClientPrespecialized(2)
   useInternalEmitIntoClientPrespecialized(2.0)
   useInternalThing(2)
+}
+// OPT-macosx: sil [available 10.50] @$s14pre_specialize40usePrespecializedEntryPointsAvailabilityyyF : $@convention(thin) () -> () {
+// OPT-macosx:  [[F1:%.*]] = function_ref @$s22pre_specialized_module20publicPrespecializedyyxlFAA8SomeDataV_Ts5 : $@convention(thin) (SomeData) -> ()
+// OPT-macosx:  apply [[F1]](
+// OPT-macosx: } // end sil function '$s14pre_specialize40usePrespecializedEntryPointsAvailabilityyyF'
+@available(macOS 10.50, *)
+public func usePrespecializedEntryPointsAvailability() {
+  publicPrespecialized(SomeData())
 }
 // OPT: sil [signature_optimized_thunk] [always_inline] @$s22pre_specialized_module16publicInlineableyyxlFSd_Ts5 : $@convention(thin) (Double) -> () {
 // NONE: sil @$s22pre_specialized_module16publicInlineableyyxlFSd_Ts5 : $@convention(thin) (Double) -> () {

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-ide-test -print-ast-typechecked -source-filename=%s -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-ide-test -print-ast-typechecked -source-filename=%s -disable-objc-attr-requires-foundation-module -define-availability 'SwiftStdlib 5.5:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0' | %FileCheck %s
 
 struct S<T> {}
 
@@ -323,3 +323,23 @@ extension Container {
 @_specialize(where S == Set<String>)
 public func takesSequenceAndElement<S, E>(_: S, _: E)
   where S : Sequence, E == S.Element {}
+
+// CHECK: @_specialize(exported: true, kind: full, availability: macOS 11, iOS 13, *; where T == Int)
+// CHECK: public func testAvailability<T>(_ t: T)
+@_specialize(exported: true, availability: macOS 11, iOS 13, *; where T == Int)
+public func testAvailability<T>(_ t: T) {}
+
+// CHECK: @_specialize(exported: true, kind: full, availability: macOS, introduced: 11; where T == Int)
+// CHECK: public func testAvailability2<T>(_ t: T)
+@_specialize(exported: true, availability: macOS 11, *; where T == Int)
+public func testAvailability2<T>(_ t: T) {}
+
+// CHECK: @_specialize(exported: true, kind: full, availability: macOS, introduced: 11; where T == Int)
+// CHECK: public func testAvailability3<T>(_ t: T)
+@_specialize(exported: true, availability: macOS, introduced: 11; where T == Int)
+public func testAvailability3<T>(_ t: T) {}
+
+// CHECK: @_specialize(exported: true, kind: full, availability: macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *; where T == Int)
+// CHECK: public func testAvailability4<T>(_ t: T)
+@_specialize(exported: true, availability: SwiftStdlib 5.5, *; where T == Int)
+public func testAvailability4<T>(_ t: T) {}

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -797,6 +797,11 @@ AllowCompilerErrors("allow-compiler-errors",
                     llvm::cl::desc("Whether to attempt to continue despite compiler errors"),
                     llvm::cl::init(false));
 
+static llvm::cl::opt<std::string>
+  DefineAvailability("define-availability",
+                     llvm::cl::desc("Define a macro for @available"),
+                     llvm::cl::cat(Category));
+
 } // namespace options
 
 static std::unique_ptr<llvm::MemoryBuffer>
@@ -3887,6 +3892,10 @@ int main(int argc, char *argv[]) {
   InitInvok.setModuleName(options::ModuleName);
 
   InitInvok.setSDKPath(options::SDK);
+
+  if (!options::DefineAvailability.empty()) {
+    InitInvok.getLangOptions().AvailabilityMacros.push_back(options::DefineAvailability);
+  }
   InitInvok.getLangOptions().CollectParsedToken = true;
   InitInvok.getLangOptions().BuildSyntaxTree = true;
   InitInvok.getLangOptions().EnableCrossImportOverlays =

--- a/utils/gyb_syntax_support/AttributeNodes.py
+++ b/utils/gyb_syntax_support/AttributeNodes.py
@@ -102,8 +102,23 @@ ATTRIBUTE_NODES = [
          element='Syntax', element_name='SpecializeAttribute',
          element_choices=[
              'LabeledSpecializeEntry',
+             'AvailabilityEntry',
              'TargetFunctionEntry',
              'GenericWhereClause',
+         ]),
+
+    Node('AvailabilityEntry', kind='Syntax',
+         description='''
+         The availability argument for the _specialize attribute
+         ''',
+         children=[
+             Child('Label', kind='IdentifierToken',
+                   description='The label of the argument'),
+             Child('Colon', kind='ColonToken',
+                   description='The colon separating the label and the value'),
+             Child('AvailabilityList', kind='AvailabilitySpecList',
+                   collection_element_name='Availability'),
+             Child('Semicolon', kind='SemicolonToken'),
          ]),
 
     # Representation of e.g. 'exported: true,'

--- a/utils/gyb_syntax_support/NodeSerializationCodes.py
+++ b/utils/gyb_syntax_support/NodeSerializationCodes.py
@@ -253,6 +253,7 @@ SYNTAX_NODE_SERIALIZATION_CODES = {
     'TargetFunctionEntry': 248,
     'PostfixIfConfigExpr': 250,
     'UnavailabilityCondition': 251,
+    'AvailabilityEntry' : 252,
 }
 
 


### PR DESCRIPTION
Allow specifying availability with an `@_specialize` attribute.

```
  @_specialize(exported: true, availability: macOS 10.50, iOS 13, *; where T == Int)
  public func testAvailability<T>(_ t: T) {}
```

rdar://74529439