### PR TITLE
[IRGen] Put 'ret void' instead of unreachable for non swiftasync cc

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -4929,7 +4929,15 @@ void irgen::emitAsyncReturn(
     arguments.push_back(arg);
 
   Builder.CreateIntrinsicCall(llvm::Intrinsic::coro_end_async, arguments);
-  Builder.CreateUnreachable();
+
+  if (IGF.IGM.AsyncTailCallKind == llvm::CallInst::TCK_MustTail) {
+    Builder.CreateUnreachable();
+  } else {
+    // If target doesn't support musttail (e.g. WebAssembly), the function
+    // passed to coro.end.async can return control back to the caller.
+    // So use ret void instead of unreachable to allow it.
+    Builder.CreateRetVoid();
+  }
 }
 
 void irgen::emitAsyncReturn(IRGenFunction &IGF, AsyncContextLayout &asyncLayout,

--- a/test/IRGen/async/non_musttail_target.sil
+++ b/test/IRGen/async/non_musttail_target.sil
@@ -1,0 +1,17 @@
+// Ensure that IRGen don't emit unreachable after coro.end.async for targets that don't support musttail call.
+// RUN: %swift -disable-legacy-type-info -parse-stdlib -target wasm32-unknown-wasi %s -disable-llvm-optzns -disable-swift-specific-llvm-optzns -disable-objc-interop -module-name main -emit-ir -o - | %FileCheck %s
+// REQUIRES: concurrency
+// REQUIRES: CODEGENERATOR=WebAssembly
+
+sil_stage canonical
+
+import Builtin
+
+sil @test_simple : $@async () -> () {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+// CHECK:     call i1 (i8*, i1, ...) @llvm.coro.end.async
+// CHECK-NOT: unreachable
+// CHECK:     ret void
+}


### PR DESCRIPTION
If target doesn't support musttail (e.g. WebAssembly, it's available only under feature flag), the function passed to coro.end.async can return control back to the caller.
So the frontend should emit 'ret void' instead of unreachable after the coro.end.async intrinsic call to allow such situation.

Detail investigation report is here: https://github.com/swiftwasm/swift/issues/3646
