### PR TITLE
[tests] Make some tests that are x86_64 hardcode that are failing on arm64 run with %target-cpu

### DIFF
--- a/test/IRGen/global_actor_function_types_backdeploy.sil
+++ b/test/IRGen/global_actor_function_types_backdeploy.sil
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -target x86_64-apple-macos12 -emit-ir -o - -primary-file %s | %FileCheck %s --check-prefix CHECK-OS
-// RUN: %target-swift-frontend -target x86_64-apple-macos11 -emit-ir -o - -primary-file %s | %FileCheck %s --check-prefix CHECK-BACKDEPLOY
+// RUN: %target-swift-frontend -target %target-cpu-apple-macos12 -emit-ir -o - -primary-file %s | %FileCheck %s --check-prefix CHECK-OS
+// RUN: %target-swift-frontend -target %target-cpu-apple-macos11 -emit-ir -o - -primary-file %s | %FileCheck %s --check-prefix CHECK-BACKDEPLOY
 // REQUIRES: concurrency
 // REQUIRES: OS=macosx
 

--- a/test/SILOptimizer/pre_specialize-macos.swift
+++ b/test/SILOptimizer/pre_specialize-macos.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -O -swift-version 5 -enable-library-evolution -emit-module -o /dev/null -emit-module-interface-path %t/pre_specialized_module.swiftinterface %S/Inputs/pre_specialized_module.swift -module-name pre_specialized_module
 // RUN: %target-swift-frontend -I %t -O -swift-version 5 -enable-library-evolution -emit-module -o /dev/null -emit-module-interface-path %t/pre_specialized_module2.swiftinterface %S/Inputs/pre_specialized_module2.swift -module-name pre_specialized_module2
-// RUN: %target-swift-frontend -I %t -O -emit-sil -target x86_64-apple-macos11 %s | %FileCheck %s --check-prefix=OPT --check-prefix=CHECK
-// RUN: %target-swift-frontend -I %t -O -emit-sil -target x86_64-apple-macosx10.9 %s | %FileCheck %s --check-prefix=NOOPT --check-prefix=CHECK
+// RUN: %target-swift-frontend -I %t -O -emit-sil -target %target-cpu-apple-macos11 %s | %FileCheck %s --check-prefix=OPT --check-prefix=CHECK
+// RUN: %target-swift-frontend -I %t -O -emit-sil -target %target-cpu-apple-macosx10.9 %s | %FileCheck %s --check-prefix=NOOPT --check-prefix=CHECK
 
 // REQUIRES: OS=macosx
 

--- a/test/Sema/api-availability-only-ok.swift
+++ b/test/Sema/api-availability-only-ok.swift
@@ -3,7 +3,7 @@
 
 // RUN: %empty-directory(%t)
 
-// RUN: %swiftc_driver -emit-module %s -target x86_64-apple-macosx10.15 -emit-module-interface -emit-module-interface-path %t/main.swiftinterface -enable-library-evolution -Xfrontend -check-api-availability-only -verify-emitted-module-interface
+// RUN: %swiftc_driver -emit-module %s -target %target-cpu-apple-macosx10.15 -emit-module-interface -emit-module-interface-path %t/main.swiftinterface -enable-library-evolution -Xfrontend -check-api-availability-only -verify-emitted-module-interface
 // RUN: %target-swift-frontend -typecheck-module-from-interface %t/main.swiftinterface
 
 // REQUIRES: OS=macosx

--- a/test/Sema/api-availability-only.swift
+++ b/test/Sema/api-availability-only.swift
@@ -1,7 +1,7 @@
 /// Test that -check-api-availability-only skips what is expected while checking
 /// the module API and SPI.
 
-// RUN: %target-typecheck-verify-swift -module-name MyModule -target x86_64-apple-macosx10.15 -check-api-availability-only -enable-library-evolution
+// RUN: %target-typecheck-verify-swift -module-name MyModule -target %target-cpu-apple-macosx10.15 -check-api-availability-only -enable-library-evolution
 
 // REQUIRES: OS=macosx
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Those tests are failing locally when running on arm64 machine basically with the same `error: could not find module '_Concurrency' for target 'x86_64-apple-macos'; found: arm64-apple-macos`.
So since none of them seems to be arch specific and are all restricted to macOS already, seems to be fine to run them with `%target-cpu` 

I didn't know who to request for review, so all requests were GitHub suggested :)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
