### PR TITLE
[SR-14987] Fix bug in name binding in presence of default protocol witnesses 

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -701,6 +701,15 @@ static void recordShadowedDecls(ArrayRef<ValueDecl *> decls,
     // attempt to desugar itself.
     if (decl->isRecursiveValidation())
       continue;
+    
+    // Check if this decl is a default witness to a protocol's requirement.
+    if (auto extension = dyn_cast<ExtensionDecl>(decl->getDeclContext())) {
+      if (isa<ProtocolDecl>(extension->getExtendedNominal()))
+        shadowed.insert(decl);
+      // FIXME: unconditionally shadowing such decls is probably too naive.
+      // what if we have multiple protocols with similarly named requirements
+      // that are satisfied by default witnesses? We'd shadow all of them!
+    }
 
     // Record this declaration based on its signature.
     auto *dc = decl->getInnermostDeclContext();

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -701,15 +701,6 @@ static void recordShadowedDecls(ArrayRef<ValueDecl *> decls,
     // attempt to desugar itself.
     if (decl->isRecursiveValidation())
       continue;
-    
-    // Check if this decl is a default witness to a protocol's requirement.
-    if (auto extension = dyn_cast<ExtensionDecl>(decl->getDeclContext())) {
-      if (isa<ProtocolDecl>(extension->getExtendedNominal()))
-        shadowed.insert(decl);
-      // FIXME: unconditionally shadowing such decls is probably too naive.
-      // what if we have multiple protocols with similarly named requirements
-      // that are satisfied by default witnesses? We'd shadow all of them!
-    }
 
     // Record this declaration based on its signature.
     auto *dc = decl->getInnermostDeclContext();

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -192,9 +192,6 @@ namespace {
         return;
       }
 
-      // FIXME: the "isa<ProtocolDecl>()" check will be wrong for
-      // default implementations in protocols.
-      //
       // If we have an imported conformance or the witness could
       // not be deserialized, getWitnessDecl() will just return
       // the requirement, so just drop the lookup result here.

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -195,8 +195,22 @@ namespace {
       // If we have an imported conformance or the witness could
       // not be deserialized, getWitnessDecl() will just return
       // the requirement, so just drop the lookup result here.
-      if (witness && !isa<ProtocolDecl>(witness->getDeclContext()))
-        addResult(witness);
+      if (witness) {
+        bool defaultWitness = false;
+        
+        // Check if this decl is a default witness to a protocol's requirement.
+        if (auto ext = dyn_cast<ExtensionDecl>(witness->getDeclContext())) {
+          if (isa<ProtocolDecl>(ext->getExtendedNominal()))
+            defaultWitness = true;
+          // FIXME: unconditionally skipping such decls is probably too naive.
+          // what if we have multiple protocols with similarly named
+          // requirements that are satisfied by default witnesses?
+          // We'd shadow all of them, I think.
+        }
+        
+        if (!defaultWitness && !isa<ProtocolDecl>(witness->getDeclContext()))
+          addResult(witness);
+      }
     }
   };
 } // end anonymous namespace

--- a/test/NameLookup/default_witness_bug.swift
+++ b/test/NameLookup/default_witness_bug.swift
@@ -1,0 +1,48 @@
+// RUN: %target-run-simple-swift(-D BAD) | %FileCheck %s
+// RUN: %target-run-simple-swift | %FileCheck %s
+
+// REQUIRES: executable_test
+
+public struct Logger {
+  var name: String = "bob" // to prevent rematerialization
+ }
+
+public protocol NetworkProtocol {
+  var defaultLogger: Logger? { get }
+  func send(logger: Logger?)
+}
+
+extension NetworkProtocol {
+    public var defaultLogger: Logger? { nil } // default witness
+}
+
+struct Implementation<Client: NetworkProtocol>: NetworkProtocol {
+  let defaultLogger: Logger // does NOT witness NetworkProtocol.defaultLogger
+  let client: Client
+
+  func send(logger: Logger?) {
+    #if BAD
+      // !! will access: NetworkProtocol.defaultLogger
+      self.client.send(logger: logger ?? self.defaultLogger)
+    #else
+      // !! will access: Implementation.defaultLogger
+      let arg = logger ?? self.defaultLogger
+      self.client.send(logger: arg)
+    #endif
+  }
+}
+
+struct Outputter: NetworkProtocol {
+  func send(logger maybeLogger: Logger?) {
+    guard let logger = maybeLogger else {
+      print("nil")
+      return
+    }
+    print(logger.name)
+  }
+}
+
+let impl = Implementation(defaultLogger: Logger(), client: Outputter())
+impl.send(logger: nil)
+
+// CHECK: bob


### PR DESCRIPTION
Protocol requirements that have default witnesses (or implementations) can be shadowed by an instance member of the conforming type that has the same name as the requirement. This situation is best described with an example:

```swift
protocol P {
  var cat: String { get }
  var dog: String? { get } 
}

// default implementations
extension P {
  var cat: String { "Cookie" }
  var dog: String? { nil }
}

struct S: P {
  var cat: Int = 10    // does NOT witness P.cat: String vs Int
  var dog: String = "Spot" // does NOT witness P.dog: String? vs String
}

let s = S()
print(s.cat)        // prints 10
print((s as P).cat) // prints Cookie

print(s.dog)        // prints Spot
print((s as P).dog) // prints nil
```

The default witness is not used when the lookup happens through a value of the conforming type. If the value is an existential, then the dispatch to the protocol's witness happens, as seen in the example above.

The name binding phase does not handle this in a robust way and can sometimes choose the wrong declaration. A problem with name binding was reported in [SR-14987](https://bugs.swift.org/browse/SR-14987) and this PR contains a distilled reproducer and fix for that bug.

This PR is a work-in-progress 🚧

rdar://81255957