### PR TITLE
Fix OSSA handling of address uses

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -77,8 +77,9 @@ inline bool isForwardingConsume(SILValue value) {
   return canOpcodeForwardOwnedValues(value);
 }
 
-/// Find all "use points" of \p guaranteedValue that determine its lifetime
-/// requirement.
+/// Find leaf "use points" of \p guaranteedValue that determine its lifetime
+/// requirement. If \p usePoints is nullptr, then the simply returns true if no
+/// PointerEscape use was found.
 ///
 /// Precondition: \p guaranteedValue is not a BorrowedValue.
 ///
@@ -99,10 +100,10 @@ inline bool isForwardingConsume(SILValue value) {
 /// When this is called on a value that does not introduce a new scope, none of
 /// the use points can be EndBorrows or Reborrows. Those uses are only allowed
 /// on borrow-introducing values.
-bool findInnerTransitiveGuaranteedUses(SILValue guaranteedValue,
-                                       SmallVectorImpl<Operand *> &usePoints);
+bool findInnerTransitiveGuaranteedUses(
+    SILValue guaranteedValue, SmallVectorImpl<Operand *> *usePoints = nullptr);
 
-/// Find all "use points" of a guaranteed value within its enclosing borrow
+/// Find leaf "use points" of a guaranteed value within its enclosing borrow
 /// scope (without looking through reborrows). To find the use points of the
 /// extended borrow scope, after looking through reborrows, use
 /// findExtendedTransitiveGuaranteedUses() instead.
@@ -666,7 +667,7 @@ BorrowedValue getSingleBorrowIntroducingValue(SILValue inputValue);
 /// be transitive uses of the given address. Used to implement \see
 /// findTransitiveUses.
 bool findTransitiveUsesForAddress(
-    SILValue address, SmallVectorImpl<Operand *> &foundUses,
+    SILValue address, SmallVectorImpl<Operand *> *foundUses = nullptr,
     std::function<void(Operand *)> *onError = nullptr);
 
 class InteriorPointerOperandKind {
@@ -834,14 +835,17 @@ struct InteriorPointerOperand {
     llvm_unreachable("Covered switch isn't covered?!");
   }
 
-  /// Transitively compute the list of uses that this interior pointer operand
-  /// puts on its parent guaranted value.
+  /// Transitively compute the list of leaf uses that this interior pointer
+  /// operand puts on its parent guaranted value.
+  ///
+  /// If \p foundUses is nullptr, this simply returns true if no PointerEscapes
+  /// were found.
   ///
   /// Example: Uses of a ref_element_addr can not occur outside of the lifetime
   /// of the instruction's operand. The uses of that address act as liveness
   /// requirements to ensure that the underlying class is alive at all use
   /// points.
-  bool findTransitiveUses(SmallVectorImpl<Operand *> &foundUses,
+  bool findTransitiveUses(SmallVectorImpl<Operand *> *foundUses = nullptr,
                           std::function<void(Operand *)> *onError = nullptr) {
     return findTransitiveUsesForAddress(getProjectedAddress(), foundUses,
                                         onError);
@@ -913,7 +917,7 @@ struct AddressOwnership {
 
   /// Transitively compute uses of this base address.
   bool findTransitiveUses(SmallVectorImpl<Operand *> &foundUses) {
-    return findTransitiveUsesForAddress(base.getBaseAddress(), foundUses);
+    return findTransitiveUsesForAddress(base.getBaseAddress(), &foundUses);
   }
 
   /// Return true of all \p uses occur before the end of the address' lifetime

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -1058,6 +1058,12 @@ public:
   /// Returns true if this ends the lifetime of an owned operand.
   bool isConsuming() const;
 
+  bool endsLocalBorrowScope() const {
+    auto ownership = getOperandOwnership();
+    return ownership == OperandOwnership::EndBorrow
+           || ownership == OperandOwnership::Reborrow;
+  }
+
   SILBasicBlock *getParentBlock() const;
   SILFunction *getParentFunction() const;
 

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -807,7 +807,7 @@ bool swift::findTransitiveUsesForAddress(
 
   // We were able to recognize all of the uses of the address, so return false
   // that we did not find any errors.
-  return foundError;
+  return !foundError;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -214,12 +214,16 @@ bool swift::findInnerTransitiveGuaranteedUses(
       break;
 
     case OperandOwnership::InteriorPointer:
+      return false;
+
+#if 0 // FIXME!!! Enable in a following commit that fixes RAUW
       // If our base guaranteed value does not have any consuming uses (consider
       // function arguments), we need to be sure to include interior pointer
       // operands since we may not get a use from a end_scope instruction.
       if (!InteriorPointerOperand(use).findTransitiveUses(usePoints)) {
         return false;
       }
+#endif
       break;
 
     case OperandOwnership::ForwardingBorrow: {

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -376,8 +376,9 @@ bool SILValueOwnershipChecker::gatherUsers(
                          << "Address User: " << *op->getUser();
           });
         };
-        foundError |= !interiorPointerOperand.findTransitiveUses(
-            &nonLifetimeEndingUsers, &onError);
+        foundError |= (interiorPointerOperand.findTransitiveUses(
+                           &nonLifetimeEndingUsers, &onError)
+                       == AddressUseKind::Unknown);
       }
 
       // Finally add the op to the non lifetime ending user list.

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -376,7 +376,7 @@ bool SILValueOwnershipChecker::gatherUsers(
                          << "Address User: " << *op->getUser();
           });
         };
-        foundError |= interiorPointerOperand.findTransitiveUses(
+        foundError |= !interiorPointerOperand.findTransitiveUses(
             nonLifetimeEndingUsers, &onError);
       }
 

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -377,7 +377,7 @@ bool SILValueOwnershipChecker::gatherUsers(
           });
         };
         foundError |= !interiorPointerOperand.findTransitiveUses(
-            nonLifetimeEndingUsers, &onError);
+            &nonLifetimeEndingUsers, &onError);
       }
 
       // Finally add the op to the non lifetime ending user list.

--- a/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
@@ -100,8 +100,7 @@ static bool canBorrowGuaranteedResult(SILValue guaranteedResult) {
     // conversion to a non-guaranteed value. Either way, not interesting.
     return true;
   }
-  SmallVector<Operand *, 16> usePoints;
-  return findInnerTransitiveGuaranteedUses(guaranteedResult, usePoints);
+  return findInnerTransitiveGuaranteedUses(guaranteedResult);
 }
 
 bool swift::canCloneTerminator(TermInst *termInst) {

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -1150,7 +1150,7 @@ OwnershipRAUWHelper::OwnershipRAUWHelper(OwnershipFixupContext &inputCtx,
   auto &oldValueUses = ctx->extraAddressFixupInfo.allAddressUsesFromOldValue;
   // FIXME: The return value of findTransitiveUsesForAddress is currently
   // inverted.
-  if (findTransitiveUsesForAddress(oldValue, oldValueUses)) {
+  if (!findTransitiveUsesForAddress(oldValue, &oldValueUses)) {
     invalidate();
     return;
   }
@@ -1520,7 +1520,7 @@ void GuaranteedPhiBorrowFixup::insertEndBorrowsAndFindPhis(
     return;
   }
   SmallVector<Operand *, 16> usePoints;
-  bool result = findInnerTransitiveGuaranteedUses(phi, usePoints);
+  bool result = findInnerTransitiveGuaranteedUses(phi, &usePoints);
   assert(result && "should be checked by canCloneTerminator");
   (void)result;
 

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -1142,15 +1142,15 @@ OwnershipRAUWHelper::OwnershipRAUWHelper(OwnershipFixupContext &inputCtx,
     return;
 
   ctx->extraAddressFixupInfo.base = addressOwnership.base;
+  SILValue baseAddress = ctx->extraAddressFixupInfo.base.getBaseAddress();
 
   // For now, just gather up uses
   //
   // FIXME: get rid of allAddressUsesFromOldValue. Shouldn't this already be
   // included in guaranteedUsePoints?
   auto &oldValueUses = ctx->extraAddressFixupInfo.allAddressUsesFromOldValue;
-  // FIXME: The return value of findTransitiveUsesForAddress is currently
-  // inverted.
-  if (!findTransitiveUsesForAddress(oldValue, &oldValueUses)) {
+  if (findTransitiveUsesForAddress(oldValue, &oldValueUses)
+      != AddressUseKind::NonEscaping) {
     invalidate();
     return;
   }
@@ -1161,7 +1161,6 @@ OwnershipRAUWHelper::OwnershipRAUWHelper(OwnershipFixupContext &inputCtx,
   }
   // This cloner check must match the later cloner invocation in
   // getReplacementAddress()
-  SILValue baseAddress = ctx->extraAddressFixupInfo.base.getBaseAddress();
   auto *baseInst = cast<SingleValueInstruction>(baseAddress);
   auto checkBase = [&](SILValue srcAddr) {
     return (srcAddr == baseInst) ? SILValue(baseInst) : SILValue();

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -61,6 +61,21 @@ struct NativeObjectStruct {
   var ele : Builtin.NativeObject
 }
 
+struct MyContiguousArrayBody {
+  @_hasStorage var count: Builtin.Int64 { get }
+  init(count: Builtin.Int64)
+}
+
+class MyContiguousArrayStorage {
+  @_hasStorage var body: MyContiguousArrayBody { get }
+  @objc deinit
+}
+
+struct MyContiguousArray {
+  @_hasStorage var storage: MyContiguousArrayStorage { get set }
+  init(storage: MyContiguousArrayStorage)
+}
+
 sil [global_init] @global_init_fun : $@convention(thin) () -> Builtin.RawPointer
 
 sil [ossa] @user : $@convention(thin) (@owned Builtin.NativeObject) -> ()
@@ -5123,3 +5138,20 @@ bb0(%0 : @owned $Klass, %1 : @owned $Klass):
   return %7 : $()
 }
 
+// CHECK-LABEL: sil [ossa] @testTransitiveAddressUse : $@convention(thin) (Builtin.Int64, @owned MyContiguousArrayStorage) -> () {
+// CHECK: [[VAL:%.*]] = struct $MyContiguousArrayBody (%0 : $Builtin.Int64)
+// CHECK: store [[VAL]] to [trivial] %{{.*}} : $*MyContiguousArrayBody
+// CHECK-LABEL: } // end sil function 'testTransitiveAddressUse'
+sil [ossa] @testTransitiveAddressUse : $@convention(thin) (Builtin.Int64, @owned MyContiguousArrayStorage) -> () {
+bb0(%0 : $Builtin.Int64, %1 : @owned $MyContiguousArrayStorage):
+  %2 = struct $MyContiguousArray (%1 : $MyContiguousArrayStorage)
+  %3 = begin_borrow %2 : $MyContiguousArray
+  %4 = struct_extract %3 : $MyContiguousArray, #MyContiguousArray.storage
+  %5 = ref_element_addr %4 : $MyContiguousArrayStorage, #MyContiguousArrayStorage.body
+  %6 = struct_element_addr %5 : $*MyContiguousArrayBody, #MyContiguousArrayBody.count
+  store %0 to [trivial] %6 : $*Builtin.Int64
+  end_borrow %3 : $MyContiguousArray
+  destroy_value %2 : $MyContiguousArray
+  %10 = tuple ()
+  return %10 : $()
+}


### PR DESCRIPTION
Fix code that analyzes address uses for use in OSSA utilities. Various correctness and efficiency issues noticed via code inspection.

This code was mostly disabled because of a bug. Fixing it exposes other bugs in OSSA utilities, so some of the logic is temporarily disabled. Those utilities have been fixed, but they are dependent on these changes so need to be in a following PR. Additional unit tests will be checked in with those changes.
