### PR TITLE
[ClangImporter] Import underlying Clang locations

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3432,7 +3432,9 @@ public:
 
   SourceLoc getStartLoc() const { return EnumLoc; }
   SourceRange getSourceRange() const {
-    return SourceRange(EnumLoc, getBraces().End);
+    if (getBraces().isValid())
+      return SourceRange(EnumLoc, getBraces().End);
+    return SourceRange();
   }
 
 public:
@@ -3600,7 +3602,9 @@ public:
 
   SourceLoc getStartLoc() const { return StructLoc; }
   SourceRange getSourceRange() const {
-    return SourceRange(StructLoc, getBraces().End);
+    if (getBraces().isValid())
+      return SourceRange(StructLoc, getBraces().End);
+    return SourceRange();
   }
 
   // Implement isa/cast/dyncast/etc.
@@ -3747,7 +3751,9 @@ public:
 
   SourceLoc getStartLoc() const { return ClassLoc; }
   SourceRange getSourceRange() const {
-    return SourceRange(ClassLoc, getBraces().End);
+    if (getBraces().isValid())
+      return SourceRange(ClassLoc, getBraces().End);
+    return SourceRange();
   }
 
   /// Determine whether the member area of this class's metadata (which consists
@@ -4216,7 +4222,9 @@ public:
   
   SourceLoc getStartLoc() const { return ProtocolLoc; }
   SourceRange getSourceRange() const {
-    return SourceRange(ProtocolLoc, getBraces().End);
+    if (getBraces().isValid())
+      return SourceRange(ProtocolLoc, getBraces().End);
+    return SourceRange();
   }
 
   /// True if this protocol can only be conformed to by class types.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -690,6 +690,7 @@ static_assert(sizeof(checkSourceLocType(&ID##Decl::getLoc)) == 2, \
     return getLocFromSource();
   switch(File->getKind()) {
   case FileUnitKind::Source:
+  case FileUnitKind::ClangModule:
     return getLocFromSource();
   case FileUnitKind::SerializedAST: {
     if (!SerializedOK)
@@ -698,7 +699,6 @@ static_assert(sizeof(checkSourceLocType(&ID##Decl::getLoc)) == 2, \
   }
   case FileUnitKind::Builtin:
   case FileUnitKind::Synthesized:
-  case FileUnitKind::ClangModule:
   case FileUnitKind::DWARFModule:
     return SourceLoc();
   }

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -165,9 +165,14 @@ SourceManager::getVirtualFile(SourceLoc Loc) const {
   if (CachedVFile.first == p)
     return CachedVFile.second;
 
-  // Returns the first element that is >p.
-  auto VFileIt = VirtualFiles.upper_bound(p);
-  if (VFileIt != VirtualFiles.end() && VFileIt->second.Range.contains(Loc)) {
+  // Returns the first element that is >=p.
+  auto VFileIt = VirtualFiles.lower_bound(p);
+  if (VFileIt == VirtualFiles.end())
+    return nullptr;
+
+  // Consider the end as within the range in order to handle EOF locations
+  const CharSourceRange &Range = VFileIt->second.Range;
+  if (Loc == Range.getEnd() || VFileIt->second.Range.contains(Loc)) {
     CachedVFile = { p, &VFileIt->second };
     return CachedVFile.second;
   }

--- a/lib/ClangImporter/ClangDiagnosticConsumer.cpp
+++ b/lib/ClangImporter/ClangDiagnosticConsumer.cpp
@@ -123,14 +123,15 @@ void ClangDiagnosticConsumer::HandleDiagnostic(
 
   const ASTContext &ctx = ImporterImpl.SwiftContext;
   ClangSourceBufferImporter &bufferImporter =
-      ImporterImpl.getBufferImporterForDiagnostics();
+      ImporterImpl.getBufferImporter();
 
   if (clangDiag.getID() == clang::diag::err_module_not_built &&
       CurrentImport && clangDiag.getArgStdStr(0) == CurrentImport->getName()) {
     SourceLoc loc = DiagLoc;
     if (clangDiag.getLocation().isValid()) {
-      loc = bufferImporter.resolveSourceLocation(clangDiag.getSourceManager(),
-                                                 clangDiag.getLocation());
+      loc = bufferImporter.importSourceLoc(clangDiag.getSourceManager(),
+                                           clangDiag.getLocation(),
+                                           /*forDiagnostics=*/true);
     }
 
     ctx.Diags.diagnose(loc, diag::clang_cannot_build_module,
@@ -172,8 +173,9 @@ void ClangDiagnosticConsumer::HandleDiagnostic(
 
     SourceLoc noteLoc;
     if (clangNoteLoc.isValid())
-      noteLoc = bufferImporter.resolveSourceLocation(clangNoteLoc.getManager(),
-                                                     clangNoteLoc);
+      noteLoc = bufferImporter.importSourceLoc(clangNoteLoc.getManager(),
+                                               clangNoteLoc,
+                                               /*forDiagnostics=*/true);
     ctx.Diags.diagnose(noteLoc, diagKind, message);
   };
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2599,12 +2599,7 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
   }
 
   if (importedName.hasCustomName() && argNames.size() != swiftParams.size()) {
-    // Note carefully: we're emitting a warning in the /Clang/ buffer.
-    auto &srcMgr = getClangASTContext().getSourceManager();
-    ClangSourceBufferImporter &bufferImporter =
-        getBufferImporterForDiagnostics();
-    SourceLoc methodLoc =
-        bufferImporter.resolveSourceLocation(srcMgr, clangDecl->getLocation());
+    SourceLoc methodLoc = importSourceLoc(clangDecl->getLocation());
     if (methodLoc.isValid()) {
       diagnose(methodLoc, diag::invalid_swift_name_method,
                                   swiftParams.size() < argNames.size(),

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -361,11 +361,11 @@ private:
   LookupTableMap LookupTables;
 
   /// A helper class used to bring Clang buffers into Swift's SourceManager
-  /// for the purpose of emitting diagnostics.
+  /// for the purpose of importing locations.
   ///
   /// Listed early so that it gets torn down after the underlying Clang
   /// instances that also use these buffers.
-  importer::ClangSourceBufferImporter BuffersForDiagnostics;
+  importer::ClangSourceBufferImporter BufferImporter;
 
   /// The fake buffer used to import modules.
   ///
@@ -717,8 +717,8 @@ public:
     return Instance->getCodeGenOpts();
   }
 
-  importer::ClangSourceBufferImporter &getBufferImporterForDiagnostics() {
-    return BuffersForDiagnostics;
+  importer::ClangSourceBufferImporter &getBufferImporter() {
+    return BufferImporter;
   }
 
   /// Imports the given header contents into the Clang context.
@@ -817,7 +817,7 @@ public:
   SourceLoc importSourceLoc(clang::SourceLocation loc);
 
   /// Import the given Clang source range into Swift.
-  SourceRange importSourceRange(clang::SourceRange loc);
+  SourceRange importSourceRange(clang::SourceRange range);
 
   /// Import the given Clang preprocessor macro as a Swift value decl.
   ///
@@ -1604,18 +1604,18 @@ class SwiftNameLookupExtension : public clang::ModuleFileExtension {
   std::unique_ptr<SwiftLookupTable> &pchLookupTable;
   LookupTableMap &lookupTables;
   ASTContext &swiftCtx;
-  ClangSourceBufferImporter &buffersForDiagnostics;
+  ClangSourceBufferImporter &bufferImporter;
   const PlatformAvailability &availability;
 
 public:
   SwiftNameLookupExtension(std::unique_ptr<SwiftLookupTable> &pchLookupTable,
                            LookupTableMap &tables, ASTContext &ctx,
-                           ClangSourceBufferImporter &buffersForDiagnostics,
+                           ClangSourceBufferImporter &bufferImporter,
                            const PlatformAvailability &avail)
       : // Update in response to D97702 landing.
         clang::ModuleFileExtension(),
         pchLookupTable(pchLookupTable), lookupTables(tables), swiftCtx(ctx),
-        buffersForDiagnostics(buffersForDiagnostics), availability(avail) {}
+        bufferImporter(bufferImporter), availability(avail) {}
 
   clang::ModuleFileExtensionMetadata getExtensionMetadata() const override;
   llvm::hash_code hashExtension(llvm::hash_code code) const override;

--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -584,7 +584,7 @@ void addMacrosToLookupTable(SwiftLookupTable &table, NameImporter &);
 /// Finalize a lookup table, handling any as-yet-unresolved entries
 /// and emitting diagnostics if necessary.
 void finalizeLookupTable(SwiftLookupTable &table, NameImporter &,
-                         ClangSourceBufferImporter &buffersForDiagnostics);
+                         ClangSourceBufferImporter &bufferImporter);
 }
 }
 

--- a/test/ClangImporter/MixedSource/Inputs/broken-modules/BrokenClangModule.h
+++ b/test/ClangImporter/MixedSource/Inputs/broken-modules/BrokenClangModule.h
@@ -8,4 +8,6 @@ typedef int conflict2;
 #define I __extension__ conflict
 int I;
 
+// Purposely missing a newline at EOF in order to test diagnostics with
+// a EOF location
 int lastLineOfFileWithoutSemicolon

--- a/test/ClangImporter/MixedSource/broken-modules.swift
+++ b/test/ClangImporter/MixedSource/broken-modules.swift
@@ -29,7 +29,7 @@ import BrokenClangModule
 // CLANG-CHECK: a-fake-file.h:42:5: note: previous definition is here
 // CLANG-CHECK: a-fake-file.h:46:5: error: expected identifier or '('
 // CLANG-CHECK: a-fake-file.h:45:11: note: expanded from macro 'I'
-// CLANG-CHECK: {{.+}}{{/|\\}}Inputs{{/|\\}}broken-modules{{/|\\}}BrokenClangModule.h:11:35: error: expected ';' after top level declarator
+// CLANG-CHECK: a-fake-file.h:50:35: error: expected ';' after top level declarator
 
 // CHECK: broken-modules.swift:[[@LINE-9]]:8: error: could not build Objective-C module 'BrokenClangModule'
 // CHECK: error: no such module 'BrokenClangModule'

--- a/test/ClangImporter/cfuncs_scope.swift
+++ b/test/ClangImporter/cfuncs_scope.swift
@@ -8,10 +8,7 @@ func testLocalVsFileScope() {
 
   theFunctionInQuestion()
   // CHECK: :[[@LINE-1]]:25: error: missing argument
-  // CHECK: LocalVsFileScope.theFunctionInQuestion:1:{{[0-9]+}}: note:
-  // This is not a wonderful test because it's relying on the diagnostic
-  // engine's synthesis of fake declarations to figure out what module the
-  // importer assigned the function to. But, well, that's what we get.
+  // CHECK: LocalVsFileScope.h:3:6: note: 'theFunctionInQuestion' declared here
 
   aFunctionInBase() // just make sure it's imported
   // CHECK-NOT: :[[@LINE-1]]:{{[0-9]+}}:

--- a/test/ClangImporter/diags-with-many-imports.swift
+++ b/test/ClangImporter/diags-with-many-imports.swift
@@ -108,4 +108,4 @@ import Module100
 obsoleted()
 // CHECK: [[@LINE-1]]:1: error:
 // CHECK: explicitly marked unavailable here
-// CHECK-NEXT: func obsoleted()
+// CHECK-NEXT: void obsoleted() __attribute__((unavailable));

--- a/test/ClangImporter/generic_compatibility_alias.swift
+++ b/test/ClangImporter/generic_compatibility_alias.swift
@@ -11,12 +11,12 @@ import ObjCIRExtras
 
 func foo(_: SwiftConstrGenericNameAlias<String>) {
 // expected-error@-1 {{'SwiftConstrGenericNameAlias' requires that 'String' inherit from 'NSNumber'}}
-// expected-note@-2  {{requirement specified as 'T' : 'NSNumber' [with T = String]}}
+// FIXME-note@-2 {{requirement specified as 'T' : 'NSNumber' [with T = String]}}
 }
 
 func faz(_: SwiftGenericNameAlias<Int>) {
 // expected-error@-1 {{'SwiftGenericNameAlias' requires that 'Int' be a class type}}
-// expected-note@-2  {{requirement specified as 'T' : 'AnyObject' [with T = Int]}}
+// FIXME-note@-2 {{requirement specified as 'T' : 'AnyObject' [with T = Int]}}
 }
 
 func bar(_: SwiftGenericNameAlias<NSNumber>) {} // Ok

--- a/test/ClangImporter/objc_bridging_generics.swift
+++ b/test/ClangImporter/objc_bridging_generics.swift
@@ -88,12 +88,12 @@ func testImportedTypeParamRequirements() {
   let _ = PettableContainer<Rock>()
   let _ = PettableContainer<Porcupine>() // expected-error{{type 'Porcupine' does not conform to protocol 'Pettable'}}
   let _ = PettableContainer<Cat>()
-  let _ = AnimalContainer<Desk>() // expected-error{{'AnimalContainer' requires that 'Desk' inherit from 'Animal'}} expected-note{{requirement specified as 'T' : 'Animal' [with T = Desk]}}
-  let _ = AnimalContainer<Rock>() // expected-error{{'AnimalContainer' requires that 'Rock' inherit from 'Animal'}} expected-note{{requirement specified as 'T' : 'Animal' [with T = Rock]}}
+  let _ = AnimalContainer<Desk>() // expected-error{{'AnimalContainer' requires that 'Desk' inherit from 'Animal'}} FIXME-note{{requirement specified as 'T' : 'Animal' [with T = Desk]}}
+  let _ = AnimalContainer<Rock>() // expected-error{{'AnimalContainer' requires that 'Rock' inherit from 'Animal'}} FIXME-note{{requirement specified as 'T' : 'Animal' [with T = Rock]}}
   let _ = AnimalContainer<Porcupine>()
   let _ = AnimalContainer<Cat>()
-  let _ = PettableAnimalContainer<Desk>() // expected-error{{'PettableAnimalContainer' requires that 'Desk' inherit from 'Animal'}} expected-note{{requirement specified as 'T' : 'Animal' [with T = Desk]}}
-  let _ = PettableAnimalContainer<Rock>() // expected-error{{'PettableAnimalContainer' requires that 'Rock' inherit from 'Animal'}} expected-note{{requirement specified as 'T' : 'Animal' [with T = Rock]}}
+  let _ = PettableAnimalContainer<Desk>() // expected-error{{'PettableAnimalContainer' requires that 'Desk' inherit from 'Animal'}} FIXME-note{{requirement specified as 'T' : 'Animal' [with T = Desk]}}
+  let _ = PettableAnimalContainer<Rock>() // expected-error{{'PettableAnimalContainer' requires that 'Rock' inherit from 'Animal'}} FIXME-note{{requirement specified as 'T' : 'Animal' [with T = Rock]}}
   let _ = PettableAnimalContainer<Porcupine>() // expected-error{{type 'Porcupine' does not conform to protocol 'Pettable'}}
   let _ = PettableAnimalContainer<Cat>()
 }

--- a/test/ClangImporter/objc_init_redundant.swift
+++ b/test/ClangImporter/objc_init_redundant.swift
@@ -10,12 +10,12 @@ import Foundation
 extension NSObject {
   @objc convenience init() { self.init() } // expected-error{{initializer 'init()' with Objective-C selector 'init' conflicts with previous declaration with the same Objective-C selector}}
 // CHECK: objc_init_redundant.swift:[[@LINE-1]]:21: error: initializer 'init()' with Objective-C selector 'init' conflicts
-// CHECK: ObjectiveC.NSObject:{{.*}}note: 'init' previously declared here
+// CHECK: NSObject.h:18:1:{{.*}}note: 'init' previously declared here
 }
 
 extension NSObject {
   @objc(class) func foo() { } // expected-error{{method 'foo()' with Objective-C selector 'class' conflicts with method 'class()' with the same Objective-C selector}}
 // CHECK: objc_init_redundant.swift:[[@LINE-1]]:21: error: method 'foo()' with Objective-C selector 'class' conflicts
-// CHECK: ObjectiveC.NSObjectProtocol:{{.*}}note: method 'class()' declared here
+// CHECK: NSObject.h:11:10:{{.*}}note: method 'class()' declared here
 }
 

--- a/test/DebugInfo/test-foundation.swift
+++ b/test/DebugInfo/test-foundation.swift
@@ -26,10 +26,8 @@ class MyObject : NSObject {
   // directly.
   // IMPORT-CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, {{.*}}entity: ![[OVERLAY]]
 
-  // ALLOCCTOR-CHECK: ![[F:.*]] = !DIFile(filename: "<compiler-generated>",
-  // ALLOCCTOR-CHECK: distinct !DISubprogram(name: "init",
-  // ALLOCCTOR-CHECK-SAME:                   linkageName: "$sSo7NSArrayCABycfC",
-  // ALLOCCTOR-CHECK-SAME:                   file: ![[F]],
+  // ALLOCCTOR-CHECK-DAG: ![[F:.*]] = !DIFile(filename: "{{.*}}Foundation.framework/Headers/NSArray.h",
+  // ALLOCCTOR-CHECK-DAG: distinct !DISubprogram(name: "init", linkageName: "$sSo7NSArrayCABycfC",{{.*}} file: ![[F]],
   @objc func foo(_ obj: MyObject) {
     return obj.foo(obj)
   }

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -343,7 +343,7 @@ func checkAnyIsAKeyword(x: Any) {}
 // CHECK13: <decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>testDefaultParam</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>arg1</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr="s:Si">Int</ref.struct></decl.var.parameter.type> = 0</decl.var.parameter>)</decl.function.free>
 
 // RUN: %sourcekitd-test -req=cursor -pos=34:4 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK14 %s
-// CHECK14: source.lang.swift.ref.function.free ({{.*}}Foo.framework/Frameworks/FooSub.framework/Headers/FooSub.h:4:5-4:16)
+// CHECK14: source.lang.swift.ref.function.free ({{.*}}Foo.framework/Frameworks/FooSub.framework/Headers/FooSub.h:4:5-4:22)
 // CHECK14: fooSubFunc1
 // CHECK14: c:@F@fooSubFunc1
 // CHECK14: source.lang.objc

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift
@@ -50,7 +50,7 @@ var x: FooClassBase
 // RUN:      == -req=cursor -pos=231:20 | %FileCheck -check-prefix=CHECK2 %s
 // The cursor points inside the interface, see 'gen_clang_module.swift.response'
 
-// CHECK2: source.lang.swift.decl.function.method.instance ({{.*}}Foo.framework/Headers/Foo.h:170:10-170:27)
+// CHECK2: source.lang.swift.decl.function.method.instance ({{.*}}Foo.framework/Headers/Foo.h:170:10-170:26)
 // CHECK2: fooInstanceFunc0
 // CHECK2: c:objc(cs)FooClassDerived(im)fooInstanceFunc0
 // CHECK2: Foo{{$}}

--- a/test/SourceKit/Mixed/cursor_mixed.swift
+++ b/test/SourceKit/Mixed/cursor_mixed.swift
@@ -6,7 +6,7 @@ func test(_ b : Base) {
 // REQUIRES: objc_interop
 // RUN: %sourcekitd-test -req=cursor -pos=3:7 %s -- %s -F %S/Inputs -module-name Mixed -import-underlying-module | %FileCheck %s
 
-// CHECK: source.lang.swift.ref.function.method.instance ({{.*}}Mixed.framework/Headers/Mixed.h:5:9-5:23)
+// CHECK: source.lang.swift.ref.function.method.instance ({{.*}}Mixed.framework/Headers/Mixed.h:5:9-5:22)
 // CHECK: doIt(_:)
 // CHECK: c:objc(cs)Base(im)doIt:
 // CHECK: (Base) -> (Int32) -> ()

--- a/test/SourceKit/Mixed/cursor_mixed_header.swift
+++ b/test/SourceKit/Mixed/cursor_mixed_header.swift
@@ -14,7 +14,7 @@ func test(_ b : BaseInHead) {
 // RUN: %sourcekitd-test -req=cursor -pos=3:7 %s -- %s -module-name Mixed -pch-output-dir %t -import-objc-header %S/Inputs/header.h | %FileCheck %s
 // RUN: stat %t/*.pch
 
-// CHECK: source.lang.swift.ref.function.method.instance ({{.*}}Inputs/header.h:4:9-4:23)
+// CHECK: source.lang.swift.ref.function.method.instance ({{.*}}Inputs/header.h:4:9-4:22)
 // CHECK: doIt(_:)
 // CHECK: c:objc(cs)BaseInHead(im)doIt:
 // CHECK: (BaseInHead) -> (Int32) -> ()


### PR DESCRIPTION
Rather than producing diagnostics with unknown locations and generated
Swift code, import the underlying header locations from Clang instead.

Resolves rdar://84127604