### PR TITLE
[test] Copy concurrency back-deployment libs to remote-run hosts

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1720,6 +1720,11 @@ back_deployment_runtime = lit_config.params.get('back_deployment_runtime', None)
 if back_deployment_runtime is not None:
     config.available_features.add('back_deployment_runtime')
 
+concurrency_back_deploy_path = ''
+if run_vendor == 'apple':
+    if 'back_deploy_concurrency' in config.available_features:
+        concurrency_back_deploy_path = os.path.join(os.path.dirname(swift_obj_root), os.path.basename(swift_obj_root).replace("swift-", "backdeployconcurrency-"), 'lib', 'swift-5.5', run_os)
+
 if 'remote_run_host' in lit_config.params:
     if 'remote_run_tmpdir' not in lit_config.params:
         lit_config.fatal("'remote_run_host' provided, but no "
@@ -1773,6 +1778,9 @@ if 'remote_run_host' in lit_config.params:
         # FIXME: This could be more principled.
         upload_dylibs(os.path.join(test_resource_dir, "clang", "lib", "darwin"))
         upload_dylibs(os.path.join(test_resource_dir, "clang", "lib", "linux"))
+        # Only copy when we have use_os_stdlib, otherwise we want to rely on the just-build concurrency
+        if concurrency_back_deploy_path and 'use_os_stdlib' in lit_config.params:
+            upload_dylibs(concurrency_back_deploy_path)
 
         # FIXME: Uploading specific files in bin/ is not very scalable.
         local_swift_reflection_test = lit.util.which(
@@ -1983,14 +1991,11 @@ if not kIsWindows:
 	else:
 		config.available_features.add('use_os_stdlib')
 		os_stdlib_path = ''
-		concurrency_back_deploy_path = ''
 		if run_vendor == 'apple':
 			#If we get swift-in-the-OS for non-Apple platforms, add a condition here
 			os_stdlib_path = "/usr/lib/swift"
 			if run_os == 'maccatalyst':
 			    os_stdlib_path = "/System/iOSSupport/usr/lib/swift:/usr/lib/swift"
-			if 'back_deploy_concurrency' in config.available_features:
-			    concurrency_back_deploy_path = os.path.join(os.path.dirname(swift_obj_root), os.path.basename(swift_obj_root).replace("swift-", "backdeployconcurrency-"), 'lib', 'swift-5.5', run_os)
 
 		all_stdlib_path = os.path.pathsep.join((os_stdlib_path, concurrency_back_deploy_path, target_stdlib_path))
 


### PR DESCRIPTION
Concurrency testing on back-deployment targets using remote-run fails to find the back-deployment libraries because the `backdeployconcurrency` wasn't included in the list of libraries copied into the remote-run `stdlib` path. This adds them to that list when `back_deploy_concurrency` is requested.

Fixes rdar://83703680