### PR TITLE
[WIP] Clock Instant Date Duration

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -515,6 +515,10 @@ public:
   /// Retrieve the type of Swift.Void.
   Type getVoidType() const;
 
+  StructDecl *getDurationDecl() const;
+
+  Type getDurationType() const;
+
   /// Retrieve the declaration of the "pointee" property of a pointer type.
   VarDecl *getPointerPointeePropertyDecl(PointerTypeKind ptrKind) const;
 

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -157,6 +157,7 @@ IDENTIFIER(withKeywordArguments)
 IDENTIFIER(wrapped)
 IDENTIFIER(wrappedValue)
 IDENTIFIER(wrapperValue)
+IDENTIFIER(Duration)
 
 // Kinds of layout constraints
 IDENTIFIER_WITH_NAME(UnknownLayout, "_UnknownLayout")

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -804,6 +804,9 @@ public:
   /// on macOS or Foundation on Linux.
   bool isCGFloatType();
 
+  bool isTimeIntervalType();
+  bool isDurationType();
+
   /// Check if this is either an Array, Set or Dictionary collection type defined
   /// at the top level of the Swift module
   bool isKnownStdlibCollectionType();

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -673,6 +673,11 @@ void swift_task_enqueueGlobal(Job *job);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_enqueueGlobalWithDelay(unsigned long long delay, Job *job);
 
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_task_enqueueGlobalWithDeadline(long long seconds, 
+                                          long long nanoseconds, 
+                                          int clockId, Job *job);
+
 /// Enqueue the given job on the main executor.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_enqueueMainExecutor(Job *job);
@@ -698,6 +703,14 @@ SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDelay_hook)(
     unsigned long long delay, Job *job,
     swift_task_enqueueGlobalWithDelay_original original);
+
+/// A hook to take over global enqueuing with deadline.
+typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDeadline_original)(
+    long long seconds, long long nanoseconds, int clockId, Job *job);
+SWIFT_EXPORT_FROM(swift_Concurrency)
+SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDeadline_hook)(
+    long long seconds, long long nanoseconds, int clockId, Job *job,
+    swift_task_enqueueGlobalWithDeadline_original original);
 
 /// A hook to take over main executor enqueueing.
 typedef SWIFT_CC(swift) void (*swift_task_enqueueMainExecutor_original)(

--- a/include/swift/Runtime/Once.h
+++ b/include/swift/Runtime/Once.h
@@ -26,20 +26,29 @@ namespace swift {
 
 typedef bool swift_once_t;
 
+#define SWIFT_ONCE_INIT false
+
 #elif defined(__APPLE__)
 
 // On OS X and iOS, swift_once_t matches dispatch_once_t.
 typedef long swift_once_t;
+
+#define SWIFT_ONCE_INIT 0
 
 #elif defined(__CYGWIN__)
 
 // On Cygwin, std::once_flag can not be used because it is larger than the
 // platform word.
 typedef uintptr_t swift_once_t;
+
+#define SWIFT_ONCE_INIT 0
+
 #else
 
 // On other platforms swift_once_t is std::once_flag
 typedef std::once_flag swift_once_t;
+
+#define SWIFT_ONCE_INIT std::once_flag()
 
 #endif
 

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -296,6 +296,10 @@ enum class ConversionRestrictionKind {
   /// Implicit conversion from a value of CGFloat type to a value of Double type
   /// via an implicit Double initializer call passing a CGFloat value.
   CGFloatToDouble,
+
+  DurationToTimeInterval,
+  TimeIntervalToDuration,
+
   /// Implicit conversion between Swift and C pointers:
   //    - Unsafe[Mutable]RawPointer -> Unsafe[Mutable]Pointer<[U]Int>
   //    - Unsafe[Mutable]Pointer<Int{8, 16, ...}> <-> Unsafe[Mutable]Pointer<UInt{8, 16, ...}>

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -225,6 +225,8 @@ struct ASTContext::Implementation {
   /// The declaration of Swift.Void.
   TypeAliasDecl *VoidDecl = nullptr;
 
+  StructDecl *DurationDecl = nullptr;
+
   /// The declaration of Swift.UnsafeMutableRawPointer.memory.
   VarDecl *UnsafeMutableRawPointerMemoryDecl = nullptr;
 
@@ -899,6 +901,30 @@ TypeAliasDecl *ASTContext::getVoidDecl() const {
 
 Type ASTContext::getVoidType() const {
   auto decl = getVoidDecl();
+  if (!decl)
+    return Type();
+  return decl->getDeclaredInterfaceType();
+}
+
+StructDecl *ASTContext::getDurationDecl() const {
+  if (getImpl().DurationDecl) {
+    return getImpl().DurationDecl;
+  }
+
+  SmallVector<ValueDecl *, 1> results;
+  lookupInSwiftModule("Duration", results);
+  for (auto result : results) {
+    if (auto typealias = dyn_cast<StructDecl>(result)) {
+      getImpl().DurationDecl = typealias;
+      return typealias;
+    }
+  }
+
+  return nullptr;
+}
+
+Type ASTContext::getDurationType() const {
+  auto decl = getDurationDecl();
   if (!decl)
     return Type();
   return decl->getDeclaredInterfaceType();

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -830,6 +830,43 @@ bool TypeBase::isCGFloatType() {
          NTD->getName().is("CGFloat");
 }
 
+bool TypeBase::isTimeIntervalType() {
+  if (auto alias = dyn_cast<TypeAliasType>(this)) {
+    auto *decl = alias->getDecl();
+    auto *module = decl->getModuleContext();
+    return module->getName().is("Foundation") &&
+           decl->getName().is("TimeInterval");
+  }
+  auto *NTD = getAnyNominal();
+  if (!NTD)
+    return false;
+
+  auto *DC = NTD->getDeclContext();
+  if (!DC->isModuleScopeContext())
+    return false;
+
+  auto *module = DC->getParentModule();
+
+  return module->getName().is("Foundation") &&
+         NTD->getName().is("TimeInterval");
+}
+
+bool TypeBase::isDurationType() {
+  auto *NTD = getAnyNominal();
+  if (!NTD)
+    return false;
+
+  auto *DC = NTD->getDeclContext();
+  if (!DC->isModuleScopeContext())
+    return false;
+
+  auto *module = DC->getParentModule();
+  
+  return module->getName().is("Swift") &&
+         NTD->getName().is("Duration");
+}
+
+
 bool TypeBase::isKnownStdlibCollectionType() {
   if (isArray() || isDictionary() || isSet()) {
     return true;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6641,7 +6641,9 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     }
 
     case ConversionRestrictionKind::CGFloatToDouble:
-    case ConversionRestrictionKind::DoubleToCGFloat: {
+    case ConversionRestrictionKind::DoubleToCGFloat:
+    case ConversionRestrictionKind::DurationToTimeInterval:
+    case ConversionRestrictionKind::TimeIntervalToDuration: {
       auto conversionKind = knownRestriction->second;
 
       auto *argExpr = locator.trySimplifyToExpr();

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -553,6 +553,11 @@ void BindingSet::addBinding(PotentialBinding binding) {
           return binding.BindingType->isDouble();
         }))
       return;
+    if (type->isTimeIntervalType() &&
+        llvm::any_of(Bindings, [](const PotentialBinding &binding) {
+          return binding.BindingType->isDurationType();
+        }))
+      return;
 
     if (type->isDouble()) {
       auto inferredCGFloat =
@@ -563,6 +568,18 @@ void BindingSet::addBinding(PotentialBinding binding) {
       if (inferredCGFloat != Bindings.end()) {
         Bindings.erase(inferredCGFloat);
         Bindings.insert(inferredCGFloat->withType(type));
+        return;
+      }
+    }
+    if (type->isDurationType()) {
+      auto inferredTimeInterval =
+          llvm::find_if(Bindings, [](const PotentialBinding &binding) {
+            return binding.BindingType->isTimeIntervalType();
+          });
+
+      if (inferredTimeInterval != Bindings.end()) {
+        Bindings.erase(inferredTimeInterval);
+        Bindings.insert(inferredTimeInterval->withType(type));
         return;
       }
     }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3564,7 +3564,6 @@ bool MissingMemberFailure::diagnoseAsError() {
 
   auto emitBasicError = [&](Type baseType) {
     auto diagnostic = diag::could_not_find_value_member;
-
     if (auto *metatype = baseType->getAs<MetatypeType>()) {
       baseType = metatype->getInstanceType();
       diagnostic = diag::could_not_find_type_member;
@@ -6724,6 +6723,8 @@ void NonEphemeralConversionFailure::emitSuggestionNotes() const {
   case ConversionRestrictionKind::ObjCTollFreeBridgeToCF:
   case ConversionRestrictionKind::CGFloatToDouble:
   case ConversionRestrictionKind::DoubleToCGFloat:
+  case ConversionRestrictionKind::DurationToTimeInterval:
+  case ConversionRestrictionKind::TimeIntervalToDuration:
     llvm_unreachable("Expected an ephemeral conversion!");
   }
 }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -385,6 +385,8 @@ namespace {
     // Don't favor narrowing conversions.
     if (argTy->isDouble() && paramTy->isCGFloatType())
       return false;
+    if (argTy->isDurationType() && paramTy->isTimeIntervalType())
+      return false;
 
     llvm::SmallSetVector<ProtocolDecl *, 2> literalProtos;
     if (auto argTypeVar = argTy->getAs<TypeVariableType>()) {
@@ -420,7 +422,8 @@ namespace {
         // it is the same as the parameter type.
         // Check whether there is a default type to compare against.
         if (paramTy->isEqual(defaultType) ||
-            (defaultType->isDouble() && paramTy->isCGFloatType()))
+            (defaultType->isDouble() && paramTy->isCGFloatType()) ||
+            (defaultType->isDurationType() && paramTy->isTimeIntervalType()))
           return true;
       }
     }
@@ -561,6 +564,8 @@ namespace {
       // which would result in conversion from CGFloat to Double; otherwise
       // it would lead to ambiguities.
       if (argTy->isCGFloatType() && paramTy->isDouble())
+        return false;
+      if (argTy->isTimeIntervalType() && paramTy->isDurationType())
         return false;
 
       return isFavoredParamAndArg(CS, paramTy, argTy) &&
@@ -721,8 +726,12 @@ namespace {
       {
         if (firstArgTy->isDouble() && firstParamTy->isCGFloatType())
           return false;
+        if (firstArgTy->isDurationType() && firstParamTy->isTimeIntervalType())
+          return false;
 
         if (secondArgTy->isDouble() && secondParamTy->isCGFloatType())
+          return false;
+        if (secondArgTy->isDurationType() && secondParamTy->isTimeIntervalType())
           return false;
       }
 

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -610,6 +610,10 @@ StringRef swift::constraints::getName(ConversionRestrictionKind kind) {
     return "[CGFloat-to-Double]";
   case ConversionRestrictionKind::DoubleToCGFloat:
     return "[Double-to-CGFloat]";
+  case ConversionRestrictionKind::TimeIntervalToDuration:
+    return "[TimeInterval-to-Duration]";
+  case ConversionRestrictionKind::DurationToTimeInterval:
+    return "[Duration-to-TimeInterval]";
   }
   llvm_unreachable("bad conversion restriction kind");
 }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -453,7 +453,9 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
   if (auto conversion =
           locator->findLast<LocatorPathElt::ImplicitConversion>()) {
     if (conversion->is(ConversionRestrictionKind::DoubleToCGFloat) ||
-        conversion->is(ConversionRestrictionKind::CGFloatToDouble)) {
+        conversion->is(ConversionRestrictionKind::CGFloatToDouble) ||
+        conversion->is(ConversionRestrictionKind::DurationToTimeInterval) ||
+        conversion->is(ConversionRestrictionKind::TimeIntervalToDuration)) {
       return getConstraintLocator(
           ASTNode(), {*conversion, ConstraintLocator::ApplyFunction,
                       ConstraintLocator::ConstructorMember});
@@ -5269,6 +5271,8 @@ ConstraintSystem::isConversionEphemeral(ConversionRestrictionKind conversion,
   case ConversionRestrictionKind::ObjCTollFreeBridgeToCF:
   case ConversionRestrictionKind::CGFloatToDouble:
   case ConversionRestrictionKind::DoubleToCGFloat:
+  case ConversionRestrictionKind::DurationToTimeInterval:
+  case ConversionRestrictionKind::TimeIntervalToDuration:
     // @_nonEphemeral has no effect on these conversions, so treat them as all
     // being non-ephemeral in order to allow their passing to an @_nonEphemeral
     // parameter.

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -109,6 +109,10 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   AsyncThrowingStream.swift
   AsyncStream.cpp
   Deque.swift
+  Clock.swift
+  MonotonicClock.swift
+  UptimeClock.swift
+  WallClock.swift
   ${swift_concurrency_extra_sources}
   linker-support/magic-symbols-for-install-name.c
 

--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+public protocol ClockProtocol: Sendable {
+  associatedtype Instant: InstantProtocol
+  
+  var now: Instant { get }
+  
+  func sleep(until deadline: Instant) async throws
+}

--- a/stdlib/public/Concurrency/MonotonicClock.swift
+++ b/stdlib/public/Concurrency/MonotonicClock.swift
@@ -1,0 +1,129 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import Swift
+
+@_silgen_name("swift_get_time")
+@usableFromInline
+func _getTime(
+  absoluteNanoseconds: UnsafeMutablePointer<UInt64>?,
+  continuousNanoseconds: UnsafeMutablePointer<UInt64>?,
+  realtimeSeconds: UnsafeMutablePointer<Int64>?,
+  realtimeNanoseconds: UnsafeMutablePointer<Int64>?
+)
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+public struct MonotonicClock {
+  public struct Instant: Codable, Sendable {
+    var nanoseconds: UInt64
+    
+    init(nanoseconds: UInt64) {
+      self.nanoseconds = nanoseconds
+    }
+    
+    public init?(converting deadline: Date) {
+      var monotonicNanoseconds = UInt64(0)
+      var realtimeSeconds = Int64(0)
+      var realtimeNanoseconds = Int64(0)
+      _getTime(
+        absoluteNanoseconds: nil,
+        continuousNanoseconds: &monotonicNanoseconds,
+        realtimeSeconds: &realtimeSeconds, realtimeNanoseconds: &realtimeNanoseconds
+      )
+      let monotonicNow = Instant(nanoseconds: monotonicNanoseconds)
+      let realtimeNow = Date(durationSince1970: .seconds(realtimeSeconds) + .nanoseconds(realtimeNanoseconds))
+      
+      let duration = realtimeNow.duration(to: deadline)
+      if duration > Duration.nanoseconds(Int64.max) {
+        return nil
+      }
+      self = monotonicNow.advanced(by: duration)
+    }
+  }
+}
+
+extension Date {
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+  public init(converting deadline: MonotonicClock.Instant) {
+    var monotonicNanoseconds = UInt64(0)
+    var realtimeSeconds = Int64(0)
+    var realtimeNanoseconds = Int64(0)
+    _getTime(
+      absoluteNanoseconds: nil,
+      continuousNanoseconds: &monotonicNanoseconds,
+      realtimeSeconds: &realtimeSeconds, realtimeNanoseconds: &realtimeNanoseconds
+    )
+    
+    let realtimeNow = Date(durationSince1970: .seconds(realtimeSeconds) + .nanoseconds(realtimeNanoseconds))
+    let monotonicNow = MonotonicClock.Instant(nanoseconds: monotonicNanoseconds)
+    let duration = monotonicNow.duration(to: deadline)
+    self = realtimeNow.advanced(by: .nanoseconds(duration.nanoseconds))
+  }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+extension ClockProtocol where Self == MonotonicClock {
+  public static var monotonic: MonotonicClock { return MonotonicClock() }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+extension MonotonicClock: ClockProtocol {
+  public var now: MonotonicClock.Instant {
+    MonotonicClock.now
+  }
+  
+  public static var now: MonotonicClock.Instant {
+    var nanoseconds = UInt64(0)
+    _getTime(
+      absoluteNanoseconds: nil,
+      continuousNanoseconds: &nanoseconds,
+      realtimeSeconds: nil, realtimeNanoseconds: nil
+    )
+    return MonotonicClock.Instant(nanoseconds: nanoseconds)
+  }
+  
+  public func sleep(until deadline: Instant) async throws {
+    try await Task.sleep(until: 0, deadline.nanoseconds, clockId: .monotonic)
+  }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+extension MonotonicClock.Instant: InstantProtocol {
+  public static var now: MonotonicClock.Instant { MonotonicClock.now }
+  
+  public func advanced(by duration: Duration) -> MonotonicClock.Instant {
+    if duration > .zero {
+      return MonotonicClock.Instant(nanoseconds: nanoseconds + duration.seconds.magnitude * 1000000000 + duration.nanoseconds.magnitude)
+    } else {
+      return MonotonicClock.Instant(nanoseconds: nanoseconds - (duration.seconds.magnitude * 1000000000 + duration.nanoseconds.magnitude))
+    }
+  }
+  
+  public func duration(to other: MonotonicClock.Instant) -> Duration {
+    if other.nanoseconds > nanoseconds {
+      return .nanoseconds(other.nanoseconds - nanoseconds)
+    } else {
+      return .nanoseconds(-Int64(nanoseconds - other.nanoseconds))
+    }
+  }
+  
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(nanoseconds)
+  }
+  
+  public static func == (_ lhs: MonotonicClock.Instant, _ rhs: MonotonicClock.Instant) -> Bool {
+    return lhs.nanoseconds == rhs.nanoseconds
+  }
+  
+  public static func < (_ lhs: MonotonicClock.Instant, _ rhs: MonotonicClock.Instant) -> Bool {
+    return lhs.nanoseconds < rhs.nanoseconds
+  }
+}

--- a/stdlib/public/Concurrency/MonotonicClock.swift
+++ b/stdlib/public/Concurrency/MonotonicClock.swift
@@ -29,7 +29,7 @@ public struct MonotonicClock {
       self.nanoseconds = nanoseconds
     }
     
-    public init?(converting deadline: Date) {
+    public init?(converting deadline: _Date) {
       var monotonicNanoseconds = UInt64(0)
       var realtimeSeconds = Int64(0)
       var realtimeNanoseconds = Int64(0)
@@ -39,7 +39,7 @@ public struct MonotonicClock {
         realtimeSeconds: &realtimeSeconds, realtimeNanoseconds: &realtimeNanoseconds
       )
       let monotonicNow = Instant(nanoseconds: monotonicNanoseconds)
-      let realtimeNow = Date(durationSince1970: .seconds(realtimeSeconds) + .nanoseconds(realtimeNanoseconds))
+      let realtimeNow = _Date(durationSince1970: .seconds(realtimeSeconds) + .nanoseconds(realtimeNanoseconds))
       
       let duration = realtimeNow.duration(to: deadline)
       if duration > Duration.nanoseconds(Int64.max) {
@@ -50,8 +50,8 @@ public struct MonotonicClock {
   }
 }
 
-extension Date {
-  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+extension _Date {
   public init(converting deadline: MonotonicClock.Instant) {
     var monotonicNanoseconds = UInt64(0)
     var realtimeSeconds = Int64(0)
@@ -62,7 +62,7 @@ extension Date {
       realtimeSeconds: &realtimeSeconds, realtimeNanoseconds: &realtimeNanoseconds
     )
     
-    let realtimeNow = Date(durationSince1970: .seconds(realtimeSeconds) + .nanoseconds(realtimeNanoseconds))
+    let realtimeNow = _Date(durationSince1970: .seconds(realtimeSeconds) + .nanoseconds(realtimeNanoseconds))
     let monotonicNow = MonotonicClock.Instant(nanoseconds: monotonicNanoseconds)
     let duration = monotonicNow.duration(to: deadline)
     self = realtimeNow.advanced(by: .nanoseconds(duration.nanoseconds))

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -751,6 +751,10 @@ func _enqueueJobGlobal(_ task: Builtin.Job)
 @usableFromInline
 func _enqueueJobGlobalWithDelay(_ delay: UInt64, _ task: Builtin.Job)
 
+@_silgen_name("swift_task_enqueueGlobalWithDeadline")
+@usableFromInline
+func _enqueueJobGlobalWithDeadline(_ seconds: UInt64, _ nanoseconds: UInt64, _ clock: Int, _ task: Builtin.Job)
+
 @available(SwiftStdlib 5.5, *)
 @_silgen_name("swift_task_asyncMainDrainQueue")
 internal func _asyncMainDrainQueue() -> Never

--- a/stdlib/public/Concurrency/UptimeClock.swift
+++ b/stdlib/public/Concurrency/UptimeClock.swift
@@ -21,7 +21,7 @@ public struct UptimeClock {
       self.nanoseconds = nanoseconds
     }
   
-    public init?(converting deadline: Date) {
+    public init?(converting deadline: _Date) {
       var absoluteNanoseconds = UInt64(0)
       var realtimeSeconds = Int64(0)
       var realtimeNanoseconds = Int64(0)
@@ -31,7 +31,7 @@ public struct UptimeClock {
         realtimeSeconds: &realtimeSeconds, realtimeNanoseconds: &realtimeNanoseconds
       )
       let monotonicNow = Instant(nanoseconds: absoluteNanoseconds)
-      let realtimeNow = Date(durationSince1970: .seconds(realtimeSeconds) + .nanoseconds(realtimeNanoseconds))
+      let realtimeNow = _Date(durationSince1970: .seconds(realtimeSeconds) + .nanoseconds(realtimeNanoseconds))
       
       let duration = realtimeNow.duration(to: deadline)
       if duration > Duration.nanoseconds(Int64.max) {

--- a/stdlib/public/Concurrency/UptimeClock.swift
+++ b/stdlib/public/Concurrency/UptimeClock.swift
@@ -1,0 +1,103 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+public struct UptimeClock {
+  public struct Instant: Codable, Sendable {
+    var nanoseconds: UInt64
+    
+    init(nanoseconds: UInt64) {
+      self.nanoseconds = nanoseconds
+    }
+  
+    public init?(converting deadline: Date) {
+      var absoluteNanoseconds = UInt64(0)
+      var realtimeSeconds = Int64(0)
+      var realtimeNanoseconds = Int64(0)
+      _getTime(
+        absoluteNanoseconds: &absoluteNanoseconds,
+        continuousNanoseconds: nil,
+        realtimeSeconds: &realtimeSeconds, realtimeNanoseconds: &realtimeNanoseconds
+      )
+      let monotonicNow = Instant(nanoseconds: absoluteNanoseconds)
+      let realtimeNow = Date(durationSince1970: .seconds(realtimeSeconds) + .nanoseconds(realtimeNanoseconds))
+      
+      let duration = realtimeNow.duration(to: deadline)
+      if duration > Duration.nanoseconds(Int64.max) {
+        return nil
+      }
+      self = monotonicNow.advanced(by: duration)
+    }
+  }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+extension ClockProtocol where Self == UptimeClock {
+  public static var uptime: UptimeClock { return UptimeClock() }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+extension UptimeClock: ClockProtocol {
+  public var now: UptimeClock.Instant {
+    UptimeClock.now
+  }
+  
+  public static var now: UptimeClock.Instant {
+    var nanoseconds = UInt64(0)
+    _getTime(
+      absoluteNanoseconds: &nanoseconds,
+      continuousNanoseconds: nil,
+      realtimeSeconds: nil, realtimeNanoseconds: nil
+    )
+    return UptimeClock.Instant(nanoseconds: nanoseconds)
+  }
+  
+  public func sleep(until deadline: Instant) async throws {
+    try await Task.sleep(until: 0, deadline.nanoseconds, clockId: .uptime)
+  }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+extension UptimeClock.Instant: InstantProtocol {
+  public static var now: UptimeClock.Instant { UptimeClock().now }
+  
+  public func advanced(by duration: Duration) -> UptimeClock.Instant {
+    if duration > .zero {
+      return UptimeClock.Instant(nanoseconds: nanoseconds + duration.seconds.magnitude * 1000000000 + duration.nanoseconds.magnitude)
+    } else {
+      return UptimeClock.Instant(nanoseconds: nanoseconds - (duration.seconds.magnitude * 1000000000 + duration.nanoseconds.magnitude))
+    }
+  }
+  
+  public func duration(to other: UptimeClock.Instant) -> Duration {
+    if other.nanoseconds > nanoseconds {
+      return .nanoseconds(other.nanoseconds - nanoseconds)
+    } else {
+      return .nanoseconds(-Int64(nanoseconds - other.nanoseconds))
+    }
+  }
+  
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(nanoseconds)
+  }
+  
+  public static func == (_ lhs: UptimeClock.Instant, _ rhs: UptimeClock.Instant) -> Bool {
+    return lhs.nanoseconds == rhs.nanoseconds
+  }
+  
+  public static func < (_ lhs: UptimeClock.Instant, _ rhs: UptimeClock.Instant) -> Bool {
+    return lhs.nanoseconds < rhs.nanoseconds
+  }
+}
+

--- a/stdlib/public/Concurrency/WallClock.swift
+++ b/stdlib/public/Concurrency/WallClock.swift
@@ -22,15 +22,15 @@ extension ClockProtocol where Self == WallClock {
 
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
 extension WallClock: ClockProtocol {
-  public var now: Date {
-    Date.now
+  public var now: _Date {
+    _Date.now
   }
   
-  public static var now: Date {
-    Date.now
+  public static var now: _Date {
+    _Date.now
   }
   
-  public func sleep(until deadline: Date) async throws {
+  public func sleep(until deadline: _Date) async throws {
     if deadline.durationSince1970 > .zero {
       try await Task.sleep(until: 
         UInt64(deadline.durationSince1970.seconds), 

--- a/stdlib/public/Concurrency/WallClock.swift
+++ b/stdlib/public/Concurrency/WallClock.swift
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+public struct WallClock { }
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+extension ClockProtocol where Self == WallClock {
+  public static var wall: WallClock { return WallClock() }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+extension WallClock: ClockProtocol {
+  public var now: Date {
+    Date.now
+  }
+  
+  public static var now: Date {
+    Date.now
+  }
+  
+  public func sleep(until deadline: Date) async throws {
+    if deadline.durationSince1970 > .zero {
+      try await Task.sleep(until: 
+        UInt64(deadline.durationSince1970.seconds), 
+        UInt64(deadline.durationSince1970.nanoseconds), 
+        clockId: .wall)
+    }
+  }
+}

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -193,7 +193,11 @@ set(SWIFTLIB_ESSENTIAL
   StringGraphemeBreaking.swift # ORDER DEPENDENCY: Must follow UTF16.swift
   ValidUTF8Buffer.swift
   WriteBackMutableSlice.swift
-  MigrationSupport.swift)
+  MigrationSupport.swift
+  Duration.swift
+  Instant.swift
+  Date.swift
+  )
 
 set(SWIFTLIB_ESSENTIAL_GYB_SOURCES
   AtomicInt.swift.gyb

--- a/stdlib/public/core/Date.swift
+++ b/stdlib/public/core/Date.swift
@@ -19,18 +19,15 @@ func _getTime(
   realtimeNanoseconds: UnsafeMutablePointer<Int64>?
 )
 
-@available(macOS 10.9, iOS 7.0, tvOS 9.0, watchOS 2.0, macCatalyst 13.0, *)
-@_originallyDefinedIn(module: "Foundation", 
-  macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999)
-public struct Date {
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+public struct _Date {
   public var durationSince1970: Duration
   
   public init(durationSince1970: Duration) {
     self.durationSince1970 = durationSince1970
   }
 
-  @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-  public static var now: Date { 
+  public static var now: _Date { 
     var realtimeSeconds = Int64(0)
     var realtimeNanoseconds = Int64(0)
     _getTime(
@@ -39,40 +36,43 @@ public struct Date {
       realtimeSeconds: &realtimeSeconds, 
       realtimeNanoseconds: &realtimeNanoseconds
     )
-    return Date(durationSince1970: 
+    return _Date(durationSince1970: 
       .seconds(realtimeSeconds) + .nanoseconds(realtimeNanoseconds))
   }
 }
 
-extension Date: Equatable {
-  public static func == (lhs: Date, rhs: Date) -> Bool {
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+extension _Date: Equatable {
+  public static func == (lhs: _Date, rhs: _Date) -> Bool {
     return lhs.durationSince1970 == rhs.durationSince1970
   }
 }
 
-extension Date: Hashable {
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+extension _Date: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(durationSince1970)
   }
 }
 
-extension Date: Comparable {
-  public static func < (lhs: Date, rhs: Date) -> Bool {
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+extension _Date: Comparable {
+  public static func < (lhs: _Date, rhs: _Date) -> Bool {
     lhs.durationSince1970 < rhs.durationSince1970
   }
   
-  public static func > (lhs: Date, rhs: Date) -> Bool {
+  public static func > (lhs: _Date, rhs: _Date) -> Bool {
     lhs.durationSince1970 > rhs.durationSince1970
   }
 }
 
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
-extension Date: InstantProtocol {
-  public func advanced(by duration: Duration) -> Date {
-    Date(durationSince1970: durationSince1970 + duration)
+extension _Date: InstantProtocol {
+  public func advanced(by duration: Duration) -> _Date {
+    _Date(durationSince1970: durationSince1970 + duration)
   }
   
-  public func duration(to other: Date) -> Duration {
+  public func duration(to other: _Date) -> Duration {
     return other.durationSince1970 - durationSince1970
   }
 }

--- a/stdlib/public/core/Date.swift
+++ b/stdlib/public/core/Date.swift
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_silgen_name("swift_get_time")
+@usableFromInline
+func _getTime(
+  absoluteNanoseconds: UnsafeMutablePointer<UInt64>?,
+  continuousNanoseconds: UnsafeMutablePointer<UInt64>?,
+  realtimeSeconds: UnsafeMutablePointer<Int64>?,
+  realtimeNanoseconds: UnsafeMutablePointer<Int64>?
+)
+
+@available(macOS 10.9, iOS 7.0, tvOS 9.0, watchOS 2.0, macCatalyst 13.0, *)
+@_originallyDefinedIn(module: "Foundation", 
+  macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999)
+public struct Date {
+  public var durationSince1970: Duration
+  
+  public init(durationSince1970: Duration) {
+    self.durationSince1970 = durationSince1970
+  }
+
+  @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+  public static var now: Date { 
+    var realtimeSeconds = Int64(0)
+    var realtimeNanoseconds = Int64(0)
+    _getTime(
+      absoluteNanoseconds: nil,
+      continuousNanoseconds: nil,
+      realtimeSeconds: &realtimeSeconds, 
+      realtimeNanoseconds: &realtimeNanoseconds
+    )
+    return Date(durationSince1970: 
+      .seconds(realtimeSeconds) + .nanoseconds(realtimeNanoseconds))
+  }
+}
+
+extension Date: Equatable {
+  public static func == (lhs: Date, rhs: Date) -> Bool {
+    return lhs.durationSince1970 == rhs.durationSince1970
+  }
+}
+
+extension Date: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(durationSince1970)
+  }
+}
+
+extension Date: Comparable {
+  public static func < (lhs: Date, rhs: Date) -> Bool {
+    lhs.durationSince1970 < rhs.durationSince1970
+  }
+  
+  public static func > (lhs: Date, rhs: Date) -> Bool {
+    lhs.durationSince1970 > rhs.durationSince1970
+  }
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+extension Date: InstantProtocol {
+  public func advanced(by duration: Duration) -> Date {
+    Date(durationSince1970: durationSince1970 + duration)
+  }
+  
+  public func duration(to other: Date) -> Duration {
+    return other.durationSince1970 - durationSince1970
+  }
+}

--- a/stdlib/public/core/Duration.swift
+++ b/stdlib/public/core/Duration.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
 @frozen
 public struct Duration: Sendable {
   @frozen
@@ -80,6 +81,7 @@ public struct Duration: Sendable {
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
 extension Duration {
   @inlinable
   public static func seconds<T: BinaryInteger>(_ seconds: T) -> Duration {
@@ -129,10 +131,13 @@ extension Duration {
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
 extension Duration: Codable { }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
 extension Duration: Hashable { }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
 extension Duration: Equatable {
   @inlinable
   public static func == (_ lhs: Duration, _ rhs: Duration) -> Bool {
@@ -140,6 +145,7 @@ extension Duration: Equatable {
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
 extension Duration: Comparable {
   @inlinable
   public static func < (_ lhs: Duration, _ rhs: Duration) -> Bool {
@@ -149,6 +155,7 @@ extension Duration: Comparable {
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
 extension Duration: AdditiveArithmetic {
   @inlinable
   public static var zero: Duration { Duration(_seconds: 0, nanoseconds: 0) }
@@ -174,6 +181,7 @@ extension Duration: AdditiveArithmetic {
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
 extension Duration {
   @inlinable
   public static func / (_ lhs: Duration, _ rhs: Double) -> Duration {
@@ -211,6 +219,7 @@ extension Duration {
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
 extension Duration: CustomStringConvertible {
   @inlinable
   public var description: String {

--- a/stdlib/public/core/Duration.swift
+++ b/stdlib/public/core/Duration.swift
@@ -1,0 +1,219 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@frozen
+public struct Duration: Sendable {
+  @frozen
+  @usableFromInline
+  struct Bits: Sendable, Codable, Hashable, Equatable {
+    @inlinable
+    static var nanosecondMask: UInt64 { 0x000000003FFFFFFF }
+    
+    @inlinable
+    static var secondsSignFlags: UInt64 { 0x8000000000000000 }
+    
+    @inlinable
+    static var nanosecondsSignFlags: UInt64 { 0x8000000000000000 }
+
+    @usableFromInline
+    var high: UInt64
+    
+    @usableFromInline
+    var low: UInt64
+    
+    @usableFromInline
+    init(high: UInt64, low: UInt64) {
+      self.high = high
+      self.low = low
+    }
+  }
+  
+  @usableFromInline
+  var bits: Bits
+  
+  @inlinable
+  public var seconds: Int64 {
+    if _sign.0 {
+      return -Int64(bits.high)
+    } else {
+      return Int64(bits.high)
+    }
+  }
+  
+  @inlinable
+  public var nanoseconds: Int64 {
+    if _sign.1 {
+      return -Int64(bitPattern: bits.low & Bits.nanosecondMask)
+    } else {
+      return Int64(bitPattern: bits.low & Bits.nanosecondMask)
+    }
+  }
+  
+  @inlinable
+  public var _sign: (Bool, Bool) {
+    return ((bits.high & Bits.secondsSignFlags) != 0, (bits.low & Bits.nanosecondsSignFlags) != 0)
+  }
+  
+  @inlinable
+  public init(_seconds seconds: Int64, nanoseconds: Int64) {
+    
+    let additionalSeconds = nanoseconds / 1000000000
+    let s = seconds + Int64(additionalSeconds)
+    let ns = nanoseconds - (additionalSeconds * 1000000000)
+    
+    bits = Bits(high: s.magnitude, low: ns.magnitude & Bits.nanosecondMask)
+    if seconds < 0  {
+      bits.low |= Bits.secondsSignFlags
+    }
+    if nanoseconds < 0 {
+      bits.low |= Bits.nanosecondsSignFlags
+    }
+  }
+}
+
+extension Duration {
+  @inlinable
+  public static func seconds<T: BinaryInteger>(_ seconds: T) -> Duration {
+    return Duration(_seconds: Int64(seconds), nanoseconds: 0)
+  }
+  
+  @inlinable
+  public static func seconds(_ seconds: Double) -> Duration {
+    let s = Int64(seconds)
+    let ns = Int64((seconds - Double(s)) * 1_000_000_000)
+    return Duration(_seconds: s, nanoseconds: ns)
+  }
+  
+  @inlinable
+  public static func milliseconds<T: BinaryInteger>(_ milliseconds: T) -> Duration {
+    let s = milliseconds / 1000
+    let ns = (milliseconds - s * 1000) * 1000000
+    return Duration(_seconds: Int64(s), nanoseconds: Int64(ns))
+  }
+  
+  @inlinable
+  public static func milliseconds(_ milliseconds: Double) -> Duration {
+    let s = Int64(milliseconds / 1000.0)
+    let ns = Int64((milliseconds - Double(s) * 1000) * 1000000)
+    return Duration(_seconds: s, nanoseconds: ns)
+  }
+  
+  @inlinable
+  public static func microseconds<T: BinaryInteger>(_ microseconds: T) -> Duration {
+    let s = microseconds / 1000000
+    let ns = (microseconds - s * 1000000) * 1000
+    return Duration(_seconds: Int64(s), nanoseconds: Int64(ns))
+  }
+  
+  @inlinable
+  public static func microseconds(_ microseconds: Double) -> Duration {
+    let s = Int64(microseconds / 1000000.0)
+    let ns = Int64((microseconds - Double(s) * 1000000) * 1000)
+    return Duration(_seconds: s, nanoseconds: ns)
+  }
+  
+  @inlinable
+  public static func nanoseconds<T: BinaryInteger>(_ nanoseconds: T) -> Duration {
+    let s = nanoseconds / 1000000000
+    let ns = nanoseconds - s * 1000000000
+    return Duration(_seconds: Int64(s), nanoseconds: Int64(ns))
+  }
+}
+
+extension Duration: Codable { }
+
+extension Duration: Hashable { }
+
+extension Duration: Equatable {
+  @inlinable
+  public static func == (_ lhs: Duration, _ rhs: Duration) -> Bool {
+    return lhs.bits == rhs.bits
+  }
+}
+
+extension Duration: Comparable {
+  @inlinable
+  public static func < (_ lhs: Duration, _ rhs: Duration) -> Bool {
+    if lhs.seconds < rhs.seconds { return true }
+    if lhs.seconds > rhs.seconds { return false }
+    return lhs.nanoseconds < rhs.nanoseconds
+  }
+}
+
+extension Duration: AdditiveArithmetic {
+  @inlinable
+  public static var zero: Duration { Duration(_seconds: 0, nanoseconds: 0) }
+   
+  @inlinable
+  public static func + (_ lhs: Duration, _ rhs: Duration) -> Duration {
+    return Duration(_seconds: lhs.seconds + rhs.seconds, nanoseconds: lhs.nanoseconds + rhs.nanoseconds)
+  }
+  
+  @inlinable
+  public static func - (_ lhs: Duration, _ rhs: Duration) -> Duration {
+    return Duration(_seconds: lhs.seconds - rhs.seconds, nanoseconds: lhs.nanoseconds - rhs.nanoseconds)
+  }
+  
+  @inlinable
+  public static func += (_ lhs: inout Duration, _ rhs: Duration) {
+    lhs = lhs + rhs
+  }
+  
+  @inlinable
+  public static func -= (_ lhs: inout Duration, _ rhs: Duration) {
+    lhs = lhs - rhs
+  }
+}
+
+extension Duration {
+  @inlinable
+  public static func / (_ lhs: Duration, _ rhs: Double) -> Duration {
+    return Duration.nanoseconds(Int64(Double(lhs.seconds * 1000000000 + lhs.nanoseconds) / rhs))
+  }
+  
+  @inlinable
+  public static func /= (_ lhs: inout Duration, _ rhs: Double) {
+    lhs = lhs / rhs
+  }
+  
+  @inlinable
+  public static func / <T: BinaryInteger>(_ lhs: Duration, _ rhs: T) -> Duration {
+    return Duration.nanoseconds(T(lhs.seconds * 1000000000 + lhs.nanoseconds) / rhs)
+  }
+  
+  @inlinable
+  public static func /= <T: BinaryInteger>(_ lhs: inout Duration, _ rhs: T) {
+    lhs = lhs / rhs
+  }
+  
+  @inlinable
+  public static func / (_ lhs: Duration, _ rhs: Duration) -> Double {
+    return (Double(lhs.seconds) * 1000000000.0 + Double(lhs.nanoseconds)) / (Double(rhs.seconds) * 1000000000.0 + Double(rhs.nanoseconds))
+  }
+  
+  @inlinable
+  public static func * (_ lhs: Duration, _ rhs: Double) -> Duration {
+    return Duration(_seconds: Int64(Double(lhs.seconds) * rhs), nanoseconds: Int64(Double(lhs.nanoseconds) * rhs))
+  }
+  
+  @inlinable
+  public static func * <T: BinaryInteger>(_ lhs: Duration, _ rhs: T) -> Duration {
+    return Duration(_seconds: Int64(T(lhs.seconds) * rhs), nanoseconds: Int64(T(lhs.nanoseconds) * rhs))
+  }
+}
+
+extension Duration: CustomStringConvertible {
+  @inlinable
+  public var description: String {
+    return (Double(seconds) + Double(nanoseconds) / 1_000_000_000.0).description + " seconds"
+  }
+}

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -231,7 +231,14 @@
     "Codable.swift",
     "LegacyABI.swift",
     "MigrationSupport.swift",
-    "PtrAuth.swift"
+    "PtrAuth.swift",
+    
+  ],
+  "Clock": [
+    "Clock.swift",
+    "Date.swift",
+    "Duration.swift",
+    "Instant.swift"
   ],
   "Result": [
     "Result.swift"

--- a/stdlib/public/core/Instant.swift
+++ b/stdlib/public/core/Instant.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+public protocol InstantProtocol: Comparable, Hashable, Sendable {
+  func advanced(by duration: Duration) -> Self
+  func duration(to other: Self) -> Duration
+}
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, macCatalyst 9999, *)
+extension InstantProtocol {
+  public static func + (_ lhs: Self, _ rhs: Duration) -> Self {
+    lhs.advanced(by: rhs)
+  }
+  
+  public static func += (_ lhs: inout Self, _ rhs: Duration) {
+    lhs = lhs.advanced(by: rhs)
+  }
+  
+  public static func - (_ lhs: Self, _ rhs: Duration) -> Self {
+    lhs.advanced(by: .zero - rhs)
+  }
+  
+  public static func -= (_ lhs: inout Self, _ rhs: Duration) {
+    lhs = lhs.advanced(by: .zero - rhs)
+  }
+  
+  public static func - (_ lhs: Self, _ rhs: Self) -> Duration {
+    rhs.duration(to: lhs)
+  }
+}

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -68,7 +68,8 @@ set(swift_runtime_sources
     ReflectionMirror.cpp
     RuntimeInvocationsTracking.cpp
     SwiftDtoa.cpp
-    SwiftTLSContext.cpp)
+    SwiftTLSContext.cpp
+    Time.cpp)
 
 # Acknowledge that the following sources are known.
 set(LLVM_OPTIONAL_SOURCES

--- a/stdlib/public/runtime/Time.cpp
+++ b/stdlib/public/runtime/Time.cpp
@@ -1,0 +1,91 @@
+//===--- Time.cpp ---------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Once.h"
+
+#if __has_include(<time.h>)
+#define HAS_TIME 1
+#include <time.h>
+#endif 
+
+#if __has_include(<System/mach/mach_time.h>)
+#define HAS_MACH_GET_TIMES 1
+#define HAS_MACH_TIME 1
+#include <System/mach/mach_time.h>
+#elif __has_include(<mach/mach_time.h>)
+#define HAS_MACH_TIME 1
+#include <mach/mach_time.h>
+#endif
+
+using namespace swift;
+
+#if HAS_MACH_TIME
+static struct mach_timebase_info timebaseInfo;
+static swift_once_t computedInfo = SWIFT_ONCE_INIT;
+
+static void _calculateTimebase(void *unused) {
+  mach_timebase_info(&timebaseInfo);
+}
+
+static inline struct mach_timebase_info calculateTimebase(void) {
+  swift_once(&computedInfo, _calculateTimebase, nullptr);
+  return timebaseInfo;
+}
+#endif
+
+SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift)
+void swift_get_time(
+  unsigned long long *_Nullable absoluteNanoseconds,
+  unsigned long long *_Nullable continuousNanoseconds,
+  long long *_Nullable realtimeSeconds,
+  long long *_Nullable realtimeNanoseconds) {
+  
+#if defined(__linux__) && HAS_TIME
+  struct timespec monotonic;
+  struct timespec uptime;
+  struct timespec realtime;
+  clock_gettime(CLOCK_MONOTONIC, &monotonic);
+  clock_gettime(CLOCK_BOOTTIME, &uptime);
+  clock_gettime(CLOCK_REALTIME, &realtime);
+
+  if (absoluteNanoseconds) *absoluteNanoseconds = monotonic.tv_sec * 1000000000 + monotonic.tv_nsec;
+  if (continuousNanoseconds) *continuousNanoseconds = uptime.tv_sec * 1000000000 + uptime.tv_nsec;
+  if (realtimeSeconds) *realtimeSeconds = realtime.tv_sec;
+  if (realtimeNanoseconds) *realtimeNanoseconds = realtime.tv_nsec;
+  
+#elif HAS_MACH_GET_TIMES
+  struct mach_timebase_info info = calculateTimebase();
+  
+  uint64_t absolute;
+  uint64_t continuous;
+  struct timespec realtime;
+  mach_get_times(&absolute, &continuous, &realtime);
+  if (absoluteNanoseconds) *absoluteNanoseconds = (absolute * info.numer) / info.denom;
+  if (continuousNanoseconds) *continuousNanoseconds = (continuous * info.numer) / info.denom;
+  if (realtimeSeconds) *realtimeSeconds = realtime.tv_sec;
+  if (realtimeNanoseconds) *realtimeNanoseconds = realtime.tv_nsec;
+#elif defined(__APPLE__) && HAS_TIME
+  struct timespec monotonic;
+  struct timespec uptime;
+  struct timespec realtime;
+  clock_gettime(CLOCK_MONOTONIC, &monotonic);
+  clock_gettime(CLOCK_UPTIME_RAW, &uptime);
+  clock_gettime(CLOCK_REALTIME, &realtime);
+  if (absoluteNanoseconds) *absoluteNanoseconds = uptime.tv_sec * 1000000000 + uptime.tv_nsec;
+  if (continuousNanoseconds) *continuousNanoseconds = monotonic.tv_sec * 1000000000 + monotonic.tv_nsec;
+  if (realtimeSeconds) *realtimeSeconds = realtime.tv_sec;
+  if (realtimeNanoseconds) *realtimeNanoseconds = realtime.tv_nsec;
+#else
+#error Missing Time!
+#endif
+}


### PR DESCRIPTION
This is a work in progress implementation of the pitch https://forums.swift.org/t/pitch-clock-instant-date-and-duration/52451

Currently this has no interoperation with TimeInterval or the lowering of Date (partially due to a ld64 crash that occurs when trying to relocate that type rdar://84036560)

The following is however functional:
Duration and arithmetics associated
ClockProtocol, InstantProtocol and their associated methods
Task.sleep using a deadline on standard clocks (wall/uptime/monotonic)
Task.sleep using a deadline on custom clocks

This does not include the following:
TimeInterval -> Duration conversion
the originally defined in mechanism for lowering Date (it is currently named _Date and not a relocated symbol)
Bridging or Foundation functionality for Date
Windows accessors for time