### PR TITLE
[Sema] Intro flag to limit availability checks to the API

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -147,6 +147,9 @@ namespace swift {
     /// Disable API availability checking.
     bool DisableAvailabilityChecking = false;
 
+    /// Only check the availability of the API, ignore function bodies.
+    bool CheckAPIAvailabilityOnly = false;
+
     /// Should conformance availability violations be diagnosed as errors?
     bool EnableConformanceAvailabilityErrors = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -465,6 +465,10 @@ def disable_availability_checking : Flag<["-"],
   "disable-availability-checking">,
   HelpText<"Disable checking for potentially unavailable APIs">;
 
+def check_api_availability_only : Flag<["-"],
+  "check-api-availability-only">,
+  HelpText<"Only check the availability of the APIs, ignore function bodies">;
+
 def enable_conformance_availability_errors : Flag<["-"],
   "enable-conformance-availability-errors">,
   HelpText<"Diagnose conformance availability violations as errors">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -473,6 +473,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.DisableAvailabilityChecking |=
       Args.hasArg(OPT_disable_availability_checking);
+  Opts.CheckAPIAvailabilityOnly |=
+      Args.hasArg(OPT_check_api_availability_only);
 
   if (auto A = Args.getLastArg(OPT_enable_conformance_availability_errors,
                                OPT_disable_conformance_availability_errors)) {
@@ -914,6 +916,12 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
   Opts.DebugTimeFunctionBodies |= Args.hasArg(OPT_debug_time_function_bodies);
   Opts.DebugTimeExpressions |=
       Args.hasArg(OPT_debug_time_expression_type_checking);
+
+  // Checking availability of the API only relies on skipping non-inlinable
+  // function bodies. Define it first so it can be overridden by the other
+  // flags.
+  if (Args.hasArg(OPT_check_api_availability_only))
+    Opts.SkipFunctionBodies = FunctionBodySkipping::NonInlinable;
 
   // Check for SkipFunctionBodies arguments in order from skipping less to
   // skipping more.

--- a/test/Sema/api-availability-only-ok.swift
+++ b/test/Sema/api-availability-only-ok.swift
@@ -1,0 +1,97 @@
+/// Derived from api-availability-only with the errors fixed to check that the
+/// generated module interface can be built.
+
+// RUN: %empty-directory(%t)
+
+// RUN: %swiftc_driver -emit-module %s -target x86_64-apple-macosx10.15 -emit-module-interface -emit-module-interface-path %t/main.swiftinterface -enable-library-evolution -Xfrontend -check-api-availability-only -verify-emitted-module-interface
+// RUN: %target-swift-frontend -typecheck-module-from-interface %t/main.swiftinterface
+
+// REQUIRES: OS=macosx
+
+@available(macOS 11.0, *)
+public protocol NewProto {}
+
+@available(macOS 11.0, *)
+public func newFunc() {}
+
+@available(macOS 11.0, *)
+public func apiFunc(s : NewProto) {
+  let _: NewProto
+  newFunc()
+}
+
+@available(macOS 11.0, *)
+@usableFromInline func usableFromInline(s : NewProto) {
+  let _: NewProto
+  newFunc()
+}
+
+@available(macOS 11.0, *)
+@inlinable func inlinable(s : NewProto) {
+  let _: NewProto
+  newFunc()
+}
+
+@available(macOS 11.0, *)
+@_spi(SomeSPI) public func spiFunc(s : NewProto) {
+  let _: NewProto
+  newFunc()
+}
+
+func internalFunc(s : NewProto) {
+  let _: NewProto
+  newFunc()
+}
+
+private func privateFunc(s : NewProto) {
+  let _: NewProto
+  newFunc()
+}
+
+fileprivate func fileprivateFunc(s : NewProto) {
+  let _: NewProto
+  newFunc()
+}
+
+public struct Struct {
+  internal var internalVar: NewProto
+  private var privateVar: NewProto
+  fileprivate var fileprivateVar: NewProto
+
+  @available(macOS 11.0, *)
+  public typealias PubTA = NewProto
+  private typealias PrivateTA = NewProto
+
+  @available(macOS 11.0, *)
+  public func apiFunc(s : NewProto) {
+    let _: NewProto
+    newFunc()
+  }
+  
+  @available(macOS 11.0, *)
+  @usableFromInline func usableFromInline(s : NewProto) {
+    let _: NewProto
+    newFunc()
+  }
+  
+  @available(macOS 11.0, *)
+  @inlinable func inlinable(s : NewProto) {
+    let _: NewProto
+    newFunc()
+  }
+  
+  func internalFunc(s : NewProto) {
+    let _: NewProto
+    newFunc()
+  }
+  
+  private func privateFunc(s : NewProto) {
+    let _: NewProto
+    newFunc()
+  }
+  
+  fileprivate func fileprivateFunc(s : NewProto) {
+    let _: NewProto
+    newFunc()
+  }
+}

--- a/test/Sema/api-availability-only.swift
+++ b/test/Sema/api-availability-only.swift
@@ -1,0 +1,109 @@
+/// Test that -check-api-availability-only skips what is expected while checking
+/// the module API and SPI.
+
+// RUN: %target-typecheck-verify-swift -module-name MyModule -target x86_64-apple-macosx10.15 -check-api-availability-only -enable-library-evolution
+
+// REQUIRES: OS=macosx
+
+@available(macOS 11.0, *)
+public protocol NewProto {}
+
+@available(macOS 11.0, *)
+public func newFunc() {}
+
+// expected-note @+1 {{add @available attribute to enclosing}}
+public func apiFunc(s : NewProto) { // expected-error {{'NewProto' is only available in macOS 11.0 or newer}}
+  let _: NewProto
+  newFunc()
+}
+
+// expected-note @+1 {{add @available attribute to enclosing}}
+@usableFromInline func usableFromInline(s : NewProto) { // expected-error {{'NewProto' is only available in macOS 11.0 or newer}}
+  let _: NewProto
+  newFunc()
+}
+
+// expected-note @+1 3 {{add @available attribute to enclosing}}
+@inlinable func inlinable(s : NewProto) { // expected-error {{'NewProto' is only available in macOS 11.0 or newer}}
+
+  // expected-note @+1 {{add 'if #available' version check}}
+  let _: NewProto // expected-error {{'NewProto' is only available in macOS 11.0 or newer}}
+
+  // expected-note @+1 {{add 'if #available' version check}}
+  newFunc() // expected-error {{'newFunc()' is only available in macOS 11.0 or newer}}
+}
+
+// expected-note @+1 {{add @available attribute to enclosing}}
+@_spi(SomeSPI) public func spiFunc(s : NewProto) { // expected-error {{'NewProto' is only available in macOS 11.0 or newer}}
+  let _: NewProto
+  newFunc()
+}
+
+func internalFunc(s : NewProto) {
+  let _: NewProto
+  newFunc()
+}
+
+private func privateFunc(s : NewProto) {
+  let _: NewProto
+  newFunc()
+}
+
+fileprivate func fileprivateFunc(s : NewProto) {
+  let _: NewProto
+  newFunc()
+}
+
+// expected-note @+1 7 {{add @available attribute to enclosing struct}}
+public struct Struct {
+  public var publicVar: NewProto // expected-error {{'NewProto' is only available in macOS 11.0 or newer}}
+  internal var internalVar: NewProto
+  private var privateVar: NewProto
+  fileprivate var fileprivateVar: NewProto
+
+  // expected-note @+1 {{add @available attribute to enclosing}}
+  public typealias PubTA = NewProto // expected-error {{'NewProto' is only available in macOS 11.0 or newer}}
+  private typealias PrivateTA = NewProto
+
+  // expected-note @+1 {{add @available attribute to enclosing}}
+  public func apiFunc(s : NewProto) { // expected-error {{'NewProto' is only available in macOS 11.0 or newer}}
+    let _: NewProto
+    newFunc()
+  }
+  
+  // expected-note @+1 {{add @available attribute to enclosing}}
+  @usableFromInline func usableFromInline(s : NewProto) { // expected-error {{'NewProto' is only available in macOS 11.0 or newer}}
+    let _: NewProto
+    newFunc()
+  }
+  
+  // expected-note @+1 3 {{add @available attribute to enclosing}}
+  @inlinable func inlinable(s : NewProto) { // expected-error {{'NewProto' is only available in macOS 11.0 or newer}}
+  
+    // expected-note @+1 {{add 'if #available' version check}}
+    let _: NewProto // expected-error {{'NewProto' is only available in macOS 11.0 or newer}}
+  
+    // expected-note @+1 {{add 'if #available' version check}}
+    newFunc() // expected-error {{'newFunc()' is only available in macOS 11.0 or newer}}
+  }
+  
+  func internalFunc(s : NewProto) {
+    let _: NewProto
+    newFunc()
+  }
+  
+  private func privateFunc(s : NewProto) {
+    let _: NewProto
+    newFunc()
+  }
+  
+  fileprivate func fileprivateFunc(s : NewProto) {
+    let _: NewProto
+    newFunc()
+  }
+}
+
+// expected-note @+1 {{add @available attribute to enclosing}}
+extension NewProto { // expected-error {{'NewProto' is only available in macOS 11.0 or newer}}
+    public func foo() {}
+}


### PR DESCRIPTION
Intro the frontend flag `-check-api-availability-only` that limits availability checking to the API and SPI. This mode doesn't check the availability of non-inlinable function bodies and of non-ABI-public decl signatures.

This mode goal is to check all that is printed in the swiftinterface file. It should be used in place of the wider `-disable-availability-checking` when generating an interface for platforms with no binaries.

rdar://81679692

---

We'll probably want to add this as a driver flag too even if it's only to make sure it's not passed to the verify-emitted-module-interface job.