### PR TITLE
[SourceKit] Add a request tracker that manages cancellation

### DIFF
--- a/test/SourceKit/Misc/cancellation.swift
+++ b/test/SourceKit/Misc/cancellation.swift
@@ -1,8 +1,6 @@
 // Check that we can cancel requests.
-// We need to wait a little bit after request scheduling and cancellation to make sure we are not cancelling the request before it got scheduled.
 
-// RUN: not %sourcekitd-test -req=cursor -id=slow -async -pos=9:5 -simulate-long-request=5000 %s -- %s == \
-// RUN: -shell -- sleep 1 == \
+// RUN: not %sourcekitd-test -req=cursor -id=slow -async -pos=7:5 -simulate-long-request=5000 %s -- %s == \
 // RUN: -cancel=slow 2>&1 \
 // RUN: | %FileCheck %s
 

--- a/tools/SourceKit/bindings/python/sourcekitd/capi.py
+++ b/tools/SourceKit/bindings/python/sourcekitd/capi.py
@@ -315,6 +315,8 @@ callbacks['dictionary_applier'] = CFUNCTYPE(
 functionList = [
     ("sourcekitd_cancel_request",
      [c_void_p]),
+    ("sourcekitd_request_handle_dispose",
+     [c_void_p]),
 
     ("sourcekitd_initialize",
      None),

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -745,8 +745,6 @@ public:
 
   virtual void dependencyUpdated() {}
 
-  virtual void cancelRequest(SourceKitCancellationToken CancellationToken) = 0;
-
   virtual void indexSource(StringRef Filename,
                            IndexingConsumer &Consumer,
                            ArrayRef<const char *> Args) = 0;

--- a/tools/SourceKit/lib/Core/Context.cpp
+++ b/tools/SourceKit/lib/Core/Context.cpp
@@ -44,7 +44,8 @@ SourceKit::Context::Context(
       DiagnosticDocumentationPath(DiagnosticDocumentationPath),
       NotificationCtr(
           new NotificationCenter(shouldDispatchNotificationsOnMain)),
-      Config(new GlobalConfig()), SlowRequestSim(new SlowRequestSimulator()) {
+      Config(new GlobalConfig()), ReqTracker(new RequestTracker()),
+      SlowRequestSim(new SlowRequestSimulator(ReqTracker)) {
   // Should be called last after everything is initialized.
   SwiftLang = LangSupportFactoryFn(*this);
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
@@ -74,6 +74,7 @@
 #ifndef LLVM_SOURCEKIT_LIB_SWIFTLANG_SWIFTASTMANAGER_H
 #define LLVM_SOURCEKIT_LIB_SWIFTLANG_SWIFTASTMANAGER_H
 
+#include "SourceKit/Core/Context.h"
 #include "SourceKit/Core/LLVM.h"
 #include "SourceKit/Support/CancellationToken.h"
 #include "SwiftInvocation.h"
@@ -223,6 +224,7 @@ public:
   explicit SwiftASTManager(std::shared_ptr<SwiftEditorDocumentFileMap>,
                            std::shared_ptr<GlobalConfig> Config,
                            std::shared_ptr<SwiftStatistics> Stats,
+                           std::shared_ptr<RequestTracker> ReqTracker,
                            StringRef RuntimeResourcePath,
                            StringRef DiagnosticDocumentationPath);
   ~SwiftASTManager();
@@ -249,12 +251,6 @@ public:
                   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fileSystem,
                   ArrayRef<ImmutableTextSnapshotRef> Snapshots =
                       ArrayRef<ImmutableTextSnapshotRef>());
-
-  /// Request the \c SwiftASTConsumer with the given \p CancellationToken to be
-  /// cancelled. If \p CancellationToken is \c nullptr or no consumer with the
-  /// given cancellation token exists (e.g. because the consumer already
-  /// finished), this is a no-op.
-  void cancelASTConsumer(SourceKitCancellationToken CancellationToken);
 
   std::unique_ptr<llvm::MemoryBuffer> getMemoryBuffer(StringRef Filename,
                                                       std::string &Error);

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -273,7 +273,7 @@ configureCompletionInstance(std::shared_ptr<CompletionInstance> CompletionInst,
 
 SwiftLangSupport::SwiftLangSupport(SourceKit::Context &SKCtx)
     : NotificationCtr(SKCtx.getNotificationCenter()),
-      CCCache(new SwiftCompletionCache) {
+      ReqTracker(SKCtx.getRequestTracker()), CCCache(new SwiftCompletionCache) {
   llvm::SmallString<128> LibPath(SKCtx.getRuntimeLibPath());
   llvm::sys::path::append(LibPath, "swift");
   RuntimeResourcePath = std::string(LibPath.str());
@@ -282,7 +282,7 @@ SwiftLangSupport::SwiftLangSupport(SourceKit::Context &SKCtx)
   Stats = std::make_shared<SwiftStatistics>();
   EditorDocuments = std::make_shared<SwiftEditorDocumentFileMap>();
   ASTMgr = std::make_shared<SwiftASTManager>(
-      EditorDocuments, SKCtx.getGlobalConfiguration(), Stats,
+      EditorDocuments, SKCtx.getGlobalConfiguration(), Stats, ReqTracker,
       RuntimeResourcePath, DiagnosticDocumentationPath);
 
   CompletionInst = std::make_shared<CompletionInstance>();
@@ -305,11 +305,6 @@ void SwiftLangSupport::globalConfigurationUpdated(
 
 void SwiftLangSupport::dependencyUpdated() {
   CompletionInst->markCachedCompilerInstanceShouldBeInvalidated();
-}
-
-void SwiftLangSupport::cancelRequest(
-    SourceKitCancellationToken CancellationToken) {
-  getASTManager()->cancelASTConsumer(CancellationToken);
 }
 
 UIdent SwiftLangSupport::getUIDForDeclLanguage(const swift::Decl *D) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -14,6 +14,7 @@
 #define LLVM_SOURCEKIT_LIB_SWIFTLANG_SWIFTLANGSUPPORT_H
 
 #include "CodeCompletion.h"
+#include "SourceKit/Core/Context.h"
 #include "SourceKit/Core/LangSupport.h"
 #include "SourceKit/Support/Concurrency.h"
 #include "SourceKit/Support/Statistic.h"
@@ -304,6 +305,7 @@ class SwiftLangSupport : public LangSupport {
   std::string DiagnosticDocumentationPath;
   std::shared_ptr<SwiftASTManager> ASTMgr;
   std::shared_ptr<SwiftEditorDocumentFileMap> EditorDocuments;
+  std::shared_ptr<RequestTracker> ReqTracker;
   SwiftInterfaceGenMap IFaceGenContexts;
   ThreadSafeRefCntPtr<SwiftCompletionCache> CCCache;
   ThreadSafeRefCntPtr<SwiftPopularAPI> PopularAPI;
@@ -486,8 +488,6 @@ public:
   void globalConfigurationUpdated(std::shared_ptr<GlobalConfig> Config) override;
 
   void dependencyUpdated() override;
-
-  void cancelRequest(SourceKitCancellationToken CancellationToken) override;
 
   void indexSource(StringRef Filename, IndexingConsumer &Consumer,
                    ArrayRef<const char *> Args) override;

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -1228,6 +1228,8 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
                             ^(sourcekitd_response_t resp) {
                               auto &info = asyncResponses[respIndex];
                               info.response = resp;
+                              sourcekitd_request_handle_dispose(
+                                  info.requestHandle);
                               info.semaphore.signal(); // Ready to be handled!
                             });
 

--- a/tools/SourceKit/tools/sourcekitd/bin/InProc/sourcekitdInProc-darwin.exports
+++ b/tools/SourceKit/tools/sourcekitd/bin/InProc/sourcekitdInProc-darwin.exports
@@ -1,4 +1,5 @@
 sourcekitd_cancel_request
+sourcekitd_request_handle_dispose
 sourcekitd_initialize
 sourcekitd_request_array_create
 sourcekitd_request_array_set_int64

--- a/tools/SourceKit/tools/sourcekitd/bin/InProc/sourcekitdInProc.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/InProc/sourcekitdInProc.cpp
@@ -162,6 +162,10 @@ void sourcekitd_cancel_request(sourcekitd_request_handle_t handle) {
   sourcekitd::cancelRequest(/*CancellationToken=*/handle);
 }
 
+void sourcekitd_request_handle_dispose(sourcekitd_request_handle_t handle) {
+  sourcekitd::disposeCancellationToken(/*CancellationToken=*/handle);
+}
+
 void
 sourcekitd_set_interrupted_connection_handler(
                           sourcekitd_interrupted_connection_handler_t handler) {

--- a/tools/SourceKit/tools/sourcekitd/bin/InProc/sourcekitdInProc.exports
+++ b/tools/SourceKit/tools/sourcekitd/bin/InProc/sourcekitdInProc.exports
@@ -1,4 +1,5 @@
 sourcekitd_cancel_request
+sourcekitd_request_handle_dispose
 sourcekitd_initialize
 sourcekitd_request_array_create
 sourcekitd_request_array_set_int64

--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Client/sourcekitd.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Client/sourcekitd.cpp
@@ -227,6 +227,17 @@ void sourcekitd_cancel_request(sourcekitd_request_handle_t handle) {
   xpc_release(msg);
 }
 
+void sourcekitd_request_handle_dispose(sourcekitd_request_handle_t handle) {
+  xpc_connection_t conn = getGlobalConnection();
+  xpc_object_t msg = xpc_dictionary_create(nullptr, nullptr, 0);
+  xpc_dictionary_set_uint64(msg, xpc::KeyDisposeRequestHandle,
+                            reinterpret_cast<uint64_t>(handle));
+
+  xpc_connection_send_message(conn, msg);
+
+  xpc_release(msg);
+}
+
 /// To avoid repeated crashes, used to notify the service to delay typechecking
 /// in the editor for a certain amount of seconds.
 static std::atomic<size_t> SemanticEditorDelaySecondsNum;

--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Client/sourcekitd.exports
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Client/sourcekitd.exports
@@ -1,4 +1,5 @@
 sourcekitd_cancel_request
+sourcekitd_request_handle_dispose
 sourcekitd_initialize
 sourcekitd_request_array_create
 sourcekitd_request_array_set_int64

--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XPCService.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XPCService.cpp
@@ -275,6 +275,11 @@ static void sourcekitdServer_peer_event_handler(xpc_connection_t peer,
                          xpc_dictionary_get_uint64(event,
                                                    xpc::KeyCancelRequest))) {
         sourcekitd::cancelRequest(/*CancellationToken=*/cancelToken);
+      } else if (SourceKitCancellationToken cancelToken =
+                     reinterpret_cast<SourceKitCancellationToken>(
+                         xpc_dictionary_get_uint64(
+                             event, xpc::KeyDisposeRequestHandle))) {
+        sourcekitd::disposeCancellationToken(/*CancellationToken=*/cancelToken);
       } else {
         assert(false && "unexpected message");
       }

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal-XPC.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal-XPC.h
@@ -25,6 +25,7 @@ static const char *KeyTracingEnabled = "tracing_enabled";
 static const char *KeyMsgResponse = "response";
 static const char *KeyCancelToken = "cancel_token";
 static const char *KeyCancelRequest = "cancel_request";
+static const char *KeyDisposeRequestHandle = "dispose_request_handle";
 
 enum class Message {
   Initialization,

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
@@ -180,6 +180,8 @@ void handleRequest(sourcekitd_object_t Request,
 
 void cancelRequest(SourceKitCancellationToken CancellationToken);
 
+void disposeCancellationToken(SourceKitCancellationToken CancellationToken);
+
 void printRequestObject(sourcekitd_object_t Obj, llvm::raw_ostream &OS);
 void printResponse(sourcekitd_response_t Resp, llvm::raw_ostream &OS);
 

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/sourcekitd.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/sourcekitd.h
@@ -627,6 +627,10 @@ SOURCEKITD_PUBLIC
 void
 sourcekitd_cancel_request(sourcekitd_request_handle_t handle);
 
+/// Dispose a request handle returned by \c sourcekitd_send_request.
+SOURCEKITD_PUBLIC
+void sourcekitd_request_handle_dispose(sourcekitd_request_handle_t handle);
+
 #if SOURCEKITD_HAS_BLOCKS
 
 /// Sets the handler which should be called to receive notifications.

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -113,7 +113,8 @@ class CursorInfoTest : public ::testing::Test {
   NullEditorConsumer Consumer;
 
 public:
-  LangSupport &getLang() { return Ctx.getSwiftLangSupport(); }
+  SourceKit::Context &getContext() { return Ctx; }
+  LangSupport &getLang() { return getContext().getSwiftLangSupport(); }
 
   void SetUp() override {
     llvm::InitializeAllTargets();
@@ -496,7 +497,7 @@ TEST_F(CursorInfoTest, CursorInfoCancellation) {
         CursorInfoSema.signal();
       });
 
-  getLang().cancelRequest(CancellationToken);
+  getContext().getRequestTracker()->cancel(CancellationToken);
 
   bool expired = CursorInfoSema.wait(30 * 1000);
   if (expired)


### PR DESCRIPTION
Previously, `SwiftASTManager` and `SlowRequestSimulator` maintained their own list of in-progress cancellation tokens. With code completion cancellation coming up, there would need to be yet another place to track in-progress requests, so let’s centralize it.

While at it, also support cancelling requests before they are scheduled, eliminating the need for a `sleep` in a test case.

The current implementaiton leaks tiny amounts of memory if a request is cancelled after if finishes. I think this is fine because it is a pretty nieche case and the leaked memory is pretty small (a `std::map` entry pointing to a `std::function` + `bool`). Alternatively, we could require the client to always dispose of the cancellation token manually.

rdar://83762402