### PR TITLE
Frontend: teach final module emitting jobs to dump a placeholder file for module semantic info

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -131,6 +131,8 @@ ERROR(error_mode_cannot_emit_symbol_graph,none,
       "this mode does not support emitting symbol graph files", ())
 ERROR(error_mode_cannot_emit_abi_descriptor,none,
       "this mode does not support emitting ABI descriptor", ())
+ERROR(error_mode_cannot_emit_module_semantic_info,none,
+      "this mode does not support emitting module semantic info", ())
 ERROR(cannot_emit_ir_skipping_function_bodies,none,
       "the -experimental-skip-*-function-bodies* flags do not support "
       "emitting IR", ())

--- a/include/swift/Basic/SupplementaryOutputPaths.h
+++ b/include/swift/Basic/SupplementaryOutputPaths.h
@@ -146,6 +146,9 @@ struct SupplementaryOutputPaths {
   /// The output path to generate ABI baseline.
   std::string ABIDescriptorOutputPath;
 
+  /// The output path of Swift semantic info for this module.
+  std::string ModuleSemanticInfoOutputPath;
+
   /// The output path for YAML optimization record file.
   std::string YAMLOptRecordPath;
 
@@ -189,6 +192,8 @@ struct SupplementaryOutputPaths {
       fn(YAMLOptRecordPath);
     if (!BitstreamOptRecordPath.empty())
       fn(BitstreamOptRecordPath);
+    if (!ModuleSemanticInfoOutputPath.empty())
+      fn(ModuleSemanticInfoOutputPath);
   }
 
   bool empty() const {
@@ -198,6 +203,7 @@ struct SupplementaryOutputPaths {
            SerializedDiagnosticsPath.empty() && LoadedModuleTracePath.empty() &&
            TBDPath.empty() && ModuleInterfaceOutputPath.empty() &&
            ModuleSourceInfoOutputPath.empty() && ABIDescriptorOutputPath.empty() &&
+           ModuleSemanticInfoOutputPath.empty() &&
            YAMLOptRecordPath.empty() && BitstreamOptRecordPath.empty();
   }
 };

--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -257,6 +257,7 @@ public:
   bool hasModuleInterfaceOutputPath() const;
   bool hasPrivateModuleInterfaceOutputPath() const;
   bool hasABIDescriptorOutputPath() const;
+  bool hasModuleSemanticInfoOutputPath() const;
   bool hasModuleSummaryOutputPath() const;
   bool hasTBDPath() const;
   bool hasYAMLOptRecordPath() const;

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -437,6 +437,7 @@ private:
   static bool canActionEmitModuleSummary(ActionType);
   static bool canActionEmitInterface(ActionType);
   static bool canActionEmitABIDescriptor(ActionType);
+  static bool canActionEmitModuleSemanticInfo(ActionType);
 
 public:
   static bool doesActionGenerateSIL(ActionType);

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -68,6 +68,10 @@ def emit_abi_descriptor_path
   : Separate<["-"], "emit-abi-descriptor-path">, MetaVarName<"<path>">,
     HelpText<"Output the ABI descriptor of current module to <path>">;
 
+def emit_module_semantic_info_path
+  : Separate<["-"], "emit-module-semantic-info-path">, MetaVarName<"<path>">,
+    HelpText<"Output semantic info of current module to <path>">;
+
 def serialize_module_interface_dependency_hashes
   : Flag<["-"], "serialize-module-interface-dependency-hashes">,
     Flags<[HelpHidden]>;

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -680,6 +680,11 @@ bool ArgsToFrontendOptionsConverter::checkUnusedSupplementaryOutputPaths()
     Diags.diagnose(SourceLoc(), diag::error_mode_cannot_emit_abi_descriptor);
     return true;
   }
+  if (!FrontendOptions::canActionEmitModuleSemanticInfo(Opts.RequestedAction) &&
+      Opts.InputsAndOutputs.hasModuleSemanticInfoOutputPath()) {
+    Diags.diagnose(SourceLoc(), diag::error_mode_cannot_emit_module_semantic_info);
+    return true;
+  }
   // If we cannot emit module doc, we cannot emit source information file either.
   if (!FrontendOptions::canActionEmitModuleDoc(Opts.RequestedAction) &&
       Opts.InputsAndOutputs.hasModuleSourceInfoOutputPath()) {

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -341,6 +341,8 @@ SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
       options::OPT_emit_module_summary_path);
   auto abiDescriptorOutput = getSupplementaryFilenamesFromArguments(
       options::OPT_emit_abi_descriptor_path);
+  auto moduleSemanticInfoOutput = getSupplementaryFilenamesFromArguments(
+      options::OPT_emit_module_semantic_info_path);
   auto optRecordOutput = getSupplementaryFilenamesFromArguments(
       options::OPT_save_optimization_record_path);
   if (!objCHeaderOutput || !moduleOutput || !moduleDocOutput ||
@@ -348,7 +350,7 @@ SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
       !serializedDiagnostics || !fixItsOutput || !loadedModuleTrace || !TBD ||
       !moduleInterfaceOutput || !privateModuleInterfaceOutput ||
       !moduleSourceInfoOutput || !moduleSummaryOutput || !abiDescriptorOutput ||
-      !optRecordOutput) {
+      !moduleSemanticInfoOutput || !optRecordOutput) {
     return None;
   }
   std::vector<SupplementaryOutputPaths> result;
@@ -371,6 +373,7 @@ SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
     sop.ModuleSourceInfoOutputPath = (*moduleSourceInfoOutput)[i];
     sop.ModuleSummaryOutputPath = (*moduleSummaryOutput)[i];
     sop.ABIDescriptorOutputPath = (*abiDescriptorOutput)[i];
+    sop.ModuleSemanticInfoOutputPath = (*moduleSemanticInfoOutput)[i];
     sop.YAMLOptRecordPath = (*optRecordOutput)[i];
     sop.BitstreamOptRecordPath = (*optRecordOutput)[i];
     result.push_back(sop);
@@ -473,6 +476,7 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
 
   // There is no non-path form of -emit-abi-descriptor-path
   auto ABIDescriptorOutputPath = pathsFromArguments.ABIDescriptorOutputPath;
+  auto ModuleSemanticInfoOutputPath = pathsFromArguments.ModuleSemanticInfoOutputPath;
   ID emitModuleOption;
   std::string moduleExtension;
   std::string mainOutputIfUsableForModule;
@@ -508,6 +512,7 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
   sop.ModuleSourceInfoOutputPath = moduleSourceInfoOutputPath;
   sop.ModuleSummaryOutputPath = moduleSummaryOutputPath;
   sop.ABIDescriptorOutputPath = ABIDescriptorOutputPath;
+  sop.ModuleSemanticInfoOutputPath = ModuleSemanticInfoOutputPath;
   sop.YAMLOptRecordPath = YAMLOptRecordPath;
   sop.BitstreamOptRecordPath = bitstreamOptRecordPath;
   return sop;

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -509,6 +509,12 @@ bool FrontendInputsAndOutputs::hasABIDescriptorOutputPath() const {
         return outs.ABIDescriptorOutputPath;
       });
 }
+bool FrontendInputsAndOutputs::hasModuleSemanticInfoOutputPath() const {
+  return hasSupplementaryOutputPath(
+      [](const SupplementaryOutputPaths &outs) -> const std::string & {
+        return outs.ModuleSemanticInfoOutputPath;
+      });
+}
 bool FrontendInputsAndOutputs::hasModuleSummaryOutputPath() const {
   return hasSupplementaryOutputPath(
       [](const SupplementaryOutputPaths &outs) -> const std::string & {

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -524,6 +524,48 @@ bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
   }
   llvm_unreachable("unhandled action");
 }
+bool FrontendOptions::canActionEmitModuleSemanticInfo(ActionType action) {
+  switch (action) {
+  case ActionType::MergeModules:
+  case ActionType::EmitModuleOnly:
+  case ActionType::CompileModuleFromInterface:
+  // For test
+  case ActionType::Typecheck:
+    return true;
+  case ActionType::NoneAction:
+  case ActionType::Parse:
+  case ActionType::ResolveImports:
+  case ActionType::DumpParse:
+  case ActionType::DumpInterfaceHash:
+  case ActionType::DumpAST:
+  case ActionType::EmitSyntax:
+  case ActionType::PrintAST:
+  case ActionType::EmitPCH:
+  case ActionType::DumpScopeMaps:
+  case ActionType::DumpTypeRefinementContexts:
+  case ActionType::DumpTypeInfo:
+  case ActionType::EmitSILGen:
+  case ActionType::TypecheckModuleFromInterface:
+  case ActionType::Immediate:
+  case ActionType::REPL:
+  case ActionType::EmitPCM:
+  case ActionType::DumpPCM:
+  case ActionType::ScanDependencies:
+  case ActionType::PrintVersion:
+  case ActionType::PrintFeature:
+  case ActionType::EmitSIL:
+  case ActionType::EmitSIBGen:
+  case ActionType::EmitSIB:
+  case ActionType::EmitIRGen:
+  case ActionType::EmitIR:
+  case ActionType::EmitBC:
+  case ActionType::EmitAssembly:
+  case ActionType::EmitObject:
+  case ActionType::EmitImportedModules:
+    return false;
+  }
+  llvm_unreachable("unhandled action");
+}
 bool FrontendOptions::canActionEmitABIDescriptor(ActionType action) {
   switch (action) {
   case ActionType::MergeModules:

--- a/test/IDE/emit-module-semantic.swift
+++ b/test/IDE/emit-module-semantic.swift
@@ -1,0 +1,7 @@
+// REQUIRES: VENDOR=apple
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module %s -emit-module-path %t/Foo.swiftmodule -module-name Foo -emit-module-semantic-info-path %t/Foo.swiftsemanticinfo
+
+// RUN: ls %t/Foo.swiftmodule
+// RUN: ls %t/Foo.swiftsemanticinfo


### PR DESCRIPTION
This additional supplement output should capture semantic info the compiler has
captured while building a Swift module. Similar to the source info file, the content of
the semantic info file should only be consumed by local tooling written in Swift.
