### PR TITLE
RequirementMachine: Tighten up type witness recursion hack

### DIFF
--- a/lib/AST/RequirementMachine/PropertyMap.h
+++ b/lib/AST/RequirementMachine/PropertyMap.h
@@ -139,6 +139,7 @@ public:
 /// Out-of-line methods are documented in PropertyMap.cpp.
 class PropertyMap {
   RewriteContext &Context;
+  RewriteSystem &System;
   std::vector<PropertyBag *> Entries;
   Trie<PropertyBag *, MatchKind::Longest> Trie;
 
@@ -156,10 +157,11 @@ class PropertyMap {
   PropertyMap &operator=(PropertyMap &&) = delete;
 
 public:
-  explicit PropertyMap(RewriteContext &ctx,
-                       const ProtocolGraph &protos)
-      : Context(ctx), Protos(protos) {
-    Debug = ctx.getDebugOptions();
+  explicit PropertyMap(RewriteSystem &system)
+      : Context(system.getRewriteContext()),
+        System(system),
+        Protos(system.getProtocols()) {
+    Debug = Context.getDebugOptions();
   }
 
   ~PropertyMap();

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -371,7 +371,7 @@ void RequirementMachine::dump(llvm::raw_ostream &out) const {
 }
 
 RequirementMachine::RequirementMachine(RewriteContext &ctx)
-    : Context(ctx), System(ctx), Map(ctx, System.getProtocols()) {
+    : Context(ctx), System(ctx), Map(System) {
   auto &langOpts = ctx.getASTContext().LangOpts;
   Dump = langOpts.DumpRequirementMachine;
   RequirementMachineStepLimit = langOpts.RequirementMachineStepLimit;

--- a/test/Generics/rdar83894546.swift
+++ b/test/Generics/rdar83894546.swift
@@ -1,0 +1,33 @@
+// RUN: %target-typecheck-verify-swift
+
+public protocol P1 {
+  associatedtype A: P1 where A.A == A
+}
+
+public protocol P2 {
+  associatedtype B: P1
+  associatedtype C: P2
+}
+
+public struct G<B : P1> : P2 {
+  public typealias C = G<B.A>
+}
+
+// C == G<B> together with the definition of G<B>.C implies an infinite series
+// of rules:
+// - C.C == G<B.A>
+// - C.C.C == G<B.A.A>
+// - C.C.C.C == G<B.A.A.A>
+// - ...
+//
+// This would normally prevent the completion procedure from terminating,
+// however A.A == A in protocol P1 means that the right hand sides simplify
+// as follows:
+//
+// - C.C == G<B.A>
+// - C.C.C == B<G.A>
+// - C.C.C.C == G<B.A>
+// - ...
+//
+// Therefore, the single rule C.C == C.C.C suffices to "tie off" the recursion.
+public protocol P3: P2 where C == G<B> {}


### PR DESCRIPTION
When a type parameter is subject to a conformance requirement and a concrete type requirement, the concrete type unification pass recursively walks each nested type introduced by the conformance requirement, and fixes it to the concrete type witness in the concrete type conformance.

In general, this can produce an infinite sequence of concrete type requirements. There are a couple of heuristics to "tie off" the recursion.

One heuristic is that if a nested type of a concrete parent type is exactly equal to the parent type, a same-type requirement is introduced between the child and the parent, preventing concrete type unification from recursing further.

This used to check for exact equality of types, but it is possible for the type witness to be equal under canonical type equivalence, but use a different spelling via same-type requirements for some type parameter appearing in structural position.

Instead, canonicalize terms here, allowing recursion where the type witness names a different spelling of the same type.

Here is an example:

```
public protocol P1 {
  associatedtype A: P1 where A.A == A
}

public protocol P2 {
  associatedtype B: P1
  associatedtype C: P2
}

public struct G<B : P1> : P2 {
  public typealias C = G<B.A>
}

public protocol P3: P2 where C == G<B> {}
```

The requirement `C == G<B>` in protocol P3 together with the definition of `G<B>.C` implies an infinite series of rules:
 ```
C.C == G<B.A>
C.C.C == G<B.A.A>
C.C.C.C == G<B.A.A.A>
...
```
This would normally prevent the completion procedure from terminating, however `A.A == A` in protocol P1 means that the right hand sides simplify as follows:
```
C.C == G<B.A>
C.C.C == B<G.A>
C.C.C.C == G<B.A>
...
```
Therefore, the single rule `C.C == C.C.C` suffices to "tie off" the recursion.

Fixes <rdar://problem/83894546>.
