### PR TITLE
Fix async_task_priority_current priority escalation test

### DIFF
--- a/test/Concurrency/Runtime/async_task_priority_current.swift
+++ b/test/Concurrency/Runtime/async_task_priority_current.swift
@@ -42,8 +42,8 @@ func test_detach() async {
   await detach(priority: .default) {
     let a3 = Task.currentPriority
     // The priority of 'a3' may either be 21 (default) or elevated to that of
-    // the main function, whichever is greater.
-    print("a3: \(a3)") // CHECK: a3: TaskPriority(rawValue: [[#max(MAIN_PRIORITY,21)]]
+    // the main function.
+    print("a3: \(a3)") // CHECK: a3: TaskPriority(rawValue: {{21|[[#MAIN_PRIORITY]]}})
   }.get()
 
   let a4 = Task.currentPriority


### PR DESCRIPTION
The priority escalation doesn't work quite as I thought it did. It isn't
whichever is greater, the priority of the task or the priority of the
place awaiting the result of the task. It seems to be less reliable than
that. I've changed the test accept either a default priority or that of
the main thread.