### PR TITLE
SIL: Lower closure functions' captures in their own expansion context.

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2212,8 +2212,13 @@ static CanSILFunctionType getSILFunctionType(
 
   // Lower the capture context parameters, if any.
   if (constant && constant->getAnyFunctionRef()) {
+    // Lower in the context of the closure. Since the set of captures is a
+    // private contract between the closure and its enclosing context, we
+    // don't need to keep its capture types opaque.
     auto expansion = TypeExpansionContext::maximal(
-        expansionContext.getContext(), expansionContext.isWholeModuleContext());
+        constant->getAnyFunctionRef()->getAsDeclContext(), false);
+    // ...unless it's inlinable, in which case it might get inlined into
+    // some place we need to keep opaque types opaque.
     if (constant->isSerialized())
       expansion = TypeExpansionContext::minimal();
     lowerCaptureContextParameters(TC, *constant, genericSig, expansion, inputs);

--- a/test/SILGen/opaque_result_type_captured.swift
+++ b/test/SILGen/opaque_result_type_captured.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-emit-silgen -disable-availability-checking -verify %s
+// rdar://83378116
+
+public protocol P {}
+public protocol Q {}
+
+struct SP<T: P>: P { init(t: T) {} }
+struct SQ: Q {}
+
+struct Tubb<C: Q, T, F> {
+}
+
+extension Tubb: P where T: P, F: P {
+    init(c: C, t: () -> T, f: () -> F) {}
+}
+
+struct SP2: P {}
+
+func bar() -> some P { return SP2() }
+
+public struct Butt {
+    public func foo() -> some P {
+        let sp = SP(t: bar())
+        return Tubb(c: SQ(), t: { sp }, f: { sp })
+    }
+}


### PR DESCRIPTION
The capture arguments are a private contract between the closure and its
context, and will only ever be bound from the enclosing context, so
there's no need to obscure opaque underlying types (unless it's
serializable because it's in inlinable code, in which case we
continue to use the minimal type expansion context to account for
inlining as before.)

Fixes rdar://83378116.