### PR TITLE
Update the OS runtime mapping for Apple OS versions.

### DIFF
--- a/test/IRGen/autolink-runtime-compatibility.swift
+++ b/test/IRGen/autolink-runtime-compatibility.swift
@@ -13,6 +13,12 @@
 // Only autolinks 5.1 compatibility library because target OS has 5.1
 // RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.15 -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=FORCE-LOAD-51 %s
 
+// Only autolinks concurrency compatibility library because target OS has 5.3
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx11 -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=FORCE-LOAD-53 %s
+
+// Only autolinks concurrency compatibility library because target OS has 5.4
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx11.3 -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=FORCE-LOAD-54 %s
+
 // Autolinks because compatibility library was explicitly asked for
 // RUN: %target-swift-frontend -runtime-compatibility-version 5.0 -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=FORCE-LOAD %s
 // RUN: %target-swift-frontend -runtime-compatibility-version 5.1 -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=FORCE-LOAD-51 %s
@@ -49,6 +55,18 @@ public func foo() {}
 // FORCE-LOAD-51-DAG: !llvm.linker.options = !{{{.*}}[[AUTOLINK_SWIFT_COMPAT]], {{.*}}[[AUTOLINK_SWIFT_COMPAT_CONCURRENCY]]{{[,}]}}
 // FORCE-LOAD-51-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility50"
 // FORCE-LOAD-51-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements"
+
+// FORCE-LOAD-53-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility50"
+// FORCE-LOAD-53-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements"
+// FORCE-LOAD-53-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility51"
+// FORCE-LOAD-53-DAG: declare {{.*}} @"_swift_FORCE_LOAD_$_swiftCompatibilityConcurrency"
+// FORCE-LOAD-53-DAG: [[AUTOLINK_SWIFT_COMPAT_CONCURRENCY:![0-9]+]] = !{!"-lswiftCompatibilityConcurrency"}
+
+// FORCE-LOAD-54-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility50"
+// FORCE-LOAD-54-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements"
+// FORCE-LOAD-54-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility51"
+// FORCE-LOAD-54-DAG: declare {{.*}} @"_swift_FORCE_LOAD_$_swiftCompatibilityConcurrency"
+// FORCE-LOAD-54-DAG: [[AUTOLINK_SWIFT_COMPAT_CONCURRENCY:![0-9]+]] = !{!"-lswiftCompatibilityConcurrency"}
 
 // FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility51"
 


### PR DESCRIPTION
Fixes the rest of rdar://84065193, makingn sure we don't link against
compatibility libraries we don't need.
