### PR TITLE
We don't need concurrency compatibility library when deploying to Swift 5.5

### DIFF
--- a/include/swift/Frontend/BackDeploymentLibs.def
+++ b/include/swift/Frontend/BackDeploymentLibs.def
@@ -27,6 +27,6 @@
 BACK_DEPLOYMENT_LIB((5, 0), all, "swiftCompatibility50")
 BACK_DEPLOYMENT_LIB((5, 1), all, "swiftCompatibility51")
 BACK_DEPLOYMENT_LIB((5, 0), executable, "swiftCompatibilityDynamicReplacements")
-BACK_DEPLOYMENT_LIB((5, 5), all, "swiftCompatibilityConcurrency")
+BACK_DEPLOYMENT_LIB((5, 4), all, "swiftCompatibilityConcurrency")
                     
 #undef BACK_DEPLOYMENT_LIB

--- a/test/IRGen/autolink-runtime-compatibility.swift
+++ b/test/IRGen/autolink-runtime-compatibility.swift
@@ -50,15 +50,15 @@ public func foo() {}
 // FORCE-LOAD-51-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility50"
 // FORCE-LOAD-51-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements"
 
+// FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility51"
+
 // FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility50"
 // FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements"
 // FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility51"
-// FORCE-LOAD-55-DAG: declare {{.*}} @"_swift_FORCE_LOAD_$_swiftCompatibilityConcurrency"
+// FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibilityConcurrency"
 // FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility50"
 // FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements"
 // FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility51"
-// FORCE-LOAD-55-DAG: [[AUTOLINK_SWIFT_COMPAT_CONCURRENCY:![0-9]+]] = !{!"-lswiftCompatibilityConcurrency"}
-// FORCE-LOAD-55-DAG: !llvm.linker.options = !{{{.*}}[[AUTOLINK_SWIFT_COMPAT_CONCURRENCY]]{{[,}]}}
 // FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility50"
 // FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements"
 // FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility51"


### PR DESCRIPTION
Part of rdar://84065193.
