### PR TITLE
[Distributed] Naive impl of whenLocal for distributed actors

### DIFF
--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -264,6 +264,7 @@ IDENTIFIER(identifier)
 IDENTIFIER(_distributedActorRemoteInitialize)
 IDENTIFIER(_distributedActorDestroy)
 IDENTIFIER(__isRemoteActor)
+IDENTIFIER(whenLocal)
 
 #undef IDENTIFIER
 #undef IDENTIFIER_

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1433,7 +1433,9 @@ namespace {
       if (!var) {
         isPotentiallyIsolated = false;
       } else if (var->getName().str().equals("__secretlyKnownToBeLocal")) {
-        // FIXME(distributed): rdar://84029304 this must be implemented properly
+        // FIXME(distributed): we did a dynamic check and know that this actor is local,
+        //  but we can't express that to the type system; the real implementation
+        //  will have to mark 'self' as "known to be local" after an is-local check.
         isPotentiallyIsolated = true;
       } else if (auto param = dyn_cast<ParamDecl>(var)) {
         isPotentiallyIsolated = param->isIsolated();

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1432,6 +1432,9 @@ namespace {
       bool isPotentiallyIsolated = false;
       if (!var) {
         isPotentiallyIsolated = false;
+      } else if (var->getName().str().equals("__secretlyKnownToBeLocal")) {
+        // FIXME(distributed): rdar://84029304 this must be implemented properly
+        isPotentiallyIsolated = true;
       } else if (auto param = dyn_cast<ParamDecl>(var)) {
         isPotentiallyIsolated = param->isIsolated();
       } else if (var->isSelfParamCapture()) {

--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -75,17 +75,6 @@ public protocol DistributedActor:
     /// Conformance to this requirement is synthesized automatically for any
     /// `distributed actor` declaration.
     nonisolated var id: AnyActorIdentity { get }
-
-
-    /// Executes the passed 'body' only when the distributed actor is local instance.
-    ///
-    /// The `Self` passed to the the body closure is isolated, meaning that the
-    /// closure can be used to call non-distributed functions, or even access actor
-    /// state.
-    ///
-    /// When the actor is remote, the closure won't be executed and this function will return nil.
-    nonisolated func whenLocal<T>(_ body: @Sendable (isolated Self) async throws -> T)
-        async rethrows -> T? where T: Sendable
 }
 
 // ==== Hashable conformance ---------------------------------------------------
@@ -132,14 +121,21 @@ extension DistributedActor {
 @available(SwiftStdlib 5.5, *)
 extension DistributedActor {
 
-    public nonisolated func whenLocal<T>(_ body: @Sendable (isolated Self) async throws -> T)
-        async rethrows -> T? where T: Sendable {
-        if __isLocalActor(self) {
-             return try await body(self)
-        } else {
-            return nil
-        }
+  /// Executes the passed 'body' only when the distributed actor is local instance.
+  ///
+  /// The `Self` passed to the the body closure is isolated, meaning that the
+  /// closure can be used to call non-distributed functions, or even access actor
+  /// state.
+  ///
+  /// When the actor is remote, the closure won't be executed and this function will return nil.
+  public nonisolated func whenLocal<T>(_ body: @Sendable (isolated Self) async throws -> T)
+    async rethrows -> T? where T: Sendable {
+    if __isLocalActor(self) {
+       return try await body(self)
+    } else {
+      return nil
     }
+  }
 }
 
 /******************************************************************************/

--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -75,6 +75,17 @@ public protocol DistributedActor:
     /// Conformance to this requirement is synthesized automatically for any
     /// `distributed actor` declaration.
     nonisolated var id: AnyActorIdentity { get }
+
+
+    /// Executes the passed 'body' only when the distributed actor is local instance.
+    ///
+    /// The `Self` passed to the the body closure is isolated, meaning that the
+    /// closure can be used to call non-distributed functions, or even access actor
+    /// state.
+    ///
+    /// When the actor is remote, the closure won't be executed and this function will return nil.
+    nonisolated func whenLocal<T>(_ body: @Sendable (isolated Self) async throws -> T)
+        async rethrows -> T? where T: Sendable
 }
 
 // ==== Hashable conformance ---------------------------------------------------
@@ -114,6 +125,21 @@ extension DistributedActor {
     var container = encoder.singleValueContainer()
     try container.encode(self.id)
   }
+}
+
+// ==== Local actor special handling -------------------------------------------
+
+@available(SwiftStdlib 5.5, *)
+extension DistributedActor {
+
+    public nonisolated func whenLocal<T>(_ body: @Sendable (isolated Self) async throws -> T)
+        async rethrows -> T? where T: Sendable {
+        if __isLocalActor(self) {
+             return try await body(self)
+        } else {
+            return nil
+        }
+    }
 }
 
 /******************************************************************************/

--- a/test/Distributed/Runtime/distributed_actor_deinit.swift
+++ b/test/Distributed/Runtime/distributed_actor_deinit.swift
@@ -7,7 +7,7 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// temporary non-support. tracked in rdar://82593574
+// FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
 import _Distributed

--- a/test/Distributed/Runtime/distributed_actor_whenLocal.swift
+++ b/test/Distributed/Runtime/distributed_actor_whenLocal.swift
@@ -1,10 +1,16 @@
 // RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -Xfrontend -enable-experimental-distributed -parse-as-library) | %FileCheck %s --dump-input=always
+
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: distributed
+
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
+
+// FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
+// UNSUPPORTED: windows
+
 import _Distributed
 
 distributed actor Capybara {

--- a/test/Distributed/Runtime/distributed_actor_whenLocal.swift
+++ b/test/Distributed/Runtime/distributed_actor_whenLocal.swift
@@ -1,0 +1,77 @@
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -Xfrontend -enable-experimental-distributed -parse-as-library) | %FileCheck %s --dump-input=always
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+import _Distributed
+
+distributed actor Capybara {
+  // only the local capybara can do this!
+  func eat() -> String {
+    "watermelon"
+  }
+}
+
+
+// ==== Fake Transport ---------------------------------------------------------
+@available(SwiftStdlib 5.5, *)
+struct ActorAddress: ActorIdentity {
+  let address: String
+  init(parse address: String) {
+    self.address = address
+  }
+}
+
+@available(SwiftStdlib 5.5, *)
+struct FakeTransport: ActorTransport {
+  func decodeIdentity(from decoder: Decoder) throws -> AnyActorIdentity {
+    fatalError("not implemented:\(#function)")
+  }
+
+  func resolve<Act>(_ identity: AnyActorIdentity, as actorType: Act.Type)
+  throws -> Act? where Act: DistributedActor {
+    return nil
+  }
+
+  func assignIdentity<Act>(_ actorType: Act.Type) -> AnyActorIdentity
+          where Act: DistributedActor {
+    let id = ActorAddress(parse: "xxx")
+    return .init(id)
+  }
+
+  func actorReady<Act>(_ actor: Act) where Act: DistributedActor {
+  }
+
+  func resignIdentity(_ id: AnyActorIdentity) {
+  }
+}
+
+func test() async throws {
+  let transport = FakeTransport()
+
+  let local = Capybara(transport: transport)
+  // await local.eat() // SHOULD ERROR
+  let valueWhenLocal: String? = await local.whenLocal { __secretlyKnownToBeLocal in
+    __secretlyKnownToBeLocal.eat()
+  }
+
+  // CHECK: valueWhenLocal: watermelon
+  print("valueWhenLocal: \(valueWhenLocal ?? "nil")")
+
+  let remote = try Capybara.resolve(local.id, using: transport)
+  let valueWhenRemote: String? = await remote.whenLocal { __secretlyKnownToBeLocal in
+    __secretlyKnownToBeLocal.eat()
+  }
+  
+  // CHECK: valueWhenRemote: nil
+  print("valueWhenRemote: \(valueWhenRemote ?? "nil")")
+}
+
+@available(SwiftStdlib 5.5, *)
+@main struct Main {
+  static func main() async {
+    try! await test()
+  }
+}

--- a/test/Distributed/actor_protocols.swift
+++ b/test/Distributed/actor_protocols.swift
@@ -52,9 +52,8 @@ actor A2: DistributedActor {
   }
 }
 
-class C2: DistributedActor {
+final class C2: DistributedActor {
   // expected-error@-1{{non-actor type 'C2' cannot conform to the 'Actor' protocol}}
-  // expected-error@-2{{non-final class 'C2' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
   nonisolated var id: AnyActorIdentity {
     fatalError()
   }


### PR DESCRIPTION
Implements `whenLocal` on a distributed actor, however in a terrible hack way.
We'll do proper "known to be local" in the type system soon and then this will be fixed. 

Terrible hack consulted with @DougGregor, thanks for the help !

rdar://84029304