### PR TITLE
Fix a couple of build warnings

### DIFF
--- a/include/swift/Demangling/ManglingMacros.h
+++ b/include/swift/Demangling/ManglingMacros.h
@@ -17,7 +17,10 @@
 #define MANGLE_AS_STRING(M) STRINGIFY_MANGLING(M)
 
 /// The mangling prefix for the new mangling.
+_Pragma("clang diagnostic push")
+_Pragma("clang diagnostic ignored \"-Wdollar-in-identifier-extension\"")
 #define MANGLING_PREFIX $s
+_Pragma("clang diagnostic pop")
 
 #define MANGLING_PREFIX_STR MANGLE_AS_STRING(MANGLING_PREFIX)
 

--- a/include/swift/SIL/BridgedSwiftObject.h
+++ b/include/swift/SIL/BridgedSwiftObject.h
@@ -20,11 +20,29 @@
 
 #include <stdint.h>
 
-#if !__has_feature(nullability)
+// TODO: These macro definitions are duplicated in Visibility.h. Move
+// them to a single file if we find a location that both Visibility.h and
+// BridgedSwiftObject.h can import.
+#if __has_feature(nullability)
+// Provide macros to temporarily suppress warning about the use of
+// _Nullable and _Nonnull.
+# define SWIFT_BEGIN_NULLABILITY_ANNOTATIONS                                   \
+  _Pragma("clang diagnostic push")                                             \
+  _Pragma("clang diagnostic ignored \"-Wnullability-extension\"")
+# define SWIFT_END_NULLABILITY_ANNOTATIONS                                     \
+  _Pragma("clang diagnostic pop")
+
+#else
+// #define _Nullable and _Nonnull to nothing if we're not being built
+// with a compiler that supports them.
 # define _Nullable
 # define _Nonnull
 # define _Null_unspecified
+# define SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
+# define SWIFT_END_NULLABILITY_ANNOTATIONS
 #endif
+
+SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
 typedef const void * _Nonnull SwiftMetatype;
 
@@ -39,5 +57,7 @@ struct BridgedSwiftObject {
 
 typedef struct BridgedSwiftObject * _Nonnull SwiftObject;
 typedef struct BridgedSwiftObject * _Nullable OptionalSwiftObject;
+
+SWIFT_END_NULLABILITY_ANNOTATIONS
 
 #endif

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -17,6 +17,8 @@
 #include <stddef.h>
 #include <string>
 
+SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
+
 typedef struct {
   const unsigned char * _Nullable data;
   size_t length;
@@ -234,5 +236,7 @@ BridgedInstruction SILBuilder_createBuiltinBinaryFunction(
           BridgedType operandType, BridgedType resultType, BridgedValueArray arguments);
 BridgedInstruction SILBuilder_createCondFail(BridgedInstruction insertionPoint,
           BridgedLocation loc, BridgedValue condition, BridgedStringRef messge);
+
+SWIFT_END_NULLABILITY_ANNOTATIONS
 
 #endif

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -15,6 +15,8 @@
 
 #include "../SIL/SILBridging.h"
 
+SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -71,5 +73,7 @@ BridgedFunction BridgedFunctionArray_get(BridgedCalleeList callees,
 #ifdef __cplusplus
 } // extern "C"
 #endif
+
+SWIFT_END_NULLABILITY_ANNOTATIONS
 
 #endif

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -6623,7 +6623,6 @@ static void deliverCompletionResults(CodeCompletionContext &CompletionContext,
       // ModuleFilename can be empty if something strange happened during
       // module loading, for example, the module file is corrupted.
       if (!ModuleFilename.empty()) {
-        auto &Ctx = TheModule->getASTContext();
         CodeCompletionCache::Key K{
             ModuleFilename.str(),
             std::string(TheModule->getName()),

--- a/lib/SILOptimizer/Utils/OnonePrespecializations.def
+++ b/lib/SILOptimizer/Utils/OnonePrespecializations.def
@@ -1,3 +1,5 @@
+_Pragma("clang diagnostic push")
+_Pragma("clang diagnostic ignored \"-Wdollar-in-identifier-extension\"")
 PRESPEC_SYMBOL($sS2ayxGycfCSJ_Tg5)
 PRESPEC_SYMBOL($sS2ayxGycfCSS_Tg5)
 PRESPEC_SYMBOL($sS2ayxGycfCSd_Tg5)
@@ -1196,3 +1198,4 @@ PRESPEC_SYMBOL($ss22_ContiguousArrayBufferVAByxGycfCs6UInt64V_Tg5)
 PRESPEC_SYMBOL($ss22_ContiguousArrayBufferVAByxGycfCs7UnicodeO6ScalarV_Tg5)
 PRESPEC_SYMBOL($ss27_allocateUninitializedArrayySayxG_BptBwlFyp_Tg5)
 
+_Pragma("clang diagnostic pop")

--- a/stdlib/public/SwiftShims/Visibility.h
+++ b/stdlib/public/SwiftShims/Visibility.h
@@ -34,6 +34,9 @@
 #define __has_cpp_attribute(attribute) 0
 #endif
 
+// TODO: These macro definitions are duplicated in BridgedSwiftObject.h. Move
+// them to a single file if we find a location that both Visibility.h and
+// BridgedSwiftObject.h can import.
 #if __has_feature(nullability)
 // Provide macros to temporarily suppress warning about the use of
 // _Nullable and _Nonnull.
@@ -219,7 +222,7 @@
 #define SWIFT_FALLTHROUGH
 #endif
 
-#if __cplusplus >= 201402l && __has_cpp_attribute(nodiscard)
+#if __cplusplus > 201402l && __has_cpp_attribute(nodiscard)
 #define SWIFT_NODISCARD [[nodiscard]]
 #elif __has_cpp_attribute(clang::warn_unused_result)
 #define SWIFT_NODISCARD [[clang::warn_unused_result]]


### PR DESCRIPTION
Fixes a couple of compiler warnings that occur frequently when building the compiler:
- Copy the nullability annotation definitions from `Visibility.h` to `BridgedSwiftObject.h` and wrap all code that contains nullability annotations in `SWIFT_BEGIN_NULLABILITY_ANNOTATIONS` and `SWIFT_END_NULLABILITY_ANNOTATIONS` (supressing the warning `type nullability specifier '_Nullable' is a Clang extension [-Wnullability-extension]`) — @eeckstein for review
- Suppress warnings about using `$` (mangling prefix) as an identifier using pragmas (supressing the warning `'$' in identifier [-Wdollar-in-identifier-extension]`) — also @eeckstein for review
- Change the macro condition of `SWIFT_NODISCARD` from `__cplusplus >= 201402l` (which checked for >= C++14) to `__cplusplus > 201402l`. This appears to have been a copy-paste error from `LLVM_NODISCARD` (supressing the warning `use of the 'nodiscard' attribute is a C++17 extension [-Wc++17-extensions]`) — @compnerd for review