### PR TITLE
Removing flaky escalation check

### DIFF
--- a/test/Concurrency/Runtime/async_task_priority_current.swift
+++ b/test/Concurrency/Runtime/async_task_priority_current.swift
@@ -39,15 +39,8 @@ func test_detach() async {
     print("a2: \(a2)") // CHECK: a2: TaskPriority(rawValue: 25)
   }.get()
 
-  await detach(priority: .default) {
-    let a3 = Task.currentPriority
-    // The priority of 'a3' may either be 21 (default) or elevated to that of
-    // the main function, whichever is greater.
-    print("a3: \(a3)") // CHECK: a3: TaskPriority(rawValue: [[#max(MAIN_PRIORITY,21)]]
-  }.get()
-
-  let a4 = Task.currentPriority
-  print("a4: \(a4)") // CHECK: a4: TaskPriority(rawValue: [[#MAIN_PRIORITY]])
+  let a3 = Task.currentPriority
+  print("a3: \(a3)") // CHECK: a3: TaskPriority(rawValue: [[#MAIN_PRIORITY]])
 }
 
 @available(SwiftStdlib 5.5, *)


### PR DESCRIPTION
Cherry-picks https://github.com/apple/swift/pull/39692

-----

I had added this clip to verify that the task priority escalation worked
as I expected. There is a bit of raciness in here with the task priority
and when the priority escalation occurs. As a result, this test can be
flaky.