### PR TITLE
[Frontend] Don't ask to report bugs for a script failure

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -2034,6 +2034,15 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     return finishDiagProcessing(1, /*verifierEnabled*/ false);
   }
 
+  // Don't ask clients to report bugs when running a script in immediate mode.
+  // When a script asserts the compiler reports the error with the same
+  // stacktrace as a compiler crash. From here we can't tell which is which,
+  // for now let's not explicitly ask for bug reports.
+  if (Invocation.getFrontendOptions().RequestedAction ==
+      FrontendOptions::ActionType::Immediate) {
+    llvm::setBugReportMsg(nullptr);
+  }
+
   PrettyStackTraceFrontend frontendTrace(Invocation.getLangOptions());
 
   // Make an array of PrettyStackTrace objects to dump the configuration files

--- a/test/Frontend/immediate-mode-crash.swift
+++ b/test/Frontend/immediate-mode-crash.swift
@@ -1,0 +1,9 @@
+/// Don't ask to file a bug report on a script failure.
+
+// REQUIRES: swift_interpreter
+
+// RUN: not --crash %target-swift-frontend -interpret %s 2>&1 | %FileCheck %s
+
+assert(false)
+// CHECK: Assertion failed
+// CHECK-NOT: Please submit a bug report


### PR DESCRIPTION
A script `crash.swift` failing on an assert such as:
```
assert(false)
```

Leads to a full stacktrace starting with a request to file a bug to swift.org:
```
% swift crash.swift
crash/crash.swift:1: Assertion failed
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the project and the crash backtrace.
Stack dump:
...
```

This message is confusing as the issue here is an expected user-side script failure. Let's remove the "Please submit a bug report..." line in immediate mode and keep the stacktrace as it has useful information, even if likely too much for the need of the script developer. Note that this will apply to failures in both client code and in the compiler.

rdar://81233463