### PR TITLE
[Concurrency] Harden async_task_locals_copy_to_sync

### DIFF
--- a/test/Concurrency/Runtime/async_task_locals_copy_to_sync.swift
+++ b/test/Concurrency/Runtime/async_task_locals_copy_to_sync.swift
@@ -19,7 +19,6 @@ import Darwin
 import Glibc
 #endif
 
-@available(SwiftStdlib 5.5, *)
 enum TL {
   @TaskLocal
   static var number: Int = 0
@@ -27,7 +26,6 @@ enum TL {
   static var other: Int = 0
 }
 
-@available(SwiftStdlib 5.5, *)
 @discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
@@ -45,9 +43,10 @@ func printTaskLocal<V>(
 
 // ==== ------------------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
 func copyTo_sync_noWait() {
   print(#function)
+  let sem = DispatchSemaphore(value: 0)
+
   TL.$number.withValue(1111) {
     TL.$number.withValue(2222) {
       TL.$other.withValue(9999) {
@@ -57,26 +56,29 @@ func copyTo_sync_noWait() {
           TL.$number.withValue(3333) {
             printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (3333)
             printTaskLocal(TL.$other) // CHECK: TaskLocal<Int>(defaultValue: 0) (9999)
+            sem.signal()
           }
         }
       }
     }
   }
 
-  sleep(1)
+  sem.wait()
 }
 
-@available(SwiftStdlib 5.5, *)
 func copyTo_sync_noValues() {
+  print(#function)
+  let sem = DispatchSemaphore(value: 0)
+
   Task {
     printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (0)
+    sem.signal()
   }
 
-  sleep(1)
+  sem.wait()
 }
 
 /// Similar to tests in `async_task_locals_copy_to_async_ but without any task involved at the top level.
-@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() {
     copyTo_sync_noWait()


### PR DESCRIPTION
The test was a bit racy in that it was using a sleep for a bit to observe the printouts, those could perhaps be slower on a very slow machine, yielding a flaky test.

Replacement: use semaphores.

resolves rdar://83940885