### PR TITLE
[CSStep] Conjunction: Stop after first ambiguous or fixed element

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5886,6 +5886,10 @@ public:
   bool needsToComputeNext() const override { return false; }
 
   bool isExhausted() const override { return Index >= Elements.size(); }
+
+  void markExhausted() {
+    Index = Elements.size();
+  }
 };
 
 /// Determine whether given type is a known one

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -949,6 +949,13 @@ protected:
     // successfully by use of fixes, and ignore the rest.
     AnySolved = false;
   }
+
+private:
+  // Restore constraint system state before conjunction.
+  //
+  // Note that this doesn't include conjunction constraint
+  // itself because we don't want to re-solve it.
+  void restoreOuterState() const;
 };
 
 } // end namespace constraints

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -1,0 +1,141 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5 -experimental-multi-statement-closures -enable-experimental-static-assert
+
+func isInt<T>(_ value: T) -> Bool {
+  return value is Int
+}
+
+func maybeGetValue<T>(_ value: T) -> T? {
+  return value
+}
+
+enum MyError: Error {
+  case featureIsTooCool
+
+  func doIt() { }
+}
+
+enum State {
+  case suspended
+  case partial(Int, Int)
+  case finished
+}
+
+func random(_: Int) -> Bool { return false }
+
+func mightThrow() throws -> Bool { throw MyError.featureIsTooCool }
+
+func mapWithMoreStatements(ints: [Int], state: State) throws {
+  let _ = try ints.map { i in
+    guard var actualValue = maybeGetValue(i) else {
+      return String(0)
+    }
+
+    let value = actualValue + 1
+    do {
+      if isInt(i) {
+        print(value)
+      } else if value == 17 {
+        print("seventeen!")
+      }
+    }
+
+    while actualValue < 100 {
+      actualValue += 1
+    }
+
+  my_repeat:
+    repeat {
+      print("still here")
+
+      if i % 7 == 0 {
+        break my_repeat
+      }
+    } while random(i)
+
+    defer {
+      print("I am so done here")
+    }
+
+    for j in 0..<i where j % 2 == 0 {
+      if j % 7 == 0 {
+        continue
+      }
+
+      switch (state, j) {
+      case (.suspended, 0):
+        print("something")
+        fallthrough
+      case (.finished, 0):
+        print("something else")
+
+      case (.partial(let current, let end), let j):
+        print("\(current) of \(end): \(j)")
+
+      default:
+        print("so, here we are")
+      }
+      print("even")
+      throw MyError.featureIsTooCool
+    }
+
+    #assert(true)
+
+    // expected-warning@+1{{danger zone}}
+    #warning("danger zone")
+
+#if false
+    struct NothingHere { }
+#else
+    struct NestedStruct {
+      var x: Int
+    }
+#endif
+
+    do {
+      print(try mightThrow())
+    } catch let e as MyError {
+      e.doIt()
+    } catch {
+      print(error)
+    }
+    return String(value)
+  }
+}
+
+func acceptsWhateverClosure<T, R>(_ value: T, _ fn: (T) -> R) { }
+
+func testReturnWithoutExpr(i: Int) {
+  acceptsWhateverClosure(i) { i in
+    print(i)
+    return
+  }
+}
+
+// `withContiguousStorageIfAvailable` is overloaded, so let's make sure that
+// filtering works correctly.
+func test_overloaded_call(arr: [Int], body: (UnsafeBufferPointer<Int>) -> Void) -> Void {
+  arr.withContiguousStorageIfAvailable { buffer in
+    let _ = type(of: buffer)
+    body(buffer) // ok
+  }
+}
+
+// Used to wrap closure in `FunctionConversionExpr` in this case,
+// but now solver would just inject return expression into optional where necessary.
+func test_result_optional_injection() {
+  func fn<T>(_: () -> T?) -> [T] {
+    []
+  }
+
+  _ = fn {
+    if true {
+      return // Ok
+    }
+  }
+}
+
+let _ = {
+  for i: Int8 in 0 ..< 20 { // Ok (pattern can inform a type of the sequence)
+    print(i)
+  }
+}


### PR DESCRIPTION
Stop a conjunction after the first invalid element in diagnostic mode.

No need to run the inference for other elements once the problem has been
found. All ambiguities and solutions with fixes are propagated back to the
outer context to be diagnosed.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
