### PR TITLE
Don't include support for old mangling in runtimes without ObjC interop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,10 +405,6 @@ option(SWIFT_REPORT_STATISTICS
     "Create json files which contain internal compilation statistics"
     FALSE)
 
-option(SWIFT_DISABLE_OBJC_INTEROP
-    "Disable Objective-C interoperability even on platforms what would normally have it"
-    FALSE)
-
 #
 # User-configurable experimental options.  Do not use in production builds.
 #

--- a/lib/Demangling/CMakeLists.txt
+++ b/lib/Demangling/CMakeLists.txt
@@ -9,7 +9,8 @@ add_swift_host_library(swiftDemangling STATIC
   Punycode.cpp
   Remangler.cpp)
 target_compile_definitions(swiftDemangling PRIVATE
-  LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
+  LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1
+  SWIFT_SUPPORT_OLD_MANGLING=1)
 
 # NOTE: Runtime libraries that depend on swiftDemangling should define
 # SWIFT_INLINE_NAMESPACE to specify the identifier that will be used for an

--- a/lib/Demangling/Context.cpp
+++ b/lib/Demangling/Context.cpp
@@ -39,10 +39,14 @@ void Context::clear() {
 }
 
 NodePointer Context::demangleSymbolAsNode(llvm::StringRef MangledName) {
+#if SWIFT_SUPPORT_OLD_MANGLING
   if (isMangledName(MangledName)) {
     return D->demangleSymbol(MangledName);
   }
   return demangleOldSymbolAsNode(MangledName, *D);
+#else
+  return D->demangleSymbol(MangledName);
+#endif
 }
 
 NodePointer Context::demangleTypeAsNode(llvm::StringRef MangledName) {

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -542,10 +542,12 @@ NodePointer Demangler::demangleSymbol(StringRef MangledName,
   DemangleInitRAII state(*this, MangledName,
                          std::move(SymbolicReferenceResolver));
 
+#if SWIFT_SUPPORT_OLD_MANGLING
   // Demangle old-style class and protocol names, which are still used in the
   // ObjC metadata.
   if (nextIf("_Tt"))
     return demangleOldSymbolAsNode(Text, *this);
+#endif
 
   unsigned PrefixLength = getManglingPrefixLength(MangledName);
   if (PrefixLength == 0)

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -68,6 +68,13 @@ else()
   set(SWIFT_STDLIB_HAS_ASL_default FALSE)
 endif()
 
+# Only Darwin platforms enable ObjC interop by default.
+if("${SWIFT_HOST_VARIANT_SDK}" MATCHES "(OSX|IOS*|TVOS*|WATCHOS*)")
+  set(SWIFT_STDLIB_ENABLE_OBJC_INTEROP_default TRUE)
+else()
+  set(SWIFT_STDLIB_ENABLE_OBJC_INTEROP_default FALSE)
+endif()
+
 #
 # User-configurable options for the standard library.
 #
@@ -78,6 +85,10 @@ endif()
 option(SWIFT_STDLIB_STABLE_ABI
        "Should stdlib be built with stable ABI (library evolution, resilience)."
        "${SWIFT_STDLIB_STABLE_ABI_default}")
+
+option(SWIFT_STDLIB_ENABLE_OBJC_INTEROP
+       "Should stdlib be built with Obj-C interop."
+       "${SWIFT_STDLIB_ENABLE_OBJC_INTEROP_default}")
 
 option(SWIFT_ENABLE_MODULE_INTERFACES
        "Generate .swiftinterface files alongside .swiftmodule files"

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -303,7 +303,7 @@ function(_add_target_variant_c_compile_flags)
     list(APPEND result "-D_WASI_EMULATED_MMAN")
   endif()
 
-  if(SWIFT_DISABLE_OBJC_INTEROP)
+  if(NOT SWIFT_STDLIB_ENABLE_OBJC_INTEROP)
     list(APPEND result "-DSWIFT_OBJC_INTEROP=0")
   endif()
 

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -494,7 +494,7 @@ function(_compile_swift_files
     list(APPEND swift_flags "-warn-swift3-objc-inference-complete")
   endif()
 
-  if(SWIFT_DISABLE_OBJC_INTEROP)
+  if(NOT SWIFT_STDLIB_ENABLE_OBJC_INTEROP)
     list(APPEND swift_flags "-Xfrontend" "-disable-objc-interop")
   endif()
 

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -66,15 +66,24 @@ if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)
     "${SWIFT_SOURCE_DIR}/lib/Demangling/Demangler.cpp"
     "${SWIFT_SOURCE_DIR}/lib/Demangling/ManglingUtils.cpp"
     "${SWIFT_SOURCE_DIR}/lib/Demangling/NodePrinter.cpp"
-    "${SWIFT_SOURCE_DIR}/lib/Demangling/OldDemangler.cpp"
-    "${SWIFT_SOURCE_DIR}/lib/Demangling/OldRemangler.cpp"
     "${SWIFT_SOURCE_DIR}/lib/Demangling/Punycode.cpp"
     "${SWIFT_SOURCE_DIR}/lib/Demangling/Remangler.cpp"
     "${SWIFT_SOURCE_DIR}/lib/Demangling/NodeDumper.cpp")
 
+  # The old mangling support is only needed on platforms with ObjC.
+  if(SWIFT_STDLIB_ENABLE_OBJC_INTEROP)
+    list(APPEND swiftDemanglingSources
+      "${SWIFT_SOURCE_DIR}/lib/Demangling/OldDemangler.cpp"
+      "${SWIFT_SOURCE_DIR}/lib/Demangling/OldRemangler.cpp"
+      )
+    set(swift_demangling_cflags -DSWIFT_SUPPORT_OLD_MANGLING=1)
+  else()
+    set(swift_demangling_cflags -DSWIFT_SUPPORT_OLD_MANGLING=0)
+  endif()
+
   add_swift_target_library(swiftDemangling OBJECT_LIBRARY
     ${swiftDemanglingSources}
-    C_COMPILE_FLAGS -DswiftCore_EXPORTS
+    C_COMPILE_FLAGS -DswiftCore_EXPORTS ${swift_demangling_cflags}
     INSTALL_IN_COMPONENT never_install)
 endif()
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -203,7 +203,7 @@ KNOWN_SETTINGS=(
     report-statistics                             "0"               "set to 1 to generate compilation statistics files for swift libraries"
     sil-verify-all                                "0"               "If enabled, run the SIL verifier after each transform when building Swift files during this build process"
     stdlib-deployment-targets                     ""                "space-separated list of targets to configure the Swift standard library to be compiled or cross-compiled for"
-    swift-objc-interop                            ""                "whether to enable interoperability with Objective-C, default is 1 on Apple platfors, 0 otherwise"
+    swift-objc-interop                            ""                "whether to enable interoperability with Objective-C, default is 1 on Darwin platforms, 0 otherwise"
     swift-enable-compatibility-overrides          "1"               "whether to support back-deploying compatibility fixes for newer apps running on older runtimes"
     swift-enable-reflection                       "1"               "whether to support reflection and mirrors"
     swift-stdlib-has-dladdr                       "1"               "whether to build stdlib assuming the runtime environment provides dladdr API"
@@ -2072,10 +2072,10 @@ for host in "${ALL_HOSTS[@]}"; do
                     )
                 fi
 
-                if [[ "${SWIFT_OBJC_INTEROP}" == "0" ]] ; then
+                if [[ "${SWIFT_OBJC_INTEROP}" ]] ; then
                     cmake_options=(
                         "${cmake_options[@]}"
-                        -DSWIFT_DISABLE_OBJC_INTEROP:BOOL=True
+                        -DSWIFT_STDLIB_ENABLE_OBJC_INTEROP:BOOL=$(true_false "${SWIFT_OBJC_INTEROP}")
                     )
                 fi
 


### PR DESCRIPTION
This saves a surprising amount of codesize in the runtime (~25 kB on x86_64).