### PR TITLE
CMO: fix handling of static globals with function references

### DIFF
--- a/test/SILOptimizer/Inputs/cross-module/cross-module.swift
+++ b/test/SILOptimizer/Inputs/cross-module/cross-module.swift
@@ -285,3 +285,8 @@ public func callCImplementationOnly<T>(_ t: T) -> Int {
 
 
 public let globalLet = 529387
+
+public struct StructWithClosure {
+  public static let c = { (x: Int) -> Int in return x }
+}
+

--- a/test/SILOptimizer/cross-module-optimization.swift
+++ b/test/SILOptimizer/cross-module-optimization.swift
@@ -140,6 +140,8 @@ func testGlobal() {
   // CHECK-OUTPUT: 529387
   // CHECK-SIL2: integer_literal $Builtin.Int{{[0-9]+}}, 529387
   print(globalLet)
+  // CHECK-OUTPUT: 41
+  print(StructWithClosure.c(41))
   // CHECK-SIL2: } // end sil function '$s4Main10testGlobalyyF'
 }
 


### PR DESCRIPTION
Referenced functions within the initializer of a SILGlobalVariable must be handled like referenced functions in other functions.

Fixes an assert crash when compiling with -cross-module-optimization
