### PR TITLE
Enabled top_level_code.swift and fixed issue with prologue.swift 

### DIFF
--- a/test/DebugInfo/prologue.swift
+++ b/test/DebugInfo/prologue.swift
@@ -7,9 +7,9 @@ func markUsed<T>(_ t: T) {}
 // CHECK: .file [[F:[0-9]+]] "{{.*}}prologue.swift"
 func bar<T, U>(_ x: T, y: U) { markUsed("bar") }
 // CHECK: $s8prologue3bar_1yyx_q_tr0_lF:
-// CHECK: .loc	[[F]] 0 0 prologue_end
+// CHECK: .loc	[[F]] 0 0 is_stmt {{[0-9]+$}}
 // Make sure there is no allocation happening between the end of
 // prologue and the beginning of the function body.
 // CHECK-NOT: callq	*
-// CHECK: .loc	[[F]] [[@LINE-6]] {{.}}
+// CHECK: .loc	[[F]] [[@LINE-6]] {{[0-9]+}} prologue_end is_stmt {{[0-9]+$}}
 // CHECK: {{callq	.*builtinStringLiteral|movq __imp_.*builtinStringLiteral}}

--- a/test/DebugInfo/top_level_code.swift
+++ b/test/DebugInfo/top_level_code.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend %s -S -g -o - | %FileCheck %s
 
-// REQUIRES: rdar73761019
-
 func markUsed<T>(_ t: T) {}
 // CHECK: {{_?}}main:
 // CHECK: Lfunc_begin0:


### PR DESCRIPTION
top_level_code.swift was disabled because of rdar://73761019 and cloned into rdar://78319083, this bug has been fixed with commit ID 1813652b0398345c4b4407d5fd5ffb749830fdd4 https://github.com/apple/llvm-project/commit/1813652b0398345c4b4407d5fd5ffb749830fdd4

prologue.swift is checking for a prologue_end on a line 0 .loc which is what this commit was fixed, so it had to be updated to reflect the changes to llvm, where no line 0 .locs will ever have a prologue_end