### PR TITLE
Clang Importer Diagnostics Pitch

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -96,5 +96,7 @@ WARNING(import_multiple_mainactor_attr,none,
 
 ERROR(module_map_not_found, none, "module map file '%0' not found", (StringRef))
 
+WARNING(function_not_imported_type_not_available, none, "function '%0' not imported: type '%1' is unavailable in Swift", (StringRef, StringRef))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -97,6 +97,7 @@ WARNING(import_multiple_mainactor_attr,none,
 ERROR(module_map_not_found, none, "module map file '%0' not found", (StringRef))
 
 WARNING(function_not_imported_type_not_available, none, "function '%0' not imported: type '%1' is unavailable in Swift", (StringRef, StringRef))
+WARNING(field_not_imported_type_not_available, none, "field '%0' not imported: type '%1' is unavailable in Swift", (StringRef, StringRef))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -311,6 +311,9 @@ namespace swift {
     /// Enable experimental flow-sensitive concurrent captures.
     bool EnableExperimentalFlowSensitiveConcurrentCaptures = false;
 
+    /// Enable experimental ClangImporter diagnostics.
+    bool EnableExperimentalClangImporterDiagnostics = false;
+
     /// Enable inference of Sendable conformances for public types.
     bool EnableInferPublicSendable = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -263,6 +263,10 @@ def enable_experimental_flow_sensitive_concurrent_captures :
   Flag<["-"], "enable-experimental-flow-sensitive-concurrent-captures">,
   HelpText<"Enable flow-sensitive concurrent captures">;
 
+def enable_experimental_clang_importer_diagnostics :
+  Flag<["-"], "enable-experimental-clang-importer-diagnostics">,
+  HelpText<"Enable experimental ClangImporter diagnostics">;
+
 def enable_resilience : Flag<["-"], "enable-resilience">,
      HelpText<"Deprecated, use -enable-library-evolution instead">;
 }

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -381,29 +381,29 @@ namespace {
       llvm_unreachable("Invalid BuiltinType.");
     }
 
-    ImportResult VisitExtIntType(const clang::ExtIntType *) {
+    ImportResult VisitExtIntType(const clang::ExtIntType *type) {
       // ExtInt is not supported in Swift.
-      return Type();
+      return ImportFailureDiagnostic(StringRef(type->getTypeClassName()));
     }
 
-    ImportResult VisitPipeType(const clang::PipeType *) {
+    ImportResult VisitPipeType(const clang::PipeType *type) {
       // OpenCL types are not supported in Swift.
-      return Type();
+      return ImportFailureDiagnostic(StringRef(type->getTypeClassName()));
     }
 
     ImportResult VisitMatrixType(const clang::MatrixType *ty) {
       // Matrix types are not supported in Swift.
-      return Type();
+      return ImportFailureDiagnostic(StringRef(ty->getTypeClassName()));
     }
 
     ImportResult VisitComplexType(const clang::ComplexType *type) {
       // FIXME: Implement once Complex is in the library.
-      return Type();
+      return ImportFailureDiagnostic(StringRef(type->getTypeClassName()));
     }
 
     ImportResult VisitAtomicType(const clang::AtomicType *type) {
       // FIXME: handle pointers and fields of atomic type
-      return Type();
+      return ImportFailureDiagnostic(StringRef(type->getTypeClassName()));
     }
 
     ImportResult VisitMemberPointerType(const clang::MemberPointerType *type) {

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1073,7 +1073,7 @@ public:
   }
 
   /// Add "Unavailable" annotation to the swift declaration.
-  void markUnavailable(ValueDecl *decl, StringRef unavailabilityMsg);
+  void markUnavailable(Decl *decl, StringRef unavailabilityMsg);
 
   /// Create a decl with error type and an "unavailable" attribute on it
   /// with the specified message.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -453,6 +453,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalFlowSensitiveConcurrentCaptures |=
     Args.hasArg(OPT_enable_experimental_flow_sensitive_concurrent_captures);
 
+  Opts.EnableExperimentalClangImporterDiagnostics |=
+      Args.hasArg(OPT_enable_experimental_clang_importer_diagnostics);
+
   Opts.DisableImplicitConcurrencyModuleImport |=
     Args.hasArg(OPT_disable_implicit_concurrency_module_import);
 

--- a/test/ClangImporter/ctypes_parse.swift
+++ b/test/ClangImporter/ctypes_parse.swift
@@ -56,6 +56,19 @@ func testPoint() -> Float {
   return p.y
 }
 
+func testPartialStructImport() {
+  let s: PartialImport
+  s.c = 5 // expected-error {{value of type 'PartialImport' has no member 'c'}}
+  s.d = 5 // expected-error {{value of type 'PartialImport' has no member 'd'}}
+  partialImport.c = 5 // expected-error {{value of type 'PartialImport' has no member 'c'}}
+  partialImport.d = 5 // expected-error {{value of type 'PartialImport' has no member 'd'}}
+  var newPartialImport = PartialImport()
+  newPartialImport.a = 5
+  newPartialImport.b = 5
+  newPartialImport.c = 5  // expected-error {{value of type 'PartialImport' has no member 'c'}}
+  newPartialImport.d = 5  // expected-error {{value of type 'PartialImport' has no member 'd'}}
+}
+
 func testAnonStructs() {
   var a_s: AnonStructs
   a_s.a = 5

--- a/test/ClangImporter/experimental_cfuncs_availability_diagnostics.swift
+++ b/test/ClangImporter/experimental_cfuncs_availability_diagnostics.swift
@@ -1,0 +1,14 @@
+// XFAIL: CPU=powerpc64le
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-clang-importer-diagnostics -typecheck -verify -I %S/Inputs %s
+
+import cfuncs
+
+func test_complex() {
+    complex_parameter(1,2,3,4) // expected-error {{'complex_parameter' is unavailable: type 'Complex' is unavailable in Swift}}
+    let _ = complex_retval() // expected-error {{'complex_retval()' is unavailable: type 'Complex' is unavailable in Swift}}
+}
+
+func test_atomic() {
+    atomic_parameter(1,2,3,4) // expected-error {{'atomic_parameter' is unavailable: type 'Atomic' is unavailable in Swift}}
+    let _ = atomic_retval() // expected-error {{'atomic_retval()' is unavailable: type 'Atomic' is unavailable in Swift}}
+}

--- a/test/ClangImporter/experimental_ctypes_availability_diagnostics.swift
+++ b/test/ClangImporter/experimental_ctypes_availability_diagnostics.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift %clang-importer-sdk -enable-experimental-clang-importer-diagnostics 
+
+import ctypes
+
+func testPartialStructImport() {
+  let s: PartialImport
+  s.c = 5 // expected-error {{'c' is unavailable: 'Complex' is unavailable in Swift}}
+  s.d = 5 // expected-error {{'d' is unavailable: 'Atomic' is unavailable in Swift}}
+  partialImport.c = 5 // expected-error {{'c' is unavailable: 'Complex' is unavailable in Swift}}
+  partialImport.d = 5 // expected-error {{'d' is unavailable: 'Atomic' is unavailable in Swift}}
+  var newPartialImport = PartialImport()
+  newPartialImport.a = 5
+  newPartialImport.b = 5
+  newPartialImport.c = 5  // expected-error {{'c' is unavailable: 'Complex' is unavailable in Swift}}
+  newPartialImport.d = 5  // expected-error {{'d' is unavailable: 'Atomic' is unavailable in Swift}}
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/cfuncs.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/cfuncs.h
@@ -54,6 +54,12 @@ void decay_param_const_array(const int p[]);
 void decay_param_func(void g(int));
 void decay_param_nested(void g(int p[]));
 
+double _Complex complex_retval();
+void complex_parameter(int, double, double _Complex, double _Complex);
+
+_Atomic(int) atomic_retval();
+void atomic_parameter(int, double, _Atomic(int), _Atomic(double));
+
 struct not_importable;
 
 void opaque_pointer_param(struct not_importable *);

--- a/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ctypes.h
@@ -22,6 +22,15 @@ struct Point {
   float y;
 };
 
+struct PartialImport {
+  int a;
+  int b;
+  int _Complex c;
+  _Atomic(int) d;
+};
+
+struct PartialImport partialImport = {1, 2, 3, 4};
+
 typedef struct {
   struct {
     int a;


### PR DESCRIPTION
This is a proof of concept for improved diagnostics in the ClangImporter. Included in this diff are new diagnostics for unsupported C types when using in struct fields declarations, or function signatures. 

This PR is meant for demonstration purposes and to accompany this pitch: https://forums.swift.org/t/pitch-improved-clangimporter-diagnostics/52687