### PR TITLE
Remove check for line number as a value of that is a constant hardcoded number off the CHECK line number and replace it with a CHECK for a non-zero line number instead

### DIFF
--- a/test/DebugInfo/top_level_code.swift
+++ b/test/DebugInfo/top_level_code.swift
@@ -7,7 +7,7 @@ func markUsed<T>(_ t: T) {}
 // proceeds to the first line.
 // CHECK: .loc    {{[0-9]}} 0 {{[0-9]}}
 // CHECK-NOT: Lfunc_end0:
-// CHECK: .loc    {{[0-9]}} [[@LINE+1]] {{[0-9]}} prologue_end
+// CHECK: .loc    {{[0-9]}} {{[0-9][0-9]*}} {{[0-9]}} prologue_end
 var a = 1
 var b = 2
 markUsed(a+b)


### PR DESCRIPTION
prologue_ends should skip line 0 locs, but the line number they should be on should just be a non-zero value, it seems like this check failed because llvm used to emit a loc with a line number 11 but now it emits 13 instead, so this CHECK just checks for non-zero line numbers instead