### PR TITLE
OSSA RAUW cleanup in preparation for fixes and features

### DIFF
--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -647,10 +647,32 @@ FullApplySite cloneFullApplySiteReplacingCallee(FullApplySite applySite,
                                                 SILValue newCallee,
                                                 SILBuilderContext &builderCtx);
 
+/// Replace all uses of \p oldValue with \p newValue, notifying the callbacks
+/// of new uses and when end-of-scope instructions are deleted.
+SILBasicBlock::iterator replaceAllUses(SILValue oldValue, SILValue newValue,
+                                       SILBasicBlock::iterator nextii,
+                                       InstModCallbacks &callbacks);
+
 /// This is a low level routine that makes all uses of \p svi uses of \p
 /// newValue (ignoring end scope markers) and then deletes \p svi and all end
 /// scope markers. Then returns the next inst to process.
 SILBasicBlock::iterator replaceAllUsesAndErase(SingleValueInstruction *svi,
+                                               SILValue newValue,
+                                               InstModCallbacks &callbacks);
+
+/// Replace all uses of \p oldValue with \p newValue, delete the instruction
+/// that defines \p oldValue, and notify the callbacks of new uses and when
+/// the defining instruction and its end-of-scope instructions are deleted.
+///
+/// Precondition: \p oldValue must be a SingleValueInstruction or a terminator
+/// result. \p oldValue must be the only result with remaining uses. For
+/// terminators with multiple results, remove all other results for, e.g. via
+/// replaceAllUsesWithUndef().
+///
+/// If \p oldValue is a terminator result, a new branch instruction is inserted
+/// in place of the old terminator and all basic block successors become
+/// unreachable except for the successor containing the replaced result.
+SILBasicBlock::iterator replaceAllUsesAndErase(SILValue oldValue,
                                                SILValue newValue,
                                                InstModCallbacks &callbacks);
 

--- a/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
@@ -104,7 +104,7 @@ private:
   }
 };
 
-/// A utility composed ontop of OwnershipFixupContext that knows how to RAUW a
+/// A utility composed on top of OwnershipFixupContext that knows how to RAUW a
 /// value or a single value instruction with a new value and then fixup
 /// ownership invariants afterwards.
 class OwnershipRAUWHelper {

--- a/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
@@ -117,14 +117,16 @@ public:
 
 private:
   OwnershipFixupContext *ctx;
-  SingleValueInstruction *oldValue;
+  SILValue oldValue;
   SILValue newValue;
 
 public:
-  OwnershipRAUWHelper() : ctx(nullptr), oldValue(nullptr), newValue(nullptr) {}
+  OwnershipRAUWHelper() : ctx(nullptr) {}
 
   /// Return an instance of this class if we can perform the specific RAUW
   /// operation ignoring if the types line up. Returns None otherwise.
+  ///
+  /// \p oldValue may be either a SingleValueInstruction or a terminator result.
   ///
   /// DISCUSSION: We do not check that the types line up here so that we can
   /// allow for our users to transform our new value in ways that preserve
@@ -133,8 +135,8 @@ public:
   /// from \p newValue at \p oldValue's must be forwarding. If \p newValue is an
   /// address, then these transforms can only transform the address into a
   /// derived address.
-  OwnershipRAUWHelper(OwnershipFixupContext &ctx,
-                      SingleValueInstruction *oldValue, SILValue newValue);
+  OwnershipRAUWHelper(OwnershipFixupContext &ctx, SILValue oldValue,
+                      SILValue newValue);
 
   /// Returns true if this helper was initialized into a valid state.
   operator bool() const { return isValid(); }

--- a/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
@@ -128,6 +128,11 @@ public:
   ///
   /// \p oldValue may be either a SingleValueInstruction or a terminator result.
   ///
+  /// Precondition: If \p oldValue is a BorrowedValue that introduces a local
+  /// borrow scope, then \p newValue must either be defined in the same block as
+  /// \p oldValue, or it must dominate \p oldValue (rather than merely
+  /// dominating its uses).
+  ///
   /// DISCUSSION: We do not check that the types line up here so that we can
   /// allow for our users to transform our new value in ways that preserve
   /// ownership at \p oldValue before we perform the actual RAUW. If \p newValue
@@ -167,6 +172,9 @@ private:
 /// A utility composed ontop of OwnershipFixupContext that knows how to replace
 /// a single use of a value with another value with a different ownership. We
 /// allow for the values to have different types.
+///
+/// Precondition: if \p use ends a borrow scope, then \p newValue dominates the
+/// BorrowedValue that begins the scope.
 ///
 /// NOTE: When not in OSSA, this just performs a normal set use, so this code is
 /// safe to use with all code.

--- a/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
@@ -108,6 +108,14 @@ private:
 /// value or a single value instruction with a new value and then fixup
 /// ownership invariants afterwards.
 class OwnershipRAUWHelper {
+public:
+  /// Return true if \p oldValue can be replaced with \p newValue in terms of
+  /// their value ownership. This ignores any current uses of \p oldValue. To
+  /// determine whether \p oldValue can be replaced as-is with it's existing
+  /// uses, create an instance of OwnershipRAUWHelper and check its validity.
+  static bool hasValidRAUWOwnership(SILValue oldValue, SILValue newValue);
+
+private:
   OwnershipFixupContext *ctx;
   SingleValueInstruction *oldValue;
   SILValue newValue;

--- a/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
@@ -196,6 +196,8 @@ public:
   OwnershipReplaceSingleUseHelper(OwnershipFixupContext &ctx, Operand *use,
                                   SILValue newValue);
 
+  ~OwnershipReplaceSingleUseHelper() { if (ctx) ctx->clear(); }
+
   /// Returns true if this helper was initialized into a valid state.
   operator bool() const { return isValid(); }
   bool isValid() const { return bool(ctx) && bool(use) && bool(newValue); }

--- a/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
@@ -123,6 +123,8 @@ private:
 public:
   OwnershipRAUWHelper() : ctx(nullptr) {}
 
+  ~OwnershipRAUWHelper() { if (ctx) ctx->clear(); }
+
   /// Return an instance of this class if we can perform the specific RAUW
   /// operation ignoring if the types line up. Returns None otherwise.
   ///
@@ -164,7 +166,6 @@ private:
                                              SILValue newValue);
 
   void invalidate() {
-    ctx->clear();
     ctx = nullptr;
   }
 };

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -4018,6 +4018,8 @@ bool SimplifyCFG::simplifyArgument(SILBasicBlock *BB, unsigned i) {
   return true;
 }
 
+// OWNERSHIP NOTE: This is always safe for guaranteed and owned arguments since
+// in both cases the phi will consume its input.
 static void tryToReplaceArgWithIncomingValue(SILBasicBlock *BB, unsigned i,
                                              DominanceInfo *DT) {
   auto *A = BB->getArgument(i);

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -654,6 +654,9 @@ OwnershipLifetimeExtender::createPlusZeroBorrow(SILValue newValue,
   }
   assert(copy && borrow);
 
+  // We don't expect an empty useRange. If it happens, then the newly created
+  // copy will never be destroyed.
+  assert(!useRange.empty());
   auto opRange = makeUserRange(useRange);
   ValueLifetimeAnalysis lifetimeAnalysis(copy, opRange);
   ValueLifetimeAnalysis::Frontier frontier;

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -1484,10 +1484,10 @@ SILBasicBlock::iterator OwnershipReplaceSingleUseHelper::perform() {
 //===----------------------------------------------------------------------===//
 
 /// Given a phi that has been newly created or converted from terminator
-/// results, check for inner guaranteed operands (which do not introduce a
-/// borrow scope). This is invalid OSSA because the phi is a reborrow, and all
-/// borrow-scope-ending instructions must directly use the BorrowedValue that
-/// introduces the scope.
+/// results, check if any of the phi's operands are inner guaranteed values.
+/// This is invalid OSSA because the phi is a reborrow. Like all
+/// borrow-scope-ending instructions a phi must directly use the BorrowedValue
+/// that introduces the scope.
 ///
 /// Create nested borrow scopes for its operands.
 ///

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -492,9 +492,14 @@ struct OwnershipLifetimeExtender {
 
 } // end anonymous namespace
 
-// Lifetime extend newValue over owned oldValue assuming that our copy will have
-// its lifetime ended by oldValue's lifetime ending uses after RAUWing by our
-// caller.
+/// Lifetime extend \p value over \p consumingPoint, assuming that \p
+/// consumingPoint will consume \p value after the client performs replacement
+/// (this implicit destruction on the caller-side makes it a "plus-one"
+/// copy). Destroy \p copy on all paths that don't reach \p consumingPoint.
+///
+/// Precondition: \p value is owned
+///
+/// Precondition: \p consumingPoint is dominated by \p value
 CopyValueInst *
 OwnershipLifetimeExtender::createPlusOneCopy(SILValue value,
                                              SILInstruction *consumingPoint) {
@@ -507,28 +512,23 @@ OwnershipLifetimeExtender::createPlusOneCopy(SILValue value,
 
   auto *result = copy;
   findJointPostDominatingSet(
-      copyPoint->getParent(), consumingPoint->getParent(),
+      copy->getParent(), consumingPoint->getParent(),
       // inputBlocksFoundDuringWalk.
       [&](SILBasicBlock *loopBlock) {
-        // This must be consumingPoint->getParent() since we only have one
-        // consuming use. In this case, we know that this is the consuming
-        // point where we will need a control equivalent copy_value (and that
-        // destroy_value will be put for the out of loop value as appropriate.
+        // Since copy dominates consumingPoint, it must be outside the
+        // loop. Otherwise backward traversal would have stopped at copyPoint.
+        //
+        // Create an extra copy when the consumingPoint is inside a loop and the
+        // original copy is outside the loop. The new copy will be consumed
+        // within the loop in the same block as the consume. The original copy
+        // will be destroyed on all paths exiting the loop.
         assert(loopBlock == consumingPoint->getParent());
         auto front = loopBlock->begin();
         SILBuilderWithScope newBuilder(front);
-
-        // Create an extra copy when the consuming point is inside a
-        // loop and both copyPoint and the destroy points are outside the
-        // loop. This copy will be consumed in the same block. The original
-        // value will be destroyed on all paths exiting the loop.
-        //
-        // Since copyPoint dominates consumingPoint, it must be outside the
-        // loop. Otherwise backward traversal would have stopped at copyPoint.
         result = newBuilder.createCopyValue(front->getLoc(), copy);
         callbacks.createdNewInst(result);
       },
-      // Input blocks in joint post dom set. We don't care about thse.
+      // Leaky blocks that never reach consumingPoint.
       [&](SILBasicBlock *postDomBlock) {
         auto front = postDomBlock->begin();
         SILBuilderWithScope newBuilder(front);

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -1632,5 +1632,9 @@ createExtendedNestedBorrowScope(SILPhiArgument *newPhi) {
 // assumes that this API will eventually be called for all such new phis until
 // OSSA is fully valid.
 bool swift::createBorrowScopeForPhiOperands(SILPhiArgument *newPhi) {
+  if (newPhi->getOwnershipKind() != OwnershipKind::Guaranteed
+      && newPhi->getOwnershipKind() != OwnershipKind::None) {
+      return false;
+  }
   return GuaranteedPhiBorrowFixup().createExtendedNestedBorrowScope(newPhi);
 }

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -410,7 +410,7 @@ static bool canFixUpOwnershipForRAUW(SILValue oldValue, SILValue newValue,
   auto visitReborrow = [&](Operand *endScope) {
     auto borrowingOper = BorrowingOperand(endScope);
     assert(borrowingOper.isReborrow());
-    // TODO: if non-phi reborrows even exist, handle them using a separate
+    // TODO: if non-phi reborrows ever exist, handle them using a separate
     // SILValue list since we don't want to refer directly to phi SILValues.
     reborrows.insert(borrowingOper.getBorrowIntroducingUserResult().value);
     context.recursiveReborrows.push_back(endScope);

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -101,6 +101,106 @@ insertOwnedBaseValueAlongBranchEdge(BranchInst *bi, SILValue innerCopy,
 }
 
 //===----------------------------------------------------------------------===//
+//                      Ownership RAUW Helper Functions
+//===----------------------------------------------------------------------===//
+
+// Determine whether it is valid to replace \p oldValue with \p newValue by
+// directly checking ownership requirements. This does not determine whether the
+// scope of the newValue can be fully extended.
+bool OwnershipRAUWHelper::hasValidRAUWOwnership(SILValue oldValue,
+                                                SILValue newValue) {
+  auto newOwnershipKind = newValue.getOwnershipKind();
+
+  // If our new kind is ValueOwnershipKind::None, then we are fine. We
+  // trivially support that. This check also ensures that we can always
+  // replace any value with a ValueOwnershipKind::None value.
+  if (newOwnershipKind == OwnershipKind::None)
+    return true;
+
+  // If our old ownership kind is ValueOwnershipKind::None and our new kind is
+  // not, we may need to do more work that has not been implemented yet. So
+  // bail.
+  //
+  // Due to our requirement that types line up, this can only occur given a
+  // non-trivial typed value with None ownership. This can only happen when
+  // oldValue is a trivial payloaded or no-payload non-trivially typed
+  // enum. That doesn't occur that often so we just bail on it today until we
+  // implement this functionality.
+  if (oldValue.getOwnershipKind() == OwnershipKind::None)
+    return false;
+
+  // First check if oldValue is SILUndef. If it is, then we know that:
+  //
+  // 1. SILUndef (and thus oldValue) must have OwnershipKind::None.
+  // 2. newValue is not OwnershipKind::None due to our check above.
+  //
+  // Thus we know that we would be replacing a value with OwnershipKind::None
+  // with a value with non-None ownership. This is a case we don't support, so
+  // we can bail now.
+  if (isa<SILUndef>(oldValue))
+    return false;
+
+  // Ok, we now know that we do not have SILUndef implying that we must be able
+  // to get a module from our value since we must have an argument or an
+  // instruction.
+  auto *m = oldValue->getModule();
+  assert(m);
+
+  // If we are in Raw SIL, just bail at this point. We do not support
+  // ownership fixups.
+  if (m->getStage() == SILStage::Raw)
+    return false;
+
+  return true;
+}
+
+// Determine whether it is valid to replace \p oldValue with \p newValue and
+// extend the lifetime of \p oldValue to cover the new uses.
+//
+// This updates the OwnershipFixupContext, populating transitiveBorrowedUses and
+// recursiveReborrows.
+static bool canFixUpOwnershipForRAUW(SILValue oldValue, SILValue newValue,
+                                     OwnershipFixupContext &context) {
+  if (!OwnershipRAUWHelper::hasValidRAUWOwnership(oldValue, newValue))
+    return false;
+
+  if (oldValue.getOwnershipKind() != OwnershipKind::Guaranteed)
+    return true;
+
+  // Check that the old lifetime can be extended and record the necessary
+  // book-keeping in the OwnershipFixupContext.
+  context.clear();
+
+  // Note: The following code is the same logic as
+  // findExtendedTransitiveGuaranteedUses(), but it handles the reborrows
+  // itself to maintain book-keeping. This is intended to be moved into a
+  // different utility in a follow-up commit.
+  SmallSetVector<SILValue, 4> reborrows;
+  auto visitReborrow = [&](Operand *endScope) {
+    auto borrowingOper = BorrowingOperand(endScope);
+    assert(borrowingOper.isReborrow());
+    // TODO: if non-phi reborrows ever exist, handle them using a separate
+    // SILValue list since we don't want to refer directly to phi SILValues.
+    reborrows.insert(borrowingOper.getBorrowIntroducingUserResult().value);
+    context.recursiveReborrows.push_back(endScope);
+  };
+  if (!findTransitiveGuaranteedUses(oldValue, context.transitiveBorrowedUses,
+                                    visitReborrow))
+    return false;
+
+  for (unsigned idx = 0; idx < reborrows.size(); ++idx) {
+    bool result =
+      findTransitiveGuaranteedUses(reborrows[idx],
+                                   context.transitiveBorrowedUses,
+                                   visitReborrow);
+    // It is impossible to find a Pointer escape while traversing reborrows.
+    assert(result && "visiting reborrows always succeeds");
+    (void)result;
+  }
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
 //                          BorrowedLifetimeExtender
 //===----------------------------------------------------------------------===//
 
@@ -330,106 +430,6 @@ extendOverBorrowScopeAndConsume(SILValue ownedValue) {
     PhiValue ownedPhi = reborrowedToOwnedPhis[reborrowedPhi];
     destroyAtScopeEnd(ownedPhi, BorrowedValue(reborrowedPhi));
   }
-}
-
-//===----------------------------------------------------------------------===//
-//                      Ownership RAUW Helper Functions
-//===----------------------------------------------------------------------===//
-
-// Determine whether it is valid to replace \p oldValue with \p newValue by
-// directly checking ownership requirements. This does not determine whether the
-// scope of the newValue can be fully extended.
-bool OwnershipRAUWHelper::hasValidRAUWOwnership(SILValue oldValue,
-                                                SILValue newValue) {
-  auto newOwnershipKind = newValue.getOwnershipKind();
-
-  // If our new kind is ValueOwnershipKind::None, then we are fine. We
-  // trivially support that. This check also ensures that we can always
-  // replace any value with a ValueOwnershipKind::None value.
-  if (newOwnershipKind == OwnershipKind::None)
-    return true;
-
-  // If our old ownership kind is ValueOwnershipKind::None and our new kind is
-  // not, we may need to do more work that has not been implemented yet. So
-  // bail.
-  //
-  // Due to our requirement that types line up, this can only occur given a
-  // non-trivial typed value with None ownership. This can only happen when
-  // oldValue is a trivial payloaded or no-payload non-trivially typed
-  // enum. That doesn't occur that often so we just bail on it today until we
-  // implement this functionality.
-  if (oldValue.getOwnershipKind() == OwnershipKind::None)
-    return false;
-
-  // First check if oldValue is SILUndef. If it is, then we know that:
-  //
-  // 1. SILUndef (and thus oldValue) must have OwnershipKind::None.
-  // 2. newValue is not OwnershipKind::None due to our check above.
-  //
-  // Thus we know that we would be replacing a value with OwnershipKind::None
-  // with a value with non-None ownership. This is a case we don't support, so
-  // we can bail now.
-  if (isa<SILUndef>(oldValue))
-    return false;
-
-  // Ok, we now know that we do not have SILUndef implying that we must be able
-  // to get a module from our value since we must have an argument or an
-  // instruction.
-  auto *m = oldValue->getModule();
-  assert(m);
-
-  // If we are in Raw SIL, just bail at this point. We do not support
-  // ownership fixups.
-  if (m->getStage() == SILStage::Raw)
-    return false;
-
-  return true;
-}
-
-// Determine whether it is valid to replace \p oldValue with \p newValue and
-// extend the lifetime of \p oldValue to cover the new uses.
-//
-// This updates the OwnershipFixupContext, populating transitiveBorrowedUses and
-// recursiveReborrows.
-static bool canFixUpOwnershipForRAUW(SILValue oldValue, SILValue newValue,
-                                     OwnershipFixupContext &context) {
-  if (!OwnershipRAUWHelper::hasValidRAUWOwnership(oldValue, newValue))
-    return false;
-
-  if (oldValue.getOwnershipKind() != OwnershipKind::Guaranteed)
-    return true;
-
-  // Check that the old lifetime can be extended and record the necessary
-  // book-keeping in the OwnershipFixupContext.
-  context.clear();
-
-  // Note: The following code is the same logic as
-  // findExtendedTransitiveGuaranteedUses(), but it handles the reborrows
-  // itself to maintain book-keeping. This is intended to be moved into a
-  // different utility in a follow-up commit.
-  SmallSetVector<SILValue, 4> reborrows;
-  auto visitReborrow = [&](Operand *endScope) {
-    auto borrowingOper = BorrowingOperand(endScope);
-    assert(borrowingOper.isReborrow());
-    // TODO: if non-phi reborrows ever exist, handle them using a separate
-    // SILValue list since we don't want to refer directly to phi SILValues.
-    reborrows.insert(borrowingOper.getBorrowIntroducingUserResult().value);
-    context.recursiveReborrows.push_back(endScope);
-  };
-  if (!findTransitiveGuaranteedUses(oldValue, context.transitiveBorrowedUses,
-                                    visitReborrow))
-    return false;
-
-  for (unsigned idx = 0; idx < reborrows.size(); ++idx) {
-    bool result =
-      findTransitiveGuaranteedUses(reborrows[idx],
-                                   context.transitiveBorrowedUses,
-                                   visitReborrow);
-    // It is impossible to find a Pointer escape while traversing reborrows.
-    assert(result && "visiting reborrows always succeeds");
-    (void)result;
-  }
-  return true;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -891,7 +891,6 @@ SILBasicBlock::iterator OwnershipRAUWUtility::handleUnowned() {
     auto extender = getLifetimeExtender();
     SILValue borrow =
         extender.createPlusZeroBorrow(newValue, oldValue->getUses());
-    SILBuilderWithScope builder(oldValue);
     return replaceAllUsesAndErase(oldValue, borrow, callbacks);
   }
   case OwnershipKind::Owned: {
@@ -921,7 +920,6 @@ SILBasicBlock::iterator OwnershipRAUWUtility::handleUnowned() {
     }
     auto extender = getLifetimeExtender();
     SILValue copy = extender.createPlusZeroCopy(newValue, oldValue->getUses());
-    SILBuilderWithScope builder(oldValue);
     auto result = replaceAllUsesAndErase(oldValue, copy, callbacks);
     return result;
   }


### PR DESCRIPTION
NFC intended, except for extra assertions.

Prepare the code in OwnershipOptUtils for subsequent fixes and features. Ease rebasing and shorten diffs.

Add comments, safeguards, assertions, and generalize a couple of interfaces.