### PR TITLE
[testing] Convert XFAIL to UNSUPPORTED in C++ module testing

### DIFF
--- a/test/Interop/Cxx/stdlib/std-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-module-interface.swift
@@ -3,13 +3,12 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=std.string -source-filename=x -enable-cxx-interop -tools-directory=%llvm_obj_root/bin -module-cache-path %t | %FileCheck %s  -check-prefix=CHECK-STRING
 
 // Clang driver on Windows doesn't support -stdlib=libc++
-// XFAIL: OS=windows-msvc
+// UNSUPPORTED: OS=windows-msvc
 
-// libstdc++ cannot currently be imported.
-// XFAIL: OS=linux-gnu
-
-// XFAIL: OS=linux-androideabi
-// XFAIL: OS=linux-android
+// libstdc++ cannot currently be imported
+// UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=linux-androideabi
+// UNSUPPORTED: OS=linux-android
 
 // CHECK-STD: import std.iosfwd
 // CHECK-STD: import std.string


### PR DESCRIPTION
It's possible to build Swift where libcxx is implicitly used, so this test is brittle if it uses XFAIL.