### PR TITLE
Fix FileCheck test for back-deployed concurrency.

### DIFF
--- a/test/Concurrency/Backdeploy/mangling.swift
+++ b/test/Concurrency/Backdeploy/mangling.swift
@@ -17,8 +17,6 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency_runtime
 
-// REQUIRES: rdar84218063
-
 actor MyActor { }
 
 protocol MyProtocol {
@@ -80,8 +78,8 @@ assert(assocIsolated(MyStruct.self) == ActorIsolatedFn.self)
 // NEW-NOT: call swiftcc %swift.metadata_response @"$syyScMYccMa"
 // NEW: call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$syyScMYccMD")
 
-// OLD: call swiftcc %swift.metadata_response @"$sSS4main7MyActorCYicMa"(i64 0) #3
+// OLD: call swiftcc %swift.metadata_response @"$sSS4main7MyActorCYicMa"(i64 0)
 // OLD-NOT: call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$sSS4main7MyActorCYicMD")
 
-// NEW-NOT: call swiftcc %swift.metadata_response @"$sSS4main7MyActorCYicMa"(i64 0) #3
+// NEW-NOT: call swiftcc %swift.metadata_response @"$sSS4main7MyActorCYicMa"(i64 0)
 // NEW: call %swift.type* @__swift_instantiateConcreteTypeFromMangledName({ i32, i32 }* @"$sSS4main7MyActorCYicMD")


### PR DESCRIPTION
**Description:** Test-only fix to re-enable a back-deployment test for concurrency.
**Risk:** Low,.
**Testing:** CI
**Original PR:** https://github.com/apple/swift/pull/39739
**Radar:** Fixes rdar://83840279.
