### PR TITLE
[Module aliasing] Mangle symbols with module real names

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2175,8 +2175,16 @@ void ASTMangler::appendModule(const ModuleDecl *module,
                               StringRef useModuleName) {
   assert(!module->getParent() && "cannot mangle nested modules!");
 
-  StringRef ModName =
-      DWARFMangling ? module->getName().str() : module->getABIName().str();
+  // Use the module real name in mangling; this is the physical name
+  // of the module on-disk, which can be different if -module-alias is
+  // used.
+  // For example, if a module Foo has 'import Bar', and '-module-alias Bar=Baz'
+  // was passed, the name 'Baz' will be used for mangling besides loading.
+  StringRef ModName = module->getRealName().str();
+  if (!DWARFMangling &&
+      module->getABIName() != module->getName()) { // check if the ABI name is set
+    ModName = module->getABIName().str();
+  }
 
   // Try the special 'swift' substitution.
   if (ModName == STDLIB_NAME) {

--- a/test/Frontend/load-module-with-alias-mangling.swift
+++ b/test/Frontend/load-module-with-alias-mangling.swift
@@ -14,12 +14,14 @@
 // RUN: echo 'public func meow() -> Cat.Klass? { return nil }' >> %t/FileFoo.swift
 // RUN: %target-swift-frontend -module-name Foo %t/FileFoo.swift -module-alias Cat=Bar -I %t -emit-module -emit-module-path %t/Foo.swiftmodule -c -o %t/ResultFoo.o
 
-/// Check Foo.swiftmodule is created and Bar.swiftmodule is loaded
+/// Check Foo.swiftmodule is created
 // RUN: test -f %t/Foo.swiftmodule
 
+/// Check the mangled name for func meow contains the real module name Bar
 // RUN: llvm-objdump -t %t/ResultFoo.o | %FileCheck %s -check-prefix=CHECK-A
-// CHECK-A: _$s3Foo4meow3Bar5KlassCSgyF
+// CHECK-A: s3Foo4meow3Bar5KlassCSgyF
 
+/// Check demangling shows the real module name Bar
 // RUN: llvm-objdump -t %t/ResultFoo.o | swift-demangle | %FileCheck %s -check-prefix=CHECK-B
 // CHECK-B: Foo.meow() -> Bar.Klass?
 

--- a/test/Frontend/load-module-with-alias-mangling.swift
+++ b/test/Frontend/load-module-with-alias-mangling.swift
@@ -1,0 +1,25 @@
+/// Test mangling with module aliasing
+
+// RUN: %empty-directory(%t)
+
+/// Create a module Bar
+// RUN: echo 'public class Klass {}' > %t/FileBar.swift
+// RUN: %target-swift-frontend -module-name Bar %t/FileBar.swift -emit-module -emit-module-path %t/Bar.swiftmodule
+
+/// Check Bar.swiftmodule is created
+// RUN: test -f %t/Bar.swiftmodule
+
+/// Create a module Foo that imports Cat with -module-alias Cat=Bar
+// RUN: echo 'import Cat' > %t/FileFoo.swift
+// RUN: echo 'public func meow() -> Cat.Klass? { return nil }' >> %t/FileFoo.swift
+// RUN: %target-swift-frontend -module-name Foo %t/FileFoo.swift -module-alias Cat=Bar -I %t -emit-module -emit-module-path %t/Foo.swiftmodule -c -o %t/ResultFoo.o
+
+/// Check Foo.swiftmodule is created and Bar.swiftmodule is loaded
+// RUN: test -f %t/Foo.swiftmodule
+
+// RUN: llvm-objdump -t %t/ResultFoo.o | %FileCheck %s -check-prefix=CHECK-A
+// CHECK-A: _$s3Foo4meow3Bar5KlassCSgyF
+
+// RUN: llvm-objdump -t %t/ResultFoo.o | swift-demangle | %FileCheck %s -check-prefix=CHECK-B
+// CHECK-B: Foo.meow() -> Bar.Klass?
+


### PR DESCRIPTION
Mangle symbols using the module real name (binary name), which can be different from the module name appearing in source files if '-module-alias' is used. The real name is also used for module loading (see #39533). Resolves rdar://83632604.