### PR TITLE
[Concurrency] SR-15309: Fix instance task.isCancelled impl to use _task

### DIFF
--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -46,13 +46,7 @@ extension Task {
   ///
   /// - SeeAlso: `checkCancellation()`
   public var isCancelled: Bool {
-    withUnsafeCurrentTask { task in
-      guard let task = task else {
-        return false
-      }
-
-      return _taskIsCancelled(task._task)
-    }
+    _taskIsCancelled(_task)
   }
 }
 

--- a/test/Concurrency/Runtime/async_task_handle_cancellation.swift
+++ b/test/Concurrency/Runtime/async_task_handle_cancellation.swift
@@ -10,17 +10,22 @@
 @available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
-    let handle = detach {
+    let task = Task.detached {
       while (!Task.isCancelled) { // no need for await here, yay
         print("waiting")
       }
 
-      print("done")
+      print("inside: Task.isCancelled = \(Task.isCancelled)")
     }
 
-    handle.cancel()
+    task.cancel()
 
-    // CHECK: done
-    await handle.get()
+    await task.value
+    print("outside: task.isCancelled = \(task.isCancelled)")
+    print("outside: Task.isCancelled = \(Task.isCancelled)")
+
+    // CHECK-DAG: inside: Task.isCancelled = true
+    // CHECK-DAG: outside: task.isCancelled = true
+    // CHECK-DAG: outside: Task.isCancelled = false
   }
 }


### PR DESCRIPTION
Instance (not static) version of `isCancelled` was using the current task, rather than the `_task` of the Task it was defined in...

Resolves SR-15309
Resolves rdar://84146091