### PR TITLE
🍒 [Concurrency] Harden async_task_locals_copy_to_sync

### DIFF
--- a/test/Concurrency/Runtime/async_task_locals_copy_to_sync.swift
+++ b/test/Concurrency/Runtime/async_task_locals_copy_to_sync.swift
@@ -17,7 +17,6 @@ import Darwin
 import Glibc
 #endif
 
-@available(SwiftStdlib 5.5, *)
 enum TL {
   @TaskLocal
   static var number: Int = 0
@@ -25,7 +24,6 @@ enum TL {
   static var other: Int = 0
 }
 
-@available(SwiftStdlib 5.5, *)
 @discardableResult
 func printTaskLocal<V>(
     _ key: TaskLocal<V>,
@@ -43,9 +41,10 @@ func printTaskLocal<V>(
 
 // ==== ------------------------------------------------------------------------
 
-@available(SwiftStdlib 5.5, *)
 func copyTo_sync_noWait() {
   print(#function)
+  let sem = DispatchSemaphore(value: 0)
+
   TL.$number.withValue(1111) {
     TL.$number.withValue(2222) {
       TL.$other.withValue(9999) {
@@ -55,26 +54,29 @@ func copyTo_sync_noWait() {
           TL.$number.withValue(3333) {
             printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (3333)
             printTaskLocal(TL.$other) // CHECK: TaskLocal<Int>(defaultValue: 0) (9999)
+            sem.signal()
           }
         }
       }
     }
   }
 
-  sleep(1)
+  sem.wait()
 }
 
-@available(SwiftStdlib 5.5, *)
 func copyTo_sync_noValues() {
+  print(#function)
+  let sem = DispatchSemaphore(value: 0)
+
   Task {
     printTaskLocal(TL.$number) // CHECK: TaskLocal<Int>(defaultValue: 0) (0)
+    sem.signal()
   }
 
-  sleep(1)
+  sem.wait()
 }
 
 /// Similar to tests in `async_task_locals_copy_to_async_ but without any task involved at the top level.
-@available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() {
     copyTo_sync_noWait()


### PR DESCRIPTION
**Description:** The test naively assumed the code will complete quickly and did a sleep after the spawning of a `Task{}` -- this leads to flaky behavior on slow machines. The test specifically must create tasks from synchronous code, to exercise the code-path for such context. This means we're not really able to use `await` as it would cause the test not utilize the intended code path. This change makes use of a semaphore instead of a naive sleep to stabilize the test.
**Risk:** Low, test-only change
**Review by:** @DougGregor 
**Testing:** PR validation on main and 5.5 branches 
**Original PR:** https://github.com/apple/swift/pull/39621
**Radar:** rdar://83940885