### PR TITLE
[stdlib] Add overload to String(describing:) for metatypes

### DIFF
--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -583,6 +583,15 @@ extension String {
     _print_unlocked(instance, &self)
   }
 
+  // An overload for metatypes because the generic function above goes through
+  // various hoops to unperformantly print metatypes. This overload simplifies
+  // this scenario and provides the same performance characteristics as
+  // `"\(Int.self)"`.
+  @_alwaysEmitIntoClient
+  public init<Subject>(describing instance: Subject.Type) {
+    self = _typeName(instance, qualified: false)
+  }
+
   // These overloads serve as fast paths for init(describing:), but they 
   // also preserve source compatibility for clients which accidentally  
   // used init(stringInterpolationSegment:) through constructs like 


### PR DESCRIPTION
Currently, String(describing:) goes through a very slow path to eventually get the textual representation of Any.Type. String interpolation on the other hand has an overload that calls directly into _typeName to make `"\(someType)"` faster than `String(describing: someType)`.

Resolves: rdar://71192147