### PR TITLE
NFC: Remove Decl* declarations made using auto

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2876,7 +2876,7 @@ void ClangImporter::lookupTypeDecl(
             !isa<clang::ObjCCompatibleAliasDecl>(clangDecl)) {
           continue;
         }
-        auto *imported = Impl.importDecl(clangDecl, Impl.CurrentVersion);
+        Decl *imported = Impl.importDecl(clangDecl, Impl.CurrentVersion);
 
         // Namespaces are imported as extensions for enums.
         if (auto ext = dyn_cast_or_null<ExtensionDecl>(imported)) {
@@ -3008,7 +3008,7 @@ void ClangModuleUnit::getTopLevelDecls(SmallVectorImpl<Decl*> &results) const {
     llvm::SmallPtrSet<ExtensionDecl *, 8> knownExtensions;
     for (auto entry : lookupTable->allGlobalsAsMembers()) {
       auto decl = entry.get<clang::NamedDecl *>();
-      auto importedDecl = owner.importDecl(decl, owner.CurrentVersion);
+      Decl *importedDecl = owner.importDecl(decl, owner.CurrentVersion);
       if (!importedDecl) continue;
 
       // Find the enclosing extension, if there is one.
@@ -3374,9 +3374,7 @@ void ClangModuleUnit::lookupObjCMethods(
     if (objcMethod->isPropertyAccessor())
       (void)owner.importDecl(objcMethod->findPropertyDecl(true),
                              owner.CurrentVersion);
-
-    auto imported =
-        owner.importDecl(objcMethod, owner.CurrentVersion);
+    Decl *imported = owner.importDecl(objcMethod, owner.CurrentVersion);
     if (!imported) continue;
 
     if (auto func = dyn_cast<AbstractFunctionDecl>(imported))

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2486,8 +2486,8 @@ namespace {
         // that we add this to the parent enum (in the "__ObjC" module) and not
         // to the extension.
         auto parentNS = cast<clang::NamespaceDecl>(decl->getParent());
-        auto parent =
-            Impl.importDecl(parentNS, getVersion(), /*UseCanonicalDecl*/ false);
+        Decl *parent = Impl.importDecl(parentNS, getVersion(),
+                                       /*UseCanonicalDecl*/ false);
         // Sometimes when the parent namespace is imported, this namespace
         // also gets imported. If that's the case, then the parent namespace
         // will be an enum (because it was able to be fully imported) in which
@@ -3590,7 +3590,7 @@ namespace {
           }
         }
 
-        auto member = Impl.importDecl(nd, getActiveSwiftVersion());
+        Decl *member = Impl.importDecl(nd, getActiveSwiftVersion());
         if (!member) {
           if (!isa<clang::TypeDecl>(nd) && !isa<clang::FunctionDecl>(nd)) {
             // We don't know what this member is.
@@ -5941,8 +5941,7 @@ namespace {
       auto name = importedName.getDeclName().getBaseIdentifier();
 
       if (name.empty()) return nullptr;
-
-      auto importedDecl =
+      Decl *importedDecl =
           Impl.importDecl(decl->getClassInterface(), getActiveSwiftVersion());
       auto typeDecl = dyn_cast_or_null<TypeDecl>(importedDecl);
       if (!typeDecl) return nullptr;
@@ -9986,7 +9985,7 @@ bool ClangImporter::Implementation::addMemberAndAlternatesToExtension(
       return true;
 
   // Then try to import the decl under the specified name.
-  auto *member = importDecl(decl, nameVersion);
+  Decl *member = importDecl(decl, nameVersion);
   if (!member)
     return false;
 


### PR DESCRIPTION
A non functional change replacing auto with Decl* for some declarations using ClangImporter::Implementation::importDecl.
Increases clarity and makes subsequent planned changes easier.
