### PR TITLE
Suggest Replacement Types for Invalid Placeholders

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3703,6 +3703,12 @@ NOTE(descriptive_generic_type_declared_here,none,
 
 ERROR(placeholder_type_not_allowed,none,
       "type placeholder not allowed here", ())
+ERROR(placeholder_type_not_allowed_in_return_type,none,
+      "type placeholder may not appear in function return type", ())
+ERROR(placeholder_type_not_allowed_in_parameter,none,
+      "type placeholder may not appear in top-level parameter", ())
+NOTE(replace_placeholder_with_inferred_type,none,
+     "replace the placeholder with the correct type %0", (Type))
 
 WARNING(use_of_void_pointer,none,
 "Unsafe%0Pointer<Void> has been replaced by Unsafe%0RawPointer", (StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3624,8 +3624,6 @@ ERROR(cannot_force_unwrap_nil_literal,none,
 
 ERROR(could_not_infer_placeholder,none,
       "could not infer type for placeholder", ())
-ERROR(top_level_placeholder_type,none,
-      "placeholders are not allowed as top-level types", ())
 
 ERROR(type_of_expression_is_ambiguous,none,
       "type of expression is ambiguous without more context", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3708,7 +3708,7 @@ ERROR(placeholder_type_not_allowed_in_return_type,none,
 ERROR(placeholder_type_not_allowed_in_parameter,none,
       "type placeholder may not appear in top-level parameter", ())
 NOTE(replace_placeholder_with_inferred_type,none,
-     "replace the placeholder with the correct type %0", (Type))
+     "replace the placeholder with the inferred type %0", (Type))
 
 WARNING(use_of_void_pointer,none,
 "Unsafe%0Pointer<Void> has been replaced by Unsafe%0RawPointer", (StringRef))

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3640,7 +3640,6 @@ GenericFunctionType *GenericFunctionType::get(GenericSignature sig,
                                               Optional<ExtInfo> info) {
   assert(sig && "no generic signature for generic function type?!");
   assert(!result->hasTypeVariable());
-  assert(!result->hasPlaceholder());
 
   llvm::FoldingSetNodeID id;
   GenericFunctionType::Profile(id, sig, params, result, info);

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1073,7 +1073,6 @@ void ASTMangler::appendType(Type type, GenericSignature sig,
   TypeBase *tybase = type.getPointer();
   switch (type->getKind()) {
     case TypeKind::TypeVariable:
-    case TypeKind::Placeholder:
       llvm_unreachable("mangling type variable");
 
     case TypeKind::Module:
@@ -1081,6 +1080,7 @@ void ASTMangler::appendType(Type type, GenericSignature sig,
 
     case TypeKind::Error:
     case TypeKind::Unresolved:
+    case TypeKind::Placeholder:
       appendOperator("Xe");
       return;
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8643,6 +8643,7 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
     Type convertType = target.getExprConversionType();
     auto shouldCoerceToContextualType = [&]() {
       return convertType &&
+          !convertType->hasPlaceholder() &&
           !target.isOptionalSomePatternInit() &&
           !(solution.getType(resultExpr)->isUninhabited() &&
             cs.getContextualTypePurpose(target.getAsExpr())

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1318,6 +1318,11 @@ namespace {
       if (result->hasError()) {
         return Type();
       }
+      // Diagnose top-level usages of placeholder types.
+      if (isa<TopLevelCodeDecl>(CS.DC) && isa<PlaceholderTypeRepr>(repr)) {
+        CS.getASTContext().Diags.diagnose(repr->getLoc(),
+                                          diag::placeholder_type_not_allowed);
+      }
       return result;
     }
 

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -1506,9 +1506,7 @@ TypeExpr *PreCheckExpression::simplifyNestedTypeExpr(UnresolvedDotExpr *UDE) {
         },
         // FIXME: Don't let placeholder types escape type resolution.
         // For now, just return the placeholder type.
-        [](auto &ctx, auto *originator) {
-          return Type();
-        });
+        PlaceholderType::get);
     const auto BaseTy = resolution.resolveType(InnerTypeRepr);
 
     if (BaseTy->mayHaveMembers()) {
@@ -2061,9 +2059,7 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
         },
         // FIXME: Don't let placeholder types escape type resolution.
         // For now, just return the placeholder type.
-        [](auto &ctx, auto *originator) {
-          return Type();
-        });
+        PlaceholderType::get);
     const auto result = resolution.resolveType(typeExpr->getTypeRepr());
     if (result->hasError())
       return nullptr;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2309,9 +2309,7 @@ static Type validateParameterType(ParamDecl *decl) {
     };
     // FIXME: Don't let placeholder types escape type resolution.
     // For now, just return the placeholder type.
-    placeholderHandler = [](auto &ctx, auto *originator) {
-      return Type();
-    };
+    placeholderHandler = PlaceholderType::get;
   } else if (isa<AbstractFunctionDecl>(dc)) {
     options = TypeResolutionOptions(TypeResolverContext::AbstractFunctionDecl);
   } else if (isa<SubscriptDecl>(dc)) {
@@ -2950,9 +2948,7 @@ ExtendedTypeRequest::evaluate(Evaluator &eval, ExtensionDecl *ext) const {
       },
       // FIXME: Don't let placeholder types escape type resolution.
       // For now, just return the placeholder type.
-      [](auto &ctx, auto *originator) {
-        return Type();
-      });
+      PlaceholderType::get);
 
   const auto extendedType = resolution.resolveType(extendedRepr);
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2213,8 +2213,9 @@ ResultTypeRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
   const auto options =
       TypeResolutionOptions(TypeResolverContext::FunctionResult);
   auto *const dc = decl->getInnermostDeclContext();
-  return TypeResolution::forInterface(dc, options, /*unboundTyOpener*/ nullptr,
-                                      /*placeholderHandler*/ nullptr)
+  return TypeResolution::forInterface(dc, options,
+                                      /*unboundTyOpener*/ nullptr,
+                                      PlaceholderType::get)
       .resolveType(resultTyRepr);
 }
 
@@ -2298,7 +2299,6 @@ static Type validateParameterType(ParamDecl *decl) {
 
   TypeResolutionOptions options(None);
   OpenUnboundGenericTypeFn unboundTyOpener = nullptr;
-  HandlePlaceholderTypeReprFn placeholderHandler = nullptr;
   if (isa<AbstractClosureExpr>(dc)) {
     options = TypeResolutionOptions(TypeResolverContext::ClosureExpr);
     options |= TypeResolutionFlags::AllowUnspecifiedTypes;
@@ -2309,7 +2309,6 @@ static Type validateParameterType(ParamDecl *decl) {
     };
     // FIXME: Don't let placeholder types escape type resolution.
     // For now, just return the placeholder type.
-    placeholderHandler = PlaceholderType::get;
   } else if (isa<AbstractFunctionDecl>(dc)) {
     options = TypeResolutionOptions(TypeResolverContext::AbstractFunctionDecl);
   } else if (isa<SubscriptDecl>(dc)) {
@@ -2332,7 +2331,7 @@ static Type validateParameterType(ParamDecl *decl) {
 
   const auto resolution =
       TypeResolution::forInterface(dc, options, unboundTyOpener,
-                                   placeholderHandler);
+                                   PlaceholderType::get);
   auto Ty = resolution.resolveType(decl->getTypeRepr());
 
   if (Ty->hasError()) {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1019,13 +1019,11 @@ static void checkDefaultArguments(ParameterList *params) {
     // Placeholder types are banned for all parameter decls. We try to use the
     // freshly-checked default expression's contextual type to suggest a
     // reasonable type to insert.
+    param->diagnose(diag::placeholder_type_not_allowed_in_parameter)
+        .highlight(param->getSourceRange());
     if (expr && !expr->getType()->hasError()) {
-      param->diagnose(diag::placeholder_type_not_allowed_in_parameter)
-          .highlight(param->getSourceRange());
       TypeChecker::notePlaceholderReplacementTypes(
           ifacety, expr->getType()->mapTypeOutOfContext());
-    } else {
-      param->diagnose(diag::placeholder_type_not_allowed);
     }
   }
 }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -18,19 +18,19 @@
 
 #include "CodeSynthesis.h"
 #include "DerivedConformances.h"
-#include "TypeChecker.h"
+#include "MiscDiagnostics.h"
 #include "TypeCheckAccess.h"
+#include "TypeCheckAvailability.h"
 #include "TypeCheckConcurrency.h"
 #include "TypeCheckDecl.h"
-#include "TypeCheckAvailability.h"
 #include "TypeCheckObjC.h"
 #include "TypeCheckType.h"
-#include "MiscDiagnostics.h"
-#include "swift/AST/AccessNotes.h"
-#include "swift/AST/AccessScope.h"
+#include "TypeChecker.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/AccessNotes.h"
+#include "swift/AST/AccessScope.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/ForeignErrorConvention.h"
@@ -42,15 +42,15 @@
 #include "swift/AST/PropertyWrappers.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SourceFile.h"
+#include "swift/AST/TypeCheckRequests.h"
+#include "swift/AST/TypeDifferenceVisitor.h"
 #include "swift/AST/TypeWalker.h"
+#include "swift/Basic/Defer.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/Parser.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
 #include "swift/Strings.h"
-#include "swift/AST/NameLookupRequests.h"
-#include "swift/AST/TypeCheckRequests.h"
-#include "swift/Basic/Defer.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/APSInt.h"
@@ -967,11 +967,67 @@ static void checkInheritedDefaultValueRestrictions(ParamDecl *PD) {
   }
 }
 
+void TypeChecker::notePlaceholderReplacementTypes(Type writtenType,
+                                                  Type inferredType) {
+  assert(writtenType && inferredType &&
+         "Must provide both written and inferred types");
+  assert(writtenType->hasPlaceholder() && "Written type has no placeholder?");
+
+  class PlaceholderNotator
+      : public CanTypeDifferenceVisitor<PlaceholderNotator> {
+  public:
+    bool visitDifferentComponentTypes(CanType t1, CanType t2) {
+      // Never replace anything the user wrote with an error type.
+      if (t2->hasError() || t2->hasUnresolvedType()) {
+        return false;
+      }
+
+      auto *placeholder = t1->getAs<PlaceholderType>();
+      if (!placeholder) {
+        return false;
+      }
+
+      if (auto *origRepr =
+              placeholder->getOriginator().dyn_cast<PlaceholderTypeRepr *>()) {
+        t1->getASTContext()
+            .Diags
+            .diagnose(origRepr->getLoc(),
+                      diag::replace_placeholder_with_inferred_type, t2)
+            .fixItReplace(origRepr->getSourceRange(), t2.getString());
+      }
+      return false;
+    }
+
+    bool check(Type t1, Type t2) {
+      return !visit(t1->getCanonicalType(), t2->getCanonicalType());
+    };
+  };
+
+  PlaceholderNotator().check(writtenType, inferredType);
+}
+
 /// Check the default arguments that occur within this pattern.
 static void checkDefaultArguments(ParameterList *params) {
   // Force the default values in case they produce diagnostics.
-  for (auto *param : *params)
-    (void)param->getTypeCheckedDefaultExpr();
+  for (auto *param : *params) {
+    auto ifacety = param->getInterfaceType();
+    auto *expr = param->getTypeCheckedDefaultExpr();
+    if (!ifacety->hasPlaceholder()) {
+      continue;
+    }
+
+    // Placeholder types are banned for all parameter decls. We try to use the
+    // freshly-checked default expression's contextual type to suggest a
+    // reasonable type to insert.
+    if (expr && !expr->getType()->hasError()) {
+      param->diagnose(diag::placeholder_type_not_allowed_in_parameter)
+          .highlight(param->getSourceRange());
+      TypeChecker::notePlaceholderReplacementTypes(
+          ifacety, expr->getType()->mapTypeOutOfContext());
+    } else {
+      param->diagnose(diag::placeholder_type_not_allowed);
+    }
+  }
 }
 
 Expr *DefaultArgumentExprRequest::evaluate(Evaluator &evaluator,

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -494,9 +494,7 @@ public:
         },
         // FIXME: Don't let placeholder types escape type resolution.
         // For now, just return the placeholder type.
-        [](auto &ctx, auto *originator) {
-          return Type();
-        });
+        PlaceholderType::get);
     const auto ty = resolution.resolveType(repr);
     auto *enumDecl = dyn_cast_or_null<EnumDecl>(ty->getAnyNominal());
     if (!enumDecl)
@@ -618,9 +616,7 @@ public:
               },
               // FIXME: Don't let placeholder types escape type resolution.
               // For now, just return the placeholder type.
-              [](auto &ctx, auto *originator) {
-                return Type();
-              })
+              PlaceholderType::get)
               .resolveType(prefixRepr);
       auto *enumDecl = dyn_cast_or_null<EnumDecl>(enumTy->getAnyNominal());
       if (!enumDecl)
@@ -830,9 +826,7 @@ Type PatternTypeRequest::evaluate(Evaluator &evaluator,
       };
       // FIXME: Don't let placeholder types escape type resolution.
       // For now, just return the placeholder type.
-      placeholderHandler = [](auto &ctx, auto *originator) {
-        return Type();
-      };
+      placeholderHandler = PlaceholderType::get;
     }
     return validateTypedPattern(
         cast<TypedPattern>(P),
@@ -900,9 +894,7 @@ Type PatternTypeRequest::evaluate(Evaluator &evaluator,
         };
         // FIXME: Don't let placeholder types escape type resolution.
         // For now, just return the placeholder type.
-        placeholderHandler = [](auto &ctx, auto *originator) {
-          return Type();
-        };
+        placeholderHandler = PlaceholderType::get;
       }
       TypedPattern *TP = cast<TypedPattern>(somePat->getSubPattern());
       const auto type = validateTypedPattern(

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1937,31 +1937,6 @@ Type ResolveTypeRequest::evaluate(Evaluator &evaluator,
   if (validateAutoClosureAttributeUse(ctx.Diags, TyR, result, options))
     return ErrorType::get(ctx);
 
-  // Diagnose an attempt to use a placeholder at the top level.
-  if (result->getCanonicalType()->is<PlaceholderType>() &&
-      resolution->getOptions().contains(TypeResolutionFlags::Direct)) {
-    if (!resolution->getOptions().contains(TypeResolutionFlags::SilenceErrors))
-      ctx.Diags.diagnose(loc, diag::top_level_placeholder_type);
-
-    TyR->setInvalid();
-    return ErrorType::get(ctx);
-  }
-
-  // Now that top-level placeholders have been diagnosed, replace them according
-  // to the user-specified handler (if it exists).
-  if (const auto handlerFn = resolution->getPlaceholderHandler()) {
-    result = result.get().transform([&](Type ty) {
-      if (auto *oldTy = ty->getAs<PlaceholderType>()) {
-        auto originator = oldTy->getOriginator();
-        if (auto *repr = originator.dyn_cast<PlaceholderTypeRepr *>())
-          if (auto newTy = handlerFn(ctx, repr))
-            return newTy;
-      }
-
-      return ty;
-    });
-  }
-
   return result;
 }
 
@@ -2090,21 +2065,18 @@ NeverNullType TypeResolver::resolveType(TypeRepr *repr,
                        options);
 
   case TypeReprKind::Placeholder: {
-    if (resolution.getPlaceholderHandler())
-      // For now, just form a `PlaceholderType` so that we can properly diagnose
-      // invalid top-level placeholders. `ResolveTypeRequest::evaluate` will
-      // take care of substituting the placeholder based on the caller-specified
-      // handler.
-      return PlaceholderType::get(getASTContext(),
-                                  cast<PlaceholderTypeRepr>(repr));
+    auto &ctx = getASTContext();
+    // Fill in the placeholder if there's an appropriate handler.
+    if (const auto handlerFn = resolution.getPlaceholderHandler())
+      if (const auto ty = handlerFn(ctx, cast<PlaceholderTypeRepr>(repr)))
+        return ty;
 
-    // If there's no handler, complain if we're allowed to and bail out with an
-    // error.
+    // Complain if we're allowed to and bail out with an error.
     if (!options.contains(TypeResolutionFlags::SilenceErrors))
-      getASTContext().Diags.diagnose(repr->getLoc(),
+      ctx.Diags.diagnose(repr->getLoc(),
                          diag::placeholder_type_not_allowed);
 
-    return ErrorType::get(getASTContext());
+    return ErrorType::get(resolution.getASTContext());
   }
 
   case TypeReprKind::Fixed:

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -285,9 +285,7 @@ public:
 /// \returns the \c null type on failure.
 using OpenUnboundGenericTypeFn = llvm::function_ref<Type(UnboundGenericType *)>;
 
-/// A function reference used to handle a \c PlaceholderTypeRepr. If the
-/// function returns a null type, then the unmodified \c PlaceholderType will be
-/// used.
+/// A function reference used to handle a PlaceholderTypeRepr.
 using HandlePlaceholderTypeReprFn =
     llvm::function_ref<Type(ASTContext &, PlaceholderTypeRepr *)>;
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -378,9 +378,7 @@ Type swift::performTypeResolution(TypeRepr *TyR, ASTContext &Ctx,
       },
       // FIXME: Don't let placeholder types escape type resolution.
       // For now, just return the placeholder type.
-      [](auto &ctx, auto *originator) {
-        return Type();
-      });
+      PlaceholderType::get);
 
   Optional<DiagnosticSuppression> suppression;
   if (!ProduceDiagnostics)

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1138,6 +1138,24 @@ bool diagnoseInvalidFunctionType(FunctionType *fnTy, SourceLoc loc,
                                  DeclContext *dc,
                                  Optional<TypeResolutionStage> stage);
 
+/// Walk the parallel structure of a type with user-provided placeholders and
+/// an inferred type produced by the type checker. Where placeholders can be
+/// found, suggest the corresponding inferred type.
+///
+/// For example,
+///
+/// \code
+///  func foo(_ x: [_] = [0])
+/// \endcode
+///
+/// Has a written type of `(ArraySlice (Placeholder))` and an inferred type of
+/// `(ArraySlice Int)`, so we walk to `Placeholder` and `Int` in each type and
+/// suggest replacing `_` with `Int`.
+///
+/// \param writtenType The interface type usually derived from a user-written
+/// type repr. \param inferredType The type inferred by the type checker.
+void notePlaceholderReplacementTypes(Type writtenType, Type inferredType);
+
 }; // namespace TypeChecker
 
 /// Returns the protocol requirement kind of the given declaration.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4289,6 +4289,13 @@ public:
   }
 
   void visitPlaceholderType(const PlaceholderType *) {
+    // If for some reason we have a placeholder type while compiling with
+    // errors, just serialize an ErrorType and continue.
+    if (S.getASTContext().LangOpts.AllowModuleWithCompilerErrors) {
+      visitErrorType(
+          cast<ErrorType>(ErrorType::get(S.getASTContext()).getPointer()));
+      return;
+    }
     llvm_unreachable("should not serialize a PlaceholderType");
   }
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1137,7 +1137,7 @@ func badTypes() {
 // rdar://34357545
 func unresolvedTypeExistential() -> Bool {
   return (Int.self==_{})
-  // expected-error@-1 {{placeholders are not allowed as top-level types}}
+  // expected-error@-1 {{type of expression is ambiguous without more context}}
 }
 
 do {

--- a/test/Sema/placeholder_type.swift
+++ b/test/Sema/placeholder_type.swift
@@ -8,7 +8,7 @@ let dict2: [Character: _] = ["h": 0]
 let arr = [_](repeating: "hi", count: 3)
 
 func foo(_ arr: [_] = [0]) {} // expected-error {{type placeholder may not appear in top-level parameter}}
-// expected-note@-1 {{replace the placeholder with the correct type 'Int'}}
+// expected-note@-1 {{replace the placeholder with the inferred type 'Int'}}
 
 let foo = _.foo // expected-error {{could not infer type for placeholder}}
 let zero: _ = .zero // expected-error {{cannot infer contextual base in reference to member 'zero'}}
@@ -76,32 +76,32 @@ where T: ExpressibleByIntegerLiteral, U: ExpressibleByIntegerLiteral {
 
 extension Bar {
   func frobnicate2() -> Bar<_, _> { // expected-error {{type placeholder may not appear in function return type}}
-    // expected-note@-1 {{replace the placeholder with the correct type 'T'}}
-    // expected-note@-2 {{replace the placeholder with the correct type 'U'}}
+    // expected-note@-1 {{replace the placeholder with the inferred type 'T'}}
+    // expected-note@-2 {{replace the placeholder with the inferred type 'U'}}
     return Bar(t: 42, u: 42)
   }
   func frobnicate3() -> Bar {
     return Bar<_, _>(t: 42, u: 42)
   }
   func frobnicate4() -> Bar<_, _> { // expected-error {{type placeholder may not appear in function return type}}
-    // expected-note@-1 {{replace the placeholder with the correct type 'Int'}}
-    // expected-note@-2 {{replace the placeholder with the correct type 'Int'}}
+    // expected-note@-1 {{replace the placeholder with the inferred type 'Int'}}
+    // expected-note@-2 {{replace the placeholder with the inferred type 'Int'}}
     return Bar<_, _>(t: 42, u: 42)
   }
   func frobnicate5() -> Bar<_, U> { // expected-error {{type placeholder may not appear in function return type}}
-    // expected-note@-1 {{replace the placeholder with the correct type 'T'}}
+    // expected-note@-1 {{replace the placeholder with the inferred type 'T'}}
     return Bar(t: 42, u: 42)
   }
   func frobnicate6() -> Bar {
     return Bar<_, U>(t: 42, u: 42)
   }
   func frobnicate7() -> Bar<_, _> { // expected-error {{type placeholder may not appear in function return type}}
-    // expected-note@-1 {{replace the placeholder with the correct type 'Int'}}
-    // expected-note@-2 {{replace the placeholder with the correct type 'U'}}
+    // expected-note@-1 {{replace the placeholder with the inferred type 'Int'}}
+    // expected-note@-2 {{replace the placeholder with the inferred type 'U'}}
     return Bar<_, U>(t: 42, u: 42)
   }
   func frobnicate8() -> Bar<_, U> { // expected-error {{type placeholder may not appear in function return type}}
-    // expected-note@-1 {{replace the placeholder with the correct type 'Int'}}
+    // expected-note@-1 {{replace the placeholder with the inferred type 'Int'}}
     return Bar<_, _>(t: 42, u: 42)
   }
 }
@@ -235,9 +235,9 @@ func mismatchedDefault<T>(_ x: [_] = [String: T]()) {} // expected-error {{type 
 
 func mismatchedReturnTypes() -> _ { // expected-error {{type placeholder may not appear in function return type}}
   if true {
-    return "" // expected-note@-2 {{replace the placeholder with the correct type 'String'}}
+    return "" // expected-note@-2 {{replace the placeholder with the inferred type 'String'}}
   } else {
-    return 0.5 // expected-note@-4 {{replace the placeholder with the correct type 'Double'}}
+    return 0.5 // expected-note@-4 {{replace the placeholder with the inferred type 'Double'}}
   }
 }
 
@@ -251,6 +251,6 @@ func opaque() -> some _ { // expected-error {{type placeholder not allowed here}
 enum EnumWithPlaceholders {
   case topLevelPlaceholder(x: _) // expected-error {{type placeholder may not appear in top-level parameter}}
   case placeholderWithDefault(x: _ = 5) // expected-error {{type placeholder may not appear in top-level parameter}}
-  // expected-note@-1 {{replace the placeholder with the correct type 'Int'}}
+  // expected-note@-1 {{replace the placeholder with the inferred type 'Int'}}
 }
 

--- a/test/Sema/placeholder_type.swift
+++ b/test/Sema/placeholder_type.swift
@@ -10,7 +10,7 @@ let arr = [_](repeating: "hi", count: 3)
 func foo(_ arr: [_] = [0]) {} // expected-error {{type placeholder may not appear in top-level parameter}}
 // expected-note@-1 {{replace the placeholder with the inferred type 'Int'}}
 
-let foo = _.foo // expected-error {{could not infer type for placeholder}}
+let foo = _.foo // expected-error {{type placeholder not allowed here}} expected-error {{could not infer type for placeholder}}
 let zero: _ = .zero // expected-error {{cannot infer contextual base in reference to member 'zero'}}
 
 struct S<T> {
@@ -49,7 +49,7 @@ func dictionary<K, V>(ofType: [K: V].Type) -> [K: V] { [:] }
 
 let _: [String: _] = dictionary(ofType: [_: Int].self)
 let _: [_: _] = dictionary(ofType: [String: Int].self)
-let _: [String: Int] = dictionary(ofType: _.self)
+let _: [String: Int] = dictionary(ofType: _.self) // expected-error {{type placeholder not allowed here}}
 
 let _: @convention(c) _ = { 0 } // expected-error {{@convention attribute only applies to function types}}
 let _: @convention(c) (_) -> _ = { (x: Double) in 0 }
@@ -107,10 +107,10 @@ extension Bar {
 }
 
 // FIXME: We should probably have better diagnostics for these situations--the user probably meant to use implicit member syntax
-let _: Int = _() // expected-error {{type of expression is ambiguous without more context}}
-let _: () -> Int = { _() } // expected-error {{unable to infer closure type in the current context}}
-let _: Int = _.init() // expected-error {{could not infer type for placeholder}}
-let _: () -> Int = { _.init() } // expected-error {{could not infer type for placeholder}}
+let _: Int = _() // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without more context}}
+let _: () -> Int = { _() } // expected-error 2 {{type placeholder not allowed here}} expected-error {{unable to infer closure type in the current context}}
+let _: Int = _.init() // expected-error {{type placeholder not allowed here}} expected-error {{could not infer type for placeholder}}
+let _: () -> Int = { _.init() } // expected-error 2 {{type placeholder not allowed here}} expected-error {{could not infer type for placeholder}}
 
 func returnsInt() -> Int { _() } // expected-error {{type of expression is ambiguous without more context}}
 func returnsIntClosure() -> () -> Int { { _() } } // expected-error {{unable to infer closure type in the current context}}
@@ -118,7 +118,7 @@ func returnsInt2() -> Int { _.init() }  // expected-error {{could not infer type
 func returnsIntClosure2() -> () -> Int { { _.init() } } // expected-error {{could not infer type for placeholder}}
 
 let _: Int.Type = _ // expected-error {{'_' can only appear in a pattern or on the left side of an assignment}}
-let _: Int.Type = _.self
+let _: Int.Type = _.self // expected-error {{type placeholder not allowed here}}
 
 struct SomeSuperLongAndComplexType {}
 func getSomething() -> SomeSuperLongAndComplexType? { .init() }
@@ -200,13 +200,13 @@ extension Publisher {
     }
 }
 
-let _: SetFailureType<Int, String> = Just<Int>().setFailureType(to: _.self)
+let _: SetFailureType<Int, String> = Just<Int>().setFailureType(to: _.self) // expected-error {{type placeholder not allowed here}}
 let _: SetFailureType<Int, [String]> = Just<Int>().setFailureType(to: [_].self)
 let _: SetFailureType<Int, (String) -> Double> = Just<Int>().setFailureType(to: ((_) -> _).self)
 let _: SetFailureType<Int, (String, Double)> = Just<Int>().setFailureType(to: (_, _).self)
 
 // TODO: Better error message here? Would be nice if we could point to the placeholder...
-let _: SetFailureType<Int, String> = Just<Int>().setFailureType(to: _.self).setFailureType(to: String.self) // expected-error {{generic parameter 'T' could not be inferred}}
+let _: SetFailureType<Int, String> = Just<Int>().setFailureType(to: _.self).setFailureType(to: String.self) // expected-error {{type placeholder not allowed here}} expected-error {{generic parameter 'T' could not be inferred}}
 
 let _: (_) = 0 as Int
 let _: Int = 0 as (_)
@@ -225,7 +225,7 @@ _ = (1...10)
         x.boolValue ? intValue : 0
     }
 
-let _: SetFailureType<Int, String> = Just<Int>().setFailureType(to: _.self).setFailureType(to: String.self) // expected-error {{generic parameter 'T' could not be inferred}}
+let _: SetFailureType<Int, String> = Just<Int>().setFailureType(to: _.self).setFailureType(to: String.self) // expected-error {{type placeholder not allowed here}} expected-error {{generic parameter 'T' could not be inferred}}
 
 // N.B. The parallel structure of the annotation and inferred default
 // initializer types is all wrong. Plus, we do not trust

--- a/test/Sema/placeholder_type.swift
+++ b/test/Sema/placeholder_type.swift
@@ -249,7 +249,7 @@ func opaque() -> some _ { // expected-error {{type placeholder not allowed here}
 }
 
 enum EnumWithPlaceholders {
-  case topLevelPlaceholder(x: _) // expected-error {{type placeholder not allowed here}}
+  case topLevelPlaceholder(x: _) // expected-error {{type placeholder may not appear in top-level parameter}}
   case placeholderWithDefault(x: _ = 5) // expected-error {{type placeholder may not appear in top-level parameter}}
   // expected-note@-1 {{replace the placeholder with the correct type 'Int'}}
 }

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -865,7 +865,7 @@ func r20802757(_ z: inout Int = &g20802757) { // expected-error {{cannot provide
   print(z)
 }
 
-_ = _.foo // expected-error {{placeholders are not allowed as top-level types}}
+_ = _.foo // expected-error {{could not infer type for placeholder}}
 
 // <rdar://problem/22211854> wrong arg list crashing sourcekit
 func r22211854() {

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -865,7 +865,7 @@ func r20802757(_ z: inout Int = &g20802757) { // expected-error {{cannot provide
   print(z)
 }
 
-_ = _.foo // expected-error {{could not infer type for placeholder}}
+_ = _.foo // expected-error {{type placeholder not allowed here}} expected-error {{could not infer type for placeholder}}
 
 // <rdar://problem/22211854> wrong arg list crashing sourcekit
 func r22211854() {


### PR DESCRIPTION
First, relax the restrictions on placeholder types appearing in interface types. In the past, we would pretty much replace every instance of them with an error type, which would lose information when we came around to apply the contextual type to any solutions for associated inference sources like initializers in pattern bindings or the return types of functions. Preserve these types in interface types so they can be opened later.

Second, now that placeholder types are preserved, we can open them wherever they appear in positions where they are used as contextual types. Use the checks we already run in the primaries to ban placeholders in top-level positions. Only now, use the inferred type of any associated expressions or statements to present the user with a contextual replacement type.

For parameters in functions and enum cases, we use any default argument expressions to get the contextual type.

For functions, we use a traversal similar to the opaque result type finder to find the type of any return statements in the program and present those as options.

Resolves rdar://82837146