### PR TITLE
🍒  5.5 [Concurrency] Limit queue width with set_width SPI call on linux

### DIFF
--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -266,7 +266,7 @@ static constexpr size_t globalQueueCacheCount =
     static_cast<size_t>(JobPriority::UserInteractive) + 1;
 static std::atomic<dispatch_queue_t> globalQueueCache[globalQueueCacheCount];
 
-#ifdef SWIFT_CONCURRENCY_BACK_DEPLOYMENT
+#if defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT) || defined(__linux__)
 extern "C" void dispatch_queue_set_width(dispatch_queue_t dq, long width);
 #endif
 
@@ -286,7 +286,7 @@ static dispatch_queue_t getGlobalQueue(JobPriority priority) {
   if (SWIFT_LIKELY(queue))
     return queue;
 
-#ifdef SWIFT_CONCURRENCY_BACK_DEPLOYMENT
+#if defined(SWIFT_CONCURRENCY_BACK_DEPLOYMENT) || defined(__linux__)
   const int DISPATCH_QUEUE_WIDTH_MAX_LOGICAL_CPUS = -3;
 
   // Create a new cooperative concurrent queue and swap it in.


### PR DESCRIPTION
**Description:** To avoid thread explosions, i.e. thread growth to the hardcoded number of 255 when tasks are blocked on Linux, and in order to get the same behavior as Swift Concurrency has on Darwin (and back deployment), we must set the global queue width as we set it up for swift concurrency. Without this, when tasks block for even short burtsts, we end up with many many threads on Linux systems. The fix sets the width, same as we do on back deployment and gets us consistent behavior across platforms, and no thread explosions. 
**Risk:** Low, this is how it was supposed to work to begin with.
**Review by:** @DougGregor
**Testing:** Verified the fix works manually on Ubuntu boxes, with sample applications. A bit hard to test this automatically, as we'd need to check for thread counts in the system.
**Original PR:** https://github.com/apple/swift/pull/39732
**Radar:** rdar://79907041

