### PR TITLE
Temporarily disable destroy hoisting when lexical lifetimes enabled.

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -44,6 +44,9 @@ public:
   /// Remove all runtime assertions during optimizations.
   bool RemoveRuntimeAsserts = false;
 
+  /// Enable experimental support for emitting defined borrow scopes.
+  bool EnableExperimentalLexicalLifetimes = false;
+
   /// Force-run SIL copy propagation to shorten object lifetime in whatever
   /// optimization pipeline is currently used.
   /// When this is 'false' the pipeline has default behavior.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -303,9 +303,6 @@ namespace swift {
     /// Enable experimental concurrency model.
     bool EnableExperimentalConcurrency = false;
 
-    /// Enable experimental support for emitting defined borrow scopes.
-    bool EnableExperimentalLexicalLifetimes = false;
-
     /// Enable experimental support for named opaque result types, e.g.
     /// `func f() -> <T> T`.
     bool EnableExperimentalNamedOpaqueTypes = false;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -434,9 +434,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalConcurrency |=
     Args.hasArg(OPT_enable_experimental_concurrency);
 
-  Opts.EnableExperimentalLexicalLifetimes |=
-      Args.hasArg(OPT_enable_experimental_lexical_lifetimes);
-
   Opts.EnableExperimentalNamedOpaqueTypes |=
       Args.hasArg(OPT_enable_experimental_named_opaque_types);
 
@@ -1400,6 +1397,8 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   // -Ounchecked might also set removal of runtime asserts (cond_fail).
   Opts.RemoveRuntimeAsserts |= Args.hasArg(OPT_RemoveRuntimeAsserts);
 
+  Opts.EnableExperimentalLexicalLifetimes |=
+      Args.hasArg(OPT_enable_experimental_lexical_lifetimes);
   Opts.EnableCopyPropagation |= Args.hasArg(OPT_enable_copy_propagation);
   Opts.DisableCopyPropagation |= Args.hasArg(OPT_disable_copy_propagation);
   Opts.EnableARCOptimizations &= !Args.hasArg(OPT_disable_arc_opts);

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -255,7 +255,7 @@ public:
   void emit(SILGenFunction &SGF, CleanupLocation l,
             ForUnwind_t forUnwind) override {
     SILValue val = SGF.VarLocs[Var].value;
-    if (SGF.getASTContext().LangOpts.EnableExperimentalLexicalLifetimes &&
+    if (SGF.getASTContext().SILOpts.EnableExperimentalLexicalLifetimes &&
         val->getOwnershipKind() != OwnershipKind::None)
       SGF.B.createEndBorrow(l, val);
     SGF.destroyLocalVariable(l, Var);
@@ -526,7 +526,7 @@ public:
       address = value;
     SILLocation PrologueLoc(vd);
 
-    if (SGF.getASTContext().LangOpts.EnableExperimentalLexicalLifetimes &&
+    if (SGF.getASTContext().SILOpts.EnableExperimentalLexicalLifetimes &&
         value->getOwnershipKind() != OwnershipKind::None)
       value = SILValue(
           SGF.B.createBeginBorrow(PrologueLoc, value, /*isLexical*/ true));
@@ -1717,7 +1717,7 @@ void SILGenFunction::destroyLocalVariable(SILLocation silLoc, VarDecl *vd) {
   SILValue Val = loc.value;
   if (!Val->getType().isAddress()) {
     SILValue valueToBeDestroyed;
-    if (getASTContext().LangOpts.EnableExperimentalLexicalLifetimes &&
+    if (getASTContext().SILOpts.EnableExperimentalLexicalLifetimes &&
         Val->getOwnershipKind() != OwnershipKind::None) {
       auto *inst = cast<BeginBorrowInst>(Val.getDefiningInstruction());
       valueToBeDestroyed = inst->getOperand();

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -254,7 +254,7 @@ struct ArgumentInitHelper {
     SILValue value = argrv.getValue();
     SILDebugVariable varinfo(pd->isImmutable(), ArgNo);
     if (!argrv.getType().isAddress()) {
-      if (SGF.getASTContext().LangOpts.EnableExperimentalLexicalLifetimes &&
+      if (SGF.getASTContext().SILOpts.EnableExperimentalLexicalLifetimes &&
           value->getOwnershipKind() == OwnershipKind::Owned) {
         value =
             SILValue(SGF.B.createBeginBorrow(loc, value, /*isLexical*/ true));

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -138,7 +138,7 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
     P.addSILSkippingChecker();
 #endif
 
-  if (Options.shouldOptimize()) {
+  if (Options.shouldOptimize() && !Options.EnableExperimentalLexicalLifetimes) {
     P.addDestroyHoisting();
   }
   P.addMandatoryInlining();

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -536,7 +536,7 @@ static bool rewriteAllocBoxAsAllocStack(AllocBoxInst *ABI) {
   bool isLexical = ABI->getFunction()
                        ->getModule()
                        .getASTContext()
-                       .LangOpts.EnableExperimentalLexicalLifetimes;
+                       .SILOpts.EnableExperimentalLexicalLifetimes;
   auto *ASI = Builder.createAllocStack(
       ABI->getLoc(),
       getSILBoxFieldType(TypeExpansionContext(*ABI->getFunction()),

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -316,7 +316,7 @@ static bool shouldAddLexicalLifetime(AllocStackInst *asi) {
          asi->getFunction()
              ->getModule()
              .getASTContext()
-             .LangOpts.EnableExperimentalLexicalLifetimes &&
+             .SILOpts.EnableExperimentalLexicalLifetimes &&
          asi->isLexical() &&
          !asi->getElementType().isTrivial(*asi->getFunction());
 }

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -600,7 +600,7 @@ SILValue SILInlineCloner::borrowFunctionArgument(SILValue callArg,
   auto enableLexicalLifetimes = Apply.getFunction()
                                     ->getModule()
                                     .getASTContext()
-                                    .LangOpts.EnableExperimentalLexicalLifetimes;
+                                    .SILOpts.EnableExperimentalLexicalLifetimes;
   if (!AI.getFunction()->hasOwnership() ||
       (callArg.getOwnershipKind() != OwnershipKind::Owned &&
        !enableLexicalLifetimes)) {

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -424,8 +424,6 @@ int main(int argc, char **argv) {
     EnableExperimentalConcurrency;
   Invocation.getLangOptions().EnableExperimentalDistributed =
     EnableExperimentalDistributed;
-  Invocation.getLangOptions().EnableExperimentalLexicalLifetimes =
-      EnableExperimentalLexicalLifetimes;
 
   Invocation.getLangOptions().EnableObjCInterop =
     EnableObjCInterop ? true :
@@ -513,6 +511,8 @@ int main(int argc, char **argv) {
   SILOpts.EnableOSSAModules = EnableOSSAModules;
   SILOpts.EnableCopyPropagation = EnableCopyPropagation;
   SILOpts.DisableCopyPropagation = DisableCopyPropagation;
+  SILOpts.EnableExperimentalLexicalLifetimes =
+      EnableExperimentalLexicalLifetimes;
 
   serialization::ExtendedValidationInfo extendedInfo;
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =


### PR DESCRIPTION
When -enable-experimental-lexical-lifetimes is passed, disable the destroy
hoisting pass.
