### PR TITLE
[DRAFT]Module aliasing: show module aliases in diagnostics

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -366,6 +366,11 @@ public:
   /// If no module aliasing is set, it will return getName(), i.e. Foo.
   Identifier getRealName() const;
 
+  /// Used for diagnostics. In case module aliasing is used, the alias which appears in source files
+  /// could be different from the actual name of this module. This returns the alias to be consistent
+  /// with what's written in source files.
+  Identifier getNameForDiags() const;
+
   /// User-defined module version number.
   llvm::VersionTuple UserModuleVersion;
   void setUserModuleVersion(llvm::VersionTuple UserVer) {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1568,6 +1568,13 @@ Identifier ModuleDecl::getRealName() const {
   return getASTContext().getRealModuleName(getName());
 }
 
+Identifier ModuleDecl::getNameForDiags() const {
+  if (!ModuleAlias.empty()) {
+    return ModuleAlias;
+  }
+  return getName();
+}
+
 Identifier ModuleDecl::getABIName() const {
   if (!ModuleABIName.empty())
     return ModuleABIName;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3634,7 +3634,7 @@ bool MissingMemberFailure::diagnoseAsError() {
     }
   } else if (auto moduleTy = baseType->getAs<ModuleType>()) {
     emitDiagnosticAt(::getLoc(memberBase), diag::no_member_of_module,
-                     moduleTy->getModule()->getName(), getName())
+                     moduleTy->getModule()->getNameForDiags(), getName())
         .highlight(getSourceRange())
         .highlight(nameLoc.getSourceRange());
     return true;

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -725,7 +725,7 @@ CheckInconsistentImplementationOnlyImportsRequest::evaluate(
     {
       InFlightDiagnostic warning =
           diags.diagnose(normalImport, diag::warn_implementation_only_conflict,
-                         normalImport->getModule()->getName());
+                         normalImport->getModule()->getNameForDiags());
       if (normalImport->getAttrs().isEmpty()) {
         // Only try to add a fix-it if there's no other annotations on the
         // import to avoid creating things like

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1864,7 +1864,7 @@ public:
     auto diag =
         DE.diagnose(diagLoc, diag::decl_from_hidden_module,
                     PGD->getDescriptiveKind(), PGD->getName(),
-                    static_cast<unsigned>(ExportabilityReason::General), M->getName(),
+                    static_cast<unsigned>(ExportabilityReason::General), M->getNameForDiags(),
                     static_cast<unsigned>(DisallowedOriginKind::ImplementationOnly)
                     );
     if (refRange.isValid())

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1216,7 +1216,7 @@ static Type diagnoseUnknownType(TypeResolution resolution,
   // Lookup into a type.
   if (auto moduleType = parentType->getAs<ModuleType>()) {
     diags.diagnose(comp->getNameLoc(), diag::no_module_type,
-                   comp->getNameRef(), moduleType->getModule()->getName());
+                   comp->getNameRef(), moduleType->getModule()->getNameForDiags());
   } else {
     LookupResult memberLookup;
     // Let's try to look any member of the parent type with the given name,
@@ -1459,7 +1459,7 @@ static void diagnoseAmbiguousMemberType(Type baseTy, SourceRange baseRange,
   auto &diags = ctx.Diags;
   if (auto moduleTy = baseTy->getAs<ModuleType>()) {
     diags.diagnose(nameLoc, diag::ambiguous_module_type, name,
-                   moduleTy->getModule()->getName())
+                   moduleTy->getModule()->getNameForDiags())
       .highlight(baseRange);
   } else {
     diags.diagnose(nameLoc, diag::ambiguous_member_type, name, baseTy)
@@ -3434,7 +3434,7 @@ TypeResolver::resolveIdentifierType(IdentTypeRepr *IdType,
       return moduleTy;
     // Otherwise, emit an error.
     if (!options.contains(TypeResolutionFlags::SilenceErrors)) {
-      auto moduleName = moduleTy->getModule()->getName();
+      auto moduleName = moduleTy->getModule()->getNameForDiags();
       diagnose(Components.back()->getNameLoc(),
                diag::cannot_find_type_in_scope, DeclNameRef(moduleName));
       diagnose(Components.back()->getNameLoc(),

--- a/test/Frontend/module-alias-diag.swift
+++ b/test/Frontend/module-alias-diag.swift
@@ -1,0 +1,75 @@
+/// Test diagnostics with module aliasing.
+///
+/// Module 'Lib' imports module 'XLogging', and 'XLogging' is aliased 'AppleLogging'.
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+/// Create AppleLogging.swiftmodule by aliasing XLogging
+// RUN: %target-swift-frontend -module-name AppleLogging -module-alias XLogging=AppleLogging %t/FileLogging.swift -emit-module -emit-module-path %t/AppleLogging.swiftmodule
+// RUN: test -f %t/AppleLogging.swiftmodule
+
+/// 1. No error
+/// Create module Lib that imports XLogging WITH -module-alias XLogging=AppleLogging
+// RUN: %target-swift-frontend -module-name LibA %t/FileLib.swift -module-alias XLogging=AppleLogging -I %t -emit-module -emit-module-path %t/LibA.swiftmodule -Rmodule-loading 2> %t/result-LibA.output
+// RUN: test -f %t/LibA.swiftmodule
+// RUN: %FileCheck %s -input-file %t/result-LibA.output -check-prefix CHECK-LOAD-A
+// CHECK-LOAD-A: remark: loaded module at {{.*}}AppleLogging.swiftmodule
+
+/// 2. Fail: No member error with module name 'XLogging'
+/// Try building module Lib that imports XLogging WITH -module-alias XLogging=AppleLogging
+// RUN: not %target-swift-frontend -module-name LibB %t/FileLibNoMember.swift -module-alias XLogging=AppleLogging -I %t -emit-module -emit-module-path %t/LibB.swiftmodule 2> %t/result-LibB.output
+// RUN: %FileCheck %s -input-file %t/result-LibB.output -check-prefix CHECK-NO-MEMBER
+// CHECK-NO-MEMBER: error: module 'XLogging' has no member named 'setupErr'
+
+/// 3. FIXME: Should fail with module not found <rdar://83592084> -- Pass for now
+/// Create module Lib that imports XLogging WITH -module-alias XLogging=AppleLogging
+// RUN: %target-swift-frontend -module-name LibC %t/FileLibRefRealName.swift -module-alias XLogging=AppleLogging -I %t -emit-module -emit-module-path %t/LibC.swiftmodule 2> %t/result-LibC.output
+// FIXME: toggle this to fail
+// RUN: not %FileCheck %s -input-file %t/result-LibC.output -check-prefix CHECK-NOT-FOUND
+// CHECK-NOT-FOUND: error: cannot find 'AppleLogging' in scope
+
+/// 4. FIXME: Should fail with no such module error <rdar://83592084> -- Pass for now
+/// Create module Lib that imports XLogging WITH -module-alias XLogging=AppleLogging
+// RUN: %target-swift-frontend -module-name LibC %t/FileLibImportRealName.swift -module-alias XLogging=AppleLogging -I %t -emit-module -emit-module-path %t/LibC.swiftmodule 2> %t/result-LibC.output
+// FIXME: toggle this to fail
+// RUN: not %FileCheck %s -input-file %t/result-LibC.output -check-prefix CHECK-NOT-FOUND
+// CHECK-NOT-FOUND: error: no such module 'AppleLogging'
+
+// BEGIN FileLogging.swift
+public struct Logger {
+  public init() {}
+}
+public func setup() -> XLogging.Logger? {
+  return Logger()
+}
+
+// BEGIN FileLib.swift
+import XLogging
+
+public func start() {
+  _ = XLogging.setup()
+}
+
+// BEGIN FileLibNoMember.swift
+import XLogging
+
+public func start() {
+  _ = XLogging.setupErr()
+}
+
+// BEGIN FileLibRefRealName.swift
+import XLogging
+
+public func start() {
+  _ = AppleLogging.setup()
+}
+
+// BEGIN FileLibImportRealName.swift
+import XLogging
+import AppleLogging
+
+public func start() {
+  _ = XLogging.setup()
+}
+


### PR DESCRIPTION
ModuleDecl has an alias which differs from the name in case module aliasing is used; alias is the name that appears in source files, so display the alias in diagnostics. Resolves rdar://83967232

Pending https://github.com/apple/swift/pull/39744
