### PR TITLE
Back-deploy @objc actor types.

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1414,6 +1414,10 @@ FUNCTION(ObjCGetClass, objc_getClass, C_CC,  AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind))
+FUNCTION(ObjCGetRequiredClass, objc_getRequiredClass, C_CC,  AlwaysAvailable,
+         RETURNS(ObjCClassPtrTy),
+         ARGS(Int8PtrTy),
+         ATTRS(NoUnwind))
 FUNCTION(ObjCGetMetaClass, objc_getMetaClass, C_CC, AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(Int8PtrTy),

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1148,6 +1148,12 @@ FUNCTION(LookUpClass, objc_lookUpClass, C_CC, AlwaysAvailable,
          ARGS(Int8PtrTy),
          ATTRS(NoUnwind, ReadNone))
 
+// Class objc_setSuperclass(Class cls, Class newSuper);
+FUNCTION(SetSuperclass, class_setSuperclass, C_CC, AlwaysAvailable,
+         RETURNS(ObjCClassPtrTy),
+         ARGS(ObjCClassPtrTy, ObjCClassPtrTy),
+         ATTRS(NoUnwind))
+
 // Metadata *swift_getObjectType(id object);
 FUNCTION(GetObjectType, swift_getObjectType, C_CC, AlwaysAvailable,
          RETURNS(TypeMetadataPtrTy),

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -960,6 +960,7 @@ void IRGenModule::emitClassDecl(ClassDecl *D) {
   emitFieldDescriptor(D);
 
   IRGen.addClassForEagerInitialization(D);
+  IRGen.addBackDeployedObjCActorInitialization(D);
 
   emitNestedTypeDecls(D->getMembers());
 }
@@ -2527,15 +2528,24 @@ ClassDecl *irgen::getRootClassForMetaclass(IRGenModule &IGM, ClassDecl *C) {
 
 ClassDecl *
 irgen::getSuperclassDeclForMetadata(IRGenModule &IGM, ClassDecl *C) {
-  if (C->isNativeNSObjectSubclass())
+  if (C->isNativeNSObjectSubclass()) {
+    // When concurrency isn't available in the OS, use NSObject instead.
+    if (!IGM.isConcurrencyAvailable()) {
+      return IGM.getObjCRuntimeBaseClass(
+          IGM.Context.getSwiftId(KnownFoundationEntity::NSObject),
+          IGM.Context.getIdentifier("NSObject"));
+    }
+
     return IGM.getSwiftNativeNSObjectDecl();
+  }
   return C->getSuperclassDecl();
 }
 
 CanType irgen::getSuperclassForMetadata(IRGenModule &IGM, ClassDecl *C) {
-  if (C->isNativeNSObjectSubclass())
-    return IGM.getSwiftNativeNSObjectDecl()->getDeclaredInterfaceType()
-                                           ->getCanonicalType();
+  if (C->isNativeNSObjectSubclass()) {
+    return getSuperclassDeclForMetadata(IGM, C)->getDeclaredInterfaceType()
+                                               ->getCanonicalType();
+  }
   if (auto superclass = C->getSuperclass())
     return superclass->getCanonicalType();
   return CanType();
@@ -2544,9 +2554,10 @@ CanType irgen::getSuperclassForMetadata(IRGenModule &IGM, ClassDecl *C) {
 CanType irgen::getSuperclassForMetadata(IRGenModule &IGM, CanType type,
                                         bool useArchetypes) {
   auto cls = type->getClassOrBoundGenericClass();
-  if (cls->isNativeNSObjectSubclass())
-    return IGM.getSwiftNativeNSObjectDecl()->getDeclaredInterfaceType()
-                                           ->getCanonicalType();
+  if (cls->isNativeNSObjectSubclass()) {
+    return getSuperclassDeclForMetadata(IGM, cls)->getDeclaredInterfaceType()
+                                                 ->getCanonicalType();
+  }
   if (auto superclass = type->getSuperclass(useArchetypes))
     return superclass->getCanonicalType();
   return CanType();

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1907,15 +1907,13 @@ void IRGenerator::emitObjCActorsNeedingSuperclassSwizzle() {
   auto swiftNativeNSObjectName =
       IGM->getAddrOfGlobalString("SwiftNativeNSObject");
   auto swiftNativeNSObjectClass = RegisterIGF.Builder.CreateCall(
-      RegisterIGF.IGM.getLookUpClassFn(), swiftNativeNSObjectName);
+      RegisterIGF.IGM.getObjCGetRequiredClassFn(), swiftNativeNSObjectName);
 
   for (ClassDecl *CD : ObjCActorsNeedingSuperclassSwizzle) {
     // The @objc actor class.
     llvm::Value *classRef = RegisterIGF.emitTypeMetadataRef(
         CD->getDeclaredInterfaceType()->getCanonicalType());
     classRef = RegisterIGF.Builder.CreateBitCast(classRef, IGM->ObjCClassPtrTy);
-    classRef = RegisterIGF.Builder.CreateCall(
-        IGM->getFixedClassInitializationFn(), classRef);
 
     // Set its superclass to SwiftNativeNSObject.
     RegisterIGF.Builder.CreateCall(
@@ -1926,8 +1924,8 @@ void IRGenerator::emitObjCActorsNeedingSuperclassSwizzle() {
 
   // Add the registration function as a static initializer. We use a priority
   // slightly lower than used for C++ global constructors, so that the code is
-  // executed before C++ global constructors (in case someone uses archives
-  // from a C++ global constructor).
+  // executed before C++ global constructors (in case someone manages to access
+  // an @objc actor from a global constructor).
   llvm::appendToGlobalCtors(IGM->Module, RegisterFn, 60000, nullptr);
 }
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1887,6 +1887,50 @@ void IRGenerator::emitEagerClassInitialization() {
   llvm::appendToGlobalCtors(IGM->Module, RegisterFn, 60000, nullptr);
 }
 
+void IRGenerator::emitObjCActorsNeedingSuperclassSwizzle() {
+  if (ObjCActorsNeedingSuperclassSwizzle.empty())
+    return;
+
+  // Emit the register function in the primary module.
+  IRGenModule *IGM = getPrimaryIGM();
+
+  llvm::Function *RegisterFn = llvm::Function::Create(
+                                llvm::FunctionType::get(IGM->VoidTy, false),
+                                llvm::GlobalValue::PrivateLinkage,
+                                "_swift_objc_actor_initialization");
+  IGM->Module.getFunctionList().push_back(RegisterFn);
+  IRGenFunction RegisterIGF(*IGM, RegisterFn);
+  RegisterFn->setAttributes(IGM->constructInitialAttributes());
+  RegisterFn->setCallingConv(IGM->DefaultCC);
+
+  // Look up the SwiftNativeNSObject class.
+  auto swiftNativeNSObjectName =
+      IGM->getAddrOfGlobalString("SwiftNativeNSObject");
+  auto swiftNativeNSObjectClass = RegisterIGF.Builder.CreateCall(
+      RegisterIGF.IGM.getLookUpClassFn(), swiftNativeNSObjectName);
+
+  for (ClassDecl *CD : ObjCActorsNeedingSuperclassSwizzle) {
+    // The @objc actor class.
+    llvm::Value *classRef = RegisterIGF.emitTypeMetadataRef(
+        CD->getDeclaredInterfaceType()->getCanonicalType());
+    classRef = RegisterIGF.Builder.CreateBitCast(classRef, IGM->ObjCClassPtrTy);
+    classRef = RegisterIGF.Builder.CreateCall(
+        IGM->getFixedClassInitializationFn(), classRef);
+
+    // Set its superclass to SwiftNativeNSObject.
+    RegisterIGF.Builder.CreateCall(
+        RegisterIGF.IGM.getSetSuperclassFn(),
+        { classRef, swiftNativeNSObjectClass});
+  }
+  RegisterIGF.Builder.CreateRetVoid();
+
+  // Add the registration function as a static initializer. We use a priority
+  // slightly lower than used for C++ global constructors, so that the code is
+  // executed before C++ global constructors (in case someone uses archives
+  // from a C++ global constructor).
+  llvm::appendToGlobalCtors(IGM->Module, RegisterFn, 60000, nullptr);
+}
+
 /// Emit symbols for eliminated dead methods, which can still be referenced
 /// from other modules. This happens e.g. if a public class contains a (dead)
 /// private method.

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1111,6 +1111,7 @@ GeneratedModule IRGenRequest::evaluate(Evaluator &evaluator,
       IGM.emitBuiltinReflectionMetadata();
       IGM.emitReflectionMetadataVersion();
       irgen.emitEagerClassInitialization();
+      irgen.emitObjCActorsNeedingSuperclassSwizzle();
       irgen.emitDynamicReplacements();
     }
 
@@ -1351,6 +1352,7 @@ static void performParallelIRGeneration(IRGenDescriptor desc) {
   irgen.emitReflectionMetadataVersion();
 
   irgen.emitEagerClassInitialization();
+  irgen.emitObjCActorsNeedingSuperclassSwizzle();
 
   // Emit reflection metadata for builtin and imported types.
   irgen.emitBuiltinReflectionMetadata();

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1134,6 +1134,22 @@ void IRGenerator::addClassForEagerInitialization(ClassDecl *ClassDecl) {
   ClassesForEagerInitialization.push_back(ClassDecl);
 }
 
+void IRGenerator::addBackDeployedObjCActorInitialization(ClassDecl *ClassDecl) {
+  if (!ClassDecl->isActor())
+    return;
+
+  if (!ClassDecl->isObjC())
+    return;
+
+  // If we are not back-deploying concurrency, there's nothing to do.
+  ASTContext &ctx = ClassDecl->getASTContext();
+  auto deploymentAvailability = AvailabilityContext::forDeploymentTarget(ctx);
+  if (deploymentAvailability.isContainedIn(ctx.getConcurrencyAvailability()))
+    return;
+
+  ObjCActorsNeedingSuperclassSwizzle.push_back(ClassDecl);
+}
+
 llvm::AttributeList IRGenModule::getAllocAttrs() {
   if (AllocAttrs.isEmpty()) {
     AllocAttrs =

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -319,6 +319,8 @@ private:
 
   llvm::SmallVector<ClassDecl *, 4> ClassesForEagerInitialization;
 
+  llvm::SmallVector<ClassDecl *, 4> ObjCActorsNeedingSuperclassSwizzle;
+
   /// The order in which all the SIL function definitions should
   /// appear in the translation unit.
   llvm::DenseMap<SILFunction*, unsigned> FunctionOrder;
@@ -407,6 +409,7 @@ public:
   void emitReflectionMetadataVersion();
 
   void emitEagerClassInitialization();
+  void emitObjCActorsNeedingSuperclassSwizzle();
 
   // Emit the code to replace dynamicReplacement(for:) functions.
   void emitDynamicReplacements();
@@ -499,6 +502,7 @@ public:
 
 
   void addClassForEagerInitialization(ClassDecl *ClassDecl);
+  void addBackDeployedObjCActorInitialization(ClassDecl *ClassDecl);
 
   unsigned getFunctionOrder(SILFunction *F) {
     auto it = FunctionOrder.find(F);

--- a/test/Concurrency/Backdeploy/objc_actor.swift
+++ b/test/Concurrency/Backdeploy/objc_actor.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -target x86_64-apple-macosx10.15 %s -o %t/test_mangling -Xfrontend -disable-availability-checking -parse-as-library
-// RUN: %target-run %t/test_mangling
+// RUN: %target-build-swift -target x86_64-apple-macosx10.15 %s -o %t/test_backdeploy -Xfrontend -parse-as-library
+// RUN: %target-run %t/test_backdeploy
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: OS=macosx

--- a/test/IRGen/actor_class_objc_backdeploy.swift
+++ b/test/IRGen/actor_class_objc_backdeploy.swift
@@ -51,10 +51,9 @@ import Foundation
 // CHECK: swift_defaultActor_destroy
 
 // CHECK-LABEL: define private void @_swift_objc_actor_initialization()
-// CHECK: [[SWIFT_NATIVE_NSOBJECT_CLASS:%.*]]  = call %objc_class* @objc_lookUpClass(i8* getelementptr inbounds ([20 x i8], [20 x i8]* [[SWIFT_NATIVE_NSOBJECT_NAME]]
+// CHECK: [[SWIFT_NATIVE_NSOBJECT_CLASS:%.*]]  = call %objc_class* @objc_getRequiredClass(i8* getelementptr inbounds ([20 x i8], [20 x i8]* [[SWIFT_NATIVE_NSOBJECT_NAME]]
 // CHECK: [[ACTOR_RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$s16actor_class_objc7MyClassCMa"(
 // CHECK: [[ACTOR_METADATA:%.*]] = extractvalue %swift.metadata_response [[ACTOR_RESPONSE]], 0
-// CHECK: [[ACTOR_CLASS_RAW:%.*]] = bitcast %swift.type* [[ACTOR_METADATA]] to %objc_class*
-// CHECK: [[ACTOR_CLASS:%.*]] = call %objc_class* @objc_opt_self(%objc_class* [[ACTOR_CLASS_RAW]])
+// CHECK: [[ACTOR_CLASS:%.*]] = bitcast %swift.type* [[ACTOR_METADATA]] to %objc_class*
 // CHECK: call %objc_class* @class_setSuperclass(%objc_class* [[ACTOR_CLASS]], %objc_class* [[SWIFT_NATIVE_NSOBJECT_CLASS]])
 

--- a/test/IRGen/actor_class_objc_backdeploy.swift
+++ b/test/IRGen/actor_class_objc_backdeploy.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s -swift-version 5 -target %target-cpu-apple-macosx12.0 | %IRGenFileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s -swift-version 5 -target %target-cpu-apple-macosx11.0 -module-name actor_class_objc | %IRGenFileCheck %s
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
@@ -10,12 +10,12 @@ import Foundation
 
 // CHECK-LABEL: @"OBJC_METACLASS_$__TtC16actor_class_objc7MyClass" = global
 //   Metaclass is an instance of the root class.
-// CHECK-SAME: %objc_class* {{.*}}@"OBJC_METACLASS_$_SwiftNativeNSObject{{(.ptrauth)?}}"
+// CHECK-SAME: %objc_class* {{.*}}@"OBJC_METACLASS_$_NSObject{{(.ptrauth)?}}"
 
 // CHECK: @"$s16actor_class_objc7MyClassCMf" = internal global
 // CHECK-SAME: @"$s16actor_class_objc7MyClassCfD{{(.ptrauth)?}}"
 // CHECK-SAME: @"OBJC_METACLASS_$__TtC16actor_class_objc7MyClass{{(.ptrauth)?}}"
-// CHECK-SAME: @"OBJC_CLASS_$_SwiftNativeNSObject{{(.ptrauth)?}}"
+// CHECK-SAME: @"OBJC_CLASS_$_NSObject{{(.ptrauth)?}}"
 //   Flags: uses Swift refcounting
 // CHECK-SAME: i32 2,
 //   Instance size
@@ -33,6 +33,12 @@ import Foundation
   public init() { self.x = 0 }
 }
 
+// CHECK: [[SWIFT_NATIVE_NSOBJECT_NAME:@.*]] = private unnamed_addr constant [20 x i8] c"SwiftNativeNSObject\00"
+
+// CHECK: @llvm.global_ctors = appending global
+// CHECK-SAME: _swift_objc_actor_initialization
+
+
 // CHECK-LABEL: define {{.*}} @"$s16actor_class_objc7MyClassC1xSivg"
 // CHECK: [[T0:%.*]] = getelementptr inbounds %T16actor_class_objc7MyClassC, %T16actor_class_objc7MyClassC* %0, i32 0, i32 2
 // CHECK: [[T1:%.*]] = getelementptr inbounds %TSi, %TSi* [[T0]], i32 0, i32 0
@@ -43,3 +49,12 @@ import Foundation
 // CHECK-LABEL: ret %T16actor_class_objc7MyClassC*
 
 // CHECK: swift_defaultActor_destroy
+
+// CHECK-LABEL: define private void @_swift_objc_actor_initialization()
+// CHECK: [[SWIFT_NATIVE_NSOBJECT_CLASS:%.*]]  = call %objc_class* @objc_lookUpClass(i8* getelementptr inbounds ([20 x i8], [20 x i8]* [[SWIFT_NATIVE_NSOBJECT_NAME]]
+// CHECK: [[ACTOR_RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$s16actor_class_objc7MyClassCMa"(
+// CHECK: [[ACTOR_METADATA:%.*]] = extractvalue %swift.metadata_response [[ACTOR_RESPONSE]], 0
+// CHECK: [[ACTOR_CLASS_RAW:%.*]] = bitcast %swift.type* [[ACTOR_METADATA]] to %objc_class*
+// CHECK: [[ACTOR_CLASS:%.*]] = call %objc_class* @objc_opt_self(%objc_class* [[ACTOR_CLASS_RAW]])
+// CHECK: call %objc_class* @class_setSuperclass(%objc_class* [[ACTOR_CLASS]], %objc_class* [[SWIFT_NATIVE_NSOBJECT_CLASS]])
+


### PR DESCRIPTION
@objc actors implicitly inherit from the new, hidden
`SwiftNativeNSObject` class that inherits from `NSObject` yet provides
Swift-native reference counting, which is important for the actor
runtime's handling of zombies. However, `SwiftNativeNSObject` is only
available in the Swift runtime in newer OS versions (e.g., macOS
12.0/iOS 15.0), and is available in the back-deployed _Concurrency
library, but there is no stable place to link against for
back-deployed code. Tricky, tricky.

When back-deploying @objc actors, record `NSObject` as the superclass
in the metadata in the binary, because we cannot reference
`SwiftNativeNSObject`. Then, emit a static initializer to
dynamically look up `SwiftNativeNSObject` by name (which will find it
in either the back-deployment library, on older systems, or in the
runtime for newer systems), then swizzle that in as the superclass of
the @objc actor.

Fixes rdar://83919973.
