### PR TITLE
Fix `ParseableInterface/verify_all_overlays.py`

### DIFF
--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Note that this test should still "pass" when no swiftinterfaces have been
 # generated.
@@ -55,6 +55,6 @@ for filename in os.listdir(sdk_overlay_dir):
     output_path = os.path.join(output_dir, module_name + ".swiftmodule")
     status = subprocess.call(compiler_invocation +
                              ["-o", output_path, "-module-name", module_name,
-                              interface_file])
+                              interface_file]).decode('utf-8')
     if status != 0:
         print("# " + target_os + ": " + module_name)


### PR DESCRIPTION
The `validation-test/ParseableInterface/verify_all_overlays.py` test calls
subprocess, which returns a bytes object in python3. We need to decode
that when using python3, but not python2. This inconsistency is not
ideal, so I'm just pining it to python3.