### PR TITLE
Implementing 0323 async main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,21 @@ CHANGELOG
 Swift 5.5
 ---------
 
+* [SE-0323][]:
+
+  The main function is executed with `MainActor` isolation applied, so functions
+  and variables with `MainActor` isolation may be called and modified
+  synchronously from the main function. If the main function is annotated with a
+  global actor explicitly, it must be the main actor or an error is emitted. If
+  no global actor annotation is present, the main function is implicitly run on
+  the main actor.
+
+  The main function is executed synchronously up to the first suspension point.
+  Any tasks enqueued by initializers in Objective-C or C++ will run after the
+  main function runs to the first suspension point. At the suspension point, the
+  main function suspends and the tasks are executed according to the Swift
+  concurrency mechanisms.
+
 * [SE-0313][]:
 
   Parameters of actor type can be declared as `isolated`, which means that they

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4289,6 +4289,10 @@ NOTE(note_add_globalactor_to_function,none,
      "add '@%0' to make %1 %2 part of global actor %3", 
      (StringRef, DescriptiveDeclKind, DeclName, Type))
 FIXIT(insert_globalactor_attr, "@%0 ", (Type))
+
+ERROR(main_function_must_be_mainActor,none,
+      "main() must be '@MainActor'", ())
+
 ERROR(not_objc_function_async,none,
       "'async' %0 cannot be represented in Objective-C", (DescriptiveDeclKind))
 NOTE(not_objc_function_type_async,none,

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -273,7 +273,7 @@ public:
     return dyn_cast_or_null<ClassDecl>(getMainDecl());
   }
   bool hasMainDecl() const { return getMainDecl(); }
-  virtual Decl *getMainDecl() const { return nullptr; }
+  virtual ValueDecl *getMainDecl() const { return nullptr; }
   FuncDecl *getMainFunc() const {
     return dyn_cast_or_null<FuncDecl>(getMainDecl());
   }

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -99,7 +99,7 @@ private:
 
   /// Either the class marked \@NS/UIApplicationMain or the synthesized FuncDecl
   /// that calls main on the type marked @main.
-  Decl *MainDecl = nullptr;
+  ValueDecl *MainDecl = nullptr;
 
   /// The source location of the main type.
   SourceLoc MainDeclDiagLoc;
@@ -488,7 +488,7 @@ public:
     llvm_unreachable("bad SourceFileKind");
   }
 
-  Decl *getMainDecl() const override { return MainDecl; }
+  ValueDecl *getMainDecl() const override { return MainDecl; }
   SourceLoc getMainDeclDiagLoc() const {
     assert(hasMainDecl());
     return MainDeclDiagLoc;
@@ -502,7 +502,7 @@ public:
   /// one.
   ///
   /// Should only be called during type-checking.
-  bool registerMainDecl(Decl *mainDecl, SourceLoc diagLoc);
+  bool registerMainDecl(ValueDecl *mainDecl, SourceLoc diagLoc);
 
   /// True if this source file has an application entry point.
   ///

--- a/include/swift/AST/TypeAlignments.h
+++ b/include/swift/AST/TypeAlignments.h
@@ -38,6 +38,7 @@ namespace swift {
   class DifferentiableAttr;
   class Expr;
   class ExtensionDecl;
+  class FileUnit;
   class GenericEnvironment;
   class GenericParamList;
   class GenericTypeParamDecl;
@@ -123,6 +124,7 @@ LLVM_DECLARE_TYPE_ALIGNMENT(swift::BraceStmt, swift::StmtAlignInBits)
 
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::ASTContext, swift::ASTContextAlignInBits);
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::DeclContext, swift::DeclContextAlignInBits)
+LLVM_DECLARE_TYPE_ALIGNMENT(swift::FileUnit, swift::DeclContextAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::DifferentiableAttr, swift::PointerAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::Expr, swift::ExprAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::CaptureListExpr, swift::ExprAlignInBits)

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -156,8 +156,11 @@ struct SILDeclRef {
     /// The main entry-point function. This may reference a SourceFile for a
     /// top-level main, or a decl for e.g an @main decl.
     EntryPoint,
+
+    /// The asynchronous main entry-point function.
+    AsyncEntryPoint,
   };
-  
+
   /// The AST node represented by this SILDeclRef.
   Loc loc;
   /// The Kind of this SILDeclRef.
@@ -226,6 +229,9 @@ struct SILDeclRef {
 
   /// Produces a SILDeclRef for a synthetic main entry-point such as @main.
   static SILDeclRef getMainDeclEntryPoint(ValueDecl *decl);
+
+  /// Produces a SILDeclRef for the synthesized async main entry-point
+  static SILDeclRef getAsyncMainDeclEntryPoint(ValueDecl *decl);
 
   /// Produces a SILDeclRef for the entry-point of a main FileUnit.
   static SILDeclRef getMainFileEntryPoint(FileUnit *file);

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -144,6 +144,10 @@ struct SILDeclRef {
     /// References the function used to initialize a property wrapper storage
     /// instance from a projected value.
     PropertyWrapperInitFromProjectedValue,
+
+    /// The main entry-point function. This may reference a SourceFile for a
+    /// top-level main, or a decl for e.g an @main decl.
+    EntryPoint,
   };
   
   /// The ValueDecl or AbstractClosureExpr represented by this SILDeclRef.
@@ -201,6 +205,12 @@ struct SILDeclRef {
   /// Produce a SIL constant for a default argument generator.
   static SILDeclRef getDefaultArgGenerator(Loc loc, unsigned defaultArgIndex);
 
+  /// Produces a SILDeclRef for a synthetic main entry-point such as @main.
+  static SILDeclRef getMainDeclEntryPoint(ValueDecl *decl);
+
+  /// Produces a SILDeclRef for the entry-point of a main FileUnit.
+  static SILDeclRef getMainFileEntryPoint(FileUnit *file);
+
   bool isNull() const { return loc.isNull(); }
   explicit operator bool() const { return !isNull(); }
   
@@ -217,7 +227,13 @@ struct SILDeclRef {
   AutoClosureExpr *getAutoClosureExpr() const;
   FuncDecl *getFuncDecl() const;
   AbstractFunctionDecl *getAbstractFunctionDecl() const;
-  
+  FileUnit *getFileUnit() const {
+    return loc.get<FileUnit *>();
+  }
+
+  /// Retrieves the ASTContext from the underlying AST node being stored.
+  ASTContext &getASTContext() const;
+
   llvm::Optional<AnyFunctionRef> getAnyFunctionRef() const;
   
   SILLocation getAsRegularLocation() const;

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -433,7 +433,7 @@ public:
 
   virtual StringRef getModuleDefiningPath() const override;
 
-  Decl *getMainDecl() const override;
+  ValueDecl *getMainDecl() const override;
 
   bool hasEntryPoint() const override;
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1587,7 +1587,7 @@ bool ModuleDecl::isBuiltinModule() const {
   return this == getASTContext().TheBuiltinModule;
 }
 
-bool SourceFile::registerMainDecl(Decl *mainDecl, SourceLoc diagLoc) {
+bool SourceFile::registerMainDecl(ValueDecl *mainDecl, SourceLoc diagLoc) {
   assert(mainDecl);
   if (mainDecl == MainDecl)
     return false;

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -473,6 +473,7 @@ namespace {
       case SILDeclRef::Kind::GlobalAccessor:
       case SILDeclRef::Kind::PropertyWrapperBackingInitializer:
       case SILDeclRef::Kind::PropertyWrapperInitFromProjectedValue:
+      case SILDeclRef::Kind::EntryPoint:
         llvm_unreachable("Method does not have a selector");
 
       case SILDeclRef::Kind::Destroyer:

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -474,6 +474,7 @@ namespace {
       case SILDeclRef::Kind::PropertyWrapperBackingInitializer:
       case SILDeclRef::Kind::PropertyWrapperInitFromProjectedValue:
       case SILDeclRef::Kind::EntryPoint:
+      case SILDeclRef::Kind::AsyncEntryPoint:
         llvm_unreachable("Method does not have a selector");
 
       case SILDeclRef::Kind::Destroyer:

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -171,14 +171,17 @@ SILDeclRef::SILDeclRef(SILDeclRef::Loc baseLoc,
 }
 
 Optional<AnyFunctionRef> SILDeclRef::getAnyFunctionRef() const {
-  if (auto vd = loc.dyn_cast<ValueDecl*>()) {
-    if (auto afd = dyn_cast<AbstractFunctionDecl>(vd)) {
+  switch (getLocKind()) {
+  case LocKind::Decl:
+    if (auto *afd = getAbstractFunctionDecl())
       return AnyFunctionRef(afd);
-    } else {
-      return None;
-    }
+    return None;
+  case LocKind::Closure:
+    return AnyFunctionRef(getAbstractClosureExpr());
+  case LocKind::File:
+    return None;
   }
-  return AnyFunctionRef(loc.get<AbstractClosureExpr*>());
+  llvm_unreachable("Unhandled case in switch");
 }
 
 ASTContext &SILDeclRef::getASTContext() const {
@@ -239,9 +242,16 @@ bool SILDeclRef::isClangGenerated(ClangNode node) {
 }
 
 bool SILDeclRef::isImplicit() const {
-  if (hasDecl())
+  switch (getLocKind()) {
+  case LocKind::Decl:
     return getDecl()->isImplicit();
-  return getAbstractClosureExpr()->isImplicit();
+  case LocKind::Closure:
+    return getAbstractClosureExpr()->isImplicit();
+  case LocKind::File:
+    // Files are currently never considered implicit.
+    return false;
+  }
+  llvm_unreachable("Unhandled case in switch");
 }
 
 SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
@@ -718,17 +728,23 @@ bool SILDeclRef::isNativeToForeignThunk() const {
   if (!isForeign)
     return false;
 
-  // We can have native-to-foreign thunks over closures.
-  if (!hasDecl())
+  switch (getLocKind()) {
+  case LocKind::Decl:
+    // A decl with a clang node doesn't have a native entry-point to forward
+    // onto.
+    if (getDecl()->hasClangNode())
+      return false;
+
+    // Only certain kinds of SILDeclRef can expose native-to-foreign thunks.
+    return kind == Kind::Func || kind == Kind::Initializer ||
+           kind == Kind::Deallocator;
+  case LocKind::Closure:
+    // We can have native-to-foreign thunks over closures.
     return true;
-
-  // A decl with a clang node doesn't have a native entry-point to forward onto.
-  if (getDecl()->hasClangNode())
+  case LocKind::File:
     return false;
-
-  // Only certain kinds of SILDeclRef can expose native-to-foreign thunks.
-  return kind == Kind::Func || kind == Kind::Initializer ||
-         kind == Kind::Deallocator;
+  }
+  llvm_unreachable("Unhandled case in switch");
 }
 
 /// Use the Clang importer to mangle a Clang declaration.
@@ -821,8 +837,8 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
 
   switch (kind) {
   case SILDeclRef::Kind::Func:
-    if (!hasDecl())
-      return mangler.mangleClosureEntity(getAbstractClosureExpr(), SKind);
+    if (auto *ACE = getAbstractClosureExpr())
+      return mangler.mangleClosureEntity(ACE, SKind);
 
     // As a special case, functions can have manually mangled names.
     // Use the SILGen name only for the original non-thunked, non-curried entry
@@ -1100,9 +1116,15 @@ SILDeclRef SILDeclRef::getOverriddenVTableEntry() const {
 }
 
 SILLocation SILDeclRef::getAsRegularLocation() const {
-  if (hasDecl())
+  switch (getLocKind()) {
+  case LocKind::Decl:
     return RegularLocation(getDecl());
-  return RegularLocation(getAbstractClosureExpr());
+  case LocKind::Closure:
+    return RegularLocation(getAbstractClosureExpr());
+  case LocKind::File:
+    return RegularLocation::getModuleLocation();
+  }
+  llvm_unreachable("Unhandled case in switch");
 }
 
 SubclassScope SILDeclRef::getSubclassScope() const {

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -16,6 +16,7 @@
 #include "swift/AST/AnyFunctionRef.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/SourceFile.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/SIL/SILLinkage.h"
@@ -180,6 +181,18 @@ Optional<AnyFunctionRef> SILDeclRef::getAnyFunctionRef() const {
   return AnyFunctionRef(loc.get<AbstractClosureExpr*>());
 }
 
+ASTContext &SILDeclRef::getASTContext() const {
+  switch (getLocKind()) {
+  case LocKind::Decl:
+    return getDecl()->getASTContext();
+  case LocKind::Closure:
+    return getAbstractClosureExpr()->getASTContext();
+  case LocKind::File:
+    return getFileUnit()->getASTContext();
+  }
+  llvm_unreachable("Unhandled case in switch");
+}
+
 bool SILDeclRef::isThunk() const {
   return isForeignToNativeThunk() || isNativeToForeignThunk();
 }
@@ -241,6 +254,10 @@ SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
   if (getAbstractClosureExpr()) {
     return isSerialized() ? SILLinkage::Shared : SILLinkage::Private;
   }
+
+  // The main entry-point is public.
+  if (kind == Kind::EntryPoint)
+    return SILLinkage::Public;
 
   // Add External to the linkage (e.g. Public -> PublicExternal) if this is a
   // declaration not a definition.
@@ -407,6 +424,23 @@ SILDeclRef SILDeclRef::getDefaultArgGenerator(Loc loc,
   return result;
 }
 
+SILDeclRef SILDeclRef::getMainDeclEntryPoint(ValueDecl *decl) {
+  auto *file = cast<FileUnit>(decl->getDeclContext()->getModuleScopeContext());
+  assert(file->getMainDecl() == decl);
+  SILDeclRef result;
+  result.loc = decl;
+  result.kind = Kind::EntryPoint;
+  return result;
+}
+
+SILDeclRef SILDeclRef::getMainFileEntryPoint(FileUnit *file) {
+  assert(file->hasEntryPoint() && !file->getMainDecl());
+  SILDeclRef result;
+  result.loc = file;
+  result.kind = Kind::EntryPoint;
+  return result;
+}
+
 bool SILDeclRef::hasClosureExpr() const {
   return loc.is<AbstractClosureExpr *>()
     && isa<ClosureExpr>(getAbstractClosureExpr());
@@ -489,6 +523,9 @@ IsSerialized_t SILDeclRef::isSerialized() const {
 
     return IsNotSerialized;
   }
+
+  if (kind == Kind::EntryPoint)
+    return IsNotSerialized;
 
   if (isIVarInitializerOrDestroyer())
     return IsNotSerialized;
@@ -856,6 +893,10 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
   case SILDeclRef::Kind::PropertyWrapperInitFromProjectedValue:
     return mangler.mangleInitFromProjectedValueEntity(cast<VarDecl>(getDecl()),
                                                       SKind);
+
+  case SILDeclRef::Kind::EntryPoint: {
+    return getASTContext().getEntryPointFunctionName();
+  }
   }
 
   llvm_unreachable("bad entity kind!");
@@ -1168,7 +1209,12 @@ SubclassScope SILDeclRef::getSubclassScope() const {
 }
 
 unsigned SILDeclRef::getParameterListCount() const {
-  if (!hasDecl() || kind == Kind::DefaultArgGenerator)
+  // Only decls can introduce currying.
+  if (!hasDecl())
+    return 1;
+
+  // Always uncurried even if the underlying function is curried.
+  if (kind == Kind::DefaultArgGenerator || kind == Kind::EntryPoint)
     return 1;
 
   auto *vd = getDecl();

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -268,6 +268,8 @@ SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
   // The main entry-point is public.
   if (kind == Kind::EntryPoint)
     return SILLinkage::Public;
+  if (kind == Kind::AsyncEntryPoint)
+    return SILLinkage::Hidden;
 
   // Add External to the linkage (e.g. Public -> PublicExternal) if this is a
   // declaration not a definition.
@@ -443,6 +445,15 @@ SILDeclRef SILDeclRef::getMainDeclEntryPoint(ValueDecl *decl) {
   return result;
 }
 
+SILDeclRef SILDeclRef::getAsyncMainDeclEntryPoint(ValueDecl *decl) {
+  auto *file = cast<FileUnit>(decl->getDeclContext()->getModuleScopeContext());
+  assert(file->getMainDecl() == decl);
+  SILDeclRef result;
+  result.loc = decl;
+  result.kind = Kind::AsyncEntryPoint;
+  return result;
+}
+
 SILDeclRef SILDeclRef::getMainFileEntryPoint(FileUnit *file) {
   assert(file->hasEntryPoint() && !file->getMainDecl());
   SILDeclRef result;
@@ -534,7 +545,7 @@ IsSerialized_t SILDeclRef::isSerialized() const {
     return IsNotSerialized;
   }
 
-  if (kind == Kind::EntryPoint)
+  if (kind == Kind::EntryPoint || kind == Kind::AsyncEntryPoint)
     return IsNotSerialized;
 
   if (isIVarInitializerOrDestroyer())
@@ -910,6 +921,9 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
     return mangler.mangleInitFromProjectedValueEntity(cast<VarDecl>(getDecl()),
                                                       SKind);
 
+  case SILDeclRef::Kind::AsyncEntryPoint: {
+    return "async_Main";
+  }
   case SILDeclRef::Kind::EntryPoint: {
     return getASTContext().getEntryPointFunctionName();
   }
@@ -1236,7 +1250,8 @@ unsigned SILDeclRef::getParameterListCount() const {
     return 1;
 
   // Always uncurried even if the underlying function is curried.
-  if (kind == Kind::DefaultArgGenerator || kind == Kind::EntryPoint)
+  if (kind == Kind::DefaultArgGenerator || kind == Kind::EntryPoint ||
+      kind == Kind::AsyncEntryPoint)
     return 1;
 
   auto *vd = getDecl();

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -3251,19 +3251,21 @@ TypeConverter::getDeclRefRepresentation(SILDeclRef c) {
   }
 
   // Anonymous functions currently always have Freestanding CC.
-  if (!c.hasDecl())
+  if (c.getAbstractClosureExpr())
     return SILFunctionTypeRepresentation::Thin;
 
   // FIXME: Assert that there is a native entry point
   // available. There's no great way to do this.
 
   // Protocol witnesses are called using the witness calling convention.
-  if (auto proto = dyn_cast<ProtocolDecl>(c.getDecl()->getDeclContext())) {
-    // Use the regular method convention for foreign-to-native thunks.
-    if (c.isForeignToNativeThunk())
-      return SILFunctionTypeRepresentation::Method;
-    assert(!c.isNativeToForeignThunk() && "shouldn't be possible");
-    return getProtocolWitnessRepresentation(proto);
+  if (c.hasDecl()) {
+    if (auto proto = dyn_cast<ProtocolDecl>(c.getDecl()->getDeclContext())) {
+      // Use the regular method convention for foreign-to-native thunks.
+      if (c.isForeignToNativeThunk())
+        return SILFunctionTypeRepresentation::Method;
+      assert(!c.isNativeToForeignThunk() && "shouldn't be possible");
+      return getProtocolWitnessRepresentation(proto);
+    }
   }
 
   switch (c.kind) {

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2497,6 +2497,9 @@ static CanSILFunctionType getNativeSILFunctionType(
     case SILDeclRef::Kind::Deallocator:
       return getSILFunctionTypeForConventions(DeallocatorConventions());
 
+    case SILDeclRef::Kind::AsyncEntryPoint:
+      return getSILFunctionTypeForConventions(
+          DefaultConventions(NormalParameterConvention::Guaranteed));
     case SILDeclRef::Kind::EntryPoint:
       llvm_unreachable("Handled by getSILFunctionTypeForAbstractCFunction");
     }
@@ -3027,6 +3030,7 @@ static ObjCSelectorFamily getObjCSelectorFamily(SILDeclRef c) {
   case SILDeclRef::Kind::PropertyWrapperBackingInitializer:
   case SILDeclRef::Kind::PropertyWrapperInitFromProjectedValue:
   case SILDeclRef::Kind::EntryPoint:
+  case SILDeclRef::Kind::AsyncEntryPoint:
     llvm_unreachable("Unexpected Kind of foreign SILDeclRef");
   }
 
@@ -3290,6 +3294,8 @@ TypeConverter::getDeclRefRepresentation(SILDeclRef c) {
     case SILDeclRef::Kind::IVarDestroyer:
       return SILFunctionTypeRepresentation::Method;
 
+    case SILDeclRef::Kind::AsyncEntryPoint:
+      return SILFunctionTypeRepresentation::Thin;
     case SILDeclRef::Kind::EntryPoint:
       return SILFunctionTypeRepresentation::CFunctionPointer;
   }
@@ -4120,6 +4126,7 @@ static AbstractFunctionDecl *getBridgedFunction(SILDeclRef declRef) {
   case SILDeclRef::Kind::IVarInitializer:
   case SILDeclRef::Kind::IVarDestroyer:
   case SILDeclRef::Kind::EntryPoint:
+  case SILDeclRef::Kind::AsyncEntryPoint:
     return nullptr;
   }
   llvm_unreachable("bad SILDeclRef kind");

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2496,6 +2496,9 @@ static CanSILFunctionType getNativeSILFunctionType(
           DefaultConventions(NormalParameterConvention::Guaranteed));
     case SILDeclRef::Kind::Deallocator:
       return getSILFunctionTypeForConventions(DeallocatorConventions());
+
+    case SILDeclRef::Kind::EntryPoint:
+      llvm_unreachable("Handled by getSILFunctionTypeForAbstractCFunction");
     }
   }
   }
@@ -3023,6 +3026,7 @@ static ObjCSelectorFamily getObjCSelectorFamily(SILDeclRef c) {
   case SILDeclRef::Kind::StoredPropertyInitializer:
   case SILDeclRef::Kind::PropertyWrapperBackingInitializer:
   case SILDeclRef::Kind::PropertyWrapperInitFromProjectedValue:
+  case SILDeclRef::Kind::EntryPoint:
     llvm_unreachable("Unexpected Kind of foreign SILDeclRef");
   }
 
@@ -3283,6 +3287,9 @@ TypeConverter::getDeclRefRepresentation(SILDeclRef c) {
     case SILDeclRef::Kind::IVarInitializer:
     case SILDeclRef::Kind::IVarDestroyer:
       return SILFunctionTypeRepresentation::Method;
+
+    case SILDeclRef::Kind::EntryPoint:
+      return SILFunctionTypeRepresentation::CFunctionPointer;
   }
 
   llvm_unreachable("Unhandled SILDeclRefKind in switch.");
@@ -4110,6 +4117,7 @@ static AbstractFunctionDecl *getBridgedFunction(SILDeclRef declRef) {
   case SILDeclRef::Kind::PropertyWrapperInitFromProjectedValue:
   case SILDeclRef::Kind::IVarInitializer:
   case SILDeclRef::Kind::IVarDestroyer:
+  case SILDeclRef::Kind::EntryPoint:
     return nullptr;
   }
   llvm_unreachable("bad SILDeclRef kind");

--- a/lib/SIL/IR/SILLocation.cpp
+++ b/lib/SIL/IR/SILLocation.cpp
@@ -42,7 +42,7 @@ SourceLoc SILLocation::getSourceLoc() const {
 
   // Don't crash if the location is a FilenameAndLocation.
   // TODO: this is a workaround until rdar://problem/25225083 is implemented.
-  if (isFilenameAndLocation())
+  if (getStorageKind() == FilenameAndLocationKind)
     return SourceLoc();
 
   return getSourceLoc(getPrimaryASTNode());

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -316,6 +316,7 @@ void SILDeclRef::print(raw_ostream &OS) const {
   switch (kind) {
   case SILDeclRef::Kind::Func:
   case SILDeclRef::Kind::EntryPoint:
+  case SILDeclRef::Kind::AsyncEntryPoint:
     break;
   case SILDeclRef::Kind::Allocator:
     OS << "!allocator";

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -311,6 +311,7 @@ void SILDeclRef::print(raw_ostream &OS) const {
   }
   switch (kind) {
   case SILDeclRef::Kind::Func:
+  case SILDeclRef::Kind::EntryPoint:
     break;
   case SILDeclRef::Kind::Allocator:
     OS << "!allocator";

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -262,53 +262,57 @@ void SILDeclRef::print(raw_ostream &OS) const {
   }
 
   bool isDot = true;
-  if (!hasDecl()) {
+  switch (getLocKind()) {
+  case LocKind::Closure:
     OS << "<anonymous function>";
-  } else if (kind == SILDeclRef::Kind::Func) {
-    auto *FD = cast<FuncDecl>(getDecl());
-    auto accessor = dyn_cast<AccessorDecl>(FD);
-    if (!accessor) {
-      printValueDecl(FD, OS);
-      isDot = false;
-    } else {
-      switch (accessor->getAccessorKind()) {
-      case AccessorKind::WillSet:
-        printValueDecl(accessor->getStorage(), OS);
-        OS << "!willSet";
-        break;
-      case AccessorKind::DidSet:
-        printValueDecl(accessor->getStorage(), OS);
-        OS << "!didSet";
-        break;
-      case AccessorKind::Get:
-        printValueDecl(accessor->getStorage(), OS);
-        OS << "!getter";
-        break;
-      case AccessorKind::Set:
-        printValueDecl(accessor->getStorage(), OS);
-        OS << "!setter";
-        break;
-      case AccessorKind::Address:
-        printValueDecl(accessor->getStorage(), OS);
-        OS << "!addressor";
-        break;
-      case AccessorKind::MutableAddress:
-        printValueDecl(accessor->getStorage(), OS);
-        OS << "!mutableAddressor";
-        break;
-      case AccessorKind::Read:
-        printValueDecl(accessor->getStorage(), OS);
-        OS << "!read";
-        break;
-      case AccessorKind::Modify:
-        printValueDecl(accessor->getStorage(), OS);
-        OS << "!modify";
-        break;
-      }
+    break;
+  case LocKind::File:
+    OS << "<file>";
+    break;
+  case LocKind::Decl: {
+    if (kind != Kind::Func) {
+      printValueDecl(getDecl(), OS);
+      break;
     }
-  } else {
-    printValueDecl(getDecl(), OS);
+
+    auto *accessor = dyn_cast<AccessorDecl>(getDecl());
+    if (!accessor) {
+      printValueDecl(getDecl(), OS);
+      isDot = false;
+      break;
+    }
+
+    printValueDecl(accessor->getStorage(), OS);
+    switch (accessor->getAccessorKind()) {
+    case AccessorKind::WillSet:
+      OS << "!willSet";
+      break;
+    case AccessorKind::DidSet:
+      OS << "!didSet";
+      break;
+    case AccessorKind::Get:
+      OS << "!getter";
+      break;
+    case AccessorKind::Set:
+      OS << "!setter";
+      break;
+    case AccessorKind::Address:
+      OS << "!addressor";
+      break;
+    case AccessorKind::MutableAddress:
+      OS << "!mutableAddressor";
+      break;
+    case AccessorKind::Read:
+      OS << "!read";
+      break;
+    case AccessorKind::Modify:
+      OS << "!modify";
+      break;
+    }
+    break;
   }
+  }
+
   switch (kind) {
   case SILDeclRef::Kind::Func:
   case SILDeclRef::Kind::EntryPoint:

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2553,6 +2553,32 @@ getFunctionInterfaceTypeWithCaptures(TypeConverter &TC,
       innerExtInfo);
 }
 
+static CanAnyFunctionType getAsyncEntryPoint(ASTContext &C) {
+
+  // @main struct Main {
+  //    static func main() async throws {}
+  //    static func $main() async throws { try await main() }
+  //  }
+  //
+  // func @async_main() async -> Void {
+  //   do {
+  //      try await Main.$main()
+  //      exit(0)
+  //   } catch {
+  //      _emitErrorInMain(error)
+  //   }
+  // }
+  //
+  // This generates the type signature for @async_main
+  // TODO: 'Never' return type would be more accurate.
+
+  CanType returnType = C.getVoidType()->getCanonicalType();
+  FunctionType::ExtInfo extInfo =
+      FunctionType::ExtInfoBuilder().withAsync(true).withThrows(false).build();
+  return CanAnyFunctionType::get(/*genericSig*/ nullptr, {}, returnType,
+                                 extInfo);
+}
+
 static CanAnyFunctionType getEntryPointInterfaceType(ASTContext &C) {
   // Use standard library types if we have them; otherwise, fall back to
   // builtins.
@@ -2666,6 +2692,8 @@ CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {
   case SILDeclRef::Kind::IVarDestroyer:
     return getIVarInitDestroyerInterfaceType(cast<ClassDecl>(vd),
                                              c.isForeign, true);
+  case SILDeclRef::Kind::AsyncEntryPoint:
+    return getAsyncEntryPoint(Context);
   case SILDeclRef::Kind::EntryPoint:
     return getEntryPointInterfaceType(Context);
   }
@@ -2720,6 +2748,7 @@ TypeConverter::getConstantGenericSignature(SILDeclRef c) {
   case SILDeclRef::Kind::StoredPropertyInitializer:
     return vd->getDeclContext()->getGenericSignatureOfContext();
   case SILDeclRef::Kind::EntryPoint:
+  case SILDeclRef::Kind::AsyncEntryPoint:
     llvm_unreachable("Doesn't have generic signature");
   }
 

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2572,7 +2572,8 @@ static CanAnyFunctionType getAsyncEntryPoint(ASTContext &C) {
   // This generates the type signature for @async_main
   // TODO: 'Never' return type would be more accurate.
 
-  CanType returnType = C.getVoidType()->getCanonicalType();
+  CanType returnType =
+      C.getVoidDecl()->getDeclaredInterfaceType()->getCanonicalType();
   FunctionType::ExtInfo extInfo =
       FunctionType::ExtInfoBuilder().withAsync(true).withThrows(false).build();
   return CanAnyFunctionType::get(/*genericSig*/ nullptr, {}, returnType,

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -434,6 +434,37 @@ SILGenModule::getCheckExpectedExecutor() {
                                     "_checkExpectedExecutor");
 }
 
+FuncDecl *SILGenModule::getAsyncMainDrainQueue() {
+  return lookupConcurrencyIntrinsic(getASTContext(), AsyncMainDrainQueue,
+                                    "_asyncMainDrainQueue");
+}
+
+FuncDecl *SILGenModule::getGetMainExecutor() {
+  return lookupConcurrencyIntrinsic(getASTContext(), GetMainExecutor,
+                                    "_getMainExecutor");
+}
+
+FuncDecl *SILGenModule::getSwiftJobRun() {
+  return lookupConcurrencyIntrinsic(getASTContext(), SwiftJobRun,
+                                    "_swiftJobRun");
+}
+
+FuncDecl *SILGenModule::getExit() {
+  if (ExitFunc)
+    return *ExitFunc;
+
+  ASTContext &C = getASTContext();
+  ModuleDecl *concurrencyShims =
+      C.getModuleByIdentifier(C.getIdentifier("_SwiftConcurrencyShims"));
+
+  if (!concurrencyShims) {
+    ExitFunc = nullptr;
+    return nullptr;
+  }
+
+  return lookupIntrinsic(*concurrencyShims, ExitFunc, C.getIdentifier("exit"));
+}
+
 ProtocolConformance *SILGenModule::getNSErrorConformanceToError() {
   if (NSErrorConformanceToError)
     return *NSErrorConformanceToError;
@@ -1027,7 +1058,27 @@ void SILGenModule::emitFunctionDefinition(SILDeclRef constant, SILFunction *f) {
     auto *decl = constant.getDecl();
     auto *dc = decl->getDeclContext();
     PrettyStackTraceSILFunction X("silgen emitArtificialTopLevel", f);
-    SILGenFunction(*this, *f, dc).emitArtificialTopLevel(decl);
+    // In all cases, a constant.kind == EntryPoint indicates the main entrypoint
+    // to the program, @main.
+    // In the synchronous case, the decl is not async, so emitArtificialTopLevel
+    // emits the error unwrapping and call to MainType.$main() into @main.
+    //
+    // In the async case, emitAsyncMainThreadStart is responsible for generating
+    // the contents of @main. This wraps @async_main in a task, passes that task
+    // to swift_job_run to execute the first thunk, and starts the runloop to
+    // run any additional continuations. The kind is EntryPoint, and the decl is
+    // async.
+    // When the kind is 'AsyncMain', we are generating @async_main. In this
+    // case, emitArtificialTopLevel emits the code for calling MaintType.$main,
+    // unwrapping errors, and calling exit(0) into @async_main to run the
+    // user-specified main function.
+    if (constant.kind == SILDeclRef::Kind::EntryPoint && isa<FuncDecl>(decl) &&
+        static_cast<FuncDecl *>(decl)->hasAsync()) {
+      SILDeclRef mainEntryPoint = SILDeclRef::getAsyncMainDeclEntryPoint(decl);
+      SILGenFunction(*this, *f, dc).emitAsyncMainThreadStart(mainEntryPoint);
+    } else {
+      SILGenFunction(*this, *f, dc).emitArtificialTopLevel(decl);
+    }
     postEmitFunction(constant, f);
     return;
   }
@@ -2005,10 +2056,15 @@ public:
 
     // If the source file contains an artificial main, emit the implicit
     // top-level code.
-    if (auto *mainDecl = sf->getMainDecl())
+    if (auto *mainDecl = sf->getMainDecl()) {
+      if (isa<FuncDecl>(mainDecl) &&
+          static_cast<FuncDecl *>(mainDecl)->hasAsync())
+        emitSILFunctionDefinition(
+            SILDeclRef::getAsyncMainDeclEntryPoint(mainDecl));
       emitSILFunctionDefinition(SILDeclRef::getMainDeclEntryPoint(mainDecl));
+    }
   }
-  
+
   void emitSILFunctionDefinition(SILDeclRef ref) {
     SGM.emitFunctionDefinition(ref, SGM.getFunction(ref, ForDefinition));
   }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -544,65 +544,6 @@ SILGenModule::getKeyPathProjectionCoroutine(bool isReadAccess,
   return fn;
 }
 
-
-SILFunction *SILGenModule::emitTopLevelFunction(SILLocation Loc) {
-  ASTContext &C = getASTContext();
-
-  // Use standard library types if we have them; otherwise, fall back to
-  // builtins.
-  CanType Int32Ty;
-  if (auto Int32Decl = C.getInt32Decl()) {
-    Int32Ty = Int32Decl->getDeclaredInterfaceType()->getCanonicalType();
-  } else {
-    Int32Ty = CanType(BuiltinIntegerType::get(32, C));
-  }
-
-  CanType PtrPtrInt8Ty = C.TheRawPointerType;
-  if (auto PointerDecl = C.getUnsafeMutablePointerDecl()) {
-    if (auto Int8Decl = C.getInt8Decl()) {
-      Type Int8Ty = Int8Decl->getDeclaredInterfaceType();
-      Type PointerInt8Ty = BoundGenericType::get(PointerDecl,
-                                                 nullptr,
-                                                 Int8Ty);
-      Type OptPointerInt8Ty = OptionalType::get(PointerInt8Ty);
-      PtrPtrInt8Ty = BoundGenericType::get(PointerDecl,
-                                           nullptr,
-                                           OptPointerInt8Ty)
-        ->getCanonicalType();
-    }
-  }
-
-  SILParameterInfo params[] = {
-    SILParameterInfo(Int32Ty, ParameterConvention::Direct_Unowned),
-    SILParameterInfo(PtrPtrInt8Ty, ParameterConvention::Direct_Unowned),
-  };
-  SILResultInfo results[] = {SILResultInfo(Int32Ty, ResultConvention::Unowned)};
-
-  auto rep = SILFunctionType::Representation::CFunctionPointer;
-  auto *clangTy = C.getCanonicalClangFunctionType(params, results[0], rep);
-  auto extInfo = SILFunctionType::ExtInfoBuilder()
-                     .withRepresentation(rep)
-                     .withClangFunctionType(clangTy)
-                     .build();
-
-  CanSILFunctionType topLevelType = SILFunctionType::get(nullptr, extInfo,
-                                   SILCoroutineKind::None,
-                                   ParameterConvention::Direct_Unowned,
-                                   params, /*yields*/ {},
-                                   SILResultInfo(Int32Ty,
-                                                 ResultConvention::Unowned),
-                                   None,
-                                   SubstitutionMap(), SubstitutionMap(),
-                                   C);
-
-  auto name = getASTContext().getEntryPointFunctionName();
-  SILGenFunctionBuilder builder(*this);
-  return builder.createFunction(
-      SILLinkage::Public, name, topLevelType, nullptr,
-      Loc, IsBare, IsNotTransparent, IsNotSerialized, IsNotDynamic,
-      ProfileCounter(), IsNotThunk, SubclassScope::NotApplicable);
-}
-
 SILFunction *SILGenModule::getEmittedFunction(SILDeclRef constant,
                                               ForDefinition_t forDefinition) {
   auto found = emittedFunctions.find(constant);
@@ -1069,6 +1010,20 @@ void SILGenModule::emitFunctionDefinition(SILDeclRef constant, SILFunction *f) {
     preEmitFunction(constant, f, loc);
     PrettyStackTraceSILFunction X("silgen emitDestructor ivar destroyer", f);
     SILGenFunction(*this, *f, cd).emitIVarDestroyer(constant);
+    postEmitFunction(constant, f);
+    return;
+  }
+  case SILDeclRef::Kind::EntryPoint: {
+    f->setBare(IsBare);
+
+    // TODO: Handle main SourceFile emission (currently done by
+    // SourceFileScope).
+    auto loc = RegularLocation::getModuleLocation();
+    preEmitFunction(constant, f, loc);
+    auto *decl = constant.getDecl();
+    auto *dc = decl->getDeclContext();
+    PrettyStackTraceSILFunction X("silgen emitArtificialTopLevel", f);
+    SILGenFunction(*this, *f, dc).emitArtificialTopLevel(decl);
     postEmitFunction(constant, f);
     return;
   }
@@ -1880,10 +1835,9 @@ namespace {
 /// An RAII class to scope source file codegen.
 class SourceFileScope {
   SILGenModule &sgm;
-  SourceFile *sf;
   Optional<Scope> scope;
 public:
-  SourceFileScope(SILGenModule &sgm, SourceFile *sf) : sgm(sgm), sf(sf) {
+  SourceFileScope(SILGenModule &sgm, SourceFile *sf) : sgm(sgm) {
     // If this is the script-mode file for the module, create a toplevel.
     if (sf->isScriptMode()) {
       assert(!sgm.TopLevelSGF && "already emitted toplevel?!");
@@ -1892,7 +1846,9 @@ public:
              "already emitted toplevel?!");
 
       RegularLocation TopLevelLoc = RegularLocation::getModuleLocation();
-      SILFunction *toplevel = sgm.emitTopLevelFunction(TopLevelLoc);
+      auto ref = SILDeclRef::getMainFileEntryPoint(sf);
+      auto *toplevel = sgm.getFunction(ref, ForDefinition);
+      toplevel->setBare(IsBare);
 
       // Assign a debug scope pointing into the void to the top level function.
       toplevel->setDebugScope(new (sgm.M) SILDebugScope(TopLevelLoc, toplevel));
@@ -2007,31 +1963,6 @@ public:
       toplevel->verify();
       sgm.emitLazyConformancesForFunction(toplevel);
     }
-
-    // If the source file contains an artificial main, emit the implicit
-    // toplevel code.
-    if (auto mainDecl = sf->getMainDecl()) {
-      assert(!sgm.M.lookUpFunction(
-                 sgm.getASTContext().getEntryPointFunctionName()) &&
-             "already emitted toplevel before main class?!");
-
-      RegularLocation TopLevelLoc = RegularLocation::getModuleLocation();
-      SILFunction *toplevel = sgm.emitTopLevelFunction(TopLevelLoc);
-
-      // Assign a debug scope pointing into the void to the top level function.
-      toplevel->setDebugScope(new (sgm.M) SILDebugScope(TopLevelLoc, toplevel));
-
-      // Create the argc and argv arguments.
-      SILGenFunction SGF(sgm, *toplevel, sf);
-      auto entry = SGF.B.getInsertionBB();
-      auto paramTypeIter =
-          SGF.F.getConventions()
-              .getParameterSILTypes(SGF.getTypeExpansionContext())
-              .begin();
-      entry->createFunctionArgument(*paramTypeIter);
-      entry->createFunctionArgument(*std::next(paramTypeIter));
-      SGF.emitArtificialTopLevel(mainDecl);
-    }
   }
 };
 
@@ -2046,7 +1977,7 @@ public:
     performTypeChecking(*sf);
 
     SourceFileScope scope(SGM, sf);
-    for (Decl *D : sf->getTopLevelDecls()) {
+    for (auto *D : sf->getTopLevelDecls()) {
       FrontendStatsTracer StatsTracer(SGM.getASTContext().Stats,
                                       "SILgen-decl", D);
       SGM.visit(D);
@@ -2067,7 +1998,13 @@ public:
         continue;
       SGM.visit(TD);
     }
+
+    // If the source file contains an artificial main, emit the implicit
+    // top-level code.
+    if (auto *mainDecl = sf->getMainDecl())
+      emitSILFunctionDefinition(SILDeclRef::getMainDeclEntryPoint(mainDecl));
   }
+  
   void emitSILFunctionDefinition(SILDeclRef ref) {
     SGM.emitFunctionDefinition(ref, SGM.getFunction(ref, ForDefinition));
   }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1016,6 +1016,7 @@ void SILGenModule::emitFunctionDefinition(SILDeclRef constant, SILFunction *f) {
     postEmitFunction(constant, f);
     return;
   }
+  case SILDeclRef::Kind::AsyncEntryPoint:
   case SILDeclRef::Kind::EntryPoint: {
     f->setBare(IsBare);
 

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -86,8 +86,6 @@ public:
   /// Set of delayed conformances that have already been forced.
   llvm::DenseSet<NormalProtocolConformance *> forcedConformances;
 
-  SILFunction *emitTopLevelFunction(SILLocation Loc);
-
   size_t anonymousSymbolCounter = 0;
 
   Optional<SILDeclRef> StringToNSStringFn;

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -132,6 +132,11 @@ public:
   Optional<FuncDecl*> RunAsyncHandler;
   Optional<FuncDecl*> CheckExpectedExecutor;
 
+  Optional<FuncDecl *> AsyncMainDrainQueue;
+  Optional<FuncDecl *> GetMainExecutor;
+  Optional<FuncDecl *> SwiftJobRun;
+  Optional<FuncDecl *> ExitFunc;
+
 public:
   SILGenModule(SILModule &M, ModuleDecl *SM);
 
@@ -512,6 +517,15 @@ public:
   FuncDecl *getRunTaskForBridgedAsyncMethod();
   /// Retrieve the _Concurrency._checkExpectedExecutor intrinsic.
   FuncDecl *getCheckExpectedExecutor();
+
+  /// Retrieve the _Concurrency._asyncMainDrainQueue intrinsic.
+  FuncDecl *getAsyncMainDrainQueue();
+  /// Retrieve the _Concurrency._getMainExecutor intrinsic.
+  FuncDecl *getGetMainExecutor();
+  /// Retrieve the _Concurrency._swiftJobRun intrinsic.
+  FuncDecl *getSwiftJobRun();
+  // Retrieve the _SwiftConcurrencyShims.exit intrinsic.
+  FuncDecl *getExit();
 
   SILFunction *getKeyPathProjectionCoroutine(bool isReadAccess,
                                              KeyPathTypeKind typeKind);

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1402,9 +1402,10 @@ emitFunctionArgumentForAsyncTaskEntryPoint(SILGenFunction &SGF,
 }
 
 // Emit SIL for the named builtin: createAsyncTask.
-static ManagedValue emitBuiltinCreateAsyncTask(
-    SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
-    ArrayRef<ManagedValue> args, SGFContext C) {
+ManagedValue emitBuiltinCreateAsyncTask(SILGenFunction &SGF, SILLocation loc,
+                                        SubstitutionMap subs,
+                                        ArrayRef<ManagedValue> args,
+                                        SGFContext C) {
   ASTContext &ctx = SGF.getASTContext();
   auto flags = args[0].forward(SGF);
 

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -26,6 +26,7 @@
 #include "swift/AST/Initializer.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/PropertyWrappers.h"
+#include "swift/AST/SourceFile.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILProfiler.h"
 #include "swift/SIL/SILUndef.h"
@@ -140,6 +141,9 @@ DeclName SILGenModule::getMagicFunctionName(SILDeclRef ref) {
   case SILDeclRef::Kind::EnumElement:
     return getMagicFunctionName(cast<EnumElementDecl>(ref.getDecl())
                                   ->getDeclContext());
+  case SILDeclRef::Kind::EntryPoint:
+    auto *file = ref.getDecl()->getDeclContext()->getParentSourceFile();
+    return getMagicFunctionName(file);
   }
 
   llvm_unreachable("Unhandled SILDeclRefKind in switch.");
@@ -605,9 +609,13 @@ void SILGenFunction::emitClosure(AbstractClosureExpr *ace) {
 }
 
 void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
-  // Load argc and argv from the entry point arguments.
-  SILValue argc = F.begin()->getArgument(0);
-  SILValue argv = F.begin()->getArgument(1);
+  // Create the argc and argv arguments.
+  auto entry = B.getInsertionBB();
+  auto paramTypeIter = F.getConventions()
+                           .getParameterSILTypes(getTypeExpansionContext())
+                           .begin();
+  SILValue argc = entry->createFunctionArgument(*paramTypeIter);
+  SILValue argv = entry->createFunctionArgument(*std::next(paramTypeIter));
 
   switch (mainDecl->getArtificialMainKind()) {
   case ArtificialMainKind::UIApplicationMain: {

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -938,9 +938,9 @@ void SILGenFunction::emitAsyncMainThreadStart(SILDeclRef entryPoint) {
   // Emit the CreateAsyncTask builtin
   TaskCreateFlags taskCreationFlagMask(0);
   taskCreationFlagMask.setInheritContext(true);
-  SILValue taskFlags =
-      emitWrapIntegerLiteral(moduleLoc, getLoweredType(ctx.getIntType()),
-                             taskCreationFlagMask.getOpaqueValue());
+  SILValue taskFlags = emitWrapIntegerLiteral(
+      moduleLoc, getLoweredType(ctx.getIntDecl()->getDeclaredInterfaceType()),
+      taskCreationFlagMask.getOpaqueValue());
 
   SILValue task =
       emitBuiltinCreateAsyncTask(*this, moduleLoc, subs,

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -141,6 +141,7 @@ DeclName SILGenModule::getMagicFunctionName(SILDeclRef ref) {
   case SILDeclRef::Kind::EnumElement:
     return getMagicFunctionName(cast<EnumElementDecl>(ref.getDecl())
                                   ->getDeclContext());
+  case SILDeclRef::Kind::AsyncEntryPoint:
   case SILDeclRef::Kind::EntryPoint:
     auto *file = ref.getDecl()->getDeclContext()->getParentSourceFile();
     return getMagicFunctionName(file);

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -946,6 +946,7 @@ void SILGenFunction::emitAsyncMainThreadStart(SILDeclRef entryPoint) {
 
   // Emit the CreateAsyncTask builtin
   TaskCreateFlags taskCreationFlagMask(0);
+  taskCreationFlagMask.setInheritContext(true);
   SILValue taskFlags =
       emitWrapIntegerLiteral(moduleLoc, getLoweredType(ctx.getIntType()),
                              taskCreationFlagMask.getOpaqueValue());

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -636,6 +636,9 @@ public:
   /// application based on a main type and optionally a main type.
   void emitArtificialTopLevel(Decl *mainDecl);
 
+  /// Generate code into @main for starting the async main on the main thread.
+  void emitAsyncMainThreadStart(SILDeclRef entryPoint);
+
   /// Generates code for a class deallocating destructor. This
   /// calls the destroying destructor and then deallocates 'self'.
   void emitDeallocatingDestructor(DestructorDecl *dd);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1888,39 +1888,29 @@ synthesizeMainBody(AbstractFunctionDecl *fn, void *arg) {
   Expr *returnedExpr;
 
   if (mainFunction->hasAsync()) {
-    // Pass main into _runAsyncMain(_ asyncFunc: () async throws -> ())
-    // Resulting $main looks like:
-    // $main() { _runAsyncMain(main) }
+    // Ensure that the concurrency module is loaded
     auto *concurrencyModule = context.getLoadedModule(context.Id_Concurrency);
     if (!concurrencyModule) {
       context.Diags.diagnose(mainFunction->getAsyncLoc(),
                              diag::async_main_no_concurrency);
       auto result = new (context) ErrorExpr(mainFunction->getSourceRange());
-      SmallVector<ASTNode, 1> stmts;
-      stmts.push_back(result);
-      auto body = BraceStmt::create(context, SourceLoc(), stmts,
-                                    SourceLoc(), /*Implicit*/true);
-
+      ASTNode stmts[] = {result};
+      auto body = BraceStmt::create(context, SourceLoc(), stmts, SourceLoc(),
+                                    /*Implicit*/ true);
       return std::make_pair(body, /*typechecked*/true);
     }
 
-    SmallVector<ValueDecl *, 1> decls;
-    concurrencyModule->lookupQualified(
-        concurrencyModule,
-        DeclNameRef(context.getIdentifier("_runAsyncMain")),
-        NL_QualifiedDefault | NL_IncludeUsableFromInline,
-        decls);
-    assert(!decls.empty() && "Failed to find _runAsyncMain");
-    FuncDecl *runner = cast<FuncDecl>(decls[0]);
-
-    auto asyncRunnerDeclRef = ConcreteDeclRef(runner, substitutionMap);
-
-    DeclRefExpr *funcExpr = new (context) DeclRefExpr(asyncRunnerDeclRef,
-                                                      DeclNameLoc(),
-                                                      /*implicit=*/true);
-    funcExpr->setType(runner->getInterfaceType());
-    auto *callExpr = CallExpr::createImplicit(context, funcExpr, memberRefExpr, {});
-    returnedExpr = callExpr;
+    // $main() async { await main() }
+    Expr *awaitExpr =
+        new (context) AwaitExpr(callExpr->getLoc(), callExpr,
+                                context.TheEmptyTupleType, /*implicit*/ true);
+    if (mainFunction->hasThrows()) {
+      // $main() async throws { try await main() }
+      awaitExpr =
+          new (context) TryExpr(callExpr->getLoc(), awaitExpr,
+                                context.TheEmptyTupleType, /*implicit*/ true);
+    }
+    returnedExpr = awaitExpr;
   } else if (mainFunction->hasThrows()) {
     auto *tryExpr = new (context) TryExpr(
         callExpr->getLoc(), callExpr, context.TheEmptyTupleType, /*implicit=*/true);
@@ -2037,7 +2027,7 @@ SynthesizeMainFunctionRequest::evaluate(Evaluator &evaluator,
       DeclName(context, DeclBaseName(context.Id_MainEntryPoint),
                ParameterList::createEmpty(context)),
       /*NameLoc=*/SourceLoc(),
-      /*Async=*/false,
+      /*Async=*/mainFunction->hasAsync(),
       /*Throws=*/mainFunction->hasThrows(),
       /*GenericParams=*/nullptr, ParameterList::createEmpty(context),
       /*FnRetType=*/TupleType::getEmpty(context), declContext);
@@ -2498,7 +2488,7 @@ static FuncDecl *findSimilarAccessor(DeclNameRef replacedVarName,
   }
 
   assert(!isa<FuncDecl>(results[0]));
-  
+
   auto *origStorage = cast<AbstractStorageDecl>(results[0]);
   if (forDynamicReplacement && !origStorage->isDynamic()) {
     Diags.diagnose(attr->getLocation(),

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2895,12 +2895,13 @@ getActorIsolationForMainFuncDecl(FuncDecl *fnDecl) {
   ASTContext &ctx = fnDecl->getASTContext();
 
   const bool isMainMain = fnDecl->isMainTypeMainMethod();
-  const bool isMain$Main =
+  const bool isMainInternalMain =
       fnDecl->getBaseIdentifier() == ctx.getIdentifier("$main") &&
       !fnDecl->isInstanceMember() &&
       fnDecl->getResultInterfaceType()->isVoid() &&
       fnDecl->getParameters()->size() == 0;
-  const bool isMainFunction = isMainDeclContext && (isMainMain || isMain$Main);
+  const bool isMainFunction =
+      isMainDeclContext && (isMainMain || isMainInternalMain);
   const bool hasMainActor = !ctx.getMainActorType().isNull();
 
   return isMainFunction && hasMainActor

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2875,6 +2875,41 @@ static ActorIsolation getActorIsolationFromWrappedProperty(VarDecl *var) {
   return ActorIsolation::forUnspecified();
 }
 
+static Optional<ActorIsolation>
+getActorIsolationForMainFuncDecl(FuncDecl *fnDecl) {
+  // Ensure that the base type that this function is declared in has @main
+  // attribute
+  NominalTypeDecl *declContext =
+      dyn_cast<NominalTypeDecl>(fnDecl->getDeclContext());
+  if (ExtensionDecl *exDecl =
+          dyn_cast<ExtensionDecl>(fnDecl->getDeclContext())) {
+    declContext = exDecl->getExtendedNominal();
+  }
+
+  // We're not even in a nominal decl type, this can't be the main function decl
+  if (!declContext)
+    return {};
+  const bool isMainDeclContext =
+      declContext->getAttrs().hasAttribute<MainTypeAttr>();
+
+  ASTContext &ctx = fnDecl->getASTContext();
+
+  const bool isMainMain = fnDecl->isMainTypeMainMethod();
+  const bool isMain$Main =
+      fnDecl->getBaseIdentifier() == ctx.getIdentifier("$main") &&
+      !fnDecl->isInstanceMember() &&
+      fnDecl->getResultInterfaceType()->isVoid() &&
+      fnDecl->getParameters()->size() == 0;
+  const bool isMainFunction = isMainDeclContext && (isMainMain || isMain$Main);
+  const bool hasMainActor = !ctx.getMainActorType().isNull();
+
+  return isMainFunction && hasMainActor
+             ? ActorIsolation::forGlobalActor(
+                   ctx.getMainActorType()->mapTypeOutOfContext(),
+                   /*isUnsafe*/ false)
+             : Optional<ActorIsolation>();
+}
+
 /// Check rules related to global actor attributes on a class declaration.
 ///
 /// \returns true if an error occurred.
@@ -2941,9 +2976,26 @@ ActorIsolation ActorIsolationRequest::evaluate(
     return ActorIsolation::forActorInstance(actor);
   }
 
+  auto isolationFromAttr = getIsolationFromAttributes(value);
+  if (FuncDecl *fd = dyn_cast<FuncDecl>(value)) {
+    // Main.main() and Main.$main are implicitly MainActor-protected.
+    // Any other isolation is an error.
+    Optional<ActorIsolation> mainIsolation =
+        getActorIsolationForMainFuncDecl(fd);
+    if (mainIsolation) {
+      if (isolationFromAttr && isolationFromAttr->isGlobalActor()) {
+        if (!areTypesEqual(isolationFromAttr->getGlobalActor(),
+                           mainIsolation->getGlobalActor())) {
+          fd->getASTContext().Diags.diagnose(
+              fd->getLoc(), diag::main_function_must_be_mainActor);
+        }
+      }
+      return *mainIsolation;
+    }
+  }
   // If this declaration has one of the actor isolation attributes, report
   // that.
-  if (auto isolationFromAttr = getIsolationFromAttributes(value)) {
+  if (isolationFromAttr) {
     // Nonisolated declarations must involve Sendable types.
     if (*isolationFromAttr == ActorIsolation::Independent) {
       SubstitutionMap subs;

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1262,9 +1262,9 @@ bool SerializedASTFile::getAllGenericSignatures(
   return true;
 }
 
-Decl *SerializedASTFile::getMainDecl() const {
+ValueDecl *SerializedASTFile::getMainDecl() const {
   assert(hasEntryPoint());
-  return File.getDecl(File.getEntryPointDeclID());
+  return cast_or_null<ValueDecl>(File.getDecl(File.getEntryPointDeclID()));
 }
 
 const version::Version &SerializedASTFile::getLanguageVersionBuiltWith() const {

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -1152,6 +1152,29 @@ void TBDGenVisitor::addFirstFileSymbols() {
   }
 }
 
+void TBDGenVisitor::addMainIfNecessary(FileUnit *file) {
+  // HACK: 'main' is a special symbol that's always emitted in SILGen if
+  //       the file has an entry point. Since it doesn't show up in the
+  //       module until SILGen, we need to explicitly add it here.
+  //
+  // Make sure to only add the main symbol for the module that we're emitting
+  // TBD for, and not for any statically linked libraries.
+  if (!file->hasEntryPoint() || file->getParentModule() != SwiftModule)
+    return;
+
+  auto entryPointSymbol =
+      SwiftModule->getASTContext().getEntryPointFunctionName();
+
+  if (auto *decl = file->getMainDecl()) {
+    auto ref = SILDeclRef::getMainDeclEntryPoint(decl);
+    addSymbol(entryPointSymbol, SymbolSource::forSILDeclRef(ref));
+    return;
+  }
+
+  auto ref = SILDeclRef::getMainFileEntryPoint(file);
+  addSymbol(entryPointSymbol, SymbolSource::forSILDeclRef(ref));
+}
+
 void TBDGenVisitor::visit(Decl *D) {
   DeclStack.push_back(D);
   SWIFT_DEFER { DeclStack.pop_back(); };
@@ -1348,8 +1371,8 @@ public:
     apigen::APIAvailability availability;
     if (source.kind == SymbolSource::Kind::SIL) {
       auto ref = source.getSILDeclRef();
-      if (auto *decl = ref.getDecl())
-        availability = getAvailability(decl);
+      if (ref.hasDecl())
+        availability = getAvailability(ref.getDecl());
     }
 
     api.addSymbol(symbol, moduleLoc, apigen::APILinkage::Exported,

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -181,18 +181,9 @@ public:
   TBDGenVisitor(const TBDGenDescriptor &desc, APIRecorder &recorder);
 
   ~TBDGenVisitor() { assert(DeclStack.empty()); }
-  void addMainIfNecessary(FileUnit *file) {
-    // HACK: 'main' is a special symbol that's always emitted in SILGen if
-    //       the file has an entry point. Since it doesn't show up in the
-    //       module until SILGen, we need to explicitly add it here.
-    //
-    // Make sure to only add the main symbol for the module that we're emitting
-    // TBD for, and not for any statically linked libraries.
-    // FIXME: We should have a SymbolSource for main.
-    if (file->hasEntryPoint() && file->getParentModule() == SwiftModule)
-      addSymbol(SwiftModule->getASTContext().getEntryPointFunctionName(),
-                SymbolSource::forUnknown());
-  }
+
+  /// Add the main symbol.
+  void addMainIfNecessary(FileUnit *file);
 
   /// Adds the global symbols associated with the first file.
   void addFirstFileSymbols();

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -808,7 +808,11 @@ func _enqueueJobGlobalWithDelay(_ delay: UInt64, _ task: Builtin.Job)
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_asyncMainDrainQueue")
-public func _asyncMainDrainQueue() -> Never
+internal func _asyncMainDrainQueue() -> Never
+
+@available(SwiftStdlib 5.5, *)
+@_silgen_name("swift_task_getMainExecutor")
+internal func _getMainExecutor() -> Builtin.Executor
 
 @available(SwiftStdlib 5.5, *)
 public func _runAsyncMain(_ asyncFun: @escaping () async throws -> ()) {

--- a/test/Concurrency/Runtime/async_task_priority_current.swift
+++ b/test/Concurrency/Runtime/async_task_priority_current.swift
@@ -18,9 +18,18 @@ extension TaskPriority: CustomStringConvertible {
 }
 
 @available(SwiftStdlib 5.5, *)
+@main struct Main {
+  static func main() async {
+    print("main priority: \(Task.currentPriority)") // CHECK: main priority: TaskPriority(rawValue: [[#MAIN_PRIORITY:]])
+    await test_detach()
+    await test_multiple_lo_indirectly_escalated()
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
 func test_detach() async {
   let a1 = Task.currentPriority
-  print("a1: \(a1)") // CHECK: TaskPriority(rawValue: 25)
+  print("a1: \(a1)") // CHECK: a1: TaskPriority(rawValue: [[#MAIN_PRIORITY]])
 
   // Note: remember to detach using a higher priority, otherwise a lower one
   // might be escalated by the get() and we could see `default` in the detached
@@ -30,8 +39,15 @@ func test_detach() async {
     print("a2: \(a2)") // CHECK: a2: TaskPriority(rawValue: 25)
   }.get()
 
-  let a3 = Task.currentPriority
-  print("a3: \(a3)") // CHECK: a3: TaskPriority(rawValue: 25)
+  await detach(priority: .default) {
+    let a3 = Task.currentPriority
+    // The priority of 'a3' may either be 21 (default) or elevated to that of
+    // the main function, whichever is greater.
+    print("a3: \(a3)") // CHECK: a3: TaskPriority(rawValue: [[#max(MAIN_PRIORITY,21)]]
+  }.get()
+
+  let a4 = Task.currentPriority
+  print("a4: \(a4)") // CHECK: a4: TaskPriority(rawValue: [[#MAIN_PRIORITY]])
 }
 
 @available(SwiftStdlib 5.5, *)
@@ -66,10 +82,4 @@ func test_multiple_lo_indirectly_escalated() async {
   print("default done") // CHECK: default done
 }
 
-@available(SwiftStdlib 5.5, *)
-@main struct Main {
-  static func main() async {
-    await test_detach()
-    await test_multiple_lo_indirectly_escalated()
-  }
-}
+

--- a/test/Concurrency/Runtime/async_task_priority_current.swift
+++ b/test/Concurrency/Runtime/async_task_priority_current.swift
@@ -20,7 +20,7 @@ extension TaskPriority: CustomStringConvertible {
 @available(SwiftStdlib 5.5, *)
 func test_detach() async {
   let a1 = Task.currentPriority
-  print("a1: \(a1)") // CHECK: TaskPriority(rawValue: 21)
+  print("a1: \(a1)") // CHECK: TaskPriority(rawValue: 25)
 
   // Note: remember to detach using a higher priority, otherwise a lower one
   // might be escalated by the get() and we could see `default` in the detached
@@ -31,7 +31,7 @@ func test_detach() async {
   }.get()
 
   let a3 = Task.currentPriority
-  print("a3: \(a3)") // CHECK: a3: TaskPriority(rawValue: 21)
+  print("a3: \(a3)") // CHECK: a3: TaskPriority(rawValue: 25)
 }
 
 @available(SwiftStdlib 5.5, *)

--- a/test/Concurrency/Runtime/class_resilience.swift
+++ b/test/Concurrency/Runtime/class_resilience.swift
@@ -55,23 +55,24 @@ func virtualWait<T>(orThrow: Bool, _ c: BaseClass<T>) async throws {
   return try await c.wait(orThrow: orThrow)
 }
 
-
-
-
 @main struct Main {
   static func main() async {
-    var AsyncVTableMethodSuite = TestSuite("ResilientClass")
-    AsyncVTableMethodSuite.test("AsyncVTableMethod") {
-      let x = MyDerived(value: 321)
+    let task = Task.detached {
+      var AsyncVTableMethodSuite = TestSuite("ResilientClass")
+      AsyncVTableMethodSuite.test("AsyncVTableMethod") {
+        let x = MyDerived(value: 321)
 
-      await virtualWaitForNothing(x)
+        await virtualWaitForNothing(x)
 
-      expectEqual(642, await virtualWait(x))
-      expectEqual(246, await virtualWaitForInt(x))
+        expectEqual(642, await virtualWait(x))
+        expectEqual(246, await virtualWaitForInt(x))
 
-      expectNil(try? await virtualWait(orThrow: true, x))
-      try! await virtualWait(orThrow: false, x)
+        expectNil(try? await virtualWait(orThrow: true, x))
+        try! await virtualWait(orThrow: false, x)
+      }
+      await runAllTestsAsync()
     }
-    await runAllTestsAsync()
+
+    await task.value
   }
 }

--- a/test/Concurrency/Runtime/protocol_resilience.swift
+++ b/test/Concurrency/Runtime/protocol_resilience.swift
@@ -62,19 +62,23 @@ func genericWait<T : Awaitable>(orThrow: Bool, _ t: T) async throws {
 
 @main struct Main {
   static func main() async {
-    var AsyncProtocolRequirementSuite = TestSuite("ResilientProtocol")
+    let task = Task.detached {
+      var AsyncProtocolRequirementSuite = TestSuite("ResilientProtocol")
 
-    AsyncProtocolRequirementSuite.test("AsyncProtocolRequirement") {
-      let x = IntAwaitable()
+      AsyncProtocolRequirementSuite.test("AsyncProtocolRequirement") {
+        let x = IntAwaitable()
 
-      await genericWaitForNothing(x)
+        await genericWaitForNothing(x)
 
-      expectEqual(123, await genericWait(x))
-      expectEqual(321, await genericWaitForInt(x))
+        expectEqual(123, await genericWait(x))
+        expectEqual(321, await genericWaitForInt(x))
 
-      expectNil(try? await genericWait(orThrow: true, x))
-      try! await genericWait(orThrow: false, x)
+        expectNil(try? await genericWait(orThrow: true, x))
+        try! await genericWait(orThrow: false, x)
+      }
+      await runAllTestsAsync()
     }
-    await runAllTestsAsync()
+
+    await task.value
   }
 }

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -56,7 +56,7 @@ func asyncFunc() async {
 
 // CHECK-SIL:       // function_ref async_Main
 // CHECK-SIL-NEXT:  %2 = function_ref @async_Main : $@convention(thin) @async () -> ()
-// CHECK-SIL-NEXT:  %3 = integer_literal $Builtin.Int64, 21
+// CHECK-SIL-NEXT:  %3 = integer_literal $Builtin.Int64, 2048
 // CHECK-SIL-NEXT:  %4 = struct $Int (%3 : $Builtin.Int64)
 // CHECK-SIL-NEXT:  %5 = metatype $@thick ().Type
 // CHECK-SIL-NEXT:  %6 = init_existential_metatype %5 : $@thick ().Type, $@thick Any.Type

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -dump-ast -enable-experimental-concurrency -disable-availability-checking -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-AST
-// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -Xfrontend -disable-availability-checking -Xfrontend -parse-as-library %s -o %t_binary
+// RUN: %target-swift-frontend -emit-sil -disable-availability-checking -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-SIL
+// RUN: %target-build-swift  -Xfrontend -disable-availability-checking -Xfrontend -parse-as-library %s -o %t_binary
 // RUN: %target-run %t_binary | %FileCheck %s --check-prefix=CHECK-EXEC
 
 // REQUIRES: concurrency
@@ -15,28 +15,67 @@ func asyncFunc() async {
 }
 
 @main struct MyProgram {
-  static func main() async {
+  static func main() async throws {
     await asyncFunc()
   }
 }
 
 // CHECK-EXEC: Hello World!
 
-// CHECK-AST-LABEL: "main()" interface
-// CHECK-AST:       (await_expr type='()'
-// CHECK-AST-NEXT:    (call_expr type='()'
-// CHECK-AST-NEXT:       (declref_expr type='() async -> ()'
-// CHECK-AST-SAME:        decl=async_main.(file).asyncFunc()@
+// static MyProgram.main()
+// CHECK-SIL-LABEL: sil hidden @$s10async_main9MyProgramV0B0yyYaKFZ : $@convention(method) @async (@thin MyProgram.Type) -> @error Error
 
-// CHECK-AST-LABEL: (func_decl implicit "$main()" interface
-// CHECK-AST:       (brace_stmt
-// CHECK-AST-NEXT:    (return_stmt implicit
-// CHECK-AST-NEXT:      (call_expr implicit type='()'
-// CHECK-AST-NEXT:        (declref_expr implicit
-// CHECK-AST-SAME:             type='(@escaping () async throws -> ()) -> ()'
-// CHECK-AST-SAME:             decl=_Concurrency.(file)._runAsyncMain
-// CHECK-AST-SAME:             function_ref=single
-// CHECK-AST-NEXT:        (paren_expr implicit type='(() async throws -> ())'
-// CHECK-AST-NEXT:          (function_conversion_expr implicit type='() async throws -> ()'
-// CHECK-AST-NEXT:          (dot_syntax_call_expr
-// CHECK-AST-NEXT:          (autoclosure_expr implicit type='(MyProgram.Type) -> () async -> ()'
+
+// static MyProgram.$main()
+// CHECK-SIL-LABEL: sil hidden @$s10async_main9MyProgramV5$mainyyYaKFZ : $@convention(method) @async (@thin MyProgram.Type) -> @error Error
+
+
+// async_Main
+// CHECK-SIL_LABEL: sil hidden @async_Main : $@convention(thin) @async () -> () {
+// call main
+// CHECK-SIL:  %0 = metatype $@thin MyProgram.Type             // user: %2
+// CHECK-SIL-NEXT:  // function_ref static MyProgram.$main()
+// CHECK-SIL-NEXT:  %1 = function_ref @$s10async_main9MyProgramV5$mainyyYaKFZ : $@convention(method) @async (@thin MyProgram.Type) -> @error Error // user: %2
+// CHECK-SIL-NEXT:  try_apply %1(%0) : $@convention(method) @async (@thin MyProgram.Type) -> @error Error, normal bb1, error bb2 // id: %2
+
+// unwrap error and exit or explode
+// CHECK-SIL: bb1(%3 : $()):
+// CHECK-SIL-NEXT:  %4 = integer_literal $Builtin.Int32, 0
+// CHECK-SIL-NEXT:  %5 = struct $Int32 (%4 : $Builtin.Int32)
+// CHECK-SIL-NEXT:  // function_ref exit
+// CHECK-SIL-NEXT:  %6 = function_ref @exit : $@convention(c) (Int32) -> Never
+// CHECK-SIL-NEXT:  %7 = apply %6(%5) : $@convention(c) (Int32) -> Never
+// CHECK-SIL-NEXT:  unreachable
+
+// CHECK-SIL: bb2(%9 : $Error):
+// CHECK-SIL-NEXT:  %10 = builtin "errorInMain"(%9 : $Error) : $()
+// CHECK-SIL-NEXT:  unreachable
+
+// main
+// CHECK-SIL-LABEL: sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+
+// CHECK-SIL:       // function_ref async_Main
+// CHECK-SIL-NEXT:  %2 = function_ref @async_Main : $@convention(thin) @async () -> ()
+// CHECK-SIL-NEXT:  %3 = integer_literal $Builtin.Int64, 21
+// CHECK-SIL-NEXT:  %4 = struct $Int (%3 : $Builtin.Int64)
+// CHECK-SIL-NEXT:  %5 = metatype $@thick ().Type
+// CHECK-SIL-NEXT:  %6 = init_existential_metatype %5 : $@thick ().Type, $@thick Any.Type
+// CHECK-SIL-NEXT:  // function_ref thunk for @escaping @convention(thin) @async () -> ()
+// CHECK-SIL-NEXT:  %7 = function_ref @$sIetH_yts5Error_pIegHrzo_TR : $@convention(thin) @async (@convention(thin) @async () -> ()) -> (@out (), @error Error)
+// CHECK-SIL-NEXT:  %8 = partial_apply [callee_guaranteed] %7(%2) : $@convention(thin) @async (@convention(thin) @async () -> ()) -> (@out (), @error Error)
+// CHECK-SIL-NEXT:  %9 = convert_function %8 : $@async @callee_guaranteed () -> (@out (), @error Error) to $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>
+// CHECK-SIL-NEXT:  %10 = builtin "createAsyncTask"<()>(%4 : $Int, %6 : $@thick Any.Type, %9 : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>) : $(Builtin.NativeObject, Builtin.RawPointer)
+// CHECK-SIL-NEXT:  %11 = tuple_extract %10 : $(Builtin.NativeObject, Builtin.RawPointer), 0
+// CHECK-SIL-NEXT:  // function_ref swift_job_run
+// CHECK-SIL-NEXT:  %12 = function_ref @swift_job_run : $@convention(thin) (UnownedJob, UnownedSerialExecutor) -> ()
+// CHECK-SIL-NEXT:  %13 = builtin "convertTaskToJob"(%11 : $Builtin.NativeObject) : $Builtin.Job
+// CHECK-SIL-NEXT:  %14 = unchecked_trivial_bit_cast %13 : $Builtin.Job to $UnownedJob
+// CHECK-SIL-NEXT:  // function_ref swift_task_getMainExecutor
+// CHECK-SIL-NEXT:  %15 = function_ref @swift_task_getMainExecutor : $@convention(thin) () -> Builtin.Executor
+// CHECK-SIL-NEXT:  %16 = apply %15() : $@convention(thin) () -> Builtin.Executor
+// CHECK-SIL-NEXT:  %17 = unchecked_trivial_bit_cast %16 : $Builtin.Executor to $UnownedSerialExecutor
+// CHECK-SIL-NEXT:  %18 = apply %12(%14, %17) : $@convention(thin) (UnownedJob, UnownedSerialExecutor) -> ()
+// CHECK-SIL-NEXT:  // function_ref swift_task_asyncMainDrainQueue
+// CHECK-SIL-NEXT:  %19 = function_ref @swift_task_asyncMainDrainQueue : $@convention(thin) () -> Never
+// CHECK-SIL-NEXT:  %20 = apply %19() : $@convention(thin) () -> Never
+// CHECK-SIL-NEXT:  unreachable

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -10,17 +10,25 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
+@MainActor
+var foo: Int = 42
+
 func asyncFunc() async {
   print("Hello World!")
 }
 
 @main struct MyProgram {
   static func main() async throws {
+    print(foo)
+    foo += 1
     await asyncFunc()
+    print(foo)
   }
 }
 
-// CHECK-EXEC: Hello World!
+// CHECK-EXEC: 42
+// CHECK-EXEC-NEXT: Hello World!
+// CHECK-EXEC-NEXT: 43
 
 // static MyProgram.main()
 // CHECK-SIL-LABEL: sil hidden @$s10async_main9MyProgramV0B0yyYaKFZ : $@convention(method) @async (@thin MyProgram.Type) -> @error Error

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -69,11 +69,11 @@ func asyncFunc() async {
 // CHECK-SIL-NEXT:  // function_ref swift_job_run
 // CHECK-SIL-NEXT:  %12 = function_ref @swift_job_run : $@convention(thin) (UnownedJob, UnownedSerialExecutor) -> ()
 // CHECK-SIL-NEXT:  %13 = builtin "convertTaskToJob"(%11 : $Builtin.NativeObject) : $Builtin.Job
-// CHECK-SIL-NEXT:  %14 = unchecked_trivial_bit_cast %13 : $Builtin.Job to $UnownedJob
+// CHECK-SIL-NEXT:  %14 = struct $UnownedJob (%13 : $Builtin.Job)
 // CHECK-SIL-NEXT:  // function_ref swift_task_getMainExecutor
 // CHECK-SIL-NEXT:  %15 = function_ref @swift_task_getMainExecutor : $@convention(thin) () -> Builtin.Executor
 // CHECK-SIL-NEXT:  %16 = apply %15() : $@convention(thin) () -> Builtin.Executor
-// CHECK-SIL-NEXT:  %17 = unchecked_trivial_bit_cast %16 : $Builtin.Executor to $UnownedSerialExecutor
+// CHECK-SIL-NEXT:  %17 = struct $UnownedSerialExecutor (%16 : $Builtin.Executor)
 // CHECK-SIL-NEXT:  %18 = apply %12(%14, %17) : $@convention(thin) (UnownedJob, UnownedSerialExecutor) -> ()
 // CHECK-SIL-NEXT:  // function_ref swift_task_asyncMainDrainQueue
 // CHECK-SIL-NEXT:  %19 = function_ref @swift_task_asyncMainDrainQueue : $@convention(thin) () -> Never

--- a/test/Concurrency/async_main_invalid_global_actor.swift
+++ b/test/Concurrency/async_main_invalid_global_actor.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -parse-as-library
+
+@globalActor
+actor Kat {
+  static let shared = Kat()
+}
+
+@Kat
+var poof: Int = 1337 // expected-note{{var declared here}}
+
+@main struct Doggo {
+  @Kat
+  static func main() { // expected-error{{main() must be '@MainActor'}}
+    // expected-error@+1{{var 'poof' isolated to global actor 'Kat' can not be referenced from different global actor 'MainActor' in a synchronous context}}
+    print("Kat value: \(poof)")
+  }
+}
+
+struct Bunny {
+  // Bunnies are not @main, so they can have a "main" function that is on
+  // another actor. It's not actually the main function, so it's fine.
+  @Kat
+  static func main() {
+  }
+}

--- a/test/Concurrency/async_main_mainactor_isolation.swift
+++ b/test/Concurrency/async_main_mainactor_isolation.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -parse-as-library
+// This should pass without any warnings or errors
+
+@MainActor
+var floofer: Int = 42
+
+@main struct Doggo { }
+
+extension Doggo {
+  static func main() {
+    print("Doggo value: \(floofer)")
+  }
+}


### PR DESCRIPTION
Cherry-picking https://github.com/apple/swift/pull/38604, https://github.com/apple/swift/pull/39503, and https://github.com/apple/swift/pull/39593, and applying necessary changes to make up for missing 

This change relies on the `SwiftDeclRef::Kind::EntryPoint` created in  https://github.com/apple/swift/pull/37014.

This implements the semantic changes described in https://github.com/apple/swift-evolution/pull/1437, Async Main Semantics.

- Explanation: This implements the semantic changes to the asynchronous main function described in SE-proposal 0323-Asynchronous Main Semantics. The main function (both synchronous and asynchronous) has `MainActor` isolation rules applied and is run synchronously up to the first suspension point.
- Scope:  Main Functions
- Risk: Low (Semantics are implemented in compiler instead of runtimes, so things can be fixed easily. There is a small source break by disallowing the main function to have any other global actor than the MainActor.)
- Testing: Added new tests cases to ensure main-actor isolation is applied and the correct SIL is emitted.
- Issue: rdar://80027250
- Reviewers:
