### PR TITLE
[Concurrency] Limit queue width with set_width SPI call on linux

### DIFF
--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -275,7 +275,7 @@ static constexpr size_t globalQueueCacheCount =
     static_cast<size_t>(JobPriority::UserInteractive) + 1;
 static std::atomic<dispatch_queue_t> globalQueueCache[globalQueueCacheCount];
 
-#ifdef SWIFT_CONCURRENCY_BACK_DEPLOYMENT
+#if defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT) || defined(__linux__)
 extern "C" void dispatch_queue_set_width(dispatch_queue_t dq, long width);
 #endif
 
@@ -295,7 +295,7 @@ static dispatch_queue_t getGlobalQueue(JobPriority priority) {
   if (SWIFT_LIKELY(queue))
     return queue;
 
-#ifdef SWIFT_CONCURRENCY_BACK_DEPLOYMENT
+#if defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT) || defined(__linux__)
   const int DISPATCH_QUEUE_WIDTH_MAX_LOGICAL_CPUS = -3;
 
   // Create a new cooperative concurrent queue and swap it in.


### PR DESCRIPTION
I confirmed on my sample app that this avoids thread explosions beyond the expected "a few x of the core count" on Linux systems.

rdar://79907041