### PR TITLE
Add ABI baseline and checking for _Concurrency library on macOS

### DIFF
--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -1,0 +1,217 @@
+// RUN: %empty-directory(%t.tmp)
+// mkdir %t.tmp/module-cache && mkdir %t.tmp/dummy.sdk
+// RUN: %api-digester -diagnose-sdk -module _Concurrency -o %t.tmp/changes.txt -module-cache-path %t.tmp/module-cache -sdk %t.tmp/dummy.sdk -abi -avoid-location
+// RUN: %clang -E -P -x c %S/stability-concurrency-abi.test -o - > %t.tmp/stability-concurrency-abi.swift.expected
+// RUN: %clang -E -P -x c %t.tmp/stability-concurrency-abi.swift.expected -o - | sed '/^\s*$/d' | sort > %t.tmp/stability-concurrency-abi.swift.expected.sorted
+// RUN: %clang -E -P -x c %t.tmp/changes.txt -o - | sed -E -e '/^\s*$/d' -e 's/ in _[0-9A-F]{32}/ in #UNSTABLE ID#/g' | sort > %t.tmp/changes.txt.tmp
+// RUN: diff -u %t.tmp/stability-concurrency-abi.swift.expected.sorted %t.tmp/changes.txt.tmp
+
+// *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment below.)
+
+// Welcome, Build Wrangler!
+//
+// This file lists APIs that are unique to stdlib builds with assertions.
+// (It is combined with the stability-stdlib-abi-without-asserts.test file
+// to generate a full list of potentially breaking API changes. In most cases
+// you'll want to edit that file instead of this one.)
+//
+// A failure in this test indicates that there is a potential breaking change in
+// the Standard Library. If you observe a failure outside of a PR test, please
+// reach out to the Standard Library team directly to make sure this gets
+// resolved quickly! If your own PR fails in this test, you probably have an
+// ABI- or source-breaking change in your commits. Please go and fix it.
+//
+// Please DO NOT DISABLE THIS TEST. In addition to ignoring the current set of
+// ABI breaks, XFAILing this test also silences any future ABI breaks that may
+// land on this branch, which simply generates extra work for the next person
+// that picks up the mess.
+//
+// Instead of disabling this test, consider extending the list of expected
+// changes at the bottom. (You'll also need to do this if your own PR triggers
+// false positives, or if you have special permission to break things.) You can
+// find a diff of what needs to be added in the output of the failed test run.
+// The order of lines doesn't matter, and you can also include comments to refer
+// to any bugs you filed. Remember that in almost all cases you'll want to edit
+// the stability-stdlib-abi-without-asserts.test file instead of this one.
+//
+// Thank you for your help ensuring the stdlib remains compatible with its past!
+//                                            -- Your friendly stdlib engineers
+
+// *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)
+
+// SR-13362
+// We currently only have a baseline for Intel CPUs on macOS.
+// REQUIRES: OS=macosx
+// REQUIRES: CPU=x86_64
+// REQUIRES: concurrency
+
+// The digester can incorrectly register a generic signature change when
+// declarations are shuffled. rdar://problem/46618883
+// UNSUPPORTED: swift_evolve
+
+// *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)
+Accessor Task._task.Get() has generic signature change from <Success, Failure where Failure : Swift.Error> to <Success, Failure where Success : Swift.Sendable, Failure : Swift.Error>
+Accessor Task.hashValue.Get() has generic signature change from <Success, Failure where Failure : Swift.Error> to <Success, Failure where Success : Swift.Sendable, Failure : Swift.Error>
+Accessor Task.isCancelled.Get() has generic signature change from <Success, Failure where Failure : Swift.Error> to <Success, Failure where Success : Swift.Sendable, Failure : Swift.Error>
+Accessor Task.result.Get() has generic signature change from <Success, Failure where Failure : Swift.Error> to <Success, Failure where Success : Swift.Sendable, Failure : Swift.Error>
+Accessor Task.value.Get() has generic signature change from <Success, Failure where Failure : Swift.Error> to <Success, Failure where Success : Swift.Sendable, Failure : Swift.Error>
+Accessor Task.value.Get() has generic signature change from <Success, Failure where Failure == Swift.Never> to <Success, Failure where Success : Swift.Sendable, Failure == Swift.Never>
+Accessor TaskGroup.Iterator.finished.Get() has generic signature change from <ChildTaskResult> to <ChildTaskResult where ChildTaskResult : Swift.Sendable>
+Accessor TaskGroup.Iterator.finished.Modify() has generic signature change from <ChildTaskResult> to <ChildTaskResult where ChildTaskResult : Swift.Sendable>
+Accessor TaskGroup.Iterator.finished.Set() has generic signature change from <ChildTaskResult> to <ChildTaskResult where ChildTaskResult : Swift.Sendable>
+Accessor TaskGroup.Iterator.group.Get() has generic signature change from <ChildTaskResult> to <ChildTaskResult where ChildTaskResult : Swift.Sendable>
+Accessor TaskGroup.Iterator.group.Modify() has generic signature change from <ChildTaskResult> to <ChildTaskResult where ChildTaskResult : Swift.Sendable>
+Accessor TaskGroup.Iterator.group.Set() has generic signature change from <ChildTaskResult> to <ChildTaskResult where ChildTaskResult : Swift.Sendable>
+Accessor TaskGroup._group.Get() has generic signature change from <ChildTaskResult> to <ChildTaskResult where ChildTaskResult : Swift.Sendable>
+Accessor TaskGroup.isCancelled.Get() has generic signature change from <ChildTaskResult> to <ChildTaskResult where ChildTaskResult : Swift.Sendable>
+Accessor TaskGroup.isEmpty.Get() has generic signature change from <ChildTaskResult> to <ChildTaskResult where ChildTaskResult : Swift.Sendable>
+Accessor TaskLocal.description.Get() has generic signature change from <Value> to <Value where Value : Swift.Sendable>
+Accessor TaskLocal.projectedValue.Get() has generic signature change from <Value> to <Value where Value : Swift.Sendable>
+Accessor TaskLocal.wrappedValue.Get() has generic signature change from <Value> to <Value where Value : Swift.Sendable>
+Accessor ThrowingTaskGroup.Iterator.finished.Get() has generic signature change from <ChildTaskResult, Failure where Failure : Swift.Error> to <ChildTaskResult, Failure where ChildTaskResult : Swift.Sendable, Failure : Swift.Error>
+Accessor ThrowingTaskGroup.Iterator.finished.Modify() has generic signature change from <ChildTaskResult, Failure where Failure : Swift.Error> to <ChildTaskResult, Failure where ChildTaskResult : Swift.Sendable, Failure : Swift.Error>
+Accessor ThrowingTaskGroup.Iterator.finished.Set() has generic signature change from <ChildTaskResult, Failure where Failure : Swift.Error> to <ChildTaskResult, Failure where ChildTaskResult : Swift.Sendable, Failure : Swift.Error>
+Accessor ThrowingTaskGroup.Iterator.group.Get() has generic signature change from <ChildTaskResult, Failure where Failure : Swift.Error> to <ChildTaskResult, Failure where ChildTaskResult : Swift.Sendable, Failure : Swift.Error>
+Accessor ThrowingTaskGroup.Iterator.group.Modify() has generic signature change from <ChildTaskResult, Failure where Failure : Swift.Error> to <ChildTaskResult, Failure where ChildTaskResult : Swift.Sendable, Failure : Swift.Error>
+Accessor ThrowingTaskGroup.Iterator.group.Set() has generic signature change from <ChildTaskResult, Failure where Failure : Swift.Error> to <ChildTaskResult, Failure where ChildTaskResult : Swift.Sendable, Failure : Swift.Error>
+Accessor ThrowingTaskGroup._group.Get() has generic signature change from <ChildTaskResult, Failure where Failure : Swift.Error> to <ChildTaskResult, Failure where ChildTaskResult : Swift.Sendable, Failure : Swift.Error>
+Accessor ThrowingTaskGroup.isCancelled.Get() has generic signature change from <ChildTaskResult, Failure where Failure : Swift.Error> to <ChildTaskResult, Failure where ChildTaskResult : Swift.Sendable, Failure : Swift.Error>
+Accessor ThrowingTaskGroup.isEmpty.Get() has generic signature change from <ChildTaskResult, Failure where Failure : Swift.Error> to <ChildTaskResult, Failure where ChildTaskResult : Swift.Sendable, Failure : Swift.Error>
+Class TaskLocal has generic signature change from <Value> to <Value where Value : Swift.Sendable>
+Class TaskLocal has removed conformance to UnsafeSendable
+Constructor TaskGroup.init(group:) has generic signature change from <ChildTaskResult> to <ChildTaskResult where ChildTaskResult : Swift.Sendable>
+Constructor TaskLocal.init(wrappedValue:) has generic signature change from <Value> to <Value where Value : Swift.Sendable>
+Constructor ThrowingTaskGroup.init(group:) has generic signature change from <ChildTaskResult, Failure where Failure : Swift.Error> to <ChildTaskResult, Failure where ChildTaskResult : Swift.Sendable, Failure : Swift.Error>
+Func MainActor.run(resultType:body:) has generic signature change from <T> to <T where T : Swift.Sendable>
+Func MainActor.run(resultType:body:) has mangled name changing from 'static Swift.MainActor.run<A>(resultType: A.Type, body: @Swift.MainActor @Sendable () throws -> A) async throws -> A' to 'static Swift.MainActor.run<A where A: Swift.Sendable>(resultType: A.Type, body: @Swift.MainActor @Sendable () throws -> A) async throws -> A'
+Func Task.==(_:_:) has generic signature change from <Success, Failure where Failure : Swift.Error> to <Success, Failure where Success : Swift.Sendable, Failure : Swift.Error>
+Func Task.cancel() has generic signature change from <Success, Failure where Failure : Swift.Error> to <Success, Failure where Success : Swift.Sendable, Failure : Swift.Error>
+Func Task.hash(into:) has generic signature change from <Success, Failure where Failure : Swift.Error> to <Success, Failure where Success : Swift.Sendable, Failure : Swift.Error>
+Func TaskGroup.Iterator.cancel() has generic signature change from <ChildTaskResult> to <ChildTaskResult where ChildTaskResult : Swift.Sendable>
+Func TaskGroup.Iterator.next() has generic signature change from <ChildTaskResult> to <ChildTaskResult where ChildTaskResult : Swift.Sendable>
+Func TaskGroup.awaitAllRemainingTasks() has generic signature change from <ChildTaskResult> to <ChildTaskResult where ChildTaskResult : Swift.Sendable>
+Func TaskGroup.cancelAll() has generic signature change from <ChildTaskResult> to <ChildTaskResult where ChildTaskResult : Swift.Sendable>
+Func TaskGroup.makeAsyncIterator() has generic signature change from <ChildTaskResult> to <ChildTaskResult where ChildTaskResult : Swift.Sendable>
+Func TaskGroup.next() has generic signature change from <ChildTaskResult> to <ChildTaskResult where ChildTaskResult : Swift.Sendable>
+Func TaskLocal.get() has generic signature change from <Value> to <Value where Value : Swift.Sendable>
+Func TaskLocal.withValue(_:operation:file:line:) has generic signature change from <Value, R> to <Value, R where Value : Swift.Sendable>
+Func ThrowingTaskGroup.Iterator.cancel() has generic signature change from <ChildTaskResult, Failure where Failure : Swift.Error> to <ChildTaskResult, Failure where ChildTaskResult : Swift.Sendable, Failure : Swift.Error>
+Func ThrowingTaskGroup.Iterator.next() has generic signature change from <ChildTaskResult, Failure where Failure : Swift.Error> to <ChildTaskResult, Failure where ChildTaskResult : Swift.Sendable, Failure : Swift.Error>
+Func ThrowingTaskGroup._waitForAll() has generic signature change from <ChildTaskResult, Failure where Failure : Swift.Error> to <ChildTaskResult, Failure where ChildTaskResult : Swift.Sendable, Failure : Swift.Error>
+Func ThrowingTaskGroup.awaitAllRemainingTasks() has generic signature change from <ChildTaskResult, Failure where Failure : Swift.Error> to <ChildTaskResult, Failure where ChildTaskResult : Swift.Sendable, Failure : Swift.Error>
+Func ThrowingTaskGroup.cancelAll() has generic signature change from <ChildTaskResult, Failure where Failure : Swift.Error> to <ChildTaskResult, Failure where ChildTaskResult : Swift.Sendable, Failure : Swift.Error>
+Func ThrowingTaskGroup.makeAsyncIterator() has generic signature change from <ChildTaskResult, Failure where Failure : Swift.Error> to <ChildTaskResult, Failure where ChildTaskResult : Swift.Sendable, Failure : Swift.Error>
+Func ThrowingTaskGroup.next() has generic signature change from <ChildTaskResult, Failure where Failure : Swift.Error> to <ChildTaskResult, Failure where ChildTaskResult : Swift.Sendable, Failure : Swift.Error>
+Func ThrowingTaskGroup.nextResult() has been renamed to Func nextResultForABI()
+Func ThrowingTaskGroup.nextResult() has generic signature change from <ChildTaskResult, Failure where Failure : Swift.Error> to <ChildTaskResult, Failure where ChildTaskResult : Swift.Sendable, Failure : Swift.Error>
+Func ThrowingTaskGroup.nextResult() has mangled name changing from 'Swift.ThrowingTaskGroup.nextResult() async throws -> Swift.Optional<Swift.Result<A, B>>' to 'Swift.ThrowingTaskGroup.nextResultForABI() async throws -> Swift.Optional<Swift.Result<A, B>>'
+Func _asyncMainDrainQueue() has been removed
+Func withTaskGroup(of:returning:body:) has generic signature change from <ChildTaskResult, GroupResult> to <ChildTaskResult, GroupResult where ChildTaskResult : Swift.Sendable>
+Func withTaskGroup(of:returning:body:) has mangled name changing from '_Concurrency.withTaskGroup<A, B>(of: A.Type, returning: B.Type, body: (inout Swift.TaskGroup<A>) async -> B) async -> B' to '_Concurrency.withTaskGroup<A, B where A: Swift.Sendable>(of: A.Type, returning: B.Type, body: (inout Swift.TaskGroup<A>) async -> B) async -> B'
+Func withThrowingTaskGroup(of:returning:body:) has generic signature change from <ChildTaskResult, GroupResult> to <ChildTaskResult, GroupResult where ChildTaskResult : Swift.Sendable>
+Func withThrowingTaskGroup(of:returning:body:) has mangled name changing from '_Concurrency.withThrowingTaskGroup<A, B>(of: A.Type, returning: B.Type, body: (inout Swift.ThrowingTaskGroup<A, Swift.Error>) async throws -> B) async throws -> B' to '_Concurrency.withThrowingTaskGroup<A, B where A: Swift.Sendable>(of: A.Type, returning: B.Type, body: (inout Swift.ThrowingTaskGroup<A, Swift.Error>) async throws -> B) async throws -> B'
+Import Swift has been renamed to Import _SwiftConcurrencyShims
+Struct AsyncCompactMapSequence is now with @frozen
+Struct AsyncCompactMapSequence.Iterator is now with @frozen
+Struct AsyncDropFirstSequence is now with @frozen
+Struct AsyncDropFirstSequence.Iterator is now with @frozen
+Struct AsyncDropWhileSequence is now with @frozen
+Struct AsyncDropWhileSequence.Iterator is now with @frozen
+Struct AsyncFilterSequence is now with @frozen
+Struct AsyncFilterSequence.Iterator is now with @frozen
+Struct AsyncFlatMapSequence is now with @frozen
+Struct AsyncFlatMapSequence.Iterator is now with @frozen
+Struct AsyncMapSequence is now with @frozen
+Struct AsyncMapSequence.Iterator is now with @frozen
+Struct AsyncPrefixSequence is now with @frozen
+Struct AsyncPrefixSequence.Iterator is now with @frozen
+Struct AsyncPrefixWhileSequence is now with @frozen
+Struct AsyncPrefixWhileSequence.Iterator is now with @frozen
+Struct AsyncThrowingCompactMapSequence is now with @frozen
+Struct AsyncThrowingCompactMapSequence.Iterator is now with @frozen
+Struct AsyncThrowingDropWhileSequence is now with @frozen
+Struct AsyncThrowingDropWhileSequence.Iterator is now with @frozen
+Struct AsyncThrowingFilterSequence is now with @frozen
+Struct AsyncThrowingFilterSequence.Iterator is now with @frozen
+Struct AsyncThrowingFlatMapSequence is now with @frozen
+Struct AsyncThrowingFlatMapSequence.Iterator is now with @frozen
+Struct AsyncThrowingMapSequence is now with @frozen
+Struct AsyncThrowingMapSequence.Iterator is now with @frozen
+Struct AsyncThrowingPrefixWhileSequence is now with @frozen
+Struct AsyncThrowingPrefixWhileSequence.Iterator is now with @frozen
+Struct Task has generic signature change from <Success, Failure where Failure : Swift.Error> to <Success, Failure where Success : Swift.Sendable, Failure : Swift.Error>
+Struct TaskGroup has generic signature change from <ChildTaskResult> to <ChildTaskResult where ChildTaskResult : Swift.Sendable>
+Struct TaskGroup.Iterator has generic signature change from <ChildTaskResult> to <ChildTaskResult where ChildTaskResult : Swift.Sendable>
+Struct ThrowingTaskGroup has generic signature change from <ChildTaskResult, Failure where Failure : Swift.Error> to <ChildTaskResult, Failure where ChildTaskResult : Swift.Sendable, Failure : Swift.Error>
+Struct ThrowingTaskGroup.Iterator has generic signature change from <ChildTaskResult, Failure where Failure : Swift.Error> to <ChildTaskResult, Failure where ChildTaskResult : Swift.Sendable, Failure : Swift.Error>
+Struct YieldingContinuation has been removed (deprecated)
+Subscript TaskLocal.subscript(_enclosingInstance:wrapped:storage:) has been removed
+Var AsyncCompactMapSequence.Iterator.baseIterator is now a stored property
+Var AsyncCompactMapSequence.Iterator.transform is now a stored property
+Var AsyncCompactMapSequence.base is now a stored property
+Var AsyncCompactMapSequence.transform is now a stored property
+Var AsyncDropFirstSequence.Iterator.baseIterator is now a stored property
+Var AsyncDropFirstSequence.Iterator.count is now a stored property
+Var AsyncDropFirstSequence.base is now a stored property
+Var AsyncDropFirstSequence.count is now a stored property
+Var AsyncDropWhileSequence.Iterator.baseIterator is now a stored property
+Var AsyncDropWhileSequence.Iterator.predicate is now a stored property
+Var AsyncDropWhileSequence.base is now a stored property
+Var AsyncDropWhileSequence.predicate is now a stored property
+Var AsyncFilterSequence.Iterator.baseIterator is now a stored property
+Var AsyncFilterSequence.Iterator.isIncluded is now a stored property
+Var AsyncFilterSequence.base is now a stored property
+Var AsyncFilterSequence.isIncluded is now a stored property
+Var AsyncFlatMapSequence.Iterator.baseIterator is now a stored property
+Var AsyncFlatMapSequence.Iterator.currentIterator is now a stored property
+Var AsyncFlatMapSequence.Iterator.finished is now a stored property
+Var AsyncFlatMapSequence.Iterator.transform is now a stored property
+Var AsyncFlatMapSequence.base is now a stored property
+Var AsyncFlatMapSequence.transform is now a stored property
+Var AsyncMapSequence.Iterator.baseIterator is now a stored property
+Var AsyncMapSequence.Iterator.transform is now a stored property
+Var AsyncMapSequence.base is now a stored property
+Var AsyncMapSequence.transform is now a stored property
+Var AsyncPrefixSequence.Iterator.baseIterator is now a stored property
+Var AsyncPrefixSequence.Iterator.remaining is now a stored property
+Var AsyncPrefixSequence.base is now a stored property
+Var AsyncPrefixSequence.count is now a stored property
+Var AsyncPrefixWhileSequence.Iterator.baseIterator is now a stored property
+Var AsyncPrefixWhileSequence.Iterator.predicate is now a stored property
+Var AsyncPrefixWhileSequence.Iterator.predicateHasFailed is now a stored property
+Var AsyncPrefixWhileSequence.base is now a stored property
+Var AsyncPrefixWhileSequence.predicate is now a stored property
+Var AsyncThrowingCompactMapSequence.Iterator.baseIterator is now a stored property
+Var AsyncThrowingCompactMapSequence.Iterator.finished is now a stored property
+Var AsyncThrowingCompactMapSequence.Iterator.transform is now a stored property
+Var AsyncThrowingCompactMapSequence.base is now a stored property
+Var AsyncThrowingCompactMapSequence.transform is now a stored property
+Var AsyncThrowingDropWhileSequence.Iterator.baseIterator is now a stored property
+Var AsyncThrowingDropWhileSequence.Iterator.doneDropping is now a stored property
+Var AsyncThrowingDropWhileSequence.Iterator.finished is now a stored property
+Var AsyncThrowingDropWhileSequence.Iterator.predicate is now a stored property
+Var AsyncThrowingDropWhileSequence.base is now a stored property
+Var AsyncThrowingDropWhileSequence.predicate is now a stored property
+Var AsyncThrowingFilterSequence.Iterator.baseIterator is now a stored property
+Var AsyncThrowingFilterSequence.Iterator.finished is now a stored property
+Var AsyncThrowingFilterSequence.Iterator.isIncluded is now a stored property
+Var AsyncThrowingFilterSequence.base is now a stored property
+Var AsyncThrowingFilterSequence.isIncluded is now a stored property
+Var AsyncThrowingFlatMapSequence.Iterator.baseIterator is now a stored property
+Var AsyncThrowingFlatMapSequence.Iterator.currentIterator is now a stored property
+Var AsyncThrowingFlatMapSequence.Iterator.finished is now a stored property
+Var AsyncThrowingFlatMapSequence.Iterator.transform is now a stored property
+Var AsyncThrowingFlatMapSequence.base is now a stored property
+Var AsyncThrowingFlatMapSequence.transform is now a stored property
+Var AsyncThrowingMapSequence.Iterator.baseIterator is now a stored property
+Var AsyncThrowingMapSequence.Iterator.finished is now a stored property
+Var AsyncThrowingMapSequence.Iterator.transform is now a stored property
+Var AsyncThrowingMapSequence.base is now a stored property
+Var AsyncThrowingMapSequence.transform is now a stored property
+Var AsyncThrowingPrefixWhileSequence.Iterator.baseIterator is now a stored property
+Var AsyncThrowingPrefixWhileSequence.Iterator.predicate is now a stored property
+Var AsyncThrowingPrefixWhileSequence.Iterator.predicateHasFailed is now a stored property
+Var AsyncThrowingPrefixWhileSequence.base is now a stored property
+Var AsyncThrowingPrefixWhileSequence.predicate is now a stored property
+Var UnownedJob.context has mangled name changing from 'Swift.UnownedJob.(context in #UNSTABLE ID#) : Builtin.Job' to 'Swift.UnownedJob.(context in #UNSTABLE ID#) : Builtin.Job'
+// *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)

--- a/utils/api_checker/FrameworkABIBaseline/_Concurrency/ABI/macos.json
+++ b/utils/api_checker/FrameworkABIBaseline/_Concurrency/ABI/macos.json
@@ -1,0 +1,18240 @@
+{
+  "kind": "Root",
+  "name": "TopLevel",
+  "printedName": "TopLevel",
+  "children": [
+    {
+      "kind": "Import",
+      "name": "Swift",
+      "printedName": "Swift",
+      "declKind": "Import",
+      "moduleName": "_Concurrency"
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "Actor",
+      "printedName": "Actor",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "unownedExecutor",
+          "printedName": "unownedExecutor",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "UnownedSerialExecutor",
+              "printedName": "_Concurrency.UnownedSerialExecutor",
+              "usr": "s:Sce"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScA15unownedExecutorScevp",
+          "moduleName": "_Concurrency",
+          "protocolReq": true,
+          "declAttributes": [
+            "Nonisolated"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "UnownedSerialExecutor",
+                  "printedName": "_Concurrency.UnownedSerialExecutor",
+                  "usr": "s:Sce"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScA15unownedExecutorScevg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.Actor>",
+              "sugared_genericSig": "<Self where Self : _Concurrency.Actor>",
+              "protocolReq": true,
+              "reqNewWitnessTableEntry": true,
+              "accessorKind": "get"
+            }
+          ]
+        }
+      ],
+      "declKind": "Protocol",
+      "usr": "s:ScA",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0 : AnyObject, τ_0_0 : Swift.Sendable>",
+      "sugared_genericSig": "<Self : AnyObject, Self : Swift.Sendable>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "Sendable",
+          "printedName": "Sendable",
+          "usr": "s:s8SendableP"
+        }
+      ]
+    },
+    {
+      "kind": "Function",
+      "name": "_defaultActorInitialize",
+      "printedName": "_defaultActorInitialize(_:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Void",
+          "printedName": "()"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "ProtocolComposition",
+          "printedName": "AnyObject"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency23_defaultActorInitializeyyyXlF",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "SILGenName",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "_defaultActorDestroy",
+      "printedName": "_defaultActorDestroy(_:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Void",
+          "printedName": "()"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "ProtocolComposition",
+          "printedName": "AnyObject"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency20_defaultActorDestroyyyyXlF",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "SILGenName",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "_enqueueOnMain",
+      "printedName": "_enqueueOnMain(_:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Void",
+          "printedName": "()"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "UnownedJob",
+          "printedName": "_Concurrency.UnownedJob",
+          "usr": "s:ScJ"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency14_enqueueOnMainyyScJF",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "UsableFromInline",
+        "SILGenName",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "_asyncLetStart",
+      "printedName": "_asyncLetStart(asyncLet:options:operation:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Void",
+          "printedName": "()"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinRawPointer",
+          "printedName": "Builtin.RawPointer"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "Optional",
+          "printedName": "Builtin.RawPointer?",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "BuiltinRawPointer",
+              "printedName": "Builtin.RawPointer"
+            }
+          ],
+          "usr": "s:Sq"
+        },
+        {
+          "kind": "TypeFunc",
+          "name": "Function",
+          "printedName": "() async throws -> τ_0_0",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            }
+          ],
+          "typeAttributes": [
+            "noescape"
+          ]
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency14_asyncLetStart0bC07options9operationyBp_BpSgxyYaYbKXEtlF",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0>",
+      "sugared_genericSig": "<T>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "SILGenName",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "_asyncLetGet",
+      "printedName": "_asyncLetGet(asyncLet:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "GenericTypeParam",
+          "printedName": "τ_0_0"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinRawPointer",
+          "printedName": "Builtin.RawPointer"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency12_asyncLetGet0bC0xBp_tYalF",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0>",
+      "sugared_genericSig": "<T>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "SILGenName",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "_asyncLetGetThrowing",
+      "printedName": "_asyncLetGetThrowing(asyncLet:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "GenericTypeParam",
+          "printedName": "τ_0_0"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinRawPointer",
+          "printedName": "Builtin.RawPointer"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency20_asyncLetGetThrowing0bC0xBp_tYaKlF",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0>",
+      "sugared_genericSig": "<T>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "SILGenName",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "throwing": true,
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "_asyncLetEnd",
+      "printedName": "_asyncLetEnd(asyncLet:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Void",
+          "printedName": "()"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinRawPointer",
+          "printedName": "Builtin.RawPointer"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency12_asyncLetEnd0bC0yBp_tF",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "SILGenName",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "_asyncLet_get",
+      "printedName": "_asyncLet_get(_:_:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinRawPointer",
+          "printedName": "Builtin.RawPointer"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinRawPointer",
+          "printedName": "Builtin.RawPointer"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinRawPointer",
+          "printedName": "Builtin.RawPointer"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency13_asyncLet_getyBpBp_BptYaF",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "SILGenName",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "_asyncLet_get_throwing",
+      "printedName": "_asyncLet_get_throwing(_:_:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinRawPointer",
+          "printedName": "Builtin.RawPointer"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinRawPointer",
+          "printedName": "Builtin.RawPointer"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinRawPointer",
+          "printedName": "Builtin.RawPointer"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency22_asyncLet_get_throwingyBpBp_BptYaKF",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "SILGenName",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "throwing": true,
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "_asyncLet_finish",
+      "printedName": "_asyncLet_finish(_:_:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Void",
+          "printedName": "()"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinRawPointer",
+          "printedName": "Builtin.RawPointer"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinRawPointer",
+          "printedName": "Builtin.RawPointer"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency16_asyncLet_finishyyBp_BptYaF",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "SILGenName",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "CheckedContinuation",
+      "printedName": "CheckedContinuation",
+      "children": [
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(continuation:function:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "CheckedContinuation",
+              "printedName": "_Concurrency.CheckedContinuation<τ_0_0, τ_0_1>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ],
+              "usr": "s:ScC"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "UnsafeContinuation",
+              "printedName": "_Concurrency.UnsafeContinuation<τ_0_0, τ_0_1>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ],
+              "usr": "s:Scc"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "String",
+              "printedName": "Swift.String",
+              "hasDefaultArg": true,
+              "usr": "s:SS"
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:ScC12continuation8functionScCyxq_GSccyxq_G_SStcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<T, E where E : Swift.Error>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "Function",
+          "name": "resume",
+          "printedName": "resume(returning:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0",
+              "paramValueOwnership": "Owned"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScC6resume9returningyxn_tF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<T, E where E : Swift.Error>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "resume",
+          "printedName": "resume(throwing:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_1",
+              "paramValueOwnership": "Owned"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScC6resume8throwingyq_n_tF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<T, E where E : Swift.Error>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:ScC",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+      "sugared_genericSig": "<T, E where E : Swift.Error>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ]
+    },
+    {
+      "kind": "Function",
+      "name": "withCheckedContinuation",
+      "printedName": "withCheckedContinuation(function:_:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "GenericTypeParam",
+          "printedName": "τ_0_0"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "String",
+          "printedName": "Swift.String",
+          "hasDefaultArg": true,
+          "usr": "s:SS"
+        },
+        {
+          "kind": "TypeFunc",
+          "name": "Function",
+          "printedName": "(_Concurrency.CheckedContinuation<τ_0_0, Swift.Never>) -> ()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "CheckedContinuation",
+              "printedName": "_Concurrency.CheckedContinuation<τ_0_0, Swift.Never>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "Never",
+                  "printedName": "Swift.Never",
+                  "usr": "s:s5NeverO"
+                }
+              ],
+              "usr": "s:ScC"
+            }
+          ],
+          "typeAttributes": [
+            "noescape"
+          ]
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency23withCheckedContinuation8function_xSS_yScCyxs5NeverOGXEtYalF",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0>",
+      "sugared_genericSig": "<T>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "withCheckedThrowingContinuation",
+      "printedName": "withCheckedThrowingContinuation(function:_:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "GenericTypeParam",
+          "printedName": "τ_0_0"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "String",
+          "printedName": "Swift.String",
+          "hasDefaultArg": true,
+          "usr": "s:SS"
+        },
+        {
+          "kind": "TypeFunc",
+          "name": "Function",
+          "printedName": "(_Concurrency.CheckedContinuation<τ_0_0, Swift.Error>) -> ()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "CheckedContinuation",
+              "printedName": "_Concurrency.CheckedContinuation<τ_0_0, Swift.Error>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "Error",
+                  "printedName": "Swift.Error",
+                  "usr": "s:s5ErrorP"
+                }
+              ],
+              "usr": "s:ScC"
+            }
+          ],
+          "typeAttributes": [
+            "noescape"
+          ]
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency31withCheckedThrowingContinuation8function_xSS_yScCyxs5Error_pGXEtYaKlF",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0>",
+      "sugared_genericSig": "<T>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "throwing": true,
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "swift_deletedAsyncMethodError",
+      "printedName": "swift_deletedAsyncMethodError()",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Void",
+          "printedName": "()"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency29swift_deletedAsyncMethodErroryyYaF",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "SILGenName",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "Executor",
+      "printedName": "Executor",
+      "children": [
+        {
+          "kind": "Function",
+          "name": "enqueue",
+          "printedName": "enqueue(_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "UnownedJob",
+              "printedName": "_Concurrency.UnownedJob",
+              "usr": "s:ScJ"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScF7enqueueyyScJF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.Executor>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.Executor>",
+          "protocolReq": true,
+          "reqNewWitnessTableEntry": true,
+          "funcSelfKind": "NonMutating"
+        }
+      ],
+      "declKind": "Protocol",
+      "usr": "s:ScF",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0 : AnyObject, τ_0_0 : Swift.Sendable>",
+      "sugared_genericSig": "<Self : AnyObject, Self : Swift.Sendable>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "Sendable",
+          "printedName": "Sendable",
+          "usr": "s:s8SendableP"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "SerialExecutor",
+      "printedName": "SerialExecutor",
+      "children": [
+        {
+          "kind": "Function",
+          "name": "enqueue",
+          "printedName": "enqueue(_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "UnownedJob",
+              "printedName": "_Concurrency.UnownedJob",
+              "usr": "s:ScJ"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Scf7enqueueyyScJF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.SerialExecutor>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.SerialExecutor>",
+          "protocolReq": true,
+          "declAttributes": [
+            "NonOverride"
+          ],
+          "reqNewWitnessTableEntry": true,
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "asUnownedSerialExecutor",
+          "printedName": "asUnownedSerialExecutor()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "UnownedSerialExecutor",
+              "printedName": "_Concurrency.UnownedSerialExecutor",
+              "usr": "s:Sce"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Scf23asUnownedSerialExecutorSceyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.SerialExecutor>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.SerialExecutor>",
+          "protocolReq": true,
+          "reqNewWitnessTableEntry": true,
+          "funcSelfKind": "NonMutating"
+        }
+      ],
+      "declKind": "Protocol",
+      "usr": "s:Scf",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0 : _Concurrency.Executor>",
+      "sugared_genericSig": "<Self : _Concurrency.Executor>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "Executor",
+          "printedName": "Executor",
+          "usr": "s:ScF"
+        },
+        {
+          "kind": "Conformance",
+          "name": "Sendable",
+          "printedName": "Sendable",
+          "usr": "s:s8SendableP"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "UnownedSerialExecutor",
+      "printedName": "UnownedSerialExecutor",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "executor",
+          "printedName": "executor",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "BuiltinExecutor",
+              "printedName": "Builtin.Executor"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:Sce8executorBevp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "fixedbinaryorder": 0,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "BuiltinExecutor",
+                  "printedName": "Builtin.Executor"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:Sce8executorBevg",
+              "moduleName": "_Concurrency",
+              "implicit": true,
+              "declAttributes": [
+                "Transparent"
+              ],
+              "accessorKind": "get"
+            },
+            {
+              "kind": "Accessor",
+              "name": "Set",
+              "printedName": "Set()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Void",
+                  "printedName": "()"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "BuiltinExecutor",
+                  "printedName": "Builtin.Executor"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:Sce8executorBevs",
+              "moduleName": "_Concurrency",
+              "implicit": true,
+              "declAttributes": [
+                "Transparent"
+              ],
+              "accessorKind": "set"
+            },
+            {
+              "kind": "Accessor",
+              "name": "Modify",
+              "printedName": "Modify()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Void",
+                  "printedName": "()"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:Sce8executorBevM",
+              "moduleName": "_Concurrency",
+              "implicit": true,
+              "declAttributes": [
+                "Transparent"
+              ],
+              "accessorKind": "_modify"
+            }
+          ]
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "UnownedSerialExecutor",
+              "printedName": "_Concurrency.UnownedSerialExecutor",
+              "usr": "s:Sce"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "BuiltinExecutor",
+              "printedName": "Builtin.Executor"
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:SceySceBecfc",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl",
+            "Inlinable"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(ordinary:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "UnownedSerialExecutor",
+              "printedName": "_Concurrency.UnownedSerialExecutor",
+              "usr": "s:Sce"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0",
+              "paramValueOwnership": "Shared"
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:Sce8ordinaryScexh_tcScfRzlufc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.SerialExecutor>",
+          "sugared_genericSig": "<E where E : _Concurrency.SerialExecutor>",
+          "declAttributes": [
+            "AccessControl",
+            "Inlinable"
+          ],
+          "init_kind": "Designated"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:Sce",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Frozen",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "Sendable",
+          "printedName": "Sendable",
+          "usr": "s:s8SendableP"
+        }
+      ]
+    },
+    {
+      "kind": "Function",
+      "name": "_checkExpectedExecutor",
+      "printedName": "_checkExpectedExecutor(_filenameStart:_filenameLength:_filenameIsASCII:_line:_executor:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Void",
+          "printedName": "()"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinRawPointer",
+          "printedName": "Builtin.RawPointer"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinInteger",
+          "printedName": "Builtin.Word"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinInteger",
+          "printedName": "Builtin.Int1"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinInteger",
+          "printedName": "Builtin.Word"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinExecutor",
+          "printedName": "Builtin.Executor"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency22_checkExpectedExecutor14_filenameStart01_E6Length01_E7IsASCII5_line9_executoryBp_BwBi1_BwBetF",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Transparent",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "AsyncCompactMapSequence",
+      "printedName": "AsyncCompactMapSequence",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "base",
+          "printedName": "base",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency23AsyncCompactMapSequenceV4basexvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency23AsyncCompactMapSequenceV4basexvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "transform",
+          "printedName": "transform",
+          "children": [
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async -> τ_0_1?",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_1?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency23AsyncCompactMapSequenceV9transformyq_Sg7ElementQzYacvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async -> τ_0_1?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Optional",
+                      "printedName": "τ_0_1?",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "GenericTypeParam",
+                          "printedName": "τ_0_1"
+                        }
+                      ],
+                      "usr": "s:Sq"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency23AsyncCompactMapSequenceV9transformyq_Sg7ElementQzYacvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(_:transform:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncCompactMapSequence",
+              "printedName": "_Concurrency.AsyncCompactMapSequence<τ_0_0, τ_0_1>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ],
+              "usr": "s:12_Concurrency23AsyncCompactMapSequenceV"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async -> τ_0_1?",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_1?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:12_Concurrency23AsyncCompactMapSequenceV_9transformACyxq_Gx_q_Sg7ElementQzYactcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "TypeDecl",
+          "name": "Iterator",
+          "printedName": "Iterator",
+          "children": [
+            {
+              "kind": "Var",
+              "name": "baseIterator",
+              "printedName": "baseIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency23AsyncCompactMapSequenceV8IteratorV04baseF00bF0Qzvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency23AsyncCompactMapSequenceV8IteratorV04baseF00bF0Qzvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency23AsyncCompactMapSequenceV8IteratorV04baseF00bF0Qzvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency23AsyncCompactMapSequenceV8IteratorV04baseF00bF0QzvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "transform",
+              "printedName": "transform",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async -> τ_0_1?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Optional",
+                      "printedName": "τ_0_1?",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "GenericTypeParam",
+                          "printedName": "τ_0_1"
+                        }
+                      ],
+                      "usr": "s:Sq"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency23AsyncCompactMapSequenceV8IteratorV9transformyq_Sg7ElementQzYacvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "isLet": true,
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "Function",
+                      "printedName": "(τ_0_0.Element) async -> τ_0_1?",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Optional",
+                          "printedName": "τ_0_1?",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "GenericTypeParam",
+                              "printedName": "τ_0_1"
+                            }
+                          ],
+                          "usr": "s:Sq"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "DependentMember",
+                          "printedName": "τ_0_0.Element"
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency23AsyncCompactMapSequenceV8IteratorV9transformyq_Sg7ElementQzYacvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                }
+              ]
+            },
+            {
+              "kind": "Constructor",
+              "name": "init",
+              "printedName": "init(_:transform:)",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncCompactMapSequence<τ_0_0, τ_0_1>.Iterator",
+                  "usr": "s:12_Concurrency23AsyncCompactMapSequenceV8IteratorV"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                },
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async -> τ_0_1?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Optional",
+                      "printedName": "τ_0_1?",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "GenericTypeParam",
+                          "printedName": "τ_0_1"
+                        }
+                      ],
+                      "usr": "s:Sq"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Constructor",
+              "usr": "s:12_Concurrency23AsyncCompactMapSequenceV8IteratorV_9transformAEyxq__G0bF0Qz_q_Sg7ElementQzYactcfc",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "init_kind": "Designated"
+            },
+            {
+              "kind": "Function",
+              "name": "next",
+              "printedName": "next()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_1?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:12_Concurrency23AsyncCompactMapSequenceV8IteratorV4nextq_SgyYaKF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "Rethrows",
+                "Mutating",
+                "AccessControl",
+                "Inlinable"
+              ],
+              "throwing": true,
+              "funcSelfKind": "Mutating"
+            }
+          ],
+          "declKind": "Struct",
+          "usr": "s:12_Concurrency23AsyncCompactMapSequenceV8IteratorV",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "conformances": [
+            {
+              "kind": "Conformance",
+              "name": "AsyncIteratorProtocol",
+              "printedName": "AsyncIteratorProtocol",
+              "children": [
+                {
+                  "kind": "TypeWitness",
+                  "name": "Element",
+                  "printedName": "Element",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    }
+                  ]
+                }
+              ],
+              "usr": "s:ScI"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "makeAsyncIterator",
+          "printedName": "makeAsyncIterator()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Iterator",
+              "printedName": "_Concurrency.AsyncCompactMapSequence<τ_0_0, τ_0_1>.Iterator",
+              "usr": "s:12_Concurrency23AsyncCompactMapSequenceV8IteratorV"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency23AsyncCompactMapSequenceV04makeB8IteratorAC0G0Vyxq__GyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:12_Concurrency23AsyncCompactMapSequenceV",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+      "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "AsyncSequence",
+          "printedName": "AsyncSequence",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "AsyncIterator",
+              "printedName": "AsyncIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncCompactMapSequence<τ_0_0, τ_0_1>.Iterator",
+                  "usr": "s:12_Concurrency23AsyncCompactMapSequenceV8IteratorV"
+                }
+              ]
+            },
+            {
+              "kind": "TypeWitness",
+              "name": "Element",
+              "printedName": "Element",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ]
+            }
+          ],
+          "usr": "s:Sci"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "AsyncDropFirstSequence",
+      "printedName": "AsyncDropFirstSequence",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "base",
+          "printedName": "base",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency22AsyncDropFirstSequenceV4basexvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency22AsyncDropFirstSequenceV4basexvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "count",
+          "printedName": "count",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Int",
+              "printedName": "Swift.Int",
+              "usr": "s:Si"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency22AsyncDropFirstSequenceV5countSivp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Int",
+                  "printedName": "Swift.Int",
+                  "usr": "s:Si"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency22AsyncDropFirstSequenceV5countSivg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(_:dropping:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncDropFirstSequence",
+              "printedName": "_Concurrency.AsyncDropFirstSequence<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:12_Concurrency22AsyncDropFirstSequenceV"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Int",
+              "printedName": "Swift.Int",
+              "usr": "s:Si"
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:12_Concurrency22AsyncDropFirstSequenceV_8droppingACyxGx_Sitcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "TypeDecl",
+          "name": "Iterator",
+          "printedName": "Iterator",
+          "children": [
+            {
+              "kind": "Var",
+              "name": "baseIterator",
+              "printedName": "baseIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency22AsyncDropFirstSequenceV8IteratorV04baseF00bF0Qzvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency22AsyncDropFirstSequenceV8IteratorV04baseF00bF0Qzvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency22AsyncDropFirstSequenceV8IteratorV04baseF00bF0Qzvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency22AsyncDropFirstSequenceV8IteratorV04baseF00bF0QzvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "count",
+              "printedName": "count",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Int",
+                  "printedName": "Swift.Int",
+                  "usr": "s:Si"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency22AsyncDropFirstSequenceV8IteratorV5countSivp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Int",
+                      "printedName": "Swift.Int",
+                      "usr": "s:Si"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency22AsyncDropFirstSequenceV8IteratorV5countSivg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Int",
+                      "printedName": "Swift.Int",
+                      "usr": "s:Si"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency22AsyncDropFirstSequenceV8IteratorV5countSivs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency22AsyncDropFirstSequenceV8IteratorV5countSivM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Constructor",
+              "name": "init",
+              "printedName": "init(_:count:)",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncDropFirstSequence<τ_0_0>.Iterator",
+                  "usr": "s:12_Concurrency22AsyncDropFirstSequenceV8IteratorV"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "Int",
+                  "printedName": "Swift.Int",
+                  "usr": "s:Si"
+                }
+              ],
+              "declKind": "Constructor",
+              "usr": "s:12_Concurrency22AsyncDropFirstSequenceV8IteratorV_5countAEyx_G0bF0Qz_Sitcfc",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "init_kind": "Designated"
+            },
+            {
+              "kind": "Function",
+              "name": "next",
+              "printedName": "next()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_0.Element?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:12_Concurrency22AsyncDropFirstSequenceV8IteratorV4next7ElementQzSgyYaKF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "Rethrows",
+                "Mutating",
+                "AccessControl",
+                "Inlinable"
+              ],
+              "throwing": true,
+              "funcSelfKind": "Mutating"
+            }
+          ],
+          "declKind": "Struct",
+          "usr": "s:12_Concurrency22AsyncDropFirstSequenceV8IteratorV",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "conformances": [
+            {
+              "kind": "Conformance",
+              "name": "AsyncIteratorProtocol",
+              "printedName": "AsyncIteratorProtocol",
+              "children": [
+                {
+                  "kind": "TypeWitness",
+                  "name": "Element",
+                  "printedName": "Element",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "usr": "s:ScI"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "makeAsyncIterator",
+          "printedName": "makeAsyncIterator()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Iterator",
+              "printedName": "_Concurrency.AsyncDropFirstSequence<τ_0_0>.Iterator",
+              "usr": "s:12_Concurrency22AsyncDropFirstSequenceV8IteratorV"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency22AsyncDropFirstSequenceV04makeB8IteratorAC0G0Vyx_GyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        },
+        {
+          "kind": "Function",
+          "name": "dropFirst",
+          "printedName": "dropFirst(_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncDropFirstSequence",
+              "printedName": "_Concurrency.AsyncDropFirstSequence<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:12_Concurrency22AsyncDropFirstSequenceV"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Int",
+              "printedName": "Swift.Int",
+              "hasDefaultArg": true,
+              "usr": "s:Si"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency22AsyncDropFirstSequenceV04dropD0yACyxGSiF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:12_Concurrency22AsyncDropFirstSequenceV",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+      "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "AsyncSequence",
+          "printedName": "AsyncSequence",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "AsyncIterator",
+              "printedName": "AsyncIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncDropFirstSequence<τ_0_0>.Iterator",
+                  "usr": "s:12_Concurrency22AsyncDropFirstSequenceV8IteratorV"
+                }
+              ]
+            },
+            {
+              "kind": "TypeWitness",
+              "name": "Element",
+              "printedName": "Element",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "usr": "s:Sci"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "AsyncDropWhileSequence",
+      "printedName": "AsyncDropWhileSequence",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "base",
+          "printedName": "base",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency22AsyncDropWhileSequenceV4basexvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency22AsyncDropWhileSequenceV4basexvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "predicate",
+          "printedName": "predicate",
+          "children": [
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency22AsyncDropWhileSequenceV9predicateySb7ElementQzYacvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency22AsyncDropWhileSequenceV9predicateySb7ElementQzYacvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(_:predicate:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncDropWhileSequence",
+              "printedName": "_Concurrency.AsyncDropWhileSequence<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:12_Concurrency22AsyncDropWhileSequenceV"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:12_Concurrency22AsyncDropWhileSequenceV_9predicateACyxGx_Sb7ElementQzYactcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "TypeDecl",
+          "name": "Iterator",
+          "printedName": "Iterator",
+          "children": [
+            {
+              "kind": "Var",
+              "name": "baseIterator",
+              "printedName": "baseIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency22AsyncDropWhileSequenceV8IteratorV04baseF00bF0Qzvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency22AsyncDropWhileSequenceV8IteratorV04baseF00bF0Qzvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency22AsyncDropWhileSequenceV8IteratorV04baseF00bF0Qzvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency22AsyncDropWhileSequenceV8IteratorV04baseF00bF0QzvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "predicate",
+              "printedName": "predicate",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "((τ_0_0.Element) async -> Swift.Bool)?",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "Function",
+                      "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Bool",
+                          "printedName": "Swift.Bool",
+                          "usr": "s:Sb"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "DependentMember",
+                          "printedName": "τ_0_0.Element"
+                        }
+                      ]
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency22AsyncDropWhileSequenceV8IteratorV9predicateSb7ElementQzYacSgvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasInitialValue",
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Optional",
+                      "printedName": "((τ_0_0.Element) async -> Swift.Bool)?",
+                      "children": [
+                        {
+                          "kind": "TypeFunc",
+                          "name": "Function",
+                          "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Bool",
+                              "printedName": "Swift.Bool",
+                              "usr": "s:Sb"
+                            },
+                            {
+                              "kind": "TypeNominal",
+                              "name": "DependentMember",
+                              "printedName": "τ_0_0.Element"
+                            }
+                          ]
+                        }
+                      ],
+                      "usr": "s:Sq"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency22AsyncDropWhileSequenceV8IteratorV9predicateSb7ElementQzYacSgvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Optional",
+                      "printedName": "((τ_0_0.Element) async -> Swift.Bool)?",
+                      "children": [
+                        {
+                          "kind": "TypeFunc",
+                          "name": "Function",
+                          "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Bool",
+                              "printedName": "Swift.Bool",
+                              "usr": "s:Sb"
+                            },
+                            {
+                              "kind": "TypeNominal",
+                              "name": "DependentMember",
+                              "printedName": "τ_0_0.Element"
+                            }
+                          ]
+                        }
+                      ],
+                      "usr": "s:Sq"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency22AsyncDropWhileSequenceV8IteratorV9predicateSb7ElementQzYacSgvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency22AsyncDropWhileSequenceV8IteratorV9predicateSb7ElementQzYacSgvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Constructor",
+              "name": "init",
+              "printedName": "init(_:predicate:)",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncDropWhileSequence<τ_0_0>.Iterator",
+                  "usr": "s:12_Concurrency22AsyncDropWhileSequenceV8IteratorV"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                },
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Constructor",
+              "usr": "s:12_Concurrency22AsyncDropWhileSequenceV8IteratorV_9predicateAEyx_G0bF0Qz_Sb7ElementQzYactcfc",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "init_kind": "Designated"
+            },
+            {
+              "kind": "Function",
+              "name": "next",
+              "printedName": "next()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_0.Element?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:12_Concurrency22AsyncDropWhileSequenceV8IteratorV4next7ElementQzSgyYaKF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "Rethrows",
+                "Mutating",
+                "AccessControl",
+                "Inlinable"
+              ],
+              "throwing": true,
+              "funcSelfKind": "Mutating"
+            }
+          ],
+          "declKind": "Struct",
+          "usr": "s:12_Concurrency22AsyncDropWhileSequenceV8IteratorV",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "conformances": [
+            {
+              "kind": "Conformance",
+              "name": "AsyncIteratorProtocol",
+              "printedName": "AsyncIteratorProtocol",
+              "children": [
+                {
+                  "kind": "TypeWitness",
+                  "name": "Element",
+                  "printedName": "Element",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "usr": "s:ScI"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "makeAsyncIterator",
+          "printedName": "makeAsyncIterator()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Iterator",
+              "printedName": "_Concurrency.AsyncDropWhileSequence<τ_0_0>.Iterator",
+              "usr": "s:12_Concurrency22AsyncDropWhileSequenceV8IteratorV"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency22AsyncDropWhileSequenceV04makeB8IteratorAC0G0Vyx_GyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:12_Concurrency22AsyncDropWhileSequenceV",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+      "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "AsyncSequence",
+          "printedName": "AsyncSequence",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "AsyncIterator",
+              "printedName": "AsyncIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncDropWhileSequence<τ_0_0>.Iterator",
+                  "usr": "s:12_Concurrency22AsyncDropWhileSequenceV8IteratorV"
+                }
+              ]
+            },
+            {
+              "kind": "TypeWitness",
+              "name": "Element",
+              "printedName": "Element",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "usr": "s:Sci"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "AsyncFilterSequence",
+      "printedName": "AsyncFilterSequence",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "base",
+          "printedName": "base",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency19AsyncFilterSequenceV4basexvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency19AsyncFilterSequenceV4basexvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "isIncluded",
+          "printedName": "isIncluded",
+          "children": [
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency19AsyncFilterSequenceV10isIncludedySb7ElementQzYacvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency19AsyncFilterSequenceV10isIncludedySb7ElementQzYacvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(_:isIncluded:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncFilterSequence",
+              "printedName": "_Concurrency.AsyncFilterSequence<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:12_Concurrency19AsyncFilterSequenceV"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:12_Concurrency19AsyncFilterSequenceV_10isIncludedACyxGx_Sb7ElementQzYactcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "TypeDecl",
+          "name": "Iterator",
+          "printedName": "Iterator",
+          "children": [
+            {
+              "kind": "Var",
+              "name": "baseIterator",
+              "printedName": "baseIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency19AsyncFilterSequenceV8IteratorV04baseE00bE0Qzvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency19AsyncFilterSequenceV8IteratorV04baseE00bE0Qzvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency19AsyncFilterSequenceV8IteratorV04baseE00bE0Qzvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency19AsyncFilterSequenceV8IteratorV04baseE00bE0QzvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "isIncluded",
+              "printedName": "isIncluded",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency19AsyncFilterSequenceV8IteratorV10isIncludedySb7ElementQzYacvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "isLet": true,
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "Function",
+                      "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Bool",
+                          "printedName": "Swift.Bool",
+                          "usr": "s:Sb"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "DependentMember",
+                          "printedName": "τ_0_0.Element"
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency19AsyncFilterSequenceV8IteratorV10isIncludedySb7ElementQzYacvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                }
+              ]
+            },
+            {
+              "kind": "Constructor",
+              "name": "init",
+              "printedName": "init(_:isIncluded:)",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncFilterSequence<τ_0_0>.Iterator",
+                  "usr": "s:12_Concurrency19AsyncFilterSequenceV8IteratorV"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                },
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Constructor",
+              "usr": "s:12_Concurrency19AsyncFilterSequenceV8IteratorV_10isIncludedAEyx_G0bE0Qz_Sb7ElementQzYactcfc",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "init_kind": "Designated"
+            },
+            {
+              "kind": "Function",
+              "name": "next",
+              "printedName": "next()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_0.Element?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:12_Concurrency19AsyncFilterSequenceV8IteratorV4next7ElementQzSgyYaKF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "Rethrows",
+                "Mutating",
+                "AccessControl",
+                "Inlinable"
+              ],
+              "throwing": true,
+              "funcSelfKind": "Mutating"
+            }
+          ],
+          "declKind": "Struct",
+          "usr": "s:12_Concurrency19AsyncFilterSequenceV8IteratorV",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "conformances": [
+            {
+              "kind": "Conformance",
+              "name": "AsyncIteratorProtocol",
+              "printedName": "AsyncIteratorProtocol",
+              "children": [
+                {
+                  "kind": "TypeWitness",
+                  "name": "Element",
+                  "printedName": "Element",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "usr": "s:ScI"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "makeAsyncIterator",
+          "printedName": "makeAsyncIterator()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Iterator",
+              "printedName": "_Concurrency.AsyncFilterSequence<τ_0_0>.Iterator",
+              "usr": "s:12_Concurrency19AsyncFilterSequenceV8IteratorV"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency19AsyncFilterSequenceV04makeB8IteratorAC0F0Vyx_GyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:12_Concurrency19AsyncFilterSequenceV",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+      "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "AsyncSequence",
+          "printedName": "AsyncSequence",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "AsyncIterator",
+              "printedName": "AsyncIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncFilterSequence<τ_0_0>.Iterator",
+                  "usr": "s:12_Concurrency19AsyncFilterSequenceV8IteratorV"
+                }
+              ]
+            },
+            {
+              "kind": "TypeWitness",
+              "name": "Element",
+              "printedName": "Element",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "usr": "s:Sci"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "AsyncFlatMapSequence",
+      "printedName": "AsyncFlatMapSequence",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "base",
+          "printedName": "base",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency20AsyncFlatMapSequenceV4basexvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency20AsyncFlatMapSequenceV4basexvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "transform",
+          "printedName": "transform",
+          "children": [
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async -> τ_0_1",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency20AsyncFlatMapSequenceV9transformyq_7ElementQzYacvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async -> τ_0_1",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency20AsyncFlatMapSequenceV9transformyq_7ElementQzYacvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(_:transform:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncFlatMapSequence",
+              "printedName": "_Concurrency.AsyncFlatMapSequence<τ_0_0, τ_0_1>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ],
+              "usr": "s:12_Concurrency20AsyncFlatMapSequenceV"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async -> τ_0_1",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:12_Concurrency20AsyncFlatMapSequenceV_9transformACyxq_Gx_q_7ElementQzYactcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "TypeDecl",
+          "name": "Iterator",
+          "printedName": "Iterator",
+          "children": [
+            {
+              "kind": "Var",
+              "name": "baseIterator",
+              "printedName": "baseIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency20AsyncFlatMapSequenceV8IteratorV04baseF00bF0Qzvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency20AsyncFlatMapSequenceV8IteratorV04baseF00bF0Qzvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency20AsyncFlatMapSequenceV8IteratorV04baseF00bF0Qzvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency20AsyncFlatMapSequenceV8IteratorV04baseF00bF0QzvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "transform",
+              "printedName": "transform",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async -> τ_0_1",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency20AsyncFlatMapSequenceV8IteratorV9transformyq_7ElementQzYacvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "isLet": true,
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "Function",
+                      "printedName": "(τ_0_0.Element) async -> τ_0_1",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "GenericTypeParam",
+                          "printedName": "τ_0_1"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "DependentMember",
+                          "printedName": "τ_0_0.Element"
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency20AsyncFlatMapSequenceV8IteratorV9transformyq_7ElementQzYacvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "currentIterator",
+              "printedName": "currentIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_1.AsyncIterator?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_1.AsyncIterator"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency20AsyncFlatMapSequenceV8IteratorV07currentF00bF0Qy_Sgvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasInitialValue",
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Optional",
+                      "printedName": "τ_0_1.AsyncIterator?",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "DependentMember",
+                          "printedName": "τ_0_1.AsyncIterator"
+                        }
+                      ],
+                      "usr": "s:Sq"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency20AsyncFlatMapSequenceV8IteratorV07currentF00bF0Qy_Sgvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Optional",
+                      "printedName": "τ_0_1.AsyncIterator?",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "DependentMember",
+                          "printedName": "τ_0_1.AsyncIterator"
+                        }
+                      ],
+                      "usr": "s:Sq"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency20AsyncFlatMapSequenceV8IteratorV07currentF00bF0Qy_Sgvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency20AsyncFlatMapSequenceV8IteratorV07currentF00bF0Qy_SgvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "finished",
+              "printedName": "finished",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency20AsyncFlatMapSequenceV8IteratorV8finishedSbvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency20AsyncFlatMapSequenceV8IteratorV8finishedSbvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency20AsyncFlatMapSequenceV8IteratorV8finishedSbvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency20AsyncFlatMapSequenceV8IteratorV8finishedSbvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Constructor",
+              "name": "init",
+              "printedName": "init(_:transform:)",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncFlatMapSequence<τ_0_0, τ_0_1>.Iterator",
+                  "usr": "s:12_Concurrency20AsyncFlatMapSequenceV8IteratorV"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                },
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async -> τ_0_1",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Constructor",
+              "usr": "s:12_Concurrency20AsyncFlatMapSequenceV8IteratorV_9transformAEyxq__G0bF0Qz_q_7ElementQzYactcfc",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "init_kind": "Designated"
+            },
+            {
+              "kind": "Function",
+              "name": "next",
+              "printedName": "next()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_1.Element?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_1.Element"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:12_Concurrency20AsyncFlatMapSequenceV8IteratorV4next7ElementQy_SgyYaKF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "Rethrows",
+                "Mutating",
+                "AccessControl",
+                "Inlinable"
+              ],
+              "throwing": true,
+              "funcSelfKind": "Mutating"
+            }
+          ],
+          "declKind": "Struct",
+          "usr": "s:12_Concurrency20AsyncFlatMapSequenceV8IteratorV",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "conformances": [
+            {
+              "kind": "Conformance",
+              "name": "AsyncIteratorProtocol",
+              "printedName": "AsyncIteratorProtocol",
+              "children": [
+                {
+                  "kind": "TypeWitness",
+                  "name": "Element",
+                  "printedName": "Element",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_1.Element"
+                    }
+                  ]
+                }
+              ],
+              "usr": "s:ScI"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "makeAsyncIterator",
+          "printedName": "makeAsyncIterator()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Iterator",
+              "printedName": "_Concurrency.AsyncFlatMapSequence<τ_0_0, τ_0_1>.Iterator",
+              "usr": "s:12_Concurrency20AsyncFlatMapSequenceV8IteratorV"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency20AsyncFlatMapSequenceV04makeB8IteratorAC0G0Vyxq__GyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:12_Concurrency20AsyncFlatMapSequenceV",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+      "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "AsyncSequence",
+          "printedName": "AsyncSequence",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "AsyncIterator",
+              "printedName": "AsyncIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncFlatMapSequence<τ_0_0, τ_0_1>.Iterator",
+                  "usr": "s:12_Concurrency20AsyncFlatMapSequenceV8IteratorV"
+                }
+              ]
+            },
+            {
+              "kind": "TypeWitness",
+              "name": "Element",
+              "printedName": "Element",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_1.Element"
+                }
+              ]
+            }
+          ],
+          "usr": "s:Sci"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "AsyncIteratorProtocol",
+      "printedName": "AsyncIteratorProtocol",
+      "children": [
+        {
+          "kind": "AssociatedType",
+          "name": "Element",
+          "printedName": "Element",
+          "declKind": "AssociatedType",
+          "usr": "s:ScI7ElementQa",
+          "moduleName": "_Concurrency",
+          "protocolReq": true
+        },
+        {
+          "kind": "Function",
+          "name": "next",
+          "printedName": "next()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Optional",
+              "printedName": "τ_0_0.Element?",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ],
+              "usr": "s:Sq"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScI4next7ElementQzSgyYaKF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncIteratorProtocol>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.AsyncIteratorProtocol>",
+          "protocolReq": true,
+          "declAttributes": [
+            "Mutating"
+          ],
+          "throwing": true,
+          "reqNewWitnessTableEntry": true,
+          "funcSelfKind": "Mutating"
+        }
+      ],
+      "declKind": "Protocol",
+      "usr": "s:ScI",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "AtRethrows",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "AsyncMapSequence",
+      "printedName": "AsyncMapSequence",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "base",
+          "printedName": "base",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency16AsyncMapSequenceV4basexvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency16AsyncMapSequenceV4basexvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "transform",
+          "printedName": "transform",
+          "children": [
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async -> τ_0_1",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency16AsyncMapSequenceV9transformyq_7ElementQzYacvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async -> τ_0_1",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency16AsyncMapSequenceV9transformyq_7ElementQzYacvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(_:transform:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncMapSequence",
+              "printedName": "_Concurrency.AsyncMapSequence<τ_0_0, τ_0_1>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ],
+              "usr": "s:12_Concurrency16AsyncMapSequenceV"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async -> τ_0_1",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:12_Concurrency16AsyncMapSequenceV_9transformACyxq_Gx_q_7ElementQzYactcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "TypeDecl",
+          "name": "Iterator",
+          "printedName": "Iterator",
+          "children": [
+            {
+              "kind": "Var",
+              "name": "baseIterator",
+              "printedName": "baseIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency16AsyncMapSequenceV8IteratorV04baseE00bE0Qzvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency16AsyncMapSequenceV8IteratorV04baseE00bE0Qzvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency16AsyncMapSequenceV8IteratorV04baseE00bE0Qzvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency16AsyncMapSequenceV8IteratorV04baseE00bE0QzvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "transform",
+              "printedName": "transform",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async -> τ_0_1",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency16AsyncMapSequenceV8IteratorV9transformyq_7ElementQzYacvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "isLet": true,
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "Function",
+                      "printedName": "(τ_0_0.Element) async -> τ_0_1",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "GenericTypeParam",
+                          "printedName": "τ_0_1"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "DependentMember",
+                          "printedName": "τ_0_0.Element"
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency16AsyncMapSequenceV8IteratorV9transformyq_7ElementQzYacvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                }
+              ]
+            },
+            {
+              "kind": "Constructor",
+              "name": "init",
+              "printedName": "init(_:transform:)",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncMapSequence<τ_0_0, τ_0_1>.Iterator",
+                  "usr": "s:12_Concurrency16AsyncMapSequenceV8IteratorV"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                },
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async -> τ_0_1",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Constructor",
+              "usr": "s:12_Concurrency16AsyncMapSequenceV8IteratorV_9transformAEyxq__G0bE0Qz_q_7ElementQzYactcfc",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "init_kind": "Designated"
+            },
+            {
+              "kind": "Function",
+              "name": "next",
+              "printedName": "next()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_1?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:12_Concurrency16AsyncMapSequenceV8IteratorV4nextq_SgyYaKF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "Rethrows",
+                "Mutating",
+                "AccessControl",
+                "Inlinable"
+              ],
+              "throwing": true,
+              "funcSelfKind": "Mutating"
+            }
+          ],
+          "declKind": "Struct",
+          "usr": "s:12_Concurrency16AsyncMapSequenceV8IteratorV",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "conformances": [
+            {
+              "kind": "Conformance",
+              "name": "AsyncIteratorProtocol",
+              "printedName": "AsyncIteratorProtocol",
+              "children": [
+                {
+                  "kind": "TypeWitness",
+                  "name": "Element",
+                  "printedName": "Element",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    }
+                  ]
+                }
+              ],
+              "usr": "s:ScI"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "makeAsyncIterator",
+          "printedName": "makeAsyncIterator()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Iterator",
+              "printedName": "_Concurrency.AsyncMapSequence<τ_0_0, τ_0_1>.Iterator",
+              "usr": "s:12_Concurrency16AsyncMapSequenceV8IteratorV"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency16AsyncMapSequenceV04makeB8IteratorAC0F0Vyxq__GyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:12_Concurrency16AsyncMapSequenceV",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+      "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "AsyncSequence",
+          "printedName": "AsyncSequence",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "AsyncIterator",
+              "printedName": "AsyncIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncMapSequence<τ_0_0, τ_0_1>.Iterator",
+                  "usr": "s:12_Concurrency16AsyncMapSequenceV8IteratorV"
+                }
+              ]
+            },
+            {
+              "kind": "TypeWitness",
+              "name": "Element",
+              "printedName": "Element",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ]
+            }
+          ],
+          "usr": "s:Sci"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "AsyncPrefixSequence",
+      "printedName": "AsyncPrefixSequence",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "base",
+          "printedName": "base",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency19AsyncPrefixSequenceV4basexvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency19AsyncPrefixSequenceV4basexvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "count",
+          "printedName": "count",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Int",
+              "printedName": "Swift.Int",
+              "usr": "s:Si"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency19AsyncPrefixSequenceV5countSivp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Int",
+                  "printedName": "Swift.Int",
+                  "usr": "s:Si"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency19AsyncPrefixSequenceV5countSivg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(_:count:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncPrefixSequence",
+              "printedName": "_Concurrency.AsyncPrefixSequence<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:12_Concurrency19AsyncPrefixSequenceV"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Int",
+              "printedName": "Swift.Int",
+              "usr": "s:Si"
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:12_Concurrency19AsyncPrefixSequenceV_5countACyxGx_Sitcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "TypeDecl",
+          "name": "Iterator",
+          "printedName": "Iterator",
+          "children": [
+            {
+              "kind": "Var",
+              "name": "baseIterator",
+              "printedName": "baseIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency19AsyncPrefixSequenceV8IteratorV04baseE00bE0Qzvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency19AsyncPrefixSequenceV8IteratorV04baseE00bE0Qzvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency19AsyncPrefixSequenceV8IteratorV04baseE00bE0Qzvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency19AsyncPrefixSequenceV8IteratorV04baseE00bE0QzvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "remaining",
+              "printedName": "remaining",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Int",
+                  "printedName": "Swift.Int",
+                  "usr": "s:Si"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency19AsyncPrefixSequenceV8IteratorV9remainingSivp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Int",
+                      "printedName": "Swift.Int",
+                      "usr": "s:Si"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency19AsyncPrefixSequenceV8IteratorV9remainingSivg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Int",
+                      "printedName": "Swift.Int",
+                      "usr": "s:Si"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency19AsyncPrefixSequenceV8IteratorV9remainingSivs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency19AsyncPrefixSequenceV8IteratorV9remainingSivM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Constructor",
+              "name": "init",
+              "printedName": "init(_:count:)",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncPrefixSequence<τ_0_0>.Iterator",
+                  "usr": "s:12_Concurrency19AsyncPrefixSequenceV8IteratorV"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "Int",
+                  "printedName": "Swift.Int",
+                  "usr": "s:Si"
+                }
+              ],
+              "declKind": "Constructor",
+              "usr": "s:12_Concurrency19AsyncPrefixSequenceV8IteratorV_5countAEyx_G0bE0Qz_Sitcfc",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "init_kind": "Designated"
+            },
+            {
+              "kind": "Function",
+              "name": "next",
+              "printedName": "next()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_0.Element?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:12_Concurrency19AsyncPrefixSequenceV8IteratorV4next7ElementQzSgyYaKF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "Rethrows",
+                "Mutating",
+                "AccessControl",
+                "Inlinable"
+              ],
+              "throwing": true,
+              "funcSelfKind": "Mutating"
+            }
+          ],
+          "declKind": "Struct",
+          "usr": "s:12_Concurrency19AsyncPrefixSequenceV8IteratorV",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "conformances": [
+            {
+              "kind": "Conformance",
+              "name": "AsyncIteratorProtocol",
+              "printedName": "AsyncIteratorProtocol",
+              "children": [
+                {
+                  "kind": "TypeWitness",
+                  "name": "Element",
+                  "printedName": "Element",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "usr": "s:ScI"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "makeAsyncIterator",
+          "printedName": "makeAsyncIterator()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Iterator",
+              "printedName": "_Concurrency.AsyncPrefixSequence<τ_0_0>.Iterator",
+              "usr": "s:12_Concurrency19AsyncPrefixSequenceV8IteratorV"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency19AsyncPrefixSequenceV04makeB8IteratorAC0F0Vyx_GyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:12_Concurrency19AsyncPrefixSequenceV",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+      "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "AsyncSequence",
+          "printedName": "AsyncSequence",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "AsyncIterator",
+              "printedName": "AsyncIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncPrefixSequence<τ_0_0>.Iterator",
+                  "usr": "s:12_Concurrency19AsyncPrefixSequenceV8IteratorV"
+                }
+              ]
+            },
+            {
+              "kind": "TypeWitness",
+              "name": "Element",
+              "printedName": "Element",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "usr": "s:Sci"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "AsyncPrefixWhileSequence",
+      "printedName": "AsyncPrefixWhileSequence",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "base",
+          "printedName": "base",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV4basexvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV4basexvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "predicate",
+          "printedName": "predicate",
+          "children": [
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV9predicateySb7ElementQzYacvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV9predicateySb7ElementQzYacvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(_:predicate:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncPrefixWhileSequence",
+              "printedName": "_Concurrency.AsyncPrefixWhileSequence<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV_9predicateACyxGx_Sb7ElementQzYactcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "TypeDecl",
+          "name": "Iterator",
+          "printedName": "Iterator",
+          "children": [
+            {
+              "kind": "Var",
+              "name": "predicateHasFailed",
+              "printedName": "predicateHasFailed",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV8IteratorV18predicateHasFailedSbvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV8IteratorV18predicateHasFailedSbvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV8IteratorV18predicateHasFailedSbvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV8IteratorV18predicateHasFailedSbvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "baseIterator",
+              "printedName": "baseIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV8IteratorV04baseF00bF0Qzvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV8IteratorV04baseF00bF0Qzvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV8IteratorV04baseF00bF0Qzvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV8IteratorV04baseF00bF0QzvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "predicate",
+              "printedName": "predicate",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV8IteratorV9predicateySb7ElementQzYacvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "isLet": true,
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "Function",
+                      "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Bool",
+                          "printedName": "Swift.Bool",
+                          "usr": "s:Sb"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "DependentMember",
+                          "printedName": "τ_0_0.Element"
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV8IteratorV9predicateySb7ElementQzYacvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                }
+              ]
+            },
+            {
+              "kind": "Constructor",
+              "name": "init",
+              "printedName": "init(_:predicate:)",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncPrefixWhileSequence<τ_0_0>.Iterator",
+                  "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV8IteratorV"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                },
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Constructor",
+              "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV8IteratorV_9predicateAEyx_G0bF0Qz_Sb7ElementQzYactcfc",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "init_kind": "Designated"
+            },
+            {
+              "kind": "Function",
+              "name": "next",
+              "printedName": "next()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_0.Element?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV8IteratorV4next7ElementQzSgyYaKF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "Rethrows",
+                "Mutating",
+                "AccessControl",
+                "Inlinable"
+              ],
+              "throwing": true,
+              "funcSelfKind": "Mutating"
+            }
+          ],
+          "declKind": "Struct",
+          "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV8IteratorV",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "conformances": [
+            {
+              "kind": "Conformance",
+              "name": "AsyncIteratorProtocol",
+              "printedName": "AsyncIteratorProtocol",
+              "children": [
+                {
+                  "kind": "TypeWitness",
+                  "name": "Element",
+                  "printedName": "Element",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "usr": "s:ScI"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "makeAsyncIterator",
+          "printedName": "makeAsyncIterator()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Iterator",
+              "printedName": "_Concurrency.AsyncPrefixWhileSequence<τ_0_0>.Iterator",
+              "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV8IteratorV"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV04makeB8IteratorAC0G0Vyx_GyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+      "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "AsyncSequence",
+          "printedName": "AsyncSequence",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "AsyncIterator",
+              "printedName": "AsyncIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncPrefixWhileSequence<τ_0_0>.Iterator",
+                  "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV8IteratorV"
+                }
+              ]
+            },
+            {
+              "kind": "TypeWitness",
+              "name": "Element",
+              "printedName": "Element",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "usr": "s:Sci"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "AsyncSequence",
+      "printedName": "AsyncSequence",
+      "children": [
+        {
+          "kind": "AssociatedType",
+          "name": "AsyncIterator",
+          "printedName": "AsyncIterator",
+          "declKind": "AssociatedType",
+          "usr": "s:Sci13AsyncIteratorQa",
+          "moduleName": "_Concurrency",
+          "protocolReq": true
+        },
+        {
+          "kind": "AssociatedType",
+          "name": "Element",
+          "printedName": "Element",
+          "declKind": "AssociatedType",
+          "usr": "s:Sci7ElementQa",
+          "moduleName": "_Concurrency",
+          "protocolReq": true
+        },
+        {
+          "kind": "Function",
+          "name": "makeAsyncIterator",
+          "printedName": "makeAsyncIterator()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "DependentMember",
+              "printedName": "τ_0_0.AsyncIterator"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci17makeAsyncIterator0bC0QzyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.AsyncSequence>",
+          "protocolReq": true,
+          "declAttributes": [
+            "Consuming"
+          ],
+          "reqNewWitnessTableEntry": true,
+          "funcSelfKind": "__Consuming"
+        },
+        {
+          "kind": "Function",
+          "name": "compactMap",
+          "printedName": "compactMap(_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncCompactMapSequence",
+              "printedName": "_Concurrency.AsyncCompactMapSequence<τ_0_0, τ_1_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_1_0"
+                }
+              ],
+              "usr": "s:12_Concurrency23AsyncCompactMapSequenceV"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async -> τ_1_0?",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_1_0?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_1_0"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE10compactMapyAA012AsyncCompactC8SequenceVyxqd__Gqd__Sg7ElementQzYaclF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_1_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self, ElementOfResult where Self : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        },
+        {
+          "kind": "Function",
+          "name": "dropFirst",
+          "printedName": "dropFirst(_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncDropFirstSequence",
+              "printedName": "_Concurrency.AsyncDropFirstSequence<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:12_Concurrency22AsyncDropFirstSequenceV"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Int",
+              "printedName": "Swift.Int",
+              "hasDefaultArg": true,
+              "usr": "s:Si"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE9dropFirstyAA09AsyncDropC8SequenceVyxGSiF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        },
+        {
+          "kind": "Function",
+          "name": "drop",
+          "printedName": "drop(while:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncDropWhileSequence",
+              "printedName": "_Concurrency.AsyncDropWhileSequence<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:12_Concurrency22AsyncDropWhileSequenceV"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE4drop5whileAA22AsyncDropWhileSequenceVyxGSb7ElementQzYac_tF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        },
+        {
+          "kind": "Function",
+          "name": "filter",
+          "printedName": "filter(_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncFilterSequence",
+              "printedName": "_Concurrency.AsyncFilterSequence<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:12_Concurrency19AsyncFilterSequenceV"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE6filteryAA19AsyncFilterSequenceVyxGSb7ElementQzYacF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        },
+        {
+          "kind": "Function",
+          "name": "flatMap",
+          "printedName": "flatMap(_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncFlatMapSequence",
+              "printedName": "_Concurrency.AsyncFlatMapSequence<τ_0_0, τ_1_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_1_0"
+                }
+              ],
+              "usr": "s:12_Concurrency20AsyncFlatMapSequenceV"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async -> τ_1_0",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_1_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE7flatMapyAA09AsyncFlatC8SequenceVyxqd__Gqd__7ElementQzYacSciRd__lF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_1_0 where τ_0_0 : _Concurrency.AsyncSequence, τ_1_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self, SegmentOfResult where Self : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        },
+        {
+          "kind": "Function",
+          "name": "map",
+          "printedName": "map(_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncMapSequence",
+              "printedName": "_Concurrency.AsyncMapSequence<τ_0_0, τ_1_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_1_0"
+                }
+              ],
+              "usr": "s:12_Concurrency16AsyncMapSequenceV"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async -> τ_1_0",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_1_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE3mapyAA16AsyncMapSequenceVyxqd__Gqd__7ElementQzYaclF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_1_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self, Transformed where Self : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        },
+        {
+          "kind": "Function",
+          "name": "prefix",
+          "printedName": "prefix(_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncPrefixSequence",
+              "printedName": "_Concurrency.AsyncPrefixSequence<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:12_Concurrency19AsyncPrefixSequenceV"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Int",
+              "printedName": "Swift.Int",
+              "usr": "s:Si"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE6prefixyAA19AsyncPrefixSequenceVyxGSiF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        },
+        {
+          "kind": "Function",
+          "name": "prefix",
+          "printedName": "prefix(while:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncPrefixWhileSequence",
+              "printedName": "_Concurrency.AsyncPrefixWhileSequence<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:12_Concurrency24AsyncPrefixWhileSequenceV"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE6prefix5whileAA24AsyncPrefixWhileSequenceVyxGSb7ElementQzYac_tKF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "Rethrows",
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "throwing": true,
+          "funcSelfKind": "__Consuming"
+        },
+        {
+          "kind": "Function",
+          "name": "reduce",
+          "printedName": "reduce(_:_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_1_0"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_1_0"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_1_0, τ_0_0.Element) async throws -> τ_1_0",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_1_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "Tuple",
+                  "printedName": "(τ_1_0, τ_0_0.Element)",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_1_0"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "typeAttributes": [
+                "noescape"
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE6reduceyqd__qd___qd__qd___7ElementQztYaKXEtYaKlF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_1_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self, Result where Self : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "Rethrows",
+            "AccessControl",
+            "Inlinable"
+          ],
+          "throwing": true,
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "reduce",
+          "printedName": "reduce(into:_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_1_0"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_1_0",
+              "paramValueOwnership": "Owned"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(inout τ_1_0, τ_0_0.Element) async throws -> ()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Void",
+                  "printedName": "()"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "Tuple",
+                  "printedName": "(inout τ_1_0, τ_0_0.Element)",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "InOut",
+                      "printedName": "inout τ_1_0"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "typeAttributes": [
+                "noescape"
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE6reduce4into_qd__qd__n_yqd__z_7ElementQztYaKXEtYaKlF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_1_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self, Result where Self : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "Rethrows",
+            "AccessControl",
+            "Inlinable"
+          ],
+          "throwing": true,
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "contains",
+          "printedName": "contains(where:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ],
+              "typeAttributes": [
+                "noescape"
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE8contains5whereS2b7ElementQzYaKXE_tYaKF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "Rethrows",
+            "AccessControl",
+            "Inlinable"
+          ],
+          "throwing": true,
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "allSatisfy",
+          "printedName": "allSatisfy(_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ],
+              "typeAttributes": [
+                "noescape"
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE10allSatisfyyS2b7ElementQzYaKXEYaKF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "Rethrows",
+            "AccessControl",
+            "Inlinable"
+          ],
+          "throwing": true,
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "contains",
+          "printedName": "contains(_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "DependentMember",
+              "printedName": "τ_0_0.Element"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencySQ7ElementRpzrlE8containsySbACYaKF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_0.Element : Swift.Equatable>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.AsyncSequence, Self.Element : Swift.Equatable>",
+          "declAttributes": [
+            "Rethrows",
+            "AccessControl",
+            "Inlinable"
+          ],
+          "throwing": true,
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "first",
+          "printedName": "first(where:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Optional",
+              "printedName": "τ_0_0.Element?",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ],
+              "usr": "s:Sq"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ],
+              "typeAttributes": [
+                "noescape"
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE5first5where7ElementQzSgSbAEYaKXE_tYaKF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "Rethrows",
+            "AccessControl",
+            "Inlinable"
+          ],
+          "throwing": true,
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "min",
+          "printedName": "min(by:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Optional",
+              "printedName": "τ_0_0.Element?",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ],
+              "usr": "s:Sq"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element, τ_0_0.Element) async throws -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "Tuple",
+                  "printedName": "(τ_0_0.Element, τ_0_0.Element)",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "typeAttributes": [
+                "noescape"
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE3min2by7ElementQzSgSbAE_AEtYaKXE_tYaKF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "Rethrows",
+            "AccessControl",
+            "Inlinable",
+            "WarnUnqualifiedAccess"
+          ],
+          "throwing": true,
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "max",
+          "printedName": "max(by:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Optional",
+              "printedName": "τ_0_0.Element?",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ],
+              "usr": "s:Sq"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element, τ_0_0.Element) async throws -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "Tuple",
+                  "printedName": "(τ_0_0.Element, τ_0_0.Element)",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "typeAttributes": [
+                "noescape"
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE3max2by7ElementQzSgSbAE_AEtYaKXE_tYaKF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "Rethrows",
+            "AccessControl",
+            "Inlinable",
+            "WarnUnqualifiedAccess"
+          ],
+          "throwing": true,
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "min",
+          "printedName": "min()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Optional",
+              "printedName": "τ_0_0.Element?",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ],
+              "usr": "s:Sq"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencySL7ElementRpzrlE3minACSgyYaKF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_0.Element : Swift.Comparable>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.AsyncSequence, Self.Element : Swift.Comparable>",
+          "declAttributes": [
+            "Rethrows",
+            "AccessControl",
+            "Inlinable",
+            "WarnUnqualifiedAccess"
+          ],
+          "throwing": true,
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "max",
+          "printedName": "max()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Optional",
+              "printedName": "τ_0_0.Element?",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ],
+              "usr": "s:Sq"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencySL7ElementRpzrlE3maxACSgyYaKF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_0.Element : Swift.Comparable>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.AsyncSequence, Self.Element : Swift.Comparable>",
+          "declAttributes": [
+            "Rethrows",
+            "AccessControl",
+            "Inlinable",
+            "WarnUnqualifiedAccess"
+          ],
+          "throwing": true,
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "compactMap",
+          "printedName": "compactMap(_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncThrowingCompactMapSequence",
+              "printedName": "_Concurrency.AsyncThrowingCompactMapSequence<τ_0_0, τ_1_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_1_0"
+                }
+              ],
+              "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> τ_1_0?",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_1_0?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_1_0"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE10compactMapyAA020AsyncThrowingCompactC8SequenceVyxqd__Gqd__Sg7ElementQzYaKclF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_1_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self, ElementOfResult where Self : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        },
+        {
+          "kind": "Function",
+          "name": "drop",
+          "printedName": "drop(while:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncThrowingDropWhileSequence",
+              "printedName": "_Concurrency.AsyncThrowingDropWhileSequence<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE4drop5whileAA30AsyncThrowingDropWhileSequenceVyxGSb7ElementQzYaKc_tF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        },
+        {
+          "kind": "Function",
+          "name": "filter",
+          "printedName": "filter(_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncThrowingFilterSequence",
+              "printedName": "_Concurrency.AsyncThrowingFilterSequence<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE6filteryAA27AsyncThrowingFilterSequenceVyxGSb7ElementQzYaKcF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        },
+        {
+          "kind": "Function",
+          "name": "flatMap",
+          "printedName": "flatMap(_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncThrowingFlatMapSequence",
+              "printedName": "_Concurrency.AsyncThrowingFlatMapSequence<τ_0_0, τ_1_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_1_0"
+                }
+              ],
+              "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> τ_1_0",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_1_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE7flatMapyAA017AsyncThrowingFlatC8SequenceVyxqd__Gqd__7ElementQzYaKcSciRd__lF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_1_0 where τ_0_0 : _Concurrency.AsyncSequence, τ_1_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self, SegmentOfResult where Self : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        },
+        {
+          "kind": "Function",
+          "name": "map",
+          "printedName": "map(_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncThrowingMapSequence",
+              "printedName": "_Concurrency.AsyncThrowingMapSequence<τ_0_0, τ_1_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_1_0"
+                }
+              ],
+              "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> τ_1_0",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_1_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE3mapyAA24AsyncThrowingMapSequenceVyxqd__Gqd__7ElementQzYaKclF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_1_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self, Transformed where Self : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        },
+        {
+          "kind": "Function",
+          "name": "prefix",
+          "printedName": "prefix(while:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncThrowingPrefixWhileSequence",
+              "printedName": "_Concurrency.AsyncThrowingPrefixWhileSequence<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sci12_ConcurrencyE6prefix5whileAA32AsyncThrowingPrefixWhileSequenceVyxGSb7ElementQzYaKc_tKF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Self where Self : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "Rethrows",
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "throwing": true,
+          "funcSelfKind": "__Consuming"
+        }
+      ],
+      "declKind": "Protocol",
+      "usr": "s:Sci",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0.AsyncIterator : _Concurrency.AsyncIteratorProtocol, τ_0_0.Element == τ_0_0.AsyncIterator.Element>",
+      "sugared_genericSig": "<Self.AsyncIterator : _Concurrency.AsyncIteratorProtocol, Self.Element == Self.AsyncIterator.Element>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "AtRethrows",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ]
+    },
+    {
+      "kind": "Function",
+      "name": "_contains",
+      "printedName": "_contains(_:where:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Bool",
+          "printedName": "Swift.Bool",
+          "usr": "s:Sb"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "GenericTypeParam",
+          "printedName": "τ_0_0"
+        },
+        {
+          "kind": "TypeFunc",
+          "name": "Function",
+          "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "DependentMember",
+              "printedName": "τ_0_0.Element"
+            }
+          ],
+          "typeAttributes": [
+            "noescape"
+          ]
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency9_contains_5whereSbx_Sb7ElementQzYaKXEtYaKSciRzlF",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+      "sugared_genericSig": "<Source where Source : _Concurrency.AsyncSequence>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "Rethrows",
+        "AccessControl",
+        "Inline",
+        "Inlinable",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "throwing": true,
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "_first",
+      "printedName": "_first(_:where:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Optional",
+          "printedName": "τ_0_0.Element?",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "DependentMember",
+              "printedName": "τ_0_0.Element"
+            }
+          ],
+          "usr": "s:Sq"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "GenericTypeParam",
+          "printedName": "τ_0_0"
+        },
+        {
+          "kind": "TypeFunc",
+          "name": "Function",
+          "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "DependentMember",
+              "printedName": "τ_0_0.Element"
+            }
+          ],
+          "typeAttributes": [
+            "noescape"
+          ]
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency6_first_5where7ElementQzSgx_SbAEYaKXEtYaKSciRzlF",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+      "sugared_genericSig": "<Source where Source : _Concurrency.AsyncSequence>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "Rethrows",
+        "AccessControl",
+        "Inline",
+        "Inlinable",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "throwing": true,
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "AsyncThrowingCompactMapSequence",
+      "printedName": "AsyncThrowingCompactMapSequence",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "base",
+          "printedName": "base",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV4basexvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV4basexvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "transform",
+          "printedName": "transform",
+          "children": [
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> τ_0_1?",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_1?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV9transformyq_Sg7ElementQzYaKcvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async throws -> τ_0_1?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Optional",
+                      "printedName": "τ_0_1?",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "GenericTypeParam",
+                          "printedName": "τ_0_1"
+                        }
+                      ],
+                      "usr": "s:Sq"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV9transformyq_Sg7ElementQzYaKcvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(_:transform:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncThrowingCompactMapSequence",
+              "printedName": "_Concurrency.AsyncThrowingCompactMapSequence<τ_0_0, τ_0_1>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ],
+              "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> τ_0_1?",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_1?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV_9transformACyxq_Gx_q_Sg7ElementQzYaKctcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "TypeDecl",
+          "name": "Iterator",
+          "printedName": "Iterator",
+          "children": [
+            {
+              "kind": "Var",
+              "name": "baseIterator",
+              "printedName": "baseIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV8IteratorV04baseG00bG0Qzvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV8IteratorV04baseG00bG0Qzvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV8IteratorV04baseG00bG0Qzvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV8IteratorV04baseG00bG0QzvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "transform",
+              "printedName": "transform",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async throws -> τ_0_1?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Optional",
+                      "printedName": "τ_0_1?",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "GenericTypeParam",
+                          "printedName": "τ_0_1"
+                        }
+                      ],
+                      "usr": "s:Sq"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV8IteratorV9transformyq_Sg7ElementQzYaKcvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "isLet": true,
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "Function",
+                      "printedName": "(τ_0_0.Element) async throws -> τ_0_1?",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Optional",
+                          "printedName": "τ_0_1?",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "GenericTypeParam",
+                              "printedName": "τ_0_1"
+                            }
+                          ],
+                          "usr": "s:Sq"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "DependentMember",
+                          "printedName": "τ_0_0.Element"
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV8IteratorV9transformyq_Sg7ElementQzYaKcvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "finished",
+              "printedName": "finished",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV8IteratorV8finishedSbvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV8IteratorV8finishedSbvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV8IteratorV8finishedSbvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV8IteratorV8finishedSbvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Constructor",
+              "name": "init",
+              "printedName": "init(_:transform:)",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncThrowingCompactMapSequence<τ_0_0, τ_0_1>.Iterator",
+                  "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV8IteratorV"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                },
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async throws -> τ_0_1?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Optional",
+                      "printedName": "τ_0_1?",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "GenericTypeParam",
+                          "printedName": "τ_0_1"
+                        }
+                      ],
+                      "usr": "s:Sq"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Constructor",
+              "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV8IteratorV_9transformAEyxq__G0bG0Qz_q_Sg7ElementQzYaKctcfc",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "init_kind": "Designated"
+            },
+            {
+              "kind": "Function",
+              "name": "next",
+              "printedName": "next()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_1?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV8IteratorV4nextq_SgyYaKF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "Mutating",
+                "AccessControl",
+                "Inlinable"
+              ],
+              "throwing": true,
+              "funcSelfKind": "Mutating"
+            }
+          ],
+          "declKind": "Struct",
+          "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV8IteratorV",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "conformances": [
+            {
+              "kind": "Conformance",
+              "name": "AsyncIteratorProtocol",
+              "printedName": "AsyncIteratorProtocol",
+              "children": [
+                {
+                  "kind": "TypeWitness",
+                  "name": "Element",
+                  "printedName": "Element",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    }
+                  ]
+                }
+              ],
+              "usr": "s:ScI"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "makeAsyncIterator",
+          "printedName": "makeAsyncIterator()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Iterator",
+              "printedName": "_Concurrency.AsyncThrowingCompactMapSequence<τ_0_0, τ_0_1>.Iterator",
+              "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV8IteratorV"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV04makeB8IteratorAC0H0Vyxq__GyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+      "sugared_genericSig": "<Base, ElementOfResult where Base : _Concurrency.AsyncSequence>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "AsyncSequence",
+          "printedName": "AsyncSequence",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "AsyncIterator",
+              "printedName": "AsyncIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncThrowingCompactMapSequence<τ_0_0, τ_0_1>.Iterator",
+                  "usr": "s:12_Concurrency31AsyncThrowingCompactMapSequenceV8IteratorV"
+                }
+              ]
+            },
+            {
+              "kind": "TypeWitness",
+              "name": "Element",
+              "printedName": "Element",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ]
+            }
+          ],
+          "usr": "s:Sci"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "AsyncThrowingDropWhileSequence",
+      "printedName": "AsyncThrowingDropWhileSequence",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "base",
+          "printedName": "base",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV4basexvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV4basexvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "predicate",
+          "printedName": "predicate",
+          "children": [
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV9predicateySb7ElementQzYaKcvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV9predicateySb7ElementQzYaKcvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(_:predicate:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncThrowingDropWhileSequence",
+              "printedName": "_Concurrency.AsyncThrowingDropWhileSequence<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV_9predicateACyxGx_Sb7ElementQzYaKctcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "TypeDecl",
+          "name": "Iterator",
+          "printedName": "Iterator",
+          "children": [
+            {
+              "kind": "Var",
+              "name": "baseIterator",
+              "printedName": "baseIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV8IteratorV04baseG00bG0Qzvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV8IteratorV04baseG00bG0Qzvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV8IteratorV04baseG00bG0Qzvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV8IteratorV04baseG00bG0QzvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "predicate",
+              "printedName": "predicate",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV8IteratorV9predicateySb7ElementQzYaKcvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "isLet": true,
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "Function",
+                      "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Bool",
+                          "printedName": "Swift.Bool",
+                          "usr": "s:Sb"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "DependentMember",
+                          "printedName": "τ_0_0.Element"
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV8IteratorV9predicateySb7ElementQzYaKcvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "finished",
+              "printedName": "finished",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV8IteratorV8finishedSbvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV8IteratorV8finishedSbvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV8IteratorV8finishedSbvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV8IteratorV8finishedSbvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "doneDropping",
+              "printedName": "doneDropping",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV8IteratorV12doneDroppingSbvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV8IteratorV12doneDroppingSbvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV8IteratorV12doneDroppingSbvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV8IteratorV12doneDroppingSbvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Constructor",
+              "name": "init",
+              "printedName": "init(_:predicate:)",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncThrowingDropWhileSequence<τ_0_0>.Iterator",
+                  "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV8IteratorV"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                },
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Constructor",
+              "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV8IteratorV_9predicateAEyx_G0bG0Qz_Sb7ElementQzYaKctcfc",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "init_kind": "Designated"
+            },
+            {
+              "kind": "Function",
+              "name": "next",
+              "printedName": "next()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_0.Element?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV8IteratorV4next7ElementQzSgyYaKF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "Mutating",
+                "AccessControl",
+                "Inlinable"
+              ],
+              "throwing": true,
+              "funcSelfKind": "Mutating"
+            }
+          ],
+          "declKind": "Struct",
+          "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV8IteratorV",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "conformances": [
+            {
+              "kind": "Conformance",
+              "name": "AsyncIteratorProtocol",
+              "printedName": "AsyncIteratorProtocol",
+              "children": [
+                {
+                  "kind": "TypeWitness",
+                  "name": "Element",
+                  "printedName": "Element",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "usr": "s:ScI"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "makeAsyncIterator",
+          "printedName": "makeAsyncIterator()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Iterator",
+              "printedName": "_Concurrency.AsyncThrowingDropWhileSequence<τ_0_0>.Iterator",
+              "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV8IteratorV"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV04makeB8IteratorAC0H0Vyx_GyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+      "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "AsyncSequence",
+          "printedName": "AsyncSequence",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "AsyncIterator",
+              "printedName": "AsyncIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncThrowingDropWhileSequence<τ_0_0>.Iterator",
+                  "usr": "s:12_Concurrency30AsyncThrowingDropWhileSequenceV8IteratorV"
+                }
+              ]
+            },
+            {
+              "kind": "TypeWitness",
+              "name": "Element",
+              "printedName": "Element",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "usr": "s:Sci"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "AsyncThrowingFilterSequence",
+      "printedName": "AsyncThrowingFilterSequence",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "base",
+          "printedName": "base",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV4basexvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV4basexvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "isIncluded",
+          "printedName": "isIncluded",
+          "children": [
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV10isIncludedySb7ElementQzYaKcvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV10isIncludedySb7ElementQzYaKcvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(_:isIncluded:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncThrowingFilterSequence",
+              "printedName": "_Concurrency.AsyncThrowingFilterSequence<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV_10isIncludedACyxGx_Sb7ElementQzYaKctcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "TypeDecl",
+          "name": "Iterator",
+          "printedName": "Iterator",
+          "children": [
+            {
+              "kind": "Var",
+              "name": "baseIterator",
+              "printedName": "baseIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV8IteratorV04baseF00bF0Qzvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV8IteratorV04baseF00bF0Qzvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV8IteratorV04baseF00bF0Qzvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV8IteratorV04baseF00bF0QzvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "isIncluded",
+              "printedName": "isIncluded",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV8IteratorV10isIncludedySb7ElementQzYaKcvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "isLet": true,
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "Function",
+                      "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Bool",
+                          "printedName": "Swift.Bool",
+                          "usr": "s:Sb"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "DependentMember",
+                          "printedName": "τ_0_0.Element"
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV8IteratorV10isIncludedySb7ElementQzYaKcvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "finished",
+              "printedName": "finished",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV8IteratorV8finishedSbvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV8IteratorV8finishedSbvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV8IteratorV8finishedSbvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV8IteratorV8finishedSbvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Constructor",
+              "name": "init",
+              "printedName": "init(_:isIncluded:)",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncThrowingFilterSequence<τ_0_0>.Iterator",
+                  "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV8IteratorV"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                },
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Constructor",
+              "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV8IteratorV_10isIncludedAEyx_G0bF0Qz_Sb7ElementQzYaKctcfc",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "init_kind": "Designated"
+            },
+            {
+              "kind": "Function",
+              "name": "next",
+              "printedName": "next()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_0.Element?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV8IteratorV4next7ElementQzSgyYaKF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "Mutating",
+                "AccessControl",
+                "Inlinable"
+              ],
+              "throwing": true,
+              "funcSelfKind": "Mutating"
+            }
+          ],
+          "declKind": "Struct",
+          "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV8IteratorV",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "conformances": [
+            {
+              "kind": "Conformance",
+              "name": "AsyncIteratorProtocol",
+              "printedName": "AsyncIteratorProtocol",
+              "children": [
+                {
+                  "kind": "TypeWitness",
+                  "name": "Element",
+                  "printedName": "Element",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "usr": "s:ScI"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "makeAsyncIterator",
+          "printedName": "makeAsyncIterator()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Iterator",
+              "printedName": "_Concurrency.AsyncThrowingFilterSequence<τ_0_0>.Iterator",
+              "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV8IteratorV"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV04makeB8IteratorAC0G0Vyx_GyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+      "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "AsyncSequence",
+          "printedName": "AsyncSequence",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "AsyncIterator",
+              "printedName": "AsyncIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncThrowingFilterSequence<τ_0_0>.Iterator",
+                  "usr": "s:12_Concurrency27AsyncThrowingFilterSequenceV8IteratorV"
+                }
+              ]
+            },
+            {
+              "kind": "TypeWitness",
+              "name": "Element",
+              "printedName": "Element",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "usr": "s:Sci"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "AsyncThrowingFlatMapSequence",
+      "printedName": "AsyncThrowingFlatMapSequence",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "base",
+          "printedName": "base",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV4basexvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV4basexvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "transform",
+          "printedName": "transform",
+          "children": [
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> τ_0_1",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV9transformyq_7ElementQzYaKcvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async throws -> τ_0_1",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV9transformyq_7ElementQzYaKcvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(_:transform:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncThrowingFlatMapSequence",
+              "printedName": "_Concurrency.AsyncThrowingFlatMapSequence<τ_0_0, τ_0_1>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ],
+              "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> τ_0_1",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV_9transformACyxq_Gx_q_7ElementQzYaKctcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "TypeDecl",
+          "name": "Iterator",
+          "printedName": "Iterator",
+          "children": [
+            {
+              "kind": "Var",
+              "name": "baseIterator",
+              "printedName": "baseIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV8IteratorV04baseG00bG0Qzvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV8IteratorV04baseG00bG0Qzvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV8IteratorV04baseG00bG0Qzvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV8IteratorV04baseG00bG0QzvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "transform",
+              "printedName": "transform",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async throws -> τ_0_1",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV8IteratorV9transformyq_7ElementQzYaKcvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "isLet": true,
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "Function",
+                      "printedName": "(τ_0_0.Element) async throws -> τ_0_1",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "GenericTypeParam",
+                          "printedName": "τ_0_1"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "DependentMember",
+                          "printedName": "τ_0_0.Element"
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV8IteratorV9transformyq_7ElementQzYaKcvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "currentIterator",
+              "printedName": "currentIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_1.AsyncIterator?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_1.AsyncIterator"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV8IteratorV07currentG00bG0Qy_Sgvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasInitialValue",
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Optional",
+                      "printedName": "τ_0_1.AsyncIterator?",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "DependentMember",
+                          "printedName": "τ_0_1.AsyncIterator"
+                        }
+                      ],
+                      "usr": "s:Sq"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV8IteratorV07currentG00bG0Qy_Sgvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Optional",
+                      "printedName": "τ_0_1.AsyncIterator?",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "DependentMember",
+                          "printedName": "τ_0_1.AsyncIterator"
+                        }
+                      ],
+                      "usr": "s:Sq"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV8IteratorV07currentG00bG0Qy_Sgvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV8IteratorV07currentG00bG0Qy_SgvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "finished",
+              "printedName": "finished",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV8IteratorV8finishedSbvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV8IteratorV8finishedSbvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV8IteratorV8finishedSbvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV8IteratorV8finishedSbvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Constructor",
+              "name": "init",
+              "printedName": "init(_:transform:)",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncThrowingFlatMapSequence<τ_0_0, τ_0_1>.Iterator",
+                  "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV8IteratorV"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                },
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async throws -> τ_0_1",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Constructor",
+              "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV8IteratorV_9transformAEyxq__G0bG0Qz_q_7ElementQzYaKctcfc",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "init_kind": "Designated"
+            },
+            {
+              "kind": "Function",
+              "name": "next",
+              "printedName": "next()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_1.Element?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_1.Element"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV8IteratorV4next7ElementQy_SgyYaKF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "Mutating",
+                "AccessControl",
+                "Inlinable"
+              ],
+              "throwing": true,
+              "funcSelfKind": "Mutating"
+            }
+          ],
+          "declKind": "Struct",
+          "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV8IteratorV",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "conformances": [
+            {
+              "kind": "Conformance",
+              "name": "AsyncIteratorProtocol",
+              "printedName": "AsyncIteratorProtocol",
+              "children": [
+                {
+                  "kind": "TypeWitness",
+                  "name": "Element",
+                  "printedName": "Element",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_1.Element"
+                    }
+                  ]
+                }
+              ],
+              "usr": "s:ScI"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "makeAsyncIterator",
+          "printedName": "makeAsyncIterator()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Iterator",
+              "printedName": "_Concurrency.AsyncThrowingFlatMapSequence<τ_0_0, τ_0_1>.Iterator",
+              "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV8IteratorV"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV04makeB8IteratorAC0H0Vyxq__GyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence, τ_0_1 : _Concurrency.AsyncSequence>",
+      "sugared_genericSig": "<Base, SegmentOfResult where Base : _Concurrency.AsyncSequence, SegmentOfResult : _Concurrency.AsyncSequence>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "AsyncSequence",
+          "printedName": "AsyncSequence",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "AsyncIterator",
+              "printedName": "AsyncIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncThrowingFlatMapSequence<τ_0_0, τ_0_1>.Iterator",
+                  "usr": "s:12_Concurrency28AsyncThrowingFlatMapSequenceV8IteratorV"
+                }
+              ]
+            },
+            {
+              "kind": "TypeWitness",
+              "name": "Element",
+              "printedName": "Element",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_1.Element"
+                }
+              ]
+            }
+          ],
+          "usr": "s:Sci"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "AsyncThrowingMapSequence",
+      "printedName": "AsyncThrowingMapSequence",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "base",
+          "printedName": "base",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV4basexvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV4basexvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "transform",
+          "printedName": "transform",
+          "children": [
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> τ_0_1",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV9transformyq_7ElementQzYaKcvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async throws -> τ_0_1",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV9transformyq_7ElementQzYaKcvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(_:transform:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncThrowingMapSequence",
+              "printedName": "_Concurrency.AsyncThrowingMapSequence<τ_0_0, τ_0_1>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ],
+              "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> τ_0_1",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV_9transformACyxq_Gx_q_7ElementQzYaKctcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "TypeDecl",
+          "name": "Iterator",
+          "printedName": "Iterator",
+          "children": [
+            {
+              "kind": "Var",
+              "name": "baseIterator",
+              "printedName": "baseIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV8IteratorV04baseF00bF0Qzvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV8IteratorV04baseF00bF0Qzvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV8IteratorV04baseF00bF0Qzvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV8IteratorV04baseF00bF0QzvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "transform",
+              "printedName": "transform",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async throws -> τ_0_1",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV8IteratorV9transformyq_7ElementQzYaKcvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "isLet": true,
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "Function",
+                      "printedName": "(τ_0_0.Element) async throws -> τ_0_1",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "GenericTypeParam",
+                          "printedName": "τ_0_1"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "DependentMember",
+                          "printedName": "τ_0_0.Element"
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV8IteratorV9transformyq_7ElementQzYaKcvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "finished",
+              "printedName": "finished",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV8IteratorV8finishedSbvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV8IteratorV8finishedSbvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV8IteratorV8finishedSbvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV8IteratorV8finishedSbvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Constructor",
+              "name": "init",
+              "printedName": "init(_:transform:)",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncThrowingMapSequence<τ_0_0, τ_0_1>.Iterator",
+                  "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV8IteratorV"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                },
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async throws -> τ_0_1",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Constructor",
+              "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV8IteratorV_9transformAEyxq__G0bF0Qz_q_7ElementQzYaKctcfc",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "init_kind": "Designated"
+            },
+            {
+              "kind": "Function",
+              "name": "next",
+              "printedName": "next()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_1?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV8IteratorV4nextq_SgyYaKF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "Mutating",
+                "AccessControl",
+                "Inlinable"
+              ],
+              "throwing": true,
+              "funcSelfKind": "Mutating"
+            }
+          ],
+          "declKind": "Struct",
+          "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV8IteratorV",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "conformances": [
+            {
+              "kind": "Conformance",
+              "name": "AsyncIteratorProtocol",
+              "printedName": "AsyncIteratorProtocol",
+              "children": [
+                {
+                  "kind": "TypeWitness",
+                  "name": "Element",
+                  "printedName": "Element",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    }
+                  ]
+                }
+              ],
+              "usr": "s:ScI"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "makeAsyncIterator",
+          "printedName": "makeAsyncIterator()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Iterator",
+              "printedName": "_Concurrency.AsyncThrowingMapSequence<τ_0_0, τ_0_1>.Iterator",
+              "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV8IteratorV"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV04makeB8IteratorAC0G0Vyxq__GyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 : _Concurrency.AsyncSequence>",
+      "sugared_genericSig": "<Base, Transformed where Base : _Concurrency.AsyncSequence>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "AsyncSequence",
+          "printedName": "AsyncSequence",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "AsyncIterator",
+              "printedName": "AsyncIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncThrowingMapSequence<τ_0_0, τ_0_1>.Iterator",
+                  "usr": "s:12_Concurrency24AsyncThrowingMapSequenceV8IteratorV"
+                }
+              ]
+            },
+            {
+              "kind": "TypeWitness",
+              "name": "Element",
+              "printedName": "Element",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ]
+            }
+          ],
+          "usr": "s:Sci"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "AsyncThrowingPrefixWhileSequence",
+      "printedName": "AsyncThrowingPrefixWhileSequence",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "base",
+          "printedName": "base",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV4basexvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV4basexvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "predicate",
+          "printedName": "predicate",
+          "children": [
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV9predicateySb7ElementQzYaKcvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV9predicateySb7ElementQzYaKcvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(_:predicate:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncThrowingPrefixWhileSequence",
+              "printedName": "_Concurrency.AsyncThrowingPrefixWhileSequence<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV_9predicateACyxGx_Sb7ElementQzYaKctcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "TypeDecl",
+          "name": "Iterator",
+          "printedName": "Iterator",
+          "children": [
+            {
+              "kind": "Var",
+              "name": "predicateHasFailed",
+              "printedName": "predicateHasFailed",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV8IteratorV18predicateHasFailedSbvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV8IteratorV18predicateHasFailedSbvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV8IteratorV18predicateHasFailedSbvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV8IteratorV18predicateHasFailedSbvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "baseIterator",
+              "printedName": "baseIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV8IteratorV04baseG00bG0Qzvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV8IteratorV04baseG00bG0Qzvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.AsyncIterator"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV8IteratorV04baseG00bG0Qzvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV8IteratorV04baseG00bG0QzvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "predicate",
+              "printedName": "predicate",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV8IteratorV9predicateySb7ElementQzYaKcvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "isLet": true,
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "Function",
+                      "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Bool",
+                          "printedName": "Swift.Bool",
+                          "usr": "s:Sb"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "DependentMember",
+                          "printedName": "τ_0_0.Element"
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV8IteratorV9predicateySb7ElementQzYaKcvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+                  "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                }
+              ]
+            },
+            {
+              "kind": "Constructor",
+              "name": "init",
+              "printedName": "init(_:predicate:)",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncThrowingPrefixWhileSequence<τ_0_0>.Iterator",
+                  "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV8IteratorV"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.AsyncIterator"
+                },
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "(τ_0_0.Element) async throws -> Swift.Bool",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Constructor",
+              "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV8IteratorV_9predicateAEyx_G0bG0Qz_Sb7ElementQzYaKctcfc",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "init_kind": "Designated"
+            },
+            {
+              "kind": "Function",
+              "name": "next",
+              "printedName": "next()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_0.Element?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV8IteratorV4next7ElementQzSgyYaKF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+              "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+              "declAttributes": [
+                "Mutating",
+                "AccessControl",
+                "Inlinable"
+              ],
+              "throwing": true,
+              "funcSelfKind": "Mutating"
+            }
+          ],
+          "declKind": "Struct",
+          "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV8IteratorV",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "conformances": [
+            {
+              "kind": "Conformance",
+              "name": "AsyncIteratorProtocol",
+              "printedName": "AsyncIteratorProtocol",
+              "children": [
+                {
+                  "kind": "TypeWitness",
+                  "name": "Element",
+                  "printedName": "Element",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "DependentMember",
+                      "printedName": "τ_0_0.Element"
+                    }
+                  ]
+                }
+              ],
+              "usr": "s:ScI"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "makeAsyncIterator",
+          "printedName": "makeAsyncIterator()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Iterator",
+              "printedName": "_Concurrency.AsyncThrowingPrefixWhileSequence<τ_0_0>.Iterator",
+              "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV8IteratorV"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV04makeB8IteratorAC0H0Vyx_GyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+          "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+          "declAttributes": [
+            "AccessControl",
+            "Consuming",
+            "Inlinable"
+          ],
+          "funcSelfKind": "__Consuming"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.AsyncSequence>",
+      "sugared_genericSig": "<Base where Base : _Concurrency.AsyncSequence>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "AsyncSequence",
+          "printedName": "AsyncSequence",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "AsyncIterator",
+              "printedName": "AsyncIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncThrowingPrefixWhileSequence<τ_0_0>.Iterator",
+                  "usr": "s:12_Concurrency32AsyncThrowingPrefixWhileSequenceV8IteratorV"
+                }
+              ]
+            },
+            {
+              "kind": "TypeWitness",
+              "name": "Element",
+              "printedName": "Element",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.Element"
+                }
+              ]
+            }
+          ],
+          "usr": "s:Sci"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "GlobalActor",
+      "printedName": "GlobalActor",
+      "children": [
+        {
+          "kind": "AssociatedType",
+          "name": "ActorType",
+          "printedName": "ActorType",
+          "declKind": "AssociatedType",
+          "usr": "s:12_Concurrency11GlobalActorP0C4TypeQa",
+          "moduleName": "_Concurrency",
+          "protocolReq": true
+        },
+        {
+          "kind": "Var",
+          "name": "shared",
+          "printedName": "shared",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "DependentMember",
+              "printedName": "τ_0_0.ActorType"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency11GlobalActorP6shared0C4TypeQzvpZ",
+          "moduleName": "_Concurrency",
+          "static": true,
+          "protocolReq": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "DependentMember",
+                  "printedName": "τ_0_0.ActorType"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency11GlobalActorP6shared0C4TypeQzvgZ",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.GlobalActor>",
+              "sugared_genericSig": "<Self where Self : _Concurrency.GlobalActor>",
+              "static": true,
+              "protocolReq": true,
+              "reqNewWitnessTableEntry": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "sharedUnownedExecutor",
+          "printedName": "sharedUnownedExecutor",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "UnownedSerialExecutor",
+              "printedName": "_Concurrency.UnownedSerialExecutor",
+              "usr": "s:Sce"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency11GlobalActorP21sharedUnownedExecutorScevpZ",
+          "moduleName": "_Concurrency",
+          "static": true,
+          "protocolReq": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "UnownedSerialExecutor",
+                  "printedName": "_Concurrency.UnownedSerialExecutor",
+                  "usr": "s:Sce"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency11GlobalActorP21sharedUnownedExecutorScevgZ",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.GlobalActor>",
+              "sugared_genericSig": "<Self where Self : _Concurrency.GlobalActor>",
+              "static": true,
+              "protocolReq": true,
+              "reqNewWitnessTableEntry": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "sharedUnownedExecutor",
+          "printedName": "sharedUnownedExecutor",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "UnownedSerialExecutor",
+              "printedName": "_Concurrency.UnownedSerialExecutor",
+              "usr": "s:Sce"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency11GlobalActorPAAE21sharedUnownedExecutorScevpZ",
+          "moduleName": "_Concurrency",
+          "static": true,
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "UnownedSerialExecutor",
+                  "printedName": "_Concurrency.UnownedSerialExecutor",
+                  "usr": "s:Sce"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency11GlobalActorPAAE21sharedUnownedExecutorScevgZ",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 : _Concurrency.GlobalActor>",
+              "sugared_genericSig": "<Self where Self : _Concurrency.GlobalActor>",
+              "static": true,
+              "accessorKind": "get"
+            }
+          ]
+        }
+      ],
+      "declKind": "Protocol",
+      "usr": "s:12_Concurrency11GlobalActorP",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0.ActorType : _Concurrency.Actor>",
+      "sugared_genericSig": "<Self.ActorType : _Concurrency.Actor>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "MainActor",
+      "printedName": "MainActor",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "shared",
+          "printedName": "shared",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "MainActor",
+              "printedName": "_Concurrency.MainActor",
+              "usr": "s:ScM"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScM6sharedScMvpZ",
+          "moduleName": "_Concurrency",
+          "static": true,
+          "declAttributes": [
+            "Final",
+            "HasStorage",
+            "AccessControl"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "MainActor",
+                  "printedName": "_Concurrency.MainActor",
+                  "usr": "s:ScM"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScM6sharedScMvgZ",
+              "moduleName": "_Concurrency",
+              "static": true,
+              "implicit": true,
+              "declAttributes": [
+                "Final"
+              ],
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "unownedExecutor",
+          "printedName": "unownedExecutor",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "UnownedSerialExecutor",
+              "printedName": "_Concurrency.UnownedSerialExecutor",
+              "usr": "s:Sce"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScM15unownedExecutorScevp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl",
+            "Final",
+            "Nonisolated",
+            "Inlinable"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "UnownedSerialExecutor",
+                  "printedName": "_Concurrency.UnownedSerialExecutor",
+                  "usr": "s:Sce"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScM15unownedExecutorScevg",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "Final"
+              ],
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "sharedUnownedExecutor",
+          "printedName": "sharedUnownedExecutor",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "UnownedSerialExecutor",
+              "printedName": "_Concurrency.UnownedSerialExecutor",
+              "usr": "s:Sce"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScM21sharedUnownedExecutorScevpZ",
+          "moduleName": "_Concurrency",
+          "static": true,
+          "declAttributes": [
+            "Final",
+            "AccessControl",
+            "Inlinable"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "UnownedSerialExecutor",
+                  "printedName": "_Concurrency.UnownedSerialExecutor",
+                  "usr": "s:Sce"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScM21sharedUnownedExecutorScevgZ",
+              "moduleName": "_Concurrency",
+              "static": true,
+              "declAttributes": [
+                "Final"
+              ],
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "enqueue",
+          "printedName": "enqueue(_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "UnownedJob",
+              "printedName": "_Concurrency.UnownedJob",
+              "usr": "s:ScJ"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScM7enqueueyyScJF",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl",
+            "Final",
+            "Nonisolated",
+            "Inlinable"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "run",
+          "printedName": "run(resultType:body:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Metatype",
+              "printedName": "τ_0_0.Type",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "hasDefaultArg": true
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "() throws -> τ_0_0",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "Void",
+                  "printedName": "()"
+                }
+              ],
+              "typeAttributes": [
+                "noescape"
+              ]
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScM3run10resultType4bodyxxm_xyYbKScMYcXEtYaKlFZ",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0>",
+          "sugared_genericSig": "<T>",
+          "static": true,
+          "declAttributes": [
+            "Rethrows",
+            "AccessControl",
+            "Final"
+          ],
+          "throwing": true,
+          "funcSelfKind": "NonMutating"
+        }
+      ],
+      "declKind": "Class",
+      "usr": "s:ScM",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Final",
+        "GlobalActor",
+        "Available",
+        "Available",
+        "Available",
+        "Available",
+        "HasMissingDesignatedInitializers"
+      ],
+      "hasMissingDesignatedInitializers": true,
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "Actor",
+          "printedName": "Actor",
+          "usr": "s:ScA"
+        },
+        {
+          "kind": "Conformance",
+          "name": "GlobalActor",
+          "printedName": "GlobalActor",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "ActorType",
+              "printedName": "ActorType",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "MainActor",
+                  "printedName": "_Concurrency.MainActor",
+                  "usr": "s:ScM"
+                }
+              ]
+            }
+          ],
+          "usr": "s:12_Concurrency11GlobalActorP"
+        },
+        {
+          "kind": "Conformance",
+          "name": "Sendable",
+          "printedName": "Sendable",
+          "usr": "s:s8SendableP"
+        }
+      ]
+    },
+    {
+      "kind": "Function",
+      "name": "_swiftJobRun",
+      "printedName": "_swiftJobRun(_:_:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Void",
+          "printedName": "()"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "UnownedJob",
+          "printedName": "_Concurrency.UnownedJob",
+          "usr": "s:ScJ"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "UnownedSerialExecutor",
+          "printedName": "_Concurrency.UnownedSerialExecutor",
+          "usr": "s:Sce"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency12_swiftJobRunyyScJ_ScetF",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "UsableFromInline",
+        "SILGenName",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "UnownedJob",
+      "printedName": "UnownedJob",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "context",
+          "printedName": "context",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "BuiltinJob",
+              "printedName": "Builtin.Job"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScJ7context33_9E0E99C2C75178F9772A69660F5CABBDLLBjvp",
+          "moduleName": "_Concurrency",
+          "isInternal": true,
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl"
+          ],
+          "fixedbinaryorder": 0,
+          "hasStorage": true
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:ScJ",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Frozen",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "Sendable",
+          "printedName": "Sendable",
+          "usr": "s:s8SendableP"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "UnsafeContinuation",
+      "printedName": "UnsafeContinuation",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "context",
+          "printedName": "context",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "BuiltinRawUnsafeContinuation",
+              "printedName": "Builtin.RawUnsafeContinuation"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:Scc7contextBcvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "fixedbinaryorder": 0,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "BuiltinRawUnsafeContinuation",
+                  "printedName": "Builtin.RawUnsafeContinuation"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:Scc7contextBcvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+              "sugared_genericSig": "<T, E where E : Swift.Error>",
+              "implicit": true,
+              "declAttributes": [
+                "Transparent"
+              ],
+              "accessorKind": "get"
+            },
+            {
+              "kind": "Accessor",
+              "name": "Set",
+              "printedName": "Set()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Void",
+                  "printedName": "()"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "BuiltinRawUnsafeContinuation",
+                  "printedName": "Builtin.RawUnsafeContinuation"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:Scc7contextBcvs",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+              "sugared_genericSig": "<T, E where E : Swift.Error>",
+              "implicit": true,
+              "declAttributes": [
+                "Transparent"
+              ],
+              "accessorKind": "set"
+            },
+            {
+              "kind": "Accessor",
+              "name": "Modify",
+              "printedName": "Modify()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Void",
+                  "printedName": "()"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:Scc7contextBcvM",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+              "sugared_genericSig": "<T, E where E : Swift.Error>",
+              "implicit": true,
+              "declAttributes": [
+                "Transparent"
+              ],
+              "accessorKind": "_modify"
+            }
+          ]
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:Scc",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+      "sugared_genericSig": "<T, E where E : Swift.Error>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Frozen",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "Sendable",
+          "printedName": "Sendable",
+          "usr": "s:s8SendableP"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "Task",
+      "printedName": "Task",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "_task",
+          "printedName": "_task",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "BuiltinNativeObject",
+              "printedName": "Builtin.NativeObject"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScT5_taskBovp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "fixedbinaryorder": 0,
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "BuiltinNativeObject",
+                  "printedName": "Builtin.NativeObject"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScT5_taskBovg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+              "sugared_genericSig": "<Success, Failure where Failure : Swift.Error>",
+              "implicit": true,
+              "declAttributes": [
+                "Transparent"
+              ],
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "value",
+          "printedName": "value",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScT5valuexvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScT5valuexvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+              "sugared_genericSig": "<Success, Failure where Failure : Swift.Error>",
+              "throwing": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "result",
+          "printedName": "result",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Result",
+              "printedName": "Swift.Result<τ_0_0, τ_0_1>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ],
+              "usr": "s:s6ResultO"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScT6results6ResultOyxq_Gvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Result",
+                  "printedName": "Swift.Result<τ_0_0, τ_0_1>",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_0"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    }
+                  ],
+                  "usr": "s:s6ResultO"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScT6results6ResultOyxq_Gvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+              "sugared_genericSig": "<Success, Failure where Failure : Swift.Error>",
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "cancel",
+          "printedName": "cancel()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScT6cancelyyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<Success, Failure where Failure : Swift.Error>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Var",
+          "name": "value",
+          "printedName": "value",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScT12_Concurrencys5NeverORs_rlE5valuexvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScT12_Concurrencys5NeverORs_rlE5valuexvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 == Swift.Never>",
+              "sugared_genericSig": "<Success, Failure where Failure == Swift.Never>",
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "hash",
+          "printedName": "hash(into:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Hasher",
+              "printedName": "Swift.Hasher",
+              "paramValueOwnership": "InOut",
+              "usr": "s:s6HasherV"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScT4hash4intoys6HasherVz_tF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<Success, Failure where Failure : Swift.Error>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Var",
+          "name": "hashValue",
+          "printedName": "hashValue",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Int",
+              "printedName": "Swift.Int",
+              "usr": "s:Si"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScT9hashValueSivp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Int",
+                  "printedName": "Swift.Int",
+                  "usr": "s:Si"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScT9hashValueSivg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+              "sugared_genericSig": "<Success, Failure where Failure : Swift.Error>",
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "==",
+          "printedName": "==(_:_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Task",
+              "printedName": "_Concurrency.Task<τ_0_0, τ_0_1>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ],
+              "usr": "s:ScT"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Task",
+              "printedName": "_Concurrency.Task<τ_0_0, τ_0_1>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ],
+              "usr": "s:ScT"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScT2eeoiySbScTyxq_G_ABtFZ",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<Success, Failure where Failure : Swift.Error>",
+          "static": true,
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Var",
+          "name": "currentPriority",
+          "printedName": "currentPriority",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScT12_Concurrencys5NeverORszACRs_rlE15currentPriorityScPvpZ",
+          "moduleName": "_Concurrency",
+          "static": true,
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "TaskPriority",
+                  "printedName": "_Concurrency.TaskPriority",
+                  "usr": "s:ScP"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScT12_Concurrencys5NeverORszACRs_rlE15currentPriorityScPvgZ",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 == Swift.Never, τ_0_1 == Swift.Never>",
+              "sugared_genericSig": "<Success, Failure where Success == Swift.Never, Failure == Swift.Never>",
+              "static": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "yield",
+          "printedName": "yield()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScT12_Concurrencys5NeverORszACRs_rlE5yieldyyYaFZ",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 == Swift.Never, τ_0_1 == Swift.Never>",
+          "sugared_genericSig": "<Success, Failure where Success == Swift.Never, Failure == Swift.Never>",
+          "static": true,
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Var",
+          "name": "isCancelled",
+          "printedName": "isCancelled",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScT11isCancelledSbvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScT11isCancelledSbvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+              "sugared_genericSig": "<Success, Failure where Failure : Swift.Error>",
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "isCancelled",
+          "printedName": "isCancelled",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScT12_Concurrencys5NeverORszACRs_rlE11isCancelledSbvpZ",
+          "moduleName": "_Concurrency",
+          "static": true,
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScT12_Concurrencys5NeverORszACRs_rlE11isCancelledSbvgZ",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 == Swift.Never, τ_0_1 == Swift.Never>",
+              "sugared_genericSig": "<Success, Failure where Success == Swift.Never, Failure == Swift.Never>",
+              "static": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "checkCancellation",
+          "printedName": "checkCancellation()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScT12_Concurrencys5NeverORszACRs_rlE17checkCancellationyyKFZ",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 == Swift.Never, τ_0_1 == Swift.Never>",
+          "sugared_genericSig": "<Success, Failure where Success == Swift.Never, Failure == Swift.Never>",
+          "static": true,
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "throwing": true,
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "sleep",
+          "printedName": "sleep(_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "UInt64",
+              "printedName": "Swift.UInt64",
+              "usr": "s:s6UInt64V"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScT12_Concurrencys5NeverORszACRs_rlE5sleepyys6UInt64VYaFZ",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 == Swift.Never, τ_0_1 == Swift.Never>",
+          "sugared_genericSig": "<Success, Failure where Success == Swift.Never, Failure == Swift.Never>",
+          "static": true,
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "sleep",
+          "printedName": "sleep(nanoseconds:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "UInt64",
+              "printedName": "Swift.UInt64",
+              "usr": "s:s6UInt64V"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScT12_Concurrencys5NeverORszACRs_rlE5sleep11nanosecondsys6UInt64V_tYaKFZ",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 == Swift.Never, τ_0_1 == Swift.Never>",
+          "sugared_genericSig": "<Success, Failure where Success == Swift.Never, Failure == Swift.Never>",
+          "static": true,
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "throwing": true,
+          "funcSelfKind": "NonMutating"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:ScT",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+      "sugared_genericSig": "<Success, Failure where Failure : Swift.Error>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Frozen",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "Sendable",
+          "printedName": "Sendable",
+          "usr": "s:s8SendableP"
+        },
+        {
+          "kind": "Conformance",
+          "name": "Hashable",
+          "printedName": "Hashable",
+          "usr": "s:SH"
+        },
+        {
+          "kind": "Conformance",
+          "name": "Equatable",
+          "printedName": "Equatable",
+          "usr": "s:SQ"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "TaskPriority",
+      "printedName": "TaskPriority",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "rawValue",
+          "printedName": "rawValue",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "UInt8",
+              "printedName": "Swift.UInt8",
+              "usr": "s:s5UInt8V"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScP8rawValues5UInt8Vvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl"
+          ],
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "UInt8",
+                  "printedName": "Swift.UInt8",
+                  "usr": "s:s5UInt8V"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScP8rawValues5UInt8Vvg",
+              "moduleName": "_Concurrency",
+              "implicit": true,
+              "accessorKind": "get"
+            },
+            {
+              "kind": "Accessor",
+              "name": "Set",
+              "printedName": "Set()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Void",
+                  "printedName": "()"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "UInt8",
+                  "printedName": "Swift.UInt8",
+                  "usr": "s:s5UInt8V"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScP8rawValues5UInt8Vvs",
+              "moduleName": "_Concurrency",
+              "implicit": true,
+              "accessorKind": "set"
+            },
+            {
+              "kind": "Accessor",
+              "name": "Modify",
+              "printedName": "Modify()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Void",
+                  "printedName": "()"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScP8rawValues5UInt8VvM",
+              "moduleName": "_Concurrency",
+              "implicit": true,
+              "accessorKind": "_modify"
+            }
+          ]
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(rawValue:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "UInt8",
+              "printedName": "Swift.UInt8",
+              "usr": "s:s5UInt8V"
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:ScP8rawValueScPs5UInt8V_tcfc",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "Var",
+          "name": "high",
+          "printedName": "high",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScP4highScPvpZ",
+          "moduleName": "_Concurrency",
+          "static": true,
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "TaskPriority",
+                  "printedName": "_Concurrency.TaskPriority",
+                  "usr": "s:ScP"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScP4highScPvgZ",
+              "moduleName": "_Concurrency",
+              "static": true,
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "low",
+          "printedName": "low",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScP3lowScPvpZ",
+          "moduleName": "_Concurrency",
+          "static": true,
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "TaskPriority",
+                  "printedName": "_Concurrency.TaskPriority",
+                  "usr": "s:ScP"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScP3lowScPvgZ",
+              "moduleName": "_Concurrency",
+              "static": true,
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "userInitiated",
+          "printedName": "userInitiated",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScP13userInitiatedScPvpZ",
+          "moduleName": "_Concurrency",
+          "static": true,
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "TaskPriority",
+                  "printedName": "_Concurrency.TaskPriority",
+                  "usr": "s:ScP"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScP13userInitiatedScPvgZ",
+              "moduleName": "_Concurrency",
+              "static": true,
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "utility",
+          "printedName": "utility",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScP7utilityScPvpZ",
+          "moduleName": "_Concurrency",
+          "static": true,
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "TaskPriority",
+                  "printedName": "_Concurrency.TaskPriority",
+                  "usr": "s:ScP"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScP7utilityScPvgZ",
+              "moduleName": "_Concurrency",
+              "static": true,
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "background",
+          "printedName": "background",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScP10backgroundScPvpZ",
+          "moduleName": "_Concurrency",
+          "static": true,
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "TaskPriority",
+                  "printedName": "_Concurrency.TaskPriority",
+                  "usr": "s:ScP"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScP10backgroundScPvgZ",
+              "moduleName": "_Concurrency",
+              "static": true,
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "default",
+          "printedName": "default",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScP7defaultScPvpZ",
+          "moduleName": "_Concurrency",
+          "static": true,
+          "deprecated": true,
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "Available"
+          ],
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "TaskPriority",
+                  "printedName": "_Concurrency.TaskPriority",
+                  "usr": "s:ScP"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScP7defaultScPvgZ",
+              "moduleName": "_Concurrency",
+              "static": true,
+              "implicit": true,
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "==",
+          "printedName": "==(_:_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScP2eeoiySbScP_ScPtFZ",
+          "moduleName": "_Concurrency",
+          "static": true,
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "!=",
+          "printedName": "!=(_:_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScP2neoiySbScP_ScPtFZ",
+          "moduleName": "_Concurrency",
+          "static": true,
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "<",
+          "printedName": "<(_:_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScP1loiySbScP_ScPtFZ",
+          "moduleName": "_Concurrency",
+          "static": true,
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "<=",
+          "printedName": "<=(_:_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScP2leoiySbScP_ScPtFZ",
+          "moduleName": "_Concurrency",
+          "static": true,
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": ">",
+          "printedName": ">(_:_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScP1goiySbScP_ScPtFZ",
+          "moduleName": "_Concurrency",
+          "static": true,
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": ">=",
+          "printedName": ">=(_:_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScP2geoiySbScP_ScPtFZ",
+          "moduleName": "_Concurrency",
+          "static": true,
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:ScP",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "RawRepresentable",
+          "printedName": "RawRepresentable",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "RawValue",
+              "printedName": "RawValue",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "UInt8",
+                  "printedName": "Swift.UInt8",
+                  "usr": "s:s5UInt8V"
+                }
+              ]
+            }
+          ],
+          "usr": "s:SY"
+        },
+        {
+          "kind": "Conformance",
+          "name": "Sendable",
+          "printedName": "Sendable",
+          "usr": "s:s8SendableP"
+        },
+        {
+          "kind": "Conformance",
+          "name": "Equatable",
+          "printedName": "Equatable",
+          "usr": "s:SQ"
+        },
+        {
+          "kind": "Conformance",
+          "name": "Comparable",
+          "printedName": "Comparable",
+          "usr": "s:SL"
+        },
+        {
+          "kind": "Conformance",
+          "name": "Decodable",
+          "printedName": "Decodable",
+          "usr": "s:Se"
+        },
+        {
+          "kind": "Conformance",
+          "name": "Encodable",
+          "printedName": "Encodable",
+          "usr": "s:SE"
+        }
+      ]
+    },
+    {
+      "kind": "Function",
+      "name": "withUnsafeCurrentTask",
+      "printedName": "withUnsafeCurrentTask(body:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "GenericTypeParam",
+          "printedName": "τ_0_0"
+        },
+        {
+          "kind": "TypeFunc",
+          "name": "Function",
+          "printedName": "(_Concurrency.UnsafeCurrentTask?) throws -> τ_0_0",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Optional",
+              "printedName": "_Concurrency.UnsafeCurrentTask?",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "UnsafeCurrentTask",
+                  "printedName": "_Concurrency.UnsafeCurrentTask",
+                  "usr": "s:Sct"
+                }
+              ],
+              "usr": "s:Sq"
+            }
+          ],
+          "typeAttributes": [
+            "noescape"
+          ]
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency21withUnsafeCurrentTask4bodyxxSctSgKXE_tKlF",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0>",
+      "sugared_genericSig": "<T>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "Rethrows",
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "throwing": true,
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "UnsafeCurrentTask",
+      "printedName": "UnsafeCurrentTask",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "isCancelled",
+          "printedName": "isCancelled",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:Sct11isCancelledSbvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:Sct11isCancelledSbvg",
+              "moduleName": "_Concurrency",
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "priority",
+          "printedName": "priority",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "TaskPriority",
+              "printedName": "_Concurrency.TaskPriority",
+              "usr": "s:ScP"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:Sct8priorityScPvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "TaskPriority",
+                  "printedName": "_Concurrency.TaskPriority",
+                  "usr": "s:ScP"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:Sct8priorityScPvg",
+              "moduleName": "_Concurrency",
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "cancel",
+          "printedName": "cancel()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sct6cancelyyF",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "hash",
+          "printedName": "hash(into:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Hasher",
+              "printedName": "Swift.Hasher",
+              "paramValueOwnership": "InOut",
+              "usr": "s:s6HasherV"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sct4hash4intoys6HasherVz_tF",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Var",
+          "name": "hashValue",
+          "printedName": "hashValue",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Int",
+              "printedName": "Swift.Int",
+              "usr": "s:Si"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:Sct9hashValueSivp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Int",
+                  "printedName": "Swift.Int",
+                  "usr": "s:Si"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:Sct9hashValueSivg",
+              "moduleName": "_Concurrency",
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "==",
+          "printedName": "==(_:_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "UnsafeCurrentTask",
+              "printedName": "_Concurrency.UnsafeCurrentTask",
+              "usr": "s:Sct"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "UnsafeCurrentTask",
+              "printedName": "_Concurrency.UnsafeCurrentTask",
+              "usr": "s:Sct"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Sct2eeoiySbSct_ScttFZ",
+          "moduleName": "_Concurrency",
+          "static": true,
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:Sct",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "Hashable",
+          "printedName": "Hashable",
+          "usr": "s:SH"
+        },
+        {
+          "kind": "Conformance",
+          "name": "Equatable",
+          "printedName": "Equatable",
+          "usr": "s:SQ"
+        }
+      ]
+    },
+    {
+      "kind": "Function",
+      "name": "_enqueueJobGlobal",
+      "printedName": "_enqueueJobGlobal(_:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Void",
+          "printedName": "()"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinJob",
+          "printedName": "Builtin.Job"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency17_enqueueJobGlobalyyBjF",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "UsableFromInline",
+        "SILGenName",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "_enqueueJobGlobalWithDelay",
+      "printedName": "_enqueueJobGlobalWithDelay(_:_:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Void",
+          "printedName": "()"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "UInt64",
+          "printedName": "Swift.UInt64",
+          "usr": "s:s6UInt64V"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinJob",
+          "printedName": "Builtin.Job"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency26_enqueueJobGlobalWithDelayyys6UInt64V_BjtF",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "UsableFromInline",
+        "SILGenName",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "_asyncMainDrainQueue",
+      "printedName": "_asyncMainDrainQueue()",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Never",
+          "printedName": "Swift.Never",
+          "usr": "s:s5NeverO"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency20_asyncMainDrainQueues5NeverOyF",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "SILGenName",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "_runAsyncMain",
+      "printedName": "_runAsyncMain(_:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Void",
+          "printedName": "()"
+        },
+        {
+          "kind": "TypeFunc",
+          "name": "Function",
+          "printedName": "() async throws -> ()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            }
+          ]
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency13_runAsyncMainyyyyYaKcF",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "_taskFutureGet",
+      "printedName": "_taskFutureGet(_:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "GenericTypeParam",
+          "printedName": "τ_0_0"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinNativeObject",
+          "printedName": "Builtin.NativeObject"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency14_taskFutureGetyxBoYalF",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0>",
+      "sugared_genericSig": "<T>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "SILGenName",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "_taskFutureGetThrowing",
+      "printedName": "_taskFutureGetThrowing(_:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "GenericTypeParam",
+          "printedName": "τ_0_0"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinNativeObject",
+          "printedName": "Builtin.NativeObject"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency22_taskFutureGetThrowingyxBoYaKlF",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0>",
+      "sugared_genericSig": "<T>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "SILGenName",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "throwing": true,
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "_taskIsCurrentExecutor",
+      "printedName": "_taskIsCurrentExecutor(_:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Bool",
+          "printedName": "Swift.Bool",
+          "usr": "s:Sb"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinExecutor",
+          "printedName": "Builtin.Executor"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency22_taskIsCurrentExecutorySbBeF",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "SILGenName",
+        "UsableFromInline",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "_reportUnexpectedExecutor",
+      "printedName": "_reportUnexpectedExecutor(_:_:_:_:_:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Void",
+          "printedName": "()"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinRawPointer",
+          "printedName": "Builtin.RawPointer"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinInteger",
+          "printedName": "Builtin.Word"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinInteger",
+          "printedName": "Builtin.Int1"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinInteger",
+          "printedName": "Builtin.Word"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinExecutor",
+          "printedName": "Builtin.Executor"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency25_reportUnexpectedExecutoryyBp_BwBi1_BwBetF",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "SILGenName",
+        "UsableFromInline",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "withTaskCancellationHandler",
+      "printedName": "withTaskCancellationHandler(operation:onCancel:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "GenericTypeParam",
+          "printedName": "τ_0_0"
+        },
+        {
+          "kind": "TypeFunc",
+          "name": "Function",
+          "printedName": "() async throws -> τ_0_0",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            }
+          ],
+          "typeAttributes": [
+            "noescape"
+          ]
+        },
+        {
+          "kind": "TypeFunc",
+          "name": "Function",
+          "printedName": "() -> ()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            }
+          ],
+          "typeAttributes": [
+            "noescape"
+          ]
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency27withTaskCancellationHandler9operation8onCancelxxyYaKXE_yyYbXEtYaKlF",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0>",
+      "sugared_genericSig": "<T>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "Rethrows",
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "throwing": true,
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "CancellationError",
+      "printedName": "CancellationError",
+      "children": [
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "CancellationError",
+              "printedName": "_Concurrency.CancellationError",
+              "usr": "s:ScE"
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:S2cEycfc",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "init_kind": "Designated"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:ScE",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "Error",
+          "printedName": "Error",
+          "usr": "s:s5ErrorP"
+        },
+        {
+          "kind": "Conformance",
+          "name": "Sendable",
+          "printedName": "Sendable",
+          "usr": "s:s8SendableP"
+        }
+      ]
+    },
+    {
+      "kind": "Function",
+      "name": "withTaskGroup",
+      "printedName": "withTaskGroup(of:returning:body:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "GenericTypeParam",
+          "printedName": "τ_0_1"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "Metatype",
+          "printedName": "τ_0_0.Type",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ]
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "Metatype",
+          "printedName": "τ_0_1.Type",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_1"
+            }
+          ],
+          "hasDefaultArg": true
+        },
+        {
+          "kind": "TypeFunc",
+          "name": "Function",
+          "printedName": "(inout _Concurrency.TaskGroup<τ_0_0>) async -> τ_0_1",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_1"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "InOut",
+              "printedName": "inout _Concurrency.TaskGroup<τ_0_0>"
+            }
+          ],
+          "typeAttributes": [
+            "noescape"
+          ]
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency13withTaskGroup2of9returning4bodyq_xm_q_mq_ScGyxGzYaXEtYar0_lF",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0, τ_0_1>",
+      "sugared_genericSig": "<ChildTaskResult, GroupResult>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Inlinable",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "withThrowingTaskGroup",
+      "printedName": "withThrowingTaskGroup(of:returning:body:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "GenericTypeParam",
+          "printedName": "τ_0_1"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "Metatype",
+          "printedName": "τ_0_0.Type",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ]
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "Metatype",
+          "printedName": "τ_0_1.Type",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_1"
+            }
+          ],
+          "hasDefaultArg": true
+        },
+        {
+          "kind": "TypeFunc",
+          "name": "Function",
+          "printedName": "(inout _Concurrency.ThrowingTaskGroup<τ_0_0, Swift.Error>) async throws -> τ_0_1",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_1"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "InOut",
+              "printedName": "inout _Concurrency.ThrowingTaskGroup<τ_0_0, Swift.Error>"
+            }
+          ],
+          "typeAttributes": [
+            "noescape"
+          ]
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency21withThrowingTaskGroup2of9returning4bodyq_xm_q_mq_Scgyxs5Error_pGzYaKXEtYaKr0_lF",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0, τ_0_1>",
+      "sugared_genericSig": "<ChildTaskResult, GroupResult>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "Rethrows",
+        "AccessControl",
+        "Inlinable",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "throwing": true,
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "TaskGroup",
+      "printedName": "TaskGroup",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "_group",
+          "printedName": "_group",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "BuiltinRawPointer",
+              "printedName": "Builtin.RawPointer"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScG6_groupBpvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "fixedbinaryorder": 0,
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "BuiltinRawPointer",
+                  "printedName": "Builtin.RawPointer"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScG6_groupBpvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0>",
+              "sugared_genericSig": "<ChildTaskResult>",
+              "implicit": true,
+              "declAttributes": [
+                "Transparent"
+              ],
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(group:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "TaskGroup",
+              "printedName": "_Concurrency.TaskGroup<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:ScG"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "BuiltinRawPointer",
+              "printedName": "Builtin.RawPointer"
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:ScG5groupScGyxGBp_tcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0>",
+          "sugared_genericSig": "<ChildTaskResult>",
+          "declAttributes": [
+            "AccessControl",
+            "Inlinable"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "Function",
+          "name": "next",
+          "printedName": "next()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Optional",
+              "printedName": "τ_0_0?",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:Sq"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScG4nextxSgyYaF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0>",
+          "sugared_genericSig": "<ChildTaskResult>",
+          "declAttributes": [
+            "Mutating",
+            "AccessControl"
+          ],
+          "funcSelfKind": "Mutating"
+        },
+        {
+          "kind": "Function",
+          "name": "awaitAllRemainingTasks",
+          "printedName": "awaitAllRemainingTasks()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScG22awaitAllRemainingTasksyyYaF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0>",
+          "sugared_genericSig": "<ChildTaskResult>",
+          "declAttributes": [
+            "Mutating",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "funcSelfKind": "Mutating"
+        },
+        {
+          "kind": "Var",
+          "name": "isEmpty",
+          "printedName": "isEmpty",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScG7isEmptySbvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScG7isEmptySbvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0>",
+              "sugared_genericSig": "<ChildTaskResult>",
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "cancelAll",
+          "printedName": "cancelAll()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScG9cancelAllyyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0>",
+          "sugared_genericSig": "<ChildTaskResult>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Var",
+          "name": "isCancelled",
+          "printedName": "isCancelled",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:ScG11isCancelledSbvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:ScG11isCancelledSbvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0>",
+              "sugared_genericSig": "<ChildTaskResult>",
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "makeAsyncIterator",
+          "printedName": "makeAsyncIterator()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Iterator",
+              "printedName": "_Concurrency.TaskGroup<τ_0_0>.Iterator",
+              "usr": "s:ScG8IteratorV"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScG17makeAsyncIteratorScG0C0Vyx_GyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0>",
+          "sugared_genericSig": "<ChildTaskResult>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "TypeDecl",
+          "name": "Iterator",
+          "printedName": "Iterator",
+          "children": [
+            {
+              "kind": "Var",
+              "name": "group",
+              "printedName": "group",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "TaskGroup",
+                  "printedName": "_Concurrency.TaskGroup<τ_0_0>",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_0"
+                    }
+                  ],
+                  "usr": "s:ScG"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:ScG8IteratorV5groupScGyxGvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "TaskGroup",
+                      "printedName": "_Concurrency.TaskGroup<τ_0_0>",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "GenericTypeParam",
+                          "printedName": "τ_0_0"
+                        }
+                      ],
+                      "usr": "s:ScG"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:ScG8IteratorV5groupScGyxGvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0>",
+                  "sugared_genericSig": "<ChildTaskResult>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "TaskGroup",
+                      "printedName": "_Concurrency.TaskGroup<τ_0_0>",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "GenericTypeParam",
+                          "printedName": "τ_0_0"
+                        }
+                      ],
+                      "usr": "s:ScG"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:ScG8IteratorV5groupScGyxGvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0>",
+                  "sugared_genericSig": "<ChildTaskResult>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:ScG8IteratorV5groupScGyxGvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0>",
+                  "sugared_genericSig": "<ChildTaskResult>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "finished",
+              "printedName": "finished",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:ScG8IteratorV8finishedSbvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:ScG8IteratorV8finishedSbvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0>",
+                  "sugared_genericSig": "<ChildTaskResult>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:ScG8IteratorV8finishedSbvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0>",
+                  "sugared_genericSig": "<ChildTaskResult>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:ScG8IteratorV8finishedSbvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0>",
+                  "sugared_genericSig": "<ChildTaskResult>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Function",
+              "name": "next",
+              "printedName": "next()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_0?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_0"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:ScG8IteratorV4nextxSgyYaF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0>",
+              "sugared_genericSig": "<ChildTaskResult>",
+              "declAttributes": [
+                "Mutating",
+                "AccessControl"
+              ],
+              "funcSelfKind": "Mutating"
+            },
+            {
+              "kind": "Function",
+              "name": "cancel",
+              "printedName": "cancel()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Void",
+                  "printedName": "()"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:ScG8IteratorV6cancelyyF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0>",
+              "sugared_genericSig": "<ChildTaskResult>",
+              "declAttributes": [
+                "Mutating",
+                "AccessControl"
+              ],
+              "funcSelfKind": "Mutating"
+            }
+          ],
+          "declKind": "Struct",
+          "usr": "s:ScG8IteratorV",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0>",
+          "sugared_genericSig": "<ChildTaskResult>",
+          "intro_Macosx": "12.0",
+          "intro_iOS": "15.0",
+          "intro_tvOS": "15.0",
+          "intro_watchOS": "8.0",
+          "declAttributes": [
+            "AccessControl",
+            "Available",
+            "Available",
+            "Available",
+            "Available"
+          ],
+          "conformances": [
+            {
+              "kind": "Conformance",
+              "name": "AsyncIteratorProtocol",
+              "printedName": "AsyncIteratorProtocol",
+              "children": [
+                {
+                  "kind": "TypeWitness",
+                  "name": "Element",
+                  "printedName": "Element",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_0"
+                    }
+                  ]
+                }
+              ],
+              "usr": "s:ScI"
+            }
+          ]
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:ScG",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0>",
+      "sugared_genericSig": "<ChildTaskResult>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Frozen",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "AsyncSequence",
+          "printedName": "AsyncSequence",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "AsyncIterator",
+              "printedName": "AsyncIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.TaskGroup<τ_0_0>.Iterator",
+                  "usr": "s:ScG8IteratorV"
+                }
+              ]
+            },
+            {
+              "kind": "TypeWitness",
+              "name": "Element",
+              "printedName": "Element",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ]
+            }
+          ],
+          "usr": "s:Sci"
+        },
+        {
+          "kind": "Conformance",
+          "name": "Sendable",
+          "printedName": "Sendable",
+          "usr": "s:s8SendableP"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "ThrowingTaskGroup",
+      "printedName": "ThrowingTaskGroup",
+      "children": [
+        {
+          "kind": "Var",
+          "name": "_group",
+          "printedName": "_group",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "BuiltinRawPointer",
+              "printedName": "Builtin.RawPointer"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:Scg6_groupBpvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "HasStorage",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "fixedbinaryorder": 0,
+          "isLet": true,
+          "hasStorage": true,
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "BuiltinRawPointer",
+                  "printedName": "Builtin.RawPointer"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:Scg6_groupBpvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+              "sugared_genericSig": "<ChildTaskResult, Failure where Failure : Swift.Error>",
+              "implicit": true,
+              "declAttributes": [
+                "Transparent"
+              ],
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(group:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "ThrowingTaskGroup",
+              "printedName": "_Concurrency.ThrowingTaskGroup<τ_0_0, τ_0_1>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ],
+              "usr": "s:Scg"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "BuiltinRawPointer",
+              "printedName": "Builtin.RawPointer"
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:Scg5groupScgyxq_GBp_tcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<ChildTaskResult, Failure where Failure : Swift.Error>",
+          "declAttributes": [
+            "AccessControl",
+            "Inlinable"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "Function",
+          "name": "awaitAllRemainingTasks",
+          "printedName": "awaitAllRemainingTasks()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Scg22awaitAllRemainingTasksyyYaF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<ChildTaskResult, Failure where Failure : Swift.Error>",
+          "declAttributes": [
+            "Mutating",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "funcSelfKind": "Mutating"
+        },
+        {
+          "kind": "Function",
+          "name": "_waitForAll",
+          "printedName": "_waitForAll()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Scg11_waitForAllyyYaKF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<ChildTaskResult, Failure where Failure : Swift.Error>",
+          "declAttributes": [
+            "Mutating",
+            "AccessControl",
+            "UsableFromInline"
+          ],
+          "throwing": true,
+          "funcSelfKind": "Mutating"
+        },
+        {
+          "kind": "Function",
+          "name": "next",
+          "printedName": "next()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Optional",
+              "printedName": "τ_0_0?",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:Sq"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Scg4nextxSgyYaKF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<ChildTaskResult, Failure where Failure : Swift.Error>",
+          "declAttributes": [
+            "Mutating",
+            "AccessControl"
+          ],
+          "throwing": true,
+          "funcSelfKind": "Mutating"
+        },
+        {
+          "kind": "Function",
+          "name": "nextResult",
+          "printedName": "nextResult()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Optional",
+              "printedName": "Swift.Result<τ_0_0, τ_0_1>?",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Result",
+                  "printedName": "Swift.Result<τ_0_0, τ_0_1>",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_0"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    }
+                  ],
+                  "usr": "s:s6ResultO"
+                }
+              ],
+              "usr": "s:Sq"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Scg10nextResults0B0Oyxq_GSgyYaKF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<ChildTaskResult, Failure where Failure : Swift.Error>",
+          "declAttributes": [
+            "Mutating",
+            "AccessControl"
+          ],
+          "throwing": true,
+          "funcSelfKind": "Mutating"
+        },
+        {
+          "kind": "Var",
+          "name": "isEmpty",
+          "printedName": "isEmpty",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:Scg7isEmptySbvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:Scg7isEmptySbvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+              "sugared_genericSig": "<ChildTaskResult, Failure where Failure : Swift.Error>",
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "cancelAll",
+          "printedName": "cancelAll()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Scg9cancelAllyyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<ChildTaskResult, Failure where Failure : Swift.Error>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Var",
+          "name": "isCancelled",
+          "printedName": "isCancelled",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:Scg11isCancelledSbvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:Scg11isCancelledSbvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+              "sugared_genericSig": "<ChildTaskResult, Failure where Failure : Swift.Error>",
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "makeAsyncIterator",
+          "printedName": "makeAsyncIterator()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Iterator",
+              "printedName": "_Concurrency.ThrowingTaskGroup<τ_0_0, τ_0_1>.Iterator",
+              "usr": "s:Scg8IteratorV"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Scg17makeAsyncIteratorScg0C0Vyxq__GyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<ChildTaskResult, Failure where Failure : Swift.Error>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "TypeDecl",
+          "name": "Iterator",
+          "printedName": "Iterator",
+          "children": [
+            {
+              "kind": "Var",
+              "name": "group",
+              "printedName": "group",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "ThrowingTaskGroup",
+                  "printedName": "_Concurrency.ThrowingTaskGroup<τ_0_0, τ_0_1>",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_0"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    }
+                  ],
+                  "usr": "s:Scg"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:Scg8IteratorV5groupScgyxq_Gvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "ThrowingTaskGroup",
+                      "printedName": "_Concurrency.ThrowingTaskGroup<τ_0_0, τ_0_1>",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "GenericTypeParam",
+                          "printedName": "τ_0_0"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "GenericTypeParam",
+                          "printedName": "τ_0_1"
+                        }
+                      ],
+                      "usr": "s:Scg"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:Scg8IteratorV5groupScgyxq_Gvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+                  "sugared_genericSig": "<ChildTaskResult, Failure where Failure : Swift.Error>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "ThrowingTaskGroup",
+                      "printedName": "_Concurrency.ThrowingTaskGroup<τ_0_0, τ_0_1>",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "GenericTypeParam",
+                          "printedName": "τ_0_0"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "GenericTypeParam",
+                          "printedName": "τ_0_1"
+                        }
+                      ],
+                      "usr": "s:Scg"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:Scg8IteratorV5groupScgyxq_Gvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+                  "sugared_genericSig": "<ChildTaskResult, Failure where Failure : Swift.Error>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:Scg8IteratorV5groupScgyxq_GvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+                  "sugared_genericSig": "<ChildTaskResult, Failure where Failure : Swift.Error>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Var",
+              "name": "finished",
+              "printedName": "finished",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Bool",
+                  "printedName": "Swift.Bool",
+                  "usr": "s:Sb"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:Scg8IteratorV8finishedSbvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "HasStorage",
+                "AccessControl",
+                "UsableFromInline"
+              ],
+              "hasStorage": true,
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:Scg8IteratorV8finishedSbvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+                  "sugared_genericSig": "<ChildTaskResult, Failure where Failure : Swift.Error>",
+                  "implicit": true,
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:Scg8IteratorV8finishedSbvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+                  "sugared_genericSig": "<ChildTaskResult, Failure where Failure : Swift.Error>",
+                  "implicit": true,
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:Scg8IteratorV8finishedSbvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+                  "sugared_genericSig": "<ChildTaskResult, Failure where Failure : Swift.Error>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Function",
+              "name": "next",
+              "printedName": "next()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_0?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_0"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:Scg8IteratorV4nextxSgyYaKF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+              "sugared_genericSig": "<ChildTaskResult, Failure where Failure : Swift.Error>",
+              "declAttributes": [
+                "Mutating",
+                "AccessControl"
+              ],
+              "throwing": true,
+              "funcSelfKind": "Mutating"
+            },
+            {
+              "kind": "Function",
+              "name": "cancel",
+              "printedName": "cancel()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Void",
+                  "printedName": "()"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:Scg8IteratorV6cancelyyF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+              "sugared_genericSig": "<ChildTaskResult, Failure where Failure : Swift.Error>",
+              "declAttributes": [
+                "Mutating",
+                "AccessControl"
+              ],
+              "funcSelfKind": "Mutating"
+            }
+          ],
+          "declKind": "Struct",
+          "usr": "s:Scg8IteratorV",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<ChildTaskResult, Failure where Failure : Swift.Error>",
+          "intro_Macosx": "12.0",
+          "intro_iOS": "15.0",
+          "intro_tvOS": "15.0",
+          "intro_watchOS": "8.0",
+          "declAttributes": [
+            "AccessControl",
+            "Available",
+            "Available",
+            "Available",
+            "Available"
+          ],
+          "conformances": [
+            {
+              "kind": "Conformance",
+              "name": "AsyncIteratorProtocol",
+              "printedName": "AsyncIteratorProtocol",
+              "children": [
+                {
+                  "kind": "TypeWitness",
+                  "name": "Element",
+                  "printedName": "Element",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_0"
+                    }
+                  ]
+                }
+              ],
+              "usr": "s:ScI"
+            }
+          ]
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:Scg",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+      "sugared_genericSig": "<ChildTaskResult, Failure where Failure : Swift.Error>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Frozen",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "AsyncSequence",
+          "printedName": "AsyncSequence",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "AsyncIterator",
+              "printedName": "AsyncIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.ThrowingTaskGroup<τ_0_0, τ_0_1>.Iterator",
+                  "usr": "s:Scg8IteratorV"
+                }
+              ]
+            },
+            {
+              "kind": "TypeWitness",
+              "name": "Element",
+              "printedName": "Element",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ]
+            }
+          ],
+          "usr": "s:Sci"
+        },
+        {
+          "kind": "Conformance",
+          "name": "Sendable",
+          "printedName": "Sendable",
+          "usr": "s:s8SendableP"
+        }
+      ]
+    },
+    {
+      "kind": "Function",
+      "name": "_taskGroupAddPendingTask",
+      "printedName": "_taskGroupAddPendingTask(group:unconditionally:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Bool",
+          "printedName": "Swift.Bool",
+          "usr": "s:Sb"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "BuiltinRawPointer",
+          "printedName": "Builtin.RawPointer"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "Bool",
+          "printedName": "Swift.Bool",
+          "usr": "s:Sb"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency24_taskGroupAddPendingTask5group15unconditionallySbBp_SbtF",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "UsableFromInline",
+        "SILGenName",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "TaskLocal",
+      "printedName": "TaskLocal",
+      "children": [
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(wrappedValue:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "TaskLocal",
+              "printedName": "_Concurrency.TaskLocal<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:12_Concurrency9TaskLocalC"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:12_Concurrency9TaskLocalC12wrappedValueACyxGx_tcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0>",
+          "sugared_genericSig": "<Value>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "Function",
+          "name": "get",
+          "printedName": "get()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency9TaskLocalC3getxyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0>",
+          "sugared_genericSig": "<Value>",
+          "declAttributes": [
+            "AccessControl",
+            "Final"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "withValue",
+          "printedName": "withValue(_:operation:file:line:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_1_0"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "() async throws -> τ_1_0",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_1_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "Void",
+                  "printedName": "()"
+                }
+              ],
+              "typeAttributes": [
+                "noescape"
+              ]
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "String",
+              "printedName": "Swift.String",
+              "hasDefaultArg": true,
+              "usr": "s:SS"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "UInt",
+              "printedName": "Swift.UInt",
+              "hasDefaultArg": true,
+              "usr": "s:Su"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency9TaskLocalC9withValue_9operation4file4lineqd__x_qd__yYaKXESSSutYaKlF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_1_0>",
+          "sugared_genericSig": "<Value, R>",
+          "declAttributes": [
+            "Rethrows",
+            "AccessControl",
+            "Final",
+            "DiscardableResult"
+          ],
+          "throwing": true,
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "withValue",
+          "printedName": "withValue(_:operation:file:line:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_1_0"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "() throws -> τ_1_0",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_1_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "Void",
+                  "printedName": "()"
+                }
+              ],
+              "typeAttributes": [
+                "noescape"
+              ]
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "String",
+              "printedName": "Swift.String",
+              "hasDefaultArg": true,
+              "usr": "s:SS"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "UInt",
+              "printedName": "Swift.UInt",
+              "hasDefaultArg": true,
+              "usr": "s:Su"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency9TaskLocalC9withValue_9operation4file4lineqd__x_qd__yKXESSSutKlF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_1_0>",
+          "sugared_genericSig": "<Value, R>",
+          "declAttributes": [
+            "Rethrows",
+            "AccessControl",
+            "Final",
+            "DiscardableResult"
+          ],
+          "throwing": true,
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Var",
+          "name": "projectedValue",
+          "printedName": "projectedValue",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "TaskLocal",
+              "printedName": "_Concurrency.TaskLocal<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:12_Concurrency9TaskLocalC"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency9TaskLocalC14projectedValueACyxGvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl",
+            "Final"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "TaskLocal",
+                  "printedName": "_Concurrency.TaskLocal<τ_0_0>",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_0"
+                    }
+                  ],
+                  "usr": "s:12_Concurrency9TaskLocalC"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency9TaskLocalC14projectedValueACyxGvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0>",
+              "sugared_genericSig": "<Value>",
+              "declAttributes": [
+                "Final"
+              ],
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Subscript",
+          "name": "subscript",
+          "printedName": "subscript(_enclosingInstance:wrapped:storage:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Never",
+              "printedName": "Swift.Never",
+              "usr": "s:s5NeverO"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "ReferenceWritableKeyPath",
+              "printedName": "Swift.ReferenceWritableKeyPath<Swift.Never, τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Never",
+                  "printedName": "Swift.Never",
+                  "usr": "s:s5NeverO"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:s24ReferenceWritableKeyPathC"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "ReferenceWritableKeyPath",
+              "printedName": "Swift.ReferenceWritableKeyPath<Swift.Never, _Concurrency.TaskLocal<τ_0_0>>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Never",
+                  "printedName": "Swift.Never",
+                  "usr": "s:s5NeverO"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "TaskLocal",
+                  "printedName": "_Concurrency.TaskLocal<τ_0_0>",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_0"
+                    }
+                  ],
+                  "usr": "s:12_Concurrency9TaskLocalC"
+                }
+              ],
+              "usr": "s:s24ReferenceWritableKeyPathC"
+            }
+          ],
+          "declKind": "Subscript",
+          "usr": "s:12_Concurrency9TaskLocalC18_enclosingInstance7wrapped7storagexs5NeverO_s24ReferenceWritableKeyPathCyAHxGAJyAhCyxGGtcipZ",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0>",
+          "sugared_genericSig": "<Value>",
+          "static": true,
+          "declAttributes": [
+            "Final",
+            "AccessControl"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "Never",
+                  "printedName": "Swift.Never",
+                  "usr": "s:s5NeverO"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "ReferenceWritableKeyPath",
+                  "printedName": "Swift.ReferenceWritableKeyPath<Swift.Never, τ_0_0>",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Never",
+                      "printedName": "Swift.Never",
+                      "usr": "s:s5NeverO"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_0"
+                    }
+                  ],
+                  "usr": "s:s24ReferenceWritableKeyPathC"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "ReferenceWritableKeyPath",
+                  "printedName": "Swift.ReferenceWritableKeyPath<Swift.Never, _Concurrency.TaskLocal<τ_0_0>>",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Never",
+                      "printedName": "Swift.Never",
+                      "usr": "s:s5NeverO"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "TaskLocal",
+                      "printedName": "_Concurrency.TaskLocal<τ_0_0>",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "GenericTypeParam",
+                          "printedName": "τ_0_0"
+                        }
+                      ],
+                      "usr": "s:12_Concurrency9TaskLocalC"
+                    }
+                  ],
+                  "usr": "s:s24ReferenceWritableKeyPathC"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency9TaskLocalC18_enclosingInstance7wrapped7storagexs5NeverO_s24ReferenceWritableKeyPathCyAHxGAJyAhCyxGGtcigZ",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0>",
+              "sugared_genericSig": "<Value>",
+              "static": true,
+              "declAttributes": [
+                "Final"
+              ],
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "wrappedValue",
+          "printedName": "wrappedValue",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency9TaskLocalC12wrappedValuexvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl",
+            "Final"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency9TaskLocalC12wrappedValuexvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0>",
+              "sugared_genericSig": "<Value>",
+              "declAttributes": [
+                "Final"
+              ],
+              "accessorKind": "get"
+            }
+          ]
+        },
+        {
+          "kind": "Var",
+          "name": "description",
+          "printedName": "description",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "String",
+              "printedName": "Swift.String",
+              "usr": "s:SS"
+            }
+          ],
+          "declKind": "Var",
+          "usr": "s:12_Concurrency9TaskLocalC11descriptionSSvp",
+          "moduleName": "_Concurrency",
+          "declAttributes": [
+            "AccessControl",
+            "Final"
+          ],
+          "accessors": [
+            {
+              "kind": "Accessor",
+              "name": "Get",
+              "printedName": "Get()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "String",
+                  "printedName": "Swift.String",
+                  "usr": "s:SS"
+                }
+              ],
+              "declKind": "Accessor",
+              "usr": "s:12_Concurrency9TaskLocalC11descriptionSSvg",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0>",
+              "sugared_genericSig": "<Value>",
+              "declAttributes": [
+                "Final"
+              ],
+              "accessorKind": "get"
+            }
+          ]
+        }
+      ],
+      "declKind": "Class",
+      "usr": "s:12_Concurrency9TaskLocalC",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0>",
+      "sugared_genericSig": "<Value>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Final",
+        "PropertyWrapper",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "UnsafeSendable",
+          "printedName": "UnsafeSendable",
+          "usr": "s:s14UnsafeSendableP"
+        },
+        {
+          "kind": "Conformance",
+          "name": "CustomStringConvertible",
+          "printedName": "CustomStringConvertible",
+          "usr": "s:s23CustomStringConvertibleP"
+        },
+        {
+          "kind": "Conformance",
+          "name": "Sendable",
+          "printedName": "Sendable",
+          "usr": "s:s8SendableP"
+        }
+      ]
+    },
+    {
+      "kind": "Function",
+      "name": "_checkIllegalTaskLocalBindingWithinWithTaskGroup",
+      "printedName": "_checkIllegalTaskLocalBindingWithinWithTaskGroup(file:line:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Void",
+          "printedName": "()"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "String",
+          "printedName": "Swift.String",
+          "usr": "s:SS"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "UInt",
+          "printedName": "Swift.UInt",
+          "usr": "s:Su"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency039_checkIllegalTaskLocalBindingWithinWithD5Group4file4lineySS_SutF",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "UsableFromInline",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "Function",
+      "name": "_reportIllegalTaskLocalBindingWithinWithTaskGroup",
+      "printedName": "_reportIllegalTaskLocalBindingWithinWithTaskGroup(_:_:_:_:)",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Void",
+          "printedName": "()"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "UnsafePointer",
+          "printedName": "Swift.UnsafePointer<Swift.Int8>",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Int8",
+              "printedName": "Swift.Int8",
+              "usr": "s:s4Int8V"
+            }
+          ],
+          "usr": "s:SP"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "Int",
+          "printedName": "Swift.Int",
+          "usr": "s:Si"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "Bool",
+          "printedName": "Swift.Bool",
+          "usr": "s:Sb"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "UInt",
+          "printedName": "Swift.UInt",
+          "usr": "s:Su"
+        }
+      ],
+      "declKind": "Func",
+      "usr": "s:12_Concurrency040_reportIllegalTaskLocalBindingWithinWithD5GroupyySPys4Int8VG_SiSbSutF",
+      "moduleName": "_Concurrency",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "SILGenName",
+        "UsableFromInline",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "funcSelfKind": "NonMutating"
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "AsyncStream",
+      "printedName": "AsyncStream",
+      "children": [
+        {
+          "kind": "TypeDecl",
+          "name": "Continuation",
+          "printedName": "Continuation",
+          "children": [
+            {
+              "kind": "TypeDecl",
+              "name": "Termination",
+              "printedName": "Termination",
+              "children": [
+                {
+                  "kind": "Var",
+                  "name": "finished",
+                  "printedName": "finished",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "GenericFunction",
+                      "printedName": "<τ_0_0> (_Concurrency.AsyncStream<τ_0_0>.Continuation.Termination.Type) -> _Concurrency.AsyncStream<τ_0_0>.Continuation.Termination",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Termination",
+                          "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.Termination",
+                          "usr": "s:ScS12ContinuationV11TerminationO"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Metatype",
+                          "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.Termination.Type",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Termination",
+                              "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.Termination",
+                              "usr": "s:ScS12ContinuationV11TerminationO"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "EnumElement",
+                  "usr": "s:ScS12ContinuationV11TerminationO8finishedyADyx__GAFmlF",
+                  "moduleName": "_Concurrency"
+                },
+                {
+                  "kind": "Var",
+                  "name": "cancelled",
+                  "printedName": "cancelled",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "GenericFunction",
+                      "printedName": "<τ_0_0> (_Concurrency.AsyncStream<τ_0_0>.Continuation.Termination.Type) -> _Concurrency.AsyncStream<τ_0_0>.Continuation.Termination",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Termination",
+                          "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.Termination",
+                          "usr": "s:ScS12ContinuationV11TerminationO"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Metatype",
+                          "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.Termination.Type",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Termination",
+                              "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.Termination",
+                              "usr": "s:ScS12ContinuationV11TerminationO"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "EnumElement",
+                  "usr": "s:ScS12ContinuationV11TerminationO9cancelledyADyx__GAFmlF",
+                  "moduleName": "_Concurrency"
+                },
+                {
+                  "kind": "Function",
+                  "name": "==",
+                  "printedName": "==(_:_:)",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Bool",
+                      "printedName": "Swift.Bool",
+                      "usr": "s:Sb"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Termination",
+                      "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.Termination",
+                      "usr": "s:ScS12ContinuationV11TerminationO"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Termination",
+                      "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.Termination",
+                      "usr": "s:ScS12ContinuationV11TerminationO"
+                    }
+                  ],
+                  "declKind": "Func",
+                  "usr": "s:ScS12ContinuationV11TerminationO2eeoiySbADyx__G_AFtFZ",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0>",
+                  "sugared_genericSig": "<Element>",
+                  "static": true,
+                  "declAttributes": [
+                    "AccessControl"
+                  ],
+                  "funcSelfKind": "NonMutating"
+                },
+                {
+                  "kind": "Function",
+                  "name": "hash",
+                  "printedName": "hash(into:)",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Hasher",
+                      "printedName": "Swift.Hasher",
+                      "paramValueOwnership": "InOut",
+                      "usr": "s:s6HasherV"
+                    }
+                  ],
+                  "declKind": "Func",
+                  "usr": "s:ScS12ContinuationV11TerminationO4hash4intoys6HasherVz_tF",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0>",
+                  "sugared_genericSig": "<Element>",
+                  "declAttributes": [
+                    "AccessControl"
+                  ],
+                  "funcSelfKind": "NonMutating"
+                },
+                {
+                  "kind": "Var",
+                  "name": "hashValue",
+                  "printedName": "hashValue",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Int",
+                      "printedName": "Swift.Int",
+                      "usr": "s:Si"
+                    }
+                  ],
+                  "declKind": "Var",
+                  "usr": "s:ScS12ContinuationV11TerminationO9hashValueSivp",
+                  "moduleName": "_Concurrency",
+                  "declAttributes": [
+                    "AccessControl"
+                  ],
+                  "accessors": [
+                    {
+                      "kind": "Accessor",
+                      "name": "Get",
+                      "printedName": "Get()",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Int",
+                          "printedName": "Swift.Int",
+                          "usr": "s:Si"
+                        }
+                      ],
+                      "declKind": "Accessor",
+                      "usr": "s:ScS12ContinuationV11TerminationO9hashValueSivg",
+                      "moduleName": "_Concurrency",
+                      "genericSig": "<τ_0_0>",
+                      "sugared_genericSig": "<Element>",
+                      "accessorKind": "get"
+                    }
+                  ]
+                }
+              ],
+              "declKind": "Enum",
+              "usr": "s:ScS12ContinuationV11TerminationO",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0>",
+              "sugared_genericSig": "<Element>",
+              "declAttributes": [
+                "AccessControl"
+              ],
+              "conformances": [
+                {
+                  "kind": "Conformance",
+                  "name": "Equatable",
+                  "printedName": "Equatable",
+                  "usr": "s:SQ"
+                },
+                {
+                  "kind": "Conformance",
+                  "name": "Hashable",
+                  "printedName": "Hashable",
+                  "usr": "s:SH"
+                }
+              ]
+            },
+            {
+              "kind": "TypeDecl",
+              "name": "YieldResult",
+              "printedName": "YieldResult",
+              "children": [
+                {
+                  "kind": "Var",
+                  "name": "enqueued",
+                  "printedName": "enqueued",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "GenericFunction",
+                      "printedName": "<τ_0_0> (_Concurrency.AsyncStream<τ_0_0>.Continuation.YieldResult.Type) -> (Swift.Int) -> _Concurrency.AsyncStream<τ_0_0>.Continuation.YieldResult",
+                      "children": [
+                        {
+                          "kind": "TypeFunc",
+                          "name": "Function",
+                          "printedName": "(Swift.Int) -> _Concurrency.AsyncStream<τ_0_0>.Continuation.YieldResult",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "YieldResult",
+                              "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.YieldResult",
+                              "usr": "s:ScS12ContinuationV11YieldResultO"
+                            },
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Tuple",
+                              "printedName": "(remaining: Swift.Int)",
+                              "children": [
+                                {
+                                  "kind": "TypeNominal",
+                                  "name": "Int",
+                                  "printedName": "Swift.Int",
+                                  "usr": "s:Si"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Metatype",
+                          "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.YieldResult.Type",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "YieldResult",
+                              "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.YieldResult",
+                              "usr": "s:ScS12ContinuationV11YieldResultO"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "EnumElement",
+                  "usr": "s:ScS12ContinuationV11YieldResultO8enqueuedyADyx__GSi_tcAFmlF",
+                  "moduleName": "_Concurrency"
+                },
+                {
+                  "kind": "Var",
+                  "name": "dropped",
+                  "printedName": "dropped",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "GenericFunction",
+                      "printedName": "<τ_0_0> (_Concurrency.AsyncStream<τ_0_0>.Continuation.YieldResult.Type) -> (τ_0_0) -> _Concurrency.AsyncStream<τ_0_0>.Continuation.YieldResult",
+                      "children": [
+                        {
+                          "kind": "TypeFunc",
+                          "name": "Function",
+                          "printedName": "(τ_0_0) -> _Concurrency.AsyncStream<τ_0_0>.Continuation.YieldResult",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "YieldResult",
+                              "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.YieldResult",
+                              "usr": "s:ScS12ContinuationV11YieldResultO"
+                            },
+                            {
+                              "kind": "TypeNominal",
+                              "name": "GenericTypeParam",
+                              "printedName": "τ_0_0"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Metatype",
+                          "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.YieldResult.Type",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "YieldResult",
+                              "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.YieldResult",
+                              "usr": "s:ScS12ContinuationV11YieldResultO"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "EnumElement",
+                  "usr": "s:ScS12ContinuationV11YieldResultO7droppedyADyx__GxcAFmlF",
+                  "moduleName": "_Concurrency"
+                },
+                {
+                  "kind": "Var",
+                  "name": "terminated",
+                  "printedName": "terminated",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "GenericFunction",
+                      "printedName": "<τ_0_0> (_Concurrency.AsyncStream<τ_0_0>.Continuation.YieldResult.Type) -> _Concurrency.AsyncStream<τ_0_0>.Continuation.YieldResult",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "YieldResult",
+                          "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.YieldResult",
+                          "usr": "s:ScS12ContinuationV11YieldResultO"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Metatype",
+                          "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.YieldResult.Type",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "YieldResult",
+                              "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.YieldResult",
+                              "usr": "s:ScS12ContinuationV11YieldResultO"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "EnumElement",
+                  "usr": "s:ScS12ContinuationV11YieldResultO10terminatedyADyx__GAFmlF",
+                  "moduleName": "_Concurrency"
+                }
+              ],
+              "declKind": "Enum",
+              "usr": "s:ScS12ContinuationV11YieldResultO",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0>",
+              "sugared_genericSig": "<Element>",
+              "declAttributes": [
+                "AccessControl"
+              ]
+            },
+            {
+              "kind": "TypeDecl",
+              "name": "BufferingPolicy",
+              "printedName": "BufferingPolicy",
+              "children": [
+                {
+                  "kind": "Var",
+                  "name": "unbounded",
+                  "printedName": "unbounded",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "GenericFunction",
+                      "printedName": "<τ_0_0> (_Concurrency.AsyncStream<τ_0_0>.Continuation.BufferingPolicy.Type) -> _Concurrency.AsyncStream<τ_0_0>.Continuation.BufferingPolicy",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "BufferingPolicy",
+                          "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.BufferingPolicy",
+                          "usr": "s:ScS12ContinuationV15BufferingPolicyO"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Metatype",
+                          "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.BufferingPolicy.Type",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "BufferingPolicy",
+                              "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.BufferingPolicy",
+                              "usr": "s:ScS12ContinuationV15BufferingPolicyO"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "EnumElement",
+                  "usr": "s:ScS12ContinuationV15BufferingPolicyO9unboundedyADyx__GAFmlF",
+                  "moduleName": "_Concurrency"
+                },
+                {
+                  "kind": "Var",
+                  "name": "bufferingOldest",
+                  "printedName": "bufferingOldest",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "GenericFunction",
+                      "printedName": "<τ_0_0> (_Concurrency.AsyncStream<τ_0_0>.Continuation.BufferingPolicy.Type) -> (Swift.Int) -> _Concurrency.AsyncStream<τ_0_0>.Continuation.BufferingPolicy",
+                      "children": [
+                        {
+                          "kind": "TypeFunc",
+                          "name": "Function",
+                          "printedName": "(Swift.Int) -> _Concurrency.AsyncStream<τ_0_0>.Continuation.BufferingPolicy",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "BufferingPolicy",
+                              "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.BufferingPolicy",
+                              "usr": "s:ScS12ContinuationV15BufferingPolicyO"
+                            },
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Int",
+                              "printedName": "Swift.Int",
+                              "usr": "s:Si"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Metatype",
+                          "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.BufferingPolicy.Type",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "BufferingPolicy",
+                              "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.BufferingPolicy",
+                              "usr": "s:ScS12ContinuationV15BufferingPolicyO"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "EnumElement",
+                  "usr": "s:ScS12ContinuationV15BufferingPolicyO15bufferingOldestyADyx__GSicAFmlF",
+                  "moduleName": "_Concurrency"
+                },
+                {
+                  "kind": "Var",
+                  "name": "bufferingNewest",
+                  "printedName": "bufferingNewest",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "GenericFunction",
+                      "printedName": "<τ_0_0> (_Concurrency.AsyncStream<τ_0_0>.Continuation.BufferingPolicy.Type) -> (Swift.Int) -> _Concurrency.AsyncStream<τ_0_0>.Continuation.BufferingPolicy",
+                      "children": [
+                        {
+                          "kind": "TypeFunc",
+                          "name": "Function",
+                          "printedName": "(Swift.Int) -> _Concurrency.AsyncStream<τ_0_0>.Continuation.BufferingPolicy",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "BufferingPolicy",
+                              "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.BufferingPolicy",
+                              "usr": "s:ScS12ContinuationV15BufferingPolicyO"
+                            },
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Int",
+                              "printedName": "Swift.Int",
+                              "usr": "s:Si"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Metatype",
+                          "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.BufferingPolicy.Type",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "BufferingPolicy",
+                              "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.BufferingPolicy",
+                              "usr": "s:ScS12ContinuationV15BufferingPolicyO"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "EnumElement",
+                  "usr": "s:ScS12ContinuationV15BufferingPolicyO15bufferingNewestyADyx__GSicAFmlF",
+                  "moduleName": "_Concurrency"
+                }
+              ],
+              "declKind": "Enum",
+              "usr": "s:ScS12ContinuationV15BufferingPolicyO",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0>",
+              "sugared_genericSig": "<Element>",
+              "declAttributes": [
+                "AccessControl"
+              ]
+            },
+            {
+              "kind": "Function",
+              "name": "yield",
+              "printedName": "yield(_:)",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "YieldResult",
+                  "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.YieldResult",
+                  "usr": "s:ScS12ContinuationV11YieldResultO"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0",
+                  "paramValueOwnership": "Owned"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:ScS12ContinuationV5yieldyAB11YieldResultOyx__GxnF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0>",
+              "sugared_genericSig": "<Element>",
+              "declAttributes": [
+                "AccessControl",
+                "DiscardableResult"
+              ],
+              "funcSelfKind": "NonMutating"
+            },
+            {
+              "kind": "Function",
+              "name": "finish",
+              "printedName": "finish()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Void",
+                  "printedName": "()"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:ScS12ContinuationV6finishyyF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0>",
+              "sugared_genericSig": "<Element>",
+              "declAttributes": [
+                "AccessControl"
+              ],
+              "funcSelfKind": "NonMutating"
+            },
+            {
+              "kind": "Var",
+              "name": "onTermination",
+              "printedName": "onTermination",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "((_Concurrency.AsyncStream<τ_0_0>.Continuation.Termination) -> ())?",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "Function",
+                      "printedName": "(_Concurrency.AsyncStream<τ_0_0>.Continuation.Termination) -> ()",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Void",
+                          "printedName": "()"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Termination",
+                          "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.Termination",
+                          "usr": "s:ScS12ContinuationV11TerminationO"
+                        }
+                      ]
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:ScS12ContinuationV13onTerminationyAB0C0Oyx__GYbcSgvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "AccessControl"
+              ],
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Optional",
+                      "printedName": "((_Concurrency.AsyncStream<τ_0_0>.Continuation.Termination) -> ())?",
+                      "children": [
+                        {
+                          "kind": "TypeFunc",
+                          "name": "Function",
+                          "printedName": "(_Concurrency.AsyncStream<τ_0_0>.Continuation.Termination) -> ()",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Void",
+                              "printedName": "()"
+                            },
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Termination",
+                              "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.Termination",
+                              "usr": "s:ScS12ContinuationV11TerminationO"
+                            }
+                          ]
+                        }
+                      ],
+                      "usr": "s:Sq"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:ScS12ContinuationV13onTerminationyAB0C0Oyx__GYbcSgvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0>",
+                  "sugared_genericSig": "<Element>",
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Optional",
+                      "printedName": "((_Concurrency.AsyncStream<τ_0_0>.Continuation.Termination) -> ())?",
+                      "children": [
+                        {
+                          "kind": "TypeFunc",
+                          "name": "Function",
+                          "printedName": "(_Concurrency.AsyncStream<τ_0_0>.Continuation.Termination) -> ()",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Void",
+                              "printedName": "()"
+                            },
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Termination",
+                              "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.Termination",
+                              "usr": "s:ScS12ContinuationV11TerminationO"
+                            }
+                          ]
+                        }
+                      ],
+                      "usr": "s:Sq"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:ScS12ContinuationV13onTerminationyAB0C0Oyx__GYbcSgvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0>",
+                  "sugared_genericSig": "<Element>",
+                  "declAttributes": [
+                    "NonMutating"
+                  ],
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:ScS12ContinuationV13onTerminationyAB0C0Oyx__GYbcSgvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0>",
+                  "sugared_genericSig": "<Element>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Function",
+              "name": "yield",
+              "printedName": "yield(with:)",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "YieldResult",
+                  "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.YieldResult",
+                  "usr": "s:ScS12ContinuationV11YieldResultO"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "Result",
+                  "printedName": "Swift.Result<τ_0_0, Swift.Never>",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_0"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Never",
+                      "printedName": "Swift.Never",
+                      "usr": "s:s5NeverO"
+                    }
+                  ],
+                  "usr": "s:s6ResultO"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:ScS12ContinuationV5yield4withAB11YieldResultOyx__Gs0E0Oyxs5NeverOG_tF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0>",
+              "sugared_genericSig": "<Element>",
+              "declAttributes": [
+                "AccessControl",
+                "DiscardableResult"
+              ],
+              "funcSelfKind": "NonMutating"
+            },
+            {
+              "kind": "Function",
+              "name": "yield",
+              "printedName": "yield()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "YieldResult",
+                  "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.YieldResult",
+                  "usr": "s:ScS12ContinuationV11YieldResultO"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:ScS12ContinuationV5yieldAB11YieldResultOyyt__GyytRszlF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0 where τ_0_0 == ()>",
+              "sugared_genericSig": "<Element where Element == Swift.Void>",
+              "declAttributes": [
+                "AccessControl",
+                "DiscardableResult"
+              ],
+              "funcSelfKind": "NonMutating"
+            }
+          ],
+          "declKind": "Struct",
+          "usr": "s:ScS12ContinuationV",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0>",
+          "sugared_genericSig": "<Element>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "conformances": [
+            {
+              "kind": "Conformance",
+              "name": "Sendable",
+              "printedName": "Sendable",
+              "usr": "s:s8SendableP"
+            }
+          ]
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(_:bufferingPolicy:_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncStream",
+              "printedName": "_Concurrency.AsyncStream<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:ScS"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Metatype",
+              "printedName": "τ_0_0.Type",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "hasDefaultArg": true
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "BufferingPolicy",
+              "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation.BufferingPolicy",
+              "hasDefaultArg": true,
+              "usr": "s:ScS12ContinuationV15BufferingPolicyO"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(_Concurrency.AsyncStream<τ_0_0>.Continuation) -> ()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Void",
+                  "printedName": "()"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "Continuation",
+                  "printedName": "_Concurrency.AsyncStream<τ_0_0>.Continuation",
+                  "usr": "s:ScS12ContinuationV"
+                }
+              ],
+              "typeAttributes": [
+                "noescape"
+              ]
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:ScS_15bufferingPolicy_ScSyxGxm_ScS12ContinuationV09BufferingB0Oyx__GyADyx_GXEtcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0>",
+          "sugared_genericSig": "<Element>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(unfolding:onCancel:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncStream",
+              "printedName": "_Concurrency.AsyncStream<τ_0_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "usr": "s:ScS"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "() async -> τ_0_0?",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_0?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_0"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "Void",
+                  "printedName": "()"
+                }
+              ]
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Optional",
+              "printedName": "(() -> ())?",
+              "children": [
+                {
+                  "kind": "TypeFunc",
+                  "name": "Function",
+                  "printedName": "() -> ()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ]
+                }
+              ],
+              "hasDefaultArg": true,
+              "usr": "s:Sq"
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:ScS9unfolding8onCancelScSyxGxSgyYac_yyYbcSgtcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0>",
+          "sugared_genericSig": "<Element>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "TypeDecl",
+          "name": "Iterator",
+          "printedName": "Iterator",
+          "children": [
+            {
+              "kind": "Function",
+              "name": "next",
+              "printedName": "next()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_0?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_0"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:ScS8IteratorV4nextxSgyYaF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0>",
+              "sugared_genericSig": "<Element>",
+              "declAttributes": [
+                "Mutating",
+                "AccessControl"
+              ],
+              "funcSelfKind": "Mutating"
+            }
+          ],
+          "declKind": "Struct",
+          "usr": "s:ScS8IteratorV",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0>",
+          "sugared_genericSig": "<Element>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "conformances": [
+            {
+              "kind": "Conformance",
+              "name": "AsyncIteratorProtocol",
+              "printedName": "AsyncIteratorProtocol",
+              "children": [
+                {
+                  "kind": "TypeWitness",
+                  "name": "Element",
+                  "printedName": "Element",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_0"
+                    }
+                  ]
+                }
+              ],
+              "usr": "s:ScI"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "makeAsyncIterator",
+          "printedName": "makeAsyncIterator()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Iterator",
+              "printedName": "_Concurrency.AsyncStream<τ_0_0>.Iterator",
+              "usr": "s:ScS8IteratorV"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:ScS17makeAsyncIteratorScS0C0Vyx_GyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0>",
+          "sugared_genericSig": "<Element>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:ScS",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0>",
+      "sugared_genericSig": "<Element>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "AsyncSequence",
+          "printedName": "AsyncSequence",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "AsyncIterator",
+              "printedName": "AsyncIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncStream<τ_0_0>.Iterator",
+                  "usr": "s:ScS8IteratorV"
+                }
+              ]
+            },
+            {
+              "kind": "TypeWitness",
+              "name": "Element",
+              "printedName": "Element",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ]
+            }
+          ],
+          "usr": "s:Sci"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "AsyncThrowingStream",
+      "printedName": "AsyncThrowingStream",
+      "children": [
+        {
+          "kind": "TypeDecl",
+          "name": "Continuation",
+          "printedName": "Continuation",
+          "children": [
+            {
+              "kind": "TypeDecl",
+              "name": "Termination",
+              "printedName": "Termination",
+              "children": [
+                {
+                  "kind": "Var",
+                  "name": "finished",
+                  "printedName": "finished",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "GenericFunction",
+                      "printedName": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error> (_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.Termination.Type) -> (τ_0_1?) -> _Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.Termination",
+                      "children": [
+                        {
+                          "kind": "TypeFunc",
+                          "name": "Function",
+                          "printedName": "(τ_0_1?) -> _Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.Termination",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Termination",
+                              "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.Termination",
+                              "usr": "s:Scs12ContinuationV11TerminationO"
+                            },
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Optional",
+                              "printedName": "τ_0_1?",
+                              "children": [
+                                {
+                                  "kind": "TypeNominal",
+                                  "name": "GenericTypeParam",
+                                  "printedName": "τ_0_1"
+                                }
+                              ],
+                              "usr": "s:Sq"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Metatype",
+                          "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.Termination.Type",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Termination",
+                              "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.Termination",
+                              "usr": "s:Scs12ContinuationV11TerminationO"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "EnumElement",
+                  "usr": "s:Scs12ContinuationV11TerminationO8finishedyADyxq___Gq_SgcAFms5ErrorR_r0_lF",
+                  "moduleName": "_Concurrency"
+                },
+                {
+                  "kind": "Var",
+                  "name": "cancelled",
+                  "printedName": "cancelled",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "GenericFunction",
+                      "printedName": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error> (_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.Termination.Type) -> _Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.Termination",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Termination",
+                          "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.Termination",
+                          "usr": "s:Scs12ContinuationV11TerminationO"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Metatype",
+                          "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.Termination.Type",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Termination",
+                              "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.Termination",
+                              "usr": "s:Scs12ContinuationV11TerminationO"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "EnumElement",
+                  "usr": "s:Scs12ContinuationV11TerminationO9cancelledyADyxq___GAFms5ErrorR_r0_lF",
+                  "moduleName": "_Concurrency"
+                }
+              ],
+              "declKind": "Enum",
+              "usr": "s:Scs12ContinuationV11TerminationO",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+              "sugared_genericSig": "<Element, Failure where Failure : Swift.Error>",
+              "declAttributes": [
+                "AccessControl"
+              ]
+            },
+            {
+              "kind": "TypeDecl",
+              "name": "YieldResult",
+              "printedName": "YieldResult",
+              "children": [
+                {
+                  "kind": "Var",
+                  "name": "enqueued",
+                  "printedName": "enqueued",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "GenericFunction",
+                      "printedName": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error> (_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.YieldResult.Type) -> (Swift.Int) -> _Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.YieldResult",
+                      "children": [
+                        {
+                          "kind": "TypeFunc",
+                          "name": "Function",
+                          "printedName": "(Swift.Int) -> _Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.YieldResult",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "YieldResult",
+                              "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.YieldResult",
+                              "usr": "s:Scs12ContinuationV11YieldResultO"
+                            },
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Tuple",
+                              "printedName": "(remaining: Swift.Int)",
+                              "children": [
+                                {
+                                  "kind": "TypeNominal",
+                                  "name": "Int",
+                                  "printedName": "Swift.Int",
+                                  "usr": "s:Si"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Metatype",
+                          "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.YieldResult.Type",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "YieldResult",
+                              "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.YieldResult",
+                              "usr": "s:Scs12ContinuationV11YieldResultO"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "EnumElement",
+                  "usr": "s:Scs12ContinuationV11YieldResultO8enqueuedyADyxq___GSi_tcAFms5ErrorR_r0_lF",
+                  "moduleName": "_Concurrency"
+                },
+                {
+                  "kind": "Var",
+                  "name": "dropped",
+                  "printedName": "dropped",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "GenericFunction",
+                      "printedName": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error> (_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.YieldResult.Type) -> (τ_0_0) -> _Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.YieldResult",
+                      "children": [
+                        {
+                          "kind": "TypeFunc",
+                          "name": "Function",
+                          "printedName": "(τ_0_0) -> _Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.YieldResult",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "YieldResult",
+                              "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.YieldResult",
+                              "usr": "s:Scs12ContinuationV11YieldResultO"
+                            },
+                            {
+                              "kind": "TypeNominal",
+                              "name": "GenericTypeParam",
+                              "printedName": "τ_0_0"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Metatype",
+                          "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.YieldResult.Type",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "YieldResult",
+                              "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.YieldResult",
+                              "usr": "s:Scs12ContinuationV11YieldResultO"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "EnumElement",
+                  "usr": "s:Scs12ContinuationV11YieldResultO7droppedyADyxq___GxcAFms5ErrorR_r0_lF",
+                  "moduleName": "_Concurrency"
+                },
+                {
+                  "kind": "Var",
+                  "name": "terminated",
+                  "printedName": "terminated",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "GenericFunction",
+                      "printedName": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error> (_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.YieldResult.Type) -> _Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.YieldResult",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "YieldResult",
+                          "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.YieldResult",
+                          "usr": "s:Scs12ContinuationV11YieldResultO"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Metatype",
+                          "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.YieldResult.Type",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "YieldResult",
+                              "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.YieldResult",
+                              "usr": "s:Scs12ContinuationV11YieldResultO"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "EnumElement",
+                  "usr": "s:Scs12ContinuationV11YieldResultO10terminatedyADyxq___GAFms5ErrorR_r0_lF",
+                  "moduleName": "_Concurrency"
+                }
+              ],
+              "declKind": "Enum",
+              "usr": "s:Scs12ContinuationV11YieldResultO",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+              "sugared_genericSig": "<Element, Failure where Failure : Swift.Error>",
+              "declAttributes": [
+                "AccessControl"
+              ]
+            },
+            {
+              "kind": "TypeDecl",
+              "name": "BufferingPolicy",
+              "printedName": "BufferingPolicy",
+              "children": [
+                {
+                  "kind": "Var",
+                  "name": "unbounded",
+                  "printedName": "unbounded",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "GenericFunction",
+                      "printedName": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error> (_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.BufferingPolicy.Type) -> _Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.BufferingPolicy",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "BufferingPolicy",
+                          "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.BufferingPolicy",
+                          "usr": "s:Scs12ContinuationV15BufferingPolicyO"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Metatype",
+                          "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.BufferingPolicy.Type",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "BufferingPolicy",
+                              "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.BufferingPolicy",
+                              "usr": "s:Scs12ContinuationV15BufferingPolicyO"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "EnumElement",
+                  "usr": "s:Scs12ContinuationV15BufferingPolicyO9unboundedyADyxq___GAFms5ErrorR_r0_lF",
+                  "moduleName": "_Concurrency"
+                },
+                {
+                  "kind": "Var",
+                  "name": "bufferingOldest",
+                  "printedName": "bufferingOldest",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "GenericFunction",
+                      "printedName": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error> (_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.BufferingPolicy.Type) -> (Swift.Int) -> _Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.BufferingPolicy",
+                      "children": [
+                        {
+                          "kind": "TypeFunc",
+                          "name": "Function",
+                          "printedName": "(Swift.Int) -> _Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.BufferingPolicy",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "BufferingPolicy",
+                              "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.BufferingPolicy",
+                              "usr": "s:Scs12ContinuationV15BufferingPolicyO"
+                            },
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Int",
+                              "printedName": "Swift.Int",
+                              "usr": "s:Si"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Metatype",
+                          "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.BufferingPolicy.Type",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "BufferingPolicy",
+                              "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.BufferingPolicy",
+                              "usr": "s:Scs12ContinuationV15BufferingPolicyO"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "EnumElement",
+                  "usr": "s:Scs12ContinuationV15BufferingPolicyO15bufferingOldestyADyxq___GSicAFms5ErrorR_r0_lF",
+                  "moduleName": "_Concurrency"
+                },
+                {
+                  "kind": "Var",
+                  "name": "bufferingNewest",
+                  "printedName": "bufferingNewest",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "GenericFunction",
+                      "printedName": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error> (_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.BufferingPolicy.Type) -> (Swift.Int) -> _Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.BufferingPolicy",
+                      "children": [
+                        {
+                          "kind": "TypeFunc",
+                          "name": "Function",
+                          "printedName": "(Swift.Int) -> _Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.BufferingPolicy",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "BufferingPolicy",
+                              "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.BufferingPolicy",
+                              "usr": "s:Scs12ContinuationV15BufferingPolicyO"
+                            },
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Int",
+                              "printedName": "Swift.Int",
+                              "usr": "s:Si"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Metatype",
+                          "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.BufferingPolicy.Type",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "BufferingPolicy",
+                              "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.BufferingPolicy",
+                              "usr": "s:Scs12ContinuationV15BufferingPolicyO"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "declKind": "EnumElement",
+                  "usr": "s:Scs12ContinuationV15BufferingPolicyO15bufferingNewestyADyxq___GSicAFms5ErrorR_r0_lF",
+                  "moduleName": "_Concurrency"
+                }
+              ],
+              "declKind": "Enum",
+              "usr": "s:Scs12ContinuationV15BufferingPolicyO",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+              "sugared_genericSig": "<Element, Failure where Failure : Swift.Error>",
+              "declAttributes": [
+                "AccessControl"
+              ]
+            },
+            {
+              "kind": "Function",
+              "name": "yield",
+              "printedName": "yield(_:)",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "YieldResult",
+                  "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.YieldResult",
+                  "usr": "s:Scs12ContinuationV11YieldResultO"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0",
+                  "paramValueOwnership": "Owned"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:Scs12ContinuationV5yieldyAB11YieldResultOyxq___GxnF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+              "sugared_genericSig": "<Element, Failure where Failure : Swift.Error>",
+              "declAttributes": [
+                "AccessControl",
+                "DiscardableResult"
+              ],
+              "funcSelfKind": "NonMutating"
+            },
+            {
+              "kind": "Function",
+              "name": "finish",
+              "printedName": "finish(throwing:)",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Void",
+                  "printedName": "()"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_1?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    }
+                  ],
+                  "hasDefaultArg": true,
+                  "paramValueOwnership": "Owned",
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:Scs12ContinuationV6finish8throwingyq_Sgn_tF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+              "sugared_genericSig": "<Element, Failure where Failure : Swift.Error>",
+              "declAttributes": [
+                "AccessControl"
+              ],
+              "funcSelfKind": "NonMutating"
+            },
+            {
+              "kind": "Var",
+              "name": "onTermination",
+              "printedName": "onTermination",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "((_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.Termination) -> ())?",
+                  "children": [
+                    {
+                      "kind": "TypeFunc",
+                      "name": "Function",
+                      "printedName": "(_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.Termination) -> ()",
+                      "children": [
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Void",
+                          "printedName": "()"
+                        },
+                        {
+                          "kind": "TypeNominal",
+                          "name": "Termination",
+                          "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.Termination",
+                          "usr": "s:Scs12ContinuationV11TerminationO"
+                        }
+                      ]
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Var",
+              "usr": "s:Scs12ContinuationV13onTerminationyAB0C0Oyxq___GYbcSgvp",
+              "moduleName": "_Concurrency",
+              "declAttributes": [
+                "AccessControl"
+              ],
+              "accessors": [
+                {
+                  "kind": "Accessor",
+                  "name": "Get",
+                  "printedName": "Get()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Optional",
+                      "printedName": "((_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.Termination) -> ())?",
+                      "children": [
+                        {
+                          "kind": "TypeFunc",
+                          "name": "Function",
+                          "printedName": "(_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.Termination) -> ()",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Void",
+                              "printedName": "()"
+                            },
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Termination",
+                              "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.Termination",
+                              "usr": "s:Scs12ContinuationV11TerminationO"
+                            }
+                          ]
+                        }
+                      ],
+                      "usr": "s:Sq"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:Scs12ContinuationV13onTerminationyAB0C0Oyxq___GYbcSgvg",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+                  "sugared_genericSig": "<Element, Failure where Failure : Swift.Error>",
+                  "accessorKind": "get"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Set",
+                  "printedName": "Set()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Optional",
+                      "printedName": "((_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.Termination) -> ())?",
+                      "children": [
+                        {
+                          "kind": "TypeFunc",
+                          "name": "Function",
+                          "printedName": "(_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.Termination) -> ()",
+                          "children": [
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Void",
+                              "printedName": "()"
+                            },
+                            {
+                              "kind": "TypeNominal",
+                              "name": "Termination",
+                              "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.Termination",
+                              "usr": "s:Scs12ContinuationV11TerminationO"
+                            }
+                          ]
+                        }
+                      ],
+                      "usr": "s:Sq"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:Scs12ContinuationV13onTerminationyAB0C0Oyxq___GYbcSgvs",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+                  "sugared_genericSig": "<Element, Failure where Failure : Swift.Error>",
+                  "declAttributes": [
+                    "NonMutating"
+                  ],
+                  "accessorKind": "set"
+                },
+                {
+                  "kind": "Accessor",
+                  "name": "Modify",
+                  "printedName": "Modify()",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "Void",
+                      "printedName": "()"
+                    }
+                  ],
+                  "declKind": "Accessor",
+                  "usr": "s:Scs12ContinuationV13onTerminationyAB0C0Oyxq___GYbcSgvM",
+                  "moduleName": "_Concurrency",
+                  "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+                  "sugared_genericSig": "<Element, Failure where Failure : Swift.Error>",
+                  "implicit": true,
+                  "accessorKind": "_modify"
+                }
+              ]
+            },
+            {
+              "kind": "Function",
+              "name": "yield",
+              "printedName": "yield(with:)",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "YieldResult",
+                  "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.YieldResult",
+                  "usr": "s:Scs12ContinuationV11YieldResultO"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "Result",
+                  "printedName": "Swift.Result<τ_0_0, τ_0_1>",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_0"
+                    },
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_1"
+                    }
+                  ],
+                  "usr": "s:s6ResultO"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:Scs12ContinuationV5yield4withAB11YieldResultOyxs5Error_p__Gs0E0OyxsAG_pG_tsAG_pRs_rlF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 == Swift.Error>",
+              "sugared_genericSig": "<Element, Failure where Failure == Swift.Error>",
+              "declAttributes": [
+                "AccessControl",
+                "DiscardableResult"
+              ],
+              "funcSelfKind": "NonMutating"
+            },
+            {
+              "kind": "Function",
+              "name": "yield",
+              "printedName": "yield()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "YieldResult",
+                  "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.YieldResult",
+                  "usr": "s:Scs12ContinuationV11YieldResultO"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:Scs12ContinuationV5yieldAB11YieldResultOyytq___GyytRszrlF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 == (), τ_0_1 : Swift.Error>",
+              "sugared_genericSig": "<Element, Failure where Element == Swift.Void, Failure : Swift.Error>",
+              "declAttributes": [
+                "AccessControl",
+                "DiscardableResult"
+              ],
+              "funcSelfKind": "NonMutating"
+            }
+          ],
+          "declKind": "Struct",
+          "usr": "s:Scs12ContinuationV",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<Element, Failure where Failure : Swift.Error>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "conformances": [
+            {
+              "kind": "Conformance",
+              "name": "Sendable",
+              "printedName": "Sendable",
+              "usr": "s:s8SendableP"
+            }
+          ]
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(_:bufferingPolicy:_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncThrowingStream",
+              "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ],
+              "usr": "s:Scs"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Metatype",
+              "printedName": "τ_0_0.Type",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ],
+              "hasDefaultArg": true
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "BufferingPolicy",
+              "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation.BufferingPolicy",
+              "hasDefaultArg": true,
+              "usr": "s:Scs12ContinuationV15BufferingPolicyO"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "(_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation) -> ()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Void",
+                  "printedName": "()"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "Continuation",
+                  "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Continuation",
+                  "usr": "s:Scs12ContinuationV"
+                }
+              ],
+              "typeAttributes": [
+                "noescape"
+              ]
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:Scs_15bufferingPolicy_Scsyxs5Error_pGxm_Scs12ContinuationV09BufferingB0OyxsAB_p__GyAEyxsAB_p_GXEtcsAB_pRs_rlufc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 == Swift.Error>",
+          "sugared_genericSig": "<Element, Failure where Failure == Swift.Error>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(unfolding:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "AsyncThrowingStream",
+              "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ],
+              "usr": "s:Scs"
+            },
+            {
+              "kind": "TypeFunc",
+              "name": "Function",
+              "printedName": "() async throws -> τ_0_0?",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_0?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_0"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "Void",
+                  "printedName": "()"
+                }
+              ]
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:Scs9unfoldingScsyxs5Error_pGxSgyYaKc_tcsAB_pRs_rlufc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 == Swift.Error>",
+          "sugared_genericSig": "<Element, Failure where Failure == Swift.Error>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "TypeDecl",
+          "name": "Iterator",
+          "printedName": "Iterator",
+          "children": [
+            {
+              "kind": "Function",
+              "name": "next",
+              "printedName": "next()",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Optional",
+                  "printedName": "τ_0_0?",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_0"
+                    }
+                  ],
+                  "usr": "s:Sq"
+                }
+              ],
+              "declKind": "Func",
+              "usr": "s:Scs8IteratorV4nextxSgyYaKF",
+              "moduleName": "_Concurrency",
+              "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+              "sugared_genericSig": "<Element, Failure where Failure : Swift.Error>",
+              "declAttributes": [
+                "Mutating",
+                "AccessControl"
+              ],
+              "throwing": true,
+              "funcSelfKind": "Mutating"
+            }
+          ],
+          "declKind": "Struct",
+          "usr": "s:Scs8IteratorV",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<Element, Failure where Failure : Swift.Error>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "conformances": [
+            {
+              "kind": "Conformance",
+              "name": "AsyncIteratorProtocol",
+              "printedName": "AsyncIteratorProtocol",
+              "children": [
+                {
+                  "kind": "TypeWitness",
+                  "name": "Element",
+                  "printedName": "Element",
+                  "children": [
+                    {
+                      "kind": "TypeNominal",
+                      "name": "GenericTypeParam",
+                      "printedName": "τ_0_0"
+                    }
+                  ]
+                }
+              ],
+              "usr": "s:ScI"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "makeAsyncIterator",
+          "printedName": "makeAsyncIterator()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Iterator",
+              "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Iterator",
+              "usr": "s:Scs8IteratorV"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:Scs17makeAsyncIteratorScs0C0Vyxq__GyF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<Element, Failure where Failure : Swift.Error>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:Scs",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+      "sugared_genericSig": "<Element, Failure where Failure : Swift.Error>",
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "AsyncSequence",
+          "printedName": "AsyncSequence",
+          "children": [
+            {
+              "kind": "TypeWitness",
+              "name": "AsyncIterator",
+              "printedName": "AsyncIterator",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "Iterator",
+                  "printedName": "_Concurrency.AsyncThrowingStream<τ_0_0, τ_0_1>.Iterator",
+                  "usr": "s:Scs8IteratorV"
+                }
+              ]
+            },
+            {
+              "kind": "TypeWitness",
+              "name": "Element",
+              "printedName": "Element",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ]
+            }
+          ],
+          "usr": "s:Sci"
+        }
+      ]
+    },
+    {
+      "kind": "TypeDecl",
+      "name": "YieldingContinuation",
+      "printedName": "YieldingContinuation",
+      "children": [
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "YieldingContinuation",
+              "printedName": "_Concurrency.YieldingContinuation<τ_0_0, τ_0_1>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ],
+              "usr": "s:12_Concurrency20YieldingContinuationV"
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:12_Concurrency20YieldingContinuationVACyxq_Gycfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<Element, Failure where Failure : Swift.Error>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(yielding:throwing:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "YieldingContinuation",
+              "printedName": "_Concurrency.YieldingContinuation<τ_0_0, τ_0_1>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ],
+              "usr": "s:12_Concurrency20YieldingContinuationV"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Metatype",
+              "printedName": "τ_0_0.Type",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ]
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Metatype",
+              "printedName": "τ_0_1.Type",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ]
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:12_Concurrency20YieldingContinuationV8yielding8throwingACyxq_Gxm_q_mtcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<Element, Failure where Failure : Swift.Error>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "Function",
+          "name": "yield",
+          "printedName": "yield(_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0",
+              "paramValueOwnership": "Owned"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency20YieldingContinuationV5yieldySbxnF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<Element, Failure where Failure : Swift.Error>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "yield",
+          "printedName": "yield(throwing:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_1",
+              "paramValueOwnership": "Owned"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency20YieldingContinuationV5yield8throwingSbq_n_tF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<Element, Failure where Failure : Swift.Error>",
+          "declAttributes": [
+            "AccessControl"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "next",
+          "printedName": "next()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency20YieldingContinuationVAAs5Error_pRs_rlE4nextxyYaKF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 == Swift.Error>",
+          "sugared_genericSig": "<Element, Failure where Failure == Swift.Error>",
+          "deprecated": true,
+          "declAttributes": [
+            "AccessControl",
+            "Available"
+          ],
+          "throwing": true,
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Constructor",
+          "name": "init",
+          "printedName": "init(yielding:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "YieldingContinuation",
+              "printedName": "_Concurrency.YieldingContinuation<τ_0_0, τ_0_1>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ],
+              "usr": "s:12_Concurrency20YieldingContinuationV"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Metatype",
+              "printedName": "τ_0_0.Type",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                }
+              ]
+            }
+          ],
+          "declKind": "Constructor",
+          "usr": "s:12_Concurrency20YieldingContinuationVAAs5NeverORs_rlE8yieldingACyxAEGxm_tcfc",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 == Swift.Never>",
+          "sugared_genericSig": "<Element, Failure where Failure == Swift.Never>",
+          "deprecated": true,
+          "declAttributes": [
+            "AccessControl",
+            "Available"
+          ],
+          "init_kind": "Designated"
+        },
+        {
+          "kind": "Function",
+          "name": "next",
+          "printedName": "next()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "GenericTypeParam",
+              "printedName": "τ_0_0"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency20YieldingContinuationVAAs5NeverORs_rlE4nextxyYaF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 == Swift.Never>",
+          "sugared_genericSig": "<Element, Failure where Failure == Swift.Never>",
+          "deprecated": true,
+          "declAttributes": [
+            "AccessControl",
+            "Available"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "yield",
+          "printedName": "yield(with:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Result",
+              "printedName": "Swift.Result<τ_0_0, τ_1_0>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_1_0"
+                }
+              ],
+              "usr": "s:s6ResultO"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency20YieldingContinuationV5yield4withSbs6ResultOyxqd__G_ts5Error_pRs_sAIRd__lF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1, τ_1_0 where τ_0_1 == Swift.Error, τ_1_0 : Swift.Error>",
+          "sugared_genericSig": "<Element, Failure, Er where Failure == Swift.Error, Er : Swift.Error>",
+          "deprecated": true,
+          "declAttributes": [
+            "AccessControl",
+            "Available"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "yield",
+          "printedName": "yield(with:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Result",
+              "printedName": "Swift.Result<τ_0_0, τ_0_1>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_0"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "τ_0_1"
+                }
+              ],
+              "usr": "s:s6ResultO"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency20YieldingContinuationV5yield4withSbs6ResultOyxq_G_tF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<Element, Failure where Failure : Swift.Error>",
+          "deprecated": true,
+          "declAttributes": [
+            "AccessControl",
+            "Available"
+          ],
+          "funcSelfKind": "NonMutating"
+        },
+        {
+          "kind": "Function",
+          "name": "yield",
+          "printedName": "yield()",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:12_Concurrency20YieldingContinuationV5yieldSbyytRszrlF",
+          "moduleName": "_Concurrency",
+          "genericSig": "<τ_0_0, τ_0_1 where τ_0_0 == (), τ_0_1 : Swift.Error>",
+          "sugared_genericSig": "<Element, Failure where Element == Swift.Void, Failure : Swift.Error>",
+          "deprecated": true,
+          "declAttributes": [
+            "AccessControl",
+            "Available"
+          ],
+          "funcSelfKind": "NonMutating"
+        }
+      ],
+      "declKind": "Struct",
+      "usr": "s:12_Concurrency20YieldingContinuationV",
+      "moduleName": "_Concurrency",
+      "genericSig": "<τ_0_0, τ_0_1 where τ_0_1 : Swift.Error>",
+      "sugared_genericSig": "<Element, Failure where Failure : Swift.Error>",
+      "deprecated": true,
+      "intro_Macosx": "12.0",
+      "intro_iOS": "15.0",
+      "intro_tvOS": "15.0",
+      "intro_watchOS": "8.0",
+      "declAttributes": [
+        "AccessControl",
+        "Available",
+        "Available",
+        "Available",
+        "Available",
+        "Available"
+      ],
+      "conformances": [
+        {
+          "kind": "Conformance",
+          "name": "Sendable",
+          "printedName": "Sendable",
+          "usr": "s:s8SendableP"
+        }
+      ]
+    }
+  ],
+  "json_format_version": 6
+}


### PR DESCRIPTION
Add the generated ABI baseline for the _Concurency model on x86_64
macOS, along with a test that checks the built _Concurrency model
against that baseline.

Right now, the test is a mess, because we have some ABI breaks to
unwind. Add it so the test passes, and then we'll audit and address
every change.

Fixes rdar://83673282.
