### PR TITLE
Fix -debug-prefix-map edge case with absolute paths

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -475,6 +475,9 @@ private:
         Dir = DirBuf;
         File = FileBuf;
       }
+    } else if (llvm::sys::path::is_absolute(FileName)) {
+      Dir = llvm::sys::path::parent_path(RemappedFile);
+      File = llvm::sys::path::filename(RemappedFile);
     } else {
       File = RemappedFile;
       // Leave <compiler-generated> & friends as is, without directory.

--- a/test/DebugInfo/debug_prefix_map.swift
+++ b/test/DebugInfo/debug_prefix_map.swift
@@ -2,6 +2,13 @@
 // RUN: %target-swift-frontend -emit-module-path %t/Globals.swiftmodule %S/Globals.swift
 // RUN: %target-swiftc_driver -g -debug-prefix-map %/S=/var/empty -debug-prefix-map %t=/var/empty %/s -I %t -emit-ir -o - | %FileCheck %s
 
+// RUN: %empty-directory(%t) && cd %t && cp %s .
+// RUN: %target-swift-frontend -emit-module-path %t/Globals.swiftmodule %S/Globals.swift
+// RUN: %target-swiftc_driver -g -debug-prefix-map %/S=. -debug-prefix-map %t=. debug_prefix_map.swift -I %t -emit-ir -o - | %FileCheck %s --check-prefix=CHECK-RELATIVE
+
+// RUN: mkdir -p %t/nested/dir && cd %t/nested/dir && echo > foo.swift
+// RUN: %target-swiftc_driver -g -debug-prefix-map %/t/nested=. %/t/nested/dir/foo.swift -emit-ir -o - | %FileCheck %s --check-prefix=CHECK-PARTIAL-REMAP
+
 import Globals
 
 func square(_ n: Int) -> Int {
@@ -10,3 +17,8 @@ func square(_ n: Int) -> Int {
 
 // CHECK: !DIFile(filename: "/var/empty/debug_prefix_map.swift"
 // CHECK: !DIModule(scope: null, name: "Globals", {{.*}}includePath: "/var/empty{{(/|\\\\)}}Globals.swiftmodule"
+
+// CHECK-RELATIVE: !DIFile(filename: "debug_prefix_map.swift", directory: ".")
+// CHECK-RELATIVE: !DIModule(scope: null, name: "Globals", {{.*}}includePath: ".{{(/|\\\\)}}Globals.swiftmodule"
+
+// CHECK-PARTIAL-REMAP: !DIFile(filename: "foo.swift", directory: "dir")


### PR DESCRIPTION
If you use debug-prefix-map when passing file paths as absolute paths
(which xcodebuild does with no way to disable), this logic would
previously end up including the relative directory twice in the `DIFile`
like this:

```
DIFile(filename: "dir/foo.swift", directory: "dir")
```

This fixes that case by using the dirname / basename as the Dir / File
respectively when the remap goes from absolute -> relative.

Resolves SR-15267

Here's an analogous change in clang, where it appears this behavior was originally copied from https://reviews.llvm.org/D111587