### PR TITLE
[cxx-interop] Fix a failing template import test for Windows

### DIFF
--- a/test/Interop/Cxx/templates/Inputs/template-type-parameter-not-in-signature.h
+++ b/test/Interop/Cxx/templates/Inputs/template-type-parameter-not-in-signature.h
@@ -11,7 +11,7 @@ template <typename T, typename U>
 U multiTemplateTypeParamOneUsedInSignature(U u) { return u; }
 
 template <typename T, typename U>
-void multiTemplateTypeParamNotUsedInSignatureWithUnrelatedParams(int x, long y) {}
+void multiTemplateTypeParamNotUsedInSignatureWithUnrelatedParams(int x, int y) {}
 
 template <typename T>
 T templateTypeParamUsedInReturnType(int x) { return x; }

--- a/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-module-interface.swift
+++ b/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-module-interface.swift
@@ -3,7 +3,7 @@
 // CHECK: func templateTypeParamNotUsedInSignature<T>(T: T.Type)
 // CHECK: func multiTemplateTypeParamNotUsedInSignature<T, U>(T: T.Type, U: U.Type)
 // CHECK: func multiTemplateTypeParamOneUsedInSignature<T, U>(_ u: U, T: T.Type) -> U
-// CHECK: func multiTemplateTypeParamNotUsedInSignatureWithUnrelatedParams<T, U>(_ x: Int32, _ y: Int, T: T.Type, U: U.Type)
+// CHECK: func multiTemplateTypeParamNotUsedInSignatureWithUnrelatedParams<T, U>(_ x: Int32, _ y: Int32, T: T.Type, U: U.Type)
 // CHECK: func templateTypeParamUsedInReturnType<T>(_ x: Int32) -> T
 // CHECK: func templateTypeParamUsedInReferenceParam<T>(_ t: UnsafeMutablePointer<T>) -> T
 // CHECK: @available(*, unavailable, message: "Variadic function is unavailable")


### PR DESCRIPTION
For Windows, longs are Int32. These tests aren't concerned with that detail so this patch changes the test to use an int instead for simplicity. 