### PR TITLE
 [ConstraintSystem] Fix non-determinism in `diagnoseAmbiguity`

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4230,10 +4230,25 @@ bool ConstraintSystem::diagnoseAmbiguity(ArrayRef<Solution> solutions) {
 
   for (unsigned i = 0, n = diff.overloads.size(); i != n; ++i) {
     auto &overload = diff.overloads[i];
+    auto *locator = overload.locator;
+
+    Expr *anchor = nullptr;
+
+    // Simplification of member locator would produce a base expression,
+    // this is what we want for diagnostics but not for comparisons here
+    // because base expression is located at a different depth which would
+    // lead to incorrect results if both reference and base expression are
+    // ambiguous e.g. `test[x].count` if both `[x]` and `count` are ambiguous
+    // than simplification of `count` would produce `[x]` which is incorrect.
+    if (locator->isLastElement<LocatorPathElt::Member>() ||
+        locator->isLastElement<LocatorPathElt::ConstructorMember>()) {
+      anchor = getAsExpr(locator->getAnchor());
+    } else {
+      anchor = getAsExpr(simplifyLocatorToAnchor(overload.locator));
+    }
 
     // If we can't resolve the locator to an anchor expression with no path,
     // we can't diagnose this well.
-    auto *anchor = getAsExpr(simplifyLocatorToAnchor(overload.locator));
     if (!anchor)
       continue;
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4252,12 +4252,12 @@ bool ConstraintSystem::diagnoseAmbiguity(ArrayRef<Solution> solutions) {
     if (!anchor)
       continue;
 
-    auto it = indexMap.find(castToExpr(anchor));
+    auto it = indexMap.find(anchor);
     if (it == indexMap.end())
       continue;
     unsigned index = it->second;
 
-    auto optDepth = getExprDepth(castToExpr(anchor));
+    auto optDepth = getExprDepth(anchor);
     if (!optDepth)
       continue;
     unsigned depth = *optDepth;


### PR DESCRIPTION
Simplification of member locator would produce a base expression,
 this is what we want for diagnostics but not for comparisons in
`diagnoseAmbiguity` because base expression is located at a different
depth which would lead to incorrect results if both reference and base
expression are ambiguous e.g. `test[x].count` if both `[x]` and `count`
are ambiguous than simplification of `count` would produce `[x]` which
is incorrect.

This is the test-case (already in the suite) that exibits this behavior:

```
func test_ambiguity_with_placeholders(pairs: [(rank: Int, count: Int)]) -> Bool {
  return pairs[<#^ARG^#>].count == 2
}
```

Here subscript would either return a tuple or `ArraySlice` and
`count` is ambiguous because both have it.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
