### PR TITLE
[5.5] ABIChecker: downgrade mangled name change breakage to warnings to unblock builds

### DIFF
--- a/include/swift/AST/DiagnosticsModuleDiffer.def
+++ b/include/swift/AST/DiagnosticsModuleDiffer.def
@@ -88,7 +88,7 @@ ERROR(not_inheriting_convenience_inits,none,"%0 no longer inherits convenience i
 
 ERROR(enum_case_added,none,"%0 has been added as a new enum case", (StringRef))
 
-ERROR(demangled_name_changed,none,"%0 has mangled name changing from '%1' to '%2'", (StringRef, StringRef, StringRef))
+WARNING(demangled_name_changed,none,"%0 has mangled name changing from '%1' to '%2'", (StringRef, StringRef, StringRef))
 
 WARNING(cannot_read_allowlist,none,"cannot read breakage allowlist at '%0'", (StringRef))
 


### PR DESCRIPTION
This is a cherry-pick of https://github.com/apple/swift/pull/39421.

rdar://83450549
