### PR TITLE
[silgen] Fix lifetime management of tuple elements so we don't leak

### DIFF
--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -854,6 +854,16 @@ void SILGenBuilder::emitDestructureValueOperation(
   }
 }
 
+void SILGenBuilder::emitDestructureValueOperation(
+    SILLocation loc, ManagedValue value,
+    SmallVectorImpl<ManagedValue> &destructuredValues) {
+  CleanupCloner cloner(*this, value);
+  emitDestructureValueOperation(
+      loc, value.forward(SGF), [&](unsigned index, SILValue subValue) {
+        destructuredValues.push_back(cloner.clone(subValue));
+      });
+}
+
 ManagedValue SILGenBuilder::createProjectBox(SILLocation loc, ManagedValue mv,
                                              unsigned index) {
   auto *pbi = createProjectBox(loc, mv.getValue(), index);

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -372,6 +372,9 @@ public:
   void emitDestructureValueOperation(
       SILLocation loc, ManagedValue value,
       function_ref<void(unsigned, ManagedValue)> func);
+  void emitDestructureValueOperation(
+      SILLocation loc, ManagedValue value,
+      SmallVectorImpl<ManagedValue> &destructuredValues);
 
   using SILBuilder::createProjectBox;
   ManagedValue createProjectBox(SILLocation loc, ManagedValue mv,

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -69,16 +69,9 @@ void TupleInitialization::copyOrInitValueInto(SILGenFunction &SGF,
   // In the address case, we forward the underlying value and store it
   // into memory and then create a +1 cleanup. since we assume here
   // that we have a +1 value since we are forwarding into memory.
-  //
-  // In order to ensure that we properly clean up along any failure paths, we
-  // need to mark value as being persistently active. We then unforward it once
-  // we are done.
   assert(value.isPlusOne(SGF) && "Can not store a +0 value into memory?!");
-  CleanupStateRestorationScope valueScope(SGF.Cleanups);
-  if (value.hasCleanup())
-    valueScope.pushCleanupState(value.getCleanup(),
-                                CleanupState::PersistentlyActive);
-  copyOrInitValueIntoHelper(
+  value = ManagedValue::forUnmanaged(value.forward(SGF));
+  return copyOrInitValueIntoHelper(
       SGF, loc, value, isInit, SubInitializations,
       [&](ManagedValue aggregate, unsigned i,
           SILType fieldType) -> ManagedValue {
@@ -90,8 +83,6 @@ void TupleInitialization::copyOrInitValueInto(SILGenFunction &SGF,
 
         return SGF.emitManagedRValueWithCleanup(elt.getValue());
       });
-  std::move(valueScope).pop();
-  value.forward(SGF);
 }
 
 void TupleInitialization::finishUninitialized(SILGenFunction &SGF) {

--- a/test/SILGen/enum.swift
+++ b/test/SILGen/enum.swift
@@ -219,3 +219,23 @@ func sr7799_1(bar: SR7799??) {
   default: print("default")
   }
 }
+
+// Make sure that we handle enum, tuple initialization composed
+// correctly. Previously, we leaked down a failure path due to us misusing
+// scopes.
+enum rdar81817725 {
+    case localAddress
+    case setOption(Int, Any)
+
+    static func takeAny(_:Any) -> Bool { return true }
+
+    static func testSwitchCleanup(syscall: rdar81817725, expectedLevel: Int,
+                                  valueMatcher: (Any) -> Bool)
+      throws -> Bool {
+        if case .setOption(expectedLevel, let value) = syscall {
+            return rdar81817725.takeAny(value)
+        } else {
+            return false
+        }
+    }
+}

--- a/test/SILGen/enum.swift
+++ b/test/SILGen/enum.swift
@@ -219,23 +219,3 @@ func sr7799_1(bar: SR7799??) {
   default: print("default")
   }
 }
-
-// Make sure that we handle enum, tuple initialization composed
-// correctly. Previously, we leaked down a failure path due to us misusing
-// scopes.
-enum rdar81817725 {
-    case localAddress
-    case setOption(Int, Any)
-
-    static func takeAny(_:Any) -> Bool { return true }
-
-    static func testSwitchCleanup(syscall: rdar81817725, expectedLevel: Int,
-                                  valueMatcher: (Any) -> Bool)
-      throws -> Bool {
-        if case .setOption(expectedLevel, let value) = syscall {
-            return rdar81817725.takeAny(value)
-        } else {
-            return false
-        }
-    }
-}

--- a/test/SILGen/indirect_enum.swift
+++ b/test/SILGen/indirect_enum.swift
@@ -448,8 +448,8 @@ func guardTreeB<T>(_ tree: TreeB<T>) {
     // CHECK:   [[TUPLE_ADDR:%.*]] = project_box [[BOX]]
     // CHECK:   copy_addr [[TUPLE_ADDR]] to [initialization] [[TUPLE_COPY:%.*]] :
     // CHECK:   [[L_COPY:%.*]] = tuple_element_addr [[TUPLE_COPY]]
-    // CHECK:   copy_addr [take] [[L_COPY]] to [initialization] [[L]]
     // CHECK:   [[R_COPY:%.*]] = tuple_element_addr [[TUPLE_COPY]]
+    // CHECK:   copy_addr [take] [[L_COPY]] to [initialization] [[L]]
     // CHECK:   copy_addr [take] [[R_COPY]] to [initialization] [[R]]
     // CHECK:   destroy_value [[BOX]]
     guard case .Branch(left: let l, right: let r) = tree else { return }
@@ -492,8 +492,8 @@ func guardTreeB<T>(_ tree: TreeB<T>) {
     // CHECK:   [[TUPLE_ADDR:%.*]] = project_box [[BOX]]
     // CHECK:   copy_addr [[TUPLE_ADDR]] to [initialization] [[TUPLE_COPY:%.*]] :
     // CHECK:   [[L_COPY:%.*]] = tuple_element_addr [[TUPLE_COPY]]
-    // CHECK:   copy_addr [take] [[L_COPY]] to [initialization] [[L]]
     // CHECK:   [[R_COPY:%.*]] = tuple_element_addr [[TUPLE_COPY]]
+    // CHECK:   copy_addr [take] [[L_COPY]] to [initialization] [[L]]
     // CHECK:   copy_addr [take] [[R_COPY]] to [initialization] [[R]]
     // CHECK:   destroy_value [[BOX]]
     // CHECK:   destroy_addr [[R]]


### PR DESCRIPTION
I also deleted the first fix that turned out to be incorrect.

rdar://83770295

----

Description: In SILGen, we were previously when initializing tuples in memory by preparing cleanups for that element and then emitting the sub-initialization, one by one. This behavior is incorrect since a sub-initialization /could/ cause an early exit meaning that any later tuple element would not have its cleanup created yet, causing us to leak along the early exit path. In an early commit (the one being reverted in this PR), I tried to work around this by introducing a new scope+some fancy stuff around using persistently active that didn't work out. In the non-revert commit I fix the actual issue by just setting up all of the tuple elements before I emit the sub-initializations.
Risk: Low, doesn't touch scopes. Just sets up cleanups before we run sub-initializations of tuples.
Review by: @atrick
Testing: Ran/added compiler tests.
Radar: rdar://83770295