### PR TITLE
Fix ReplaceOpaqueTypesWithUnderlyingTypes::operator()(CanType maybeOpaqueType, Type replacementType, ProtocolDecl *protocol) to no recurse needlessly

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3435,7 +3435,7 @@ operator()(CanType maybeOpaqueType, Type replacementType,
       partialSubstRef.subst(partialSubstTy, opaqueRoot->getSubstitutions());
 
   // If the type still contains opaque types, recur.
-  if (substTy->hasOpaqueArchetype()) {
+  if (!substTy->isEqual(maybeOpaqueType) && substTy->hasOpaqueArchetype()) {
     return ::substOpaqueTypesWithUnderlyingTypes(
         substRef, substTy, inContext, contextExpansion, isContextWholeModule);
   }


### PR DESCRIPTION

I don't have a reproducer -- only stack overflow backtraces.

rdar://82899787
