### PR TITLE
[SourceKit] Flush llvm::outs() before printing to STDOUT_FILENO in soucekitd-test

### DIFF
--- a/test/SourceKit/CompileNotifications/cursor-info.swift
+++ b/test/SourceKit/CompileNotifications/cursor-info.swift
@@ -1,4 +1,5 @@
 // RUN: %sourcekitd-test -req=track-compiles == -req=cursor %s -offset=0 -- %s | %FileCheck %s -check-prefix=COMPILE_1 --enable-yaml-compatibility
+// COMPILE_1: <empty cursor info; internal diagnostic: "Unable to resolve cursor info.">
 // COMPILE_1: {
 // COMPILE_1:  key.notification: source.notification.compile-will-start,
 // COMPILE_1:  key.filepath: "SOURCE_DIR{{.*}}cursor-info.swift",
@@ -8,6 +9,5 @@
 // COMPILE_1:   key.notification: source.notification.compile-did-finish,
 // COMPILE_1:   key.compileid: [[CID1]]
 // COMPILE_1: }
-// COMPILE_1: <empty cursor info; internal diagnostic: "Unable to resolve cursor info.">
 // COMPILE_1-NOT: compile-will-start
 // COMPILE_1-NOT: compile-did-finish

--- a/tools/SourceKit/tools/complete-test/complete-test.cpp
+++ b/tools/SourceKit/tools/complete-test/complete-test.cpp
@@ -568,6 +568,7 @@ public:
 static void printResponse(sourcekitd_response_t resp, bool raw, bool structure,
                           unsigned indentation) {
   if (raw) {
+    llvm::outs().flush();
     sourcekitd_response_description_dump_filedesc(resp, STDOUT_FILENO);
     return;
   }


### PR DESCRIPTION
Otherwise, we get non-deterministic ordering of results printed through `llvm::outs()` and `STDOUT_FILENO`.

---

Cherry-picked from https://github.com/apple/swift/pull/39585 to check whether this commit or the actual functionality change in that PR causes the Windows CI failure.