### PR TITLE
Filter std::function call symbol

### DIFF
--- a/test/stdlib/symbol-visibility-linux.test-sh
+++ b/test/stdlib/symbol-visibility-linux.test-sh
@@ -34,6 +34,7 @@
 // RUN:             -e  _ZZNSt8__detail18__to_chars_10_implImEEvPcjT_E8__digits \
 // RUN:             -e  _ZNKSt8functionIFNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmmEEclEmm \
 // RUN:             -e  _ZSt9call_onceIRFvPvEJDnEEvRSt9once_flagOT_DpOT0_ \
+// RUN:             -e _ZNKSt8functionIFSsmmEEclEmm \
 // RUN:   > %t/swiftCore-all.txt
 // RUN: %llvm-nm --defined-only --extern-only --no-weak %platform-dylib-dir/%target-library-name(swiftCore) > %t/swiftCore-no-weak.txt
 // RUN: diff -u %t/swiftCore-all.txt %t/swiftCore-no-weak.txt
@@ -59,6 +60,7 @@
 // RUN:             -e  _ZZNSt8__detail18__to_chars_10_implImEEvPcjT_E8__digits \
 // RUN:             -e  _ZNKSt8functionIFNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmmEEclEmm \
 // RUN:             -e  _ZSt9call_onceIRFvPvEJDnEEvRSt9once_flagOT_DpOT0_ \
+// RUN:             -e _ZNKSt8functionIFSsmmEEclEmm \
 // RUN:   > %t/swiftRemoteMirror-all.txt
 // RUN: %llvm-nm --defined-only --extern-only --no-weak %platform-dylib-dir/%target-library-name(swiftRemoteMirror) > %t/swiftRemoteMirror-no-weak.txt
 // RUN: diff -u %t/swiftRemoteMirror-all.txt %t/swiftRemoteMirror-no-weak.txt


### PR DESCRIPTION
The `std::function` symbol is showing up on centos 7. It should be okay.

https://ci.swift.org/job/oss-swift-package-centos-7/1254/console