### PR TITLE
Demangling: degrade better with VS2017

### DIFF
--- a/include/swift/Demangling/ManglingMacros.h
+++ b/include/swift/Demangling/ManglingMacros.h
@@ -17,10 +17,14 @@
 #define MANGLE_AS_STRING(M) STRINGIFY_MANGLING(M)
 
 /// The mangling prefix for the new mangling.
+#if !defined(_MSC_VER) || _MSC_VER-0 >= 1926
 _Pragma("clang diagnostic push")
 _Pragma("clang diagnostic ignored \"-Wdollar-in-identifier-extension\"")
+#endif
 #define MANGLING_PREFIX $s
+#if !defined(_MSC_VER) || _MSC_VER-0 >= 1926
 _Pragma("clang diagnostic pop")
+#endif
 
 #define MANGLING_PREFIX_STR MANGLE_AS_STRING(MANGLING_PREFIX)
 


### PR DESCRIPTION
`_Pragma` support was added to VS with VS2019 U6, version 16.6, toolset
14.26.  Add a conditional to avoid the use of `_Pragma` prior to that
version.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
