### PR TITLE
[dnm] dynamicMemberLookup ABI test

### DIFF
--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -205,6 +205,7 @@
 ///       let numberPointer = UnsafePointer<Int>(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
 @frozen // unsafe-performance
+@dynamicMemberLookup
 public struct UnsafePointer<Pointee>: _Pointer, Sendable {
 
   /// A type that represents the distance between two pointers.
@@ -314,6 +315,23 @@ public struct UnsafePointer<Pointee>: _Pointer, Sendable {
     unsafeAddress {
       return self + i
     }
+  }
+
+  /// Returns a pointer to the stored property referred to by a key path
+  ///
+  /// Obtain a pointer to a stored property. If the key path represents
+  /// a computed property, this subscript will return `nil`.
+  ///
+  /// - Parameter property: A `KeyPath` whose `Root` is `Pointee`
+  /// - Returns: A pointer to the stored property represented
+  ///            by the key path, or `nil`.
+  @inlinable
+  @_alwaysEmitIntoClient
+  public subscript<Property>(
+    dynamicMember property: KeyPath<Pointee, Property>
+  ) -> UnsafePointer<Property>? {
+    guard let o = property._storedInlineOffset else { return nil }
+    return .init(Builtin.gepRaw_Word(_rawValue, o._builtinWordValue))
   }
 
   @inlinable // unsafe-performance
@@ -511,6 +529,7 @@ public struct UnsafePointer<Pointee>: _Pointer, Sendable {
 ///       let numberPointer = UnsafeMutablePointer<Int>(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
 @frozen // unsafe-performance
+@dynamicMemberLookup
 public struct UnsafeMutablePointer<Pointee>: _Pointer, Sendable {
 
   /// A type that represents the distance between two pointers.
@@ -975,6 +994,40 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer, Sendable {
     nonmutating unsafeMutableAddress {
       return self + i
     }
+  }
+
+  /// Returns a pointer to the stored property referred to by a key path
+  ///
+  /// Obtain a pointer to a stored property. If the key path represents
+  /// a computed property, this subscript will return `nil`.
+  ///
+  /// - Parameter property: A `KeyPath` whose `Root` is `Pointee`
+  /// - Returns: A pointer to the stored property represented
+  ///            by the key path, or `nil`.
+  @inlinable
+  @_alwaysEmitIntoClient
+  public subscript<Property>(
+    dynamicMember property: KeyPath<Pointee, Property>
+  ) -> UnsafePointer<Property>? {
+    guard let o = property._storedInlineOffset else { return nil }
+    return .init(Builtin.gepRaw_Word(_rawValue, o._builtinWordValue))
+  }
+
+  /// Returns a mutable pointer to the stored property referred to by a key path
+  ///
+  /// Obtain a mutable pointer to a stored property. If the key path represents
+  /// a computed property, this subscript will return `nil`.
+  ///
+  /// - Parameter property: A `WritableKeyPath` whose `Root` is `Pointee`
+  /// - Returns: A mutable pointer to the stored property represented
+  ///            by the key path, or `nil`.
+  @inlinable
+  @_alwaysEmitIntoClient
+  public subscript<Property>(
+    dynamicMember property: WritableKeyPath<Pointee, Property>
+  ) -> UnsafeMutablePointer<Property>? {
+    guard let o = property._storedInlineOffset else { return nil }
+    return .init(Builtin.gepRaw_Word(_rawValue, o._builtinWordValue))
   }
 
   @inlinable // unsafe-performance

--- a/test/IDE/complete_stdlib_builtin.swift
+++ b/test/IDE/complete_stdlib_builtin.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=BUILTIN_1 | %FileCheck %s -check-prefix=NO_CRASH
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=BUILTIN_2 | %FileCheck %s -check-prefix=NO_CRASH
 
 // NO_CRASH-NOT: Begin completions
 
@@ -11,8 +10,4 @@
 
 func testBuiltinRawPointer1(a: UnsafeMutablePointer<UInt8>) {
   a.value#^BUILTIN_1^#
-}
-
-func testBuiltinRawPointer2(a: UnsafeMutablePointer<UInt8>) {
-  a.value.#^BUILTIN_2^#
 }

--- a/test/decl/subscript/addressors.swift
+++ b/test/decl/subscript/addressors.swift
@@ -67,19 +67,6 @@ struct RepeatedMutable {
   }
 }
 
-struct AddressorAndGet {
-  var base: UnsafePointer<Int>
-
-  subscript(index: Int) -> Int {
-    unsafeAddress { // expected-error {{subscript cannot provide both an addressor and a getter}}
-      return base
-    }
-    get { // expected-note {{getter defined here}}
-      return base.get() // expected-error {{value of type 'UnsafePointer<Int>' has no member 'get'}}
-    }
-  }
-}
-
 struct AddressorAndSet {
   var base: UnsafePointer<Int>
 

--- a/test/stdlib/UnsafePointer.swift.gyb
+++ b/test/stdlib/UnsafePointer.swift.gyb
@@ -472,4 +472,21 @@ ${SelfName}TestSuite.test("withMemoryRebound") {
 
 % end
 
+struct TestStruct {
+  var x: Float
+  var y: Int
+}
+
+UnsafeMutablePointerTestSuite.test("dynamicMember") {
+  let mut = UnsafeMutablePointer<TestStruct>.allocate(capacity: 1)
+  defer { mut.deallocate() }
+
+  let test = TestStruct(x: .random(in: 0..<100), y: .random(in: 0..<100))
+  mut.initialize(to: test)
+  defer { mut.deinitialize(count: 1) }
+
+  expectEqual(test.x, mut.x?.pointee)
+  expectEqual(test.y, mut.y?.pointee)
+}
+
 runAllTests()


### PR DESCRIPTION
In pitching a new API for `UnsafePointer`s to `Pointee`s of aggregate types, a question came up as to whether the `@dynamicMemberLookup` affects the ABI.

Since we still don't know, this bare-bones implementation can at least be tested against the ABI test run by the continuous integration bots. We shall see whether we believe the results.

[Do not merge]