### PR TITLE
Module aliasing: use module real name to create DIModule

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -777,7 +777,12 @@ private:
     if (Optional<ASTSourceDescriptor> ModuleDesc = getClangModule(*M))
       return getOrCreateModule(*ModuleDesc, ModuleDesc->getModuleOrNull());
     StringRef Path = getFilenameFromDC(M);
-    StringRef Name = M->getName().str();
+    // Use the module 'real' name, which can be different from the name if module
+    // aliasing was used (swift modules only). For example, if a source file has
+    // 'import Foo', and '-module-alias Foo=Bar' was passed in, the real name of
+    // the module on disk is Bar (.swiftmodule or .swiftinterface), and is used
+    // for loading and mangling.
+    StringRef Name = M->getRealName().str();
     return getOrCreateModule(M, TheCU, Name, Path);
   }
 

--- a/test/DebugInfo/module-alias-load-module.swift
+++ b/test/DebugInfo/module-alias-load-module.swift
@@ -8,8 +8,9 @@
 /// Create a module Foo that imports Cat with -module-alias Cat=Bar
 // RUN: %target-swift-frontend -emit-ir -module-name Foo -module-alias Cat=Bar %s -I %t -g -o - | %FileCheck %s
 
+// CHECK-DAG: ![[FILE:[0-9]+]] = !DIFile(filename: "{{.*}}test{{/|\\\\}}DebugInfo{{/|\\\\}}module-alias-load-module.swift"
 // CHECK-DAG: ![[BARMODULE:[0-9]+]] = !DIModule({{.*}}, name: "Bar"
-// CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[THISFILE]], entity: ![[BARMODULE]]
+// CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[FILE]], entity: ![[BARMODULE]]
 
 import Cat
 public func meow() -> Cat.Klass? { return nil }

--- a/test/DebugInfo/module-alias-load-module.swift
+++ b/test/DebugInfo/module-alias-load-module.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+
+/// Create a module Bar
+// RUN: echo 'public class Klass {}' > %t/FileBar.swift
+// RUN: %target-swift-frontend -module-name Bar %t/FileBar.swift -emit-module -emit-module-path %t/Bar.swiftmodule
+// RUN: test -f %t/Bar.swiftmodule
+
+/// Create a module Foo that imports Cat with -module-alias Cat=Bar
+// RUN: %target-swift-frontend -emit-ir -module-name Foo -module-alias Cat=Bar %s -I %t -g -o - | %FileCheck %s
+
+// CHECK-DAG: ![[BARMODULE:[0-9]+]] = !DIModule({{.*}}, name: "Bar"
+// CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[THISFILE]], entity: ![[BARMODULE]]
+
+import Cat
+public func meow() -> Cat.Klass? { return nil }


### PR DESCRIPTION
Use module real name when creating DIModule, which can be different from the name if module aliasing is used. Resolves rdar://83967186.