### PR TITLE
[SR-15281] [Sema] Couple of contextual mismatch and runtime cast diagnostic fixes

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2180,6 +2180,10 @@ public:
 using RewriteTargetFn = std::function<
     Optional<SolutionApplicationTarget> (SolutionApplicationTarget)>;
 
+/// Represents a conversion restriction between two types.
+using ConversionRestriction =
+    std::tuple<TypeBase *, TypeBase *, ConversionRestrictionKind>;
+
 enum class ConstraintSystemPhase {
   ConstraintGeneration,
   Solving,
@@ -2364,8 +2368,7 @@ private:
   /// there are multiple ways in which one type could convert to another, e.g.,
   /// given class types A and B, the solver might choose either a superclass
   /// conversion or a user-defined conversion.
-  std::vector<std::tuple<Type, Type, ConversionRestrictionKind>>
-      ConstraintRestrictions;
+  std::vector<ConversionRestriction> ConstraintRestrictions;
 
   /// The set of fixes applied to make the solution work.
   llvm::SmallVector<ConstraintFix *, 4> Fixes;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2953,9 +2953,9 @@ bool ContextualFailure::tryTypeCoercionFixIt(
   if (!toType->hasTypeRepr())
     return false;
 
-  // If optional unwrapped type is a subtype of the specified contextual type,
-  // let's suggest a force unwrap "!". Otherwise fallback to potential coercion
-  // or force cast.
+  // If object of the optional type is a subtype of the specified contextual
+  // type, let's suggest a force unwrap "!". Otherwise fallback to potential
+  // coercion or force cast.
   if (!bothOptional && fromType->getOptionalObjectType()) {
     if (TypeChecker::isSubtypeOf(fromType->lookThroughAllOptionalTypes(),
                                  toType, getDC())) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2953,6 +2953,20 @@ bool ContextualFailure::tryTypeCoercionFixIt(
   if (!toType->hasTypeRepr())
     return false;
 
+  // If optional unwrapped type is a subtype of the specified contextual type,
+  // let's suggest a force unwrap "!". Otherwise fallback to potential coercion
+  // or force cast.
+  if (!bothOptional && fromType->getOptionalObjectType()) {
+    if (TypeChecker::isSubtypeOf(fromType->lookThroughAllOptionalTypes(),
+                                 toType, getDC())) {
+      diagnostic.fixItInsert(
+          Lexer::getLocForEndOfToken(getASTContext().SourceMgr,
+                                     getSourceRange().End),
+          "!");
+      return true;
+    }
+  }
+
   CheckedCastKind Kind =
       TypeChecker::typeCheckCheckedCast(fromType, toType,
                                         CheckedCastContextKind::None, getDC(),

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6735,7 +6735,7 @@ static ConstraintFix *maybeWarnAboutExtraneousCast(
   // we need to store the difference as a signed integer.
   int extraOptionals = fromOptionals.size() - toOptionals.size();
 
-  // From expression could be a type variable with a value to optional
+  // "from" expression could be a type variable with value-to-optional
   // restrictions that we have to account for optionality mismatch.
   const auto subExprType = cs.getType(castExpr->getSubExpr());
   if (llvm::any_of(constraintRestrictions, [&](auto &entry) {

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -231,9 +231,10 @@ void ConstraintSystem::applySolution(const Solution &solution) {
   // Register constraint restrictions.
   // FIXME: Copy these directly into some kind of partial solution?
   for (auto restriction : solution.ConstraintRestrictions) {
-    ConstraintRestrictions.push_back(
-        std::make_tuple(restriction.first.first, restriction.first.second,
-                        restriction.second));
+    auto &types = restriction.first;
+    ConstraintRestrictions.push_back(std::make_tuple(types.first.getPointer(),
+                                                     types.second.getPointer(),
+                                                     restriction.second));
   }
 
   // Register the solution's disjunction choices.

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -613,3 +613,23 @@ func decodeStringOrIntDictionary<T: FixedWidthInteger>() -> [Int: T] {
     fatalError()
   }
 }
+
+// SR-15281
+struct SR15281_A { }
+
+struct SR15281_B {
+  init(a: SR15281_A) { }
+}
+
+struct SR15281_S {
+  var a: SR15281_A? = SR15281_A()
+
+  var b1: SR15281_B {
+    a.flatMap(SR15281_B.init(a:)) as! SR15281_B 
+    // expected-warning@-1 {{forced cast from 'SR15281_B?' to 'SR15281_B' only unwraps optionals; did you mean to use '!'?}} {{34-34=!}} {{34-48=}}
+  }
+
+  var b: SR15281_B {
+    a.flatMap(SR15281_B.init(a:)) // expected-error{{cannot convert return expression of type 'SR15281_B?' to return type 'SR15281_B'}} {{34-34= as! SR15281_B}}
+  }
+}

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -614,9 +614,9 @@ func decodeStringOrIntDictionary<T: FixedWidthInteger>() -> [Int: T] {
   }
 }
 
+
 // SR-15281
 struct SR15281_A { }
-
 struct SR15281_B {
   init(a: SR15281_A) { }
 }
@@ -624,12 +624,30 @@ struct SR15281_B {
 struct SR15281_S {
   var a: SR15281_A? = SR15281_A()
 
+  var b: SR15281_B {
+    a.flatMap(SR15281_B.init(a:)) // expected-error{{cannot convert return expression of type 'SR15281_B?' to return type 'SR15281_B'}} {{34-34=!}}
+  }
+
   var b1: SR15281_B {
     a.flatMap(SR15281_B.init(a:)) as! SR15281_B 
     // expected-warning@-1 {{forced cast from 'SR15281_B?' to 'SR15281_B' only unwraps optionals; did you mean to use '!'?}} {{34-34=!}} {{34-48=}}
   }
+}
 
-  var b: SR15281_B {
-    a.flatMap(SR15281_B.init(a:)) // expected-error{{cannot convert return expression of type 'SR15281_B?' to return type 'SR15281_B'}} {{34-34= as! SR15281_B}}
+class SR15281_AC {}
+class SR15281_BC {
+  init(a: SR15281_AC) { }
+}
+class SR15281_CC: SR15281_BC {}
+
+struct SR15281_SC {
+  var a: SR15281_AC? = SR15281_AC()
+
+  var b: SR15281_BC {
+    a.flatMap(SR15281_BC.init(a:)) // expected-error{{cannot convert return expression of type 'SR15281_BC?' to return type 'SR15281_BC'}} {{35-35=!}}
+  }
+
+  var c: SR15281_BC {
+    a.flatMap(SR15281_CC.init(a:)) // expected-error{{cannot convert return expression of type 'SR15281_CC?' to return type 'SR15281_BC'}} {{35-35=!}}
   }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
This is twofold:
First commit is taking into account value-to-optional restrictions for an extra layer of optionality when recording the fix, 
because otherwise we would compute the same type conversion. 
```swift 
  var b1: B {
    a.flatMap(B.init(a:)) as! B 
   // flatMap opens a type variable for generic parameter as result `T?` with a layer of optionality that we were not 
   // considering so fix was considering only `B` as! `B` which lead to misleading diagnostic reported.
  }
```
Second commit: Instead of suggesting a ' as! B' fix-it on `B?` to `B` contextual mismatch, if we know from type has a subtype relation with to type, it would make more sense to suggest a force unwrap "!". 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-15281.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
