### PR TITLE
Removed 'REQUIRES: rdar73761019' from top_level_code.swift since the issue has been fixed.

### DIFF
--- a/test/DebugInfo/top_level_code.swift
+++ b/test/DebugInfo/top_level_code.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend %s -S -g -o - | %FileCheck %s
 
-// REQUIRES: rdar73761019
-
 func markUsed<T>(_ t: T) {}
 // CHECK: {{_?}}main:
 // CHECK: Lfunc_begin0:


### PR DESCRIPTION
Commit ID: 1813652b0398345c4b4407d5fd5ffb749830fdd4 fixed the issue with line 0 prologue_ends so we do not need the REQUIRES anymore