### PR TITLE
Make sure that `Task.isCancelled` fix works on older OSs.

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -698,7 +698,7 @@ public struct UnsafeCurrentTask {
   /// Returns `true` if the task is cancelled, and should stop executing.
   ///
   /// - SeeAlso: `checkCancellation()`
-  public var isCancelled: Bool {
+  @_transparent public var isCancelled: Bool {
     _taskIsCancelled(_task)
   }
 
@@ -796,6 +796,7 @@ func _taskCancel(_ task: Builtin.NativeObject)
 
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_isCancelled")
+@usableFromInline
 func _taskIsCancelled(_ task: Builtin.NativeObject) -> Bool
 
 @available(SwiftStdlib 5.5, *)

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -698,7 +698,7 @@ public struct UnsafeCurrentTask {
   /// Returns `true` if the task is cancelled, and should stop executing.
   ///
   /// - SeeAlso: `checkCancellation()`
-  @_transparent public var isCancelled: Bool {
+  public var isCancelled: Bool {
     _taskIsCancelled(_task)
   }
 

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -45,7 +45,7 @@ extension Task {
   /// Returns `true` if the task is cancelled, and should stop executing.
   ///
   /// - SeeAlso: `checkCancellation()`
-  public var isCancelled: Bool {
+  @_transparent public var isCancelled: Bool {
     _taskIsCancelled(_task)
   }
 }


### PR DESCRIPTION
Part of rdar://84146091 & SR-15309.
