### PR TITLE
Remove _NSGetArgc/_NSGetArgv from the expected symbol list for 'freestanding'

### DIFF
--- a/utils/check_freestanding_dependencies.py
+++ b/utils/check_freestanding_dependencies.py
@@ -59,7 +59,7 @@ common_expected_dependencies = [
     "_strtol", "_strtold_l", "_vsnprintf", "_write",
 ] + icu_dependencies + cxx_dependencies + math_dependencies
 vendor_apple_specific_dependencies = [
-    "__NSGetArgc", "__NSGetArgv", "___stack_chk_fail", "___stack_chk_guard",
+    "___stack_chk_fail", "___stack_chk_guard",
     "_getsectiondata", "__dyld_register_func_for_add_image",
 ]
 ################################################################################


### PR DESCRIPTION
Was removed via <https://github.com/apple/swift/pull/39591>.