### PR TITLE
[ClangImporter] Check `!isUnimportable` instead of `isAvailable` for `canImport`.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1798,13 +1798,13 @@ bool ClangImporter::canImportModule(ImportPath::Element moduleID,
   clang::Module::UnresolvedHeaderDirective mh;
   clang::Module *m;
   auto &ctx = Impl.getClangASTContext();
-  auto available = clangModule->isAvailable(ctx.getLangOpts(), getTargetInfo(),
-                                            r, mh, m);
-  if (!available)
+  auto importable =
+      !clangModule->isUnimportable(ctx.getLangOpts(), getTargetInfo(), r, m);
+  if (!importable)
     return false;
   if (version.empty())
     return true;
-  assert(available);
+  assert(importable);
   assert(!version.empty());
   llvm::VersionTuple currentVersion;
   StringRef path = getClangASTContext().getSourceManager()

--- a/test/ClangImporter/Inputs/custom-modules/EmbeddedFiles/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/EmbeddedFiles/module.map
@@ -1,0 +1,4 @@
+module EmbeddedFiles {
+    header "types.h"
+    textual header "textual.inc"
+}

--- a/test/ClangImporter/Inputs/custom-modules/EmbeddedFiles/textual.inc
+++ b/test/ClangImporter/Inputs/custom-modules/EmbeddedFiles/textual.inc
@@ -1,0 +1,10 @@
+#ifndef FIELD
+#error "FIELD must be defined before including this file"
+#endif
+
+// FIELD(TYPE, NAME)
+
+FIELD(int, number)
+FIELD(const char *, name)
+
+#undef FIELD

--- a/test/ClangImporter/Inputs/custom-modules/EmbeddedFiles/types.h
+++ b/test/ClangImporter/Inputs/custom-modules/EmbeddedFiles/types.h
@@ -1,0 +1,4 @@
+struct EmbeddedFilesTy {
+#define FIELD(TYPE, NAME) TYPE field_##NAME;
+#include "textual.inc"
+};

--- a/test/ClangImporter/can_import_explicit_module_without_headers.swift
+++ b/test/ClangImporter/can_import_explicit_module_without_headers.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+
+// Copy the module map and headers into a sandbox.
+// RUN: mkdir %t/sandbox
+// RUN: cp %S/Inputs/custom-modules/EmbeddedFiles/module.map %t/sandbox
+// RUN: cp %S/Inputs/custom-modules/EmbeddedFiles/textual.inc %t/sandbox
+// RUN: cp %S/Inputs/custom-modules/EmbeddedFiles/types.h %t/sandbox
+
+// Embed all input files in the explicit module. This makes it self-contained,
+// letting us copy it around without bringing along all of its headers.
+// RUN: %target-swift-emit-pcm -module-name EmbeddedFiles -Xcc -Xclang -Xcc -fmodules-embed-all-files -o %t/EmbeddedFiles.pcm %t/sandbox/module.map
+
+// Delete the headers from the sandbox.
+// RUN: rm %t/sandbox/textual.inc %t/sandbox/types.h
+
+// Verify that ClangImporter still reports that the module is importable.
+// Use the `-fmodule-file=NAME=PATH` form of the flag that only loads the
+// module when it is requested.
+// RUN: %target-swift-frontend -typecheck -verify -Xcc -fmodule-map-file=%t/sandbox/module.map -Xcc -fmodule-file=EmbeddedFiles=%t/EmbeddedFiles.pcm %s
+
+#if canImport(EmbeddedFiles)
+  import EmbeddedFiles
+#endif
+
+var _ = EmbeddedFilesTy(
+    field_number: 0,
+    field_name: nil)


### PR DESCRIPTION
So... this one's a doozy.

As we started using explicit modules for more of our Obj-C dependencies, we found that if we used `#if canImport`, it would evaluate to false even when the explicit module was present. Here's a summary of why this was happening, and why I think this is the correct fix.

## What's happening

In our builds, we compile explicit modules with `-fmodules-embed-all-files` to create a standalone module file—all the headers are embedded in the module so we don't have to copy them over to remote build machines (except for headers directly included by a Clang module being compiled, because Clang requires they be physically on the file system before it will map them to the correct module).

Each time we invoke `swiftc`, we use the `-fmodule-file=NAME=PATH` form that lets us override the path that Clang should find each module at. We have to do this because:

*   The modules contain absolute paths to the modules they depend on.
*   We can't use `-fmodule-map-file-home-is-cwd` to make those paths CWD-relative because this flag isn't compatible with Apple's framework modules.
*   We also can't use the simpler `-fmodule-file=PATH`; when Clang tries to load the AST, it would try to load the dependencies' ASTs from absolute paths that no longer exist.

The `-fmodule-file=NAME=PATH` form works, but it has another side effect—it _delays loading of the module_ until it is actually requested by the compiler (whereas `-fmodule-file=PATH` _eagerly loads_ the module). This accounts for the difference in behavior for `canImport`. If the module was eagerly loaded with `-fmodule-file=PATH`, then Clang's ASTReader would [set the `Module::IsAvailable` flag to true](https://github.com/apple/llvm-project/blob/7e5a9fd2d89798646b38c63a44c348b478f098be/clang/lib/Serialization/ASTReader.cpp#L5566) and the `Module::isAvailable()` check made by `ClangImporter` would [immediately return true](https://github.com/apple/llvm-project/blob/7e5a9fd2d89798646b38c63a44c348b478f098be/clang/lib/Basic/Module.cpp#L163-L164). In fact, there is a comment explicitly noting that [missing headers do not make an explicit module file unavailable](https://github.com/apple/llvm-project/blob/7e5a9fd2d89798646b38c63a44c348b478f098be/clang/lib/Serialization/ASTReader.cpp#L5559-L5561) when it is deserialized.

**However,** if a module is passed to be loaded on-demand with `-fmodule-file=NAME=PATH`, and we consider that `#if canImport` typically guards the loading of that very same module, then when ClangImporter evaluates the `canImport` expression, the module naturally hasn't been loaded yet. This sends the `Module::isAvailable()` function through a different code path:

*   The `IsAvailable` fast-path flag isn't true, so it keeps going.
*   It checks that [`isUnimportable` returns false](https://github.com/apple/llvm-project/blob/7e5a9fd2d89798646b38c63a44c348b478f098be/clang/lib/Basic/Module.cpp#L166), so as long as requirements are satisfied, it keeps going.
*   _(Here's where things go wrong)_  It looks for missing headers, and reports that the module [is unavailable if there were any](https://github.com/apple/llvm-project/blob/7e5a9fd2d89798646b38c63a44c348b478f098be/clang/lib/Basic/Module.cpp#L169-L176). This happens even if the headers aren't available on the filesystem, even if they were embedded in the module via `-fmodules-embed-all-files`.

## Proposed fix

Use `!isUnimportable` instead of `isAvailable` to determine whether a module can be imported or not. This works with `-fmodule-file=NAME=PATH`, even when the headers are embedded and not otherwise present on the filesystem, and is consistent with the availability of the module once it was loaded anyway.

The one situation I can potentially see this allowing that wasn't allowed before is that `canImport` would now return `true` instead of `false` for a module defined in a regular module map but whose headers were missing. I'm not sure we should worry about that—surely that module is broken anyway, right?

WDYT? 😬 