### PR TITLE
Fix begin_apply inlining when there are no yields

### DIFF
--- a/include/swift/SILOptimizer/Utils/GenericCloner.h
+++ b/include/swift/SILOptimizer/Utils/GenericCloner.h
@@ -71,7 +71,7 @@ public:
     return SC.getCloned();
   }
 
-  void fixUp(SILFunction *calleeFunction);
+  void postFixUp(SILFunction *calleeFunction);
 
   static SILFunction *createDeclaration(SILOptFunctionBuilder &FuncBuilder,
                                         SILFunction *Orig,

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -209,7 +209,7 @@ const SILDebugScope *GenericCloner::remapScope(const SILDebugScope *DS) {
   return RemappedScope;
 }
 
-void GenericCloner::fixUp(SILFunction *f) {
+void GenericCloner::postFixUp(SILFunction *f) {
   for (auto *apply : noReturnApplies) {
     auto applyBlock = apply->getParent();
     applyBlock->split(std::next(SILBasicBlock::iterator(apply)));

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -293,9 +293,12 @@ protected:
   /// This hook is called after either of the top-level visitors:
   /// cloneReachableBlocks or cloneSILFunction.
   ///
-  /// After fixUp, the SIL must be valid and semantically equivalent to the SIL
-  /// before cloning.
-  void fixUp(SILFunction *calleeFunction);
+  /// After `preFixUp` is called `commonFixUp` will be called.
+  void preFixUp(SILFunction *calleeFunction);
+
+  /// After postFixUp, the SIL must be valid and semantically equivalent to the
+  /// SIL before cloning.
+  void postFixUp(SILFunction *calleeFunction);
 
   const SILDebugScope *getOrCreateInlineScope(const SILDebugScope *DS);
 
@@ -602,12 +605,14 @@ void SILInlineCloner::visitTerminator(SILBasicBlock *BB) {
   visit(BB->getTerminator());
 }
 
-void SILInlineCloner::fixUp(SILFunction *calleeFunction) {
+void SILInlineCloner::preFixUp(SILFunction *calleeFunction) {
   // "Completing" the BeginApply only fixes the end of the apply scope. The
   // begin_apply itself lingers.
   if (BeginApply)
     BeginApply->complete();
+}
 
+void SILInlineCloner::postFixUp(SILFunction *calleeFunction) {
   NextIter = std::next(Apply.getInstruction()->getIterator());
 
   assert(!Apply.getInstruction()->hasUsesOfAnyResult());

--- a/test/SILOptimizer/inline_begin_apply.sil
+++ b/test/SILOptimizer/inline_begin_apply.sil
@@ -44,6 +44,11 @@ unwind:
   unwind
 }
 
+sil [transparent] [ossa] @test_unreachable : $@yield_once <C: SomeClass> () -> (@yields @in Indirect<C>) {
+entry:
+  unreachable 
+}
+
 // CHECK-LABEL: sil @test_simple_call
 // CHECK: bb0(%0 : $Builtin.Int1):
 // CHECK:  [[MARKER:%.*]] = function_ref @marker
@@ -84,6 +89,40 @@ sil @test_simple_call : $(Builtin.Int1) -> () {
 entry(%flag : $Builtin.Int1):
   %marker = function_ref @marker : $@convention(thin) (Builtin.Int32) -> ()
   %0 = function_ref @test_one_yield : $@convention(thin) @yield_once <T: SomeClass> () -> (@yields @in Indirect<T>)
+  (%value, %token) = begin_apply %0<SomeSubclass>() : $@convention(thin) @yield_once <T: SomeClass> () -> (@yields @in Indirect<T>)
+  destroy_addr %value : $*Indirect<SomeSubclass>
+  cond_br %flag, yes, no
+
+yes:
+  %10 = integer_literal $Builtin.Int32, 10
+  apply %marker(%10) : $@convention(thin) (Builtin.Int32) -> ()
+  end_apply %token
+  %20 = integer_literal $Builtin.Int32, 20
+  apply %marker(%20) : $@convention(thin) (Builtin.Int32) -> ()
+  br cont
+
+no:
+  %11 = integer_literal $Builtin.Int32, 11
+  apply %marker(%11) : $@convention(thin) (Builtin.Int32) -> ()
+  abort_apply %token
+  %21 = integer_literal $Builtin.Int32, 21
+  apply %marker(%21) : $@convention(thin) (Builtin.Int32) -> ()
+  br cont
+
+cont:
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil @test_unreachable_call :
+// CHECK: bb0(%0 : $Builtin.Int1):
+// CHECK:  [[MARKER:%.*]] = function_ref @marker
+// CHECK:  unreachable
+// CHECK: } // end sil function 'test_unreachable_call'
+sil @test_unreachable_call : $(Builtin.Int1) -> () {
+entry(%flag : $Builtin.Int1):
+  %marker = function_ref @marker : $@convention(thin) (Builtin.Int32) -> ()
+  %0 = function_ref @test_unreachable : $@convention(thin) @yield_once <T: SomeClass> () -> (@yields @in Indirect<T>)
   (%value, %token) = begin_apply %0<SomeSubclass>() : $@convention(thin) @yield_once <T: SomeClass> () -> (@yields @in Indirect<T>)
   destroy_addr %value : $*Indirect<SomeSubclass>
   cond_br %flag, yes, no


### PR DESCRIPTION
In this PR, preFixUp function in SILCloner is added which can be
overidden by implementations so that the SIL is cleaned for `commonFixup` processing.
For begin_apply inlining, blocks split due to end_apply and abort_apply
are fixed when no yields are found.

