### PR TITLE
SILCombine - Fix worklist logic for OSSA canonicalization

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -384,7 +384,7 @@ public:
 
   /// Apply CanonicalizeOSSALifetime to the extended lifetime of any copy
   /// introduced during SILCombine for an owned value.
-  void canonicalizeOSSALifetimes();
+  void canonicalizeOSSALifetimes(SILInstruction *currentInst);
 
   // Optimize concatenation of string literals.
   // Constant-fold concatenation of string literals known at compile-time.


### PR DESCRIPTION
Required before fixing/re-enabling OSSA RAUW utilities.

Make sure the SILCombine worklist canonicalizes all the copies and
guarantees termination.

Run canonicalization on every existing copy_value once
and once for every new copy_value added during SILCombine.

Only add copies and their uses back to the worklist if
canonicalization deleted an instruction.

Add tracing for sinking forwaring instructions.
