### PR TITLE
[BuildScript] Don't install SwiftSyntax

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swiftsyntax.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftsyntax.py
@@ -94,17 +94,10 @@ class SwiftSyntax(product.Product):
         return self.args.install_swiftsyntax
 
     def install(self, target_name):
-        install_prefix = self.args.install_destdir + self.args.install_prefix
-
-        dylib_dir = os.path.join(install_prefix, 'lib')
-
-        additional_params = [
-            '--dylib-dir', dylib_dir,
-            '--install'
-        ]
-
-        self.run_swiftsyntax_build_script(target=target_name,
-                                          additional_params=additional_params)
+        # SwiftSyntax doesn't produce any products thate should be installed 
+        # into the toolchein. All tools using it link against SwiftSyntax 
+        # statically.
+        pass
 
     @classmethod
     def get_dependencies(cls):


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/323

---

Instead, link all binaries in the toolchain using SwiftSyntax (currently only `sk-stress-test`) should link to the binary statically. This simplifies the way SwiftSyntax is built and at the same time slightly reduces the toolchain size.