### PR TITLE
[Index] Do not generate pseudo accessors for parameters

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1167,7 +1167,7 @@ bool IndexSwiftASTWalker::report(ValueDecl *D) {
     // Pass accessors.
     if (auto StoreD = dyn_cast<AbstractStorageDecl>(D)) {
       bool usedPseudoAccessors = false;
-      if (isa<VarDecl>(D) &&
+      if (isa<VarDecl>(D) && !isa<ParamDecl>(D) &&
           !StoreD->getParsedAccessor(AccessorKind::Get) &&
           !StoreD->getParsedAccessor(AccessorKind::Set)) {
         usedPseudoAccessors = true;
@@ -1256,17 +1256,19 @@ bool IndexSwiftASTWalker::reportRef(ValueDecl *D, SourceLoc Loc,
 
   // Report the accessors that were utilized.
   if (auto *ASD = dyn_cast<AbstractStorageDecl>(D)) {
-    bool UsesGetter = Info.roles & (SymbolRoleSet)SymbolRole::Read;
-    bool UsesSetter = Info.roles & (SymbolRoleSet)SymbolRole::Write;
+    if (!isa<ParamDecl>(D)) {
+      bool UsesGetter = Info.roles & (SymbolRoleSet)SymbolRole::Read;
+      bool UsesSetter = Info.roles & (SymbolRoleSet)SymbolRole::Write;
 
-    if (UsesGetter)
-      if (!reportPseudoAccessor(ASD, AccessorKind::Get, /*IsRef=*/true,
-                                Loc))
-        return false;
-    if (UsesSetter)
-      if (!reportPseudoAccessor(ASD, AccessorKind::Set, /*IsRef=*/true,
-                                Loc))
-        return false;
+      if (UsesGetter)
+        if (!reportPseudoAccessor(ASD, AccessorKind::Get, /*IsRef=*/true,
+                                  Loc))
+          return false;
+      if (UsesSetter)
+        if (!reportPseudoAccessor(ASD, AccessorKind::Set, /*IsRef=*/true,
+                                  Loc))
+          return false;
+    }
   }
 
   return finishCurrentEntity();

--- a/test/Index/invalid_code.swift
+++ b/test/Index/invalid_code.swift
@@ -42,8 +42,6 @@ extension Protector where T: RangeReplaceableCollection {
   func append(_ newElement: T.Iterator.Element) {
     undefined { (foo: T) in
     // CHECK: [[@LINE-1]]:18 | param(local)/Swift | foo | {{.*}} | Def,RelChild
-    // CHECK: [[@LINE-2]]:18 | function/acc-get(local)/Swift | getter:foo | {{.*}} | Def,Impl,RelChild,RelAcc
-    // CHECK: [[@LINE-3]]:18 | function/acc-set(local)/Swift | setter:foo | {{.*}} | Def,Impl,RelChild,RelAcc
       _ = newElement
     }
   }

--- a/test/Index/local.swift
+++ b/test/Index/local.swift
@@ -2,9 +2,13 @@
 // RUN: %target-swift-ide-test -print-indexed-symbols -include-locals  -source-filename %s | %FileCheck -check-prefix=LOCAL %s
 
 func foo(a: Int, b: Int, c: Int) {
+  // CHECK-NOT: [[@LINE-1]]:10 | function/acc-get/Swift | getter:a
+  // CHECK-NOT: [[@LINE-1]]:10 | function/acc-set/Swift | setter:a
+
     let x = a + b
     // LOCAL: [[@LINE-1]]:9 | variable(local)/Swift | x | [[x_USR:.*]] | Def,RelChild | rel: 1
     // CHECK-NOT: [[@LINE-2]]:9 | variable(local)/Swift | x | {{.*}} | Def,RelChild | rel: 1
+    // LOCAL-NOT: [[@LINE-3]]:13 | function/acc-get/Swift | getter:a
 
     let y = x + c
     // LOCAL: [[@LINE-1]]:9 | variable(local)/Swift | y | [[y_USR:.*]] | Def,RelChild | rel: 1


### PR DESCRIPTION
Parameters cannot be computed variables, so don't generate pseudo
accessors for them.

Resolves rdar://84227937