### PR TITLE
Add AddressOwnership utility and cleanup OSSA rauw

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -150,7 +150,7 @@ bool findTransitiveGuaranteedUses(SILValue guaranteedValue,
 /// 1. If \p guaranteedValue introduces a borrow scope (begin_borrow,
 /// load_borrow, or phi), then its only use points are the extended scope-ending
 /// uses, and this function returns true. This is, in fact, equivalent to
-/// calling BorrowedValue::visitExtendedLocalScopeEndingUses().
+/// calling BorrowedValue::visitExtendedScopeEndingUses().
 ///
 /// 2. If \p guaranteedValue does not introduce a borrow scope (it is not a
 /// valid BorrowedValue), then its uses are discovered transitively by looking
@@ -320,8 +320,6 @@ struct BorrowingOperand {
   /// BorrowingOperand.
   ///
   /// Returns false and early exits if the visitor \p func returns false.
-  ///
-  /// Note: this does not visit the intermediate reborrows.
   bool visitExtendedScopeEndingUses(function_ref<bool(Operand *)> func) const;
 
   /// Returns true if this borrow scope operand consumes guaranteed
@@ -504,7 +502,7 @@ struct InteriorPointerOperand;
 /// jointly post-dominate this value (see visitLocalScopeEndingUses()). The
 /// extended scope, including reborrows has end points that are not dominated by
 /// this value but still jointly post-dominate (see
-/// visitExtendedLocalScopeEndingUses()).
+/// visitExtendedScopeEndingUses()).
 struct BorrowedValue {
   SILValue value;
   BorrowedValueKind kind = BorrowedValueKind::Invalid;
@@ -563,8 +561,8 @@ struct BorrowedValue {
   /// Given a local borrow scope introducer, visit all non-forwarding consuming
   /// users. This means that this looks through guaranteed block arguments. \p
   /// visitor is *not* called on Reborrows, only on final scope ending uses.
-  bool visitExtendedLocalScopeEndingUses(
-      function_ref<bool(Operand *)> visitor) const;
+  bool
+  visitExtendedScopeEndingUses(function_ref<bool(Operand *)> visitor) const;
 
   void print(llvm::raw_ostream &os) const;
   SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -172,8 +172,8 @@ public:
     return use->getOwnershipConstraint();
   }
 
-  ValueOwnershipKind getOwnershipKind() const;
-  void setOwnershipKind(ValueOwnershipKind newKind) const;
+  ValueOwnershipKind getForwardingOwnershipKind() const;
+  void setForwardingOwnershipKind(ValueOwnershipKind newKind) const;
   void replaceOwnershipKind(ValueOwnershipKind oldKind,
                             ValueOwnershipKind newKind) const;
 

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -306,6 +306,15 @@ struct BorrowingOperand {
   /// visits the end of the introduced borrow scope.
   bool visitScopeEndingUses(function_ref<bool(Operand *)> func) const;
 
+  /// Returns true for borrows that create a local borrow scope but have no
+  /// scope-ending uses (presumably all paths are dead-end blocks). This does
+  /// not include instantaneous borrows, which don't require explicit scope
+  /// ending uses.
+  ///
+  /// FIXME: Borrow scopes should have scope-ending uses on all paths, even to
+  /// dead end blocks. When the verifier enforces this, remove this check.
+  bool hasEmptyRequiredEndingUses() const;
+
   /// Visit the scope ending operands of the extended scope, after transitively
   /// searching through reborrows. These uses might not be dominated by this
   /// BorrowingOperand.

--- a/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
@@ -74,11 +74,14 @@ struct OwnershipFixupContext {
     /// This is the interior pointer operand that the new value we want to RAUW
     /// is transitively derived from and enables us to know the underlying
     /// borrowed base value that we need to lifetime extend.
-    InteriorPointerOperand intPtrOp;
+    ///
+    /// This is only initialized when the interior pointer has uses that must be
+    /// replaced.
+    AccessBase base;
 
     void clear() {
       allAddressUsesFromOldValue.clear();
-      intPtrOp = InteriorPointerOperand();
+      base = AccessBase();
     }
   };
   AddressFixupContext extraAddressFixupInfo;
@@ -90,14 +93,14 @@ struct OwnershipFixupContext {
     transitiveBorrowedUses.clear();
     recursiveReborrows.clear();
     extraAddressFixupInfo.allAddressUsesFromOldValue.clear();
-    extraAddressFixupInfo.intPtrOp = InteriorPointerOperand();
+    extraAddressFixupInfo.base = AccessBase();
   }
 
 private:
   /// Helper method called to determine if we discovered we needed interior
   /// pointer fixups while simplifying.
   bool needsInteriorPointerFixups() const {
-    return bool(extraAddressFixupInfo.intPtrOp);
+    return bool(extraAddressFixupInfo.base);
   }
 };
 

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -1124,7 +1124,7 @@ ForwardingOperand::ForwardingOperand(Operand *use) {
   this->use = use;
 }
 
-ValueOwnershipKind ForwardingOperand::getOwnershipKind() const {
+ValueOwnershipKind ForwardingOperand::getForwardingOwnershipKind() const {
   auto *user = use->getUser();
 
   // NOTE: This if chain is meant to be a covered switch, so make sure to return
@@ -1156,7 +1156,8 @@ ValueOwnershipKind ForwardingOperand::getOwnershipKind() const {
   llvm_unreachable("Unhandled forwarding inst?!");
 }
 
-void ForwardingOperand::setOwnershipKind(ValueOwnershipKind newKind) const {
+void ForwardingOperand::setForwardingOwnershipKind(
+    ValueOwnershipKind newKind) const {
   auto *user = use->getUser();
   // NOTE: This if chain is meant to be a covered switch, so make sure to return
   // in each if itself since we have an unreachable at the bottom to ensure if a

--- a/lib/SILOptimizer/Mandatory/DiagnoseLifetimeIssues.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseLifetimeIssues.cpp
@@ -315,24 +315,7 @@ static bool isOutOfLifetime(SILInstruction *inst, PrunedLiveness &liveness) {
   // impossible that a use of the object is not a potential load. So we would
   // always see a potential load if the lifetime of the object goes beyond the
   // store_weak.
-
-  SILBasicBlock *block = inst->getParent();
-  if (liveness.getBlockLiveness(block) != PrunedLiveBlocks::LiveWithin)
-    return false;
-
-  // If there are any uses after the store_weak, it means that the liferange of
-  // the object goes beyond the store_weak.
-  for (SILInstruction &inst : make_range(std::next(inst->getIterator()),
-                                         block->end())) {
-    switch (liveness.isInterestingUser(&inst)) {
-    case PrunedLiveness::NonUser:
-      break;
-    case PrunedLiveness::NonLifetimeEndingUse:
-    case PrunedLiveness::LifetimeEndingUse:
-      return false;
-    }
-  }
-  return true;
+  return !liveness.isWithinBoundary(inst);
 }
 
 /// Reports a warning if the stored object \p storedObj is never loaded within

--- a/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
@@ -186,9 +186,8 @@ bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(
       return false;
     SmallVector<Operand *, 8> scratchSpace;
     if (llvm::any_of(borrowScopeIntroducers, [&](BorrowedValue borrowScope) {
-          return !borrowScope.areUsesWithinScope(lr.getAllConsumingUses(),
-                                                 scratchSpace,
-                                                 getDeadEndBlocks());
+          return !borrowScope.areUsesWithinLocalScope(lr.getAllConsumingUses(),
+                                                      getDeadEndBlocks());
         })) {
       return false;
     }
@@ -216,9 +215,8 @@ bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(
       }
 
       if (llvm::any_of(borrowScopeIntroducers, [&](BorrowedValue borrowScope) {
-            return !borrowScope.areUsesWithinScope(
-                phiArgLR.getAllConsumingUses(), scratchSpace,
-                getDeadEndBlocks());
+            return !borrowScope.areUsesWithinLocalScope(
+                phiArgLR.getAllConsumingUses(), getDeadEndBlocks());
           })) {
         return false;
       }

--- a/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
@@ -455,7 +455,8 @@ public:
     // Update this operand bypassing any copies.
     SILValue value = use->get();
     use->set(scope.findDefInBorrowScope(value));
-    ForwardingOperand(use).setOwnershipKind(OwnershipKind::Guaranteed);
+    ForwardingOperand(use).setForwardingOwnershipKind(
+        OwnershipKind::Guaranteed);
     deleteCopyChain(value, scope.getDeleter());
     return true;
   }
@@ -570,7 +571,8 @@ public:
       LLVM_DEBUG(llvm::dbgs() << "  Deleted " << *user);
     } else {
       use->set(scope.findDefInBorrowScope(use->get()));
-      ForwardingOperand(use).setOwnershipKind(OwnershipKind::Guaranteed);
+      ForwardingOperand(use).setForwardingOwnershipKind(
+          OwnershipKind::Guaranteed);
     }
     deleteCopyChain(innerValue, scope.getDeleter());
     return true;
@@ -659,7 +661,7 @@ SILValue RewriteOuterBorrowUses::createOuterValues(SILValue innerValue) {
   scope.getCallbacks().createdNewInst(clone);
   Operand *use = &clone->getOperandRef(0);
   use->set(incomingOuterVal);
-  ForwardingOperand(use).setOwnershipKind(OwnershipKind::Owned);
+  ForwardingOperand(use).setForwardingOwnershipKind(OwnershipKind::Owned);
 
   LLVM_DEBUG(llvm::dbgs() << "  Hoisted forward " << *clone);
 

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -672,7 +672,6 @@ OwnershipLifetimeExtender::createPlusZeroBorrow(SILValue newValue,
     callbacks.createdNewInst(ebi);
     callbacks.createdNewInst(dvi);
   }
-
   return borrow;
 }
 
@@ -1032,7 +1031,7 @@ OwnershipRAUWHelper::replaceAddressUses(SingleValueInstruction *oldValue,
   // If we are replacing addresses, see if we need to handle interior pointer
   // fixups. If we don't have any extra info, then we know that we can just RAUW
   // without any further work.
-  if (!ctx->extraAddressFixupInfo.intPtrOp)
+  if (!ctx->extraAddressFixupInfo.base)
     return replaceAllUsesAndErase(oldValue, newValue, ctx->callbacks);
 
   // We are RAUWing two addresses and we found that:
@@ -1045,25 +1044,26 @@ OwnershipRAUWHelper::replaceAddressUses(SingleValueInstruction *oldValue,
   // interior pointer instruction and change the clone to use our new borrowed
   // value. Then we RAUW as appropriate.
   OwnershipLifetimeExtender extender{*ctx};
-  auto &extraInfo = ctx->extraAddressFixupInfo;
-  auto intPtr = *extraInfo.intPtrOp;
+  auto base = ctx->extraAddressFixupInfo.base;
+  // FIXME: why does this use allAddressUsesFromOldValue instead of
+  // guaranteedUsePoints?
   BeginBorrowInst *bbi = extender.createPlusZeroBorrow(
-      intPtr->get(), llvm::makeArrayRef(extraInfo.allAddressUsesFromOldValue));
+      base.getReference(),
+      llvm::makeArrayRef(
+        ctx->extraAddressFixupInfo.allAddressUsesFromOldValue));
   auto bbiNext = &*std::next(bbi->getIterator());
-  auto *newIntPtrUser =
-      cast<SingleValueInstruction>(intPtr->getUser()->clone(bbiNext));
-  ctx->callbacks.createdNewInst(newIntPtrUser);
-  newIntPtrUser->setOperand(0, bbi);
+  auto *refProjection = cast<SingleValueInstruction>(base.getBaseAddress());
+  auto *newBase = refProjection->clone(bbiNext);
+  ctx->callbacks.createdNewInst(newBase);
+  newBase->setOperand(0, bbi);
 
   // Now that we have extended our lifetime as appropriate, we need to recreate
-  // the access path from newValue to intPtr but upon newIntPtr. Then we make it
-  // use newIntPtr.
-  auto *intPtrUser = cast<SingleValueInstruction>(intPtr->getUser());
-
+  // the access path from newValue to refProjection but upon newBase.
+  //
   // This cloner invocation must match the canCloneUseDefChain check in the
   // constructor.
   auto checkBase = [&](SILValue srcAddr) {
-    return (srcAddr == intPtrUser) ? SILValue(newIntPtrUser) : SILValue();
+    return (srcAddr == refProjection) ? SILValue(newBase) : SILValue();
   };
   SILValue clonedAddr =
       cloneUseDefChain(newValue, /*insetPt*/ oldValue, checkBase);
@@ -1141,47 +1141,34 @@ OwnershipRAUWHelper::OwnershipRAUWHelper(OwnershipFixupContext &inputCtx,
   if (!addressOwnership.hasLocalOwnershipLifetime())
     return;
 
-  auto intPtrOp =
-    InteriorPointerOperand::inferFromResult(
-      addressOwnership.base.getBaseAddress());
-  if (!intPtrOp) {
-    invalidate();
-    return;
-  }
-
-  ctx->extraAddressFixupInfo.intPtrOp = intPtrOp;
-  auto borrowedValue = intPtrOp.getSingleBorrowedValue();
-  if (!borrowedValue) {
-    invalidate();
-    return;
-  }
-
-  auto *intPtrInst =
-    cast<SingleValueInstruction>(intPtrOp.getUser());
-  auto checkBase = [&](SILValue srcAddr) {
-    return (srcAddr == intPtrInst) ? SILValue(intPtrInst) : SILValue();
-  };
-  // This cloner check must match the later cloner invocation in
-  // replaceAddressUses()
-  if (!canCloneUseDefChain(newValue, checkBase)) {
-    invalidate();
-    return;
-  }
+  ctx->extraAddressFixupInfo.base = addressOwnership.base;
 
   // For now, just gather up uses
+  //
+  // FIXME: get rid of allAddressUsesFromOldValue. Shouldn't this already be
+  // included in guaranteedUsePoints?
   auto &oldValueUses = ctx->extraAddressFixupInfo.allAddressUsesFromOldValue;
+  // FIXME: The return value of findTransitiveUsesForAddress is currently
+  // inverted.
   if (findTransitiveUsesForAddress(oldValue, oldValueUses)) {
     invalidate();
     return;
   }
-
-  // Ok, at this point we know that we can optimize. The only question is if we
-  // need to perform the copy or not when we actually RAUW. So perform the is
-  // within region check. If we succeed, clear our extra state so we perform a
-  // normal RAUW.
-  if (borrowedValue.areUsesWithinLocalScope(oldValueUses, ctx->deBlocks)) {
+  if (addressOwnership.areUsesWithinLifetime(oldValueUses, ctx->deBlocks)) {
     // We do not need to copy the base value! Clear the extra info we have.
     ctx->extraAddressFixupInfo.clear();
+    return;
+  }
+  // This cloner check must match the later cloner invocation in
+  // getReplacementAddress()
+  SILValue baseAddress = ctx->extraAddressFixupInfo.base.getBaseAddress();
+  auto *baseInst = cast<SingleValueInstruction>(baseAddress);
+  auto checkBase = [&](SILValue srcAddr) {
+    return (srcAddr == baseInst) ? SILValue(baseInst) : SILValue();
+  };
+  if (!canCloneUseDefChain(newValue, checkBase)) {
+    invalidate();
+    return;
   }
 }
 
@@ -1190,8 +1177,25 @@ OwnershipRAUWHelper::perform(SingleValueInstruction *maybeTransformedNewValue) {
   assert(isValid() && "OwnershipRAUWHelper invalid?!");
 
   SILValue actualNewValue = newValue;
-  if (maybeTransformedNewValue)
+  if (maybeTransformedNewValue) {
+    // Temporary variable for rebasing
+    SILValue rewrittenNewValue = maybeTransformedNewValue;
+    // Everything about \n newValue that the constructor checks should also be
+    // true for rewrittenNewValue.
+    // FIXME: enable these...
+    // assert(rewrittenNewValue->getType() == newValue->getType());
+    // assert(rewrittenNewValue->getOwnershipKind()
+    //        == newValue->getOwnershipKind());
+    // assert(rewrittenNewValue->getParentBlock() == newValue->getParentBlock());
+    assert(!newValue->getType().isAddress() ||
+           AddressOwnership(rewrittenNewValue) == AddressOwnership(newValue));
+
     actualNewValue = maybeTransformedNewValue;
+
+    // TODO: newValue = rewrittenNewValue; (remove actualNewValue)
+  }
+  assert(newValue && "prepareReplacement can only be called once");
+  SWIFT_DEFER { newValue = SILValue(); };
 
   if (!oldValue->getFunction()->hasOwnership())
     return replaceAllUsesAndErase(oldValue, actualNewValue, ctx->callbacks);

--- a/test/SILOptimizer/cse_ossa_nontrivial.sil
+++ b/test/SILOptimizer/cse_ossa_nontrivial.sil
@@ -842,12 +842,15 @@ class TestKlass {
 
 sil [ossa] @use_klass : $@convention(thin) (@guaranteed Klass) -> ()
 
-// Currently ownership rauw does not handle this case
-// CHECK-LABEL: sil [ossa] @cse_ossa_accesspathclonetest :
+// An interior pointer, struct_element_addr, can be reused during an
+// OSSA/RAUW because its new uses are within the borrowed value
+// (function argument %0).
+//
+// CHECK-LABEL: sil [ossa] @cse_ossa_interioruseswithinarg :
 // CHECK: struct_element_addr
-// CHECK: struct_element_addr
-// CHECK-LABEL: } // end sil function 'cse_ossa_accesspathclonetest'
-sil [ossa] @cse_ossa_accesspathclonetest : $@convention(thin) (@guaranteed TestKlass) -> () {
+// CHECK-NOT: struct_element_addr
+// CHECK-LABEL: } // end sil function 'cse_ossa_interioruseswithinarg'
+sil [ossa] @cse_ossa_interioruseswithinarg : $@convention(thin) (@guaranteed TestKlass) -> () {
 bb0(%0 : @guaranteed $TestKlass):
   %1 = ref_element_addr %0 : $TestKlass, #TestKlass.testStruct
   %2 = begin_access [modify] [dynamic] %1 : $*NonTrivialStruct
@@ -861,6 +864,34 @@ bb0(%0 : @guaranteed $TestKlass):
   %ca = apply %f(%4a) : $@convention(thin) (@guaranteed Klass) -> ()
   end_borrow %4a : $Klass
   end_access %2 : $*NonTrivialStruct
+  %139 = tuple ()
+  return %139 : $()
+}
+
+// An interior pointer, struct_element_addr, cannot be reused without
+// cloning the access scope, which we don't do. The two
+// struct_element_addr's are not currently considered equivalent.
+//
+// CHECK-LABEL: sil [ossa] @cse_ossa_outsideaccessscope :
+// CHECK: struct_element_addr
+// CHECK: struct_element_addr
+// CHECK-LABEL: } // end sil function 'cse_ossa_outsideaccessscope'
+sil [ossa] @cse_ossa_outsideaccessscope : $@convention(thin) (@guaranteed TestKlass) -> () {
+bb0(%0 : @guaranteed $TestKlass):
+  %1 = ref_element_addr %0 : $TestKlass, #TestKlass.testStruct
+  %a1 = begin_access [modify] [dynamic] %1 : $*NonTrivialStruct
+  %e1 = struct_element_addr %a1 : $*NonTrivialStruct, #NonTrivialStruct.val
+  %l1 = load_borrow %e1 : $*Klass
+  end_access %a1 : $*NonTrivialStruct
+  %f = function_ref @use_klass : $@convention(thin) (@guaranteed Klass) -> ()
+  %c1 = apply %f(%l1) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %l1 : $Klass
+  %a2 = begin_access [modify] [dynamic] %1 : $*NonTrivialStruct
+  %e2 = struct_element_addr %a2 : $*NonTrivialStruct, #NonTrivialStruct.val
+  %l2 = load_borrow %e2 : $*Klass
+  end_access %a2 : $*NonTrivialStruct
+  %c2 = apply %f(%l2) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %l2 : $Klass
   %139 = tuple ()
   return %139 : $()
 }


### PR DESCRIPTION
AddressOwnership OSSA utility replaces the recent BorrowedAddress utility (the address may not be borrowed!)

This is my best effort at extracting NFC changes from an ongoing OSSA utility rewrite. However, it does improve optimization in some cases, so could expose latent OSSA bugs. I may have also fixed those bugs already during the rewrite, but checking in all 100 commits at once would be too shocking.

APIs:

    AddressOwnership::hasLocalOwnershipLifetime() - convenience on top of
    AccessBase::hasLocalOwnershipLifetime().

    AddressOwnership::getOwnershipReferenceRoot() - convenience on top of
    AccessBase::getOwnershipReferenceRoot().

    AddressOwnership::findTransitiveUses() - wrapper API over the internal
    helper findTransitiveUsesForAddress()

    AddressOwnership::areUsesWithinLifetime() - wrapper adds a quick check
    on top of BorrowedValue::areUsesWithinLifetime()