### PR TITLE
🍒 5.5 [Concurrency] SR-15309: Fix instance task.isCancelled impl to use _task

### DIFF
--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -50,7 +50,7 @@ extension Task {
   /// There is no way to uncancel a task.
   ///
   /// - SeeAlso: `checkCancellation()`
-  public var isCancelled: Bool {
+  @_transparent public var isCancelled: Bool {
     _taskIsCancelled(_task)
   }
 }

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -51,13 +51,7 @@ extension Task {
   ///
   /// - SeeAlso: `checkCancellation()`
   public var isCancelled: Bool {
-    withUnsafeCurrentTask { task in
-      guard let task = task else {
-        return false
-      }
-
-      return _taskIsCancelled(task._task)
-    }
+    _taskIsCancelled(_task)
   }
 }
 

--- a/test/Concurrency/Runtime/async_task_handle_cancellation.swift
+++ b/test/Concurrency/Runtime/async_task_handle_cancellation.swift
@@ -17,17 +17,22 @@
 @available(SwiftStdlib 5.5, *)
 @main struct Main {
   static func main() async {
-    let handle = detach {
+    let task = Task.detached {
       while (!Task.isCancelled) { // no need for await here, yay
         print("waiting")
       }
 
-      print("done")
+      print("inside: Task.isCancelled = \(Task.isCancelled)")
     }
 
-    handle.cancel()
+    task.cancel()
 
-    // CHECK: done
-    await handle.get()
+    await task.value
+    print("outside: task.isCancelled = \(task.isCancelled)")
+    print("outside: Task.isCancelled = \(Task.isCancelled)")
+
+    // CHECK-DAG: inside: Task.isCancelled = true
+    // CHECK-DAG: outside: task.isCancelled = true
+    // CHECK-DAG: outside: Task.isCancelled = false
   }
 }


### PR DESCRIPTION
**Description:** The instance version of the `isCancelled` function on `Task` was incorrectly reaching for the _current task_ and checking that, rather than checking the `_task` it represents. The `UnsafeCurrentTask` version of this API was correct, only this API was mistaken.
**Risk:** Low
**Review by:** @DougGregor
**Testing:** Added test covering this case, PR testing on CI.
**Original PR:** https://github.com/apple/swift/pull/39710
**Radar:** rdar://84146091 & [SR-15309](https://bugs.swift.org/browse/SR-15309)