### PR TITLE
Ensure that we link the right set of compatibility libraries on Apple OS's

### DIFF
--- a/include/swift/Frontend/BackDeploymentLibs.def
+++ b/include/swift/Frontend/BackDeploymentLibs.def
@@ -27,6 +27,6 @@
 BACK_DEPLOYMENT_LIB((5, 0), all, "swiftCompatibility50")
 BACK_DEPLOYMENT_LIB((5, 1), all, "swiftCompatibility51")
 BACK_DEPLOYMENT_LIB((5, 0), executable, "swiftCompatibilityDynamicReplacements")
-BACK_DEPLOYMENT_LIB((5, 5), all, "swiftCompatibilityConcurrency")
+BACK_DEPLOYMENT_LIB((5, 4), all, "swiftCompatibilityConcurrency")
                     
 #undef BACK_DEPLOYMENT_LIB

--- a/stdlib/public/BackDeployConcurrency/CMakeLists.txt
+++ b/stdlib/public/BackDeployConcurrency/CMakeLists.txt
@@ -44,7 +44,8 @@ add_compile_definitions(SWIFT_CONCURRENCY_BACK_DEPLOYMENT)
 set(swift_concurrency_install_component back-deployment)
 set(swift_concurrency_options
   BACK_DEPLOYMENT_LIBRARY 5.5
-  DARWIN_INSTALL_NAME_DIR "@rpath")
+  DARWIN_INSTALL_NAME_DIR "@rpath"
+  LINK_FLAGS -lobjc)
 set(swift_concurrency_extra_sources
   "../BackDeployConcurrency/Exclusivity.cpp"
   "../BackDeployConcurrency/Metadata.cpp"

--- a/test/IRGen/autolink-runtime-compatibility.swift
+++ b/test/IRGen/autolink-runtime-compatibility.swift
@@ -13,6 +13,12 @@
 // Only autolinks 5.1 compatibility library because target OS has 5.1
 // RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.15 -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=FORCE-LOAD-51 %s
 
+// Only autolinks concurrency compatibility library because target OS has 5.3
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx11 -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=FORCE-LOAD-53 %s
+
+// Only autolinks concurrency compatibility library because target OS has 5.4
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx11.3 -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=FORCE-LOAD-54 %s
+
 // Autolinks because compatibility library was explicitly asked for
 // RUN: %target-swift-frontend -runtime-compatibility-version 5.0 -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=FORCE-LOAD %s
 // RUN: %target-swift-frontend -runtime-compatibility-version 5.1 -emit-ir -parse-stdlib %s | %FileCheck -check-prefix=FORCE-LOAD-51 %s
@@ -49,6 +55,18 @@ public func foo() {}
 // FORCE-LOAD-51-DAG: !llvm.linker.options = !{{{.*}}[[AUTOLINK_SWIFT_COMPAT]], {{.*}}[[AUTOLINK_SWIFT_COMPAT_CONCURRENCY]]{{[,}]}}
 // FORCE-LOAD-51-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility50"
 // FORCE-LOAD-51-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements"
+
+// FORCE-LOAD-53-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility50"
+// FORCE-LOAD-53-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements"
+// FORCE-LOAD-53-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility51"
+// FORCE-LOAD-53-DAG: declare {{.*}} @"_swift_FORCE_LOAD_$_swiftCompatibilityConcurrency"
+// FORCE-LOAD-53-DAG: [[AUTOLINK_SWIFT_COMPAT_CONCURRENCY:![0-9]+]] = !{!"-lswiftCompatibilityConcurrency"}
+
+// FORCE-LOAD-54-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility50"
+// FORCE-LOAD-54-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements"
+// FORCE-LOAD-54-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility51"
+// FORCE-LOAD-54-DAG: declare {{.*}} @"_swift_FORCE_LOAD_$_swiftCompatibilityConcurrency"
+// FORCE-LOAD-54-DAG: [[AUTOLINK_SWIFT_COMPAT_CONCURRENCY:![0-9]+]] = !{!"-lswiftCompatibilityConcurrency"}
 
 // FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility51"
 

--- a/test/IRGen/autolink-runtime-compatibility.swift
+++ b/test/IRGen/autolink-runtime-compatibility.swift
@@ -50,15 +50,15 @@ public func foo() {}
 // FORCE-LOAD-51-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility50"
 // FORCE-LOAD-51-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements"
 
+// FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility51"
+
 // FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility50"
 // FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements"
 // FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility51"
-// FORCE-LOAD-55-DAG: declare {{.*}} @"_swift_FORCE_LOAD_$_swiftCompatibilityConcurrency"
+// FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibilityConcurrency"
 // FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility50"
 // FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements"
 // FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility51"
-// FORCE-LOAD-55-DAG: [[AUTOLINK_SWIFT_COMPAT_CONCURRENCY:![0-9]+]] = !{!"-lswiftCompatibilityConcurrency"}
-// FORCE-LOAD-55-DAG: !llvm.linker.options = !{{{.*}}[[AUTOLINK_SWIFT_COMPAT_CONCURRENCY]]{{[,}]}}
 // FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility50"
 // FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibilityDynamicReplacements"
 // FORCE-LOAD-55-NOT: @"_swift_FORCE_LOAD_$_swiftCompatibility51"


### PR DESCRIPTION
**Description:** Update the OS runtime mapping for Apple OS versions to account for the last year's worth of releases and ensure that we don't link against compatibility libraries we don't need.
**Risk:** Low
**Testing:** Added test covering this case, PR testing on CI.
**Original PR:** https://github.com/apple/swift/pull/39724 & https://github.com/apple/swift/pull/39737
**Radar:** rdar://84065193