### PR TITLE
build-presets: enable testing of libswift bootstrapping on two CI bots

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -605,6 +605,13 @@ elseif(LIBSWIFT_BUILD_MODE STREQUAL "BOOTSTRAPPING" OR LIBSWIFT_BUILD_MODE STREQ
   set(SWIFT_EXEC_FOR_LIBSWIFT "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/swiftc")
 endif()
 
+if(LIBSWIFT_BUILD_MODE STREQUAL "HOSTTOOLS" OR LIBSWIFT_BUILD_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
+  if(SWIFT_ENABLE_ARRAY_COW_CHECKS)
+    message(STATUS "array COW checks disabled when building libswift with host libraries")
+    set(SWIFT_ENABLE_ARRAY_COW_CHECKS FALSE)
+  endif()
+endif()
+
 # This setting causes all CMakeLists.txt to automatically have
 # ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CURRENT_SOURCE_DIR} as an
 # include_directories path. This is done for developer

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -910,7 +910,7 @@ function(add_swift_host_tool executable)
 
         # At build time link against the built swift libraries from the
         # previous bootstrapping stage.
-        get_bootstrapping_swift_lib_dir(bs_lib_dir "${bootstrapping}")
+        get_bootstrapping_swift_lib_dir(bs_lib_dir "${ASHT_BOOTSTRAPPING}")
         target_link_directories(${executable} PRIVATE ${bs_lib_dir})
 
         # At runtime link against the built swift libraries from the current
@@ -979,7 +979,7 @@ function(add_swift_host_tool executable)
     elseif(LIBSWIFT_BUILD_MODE STREQUAL "BOOTSTRAPPING")
       # At build time link against the built swift libraries from the
       # previous bootstrapping stage.
-      get_bootstrapping_swift_lib_dir(bs_lib_dir "${bootstrapping}")
+      get_bootstrapping_swift_lib_dir(bs_lib_dir "${ASHT_BOOTSTRAPPING}")
       target_link_directories(${executable} PRIVATE ${bs_lib_dir})
 
       # At runtime link against the built swift libraries from the current

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -20,27 +20,54 @@ set(swiftDarwin_target_sdks ALL_APPLE_PLATFORMS)
 if(SWIFT_FREESTANDING_FLAVOR STREQUAL "apple")
   set(swiftDarwin_target_sdks ALL_APPLE_PLATFORMS FREESTANDING)
 endif()
-add_swift_target_library(swiftDarwin ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
-    ${swift_platform_sources}
-    POSIXError.swift
-    MachError.swift
 
-    "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
+set(swiftDarwin_common_options
+      IS_SDK_OVERLAY
+      ${swift_platform_sources}
+      POSIXError.swift
+      MachError.swift
 
-    GYB_SOURCES
-      ${swift_platform_gyb_sources}
-      Darwin.swift.gyb
+      "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
 
-    SWIFT_COMPILE_FLAGS
-      ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}
-      ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
-      -Xfrontend -disable-objc-attr-requires-foundation-module
-      ${swift_platform_compile_flags}
-    LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
+      GYB_SOURCES
+        ${swift_platform_gyb_sources}
+        Darwin.swift.gyb
+
+      SWIFT_COMPILE_FLAGS
+        ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}
+        ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+        -Xfrontend -disable-objc-attr-requires-foundation-module
+        ${swift_platform_compile_flags}
+      LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
+      DEPENDS ${darwin_depends})
+
+
+if(${LIBSWIFT_BUILD_MODE} STREQUAL "BOOTSTRAPPING")
+
+  set(swiftDarwin_common_bootstrapping_options
+      ${swiftDarwin_common_options}
+      SHARED
+      IS_STDLIB
+      SDK ${SWIFT_HOST_VARIANT_SDK}
+      ARCHITECTURE ${SWIFT_HOST_VARIANT_ARCH}
+      INSTALL_IN_COMPONENT "never_install")
+
+  add_swift_target_library_single(swiftDarwin-bootstrapping0 swiftDarwin
+      ${swiftDarwin_common_bootstrapping_options}
+      BOOTSTRAPPING 0)
+
+  add_swift_target_library_single(swiftDarwin-bootstrapping1 swiftDarwin
+      ${swiftDarwin_common_bootstrapping_options}
+      BOOTSTRAPPING 1)
+
+  add_dependencies(bootstrapping1-all swiftDarwin-bootstrapping1)
+  add_dependencies(bootstrapping0-all swiftDarwin-bootstrapping0)
+endif()
+
+add_swift_target_library(swiftDarwin ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES}
+    ${swiftDarwin_common_options}
     TARGET_SDKS "${swiftDarwin_target_sdks}"
-    INSTALL_IN_COMPONENT sdk-overlay
-
-    DEPENDS ${darwin_depends})
+    INSTALL_IN_COMPONENT sdk-overlay)
 
 set(swiftGlibc_target_sdks ANDROID CYGWIN FREEBSD OPENBSD LINUX HAIKU)
 if(SWIFT_FREESTANDING_FLAVOR STREQUAL "linux")

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -192,6 +192,7 @@ skip-test-ios-host
 skip-test-tvos-host
 skip-test-watchos-host
 
+libswift=bootstrapping-with-hostlibs
 
 [preset: buildbot,tools=RA,stdlib=RD,test=non_executable]
 mixin-preset=
@@ -370,6 +371,8 @@ install-llbuild
 install-swiftpm
 install-swift-driver
 install-libcxx
+
+libswift=bootstrapping
 
 [preset: buildbot_incremental,tools=RA,stdlib=RA,apple_silicon]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RA


### PR DESCRIPTION
Enable the "bootstrapping" build mode on buildbot_incremental,tools=RA,stdlib=RA
and the "bootstrapping-with-hostlibs" mode on buildbot,tools=RA,stdlib=RD
