### PR TITLE
[SwiftSyntax] Include stdint.h from SwiftSyntaxCDataTypes.h

### DIFF
--- a/include/swift-c/SyntaxParser/SwiftSyntaxCDataTypes.h
+++ b/include/swift-c/SyntaxParser/SwiftSyntaxCDataTypes.h
@@ -27,6 +27,7 @@
 #define SWIFT_C_SYNTAX_C_DATA_TYPES_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 /// Offset+length in UTF8 bytes.
 typedef struct {


### PR DESCRIPTION
Depending on the environment, the missing include could cause compilation errors.