### PR TITLE
Fix DebugInfo/prologue.swift for

### DIFF
--- a/test/DebugInfo/prologue.swift
+++ b/test/DebugInfo/prologue.swift
@@ -7,7 +7,7 @@ func markUsed<T>(_ t: T) {}
 // CHECK: .file [[F:[0-9]+]] "{{.*}}prologue.swift"
 func bar<T, U>(_ x: T, y: U) { markUsed("bar") }
 // CHECK: $s8prologue3bar_1yyx_q_tr0_lF:
-// CHECK: .loc	[[F]] 0 0 prologue_end
+// CHECK: .loc	[[F]] 0 0 is_stmt 0
 // Make sure there is no allocation happening between the end of
 // prologue and the beginning of the function body.
 // CHECK-NOT: callq	*


### PR DESCRIPTION
llvm-project commit 1813652b0398345c4b4407d5fd5ffb749830fdd4 removed the
prologue_end, so this test started failing. That directive is now annotated with `is_stmt 0`.