### PR TITLE
TypeResolution: Abolish TypeResolutionStage::Contextual

### DIFF
--- a/include/swift/AST/TypeResolutionStage.h
+++ b/include/swift/AST/TypeResolutionStage.h
@@ -31,10 +31,6 @@ enum class TypeResolutionStage : uint8_t {
   /// Produces a complete interface type where all member references have been
   /// resolved.
   Interface,
-
-  /// Produces a contextual type involving archetypes within the context of
-  /// the type.
-  Contextual,
 };
 
 /// Display a type resolution stage.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4037,9 +4037,12 @@ public:
   /// parent type by introducing fresh type variables for generic parameters
   /// and constructing a bound generic type from these type variables.
   ///
+  /// \param isTypeResolution Whether we are in the process of resolving a type.
+  ///
   /// \returns The opened type.
   Type openUnboundGenericType(GenericTypeDecl *decl, Type parentTy,
-                              ConstraintLocatorBuilder locator);
+                              ConstraintLocatorBuilder locator,
+                              bool isTypeResolution);
 
   /// Replace placeholder types with fresh type variables, and unbound generic
   /// types with bound generic types whose generic args are fresh type
@@ -5275,7 +5278,8 @@ public:
 
   Type operator()(UnboundGenericType *unboundTy) const {
     return cs.openUnboundGenericType(unboundTy->getDecl(),
-                                     unboundTy->getParent(), locator);
+                                     unboundTy->getParent(), locator,
+                                     /*isTypeResolution=*/true);
   }
 };
 

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -157,7 +157,7 @@ namespace swift {
   /// emitted.
   void performWholeModuleTypeChecking(SourceFile &SF);
 
-  /// Resolve the given \c TypeRepr to a contextual type.
+  /// Resolve the given \c TypeRepr to an interface type.
   ///
   /// This is used when dealing with partial source files (e.g. SIL parsing,
   /// code completion).

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -86,7 +86,8 @@ Optional<Type> GenericEnvironment::getMappingIfPresent(
 
 Type GenericEnvironment::mapTypeIntoContext(GenericEnvironment *env,
                                             Type type) {
-  assert(!type->hasArchetype() && "already have a contextual type");
+  assert((!type->hasArchetype() || type->hasOpenedExistential()) &&
+         "already have a contextual type");
   assert((env || !type->hasTypeParameter()) &&
          "no generic environment provided for type with type parameters");
 
@@ -230,8 +231,8 @@ Type QueryInterfaceTypeSubstitutions::operator()(SubstitutableType *type) const{
 Type GenericEnvironment::mapTypeIntoContext(
                                 Type type,
                                 LookupConformanceFn lookupConformance) const {
-  assert(!type->hasOpenedExistential() &&
-         "Opened existentials are special and so are you");
+  assert((!type->hasArchetype() || type->hasOpenedExistential()) &&
+         "already have a contextual type");
 
   Type result = type.subst(QueryInterfaceTypeSubstitutions(this),
                            lookupConformance,

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -58,10 +58,6 @@ void swift::simple_display(llvm::raw_ostream &out,
   case TypeResolutionStage::Interface:
     out << "interface";
     break;
-
-  case TypeResolutionStage::Contextual:
-    out << "contextual";
-    break;
   }
 }
 

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -225,6 +225,8 @@ void AttributedTypeRepr::printAttrs(ASTPrinter &Printer,
 
   if (hasAttr(TAK_async))
     Printer.printSimpleAttr("@async") << " ";
+  if (hasAttr(TAK_opened))
+    Printer.printSimpleAttr("@opened") << " ";
 }
 
 IdentTypeRepr *IdentTypeRepr::create(ASTContext &C,

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1580,10 +1580,12 @@ class CodeCompletionCallbacksImpl : public CodeCompletionCallbacks {
         /*GenericParams=*/nullptr,
         CurDeclContext,
         /*ProduceDiagnostics=*/false);
-    ParsedTypeLoc.setType(ty);
-    if (!ParsedTypeLoc.isError()) {
+    if (!ty->hasError()) {
+      ParsedTypeLoc.setType(CurDeclContext->mapTypeIntoContext(ty));
       return true;
     }
+
+    ParsedTypeLoc.setType(ty);
 
     // It doesn't type check as a type, so see if it's a qualifying module name.
     if (auto *ITR = dyn_cast<IdentTypeRepr>(ParsedTypeLoc.getTypeRepr())) {

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -308,7 +308,7 @@ void swift::ide::collectPossibleReturnTypesFromContext(
               const_cast<DeclContext *>(DC), /*diagnostics=*/false);
 
           if (!type->hasError()) {
-            candidates.push_back(type);
+            candidates.push_back(DC->mapTypeIntoContext(type));
             return;
           }
         }

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -150,7 +150,7 @@ namespace {
 
     Type performTypeResolution(TypeRepr *TyR, bool IsSILType,
                                GenericEnvironment *GenericEnv,
-                               GenericParamList *GenericParams);
+                               GenericParamList *GenericParams) const;
 
     void convertRequirements(ArrayRef<RequirementRepr> From,
                              SmallVectorImpl<Requirement> &To);
@@ -915,9 +915,8 @@ void SILParser::convertRequirements(ArrayRef<RequirementRepr> From,
   // Use parser lexical scopes to resolve references
   // to the generic parameters.
   auto ResolveToInterfaceType = [&](TypeRepr *TyR) -> Type {
-    return performTypeResolution(TyR, /*IsSILType=*/false,
-                                 ContextGenericEnv, ContextGenericParams)
-        ->mapTypeOutOfContext();
+    return performTypeResolution(TyR, /*IsSILType=*/false, ContextGenericEnv,
+                                 ContextGenericParams);
   };
 
   for (auto &Req : From) {
@@ -1187,7 +1186,7 @@ static bool parseDeclSILOptional(bool *isTransparent,
 
 Type SILParser::performTypeResolution(TypeRepr *TyR, bool IsSILType,
                                       GenericEnvironment *GenericEnv,
-                                      GenericParamList *GenericParams) {
+                                      GenericParamList *GenericParams) const {
   if (GenericEnv == nullptr)
     GenericEnv = ContextGenericEnv;
 
@@ -1251,26 +1250,26 @@ bool SILParser::parseASTType(CanType &result,
   ParserResult<TypeRepr> parsedType = P.parseType();
   if (parsedType.isNull()) return true;
 
-  bool wantInterfaceType = true;
+  bool wantContextualType = false;
   if (genericEnv == nullptr) {
     genericEnv = ContextGenericEnv;
-    wantInterfaceType = false;
+    wantContextualType = true;
   }
   if (genericParams == nullptr)
     genericParams = ContextGenericParams;
 
   bindSILGenericParams(parsedType.get());
 
-  const auto resolvedType =
-      performTypeResolution(parsedType.get(), /*isSILType=*/false,
-                            genericEnv, genericParams);
+  auto resolvedType = performTypeResolution(
+      parsedType.get(), /*isSILType=*/false, genericEnv, genericParams);
+  if (wantContextualType && genericEnv) {
+    resolvedType = genericEnv->mapTypeIntoContext(resolvedType);
+  }
+
   if (resolvedType->hasError())
     return true;
 
-  if (wantInterfaceType)
-    result = resolvedType->mapTypeOutOfContext()->getCanonicalType();
-  else
-    result = resolvedType->getCanonicalType();
+  result = resolvedType->getCanonicalType();
 
   return false;
 }
@@ -1363,9 +1362,12 @@ bool SILParser::parseSILType(SILType &Result,
   auto *attrRepr =
       P.applyAttributeToType(
         TyR.get(), attrs, specifier, specifierLoc, isolatedLoc);
-  const auto Ty =
-      performTypeResolution(attrRepr, /*IsSILType=*/true,
-                            OuterGenericEnv, OuterGenericParams);
+  auto Ty = performTypeResolution(attrRepr, /*IsSILType=*/true, OuterGenericEnv,
+                                  OuterGenericParams);
+  if (OuterGenericEnv) {
+    Ty = OuterGenericEnv->mapTypeIntoContext(Ty);
+  }
+
   if (Ty->hasError())
     return true;
 
@@ -1930,9 +1932,12 @@ bool SILParser::parseSubstitutions(SmallVectorImpl<ParsedSubstitution> &parsed,
     if (TyR.isNull())
       return true;
 
-    const auto Ty =
-        performTypeResolution(TyR.get(), /*IsSILType=*/false,
-                              GenericEnv, GenericParams);
+    auto Ty = performTypeResolution(TyR.get(), /*IsSILType=*/false, GenericEnv,
+                                    GenericParams);
+    if (GenericEnv) {
+      Ty = GenericEnv->mapTypeIntoContext(Ty);
+    }
+
     if (Ty->hasError())
       return true;
     parsed.push_back({Loc, Ty});
@@ -2321,9 +2326,8 @@ bool SILParser::parseSILDeclRef(SILDeclRef &Member, bool FnTypeRequired) {
       genericParams = fnType->getGenericParams();
     }
 
-    const auto Ty =
-        performTypeResolution(TyR.get(), /*IsSILType=*/false,
-                              genericEnv, genericParams);
+    const auto Ty = performTypeResolution(TyR.get(), /*IsSILType=*/false,
+                                          genericEnv, genericParams);
     if (Ty->hasError())
       return true;
 
@@ -6841,9 +6845,12 @@ ProtocolConformanceRef SILParser::parseProtocolConformanceHelper(
   if (witnessParams == nullptr)
     witnessParams = ContextGenericParams;
 
-  const auto ConformingTy =
-      performTypeResolution(TyR.get(), /*IsSILType=*/false,
-                            witnessEnv, witnessParams);
+  auto ConformingTy = performTypeResolution(TyR.get(), /*IsSILType=*/false,
+                                            witnessEnv, witnessParams);
+  if (witnessEnv) {
+    ConformingTy = witnessEnv->mapTypeIntoContext(ConformingTy);
+  }
+
   if (ConformingTy->hasError())
     return ProtocolConformanceRef();
 
@@ -6957,13 +6964,17 @@ static bool parseSILWitnessTableEntry(
       if (TyR.isNull())
         return true;
 
-      const auto Ty =
+      auto Ty =
           swift::performTypeResolution(TyR.get(), P.Context,
                                        /*isSILMode=*/false,
                                        /*isSILType=*/false,
                                        witnessEnv,
                                        witnessParams,
                                        &P.SF);
+      if (witnessEnv) {
+        Ty = witnessEnv->mapTypeIntoContext(Ty);
+      }
+
       if (Ty->hasError())
         return true;
 
@@ -7018,12 +7029,16 @@ static bool parseSILWitnessTableEntry(
     if (TyR.isNull())
       return true;
 
-    const auto Ty =
+    auto Ty =
         swift::performTypeResolution(TyR.get(), P.Context,
                                      /*isSILMode=*/false,
                                      /*isSILType=*/false,
                                      witnessEnv, witnessParams,
                                      &P.SF);
+    if (witnessEnv) {
+      Ty = witnessEnv->mapTypeIntoContext(Ty);
+    }
+
     if (Ty->hasError())
       return true;
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1818,9 +1818,10 @@ bool TypeVarBindingProducer::computeNext() {
       // always preserved.
       auto *BGT = type->castTo<BoundGenericType>();
       auto dstLocator = TypeVar->getImpl().getLocator();
-      auto newType = CS.openUnboundGenericType(BGT->getDecl(), BGT->getParent(),
-                                               dstLocator)
-                         ->reconstituteSugar(/*recursive=*/false);
+      auto newType =
+          CS.openUnboundGenericType(BGT->getDecl(), BGT->getParent(),
+                                    dstLocator, /*isTypeResolution=*/false)
+              ->reconstituteSugar(/*recursive=*/false);
       addNewBinding(binding.withType(newType));
     }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1321,10 +1321,8 @@ namespace {
       // Introduce type variables for unbound generics.
       const auto genericOpener = OpenUnboundGenericType(CS, locator);
       const auto placeholderHandler = HandlePlaceholderType(CS, locator);
-      const auto result = TypeResolution::forContextual(CS.DC, resCtx,
-                                                        genericOpener,
-                                                        placeholderHandler)
-              .resolveType(repr);
+      const auto result = TypeResolution::resolveContextualType(
+          repr, CS.DC, resCtx, genericOpener, placeholderHandler);
       if (result->hasError()) {
         return Type();
       }
@@ -1597,13 +1595,12 @@ namespace {
           auto *const locator = CS.getConstraintLocator(expr);
           const auto options =
               TypeResolutionOptions(TypeResolverContext::InExpression);
-          for (size_t i = 0, size = specializations.size(); i < size; ++i) {
-            const auto resolution = TypeResolution::forContextual(
-                CS.DC, options,
+          for (size_t i = 0, e = specializations.size(); i < e; ++i) {
+            const auto result = TypeResolution::resolveContextualType(
+                specializations[i], CS.DC, options,
                 // Introduce type variables for unbound generics.
                 OpenUnboundGenericType(CS, locator),
                 HandlePlaceholderType(CS, locator));
-            const auto result = resolution.resolveType(specializations[i]);
             if (result->hasError())
               return Type();
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1098,16 +1098,14 @@ void ConstraintSystem::shrink(Expr *expr) {
           auto *const typeRepr = coerceExpr->getCastTypeRepr();
 
           if (typeRepr && isSuitableCollection(typeRepr)) {
-            const auto coercionType =
-                TypeResolution::forContextual(
-                    CS.DC, None,
-                    // FIXME: Should we really be unconditionally complaining
-                    // about unbound generics and placeholders here? For
-                    // example:
-                    // let foo: [Array<Float>] = [[0], [1], [2]] as [Array]
-                    // let foo: [Array<Float>] = [[0], [1], [2]] as [Array<_>]
-                    /*unboundTyOpener*/ nullptr, /*placeholderHandler*/ nullptr)
-                    .resolveType(typeRepr);
+            const auto coercionType = TypeResolution::resolveContextualType(
+                typeRepr, CS.DC, None,
+                // FIXME: Should we really be unconditionally complaining
+                // about unbound generics and placeholders here? For
+                // example:
+                // let foo: [Array<Float>] = [[0], [1], [2]] as [Array]
+                // let foo: [Array<Float>] = [[0], [1], [2]] as [Array<_>]
+                /*unboundTyOpener*/ nullptr, /*placeholderHandler*/ nullptr);
 
             // Looks like coercion type is invalid, let's skip this sub-tree.
             if (coercionType->hasError())

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1349,11 +1349,12 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
   if (auto typeDecl = dyn_cast<TypeDecl>(value)) {
     // Resolve the reference to this type declaration in our current context.
     auto type =
-        TypeResolution::forContextual(useDC, TypeResolverContext::InExpression,
-                                      /*unboundTyOpener*/ nullptr,
-                                      /*placeholderHandler*/ nullptr)
+        TypeResolution::forInterface(useDC, TypeResolverContext::InExpression,
+                                     /*unboundTyOpener*/ nullptr,
+                                     /*placeholderHandler*/ nullptr)
             .resolveTypeInContext(typeDecl, /*foundDC*/ nullptr,
                                   /*isSpecialized=*/false);
+    type = useDC->mapTypeIntoContext(type);
 
     checkNestedTypeConstraints(*this, type, locator);
 
@@ -2393,11 +2394,10 @@ FunctionType::ExtInfo ConstraintSystem::closureEffects(ClosureExpr *expr) {
       while (auto isp = dyn_cast<IsPattern>(pattern)) {
         Type castType;
         if (auto castTypeRepr = isp->getCastTypeRepr()) {
-          castType = TypeResolution::forContextual(
-                         DC, TypeResolverContext::InExpression,
-                         /*unboundTyOpener*/ nullptr,
-                         /*placeholderHandler*/ nullptr)
-                         .resolveType(castTypeRepr);
+          castType = TypeResolution::resolveContextualType(
+              castTypeRepr, DC, TypeResolverContext::InExpression,
+              /*unboundTyOpener*/ nullptr,
+              /*placeholderHandler*/ nullptr);
         } else {
           castType = isp->getCastType();
         }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2756,13 +2756,13 @@ ResolveTypeEraserTypeRequest::evaluate(Evaluator &evaluator,
                                        ProtocolDecl *PD,
                                        TypeEraserAttr *attr) const {
   if (auto *typeEraserRepr = attr->getParsedTypeEraserTypeRepr()) {
-    return TypeResolution::forContextual(PD, None,
-                                         // Unbound generics and placeholders
-                                         // are not allowed within this
-                                         // attribute.
-                                         /*unboundTyOpener*/ nullptr,
-                                         /*placeholderHandler*/ nullptr)
-        .resolveType(typeEraserRepr);
+    return TypeResolution::resolveContextualType(
+        typeEraserRepr, PD, None,
+        // Unbound generics and placeholders
+        // are not allowed within this
+        // attribute.
+        /*unboundTyOpener*/ nullptr,
+        /*placeholderHandler*/ nullptr);
   } else {
     auto *LazyResolver = attr->Resolver;
     assert(LazyResolver && "type eraser was neither parsed nor deserialized?");
@@ -2939,9 +2939,9 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
 
   Type T = attr->getProtocolType();
   if (!T && attr->getProtocolTypeRepr()) {
-    T = TypeResolution::forContextual(DC, None, /*unboundTyOpener*/ nullptr,
-                                      /*placeholderHandler*/ nullptr)
-            .resolveType(attr->getProtocolTypeRepr());
+    T = TypeResolution::resolveContextualType(attr->getProtocolTypeRepr(), DC,
+                                              None, /*unboundTyOpener*/ nullptr,
+                                              /*placeholderHandler*/ nullptr);
   }
 
   // Definite error-types were already diagnosed in resolveType.
@@ -4741,11 +4741,10 @@ static bool typeCheckDerivativeAttr(ASTContext &Ctx, Decl *D,
   if (auto *baseTypeRepr = attr->getBaseTypeRepr()) {
     const auto options =
         TypeResolutionOptions(None) | TypeResolutionFlags::AllowModule;
-    baseType =
-        TypeResolution::forContextual(derivative->getDeclContext(), options,
-                                      /*unboundTyOpener*/ nullptr,
-                                      /*placeholderHandler*/ nullptr)
-            .resolveType(baseTypeRepr);
+    baseType = TypeResolution::resolveContextualType(
+        baseTypeRepr, derivative->getDeclContext(), options,
+        /*unboundTyOpener*/ nullptr,
+        /*placeholderHandler*/ nullptr);
   }
   if (baseType && baseType->hasError())
     return true;
@@ -5334,10 +5333,10 @@ void AttributeChecker::visitTransposeAttr(TransposeAttr *attr) {
 
   Type baseType;
   if (attr->getBaseTypeRepr()) {
-    baseType = TypeResolution::forContextual(transpose->getDeclContext(), None,
-                                             /*unboundTyOpener*/ nullptr,
-                                             /*placeholderHandler*/ nullptr)
-                   .resolveType(attr->getBaseTypeRepr());
+    baseType = TypeResolution::resolveContextualType(
+        attr->getBaseTypeRepr(), transpose->getDeclContext(), None,
+        /*unboundTyOpener*/ nullptr,
+        /*placeholderHandler*/ nullptr);
   }
   auto lookupOptions =
       (attr->getBaseTypeRepr() ? defaultMemberLookupOptions

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -965,9 +965,6 @@ RequirementRequest::evaluate(Evaluator &evaluator,
                                               /*unboundTyOpener*/ nullptr,
                                               /*placeholderHandler*/ nullptr);
     break;
-
-  case TypeResolutionStage::Contextual:
-    llvm_unreachable("No clients care about this. Use mapTypeIntoContext()");
   }
 
   auto &reqRepr = getRequirement();

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -485,8 +485,8 @@ public:
     auto *repr = IdentTypeRepr::create(Context, components);
 
     // See if the repr resolves to a type.
-    const auto resolution = TypeResolution::forContextual(
-        DC, options,
+    const auto ty = TypeResolution::resolveContextualType(
+        repr, DC, options,
         [](auto unboundTy) {
           // FIXME: Don't let unbound generic types escape type resolution.
           // For now, just return the unbound generic type.
@@ -495,7 +495,7 @@ public:
         // FIXME: Don't let placeholder types escape type resolution.
         // For now, just return the placeholder type.
         PlaceholderType::get);
-    const auto ty = resolution.resolveType(repr);
+
     auto *enumDecl = dyn_cast_or_null<EnumDecl>(ty->getAnyNominal());
     if (!enumDecl)
       return nullptr;
@@ -751,9 +751,9 @@ validateTypedPattern(TypedPattern *TP, DeclContext *dc,
     return named->getDecl()->getDeclContext()->mapTypeIntoContext(opaqueTy);
   }
 
-  auto ty = TypeResolution::forContextual(dc, options, unboundTyOpener,
-                                          placeholderHandler)
-                .resolveType(Repr);
+  const auto ty = TypeResolution::resolveContextualType(
+      Repr, dc, options, unboundTyOpener, placeholderHandler);
+
   if (ty->hasError()) {
     return ErrorType::get(Context);
   }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4705,8 +4705,9 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
     // If the type comes from a constrained extension or has a 'where'
     // clause, check those requirements now.
     if (!skipRequirementCheck &&
-        !TypeChecker::checkContextualRequirements(genericDecl, Adoptee,
-                                                  SourceLoc(), DC)) {
+        !TypeChecker::checkContextualRequirements(
+            genericDecl, Adoptee, SourceLoc(), DC->getParentModule(),
+            DC->getGenericSignatureOfContext())) {
       continue;
     }
 
@@ -4798,7 +4799,7 @@ void ConformanceChecker::ensureRequirementsAreSatisfied() {
       proto, substitutingType, ProtocolConformanceRef(Conformance));
 
   auto result = TypeChecker::checkGenericArguments(
-      DC, Loc, Loc,
+      DC->getParentModule(), Loc, Loc,
       // FIXME: maybe this should be the conformance's type
       proto->getDeclaredInterfaceType(),
       { proto->getSelfInterfaceType() },

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -1086,8 +1086,8 @@ bool AssociatedTypeInference::checkCurrentTypeWitnesses(
   sanitizeProtocolRequirements(proto, proto->getRequirementSignature(),
                                sanitizedRequirements);
   auto result =
-    TypeChecker::checkGenericArguments(dc, SourceLoc(), SourceLoc(),
-                                       typeInContext,
+    TypeChecker::checkGenericArguments(dc->getParentModule(), SourceLoc(),
+                                       SourceLoc(), typeInContext,
                                        { proto->getSelfInterfaceType() },
                                        sanitizedRequirements,
                                        QuerySubstitutionMap{substitutions},
@@ -1134,7 +1134,7 @@ bool AssociatedTypeInference::checkConstrainedExtension(ExtensionDecl *ext) {
 
   SubstOptions options = getSubstOptionsWithCurrentTypeWitnesses();
   switch (TypeChecker::checkGenericArguments(
-                       dc, SourceLoc(), SourceLoc(), adoptee,
+                       dc->getParentModule(), SourceLoc(), SourceLoc(), adoptee,
                        ext->getGenericSignature().getGenericParams(),
                        ext->getGenericSignature().getRequirements(),
                        QueryTypeSubstitutionMap{subs},

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -56,17 +56,6 @@ Type InheritedTypeRequest::evaluate(
                                      /*unboundTyOpener*/ nullptr,
                                      /*placeholderHandler*/ nullptr);
     break;
-
-  case TypeResolutionStage::Contextual: {
-    // Compute the contextual type by mapping the interface type into context.
-    auto result =
-      evaluator(InheritedTypeRequest{decl, index,
-                                     TypeResolutionStage::Interface});
-    if (!result)
-      return Type();
-
-    return dc->mapTypeIntoContext(*result);
-  }
   }
 
   const TypeLoc &typeLoc = getInheritedTypeLocAtIndex(decl, index);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -72,8 +72,18 @@ TypeResolution
 TypeResolution::forInterface(DeclContext *dc, TypeResolutionOptions options,
                              OpenUnboundGenericTypeFn unboundTyOpener,
                              HandlePlaceholderTypeReprFn placeholderHandler) {
+  return forInterface(dc, dc->getGenericEnvironmentOfContext(), options,
+                      unboundTyOpener, placeholderHandler);
+}
+
+TypeResolution
+TypeResolution::forInterface(DeclContext *dc, GenericEnvironment *genericEnv,
+                             TypeResolutionOptions options,
+                             OpenUnboundGenericTypeFn unboundTyOpener,
+                             HandlePlaceholderTypeReprFn placeholderHandler) {
   TypeResolution result(dc, TypeResolutionStage::Interface, options,
                         unboundTyOpener, placeholderHandler);
+  result.genericEnv = genericEnv;
   return result;
 }
 

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -303,9 +303,6 @@ private:
   /// The generic environment used to map to archetypes.
   GenericEnvironment *genericEnv;
 
-  /// The generic signature to use for type resolution.
-  GenericSignature genericSig;
-
   TypeResolution(DeclContext *dc, TypeResolutionStage stage,
                  TypeResolutionOptions options,
                  OpenUnboundGenericTypeFn unboundTyOpener,

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -328,6 +328,14 @@ public:
                OpenUnboundGenericTypeFn unboundTyOpener,
                HandlePlaceholderTypeReprFn placeholderHandler);
 
+  /// Form a type resolution for an interface type, which is a complete
+  /// description of the type using generic parameters.
+  static TypeResolution
+  forInterface(DeclContext *dc, GenericEnvironment *genericEnv,
+               TypeResolutionOptions opts,
+               OpenUnboundGenericTypeFn unboundTyOpener,
+               HandlePlaceholderTypeReprFn placeholderHandler);
+
   /// Form a type resolution for a contextual type, which is a complete
   /// description of the type using the archetypes of the given declaration
   /// context.

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -337,22 +337,8 @@ public:
                HandlePlaceholderTypeReprFn placeholderHandler);
 
   /// Form a type resolution for a contextual type, which is a complete
-  /// description of the type using the archetypes of the given declaration
-  /// context.
-  static TypeResolution
-  forContextual(DeclContext *dc, TypeResolutionOptions opts,
-                OpenUnboundGenericTypeFn unboundTyOpener,
-                HandlePlaceholderTypeReprFn placeholderHandler);
-
-  /// Form a type resolution for a contextual type, which is a complete
   /// description of the type using the archetypes of the given generic
   /// environment.
-  static TypeResolution
-  forContextual(DeclContext *dc, GenericEnvironment *genericEnv,
-                TypeResolutionOptions opts,
-                OpenUnboundGenericTypeFn unboundTyOpener,
-                HandlePlaceholderTypeReprFn placeholderHandler);
-
   static Type
   resolveContextualType(TypeRepr *TyR, DeclContext *dc,
                         TypeResolutionOptions opts,
@@ -405,12 +391,6 @@ public:
   /// \returns A well-formed type that is never null, or an \c ErrorType in case of an error.
   Type resolveType(TypeRepr *TyR,
                    GenericParamList *silParams=nullptr) const;
-
-  /// Whether this type resolution uses archetypes (vs. generic parameters).
-  bool usesArchetypes() const;
-
-  /// Map the given type (that involves generic parameters)
-  Type mapTypeIntoContext(Type type) const;
 
   /// Resolve a reference to a member type of the given (dependent) base and
   /// name.

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -312,10 +312,6 @@ private:
         placeholderHandler(placeholderHandler),
         genericEnv(nullptr) {}
 
-  /// Retrieves the generic signature for the context, or NULL if there is
-  /// no generic signature to resolve types.
-  GenericSignature getGenericSignature() const;
-
 public:
   /// Form a type resolution for the structure of a type, which does not
   /// attempt to resolve member types of type parameters to a particular
@@ -372,6 +368,10 @@ public:
   HandlePlaceholderTypeReprFn getPlaceholderHandler() const {
     return placeholderHandler;
   }
+
+  /// Retrieves the generic signature for the context, or NULL if there is
+  /// no generic signature to resolve types.
+  GenericSignature getGenericSignature() const;
 
   /// Resolves a TypeRepr to a type.
   ///

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -353,6 +353,19 @@ public:
                 OpenUnboundGenericTypeFn unboundTyOpener,
                 HandlePlaceholderTypeReprFn placeholderHandler);
 
+  static Type
+  resolveContextualType(TypeRepr *TyR, DeclContext *dc,
+                        TypeResolutionOptions opts,
+                        OpenUnboundGenericTypeFn unboundTyOpener,
+                        HandlePlaceholderTypeReprFn placeholderHandler,
+                        GenericParamList *silParams = nullptr);
+
+  static Type resolveContextualType(
+      TypeRepr *TyR, DeclContext *dc, GenericEnvironment *genericEnv,
+      TypeResolutionOptions opts, OpenUnboundGenericTypeFn unboundTyOpener,
+      HandlePlaceholderTypeReprFn placeholderHandler,
+      GenericParamList *silParams = nullptr);
+
 public:
   TypeResolution withOptions(TypeResolutionOptions opts) const;
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -502,7 +502,7 @@ TypeChecker::getDeclTypeCheckingSemantics(ValueDecl *decl) {
 bool TypeChecker::isDifferentiable(Type type, bool tangentVectorEqualsSelf,
                                    DeclContext *dc,
                                    Optional<TypeResolutionStage> stage) {
-  if (stage && stage != TypeResolutionStage::Contextual)
+  if (stage)
     type = dc->mapTypeIntoContext(type);
   auto tanSpace = type->getAutoDiffTangentSpace(
       LookUpConformanceInModule(dc->getParentModule()));

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -369,22 +369,21 @@ Type swift::performTypeResolution(TypeRepr *TyR, ASTContext &Ctx,
   if (isSILType)
     options |= TypeResolutionFlags::SILType;
 
-  const auto resolution = TypeResolution::forContextual(
-      DC, GenericEnv, options,
-      [](auto unboundTy) {
-        // FIXME: Don't let unbound generic types escape type resolution.
-        // For now, just return the unbound generic type.
-        return unboundTy;
-      },
-      // FIXME: Don't let placeholder types escape type resolution.
-      // For now, just return the placeholder type.
-      PlaceholderType::get);
-
   Optional<DiagnosticSuppression> suppression;
   if (!ProduceDiagnostics)
     suppression.emplace(Ctx.Diags);
 
-  return resolution.resolveType(TyR, GenericParams);
+  return TypeResolution::forInterface(
+             DC, GenericEnv, options,
+             [](auto unboundTy) {
+               // FIXME: Don't let unbound generic types escape type resolution.
+               // For now, just return the unbound generic type.
+               return unboundTy;
+             },
+             // FIXME: Don't let placeholder types escape type resolution.
+             // For now, just return the placeholder type.
+             PlaceholderType::get)
+      .resolveType(TyR, GenericParams);
 }
 
 namespace {

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -930,3 +930,14 @@ func rdar79757320() {
   // expected-error@-1 {{cannot infer contextual base in reference to member 'a'}}
   // expected-error@-2 {{cannot infer contextual base in reference to member 'b'}}
 }
+
+protocol P_eaf0300ff7a {}
+do {
+  struct Outer<T: P_eaf0300ff7a> {
+    struct Inner<U> {}
+
+    func container<T>() -> Inner<T> {
+      return Inner()
+    }
+  }
+}

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -245,3 +245,16 @@ struct UnsolvableInheritance2<T : U.A, U : T.A> {}
 
 enum X7<T> where X7.X : G { case X } // expected-error{{enum case 'X' is not a member type of 'X7<T>'}}
 // expected-error@-1{{cannot find type 'G' in scope}}
+
+protocol MetatypeTypeResolutionProto {}
+struct X8<T> {
+  static var property1: T.Type { T.self }
+  static func method1() -> T.Type { T.self }
+}
+extension X8 where T == MetatypeTypeResolutionProto {
+  // FIXME: Inconsistent contextual type resolution for generic metatypes;
+  // should be .Protocol in both cases.
+  static var property2: T.Type { property1 }
+  // expected-error@-1 {{cannot convert return expression of type 'MetatypeTypeResolutionProto.Protocol' to return type 'MetatypeTypeResolutionProto.Type'}}
+  static func method2() -> T.Type { method1() } // ok
+}

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -246,15 +246,14 @@ struct UnsolvableInheritance2<T : U.A, U : T.A> {}
 enum X7<T> where X7.X : G { case X } // expected-error{{enum case 'X' is not a member type of 'X7<T>'}}
 // expected-error@-1{{cannot find type 'G' in scope}}
 
+// Test that contextual type resolution for generic metatypes is consistent
+// under a same-type constraint.
 protocol MetatypeTypeResolutionProto {}
 struct X8<T> {
   static var property1: T.Type { T.self }
   static func method1() -> T.Type { T.self }
 }
 extension X8 where T == MetatypeTypeResolutionProto {
-  // FIXME: Inconsistent contextual type resolution for generic metatypes;
-  // should be .Protocol in both cases.
-  static var property2: T.Type { property1 }
-  // expected-error@-1 {{cannot convert return expression of type 'MetatypeTypeResolutionProto.Protocol' to return type 'MetatypeTypeResolutionProto.Type'}}
-  static func method2() -> T.Type { method1() } // ok
+  static var property2: T.Type { property1 } // ok, still .Protocol
+  static func method2() -> T.Type { method1() } // ok, still .Protocol
 }

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -132,6 +132,11 @@ class GenericClass<T> {
   typealias TA<U> = MyType<T, U>
   typealias TAI<U> = MyType<Int, U>
 
+  func testNestedUnbound(t: T) {
+    typealias Nested<X, Y> = MyType<X, Y>
+    _ = Nested(a: t, b: t)
+  }
+
   func testCapture<S>(s: S, t: T) -> TA<S> {
     return TA<S>(a: t, b: s)
   }

--- a/validation-test/compiler_crashers_2_fixed/0161-sr6569.swift
+++ b/validation-test/compiler_crashers_2_fixed/0161-sr6569.swift
@@ -6,8 +6,8 @@ protocol P {
 
 struct Type<Param> {}
 extension Type: P where Param: P, Param.A == Type<Param> {
-  // expected-error@-1 5{{extension of generic struct 'Type' has self-referential generic requirements}}
-  // expected-note@-2 5{{through reference here}}
+  // expected-error@-1 6{{extension of generic struct 'Type' has self-referential generic requirements}}
+  // expected-note@-2 6{{through reference here}}
   // expected-error@-3 {{type 'Type<Param>' does not conform to protocol 'P'}}
   typealias A = Param
   // expected-note@-1 2{{through reference here}}


### PR DESCRIPTION
The correctness issue that lead to this refactoring is an inconsistency in how generic metatypes are resolved in properties that are referenced and declared under a certain kind of same-type constraint:

```swift
protocol P {}
struct Foo<T> {
  static var property1: T.Type { T.self }
}
extension Foo where T == P {
  // error: cannot convert return expression of type 'P.Protocol' to return type 'P.Type'
  static var property2: T.Type { property1 } 
}
```

This is a source-breaking change, since these generic metatypes would no longer resolve to existential metatypes when a same-type constraint binds the 'instance type' type parameter to an existential type, be it a protocol requirement or other member.
___
Extracted from #39492