### PR TITLE
[cxx-interop] Add members to the LookupTable where possible.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3073,6 +3073,10 @@ class NominalTypeDecl : public GenericTypeDecl, public IterableDeclContext {
   /// Prepare to traverse the list of extensions.
   void prepareExtensions();
 
+  /// Add loaded members from all extensions. Eagerly load any members that we
+  /// can't lazily load.
+  void addLoadedExtensions();
+
   /// Retrieve the conformance loader (if any), and removing it in the
   /// same operation. The caller is responsible for loading the
   /// conformances.
@@ -3194,6 +3198,11 @@ public:
 
   /// Add a new extension to this nominal type.
   void addExtension(ExtensionDecl *extension);
+
+  /// Add a member to this decl's lookup table.
+  ///
+  /// Calls "prepareLookupTable" as a side effect.
+  void addMemberToLookupTable(Decl *member);
 
   /// Retrieve the set of extensions of this type.
   ExtensionRange getExtensions();

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -867,6 +867,10 @@ void IterableDeclContext::addMemberSilently(Decl *member, Decl *hint,
       if (d->isImplicit())
         return true;
 
+      // Imported decls won't have complete location info.
+      if (d->hasClangNode())
+        return true;
+
       return false;
     };
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1220,6 +1220,12 @@ void ExtensionDecl::addedMember(Decl *member) {
   }
 }
 
+void NominalTypeDecl::addMemberToLookupTable(Decl *member) {
+  prepareLookupTable();
+
+  LookupTable->addMember(member);
+}
+
 // For lack of anywhere more sensible to put it, here's a diagram of the pieces
 // involved in finding members and extensions of a NominalTypeDecl.
 //
@@ -1332,7 +1338,9 @@ void NominalTypeDecl::prepareLookupTable() {
   } else {
     LookupTable->addMembers(getMembers());
   }
+}
 
+void NominalTypeDecl::addLoadedExtensions() {
   for (auto e : getExtensions()) {
     // If we can lazy-load this extension, only take the members we've loaded
     // so far.
@@ -1424,10 +1432,10 @@ DirectLookupRequest::evaluate(Evaluator &evaluator,
 
   decl->prepareLookupTable();
 
-  // If we're allowed to load extensions, call prepareExtensions to ensure we
+  // If we're allowed to load extensions, call addLoadedExtensions to ensure we
   // properly invalidate the lazily-complete cache for any extensions brought in
   // by modules loaded after-the-fact. This can happen with the LLDB REPL.
-  decl->prepareExtensions();
+  decl->addLoadedExtensions();
 
   auto &Table = *decl->LookupTable;
   if (!useNamedLazyMemberLoading) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4053,7 +4053,8 @@ ClangImporter::Implementation::loadNamedMembers(
   auto table = findLookupTable(*CMO);
   assert(table && "clang module without lookup table");
 
-  assert(isa<clang::ObjCContainerDecl>(CD) || isa<clang::NamespaceDecl>(CD));
+  assert(isa<clang::ObjCContainerDecl>(CD) || isa<clang::NamespaceDecl>(CD) ||
+         isa<clang::RecordDecl>(CD));
 
   // Force the members of the entire inheritance hierarchy to be loaded and
   // deserialized before loading the named member of a class. This warms up

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2401,48 +2401,6 @@ namespace {
         if (auto *typedefForAnon = decl->getTypedefNameForAnonDecl())
           return importFullName(typedefForAnon);
       }
-
-      if (!decl->isRecord())
-        return {ImportedName(), None};
-
-      // If the type has no name and no structure name, but is not anonymous,
-      // generate a name for it. Specifically this is for cases like:
-      //   struct a {
-      //     struct {} z;
-      //   }
-      // Where the member z is an unnamed struct, but does have a member-name
-      // and is accessible as a member of struct a.
-      if (auto recordDecl = dyn_cast<clang::RecordDecl>(
-                              decl->getLexicalDeclContext())) {
-        for (auto field : recordDecl->fields()) {
-          if (field->getType()->getAsTagDecl() == decl) {
-            // Create a name for the declaration from the field name.
-            std::string Id;
-            llvm::raw_string_ostream IdStream(Id);
-
-            const char *kind;
-            if (decl->isStruct())
-              kind = "struct";
-            else if (decl->isUnion())
-              kind = "union";
-            else
-              llvm_unreachable("unknown decl kind");
-
-            IdStream << "__Unnamed_" << kind << "_";
-            if (field->isAnonymousStructOrUnion()) {
-              IdStream << "__Anonymous_field" << field->getFieldIndex();
-            } else {
-              assert(!field->getDeclName().isEmpty() &&
-                     "Microsoft anonymous struct extension?");
-              IdStream << field->getName();
-            }
-            ImportedName Result;
-            Result.setDeclName(Impl.SwiftContext.getIdentifier(IdStream.str()));
-            Result.setEffectiveContext(decl->getDeclContext());
-            return {Result, None};
-          }
-        }
-      }
       
       return {ImportedName(), None};
     }
@@ -3634,7 +3592,7 @@ namespace {
         if (auto nominalDecl =
                 dyn_cast<NominalTypeDecl>(nestedType->getDeclContext())) {
           assert(nominalDecl == result && "interesting nesting of C types?");
-          nominalDecl->addMember(nestedType);
+          nominalDecl->addMemberToLookupTable(nestedType);
         }
       }
 
@@ -3675,7 +3633,7 @@ namespace {
                                                   /*wantBody=*/true);
           ctors.push_back(valueCtor);
         }
-        result->addMember(member);
+        result->addMemberToLookupTable(member);
       }
 
       const clang::CXXRecordDecl *cxxRecordDecl =
@@ -3710,12 +3668,14 @@ namespace {
         ctors.push_back(valueCtor);
       }
 
+      // Add ctors directly as they cannot always be looked up from the clang
+      // decl (some are synthesized by Swift).
       for (auto ctor : ctors) {
         result->addMember(ctor);
       }
 
       for (auto method : methods) {
-        result->addMember(method);
+        result->addMemberToLookupTable(method);
       }
 
       result->setHasUnreferenceableStorage(hasUnreferenceableStorage);
@@ -3731,10 +3691,13 @@ namespace {
           auto getterAndSetter = subscriptInfo.second;
           auto subscript = makeSubscript(getterAndSetter.first,
                                          getterAndSetter.second);
+          // Also add subscripts directly because they won't be found from the
+          // clang decl.
           result->addMember(subscript);
         }
       }
 
+      result->setMemberLoader(&Impl, 0);
       return result;
     }
 
@@ -4363,21 +4326,9 @@ namespace {
       Optional<ImportedName> correctSwiftName;
       ImportedName importedName;
 
-      if (!decl->isAnonymousStructOrUnion() && !decl->getDeclName().isEmpty()) {
-        std::tie(importedName, correctSwiftName) = importFullName(decl);
-        if (!importedName) {
-          return nullptr;
-        }
-      } else {
-        // Generate a field name for anonymous fields, this will be used in
-        // order to be able to expose the indirect fields injected from there
-        // as computed properties forwarding the access to the subfield.
-        std::string Id;
-        llvm::raw_string_ostream IdStream(Id);
-
-        IdStream << "__Anonymous_field" << decl->getFieldIndex();
-        importedName.setDeclName(Impl.SwiftContext.getIdentifier(IdStream.str()));
-        importedName.setEffectiveContext(decl->getDeclContext());
+      std::tie(importedName, correctSwiftName) = importFullName(decl);
+      if (!importedName) {
+        return nullptr;
       }
 
       auto name = importedName.getDeclName().getBaseIdentifier();
@@ -9875,6 +9826,38 @@ static void loadAllMembersOfSuperclassIfNeeded(ClassDecl *CD) {
     E->loadAllMembers();
 }
 
+static void loadAllMembersOfRecordDecl(StructDecl *recordDecl) {
+  auto &ctx = recordDecl->getASTContext();
+  auto clangRecord = cast<clang::RecordDecl>(recordDecl->getClangDecl());
+
+  // This is only to keep track of the members we've already seen.
+  llvm::SmallPtrSet<Decl *, 16> addedMembers;
+  for (auto member : recordDecl->getCurrentMembersWithoutLoading())
+    addedMembers.insert(member);
+
+  for (auto member : clangRecord->decls()) {
+    auto namedDecl = dyn_cast<clang::NamedDecl>(member);
+    if (!namedDecl)
+      continue;
+
+    // Don't try to load ourselves (this will create an infinite loop).
+    if (auto possibleSelf = dyn_cast<clang::RecordDecl>(member))
+      if (possibleSelf->getDefinition() == clangRecord)
+        continue;
+
+    auto name = ctx.getClangModuleLoader()->importName(namedDecl);
+    if (!name)
+      continue;
+
+    for (auto found : recordDecl->lookupDirect(name)) {
+      if (addedMembers.insert(found).second &&
+          // TODO: remove this check once PR#38675 lands.
+          found->getDeclContext() == recordDecl)
+        recordDecl->addMember(found);
+    }
+  }
+}
+
 void
 ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
 
@@ -9893,26 +9876,8 @@ ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
     return;
   }
 
-  auto namespaceDecl =
-      dyn_cast_or_null<clang::NamespaceDecl>(D->getClangDecl());
-  if (namespaceDecl) {
-    auto *enumDecl = cast<EnumDecl>(D);
-    // TODO: This redecls should only match redecls that are in the same
-    // module as namespaceDecl after we import one namespace per clang module.
-    for (auto ns : namespaceDecl->redecls()) {
-      for (auto m : ns->decls()) {
-        auto nd = dyn_cast<clang::NamedDecl>(m);
-        if (!nd)
-          continue;
-        auto member = importDecl(nd, CurrentVersion);
-        if (!member)
-          continue;
-
-        // TODO: remove this change when #34706 lands.
-        if (!member->NextDecl)
-          enumDecl->addMember(member);
-      }
-    }
+  if (D->getClangDecl() && isa<clang::RecordDecl>(D->getClangDecl())) {
+    loadAllMembersOfRecordDecl(cast<StructDecl>(D));
     return;
   }
 

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1670,9 +1670,67 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     }
   }
 
-  // For empty names, there is nothing to do.
-  if (D->getDeclName().isEmpty())
+  // Spcial case: unnamed/anonymous fields.
+  if (auto field = dyn_cast<clang::FieldDecl>(D)) {
+    if (field->isAnonymousStructOrUnion() || field->getDeclName().isEmpty()) {
+      // Generate a field name for anonymous fields, this will be used in
+      // order to be able to expose the indirect fields injected from there
+      // as computed properties forwarding the access to the subfield.
+      std::string name;
+      llvm::raw_string_ostream nameStream(name);
+
+      nameStream << "__Anonymous_field" << field->getFieldIndex();
+      result.setDeclName(swiftCtx.getIdentifier(nameStream.str()));
+      result.setEffectiveContext(field->getDeclContext());
+      return result;
+    }
+  }
+
+  if (D->getDeclName().isEmpty()) {
+    // If the type has no name and no structure name, but is not anonymous,
+    // generate a name for it. Specifically this is for cases like:
+    //   struct a {
+    //     struct {} z;
+    //   }
+    // Where the member z is an unnamed struct, but does have a member-name
+    // and is accessible as a member of struct a.
+    if (auto recordDecl = dyn_cast<clang::RecordDecl>(
+                            D->getLexicalDeclContext())) {
+      for (auto field : recordDecl->fields()) {
+        auto fieldTagDecl = field->getType()->getAsTagDecl();
+        if (fieldTagDecl == D) {
+          // Create a name for the declaration from the field name.
+          std::string name;
+          llvm::raw_string_ostream nameStream(name);
+
+          const char *kind;
+          if (fieldTagDecl->isStruct())
+            kind = "struct";
+          else if (fieldTagDecl->isUnion())
+            kind = "union";
+          else if  (fieldTagDecl->isEnum())
+            kind = "enum";
+          else
+            llvm_unreachable("unknown decl kind");
+
+          nameStream << "__Unnamed_" << kind << "_";
+          if (field->isAnonymousStructOrUnion()) {
+            nameStream << "__Anonymous_field" << field->getFieldIndex();
+          } else {
+            assert(!field->getDeclName().isEmpty() &&
+                   "Microsoft anonymous struct extension?");
+            nameStream << field->getName();
+          }
+          result.setDeclName(swiftCtx.getIdentifier(nameStream.str()));
+          result.setEffectiveContext(D->getDeclContext());
+          return result;
+        }
+      }
+    }
+
+    // Otherwise, for empty names, there is nothing to do.
     return result;
+  }
 
   /// Whether the result is a function name.
   bool isFunction = false;

--- a/test/ClangImporter/Inputs/SwiftPrivateAttr.txt
+++ b/test/ClangImporter/Inputs/SwiftPrivateAttr.txt
@@ -41,19 +41,19 @@ class __PrivFooSub : Foo {
 }
 func __privTest()
 struct S0 {
-  var __privValue: Int32
   init()
   init(__privValue: Int32)
+  var __privValue: Int32
 }
 struct __PrivS1 {
-  var value: Int32
   init()
   init(value: Int32)
+  var value: Int32
 }
 struct __PrivS2 {
-  var value: Int32
   init()
   init(value: Int32)
+  var value: Int32
 }
 var __PrivAnonymousA: Int { get }
 struct E0 : Equatable, RawRepresentable {

--- a/test/ClangImporter/ctypes_parse.swift
+++ b/test/ClangImporter/ctypes_parse.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift %clang-importer-sdk
+// RUN: %target-typecheck-verify-swift %clang-importer-sdk -verify-ignore-unknown
 
 import ctypes
 

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -128,9 +128,9 @@
 // PRINT-NEXT:  func takeMyABIOldTypeNonNullNS(_: String)
 //
 // PRINT-NEXT:  struct NSSomeContext {
-// PRINT-NEXT:    var i: Int32
 // PRINT-NEXT:    init()
 // PRINT-NEXT:    init(i: Int32)
+// PRINT-NEXT:    var i: Int32
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension NSSomeContext {
 // PRINT-NEXT:    struct Name : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable {

--- a/test/IDE/print_clang_decls.swift
+++ b/test/IDE/print_clang_decls.swift
@@ -26,20 +26,20 @@
 // RUN: %FileCheck %s -check-prefix=CHECK-BRIDGED-TYPEDEF -strict-whitespace < %t.printed.txt
 
 // TAG_DECLS_AND_TYPEDEFS: {{^}}struct FooStruct1 {{{$}}
-// TAG_DECLS_AND_TYPEDEFS: {{^}}  var x: Int32{{$}}
-// TAG_DECLS_AND_TYPEDEFS: {{^}}  var y: Double{{$}}
 // TAG_DECLS_AND_TYPEDEFS: {{^}}  init(){{$}}
 // TAG_DECLS_AND_TYPEDEFS: {{^}}  init(x: Int32, y: Double){{$}}
+// TAG_DECLS_AND_TYPEDEFS: {{^}}  var x: Int32{{$}}
+// TAG_DECLS_AND_TYPEDEFS: {{^}}  var y: Double{{$}}
 // TAG_DECLS_AND_TYPEDEFS: {{^}}}{{$}}
 
 // TAG_DECLS_AND_TYPEDEFS:      /**
 // TAG_DECLS_AND_TYPEDEFS-NEXT:   @keyword Foo2
 // TAG_DECLS_AND_TYPEDEFS-NEXT: */
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}struct FooStruct2 {{{$}}
-// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var x: Int32{{$}}
-// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var y: Double{{$}}
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  init(){{$}}
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  init(x: Int32, y: Double){{$}}
+// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var x: Int32{{$}}
+// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var y: Double{{$}}
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}}{{$}}
 
 // TAG_DECLS_AND_TYPEDEFS:      /**
@@ -48,38 +48,38 @@
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}typealias FooStructTypedef1 = FooStruct2{{$}}
 
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}struct FooStructTypedef2 {{{$}}
-// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var x: Int32{{$}}
-// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var y: Double{{$}}
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  init(){{$}}
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  init(x: Int32, y: Double){{$}}
+// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var x: Int32{{$}}
+// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var y: Double{{$}}
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}}{{$}}
 
 // TAG_DECLS_AND_TYPEDEFS: {{^}}struct FooStruct3 {{{$}}
-// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var x: Int32{{$}}
-// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var y: Double{{$}}
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  init(){{$}}
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  init(x: Int32, y: Double){{$}}
+// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var x: Int32{{$}}
+// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var y: Double{{$}}
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}}{{$}}
 
 // TAG_DECLS_AND_TYPEDEFS: {{^}}struct FooStruct4 {{{$}}
-// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var x: Int32{{$}}
-// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var y: Double{{$}}
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  init(){{$}}
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  init(x: Int32, y: Double){{$}}
+// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var x: Int32{{$}}
+// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var y: Double{{$}}
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}}{{$}}
 
 // TAG_DECLS_AND_TYPEDEFS: {{^}}struct FooStruct5 {{{$}}
-// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var x: Int32{{$}}
-// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var y: Double{{$}}
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  init(){{$}}
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  init(x: Int32, y: Double){{$}}
+// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var x: Int32{{$}}
+// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var y: Double{{$}}
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}}{{$}}
 
 // TAG_DECLS_AND_TYPEDEFS: {{^}}struct FooStruct6 {{{$}}
-// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var x: Int32{{$}}
-// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var y: Double{{$}}
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  init(){{$}}
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  init(x: Int32, y: Double){{$}}
+// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var x: Int32{{$}}
+// TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}  var y: Double{{$}}
 // TAG_DECLS_AND_TYPEDEFS-NEXT: {{^}}}{{$}}
 
 // Skip through unavailable typedefs when importing types.

--- a/test/Interop/C/struct/struct-decl-context-module-interface.swift
+++ b/test/Interop/C/struct/struct-decl-context-module-interface.swift
@@ -5,16 +5,16 @@
 // nested in other C structs.
 
 // CHECK: struct StructRegular {
-// CHECK-NEXT:   var complete_immediately: StructNestedComplete1
-// CHECK-NEXT:   var completed_later: UnsafeMutablePointer<StructNestedCompletedLater1>!
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(complete_immediately: StructNestedComplete1, completed_later: UnsafeMutablePointer<StructNestedCompletedLater1>!)
+// CHECK-NEXT:   var complete_immediately: StructNestedComplete1
+// CHECK-NEXT:   var completed_later: UnsafeMutablePointer<StructNestedCompletedLater1>!
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructNestedComplete1 {
-// CHECK-NEXT:   var complete_immediately_nested: StructNestedNestedComplete1
-// CHECK-NEXT:   var completed_later_nested: UnsafeMutablePointer<StructNestedNestedCompletedLater1>!
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(complete_immediately_nested: StructNestedNestedComplete1, completed_later_nested: UnsafeMutablePointer<StructNestedNestedCompletedLater1>!)
+// CHECK-NEXT:   var complete_immediately_nested: StructNestedNestedComplete1
+// CHECK-NEXT:   var completed_later_nested: UnsafeMutablePointer<StructNestedNestedCompletedLater1>!
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructNestedNestedComplete1 {
 // CHECK-NEXT:   init()
@@ -26,10 +26,10 @@
 // CHECK-NEXT:   init()
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructTypedefTag2 {
-// CHECK-NEXT:   var complete_immediately: StructNestedComplete2
-// CHECK-NEXT:   var completed_later: UnsafeMutablePointer<StructNestedCompletedLater2>!
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(complete_immediately: StructNestedComplete2, completed_later: UnsafeMutablePointer<StructNestedCompletedLater2>!)
+// CHECK-NEXT:   var complete_immediately: StructNestedComplete2
+// CHECK-NEXT:   var completed_later: UnsafeMutablePointer<StructNestedCompletedLater2>!
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructNestedComplete2 {
 // CHECK-NEXT:   init()
@@ -39,10 +39,10 @@
 // CHECK-NEXT:   init()
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructTypedefName3 {
-// CHECK-NEXT:   var complete_immediately: StructNestedComplete3
-// CHECK-NEXT:   var completed_later: UnsafeMutablePointer<StructNestedCompletedLater3>!
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(complete_immediately: StructNestedComplete3, completed_later: UnsafeMutablePointer<StructNestedCompletedLater3>!)
+// CHECK-NEXT:   var complete_immediately: StructNestedComplete3
+// CHECK-NEXT:   var completed_later: UnsafeMutablePointer<StructNestedCompletedLater3>!
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructNestedComplete3 {
 // CHECK-NEXT:   init()
@@ -51,10 +51,10 @@
 // CHECK-NEXT:   init()
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructTypedefTag4 {
-// CHECK-NEXT:   var complete_immediately: StructNestedComplete4
-// CHECK-NEXT:   var completed_later: UnsafeMutablePointer<StructNestedCompletedLater4>!
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(complete_immediately: StructNestedComplete4, completed_later: UnsafeMutablePointer<StructNestedCompletedLater4>!)
+// CHECK-NEXT:   var complete_immediately: StructNestedComplete4
+// CHECK-NEXT:   var completed_later: UnsafeMutablePointer<StructNestedCompletedLater4>!
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructNestedComplete4 {
 // CHECK-NEXT:   init()
@@ -71,10 +71,10 @@
 // CHECK-NEXT:   init()
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructTypedefName6 {
-// CHECK-NEXT:   var complete_immediately: StructNestedComplete6
-// CHECK-NEXT:   var completed_later: UnsafeMutablePointer<StructNestedCompletedLater6>!
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(complete_immediately: StructNestedComplete6, completed_later: UnsafeMutablePointer<StructNestedCompletedLater6>!)
+// CHECK-NEXT:   var complete_immediately: StructNestedComplete6
+// CHECK-NEXT:   var completed_later: UnsafeMutablePointer<StructNestedCompletedLater6>!
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructNestedComplete6 {
 // CHECK-NEXT:   init()
@@ -84,10 +84,10 @@
 // CHECK-NEXT:   init()
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructTypedefName7 {
-// CHECK-NEXT:   var complete_immediately: StructNestedComplete7
-// CHECK-NEXT:   var completed_later: UnsafeMutablePointer<StructNestedCompletedLater7>!
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(complete_immediately: StructNestedComplete7, completed_later: UnsafeMutablePointer<StructNestedCompletedLater7>!)
+// CHECK-NEXT:   var complete_immediately: StructNestedComplete7
+// CHECK-NEXT:   var completed_later: UnsafeMutablePointer<StructNestedCompletedLater7>!
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructNestedComplete7 {
 // CHECK-NEXT:   init()
@@ -97,10 +97,10 @@
 // CHECK-NEXT:   init()
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructTypedefName8 {
-// CHECK-NEXT:   var complete_immediately: StructNestedComplete8
-// CHECK-NEXT:   var completed_later: UnsafeMutablePointer<StructNestedCompletedLater8>!
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(complete_immediately: StructNestedComplete8, completed_later: UnsafeMutablePointer<StructNestedCompletedLater8>!)
+// CHECK-NEXT:   var complete_immediately: StructNestedComplete8
+// CHECK-NEXT:   var completed_later: UnsafeMutablePointer<StructNestedCompletedLater8>!
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructNestedComplete8 {
 // CHECK-NEXT:   init()

--- a/test/Interop/Cxx/class/access-specifiers-module-interface.swift
+++ b/test/Interop/Cxx/class/access-specifiers-module-interface.swift
@@ -4,6 +4,9 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=AccessSpecifiers -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
 
 // CHECK:      struct PublicPrivate {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   static var PublicStaticMemberVar: Int32
+// CHECK-NEXT:   mutating func publicMemberFunc()
 // CHECK-NEXT:   typealias PublicTypedef = Int32
 // CHECK-NEXT:   struct PublicStruct {
 // CHECK-NEXT:     init()
@@ -37,8 +40,5 @@
 // CHECK-NEXT:     typealias Element = PublicPrivate.PublicFlagEnum
 // CHECK-NEXT:     typealias ArrayLiteralElement = PublicPrivate.PublicFlagEnum
 // CHECK-NEXT:   }
-// CHECK-NEXT:   static var PublicStaticMemberVar: Int32
 // CHECK-NEXT:   var PublicMemberVar: Int32
-// CHECK-NEXT:   init()
-// CHECK-NEXT:   mutating func publicMemberFunc()
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/constructors-module-interface.swift
+++ b/test/Interop/Cxx/class/constructors-module-interface.swift
@@ -1,26 +1,26 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=Constructors -I %S/Inputs/ -source-filename=x -enable-cxx-interop | %FileCheck %s
 
 // CHECK:      struct ExplicitDefaultConstructor {
-// CHECK-NEXT:   var x: Int32
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   var x: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct ImplicitDefaultConstructor {
-// CHECK-NEXT:   var x: Int32
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(x: Int32)
+// CHECK-NEXT:   var x: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct MemberOfClassType {
-// CHECK-NEXT:   var member: ImplicitDefaultConstructor
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(member: ImplicitDefaultConstructor)
+// CHECK-NEXT:   var member: ImplicitDefaultConstructor
 // CHECK-NEXT: }
 // CHECK-NEXT: struct DefaultConstructorDeleted {
-// CHECK-NEXT:   var a: UnsafeMutablePointer<Int32>
 // CHECK-NEXT:   init(a: UnsafeMutablePointer<Int32>)
+// CHECK-NEXT:   var a: UnsafeMutablePointer<Int32>
 // CHECK-NEXT: }
 // CHECK-NEXT: struct ConstructorWithParam {
-// CHECK-NEXT:   var x: Int32
 // CHECK-NEXT:   init(_ val: Int32)
+// CHECK-NEXT:   var x: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct CopyAndMoveConstructor {
 // CHECK-NEXT: }
@@ -28,17 +28,17 @@
 // CHECK-NEXT:   init()
 // CHECK-NEXT: }
 // CHECK-NEXT: struct ArgType {
-// CHECK-NEXT:   var i: Int32
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(i: Int32)
+// CHECK-NEXT:   var i: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct HasVirtualBase {
-// CHECK-NEXT:   var i: Int32
 // CHECK-NEXT:   init(_ Arg: ArgType)
+// CHECK-NEXT:   var i: Int32
 // CHECK-NEXT: }
 // CHECK:      struct TemplatedConstructor {
-// CHECK-NEXT:   var value: ArgType
 // CHECK-NEXT:   init<T>(_ value: T)
+// CHECK-NEXT:   var value: ArgType
 // CHECK-NEXT: }
 // CHECK:      struct TemplatedConstructorWithExtraArg {
 // CHECK-NEXT:   init<T>(_: Int32, _ value: T)

--- a/test/Interop/Cxx/class/linked-records-module-interface.swift
+++ b/test/Interop/Cxx/class/linked-records-module-interface.swift
@@ -3,16 +3,16 @@
 // CHECK: extension Space {
 // CHECK:   struct C {
 // CHECK:     struct D {
-// CHECK:       var B: Space.A.B
 // CHECK:       init(B: Space.A.B)
+// CHECK:       var B: Space.A.B
 // CHECK:     }
 // CHECK:   }
 // CHECK:   struct A {
+// CHECK:     init()
 // CHECK:     struct B {
 // CHECK:       init(_: Int32)
 // CHECK:       init(_: CChar)
 // CHECK:     }
-// CHECK:     init()
 // CHECK:   }
 // CHECK:   struct E {
 // CHECK:     init()
@@ -24,20 +24,20 @@
 // CHECK:   init()
 // CHECK: }
 // CHECK: struct F {
+// CHECK:   init()
+// CHECK:   init(_ __Anonymous_field0: F.__Unnamed_union___Anonymous_field0, m2: M)
 // CHECK:   struct __Unnamed_union___Anonymous_field0 {
+// CHECK:     init()
+// CHECK:     init(c: F.__Unnamed_union___Anonymous_field0.__Unnamed_struct_c)
+// CHECK:     init(m: M)
 // CHECK:     struct __Unnamed_struct_c {
 // CHECK:       init()
 // CHECK:     }
 // CHECK:     var c: F.__Unnamed_union___Anonymous_field0.__Unnamed_struct_c
 // CHECK:     var m: M
-// CHECK:     init()
-// CHECK:     init(c: F.__Unnamed_union___Anonymous_field0.__Unnamed_struct_c)
-// CHECK:     init(m: M)
 // CHECK:   }
 // CHECK:   var __Anonymous_field0: F.__Unnamed_union___Anonymous_field0
 // CHECK:   var c: F.__Unnamed_union___Anonymous_field0.__Unnamed_struct_c
 // CHECK:   var m: M
 // CHECK:   var m2: M
-// CHECK:   init()
-// CHECK:   init(_ __Anonymous_field0: F.__Unnamed_union___Anonymous_field0, m2: M)
 // CHECK: }

--- a/test/Interop/Cxx/class/member-variables-module-interface.swift
+++ b/test/Interop/Cxx/class/member-variables-module-interface.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=MemberVariables -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
 
 // CHECK:      struct MyClass {
-// CHECK-NEXT:   var const_member: Int32 { get }
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(const_member: Int32)
+// CHECK-NEXT:   var const_member: Int32 { get }
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/memberwise-initializer-module-interface.swift
+++ b/test/Interop/Cxx/class/memberwise-initializer-module-interface.swift
@@ -4,41 +4,41 @@
 // CHECK-NEXT:   init()
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructPublicOnly {
-// CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(varPublic: Int32)
+// CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructEmptyPrivateSection {
-// CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(varPublic: Int32)
+// CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructPublicAndPrivate {
-// CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct StructWithUnimportedMemberFunction {
-// CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(varPublic: Int32)
+// CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct ClassPrivateOnly {
 // CHECK-NEXT:   init()
 // CHECK-NEXT: }
 // CHECK-NEXT: struct ClassPublicOnly {
-// CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(varPublic: Int32)
+// CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct ClassEmptyPublicSection {
 // CHECK-NEXT:   init()
 // CHECK-NEXT: }
 // CHECK-NEXT: struct ClassPrivateAndPublic {
-// CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct ClassWithUnimportedMemberFunction {
-// CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(varPublic: Int32)
+// CHECK-NEXT:   var varPublic: Int32
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/mutable-members-module-interface.swift
+++ b/test/Interop/Cxx/class/mutable-members-module-interface.swift
@@ -1,8 +1,8 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=MutableMembers -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
 
 // CHECK: struct HasPublicMutableMember {
-// CHECK:   var a: Int32
 // CHECK:   mutating func foo() -> Int32
+// CHECK:   var a: Int32
 // CHECK: }
 
 // CHECK: struct HasPrivateMutableMember {

--- a/test/Interop/Cxx/class/nested-records-module-interface.swift
+++ b/test/Interop/Cxx/class/nested-records-module-interface.swift
@@ -28,10 +28,10 @@
 // CHECK: }
  
 // CHECK: struct S6 {
+// CHECK:   init()
 // CHECK:   struct E3 : Equatable, RawRepresentable {
 // CHECK:     typealias RawValue = {{UInt32|Int32}}
 // CHECK:   }
-// CHECK:   init()
 // CHECK: }
  
 // CHECK: struct S7 {
@@ -57,22 +57,22 @@
 // CHECK: }
 
 // CHECK: struct HasForwardDeclaredNestedType {
+// CHECK:   init()
 // CHECK:   struct ForwardDeclaredType {
 // CHECK:     init()
 // CHECK:   }
 // CHECK:   struct NormalSubType {
 // CHECK:     init()
 // CHECK:   }
-// CHECK:   init()
 // CHECK: }
 
 // CHECK: struct HasForwardDeclaredTemplateChild {
+// CHECK:   init()
 // CHECK:   struct ForwardDeclaredClassTemplate<T> {
 // CHECK:   }
 // CHECK:   struct DeclaresForwardDeclaredClassTemplateFriend {
 // CHECK:     init()
 // CHECK:   }
-// CHECK:   init()
 // CHECK: }
 
 // CHECK: extension NestedDeclIsAFirstForwardDeclaration {
@@ -84,12 +84,12 @@
 // CHECK:   }
 // CHECK:   static func takesFriend(_ b: NestedDeclIsAFirstForwardDeclaration.ForwardDeclaredFriend)
 // CHECK:   struct HasNestedForwardDeclaration {
+// CHECK:     init()
 // CHECK:     struct IsNestedForwardDeclaration {
-// CHECK:       var a: Int32
 // CHECK:       init()
 // CHECK:       init(a: Int32)
+// CHECK:       var a: Int32
 // CHECK:     }
-// CHECK:     init()
 // CHECK:   }
 // CHECK:   static func takesHasNestedForwardDeclaration(_: NestedDeclIsAFirstForwardDeclaration.HasNestedForwardDeclaration)
 // CHECK: }

--- a/test/Interop/Cxx/enum/bool-enums-module-interface.swift
+++ b/test/Interop/Cxx/enum/bool-enums-module-interface.swift
@@ -29,6 +29,7 @@
 // CHECK: }
 
 // CHECK:       struct WrapperStruct {
+// CHECK-NEXT:    init()
 // TODO: where is "A" and "B"? They should be member variables.
 // CHECK-NEXT:    struct InnerBoolEnum : Equatable, RawRepresentable {
 // CHECK-NEXT:      init(_ rawValue: Bool)
@@ -36,5 +37,4 @@
 // CHECK-NEXT:      var rawValue: Bool
 // CHECK-NEXT:      typealias RawValue = Bool
 // CHECK-NEXT:    }
-// CHECK-NEXT:    init()
 // CHECK-NEXT:  }

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -18,12 +18,7 @@
 
 
 // CHECK: struct ReadWriteIntArray {
-// CHECK:   struct NestedIntArray {
-// CHECK:     @available(*, unavailable, message: "use subscript")
-// CHECK:     func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>
-
-// CHECK:     subscript(x: Int32) -> Int32 { get }
-// CHECK:   }
+// CHECK:   subscript(x: Int32) -> Int32
 
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>
@@ -31,35 +26,38 @@
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   mutating func __operatorSubscript(_ x: Int32) -> UnsafeMutablePointer<Int32>
 
-// CHECK:   subscript(x: Int32) -> Int32
+// CHECK:   struct NestedIntArray {
+// CHECK:     subscript(x: Int32) -> Int32 { get }
+
+// CHECK:     @available(*, unavailable, message: "use subscript")
+// CHECK:     func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>
+// CHECK:   }
 // CHECK: }
 
 
 // CHECK: struct ReadOnlyIntArray {
+// CHECK:   subscript(x: Int32) -> Int32 { get }
+
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>
-
-// CHECK:   subscript(x: Int32) -> Int32 { get }
 // CHECK: }
 
 
 // CHECK: struct WriteOnlyIntArray {
+// CHECK:   subscript(x: Int32) -> Int32 { mutating get set }
+
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   mutating func __operatorSubscript(_ x: Int32) -> UnsafeMutablePointer<Int32>
-
-// CHECK:   subscript(x: Int32) -> Int32 { mutating get set }
 // CHECK: }
 
 
 // CHECK: struct DifferentTypesArray {
+// CHECK:   subscript(x: Int32) -> Int32
+// CHECK:   subscript(x: Bool) -> Bool
+// CHECK:   subscript(x: Double) -> Double { get }
+
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>
-
-// CHECK:   @available(*, unavailable, message: "use subscript")
-// CHECK:   mutating func __operatorSubscript(_ x: Int32) -> UnsafeMutablePointer<Int32>
-
-// CHECK:   @available(*, unavailable, message: "use subscript")
-// CHECK:   mutating func __operatorSubscript(_ x: Bool) -> UnsafeMutablePointer<Bool>
 
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   func __operatorSubscriptConst(_ x: Bool) -> UnsafePointer<Bool>
@@ -67,22 +65,24 @@
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   func __operatorSubscriptConst(_ x: Double) -> UnsafePointer<Double>
 
-// CHECK:   subscript(x: Int32) -> Int32
-// CHECK:   subscript(x: Bool) -> Bool
-// CHECK:   subscript(x: Double) -> Double { get }
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscript(_ x: Int32) -> UnsafeMutablePointer<Int32>
+
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscript(_ x: Bool) -> UnsafeMutablePointer<Bool>
 // CHECK: }
 
 
 // CHECK: struct TemplatedArray<T> {
 // CHECK: }
 // CHECK: struct __CxxTemplateInst14TemplatedArrayIdE {
+// CHECK:   subscript(i: Int32) -> Double
+
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   mutating func __operatorSubscript(_ i: Int32) -> UnsafeMutablePointer<Double>
 
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   func __operatorSubscriptConst(_ i: Int32) -> UnsafePointer<Double>
-
-// CHECK:   subscript(i: Int32) -> Double
 // CHECK: }
 // CHECK: typealias TemplatedDoubleArray = __CxxTemplateInst14TemplatedArrayIdE
 
@@ -92,18 +92,22 @@
 
 
 // CHECK: struct IntArrayByVal {
+// CHECK:   subscript(x: Int32) -> Int32 { get }
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   func __operatorSubscriptConst(_ x: Int32) -> Int32
-// CHECK:   subscript(x: Int32) -> Int32 { get }
 // CHECK: }
 
 // CHECK: struct NonTrivialIntArrayByVal {
+// CHECK:   subscript(x: Int32) -> Int32 { get }
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   func __operatorSubscriptConst(_ x: Int32) -> Int32
-// CHECK:   subscript(x: Int32) -> Int32 { get }
 // CHECK: }
 
 // CHECK: struct DifferentTypesArrayByVal {
+// CHECK:   subscript(x: Int32) -> Int32 { mutating get }
+// CHECK:   subscript(x: Bool) -> Bool { mutating get }
+// CHECK:   subscript(x: Double) -> Double { get }
+
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   func __operatorSubscriptConst(_ x: Int32) -> Int32
 
@@ -112,56 +116,52 @@
 
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   func __operatorSubscriptConst(_ x: Double) -> Double
-
-// CHECK:   subscript(x: Int32) -> Int32 { mutating get }
-// CHECK:   subscript(x: Bool) -> Bool { mutating get }
-// CHECK:   subscript(x: Double) -> Double { get }
 // CHECK: }
 
 
 // CHECK: struct TemplatedArrayByVal<T> {
 // CHECK: }
 // CHECK: struct __CxxTemplateInst19TemplatedArrayByValIdE {
+// CHECK:   subscript(i: Int32) -> Double { mutating get }
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   mutating func __operatorSubscriptConst(_ i: Int32) -> Double
-// CHECK:   subscript(i: Int32) -> Double { mutating get }
 // CHECK: }
 // CHECK: typealias TemplatedDoubleArrayByVal = __CxxTemplateInst19TemplatedArrayByValIdE
 
 
 // CHECK: struct TemplatedSubscriptArrayByVal {
+// CHECK:   subscript(i: T) -> T { mutating get }
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   mutating func __operatorSubscriptConst<T>(_ i: T) -> T
-// CHECK:   subscript(i: T) -> T { mutating get }
 // CHECK: }
 
 // CHECK: struct NonTrivialArrayByVal {
+// CHECK:   subscript(x: Int32) -> NonTrivial { mutating get }
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   mutating func __operatorSubscriptConst(_ x: Int32) -> NonTrivial
-// CHECK:   subscript(x: Int32) -> NonTrivial { mutating get }
 // CHECK: }
 // CHECK: struct PtrByVal {
+// CHECK:   subscript(x: Int32) -> UnsafeMutablePointer<Int32>! { mutating get }
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   mutating func __operatorSubscript(_ x: Int32) -> UnsafeMutablePointer<Int32>!
-// CHECK:   subscript(x: Int32) -> UnsafeMutablePointer<Int32>! { mutating get }
 // CHECK: }
 // CHECK: struct RefToPtr {
+// CHECK:   subscript(x: Int32) -> UnsafeMutablePointer<Int32>? { mutating get set }
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   mutating func __operatorSubscript(_ x: Int32) -> UnsafeMutablePointer<UnsafeMutablePointer<Int32>?>
-// CHECK:   subscript(x: Int32) -> UnsafeMutablePointer<Int32>? { mutating get set }
 // CHECK: }
 // CHECK: struct PtrToPtr {
+// CHECK:   subscript(x: Int32) -> UnsafeMutablePointer<UnsafeMutablePointer<Int32>?>! { mutating get }
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   mutating func __operatorSubscript(_ x: Int32) -> UnsafeMutablePointer<UnsafeMutablePointer<Int32>?>!
-// CHECK:   subscript(x: Int32) -> UnsafeMutablePointer<UnsafeMutablePointer<Int32>?>! { mutating get }
 // CHECK: }
 // CHECK: struct ConstOpPtrByVal {
+// CHECK:   subscript(x: Int32) -> UnsafePointer<Int32>! { get }
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>!
-// CHECK:   subscript(x: Int32) -> UnsafePointer<Int32>! { get }
 // CHECK: }
 // CHECK: struct ConstPtrByVal {
+// CHECK:   subscript(x: Int32) -> UnsafePointer<Int32>! { mutating get }
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   mutating func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>!
-// CHECK:   subscript(x: Int32) -> UnsafePointer<Int32>! { mutating get }
 // CHECK: }

--- a/test/Interop/Cxx/static/static-member-var-module-interface.swift
+++ b/test/Interop/Cxx/static/static-member-var-module-interface.swift
@@ -1,8 +1,8 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=StaticMemberVar -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
 
 // CHECK: struct WithStaticAndInstanceMember {
-// CHECK-NEXT:   static var myStatic: Int32
-// CHECK-NEXT:   var myInstance: Int32
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(myInstance: Int32)
+// CHECK-NEXT:   static var myStatic: Int32
+// CHECK-NEXT:   var myInstance: Int32
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/templates/canonical-types-module-interface.swift
+++ b/test/Interop/Cxx/templates/canonical-types-module-interface.swift
@@ -1,16 +1,16 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=CanonicalTypes -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
 
-// CHECK: struct __CxxTemplateInst12MagicWrapperI10IntWrapperE {
-// CHECK-NEXT:   var t: IntWrapper
+// CHECK:      struct __CxxTemplateInst12MagicWrapperI10IntWrapperE {
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(t: IntWrapper)
+// CHECK-NEXT:   var t: IntWrapper
 // CHECK-NEXT:   func getValuePlusArg(_ arg: Int32) -> Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct IntWrapper {
-// CHECK-NEXT:   var value: Int32
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(value: Int32)
 // CHECK-NEXT:   func getValue() -> Int32
+// CHECK-NEXT:   var value: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: typealias WrappedMagicNumberA = __CxxTemplateInst12MagicWrapperI10IntWrapperE
 // CHECK-NEXT: typealias WrappedMagicNumberB = __CxxTemplateInst12MagicWrapperI10IntWrapperE

--- a/test/Interop/Cxx/templates/class-template-with-typedef-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-with-typedef-module-interface.swift
@@ -1,8 +1,8 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateWithTypedef -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
 
 // CHECK: struct __CxxTemplateInst6LanderIcE {
-// CHECK:   typealias size_type = {{UInt|UInt32}}
 // CHECK:   init()
+// CHECK:   typealias size_type = {{UInt|UInt32}}
 // CHECK:   mutating func test(_: {{UInt|UInt32}})
 // CHECK: }
 // CHECK: typealias Surveyor = __CxxTemplateInst6LanderIcE

--- a/test/Interop/Cxx/templates/large-class-templates-module-interface.swift
+++ b/test/Interop/Cxx/templates/large-class-templates-module-interface.swift
@@ -4,8 +4,8 @@
 // CHECK: }
 
 // CHECK: struct __CxxTemplateInst22HasTypeWithSelfAsParamIiE {
-// CHECK:   typealias TT = __CxxTemplateInst22HasTypeWithSelfAsParamIS_IiEE
 // CHECK:   init()
+// CHECK:   typealias TT = __CxxTemplateInst22HasTypeWithSelfAsParamIS_IiEE
 // CHECK: }
 
 // CHECK: typealias WillBeInfinite = __CxxTemplateInst22HasTypeWithSelfAsParamIiE

--- a/test/Interop/Cxx/templates/member-templates-module-interface.swift
+++ b/test/Interop/Cxx/templates/member-templates-module-interface.swift
@@ -13,8 +13,8 @@
 // CHECK: }
 
 // CHECK: struct __CxxTemplateInst32TemplateClassWithMemberTemplatesIiE {
-// CHECK:   var value: Int32
 // CHECK:   init(_ val: Int32)
+// CHECK:   var value: Int32
 // CHECK:   mutating func setValue<U>(_ val: U)
 // CHECK: }
 

--- a/test/Interop/Cxx/templates/not-pre-defined-class-template-module-interface.swift
+++ b/test/Interop/Cxx/templates/not-pre-defined-class-template-module-interface.swift
@@ -1,15 +1,17 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=NotPreDefinedClassTemplate -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
 
-// CHECK: struct __CxxTemplateInst12MagicWrapperI10IntWrapperE {
-// CHECK-NEXT:   var t: IntWrapper
+// CHECK:      struct __CxxTemplateInst12MagicWrapperI10IntWrapperE {
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(t: IntWrapper)
+// CHECK-NEXT:   var t: IntWrapper
 // CHECK-NEXT:   func getValuePlusArg(_ arg: Int32) -> Int32
 // CHECK-NEXT: }
+
 // CHECK-NEXT: struct IntWrapper {
-// CHECK-NEXT:   var value: Int32
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(value: Int32)
 // CHECK-NEXT:   func getValue() -> Int32
+// CHECK-NEXT:   var value: Int32
 // CHECK-NEXT: }
+
 // CHECK-NEXT: typealias MagicallyWrappedIntWithoutDefinition = __CxxTemplateInst12MagicWrapperI10IntWrapperE

--- a/test/Interop/Cxx/templates/using-directive-module-interface.swift
+++ b/test/Interop/Cxx/templates/using-directive-module-interface.swift
@@ -1,15 +1,15 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=UsingDirective -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
 
-// CHECK: struct __CxxTemplateInst12MagicWrapperI10IntWrapperE {
-// CHECK-NEXT:   var t: IntWrapper
+// CHECK:      struct __CxxTemplateInst12MagicWrapperI10IntWrapperE {
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(t: IntWrapper)
+// CHECK-NEXT:   var t: IntWrapper
 // CHECK-NEXT:   func getValuePlusArg(_ arg: Int32) -> Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: struct IntWrapper {
-// CHECK-NEXT:   var value: Int32
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(value: Int32)
 // CHECK-NEXT:   func getValue() -> Int32
+// CHECK-NEXT:   var value: Int32
 // CHECK-NEXT: }
 // CHECK-NEXT: typealias UsingWrappedMagicNumber = __CxxTemplateInst12MagicWrapperI10IntWrapperE

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -116,35 +116,35 @@ extension FooRuncingOptions {
 }
 struct FooStruct1 {
 
-    var x: Int32
-
-    var y: Double
-
     init()
 
     init(x x: Int32, y y: Double)
+
+    var x: Int32
+
+    var y: Double
 }
 typealias FooStruct1Pointer = UnsafeMutablePointer<FooStruct1>
 struct FooStruct2 {
 
-    var x: Int32
-
-    var y: Double
-
     init()
 
     init(x x: Int32, y y: Double)
+
+    var x: Int32
+
+    var y: Double
 }
 typealias FooStructTypedef1 = FooStruct2
 struct FooStructTypedef2 {
 
-    var x: Int32
-
-    var y: Double
-
     init()
 
     init(x x: Int32, y y: Double)
+
+    var x: Int32
+
+    var y: Double
 }
 typealias FooTypedef1 = Int32
 var fooIntVar: Int32
@@ -241,11 +241,11 @@ func theLastDeclInFoo()
 func _internalTopLevelFunc()
 struct _InternalStruct {
 
-    var x: Int32
-
     init()
 
     init(x x: Int32)
+
+    var x: Int32
 }
 extension FooClassBase {
 
@@ -2089,79 +2089,79 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 3123,
-    key.length: 3
+    key.length: 4
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3127,
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3135,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 3140,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 3142,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3130,
+    key.offset: 3145,
     key.length: 5
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3141,
-    key.length: 3
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 3152,
+    key.length: 1
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3145,
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 3154,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Double",
     key.usr: "s:Sd",
-    key.offset: 3148,
+    key.offset: 3157,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3160,
-    key.length: 4
+    key.offset: 3170,
+    key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3172,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3177,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3179,
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3174,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3182,
+    key.offset: 3177,
     key.length: 5
   },
   {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3189,
-    key.length: 1
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3188,
+    key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3191,
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3192,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Double",
     key.usr: "s:Sd",
-    key.offset: 3194,
+    key.offset: 3195,
     key.length: 6
   },
   {
@@ -2201,79 +2201,79 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 3292,
-    key.length: 3
+    key.length: 4
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3296,
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3304,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 3309,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 3311,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3299,
+    key.offset: 3314,
     key.length: 5
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3310,
-    key.length: 3
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 3321,
+    key.length: 1
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3314,
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 3323,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Double",
     key.usr: "s:Sd",
-    key.offset: 3317,
+    key.offset: 3326,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3329,
-    key.length: 4
+    key.offset: 3339,
+    key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3341,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3346,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3348,
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3343,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3351,
+    key.offset: 3346,
     key.length: 5
   },
   {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3358,
-    key.length: 1
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3357,
+    key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3360,
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3361,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Double",
     key.usr: "s:Sd",
-    key.offset: 3363,
+    key.offset: 3364,
     key.length: 6
   },
   {
@@ -2306,79 +2306,79 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 3446,
-    key.length: 3
+    key.length: 4
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3450,
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3458,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 3463,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 3465,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3453,
+    key.offset: 3468,
     key.length: 5
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3464,
-    key.length: 3
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 3475,
+    key.length: 1
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3468,
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 3477,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Double",
     key.usr: "s:Sd",
-    key.offset: 3471,
+    key.offset: 3480,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3483,
-    key.length: 4
+    key.offset: 3493,
+    key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3495,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3500,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3502,
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3497,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3505,
+    key.offset: 3500,
     key.length: 5
   },
   {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3512,
-    key.length: 1
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3511,
+    key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3514,
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3515,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Double",
     key.usr: "s:Sd",
-    key.offset: 3517,
+    key.offset: 3518,
     key.length: 6
   },
   {
@@ -3688,45 +3688,45 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 5915,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5919,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int32",
-    key.usr: "s:s5Int32V",
-    key.offset: 5922,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5933,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5945,
+    key.offset: 5927,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 5950,
+    key.offset: 5932,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 5952,
+    key.offset: 5934,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 5955,
+    key.offset: 5937,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5949,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5953,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int32",
+    key.usr: "s:s5Int32V",
+    key.offset: 5956,
     key.length: 5
   },
   {
@@ -5530,26 +5530,10 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooStruct1</decl.name></decl.struct>",
     key.entities: [
       {
-        key.kind: source.lang.swift.decl.var.instance,
-        key.name: "x",
-        key.usr: "c:@S@FooStruct1@FI@x",
-        key.offset: 3123,
-        key.length: 12,
-        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>x</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type></decl.var.instance>"
-      },
-      {
-        key.kind: source.lang.swift.decl.var.instance,
-        key.name: "y",
-        key.usr: "c:@S@FooStruct1@FI@y",
-        key.offset: 3141,
-        key.length: 13,
-        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>y</decl.name>: <decl.var.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.type></decl.var.instance>"
-      },
-      {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
         key.usr: "s:So10FooStruct1VABycfc",
-        key.offset: 3160,
+        key.offset: 3123,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
       },
@@ -5557,7 +5541,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:y:)",
         key.usr: "s:So10FooStruct1V1x1yABs5Int32V_Sdtcfc",
-        key.offset: 3172,
+        key.offset: 3135,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -5565,17 +5549,33 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "x",
             key.name: "x",
-            key.offset: 3182,
+            key.offset: 3145,
             key.length: 5
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "y",
             key.name: "y",
-            key.offset: 3194,
+            key.offset: 3157,
             key.length: 6
           }
         ]
+      },
+      {
+        key.kind: source.lang.swift.decl.var.instance,
+        key.name: "x",
+        key.usr: "c:@S@FooStruct1@FI@x",
+        key.offset: 3170,
+        key.length: 12,
+        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>x</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type></decl.var.instance>"
+      },
+      {
+        key.kind: source.lang.swift.decl.var.instance,
+        key.name: "y",
+        key.usr: "c:@S@FooStruct1@FI@y",
+        key.offset: 3188,
+        key.length: 13,
+        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>y</decl.name>: <decl.var.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.type></decl.var.instance>"
       }
     ]
   },
@@ -5608,26 +5608,10 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooStruct2</decl.name></decl.struct>",
     key.entities: [
       {
-        key.kind: source.lang.swift.decl.var.instance,
-        key.name: "x",
-        key.usr: "c:@S@FooStruct2@FI@x",
-        key.offset: 3292,
-        key.length: 12,
-        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>x</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type></decl.var.instance>"
-      },
-      {
-        key.kind: source.lang.swift.decl.var.instance,
-        key.name: "y",
-        key.usr: "c:@S@FooStruct2@FI@y",
-        key.offset: 3310,
-        key.length: 13,
-        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>y</decl.name>: <decl.var.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.type></decl.var.instance>"
-      },
-      {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
         key.usr: "s:So10FooStruct2VABycfc",
-        key.offset: 3329,
+        key.offset: 3292,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
       },
@@ -5635,7 +5619,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:y:)",
         key.usr: "s:So10FooStruct2V1x1yABs5Int32V_Sdtcfc",
-        key.offset: 3341,
+        key.offset: 3304,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -5643,17 +5627,33 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "x",
             key.name: "x",
-            key.offset: 3351,
+            key.offset: 3314,
             key.length: 5
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "y",
             key.name: "y",
-            key.offset: 3363,
+            key.offset: 3326,
             key.length: 6
           }
         ]
+      },
+      {
+        key.kind: source.lang.swift.decl.var.instance,
+        key.name: "x",
+        key.usr: "c:@S@FooStruct2@FI@x",
+        key.offset: 3339,
+        key.length: 12,
+        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>x</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type></decl.var.instance>"
+      },
+      {
+        key.kind: source.lang.swift.decl.var.instance,
+        key.name: "y",
+        key.usr: "c:@S@FooStruct2@FI@y",
+        key.offset: 3357,
+        key.length: 13,
+        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>y</decl.name>: <decl.var.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.type></decl.var.instance>"
       }
     ]
   },
@@ -5674,26 +5674,10 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooStructTypedef2</decl.name></decl.struct>",
     key.entities: [
       {
-        key.kind: source.lang.swift.decl.var.instance,
-        key.name: "x",
-        key.usr: "c:@SA@FooStructTypedef2@FI@x",
-        key.offset: 3446,
-        key.length: 12,
-        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>x</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type></decl.var.instance>"
-      },
-      {
-        key.kind: source.lang.swift.decl.var.instance,
-        key.name: "y",
-        key.usr: "c:@SA@FooStructTypedef2@FI@y",
-        key.offset: 3464,
-        key.length: 13,
-        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>y</decl.name>: <decl.var.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.type></decl.var.instance>"
-      },
-      {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
         key.usr: "s:So17FooStructTypedef2aABycfc",
-        key.offset: 3483,
+        key.offset: 3446,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
       },
@@ -5701,7 +5685,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:y:)",
         key.usr: "s:So17FooStructTypedef2a1x1yABs5Int32V_Sdtcfc",
-        key.offset: 3495,
+        key.offset: 3458,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -5709,17 +5693,33 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "x",
             key.name: "x",
-            key.offset: 3505,
+            key.offset: 3468,
             key.length: 5
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "y",
             key.name: "y",
-            key.offset: 3517,
+            key.offset: 3480,
             key.length: 6
           }
         ]
+      },
+      {
+        key.kind: source.lang.swift.decl.var.instance,
+        key.name: "x",
+        key.usr: "c:@SA@FooStructTypedef2@FI@x",
+        key.offset: 3493,
+        key.length: 12,
+        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>x</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type></decl.var.instance>"
+      },
+      {
+        key.kind: source.lang.swift.decl.var.instance,
+        key.name: "y",
+        key.usr: "c:@SA@FooStructTypedef2@FI@y",
+        key.offset: 3511,
+        key.length: 13,
+        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>y</decl.name>: <decl.var.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.type></decl.var.instance>"
       }
     ]
   },
@@ -6443,18 +6443,10 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>_InternalStruct</decl.name></decl.struct>",
     key.entities: [
       {
-        key.kind: source.lang.swift.decl.var.instance,
-        key.name: "x",
-        key.usr: "c:@S@_InternalStruct@FI@x",
-        key.offset: 5915,
-        key.length: 12,
-        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>x</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type></decl.var.instance>"
-      },
-      {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
         key.usr: "s:So15_InternalStructVABycfc",
-        key.offset: 5933,
+        key.offset: 5915,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
       },
@@ -6462,7 +6454,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:)",
         key.usr: "s:So15_InternalStructV1xABs5Int32V_tcfc",
-        key.offset: 5945,
+        key.offset: 5927,
         key.length: 16,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -6470,10 +6462,18 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "x",
             key.name: "x",
-            key.offset: 5955,
+            key.offset: 5937,
             key.length: 5
           }
         ]
+      },
+      {
+        key.kind: source.lang.swift.decl.var.instance,
+        key.name: "x",
+        key.usr: "c:@S@_InternalStruct@FI@x",
+        key.offset: 5949,
+        key.length: 12,
+        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>x</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type></decl.var.instance>"
       }
     ]
   },

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -71,37 +71,37 @@ public struct FooRuncingOptions : OptionSet {
 
 public struct FooStruct1 {
 
-    public var x: Int32
-
-    public var y: Double
-
     public init()
 
     public init(x: Int32, y: Double)
+
+    public var x: Int32
+
+    public var y: Double
 }
 public typealias FooStruct1Pointer = UnsafeMutablePointer<FooStruct1>
 
 public struct FooStruct2 {
 
-    public var x: Int32
-
-    public var y: Double
-
     public init()
 
     public init(x: Int32, y: Double)
+
+    public var x: Int32
+
+    public var y: Double
 }
 public typealias FooStructTypedef1 = FooStruct2
 
 public struct FooStructTypedef2 {
 
-    public var x: Int32
-
-    public var y: Double
-
     public init()
 
     public init(x: Int32, y: Double)
+
+    public var x: Int32
+
+    public var y: Double
 }
 
 /// Aaa.  FooTypedef1.  Bbb.
@@ -270,11 +270,11 @@ public func _internalTopLevelFunc()
 
 public struct _InternalStruct {
 
-    public var x: Int32
-
     public init()
 
     public init(x: Int32)
+
+    public var x: Int32
 }
 
 extension FooClassBase {
@@ -1036,76 +1036,76 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 1465,
-    key.length: 3
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1477,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1484,
+    key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1469,
+    key.offset: 1489,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1472,
+    key.offset: 1492,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1499,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1502,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1515,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1522,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1526,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1529,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1483,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1490,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1494,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1497,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1509,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1516,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1528,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1535,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 1540,
-    key.length: 1
+    key.length: 6
   },
   {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1543,
-    key.length: 5
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1547,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1550,
+    key.offset: 1551,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1553,
+    key.offset: 1554,
     key.length: 6
   },
   {
@@ -1156,76 +1156,76 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 1673,
-    key.length: 3
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1685,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1692,
+    key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1677,
+    key.offset: 1697,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1680,
+    key.offset: 1700,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1707,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1710,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1723,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1730,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1734,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1737,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1691,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1698,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1702,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1705,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1717,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1724,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1736,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1743,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 1748,
-    key.length: 1
+    key.length: 6
   },
   {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1751,
-    key.length: 5
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1755,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1758,
+    key.offset: 1759,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1761,
+    key.offset: 1762,
     key.length: 6
   },
   {
@@ -1271,76 +1271,76 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 1866,
-    key.length: 3
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1878,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1885,
+    key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1870,
+    key.offset: 1890,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1873,
+    key.offset: 1893,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1900,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1903,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1916,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1923,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1927,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1930,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1884,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1891,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1895,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1898,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1910,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1917,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1929,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1936,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 1941,
-    key.length: 1
+    key.length: 6
   },
   {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1944,
-    key.length: 5
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1948,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1951,
+    key.offset: 1952,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1954,
+    key.offset: 1955,
     key.length: 6
   },
   {
@@ -2891,46 +2891,46 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 5515,
-    key.length: 3
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5527,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5534,
+    key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5519,
+    key.offset: 5539,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5522,
+    key.offset: 5542,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5533,
+    key.offset: 5554,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5540,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5552,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5559,
-    key.length: 4
+    key.offset: 5561,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5564,
+    key.offset: 5565,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5567,
+    key.offset: 5568,
     key.length: 5
   },
   {
@@ -3756,25 +3756,25 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1472,
+    key.offset: 1492,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1497,
+    key.offset: 1502,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1543,
+    key.offset: 1529,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1553,
+    key.offset: 1554,
     key.length: 6,
     key.is_system: 1
   },
@@ -3791,25 +3791,25 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1680,
+    key.offset: 1700,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1705,
+    key.offset: 1710,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1751,
+    key.offset: 1737,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1761,
+    key.offset: 1762,
     key.length: 6,
     key.is_system: 1
   },
@@ -3820,25 +3820,25 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1873,
+    key.offset: 1893,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1898,
+    key.offset: 1903,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1944,
+    key.offset: 1930,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1954,
+    key.offset: 1955,
     key.length: 6,
     key.is_system: 1
   },
@@ -4150,13 +4150,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5522,
+    key.offset: 5542,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5567,
+    key.offset: 5568,
     key.length: 5,
     key.is_system: 1
   },
@@ -4882,18 +4882,70 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.substructure: [
       {
+        key.kind: source.lang.swift.decl.function.method.instance,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "init()",
+        key.offset: 1465,
+        key.length: 6,
+        key.nameoffset: 1465,
+        key.namelength: 6,
+        key.attributes: [
+          {
+            key.offset: 1458,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      },
+      {
+        key.kind: source.lang.swift.decl.function.method.instance,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "init(x:y:)",
+        key.offset: 1484,
+        key.length: 25,
+        key.nameoffset: 1484,
+        key.namelength: 25,
+        key.attributes: [
+          {
+            key.offset: 1477,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ],
+        key.substructure: [
+          {
+            key.kind: source.lang.swift.decl.var.parameter,
+            key.name: "x",
+            key.offset: 1489,
+            key.length: 8,
+            key.typename: "Int32",
+            key.nameoffset: 1489,
+            key.namelength: 1
+          },
+          {
+            key.kind: source.lang.swift.decl.var.parameter,
+            key.name: "y",
+            key.offset: 1499,
+            key.length: 9,
+            key.typename: "Double",
+            key.nameoffset: 1499,
+            key.namelength: 1
+          }
+        ]
+      },
+      {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 1465,
+        key.offset: 1522,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 1469,
+        key.nameoffset: 1526,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1458,
+            key.offset: 1515,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4904,68 +4956,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "y",
-        key.offset: 1490,
+        key.offset: 1547,
         key.length: 13,
         key.typename: "Double",
-        key.nameoffset: 1494,
+        key.nameoffset: 1551,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1483,
-            key.length: 6,
-            key.attribute: source.decl.attribute.public
-          }
-        ]
-      },
-      {
-        key.kind: source.lang.swift.decl.function.method.instance,
-        key.accessibility: source.lang.swift.accessibility.public,
-        key.name: "init()",
-        key.offset: 1516,
-        key.length: 6,
-        key.nameoffset: 1516,
-        key.namelength: 6,
-        key.attributes: [
-          {
-            key.offset: 1509,
-            key.length: 6,
-            key.attribute: source.decl.attribute.public
-          }
-        ]
-      },
-      {
-        key.kind: source.lang.swift.decl.function.method.instance,
-        key.accessibility: source.lang.swift.accessibility.public,
-        key.name: "init(x:y:)",
-        key.offset: 1535,
-        key.length: 25,
-        key.nameoffset: 1535,
-        key.namelength: 25,
-        key.attributes: [
-          {
-            key.offset: 1528,
-            key.length: 6,
-            key.attribute: source.decl.attribute.public
-          }
-        ],
-        key.substructure: [
-          {
-            key.kind: source.lang.swift.decl.var.parameter,
-            key.name: "x",
             key.offset: 1540,
-            key.length: 8,
-            key.typename: "Int32",
-            key.nameoffset: 1540,
-            key.namelength: 1
-          },
-          {
-            key.kind: source.lang.swift.decl.var.parameter,
-            key.name: "y",
-            key.offset: 1550,
-            key.length: 9,
-            key.typename: "Double",
-            key.nameoffset: 1550,
-            key.namelength: 1
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
           }
         ]
       }
@@ -5006,18 +5006,70 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.substructure: [
       {
+        key.kind: source.lang.swift.decl.function.method.instance,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "init()",
+        key.offset: 1673,
+        key.length: 6,
+        key.nameoffset: 1673,
+        key.namelength: 6,
+        key.attributes: [
+          {
+            key.offset: 1666,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      },
+      {
+        key.kind: source.lang.swift.decl.function.method.instance,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "init(x:y:)",
+        key.offset: 1692,
+        key.length: 25,
+        key.nameoffset: 1692,
+        key.namelength: 25,
+        key.attributes: [
+          {
+            key.offset: 1685,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ],
+        key.substructure: [
+          {
+            key.kind: source.lang.swift.decl.var.parameter,
+            key.name: "x",
+            key.offset: 1697,
+            key.length: 8,
+            key.typename: "Int32",
+            key.nameoffset: 1697,
+            key.namelength: 1
+          },
+          {
+            key.kind: source.lang.swift.decl.var.parameter,
+            key.name: "y",
+            key.offset: 1707,
+            key.length: 9,
+            key.typename: "Double",
+            key.nameoffset: 1707,
+            key.namelength: 1
+          }
+        ]
+      },
+      {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 1673,
+        key.offset: 1730,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 1677,
+        key.nameoffset: 1734,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1666,
+            key.offset: 1723,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5028,68 +5080,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "y",
-        key.offset: 1698,
+        key.offset: 1755,
         key.length: 13,
         key.typename: "Double",
-        key.nameoffset: 1702,
+        key.nameoffset: 1759,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1691,
-            key.length: 6,
-            key.attribute: source.decl.attribute.public
-          }
-        ]
-      },
-      {
-        key.kind: source.lang.swift.decl.function.method.instance,
-        key.accessibility: source.lang.swift.accessibility.public,
-        key.name: "init()",
-        key.offset: 1724,
-        key.length: 6,
-        key.nameoffset: 1724,
-        key.namelength: 6,
-        key.attributes: [
-          {
-            key.offset: 1717,
-            key.length: 6,
-            key.attribute: source.decl.attribute.public
-          }
-        ]
-      },
-      {
-        key.kind: source.lang.swift.decl.function.method.instance,
-        key.accessibility: source.lang.swift.accessibility.public,
-        key.name: "init(x:y:)",
-        key.offset: 1743,
-        key.length: 25,
-        key.nameoffset: 1743,
-        key.namelength: 25,
-        key.attributes: [
-          {
-            key.offset: 1736,
-            key.length: 6,
-            key.attribute: source.decl.attribute.public
-          }
-        ],
-        key.substructure: [
-          {
-            key.kind: source.lang.swift.decl.var.parameter,
-            key.name: "x",
             key.offset: 1748,
-            key.length: 8,
-            key.typename: "Int32",
-            key.nameoffset: 1748,
-            key.namelength: 1
-          },
-          {
-            key.kind: source.lang.swift.decl.var.parameter,
-            key.name: "y",
-            key.offset: 1758,
-            key.length: 9,
-            key.typename: "Double",
-            key.nameoffset: 1758,
-            key.namelength: 1
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
           }
         ]
       }
@@ -5130,18 +5130,70 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.substructure: [
       {
+        key.kind: source.lang.swift.decl.function.method.instance,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "init()",
+        key.offset: 1866,
+        key.length: 6,
+        key.nameoffset: 1866,
+        key.namelength: 6,
+        key.attributes: [
+          {
+            key.offset: 1859,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      },
+      {
+        key.kind: source.lang.swift.decl.function.method.instance,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "init(x:y:)",
+        key.offset: 1885,
+        key.length: 25,
+        key.nameoffset: 1885,
+        key.namelength: 25,
+        key.attributes: [
+          {
+            key.offset: 1878,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ],
+        key.substructure: [
+          {
+            key.kind: source.lang.swift.decl.var.parameter,
+            key.name: "x",
+            key.offset: 1890,
+            key.length: 8,
+            key.typename: "Int32",
+            key.nameoffset: 1890,
+            key.namelength: 1
+          },
+          {
+            key.kind: source.lang.swift.decl.var.parameter,
+            key.name: "y",
+            key.offset: 1900,
+            key.length: 9,
+            key.typename: "Double",
+            key.nameoffset: 1900,
+            key.namelength: 1
+          }
+        ]
+      },
+      {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 1866,
+        key.offset: 1923,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 1870,
+        key.nameoffset: 1927,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1859,
+            key.offset: 1916,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5152,68 +5204,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "y",
-        key.offset: 1891,
+        key.offset: 1948,
         key.length: 13,
         key.typename: "Double",
-        key.nameoffset: 1895,
+        key.nameoffset: 1952,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1884,
-            key.length: 6,
-            key.attribute: source.decl.attribute.public
-          }
-        ]
-      },
-      {
-        key.kind: source.lang.swift.decl.function.method.instance,
-        key.accessibility: source.lang.swift.accessibility.public,
-        key.name: "init()",
-        key.offset: 1917,
-        key.length: 6,
-        key.nameoffset: 1917,
-        key.namelength: 6,
-        key.attributes: [
-          {
-            key.offset: 1910,
-            key.length: 6,
-            key.attribute: source.decl.attribute.public
-          }
-        ]
-      },
-      {
-        key.kind: source.lang.swift.decl.function.method.instance,
-        key.accessibility: source.lang.swift.accessibility.public,
-        key.name: "init(x:y:)",
-        key.offset: 1936,
-        key.length: 25,
-        key.nameoffset: 1936,
-        key.namelength: 25,
-        key.attributes: [
-          {
-            key.offset: 1929,
-            key.length: 6,
-            key.attribute: source.decl.attribute.public
-          }
-        ],
-        key.substructure: [
-          {
-            key.kind: source.lang.swift.decl.var.parameter,
-            key.name: "x",
             key.offset: 1941,
-            key.length: 8,
-            key.typename: "Int32",
-            key.nameoffset: 1941,
-            key.namelength: 1
-          },
-          {
-            key.kind: source.lang.swift.decl.var.parameter,
-            key.name: "y",
-            key.offset: 1951,
-            key.length: 9,
-            key.typename: "Double",
-            key.nameoffset: 1951,
-            key.namelength: 1
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
           }
         ]
       }
@@ -6451,15 +6451,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.substructure: [
       {
-        key.kind: source.lang.swift.decl.var.instance,
+        key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
-        key.setter_accessibility: source.lang.swift.accessibility.public,
-        key.name: "x",
+        key.name: "init()",
         key.offset: 5515,
-        key.length: 12,
-        key.typename: "Int32",
-        key.nameoffset: 5519,
-        key.namelength: 1,
+        key.length: 6,
+        key.nameoffset: 5515,
+        key.namelength: 6,
         key.attributes: [
           {
             key.offset: 5508,
@@ -6471,30 +6469,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
-        key.name: "init()",
-        key.offset: 5540,
-        key.length: 6,
-        key.nameoffset: 5540,
-        key.namelength: 6,
-        key.attributes: [
-          {
-            key.offset: 5533,
-            key.length: 6,
-            key.attribute: source.decl.attribute.public
-          }
-        ]
-      },
-      {
-        key.kind: source.lang.swift.decl.function.method.instance,
-        key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:)",
-        key.offset: 5559,
+        key.offset: 5534,
         key.length: 14,
-        key.nameoffset: 5559,
+        key.nameoffset: 5534,
         key.namelength: 14,
         key.attributes: [
           {
-            key.offset: 5552,
+            key.offset: 5527,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6503,11 +6485,29 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 5564,
+            key.offset: 5539,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 5564,
+            key.nameoffset: 5539,
             key.namelength: 1
+          }
+        ]
+      },
+      {
+        key.kind: source.lang.swift.decl.var.instance,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.setter_accessibility: source.lang.swift.accessibility.public,
+        key.name: "x",
+        key.offset: 5561,
+        key.length: 12,
+        key.typename: "Int32",
+        key.nameoffset: 5565,
+        key.namelength: 1,
+        key.attributes: [
+          {
+            key.offset: 5554,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
           }
         ]
       }

--- a/test/SourceKit/InterfaceGen/gen_header.swift.header2.response
+++ b/test/SourceKit/InterfaceGen/gen_header.swift.header2.response
@@ -1,6 +1,10 @@
 
 public struct NUPixelSize {
 
+    public init()
+
+    public init(width: Int, height: Int)
+
     /** Some clang-style comments */
     public var width: Int
 
@@ -8,10 +12,6 @@ public struct NUPixelSize {
      * Some clang-style comments
      */
     public var height: Int
-
-    public init()
-
-    public init(width: Int, height: Int)
 }
 
 [
@@ -31,118 +31,118 @@ public struct NUPixelSize {
     key.length: 11
   },
   {
-    key.kind: source.lang.swift.syntaxtype.doccomment,
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 34,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 41,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 53,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 60,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 65,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 72,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 77,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 85,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.doccomment,
+    key.offset: 95,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 71,
+    key.offset: 132,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 78,
+    key.offset: 139,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 82,
+    key.offset: 143,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 89,
+    key.offset: 150,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 98,
+    key.offset: 159,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 147,
+    key.offset: 208,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 154,
+    key.offset: 215,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 158,
+    key.offset: 219,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 166,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 175,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 182,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 194,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 201,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 206,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 213,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 218,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 226,
+    key.offset: 227,
     key.length: 3
   }
 ]
 [
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 89,
+    key.offset: 72,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 166,
+    key.offset: 85,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 213,
+    key.offset: 150,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 226,
+    key.offset: 227,
     key.length: 3,
     key.is_system: 1
   }
@@ -167,20 +167,72 @@ public struct NUPixelSize {
     ],
     key.substructure: [
       {
+        key.kind: source.lang.swift.decl.function.method.instance,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "init()",
+        key.offset: 41,
+        key.length: 6,
+        key.nameoffset: 41,
+        key.namelength: 6,
+        key.attributes: [
+          {
+            key.offset: 34,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      },
+      {
+        key.kind: source.lang.swift.decl.function.method.instance,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "init(width:height:)",
+        key.offset: 60,
+        key.length: 29,
+        key.nameoffset: 60,
+        key.namelength: 29,
+        key.attributes: [
+          {
+            key.offset: 53,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ],
+        key.substructure: [
+          {
+            key.kind: source.lang.swift.decl.var.parameter,
+            key.name: "width",
+            key.offset: 65,
+            key.length: 10,
+            key.typename: "Int",
+            key.nameoffset: 65,
+            key.namelength: 5
+          },
+          {
+            key.kind: source.lang.swift.decl.var.parameter,
+            key.name: "height",
+            key.offset: 77,
+            key.length: 11,
+            key.typename: "Int",
+            key.nameoffset: 77,
+            key.namelength: 6
+          }
+        ]
+      },
+      {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "width",
-        key.offset: 78,
+        key.offset: 139,
         key.length: 14,
         key.typename: "Int",
-        key.nameoffset: 82,
+        key.nameoffset: 143,
         key.namelength: 5,
-        key.docoffset: 34,
+        key.docoffset: 95,
         key.doclength: 32,
         key.attributes: [
           {
-            key.offset: 71,
+            key.offset: 132,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -191,70 +243,18 @@ public struct NUPixelSize {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "height",
-        key.offset: 154,
+        key.offset: 215,
         key.length: 15,
         key.typename: "Int",
-        key.nameoffset: 158,
+        key.nameoffset: 219,
         key.namelength: 6,
-        key.docoffset: 98,
+        key.docoffset: 159,
         key.doclength: 44,
         key.attributes: [
           {
-            key.offset: 147,
+            key.offset: 208,
             key.length: 6,
             key.attribute: source.decl.attribute.public
-          }
-        ]
-      },
-      {
-        key.kind: source.lang.swift.decl.function.method.instance,
-        key.accessibility: source.lang.swift.accessibility.public,
-        key.name: "init()",
-        key.offset: 182,
-        key.length: 6,
-        key.nameoffset: 182,
-        key.namelength: 6,
-        key.attributes: [
-          {
-            key.offset: 175,
-            key.length: 6,
-            key.attribute: source.decl.attribute.public
-          }
-        ]
-      },
-      {
-        key.kind: source.lang.swift.decl.function.method.instance,
-        key.accessibility: source.lang.swift.accessibility.public,
-        key.name: "init(width:height:)",
-        key.offset: 201,
-        key.length: 29,
-        key.nameoffset: 201,
-        key.namelength: 29,
-        key.attributes: [
-          {
-            key.offset: 194,
-            key.length: 6,
-            key.attribute: source.decl.attribute.public
-          }
-        ],
-        key.substructure: [
-          {
-            key.kind: source.lang.swift.decl.var.parameter,
-            key.name: "width",
-            key.offset: 206,
-            key.length: 10,
-            key.typename: "Int",
-            key.nameoffset: 206,
-            key.namelength: 5
-          },
-          {
-            key.kind: source.lang.swift.decl.var.parameter,
-            key.name: "height",
-            key.offset: 218,
-            key.length: 11,
-            key.typename: "Int",
-            key.nameoffset: 218,
-            key.namelength: 6
           }
         ]
       }


### PR DESCRIPTION
If possible, add imported members to the StructDecl's LookupTable rather than adding them directly as members. This will fix the issues with ordering that #39436 poorly attempted to solve during IRGen.

This also allows us to break out most of the test changes from #39436.