### PR TITLE
[ConstraintSystem] Allow function-function conversions for keypath literals

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -697,6 +697,12 @@ ERROR(expr_smart_keypath_application_type_mismatch,none,
       "key path of type %0 cannot be applied to a base of type %1",
       (Type, Type))
 ERROR(expr_keypath_root_type_mismatch, none,
+      "key path root type %0 cannot be converted to contextual type %1",
+      (Type, Type))
+ERROR(expr_keypath_type_mismatch, none,
+      "key path of type %0 cannot be converted to contextual type %1",
+      (Type, Type))
+ERROR(expr_keypath_application_root_type_mismatch, none,
       "key path with root type %0 cannot be applied to a base of type %1",
       (Type, Type))
 ERROR(expr_swift_keypath_anyobject_root,none,

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1733,6 +1733,11 @@ public:
   /// Retrieve the type of the \p ComponentIndex-th component in \p KP.
   Type getType(const KeyPathExpr *KP, unsigned ComponentIndex) const;
 
+  TypeVariableType *getKeyPathRootType(const KeyPathExpr *keyPath) const;
+
+  TypeVariableType *
+  getKeyPathRootTypeIfAvailable(const KeyPathExpr *keyPath) const;
+
   /// Retrieve the type of the given node as recorded in this solution
   /// and resolve all of the type variables in contains to form a fully
   /// "resolved" concrete type.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4971,20 +4971,18 @@ namespace {
       // Resolve each of the components.
       bool didOptionalChain = false;
       bool isFunctionType = false;
-      Type baseTy, leafTy;
+      auto baseTy = cs.simplifyType(solution.getKeyPathRootType(E));
+      Type leafTy;
       Type exprType = cs.getType(E);
       if (auto fnTy = exprType->getAs<FunctionType>()) {
-        baseTy = fnTy->getParams()[0].getParameterType();
         leafTy = fnTy->getResult();
         isFunctionType = true;
       } else if (auto *existential = exprType->getAs<ExistentialType>()) {
         auto layout = existential->getExistentialLayout();
         auto keyPathTy = layout.explicitSuperclass->castTo<BoundGenericType>();
-        baseTy = keyPathTy->getGenericArgs()[0];
         leafTy = keyPathTy->getGenericArgs()[1];
       } else {
         auto keyPathTy = exprType->castTo<BoundGenericType>();
-        baseTy = keyPathTy->getGenericArgs()[0];
         leafTy = keyPathTy->getGenericArgs()[1];
       }
 
@@ -5103,13 +5101,11 @@ namespace {
         assert(!resolvedComponents.empty());
         componentTy = resolvedComponents.back().getComponentType();
       }
-      
+
       // Wrap a non-optional result if there was chaining involved.
       if (didOptionalChain && componentTy &&
           !componentTy->hasUnresolvedType() &&
           !componentTy->getWithoutSpecifierType()->isEqual(leafTy)) {
-        assert(leafTy->getOptionalObjectType()->isEqual(
-            componentTy->getWithoutSpecifierType()));
         auto component = KeyPathExpr::Component::forOptionalWrap(leafTy);
         resolvedComponents.push_back(component);
         componentTy = leafTy;
@@ -5122,11 +5118,6 @@ namespace {
       // See whether there's an equivalent ObjC key path string we can produce
       // for interop purposes.
       checkAndSetObjCKeyPathString(E);
-      
-      // The final component type ought to line up with the leaf type of the
-      // key path.
-      assert(!componentTy || componentTy->hasUnresolvedType()
-             || componentTy->getWithoutSpecifierType()->isEqual(leafTy));
 
       if (!isFunctionType)
         return E;
@@ -9787,6 +9778,21 @@ Type Solution::getType(ASTNode node) const {
 Type Solution::getType(const KeyPathExpr *KP, unsigned I) const {
   assert(hasType(KP, I) && "Expected type to have been set!");
   return keyPathComponentTypes.find(std::make_pair(KP, I))->second;
+}
+
+TypeVariableType *
+Solution::getKeyPathRootType(const KeyPathExpr *keyPath) const {
+  auto result = getKeyPathRootTypeIfAvailable(keyPath);
+  assert(result);
+  return result;
+}
+
+TypeVariableType *
+Solution::getKeyPathRootTypeIfAvailable(const KeyPathExpr *keyPath) const {
+  auto result = KeyPaths.find(keyPath);
+  if (result != KeyPaths.end())
+    return std::get<0>(result->second);
+  return nullptr;
 }
 
 Type Solution::getResolvedType(ASTNode node) const {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2498,9 +2498,13 @@ bool ContextualFailure::diagnoseAsError() {
 
   if (path.empty()) {
     if (auto *KPE = getAsExpr<KeyPathExpr>(anchor)) {
-      emitDiagnosticAt(KPE->getLoc(),
-                       diag::expr_keypath_type_covert_to_contextual_type,
-                       getFromType(), getToType());
+      Diag<Type, Type> diag;
+      if (auto ctxDiag = getDiagnosticFor(CTP, getToType())) {
+        diag = *ctxDiag;
+      } else {
+        diag = diag::expr_keypath_type_mismatch;
+      }
+      emitDiagnosticAt(KPE->getLoc(), diag, getFromType(), getToType());
       return true;
     }
 
@@ -2751,9 +2755,14 @@ bool ContextualFailure::diagnoseAsError() {
     break;
   }
 
+  case ConstraintLocator::FunctionResult:
   case ConstraintLocator::KeyPathValue: {
-    diagnostic = diag::expr_keypath_value_covert_to_contextual_type;
-    break;
+    if (auto *KPE = getAsExpr<KeyPathExpr>(anchor)) {
+      diagnostic = diag::expr_keypath_value_covert_to_contextual_type;
+      break;
+    } else {
+      return false;
+    }
   }
 
   default:
@@ -8263,13 +8272,24 @@ bool CoercionAsForceCastFailure::diagnoseAsError() {
 
 bool KeyPathRootTypeMismatchFailure::diagnoseAsError() {
   auto locator = getLocator();
+  auto anchor = locator->getAnchor();
   assert(locator->isKeyPathRoot() && "Expected a key path root");
-  
-  auto baseType = getFromType();
-  auto rootType = getToType();
 
-  emitDiagnostic(diag::expr_keypath_root_type_mismatch,
-                 rootType, baseType);
+
+
+  if (isExpr<KeyPathApplicationExpr>(anchor) || isExpr<SubscriptExpr>(anchor)) {
+    auto baseType = getFromType();
+    auto rootType = getToType();
+
+    emitDiagnostic(diag::expr_keypath_application_root_type_mismatch,
+                   rootType, baseType);
+  } else {
+    auto rootType = getFromType();
+    auto expectedType = getToType();
+
+    emitDiagnostic(diag::expr_keypath_root_type_mismatch, rootType,
+                   expectedType);
+  }
   return true;
 }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5221,6 +5221,13 @@ bool ConstraintSystem::repairFailures(
                         });
   };
 
+  auto hasAnyRestriction = [&]() {
+    return llvm::any_of(conversionsOrFixes,
+                        [](const RestrictionOrFix &correction) {
+                          return bool(correction.getRestriction());
+                        });
+  };
+
   // Check whether this is a tuple with a single unlabeled element
   // i.e. `(_: Int)` and return type of that element if so. Note that
   // if the element is pack expansion type the tuple is significant.
@@ -5246,6 +5253,40 @@ bool ConstraintSystem::repairFailures(
     return true;
   }
 
+  auto maybeRepairKeyPathResultFailure = [&](KeyPathExpr *kpExpr) {
+    if (lhs->isPlaceholder() || rhs->isPlaceholder())
+      return true;
+    if (lhs->isTypeVariableOrMember() || rhs->isTypeVariableOrMember())
+      return false;
+
+    if (hasConversionOrRestriction(ConversionRestrictionKind::DeepEquality) ||
+        hasConversionOrRestriction(ConversionRestrictionKind::ValueToOptional))
+      return false;
+
+    auto i = kpExpr->getComponents().size() - 1;
+    auto lastCompLoc =
+        getConstraintLocator(kpExpr, LocatorPathElt::KeyPathComponent(i));
+    if (hasFixFor(lastCompLoc, FixKind::AllowTypeOrInstanceMember))
+      return true;
+
+    auto *keyPathLoc = getConstraintLocator(anchor);
+
+    if (hasFixFor(keyPathLoc))
+      return true;
+
+    if (auto contextualInfo = getContextualTypeInfo(anchor)) {
+      if (hasFixFor(getConstraintLocator(
+              keyPathLoc,
+              LocatorPathElt::ContextualType(contextualInfo->purpose))))
+        return true;
+    }
+
+    conversionsOrFixes.push_back(IgnoreContextualType::create(
+        *this, lhs, rhs,
+        getConstraintLocator(keyPathLoc, ConstraintLocator::KeyPathValue)));
+    return true;
+  };
+
   if (path.empty()) {
     if (!anchor)
       return false;
@@ -5265,9 +5306,9 @@ bool ConstraintSystem::repairFailures(
     // instance fix recorded.
     if (auto *kpExpr = getAsExpr<KeyPathExpr>(anchor)) {
       if (isKnownKeyPathType(lhs) && isKnownKeyPathType(rhs)) {
-        // If we have keypath capabilities for both sides and one of the bases
-        // is unresolved, it is too early to record fix.
-        if (hasConversionOrRestriction(ConversionRestrictionKind::DeepEquality))
+        // If we have a conversion happening here, we should let fix happen in
+        // simplifyRestrictedConstraint.
+        if (hasAnyRestriction())
           return false;
       }
 
@@ -5667,10 +5708,7 @@ bool ConstraintSystem::repairFailures(
 
     // If there are any restrictions here we need to wait and let
     // `simplifyRestrictedConstraintImpl` handle them.
-    if (llvm::any_of(conversionsOrFixes,
-                     [](const RestrictionOrFix &correction) {
-                       return bool(correction.getRestriction());
-                     }))
+    if (hasAnyRestriction())
       break;
 
     if (auto *fix = fixPropertyWrapperFailure(
@@ -6089,10 +6127,7 @@ bool ConstraintSystem::repairFailures(
 
     // If there are any restrictions here we need to wait and let
     // `simplifyRestrictedConstraintImpl` handle them.
-    if (llvm::any_of(conversionsOrFixes,
-                     [](const RestrictionOrFix &correction) {
-                       return bool(correction.getRestriction());
-                     }))
+    if (hasAnyRestriction())
       break;
 
     // `lhs` - is an result type and `rhs` is a contextual type.
@@ -6109,6 +6144,10 @@ bool ConstraintSystem::repairFailures(
       recordAnyTypeVarAsPotentialHole(lhs);
       recordAnyTypeVarAsPotentialHole(rhs);
       return true;
+    }
+
+    if (auto *kpExpr = getAsExpr<KeyPathExpr>(anchor)) {
+      return maybeRepairKeyPathResultFailure(kpExpr);
     }
 
     auto *loc = getConstraintLocator(anchor, {path.begin(), path.end() - 1});
@@ -6682,37 +6721,9 @@ bool ConstraintSystem::repairFailures(
     return true;
   }
   case ConstraintLocator::KeyPathValue: {
-    if (lhs->isPlaceholder() || rhs->isPlaceholder())
-      return true;
-    if (lhs->isTypeVariableOrMember() || rhs->isTypeVariableOrMember())
-      break;
-
-    if (hasConversionOrRestriction(ConversionRestrictionKind::DeepEquality) ||
-        hasConversionOrRestriction(ConversionRestrictionKind::ValueToOptional))
-      return false;
-
-    auto kpExpr = castToExpr<KeyPathExpr>(anchor);
-    auto i = kpExpr->getComponents().size() - 1;
-    auto lastCompLoc =
-        getConstraintLocator(kpExpr, LocatorPathElt::KeyPathComponent(i));
-    if (hasFixFor(lastCompLoc, FixKind::AllowTypeOrInstanceMember))
+    if (maybeRepairKeyPathResultFailure(getAsExpr<KeyPathExpr>(anchor)))
       return true;
 
-    auto *keyPathLoc = getConstraintLocator(anchor);
-
-    if (hasFixFor(keyPathLoc))
-      return true;
-
-    if (auto contextualInfo = getContextualTypeInfo(anchor)) {
-      if (hasFixFor(getConstraintLocator(
-              keyPathLoc,
-              LocatorPathElt::ContextualType(contextualInfo->purpose))))
-        return true;
-    }
-
-    conversionsOrFixes.push_back(IgnoreContextualType::create(
-        *this, lhs, rhs,
-        getConstraintLocator(keyPathLoc, ConstraintLocator::KeyPathValue)));
     break;
   }
   default:
@@ -12246,12 +12257,26 @@ ConstraintSystem::simplifyKeyPathConstraint(
 
     if (auto fnTy = contextualTy->getAs<FunctionType>()) {
       assert(fnTy->getParams().size() == 1);
-      // Match up the root and value types to the function's param and return
-      // types. Note that we're using the type of the parameter as referenced
-      // from inside the function body as we'll be transforming the code into:
-      // { root in root[keyPath: kp] }.
-      contextualRootTy = fnTy->getParams()[0].getParameterType();
-      contextualValueTy = fnTy->getResult();
+      // Key paths may be converted to a function of compatible type. We will
+      // later form from this key path an implicit closure of the form
+      // `{ root in root[keyPath: kp] }` so any conversions that are valid with
+      // a source type of `(Root) -> Value` should be valid here too.
+      auto rootParam = AnyFunctionType::Param(rootTy);
+      auto kpFnTy = FunctionType::get(rootParam, valueTy, fnTy->getExtInfo());
+
+      // Note: because the keypath is applied to `root` as a parameter internal
+      // to the closure, we use the function parameter's "parameter type" rather
+      // than the raw type. This enables things like:
+      // ```
+      // let countKeyPath: (String...) -> Int = \.count
+      // ```
+      auto paramTy = fnTy->getParams()[0].getParameterType();
+      auto paramParam = AnyFunctionType::Param(paramTy);
+      auto paramFnTy = FunctionType::get(paramParam, fnTy->getResult(),
+                                         fnTy->getExtInfo());
+
+      return matchTypes(kpFnTy, paramFnTy, ConstraintKind::Conversion, subflags,
+                        locator).isSuccess();
     }
 
     assert(contextualRootTy && contextualValueTy);

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -81,8 +81,8 @@ func testVariadicKeypathAsFunc() {
 
   // These are not okay, the KeyPath should have a base that matches the
   // internal parameter type of the function, i.e (S...).
-  let _: (S...) -> Int = \S.i // expected-error {{key path with root type 'S...' cannot be applied to a base of type 'S'}}
-  takesVariadicFnWithGenericRet(\S.i) // expected-error {{key path with root type 'S...' cannot be applied to a base of type 'S'}}
+  let _: (S...) -> Int = \S.i // expected-error {{key path root type 'S' cannot be converted to contextual type 'S...'}}
+  takesVariadicFnWithGenericRet(\S.i) // expected-error {{key path root type 'S' cannot be converted to contextual type 'S...'}}
 }
 
 // rdar://problem/54322807
@@ -231,7 +231,7 @@ func issue_65965() {
   let refKP: ReferenceWritableKeyPath<S, String>
   refKP = \.s
   // expected-error@-1 {{cannot convert key path type 'WritableKeyPath<S, String>' to contextual type 'ReferenceWritableKeyPath<S, String>'}}
-	
+
   let writeKP: WritableKeyPath<S, String>
   writeKP = \.v
   // expected-error@-1 {{cannot convert key path type 'KeyPath<S, String>' to contextual type 'WritableKeyPath<S, String>'}}

--- a/unittests/Sema/CMakeLists.txt
+++ b/unittests/Sema/CMakeLists.txt
@@ -6,7 +6,8 @@ add_swift_unittest(swiftSemaTests
   ConstraintSimplificationTests.cpp
   UnresolvedMemberLookupTests.cpp
   PlaceholderTypeInferenceTests.cpp
-  SolutionFilteringTests.cpp)
+  SolutionFilteringTests.cpp
+  KeypathFunctionConversionTests.cpp)
 
 target_link_libraries(swiftSemaTests
   PRIVATE

--- a/unittests/Sema/KeypathFunctionConversionTests.cpp
+++ b/unittests/Sema/KeypathFunctionConversionTests.cpp
@@ -1,0 +1,125 @@
+//===--- UnresolvedMemberLookupTests.cpp --------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "SemaFixture.h"
+#include "swift/AST/GenericParamList.h"
+#include "swift/Sema/ConstraintSystem.h"
+
+using namespace swift;
+using namespace swift::unittest;
+using namespace swift::constraints;
+
+/// Even in the face of a more permissive conversion that might be chosen based
+/// on other ranking rules (e.g., the overload required is non-generic), ensure
+/// that we will select the solution which requires the more narrow conversion
+/// (e.g., the overload *is* generic).
+TEST_F(SemaTest, TestKeypathFunctionConversionPrefersNarrowConversion) {
+  auto boolType = getStdlibType("Bool");
+  auto boolOptType = OptionalType::get(boolType);
+  auto stringType = getStdlibType("String");
+
+  auto *genericParam1 = GenericTypeParamDecl::createImplicit(
+      DC, Context.getIdentifier("T"), 0, 0);
+  auto genericType1 =
+      genericParam1->getDeclaredInterfaceType()->getAs<GenericTypeParamType>();
+
+  auto *genericParam2 = GenericTypeParamDecl::createImplicit(
+      DC, Context.getIdentifier("T"), 0, 1);
+  auto genericType2 =
+      genericParam2->getDeclaredInterfaceType()->getAs<GenericTypeParamType>();
+
+  auto declName = DeclName(Context, Context.getIdentifier("f"), {Identifier()});
+
+  // func f<T, U>(_: (T) -> U))
+  auto innerGenericFnParam = AnyFunctionType::Param(genericType1);
+  auto genericFnParamTy = FunctionType::get({innerGenericFnParam}, genericType2)
+                              ->withExtInfo(AnyFunctionType::ExtInfo());
+  auto *genericFnParamDecl = ParamDecl::createImplicit(
+      Context, Identifier(), Identifier(), genericFnParamTy, DC);
+  genericFnParamDecl->setSpecifier(ParamSpecifier::Default);
+  auto *genericFnParamList =
+      ParameterList::createWithoutLoc(genericFnParamDecl);
+  llvm::SmallVector<GenericTypeParamDecl *, 2> genericParams = {genericParam1,
+                                                                genericParam2};
+  auto *genericParamList =
+      GenericParamList::create(Context, SourceLoc(), {}, SourceLoc());
+  auto genericFnDecl = FuncDecl::create(
+      Context, SourceLoc(), StaticSpellingKind::None, SourceLoc(), declName,
+      SourceLoc(), /*async=*/false, SourceLoc(), /*throws=*/false, SourceLoc(),
+      nullptr, genericParamList, genericFnParamList, nullptr, DC);
+  auto genericFnParam = AnyFunctionType::Param(genericFnParamTy);
+  llvm::SmallVector<GenericTypeParamType *, 2> genericTypeParams = {
+      genericType1, genericType2};
+  auto genericSig = GenericSignature::get(genericTypeParams, {});
+  auto genericFnTy = GenericFunctionType::get(genericSig, {genericFnParam},
+                                              Context.TheEmptyTupleType)
+                         ->withExtInfo(AnyFunctionType::ExtInfo());
+  genericFnDecl->setInterfaceType(genericFnTy);
+
+  // func f(_: (String) -> Bool?)
+  auto innerConcreteFnParam = AnyFunctionType::Param(stringType);
+  auto concreteFnParamTy =
+      FunctionType::get({innerConcreteFnParam}, boolOptType)
+          ->withExtInfo(AnyFunctionType::ExtInfo());
+  auto *concreteFnParamDecl = ParamDecl::createImplicit(
+      Context, Identifier(), Identifier(), concreteFnParamTy, DC);
+  concreteFnParamDecl->setSpecifier(ParamSpecifier::Default);
+  auto *concreteFnParamList =
+      ParameterList::createWithoutLoc(concreteFnParamDecl);
+  auto concreteFnDecl = FuncDecl::create(
+      Context, SourceLoc(), StaticSpellingKind::None, SourceLoc(), declName,
+      SourceLoc(), /*async=*/false, SourceLoc(), /*throws=*/false, SourceLoc(),
+      nullptr, nullptr, concreteFnParamList, nullptr, DC);
+  auto concreteFnParam = AnyFunctionType::Param(concreteFnParamTy);
+  auto concreteFnTy =
+      FunctionType::get({concreteFnParam}, Context.TheEmptyTupleType)
+          ->withExtInfo(AnyFunctionType::ExtInfo());
+  concreteFnDecl->setInterfaceType(concreteFnTy);
+
+  // \String.isEmpty
+  auto *stringDRE = TypeExpr::createImplicitForDecl(
+      DeclNameLoc(), stringType->getAnyNominal(), Context.getStdlibModule(),
+      stringType);
+  auto *isEmptyDE = new (Context) UnresolvedDotExpr(
+      stringDRE, SourceLoc(), DeclNameRef(Context.getIdentifier("isEmpty")),
+      DeclNameLoc(), false);
+  auto *kpExpr = KeyPathExpr::createParsed(Context, SourceLoc(), isEmptyDE,
+                                           nullptr, false);
+
+  // f(\String.isEmpty)
+  auto kpArg = Argument(SourceLoc(), Identifier(), kpExpr);
+  auto *argList = ArgumentList::create(Context, SourceLoc(), {kpArg},
+                                       SourceLoc(), llvm::None, false);
+  llvm::SmallVector<ValueDecl *, 2> fDecls = {genericFnDecl, concreteFnDecl};
+  auto *fDRE = new (Context) OverloadedDeclRefExpr(
+      fDecls, DeclNameLoc(), FunctionRefKind::SingleApply, false);
+  auto *callExpr = CallExpr::create(Context, fDRE, argList, false);
+
+  Expr *target = callExpr;
+  ConstraintSystem cs(DC, ConstraintSystemOptions());
+  ASSERT_FALSE(cs.preCheckExpression(target, DC, false));
+  auto *expr = cs.generateConstraints(callExpr, DC);
+  ASSERT_TRUE(expr);
+
+  SmallVector<Solution, 2> solutions;
+  cs.solve(solutions);
+
+  // We should have a solution.
+  ASSERT_EQ(solutions.size(), 1u);
+
+  auto &solution = solutions[0];
+  auto *locator = cs.getConstraintLocator(fDRE);
+  auto choice = solution.getOverloadChoice(locator).choice;
+
+  // We should select the generic function since it requires 'less' conversion.
+  ASSERT_EQ(choice.getDecl(), genericFnDecl);
+}


### PR DESCRIPTION
Currently the keypath-to-function conversion is extremely narrow—root and value types of the keypath must exactly match the function argument and result types of the function, respectively.

This PR allows the keypath-to-function conversion to partake in the full generality of function-function type conversion. This means a keypath literal can be covariant in result type and contravariant in argument type, etc.
